### PR TITLE
feat(stickers): show placed stickers on post pages

### DIFF
--- a/src/components/Post/Detail/PostImages.tsx
+++ b/src/components/Post/Detail/PostImages.tsx
@@ -1,6 +1,6 @@
 import { ActionIcon, Badge, Button, Center, Group, Loader, Paper, Stack } from '@mantine/core';
 import { IconBrush, IconInfoCircle } from '@tabler/icons-react';
-import { Fragment, useRef, useState } from 'react';
+import { Fragment, useMemo, useRef, useState } from 'react';
 import { AdUnitTop } from '~/components/Ads/AdUnit';
 import HoverActionButton from '~/components/Cards/components/HoverActionButton';
 import { RoutedDialogLink } from '~/components/Dialog/RoutedDialogLink';
@@ -12,6 +12,9 @@ import { ImageMetaPopover2 } from '~/components/Image/Meta/ImageMetaPopover';
 import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
 import { MediaHash } from '~/components/ImageHash/ImageHash';
 import { PostContestCollectionInfoAlert } from '~/components/Post/Detail/PostContestCollectionInfoAlert';
+import { PostStickerOverlay } from '~/components/Post/Detail/PostStickerOverlay';
+import { StickerPlacementBatchProvider } from '~/components/Sticker/StickerPlacementBatchProvider';
+import { StickerPlacementCardBadge } from '~/components/Sticker/StickerPlacementCardBadge';
 import { Reactions } from '~/components/Reaction/Reactions';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { MAX_POST_IMAGES_WIDTH } from '~/server/common/constants';
@@ -46,6 +49,12 @@ export function PostImages({
   const videoRef = useRef<EdgeVideoRef | null>(null);
   const features = useFeatureFlags();
 
+  // Every image in the post, not the `_images` slice below: the batch provider
+  // keys its chunks on the joined id string, so handing it a slice that grows on
+  // "Load more" refetches the first twenty alongside the rest. A post is well
+  // inside the provider's 100-id chunk, so this is one query either way.
+  const imageIds = useMemo(() => images.map((image) => image.id), [images]);
+
   if (isLoading)
     return (
       <Paper component={Center} p="xl" mih={300} withBorder>
@@ -60,162 +69,175 @@ export function PostImages({
   const _images = showMore ? images : images.slice(0, maxInitialImages);
 
   return (
-    <ContainerProvider containerName="post-detail" className="gap-4">
-      {_images.map((image, i) => {
-        const width = image.width ?? maxWidth;
-        const imageCollectionItem = collectionItems?.find((item) => item.imageId === image.id);
-        const showImageCollectionBadge =
-          imageCollectionItem?.tag &&
-          (isOwner || isModerator || imageCollectionItem.status === CollectionItemStatus.ACCEPTED);
-        const vimeoVideoId = (image.metadata as VideoMetadata)?.vimeoVideoId;
-        // One predicate for both the prop that asks for a control strip and the
-        // class that moves the reaction bar clear of one. Spelling it twice is
-        // how the reaction bar came to sit top-left over still images:
-        // `nativeVideoControls` is a site-wide user preference, and EdgeMedia
-        // only forwards `html5Controls` to EdgeVideo.
-        const showsControlStrip =
-          image.type === MediaType.video &&
-          (features.nativeVideoControls || shouldDisplayHtmlControls(image));
+    <StickerPlacementBatchProvider imageIds={imageIds}>
+      <ContainerProvider containerName="post-detail" className="gap-4">
+        {_images.map((image, i) => {
+          const width = image.width ?? maxWidth;
+          const imageCollectionItem = collectionItems?.find((item) => item.imageId === image.id);
+          const showImageCollectionBadge =
+            imageCollectionItem?.tag &&
+            (isOwner ||
+              isModerator ||
+              imageCollectionItem.status === CollectionItemStatus.ACCEPTED);
+          const vimeoVideoId = (image.metadata as VideoMetadata)?.vimeoVideoId;
+          // One predicate for both the prop that asks for a control strip and the
+          // class that moves the reaction bar clear of one. Spelling it twice is
+          // how the reaction bar came to sit top-left over still images:
+          // `nativeVideoControls` is a site-wide user preference, and EdgeMedia
+          // only forwards `html5Controls` to EdgeVideo.
+          const showsControlStrip =
+            image.type === MediaType.video &&
+            (features.nativeVideoControls || shouldDisplayHtmlControls(image));
 
-        return (
-          <Fragment key={image.id}>
-            <PostContestCollectionInfoAlert
-              isOwner={isOwner}
-              collectionItem={imageCollectionItem}
-              itemLabel="image"
-              isModerator={isModerator}
-            />
-            <Paper
-              key={image.id}
-              radius="md"
-              className="relative overflow-hidden"
-              shadow="md"
-              mx="auto"
-              style={{
-                maxWidth: '100%',
-                width: width < maxWidth ? width : maxWidth,
-                aspectRatio:
-                  image.width && image.height ? `${image.width}/${image.height}` : undefined,
-              }}
-            >
-              <ImageGuard2 image={image} connectType="post" connectId={postId}>
-                {(safe) => (
-                  <>
-                    <Group gap={4} className="absolute left-2 top-2 z-10">
-                      <ImageGuard2.BlurToggle />
-                      {showImageCollectionBadge && (
-                        <Badge variant="filled" color="gray">
-                          {imageCollectionItem?.tag?.name}
-                        </Badge>
-                      )}
-                    </Group>
-                    <div
-                      className={clsx('absolute right-2 top-2 z-10 flex flex-col gap-2', {
-                        'right-10 top-2.5': !!vimeoVideoId,
-                      })}
-                    >
-                      <ImageContextMenu image={image} />
-                      {features.imageGeneration && isRemixMenuVisible(image) && (
-                        <RemixMenu image={image} source="remix:post-image-card">
-                          <HoverActionButton
-                            label="Remix"
-                            size={30}
-                            color="white"
-                            variant="filled"
-                            data-activity="remix:post-image-card"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              e.stopPropagation();
+          return (
+            <Fragment key={image.id}>
+              <PostContestCollectionInfoAlert
+                isOwner={isOwner}
+                collectionItem={imageCollectionItem}
+                itemLabel="image"
+                isModerator={isModerator}
+              />
+              <Paper
+                key={image.id}
+                radius="md"
+                className="relative overflow-hidden"
+                shadow="md"
+                mx="auto"
+                style={{
+                  maxWidth: '100%',
+                  width: width < maxWidth ? width : maxWidth,
+                  aspectRatio:
+                    image.width && image.height ? `${image.width}/${image.height}` : undefined,
+                }}
+              >
+                <ImageGuard2 image={image} connectType="post" connectId={postId}>
+                  {(safe) => (
+                    <>
+                      <Group gap={4} className="absolute left-2 top-2 z-10">
+                        <ImageGuard2.BlurToggle />
+                        {/* Beside the blur toggle rather than the reactions, where
+                          a feed card puts it: this bar moves to three different
+                          corners depending on video controls. */}
+                        {features.stickerPlacement && (
+                          <StickerPlacementCardBadge imageId={image.id} />
+                        )}
+                        {showImageCollectionBadge && (
+                          <Badge variant="filled" color="gray">
+                            {imageCollectionItem?.tag?.name}
+                          </Badge>
+                        )}
+                      </Group>
+                      <div
+                        className={clsx('absolute right-2 top-2 z-10 flex flex-col gap-2', {
+                          'right-10 top-2.5': !!vimeoVideoId,
+                        })}
+                      >
+                        <ImageContextMenu image={image} />
+                        {features.imageGeneration && isRemixMenuVisible(image) && (
+                          <RemixMenu image={image} source="remix:post-image-card">
+                            <HoverActionButton
+                              label="Remix"
+                              size={30}
+                              color="white"
+                              variant="filled"
+                              data-activity="remix:post-image-card"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                              }}
+                            >
+                              <IconBrush stroke={2.5} size={16} />
+                            </HoverActionButton>
+                          </RemixMenu>
+                        )}
+                      </div>
+                      <RoutedDialogLink
+                        name="imageDetail"
+                        state={{
+                          imageId: image.id,
+                          images,
+                          collectionId: imageCollectionItem?.collection?.id,
+                        }}
+                        onClick={() => {
+                          if (videoRef.current) videoRef.current.stop();
+                        }}
+                      >
+                        {!safe ? (
+                          <div
+                            style={{
+                              position: 'absolute',
+                              top: 0,
+                              bottom: 0,
+                              aspectRatio: (image.width ?? 1) / (image.height ?? 1),
                             }}
                           >
-                            <IconBrush stroke={2.5} size={16} />
-                          </HoverActionButton>
-                        </RemixMenu>
+                            <MediaHash {...image} />
+                          </div>
+                        ) : (
+                          <EdgeMedia
+                            src={image.url}
+                            name={image.name}
+                            alt={image.name ?? undefined}
+                            type={image.type}
+                            imageId={image.id}
+                            width={width < maxWidth ? width : maxWidth}
+                            original={image.type === 'video'}
+                            anim={safe}
+                            html5Controls={showsControlStrip}
+                            videoRef={videoRef}
+                            vimeoVideoId={vimeoVideoId}
+                          />
+                        )}
+                      </RoutedDialogLink>
+                      {safe && features.stickerPlacement && (
+                        <PostStickerOverlay imageId={image.id} />
                       )}
-                    </div>
-                    <RoutedDialogLink
-                      name="imageDetail"
-                      state={{
-                        imageId: image.id,
-                        images,
-                        collectionId: imageCollectionItem?.collection?.id,
-                      }}
-                      onClick={() => {
-                        if (videoRef.current) videoRef.current.stop();
-                      }}
-                    >
-                      {!safe ? (
-                        <div
-                          style={{
-                            position: 'absolute',
-                            top: 0,
-                            bottom: 0,
-                            aspectRatio: (image.width ?? 1) / (image.height ?? 1),
-                          }}
-                        >
-                          <MediaHash {...image} />
+                      <Reactions
+                        className={clsx(classes.reactions, {
+                          [classes.reactionsWithControls]: !vimeoVideoId && showsControlStrip,
+                          [classes.vimeoReactions]: !!vimeoVideoId,
+                        })}
+                        entityId={image.id}
+                        entityType="image"
+                        reactions={image.reactions}
+                        metrics={{
+                          likeCount: image.stats?.likeCountAllTime,
+                          dislikeCount: image.stats?.dislikeCountAllTime,
+                          heartCount: image.stats?.heartCountAllTime,
+                          laughCount: image.stats?.laughCountAllTime,
+                          cryCount: image.stats?.cryCountAllTime,
+                        }}
+                        targetUserId={image.user.id}
+                        readonly={!safe}
+                        disableBuzzTip={image.poi}
+                      />
+                      {image.hasMeta && (
+                        <div className="absolute bottom-2 right-2">
+                          <ImageMetaPopover2 imageId={image.id} type={image.type}>
+                            <LegacyActionIcon variant="transparent" size="lg" component="span">
+                              <IconInfoCircle
+                                color="white"
+                                filter="drop-shadow(1px 1px 2px rgb(0 0 0 / 50%)) drop-shadow(0px 5px 15px rgb(0 0 0 / 60%))"
+                                opacity={0.8}
+                                strokeWidth={2.5}
+                                size={26}
+                              />
+                            </LegacyActionIcon>
+                          </ImageMetaPopover2>
                         </div>
-                      ) : (
-                        <EdgeMedia
-                          src={image.url}
-                          name={image.name}
-                          alt={image.name ?? undefined}
-                          type={image.type}
-                          imageId={image.id}
-                          width={width < maxWidth ? width : maxWidth}
-                          original={image.type === 'video'}
-                          anim={safe}
-                          html5Controls={showsControlStrip}
-                          videoRef={videoRef}
-                          vimeoVideoId={vimeoVideoId}
-                        />
                       )}
-                    </RoutedDialogLink>
-                    <Reactions
-                      className={clsx(classes.reactions, {
-                        [classes.reactionsWithControls]: !vimeoVideoId && showsControlStrip,
-                        [classes.vimeoReactions]: !!vimeoVideoId,
-                      })}
-                      entityId={image.id}
-                      entityType="image"
-                      reactions={image.reactions}
-                      metrics={{
-                        likeCount: image.stats?.likeCountAllTime,
-                        dislikeCount: image.stats?.dislikeCountAllTime,
-                        heartCount: image.stats?.heartCountAllTime,
-                        laughCount: image.stats?.laughCountAllTime,
-                        cryCount: image.stats?.cryCountAllTime,
-                      }}
-                      targetUserId={image.user.id}
-                      readonly={!safe}
-                      disableBuzzTip={image.poi}
-                    />
-                    {image.hasMeta && (
-                      <div className="absolute bottom-2 right-2">
-                        <ImageMetaPopover2 imageId={image.id} type={image.type}>
-                          <LegacyActionIcon variant="transparent" size="lg" component="span">
-                            <IconInfoCircle
-                              color="white"
-                              filter="drop-shadow(1px 1px 2px rgb(0 0 0 / 50%)) drop-shadow(0px 5px 15px rgb(0 0 0 / 60%))"
-                              opacity={0.8}
-                              strokeWidth={2.5}
-                              size={26}
-                            />
-                          </LegacyActionIcon>
-                        </ImageMetaPopover2>
-                      </div>
-                    )}
-                  </>
-                )}
-              </ImageGuard2>
-            </Paper>
-            {i > 0 && (i - 1) % 3 === 0 && <AdUnitTop maxWidth={760} preserveLayout={false} />}
-          </Fragment>
-        );
-      })}
-      {remainingImages > 0 && (
-        <Button onClick={() => setShowMore(true)}>Load {remainingImages} more images</Button>
-      )}
-    </ContainerProvider>
+                    </>
+                  )}
+                </ImageGuard2>
+              </Paper>
+              {i > 0 && (i - 1) % 3 === 0 && <AdUnitTop maxWidth={760} preserveLayout={false} />}
+            </Fragment>
+          );
+        })}
+        {remainingImages > 0 && (
+          <Button onClick={() => setShowMore(true)}>Load {remainingImages} more images</Button>
+        )}
+      </ContainerProvider>
+    </StickerPlacementBatchProvider>
   );
 }

--- a/src/components/Post/Detail/PostStickerOverlay.browser.test.tsx
+++ b/src/components/Post/Detail/PostStickerOverlay.browser.test.tsx
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type * as BatchProvider from '~/components/Sticker/StickerPlacementBatchProvider';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { LOADABLE_IMAGE_DATA_URI, renderWithProviders } from '../../../../test/component-setup';
+import { PostStickerOverlay } from '~/components/Post/Detail/PostStickerOverlay';
+import { useStickerRevealStore } from '~/store/sticker-reveal.store';
+
+const IMAGE_ID = 1;
+
+type Batch = ReturnType<typeof BatchProvider.useStickerPlacementBatch>;
+
+const batchState: { value: Batch } = { value: null };
+
+const placement = (id: number) => ({
+  id,
+  imageId: IMAGE_ID,
+  isPending: false,
+  data: { cosmeticId: 5, x: 0.5, y: 0.5, scale: 0.25, rotation: 0 },
+});
+
+// Spread the real module: a hand-listed mock couples this file to the whole
+// transitive import graph of the provider, and nothing warns when that grows.
+vi.mock('~/components/Sticker/StickerPlacementBatchProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof BatchProvider>()),
+  useStickerPlacementBatch: () => batchState.value,
+}));
+
+// Stubbed because the thing under test is the rectangle this component measures
+// and hands down, not what the shared overlay draws inside it. The stub keeps the
+// wrapper's box readable: its parent IS the measured element.
+vi.mock('~/components/Sticker/StickerPlacementOverlay', () => ({
+  StickerPlacementOverlay: ({ placements }: { placements: unknown[] }) => (
+    <div data-testid="sticker-overlay">{placements.length}</div>
+  ),
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 7 }) }));
+
+/**
+ * The post page's shape, reduced to the part that decides the geometry: a
+ * positioned container whose only child is an INLINE anchor around the media.
+ * The anchor is what makes the container taller than the image — a line box
+ * reserves room for descenders under an inline image.
+ */
+function PostImageFixture() {
+  return (
+    <div data-testid="paper" style={{ position: 'relative', width: 400 }}>
+      <a href="#">
+        <img
+          data-testid="media"
+          src={LOADABLE_IMAGE_DATA_URI}
+          alt=""
+          style={{ width: '100%', height: 'auto', aspectRatio: '4 / 3' }}
+        />
+      </a>
+      <PostStickerOverlay imageId={IMAGE_ID} />
+    </div>
+  );
+}
+
+const el = (testId: string) =>
+  document.querySelector<HTMLElement>(`[data-testid="${testId}"]`) ?? null;
+
+const overlays = () => document.querySelectorAll('[data-testid="sticker-overlay"]').length;
+
+describe('PostStickerOverlay', () => {
+  beforeEach(() => {
+    batchState.value = {
+      count: 1,
+      placements: [placement(1)],
+      pending: [],
+      sticker: new Map(),
+      treatment: 'still',
+    } as unknown as Batch;
+    useStickerRevealStore.getState().setRevealed(true);
+  });
+
+  test('draws nothing while the reveal is off', async () => {
+    useStickerRevealStore.getState().setRevealed(false);
+    renderWithProviders(<PostImageFixture />);
+
+    // The image is the absorbing state here — it is present from the first
+    // paint and nothing removes it — so waiting on it is what proves the tree
+    // rendered before counting overlays that should not be there.
+    await vi.waitFor(() => expect(el('media')).not.toBeNull());
+    expect(overlays()).toBe(0);
+  });
+
+  test('sizes the sticker layer to the media, not to the container around it', async () => {
+    renderWithProviders(<PostImageFixture />);
+
+    await vi.waitFor(() => expect(overlays()).toBe(1));
+
+    const media = el('media');
+    const paper = el('paper');
+    const box = el('sticker-overlay')?.parentElement ?? null;
+    expect(media).not.toBeNull();
+    expect(paper).not.toBeNull();
+    expect(box).not.toBeNull();
+
+    // Control: without this the assertion below is vacuous, because measuring
+    // and not measuring produce the same number whenever the two boxes agree.
+    // This is the descender gap the measurement exists for.
+    expect(paper!.offsetHeight).toBeGreaterThan(media!.offsetHeight);
+
+    await vi.waitFor(() => {
+      expect(box!.offsetWidth).toBe(media!.offsetWidth);
+      expect(box!.offsetHeight).toBe(media!.offsetHeight);
+    });
+  });
+});

--- a/src/components/Post/Detail/PostStickerOverlay.browser.test.tsx
+++ b/src/components/Post/Detail/PostStickerOverlay.browser.test.tsx
@@ -38,13 +38,26 @@ vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 7 }) }))
 
 /**
  * The post page's shape, reduced to the part that decides the geometry: a
- * positioned container whose only child is an INLINE anchor around the media.
- * The anchor is what makes the container taller than the image — a line box
- * reserves room for descenders under an inline image.
+ * positioned container, an anchor around the media, and the overlay as the
+ * anchor's next sibling — which is the relationship the component navigates.
+ *
+ * The container is taller than the media HERE because no stylesheet loads in
+ * this project, so `img` keeps its inline default and the line box reserves
+ * descender room. Production has Tailwind's preflight, where `img` is a block
+ * and the two boxes agree (measured on `/posts/30077020`). So the gap below is
+ * a property of this fixture, and it is what makes the sizing assertion able to
+ * tell measuring from not-measuring at all — not a claim about the real page.
  */
 function PostImageFixture() {
   return (
     <div data-testid="paper" style={{ position: 'relative', width: 400 }}>
+      {/* The control group the post page renders above the media, standing in
+          for anything image-bearing someone adds to it later. It comes first in
+          document order, so a container-wide search finds this 16px icon
+          instead of the artwork. */}
+      <div>
+        <img data-testid="chip-icon" src={LOADABLE_IMAGE_DATA_URI} alt="" width={16} height={16} />
+      </div>
       <a href="#">
         <img
           data-testid="media"
@@ -99,8 +112,8 @@ describe('PostStickerOverlay', () => {
     expect(box).not.toBeNull();
 
     // Control: without this the assertion below is vacuous, because measuring
-    // and not measuring produce the same number whenever the two boxes agree.
-    // This is the descender gap the measurement exists for.
+    // and not measuring produce the same number whenever the two boxes agree —
+    // which is what production does. It proves this fixture can tell them apart.
     expect(paper!.offsetHeight).toBeGreaterThan(media!.offsetHeight);
 
     await vi.waitFor(() => {

--- a/src/components/Post/Detail/PostStickerOverlay.tsx
+++ b/src/components/Post/Detail/PostStickerOverlay.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from 'react';
+import { offsetWithin } from '~/components/Sticker/CardStickerOverlay';
+import { StickerPlacementOverlay } from '~/components/Sticker/StickerPlacementOverlay';
+import { useStickerPlacementBatch } from '~/components/Sticker/StickerPlacementBatchProvider';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useStickerRevealStore } from '~/store/sticker-reveal.store';
+
+type Box = { width: number; height: number; left: number; top: number };
+
+/** Matches `ImageStickerOverlay`: most of the image on screen, not a sliver. */
+const ARM_AT = 0.6;
+
+const same = (a: Box | null, b: Box) =>
+  !!a && a.width === b.width && a.height === b.height && a.left === b.left && a.top === b.top;
+
+/**
+ * Placed stickers on a post page image. Display only — no placing from here.
+ *
+ * Measured off the media element rather than stretched over the container, but
+ * for a different reason than the feed card's: a post has no hover transform and
+ * no `object-fit: cover`, so the container's own box is nearly right. Nearly —
+ * the media is wrapped in a `RoutedDialogLink`, which renders an inline anchor,
+ * and an inline box around an image carries the line-box descender gap. That
+ * makes the container a few pixels taller than the artwork, which tilts every
+ * vertical fraction by an amount that is invisible on a square image and wrong
+ * on a tall one.
+ *
+ * `artworkWidth` is left at `StickerPlacementOverlay`'s 512 rather than the
+ * card's 256: a post image draws at up to `MAX_POST_IMAGES_WIDTH` (800), where a
+ * default-capped sticker wants ~400 device pixels on a DPR-2 display.
+ */
+export function PostStickerOverlay({ imageId }: { imageId: number }) {
+  const currentUser = useCurrentUser();
+  const revealed = useStickerRevealStore((state) => state.revealed);
+  const batch = useStickerPlacementBatch(imageId);
+  const ref = useRef<HTMLDivElement>(null);
+  const [box, setBox] = useState<Box | null>(null);
+
+  // Off means off, pending included — same rule as the feed card. The chip
+  // beside the reactions still counts the viewer's own pending, so an owner who
+  // arrived from a notification has one press to what they came for.
+  const placements = batch && revealed ? batch.placements : [];
+
+  const hasPlacements = placements.length > 0;
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || !hasPlacements) return;
+
+    // The media is a sibling subtree: nesting the overlay inside the link would
+    // make it part of the link's click target.
+    const media = node.parentElement?.querySelector('img, video');
+    if (!media) return;
+
+    const measure = () => {
+      const element = media as HTMLElement;
+      if (element.offsetWidth <= 0 || element.offsetHeight <= 0) return;
+
+      const stop = node.offsetParent;
+      const at = offsetWithin(element, stop);
+      const self = offsetWithin(node, stop);
+      if (!at || !self) return;
+
+      const next = {
+        width: element.offsetWidth,
+        height: element.offsetHeight,
+        left: at.x - self.x,
+        top: at.y - self.y,
+      };
+      setBox((current) => (same(current, next) ? current : next));
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    observer.observe(media);
+    return () => observer.disconnect();
+  }, [hasPlacements]);
+
+  // A post is a scroll, so an overlay that armed on mount would play its whole
+  // reveal for an image still thousands of pixels below the fold and be settled
+  // before anyone reached it.
+  const [armed, setArmed] = useState(false);
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || !hasPlacements) return;
+
+    // Stickers are held at zero opacity until armed, so the failure without an
+    // observer has to be "reveal immediately", never "stay hidden".
+    if (typeof IntersectionObserver === 'undefined') {
+      setArmed(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        // Keeps observing after the first hit: scrolling an image away disarms
+        // it, so scrolling back reveals again.
+        if (entry.intersectionRatio >= ARM_AT) setArmed(true);
+        else if (entry.intersectionRatio === 0) setArmed(false);
+      },
+      { threshold: [0, ARM_AT] }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [hasPlacements]);
+
+  // Narrows `batch` as well: `placements` is empty without one.
+  if (!batch || !hasPlacements) return null;
+
+  return (
+    <div ref={ref} className="pointer-events-none absolute inset-0 overflow-hidden">
+      {box && (
+        <div className="pointer-events-none absolute" style={box}>
+          <StickerPlacementOverlay
+            placements={placements}
+            viewerId={currentUser?.id}
+            interactive={false}
+            sticker={batch.sticker}
+            treatment={batch.treatment}
+            surface="detail"
+            stagger
+            armed={armed}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Post/Detail/PostStickerOverlay.tsx
+++ b/src/components/Post/Detail/PostStickerOverlay.tsx
@@ -16,14 +16,18 @@ const same = (a: Box | null, b: Box) =>
 /**
  * Placed stickers on a post page image. Display only — no placing from here.
  *
- * Measured off the media element rather than stretched over the container, but
- * for a different reason than the feed card's: a post has no hover transform and
- * no `object-fit: cover`, so the container's own box is nearly right. Nearly —
- * the media is wrapped in a `RoutedDialogLink`, which renders an inline anchor,
- * and an inline box around an image carries the line-box descender gap. That
- * makes the container a few pixels taller than the artwork, which tilts every
- * vertical fraction by an amount that is invisible on a square image and wrong
- * on a tall one.
+ * Sized to the media element, not to the container. A placement is a fraction of
+ * the artwork's bounds, and the container's height is derived from the image's
+ * *stored* dimensions (`PostImages.tsx` sets `aspectRatio` from
+ * `image.width`/`image.height`) — a different source of truth from the file the
+ * CDN actually serves, and only the served file is what a fraction means.
+ *
+ * Measured rather than assumed, on `/posts/30077020` (a 1006x1520 image): the
+ * container and the media are the same box, 1100px both, with and without that
+ * `aspectRatio`. The `RoutedDialogLink` anchor computes to `display: inline`,
+ * but it contributes no descender gap, because Tailwind's preflight makes `img`
+ * a block. So this is not correcting a divergence that exists today; it is
+ * declining to depend on two sources agreeing.
  *
  * `artworkWidth` is left at `StickerPlacementOverlay`'s 512 rather than the
  * card's 256: a post image draws at up to `MAX_POST_IMAGES_WIDTH` (800), where a
@@ -47,9 +51,12 @@ export function PostStickerOverlay({ imageId }: { imageId: number }) {
     const node = ref.current;
     if (!node || !hasPlacements) return;
 
-    // The media is a sibling subtree: nesting the overlay inside the link would
-    // make it part of the link's click target.
-    const media = node.parentElement?.querySelector('img, video');
+    // The link immediately before this overlay, not the whole container: the
+    // overlay is a sibling of the link because nesting it inside would make it
+    // part of the link's click target, and searching the container instead
+    // would take the first `img`/`video` in document order — which is whatever
+    // the control group above the media happens to render.
+    const media = node.previousElementSibling?.querySelector('img, video');
     if (!media) return;
 
     const measure = () => {

--- a/src/components/Sticker/CardStickerOverlay.tsx
+++ b/src/components/Sticker/CardStickerOverlay.tsx
@@ -38,7 +38,7 @@ const same = (a: Box | null, b: Box) =>
  * positioned link, the overlay is a sibling of that link. Hence the walk rather
  * than a subtraction of two `offsetLeft`s.
  */
-const offsetWithin = (el: HTMLElement, stop: Element | null) => {
+export const offsetWithin = (el: HTMLElement, stop: Element | null) => {
   let x = 0;
   let y = 0;
   let current: HTMLElement | null = el;


### PR DESCRIPTION
Stickers placed on an image did not appear on the post page. This makes them appear there, with the same reveal toggle a feed card has. **Display only** — no placing, editing or tray from a post page.

## The post page was missing the provider, not just the layer

`src/components/Post/Detail/PostImages.tsx` had no sticker overlay, which is the visible half. The half that explains why this was not a one-line change: it also had no `StickerPlacementBatchProvider`. That provider is mounted in exactly one place, `src/components/Image/Providers/ImagesProvider.tsx:70`, and `useStickerPlacementBatch` deliberately has **no per-card fallback query** (`StickerPlacementBatchProvider.tsx:145-152`) so that a surface which forgets the provider fails visibly rather than reintroducing a request per card. `PostDetail.tsx` does not render `ImagesProvider`. So on a post page the placement data was never fetched at all.

The result was that a creator could configure per-image placement space from the post editor (`PostEditSidebar.tsx`, `PostImageCards/AddedImage.tsx` — the only `Sticker` references under `src/components/Post/`) and the stickers it earned were invisible on the post itself.

**The provider is fed every image in the post, not the 20-item `_images` slice.** Its chunk memo keys on the joined id string (`StickerPlacementBatchProvider.tsx:53-61`), so handing it a slice that grows on "Load more" refetches the first twenty alongside the rest — a bug with no error attached to it, only extra queries nobody counts.

**It is mounted unguarded, and that costs nothing when the flag is off.** It reads like an unflagged query for every post viewer; it is not. It self-gates on `!!features.stickers && !!features.stickerPlacement`, produces `[]` chunks, and returns `<>{children}</>` — no query, and no wrapper element in the DOM.

## Geometry: measured, and the first reason I gave for it was wrong

The overlay sizes itself to the media element rather than stretching over the container. **The original rationale in this PR was that `RoutedDialogLink` renders an inline Mantine `Anchor`, so the container carries a line-box descender gap under the image. That was measured on a real post and is false** — see the comment below for the numbers. Tailwind's preflight sets `img { display: block }`, so the anchor being inline never produces a gap, and container and media are the same box.

**The reason that survives, and the one the code now states:** the container's height comes from the image's **stored** dimensions (`PostImages.tsx:98-109` sets `aspectRatio` from `image.width`/`image.height`) while a placement is a fraction of **the file the CDN serves**. Those are two sources of truth, and only the served file is what a fraction means. Measuring declines to depend on them agreeing.

**Declared gap: the video path is unverified either way, and it is the case most likely to diverge.** `EdgeVideo` renders through a wrapper `EdgeMedia` does not use for images. No dev post has both a video and a placement, so neither agreement nor divergence has been observed there. That gap is most of the argument for keeping the measurement rather than using `inset-0`: the agreement is verified for images and unverifiable for video, and dropping it would buy silent misplacement on the surface that could not be tested.

`offsetWithin` is now exported from `CardStickerOverlay.tsx` (a one-line change, no behaviour) rather than copied — 25 lines of duplicated measurement geometry is the kind of copy where the original gets a fix and the copy does not.

The media is found via `node.previousElementSibling` — the link — not the container: a container-wide `querySelector('img, video')` takes the first raster element in document order, which is whatever the control group above the media renders.

Two constants deliberately not re-derived:
- **`artworkWidth` stays at `StickerPlacementOverlay`'s 512 default.** The card's 256 is derived for a 450px card; a post image draws at up to `MAX_POST_IMAGES_WIDTH` (800), where a default-capped sticker wants ~400 device px at DPR 2.
- **`surface="detail"`.** The two surface-dependent behaviours — an inset pending ring, and a card-scale die-cut edge with an animation fallback — both exist because a card crops with `cover`. A post image does not crop. The card overrides both defaults; this does not.

## Reveal toggle

`useStickerRevealStore` is one persisted site-wide flag (`src/store/sticker-reveal.store.ts`), so per-image vs per-post only decides where the control sits, not what it drives. This uses the per-image chip, `StickerPlacementCardBadge`, unchanged: it returns `null` when an image has no stickers, so it is also the only per-image indication of which images in a post carry them.

It sits beside the blur toggle rather than the reactions, where a feed card puts it, because the post page's reaction bar moves between three corners depending on video controls — and because its tooltip is "Show stickers on all images", making it a page-level control that belongs with the persistent ones.

Reveal is staggered on intersection rather than on mount — a post is a scroll, and an overlay armed at mount plays its whole reveal for an image still thousands of pixels below the fold. It carries the `ImageStickerOverlay` fallback with it: no `IntersectionObserver` means reveal immediately, never stay hidden.

## Verification, including what is not covered

`src/components/Post/Detail/PostStickerOverlay.browser.test.tsx`, browser mode so the layout is real rather than a fake's return value. Both tests were checked by mutation, not by observing that they pass:

| mutation | result |
|---|---|
| drop the reveal gate (`batch && revealed` → `batch`) | `expected 1 to be +0` — `1 failed \| 1 passed (2)`, exit 1 |
| search the container rather than the link (`previousElementSibling` → `parentElement`) | `expected 16 to be 400` — the overlay measures the control group's 16px icon. `1 failed \| 1 passed (2)`, exit 1 |
| measure the container instead of the media | `expected 182704 to be 300` — `1 failed \| 1 passed (2)`, exit 1 |
| measure the overlay node's own box | `expected +0 to be 300` — `1 failed \| 1 passed (2)`, exit 1 |

The sizing test carries a control assertion — the container is taller than the media **in the fixture** — because without it the assertion is vacuous whenever the two boxes agree, which is what production does. The gap it asserts exists only because no stylesheet loads in the component project; it is what lets the test tell measuring from not-measuring at all, not a claim about the real page.

**Declared gaps, rather than tests that cannot fail:**
- **The video path** (above): unverified either way, and the case most likely to diverge.
- There is no test for "renders nothing without a batch provider". With no provider the placement list is empty and the empty-list path already returns `null`, so no mutation of this component can make such a test fail. It would name a failure it cannot detect.
- The reveal *animation* (stagger, arming on intersection) is not asserted. Arming is a self-deleting state and the honest options were a race or a widened timeout; the mocked overlay in the test does not draw it either.

Clean run: `Test Files 1 passed (1)`, `Tests 2 passed (2)`, exit 0, log naming `C:/Dev/Repos/work/wt-post-stickers`. `TYPECHECK_HEAP_MB=12288 pnpm run typecheck` → `OK — 0 type errors in 42s`. ESLint over the changed files — 0 errors (warnings are pre-existing unused imports and two fixture `<img>`s that must stay raw). Full unit suite result posted as a comment.

Note on the diff size: `PostImages.tsx` shows as a rewrite because wrapping the list in the provider re-indented the whole JSX body under Prettier. The semantic change there is four lines.
