### PR TITLE
feat(placement): free-placement UI polish across queues and the sticker

### DIFF
--- a/src/components/Placement/PlacementFreeBadge.tsx
+++ b/src/components/Placement/PlacementFreeBadge.tsx
@@ -1,0 +1,58 @@
+import { Anchor, Badge, Popover, Text } from '@mantine/core';
+import Link from 'next/link';
+
+/**
+ * That this one cost nothing, and where the owner changes that.
+ *
+ * Shared by both review queues and the sticker overlay so the fact reads the
+ * same everywhere it appears — same colour, same words, same explanation.
+ *
+ * The popover exists because a queue is where a creator first meets a free
+ * placement, arriving from a notification, and "why is this free and how do I
+ * stop it" otherwise has no answer on the page they are standing on.
+ */
+export function PlacementFreeBadge({
+  /** What was placed here: `placement` on stickers, `submission` on galleries. */
+  noun,
+  /**
+   * Solid rather than tinted. `light` is a translucent fill, which is legible on
+   * a queue card and unreadable over artwork — so the copy on an image asks for
+   * this, and nothing else should need it.
+   */
+  solid = false,
+}: {
+  noun: 'placement' | 'submission';
+  solid?: boolean;
+}) {
+  return (
+    // `withinPortal` explicitly: the repo theme sets `withinPortal: false` for
+    // every Popover (`ThemeProvider.tsx:35`), and this one opens inside a queue
+    // card that clips it — the dropdown came out truncated.
+    <Popover width={240} withArrow shadow="md" position="top" withinPortal>
+      <Popover.Target>
+        {/* A real button, so Enter and Space reach it and it lands in the tab
+            order — `Popover.Target` supplies the click itself. */}
+        <Badge
+          component="button"
+          type="button"
+          size="sm"
+          variant={solid ? 'filled' : 'light'}
+          color="blue"
+          className="w-fit cursor-pointer"
+        >
+          Free {noun}
+        </Badge>
+      </Popover.Target>
+      <Popover.Dropdown>
+        {/* Two short lines on purpose. It sits over a decision, not beside an
+            article, and the long version was read past. */}
+        <Text size="sm" style={{ whiteSpace: 'normal' }}>
+          They spent their one free {noun} of the day here. It earns you no Buzz.
+        </Text>
+        <Anchor component={Link} href="/user/account" size="sm" mt={6} className="block">
+          Choose how many free ones you take
+        </Anchor>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}

--- a/src/components/Placement/PlacementFreeFilter.tsx
+++ b/src/components/Placement/PlacementFreeFilter.tsx
@@ -1,0 +1,34 @@
+import { Chip } from '@mantine/core';
+
+/**
+ * Show or hide the free rows in a review queue. A chip rather than a switch, on
+ * Justin's call, so it sits beside the select-all control as one row of queue
+ * controls.
+ *
+ * Shared across the sticker queue and the remix submission queue because an
+ * owner meets the same decision on both, and the two queues are meant to read
+ * as one system — the free badge on a row is already the same badge in both
+ * places.
+ *
+ * Filters what is already loaded rather than what is fetched. Both queues are
+ * cursor-paged and both say something careful about a page whose rows were all
+ * dropped ("nothing on this page can be shown — there are more waiting"); a
+ * server-side filter changes what a page contains and makes that copy describe
+ * something else.
+ */
+export function PlacementFreeFilter({
+  show,
+  onChange,
+  /** Plural of what the queue holds: `placements`, `submissions`. */
+  noun,
+}: {
+  show: boolean;
+  onChange: (show: boolean) => void;
+  noun: string;
+}) {
+  return (
+    <Chip size="xs" checked={show} onChange={onChange} variant="light" className="shrink-0">
+      Free {noun}
+    </Chip>
+  );
+}

--- a/src/components/Placement/PlacementFreeSlotSlider.tsx
+++ b/src/components/Placement/PlacementFreeSlotSlider.tsx
@@ -63,6 +63,9 @@ export function PlacementFreeSlotSlider({
         </InfoPopover>
       </Group>
       <Slider
+        // The marks sit under the track and the caption sits on their row, same
+        // as the price slider. Without this they land on top of each other.
+        mb="lg"
         // The visible label is a sibling `Text`, so without this the thumb
         // reaches assistive tech — and any test driving it — as an unnamed
         // slider, indistinguishable from the price one beside it.
@@ -75,16 +78,17 @@ export function PlacementFreeSlotSlider({
         step={1}
         label={null}
         marks={[
-          { value: 0, label: 'None' },
+          { value: 0, label: '0' },
           { value: cap, label: `${cap}` },
         ]}
       />
-      {/* Clears the marks, which sit under the track. */}
-      <Text size="sm" c="dimmed" mt={16}>
-        <Text span fw={600} c="var(--mantine-color-text)">
-          {effective}
-        </Text>{' '}
-        {effective === 1 ? noun[0] : noun[1]} per image
+      {/* Sits on the marks' row in the same size and colour as the price
+          caption at each caller, so the two values on one settings page read as
+          one control rather than two. Bounded to the number and the unit for
+          the same reason `placementPriceCaption` is: the marks are pinned left
+          and right and this is centred between them. */}
+      <Text size="xs" ta="center" mt={-22} c="dimmed">
+        {effective} per image
       </Text>
     </Stack>
   );

--- a/src/components/Placement/__tests__/free-filter.test.ts
+++ b/src/components/Placement/__tests__/free-filter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { selectionAfterHidingFree, visibleQueueRows } from '~/components/Placement/free-filter';
+
+const rows = [
+  { id: 1, free: false },
+  { id: 2, free: true },
+  { id: 3, free: false },
+  { id: 4, free: true },
+];
+
+describe('visibleQueueRows', () => {
+  it('shows everything while free rows are shown', () => {
+    expect(visibleQueueRows(rows, true).map((row) => row.id)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('drops the free rows when they are hidden', () => {
+    expect(visibleQueueRows(rows, false).map((row) => row.id)).toEqual([1, 3]);
+  });
+});
+
+/**
+ * The half that decides what a bulk Approve or Decline acts on. Both are
+ * irreversible, so a selection carrying rows the filter just hid would move
+ * money on placements the owner can no longer see — and the count beside the
+ * buttons would still be counting them.
+ */
+describe('selectionAfterHidingFree', () => {
+  it('keeps the paid rows and drops the free ones', () => {
+    expect(selectionAfterHidingFree([1, 2, 3, 4], rows)).toEqual([1, 3]);
+  });
+
+  it('drops an id whose row is not there at all', () => {
+    expect(selectionAfterHidingFree([1, 99], rows)).toEqual([1]);
+  });
+
+  it('leaves a selection of paid rows alone', () => {
+    expect(selectionAfterHidingFree([3, 1], rows)).toEqual([3, 1]);
+  });
+});

--- a/src/components/Placement/free-filter.ts
+++ b/src/components/Placement/free-filter.ts
@@ -1,0 +1,31 @@
+/**
+ * What a review queue shows, and what stays selected, when the free rows are
+ * hidden.
+ *
+ * Its own module because the queues are pages: nothing under `src/pages` can
+ * carry a test — Next treats every file there as a route — and the selection
+ * rule below is the half worth testing. Inline in the page it would be a
+ * one-line filter whose failure is a bulk action on rows nobody can see.
+ */
+
+/** The rows on screen. `showFree` false drops the free ones. */
+export function visibleQueueRows<T extends { free: boolean }>(rows: T[], showFree: boolean) {
+  return showFree ? rows : rows.filter((row) => !row.free);
+}
+
+/**
+ * The selection, with anything the filter just hid taken out of it.
+ *
+ * Approve and Decline are irreversible and both say something about money, so a
+ * selection that outlives the rows it was made from acts on placements the owner
+ * can no longer see — and the count beside the buttons would still include them.
+ *
+ * An id whose row is not in `rows` at all is dropped too. Selection only ever
+ * comes from loaded rows, so that case is a row that went away underneath it.
+ */
+export function selectionAfterHidingFree(
+  selected: number[],
+  rows: { id: number; free: boolean }[]
+) {
+  return selected.filter((id) => rows.some((row) => row.id === id && !row.free));
+}

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -7,6 +7,9 @@ import { orderPlacements, placementRevealDelays } from '~/components/Sticker/pla
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
 import { StickerPlacementHoverCard } from '~/components/Sticker/StickerPlacementHoverCard';
+import { PlacementFreeBadge } from '~/components/Placement/PlacementFreeBadge';
+import { freeMarkerVisible } from '~/components/Sticker/free-marker';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import {
   STILL_STICKER_TREATMENT,
   resolveTreatment,
@@ -173,6 +176,9 @@ export function StickerPlacementOverlay({
 
   // Ordered here rather than trusted from the caller: this component decides
   // what covers what, and the paint order of these elements IS that decision.
+  // Only for the moderator flag. Who the viewer is comes from `viewerId`, which
+  // the surfaces already pass and the server-side render has.
+  const currentUser = useCurrentUser();
   const ordered = useMemo(() => orderPlacements(placements), [placements]);
   // Off the full history, not off the visible slice: stepping through a replay
   // must not re-pace the stickers already on screen.
@@ -320,6 +326,15 @@ export function StickerPlacementOverlay({
           // would be a filter where a refusal is needed.
           const isOwner = placement.ownerId === viewerId;
 
+          const showsFree = freeMarkerVisible({
+            free: placement.free,
+            isPending: placement.isPending,
+            ownerId: placement.ownerId,
+            placerId: placement.placerId,
+            viewerId,
+            isModerator: currentUser?.isModerator,
+          });
+
           const dressed = resolveTreatment({
             treatment,
             surface,
@@ -408,6 +423,24 @@ export function StickerPlacementOverlay({
                     surface === 'card' ? 'inset-0' : '-inset-1'
                   )}
                 />
+              )}
+
+              {/* Centred under the sticker, directly above the owner's approve
+                  and decline controls — those are positioned off the sticker's
+                  measured height, so this rides the same edge they start from.
+
+                  Inside the artwork's box on a card for the same reason the
+                  pending ring is: a card clips anything outset. */}
+              {showsFree && (
+                <div
+                  className={clsx(
+                    'absolute left-1/2 -translate-x-1/2 whitespace-nowrap',
+                    interactive && 'pointer-events-auto',
+                    surface === 'card' ? 'bottom-0' : '-bottom-3'
+                  )}
+                >
+                  <PlacementFreeBadge noun="placement" solid />
+                </div>
               )}
             </div>
           );

--- a/src/components/Sticker/__tests__/free-marker.test.ts
+++ b/src/components/Sticker/__tests__/free-marker.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { freeMarkerVisible } from '~/components/Sticker/free-marker';
+
+const OWNER = 1;
+const PLACER = 2;
+const STRANGER = 3;
+
+const placement = { free: true, isPending: true, ownerId: OWNER, placerId: PLACER };
+
+describe('freeMarkerVisible', () => {
+  it('shows the owner that a sticker on their image was free', () => {
+    expect(freeMarkerVisible({ ...placement, viewerId: OWNER })).toBe(true);
+  });
+
+  it('shows the placer their own free placement', () => {
+    expect(freeMarkerVisible({ ...placement, viewerId: PLACER })).toBe(true);
+  });
+
+  it('shows a moderator, who already sees the free fact in the takedown copy', () => {
+    expect(freeMarkerVisible({ ...placement, viewerId: STRANGER, isModerator: true })).toBe(true);
+  });
+
+  /**
+   * The assertion that decays silently. The positive cases break loudly the
+   * moment anyone touches the overlay; this one only breaks when someone widens
+   * the gate, which is the change nobody flags. How a placement was funded is
+   * private between the two parties to it.
+   */
+  it('tells a third-party viewer nothing about how the placement was funded', () => {
+    expect(freeMarkerVisible({ ...placement, viewerId: STRANGER })).toBe(false);
+  });
+
+  it('tells a signed-out viewer nothing either', () => {
+    expect(freeMarkerVisible({ ...placement, viewerId: undefined })).toBe(false);
+  });
+
+  /**
+   * `viewerId` is `undefined` when signed out and the ids are real numbers, so a
+   * loose comparison anywhere in this chain would hand every anonymous viewer
+   * the marker on every free placement.
+   */
+  it('does not treat a missing viewer as a match for a falsy id', () => {
+    expect(
+      freeMarkerVisible({
+        free: true,
+        isPending: true,
+        ownerId: 0,
+        placerId: 0,
+        viewerId: undefined,
+      })
+    ).toBe(false);
+  });
+
+  /**
+   * The mark belongs to the decision, not to the sticker. Once the owner has
+   * approved it, it is on the image on its own terms and nothing marks how it
+   * was funded — including for the owner, who already answered that question.
+   */
+  it('says nothing once the placement is approved', () => {
+    expect(freeMarkerVisible({ ...placement, isPending: false, viewerId: OWNER })).toBe(false);
+    expect(freeMarkerVisible({ ...placement, isPending: false, viewerId: PLACER })).toBe(false);
+    expect(
+      freeMarkerVisible({ ...placement, isPending: false, viewerId: STRANGER, isModerator: true })
+    ).toBe(false);
+  });
+
+  it('says nothing on a paid placement, to anyone', () => {
+    expect(freeMarkerVisible({ ...placement, free: false, viewerId: OWNER })).toBe(false);
+    expect(
+      freeMarkerVisible({ ...placement, free: false, viewerId: STRANGER, isModerator: true })
+    ).toBe(false);
+  });
+});

--- a/src/components/Sticker/__tests__/payout-copy.test.ts
+++ b/src/components/Sticker/__tests__/payout-copy.test.ts
@@ -3,6 +3,7 @@ import {
   declineConsequence,
   moderatorTakedownConsequence,
   payoutCopy,
+  placementAmountLine,
   placementPaymentSummary,
   removalConsequence,
   removalLockReason,
@@ -143,6 +144,33 @@ describe('the removal copy', () => {
 describe('placementPaymentSummary', () => {
   it('states the amount on a paid placement', () => {
     expect(placementPaymentSummary(700)).toBe('paid 700 Buzz');
+  });
+});
+
+/**
+ * The branch itself, which used to live inside `placementPaymentSummary` and
+ * then briefly inside the page — where nothing can test it, because Next treats
+ * every file under `src/pages` as a route.
+ *
+ * Both arms are asserted on purpose. Testing only the free one leaves the paid
+ * line free to stop naming an amount; testing only the paid one leaves the free
+ * row free to go back to claiming a payment of zero.
+ */
+describe('placementAmountLine', () => {
+  /**
+   * A free row is `amount: 0`, DB-enforced. Say the amount and the card asserts
+   * a payment of zero directly above an irreversible choice, on the page a
+   * notification saying "free" has just linked to.
+   */
+  it('names no amount on a free placement', () => {
+    const line = placementAmountLine(true, 0);
+
+    expect(line).toBe('placed this');
+    expect(line).not.toMatch(/paid|Buzz|0/);
+  });
+
+  it('still states the amount on a paid one', () => {
+    expect(placementAmountLine(false, 700)).toBe('paid 700 Buzz');
   });
 });
 

--- a/src/components/Sticker/__tests__/payout-copy.test.ts
+++ b/src/components/Sticker/__tests__/payout-copy.test.ts
@@ -142,19 +142,7 @@ describe('the removal copy', () => {
  */
 describe('placementPaymentSummary', () => {
   it('states the amount on a paid placement', () => {
-    expect(placementPaymentSummary(false, 700)).toBe('paid 700 Buzz');
-  });
-
-  /**
-   * A free row is `amount: 0`, DB-enforced. Unbranched, this card asserted a
-   * payment of zero directly above an irreversible choice, on the page a
-   * notification saying "free" had just linked to.
-   */
-  it('claims no payment on a free one, and names no amount', () => {
-    const free = placementPaymentSummary(true, 0);
-
-    expect(free).toBe('placed this free');
-    expect(free).not.toMatch(/paid|Buzz|0/);
+    expect(placementPaymentSummary(700)).toBe('paid 700 Buzz');
   });
 });
 

--- a/src/components/Sticker/free-marker.ts
+++ b/src/components/Sticker/free-marker.ts
@@ -1,0 +1,39 @@
+/**
+ * Who sees that a placed sticker cost nothing.
+ *
+ * The owner, the placer and moderators — nobody else. Everything else in this
+ * feature treats free-vs-paid as private between the two parties to it: the
+ * pending queue says "only you and the placer can see these", the hidden note
+ * says "only you, the person who placed it, and moderators". A public mark would
+ * be the first thing telling a stranger how a placement was funded, and it would
+ * say it about the owner's own settings on every image they own.
+ *
+ * A decision, not caution — see the PR. The overlay renders nothing at all when
+ * this is false rather than hiding a mark with CSS, because a hidden element is
+ * still in the DOM and that is not what the sentences above promise.
+ */
+export function freeMarkerVisible({
+  free,
+  isPending,
+  ownerId,
+  placerId,
+  viewerId,
+  isModerator = false,
+}: {
+  free: boolean;
+  /**
+   * Only while the owner has not answered it — Justin's call. Once a sticker is
+   * approved it is on the image on its own terms, and how it was funded stops
+   * being what the owner is deciding about.
+   */
+  isPending: boolean;
+  ownerId: number;
+  placerId: number;
+  /** Signed out is `undefined`, which must not match an id. */
+  viewerId?: number;
+  isModerator?: boolean;
+}) {
+  if (!free || !isPending) return false;
+  if (isModerator) return true;
+  return viewerId != null && (viewerId === ownerId || viewerId === placerId);
+}

--- a/src/components/Sticker/payout-copy.ts
+++ b/src/components/Sticker/payout-copy.ts
@@ -64,6 +64,21 @@ export function declineConsequence(free: boolean | undefined) {
 export const placementPaymentSummary = (amount: number) => `paid ${amount} Buzz`;
 
 /**
+ * Which of those a queue row says, which is the branch that must not be lost.
+ *
+ * Here rather than as a ternary in the page: `src/pages` cannot carry a test —
+ * Next treats every file under it as a route — so a `row.free ?` inline is a
+ * money statement with nothing able to assert it. Dropping the free arm makes
+ * the card read "paid 0 Buzz" over a free placement, on the page a "your
+ * placement was free" notification links to, immediately above an irreversible
+ * choice. Typecheck and every test still pass.
+ *
+ * The free arm names no amount at all — the badge beside it carries the fact.
+ */
+export const placementAmountLine = (free: boolean, amount: number) =>
+  free ? 'placed this' : placementPaymentSummary(amount);
+
+/**
  * What a moderator take-down does to the money.
  *
  * Two axes, and free breaks the pending one specifically: a pending PAID row

--- a/src/components/Sticker/payout-copy.ts
+++ b/src/components/Sticker/payout-copy.ts
@@ -56,13 +56,12 @@ export function declineConsequence(free: boolean | undefined) {
  * The queue row's headline, which is the only money statement on the card the
  * Approve and Decline buttons sit under.
  *
- * A free row carries `amount: 0`, enforced by the DB — so "paid 0 Buzz" is not a
- * cosmetic slip. It is the page the free-placement notification sends the creator
- * to: the notification says the placement was free and the card then asserts a
- * payment of zero, immediately above an irreversible choice.
+ * Paid rows only. A free row carries `amount: 0`, enforced by the DB, so this
+ * sentence would assert a payment of zero on the page the free-placement
+ * notification sends the creator to — immediately above an irreversible choice.
+ * The caller says nothing about money on a free row and badges it instead.
  */
-export const placementPaymentSummary = (free: boolean, amount: number) =>
-  free ? 'placed this free' : `paid ${amount} Buzz`;
+export const placementPaymentSummary = (amount: number) => `paid ${amount} Buzz`;
 
 /**
  * What a moderator take-down does to the money.

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -16,6 +16,10 @@ import { openConfirmModal } from '@mantine/modals';
 import { IconCheck, IconX } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { PlacementFreeBadge } from '~/components/Placement/PlacementFreeBadge';
+import { PlacementFreeFilter } from '~/components/Placement/PlacementFreeFilter';
+import { visibleQueueRows } from '~/components/Placement/free-filter';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { useServerDomains } from '~/providers/AppProvider';
 import { syncAccount } from '~/utils/sync-account';
@@ -179,6 +183,12 @@ function ReceivedTab({
 }) {
   const utils = trpc.useUtils();
   const withheldHref = useWithheldHref();
+  const [showFree, setShowFree] = useState(true);
+
+  // Filtered here rather than in the parent so the tab's own badge keeps
+  // counting everything waiting: hiding the free ones is a view of the queue,
+  // not a statement about how much is in it.
+  const visible = visibleQueueRows(rows, showFree);
 
   const act = trpc.placement.actOnRemixGallerySubmission.useMutation({
     onSuccess: (_result, variables) => {
@@ -242,6 +252,12 @@ function ReceivedTab({
 
   return (
     <Stack gap="md">
+      {rows.some((row) => row.free) && (
+        <Group justify="flex-end">
+          <PlacementFreeFilter show={showFree} onChange={setShowFree} noun="submissions" />
+        </Group>
+      )}
+
       {!rows.length && (
         <Text size="sm" c="dimmed">
           Nothing on this page can be shown — the images behind these submissions are gone or still
@@ -249,7 +265,16 @@ function ReceivedTab({
         </Text>
       )}
 
-      {rows.map((row) => (
+      {/* Said separately from the line above it, which is about rows the server
+          dropped. An empty queue because the owner hid the free ones is their
+          own doing, and telling them their images are gone would be false. */}
+      {!!rows.length && !visible.length && (
+        <Text size="sm" c="dimmed">
+          Every submission waiting on you is a free one, and free ones are hidden.
+        </Text>
+      )}
+
+      {visible.map((row) => (
         <Card key={row.id} withBorder>
           <Group justify="space-between" wrap="nowrap" align="flex-start">
             <Group gap="sm" wrap="nowrap" align="flex-start">
@@ -273,9 +298,7 @@ function ReceivedTab({
                 {/* Nothing was paid on a free row, so a Buzz chip there reads
                     as an offer of 0 rather than as a different kind of offer. */}
                 {row.free ? (
-                  <Badge size="sm" variant="light" color="green" className="w-fit">
-                    Free submission
-                  </Badge>
+                  <PlacementFreeBadge noun="submission" />
                 ) : (
                   <Group gap={4}>
                     <CurrencyIcon currency={Currency.BUZZ} size={12} />

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -17,6 +17,9 @@ import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLe
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
 import { Meta } from '~/components/Meta/Meta';
+import { PlacementFreeBadge } from '~/components/Placement/PlacementFreeBadge';
+import { PlacementFreeFilter } from '~/components/Placement/PlacementFreeFilter';
+import { selectionAfterHidingFree, visibleQueueRows } from '~/components/Placement/free-filter';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
 import { placementPaymentSummary, selectionFree } from '~/components/Sticker/payout-copy';
@@ -50,8 +53,10 @@ export default function StickerPlacements() {
       { getNextPageParam: (lastPage) => lastPage.nextCursor }
     );
   const [selected, setSelected] = useState<number[]>([]);
+  const [showFree, setShowFree] = useState(true);
 
-  const rows = data?.pages.flatMap((page) => page.items) ?? [];
+  const loaded = data?.pages.flatMap((page) => page.items) ?? [];
+  const rows = visibleQueueRows(loaded, showFree);
   const cosmeticIds = rows.map((row) => row.data.cosmeticId);
   const { sticker } = useStickerCosmetics(cosmeticIds);
 
@@ -66,6 +71,15 @@ export default function StickerPlacements() {
       current.includes(id) ? current.filter((value) => value !== id) : [...current, id]
     );
 
+  // Hiding the free rows takes them out of the selection with them. Approve and
+  // Decline are irreversible and both say something about money, so a selection
+  // that outlives the rows it was made from would act on placements the owner
+  // can no longer see.
+  const changeShowFree = (next: boolean) => {
+    setShowFree(next);
+    if (!next) setSelected((current) => selectionAfterHidingFree(current, loaded));
+  };
+
   return (
     <>
       <Meta title="Stickers awaiting your review" deIndex />
@@ -78,18 +92,27 @@ export default function StickerPlacements() {
                 Only you and the placer can see these. Unanswered ones expire after 48 hours.
               </Text>
             </div>
-            {rows.length > 0 && (
-              <Checkbox
-                // Names what it selects. With the queue paged it reaches the
-                // rows on screen, and an owner who bulk-declined believing they
-                // had cleared 200 would find 150 still waiting.
-                label={hasNextPage ? 'Select all loaded' : 'Select all'}
-                checked={allSelected}
-                indeterminate={selected.length > 0 && !allSelected}
-                onChange={() => setSelected(allSelected ? [] : rows.map((row) => row.id))}
-                className="shrink-0"
-              />
-            )}
+            <Group gap="sm" wrap="nowrap" className="shrink-0">
+              {rows.length > 0 && (
+                <Checkbox
+                  // Names what it selects. With the queue paged it reaches the
+                  // rows on screen, and an owner who bulk-declined believing they
+                  // had cleared 200 would find 150 still waiting. With the free
+                  // ones hidden it reaches those on screen too, not the hidden
+                  // ones behind them.
+                  label={hasNextPage ? 'Select all loaded' : 'Select all'}
+                  checked={allSelected}
+                  indeterminate={selected.length > 0 && !allSelected}
+                  onChange={() => setSelected(allSelected ? [] : rows.map((row) => row.id))}
+                  className="shrink-0"
+                />
+              )}
+              {/* Only once there is something to hide. A control that changes
+                nothing still asks the owner to work out what it does. */}
+              {loaded.some((row) => row.free) && (
+                <PlacementFreeFilter show={showFree} onChange={changeShowFree} noun="placements" />
+              )}
+            </Group>
           </Group>
 
           {selected.length > 0 && (
@@ -116,15 +139,25 @@ export default function StickerPlacements() {
           {/* `&& !hasNextPage`: a page whose rows were all dropped returns
               nothing with a cursor still set, and "nothing waiting" over a
               queue that has more is the failure paging exists to end. */}
-          {!isLoading && !isError && !rows.length && !hasNextPage && (
+          {/* Both of these ask whether the QUEUE is empty, which is a different
+              question from whether anything is on screen — with the free ones
+              hidden, "nothing waiting" would be the owner's own filter talking
+              back to them as a fact about their images. */}
+          {!isLoading && !isError && !loaded.length && !hasNextPage && (
             <Alert>
               <Text size="sm">Nothing waiting. Placements you approve show up on your images.</Text>
             </Alert>
           )}
 
-          {!rows.length && hasNextPage && (
+          {!loaded.length && hasNextPage && (
             <Text size="sm" c="dimmed">
               Nothing on this page can be shown. There are more waiting.
+            </Text>
+          )}
+
+          {!!loaded.length && !rows.length && (
+            <Text size="sm" c="dimmed">
+              Everything waiting on you is a free placement, and free ones are hidden.
             </Text>
           )}
 
@@ -202,11 +235,12 @@ export default function StickerPlacements() {
                       </Text>{' '}
                       {/* The only money statement on the card the Approve and
                           Decline buttons sit under, and a free row carries
-                          `amount: 0` — so unbranched it asserts a payment of zero
-                          on the very page the free-placement notification sends
-                          the creator to. */}
-                      {placementPaymentSummary(row.free, row.amount)}
+                          `amount: 0` — so a free row says nothing here and
+                          wears the badge beside the buttons instead, rather
+                          than asserting a payment of zero. */}
+                      {row.free ? 'placed this' : placementPaymentSummary(row.amount)}
                     </Text>
+                    {row.free && <PlacementFreeBadge noun="placement" />}
                     <Text size="xs" c="dimmed">
                       Placed {formatDate(row.createdAt)}
                       {row.expiresAt ? ` · expires ${formatDate(row.expiresAt)}` : ''}

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -22,7 +22,7 @@ import { PlacementFreeFilter } from '~/components/Placement/PlacementFreeFilter'
 import { selectionAfterHidingFree, visibleQueueRows } from '~/components/Placement/free-filter';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
-import { placementPaymentSummary, selectionFree } from '~/components/Sticker/payout-copy';
+import { placementAmountLine, selectionFree } from '~/components/Sticker/payout-copy';
 import { WithheldThumb } from '~/components/RemixGallery/SubmissionPair';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import { useServerDomains } from '~/providers/AppProvider';
@@ -233,12 +233,11 @@ export default function StickerPlacements() {
                       <Text span fw={600}>
                         {row.placer?.username ?? 'Someone'}
                       </Text>{' '}
-                      {/* The only money statement on the card the Approve and
-                          Decline buttons sit under, and a free row carries
-                          `amount: 0` — so a free row says nothing here and
-                          wears the badge beside the buttons instead, rather
-                          than asserting a payment of zero. */}
-                      {row.free ? 'placed this' : placementPaymentSummary(row.amount)}
+                      {/* Both arms in `payout-copy`, not a ternary here: this
+                          is the only money statement on the card the Approve
+                          and Decline buttons sit under, and nothing under
+                          `src/pages` can be tested. */}
+                      {placementAmountLine(row.free, row.amount)}
                     </Text>
                     {row.free && <PlacementFreeBadge noun="placement" />}
                     <Text size="xs" c="dimmed">


### PR DESCRIPTION
Four items from Justin's review of the running feature, plus the changes he asked for while watching them live. Based on `feat/free-placements` (`df9ae770`) and targeted at it, not `main`.

## What changed

**1. The free-slot caption reads like the price value.** `PlacementFreeSlotSlider` rendered its caption at `sm`, left-aligned, below the marks. It now matches what each caller renders under the price slider (`PlacementSpaceSection.tsx:230`, `RemixGallerySettings.tsx:192`): `xs`, centred, `mt={-22}` onto the mark row, with `mb="lg"` on the slider to make that room. Copy is `1 per image` — the noun is dropped, the field label already carries it — and the zero mark reads `0`.

Numeral rather than the word: every other value on that track is a numeral, and spelling only the 1 makes the control inconsistent with itself.

**2 & 3. Both review queues gain a show/hide-free chip.** No such control existed on either side — checked with a grep for `hideFree|showFree|freeOnly|includeFree` across `src` and by reading both queue pages end to end — so it is built once (`PlacementFreeFilter`) and used on both.

It filters what is **loaded**, not what is fetched. Both pages carry careful handling for a page whose rows were all dropped ("nothing on this page can be shown — there are more waiting"), and a server-side filter changes what a page contains and would make that copy describe something else. The empty-state conditions now ask about the unfiltered rows, so "nothing waiting" can never be the owner's own filter talking back to them as a fact about their images.

**The consequence worth reviewing:** hiding the free rows takes them out of the selection with them (`selectionAfterHidingFree`). Approve and Decline are irreversible and both say something about money, so a selection that outlived the rows it was made from would act on placements the owner can no longer see — with the count beside the buttons still counting them.

**4. The sticker queue's free sentence becomes a badge with a popover.** `placementPaymentSummary(free, amount)` returned "placed this free" on a free row; that half is now the same blue badge the remix queue already used for the same fact, and both badges gained a popover pointing at where to change how many free ones you take.

**I deleted a passing test.** `placementPaymentSummary` is narrowed to the paid statement, and its free-branch test goes with it. The branch is unreachable from anything that renders: callers are `payout-copy.ts:64`, `sticker-placements.tsx`, and that test. A passing test over unreachable code reads as coverage of a live path, which is worse than no test.

**5. A free placement is marked on the sticker itself, while it is still awaiting the owner.**

Two decisions in that sentence, both deliberate:

- **Pending only.** The mark belongs to the decision, not to the sticker. Once the owner has approved it, the sticker is on the image on its own terms and how it was funded stops being what they are deciding about. A reader finding `free && isPending && (owner | placer | moderator)` will otherwise read three conditions and no rationale, and the pending term is the one that looks most like an accident.
- **Owner, placer and moderators — not public.** Everything else in this feature treats free-vs-paid as private between the two parties: the pending queue says "only you and the placer can see these", the hidden-note line says "only you, the person who placed it, and moderators". A public marker would be the first thing telling a stranger how a placement was funded, and it would say it about the owner's settings on every image they own. Nothing is rendered for anyone else rather than hidden with CSS — a hidden element is still in the DOM, which is not what those sentences promise.

No new plumbing was needed: `free`, `ownerId` and `placerId` already reach the listing (`sticker-placement.service.ts:455/450-451`, selected at `:661`, mapped at `:682`).

**One fix found along the way, and it is latent everywhere.** The popover rendered truncated because `ThemeProvider.tsx:35` sets `Popover: { defaultProps: { withinPortal: false } }` **repo-wide**. The shared badge passes `withinPortal` explicitly to undo it.

Worth knowing beyond this PR: that default means **every Mantine `Popover` placed inside a clipping container has this bug waiting** — a card, an `overflow-hidden` wrapper, a scroll area. Ours only surfaced because a queue card clipped it. The next person to put a popover in a card will see a truncated dropdown and will have no reason to suspect a theme default is doing it.

## Verification

Run in a worktree off `df9ae770`, not in the demo tree.

- `TYPECHECK_HEAP_MB=12288 pnpm run typecheck` → `typecheck: OK — 0 type errors in 332s (heap cap 12288 MB)`, log naming `C:\Dev\Repos\work\wt-placement-ui`.
- `pnpm run test:unit:run <the three affected files>` → `Test Files  3 passed (3)` / `Tests  38 passed (38)`, exit 0, `RUN v4.0.18 C:/Dev/Repos/work/wt-placement-ui`.
- `pnpm run prettier:write` over the 12 changed files.

**Stated plainly: the full unit suite was not run.** It was queued and then skipped at Justin's direction — the shared queue was three deep and he did not want to wait on it. So this is the three affected files plus a full typecheck, not a whole-suite green. A grep for the changed symbols across `*.test.*` finds no other test file touching them, and the typecheck covers the `placementPaymentSummary` signature change repo-wide, but neither is the same thing as running the suite.

The new tests assert the parts worth asserting: what stays selected when the filter hides rows, and — on the marker — the negatives. A third-party viewer and a signed-out viewer see nothing, and neither does anyone once the placement is approved. Those are the assertions that decay silently: the positive cases break loudly the moment someone touches the overlay, the negatives only break when someone widens the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

