### PR TITLE
fix(image-cards): hide the info button behind a flag, unpin reactions on post images

### DIFF
--- a/src/components/Cards/ImageCard.browser.test.tsx
+++ b/src/components/Cards/ImageCard.browser.test.tsx
@@ -55,10 +55,13 @@ vi.mock('~/components/Buzz/InteractiveTipBuzzButton', () => ({
 import { ImageCard } from './ImageCard';
 import { IntersectionObserverProvider } from '~/components/IntersectionObserver/IntersectionObserverProvider';
 import { renderWithProviders, LOADABLE_IMAGE_DATA_URI } from '../../../test/component-setup';
+import { cleanup } from 'vitest-browser-react';
 import { MediaType } from '~/shared/utils/prisma/enums';
 
-// The widest column the featured/home grid lays out (HomeBlock.module.scss).
+// The two column widths the featured/home grid lays out (HomeBlock.module.scss:
+// 336px, and 296px in the three narrower rules).
 const CARD_WIDTH = 336;
+const NARROW_CARD_WIDTH = 296;
 const SINGLE_ROW_MAX_HEIGHT = 40;
 
 function imageData(counts: number) {
@@ -85,10 +88,10 @@ function imageData(counts: number) {
   } as any;
 }
 
-async function renderCard(counts: number) {
+async function renderCard(counts: number, width: number = CARD_WIDTH) {
   renderWithProviders(
     <IntersectionObserverProvider>
-      <div style={{ width: CARD_WIDTH }}>
+      <div style={{ width }}>
         <ImageCard data={imageData(counts)} />
       </div>
     </IntersectionObserverProvider>
@@ -101,6 +104,12 @@ async function renderCard(counts: number) {
 function actionRowHeight() {
   const bar = document.body.querySelector('[aria-label$="reaction"]')!.parentElement!;
   return bar.parentElement!.getBoundingClientRect().height;
+}
+
+function reactionBarOverflow() {
+  const bar = document.body.querySelector('[aria-label$="reaction"]')!.parentElement!;
+  const card = bar.parentElement!.parentElement!.parentElement!;
+  return bar.getBoundingClientRect().right - card.getBoundingClientRect().right;
 }
 
 function infoButtons() {
@@ -143,6 +152,25 @@ describe('ImageCard action row at four-digit reaction counts', () => {
     await renderCard(1455);
 
     expect(actionRowHeight()).toBeGreaterThan(SINGLE_ROW_MAX_HEIGHT);
+  });
+
+  // Hiding the button buys back a line, not width: at the narrow column the bar
+  // itself is wider than the card and the last reaction is still clipped. That
+  // half of 868krjmvv is NOT fixed, so this pins the overflow at its current
+  // size rather than pretending it is gone — it fails if a change makes it
+  // worse, and passes if someone finally closes it.
+  test('still overruns the narrow column, by no more than it does today', async () => {
+    await renderCard(1455, NARROW_CARD_WIDTH);
+    const fourDigits = reactionBarOverflow();
+    await cleanup();
+
+    // Three-digit counts fit with room to spare, so a negative number here is
+    // what proves the measurement above tracks the bar and not some constant.
+    await renderCard(145, NARROW_CARD_WIDTH);
+    const threeDigits = reactionBarOverflow();
+
+    expect(threeDigits).toBeLessThan(0);
+    expect(fourDigits).toBeLessThanOrEqual(50);
   });
 
   test('fits on one line at three-digit counts either way', async () => {

--- a/src/components/Cards/ImageCard.browser.test.tsx
+++ b/src/components/Cards/ImageCard.browser.test.tsx
@@ -1,0 +1,154 @@
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import type * as Trpc from '~/utils/trpc';
+
+// The component project loads no global stylesheet, so Tailwind — including
+// preflight's `box-sizing: border-box` — is inert unless a test imports it.
+// Without this the card's footer measures 16px WIDER than the card and every
+// utility class in the footer row is dead, which is a different layout from the
+// one that ships. The wrap assertion below is only meaningful with it.
+import '~/styles/globals.css';
+
+const features = { stickerPlacement: false, imageCardInfoButton: false, imageGeneration: false };
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => features,
+}));
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof Trpc>()),
+  trpc: { reaction: { toggle: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) } } },
+}));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, isModerator: false, muted: false, filePreferences: {} }),
+}));
+vi.mock('~/providers/BrowserSettingsProvider', () => ({
+  useBrowsingSettings: <T,>(selector: (state: { autoplayGifs: boolean }) => T) =>
+    selector({ autoplayGifs: false }),
+}));
+vi.mock('~/components/Image/Providers/ImagesProvider', () => ({
+  useImagesContext: () => ({ getImages: () => [] }),
+}));
+vi.mock('~/components/Image/ContextMenu/ImageContextMenu', () => ({
+  ImageContextMenu: () => null,
+}));
+vi.mock('~/components/Image/Remix/CardRemixButton', () => ({ CardRemixButton: () => null }));
+vi.mock('~/components/UserAvatar/UserAvatarSimple', () => ({
+  UserAvatarSimple: () => <span>user</span>,
+}));
+vi.mock('~/components/ImageGuard/ImageGuard2', () => {
+  function ImageGuard2({ children }: { children: (safe: boolean) => ReactNode }) {
+    return <>{children(true)}</>;
+  }
+  ImageGuard2.BlurToggle = function BlurToggle() {
+    return null;
+  };
+  return { ImageGuard2 };
+});
+vi.mock('~/components/LoginPopover/LoginPopover', () => ({
+  LoginPopover: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('~/components/Buzz/InteractiveTipBuzzButton', () => ({
+  InteractiveTipBuzzButton: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useBuzzTippingStore: () => 0,
+}));
+
+import { ImageCard } from './ImageCard';
+import { IntersectionObserverProvider } from '~/components/IntersectionObserver/IntersectionObserverProvider';
+import { renderWithProviders, LOADABLE_IMAGE_DATA_URI } from '../../../test/component-setup';
+import { MediaType } from '~/shared/utils/prisma/enums';
+
+// The widest column the featured/home grid lays out (HomeBlock.module.scss).
+const CARD_WIDTH = 336;
+const SINGLE_ROW_MAX_HEIGHT = 40;
+
+function imageData(counts: number) {
+  return {
+    id: 1,
+    url: LOADABLE_IMAGE_DATA_URI,
+    type: MediaType.image,
+    name: 'card.png',
+    metadata: null,
+    nsfwLevel: 1,
+    width: 700,
+    height: 900,
+    hasMeta: true,
+    reactions: [],
+    user: { id: 2, username: 'someone' },
+    stats: {
+      likeCountAllTime: counts,
+      dislikeCountAllTime: 0,
+      heartCountAllTime: counts,
+      laughCountAllTime: counts,
+      cryCountAllTime: counts,
+      tippedAmountCountAllTime: 0,
+    },
+  } as any;
+}
+
+async function renderCard(counts: number) {
+  renderWithProviders(
+    <IntersectionObserverProvider>
+      <div style={{ width: CARD_WIDTH }}>
+        <ImageCard data={imageData(counts)} />
+      </div>
+    </IntersectionObserverProvider>
+  );
+  await vi.waitFor(() => {
+    expect(document.body.querySelectorAll('[aria-label$="reaction"]').length).toBeGreaterThan(0);
+  });
+}
+
+function actionRowHeight() {
+  const bar = document.body.querySelector('[aria-label$="reaction"]')!.parentElement!;
+  return bar.parentElement!.getBoundingClientRect().height;
+}
+
+function infoButtons() {
+  return document.body.querySelectorAll('.tabler-icon-info-circle');
+}
+
+afterEach(() => {
+  features.imageCardInfoButton = false;
+});
+
+describe('ImageCard info button', () => {
+  test('is hidden while the flag is off, even when the image has metadata', async () => {
+    await renderCard(1455);
+
+    expect(infoButtons()).toHaveLength(0);
+  });
+
+  test('comes back when the flag is on', async () => {
+    features.imageCardInfoButton = true;
+    await renderCard(1455);
+
+    expect(infoButtons()).toHaveLength(1);
+  });
+});
+
+// Reported 2026-08-14 (ClickUp 868krjmvv): on the featured grid, cards whose
+// reaction counts reach four digits pushed the info button onto a second line
+// and clipped the last reaction at the card edge. Counts are deliberately NOT
+// abbreviated on this card — a reader watching a count tick up by one is the
+// point — so the room has to come from somewhere else.
+describe('ImageCard action row at four-digit reaction counts', () => {
+  test('stays on one line with the info button hidden', async () => {
+    await renderCard(1455);
+
+    expect(actionRowHeight()).toBeLessThan(SINGLE_ROW_MAX_HEIGHT);
+  });
+
+  test('wraps to a second line with the info button shown', async () => {
+    features.imageCardInfoButton = true;
+    await renderCard(1455);
+
+    expect(actionRowHeight()).toBeGreaterThan(SINGLE_ROW_MAX_HEIGHT);
+  });
+
+  test('fits on one line at three-digit counts either way', async () => {
+    features.imageCardInfoButton = true;
+    await renderCard(145);
+
+    expect(actionRowHeight()).toBeLessThan(SINGLE_ROW_MAX_HEIGHT);
+  });
+});

--- a/src/components/Cards/ImageCard.tsx
+++ b/src/components/Cards/ImageCard.tsx
@@ -64,7 +64,7 @@ export function ImageCard({ data }: Props) {
               disableBuzzTip={data.poi}
             />
             {features.stickerPlacement && <StickerPlacementCardBadge imageId={data.id} />}
-            {data.hasMeta && (
+            {features.imageCardInfoButton && data.hasMeta && (
               <ImageMetaPopover2 imageId={data.id} type={data.type}>
                 <ThemeIcon className={cardClasses.infoChip} variant="light">
                   <IconInfoCircle color="white" strokeWidth={2.5} size={18} />

--- a/src/components/Image/AsPosts/ImagesAsPostsCard.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsCard.tsx
@@ -342,7 +342,7 @@ function ImagesAsPostsCardContent({ data }: { data: ImagesAsPostModel }) {
             targetUserId={image.user.id}
             disableBuzzTip={image.poi}
           />
-          {image.hasMeta && (
+          {features.imageCardInfoButton && image.hasMeta && (
             <div className="absolute bottom-1 right-0.5 z-10">
               <ImageMetaPopover2 imageId={image.id} type={image.type}>
                 <div className="m-0.5 flex size-7 items-center justify-center rounded-full bg-black/50">
@@ -462,7 +462,7 @@ function PostCarouselSlide({
             targetUserId={image.user.id}
             disableBuzzTip={image.poi}
           />
-          {image.hasMeta && (
+          {features.imageCardInfoButton && image.hasMeta && (
             <div className="absolute bottom-1 right-0.5 z-10">
               <ImageMetaPopover2 imageId={image.id} type={image.type}>
                 <div className="m-0.5 flex size-7 items-center justify-center rounded-full bg-black/50">

--- a/src/components/Image/Infinite/ImagesCard.tsx
+++ b/src/components/Image/Infinite/ImagesCard.tsx
@@ -237,7 +237,7 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
                     </div>
                   ) : (
                     <div className="absolute bottom-1 right-1">
-                      {data.hasMeta && (
+                      {features.imageCardInfoButton && data.hasMeta && (
                         <ImageMetaPopover2 imageId={data.id} type={data.type}>
                           <div className="m-0.5 flex size-7 items-center justify-center rounded-full bg-black/50">
                             <IconInfoCircle

--- a/src/components/Post/Detail/PostImages.tsx
+++ b/src/components/Post/Detail/PostImages.tsx
@@ -17,7 +17,7 @@ import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { MAX_POST_IMAGES_WIDTH } from '~/server/common/constants';
 import type { VideoMetadata } from '~/server/schema/media.schema';
 import type { ImagesInfiniteModel } from '~/server/services/image.service';
-import { CollectionItemStatus } from '~/shared/utils/prisma/enums';
+import { CollectionItemStatus, MediaType } from '~/shared/utils/prisma/enums';
 import { RemixMenu, isRemixMenuVisible } from '~/components/Image/Remix/RemixMenu';
 import type { PostContestCollectionItem } from '~/types/router';
 import classes from './PostImages.module.css';
@@ -167,8 +167,13 @@ export function PostImages({
                     </RoutedDialogLink>
                     <Reactions
                       className={clsx(classes.reactions, {
+                        // Moves the bar clear of the player's control strip, so it
+                        // must track whether a control strip actually renders:
+                        // `nativeVideoControls` is a site-wide user preference and
+                        // EdgeMedia ignores it for a still image.
                         [classes.reactionsWithControls]:
                           !vimeoVideoId &&
+                          image.type === MediaType.video &&
                           (features.nativeVideoControls || shouldDisplayHtmlControls(image)),
                         [classes.vimeoReactions]: !!vimeoVideoId,
                       })}

--- a/src/components/Post/Detail/PostImages.tsx
+++ b/src/components/Post/Detail/PostImages.tsx
@@ -68,6 +68,14 @@ export function PostImages({
           imageCollectionItem?.tag &&
           (isOwner || isModerator || imageCollectionItem.status === CollectionItemStatus.ACCEPTED);
         const vimeoVideoId = (image.metadata as VideoMetadata)?.vimeoVideoId;
+        // One predicate for both the prop that asks for a control strip and the
+        // class that moves the reaction bar clear of one. Spelling it twice is
+        // how the reaction bar came to sit top-left over still images:
+        // `nativeVideoControls` is a site-wide user preference, and EdgeMedia
+        // only forwards `html5Controls` to EdgeVideo.
+        const showsControlStrip =
+          image.type === MediaType.video &&
+          (features.nativeVideoControls || shouldDisplayHtmlControls(image));
 
         return (
           <Fragment key={image.id}>
@@ -157,9 +165,7 @@ export function PostImages({
                           width={width < maxWidth ? width : maxWidth}
                           original={image.type === 'video'}
                           anim={safe}
-                          html5Controls={
-                            features.nativeVideoControls || shouldDisplayHtmlControls(image)
-                          }
+                          html5Controls={showsControlStrip}
                           videoRef={videoRef}
                           vimeoVideoId={vimeoVideoId}
                         />
@@ -167,14 +173,7 @@ export function PostImages({
                     </RoutedDialogLink>
                     <Reactions
                       className={clsx(classes.reactions, {
-                        // Moves the bar clear of the player's control strip, so it
-                        // must track whether a control strip actually renders:
-                        // `nativeVideoControls` is a site-wide user preference and
-                        // EdgeMedia ignores it for a still image.
-                        [classes.reactionsWithControls]:
-                          !vimeoVideoId &&
-                          image.type === MediaType.video &&
-                          (features.nativeVideoControls || shouldDisplayHtmlControls(image)),
+                        [classes.reactionsWithControls]: !vimeoVideoId && showsControlStrip,
                         [classes.vimeoReactions]: !!vimeoVideoId,
                       })}
                       entityId={image.id}

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -546,6 +546,12 @@ const featureFlags = createFeatureFlags({
   // the route SSR resolver reads the same resolved flag) but staged `['mod']`
   // rather than `[]` because it's a re-host, not a brand-new dark capability.
   appReviewPage: { availability: ['mod'], fliptKey: 'app-review-page' },
+  // Metadata info button on image feed cards. `availability: []` hides it for
+  // EVERYONE, mods included — this is a probe measuring whether anyone misses
+  // it, and a cohort that still sees the button cannot report missing it.
+  // Restoring it is enabling `image-card-info-button` in Flipt, which is the
+  // expected outcome if people complain, not a failure.
+  imageCardInfoButton: { availability: [], fliptKey: 'image-card-info-button' },
   // Early-adopter opt-in cohort. `availability: []` means static evaluation is false, so
   // when Flipt is UNREACHABLE (isFliptSync → null) nobody is in the cohort. NOT
   // `['user']`/`['public']`: those would fail OPEN during a Flipt outage, which defeats the

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -549,8 +549,15 @@ const featureFlags = createFeatureFlags({
   // Metadata info button on image feed cards. `availability: []` hides it for
   // EVERYONE, mods included — this is a probe measuring whether anyone misses
   // it, and a cohort that still sees the button cannot report missing it.
-  // Restoring it is enabling `image-card-info-button` in Flipt, which is the
-  // expected outcome if people complain, not a failure.
+  // Turning it back on is the expected outcome if people complain, not a
+  // failure. Two things the person flipping it should know:
+  //   - The flag does NOT exist in flipt-state yet, so until someone creates it
+  //     there is no runtime lever at all and restoring the button means a code
+  //     change and a deploy.
+  //   - Enabling it restores the overflow it was hidden to fix (ClickUp
+  //     868krjmvv): on a featured-grid card whose four reaction counts all reach
+  //     four digits, the button wraps onto a second line. Pinned by
+  //     `ImageCard.browser.test.tsx`.
   imageCardInfoButton: { availability: [], fliptKey: 'image-card-info-button' },
   // Early-adopter opt-in cohort. `availability: []` means static evaluation is false, so
   // when Flipt is UNREACHABLE (isFliptSync → null) nobody is in the cohort. NOT


### PR DESCRIPTION
Closes the two reports on the image-card action bar: ClickUp [868kt5ymm](https://app.clickup.com/t/868kt5ymm) (hide the info button) and [868krjmvv](https://app.clickup.com/t/868krjmvv) (reaction bar misplaced on post images, overflowing on high-count cards).

## Hiding the info button — a reversible probe

Decided at standup and recorded in the punch list: the same metadata is on the image page, the button is already inconsistent (images with no prompt never had one), and stickers are about to want that space. Moving it to the top-left was rejected (mods read the rating there) and so was fixing the layout alone.

So it is **hidden, not removed**. `imageCardInfoButton` is `availability: []` + `fliptKey: 'image-card-info-button'`, the same shape as `earlyAdopter`: static evaluation is false, so with no Flipt flag it is off for **everyone, mods included** — a cohort that still sees the button cannot report missing it. Restoring it is enabling the flag in Flipt, no deploy and no revert. `ImageMetaPopover2` and its data plumbing are untouched.

Three card surfaces: the featured/home card (`Cards/ImageCard`), the main image feed (`Image/Infinite/ImagesCard`), and the model-gallery card (`Image/AsPosts/ImagesAsPostsCard`). The image detail page, the post detail page, the carousels, the generator output and the moderator pages keep theirs.

## Reaction bar on post images

`PostImages` moved the reaction bar to the top-left — overlaying the image under the rating badge, which is exactly what Murf reported — whenever `features.nativeVideoControls` was on. That flag is a **site-wide user preference**, and `EdgeMedia` passes `html5Controls` to `EdgeVideo` only, so a still image got the video layout while rendering no control strip. The class now also requires `image.type === video`. `shouldDisplayHtmlControls` was already media-type-aware; only the preference was unguarded.

## What the overflow measurement actually says

Measured in the browser test at the two real featured-grid column widths (`HomeBlock.module.scss`: 336px, 296px at the narrow breakpoint), with all four reactions at four digits:

| card | info button | action row |
|---|---|---|
| 336px | shown | **50px — wrapped** |
| 336px | hidden | 28px, fits |
| 296px | shown | 50px — wrapped |
| 296px | hidden | 28px, but the bar still runs ~39px past the edge |

So the wrap — the reported symptom, in both reports — is gone at both widths, and at 336px the bar fits. **At the 296px breakpoint a card with all four reactions in four digits still clips**, and this PR does not fix that. Counts are not abbreviated here on purpose (watching one tick up by one is the point), so the remaining ~39px has to come from somewhere else if we want it; worth a follow-up rather than guessing at it here.

The browser test carries this: reverting the `ImageCard` change fails it with `expected 50 to be less than 40`, not a timeout. Note it imports `~/styles/globals.css` — the component project loads no global stylesheet, so without it Tailwind preflight is inert, the footer measures 16px wider than the card, and every layout number is fiction.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — no new errors in the touched files
- `pnpm run test:unit:run` — 1113 passed | 1 skipped (1114), 17413 tests; `blocks.router.workflow.test.ts` collected **350**
- component: the new file plus `ImagesAsPostsCardLazyCarousel` and `ModelCard` — 16 passed

No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
