### PR TITLE
fix(router): lower the Next-owns-this-navigation flag on every ending

### DIFF
--- a/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
@@ -214,6 +214,19 @@ describe('BrowserRouterProvider after a hash-only navigation', () => {
       // The hash-only pop: `beforePopState` hands it to Next, which emits
       // `hashChangeComplete` and never `routeChangeComplete`.
       setUsingNextRouter(true);
+
+      // Negative control for the raise itself: while the flag is up, an update
+      // must NOT land. Without this the test passes even if the gate it is about
+      // were deleted, because it only ever asserts that an update arrives.
+      const dropped = { as: '/images/999', url: '/images/999', state: {} };
+      window.history.replaceState(dropped, '');
+      window.dispatchEvent(new CustomEvent('locationchange', { detail: [dropped] }));
+      // Give React a chance to commit before asserting the absence, or the probe
+      // reads the pre-dispatch DOM and the assertion cannot fail. (Measured: a
+      // synchronous read passed with the gate deleted.)
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(probeText()).toBe('/images');
+
       // No assertion on registration: if the listener is missing the loop is a
       // no-op, the flag stays raised, and the behavioural assertion below is what
       // reports it. Checking registration first would fail with a count instead.

--- a/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
@@ -214,7 +214,9 @@ describe('BrowserRouterProvider after a hash-only navigation', () => {
       // The hash-only pop: `beforePopState` hands it to Next, which emits
       // `hashChangeComplete` and never `routeChangeComplete`.
       setUsingNextRouter(true);
-      expect(handlers.hashChangeComplete?.length ?? 0).toBeGreaterThan(0);
+      // No assertion on registration: if the listener is missing the loop is a
+      // no-op, the flag stays raised, and the behavioural assertion below is what
+      // reports it. Checking registration first would fail with a count instead.
       for (const handler of handlers.hashChangeComplete ?? []) handler();
 
       // What a routed dialog opening looks like: `browserRouter.push` dispatches

--- a/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
@@ -176,3 +176,67 @@ describe('BrowserRouterProvider back navigation onto a dynamic route', () => {
     }
   });
 });
+
+// After a hash-only back navigation, routed dialogs stopped opening (ClickUp
+// 868kta76n). `beforePopState` raises `usingNextRouter` for every pop it hands
+// to Next, and the flag was lowered only in the `routeChangeComplete` handler —
+// but Next's hash-only branch emits `hashChangeComplete` and returns, so the
+// flag stayed raised and the `locationchange` handler dropped every update after
+// it. Measured on a dev server: after `router.push('/images#probe')` and back, a
+// feed card changed the URL to `/images/139360504` and no dialog appeared;
+// without the pop the same click opened it every time.
+describe('BrowserRouterProvider after a hash-only navigation', () => {
+  test('keeps publishing location changes, so routed dialogs still open', async () => {
+    const originalState = window.history.state;
+    const on = vi.mocked(Router.events.on);
+    const passThrough = on.getMockImplementation();
+    const handlers: Record<string, Array<() => void>> = {};
+    on.mockImplementation(((event: string, fn: () => void) => {
+      (handlers[event] ??= []).push(fn);
+      return passThrough?.(event as never, fn as never);
+    }) as typeof Router.events.on);
+
+    try {
+      renderWithProviders(
+        <BrowserRouterProvider>
+          <AsPathProbe />
+        </BrowserRouterProvider>
+      );
+
+      setUsingNextRouter(false);
+      const liveness = { as: '/images', url: '/images', state: {} };
+      window.history.replaceState(liveness, '');
+      await vi.waitFor(() => {
+        window.dispatchEvent(new PopStateEvent('popstate', { state: liveness }));
+        expect(probeText()).toBe('/images');
+      });
+
+      // The hash-only pop: `beforePopState` hands it to Next, which emits
+      // `hashChangeComplete` and never `routeChangeComplete`.
+      setUsingNextRouter(true);
+      expect(handlers.hashChangeComplete?.length ?? 0).toBeGreaterThan(0);
+      for (const handler of handlers.hashChangeComplete ?? []) handler();
+
+      // What a routed dialog opening looks like: `browserRouter.push` dispatches
+      // `locationchange`, and the provider must still publish it.
+      const opened = {
+        as: '/images/139360504',
+        url: '/images?dialog=imageDetail&imageId=139360504',
+        state: {},
+      };
+      window.history.replaceState(opened, '');
+      window.dispatchEvent(new CustomEvent('locationchange', { detail: [opened] }));
+
+      await vi.waitFor(() => {
+        expect(probeText()).toBe('/images/139360504');
+      });
+      // The regression: the flag was still raised, this update was dropped, and
+      // asPath stayed at '/images' with no dialog on screen.
+      expect(imageIdText()).toBe('139360504');
+    } finally {
+      setUsingNextRouter(false);
+      on.mockImplementation(passThrough ?? (() => undefined));
+      window.history.replaceState(originalState, '');
+    }
+  });
+});

--- a/src/components/BrowserRouter/BrowserRouterProvider.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.tsx
@@ -100,6 +100,11 @@ export function BrowserRouterProvider({ children }: { children: React.ReactNode 
     // this app aborts by throwing from `routeChangeStart` (RoutedDialogProvider)
     // exits before any terminal event at all. Both leave the flag raised, which
     // is the old behaviour, not a new fault.
+    //
+    // The listener also fires for hash navigations other than the pop that raised
+    // the flag — an in-page anchor clicked while a pop is still in flight lowers
+    // it early. Narrow, and still better than staying wedged, but it is the same
+    // ownership-by-boolean weakness rather than an exception to it.
     const releaseNextRouter = () => setUsingNextRouter(false);
 
     router.events.on('routeChangeComplete', handleRouteChangeComplete);

--- a/src/components/BrowserRouter/BrowserRouterProvider.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.tsx
@@ -89,10 +89,20 @@ export function BrowserRouterProvider({ children }: { children: React.ReactNode 
       setUsingNextRouter(false);
     };
 
+    // A navigation Next takes does not always end in `routeChangeComplete`: a
+    // hash-only pop returns after `hashChangeComplete`, and a cancelled or failed
+    // one ends in `routeChangeError`. Either way the flag has to come back down,
+    // or every later `locationchange` is dropped and routed dialogs stop opening.
+    const releaseNextRouter = () => setUsingNextRouter(false);
+
     router.events.on('routeChangeComplete', handleRouteChangeComplete);
+    router.events.on('hashChangeComplete', releaseNextRouter);
+    router.events.on('routeChangeError', releaseNextRouter);
 
     return () => {
       router.events.off('routeChangeComplete', handleRouteChangeComplete);
+      router.events.off('hashChangeComplete', releaseNextRouter);
+      router.events.off('routeChangeError', releaseNextRouter);
     };
   }, []); //eslint-disable-line
 

--- a/src/components/BrowserRouter/BrowserRouterProvider.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.tsx
@@ -89,20 +89,25 @@ export function BrowserRouterProvider({ children }: { children: React.ReactNode 
       setUsingNextRouter(false);
     };
 
-    // A navigation Next takes does not always end in `routeChangeComplete`: a
-    // hash-only pop returns after `hashChangeComplete`, and a cancelled or failed
-    // one ends in `routeChangeError`. Either way the flag has to come back down,
-    // or every later `locationchange` is dropped and routed dialogs stop opening.
+    // A hash-only navigation ends at `hashChangeComplete` and never reaches
+    // `routeChangeComplete`, so without this the flag stays raised and every
+    // later `locationchange` is dropped — routed dialogs stop opening.
+    //
+    // This list is NOT every way a navigation can end, and the two it leaves out
+    // are deliberate. `routeChangeError` also fires for the navigation being
+    // CANCELLED by the next one (router.js:872), so lowering there would release
+    // the flag while Next is mid-render of the newer route. And a route change
+    // this app aborts by throwing from `routeChangeStart` (RoutedDialogProvider)
+    // exits before any terminal event at all. Both leave the flag raised, which
+    // is the old behaviour, not a new fault.
     const releaseNextRouter = () => setUsingNextRouter(false);
 
     router.events.on('routeChangeComplete', handleRouteChangeComplete);
     router.events.on('hashChangeComplete', releaseNextRouter);
-    router.events.on('routeChangeError', releaseNextRouter);
 
     return () => {
       router.events.off('routeChangeComplete', handleRouteChangeComplete);
       router.events.off('hashChangeComplete', releaseNextRouter);
-      router.events.off('routeChangeError', releaseNextRouter);
     };
   }, []); //eslint-disable-line
 


### PR DESCRIPTION
Closes [`868kta76n`](https://app.clickup.com/t/868kta76n) — routed dialogs stop opening after a hash-only back navigation. Found while reviewing #4039; filed separately at Justin's direction rather than widening that PR.

## Repro, with a paired control

On a dev server, same build, minutes apart:

| build | after `router.push('/images#probe')` → back → click a feed card | dialog |
|---|---|---|
| with this fix | URL becomes `/images/139360504` | **opens** |
| `hashChangeComplete` listener removed | URL becomes `/images/139394833` | **does not open** |

The URL changes either way, which is what makes it silent — no error, no failed request, the dialog simply never appears.

⚠️ It has to be a hash navigation Next owns. My first attempt used `location.hash = 'probe'`, which writes no `__N` history state, so Next ignores the popstate, `beforePopState` never runs, and nothing wedges. That is why the ticket said "not reproduced".

## Cause

`RoutedDialogProvider.beforePopState` raises `usingNextRouter` for **every** pop it hands to Next. The flag was lowered in exactly one place: the `routeChangeComplete` handler.

A hash-only pop takes Next's `onlyAHashChange` branch (`next/dist/shared/lib/router/router.js:883-895`), which emits `hashChangeStart`/`hashChangeComplete` and **returns without ever emitting `routeChangeComplete`**. So the flag stays raised, and from then on `if (!usingNextRouter) useBrowserRouterState.setState(...)` in the `locationchange` handler drops every update — including the one `browserRouter.push` fires to open a routed dialog. It stays wedged until some unrelated full route change completes.

`beforePopState` lets the hash pop through because `router.asPath.split('?')[0]` keeps the fragment and so never equals `state.as.split('?')[0]`.

A navigation that ends in `routeChangeError` (chunk-load failure, cancellation) wedges the same way.

## Fix

Lower the flag on `hashChangeComplete`.

**Review round 1 removed the `routeChangeError` lowering I had first written**, and the reason is worth recording: `routeChangeError` is not only a terminal event for the *current* navigation. `change()` emits it with a cancellation error for the **previous** in-flight navigation as a new one starts (`router.js:872`), so lowering there releases the flag while Next is mid-render of the newer route — which reopens the stale-query class #4039 closed. Two quick Back presses is enough to reach it.

Two ways a navigation can end still leave the flag raised, and the comment says so rather than implying the list is exhaustive: a navigation that genuinely errors, and one this app aborts by throwing from `routeChangeStart` (`RoutedDialogProvider`), which exits before any terminal event. Both are the pre-existing behaviour, not a new fault, and both want the derived-ownership fix below rather than another lowering site.

## Verification

- Dev-server repro above, both directions, on the same build.
- `BrowserRouterProvider.browser.test.tsx` — 3 passed, one new. On revert it fails with `expected '/images' to be '/images/139360504'`. ⚠️ Round 1 caught that my re-cut was incomplete: a registration assertion was still sitting *ahead* of the behavioural one, so a revert failed with `expected 0 to be greater than 0` — a count, not the bug. Removed; the missing listener now surfaces through the behaviour.
- `browserRouterState.test.ts` + `blocks.router.workflow.test.ts` — 367 passed, the latter collecting 350, so the worktree submodule is initialised.
- `pnpm run typecheck` clean, run in this worktree.

⚠️ **Coverage limit, stated rather than implied:** no CI job runs `*.browser.test.tsx` — three workflow files, none invokes `test:component`, and `lint.yml:248` says the unit job is Node-only because component tests need a Chromium it does not install. **So the guard on this fix does not run on `main`.** The arbitration between the two routers has no CI-enforced coverage at all; that is a property of where the logic lives, not of this PR.

## The larger point, not fixed here

An audit of this machinery (requested by Justin tonight) reached this: `usingNextRouter` is a module-level boolean arbitrating a shared `popstate` stream, so the set of events that must lower it is defined by Next's internals and can grow silently on upgrade. Both this bug and #4039 are that same seam from opposite sides. The recommendation was to make ownership **derived per event** rather than latched — which removes the class instead of adding another lowering site. That is a bigger change than this one and belongs in its own ticket.

No migration.
