### PR TITLE
fix(image-scan-result): bind scan-result values as SQL parameters

### DIFF
--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -591,14 +591,30 @@ describe('image-scan-result webhook - pipeline tests', () => {
   });
 
   describe('perceptual hash handling', () => {
-    it('rejects a blank hash instead of looking up hashes near zero', async () => {
+    it('records the scan without a lookup when the hash is blank', async () => {
       envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
 
       const req = runWebhook({ id: 11, status: 0, source: TagSource.ImageHash, hash: '   ' });
       await req.promise;
 
       expect(mockClickhouseQuery).not.toHaveBeenCalled();
-      expect(req.res.status).toHaveBeenCalledWith(400);
+      expect(req.res.status).toHaveBeenCalledWith(200);
+      const update = imageUpdates.find((u) => u.text.includes('jsonb_build_object'));
+      expect(update).toBeDefined();
+      expect(update!.text).not.toContain('"pHash"');
+    });
+
+    it('completes the scan when the blocklist lookup fails', async () => {
+      envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
+      mockClickhouseQuery.mockRejectedValue(new Error('socket hang up'));
+
+      const req = runWebhook({ id: 14, status: 0, source: TagSource.ImageHash, hash: '42' });
+      await req.promise;
+
+      expect(mockClickhouseQuery).toHaveBeenCalled();
+      expect(req.res.status).toHaveBeenCalledWith(200);
+      const update = imageUpdates.find((u) => u.params.includes(42n));
+      expect(update).toBeDefined();
     });
 
     it('rejects a hash wider than Int64 rather than letting ClickHouse reject it', async () => {

--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -589,4 +589,40 @@ describe('image-scan-result webhook - pipeline tests', () => {
       expect(update!.params).toContain(`x'; DROP TABLE "Image"; --`);
     });
   });
+
+  describe('perceptual hash handling', () => {
+    it('rejects a blank hash instead of looking up hashes near zero', async () => {
+      envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
+
+      const req = runWebhook({ id: 11, status: 0, source: TagSource.ImageHash, hash: '   ' });
+      await req.promise;
+
+      expect(mockClickhouseQuery).not.toHaveBeenCalled();
+      expect(req.res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('rejects a hash wider than Int64 rather than letting ClickHouse reject it', async () => {
+      envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
+
+      const req = runWebhook({
+        id: 12,
+        status: 0,
+        source: TagSource.ImageHash,
+        hash: '99999999999999999999',
+      });
+      await req.promise;
+
+      expect(mockClickhouseQuery).not.toHaveBeenCalled();
+      expect(req.res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('writes a zero hash rather than leaving the column null', async () => {
+      const req = runWebhook({ id: 13, status: 0, source: TagSource.ImageHash, hash: '0' });
+      await req.promise;
+
+      const update = imageUpdates.find((u) => u.text.includes('"pHash"'));
+      expect(update).toBeDefined();
+      expect(update!.params).toContain(0n);
+    });
+  });
 });

--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -163,7 +163,15 @@ vi.mock('~/env/server', () => ({
 // env proxy: every `if (!clickhouse) return` guard now falls through to the stub below.
 vi.mock('~/server/clickhouse/client', async (importOriginal) => ({
   ...(await importOriginal<typeof ClickhouseClient>()),
-  clickhouse: { $query: mockClickhouseQuery },
+  clickhouse: {
+    $query: mockClickhouseQuery,
+    // Stubbed because the guards above now fall through: the real client also exposes these, and
+    // a path reaching one would otherwise fail as `clickhouse.insert is not a function`.
+    $exec: vi.fn().mockResolvedValue(undefined),
+    insert: vi.fn().mockResolvedValue(undefined),
+    command: vi.fn().mockResolvedValue(undefined),
+    query: vi.fn().mockResolvedValue({ json: async () => [] }),
+  },
 }));
 
 vi.mock('~/server/services/feature-flags.service', async (importOriginal) => {
@@ -606,13 +614,16 @@ describe('image-scan-result webhook - pipeline tests', () => {
       ).toBe(true);
     });
 
-    it('writes a zero hash rather than leaving the column null', async () => {
+    it('stores a zero hash but does not look it up', async () => {
+      envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
+
       const req = runWebhook({ id: 15, status: 0, source: TagSource.ImageHash, hash: '0' });
       await req.promise;
 
       const update = imageUpdates.find((u) => u.text.includes('"pHash"'));
       expect(update).toBeDefined();
       expect(update!.params).toContain(0n);
+      expect(mockClickhouseQuery).not.toHaveBeenCalled();
     });
 
     it('completes the scan when the blocklist lookup fails', async () => {

--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -9,13 +9,15 @@ const {
   mockInsertTagsOnImageNew,
   mockUpsertTagsOnImageNew,
   mockLogToAxiom,
+  mockClickhouseQuery,
+  envOverrides,
   tagsDb,
 } = vi.hoisted(() => {
   const tagsDb = [
     { id: 100, name: 'hate symbols', nsfwLevel: 32 }, // Blocked
-    { id: 200, name: 'teen', nsfwLevel: 1 },         // PG
+    { id: 200, name: 'teen', nsfwLevel: 1 }, // PG
     { id: 300, name: 'potential celebrity', nsfwLevel: 1 }, // PG
-    { id: 400, name: 'some-tag', nsfwLevel: 8 },      // X
+    { id: 400, name: 'some-tag', nsfwLevel: 8 }, // X
     { id: 1001, name: 'pg', nsfwLevel: 1 },
     { id: 1002, name: 'pg-13', nsfwLevel: 2 },
     { id: 1003, name: 'r', nsfwLevel: 4 },
@@ -109,6 +111,8 @@ const {
 
   return {
     tagsDb,
+    envOverrides: { BLOCKED_IMAGE_HASH_CHECK: false } as { BLOCKED_IMAGE_HASH_CHECK: boolean },
+    mockClickhouseQuery: vi.fn().mockResolvedValue([{ count: 0 }]),
     mockDbWrite: createDbMock(),
     mockInsertTagsOnImageNew: vi.fn().mockResolvedValue(undefined),
     mockUpsertTagsOnImageNew: vi.fn().mockResolvedValue(undefined),
@@ -134,19 +138,36 @@ vi.mock('~/server/logging/client', () => ({
 }));
 
 vi.mock('~/env/server', () => ({
-  env: new Proxy({}, {
-    get(target, prop: string) {
-      if (prop === 'WEBHOOK_TOKEN') return 'mock-webhook-token';
-      if (prop === 'BLOCKED_IMAGE_HASH_CHECK') return false;
-      if (prop === 'LOGGING') return [];
-      if (prop === 'EMAIL_PORT') return 587;
-      if (prop === 'DATABASE_SSL') return false;
-      if (prop.endsWith('URL') || prop.endsWith('_URL') || prop.endsWith('ENDPOINT')) return 'http://localhost:3000';
-      if (prop.endsWith('CONCURRENCY')) return 5;
-      return 'mock-value';
-    },
-  }),
+  env: new Proxy(
+    {},
+    {
+      get(target, prop: string) {
+        if (prop === 'WEBHOOK_TOKEN') return 'mock-webhook-token';
+        if (prop === 'BLOCKED_IMAGE_HASH_CHECK') return envOverrides.BLOCKED_IMAGE_HASH_CHECK;
+        if (prop === 'LOGGING') return [];
+        if (prop === 'EMAIL_PORT') return 587;
+        if (prop === 'DATABASE_SSL') return false;
+        if (prop.endsWith('URL') || prop.endsWith('_URL') || prop.endsWith('ENDPOINT'))
+          return 'http://localhost:3000';
+        if (prop.endsWith('CONCURRENCY')) return 5;
+        return 'mock-value';
+      },
+    }
+  ),
 }));
+
+// Namespace proxy rather than a hand-listed mock: the module also re-exports the Tracker, and
+// importing it for real builds a live ClickHouse client.
+vi.mock('~/server/clickhouse/client', () => {
+  const known: Record<string, unknown> = { clickhouse: { $query: mockClickhouseQuery } };
+  return new Proxy(known, {
+    get(target, prop) {
+      if (typeof prop !== 'string' || prop === 'then' || prop === '__esModule') return undefined;
+      if (!(prop in target)) target[prop] = vi.fn();
+      return target[prop];
+    },
+  });
+});
 
 vi.mock('~/server/services/feature-flags.service', async (importOriginal) => {
   const actual = await importOriginal<any>();
@@ -236,13 +257,38 @@ vi.mock('~/server/services/image.service', () => ({
   imageScanTypes: [3, 9], // ImageScanType.WD14, ImageScanType.SpineRating
 }));
 
+// Render a Prisma tagged-template call the way the driver does: nested `Prisma.sql` fragments
+// are inlined, every interpolated value becomes a `$n` placeholder. A value that shows up in
+// `text` rather than `params` is being concatenated into SQL, which is what the injection tests
+// below assert against.
+const renderSql = (strings: readonly string[], values: any[]): { text: string; params: any[] } => {
+  let text = '';
+  const params: any[] = [];
+  strings.forEach((part, i) => {
+    text += part;
+    if (i >= values.length) return;
+    const value = values[i];
+    if (value && Array.isArray(value.strings) && Array.isArray(value.values)) {
+      const inner = renderSql(value.strings, value.values);
+      text += inner.text.replace(/\$(\d+)/g, (_m, n) => `$${params.length + Number(n)}`);
+      params.push(...inner.params);
+    } else {
+      params.push(value);
+      text += `$${params.length}`;
+    }
+  });
+  return { text, params };
+};
+
 describe('image-scan-result webhook - pipeline tests', () => {
   const imageDbState = new Map<number, any>();
+  const imageUpdates: { text: string; params: any[] }[] = [];
 
   const getImageState = (id: number) => {
     if (!imageDbState.has(id)) {
       // Set initial scans: Image 2, 5, 6, 7 have SpineRating pre-completed
-      const scans = (id === 2 || id === 5 || id === 6 || id === 7) ? { [TagSource.SpineRating]: Date.now() } : {};
+      const scans =
+        id === 2 || id === 5 || id === 6 || id === 7 ? { [TagSource.SpineRating]: Date.now() } : {};
       imageDbState.set(id, {
         id,
         createdAt: new Date(),
@@ -264,10 +310,15 @@ describe('image-scan-result webhook - pipeline tests', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     imageDbState.clear();
+    imageUpdates.length = 0;
+    envOverrides.BLOCKED_IMAGE_HASH_CHECK = false;
+    mockClickhouseQuery.mockResolvedValue([{ count: 0 }]);
 
-    mockDbWrite.image.findUnique.mockImplementation(async ({ where }: { where: { id: number } }) => {
-      return getImageState(where.id);
-    });
+    mockDbWrite.image.findUnique.mockImplementation(
+      async ({ where }: { where: { id: number } }) => {
+        return getImageState(where.id);
+      }
+    );
 
     mockDbWrite.tag.findMany.mockImplementation(async ({ where }: any) => {
       if (where.name?.in) {
@@ -281,34 +332,27 @@ describe('image-scan-result webhook - pipeline tests', () => {
       return [];
     });
 
-    mockDbWrite.$queryRawUnsafe.mockImplementation(async (query: string) => {
-      const match = query.match(/WHERE id = (\d+)/) || query.match(/id = (\d+)/) || query.match(/id IN \((\d+)\)/);
-      const id = match ? parseInt(match[1], 10) : 1;
-      const state = getImageState(id);
-
-      let source: string | undefined;
-      if (query.includes('Clavata')) source = 'Clavata';
-      else if (query.includes('WD14')) source = 'WD14';
-      else if (query.includes('SpineRating')) source = 'SpineRating';
-
-      if (source) {
-        state.scanJobs.scans[source] = Date.now();
-      }
-
-      return [
-        {
-          scanJobs: state.scanJobs,
-          type: 'image',
-        },
-      ];
-    });
-
     mockDbWrite.$queryRaw.mockImplementation(async (query: any, ...values: any[]) => {
       const queryString = Array.isArray(query)
         ? query.join('')
         : query?.strings
         ? query.strings.join('')
         : String(query);
+
+      if (queryString.includes('UPDATE "Image"')) {
+        const rendered = renderSql(Array.isArray(query) ? query : query.strings, values);
+        imageUpdates.push(rendered);
+
+        const idIndex = rendered.text.match(/id = \$(\d+)/);
+        const id = idIndex ? rendered.params[Number(idIndex[1]) - 1] : 1;
+        const state = getImageState(id);
+
+        const sourceIndex = rendered.text.match(/jsonb_build_object\(\$(\d+)::text/);
+        const source = sourceIndex ? rendered.params[Number(sourceIndex[1]) - 1] : undefined;
+        if (source) state.scanJobs.scans[source] = Date.now();
+
+        return [{ scanJobs: state.scanJobs, type: 'image' }];
+      }
 
       if (queryString.includes('is_new_user')) {
         return [{ isNewUser: false }];
@@ -328,7 +372,7 @@ describe('image-scan-result webhook - pipeline tests', () => {
         return insertedTags
           .filter((t) => t.imageId === imageId && !t.disabled)
           .map((t) => {
-            const tagInfo = tagsDb.find(td => td.id === t.tagId);
+            const tagInfo = tagsDb.find((td) => td.id === t.tagId);
             return {
               id: t.tagId,
               name: tagInfo?.name ?? 'unknown-tag',
@@ -428,9 +472,8 @@ describe('image-scan-result webhook - pipeline tests', () => {
     await req.promise;
 
     expect(req.res.status).toHaveBeenCalledWith(200);
-    expect(mockDbWrite.$queryRawUnsafe).toHaveBeenCalled();
-    const queryCall = mockDbWrite.$queryRawUnsafe.mock.calls.find((call: any) =>
-      call[0].includes('retryCount') && call[0].includes('4')
+    const queryCall = imageUpdates.find(
+      (update) => update.text.includes('retryCount') && update.params.includes(4)
     );
     expect(queryCall).toBeDefined();
   });
@@ -493,5 +536,57 @@ describe('image-scan-result webhook - pipeline tests', () => {
     const updateForImage7 = dbUpdates.find((call: any) => call[0].where.id === 7);
     expect(updateForImage7).toBeDefined();
     expect(updateForImage7[0].data.nsfwLevel).toBeUndefined(); // locked, so undefined (not updated)
+  });
+
+  describe('webhook body strings never reach SQL text', () => {
+    const INJECTED = `1 OR 1=1) < 5 AND disabled = false -- `;
+
+    it('rejects a non-numeric hash before it can reach the ClickHouse query', async () => {
+      envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
+
+      const req = runWebhook({
+        id: 8,
+        status: 0,
+        source: TagSource.ImageHash,
+        hash: INJECTED,
+      });
+      await req.promise;
+
+      expect(mockClickhouseQuery).not.toHaveBeenCalled();
+      expect(req.res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('passes a valid hash to ClickHouse as digits only', async () => {
+      envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
+
+      const req = runWebhook({
+        id: 9,
+        status: 0,
+        source: TagSource.ImageHash,
+        hash: '-1234567890123456789',
+      });
+      await req.promise;
+
+      expect(mockClickhouseQuery).toHaveBeenCalled();
+      const [strings, ...values] = mockClickhouseQuery.mock.calls[0];
+      expect(strings.join('?')).toContain('bitXor(hash, ?)');
+      expect(values).toEqual([-1234567890123456789n]);
+    });
+
+    it('sends the scanner-supplied model id as a parameter, not as SQL text', async () => {
+      const req = runWebhook({
+        id: 10,
+        status: 0,
+        source: TagSource.WD14,
+        tags: [],
+        context: { movie_rating: 'PG', movie_rating_model_id: `x'; DROP TABLE "Image"; --` },
+      });
+      await req.promise;
+
+      const update = imageUpdates.find((u) => u.text.includes('"aiModel"'));
+      expect(update).toBeDefined();
+      expect(update!.text).not.toContain('DROP TABLE');
+      expect(update!.params).toContain(`x'; DROP TABLE "Image"; --`);
+    });
   });
 });

--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import handler from '~/pages/api/webhooks/image-scan-result';
+import type * as ClickhouseClient from '~/server/clickhouse/client';
 import { TagSource, ImageIngestionStatus } from '~/shared/utils/prisma/enums';
 import { NsfwLevel } from '~/server/common/enums';
 
@@ -156,11 +157,12 @@ vi.mock('~/env/server', () => ({
   ),
 }));
 
-// Mocked rather than imported for real, which would build a live ClickHouse client. Deliberately
-// NOT a namespace proxy: this makes `clickhouse` truthy for the whole suite, so every
-// `if (!clickhouse) return` guard in the handler's graph now falls through to this object. A
-// call it does not stub should fail loudly here rather than auto-vivify into a silent no-op.
-vi.mock('~/server/clickhouse/client', () => ({
+// Spread the real module so the Tracker and the re-exported base client stay intact — two modules
+// in the handler's graph import from this path. Only `clickhouse` is replaced, and doing so makes
+// it truthy for the whole file, where the real shim resolves it to undefined under this suite's
+// env proxy: every `if (!clickhouse) return` guard now falls through to the stub below.
+vi.mock('~/server/clickhouse/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof ClickhouseClient>()),
   clickhouse: { $query: mockClickhouseQuery },
 }));
 
@@ -642,13 +644,19 @@ describe('image-scan-result webhook - pipeline tests', () => {
       expect(req.res.status).toHaveBeenCalledWith(400);
     });
 
-    it('writes a zero hash rather than leaving the column null', async () => {
-      const req = runWebhook({ id: 13, status: 0, source: TagSource.ImageHash, hash: '0' });
+    it('binds a hash as a bigint parameter, not as SQL text', async () => {
+      const req = runWebhook({
+        id: 13,
+        status: 0,
+        source: TagSource.ImageHash,
+        hash: '4611686018427387904',
+      });
       await req.promise;
 
       const update = imageUpdates.find((u) => u.text.includes('"pHash"'));
       expect(update).toBeDefined();
-      expect(update!.params).toContain(0n);
+      expect(update!.params).toContain(4611686018427387904n);
+      expect(update!.text).not.toContain('4611686018427387904');
     });
   });
 });

--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -156,18 +156,13 @@ vi.mock('~/env/server', () => ({
   ),
 }));
 
-// Namespace proxy rather than a hand-listed mock: the module also re-exports the Tracker, and
-// importing it for real builds a live ClickHouse client.
-vi.mock('~/server/clickhouse/client', () => {
-  const known: Record<string, unknown> = { clickhouse: { $query: mockClickhouseQuery } };
-  return new Proxy(known, {
-    get(target, prop) {
-      if (typeof prop !== 'string' || prop === 'then' || prop === '__esModule') return undefined;
-      if (!(prop in target)) target[prop] = vi.fn();
-      return target[prop];
-    },
-  });
-});
+// Mocked rather than imported for real, which would build a live ClickHouse client. Deliberately
+// NOT a namespace proxy: this makes `clickhouse` truthy for the whole suite, so every
+// `if (!clickhouse) return` guard in the handler's graph now falls through to this object. A
+// call it does not stub should fail loudly here rather than auto-vivify into a silent no-op.
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: { $query: mockClickhouseQuery },
+}));
 
 vi.mock('~/server/services/feature-flags.service', async (importOriginal) => {
   const actual = await importOriginal<any>();
@@ -602,19 +597,21 @@ describe('image-scan-result webhook - pipeline tests', () => {
       const update = imageUpdates.find((u) => u.text.includes('jsonb_build_object'));
       expect(update).toBeDefined();
       expect(update!.text).not.toContain('"pHash"');
+      expect(
+        mockLogToAxiom.mock.calls.some(
+          (call) => call[0]?.message === 'blank hash from ImageHash scan'
+        )
+      ).toBe(true);
     });
 
-    it('retries the blocklist lookup after a dropped socket', async () => {
+    it('does not re-run the blocklist lookup after a failure', async () => {
       envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
-      mockClickhouseQuery
-        .mockRejectedValueOnce(new Error('socket hang up'))
-        .mockResolvedValue([{ count: 0 }]);
+      mockClickhouseQuery.mockRejectedValue(new Error('socket hang up'));
 
       const req = runWebhook({ id: 15, status: 0, source: TagSource.ImageHash, hash: '42' });
       await req.promise;
 
-      expect(mockClickhouseQuery).toHaveBeenCalledTimes(2);
-      expect(req.res.status).toHaveBeenCalledWith(200);
+      expect(mockClickhouseQuery).toHaveBeenCalledTimes(1);
     });
 
     it('completes the scan when the blocklist lookup fails', async () => {

--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -604,6 +604,19 @@ describe('image-scan-result webhook - pipeline tests', () => {
       expect(update!.text).not.toContain('"pHash"');
     });
 
+    it('retries the blocklist lookup after a dropped socket', async () => {
+      envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
+      mockClickhouseQuery
+        .mockRejectedValueOnce(new Error('socket hang up'))
+        .mockResolvedValue([{ count: 0 }]);
+
+      const req = runWebhook({ id: 15, status: 0, source: TagSource.ImageHash, hash: '42' });
+      await req.promise;
+
+      expect(mockClickhouseQuery).toHaveBeenCalledTimes(2);
+      expect(req.res.status).toHaveBeenCalledWith(200);
+    });
+
     it('completes the scan when the blocklist lookup fails', async () => {
       envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
       mockClickhouseQuery.mockRejectedValue(new Error('socket hang up'));

--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -561,6 +561,20 @@ describe('image-scan-result webhook - pipeline tests', () => {
       expect(req.res.status).toHaveBeenCalledWith(400);
     });
 
+    it('logs a match against the parsed hash, not the string the scanner sent', async () => {
+      envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
+      mockClickhouseQuery.mockResolvedValue([{ count: 1 }]);
+
+      const req = runWebhook({ id: 16, status: 0, source: TagSource.ImageHash, hash: ' 42 ' });
+      await req.promise;
+
+      const match = mockLogToAxiom.mock.calls.find(
+        (call) => call[0]?.message === 'Image pHash matched a blocked image'
+      );
+      expect(match).toBeDefined();
+      expect(match![0].pHash).toBe('42');
+    });
+
     it('passes a valid hash to ClickHouse as digits only', async () => {
       envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
 

--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -606,14 +606,13 @@ describe('image-scan-result webhook - pipeline tests', () => {
       ).toBe(true);
     });
 
-    it('does not re-run the blocklist lookup after a failure', async () => {
-      envOverrides.BLOCKED_IMAGE_HASH_CHECK = true;
-      mockClickhouseQuery.mockRejectedValue(new Error('socket hang up'));
-
-      const req = runWebhook({ id: 15, status: 0, source: TagSource.ImageHash, hash: '42' });
+    it('writes a zero hash rather than leaving the column null', async () => {
+      const req = runWebhook({ id: 15, status: 0, source: TagSource.ImageHash, hash: '0' });
       await req.promise;
 
-      expect(mockClickhouseQuery).toHaveBeenCalledTimes(1);
+      const update = imageUpdates.find((u) => u.text.includes('"pHash"'));
+      expect(update).toBeDefined();
+      expect(update!.params).toContain(0n);
     });
 
     it('completes the scan when the blocklist lookup fails', async () => {

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -233,14 +233,7 @@ export default WebhookEndpoint(async (req, res) => {
 
 type Tag = { tag: string; confidence: number; id?: number; source?: TagSource };
 
-// @see https://stackoverflow.com/questions/14925151/hamming-distance-optimization-for-mysql-or-postgresql
-// 1-10:  The images are visually almost identical
-// 11-20: The images are visually similar
-// 21-30: The images are visually somewhat similar
-// `BigInt('  ')` is 0n, which would silently become a real Hamming lookup against every
-// blocked image within 4 bits of zero. Undefined rather than a throw, so a blank hash
-// still records the scan the way it did before the hash was parsed at all — a 400 here
-// makes the scanner redeliver the same unusable result forever.
+// `BigInt('  ')` is 0n, which a blank hash must not become: it is a legitimate hash value.
 function parsePerceptualHash(hash: string) {
   const invalid = new Error('invalid hash from ImageHash scan');
   if (!hash.trim()) return undefined;
@@ -256,14 +249,16 @@ function parsePerceptualHash(hash: string) {
   return parsed;
 }
 
+// @see https://stackoverflow.com/questions/14925151/hamming-distance-optimization-for-mysql-or-postgresql
+// 1-10:  The images are visually almost identical
+// 11-20: The images are visually similar
+// 21-30: The images are visually somewhat similar
+//
 // `$query` interpolates into the SQL text rather than binding parameters, so this must
 // only ever be handed a bigint — never the raw string off the webhook body.
 async function isBlocked(hash: bigint) {
   if (!env.BLOCKED_IMAGE_HASH_CHECK || !clickhouse) return false;
 
-  // One attempt on purpose. Nothing consumes this result — the blocking update it feeds is
-  // commented out — so retrying buys a log line, and against a hung ClickHouse rather than a
-  // refused one it would hold the request for a multiple of the client timeout.
   const rows = await clickhouse.$query<{ count: number }>`
     SELECT cast(count() as int) as count
     FROM blocked_images
@@ -885,10 +880,7 @@ async function updateImageScanJobs({
   );
 
   const setClauses: Prisma.Sql[] = [];
-  // A zero hash is skipped, so a flat image keeps a null pHash. That is what this did before
-  // the rewrite, and whether to store the zero instead is open — writing it would let one
-  // blocked flat image match every other flat image at distance 0.
-  if (pHash) setClauses.push(Prisma.sql`"pHash" = ${pHash}`);
+  if (pHash !== undefined) setClauses.push(Prisma.sql`"pHash" = ${pHash}`);
   if (ingestion) setClauses.push(Prisma.sql`"ingestion" = ${ingestion}::"ImageIngestionStatus"`);
   if (nsfwLevel) setClauses.push(Prisma.sql`"nsfwLevel" = ${nsfwLevel}`);
   if (blockedFor) setClauses.push(Prisma.sql`"blockedFor" = ${blockedFor}`);
@@ -947,8 +939,6 @@ async function processScanResult({
       if (!hash) throw new Error('missing hash from ImageHash scan');
       const pHash = parsePerceptualHash(hash);
       if (pHash === undefined) {
-        // Acked rather than rejected, so a hasher regression emitting blanks is otherwise
-        // invisible: the rows go out scanned with a null pHash and the scanner never retries.
         logToAxiom(
           {
             name: 'image-phash-match',
@@ -960,8 +950,6 @@ async function processScanResult({
           'webhooks'
         ).catch(() => null);
       }
-      // Nothing branches on this result — the blocking update below is commented out — so a
-      // ClickHouse blip must not discard a scan result.
       const blocked =
         pHash === undefined
           ? false
@@ -992,6 +980,8 @@ async function processScanResult({
           'webhooks'
         ).catch(() => null);
 
+        // Before uncommenting: `isBlocked` swallows a ClickHouse failure as "not blocked", and
+        // does not retry. Both are only safe while nothing acts on the result.
         // return await updateImageScanJobs({
         //   id,
         //   source,

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -885,9 +885,10 @@ async function updateImageScanJobs({
   );
 
   const setClauses: Prisma.Sql[] = [];
-  // 0n is a legitimate hash (a flat image), and skipping it leaves the row scanned with a
-  // null pHash, which excludes it from blocklist matching for good.
-  if (pHash !== undefined) setClauses.push(Prisma.sql`"pHash" = ${pHash}`);
+  // A zero hash is skipped, so a flat image keeps a null pHash. That is what this did before
+  // the rewrite, and whether to store the zero instead is open — writing it would let one
+  // blocked flat image match every other flat image at distance 0.
+  if (pHash) setClauses.push(Prisma.sql`"pHash" = ${pHash}`);
   if (ingestion) setClauses.push(Prisma.sql`"ingestion" = ${ingestion}::"ImageIngestionStatus"`);
   if (nsfwLevel) setClauses.push(Prisma.sql`"nsfwLevel" = ${nsfwLevel}`);
   if (blockedFor) setClauses.push(Prisma.sql`"blockedFor" = ${blockedFor}`);

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -51,6 +51,7 @@ import {
   TagType,
 } from '~/shared/utils/prisma/enums';
 import { decreaseDate } from '~/utils/date-helpers';
+import { withRetries } from '~/utils/errorHandling';
 import {
   auditMetaData,
   getTagsFromPrompt,
@@ -261,13 +262,19 @@ function parsePerceptualHash(hash: string) {
 async function isBlocked(hash: bigint) {
   if (!env.BLOCKED_IMAGE_HASH_CHECK || !clickhouse) return false;
 
-  const [{ count }] = await clickhouse.$query<{ count: number }>`
-    SELECT cast(count() as int) as count
-    FROM blocked_images
-    WHERE bitCount(bitXor(hash, ${hash})) < 5 AND disabled = false
-  `;
+  const client = clickhouse;
+  // `$query` has no retry of its own and the observed failure is a dropped socket.
+  const rows = await withRetries(
+    () => client.$query<{ count: number }>`
+      SELECT cast(count() as int) as count
+      FROM blocked_images
+      WHERE bitCount(bitXor(hash, ${hash})) < 5 AND disabled = false
+    `,
+    2,
+    250
+  );
 
-  return count > 0;
+  return (rows?.[0]?.count ?? 0) > 0;
 }
 
 async function handleSuccess(args: BodyProps, req: NextApiRequest) {

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -950,23 +950,24 @@ async function processScanResult({
           'webhooks'
         ).catch(() => null);
       }
-      const blocked =
-        pHash === undefined
-          ? false
-          : await isBlocked(pHash).catch((error) => {
-              logToAxiom(
-                {
-                  name: 'image-phash-match',
-                  type: 'warning',
-                  message: 'pHash blocklist check failed',
-                  imageId: id,
-                  error: error instanceof Error ? error.message : 'Unknown error',
-                  source: 'webhook-legacy',
-                },
-                'webhooks'
-              ).catch(() => null);
-              return false;
-            });
+      // Skipped at zero: `bitXor(hash, 0)` degenerates to `bitCount(hash) < 5`, which matches any
+      // low-popcount blocked hash rather than a near-duplicate of this image. Stored regardless.
+      const blocked = !pHash
+        ? false
+        : await isBlocked(pHash).catch((error) => {
+            logToAxiom(
+              {
+                name: 'image-phash-match',
+                type: 'warning',
+                message: 'pHash blocklist check failed',
+                imageId: id,
+                error: error instanceof Error ? error.message : 'Unknown error',
+                source: 'webhook-legacy',
+              },
+              'webhooks'
+            ).catch(() => null);
+            return false;
+          });
       if (blocked) {
         logToAxiom(
           {

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -237,12 +237,13 @@ type Tag = { tag: string; confidence: number; id?: number; source?: TagSource };
 // 1-10:  The images are visually almost identical
 // 11-20: The images are visually similar
 // 21-30: The images are visually somewhat similar
-// `BigInt('')` and `BigInt('  ')` are 0n, which would silently become a real Hamming
-// lookup against every blocked image within 4 bits of zero. Out-of-Int64 values would
-// reach ClickHouse and fail there, past the point this claims to have checked them.
+// `BigInt('  ')` is 0n, which would silently become a real Hamming lookup against every
+// blocked image within 4 bits of zero. Undefined rather than a throw, so a blank hash
+// still records the scan the way it did before the hash was parsed at all — a 400 here
+// makes the scanner redeliver the same unusable result forever.
 function parsePerceptualHash(hash: string) {
   const invalid = new Error('invalid hash from ImageHash scan');
-  if (!hash.trim()) throw invalid;
+  if (!hash.trim()) return undefined;
 
   let parsed: bigint;
   try {
@@ -941,7 +942,25 @@ async function processScanResult({
     case TagSource.ImageHash: {
       if (!hash) throw new Error('missing hash from ImageHash scan');
       const pHash = parsePerceptualHash(hash);
-      const blocked = await isBlocked(pHash);
+      // Nothing branches on this result — the blocking update below is commented out — so a
+      // ClickHouse blip must not discard a scan result. Same reasoning as `getIsImageBlocked`.
+      const blocked =
+        pHash === undefined
+          ? false
+          : await isBlocked(pHash).catch((error) => {
+              logToAxiom(
+                {
+                  name: 'image-phash-match',
+                  type: 'warning',
+                  message: 'pHash blocklist check failed',
+                  imageId: id,
+                  error: error instanceof Error ? error.message : 'Unknown error',
+                  source: 'webhook-legacy',
+                },
+                'webhooks'
+              ).catch(() => null);
+              return false;
+            });
       if (blocked) {
         logToAxiom(
           {

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -237,12 +237,22 @@ type Tag = { tag: string; confidence: number; id?: number; source?: TagSource };
 // 1-10:  The images are visually almost identical
 // 11-20: The images are visually similar
 // 21-30: The images are visually somewhat similar
+// `BigInt('')` and `BigInt('  ')` are 0n, which would silently become a real Hamming
+// lookup against every blocked image within 4 bits of zero. Out-of-Int64 values would
+// reach ClickHouse and fail there, past the point this claims to have checked them.
 function parsePerceptualHash(hash: string) {
+  const invalid = new Error('invalid hash from ImageHash scan');
+  if (!hash.trim()) throw invalid;
+
+  let parsed: bigint;
   try {
-    return BigInt(hash);
+    parsed = BigInt(hash);
   } catch {
-    throw new Error('invalid hash from ImageHash scan');
+    throw invalid;
   }
+  if (BigInt.asIntN(64, parsed) !== parsed) throw invalid;
+
+  return parsed;
 }
 
 // `$query` interpolates into the SQL text rather than binding parameters, so this must
@@ -871,7 +881,9 @@ async function updateImageScanJobs({
   );
 
   const setClauses: Prisma.Sql[] = [];
-  if (pHash) setClauses.push(Prisma.sql`"pHash" = ${pHash}`);
+  // 0n is a legitimate hash (a flat image), and skipping it leaves the row scanned with a
+  // null pHash, which excludes it from blocklist matching for good.
+  if (pHash !== undefined) setClauses.push(Prisma.sql`"pHash" = ${pHash}`);
   if (ingestion) setClauses.push(Prisma.sql`"ingestion" = ${ingestion}::"ImageIngestionStatus"`);
   if (nsfwLevel) setClauses.push(Prisma.sql`"nsfwLevel" = ${nsfwLevel}`);
   if (blockedFor) setClauses.push(Prisma.sql`"blockedFor" = ${blockedFor}`);

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -51,7 +51,6 @@ import {
   TagType,
 } from '~/shared/utils/prisma/enums';
 import { decreaseDate } from '~/utils/date-helpers';
-import { withRetries } from '~/utils/errorHandling';
 import {
   auditMetaData,
   getTagsFromPrompt,
@@ -262,17 +261,14 @@ function parsePerceptualHash(hash: string) {
 async function isBlocked(hash: bigint) {
   if (!env.BLOCKED_IMAGE_HASH_CHECK || !clickhouse) return false;
 
-  const client = clickhouse;
-  // `$query` has no retry of its own and the observed failure is a dropped socket.
-  const rows = await withRetries(
-    () => client.$query<{ count: number }>`
-      SELECT cast(count() as int) as count
-      FROM blocked_images
-      WHERE bitCount(bitXor(hash, ${hash})) < 5 AND disabled = false
-    `,
-    2,
-    250
-  );
+  // One attempt on purpose. Nothing consumes this result — the blocking update it feeds is
+  // commented out — so retrying buys a log line, and against a hung ClickHouse rather than a
+  // refused one it would hold the request for a multiple of the client timeout.
+  const rows = await clickhouse.$query<{ count: number }>`
+    SELECT cast(count() as int) as count
+    FROM blocked_images
+    WHERE bitCount(bitXor(hash, ${hash})) < 5 AND disabled = false
+  `;
 
   return (rows?.[0]?.count ?? 0) > 0;
 }
@@ -949,8 +945,22 @@ async function processScanResult({
     case TagSource.ImageHash: {
       if (!hash) throw new Error('missing hash from ImageHash scan');
       const pHash = parsePerceptualHash(hash);
+      if (pHash === undefined) {
+        // Acked rather than rejected, so a hasher regression emitting blanks is otherwise
+        // invisible: the rows go out scanned with a null pHash and the scanner never retries.
+        logToAxiom(
+          {
+            name: 'image-phash-match',
+            type: 'warning',
+            message: 'blank hash from ImageHash scan',
+            imageId: id,
+            source: 'webhook-legacy',
+          },
+          'webhooks'
+        ).catch(() => null);
+      }
       // Nothing branches on this result — the blocking update below is commented out — so a
-      // ClickHouse blip must not discard a scan result. Same reasoning as `getIsImageBlocked`.
+      // ClickHouse blip must not discard a scan result.
       const blocked =
         pHash === undefined
           ? false

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -1,5 +1,5 @@
 import { isDev } from '~/env/other';
-import type { Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { uniqBy } from 'lodash-es';
 import * as z from 'zod';
 import { env } from '~/env/server';
@@ -237,7 +237,17 @@ type Tag = { tag: string; confidence: number; id?: number; source?: TagSource };
 // 1-10:  The images are visually almost identical
 // 11-20: The images are visually similar
 // 21-30: The images are visually somewhat similar
-async function isBlocked(hash: string) {
+function parsePerceptualHash(hash: string) {
+  try {
+    return BigInt(hash);
+  } catch {
+    throw new Error('invalid hash from ImageHash scan');
+  }
+}
+
+// `$query` interpolates into the SQL text rather than binding parameters, so this must
+// only ever be handed a bigint — never the raw string off the webhook body.
+async function isBlocked(hash: bigint) {
   if (!env.BLOCKED_IMAGE_HASH_CHECK || !clickhouse) return false;
 
   const [{ count }] = await clickhouse.$query<{ count: number }>`
@@ -836,17 +846,19 @@ async function updateImageScanJobs({
   whereIngestionIn?: ImageIngestionStatus[];
 }) {
   // Build scanJobs update SQL by composing jsonb operations
-  const scanJobsOps: { path: string; value: string }[] = [];
+  const scanJobsOps: { path: Prisma.Sql; value: Prisma.Sql }[] = [];
   if (source) {
     scanJobsOps.push({
-      path: `'{scans}'`,
-      value: `COALESCE("scanJobs"->'scans', '{}') || '{"${source}": ${Date.now()}}'::jsonb`,
+      path: Prisma.sql`'{scans}'`,
+      value: Prisma.sql`COALESCE("scanJobs"->'scans', '{}') || jsonb_build_object(${source}::text, ${String(
+        Date.now()
+      )}::bigint)`,
     });
   }
   if (incrementRetryCount) {
     scanJobsOps.push({
-      path: `'{retryCount}'`,
-      value: `to_jsonb(COALESCE(("scanJobs"->>'retryCount')::int, 0) + 1)`,
+      path: Prisma.sql`'{retryCount}'`,
+      value: Prisma.sql`to_jsonb(COALESCE(("scanJobs"->>'retryCount')::int, 0) + 1)`,
     });
   }
   if (!scanJobsOps.length) {
@@ -854,34 +866,39 @@ async function updateImageScanJobs({
   }
   // Nest jsonb_set calls: jsonb_set(jsonb_set(base, path1, val1), path2, val2)
   const scanJobsSql = scanJobsOps.reduce(
-    (acc, op) => `jsonb_set(${acc}, ${op.path}, ${op.value})`,
-    `COALESCE("scanJobs", '{}')`
+    (acc, op) => Prisma.sql`jsonb_set(${acc}, ${op.path}, ${op.value})`,
+    Prisma.sql`COALESCE("scanJobs", '{}')`
   );
 
-  // Build WHERE clause dynamically
-  const whereConditions = [`id = ${id}`];
-  if (whereIngestionIn?.length) {
-    whereConditions.push(`ingestion IN (${whereIngestionIn.map((s) => `'${s}'`).join(', ')})`);
-  }
-  const whereClause = whereConditions.join(' AND ');
+  const setClauses: Prisma.Sql[] = [];
+  if (pHash) setClauses.push(Prisma.sql`"pHash" = ${pHash}`);
+  if (ingestion) setClauses.push(Prisma.sql`"ingestion" = ${ingestion}::"ImageIngestionStatus"`);
+  if (nsfwLevel) setClauses.push(Prisma.sql`"nsfwLevel" = ${nsfwLevel}`);
+  if (blockedFor) setClauses.push(Prisma.sql`"blockedFor" = ${blockedFor}`);
+  if (aiRating) setClauses.push(Prisma.sql`"aiNsfwLevel" = ${aiRating}`);
+  if (aiModel) setClauses.push(Prisma.sql`"aiModel" = ${aiModel}`);
+  setClauses.push(Prisma.sql`"scanJobs" = ${scanJobsSql}`);
 
-  const result = await dbWrite.$queryRawUnsafe<
+  const whereConditions = [Prisma.sql`id = ${id}`];
+  if (whereIngestionIn?.length) {
+    whereConditions.push(
+      Prisma.sql`ingestion IN (${Prisma.join(
+        whereIngestionIn.map((s) => Prisma.sql`${s}::"ImageIngestionStatus"`)
+      )})`
+    );
+  }
+
+  const result = await dbWrite.$queryRaw<
     {
       scanJobs: { scans?: Record<string, TagSource> };
       type: MediaType;
     }[]
-  >(`
+  >`
       UPDATE "Image" SET
-      ${pHash ? `"pHash" = ${pHash},` : ''}
-      ${ingestion ? `"ingestion" = '${ingestion}',` : ''}
-      ${nsfwLevel ? `"nsfwLevel" = ${nsfwLevel},` : ''}
-      ${blockedFor ? `"blockedFor" = '${blockedFor}',` : ''}
-      ${aiRating ? `"aiNsfwLevel" = ${aiRating},` : ''}
-      ${aiModel ? `"aiModel" = '${aiModel}',` : ''}
-      "scanJobs" = ${scanJobsSql}
-      WHERE ${whereClause}
+      ${Prisma.join(setClauses, ', ')}
+      WHERE ${Prisma.join(whereConditions, ' AND ')}
       RETURNING "scanJobs", type;
-    `);
+    `;
 
   return result[0]?.type === 'video'
     ? getHasRequiredVideoScans(result[0]?.scanJobs?.scans)
@@ -911,8 +928,8 @@ async function processScanResult({
   switch (source) {
     case TagSource.ImageHash: {
       if (!hash) throw new Error('missing hash from ImageHash scan');
-      const blocked = await isBlocked(hash);
-      const pHash = BigInt(hash);
+      const pHash = parsePerceptualHash(hash);
+      const blocked = await isBlocked(pHash);
       if (blocked) {
         logToAxiom(
           {

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -950,8 +950,10 @@ async function processScanResult({
           'webhooks'
         ).catch(() => null);
       }
-      // Skipped at zero: `bitXor(hash, 0)` degenerates to `bitCount(hash) < 5`, which matches any
-      // low-popcount blocked hash rather than a near-duplicate of this image. Stored regardless.
+      // Skipped at zero because an all-zero hash is degenerate, not because it cannot match: it
+      // matches every blocked entry with under 5 set bits, and those matches say nothing about
+      // the image. Anything acting on this result rather than logging it needs that decided
+      // properly — a flat image currently bypasses the check. Stored either way.
       const blocked = !pHash
         ? false
         : await isBlocked(pHash).catch((error) => {
@@ -975,7 +977,7 @@ async function processScanResult({
             type: 'info',
             message: 'Image pHash matched a blocked image',
             imageId: id,
-            pHash: hash,
+            pHash: pHash?.toString(),
             source: 'webhook-legacy',
           },
           'webhooks'


### PR DESCRIPTION
ClickUp: https://app.clickup.com/t/868krnzde

The legacy scan-result webhook handed values from the request body to two queries that build their SQL by string concatenation.

- **ClickHouse blocked-image lookup.** `clickhouse.$query` interpolates into the query text rather than binding parameters, and the handler passed the body's `hash` field to it as a string. The hash is now parsed to a `bigint` first, so only a numeric value can reach that query.
- **`updateImageScanJobs` Postgres update.** Its SET and WHERE clauses were assembled with template strings and run through `$queryRawUnsafe`, which put the scanner-supplied `movie_rating_model_id` into the SQL text. It now composes `Prisma.sql` fragments and runs through `$queryRaw`, so every value is a bound parameter. The generated statement is otherwise the same.

The endpoint is `WebhookEndpoint`-guarded, so this is closing a hole rather than an incident.

## Four smaller things the review turned up

- A blank hash returns `undefined` rather than throwing: it records the scan with no lookup and no `pHash` write, which is what happened before the hash was parsed at all. Rejecting it would have the scanner redeliver the same unusable result forever.
- A hash outside Int64 is rejected here instead of failing later at the ClickHouse or Postgres write, past the point the parse claims to have checked it. Such a value is a 400 either way — before at the database, now at the parse. There is a third option, which is to wrap the way `computePerceptualHash` does; that suits it because it parses hex where the high bit is expected, whereas wrapping a decimal here would silently store a different hash than the scanner computed. (An earlier version of this description argued from a sample of prod `Image.pHash` rows being signed; that reasoning was circular, since the column is a signed `BigInt` and could not have held anything else.)
- A blank hash is logged to Axiom. It is acked rather than rejected, so without the log a hasher regression emitting blanks would be invisible: rows go out scanned with a null `pHash` and the scanner never redelivers.
- The blocklist lookup gets one attempt, not a retry. Its result feeds a log statement and nothing else, so retrying buys a log line and, against a hung ClickHouse rather than a refused one, would hold the request for a multiple of the client timeout.
- A zero hash is now written rather than skipped. It is a legitimate hash (a flat image), and the path replacing this one already stores it — `resolveScanOutcome` writes `"pHash" = ${pHash ?? null}`, and `computePerceptualHash` documents an all-zero hash as legitimate and says to test against `undefined`, not falsiness. Skipping it left the same image hashed on one path and null on the other.
- Still inconsistent, and raised with Justin rather than guessed: `hash: ""` is a 400 (the scanner redelivers) while `hash: "   "` is a 200 with the scan recorded. Both match today's behaviour, so nothing changes here either way.
- The blocklist lookup had no catch, so a dropped ClickHouse socket discarded a scan result that nothing branches on (the blocking update it feeds is commented out). Now caught and logged, matching `getIsImageBlocked`.

## Verification

All logs written to a per-session scratchpad and checked for the worktree name on line 3 before any number below was read.

- `pnpm run typecheck` — 0 errors, matching CI's `tekton / typecheck` on this head SHA. (`Typecheck (fork PRs / non-main base)` shows as skipped, but it is not the only one — the tekton check is a StatusContext rather than a CheckRun and reports `success`.)
- `pnpm run lint` — 0 errors in the two touched files (warnings only; the repo baseline is 368 errors elsewhere).
- `pnpm exec vitest run --project 'unit*' --max-workers=8` — 1113 passed | 1 skipped (1114) files, 17420 passed | 23 skipped (17443) tests, no `ELIFECYCLE`, exit 0. `blocks.router.workflow.test.ts` collected 350 tests.
- Seven new tests in the existing webhook suite. One earlier test was dropped rather than kept: it asserted the absence of a retry that never existed on `main`, so it passed against a full revert and pinned a decision rather than a behaviour. Two control runs, each reverting one group of the fixes, produce legible failures: `expected "vi.fn()" to not be called at all, but actually been called 1 times`, `expected [ '-1234567890123456789' ] to deeply equal [ -1234567890123456789n ]`, `expected '\n UPDATE "Image" SET\n "ai…' not to contain 'DROP TABLE'`, and `expected "vi.fn()" to be called with arguments: [ 200 ]`.
- The rewritten statement was run against a real database through Prisma: the enum-cast parameters, the bigint parameter and `jsonb_build_object(text, bigint)` all bind, and the jsonb produced matches what the old literal produced.

The existing suite's `$queryRawUnsafe` stub was replaced with a renderer that inlines nested `Prisma.sql` fragments and turns each interpolated value into a `$n` placeholder, so the tests can tell a bound parameter from concatenated text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
