### PR TITLE
fix(dev-server): unlink worktree symlinks with the POSIX call

### DIFF
--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -11,7 +11,7 @@
  */
 
 import { execFileSync } from 'child_process';
-import { readdirSync, lstatSync, rmdirSync, rmSync, existsSync } from 'fs';
+import { readdirSync, lstatSync, rmdirSync, rmSync, unlinkSync, existsSync } from 'fs';
 import { resolve, sep } from 'path';
 
 function git(args, cwd) {
@@ -77,6 +77,23 @@ function findReparsePoints(root) {
     }
   }
   return found.sort((a, b) => b.split(sep).length - a.split(sep).length);
+}
+
+/**
+ * Removes the link itself, never its target. Which call does that is platform-specific and each
+ * one errors on the other's link type: a POSIX symlink needs `unlink` and gives ENOTDIR to
+ * `rmdir`, a Windows directory junction is the reverse and gives EPERM to `unlink`. Trying only
+ * `rmdir` is what made `wt rm` unusable on macOS against any tree that had been `pnpm install`ed.
+ */
+function unlinkReparsePoint(link) {
+  try {
+    if (process.platform === 'win32') rmdirSync(link);
+    else unlinkSync(link);
+  } catch (err) {
+    if (err.code !== 'ENOTDIR' && err.code !== 'EPERM' && err.code !== 'EISDIR') throw err;
+    if (process.platform === 'win32') unlinkSync(link);
+    else rmdirSync(link);
+  }
 }
 
 /**
@@ -224,7 +241,7 @@ export async function cmdRemove(primary, targetArg, opts, daemonRequest) {
     const links = findReparsePoints(target);
     console.log(`reparse points: ${links.length}`);
     for (const link of links) {
-      rmdirSync(link); // link-only; a recursive delete would walk THROUGH it
+      unlinkReparsePoint(link);
     }
     const left = findReparsePoints(target);
     if (left.length) {


### PR DESCRIPTION
## The bug

`wt rm` unlinked each reparse point with `rmdirSync`. That is the **Windows junction** call — a POSIX symlink answers it with `ENOTDIR`:

```
Error: ENOTDIR: not a directory, rmdir '.../node_modules/.pnpm/zustand@4.5.7_.../node_modules/@types/react'
    at cmdRemove (.claude/skills/dev-server/scripts/worktree.mjs:227)
```

It throws on the first link it meets, so on macOS or Linux the command could not remove **any** worktree that had been `pnpm install`ed — and pnpm makes nearly every package a link, so that is all of them. It hit twice in one session today; both worktrees had to be torn down by hand with `rm -rf` after checking the tree was clean and the work was on `origin/main`.

Nothing was wrong with the design, only with the syscall: the file was written and measured on Windows (see the header note dated 2026-08-12), where `rmdirSync` is correct.

## The fix

`unlinkReparsePoint` picks the call by platform and falls back to the other, since each link type errors on the other's call (`ENOTDIR` one way, `EPERM` the other):

```js
if (process.platform === 'win32') rmdirSync(link);
else unlinkSync(link);
```

The pre-pass keeps the purpose the file header gives it — **speed, not safety**: removing pnpm's links as links avoids walking ~200k files through them. The assert-zero gate after it is untouched.

## Verification

Two runs on macOS against real scratch worktrees carrying a pnpm-shaped directory symlink:

1. **It works** — `reparse points: 1` → `remaining: 0` → `directory deleted` → `pruned`, exit 0, and the branch correctly KEPT with `no merged PR found`.
2. **Nothing is followed through the link** — repeated with the symlink pointing at a sentinel file **outside** the worktree. The worktree was removed and the sentinel still reads `MUST SURVIVE`.

That second one is the property the assert-zero gate exists to protect, so it is the one worth pinning. `node --check` passes and `wt stale` still runs.

Scratch worktrees, probe branch and sentinel were all cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
