### PR TITLE
fix(router): keep the path param when back lands on a dynamic route

### DIFF
--- a/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
@@ -30,16 +30,18 @@ import { renderWithProviders } from '../../../test/component-setup';
 // window `error` event, so an onError spy is NOT a reliable guard here.)
 
 function AsPathProbe() {
-  const { asPath, query } = useBrowserRouter();
+  const { asPath, query, state } = useBrowserRouter();
   return (
     <>
       <div data-testid="aspath">{asPath}</div>
       <div data-testid="imageid">{String(query.imageId)}</div>
+      <div data-testid="prev">{String(state?.prev?.asPath)}</div>
     </>
   );
 }
 const probeText = () => page.getByTestId('aspath').element().textContent;
 const imageIdText = () => page.getByTestId('imageid').element().textContent;
+const prevText = () => page.getByTestId('prev').element().textContent;
 
 describe('BrowserRouterProvider + ClientHistoryStore popstate handling (Safari null state)', () => {
   test('a back navigation with null history.state degrades to the current location instead of crashing', async () => {
@@ -136,12 +138,22 @@ describe('BrowserRouterProvider back navigation onto a dynamic route', () => {
       // The pop: leaving `/models/[id]`, landing on `/images/135356251`. Next
       // takes this one, which is what defers the commit to `routeChangeComplete`.
       setUsingNextRouter(true);
-      const popped = { as: '/images/135356251', url: '/images/135356251', state: {} };
+      const popped = {
+        as: '/images/135356251',
+        url: '/images/135356251',
+        state: { prev: { asPath: '/models/827184' } },
+      };
       window.history.replaceState(popped, '');
       window.dispatchEvent(new PopStateEvent('popstate', { state: popped }));
 
       // Next finishes: it has interpolated `imageId` into its own query, and only
-      // then emits `routeChangeComplete`.
+      // then emits `routeChangeComplete`. Its `changeState` has already replaced
+      // `history.state` with its own shape — note there is no `state` key, so the
+      // entry's payload now exists only in the popstate snapshot.
+      window.history.replaceState(
+        { url: '/images/[imageId]', as: '/images/135356251', options: {}, __N: true, key: 'k' },
+        ''
+      );
       Router.asPath = '/images/135356251';
       Router.query = { imageId: '135356251' };
       expect(handlers.length).toBeGreaterThan(0);
@@ -153,6 +165,8 @@ describe('BrowserRouterProvider back navigation onto a dynamic route', () => {
       // The regression: this read `undefined` and `/images/[imageId]` rendered
       // `<NotFound />`.
       expect(imageIdText()).toBe('135356251');
+      // And the entry's payload survives, which routed dialogs are handed as props.
+      expect(prevText()).toBe('/models/827184');
     } finally {
       setUsingNextRouter(false);
       Router.asPath = originalAsPath;

--- a/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
-import { BrowserRouterProvider, useBrowserRouter } from '~/components/BrowserRouter/BrowserRouterProvider';
+import Router from 'next/router';
+import {
+  BrowserRouterProvider,
+  setUsingNextRouter,
+  useBrowserRouter,
+} from '~/components/BrowserRouter/BrowserRouterProvider';
 import { ClientHistoryStore } from '~/store/ClientHistoryStore';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
@@ -25,10 +30,16 @@ import { renderWithProviders } from '../../../test/component-setup';
 // window `error` event, so an onError spy is NOT a reliable guard here.)
 
 function AsPathProbe() {
-  const { asPath } = useBrowserRouter();
-  return <div data-testid="aspath">{asPath}</div>;
+  const { asPath, query } = useBrowserRouter();
+  return (
+    <>
+      <div data-testid="aspath">{asPath}</div>
+      <div data-testid="imageid">{String(query.imageId)}</div>
+    </>
+  );
 }
 const probeText = () => page.getByTestId('aspath').element().textContent;
+const imageIdText = () => page.getByTestId('imageid').element().textContent;
 
 describe('BrowserRouterProvider + ClientHistoryStore popstate handling (Safari null state)', () => {
   test('a back navigation with null history.state degrades to the current location instead of crashing', async () => {
@@ -78,6 +89,69 @@ describe('BrowserRouterProvider + ClientHistoryStore popstate handling (Safari n
       // handler ran and did not throw before updating).
       expect(probeText()).not.toBe('/search?query=cats');
     } finally {
+      window.history.replaceState(originalState, '');
+    }
+  });
+});
+
+// A back navigation onto `/images/[imageId]` from another dynamic route
+// (ClickUp 868kt41x7). Next owns this pop, but the browser-router state was
+// resolved in the popstate handler — where `Router.pathname` is still the route
+// being LEFT — and then committed verbatim on `routeChangeComplete`, landing a
+// query with no `imageId` on a page that reads its id from there. The page
+// rendered its not-found branch; a refresh loaded the same URL fine.
+describe('BrowserRouterProvider back navigation onto a dynamic route', () => {
+  test('keeps the path param of the route being returned TO, not the one being left', async () => {
+    const originalState = window.history.state;
+    const originalPathname = Router.pathname;
+    const handlers: Array<(url: string) => void> = [];
+    vi.mocked(Router.events.on).mockImplementation(((event: string, fn: (url: string) => void) => {
+      if (event === 'routeChangeComplete') handlers.push(fn);
+    }) as any);
+
+    try {
+      renderWithProviders(
+        <BrowserRouterProvider>
+          <AsPathProbe />
+        </BrowserRouterProvider>
+      );
+
+      // Prove the popstate listener is live before the assertion that matters —
+      // it attaches in a mount effect, so a single early dispatch is lost and
+      // the test would pass against the broken code.
+      setUsingNextRouter(false);
+      const liveness = { as: '/models?sort=Newest', url: '/models?sort=Newest', state: {} };
+      window.history.replaceState(liveness, '');
+      await vi.waitFor(() => {
+        window.dispatchEvent(new PopStateEvent('popstate', { state: liveness }));
+        expect(probeText()).toBe('/models?sort=Newest');
+      });
+      expect(imageIdText()).toBe('undefined');
+
+      // The pop itself: leaving `/models/[id]`, landing on `/images/135356251`.
+      // `beforePopState` hands this one to Next, which is what defers the state
+      // commit to `routeChangeComplete`.
+      Router.pathname = '/models/[id]';
+      setUsingNextRouter(true);
+      const popped = { as: '/images/135356251', url: '/images/135356251', state: {} };
+      window.history.replaceState(popped, '');
+      window.dispatchEvent(new PopStateEvent('popstate', { state: popped }));
+
+      // Next finishes the transition: the rendered route is now the image page.
+      Router.pathname = '/images/[imageId]';
+      expect(handlers.length).toBeGreaterThan(0);
+      for (const handler of handlers) handler('/images/135356251');
+
+      await vi.waitFor(() => {
+        expect(probeText()).toBe('/images/135356251');
+      });
+      // The regression: this read `undefined` and `/images/[imageId]` rendered
+      // `<NotFound />`.
+      expect(imageIdText()).toBe('135356251');
+    } finally {
+      setUsingNextRouter(false);
+      Router.pathname = originalPathname;
+      vi.mocked(Router.events.on).mockReset();
       window.history.replaceState(originalState, '');
     }
   });

--- a/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
@@ -157,8 +157,7 @@ describe('BrowserRouterProvider back navigation onto a dynamic route', () => {
       setUsingNextRouter(false);
       Router.asPath = originalAsPath;
       Router.query = originalQuery;
-      if (passThrough) on.mockImplementation(passThrough);
-      else on.mockReset();
+      on.mockImplementation(passThrough ?? (() => undefined));
       window.history.replaceState(originalState, '');
     }
   });

--- a/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
@@ -95,19 +95,24 @@ describe('BrowserRouterProvider + ClientHistoryStore popstate handling (Safari n
 });
 
 // A back navigation onto `/images/[imageId]` from another dynamic route
-// (ClickUp 868kt41x7). Next owns this pop, but the browser-router state was
-// resolved in the popstate handler — where `Router.pathname` is still the route
-// being LEFT — and then committed verbatim on `routeChangeComplete`, landing a
-// query with no `imageId` on a page that reads its id from there. The page
-// rendered its not-found branch; a refresh loaded the same URL fine.
+// (ClickUp 868kt41x7). Next owns this pop and repopulates its own `router.query`
+// with the path params of the route it just rendered — but the provider then
+// overwrote that on `routeChangeComplete` with state rebuilt in the popstate
+// handler, where `Router.pathname` was still the route being LEFT. The page,
+// which reads its id from the browser router, saw no `imageId` and rendered its
+// not-found branch; a refresh of the same URL loaded fine.
 describe('BrowserRouterProvider back navigation onto a dynamic route', () => {
-  test('keeps the path param of the route being returned TO, not the one being left', async () => {
+  test("publishes Next's query for the route it just rendered", async () => {
     const originalState = window.history.state;
-    const originalPathname = Router.pathname;
+    const originalAsPath = Router.asPath;
+    const originalQuery = Router.query;
+    const on = vi.mocked(Router.events.on);
+    const passThrough = on.getMockImplementation();
     const handlers: Array<(url: string) => void> = [];
-    vi.mocked(Router.events.on).mockImplementation(((event: string, fn: (url: string) => void) => {
+    on.mockImplementation(((event: string, fn: (url: string) => void) => {
       if (event === 'routeChangeComplete') handlers.push(fn);
-    }) as any);
+      return passThrough?.(event as never, fn as never);
+    }) as typeof Router.events.on);
 
     try {
       renderWithProviders(
@@ -117,8 +122,8 @@ describe('BrowserRouterProvider back navigation onto a dynamic route', () => {
       );
 
       // Prove the popstate listener is live before the assertion that matters —
-      // it attaches in a mount effect, so a single early dispatch is lost and
-      // the test would pass against the broken code.
+      // it attaches in a mount effect, so a single early dispatch is lost and the
+      // test would pass against the broken code.
       setUsingNextRouter(false);
       const liveness = { as: '/models?sort=Newest', url: '/models?sort=Newest', state: {} };
       window.history.replaceState(liveness, '');
@@ -128,17 +133,17 @@ describe('BrowserRouterProvider back navigation onto a dynamic route', () => {
       });
       expect(imageIdText()).toBe('undefined');
 
-      // The pop itself: leaving `/models/[id]`, landing on `/images/135356251`.
-      // `beforePopState` hands this one to Next, which is what defers the state
-      // commit to `routeChangeComplete`.
-      Router.pathname = '/models/[id]';
+      // The pop: leaving `/models/[id]`, landing on `/images/135356251`. Next
+      // takes this one, which is what defers the commit to `routeChangeComplete`.
       setUsingNextRouter(true);
       const popped = { as: '/images/135356251', url: '/images/135356251', state: {} };
       window.history.replaceState(popped, '');
       window.dispatchEvent(new PopStateEvent('popstate', { state: popped }));
 
-      // Next finishes the transition: the rendered route is now the image page.
-      Router.pathname = '/images/[imageId]';
+      // Next finishes: it has interpolated `imageId` into its own query, and only
+      // then emits `routeChangeComplete`.
+      Router.asPath = '/images/135356251';
+      Router.query = { imageId: '135356251' };
       expect(handlers.length).toBeGreaterThan(0);
       for (const handler of handlers) handler('/images/135356251');
 
@@ -150,8 +155,10 @@ describe('BrowserRouterProvider back navigation onto a dynamic route', () => {
       expect(imageIdText()).toBe('135356251');
     } finally {
       setUsingNextRouter(false);
-      Router.pathname = originalPathname;
-      vi.mocked(Router.events.on).mockReset();
+      Router.asPath = originalAsPath;
+      Router.query = originalQuery;
+      if (passThrough) on.mockImplementation(passThrough);
+      else on.mockReset();
       window.history.replaceState(originalState, '');
     }
   });

--- a/src/components/BrowserRouter/BrowserRouterProvider.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.tsx
@@ -74,10 +74,15 @@ export function BrowserRouterProvider({ children }: { children: React.ReactNode 
 
   useEffect(() => {
     const handleRouteChangeComplete = () => {
-      if (stateRef.current && stateRef.current?.asPath === history.state?.as)
-        useBrowserRouterState.setState(
-          resolveRouteChangeState(Router, stateRef.current.state ?? {})
-        );
+      // Both sources have to describe the entry we are on: `Router` supplies the
+      // path and query, `history.state` the payload, and two pops in quick
+      // succession can otherwise pair one entry's query with another's state.
+      if (
+        stateRef.current &&
+        stateRef.current.asPath === history.state?.as &&
+        Router.asPath === history.state?.as
+      )
+        useBrowserRouterState.setState(resolveRouteChangeState(Router, history.state?.state ?? {}));
 
       setUsingNextRouter(false);
     };

--- a/src/components/BrowserRouter/BrowserRouterProvider.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.tsx
@@ -75,7 +75,9 @@ export function BrowserRouterProvider({ children }: { children: React.ReactNode 
   useEffect(() => {
     const handleRouteChangeComplete = () => {
       if (stateRef.current && stateRef.current?.asPath === history.state?.as)
-        useBrowserRouterState.setState(resolveRouteChangeState(stateRef.current, Router.pathname));
+        useBrowserRouterState.setState(
+          resolveRouteChangeState(Router, stateRef.current.state ?? {})
+        );
 
       setUsingNextRouter(false);
     };

--- a/src/components/BrowserRouter/BrowserRouterProvider.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.tsx
@@ -7,6 +7,7 @@ import { create } from 'zustand';
 import { useDidUpdate } from '@mantine/hooks';
 import {
   resolveLocationChangeState,
+  resolveRouteChangeState,
   type BrowserRouterState,
   type HistoryState,
 } from '~/components/BrowserRouter/browserRouterState';
@@ -74,7 +75,7 @@ export function BrowserRouterProvider({ children }: { children: React.ReactNode 
   useEffect(() => {
     const handleRouteChangeComplete = () => {
       if (stateRef.current && stateRef.current?.asPath === history.state?.as)
-        useBrowserRouterState.setState(stateRef.current);
+        useBrowserRouterState.setState(resolveRouteChangeState(stateRef.current, Router.pathname));
 
       setUsingNextRouter(false);
     };

--- a/src/components/BrowserRouter/BrowserRouterProvider.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.tsx
@@ -74,15 +74,17 @@ export function BrowserRouterProvider({ children }: { children: React.ReactNode 
 
   useEffect(() => {
     const handleRouteChangeComplete = () => {
-      // Both sources have to describe the entry we are on: `Router` supplies the
-      // path and query, `history.state` the payload, and two pops in quick
-      // succession can otherwise pair one entry's query with another's state.
+      // The payload has to come from the popstate snapshot: Next's `changeState`
+      // replaces `history.state` wholesale, with no `state` key, before it emits
+      // this event — so by now the entry's own payload exists nowhere else.
       if (
         stateRef.current &&
         stateRef.current.asPath === history.state?.as &&
         Router.asPath === history.state?.as
       )
-        useBrowserRouterState.setState(resolveRouteChangeState(Router, history.state?.state ?? {}));
+        useBrowserRouterState.setState(
+          resolveRouteChangeState(Router, stateRef.current.state ?? {})
+        );
 
       setUsingNextRouter(false);
     };

--- a/src/components/BrowserRouter/__tests__/browserRouterState.test.ts
+++ b/src/components/BrowserRouter/__tests__/browserRouterState.test.ts
@@ -151,38 +151,58 @@ describe('resolveLocationChangeState', () => {
 // `routeChangeComplete`, so the params have to be re-derived there against the
 // route now rendered.
 describe('resolveRouteChangeState', () => {
-  it('recovers the path param of the route that is now rendered', () => {
-    const popped = { asPath: '/images/135356251', query: {}, state: {} };
-    const result = resolveRouteChangeState(popped, '/images/[imageId]');
+  it("publishes Next's query, which has the params of the route just rendered", () => {
+    const result = resolveRouteChangeState(
+      { asPath: '/images/135356251', query: { imageId: '135356251' } },
+      {}
+    );
+    expect(result.asPath).toBe('/images/135356251');
     expect(result.query.imageId).toBe(135356251);
   });
 
-  it('keeps asPath and state untouched', () => {
-    const popped = {
-      asPath: '/images/135356251',
-      query: {},
-      state: { prev: { asPath: '/models/827184' } },
-    };
-    const result = resolveRouteChangeState(popped, '/images/[imageId]');
-    expect(result.asPath).toBe('/images/135356251');
+  it('types params like the rest of the query rather than as strings', () => {
+    // Consumers hand `imageId` straight to tRPC inputs typed as numbers.
+    const result = resolveRouteChangeState(
+      { asPath: '/images/135356251', query: { imageId: '135356251' } },
+      {}
+    );
+    expect(typeof result.query.imageId).toBe('number');
+  });
+
+  it('carries the history state, which Next does not', () => {
+    const result = resolveRouteChangeState(
+      { asPath: '/images/135356251', query: { imageId: '135356251' } },
+      { prev: { asPath: '/models/827184' } }
+    );
     expect(result.state).toEqual({ prev: { asPath: '/models/827184' } });
   });
 
-  it('lets the query string win over the path param', () => {
-    const popped = { asPath: '/images/135356251', query: { imageId: 999 }, state: {} };
-    const result = resolveRouteChangeState(popped, '/images/[imageId]');
-    expect(result.query.imageId).toBe(999);
+  it('keeps no param of the route being left', () => {
+    // The pop resolved in the popstate handler carried `id: 'project'` from the
+    // OUTGOING pattern; nothing of it may survive into what we publish.
+    const result = resolveRouteChangeState(
+      { asPath: '/comics/project/55/chapter/2', query: { id: '55', chapterPosition: '2' } },
+      {}
+    );
+    expect(result.query).toEqual({ id: 55, chapterPosition: 2 });
   });
+});
 
-  it('contributes nothing when the rendered route is static', () => {
-    const popped = { asPath: '/images', query: { sort: 'Newest' }, state: {} };
-    const result = resolveRouteChangeState(popped, '/images');
-    expect(result.query).toEqual({ sort: 'Newest' });
-  });
-
-  it('contributes nothing when the pattern does not match the path', () => {
-    const popped = { asPath: '/models/827184', query: {}, state: {} };
-    const result = resolveRouteChangeState(popped, '/images/[imageId]');
-    expect(result.query).toEqual({});
+describe('a URL fragment', () => {
+  it('does not end up inside the path param', () => {
+    // `eventState.as` keeps the hash, and `imageId: '135356251#comments'` reaches
+    // tRPC as the image id.
+    const eventState = {
+      as: '/images/135356251#comments',
+      url: '/images/135356251#comments',
+      state: {},
+    };
+    const result = resolveLocationChangeState(
+      eventState,
+      eventState,
+      { pathname: '/images/135356251', search: '' },
+      '/images/[imageId]'
+    );
+    expect(result.query.imageId).toBe(135356251);
   });
 });

--- a/src/components/BrowserRouter/__tests__/browserRouterState.test.ts
+++ b/src/components/BrowserRouter/__tests__/browserRouterState.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { resolveLocationChangeState } from '~/components/BrowserRouter/browserRouterState';
+import {
+  resolveLocationChangeState,
+  resolveRouteChangeState,
+} from '~/components/BrowserRouter/browserRouterState';
 
 // Regression coverage for the Safari/iOS back-navigation crash:
 //   TypeError: null is not an object (evaluating 't.as')
@@ -37,7 +40,11 @@ describe('resolveLocationChangeState', () => {
 
     it('uses history.state.url for query when popstate e.state is null but history.state exists', () => {
       // Safari can null the popstate `e.state` while `history.state` is present.
-      const historyState = { url: '/search?query=cats', as: '/search', state: { prev: { asPath: '/' } } };
+      const historyState = {
+        url: '/search?query=cats',
+        as: '/search',
+        state: { prev: { asPath: '/' } },
+      };
       const result = resolveLocationChangeState(null, historyState, location);
       // asPath still degrades to location (e.state.as is what normally supplies it).
       expect(result.asPath).toBe('/models?sort=Newest');
@@ -135,5 +142,47 @@ describe('resolveLocationChangeState', () => {
       const result = resolveLocationChangeState(eventState, eventState, location, '/images');
       expect(result.query).toEqual({});
     });
+  });
+});
+
+// The popstate handler resolves against the route being LEFT, so a pop Next owns
+// — `/models/[id]` back onto `/images/123` — matched no pattern and produced a
+// query with no `imageId`. `BrowserRouterProvider` commits that on
+// `routeChangeComplete`, so the params have to be re-derived there against the
+// route now rendered.
+describe('resolveRouteChangeState', () => {
+  it('recovers the path param of the route that is now rendered', () => {
+    const popped = { asPath: '/images/135356251', query: {}, state: {} };
+    const result = resolveRouteChangeState(popped, '/images/[imageId]');
+    expect(result.query.imageId).toBe(135356251);
+  });
+
+  it('keeps asPath and state untouched', () => {
+    const popped = {
+      asPath: '/images/135356251',
+      query: {},
+      state: { prev: { asPath: '/models/827184' } },
+    };
+    const result = resolveRouteChangeState(popped, '/images/[imageId]');
+    expect(result.asPath).toBe('/images/135356251');
+    expect(result.state).toEqual({ prev: { asPath: '/models/827184' } });
+  });
+
+  it('lets the query string win over the path param', () => {
+    const popped = { asPath: '/images/135356251', query: { imageId: 999 }, state: {} };
+    const result = resolveRouteChangeState(popped, '/images/[imageId]');
+    expect(result.query.imageId).toBe(999);
+  });
+
+  it('contributes nothing when the rendered route is static', () => {
+    const popped = { asPath: '/images', query: { sort: 'Newest' }, state: {} };
+    const result = resolveRouteChangeState(popped, '/images');
+    expect(result.query).toEqual({ sort: 'Newest' });
+  });
+
+  it('contributes nothing when the pattern does not match the path', () => {
+    const popped = { asPath: '/models/827184', query: {}, state: {} };
+    const result = resolveRouteChangeState(popped, '/images/[imageId]');
+    expect(result.query).toEqual({});
   });
 });

--- a/src/components/BrowserRouter/__tests__/browserRouterState.test.ts
+++ b/src/components/BrowserRouter/__tests__/browserRouterState.test.ts
@@ -205,4 +205,21 @@ describe('a URL fragment', () => {
     );
     expect(result.query.imageId).toBe(135356251);
   });
+
+  it('does not end up on the last query param either', () => {
+    // The query string is everything after `?`, fragment included, and it is
+    // spread over the path params — so this shadowed the fix above.
+    const eventState = {
+      as: '/models/827184?modelVersionId=5#reviews',
+      url: '/models/[id]?modelVersionId=5#reviews',
+      state: {},
+    };
+    const result = resolveLocationChangeState(
+      eventState,
+      eventState,
+      { pathname: '/models/827184', search: '?modelVersionId=5' },
+      '/models/[id]'
+    );
+    expect(result.query.modelVersionId).toBe(5);
+  });
 });

--- a/src/components/BrowserRouter/__tests__/browserRouterState.test.ts
+++ b/src/components/BrowserRouter/__tests__/browserRouterState.test.ts
@@ -177,14 +177,15 @@ describe('resolveRouteChangeState', () => {
     expect(result.state).toEqual({ prev: { asPath: '/models/827184' } });
   });
 
-  it('keeps no param of the route being left', () => {
-    // The pop resolved in the popstate handler carried `id: 'project'` from the
-    // OUTGOING pattern; nothing of it may survive into what we publish.
+  it('publishes only what Next has, so nothing can be merged over it', () => {
+    // Not a re-derivation: the query is copied whole. A reader who reintroduced a
+    // merge would have somewhere for an outgoing-route param to come back in.
     const result = resolveRouteChangeState(
       { asPath: '/comics/project/55/chapter/2', query: { id: '55', chapterPosition: '2' } },
       {}
     );
-    expect(result.query).toEqual({ id: 55, chapterPosition: 2 });
+    expect(Object.keys(result.query)).toEqual(['id', 'chapterPosition']);
+    expect(result.query.id).toBe(55);
   });
 });
 

--- a/src/components/BrowserRouter/browserRouterState.ts
+++ b/src/components/BrowserRouter/browserRouterState.ts
@@ -62,23 +62,28 @@ export function resolveLocationChangeState(
 }
 
 /**
- * Re-derive the path params once Next has finished a pop it owned.
+ * The state to publish once Next has finished a navigation it owned.
  *
- * `resolveLocationChangeState` runs in the popstate handler, where
- * `Router.pathname` is still the route being LEFT, so a pop from `/models/[id]`
- * back to `/images/123` matches no pattern and yields a query with no `imageId`.
- * `BrowserRouterProvider` then commits that query on `routeChangeComplete` —
- * after Next has already repopulated its own `router.query` — and the page reads
- * the empty one and renders its not-found branch. Resolving again against the
- * route now rendered is what puts `imageId` back.
+ * `resolveLocationChangeState` reconstructs `asPath`/`query` from the history
+ * entry because on a pop Next declines (a routed dialog) nothing else will. When
+ * Next DOES own the pop, that reconstruction is both unnecessary and wrong: it
+ * runs in the popstate handler, where `Router.pathname` is still the route being
+ * LEFT, so the path params come out of the outgoing pattern — empty for
+ * `/models/[id]` → `/images/123`, which is what left `/images/[imageId]` with no
+ * `imageId` and rendered its not-found branch. Take Next's own query instead; it
+ * has already re-interpolated the params for the route it just rendered.
+ *
+ * Only `state` (the history entry's own payload) still comes from the pop —
+ * Next does not carry it.
  */
 export function resolveRouteChangeState(
-  state: BrowserRouterState,
-  routePattern?: string
+  router: { asPath: string; query: Record<string, any> },
+  state: HistoryState
 ): BrowserRouterState {
   return {
-    ...state,
-    query: { ...getDynamicRouteParams(routePattern, state.asPath), ...state.query },
+    asPath: router.asPath,
+    query: QS.parse(QS.stringify(router.query)) as Record<string, any>,
+    state,
   };
 }
 
@@ -91,11 +96,14 @@ export function resolveRouteChangeState(
  * Round-tripped through `QS` so params land as the same types the rest of the
  * query does — the matcher yields strings, and consumers pass these straight to
  * tRPC inputs typed as numbers.
+ *
+ * The hash is stripped along with the query string: `eventState.as` keeps it, and
+ * `/images/123#comments` otherwise matches with `imageId: '123#comments'`.
  */
 function getDynamicRouteParams(routePattern: string | undefined, asPath: string) {
   if (!routePattern?.includes('[')) return {};
   try {
-    const params = getRouteMatcher(getRouteRegex(routePattern))(asPath.split('?')[0]);
+    const params = getRouteMatcher(getRouteRegex(routePattern))(asPath.split(/[?#]/)[0]);
     return params ? QS.parse(QS.stringify(params)) : {};
   } catch {
     return {};

--- a/src/components/BrowserRouter/browserRouterState.ts
+++ b/src/components/BrowserRouter/browserRouterState.ts
@@ -62,11 +62,31 @@ export function resolveLocationChangeState(
 }
 
 /**
+ * Re-derive the path params once Next has finished a pop it owned.
+ *
+ * `resolveLocationChangeState` runs in the popstate handler, where
+ * `Router.pathname` is still the route being LEFT, so a pop from `/models/[id]`
+ * back to `/images/123` matches no pattern and yields a query with no `imageId`.
+ * `BrowserRouterProvider` then commits that query on `routeChangeComplete` —
+ * after Next has already repopulated its own `router.query` — and the page reads
+ * the empty one and renders its not-found branch. Resolving again against the
+ * route now rendered is what puts `imageId` back.
+ */
+export function resolveRouteChangeState(
+  state: BrowserRouterState,
+  routePattern?: string
+): BrowserRouterState {
+  return {
+    ...state,
+    query: { ...getDynamicRouteParams(routePattern, state.asPath), ...state.query },
+  };
+}
+
+/**
  * `/images/[imageId]` + `/images/123` → `{ imageId: '123' }`.
  *
  * Self-guarding: a pattern that doesn't match the path yields nothing, so a pop
- * to a *different* route contributes no stale params (Next handles those pops
- * itself and repopulates the query on `routeChangeComplete`).
+ * to a *different* route contributes no stale params.
  *
  * Round-tripped through `QS` so params land as the same types the rest of the
  * query does — the matcher yields strings, and consumers pass these straight to

--- a/src/components/BrowserRouter/browserRouterState.ts
+++ b/src/components/BrowserRouter/browserRouterState.ts
@@ -49,7 +49,8 @@ export function resolveLocationChangeState(
 ): BrowserRouterState {
   const locationHref = `${currentLocation.pathname}${currentLocation.search}`;
   const urlSource: string = eventState?.url ?? historyState?.url ?? locationHref;
-  const [, queryString] = urlSource.split('?');
+  const [, search] = urlSource.split('?');
+  const queryString = search?.split('#')[0];
   const asPath = eventState?.as ?? locationHref;
   return {
     asPath,
@@ -90,8 +91,12 @@ export function resolveRouteChangeState(
 /**
  * `/images/[imageId]` + `/images/123` → `{ imageId: '123' }`.
  *
- * Self-guarding: a pattern that doesn't match the path yields nothing, so a pop
- * to a *different* route contributes no stale params.
+ * A pattern that doesn't match the path yields nothing. That is not a guarantee
+ * of the right param on the `resolveLocationChangeState` path: the pattern there
+ * is the OUTGOING route, and two patterns can both match one path
+ * (`/comics/[id]/[[...slug]]` reads `/comics/project/55/chapter/2` as
+ * `id: 'project'`). Only `resolveRouteChangeState`, which takes Next's own
+ * query, is free of that.
  *
  * Round-tripped through `QS` so params land as the same types the rest of the
  * query does — the matcher yields strings, and consumers pass these straight to


### PR DESCRIPTION
Closes the image 404 on back navigation (ClickUp [868kt41x7](https://app.clickup.com/t/868kt41x7)).

## Repro (production, logged out, 2/2 deterministic)

1. Open `/images/139360504` directly.
2. Click a resource link in the sidebar → `/models/827184/...`.
3. Hit back → **404 Page Not Found**. Refresh the same URL → the image loads.

So this is live in `main`, not merely unshipped. The dynamic-param recovery added with the remix-gallery work (fb54ea66e8, #3810) covers the pop *out of a routed dialog*; this is the neighbouring case it does not reach.

## Cause

`resolveLocationChangeState` runs in the popstate handler, where `Router.pathname` is still the route being **left** (`/models/[id]`). Matching that pattern against `/images/139360504` yields nothing, so the query it builds has no `imageId`.

Next owns this pop, and it repopulates `router.query` correctly — `await this.set(...)` renders and only then emits `routeChangeComplete` (`next/dist/shared/lib/router/router.js:1261-1278`). The provider's `routeChangeComplete` handler then **overwrote** that with the state rebuilt in the popstate handler. `/images/[imageId]` reads its id from the browser router, saw no `imageId`, and rendered `<NotFound />`. SSR never goes through this path, which is why a refresh works.

## Fix

On a navigation Next owns, publish Next's own `asPath`/`query` rather than rebuilding them; only `state` (the history entry's payload, which Next does not carry) still comes from the pop.

The first cut re-derived the params against the new route pattern instead. Review found that could still lose: the popstate handler has already merged params from the *outgoing* pattern into that query, so where two patterns overlap the stale one shadows the fresh one — `/comics/[id]/[[...slug]]` matches `/comics/project/55/chapter/2` as `id: 'project'`, and that survived into `/comics/project/[id]/chapter/[chapterPosition]`. Taking Next's query removes the class rather than patching an instance.

Second, smaller fix in the same file: `getDynamicRouteParams` stripped `?` but not `#`, and `as` keeps the fragment, so `/images/123#comments` matched with `imageId: '123#comments'` — a string handed to tRPC as the image id. That one is on the popstate path (pop out of a routed dialog), pre-existing since #3810.

Two smaller things from later review rounds, same file: the guard now requires `Router` and `history.state` to describe the same entry (two pops in quick succession could otherwise pair one entry's query with another's payload), and the payload is read from `history.state` rather than from the popstate snapshot, which a repeated path can match.

## Known, not fixed here

`usingNextRouter` is cleared **only** in the `routeChangeComplete` handler. A hash-only pop takes Next's `onlyAHashChange` branch, which emits `hashChangeComplete` and never `routeChangeComplete`, so the flag stays `true` and every later `locationchange` update is dropped — routed dialogs then stop opening until an unrelated route change completes. Pre-existing, unchanged by this PR, and not what was reported; raised with Justin rather than folded in.

## Verification

- **Dev server, end to end, run again after the rework:** reverted → "Page Not Found"; with the fix → the image page. Both observed in a real browser against this branch.
- **Routed dialogs still work:** opened an image from the feed (dialog present at `/images/139360504`) and closed it with back (`/images`, dialog gone), on the final code.
- `browserRouterState.test.ts` — 17 passed, 6 of them new. The hash test fails on revert with `expected '135356251#comments' to be 135356251`.
- `BrowserRouterProvider.browser.test.tsx` — 2 passed; the new one fails on revert with `expected 'undefined' to be '135356251'`. ⚠️ **No CI job runs `*.browser.test.tsx`** (`lint.yml:244` says so explicitly, and no workflow invokes `test:component`), so treat that as a local check, not CI coverage. The CI-enforced guard here is the unit file, which covers the helper rather than the call site.
- `pnpm run typecheck` clean (run in this worktree, log in my own scratchpad; controlled by planting a type error and confirming it was caught).
- `pnpm run lint` adds no new errors — one `no-explicit-any` warning in the test mock. `test:lint-rules` 220 passed.
- Full unit suite not run locally, at Justin's direction while the box was busy; CI's Unit / App unit / Package unit jobs are green on the branch. `blocks.router.workflow.test.ts` collected 350 tests here, so the worktree submodule is initialised.

No migration.
