### PR TITLE
fix(app-listings): rate-limit getMyListingForApp (60/60), and prove it enforced

### DIFF
--- a/src/server/routers/__tests__/app-listings.router.getMyListingForApp.rate-limit.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.getMyListingForApp.rate-limit.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// Type-only, so they are erased and safe to reference from the hoisted `vi.mock`
+// factories below (and `@typescript-eslint/consistent-type-imports` bans the inline
+// `typeof import(...)` form the older sibling suites use).
+import type * as FeatureFlagsService from '~/server/services/feature-flags.service';
+import type * as EnvOther from '~/env/other';
+
+/**
+ * civitai/civitai#4003 — `appListings.getMyListingForApp` is RATE-LIMITED, enforced.
+ *
+ * The proc's slug arm resolves any top-level listing and distinguishes "not yours"
+ * (NOT_OWNED→FORBIDDEN) from "no such row" (NOT_FOUND), so an unlimited `.query` is a
+ * slug-existence oracle over the whole namespace. `.use(rateLimit({ limit: 60,
+ * period: 60 }))` meters it.
+ *
+ * 🔴 This file deliberately does NOT mock `~/server/middleware.trpc` — every sibling
+ * router test stubs `rateLimit` to a pass-through, which is exactly what makes those
+ * suites blind to whether the middleware is wired at all. Here the REAL middleware
+ * runs, against the globally-mocked redis client, so the assertions are about the
+ * procedure's own chain.
+ *
+ * Two things had to be defeated for the limiter to be reachable at all, and both are
+ * why a naive "call it 61 times" test would pass with the middleware DELETED:
+ *   - `rateLimit` early-returns when `isDev || isTest || isPreview` → `~/env/other` is
+ *     mocked with `isTest: false` (everything else actual).
+ *   - it also early-returns for moderators → the caller is a NON-mod author from the
+ *     tester cohort, with `getFeatureFlags().appBlocksAuthor` mocked true for them.
+ *
+ * The matrix pins BOTH numbers rather than just "it can throw":
+ *   - 61 attempts spread across the last 59s → TOO_MANY_REQUESTS  (kills limit > 60,
+ *     and kills a SHORTER period, which would age most of that spread out)
+ *   - 60 attempts across the same window     → resolves           (kills limit < 60)
+ *   - 200 attempts, all 90–120s old          → resolves           (kills a LONGER
+ *     period, e.g. the 3600 the write procs use, which would count every one)
+ *
+ * The window arithmetic is `attempts > limit` in the middleware (strictly greater), so
+ * 60 recorded attempts is the last passing state and 61 is the first refusal.
+ */
+
+const AUTHOR_IDS = new Set([2]); // non-mod app-dev-tester cohort
+
+const { mockGetMyListingForApp, mockHSetWithTTL, mockIsAppBlocksAuthorEnabled } = vi.hoisted(
+  () => ({
+    mockGetMyListingForApp: vi.fn(async () => ({ appListingId: 'apl_1', status: 'draft' })),
+    mockHSetWithTTL: vi.fn(async () => undefined),
+    mockIsAppBlocksAuthorEnabled: vi.fn(async () => true),
+  })
+);
+
+vi.mock('~/server/services/blocks/offsite-listing.service', () => ({
+  getMyListingForApp: mockGetMyListingForApp,
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: vi.fn(async () => true),
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+  isAppListingsEnabled: vi.fn(async () => true),
+  resolveStoreVisibilityScope: vi.fn(async () => 'full'),
+}));
+// `appDeveloperProcedure` gates on `getFeatureFlags(ctx).appBlocksAuthor`; the cohort
+// rule mirrors the sibling authz suite (mod floor OR the tester cohort).
+vi.mock('~/server/services/feature-flags.service', async () => {
+  const actual = await vi.importActual<typeof FeatureFlagsService>(
+    '~/server/services/feature-flags.service'
+  );
+  return {
+    ...actual,
+    getFeatureFlags: (ctx: { user?: { id?: number; isModerator?: boolean } }) => ({
+      appBlocksAuthor: !!ctx.user && (!!ctx.user.isModerator || AUTHOR_IDS.has(ctx.user.id ?? -1)),
+    }),
+  };
+});
+// The one lever that makes the limiter run at all under vitest.
+vi.mock('~/env/other', async () => ({
+  ...(await vi.importActual<typeof EnvOther>('~/env/other')),
+  isDev: false,
+  isTest: false,
+  isPreview: false,
+}));
+// The quota WRITE. Stubbed so the sliding-window read is the only thing under test
+// (and so a fail-open log line can't be mistaken for the limiter working).
+vi.mock('~/server/redis/atomic', () => ({ hSetWithTTL: mockHSetWithTTL }));
+vi.mock('~/server/utils/server-domain', () => ({ isHostForColor: () => false }));
+
+import { TRPCError } from '@trpc/server';
+import { appListingsRouter } from '../app-listings.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+const mockHGet = redisMock.redis.packed.hGet;
+
+const author = { id: 2, isModerator: false, tier: 'free', username: 'tester', onboarding: 0x1f };
+
+function authorCtx() {
+  return {
+    acceptableOrigin: true,
+    user: author as never,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+/** `n` recorded attempts spread evenly across the `spanMs` immediately before now. */
+function attemptsSpanning(n: number, spanMs: number, offsetMs = 0) {
+  const now = Date.now();
+  return Array.from({ length: n }, (_, i) => now - offsetMs - Math.round((spanMs * i) / n));
+}
+
+function call() {
+  return appListingsRouter.createCaller(authorCtx() as never).getMyListingForApp({
+    appBlockId: 'apb_1',
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetMyListingForApp.mockResolvedValue({ appListingId: 'apl_1', status: 'draft' });
+  mockIsAppBlocksAuthorEnabled.mockResolvedValue(true);
+  mockHGet.mockResolvedValue([]);
+});
+
+describe('getMyListingForApp — the rate limit is ENFORCED (civitai#4003)', () => {
+  it('refuses with TOO_MANY_REQUESTS once the window holds more than 60 attempts', async () => {
+    mockHGet.mockResolvedValue(attemptsSpanning(61, 59_000));
+
+    const err = await call().then(
+      () => null,
+      (e: unknown) => e as TRPCError
+    );
+
+    expect(err).toBeInstanceOf(TRPCError);
+    expect(err?.code).toBe('TOO_MANY_REQUESTS');
+    expect(err?.message).toBe('Too many listing lookups — slow down.');
+    // The refusal happens BEFORE the resolve — no row is read for a metered probe.
+    expect(mockGetMyListingForApp).not.toHaveBeenCalled();
+  });
+
+  it('still serves the 60th attempt in the window (the limit is 60, not lower)', async () => {
+    mockHGet.mockResolvedValue(attemptsSpanning(60, 59_000));
+
+    await expect(call()).resolves.toEqual({ appListingId: 'apl_1', status: 'draft' });
+    expect(mockGetMyListingForApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('ages attempts out after 60s — 200 older ones do not refuse (the period is 60, not hourly)', async () => {
+    // 200 attempts, every one between 90s and 120s ago: outside a 60s window, inside
+    // any longer one. A period of 3600 (this router's write shape) would refuse here.
+    mockHGet.mockResolvedValue(attemptsSpanning(200, 30_000, 90_000));
+
+    await expect(call()).resolves.toEqual({ appListingId: 'apl_1', status: 'draft' });
+    expect(mockGetMyListingForApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the served attempt against the caller quota', async () => {
+    mockHGet.mockResolvedValue([]);
+
+    await call();
+
+    expect(mockHSetWithTTL).toHaveBeenCalledTimes(1);
+    // Bucketed by user id, not by IP — the author is authenticated.
+    expect(mockHSetWithTTL.mock.calls[0]?.[2]).toBe(`user:${author.id}`);
+  });
+
+  it('does not record an attempt for a refused call beyond recording nothing new', async () => {
+    mockHGet.mockResolvedValue(attemptsSpanning(61, 59_000));
+
+    await expect(call()).rejects.toThrow();
+
+    expect(mockHSetWithTTL).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -633,9 +633,31 @@ export const appListingsRouter = router({
    * CALLER'S OWN listing only — nothing here is exposed to a public listing DTO);
    * typed failures map via `mapOffsiteError` (NOT_OWNED→FORBIDDEN, NOT_FOUND when no
    * listing row exists for the app).
+   *
+   * Rate-limited because the SLUG arm resolves any top-level listing and its two
+   * outcomes are distinguishable (NOT_OWNED→FORBIDDEN vs NOT_FOUND), i.e. it answers
+   * "does this slug exist?" for rows the public catalogue never shows — civitai#4003.
+   * Bounding is defence-in-depth, not closure: `submitExternalListing`'s
+   * `slugTakenError` is the same oracle at 10/hour. See the enforcement matrix in
+   * `app-listings.router.getMyListingForApp.rate-limit.test.ts` — both numbers are
+   * pinned there, so change them together.
    */
   getMyListingForApp: appDeveloperProcedure
     .meta(listingMediaCliScope)
+    .use(
+      rateLimit({
+        // A READ limit, shaped like this router's other reads (`getAppDetail`,
+        // `listAvailable`, `listReviews` are all 60/60) rather than like the hourly
+        // write caps — it must not interrupt authoring. The media editor invalidates
+        // this query after EVERY asset mutation, and the heaviest legitimate burst
+        // (a screenshot batch + icon + cover + reorders) is well under a refetch a
+        // second; the CLI calls it once per `app listing`. 60/60 clears both with
+        // room, while turning an unbounded enumeration into a metered one.
+        limit: 60,
+        period: 60,
+        errorMessage: 'Too many listing lookups — slow down.',
+      })
+    )
     .input(getMyListingForAppSchema)
     .query(async ({ ctx, input }) => {
       if (!ctx.user) throw throwAuthorizationError('Not authenticated');


### PR DESCRIPTION
Resolves civitai/civitai#4003

## What

`appListings.getMyListingForApp` (`app-listings.router.ts:637`) was an unrate-limited `.query`. Since #3989 its slug arm resolves **any** top-level listing (either kind, any status), and its two outcomes are distinguishable — `NOT_OWNED` → `FORBIDDEN` vs `NOT_FOUND` — so it answered *"does this slug exist?"* over the whole `AppListing` namespace, including the `draft` / `pending` / `rejected` / `removed` rows the public catalogue (`getAppDetail`, approved-only) never shows. At whatever rate the caller wanted.

One `.use(rateLimit({ limit: 60, period: 60 }))` between `.meta(...)` and `.input(...)`, plus an enforcement test.

## The numbers, and why

**`{ limit: 60, period: 60 }` — a READ limit.**

- **Shape.** This router's reads are all 60/60 (`getAppDetail:1340`, `listAvailable:1318`, `listReviews:1424`); its hourly caps (10–60 / 3600) are on the *writes* (`submitExternalListing`, `updateListing`, `submitListingRevision`, `persistAssetImage`, the two ingests). This is a read, so it takes the read shape. Issue #4003's own option 1 proposes the same.
- **It must not interrupt authoring.** `ListingMediaEditor` invalidates this query after **every** asset mutation (`handleAssetMutated`, plus `handleSubmit`), and the query is `staleTime: Infinity` / `retry: false`, so each invalidation is exactly one refetch. The heaviest legitimate burst — a screenshot batch plus icon, cover, reorders, caption edits — is nowhere near a refetch a second, and it is independently capped upstream by `persistAssetImage` at 60/hour. The CLI (`internal/appapi/listing.go`, `resolveListing`) calls it **once per `civitai app listing …` invocation**. 60/60 clears both with room.
- **An hourly cap was considered and rejected.** One tight enough to bound sustained enumeration meaningfully (a few hundred/hour) sits uncomfortably close to a heavy editing session, and the repo has **zero** precedent for the middleware's array form — `grep` finds no `rateLimit([...])` anywhere — so a dual limit would be the first exercise of that path in production. Not worth it for this cohort.

## Honest scope: defence-in-depth, not closure

This **bounds** the oracle; it does not remove it.

- The same information is still reachable, by the same cohort, through `submitExternalListing`'s `slugTakenError` (`findUnique({ where: { slug } })`, no kind/status/`revisionOfId` filter) at **10/hour**. That path is untouched here.
- 60/60 still permits 3600 probes/hour sustained — far more than that 10/hour comparator. The value delivered is that an *unbounded* enumeration behind a read becomes a *metered* one; it is not an information-leak fix. Option 2 in the issue (collapse `NOT_OWNED` onto `NOT_FOUND` for the slug arm) is the one that would actually remove the discriminator, at the cost of a worse error for the legitimate wrong-account case — and it would still leave `submitExternalListing` standing. Not attempted here.
- Mitigations that already existed and are unchanged: the cohort is gated (`appDeveloperProcedure` → `appBlocksAuthor`, static fallback `availability: ['mod']` + Flipt), and #3988 (`beaa9a6dda`) capped tRPC batch width at 30 server-side, so per-request amplification was already bounded.

## The enforcement test — red/green evidence

`src/server/routers/__tests__/app-listings.router.getMyListingForApp.rate-limit.test.ts` (5 tests).

🔴 **It deliberately does not stub `~/server/middleware.trpc`.** Every sibling router suite mocks `rateLimit` to a pass-through, which is precisely what makes them unable to see whether a limiter is wired at all. Here the real middleware runs against the globally-mocked redis client.

Two early-returns had to be defeated, and both are why a naive "call it 61 times" test would pass with the middleware **deleted**:
- `rateLimit` returns early when `isDev || isTest || isPreview` → `~/env/other` is mocked with `isTest: false` (everything else actual).
- it also returns early for moderators → the caller is a **non-mod** author from the tester cohort, with `getFeatureFlags().appBlocksAuthor` mocked true for them.

**Mutation matrix — every mutant killed, each by the test that is supposed to own it** (source restored and md5-verified identical afterwards):

| mutant | result | killed by |
| --- | --- | --- |
| `.use(rateLimit({…}))` **deleted** | 3 failed / 2 passed | the refusal case, the quota-write case, the no-write-on-refusal case |
| `limit: 60` → `30` | 1 failed | "still serves the 60th attempt" |
| `limit: 60` → `120` | 2 failed | the refusal case + no-write-on-refusal |
| `period: 60` → `3600` | 1 failed | "ages attempts out after 60s" |
| `period: 60` → `30` | 2 failed | the refusal case + no-write-on-refusal |
| `errorMessage` → a neighbour's wording | 1 failed | the refusal case (asserts the whole string) |

Unmutated: **5/5 green**. The three window cases are built so each number is pinned from both sides — 61 attempts *spread across the last 59s* refuse (kills a larger limit **and** a shorter period, which would age most of that spread out), 60 across the same window still serve (kills a smaller limit), and 200 attempts aged 90–120s do not refuse (kills a longer period). The middleware compares `attempts > limit`, so 60 recorded is the last passing state.

## Gate

Run in a clean worktree off `origin/main` (`4288b08efc`), toolchain via the repo flake.

- `pnpm run typecheck` — **OK, 0 type errors** (70s)
- `pnpm run lint` — 4366 problems (371 errors, 3995 warnings), all pre-existing. `eslint` on **just the two touched files** → **0 problems**. (It caught two real ones first: `typeof import(...)` inline type annotations, banned by `@typescript-eslint/consistent-type-imports`; converted to top-level `import type`. The older sibling suites still use the inline form — that's part of the 371.)
- `pnpm run prettier:write` — both files formatted, diff reviewed
- `pnpm run test:unit:run` — **1123 passed | 1 skipped (1124 files)**, **17547 passed | 21 skipped (17568 tests)**, 124s. Both projects ran (17 `unit` + 6 `unit-native` files visible in the tail; the six `unit-native` files match the documented count). 0 `FAIL` lines, 0 `timed out` panics — counted from the output, not read off the exit code.
- CLI wire contract unaffected: `app-collaborator.cli-contract.test.ts` + `app-listings.router.cli-scope.test.ts` + `app-listings.router.offsite-authz.test.ts` → **91/91 green**. Nothing about the input shape changed; the limiter sits above `.input(...)`.

Based directly on `main`, not stacked.
