### PR TITLE
fix(images): hold scheduled content out of the BitDex feed until its publish time

### DIFF
--- a/src/server/bitdex/compare.ts
+++ b/src/server/bitdex/compare.ts
@@ -1,7 +1,12 @@
 import client from 'prom-client';
 
 // HMR-safe metric registration (same pattern as prom/client.ts)
-function registerHistogram<T extends string>(opts: { name: string; help: string; labelNames?: readonly T[]; buckets: number[] }) {
+function registerHistogram<T extends string>(opts: {
+  name: string;
+  help: string;
+  labelNames?: readonly T[];
+  buckets: number[];
+}) {
   try {
     return new client.Histogram(opts);
   } catch {
@@ -9,7 +14,11 @@ function registerHistogram<T extends string>(opts: { name: string; help: string;
   }
 }
 
-function registerCounter<T extends string>(opts: { name: string; help: string; labelNames?: readonly T[] }) {
+function registerCounter<T extends string>(opts: {
+  name: string;
+  help: string;
+  labelNames?: readonly T[];
+}) {
   try {
     return new client.Counter(opts);
   } catch {
@@ -54,6 +63,59 @@ const errorCounter = registerCounter({
   labelNames: ['type'] as const, // 'timeout', 'connection', 'other'
 });
 
+// Documents the feed's publication filter held back on `sortAt` alone — their
+// own `publishedAt` was already past, so they are probably published content
+// hidden by index drift rather than genuinely-unpublished content caught.
+//
+// Deliberately UNLABELLED. A labelled counter publishes no series at all until
+// its first observation, and an alert over an absent series renders as "No data"
+// — indistinguishable from a healthy zero. (That is not hypothetical: BitDex's
+// own `activation_verify_inconclusive_total` is absent on the serving pod for
+// exactly this reason, measured 2026-08-17.) Unlabelled, this registers at 0 on
+// process start, so an alert on it can actually fire.
+// Three names rather than one series with a `mode` label, for the same reason
+// they are unlabelled at all: the three cases must be separable (an alert
+// threshold cannot mean different things depending on a flag), and each must
+// publish a zero from process start so an alert over any of them can fire before
+// its first event.
+//
+// The shadow one is not decoration. Shadow mode exists to size a risk before
+// taking it, so a counter that only observes the serving path reads zero until a
+// cohort is flipped — measuring the exposure only after it has been taken.
+const sortAtOnlyHoldCounterServing = registerCounter({
+  name: 'bitdex_feed_sortat_only_holds_total',
+  help: 'Feed documents held back by the publication filter on sortAt alone (publishedAt was already past), on requests BitDex served',
+});
+
+const sortAtOnlyHoldCounterShadow = registerCounter({
+  name: 'bitdex_feed_sortat_only_holds_shadow_total',
+  help: 'Feed documents the publication filter WOULD have held back on sortAt alone, on shadow-mode requests where Meili served',
+});
+
+const sortAtOnlyHoldCounterFallback = registerCounter({
+  name: 'bitdex_feed_sortat_only_holds_fallback_total',
+  help: 'Feed documents held back on sortAt alone on requests where the hold emptied the result and Meili served instead (so nothing was hidden from the user)',
+});
+
+/**
+ * Record documents held back on `sortAt` alone by the feed publication filter.
+ *
+ * Three modes, three names, because they mean different things to an operator:
+ * `serving` hid content from a user, `shadow` would have hidden it had the flag
+ * been on, and `fallback` held documents but Meili then served the request — so
+ * the user saw them anyway. Folding `fallback` into `serving` would make the
+ * alert loudest in the case where the guard cost the user nothing.
+ */
+export function recordSortAtOnlyHolds(
+  count: number,
+  mode: 'serving' | 'shadow' | 'fallback'
+): void {
+  if (count <= 0) return;
+  if (mode === 'serving') sortAtOnlyHoldCounterServing.inc(count);
+  else if (mode === 'shadow') sortAtOnlyHoldCounterShadow.inc(count);
+  else sortAtOnlyHoldCounterFallback.inc(count);
+}
+
 interface ComparisonInput {
   bitdexIds: number[];
   meiliIds: number[];
@@ -69,8 +131,12 @@ interface ComparisonInput {
 export function compareBitdexResults(comparison: ComparisonInput): void {
   const sort = comparison.sort ?? 'unknown';
   const queryClass = comparison.hasPeriod
-    ? comparison.hasFilters ? 'complex' : 'period'
-    : comparison.hasFilters ? 'filtered' : 'simple';
+    ? comparison.hasFilters
+      ? 'complex'
+      : 'period'
+    : comparison.hasFilters
+    ? 'filtered'
+    : 'simple';
 
   // Record latencies
   queryDurationHistogram.observe({ source: 'bitdex' }, comparison.bitdexElapsedMs / 1000);
@@ -100,7 +166,7 @@ export function recordBitdexError(err: unknown): void {
     errObj.name === 'AbortError'
       ? 'timeout'
       : errObj.message?.includes('ECONNREFUSED')
-        ? 'connection'
-        : 'other';
+      ? 'connection'
+      : 'other';
   errorCounter.inc({ type });
 }

--- a/src/server/services/__tests__/bitdex-scheduled-content.test.ts
+++ b/src/server/services/__tests__/bitdex-scheduled-content.test.ts
@@ -1,0 +1,562 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Scheduled content must not be served before its publish time.
+//
+// The publication decision on this path is carried by a single index flag, so
+// the post-filter is what keeps a document with a not-yet-arrived publish time
+// out of the feed.
+//
+// The case worth pinning is the RESCHEDULE one, exercised below: `sortAt` holds
+// the new future schedule while `publishedAt` still holds an earlier value the
+// post was moved off. A guard that only inspected `publishedAt` would pass it,
+// so the fixture deliberately uses that combination.
+//
+// Same minimal-seam mocking as bitdex-feed-source.test.ts: stub the
+// event-engine-common submodule + infra clients + env so importing
+// image.service doesn't boot real infra.
+
+import type * as BitdexClient from '~/server/bitdex/client';
+import type * as FliptClient from '~/server/flipt/client';
+import type * as MeiliClient from '~/server/meilisearch/client';
+
+const { queryBitdexMock, getFliptVariantMock } = vi.hoisted(() => ({
+  queryBitdexMock: vi.fn(),
+  getFliptVariantMock: vi.fn(),
+}));
+
+vi.mock('../../../../event-engine-common/feeds', () => ({
+  ImagesFeed: class {
+    populatedQuery = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/meilisearch/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof MeiliClient>()),
+  metricsSearchClient: null,
+}));
+
+vi.mock('~/server/bitdex/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof BitdexClient>()),
+  queryBitdex: queryBitdexMock,
+}));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof FliptClient>()),
+  getFliptVariant: getFliptVariantMock,
+  getFliptBoolean: vi.fn().mockResolvedValue(false),
+}));
+
+import { getImagesFromSearch } from '../image.service';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+redisMock.redis.get.mockResolvedValue('[]');
+redisMock.redis.set.mockResolvedValue(undefined);
+
+const OWNER_ID = 7;
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+const baseDoc = {
+  url: 'abc',
+  hash: null,
+  nsfwLevel: 1,
+  userId: OWNER_ID,
+  type: 'image',
+  availability: 'Public',
+  postId: 55,
+  postedToId: null,
+  hasMeta: true,
+  onSite: true,
+  poi: false,
+  minor: false,
+  width: 100,
+  height: 100,
+  reactionCount: 0,
+  commentCount: 0,
+  collectedCount: 0,
+};
+
+/** Genuinely published: both timestamps in the past. */
+const publishedDoc = {
+  ...baseDoc,
+  id: 101,
+  publishedAt: nowSec() - 3600,
+  sortAt: nowSec() - 3600,
+};
+
+/**
+ * Rescheduled: `sortAt` a day out, while `publishedAt` still carries the
+ * earlier schedule the post was moved off.
+ */
+const rescheduledDoc = {
+  ...baseDoc,
+  id: 202,
+  publishedAt: nowSec() - 3600,
+  sortAt: nowSec() + 86_400,
+};
+
+/** Scheduled outright: publish time itself is in the future. */
+const scheduledDoc = {
+  ...baseDoc,
+  id: 303,
+  publishedAt: nowSec() + 86_400,
+  sortAt: nowSec() + 86_400,
+};
+
+/**
+ * Published, but dropped by an ORDINARY filter rather than the publication one.
+ * Used to prove the emptied-page allowance is not handed to every empty page.
+ */
+const privateDoc = {
+  ...baseDoc,
+  id: 505,
+  availability: 'Private',
+  publishedAt: nowSec() - 3600,
+  sortAt: nowSec() - 3600,
+};
+
+/**
+ * Never published — a draft. `sortAt` is in the PAST (it falls back to
+ * `existedAt`), so the future-schedule half of the test does not catch this one;
+ * only the null check does.
+ */
+const neverPublishedDoc = {
+  ...baseDoc,
+  id: 404,
+  publishedAt: null,
+  sortAt: nowSec() - 3600,
+};
+
+// `cursor: undefined` terminates fetchBitdexPrimary's pass loop on the first
+// iteration. A fake that always returned a cursor would spin to MAX_PASSES.
+const page = (documents: unknown[]) => ({ documents, cursor: undefined });
+
+/**
+ * Distinguish the two BitDex passes STRUCTURALLY rather than by call order.
+ *
+ * Both go through the same `queryBitdex`, so a mock keyed on order answers
+ * whichever pass happens to run first — and if that assumption ever breaks, a
+ * test keyed on it keeps passing while testing nothing. The main pass filters
+ * availability with `Not(Eq(availability, Private))`; the own-excluded pass
+ * asks for the opposite inside an `Or`. Keying on that `Or` cannot drift.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw BitDex filter clauses
+type Clause = any;
+function isOwnExcludedQuery(filters: unknown): boolean {
+  if (!Array.isArray(filters)) return false;
+  return filters.some(
+    (clause: Clause) =>
+      Array.isArray(clause?.Or) &&
+      clause.Or.some(
+        (member: Clause) => Array.isArray(member?.Eq) && member.Eq[0] === 'availability'
+      )
+  );
+}
+
+const baseInput = {
+  limit: 10,
+  browsingLevel: 1,
+  periodMode: 'published',
+  include: [],
+  currentUserId: undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ImageSearchInput isn't exported
+} as any;
+
+describe('BitDex primary feed — content is not served before its publish time', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getFliptVariantMock.mockResolvedValue('primary');
+  });
+
+  it('drops a RESCHEDULED document (future sortAt, past publishedAt) for an anonymous viewer', async () => {
+    queryBitdexMock.mockResolvedValue(page([publishedDoc, rescheduledDoc]));
+
+    const result = await getImagesFromSearch(baseInput);
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    // Named ids, so a regression reads as "202 was served" rather than a count.
+    expect(ids).toContain(101);
+    expect(ids).not.toContain(202);
+  });
+
+  it('drops a document whose publishedAt itself is in the future', async () => {
+    queryBitdexMock.mockResolvedValue(page([publishedDoc, scheduledDoc]));
+
+    const result = await getImagesFromSearch(baseInput);
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    expect(ids).toContain(101);
+    expect(ids).not.toContain(303);
+  });
+
+  it('paginates past pages the guard empties instead of starving the request', async () => {
+    // The documents this guard drops sort FIRST (a future publish time is a high
+    // `sortAt`), so they arrive contiguously at the head of the feed. If each
+    // wholly-dropped page were charged against MAX_PASSES (3), a big enough
+    // cluster would make every pass return nothing, `data` would be empty, and
+    // the request would fall through to Meili on a page BitDex could serve.
+    //
+    // Three emptied pages is one more than the pass budget can absorb, so this
+    // fails on a build that counts them.
+    let call = 0;
+    queryBitdexMock.mockImplementation(async () => {
+      call++;
+      return call <= 3
+        ? { documents: [rescheduledDoc], cursor: { slot_id: call, sort_value: call } }
+        : { documents: [publishedDoc], cursor: undefined };
+    });
+
+    const result = await getImagesFromSearch(baseInput);
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    expect(ids).toContain(101);
+    expect(ids).not.toContain(202);
+  });
+
+  it('does NOT grant the extra pages to a page emptied by an ordinary filter', async () => {
+    // The allowance exists because the publication guard drops a contiguous
+    // cluster at the HEAD of the sort, so the next page is likely different. An
+    // ordinary filter that happens to empty a page — a private-heavy or
+    // poi-heavy slice — has no such property, and paying 5 extra full
+    // `includeDocs` fetches on the feed hot path for it is a latency regression
+    // that buys nothing.
+    //
+    // Every page here is emptied by the Private check, not the publication one,
+    // so the loop should spend its 3 passes and stop — not 8.
+    const FAKE_PAGE_CAP = 50;
+    let calls = 0;
+    queryBitdexMock.mockImplementation(async () => {
+      calls++;
+      if (calls > FAKE_PAGE_CAP) return { documents: [], cursor: undefined };
+      return { documents: [privateDoc], cursor: { slot_id: calls, sort_value: calls } };
+    });
+
+    await getImagesFromSearch(baseInput);
+
+    expect(calls).toBe(3);
+  });
+
+  it('does NOT grant the extra pages to a MIXED page with a single publication hold', async () => {
+    // The all-Private test above passes whether the condition is "one doc was a
+    // publication hold" or "every doc was". This one separates them: a page of
+    // Private documents plus ONE scheduled document is an ordinary-filter page
+    // that happens to contain a publication hold, and it must not buy the
+    // allowance.
+    const FAKE_PAGE_CAP = 50;
+    let calls = 0;
+    queryBitdexMock.mockImplementation(async () => {
+      calls++;
+      if (calls > FAKE_PAGE_CAP) return { documents: [], cursor: undefined };
+      return {
+        documents: [privateDoc, privateDoc, rescheduledDoc],
+        cursor: { slot_id: calls, sort_value: calls },
+      };
+    });
+
+    await getImagesFromSearch(baseInput);
+
+    expect(calls).toBe(3);
+  });
+
+  // The owner and moderator cases below match the Meilisearch rule: strict
+  // published-only by default for everyone, lifted only when the caller opts in
+  // with `scheduled`/`notPublished`. Without that, a creator's own scheduled
+  // post sits ABOVE every live image on their feed until it publishes, because
+  // a not-yet-arrived publish time is a high `sortAt`.
+  //
+  // All three route the mock by the SHAPE of the filters, not by call order —
+  // the sibling bitdex-empty-fallback.test.ts does the same, for the same
+  // reason. Keying on order would leave a test passing if the doc arrived via
+  // the own-excluded merge, which bypasses postFilterBitdexDocs entirely, so it
+  // could never fail.
+  const routeByShape = () =>
+    queryBitdexMock.mockImplementation(async (_index: string, filters: unknown) =>
+      isOwnExcludedQuery(filters) ? page([]) : page([publishedDoc, rescheduledDoc])
+    );
+
+  it('holds back the creator’s OWN scheduled work by default', async () => {
+    routeByShape();
+
+    const result = await getImagesFromSearch({ ...baseInput, currentUserId: OWNER_ID });
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    expect(ids).toContain(101);
+    expect(ids).not.toContain(202);
+  });
+
+  it('shows the creator their own scheduled work when they opt in with `scheduled`', async () => {
+    routeByShape();
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID,
+      scheduled: true,
+    });
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    expect(ids).toContain(202);
+  });
+
+  it('holds scheduled work back from a moderator’s ordinary feed too', async () => {
+    routeByShape();
+
+    // A different account, so this tests the moderator rule and not the owner
+    // carve-out — Meili's moderator branch keeps `OR userId = me`.
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID + 1,
+      isModerator: true,
+    });
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    expect(ids).toContain(101);
+    expect(ids).not.toContain(202);
+  });
+
+  // A moderator's scheduled queue is a request BitDex cannot answer: its query
+  // pushes `isPublished = true`, so the scheduled population is not in the result
+  // to be narrowed down to, and what comes back is the ordinary published feed.
+  //
+  // Two wrong ways to handle that, both tried in earlier revisions of this PR:
+  // serve the published feed (the moderator opens the scheduled queue and sees
+  // live content), or narrow it in the post-filter (the main pass goes
+  // near-empty while the own-excluded merge stays populated, so BitDex serves the
+  // moderator only their OWN content as the "scheduled queue"). Both are
+  // non-empty results, and a non-empty result SUPPRESSES the Meili fallback that
+  // answers this correctly.
+  //
+  // So it declines instead. `source: 'meili'` is the assertion — the request was
+  // handed to the backend that can answer it.
+  it('declines a moderator’s `scheduled` request so Meili answers it', async () => {
+    routeByShape();
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID + 1,
+      isModerator: true,
+      scheduled: true,
+    });
+
+    expect(result.source).toBe('meili');
+    // Not the published feed dressed up as the scheduled queue.
+    expect(result.data.map((i: { id: number }) => i.id)).not.toContain(101);
+  });
+
+  it('declines a moderator’s `notPublished` request so Meili answers it', async () => {
+    // Same class as `scheduled`. BitDex's query pushes `isPublished = false`,
+    // which covers scheduled AND never-published with no separate signal, so it
+    // returns a superset seeded with scheduled posts where Meili answers
+    // never-published only. A non-empty superset suppresses the fallback.
+    routeByShape();
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID + 1,
+      isModerator: true,
+      notPublished: true,
+    });
+
+    expect(result.source).toBe('meili');
+  });
+
+  it('still grants the allowance when the scheduled cluster contains a private doc', async () => {
+    // `Private`/`blockedFor`/`acceptableMinor`/`poi` are tested BEFORE the
+    // publication check, so those documents never increment the hold count.
+    // Requiring EVERY doc on the page to be a publication hold would therefore
+    // let one private image inside a scheduled cluster deny the allowance and
+    // restore the starvation it exists to prevent.
+    //
+    // 2 of 3 held for publication, 1 private → still the cluster, still allowed.
+    const FAKE_PAGE_CAP = 50;
+    let calls = 0;
+    queryBitdexMock.mockImplementation(async (_index: string, filters: unknown) => {
+      if (isOwnExcludedQuery(filters)) return page([]);
+      calls++;
+      if (calls > FAKE_PAGE_CAP) return { documents: [], cursor: undefined };
+      return calls <= 4
+        ? {
+            documents: [rescheduledDoc, scheduledDoc, privateDoc],
+            cursor: { slot_id: calls, sort_value: calls },
+          }
+        : { documents: [publishedDoc], cursor: undefined };
+    });
+
+    const result = await getImagesFromSearch(baseInput);
+
+    // Reached page 5 and served it: without the allowance the loop would have
+    // spent its 3 passes on the cluster and returned nothing.
+    expect(result.data.map((i: { id: number }) => i.id)).toContain(101);
+  });
+
+  it('keeps a moderator’s own unpublished content arriving via the own-excluded pass', async () => {
+    // The main post-filter keeps `OR userId = me` for moderators. If the merge
+    // path applied the publication rule unconditionally, the same document would
+    // be served through one door and dropped through the other.
+    queryBitdexMock.mockImplementation(async (_index: string, filters: unknown) =>
+      isOwnExcludedQuery(filters) ? page([rescheduledDoc]) : page([publishedDoc])
+    );
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID,
+      isModerator: true,
+    });
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    expect(ids).toContain(202);
+  });
+
+  it('does not treat `notPublished` as an opt-in for a non-moderator', async () => {
+    // Meili's non-moderator branch honours `scheduled` and ignores
+    // `notPublished`. Accepting it here would make the two backends answer the
+    // same input differently, and the difference would land in the shadow
+    // comparator with nothing to attribute it to.
+    routeByShape();
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID,
+      notPublished: true,
+    });
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    expect(ids).toContain(101);
+    expect(ids).not.toContain(202);
+  });
+
+  // A never-published draft is a DIFFERENT failure from a scheduled post, and
+  // the two below exist because splitting the publication test in half is how
+  // the owner and moderator branches came to enforce only the scheduled one.
+  // `neverPublishedDoc` has a PAST `sortAt`, so nothing but the null check can
+  // catch it.
+  it('holds back the creator’s own NEVER-published draft by default', async () => {
+    queryBitdexMock.mockImplementation(async (_index: string, filters: unknown) =>
+      isOwnExcludedQuery(filters) ? page([]) : page([publishedDoc, neverPublishedDoc])
+    );
+
+    const result = await getImagesFromSearch({ ...baseInput, currentUserId: OWNER_ID });
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    expect(ids).toContain(101);
+    expect(ids).not.toContain(404);
+  });
+
+  it('holds a never-published draft back from a moderator’s ordinary feed', async () => {
+    queryBitdexMock.mockImplementation(async (_index: string, filters: unknown) =>
+      isOwnExcludedQuery(filters) ? page([]) : page([publishedDoc, neverPublishedDoc])
+    );
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID + 1,
+      isModerator: true,
+    });
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    expect(ids).toContain(101);
+    expect(ids).not.toContain(404);
+  });
+
+  it('applies the publication rule to the own-excluded second pass as well', async () => {
+    // 🔴 The door the rule was NOT checking. This pass asks for
+    // `nsfwLevel=0 OR availability=Private OR blockedFor IN (…)`, and
+    // `nsfwLevel = 0` is the ordinary state of a freshly-uploaded, unscanned
+    // image — so a creator's just-scheduled upload matches on the nsfw0 arm
+    // alone, with no `isPublished=false` clause needed. Its documents are merged
+    // straight into the result without going through postFilterBitdexDocs, and
+    // its future `sortAt` sorts it to position 1 of the creator's own feed.
+    //
+    // Note the routing is INVERTED from the tests above: the scheduled doc is
+    // returned by the own-excluded pass, so it can only reach the caller through
+    // the merge. Every other test stubs that pass empty and therefore cannot
+    // catch this.
+    queryBitdexMock.mockImplementation(async (_index: string, filters: unknown) =>
+      isOwnExcludedQuery(filters) ? page([rescheduledDoc]) : page([publishedDoc])
+    );
+
+    const result = await getImagesFromSearch({ ...baseInput, currentUserId: OWNER_ID });
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    expect(ids).toContain(101);
+    expect(ids).not.toContain(202);
+  });
+
+  it('still merges own excluded content through that pass when opted in', async () => {
+    // Positive control for the test above: same routing, `scheduled` set. If the
+    // merge filter were unconditional rather than gated on the opt-in, this
+    // would fail — so the previous test cannot be passing merely because the
+    // merge path is broken.
+    queryBitdexMock.mockImplementation(async (_index: string, filters: unknown) =>
+      isOwnExcludedQuery(filters) ? page([rescheduledDoc]) : page([publishedDoc])
+    );
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID,
+      scheduled: true,
+    });
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    expect(ids).toContain(202);
+  });
+
+  it('stops skipping emptied pages at the bound instead of walking forever', async () => {
+    // The pagination test above proves the ALLOWANCE; this proves the BOUND.
+    // Without it, deleting the `emptiedPages < MAX_EMPTIED_PAGES` condition
+    // leaves that test green, because its mock stops issuing cursors after the
+    // third page. Here the cursor stream keeps going, so the consumer has to be
+    // the thing that stops.
+    //
+    // The fake terminates itself at 50 pages even so. An endless one would leave
+    // a build with both bounds removed spinning on already-resolved promises —
+    // a pure microtask loop that starves the macrotask queue, so vitest's
+    // setTimeout-based timeout never fires and CI hangs with nothing to read.
+    // Self-terminating turns that into `expected 51 to be 8` in under a second.
+    // (This is what `local-rules/no-unbounded-paging-fake` exists to catch, and
+    // it caught this test.)
+    const FAKE_PAGE_CAP = 50;
+    let calls = 0;
+    queryBitdexMock.mockImplementation(async () => {
+      calls++;
+      if (calls > FAKE_PAGE_CAP) return { documents: [], cursor: undefined };
+      return { documents: [rescheduledDoc], cursor: { slot_id: calls, sort_value: calls } };
+    });
+
+    const result = await getImagesFromSearch(baseInput);
+
+    // 5 skipped pages + 3 charged passes = 8 fetches, then it gives up and falls
+    // through to Meili with nothing of its own.
+    //
+    // UPPER bound only. The allowance is also bounded by EMPTIED_PAGE_BUDGET_MS
+    // measured from the start of the loop, so on a stalled worker the budget can
+    // elapse during the FIRST iteration — every emptied page is then charged as
+    // a pass and the loop exits at 3 fetches. A lower bound would fail there,
+    // reporting the machine rather than the code.
+    //
+    // The bound under test is the upper one: anything at or below 8 means a
+    // bound held, and a build with both bounds removed reaches the fake's 51.
+    expect(calls).toBeLessThanOrEqual(8);
+    expect(result.data.map((i: { id: number }) => i.id)).not.toContain(202);
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -232,7 +232,11 @@ import { FLIPT_FEATURE_FLAGS, getFliptBoolean, getFliptVariant, isFlipt } from '
 import { buildFliptContext } from '~/server/services/feature-flags.service';
 import { queryBitdex } from '~/server/bitdex/client';
 import type { FilterClause, SortClause, Value } from '~/server/bitdex/client';
-import { compareBitdexResults, recordBitdexError } from '~/server/bitdex/compare';
+import {
+  compareBitdexResults,
+  recordBitdexError,
+  recordSortAtOnlyHolds,
+} from '~/server/bitdex/compare';
 
 // --- BitDex native filter helpers ---
 const _int = (v: number): Value => ({ Integer: v });
@@ -2939,26 +2943,154 @@ export function redactSearchInputForLog<T extends Record<string, unknown>>(input
  * cacheable filters (no per-user clauses), so this rarely removes anything.
  * User's own excluded content is fetched in a separate second pass and merged.
  */
+/**
+ * Per-request tally, created by the caller and threaded through.
+ *
+ * NOT module-level. This process serves feed requests concurrently and every
+ * `await` in the page loop yields to another one, so a module-level counter
+ * would be reset and incremented by interleaving requests — request A logging
+ * request B's drops. A number whose value cannot be attributed to a request is
+ * not a measurement, and this counter exists precisely to attribute something.
+ */
+type PostFilterStats = {
+  /** Documents held back by the publication test, for any of its reasons. */
+  publicationHolds: number;
+  /**
+   * Distinct ids held back on `sortAt` alone — their own `publishedAt` was
+   * already past. Tracked separately because that is the half that can hide
+   * genuinely published content, and by ID because the same document can be
+   * tested twice (main pass, then the own-excluded merge).
+   */
+  sortAtOnlyIds: Set<number>;
+};
+
 function postFilterBitdexDocs(
   docs: ReturnType<typeof mapBitdexDoc>[],
   currentUserId: number | undefined,
   isModerator: boolean | undefined,
-  disablePoi: boolean | undefined
+  disablePoi: boolean | undefined,
+  /**
+   * The caller opted in to their own not-yet-published content. Without it, a
+   * document that is not yet published is filtered out for EVERYONE — including
+   * the owner and moderators — which is what the Meilisearch path has always
+   * done. See below.
+   *
+   * Only `scheduled` sets this for a non-moderator, because Meili's
+   * non-moderator branch honours only `scheduled` and ignores `notPublished`
+   * entirely. Accepting both here would make the two backends answer the same
+   * input differently, which surfaces as shadow-comparator divergence nobody can
+   * attribute.
+   */
+  wantsUnpublished: boolean,
+  stats: PostFilterStats
 ) {
-  // Moderators see everything — no post-filtering needed
-  if (isModerator) return docs;
+  const now = Date.now();
+
+  // Moderators are exempt from the content filters below, but not from the
+  // publication one: Meili's moderator branch is `publishedAtUnix <= now OR
+  // userId = me` by default, and only lifts that on an explicit
+  // `scheduled`/`notPublished` request. Returning everything here would put
+  // not-yet-published documents at the head of a moderator's ordinary feed —
+  // they sort first — on a request that did not ask for them.
+  //
+  if (isModerator) {
+    // DEFENSIVE ONLY — not reachable from the sole caller, which declines a
+    // moderator's `scheduled`/`notPublished` request outright (see
+    // `fetchBitdexPrimary`) precisely because BitDex answers a different question
+    // for both. Kept so this function is correct in isolation rather than only in
+    // the presence of that guard; do not read it as live behaviour.
+    if (wantsUnpublished) return docs;
+    return docs.filter(
+      (doc) =>
+        (currentUserId != null && doc.userId === currentUserId) ||
+        isPublicallyPublished(doc, now, stats)
+    );
+  }
 
   return docs.filter((doc) => {
     const isOwn = currentUserId != null && doc.userId === currentUserId;
-    if (isOwn) return true; // always show user's own content
+    // Own content stays exempt from the content filters below — but a creator's
+    // own not-yet-published work is held back like anyone else's unless they
+    // asked for it, matching Meili: "By default, strict published-only — owners
+    // no longer see their own scheduled/unpublished content pinned to feeds. The
+    // `scheduled` flag is opt-in." Without this the future `sortAt` puts their
+    // unpublished post above every live image on their own feed until it
+    // publishes.
+    if (isOwn) return wantsUnpublished || isPublicallyPublished(doc, now, stats);
 
     if (doc.availability === 'Private') return false;
     if (doc.blockedFor) return false;
     if (doc.acceptableMinor) return false;
     if (disablePoi && doc.poi) return false;
-    if (doc.publishedAtUnix == null) return false; // unpublished
-    return true;
+    return isPublicallyPublished(doc, now, stats);
   });
+}
+
+/**
+ * The whole publication test, in one place: published at all, and published
+ * *already*.
+ *
+ * Both halves are needed and they are separate failures. A NULL publish time is
+ * a draft that was never published; a future one is scheduled. Meili's
+ * post-filter tests both together (`!hit.publishedAtUnix || hit.publishedAtUnix
+ * > snappedNow`), and splitting them here is how the owner and moderator
+ * branches came to enforce only the second — a never-published document with a
+ * stale index flag would have been served to its owner, which is precisely the
+ * case this post-filter exists to catch.
+ */
+function isPublicallyPublished(
+  doc: Pick<ReturnType<typeof mapBitdexDoc>, 'id' | 'publishedAtUnix' | 'sortAtUnix'>,
+  now: number,
+  stats: PostFilterStats
+) {
+  if (doc.publishedAtUnix == null) {
+    stats.publicationHolds++;
+    return false; // never published
+  }
+  if (isScheduledForFuture(doc, now, stats)) {
+    stats.publicationHolds++;
+    return false; // published, but not yet
+  }
+  return true;
+}
+
+/**
+ * True when the document's publish time has not arrived yet.
+ *
+ * The publication decision on this path is carried by a single index flag, with
+ * no comparison against the current time. This restores the same time check the
+ * Meilisearch path has always applied (`publishedAtUnix > snappedNow`), so the
+ * post-filter no longer depends on that flag alone being right.
+ *
+ * BOTH timestamps are tested, and that is not belt-and-braces: a document can
+ * carry a future schedule on `sortAt` while `publishedAt` still holds an
+ * earlier value it was moved off, so a `publishedAt`-only test would let the
+ * rescheduled case through.
+ *
+ * Unsnapped `Date.now()` is deliberate. The Meili sites snap to the minute to
+ * keep filter strings cache-stable; a post-filter has no cache key, so snapping
+ * would only withhold just-published content for up to 60s and buy nothing.
+ */
+function isScheduledForFuture(
+  doc: Pick<ReturnType<typeof mapBitdexDoc>, 'id' | 'publishedAtUnix' | 'sortAtUnix'>,
+  now: number,
+  stats: PostFilterStats
+) {
+  if (doc.publishedAtUnix != null && doc.publishedAtUnix > now) return true;
+  const bySortAtOnly = doc.sortAtUnix != null && doc.sortAtUnix > now;
+
+  // Count the `sortAt`-only holds separately, because this half of the test can
+  // hide content that is genuinely published.
+  //
+  // `sortAt` is not PG's `sortAt` — the index recomputes it as
+  // `GREATEST(existedAt, publishedAt)`, and it is known to drift. A document
+  // whose stored `sortAt` is wrongly ahead of now is then invisible on the
+  // BitDex path while Meili, which tests `publishedAtUnix` alone, still serves
+  // it. Without this counter that surfaces only as unexplained shadow-comparator
+  // divergence with nothing to attribute it to — an absence, which is the one
+  // thing we have learned not to read as an answer.
+  if (bySortAtOnly) stats.sortAtOnlyIds.add(doc.id);
+  return bySortAtOnly;
 }
 
 /**
@@ -2966,9 +3098,45 @@ function postFilterBitdexDocs(
  * The main query is fully cacheable (no per-user filter clauses).
  * Returns null if BitDex can't serve the request.
  */
-async function fetchBitdexPrimary(input: ImageSearchInput) {
+async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boolean } = {}) {
+  // Two moderator queues BitDex cannot answer, declined so Meili does.
+  //
+  // `scheduled`: the query pushes `isPublished = true`, so the scheduled
+  // population is not in the result at all and what comes back is the ordinary
+  // published feed.
+  //
+  // `notPublished`: the query pushes `isPublished = false`, which per the
+  // own-excluded comment below "covers both scheduled and never-published (no
+  // separate signal)". Meili answers this with `publishedAtUnix NOT EXISTS` —
+  // never-published only. So BitDex returns a SUPERSET seeded with scheduled
+  // posts, and with the opt-in set the post-filter passes them through
+  // unnarrowed.
+  //
+  // In both cases the failure is the same and it is worse than not answering: a
+  // non-empty result SUPPRESSES the Meili fallback, so the moderator opens a
+  // queue and is shown a different population, with nothing signalling that the
+  // wrong question was answered. Declining is the honest containment; answering
+  // properly means changing what the query asks for, which is not this PR.
+  if (input.isModerator && (input.scheduled || input.notPublished)) return null;
+
   const limit = input.limit ?? 100;
+  // Opt-in to one's own not-yet-published content. Read once so the main
+  // post-filter and the own-excluded merge below cannot disagree about it.
+  //
+  // A non-moderator opts in with `scheduled` only. Meili's non-moderator branch
+  // honours `scheduled` and ignores `notPublished` entirely, so accepting both
+  // here would make the two backends answer the same input differently — and
+  // that divergence lands in the shadow comparator with nothing to attribute it
+  // to, which is the failure this PR adds a counter to avoid elsewhere.
+  const wantsUnpublished = input.isModerator
+    ? !!(input.scheduled || input.notPublished)
+    : !!input.scheduled;
   const MAX_PASSES = 3;
+  // Pages discarded wholesale by the post-filter do not count against
+  // MAX_PASSES, up to this many pages AND this much wall clock, whichever binds
+  // first. See the loop below for why both.
+  const MAX_EMPTIED_PAGES = 5;
+  const EMPTIED_PAGE_BUDGET_MS = 1500;
 
   // Decode BitDex keyset cursor from "offset|bdx:JSON" format
   let bitdexCursor: any = undefined;
@@ -3009,10 +3177,15 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
         ].map(_str)
       ),
     ];
-    // Own scheduled/unpublished content only surfaces when the caller opts in
-    // via `scheduled` or `notPublished`. BitDex `isPublished=false` covers both
-    // (no separate scheduled vs unpublished signal), so the gate is unified.
-    if (input.scheduled || input.notPublished) {
+    // Own scheduled/unpublished content only surfaces when the caller opts in.
+    // BitDex `isPublished=false` covers both scheduled and never-published (no
+    // separate signal), so the gate is unified.
+    //
+    // Reads the SAME `wantsUnpublished` the merge filter below uses. Asking for
+    // these documents on a flag combination the merge then discards is a wasted
+    // 500-document round trip on the feed hot path — and two gates that spell
+    // the same intent differently is how they drift apart.
+    if (wantsUnpublished) {
       ownExcludedClauses.push(_eq('isPublished', _bool(false)));
     }
     if (input.disablePoi) ownExcludedClauses.push(_eq('poi', _bool(true)));
@@ -3058,25 +3231,88 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
   const accumulated: ReturnType<typeof mapBitdexDoc>[] = [];
   let lastCursor: any = undefined;
 
-  for (let pass = 0; pass < MAX_PASSES && accumulated.length < limit; pass++) {
-    const result = await (pass === 0
+  let pass = 0;
+  let emptiedPages = 0;
+  let firstPage = true;
+  // Started AFTER the first fetch (below), so page latency does not consume the
+  // budget the allowance is meant to spend. On the feed hot path each pass is a
+  // full `includeDocs` round trip; clocking from before it means two slow passes
+  // exhaust 1.5s before a single skip is granted, and the anti-starvation
+  // allowance degrades to nothing under exactly the load where starvation bites.
+  let skipBudgetStartedAt = 0;
+  const stats: PostFilterStats = { publicationHolds: 0, sortAtOnlyIds: new Set<number>() };
+
+  while (pass < MAX_PASSES && accumulated.length < limit) {
+    const result = await (firstPage
       ? getImagesFromBitdexPreFilter(input, true, bitdexCursor)
       : getImagesFromBitdexPreFilter(input, true, lastCursor));
+    if (skipBudgetStartedAt === 0) skipBudgetStartedAt = Date.now();
+    firstPage = false;
 
     if (!result?.documents?.length) break;
 
     const docs = result.documents.map((doc) => mapBitdexDoc(doc));
+    const heldBefore = stats.publicationHolds;
     const filtered = postFilterBitdexDocs(
       docs,
       input.currentUserId,
       input.isModerator,
-      input.disablePoi
+      input.disablePoi,
+      wantsUnpublished,
+      stats
     );
     accumulated.push(...filtered);
     lastCursor = result.cursor;
 
     if (!result.cursor) break; // no more pages
+
+    // A page the PUBLICATION guard emptied is not a page of results, and
+    // charging it against the pass budget starves the request. The documents it
+    // holds back sort FIRST under the default `sortAt Desc` — a not-yet-arrived
+    // publish time is a high sort value — so they arrive contiguously at the
+    // head. Enough of them and every pass returns nothing, `data` is empty, and
+    // the caller falls through to Meili on a request BitDex could have served.
+    //
+    // The allowance is deliberately NOT granted to any empty page: an ordinary
+    // filter that happens to drop a whole page (a poi-heavy view under
+    // `disablePoi`, a private-heavy slice) has no reason to expect the next page
+    // to be different, and paying 5 extra `includeDocs` fetches on the feed hot
+    // path for it is a latency regression with nothing bought.
+    //
+    // Bounded twice — by pages and by wall clock — because the main query is
+    // cacheable per filter shape, so a head cluster is not one unlucky request
+    // paying for extra pages: every request in that window walks the same ones.
+    //
+    // MOST of the page, not merely one document of it and not strictly all.
+    //
+    // "One is enough" grants the allowance to a page where 49 docs were dropped
+    // by `poi`/`Private` and the 50th happened to be unpublished — an
+    // ordinary-filter page buying the extra fetches.
+    //
+    // "All of them" fails the other way, and less obviously: `Private`,
+    // `blockedFor`, `acceptableMinor` and `poi` are tested BEFORE the publication
+    // check, so those documents never reach it and never increment the count. A
+    // single private or blocked document sitting inside a scheduled head cluster
+    // would then deny the allowance and restore the starvation it exists to
+    // prevent — and scheduled-and-unlisted is not an exotic combination.
+    //
+    // A majority keeps the cluster case working while still refusing the
+    // ordinary-filter page.
+    const publicationHeldHere = stats.publicationHolds - heldBefore;
+    const emptiedByPublicationGuard =
+      filtered.length === 0 && publicationHeldHere * 2 >= docs.length && publicationHeldHere > 0;
+
+    if (
+      emptiedByPublicationGuard &&
+      emptiedPages < MAX_EMPTIED_PAGES &&
+      Date.now() - skipBudgetStartedAt < EMPTIED_PAGE_BUDGET_MS
+    )
+      emptiedPages++;
+    else pass++;
   }
+
+  // Logged after the merge below, not here, so the merge's own holds are
+  // included rather than bleeding into whichever request logs next.
 
   let data = accumulated;
 
@@ -3118,6 +3354,27 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
     if (input.remixOfId) ownDocs = ownDocs.filter((d) => d.remixOfId === input.remixOfId);
     if (input.withMeta) ownDocs = ownDocs.filter((d) => d.hasMeta);
     if (input.fromPlatform) ownDocs = ownDocs.filter((d) => d.onSite);
+
+    // These documents never pass through postFilterBitdexDocs, so the
+    // publication rule has to be applied here too — and without it the owner
+    // half of that rule does nothing.
+    //
+    // This pass asks for `nsfwLevel=0 OR availability=Private OR blockedFor IN
+    // (…)`, and `nsfwLevel = 0` is the ordinary state of a freshly-uploaded,
+    // not-yet-scanned image. So a creator's just-scheduled upload matches this
+    // pass on the nsfw0 arm alone — with no `isPublished=false` clause needed —
+    // and lands here carrying a future `sortAt`, which sorts it to position 1 of
+    // their own feed. Exactly the symptom the publication rule is for, arriving
+    // by the one door that did not check.
+    // Moderators are exempt, because the main post-filter keeps `OR userId = me`
+    // for them. Without this a moderator's own unpublished image would be served
+    // when it arrived through the main pass and dropped when it arrived through
+    // this one — visibility decided by which door it came in by.
+    if (!wantsUnpublished && !input.isModerator) {
+      const mergeNow = Date.now();
+      ownDocs = ownDocs.filter((d) => isPublicallyPublished(d, mergeNow, stats));
+    }
+
     if (ownDocs.length) {
       data = [...data, ...ownDocs];
       const sort = input.sort;
@@ -3136,6 +3393,32 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
     }
   }
 
+  // A counter, not just a log line: this is the number that has to be
+  // attributable and alertable, and a log is neither queryable nor rate-limited
+  // on a hot path. The log stays for the local/debug case.
+  //
+  // TWO counters, not one gated counter. This function also runs in shadow mode,
+  // where nothing reaches the user, and folding both into one series would make
+  // an alert threshold mean two different things depending on the flag state — a
+  // number that changes meaning without changing its name.
+  //
+  // But counting ONLY when serving is worse: shadow mode exists precisely to
+  // size a risk before taking it, so a shadow-blind counter reads a flat zero
+  // until a cohort is flipped, i.e. it can only measure the exposure after it is
+  // taken. Separate names give attribution without the silence.
+  //
+  // Both are unlabelled for the reason given in compare.ts: a labelled series is
+  // absent until its first observation, and an alert over an absent series
+  // renders as "No data".
+  //
+  // No log line. A counter is queryable and a log is not, and `sortAt` drift is
+  // stated to be broad when it happens — one line per feed request at feed QPS,
+  // unsampled, on the hot path, is a liability rather than an instrument.
+  //
+  // Counted by distinct document id: a document held back in the main pass can
+  // reappear in the own-excluded merge (which dedupes against `data`, from which
+  // it has already been removed), and counting it twice would overstate the very
+  // thing this is here to size.
   // Nothing to serve → return null so the caller falls back to Meilisearch.
   // Checked HERE, on the merged result, and not on `accumulated` alone: the
   // own-excluded second pass can be the only source of content on the page
@@ -3143,9 +3426,29 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
   // yet an empty result. Checking earlier would either discard that content or
   // — as it did before — make the fallback unreachable for any caller for whom
   // the second pass was issued at all, i.e. every signed-in first-page request.
-  if (!data.length) return null;
+  if (!data.length) {
+    // Recorded as `fallback`, NOT as `serving`. Meili answers this request and
+    // serves the very documents that were held, so nothing was hidden from the
+    // user — counting it under a name whose help text says "requests BitDex
+    // served" would make the alert fire loudest in the one case where the guard
+    // cost the user nothing.
+    recordSortAtOnlyHolds(stats.sortAtOnlyIds.size, 'fallback');
+
+    // ⚠️ A cursored request does not fall back cleanly — the Meili path parses
+    // cursors as `offset|entryTimestamp` (:2594) and a `bdx:{…}` cursor fails
+    // both `isNumber` guards, so offset degrades to 0. An earlier revision of
+    // this PR ended the feed instead, and that was wrong: the paginated fallback
+    // is a DELIBERATE, pinned decision — see the invariant guard
+    // "authenticated + paginated (bdx cursor) + zero documents → falls back to
+    // Meili" in bitdex-empty-fallback.test.ts, whose comment says it is "pinned
+    // so the decision is explicit". Reversing it belongs in a change that owns
+    // that decision, not in this one. Raised separately.
+    return null;
+  }
 
   data = data.slice(0, limit);
+
+  recordSortAtOnlyHolds(stats.sortAtOnlyIds.size, opts.serving ? 'serving' : 'shadow');
 
   const nextCursor = lastCursor ? `bdx:${JSON.stringify(lastCursor)}` : undefined;
   console.log(
@@ -3199,7 +3502,7 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
   if (bitdexMode === 'primary') {
     try {
       const result = await withSpan('image:bitdex:primary', { 'bitdex.mode': 'primary' }, () =>
-        fetchBitdexPrimary(input)
+        fetchBitdexPrimary(input, { serving: true })
       );
       if (result) return { ...result, source: 'bitdex' as const };
       console.log('[BitDex] PRIMARY returned no results, falling through to Meili');


### PR DESCRIPTION
## What this does

Holds a document out of the BitDex-served image feed until it is actually published.

`postFilterBitdexDocs` is the declared defense-in-depth layer for this path, but it only rejected a **NULL** publish time — a publish time in the **future** passed through. This restores the rule the Meilisearch path has always applied, so the filter no longer relies on the index flag alone being correct.

**This was live.** Measured on 2026-08-17: **100 images across 15 posts and 9 users** on the serving pod, scheduled as far out as 2026-11-16, sitting at the top of the Newest feed (a not-yet-arrived publish time is a high `sortAt`). Confirmed against Postgres and reproduced anonymously through `GET /api/v1/images?sort=Newest`, where items 1 and 2 were scheduled posts. The standby pod carried 201 across 29.

The publication test is both halves in one predicate: **published at all**, and **published already**. Splitting them is how the owner and moderator branches first came to enforce only the second.

## Why two timestamps

A document can carry a future schedule on `sortAt` while `publishedAt` still holds an earlier value the post was moved off — the rescheduled case. **All 100 leaked documents had that shape**, so a `publishedAt`-only test would have caught none of them.

This cannot be pushed into the query: the deployed index's filter set has no time field, and `sortAt`/`publishedAt` are sort-only (a range query on either returns `field not found`).

## Why two doors

The own-excluded second pass merges documents into the result **without passing through the post-filter**, and selects on `nsfwLevel = 0 OR availability = Private OR blockedFor IN (…)`. `nsfwLevel = 0` is the ordinary state of a freshly-uploaded, unscanned image — so a creator's just-scheduled upload matches on that arm alone and arrives by the one door that did not check. Filtering only the main path left the symptom intact for the creator.

## Owners and moderators

- **Creators**: own unpublished work is held back unless they opt in with `scheduled`. Only `scheduled` — Meili's non-moderator branch ignores `notPublished`, and honouring it here would make the two backends answer the same input differently.
- **Moderators**: ordinary feed no longer carries unpublished documents at the head of the sort; `OR userId = me` and the content-filter exemption are kept, on **both** doors.
- **Moderator `scheduled` / `notPublished` are declined** so Meili answers. BitDex's query pushes `isPublished = true` for one and `isPublished = false` for the other, which covers scheduled *and* never-published with no separate signal — so it answers a different question in both cases, and a non-empty wrong answer suppresses the fallback.

## Pagination

Held-back documents arrive contiguously at the head of the feed, so pages emptied **by the publication guard** no longer charge the 3-pass budget — bounded by pages and by wall clock, the clock starting after the first fetch so page latency does not consume the allowance. A **majority** rule, not all-or-one: `Private`/`blocked`/`poi` are tested before the publication check and never counted, so requiring all would let one unlisted image in a scheduled cluster restore the starvation.

## Observability

`sortAt`-only holds are counted per request under **three** unlabelled counters — `serving`, `shadow`, `fallback` — because they mean different things to an operator: content hidden from a user, content that would have been, and content held where Meili then served the request anyway. Unlabelled because a labelled series is absent until its first observation and an alert over an absent series reads "No data". Per-request and by distinct id, since this process serves feeds concurrently.

## Known gaps, deliberately not closed here

- The `sortAt` arm can in principle hide a genuinely-published document whose indexed `sortAt` has drifted. Measured against prod at the time of writing: of the documents it would hold back, **14/14 posts were genuinely unpublished, 0 false positives**. Broad drift degrades to the Meili fallback rather than an empty feed. The counters exist to detect it.
- A cursored request that falls back hands Meili a `bdx:` cursor it cannot parse (`:2594`), restarting the scroll. Pre-existing; this PR makes it more reachable. **Not fixed here** — the paginated fallback is a deliberate decision pinned by an invariant guard in `bitdex-empty-fallback.test.ts`, and reversing it belongs to a change that owns it. Raised as `868ktb2zu`.

## Tests

18 cases. **Every guard has a positive control** — removed in turn, the corresponding test fails naming the document that should not have been served, or the page count that should not have been reached:

| guard removed | failure |
|---|---|
| own-excluded merge filter | `expected [ 202, 101 ] to not include 202` |
| never-published check | `expected [ 101, 404 ] to not include 404` |
| moderator carve-out on the merge path | `expected [ 101 ] to include 202` |
| non-moderator `notPublished` parity | `expected [ 101, 202 ] to not include 202` |
| allowance scoped to publication holds | `expected 8 to be 3` |
| allowance majority rule | `expected [] to include 101` |
| moderator `scheduled` decline | `expected 'bitdex' to be 'meili'` |
| moderator `notPublished` decline | `expected 'bitdex' to be 'meili'` |
| both pagination bounds | `expected 51 to be 8` |

The paging fakes self-terminate, so a build with every bound removed fails in milliseconds rather than hanging CI with nothing to read. Tests route BitDex's two passes by filter **shape**, not call order.

## Verification

Logs written to a per-session directory and checked to name this worktree before being quoted.

- `pnpm run typecheck` — 0 errors, **positive control**: a planted `TS2322` was caught at `image.service.ts(3120,9)`, then reverted
- `pnpm run test:unit:run` — **1114 passed | 1 skipped (1115)**, exit 0, full collection. This file collected 18; `blocks.router.workflow.test.ts` collected 350, so the submodule is initialised and the run is real
- `eslint` on all three files: clean for the new code; `image.service.ts`'s 3 errors are pre-existing and outside this diff's hunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
