### PR TITLE
test(image-card): pin the narrow-column overflow to a bound the CI browser can meet

### DIFF
--- a/src/components/Cards/ImageCard.browser.test.tsx
+++ b/src/components/Cards/ImageCard.browser.test.tsx
@@ -64,6 +64,24 @@ const CARD_WIDTH = 336;
 const NARROW_CARD_WIDTH = 296;
 const SINGLE_ROW_MAX_HEIGHT = 40;
 
+// How far the reaction bar may stick out past the narrow card before we call it a
+// regression. `reactionBarOverflow()` is a raw pixel distance driven by the WIDTH
+// OF RENDERED TEXT, so unlike the height assertions above it moves with font
+// metrics and therefore with the environment:
+//
+//   50px  the value this test shipped with (#4034) — measured off-CI
+//   57px  the CI browser, measured 2026-08-17 on two independent runs
+//
+// It shipped red for that reason: `preview / component-tests` is report-only, and
+// no component-tests status was ever posted on #4034, so nothing said so.
+//
+// The bound sits above the largest observed value rather than ON it, because the
+// regression this guards against — an extra control in the row, an un-hidden info
+// button, a wider count format — moves this number by TENS of px, while a browser
+// or font-stack change moves it by a few. Pinning it tight would buy no sensitivity
+// and would re-red the suite on an unrelated chromium bump.
+const MAX_NARROW_OVERFLOW_PX = 64;
+
 function imageData(counts: number) {
   return {
     id: 1,
@@ -170,7 +188,7 @@ describe('ImageCard action row at four-digit reaction counts', () => {
     const threeDigits = reactionBarOverflow();
 
     expect(threeDigits).toBeLessThan(0);
-    expect(fourDigits).toBeLessThanOrEqual(50);
+    expect(fourDigits).toBeLessThanOrEqual(MAX_NARROW_OVERFLOW_PX);
   });
 
   test('fits on one line at three-digit counts either way', async () => {


### PR DESCRIPTION
`main` has been red on `preview / component-tests` since #4034 landed this afternoon:

```
AssertionError: expected 57 to be less than or equal to 50
  ImageCard action row at four-digit reaction counts
    > still overruns the narrow column, by no more than it does today
```

## It's the environment, not a regression

`reactionBarOverflow()` returns `bar.right - card.right` — a raw pixel distance driven by the **width of rendered text**. Unlike the height assertions beside it, that moves with font metrics, and therefore with the environment:

| | |
|---|---|
| `50` | the value this test shipped with, measured off-CI |
| `57` | the CI browser — **deterministic**, same value on two independent runs, on two different branches |

And it is not a regression that arrived after #4034: **no commit since then touches `src/components/Cards`, `src/components/Reaction`, or `src/styles`**, so 57 is simply what #4034's own code renders in that browser.

## Why nobody knew

`preview / component-tests` is **report-only**, and no `component-tests` status was ever posted on #4034 at all — so the suite went red on `main` within hours of the test landing, and nothing anywhere said so. That gap is worth a separate look; this PR just stops the bleeding.

## The change

The bound becomes a named constant, documented with both measurements, and sits **above** the largest observed value rather than on it. The regression this test exists to catch — an extra control in the row, an un-hidden info button, a wider count format — moves the number by *tens* of px; a browser or font-stack change moves it by a few. Pinning tight would buy no sensitivity and would re-red the suite on an unrelated chromium bump.

The test's intent is unchanged: it still fails if something makes the overflow worse, and still passes if someone finally closes the 868krjmvv clipping it characterizes.

**Raising an upper bound cannot break a stricter environment** — this stays green wherever it was already green, including @JustMaier's local run at 50.

## Verification

Not run locally: the component project wants a playwright build this NixOS box doesn't have, so CI is the instrument. Watching `preview / component-tests` on this PR is the check that matters — it must go from `1 failed | 1669 passed` to all-green.

@JustMaier — flagging rather than assuming: if you think 57 means the bar genuinely got wider in that browser and the *layout* is what should change, say so and I'll close this.
