### PR TITLE
fix(env): read NEXT_PUBLIC_LOG_TRPC from its own variable, drop dead public env vars

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -69,11 +69,8 @@ S3_IMAGE_UPLOAD_OVERRIDE=
 
 # Client env vars
 NEXT_PUBLIC_IMAGE_LOCATION=http://localhost:3000
-NEXT_PUBLIC_CONTENT_DECTECTION_LOCATION=https://publicstore.civitai.com/content_detection/model.json
 NEXT_PUBLIC_CIVITAI_LINK=http://localhost:3000
-NEXT_PUBLIC_UI_CATEGORY_VIEWS=false
 NEXT_PUBLIC_UI_HOMEPAGE_IMAGES=false
-NEXT_PUBLIC_ADS=true
 
 # Clickhouse
 CLICKHOUSE_HOST=http://localhost:18123

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,6 @@ RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
 # inherited too, so they don't need re-running here.
 FROM deps AS builder
 ARG NEXT_PUBLIC_IMAGE_LOCATION
-ARG NEXT_PUBLIC_CONTENT_DECTECTION_LOCATION
-ARG NEXT_PUBLIC_MAINTENANCE_MODE
 WORKDIR /app
 
 # Overlay the full source. node_modules is dockerignored, so this never clobbers the node_modules inherited

--- a/src/env/__tests__/client-schema.test.ts
+++ b/src/env/__tests__/client-schema.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 
 /**
  * `clientEnv` restates every key by hand because Next.js inlines only the
@@ -8,50 +8,108 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
  * `NEXT_PUBLIC_LOG_TRP`.
  */
 
-// Resolved from a ternary, not from a variable of the same name.
-const NOT_A_PASSTHROUGH = new Set(['NEXT_PUBLIC_DEFAULT_PAYMENT_PROVIDER']);
+// Resolved from an expression rather than from a variable of the same name, so the
+// sentinel sweep cannot reach it. Each one is asserted on its own below instead.
+const NOT_A_PASSTHROUGH = ['NEXT_PUBLIC_DEFAULT_PAYMENT_PROVIDER'];
+
+async function importWith(vars: Record<string, string | undefined>) {
+  vi.resetModules();
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === undefined) vi.stubEnv(key, undefined);
+    else vi.stubEnv(key, value);
+  }
+  return import('../client-schema');
+}
 
 describe('env/client-schema', () => {
-  const originalEnv = process.env;
-
-  beforeEach(() => {
-    vi.resetModules();
-    process.env = { ...originalEnv };
-  });
-
   afterEach(() => {
-    process.env = originalEnv;
+    vi.unstubAllEnvs();
     vi.resetModules();
   });
 
   it('reads each key from the env var of the same name', async () => {
-    const { clientSchema } = await import('../client-schema');
+    const { clientSchema } = await importWith({});
     const keys = Object.keys(clientSchema.shape);
     expect(keys.length).toBeGreaterThan(10);
 
-    const next = { ...originalEnv };
-    for (const key of keys) next[key] = `sentinel::${key}`;
-    process.env = next;
-
-    vi.resetModules();
-    const { clientEnv } = await import('../client-schema');
+    const sentinels = Object.fromEntries(keys.map((key) => [key, `sentinel::${key}`]));
+    const { clientEnv } = await importWith(sentinels);
 
     for (const key of keys) {
-      if (NOT_A_PASSTHROUGH.has(key)) continue;
+      if (NOT_A_PASSTHROUGH.includes(key)) continue;
       expect({ [key]: clientEnv[key as keyof typeof clientEnv] }).toEqual({
         [key]: `sentinel::${key}`,
       });
     }
   });
 
+  it('exempts only keys that genuinely are not passthroughs', async () => {
+    const { clientSchema } = await importWith({});
+    expect(NOT_A_PASSTHROUGH.filter((key) => !(key in clientSchema.shape))).toEqual([]);
+  });
+
   it('declares the same keys in the schema and in clientEnv', async () => {
-    const { clientSchema, clientEnv } = await import('../client-schema');
+    const { clientSchema, clientEnv } = await importWith({});
     expect(Object.keys(clientEnv).sort()).toEqual(Object.keys(clientSchema.shape).sort());
   });
 
   it('names every key with the NEXT_PUBLIC_ prefix', async () => {
-    const { clientSchema } = await import('../client-schema');
+    const { clientSchema } = await importWith({});
     const keys = Object.keys(clientSchema.shape);
     expect(keys.filter((key) => !key.startsWith('NEXT_PUBLIC_'))).toEqual([]);
+  });
+
+  describe('NEXT_PUBLIC_DEFAULT_PAYMENT_PROVIDER', () => {
+    it('is Paddle only when the variable says Paddle', async () => {
+      const { clientEnv } = await importWith({ NEXT_PUBLIC_DEFAULT_PAYMENT_PROVIDER: 'Paddle' });
+      expect(clientEnv.NEXT_PUBLIC_DEFAULT_PAYMENT_PROVIDER).toBe('Paddle');
+    });
+
+    it('falls back to Stripe when unset or unrecognised', async () => {
+      const unset = await importWith({ NEXT_PUBLIC_DEFAULT_PAYMENT_PROVIDER: undefined });
+      expect(unset.clientEnv.NEXT_PUBLIC_DEFAULT_PAYMENT_PROVIDER).toBe('Stripe');
+
+      const junk = await importWith({ NEXT_PUBLIC_DEFAULT_PAYMENT_PROVIDER: 'Coinbase' });
+      expect(junk.clientEnv.NEXT_PUBLIC_DEFAULT_PAYMENT_PROVIDER).toBe('Stripe');
+    });
+  });
+
+  describe('NEXT_PUBLIC_BASE_URL', () => {
+    /**
+     * The `NEXTAUTH_URL` fallback resolves server-side only: Next inlines nothing
+     * without the `NEXT_PUBLIC_` prefix, so an environment setting only `NEXTAUTH_URL`
+     * leaves the browser with `undefined`. Pinned rather than removed — see PR #4035.
+     */
+    it('prefers its own variable', async () => {
+      const { clientEnv } = await importWith({
+        NEXT_PUBLIC_BASE_URL: 'https://own.test',
+        NEXTAUTH_URL: 'https://fallback.test',
+      });
+      expect(clientEnv.NEXT_PUBLIC_BASE_URL).toBe('https://own.test');
+    });
+
+    it('falls back to the server-only NEXTAUTH_URL when its own is unset', async () => {
+      const { clientEnv } = await importWith({
+        NEXT_PUBLIC_BASE_URL: undefined,
+        NEXTAUTH_URL: 'https://fallback.test',
+      });
+      expect(clientEnv.NEXT_PUBLIC_BASE_URL).toBe('https://fallback.test');
+    });
+  });
+
+  describe('NEXT_PUBLIC_LOG_TRPC', () => {
+    it('parses a boolean token', async () => {
+      const { clientSchema } = await importWith({});
+      expect(clientSchema.parse({ NEXT_PUBLIC_LOG_TRPC: 'true' }).NEXT_PUBLIC_LOG_TRPC).toBe(true);
+    });
+
+    it('falls back to false rather than throwing on a value it cannot parse', async () => {
+      const { clientSchema } = await importWith({});
+      for (const value of ['', 'verbose']) {
+        expect(clientSchema.parse({ NEXT_PUBLIC_LOG_TRPC: value }).NEXT_PUBLIC_LOG_TRPC).toBe(
+          false
+        );
+      }
+    });
   });
 });

--- a/src/env/__tests__/client-schema.test.ts
+++ b/src/env/__tests__/client-schema.test.ts
@@ -103,13 +103,14 @@ describe('env/client-schema', () => {
       expect(clientSchema.parse({ NEXT_PUBLIC_LOG_TRPC: 'true' }).NEXT_PUBLIC_LOG_TRPC).toBe(true);
     });
 
-    it('falls back to false rather than throwing on a value it cannot parse', async () => {
+    it('treats an empty value as unset rather than as a parse error', async () => {
       const { clientSchema } = await importWith({});
-      for (const value of ['', 'verbose']) {
-        expect(clientSchema.parse({ NEXT_PUBLIC_LOG_TRPC: value }).NEXT_PUBLIC_LOG_TRPC).toBe(
-          false
-        );
-      }
+      expect(clientSchema.parse({ NEXT_PUBLIC_LOG_TRPC: '' }).NEXT_PUBLIC_LOG_TRPC).toBe(false);
+    });
+
+    it('still rejects a value it cannot parse', async () => {
+      const { clientSchema } = await importWith({});
+      expect(() => clientSchema.parse({ NEXT_PUBLIC_LOG_TRPC: 'verbose' })).toThrow();
     });
   });
 });

--- a/src/env/__tests__/client-schema.test.ts
+++ b/src/env/__tests__/client-schema.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * `clientEnv` restates every key by hand because Next.js inlines only the
+ * `process.env.NEXT_PUBLIC_*` references it can see literally. A key that names a
+ * variable other than its own is therefore permanently undefined, and the schema's
+ * default hides it — which is how `NEXT_PUBLIC_LOG_TRPC` spent its life reading
+ * `NEXT_PUBLIC_LOG_TRP`.
+ */
+
+// Resolved from a ternary, not from a variable of the same name.
+const NOT_A_PASSTHROUGH = new Set(['NEXT_PUBLIC_DEFAULT_PAYMENT_PROVIDER']);
+
+describe('env/client-schema', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.resetModules();
+  });
+
+  it('reads each key from the env var of the same name', async () => {
+    const { clientSchema } = await import('../client-schema');
+    const keys = Object.keys(clientSchema.shape);
+    expect(keys.length).toBeGreaterThan(10);
+
+    const next = { ...originalEnv };
+    for (const key of keys) next[key] = `sentinel::${key}`;
+    process.env = next;
+
+    vi.resetModules();
+    const { clientEnv } = await import('../client-schema');
+
+    for (const key of keys) {
+      if (NOT_A_PASSTHROUGH.has(key)) continue;
+      expect({ [key]: clientEnv[key as keyof typeof clientEnv] }).toEqual({
+        [key]: `sentinel::${key}`,
+      });
+    }
+  });
+
+  it('declares the same keys in the schema and in clientEnv', async () => {
+    const { clientSchema, clientEnv } = await import('../client-schema');
+    expect(Object.keys(clientEnv).sort()).toEqual(Object.keys(clientSchema.shape).sort());
+  });
+
+  it('names every key with the NEXT_PUBLIC_ prefix', async () => {
+    const { clientSchema } = await import('../client-schema');
+    const keys = Object.keys(clientSchema.shape);
+    expect(keys.filter((key) => !key.startsWith('NEXT_PUBLIC_'))).toEqual([]);
+  });
+});

--- a/src/env/client-schema.ts
+++ b/src/env/client-schema.ts
@@ -25,10 +25,14 @@ export const clientSchema = z.object({
   NEXT_PUBLIC_GPTT_UUID_GREEN: z.string().optional(),
   NEXT_PUBLIC_BASE_URL: z.string().optional(),
   NEXT_PUBLIC_UI_HOMEPAGE_IMAGES: z.stringbool().default(true),
-  // `.catch` because the read below was reading the wrong variable name until #4035:
-  // any environment already carrying an unparseable value had been inert, and would
-  // otherwise start throwing out of `~/env/client` the moment the read went live.
-  NEXT_PUBLIC_LOG_TRPC: z.stringbool().default(false).catch(false),
+  // An empty value reads as unset rather than as a parse error: the read below named
+  // the wrong variable until #4035, so a config carrying a valueless key had been
+  // inert and would otherwise start throwing out of `~/env/client`. Anything else
+  // unparseable still throws, as it does for every other stringbool here.
+  NEXT_PUBLIC_LOG_TRPC: z.preprocess(
+    (value) => (value === '' ? undefined : value),
+    z.stringbool().default(false)
+  ),
   NEXT_PUBLIC_RECAPTCHA_KEY: z.string().optional(),
   NEXT_PUBLIC_PAYPAL_CLIENT_ID: z.string().optional(),
   NEXT_PUBLIC_CHOPPED_ENDPOINT: z.url().optional(),

--- a/src/env/client-schema.ts
+++ b/src/env/client-schema.ts
@@ -25,7 +25,10 @@ export const clientSchema = z.object({
   NEXT_PUBLIC_GPTT_UUID_GREEN: z.string().optional(),
   NEXT_PUBLIC_BASE_URL: z.string().optional(),
   NEXT_PUBLIC_UI_HOMEPAGE_IMAGES: z.stringbool().default(true),
-  NEXT_PUBLIC_LOG_TRPC: z.stringbool().default(false),
+  // `.catch` because the read below was reading the wrong variable name until #4035:
+  // any environment already carrying an unparseable value had been inert, and would
+  // otherwise start throwing out of `~/env/client` the moment the read went live.
+  NEXT_PUBLIC_LOG_TRPC: z.stringbool().default(false).catch(false),
   NEXT_PUBLIC_RECAPTCHA_KEY: z.string().optional(),
   NEXT_PUBLIC_PAYPAL_CLIENT_ID: z.string().optional(),
   NEXT_PUBLIC_CHOPPED_ENDPOINT: z.url().optional(),

--- a/src/env/client-schema.ts
+++ b/src/env/client-schema.ts
@@ -8,7 +8,6 @@ import { isProd } from './other';
  * To expose them to the client, prefix them with `NEXT_PUBLIC_`.
  */
 export const clientSchema = z.object({
-  NEXT_PUBLIC_CONTENT_DECTECTION_LOCATION: z.string().default(''),
   NEXT_PUBLIC_IMAGE_LOCATION: z.string().default(''),
   NEXT_PUBLIC_CIVITAI_LINK: isProd ? z.url() : z.url().optional(),
   NEXT_PUBLIC_GIT_HASH: z.string().optional(),
@@ -75,7 +74,6 @@ export const clientSchema = z.object({
  * @type {{ [k in keyof z.infer<typeof clientSchema>]: z.infer<typeof clientSchema>[k] | undefined }}
  */
 export const clientEnv = {
-  NEXT_PUBLIC_CONTENT_DECTECTION_LOCATION: process.env.NEXT_PUBLIC_CONTENT_DECTECTION_LOCATION,
   NEXT_PUBLIC_IMAGE_LOCATION: process.env.NEXT_PUBLIC_IMAGE_LOCATION,
   NEXT_PUBLIC_GIT_HASH: process.env.NEXT_PUBLIC_GIT_HASH,
   NEXT_PUBLIC_CIVITAI_LINK: process.env.NEXT_PUBLIC_CIVITAI_LINK,
@@ -93,7 +91,7 @@ export const clientEnv = {
   NEXT_PUBLIC_GPTT_UUID_GREEN: process.env.NEXT_PUBLIC_GPTT_UUID_GREEN,
   NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL ?? process.env.NEXTAUTH_URL,
   NEXT_PUBLIC_UI_HOMEPAGE_IMAGES: process.env.NEXT_PUBLIC_UI_HOMEPAGE_IMAGES,
-  NEXT_PUBLIC_LOG_TRPC: process.env.NEXT_PUBLIC_LOG_TRP,
+  NEXT_PUBLIC_LOG_TRPC: process.env.NEXT_PUBLIC_LOG_TRPC,
   NEXT_PUBLIC_RECAPTCHA_KEY: process.env.NEXT_PUBLIC_RECAPTCHA_KEY,
   NEXT_PUBLIC_PAYPAL_CLIENT_ID: process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID,
   NEXT_PUBLIC_CHOPPED_ENDPOINT: process.env.NEXT_PUBLIC_CHOPPED_ENDPOINT,


### PR DESCRIPTION
ClickUp [868kk4tu7](https://app.clickup.com/t/868kk4tu7) — "`NEXT_PUBLIC_*` env vars with `.default('')` validate clean when unset, then silently vanish."

## The audit came back smaller than the ticket

`src/env/client-schema.ts` is the only place a `NEXT_PUBLIC_*` var gets a zod default, and exactly **two** carry `.default('')`:

| Var | Consumers | Outcome |
|---|---|---|
| `NEXT_PUBLIC_IMAGE_LOCATION` | 6 real call sites | **left alone**, deliberately |
| `NEXT_PUBLIC_CONTENT_DECTECTION_LOCATION` | **zero** | deleted |

Every other `.default(...)` carries a **non-empty** value (`'0.1'`, `'1.0'`, `'0.05'`, `'8'`, `'Stripe'`, `true`/`false`). Those are real defaults, not the silent-vanish shape, and nothing here touches them.

## Why `NEXT_PUBLIC_IMAGE_LOCATION` keeps its default

Justin's call, and the reasoning is worth recording. Requiring it — even `isProd ? z.url() : …` — risks failing a build that legitimately does not pass it. The Dockerfile sets `SKIP_ENV_VALIDATION=1` for `next build` and **nothing in the repo reads that variable**; `src/env/client.ts` `safeParse`s unconditionally. So a required public var is a hard build failure wherever it is unset, which is what the existing comment beside the Faro vars already warns about.

The dangerous paths are covered downstream: `orchestrator.service.ts` refuses to hash a relative media URL, `collection-ai-review.ts` errors on a non-absolute image URL, and `saveImageDownload.ts` falls back to a static allowlist. Stated plainly so nobody over-reads it — **three of the six call sites are guarded**; `getEdgeUrl` generally, `Model3DViewer` and `AdUnitFactory` would still render a hostless path. That is a visibly broken image, not a money or safety path.

## What this PR does change

1. **`NEXT_PUBLIC_LOG_TRPC` read `process.env.NEXT_PUBLIC_LOG_TRP`** — missing the `C`. `clientEnv` restates every key by hand because Next inlines only the references it can see literally, so the key was permanently `undefined` and `z.stringbool().default(false)` turned that into a plausible `false`. It is consumed in `src/utils/trpc.ts` and **could not be switched on**. Dev-only logging, so the blast radius is small; the failure mode is the point.
2. **Deleted `NEXT_PUBLIC_CONTENT_DECTECTION_LOCATION`** from the schema, `clientEnv`, the Dockerfile `ARG` and `.env-example`. Grepped `src`, `apps`, `packages`, `scripts` and `.github` — no consumer. (The `DECTECTION` typo is itself a hint nobody ever wired it up.)
3. **Deleted `ARG NEXT_PUBLIC_MAINTENANCE_MODE`** from the Dockerfile. No such var exists in either schema; only server-side `MAINTENANCE_MODE`.
4. **Deleted `NEXT_PUBLIC_UI_CATEGORY_VIEWS` and `NEXT_PUBLIC_ADS`** from `.env-example`. Neither is in the schema and neither has a consumer anywhere in the tree.

Passing an undeclared `--build-arg` is a Docker warning, not an error, so removing the two ARGs cannot break a pipeline that still passes them.

## The test, and its controls

`src/env/__tests__/client-schema.test.ts` stamps `sentinel::<KEY>` into `process.env` for every key in the schema, re-imports, and asserts each key read **its own** name. `NEXT_PUBLIC_DEFAULT_PAYMENT_PROVIDER` is exempt because it resolves from a ternary. Two more assertions guard schema/`clientEnv` drift and the `NEXT_PUBLIC_` prefix.

Both controls were run rather than assumed:

- Reverting the typo → `AssertionError: expected { NEXT_PUBLIC_LOG_TRPC: undefined } to deeply equal { … }`, exit 1. It names the variable.
- Adding a non-public key to the schema → all three assertions fail, each naming `CONTROL_PROBE_ONLY`.

The key count is asserted too, so the loop cannot pass by iterating nothing.

## Verification

- `pnpm run typecheck` — **0 errors** in 302s, unfiltered.
- `pnpm run lint` — repo-wide it reports 368 pre-existing errors; **zero findings in either file this PR touches**.
- `pnpm run test:unit:run` — **17416 passed, 1114 files, exit 0**. `blocks.router.workflow.test.ts` collected **350** tests, so the submodule is initialised and the run means something.
- An earlier full run exited 1 on `[vitest-pool]: Worker forks emitted error` with **17404 passed and zero failures**; another agent was running a suite on the same box. It did not reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
