### PR TITLE
fix(feedback): send a Flipt evaluation context so a feedback area can be segment-targeted

### DIFF
--- a/src/server/routers/__tests__/feedback.router.flag-context.test.ts
+++ b/src/server/routers/__tests__/feedback.router.flag-context.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OnboardingSteps } from '~/server/common/enums';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * THE SEAM: the notice (`getArea`, a READ) and the submit endpoint (`create`, a
+ * WRITE) are gated by the same flag, and must resolve it identically.
+ *
+ * Each half is easy to get right alone and the pair is what breaks: if only the read
+ * path carries an evaluation context, a cohort member is shown a prompt whose submit
+ * is then rejected — or, the other way round, a user who cannot see the prompt is the
+ * only one whose submit would succeed. Neither is visible from a test scoped to one
+ * procedure, because both procedures pass in isolation.
+ *
+ * So this drives BOTH through the REAL router, the REAL `feedback.service` and the
+ * REAL `buildFliptContext`, stubbing only the Flipt edge, and asserts (a) that the two
+ * evaluations are the SAME (flag, entityId, context) triple and (b) that a
+ * segment-gated area lets the same user through both doors.
+ */
+
+const { mockIsFlipt } = vi.hoisted(() => ({ mockIsFlipt: vi.fn() }));
+
+vi.mock('~/server/flipt/client', () => ({ isFlipt: (...args: unknown[]) => mockIsFlipt(...args) }));
+
+const { feedbackRouter } = await import('~/server/routers/feedback.router');
+
+const USER_ID = 42;
+
+/**
+ * `isEarlyAdopter` is the ONLY thing that varies between the two callers below, so a
+ * difference in outcome can only be the cohort property — not tier, mute or onboarding.
+ */
+const caller = (isEarlyAdopter: boolean) =>
+  feedbackRouter.createCaller({
+    user: {
+      id: USER_ID,
+      isModerator: false,
+      muted: false,
+      onboarding: OnboardingSteps.Buzz,
+      isEarlyAdopter,
+    },
+    acceptableOrigin: true,
+    // A full token scope, or the guarded chain throws FORBIDDEN for a SCOPE reason —
+    // which the `create` expectations below would otherwise happily accept.
+    tokenScope: TokenScope.Full,
+    features: {},
+  } as never);
+
+const submission = {
+  area: 'bitdex-image-feed' as const,
+  message: 'the feed repeated itself',
+};
+
+/** What the live `early-adopters` segment does: eq on the STRING 'true'. */
+const earlyAdoptersSegment = async (
+  _flag: string,
+  _entityId: string,
+  context?: Record<string, string>
+) => context?.isEarlyAdopter === 'true';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMock.dbWrite.feedback.create.mockResolvedValue({ id: 1 });
+  mockIsFlipt.mockImplementation(earlyAdoptersSegment);
+});
+
+const evalCalls = () =>
+  mockIsFlipt.mock.calls as [string, string, Record<string, string> | undefined][];
+
+describe('feedback flag gate — read and write evaluate the flag identically', () => {
+  it('hands Flipt the same flag, entityId and context from getArea and from create', async () => {
+    await caller(true).getArea({ area: submission.area });
+    await caller(true).create(submission);
+
+    expect(evalCalls()).toHaveLength(2);
+    const [read, write] = evalCalls();
+    expect(read[0]).toBe('feedback-area-bitdex-image-feed');
+    // Not `toEqual(read)` on the whole call by accident: name the three parts, so a
+    // future argument that differs between the paths is a visible failure rather than
+    // an object comparison nobody reads.
+    expect(write[0]).toBe(read[0]);
+    expect(write[1]).toBe(read[1]);
+    expect(write[2]).toEqual(read[2]);
+    // And the context is really there on both — an assertion that two `undefined`s
+    // match would be satisfied by the very defect this file exists to prevent.
+    expect(read[2]?.isEarlyAdopter).toBe('true');
+    expect(write[2]?.isEarlyAdopter).toBe('true');
+    expect(read[1]).toBe('42');
+  });
+
+  it('a cohort member sees the notice AND can submit', async () => {
+    await expect(caller(true).getArea({ area: submission.area })).resolves.toEqual({
+      enabled: true,
+    });
+    await expect(caller(true).create(submission)).resolves.toEqual({ id: 1 });
+    expect(dbMock.dbWrite.feedback.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('a user outside the cohort sees no notice AND is refused by the submit endpoint', async () => {
+    await expect(caller(false).getArea({ area: submission.area })).resolves.toEqual({
+      enabled: false,
+    });
+    // Matched on the message too: mute, onboarding and token-scope middlewares in this
+    // chain also throw FORBIDDEN, and a code-only assertion would pass on any of them
+    // while saying nothing about the flag.
+    await expect(caller(false).create(submission)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Feedback is not being collected here right now.',
+    });
+    expect(dbMock.dbWrite.feedback.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/feedback.router.ts
+++ b/src/server/routers/feedback.router.ts
@@ -8,8 +8,12 @@ import { guardedProcedure, router } from '~/server/trpc';
 export const feedbackRouter = router({
   // Same procedure level as `create`: anyone who can see the prompt must be able
   // to submit, or a muted user types into a box that will reject them.
+  // `ctx.user` (the full server-resolved SessionUser), never a client-supplied id:
+  // the flag's context carries cohort properties, so it must be built from what the
+  // server knows about the caller. Both procedures pass the SAME thing, which is what
+  // keeps the notice and the submit endpoint from disagreeing.
   getArea: guardedProcedure.input(getFeedbackAreaSchema).query(async ({ input, ctx }) => {
-    const enabled = await isFeedbackAreaEnabled({ area: input.area, userId: ctx.user.id });
+    const enabled = await isFeedbackAreaEnabled({ area: input.area, user: ctx.user });
     return { enabled };
   }),
   create: guardedProcedure
@@ -22,7 +26,7 @@ export const feedbackRouter = router({
     )
     .input(createFeedbackSchema)
     .mutation(async ({ input, ctx }) => {
-      const enabled = await isFeedbackAreaEnabled({ area: input.area, userId: ctx.user.id });
+      const enabled = await isFeedbackAreaEnabled({ area: input.area, user: ctx.user });
       // Loud rather than dropped: if the area went off mid-typing, say so.
       if (!enabled)
         throw new TRPCError({

--- a/src/server/services/__tests__/feedback.service.test.ts
+++ b/src/server/services/__tests__/feedback.service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFeedbackSchema } from '~/server/schema/feedback.schema';
+import type { SessionUser } from '~/types/session';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 
 const { mocks } = vi.hoisted(() => ({
@@ -114,14 +115,124 @@ describe('createFeedback — extended context', () => {
   });
 });
 
-describe('isFeedbackAreaEnabled (invariant guard — unchanged by this work)', () => {
-  it('asks Flipt for the area flag keyed on the user id', async () => {
-    await isFeedbackAreaEnabled({ area: 'bitdex-image-feed', userId: 7 });
-    expect(mocks.isFlipt).toHaveBeenCalledWith('feedback-area-bitdex-image-feed', '7');
+/**
+ * `isFeedbackAreaEnabled` — the EVALUATION CONTEXT, i.e. the third argument.
+ *
+ * `isFlipt` is `isEnabled(flag, entityId = 'global', context = {})`. Omitting the
+ * third argument is not a smaller call, it is a DIFFERENT evaluation: Flipt matches
+ * a segment against the context, so with `{}` no segment can match and the answer
+ * collapses to the flag's own default. An area switched on for a cohort then reads
+ * as off for every one of its members, with nothing logged and no error raised.
+ *
+ * `buildFliptContext` is the REAL function here (only the Flipt edge is stubbed), so
+ * these assertions pin the context the LIVE evaluation would receive rather than a
+ * shape invented by the test — the same arrangement as the App Blocks flag tests.
+ */
+describe('isFeedbackAreaEnabled — the Flipt evaluation context', () => {
+  const sessionUser = (over: Partial<SessionUser> = {}): SessionUser =>
+    ({
+      id: 7,
+      showNsfw: false,
+      blurNsfw: true,
+      browsingLevel: 1,
+      onboarding: 0,
+      ...over,
+    } as SessionUser);
+
+  /** The (flag, entityId, context) triple the service actually handed Flipt. */
+  const evalCall = () =>
+    mocks.isFlipt.mock.calls[0] as [string, string, Record<string, string> | undefined];
+
+  it('passes a context as the third argument, keyed on the user id', async () => {
+    await isFeedbackAreaEnabled({ area: 'bitdex-image-feed', user: sessionUser() });
+
+    const [flag, entityId, context] = evalCall();
+    expect(flag).toBe('feedback-area-bitdex-image-feed');
+    expect(entityId).toBe('7');
+    // The load-bearing assertion. `undefined` here is the defect: a segment-based
+    // rollout on this flag could never match, for anybody, ever.
+    expect(context).toBeDefined();
+    expect(context?.userId).toBe('7');
+    expect(context?.isLoggedIn).toBe('true');
   });
 
-  it('falls back to the anonymous entity id', async () => {
+  /**
+   * A CONTRACT WITH A LIVE SEGMENT, hand-typed on both sides.
+   *
+   * The `early-adopters` segment constrains `property: isEarlyAdopter`,
+   * `operator: eq`, `value: "true"` — the STRING. A typo in the property name, or a
+   * boolean `true`, or 'True', fails that constraint as "nobody matches" rather than
+   * as an error, so both halves are pinned by literal value. Neither is read from the
+   * implementation.
+   */
+  it('emits isEarlyAdopter as the STRING "true" for an opted-in user', async () => {
+    await isFeedbackAreaEnabled({
+      area: 'bitdex-image-feed',
+      user: sessionUser({ isEarlyAdopter: true }),
+    });
+
+    const [, , context] = evalCall();
+    expect(context).toHaveProperty('isEarlyAdopter');
+    expect(context?.isEarlyAdopter).toBe('true');
+    expect(typeof context?.isEarlyAdopter).toBe('string');
+    expect(context?.isEarlyAdopter).not.toBe(true as unknown as string);
+  });
+
+  it('emits "false" for a user who has not opted in, so an eq-"true" segment excludes them', async () => {
+    await isFeedbackAreaEnabled({
+      area: 'bitdex-image-feed',
+      user: sessionUser({ isEarlyAdopter: false }),
+    });
+
+    expect(evalCall()[2]?.isEarlyAdopter).toBe('false');
+  });
+
+  it('evaluates an anonymous request with an anonymous context that carries no cohort property', async () => {
     await isFeedbackAreaEnabled({ area: 'bitdex-image-feed' });
-    expect(mocks.isFlipt).toHaveBeenCalledWith('feedback-area-bitdex-image-feed', 'anonymous');
+
+    const [flag, entityId, context] = evalCall();
+    expect(flag).toBe('feedback-area-bitdex-image-feed');
+    // Unchanged: every anonymous request shares one entityId.
+    expect(entityId).toBe('anonymous');
+    expect(context?.isLoggedIn).toBe('false');
+    // ABSENT, not 'false': there is no user to attribute an opt-in to. Either value
+    // excludes them from an eq-'true' segment; absence also stops 'anonymous' from
+    // being spelled as a member of any cohort segment at all.
+    expect('isEarlyAdopter' in (context ?? {})).toBe(false);
+    expect(context?.userId).toBeUndefined();
+  });
+
+  /**
+   * BEHAVIOURAL, not structural. The stub implements what the live `early-adopters`
+   * segment does — match iff the context says `isEarlyAdopter === 'true'` — so this
+   * asserts the outcome the operator actually wants, not merely that some object was
+   * passed. Structurally-correct-but-wrong-property mutations die here too.
+   */
+  describe('against a stub that behaves like the early-adopters segment', () => {
+    beforeEach(() => {
+      mocks.isFlipt.mockImplementation(
+        async (_flag: string, _entityId: string, context?: Record<string, string>) =>
+          context?.isEarlyAdopter === 'true'
+      );
+    });
+
+    it('a segment-gated area is ON for a member of the cohort', async () => {
+      await expect(
+        isFeedbackAreaEnabled({
+          area: 'bitdex-image-feed',
+          user: sessionUser({ isEarlyAdopter: true }),
+        })
+      ).resolves.toBe(true);
+    });
+
+    it('and OFF for a logged-in user outside it', async () => {
+      await expect(
+        isFeedbackAreaEnabled({ area: 'bitdex-image-feed', user: sessionUser() })
+      ).resolves.toBe(false);
+    });
+
+    it('and OFF for an anonymous request', async () => {
+      await expect(isFeedbackAreaEnabled({ area: 'bitdex-image-feed' })).resolves.toBe(false);
+    });
   });
 });

--- a/src/server/services/feedback.service.ts
+++ b/src/server/services/feedback.service.ts
@@ -1,19 +1,50 @@
 import { dbWrite } from '~/server/db/client';
 import { isFlipt } from '~/server/flipt/client';
 import type { CreateFeedbackInput } from '~/server/schema/feedback.schema';
+import { buildFliptContext } from '~/server/services/feature-flags.service';
 import type { FeedbackArea } from '~/shared/constants/feedback.constants';
 import { feedbackAreaFlagKey } from '~/shared/constants/feedback.constants';
+import type { SessionUser } from '~/types/session';
 
+/**
+ * entityId for an evaluation with no user. Only percentage rollouts read it, and
+ * every anonymous request shares this one value, so a percentage rollout is
+ * all-or-nothing for anonymous traffic — deliberate, and unchanged by the context
+ * work below.
+ */
+const ANONYMOUS_ENTITY_ID = 'anonymous';
+
+/**
+ * Is this feedback area collecting right now, for THIS user?
+ *
+ * Takes the SessionUser rather than a bare id because the third argument below is
+ * the whole point: Flipt matches a segment against the EVALUATION CONTEXT, so a
+ * flag whose rollout targets a cohort (`isEarlyAdopter`, `tier`, `isModerator`, …)
+ * can only ever match if that context is sent. Passing entityId alone leaves the
+ * context empty, and an empty context matches no segment — every rollout then
+ * collapses to the flag's own default, i.e. the area looks off for the cohort it
+ * was just switched on for. Nothing errors; it silently reads as "nobody matches".
+ *
+ * The context comes from the SAME `buildFliptContext` the client gate
+ * (`getFeatureFlags`) uses, so the two gates cannot resolve a user differently.
+ *
+ * No user → an honest anonymous context (`isLoggedIn: 'false'`, and no cohort
+ * properties at all), so a cohort-segmented area can never match anonymously.
+ */
 export async function isFeedbackAreaEnabled({
   area,
-  userId,
+  user,
 }: {
   area: FeedbackArea;
-  userId?: number;
+  user?: SessionUser;
 }) {
   // isEnabled, not getBoolean: getBoolean deliberately ignores
   // FLIPT_LOCAL_OVERRIDES, so an area could never be switched on locally.
-  return isFlipt(feedbackAreaFlagKey(area), userId?.toString() ?? 'anonymous');
+  return isFlipt(
+    feedbackAreaFlagKey(area),
+    user ? String(user.id) : ANONYMOUS_ENTITY_ID,
+    buildFliptContext(user)
+  );
 }
 
 export async function createFeedback({


### PR DESCRIPTION
## The defect

`isFeedbackAreaEnabled` evaluated its Flipt flag like this:

```ts
return isFlipt(feedbackAreaFlagKey(area), userId?.toString() ?? 'anonymous');
```

`isFlipt` is `isEnabled(flag, entityId = 'global', context = {})`. **The third argument was
omitted, so every `feedback-area-<slug>` flag was evaluated with an EMPTY context.** Flipt
matches a segment against that context, so a rollout targeting a cohort — `isEarlyAdopter`,
`tier`, `isModerator`, anything a constraint reads — could not match. For anyone. On any area.

The failure is silent and reads as the opposite of what it is: with no segment matching, the
evaluation falls through to the flag's own default, so an area that was *just switched on for a
cohort* reports "off" for every member of that cohort. Nothing errors, nothing is logged. The
only ways to switch a feedback surface on were a site-wide `enabled: true` or an entityId-keyed
percentage — neither of which is cohort targeting.

Observable directly from the evaluation shape: with `{}` the result is `enabled=false` /
`DEFAULT_EVALUATION_REASON` / `segmentKeys=[]`; with `{"isEarlyAdopter":"true"}` and the *same*
entityId it is `enabled=true` / `MATCH_EVALUATION_REASON` / `segmentKeys=["early-adopters"]`.

This was never specific to one flag — every feedback area goes through this one function.

## The fix

Take the request's `SessionUser` instead of a bare id, and pass `buildFliptContext(user)` — the
same builder the client gate (`getFeatureFlags`) already uses, so the two gates cannot resolve
one user differently. This is the pattern `app-blocks-flag.ts` uses for the same reason; nothing
new is invented here.

### Design decisions

**1. The context is threaded from the callers, not resolved inside the service.** Both callers
are `guardedProcedure`s, so `ctx.user` is a fully server-resolved `SessionUser` that is already
in hand — the change is a pass-through with no extra lookup. Resolving a session *inside* the
service would add I/O to a path that runs on every mount of the prompt, and would risk the server
gate seeing a different user shape than the client gate saw for the same request, which is
exactly the divergence class the App Blocks hydrate test exists to prevent. It is also the
server-side user, never a client-supplied id: the context carries cohort properties, so anything
a client could assert would be a targeting bypass.

Threading a richer object across a service boundary is a real cost, and it is paid narrowly:
only the flag function takes the user. `createFeedback` still takes `userId: number`.

**2. Anonymous evaluations get an honest anonymous context, in ONE branch — not two.**
`buildFliptContext(undefined)` emits `isLoggedIn: 'false'` and **no cohort properties at all**, so
a cohort-segmented area can never match anonymously (an `eq` constraint on an absent property does
not match). The `'anonymous'` entityId is unchanged, so percentage rollouts behave exactly as
before.

Deliberately *not* the two-branch shape `app-blocks-flag.ts` uses. That function has real
machine/webhook callers with no user, where "do not fabricate user context" is the rule and a
bare global eval is the documented behaviour. This function has no such caller: both call sites
are authenticated user requests. A second branch here would be a duplicated predicate maintained
for a caller that does not exist — one rule, one place. The anonymous path is kept expressible
(the parameter was already optional) and given a defined, tested meaning rather than deleted.

**3. Read and write paths are consistent by construction.** The flag gates both the notice
(`feedback.getArea`) and the submit endpoint (`feedback.create`). Both go through this one
function and both now pass `ctx.user`, so they cannot disagree — a user cannot be shown a prompt
whose submit then rejects them, or vice versa. That is pinned behaviourally rather than left to
convention: a new router-level test drives *both* procedures through the real service and the
real `buildFliptContext` and asserts they hand Flipt the same `(flag, entityId, context)` triple.

## Callers

Enumerated, not assumed — `isFeedbackAreaEnabled` has exactly two call sites, both in
`src/server/routers/feedback.router.ts`:

| Call site | Kind | Procedure |
|---|---|---|
| `feedback.getArea` | read — decides whether the notice renders | `guardedProcedure` |
| `feedback.create` | write — rejects a submission into a disabled area | `guardedProcedure` |

There is no other server caller, no REST route, and no separate client-side evaluation: the
component calls `feedback.getArea`, so the client's view of the flag is this same server answer.

## Tests

- The **context argument is asserted by value**, not by `expect.anything()`: it must be defined,
  and carry `userId` / `isLoggedIn` / `isEarlyAdopter`.
- The **segment contract is hand-typed on both sides** — property `isEarlyAdopter`, value the
  **string** `'true'`. The context is `Record<string, string>`, so a boolean `true`, `'True'`, or
  a mistyped property name all fail an `eq` constraint *silently*, as "nobody matches", never as
  an error. Pinned as literals, with a `typeof` check and an explicit not-the-boolean assertion.
- A stub that **behaves like the live segment** (`context?.isEarlyAdopter === 'true'`) proves the
  outcome an operator actually wants: ON for a cohort member, OFF for a logged-in non-member, OFF
  for anonymous.
- `buildFliptContext` is the **real** function throughout; only the Flipt edge is stubbed, so the
  assertions describe the context a live evaluation would receive.

### Red at base, green at HEAD

Same environment, back to back, three test files (`feedback.service`, the new
`feedback.router.flag-context`, and the pre-existing `feedback.router`):

| Tree | Result |
|---|---|
| base (`c66c307cf8`) + these tests | **7 failed** \| 18 passed (25) |
| HEAD (`145ad1a923`) | **25 passed** (25) |

Sample failures at base: `expected { enabled: false } to deeply equal { enabled: true }`,
`expected 'anonymous' to be '7'`, `expected undefined to be 'false'`.

### Mutation matrix

Every mutant enumerated from a semantic failure mode, applied one at a time, killed with an error
that names the property under test. A restored-tree control ran green afterwards.

| Mutant | Killed by | Error |
|---|---|---|
| M1 context argument omitted (the original defect) | 7 tests | `expected undefined to be defined` |
| M2 context passed but empty `{}` | 7 tests | `expected {} to have property "isEarlyAdopter"` |
| M3 wrong property name (`isEarlyadopter`) | 5 tests | `expected { userId: '7', …(6) } to have property "isEarlyAdopter"` |
| M4 value a boolean instead of the string | 5 tests | `expected true to be 'true'` |
| M5 entityId and context swapped | 7 tests | `expected { userId: '7', …(6) } to be '7'` |
| M6 anonymous fabricates a cohort context | 2 tests | `expected 'true' to be 'false'` |
| M7 write path left unfixed (`create` sends no user) | 2 tests | `promise rejected "TRPCError: Feedback is not being collecte…" instead of resolving` |
| M8 read path left unfixed (`getArea` sends no user) | 2 tests | `expected '42' to be 'anonymous'` |
| control: restored tree | — | 17 passed |

M6/M7/M8 are the ones worth noting: each is killed by an assertion aimed at exactly its failure
mode (the anonymous-context guard, and the read/write seam), not by a neighbouring assertion.

`pnpm typecheck` produces an **identical** 12-error set at base and at HEAD (all in
`image.service.ts` / `bitdex-stats.ts`, from an uninitialised submodule in a fresh worktree) —
zero introduced. ESLint and Prettier are clean on all four changed files, both validated against
a known-bad input first.
