### PR TITLE
docs: say why a Popover inside a card renders truncated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,17 @@ import styles from './Component.module.scss';
 - Define Props interfaces for components
 - Use enums from `~/shared/utils/prisma/enums`
 
+#### 5. A `Popover` inside anything that clips needs `withinPortal`
+
+`src/providers/ThemeProvider.tsx` sets `Popover: { defaultProps: { withinPortal: false } }` for the
+whole app. So a `Popover` rendered inside a `Card`, an `overflow-hidden` wrapper or a scroll area
+draws **inside** that container and is clipped by it — the dropdown comes out truncated, at every
+call site, with nothing in the JSX pointing at the cause. Pass `withinPortal` explicitly there.
+
+Only `Popover` carries it — `HoverCard` has no theme entry at all and `Tooltip`'s sets `withArrow`
+alone. Several components pass `withinPortal` to those two anyway, so grepping for the prop does not
+tell you which call sites actually needed it.
+
 ### Coding Standards
 
 #### Imports Order


### PR DESCRIPTION
One paragraph in Component Standards, from a bug hit while building #4051.

`src/providers/ThemeProvider.tsx:35` sets `Popover: { defaultProps: { withinPortal: false } }` for the whole app. A `Popover` inside a `Card`, an `overflow-hidden` wrapper or a scroll area therefore draws inside that container and is clipped by it — the dropdown renders truncated, and nothing in the JSX at the call site points at a theme default as the cause. Passing `withinPortal` explicitly fixes it.

Worth writing down rather than just fixing, because the default is wrong only in one specific structural situation, is set globally, and is invisible at every call site. Mine surfaced because a review-queue card clipped it; the next person to put a popover in a card gets the same truncation with no thread to pull.

Verified rather than assumed while writing it: only `Popover` carries that default. `HoverCard` has no theme entry, and `Tooltip`'s sets `withArrow` alone. Several components pass `withinPortal` to those two anyway, which is why grepping for the prop does not tell you which call sites needed it — that sentence is in the note so the next reader does not repeat the grep and draw the wrong conclusion.

Docs only, no code. Off `main` rather than folded into #4051 so it cannot collide with the release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
