### PR TITLE
fix(release): refuse an app release from a branch behind its released history

### DIFF
--- a/scripts/__tests__/release-app-skew-guard.test.ts
+++ b/scripts/__tests__/release-app-skew-guard.test.ts
@@ -1,0 +1,132 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+// BEHAVIOURAL guard for scripts/release-app.mjs.
+//
+// release-version.test.ts pins the version arithmetic in isolation, which proves
+// nothing about whether release-app.mjs actually CALLS it — a guard that is never
+// reached is not a guard. So these run the real script, as a real process, against
+// a throwaway git repo with a real (local, bare) remote so `git pull --rebase`
+// succeeds and execution reaches the guard.
+//
+// Everything is offline and confined to a temp dir: no network, no tags or commits
+// in the actual repository.
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const RELEASE_SCRIPT = path.resolve(HERE, '../release-app.mjs');
+
+const sandboxes: string[] = [];
+afterAll(() => {
+  for (const dir of sandboxes) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A git repo on branch `main`, tracking a bare remote, with apps/moderator at `version`. */
+function makeSandbox(version: string, tags: string[]) {
+  const root = mkdtempSync(path.join(tmpdir(), 'release-skew-'));
+  sandboxes.push(root);
+  const remote = path.join(root, 'remote.git');
+  const work = path.join(root, 'work');
+
+  const git = (cwd: string, args: string[]) =>
+    execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: 'test',
+        GIT_AUTHOR_EMAIL: 'test@example.com',
+        GIT_COMMITTER_NAME: 'test',
+        GIT_COMMITTER_EMAIL: 'test@example.com',
+      },
+    });
+
+  execFileSync('git', ['init', '--bare', '-b', 'main', remote]);
+  execFileSync('git', ['clone', remote, work]);
+  git(work, ['config', 'user.name', 'test']);
+  git(work, ['config', 'user.email', 'test@example.com']);
+
+  mkdirSync(path.join(work, 'apps/moderator'), { recursive: true });
+  writeFileSync(
+    path.join(work, 'apps/moderator/package.json'),
+    `${JSON.stringify({ name: '@civitai/moderator-app', version, private: true }, null, 2)}\n`
+  );
+  git(work, ['add', 'apps/moderator/package.json']);
+  git(work, ['commit', '-m', 'seed']);
+  git(work, ['push', '-u', 'origin', 'main']);
+  for (const tag of tags) git(work, ['tag', tag]);
+
+  return { work, git };
+}
+
+const RELEASED_TAGS = Array.from({ length: 26 }, (_, i) => `moderator-v0.0.${i + 1}`);
+
+function runRelease(cwd: string, bump: string) {
+  return spawnSync(process.execPath, [RELEASE_SCRIPT, 'apps/moderator', 'moderator-v', bump], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+}
+
+const versionOf = (work: string) =>
+  JSON.parse(readFileSync(path.join(work, 'apps/moderator/package.json'), 'utf8')).version;
+
+describe('release-app.mjs refuses to release from a branch behind the released history', () => {
+  it('blocks a patch release and leaves the tree untouched', () => {
+    const { work, git } = makeSandbox('0.0.1', RELEASED_TAGS);
+    const before = git(work, ['rev-parse', 'HEAD']).trim();
+
+    const res = runRelease(work, 'patch');
+
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain('refusing to release');
+    expect(res.stderr).toContain('moderator-v0.0.26 is already released');
+    // A refusal must not leave the half-done state the old code did: the version is
+    // unbumped and no release commit exists.
+    expect(versionOf(work)).toBe('0.0.1');
+    expect(git(work, ['rev-parse', 'HEAD']).trim()).toBe(before);
+    expect(git(work, ['status', '--porcelain']).trim()).toBe('');
+  });
+
+  // The dangerous path: 0.1.0 collides with nothing, so without this guard the
+  // release SUCCEEDS and becomes the highest tag for the app.
+  it('blocks a minor release, which no tag collision would have caught', () => {
+    const { work } = makeSandbox('0.0.1', RELEASED_TAGS);
+    expect(RELEASED_TAGS).not.toContain('moderator-v0.1.0');
+
+    const res = runRelease(work, 'minor');
+
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain('refusing to release');
+    expect(versionOf(work)).toBe('0.0.1');
+  });
+
+  // Positive control: the guard must not block the legitimate release, or it would
+  // just be an outage of its own. Runs the script to completion.
+  it('allows a release from a branch that carries the released history', () => {
+    const { work, git } = makeSandbox('0.0.26', RELEASED_TAGS);
+
+    const res = runRelease(work, 'patch');
+
+    expect(res.stderr).not.toContain('refusing to release');
+    expect(res.status).toBe(0);
+    expect(versionOf(work)).toBe('0.0.27');
+    expect(git(work, ['tag', '-l', 'moderator-v0.0.27']).trim()).toBe('moderator-v0.0.27');
+  });
+
+  // An app with no releases yet must still be releasable.
+  it('allows the first release of an app that has never been tagged', () => {
+    const { work } = makeSandbox('0.0.1', []);
+
+    const res = runRelease(work, 'patch');
+
+    expect(res.stderr).not.toContain('refusing to release');
+    expect(res.status).toBe(0);
+    expect(versionOf(work)).toBe('0.0.2');
+  });
+});

--- a/scripts/__tests__/release-version.test.ts
+++ b/scripts/__tests__/release-version.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  compareSemver,
+  highestTagVersion,
+  parseSemver,
+  releaseSkew,
+  skewMessage,
+} from '../lib/release-version.mjs';
+
+// Guards for scripts/release-app.mjs's "is this branch behind the released
+// history?" check.
+//
+// The concrete state these are written against, measured 2026-08-17: apps/moderator
+// is 0.0.1 on `main`, 0.0.26 is live in production, and all 26 releases were cut
+// from `moderator-app-pages` — 211 commits that never merged to main. Expected
+// values below are written from the released tag list and the deployment, NOT read
+// back out of the implementation.
+
+const MODERATOR_TAGS = Array.from({ length: 26 }, (_, i) => `moderator-v0.0.${i + 1}`);
+
+describe('parseSemver', () => {
+  it('accepts a plain x.y.z and rejects anything else', () => {
+    expect(parseSemver('0.0.26')).toEqual({ major: 0, minor: 0, patch: 26 });
+    expect(parseSemver('1.9.12')).toEqual({ major: 1, minor: 9, patch: 12 });
+    expect(parseSemver('0.0.26-rc.1')).toBeNull();
+    expect(parseSemver('v0.0.26')).toBeNull();
+    expect(parseSemver('')).toBeNull();
+    expect(parseSemver(undefined)).toBeNull();
+  });
+});
+
+describe('compareSemver', () => {
+  it('orders by major, then minor, then patch', () => {
+    expect(compareSemver('0.0.2', '0.0.26')).toBeLessThan(0);
+    expect(compareSemver('0.1.0', '0.0.26')).toBeGreaterThan(0);
+    expect(compareSemver('1.0.0', '0.9.9')).toBeGreaterThan(0);
+    expect(compareSemver('0.0.26', '0.0.26')).toBe(0);
+  });
+
+  // 0.0.2 vs 0.0.26 is the pair a string comparison gets wrong ('0.0.2' > '0.0.26'
+  // lexicographically), and it is exactly the pair this app is sitting on.
+  it('compares numerically, not lexicographically', () => {
+    expect(compareSemver('0.0.9', '0.0.10')).toBeLessThan(0);
+    expect(compareSemver('0.0.2', '0.0.26')).toBeLessThan(0);
+  });
+});
+
+describe('highestTagVersion', () => {
+  it('finds the highest released version for the prefix', () => {
+    expect(highestTagVersion(MODERATOR_TAGS, 'moderator-v')).toBe('0.0.26');
+  });
+
+  it('ignores tags belonging to other apps', () => {
+    const mixed = [...MODERATOR_TAGS, 'auth-app-v9.9.9', 'event-engine-v1.9.12'];
+    expect(highestTagVersion(mixed, 'moderator-v')).toBe('0.0.26');
+  });
+
+  it('ignores unparseable tags instead of throwing', () => {
+    // One hand-cut oddity must not disable the guard for every later release.
+    const withJunk = [...MODERATOR_TAGS, 'moderator-vNIGHTLY', 'moderator-v0.0.26-hotfix'];
+    expect(highestTagVersion(withJunk, 'moderator-v')).toBe('0.0.26');
+  });
+
+  it('returns null when the app has never been released', () => {
+    expect(highestTagVersion(MODERATOR_TAGS, 'brand-new-app-v')).toBeNull();
+  });
+});
+
+describe('releaseSkew', () => {
+  it('refuses a release from a branch behind the released history', () => {
+    const skew = releaseSkew({
+      currentVersion: '0.0.1',
+      tags: MODERATOR_TAGS,
+      tagPrefix: 'moderator-v',
+    });
+    expect(skew).toEqual({ behind: true, current: '0.0.1', highest: '0.0.26' });
+  });
+
+  // The case with no natural brake, and the reason this guard exists: a minor bump
+  // off the stale base computes 0.1.0, which collides with NOTHING, becomes the
+  // highest tag for the app, and is therefore what the Flux ImagePolicy selects.
+  // The guard has to fire on the branch state, before the bump is even computed.
+  it('fires on the stale base regardless of which bump would follow', () => {
+    expect(
+      releaseSkew({ currentVersion: '0.0.1', tags: MODERATOR_TAGS, tagPrefix: 'moderator-v' })
+        .behind
+    ).toBe(true);
+    expect(MODERATOR_TAGS).not.toContain('moderator-v0.1.0');
+  });
+
+  it('allows a release when the branch matches the released history', () => {
+    // The legitimate path: releasing 0.0.27 from the branch that carries 0.0.26.
+    expect(
+      releaseSkew({ currentVersion: '0.0.26', tags: MODERATOR_TAGS, tagPrefix: 'moderator-v' })
+    ).toEqual({ behind: false, current: '0.0.26', highest: '0.0.26' });
+  });
+
+  it('allows a release when the branch is ahead', () => {
+    expect(
+      releaseSkew({ currentVersion: '0.1.0', tags: MODERATOR_TAGS, tagPrefix: 'moderator-v' })
+        .behind
+    ).toBe(false);
+  });
+
+  it('allows the first ever release of an app', () => {
+    expect(
+      releaseSkew({ currentVersion: '0.0.1', tags: MODERATOR_TAGS, tagPrefix: 'storage-v' })
+    ).toEqual({ behind: false, current: '0.0.1', highest: null });
+  });
+
+  it('throws rather than passing when package.json holds a non-semver version', () => {
+    expect(() =>
+      releaseSkew({ currentVersion: 'nightly', tags: MODERATOR_TAGS, tagPrefix: 'moderator-v' })
+    ).toThrow(/not a plain x\.y\.z/);
+  });
+});
+
+describe('skewMessage', () => {
+  it('names the app, both versions, and the branch', () => {
+    const msg = skewMessage({
+      appDir: 'apps/moderator',
+      tagPrefix: 'moderator-v',
+      current: '0.0.1',
+      highest: '0.0.26',
+      branch: 'main',
+    });
+    expect(msg).toContain('apps/moderator/package.json is 0.0.1');
+    expect(msg).toContain('moderator-v0.0.26 is already released');
+    expect(msg).toContain("on 'main'");
+  });
+
+  // The remedy has to say "fix the branch", because the obvious reading — set the
+  // number to the released one — removes the tag collision that is currently the
+  // only thing preventing a stale deploy.
+  it('steers away from hand-setting the version', () => {
+    const msg = skewMessage({
+      appDir: 'apps/moderator',
+      tagPrefix: 'moderator-v',
+      current: '0.0.1',
+      highest: '0.0.26',
+      branch: 'main',
+    });
+    expect(msg).toContain('Fix the branch, not the number');
+    expect(msg).toContain('Setting the version to 0.0.26 by hand removes the collision');
+  });
+});

--- a/scripts/lib/release-version.mjs
+++ b/scripts/lib/release-version.mjs
@@ -1,0 +1,88 @@
+// Version arithmetic for scripts/release-app.mjs, kept separate so it is testable
+// without shelling out to git or cutting a real release.
+//
+// ── The failure this exists to stop ─────────────────────────────────────────────
+// `release-app.mjs` derives the next version from `apps/<app>/package.json` ON THE
+// CURRENT BRANCH. If that branch is behind the app's released history, the tag it
+// computes is wrong in one of two ways:
+//
+//   * it ALREADY EXISTS  -> `git tag` aborts, but only AFTER the release commit has
+//     been made, leaving a junk commit on the branch;
+//   * it does NOT exist but is a DIFFERENT LINE (a minor/major bump off a stale
+//     base) -> nothing collides, the tag becomes the HIGHEST for that app, and
+//     since the Flux ImagePolicy selects the highest semver in range rather than
+//     the most recently pushed, that stale build is what production runs.
+//
+// The second is the dangerous one and has no natural brake. Measured 2026-08-17:
+// `apps/moderator` is 0.0.1 on `main` while 0.0.26 is live, because all 26 releases
+// were cut from `moderator-app-pages` (211 commits / +38,630 lines never merged to
+// main). `pnpm release:moderator` from main collides on the existing 0.0.2 and
+// aborts — but `release:moderator:minor` computes 0.1.0, which does NOT exist, and
+// would deploy main's stale copy of the app to production.
+
+/** Parse a plain `x.y.z` version. Returns null for anything else (pre-release, junk). */
+export function parseSemver(value) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(String(value ?? '').trim());
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+
+/** Compare two `x.y.z` strings. >0 if a is newer, <0 if b is newer, 0 if equal. */
+export function compareSemver(a, b) {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) throw new Error(`cannot compare non-semver versions: ${a} vs ${b}`);
+  return pa.major - pb.major || pa.minor - pb.minor || pa.patch - pb.patch;
+}
+
+/**
+ * Highest released version among `tags` carrying `tagPrefix`, or null if none.
+ * Tags that do not parse are ignored rather than throwing: an app's tag namespace
+ * can legitimately contain hand-cut oddities, and one of those must not be able to
+ * disable the guard for every subsequent release.
+ */
+export function highestTagVersion(tags, tagPrefix) {
+  let best = null;
+  for (const raw of tags) {
+    const tag = String(raw).trim();
+    if (!tag.startsWith(tagPrefix)) continue;
+    const version = tag.slice(tagPrefix.length);
+    if (!parseSemver(version)) continue;
+    if (best === null || compareSemver(version, best) > 0) best = version;
+  }
+  return best;
+}
+
+/**
+ * Is this branch's package.json behind the app's released history?
+ *
+ * Equal is fine — that is the normal state right before a release. Ahead is fine
+ * too (someone bumped by hand). Only BEHIND is refused, because that is the state
+ * in which the computed tag does not continue the released line.
+ */
+export function releaseSkew({ currentVersion, tags, tagPrefix }) {
+  const highest = highestTagVersion(tags, tagPrefix);
+  if (highest === null) return { behind: false, current: currentVersion, highest: null };
+  if (!parseSemver(currentVersion)) {
+    throw new Error(`package.json version is not a plain x.y.z version: ${currentVersion}`);
+  }
+  return {
+    behind: compareSemver(currentVersion, highest) < 0,
+    current: currentVersion,
+    highest,
+  };
+}
+
+/** The refusal text. Separate from the check so a test can pin what an operator is told. */
+export function skewMessage({ appDir, tagPrefix, current, highest, branch }) {
+  return [
+    `refusing to release: ${appDir}/package.json is ${current} on '${branch}', but ${tagPrefix}${highest} is already released.`,
+    `This branch is BEHIND the app's released history, so the tag this would cut does not continue that line.`,
+    `Either it collides with an existing tag (the release aborts half-done), or — for a minor/major bump — it becomes`,
+    `the highest tag for this app and Flux deploys THIS branch's code, because the ImagePolicy selects the highest`,
+    `semver rather than the most recent push.`,
+    ``,
+    `Fix the branch, not the number: merge or rebase the branch that carries the releases, then release from there.`,
+    `Setting the version to ${highest} by hand removes the collision that is currently the only thing stopping this.`,
+  ].join('\n');
+}

--- a/scripts/release-app.mjs
+++ b/scripts/release-app.mjs
@@ -14,6 +14,7 @@
 // are never swept into the release commit.
 import { execSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
+import { releaseSkew, skewMessage } from './lib/release-version.mjs';
 
 const [appDir, tagPrefix, bump] = process.argv.slice(2);
 const BUMPS = new Set(['patch', 'minor', 'major']);
@@ -52,6 +53,23 @@ if (branch !== 'main') {
 
 sh('git pull --rebase');
 
+// 🔴 Refuse if this branch is BEHIND the app's released history. Checked here —
+// after the pull so the tag list is current, and BEFORE `npm version` so a refusal
+// leaves the tree exactly as it found it. See scripts/lib/release-version.mjs for
+// the two ways a stale base produces a wrong tag; the dangerous one deploys this
+// branch's code to production without colliding with anything.
+{
+  const currentVersion = JSON.parse(readFileSync(`${appDir}/package.json`, 'utf8')).version;
+  const tags = cap('git tag -l').split('\n').filter(Boolean);
+  const skew = releaseSkew({ currentVersion, tags, tagPrefix });
+  if (skew.behind) {
+    console.error(
+      skewMessage({ appDir, tagPrefix, current: skew.current, highest: skew.highest, branch })
+    );
+    process.exit(1);
+  }
+}
+
 // Bump the sub-package version ONLY (no git side effects from npm).
 sh(`npm --prefix ${appDir} version ${bump} --no-git-tag-version`);
 const version = JSON.parse(readFileSync(`${appDir}/package.json`, 'utf8')).version;
@@ -64,4 +82,6 @@ sh(`git commit -m "chore(${app}): release ${tag}"`);
 sh(`git tag -a ${tag} -m ${tag}`);
 sh('git push --follow-tags');
 
-console.log(`\nReleased ${tag} (pushed to ${branch}). The tag-webhook will build + Flux will deploy.`);
+console.log(
+  `\nReleased ${tag} (pushed to ${branch}). The tag-webhook will build + Flux will deploy.`
+);


### PR DESCRIPTION
## The bug, and why the obvious fix is the wrong one

`scripts/release-app.mjs` derives the next version from `apps/<app>/package.json` **on the current branch**. If that branch is behind the app's released history, the tag it computes doesn't continue that line:

- **it already exists** → `git tag` aborts, but only *after* the release commit is made, leaving a junk commit on the branch;
- **it's a different line** (a minor/major bump off a stale base) → nothing collides, the tag becomes the **highest** for that app, and the Flux ImagePolicy selects the **highest semver**, not the most recent push. That stale build is what production runs.

`apps/moderator` is in exactly this state (measured 2026-08-17):

| | |
|---|---|
| `main` | `0.0.1` |
| live in production | `ghcr.io/civitai/civitai-moderator:0.0.26` |
| where all 26 releases were cut | `moderator-app-pages` — **211 commits / 333 files / +38,630 lines** never merged to `main` |

`pnpm release:moderator` from `main` computes `0.0.2`, which exists, so it aborts. But **`pnpm release:moderator:minor` computes `0.1.0`, which does not exist** — it would tag, build, and deploy `main`'s stale copy of the app to production. One command, no collision, no warning.

**This PR deliberately does not bump moderator to `0.0.26`.** That's the obvious fix (and what the ticket proposed), and it is actively harmful: it removes the accidental tag collision that is currently the only brake, while leaving the app 211 commits stale. The real remedy is landing `moderator-app-pages`; this guard makes the trap loud until someone does.

## The guard

Refuses when the highest released tag for the prefix is greater than the branch's `package.json` version. Equal is fine (the normal pre-release state) and ahead is fine. Placed **after** `git pull --rebase` so the tag list is current, and **before** `npm version` so a refusal leaves the tree exactly as it found it.

The legitimate path is unaffected: releasing `0.0.27` from the branch that carries `0.0.26` passes, and so does an app's first-ever release.

## Verification

19 tests. The version arithmetic is unit-tested — including `0.0.2` vs `0.0.26`, the pair a string comparison gets backwards, which is the pair this app is actually sitting on.

Because a guard nothing calls is not a guard, `release-app.mjs` is also driven **end-to-end as a real process** against a throwaway git repo with a local bare remote (fully offline; no tags or commits touch this repository).

Mutation-tested — 4 mutants, each the narrowest expression that can be wrong:

| Mutant | Result |
|---|---|
| invert the behind-comparison | 5 tests fail |
| lexicographic highest-tag compare | 6 tests fail |
| **guard computed but never acted on** | **only the 2 behavioural tests fail** — this is what pins reachability |
| drop the unparseable-tag skip | exactly 1 test fails |

Baseline restored green (19/19) after the battery.

## One caveat, stated rather than buried

`scripts/**/*.test.ts` runs in the `unit` vitest project, which is `continue-on-error: true` in `lint.yml` — so these tests **run but cannot fail CI today**. Tracked separately (868kp7fdr). It makes them a local and post-fix gate, not a live one.

## Follow-up this does not do

`moderator-app-pages` still needs to land on `main`, or `apps/moderator` on `main` stays a stale copy of a live app. That's an owner decision (@manuelurenah), not something to fold into a guard PR.
