### PR TITLE
fix(generation): stop the #4036 backfill deferring the draft reaper by 30 days

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260817200000_generation_coverage_require_rentcivit/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260817200000_generation_coverage_require_rentcivit/migration.sql
@@ -14,12 +14,16 @@
 --      defaulted `{Sell}` rather than a creator's choice; without this, applying the view removes
 --      ~65,000 of them from the generator on a permission nobody set.
 --   3. APPLY this migration.
---   4. PURGE both caches that store `covered`, and run ?action=reindex:
---        packed:generation:resource-data-3  (resourceDataCache, TTL 1h) — this is the one the
---          generator itself reads; `generation.service.ts` rejects on `!x.covered`, so a version
---          that just lost coverage stays generatable for up to an hour without this.
+--   4. PURGE the two caches that store `covered` BY KEY, not wholesale, and run ?action=reindex.
+--      ~2,415 versions actually change, and step 2's response carries their model ids:
+--        packed:generation:resource-data-3  (resourceDataCache, TTL 1h) — the one the generator
+--          itself reads; `generation.service.ts` rejects on `!x.covered`, so a version that just
+--          lost coverage stays generatable for up to an hour without this. 🔴 Flushing this key
+--          space wholesale makes every concurrent generation request rebuild from Postgres at
+--          once, joining ModelVersion against GenerationCoverage — a stampede on the hot path, in
+--          the same window the coverage change lands. Purge the affected ids.
 --        packed:caches:data-for-model       (dataForModelsCache, TTL 1d) — the model page's
---          Create button.
+--          Create button. Same reasoning, lower stakes.
 --      ?action=reindex queues the uncovered models into the search index, which otherwise keeps
 --      serving canGenerate: true for them under the on-site-generation filter.
 --

--- a/src/pages/api/admin/temp/backfill-trained-model-permissions.ts
+++ b/src/pages/api/admin/temp/backfill-trained-model-permissions.ts
@@ -124,14 +124,27 @@ export default WebhookEndpoint(async (req, res) => {
   // the queue entry, so the models are never re-queued and stay listed under the on-site-generation
   // filter. Ask the view whether it has been replaced yet rather than trusting the runbook, and
   // refuse before paying for a ~63k-row scan.
-  if (params.action === 'reindex') {
+  //
+  // Live runs only. The predicate was chosen so it answers the same either side of the swap, and
+  // blocking the dry run takes that property away at the one moment an operator wants it — sizing
+  // the reindex set before the migration lands.
+  //
+  // The two exempt branches must be excluded or the probe outlives what it is testing: a curated
+  // EcosystemCheckpoint or an ExternalGeneration version stays covered under the NEW view without
+  // consulting `allowCommercialUse` at all, so one such row carrying a legacy permission set would
+  // make this 409 forever, telling the operator to apply a migration that is already applied.
+  // (0 such rows on the prod replica today — latent, not live.)
+  if (params.action === 'reindex' && !params.dryRun) {
     const [stale] = await dbRead.$queryRaw<{ one: number }[]>`
       SELECT 1 AS one
       FROM "GenerationCoverage" gc
       JOIN "Model" m ON m.id = gc."modelId"
+      JOIN "ModelVersion" mv ON mv.id = gc."modelVersionId"
       WHERE gc.covered
         AND NOT (m."allowCommercialUse" && ARRAY['RentCivit']::"CommercialUse"[])
         AND m."allowCommercialUse" && ARRAY['Rent', 'Sell']::"CommercialUse"[]
+        AND mv."usageControl" <> 'ExternalGeneration'
+        AND mv.id NOT IN (SELECT id FROM "EcosystemCheckpoints")
       LIMIT 1
     `;
     if (stale) {
@@ -194,12 +207,20 @@ export default WebhookEndpoint(async (req, res) => {
     // explicit queueUpdate below is the ONLY route into the index — and `addToQueue` fails open on a
     // degraded sysRedis, dropping the enqueue silently while this still reports success. The bump
     // restores the delta scan as the backstop its own comment assumes exists.
+    //
+    // 🔴 Published rows ONLY, and the scoping is the point rather than caution. That delta scan
+    // reads `status = 'Published'` (models.search-index.ts), so bumping anything else buys no index
+    // coverage — while `remove-old-drafts` hard-deletes Draft/Deleted models on
+    // `updatedAt < now() - 30 days`, so a blanket bump would silently defer the reaper by a month
+    // across ~65k rows. Measured on the prod replica: 1,173 of this endpoint's own candidates are
+    // eligible for that job today, and every one of them would have been spared, deferring the
+    // cascade deletes and the storage reclamation they drive.
     const changed =
       params.action === 'repair'
         ? await dbWrite.$queryRaw<{ id: number }[]>`
             UPDATE "Model"
             SET "allowCommercialUse" = ARRAY['Image', 'RentCivit', 'Rent', 'Sell']::"CommercialUse"[],
-                "updatedAt" = NOW()
+                "updatedAt" = CASE WHEN status = 'Published' THEN NOW() ELSE "updatedAt" END
             WHERE id = ANY(${batch}::int[])
               AND "allowCommercialUse" = ARRAY['Sell']::"CommercialUse"[]
             RETURNING id


### PR DESCRIPTION
Follow-up to #4036, from a post-merge review of its final commit — which had merged without a review of its own. **Nothing from #4036 has been applied to any database yet, so none of this reached production.**

## The one that matters

#4036 added `"updatedAt" = NOW()` to the repair's `UPDATE`, to restore the models-index delta scan as a backstop (`addToQueue` fails open on a degraded sysRedis, so the explicit enqueue is not guaranteed). It was unscoped, and `updatedAt` has a second reader.

`src/server/jobs/remove-old-drafts.ts:19` hard-deletes `Draft`/`Deleted` models where `updatedAt < now() - INTERVAL '30 days'` and `downloadCount < 10`. The repair set is **40,627 `Draft` + 24,782 `Deleted`** rows, so a blanket bump defers all of them by a month — along with the cascade deletes and the `deregisterFileLocationsBatch` storage reclamation they drive.

Measured on the prod replica with the endpoint's own predicate: **1,173 candidates are eligible for that job today**, and every one would have been spared.

The fix costs nothing, which is what makes it clearly right rather than a trade: the delta scan the bump exists for reads `status = 'Published'` (`models.search-index.ts:529`), so bumping `Draft`/`Deleted` never bought index coverage in the first place.

```sql
"updatedAt" = CASE WHEN status = 'Published' THEN NOW() ELSE "updatedAt" END
```

## Three smaller ones from the same pass

- **The reindex 409 guard ran on dry runs.** The predicate was chosen precisely because it answers the same either side of the view swap; blocking the dry run removed that property at the one moment an operator wants it — sizing the reindex set before the migration lands. Live runs only now.

- **That guard's probe could outlive what it tests.** The new view keeps two branches that never consult `allowCommercialUse` — `EcosystemCheckpoints` and `usageControl = 'ExternalGeneration'`. A version reachable through either, carrying a legacy permission set without `RentCivit`, would satisfy the probe *after* the swap and 409 forever, telling the operator to apply a migration that is already applied. Both excluded. **0 such rows on the prod replica today** — latent, not live.

- **Step 4 of the runbook prescribed a wholesale purge** of `packed:generation:resource-data-3` and `packed:caches:data-for-model`. Only ~2,415 versions change and step 2 returns their ids; the first of those caches is what `generation.service.ts` reads on every generation request, so flushing the key space stampedes the hot path in the same window the coverage change lands. Now says purge by key.

## Verification

`typecheck` **0 errors**, `lint` clean on the touched file, `prettier --write` — all read from a session-private path with the package directory grepped out of the log first (`C:\Dev\Repos\work\wt-rentcivit-followup`).

No unit test reaches any of this; the reaper interaction was established by reading `remove-old-drafts.ts` and counting the affected rows against the prod replica, and the `EcosystemCheckpoints`/`ExternalGeneration` exemption by reading the view body this PR does not change.
