### PR TITLE
fix(stripe): derive buzz purchase currency from domain, not client

### DIFF
--- a/src/server/controllers/stripe.controller.ts
+++ b/src/server/controllers/stripe.controller.ts
@@ -159,6 +159,7 @@ export const getPaymentIntentHandler = async ({
         email,
       },
       customerId,
+      domain: ctx.domain,
     });
 
     return result;

--- a/src/server/schema/stripe.schema.ts
+++ b/src/server/schema/stripe.schema.ts
@@ -45,7 +45,11 @@ const buzzPurchaseMetadataSchema = z
     unitAmount: z.coerce.number().positive(),
     userId: z.coerce.number().positive(),
     transactionId: z.string().optional(),
-    buzzType: z.enum(['green', 'yellow', 'blue', 'red']).default('yellow').optional(),
+    // UNTRUSTED. `getPaymentIntent` overwrites this with the currency derived from the
+    // request's domain before it reaches Stripe, so whatever the client sends is inert.
+    // Do not reintroduce a `.default()` here: `.optional()` after it re-admits `undefined`,
+    // which made the old default never apply and hid that nothing re-derived the value.
+    buzzType: z.enum(['green', 'yellow', 'blue', 'red']).optional(),
     blueBuzzGranted: z.coerce.boolean().optional(),
     cosmeticsGranted: z.coerce.boolean().optional(),
     // App Blocks attribution — populated only when the buzz purchase

--- a/src/server/services/__tests__/stripe.getPaymentIntent.buzz-currency.test.ts
+++ b/src/server/services/__tests__/stripe.getPaymentIntent.buzz-currency.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
+
+/**
+ * The currency a real-money Buzz purchase is credited in must be derived from the domain the
+ * request arrived on, never taken from the client.
+ *
+ * The browser builds the payment-intent metadata and stamps `buzzType` into it; the Stripe webhook
+ * later credits whatever colour it finds there. Nothing in between re-derived it, so a modified
+ * client could pick the colour its purchase landed in — including `blue`, the FREE currency.
+ * `getPaymentIntent` is the last point that still knows the request's domain, so the override lives
+ * there and these tests assert on what is handed to `paymentIntents.create`.
+ */
+
+const { mockPaymentIntentsCreate, mockGetServerStripe } = vi.hoisted(() => ({
+  mockPaymentIntentsCreate: vi.fn(),
+  mockGetServerStripe: vi.fn(),
+}));
+
+vi.mock('~/server/utils/get-server-stripe', () => ({
+  getServerStripe: (...args: unknown[]) => mockGetServerStripe(...args),
+}));
+// The block-attribution validator has its own suite and pulls in the block registry. Pass the
+// metadata through untouched so the only thing this file can be measuring is the buzzType override.
+vi.mock('~/server/services/blocks/attribution-validator.service', () => ({
+  validateBuzzPurchaseAttribution: ({ metadata }: { metadata: Record<string, unknown> }) =>
+    Promise.resolve(metadata),
+}));
+
+import { getPaymentIntent } from '../stripe.service';
+
+const USER = { id: 100, email: 'buyer@example.com' };
+const CUSTOMER_ID = 'cus_test';
+const UNIT_AMOUNT = 1000;
+
+async function purchase({
+  domain,
+  buzzType,
+}: {
+  domain: 'green' | 'blue' | 'red';
+  buzzType?: 'green' | 'yellow' | 'blue' | 'red';
+}) {
+  await getPaymentIntent({
+    unitAmount: UNIT_AMOUNT,
+    currency: 'USD' as never,
+    recaptchaToken: 'token',
+    setupFuturePayment: true,
+    metadata: {
+      type: 'buzzPurchase',
+      // buzzAmount must be unitAmount * 10 or the amount-tamper guard rejects the purchase first.
+      buzzAmount: UNIT_AMOUNT * 10,
+      unitAmount: UNIT_AMOUNT,
+      userId: USER.id,
+      ...(buzzType ? { buzzType } : {}),
+    },
+    user: USER,
+    // Supplied so the run never reaches createCustomer, which would hit Stripe and the db.
+    customerId: CUSTOMER_ID,
+    domain,
+  });
+
+  return mockPaymentIntentsCreate.mock.calls[0]?.[0]?.metadata?.buzzType;
+}
+
+function overrideLogs() {
+  return (loggingMock.logToAxiom.mock.calls as [{ name?: string }][]).filter(
+    ([payload]) => payload?.name === 'buzz-purchase-currency'
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPaymentIntentsCreate.mockResolvedValue({
+    client_secret: 'secret',
+    payment_method_types: ['card'],
+  });
+  mockGetServerStripe.mockResolvedValue({
+    paymentIntents: { create: mockPaymentIntentsCreate },
+  });
+});
+
+describe('getPaymentIntent — buzz purchase currency', () => {
+  it('credits green on the green domain even when the client asks for yellow', async () => {
+    expect(await purchase({ domain: 'green', buzzType: 'yellow' })).toBe('green');
+  });
+
+  it('credits yellow off-green even when the client asks for green', async () => {
+    expect(await purchase({ domain: 'blue', buzzType: 'green' })).toBe('yellow');
+  });
+
+  it('never credits blue, the free currency, however the client asks', async () => {
+    expect(await purchase({ domain: 'red', buzzType: 'blue' })).toBe('yellow');
+    mockPaymentIntentsCreate.mockClear();
+    expect(await purchase({ domain: 'green', buzzType: 'blue' })).toBe('green');
+  });
+
+  it('stamps a currency when the client omits one, rather than leaving it to a downstream default', async () => {
+    expect(await purchase({ domain: 'green' })).toBe('green');
+    mockPaymentIntentsCreate.mockClear();
+    expect(await purchase({ domain: 'blue' })).toBe('yellow');
+  });
+
+  it('logs the override so a modified client is visible', async () => {
+    await purchase({ domain: 'green', buzzType: 'blue' });
+
+    expect(overrideLogs()).toHaveLength(1);
+    expect(overrideLogs()[0][0]).toMatchObject({
+      userId: USER.id,
+      domain: 'green',
+      clientBuzzType: 'blue',
+      derivedBuzzType: 'green',
+    });
+  });
+
+  it('stays quiet when the client asked for the currency it was going to get', async () => {
+    await purchase({ domain: 'green', buzzType: 'green' });
+
+    expect(overrideLogs()).toHaveLength(0);
+  });
+});

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -52,6 +52,7 @@ import {
   BuzzTypes,
   buzzSpendTypes,
   CASH_SETTLED_ALIASES,
+  coercePurchasedBuzzType,
   TransactionType,
 } from '~/shared/constants/buzz.constants';
 import type { PaymentIntentMetadataSchema } from '~/server/schema/stripe.schema';
@@ -1003,7 +1004,7 @@ export async function completeStripeBuzzTransaction({
       amount: buzzAmount,
       fromAccountId: 0,
       toAccountId: userId,
-      toAccountType: (metadata.buzzType as any) ?? 'yellow', // Default to yellow if not specified
+      toAccountType: coercePurchasedBuzzType(metadata.buzzType),
       type: TransactionType.Purchase,
       description: `Purchase of ${amount} Buzz via Stripe. ${
         purchasesMultiplier && purchasesMultiplier > 1

--- a/src/server/services/stripe.service.ts
+++ b/src/server/services/stripe.service.ts
@@ -36,7 +36,12 @@ import {
 import { sleep } from '~/server/utils/concurrency-helpers';
 import type { SubscriptionProductMetadata } from '~/server/schema/subscriptions.schema';
 import { subscriptionProductMetadataSchema } from '~/server/schema/subscriptions.schema';
-import { TransactionType, buzzConstants } from '~/shared/constants/buzz.constants';
+import {
+  TransactionType,
+  buzzConstants,
+  deriveDomainBuzzType,
+} from '~/shared/constants/buzz.constants';
+import type { ColorDomain } from '~/shared/constants/domain.constants';
 import { invalidateSubscriptionCaches } from '~/server/utils/subscription.utils';
 import { userUpdateCounter } from '~/server/prom/client';
 
@@ -1253,10 +1258,12 @@ export const getPaymentIntent = async ({
   paymentMethodTypes,
   customerId,
   user,
+  domain,
   setupFuturePayment = true,
 }: Schema.PaymentIntentCreationSchema & {
   user: { id: number; email: string };
   customerId?: string;
+  domain: ColorDomain;
 }) => {
   // TODO: If a user doesn't exist, create one. Initially, this will be protected, but ideally, we should create the user on our end
   if (!customerId) {
@@ -1296,6 +1303,26 @@ export const getPaymentIntent = async ({
     sessionUserId: user.id,
   });
 
+  // The browser stamps `metadata.buzzType` and the webhook credits whatever colour it finds
+  // there, so a modified client could route a real-money purchase into a currency it didn't
+  // buy — including `blue`, the free one. Re-derive it here, the last point that still knows
+  // which domain the request came from, and overwrite the client's value.
+  const buzzType = deriveDomainBuzzType(domain);
+  if (metadata.buzzType && metadata.buzzType !== buzzType) {
+    logToAxiom(
+      {
+        name: 'buzz-purchase-currency',
+        type: 'warning',
+        message: 'overrode client-supplied buzzType with the domain-derived currency',
+        userId: user.id,
+        domain,
+        clientBuzzType: metadata.buzzType,
+        derivedBuzzType: buzzType,
+      },
+      'webhooks'
+    ).catch(() => null);
+  }
+
   const stripe = await getServerStripe();
   if (!stripe) throw throwBadRequestError('Stripe is not available');
   const paymentIntent = await stripe.paymentIntents.create({
@@ -1308,7 +1335,7 @@ export const getPaymentIntent = async ({
           }
         : undefined,
     customer: customerId,
-    metadata: validatedMetadata as MetadataParam,
+    metadata: { ...(validatedMetadata as MetadataParam), buzzType },
     payment_method_types: setupFuturePayment
       ? paymentMethodTypes || undefined
       : futureUsageNotSupportedPaymentMethods,

--- a/src/shared/constants/buzz-purchase-currency.test.ts
+++ b/src/shared/constants/buzz-purchase-currency.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buzzPurchaseTypes,
+  coercePurchasedBuzzType,
+  deriveDomainBuzzType,
+} from '~/shared/constants/buzz.constants';
+import { colorDomainNames } from '~/shared/constants/domain.constants';
+
+/**
+ * The two halves of "a real-money Buzz purchase is credited in a currency the buyer actually paid
+ * for": derive the colour from the domain when the intent is created, and narrow whatever comes
+ * back off the provider's metadata when it is credited.
+ */
+
+describe('deriveDomainBuzzType', () => {
+  it('sells green Buzz on the green domain and yellow everywhere else', () => {
+    expect(colorDomainNames.map(deriveDomainBuzzType)).toEqual(
+      // green, blue, red — asserted through the real domain list so a new colour lands here rather
+      // than silently defaulting to yellow.
+      ['green', 'yellow', 'yellow']
+    );
+  });
+
+  it('only ever returns a currency that is actually for sale', () => {
+    for (const domain of colorDomainNames) {
+      expect(buzzPurchaseTypes).toContain(deriveDomainBuzzType(domain));
+    }
+  });
+});
+
+describe('coercePurchasedBuzzType', () => {
+  it('credits blue — the FREE currency — as yellow, however it got into the metadata', () => {
+    expect(coercePurchasedBuzzType('blue')).toBe('yellow');
+  });
+
+  it('keeps green and passes everything else through as yellow', () => {
+    expect(coercePurchasedBuzzType('green')).toBe('green');
+    expect(coercePurchasedBuzzType('yellow')).toBe('yellow');
+    expect(coercePurchasedBuzzType('red')).toBe('yellow');
+    expect(coercePurchasedBuzzType(undefined)).toBe('yellow');
+    expect(coercePurchasedBuzzType('GREEN')).toBe('yellow');
+  });
+});

--- a/src/shared/constants/buzz.constants.ts
+++ b/src/shared/constants/buzz.constants.ts
@@ -14,6 +14,7 @@ import type {
   BuzzCashType,
   LegacyBuzzType,
 } from '@civitai/buzz';
+import type { ColorDomain } from '~/shared/constants/domain.constants';
 
 // The account-type model + friendly↔API name map now live in @civitai/buzz (browser-safe,
 // shared with the SvelteKit spokes). Re-exported here so existing imports keep working.
@@ -127,6 +128,27 @@ export const buzzPurchaseTypes = buzzSpendTypes.filter((type) => {
   const config = buzzTypeConfig[type];
   return config.type === 'spend' && config.purchasable;
 });
+
+/** The currencies a real-money purchase can be credited in. Notably excludes `blue`, which is free. */
+export type PurchasableBuzzType = Extract<BuzzSpendType, 'green' | 'yellow'>;
+
+/**
+ * Which currency a real-money Buzz purchase made on `domain` is credited in. The browser applies the
+ * same rule when it builds the payment-intent metadata; the server re-derives it so a modified client
+ * can't pick a colour it didn't pay for.
+ */
+export function deriveDomainBuzzType(domain: ColorDomain): PurchasableBuzzType {
+  return domain === 'green' ? 'green' : 'yellow';
+}
+
+/**
+ * Narrow a buzz type read back off a payment provider's metadata bag. Provider metadata is
+ * stringly-typed on the wire, and intents created before the server started stamping `buzzType` may
+ * still carry whatever the client asked for — including `blue`, the free currency.
+ */
+export function coercePurchasedBuzzType(value: unknown): PurchasableBuzzType {
+  return value === 'green' ? 'green' : 'yellow';
+}
 
 export class BuzzTypes {
   static getConfig(type: BuzzSpendType) {


### PR DESCRIPTION
The browser stamped `metadata.buzzType` on the payment intent and the Stripe webhook credited whatever colour it found there, so a modified client could route a real-money purchase into a currency it never paid for — including blue, the free one. `getPaymentIntent` now re-derives the currency from the request's domain and overwrites the client value (logging any mismatch), and the webhook credit path narrows the metadata through `coercePurchasedBuzzType` so pre-existing intents can't credit blue either.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868krnzg7`). Reviewed locally before push.