### PR TITLE
fix(feedback): page capture works on pages using modern CSS colours

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "happy-dom": "^20.0.2",
     "he": "^1.2.0",
     "html-to-text": "^9.0.5",
-    "html2canvas": "1.4.1",
+    "html2canvas-pro": "2.3.8",
     "idb-keyval": "^6.2.0",
     "immer": "^9.0.15",
     "instantsearch.js": "4.64.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,9 +421,9 @@ importers:
       html-to-text:
         specifier: ^9.0.5
         version: 9.0.5
-      html2canvas:
-        specifier: 1.4.1
-        version: 1.4.1
+      html2canvas-pro:
+        specifier: 2.3.8
+        version: 2.3.8
       idb-keyval:
         specifier: ^6.2.0
         version: 6.2.2
@@ -8304,9 +8304,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
-  html2canvas@1.4.1:
-    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
-    engines: {node: '>=8.0.0'}
+  html2canvas-pro@2.3.8:
+    resolution: {integrity: sha512-z4qgQmElYHkF4m0yhL4gW+keDInZwDu070xwbAoTsssS+1ieVc8uoWOHGXF8ClaqEzw5puGclxwqZa7T4XR35A==}
+    engines: {node: '>=16.0.0'}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -21332,7 +21332,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html2canvas@1.4.1:
+  html2canvas-pro@2.3.8:
     dependencies:
       css-line-break: 2.1.0
       text-segmentation: 1.0.3

--- a/src/components/Feedback/captureScreenshot.color4.browser.test.tsx
+++ b/src/components/Feedback/captureScreenshot.color4.browser.test.tsx
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { captureConsentedScreenshot } from '~/components/Feedback/captureScreenshot';
+
+/**
+ * 🔴 CSS COLOR LEVEL 4 — the capture must survive a page that uses modern colours.
+ *
+ * THE BUG THIS PINS. `html2canvas@1.4.1` (Feb 2022, that library's last release)
+ * predates Color 4 and its parser THROWS rather than degrading:
+ * `Attempting to parse an unsupported color function "color"`. It throws while
+ * walking the cloned subtree, so it is not a per-element fallback — ONE element
+ * anywhere in the capture takes the whole capture down. Measured in production on
+ * `/images`: of 3,998 elements, exactly one computed to a Color 4 value (a
+ * translucent-yellow pill at `color(srgb 1 0.878431 0.4 / 0.1)`), and the feature
+ * was 100% broken for every user who ticked the box.
+ *
+ * 🔴 WHY THIS IS A COMPUTED-STYLE TEST AND NOT A STYLESHEET LINT. The app need never
+ * write `color()` anywhere for this to fire. Browsers SERIALIZE into these forms:
+ * `color-mix(in oklab, …)` computes to `oklab(…)`, a P3 or relative colour computes
+ * to `color(srgb …)`. Measured in Chromium here — the `instrument:` cases below are
+ * the check on that claim. A grep over `src/**` can come back clean
+ * while every capture on the page fails, which is why sanitising colours before
+ * capture was rejected in favour of a renderer that parses them.
+ *
+ * 🔴 EACH CASE ASSERTS A PIXEL, NOT JUST A RESOLVED PROMISE. A renderer that silently
+ * skipped an unparseable colour would leave the capture technically successful and
+ * visually wrong — the reporter would send us a screenshot missing the thing they
+ * were reporting. Reading the drawn colour back out is what separates "parsed" from
+ * "tolerated".
+ */
+
+type Rgb = { r: number; g: number; b: number };
+
+/** JPEG is lossy, so assert channel DOMINANCE. Both targets are saturated primaries. */
+const isRed = ({ r, g, b }: Rgb) => r > 180 && g < 90 && b < 90;
+const isGreen = ({ r, g, b }: Rgb) => g > 180 && r < 90 && b < 90;
+
+type Case = {
+  label: string;
+  /** Written into `style.backgroundColor`. */
+  css: string;
+  /** What `getComputedStyle` must still be serializing — the whole point of the case. */
+  computedPrefix: string;
+  expect: (pixel: Rgb) => boolean;
+  expectLabel: string;
+};
+
+/**
+ * Every value below is the SAME colour expressed in a different Color 4 function, so
+ * a failure names the function rather than the colour. The `oklch`/`lab`/`lch`/`oklab`
+ * quadruple is sRGB red; `color(srgb …)` is red directly; `color(display-p3 0 1 0)` is
+ * a wide-gamut green that clamps into sRGB green on a 2D canvas.
+ */
+const CASES: Case[] = [
+  {
+    label: 'color(srgb …) — the function that broke production',
+    css: 'color(srgb 1 0 0)',
+    computedPrefix: 'color(srgb',
+    expect: isRed,
+    expectLabel: 'red',
+  },
+  {
+    label: 'color(display-p3 …) — a wide-gamut source',
+    css: 'color(display-p3 0 1 0)',
+    computedPrefix: 'color(display-p3',
+    expect: isGreen,
+    expectLabel: 'green',
+  },
+  {
+    label: 'oklch()',
+    css: 'oklch(0.62796 0.25768 29.234)',
+    computedPrefix: 'oklch(',
+    expect: isRed,
+    expectLabel: 'red',
+  },
+  {
+    label: 'lab()',
+    css: 'lab(54.29 80.8 69.89)',
+    computedPrefix: 'lab(',
+    expect: isRed,
+    expectLabel: 'red',
+  },
+  {
+    label: 'lch()',
+    css: 'lch(54.29 106.84 40.85)',
+    computedPrefix: 'lch(',
+    expect: isRed,
+    expectLabel: 'red',
+  },
+  {
+    label: 'oklab()',
+    css: 'oklab(0.62796 0.22486 0.12585)',
+    computedPrefix: 'oklab(',
+    expect: isRed,
+    expectLabel: 'red',
+  },
+  {
+    // 🔴 The one a source grep can never find. `color-mix()` does not survive into the
+    // computed value at all — Chromium resolves it to `oklab(…)` — so a page can reach
+    // the broken parser through a function that appears nowhere in the computed styles
+    // AND a function that appears nowhere in the source.
+    label: 'color-mix() — which computes to oklab()',
+    css: 'color-mix(in oklab, red, red)',
+    computedPrefix: 'oklab(',
+    expect: isRed,
+    expectLabel: 'red',
+  },
+];
+
+/** The literal value measured on the live page, translucent alpha and all. */
+const PRODUCTION_TRIGGER = 'color(srgb 1 0.878431 0.4 / 0.1)';
+
+/** Inside the fixture block, well clear of any edge. */
+const PROBE = { x: 10, y: 10 };
+
+let fixture: HTMLElement | null = null;
+
+/**
+ * A viewport-covering block in the colour under test. `position: fixed` so it lands at
+ * the probe pixel regardless of scroll, and a maximal z-index so nothing the runner
+ * paints can sit on top of it and satisfy the assertion for the wrong reason.
+ */
+function paint(css: string): HTMLElement {
+  const el = document.createElement('div');
+  el.style.cssText =
+    'position:fixed;left:0;top:0;width:100vw;height:100vh;z-index:2147483647;' +
+    `background-color:${css};`;
+  document.body.appendChild(el);
+  fixture = el;
+  return el;
+}
+
+async function pixelAt(file: Blob, x: number, y: number): Promise<Rgb> {
+  const bitmap = await createImageBitmap(file);
+  const canvas = document.createElement('canvas');
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('no 2d context');
+  ctx.drawImage(bitmap, 0, 0);
+  const [r, g, b] = ctx.getImageData(x, y, 1, 1).data;
+  bitmap.close();
+  return { r, g, b };
+}
+
+/**
+ * Resolve the capture, or return the rejection so the assertion message can carry the
+ * renderer's own words. Without this the failure reads as an unhandled rejection and
+ * the actual diagnosis — which colour function, which parser — is lost from the output.
+ */
+async function capture(): Promise<File | Error> {
+  try {
+    const file = await captureConsentedScreenshot({ consented: true });
+    return file ?? new Error('capture returned null despite explicit consent');
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+const describeResult = (result: File | Error) =>
+  result instanceof Error ? `capture REJECTED: ${result.message}` : 'capture resolved';
+
+afterEach(() => {
+  fixture?.remove();
+  fixture = null;
+});
+
+describe('page capture survives CSS Color Level 4 computed values', () => {
+  /**
+   * 🔴 INSTRUMENT CHECK, and it is not optional. Every case below is only meaningful
+   * while Chromium still SERIALIZES these functions rather than normalising them to
+   * `rgb()`. It normalises some already — `hwb(120 10% 20%)` computes to
+   * `rgb(26, 204, 26)` and is therefore harmless — so "the browser normalises it" is a
+   * real, observed behaviour and not a hypothetical. If a future Chromium starts doing
+   * that to `oklch()` too, this test must go RED rather than let that case start
+   * passing without ever exercising a Color 4 parser.
+   */
+  test.each(CASES.map((c) => [c.label, c] as const))(
+    'instrument: %s still reaches the renderer as a Color 4 value',
+    (_label, testCase) => {
+      const el = paint(testCase.css);
+      const computed = getComputedStyle(el).backgroundColor;
+
+      expect(
+        computed.startsWith(testCase.computedPrefix),
+        `computed background-color was "${computed}", which does not start with ` +
+          `"${testCase.computedPrefix}" — this case no longer exercises a Color 4 parser`
+      ).toBe(true);
+    }
+  );
+
+  test('instrument: the production trigger value survives computation verbatim', () => {
+    const el = paint(PRODUCTION_TRIGGER);
+
+    expect(getComputedStyle(el).backgroundColor).toBe(PRODUCTION_TRIGGER);
+  });
+
+  /**
+   * 🔴 THE PRODUCTION REPRODUCTION. `html2canvas@1.4.1` fails this with
+   * `Attempting to parse an unsupported color function "color"` — the exact string
+   * users were shown under "Could not capture the page".
+   */
+  test(`captures a page containing ${PRODUCTION_TRIGGER}`, async () => {
+    paint(PRODUCTION_TRIGGER);
+
+    const result = await capture();
+
+    expect(result, describeResult(result)).toBeInstanceOf(File);
+  });
+
+  test.each(CASES.map((c) => [c.label, c] as const))(
+    'captures and DRAWS %s',
+    async (_label, testCase) => {
+      paint(testCase.css);
+
+      const result = await capture();
+      expect(result, describeResult(result)).toBeInstanceOf(File);
+
+      const pixel = await pixelAt(result as File, PROBE.x, PROBE.y);
+      expect(
+        testCase.expect(pixel),
+        `expected ${testCase.expectLabel}, got rgb(${pixel.r},${pixel.g},${pixel.b}) — ` +
+          `the capture succeeded but did not draw ${testCase.css}`
+      ).toBe(true);
+    }
+  );
+
+  /**
+   * A legacy-serializing function, kept as the CONTRAST case. It computes to `rgb()`,
+   * so it went through the old renderer untouched: a suite where this one case is the
+   * only green is a suite that has not tested anything the fix is about.
+   */
+  test('hwb() computes to rgb() and was never the problem', async () => {
+    const el = paint('hwb(0 0% 0%)');
+    expect(getComputedStyle(el).backgroundColor).toBe('rgb(255, 0, 0)');
+
+    const result = await capture();
+    expect(result, describeResult(result)).toBeInstanceOf(File);
+    expect(isRed(await pixelAt(result as File, PROBE.x, PROBE.y))).toBe(true);
+  });
+});

--- a/src/components/Feedback/captureScreenshot.render.browser.test.tsx
+++ b/src/components/Feedback/captureScreenshot.render.browser.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { captureConsentedScreenshot } from '~/components/Feedback/captureScreenshot';
 
 /**
- * 🔴 RENDER SEAM — what html2canvas actually DRAWS, not what options we passed it.
+ * 🔴 RENDER SEAM — what the renderer actually DRAWS, not what options we passed it.
  *
  * `captureScreenshot.test.ts` pins the arguments. That is a real guard, and it is not
  * this one: passing `x: window.scrollY` and passing the RIGHT coordinate space are
@@ -11,8 +11,10 @@ import { captureConsentedScreenshot } from '~/components/Feedback/captureScreens
  * assertion was green while the app's sticky header was silently missing from every
  * capture and the feed content behind it was drawn in its place.
  *
- * So this file runs the REAL html2canvas against a REAL scrolled document in real
- * Chromium and reads pixels out of the produced JPEG.
+ * So this file runs the REAL html2canvas-pro against a REAL scrolled document in real
+ * Chromium and reads pixels out of the produced JPEG. Keeping the negative control on
+ * the SAME library the product uses is the point — it is what proved the fork kept
+ * `scrollX`/`scrollY` defaulting to the page offsets when the renderer was swapped.
  *
  * 🔴 It carries its own NEGATIVE CONTROL. The first test re-applies the defect
  * through the same fixture and the same encode path, and requires the OPPOSITE
@@ -113,7 +115,7 @@ describe('viewport capture places fixed/sticky elements correctly', () => {
   });
 
   test('🔴 NEGATIVE CONTROL — with scrollX/scrollY forced to 0 the fixed bar is LOST', async () => {
-    const html2canvas = (await import('html2canvas')).default;
+    const html2canvas = (await import('html2canvas-pro')).default;
     const canvas = await html2canvas(document.body, {
       logging: false,
       useCORS: true,

--- a/src/components/Feedback/captureScreenshot.ts
+++ b/src/components/Feedback/captureScreenshot.ts
@@ -12,15 +12,32 @@
  * Do not "optimise" step 1 away by inferring consent from the presence of a
  * callback or from the prompt being open. Consent is a value the user set.
  *
- * 🔴 `html2canvas` (~200 kB) is reached ONLY through a dynamic `import()`, so it is
- * code-split out of the main bundle and costs nothing on the ~100% of page loads
- * that never open the prompt. That property is pinned by the source gate in
+ * 🔴 THE RENDERER IS `html2canvas-pro`, NOT `html2canvas`, AND THAT IS A BUG FIX.
+ * `html2canvas@1.4.1` is that library's last release (Feb 2022) and predates CSS
+ * Color Level 4: its colour parser THROWS — `Attempting to parse an unsupported
+ * color function "<fn>"` — rather than degrading, so a SINGLE element anywhere in
+ * the captured subtree whose computed colour is `color()`, `oklch()`, `oklab()`,
+ * `lab()` or `lch()` takes the whole capture down. In production that was literally
+ * one element in 3,998 on `/images`. Note this is a COMPUTED-style problem, not a
+ * source-text one: `color-mix()` computes to `oklab(...)` and a P3 or relative
+ * colour computes to `color(srgb ...)`, so the app can break without ever writing
+ * one of those functions in a stylesheet — grepping the CSS proves nothing.
+ * `html2canvas-pro` is the maintained fork that added exactly those parsers; it is
+ * signature-identical and takes the same option names. Pinned by
+ * `captureScreenshot.color4.browser.test.tsx`, which renders each function and
+ * fails on the old library.
+ *
+ * 🔴 It (~250 kB) is reached ONLY through a dynamic `import()`, so it is code-split
+ * out of the main bundle and costs nothing on the ~100% of page loads that never
+ * open the prompt. That property is pinned by the source gate in
  * `src/server/services/__tests__/no-static-html2canvas-import.test.ts` — a static
- * `import html2canvas from 'html2canvas'` anywhere under `src/` fails that test.
+ * `import html2canvas from 'html2canvas-pro'` anywhere under `src/` fails that test.
+ * The fork is ~15 kB gzip LARGER than the library it replaces, so the split matters
+ * slightly more now than it did, not less.
  */
 
 /**
- * The subset of html2canvas's real signature this module uses.
+ * The subset of the renderer's real signature this module uses.
  *
  * Written against the published types (`html2canvas(element, options?) =>
  * Promise<HTMLCanvasElement>`), not against a convenient shape — a loader fake in a
@@ -48,7 +65,7 @@ export const SCREENSHOT_FILENAME = 'page-capture.jpg';
 export const SCREENSHOT_MAX_BYTES = 5 * 1024 * 1024;
 
 const defaultLoader: Html2CanvasLoader = async () =>
-  (await import('html2canvas')).default as unknown as Html2CanvasFn;
+  (await import('html2canvas-pro')).default as unknown as Html2CanvasFn;
 
 export type CaptureScreenshotArgs = {
   /**

--- a/src/server/services/__tests__/no-static-html2canvas-import.test.ts
+++ b/src/server/services/__tests__/no-static-html2canvas-import.test.ts
@@ -3,16 +3,24 @@ import { readdirSync, readFileSync, statSync } from 'fs';
 import path from 'path';
 
 /**
- * 🔴 SOURCE GATE — `html2canvas` may only be reached through a dynamic `import()`.
+ * 🔴 SOURCE GATE — the DOM-capture renderer may only be reached through a dynamic
+ * `import()`.
  *
- * WHY. html2canvas is ~200 kB and exists for one control on one prompt: the opt-in
- * page capture in `src/components/Feedback/captureScreenshot.ts`. Behind a dynamic
+ * WHY. It is ~250 kB and exists for one control on one prompt: the opt-in page
+ * capture in `src/components/Feedback/captureScreenshot.ts`. Behind a dynamic
  * `import()` the bundler code-splits it into its own chunk, so the ~100% of page
  * loads that never open the feedback prompt never download it. A single static
- * `import html2canvas from 'html2canvas'` anywhere in the app graph collapses that
- * — the chunk merges back into whatever entry reaches it — and NOTHING else in the
- * repo would notice: the feature still works, the tests still pass, and the cost
- * lands on every visitor.
+ * `import html2canvas from 'html2canvas-pro'` anywhere in the app graph collapses
+ * that — the chunk merges back into whatever entry reaches it — and NOTHING else in
+ * the repo would notice: the feature still works, the tests still pass, and the
+ * cost lands on every visitor.
+ *
+ * WHY THERE ARE TWO NAMES HERE. The renderer used to be `html2canvas`, which throws
+ * on any CSS Color Level 4 computed value and so could not capture this site at all;
+ * it was replaced by the maintained fork `html2canvas-pro`. `RETIRED` keeps the dead
+ * name from creeping back in through a stale snippet or a half-finished migration —
+ * in ANY import form, static or dynamic, since neither works once the package is
+ * gone from `package.json`.
  *
  * WHY A SOURCE GATE RATHER THAN A BUNDLE ASSERTION. Measuring the emitted chunks
  * needs a full `next build` (many minutes, and it does not run in the `unit`
@@ -22,7 +30,8 @@ import path from 'path';
  */
 
 const SRC = path.resolve(__dirname, '../../../../src');
-const DEPENDENCY = 'html2canvas';
+const DEPENDENCY = 'html2canvas-pro';
+const RETIRED = 'html2canvas';
 
 const CODE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts']);
 const SKIP_DIRS = new Set(['node_modules', '__screenshots__']);
@@ -46,19 +55,27 @@ const stripComments = (s: string) =>
   s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
 
 /**
- * A STATIC reference: an ESM `import ... from 'html2canvas'`, a bare side-effect
- * `import 'html2canvas'`, an `export ... from 'html2canvas'`, or a CommonJS
- * `require('html2canvas')`. A dynamic `import('html2canvas')` is deliberately NOT
- * matched — the `import` keyword there is followed by `(`, not by a specifier list
- * or a quote.
+ * A STATIC reference to `dep`: an ESM `import ... from '<dep>'`, a bare side-effect
+ * `import '<dep>'`, an `export ... from '<dep>'`, or a CommonJS `require('<dep>')`.
+ * A dynamic `import('<dep>')` is deliberately NOT matched — the `import` keyword
+ * there is followed by `(`, not by a specifier list or a quote.
+ *
+ * The closing `['"]` is what keeps `RETIRED` from matching `DEPENDENCY`, which is a
+ * prefix relationship rather than a coincidence. Pinned below.
  */
-const staticReference = new RegExp(
-  String.raw`(?:^|[\s;}])(?:import|export)\s+(?:[^'"();]*?\sfrom\s+)?['"]${DEPENDENCY}['"]` +
-    String.raw`|require\(\s*['"]${DEPENDENCY}['"]\s*\)`,
-  'm'
-);
+const staticFor = (dep: string) =>
+  new RegExp(
+    String.raw`(?:^|[\s;}])(?:import|export)\s+(?:[^'"();]*?\sfrom\s+)?['"]${dep}['"]` +
+      String.raw`|require\(\s*['"]${dep}['"]\s*\)`,
+    'm'
+  );
 
-const dynamicReference = new RegExp(String.raw`import\(\s*['"]${DEPENDENCY}['"]\s*\)`);
+const dynamicFor = (dep: string) => new RegExp(String.raw`import\(\s*['"]${dep}['"]\s*\)`);
+
+const staticReference = staticFor(DEPENDENCY);
+const dynamicReference = dynamicFor(DEPENDENCY);
+const retiredStatic = staticFor(RETIRED);
+const retiredDynamic = dynamicFor(RETIRED);
 
 const files = walk(SRC);
 
@@ -70,9 +87,9 @@ describe(`🔴 ${DEPENDENCY} is code-split out of the main bundle`, () => {
   });
 
   /**
-   * 🔴 Every fixture below INTERPOLATES `DEPENDENCY` rather than spelling it. The
-   * scan runs over `src/` and this file lives in `src/`, so a literal
-   * `import x from 'html2canvas'` written here as a control would be found by the
+   * 🔴 Every fixture below INTERPOLATES `DEPENDENCY`/`RETIRED` rather than spelling
+   * either out. The scan runs over `src/` and this file lives in `src/`, so a
+   * literal `import x from '<dep>'` written here as a control would be found by the
    * scan and reported as a real offender. Interpolating keeps the file honest
    * without an exclusion list — and an exclusion list is exactly where a genuine
    * offender would eventually hide.
@@ -103,6 +120,27 @@ describe(`🔴 ${DEPENDENCY} is code-split out of the main bundle`, () => {
       expect(stripComments(`${commented}\nconst a = 1;`)).toContain('const a = 1;');
       expect(staticReference.test(stripComments(commented))).toBe(false);
     });
+
+    /**
+     * 🔴 `RETIRED` is a PREFIX of `DEPENDENCY`, so the two matcher pairs only stay
+     * distinct because each requires the closing quote immediately after the name.
+     * That is invisible at the call site and load-bearing in both directions: a
+     * looser `RETIRED` matcher would flag every legitimate fork import as a revival
+     * of the dead package, and a looser `DEPENDENCY` matcher would accept the dead
+     * package as the fork. Neither mistake produces a wrong-looking regex.
+     */
+    it('the retired name does not match the fork, and the fork does not match the retired name', () => {
+      expect(retiredStatic.test(`import h from '${DEPENDENCY}';`)).toBe(false);
+      expect(retiredDynamic.test(`await import('${DEPENDENCY}');`)).toBe(false);
+      expect(staticReference.test(`import h from '${RETIRED}';`)).toBe(false);
+      expect(dynamicReference.test(`await import('${RETIRED}');`)).toBe(false);
+
+      // …and each still sees its own, so the four negatives above are not vacuous.
+      expect(retiredStatic.test(`import h from '${RETIRED}';`)).toBe(true);
+      expect(retiredDynamic.test(`await import('${RETIRED}');`)).toBe(true);
+      expect(staticReference.test(`import h from '${DEPENDENCY}';`)).toBe(true);
+      expect(dynamicReference.test(`await import('${DEPENDENCY}');`)).toBe(true);
+    });
   });
 
   it('no file under src/ imports it statically', () => {
@@ -112,8 +150,24 @@ describe(`🔴 ${DEPENDENCY} is code-split out of the main bundle`, () => {
 
     expect(
       offenders.map((f) => path.relative(SRC, f)),
-      `A static import of ${DEPENDENCY} merges its ~200 kB back into the importing entry. ` +
+      `A static import of ${DEPENDENCY} merges its ~250 kB back into the importing entry. ` +
         `Reach it through 'await import()' instead — see src/components/Feedback/captureScreenshot.ts.`
+    ).toEqual([]);
+  });
+
+  it(`the retired ${RETIRED} package is gone from src/ entirely, in every import form`, () => {
+    // Not merely "not static": the package is no longer in package.json, so a
+    // dynamic import of it is a runtime failure rather than a bundle-size problem —
+    // which is how the capture broke in the first place. Both forms are offences.
+    const offenders = files.filter((file) => {
+      const source = stripComments(readFileSync(file, 'utf8'));
+      return retiredStatic.test(source) || retiredDynamic.test(source);
+    });
+
+    expect(
+      offenders.map((f) => path.relative(SRC, f)),
+      `'${RETIRED}' was replaced by '${DEPENDENCY}' because it throws on every CSS ` +
+        `Color Level 4 computed value. It is not an installed dependency any more.`
     ).toEqual([]);
   });
 
@@ -126,10 +180,13 @@ describe(`🔴 ${DEPENDENCY} is code-split out of the main bundle`, () => {
     //   - captureScreenshot.ts — the production lazy load. This is the one the split
     //     is about.
     //   - captureScreenshot.render.browser.test.ts(x) — the render-seam test's
-    //     NEGATIVE CONTROL, which drives html2canvas directly with the historical
+    //     NEGATIVE CONTROL, which drives the renderer directly with the historical
     //     `scrollX/scrollY: 0` defect to prove the fixture discriminates. Test files
     //     are not in the app bundle, so this costs a user nothing; it is listed
     //     rather than filtered out so the set stays honest about what the scan saw.
+    //   - captureScreenshot.color4.browser.test.tsx is deliberately NOT here: it
+    //     goes through `captureConsentedScreenshot`, so it exercises the PRODUCTION
+    //     loader rather than reaching past it.
     const dynamicUsers = files
       .filter((file) => dynamicReference.test(stripComments(readFileSync(file, 'utf8'))))
       .map((f) => path.relative(SRC, f))
@@ -157,7 +214,7 @@ describe(`🔴 ${DEPENDENCY} is code-split out of the main bundle`, () => {
 /**
  * 🔴 SCOPE, stated honestly. This proves the import FORM across `src/`. It does not
  * measure emitted chunk sizes, and it does not see a static import introduced from
- * `packages/`, `apps/`, or a transitive dependency that happens to bundle
- * html2canvas itself. Those are different failure modes and would need a real build
+ * `packages/`, `apps/`, or a transitive dependency that happens to bundle the
+ * renderer itself. Those are different failure modes and would need a real build
  * to catch.
  */


### PR DESCRIPTION
## The bug

Ticking **"Attach a screenshot of this page"** in the feedback prompt fails:

> Could not capture the page
> Attempting to parse an unsupported color function "color"

The submission still succeeds and the capture is silently dropped, so the failure is quiet — the stored row carries the text and the attached images and no screenshot. This half of the feature has never worked.

`html2canvas@1.4.1` is that library's last release (Feb 2022) and predates CSS Color Level 4. Its colour parser **throws instead of degrading**, so one element anywhere in the captured subtree is enough to fail the whole capture. Measured on a real page: of **3,998 elements, exactly one** computed to a Color 4 value — a translucent pill at `color(srgb 1 0.878431 0.4 / 0.1)`.

## The fix

Swap to `html2canvas-pro`, the maintained fork that added the `color()` / `oklch()` / `oklab()` / `lab()` / `lch()` parsers for exactly this error. The only production change is the module specifier in the dynamic import.

### Why this library, measured rather than assumed

| | `html2canvas@1.4.1` | `html2canvas-pro@2.3.8` |
|---|---|---|
| Last release | 2022-01-22 | 2026-08-14 |
| Signature | `(el, options?) => Promise<HTMLCanvasElement>` | identical |
| Transitive deps | `css-line-break`, `text-segmentation` | identical |
| Bundled + minified | 204,784 B | 250,924 B |
| gzip | 47,257 B | 62,686 B |
| brotli | 39,278 B | 52,285 B |
| License | MIT | MIT |

- **API compatibility**: every option this call site passes — `logging`, `useCORS`, `allowTaint`, `scale`, `x`, `y`, `width`, `height`, `windowWidth`, `windowHeight` — exists in the fork under the same name and the same meaning, including `scrollX`/`scrollY` still defaulting to the page offsets. That last one is not taken on faith: the existing render-seam test's negative control re-applies the historical `scrollX/scrollY: 0` defect through the fork and still produces the opposite pixel, which is what proves the coordinate space did not shift under the swap.
- **Size**: +15 kB gzip, and it lands in the lazily-loaded chunk that only downloads when someone ticks the box. No page load pays it. This makes the existing code-split gate *more* load-bearing, not less, so the dynamic import stays and the gate that pins it was updated rather than relaxed.
- **Output**: not just "does not throw". Every colour function is asserted by reading the **drawn pixel** back out of the produced JPEG. A renderer that quietly skipped a colour it could not parse would produce a technically-successful, visually-wrong capture and pass a resolve-only test.
- **Maintenance**: active (544 stars, 1 open issue, releases through last week), MIT, same author lineage as the original.

### Why not sanitise colours before capture

It is a standing tax — every new colour function the design system adopts has to be chased — and, more importantly, it cannot be driven from source. These values are produced by **serialization**, not authored: `color-mix(in oklab, …)` computes to `oklab(…)`, and a P3 or relative colour computes to `color(srgb …)`. A grep over the stylesheets can come back completely clean while every capture on the page fails. That is a measured property of the browser, and it is pinned in the new test.

## What is covered now

Verified in real Chromium, reading the drawn pixel:

| function | old | new |
|---|---|---|
| `color(srgb …)` | throws | ✅ |
| `color(display-p3 …)` | throws | ✅ |
| `oklch()` | throws | ✅ |
| `oklab()` | throws | ✅ |
| `lab()` | throws | ✅ |
| `lch()` | throws | ✅ |
| `color-mix()` (computes to `oklab()`) | throws | ✅ |
| `hwb()` | fine — computes to `rgb()` | ✅ |

`hwb()` is kept as the contrast case: it normalises to `rgb()` and was never affected, so a suite where it is the only green is a suite that has not tested the fix.

## Test evidence

**Red at base, green at HEAD** — the same new test file, dropped unchanged onto a clean checkout of `main`, run back-to-back on one machine:

```
base (a4bcdefebc) + the new test file only
  component  src/components/Feedback/  →  8 failed | 32 passed (40)
  every failure: "capture REJECTED: Attempting to parse an unsupported color function ..."

HEAD
  component  src/components/Feedback/  →  40 passed (40)
  unit       Feedback + the code-split gate  →  55 passed (55)   (53 at base; +2 new gate tests)
```

The 9 tests that pass at base are the instrument checks and the `hwb()` contrast case — exactly the ones that should not depend on the renderer.

**Mutation matrix.** Each mutant was killed by the intended guard, with that guard's own message, and by no other:

| # | mutation | killed by | literal message |
|---|---|---|---|
| M1 | run the new test on the old library | 8 capture cases | `capture REJECTED: Attempting to parse an unsupported color function "color"` / `"oklch"` / `"lab"` / `"lch"` / `"oklab"` |
| M2 | swap a case's value for one the browser normalises (`oklch(…)` → `hwb(…)`) | the instrument check alone (1 failed / 16 passed) | `computed background-color was "rgb(255, 0, 0)", which does not start with "oklch(" — this case no longer exercises a Color 4 parser` |
| M3 | make a case draw the wrong colour while still capturing (`color(srgb 1 0 0)` → `color(srgb 0 0 1)`) | the pixel assertion alone (1 failed / 16 passed) | `expected red, got rgb(0,0,254) — the capture succeeded but did not draw color(srgb 0 0 1)` |
| M4 | revive the retired package via `require()` | the retired-package scan alone | `'html2canvas' was replaced by 'html2canvas-pro' … expected [ 'components/Feedback/zzmutant.ts' ] to deeply equal []` |
| M5 | static-import the fork | the code-split gate alone | `A static import of html2canvas-pro merges its ~250 kB back into the importing entry.` |
| M6 | drop the closing quote from the matchers so the two package names collide | the prefix-disjointness control **and** the retired scan (which then flags 2 legitimate files) | `expected true to be false` |

M2 and M3 are the ones worth noting: in each, the *other* assertions on the same case stayed green. The instrument check is the only thing standing between a future browser normalising a value and a case that passes without ever reaching a Color 4 parser; the pixel assertion is the only thing standing between "parsed" and "tolerated".

M6 is why the prefix-disjointness control exists — `html2canvas` is a prefix of `html2canvas-pro`, so the two matchers only stay apart because each requires the closing quote. A looser matcher fails in both directions at once, and neither mistake produces a wrong-looking regex.

## Unchanged on purpose

- The capture is still **opt-in behind the checkbox**, and consent is still a literal `consented !== true` short-circuit that returns before the renderer is even loaded. Nothing here touches it; its tests still pass.
- A capture that cannot complete still **drops the attachment and lets the submission succeed** — the graceful path is the same, it just has far less to do now.
- The renderer stays **dynamically imported**. The gate that pins that was updated to the new package name and strengthened, not relaxed.

## Checks run

- `pnpm typecheck`: **0 errors** at base and at HEAD (both measured — base was confirmed clean first).
- ESLint + Prettier clean on all four touched files, with a negative control confirming each tool can go red.
- `pnpm run test:lint-rules`: 243 passed.
- Full `component` project: 1686 passed / 1 failed — the one failure (`ImageCard … still overruns the narrow column`, `expected 57 to be less than or equal to 50`) is **pre-existing and identical at base**, a host font-metric difference unrelated to this change.
- Lockfile regenerated with `--lockfile-only` so the diff is the dependency swap and nothing else (7 insertions / 7 deletions); `pnpm install --frozen-lockfile` passes, which is what CI runs.

## Not verified

The capture was exercised through the production entry point in **real Chromium via the browser-mode test harness**, not by clicking the checkbox in a running app against the live page that produced the original report. The harness drives the same `captureConsentedScreenshot` the checkbox calls and reproduces the exact failing error string, but a manual click-through on the reported page would be the last mile.
