### PR TITLE
fix(app-store): fail CLOSED on an absent scope, and make the PUBLIC catalog a deliberate grant (#3983)

### DIFF
--- a/src/pages/api/v1/apps/[slug].ts
+++ b/src/pages/api/v1/apps/[slug].ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 import { resolveStoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import { getListingDetail } from '~/server/services/blocks/app-listing.service';
 import { recordStoreScopeApplied } from '~/server/prom/store-scope.metrics';
-import { narrowStoreScope } from '~/shared/utils/store-visibility-scope';
+import { resolvePublicAppsCatalogScope } from '~/server/services/blocks/public-apps-catalog';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { enforceAppsCatalogRateLimit } from '~/server/utils/apps-catalog-rate-limit';
 import { isHostForColor } from '~/server/utils/server-domain';
@@ -20,12 +20,13 @@ import { REST_ERROR_CODE, restErrorBody } from '~/server/utils/rest-error-envelo
  * when present and otherwise proceeds anonymous; an absent / invalid / expired
  * token is treated as anonymous, never a hard error.
  *
- * ## Visibility — per-user SCOPE, DEFAULT CLOSED
+ * ## Visibility — a PUBLIC catalog, by decision
  * Same gate as the list endpoint: `resolveStoreVisibilityScope({ user })` is
- * computed and passed EXPLICITLY to the listing service. A `none` scope (anon /
- * non-privileged, pre-launch default) yields 404 — a caller can never enumerate
- * a listing outside their scope, and the boundary AUTO-WIDENS with the same
- * marketplace flag the store UI keys on (no code change here).
+ * computed, run through `resolvePublicAppsCatalogScope` (a privileged caller keeps
+ * their own scope; everyone else gets the deliberate public grant, which an
+ * operator can withhold), and the result is passed EXPLICITLY to the listing
+ * service. A `none` scope — i.e. the grant withheld — yields 404, and a caller can
+ * never enumerate a listing outside whatever scope they end up with.
  *
  * ## 404 posture
  * A missing slug, a non-approved listing, an onsite listing under
@@ -87,10 +88,12 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
     // See the sibling `index.ts` + store-scope.metrics: recorded BEFORE narrowing so
     // an ABSENT scope is distinguishable from a resolved one in production (#3983).
     recordStoreScopeApplied(rawScope as string | undefined, 'rest-detail');
-    // 🔴 FAIL CLOSED independently of the resolver — see the sibling `index.ts`. An
-    // absent scope used to slip past this negative test and meet `getListingDetail`'s
-    // `?? 'full'`, serving an on-site listing's detail to an unauthenticated caller.
-    const scope = narrowStoreScope(rawScope);
+    // The PUBLIC-CATALOG decision — see the sibling `index.ts` and
+    // `~/server/services/blocks/public-apps-catalog`. Narrows first (#4041: an
+    // absent scope is never an entitlement — it used to slip past this negative
+    // test and meet `getListingDetail`'s `?? 'full'`), passes a privileged caller
+    // through verbatim, then applies the deliberate public grant.
+    const scope = await resolvePublicAppsCatalogScope(rawScope, 'rest-detail');
     if (scope === 'none') {
       return res.status(404).json(restErrorBody(REST_ERROR_CODE.NOT_FOUND, 'App not found'));
     }

--- a/src/pages/api/v1/apps/[slug].ts
+++ b/src/pages/api/v1/apps/[slug].ts
@@ -83,7 +83,8 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
     const limited = await enforceAppsCatalogRateLimit({ req, res, user, log: req.log });
     if (limited) return;
 
-    // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
+    // The caller's OWN scope — see the sibling `index.ts`. Typed `unknown`; never
+    // branched on until it has been through the public-catalog decision below.
     const rawScope: unknown = await resolveStoreVisibilityScope({ user });
     // See the sibling `index.ts` + store-scope.metrics: recorded BEFORE narrowing so
     // an ABSENT scope is distinguishable from a resolved one in production (#3983).

--- a/src/pages/api/v1/apps/[slug].ts
+++ b/src/pages/api/v1/apps/[slug].ts
@@ -2,6 +2,7 @@ import * as z from 'zod';
 import { resolveStoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import { getListingDetail } from '~/server/services/blocks/app-listing.service';
 import { recordStoreScopeApplied } from '~/server/prom/store-scope.metrics';
+import { narrowStoreScope } from '~/shared/utils/store-visibility-scope';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { enforceAppsCatalogRateLimit } from '~/server/utils/apps-catalog-rate-limit';
 import { isHostForColor } from '~/server/utils/server-domain';
@@ -82,10 +83,14 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
     if (limited) return;
 
     // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
-    const scope = await resolveStoreVisibilityScope({ user });
-    // See the sibling `index.ts` + store-scope.metrics: recorded so an ABSENT scope
-    // is distinguishable from a resolved one in production (civitai#3983).
-    recordStoreScopeApplied(scope, 'rest-detail');
+    const rawScope: unknown = await resolveStoreVisibilityScope({ user });
+    // See the sibling `index.ts` + store-scope.metrics: recorded BEFORE narrowing so
+    // an ABSENT scope is distinguishable from a resolved one in production (#3983).
+    recordStoreScopeApplied(rawScope as string | undefined, 'rest-detail');
+    // 🔴 FAIL CLOSED independently of the resolver — see the sibling `index.ts`. An
+    // absent scope used to slip past this negative test and meet `getListingDetail`'s
+    // `?? 'full'`, serving an on-site listing's detail to an unauthenticated caller.
+    const scope = narrowStoreScope(rawScope);
     if (scope === 'none') {
       return res.status(404).json(restErrorBody(REST_ERROR_CODE.NOT_FOUND, 'App not found'));
     }

--- a/src/pages/api/v1/apps/index.ts
+++ b/src/pages/api/v1/apps/index.ts
@@ -102,7 +102,9 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
     const limited = await enforceAppsCatalogRateLimit({ req, res, user, log: req.log });
     if (limited) return;
 
-    // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
+    // The caller's OWN scope. Typed `unknown` because production has been observed
+    // carrying nothing across this boundary while the types checked green (#3983);
+    // it is not branched on until it has been through the decision below.
     const rawScope: unknown = await resolveStoreVisibilityScope({ user });
     // Record what this entry point actually branched on, BEFORE narrowing — an
     // ABSENT scope must stay distinguishable from a resolved `none` in production

--- a/src/pages/api/v1/apps/index.ts
+++ b/src/pages/api/v1/apps/index.ts
@@ -3,7 +3,7 @@ import { getAppListingsListQuery } from '~/server/schema/blocks/app-listing-read
 import { resolveStoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import { listAvailableListings } from '~/server/services/blocks/app-listing.service';
 import { recordStoreScopeApplied } from '~/server/prom/store-scope.metrics';
-import { narrowStoreScope } from '~/shared/utils/store-visibility-scope';
+import { resolvePublicAppsCatalogScope } from '~/server/services/blocks/public-apps-catalog';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { enforceAppsCatalogRateLimit } from '~/server/utils/apps-catalog-rate-limit';
 import { getNextPage } from '~/server/utils/pagination-helpers';
@@ -24,25 +24,33 @@ import { REST_ERROR_CODE, restErrorBody } from '~/server/utils/rest-error-envelo
  * uses) and otherwise proceeds as anonymous. An absent / invalid / expired token
  * is simply treated as anonymous — NEVER a hard error.
  *
- * ## Visibility — per-user SCOPE, DEFAULT CLOSED (the security crux)
- * The catalog is gated by `resolveStoreVisibilityScope({ user })` — the SAME
- * helper the store tRPC read middleware uses — and its result is passed
- * EXPLICITLY to the listing service.
+ * ## Visibility — a PUBLIC catalog, by decision (the security crux)
+ * The caller's own scope comes from `resolveStoreVisibilityScope({ user })` — the
+ * SAME helper the store tRPC read middleware uses — and is then passed through
+ * `resolvePublicAppsCatalogScope`, which produces the scope handed EXPLICITLY to
+ * the listing service:
+ *   - a privileged caller (moderator / app-dev-tester → `full`, the external-only
+ *     cohort → `public-external`) keeps their own scope, verbatim;
+ *   - everyone else, INCLUDING an anonymous caller, gets the deliberate public
+ *     catalog grant (`~/server/services/blocks/public-apps-catalog`), which an
+ *     operator can withhold with a kill switch;
+ *   - withheld → empty page.
  *
- * 🔴 The scope is NARROWED (`narrowStoreScope`) before it is branched on, and the
- * listing service now defaults an absent scope to `none` rather than `full`. Both
- * changes are civitai#3983: on the serving build this endpoint received NO scope at
- * all for an anonymous caller, the old `scope === 'none'` negative test admitted it,
- * and the service's old `?? 'full'` turned that missing value into the whole approved
- * catalog — on-site apps included — for an unauthenticated request. Either guard
- * alone would have prevented it; both exist so a future consumer inherits the
- * fail-closed direction by default instead of re-deriving it.
- *   - `none`            → empty page (anon / non-privileged, pre-launch default).
- *   - `full`            → the whole approved catalog (mods + app-dev-testers).
- *   - `public-external` → offsite listings only (once the public flag opens).
- * This AUTO-WIDENS for everyone the instant the marketplace Flipt segment opens,
- * with no code change here — the endpoint defers to the same flag the store UI
- * keys on.
+ * 🔴 The scope is NARROWED before any of that (`narrowStoreScope`, inside the
+ * decision), and the listing service defaults an absent scope to `none` rather than
+ * `full`. Both are civitai#3983: on the serving build this endpoint received NO
+ * scope at all for an anonymous caller, the old `scope === 'none'` negative test
+ * admitted it, and the service's old `?? 'full'` turned that missing value into the
+ * whole approved catalog. The exploit was NOT that the catalog is public — that is
+ * intended — it was that an ABSENT scope bought MORE than a resolved `none` did.
+ * That is closed: absent and `none` are now the same input to the same decision, so
+ * no failure of the resolver can widen this endpoint beyond what the public grant
+ * already, deliberately, allows.
+ *
+ * 🔴 This endpoint's public reach is deliberately NOT expressed as a store flag.
+ * `appListings` / `appBlocks` / `appListingsPublicExternal` also gate the `/apps`
+ * PAGE through `hasAppsStoreAccess`, so granting public REST access through one of
+ * them would launch the store. See the module doc for the full reasoning.
  *
  * ## Response — the standard paginated `/api/v1` envelope
  * `{ items: ListingCard[], metadata: { nextCursor, nextPage } }` — keyset cursor
@@ -100,15 +108,16 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
     // ABSENT scope must stay distinguishable from a resolved `none` in production
     // (see store-scope.metrics; civitai#3983).
     recordStoreScopeApplied(rawScope as string | undefined, 'rest-list');
-    // 🔴 FAIL CLOSED, independently of the resolver. `scope === 'none'` is a NEGATIVE
-    // test: it admits every value that is not the string `none`, including the
-    // `undefined` production actually carries here — which then met the listing
-    // service's `?? 'full'` and served the whole approved catalog, on-site apps
-    // included, to an unauthenticated caller. Narrowing first makes the branch an
-    // ALLOWLIST over the closed set: anything uninterpretable is `none`.
-    const scope = narrowStoreScope(rawScope);
+    // The PUBLIC-CATALOG decision. It narrows first (#4041's fail-closed rule —
+    // anything uninterpretable becomes `none`, never an entitlement), passes a
+    // privileged caller through verbatim, and then applies the DELIBERATE public
+    // grant to everyone else. See `~/server/services/blocks/public-apps-catalog`
+    // for why that grant lives in its own module and is NOT a store flag: the
+    // store flags gate the `/apps` PAGE too, and this endpoint being public must
+    // not launch the store.
+    const scope = await resolvePublicAppsCatalogScope(rawScope, 'rest-list');
     if (scope === 'none') {
-      // Anon / non-privileged pre-launch → empty page, NEVER the full catalog.
+      // The public grant is withheld (operator kill switch) → empty page.
       return res
         .status(200)
         .json({ items: [], metadata: { nextCursor: undefined, nextPage: undefined } });

--- a/src/pages/api/v1/apps/index.ts
+++ b/src/pages/api/v1/apps/index.ts
@@ -3,6 +3,7 @@ import { getAppListingsListQuery } from '~/server/schema/blocks/app-listing-read
 import { resolveStoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import { listAvailableListings } from '~/server/services/blocks/app-listing.service';
 import { recordStoreScopeApplied } from '~/server/prom/store-scope.metrics';
+import { narrowStoreScope } from '~/shared/utils/store-visibility-scope';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { enforceAppsCatalogRateLimit } from '~/server/utils/apps-catalog-rate-limit';
 import { getNextPage } from '~/server/utils/pagination-helpers';
@@ -26,9 +27,16 @@ import { REST_ERROR_CODE, restErrorBody } from '~/server/utils/rest-error-envelo
  * ## Visibility — per-user SCOPE, DEFAULT CLOSED (the security crux)
  * The catalog is gated by `resolveStoreVisibilityScope({ user })` — the SAME
  * helper the store tRPC read middleware uses — and its result is passed
- * EXPLICITLY to the listing service. The service is scope-parametric and
- * defaults to `full`, so the scope MUST be threaded through: never let an
- * unscoped caller fall through to the full catalog.
+ * EXPLICITLY to the listing service.
+ *
+ * 🔴 The scope is NARROWED (`narrowStoreScope`) before it is branched on, and the
+ * listing service now defaults an absent scope to `none` rather than `full`. Both
+ * changes are civitai#3983: on the serving build this endpoint received NO scope at
+ * all for an anonymous caller, the old `scope === 'none'` negative test admitted it,
+ * and the service's old `?? 'full'` turned that missing value into the whole approved
+ * catalog — on-site apps included — for an unauthenticated request. Either guard
+ * alone would have prevented it; both exist so a future consumer inherits the
+ * fail-closed direction by default instead of re-deriving it.
  *   - `none`            → empty page (anon / non-privileged, pre-launch default).
  *   - `full`            → the whole approved catalog (mods + app-dev-testers).
  *   - `public-external` → offsite listings only (once the public flag opens).
@@ -87,12 +95,18 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
     if (limited) return;
 
     // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
-    const scope = await resolveStoreVisibilityScope({ user });
-    // Record what this entry point actually branched on. 🔴 The listing service
-    // defaults an ABSENT scope to `full`, so "no scope arrived" and "resolved full"
-    // produce the identical response here — `recordStoreScopeApplied` is what keeps
-    // those two apart in production (see store-scope.metrics; civitai#3983).
-    recordStoreScopeApplied(scope, 'rest-list');
+    const rawScope: unknown = await resolveStoreVisibilityScope({ user });
+    // Record what this entry point actually branched on, BEFORE narrowing — an
+    // ABSENT scope must stay distinguishable from a resolved `none` in production
+    // (see store-scope.metrics; civitai#3983).
+    recordStoreScopeApplied(rawScope as string | undefined, 'rest-list');
+    // 🔴 FAIL CLOSED, independently of the resolver. `scope === 'none'` is a NEGATIVE
+    // test: it admits every value that is not the string `none`, including the
+    // `undefined` production actually carries here — which then met the listing
+    // service's `?? 'full'` and served the whole approved catalog, on-site apps
+    // included, to an unauthenticated caller. Narrowing first makes the branch an
+    // ALLOWLIST over the closed set: anything uninterpretable is `none`.
+    const scope = narrowStoreScope(rawScope);
     if (scope === 'none') {
       // Anon / non-privileged pre-launch → empty page, NEVER the full catalog.
       return res

--- a/src/server/prom/store-scope.metrics.ts
+++ b/src/server/prom/store-scope.metrics.ts
@@ -69,6 +69,7 @@ declare global {
         resolutions: client.Counter<string>;
         applied: client.Counter<string>;
         divergence: client.Counter<string>;
+        publicCatalog: client.Counter<string>;
       }
     | undefined;
 }
@@ -103,6 +104,18 @@ const metrics =
         'hold it. Any non-zero rate means the page gate and the read path disagree for a ' +
         'real viewer — alert on it.',
       labelNames: ['flag'],
+    }),
+    publicCatalog: new client.Counter({
+      name: PROM_PREFIX + 'store_public_catalog_decisions_total',
+      help:
+        'Cumulative PUBLIC App-catalog grant decisions at the /api/v1/apps REST endpoints, ' +
+        'by outcome and entrypoint. `granted` = a caller who resolved no scope of their own ' +
+        'was served the public catalog (the intended steady state); `withheld` = the ' +
+        'apps-public-catalog-disabled kill switch was on; `privileged` = the caller resolved ' +
+        'a real scope and was passed through untouched. This is the ONLY signal that says ' +
+        'whether the public catalog is actually open — a `withheld` rate rising from zero is ' +
+        'the kill switch having been thrown, deliberately or not.',
+      labelNames: ['outcome', 'entrypoint'],
     }),
   });
 
@@ -143,6 +156,31 @@ export function recordStoreScopeApplied(
 export function recordStoreScopeResolution(scope: string, principal: StoreScopePrincipal): void {
   try {
     metrics.resolutions.inc({ scope, principal });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+/** The three ways the public-catalog grant can answer. Bounded on purpose. */
+export type PublicCatalogOutcome = 'granted' | 'withheld' | 'privileged';
+
+/**
+ * Record one public-catalog grant decision (see
+ * `~/server/services/blocks/public-apps-catalog`). Never throws — telemetry must not
+ * break a read.
+ *
+ * Read as a PAIR with `store_scope_applied_total`: that counter says what the
+ * resolver produced, this one says what the public REST surface decided to do about
+ * it. `applied{scope="absent"}` with `decisions{outcome="granted"}` is the known,
+ * open #3983 resolver defect being absorbed by the deliberate grant — not a new
+ * exposure, because `absent` and a resolved `none` take the identical branch.
+ */
+export function recordPublicCatalogDecision(
+  outcome: PublicCatalogOutcome,
+  entrypoint: StoreScopeEntrypoint
+): void {
+  try {
+    metrics.publicCatalog.inc({ outcome, entrypoint });
   } catch {
     /* never throw from telemetry */
   }

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -63,6 +63,7 @@ import {
   type StoreScopeEntrypoint,
 } from '~/server/prom/store-scope.metrics';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { narrowStoreScope } from '~/shared/utils/store-visibility-scope';
 import {
   isAppBlocksAuthorEnabled,
   isAppBlocksEnabled,
@@ -219,9 +220,14 @@ function isRedCapableRequest(ctx: { req?: { headers?: { host?: string } } }): bo
  * investigation. `recordStoreScopeApplied` keeps them apart (`none` vs `absent`).
  */
 function applyStoreScope(ctx: unknown, entrypoint: StoreScopeEntrypoint): StoreVisibilityScope {
-  const raw = (ctx as { _storeScope?: StoreVisibilityScope })._storeScope;
-  recordStoreScopeApplied(raw, entrypoint);
-  return raw ?? 'none';
+  const raw = (ctx as { _storeScope?: unknown })._storeScope;
+  recordStoreScopeApplied(raw as string | undefined, entrypoint);
+  // 🔴 `raw ?? 'none'` already failed closed for a MISSING scope; `narrowStoreScope`
+  // extends that to any value outside the closed set (a typo, a scope from a newer
+  // branch this build cannot interpret), and — the point of consolidating it — makes
+  // this branch and the two REST handlers apply the SAME rule instead of three
+  // independently-written defaults that disagreed (civitai#3983).
+  return narrowStoreScope(raw);
 }
 
 /**

--- a/src/server/services/__tests__/public-apps-catalog.page-gate.seam.test.ts
+++ b/src/server/services/__tests__/public-apps-catalog.page-gate.seam.test.ts
@@ -1,0 +1,246 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IncomingMessage } from 'http';
+import type { NextApiRequest } from 'next';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * 🔴 THE SEAM THIS CHANGE CREATES: the public REST catalog is OPEN while `/apps`
+ * stays DARK — for the same anonymous viewer, in the same flag configuration.
+ *
+ * That combination is the entire point of `~/server/services/blocks/public-apps-catalog`
+ * and it is not reachable by ANY setting of the three store flags: `appListings`,
+ * `appBlocks` and `appListingsPublicExternal` all feed `hasAppsStoreAccess`, which
+ * gates the `/apps` PAGE as well as the read scope, so granting public catalog access
+ * through one of them would launch the store to every visitor. The grant therefore
+ * lives on its own axis — and an axis nobody tests is an axis that quietly grows a
+ * second consumer.
+ *
+ * ⚠️ ISOLATION IS THE FAILURE MODE HERE, so this file deliberately loads BOTH REAL
+ * SIDES against ONE fake Flipt configuration:
+ *   - READ PATH   real `resolveStoreVisibilityScope` → real `resolvePublicAppsCatalogScope`
+ *                 (what `/api/v1/apps*` hands the listing service);
+ *   - PAGE GATE   real `getFeatureFlags` → real `hasAppsStoreAccess` → real
+ *                 `resolveAppsPageAccess` (what `/apps` does with the same viewer).
+ * A suite that mocked either side could be green while the pair is incoherent — which
+ * is precisely how civitai#3983 stayed invisible through 75 green store-scope tests.
+ *
+ * The RELATIONSHIP asserted, and it is behavioural (a rendered access decision), not
+ * a spelling:
+ *
+ *      anonymous, no store flags  ⟹  read scope `full`  AND  `/apps` notFound
+ *      privileged                 ⟹  read scope untouched by the grant
+ *
+ * ## What this suite structurally CANNOT see
+ *
+ * - Whether the live endpoint actually serves anything. Flipt is FAKED here; the
+ *   production resolver defect (civitai#3983: no scope value at all for an anonymous
+ *   principal) does not reproduce from source under vitest, so nothing in this file
+ *   is evidence about production. The absent-scope cases are covered separately.
+ * - The `/apps` page BODY's own React render. `resolveAppsPageAccess` is the SSR
+ *   decision; the body re-checks the same shared predicate, pinned by
+ *   `components/Apps/__tests__/appsStoreAccessCallSites.test.ts`.
+ */
+
+// Read at IMPORT time by feature-flags.service (color-host sets) — set before the
+// module evaluates, mirroring the sibling seam suite.
+vi.hoisted(() => {
+  process.env.SERVER_DOMAIN_GREEN = 'civitai.com';
+  process.env.SERVER_DOMAIN_BLUE = 'civitai.blue';
+  process.env.SERVER_DOMAIN_RED = 'civitai.red';
+});
+
+type FlagShape =
+  | { kind: 'absent' }
+  | { kind: 'base'; enabled: boolean }
+  | { kind: 'segment'; base: boolean; match: (ctx: Record<string, string>) => boolean };
+
+const { flagState } = vi.hoisted(() => ({
+  flagState: { flags: {} as Record<string, unknown> },
+}));
+
+/** `evalFlag` returns `null` for "flag not found", exactly like Flipt. */
+function evalFlag(
+  flag: string,
+  _entityId: string,
+  context: Record<string, string>
+): boolean | null {
+  const shape = (flagState.flags[flag] as FlagShape | undefined) ?? { kind: 'absent' };
+  switch (shape.kind) {
+    case 'absent':
+      return null;
+    case 'base':
+      return shape.enabled;
+    case 'segment':
+      return shape.match(context) ? true : shape.base;
+  }
+}
+
+vi.mock('~/server/flipt/client', () => ({
+  // ASYNC: swallows "not found" and returns FALSE (see @civitai/flipt isEnabled).
+  isFlipt: async (flag: string, entityId = 'global', context: Record<string, string> = {}) =>
+    evalFlag(flag, entityId, context) ?? false,
+  // SYNC: returns NULL for "not found" so the caller falls through to the static
+  // availability (see @civitai/flipt isEnabledSync).
+  isFliptSync: (flag: string, entityId = 'global', context: Record<string, string> = {}) =>
+    evalFlag(flag, entityId, context),
+  ensureFliptInitialized: async () => undefined,
+}));
+
+import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
+import { resolveStoreVisibilityScope } from '../app-blocks-flag';
+import { getFeatureFlags, getFeatureFlagsAsync } from '../feature-flags.service';
+import {
+  PUBLIC_APPS_CATALOG_DISABLED_FLAG,
+  resolvePublicAppsCatalogScope,
+} from '../blocks/public-apps-catalog';
+import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
+
+const LISTINGS = 'app-listings';
+const BLOCKS = 'app-blocks-enabled';
+const EXTERNAL = 'app-listings-public-external';
+
+function makeUser(over: Partial<SessionUser> = {}): SessionUser {
+  return {
+    id: 100,
+    username: 'u',
+    isModerator: false,
+    tier: 'free',
+    permissions: [],
+    onboarding: 0,
+    ...over,
+  } as SessionUser;
+}
+
+/** `getFeatureFlags` memoizes on (user, host, region) for 10s — vary the host. */
+let hostSeq = 0;
+function makeReq(): NextApiRequest {
+  return { headers: { host: `c${hostSeq++}.civitai.com` } } as unknown as NextApiRequest;
+}
+
+type Ctx = { user?: SessionUser; req: NextApiRequest | IncomingMessage };
+
+beforeAll(async () => {
+  // Prime the service's private `_fliptModule` (our mock) so the SYNC Flipt branch
+  // inside `hasFeature` is live. Without this the branch is skipped and every flag
+  // falls to its static availability — the suite would be green and measuring nothing.
+  await getFeatureFlagsAsync({ req: makeReq() });
+});
+
+beforeEach(() => {
+  flagState.flags = {};
+});
+
+/** BOTH halves of the seam, measured against ONE flag config. */
+async function measure(user?: SessionUser) {
+  const own = await resolveStoreVisibilityScope({ user });
+  const restScope = await resolvePublicAppsCatalogScope(own, 'rest-list');
+  const features = getFeatureFlags({ user, req: makeReq() } as Ctx);
+  const page = resolveAppsPageAccess({ features });
+  return { own, restScope, pageGranted: 'props' in page, predicate: hasAppsStoreAccess(features) };
+}
+
+// ---------------------------------------------------------------------------
+// Instrument controls — a verdict from an unvalidated harness is worthless
+// ---------------------------------------------------------------------------
+
+describe('the harness (validate the instrument before reading its verdict)', () => {
+  it('🔴 POSITIVE CONTROL: the Flipt branch is LIVE — a config change moves BOTH sides', async () => {
+    // Without this, "the page is dark" is indistinguishable from a fake wired to
+    // nothing, and every assertion below would be about the harness.
+    const user = makeUser({ id: 555 });
+    const dark = await measure(user);
+    expect(dark.pageGranted).toBe(false);
+    expect(dark.own).toBe('none');
+
+    flagState.flags[LISTINGS] = { kind: 'base', enabled: true } satisfies FlagShape;
+    const lit = await measure(user);
+    expect(lit.pageGranted).toBe(true);
+    expect(lit.own).toBe('full');
+  });
+
+  it('🔴 POSITIVE CONTROL: the kill switch is LIVE — it moves the REST scope', async () => {
+    // Proves the `withheld` arm below is a real branch and not an inert flag key.
+    expect((await measure(undefined)).restScope).toBe('full');
+    flagState.flags[PUBLIC_APPS_CATALOG_DISABLED_FLAG] = {
+      kind: 'base',
+      enabled: true,
+    } satisfies FlagShape;
+    expect((await measure(undefined)).restScope).toBe('none');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The relationship
+// ---------------------------------------------------------------------------
+
+describe('anonymous viewer, no store flags — the intended production posture', () => {
+  it('🔴 the REST catalog is OPEN and `/apps` is DARK, simultaneously', async () => {
+    const m = await measure(undefined);
+
+    // Read path: served the whole public catalog, by deliberate grant.
+    expect(m.own).toBe('none');
+    expect(m.restScope).toBe('full');
+
+    // Page gate: unchanged, and it must STAY unchanged — this is the "did we
+    // accidentally launch the store" guard. Behavioural: the SSR resolver's own
+    // decision, plus the shared predicate it is built from.
+    expect(m.pageGranted).toBe(false);
+    expect(m.predicate).toBe(false);
+  });
+
+  it('a LOGGED-IN but non-privileged viewer is in exactly the same position', async () => {
+    const m = await measure(makeUser({ id: 4242 }));
+    expect(m.restScope).toBe('full');
+    expect(m.pageGranted).toBe(false);
+  });
+
+  it('withholding the public catalog does NOT change the page gate either (the axes are independent)', async () => {
+    flagState.flags[PUBLIC_APPS_CATALOG_DISABLED_FLAG] = {
+      kind: 'base',
+      enabled: true,
+    } satisfies FlagShape;
+    const m = await measure(undefined);
+    expect(m.restScope).toBe('none');
+    expect(m.pageGranted).toBe(false);
+  });
+
+  // The inverse of the trap: the grant must not be reachable FROM the store flags,
+  // and the store flags must keep meaning what they meant. Enabling one still opens
+  // the page — that is their job — which is why the grant could not be one of them.
+  it.each([LISTINGS, BLOCKS, EXTERNAL])(
+    'enabling the store flag `%s` still opens the PAGE — which is why the grant is not one of them',
+    async (flag) => {
+      flagState.flags[flag] = { kind: 'base', enabled: true } satisfies FlagShape;
+      const m = await measure(makeUser({ id: 77 }));
+      expect(m.pageGranted).toBe(true);
+    }
+  );
+});
+
+describe('a privileged principal is NOT narrowed by the public grant', () => {
+  it('a moderator/tester keeps `full` — and the kill switch cannot take it away', async () => {
+    flagState.flags[LISTINGS] = { kind: 'base', enabled: true } satisfies FlagShape;
+    flagState.flags[PUBLIC_APPS_CATALOG_DISABLED_FLAG] = {
+      kind: 'base',
+      enabled: true,
+    } satisfies FlagShape;
+    const m = await measure(makeUser({ id: 7, isModerator: true }));
+
+    expect(m.own).toBe('full');
+    expect(m.restScope).toBe('full');
+    expect(m.pageGranted).toBe(true);
+  });
+
+  it('the external-only cohort keeps `public-external` — the grant never rewrites a resolved scope', async () => {
+    flagState.flags[EXTERNAL] = { kind: 'base', enabled: true } satisfies FlagShape;
+    flagState.flags[PUBLIC_APPS_CATALOG_DISABLED_FLAG] = {
+      kind: 'base',
+      enabled: true,
+    } satisfies FlagShape;
+    const m = await measure(makeUser({ id: 9 }));
+
+    expect(m.own).toBe('public-external');
+    expect(m.restScope).toBe('public-external');
+    expect(m.pageGranted).toBe(true);
+  });
+});

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -6,6 +6,10 @@ import {
   recordStoreScopeResolution,
 } from '~/server/prom/store-scope.metrics';
 import { buildFliptContext } from '~/server/services/feature-flags.service';
+import {
+  narrowStoreScope,
+  type StoreVisibilityScope as StoreVisibilityScopeValue,
+} from '~/shared/utils/store-visibility-scope';
 
 const APP_BLOCKS_FLAG = 'app-blocks-enabled';
 
@@ -700,14 +704,14 @@ export async function isExternalListingsPublicEnabled(opts?: {
 }
 
 /**
- * The store read-path VISIBILITY SCOPE resolved once per request, then threaded
- * into every store read proc + the data-layer kind predicate:
- *   - `full`            — the caller sees ALL kinds (today's mod/tester gate).
- *   - `public-external` — the caller sees ONLY `kind='offsite'` approved listings
- *     (both `connect` and `external-link` sub-kinds); onsite is excluded.
- *   - `none`            — the caller sees NOTHING (dark; today's public default).
+ * The store read-path VISIBILITY SCOPE. Re-exported from the dependency-free
+ * `~/shared/utils/store-visibility-scope`, which owns the closed value set, the
+ * runtime membership test and the ONE fail-closed narrowing rule — so the data
+ * layer and the client can share them without importing this server module.
+ * Existing `import type { StoreVisibilityScope } from '~/server/services/app-blocks-flag'`
+ * call sites keep working unchanged.
  */
-export type StoreVisibilityScope = 'full' | 'public-external' | 'none';
+export type { StoreVisibilityScope } from '~/shared/utils/store-visibility-scope';
 
 /**
  * Resolve the {@link StoreVisibilityScope} for a store read request. The two flags
@@ -737,20 +741,44 @@ export type StoreVisibilityScope = 'full' | 'public-external' | 'none';
  */
 export async function resolveStoreVisibilityScope(opts?: {
   user?: SessionUser;
-}): Promise<StoreVisibilityScope> {
-  const scope = await resolveStoreVisibilityScopeUninstrumented(opts);
+}): Promise<StoreVisibilityScopeValue> {
+  const raw = (await resolveStoreVisibilityScopeUninstrumented(opts)) as unknown;
   // Instrumentation is deliberately at THIS choke point and nowhere else: it is the
   // single place both read paths (tRPC middleware + the REST handlers) and the SSR
   // store pages agree on, so one counter covers every entry point and cannot drift
   // the way per-call-site logging would.
-  recordStoreScopeResolution(scope, opts?.user ? 'user' : 'anon');
+  //
+  // 🔴 RECORD THE RAW VALUE, BEFORE NARROWING. `civitai_app_store_scope_resolutions_total`
+  // is the only instrument that can say what this function actually produced; if it
+  // recorded the narrowed answer, a value that is not a scope at all would be
+  // indistinguishable from a legitimately-resolved `none` and civitai#3983's central
+  // observation (`{principal="anon", scope="undefined"}`) would have been erased by
+  // the very change that closed the exposure.
+  recordStoreScopeResolution(raw as string, opts?.user ? 'user' : 'anon');
+  // 🔴 ENFORCE THE DECLARED CONTRACT AT RUNTIME, FAILING CLOSED. Every branch below
+  // returns a literal, so this narrowing is unreachable by inspection — and in
+  // production it is not: the counter above records `undefined` for the anonymous
+  // principal on this exact build, and both REST entry points independently record
+  // `absent` at their branch. Until that mechanism is identified, a declared return
+  // type is a claim, not a guarantee, and the fail-open half of the split (the
+  // listing service's `?? 'full'`) served the whole approved catalog — on-site apps
+  // included — to unauthenticated callers. An uninterpretable value is not evidence
+  // of an entitlement: it resolves to `none`.
+  //
+  // No extra log is emitted here on purpose. The counter above already carries the
+  // discriminator — prom-client renders the raw label verbatim, so `scope="undefined"`,
+  // `scope="[object Promise]"` and `scope="<unknown-string>"` are three different
+  // series — and this runs on an unauthenticated, public endpoint where a per-request
+  // log would be unbounded. Alert on
+  // `store_scope_resolutions_total{scope!~"full|public-external|none"}`.
+  const scope = narrowStoreScope(raw);
   if (scope === 'none' && opts?.user) reportSilentStoreGate(opts.user);
   return scope;
 }
 
 async function resolveStoreVisibilityScopeUninstrumented(opts?: {
   user?: SessionUser;
-}): Promise<StoreVisibilityScope> {
+}): Promise<StoreVisibilityScopeValue> {
   // Axis 1 — the existing catalog-visibility gate (mods + app-dev-testers). MUST be
   // checked FIRST so a privileged viewer always gets `full`, never `public-external`
   // (the external flag can only ever LIFT a non-privileged viewer, never narrow a mod).

--- a/src/server/services/blocks/__tests__/app-listing.deploy-gate.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.deploy-gate.test.ts
@@ -107,8 +107,7 @@ function offsiteRow(over: Record<string, unknown> = {}) {
   };
 }
 
-const ONSITE_DEPLOY_GATE =
-  /al\.kind <> 'onsite' OR ab\.current_version_deployed_at IS NOT NULL/i;
+const ONSITE_DEPLOY_GATE = /al\.kind <> 'onsite' OR ab\.current_version_deployed_at IS NOT NULL/i;
 
 describe('listAvailableListings — DEPLOY-GATE WHERE clause', () => {
   beforeEach(() => {
@@ -136,12 +135,12 @@ describe('getListingDetail — DEPLOY-GATE (app-layer)', () => {
       ...onsiteRow({ appBlock: { currentVersionDeployedAt: null, manifest: {} } }),
       status: 'approved',
     });
-    expect(await getListingDetail({ slug: 'cool-app' })).toBeNull();
+    expect(await getListingDetail({ slug: 'cool-app' }, { scope: 'full' })).toBeNull();
   });
 
   it('SHOWS a deployed ONSITE listing', async () => {
     mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...onsiteRow(), status: 'approved' });
-    const detail = await getListingDetail({ slug: 'cool-app' });
+    const detail = await getListingDetail({ slug: 'cool-app' }, { scope: 'full' });
     expect(detail).not.toBeNull();
     expect(detail!.id).toBe('apl_1');
   });
@@ -156,12 +155,12 @@ describe('getListingDetail — DEPLOY-GATE (app-layer)', () => {
       }),
       status: 'approved',
     });
-    expect(await getListingDetail({ slug: 'cool-app' })).not.toBeNull();
+    expect(await getListingDetail({ slug: 'cool-app' }, { scope: 'full' })).not.toBeNull();
   });
 
   it('SHOWS an OFFSITE listing (no backing AppBlock/deploy — exempt)', async () => {
     mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...offsiteRow(), status: 'approved' });
-    const detail = await getListingDetail({ slug: 'ext-app' });
+    const detail = await getListingDetail({ slug: 'ext-app' }, { scope: 'full' });
     expect(detail).not.toBeNull();
     expect(detail!.id).toBe('apl_2');
   });

--- a/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
@@ -58,6 +58,18 @@ function capturedSql(): string {
   return first && typeof first.sql === 'string' ? first.sql : '';
 }
 
+/**
+ * The captured SQL with `--` comments stripped.
+ *
+ * 🔴 Necessary, not cosmetic: the query's own comment reads "full scope emits TRUE
+ * (unchanged)", so a bare `/\bTRUE\b/` over the raw text matches the PROSE and reports
+ * a fail-open predicate on a query whose predicate is `FALSE`. An assertion that can be
+ * satisfied by a comment is not an assertion about the SQL.
+ */
+function capturedPredicateSql(): string {
+  return capturedSql().replace(/--[^\n]*/g, '');
+}
+
 /** A hydrated ONSITE listing row (as `listingHydrateSelect` returns). */
 function onsiteRow(over: Record<string, unknown> = {}) {
   return {
@@ -161,9 +173,44 @@ describe('listAvailableListings — STORE-SCOPE kind gate in the keyset WHERE', 
     expect(sql).not.toMatch(/al\.kind = 'offsite'/i);
   });
 
-  it('no scope passed → defaults to full (offsite clause absent — back-compat)', async () => {
-    await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 });
-    expect(capturedSql()).not.toMatch(/al\.kind = 'offsite'/i);
+  // 🔴 civitai#3983 REGRESSION GUARD — the fail-open default this replaced.
+  //
+  // The test that used to sit here read: "no scope passed → defaults to full (offsite
+  // clause absent)". It asserted an ABSENCE (`not.toMatch(/al.kind = 'offsite'/)`) that
+  // `full` (TRUE) and `none` (FALSE) BOTH satisfy, so it could not tell the whole
+  // catalog from an empty one — it was green for the entire time production served the
+  // full approved catalog, on-site apps included, to anonymous callers of
+  // `GET /api/v1/apps` through exactly this `?? 'full'` default.
+  //
+  // Assert the PREDICATE that is emitted, positively, for each way a scope can be
+  // missing or uninterpretable. `FALSE` is the whole claim: an absent scope selects
+  // nothing.
+  it.each([
+    ['omitted entirely', undefined as unknown],
+    ['explicitly undefined', undefined as unknown],
+    ['null', null as unknown],
+    ['a string outside the closed set', 'FULL' as unknown],
+    ['a non-string', 1 as unknown],
+  ])('ABSENT SCOPE FAILS CLOSED — %s → the FALSE predicate, never TRUE', async (_label, value) => {
+    await listAvailableListings(
+      { kind: 'all', sort: 'newest', limit: 20 },
+      // deliberately bypassing the compile-time union: the point is the RUNTIME value
+      // production actually carried past a green typecheck.
+      { scope: value as never }
+    );
+    const sql = capturedPredicateSql();
+    expect(sql).toMatch(/\bFALSE\b/);
+    expect(sql).not.toMatch(/\bTRUE\b/);
+  });
+
+  // POSITIVE CONTROL for the guard above: the same assertion must be able to FAIL.
+  // A privileged caller still emits TRUE, so "matches FALSE / not TRUE" is a claim
+  // about the absent-scope case and not a property of every query this builds.
+  it('POSITIVE CONTROL: an explicit `full` scope still emits TRUE, not FALSE', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 }, { scope: 'full' });
+    const sql = capturedPredicateSql();
+    expect(sql).toMatch(/\bTRUE\b/);
+    expect(sql).not.toMatch(/\bFALSE\b/);
   });
 
   // 🔴 SECURITY (W13 draft-at-submit): a pre-approval DRAFT onsite listing exists in
@@ -245,9 +292,36 @@ describe('getListingDetail — STORE-SCOPE kind gate (app-layer)', () => {
     expect(detail!.id).toBe('apl_1');
   });
 
-  it('default scope (none passed) → full: ONSITE shown (back-compat)', async () => {
+  // 🔴 civitai#3983 REGRESSION GUARD — replaces "default scope (none passed) → full:
+  // ONSITE shown (back-compat)", the test that CODIFIED the fail-open default. Under
+  // it, an absent scope reached an ONSITE listing's full detail through the public,
+  // unauthenticated `GET /api/v1/apps/{slug}`.
+  //
+  // The DB assertion is the load-bearing half: the guard must short-circuit BEFORE the
+  // hydration read, so a mocked approved row cannot leak even if a later projection
+  // change would have rendered it.
+  it.each([
+    ['omitted entirely', undefined as unknown],
+    ['explicitly undefined', undefined as unknown],
+    ['null', null as unknown],
+    ['a string outside the closed set', 'FULL' as unknown],
+  ])(
+    'ABSENT SCOPE FAILS CLOSED — %s → null, and the DB is never touched',
+    async (_label, value) => {
+      mockDbRead.appListing.findFirst.mockResolvedValueOnce({
+        ...onsiteRow(),
+        status: 'approved',
+      });
+      expect(await getListingDetail({ slug: 'cool-app' }, { scope: value as never })).toBeNull();
+      expect(mockDbRead.appListing.findFirst).not.toHaveBeenCalled();
+    }
+  );
+
+  // POSITIVE CONTROL: the seeded row IS reachable with a real scope, so the nulls
+  // above are attributable to the scope and not to a broken fixture.
+  it('POSITIVE CONTROL: the same seeded row IS returned under an explicit `full`', async () => {
     mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...onsiteRow(), status: 'approved' });
-    expect(await getListingDetail({ slug: 'cool-app' })).not.toBeNull();
+    expect(await getListingDetail({ slug: 'cool-app' }, { scope: 'full' })).not.toBeNull();
   });
 
   // 🔴 SECURITY (W13 draft-at-submit): the DETAIL proc app-layer gate returns null for
@@ -255,7 +329,7 @@ describe('getListingDetail — STORE-SCOPE kind gate (app-layer)', () => {
   // PENDING) onsite listing is indistinguishable from a missing one — even under the
   // most-permissive `full` scope. A crafted slug/id can never reach a draft's data on
   // the public REST `/api/v1/apps/[slug]` or the tRPC store detail.
-  it("DRAFT CANNOT LEAK — a pre-approval DRAFT onsite listing → null under full scope", async () => {
+  it('DRAFT CANNOT LEAK — a pre-approval DRAFT onsite listing → null under full scope', async () => {
     mockDbRead.appListing.findFirst.mockResolvedValueOnce({
       ...onsiteRow(),
       status: 'draft',

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -269,7 +269,10 @@ describe('projectListingCard — public allowlist (no internal leaks)', () => {
   it('onsite card liveUrl is `https://<slug>.<APPS_DOMAIN>` for the seeded slug', () => {
     const row = hydratedRow({ slug: 'my-neat-app' });
     const card = projectListingCard(row as never);
-    expect(card.kindData).toMatchObject({ kind: 'onsite', liveUrl: 'https://my-neat-app.civit.ai' });
+    expect(card.kindData).toMatchObject({
+      kind: 'onsite',
+      liveUrl: 'https://my-neat-app.civit.ai',
+    });
   });
 
   it('PARITY GUARD: onsite card liveUrl === detail liveUrl for the same listing (anti-drift)', () => {
@@ -546,7 +549,14 @@ describe('listAvailableListings — query building + pagination', () => {
     ]);
     // findMany returns the rows OUT OF ORDER — the service must re-apply the id order.
     mockDbRead.appListing.findMany.mockResolvedValueOnce([
-      hydratedRow({ id: 'apl_b', kind: 'offsite', appBlockId: null, appBlock: null, connectClientId: 'oc_1', slug: 'b-app' }),
+      hydratedRow({
+        id: 'apl_b',
+        kind: 'offsite',
+        appBlockId: null,
+        appBlock: null,
+        connectClientId: 'oc_1',
+        slug: 'b-app',
+      }),
       hydratedRow({ id: 'apl_a', kind: 'onsite', slug: 'a-app' }),
     ]);
     const { items } = await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 });
@@ -597,7 +607,11 @@ describe('listAvailableListings — query building + pagination', () => {
       hydratedRow({ id: 'apl_0' }),
       hydratedRow({ id: 'apl_1' }),
     ]);
-    const { nextCursor } = await listAvailableListings({ kind: 'all', sort: 'top-rated', limit: 2 });
+    const { nextCursor } = await listAvailableListings({
+      kind: 'all',
+      sort: 'top-rated',
+      limit: 2,
+    });
     const decoded = Buffer.from(nextCursor as string, 'base64url').toString('utf8');
     expect(decoded).toBe(`000000790${SEP}apl_1${SEP}0.8`);
   });
@@ -713,7 +727,7 @@ describe('getListingDetail — approved-only + maturity gate', () => {
 
   it('returns the projected detail for an approved listing (by slug)', async () => {
     mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...hydratedRow(), status: 'approved' });
-    const detail = await getListingDetail({ slug: 'cool-app' });
+    const detail = await getListingDetail({ slug: 'cool-app' }, { scope: 'full' });
     expect(detail?.id).toBe('apl_1');
     // Looked up by slug.
     const where = (mockDbRead.appListing.findFirst.mock.calls.at(-1)?.[0] as { where?: unknown })
@@ -724,7 +738,7 @@ describe('getListingDetail — approved-only + maturity gate', () => {
 
   it('looks up by id when id is provided', async () => {
     mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...hydratedRow(), status: 'approved' });
-    await getListingDetail({ id: 'apl_1' });
+    await getListingDetail({ id: 'apl_1' }, { scope: 'full' });
     const where = (mockDbRead.appListing.findFirst.mock.calls.at(-1)?.[0] as { where?: unknown })
       ?.where;
     expect(where).toEqual({ id: 'apl_1', revisionOfId: null });
@@ -732,31 +746,37 @@ describe('getListingDetail — approved-only + maturity gate', () => {
 
   it('the WHERE excludes SHADOW revision drafts (revisionOfId: null) for BOTH selectors', async () => {
     mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...hydratedRow(), status: 'approved' });
-    await getListingDetail({ slug: 'cool-app' });
-    const bySlug = (mockDbRead.appListing.findFirst.mock.calls.at(-1)?.[0] as { where?: { revisionOfId?: unknown } })?.where;
+    await getListingDetail({ slug: 'cool-app' }, { scope: 'full' });
+    const bySlug = (
+      mockDbRead.appListing.findFirst.mock.calls.at(-1)?.[0] as {
+        where?: { revisionOfId?: unknown };
+      }
+    )?.where;
     expect(bySlug?.revisionOfId).toBeNull();
   });
 
   it('returns null for a missing listing', async () => {
     mockDbRead.appListing.findFirst.mockResolvedValueOnce(null);
-    expect(await getListingDetail({ slug: 'nope' })).toBeNull();
+    expect(await getListingDetail({ slug: 'nope' }, { scope: 'full' })).toBeNull();
   });
 
   it('returns null (no query) when NEITHER slug nor id is provided (enumeration guard)', async () => {
     // The zod .refine guards the tRPC boundary, but the service is exported —
     // `findFirst({ slug: undefined })` would return an arbitrary approved row.
-    expect(await getListingDetail({} as never)).toBeNull();
+    expect(await getListingDetail({} as never, { scope: 'full' })).toBeNull();
     expect(mockDbRead.appListing.findFirst).not.toHaveBeenCalled();
   });
 
   it('returns null (no query) when BOTH slug and id are provided (ambiguous)', async () => {
-    expect(await getListingDetail({ slug: 'cool-app', id: 'apl_1' } as never)).toBeNull();
+    expect(
+      await getListingDetail({ slug: 'cool-app', id: 'apl_1' } as never, { scope: 'full' })
+    ).toBeNull();
     expect(mockDbRead.appListing.findFirst).not.toHaveBeenCalled();
   });
 
   it.each(['draft', 'pending', 'rejected'])('returns null for a %s listing', async (status) => {
     mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...hydratedRow(), status });
-    expect(await getListingDetail({ slug: 'cool-app' })).toBeNull();
+    expect(await getListingDetail({ slug: 'cool-app' }, { scope: 'full' })).toBeNull();
   });
 
   it('hides a mature (x) listing off a non-red host', async () => {
@@ -764,7 +784,9 @@ describe('getListingDetail — approved-only + maturity gate', () => {
       ...hydratedRow({ contentRating: 'x' }),
       status: 'approved',
     });
-    expect(await getListingDetail({ slug: 'cool-app' }, { redCapable: false })).toBeNull();
+    expect(
+      await getListingDetail({ slug: 'cool-app' }, { redCapable: false, scope: 'full' })
+    ).toBeNull();
   });
 
   it('shows a mature (x) listing on a red-capable host', async () => {
@@ -772,7 +794,10 @@ describe('getListingDetail — approved-only + maturity gate', () => {
       ...hydratedRow({ contentRating: 'x' }),
       status: 'approved',
     });
-    const detail = await getListingDetail({ slug: 'cool-app' }, { redCapable: true });
+    const detail = await getListingDetail(
+      { slug: 'cool-app' },
+      { redCapable: true, scope: 'full' }
+    );
     expect(detail?.contentRating).toBe('x');
   });
 });

--- a/src/server/services/blocks/__tests__/public-apps-catalog.test.ts
+++ b/src/server/services/blocks/__tests__/public-apps-catalog.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The PUBLIC App-catalog grant decision, in isolation.
+ *
+ * 🔴 LABEL, honestly: this file is UNIT coverage for a module that did not exist
+ * before, so it cannot be shown red at the base ref — there is nothing at base for
+ * it to import. It pins the decision's shape; the REGRESSION coverage (an anonymous
+ * caller is actually served, and `/apps` stays dark) lives in the handler suites
+ * `src/tests/api/v1/apps/*`, which ARE red at base because they drive the real
+ * handlers through a behaviour that changed.
+ *
+ * What it structurally cannot see: whether `resolveStoreVisibilityScope` produces
+ * anything sane in production (it does not, for an anonymous principal — civitai#3983
+ * is still open upstream), and whether the Flipt flag exists. Both are mocked here.
+ */
+
+const { mockIsFlipt } = vi.hoisted(() => ({ mockIsFlipt: vi.fn() }));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isFlipt: mockIsFlipt,
+}));
+
+import {
+  PUBLIC_APPS_CATALOG_DISABLED_FLAG,
+  PUBLIC_APPS_CATALOG_SCOPE,
+  resolvePublicAppsCatalogScope,
+} from '~/server/services/blocks/public-apps-catalog';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The flag's ABSENT state. `isFlipt` returns false for a flag that does not exist
+  // and for an unreachable Flipt, so this is also the as-merged production config.
+  mockIsFlipt.mockResolvedValue(false);
+});
+
+describe('resolvePublicAppsCatalogScope — the public grant', () => {
+  it('grants the public catalog to a caller who resolved `none`', async () => {
+    await expect(resolvePublicAppsCatalogScope('none', 'rest-list')).resolves.toBe(
+      PUBLIC_APPS_CATALOG_SCOPE
+    );
+  });
+
+  // The KILL-SWITCH POLARITY, which is the one property that decides whether merging
+  // this empties a live endpoint. Asserted as a discrimination so it cannot pass on a
+  // function that ignores the flag in either direction.
+  it('POLARITY: flag ABSENT/false → granted; flag true → withheld', async () => {
+    mockIsFlipt.mockResolvedValue(false);
+    await expect(resolvePublicAppsCatalogScope('none', 'rest-list')).resolves.toBe('full');
+    mockIsFlipt.mockResolvedValue(true);
+    await expect(resolvePublicAppsCatalogScope('none', 'rest-list')).resolves.toBe('none');
+  });
+
+  it('reads the kill switch GLOBALLY (no entityId/context — these callers have none)', async () => {
+    await resolvePublicAppsCatalogScope('none', 'rest-list');
+    expect(mockIsFlipt).toHaveBeenCalledTimes(1);
+    // A segmented/percentage flag cannot match a global eval; the flag key and the
+    // absence of an entity are both part of the operator contract in the module doc.
+    expect(mockIsFlipt.mock.calls[0]).toEqual([PUBLIC_APPS_CATALOG_DISABLED_FLAG]);
+  });
+});
+
+describe('resolvePublicAppsCatalogScope — a privileged caller is never touched', () => {
+  it.each(['full', 'public-external'] as const)(
+    'passes `%s` through verbatim, and does not even READ the kill switch',
+    async (scope) => {
+      await expect(resolvePublicAppsCatalogScope(scope, 'rest-list')).resolves.toBe(scope);
+      // Short-circuit, proven by absence of the eval: no configuration of the switch
+      // can narrow, widen or slow a caller who resolved a scope of their own.
+      expect(mockIsFlipt).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['full', 'public-external'] as const)(
+    'still passes `%s` through with the kill switch ON',
+    async (scope) => {
+      mockIsFlipt.mockResolvedValue(true);
+      await expect(resolvePublicAppsCatalogScope(scope, 'rest-list')).resolves.toBe(scope);
+    }
+  );
+});
+
+describe('resolvePublicAppsCatalogScope — #4041 narrowing is applied FIRST', () => {
+  /** Every runtime shape production's missing scope can arrive as. */
+  const ABSENT: [string, unknown][] = [
+    ['undefined (what production records for an anonymous principal)', undefined],
+    ['null', null],
+    ['an empty string', ''],
+    ['a wrong-cased scope', 'FULL'],
+    ['a near-miss', 'public_external'],
+    ['a scope from a hypothetical newer branch', 'public-onsite'],
+    ['a number', 1],
+    ['a boolean', true],
+    ['an object', { scope: 'full' }],
+    ['a Promise (an unawaited resolver call)', Promise.resolve('full')],
+  ];
+
+  // 🔴 THE #3983 INVARIANT, restated for a public surface: an uninterpretable value
+  // must land on the same branch as a resolved `none`, never on its own wider one.
+  // Both configurations are checked, because "same as none" is only meaningful if
+  // `none` itself can be closed.
+  it.each(ABSENT)('%s is treated EXACTLY as a resolved `none` — switch off', async (_l, value) => {
+    const absent = await resolvePublicAppsCatalogScope(value, 'rest-list');
+    const none = await resolvePublicAppsCatalogScope('none', 'rest-list');
+    expect(absent).toBe(none);
+  });
+
+  it.each(ABSENT)('%s is treated EXACTLY as a resolved `none` — switch on', async (_l, value) => {
+    mockIsFlipt.mockResolvedValue(true);
+    const absent = await resolvePublicAppsCatalogScope(value, 'rest-list');
+    const none = await resolvePublicAppsCatalogScope('none', 'rest-list');
+    expect(absent).toBe(none);
+    // And that shared answer is the closed one — so an absent scope cannot slip past
+    // an operator who has deliberately withheld the catalog.
+    expect(absent).toBe('none');
+  });
+});

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -7,6 +7,7 @@ import { dbRead } from '~/server/db/client';
 import { toPublicBlockManifest } from '~/server/schema/blocks/subscription.schema';
 import { isMatureContentRating } from '~/server/utils/server-domain';
 import type { StoreVisibilityScope } from '~/server/services/app-blocks-flag';
+import { narrowStoreScope } from '~/shared/utils/store-visibility-scope';
 import type {
   GetAppListingDetailInput,
   ListAllListingsForModerationInput,
@@ -552,18 +553,22 @@ export async function listAvailableListings(
 ): Promise<{ items: ListingCard[]; nextCursor?: string }> {
   const { kind, category, sort, cursor, limit } = input;
   const redCapable = opts.redCapable ?? false;
-  // Default `full` for callers that don't pass a scope (the router ALWAYS passes
-  // an explicit scope and NEVER calls this with `none` — it short-circuits an
-  // empty page at the proc). `full` → `TRUE` predicate → byte-identical WHERE.
-  const scope = opts.scope ?? 'full';
+  // 🔴 FAIL CLOSED on an absent / unrecognized scope (civitai#3983). This used to be
+  // `opts.scope ?? 'full'`, on the reasoning that every caller passes an explicit
+  // scope. Every caller does — and production still reached here with `undefined`,
+  // so the `??` fired and this function served the WHOLE approved catalog (on-site
+  // apps included) to anonymous callers of the public REST endpoint. A default is an
+  // authorization decision; the only safe one here is `none` → `FALSE` predicate →
+  // an empty page. `narrowStoreScope` is the single shared rule; see
+  // `~/shared/utils/store-visibility-scope`.
+  const scope = narrowStoreScope(opts.scope);
 
   const { cursorSortKey, cursorId, cursorMean } = decodeListingCursor(cursor);
 
   // Only `top-rated` needs the global mean. PIN it into the cursor across a
   // paging session (page 1 reads the 1h cache + encodes it; pages 2..N reuse
   // the pinned value, NOT a fresh read) so the sort key can't shift mid-scan.
-  const globalMean =
-    sort === 'top-rated' ? cursorMean ?? (await getGlobalRecommendMean()) : 0;
+  const globalMean = sort === 'top-rated' ? cursorMean ?? (await getGlobalRecommendMean()) : 0;
 
   const { expr: sortKeyExpr, descending } = listingSortKeyExpr(sort, globalMean);
   const dir = descending ? Prisma.sql`DESC` : Prisma.sql`ASC`;
@@ -620,9 +625,7 @@ export async function listAvailableListings(
     where: { id: { in: pageIds } },
     select: listingHydrateSelect,
   });
-  const byId = new Map(
-    hydrated.map((r: HydratedListing): [string, HydratedListing] => [r.id, r])
-  );
+  const byId = new Map(hydrated.map((r: HydratedListing): [string, HydratedListing] => [r.id, r]));
   const items = pageIds
     .map((id: string) => byId.get(id))
     .filter((r): r is HydratedListing => r != null)
@@ -642,8 +645,10 @@ export async function getListingDetail(
   opts: { redCapable?: boolean; scope?: StoreVisibilityScope } = {}
 ): Promise<ListingDetail | null> {
   const redCapable = opts.redCapable ?? false;
-  // Default `full` for callers that don't pass a scope (see listAvailableListings).
-  const scope = opts.scope ?? 'full';
+  // 🔴 FAIL CLOSED on an absent / unrecognized scope — see listAvailableListings
+  // (civitai#3983). Previously `opts.scope ?? 'full'`, which let an absent scope
+  // reach a listing's full detail through the public REST endpoint.
+  const scope = narrowStoreScope(opts.scope);
   // STORE-SCOPE `none` (default-closed): a caller with no store visibility gets
   // nothing — symmetric with the list path's `listingPublicVisibilityFilter('none')`
   // → FALSE. The v1 endpoints short-circuit `none` before calling this, but honor
@@ -822,7 +827,9 @@ export const moderationListingSelect = {
   },
 } satisfies Prisma.AppListingSelect;
 
-type HydratedModerationRow = Prisma.AppListingGetPayload<{ select: typeof moderationListingSelect }>;
+type HydratedModerationRow = Prisma.AppListingGetPayload<{
+  select: typeof moderationListingSelect;
+}>;
 
 /** Project a hydrated moderation row → the {@link ModerationListingRow} DTO. */
 export function projectModerationListing(row: HydratedModerationRow): ModerationListingRow {
@@ -868,9 +875,7 @@ export function projectModerationListing(row: HydratedModerationRow): Moderation
  * Pure, total. Returned as its own fragment so the caller composes it under `AND`
  * (this clause may itself be an `OR`, which would collide with the `search` `OR`).
  */
-export function moderationStatusWhere(
-  status: string | undefined
-): Prisma.AppListingWhereInput {
+export function moderationStatusWhere(status: string | undefined): Prisma.AppListingWhereInput {
   if (!status) return {};
   if (status === 'pending') {
     return {

--- a/src/server/services/blocks/public-apps-catalog.ts
+++ b/src/server/services/blocks/public-apps-catalog.ts
@@ -1,0 +1,150 @@
+import { isFlipt } from '~/server/flipt/client';
+import { narrowStoreScope, type StoreVisibilityScope } from '~/shared/utils/store-visibility-scope';
+import {
+  recordPublicCatalogDecision,
+  type StoreScopeEntrypoint,
+} from '~/server/prom/store-scope.metrics';
+
+/**
+ * The PUBLIC App-catalog read grant — the deliberate decision that the REST
+ * catalog endpoints (`GET /api/v1/apps`, `GET /api/v1/apps/{slug}`) are readable
+ * by anyone, including an unauthenticated caller.
+ *
+ * ## Why this is its own module, and not another term in `resolveStoreVisibilityScope`
+ *
+ * Public REST catalog access is INTENDED product behaviour, but until now it was
+ * not something anyone had decided — it was a side effect. `resolveStoreVisibility
+ * Scope` resolved nothing for an anonymous principal, and the listing service's
+ * `?? 'full'` turned that missing value into the whole approved catalog
+ * (civitai#3983). #4041 makes an absent scope fail CLOSED everywhere, which is
+ * correct and must stay — and which, on its own, would have taken a live public
+ * endpoint from 14 items to zero. This module is the other half: it re-grants that
+ * access ON PURPOSE, in one named place, so the catalog's public reach is a
+ * decision a reader can find rather than a `??` nobody meant.
+ *
+ * 🔴 IT IS DELIBERATELY NOT `hasAppsStoreAccess`, AND NOT A STORE FLAG. The
+ * existing store predicate is `appListings || appBlocks || appListingsPublic
+ * External`, and it gates the `/apps` PAGE as well as the read scope. Granting
+ * public REST access by enabling any of those three flags — or by reusing that
+ * predicate here — would also open `/apps` to every visitor, i.e. launch the store.
+ * Nobody asked for that. The state this module encodes (catalog readable over the
+ * REST API, `/apps` still dark for an anonymous viewer) is not reachable by ANY
+ * combination of those flags; that is precisely why it needs its own decision
+ * point. Adding a store flag to this module's inputs re-creates the coupling — do
+ * not do it.
+ *
+ * ## What it does, exactly
+ *
+ * {@link resolvePublicAppsCatalogScope} takes the value `resolveStoreVisibility
+ * Scope` produced and answers the only question the REST handlers actually have:
+ * *what may this caller read from the public catalog?*
+ *
+ *   1. NARROW first ({@link narrowStoreScope}) — #4041's fail-closed rule is
+ *      applied unchanged and FIRST, so an absent or uninterpretable value can never
+ *      be mistaken for an entitlement.
+ *   2. A caller who resolved a real scope (`full` for a moderator / app-dev-tester,
+ *      `public-external` for the external-only cohort) is returned VERBATIM. The
+ *      public grant is a FLOOR, never a ceiling: it can only ever lift a caller who
+ *      resolved `none`, and it short-circuits before the kill switch is even read,
+ *      so a privileged caller is unaffected by this module in every configuration.
+ *   3. Everyone else — `none` — gets {@link PUBLIC_APPS_CATALOG_SCOPE}, unless the
+ *      operator kill switch is on, in which case they get `none` and the endpoints
+ *      go back to an empty page / 404.
+ *
+ * ## The fail-closed invariant this preserves (read this before "simplifying" it)
+ *
+ * #3983's exploit was not that anonymous callers could read the catalog — that is
+ * intended. It was that an ABSENT scope produced a WIDER answer than a resolved
+ * one: absent → `full`, resolved-`none` → empty, from the same request. Step 1
+ * collapses that: absent and `none` are the same input to step 3 and therefore
+ * produce the same response. There is no value the resolver can fail to produce
+ * that buys a caller more than a correctly-resolved `none` does. Every other
+ * consumer of the scope — both listing-service entry points, the three store tRPC
+ * procs — keeps failing closed exactly as #4041 left them; this module is scoped to
+ * the two public REST handlers and nothing else imports it.
+ *
+ * ⚠️ Honest consequence, stated rather than discovered later: while the grant is
+ * active, `public-external` is not a narrower answer than the public floor at these
+ * two endpoints — the floor is already `full`, so a caller in the external-only
+ * cohort and an anonymous caller read the same catalog here. The distinction starts
+ * to matter again the moment the kill switch is thrown, and it has always mattered
+ * on the tRPC/page surfaces, which this module does not touch.
+ */
+
+/**
+ * What the public catalog is readable AS. `full` — both `onsite` and `offsite`
+ * approved listings, which is what `GET /api/v1/apps` has been serving publicly all
+ * along (measured: 14 items, 10 onsite + 4 offsite). This constant exists so
+ * narrowing the public catalog later (e.g. to `public-external`) is a one-line,
+ * reviewable product decision rather than an edit threaded through two handlers.
+ *
+ * Approved-only, deploy-gated and maturity-gated filtering still applies inside the
+ * listing service — `full` is a KIND predicate, not "everything in the table".
+ */
+export const PUBLIC_APPS_CATALOG_SCOPE: StoreVisibilityScope = 'full';
+
+/**
+ * Operator KILL SWITCH for the public catalog. Flipt flag; when it resolves TRUE the
+ * public grant is withheld and an unauthenticated caller is back to an empty page /
+ * 404. Privileged callers are unaffected (they never reach it).
+ *
+ * 🔴 THE POLARITY IS THE WHOLE POINT — it is a DISABLE flag, not an ENABLE flag.
+ * `isFlipt` returns `false` for a flag that does not exist and for an unreachable
+ * Flipt, so the absent/dark/broken state of this switch is **public access stays
+ * on**. An enable-shaped flag would have made merging this PR empty the live
+ * endpoint until someone remembered to create the flag — the exact regression the
+ * grant exists to prevent, re-introduced by its own kill switch. If you ever invert
+ * this to an `apps-public-catalog-enabled` flag, you must create AND enable it in
+ * flipt-state BEFORE the code merges, and the window between the two is an outage of
+ * a public endpoint.
+ *
+ * The flag does NOT exist in Flipt as merged, and does not need to: the as-merged
+ * behaviour is the intended one. To throw the switch, create it as a PLAIN base
+ * `enabled: true` boolean (NO segments, NO percentage rollout) — it is evaluated
+ * GLOBALLY (entityId `'global'`, empty context) because the callers it governs are
+ * unauthenticated and carry no context for a segment to match. A segmented or
+ * percentage-rollout shape cannot reliably match a global eval and would read as a
+ * switch that does nothing.
+ *
+ * Propagation is the Flipt eval cache (~10s) plus the config poll (~60s), on top of
+ * whatever the CDN is still serving for `s-maxage`. It is not instant; that is
+ * acceptable for a catalog-visibility switch and is why it is deliberately NOT in
+ * the client's cache-bypass set (these are hot, unauthenticated endpoints).
+ */
+export const PUBLIC_APPS_CATALOG_DISABLED_FLAG = 'apps-public-catalog-disabled';
+
+/** Global eval — these callers are unauthenticated and carry no Flipt context. */
+async function isPublicAppsCatalogDisabled(): Promise<boolean> {
+  return isFlipt(PUBLIC_APPS_CATALOG_DISABLED_FLAG);
+}
+
+/**
+ * Resolve what the PUBLIC REST catalog endpoints may serve this caller.
+ *
+ * @param resolved the raw value from `resolveStoreVisibilityScope` — typed `unknown`
+ *   on purpose. Production has been observed carrying `undefined` across exactly this
+ *   boundary while every type checked green (civitai#3983), so the narrowing has to
+ *   happen at runtime, here, on the value that actually arrived.
+ * @param entrypoint which REST handler is asking — for the decision counter only.
+ */
+export async function resolvePublicAppsCatalogScope(
+  resolved: unknown,
+  entrypoint: StoreScopeEntrypoint
+): Promise<StoreVisibilityScope> {
+  // 1. #4041's rule, first and unchanged: anything uninterpretable becomes `none`.
+  const scope = narrowStoreScope(resolved);
+  // 2. A caller who resolved a real scope keeps it verbatim — and never pays for the
+  //    kill-switch eval, so this module cannot narrow, widen or slow a privileged
+  //    read in any configuration.
+  if (scope !== 'none') {
+    recordPublicCatalogDecision('privileged', entrypoint);
+    return scope;
+  }
+  // 3. The public floor, unless an operator has withheld it.
+  if (await isPublicAppsCatalogDisabled()) {
+    recordPublicCatalogDecision('withheld', entrypoint);
+    return 'none';
+  }
+  recordPublicCatalogDecision('granted', entrypoint);
+  return PUBLIC_APPS_CATALOG_SCOPE;
+}

--- a/src/shared/utils/__tests__/store-visibility-scope.test.ts
+++ b/src/shared/utils/__tests__/store-visibility-scope.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isStoreVisibilityScope,
+  narrowStoreScope,
+  STORE_VISIBILITY_SCOPES,
+} from '~/shared/utils/store-visibility-scope';
+
+/**
+ * The ONE narrowing rule the App-store read path applies to a possibly-absent scope
+ * (civitai#3983). Every consumer — both `/api/v1/apps*` REST handlers, the store tRPC
+ * branch point, and both listing-service entry points — routes through
+ * `narrowStoreScope`, so this is the single place the fail-closed direction is pinned.
+ *
+ * The rule that matters is asymmetric and worth stating on its own: an uninterpretable
+ * value must resolve to `none`, NEVER to `full` or `public-external`. The bug this
+ * replaces was a `?? 'full'` — a default that silently issued the widest entitlement
+ * in the system to whatever code path failed to supply an argument.
+ */
+describe('narrowStoreScope — an unrecognized scope resolves to `none`, never to access', () => {
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['an empty string', ''],
+    ['a wrong-cased scope', 'FULL'],
+    ['a near-miss', 'public_external'],
+    ['a scope from a hypothetical newer branch', 'public-onsite'],
+    ['a number', 1],
+    ['a boolean', true],
+    ['an object', { scope: 'full' }],
+    ['an array', ['full']],
+    ['a Promise (an unawaited resolver call)', Promise.resolve('full')],
+  ])('%s → none', (_label, value) => {
+    expect(narrowStoreScope(value)).toBe('none');
+  });
+
+  it.each(STORE_VISIBILITY_SCOPES)('passes the real scope `%s` through unchanged', (scope) => {
+    expect(narrowStoreScope(scope)).toBe(scope);
+  });
+
+  // The closed set is the contract; pin its exact membership so widening it becomes a
+  // deliberate edit here rather than a silent consequence of a new branch elsewhere.
+  it('the closed set is exactly full | public-external | none', () => {
+    expect([...STORE_VISIBILITY_SCOPES]).toEqual(['full', 'public-external', 'none']);
+  });
+
+  it('isStoreVisibilityScope accepts every member and rejects everything else', () => {
+    for (const scope of STORE_VISIBILITY_SCOPES) expect(isStoreVisibilityScope(scope)).toBe(true);
+    for (const value of [undefined, null, '', 'FULL', 0, {}, []])
+      expect(isStoreVisibilityScope(value)).toBe(false);
+  });
+});

--- a/src/shared/utils/store-visibility-scope.ts
+++ b/src/shared/utils/store-visibility-scope.ts
@@ -1,0 +1,75 @@
+/**
+ * The App-store read VISIBILITY SCOPE — its closed value set, and the ONE
+ * narrowing rule every consumer applies to an untrusted / possibly-absent scope.
+ *
+ * ## Why this lives in its own dependency-free module (civitai#3983)
+ *
+ * The scope is produced in one place (`resolveStoreVisibilityScope`) and branched
+ * on in five (the three store tRPC procs, both `/api/v1/apps*` REST handlers) plus
+ * the two data-layer entry points (`listAvailableListings` / `getListingDetail`).
+ * Before this module each of those sites carried its OWN default for "no scope
+ * arrived", and they did not agree:
+ *
+ *   - the tRPC procs defaulted an absent scope to `none`  → an EMPTY store;
+ *   - the listing service defaulted it to `full`          → the WHOLE catalog.
+ *
+ * So a single missing value produced two opposite failures, and the one that
+ * widened access was the silent one: an anonymous caller received the full
+ * approved catalog — on-site apps included — from a public REST endpoint, while
+ * looking exactly like a working feature. That is civitai#3983.
+ *
+ * 🔴 A DEFAULT IS A SECURITY DECISION. `?? 'full'` is not a convenience; it is an
+ * authorization grant issued by whatever code forgot to pass an argument. There is
+ * one correct default for an absent or unrecognized scope and it is `none` — the
+ * caller sees nothing. {@link narrowStoreScope} is that rule, in one place, so a
+ * new consumer cannot re-derive a different one.
+ *
+ * ## Why a runtime guard rather than the type
+ *
+ * `StoreVisibilityScope` is a compile-time union; every producer and consumer here
+ * already type-checks green while production carries `undefined` across the same
+ * boundary. A declared type is not a code path — only a branch on the value is —
+ * so the check has to exist at runtime, at the branch, on every path that can
+ * widen access.
+ *
+ * This module deliberately imports NOTHING: it is reachable from the server data
+ * layer, the REST handlers, the tRPC router and the client, and must never drag a
+ * server dependency into any of them.
+ */
+
+/** The closed value set. The runtime source of truth for the type below. */
+export const STORE_VISIBILITY_SCOPES = ['full', 'public-external', 'none'] as const;
+
+/**
+ * The store read-path VISIBILITY SCOPE resolved once per request, then threaded
+ * into every store read proc + the data-layer kind predicate:
+ *   - `full`            — the caller sees ALL kinds.
+ *   - `public-external` — the caller sees ONLY `kind='offsite'` approved listings
+ *     (both `connect` and `external-link` sub-kinds); onsite is excluded.
+ *   - `none`            — the caller sees NOTHING (dark; the public default).
+ */
+export type StoreVisibilityScope = (typeof STORE_VISIBILITY_SCOPES)[number];
+
+/** Runtime membership test for the closed set above. */
+export function isStoreVisibilityScope(value: unknown): value is StoreVisibilityScope {
+  return (
+    typeof value === 'string' && (STORE_VISIBILITY_SCOPES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Narrow an untrusted, absent or unrecognized scope to a real one, FAILING CLOSED.
+ *
+ * 🔴 Every value that is not exactly one of {@link STORE_VISIBILITY_SCOPES} maps to
+ * `none` — `undefined`, `null`, a typo, a scope from a future branch this build
+ * does not understand. Never to `full`, and never to `public-external`: a value we
+ * cannot interpret is not evidence of an entitlement.
+ *
+ * Call this AFTER recording the raw value for telemetry, never before — the
+ * distinction between "resolved `none`" and "no scope arrived" is the signal
+ * civitai#3983 spent its whole investigation unable to observe, and narrowing
+ * erases it.
+ */
+export function narrowStoreScope(value: unknown): StoreVisibilityScope {
+  return isStoreVisibilityScope(value) ? value : 'none';
+}

--- a/src/tests/api/v1/apps/apps-error-envelope.test.ts
+++ b/src/tests/api/v1/apps/apps-error-envelope.test.ts
@@ -17,14 +17,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  *      machine-readable `code`, and a real 200 does NOT carry it.
  */
 
-const { mockResolveScope, mockDetail, mockRateLimit, mockIsHostForColor, mockLogToAxiom } =
-  vi.hoisted(() => ({
-    mockResolveScope: vi.fn(),
-    mockDetail: vi.fn(),
-    mockRateLimit: vi.fn(),
-    mockIsHostForColor: vi.fn(),
-    mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
-  }));
+const {
+  mockResolveScope,
+  mockDetail,
+  mockRateLimit,
+  mockIsHostForColor,
+  mockLogToAxiom,
+  mockIsFlipt,
+} = vi.hoisted(() => ({
+  mockResolveScope: vi.fn(),
+  mockDetail: vi.fn(),
+  mockRateLimit: vi.fn(),
+  mockIsHostForColor: vi.fn(),
+  mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
+  mockIsFlipt: vi.fn(),
+}));
 
 // Keep the REAL handleEndpointError — that is the whole point of this suite.
 // Only the auth wrapper is stubbed (it would need a live session + db).
@@ -59,6 +66,13 @@ vi.mock('~/server/services/blocks/app-listing.service', () => ({
 }));
 vi.mock('~/server/utils/apps-catalog-rate-limit', () => ({
   enforceAppsCatalogRateLimit: mockRateLimit,
+}));
+// The public-catalog kill switch, so the scope-gate 404 branch stays REACHABLE:
+// with the switch off (its dark/absent state) an anonymous caller is served the
+// public catalog, so `none` at this handler now means "the grant was withheld".
+vi.mock('~/server/flipt/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isFlipt: mockIsFlipt,
 }));
 
 import { TRPCError } from '@trpc/server';
@@ -194,6 +208,8 @@ beforeEach(() => {
   mockResolveScope.mockImplementation(async ({ user }: { user?: { isModerator?: boolean } }) =>
     user?.isModerator ? 'full' : 'none'
   );
+  // Kill switch OFF = the public catalog is open (its absent/dark state).
+  mockIsFlipt.mockResolvedValue(false);
   mockDetail.mockResolvedValue({ id: 'al_a', serialId: 1, slug: 'a', kind: 'onsite', name: 'a' });
 });
 
@@ -226,7 +242,10 @@ describe('GET /api/v1/apps/{slug} — error envelope + disclosure', () => {
     expect(bad.res._status()).toBe(400);
     expectErrorEnvelope(bad.res._json(), '400', 'BAD_REQUEST', ZOD_FLATTEN);
 
-    // 404 — out-of-scope caller (the default-closed scope gate).
+    // 404 — the SCOPE-GATE branch. Reached by withholding the public-catalog grant
+    // (kill switch on), which is now the only way a caller with no scope of their
+    // own gets `none` at this handler.
+    mockIsFlipt.mockResolvedValueOnce(true);
     const scoped = createMocks({ query: { slug: 'secret-app' } });
     await (detailHandler as unknown as Handler)(scoped.req, scoped.res, undefined);
     expect(scoped.res._status()).toBe(404);

--- a/src/tests/api/v1/apps/apps.absent-scope-fail-closed.test.ts
+++ b/src/tests/api/v1/apps/apps.absent-scope-fail-closed.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * 🔴 civitai#3983 — AN ABSENT STORE SCOPE MUST FAIL CLOSED AT EVERY BRANCH.
+ *
+ * ## What production did, and why nothing caught it
+ *
+ * On the serving build, `resolveStoreVisibilityScope` produced NO value for an
+ * anonymous principal — recorded as `store_scope_resolutions_total{principal="anon",
+ * scope="undefined"}` at the resolver and, independently, as
+ * `store_scope_applied_total{entrypoint="rest-list"|"rest-detail", scope="absent"}`
+ * at each REST branch. One missing value then hit two DISAGREEING defaults:
+ *
+ *   - `listAvailableListings` / `getListingDetail`: `opts.scope ?? 'full'`
+ *       → the WHOLE approved catalog, on-site apps included, to an unauthenticated
+ *         caller of the public REST endpoints;
+ *   - the store tRPC procs: `_storeScope ?? 'none'`
+ *       → an EMPTY store for the cohort that was supposed to see it.
+ *
+ * Both halves were invisible: an over-wide catalog looks like a working public API,
+ * and an empty one looks like an empty catalog. The existing handler suite
+ * (`apps.test.ts`) never exercised an absent scope — its resolver mock only ever
+ * returned `full` or `none` — so 75 green store-scope tests coexisted with the bug
+ * for its whole life.
+ *
+ * These tests drive the REAL handlers with the resolver returning exactly what
+ * production returns, and assert the handler refuses. They are RED before the
+ * `narrowStoreScope` hardening (the list handler serves the mocked catalog; the
+ * detail handler serves the mocked listing) and green after.
+ *
+ * ## What this suite structurally CANNOT see
+ *
+ * - WHY the resolver yields no value in the production runtime. The resolver is
+ *   MOCKED here precisely so the assertion is about the consumers' defaults, which
+ *   is the half that decides whether a missing value widens access. The mechanism
+ *   upstream is still open; see the issue.
+ * - The compiled production artifact. This runs the TypeScript source under vitest,
+ *   and the same source resolves `none` correctly here while production does not.
+ * - The tRPC branch point (`applyStoreScope`) — covered by the router suites.
+ */
+
+const {
+  mockResolveScope,
+  mockList,
+  mockDetail,
+  mockRateLimit,
+  mockGetNextPage,
+  mockIsHostForColor,
+} = vi.hoisted(() => ({
+  mockResolveScope: vi.fn(),
+  mockList: vi.fn(),
+  mockDetail: vi.fn(),
+  mockRateLimit: vi.fn(),
+  mockGetNextPage: vi.fn(),
+  mockIsHostForColor: vi.fn(),
+}));
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  MixedAuthEndpoint: (handler: unknown) => handler,
+  handleEndpointError: (
+    res: { status: (n: number) => { json: (b: unknown) => unknown } },
+    e: unknown
+  ) => res.status(500).json({ message: (e as Error)?.message ?? 'error' }),
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  resolveStoreVisibilityScope: mockResolveScope,
+}));
+vi.mock('~/server/services/blocks/app-listing.service', () => ({
+  listAvailableListings: mockList,
+  getListingDetail: mockDetail,
+}));
+vi.mock('~/server/utils/apps-catalog-rate-limit', () => ({
+  enforceAppsCatalogRateLimit: mockRateLimit,
+}));
+vi.mock('~/server/utils/pagination-helpers', () => ({ getNextPage: mockGetNextPage }));
+vi.mock('~/server/utils/server-domain', () => ({ isHostForColor: mockIsHostForColor }));
+
+import listHandler from '~/pages/api/v1/apps/index';
+import detailHandler from '~/pages/api/v1/apps/[slug]';
+
+type Handler = (req: unknown, res: unknown, user: unknown) => Promise<unknown>;
+
+function createMocks(query: Record<string, string> = {}) {
+  const req = {
+    method: 'GET',
+    url: '/api/v1/apps',
+    query,
+    headers: { host: 'civitai.com' },
+    socket: { remoteAddress: '203.0.113.7' },
+    log: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+  };
+  let statusCode = 200;
+  let payload: unknown;
+  const headers: Record<string, string> = {};
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+/** The listing service is mocked NON-EMPTY on purpose: if the handler ever calls it
+ *  with an absent scope, the catalog appears in the response and the test fails
+ *  loudly rather than passing on an incidentally-empty page. */
+const CATALOG = [
+  { id: 'apl_1', slug: 'onsite-app', kind: 'onsite', name: 'Onsite App' },
+  { id: 'apl_2', slug: 'offsite-app', kind: 'offsite', name: 'Offsite App' },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRateLimit.mockResolvedValue(false);
+  mockIsHostForColor.mockReturnValue(false);
+  mockGetNextPage.mockReturnValue({ nextPage: undefined });
+  mockList.mockResolvedValue({ items: CATALOG, nextCursor: undefined });
+  mockDetail.mockResolvedValue({ id: 'apl_1', serialId: 1, slug: 'onsite-app', kind: 'onsite' });
+});
+
+/** Every runtime shape a "no scope" can arrive as. `undefined` is the one production
+ *  is recorded emitting; the others are the same class and must not be treated as an
+ *  entitlement either. */
+const ABSENT_SCOPES: [string, unknown][] = [
+  ['undefined (the value production records for an anonymous principal)', undefined],
+  ['null', null],
+  ['a string outside the closed set', 'FULL'],
+  ['an empty string', ''],
+  ['a non-string', 0],
+];
+
+describe('GET /api/v1/apps — an absent scope must never widen the catalog (civitai#3983)', () => {
+  it.each(ABSENT_SCOPES)(
+    'resolver yields %s → empty page, and the listing service is NEVER reached',
+    async (_label, scope) => {
+      mockResolveScope.mockResolvedValue(scope);
+      const { req, res } = createMocks();
+      await (listHandler as unknown as Handler)(req, res, undefined);
+
+      expect(res._status()).toBe(200);
+      expect(res._json()).toEqual({
+        items: [],
+        metadata: { nextCursor: undefined, nextPage: undefined },
+      });
+      // The load-bearing half: the handler must short-circuit, not rely on the
+      // service to refuse. Calling it at all is what let `?? 'full'` decide.
+      expect(mockList).not.toHaveBeenCalled();
+    }
+  );
+
+  // POSITIVE CONTROL — without it, "items: []" is indistinguishable from a handler
+  // wired to nothing, and a mutation that closed EVERY scope would pass the block
+  // above while silently taking the store dark for the people entitled to it.
+  it('POSITIVE CONTROL: a resolved `full` still serves the catalog', async () => {
+    mockResolveScope.mockResolvedValue('full');
+    const { req, res } = createMocks();
+    await (listHandler as unknown as Handler)(req, res, undefined);
+
+    expect(mockList).toHaveBeenCalledTimes(1);
+    expect((mockList.mock.calls[0][1] as { scope: string }).scope).toBe('full');
+    expect((res._json() as { items: unknown[] }).items).toHaveLength(2);
+  });
+
+  it('POSITIVE CONTROL: a resolved `public-external` is threaded through unchanged', async () => {
+    mockResolveScope.mockResolvedValue('public-external');
+    const { req, res } = createMocks();
+    await (listHandler as unknown as Handler)(req, res, undefined);
+
+    expect(mockList).toHaveBeenCalledTimes(1);
+    expect((mockList.mock.calls[0][1] as { scope: string }).scope).toBe('public-external');
+  });
+});
+
+describe('GET /api/v1/apps/{slug} — an absent scope must never disclose a listing (civitai#3983)', () => {
+  it.each(ABSENT_SCOPES)(
+    'resolver yields %s → 404, and the detail service is NEVER reached',
+    async (_label, scope) => {
+      mockResolveScope.mockResolvedValue(scope);
+      const { req, res } = createMocks({ slug: 'onsite-app' });
+      await (detailHandler as unknown as Handler)(req, res, undefined);
+
+      expect(res._status()).toBe(404);
+      expect((res._json() as { code: string }).code).toBe('NOT_FOUND');
+      expect(mockDetail).not.toHaveBeenCalled();
+    }
+  );
+
+  it('POSITIVE CONTROL: a resolved `full` still serves the detail', async () => {
+    mockResolveScope.mockResolvedValue('full');
+    const { req, res } = createMocks({ slug: 'onsite-app' });
+    await (detailHandler as unknown as Handler)(req, res, undefined);
+
+    expect(res._status()).toBe(200);
+    expect(mockDetail).toHaveBeenCalledTimes(1);
+    expect((mockDetail.mock.calls[0][1] as { scope: string }).scope).toBe('full');
+  });
+});

--- a/src/tests/api/v1/apps/apps.absent-scope-fail-closed.test.ts
+++ b/src/tests/api/v1/apps/apps.absent-scope-fail-closed.test.ts
@@ -23,10 +23,26 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * returned `full` or `none` — so 75 green store-scope tests coexisted with the bug
  * for its whole life.
  *
- * These tests drive the REAL handlers with the resolver returning exactly what
- * production returns, and assert the handler refuses. They are RED before the
- * `narrowStoreScope` hardening (the list handler serves the mocked catalog; the
- * detail handler serves the mocked listing) and green after.
+ * ## 🔴 WHAT "FAIL CLOSED" MEANS AT A PUBLIC ENDPOINT — read before editing
+ *
+ * These two REST endpoints are a PUBLIC catalog by decision (see
+ * `~/server/services/blocks/public-apps-catalog`): a caller who resolves no scope
+ * of their own is served the catalog on purpose. So the invariant here is NOT "an
+ * absent scope yields nothing" — at this surface, a resolved `none` does not yield
+ * nothing either. The invariant is the one #3983 actually violated:
+ *
+ *   🔴 AN ABSENT SCOPE MUST NEVER BUY MORE THAN A CORRECTLY-RESOLVED `none`.
+ *
+ * That is what was broken: absent → `full` while resolved-`none` → empty, from the
+ * same request, differing only in whether the resolver worked. It is pinned below as
+ * an EQUIVALENCE (identical response and identical service call for both), plus the
+ * withheld configuration (kill switch on), where both must produce nothing at all.
+ * The absent value never gets its own branch, so there is nothing for it to widen.
+ *
+ * Everywhere OUTSIDE these two handlers the stronger rule still holds verbatim and
+ * is pinned by its own suites: `narrowStoreScope` (`shared/utils/__tests__/`), the
+ * listing service's `none`-means-FALSE predicate (`app-listing.public-scope.test.ts`)
+ * and the tRPC branch point. None of them is touched by the public grant.
  *
  * ## What this suite structurally CANNOT see
  *
@@ -36,6 +52,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  *   upstream is still open; see the issue.
  * - The compiled production artifact. This runs the TypeScript source under vitest,
  *   and the same source resolves `none` correctly here while production does not.
+ *   Nothing in this file is evidence about what the live endpoint serves.
  * - The tRPC branch point (`applyStoreScope`) — covered by the router suites.
  */
 
@@ -46,6 +63,7 @@ const {
   mockRateLimit,
   mockGetNextPage,
   mockIsHostForColor,
+  mockIsFlipt,
 } = vi.hoisted(() => ({
   mockResolveScope: vi.fn(),
   mockList: vi.fn(),
@@ -53,6 +71,7 @@ const {
   mockRateLimit: vi.fn(),
   mockGetNextPage: vi.fn(),
   mockIsHostForColor: vi.fn(),
+  mockIsFlipt: vi.fn(),
 }));
 
 vi.mock('~/server/utils/endpoint-helpers', () => ({
@@ -74,6 +93,12 @@ vi.mock('~/server/utils/apps-catalog-rate-limit', () => ({
 }));
 vi.mock('~/server/utils/pagination-helpers', () => ({ getNextPage: mockGetNextPage }));
 vi.mock('~/server/utils/server-domain', () => ({ isHostForColor: mockIsHostForColor }));
+// The public-catalog kill switch is a Flipt flag; spread the real module so this
+// mock does not go silently stale if the decision reads another export.
+vi.mock('~/server/flipt/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isFlipt: mockIsFlipt,
+}));
 
 import listHandler from '~/pages/api/v1/apps/index';
 import detailHandler from '~/pages/api/v1/apps/[slug]';
@@ -128,6 +153,8 @@ beforeEach(() => {
   mockGetNextPage.mockReturnValue({ nextPage: undefined });
   mockList.mockResolvedValue({ items: CATALOG, nextCursor: undefined });
   mockDetail.mockResolvedValue({ id: 'apl_1', serialId: 1, slug: 'onsite-app', kind: 'onsite' });
+  // Kill switch OFF — its absent/dark state, and the as-merged production config.
+  mockIsFlipt.mockResolvedValue(false);
 });
 
 /** Every runtime shape a "no scope" can arrive as. `undefined` is the one production
@@ -141,69 +168,140 @@ const ABSENT_SCOPES: [string, unknown][] = [
   ['a non-string', 0],
 ];
 
-describe('GET /api/v1/apps — an absent scope must never widen the catalog (civitai#3983)', () => {
-  it.each(ABSENT_SCOPES)(
-    'resolver yields %s → empty page, and the listing service is NEVER reached',
-    async (_label, scope) => {
-      mockResolveScope.mockResolvedValue(scope);
-      const { req, res } = createMocks();
-      await (listHandler as unknown as Handler)(req, res, undefined);
+/** Drive the LIST handler once for a given resolver answer; return what came out. */
+async function callList(scope: unknown) {
+  mockResolveScope.mockResolvedValue(scope);
+  const { req, res } = createMocks();
+  await (listHandler as unknown as Handler)(req, res, undefined);
+  return {
+    status: res._status(),
+    body: res._json(),
+    serviceCalls: mockList.mock.calls.map((c) => c[1]),
+  };
+}
 
-      expect(res._status()).toBe(200);
-      expect(res._json()).toEqual({
+/** Drive the DETAIL handler once for a given resolver answer. */
+async function callDetail(scope: unknown) {
+  mockResolveScope.mockResolvedValue(scope);
+  const { req, res } = createMocks({ slug: 'onsite-app' });
+  await (detailHandler as unknown as Handler)(req, res, undefined);
+  return {
+    status: res._status(),
+    body: res._json(),
+    serviceCalls: mockDetail.mock.calls.map((c) => c[1]),
+  };
+}
+
+describe('GET /api/v1/apps — an absent scope must never buy more than a resolved `none` (civitai#3983)', () => {
+  it.each(ABSENT_SCOPES)(
+    'resolver yields %s → EXACTLY what a resolved `none` yields (response AND service call)',
+    async (_label, scope) => {
+      const absent = await callList(scope);
+      vi.clearAllMocks();
+      mockRateLimit.mockResolvedValue(false);
+      mockIsHostForColor.mockReturnValue(false);
+      mockGetNextPage.mockReturnValue({ nextPage: undefined });
+      mockList.mockResolvedValue({ items: CATALOG, nextCursor: undefined });
+      mockIsFlipt.mockResolvedValue(false);
+      const none = await callList('none');
+
+      // The whole of #3983 in one assertion: these two differ only in whether the
+      // resolver produced a value, and they must be indistinguishable downstream.
+      expect(absent.status).toEqual(none.status);
+      expect(absent.body).toEqual(none.body);
+      expect(absent.serviceCalls).toEqual(none.serviceCalls);
+    }
+  );
+
+  it.each(ABSENT_SCOPES)(
+    'KILL SWITCH ON — resolver yields %s → empty page, and the listing service is NEVER reached',
+    async (_label, scope) => {
+      mockIsFlipt.mockResolvedValue(true);
+      const res = await callList(scope);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
         items: [],
         metadata: { nextCursor: undefined, nextPage: undefined },
       });
       // The load-bearing half: the handler must short-circuit, not rely on the
       // service to refuse. Calling it at all is what let `?? 'full'` decide.
-      expect(mockList).not.toHaveBeenCalled();
+      expect(res.serviceCalls).toEqual([]);
     }
   );
 
-  // POSITIVE CONTROL — without it, "items: []" is indistinguishable from a handler
-  // wired to nothing, and a mutation that closed EVERY scope would pass the block
-  // above while silently taking the store dark for the people entitled to it.
-  it('POSITIVE CONTROL: a resolved `full` still serves the catalog', async () => {
-    mockResolveScope.mockResolvedValue('full');
-    const { req, res } = createMocks();
-    await (listHandler as unknown as Handler)(req, res, undefined);
+  // POSITIVE CONTROL — without it, "items: []" above is indistinguishable from a
+  // handler wired to nothing, and a mutation that closed EVERY scope would pass the
+  // block above while silently taking the catalog dark for everyone.
+  it('POSITIVE CONTROL: with the switch ON, a resolved `full` is STILL served (privileged callers are untouched)', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    const res = await callList('full');
 
-    expect(mockList).toHaveBeenCalledTimes(1);
-    expect((mockList.mock.calls[0][1] as { scope: string }).scope).toBe('full');
-    expect((res._json() as { items: unknown[] }).items).toHaveLength(2);
+    expect(res.serviceCalls).toEqual([expect.objectContaining({ scope: 'full' })]);
+    expect((res.body as { items: unknown[] }).items).toHaveLength(2);
   });
 
   it('POSITIVE CONTROL: a resolved `public-external` is threaded through unchanged', async () => {
-    mockResolveScope.mockResolvedValue('public-external');
-    const { req, res } = createMocks();
-    await (listHandler as unknown as Handler)(req, res, undefined);
+    const res = await callList('public-external');
+    expect(res.serviceCalls).toEqual([expect.objectContaining({ scope: 'public-external' })]);
+  });
 
-    expect(mockList).toHaveBeenCalledTimes(1);
-    expect((mockList.mock.calls[0][1] as { scope: string }).scope).toBe('public-external');
+  // The PUBLIC half, and the reason this endpoint may merge: while the resolver
+  // defect persists in production, an absent scope must still leave the public
+  // catalog SERVED rather than empty. Red before the public-catalog grant.
+  it('the public grant applies to an absent scope too — the endpoint does NOT go dark on a resolver failure', async () => {
+    const res = await callList(undefined);
+    expect(res.serviceCalls).toEqual([expect.objectContaining({ scope: 'full' })]);
+    expect((res.body as { items: unknown[] }).items).toHaveLength(2);
   });
 });
 
-describe('GET /api/v1/apps/{slug} — an absent scope must never disclose a listing (civitai#3983)', () => {
+describe('GET /api/v1/apps/{slug} — an absent scope must never buy more than a resolved `none` (civitai#3983)', () => {
   it.each(ABSENT_SCOPES)(
-    'resolver yields %s → 404, and the detail service is NEVER reached',
+    'resolver yields %s → EXACTLY what a resolved `none` yields (response AND service call)',
     async (_label, scope) => {
-      mockResolveScope.mockResolvedValue(scope);
-      const { req, res } = createMocks({ slug: 'onsite-app' });
-      await (detailHandler as unknown as Handler)(req, res, undefined);
+      const absent = await callDetail(scope);
+      vi.clearAllMocks();
+      mockRateLimit.mockResolvedValue(false);
+      mockIsHostForColor.mockReturnValue(false);
+      mockDetail.mockResolvedValue({
+        id: 'apl_1',
+        serialId: 1,
+        slug: 'onsite-app',
+        kind: 'onsite',
+      });
+      mockIsFlipt.mockResolvedValue(false);
+      const none = await callDetail('none');
 
-      expect(res._status()).toBe(404);
-      expect((res._json() as { code: string }).code).toBe('NOT_FOUND');
-      expect(mockDetail).not.toHaveBeenCalled();
+      expect(absent.status).toEqual(none.status);
+      expect(absent.body).toEqual(none.body);
+      expect(absent.serviceCalls).toEqual(none.serviceCalls);
     }
   );
 
-  it('POSITIVE CONTROL: a resolved `full` still serves the detail', async () => {
-    mockResolveScope.mockResolvedValue('full');
-    const { req, res } = createMocks({ slug: 'onsite-app' });
-    await (detailHandler as unknown as Handler)(req, res, undefined);
+  it.each(ABSENT_SCOPES)(
+    'KILL SWITCH ON — resolver yields %s → 404, and the detail service is NEVER reached',
+    async (_label, scope) => {
+      mockIsFlipt.mockResolvedValue(true);
+      const res = await callDetail(scope);
 
-    expect(res._status()).toBe(200);
-    expect(mockDetail).toHaveBeenCalledTimes(1);
-    expect((mockDetail.mock.calls[0][1] as { scope: string }).scope).toBe('full');
+      expect(res.status).toBe(404);
+      expect((res.body as { code: string }).code).toBe('NOT_FOUND');
+      expect(res.serviceCalls).toEqual([]);
+    }
+  );
+
+  it('POSITIVE CONTROL: with the switch ON, a resolved `full` still serves the detail', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    const res = await callDetail('full');
+
+    expect(res.status).toBe(200);
+    expect(res.serviceCalls).toEqual([expect.objectContaining({ scope: 'full' })]);
+  });
+
+  it('the public grant applies to an absent scope too — the detail endpoint does NOT start 404ing on a resolver failure', async () => {
+    const res = await callDetail(undefined);
+    expect(res.status).toBe(200);
+    expect(res.serviceCalls).toEqual([expect.objectContaining({ scope: 'full' })]);
   });
 });

--- a/src/tests/api/v1/apps/apps.test.ts
+++ b/src/tests/api/v1/apps/apps.test.ts
@@ -7,11 +7,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  *
  * The security crux is the DEFAULT-CLOSED per-user scope gate: an anonymous /
  * non-privileged caller resolves scope `none` and MUST receive the empty page /
- * 404 — NEVER the full catalog — even though the underlying listing service
- * defaults to `full`. The load-bearing guards (`does NOT leak the catalog to
- * anon`) mock the service to return NON-empty data and assert the handler still
- * returns nothing for an unscoped caller, so deleting the scope wiring fails the
- * test.
+ * 404 — NEVER the full catalog. The load-bearing guards (`does NOT leak the
+ * catalog to anon`) mock the service to return NON-empty data and assert the
+ * handler still returns nothing for an unscoped caller, so deleting the scope
+ * wiring fails the test.
+ *
+ * 🔴 WHAT THIS SUITE STRUCTURALLY CANNOT SEE, and did not see for the whole life of
+ * civitai#3983: its resolver mock only ever returns `full` or `none`, so the case
+ * production actually hit — the resolver returning NOTHING — is not exercised here
+ * at all. The listing service used to turn that missing value into `full`. The
+ * absent-scope cases live in `apps.absent-scope-fail-closed.test.ts`; keep them
+ * there rather than assuming this suite covers them.
  */
 
 const {
@@ -32,8 +38,10 @@ const {
 
 vi.mock('~/server/utils/endpoint-helpers', () => ({
   MixedAuthEndpoint: (handler: unknown) => handler,
-  handleEndpointError: (res: { status: (n: number) => { json: (b: unknown) => unknown } }, e: unknown) =>
-    res.status(500).json({ message: (e as Error)?.message ?? 'error' }),
+  handleEndpointError: (
+    res: { status: (n: number) => { json: (b: unknown) => unknown } },
+    e: unknown
+  ) => res.status(500).json({ message: (e as Error)?.message ?? 'error' }),
 }));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   resolveStoreVisibilityScope: mockResolveScope,
@@ -231,10 +239,12 @@ describe('GET /api/v1/apps (list)', () => {
   });
 
   it('429 when rate-limited: the limiter short-circuits before any scope/service work', async () => {
-    mockRateLimit.mockImplementationOnce(async ({ res }: { res: { status: (n: number) => { json: (b: unknown) => unknown } } }) => {
-      res.status(429).json({ message: 'Rate limit exceeded' });
-      return true;
-    });
+    mockRateLimit.mockImplementationOnce(
+      async ({ res }: { res: { status: (n: number) => { json: (b: unknown) => unknown } } }) => {
+        res.status(429).json({ message: 'Rate limit exceeded' });
+        return true;
+      }
+    );
     const { req, res } = createMocks();
     await (listHandler as unknown as Handler)(req, res, MOD);
     expect(res._status()).toBe(429);
@@ -287,16 +297,21 @@ describe('GET /api/v1/apps/{slug} (detail)', () => {
   });
 
   it('invalid/expired token → anonymous → 404 (not a 500)', async () => {
-    const { req, res } = createMocks({ query: { slug: 'my-app' }, headers: { authorization: 'Bearer garbage' } });
+    const { req, res } = createMocks({
+      query: { slug: 'my-app' },
+      headers: { authorization: 'Bearer garbage' },
+    });
     await (detailHandler as unknown as Handler)(req, res, undefined);
     expect(res._status()).toBe(404);
   });
 
   it('429 when rate-limited: short-circuits before scope/service', async () => {
-    mockRateLimit.mockImplementationOnce(async ({ res }: { res: { status: (n: number) => { json: (b: unknown) => unknown } } }) => {
-      res.status(429).json({ message: 'Rate limit exceeded' });
-      return true;
-    });
+    mockRateLimit.mockImplementationOnce(
+      async ({ res }: { res: { status: (n: number) => { json: (b: unknown) => unknown } } }) => {
+        res.status(429).json({ message: 'Rate limit exceeded' });
+        return true;
+      }
+    );
     const { req, res } = createMocks({ query: { slug: 'my-app' } });
     await (detailHandler as unknown as Handler)(req, res, MOD);
     expect(res._status()).toBe(429);

--- a/src/tests/api/v1/apps/apps.test.ts
+++ b/src/tests/api/v1/apps/apps.test.ts
@@ -5,19 +5,26 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  *   - GET /api/v1/apps          (list + filter, keyset paginated)
  *   - GET /api/v1/apps/{slug}   (single detail)
  *
- * The security crux is the DEFAULT-CLOSED per-user scope gate: an anonymous /
- * non-privileged caller resolves scope `none` and MUST receive the empty page /
- * 404 — NEVER the full catalog. The load-bearing guards (`does NOT leak the
- * catalog to anon`) mock the service to return NON-empty data and assert the
- * handler still returns nothing for an unscoped caller, so deleting the scope
- * wiring fails the test.
+ * These endpoints are a PUBLIC catalog by decision: a caller who resolves no scope
+ * of their own — anonymous or merely non-privileged — is served the catalog under
+ * the deliberate grant in `~/server/services/blocks/public-apps-catalog`, and an
+ * operator kill switch is the one thing that takes it away. A caller who DOES
+ * resolve a scope (`full` for a mod / app-dev-tester, `public-external` for the
+ * external-only cohort) keeps it verbatim, and the scope is threaded EXPLICITLY
+ * into the listing service on every path — the guards below mock the service to
+ * return NON-empty data so a handler that stopped threading the scope, or stopped
+ * honouring the kill switch, fails rather than passing on an incidentally-empty
+ * page.
  *
- * 🔴 WHAT THIS SUITE STRUCTURALLY CANNOT SEE, and did not see for the whole life of
- * civitai#3983: its resolver mock only ever returns `full` or `none`, so the case
- * production actually hit — the resolver returning NOTHING — is not exercised here
- * at all. The listing service used to turn that missing value into `full`. The
- * absent-scope cases live in `apps.absent-scope-fail-closed.test.ts`; keep them
- * there rather than assuming this suite covers them.
+ * 🔴 WHAT THIS SUITE STRUCTURALLY CANNOT SEE — twice over:
+ *   - its resolver mock returns only `full`, `public-external` or `none`, so the
+ *     case production actually hit (civitai#3983: the resolver returning NOTHING)
+ *     is not exercised here at all. Those cases live in
+ *     `apps.absent-scope-fail-closed.test.ts`; keep them there rather than assuming
+ *     this suite covers them.
+ *   - every scope, flag and service answer here is a MOCK, so nothing in this file
+ *     can attest that the live endpoint serves anything. It pins what the handler
+ *     does with an answer, never what the answer is in production.
  */
 
 const {
@@ -27,6 +34,7 @@ const {
   mockRateLimit,
   mockGetNextPage,
   mockIsHostForColor,
+  mockIsFlipt,
 } = vi.hoisted(() => ({
   mockResolveScope: vi.fn(),
   mockList: vi.fn(),
@@ -34,6 +42,7 @@ const {
   mockRateLimit: vi.fn(),
   mockGetNextPage: vi.fn(),
   mockIsHostForColor: vi.fn(),
+  mockIsFlipt: vi.fn(),
 }));
 
 vi.mock('~/server/utils/endpoint-helpers', () => ({
@@ -59,7 +68,15 @@ vi.mock('~/server/utils/pagination-helpers', () => ({
 vi.mock('~/server/utils/server-domain', () => ({
   isHostForColor: mockIsHostForColor,
 }));
+// The public-catalog KILL SWITCH is a Flipt flag, so the flag client is the seam.
+// Spread the real module (rather than replacing it) so this stays honest if the
+// decision module ever reads another export from it.
+vi.mock('~/server/flipt/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof FliptClient>()),
+  isFlipt: mockIsFlipt,
+}));
 
+import type * as FliptClient from '~/server/flipt/client';
 import listHandler from '~/pages/api/v1/apps/index';
 import detailHandler from '~/pages/api/v1/apps/[slug]';
 
@@ -120,33 +137,63 @@ beforeEach(() => {
     baseUrl: new URL('http://localhost/api/v1/apps'),
     nextPage: nextCursor ? `http://localhost/api/v1/apps?cursor=${nextCursor}` : undefined,
   }));
-  // Default identity scope: mods → full, everyone else → none (the pre-launch default).
+  // Default identity scope: mods → full, everyone else → none (they then meet the
+  // public-catalog grant, which is what makes these endpoints public).
   mockResolveScope.mockImplementation(async ({ user }: { user?: { isModerator?: boolean } }) =>
     user?.isModerator ? 'full' : 'none'
   );
+  // The kill switch is a DISABLE flag: `false` is its absent/dark state and means
+  // the public catalog is OPEN. This mirrors what `isFlipt` returns for a flag that
+  // does not exist — which is the as-merged production configuration.
+  mockIsFlipt.mockResolvedValue(false);
   mockList.mockResolvedValue({ items: [card('a'), card('b')], nextCursor: undefined });
   mockDetail.mockResolvedValue(detail('a'));
 });
 
 describe('GET /api/v1/apps (list)', () => {
-  it('SECURITY: anonymous caller gets the CLOSED scope — empty page, NOT the full catalog', async () => {
-    // The service is mocked to ALWAYS return items; the handler must still return
-    // empty for an unscoped (anon) caller. This fails if the scope gate is removed.
-    mockList.mockResolvedValue({ items: [card('leak-a'), card('leak-b')], nextCursor: 'x' });
+  // 🔴 PUBLIC BY DECISION. An anonymous caller resolves `none` of their own and is
+  // then served the catalog by the deliberate grant. This is the assertion that
+  // fails if someone removes the grant, so the endpoint cannot silently go dark
+  // again — which is exactly what merging the #4041 hardening alone would have done
+  // to a live public URL.
+  it('PUBLIC GRANT: an anonymous caller is served the catalog, under an explicit `full` scope', async () => {
     const { req, res } = createMocks();
     await (listHandler as unknown as Handler)(req, res, undefined);
     expect(res._status()).toBe(200);
-    expect((res._json() as { items: unknown[] }).items).toEqual([]);
-    // The catalog service is never consulted for a `none` scope.
-    expect(mockList).not.toHaveBeenCalled();
+    expect((res._json() as { items: unknown[] }).items).toHaveLength(2);
+    // Threaded EXPLICITLY — never left to a service-side default (civitai#3983).
+    expect(mockList).toHaveBeenCalledTimes(1);
+    expect(mockList.mock.calls[0][1]).toMatchObject({ scope: 'full' });
   });
 
-  it('SECURITY: a normal (non-privileged) authed user also gets the closed scope', async () => {
-    mockList.mockResolvedValue({ items: [card('leak')], nextCursor: undefined });
+  it('PUBLIC GRANT: a normal (non-privileged) authed user is served the same public catalog', async () => {
     const { req, res } = createMocks();
     await (listHandler as unknown as Handler)(req, res, NORMAL);
-    expect((res._json() as { items: unknown[] }).items).toEqual([]);
-    expect(mockList).not.toHaveBeenCalled();
+    expect(res._status()).toBe(200);
+    expect((res._json() as { items: unknown[] }).items).toHaveLength(2);
+    expect(mockList.mock.calls[0][1]).toMatchObject({ scope: 'full' });
+  });
+
+  // The KILL SWITCH, asserted as a DISCRIMINATION rather than as one state: both
+  // arms run in one test against one mocked catalog, so a handler that ignores the
+  // switch fails the OFF→ON arm and a handler that serves nothing fails the ON→OFF
+  // arm. Asserting only the "switch on → empty" half would pass on a handler that
+  // is simply dark, which is the regression this whole change exists to prevent.
+  it('KILL SWITCH discriminates: OFF → the catalog; ON → an empty page and the service is never reached', async () => {
+    mockList.mockResolvedValue({ items: [card('a'), card('b')], nextCursor: 'x' });
+
+    mockIsFlipt.mockResolvedValue(false);
+    const open = createMocks();
+    await (listHandler as unknown as Handler)(open.req, open.res, undefined);
+    expect((open.res._json() as { items: unknown[] }).items).toHaveLength(2);
+
+    mockIsFlipt.mockResolvedValue(true);
+    const shut = createMocks();
+    await (listHandler as unknown as Handler)(shut.req, shut.res, undefined);
+    expect(shut.res._status()).toBe(200);
+    expect((shut.res._json() as { items: unknown[] }).items).toEqual([]);
+    // Withheld means SHORT-CIRCUITED, not "the service returned nothing".
+    expect(mockList).toHaveBeenCalledTimes(1);
   });
 
   it('a mod (full scope) gets the catalog — service called WITH the resolved scope', async () => {
@@ -218,13 +265,13 @@ describe('GET /api/v1/apps (list)', () => {
     expect(opts).toMatchObject({ redCapable: true });
   });
 
-  it('invalid/expired token → treated as anonymous (no 500): user undefined → empty page', async () => {
-    // MixedAuthEndpoint resolves an invalid bearer to `undefined`; the handler
-    // must treat that as anon (empty), never crash.
+  it('invalid/expired token → treated as anonymous (no 500): the public catalog, never a crash', async () => {
+    // MixedAuthEndpoint resolves an invalid bearer to `undefined`; the handler must
+    // treat that as anon — i.e. the public grant applies — never as an error.
     const { req, res } = createMocks({ headers: { authorization: 'Bearer garbage' } });
     await (listHandler as unknown as Handler)(req, res, undefined);
     expect(res._status()).toBe(200);
-    expect((res._json() as { items: unknown[] }).items).toEqual([]);
+    expect((res._json() as { items: unknown[] }).items).toHaveLength(2);
   });
 
   it('400 on an out-of-range limit', async () => {
@@ -261,13 +308,31 @@ describe('GET /api/v1/apps (list)', () => {
 });
 
 describe('GET /api/v1/apps/{slug} (detail)', () => {
-  it('SECURITY: an out-of-scope (anon) caller gets 404, and the service is never called', async () => {
-    // Service mocked to return a real listing; the scope gate must still 404.
-    mockDetail.mockResolvedValue(detail('secret-app'));
-    const { req, res } = createMocks({ query: { slug: 'secret-app' } });
+  // 🔴 PUBLIC BY DECISION — the detail sibling of the list guard above. Fails if the
+  // grant is removed, so `/api/v1/apps/{slug}` cannot silently start 404ing.
+  it('PUBLIC GRANT: an anonymous caller is served the detail, under an explicit `full` scope', async () => {
+    const { req, res } = createMocks({ query: { slug: 'my-app' } });
     await (detailHandler as unknown as Handler)(req, res, undefined);
-    expect(res._status()).toBe(404);
-    expect(mockDetail).not.toHaveBeenCalled();
+    expect(res._status()).toBe(200);
+    expect(mockDetail).toHaveBeenCalledWith(
+      { slug: 'my-app' },
+      expect.objectContaining({ scope: 'full' })
+    );
+  });
+
+  it('KILL SWITCH discriminates: OFF → 200 with the detail; ON → 404 and the service is never reached', async () => {
+    mockDetail.mockResolvedValue(detail('secret-app'));
+
+    mockIsFlipt.mockResolvedValue(false);
+    const open = createMocks({ query: { slug: 'secret-app' } });
+    await (detailHandler as unknown as Handler)(open.req, open.res, undefined);
+    expect(open.res._status()).toBe(200);
+
+    mockIsFlipt.mockResolvedValue(true);
+    const shut = createMocks({ query: { slug: 'secret-app' } });
+    await (detailHandler as unknown as Handler)(shut.req, shut.res, undefined);
+    expect(shut.res._status()).toBe(404);
+    expect(mockDetail).toHaveBeenCalledTimes(1);
   });
 
   it('found in scope → 200 with the detail + manifest-derived fields', async () => {
@@ -296,13 +361,13 @@ describe('GET /api/v1/apps/{slug} (detail)', () => {
     expect(mockDetail).not.toHaveBeenCalled();
   });
 
-  it('invalid/expired token → anonymous → 404 (not a 500)', async () => {
+  it('invalid/expired token → anonymous → served under the public grant (not a 500)', async () => {
     const { req, res } = createMocks({
       query: { slug: 'my-app' },
       headers: { authorization: 'Bearer garbage' },
     });
     await (detailHandler as unknown as Handler)(req, res, undefined);
-    expect(res._status()).toBe(404);
+    expect(res._status()).toBe(200);
   });
 
   it('429 when rate-limited: short-circuits before scope/service', async () => {


### PR DESCRIPTION
Closes the exploitable half of #3983 and pins it. **It does not identify why the resolver's value goes missing** — that hunt is written up below with what it eliminated, because a guess presented as a diagnosis would be worse than saying so.

---

## 🔴 Read first: this is now ONE mergeable unit — no window where the public API is empty

An earlier revision of this PR would have taken `GET /api/v1/apps` from **14 items (10 `onsite` + 4 `offsite`)** to an **empty page** for an anonymous caller, and `GET /api/v1/apps/{slug}` to a **404**. That is no longer true, and merging no longer needs a flag flipped first.

Public REST catalog access is **intended product behaviour** (confirmed with the operator). What was wrong was not that the catalog is public — it is that its public reach was produced by a *failure*: the resolver yielded no scope, and the listing service's `?? 'full'` turned that missing value into the whole catalog. Removing the `??` without replacing the intent is a regression of a live public URL.

So this PR now carries **both halves**:

1. **fail closed everywhere** — an absent / uninterpretable scope becomes `none`, never an entitlement (unchanged from the original commit);
2. **grant the public catalog on purpose** — a new, dedicated decision in `~/server/services/blocks/public-apps-catalog`, applied at the two REST handlers only.

Net effect for a caller today: **byte-identical to what production already serves.** Same 14 items, both kinds, anonymously.

---

## The public-catalog grant — why it is its own axis

🔴 **It is deliberately NOT a store flag, and not `hasAppsStoreAccess`.** That predicate is `appListings || appBlocks || appListingsPublicExternal`, and it gates the `/apps` **page** as well as the read scope. Granting public REST access by enabling any of those three — or by reusing the predicate — would also open `/apps` to every visitor, i.e. launch the store. Today's actual state (catalog public over the API, `/apps` dark for anonymous) is reachable by **no** combination of those flags; it exists only because of the bug. This makes it reachable deliberately.

`resolvePublicAppsCatalogScope(resolved, entrypoint)`:

| step | behaviour |
|---|---|
| 1 | **narrow first** — this PR's `narrowStoreScope` rule, unchanged: anything uninterpretable is `none` |
| 2 | a caller who resolved a real scope (`full` for a mod / app-dev-tester, `public-external` for the external-only cohort) is returned **verbatim**, short-circuiting *before* the kill switch is even read |
| 3 | everyone else gets the public catalog (`full`), unless an operator has withheld it |

**Kill switch: `apps-public-catalog-disabled` — a DISABLE flag, on purpose.** `isFlipt` returns `false` for a flag that does not exist and for an unreachable Flipt, so the switch's absent/dark/broken state is *"public access stays on"*. An enable-shaped flag would have emptied the live endpoint in the window between this merging and someone creating the flag — re-creating the very regression the grant exists to prevent. **The flag does not exist in Flipt and does not need to; there is no companion `flipt-state` PR gating this merge.** To throw it, create it as a plain base-`enabled: true` boolean (no segments, no percentage rollout — it is evaluated globally, because these callers are unauthenticated and carry no context).

New counter `civitai_app_store_public_catalog_decisions_total{outcome,entrypoint}` (`granted|withheld|privileged`) — the only signal that says whether the public catalog is actually open.

### The fail-closed invariant, restated for a public surface

#3983's exploit was **not** that anonymous callers can read the catalog. It was that an **absent** scope produced a **wider** answer than a resolved one — `full` vs empty, from the same request, differing only in whether the resolver worked. Step 1 collapses that: absent and `none` are the same input to the same decision, so no failure of the resolver can widen these endpoints past what the grant already, deliberately, allows. Every other consumer — both listing-service entry points and the three store tRPC procs — is untouched and still fails closed to nothing. `/apps` remains 404 for an anonymous viewer, asserted behaviourally.

---

## What production actually does — measured from outside, without the counters

Anonymously, within one minute, interleaved, with cache-busted requests confirmed to reach the origin rather than the CDN:

| entry point | result | runs |
|---|---|---|
| `GET /api/v1/apps?limit=<distinct>` | **14 items, 10 `onsite`** | 8/8 |
| `GET /api/trpc/appListings.listAvailable` | **`items: []`** | 8/8 |

Both call `resolveStoreVisibilityScope({ user: undefined })` with the **same argument**, and both branch on the result. `GET /apps` **404s** for an anonymous viewer, and `hasAppsStoreAccess` is `appListings || appBlocks || appListingsPublicExternal` — so no store flag is base-enabled, and a correctly-resolved anonymous scope can only be `none`.

**No single resolved scope explains both answers:**

- `none` → the REST list would be empty. It has 14 items.
- `full` → the tRPC list would have 14 items. It is empty.
- `public-external` → the REST list would drop the 10 on-site rows. It keeps them.

The only value consistent with both is a **missing** one, split by two defaults pointing opposite ways:

```
listAvailableListings / getListingDetail   opts.scope ?? 'full'    → the whole catalog
the three store tRPC procs                 _storeScope ?? 'none'   → an empty store
```

This is an independent, black-box confirmation of the #3985 counters, which say the same thing from two separate recording sites: `store_scope_resolutions_total{principal="anon", scope="undefined"}` at the resolver, and `store_scope_applied_total{entrypoint="rest-list"|"rest-detail", scope="absent"}` at each REST branch. **The metric is not lying** — that was worth checking early, and it checks out.

Also ruled out along the way:

- **Per-instance Flipt-client divergence.** The split is 100% by entry point and 0% by serving instance — every response was attributable to a different origin instance of the same build, and the answer never varied within an entry point. If it were client state, results would mix *within* an entry point.
- **The tRPC ctx-plumbing theory** (resolver fine, `_storeScope` lost in transit). The counters show `store_scope_applied_total{entrypoint="trpc-list", scope="full"}` moving on a moderator stimulus, so the middleware→procedure ctx transport demonstrably delivers a real scope. If the resolver returned `full` for anon, tRPC would have served 14 items.
- **A stale artifact.** The serving build corresponds to the current `origin/release` tip, and `git diff origin/release origin/main` is empty for every file involved. The REST scope gate has existed since the endpoint was introduced — there is no gate-less version to be running.

## What is still open: *why* the value is missing

`resolveStoreVisibilityScope` returns a string literal on every path and cannot return `undefined` by inspection. Driving the **real** resolver over the **real** Flipt client (the #3985 fixture harness) for the anonymous case returns `'none'`, and running the **real REST handler** end to end over that resolver returns `{items: []}` without ever reaching the listing service. So the mechanism does not reproduce from source, and I could not name it. What I can say precisely:

- it is **specific to the anonymous branch** (a moderator resolves `full` correctly, on both entry points);
- the anonymous branch is the only one that evaluates *both* flag axes and reaches the final `return 'none'`;
- it is **deterministic**, not racy.

The cheapest next probe, for whoever can read the metrics backend: alert on / read `store_scope_resolutions_total{scope!~"full|public-external|none"}`. prom-client renders the raw label verbatim, so `undefined`, `[object Promise]` and an unrecognized string are three distinct series — which separates "no value" from "an unawaited promise" from "a value this build does not recognize" without another deploy. This PR deliberately keeps that signal alive (see below).

## The change

**One rule, one place.** New dependency-free `~/shared/utils/store-visibility-scope` owns the closed value set, a runtime membership test, and the single narrowing rule: anything that is not exactly `full | public-external | none` becomes **`none`**, never `full`.

Applied at **all four branch points that can widen access**, replacing three independently-written defaults that disagreed:

| site | before | after |
|---|---|---|
| `listAvailableListings` | `opts.scope ?? 'full'` | `narrowStoreScope(opts.scope)` |
| `getListingDetail` | `opts.scope ?? 'full'` | `narrowStoreScope(opts.scope)` |
| `GET /api/v1/apps` + `/{slug}` | `if (scope === 'none')` — a **negative** test that admits every non-`none` value, `undefined` included | narrow first, so the branch is an allowlist over the closed set |
| tRPC `applyStoreScope` | `raw ?? 'none'` (already closed for nullish) | `narrowStoreScope(raw)` — also closed for a value outside the set |

Either the service-side or the handler-side hardening **alone** would have prevented the anonymous full-catalog behaviour. Both are here so a new consumer inherits the direction instead of re-deriving it — that re-derivation is what produced the disagreement in the first place.

`resolveStoreVisibilityScope` now enforces its own declared return type at runtime, **after** recording the raw value. Ordering is load-bearing: the counter is the only instrument that can say what the resolver actually produced, and narrowing before recording would erase the observation this whole investigation rests on. No extra log is emitted — this runs on an unauthenticated public endpoint and the counter already carries the discriminator.

## Test matrix — the fail-closed commit (red at `d3a66f58f1`, green at `c6a0544a45`)

⚠️ Measured **as of `c6a0544a45`**, before the public-catalog grant. The REST-handler half of it has since been restated (see the next section): at those two endpoints the invariant is now the *equivalence* — an absent scope must not buy more than a resolved `none` — rather than “absent yields nothing”, because a resolved `none` no longer yields nothing there either. The listing-service and tRPC halves are unchanged and still assert the strict form.

Same test files, source reverted to the branch base:

```
RED  @ d3a66f58f1 : 17 failed / 54            (base source, new tests)
GREEN@ c6a0544a45 : 54 passed
```

The 17:

- **10** in `apps.absent-scope-fail-closed.test.ts` — the REST handlers served the mocked catalog / the mocked listing when the resolver yields `undefined`, `null`, `''`, a non-string, or an unrecognized string.
- **3** in `listAvailableListings` — the keyset `WHERE` carried `TRUE` instead of `FALSE` for an omitted / `undefined` / `null` scope.
- **4** in `getListingDetail` — an approved on-site listing was projected and returned for the same inputs, *and the DB was reached*.

Honest notes on that matrix:

- Two of the parameterised list cases (`'FULL'`, a non-string) were **already green at base** — not nullish, so `??` never fired and `listingPublicVisibilityFilter` fell through to `FALSE`. They are **invariant guards**, not regression coverage; the regression cases are the nullish ones.
- The `narrowStoreScope` call **inside the resolver** is defense-in-depth and is **not reachable** from any input the module accepts — it exists because production contradicts the source. Labelled as such rather than counted as covered. The four consumer-side guards are reachable and mutation-tested.
- **Mutation check:** flipping `narrowStoreScope`'s fallback from `'none'` to `'full'` kills **30 tests across all three suites** — the guard is load-bearing at every consumer, not just declared.

Also: two existing tests **codified the fail-open default** and are replaced by their inverse. One of them, `no scope passed → defaults to full`, asserted an *absence* (`not.toMatch(/al.kind = 'offsite'/)`) that `full` (TRUE) and `none` (FALSE) both satisfy — it could not tell the whole catalog from an empty one, and was green for the entire life of the bug. Unrelated suites that called `getListingDetail` without a scope now pass `{ scope: 'full' }` explicitly, so each still tests its own property rather than passing off the new default.

## Test matrix — the public-catalog grant (commit `fcfc29bbc3`)

Base for this half is the previous branch tip `c6a0544a45` (this PR's fail-closed commit). Same test files, source reverted to that base:

```
RED  @ c6a0544a45 : 9 failed / 53   (base source, new tests)
GREEN@ fcfc29bbc3 : 90 passed / 90  (incl. the two new suites)
```

The 9 red-at-base, all in the two REST handler suites:

- `apps.test.ts` — the anonymous caller is served the catalog (list), and the detail (2); a non-privileged **logged-in** caller likewise (1); the kill switch **discriminates** off→catalog / on→empty, list and detail (2); an invalid bearer is treated as anon and served rather than emptied, list and detail (2).
- `apps.absent-scope-fail-closed.test.ts` — the grant applies to an **absent** scope too, so the endpoint does not go dark while the resolver defect persists upstream (2).

Honest labels on the rest, rather than counting them as regression coverage:

- The **absent ≡ resolved-`none` equivalence** cases (5 list + 5 detail) and the **kill-switch-ON** cases (5 + 5) are **invariant guards** — they were green at base too, because base is unconditionally closed for those inputs. They pin the #3983 invariant in its new, correct form; they are not evidence that anything changed.
- `public-apps-catalog.test.ts` and `public-apps-catalog.page-gate.seam.test.ts` are **new files importing a new module**, so they cannot be shown red at base except by import failure. Labelled as such in the files themselves.

**Mutation check** (each run against the 5 suites, 90 tests, control green):

| mutant | result |
|---|---|
| remove the public grant (return `none`) | **14 fail** across 4 files |
| invert the kill-switch polarity | **36 fail** across 5 files |
| delete the privileged short-circuit | **10 fail** across 4 files |
| drop `narrowStoreScope` (the original #3983 shape) | **41 fail** across 2 files |
| force `hasAppsStoreAccess` → `true` (i.e. accidentally launch the store) | the seam suite's *"`/apps` is DARK"* assertions go red, **4 fail** |

The last one is the point of the seam suite: it drives the **real** `resolveStoreVisibilityScope` **and** the **real** `/apps` SSR gate against one fake Flipt config and asserts the relationship — REST open **and** page `notFound`, simultaneously, for the same anonymous viewer. It also carries two positive controls (the Flipt branch is live; the kill switch moves the REST scope), because a suite whose fake is wired to nothing reports a reassuring "the page is dark".

### What THIS coverage structurally cannot see

- **Whether the live endpoint serves anything.** The production failure mode does not reproduce from source under vitest — the same source resolves `none` correctly here while production does not — and every scope, flag and service answer in these suites is a mock. **The real check is post-promotion**, not "the tests pass".
- **The Flipt document.** The kill switch is exercised against a fake; no test here proves the flag key is spelled the same way in flipt-state (it is deliberately absent there).
- **The CDN.** `s-maxage` means a thrown kill switch is not observable at the edge for minutes after it is observable at the origin.

## What this coverage structurally CANNOT see

- **Why the resolver yields no value in the production runtime.** The new handler suite *mocks* the resolver on purpose — the assertion is about the consumers' defaults, the half that decides whether a missing value widens access. The mechanism upstream is still open.
- **The compiled production artifact.** Everything here runs the TypeScript source under vitest, and that same source resolves `none` correctly in-process while production does not. Whatever the mechanism is, no test in this repo currently observes it.
- **A live Flipt document.** Unchanged from #3985: the integration fixture pins the flag *shape*, not the live config.

## Verification status

- ✅ `pnpm typecheck` — 0 errors
- ✅ unit suites for the whole app-store surface re-run after the grant — 436 files / 7404 tests passing (`src/server/services`, `src/server/routers` app-listings, `src/components/Apps`, `src/tests/api/v1/apps`, `src/shared/utils`)
- ✅ eslint + prettier clean on the changed files (one pre-existing unused-import warning untouched)
- ❌ **not verified in production, and the failure mode does not reproduce from source.** Merged ≠ promoted ≠ serving ≠ verified; production serves from the `release` branch, so this needs a `main` → `release` promotion before any of it is live. **Do not read a green suite as evidence the public endpoint still works.** After it is serving, the checks are: anonymous `GET /api/v1/apps` still returns **14 items, 10 `onsite`**; `GET /api/v1/apps/{slug}` still 200s for an onsite slug; `/apps` still 404s for a logged-out viewer; and `store_public_catalog_decisions_total{outcome="granted"}` moves while `withheld` stays flat.

## Follow-ups not in this PR

1. **The root cause is still open.** #3983 should stay open on that basis; this PR closes the disclosure, not the mystery.
2. **The anonymous seam.** For an anon viewer the server data path evaluates flags at `entityId='global'/{}` while the client gate uses `'anonymous'/{isLoggedIn:'false'}`. It is documented and currently harmless, but it means "the page gate says no" and "the data path says no" are not the same computation.
3. **Pre-create the kill switch in `flipt-state`** as base `enabled: false` (i.e. *not* disabled — catalog on). Not required by this merge and deliberately not opened as a blocking PR, but creating a flag during an incident is more error-prone than flipping one that already exists.
4. **One resolver, one answer** (item C of the original brief): REST and tRPC resolve independently. This PR makes them share a narrowing rule; a contract test asserting both entry points return the same scope for the same principal is the cheap next step, and a shared entry point the real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

