### PR TITLE
fix(collections): bind follow and unfollow to the caller

### DIFF
--- a/src/server/controllers/__tests__/collection.controller.follow-self-bind.test.ts
+++ b/src/server/controllers/__tests__/collection.controller.follow-self-bind.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as CollectionService from '~/server/services/collection.service';
+
+const { mockAddContributor, mockRemoveContributor } = vi.hoisted(() => ({
+  mockAddContributor: vi.fn(),
+  mockRemoveContributor: vi.fn(),
+}));
+
+vi.mock('~/server/services/collection.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof CollectionService>()),
+  addContributorToCollection: mockAddContributor,
+  removeContributorFromCollection: mockRemoveContributor,
+}));
+
+import { followHandler, unfollowHandler } from '../collection.controller';
+import { followCollectionInputSchema } from '~/server/schema/collection.schema';
+
+const CALLER_ID = 1;
+const VICTIM_ID = 999;
+const COLLECTION_ID = 42;
+
+const ctx = { user: { id: CALLER_ID, isModerator: false } } as never;
+
+// Both services accept a target other than the caller on `manage` alone, which the owner, every
+// Manager and every moderator hold. Reached through these two handlers that skipped every guard
+// the collaborator paths apply: the two-way block check, the caps, and the owner-only rule over a
+// Manager's seat. So the handlers must bind to the caller and offer no way to name anyone else.
+describe('follow/unfollow are self-bound', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The router parses with this schema before the handler runs, so a smuggled key never arrives.
+  it('strips a target user from the input', () => {
+    const parsed = followCollectionInputSchema.parse({
+      collectionId: COLLECTION_ID,
+      userId: VICTIM_ID,
+    });
+
+    expect(parsed).toEqual({ collectionId: COLLECTION_ID });
+    expect(parsed).not.toHaveProperty('userId');
+  });
+
+  it('follows as the caller even when a target is smuggled past the schema', () => {
+    followHandler({ ctx, input: { collectionId: COLLECTION_ID, userId: VICTIM_ID } as never });
+
+    expect(mockAddContributor).toHaveBeenCalledWith({
+      collectionId: COLLECTION_ID,
+      userId: CALLER_ID,
+      targetUserId: CALLER_ID,
+    });
+  });
+
+  // The one that matters most: removeContributorFromCollection checks `manage` and nothing else,
+  // so a target here let a Manager delete another Manager's row — which removeCollaborator refuses.
+  it('unfollows as the caller even when a target is smuggled past the schema', () => {
+    unfollowHandler({ ctx, input: { collectionId: COLLECTION_ID, userId: VICTIM_ID } as never });
+
+    expect(mockRemoveContributor).toHaveBeenCalledWith({
+      collectionId: COLLECTION_ID,
+      userId: CALLER_ID,
+      targetUserId: CALLER_ID,
+    });
+  });
+});

--- a/src/server/controllers/collection.controller.ts
+++ b/src/server/controllers/collection.controller.ts
@@ -461,8 +461,8 @@ export const followHandler = ({
 
   try {
     return addContributorToCollection({
-      targetUserId: input.userId || user?.id,
-      userId: user?.id,
+      targetUserId: user.id,
+      userId: user.id,
       collectionId,
     });
   } catch (error) {
@@ -482,8 +482,8 @@ export const unfollowHandler = ({
 
   try {
     return removeContributorFromCollection({
-      targetUserId: input.userId || user?.id,
-      userId: user?.id,
+      targetUserId: user.id,
+      userId: user.id,
       collectionId,
     });
   } catch (error) {

--- a/src/server/schema/collection.schema.ts
+++ b/src/server/schema/collection.schema.ts
@@ -248,9 +248,11 @@ export const getUserCollectionItemsByItemSchema = collectionItemSchema
 
 export type FollowCollectionInputSchema = z.infer<typeof followCollectionInputSchema>;
 
+// No target user: follow and unfollow act on the caller. Managing someone else's row belongs to
+// inviteCollaborator / updateCollaboratorRole / removeCollaborator, which carry the guards these
+// two services don't — the block check, the caps, and the owner-only rule over a Manager's seat.
 export const followCollectionInputSchema = z.object({
   collectionId: z.number(),
-  userId: z.number().optional(),
 });
 
 export type GetAllCollectionItemsSchema = z.infer<typeof getAllCollectionItemsSchema>;

--- a/src/server/services/__tests__/collection-collaborator-permissions.test.ts
+++ b/src/server/services/__tests__/collection-collaborator-permissions.test.ts
@@ -192,9 +192,10 @@ describe('collection collaborator permissions', () => {
   });
 });
 
-// I2: `collection.follow` takes an optional userId and uses it as the TARGET, while the
-// upsert REPLACES that user's permissions — so on any community collection a stranger could
-// rewrite a manager's row down to the collection's follow grant.
+// The upsert REPLACES the target's permissions, so a caller who can name someone else can rewrite
+// a manager's row down to the collection's follow grant. `collection.follow` no longer offers a
+// target (see collection.controller.follow-self-bind.test.ts); these pin the service's own rule for
+// the invite paths that still pass one.
 describe('addContributorToCollection authorization', () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
Tracker: [CU 868kr9y0u](https://app.clickup.com/t/868kr9y0u). Branched off `main`, independent of #3925 — the bug predates it, but #3925 is what makes the second half of it matter.

## The problem

`followCollectionInputSchema` carried an optional `userId`, and `followHandler` / `unfollowHandler` passed it straight through as `targetUserId`. Both underlying services accept a target other than the caller on `manage` alone, which the collection owner, every Manager and every moderator hold. So the two procedures were a second door to `CollectionContributor`, past the guards the collaborator paths apply.

**Unfollow is the sharper half.** `removeContributorFromCollection` checks `manage` and nothing else before deleting the row. The intended path, `removeCollaborator`, explicitly refuses the same operation — *"Only the collection owner can remove a manager."* #3925 makes `updateCollaboratorRole` owner-only in both directions for exactly that reason: otherwise a Manager can clear out the other Managers and hold the collection alone. Unfollow reached the same delete without that rule, so the guarantee did not hold. It also skipped the `collectionInvite.deleteMany` that `removeCollaborator` does, leaving an **Accepted** invite behind with no contributor row — which `countCollaborators` still counts toward the Manager cap.

**Follow is the milder half**, and narrower than the tracker title suggests. It attached a user to a collection with the collection's free grant, bypassing the two-way block check, the membership requirement and the caps that `inviteCollaborator` enforces. It could **not** make anyone a collaborator: `followHandler` passes no `permissions`, so the row gets `followPermissions`, which is derived from the same `read`/`write` columns as `freeGrantBaseline` and therefore always equals it. `hasElevatedPermission` is false, there is no accepted invite, so `isCollaboratorRow` is false and `getCollectionRoster` filters the row out of the roster and the public header stack. Checked every configuration:

| read / write | followPermissions | row written | reads as collaborator |
| --- | --- | --- | --- |
| Private / Private | `[]` | no — empty grant returns early | — |
| Private / Public | `[ADD]` | yes | no |
| Public / Private | `[VIEW]` | yes | no |
| Public / Review | `[VIEW, ADD_REVIEW]` | yes | no |

So that half is a nuisance vector rather than privilege escalation — an involuntary entry in someone's collection list, from a user they may have blocked, with no notification. It lands harder since #3925 restored follow-on-submission, which makes that list the main way back to a collection you post to.

## The fix

Both handlers take actor and target from `ctx.user.id`, and `userId` is gone from the input schema. Naming someone else keeps its home in `inviteCollaborator`, `updateCollaboratorRole` and `removeCollaborator`, which carry the guards.

Nothing passed the field: `CollectionFollow.tsx` — the only caller of either procedure — sends `{ collectionId }`, and `/api/v1/blocks/collections/[id]/follow` was already self-bound. The services keep their `manage`-based rule, because `inviteCollaborator` and `respondToInvite` legitimately pass a target through them; the existing service-level tests still pin that, and their stale comment describing this as a live issue on `collection.follow` was corrected.

## Tests

`collection.controller.follow-self-bind.test.ts` covers three things: the schema strips a smuggled `userId` (the router parses before the handler runs, so that is the real boundary), and each handler calls its service with `targetUserId === ctx.user.id` even when one is forced past the schema in the input.

Checked against a negative control rather than assumed: restoring `input.userId || user.id` and the schema field makes the unfollow and follow assertions fail on the target id, so a revert is legible rather than silent.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run test:unit:run` — 17,523 passed, 22 skipped, 1,119 files
- `pnpm eslint` over the changed files — 0 errors (one pre-existing `userPreferences` warning, untouched by this change)

No schema or data change, so nothing to apply by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
