### PR TITLE
fix(notification-db): restore search_path so the dev fixture bootstraps at all

### DIFF
--- a/containers/notification-db/docker-init/01_all_ddl.sql
+++ b/containers/notification-db/docker-init/01_all_ddl.sql
@@ -134,6 +134,15 @@ CREATE INDEX "UserNotification_viewed_idx" ON public."UserNotification" USING bt
 ALTER TABLE ONLY public."UserNotification"
     ADD CONSTRAINT "UserNotification_notificationId_fkey" FOREIGN KEY ("notificationId") REFERENCES public."Notification"(id) ON DELETE CASCADE;
 
+-- Everything below this line is hand-written DDL appended after the pg_dump body.
+-- The dump's preamble (line 10) does `set_config('search_path', '', false)`, so an
+-- UNQUALIFIED name here resolves against an EMPTY search path and the statement
+-- fails with `relation "X" does not exist`. The dump's own statements are all
+-- schema-qualified and so are unaffected; hand-appended ones have not been.
+-- Restore the default search path once, here, so this block and anything appended
+-- after it behave the way they read.
+SET search_path = public;
+
 CREATE INDEX CONCURRENTLY "UserNotification_userId_createdAt_idx" ON "UserNotification" ("userId", "createdAt" DESC) INCLUDE ("viewed", "notificationId");
 CREATE INDEX CONCURRENTLY "Notification_id_with_category_idx" ON "Notification" (id) INCLUDE (category);
 


### PR DESCRIPTION
## What

The `notification-db` dev fixture has not started since **2025-04-24** (`856e9a8e7f`). On any fresh volume the container exits 3:

```
psql:/docker-entrypoint-initdb.d/01_all_ddl.sql:137:
  ERROR:  relation "UserNotification" does not exist
```

## Why

Line 10 is the standard pg_dump preamble:

```sql
SELECT pg_catalog.set_config('search_path', '', false);
```

That empties the search path on purpose, so the dump's own statements are all schema-qualified (`public."UserNotification"`). The **nine statements hand-appended after the dump body are not** — they say `"UserNotification"`, which now resolves against an empty search path. `ON_ERROR_STOP` is on, so the first one aborts init and the service never comes up.

Only fresh volumes are affected, which is why it went unnoticed: anyone whose volume predates the bad lines keeps a working DB.

## The fix

One `SET search_path = public;` at the top of the appended block, instead of qualifying nine names. It also covers whatever gets appended next — which is how this recurs.

## Verification

Against `postgres:15-bookworm` at the digest this fixture pins, running **the image's own entrypoint** rather than a hand-rolled psql:

| | before | after |
|---|---|---|
| container | **exits 3**, init aborts at line 137 | **stays up**, 0 init errors |
| `CONCURRENTLY` indexes the block creates | absent | all **3** present |
| `DROP INDEX` targets | still present | all **4** gone |
| `dedupeKey` columns | absent | both present |

The effects are asserted, not just "the container survived" — a fixture that comes up having silently skipped its DDL is the same defect wearing a green hat.

## How this was found

While building a CI gate for exactly this class (talos-infra `868kt4bhq`). Nothing in CI builds or runs any Dockerfile or fixture, so this kind of breakage ships green: #3992 broke ClickHouse bootstrap the same way last week, and this one sat broken for ~16 months.
