### PR TITLE
fix(placement): apply the creator's sticker size limit to moderators

### DIFF
--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -241,7 +241,6 @@ export const placementRouter = router({
         // it. Read off the payload it would spend someone else's daily
         // allowance and place under their name with nothing raising.
         placerId: ctx.user.id,
-        isModerator: ctx.user.isModerator,
         // From the request's own domain, never the input: `...input` spreads
         // first, so a client-sent `spendType` cannot survive this line.
         spendType: domainSpendType(ctx.features),

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -285,17 +285,23 @@ describe("the creator's size limit", () => {
     expect(placementCreate).not.toHaveBeenCalled();
   });
 
-  it('lets a moderator exceed it', async () => {
+  /**
+   * The limit is the creator's, so nobody is above it — moderating someone's
+   * content is not a licence to put a bigger sticker on it.
+   *
+   * `isModerator` is no longer part of this input at all, and is sent here
+   * anyway, cast: a revert reinstating the exemption gives the field a reader
+   * again, and this is then the test that fails rather than one asserting a
+   * flag nothing looks at.
+   */
+  it('refuses a moderator the same way', async () => {
     resolvePlacementSpaceFor.mockResolvedValue(capped);
     givenStickerAndBalance();
 
     await expect(
-      createStickerPlacement({
-        ...placeInput,
-        data: OVERSIZE,
-        isModerator: true,
-      })
-    ).resolves.toMatchObject({ placementId: PLACEMENT });
+      createStickerPlacement({ ...placeInput, data: OVERSIZE, isModerator: true } as never)
+    ).rejects.toThrow(/up to 20%/);
+    expect(placementCreate).not.toHaveBeenCalled();
   });
 
   it('applies the default when the creator has set nothing', async () => {

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -286,6 +286,28 @@ describe("the creator's size limit", () => {
   });
 
   /**
+   * The refusal sits above `if (free) return placeFreeSticker(...)`, so the free
+   * offer inherits it. That is positional, and nothing else here would notice a
+   * merge that kept both lines and put the branch first — the free path would
+   * stop refusing while every other test stayed green, and free placements carry
+   * no price, so no settlement figure would look wrong either.
+   *
+   * The message assertion carries that property on its own. The second one reads
+   * `createFreePlacement` because that is what the free branch delegates to
+   * today: give `placeFreeSticker` a different callee and it goes quiet rather
+   * than failing.
+   */
+  it('refuses a free placement the same way, before the free branch', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue(capped);
+    givenStickerAndBalance();
+
+    await expect(
+      createStickerPlacement({ ...placeInput, data: OVERSIZE, free: true })
+    ).rejects.toThrow(/up to 20%/);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  /**
    * The limit is the creator's, so nobody is above it — moderating someone's
    * content is not a licence to put a bigger sticker on it.
    *

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -126,8 +126,6 @@ export type CreateStickerPlacement = {
   placerId: number;
   imageId: number;
   data: Omit<StickerPlacementInput, 'cosmeticId'> & { cosmeticId: number };
-  /** Moderators may exceed a creator's size limit. Justin's call. */
-  isModerator?: boolean;
   /**
    * Which of the two offers the placer took. A choice, not a claim: it selects
    * the path, and the path re-decides every rule for itself under a lock. The
@@ -185,7 +183,6 @@ export async function createStickerPlacement({
   placerId,
   imageId,
   data,
-  isModerator = false,
   free = false,
   spendType,
 }: CreateStickerPlacement) {
@@ -215,7 +212,7 @@ export async function createStickerPlacement({
   // they were accepted at, and a creator lowering their limit is not a licence
   // to take back something already paid for.
   const maxScale = stickerMaxScale(space.settings);
-  if (!isModerator && data.scale > maxScale)
+  if (data.scale > maxScale)
     throw throwBadRequestError(
       `placement: this creator allows stickers up to ${Math.round(
         maxScale * 100


### PR DESCRIPTION
## The bug

`createStickerPlacement` exempted moderators from the creator's sticker size limit:

```ts
if (!isModerator && data.scale > maxScale)
```

So a moderator could place a sticker larger than a creator allows, on that creator's own image. Observed rather than inferred: a placement at scale `0.3` against a `0.25` space limit was accepted on the dev database (placement 50, image 131420251, pending).

Pre-existing — `git log -S` dates the line to `302983c7` (#3595, the paid-placement foundation).

**Based on `feat/free-placements`, not `main`**, so the fix ships inside the release rather than racing it. The old line lives on that branch too; landing this separately would have put the bug on the branch side of a conflict nobody was reviewing for it.

## The change

**Three sites, all on the create path:** the guard, the `CreateStickerPlacement.isModerator` field (with its doc-comment asserting the behaviour being removed), and the destructure default. `isModerator` had no other reader inside `createStickerPlacement`, so it is removed end to end rather than left inert.

🔴 **`isModerator` appears at ten further sites in this service and every one survives untouched** — listing visibility, act-on, remove, and moderator takedown. Those are legitimate moderator powers. The counts, against this PR's actual base:

| | `sticker-placement.service.ts` | `placement.router.ts` |
|---|---|---|
| `feat/free-placements` | 22 lines mention `isModerator` | 6 |
| this branch | 19 | 5 |

Three and one: exactly the sites named above, nothing else. `createSticker` at `placement.router.ts:232-248` passes no `isModerator`.

**The free path inherits the refusal.** The guard sits at `:214-215`, above `if (free) return placeFreeSticker(...)` at `:228`, so both offers hit it. That is positional, not textual — see the second commit.

There is no reposition or resize path: a placement's size is settable once, at creation. The three client call sites of `stickerMaxScale` never consulted `isModerator`, so the editor already capped a moderator's drag handles like anyone else's — the exemption was unreachable from the product UI and only reachable by a crafted request, which is why coverage is at the service and not in a browser test.

**Not retroactive.** Nothing on the read path changed; placements already accepted keep the size they were accepted at, and the two tests pinning that still pass. Placement 50 on dev stays valid.

## Commits

- `af308ebb31` — the fix.
- `694761d815` — a test pinning the refusal **above** the free branch. Separate so the fix can be taken without it.

That ordering was true by inspection only and nothing asserted it. A merge that keeps both lines but branches first stops refusing oversized **free** placements while every other test stays green — and a free placement carries no price, so no settlement figure looks wrong either.

## Verification

Local only — ⚠️ **no CI runs on PRs into `feat/free-placements`**: the workflows filter to `main`/`release`, so `gh pr checks` prints "no checks reported" and exits 0, which reads exactly like green.

- **`pnpm run db:generate` was required after rebasing** — this branch adds `Placement.free` to `schema.full.prisma`, and a worktree carrying a `main`-generated client fails typecheck with 44 errors (`'free' does not exist in type 'PlacementSelect'`). The working tree was clean afterwards, so `db:check-generated` is satisfied.
- `TYPECHECK_HEAP_MB=12288 pnpm run typecheck` → **`typecheck: OK — 0 type errors in 440s`**, exit 0, unfiltered.
- Sticker service suite: `Test Files 1 passed (1)`, `Tests 90 passed (90)`. With the router and free-placement suites: `3 passed (3)` / `124 passed (124)`.
- **Mutation probes, both on this tree.** Ordering flipped so the free branch precedes the guard → `Tests 2 failed | 88 passed (90)`, the new test among them. Moderator exemption reinstated → `Tests 1 failed | 89 passed (90)`, failing on the assertion diff. Both reverted; residue grepped.
- Full unit suite: `Test Files 1 failed | 1119 passed | 1 skipped (1121)`, `Tests 1 failed | 17672 passed | 23 skipped (17696)`. Totals reconcile, so no files were lost to a dead worker.

  The single failure is **`home-block-fetch-sizing.test.ts` — `Error: Test timed out in 60000ms`**, not an assertion. It passes alone (`7 passed (7)`) but its slowest test takes **41.2 s against a 60 s timeout**, and three suites were queued from three worktrees at the time. It contains zero references to stickers or placement; this diff is three files in the placement service, its test, and the placement router. Pre-existing and unreachable from this change.
