### PR TITLE
feat(placement): free placements — free slots, both accept rewards, sticker and remix surfaces

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260817120000_placement_free_capacity/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260817120000_placement_free_capacity/migration.sql
@@ -1,0 +1,120 @@
+-- Free placement capacity: how many free placements a space accepts, and which
+-- placements were made against that capacity rather than paid for.
+--
+-- APPLY BEFORE deploying the app that reads these. Both columns are additive and
+-- carry defaults that reproduce today's behaviour exactly, so an old pod is
+-- unaffected by their existence:
+--
+--   * "PlacementSpace"."freeSlots" is nullable with no default. NULL means the
+--     owner has never chosen, which the app resolves to the surface default.
+--     Old code never selects it and never writes it.
+--   * "Placement"."free" defaults to false, so every row an old pod writes is a
+--     paid placement, which is what it is.
+--
+-- NO BACKFILL, and none is needed: every placement that exists was paid for, and
+-- false is the truth for all of them.
+--
+-- ⚠️ THE UNSAFE DIRECTION IS A ROLLBACK WITH FREE ROWS ALREADY MADE. Old code
+-- does not know about `free`, so it settles such a row through the ordinary
+-- money path. That path derives its payout from RECEIPTED HOLDS, of which a free
+-- placement has none, so every leg computes to zero and is filtered out before it
+-- is persisted — old code moves no money for a free row and cannot. What it does
+-- lose is the reservation: old `resolvePlacementSpaceFor` does not count free
+-- rows, so a space's free slots are unbounded while rolled back. The surfaces
+-- that create free placements are behind the `sticker-placement` and
+-- `remix-gallery` Flipt flags; turn those off before rolling back and the set
+-- cannot grow.
+--
+-- ⚠️ NEVER DROP THESE COLUMNS on a rollback. `free` is the only record of which
+-- placements were never paid for, and dropping it would make a later roll-forward
+-- treat them as paid — reserving nothing, and offering a refund path to rows that
+-- have nothing behind them. Old Prisma clients emit explicit column lists, so
+-- leaving both in place costs nothing.
+
+SET lock_timeout = '5s';
+BEGIN;
+
+-- 1. How many free placements this space accepts. Uncapped here on purpose: the
+--    score/tier ceiling is computed at read, and a stored effective value would
+--    go stale the moment a membership lapses. The CHECK only keeps the column
+--    meaningful — a negative slot count is not a small number, it is nonsense
+--    that would make `cap - reserved` arithmetic hand out capacity nobody set.
+ALTER TABLE "PlacementSpace" ADD COLUMN IF NOT EXISTS "freeSlots" INTEGER;
+
+ALTER TABLE "PlacementSpace" DROP CONSTRAINT IF EXISTS "PlacementSpace_freeSlots_check";
+ALTER TABLE "PlacementSpace" ADD CONSTRAINT "PlacementSpace_freeSlots_check"
+  CHECK ("freeSlots" IS NULL OR "freeSlots" >= 0);
+
+-- 2. Whether this placement was made against free capacity.
+--
+--    NOT NULL with a default rather than nullable: there is no third state, and a
+--    NULL here would have to be interpreted by every reader that decides whether
+--    money moves.
+ALTER TABLE "Placement" ADD COLUMN IF NOT EXISTS "free" BOOLEAN NOT NULL DEFAULT false;
+
+-- 3. A free placement is worth zero, structurally.
+--
+--    The application never sizes a payout from `amount` — it reads receipted
+--    holds, and a free placement has none — so this does not prevent a payout on
+--    its own. What it prevents is a free row that LOOKS paid: `amount` is what
+--    every report, every support answer and every future reader will quote, and a
+--    free placement carrying a price is a row that says a creator earned
+--    something they did not.
+ALTER TABLE "Placement" DROP CONSTRAINT IF EXISTS "Placement_free_amount_check";
+ALTER TABLE "Placement" ADD CONSTRAINT "Placement_free_amount_check"
+  CHECK (NOT "free" OR "amount" = 0);
+
+-- 4. The index behind both entitlement checks — the daily allowance and the
+--    never-twice rule — which run inside the claim transaction and so sit on the
+--    latency path of every free placement.
+--
+--    PARTIAL (`WHERE "free"`), which Prisma cannot express: without the predicate
+--    this indexes every placement ever made in order to answer questions asked
+--    only about the free ones. Not CONCURRENTLY: the predicate matches zero rows
+--    at apply time, so the build is instant, and a cancelled CONCURRENTLY build
+--    leaves an INVALID index behind that then has to be found and dropped.
+CREATE INDEX IF NOT EXISTS "Placement_placerId_free_createdAt_idx"
+  ON "Placement" ("placerId", "free", "createdAt")
+  WHERE "free";
+
+COMMIT;
+
+-- 5. VERIFY THE SCHEMA. Every statement above is idempotent and reports success
+--    on a retry, so confirm each landed rather than reading a clean exit as
+--    proof.
+--
+--      SELECT table_name, column_name, is_nullable, data_type, column_default
+--      FROM information_schema.columns
+--      WHERE (table_name, column_name)
+--        IN (('PlacementSpace', 'freeSlots'), ('Placement', 'free'));
+--
+--    Expect two rows: a nullable `integer` with no default, and a NOT NULL
+--    `boolean` defaulting to false.
+--
+--      SELECT conname, pg_get_constraintdef(oid), convalidated FROM pg_constraint
+--      WHERE conname IN ('PlacementSpace_freeSlots_check', 'Placement_free_amount_check');
+--
+--    Both must report `convalidated = true`.
+--
+--      SELECT indexname, indexdef FROM pg_indexes
+--      WHERE indexname = 'Placement_placerId_free_createdAt_idx';
+--
+--    The definition must contain `WHERE free`. An index built without the
+--    predicate is not a smaller mistake — it is a full-table index that will be
+--    quietly maintained on every placement forever.
+--
+-- 6. VERIFY THE BEHAVIOUR, after the deploy. Nothing above proves the app writes
+--    these. Make one free placement, then:
+--
+--      SELECT id, free, amount, status, "expiresAt" FROM "Placement"
+--      ORDER BY id DESC LIMIT 5;
+--
+--    The new row must read `free = true`, `amount = 0`, and carry a NON-NULL
+--    `expiresAt`. The deadline is what releases the slot when the creator never
+--    acts; a free row without one holds its slot forever and no sweep will ever
+--    reach it.
+--
+--    Standing check afterwards — this should never return a row:
+--
+--      SELECT id, "createdAt" FROM "Placement"
+--      WHERE free AND "expiresAt" IS NULL AND status = 'pending';

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -7837,6 +7837,17 @@ model PlacementSpace {
   /// What the owner asks. The charged price is min(price, cap) computed at read; a
   /// stored effective price goes stale the moment a membership lapses.
   price      Int?
+  /// How many free placements this space accepts. NULL means the owner has never
+  /// chosen, which resolves to the surface's default (1) rather than to zero —
+  /// free capacity is opt-out. An explicit 0 is the owner taking none, which is
+  /// why this replaces an on/off toggle instead of sitting beside one.
+  ///
+  /// Stored uncapped and ceilinged at read by the score/tier table, exactly like
+  /// `price`: a stored effective value goes stale the moment a membership lapses.
+  ///
+  /// A column rather than a key in `settings`, because the foundation reads it
+  /// and `settings` is surface-owned by construction.
+  freeSlots  Int?
   /// Surface-owned settings, read only by the surface that wrote them — a max
   /// sticker size means nothing to a remix gallery. Kept as JSON so this layer
   /// does not grow a column per surface idea.
@@ -7876,7 +7887,20 @@ model Placement {
   removedBy             String?
   /// What the placer paid into escrow, in Buzz. Kept per row rather than read back from
   /// the space, whose price may move between placement and release.
+  ///
+  /// Always 0 on a free placement, and nothing reads it there — the payout is
+  /// derived from receipted holds, of which a free placement has none.
   amount                Int
+  /// A placement made against the space's free capacity rather than paid for.
+  ///
+  /// Escrow is bypassed entirely: zero-amount Buzz transactions are a landmine,
+  /// and the escrow's two-hold structure has neither a decline fee nor a
+  /// principal to hold. Settlement moves no money at all for one of these.
+  ///
+  /// On the row rather than inferred from `amount = 0`, which is also what a paid
+  /// placement into a zero-priced space looks like. It also has to be immutable
+  /// and readable by a sweeper that never saw the request that made it.
+  free                  Boolean   @default(false)
   /// Which Buzz the placer paid in, so the settlement pays the same kind back out.
   /// On the row for the same reason `amount` is: settlement is resumable, and the
   /// domain that decided the currency is not visible to a sweeper.
@@ -7938,6 +7962,17 @@ model Placement {
   /// `[ownerId, status]` above, which the moderation lookups still want.
   @@index([ownerId, surface, status, createdAt, id])
   @@index([placerId, status])
+  /// Both free-placement entitlement checks, which run inside the claim
+  /// transaction and so are on the latency path of every free placement: the
+  /// daily allowance (this placer, free rows, since midnight UTC) and the
+  /// never-twice rule (this placer, free rows, this target). One index serves
+  /// both because the allowance bounds a placer to one free row per day, so
+  /// "every free row this placer has" is a handful of tuples either way.
+  ///
+  /// Applied as a PARTIAL index (`WHERE free`) — see the migration. Prisma cannot
+  /// express the predicate, and without it this indexes every placement ever made
+  /// to answer questions only about the free ones.
+  @@index([placerId, free, createdAt])
   @@index([status, expiresAt])
   /// Applied as a PARTIAL index (`WHERE "metricCountedAt" IS NULL`) — see the
   /// migration. Prisma can express neither the predicate nor the reason the key

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -3036,8 +3036,23 @@ export type Placement = {
   /**
    * What the placer paid into escrow, in Buzz. Kept per row rather than read back from
    * the space, whose price may move between placement and release.
+   *
+   * Always 0 on a free placement, and nothing reads it there — the payout is
+   * derived from receipted holds, of which a free placement has none.
    */
   amount: number;
+  /**
+   * A placement made against the space's free capacity rather than paid for.
+   *
+   * Escrow is bypassed entirely: zero-amount Buzz transactions are a landmine,
+   * and the escrow's two-hold structure has neither a decline fee nor a
+   * principal to hold. Settlement moves no money at all for one of these.
+   *
+   * On the row rather than inferred from `amount = 0`, which is also what a paid
+   * placement into a zero-priced space looks like. It also has to be immutable
+   * and readable by a sweeper that never saw the request that made it.
+   */
+  free: Generated<boolean>;
   /**
    * Which Buzz the placer paid in, so the settlement pays the same kind back out.
    * On the row for the same reason `amount` is: settlement is resumable, and the
@@ -3109,6 +3124,19 @@ export type PlacementSpace = {
    * stored effective price goes stale the moment a membership lapses.
    */
   price: number | null;
+  /**
+   * How many free placements this space accepts. NULL means the owner has never
+   * chosen, which resolves to the surface's default (1) rather than to zero —
+   * free capacity is opt-out. An explicit 0 is the owner taking none, which is
+   * why this replaces an on/off toggle instead of sitting beside one.
+   *
+   * Stored uncapped and ceilinged at read by the score/tier table, exactly like
+   * `price`: a stored effective value goes stale the moment a membership lapses.
+   *
+   * A column rather than a key in `settings`, because the foundation reads it
+   * and `settings` is surface-owned by construction.
+   */
+  freeSlots: number | null;
   /**
    * Surface-owned settings, read only by the surface that wrote them — a max
    * sticker size means nothing to a remix gallery. Kept as JSON so this layer

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -5309,6 +5309,7 @@ export interface PlacementSpace {
   entityId: number;
   mode: string;
   price: number | null;
+  freeSlots: number | null;
   settings: JsonValue;
   createdAt: Date;
   updatedAt: Date;
@@ -5327,6 +5328,7 @@ export interface Placement {
   status: string;
   removedBy: string | null;
   amount: number;
+  free: boolean;
   spendType: string | null;
   sellerId: number | null;
   seller?: User | null;

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -191,6 +191,12 @@ vi.mock('~/server/prom/client', () => ({
   vaultItemFailedCounter: promMetricStub(),
   rewardGivenCounter: promMetricStub(),
   rewardFailedCounter: promMetricStub(),
+  // Re-exported from '@civitai/telemetry/client' rather than declared in
+  // prom/client, so this module-replacing mock drops it. `base.reward` and
+  // `image.service` both call `.inc()` on it WITHOUT the `?.inc?.()` guard their
+  // neighbours use, so the first test to drive either fail-soft path dies here
+  // rather than on whatever it was written to check.
+  clickhouseFailSoftCounter: promMetricStub(),
   clavataCounter: promMetricStub(),
   cacheHitCounter: promMetricStub(),
   cacheMissCounter: promMetricStub(),

--- a/src/components/Account/PlacementSpaceSection.freeSlots.browser.test.tsx
+++ b/src/components/Account/PlacementSpaceSection.freeSlots.browser.test.tsx
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import type * as TrpcModule from '~/utils/trpc';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * The free-slot control on the account settings page, and specifically the one
+ * property no server test can see: **what this page sends when the creator did
+ * not touch it.**
+ *
+ * `freeSlots` is three-way — NULL follows the surface default, a number stops
+ * following it, and 0 is the creator saying no. The mechanism only works while
+ * NULL survives an unrelated save. The first version of this control sent the
+ * on-screen number on every commit, so changing the mode wrote an explicit `1`;
+ * every assertion about the column, the cascade and the resolver stayed green,
+ * because each of them was true. Within a few weeks of ordinary use almost every
+ * space would have been frozen, and raising the default later would have reached
+ * nobody.
+ */
+
+const { mutate, spaces } = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  spaces: { value: [] as Record<string, unknown>[] },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 7 }) }));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ stickerPlacement: true }),
+}));
+vi.mock('~/utils/notifications', () => ({ showErrorNotification: vi.fn() }));
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    useUtils: () => ({ placement: { invalidate: vi.fn() } }),
+    placement: {
+      getPriceRange: {
+        useQuery: () => ({ data: { min: 50, max: 500, freeSlotCap: 4, score: 0, tier: 'free' } }),
+      },
+      getMySpaces: {
+        useQuery: () => ({ data: spaces.value, isPending: false, isError: false }),
+      },
+      getPending: { useQuery: () => ({ data: { items: [], nextCursor: null } }) },
+      setSpace: { useMutation: () => ({ mutate, isPending: false }) },
+    },
+  },
+}));
+
+import { PlacementSpaceSection } from '~/components/Account/PlacementSpaceSection';
+
+/** A space row as `getMySpaces` returns it. */
+const givenSpace = (freeSlots: number | null) => {
+  spaces.value = [
+    { entityType: 'user', entityId: 7, mode: 'review', price: 100, freeSlots, settings: {} },
+  ];
+};
+
+const lastPayload = () => mutate.mock.calls[mutate.mock.calls.length - 1][0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  spaces.value = [];
+});
+
+describe('PlacementSpaceSection — what a save sends for freeSlots', () => {
+  test('an unrelated save leaves a NULL count untouched', async () => {
+    givenSpace(null);
+    renderWithProviders(<PlacementSpaceSection />);
+
+    await userEvent.click(page.getByText('Accept all'));
+
+    // Absent, not `null`. `null` is a different instruction — it CLEARS the
+    // level so it inherits — and both are distinguishable from a number, which
+    // is the whole point of the three-way schema. `toHaveProperty` rather than a
+    // value comparison, because `undefined` and an omitted key read the same in
+    // an equality assertion and only one of them is what the mutation sends.
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(lastPayload()).not.toHaveProperty('freeSlots', null);
+    expect(lastPayload().freeSlots).toBeUndefined();
+  });
+
+  test('an unrelated save leaves a stored count untouched too', async () => {
+    // The stored-number case is not covered by the NULL one. A control that sent
+    // its on-screen value would pass here by coincidence — the value happens to
+    // match — so this pins that the key is absent rather than that it is right.
+    givenSpace(3);
+    renderWithProviders(<PlacementSpaceSection />);
+
+    await userEvent.click(page.getByText('Accept all'));
+
+    expect(lastPayload().freeSlots).toBeUndefined();
+  });
+
+  // The negative control. Without it, "never send freeSlots" would pass every
+  // assertion above and the creator could never change the number at all.
+  test('moving the control sends the number', async () => {
+    givenSpace(null);
+    renderWithProviders(<PlacementSpaceSection />);
+
+    const slider = page.getByRole('slider', { name: /free stickers/i });
+    await expect.element(slider).toBeInTheDocument();
+    // Focused directly and driven by keyboard. A click on the thumb times out —
+    // it is a zero-size element the track paints over — and a synthesised drag
+    // does not reliably reach Mantine's `onChangeEnd`, which is what commits.
+    (slider.element() as HTMLElement).focus();
+    await userEvent.keyboard('{ArrowRight}');
+
+    expect(mutate).toHaveBeenCalled();
+    // The number CHOSEN, not merely a number. `typeof … === 'number'` passes for
+    // a control that sends its pre-move value, which moves the thumb, saves, and
+    // stores the old count. Fully determined: the space is unset, so the thumb
+    // rests on the surface default of 1 and one ArrowRight makes it 2.
+    expect(lastPayload().freeSlots).toBe(2);
+  });
+});

--- a/src/components/Account/PlacementSpaceSection.tsx
+++ b/src/components/Account/PlacementSpaceSection.tsx
@@ -22,6 +22,7 @@ import {
   STICKER_PLACEMENT_MIN_SCALE,
   stickerMaxScale,
 } from '~/shared/utils/sticker-placement';
+import { PlacementFreeSlotSlider } from '~/components/Placement/PlacementFreeSlotSlider';
 import { PlacementPriceSlider } from '~/components/Placement/PlacementPriceSlider';
 import { placementPriceCaption, PLACEMENT_SURFACES } from '~/shared/utils/placement';
 import { showErrorNotification } from '~/utils/notifications';
@@ -69,15 +70,26 @@ export function PlacementSpaceSection() {
   const [mode, setMode] = useState<string>(DEFAULT_MODE);
   const [price, setPrice] = useState<number | ''>(DEFAULT_PRICE ?? '');
   const [maxScale, setMaxScale] = useState(STICKER_PLACEMENT_DEFAULT_MAX_SCALE);
+  // `null`, not the default value, and that distinction is the mechanism rather
+  // than a nicety: a stored number stops tracking the surface default when it
+  // moves. Seeding this to `1` and sending it on every commit wrote an explicit
+  // `1` the first time a creator touched anything else on this page, so within a
+  // few weeks of normal use raising the default would have reached nobody.
+  //
+  // It also cannot be recovered by diffing against the default, because "unset"
+  // and "deliberately set to 1" are the same number.
+  const [freeSlots, setFreeSlots] = useState<number | null>(null);
 
   useEffect(() => {
     if (!stored) {
       setMode(DEFAULT_MODE);
       setPrice(DEFAULT_PRICE ?? '');
+      setFreeSlots(null);
       return;
     }
     setMode(stored.mode);
     setPrice(stored.price ?? '');
+    setFreeSlots(stored.freeSlots);
     setMaxScale(stickerMaxScale(stored.settings as Record<string, unknown>));
   }, [stored]);
 
@@ -94,6 +106,7 @@ export function PlacementSpaceSection() {
       // page asserting a price the creator never chose — which the next commit
       // would then write into their row.
       setPrice(stored ? stored.price ?? '' : DEFAULT_PRICE ?? '');
+      setFreeSlots(stored?.freeSlots ?? null);
       showErrorNotification({ title: "Couldn't save that", error: new Error(error.message) });
     },
   });
@@ -107,6 +120,7 @@ export function PlacementSpaceSection() {
   if (spacesPending || spacesFailed) return null;
 
   const cap = range?.max ?? 0;
+  const freeSlotCap = range?.freeSlotCap ?? 0;
   const waiting = pending?.items.length ?? 0;
   // One page's worth is a floor, not a total. Badging it as an exact number
   // tells an owner with 200 waiting that they have 50, which is the same lie
@@ -118,9 +132,21 @@ export function PlacementSpaceSection() {
     range?.max ?? null
   );
 
-  const commit = (nextMode: string, nextPrice: number | '', nextMaxScale = maxScale) =>
+  const commit = (
+    nextMode: string,
+    nextPrice: number | '',
+    nextMaxScale = maxScale,
+    /**
+     * Sent ONLY when the free-slot control was the thing that moved. `undefined`
+     * leaves the stored value alone, which for a creator who has never touched
+     * it means leaving it NULL — and NULL is what tracks the surface default.
+     * Sending the on-screen number on every commit is what froze it.
+     */
+    nextFreeSlots?: number
+  ) =>
     save.mutate({
       settings: { maxScale: nextMaxScale },
+      freeSlots: nextFreeSlots,
       surface: 'sticker',
       entityType: 'user',
       // Keyed by the owner's own id; the service refuses any other, so this
@@ -238,6 +264,23 @@ export function PlacementSpaceSection() {
           of the size of the image
         </Text>
       </Stack>
+
+      {/* Hidden entirely at a cap of 0 rather than shown disabled: a control whose
+          every position means the same thing is asking a question with one
+          answer, and the cap moves on its own as a score or a membership does. */}
+      {freeSlotCap > 0 && mode !== 'off' && (
+        <PlacementFreeSlotSlider
+          surface="sticker"
+          cap={freeSlotCap}
+          value={freeSlots}
+          noun={['free sticker', 'free stickers']}
+          onChange={setFreeSlots}
+          onCommit={(value) => {
+            setFreeSlots(value);
+            commit(mode, price, maxScale, value);
+          }}
+        />
+      )}
 
       {/* The queue is otherwise unreachable: the notification links to the image,
           and nothing else in the app points at it. */}

--- a/src/components/Placement/PlacementFreeBadge.tsx
+++ b/src/components/Placement/PlacementFreeBadge.tsx
@@ -1,0 +1,58 @@
+import { Anchor, Badge, Popover, Text } from '@mantine/core';
+import Link from 'next/link';
+
+/**
+ * That this one cost nothing, and where the owner changes that.
+ *
+ * Shared by both review queues and the sticker overlay so the fact reads the
+ * same everywhere it appears — same colour, same words, same explanation.
+ *
+ * The popover exists because a queue is where a creator first meets a free
+ * placement, arriving from a notification, and "why is this free and how do I
+ * stop it" otherwise has no answer on the page they are standing on.
+ */
+export function PlacementFreeBadge({
+  /** What was placed here: `placement` on stickers, `submission` on galleries. */
+  noun,
+  /**
+   * Solid rather than tinted. `light` is a translucent fill, which is legible on
+   * a queue card and unreadable over artwork — so the copy on an image asks for
+   * this, and nothing else should need it.
+   */
+  solid = false,
+}: {
+  noun: 'placement' | 'submission';
+  solid?: boolean;
+}) {
+  return (
+    // `withinPortal` explicitly: the repo theme sets `withinPortal: false` for
+    // every Popover (`ThemeProvider.tsx:35`), and this one opens inside a queue
+    // card that clips it — the dropdown came out truncated.
+    <Popover width={240} withArrow shadow="md" position="top" withinPortal>
+      <Popover.Target>
+        {/* A real button, so Enter and Space reach it and it lands in the tab
+            order — `Popover.Target` supplies the click itself. */}
+        <Badge
+          component="button"
+          type="button"
+          size="sm"
+          variant={solid ? 'filled' : 'light'}
+          color="blue"
+          className="w-fit cursor-pointer"
+        >
+          Free {noun}
+        </Badge>
+      </Popover.Target>
+      <Popover.Dropdown>
+        {/* Two short lines on purpose. It sits over a decision, not beside an
+            article, and the long version was read past. */}
+        <Text size="sm" style={{ whiteSpace: 'normal' }}>
+          They spent their one free {noun} of the day here. It earns you no Buzz.
+        </Text>
+        <Anchor component={Link} href="/user/account" size="sm" mt={6} className="block">
+          Choose how many free ones you take
+        </Anchor>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}

--- a/src/components/Placement/PlacementFreeFilter.tsx
+++ b/src/components/Placement/PlacementFreeFilter.tsx
@@ -1,0 +1,34 @@
+import { Chip } from '@mantine/core';
+
+/**
+ * Show or hide the free rows in a review queue. A chip rather than a switch, on
+ * Justin's call, so it sits beside the select-all control as one row of queue
+ * controls.
+ *
+ * Shared across the sticker queue and the remix submission queue because an
+ * owner meets the same decision on both, and the two queues are meant to read
+ * as one system — the free badge on a row is already the same badge in both
+ * places.
+ *
+ * Filters what is already loaded rather than what is fetched. Both queues are
+ * cursor-paged and both say something careful about a page whose rows were all
+ * dropped ("nothing on this page can be shown — there are more waiting"); a
+ * server-side filter changes what a page contains and makes that copy describe
+ * something else.
+ */
+export function PlacementFreeFilter({
+  show,
+  onChange,
+  /** Plural of what the queue holds: `placements`, `submissions`. */
+  noun,
+}: {
+  show: boolean;
+  onChange: (show: boolean) => void;
+  noun: string;
+}) {
+  return (
+    <Chip size="xs" checked={show} onChange={onChange} variant="light" className="shrink-0">
+      Free {noun}
+    </Chip>
+  );
+}

--- a/src/components/Placement/PlacementFreeSlotSlider.tsx
+++ b/src/components/Placement/PlacementFreeSlotSlider.tsx
@@ -1,0 +1,91 @@
+import { Group, Slider, Stack, Text } from '@mantine/core';
+import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
+import { effectiveFreeSlots, PLACEMENT_SURFACES } from '~/shared/utils/placement';
+import type { PlacementSurface } from '~/shared/utils/placement';
+
+/**
+ * How many free placements a creator will accept on a space.
+ *
+ * Shared for the same reason `PlacementPriceSlider` is: a creator meets this
+ * control on more than one surface and, once the per-image override lands, at
+ * more than one level. Two implementations of one decision is two sets of
+ * reachable answers, and the pasted pair this replaced had already diverged on
+ * whether the displayed number was floored at zero.
+ *
+ * Renders its own label and caption, unlike the price slider, because there is
+ * nothing surface-specific left to say once the noun is supplied — no
+ * inheriting, no off-grid, no over-cap disclosure. The caller passes the words
+ * for the thing being placed and nothing else.
+ */
+export function PlacementFreeSlotSlider({
+  surface,
+  cap,
+  value,
+  onChange,
+  onCommit,
+  /** Singular and plural of what is placed here: `['free sticker', 'free stickers']`. */
+  noun,
+}: {
+  surface: PlacementSurface;
+  /** The creator's ceiling. `0` hides the control — see below. */
+  cap: number;
+  /**
+   * What the creator has chosen, or `null` for "never chosen", which follows the
+   * surface default. The distinction is the whole mechanism: a stored number
+   * stops tracking the default when it moves, so a control that cannot express
+   * "unset" writes one on the first save and freezes it.
+   */
+  value: number | null;
+  onChange: (value: number) => void;
+  onCommit: (value: number) => void;
+  noun: [singular: string, plural: string];
+}) {
+  const set = value ?? PLACEMENT_SURFACES[surface].defaultFreeSlots;
+  // What the server will honour, through the shared helper rather than a local
+  // `Math.min`. A stored count above the cap is carried rather than rewritten —
+  // the same treatment a price gets — so the page has to state the smaller
+  // number instead of the one on the row.
+  const effective = effectiveFreeSlots(set, cap);
+
+  return (
+    <Stack gap={4}>
+      <Group gap={4} wrap="nowrap">
+        <Text size="sm" fw={500}>
+          Free {noun[1]} you&apos;ll accept
+        </Text>
+        <InfoPopover size="xs" iconProps={{ size: 14 }} width={320}>
+          <Text size="sm" maw={300} style={{ whiteSpace: 'normal' }}>
+            People get one free placement a day across the whole site, and these are the slots they
+            can spend it on. A slot is held while one waits for you, and comes back if you decline
+            it or let it expire. Your maximum is {cap}, set by your creator score and membership
+            tier. Paid placements never use these up.
+          </Text>
+        </InfoPopover>
+      </Group>
+      <Slider
+        // The visible label is a sibling `Text`, so without this the thumb
+        // reaches assistive tech — and any test driving it — as an unnamed
+        // slider, indistinguishable from the price one beside it.
+        thumbLabel={`Free ${noun[1]} you'll accept`}
+        value={effective}
+        onChange={onChange}
+        onChangeEnd={onCommit}
+        min={0}
+        max={cap}
+        step={1}
+        label={null}
+        marks={[
+          { value: 0, label: 'None' },
+          { value: cap, label: `${cap}` },
+        ]}
+      />
+      {/* Clears the marks, which sit under the track. */}
+      <Text size="sm" c="dimmed" mt={16}>
+        <Text span fw={600} c="var(--mantine-color-text)">
+          {effective}
+        </Text>{' '}
+        {effective === 1 ? noun[0] : noun[1]} per image
+      </Text>
+    </Stack>
+  );
+}

--- a/src/components/Placement/PlacementFreeSlotSlider.tsx
+++ b/src/components/Placement/PlacementFreeSlotSlider.tsx
@@ -63,6 +63,9 @@ export function PlacementFreeSlotSlider({
         </InfoPopover>
       </Group>
       <Slider
+        // The marks sit under the track and the caption sits on their row, same
+        // as the price slider. Without this they land on top of each other.
+        mb="lg"
         // The visible label is a sibling `Text`, so without this the thumb
         // reaches assistive tech — and any test driving it — as an unnamed
         // slider, indistinguishable from the price one beside it.
@@ -75,16 +78,17 @@ export function PlacementFreeSlotSlider({
         step={1}
         label={null}
         marks={[
-          { value: 0, label: 'None' },
+          { value: 0, label: '0' },
           { value: cap, label: `${cap}` },
         ]}
       />
-      {/* Clears the marks, which sit under the track. */}
-      <Text size="sm" c="dimmed" mt={16}>
-        <Text span fw={600} c="var(--mantine-color-text)">
-          {effective}
-        </Text>{' '}
-        {effective === 1 ? noun[0] : noun[1]} per image
+      {/* Sits on the marks' row in the same size and colour as the price
+          caption at each caller, so the two values on one settings page read as
+          one control rather than two. Bounded to the number and the unit for
+          the same reason `placementPriceCaption` is: the marks are pinned left
+          and right and this is centred between them. */}
+      <Text size="xs" ta="center" mt={-22} c="dimmed">
+        {effective} per image
       </Text>
     </Stack>
   );

--- a/src/components/Placement/__tests__/free-filter.test.ts
+++ b/src/components/Placement/__tests__/free-filter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { selectionAfterHidingFree, visibleQueueRows } from '~/components/Placement/free-filter';
+
+const rows = [
+  { id: 1, free: false },
+  { id: 2, free: true },
+  { id: 3, free: false },
+  { id: 4, free: true },
+];
+
+describe('visibleQueueRows', () => {
+  it('shows everything while free rows are shown', () => {
+    expect(visibleQueueRows(rows, true).map((row) => row.id)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('drops the free rows when they are hidden', () => {
+    expect(visibleQueueRows(rows, false).map((row) => row.id)).toEqual([1, 3]);
+  });
+});
+
+/**
+ * The half that decides what a bulk Approve or Decline acts on. Both are
+ * irreversible, so a selection carrying rows the filter just hid would move
+ * money on placements the owner can no longer see — and the count beside the
+ * buttons would still be counting them.
+ */
+describe('selectionAfterHidingFree', () => {
+  it('keeps the paid rows and drops the free ones', () => {
+    expect(selectionAfterHidingFree([1, 2, 3, 4], rows)).toEqual([1, 3]);
+  });
+
+  it('drops an id whose row is not there at all', () => {
+    expect(selectionAfterHidingFree([1, 99], rows)).toEqual([1]);
+  });
+
+  it('leaves a selection of paid rows alone', () => {
+    expect(selectionAfterHidingFree([3, 1], rows)).toEqual([3, 1]);
+  });
+});

--- a/src/components/Placement/free-filter.ts
+++ b/src/components/Placement/free-filter.ts
@@ -1,0 +1,31 @@
+/**
+ * What a review queue shows, and what stays selected, when the free rows are
+ * hidden.
+ *
+ * Its own module because the queues are pages: nothing under `src/pages` can
+ * carry a test — Next treats every file there as a route — and the selection
+ * rule below is the half worth testing. Inline in the page it would be a
+ * one-line filter whose failure is a bulk action on rows nobody can see.
+ */
+
+/** The rows on screen. `showFree` false drops the free ones. */
+export function visibleQueueRows<T extends { free: boolean }>(rows: T[], showFree: boolean) {
+  return showFree ? rows : rows.filter((row) => !row.free);
+}
+
+/**
+ * The selection, with anything the filter just hid taken out of it.
+ *
+ * Approve and Decline are irreversible and both say something about money, so a
+ * selection that outlives the rows it was made from acts on placements the owner
+ * can no longer see — and the count beside the buttons would still include them.
+ *
+ * An id whose row is not in `rows` at all is dropped too. Selection only ever
+ * comes from loaded rows, so that case is a row that went away underneath it.
+ */
+export function selectionAfterHidingFree(
+  selected: number[],
+  rows: { id: number; free: boolean }[]
+) {
+  return selected.filter((id) => rows.some((row) => row.id === id && !row.free));
+}

--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -348,9 +348,9 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                                 children: (
                                   <Text size="sm">
                                     Every pending submission rated above{' '}
-                                    {getBrowsingLevelLabel(acceptedMaxLevel)} is declined. Each one
-                                    keeps you the decline fee and returns the rest to its submitter.
-                                    This can&apos;t be undone.
+                                    {getBrowsingLevelLabel(acceptedMaxLevel)} is declined. Paid ones
+                                    keep you the decline fee and return the rest to their submitter;
+                                    free ones move no Buzz either way. This can&apos;t be undone.
                                   </Text>
                                 ),
                                 labels: { confirm: 'Decline them', cancel: 'Cancel' },
@@ -465,16 +465,30 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                               and marking those would turn a missing signal into a
                               verdict. */}
                           {row.data.derivedFromHost && <VerifiedRemixBadge />}
+                          {/* What this row IS, since the buttons no longer carry
+                              a number for it. Without this the queue shows a
+                              free submission as a paid one with its earnings
+                              missing, which reads as a bug rather than as a
+                              different kind of offer — and the notification that
+                              brought the owner here already called it free. */}
+                          {row.free && (
+                            <Badge size="sm" variant="light" color="green" className="w-fit">
+                              Free submission
+                            </Badge>
+                          )}
                         </Stack>
                       </Group>
                       {/* Stacked, and the same width, so the pair reads as one
                         decision with two answers rather than a row of buttons.
                         Keyed to the row and the action — bare `act.isPending`
                         spun every button in the queue on any one click. */}
-                      {/* Each answer carries what it pays, so the owner never has
-                          to know that declining still earns a fee — the numbers
-                          come from the server, computed with the settlement's own
-                          helpers against this row's amount. */}
+                      {/* A PAID row's answers each carry what they pay, so the
+                          owner never has to know that declining still earns a
+                          fee — the numbers come from the server, computed with
+                          the settlement's own helpers against this row's amount.
+                          A free row carries neither, because nothing was paid in
+                          and there is no fee to earn: `earnings` is null there
+                          and the badge above says what the row is instead. */}
                       <Stack gap={6} className="w-36 shrink-0">
                         {/* Approving is the one answer that needs the picture.
                             Declining does not — it is a refusal, and a rating is
@@ -509,7 +523,15 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                             fullWidth
                             classNames={{ label: 'w-full justify-between gap-2' }}
                             leftSection={<IconCheck size={14} />}
-                            rightSection={<EarningsChip amount={row.earnings.approve} />}
+                            // Nothing on a free row rather than a chip reading
+                            // "+0". `EarningsChip`'s `+` is what stops a bare
+                            // amount reading as a price; on a free submission it
+                            // makes the opposite false claim instead — that the
+                            // creator earns nothing for accepting. The badge
+                            // beside the submitter says what this row is.
+                            rightSection={
+                              row.earnings ? <EarningsChip amount={row.earnings.approve} /> : null
+                            }
                             loading={actingOn(row.id, 'approve')}
                             onClick={() => act.mutate({ placementId: row.id, action: 'approve' })}
                           >
@@ -522,7 +544,12 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                           variant="default"
                           classNames={{ label: 'w-full justify-between gap-2' }}
                           leftSection={<IconX size={14} />}
-                          rightSection={<EarningsChip amount={row.earnings.decline} />}
+                          // Same reason, and sharper here: a decline fee is the
+                          // submitter's money moving to the owner, and a free
+                          // submission has none to move.
+                          rightSection={
+                            row.earnings ? <EarningsChip amount={row.earnings.decline} /> : null
+                          }
                           loading={actingOn(row.id, 'decline')}
                           onClick={() => act.mutate({ placementId: row.id, action: 'decline' })}
                         >

--- a/src/components/RemixGallery/RemixGallerySettings.tsx
+++ b/src/components/RemixGallery/RemixGallerySettings.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mantine/core';
 import { useEffect, useState } from 'react';
 import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
+import { PlacementFreeSlotSlider } from '~/components/Placement/PlacementFreeSlotSlider';
 import { PlacementPriceSlider } from '~/components/Placement/PlacementPriceSlider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -59,11 +60,16 @@ export function RemixGallerySettings() {
   const [mode, setMode] = useState<string>(PLACEMENT_SURFACES.remixGallery.defaultMode);
   const [price, setPrice] = useState<number | ''>('');
   const [contentRule, setContentRule] = useState<RemixGalleryContentRule>('atOrBelow');
+  // `null`, not the default value: a stored number stops tracking the surface
+  // default when it moves, and "unset" and "deliberately set to 1" are the same
+  // number, so this cannot be recovered by diffing against the default later.
+  const [freeSlots, setFreeSlots] = useState<number | null>(null);
 
   useEffect(() => {
     if (!stored) return;
     setMode(stored.mode);
     setPrice(stored.price ?? '');
+    setFreeSlots(stored.freeSlots);
     setContentRule(remixGalleryContentRule(stored.settings as Record<string, unknown>));
   }, [stored]);
 
@@ -76,6 +82,7 @@ export function RemixGallerySettings() {
   if (!enabled || !currentUser) return null;
 
   const cap = range?.max ?? 0;
+  const freeSlotCap = range?.freeSlotCap ?? 0;
   const overCap = typeof price === 'number' && cap > 0 && price > cap;
   // Waiting on the owner, and waiting on someone else. Only the first is a
   // to-do, which is why it is the one badged in yellow.
@@ -93,10 +100,17 @@ export function RemixGallerySettings() {
   const commit = (
     nextMode: string,
     nextPrice: number | '',
-    nextRule: RemixGalleryContentRule = contentRule
+    nextRule: RemixGalleryContentRule = contentRule,
+    /**
+     * Sent ONLY when the free-slot control was the thing that moved. `undefined`
+     * leaves the stored value alone, and for a creator who has never touched it
+     * that means leaving it NULL — which is what tracks the surface default.
+     */
+    nextFreeSlots?: number
   ) =>
     save.mutate({
       settings: { contentRule: nextRule },
+      freeSlots: nextFreeSlots,
       surface: 'remixGallery',
       entityType: 'user',
       entityId: currentUser.id,
@@ -207,6 +221,23 @@ export function RemixGallerySettings() {
           ]}
         />
       </Stack>
+
+      {/* Hidden at a cap of 0 rather than shown disabled — every position would
+          mean the same thing — and hidden with the gallery closed, where there is
+          nothing to hold a slot on. */}
+      {freeSlotCap > 0 && mode !== 'off' && (
+        <PlacementFreeSlotSlider
+          surface="remixGallery"
+          cap={freeSlotCap}
+          value={freeSlots}
+          noun={['free submission', 'free submissions']}
+          onChange={setFreeSlots}
+          onCommit={(value) => {
+            setFreeSlots(value);
+            commit(mode, price, contentRule, value);
+          }}
+        />
+      )}
 
       {/* Two directions, two buttons. A gallery owner both receives submissions
           and makes them, and the counts need somewhere to live — a link with an

--- a/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
@@ -1,0 +1,479 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcModule from '~/utils/trpc';
+
+/**
+ * The three branches of the submit card that decide what somebody is CHARGED or
+ * TOLD, and that no other layer can see.
+ *
+ * The card's policy lives in pure functions with their own unit tests — the
+ * refusal ladder, whether a refusal is explainable, whether recommending Buzz is
+ * honest. This file covers only the wiring between those answers and the DOM,
+ * because each branch below is a single token whose inversion is silent
+ * everywhere else:
+ *
+ * 1. The submit button. Inverted, a submission the user chose to make FREE goes
+ *    through `BuzzTransactionButton` carrying `expectedPrice` — a spend the user
+ *    did not consent to, with nothing red at any layer.
+ * 2. The unexplained-refusal notification. Inverted, the server's own refusal
+ *    reaches nobody: a blocked or suspended submitter presses Submit and sees
+ *    NOTHING. That is exactly the behaviour the refusal split removed.
+ * 3. The decline-fee note. Shown on a free submission it describes escrow that
+ *    never existed — "the creator keeps N Buzz and the rest comes back" about
+ *    money nobody paid.
+ *
+ * `toHaveBeenCalledTimes(1)` sits beside every `toHaveBeenCalledWith`, so a
+ * doubled submit cannot pass as a correct one.
+ */
+
+const HOST = 74;
+const MINE = 85;
+const PRICE = 700;
+
+const mocks = vi.hoisted(() => ({
+  submit: vi.fn(),
+  showError: vi.fn(),
+  visibility: {} as Record<string, unknown>,
+  /** What the post-refusal re-read returns. Separate from the query's answer on
+   *  purpose: reassigning one object between render and click had the same fake
+   *  backing both, which holds today and is one added effect away from
+   *  unmounting the button mid-click and hanging to the 15s ceiling. */
+  nextVisibility: null as Record<string, unknown> | null,
+  eligibility: {} as Record<string, unknown>,
+  /**
+   * What a FRESH eligibility read returns, mirroring `nextVisibility`. Set it to
+   * make the cached and fresh answers disagree, which is the only way a test can
+   * tell a real re-read from a cache hit on this half.
+   */
+  nextEligibility: null as Record<string, unknown> | null,
+  /** When set, the mutation refuses with this message. */
+  refuseWith: '' as string,
+}));
+
+// The real module spread first, so a new export does not silently become
+// `undefined` for every importer in this test's graph — which fails the whole
+// file to load and collects zero tests without one failing assertion.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    useUtils: () => ({
+      placement: {
+        invalidate: vi.fn(),
+        /**
+         * 🔴 The fake honours `staleTime`, and that is the point rather than
+         * fidelity for its own sake.
+         *
+         * A fake that is fresh by construction cannot express the failure this
+         * handler exists to avoid. The client's global default is
+         * `staleTime: Infinity` and `fetchQuery` applies it, so a `.fetch()`
+         * without options resolves the CACHE — here, whatever the render is
+         * already showing — and never calls the procedure. Modelled by returning
+         * `mocks.visibility` in that case and the fresh value only when the call
+         * asks for it.
+         *
+         * Six review rounds passed over the missing option because the previous
+         * fake returned fresh data either way. This is the one line that makes
+         * every test below able to fail for the real reason.
+         */
+        getRemixGalleryVisibility: {
+          fetch: async (_input: unknown, opts?: { staleTime?: number }) =>
+            opts?.staleTime === 0 ? mocks.nextVisibility ?? mocks.visibility : mocks.visibility,
+          invalidate: vi.fn(),
+        },
+        getRemixGalleryFreeEligibility: {
+          fetch: async (_input: unknown, opts?: { staleTime?: number }) =>
+            opts?.staleTime === 0 ? mocks.nextEligibility ?? mocks.eligibility : mocks.eligibility,
+        },
+      },
+    }),
+    placement: {
+      getRemixGalleryVisibility: { useQuery: () => ({ data: mocks.visibility, isError: false }) },
+      getRemixGalleryFreeEligibility: { useQuery: () => ({ data: mocks.eligibility }) },
+      submitToRemixGallery: {
+        // Drives the real `onError` rather than exposing it, so the branch under
+        // test is reached the way the mutation reaches it.
+        useMutation: (opts: { onError: (e: { message: string }) => void | Promise<void> }) => ({
+          mutate: (input: unknown) => {
+            mocks.submit(input);
+            if (mocks.refuseWith) return opts.onError({ message: mocks.refuseWith });
+          },
+          isPending: false,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showErrorNotification: (args: unknown) => mocks.showError(args),
+  showSuccessNotification: vi.fn(),
+}));
+
+vi.mock('~/components/Dialog/DialogProvider', () => ({
+  useDialogContext: () => ({ opened: true, onClose: vi.fn() }),
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 52 }) }));
+vi.mock('~/components/Buzz/useAvailableBuzz', () => ({ useAvailableBuzz: () => ['yellow'] }));
+
+vi.mock('~/components/Image/image.utils', () => ({
+  useQueryImages: () => ({
+    images: [{ id: MINE, nsfwLevel: 1, url: 'x', width: 1, height: 1, type: 'image' }],
+    isLoading: false,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isRefetching: false,
+  }),
+}));
+
+// Stubbed to a plain button so the test drives the real branch rather than
+// Mantine's internals — and so a Buzz submit is distinguishable from a free one
+// by which testid appears at all.
+vi.mock('~/components/Buzz/BuzzTransactionButton', () => ({
+  BuzzTransactionButton: ({
+    label,
+    onPerformTransaction,
+    disabled,
+  }: {
+    label: string;
+    onPerformTransaction: () => void;
+    disabled?: boolean;
+  }) => (
+    <button data-testid="buzz-submit" disabled={disabled} onClick={onPerformTransaction}>
+      {label}
+    </button>
+  ),
+}));
+
+vi.mock('~/components/CardTemplates/AspectRatioImageCard', () => ({
+  AspectRatioImageCard: ({ image, onClick }: { image: { id: number }; onClick: () => void }) => (
+    <button data-testid={`pick-${image.id}`} onClick={onClick}>
+      pick
+    </button>
+  ),
+}));
+vi.mock('~/components/InView/InViewLoader', () => ({ InViewLoader: () => null }));
+
+const { RemixGallerySubmitModal } = await import('./RemixGallerySubmitModal');
+
+/** Everything set so the free option is genuinely on offer. */
+const freeIsOffered = () => {
+  mocks.visibility = {
+    open: true,
+    price: PRICE,
+    declineFee: 210,
+    freeSlots: 2,
+    freeSlotsRemaining: 1,
+    maxSubmissionLevel: 32,
+    ownerId: 41,
+    viewerPending: [],
+    pendingCount: 0,
+  };
+  mocks.eligibility = {
+    verifiedImageIds: [MINE],
+    usedHere: false,
+    allowance: { used: 0, remaining: 1, resetsAt: new Date('2026-03-04') },
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  freeIsOffered();
+  mocks.nextVisibility = null;
+  mocks.nextEligibility = null;
+  mocks.refuseWith = '';
+});
+
+const openAndPick = async () => {
+  renderWithProviders(<RemixGallerySubmitModal hostImageId={HOST} />);
+  await page.getByTestId(`pick-${MINE}`).click();
+};
+
+describe('the submit button', () => {
+  test('a free submission never goes through the Buzz path', async () => {
+    // 🔴 The spend-without-consent branch. Inverted, this sends `expectedPrice`
+    // through `onPerformTransaction` for a submission the user chose to make
+    // free, and nothing at any other layer notices.
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    expect(mocks.submit).toHaveBeenCalledTimes(1);
+    expect(mocks.submit).toHaveBeenCalledWith({ hostImageId: HOST, imageId: MINE, free: true });
+    // The payload carries no price, and the Buzz button is not even mounted.
+    expect(mocks.submit.mock.calls[0][0]).not.toHaveProperty('expectedPrice');
+    await expect.element(page.getByTestId('buzz-submit')).not.toBeInTheDocument();
+  });
+
+  test('the paid submission still carries the price it was shown', async () => {
+    await openAndPick();
+    await page.getByRole('radio', { name: new RegExp(`${PRICE} Buzz`) }).click();
+    await page.getByTestId('buzz-submit').click();
+
+    expect(mocks.submit).toHaveBeenCalledTimes(1);
+    expect(mocks.submit).toHaveBeenCalledWith({
+      hostImageId: HOST,
+      imageId: MINE,
+      expectedPrice: PRICE,
+    });
+  });
+});
+
+describe('a refused free submission', () => {
+  const SERVER_PROSE =
+    'remix gallery: free submissions are for remixes made from this image on-site';
+
+  test('surfaces the server’s own refusal when a re-read cannot explain it', async () => {
+    // 🔴 Invert the guard and this reaches nobody: a blocked or suspended
+    // submitter presses Submit and sees NOTHING at all. The re-read below still
+    // reports free as available, so the refusal was not about capacity.
+    mocks.refuseWith = SERVER_PROSE;
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    await vi.waitFor(() => expect(mocks.showError).toHaveBeenCalledTimes(1));
+    expect(mocks.showError).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.objectContaining({ message: SERVER_PROSE }) })
+    );
+  });
+
+  test('explains a capacity refusal inline instead, with no error toast', async () => {
+    mocks.refuseWith = 'remix gallery: the free slots on this one are taken';
+    // The re-read the handler makes after the refusal says the slots went; the
+    // query's own answer is untouched, so nothing re-renders mid-click.
+    mocks.nextVisibility = { ...mocks.visibility, freeSlotsRemaining: 0 };
+    await openAndPick();
+
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    await expect.element(page.getByText(/all taken right now/i)).toBeInTheDocument();
+
+    // An ordinary outcome with a next step, not an error.
+    expect(mocks.showError).not.toHaveBeenCalled();
+    // And never the server's raw wording.
+    await expect
+      .element(page.getByText(/free slots on this one are taken/i))
+      .not.toBeInTheDocument();
+  });
+});
+
+describe('a gallery that takes free submissions and refuses paid ones', () => {
+  /**
+   * The service holds free submissions to none of the price rules — there are
+   * tests asserting an unpriced and a below-floor gallery accept free and refuse
+   * paid — so this is a supported configuration, not an edge case.
+   */
+  const paidClosed = (price: number | null) => {
+    mocks.visibility = { ...mocks.visibility, price };
+    mocks.nextVisibility = { ...mocks.visibility, price, freeSlotsRemaining: 0 };
+    mocks.refuseWith = 'remix gallery: the free slots on this one are taken';
+  };
+
+  test.each([
+    ['unpriced', null],
+    ['priced below the floor', 10],
+  ])('does not offer Buzz as the alternative — %s', async (_label, price) => {
+    paidClosed(price);
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    // Says the true thing rather than pointing at a button that is disabled
+    // (unpriced) or that leads into a second refusal and a buy-Buzz prompt
+    // (below the floor).
+    await expect.element(page.getByText(/not taking paid submissions/i)).toBeInTheDocument();
+    await expect.element(page.getByText(/still submit with Buzz/i)).not.toBeInTheDocument();
+
+    // An explained refusal, so it stays inline — this is the assertion that dies
+    // if the banner goes back to being keyed on `fallBackToPaid`, which is false
+    // here while the refusal is still perfectly explainable.
+    expect(mocks.showError).not.toHaveBeenCalled();
+  });
+
+  test('decides the alternative from the FRESH price, not the rendered one', async () => {
+    // 🔴 The only case where fresh and stale disagree, and the suite had none:
+    // every other fixture gives `nextVisibility` the same price as `visibility`.
+    //
+    // Not a millisecond race either. `getRemixGalleryVisibility.useQuery` passes
+    // no options, so it inherits `staleTime: Infinity` with no refetch on focus
+    // — a modal left open across a price change holds the render value for the
+    // whole session. An owner clearing their price mid-submission is the case.
+    mocks.nextVisibility = { ...mocks.visibility, price: null, freeSlotsRemaining: 0 };
+    mocks.refuseWith = 'remix gallery: the free slots on this one are taken';
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    // Decided off the fresh price: paid is closed now, so the banner must not
+    // point at Buzz and the control must not move there.
+    await expect.element(page.getByText(/not taking paid submissions/i)).toBeInTheDocument();
+    await expect.element(page.getByText(/still submit with Buzz/i)).not.toBeInTheDocument();
+    await expect.element(page.getByTestId('buzz-submit')).not.toBeInTheDocument();
+  });
+
+  test('builds the EXPLANATION from the fresh price, not just the outcome', async () => {
+    // 🔴 The last unpinned argument on this axis. Only rung 1 (`!verified`)
+    // branches on `paidOpen`, and reaching it in the explanation needs the fresh
+    // read to disagree with the render on BOTH halves at once: verified when the
+    // button was pressed, unverified a moment later, on a gallery whose price
+    // was cleared in the same window. The eligibility fake could not express its
+    // half until this round, which is why reverting this argument stayed green.
+    mocks.nextVisibility = { ...mocks.visibility, price: null };
+    mocks.nextEligibility = { ...mocks.eligibility, verifiedImageIds: [] };
+    mocks.refuseWith = 'remix gallery: free submissions are for remixes made from this image';
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    await expect.element(page.getByText(/where we can check/i)).toBeInTheDocument();
+    // The half the argument decides: paid is closed on the FRESH read, so the
+    // sentence must not offer it.
+    await expect
+      .element(page.getByText(/can still be submitted with Buzz/i))
+      .not.toBeInTheDocument();
+    await expect.element(page.getByText(/not taking paid submissions/i)).toBeInTheDocument();
+  });
+
+  test('reads the ALLOWANCE half fresh too, not just the price', async () => {
+    // 🔴 The eligibility fetch has its own `staleTime: 0`, and until this test
+    // the fake could not tell whether it was there: `useQuery` and `fetch`
+    // returned the same object, so cached and fresh never disagreed on this
+    // half. That is the layer the six review rounds could not see.
+    //
+    // Render says the gallery is unused, so the free button is pressable. The
+    // fresh read says it has been used — which is what the server just refused
+    // on, and what the banner has to say.
+    mocks.nextEligibility = { ...mocks.eligibility, usedHere: true };
+    mocks.refuseWith = 'remix gallery: you have already used a free placement here';
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    await expect.element(page.getByText(/once per gallery/i)).toBeInTheDocument();
+    // Never the server's own wording — that is the branch a cache hit falls to.
+    expect(mocks.showError).not.toHaveBeenCalled();
+  });
+
+  test('moves the control to paid when paid IS open', async () => {
+    // `setChosen('paid')` was asserted by nothing in either file — the other
+    // cases here all read the banner, which `setFreeRefusal` sets independently.
+    // The docstring argues that moving the control asserts money was the
+    // problem; this is that argument reaching the DOM.
+    mocks.nextVisibility = { ...mocks.visibility, freeSlotsRemaining: 0 };
+    mocks.refuseWith = 'remix gallery: the free slots on this one are taken';
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    await expect.element(page.getByTestId('buzz-submit')).toBeInTheDocument();
+  });
+
+  test('holds on free rather than offering a paid button that cannot work', async () => {
+    // 🔴 A STATIC fixture, no click and no refusal: free is unavailable from
+    // first paint (`usedHere`) and paid is closed (`price: null`), which is
+    // `submissionMethod(null, false, false, true)`.
+    //
+    // With the rule, that resolves to free — a plain Button. Without it, to
+    // paid, and the `BuzzTransactionButton` stub mounts its testid. So this
+    // reaches the rule with no cache write-through at all, which is what the
+    // previous version of this comment wrongly said was impossible.
+    mocks.visibility = { ...mocks.visibility, price: null };
+    mocks.eligibility = { ...mocks.eligibility, usedHere: true };
+    await openAndPick();
+
+    await expect.element(page.getByTestId('buzz-submit')).not.toBeInTheDocument();
+    // And the reason renders beside the disabled control, which is the whole
+    // justification for holding there: three dead buttons and no explanation is
+    // worse than the paid button this replaced.
+    await expect.element(page.getByText(/once per gallery/i)).toBeInTheDocument();
+    // Not a claim about spending, on a path that cannot be pressed.
+    await expect.element(page.getByText(/spends a free placement/i)).not.toBeInTheDocument();
+  });
+
+  /**
+   * ⚠️ What this file does NOT pin, stated so nothing above is over-read.
+   *
+   * The mock's `useQuery` returns `mocks.visibility` and only `fetch` reads
+   * `mocks.nextVisibility`, so **nothing here can observe any state keyed on
+   * `freeAvailable` becoming false after a render** — not the free segment's
+   * disabled state, not `freeUnavailableReason` arriving late, not
+   * `slotsHeldKnown`, and not `submissionMethod`'s stale-choice rule, which is
+   * the "lost the race for the last slot" behaviour the feature is built around.
+   * That is broader than the `paidOpen` half this block used to name.
+   *
+   * Scope, because the previous version of this block got it wrong in both
+   * directions: the stale-choice rule IS pinned as a pure function in
+   * `remix-gallery.utils.test.ts` ("never resolves to free once free stops being
+   * available"). What lives nowhere is the **wired** rule — that rule firing
+   * through a real query cache — and reaching it needs a fixture that would grow
+   * its own bugs for one line. Said plainly rather than left to look covered,
+   * and scoped so a reader who greps does not stop believing the rest of it.
+   *
+   * ✅ What it CAN now express, since it could not before and six review rounds
+   * passed over a dead subsystem because of it: **cache-hit staleness on both
+   * halves.** `fetch` returns the cached value unless the call passes
+   * `staleTime: 0`, which is what the client's `staleTime: Infinity` default
+   * actually does — so dropping that option from either `.fetch` now fails here
+   * instead of quietly resolving whatever the render already had.
+   *
+   * The same limitation makes the `!freeRefusal` term of the reason's gate
+   * unpinnable here, and I checked rather than assumed: dropping it leaves all
+   * of these green. The two messages can only collide when a refusal lands
+   * while `offer.reason` is non-null, and `offer.reason` is computed from the
+   * static query fixture — which still says free is available at the moment the
+   * refusal arrives. An assertion here would be vacuous, so there is not one.
+   */
+});
+
+describe('an unverified remix on an ordinarily-priced gallery', () => {
+  test('says why free is unavailable, beside a WORKING paid button', async () => {
+    // 🔴 The commonest case there is, and no test observed the sentence in it:
+    // every other case that watches it render has `price: null`, so adding
+    // `&& !paidOpen` to the gate would stay green while hiding the reason in
+    // exactly this state. The gate has now been narrowed wrongly three times;
+    // this is what would notice a fourth.
+    mocks.eligibility = { ...mocks.eligibility, verifiedImageIds: [] };
+    await openAndPick();
+
+    await expect.element(page.getByText(/where we can check/i)).toBeInTheDocument();
+    // The negative control that separates this from the paid-closed cases: paid
+    // really is available here, so the sentence must name it AND the button must
+    // be on the screen.
+    await expect.element(page.getByText(/can still be submitted with Buzz/i)).toBeInTheDocument();
+    await expect.element(page.getByTestId('buzz-submit')).toBeInTheDocument();
+  });
+});
+
+describe('a gallery with neither path open', () => {
+  test('says why, rather than showing a dead control with no explanation', async () => {
+    // The state r5's `takesFree` change exists to serve: no free capacity and no
+    // usable price. The card falls through to paid-disabled — and the sentence
+    // explaining it has to render from OUTSIDE the free/paid block, which is
+    // hidden exactly here.
+    mocks.visibility = { ...mocks.visibility, price: null, freeSlots: 0, freeSlotsRemaining: 0 };
+    await openAndPick();
+
+    await expect.element(page.getByText(/doesn't take free submissions/i)).toBeInTheDocument();
+    await expect
+      .element(page.getByRole('button', { name: /submit for free/i }))
+      .not.toBeInTheDocument();
+    // Mounted, and unusable. `remix-gallery.utils.ts` leans on exactly this —
+    // "either not mounted at all, or mounted disabled when the card falls
+    // through to paid" — and nothing was reading the attribute, so dropping
+    // `|| !paidOpen` from the button left every test green.
+    await expect.element(page.getByTestId('buzz-submit')).toBeDisabled();
+  });
+});
+
+describe('the decline-fee note', () => {
+  test('is not shown while the free option is selected', async () => {
+    // It describes escrow. A free submission puts none up, so this would tell a
+    // submitter the creator keeps Buzz they never paid.
+    await openAndPick();
+
+    await expect.element(page.getByText(/creator keeps/i)).not.toBeInTheDocument();
+  });
+
+  test('is shown on the paid option, where it is true', async () => {
+    await openAndPick();
+    await page.getByRole('radio', { name: new RegExp(`${PRICE} Buzz`) }).click();
+
+    await expect.element(page.getByText(/creator keeps 210 Buzz/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -1,4 +1,15 @@
-import { Alert, Anchor, Button, Divider, Group, Loader, Modal, Stack, Text } from '@mantine/core';
+import {
+  Alert,
+  Anchor,
+  Button,
+  Divider,
+  Group,
+  Loader,
+  Modal,
+  SegmentedControl,
+  Stack,
+  Text,
+} from '@mantine/core';
 import { IconAlertTriangle, IconInfoCircle } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useState } from 'react';
@@ -8,6 +19,13 @@ import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { useQueryImages } from '~/components/Image/image.utils';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { NoContent } from '~/components/NoContent/NoContent';
+import {
+  freeRefusalExplanation,
+  freeRefusalOutcome,
+  freeSubmissionOffer,
+  paidSubmissionOpen,
+  submissionMethod,
+} from '~/components/RemixGallery/remix-gallery.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -25,14 +43,76 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
   const utils = trpc.useUtils();
   const spendTypes = useAvailableBuzz();
   const [selected, setSelected] = useState<number | null>(null);
+  /**
+   * An explicit choice, or `null` for "whatever the default is". Kept apart from
+   * the resolved method below so the default can reapply when the selection
+   * changes — free eligibility is a property of the image, not of the gallery,
+   * so a choice made about one remix must not carry to the next.
+   */
+  const [chosen, setChosen] = useState<'free' | 'paid' | null>(null);
+  /**
+   * Why a free submission was refused, when a re-read could explain it. Held
+   * here rather than shown as an error notification because it is an ordinary
+   * outcome with a next step — the paid option, already on screen.
+   */
+  const [freeRefusal, setFreeRefusal] = useState<string | null>(null);
 
   const { data: visibility, isError: visibilityFailed } =
     trpc.placement.getRemixGalleryVisibility.useQuery({ imageId: hostImageId });
+
+  /**
+   * Asked for the selected image alone rather than for the whole grid. The
+   * verification is a per-row containment test, and the control only ever needs
+   * the answer for the one image about to be submitted — probing every image the
+   * picker has paged through would grow without bound for the sake of a state
+   * nobody is looking at.
+   */
+  const { data: freeInfo } = trpc.placement.getRemixGalleryFreeEligibility.useQuery(
+    { hostImageId, imageIds: selected != null ? [selected] : [] },
+    { enabled: !!currentUser && selected != null }
+  );
 
   const { images, isLoading, fetchNextPage, hasNextPage, isRefetching } = useQueryImages(
     { userId: currentUser?.id, period: 'AllTime', limit: 50 },
     { enabled: !!currentUser }
   );
+
+  const price = visibility?.price ?? null;
+
+  const takesFree = (visibility?.freeSlots ?? 0) > 0;
+
+  // `null` rather than a number when the viewer may not be told how many of a
+  // creator's free slots are currently held — signed out, gallery closed, or
+  // their own image. Treated as "not on offer" rather than as zero, because zero
+  // would render "all taken right now" about a count we were not given.
+  const slotsHeldKnown = visibility?.freeSlotsRemaining != null;
+
+  // Not `visibility.open`, which is `mode !== 'off'` and says nothing about
+  // price. A gallery can take free submissions and refuse every paid one.
+  //
+  // ⚠️ An UNLOADED gallery is not a closed one. `visibility?.price` is undefined
+  // while the query is in flight, and treating that as closed put the card on
+  // "Submit for free" for a beat on every ordinary paid gallery before it
+  // flipped. Unknown reads as open, which is the pre-existing behaviour and the
+  // one that does not flash.
+  const paidOpen = visibility ? paidSubmissionOpen(visibility.price) : true;
+
+  const offer = freeSubmissionOffer({
+    verified: selected != null && !!freeInfo?.verifiedImageIds.includes(selected),
+    freeSlots: visibility?.freeSlots ?? 0,
+    freeSlotsRemaining: visibility?.freeSlotsRemaining ?? 0,
+    allowanceRemaining: freeInfo?.allowance.remaining ?? 0,
+    usedHere: !!freeInfo?.usedHere,
+    resetsAt: freeInfo?.allowance.resetsAt ?? new Date(),
+    paidOpen,
+  });
+  const freeAvailable = offer.available && slotsHeldKnown;
+  // Withheld while the answer is in flight, so the card says nothing rather than
+  // briefly asserting a reason drawn from defaulted zeroes.
+  const freeUnavailableReason =
+    selected != null && freeInfo && slotsHeldKnown ? offer.reason : null;
+
+  const method = submissionMethod(chosen, freeAvailable, paidOpen, takesFree);
 
   const submit = trpc.placement.submitToRemixGallery.useMutation({
     onSuccess: () => {
@@ -43,14 +123,105 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
       utils.placement.invalidate();
       dialog.onClose();
     },
-    onError: (error) =>
-      showErrorNotification({
-        title: "Couldn't submit that",
-        error: new Error(error.message),
-      }),
-  });
+    onError: async (error) => {
+      /**
+       * A free submission can be refused for two very different kinds of reason,
+       * and only one of them is an ordinary outcome.
+       *
+       * The free primitive re-counts under its lock, so losing the last slot —
+       * or the allowance, or the never-twice rule — is a race the control cannot
+       * win and should not report as an error. Everything else is a real refusal
+       * the submitter needs to read: unverified, a duplicate entry, an
+       * unpublished image, the content rule, a block.
+       *
+       * Told apart by re-reading rather than by matching the server's wording,
+       * which is prose it is free to change. If the fresh numbers still say free
+       * was on offer, the refusal was not about capacity and the message is
+       * shown. Falls back to showing it if the re-read itself fails, because
+       * silence is the one outcome that leaves nobody informed.
+       */
+      /**
+       * 🔴 `staleTime: 0` on both fetches, and it is load-bearing rather than
+       * decorative — the sticker sibling says the same thing at
+       * `Sticker/placement.util.ts`. The client's global default is
+       * `staleTime: Infinity`, and `fetchQuery` applies it: both keys below are
+       * the mounted queries' own keys and both have data at click time, so
+       * without this the "re-read" resolves the CACHE and never calls the
+       * procedure.
+       *
+       * What that cost when it was missing is the whole point of this handler.
+       * Pressing Submit for free requires `freeAvailable`, which means
+       * `freeSubmissionOffer` over those cached inputs returned available — and
+       * `freeRefusalExplanation` is that same function over those same inputs,
+       * so it returned `null` every time. Every refused free submission fell to
+       * the server branch and showed raw server prose, which is precisely the
+       * behaviour the refusal split exists to remove.
+       *
+       * The FRESH `paidOpen` then travels out beside the explanation, because
+       * the rendered one is not merely stale: with `staleTime: Infinity` and no
+       * refetch on focus, a modal left open across a price change holds the
+       * render value for the whole session.
+       *
+       * Using the stale flag here while the explanation beside it used the fresh
+       * one produced the exact failure `paidOpen` was added to prevent: an owner
+       * clearing their price mid-submission got "you can still submit with Buzz"
+       * and a control moved to paid, then `submissionMethod` pulled it back to
+       * free-disabled on the next render — a banner pointing at a button that is
+       * not on the screen.
+       */
+      const refusal =
+        method === 'free' && selected != null
+          ? await utils.placement.getRemixGalleryVisibility
+              .fetch({ imageId: hostImageId }, { staleTime: 0 })
+              .then(async (space) => {
+                const standing = await utils.placement.getRemixGalleryFreeEligibility.fetch(
+                  { hostImageId, imageIds: [selected] },
+                  { staleTime: 0 }
+                );
 
-  const price = visibility?.price ?? null;
+                const freshPaidOpen = paidSubmissionOpen(space.price);
+                return {
+                  paidOpen: freshPaidOpen,
+                  explained:
+                    space.freeSlotsRemaining == null
+                      ? null
+                      : freeRefusalExplanation({
+                          verified: standing.verifiedImageIds.includes(selected),
+                          freeSlots: space.freeSlots,
+                          freeSlotsRemaining: space.freeSlotsRemaining,
+                          allowanceRemaining: standing.allowance.remaining,
+                          usedHere: standing.usedHere,
+                          resetsAt: standing.allowance.resetsAt,
+                          paidOpen: freshPaidOpen,
+                        }),
+                };
+              })
+              // A real network read can reject, which is what `staleTime: 0`
+              // reintroduces. A failed re-read explains nothing, so this lands on
+              // the server's own message — the outcome that leaves somebody
+              // informed. The `paidOpen` here is never read: `freeRefusalOutcome`
+              // consults it only on the explained branch. Supplied so the shape
+              // matches rather than because it decides anything.
+              .catch(() => ({ paidOpen, explained: null }))
+          : { paidOpen, explained: null };
+
+      const explained = refusal.explained;
+      const outcome = freeRefusalOutcome(explained, error.message, refusal.paidOpen);
+      if (outcome.fallBackToPaid) setChosen('paid');
+
+      // Keyed on whether we could explain it, NOT on whether we moved the
+      // control. Those came apart once paid stopped being a guaranteed
+      // alternative: an explained refusal on a gallery that takes no paid
+      // submissions still has something worth saying, and routing it to the
+      // toast instead would file an ordinary outcome as an error.
+      setFreeRefusal(explained !== null ? outcome.message : null);
+      if (explained === null)
+        showErrorNotification({
+          title: outcome.title,
+          error: new Error(outcome.message),
+        });
+    },
+  });
 
   // Filtered rather than shown-and-refused. Until the ceiling arrives nothing is
   // offered: rendering the whole grid first and removing images a moment later
@@ -193,7 +364,13 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                     key={image.id}
                     aspectRatio="square"
                     image={image}
-                    onClick={() => setSelected(image.id)}
+                    onClick={() => {
+                      setSelected(image.id);
+                      // Free eligibility is a property of the image, so a choice
+                      // made about one remix must not carry to the next.
+                      setChosen(null);
+                      setFreeRefusal(null);
+                    }}
                     className={clsx(
                       'cursor-pointer',
                       selected === image.id && 'ring-2 ring-blue-5'
@@ -261,13 +438,110 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
 
         <Divider />
 
-        {/* Same shape as the crypto deposit card's warnings. The amount is the
-            server's own figure, computed with the helper the refund uses from
-            the operator-set rate — quoting "30%" here would be a number this
-            file cannot keep true, and it is the one fact a submitter needs
-            before spending. */}
+        {/* The free/paid choice, and the last moment it can be made. It carries
+            the mode as well as the price because those are two different offers
+            and the placer is about to spend something either way — a free
+            submission still costs them their daily allowance, decline or not.
+            Hidden entirely when the gallery takes no free submissions at all: a
+            control with one reachable answer is not a choice. */}
+        {/* 🔴 Outside the block below, and that is the point rather than layout.
+            The choice is hidden when the creator takes no free submissions —
+            and `freeSlots <= 0` is ALSO one of the rungs that can explain a
+            refusal, when a creator closes their free capacity mid-modal. Nested,
+            the same fresh read that produces this message unmounts the thing
+            rendering it: the submission fails, the toast is suppressed because
+            the refusal was explained, and the only visible change is the control
+            quietly turning into a Buzz button. That is the same shape as the bug
+            this message exists to fix — written for somebody, shown to nobody. */}
+        {freeRefusal && (
+          <>
+            <Divider />
+            <Group gap="xs" wrap="nowrap" align="flex-start" className="shrink-0 px-4 pt-3">
+              <IconAlertTriangle
+                size={14}
+                className="text-yellow-500"
+                style={{ flexShrink: 0, marginTop: 2 }}
+              />
+              <Text size="xs" c="yellow">
+                {freeRefusal}
+              </Text>
+            </Group>
+          </>
+        )}
+
+        {/* 🔴 OUTSIDE the free/paid block, and that is the point rather than
+            layout. This is the sentence saying WHY free is unavailable, and
+            every gate it has lived behind has hidden it in the state that needed
+            it most: `method === 'paid'` hid it once the card started holding on
+            free, and `takesFree` hides it on a gallery that takes no free
+            submissions and no paid ones either — a dead end with no explanation.
+            `offer.reason` is null whenever free is genuinely on offer, so this
+            cannot fire against the FREE button. It can and should fire beside a
+            working PAID one — an unverified remix on an ordinarily-priced
+            gallery is the commonest case there is, and the sentence is the only
+            thing explaining why the free option is greyed out. */}
+        {selected != null && !freeRefusal && freeUnavailableReason && (
+          <>
+            <Divider />
+            <Text size="xs" c="dimmed" className="shrink-0 px-4 pt-3">
+              {freeUnavailableReason}
+            </Text>
+          </>
+        )}
+
+        {selected != null && takesFree && (
+          <>
+            <Divider />
+            <Stack gap={6} className="shrink-0 px-4 pt-3">
+              <SegmentedControl
+                value={method}
+                onChange={(value) => setChosen(value as 'free' | 'paid')}
+                data={[
+                  {
+                    value: 'free',
+                    // Always "needs review" on this surface: a gallery places
+                    // arbitrary media on someone else's page, so `auto` is
+                    // refused for it in three places. Written out rather than
+                    // branched on the mode, which cannot be anything else here.
+                    label: 'Free · needs review',
+                    disabled: !freeAvailable,
+                  },
+                  {
+                    value: 'paid',
+                    label: paidOpen ? `${price} Buzz` : 'With Buzz',
+                    // Not `price == null`: a gallery priced below the surface
+                    // floor refuses paid submissions too, and offering that
+                    // option leads into a second refusal rather than a disabled
+                    // button. Same predicate as the copy, one layer down —
+                    // `paidOpen` reaching only the sentence is how this shipped
+                    // wrong once already.
+                    disabled: !paidOpen,
+                  },
+                ]}
+              />
+
+              {/* No number and no reset time written here. The allowance is a
+                  server-side rule and both of its facts already come back from
+                  `getFreePlacementAllowance`; a sentence that spells either one
+                  out is a claim this file cannot keep true. */}
+              {method === 'free' && freeAvailable && (
+                <Text size="xs" c="dimmed">
+                  This spends a free placement from today&apos;s allowance, and it is spent even if
+                  the creator declines.
+                </Text>
+              )}
+            </Stack>
+          </>
+        )}
+
         <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
-          {visibility?.declineFee ? (
+          {/* The paid path's own warning, and paid-only: a free submission puts
+              nothing in escrow, so there is no decline fee and quoting one would
+              describe money that never moved. The amount is the server's own
+              figure, computed with the helper the refund uses from the
+              operator-set rate — "30%" written here would be a number this file
+              cannot keep true. */}
+          {method === 'paid' && visibility?.declineFee ? (
             // `min-w-0` is what makes the note wrap instead of pushing: a flex
             // item's floor is its content width otherwise, so a long sentence
             // squeezed the Submit button until its label clipped.
@@ -286,30 +560,46 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
             <span className="flex-1" />
           )}
           <div className="shrink-0">
-            {/* The price shown here is the one the balance check runs against, and
+            {/* A plain button on the free path. `BuzzTransactionButton` exists to
+              check a balance and open the top-up flow, and running a free
+              submission through it would ask someone to have Buzz they are not
+              about to spend. */}
+            {method === 'free' ? (
+              <Button
+                disabled={!selected || !visibility?.open || !freeAvailable}
+                loading={submit.isPending}
+                onClick={() =>
+                  selected != null && submit.mutate({ hostImageId, imageId: selected, free: true })
+                }
+              >
+                Submit for free
+              </Button>
+            ) : (
+              /* The price shown here is the one the balance check runs against, and
               the owner can move it between this render and the click. The
               mutation reads the price fresh, so the button is honest about
               affordability but cannot promise the amount — hence the note above
-              it rather than a silent charge. */}
-            <BuzzTransactionButton
-              buzzAmount={price ?? 0}
-              // Says what it means. `BuzzTransactionButton` already ran the pair
-              // through `useAvailableBuzz`, which strips both and appends the
-              // domain's, so this renders identically — the pair was never the
-              // hole. That was server-side, where the escrow drew from both.
-              accountTypes={spendTypes}
-              label="Submit"
-              disabled={!selected || !visibility?.open || price == null}
-              loading={submit.isPending}
-              // The price this render displayed travels with the submission, so
-              // the server refuses rather than charging a number the submitter
-              // never agreed to. Affordability was checked against this one too.
-              onPerformTransaction={() =>
-                selected != null &&
-                price != null &&
-                submit.mutate({ hostImageId, imageId: selected, expectedPrice: price })
-              }
-            />
+              it rather than a silent charge. */
+              <BuzzTransactionButton
+                buzzAmount={price ?? 0}
+                // Says what it means. `BuzzTransactionButton` already ran the pair
+                // through `useAvailableBuzz`, which strips both and appends the
+                // domain's, so this renders identically — the pair was never the
+                // hole. That was server-side, where the escrow drew from both.
+                accountTypes={spendTypes}
+                label="Submit"
+                disabled={!selected || !visibility?.open || !paidOpen}
+                loading={submit.isPending}
+                // The price this render displayed travels with the submission, so
+                // the server refuses rather than charging a number the submitter
+                // never agreed to. Affordability was checked against this one too.
+                onPerformTransaction={() =>
+                  selected != null &&
+                  price != null &&
+                  submit.mutate({ hostImageId, imageId: selected, expectedPrice: price })
+                }
+              />
+            )}
           </div>
         </div>
       </div>

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -2,9 +2,325 @@ import { describe, expect, it } from 'vitest';
 import type { RemixGalleryItem } from '~/components/RemixGallery/remix-gallery.utils';
 import {
   dedupeGalleryItems,
+  freeRefusalExplanation,
+  freeRefusalOutcome,
+  freeSubmissionOffer,
   galleryDialogImages,
+  paidSubmissionOpen,
+  submissionMethod,
   trimToWholeRows,
 } from '~/components/RemixGallery/remix-gallery.utils';
+import { PLACEMENT_SURFACES } from '~/shared/utils/placement';
+
+describe('what a refused free submission is told', () => {
+  const stillOffered = {
+    verified: true,
+    freeSlots: 3,
+    freeSlotsRemaining: 2,
+    allowanceRemaining: 1,
+    usedHere: false,
+    resetsAt: new Date('2026-03-04T00:00:00Z'),
+    paidOpen: true,
+  };
+
+  it('explains nothing when the re-read says free was still on offer', () => {
+    // 🔴 The null is the fix. `freeSubmissionOffer` always has an answer, so a
+    // caller asking it AFTER a refusal is always given one — and the free path
+    // is refused for at least a dozen reasons it cannot see: unverified, a
+    // duplicate entry, an unpublished image, the content rule, a block, a
+    // moderator suspension. A shape that cannot say "I don't know" reports every
+    // one of those as whichever rung happens to be lowest.
+    expect(freeRefusalExplanation(stillOffered)).toBeNull();
+  });
+
+  it('explains a refusal the re-read does account for', () => {
+    expect(freeRefusalExplanation({ ...stillOffered, freeSlotsRemaining: 0 })).toMatch(
+      /all taken right now/i
+    );
+  });
+
+  it('shows the server’s own words when nothing explains it', () => {
+    // The message the careful copy lives in. Without this branch,
+    // `FREE_NEEDS_VERIFIED_REFUSAL` — the sentence explaining why paying is the
+    // alternative — reaches nobody, because this handler is its only path.
+    const outcome = freeRefusalOutcome(
+      null,
+      'remix gallery: free submissions are for remixes…',
+      true
+    );
+
+    expect(outcome.message).toBe('remix gallery: free submissions are for remixes…');
+    expect(outcome.title).toMatch(/couldn't submit/i);
+  });
+
+  it('does NOT move the control to paid on an unexplained refusal', () => {
+    // Settling on paid asserts that money was the problem. For a blocked or
+    // suspended placer it is not: they press the paid button and meet the same
+    // refusal, having been told the opposite of what is wrong.
+    expect(
+      freeRefusalOutcome(null, 'remix gallery: you cannot place right now', true).fallBackToPaid
+    ).toBe(false);
+  });
+
+  it('treats an EMPTY explanation as explained, not as unexplained', () => {
+    // The guard is `explained !== null` and the comment says why; nothing
+    // asserted it, because no rung returns ''. Under truthiness an empty rung
+    // would take the branch that means "we could not explain this" and hand the
+    // submitter raw server prose instead.
+    expect(freeRefusalOutcome('', 'server prose', true)).toMatchObject({
+      fallBackToPaid: true,
+    });
+    expect(freeRefusalOutcome('', 'server prose', true).message).not.toContain('server prose');
+  });
+
+  it('moves the control to paid when the refusal WAS about free capacity', () => {
+    // Every rung is a limit on free capacity that Buzz is not subject to, so
+    // here the fall-back is a true statement about the next step.
+    const outcome = freeRefusalOutcome(
+      'The free slots on this image are all taken right now.',
+      'x',
+      true
+    );
+
+    expect(outcome.fallBackToPaid).toBe(true);
+    expect(outcome.message).toMatch(/all taken right now/i);
+    expect(outcome.message).toMatch(/still submit with Buzz/i);
+  });
+
+  it('does not recommend Buzz on a gallery that refuses paid submissions', () => {
+    // 🔴 The two paths are deliberately asymmetric: the service holds free to
+    // none of the price rules, so an unpriced or below-floor gallery accepts
+    // free and refuses paid. Recommending Buzz there sends someone to a disabled
+    // button or into a second refusal.
+    const outcome = freeRefusalOutcome(
+      'The free slots on this image are all taken right now.',
+      'x',
+      false
+    );
+
+    expect(outcome.fallBackToPaid).toBe(false);
+    expect(outcome.message).not.toMatch(/still submit with Buzz/i);
+    expect(outcome.message).toMatch(/not taking paid submissions/i);
+  });
+});
+
+describe('submissionMethod', () => {
+  it('defaults to free when free is available, and to paid when it is not', () => {
+    expect(submissionMethod(null, true, true, true)).toBe('free');
+    expect(submissionMethod(null, false, true, true)).toBe('paid');
+  });
+
+  it('honours an explicit choice', () => {
+    expect(submissionMethod('paid', true, true, true)).toBe('paid');
+    expect(submissionMethod('free', true, true, true)).toBe('free');
+  });
+
+  it('never resolves to free once free stops being available', () => {
+    // The half that survives losing the race for the last slot: `chosen` still
+    // says free, the fresh numbers no longer do, and the control must not submit
+    // free anyway.
+    expect(submissionMethod('free', false, true, true)).toBe('paid');
+  });
+
+  it('falls through to paid when NEITHER path is open', () => {
+    // Nothing to hold on. Forcing free here renders a disabled "Submit for
+    // free" on a gallery that takes none; paid-disabled-beside-the-reason is
+    // the honest rendering of "no route in".
+    expect(submissionMethod(null, false, false, false)).toBe('paid');
+  });
+
+  it.each([
+    ['a stale free choice', 'free' as const, false],
+    ['an explicit paid choice', 'paid' as const, true],
+    ['no choice at all', null, false],
+  ])('stays on free when paid is closed — %s', (_label, chosen, freeAvailable) => {
+    // 🔴 Falling to paid is only honest when paid exists. On a gallery that
+    // takes free submissions and refuses every paid one, dropping to paid lands
+    // on a disabled button with no explanation, or on an enabled one that opens
+    // the buy-Buzz flow for a submission the server will refuse.
+    //
+    // Every route into paid is covered, because each is a different line: the
+    // stale-choice rule, an explicit press, and the default.
+    expect(submissionMethod(chosen, freeAvailable, false, true)).toBe('free');
+  });
+});
+
+describe('paidSubmissionOpen', () => {
+  // Mirrors the two refusals the paid path makes, which `open` does not cover —
+  // that is `mode !== 'off'` and says nothing about price.
+  it.each([
+    ['unpriced', null],
+    ['undefined while loading', undefined],
+    ['below the surface floor', PLACEMENT_SURFACES.remixGallery.serverMinPrice - 1],
+  ])('is closed when %s', (_label, price) => {
+    expect(paidSubmissionOpen(price)).toBe(false);
+  });
+
+  it.each([
+    ['exactly at the floor', PLACEMENT_SURFACES.remixGallery.serverMinPrice],
+    ['above it', PLACEMENT_SURFACES.remixGallery.serverMinPrice + 10],
+  ])('is open when priced %s', (_label, price) => {
+    expect(paidSubmissionOpen(price)).toBe(true);
+  });
+});
+
+describe('freeSubmissionOffer', () => {
+  const RESETS_AT = new Date('2026-03-04T00:00:00Z');
+
+  /** Everything satisfied, so each case below breaks exactly one thing. */
+  const eligible = {
+    verified: true,
+    freeSlots: 3,
+    freeSlotsRemaining: 2,
+    allowanceRemaining: 1,
+    usedHere: false,
+    resetsAt: RESETS_AT,
+    paidOpen: true,
+  };
+
+  /** Each condition on its own, so a pair can be built by merging two. */
+  const broken = {
+    verified: { verified: false },
+    usedHere: { usedHere: true },
+    freeSlots: { freeSlots: 0, freeSlotsRemaining: 0 },
+    allowanceRemaining: { allowanceRemaining: 0 },
+    freeSlotsRemaining: { freeSlotsRemaining: 0 },
+  } as const;
+
+  /**
+   * The ladder, longest-lasting refusal first, with the fragment each one owns.
+   *
+   * The order is the design: a refusal that lifts tonight must never be reported
+   * over one that never lifts, or someone comes back tomorrow to be told the
+   * thing nobody told them today.
+   */
+  const ladder = [
+    ['verified', /where we can check/i],
+    ['usedHere', /once per gallery/i],
+    ['freeSlots', /doesn't take free/i],
+    ['allowanceRemaining', /used today's free placement/i],
+    ['freeSlotsRemaining', /all taken right now/i],
+  ] as const;
+
+  it.each(ladder.slice(0, -1).map((entry, index) => [entry[0], ladder[index + 1][0]] as const))(
+    'reports %s ahead of %s when BOTH are true',
+    (first, second) => {
+      // Both set at once, which is the only way an ordering can be asserted.
+      // Fixtures that break one condition at a time pass under any order, so
+      // the two-line swap that inverts the ladder would go unnoticed.
+      const expected = ladder.find(([name]) => name === first)![1];
+      const { available, reason } = freeSubmissionOffer({
+        ...eligible,
+        ...broken[first],
+        ...broken[second],
+      });
+
+      // `available` on every branch, not only on the happy one. The modal reads
+      // it to decide whether the free button works, and a rung returning a
+      // refusal reason alongside `available: true` would offer a submission the
+      // claim then refuses — the state the docstring calls impossible and which
+      // nothing asserted on four of six outcomes.
+      expect(available).toBe(false);
+      expect(reason).toMatch(expected);
+    }
+  );
+
+  it.each(ladder.map((entry, index) => [entry[0], index] as const))(
+    'reports %s over every rung BELOW it, all set at once',
+    (name, index) => {
+      // A suffix cascade rather than one all-true case. All-true asserts only
+      // that rung 1 wins, so a swap anywhere among the rest leaves it green —
+      // it reads as a transitivity check and is not one. Breaking every rung
+      // from this one down, for each rung in turn, is the check that
+      // discriminates: any reordering changes at least one winner.
+      const { available, reason } = freeSubmissionOffer(
+        ladder
+          .slice(index)
+          .reduce((input, [rung]) => ({ ...input, ...broken[rung] }), { ...eligible })
+      );
+
+      expect(available).toBe(false);
+      expect(reason).toMatch(ladder[index][1]);
+    }
+  );
+
+  it('reads the reset moment off the server date rather than naming a timezone', () => {
+    // "midnight UTC" is true of the rule and misleading to a person, and it is a
+    // server-side rule this file must not restate — raise the reset and a
+    // hardcoded sentence goes quietly false.
+    const { reason } = freeSubmissionOffer({ ...eligible, ...broken.allowanceRemaining });
+
+    expect(reason).not.toMatch(/UTC/i);
+    expect(reason).toContain(
+      RESETS_AT.toLocaleString(undefined, { weekday: 'short', hour: 'numeric', minute: '2-digit' })
+    );
+  });
+
+  it('offers free when every condition holds', () => {
+    expect(freeSubmissionOffer(eligible)).toEqual({ available: true, reason: null });
+  });
+
+  it('refuses an unverified remix and names paying as the alternative', () => {
+    const { available, reason } = freeSubmissionOffer({ ...eligible, verified: false });
+
+    expect(available).toBe(false);
+    expect(reason).toMatch(/with Buzz/i);
+    // It must not call an off-site remix "not a remix": that is both wrong and
+    // an accusation, and it is the case a submitter is most likely to hit on
+    // work they know they made.
+    expect(reason).not.toMatch(/not a remix|isn't a remix/i);
+  });
+
+  it('does not name paying when paid is closed either', () => {
+    // 🔴 `freeRefusalOutcome` got this a round earlier and this rung did not.
+    // On an unpriced or below-floor gallery the card holds on free with every
+    // control disabled and no Buzz button mounted at all, so pointing at one is
+    // pointing off the screen — and at a submission the server would refuse.
+    const { reason } = freeSubmissionOffer({ ...eligible, verified: false, paidOpen: false });
+
+    expect(reason).toMatch(/where we can check/i);
+    expect(reason).not.toMatch(/can still be submitted with Buzz/i);
+    expect(reason).toMatch(/not taking paid submissions/i);
+  });
+
+  it('leads with verification even when a slot shortage is also true', () => {
+    // Order is the whole design here. Naming the shortage would send someone
+    // back tomorrow to be refused for the reason they were refused today.
+    const { reason } = freeSubmissionOffer({
+      ...eligible,
+      verified: false,
+      freeSlotsRemaining: 0,
+      allowanceRemaining: 0,
+      usedHere: true,
+    });
+
+    expect(reason).toMatch(/where we can check/i);
+  });
+
+  it('tells the two meanings of "no slots remaining" apart', () => {
+    // `freeSlotsRemaining: 0` covers both "this creator takes none" and "they
+    // are all held right now" — the resolver short-circuits the count at zero
+    // capacity — and the difference decides whether coming back later helps.
+    const takesNone = freeSubmissionOffer({ ...eligible, freeSlots: 0, freeSlotsRemaining: 0 });
+    const allHeld = freeSubmissionOffer({ ...eligible, freeSlots: 3, freeSlotsRemaining: 0 });
+
+    expect(takesNone.reason).toMatch(/doesn't take free/i);
+    expect(allHeld.reason).toMatch(/all taken right now/i);
+    expect(takesNone.reason).not.toBe(allHeld.reason);
+  });
+
+  it('separates a spent daily allowance from a gallery already used', () => {
+    // One comes back at midnight and the other never does, so a single message
+    // for both would tell half of them to wait for something that will not
+    // happen.
+    expect(freeSubmissionOffer({ ...eligible, allowanceRemaining: 0 }).reason).toMatch(
+      /comes back at/i
+    );
+    expect(freeSubmissionOffer({ ...eligible, usedHere: true }).reason).toMatch(
+      /once per gallery/i
+    );
+  });
+});
 
 const items = (count: number, startId = 1) =>
   Array.from({ length: count }, (_, index) => ({

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -1,4 +1,5 @@
 import type { ImageGetInfinite } from '~/types/router';
+import { PLACEMENT_SURFACES } from '~/shared/utils/placement';
 import { REMIX_GALLERY_ROW_WIDTH } from '~/shared/utils/remix-gallery';
 
 /**
@@ -66,3 +67,248 @@ export function galleryDialogImages(imageId: number, items: RemixGalleryItem[]) 
   if (index === -1) return [];
   return images.slice(Math.max(index - 50, 0), index + 50);
 }
+
+export type FreeSubmissionInputs = {
+  /** The server resolved this remix as derived from the host image. */
+  verified: boolean;
+  /** What the creator accepts. `0` is them taking none — a setting, not a queue. */
+  freeSlots: number;
+  /** What is left right now. Stale by construction; the mutation re-counts. */
+  freeSlotsRemaining: number;
+  /** Free placements the placer has left today, across every surface. */
+  allowanceRemaining: number;
+  /** Free is once per gallery per placer, ever — not once per day. */
+  usedHere: boolean;
+  /**
+   * Whether the paid path would accept this submission — see
+   * `paidSubmissionOpen`. Here because the FIRST rung names paying as the
+   * alternative, and a gallery can take free submissions and refuse every paid
+   * one. `freeRefusalOutcome` got this a round earlier; this sentence did not,
+   * and the r6 gate widened the states it renders in.
+   */
+  paidOpen: boolean;
+  /**
+   * When the allowance comes back, from `getFreePlacementAllowance` rather than
+   * a sentence written here. The reset is midnight UTC today and that is a
+   * server-side rule; a client that spells it out is asserting something it does
+   * not own, and would keep asserting it after the rule moved.
+   */
+  resetsAt: Date | string;
+};
+
+/**
+ * When the allowance returns, in the reader's own timezone.
+ *
+ * Not "midnight UTC": that is true of the rule and misleading to a person, for
+ * whom the boundary lands at some ordinary hour of their own day. Derived from
+ * the server's date either way, so nothing here has to stay correct on its own.
+ */
+const allowanceResetLabel = (resetsAt: Date | string) =>
+  new Date(resetsAt).toLocaleString(undefined, {
+    weekday: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+/**
+ * Whether the free option may be offered, and if not, why.
+ *
+ * Pure, and apart from the modal, because this is the part worth being sure
+ * about: five inputs, an order that matters, and copy that is wrong in a
+ * different way for each of them. Rendering it is the easy half.
+ *
+ * **The order is by how long each refusal lasts, longest first**, and every
+ * adjacent pair is pinned by a test that makes both conditions true at once —
+ * which is the only way an ordering can be asserted at all.
+ *
+ * Permanent for this image (`verified`), then permanent for this gallery
+ * (`usedHere`), then the creator's own setting (`freeSlots`), then today
+ * (`allowanceRemaining`), then right now (`freeSlotsRemaining`). Getting this
+ * backwards is not a cosmetic problem: "it comes back at midnight UTC" told to
+ * someone whose real obstacle is a creator taking no free submissions is a
+ * promise about a gallery that will never accept one, and they will come back
+ * tomorrow to be refused for the reason nobody named today.
+ *
+ * `reason` is `null` exactly when free is on offer, so a caller cannot render a
+ * refusal and an offer at once.
+ */
+export function freeSubmissionOffer({
+  verified,
+  freeSlots,
+  freeSlotsRemaining,
+  allowanceRemaining,
+  usedHere,
+  resetsAt,
+  paidOpen,
+}: FreeSubmissionInputs): { available: boolean; reason: string | null } {
+  if (!verified)
+    return {
+      available: false,
+      // 🔴 The alternative is only named when it exists. On an unpriced or
+      // below-floor gallery the paid control is unusable — either not mounted at
+      // all, or mounted disabled when the card falls through to paid — so the
+      // unconditional version of this sentence pointed at a Buzz control nobody
+      // can press, for a submission the server would refuse anyway.
+      reason: paidOpen
+        ? 'Free submissions are for remixes made from this image here on the site, where we can check. Anything else can still be submitted with Buzz.'
+        : 'Free submissions are for remixes made from this image here on the site, where we can check — and this creator is not taking paid submissions either.',
+    };
+
+  if (usedHere)
+    return {
+      available: false,
+      reason:
+        "You've already used a free submission on this gallery. Free is once per gallery, not once a day.",
+    };
+
+  // Above the allowance, because this one never lifts: a creator who takes no
+  // free submissions will not start at midnight. The two states behind
+  // `freeSlotsRemaining: 0` are told apart by reading `freeSlots` beside it —
+  // the resolver short-circuits the reservation count at zero capacity, so the
+  // number alone cannot say which one this is.
+  if (freeSlots <= 0)
+    return { available: false, reason: "This creator doesn't take free submissions." };
+
+  // ⚠️ `~/components/Sticker/free-offer.ts` (`freeRefusalMessage`) says the same
+  // thing about the same number, written independently — the allowance is one
+  // count across every surface. Deliberately not shared: the two ladders order
+  // their reasons differently, and that ordering is what decides which sentence
+  // a person sees, so a shared module would have to hold the ordering too.
+  // Change this wording and change its twin. Its twin still spells out "midnight
+  // UTC" rather than reading `resetsAt`; that is the same fix as this one.
+  if (allowanceRemaining <= 0)
+    return {
+      available: false,
+      reason: `You've used today's free placement. It comes back at ${allowanceResetLabel(
+        resetsAt
+      )}.`,
+    };
+
+  if (freeSlotsRemaining <= 0)
+    return { available: false, reason: 'The free slots on this image are all taken right now.' };
+
+  return { available: true, reason: null };
+}
+
+/**
+ * Whether a re-read explains a free submission that was just refused — and
+ * `null` when it does not.
+ *
+ * **The null is the whole point.** `freeSubmissionOffer` always has an answer,
+ * because the caller hands it every input it needs; asked *after* a refusal it
+ * therefore always sounds certain, and a caller consulting it will always
+ * believe it. But the free path is refused for at least a dozen reasons this
+ * function cannot see — an unverified remix, a duplicate entry, an unpublished
+ * image, the content rule, a block or a moderator suspension — and a shape that
+ * cannot say "I don't know" turns every one of those into whatever rung happens
+ * to be lowest.
+ *
+ * So: re-read, ask again, and if the fresh numbers say free was still on offer,
+ * the refusal was not about capacity and this returns nothing. What to do with
+ * that is `freeRefusalOutcome`'s decision, not this one's.
+ */
+export const freeRefusalExplanation = (fresh: FreeSubmissionInputs) =>
+  freeSubmissionOffer(fresh).reason;
+
+/**
+ * What to tell someone whose free submission was refused, and whether to move
+ * the control to paid.
+ *
+ * Falling back is its own decision rather than a consequence of having a
+ * message, because settling the control on paid **asserts that money was the
+ * problem**. That is true of every rung above — each one is a limit on free
+ * capacity that Buzz is not subject to — and false of everything the re-read
+ * could not explain: a blocked or suspended placer who is quietly moved to the
+ * paid button presses it and meets the same refusal, having been told the
+ * opposite of what is wrong.
+ *
+ * Pure, so both halves are testable without a query client, and so the modal
+ * holds no policy about which refusals money solves.
+ */
+export function freeRefusalOutcome(
+  explained: string | null,
+  serverMessage: string,
+  /** Whether the paid path would actually accept this submission. */
+  paidOpen: boolean
+) {
+  // `!== null`, not truthiness. They agree today only because every rung returns
+  // a sentence; a rung that ever returned an empty string would silently take
+  // the server branch, which is the branch that says "we could not explain this".
+  if (explained !== null)
+    return {
+      title: 'That free slot got away',
+      // 🔴 The offer of the paid path is conditional on the paid path existing.
+      // A gallery can accept free submissions and refuse paid ones — the service
+      // deliberately holds free to none of the price rules, and there are tests
+      // asserting both an unpriced and a below-floor gallery take free and
+      // refuse paid. Told to pay on one of those, a submitter meets either a
+      // disabled button or a second refusal.
+      message: paidOpen
+        ? `${explained} Nothing was spent — you can still submit with Buzz.`
+        : `${explained} Nothing was spent, and this gallery is not taking paid submissions either.`,
+      // Same condition, because moving the control is the same claim as making
+      // it in words.
+      fallBackToPaid: paidOpen,
+    };
+
+  // The server's own words, unedited. It is the only party that knows, and
+  // guessing here is what produced a modal that told everyone they lost a race.
+  return { title: "Couldn't submit that", message: serverMessage, fallBackToPaid: false };
+}
+
+/**
+ * Whether this gallery would accept a PAID submission.
+ *
+ * Not the same question as `open`, which `getRemixGalleryVisibility` answers
+ * from `mode !== 'off'` alone. Price and free capacity are independent in the
+ * schema, so a gallery can be open, take free submissions, and refuse every paid
+ * one — unpriced, where the submit button is disabled, or priced below the
+ * surface floor, where the button works and the mutation refuses.
+ *
+ * Mirrors the two refusals on the paid path in `createRemixGallerySubmission`.
+ * A third rule there needs one here, or the card starts recommending a refusal
+ * again.
+ */
+export const paidSubmissionOpen = (price: number | null | undefined) =>
+  price != null && price >= PLACEMENT_SURFACES.remixGallery.serverMinPrice;
+
+/**
+ * Which option the control is on: an explicit choice, else free when it is
+ * available.
+ *
+ * Two rules, and the second took a round to get right.
+ *
+ * `chosen === 'free'` cannot survive free becoming unavailable — that is what
+ * carries a lost race for the last slot without the submitter watching a control
+ * change under them. But falling to paid is only honest when paid exists: on a
+ * gallery that takes free submissions and refuses every paid one, dropping to
+ * paid lands either on a disabled button with no explanation, or on an enabled
+ * one that opens the buy-Buzz flow for a submission the server will refuse.
+ * Being asked to top up for a guaranteed refusal is worse than the refusal. So
+ * `paidOpen` is checked first and the control stays on free.
+ *
+ * ⚠️ That leaves the free button disabled whenever free is also unavailable, and
+ * the card MUST still render `freeSubmissionOffer`'s reason there — the sentence
+ * saying why. Gating that sentence on the paid option being selected made it
+ * unreachable in exactly this state, which is three disabled controls and no
+ * explanation. If you change this function, check what renders beside it.
+ *
+ * Pure and out here because its inversion charges someone Buzz, and because
+ * `paidOpen` reaching only the copy — true in the sentence, false in the control
+ * — is how this shipped wrong the first time.
+ */
+export const submissionMethod = (
+  chosen: 'free' | 'paid' | null,
+  freeAvailable: boolean,
+  paidOpen: boolean,
+  /** Whether this gallery accepts free submissions at all. */
+  takesFree: boolean
+): 'free' | 'paid' => {
+  // `takesFree`, not just `!paidOpen`: with NEITHER path open there is nothing
+  // to hold on, and forcing free there renders a disabled "Submit for free" on
+  // a gallery that takes none. Falling through puts the card on paid, disabled.
+  // The reason renders from outside the free/paid block precisely so this state
+  // is not a dead end with no explanation — check that gate if you change this.
+  if (!paidOpen && takesFree) return 'free';
+  return chosen === 'free' && !freeAvailable ? 'paid' : chosen ?? (freeAvailable ? 'free' : 'paid');
+};

--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -1,0 +1,336 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import type * as PlacementUtil from '~/components/Sticker/placement.util';
+import type * as StickerUtil from '~/components/Sticker/sticker.util';
+import type * as CosmeticShopUtil from '~/components/CosmeticShop/cosmetic-shop.util';
+import type * as Trpc from '~/utils/trpc';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { resolveTreatment } from '~/components/Sticker/treatments/sticker-treatments';
+import type { StickerDraft } from '~/store/sticker-placement-draft.store';
+
+/**
+ * What the buttons on a draft actually SEND.
+ *
+ * `isPlacingFree` is well covered as a function; nothing covered the component
+ * using it to fill the payload. Deleting `free: placingFree` from the mutation
+ * input left every test in this PR green while every free press charged Buzz —
+ * so what is asserted here is the value on the wire, not that a prop of the right
+ * type exists.
+ */
+const IMAGE_ID = 74;
+const COSMETIC_ID = 85;
+const PRICE = 700;
+
+/** Every press, with its variables, in order. */
+const placed: { imageId: number; free: boolean; data: Record<string, unknown> }[] = [];
+
+vi.mock('~/components/Sticker/placement.util', async (importOriginal) => ({
+  ...(await importOriginal<typeof PlacementUtil>()),
+  useCreateStickerPlacement: () => ({
+    mutate: (variables: (typeof placed)[number]) => placed.push(variables),
+    isPending: false,
+  }),
+}));
+
+/**
+ * Mocked because it is a dependency, not the thing under test: the real one
+ * renders a currency badge and an account picker and wants the Buzz providers.
+ * Reduced to a button that calls what it is given, so a paid press is still
+ * observable here — the free press goes through a real Mantine `Button`.
+ */
+vi.mock('~/components/Buzz/BuzzTransactionButton', () => ({
+  BuzzTransactionButton: ({
+    label,
+    onPerformTransaction,
+  }: {
+    label: string;
+    onPerformTransaction: () => void;
+  }) => (
+    // `data-buzz-button` is load-bearing. Without it the stub is
+    // indistinguishable from a plain Mantine `Button` by name alone, so swapping
+    // the free option TO a BuzzTransactionButton left all ten tests green — the
+    // component's own docstring argues at length that it must not be one, and
+    // nothing held that argument.
+    <button type="button" data-buzz-button onClick={onPerformTransaction}>
+      {label}
+    </button>
+  ),
+}));
+
+vi.mock('~/components/Buzz/useAvailableBuzz', () => ({ useAvailableBuzz: () => ['yellow'] }));
+
+// `EdgeImage` resolves its URL through `useCurrentUser`, which reads a session
+// context this tree does not mount — and the throw happens inside render, so the
+// whole draft comes back empty rather than failing on the missing provider.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 7 }) }));
+
+// Every one of these spreads the real module rather than listing its exports. A
+// hand-listed mock couples this file to the whole transitive graph of the draft
+// and nothing warns when that graph grows — the wholesale `~/utils/trpc` version
+// of this file collected ZERO tests, because another module in the graph imports
+// `setTrpcBatchingEnabled` and the stub did not provide it.
+vi.mock('~/components/CosmeticShop/cosmetic-shop.util', async (importOriginal) => ({
+  ...(await importOriginal<typeof CosmeticShopUtil>()),
+  useMutateCosmeticShop: () => ({ purchaseShopItem: vi.fn(), purchasingShopItem: false }),
+}));
+vi.mock('~/components/Sticker/sticker.util', async (importOriginal) => ({
+  ...(await importOriginal<typeof StickerUtil>()),
+  useBuyStickerUses: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof Trpc>();
+  return {
+    ...actual,
+    trpc: {
+      ...actual.trpc,
+      useUtils: () => ({ cosmetic: { getStickerBalances: { invalidate: vi.fn() } } }),
+    },
+  };
+});
+
+const draft: StickerDraft = {
+  id: 'draft-1',
+  imageId: IMAGE_ID,
+  cosmeticId: COSMETIC_ID,
+  x: 0.5,
+  // Mid-height and small, so the buy cluster is reachable whichever side of the
+  // sticker it settles on. It is absolutely positioned and flips above the
+  // sticker when the space below is obstructed, and a cluster that lands outside
+  // the harness iframe cannot be scrolled to — Playwright then reports "visible,
+  // enabled and stable", fails to scroll, and burns the whole click budget on
+  // something that reads as actionable. The container is sized under the default
+  // 414x896 viewport for the same reason; 800 wide put it off the right edge.
+  y: 0.6,
+  scale: 0.25,
+  rotation: 15,
+  flip: false,
+  opacity: 1,
+};
+
+const art = { id: COSMETIC_ID, name: 'Star', slug: 'star', url: 'star.png' };
+
+const { DraftSticker } = await import('~/components/Sticker/DraftSticker');
+
+/**
+ * `ownerShare` is opt-in, and that is not tidiness.
+ *
+ * The payout chip is `max-w-[240px]`, and it is the widest child of a `w-max`
+ * cluster — so rendering it pushes the cluster's centre far enough left that the
+ * Place button lands at a NEGATIVE x, outside the harness iframe and unreachable
+ * by any amount of scrolling. Measured: x = -65 in a 414-wide viewport.
+ *
+ * So the tests that press a button render without it, and the two that assert the
+ * chip do not press anything. Splitting them keeps both properties covered
+ * without either test depending on the other's layout.
+ */
+const renderDraft = async (
+  freeOffer: { instant: boolean } | null,
+  { ownerShare }: { ownerShare?: number } = {}
+) => {
+  renderWithProviders(
+    // Positioned absolutely inside the media box in the app; a plain relative
+    // parent is enough here, since none of this asserts geometry.
+    // Sized to fit inside the harness iframe rather than to look like a media
+    // box: the cluster has to be reachable, and none of this asserts geometry.
+    <div style={{ position: 'relative', width: 380, height: 600 }}>
+      <DraftSticker
+        draft={draft}
+        art={art}
+        selected
+        dressed={resolveTreatment({ treatment: 'none', surface: 'detail', isPending: false })}
+        price={PRICE}
+        freeOffer={freeOffer}
+        ownerShare={ownerShare}
+        ownerUsername="creator"
+        onGesture={() => true}
+      />
+    </div>
+  );
+
+  // Anchored on the button existing rather than on a name, so an ambiguous
+  // locator fails as an assertion instead of a 15 s strict-mode retry.
+  await expect.element(page.getByRole('button').first()).toBeInTheDocument();
+};
+
+/**
+ * The paid button, pressed through the DOM rather than through the locator.
+ *
+ * ⚠️ **Why this is acceptable here and nowhere else:** `BuzzTransactionButton` is
+ * mocked down to a bare `<button onClick={…}>`, so the actionability a locator
+ * click would check belongs to the stub rather than to anything shipped. There is
+ * no real control here whose reachability could be asserted, whatever method is
+ * used — and what these two tests are for is the payload the handler sends. The
+ * free press, which is the button this PR added and a real Mantine one, goes
+ * through the ordinary locator with its full actionability check.
+ *
+ * (A locator click on the stub does not succeed in this harness: the cluster is
+ * absolutely positioned inside the rotated draft, and the measured failure was a
+ * negative **x**. Nothing in the component moves it horizontally —
+ * `shouldFlipPlaceButton` is vertical only, as `DraftSticker.tsx` says where it is
+ * used — so the flip is not the cause. Beyond that the mechanism is unestablished,
+ * and it is not the reason for the exemption either way.)
+ *
+ * 🔴 **Five things end this exemption**, and any one of them means going back to a
+ * locator click and solving the reachability properly:
+ * 1. `BuzzTransactionButton` stops being mocked.
+ * 2. Either helper is used to assert reachability, or enabled/disabled state,
+ *    rather than the payload.
+ * 3. The cluster gains an overlay, so a press could be intercepted.
+ * 4. The pattern is copied into another file as habit.
+ * 5. **The paid control acquires an inert state.** The real button is
+ *    `disabled={… || !!error || isLoadingBalance || loading}` and routes its click
+ *    through `conditionalPerformTransaction`, which can open the buy-Buzz flow
+ *    INSTEAD of calling the handler. The stub honours none of that, and the draft
+ *    already passes `loading={place.isPending}` — so the moment an error or
+ *    disabled condition is added, or a test renders with `isPending: true`, a DOM
+ *    press fires a handler a real user could not fire and both payload tests
+ *    assert a send that cannot happen.
+ */
+const pressPaid = async () => {
+  const button = (await page.getByRole('button', { name: 'Place' }).element()) as HTMLElement;
+  button.click();
+};
+
+/**
+ * The paid segment, pressed the same way and for the same reason — it sits in the
+ * same cluster. A Mantine `SegmentedControl` radio is a visually-hidden input
+ * besides, so a locator click is waiting on something that is never visible by
+ * design.
+ */
+const choosePaid = async () => {
+  const radio = (await page.getByRole('radio', { name: `${PRICE} Buzz` }).element()) as HTMLElement;
+  radio.click();
+};
+
+beforeEach(() => {
+  placed.length = 0;
+});
+
+describe('what a draft sends when it is placed', () => {
+  test('a free press sends free: true', async () => {
+    await renderDraft({ instant: true });
+
+    await page.getByRole('button', { name: 'Place free' }).click();
+
+    expect(placed).toHaveLength(1);
+    // The value, not the presence of a correctly-typed prop. `free: false` here
+    // is the whole defect: it charges Buzz for a placement somebody chose to
+    // make free, and no other test in this PR can see it.
+    expect(placed[0].free).toBe(true);
+    expect(placed[0].imageId).toBe(IMAGE_ID);
+  });
+
+  test('a paid press sends free: false', async () => {
+    await renderDraft(null);
+
+    await pressPaid();
+
+    expect(placed).toHaveLength(1);
+    expect(placed[0].free).toBe(false);
+  });
+
+  /**
+   * The default, observed through the payload rather than through the control's
+   * selected value — a segmented control reading "free" that sends `free: false`
+   * is the failure this file exists for, and only the payload separates them.
+   */
+  test('defaults to the free offer without anybody choosing it', async () => {
+    await renderDraft({ instant: false });
+
+    // No interaction with the segmented control at all.
+    await page.getByRole('button', { name: 'Place free' }).click();
+
+    expect(placed[0].free).toBe(true);
+  });
+
+  test('sends what was chosen after switching to paid', async () => {
+    await renderDraft({ instant: true });
+
+    await choosePaid();
+    await pressPaid();
+
+    expect(placed[0].free).toBe(false);
+  });
+
+  /**
+   * The free option must not be a `BuzzTransactionButton`, which the component's
+   * docstring argues at length — that control exists to show a price and check a
+   * balance, and a free placement has neither. Asserted through the mock's marker
+   * rather than by name, because by name the stub and a plain Mantine button are
+   * the same thing: the swap this pins used to leave every test green.
+   */
+  test('places free through a plain button, not a Buzz one', async () => {
+    await renderDraft({ instant: true });
+
+    const free = (await page.getByRole('button', { name: 'Place free' }).element()) as HTMLElement;
+    expect(free.hasAttribute('data-buzz-button')).toBe(false);
+  });
+
+  test('places paid through a Buzz button, which is where a price belongs', async () => {
+    await renderDraft(null);
+
+    const paid = (await page.getByRole('button', { name: 'Place' }).element()) as HTMLElement;
+    expect(paid.hasAttribute('data-buzz-button')).toBe(true);
+  });
+
+  test('carries the draft geometry either way', async () => {
+    await renderDraft({ instant: true });
+
+    await page.getByRole('button', { name: 'Place free' }).click();
+
+    expect(placed[0].data).toMatchObject({
+      cosmeticId: COSMETIC_ID,
+      x: draft.x,
+      y: draft.y,
+      scale: draft.scale,
+      rotation: draft.rotation,
+    });
+  });
+});
+
+/**
+ * The mode belongs to the free option, not to the button upstream, so it has to
+ * be readable here — and the two modes have to read differently or the placer
+ * cannot tell an instant placement from one that spends their day on a review
+ * they may lose.
+ */
+describe('the free option carries the mode', () => {
+  test('says instant on an auto-accept space, with no review caveat', async () => {
+    await renderDraft({ instant: true });
+
+    await expect.element(page.getByText('Free · instant')).toBeInTheDocument();
+    expect(page.getByText(/spent even if they decline/).elements()).toHaveLength(0);
+  });
+
+  test('says needs review, and warns the day is spent regardless', async () => {
+    await renderDraft({ instant: false });
+
+    await expect.element(page.getByText('Free · needs review')).toBeInTheDocument();
+    await expect.element(page.getByText(/spent even if they decline/)).toBeInTheDocument();
+  });
+
+  test('offers no choice at all where there is no free offer', async () => {
+    await renderDraft(null);
+
+    expect(page.getByText(/^Free ·/).elements()).toHaveLength(0);
+    expect(page.getByRole('button', { name: 'Place free' }).elements()).toHaveLength(0);
+  });
+
+  /**
+   * No proceeds to split on a free placement, so the share caption must not
+   * appear — it is a claim about money that does not move, and PR 3's accept
+   * reward is a separate mechanism not derived from this split.
+   */
+  test('claims no payout while free is selected', async () => {
+    await renderDraft({ instant: true }, { ownerShare: 1 });
+
+    expect(page.getByText(/proceeds go to/).elements()).toHaveLength(0);
+  });
+
+  test('names the payout on the paid option', async () => {
+    await renderDraft(null, { ownerShare: 1 });
+
+    await expect.element(page.getByText(/proceeds go to/)).toBeInTheDocument();
+  });
+});

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -1,5 +1,6 @@
 import {
   ActionIcon,
+  Button,
   Popover,
   SegmentedControl,
   Slider,
@@ -30,6 +31,11 @@ import {
   shouldFlipPlaceButton,
 } from '~/components/Sticker/place-button-position';
 import { useMutateCosmeticShop } from '~/components/CosmeticShop/cosmetic-shop.util';
+import {
+  FREE_REVIEW_CAVEAT,
+  freeOptionLabel,
+  isPlacingFree,
+} from '~/components/Sticker/free-offer';
 import { payoutCopy, stickerPurchaseCopy } from '~/components/Sticker/payout-copy';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { useCreateStickerPlacement } from '~/components/Sticker/placement.util';
@@ -122,6 +128,7 @@ export function DraftSticker({
   selected,
   dressed,
   price,
+  freeOffer,
   ownerShare,
   ownerUsername,
   onGesture,
@@ -132,16 +139,16 @@ export function DraftSticker({
   selected: boolean;
   dressed: StickerTreatment;
   price: number;
+  /**
+   * The free option, when this creator has a slot open and the placer still has
+   * their day. `null` means paid is the only offer — including while the
+   * standing query is still in flight.
+   */
+  freeOffer: { instant: boolean } | null;
   ownerShare: number | undefined;
   ownerUsername: string | null | undefined;
   onGesture: StartGesture;
 }) {
-  // While the sticker is unbought the chip names who that payment goes to — the
-  // sticker's maker — not who the later placement pays. Two payments, two
-  // recipients, and only one of them is being made right now.
-  const payout = draft.purchase
-    ? stickerPurchaseCopy(draft.purchase.creatorUsername)
-    : payoutCopy(ownerShare, ownerUsername);
   const markPurchased = useStickerPlacementDraftStore((state) => state.markPurchased);
   const { purchaseShopItem, purchasingShopItem } = useMutateCosmeticShop();
   const queryUtils = trpc.useUtils();
@@ -217,8 +224,33 @@ export function DraftSticker({
   const select = useStickerPlacementDraftStore((state) => state.select);
   const cancelDraft = useStickerPlacementDraftStore((state) => state.cancelDraft);
   const move = useStickerPlacementDraftStore((state) => state.move);
-  const place = useCreateStickerPlacement(draft.id);
+
+  // `null` until somebody presses the control, which is what lets the default
+  // track an offer that arrives with a query rather than freezing whatever was
+  // known on the first render. See `isPlacingFree`.
+  const [payChoice, setPayChoice] = useState<'free' | 'paid' | null>(null);
+  const placingFree = isPlacingFree(payChoice, freeOffer);
+  const payMode = placingFree ? 'free' : 'paid';
+
+  // Settling on paid after a refused claim, rather than leaving the control on
+  // an offer that is gone. Passed down rather than handled here because the
+  // mutation is the only thing that knows the claim was refused.
+  const place = useCreateStickerPlacement(draft.id, () => setPayChoice('paid'));
   const spendTypes = useAvailableBuzz();
+
+  // While the sticker is unbought the chip names who that payment goes to — the
+  // sticker's maker — not who the later placement pays. Two payments, two
+  // recipients, and only one of them is being made right now.
+  //
+  // Nothing at all on a free placement: there are no proceeds to split, so a
+  // share of them is a claim about money that does not move. PR 3's accept
+  // reward is the creator's side of a free placement and is not derived from
+  // this split, so it does not belong in this sentence either.
+  const payout = draft.purchase
+    ? stickerPurchaseCopy(draft.purchase.creatorUsername)
+    : placingFree
+    ? null
+    : payoutCopy(ownerShare, ownerUsername);
 
   // Which of the two refill prices is being offered. Defaults to the single
   // use: it is the cheaper of the two and exactly what placing this draft
@@ -473,6 +505,26 @@ export function DraftSticker({
     if (!useStickerPlacementDraftStore.getState().interaction) select(draft.id);
   };
 
+  // One payload for both buttons, so the two offers cannot drift into placing
+  // different stickers. `free` is the only thing that differs, and it selects a
+  // path rather than asserting anything — the server re-decides all of it.
+  const placementInput = () => ({
+    imageId: draft.imageId,
+    free: placingFree,
+    data: {
+      cosmeticId: draft.cosmeticId,
+      x: draft.x,
+      y: draft.y,
+      scale: draft.scale,
+      rotation: draft.rotation,
+      flip: draft.flip,
+      opacity: draft.opacity,
+      // Sent only when there is something to send, so an opened-then-abandoned
+      // field is the same as never opening it.
+      ...(note.trim() ? { comment: note } : {}),
+    },
+  });
+
   const flipControl = (
     <Tooltip label={draft.flip ? 'Unflip' : 'Flip'} withinPortal>
       <ActionIcon
@@ -686,9 +738,11 @@ export function DraftSticker({
             box is most of the frame, because almost every draft there is narrow.
             This cluster is the one piece of chrome that already knows where it
             is on screen: it measures itself against the tray and the clipping
-            ancestor and moves to whichever side is visible. Handing it the
-            controls means they inherit that, instead of a third set of
-            hand-derived offsets to get wrong. */}
+            ancestor and moves ABOVE or BELOW the sticker accordingly.
+            `shouldFlipPlaceButton` is vertical only — the horizontal position
+            follows the draft's own x with nothing clamping it — so handing it the
+            controls buys them the vertical avoidance and no more. Still better
+            than a third set of hand-derived offsets. */}
         {!panelsInside && (
           <div
             className="flex items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5"
@@ -761,6 +815,39 @@ export function DraftSticker({
           />
         )}
 
+        {/* The other two-way choice, and deliberately the same control as the
+            one above it: this is the same kind of decision — which of two
+            offers you are taking — made a step later, so giving it a different
+            shape would make them read as unrelated. They never coexist; the one
+            above only appears on a sticker that still has to be bought.
+
+            The free option carries the mode, which the sticker button upstream
+            deliberately does not. This is the last moment the placer can change
+            their mind, and it is what makes auto-accept and review read as two
+            different offers rather than a setting nobody can see. */}
+        {!draft.purchase && freeOffer && (
+          <SegmentedControl
+            size="xs"
+            radius="xl"
+            value={payMode}
+            onChange={(value) => setPayChoice(value as 'free' | 'paid')}
+            data={[
+              { label: freeOptionLabel(freeOffer.instant), value: 'free' },
+              { label: `${numberWithCommas(price)} Buzz`, value: 'paid' },
+            ]}
+          />
+        )}
+
+        {/* Only where it is true. On an auto-accept space the placement is live
+            the moment it is made, so there is no decline to warn about. */}
+        {placingFree && freeOffer && !freeOffer.instant && (
+          <div className="max-w-[240px] whitespace-normal rounded-lg bg-black/80 px-2 py-1 text-center">
+            <Text size="xs" c="gray.3" className="leading-tight">
+              {FREE_REVIEW_CAVEAT}
+            </Text>
+          </div>
+        )}
+
         {draft.purchase && effectiveMode === 'pack' && draft.purchase.pack ? (
           <BuzzTransactionButton
             size="sm"
@@ -791,6 +878,23 @@ export function DraftSticker({
             }
             onPerformTransaction={buyOneUse}
           />
+        ) : placingFree ? (
+          // Not a `BuzzTransactionButton`. That control exists to show a price
+          // and check a balance against it, and a free placement has neither —
+          // rendering it at zero would put a currency badge on something nobody
+          // is paying for, and its account picker would ask which Buzz to spend.
+          // The use it does spend is shown by the tray's own count, and refused
+          // by the server independently.
+          <Button
+            size="sm"
+            radius="xl"
+            color="yellow"
+            style={{ minWidth: BUY_BUTTON_MIN_WIDTH }}
+            loading={place.isPending}
+            onClick={() => place.mutate(placementInput())}
+          >
+            Place free
+          </Button>
         ) : (
           <BuzzTransactionButton
             size="sm"
@@ -799,23 +903,7 @@ export function DraftSticker({
             accountTypes={spendTypes}
             label="Place"
             loading={place.isPending}
-            onPerformTransaction={() =>
-              place.mutate({
-                imageId: draft.imageId,
-                data: {
-                  cosmeticId: draft.cosmeticId,
-                  x: draft.x,
-                  y: draft.y,
-                  scale: draft.scale,
-                  rotation: draft.rotation,
-                  flip: draft.flip,
-                  opacity: draft.opacity,
-                  // Sent only when there is something to send, so an opened-then-
-                  // abandoned field is the same as never opening it.
-                  ...(note.trim() ? { comment: note } : {}),
-                },
-              })
-            }
+            onPerformTransaction={() => place.mutate(placementInput())}
           />
         )}
 

--- a/src/components/Sticker/DraftStickerLayer.tsx
+++ b/src/components/Sticker/DraftStickerLayer.tsx
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { Gesture } from '~/components/Sticker/draft-gesture';
 import { rotate } from '~/components/Sticker/draft-gesture';
 import { DraftSticker } from '~/components/Sticker/DraftSticker';
-import { useImagePlacementSpace } from '~/components/Sticker/placement.util';
+import { freeOfferFor } from '~/components/Sticker/free-offer';
+import {
+  useFreePlacementStanding,
+  useImagePlacementSpace,
+} from '~/components/Sticker/placement.util';
 import { useOwnedSticker, useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import { resolveTreatment } from '~/components/Sticker/treatments/sticker-treatments';
 import { useStickerTreatment } from '~/components/Sticker/treatments/useStickerTreatment';
@@ -53,6 +57,12 @@ export function DraftStickerLayer() {
   // refuse. The refusal is still on the server — this only means nobody has to
   // discover it by being told no after a drag.
   const maxScale = stickerMaxScale(space?.settings);
+
+  // Resolved once for the layer, for the same reason the treatment is: one query
+  // answering a question about the image and the viewer, where a subscription
+  // per sticker would be N observers refetching through an arrangement.
+  const { standing } = useFreePlacementStanding(targetImageId ?? undefined);
+  const freeOffer = freeOfferFor(space, standing);
 
   const gesture = useRef<Gesture | null>(null);
   // Held in a ref because the pointer listener is bound once; re-binding it when
@@ -229,6 +239,7 @@ export function DraftStickerLayer() {
             selected={draft.id === selectedDraftId}
             dressed={dressed}
             price={space?.price ?? 0}
+            freeOffer={freeOffer}
             ownerShare={space?.ownerShare}
             ownerUsername={space?.ownerUsername}
             onGesture={onGesture}

--- a/src/components/Sticker/RemoveReportedPlacement.tsx
+++ b/src/components/Sticker/RemoveReportedPlacement.tsx
@@ -2,6 +2,7 @@ import { Alert, Button, Group, Stack, Text } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
 import { IconEye, IconEyeOff, IconTrash } from '@tabler/icons-react';
 import { useForgetStickerPlacement } from '~/components/Sticker/placement.util';
+import { moderatorTakedownConsequence } from '~/components/Sticker/payout-copy';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -80,8 +81,17 @@ export function RemoveReportedPlacement({
             {placement.sticker?.name ?? 'This sticker'}, placed by{' '}
             {placement.placer?.username ?? 'an unknown user'}, comes off the image for everyone.
           </Text>
+          {/* Both branches were false on a free row: there is no escrow to
+              forfeit and no payment the creator already received. The suspension
+              pointer is worth keeping in the paid wording, so the two are
+              separate sentences rather than one with a clause swapped. */}
           <Text size="sm" c="dimmed">
-            {placement.status === 'pending'
+            {placement.free
+              ? moderatorTakedownConsequence({
+                  pending: placement.status === 'pending',
+                  free: true,
+                })
+              : placement.status === 'pending'
               ? 'It never went live, so its escrow is forfeited rather than refunded.'
               : 'No Buzz moves: the creator was already paid for it, and clawing that back would punish the wrong person. Suspend the placer if the problem is them rather than this one sticker.'}
           </Text>

--- a/src/components/Sticker/StickerPlacementActions.tsx
+++ b/src/components/Sticker/StickerPlacementActions.tsx
@@ -2,6 +2,7 @@ import { Button, Group, Popover, Skeleton, Stack, Text } from '@mantine/core';
 import { IconMessage } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useState } from 'react';
+import { declineConsequence } from '~/components/Sticker/payout-copy';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -11,21 +12,37 @@ import { trpc } from '~/utils/trpc';
  * One component for the image and the queue, so the two cannot end up asking
  * different questions before taking someone's money.
  *
- * **Decline confirms; approve confirms only when there is a note.** Declining
- * keeps 30% of what the placer paid and cannot be undone. A plain approve takes
- * nothing from the placer they did not choose to spend, so it goes straight
- * through — but an approve that would publish someone's words is a second
- * decision, and it is the one the owner cannot see the subject of otherwise.
+ * **Decline confirms; approve confirms only when there is a note.** A decline
+ * cannot be undone, and what it costs depends on the placement — see
+ * `declineConsequence`, which is where that sentence lives now that a free row
+ * has no payment to keep a share of. No rate is named here: the shares are
+ * operator-tunable at runtime, so a number written down in a comment is a claim
+ * about money that stops being true with nothing failing.
+ *
+ * A plain approve takes nothing from the placer they did not choose to spend, so
+ * it goes straight through — but an approve that would publish someone's words is
+ * a second decision, and it is the one the owner cannot see the subject of
+ * otherwise.
  */
 export function StickerPlacementActions({
   placementIds,
   compact = false,
   hasComment = false,
+  free,
   stacked = false,
   onDone,
 }: {
   placementIds: number[];
   compact?: boolean;
+  /**
+   * Whether every placement in this set was placed free, which decides what the
+   * decline confirmation says a decline costs.
+   *
+   * `undefined` means a mixed selection rather than an unknown one — a bulk
+   * decline legitimately holds both kinds, and no single sentence about money is
+   * true of all of them. See `declineConsequence`.
+   */
+  free?: boolean;
   /**
    * Whether this carries a note. Only meaningful for a single placement — a bulk
    * action deliberately does not offer the choice, so a mixed selection cannot
@@ -131,8 +148,7 @@ export function StickerPlacementActions({
               {placementIds.length > 1
                 ? `Decline ${placementIds.length} placements?`
                 : 'Decline this placement?'}{' '}
-              The placer keeps most of what they paid, and a fee stays with you. This can&apos;t be
-              undone.
+              {declineConsequence(free)} This can&apos;t be undone.
             </Text>
             <Group gap="xs" justify="end">
               <Button size="compact-xs" variant="default" onClick={() => setConfirming(false)}>

--- a/src/components/Sticker/StickerPlacementBar.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementBar.browser.test.tsx
@@ -29,6 +29,16 @@ const queryState = {
   countsError: false,
   placementsLoading: false,
   pending: [] as { imageId: number; isPending: boolean }[],
+  /**
+   * The creator's free capacity, and how much of it is left.
+   *
+   * Both, because `freeSlotsRemaining: 0` means two different things — "takes no
+   * free stickers" and "all slots currently held" — and the bar's copy has to
+   * tell them apart. A fixture carrying only the remainder could not express the
+   * difference, so the tests would agree with either behaviour.
+   */
+  freeSlots: 0,
+  freeSlotsRemaining: 0,
 };
 
 // Spread the real module: a hand-listed mock couples this test to the whole
@@ -48,7 +58,13 @@ vi.mock('~/components/Sticker/placement.util', async (importOriginal) => ({
     };
   },
   useImagePlacementSpace: () => ({
-    space: { mode: 'open', price: 100, ownerId: 999 },
+    space: {
+      mode: 'open',
+      price: 100,
+      ownerId: 999,
+      freeSlots: queryState.freeSlots,
+      freeSlotsRemaining: queryState.freeSlotsRemaining,
+    },
     isLoading: false,
   }),
 }));
@@ -166,5 +182,126 @@ describe('StickerPlacementBar', () => {
     // nothing to act on, so the argument is the thing worth pinning.
     expect(placementsEnabled.length).toBeGreaterThan(0);
     expect(placementsEnabled.every((enabled) => enabled === true)).toBe(true);
+  });
+});
+
+/**
+ * The one number the sticker button carries.
+ *
+ * Every state here is absorbing — nothing on a timer, nothing the component
+ * tears down — so these assert after a settled render rather than awaiting a
+ * state that could leave.
+ */
+describe('StickerPlacementBar — free slots', () => {
+  const settled = {
+    counts: {},
+    countsLoading: false,
+    countsError: false,
+    placementsLoading: false,
+    pending: [],
+  };
+
+  const placeButton = () => page.getByRole('button', { name: /^Place a sticker/ });
+  // By exact name, because the comparison below renders twice in one test and
+  // both buttons stay mounted — a pattern locator resolves to two elements there
+  // and fails on strict mode rather than on the property being tested.
+  const backgroundOf = async (name: string) =>
+    getComputedStyle(await page.getByRole('button', { name }).element()).backgroundColor;
+
+  test('carries the remaining count out of the creator capacity', async () => {
+    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 2 });
+    await renderBar();
+
+    await expect.element(page.getByText('2 of 4 free')).toBeInTheDocument();
+    // On the accessible name too. A number only a sighted user can read is not
+    // the button carrying it.
+    expect(
+      page.getByRole('button', { name: 'Place a sticker · 2 of 4 free' }).elements()
+    ).toHaveLength(1);
+  });
+
+  /**
+   * The ambiguity that needed two numbers to resolve. A creator whose slots are
+   * all held still has something to say, because a slot comes back the moment
+   * one is declined — so this state reads `0 of 4`, not silence.
+   */
+  test('says nothing about free stickers when the creator takes none', async () => {
+    Object.assign(queryState, settled, { freeSlots: 0, freeSlotsRemaining: 0 });
+    await renderBar();
+
+    expect(page.getByText(/free$/).elements()).toHaveLength(0);
+    // `exact`, because the default is a substring match — so the bare name also
+    // matched "Place a sticker · 0 of 0 free" and the assertion survived the
+    // mutation `showsFree = canPlace`, which is the one it exists to catch.
+    expect(
+      page.getByRole('button', { name: 'Place a sticker', exact: true }).elements()
+    ).toHaveLength(1);
+  });
+
+  test('still reports the capacity when every slot is currently held', async () => {
+    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 0 });
+    await renderBar();
+
+    await expect.element(page.getByText('0 of 4 free')).toBeInTheDocument();
+  });
+
+  /**
+   * The shiny treatment, asserted as a difference rather than as a colour: what
+   * has to be true is that a slot being available looks unlike one that is not.
+   * Pinning the exact rgba would fail on a theme change that kept the behaviour.
+   */
+  test('draws the button differently when a slot is available', async () => {
+    // A stickered image, deliberately. On an empty one the button already wears
+    // this tint as half of the "place the first one" invitation, so both renders
+    // would come back identical and the test would pass for the wrong reason —
+    // or fail, as it did, on a cause that has nothing to do with free slots.
+    const stickered = { ...settled, counts: { [IMAGE_ID]: 3 } };
+
+    Object.assign(queryState, stickered, { freeSlots: 4, freeSlotsRemaining: 1 });
+    await renderBar();
+    const available = await backgroundOf('Place a sticker · 1 of 4 free');
+
+    Object.assign(queryState, stickered, { freeSlots: 4, freeSlotsRemaining: 0 });
+    await renderBar();
+    const taken = await backgroundOf('Place a sticker · 0 of 4 free');
+
+    expect(available).not.toBe(taken);
+  });
+
+  /**
+   * 🔴 The bar must never promise free, and the count is why it is tempting to.
+   *
+   * `freeSlotsRemaining` is the CREATOR's capacity. It says nothing about this
+   * viewer — somebody who spent today's allowance, or already free-placed on this
+   * image, has no free option at all — and only the standing query answers that,
+   * which this bar deliberately does not make because it renders per feed card.
+   * So a "free" label here is read by the people it is false for, who then open
+   * the tray and pay a number they were never shown.
+   *
+   * Asserted across both capacity states, because the defect only appeared in one
+   * of them: a test pinned to the empty case passes while the promise is made.
+   */
+  test.each([
+    ['slots remaining', 2],
+    ['slots all taken', 0],
+  ])('quotes the price and never promises free — %s', async (_name, remaining) => {
+    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: remaining });
+    await renderBar();
+
+    await placeButton().hover();
+    await expect.element(page.getByText('Place a sticker · 100 Buzz')).toBeInTheDocument();
+    expect(page.getByText(/·\s*free/).elements()).toHaveLength(0);
+  });
+
+  /**
+   * The count itself stays, and this is the line between the two: a number about
+   * the creator's capacity is a fact the bar has, and a claim about what THIS
+   * viewer will be charged is not.
+   */
+  test('still states the creator capacity it does know', async () => {
+    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 2 });
+    await renderBar();
+
+    await expect.element(page.getByText('2 of 4 free')).toBeInTheDocument();
   });
 });

--- a/src/components/Sticker/StickerPlacementBar.tsx
+++ b/src/components/Sticker/StickerPlacementBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip } from '@mantine/core';
+import { Button, Text, Tooltip } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useReactionSettingsContext } from '~/components/Reaction/ReactionSettingsProvider';
@@ -73,6 +73,24 @@ export function StickerPlacementBar({
   // Approved plus the viewer's own pending, which is what the toggle reveals.
   const total = count + pending;
 
+  /**
+   * How much of this creator's free capacity is still open.
+   *
+   * ⚠️ `freeSlotsRemaining === 0` covers two different facts and only
+   * `freeSlots` tells them apart: the resolver short-circuits the reservation
+   * count when there is no capacity, so zero is both "this creator takes no free
+   * placements" and "their slots are all currently held". The first has nothing
+   * to say and the second does, because a slot comes back on a decline.
+   *
+   * Both numbers ride on the space query this bar already makes, so the count
+   * costs nothing extra. It is a display number and stale by construction — the
+   * claim re-counts under a lock — which is why the button offers rather than
+   * promises.
+   */
+  const freeSlots = space?.freeSlots ?? 0;
+  const freeRemaining = space?.freeSlotsRemaining ?? 0;
+  const showsFree = canPlace && freeSlots > 0;
+
   // The invitation needs a zero that is KNOWN to be zero. `total` is fed by two
   // separate queries and a failure of either reads as empty, so an image with
   // stickers would otherwise show the invitation — and a press there opens a
@@ -128,14 +146,35 @@ export function StickerPlacementBar({
         )}
 
         {canPlace && (
-          <Tooltip label={`Place a sticker · ${space?.price} Buzz`} withArrow>
+          <Tooltip
+            /**
+             * 🔴 The price, always — never "free".
+             *
+             * `freeRemaining` is the CREATOR's capacity and says nothing about
+             * this viewer: somebody who has spent today's allowance, or already
+             * free-placed on this image, would be promised free and then pay a
+             * number they were never shown. Only the standing query answers that,
+             * and this bar deliberately does not make it — it renders per feed
+             * card, so it would be one request per card.
+             *
+             * So the bar states the fact it has (the count beside this, which is
+             * about the creator) and makes no claim about the offer. The offer is
+             * made in the tray, where the standing is known.
+             */
+            label={`Place a sticker · ${space?.price} Buzz`}
+            withArrow
+          >
             <Button
               size="compact-sm"
               radius="xl"
               variant="light"
               color="yellow"
               onClick={() => openTray(imageId)}
-              aria-label="Place a sticker"
+              aria-label={
+                showsFree
+                  ? `Place a sticker · ${freeRemaining} of ${freeSlots} free`
+                  : 'Place a sticker'
+              }
               // A plus rather than a second sticker glyph: beside a count of
               // stickers it reads as "add one" without a word, which is what
               // keeps the fused control narrow enough to belong in this row.
@@ -143,9 +182,26 @@ export function StickerPlacementBar({
               // Last, and merged over whatever the row's styling set: at zero
               // the plus is half the invitation, so it has to carry the same
               // tint the chip does or the pair reads as two unrelated controls.
-              style={{ ...buttonStyling?.('BuzzTip')?.style, ...(inviting ? inviteStyle : null) }}
+              //
+              // A free slot borrows the same tint for the same reason it exists:
+              // it is the row's own "there is something for you here" language,
+              // and inventing a second one for the free tier would make the two
+              // states compete rather than agree.
+              style={{
+                ...buttonStyling?.('BuzzTip')?.style,
+                ...(inviting || freeRemaining > 0 ? inviteStyle : null),
+              }}
             >
               <IconPlus size={16} stroke={2.5} />
+              {/* One number. Rendered even at zero remaining, because a full
+                  space is a thing worth knowing — a slot comes back on a
+                  decline — while a creator who takes no free placements has
+                  nothing to say and gets no label at all. */}
+              {showsFree && (
+                <Text size="xs" fw={600} className="ml-1">
+                  {freeRemaining} of {freeSlots} free
+                </Text>
+              )}
             </Button>
           </Tooltip>
         )}

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -14,6 +14,11 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { openReportModal } from '~/components/Dialog/triggers/report';
 import { useForgetStickerPlacement } from '~/components/Sticker/placement.util';
+import {
+  moderatorTakedownConsequence,
+  removalConsequence,
+  removalLockReason,
+} from '~/components/Sticker/payout-copy';
 import { ReportEntity } from '~/shared/utils/report-helpers';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
@@ -210,9 +215,17 @@ export function StickerPlacementHoverCard({
                   for as long as the page stays open — and that value would pick
                   the confirmation's sentence about the placer's money, right
                   before an irreversible click. */}
-              <ModeratorRemove placementId={placementId} pending={data.status === 'pending'} />
+              <ModeratorRemove
+                placementId={placementId}
+                pending={data.status === 'pending'}
+                free={data.free}
+              />
               {data.viewerIsOwner && data.status === 'approved' && (
-                <OwnerRemove placementId={placementId} removableAt={data.removableAt} />
+                <OwnerRemove
+                  placementId={placementId}
+                  removableAt={data.removableAt}
+                  free={data.free}
+                />
               )}
             </>
           )}
@@ -426,9 +439,15 @@ function HideNote({ placementId, commentHidden }: { placementId: number; comment
 function OwnerRemove({
   placementId,
   removableAt,
+  free,
 }: {
   placementId: number;
   removableAt: Date | string | null;
+  /**
+   * Whether this was placed against the creator's free capacity. Both sentences
+   * below are about money, and both are false when none moved.
+   */
+  free: boolean;
 }) {
   const forget = useForgetStickerPlacement();
 
@@ -450,9 +469,7 @@ function OwnerRemove({
       w={240}
       label={
         locked
-          ? `Someone paid to place this, so it stays up for a week. You can remove it from ${formatDate(
-              removableAt as Date
-            )}.`
+          ? `${removalLockReason(free)} You can remove it from ${formatDate(removableAt as Date)}.`
           : 'Takes the sticker off your image. No Buzz moves.'
       }
     >
@@ -470,12 +487,7 @@ function OwnerRemove({
           onClick={() =>
             openConfirmModal({
               title: 'Remove this sticker',
-              children: (
-                <Text size="sm">
-                  It comes off your image for everyone. The Buzz you were paid for it stays with
-                  you, and nobody is notified.
-                </Text>
-              ),
+              children: <Text size="sm">{removalConsequence(free)}</Text>,
               labels: { confirm: 'Remove', cancel: 'Cancel' },
               confirmProps: { color: 'red' },
               onConfirm: () => remove.mutate({ placementIds: [placementId], action: 'remove' }),
@@ -501,9 +513,12 @@ function OwnerRemove({
  * On a live placement nothing else happens: no refund, and nobody is notified
  * (Justin, 2026-08-08). The escrow was paid to a content owner who did not
  * choose the sticker, and clawing it back would charge them for someone else's
- * problem. **A pending one is not that**: it settles as `removeByModerator`,
+ * problem. **A pending PAID one is not that**: it settles as `removeByModerator`,
  * whose payout is a forfeit of the whole escrow, fee and principal — so the
  * confirmation has to say a different thing about the money.
+ *
+ * A free row has no escrow at all, in either state, so both of those sentences are
+ * false of one and the confirmation branches on `free` as well as on `pending`.
  *
  * Rendered for moderators only, which is convenience — `removePlacement` is a
  * `moderatorProcedure`, so the refusal is on the mutation and stays there.
@@ -511,9 +526,12 @@ function OwnerRemove({
 function ModeratorRemove({
   placementId,
   pending = false,
+  free,
 }: {
   placementId: number;
   pending?: boolean;
+  /** No escrow exists on a free row, so neither branch below is true of one. */
+  free: boolean;
 }) {
   const currentUser = useCurrentUser();
   const forget = useForgetStickerPlacement();
@@ -549,13 +567,7 @@ function ModeratorRemove({
         onClick={() =>
           openConfirmModal({
             title: 'Take this placement down',
-            children: (
-              <Text size="sm">
-                {pending
-                  ? 'This one is still awaiting the owner. Taking it down forfeits everything the placer paid — they get nothing back, and nobody is notified.'
-                  : 'The sticker comes off this content for everyone, recorded as a moderator takedown. No Buzz moves and nobody is notified.'}
-              </Text>
-            ),
+            children: <Text size="sm">{moderatorTakedownConsequence({ pending, free })}</Text>,
             labels: { confirm: 'Take down', cancel: 'Cancel' },
             confirmProps: { color: 'red' },
             onConfirm: () => remove.mutate({ placementId }),

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -7,6 +7,9 @@ import { orderPlacements, placementRevealDelays } from '~/components/Sticker/pla
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
 import { StickerPlacementHoverCard } from '~/components/Sticker/StickerPlacementHoverCard';
+import { PlacementFreeBadge } from '~/components/Placement/PlacementFreeBadge';
+import { freeMarkerVisible } from '~/components/Sticker/free-marker';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import {
   STILL_STICKER_TREATMENT,
   resolveTreatment,
@@ -173,6 +176,9 @@ export function StickerPlacementOverlay({
 
   // Ordered here rather than trusted from the caller: this component decides
   // what covers what, and the paint order of these elements IS that decision.
+  // Only for the moderator flag. Who the viewer is comes from `viewerId`, which
+  // the surfaces already pass and the server-side render has.
+  const currentUser = useCurrentUser();
   const ordered = useMemo(() => orderPlacements(placements), [placements]);
   // Off the full history, not off the visible slice: stepping through a replay
   // must not re-pace the stickers already on screen.
@@ -320,6 +326,15 @@ export function StickerPlacementOverlay({
           // would be a filter where a refusal is needed.
           const isOwner = placement.ownerId === viewerId;
 
+          const showsFree = freeMarkerVisible({
+            free: placement.free,
+            isPending: placement.isPending,
+            ownerId: placement.ownerId,
+            placerId: placement.placerId,
+            viewerId,
+            isModerator: currentUser?.isModerator,
+          });
+
           const dressed = resolveTreatment({
             treatment,
             surface,
@@ -408,6 +423,24 @@ export function StickerPlacementOverlay({
                     surface === 'card' ? 'inset-0' : '-inset-1'
                   )}
                 />
+              )}
+
+              {/* Centred under the sticker, directly above the owner's approve
+                  and decline controls — those are positioned off the sticker's
+                  measured height, so this rides the same edge they start from.
+
+                  Inside the artwork's box on a card for the same reason the
+                  pending ring is: a card clips anything outset. */}
+              {showsFree && (
+                <div
+                  className={clsx(
+                    'absolute left-1/2 -translate-x-1/2 whitespace-nowrap',
+                    interactive && 'pointer-events-auto',
+                    surface === 'card' ? 'bottom-0' : '-bottom-3'
+                  )}
+                >
+                  <PlacementFreeBadge noun="placement" solid />
+                </div>
               )}
             </div>
           );

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -498,6 +498,7 @@ export function StickerPlacementOverlay({
                       <StickerPlacementActions
                         placementIds={[placement.id]}
                         hasComment={placement.hasComment}
+                        free={placement.free}
                         compact
                       />
                     ) : (

--- a/src/components/Sticker/StickerPlacementTray.tsx
+++ b/src/components/Sticker/StickerPlacementTray.tsx
@@ -3,10 +3,14 @@ import { IconPlus, IconSticker } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
+import { freeOfferFor, trayPriceLine, trayReviewLine } from '~/components/Sticker/free-offer';
 import { StickerShopPanel } from '~/components/Sticker/StickerShopPanel';
 import { StickerShopTile } from '~/components/Sticker/StickerShopTile';
 import { useStickerDragOut } from '~/components/Sticker/use-sticker-drag-out';
-import { useImagePlacementSpace } from '~/components/Sticker/placement.util';
+import {
+  useFreePlacementStanding,
+  useImagePlacementSpace,
+} from '~/components/Sticker/placement.util';
 import { stickerMaxScale } from '~/shared/utils/sticker-placement';
 import { useOwnedSticker } from '~/components/Sticker/sticker.util';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -63,6 +67,10 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
   }, [showing, setTray]);
 
   const { space } = useImagePlacementSpace(targetImageId ?? undefined);
+  // Same query key as the layer's, so this shares its cache rather than making a
+  // second request. Here it only decides one clause of one sentence; the choice
+  // itself is made on the draft, where the mode is also shown.
+  const { standing } = useFreePlacementStanding(targetImageId ?? undefined);
   const { data: balances } = trpc.cosmetic.getStickerBalances.useQuery(undefined, {
     enabled: !!currentUser && targetImageId != null,
   });
@@ -134,6 +142,9 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
   };
 
   const price = space?.price ?? 0;
+  // The same predicate the draft's own control uses, so the sentence here and
+  // the button down there cannot disagree about what is on offer.
+  const freeAvailable = !!freeOfferFor(space, standing);
   // Says the panel can be got out of the way, and that more than one is allowed,
   // only once there is something that would survive it. Before that both are
   // instructions about nothing.
@@ -157,9 +168,16 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
                 {instruction}
               </Text>
               <Text size="xs" c="dimmed">
-                {price} Buzz + one use
+                {/* Both sentences come from `free-offer.ts`, where their
+                    branches are covered — inline here, dropping either ternary
+                    is a mutation nothing in the suite can observe, and what it
+                    produces is the exact contradiction these lines exist to
+                    prevent. The free half of the decline warning is
+                    FREE_REVIEW_CAVEAT itself rather than a paraphrase. */}
+                {trayPriceLine(freeAvailable, price)}
                 {space?.mode === 'review' &&
-                  ' · this creator reviews placements, so only you will see it until they approve. If they decline, part of what you paid stays with them.'}
+                  ' · this creator reviews placements, so only you will see it until they approve.'}
+                {space?.mode === 'review' && trayReviewLine(freeAvailable)}
               </Text>
             </div>
             <CloseButton

--- a/src/components/Sticker/__tests__/free-marker.test.ts
+++ b/src/components/Sticker/__tests__/free-marker.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { freeMarkerVisible } from '~/components/Sticker/free-marker';
+
+const OWNER = 1;
+const PLACER = 2;
+const STRANGER = 3;
+
+const placement = { free: true, isPending: true, ownerId: OWNER, placerId: PLACER };
+
+describe('freeMarkerVisible', () => {
+  it('shows the owner that a sticker on their image was free', () => {
+    expect(freeMarkerVisible({ ...placement, viewerId: OWNER })).toBe(true);
+  });
+
+  it('shows the placer their own free placement', () => {
+    expect(freeMarkerVisible({ ...placement, viewerId: PLACER })).toBe(true);
+  });
+
+  it('shows a moderator, who already sees the free fact in the takedown copy', () => {
+    expect(freeMarkerVisible({ ...placement, viewerId: STRANGER, isModerator: true })).toBe(true);
+  });
+
+  /**
+   * The assertion that decays silently. The positive cases break loudly the
+   * moment anyone touches the overlay; this one only breaks when someone widens
+   * the gate, which is the change nobody flags. How a placement was funded is
+   * private between the two parties to it.
+   */
+  it('tells a third-party viewer nothing about how the placement was funded', () => {
+    expect(freeMarkerVisible({ ...placement, viewerId: STRANGER })).toBe(false);
+  });
+
+  it('tells a signed-out viewer nothing either', () => {
+    expect(freeMarkerVisible({ ...placement, viewerId: undefined })).toBe(false);
+  });
+
+  /**
+   * `viewerId` is `undefined` when signed out and the ids are real numbers, so a
+   * loose comparison anywhere in this chain would hand every anonymous viewer
+   * the marker on every free placement.
+   */
+  it('does not treat a missing viewer as a match for a falsy id', () => {
+    expect(
+      freeMarkerVisible({
+        free: true,
+        isPending: true,
+        ownerId: 0,
+        placerId: 0,
+        viewerId: undefined,
+      })
+    ).toBe(false);
+  });
+
+  /**
+   * The mark belongs to the decision, not to the sticker. Once the owner has
+   * approved it, it is on the image on its own terms and nothing marks how it
+   * was funded — including for the owner, who already answered that question.
+   */
+  it('says nothing once the placement is approved', () => {
+    expect(freeMarkerVisible({ ...placement, isPending: false, viewerId: OWNER })).toBe(false);
+    expect(freeMarkerVisible({ ...placement, isPending: false, viewerId: PLACER })).toBe(false);
+    expect(
+      freeMarkerVisible({ ...placement, isPending: false, viewerId: STRANGER, isModerator: true })
+    ).toBe(false);
+  });
+
+  it('says nothing on a paid placement, to anyone', () => {
+    expect(freeMarkerVisible({ ...placement, free: false, viewerId: OWNER })).toBe(false);
+    expect(
+      freeMarkerVisible({ ...placement, free: false, viewerId: STRANGER, isModerator: true })
+    ).toBe(false);
+  });
+});

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FREE_REVIEW_CAVEAT,
+  freeOfferFor,
+  freeOptionLabel,
+  freeRefusalMessage,
+  freeRefusalOutcome,
+  isPlacingFree,
+  trayPriceLine,
+  trayReviewLine,
+} from '~/components/Sticker/free-offer';
+
+describe('the free option carries the mode', () => {
+  it('says instant on an auto-accept space and needs review otherwise', () => {
+    expect(freeOptionLabel(true)).toBe('Free · instant');
+    expect(freeOptionLabel(false)).toBe('Free · needs review');
+  });
+
+  /**
+   * The distinction is the whole reason the mode is on this option rather than on
+   * the sticker button: a placer choosing between two offers needs to know which
+   * one goes live now. A label that read the same either way would leave the mode
+   * a hidden setting again.
+   */
+  it('reads differently in the two modes', () => {
+    expect(freeOptionLabel(true)).not.toBe(freeOptionLabel(false));
+  });
+
+  it('states the asymmetry a decline creates', () => {
+    // The image's slot comes back and the placer's day does not, which is the
+    // one fact somebody might choose to pay to avoid.
+    expect(FREE_REVIEW_CAVEAT).toMatch(/spent even if they decline/);
+    expect(FREE_REVIEW_CAVEAT).toMatch(/allowance does not/);
+  });
+});
+
+/**
+ * The refusal copy, chosen from state re-read after the claim was refused rather
+ * than from the server's own message.
+ *
+ * Ordered most specific first, so the most useful true thing wins. Each case
+ * below is a distinct thing to tell somebody and a distinct thing to do next —
+ * wait for midnight, pick a different image, or just pay — so collapsing any two
+ * of them would send a person to the wrong remedy.
+ */
+describe('what a refused free claim says', () => {
+  const HAS_SLOT = { freeSlots: 4, freeSlotsRemaining: 2 };
+  const FULL = { freeSlots: 4, freeSlotsRemaining: 0 };
+  const CLOSED = { freeSlots: 0, freeSlotsRemaining: 0 };
+  const HAS_DAY = { remaining: 1, usedHere: false };
+
+  it('names this image when the placer has already used one here', () => {
+    expect(freeRefusalMessage({ remaining: 1, usedHere: true }, HAS_SLOT)).toMatch(
+      /already used a free sticker on this image/
+    );
+  });
+
+  it('names the reset when the day is spent', () => {
+    expect(freeRefusalMessage({ remaining: 0, usedHere: false }, HAS_SLOT)).toMatch(/midnight UTC/);
+  });
+
+  it('names the race when the last slot went to somebody else', () => {
+    expect(freeRefusalMessage(HAS_DAY, FULL)).toMatch(/took the last free slot/);
+  });
+
+  /**
+   * `freeSlotsRemaining === 0` covers two different facts, and this is where the
+   * two have to be told apart: the resolver short-circuits the reservation count
+   * when there is no capacity, so a creator who takes no free stickers looks
+   * identical to one whose slots are full unless `freeSlots` is read alongside.
+   * Saying somebody beat them to it would be a lie about a slot that never
+   * existed.
+   */
+  it('distinguishes a closed space from a full one', () => {
+    const closed = freeRefusalMessage(HAS_DAY, CLOSED);
+
+    expect(closed).toMatch(/not taking free stickers/);
+    expect(closed).not.toBe(freeRefusalMessage(HAS_DAY, FULL));
+  });
+
+  it('never quotes the server where it does speak, since prose may be reworded', () => {
+    const spoken = [
+      freeRefusalMessage({ remaining: 1, usedHere: true }, HAS_SLOT),
+      freeRefusalMessage({ remaining: 0, usedHere: false }, HAS_SLOT),
+      freeRefusalMessage(HAS_DAY, FULL),
+      freeRefusalMessage(HAS_DAY, CLOSED),
+    ];
+
+    // Every rung answers, so a null here would mean a branch stopped firing and
+    // the loop below went vacuous.
+    expect(spoken.filter(Boolean)).toHaveLength(spoken.length);
+    // The service prefixes every placement refusal this way. A message carrying
+    // it would mean the client had started parsing prose instead.
+    for (const message of spoken) expect(message).not.toContain('placement:');
+  });
+});
+
+/**
+ * Whether the free offer is on the table at all.
+ *
+ * Three separate facts, each a different reason to be looking at the paid
+ * button, so each is checked on its own — a predicate that dropped one would
+ * offer something the claim then refuses, and the placer would meet a refusal
+ * after choosing rather than an offer that was never there.
+ */
+describe('whether the free offer is available', () => {
+  const OPEN = { mode: 'review', freeSlots: 4, freeSlotsRemaining: 2 };
+  const HAS_DAY = { remaining: 1, usedHere: false };
+
+  it('offers free when the creator has a slot and the placer has their day', () => {
+    expect(freeOfferFor(OPEN, HAS_DAY)).toEqual({ instant: false });
+  });
+
+  it('carries the mode, which is what the option label needs', () => {
+    expect(freeOfferFor({ ...OPEN, mode: 'auto' }, HAS_DAY)).toEqual({ instant: true });
+  });
+
+  it('withholds it when the creator has no slots left', () => {
+    expect(freeOfferFor({ ...OPEN, freeSlotsRemaining: 0 }, HAS_DAY)).toBeNull();
+  });
+
+  it('withholds it when the placer has spent their day', () => {
+    expect(freeOfferFor(OPEN, { remaining: 0, usedHere: false })).toBeNull();
+  });
+
+  it('withholds it when the placer has already placed free on this image', () => {
+    expect(freeOfferFor(OPEN, { remaining: 1, usedHere: true })).toBeNull();
+  });
+
+  /**
+   * Paid first while either answer is unknown. The other order shows a free
+   * option and then removes it as the query lands, which is the one thing worse
+   * than not offering it — somebody reads a free offer, reaches for it, and it
+   * has become a charge.
+   */
+  it('withholds it until both answers have arrived', () => {
+    expect(freeOfferFor(undefined, HAS_DAY)).toBeNull();
+    expect(freeOfferFor(OPEN, undefined)).toBeNull();
+    expect(freeOfferFor()).toBeNull();
+  });
+});
+
+/**
+ * Which offer is selected. The default is the whole decision here: free wherever
+ * one is available, because the point of the free tier is that somebody tries
+ * the feature without paying to find out whether they like it.
+ */
+describe('which offer is selected', () => {
+  const OFFER = { instant: false };
+
+  it('defaults to free whenever an offer is available', () => {
+    expect(isPlacingFree(null, OFFER)).toBe(true);
+  });
+
+  it('defaults to paid when there is no free offer', () => {
+    expect(isPlacingFree(null, null)).toBe(false);
+  });
+
+  it('respects an explicit choice of paid while free is still available', () => {
+    // Paid placements never consume free slots, so choosing to pay when a free
+    // slot exists is a real choice rather than a mistake to correct.
+    expect(isPlacingFree('paid', OFFER)).toBe(false);
+  });
+
+  /**
+   * The fallback after a lost slot race, and the reason the second argument wins
+   * over the first: the control settles on paid by clearing the offer as well as
+   * by setting the choice, and a stale `'free'` must not survive either.
+   */
+  it('never places free once the offer has gone, whatever was chosen', () => {
+    expect(isPlacingFree('free', null)).toBe(false);
+  });
+});
+
+/**
+ * The ladder's ORDER, which no single-condition fixture can hold.
+ *
+ * More than one rung is true at once in ordinary use — a placer who spent their
+ * day on a creator who has since closed their slots trips two — and the first
+ * match is what gets said. A test that only ever sets one condition passes for
+ * every permutation of the ladder, so the swap that turns a true sentence into a
+ * false one is invisible to it.
+ *
+ * Each case below sets BOTH conditions of one adjacent pair and names the rung
+ * that has to win. The rule is that a refusal which is permanent for this image
+ * outranks one that lifts by itself: "your allowance comes back at midnight" is a
+ * promise about tomorrow, and on an image whose creator takes no free stickers it
+ * is simply false.
+ */
+describe('the refusal ladder is ordered, not merely complete', () => {
+  const CLOSED = { freeSlots: 0, freeSlotsRemaining: 0 };
+  const FULL = { freeSlots: 4, freeSlotsRemaining: 0 };
+  const OPEN = { freeSlots: 4, freeSlotsRemaining: 2 };
+  const SPENT = { remaining: 0, usedHere: false };
+  const PLACED_HERE = { remaining: 1, usedHere: true };
+  const BOTH_SPENT = { remaining: 0, usedHere: true };
+
+  it.each([
+    [
+      'a closed space outranks having already placed here',
+      CLOSED,
+      PLACED_HERE,
+      /not taking free stickers/,
+    ],
+    [
+      'having already placed here outranks a spent day',
+      OPEN,
+      BOTH_SPENT,
+      /already used a free sticker on this image/,
+    ],
+    ['a spent day outranks a full space', FULL, SPENT, /midnight UTC/],
+  ])('%s', (_name, space, standing, expected) => {
+    expect(freeRefusalMessage(standing, space)).toMatch(expected);
+  });
+
+  /**
+   * The transitive case, stated separately because pairwise adjacency does not
+   * imply it: every rung true at once still has to produce the permanent one.
+   * This is the state a creator closing their slots leaves behind for somebody
+   * who had already placed and already spent their day.
+   */
+  it('says the permanent thing when every rung is true', () => {
+    expect(freeRefusalMessage(BOTH_SPENT, CLOSED)).toMatch(/not taking free stickers/);
+  });
+
+  /**
+   * The specific false promise the order exists to prevent, asserted as an
+   * absence as well as a presence — a reordering that produced some other true
+   * sentence would still be caught by the pairs above, but this is the one that
+   * sends somebody back tomorrow for nothing.
+   */
+  it('never promises a reset on an image that will never take a free sticker', () => {
+    expect(freeRefusalMessage(SPENT, CLOSED)).not.toMatch(/midnight/);
+  });
+});
+
+/**
+ * What the ladder deliberately will NOT answer.
+ *
+ * A free placement is refused by everything the paid one is — a block, a
+ * moderator suspension, self-placement, a sticker over the creator's size limit
+ * — and each of those arrives with a message written for the person who hit it.
+ * `null` is what tells the caller to show that message instead of inventing one,
+ * and it is the difference between a wrong reason and a wrong remedy: offering
+ * the paid button to somebody who is blocked fails the same way again.
+ */
+describe('the ladder stays silent where it does not know', () => {
+  it('returns null when nothing about the free tier explains the refusal', () => {
+    expect(
+      freeRefusalMessage({ remaining: 1, usedHere: false }, { freeSlots: 4, freeSlotsRemaining: 2 })
+    ).toBeNull();
+  });
+
+  it('returns null when the re-read itself did not arrive', () => {
+    expect(freeRefusalMessage()).toBeNull();
+    expect(freeRefusalMessage({ remaining: 1, usedHere: false })).toBeNull();
+    expect(freeRefusalMessage(undefined, { freeSlots: 4, freeSlotsRemaining: 2 })).toBeNull();
+  });
+});
+
+/**
+ * What the refusal does, as distinct from what it says.
+ *
+ * `fallBackToPaid` is the consequential half. A control that settles on paid is
+ * telling somebody the problem was money — right when the free slots ran out,
+ * and wrong when the placement itself was refused, because the paid button then
+ * fails the same way and they have been sent to a remedy that cannot work.
+ */
+describe('what a refused free claim does next', () => {
+  const SERVER = 'placement: you cannot place a sticker on your own content';
+
+  it('falls back to paid, with its own wording, where free specifically ran out', () => {
+    const outcome = freeRefusalOutcome(
+      'Someone took the last free slot on this image first.',
+      SERVER
+    );
+
+    expect(outcome.fallBackToPaid).toBe(true);
+    expect(outcome.message).toMatch(/last free slot/);
+    // Not the server's prose, which does not say which rule stopped it.
+    expect(outcome.message).not.toContain('placement:');
+  });
+
+  /**
+   * The defect this shape exists to avoid: a refusal that has nothing to do with
+   * the free tier arrives with a message somebody wrote for exactly this moment,
+   * and reporting it as a lost race discards that message AND offers a button
+   * that will fail identically.
+   */
+  it('keeps the server message and does not offer paid where the placement was refused', () => {
+    const outcome = freeRefusalOutcome(null, SERVER);
+
+    expect(outcome.fallBackToPaid).toBe(false);
+    expect(outcome.message).toBe(SERVER);
+    expect(outcome.message).not.toMatch(/free slot/);
+  });
+
+  it('titles the two cases differently, since one is about price and one is not', () => {
+    expect(freeRefusalOutcome('anything', SERVER).title).not.toBe(
+      freeRefusalOutcome(null, SERVER).title
+    );
+  });
+});
+
+/**
+ * The tray's two sentences, here rather than in the component because inline
+ * neither ternary was observable: dropping either one turns nothing red and
+ * produces the exact contradiction the lines exist to prevent.
+ */
+describe('the tray states both offers when both are open', () => {
+  it('names free and the price together, with the use as the constant', () => {
+    const both = trayPriceLine(true, 700);
+
+    expect(both).toMatch(/Free/);
+    expect(both).toMatch(/700 Buzz/);
+    // Free of the creator's price and of nothing else. Without this the tray and
+    // the Place button disagree about what a sticker costs.
+    expect(both).toMatch(/one use either way/);
+  });
+
+  it('names only the price when free is not on offer', () => {
+    const paid = trayPriceLine(false, 700);
+
+    expect(paid).toBe('700 Buzz + one use');
+    expect(paid).not.toMatch(/[Ff]ree/);
+  });
+
+  /**
+   * 🔴 The free half is `FREE_REVIEW_CAVEAT` itself, not a paraphrase. Three
+   * places in the product state what a decline costs a free placer — this, the
+   * caveat under the draft's own free option, and `declineConsequence` on the
+   * owner's side — and two of the three now come from one constant.
+   */
+  it('reuses the owned caveat rather than restating it', () => {
+    expect(trayReviewLine(true)).toContain(FREE_REVIEW_CAVEAT);
+  });
+
+  it('keeps the paid fee disclosure in both branches', () => {
+    // Where both offers are open, somebody choosing to pay still needs it.
+    for (const freeAvailable of [true, false])
+      expect(trayReviewLine(freeAvailable)).toMatch(/part of what you paid/);
+  });
+
+  it('says nothing about an allowance when free is not on offer', () => {
+    expect(trayReviewLine(false)).not.toMatch(/allowance/);
+  });
+});
+
+/**
+ * When the allowance comes back, taken from the value the server computed rather
+ * than from a boundary written down twice.
+ */
+describe('the reset the refusal names', () => {
+  const spent = { remaining: 0, usedHere: false };
+  const open = { freeSlots: 4, freeSlotsRemaining: 2 };
+
+  it('uses the reset the server shipped', () => {
+    expect(
+      freeRefusalMessage({ ...spent, resetsAt: new Date('2026-08-18T00:00:00Z') }, open)
+    ).toMatch(/comes back at 00:00 UTC/);
+  });
+
+  /**
+   * The point of deriving it: the day boundary is the server's rule, so a
+   * different one has to change this sentence rather than leave it wrong.
+   */
+  it('follows a reset that is not midnight', () => {
+    expect(
+      freeRefusalMessage({ ...spent, resetsAt: new Date('2026-08-18T06:30:00Z') }, open)
+    ).toMatch(/comes back at 06:30 UTC/);
+  });
+
+  it('still says when it lifts if the reset never arrived', () => {
+    expect(freeRefusalMessage(spent, open)).toMatch(/comes back at midnight UTC/);
+    expect(freeRefusalMessage({ ...spent, resetsAt: 'not a date' }, open)).toMatch(
+      /comes back at midnight UTC/
+    );
+  });
+});

--- a/src/components/Sticker/__tests__/payout-copy.test.ts
+++ b/src/components/Sticker/__tests__/payout-copy.test.ts
@@ -3,6 +3,7 @@ import {
   declineConsequence,
   moderatorTakedownConsequence,
   payoutCopy,
+  placementAmountLine,
   placementPaymentSummary,
   removalConsequence,
   removalLockReason,
@@ -142,19 +143,34 @@ describe('the removal copy', () => {
  */
 describe('placementPaymentSummary', () => {
   it('states the amount on a paid placement', () => {
-    expect(placementPaymentSummary(false, 700)).toBe('paid 700 Buzz');
+    expect(placementPaymentSummary(700)).toBe('paid 700 Buzz');
+  });
+});
+
+/**
+ * The branch itself, which used to live inside `placementPaymentSummary` and
+ * then briefly inside the page — where nothing can test it, because Next treats
+ * every file under `src/pages` as a route.
+ *
+ * Both arms are asserted on purpose. Testing only the free one leaves the paid
+ * line free to stop naming an amount; testing only the paid one leaves the free
+ * row free to go back to claiming a payment of zero.
+ */
+describe('placementAmountLine', () => {
+  /**
+   * A free row is `amount: 0`, DB-enforced. Say the amount and the card asserts
+   * a payment of zero directly above an irreversible choice, on the page a
+   * notification saying "free" has just linked to.
+   */
+  it('names no amount on a free placement', () => {
+    const line = placementAmountLine(true, 0);
+
+    expect(line).toBe('placed this');
+    expect(line).not.toMatch(/paid|Buzz|0/);
   });
 
-  /**
-   * A free row is `amount: 0`, DB-enforced. Unbranched, this card asserted a
-   * payment of zero directly above an irreversible choice, on the page a
-   * notification saying "free" had just linked to.
-   */
-  it('claims no payment on a free one, and names no amount', () => {
-    const free = placementPaymentSummary(true, 0);
-
-    expect(free).toBe('placed this free');
-    expect(free).not.toMatch(/paid|Buzz|0/);
+  it('still states the amount on a paid one', () => {
+    expect(placementAmountLine(false, 700)).toBe('paid 700 Buzz');
   });
 });
 

--- a/src/components/Sticker/__tests__/payout-copy.test.ts
+++ b/src/components/Sticker/__tests__/payout-copy.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { payoutCopy, stickerPurchaseCopy } from '~/components/Sticker/payout-copy';
+import {
+  declineConsequence,
+  moderatorTakedownConsequence,
+  payoutCopy,
+  placementPaymentSummary,
+  removalConsequence,
+  removalLockReason,
+  selectionFree,
+  stickerPurchaseCopy,
+} from '~/components/Sticker/payout-copy';
 
 describe('payoutCopy', () => {
   // The whole reason the name is there. "The creator" is read while looking at
@@ -64,5 +73,158 @@ describe('stickerPurchaseCopy', () => {
   // name the wrong recipient of real money.
   it('says nothing when the maker is unknown rather than absent', () => {
     expect(stickerPurchaseCopy(undefined)).toBeNull();
+  });
+});
+
+/**
+ * The money copy the OWNER decides on.
+ *
+ * Every sentence here is read at the moment somebody presses approve, decline or
+ * remove, and each one asserts something about Buzz. The paid versions describe
+ * the escrow's two holds, which a free row does not have — so on a free row they
+ * are not loosely worded, they are false statements about money made where a
+ * decision is taken and later repeated to support.
+ */
+describe('declineConsequence', () => {
+  it('describes the two holds on a paid placement', () => {
+    expect(declineConsequence(false)).toMatch(/keeps most of what they paid/);
+  });
+
+  it('claims no payment on a free one, and says what the placer does lose', () => {
+    const free = declineConsequence(true);
+
+    expect(free).not.toMatch(/paid for it|what they paid/);
+    // The asymmetry the placer was warned about before pressing: the image's
+    // slot comes back, their day does not. The owner deciding should see it too.
+    expect(free).toMatch(/free placement for today is still spent/);
+  });
+
+  /**
+   * `undefined` is a mixed bulk selection, not a missing value. Either concrete
+   * sentence would be false about half of what is selected, so this branch says
+   * only what covers both — and it must not read as one of them.
+   */
+  it('covers both kinds without asserting either, for a mixed selection', () => {
+    const mixed = declineConsequence(undefined);
+
+    expect(mixed).toMatch(/free placement moves no Buzz/);
+    expect(mixed).toMatch(/fee staying with you/);
+    expect(mixed).not.toBe(declineConsequence(true));
+    expect(mixed).not.toBe(declineConsequence(false));
+  });
+});
+
+describe('the removal copy', () => {
+  it('gives the true reason for the week on each kind', () => {
+    expect(removalLockReason(false)).toMatch(/Someone paid to place this/);
+    expect(removalLockReason(true)).toMatch(/commitment to keep it up for a week/);
+    // The client must not restate the paid reason on a free row — this mirrors
+    // the server's refusal, which was corrected for the same reason.
+    expect(removalLockReason(true)).not.toMatch(/paid/);
+  });
+
+  it('promises the owner no payment they never received', () => {
+    expect(removalConsequence(false)).toMatch(/Buzz you were paid for it stays with you/);
+    expect(removalConsequence(true)).not.toMatch(/you were paid/);
+    expect(removalConsequence(true)).toMatch(/No Buzz was paid for it/);
+  });
+
+  it('says nobody is notified either way, which is true of both', () => {
+    for (const free of [true, false])
+      expect(removalConsequence(free)).toMatch(/nobody is notified/);
+  });
+});
+
+/**
+ * The queue row's headline, which is the only money statement on the card the
+ * Approve and Decline buttons sit under — and the page the free-placement
+ * notification sends the creator to.
+ */
+describe('placementPaymentSummary', () => {
+  it('states the amount on a paid placement', () => {
+    expect(placementPaymentSummary(false, 700)).toBe('paid 700 Buzz');
+  });
+
+  /**
+   * A free row is `amount: 0`, DB-enforced. Unbranched, this card asserted a
+   * payment of zero directly above an irreversible choice, on the page a
+   * notification saying "free" had just linked to.
+   */
+  it('claims no payment on a free one, and names no amount', () => {
+    const free = placementPaymentSummary(true, 0);
+
+    expect(free).toBe('placed this free');
+    expect(free).not.toMatch(/paid|Buzz|0/);
+  });
+});
+
+describe('moderatorTakedownConsequence', () => {
+  it('warns that a pending paid placement forfeits the whole escrow', () => {
+    expect(moderatorTakedownConsequence({ pending: true, free: false })).toMatch(
+      /forfeits everything the placer paid/
+    );
+  });
+
+  it('says no Buzz moves on a live paid placement', () => {
+    expect(moderatorTakedownConsequence({ pending: false, free: false })).toMatch(/No Buzz moves/);
+  });
+
+  /**
+   * There is no escrow on a free row in either state, so the pending branch's
+   * forfeit is a claim about money that does not exist — asserted at an
+   * irreversible action a moderator is about to take.
+   */
+  it.each([true, false])('never claims a forfeit on a free row — pending %s', (pending) => {
+    const free = moderatorTakedownConsequence({ pending, free: true });
+
+    expect(free).not.toMatch(/forfeit|already paid|gets? nothing back/);
+    expect(free).toMatch(/[Nn]othing was paid for it/);
+    expect(free).toMatch(/nobody is notified/);
+  });
+
+  it('separates the two states on a free row too', () => {
+    expect(moderatorTakedownConsequence({ pending: true, free: true })).not.toBe(
+      moderatorTakedownConsequence({ pending: false, free: true })
+    );
+  });
+});
+
+/**
+ * All free, all paid, or mixed — extracted from the queue page because the mixed
+ * case is the one that matters and it was untestable inline.
+ */
+describe('selectionFree', () => {
+  const rows = [
+    { id: 1, free: true },
+    { id: 2, free: true },
+    { id: 3, free: false },
+  ];
+
+  it('reports a uniform selection', () => {
+    expect(selectionFree([1, 2], rows)).toBe(true);
+    expect(selectionFree([3], rows)).toBe(false);
+  });
+
+  /**
+   * The mutation this exists for: collapsing to whichever kind came first makes a
+   * bulk decline assert a sentence false of half the rows it is about.
+   */
+  it('reports mixed as undefined rather than picking a side', () => {
+    expect(selectionFree([1, 3], rows)).toBeUndefined();
+    expect(selectionFree([3, 1], rows)).toBeUndefined();
+  });
+
+  /**
+   * An id whose row has not paged in yet is unknown, which makes the whole
+   * selection mixed — the safe direction, because `declineConsequence` then says
+   * only what covers both.
+   */
+  it('treats a row it cannot see as unknown', () => {
+    expect(selectionFree([1, 99], rows)).toBeUndefined();
+    expect(selectionFree([99], rows)).toBeUndefined();
+  });
+
+  it('says nothing about an empty selection', () => {
+    expect(selectionFree([], rows)).toBeUndefined();
   });
 });

--- a/src/components/Sticker/free-marker.ts
+++ b/src/components/Sticker/free-marker.ts
@@ -1,0 +1,39 @@
+/**
+ * Who sees that a placed sticker cost nothing.
+ *
+ * The owner, the placer and moderators — nobody else. Everything else in this
+ * feature treats free-vs-paid as private between the two parties to it: the
+ * pending queue says "only you and the placer can see these", the hidden note
+ * says "only you, the person who placed it, and moderators". A public mark would
+ * be the first thing telling a stranger how a placement was funded, and it would
+ * say it about the owner's own settings on every image they own.
+ *
+ * A decision, not caution — see the PR. The overlay renders nothing at all when
+ * this is false rather than hiding a mark with CSS, because a hidden element is
+ * still in the DOM and that is not what the sentences above promise.
+ */
+export function freeMarkerVisible({
+  free,
+  isPending,
+  ownerId,
+  placerId,
+  viewerId,
+  isModerator = false,
+}: {
+  free: boolean;
+  /**
+   * Only while the owner has not answered it — Justin's call. Once a sticker is
+   * approved it is on the image on its own terms, and how it was funded stops
+   * being what the owner is deciding about.
+   */
+  isPending: boolean;
+  ownerId: number;
+  placerId: number;
+  /** Signed out is `undefined`, which must not match an id. */
+  viewerId?: number;
+  isModerator?: boolean;
+}) {
+  if (!free || !isPending) return false;
+  if (isModerator) return true;
+  return viewerId != null && (viewerId === ownerId || viewerId === placerId);
+}

--- a/src/components/Sticker/free-offer.ts
+++ b/src/components/Sticker/free-offer.ts
@@ -1,0 +1,194 @@
+/**
+ * Whether the free offer is on the table, and what it says.
+ *
+ * Its own module with no imports, for the same reason `payout-copy.ts` is one:
+ * these are the branches most worth testing and the least worth dragging
+ * Mantine, tRPC and the edge image loader into a unit run to reach.
+ *
+ * The predicate lives here rather than at each of the three places that need it
+ * — the button's tray, the draft layer, and the draft itself — because three
+ * copies of a three-term condition is how one of them starts offering free where
+ * the others do not.
+ */
+
+/**
+ * The free offer, or `null` when paid is the only one.
+ *
+ * All three facts have to hold, and each is a different reason to be looking at
+ * the paid button: the creator may take no free stickers or have none left, the
+ * placer may have spent their day, or they may have already placed free on this
+ * image. Missing any one of them offers something the claim then refuses.
+ *
+ * `null` while either query is in flight, which shows the paid button first and
+ * adds the choice when it lands. The other order offers free and takes it away.
+ *
+ * ⚠️ Both inputs are display state and stale the moment they arrive. This picks
+ * which offer to SHOW; `createFreePlacement` decides whether one is allowed,
+ * under a lock, in the transaction that inserts.
+ */
+export function freeOfferFor(
+  space?: FreeCapacity & { mode?: string },
+  standing?: FreeStanding
+): { instant: boolean } | null {
+  if (!space || !standing) return null;
+  if (space.freeSlotsRemaining <= 0) return null;
+  if (standing.remaining <= 0 || standing.usedHere) return null;
+
+  return { instant: space.mode === 'auto' };
+}
+
+/**
+ * Which offer is selected, defaulting to free whenever one is available.
+ *
+ * `null` means nobody has pressed the control, and that is what makes the
+ * default work: the offer arrives with a query, so a value chosen on the first
+ * render would be paid and would stay paid once the real answer landed.
+ *
+ * Paid placements never consume free slots, so both can be genuinely available
+ * at once — this is a choice, not a fallback.
+ */
+export const isPlacingFree = (chosen: 'free' | 'paid' | null, offer: { instant: boolean } | null) =>
+  (chosen ?? (offer ? 'free' : 'paid')) === 'free' && !!offer;
+
+/**
+ * The free option's own label, which carries the mode.
+ *
+ * The mode goes here rather than on the sticker button because this is the last
+ * moment the placer can change their mind, and it makes auto-accept and review
+ * read as two different offers rather than one setting they cannot see. The
+ * button upstream stays a single number.
+ */
+export const freeOptionLabel = (instant: boolean) =>
+  instant ? 'Free · instant' : 'Free · needs review';
+
+/**
+ * The one line under a review-mode free option.
+ *
+ * Said before the press, not after, because it is the whole asymmetry of the
+ * free tier: the image's slot comes back when a creator declines and the
+ * placer's day does not. Somebody who would rather spend Buzz on a creator who
+ * reviews needs that fact while both options are still on screen.
+ */
+export const FREE_REVIEW_CAVEAT =
+  "Your free placement for today is spent even if they decline. The creator's slot comes back; your allowance does not.";
+
+/**
+ * What went wrong when a free claim was refused, from state re-read after the
+ * refusal rather than from the server's message — or `null` when the re-read
+ * does not explain it.
+ *
+ * The numbers the control renders are stale by construction — the claim
+ * re-counts under a lock — so losing the last slot to someone else is an
+ * ordinary outcome rather than an error, and it deserves a sentence written for
+ * the person reading it. Re-reading is what makes the sentence true: the refusal
+ * does not say which rule stopped it, and reading its text would be a client
+ * parsing prose the server is free to reword.
+ *
+ * 🔴 **`null` is the important return.** A free placement can be refused for
+ * plenty of reasons that have nothing to do with the free tier — a block, a
+ * moderator suspension, self-placement, a sticker over the creator's size limit
+ * — each with a message written for the person who hit it. Answering "someone
+ * took the last slot" to any of those throws that message away and sends them to
+ * a remedy that will not work. So this speaks only where it knows, and the
+ * caller shows the server's own refusal otherwise.
+ *
+ * 🔴 **Ordered so a refusal that is PERMANENT for this image outranks one that
+ * lifts by itself**, because more than one can be true at once and the first
+ * match is what gets said. Telling somebody their allowance comes back at
+ * midnight, when the real answer is that this creator takes no free stickers at
+ * all, is a false promise about a specific image — they come back tomorrow to
+ * the same refusal. The pairwise tests exist to hold this order: each sets both
+ * conditions of an adjacent pair, so a swap fails rather than passing on
+ * fixtures that only ever trip one rung.
+ */
+export function freeRefusalMessage(standing?: FreeStanding, space?: FreeCapacity) {
+  // Permanent for this image, and true of everybody — so it outranks the two
+  // below it, which are about this placer and about right now.
+  if (space && space.freeSlots <= 0)
+    return 'This creator is not taking free stickers on this image.';
+  // Permanent for this placer on this image: once ever, not once per day.
+  if (standing?.usedHere) return 'You have already used a free sticker on this image.';
+  // Transient, and it says when it lifts — derived from the reset the server
+  // computed rather than restating the boundary here.
+  if (standing && standing.remaining <= 0)
+    return `You have used today's free placement. It comes back ${allowanceResetLabel(
+      standing.resetsAt
+    )}.`;
+  // The most transient of all — a declined placement releases its slot at once.
+  if (space && space.freeSlotsRemaining <= 0)
+    return 'Someone took the last free slot on this image first.';
+  return null;
+}
+
+/**
+ * What to say and what to do when a free claim was refused.
+ *
+ * Pure, and separate from `freeRefusalMessage`, because the consequential half is
+ * not the wording — it is `fallBackToPaid`. Offering the paid button is right
+ * when free specifically ran out and wrong when the whole placement was refused:
+ * somebody who is blocked, suspended, or placing on their own image would press
+ * it and meet the same refusal, having been told the problem was money.
+ *
+ * A hook cannot be asked this question without a query client and a tRPC
+ * provider, so the decision lives here where a test can put both cases to it.
+ */
+export const freeRefusalOutcome = (explained: string | null, serverMessage: string) =>
+  explained
+    ? { title: 'That one has to be paid for', message: explained, fallBackToPaid: true }
+    : { title: "Couldn't place that sticker", message: serverMessage, fallBackToPaid: false };
+
+type FreeStanding = {
+  remaining: number;
+  usedHere: boolean;
+  /**
+   * When the allowance comes back. Computed by `getFreePlacementAllowance` and
+   * shipped on every read — so a sentence that hardcodes the boundary is a second
+   * copy of a rule the server already owns, and the two are free to disagree the
+   * day the day-boundary or the per-day count moves.
+   */
+  resetsAt?: Date | string;
+};
+type FreeCapacity = { freeSlots: number; freeSlotsRemaining: number };
+
+/**
+ * When the daily allowance comes back, in words.
+ *
+ * Falls back to the boundary the server currently uses rather than saying nothing,
+ * because a refusal that cannot say when it lifts is worse than one that names a
+ * default — but the value is preferred, so changing the day boundary changes this
+ * sentence instead of making it wrong.
+ */
+function allowanceResetLabel(resetsAt?: Date | string) {
+  if (!resetsAt) return 'at midnight UTC';
+  const at = new Date(resetsAt);
+  if (Number.isNaN(at.getTime())) return 'at midnight UTC';
+
+  return `at ${at.toISOString().slice(11, 16)} UTC`;
+}
+
+/**
+ * The tray's price line, which has to name both offers when both are open.
+ *
+ * The use is the constant: a free placement is free of the creator's price and of
+ * nothing else. Saying so here is what stops the tray and the Place button
+ * disagreeing about what a sticker costs.
+ */
+export const trayPriceLine = (freeAvailable: boolean, price: number) =>
+  freeAvailable ? `Free, or ${price} Buzz · one use either way` : `${price} Buzz + one use`;
+
+/**
+ * What the tray says a decline costs on a review-mode space.
+ *
+ * 🔴 The free half is `FREE_REVIEW_CAVEAT` itself rather than a paraphrase of it.
+ * There are three statements of this rule in the product — this one, the caveat
+ * under the draft's own free option, and `declineConsequence`'s free branch on the
+ * owner's side — and two of the three now come from one constant, so a change to
+ * what a decline costs cannot leave a stale copy behind in the tray.
+ *
+ * The paid half is kept in both branches: where both offers are open, somebody
+ * choosing to pay still needs the fee disclosure.
+ */
+export const trayReviewLine = (freeAvailable: boolean) =>
+  freeAvailable
+    ? ` ${FREE_REVIEW_CAVEAT} A paid placement leaves part of what you paid with them.`
+    : ' If they decline, part of what you paid stays with them.';

--- a/src/components/Sticker/payout-copy.ts
+++ b/src/components/Sticker/payout-copy.ts
@@ -33,6 +33,109 @@ export function payoutCopy(
 }
 
 /**
+ * What the owner is told a decline costs, which is a different fact on a free
+ * placement.
+ *
+ * The paid sentence — the placer keeps most of what they paid, a fee stays with
+ * you — is the escrow's two-hold structure, and a free row has neither hold. So
+ * on a free row it is not a rounding error in the wording, it is a false
+ * statement about money made at the moment somebody decides.
+ *
+ * ⚠️ **`undefined` is a real case, not a missing value.** A bulk decline can hold
+ * both kinds at once, where neither sentence is true of everything selected —
+ * so that branch says only what covers both rather than picking the majority.
+ */
+export function declineConsequence(free: boolean | undefined) {
+  if (free === true)
+    return 'No Buzz moves — nothing was paid for this one. Their free placement for today is still spent.';
+  if (free === false) return 'The placer keeps most of what they paid, and a fee stays with you.';
+  return 'Any Buzz paid mostly returns to the placer with a fee staying with you; a free placement moves no Buzz.';
+}
+
+/**
+ * The queue row's headline, which is the only money statement on the card the
+ * Approve and Decline buttons sit under.
+ *
+ * A free row carries `amount: 0`, enforced by the DB — so "paid 0 Buzz" is not a
+ * cosmetic slip. It is the page the free-placement notification sends the creator
+ * to: the notification says the placement was free and the card then asserts a
+ * payment of zero, immediately above an irreversible choice.
+ */
+export const placementPaymentSummary = (free: boolean, amount: number) =>
+  free ? 'placed this free' : `paid ${amount} Buzz`;
+
+/**
+ * What a moderator take-down does to the money.
+ *
+ * Two axes, and free breaks the pending one specifically: a pending PAID row
+ * settles as a forfeit of the whole escrow, and a pending free row has no escrow
+ * to forfeit. Both statements are false on a free row in
+ * `RemoveReportedPlacement`, where the live branch also promises the creator was
+ * already paid.
+ */
+export function moderatorTakedownConsequence({
+  pending,
+  free,
+}: {
+  pending: boolean;
+  free: boolean;
+}) {
+  if (free)
+    return pending
+      ? 'This one is still awaiting the owner. Nothing was paid for it, so no Buzz moves, and nobody is notified.'
+      : 'The sticker comes off this content for everyone, recorded as a moderator takedown. Nothing was paid for it, so no Buzz moves, and nobody is notified.';
+
+  return pending
+    ? 'This one is still awaiting the owner. Taking it down forfeits everything the placer paid — they get nothing back, and nobody is notified.'
+    : 'The sticker comes off this content for everyone, recorded as a moderator takedown. No Buzz moves and nobody is notified.';
+}
+
+/**
+ * Whether a set of selected rows is all free, all paid, or mixed.
+ *
+ * Here rather than in the page because `declineConsequence` is what consumes it
+ * and its `undefined` branch is already covered — inline in a page component the
+ * collapse from "mixed" to "whichever kind we saw first" is a mutation nothing
+ * can observe, and it makes a bulk decline assert a sentence false of half the
+ * rows it is about.
+ *
+ * An id whose row is not paged in yet counts as unknown, which makes the whole
+ * selection mixed. That is the safe direction: it says only what covers both.
+ */
+export function selectionFree(
+  selected: number[],
+  rows: { id: number; free: boolean }[]
+): boolean | undefined {
+  const kinds = new Set(selected.map((id) => rows.find((row) => row.id === id)?.free));
+  return kinds.size === 1 ? [...kinds][0] : undefined;
+}
+
+/**
+ * Why a live sticker cannot be taken off yet.
+ *
+ * Mirrors the server's refusal in `removeApprovedSticker`, which is the thing
+ * that actually decides. The week is the same either way — Justin's call — so
+ * only the reason differs, and the paid reason is untrue on a free row.
+ */
+export const removalLockReason = (free: boolean) =>
+  free
+    ? 'Accepting a sticker is a commitment to keep it up for a week.'
+    : 'Someone paid to place this, so it stays up for a week.';
+
+/**
+ * What a removal does to the money, once it is allowed.
+ *
+ * The paid line reassures the owner that the Buzz they were paid stays with
+ * them. There is none on a free row, and inventing a reassurance about a payment
+ * that never happened is how a support thread starts with somebody insisting
+ * they were paid.
+ */
+export const removalConsequence = (free: boolean) =>
+  free
+    ? 'It comes off your image for everyone. No Buzz was paid for it, so none moves, and nobody is notified.'
+    : 'It comes off your image for everyone. The Buzz you were paid for it stays with you, and nobody is notified.';
+
+/**
  * The same chip, for the step before: buying the sticker itself.
  *
  * Named rather than "the creator" for the reason above, and more sharply here —

--- a/src/components/Sticker/payout-copy.ts
+++ b/src/components/Sticker/payout-copy.ts
@@ -56,13 +56,27 @@ export function declineConsequence(free: boolean | undefined) {
  * The queue row's headline, which is the only money statement on the card the
  * Approve and Decline buttons sit under.
  *
- * A free row carries `amount: 0`, enforced by the DB — so "paid 0 Buzz" is not a
- * cosmetic slip. It is the page the free-placement notification sends the creator
- * to: the notification says the placement was free and the card then asserts a
- * payment of zero, immediately above an irreversible choice.
+ * Paid rows only. A free row carries `amount: 0`, enforced by the DB, so this
+ * sentence would assert a payment of zero on the page the free-placement
+ * notification sends the creator to — immediately above an irreversible choice.
+ * The caller says nothing about money on a free row and badges it instead.
  */
-export const placementPaymentSummary = (free: boolean, amount: number) =>
-  free ? 'placed this free' : `paid ${amount} Buzz`;
+export const placementPaymentSummary = (amount: number) => `paid ${amount} Buzz`;
+
+/**
+ * Which of those a queue row says, which is the branch that must not be lost.
+ *
+ * Here rather than as a ternary in the page: `src/pages` cannot carry a test —
+ * Next treats every file under it as a route — so a `row.free ?` inline is a
+ * money statement with nothing able to assert it. Dropping the free arm makes
+ * the card read "paid 0 Buzz" over a free placement, on the page a "your
+ * placement was free" notification links to, immediately above an irreversible
+ * choice. Typecheck and every test still pass.
+ *
+ * The free arm names no amount at all — the badge beside it carries the fact.
+ */
+export const placementAmountLine = (free: boolean, amount: number) =>
+  free ? 'placed this' : placementPaymentSummary(amount);
 
 /**
  * What a moderator take-down does to the money.

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { getQueryKey } from '@trpc/react-query';
 import { useCallback, useMemo } from 'react';
+import { freeRefusalMessage, freeRefusalOutcome } from '~/components/Sticker/free-offer';
 import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -13,6 +14,15 @@ export type PlacedSticker = {
   ownerId: number;
   status: string;
   amount: number;
+  /**
+   * Placed against the creator's free capacity, so nothing was paid for it.
+   *
+   * On the listing rather than derived from `amount`, because every surface that
+   * reads this decides what to SAY about money — what a decline returns, why a
+   * removal is locked — and a zero is a number rather than the fact that answers
+   * that.
+   */
+  free: boolean;
   data: StickerPlacementData;
   /**
    * `Date` over superjson, a string out of anything that stringified the cache
@@ -179,6 +189,25 @@ export function useForgetStickerPlacement() {
   );
 }
 
+/**
+ * Where the viewer stands against the free tier on one image.
+ *
+ * Its own query rather than folded into the space: the space is public and
+ * cached per image, and this is per viewer — merging them would make one
+ * person's allowance part of a payload every other viewer of that image shares.
+ *
+ * **A listing.** Whatever it says, the claim re-decides all of it under a lock,
+ * so this only ever chooses which offer to show — never whether one is allowed.
+ */
+export function useFreePlacementStanding(imageId?: number) {
+  const { data, isLoading } = trpc.placement.getFreeStanding.useQuery(
+    { surface: 'sticker', targetType: 'image', targetId: imageId as number },
+    { enabled: !!imageId, staleTime: 60_000 }
+  );
+
+  return { standing: data, isLoading };
+}
+
 export function useImagePlacementSpace(imageId?: number) {
   const { data, isLoading } = trpc.placement.getSpace.useQuery(
     { surface: 'sticker', targetType: 'image', targetId: imageId as number },
@@ -194,7 +223,16 @@ export function useImagePlacementSpace(imageId?: number) {
  * One hook rather than the mutation inline, so the tray and the sticker's own
  * buy button cannot drift into two versions of what happens on success.
  */
-export function useCreateStickerPlacement(draftId: string) {
+export function useCreateStickerPlacement(
+  draftId: string,
+  /**
+   * Called when a free claim was refused, so the control can settle on the paid
+   * option. Losing the last slot to someone else is an ordinary race rather than
+   * a fault, and leaving the control on an offer that no longer exists would
+   * make the next press fail the same way.
+   */
+  onFreeRefused?: () => void
+) {
   const utils = trpc.useUtils();
   const cancelDraft = useStickerPlacementDraftStore((state) => state.cancelDraft);
 
@@ -226,10 +264,66 @@ export function useCreateStickerPlacement(draftId: string) {
       // would draw the same sticker twice with one of them uncommitted.
       cancelDraft(draftId);
     },
-    onError: (error) =>
-      showErrorNotification({
-        title: "Couldn't place that sticker",
-        error: new Error(error.message),
-      }),
+    onError: async (error, variables) => {
+      if (!variables.free)
+        return showErrorNotification({
+          title: "Couldn't place that sticker",
+          error: new Error(error.message),
+        });
+
+      // Re-read before saying anything. The refusal does not name which of the
+      // free-tier rungs stopped it, and the numbers this control rendered are
+      // stale by construction — so the honest sentence comes from fresh state,
+      // not from the server's prose.
+      const target = {
+        surface: 'sticker' as const,
+        targetType: 'image' as const,
+        targetId: variables.imageId,
+      };
+
+      // `staleTime: 0` rather than invalidate-then-read, so freshness is a
+      // property of the call instead of the order two statements happen to be in.
+      // With the two-step version, hoisting the reads above the invalidation is a
+      // mutation nothing can observe, and what it produces is exactly the stale
+      // numbers this re-read exists to avoid.
+      //
+      // 🔴 **The catches are not defensive padding.** `invalidate` and `getData`
+      // were total — neither can reject — and `fetch` REJECTS on query error, with
+      // no try/catch in this handler. `getFreeStanding` is a protectedProcedure,
+      // so an expired session fails the placement and then fails this re-read too:
+      // unguarded, the rejection skips the notification entirely and somebody
+      // presses Place free, watches the button return to idle, and is told
+      // nothing. A failed re-read explains nothing, which is already what
+      // `freeRefusalMessage` says about `undefined` — every rung is guarded on
+      // `space &&` / `standing?.` — so it lands on the server's own message with
+      // no fall back to paid, which is the outcome that leaves someone informed.
+      const [space, standing] = await Promise.all([
+        utils.placement.getSpace.fetch(target, { staleTime: 0 }).catch(() => undefined),
+        utils.placement.getFreeStanding.fetch(target, { staleTime: 0 }).catch(() => undefined),
+      ]);
+
+      // Every OTHER image's cached standing is stale too, because the allowance
+      // is one placement a day across the whole site — and that stale number is
+      // what a control elsewhere reads to decide whether to offer free at all.
+      // Unkeyed for that reason; the space is per image and needs no sweep.
+      void utils.placement.getFreeStanding.invalidate();
+
+      // 🔴 Only a refusal the re-read can account for falls back to paid. The
+      // free path refuses plenty of things that have nothing to do with the free
+      // tier — a block, a suspension, self-placement, a sticker over the
+      // creator's size limit — each arriving with a message written for the
+      // person who hit it. Answering all of them with "someone took the last
+      // slot" throws those away and offers a paid button that fails the same
+      // way, which is the worse half: the remedy is wrong, not just the reason.
+      // The branch itself is `freeRefusalOutcome`, where it is testable.
+      const outcome = freeRefusalOutcome(freeRefusalMessage(standing, space), error.message);
+
+      // Paid rather than an error where free ran out, which is the cross-surface
+      // rule: the placement they arranged is still available, it just costs Buzz
+      // now, and starting over would throw away the arrangement over a race that
+      // took nothing from them.
+      if (outcome.fallBackToPaid) onFreeRefused?.();
+      showErrorNotification({ title: outcome.title, error: new Error(outcome.message) });
+    },
   });
 }

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -16,6 +16,10 @@ import { openConfirmModal } from '@mantine/modals';
 import { IconCheck, IconX } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { PlacementFreeBadge } from '~/components/Placement/PlacementFreeBadge';
+import { PlacementFreeFilter } from '~/components/Placement/PlacementFreeFilter';
+import { visibleQueueRows } from '~/components/Placement/free-filter';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { useServerDomains } from '~/providers/AppProvider';
 import { syncAccount } from '~/utils/sync-account';
@@ -179,6 +183,12 @@ function ReceivedTab({
 }) {
   const utils = trpc.useUtils();
   const withheldHref = useWithheldHref();
+  const [showFree, setShowFree] = useState(true);
+
+  // Filtered here rather than in the parent so the tab's own badge keeps
+  // counting everything waiting: hiding the free ones is a view of the queue,
+  // not a statement about how much is in it.
+  const visible = visibleQueueRows(rows, showFree);
 
   const act = trpc.placement.actOnRemixGallerySubmission.useMutation({
     onSuccess: (_result, variables) => {
@@ -242,6 +252,12 @@ function ReceivedTab({
 
   return (
     <Stack gap="md">
+      {rows.some((row) => row.free) && (
+        <Group justify="flex-end">
+          <PlacementFreeFilter show={showFree} onChange={setShowFree} noun="submissions" />
+        </Group>
+      )}
+
       {!rows.length && (
         <Text size="sm" c="dimmed">
           Nothing on this page can be shown — the images behind these submissions are gone or still
@@ -249,7 +265,16 @@ function ReceivedTab({
         </Text>
       )}
 
-      {rows.map((row) => (
+      {/* Said separately from the line above it, which is about rows the server
+          dropped. An empty queue because the owner hid the free ones is their
+          own doing, and telling them their images are gone would be false. */}
+      {!!rows.length && !visible.length && (
+        <Text size="sm" c="dimmed">
+          Every submission waiting on you is a free one, and free ones are hidden.
+        </Text>
+      )}
+
+      {visible.map((row) => (
         <Card key={row.id} withBorder>
           <Group justify="space-between" wrap="nowrap" align="flex-start">
             <Group gap="sm" wrap="nowrap" align="flex-start">
@@ -273,9 +298,7 @@ function ReceivedTab({
                 {/* Nothing was paid on a free row, so a Buzz chip there reads
                     as an offer of 0 rather than as a different kind of offer. */}
                 {row.free ? (
-                  <Badge size="sm" variant="light" color="green" className="w-fit">
-                    Free submission
-                  </Badge>
+                  <PlacementFreeBadge noun="submission" />
                 ) : (
                   <Group gap={4}>
                     <CurrencyIcon currency={Currency.BUZZ} size={12} />

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -229,8 +229,9 @@ function ReceivedTab({
       <Alert color="gray">
         <Text size="sm">Nothing is waiting for your review.</Text>
         <Text size="sm" c="dimmed" mt={4}>
-          When someone pays to feature their remix on one of your images, it appears here for you to
-          approve or decline. You choose whether to accept them at all, and what they cost, in{' '}
+          When someone submits a remix on one of your images — paid, or against the free slots you
+          offer — it appears here for you to approve or decline. You choose whether to accept them
+          at all, how many free ones you take, and what the paid ones cost, in{' '}
           <Anchor component={Link} href="/user/account">
             your account settings
           </Anchor>
@@ -269,12 +270,20 @@ function ReceivedTab({
                   </Text>{' '}
                   wants to feature this on your image
                 </Text>
-                <Group gap={4}>
-                  <CurrencyIcon currency={Currency.BUZZ} size={12} />
-                  <Text size="xs" c="dimmed">
-                    {row.amount}
-                  </Text>
-                </Group>
+                {/* Nothing was paid on a free row, so a Buzz chip there reads
+                    as an offer of 0 rather than as a different kind of offer. */}
+                {row.free ? (
+                  <Badge size="sm" variant="light" color="green" className="w-fit">
+                    Free submission
+                  </Badge>
+                ) : (
+                  <Group gap={4}>
+                    <CurrencyIcon currency={Currency.BUZZ} size={12} />
+                    <Text size="xs" c="dimmed">
+                      {row.amount}
+                    </Text>
+                  </Group>
+                )}
                 <Text size="xs" c="dimmed">
                   Sent {agedLabel(row.createdAt)}
                   {row.expiresAt ? ` — expires ${formatDate(row.expiresAt)}` : ''}
@@ -335,9 +344,13 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
       // States what happened, not what the ledger has done. A successful settle
       // means the transition was claimed, not that the refund leg has paid —
       // chunk C ships a sweep for unpaid legs precisely because those differ.
+      // No Buzz claim: this fires for free submissions too, which put nothing
+      // in escrow, and the row-level confirmation above already said what each
+      // kind gets back. A blanket "your Buzz is on its way" is false on half of
+      // them and unverifiable on the other half from here.
       showSuccessNotification({
         title: 'Withdrawn',
-        message: 'Your submission is withdrawn. Your Buzz is on its way back.',
+        message: 'Your submission is withdrawn.',
       });
       utils.placement.invalidate();
     },
@@ -366,8 +379,9 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
   return (
     <Stack gap="md">
       <Text size="sm" c="dimmed">
-        You can withdraw a submission any time before the creator reviews it and get your Buzz back
-        in full. Once it has been accepted there is nothing to withdraw.
+        You can withdraw a submission any time before the creator reviews it. A paid one refunds in
+        full; a free one does not return your daily free placement. Once it has been accepted there
+        is nothing to withdraw.
       </Text>
 
       {/* Neither queue pages. A list that stops at the cap and says nothing
@@ -401,12 +415,18 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
                   >
                     {row.status === 'approved' ? 'Live' : 'Awaiting review'}
                   </Badge>
-                  <Group gap={4}>
-                    <CurrencyIcon currency={Currency.BUZZ} size={12} />
-                    <Text size="xs" c="dimmed">
-                      {row.amount}
-                    </Text>
-                  </Group>
+                  {row.free ? (
+                    <Badge size="sm" variant="light" color="green">
+                      Free
+                    </Badge>
+                  ) : (
+                    <Group gap={4}>
+                      <CurrencyIcon currency={Currency.BUZZ} size={12} />
+                      <Text size="xs" c="dimmed">
+                        {row.amount}
+                      </Text>
+                    </Group>
+                  )}
                 </Group>
                 <Text size="sm">On {row.owner?.username ?? 'a creator'}&apos;s image</Text>
                 <Text size="xs" c="dimmed">
@@ -436,8 +456,9 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
                     children: (
                       <Text size="sm">
                         It comes out of {row.owner?.username ?? 'the creator'}&apos;s review queue
-                        and your {row.amount} Buzz starts on its way back. You can submit it again
-                        later.
+                        {row.free
+                          ? '. Your free placement for today stays spent, and free is once per gallery — withdrawing does not give it back, so you will not be able to submit here for free again.'
+                          : ` and your ${row.amount} Buzz starts on its way back. You can submit it again later.`}
                       </Text>
                     ),
                     labels: { confirm: 'Withdraw', cancel: 'Keep it' },

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -17,9 +17,12 @@ import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLe
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
 import { Meta } from '~/components/Meta/Meta';
+import { PlacementFreeBadge } from '~/components/Placement/PlacementFreeBadge';
+import { PlacementFreeFilter } from '~/components/Placement/PlacementFreeFilter';
+import { selectionAfterHidingFree, visibleQueueRows } from '~/components/Placement/free-filter';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
-import { placementPaymentSummary, selectionFree } from '~/components/Sticker/payout-copy';
+import { placementAmountLine, selectionFree } from '~/components/Sticker/payout-copy';
 import { WithheldThumb } from '~/components/RemixGallery/SubmissionPair';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import { useServerDomains } from '~/providers/AppProvider';
@@ -50,8 +53,10 @@ export default function StickerPlacements() {
       { getNextPageParam: (lastPage) => lastPage.nextCursor }
     );
   const [selected, setSelected] = useState<number[]>([]);
+  const [showFree, setShowFree] = useState(true);
 
-  const rows = data?.pages.flatMap((page) => page.items) ?? [];
+  const loaded = data?.pages.flatMap((page) => page.items) ?? [];
+  const rows = visibleQueueRows(loaded, showFree);
   const cosmeticIds = rows.map((row) => row.data.cosmeticId);
   const { sticker } = useStickerCosmetics(cosmeticIds);
 
@@ -66,6 +71,15 @@ export default function StickerPlacements() {
       current.includes(id) ? current.filter((value) => value !== id) : [...current, id]
     );
 
+  // Hiding the free rows takes them out of the selection with them. Approve and
+  // Decline are irreversible and both say something about money, so a selection
+  // that outlives the rows it was made from would act on placements the owner
+  // can no longer see.
+  const changeShowFree = (next: boolean) => {
+    setShowFree(next);
+    if (!next) setSelected((current) => selectionAfterHidingFree(current, loaded));
+  };
+
   return (
     <>
       <Meta title="Stickers awaiting your review" deIndex />
@@ -78,18 +92,27 @@ export default function StickerPlacements() {
                 Only you and the placer can see these. Unanswered ones expire after 48 hours.
               </Text>
             </div>
-            {rows.length > 0 && (
-              <Checkbox
-                // Names what it selects. With the queue paged it reaches the
-                // rows on screen, and an owner who bulk-declined believing they
-                // had cleared 200 would find 150 still waiting.
-                label={hasNextPage ? 'Select all loaded' : 'Select all'}
-                checked={allSelected}
-                indeterminate={selected.length > 0 && !allSelected}
-                onChange={() => setSelected(allSelected ? [] : rows.map((row) => row.id))}
-                className="shrink-0"
-              />
-            )}
+            <Group gap="sm" wrap="nowrap" className="shrink-0">
+              {rows.length > 0 && (
+                <Checkbox
+                  // Names what it selects. With the queue paged it reaches the
+                  // rows on screen, and an owner who bulk-declined believing they
+                  // had cleared 200 would find 150 still waiting. With the free
+                  // ones hidden it reaches those on screen too, not the hidden
+                  // ones behind them.
+                  label={hasNextPage ? 'Select all loaded' : 'Select all'}
+                  checked={allSelected}
+                  indeterminate={selected.length > 0 && !allSelected}
+                  onChange={() => setSelected(allSelected ? [] : rows.map((row) => row.id))}
+                  className="shrink-0"
+                />
+              )}
+              {/* Only once there is something to hide. A control that changes
+                nothing still asks the owner to work out what it does. */}
+              {loaded.some((row) => row.free) && (
+                <PlacementFreeFilter show={showFree} onChange={changeShowFree} noun="placements" />
+              )}
+            </Group>
           </Group>
 
           {selected.length > 0 && (
@@ -116,15 +139,25 @@ export default function StickerPlacements() {
           {/* `&& !hasNextPage`: a page whose rows were all dropped returns
               nothing with a cursor still set, and "nothing waiting" over a
               queue that has more is the failure paging exists to end. */}
-          {!isLoading && !isError && !rows.length && !hasNextPage && (
+          {/* Both of these ask whether the QUEUE is empty, which is a different
+              question from whether anything is on screen — with the free ones
+              hidden, "nothing waiting" would be the owner's own filter talking
+              back to them as a fact about their images. */}
+          {!isLoading && !isError && !loaded.length && !hasNextPage && (
             <Alert>
               <Text size="sm">Nothing waiting. Placements you approve show up on your images.</Text>
             </Alert>
           )}
 
-          {!rows.length && hasNextPage && (
+          {!loaded.length && hasNextPage && (
             <Text size="sm" c="dimmed">
               Nothing on this page can be shown. There are more waiting.
+            </Text>
+          )}
+
+          {!!loaded.length && !rows.length && (
+            <Text size="sm" c="dimmed">
+              Everything waiting on you is a free placement, and free ones are hidden.
             </Text>
           )}
 
@@ -200,13 +233,13 @@ export default function StickerPlacements() {
                       <Text span fw={600}>
                         {row.placer?.username ?? 'Someone'}
                       </Text>{' '}
-                      {/* The only money statement on the card the Approve and
-                          Decline buttons sit under, and a free row carries
-                          `amount: 0` — so unbranched it asserts a payment of zero
-                          on the very page the free-placement notification sends
-                          the creator to. */}
-                      {placementPaymentSummary(row.free, row.amount)}
+                      {/* Both arms in `payout-copy`, not a ternary here: this
+                          is the only money statement on the card the Approve
+                          and Decline buttons sit under, and nothing under
+                          `src/pages` can be tested. */}
+                      {placementAmountLine(row.free, row.amount)}
                     </Text>
+                    {row.free && <PlacementFreeBadge noun="placement" />}
                     <Text size="xs" c="dimmed">
                       Placed {formatDate(row.createdAt)}
                       {row.expiresAt ? ` · expires ${formatDate(row.expiresAt)}` : ''}

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -19,6 +19,7 @@ import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
 import { Meta } from '~/components/Meta/Meta';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
+import { placementPaymentSummary, selectionFree } from '~/components/Sticker/payout-copy';
 import { WithheldThumb } from '~/components/RemixGallery/SubmissionPair';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import { useServerDomains } from '~/providers/AppProvider';
@@ -56,6 +57,10 @@ export default function StickerPlacements() {
 
   const allSelected = rows.length > 0 && selected.length === rows.length;
 
+  // All free, all paid, or mixed. Derived beside `declineConsequence`, which is
+  // the only consumer and where the mixed branch is already covered.
+  const selectedFree = selectionFree(selected, rows);
+
   const toggle = (id: number) =>
     setSelected((current) =>
       current.includes(id) ? current.filter((value) => value !== id) : [...current, id]
@@ -91,7 +96,11 @@ export default function StickerPlacements() {
             <Card withBorder p="xs">
               <Group justify="space-between">
                 <Text size="sm">{selected.length} selected</Text>
-                <StickerPlacementActions placementIds={selected} onDone={() => setSelected([])} />
+                <StickerPlacementActions
+                  placementIds={selected}
+                  free={selectedFree}
+                  onDone={() => setSelected([])}
+                />
               </Group>
             </Card>
           )}
@@ -191,11 +200,12 @@ export default function StickerPlacements() {
                       <Text span fw={600}>
                         {row.placer?.username ?? 'Someone'}
                       </Text>{' '}
-                      paid{' '}
-                      <Text span fw={600}>
-                        {row.amount}
-                      </Text>{' '}
-                      Buzz
+                      {/* The only money statement on the card the Approve and
+                          Decline buttons sit under, and a free row carries
+                          `amount: 0` — so unbranched it asserts a payment of zero
+                          on the very page the free-placement notification sends
+                          the creator to. */}
+                      {placementPaymentSummary(row.free, row.amount)}
                     </Text>
                     <Text size="xs" c="dimmed">
                       Placed {formatDate(row.createdAt)}
@@ -225,6 +235,7 @@ export default function StickerPlacements() {
                   <StickerPlacementActions
                     placementIds={[row.id]}
                     hasComment={!!row.data.comment}
+                    free={row.free}
                     stacked
                     compact
                   />

--- a/src/server/notifications/__tests__/placement-free-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-free-notification.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { placementNotifications } from '~/server/notifications/placement.notifications';
+
+/**
+ * The free placement's own notification, and the paid one it must not collide
+ * with.
+ *
+ * These assert the SQL as text, which is what every other notification test
+ * here does and is weaker than running it — the queries are built as strings
+ * and never parsed in a unit run. What they can still catch is the whole reason
+ * this type exists: that the two are scoped apart, and that each honours its own
+ * setting. Both of those failures are silent in production — one sends the wrong
+ * sentence, the other ignores a switch the UI shows as working.
+ */
+type Def = (typeof placementNotifications)['sticker-placement-pending'];
+const defs = placementNotifications as Record<string, Def>;
+
+const LAST_SENT = '2026-08-16 00:00:00';
+const query = async (type: string) =>
+  (await defs[type].prepareQuery!({
+    lastSent: LAST_SENT,
+    lastSentDate: new Date(0),
+    clickhouse: undefined,
+  })) as string;
+
+describe('the free sticker notification is its own type', () => {
+  it('is registered and toggleable, in the creator category', () => {
+    const def = defs['sticker-placement-free-pending'];
+
+    expect(def).toBeTruthy();
+    expect(def.category).toBe('Creator');
+    // Not opt-in. `optIn` inverts what a settings row MEANS, and it may only be
+    // set by a processor that derives its recipients by joining that table —
+    // this one derives them from the placement and excludes with NOT EXISTS, so
+    // opting in here would ship the notification on while the UI drew it off.
+    expect(def.optIn).toBeUndefined();
+  });
+
+  it('names no amount, because there is none to name', () => {
+    const message = defs['sticker-placement-free-pending'].prepareMessage({
+      type: 'sticker-placement-free-pending',
+      details: { imageId: 74, placerUsername: 'somebody' },
+    } as Parameters<Def['prepareMessage']>[0])!;
+
+    expect(message.message).toBe('somebody wants to place a free sticker on your image');
+    // "0 Buzz" reads as a bug rather than as the offer.
+    expect(message.message).not.toMatch(/buzz|\b0\b/i);
+    // The image, not the queue: answering means seeing the sticker on the work
+    // it was placed on.
+    expect(message.url).toBe('/images/74');
+  });
+});
+
+describe('the two sticker notifications are scoped apart', () => {
+  it('sends the paid one for paid rows only', async () => {
+    expect(await query('sticker-placement-pending')).toMatch(/AND\s+p\.free\s*=\s*false/);
+  });
+
+  it('sends the free one for free rows only', async () => {
+    expect(await query('sticker-placement-free-pending')).toMatch(/AND\s+p\.free\s*=\s*true/);
+  });
+
+  /**
+   * Without both halves a free placement produces two notifications, one of
+   * which offers to review it "for 0 Buzz", and muting either kind mutes the
+   * wrong one. Asserted as a pair rather than twice, because it is the pair that
+   * has to partition.
+   */
+  it('gives each its own dedupe key', async () => {
+    expect(await query('sticker-placement-pending')).toContain("'sticker-placement-pending:'");
+    expect(await query('sticker-placement-free-pending')).toContain(
+      "'sticker-placement-free-pending:'"
+    );
+  });
+});
+
+/**
+ * Who hears about it, and where it sends them.
+ *
+ * Both are one identifier in a `jsonb_build_object`, and both swaps are green:
+ * `p."ownerId"` -> `p."placerId"` notifies the placer that they themselves want
+ * to place something, and `p."targetId"` -> `p.id` builds `/images/<placementId>`
+ * — a dead URL for the one person who has to act.
+ */
+describe('the free notification reaches the creator, about the right image', () => {
+  it.each(['sticker-placement-pending', 'sticker-placement-free-pending'])(
+    '%s notifies the owner, not the placer',
+    async (type) => {
+      const sql = await query(type);
+
+      expect(sql).toMatch(/p\."ownerId"\s+"userId"/);
+      // The placer is carried in the details for the message, so its presence is
+      // not the thing to assert — the recipient column is.
+      expect(sql).not.toMatch(/p\."placerId"\s+"userId"/);
+    }
+  );
+
+  it.each(['sticker-placement-pending', 'sticker-placement-free-pending'])(
+    '%s links to the image rather than to the placement',
+    async (type) => {
+      const sql = await query(type);
+
+      expect(sql).toMatch(/'imageId',\s*p\."targetId"/);
+      expect(sql).not.toMatch(/'imageId',\s*p\.id/);
+    }
+  );
+
+  it('sends the creator to the image, which is where the sticker is', () => {
+    const message = defs['sticker-placement-free-pending'].prepareMessage({
+      type: 'sticker-placement-free-pending',
+      details: { imageId: 74, placerId: 52, placerUsername: 'somebody' },
+    } as Parameters<Def['prepareMessage']>[0])!;
+
+    // Off `imageId`, so a details payload carrying the placement id cannot
+    // produce a URL that looks right and resolves to nothing.
+    expect(message.url).toBe('/images/74');
+  });
+});
+
+describe('each honours its own setting', () => {
+  /**
+   * 🔴 A settings row means opted OUT, and nothing applies that globally — every
+   * processor that honours its toggle writes the clause itself. Without it the
+   * setting renders, saves, and does nothing, which is a toggle that is a
+   * listing rather than a guard.
+   */
+  it.each(['sticker-placement-pending', 'sticker-placement-free-pending'])(
+    '%s excludes users who have opted out of that exact type',
+    async (type) => {
+      const sql = await query(type);
+
+      expect(sql).toMatch(/NOT EXISTS\s*\(\s*SELECT 1 FROM "UserNotificationSettings"/);
+      // The type in the clause has to be this one. A copy-paste carrying the
+      // other type's name would silence the wrong notification and leave this
+      // one unmutable, and every other assertion here would still pass.
+      expect(sql).toMatch(new RegExp(`type = '${type}'\\s*\\n?\\s*\\)`));
+    }
+  );
+});
+
+describe('neither notifies about a row that is no longer waiting', () => {
+  it.each(['sticker-placement-pending', 'sticker-placement-free-pending'])(
+    '%s requires pending status and a deadline',
+    async (type) => {
+      const sql = await query(type);
+
+      // Pending is what keeps an auto-accept space out of this entirely: the
+      // call site approves the row before the job next runs.
+      expect(sql).toContain("p.status = 'pending'");
+      expect(sql).toContain('p."expiresAt" IS NOT NULL');
+      expect(sql).toContain(LAST_SENT);
+    }
+  );
+});

--- a/src/server/notifications/__tests__/placement.free-pending.test.ts
+++ b/src/server/notifications/__tests__/placement.free-pending.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { placementNotifications } from '~/server/notifications/placement.notifications';
+
+/**
+ * The two remix-gallery pending types partition the pending rows between them.
+ *
+ * Asserted on the SQL rather than through a database, the same way the polarity
+ * guard is: what these tests protect is a `WHERE` clause, and the failure they
+ * exist to catch — one row producing both notifications, or neither — is a
+ * property of the predicate and not of any particular row.
+ */
+describe('remix gallery pending notifications', () => {
+  const queryFor = async (type: string) =>
+    (await placementNotifications[type].prepareQuery!({
+      lastSent: '2026-01-01',
+      lastSentDate: new Date('2026-01-01'),
+      clickhouse: undefined,
+    })) as string;
+
+  it('sends the paid type for paid rows only', async () => {
+    // Without this the paid message goes out for a free submission quoting
+    // "for 0 Buzz", and a creator who turned the free type off still gets one.
+    expect(await queryFor('remix-gallery-pending')).toContain('AND NOT p.free');
+  });
+
+  it('sends the free type for free rows only', async () => {
+    const query = await queryFor('remix-gallery-free-pending');
+    expect(query).toMatch(/AND p\.free\b/);
+    expect(query).not.toContain('AND NOT p.free');
+    // `AND p.free\b` alone survives widening to `AND p.free IS NOT NULL`, which
+    // is true of every row — the column is NOT NULL — so the free notification
+    // would fire for every pending submission, paid ones included, under a
+    // toggle their owner never opted into.
+    expect(query).not.toContain('IS NOT NULL');
+  });
+
+  it.each(['remix-gallery-pending', 'remix-gallery-free-pending'])(
+    '%s honours its own toggle',
+    async (type) => {
+      // A row in `UserNotificationSettings` means opted OUT, and there is no
+      // global filter — a processor without this clause renders a setting that
+      // saves and does nothing, which is what the paid type did until now.
+      //
+      // Asserted per type rather than once, because the two toggles are separate
+      // switches: silencing free submissions must not silence the paid queue a
+      // creator is being paid for.
+      //
+      // Pinned as ONE whole clause rather than by prefix. A prefix match stays
+      // green if the recipient column drifts to `p."placerId"` — silencing the
+      // submitter's setting instead of the owner's — or if the type string is
+      // copy-pasted from its sibling, which mutes the wrong toggle. Both are the
+      // realistic edits here, and neither changes the prefix.
+      expect(await queryFor(type)).toContain(
+        `NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = p."ownerId" AND type = '${type}')`
+      );
+      expect(placementNotifications[type].optIn).toBeFalsy();
+    }
+  );
+
+  it('quotes no amount on a free submission', async () => {
+    // A free row's `amount` is 0 and the DB enforces it, so any wording built
+    // around a number here would tell a creator they are being offered 0 Buzz.
+    const message = placementNotifications['remix-gallery-free-pending'].prepareMessage({
+      details: { placementId: 5, imageId: 74, placerId: 52, placerUsername: 'someone' },
+    });
+
+    expect(message!.message).toContain('someone');
+    expect(message!.message).not.toMatch(/buzz|\d/i);
+    expect(message!.url).toBe('/images/74');
+  });
+});

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -37,15 +37,25 @@ export const placementNotifications = createNotificationProcessor({
         JOIN "User" u ON u.id = p."placerId"
         WHERE p.surface = 'sticker'
           AND p."targetType" = 'image'
+          -- Paid rows only. A free one carries amount 0, so without this it
+          -- reads "wants to place a sticker on your image for 0 Buzz" and is
+          -- silenced by the toggle for the paid kind.
+          AND p.free = false
           -- Only rows that are still waiting. A placement approved, declined or
           -- expired between the last run and this one has already been answered,
           -- and telling someone to review it sends them to a dead link.
           AND p.status = 'pending'
-          -- Stamped by holdPlacementEscrow, so its presence means the escrow has
-          -- at least been attempted. The row is created before that runs, and a
-          -- notification landing in the gap would send someone to review a
-          -- placement that is about to be unwound, or one in an auto space that
-          -- approves itself seconds later.
+          -- Stamped by holdPlacementEscrow, so on the rows THIS query can see its
+          -- presence means the escrow has at least been attempted. The row is
+          -- created before that runs, and a notification landing in the gap would
+          -- send someone to review a placement about to be unwound, or one in an
+          -- auto space that approves itself seconds later.
+          --
+          -- ⚠️ The escrow half of that reasoning holds only because of the
+          -- p.free = false above. A free row gets its deadline from the same
+          -- INSERT that creates it and never touches escrow, so this gate alone
+          -- would pass one straight through — announced as a paid placement,
+          -- quoting 0 Buzz. The two clauses are load-bearing together.
           AND p."expiresAt" IS NOT NULL
           AND p."createdAt" > '${lastSent}'
       )
@@ -55,6 +65,71 @@ export const placementNotifications = createNotificationProcessor({
         'sticker-placement-pending' "type",
         details
       FROM data
+      -- A row means opted OUT. There is no global filter — every processor that
+      -- honours its own toggle writes this clause itself — so without it the
+      -- setting renders, saves, and does nothing. Kept on one line because the
+      -- notification-settings-polarity guard matches the clause as a literal.
+      WHERE NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = data."userId" AND type = 'sticker-placement-pending')
+    `,
+  },
+
+  /**
+   * Its own type, not a branch of the paid one, because it is a different
+   * decision to make and a different one to mute.
+   *
+   * A creator who has opened free capacity has said yes to the free tier in
+   * particular, and one who wants only the paid queue in their notifications
+   * needs to be able to say so without silencing the placements they are being
+   * paid for. One type with a branching message would make those two settings
+   * the same switch.
+   *
+   * The message carries no amount for the obvious reason and one less obvious
+   * one: "0 Buzz" reads as a bug rather than as the offer, and the thing worth
+   * saying instead is that a slot is being held while they decide.
+   *
+   * Only ever fires for a review-mode space. An auto space approves the row at
+   * the call site before the job next runs, and `status = 'pending'` is what
+   * keeps this from telling someone to review something already live.
+   */
+  'sticker-placement-free-pending': {
+    displayName: 'Free sticker awaiting your review',
+    category: NotificationCategory.Creator,
+    prepareMessage: ({ details }) => ({
+      message: `${details.placerUsername} wants to place a free sticker on your image`,
+      url: `/images/${details.imageId}`,
+    }),
+    prepareQuery: async ({ lastSent }) => `
+      WITH data AS (
+        SELECT
+          p."ownerId" "userId",
+          p.id "placementId",
+          jsonb_build_object(
+            'placementId', p.id,
+            'imageId', p."targetId",
+            'placerId', p."placerId",
+            'placerUsername', u.username
+          ) as "details"
+        FROM "Placement" p
+        JOIN "User" u ON u.id = p."placerId"
+        WHERE p.surface = 'sticker'
+          AND p."targetType" = 'image'
+          AND p.free = true
+          AND p.status = 'pending'
+          -- Written by the same INSERT that creates a free row rather than
+          -- stamped afterwards, so unlike the paid path there is no window where
+          -- this is null. Kept anyway: it is the one column that says the row is
+          -- reachable by the expiry sweep, and a free row that is not would hold
+          -- one of the creator's slots forever.
+          AND p."expiresAt" IS NOT NULL
+          AND p."createdAt" > '${lastSent}'
+      )
+      SELECT
+        CONCAT('sticker-placement-free-pending:',"placementId") "key",
+        "userId",
+        'sticker-placement-free-pending' "type",
+        details
+      FROM data
+      WHERE NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = data."userId" AND type = 'sticker-placement-free-pending')
     `,
   },
 

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -165,16 +165,82 @@ export const placementNotifications = createNotificationProcessor({
         WHERE p.surface = 'remixGallery'
           AND p."targetType" = 'image'
           AND p.status = 'pending'
+          -- Free submissions are their own type, with their own toggle. Excluded
+          -- here rather than left to fall through both: this message quotes an
+          -- amount, and a free row's amount is 0.
+          AND NOT p.free
           -- Stamped by holdPlacementEscrow. Its absence means the row exists but
           -- the escrow has not been attempted, and a notification landing in that
           -- gap sends someone to review a submission about to be unwound.
           AND p."expiresAt" IS NOT NULL
           AND p."createdAt" > '${lastSent}'
+          -- A row means opted OUT, and there is no global filter — every
+          -- processor that honours its own toggle writes this clause itself. It
+          -- was missing here, so the setting rendered, saved, and did nothing.
+          --
+          -- Inside the CTE and against p."ownerId", which is the recipient; the
+          -- projected "userId" outside the CTE is the same value and would work
+          -- there too. Kept on one line either way, because the polarity guard
+          -- matches the clause as a literal.
+          AND NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = p."ownerId" AND type = 'remix-gallery-pending')
       )
       SELECT
         CONCAT('remix-gallery-pending:',"placementId") "key",
         "userId",
         'remix-gallery-pending' "type",
+        details
+      FROM data
+    `,
+  },
+
+  /**
+   * The free tier's own type, so a creator can take one stream and not the other.
+   *
+   * Separate rather than a branch inside the paid message, because the two are
+   * different offers: the paid one quotes Buzz and the free one spends one of the
+   * creator's own slots and pays them nothing until they accept. A creator who
+   * wants only paid submissions announced has no way to say so if both arrive
+   * under one type.
+   *
+   * `expiresAt` is not checked here. It gates the paid types because
+   * `holdPlacementEscrow` stamps it in a second statement, so its absence means
+   * the escrow has not been attempted yet; a free row is written with its
+   * deadline by the same INSERT, so there is no such gap to wait out.
+   */
+  'remix-gallery-free-pending': {
+    displayName: 'Free remix awaiting your review',
+    category: NotificationCategory.Creator,
+    prepareMessage: ({ details }) => ({
+      message: `${details.placerUsername} submitted a free remix to your gallery`,
+      url: `/images/${details.imageId}`,
+    }),
+    prepareQuery: async ({ lastSent }) => `
+      WITH data AS (
+        SELECT
+          p."ownerId" "userId",
+          p.id "placementId",
+          jsonb_build_object(
+            'placementId', p.id,
+            'imageId', p."targetId",
+            'placerId', p."placerId",
+            'placerUsername', u.username
+          ) as "details"
+        FROM "Placement" p
+        JOIN "User" u ON u.id = p."placerId"
+        WHERE p.surface = 'remixGallery'
+          AND p."targetType" = 'image'
+          AND p.status = 'pending'
+          AND p.free
+          AND p."createdAt" > '${lastSent}'
+          -- A row here means opted OUT, and its own type rather than the paid
+          -- one's: silencing free submissions must not silence the queue a
+          -- creator is being paid for.
+          AND NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = p."ownerId" AND type = 'remix-gallery-free-pending')
+      )
+      SELECT
+        CONCAT('remix-gallery-free-pending:',"placementId") "key",
+        "userId",
+        'remix-gallery-free-pending' "type",
         details
       FROM data
     `,

--- a/src/server/rewards/__tests__/base.reward.mock-surface.test.ts
+++ b/src/server/rewards/__tests__/base.reward.mock-surface.test.ts
@@ -1,0 +1,202 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Every `vi.mock` factory that stands in for a module `base.reward` imports must
+ * provide the bindings it actually imports.
+ *
+ * Two of those modules cannot be mocked by spreading `importOriginal` — the
+ * reward suites replace `~/server/clickhouse/client` and
+ * `~/server/services/buzz.service` precisely to avoid constructing the real
+ * clients, and spreading loads them for real (measured at 1.8s → 15.6s of import
+ * on one file). `~/server/prom/client` is replaced globally in `setup.ts` for
+ * the same reason. So the export surface is hand-written in three places, and a
+ * hand-written surface pins itself to the day it was typed.
+ *
+ * The failure when it falls behind is the invisible one: the missing binding
+ * resolves to `undefined`, the test file fails to LOAD, and a file that fails to
+ * load reports **0 tests** rather than a red one.
+ *
+ * Two properties make this an actual guard rather than a restatement:
+ *
+ *  - It reads the **mock factories themselves**, not a list kept alongside them.
+ *    An earlier version asserted `base.reward`'s imports against a literal in
+ *    this file, which left the mocks — the thing that has to be right —
+ *    unchecked, and made "add the name to the literal" the fastest way to get
+ *    green while the suites still collected nothing.
+ *  - It derives the modules from `base.reward`'s own imports, so a module it
+ *    starts importing is covered without anyone adding it here. The prom
+ *    regression that produced this file was in a module the earlier version did
+ *    not name.
+ *
+ * It lives in its own file, importing only `fs`, on purpose: a check inside a
+ * suite that fails to load cannot run either.
+ */
+
+const REWARDS_TESTS = path.resolve(__dirname);
+const BASE_REWARD = path.resolve(__dirname, '../base.reward.ts');
+const GLOBAL_SETUP = path.resolve(__dirname, '../../../__tests__/setup.ts');
+
+/** Files whose `vi.mock` factories can stand in for a module base.reward loads. */
+const mockSources = () => [
+  GLOBAL_SETUP,
+  ...fs
+    .readdirSync(REWARDS_TESTS)
+    .filter((name) => name.endsWith('.test.ts'))
+    .map((name) => path.join(REWARDS_TESTS, name))
+    .filter((file) => file !== __filename),
+];
+
+const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Comments out, quotes intact.
+ *
+ * Not optional tidying: `setup.ts`'s prom factory carries a comment containing a
+ * literal `'...'`, which the brace scanner below read as a spread and reported
+ * the whole module as fully mocked. That is how the first version of this guard
+ * passed while the very stub it should have demanded was missing.
+ */
+function stripComments(source: string) {
+  let out = '';
+  let quote = '';
+  for (let i = 0; i < source.length; i++) {
+    const char = source[i];
+    if (quote) {
+      out += char;
+      if (char === '\\') out += source[++i] ?? '';
+      else if (char === quote) quote = '';
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+      out += char;
+      continue;
+    }
+    if (char === '/' && source[i + 1] === '/') {
+      while (i < source.length && source[i] !== '\n') i++;
+      out += '\n';
+      continue;
+    }
+    if (char === '/' && source[i + 1] === '*') {
+      i = source.indexOf('*/', i + 2) + 1;
+      if (i === 0) throw new Error('mock-surface guard: unterminated block comment');
+      continue;
+    }
+    out += char;
+  }
+
+  return out;
+}
+
+/** The named value bindings `source` imports from `module`. */
+function valueImportsFrom(source: string, module: string) {
+  const pattern = new RegExp(
+    `import\\s+(?!type\\s)\\{([^}]*)\\}\\s+from\\s+'${escape(module)}'`,
+    'g'
+  );
+  const names = new Set<string>();
+  for (const match of source.matchAll(pattern))
+    for (const specifier of match[1].split(','))
+      if (specifier.trim()) names.add(specifier.trim().split(/\s+as\s+/)[0]);
+
+  return [...names];
+}
+
+/** Every module `base.reward` takes a value binding from, with those bindings. */
+function importedModules(source: string) {
+  const modules = new Map<string, string[]>();
+  for (const [, module] of source.matchAll(/from\s+'([^']+)'/g))
+    if (!modules.has(module)) {
+      const imports = valueImportsFrom(source, module);
+      if (imports.length) modules.set(module, imports);
+    }
+
+  return modules;
+}
+
+/** The text between `open` and its matching close, exclusive. */
+function balanced(source: string, open: number, closing: string) {
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '(' || source[i] === '{') depth++;
+    else if (source[i] === ')' || source[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        if (source[i] !== closing) break;
+        return source.slice(open + 1, i);
+      }
+    }
+  }
+
+  throw new Error(`mock-surface guard: unbalanced ${closing} — the parser needs fixing, not you`);
+}
+
+/**
+ * What a file's `vi.mock` of `module` provides: the factory's top-level keys, or
+ * `'all'` when it spreads (`importOriginal`), or `null` when it does not mock it.
+ *
+ * Throws rather than returning nothing when a mock is present but unreadable —
+ * a parser that quietly gives up would report every suite as covered.
+ */
+function mockedExports(source: string, module: string): string[] | 'all' | null {
+  const call = source.indexOf(`vi.mock('${module}'`);
+  if (call === -1) return null;
+
+  const args = balanced(source, source.indexOf('(', call), ')');
+  const factory = args.indexOf('=>');
+  // `vi.mock(path)` with no factory automocks and keeps the real shape.
+  if (factory === -1) return 'all';
+
+  const literal = args.indexOf('{', factory);
+  if (literal === -1)
+    throw new Error(`mock-surface guard: could not read the factory for ${module}`);
+
+  const body = balanced(args, literal, '}');
+  const keys: string[] = [];
+  let depth = 0;
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] === '(' || body[i] === '{' || body[i] === '[') depth++;
+    else if (body[i] === ')' || body[i] === '}' || body[i] === ']') depth--;
+    else if (depth === 0) {
+      if (body.startsWith('...', i)) return 'all';
+      const key = /^([A-Za-z_$][\w$]*)\s*:/.exec(body.slice(i));
+      if (key && (i === 0 || /[\s,]/.test(body[i - 1]))) keys.push(key[1]);
+    }
+  }
+
+  return keys;
+}
+
+// Stripped for the same reason the mock sources are: a commented-out import
+// would otherwise be demanded of every mock.
+const baseReward = stripComments(fs.readFileSync(BASE_REWARD, 'utf-8'));
+
+const cases = mockSources().flatMap((file) => {
+  const source = stripComments(fs.readFileSync(file, 'utf-8'));
+  return [...importedModules(baseReward)]
+    .map(([module, imports]) => ({ file, module, imports, mocked: mockedExports(source, module) }))
+    .filter((entry) => entry.mocked !== null)
+    .map((entry) => [`${path.basename(entry.file)} mocks ${entry.module}`, entry] as const);
+});
+
+describe('the mocks the reward suites stand in for base.reward with', () => {
+  // A file that mocks nothing base.reward imports contributes no case, so an
+  // empty set would mean the discovery above broke rather than that all is well.
+  it('finds the mocks to check', () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)('%s and provides everything it imports', (_, { module, imports, mocked }) => {
+    if (mocked === 'all') return;
+
+    // A mock missing one of these does not fail here at runtime — it makes the
+    // suite that uses it collect 0 tests, silently. Add the binding to that
+    // factory (or spread `importOriginal`, if the module is cheap to load).
+    expect({ module, missing: imports.filter((name) => !mocked.includes(name)) }).toEqual({
+      module,
+      missing: [],
+    });
+  });
+});

--- a/src/server/rewards/__tests__/remixAccept.reward.test.ts
+++ b/src/server/rewards/__tests__/remixAccept.reward.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// What is under test is the reward's own definition — who is paid, in what
+// currency, keyed on what, and against which cap. `base.reward` pulls a live
+// client out of the two modules below, so both are hand-written rather than
+// spread from `importOriginal`: the spread loads the real graph, which is the
+// client construction the mock exists to avoid (1.8s → 15.6s of import here).
+//
+// What makes a hand-written factory safe is `base.reward.mock-surface.test.ts`,
+// which reads `base.reward`'s imports as source and fails if either module's
+// surface grows past what these factories provide. Without that guard this
+// shape breaks the whole FILE — 0 collected, nothing red — the first time it
+// drifts. Change either factory only together with that file's
+// `MOCKED_MODULE_SURFACE`.
+//
+// `~/server/prom/client` needs nothing here: `src/__tests__/setup.ts` already
+// stubs it, and hand-listing three of its ~40 exports narrowed that stub.
+const h = vi.hoisted(() => ({
+  insert: vi.fn(async () => undefined),
+  createBuzzTransactionMany: vi.fn(async () => undefined),
+  getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
+}));
+const { createBuzzTransactionMany, getMultipliersForUser } = h;
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: { insert: (...args: unknown[]) => h.insert(...args) },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: h.createBuzzTransactionMany,
+  getMultipliersForUser: h.getMultipliersForUser,
+}));
+
+import { remixAcceptReward } from '~/server/rewards/active/remixAccept.reward';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+/** Distinct, so a value reaching the wrong field cannot pass by colliding. */
+const OWNER = 41;
+const PLACER = 52;
+const PLACEMENT = 96;
+
+const AWARD = 20;
+const DAILY_CAP = 100;
+
+const accept = (over: Partial<Parameters<typeof remixAcceptReward.apply>[0]> = {}) =>
+  remixAcceptReward.apply({
+    placementId: PLACEMENT,
+    ownerId: OWNER,
+    placerId: PLACER,
+    ...over,
+  });
+
+/** The Lua call's ARGV, which is where the award and the cap are actually decided. */
+const lastEvalArgs = () => {
+  const [, options] = redisMock.redis.eval.mock.calls.at(-1) as [unknown, { arguments: string[] }];
+  return options.arguments;
+};
+
+const lastTransaction = () => createBuzzTransactionMany.mock.calls.at(-1)?.[0]?.[0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 1 });
+  // What the Lua script returns when the accept is inside the day's cap.
+  redisMock.redis.eval.mockResolvedValue(AWARD);
+});
+
+describe('remixAcceptReward', () => {
+  it('pays the owner in blue buzz, with the submitter recorded as the cause', async () => {
+    await accept();
+
+    expect(lastTransaction()).toMatchObject({
+      toAccountId: OWNER,
+      toAccountType: 'blue',
+      amount: AWARD,
+      details: { forId: PLACEMENT, byUserId: PLACER },
+    });
+  });
+
+  // The ledger key is the double-pay backstop under the caller's once-ever gate,
+  // and it is built from (forId, toUserId, byUserId). Keyed on anything the owner
+  // can produce twice — the host image, the submitted image — a second accept on
+  // the same host would be refused as a duplicate and pay nothing.
+  it('keys the ledger on the placement, not on either image', async () => {
+    await accept();
+
+    expect(lastTransaction()?.externalTransactionId).toBe(
+      `remixAccept:${PLACEMENT}-${OWNER}-${PLACER}`
+    );
+  });
+
+  // 20 × 5 = 100. At a cap equal to the award the first accept of the day would
+  // exhaust it and every later one would pay nothing, which is a different reward
+  // from the one that was designed.
+  it('asks redis for a cap of five accepts a day, not one', async () => {
+    await accept();
+
+    const [, , award, cap] = lastEvalArgs();
+    expect(award).toBe(String(AWARD));
+    expect(cap).toBe(String(DAILY_CAP));
+  });
+
+  // Rewards multiply with membership tier here as everywhere else, and the cap has
+  // to move with the award: multiplying one alone silently changes how many
+  // accepts a member is paid for.
+  it('scales the award and the cap together by the membership multiplier', async () => {
+    getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 4 });
+    await accept();
+
+    const [, , award, cap] = lastEvalArgs();
+    expect(award).toBe(String(AWARD * 4));
+    expect(cap).toBe(String(DAILY_CAP * 4));
+  });
+
+  // The multiplier is the OWNER's — they are the one being paid. Reading the
+  // submitter's would let a gold-tier submitter mint four times the reward into a
+  // free account, and would pay two owners differently for the same accept.
+  it('reads the multiplier for the owner being paid', async () => {
+    await accept();
+
+    expect(getMultipliersForUser).toHaveBeenCalledWith(OWNER);
+  });
+
+  // Redis returns 0 once the day's cap is spent. The event is still recorded, so
+  // the dashboard can show the cap was reached, but no buzz moves.
+  it('records a capped accept without paying for it', async () => {
+    redisMock.redis.eval.mockResolvedValue(0);
+    await accept();
+
+    expect(h.insert).toHaveBeenCalled();
+    expect(createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  // The Blue Buzz minting path. Refused here rather than left to the submission
+  // path's `space.ownerId === placerId` refusal two layers up: that one is a
+  // product rule about who may submit, and this one is about who may be paid.
+  it('pays nothing for an owner accepting their own submission', async () => {
+    await accept({ placerId: OWNER });
+
+    expect(redisMock.redis.eval).not.toHaveBeenCalled();
+    expect(h.insert).not.toHaveBeenCalled();
+    expect(createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  // -1 is the Lua dedup hit: this placement already paid today. Nothing is
+  // recorded and nothing is paid.
+  it('does nothing for a placement already rewarded today', async () => {
+    redisMock.redis.eval.mockResolvedValue(-1);
+    await accept();
+
+    expect(h.insert).not.toHaveBeenCalled();
+    expect(createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/rewards/__tests__/stickerPlacementAccepted.reward.test.ts
+++ b/src/server/rewards/__tests__/stickerPlacementAccepted.reward.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// base.reward builds a ClickHouse client, redis handles and prom collectors at
+// import time. Mocked to the surface it touches so this suite can collect.
+const h = vi.hoisted(() => ({
+  insert: vi.fn(async () => undefined),
+  createBuzzTransactionMany: vi.fn(async () => ({ transactions: [] })),
+  getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
+  eval: vi.fn(async () => 0 as number),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: { insert: (...args: unknown[]) => h.insert(...(args as [])) },
+}));
+// Prom is NOT mocked here: setup.ts stubs it globally, including the
+// `clickhouseFailSoftCounter` this branch needs — which it was missing until
+// this PR added it, so a local three-item factory here would have been the
+// wider surface, not the narrower one. Neither ClickHouse nor buzz.service is
+// stubbed globally, and spreading either would build a real client at import,
+// so those two stay hand-written and base.reward.mock-surface.test.ts checks
+// them against what base.reward actually imports.
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: (...args: unknown[]) => h.createBuzzTransactionMany(...(args as [])),
+  getMultipliersForUser: (...args: unknown[]) => h.getMultipliersForUser(...(args as [])),
+}));
+
+import { stickerPlacementAcceptedReward } from '~/server/rewards/active/stickerPlacementAccepted.reward';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+redisMock.redis.eval.mockImplementation((...args: unknown[]) => h.eval(...(args as [])));
+
+const OWNER = 10;
+const PLACER = 20;
+const PLACEMENT = 777;
+
+/** The award and cap the Lua script was handed, both already multiplied. */
+const luaBudget = () => {
+  const [, options] = h.eval.mock.calls.at(-1) as unknown as [string, { arguments: string[] }];
+  const [, , award, cap] = options.arguments;
+  return { award: Number(award), cap: Number(cap) };
+};
+
+const grant = () =>
+  (h.createBuzzTransactionMany.mock.calls.at(-1) as unknown as [Record<string, unknown>[]])[0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 1 });
+  // The award landed rather than hitting the cap, unless a test says otherwise.
+  h.eval.mockResolvedValue(10);
+});
+
+const accept = (overrides: Partial<Record<'placementId' | 'ownerId' | 'placerId', number>> = {}) =>
+  stickerPlacementAcceptedReward.apply({
+    placementId: PLACEMENT,
+    ownerId: OWNER,
+    placerId: PLACER,
+    ...overrides,
+  });
+
+describe('the sticker accept reward', () => {
+  it('pays the owner ten Blue Buzz, from the placer', async () => {
+    await accept();
+
+    expect(grant()).toEqual([
+      expect.objectContaining({
+        toAccountId: OWNER,
+        toAccountType: 'blue',
+        amount: 10,
+        details: expect.objectContaining({ byUserId: PLACER, forId: PLACEMENT }),
+      }),
+    ]);
+  });
+
+  // The ledger's own idempotency key. It is what makes a re-presented placement
+  // silently pay nothing rather than pay twice — and therefore what the caller's
+  // once-per-settle guard exists to keep out of reach.
+  it('keys the transaction on the placement', async () => {
+    await accept();
+
+    expect(grant()[0]).toMatchObject({
+      externalTransactionId: `stickerPlacementAccepted:${PLACEMENT}-${OWNER}-${PLACER}`,
+    });
+  });
+
+  // An auto-accept space performs no accept: the placement settles inline in the
+  // placer's request. Copy about accepting is false there, and the intent doc
+  // expects auto to become the majority path. Justin's framing is "10 Buzz for
+  // each image sticker you get each day".
+  it('describes the reward as getting a sticker, never as accepting one', async () => {
+    const details = await stickerPlacementAcceptedReward.getUserRewardDetails(OWNER);
+
+    expect(details.description).toBe('You got a sticker on your content');
+    expect(details.triggerDescription).toBe(
+      'For each sticker you get on your content, up to 10 a day'
+    );
+  });
+
+  it('caps the day at ten accepted stickers', async () => {
+    await accept();
+
+    expect(luaBudget()).toEqual({ award: 10, cap: 100 });
+  });
+
+  // Every other reward multiplies both halves with the membership tier, so a
+  // gold member's ten a day is forty. Deliberate, and confirmed with Justin.
+  it('multiplies the award and the cap together with membership', async () => {
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 4 });
+
+    await accept();
+
+    expect(luaBudget()).toEqual({ award: 40, cap: 400 });
+  });
+
+  it('moves no Buzz once the day is spent', async () => {
+    h.eval.mockResolvedValue(0);
+
+    await accept();
+
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  // A capped accept is still a thing that happened, and the buzzEvents row is
+  // what the cap is later read back from. Dropping it would make the day look
+  // less spent than it was.
+  it('records a capped accept without paying for it', async () => {
+    h.eval.mockResolvedValue(0);
+
+    await accept();
+
+    expect(h.insert).toHaveBeenCalled();
+  });
+
+  // -1 is the Lua dedup hit: this placement already paid today. Nothing further
+  // is written — no audit row, no grant — so a retry is inert rather than noisy.
+  it('writes nothing at all when the placement already paid today', async () => {
+    h.eval.mockResolvedValue(-1);
+
+    await accept();
+
+    expect(h.insert).not.toHaveBeenCalled();
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  // Accepting your own sticker is minting Blue Buzz out of nothing. Both
+  // placement paths already refuse self-placement, and this is what stops the
+  // reward relying on that.
+  it('pays nothing when the owner is the placer', async () => {
+    await accept({ placerId: OWNER });
+
+    expect(h.eval).not.toHaveBeenCalled();
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/rewards/active/remixAccept.reward.ts
+++ b/src/server/rewards/active/remixAccept.reward.ts
@@ -1,0 +1,75 @@
+import { createBuzzEvent } from '../base.reward';
+
+const ACCEPT_AWARD = 20;
+
+// Daily ceiling across every gallery the owner runs, not a per-submission cap.
+// The on-demand Lua cap counts all entries in the per-(user, type) daily hash, so
+// this is a total: 20 Buzz for each of the first 5 accepts per UTC day.
+//   ⚠️ At `cap === ACCEPT_AWARD` the first accept of the day would exhaust it and
+//   every later one would award 0, which is not the reward that was designed.
+//   ⚠️ This is 100/day for REMIX accepts, not for accepting placements. The
+//   sticker accept reward carries its own separate 100/day against its own type
+//   key, so a creator running both surfaces can earn 200 in a day — and both
+//   numbers multiply by membership tier and again by any global bonus event.
+//   The two caps matching today is a coincidence, not a shared limit.
+const DAILY_ACCEPT_CEILING = ACCEPT_AWARD * 5;
+
+/**
+ * Blue-buzz reward paid to a creator for accepting a remix submission.
+ *
+ * Paid for **every** accepted submission, free or paid: this rewards running the
+ * surface at all, and is not compensation for a placement having been free.
+ *
+ * ONCE EVER PER PLACEMENT, and the guarantee is not this cap. `settlePlacement`
+ * claims its transition with `WHERE status = 'pending'`, so exactly one call in a
+ * placement's life returns `settled: true`, and the caller fires this only on
+ * that one. Nothing moves an approved row back to pending, so there is no second
+ * winning approve to fire on.
+ *
+ * That gate is load-bearing rather than belt-and-braces, because the two dedups
+ * underneath it expire on different clocks. The Buzz ledger keys this on the
+ * placement — `remixAccept:<placementId>-<ownerId>-<placerId>` — and that key
+ * never expires, while the on-demand dedup and the cap live in a Redis hash that
+ * expires at the end of the UTC day. So re-presenting an already-rewarded
+ * placement on a later day passes the dedup, **spends a slot of the owner's
+ * daily cap**, and is then refused by the ledger as a duplicate: the owner loses
+ * one of their five accepts for the day and no Buzz moves, silently. Any future
+ * caller that can hand this a placement it already paid for has to establish the
+ * same once-ever property before calling.
+ *
+ * The cap multiplies with membership tier, as every reward here does — a gold
+ * member's 100/day is 400/day. Known and accepted.
+ */
+export const remixAcceptReward = createBuzzEvent({
+  type: 'remixAccept',
+  toAccountType: 'blue',
+  description: 'You accepted a remix into your gallery',
+  triggerDescription: 'For each of the first 5 remix submissions you accept each day',
+  awardAmount: ACCEPT_AWARD,
+  cap: DAILY_ACCEPT_CEILING,
+  onDemand: true,
+  getKey: async (input: RemixAcceptEvent) => {
+    // Blue Buzz is minted here, so an owner accepting their own submission must
+    // pay nothing. Unreachable today — `createRemixGallerySubmission` refuses
+    // `space.ownerId === placerId` — but that is two layers away and a product
+    // rule, and this is the layer that makes the money. Kept rather than left to
+    // distance, and symmetrical with the sticker accept reward.
+    if (input.ownerId === input.placerId) return false;
+
+    return {
+      // The owner earns it; the submitter is recorded as the cause, not paid.
+      toUserId: input.ownerId,
+      // The Redis dedup anchor as well as the ledger's: distinct placements hash
+      // to distinct cache keys and each pays, while the same placement
+      // re-presented within the day is deduped.
+      forId: input.placementId,
+      byUserId: input.placerId,
+    };
+  },
+});
+
+type RemixAcceptEvent = {
+  placementId: number;
+  ownerId: number;
+  placerId: number;
+};

--- a/src/server/rewards/active/stickerPlacementAccepted.reward.ts
+++ b/src/server/rewards/active/stickerPlacementAccepted.reward.ts
@@ -1,0 +1,63 @@
+import { createBuzzEvent } from '../base.reward';
+
+const ACCEPT_AWARD = 10;
+
+/**
+ * Ten a day, whatever the membership multiplier does to it. A daily cap can only
+ * be satisfied by showing up daily, which is the behaviour being paid for; a
+ * monthly one is filled in an afternoon and the account is then abandoned.
+ */
+const DAILY_ACCEPT_CEILING = ACCEPT_AWARD * 10;
+
+/**
+ * Blue Buzz to the owner of the space for a sticker going live on it.
+ *
+ * Paid on every one, free or paid. It is not compensation for a placement having
+ * been free — it pays for running the surface at all, which is why the paid path
+ * earns it too.
+ *
+ * **The user-facing strings say "get", not "accept", and that is load-bearing.**
+ * On an auto-accept space nobody performs an accept: `createStickerPlacement`
+ * settles inline inside the *placer's* request and records the owner as the
+ * actor, which is what makes it read as an approval everywhere downstream. Copy
+ * about accepting would be false on what is expected to be the majority path,
+ * in the one sentence a creator reads to work out where their Buzz came from.
+ *
+ * **Once per placement, ever, and the caller owns that.** The Buzz ledger keys
+ * this on `stickerPlacementAccepted:<placementId>-<ownerId>-<placerId>` and that
+ * key never expires, while the daily cap lives in a Redis hash that drops at the
+ * end of each UTC day. So a placement re-presented on a later day passes the cap,
+ * spends a tenth of the owner's day, and is then refused by the ledger as a
+ * duplicate: no Buzz moves and nothing says so. `settlePlacement` is the only
+ * caller and applies this only on the settle whose `WHERE status = 'pending'`
+ * matched, so a second approve of the same placement never reaches here.
+ */
+export const stickerPlacementAcceptedReward = createBuzzEvent({
+  type: 'stickerPlacementAccepted',
+  toAccountType: 'blue',
+  description: 'You got a sticker on your content',
+  triggerDescription: 'For each sticker you get on your content, up to 10 a day',
+  awardAmount: ACCEPT_AWARD,
+  cap: DAILY_ACCEPT_CEILING,
+  onDemand: true,
+  getKey: async (input: StickerPlacementAcceptedEvent) => {
+    // Both placement paths already refuse self-placement, so this is unreachable
+    // today. It is here because the thing it prevents is minting Blue Buzz out of
+    // nothing — accept your own sticker, collect — and the refusals that stop it
+    // are two layers away and are about a product rule, not about this reward.
+    if (input.ownerId === input.placerId) return false;
+
+    return {
+      toUserId: input.ownerId,
+      forId: input.placementId,
+      byUserId: input.placerId,
+      type: `stickerPlacementAccepted`,
+    };
+  },
+});
+
+type StickerPlacementAcceptedEvent = {
+  placementId: number;
+  ownerId: number;
+  placerId: number;
+};

--- a/src/server/rewards/index.ts
+++ b/src/server/rewards/index.ts
@@ -12,4 +12,5 @@ export { reportAcceptedReward } from './passive/reportAccepted.reward';
 export { firstDailyFollowReward } from './active/firstDailyFollow.reward';
 export { dailyBoostReward } from './active/dailyBoost.reward';
 export { generatorFeedbackReward } from './active/generatorFeedback.reward';
+export { stickerPlacementAcceptedReward } from './active/stickerPlacementAccepted.reward';
 // export { adWatchedReward } from './active/adWatched.reward';

--- a/src/server/rewards/index.ts
+++ b/src/server/rewards/index.ts
@@ -13,4 +13,5 @@ export { firstDailyFollowReward } from './active/firstDailyFollow.reward';
 export { dailyBoostReward } from './active/dailyBoost.reward';
 export { generatorFeedbackReward } from './active/generatorFeedback.reward';
 export { stickerPlacementAcceptedReward } from './active/stickerPlacementAccepted.reward';
+export { remixAcceptReward } from './active/remixAccept.reward';
 // export { adWatchedReward } from './active/adWatched.reward';

--- a/src/server/routers/__tests__/placement.router.spend-type.test.ts
+++ b/src/server/routers/__tests__/placement.router.spend-type.test.ts
@@ -109,4 +109,48 @@ describe('placement router — the charged currency is the domain’s', () => {
       expect.objectContaining({ spendType: 'green' })
     );
   });
+
+  /**
+   * The same shape as the currency above, and higher stakes.
+   *
+   * `createFreePlacement` takes `placerId` as a plain number and cannot tell
+   * where it came from, and every check below it — the daily allowance, the
+   * never-twice rule, self-placement — is *about* that id rather than a check
+   * *of* it. So a router reading it off the payload would let anyone spend
+   * someone else's free placement and submit under their account, with nothing
+   * downstream raising.
+   *
+   * Two independent things keep that true — the schema has no `placerId`, so zod
+   * strips it, and `...input` spreads before the session id — and this asserts
+   * the outcome rather than either mechanism. Measured: breaking one alone does
+   * not fail it, because the other still holds; adding `placerId` to the schema
+   * AND flipping the spread order does.
+   */
+  it('takes placerId from the session even when the client sends its own', async () => {
+    await callerOn(false).submitToRemixGallery({
+      hostImageId: 11,
+      imageId: 12,
+      free: true,
+      placerId: PLACER + 1,
+    } as never);
+
+    expect(createRemixGallerySubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ placerId: PLACER, free: true })
+    );
+  });
+
+  it('defaults a submission to paid when the client says nothing', async () => {
+    // The free path is asked for, never assumed: a client cached from before the
+    // free tier existed must keep paying rather than start spending an allowance
+    // it does not know it has.
+    await callerOn(false).submitToRemixGallery({
+      hostImageId: 11,
+      imageId: 12,
+      expectedPrice: 100,
+    } as never);
+
+    expect(createRemixGallerySubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ free: false })
+    );
+  });
 });

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -241,7 +241,6 @@ export const placementRouter = router({
         // it. Read off the payload it would spend someone else's daily
         // allowance and place under their name with nothing raising.
         placerId: ctx.user.id,
-        isModerator: ctx.user.isModerator,
         // From the request's own domain, never the input: `...input` spreads
         // first, so a client-sent `spendType` cannot survive this line.
         spendType: domainSpendType(ctx.features),

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -11,6 +11,7 @@ import {
   getPendingRemixGallerySubmissionsSchema,
   getPendingStickerPlacementsSchema,
   getRemixGallerySchema,
+  getRemixGalleryFreeEligibilitySchema,
   getRemixGalleryVisibilitySchema,
   getStickerPlacementDetailSchema,
   getStickerPlacementsSchema,
@@ -61,6 +62,7 @@ import {
   getMyRemixGallerySubmissions,
   getPendingRemixGallerySubmissions,
   getRemixGallery,
+  getRemixGalleryFreeEligibility,
   getRemixGalleryVisibility,
   retractRemixGallerySubmission,
   setRemixGalleryPins,
@@ -402,10 +404,25 @@ export const placementRouter = router({
       assertRemixGalleryEnabled(ctx);
       return createRemixGallerySubmission({
         ...input,
+        // From the session, never the input. `createFreePlacement` takes this as
+        // a plain number and cannot tell where it came from, and every check
+        // downstream is *about* this id rather than a check *of* it — so a
+        // client-supplied one would spend someone else's daily allowance and
+        // submit under their account with nothing raising. `...input` spreads
+        // first, so no client value can survive this line.
         placerId: ctx.user.id,
         spendType: domainSpendType(ctx.features),
       });
     }),
+
+  /**
+   * The free option's inputs, for the submit card. A listing: everything it
+   * returns is stale by the time it renders, and the refusals live on the
+   * mutation.
+   */
+  getRemixGalleryFreeEligibility: protectedProcedure
+    .input(getRemixGalleryFreeEligibilitySchema)
+    .query(({ input, ctx }) => getRemixGalleryFreeEligibility({ ...input, placerId: ctx.user.id })),
 
   /**
    * Not flag-gated, for the same reason `actOnStickers` isn't: turning the flag

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -24,6 +24,10 @@ import {
   submitToRemixGallerySchema,
   suspendPlacerSchema,
 } from '~/server/schema/placement.schema';
+import {
+  getFreePlacementAllowance,
+  hasUsedFreePlacementOn,
+} from '~/server/services/free-placement.service';
 import { placementPriceRange } from '~/server/services/placement.service';
 import {
   clearPlacementSpace,
@@ -167,6 +171,34 @@ export const placementRouter = router({
     return setPlacementSpace({ ...input, userId: ctx.user.id });
   }),
 
+  /**
+   * Where the viewer stands against the free tier on one target: their daily
+   * allowance, and whether they have already spent a free placement here.
+   *
+   * **A listing.** Both halves read a replica and are stale the moment they
+   * return; the refusals live in `createFreePlacement`, under a lock, in the
+   * transaction that inserts. This exists so the choice can be offered with the
+   * numbers visible — an allowance spent silently is the worst version of a
+   * scarce thing — and for no other purpose.
+   *
+   * Takes the target rather than being sticker-specific, because the allowance
+   * is one placement a day across the whole site and both surfaces need to say
+   * so. Surface-agnostic by reusing what PR 1 already exposes, not by anything
+   * new sitting between the two.
+   *
+   * `placerId` is the session's. Off the input it would read anyone's allowance.
+   */
+  getFreeStanding: protectedProcedure
+    .input(getPlacementSpaceSchema)
+    .query(async ({ input, ctx }) => {
+      const [allowance, usedHere] = await Promise.all([
+        getFreePlacementAllowance({ placerId: ctx.user.id }),
+        hasUsedFreePlacementOn({ ...input, placerId: ctx.user.id }),
+      ]);
+
+      return { ...allowance, usedHere };
+    }),
+
   getStickerPlacements: publicProcedure
     .input(getStickerPlacementsSchema)
     .query(({ input, ctx }) =>
@@ -201,6 +233,11 @@ export const placementRouter = router({
       assertPlacementEnabled(ctx);
       return createStickerPlacement({
         ...input,
+        // After the spread, and the schema has no `placerId` to strip anyway —
+        // both, because this is the id the whole free tier is scoped by and
+        // every check downstream is a statement about it rather than a check of
+        // it. Read off the payload it would spend someone else's daily
+        // allowance and place under their name with nothing raising.
         placerId: ctx.user.id,
         isModerator: ctx.user.isModerator,
         // From the request's own domain, never the input: `...input` spreads

--- a/src/server/schema/__tests__/create-sticker-placement.schema.test.ts
+++ b/src/server/schema/__tests__/create-sticker-placement.schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { createStickerPlacementSchema } from '~/server/schema/placement.schema';
+
+const data = { cosmeticId: 85, x: 0.25, y: 0.75, scale: 0.2, rotation: 15 };
+
+describe('the free flag selects a path and asserts nothing', () => {
+  it('defaults to paid, so a client cached from before the free tier still places', () => {
+    expect(createStickerPlacementSchema.parse({ imageId: 74, data })).toMatchObject({
+      free: false,
+    });
+  });
+
+  it('accepts an explicit choice either way', () => {
+    expect(createStickerPlacementSchema.parse({ imageId: 74, data, free: true }).free).toBe(true);
+    expect(createStickerPlacementSchema.parse({ imageId: 74, data, free: false }).free).toBe(false);
+  });
+});
+
+/**
+ * 🔴 The one field this input must never carry.
+ *
+ * `createFreePlacement` takes `placerId` as a plain number and cannot tell where
+ * it came from, and every free-tier rule — the daily allowance,
+ * never-twice-here, the block and suspension checks — is a statement *about*
+ * that id rather than a check *of* it. So nothing downstream notices a wrong
+ * one: it would spend somebody else's allowance, place under their name, and
+ * have the never-twice rule protect the wrong account.
+ *
+ * The router reads it from the session, and this is the second lock on the same
+ * door: zod strips what it does not declare, so a `placerId` on the wire cannot
+ * survive parsing even if a future spread order stopped overwriting it.
+ */
+describe('the placer cannot come from the request body', () => {
+  it('strips a client-supplied placerId rather than carrying it', () => {
+    const parsed = createStickerPlacementSchema.parse({ imageId: 74, data, placerId: 999 });
+
+    expect(parsed).not.toHaveProperty('placerId');
+  });
+
+  it('declares no placerId at all', () => {
+    // Read off the shape rather than off one parse, so adding the field is
+    // caught even if a caller never sends it. If this ever needs relaxing, the
+    // reason has to be written down somewhere other than here.
+    expect(Object.keys(createStickerPlacementSchema.shape)).toEqual(['imageId', 'data', 'free']);
+  });
+});

--- a/src/server/schema/__tests__/submit-to-remix-gallery.schema.test.ts
+++ b/src/server/schema/__tests__/submit-to-remix-gallery.schema.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getRemixGalleryFreeEligibilitySchema,
+  submitToRemixGallerySchema,
+} from '~/server/schema/placement.schema';
+
+describe('getRemixGalleryFreeEligibilitySchema', () => {
+  it('bounds the candidate list', () => {
+    // The only ceiling on the work: the service runs a jsonb containment test
+    // per row, so the cap is what stops one request probing an arbitrary slice
+    // of somebody's library. It is a claim the service's own docstring makes
+    // about this file, and nothing asserted it.
+    const ids = Array.from({ length: 201 }, (_, index) => index + 1);
+
+    expect(
+      getRemixGalleryFreeEligibilitySchema.safeParse({ hostImageId: 1, imageIds: ids }).success
+    ).toBe(false);
+    expect(
+      getRemixGalleryFreeEligibilitySchema.safeParse({
+        hostImageId: 1,
+        imageIds: ids.slice(0, 200),
+      }).success
+    ).toBe(true);
+  });
+
+  it('accepts the empty list the picker opens with', () => {
+    // Nothing selected is the modal's first render, and the service answers it
+    // without a query at all. A minimum here would make that state an error.
+    expect(
+      getRemixGalleryFreeEligibilitySchema.safeParse({ hostImageId: 1, imageIds: [] }).success
+    ).toBe(true);
+  });
+});
+
+/**
+ * The submission contract, at the boundary where a client's payload becomes an
+ * argument.
+ *
+ * Two things below the schema depend on it and neither can check it: the service
+ * reads a missing `expectedPrice` as "the submitter agreed to whatever the price
+ * is now", and `createFreePlacement` takes `placerId` as a plain number it
+ * cannot trace to a session.
+ */
+describe('submitToRemixGallerySchema', () => {
+  const paid = { hostImageId: 11, imageId: 12, expectedPrice: 100 };
+
+  it('defaults a submission to paid', () => {
+    // Asked for, never assumed. A client cached from before the free tier must
+    // keep paying rather than start spending an allowance it does not know it
+    // has.
+    expect(submitToRemixGallerySchema.parse(paid).free).toBe(false);
+  });
+
+  it('requires the price a paid submission was shown', () => {
+    // The consent check. Without it the service charges whatever the price is at
+    // the moment of the click, which is the spend-without-consent case
+    // `expectedPrice` exists to prevent — and an owner can move their price at
+    // any time.
+    const result = submitToRemixGallerySchema.safeParse({ hostImageId: 11, imageId: 12 });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].path).toEqual(['expectedPrice']);
+  });
+
+  it('lets a free submission omit the price it is not paying', () => {
+    const result = submitToRemixGallerySchema.safeParse({
+      hostImageId: 11,
+      imageId: 12,
+      free: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.expectedPrice).toBeUndefined();
+  });
+
+  it('strips a client-supplied placerId rather than carrying it', () => {
+    // 🔴 The half of the placerId defence that lives in this file. The router
+    // spreads `...input` before the session id, so both would have to break for
+    // a client value to survive — but a `placerId` accepted here is one of the
+    // two, and nothing downstream would catch it: every check in
+    // `createFreePlacement` is *about* that id rather than a check *of* it.
+    const parsed = submitToRemixGallerySchema.parse({ ...paid, placerId: 999 });
+
+    expect(parsed).not.toHaveProperty('placerId');
+  });
+});

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -197,17 +197,53 @@ export const getRemixGalleryVisibilitySchema = z.object({
   browsingLevel: z.number().min(0).default(allBrowsingLevelsFlag),
 });
 
-export const submitToRemixGallerySchema = z.object({
+export const submitToRemixGallerySchema = z
+  .object({
+    hostImageId: z.number().int().positive(),
+    imageId: z.number().int().positive(),
+    /**
+     * The price the submitter was shown. Refused if the owner has moved it since,
+     * rather than silently charging the new one — the client can only check
+     * affordability against the number it rendered, so without this an owner
+     * raising their price between the modal opening and the button being pressed
+     * is charged without consent.
+     *
+     * Optional only because a free submission has no price to agree to. The
+     * refinement below still requires it on the paid path, so this cannot become
+     * a route to submitting without one.
+     */
+    expectedPrice: z.number().int().min(0).optional(),
+    /**
+     * Spend the daily free placement instead of Buzz. The server decides whether
+     * that is allowed — the remix must be one it resolved as derived from the
+     * host, and the creator must have a slot free — so this asks rather than
+     * asserts. `placerId` is never taken from here; it comes from the session.
+     */
+    free: z.boolean().default(false),
+  })
+  .superRefine((input, ctx) => {
+    // Without this, omitting `expectedPrice` on a paid submission reaches the
+    // service as `undefined`, which it reads as "the submitter agreed to
+    // whatever it is now" — the exact consent hole the field exists to close.
+    if (!input.free && input.expectedPrice == null)
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['expectedPrice'],
+        message: 'A paid submission has to carry the price it was shown',
+      });
+  });
+
+/**
+ * What the submit card needs to offer the free option, for the candidates it has
+ * already loaded.
+ *
+ * Bounded to one page of the picker rather than taking the viewer's whole
+ * library: the verification is a jsonb containment test per row, and answering
+ * it for every image someone has ever posted is a scan nobody asked for.
+ */
+export const getRemixGalleryFreeEligibilitySchema = z.object({
   hostImageId: z.number().int().positive(),
-  imageId: z.number().int().positive(),
-  /**
-   * The price the submitter was shown. Refused if the owner has moved it since,
-   * rather than silently charging the new one — the client can only check
-   * affordability against the number it rendered, so without this an owner
-   * raising their price between the modal opening and the button being pressed
-   * is charged without consent.
-   */
-  expectedPrice: z.number().int().min(0),
+  imageIds: z.array(z.number().int().positive()).max(200),
 });
 
 export const actOnRemixGallerySubmissionSchema = z.object({

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -51,6 +51,18 @@ export const stickerPlacementDataSchema = z.object({
 export const createStickerPlacementSchema = z.object({
   imageId: z.number().int().positive(),
   data: stickerPlacementDataSchema,
+  /**
+   * Take the creator's free capacity rather than paying their price.
+   *
+   * Safe to accept from the client because it selects a path, not an outcome:
+   * everything that makes a free placement legal is re-decided by
+   * `createFreePlacement` under a lock. Defaulted false so a client cached from
+   * before the free tier existed still places a paid sticker.
+   *
+   * 🔴 There is deliberately no `placerId` here, and there must never be one —
+   * see the note on `CreateStickerPlacement`.
+   */
+  free: z.boolean().default(false),
 });
 export type CreateStickerPlacementInput = z.infer<typeof createStickerPlacementSchema>;
 

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { allBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
-import { placementSurfaces } from '~/shared/utils/placement';
+import { PLACEMENT_SURFACES, placementSurfaces } from '~/shared/utils/placement';
 import { REMIX_GALLERY_MAX_PINNED } from '~/shared/utils/remix-gallery';
 import {
   STICKER_COMMENT_MAX_LENGTH,
@@ -72,6 +72,13 @@ export const placementSpaceSchema = z
     // Distinguishes "leave whatever is set" from "clear it and inherit", which a
     // single optional number cannot: `undefined` keeps, `null` clears.
     price: z.number().int().min(0).nullable().optional(),
+    // Same three-way distinction as `price`, for the same reason: `undefined`
+    // keeps, `null` clears so the level inherits, a number sets. Bounded below
+    // only — the score/tier ceiling is applied at read, so refusing above it here
+    // would rewrite a creator's choice the moment their tier lapsed. The upper
+    // bound is a sanity limit on what may reach the column at all, well above the
+    // highest cap the table can produce.
+    freeSlots: z.number().int().min(0).max(1_000).nullable().optional(),
     // Surface-owned. Bounded here so a client cannot store a max size outside the
     // global limits; the reader clamps too, since the column is editable by hand.
     // Each surface reads only its own keys, so the union is carried rather than
@@ -90,11 +97,19 @@ export const placementSpaceSchema = z
     // moderated catalogue; nothing bounds what an image can be. Refused where
     // the value is stored rather than merely omitted from the settings picker —
     // a listing that filters is not a mutation that refuses.
-    if (input.surface === 'remixGallery' && input.mode === 'auto')
+    //
+    // Read from the surface table rather than naming `remixGallery` here, so
+    // this and the refusal on the acting side (`createFreePlacement`) cannot
+    // disagree about which modes a surface allows.
+    const allowed = PLACEMENT_SURFACES[input.surface].allowedModes as readonly string[];
+    if (!allowed.includes(input.mode))
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['mode'],
-        message: 'Remix gallery submissions always need review',
+        message:
+          input.surface === 'remixGallery'
+            ? 'Remix gallery submissions always need review'
+            : 'That is not a mode this surface accepts',
       });
   });
 

--- a/src/server/services/__tests__/free-placement.service.test.ts
+++ b/src/server/services/__tests__/free-placement.service.test.ts
@@ -1,0 +1,491 @@
+import fs from 'fs';
+import path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import type * as PlacementModeration from '~/server/services/placement-moderation.service';
+import type * as PlacementSpaceService from '~/server/services/placement-space.service';
+import type { ResolvedPlacementSpace } from '~/server/services/placement-space.service';
+import { FREE_PLACEMENTS_PER_DAY, PLACEMENT_SURFACES } from '~/shared/utils/placement';
+
+const resolveSpace = vi.fn();
+const assertCanPlace = vi.fn();
+
+// `reservedFreeSlots` is deliberately NOT stubbed: it is the predicate the claim
+// decides on, and a double would let the count-under-lock be tested against a
+// shape the real query does not have.
+vi.mock('~/server/services/placement-space.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof PlacementSpaceService>()),
+  resolvePlacementSpaceFor: resolveSpace,
+}));
+vi.mock('~/server/services/placement-moderation.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof PlacementModeration>()),
+  assertCanPlace,
+}));
+
+const { createFreePlacement, getFreePlacementAllowance } = await import(
+  '~/server/services/free-placement.service'
+);
+
+const OWNER = 10;
+const PLACER = 20;
+const TARGET = 77;
+
+const placementCount = dbMock.dbWrite.placement.count;
+const placementCreate = dbMock.dbWrite.placement.create;
+const executeRaw = dbMock.dbWrite.$executeRaw;
+
+/**
+ * The four counts the claim runs, told apart by their `where` rather than by the
+ * order they happen to be called in.
+ *
+ * Ordering the answers with `mockResolvedValueOnce` would pass just as well if
+ * the service asked the same question four times — which is the mistake worth
+ * catching, since these differ only in their predicates.
+ */
+const givenCounts = ({ usedToday = 0, pending = 0, alreadyHere = 0, reserved = 0 } = {}) =>
+  placementCount.mockImplementation(async ({ where }: { where: Record<string, unknown> }) => {
+    if (where.createdAt) return usedToday;
+    if (where.ownerId !== undefined) return pending;
+    if (where.status) return reserved;
+    if (where.targetId !== undefined) return alreadyHere;
+    throw new Error(`unrecognised count: ${JSON.stringify(where)}`);
+  });
+
+const givenSpace = (overrides: Partial<ResolvedPlacementSpace> = {}) =>
+  resolveSpace.mockResolvedValue({
+    ownerId: OWNER,
+    ownerUsername: 'creator',
+    mode: 'review',
+    setPrice: 100,
+    price: 100,
+    cap: 500,
+    ownerShare: 1,
+    setFreeSlots: 4,
+    freeSlots: 4,
+    freeSlotCap: 4,
+    // Deliberately generous, and deliberately ignored: this is what a surface
+    // SHOWS, computed before the caller's other checks ran. Every refusal below
+    // has to come from the counts re-read under the lock instead.
+    freeSlotsRemaining: 99,
+    settings: {},
+    ...overrides,
+  } satisfies ResolvedPlacementSpace);
+
+const claim = () =>
+  createFreePlacement({
+    surface: 'sticker',
+    targetType: 'image',
+    targetId: TARGET,
+    placerId: PLACER,
+    data: { cosmeticId: 5 },
+  });
+
+const whereOf = (predicate: (where: Record<string, unknown>) => boolean) =>
+  placementCount.mock.calls
+    .map(([args]: [{ where: Record<string, unknown> }]) => args.where)
+    .find(predicate);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  givenCounts();
+  givenSpace();
+  assertCanPlace.mockResolvedValue(undefined);
+  placementCreate.mockResolvedValue({ id: 1 });
+});
+
+describe('createFreePlacement', () => {
+  it('writes a free row worth nothing, with a deadline on it', async () => {
+    await claim();
+
+    const written = placementCreate.mock.calls[0][0].data;
+    expect(written).toMatchObject({ free: true, amount: 0, status: 'pending', ownerId: OWNER });
+    // The deadline is what releases the slot when the creator never acts. A free
+    // row without one holds a slot forever and no sweep will reach it: the expiry
+    // query is `expiresAt <= now()`, which NULL never satisfies.
+    expect(written.expiresAt).toBeInstanceOf(Date);
+    expect(written.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  // The owner is taken from the space this function resolved, from the target it
+  // was given. Passing a pre-resolved space alongside a separate target let the
+  // two disagree: a caller resolving once and looping would write a placement
+  // onto image B carrying image A's owner, sending the review and every payout
+  // attribution to the wrong creator with nothing raising.
+  it('resolves the space from the target it is about, not from an argument', async () => {
+    await claim();
+
+    expect(resolveSpace).toHaveBeenCalledWith({
+      surface: 'sticker',
+      targetType: 'image',
+      targetId: TARGET,
+    });
+    expect(placementCreate.mock.calls[0][0].data.targetId).toBe(TARGET);
+  });
+});
+
+/**
+ * Free is placement that costs no Buzz, not a lighter kind of placement. Every
+ * rule about who may place on whom is untouched by the price being zero, and the
+ * function's own docstring promises they are all here — a promise PR 2's author
+ * will read and rely on.
+ */
+describe('createFreePlacement — the refusals the paid path makes', () => {
+  it('refuses a space its owner has closed', async () => {
+    givenSpace({ mode: 'off' });
+
+    await expect(claim()).rejects.toThrow(/not accepting placements/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  // A gallery row saying `auto` predates the rule that galleries always review.
+  // Refused where it is acted on, not only where it is written: a listing that
+  // filters is not a mutation that refuses.
+  it('refuses a mode the surface no longer allows, however the row got that way', async () => {
+    givenSpace({ mode: 'auto' });
+
+    await expect(
+      createFreePlacement({
+        surface: 'remixGallery',
+        targetType: 'image',
+        targetId: TARGET,
+        placerId: PLACER,
+        data: {},
+      })
+    ).rejects.toThrow(/not accepting placements/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('still allows auto on a surface that permits it', async () => {
+    givenSpace({ mode: 'auto' });
+
+    await expect(claim()).resolves.toBeDefined();
+  });
+
+  // Free self-placement is not "harmless because no money moves" — it is the
+  // creator filling their own slots so nobody else can have them, which defeats
+  // the scarcity the feature is built on.
+  it('refuses placing on your own content', async () => {
+    givenSpace({ ownerId: PLACER });
+
+    await expect(claim()).rejects.toThrow(/your own content/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  // The half the free path could not do without: a block declines the rows
+  // pending when it lands, but a moderator suspension is the only thing that
+  // stops tomorrow's placement. Without this a suspended placer keeps placing
+  // free ones forever.
+  it('refuses a suspended or blocked placer, before any lock is taken', async () => {
+    assertCanPlace.mockRejectedValue(
+      new Error('placement: your placement privileges are suspended')
+    );
+
+    await expect(claim()).rejects.toThrow(/suspended/);
+    expect(placementCreate).not.toHaveBeenCalled();
+    // Outside the transaction, because it is I/O and `no-io-in-transaction`
+    // guards that — and because a refusal should not first queue on a lock.
+    expect(executeRaw).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.$executeRawUnsafe).not.toHaveBeenCalled();
+  });
+
+  it('checks the placer against the owner it resolved, not against the target', async () => {
+    await claim();
+
+    expect(assertCanPlace).toHaveBeenCalledWith({ ownerId: OWNER, placerId: PLACER });
+  });
+
+  it('refuses once the placer holds the maximum pending with this creator', async () => {
+    givenCounts({ pending: PLACEMENT_SURFACES.sticker.maxPendingPerOwner });
+
+    await expect(claim()).rejects.toThrow(/maximum pending/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('counts that cap per surface and per owner, over pending rows only', async () => {
+    givenCounts({ pending: PLACEMENT_SURFACES.sticker.maxPendingPerOwner });
+    await expect(claim()).rejects.toThrow(/maximum pending/);
+
+    expect(whereOf((where) => where.ownerId !== undefined)).toMatchObject({
+      surface: 'sticker',
+      ownerId: OWNER,
+      placerId: PLACER,
+      status: 'pending',
+    });
+  });
+});
+
+describe('createFreePlacement — the free-tier refusals', () => {
+  it('refuses once the slots on this image are taken', async () => {
+    givenCounts({ reserved: 4 });
+
+    await expect(claim()).rejects.toThrow(/free slots/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('counts a pending placement as holding its slot', async () => {
+    // The distinction the whole feature rests on. If the count asked only for
+    // `approved`, fifty people would submit into four slots and the creator
+    // would get a fifty-item review queue.
+    givenCounts({ reserved: 4 });
+    await expect(claim()).rejects.toThrow(/free slots/);
+
+    const where = whereOf(
+      (candidate) => !!candidate.status && typeof candidate.status === 'object'
+    );
+    expect((where?.status as { in: string[] }).in.slice().sort()).toEqual(['approved', 'pending']);
+    expect(where).toMatchObject({ free: true, surface: 'sticker', targetId: TARGET });
+  });
+
+  it('refuses a space whose owner takes no free placements', async () => {
+    givenSpace({ freeSlots: 0 });
+
+    await expect(claim()).rejects.toThrow(/not taking free/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses a second free placement in the same UTC day', async () => {
+    givenCounts({ usedToday: FREE_PLACEMENTS_PER_DAY });
+
+    await expect(claim()).rejects.toThrow(/today/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('asks about free rows only, in this UTC day, whatever became of them', async () => {
+    givenCounts({ usedToday: FREE_PLACEMENTS_PER_DAY });
+    await expect(claim()).rejects.toThrow(/today/);
+
+    const daily = whereOf((where) => !!where.createdAt);
+    // `free: true` asserted, not assumed. Without it a PAID placement spends the
+    // free day, and every other test in this file stays green.
+    expect(daily).toMatchObject({ placerId: PLACER, free: true });
+    // No status predicate, asymmetrically with the slot count above: a decline or
+    // an expiry gives the IMAGE's slot back but not the placer's day. Refunding
+    // the day turns the free tier into an unlimited retry loop against whoever
+    // declines fastest.
+    expect(daily).not.toHaveProperty('status');
+    // No surface predicate: the allowance is one placement a day across the
+    // site, not one per surface.
+    expect(daily).not.toHaveProperty('surface');
+
+    // The window itself. `gte: new Date(0)` makes the allowance once-ever and
+    // `gte: Date.now()` makes it never spend; both leave every assertion above
+    // untouched.
+    const since = (daily?.createdAt as { gte: Date }).gte;
+    expect(since.toISOString()).toMatch(/T00:00:00\.000Z$/);
+    expect(since.getTime()).toBeLessThanOrEqual(Date.now());
+    expect(Date.now() - since.getTime()).toBeLessThan(24 * 3_600_000);
+  });
+
+  it('refuses a second free placement on the same image, ever', async () => {
+    givenCounts({ alreadyHere: 1 });
+
+    await expect(claim()).rejects.toThrow(/already used a free placement here/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('asks about this image without a date or a status, so it means "ever"', async () => {
+    givenCounts({ alreadyHere: 1 });
+    await expect(claim()).rejects.toThrow(/already used/);
+
+    // An image posted and deleted daily is otherwise a farm for one account's
+    // alts: a day-scoped or status-scoped version would let the same placer back
+    // onto the same image tomorrow, or after a decline.
+    const everHere = whereOf(
+      (where) => where.targetId !== undefined && !where.createdAt && !where.status
+    );
+    expect(everHere).toMatchObject({ placerId: PLACER, free: true, surface: 'sticker' });
+  });
+});
+
+describe('createFreePlacement — the lock', () => {
+  /**
+   * The lock statements, reassembled from the tagged template.
+   *
+   * `join('?')` marks where a bound parameter goes, so this reads as SQL rather
+   * than as a mock's argument shape — which matters for exactly one statement
+   * below, where a parameter is the bug.
+   */
+  const lockStatements = () =>
+    executeRaw.mock.calls.map(([strings]: [string[]]) => strings.join('?'));
+
+  it('bounds how long a claim waits, so a wedged holder cannot pile up backends', async () => {
+    await claim();
+
+    // `pg_advisory_xact_lock` waits forever by default, and Prisma's client-side
+    // timeout does not cancel a backend already blocked inside the statement.
+    //
+    // 🔴 Asserted on `$executeRawUnsafe`, and on the LITERAL. Postgres has no
+    // parameter form for `SET`, so the tagged-template version sends
+    // `SET LOCAL lock_timeout = $1` and raises `syntax error at or near "$1"` —
+    // and because this is the first statement in the transaction, that does not
+    // merely make the timeout inert, it kills every claim. The previous version
+    // of this test rebuilt the template with a placeholder and asserted the
+    // prefix, which passes on precisely the broken form.
+    expect(dbMock.dbWrite.$executeRawUnsafe).toHaveBeenCalledTimes(1);
+    const [statement] = dbMock.dbWrite.$executeRawUnsafe.mock.calls[0];
+    // WHAT the statement is, kept alongside the two checks on how it is sent.
+    // Without it `SET LOCAL statement_timeout = '3s'` passes, and so does
+    // `SET lock_timeout = '3s'` — which on a pooled connection leaks a 3s lock
+    // timeout onto every later statement borrowing that backend, well outside
+    // this feature. The `$1` fix replaced this assertion instead of joining it;
+    // when tightening a test, add and keep.
+    expect(statement).toContain('SET LOCAL lock_timeout');
+    expect(statement).toContain(`'3s'`);
+    expect(statement).not.toContain('$1');
+  });
+
+  // The `SET` is on `$executeRawUnsafe` and the locks are on `$executeRaw`, so
+  // no per-mock call count can see their relative order. Move the `SET` below
+  // both acquisitions and every other assertion in this file stays green while
+  // the timeout is inert for the first and most contended wait — which is the
+  // entire reason the statement exists.
+  it('sets the timeout before it waits on anything', async () => {
+    await claim();
+
+    expect(dbMock.dbWrite.$executeRawUnsafe.mock.invocationCallOrder[0]).toBeLessThan(
+      executeRaw.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('takes the placer lock first and the target lock second', async () => {
+    await claim();
+
+    const [placerLock, targetLock] = lockStatements();
+    expect(placerLock).toContain('pg_advisory_xact_lock');
+    expect(targetLock).toContain('hashtext');
+    // The locks bind their arguments, unlike the `SET` above — advisory-lock
+    // functions are ordinary functions and take parameters.
+    expect(placerLock).toContain('?');
+    expect(executeRaw).toHaveBeenCalledTimes(2);
+  });
+
+  // Asserted on the calls because a unit test cannot observe Postgres
+  // serialising. What it CAN pin is that both locks are held before the reads
+  // that depend on them, in one fixed order — a second call site acquiring them
+  // the other way round is the deadlock this ordering exists to prevent.
+  it('holds the target lock before it counts what is reserved on the target', async () => {
+    givenCounts({ reserved: 4 });
+    await expect(claim()).rejects.toThrow(/free slots/);
+
+    const targetLockAt = executeRaw.mock.invocationCallOrder[1];
+    const reservedCountAt =
+      placementCount.mock.invocationCallOrder[placementCount.mock.calls.length - 1];
+    expect(targetLockAt).toBeLessThan(reservedCountAt);
+  });
+
+  // Everyone who has already spent their day would otherwise queue on a shared,
+  // contended lock to learn a fact about nobody but themselves.
+  it('answers the placer-only question before taking the shared target lock', async () => {
+    givenCounts({ usedToday: FREE_PLACEMENTS_PER_DAY });
+    await expect(claim()).rejects.toThrow(/today/);
+
+    // One lock, not two: it refused before the target lock existed.
+    expect(executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('claims inside one transaction, so the count and the insert cannot be split', async () => {
+    await claim();
+
+    expect(dbMock.dbWrite.$transaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The lock ordering is load-bearing and cannot be enforced by a type.
+ *
+ * PRs 2 and 4 are written by people who have not read the file that explains it,
+ * so "take them placer-first" must not be a rule anyone has to know. The keys are
+ * module-private and there is one acquisition site; this is what makes that a
+ * fact rather than an intention, and it fails on the commit that adds a second
+ * site rather than under load six months later.
+ */
+describe('the advisory locks have exactly one call site', () => {
+  /**
+   * Any advisory lock, of any arity.
+   *
+   * Deliberately not scoped to the two-argument form. Disjoint key spaces mean a
+   * one-argument lock can never *be* one of these — but a deadlock needs a cycle
+   * in the waits-for graph, not a shared key space, so a one-argument lock taken
+   * inside this transaction deadlocks against a caller taking them the other way
+   * round exactly as one in the same space would. An arity-scoped pattern is also
+   * brittle in both directions: `pg_advisory_xact_lock(hashtext(key), id)` is a
+   * two-argument call it would miss, and `pg_advisory_xact_lock(hashtext(a, b))`
+   * a one-argument call it would flag.
+   *
+   * An explicit expected list rather than a "no new matches" count: a count
+   * passes when one caller is added and another removed, and says nothing about
+   * which files it was happy with.
+   */
+  const ADVISORY_LOCK = /pg_advisory/;
+  const ALLOWED = ['services/article.service.ts', 'services/free-placement.service.ts'];
+
+  it('is taken only inside createFreePlacement', () => {
+    const root = path.resolve(__dirname, '../..');
+    const callers = fs
+      .readdirSync(root, { recursive: true, encoding: 'utf8' })
+      .map((name) => name.split(path.sep).join('/'))
+      // Excluded explicitly rather than left to luck: this file names the
+      // function it is guarding, so without this it matches itself.
+      .filter((name) => name.endsWith('.ts') && !name.includes('__tests__/'))
+      // Comments stripped first. `webhook-debounce.ts` explains the article
+      // service's lock in prose, and an allowlist entry for a file that takes no
+      // lock is an entry nobody can later tell from a real one.
+      .filter((name) =>
+        ADVISORY_LOCK.test(
+          fs
+            .readFileSync(path.join(root, name), 'utf8')
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/\/\/[^\n]*/g, '')
+        )
+      );
+
+    expect(callers.sort()).toEqual(ALLOWED);
+  });
+
+  it('exports nothing but the three functions, so there is no lock to take', async () => {
+    const exported = await import('~/server/services/free-placement.service');
+
+    // Surface-shaped, not name-shaped: a pattern like /LOCK/ passes for a new
+    // export under any other name, which is most of them.
+    expect(Object.keys(exported).sort()).toEqual([
+      'createFreePlacement',
+      'getFreePlacementAllowance',
+      'hasUsedFreePlacementOn',
+    ]);
+  });
+});
+
+describe('getFreePlacementAllowance', () => {
+  it('reports the day as spent and says when it comes back', async () => {
+    dbMock.dbRead.placement.count.mockResolvedValue(FREE_PLACEMENTS_PER_DAY);
+
+    const allowance = await getFreePlacementAllowance({ placerId: PLACER });
+
+    expect(allowance).toMatchObject({ used: FREE_PLACEMENTS_PER_DAY, remaining: 0 });
+    expect(allowance.resetsAt.getTime()).toBeGreaterThan(Date.now());
+    // Midnight UTC, not the placer's midnight: a local day would refresh twice
+    // for anyone willing to change timezone, and two servers would disagree about
+    // which day a placement fell in.
+    expect(allowance.resetsAt.toISOString()).toMatch(/T00:00:00\.000Z$/);
+  });
+
+  it('never reports a negative remainder', async () => {
+    dbMock.dbRead.placement.count.mockResolvedValue(FREE_PLACEMENTS_PER_DAY + 5);
+
+    expect((await getFreePlacementAllowance({ placerId: PLACER })).remaining).toBe(0);
+  });
+
+  // The predicate is shared with the claim rather than written twice. Scope it by
+  // status in one copy and the surface offers a placement the mutation refuses.
+  it('asks the same question the claim decides on', async () => {
+    dbMock.dbRead.placement.count.mockResolvedValue(0);
+    await getFreePlacementAllowance({ placerId: PLACER });
+    const displayed = dbMock.dbRead.placement.count.mock.calls[0][0].where;
+
+    givenCounts();
+    await claim();
+    const decided = whereOf((where) => !!where.createdAt);
+
+    expect(displayed).toEqual(decided);
+  });
+});

--- a/src/server/services/__tests__/placement-escrow.service.test.ts
+++ b/src/server/services/__tests__/placement-escrow.service.test.ts
@@ -1,5 +1,8 @@
 import { Prisma } from '@prisma/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+// Mocked below; imported for the assertion that a swallowed reward failure is
+// still reported.
+import { logToAxiom } from '~/server/logging/client';
 // Stubbed globally in src/__tests__/setup.ts.
 import { placementUnfundedSettlementsGauge } from '~/server/prom/client';
 
@@ -13,6 +16,25 @@ vi.mock('~/server/services/buzz.service', () => ({
   createBuzzTransaction,
 }));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValue(undefined) }));
+
+// Wholesale on purpose: the real module loads `base.reward`, which builds a
+// ClickHouse client, redis handles and prom collectors at import time. The
+// reward's own behaviour is tested in stickerPlacementAccepted.reward.test.ts;
+// what this suite owns is WHEN settlement hands it a placement.
+const applyAcceptReward = vi.fn();
+vi.mock('~/server/rewards/active/stickerPlacementAccepted.reward', () => ({
+  stickerPlacementAcceptedReward: { apply: applyAcceptReward },
+}));
+
+// The remix reward, which this service must NEVER grant — it is granted from
+// `actOnRemixGallerySubmission`, the only path by which a remix submission is
+// approved. Mocked here so the exclusivity test below observes the real shared
+// chokepoint: this suite is the only place that exercises it, since the remix
+// suite mocks `settlePlacement` wholesale and cannot see what it fires.
+const applyRemixReward = vi.fn();
+vi.mock('~/server/rewards/active/remixAccept.reward', () => ({
+  remixAcceptReward: { apply: applyRemixReward },
+}));
 
 // A real mutex, not a pass-through: the lock is what stops two callers both
 // reaching the Buzz call after one has claimed the ledger row, so a double that
@@ -358,6 +380,8 @@ beforeEach(() => {
   configState.shares = { seller: 0, platform: 0.3 };
   createMultiAccountBuzzTransaction.mockResolvedValue({ transactionCount: 2, totalAmount: 0 });
   createBuzzTransaction.mockResolvedValue({ transactionId: 'buzz-tx' });
+  applyAcceptReward.mockResolvedValue(undefined);
+  applyRemixReward.mockResolvedValue(undefined);
   // The real response carries the legs it reversed. The double used to return
   // only the prefix, which let a refund that moved NOTHING look identical to one
   // that moved everything — the exact discrepancy the service now refuses on.
@@ -1847,5 +1871,219 @@ describe('a free placement never touches the money path', () => {
 
     expect(moneyMoved()).toBe(0);
     expect(legsFor(1)).toEqual({});
+  });
+});
+
+describe('the accept reward', () => {
+  const hold = () =>
+    holdPlacementEscrow({
+      spendType: 'yellow',
+      placementId: 1,
+      placerId: PLACER,
+      surface: 'sticker',
+      amount: 1000,
+    });
+
+  it('pays the owner of the space, for the placement, crediting the placer', async () => {
+    givenPlacement();
+    await hold();
+
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+
+    expect(applyAcceptReward).toHaveBeenCalledTimes(1);
+    expect(applyAcceptReward).toHaveBeenCalledWith({
+      placementId: 1,
+      ownerId: OWNER,
+      placerId: PLACER,
+    });
+  });
+
+  it('pays it for a free placement too', async () => {
+    givenPlacement({ free: true, amount: 0 });
+
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+
+    expect(applyAcceptReward).toHaveBeenCalledTimes(1);
+  });
+
+  // The reason it hangs off `count > 0` and not off the callers. The ledger key
+  // never expires while the daily cap does, so a second presentation of the same
+  // placement on a later day spends a tenth of the owner's day and moves no Buzz.
+  it('pays nothing on a second approve of the same placement', async () => {
+    givenPlacement();
+    await hold();
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+    applyAcceptReward.mockClear();
+
+    const { settled } = await settlePlacement({
+      placementId: 1,
+      action: 'approve',
+      actorId: OWNER,
+    });
+
+    expect(settled).toBe(false);
+    expect(applyAcceptReward).not.toHaveBeenCalled();
+  });
+
+  it.each(['decline', 'expire', 'removeByOwner', 'removeByModerator'] as const)(
+    'pays nothing when the placement settles as %s',
+    async (action) => {
+      givenPlacement();
+      await hold();
+
+      const { settled } = await settlePlacement({ placementId: 1, action, actorId: OWNER });
+
+      // The settle has to have happened, or "the reward did not fire" is true of
+      // a call that did nothing at all and the assertion below proves nothing.
+      expect(settled).toBe(true);
+      expect(applyAcceptReward).not.toHaveBeenCalled();
+    }
+  );
+
+  /**
+   * 🔴 **Auto-accept pays, and that is designed** — but read what this asserts.
+   *
+   * This service has no notion of space mode. Both sticker approve paths — the
+   * owner acting through `actOnStickerPlacement`, and `createStickerPlacement`
+   * settling inline at placement time when `space.mode === 'auto'` — arrive here
+   * as the identical call, which is exactly why the reward hangs off the settle
+   * rather than off either caller. So this cannot tell them apart, and is not
+   * named as though it can: what it pins is that **any** approve pays.
+   *
+   * The auto half is pinned in two places that together need no inference:
+   * 'settles an auto space immediately' in sticker-placement.service.test.ts
+   * asserts that path issues exactly this settle, and this asserts that settle
+   * pays.
+   *
+   * Written out because the intent otherwise lives only in a Discord thread.
+   * Justin's decision, in the intent doc: creators switching from Review to Auto
+   * Accept to collect this is a fine outcome, not a leak. A reviewer reading the
+   * code alone has already once read auto-mode paying as an oversight and
+   * recommended removing it. If you are here to make auto stop paying, that is
+   * the conversation you are having, and it is Justin's to have.
+   */
+  it('pays on any approve, whichever of the two sticker paths issued it', async () => {
+    givenPlacement();
+    await hold();
+
+    const { settled } = await settlePlacement({
+      placementId: 1,
+      action: 'approve',
+      actorId: OWNER,
+    });
+
+    expect(settled).toBe(true);
+    expect(applyAcceptReward).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * 🔴 **Exactly one reward per surface, and this is the only place that can see
+   * it.** The tempting cleanup after both reward PRs land is to consolidate here
+   * — move the remix `apply` into `rewardAccepted` — and leave the call in
+   * `actOnRemixGallerySubmission` in place. That double-pays 20 Blue Buzz on
+   * every remix accept, and nothing else goes red: the remix suite mocks
+   * `settlePlacement` wholesale so it cannot observe this service firing
+   * anything, the two ledger keys differ by type, and the daily cap hash is
+   * keyed `userId:type` so both grants look legitimate to both caps.
+   *
+   * The consolidation is a recorded follow-up and is fine to do — but it must
+   * MOVE the remix call, not add one. This test is what tells you which you did.
+   *
+   * ⚠️ The remix half is **inert until #4013 lands**: nothing on this branch can
+   * call `remixAcceptReward`, because the module it mocks does not exist here
+   * yet. Verified that this suite still collects all its tests with the mock in
+   * place (Vitest resolves a mocked path lazily), so it is a tripwire armed on
+   * merge rather than coverage you have today.
+   */
+  it('grants exactly one reward per surface, and never the other surface reward', async () => {
+    givenPlacement({ id: 1, surface: 'sticker' });
+    givenPlacement({ id: 2, surface: 'remixGallery' });
+
+    const sticker = await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+    expect(sticker.settled).toBe(true);
+    expect(applyAcceptReward).toHaveBeenCalledTimes(1);
+    expect(applyRemixReward).not.toHaveBeenCalled();
+
+    applyAcceptReward.mockClear();
+
+    const remix = await settlePlacement({ placementId: 2, action: 'approve', actorId: OWNER });
+    expect(remix.settled).toBe(true);
+    expect(applyRemixReward).not.toHaveBeenCalled();
+    expect(applyAcceptReward).not.toHaveBeenCalled();
+  });
+
+  // 🔴 If you are here because you added a `remixGallery` branch to
+  // `rewardAccepted`: that reward is already granted from
+  // `actOnRemixGallerySubmission`, the only path by which a remix submission is
+  // approved. A branch here does not replace that grant, it doubles it — and no
+  // guard either reward owns can tell: the types differ, so the ledger keys
+  // differ, and the daily cap hash is keyed `userId:type`. This test is the only
+  // thing standing between that edit and paying every remix approval twice.
+  it('pays nothing on a remix approval, which is granted from its own surface', async () => {
+    givenPlacement({ surface: 'remixGallery' });
+    await hold();
+
+    const { settled } = await settlePlacement({
+      placementId: 1,
+      action: 'approve',
+      actorId: OWNER,
+    });
+
+    // Establishes the approval actually happened, so this is "approved and paid
+    // nothing" rather than a call that quietly did nothing at all.
+    expect(settled).toBe(true);
+    expect(applyAcceptReward).not.toHaveBeenCalled();
+  });
+
+  // The approval has already paid the owner out of escrow by this point. A
+  // throw here would 500 a request whose money has moved, and the caller would
+  // read that as the approval having failed.
+  it('does not fail the approval when the reward throws', async () => {
+    givenPlacement();
+    await hold();
+    applyAcceptReward.mockRejectedValue(new Error('clickhouse is gone'));
+
+    const { settled, placement } = await settlePlacement({
+      placementId: 1,
+      action: 'approve',
+      actorId: OWNER,
+    });
+
+    expect(settled).toBe(true);
+    expect(placement.status).toBe('approved');
+    expect(legsFor(1)).toMatchObject({ toOwner: 700 });
+  });
+
+  /**
+   * The log is the entire compensation for swallowing the throw. Without it a
+   * reward that never arrived leaves no trace at all on a money path — and
+   * `.catch(() => null)` is a plausible-looking edit that produces exactly that
+   * while every other assertion here stays green.
+   *
+   * Rejected with a non-`Error` on purpose: that is what tells `.message` apart
+   * from the `instanceof` narrowing, and a bare `.message` logs `undefined` —
+   * the failure reads as "the reward failed, cause unknown", which is the shape
+   * that makes an outage unreadable at 3am.
+   */
+  it('reports a swallowed reward failure, whatever was thrown', async () => {
+    givenPlacement();
+    await hold();
+    applyAcceptReward.mockRejectedValue('clickhouse is gone');
+
+    const { settled } = await settlePlacement({
+      placementId: 1,
+      action: 'approve',
+      actorId: OWNER,
+    });
+
+    expect(settled).toBe(true);
+    expect(vi.mocked(logToAxiom)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'placement-escrow',
+        message: 'accept reward failed',
+        placementId: 1,
+        error: 'clickhouse is gone',
+      })
+    );
   });
 });

--- a/src/server/services/__tests__/placement-escrow.service.test.ts
+++ b/src/server/services/__tests__/placement-escrow.service.test.ts
@@ -290,6 +290,10 @@ const givenPlacement = (overrides: Record<string, unknown> = {}) => {
     // double answer `undefined` where Postgres answers NULL, which is a
     // different thing to a `where: { spendType: null }` predicate.
     spendType: null,
+    // Present and false, as the column is on a real row. Left off, `free` reads
+    // `undefined` here where Postgres answers false — falsy either way today, and
+    // a difference the moment anything compares it rather than tests it.
+    free: false,
     expiresAt: null,
     resolvedAt: null,
     resolvedById: null,
@@ -1746,5 +1750,102 @@ describe('the Buzz call bound', () => {
     expect(BUZZ_CALL_TIMEOUT_MS).toBeLessThanOrEqual(120_000);
     expect(BUZZ_CALL_TIMEOUT_MS).toBeLessThan(LEG_RETRY_BACKOFF_MINUTES * 60_000);
     expect(BUZZ_CALL_TIMEOUT_MS).toBeGreaterThanOrEqual(10_000);
+  });
+});
+
+describe('a free placement never touches the money path', () => {
+  /**
+   * Escrow that a free row must not be able to release.
+   *
+   * Receipted, so `heldAmountsFor` counts it as real Buzz sitting in the escrow
+   * account. That state should be unreachable — the free path takes no holds and
+   * `holdPlacementEscrow` refuses a free row — and it is exactly the state the
+   * guard has to survive, because "unreachable" is a claim about today's callers
+   * and PRs 2 and 4 are the callers that do not exist yet.
+   *
+   * Without this fixture the free-row tests below are vacuous: with no holds,
+   * every branch of the payout already computes to zero and is filtered out, so
+   * deleting the guard would change nothing they observe.
+   */
+  const givenReceiptedHolds = () => {
+    db.legs.set('1:holdFee', {
+      placementId: 1,
+      kind: 'holdFee',
+      amount: 300,
+      transactionId: 'placement-1-holdFee',
+      attempts: 1,
+      createdAt: new Date(0),
+    });
+    db.legs.set('1:holdPrincipal', {
+      placementId: 1,
+      kind: 'holdPrincipal',
+      amount: 700,
+      transactionId: 'placement-1-holdPrincipal',
+      attempts: 1,
+      createdAt: new Date(0),
+    });
+  };
+
+  it('plans nothing on approval, even with escrow sitting behind the row', async () => {
+    givenPlacement({ free: true, amount: 0 });
+    givenReceiptedHolds();
+    clearMoneyMocks();
+
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+
+    expect(legsFor(1)).toEqual({ holdFee: 300, holdPrincipal: 700 });
+    expect(moneyMoved()).toBe(0);
+  });
+
+  it('takes no decline fee, so a decline costs the placer nothing', async () => {
+    givenPlacement({ free: true, amount: 0 });
+    givenReceiptedHolds();
+    clearMoneyMocks();
+
+    await settlePlacement({ placementId: 1, action: 'decline', actorId: OWNER });
+
+    expect(legsFor(1)).not.toHaveProperty('feeToOwner');
+    expect(moneyMoved()).toBe(0);
+  });
+
+  it('refunds nothing on expiry, because nothing was ever taken', async () => {
+    givenPlacement({ free: true, amount: 0 });
+    givenReceiptedHolds();
+    clearMoneyMocks();
+
+    await settlePlacement({ placementId: 1, action: 'expire' });
+
+    expect(legsFor(1)).not.toHaveProperty('principalToPlacer');
+    expect(moneyMoved()).toBe(0);
+  });
+
+  it('still settles the row, so the slot it holds is released', async () => {
+    givenPlacement({ free: true, amount: 0 });
+
+    const { settled, placement } = await settlePlacement({ placementId: 1, action: 'decline' });
+
+    // The money is the part that does nothing. The status transition is the part
+    // that matters — it is what takes the placement out of
+    // `FREE_SLOT_HOLDING_STATUSES` and hands the slot to the next placer.
+    expect(settled).toBe(true);
+    expect(placement.status).toBe('declined');
+  });
+
+  it('refuses to take escrow at all, rather than holding zero', async () => {
+    givenPlacement({ free: true, amount: 0 });
+    clearMoneyMocks();
+
+    await expect(
+      holdPlacementEscrow({
+        placementId: 1,
+        placerId: PLACER,
+        surface: 'sticker',
+        amount: 100,
+        spendType: 'yellow',
+      })
+    ).rejects.toThrow(/free/);
+
+    expect(moneyMoved()).toBe(0);
+    expect(legsFor(1)).toEqual({});
   });
 });

--- a/src/server/services/__tests__/placement-escrow.service.test.ts
+++ b/src/server/services/__tests__/placement-escrow.service.test.ts
@@ -1989,11 +1989,9 @@ describe('the accept reward', () => {
    * The consolidation is a recorded follow-up and is fine to do — but it must
    * MOVE the remix call, not add one. This test is what tells you which you did.
    *
-   * ⚠️ The remix half is **inert until #4013 lands**: nothing on this branch can
-   * call `remixAcceptReward`, because the module it mocks does not exist here
-   * yet. Verified that this suite still collects all its tests with the mock in
-   * place (Vitest resolves a mocked path lazily), so it is a tripwire armed on
-   * merge rather than coverage you have today.
+   * The remix half was inert while `remixAcceptReward` did not exist on this
+   * branch — a tripwire armed on merge rather than coverage. #4013 landed it, so
+   * both halves are live and the mocked path now resolves to a real module.
    */
   it('grants exactly one reward per surface, and never the other surface reward', async () => {
     givenPlacement({ id: 1, surface: 'sticker' });
@@ -2033,6 +2031,10 @@ describe('the accept reward', () => {
     // nothing" rather than a call that quietly did nothing at all.
     expect(settled).toBe(true);
     expect(applyAcceptReward).not.toHaveBeenCalled();
+    // The reward the comment above is about. Without this the test asserted only
+    // that the STICKER reward stayed out of a remix approval, so the exact edit
+    // it warns against — a `remixGallery` branch here — left it green.
+    expect(applyRemixReward).not.toHaveBeenCalled();
   });
 
   // The approval has already paid the owner out of escrow by this point. A

--- a/src/server/services/__tests__/placement-space.service.test.ts
+++ b/src/server/services/__tests__/placement-space.service.test.ts
@@ -10,10 +10,20 @@ const imageFindUnique = dbMock.dbWrite.image.findUnique;
 
 vi.mock('~/server/services/placement.service', async (importOriginal) => ({
   ...(await importOriginal<typeof PlacementService>()),
-  placementPriceRange: async () => ({ min: 0, max: 500, score: 0, tier: 'free' as const }),
+  placementPriceRange: async () => ({
+    min: 0,
+    max: 500,
+    freeSlotCap: capState.freeSlotCap,
+    score: 0,
+    tier: 'free' as const,
+  }),
 }));
 
-const { setPlacementSpace } = await import('~/server/services/placement-space.service');
+const capState = { freeSlotCap: 4 };
+
+const { resolvePlacementSpaceFor, setPlacementSpace } = await import(
+  '~/server/services/placement-space.service'
+);
 
 const OWNER = 7;
 const base = {
@@ -198,5 +208,155 @@ describe('setPlacementSpace — the price guard', () => {
     expect(PLACEMENT_SURFACES.remixGallery.defaultPrice!).toBeGreaterThanOrEqual(
       PLACEMENT_SURFACES.remixGallery.serverMinPrice
     );
+  });
+});
+
+describe('resolvePlacementSpaceFor — free capacity', () => {
+  // `dbRead`: the reservation feeds a display-only number on a public query, and
+  // the claim re-counts under its own lock. Everything else in this resolver
+  // reads the primary because it decides a mutation.
+  const placementCount = dbMock.dbRead.placement.count;
+
+  const resolve = () =>
+    resolvePlacementSpaceFor({ surface: 'sticker', targetType: 'image', targetId: 42 });
+
+  beforeEach(() => {
+    capState.freeSlotCap = 4;
+    imageFindUnique.mockResolvedValue({
+      id: 42,
+      userId: OWNER,
+      postId: null,
+      user: { username: 'creator' },
+    });
+    placementCount.mockResolvedValue(0);
+  });
+
+  it('gives an unconfigured space the surface default', async () => {
+    const space = await resolve();
+
+    expect(space.setFreeSlots).toBe(PLACEMENT_SURFACES.sticker.defaultFreeSlots);
+    expect(space.freeSlots).toBe(PLACEMENT_SURFACES.sticker.defaultFreeSlots);
+    expect(space.freeSlotsRemaining).toBe(PLACEMENT_SURFACES.sticker.defaultFreeSlots);
+  });
+
+  it('subtracts what is already reserved', async () => {
+    spaceFindMany.mockResolvedValue([
+      { entityType: 'image', mode: 'review', price: 100, freeSlots: 4 },
+    ]);
+    placementCount.mockResolvedValue(3);
+
+    expect((await resolve()).freeSlotsRemaining).toBe(1);
+  });
+
+  // Both statuses, and free rows only. A count that took every status would never
+  // release a slot after a decline; one that ignored `free` would let paid
+  // placements eat the free capacity, which the two counters exist to keep apart.
+  it('reserves against pending and approved free rows, and nothing else', async () => {
+    spaceFindMany.mockResolvedValue([
+      { entityType: 'image', mode: 'review', price: 100, freeSlots: 4 },
+    ]);
+
+    await resolve();
+
+    const { where } = placementCount.mock.calls[0][0];
+    expect(where).toMatchObject({
+      surface: 'sticker',
+      targetType: 'image',
+      targetId: 42,
+      free: true,
+    });
+    expect(where.status.in.slice().sort()).toEqual(['approved', 'pending']);
+  });
+
+  it('never reports negative room when the owner lowers their slider', async () => {
+    // Not a takeback: the placements they already accepted stay, and the space
+    // simply accepts nothing further until one is released.
+    spaceFindMany.mockResolvedValue([
+      { entityType: 'image', mode: 'review', price: 100, freeSlots: 1 },
+    ]);
+    placementCount.mockResolvedValue(3);
+
+    expect((await resolve()).freeSlotsRemaining).toBe(0);
+  });
+
+  it('ceilings a stored count at the cap without rewriting the row', async () => {
+    capState.freeSlotCap = 2;
+    spaceFindMany.mockResolvedValue([
+      { entityType: 'image', mode: 'review', price: 100, freeSlots: 9 },
+    ]);
+
+    const space = await resolve();
+
+    expect(space.setFreeSlots).toBe(9);
+    expect(space.freeSlots).toBe(2);
+  });
+
+  it('asks nothing of the database when the space takes no free placements', async () => {
+    spaceFindMany.mockResolvedValue([
+      { entityType: 'image', mode: 'review', price: 100, freeSlots: 0 },
+    ]);
+
+    const space = await resolve();
+
+    expect(space.freeSlotsRemaining).toBe(0);
+    // The answer is 0 whatever the count says, so the query is a round trip that
+    // cannot change it.
+    expect(placementCount).not.toHaveBeenCalled();
+  });
+});
+
+describe('setPlacementSpace — free slots', () => {
+  // The same three-way distinction as the price, and it has to be, because the
+  // per-image toggle sends `mode` and `price` and nothing else: without this an
+  // owner flipping one image on would silently clear their account-level count.
+  it('leaves a stored count alone when none is sent', async () => {
+    await setPlacementSpace({ ...base, mode: 'review' });
+
+    expect(priceWritten()).not.toHaveProperty('freeSlots');
+  });
+
+  /**
+   * The `create` half, which every other test here reads past — `priceWritten()`
+   * is the `update` clause.
+   *
+   * This is the first-ever save for a space, and it is the likeliest place for
+   * the freeze-the-default failure to land: `freeSlots: freeSlots ?? 0` in the
+   * create clause writes an explicit `0` for a creator who has expressed no
+   * preference, permanently opting the space out of tracking the surface default
+   * AND closing it. Every assertion on the `update` side stays green.
+   */
+  it('creates a first-ever row with no count of its own, not with a zero', async () => {
+    await setPlacementSpace({ ...base, mode: 'review' });
+
+    expect(spaceUpsert.mock.calls[0][0].create).toMatchObject({ freeSlots: null });
+  });
+
+  it('creates with the count when the creator did choose one', async () => {
+    await setPlacementSpace({ ...base, mode: 'review', freeSlots: 0 });
+
+    expect(spaceUpsert.mock.calls[0][0].create).toMatchObject({ freeSlots: 0 });
+  });
+
+  it('clears a count to null so the level inherits again', async () => {
+    await setPlacementSpace({ ...base, mode: 'review', freeSlots: null });
+
+    expect(priceWritten()).toMatchObject({ freeSlots: null });
+  });
+
+  // Stored uncapped, exactly as the price is. A creator whose tier lapses and
+  // returns gets their number back rather than finding it silently rewritten to
+  // whatever their cap happened to be on the day they last saved.
+  it('stores a count above the current cap rather than refusing or clamping it', async () => {
+    await setPlacementSpace({ ...base, mode: 'review', freeSlots: 9 });
+
+    expect(priceWritten()).toMatchObject({ freeSlots: 9 });
+  });
+
+  // The state that replaces an on/off toggle. Written through, not treated as
+  // "unset", or the creator's no would resolve back to the surface default.
+  it('stores an explicit zero', async () => {
+    await setPlacementSpace({ ...base, mode: 'review', freeSlots: 0 });
+
+    expect(priceWritten()).toMatchObject({ freeSlots: 0 });
   });
 });

--- a/src/server/services/__tests__/placement.service.test.ts
+++ b/src/server/services/__tests__/placement.service.test.ts
@@ -4,6 +4,7 @@ import {
   MAX_DECLINE_FEE_RATE,
   MIN_DECLINE_FEE_RATE,
   MIN_OWNER_SHARE,
+  PLACEMENT_FREE_SLOT_CAP_TIERS,
   PLACEMENT_PRICE_CAP_TIERS,
   PLACEMENT_SURFACES,
   placementSurfaces,
@@ -170,5 +171,72 @@ describe('placementPriceRange', () => {
     const range = await placementPriceRange(1, 'sticker');
     expect(range.score).toBe(0);
     expect(range.max).toBe(100);
+  });
+});
+
+describe('the free-slot cap table', () => {
+  const band = (caps: Record<string, number>) => [{ minScore: 0, caps }];
+
+  it('is what decides the free-slot cap, not the price table', async () => {
+    storedConfig({
+      priceCapTiers: band({ free: 999, bronze: 999, silver: 999, gold: 999 }),
+      freeSlotTiers: band({ free: 3, bronze: 4, silver: 5, gold: 6 }),
+    });
+
+    const range = await placementPriceRange(1, 'sticker');
+
+    // Two numbers from two tables through one query. Reading `max` for both is
+    // the failure this separates: a creator's Buzz ceiling is in the hundreds,
+    // and applied to slots it would be hundreds of free placements per image.
+    expect(range.freeSlotCap).toBe(3);
+    expect(range.max).toBe(999);
+  });
+
+  it('takes a per-surface override over the shared one', async () => {
+    storedConfig({
+      freeSlotTiers: band({ free: 2, bronze: 2, silver: 2, gold: 2 }),
+      freeSlotTiersBySurface: {
+        remixGallery: band({ free: 7, bronze: 7, silver: 7, gold: 7 }),
+      },
+    });
+
+    expect((await placementPriceRange(1, 'sticker')).freeSlotCap).toBe(2);
+    expect((await placementPriceRange(1, 'remixGallery')).freeSlotCap).toBe(7);
+  });
+
+  /**
+   * The failure this closes is not "the override is ignored" — it is the override
+   * falling back to the wrong table.
+   *
+   * A stored table with no zero band is unusable, and the shared helper that
+   * detects that has to be handed the FREE-SLOT defaults. Handed the price ones
+   * instead, a single malformed config edit silently grants 500-1000 free
+   * placements per space, which is the price cap read as a slot count.
+   */
+  it('falls back to the compiled free-slot table when the stored one is unusable', async () => {
+    storedConfig({ freeSlotTiers: band({ free: 5, bronze: 5, silver: 5, gold: 5 }) });
+    const configured = (await placementPriceRange(1, 'sticker')).freeSlotCap;
+
+    storedConfig({
+      freeSlotTiers: [{ minScore: 5_000, caps: { free: 5, bronze: 5, silver: 5, gold: 5 } }],
+    });
+    const fellBack = (await placementPriceRange(1, 'sticker')).freeSlotCap;
+
+    expect(configured).toBe(5);
+    // Asserted by identity against the compiled table rather than against a
+    // literal, the same way the price side is: a number would also match the
+    // price table's bottom band on the day someone gets the fallback wrong.
+    expect(fellBack).toBe(PLACEMENT_FREE_SLOT_CAP_TIERS[0].caps.free);
+    expect(fellBack).not.toBe(PLACEMENT_PRICE_CAP_TIERS[0].caps.free);
+  });
+
+  it('refuses a fractional slot count the same way it refuses a fractional price', async () => {
+    storedConfig({ freeSlotTiers: band({ free: 1.5, bronze: 2, silver: 3, gold: 4 }) });
+
+    // The whole config fails to parse and every accessor falls back, which is the
+    // documented behaviour: a bad edit must not take the feature down.
+    expect((await placementPriceRange(1, 'sticker')).freeSlotCap).toBe(
+      PLACEMENT_FREE_SLOT_CAP_TIERS[0].caps.free
+    );
   });
 });

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NsfwLevel } from '~/server/common/enums';
 import {
   allBrowsingLevelsFlag,
@@ -23,6 +23,7 @@ const STRANGER = 63;
 const HOST_IMAGE = 74;
 const REMIX_IMAGE = 85;
 const PLACEMENT = 96;
+const FREE_PLACEMENT = 107;
 const PRICE = 700;
 
 const holdPlacementEscrow = vi.fn(async () => ({ fee: 210, principal: 490 }));
@@ -50,6 +51,26 @@ vi.mock('~/server/services/placement-moderation.service', () => ({ assertCanPlac
 const rewardApply = vi.fn(async () => undefined);
 vi.mock('~/server/rewards/active/remixAccept.reward', () => ({
   remixAcceptReward: { apply: rewardApply },
+}));
+
+/**
+ * The free claim is the boundary this file tests against, not through. It owns
+ * an advisory-locked transaction and every refusal the paid path makes, all of
+ * which are `free-placement.service`'s own tests to keep — what matters here is
+ * that the free branch delegates to it with the right target instead of building
+ * a row of its own.
+ */
+const createFreePlacement = vi.fn(async () => ({ id: FREE_PLACEMENT }));
+const getFreePlacementAllowance = vi.fn(async () => ({
+  used: 0,
+  remaining: 1,
+  resetsAt: new Date('2026-01-02'),
+}));
+const hasUsedFreePlacementOn = vi.fn(async () => false);
+vi.mock('~/server/services/free-placement.service', () => ({
+  createFreePlacement,
+  getFreePlacementAllowance,
+  hasUsedFreePlacementOn,
 }));
 
 const resolvePlacementSpaceFor = vi.fn();
@@ -122,6 +143,8 @@ const {
   parseGalleryCursor,
   getRemixGallery,
   getRemixGalleryVisibility,
+  getRemixGalleryFreeEligibility,
+  getMyRemixGallerySubmissions,
   getPendingRemixGallerySubmissions,
   declineOutOfBandRemixGallerySubmissions,
 } = await import('~/server/services/remix-gallery.service');
@@ -175,7 +198,15 @@ const openSpace = {
   setPrice: PRICE,
   price: PRICE,
   cap: 1000,
+  freeSlots: 2,
+  freeSlotsRemaining: 1,
   settings: {},
+};
+
+/** A submission the server itself resolved as derived from the host image. */
+const verifiedSubmission: SubmissionFixture = {
+  ...goodSubmission,
+  sourceImageIds: [HOST_IMAGE],
 };
 
 /**
@@ -213,6 +244,8 @@ beforeEach(() => {
   placementCount.mockResolvedValue(0);
   placementFindFirst.mockResolvedValue(null);
   settlePlacement.mockResolvedValue({ settled: true });
+  createFreePlacement.mockResolvedValue({ id: FREE_PLACEMENT });
+  hasUsedFreePlacementOn.mockResolvedValue(false);
   holdPlacementEscrow.mockImplementation(async () => {
     calls.push('hold');
     return { fee: 210, principal: 490 };
@@ -228,6 +261,36 @@ const submit = (over: Partial<Parameters<typeof createRemixGallerySubmission>[0]
     imageId: REMIX_IMAGE,
     ...over,
   });
+
+/**
+ * The SQL a raw query actually carries, as one string.
+ *
+ * Nested `Prisma.sql` fragments arrive as VALUES rather than as part of the
+ * template's string array, so flattening is what makes an assertion see a
+ * predicate that lives inside a fragment at all.
+ *
+ * At module scope because two suites need it and both encode the same guess
+ * about Prisma's internals — `strings` and `values` on a fragment. When that
+ * shape changes, one copy gets fixed and the other keeps passing over SQL it can
+ * no longer read.
+ */
+const flatten = (value: unknown): string => {
+  if (Array.isArray(value)) return value.map(flatten).join(' ');
+  if (value && typeof value === 'object' && 'strings' in value)
+    return [
+      flatten((value as { strings: unknown }).strings),
+      flatten((value as { values?: unknown }).values ?? []),
+    ].join(' ');
+  return typeof value === 'string' ? value : '';
+};
+
+/** The bound parameters, which `flatten` drops — it keeps only strings. */
+const boundValues = (value: unknown): unknown[] => {
+  if (Array.isArray(value)) return value.flatMap(boundValues);
+  if (value && typeof value === 'object' && 'strings' in value)
+    return boundValues((value as { values?: unknown }).values ?? []);
+  return [value];
+};
 
 describe('content level rules', () => {
   it('refuses an unrated submission under BOTH rules', () => {
@@ -460,20 +523,6 @@ describe('the ceiling is applied on read, not only on the mutation', () => {
   // from a read query and every other test in this file still passes, while
   // entries approved before a host was flagged keep rendering — and the owner
   // cannot take them down for a week.
-  //
-  // Nested `Prisma.sql` fragments arrive as VALUES rather than as part of the
-  // template's string array, so flattening them is what makes this see the
-  // predicate at all.
-  const flatten = (value: unknown): string => {
-    if (Array.isArray(value)) return value.map(flatten).join(' ');
-    if (value && typeof value === 'object' && 'strings' in value)
-      return [
-        flatten((value as { strings: unknown }).strings),
-        flatten((value as { values?: unknown }).values ?? []),
-      ].join(' ');
-    return typeof value === 'string' ? value : '';
-  };
-
   const sqlFrom = () => queryRaw.mock.calls.map(flatten).join(' ');
 
   /**
@@ -1650,5 +1699,511 @@ describe('declining everything out of band', () => {
     ).rejects.toThrow();
 
     expect(settlePlacement).not.toHaveBeenCalled();
+  });
+});
+
+describe('free submissions', () => {
+  const submitFree = (over: Partial<Parameters<typeof createRemixGallerySubmission>[0]> = {}) =>
+    submit({ free: true, ...over });
+
+  it('refuses a remix the server did not resolve as derived from the host', async () => {
+    // The gate the whole surface rests on. `sourceImageIds` is empty on the
+    // default fixture, which is what an off-site remix looks like — a real remix
+    // carrying no signal, which is why the refusal names paying as the
+    // alternative rather than calling it not a remix.
+    await expect(submitFree()).rejects.toThrow(/made from this image on-site/i);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the host is not among the inputs, only some other image', async () => {
+    // Derivation is membership, not "this generation had inputs at all". A remix
+    // built entirely from someone else's image would otherwise buy a free slot
+    // in a queue it has nothing to do with.
+    primeQueries({ submission: { ...goodSubmission, sourceImageIds: [STRANGER] } });
+    await expect(submitFree()).rejects.toThrow(/made from this image on-site/i);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  it('claims through the free primitive rather than writing its own row', async () => {
+    primeQueries({ submission: verifiedSubmission });
+
+    const result = await submitFree();
+
+    expect(result).toEqual({ id: FREE_PLACEMENT });
+    // No row of its own and no escrow: the three refusals the free tier adds
+    // have to hold together under the claim's lock, in the same transaction as
+    // its insert, and a row built here would be a second creation route.
+    expect(placementCreate).not.toHaveBeenCalled();
+    expect(holdPlacementEscrow).not.toHaveBeenCalled();
+
+    expect(createFreePlacement).toHaveBeenCalledWith({
+      surface: 'remixGallery',
+      targetType: 'image',
+      targetId: HOST_IMAGE,
+      placerId: PLACER,
+      data: { imageId: REMIX_IMAGE, remixOfId: null, derivedFromHost: true },
+    });
+  });
+
+  it('hands the claim the host image, never the submitted one', async () => {
+    // Both ids are in scope at the call site and swapping them is a one-token
+    // edit that type-checks: the placement would land on the submitter's own
+    // image, attributed to themselves, holding a slot on the wrong creator.
+    primeQueries({ submission: verifiedSubmission });
+    await submitFree();
+
+    const claim = createFreePlacement.mock.calls[0][0] as { targetId: number; placerId: number };
+    expect(claim.targetId).toBe(HOST_IMAGE);
+    expect(claim.targetId).not.toBe(REMIX_IMAGE);
+    expect(claim.placerId).toBe(PLACER);
+  });
+
+  it('does not let a free submission skip the one-per-gallery duplicate check', async () => {
+    // `createFreePlacement` bounds free rows per placer and per target, which is
+    // a different question from "is this picture already in this gallery" — a
+    // paid entry followed by a free one would otherwise put the same image in
+    // twice and defeat the rotation.
+    primeQueries({ submission: verifiedSubmission });
+    placementFindFirst.mockResolvedValue({ id: 1 });
+
+    await expect(submitFree()).rejects.toThrow(/already in this gallery/i);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['off', /not accepting/i],
+    ['auto', /need review/i],
+  ] as const)('refuses a free submission to a %s gallery', async (mode, message) => {
+    primeQueries({ submission: verifiedSubmission });
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, mode });
+
+    await expect(submitFree()).rejects.toThrow(message);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  it('refuses a free submission to your own gallery', async () => {
+    primeQueries({ submission: verifiedSubmission });
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, ownerId: PLACER });
+
+    await expect(submitFree()).rejects.toThrow(/your own gallery/i);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  it('applies every content rule to a free submission', async () => {
+    // Free is placement that costs no Buzz, not a lighter kind of placement.
+    // These are the checks a free path is most tempting to skip, because nobody
+    // is being charged for the refusal.
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, settings: { contentRule: 'any' } });
+    primeQueries({ submission: { ...verifiedSubmission, tosViolation: true } });
+    await expect(submitFree()).rejects.toThrow(/cannot be submitted/i);
+
+    resolvePlacementSpaceFor.mockResolvedValue(openSpace);
+    primeQueries({ submission: { ...verifiedSubmission, nsfwLevel: NsfwLevel.XXX } });
+    await expect(submitFree()).rejects.toThrow(/rating/i);
+
+    primeQueries({ submission: verifiedSubmission, hostShowable: false });
+    await expect(submitFree()).rejects.toThrow(/cannot show a gallery/i);
+
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['unpriced', null],
+    ['priced below the floor', 10],
+  ] as const)('accepts a free submission to a %s gallery', async (_label, price) => {
+    // The price is the PAID path's spam gate — nothing verifies that a paid
+    // submission is really a remix. A free one is gated on the server having
+    // verified exactly that, so refusing it over a price it does not pay would
+    // refuse it for a reason that does not apply.
+    primeQueries({ submission: verifiedSubmission });
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, price, setPrice: price });
+
+    await expect(submitFree()).resolves.toEqual({ id: FREE_PLACEMENT });
+    expect(createFreePlacement).toHaveBeenCalledTimes(1);
+  });
+
+  it('still refuses a PAID submission to those same galleries', async () => {
+    // The other half of the pair above, which would also pass if the price
+    // checks had been deleted rather than moved onto the paid path.
+    // Re-primed between the two, because the raw-query fake answers by call
+    // index: without it the second submission reads the host row as its
+    // submission and fails on the wrong thing entirely.
+    primeQueries();
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, price: null, setPrice: null });
+    await expect(submit()).rejects.toThrow(/has not set a price/i);
+
+    primeQueries();
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, price: 10, setPrice: 10 });
+    await expect(submit()).rejects.toThrow(/not priced for submissions/i);
+  });
+
+  it('ignores expectedPrice on the free path instead of refusing on it', async () => {
+    // A client that keeps sending the price it rendered must not have a stale
+    // one turn a free submission into a refusal about money it is not spending.
+    primeQueries({ submission: verifiedSubmission });
+
+    await expect(submitFree({ expectedPrice: PRICE + 1 })).resolves.toEqual({ id: FREE_PLACEMENT });
+  });
+});
+
+describe('what the public visibility query says about free capacity', () => {
+  const visibility = (viewerId?: number) => {
+    // One row satisfying every raw read this path makes. The host has to come
+    // back SHOWABLE: an unresolvable host fails closed, which would make the
+    // withheld cases below pass for the wrong reason.
+    queryRaw.mockImplementation(async () => [
+      { exists: false, count: 0, nsfwLevel: NsfwLevel.PG, minor: false, showable: true },
+    ]);
+    return getRemixGalleryVisibility({
+      hostImageId: HOST_IMAGE,
+      browsingLevel: allBrowsingLevelsFlag,
+      viewerId,
+      domainLevels: allBrowsingLevelsFlag,
+    });
+  };
+
+  it('publishes what the creator accepts', async () => {
+    // Their own setting on their own image, the same standing as `price`, and
+    // the only half a signed-out viewer needs: whether free is a thing here.
+    await expect(visibility()).resolves.toMatchObject({ freeSlots: openSpace.freeSlots });
+  });
+
+  it.each([
+    ['signed out', undefined],
+    ['the owner', OWNER],
+  ] as const)('withholds how many are currently HELD from %s', async (_who, viewerId) => {
+    // A count of pending and approved submissions on someone's image — the same
+    // fact `pendingCount` is owner-only to protect. Public, it would let anyone
+    // watch a creator's queue fill by polling an id.
+    await expect(visibility(viewerId)).resolves.toMatchObject({ freeSlotsRemaining: null });
+  });
+
+  it('gives it to the one viewer who has to act on it', async () => {
+    await expect(visibility(PLACER)).resolves.toMatchObject({
+      freeSlotsRemaining: openSpace.freeSlotsRemaining,
+    });
+  });
+
+  it('withholds it on a closed gallery even from a would-be submitter', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, mode: 'off' });
+    await expect(visibility(PLACER)).resolves.toMatchObject({ freeSlotsRemaining: null });
+  });
+});
+
+describe('what the owner’s review queue says a free submission is worth', () => {
+  const queueRow = (free: boolean) => ({
+    id: PLACEMENT,
+    targetId: HOST_IMAGE,
+    placerId: PLACER,
+    amount: free ? 0 : PRICE,
+    free,
+    data: { imageId: REMIX_IMAGE },
+    createdAt: new Date('2026-01-01'),
+    expiresAt: new Date('2026-01-03'),
+    placer: { id: PLACER, username: 'someone', image: null },
+  });
+
+  const queue = async (free: boolean) => {
+    // The listable-ids query first, then the images fetch; the rows come from
+    // `findMany`, which is a separate mock.
+    let call = 0;
+    queryRaw.mockImplementation(async () => {
+      call += 1;
+      if (call === 1) return [{ id: PLACEMENT, createdAt: new Date('2026-01-01') }];
+      return [
+        {
+          id: REMIX_IMAGE,
+          url: 'a',
+          width: 1,
+          height: 1,
+          type: 'image',
+          metadata: {},
+          nsfwLevel: 1,
+        },
+        {
+          id: HOST_IMAGE,
+          url: 'b',
+          width: 1,
+          height: 1,
+          type: 'image',
+          metadata: {},
+          nsfwLevel: 1,
+        },
+      ];
+    });
+    placementFindMany.mockResolvedValue([queueRow(free)]);
+
+    const { items } = await getPendingRemixGallerySubmissions({
+      ownerId: OWNER,
+      domainLevels: allBrowsingLevelsFlag,
+      viewerLevels: allBrowsingLevelsFlag,
+    });
+    return items[0];
+  };
+
+  it('selects `free`, so the queue can tell the two kinds apart at all', async () => {
+    await queue(true);
+
+    // Omitted from the select, the client cannot branch however it renders — and
+    // the row would show as a paid one with its earnings missing.
+    expect(placementFindMany.mock.calls[0][0].select).toMatchObject({ free: true });
+  });
+
+  it('quotes no earnings on a free row, rather than quoting zero', async () => {
+    // 🔴 Both numbers derive from `amount`, and a free row's is 0 by DB
+    // constraint. Rendered, that is "+0 Buzz" on Approve AND Decline: the
+    // decision surface for the whole free tier telling a creator they earn
+    // nothing, on a row the free notification just called a gift.
+    const row = await queue(true);
+
+    expect(row.free).toBe(true);
+    expect(row.earnings).toBeNull();
+  });
+
+  it('still quotes both numbers on a paid row', async () => {
+    const row = await queue(false);
+
+    expect(row.earnings).toMatchObject({ approve: expect.any(Number) });
+    expect(row.earnings!.approve).toBeGreaterThan(0);
+    expect(row.earnings!.decline).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * 🔴 Every `placement.findMany` ANY test in this file makes, checked after it
+ * runs: if the select asks for `amount`, it must also ask for `free`.
+ *
+ * `amount` is 0 on a free row by DB constraint, so a consumer that renders it
+ * without knowing the row is free shows "0 Buzz" — and the copy around it ("your
+ * Buzz is on its way back") is false outright. The owner queue was found by
+ * review; two more were found only by sweeping.
+ *
+ * An `afterEach` rather than one `it` per named function, and the difference is
+ * the point: a per-function test retires the worry for the functions somebody
+ * remembered to list, and a third select added tomorrow is looked at by neither.
+ * It also has to loop rather than `.find(...)` — first-match-wins would skip a
+ * second amount-carrying select inside the SAME function and stay green, which
+ * is this repo's catalogued hazard reproduced inside the guard written to close
+ * a sweep.
+ *
+ * ⚠️ What it still cannot see: a read no test in this file exercises. It is a
+ * guard over exercised reads, not over the service.
+ */
+afterEach(() => {
+  for (const [args] of placementFindMany.mock.calls as { select?: Record<string, unknown> }[][])
+    if (args?.select?.amount)
+      expect(args.select.free, 'a read carrying `amount` must also carry `free`').toBe(true);
+});
+
+describe('the reads a Buzz figure is rendered from', () => {
+  it('the submitter’s own submissions list', async () => {
+    placementFindMany.mockResolvedValue([]);
+    await getMyRemixGallerySubmissions({
+      placerId: PLACER,
+      domainLevels: allBrowsingLevelsFlag,
+      viewerLevels: allBrowsingLevelsFlag,
+    });
+
+    // The real assertion is the `afterEach` above, which inspects every select
+    // this call made. This only proves the read happened, so the hook has
+    // something to inspect — deleting it as pointless removes the guard's
+    // anchor with nothing turning red.
+    expect(placementFindMany).toHaveBeenCalled();
+  });
+
+  it('the submitter’s pending rows on the image detail card', async () => {
+    queryRaw.mockImplementation(async () => [
+      { exists: false, count: 0, nsfwLevel: NsfwLevel.PG, minor: false, showable: true },
+    ]);
+    placementFindMany.mockResolvedValue([]);
+
+    await getRemixGalleryVisibility({
+      hostImageId: HOST_IMAGE,
+      browsingLevel: allBrowsingLevelsFlag,
+      viewerId: PLACER,
+      domainLevels: allBrowsingLevelsFlag,
+    });
+
+    // Same as above: the `afterEach` holds the assertion. This is the anchor.
+    expect(placementFindMany).toHaveBeenCalled();
+  });
+});
+
+describe('the free eligibility listing', () => {
+  const eligibility = () =>
+    getRemixGalleryFreeEligibility({
+      hostImageId: HOST_IMAGE,
+      placerId: PLACER,
+      imageIds: [REMIX_IMAGE],
+    });
+
+  beforeEach(() => queryRaw.mockResolvedValue([{ id: REMIX_IMAGE }]));
+
+  it('answers only for the viewer’s OWN images', async () => {
+    // The predicate this asserts is the whole reason the endpoint is not an
+    // oracle: without it, anyone could ask whether any image was generated from
+    // any other, which is a fact about someone else's generation inputs. Delete
+    // it and nothing else in this file notices.
+    await eligibility();
+
+    const sql = queryRaw.mock.calls.map(flatten).join(' ');
+    expect(sql).toContain('i."userId" =');
+    expect(boundValues(queryRaw.mock.calls)).toContain(PLACER);
+  });
+
+  it('reads derivation through the shared expression, not a containment test', async () => {
+    // `@>` on the raw JSON is NOT the same predicate — scalar containment is
+    // equality, so a non-array value would read as a match where this yields an
+    // empty array, and an array of strings goes the other way. The picker must
+    // offer exactly what the claim accepts, so both go through one expression.
+    await eligibility();
+
+    const sql = queryRaw.mock.calls.map(flatten).join(' ');
+    expect(sql).toContain('jsonb_array_elements');
+    expect(sql).toMatch(/jsonb_typeof\([\s\S]*'array'/);
+    expect(sql).toContain('= ANY(');
+    expect(sql).not.toContain('@>');
+    expect(boundValues(queryRaw.mock.calls)).toContain(HOST_IMAGE);
+  });
+
+  it('asks only about the candidates it was given', async () => {
+    // The `IN` list is the only thing bounding the work: a jsonb containment
+    // test runs per row, so without it the query answers for every image the
+    // placer owns. Delete the clause and the `userId` scope still holds — this
+    // is about cost and about answering a question nobody asked, not a leak.
+    await getRemixGalleryFreeEligibility({
+      hostImageId: HOST_IMAGE,
+      placerId: PLACER,
+      imageIds: [REMIX_IMAGE, REMIX_IMAGE + 1],
+    });
+
+    const sql = queryRaw.mock.calls.map(flatten).join(' ');
+    expect(sql).toContain('i.id IN (');
+    expect(boundValues(queryRaw.mock.calls)).toEqual(
+      expect.arrayContaining([REMIX_IMAGE, REMIX_IMAGE + 1])
+    );
+  });
+
+  it('scopes to the SESSION placer, never a caller-supplied one', async () => {
+    // Same two-mechanism defence as the submit path — the schema has no
+    // `placerId` and the router passes `ctx.user.id` — and the same reason it is
+    // asserted at the outcome: this endpoint answers a question about somebody's
+    // generation inputs, so a caller-chosen id would read another user's
+    // library. The submit path had this test; this one did not.
+    await getRemixGalleryFreeEligibility({
+      hostImageId: HOST_IMAGE,
+      placerId: PLACER,
+      imageIds: [REMIX_IMAGE],
+    });
+
+    expect(boundValues(queryRaw.mock.calls)).toContain(PLACER);
+    expect(boundValues(queryRaw.mock.calls)).not.toContain(STRANGER);
+    expect(hasUsedFreePlacementOn).toHaveBeenCalledWith(
+      expect.objectContaining({ placerId: PLACER })
+    );
+    expect(getFreePlacementAllowance).toHaveBeenCalledWith({ placerId: PLACER });
+  });
+
+  it('runs no query at all for an empty candidate list', async () => {
+    // `IN ()` is a syntax error, not an empty result, so the short-circuit is
+    // load-bearing rather than an optimisation — and the picker asks with
+    // nothing selected on every open.
+    const result = await getRemixGalleryFreeEligibility({
+      hostImageId: HOST_IMAGE,
+      placerId: PLACER,
+      imageIds: [],
+    });
+
+    expect(queryRaw).not.toHaveBeenCalled();
+    expect(result.verifiedImageIds).toEqual([]);
+  });
+
+  it('carries the allowance and the never-twice answer through unchanged', async () => {
+    getFreePlacementAllowance.mockResolvedValue({
+      used: 1,
+      remaining: 0,
+      resetsAt: new Date('2026-03-04'),
+    });
+    hasUsedFreePlacementOn.mockResolvedValue(true);
+
+    await expect(eligibility()).resolves.toEqual({
+      allowance: { used: 1, remaining: 0, resetsAt: new Date('2026-03-04') },
+      usedHere: true,
+      verifiedImageIds: [REMIX_IMAGE],
+    });
+  });
+
+  it('asks the never-twice question about THIS surface and THIS host', async () => {
+    // Free is scoped per surface and per target. Widen either and a placer who
+    // stickered an image is told they cannot submit a remix to it.
+    await eligibility();
+
+    expect(hasUsedFreePlacementOn).toHaveBeenCalledWith({
+      placerId: PLACER,
+      surface: 'remixGallery',
+      targetType: 'image',
+      targetId: HOST_IMAGE,
+    });
+  });
+});
+
+describe('the removal cooldown on a free entry', () => {
+  const approvedAt = new Date(Date.now() - 60 * 60 * 1000);
+
+  const arrangeApproved = (free: boolean) =>
+    placementFindUnique.mockResolvedValue({
+      id: PLACEMENT,
+      ownerId: OWNER,
+      placerId: PLACER,
+      targetId: HOST_IMAGE,
+      amount: free ? 0 : PRICE,
+      status: 'approved',
+      surface: 'remixGallery',
+      free,
+      data: { imageId: REMIX_IMAGE },
+      resolvedAt: approvedAt,
+      createdAt: approvedAt,
+    });
+
+  it('keeps the full week on a free entry, exactly as on a paid one', async () => {
+    // Justin's call, and asserted rather than assumed because both agents who
+    // looked at it recommended waiving it. Accepting a free remix therefore also
+    // holds one of the creator's free slots for the whole week — intended, not
+    // an oversight.
+    for (const free of [true, false]) {
+      arrangeApproved(free);
+      await expect(
+        actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'remove', userId: OWNER })
+      ).rejects.toThrow(/can be removed from/i);
+    }
+    expect(placementUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('does not tell a creator that someone paid for a free entry', async () => {
+    // The copy is the whole change here, so it is the thing asserted. Left
+    // alone, the refusal justifies the week with a payment that never happened.
+    arrangeApproved(true);
+    await expect(
+      actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'remove', userId: OWNER })
+    ).rejects.toThrow(/week-long commitment/i);
+
+    arrangeApproved(false);
+    await expect(
+      actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'remove', userId: OWNER })
+    ).rejects.toThrow(/someone paid/i);
+  });
+
+  it('lets a moderator take a free entry down inside the week', async () => {
+    arrangeApproved(true);
+    placementUpdateMany.mockResolvedValue({ count: 1 });
+    await expect(
+      actOnRemixGallerySubmission({
+        placementId: PLACEMENT,
+        action: 'remove',
+        userId: STRANGER,
+        isModerator: true,
+      })
+    ).resolves.toMatchObject({ removed: true });
   });
 });

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -43,6 +43,15 @@ vi.mock('~/server/services/placement-escrow.service', () => ({
 const assertCanPlace = vi.fn(async () => undefined);
 vi.mock('~/server/services/placement-moderation.service', () => ({ assertCanPlace }));
 
+// Stubbed rather than spread from the original: the real module loads
+// `base.reward`, which pulls the buzz service and its whole import graph into a
+// suite that mocks the escrow service precisely to keep it out. What the reward
+// itself does with these arguments is its own suite's job.
+const rewardApply = vi.fn(async () => undefined);
+vi.mock('~/server/rewards/active/remixAccept.reward', () => ({
+  remixAcceptReward: { apply: rewardApply },
+}));
+
 const resolvePlacementSpaceFor = vi.fn();
 vi.mock('~/server/services/placement-space.service', () => ({ resolvePlacementSpaceFor }));
 
@@ -671,6 +680,7 @@ describe('owner actions', () => {
   const pending = {
     id: PLACEMENT,
     ownerId: OWNER,
+    placerId: PLACER,
     status: 'pending',
     surface: 'remixGallery',
     data: { imageId: REMIX_IMAGE },
@@ -689,6 +699,11 @@ describe('owner actions', () => {
     await expect(
       actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'approve', userId: OWNER })
     ).rejects.toThrow(/no longer exists/i);
+    // The remix accept reward is scoped by this refusal and by nothing else. A
+    // sticker approval that reached it would pay the remix reward on top of the
+    // sticker one, which is the shape a bad merge between the two reward changes
+    // would take.
+    expect(rewardApply).not.toHaveBeenCalled();
   });
 
   it('re-checks the submission at approval, because a rating can move', async () => {
@@ -733,6 +748,62 @@ describe('owner actions', () => {
     await expect(
       actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'decline', userId: OWNER })
     ).rejects.toThrow(/already resolved/i);
+  });
+
+  describe('accept reward', () => {
+    const approve = () =>
+      actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'approve', userId: OWNER });
+
+    beforeEach(() => {
+      placementFindUnique.mockResolvedValue(pending);
+    });
+
+    it('pays the owner for the accept, crediting the submitter as the cause', async () => {
+      await approve();
+      // The count, not just the arguments. `toHaveBeenCalledWith` alone is
+      // satisfied by a doubled call, and the double-pay this reward has to avoid
+      // is a second `apply` — most plausibly a later refactor that moves the
+      // reward into the shared settle and leaves this call behind. That pays 20
+      // Blue Buzz twice for one accept and the argument assertion sees nothing.
+      expect(rewardApply).toHaveBeenCalledTimes(1);
+      expect(rewardApply).toHaveBeenCalledWith({
+        placementId: PLACEMENT,
+        ownerId: OWNER,
+        placerId: PLACER,
+      });
+    });
+
+    it('pays nothing for a decline', async () => {
+      await actOnRemixGallerySubmission({
+        placementId: PLACEMENT,
+        action: 'decline',
+        userId: OWNER,
+      });
+      expect(rewardApply).not.toHaveBeenCalled();
+    });
+
+    // The whole double-pay guard. `settlePlacement` claims pending → approved
+    // with `WHERE status = 'pending'`, so exactly one call in a placement's life
+    // returns settled: true, and the reward hangs off that. Move it above this
+    // check and a re-settle re-presents a placement the reward already paid:
+    // the ledger refuses it as a duplicate, no buzz moves, and the owner has
+    // silently lost one of their five accepts for the day.
+    it('pays nothing when the settle claimed nothing', async () => {
+      settlePlacement.mockResolvedValue({ settled: false });
+      await expect(approve()).rejects.toThrow(/already resolved/i);
+      expect(rewardApply).not.toHaveBeenCalled();
+    });
+
+    // The approval already committed and paid out of escrow before this runs, and
+    // it cannot be retried. Reporting it as failed would tell the owner their
+    // accept did not happen when the entry is live in their gallery.
+    it('still reports the approval when the reward fails', async () => {
+      rewardApply.mockRejectedValueOnce(new Error('buzz service down'));
+      await expect(approve()).resolves.toMatchObject({ settled: true });
+      expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringMatching(/reward failed/i) })
+      );
+    });
   });
 
   it('refuses to remove a live entry inside the removal lock', async () => {

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -285,17 +285,45 @@ describe("the creator's size limit", () => {
     expect(placementCreate).not.toHaveBeenCalled();
   });
 
-  it('lets a moderator exceed it', async () => {
+  /**
+   * The refusal sits above `if (free) return placeFreeSticker(...)`, so the free
+   * offer inherits it. That is positional, and nothing else here would notice a
+   * merge that kept both lines and put the branch first — the free path would
+   * stop refusing while every other test stayed green, and free placements carry
+   * no price, so no settlement figure would look wrong either.
+   *
+   * The message assertion carries that property on its own. The second one reads
+   * `createFreePlacement` because that is what the free branch delegates to
+   * today: give `placeFreeSticker` a different callee and it goes quiet rather
+   * than failing.
+   */
+  it('refuses a free placement the same way, before the free branch', async () => {
     resolvePlacementSpaceFor.mockResolvedValue(capped);
     givenStickerAndBalance();
 
     await expect(
-      createStickerPlacement({
-        ...placeInput,
-        data: OVERSIZE,
-        isModerator: true,
-      })
-    ).resolves.toMatchObject({ placementId: PLACEMENT });
+      createStickerPlacement({ ...placeInput, data: OVERSIZE, free: true })
+    ).rejects.toThrow(/up to 20%/);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The limit is the creator's, so nobody is above it — moderating someone's
+   * content is not a licence to put a bigger sticker on it.
+   *
+   * `isModerator` is no longer part of this input at all, and is sent here
+   * anyway, cast: a revert reinstating the exemption gives the field a reader
+   * again, and this is then the test that fails rather than one asserting a
+   * flag nothing looks at.
+   */
+  it('refuses a moderator the same way', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue(capped);
+    givenStickerAndBalance();
+
+    await expect(
+      createStickerPlacement({ ...placeInput, data: OVERSIZE, isModerator: true } as never)
+    ).rejects.toThrow(/up to 20%/);
+    expect(placementCreate).not.toHaveBeenCalled();
   });
 
   it('applies the default when the creator has set nothing', async () => {

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -19,6 +19,8 @@ const SELLER = 63;
 const IMAGE = 74;
 const COSMETIC = 85;
 const PLACEMENT = 96;
+/** Distinct from `PLACEMENT`: the two creation routes must not be confusable. */
+const FREE_PLACEMENT = 107;
 
 /**
  * `setPrice` is what the owner asks; `price` is `min(setPrice, cap)` — what a
@@ -47,6 +49,22 @@ vi.mock('~/server/services/placement-space.service', () => ({ resolvePlacementSp
 
 const spendStickerUsesFor = vi.fn(async () => undefined);
 vi.mock('~/server/services/sticker.service', () => ({ spendStickerUsesFor }));
+
+/**
+ * The whole free claim, stubbed at its own boundary.
+ *
+ * Deliberately not re-implemented here: the daily allowance, never-twice-here
+ * and the slot count are decided inside it under a lock, and a fake that
+ * enforced them would let this file pass while the service checked nothing. What
+ * these tests are for is the part that is genuinely this service's — that it
+ * routes through the claim rather than around it, and what it does after one
+ * succeeds.
+ */
+const createFreePlacement = vi.fn<PrismaStub<{ id: number }>>(async () => {
+  calls.push('claim');
+  return { id: FREE_PLACEMENT };
+});
+vi.mock('~/server/services/free-placement.service', () => ({ createFreePlacement }));
 
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValue(undefined) }));
 
@@ -82,6 +100,10 @@ const imageFindMany = vi.fn<PrismaStub<unknown[]>>(async () => []);
 const placementFindUnique = vi.fn<PrismaStub<unknown>>(async () => null);
 const placementUpdate = vi.fn<PrismaStub<object>>(async () => ({}));
 const placementUpdateMany = vi.fn<PrismaStub<{ count: number }>>(async () => ({ count: 1 }));
+const placementDeleteMany = vi.fn<PrismaStub<{ count: number }>>(async () => {
+  calls.push('discard');
+  return { count: 1 };
+});
 
 vi.mock('~/server/db/client', () => ({
   dbWrite: {
@@ -92,6 +114,7 @@ vi.mock('~/server/db/client', () => ({
       findUnique: placementFindUnique,
       update: placementUpdate,
       updateMany: placementUpdateMany,
+      deleteMany: placementDeleteMany,
     },
   },
   dbRead: {
@@ -1355,5 +1378,275 @@ describe('getPendingStickerPlacements domain ceiling', () => {
       withinViewerLevel: false,
       url: 'asset',
     });
+  });
+});
+
+/**
+ * The free path: same placement, taken out of the creator's free capacity.
+ *
+ * `createFreePlacement` is stubbed, so nothing here asserts the three free-tier
+ * refusals — those belong to `free-placement.service.test.ts`, where they can be
+ * tested against the lock and the transaction that actually enforce them. What
+ * is this service's own is everything around the claim: routing through it
+ * rather than around it, spending the use, and the settle a claim deliberately
+ * does not do.
+ */
+describe('the free path', () => {
+  const freeInput: CreateStickerPlacement = { ...placeInput, free: true };
+
+  beforeEach(() => {
+    givenStickerAndBalance();
+  });
+
+  it('claims through createFreePlacement rather than writing its own row', async () => {
+    const result = await createStickerPlacement(freeInput);
+
+    expect(result).toEqual({ placementId: FREE_PLACEMENT, status: 'pending' });
+    // The two things a second creation route would show up as. A free branch
+    // that built the row itself would have to re-implement the daily allowance,
+    // never-twice-here and the slot count outside the lock that makes them true.
+    expect(placementCreate).not.toHaveBeenCalled();
+    expect(holdPlacementEscrow).not.toHaveBeenCalled();
+  });
+
+  it('hands the claim the session placer and the sticker seller, and no space', async () => {
+    await createStickerPlacement(freeInput);
+
+    const args = createFreePlacement.mock.calls[0][0] as Record<string, unknown>;
+    expect(args).toMatchObject({
+      surface: 'sticker',
+      targetType: 'image',
+      targetId: IMAGE,
+      placerId: PLACER,
+      sellerId: SELLER,
+    });
+    // Not a resolved space. One alongside a separate target id is two facts
+    // that can disagree, and the claim resolves from the id on purpose.
+    expect(args).not.toHaveProperty('space');
+    expect(args).not.toHaveProperty('ownerId');
+  });
+
+  it('spends a use, because free is free of Buzz and of nothing else', async () => {
+    await createStickerPlacement(freeInput);
+
+    expect(spendStickerUsesFor).toHaveBeenCalledWith({
+      userId: PLACER,
+      counts: new Map([[COSMETIC, 1]]),
+    });
+    // After the claim: a spend before it would take a use for a placement the
+    // slot count then refuses.
+    expect(calls).toEqual(['claim', 'spend']);
+  });
+
+  /**
+   * The hazard this path was written around.
+   *
+   * `createFreePlacement` always writes `pending` and never settles, and
+   * sticker's `allowedModes` includes `auto` — so without this the free sticker
+   * sits pending for the full expiry window holding one of the creator's slots,
+   * while the placer has been told it is live and the creator watches a queue
+   * they turned off. Nothing throws in either direction, which is why it is
+   * asserted rather than assumed.
+   */
+  it('approves a free placement on an auto space, which the claim will not do', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue({ ...OPEN_SPACE, mode: 'auto' });
+
+    const result = await createStickerPlacement(freeInput);
+
+    expect(settlePlacement).toHaveBeenCalledWith({
+      placementId: FREE_PLACEMENT,
+      action: 'approve',
+      actorId: OWNER,
+    });
+    expect(result.status).toBe('approved');
+    // Last, so nothing can put a placement live before the use behind it is
+    // spent.
+    expect(calls).toEqual(['claim', 'spend', 'settle:approve']);
+  });
+
+  it('leaves a free placement on a review space pending', async () => {
+    const result = await createStickerPlacement(freeInput);
+
+    expect(settlePlacement).not.toHaveBeenCalled();
+    expect(result.status).toBe('pending');
+  });
+
+  /**
+   * The unwind deletes rather than expiring, and that is a decision about the
+   * placer's day rather than about tidiness: the daily allowance counts on
+   * `createdAt` across every status, so an expired row is indistinguishable
+   * from one a creator declined. A free row has no escrow legs to preserve, so
+   * the delete destroys nothing.
+   */
+  it('deletes the row when the use spend fails, rather than expiring it', async () => {
+    spendStickerUsesFor.mockRejectedValueOnce(new Error('no uses left'));
+
+    await expect(createStickerPlacement(freeInput)).rejects.toThrow(/no uses left/);
+
+    expect(placementDeleteMany).toHaveBeenCalledWith({
+      // Scoped, so a claim someone has since acted on cannot be deleted out
+      // from under them.
+      where: { id: FREE_PLACEMENT, free: true, status: 'pending' },
+    });
+    expect(settlePlacement).not.toHaveBeenCalled();
+  });
+
+  it('does not approve a placement whose use spend failed', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue({ ...OPEN_SPACE, mode: 'auto' });
+    spendStickerUsesFor.mockRejectedValueOnce(new Error('no uses left'));
+
+    await expect(createStickerPlacement(freeInput)).rejects.toThrow(/no uses left/);
+
+    expect(settlePlacement).not.toHaveBeenCalled();
+    expect(calls).toEqual(['claim', 'discard']);
+  });
+
+  it('refuses without spending a use when the claim refuses', async () => {
+    createFreePlacement.mockRejectedValueOnce(
+      new Error('placement: the free slots on this one are taken')
+    );
+
+    await expect(createStickerPlacement(freeInput)).rejects.toThrow(/free slots/);
+
+    expect(spendStickerUsesFor).not.toHaveBeenCalled();
+    expect(placementDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it('places free on a space that has never been priced', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue({ ...OPEN_SPACE, setPrice: null, price: null });
+
+    // The price refusal gates the offer that needs one. A creator can open free
+    // capacity without ever setting a price, and refusing here would close the
+    // free tier on exactly the spaces it was built for.
+    await expect(createStickerPlacement(freeInput)).resolves.toMatchObject({
+      placementId: FREE_PLACEMENT,
+    });
+  });
+
+  it('still refuses a sticker the placer does not own', async () => {
+    queryRaw.mockReset();
+    givenStickerAndBalance({ owned: false, createdById: SELLER });
+
+    await expect(createStickerPlacement(freeInput)).rejects.toThrow(/do not own that sticker/);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  it('still refuses a sticker larger than the creator allows', async () => {
+    await expect(
+      createStickerPlacement({ ...freeInput, data: { ...freeInput.data, scale: 0.99 } })
+    ).rejects.toThrow(/allows stickers up to/);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The removal lock's copy, which was justified by a payment a free row never
+ * made.
+ *
+ * The week itself is unchanged — Justin's call, 2026-08-17 — so what is asserted
+ * here is only that the reason given is true of the row it is given for. A
+ * stated reason that is false is worse than a shorter one, because it is what a
+ * support answer repeats back.
+ */
+describe('the removal lock explains itself truthfully on a free row', () => {
+  const approvedAt = new Date(Date.now() - 60_000);
+  const remove = () =>
+    actOnStickerPlacement({ placementId: PLACEMENT, action: 'remove', userId: OWNER });
+
+  const givenApproved = (free: boolean) =>
+    placementFindUnique.mockResolvedValue({
+      id: PLACEMENT,
+      ownerId: OWNER,
+      placerId: PLACER,
+      targetId: IMAGE,
+      amount: free ? 0 : PRICE,
+      status: 'approved',
+      surface: 'sticker',
+      free,
+      data: { cosmeticId: COSMETIC, x: 0.1, y: 0.1, scale: 0.2, rotation: 0 },
+      createdAt: approvedAt,
+      resolvedAt: approvedAt,
+    });
+
+  it('does not claim someone paid for a free placement', async () => {
+    givenApproved(true);
+
+    await expect(remove()).rejects.toThrow(/commitment to keep it up for a week/);
+    await expect(remove()).rejects.not.toThrow(/paid/);
+  });
+
+  it('keeps the paid reason on a paid placement', async () => {
+    givenApproved(false);
+
+    await expect(remove()).rejects.toThrow(/Someone paid to place it/);
+  });
+
+  it('refuses both for the same week, whatever the reason says', async () => {
+    givenApproved(true);
+
+    await expect(remove()).rejects.toThrow(/can be removed from/);
+    expect(placementUpdateMany).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * What the free claim is actually handed.
+ *
+ * The tests above pin that the claim was CALLED and what happened after. Nothing
+ * pinned the payload, so deleting the normaliser or the note spread left every
+ * one of them green while free stickers landed at unnormalised coordinates, or
+ * silently without the note their placer wrote.
+ */
+describe('the payload handed to the free claim', () => {
+  beforeEach(() => {
+    givenStickerAndBalance();
+  });
+
+  const claimData = () =>
+    (createFreePlacement.mock.calls[0][0] as { data: Record<string, unknown> }).data;
+
+  it('normalises the position rather than forwarding the raw draft', async () => {
+    await createStickerPlacement({
+      ...placeInput,
+      free: true,
+      // Past both bounds on purpose. The normaliser is the only thing between a
+      // drag that ran off the edge and a sticker rendered outside the image.
+      data: { ...placeInput.data, x: 1.4, y: -0.3, rotation: 15 },
+    });
+
+    const data = claimData();
+    expect(data.x).toBeLessThanOrEqual(1);
+    expect(data.x).toBeGreaterThanOrEqual(0);
+    expect(data.y).toBeLessThanOrEqual(1);
+    expect(data.y).toBeGreaterThanOrEqual(0);
+    // The cosmetic comes from the row the server loaded, not from the payload —
+    // the same id either way here, which is why the bounds above are what makes
+    // this test fail on a deleted normaliser.
+    expect(data.cosmeticId).toBe(COSMETIC);
+  });
+
+  it('carries the note the placer wrote', async () => {
+    await createStickerPlacement({
+      ...placeInput,
+      free: true,
+      data: { ...placeInput.data, comment: 'nice one' },
+    });
+
+    expect(claimData().comment).toBe('nice one');
+  });
+
+  /**
+   * Omitted rather than stored empty, so "left the field blank" and "typed only
+   * spaces" are the same row — the property the paid path already has, asserted
+   * here because the free path builds its own payload.
+   */
+  it('omits a note that is only whitespace', async () => {
+    await createStickerPlacement({
+      ...placeInput,
+      free: true,
+      data: { ...placeInput.data, comment: '   ' },
+    });
+
+    expect(claimData()).not.toHaveProperty('comment');
   });
 });

--- a/src/server/services/free-placement.service.ts
+++ b/src/server/services/free-placement.service.ts
@@ -1,0 +1,314 @@
+import type { Prisma } from '@prisma/client';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { getPlacementConfig } from '~/server/services/placement.service';
+import { assertCanPlace } from '~/server/services/placement-moderation.service';
+import {
+  reservedFreeSlots,
+  resolvePlacementSpaceFor,
+} from '~/server/services/placement-space.service';
+import { throwBadRequestError } from '~/server/utils/errorHandling';
+import type {
+  PlacementSpaceEntity,
+  PlacementSpaceMode,
+  PlacementSurface,
+} from '~/shared/utils/placement';
+import {
+  FREE_PLACEMENTS_PER_DAY,
+  PLACEMENT_SURFACES,
+  freePlacementDayStart,
+} from '~/shared/utils/placement';
+
+/**
+ * A placement made against a creator's free capacity instead of paid for.
+ *
+ * The whole free path is here rather than branched into each surface, and that
+ * is the point of this file: **every refusal the paid path makes, plus the three
+ * the free tier adds, in one function**, with the free-tier ones under a lock in
+ * the same transaction as the insert. A surface that built its own row and then
+ * checked would be a second creation route with the checks bolted on the
+ * outside — the guard-versus-filter shape this feature shipped five times in v1.
+ *
+ * Escrow is bypassed **entirely**, not taken at zero. Zero-amount Buzz
+ * transactions are a landmine, and the escrow's two-hold structure has neither a
+ * decline fee nor a principal to hold — `holdPlacementEscrow` refuses a free row
+ * outright for that reason.
+ */
+
+/**
+ * Advisory-lock class keys.
+ *
+ * 🔴 **A free placement takes BOTH, and they must be taken in the order below —
+ * placer, then target.** Two callers acquiring them in opposite orders deadlock:
+ * A holds the placer lock and waits for the target, B holds the target lock and
+ * waits for the placer, and Postgres kills one. That needs two placers claiming
+ * at once, so it will not appear in testing and will appear when the feature is
+ * finally popular.
+ *
+ * The same hazard exists against **any** other lock taken inside this
+ * transaction, of any arity: a deadlock needs a cycle in the waits-for graph,
+ * not a shared key space. Kept unexported alongside the only acquisition site,
+ * with a guard test asserting the whole file list, so ordering is not a rule a
+ * future caller has to know. If you need a lock here, call `createFreePlacement`
+ * rather than export one.
+ */
+const PLACER_LOCK_CLASS = 0x74ee0001;
+const TARGET_LOCK_CLASS = 0x74ee0002;
+
+/**
+ * How long a claim will wait for a lock before failing.
+ *
+ * `pg_advisory_xact_lock` waits forever by default, and Prisma's client-side
+ * timeout does not cancel a backend already blocked inside the lock statement.
+ * Without a bound, a wedged holder accumulates blocked backends on the write
+ * pool rather than failing the claims that are queued behind it.
+ *
+ * ⚠️ Compiled into the statement below rather than bound as a parameter, because
+ * **Postgres has no parameter form for `SET`** — a tagged-template `$executeRaw`
+ * sends `$1` and the statement raises `syntax error at or near "$1"`. Every other
+ * `SET LOCAL` in this repo uses `$executeRawUnsafe` or a raw `client.query` for
+ * the same reason. A module constant, so "unsafe" is about the API's name and not
+ * about anything reaching it from a request.
+ */
+const LOCK_TIMEOUT = '3s';
+
+/**
+ * A stable key for one space, hashed into the target lock.
+ *
+ * The surface is in it because the same image id is a valid target on both
+ * surfaces, and locking on the id alone would serialise a sticker placement
+ * behind an unrelated remix submission. Hash collisions are possible and
+ * harmless — two unrelated spaces sharing one serialise with each other, which
+ * costs a little contention and no correctness.
+ */
+const spaceLockKey = (
+  surface: PlacementSurface,
+  targetType: PlacementSpaceEntity,
+  targetId: number
+) => `${surface}:${targetType}:${targetId}`;
+
+type PlacementClient = Pick<typeof dbWrite, 'placement'>;
+type SpaceTarget = {
+  surface: PlacementSurface;
+  targetType: PlacementSpaceEntity;
+  targetId: number;
+};
+
+/**
+ * The daily entitlement, as one predicate.
+ *
+ * Every status, deliberately: a decline or an expiry gives the image's slot back
+ * but NOT the placer's day, because refunding the day turns the free tier into
+ * an unlimited retry loop against whoever declines fastest. Every surface, too —
+ * the allowance is one placement a day across the site, not one per surface.
+ *
+ * Written once because the claim decides on it and the UI displays it. Scope it
+ * by status later in one of two copies and the surface offers a placement the
+ * mutation refuses.
+ */
+const countFreePlacementsToday = (client: PlacementClient, placerId: number) =>
+  client.placement.count({
+    where: { placerId, free: true, createdAt: { gte: freePlacementDayStart() } },
+  });
+
+/**
+ * Never twice on the same target by the same placer, as one predicate.
+ *
+ * Once ever: not once per day, and not scoped by status. An image posted and
+ * deleted daily is otherwise a farm for one account's alts. Scoped to this
+ * surface, because placing a sticker and submitting a remix are different acts
+ * on the same image and one should not consume the other — and the daily
+ * allowance already makes that pair cost two days, so it raises no farm rate.
+ *
+ * Shared with the display path for the same reason as the daily count.
+ */
+const countFreePlacementsOn = (
+  client: PlacementClient,
+  { placerId, surface, targetType, targetId }: SpaceTarget & { placerId: number }
+) => client.placement.count({ where: { placerId, free: true, surface, targetType, targetId } });
+
+export type CreateFreePlacement = SpaceTarget & {
+  placerId: number;
+  /** Who sold the placed thing, when an approval would owe them a cut. */
+  sellerId?: number | null;
+  /** The surface's own payload. Opaque here, exactly as on the paid path. */
+  data: Prisma.InputJsonValue;
+};
+
+/**
+ * Claims a free slot and creates the placement, or refuses.
+ *
+ * **The space is resolved here, from the target, rather than passed in.** A
+ * caller-supplied space and a separate `targetId` are two facts that can
+ * disagree: a caller resolving once and looping would write a placement onto
+ * image B carrying image A's owner, so the review queue and every payout
+ * attribution would belong to the wrong creator, with nothing raising. Resolving
+ * from the one identifier makes that unrepresentable rather than merely
+ * unlikely. It costs one extra resolution on a mutation path.
+ *
+ * **The race is closed by two transaction-scoped advisory locks, not by a unique
+ * constraint.** Neither free-tier rule is expressible as one: "at most N held
+ * free rows on this target" and "at most one free row for this placer today" are
+ * both counts, and Postgres has no partial-unique form for a count. The
+ * alternatives were a serializable transaction, which turns a lost race into a
+ * retry every caller has to write, and `withDistributedLock`, which returns null
+ * rather than running when Redis is down — free placements would then be refused
+ * during a Redis outage while the paid path kept working. An advisory lock needs
+ * no extra infrastructure, releases on commit or rollback with nothing to leak,
+ * and makes count-then-insert atomic without holding a row lock on `Placement`.
+ *
+ * The placer's own check sits between the two acquisitions on purpose. Taking
+ * the shared target lock first would queue every placer who has already spent
+ * their day behind a contended lock to learn a fact about nobody but themselves.
+ *
+ * The deadline is computed BEFORE the transaction opens and written by the same
+ * insert. `holdPlacementEscrow` stamps the paid path's deadline in a second
+ * statement, and its comment explains what a throw between the two costs: a
+ * pending row with a NULL `expiresAt` is never `<= now()`, so the expiry sweep
+ * steps over it forever. On the free path that row would also hold one of the
+ * creator's slots for good, so there is no window at all.
+ */
+export async function createFreePlacement({
+  surface,
+  targetType,
+  targetId,
+  placerId,
+  sellerId,
+  data,
+}: CreateFreePlacement) {
+  const target = { surface, targetType, targetId };
+  const space = await resolvePlacementSpaceFor(target);
+
+  // Everything the paid path refuses, refused here too. The free path is not a
+  // lighter version of placement — it is placement that costs no Buzz, and every
+  // rule about who may place on whom is untouched by the price being zero.
+  //
+  // Two separate refusals that read as one. `off` is a valid stored mode, so it
+  // is IN `allowedModes` — the table says what may be written, not what may be
+  // placed into. A mode outside the table is the other case: a gallery row saying
+  // `auto` predates the rule that galleries always review, and would otherwise
+  // put arbitrary media live unreviewed. Both are refused where the placement is
+  // made, not only where the setting is stored.
+  const allowedModes = PLACEMENT_SURFACES[surface].allowedModes as readonly PlacementSpaceMode[];
+  if (space.mode === 'off' || !allowedModes.includes(space.mode))
+    throw throwBadRequestError('placement: this creator is not accepting placements here');
+
+  // Refused rather than allowed-because-it-is-free. On the paid path this is a
+  // product decision and not an accounting one — free self-placement would be
+  // the creator filling their own slots so nobody else can have them, which
+  // defeats the scarcity the whole feature is built on.
+  if (space.ownerId === placerId)
+    throw throwBadRequestError('placement: you cannot place on your own content');
+
+  if (space.freeSlots <= 0)
+    throw throwBadRequestError('placement: this creator is not taking free placements here');
+
+  // Outside the transaction: it is I/O, which `no-io-in-transaction` guards, and
+  // it reads the primary so a suspension or a block committed seconds ago
+  // refuses rather than being one replica-lag behind.
+  //
+  // The suspension half is the one the free path could not do without. A block
+  // declines the rows pending when it lands; a moderator suspension is the only
+  // thing that stops tomorrow's placement, and without this call a suspended
+  // placer keeps placing free ones forever.
+  await assertCanPlace({ ownerId: space.ownerId, placerId });
+
+  // Read before the transaction opens, for the same no-I/O reason. It falls back
+  // to the compiled defaults rather than throwing, so there is no path where
+  // this leaves the deadline unset.
+  const expiryHours = (await getPlacementConfig()).expiryHours(surface);
+  const expiresAt = new Date(Date.now() + expiryHours * 3_600_000);
+
+  return dbWrite.$transaction(async (tx) => {
+    await tx.$executeRawUnsafe(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(${PLACER_LOCK_CLASS}::int, ${placerId}::int)`;
+
+    const usedToday = await countFreePlacementsToday(tx, placerId);
+    if (usedToday >= FREE_PLACEMENTS_PER_DAY)
+      throw throwBadRequestError(
+        'placement: you have used your free placement for today. It resets at midnight UTC.'
+      );
+
+    // Per (owner, placer), so the placer lock above already serialises it. The
+    // paid path's cap, applied here for the same reason: it bounds a review
+    // queue an owner can actually work through, and the owner's remedy for the
+    // rest is block.
+    const pending = await tx.placement.count({
+      where: { surface, ownerId: space.ownerId, placerId, status: 'pending' },
+    });
+    if (pending >= PLACEMENT_SURFACES[surface].maxPendingPerOwner)
+      throw throwBadRequestError(
+        'placement: you already have the maximum pending placements with this creator'
+      );
+
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(${TARGET_LOCK_CLASS}::int, hashtext(${spaceLockKey(
+      surface,
+      targetType,
+      targetId
+    )}))`;
+
+    const already = await countFreePlacementsOn(tx, { placerId, ...target });
+    if (already > 0)
+      throw throwBadRequestError(
+        `placement: you have already used a free placement here. Free ${PLACEMENT_SURFACES[surface].label} are once per image.`
+      );
+
+    // Re-counted inside the lock. `space.freeSlotsRemaining` is what a surface
+    // shows someone; this is what decides.
+    const reserved = await reservedFreeSlots(tx, target);
+    if (reserved >= space.freeSlots)
+      throw throwBadRequestError('placement: the free slots on this one are taken');
+
+    return tx.placement.create({
+      data: {
+        surface,
+        targetType,
+        targetId,
+        ownerId: space.ownerId,
+        placerId,
+        sellerId: sellerId ?? null,
+        free: true,
+        // Zero, and the DB enforces it. Nothing sizes a payout from this — the
+        // money path reads receipted holds, of which there are none — but every
+        // report and every support answer quotes it, and a free placement
+        // carrying a price says a creator earned something they did not.
+        amount: 0,
+        status: 'pending',
+        expiresAt,
+        data,
+      },
+      select: { id: true },
+    });
+  });
+}
+
+/**
+ * Where a placer stands against their daily allowance.
+ *
+ * For surfaces that need to say so before someone commits — the free/paid choice
+ * is worth making with the number visible, and an allowance spent silently is
+ * the worst version of a scarce thing.
+ *
+ * **A listing, not a guard.** It is stale the moment it returns, reads a replica,
+ * and the refusal lives in `createFreePlacement` under the lock. Do not gate a
+ * mutation on it.
+ */
+export async function getFreePlacementAllowance({ placerId }: { placerId: number }) {
+  const dayStart = freePlacementDayStart();
+  const used = await countFreePlacementsToday(dbRead, placerId);
+
+  return {
+    used,
+    remaining: Math.max(FREE_PLACEMENTS_PER_DAY - used, 0),
+    /** Midnight UTC ending the current day, when the allowance comes back. */
+    resetsAt: new Date(dayStart.getTime() + 24 * 3_600_000),
+  };
+}
+
+/**
+ * Whether this placer has already spent a free placement on this target.
+ *
+ * Same standing as the allowance above: a listing for the surface to render,
+ * never the thing a mutation decides on.
+ */
+export const hasUsedFreePlacementOn = async (input: SpaceTarget & { placerId: number }) =>
+  (await countFreePlacementsOn(dbRead, input)) > 0;

--- a/src/server/services/placement-escrow.service.ts
+++ b/src/server/services/placement-escrow.service.ts
@@ -425,6 +425,20 @@ export async function holdPlacementEscrow({
   if (!Number.isSafeInteger(amount) || amount < 0)
     throw new Error(`placement escrow: amount must be a non-negative integer, got ${amount}`);
 
+  // A free placement must never reach the escrow, even for zero. `amount === 0`
+  // returns harmlessly below, so this is not about the money — it is about
+  // `expiresAt` and `spendType` being stamped by whichever path made the row, and
+  // about a caller that reached here having taken the wrong branch somewhere
+  // upstream. Refused on the mutation rather than absorbed, because absorbing it
+  // is how the free path silently acquires a second, half-built creation route.
+  const row = await dbWrite.placement.findUnique({
+    where: { id: placementId },
+    select: { free: true },
+  });
+  if (!row) throw new Error(`placement escrow: placement ${placementId} not found`);
+  if (row.free)
+    throw new Error(`placement escrow: placement ${placementId} is free and takes no escrow`);
+
   // Stamped from the surface's compiled default BEFORE the config is read.
   // `getPlacementConfig` touches KeyValue, so it can throw — and a throw here
   // used to leave a pending row with a null `expiresAt`, which is never
@@ -678,6 +692,16 @@ async function payoutLegsFor(
   placement: PlacementRow,
   held: Map<string, number>
 ): Promise<PlannedLeg[]> {
+  // A free placement never entered escrow, so there is nothing to release on any
+  // path: no principal, no decline fee, no seller split, no forfeit.
+  //
+  // Stated rather than left to arithmetic. Every branch below already computes to
+  // zero from the empty `held` map and would be filtered out before persisting —
+  // but that is a property of four separate expressions all happening to reduce
+  // to nothing, which the next person to add a leg has to rediscover. The row
+  // says it is free; this says what free means, once.
+  if (placement.free) return [];
+
   const fee = held.get('holdFee') ?? 0;
   const principal = held.get('holdPrincipal') ?? 0;
   const outcome = placementOutcomeFromStatus(

--- a/src/server/services/placement-escrow.service.ts
+++ b/src/server/services/placement-escrow.service.ts
@@ -11,6 +11,7 @@ import {
   createMultiAccountBuzzTransaction,
   refundMultiAccountTransaction,
 } from '~/server/services/buzz.service';
+import { stickerPlacementAcceptedReward } from '~/server/rewards/active/stickerPlacementAccepted.reward';
 import { getPlacementConfig } from '~/server/services/placement.service';
 import { withDistributedLock } from '~/server/utils/distributed-lock';
 import { isPlacementSpendType } from '~/shared/constants/placement.constants';
@@ -623,7 +624,55 @@ export async function settlePlacement({
 
   await payOutPlacement(placement);
 
+  if (count > 0 && status === 'approved') await rewardAccepted(placement);
+
   return { settled: count > 0, placement };
+}
+
+/**
+ * The owner's reward for accepting a placement onto their space.
+ *
+ * Hung off `count > 0` rather than off the approve callers: that is the settle
+ * whose `WHERE status = 'pending'` matched, and it happens exactly once per
+ * placement no matter how many approvals race or how often a caller retries. The
+ * reward's ledger key never expires while its daily cap does, so a second
+ * presentation of the same placement would silently burn a tenth of the owner's
+ * day and pay nothing.
+ *
+ * 🔴 **Sticker only, and no other surface may be added here.** The remix gallery
+ * reward is granted from `actOnRemixGallerySubmission`, which is the only way a
+ * remix submission is approved. A `remixGallery` branch in this function would
+ * not replace that call, it would double it — and nothing downstream catches a
+ * double: the two reward types have different `externalTransactionId`s, and the
+ * daily cap hash is keyed `userId:type`, so both grants look legitimate to every
+ * guard either reward has. A surface whose approvals arrive only through its own
+ * action handler belongs there, not here.
+ *
+ * After the payout, so a reward failure can never be why an approved placement
+ * went unpaid — and swallowed, because the money has already moved and a throw
+ * would 500 an approval that succeeded. Note what that costs: `base.reward`
+ * deliberately rethrows a genuine ClickHouse schema break so it surfaces as a
+ * 500, and this `.catch` takes that away. Such a break arrives here as an Axiom
+ * error rather than an alerting one, which is the trade this call site makes.
+ */
+async function rewardAccepted(placement: PlacementRow) {
+  if (placement.surface !== 'sticker') return;
+
+  await stickerPlacementAcceptedReward
+    .apply({
+      placementId: placement.id,
+      ownerId: placement.ownerId,
+      placerId: placement.placerId,
+    })
+    .catch((error) =>
+      logToAxiom({
+        name: 'placement-escrow',
+        type: 'error',
+        message: 'accept reward failed',
+        placementId: placement.id,
+        error: error instanceof Error ? error.message : String(error),
+      }).catch(() => null)
+    );
 }
 
 type PlacementRow = NonNullable<Awaited<ReturnType<typeof dbWrite.placement.findUnique>>>;

--- a/src/server/services/placement-space.service.ts
+++ b/src/server/services/placement-space.service.ts
@@ -10,7 +10,9 @@ import type {
   PlacementSurface,
 } from '~/shared/utils/placement';
 import {
+  effectiveFreeSlots,
   effectivePlacementPrice,
+  FREE_SLOT_HOLDING_STATUSES,
   PLACEMENT_SURFACES,
   resolvePlacementSpace,
   surfaceAcceptsTarget,
@@ -68,9 +70,67 @@ export type ResolvedPlacementSpace = {
    * stop being true.
    */
   ownerShare: number;
+  /**
+   * The count the cascade resolved, before the cap — the same relationship
+   * `setPrice` has to `price`, so a caller can say "you have set 9, we are
+   * honouring 2" rather than only showing the smaller number.
+   */
+  setFreeSlots: number;
+  /** `min(setFreeSlots, freeSlotCap)`, computed here and never stored. */
+  freeSlots: number;
+  freeSlotCap: number;
+  /**
+   * How many free placements this space will still accept, right now.
+   *
+   * Never negative. A creator who lowers their slider below what is already
+   * reserved is not taking anything back — the placements they already accepted
+   * stay — so the space simply accepts nothing further until they release.
+   *
+   * ⚠️ This is what a caller SHOWS. It is not what a caller may decide on: by the
+   * time it is read the count is already stale. The refusal lives in
+   * `createFreePlacement`, which re-counts under a lock in the same transaction
+   * that inserts.
+   */
+  freeSlotsRemaining: number;
   /** Surface-owned; this layer carries it without reading inside it. */
   settings: PlacementSpaceSettings;
 };
+
+/**
+ * How many of a space's free slots are spoken for.
+ *
+ * Pending counts, and that is the whole feature: a free placement holds its slot
+ * from the moment it is made. Without it fifty people submit into four slots and
+ * the creator gets a fifty-item review queue — the exact outcome the slider
+ * exists to prevent. Declined, expired and removed rows are absent from the
+ * status list, so a released slot is claimable by the next caller with no sweep
+ * in between.
+ *
+ * Paid placements are not counted. The two counters are independent, so a
+ * fully-booked paid image still shows its free slots as available.
+ */
+export const reservedFreeSlots = (
+  /**
+   * Narrowed to the one model it touches so a transaction client satisfies it.
+   * The claim MUST pass its `tx` — counting on any other connection would read
+   * outside the lock it just took, and the count would be a listing again.
+   */
+  client: Pick<typeof dbWrite, 'placement'>,
+  {
+    surface,
+    targetType,
+    targetId,
+  }: { surface: PlacementSurface; targetType: PlacementSpaceEntity; targetId: number }
+) =>
+  client.placement.count({
+    where: {
+      surface,
+      targetType,
+      targetId,
+      free: true,
+      status: { in: [...FREE_SLOT_HOLDING_STATUSES] },
+    },
+  });
 
 /**
  * The space that governs one target, with the cascade already applied.
@@ -102,7 +162,7 @@ export async function resolvePlacementSpaceFor({
         { entityType: 'user', entityId: ownerId },
       ],
     },
-    select: { entityType: true, mode: true, price: true, settings: true },
+    select: { entityType: true, mode: true, price: true, freeSlots: true, settings: true },
   });
 
   const at = (entityType: PlacementSpaceEntity): PlacementSpaceSetting | undefined => {
@@ -111,6 +171,7 @@ export async function resolvePlacementSpaceFor({
       ? {
           mode: row.mode as PlacementSpaceMode,
           price: row.price,
+          freeSlots: row.freeSlots,
           settings: (row.settings ?? {}) as PlacementSpaceSettings,
         }
       : undefined;
@@ -122,8 +183,25 @@ export async function resolvePlacementSpaceFor({
     user: at('user'),
   });
 
-  const { max: cap } = await placementPriceRange(ownerId, surface);
+  const { max: cap, freeSlotCap } = await placementPriceRange(ownerId, surface);
   const shares = (await getPlacementConfig()).approvalShares(surface);
+
+  // `resolvePlacementSpace` is the one place the surface default is applied, so
+  // this reads it rather than defaulting again — the same shape as `setPrice`
+  // directly above.
+  const setFreeSlots = resolved.freeSlots;
+  const freeSlots = effectiveFreeSlots(setFreeSlots, freeSlotCap);
+  // `dbRead`, unlike everything above it. The rest of this function decides
+  // whether a mutation is allowed and what it charges, which a lagging replica
+  // must not answer; `freeSlotsRemaining` is display-only by construction — the
+  // claim re-counts under its own lock — and this read is on a public query
+  // reached from every image detail view.
+  //
+  // Skipped when there is no capacity to reserve against. That is rarer than it
+  // looks: the default and the bottom band are both 1, so it fires only for a
+  // creator who has explicitly closed their slots.
+  const reserved =
+    freeSlots > 0 ? await reservedFreeSlots(dbRead, { surface, targetType, targetId }) : 0;
 
   return {
     ownerId,
@@ -133,6 +211,10 @@ export async function resolvePlacementSpaceFor({
     price: effectivePlacementPrice(resolved.price, cap),
     cap,
     ownerShare: 1 - shares.seller - shares.platform,
+    setFreeSlots,
+    freeSlots,
+    freeSlotCap,
+    freeSlotsRemaining: Math.max(freeSlots - reserved, 0),
     settings: resolved.settings ?? {},
   };
 }
@@ -175,6 +257,7 @@ export async function setPlacementSpace({
   entityId,
   mode,
   price,
+  freeSlots,
   settings,
   userId,
 }: {
@@ -183,6 +266,17 @@ export async function setPlacementSpace({
   entityId: number;
   mode: PlacementSpaceMode;
   price?: number | null;
+  /**
+   * `undefined` leaves this level's count alone, `null` clears it so the level
+   * inherits again, and a number sets it — the same three-way distinction
+   * `price` carries, for the same reason: an unset count follows the surface
+   * default when that moves, where a stored one freezes today's.
+   *
+   * Stored uncapped. The score/tier ceiling is applied at read, exactly like the
+   * price cap, so a creator whose tier lapses and returns gets their number back
+   * rather than having found it silently rewritten.
+   */
+  freeSlots?: number | null;
   settings?: PlacementSpaceSettings;
   userId: number;
 }) {
@@ -230,9 +324,7 @@ export async function setPlacementSpace({
   // the floor; lets an existing one be carried.
   const floor = PLACEMENT_SURFACES[surface].serverMinPrice;
   if (price != null && price < floor && price !== existing?.price)
-    throw throwBadRequestError(
-      `placement: the lowest you can charge is ${floor} Buzz`
-    );
+    throw throwBadRequestError(`placement: the lowest you can charge is ${floor} Buzz`);
 
   await dbWrite.placementSpace.upsert({
     where: { surface_entityType_entityId: { surface, entityType, entityId } },
@@ -242,11 +334,13 @@ export async function setPlacementSpace({
       entityId,
       mode,
       price: price ?? null,
+      freeSlots: freeSlots ?? null,
       settings: (settings ?? {}) as Prisma.InputJsonValue,
     },
     update: {
       mode,
       ...(price === undefined ? {} : { price }),
+      ...(freeSlots === undefined ? {} : { freeSlots }),
       // Replaced wholesale, not merged: the caller sends the settings it owns,
       // and a merge here would make a removed key impossible to express.
       ...(settings === undefined ? {} : { settings: settings as Prisma.InputJsonValue }),
@@ -308,7 +402,14 @@ export const getPlacementSpaces = ({
 }) =>
   dbRead.placementSpace.findMany({
     where: { surface, entityType: 'user', entityId: userId },
-    select: { entityType: true, entityId: true, mode: true, price: true, settings: true },
+    select: {
+      entityType: true,
+      entityId: true,
+      mode: true,
+      price: true,
+      freeSlots: true,
+      settings: true,
+    },
   });
 
 /**
@@ -334,7 +435,7 @@ export async function getPlacementSpaceRow({
 
   return dbRead.placementSpace.findUnique({
     where: { surface_entityType_entityId: { surface, entityType, entityId } },
-    select: { mode: true, price: true, settings: true },
+    select: { mode: true, price: true, freeSlots: true, settings: true },
   });
 }
 

--- a/src/server/services/placement.service.ts
+++ b/src/server/services/placement.service.ts
@@ -6,8 +6,10 @@ import type { PlacementPriceTier, PlacementSurface } from '~/shared/utils/placem
 import {
   clampApprovalShares,
   clampDeclineFeeRate,
+  PLACEMENT_FREE_SLOT_CAP_TIERS,
   PLACEMENT_PRICE_CAP_TIERS,
   PLACEMENT_SURFACES,
+  placementFreeSlotCap,
   placementPriceCap,
 } from '~/shared/utils/placement';
 
@@ -34,6 +36,8 @@ const placementConfigSchema = z.object({
   priceCapTiers: z.array(priceCapTierSchema).min(1).optional(),
   /** Per-surface override, so stickers and galleries can be priced apart later. */
   priceCapTiersBySurface: z.record(z.string(), z.array(priceCapTierSchema).min(1)).optional(),
+  freeSlotTiers: z.array(priceCapTierSchema).min(1).optional(),
+  freeSlotTiersBySurface: z.record(z.string(), z.array(priceCapTierSchema).min(1)).optional(),
   approvalShares: z
     .record(
       z.string(),
@@ -46,6 +50,8 @@ export type PlacementConfig = {
   declineFeeRate: (surface: PlacementSurface) => number;
   expiryHours: (surface: PlacementSurface) => number;
   priceCapTiers: (surface: PlacementSurface) => PlacementPriceTier[];
+  /** Same table shape and same resolver as the price caps — see the constant. */
+  freeSlotTiers: (surface: PlacementSurface) => PlacementPriceTier[];
   /** The only producer of the approved-placement shares. Nothing may pass its own. */
   approvalShares: (surface: PlacementSurface) => { seller: number; platform: number };
 };
@@ -79,7 +85,15 @@ export async function getPlacementConfig(): Promise<PlacementConfig> {
     expiryHours: (surface) =>
       clampExpiryHours(stored.expiryHours?.[surface], PLACEMENT_SURFACES[surface].expiryHours),
     priceCapTiers: (surface) =>
-      usablePriceCapTiers(stored.priceCapTiersBySurface?.[surface] ?? stored.priceCapTiers),
+      usableCapTiers(
+        stored.priceCapTiersBySurface?.[surface] ?? stored.priceCapTiers,
+        PLACEMENT_PRICE_CAP_TIERS
+      ),
+    freeSlotTiers: (surface) =>
+      usableCapTiers(
+        stored.freeSlotTiersBySurface?.[surface] ?? stored.freeSlotTiers,
+        PLACEMENT_FREE_SLOT_CAP_TIERS
+      ),
     approvalShares: (surface) =>
       clampApprovalShares(stored.approvalShares?.[surface] ?? {}, {
         seller: PLACEMENT_SURFACES[surface].defaultSellerShare,
@@ -91,14 +105,24 @@ export async function getPlacementConfig(): Promise<PlacementConfig> {
 export type PlacementPriceRange = {
   min: number;
   max: number;
+  /**
+   * The most free placements this creator may accept on one space.
+   *
+   * Carried here rather than on its own query because it is decided by the same
+   * two facts — creator score and membership tier — and both are one round trip
+   * each. A second endpoint would double that cost to answer with the same
+   * numbers, and would be free to disagree about them.
+   */
+  freeSlotCap: number;
   score: number;
   tier: 'free' | MembershipTier;
 };
 
 /**
- * The single authority on what a creator may charge. D and E must not each
- * reimplement the score-and-tier scaling, and nothing may persist the result —
- * the cap moves the moment a membership lapses or a score is recomputed.
+ * The single authority on what a creator may charge, and on how much free
+ * capacity they may offer. D and E must not each reimplement the score-and-tier
+ * scaling, and nothing may persist the result — the caps move the moment a
+ * membership lapses or a score is recomputed.
  */
 export async function placementPriceRange(
   userId: number,
@@ -127,6 +151,7 @@ export async function placementPriceRange(
   return {
     min: PLACEMENT_SURFACES[surface].serverMinPrice,
     max: placementPriceCap(score, tier, config.priceCapTiers(surface)),
+    freeSlotCap: placementFreeSlotCap(score, tier, config.freeSlotTiers(surface)),
     score,
     tier,
   };
@@ -150,8 +175,8 @@ const clampExpiryHours = (hours: number | undefined, fallback: number) => {
  * it a cap of 0, i.e. a space nobody can be charged for. It fails toward free
  * rather than toward overcharging, but silently, and the schema can't see it.
  */
-const usablePriceCapTiers = (tiers: PlacementPriceTier[] | undefined) =>
-  tiers?.some((tier) => tier.minScore === 0) ? tiers : PLACEMENT_PRICE_CAP_TIERS;
+const usableCapTiers = (tiers: PlacementPriceTier[] | undefined, fallback: PlacementPriceTier[]) =>
+  tiers?.some((tier) => tier.minScore === 0) ? tiers : fallback;
 
 const MEMBERSHIP_TIERS: MembershipTier[] = ['bronze', 'silver', 'gold'];
 

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -7,6 +7,11 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { remixAcceptReward } from '~/server/rewards/active/remixAccept.reward';
 import { getAllImages } from '~/server/services/image.service';
+import {
+  createFreePlacement,
+  getFreePlacementAllowance,
+  hasUsedFreePlacementOn,
+} from '~/server/services/free-placement.service';
 import { holdPlacementEscrow, settlePlacement } from '~/server/services/placement-escrow.service';
 import { assertCanPlace } from '~/server/services/placement-moderation.service';
 import { getPlacementConfig } from '~/server/services/placement.service';
@@ -59,6 +64,37 @@ type SubmissionImage = {
 };
 
 /**
+ * The ids the server verified this image was generated from.
+ *
+ * One definition, used by the mutation that decides and by the listing that
+ * offers — because "is this a remix of that" has to mean the same thing in both
+ * or the picker offers what the claim refuses.
+ *
+ * ⚠️ Not interchangeable with a bare `@>` containment test on the raw JSON, which
+ * is what a second copy naturally becomes. `'7'::jsonb @> '7'::jsonb` is true
+ * (scalar containment is equality), so a non-array value would read as a match
+ * where this yields `[]`; an array of strings goes the other way, matching here
+ * after the cast and not there. They agree today only because
+ * `sanitizeProvenance` happens to write an integer array.
+ *
+ * Parameterised by alias rather than written twice, for the reason `hostIsMinor`
+ * is: a hand-written duplicate is exactly the shape that drifts silently.
+ */
+const sourceImageIdsSql = (alias = 'i') => {
+  const t = Prisma.raw(`"${alias}"`);
+  return Prisma.sql`ARRAY(
+    SELECT (value #>> '{}')::int
+    FROM jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(${t}.meta -> 'extra' -> 'sourceImageIds') = 'array'
+        THEN ${t}.meta -> 'extra' -> 'sourceImageIds'
+        ELSE '[]'::jsonb
+      END
+    )
+  )`;
+};
+
+/**
  * The submitted image, from the primary, with everything the refusals need.
  *
  * `dbWrite` rather than a replica for the same reason `assertCanPlace` uses it:
@@ -71,16 +107,7 @@ async function loadSubmissionImage(imageId: number): Promise<SubmissionImage> {
            i.ingestion::text AS ingestion, i."needsReview",
            p."publishedAt",
            (i.meta -> 'extra' ->> 'remixOfId')::int AS "remixOfId",
-           ARRAY(
-             SELECT (value #>> '{}')::int
-             FROM jsonb_array_elements(
-               CASE
-                 WHEN jsonb_typeof(i.meta -> 'extra' -> 'sourceImageIds') = 'array'
-                 THEN i.meta -> 'extra' -> 'sourceImageIds'
-                 ELSE '[]'::jsonb
-               END
-             )
-           ) AS "sourceImageIds"
+           ${sourceImageIdsSql()} AS "sourceImageIds"
     FROM "Image" i
     LEFT JOIN "Post" p ON p.id = i."postId"
     WHERE i.id = ${imageId}
@@ -123,12 +150,32 @@ export type CreateRemixGallerySubmission = {
   /** What the submitter was shown. Refused if the owner has moved it since. */
   expectedPrice?: number;
   /**
+   * Spend the placer's daily free placement instead of Buzz. Allowed only for a
+   * remix this server itself resolved as derived from the host image.
+   */
+  free?: boolean;
+  /**
    * The domain's currency, decided at the router from the request's own feature
    * flags rather than anything the client sends — a client-supplied currency
    * would let a request on one domain spend the other's Buzz.
    */
   spendType: BuzzSpendType;
 };
+
+/**
+ * Why an unverified remix cannot be submitted free.
+ *
+ * Names the alternative rather than only the refusal: paying is what buys a slot
+ * in someone's review queue when the server cannot tell that the submission came
+ * from their image, and a bare "not eligible" reads as a bug on a remix the
+ * submitter knows they made.
+ *
+ * It does not say the submission "is not a remix" — an off-site remix is a real
+ * remix that carries no signal, and calling it otherwise is both wrong and an
+ * accusation.
+ */
+const FREE_NEEDS_VERIFIED_REFUSAL =
+  'remix gallery: free submissions are for remixes made from this image on-site, which is something we can check. Submit this one with Buzz instead.';
 
 /**
  * Submits an image into someone's remix gallery, charging the owner's price.
@@ -141,13 +188,15 @@ export type CreateRemixGallerySubmission = {
  * settle also fails.
  *
  * Nothing here consumes an inventory item; unlike a sticker, the thing being
- * placed is content the submitter already owns.
+ * placed is content the submitter already owns. That is also why the free path
+ * below has no unwind: there is no second write to fail after the row exists.
  */
 export async function createRemixGallerySubmission({
   placerId,
   hostImageId,
   imageId,
   expectedPrice,
+  free = false,
   spendType,
 }: CreateRemixGallerySubmission) {
   if (hostImageId === imageId)
@@ -169,26 +218,6 @@ export async function createRemixGallerySubmission({
 
   if (space.ownerId === placerId)
     throw throwBadRequestError('remix gallery: you cannot submit to your own gallery');
-
-  if (space.price == null)
-    throw throwBadRequestError('remix gallery: this creator has not set a price yet');
-
-  // `setPlacementSpace` refuses to write a price below the floor, but it lets an
-  // existing lower one be carried, so a row predating the rule still reads back
-  // here — and the floor is the only spam gate this surface has, since nothing
-  // verifies a submission is really a remix. Refused rather than rounded up:
-  // charging more than the number the submitter was shown is the thing
-  // `expectedPrice` below exists to prevent.
-  if (space.price < PLACEMENT_SURFACES[SURFACE].serverMinPrice)
-    throw throwBadRequestError('remix gallery: this gallery is not priced for submissions');
-
-  // Refused rather than charged. The client can only check affordability against
-  // the number it rendered, so charging a price the submitter never saw is a
-  // spend without consent — and an owner can move their price at any time.
-  if (expectedPrice != null && expectedPrice !== space.price)
-    throw throwBadRequestError(
-      `remix gallery: the price changed to ${space.price} Buzz while you were deciding`
-    );
 
   const submission = await loadSubmissionImage(imageId);
   if (submission.userId !== placerId)
@@ -226,6 +255,75 @@ export async function createRemixGallerySubmission({
         : "remix gallery: this creator only accepts submissions rated at or below their image's rating"
     );
 
+  // The server's own answer, from ids `sanitizeProvenance` wrote — a submitter
+  // cannot assert this by editing their image's meta. It is what the free path
+  // is gated on, so where it comes from decides whether that gate is real.
+  const derivedFromHost = submission.sourceImageIds?.includes(hostImageId) ?? false;
+
+  // Refused here, on the mutation, and deliberately not only by hiding the free
+  // option: a listing that filters is not a mutation that refuses, and this one
+  // decides whether someone gets into a creator's review queue without paying.
+  if (free && !derivedFromHost) throw throwBadRequestError(FREE_NEEDS_VERIFIED_REFUSAL);
+
+  const data = {
+    imageId,
+    remixOfId: submission.remixOfId,
+    // Present only when the server itself resolved this host image as an input
+    // to the generation. Left off rather than set false: "made elsewhere" and
+    // "no signal" are the same state, and the owner-review UI must keep saying
+    // nothing about either.
+    ...(derivedFromHost ? { derivedFromHost: true } : {}),
+  } satisfies RemixGalleryPlacementData;
+
+  // Before the branch, so a free submission cannot occupy a second slot of the
+  // same gallery with the same picture — `createFreePlacement` bounds free rows
+  // per placer and per target, which is a different question from this one.
+  await assertNotAlreadySubmitted({ hostImageId, imageId });
+
+  // Every remaining refusal — mode, self-placement, `assertCanPlace`, the
+  // per-owner pending cap — is made by `createFreePlacement` under its lock, in
+  // the same transaction as the insert. Repeating them here would be a second
+  // creation route with the checks bolted on the outside.
+  //
+  // No settle afterwards, and that is checked rather than assumed: `auto` is
+  // refused for this surface where a space is stored (`placementSpaceSchema`),
+  // where a submission is made (above), and by `createFreePlacement` itself
+  // against `allowedModes`. So a free submission here is always pending and
+  // always the owner's to answer.
+  if (free)
+    return createFreePlacement({
+      surface: SURFACE,
+      targetType: TARGET_TYPE,
+      targetId: hostImageId,
+      placerId,
+      data,
+    });
+
+  // Every rule from here down is the paid path's, which is why none of them is
+  // reached above. The floor in particular exists because the price is this
+  // surface's only spam gate — nothing verifies that a *paid* submission is
+  // really a remix — and a free one is gated on the server having verified
+  // exactly that, plus the creator's slots and the placer's daily allowance.
+  // Refusing a free submission because a legacy row is priced at 40 would refuse
+  // it for a reason that does not apply to it.
+  if (space.price == null)
+    throw throwBadRequestError('remix gallery: this creator has not set a price yet');
+
+  // `setPlacementSpace` refuses to write a price below the floor, but it lets an
+  // existing lower one be carried, so a row predating the rule still reads back
+  // here. Refused rather than rounded up: charging more than the number the
+  // submitter was shown is the thing `expectedPrice` exists to prevent.
+  if (space.price < PLACEMENT_SURFACES[SURFACE].serverMinPrice)
+    throw throwBadRequestError('remix gallery: this gallery is not priced for submissions');
+
+  // Refused rather than charged. The client can only check affordability against
+  // the number it rendered, so charging a price the submitter never saw is a
+  // spend without consent — and an owner can move their price at any time.
+  if (expectedPrice != null && expectedPrice !== space.price)
+    throw throwBadRequestError(
+      `remix gallery: the price changed to ${space.price} Buzz while you were deciding`
+    );
+
   await assertCanPlace({ ownerId: space.ownerId, placerId });
 
   const pending = await dbWrite.placement.count({
@@ -235,8 +333,6 @@ export async function createRemixGallerySubmission({
     throw throwBadRequestError(
       'remix gallery: you already have the maximum submissions waiting with this creator'
     );
-
-  await assertNotAlreadySubmitted({ hostImageId, imageId });
 
   const placement = await dbWrite.placement.create({
     data: {
@@ -250,15 +346,7 @@ export async function createRemixGallerySubmission({
       sellerId: null,
       amount: space.price,
       status: 'pending',
-      data: {
-        imageId,
-        remixOfId: submission.remixOfId,
-        // Present only when the server itself resolved this host image as an
-        // input to the generation. Left off rather than set false: "made
-        // elsewhere" and "no signal" are the same state, and the owner-review
-        // UI must keep saying nothing about either.
-        ...(submission.sourceImageIds?.includes(hostImageId) ? { derivedFromHost: true } : {}),
-      } satisfies RemixGalleryPlacementData,
+      data,
     },
     select: { id: true },
   });
@@ -339,6 +427,7 @@ export async function actOnRemixGallerySubmission({
       amount: true,
       status: true,
       surface: true,
+      free: true,
       data: true,
       resolvedAt: true,
       createdAt: true,
@@ -400,7 +489,17 @@ export async function actOnRemixGallerySubmission({
       const removableAt = remixGalleryRemovableAt(placement.resolvedAt ?? placement.createdAt);
       if (removableAt > new Date())
         throw throwBadRequestError(
-          `remix gallery: this entry can be removed from ${removableAt.toISOString()}. Someone paid to be featured here, so it stays up for a week after you approve it.`
+          `remix gallery: this entry can be removed from ${removableAt.toISOString()}. ${
+            // The week itself is unchanged for a free entry — Justin's call, so
+            // the two paths cannot differ on how long an approval binds. Only the
+            // reason differs: nothing was paid, so the copy cannot say it was.
+            // Note what this costs, because it is intended rather than an
+            // oversight: an approved free entry holds one of the creator's free
+            // slots for the whole week too.
+            placement.free
+              ? 'Accepting a remix is a week-long commitment either way, so it stays up for a week after you approve it.'
+              : 'Someone paid to be featured here, so it stays up for a week after you approve it.'
+          }`
         );
     }
 
@@ -1153,7 +1252,7 @@ async function getViewerPendingSubmissions({
       placerId: viewerId,
       status: 'pending',
     },
-    select: { id: true, amount: true, data: true, createdAt: true, expiresAt: true },
+    select: { id: true, amount: true, free: true, data: true, createdAt: true, expiresAt: true },
     orderBy: { createdAt: 'asc' },
     take: REMIX_GALLERY_MAX_PENDING_PER_OWNER,
   });
@@ -1172,6 +1271,7 @@ async function getViewerPendingSubmissions({
   return entries.map((row) => ({
     placementId: row.id,
     amount: row.amount,
+    free: row.free,
     createdAt: row.createdAt,
     expiresAt: row.expiresAt,
     image: toQueueImage(
@@ -1356,11 +1456,88 @@ export async function getRemixGalleryVisibility({
     ownerId: space.ownerId,
     ownerUsername: owner?.username ?? null,
     ownerShare: space.ownerShare,
+    // What the creator accepts is theirs to publish — it is a setting on their
+    // own image, the same standing as `price`.
+    freeSlots: space.freeSlots,
+    // How many are currently *held* is not. It is a count of pending and
+    // approved submissions on someone's image, which is the fact `pendingCount`
+    // above is owner-only to protect — a public number here would let anyone
+    // watch a creator's queue fill by polling an id.
+    //
+    // Withheld under the same rule as `maxSubmissionLevel`: signed in, gallery
+    // open, not your own. That is exactly the case the submit card needs, and
+    // nothing wider. `freeSlots` alone still tells a signed-out viewer whether
+    // the creator takes free submissions at all.
+    //
+    // Both are needed together because `freeSlotsRemaining: 0` means two things
+    // — the resolver short-circuits the reservation count at zero capacity — and
+    // the two need different copy: one is a setting, the other is a queue.
+    freeSlotsRemaining: canSubmitHere ? space.freeSlotsRemaining : null,
     declineFee,
     pendingCount,
     viewerPending,
     maxSubmissionLevel,
     acceptedMaxLevel,
+  };
+}
+
+/**
+ * Where the viewer stands on submitting to this gallery for free.
+ *
+ * **Every number here is a listing.** The allowance, the slot count and the
+ * verification are all stale the moment they return, and the refusals live in
+ * `createRemixGallerySubmission` and `createFreePlacement`. This exists so the
+ * submit card can offer the free option and say what it costs, not so anything
+ * can be decided on it — a control that defaults to free has to survive losing
+ * the race for the last slot.
+ *
+ * Scoped to `imageIds` the picker has already loaded rather than sweeping the
+ * viewer's library: a submitter with tens of thousands of images would otherwise
+ * pay for a containment scan over all of them to render one badge.
+ *
+ * And scoped to the viewer's **own** images, which is not only about relevance:
+ * answering "was this image generated from that one" for arbitrary ids would
+ * turn the endpoint into an oracle for other people's generation inputs.
+ */
+export async function getRemixGalleryFreeEligibility({
+  hostImageId,
+  placerId,
+  imageIds,
+}: {
+  hostImageId: number;
+  placerId: number;
+  /** The candidates on screen. Bounded by the schema. */
+  imageIds: number[];
+}) {
+  const [allowance, usedHere, verified] = await Promise.all([
+    getFreePlacementAllowance({ placerId }),
+    hasUsedFreePlacementOn({
+      placerId,
+      surface: SURFACE,
+      targetType: TARGET_TYPE,
+      targetId: hostImageId,
+    }),
+    imageIds.length
+      ? dbRead.$queryRaw<{ id: number }[]>`
+          SELECT i.id
+          FROM "Image" i
+          WHERE i.id IN (${Prisma.join(imageIds)})
+            AND i."userId" = ${placerId}
+            -- The same fact the mutation gates on, through the same expression
+            -- rather than a second reading of the same JSON: ids that
+            -- sanitizeProvenance wrote after verifying a signed token or the
+            -- workflow itself. A submitter editing their own image's meta cannot
+            -- put one here, which is what makes the free gate mean anything.
+            AND ${hostImageId} = ANY(${sourceImageIdsSql()})
+        `
+      : [],
+  ]);
+
+  return {
+    allowance,
+    /** Free is once per gallery per placer, ever — not once per day. */
+    usedHere,
+    verifiedImageIds: verified.map((row) => row.id),
   };
 }
 
@@ -1435,6 +1612,12 @@ export async function getPendingRemixGallerySubmissions({
       targetId: true,
       placerId: true,
       amount: true,
+      // Without it the queue cannot tell a free submission from a paid one, and
+      // the earnings below — both computed from `amount`, which a free row
+      // pins at 0 — render as "+0 Buzz" on approve AND decline. That is the
+      // decision surface for the whole free tier telling a creator they earn
+      // nothing, on the same row the free notification told them was a gift.
+      free: true,
       data: true,
       createdAt: true,
       expiresAt: true,
@@ -1498,16 +1681,24 @@ export async function getPendingRemixGallerySubmissions({
           viewerLevels
         ),
         targetImage: toQueueImage(byId.get(row.targetId), domainLevels, viewerLevels),
-        earnings: {
-          approve: splitPlacementPayment({
-            amount: row.amount,
-            outcome: 'approved',
-            declineFeeRate,
-            sellerShare: shares.seller,
-            platformShare: shares.platform,
-          }).toOwner,
-          decline: declineFeeAmount(row.amount, declineFeeRate),
-        },
+        // `null` on a free row rather than the zeroes the arithmetic produces.
+        // Nothing was paid in, so there is no split and no decline fee — and a
+        // "+0 Buzz" chip does not say that, it says this creator earns nothing
+        // for accepting, which is both false in spirit and about to be false in
+        // fact once the accept reward lands. The absence is what lets the queue
+        // render something else instead of a number.
+        earnings: row.free
+          ? null
+          : {
+              approve: splitPlacementPayment({
+                amount: row.amount,
+                outcome: 'approved',
+                declineFeeRate,
+                sellerShare: shares.seller,
+                platformShare: shares.platform,
+              }).toOwner,
+              decline: declineFeeAmount(row.amount, declineFeeRate),
+            },
       }))
       // Both halves, for the same reason: the owner cannot judge a remix they
       // cannot see, and cannot judge it against a host that no longer renders.
@@ -1547,6 +1738,10 @@ export async function getMyRemixGallerySubmissions({
       ownerId: true,
       status: true,
       amount: true,
+      // The submitter's side of the same problem the owner queue had: `amount`
+      // is 0 on a free row, so without this every Buzz figure and every "your
+      // Buzz is on its way back" renders about money that never moved.
+      free: true,
       data: true,
       createdAt: true,
       expiresAt: true,

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -5,6 +5,7 @@ import { ImageSort, NsfwLevel } from '~/server/common/enums';
 import type { SessionUser } from '~/types/session';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
+import { remixAcceptReward } from '~/server/rewards/active/remixAccept.reward';
 import { getAllImages } from '~/server/services/image.service';
 import { holdPlacementEscrow, settlePlacement } from '~/server/services/placement-escrow.service';
 import { assertCanPlace } from '~/server/services/placement-moderation.service';
@@ -451,6 +452,31 @@ export async function actOnRemixGallerySubmission({
   // appeared to work and did not is what this cost us on chunk D.
   if (!result.settled)
     throw throwBadRequestError('remix gallery: that submission was already resolved elsewhere');
+
+  // Fired only from behind that `settled` check, which is the whole double-pay
+  // guard: it is true for exactly one call in a placement's life. Re-presenting a
+  // placement this already paid for would spend a slot of the owner's daily cap
+  // and move no Buzz, silently — see `remixAcceptReward`.
+  //
+  // Swallowed rather than rethrown, unlike the reward's own inline fail-soft: the
+  // settle above already committed and paid out, so a throw here would report a
+  // failure for an approval that happened and cannot be retried.
+  if (action === 'approve')
+    await remixAcceptReward
+      .apply({
+        placementId: placement.id,
+        ownerId: placement.ownerId,
+        placerId: placement.placerId,
+      })
+      .catch((error) =>
+        logToAxiom({
+          name: 'remix-gallery',
+          type: 'error',
+          message: 'accept reward failed; the submission is approved and the owner unpaid',
+          placementId: placement.id,
+          error: error instanceof Error ? error.message : String(error),
+        }).catch(() => undefined)
+      );
 
   return result;
 }

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -19,6 +19,7 @@ import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import type { PlacementStatus } from '~/shared/utils/placement';
 import {
   PLACEMENT_QUEUE_PAGE_SIZE,
+  PLACEMENT_SURFACES,
   encodePlacementQueueCursor,
   parsePlacementQueueCursor,
   placementQueueKeyset,
@@ -46,8 +47,11 @@ const TARGET_TYPE = 'image' as const;
  * A cap rather than a rate limit: the cost is already real Buzz, so this is not
  * about spam economics but about a review queue an owner can actually work
  * through. Their remedy for the rest is block, which declines all of them.
+ *
+ * In the surface table because the free path enforces it too, and three copies
+ * of one number is how they start disagreeing.
  */
-const MAX_PENDING_PER_OWNER = 10;
+const MAX_PENDING_PER_OWNER = PLACEMENT_SURFACES.sticker.maxPendingPerOwner;
 
 /**
  * The note on a placement, if this viewer may read it.

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -6,6 +6,7 @@ import {
   settlePlacement,
   MAX_LEG_ATTEMPTS,
 } from '~/server/services/placement-escrow.service';
+import { createFreePlacement } from '~/server/services/free-placement.service';
 import { assertCanPlace } from '~/server/services/placement-moderation.service';
 import { resolvePlacementSpaceFor } from '~/server/services/placement-space.service';
 import { spendStickerUsesFor } from '~/server/services/sticker.service';
@@ -115,11 +116,25 @@ async function loadPlaceableSticker({
 }
 
 export type CreateStickerPlacement = {
+  /**
+   * 🔴 From the session, never from the request body. Every free-tier rule —
+   * the daily allowance, never-twice-here, the block and suspension checks — is
+   * a statement *about* this id, so none of them notice when it is the wrong
+   * one: a placer read off the payload would spend someone else's allowance and
+   * place under their name with nothing raising.
+   */
   placerId: number;
   imageId: number;
   data: Omit<StickerPlacementInput, 'cosmeticId'> & { cosmeticId: number };
   /** Moderators may exceed a creator's size limit. Justin's call. */
   isModerator?: boolean;
+  /**
+   * Which of the two offers the placer took. A choice, not a claim: it selects
+   * the path, and the path re-decides every rule for itself under a lock. The
+   * number the client rendered is stale by the time it is read, so a `true` here
+   * is a request for a free slot rather than an assertion that one is free.
+   */
+  free?: boolean;
   /**
    * The domain's currency, decided at the router from the request's own feature
    * flags rather than anything the client sends — a client-supplied currency
@@ -171,6 +186,7 @@ export async function createStickerPlacement({
   imageId,
   data,
   isModerator = false,
+  free = false,
   spendType,
 }: CreateStickerPlacement) {
   const space = await resolvePlacementSpaceFor({
@@ -189,9 +205,6 @@ export async function createStickerPlacement({
   if (space.ownerId === placerId)
     throw throwBadRequestError('placement: you cannot place a sticker on your own content');
 
-  if (space.price == null)
-    throw throwBadRequestError('placement: this creator has not set a price yet');
-
   // The creator's size limit, refused rather than clamped. Quietly shrinking a
   // sticker someone just paid for is the same shape as v1's recurring defect: a
   // rule applied as a filter where a refusal was needed. The editor also caps
@@ -208,6 +221,21 @@ export async function createStickerPlacement({
         maxScale * 100
       )}% of the image width`
     );
+
+  // Everything below is the paid path: the escrow, the price, and the two
+  // refusals `createFreePlacement` makes for itself under its lock. Branching
+  // here rather than threading `free` through them keeps one creation route per
+  // offer — the alternative is a paid path with free-shaped holes in it, which
+  // is the guard-versus-filter shape this feature has already shipped five
+  // times.
+  if (free) return placeFreeSticker({ placerId, imageId, data, space });
+
+  // Below the branch rather than above it, and not a `!free` condition: a
+  // creator can open free capacity on a space they have never priced, so an
+  // unset price is only a refusal for the offer that needs one. Placed here it
+  // also narrows the type for the escrow, which a conditional guard cannot.
+  if (space.price == null)
+    throw throwBadRequestError('placement: this creator has not set a price yet');
 
   await assertCanPlace({ ownerId: space.ownerId, placerId });
 
@@ -287,6 +315,114 @@ export async function createStickerPlacement({
 }
 
 /**
+ * The same placement, taken out of the creator's free capacity instead of paid
+ * for.
+ *
+ * Free of Buzz, not of everything: the use still comes out of the placer's
+ * sticker inventory, so a free placement costs the same thing the paid one does
+ * minus the creator's price.
+ *
+ * **No refusal is re-implemented here.** The mode, the self-placement rule, the
+ * block and suspension checks, the per-owner pending cap, the daily allowance,
+ * never-twice-here and the slot count all live inside `createFreePlacement`,
+ * where the last three are decided under a lock in the transaction that
+ * inserts. Anything this function checked instead would be a second opinion
+ * that is free to disagree with the one that actually holds.
+ *
+ * 🔴 **The approval at the end is not optional.** `createFreePlacement` always
+ * writes `pending` and deliberately never settles — settlement is the money
+ * path and does I/O, and the claim runs inside a transaction. Sticker's
+ * `allowedModes` includes `auto`, so an auto space is reachable here, and
+ * without this the placement sits pending for 48 hours holding a slot while the
+ * placer has been told it is live and the creator watches a review queue they
+ * turned off. It fails silently in both directions, which is why it is the last
+ * thing this function does rather than a caller's job.
+ */
+async function placeFreeSticker({
+  placerId,
+  imageId,
+  data,
+  space,
+}: {
+  placerId: number;
+  imageId: number;
+  data: Omit<StickerPlacementInput, 'cosmeticId'> & { cosmeticId: number };
+  space: Awaited<ReturnType<typeof resolvePlacementSpaceFor>>;
+}) {
+  const sticker = await loadPlaceableSticker({ cosmeticId: data.cosmeticId, placerId });
+  await assertHasUse({ userId: placerId, cosmeticId: sticker.id });
+
+  const comment = commentFrom(data);
+
+  const placement = await createFreePlacement({
+    surface: SURFACE,
+    targetType: TARGET_TYPE,
+    targetId: imageId,
+    placerId,
+    // Carried for the same reason the paid path carries it — settlement is
+    // resumable and a sweeper never sees an argument. A free approval plans no
+    // legs, so nothing is ever paid out against it.
+    sellerId: sticker.createdById,
+    data: {
+      cosmeticId: sticker.id,
+      ...normalizeStickerPlacement(data),
+      ...(comment ? { comment } : {}),
+    },
+  });
+
+  try {
+    await spendStickerUsesFor({ userId: placerId, counts: new Map([[sticker.id, 1]]) });
+  } catch (error) {
+    await discardFreePlacement(placement.id);
+    throw error;
+  }
+
+  if (space.mode === 'auto')
+    await settlePlacement({
+      placementId: placement.id,
+      action: 'approve',
+      actorId: space.ownerId,
+    });
+
+  return { placementId: placement.id, status: space.mode === 'auto' ? 'approved' : 'pending' };
+}
+
+/**
+ * The unwind for a free placement, which DELETES the row rather than expiring
+ * it.
+ *
+ * The paid path expires, because the escrow's claim rows are the evidence
+ * recovery depends on and rolling them back destroys it. A free row has none —
+ * no holds, no ledger, nothing carrying a foreign key to it — so there is
+ * nothing to preserve, and expiring it would cost the placer their whole day:
+ * the daily allowance counts on `createdAt` across every status, so an expired
+ * row is indistinguishable from one a creator declined. Being unforgiving about
+ * a decline is deliberate; being unforgiving about our own failed spend is not.
+ *
+ * Scoped to a pending free row so a claim someone has since acted on cannot be
+ * deleted out from under them.
+ */
+async function discardFreePlacement(placementId: number) {
+  try {
+    await dbWrite.placement.deleteMany({
+      where: { id: placementId, free: true, status: 'pending' },
+    });
+  } catch (error) {
+    // The row still carries its deadline, so the expiry sweep releases the
+    // creator's slot within the window either way. What is lost is the placer's
+    // free placement for the day, which is why this is worth a line rather than
+    // a swallow.
+    logToAxiom({
+      name: 'sticker-placement',
+      type: 'error',
+      message: 'could not discard a free placement whose use spend failed',
+      placementId,
+      error: (error as Error).message,
+    }).catch(() => null);
+  }
+}
+
+/**
  * A courtesy refusal before any money moves. The spend after the escrow is the
  * authority — this only exists so "you're out of uses" arrives before a charge
  * and a refund rather than as a surprising round trip.
@@ -315,6 +451,8 @@ export type StickerPlacementView = {
   ownerId: number;
   status: PlacementStatus;
   amount: number;
+  /** Placed against the creator's free capacity, so no Buzz moved for it. */
+  free: boolean;
   data: StickerPlacementData;
   /**
    * When it was placed, which is what decides what covers what — and, on the
@@ -387,6 +525,11 @@ export async function getStickerPlacementDetail({
       createdAt: true,
       resolvedAt: true,
       status: true,
+      // Every surface built on this card says something about money — what a
+      // decline returns, why a removal is locked, what the owner keeps. All of
+      // it is false on a free row, and without this column the client has to
+      // infer it from `amount`, which is a number rather than a fact.
+      free: true,
       data: true,
       ownerId: true,
       placerId: true,
@@ -419,6 +562,7 @@ export async function getStickerPlacementDetail({
     // queue for two days did not change that.
     placedAt: placement.createdAt,
     status: placement.status as PlacementStatus,
+    free: placement.free,
     placer: placement.placer,
     comment: data ? visibleStickerComment(data, isParty) ?? null : null,
     /**
@@ -510,6 +654,11 @@ export async function getStickerPlacements({
       ownerId: true,
       status: true,
       amount: true,
+      // Beside `amount` rather than derived from it. Zero is what a free row
+      // carries, but it is not what makes it free — and the owner controls the
+      // copy that depends on the answer, so an inference is a wrong sentence
+      // about money rather than a missing one.
+      free: true,
       data: true,
       createdAt: true,
     },
@@ -530,6 +679,7 @@ export async function getStickerPlacements({
         ownerId: row.ownerId,
         status: row.status as PlacementStatus,
         amount: row.amount,
+        free: row.free,
         placedAt: row.createdAt,
         // The note's text is deliberately NOT in the listing, which runs for
         // every image on a feed page — only whether there is one, so an overlay
@@ -669,6 +819,7 @@ export async function actOnStickerPlacement({
       amount: true,
       status: true,
       surface: true,
+      free: true,
       data: true,
       createdAt: true,
       resolvedAt: true,
@@ -705,6 +856,7 @@ type ActionablePlacement = {
   id: number;
   ownerId: number;
   status: string;
+  free: boolean;
   data: unknown;
   createdAt: Date;
   resolvedAt: Date | null;
@@ -750,7 +902,16 @@ async function removeApprovedSticker({
     const removableAt = stickerRemovableAt(placement.resolvedAt ?? placement.createdAt);
     if (removableAt > new Date())
       throw throwBadRequestError(
-        `placement: this sticker can be removed from ${removableAt.toISOString()}. Someone paid to place it, so it stays up for a week after you accept it.`
+        `placement: this sticker can be removed from ${removableAt.toISOString()}. ${
+          placement.free
+            ? // Nobody paid for a free row, so the paid path's reason is simply
+              // untrue here — and a stated reason that is false is worse than a
+              // shorter one, because it is what a support answer repeats. The
+              // week itself is unchanged: Justin's call, 2026-08-17, on the
+              // grounds that accepting is the commitment whatever it cost.
+              'Accepting a sticker is a commitment to keep it up for a week.'
+            : 'Someone paid to place it, so it stays up for a week after you accept it.'
+        }`
       );
   }
 
@@ -862,6 +1023,10 @@ export async function getPendingStickerPlacements({
       targetId: true,
       placerId: true,
       amount: true,
+      // The queue's decline confirmation states what a decline costs, which is a
+      // different sentence on a free row — and a bulk selection can hold both
+      // kinds, so the caller needs it per row rather than per page.
+      free: true,
       data: true,
       createdAt: true,
       expiresAt: true,

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -126,8 +126,6 @@ export type CreateStickerPlacement = {
   placerId: number;
   imageId: number;
   data: Omit<StickerPlacementInput, 'cosmeticId'> & { cosmeticId: number };
-  /** Moderators may exceed a creator's size limit. Justin's call. */
-  isModerator?: boolean;
   /**
    * Which of the two offers the placer took. A choice, not a claim: it selects
    * the path, and the path re-decides every rule for itself under a lock. The
@@ -185,7 +183,6 @@ export async function createStickerPlacement({
   placerId,
   imageId,
   data,
-  isModerator = false,
   free = false,
   spendType,
 }: CreateStickerPlacement) {
@@ -215,7 +212,7 @@ export async function createStickerPlacement({
   // they were accepted at, and a creator lowering their limit is not a licence
   // to take back something already paid for.
   const maxScale = stickerMaxScale(space.settings);
-  if (!isModerator && data.scale > maxScale)
+  if (data.scale > maxScale)
     throw throwBadRequestError(
       `placement: this creator allows stickers up to ${Math.round(
         maxScale * 100

--- a/src/shared/utils/__tests__/placement.test.ts
+++ b/src/shared/utils/__tests__/placement.test.ts
@@ -3,8 +3,14 @@ import type { PlacementOutcome, PlacementStatus } from '~/shared/utils/placement
 import {
   clampDeclineFeeRate,
   declineFeeAmount,
+  effectiveFreeSlots,
   effectivePlacementPrice,
+  FREE_PLACEMENTS_PER_DAY,
+  FREE_SLOT_HOLDING_STATUSES,
+  freePlacementDayStart,
   isPlacementSurface,
+  PLACEMENT_FREE_SLOT_CAP_TIERS,
+  placementFreeSlotCap,
   MAX_DECLINE_FEE_RATE,
   MIN_DECLINE_FEE_RATE,
   PLACEMENT_SURFACES,
@@ -328,6 +334,7 @@ describe('space resolution', () => {
     expect(resolvePlacementSpace('sticker', {})).toEqual({
       mode: PLACEMENT_SURFACES.sticker.defaultMode,
       price: PLACEMENT_SURFACES.sticker.defaultPrice,
+      freeSlots: PLACEMENT_SURFACES.sticker.defaultFreeSlots,
       settings: {},
     });
   });
@@ -405,7 +412,12 @@ describe('space resolution', () => {
       image: mode('auto'),
       user: mode('off', 250),
     });
-    expect(resolved).toEqual({ mode: 'auto', price: 250, settings: {} });
+    expect(resolved).toEqual({
+      mode: 'auto',
+      price: 250,
+      freeSlots: PLACEMENT_SURFACES.sticker.defaultFreeSlots,
+      settings: {},
+    });
   });
 
   it('merges settings per key, with the most specific level winning', () => {
@@ -442,5 +454,140 @@ describe('the surface table', () => {
       expect(config.defaultDeclineFeeRate).toBeLessThanOrEqual(MAX_DECLINE_FEE_RATE);
       expect(config.expiryHours).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('free capacity', () => {
+  // The two ends of the scale are decided and published; the middle is a
+  // judgement. Pinning both ends means a table edit that moves them is a
+  // deliberate change to this file rather than something a reviewer has to spot.
+  it('starts a new creator at one and tops out at ten', () => {
+    expect(placementFreeSlotCap(0, 'free')).toBe(1);
+    expect(placementFreeSlotCap(1_000_000, 'gold')).toBe(10);
+  });
+
+  it('never lets a lower tier or a lower score buy more slots', () => {
+    const tiers = ['free', 'bronze', 'silver', 'gold'] as const;
+    const scores = PLACEMENT_FREE_SLOT_CAP_TIERS.map((band) => band.minScore);
+
+    for (const score of scores)
+      for (let i = 1; i < tiers.length; i++)
+        expect(placementFreeSlotCap(score, tiers[i])).toBeGreaterThanOrEqual(
+          placementFreeSlotCap(score, tiers[i - 1])
+        );
+
+    for (const tier of tiers)
+      for (let i = 1; i < scores.length; i++)
+        expect(placementFreeSlotCap(scores[i], tier)).toBeGreaterThanOrEqual(
+          placementFreeSlotCap(scores[i - 1], tier)
+        );
+  });
+
+  // The same resolver as the price caps, deliberately — one mechanism, so a fix
+  // to the band-picking cannot land on one table and miss the other. This is what
+  // makes that reuse a fact rather than an intention.
+  it('is resolved by the price cap resolver, not a second one', () => {
+    for (const band of PLACEMENT_FREE_SLOT_CAP_TIERS)
+      expect(placementFreeSlotCap(band.minScore, 'gold')).toBe(
+        placementPriceCap(band.minScore, 'gold', PLACEMENT_FREE_SLOT_CAP_TIERS)
+      );
+  });
+
+  // The surface default is applied by the cascade and nowhere else, so an unset
+  // count never reaches this. Applying it here too had one read path defaulting
+  // three times, with two of them unreachable.
+  it('gives an unset space the surface default, in the cascade and only there', () => {
+    for (const surface of placementSurfaces)
+      expect(resolvePlacementSpace(surface, {}).freeSlots).toBe(
+        PLACEMENT_SURFACES[surface].defaultFreeSlots
+      );
+  });
+
+  // The distinction that lets this replace an on/off toggle instead of sitting
+  // beside one. Defaulting a stored 0 away would reopen a space its owner closed.
+  it('keeps an explicit zero through the cascade, which is the creator saying no', () => {
+    expect(
+      resolvePlacementSpace('sticker', { user: { mode: 'review', price: 100, freeSlots: 0 } })
+        .freeSlots
+    ).toBe(0);
+    expect(effectiveFreeSlots(0, 10)).toBe(0);
+  });
+
+  it('ceilings a stored count without rewriting it', () => {
+    expect(effectiveFreeSlots(8, 3)).toBe(3);
+  });
+
+  it('cannot go negative, however the cap is misconfigured', () => {
+    expect(effectiveFreeSlots(4, -2)).toBe(0);
+  });
+
+  it('resolves image over post over account, independently of price', () => {
+    const resolved = resolvePlacementSpace('sticker', {
+      image: { mode: 'review', price: null, freeSlots: 2 },
+      post: { mode: 'review', price: 300, freeSlots: 5 },
+      user: { mode: 'review', price: 500, freeSlots: 9 },
+    });
+
+    expect(resolved.freeSlots).toBe(2);
+    // The price came from the post while the count came from the image, which is
+    // the whole reason these resolve separately: an owner who set their capacity
+    // once should keep it on an image they later reprice.
+    expect(resolved.price).toBe(300);
+  });
+
+  it('falls through a level that has not chosen', () => {
+    const resolved = resolvePlacementSpace('sticker', {
+      image: { mode: 'review', price: 100 },
+      user: { mode: 'review', price: 500, freeSlots: 6 },
+    });
+
+    expect(resolved.freeSlots).toBe(6);
+  });
+
+  // Pending is the point of the feature: without it fifty people submit into
+  // four slots and the creator gets a fifty-item review queue.
+  it('holds a slot while a placement is pending, and releases every other status', () => {
+    expect([...FREE_SLOT_HOLDING_STATUSES].sort()).toEqual(['approved', 'pending']);
+  });
+
+  it('starts the day at midnight UTC, wherever the placer is', () => {
+    // Both probes sit INSIDE one UTC day and straddle every real offset: 04:00Z
+    // is the previous local day west of UTC, 20:00Z the next local day east of
+    // it. Midnight-aligned probes alone would prove nothing about the day
+    // boundary at all.
+    for (const at of ['2026-08-17T04:00:00.000Z', '2026-08-17T20:00:00.000Z'])
+      expect(freePlacementDayStart(new Date(at)).toISOString()).toBe('2026-08-17T00:00:00.000Z');
+
+    // The boundary itself, so the window is a day rather than merely aligned.
+    expect(freePlacementDayStart(new Date('2026-08-18T00:00:00.000Z')).toISOString()).toBe(
+      '2026-08-18T00:00:00.000Z'
+    );
+  });
+
+  /**
+   * The timezone independence itself, which the probes above cannot reach.
+   *
+   * On a UTC runner a local-day boundary and a UTC one are the SAME function, so
+   * no input can separate them — and CI is UTC with no `TZ` pinned. Rather than
+   * write a test named for a property it can only fail on a machine that never
+   * gates the PR, the implementation floors the epoch, which has no ambient
+   * timezone to read. This asserts that shape: every result lands on a whole
+   * multiple of a day, which a calendar-getter version cannot promise off UTC.
+   */
+  it('lands on a whole day boundary, with no timezone to read', () => {
+    const day = 24 * 3_600_000;
+    for (const at of [0, 1, 1_000, day - 1, day, 1_786_000_000_000, Date.now()])
+      expect(freePlacementDayStart(new Date(at)).getTime() % day).toBe(0);
+  });
+
+  it('floors rather than rounds, so the day never starts in the future', () => {
+    for (const at of ['2026-08-17T00:00:00.000Z', '2026-08-17T23:59:59.999Z'].map(
+      (iso) => new Date(iso)
+    ))
+      expect(freePlacementDayStart(at).getTime()).toBeLessThanOrEqual(at.getTime());
+  });
+
+  it('is one placement a day, which is what makes free scarce', () => {
+    expect(FREE_PLACEMENTS_PER_DAY).toBe(1);
   });
 });

--- a/src/shared/utils/placement.ts
+++ b/src/shared/utils/placement.ts
@@ -108,6 +108,9 @@ export const PLACEMENT_SURFACES = {
     // Changing this makes that copy false — change both or neither.
     defaultPlatformShare: 0,
     expiryHours: 48,
+    defaultFreeSlots: 1,
+    maxPendingPerOwner: 10,
+    allowedModes: ['off', 'review', 'auto'],
   },
   remixGallery: {
     label: 'remix galleries',
@@ -141,6 +144,11 @@ export const PLACEMENT_SURFACES = {
     // row: `approvalShares.remixGallery.platform`.
     defaultPlatformShare: 0,
     expiryHours: 48,
+    defaultFreeSlots: 1,
+    maxPendingPerOwner: 10,
+    // Never `auto`: a gallery places arbitrary user-uploaded media on someone
+    // else's page, so every entry passes its owner.
+    allowedModes: ['off', 'review'],
   },
 } as const satisfies Record<
   PlacementSurface,
@@ -166,6 +174,34 @@ export const PLACEMENT_SURFACES = {
     defaultSellerShare: number;
     defaultPlatformShare: number;
     expiryHours: number;
+    /**
+     * How many free placements a space accepts when its owner has never chosen.
+     *
+     * `1` rather than `0` because free capacity is opt-OUT, the same decision the
+     * gallery's `defaultMode` records: a creator who never opens these settings
+     * takes one free placement, which is what makes the habit reachable at all.
+     * It is still ceilinged by the score/tier cap, so the bottom band's range of
+     * 0-1 makes this both the default and the maximum for a new creator.
+     */
+    defaultFreeSlots: number;
+    /**
+     * How many pending placements one placer may have waiting on one owner.
+     *
+     * A cap on a review queue an owner can work through, not a spam gate — the
+     * owner's remedy for the rest is block, which declines all of them.
+     *
+     * In the table because three call sites enforce it: both paid creation paths
+     * and the free one. It was two constants of the same value in two services
+     * before the free path needed a third.
+     */
+    maxPendingPerOwner: number;
+    /**
+     * Modes this surface may actually be in. A mode outside this list is refused
+     * where it is stored AND where it is acted on — a row written before a rule
+     * existed still reads back, and a listing that filters is not a mutation that
+     * refuses.
+     */
+    allowedModes: readonly PlacementSpaceMode[];
   }
 >;
 
@@ -261,6 +297,17 @@ export type PlacementSpaceSettings = Record<string, unknown>;
 export type PlacementSpaceSetting = {
   mode: PlacementSpaceMode;
   price: number | null;
+  /**
+   * How many free placements this space accepts. `0` is a real answer — the
+   * creator taking none — which is why this replaces an on/off toggle rather
+   * than sitting beside one, and why `null` has to mean "unset" instead.
+   *
+   * A column rather than a key in `settings`. Both surfaces have the same
+   * concept and this layer reads it: `settings` is documented as surface-owned
+   * and never read here, so putting it there would either break that or force
+   * each surface to reimplement the reservation.
+   */
+  freeSlots?: number | null;
   settings?: PlacementSpaceSettings;
 };
 
@@ -279,7 +326,11 @@ export function resolvePlacementSpace(
     post?: PlacementSpaceSetting;
     user?: PlacementSpaceSetting;
   }
-): PlacementSpaceSetting {
+  // `freeSlots` narrowed to a number: this is the ONE place the surface default
+  // is applied, so callers read it rather than defaulting again. `price` is
+  // nullable here for a real reason — an unpriced space must not be charged for
+  // — where an unset slot count has an unambiguous answer.
+): PlacementSpaceSetting & { freeSlots: number } {
   const ordered = [levels.image, levels.post, levels.user];
   return {
     mode:
@@ -288,6 +339,12 @@ export function resolvePlacementSpace(
     price:
       ordered.find((level) => level?.price != null)?.price ??
       PLACEMENT_SURFACES[surface].defaultPrice,
+    // Independently of `mode` and of `price`, for the same reason they are
+    // independent of each other: an owner who set their free capacity once, at
+    // the account level, should keep it on an image they later reprice.
+    freeSlots:
+      ordered.find((level) => level?.freeSlots != null)?.freeSlots ??
+      PLACEMENT_SURFACES[surface].defaultFreeSlots,
     // Merged per key, most specific last, rather than taking the first level
     // that has any settings at all: an owner who set a max size on their account
     // and something unrelated on one image should keep both.
@@ -449,6 +506,103 @@ export function placementPriceCap(
  */
 export const effectivePlacementPrice = (setPrice: number | null, cap: number) =>
   setPrice == null ? null : Math.max(Math.min(setPrice, cap), PLACEMENT_MIN_PRICE);
+
+// ---------------------------------------------------------------------------
+// Free capacity
+// ---------------------------------------------------------------------------
+
+/**
+ * How many free placements a creator may accept, capped by creator score and
+ * membership tier.
+ *
+ * Deliberately the same table shape, the same resolver (`placementPriceCap`) and
+ * the same `placement:config` override as the price caps above — this is the
+ * same idea applied to a different number, and a second mechanism for it would
+ * be two things to keep in agreement.
+ *
+ * The bottom band is 0-1: a brand-new creator takes one free placement, which is
+ * also `defaultFreeSlots`, so the default and the maximum coincide until they
+ * earn room to raise it. The top is 10, at gold on the highest score band.
+ *
+ * ⚠️ The middle bands are a judgement, not a measurement. The shape is the
+ * commitment: read at request time, overridable without a deploy, never written
+ * to a space or a placement row.
+ */
+export const PLACEMENT_FREE_SLOT_CAP_TIERS: PlacementPriceTier[] = [
+  { minScore: 0, caps: { free: 1, bronze: 2, silver: 3, gold: 4 } },
+  { minScore: 10_000, caps: { free: 2, bronze: 3, silver: 4, gold: 6 } },
+  { minScore: 25_000, caps: { free: 3, bronze: 4, silver: 6, gold: 8 } },
+  { minScore: 100_000, caps: { free: 4, bronze: 6, silver: 8, gold: 10 } },
+];
+
+/**
+ * The most free placements this creator may accept on one space.
+ *
+ * A thin naming of `placementPriceCap` over the free-slot table, not a second
+ * resolver: the band-picking rules (highest band at or below the score, unknown
+ * tier reads as free, a table with no zero band is unusable) are the same rules,
+ * and two copies of them would be free to drift.
+ */
+export const placementFreeSlotCap = (
+  score: number,
+  tier: PriceCapTier,
+  tiers: PlacementPriceTier[] = PLACEMENT_FREE_SLOT_CAP_TIERS
+) => placementPriceCap(score, tier, tiers);
+
+/**
+ * What a space actually accepts, computed at read like the effective price.
+ *
+ * Clamping only. Defaulting an unset count belongs to `resolvePlacementSpace`
+ * and happens there once — this used to re-apply it, which had one read path
+ * defaulting three times with two of them unreachable.
+ *
+ * The floor is not decoration: a misconfigured cap must not let `cap - reserved`
+ * hand out capacity nobody set.
+ */
+export const effectiveFreeSlots = (setSlots: number, cap: number) =>
+  Math.max(Math.min(setSlots, cap), 0);
+
+/**
+ * How many free placements one placer may make in a UTC day, across every
+ * surface. The scarcity is the product: an unbounded free tier is a spam tier,
+ * and the people it costs are the creators who then close their spaces.
+ */
+export const FREE_PLACEMENTS_PER_DAY = 1;
+
+/** Milliseconds in a UTC day. Unix time has no leap seconds, so this is exact. */
+const DAY_MS = 24 * 3_600_000;
+
+/**
+ * Midnight UTC for the day containing `at`.
+ *
+ * UTC rather than the placer's local day, so the allowance cannot be refreshed
+ * twice by moving timezone, and so two servers never disagree about which day a
+ * placement fell in.
+ *
+ * **Epoch arithmetic rather than calendar getters, because the calendar version
+ * is not testable where it matters.** Written as
+ * `Date.UTC(at.getUTCFullYear(), …)`, the one-character slip to
+ * `at.getFullYear()` produces a local-day boundary — and on a UTC runner, which
+ * is what CI is with no `TZ` pinned, the two are the *same function*. No test can
+ * separate them there, so a test claiming to would be asserting a property it
+ * cannot fail on. Flooring the epoch has no ambient timezone to read, so there is
+ * no such slip to make and the property is structural instead of hoped for.
+ */
+export const freePlacementDayStart = (at: Date = new Date()) =>
+  new Date(Math.floor(at.getTime() / DAY_MS) * DAY_MS);
+
+/**
+ * Statuses that hold a free slot.
+ *
+ * Pending is in the list and that is the entire point of the feature: without
+ * reservation, fifty people submit into four slots and the creator gets a
+ * fifty-item review queue, which is what the slider exists to prevent. Everything
+ * else — declined, expired, removed — releases the slot, immediately.
+ */
+export const FREE_SLOT_HOLDING_STATUSES = [
+  'pending',
+  'approved',
+] as const satisfies readonly PlacementStatus[];
 
 // ---------------------------------------------------------------------------
 // The split

--- a/src/shared/utils/remix-gallery.ts
+++ b/src/shared/utils/remix-gallery.ts
@@ -1,4 +1,5 @@
 import { NsfwLevel } from '~/server/common/enums';
+import { PLACEMENT_SURFACES } from '~/shared/utils/placement';
 
 /**
  * What a remix-gallery placement carries. Opaque to the placement foundation,
@@ -58,7 +59,8 @@ export const REMIX_GALLERY_ROW_WIDTH = 4;
  * about a review queue the owner can work through rather than about spam
  * economics. Their remedy for the rest is block.
  */
-export const REMIX_GALLERY_MAX_PENDING_PER_OWNER = 10;
+export const REMIX_GALLERY_MAX_PENDING_PER_OWNER =
+  PLACEMENT_SURFACES.remixGallery.maxPendingPerOwner;
 
 /**
  * How long an approved entry is protected from the owner removing it.


### PR DESCRIPTION
Free placements: a creator-set number of free slots per image, on both the sticker and remix-gallery surfaces, plus a Blue Buzz reward to the creator for each acceptance.

## What is in it

| PR | What |
| --- | --- |
| #4009 | Free capacity primitive — `freeSlots` column on placement space settings, score/tier cap table, daily entitlement, once-ever-per-image per surface, escrow bypassed entirely rather than zero-amount holds, slot release on decline/expire/remove |
| #4014 | 10 Blue Buzz to the owner for accepting a sticker, 100/day, keyed on placement id so a re-settle cannot double-pay |
| #4013 | 20 Buzz × the first 5 remix accepts a day |
| #4018 | Free sticker placement — free/paid segmented control, remaining slots on the button, auto-accept vs review shown on the free option |
| #4017 | Free submission of a server-verified remix, its own free-slot slider and notification type |

## Before this deploys

- [x] **Migration `20260817120000_placement_free_capacity` is already applied to dev and prod**, verified object by object: both columns, both CHECKs `convalidated = true`, and the partial index carrying its `WHERE free` predicate on both targets.
- [ ] 🔴 **Disable `stickerPlacementAccepted` and `remixAccept` in the `rewards:config` row before this ships.** Neither reward sets `visible: false`, so both appear on the Buzz dashboard the moment the code lands — advertising the feature ahead of the articles, the changelog, the Discord post and the 2× banner. Disabling them in the config row rather than in code means turning them on at launch is a click in `/moderator/rewards` instead of a deploy.

**Rollback rule: flags off first, then roll back, and never drop the new columns.** `Placement.free` is the only record of which placements were never paid for, so a rollback with free rows in the table loses the reservation rather than moving money.

## Notes

- 🔴 `20260817120000_disable_follow_and_feedback_rewards` (merged in #4012) is **deliberately never applied**. Those rewards get turned off through the moderator panel instead. Applying that SQL later would overwrite whatever the panel is set to, because `setRewardConfig` is an unconditional replace with no version guard.
- No CI runs on PRs into `feat/free-placements` — all three workflows filter to `main`/`release` — so **this PR is the first time the whole stack is gated**. Each individual PR was gated on local verification plus review instead: 22 review rounds across the five, every finding cited to a file and line.

## Known follow-ups, tracked and deliberately not in scope

Bare `utils.*.fetch()` calls elsewhere in the repo read cache rather than the server under the global `staleTime: Infinity` (15 call sites, 2 guarded, one confirmed bug fixed here); `getRemixGalleryFreeEligibility` has no error path; the remix owner queue shows no earnings figure on a free row although accepting one now pays 20 Buzz; fail-open items 2–8 on the reward config.
