### PR TITLE
fix(db): apply connection-pool defaults on the Kysely connection-string path

### DIFF
--- a/apps/auth/src/lib/server/db/db.ts
+++ b/apps/auth/src/lib/server/db/db.ts
@@ -28,7 +28,15 @@ function buildConnectionString(): string {
   return url.toString();
 }
 
-const pool = new Pool({ connectionString: buildConnectionString() });
+// Explicit pool sizing, matching what `@civitai/db`'s createKyselyClients applies for the apps that
+// use the shared factory. `connectionTimeoutMillis` is the important one: pg defaults it to 0, i.e.
+// "wait forever", so an exhausted pool silently queues every caller instead of failing fast.
+const pool = new Pool({
+  connectionString: buildConnectionString(),
+  max: 20,
+  idleTimeoutMillis: 30_000,
+  connectionTimeoutMillis: 5_000,
+});
 
 export const db = new Kysely<DB>({
   dialect: new PostgresDialect({ pool }),

--- a/packages/civitai-db/src/kysely.pool-defaults.test.ts
+++ b/packages/civitai-db/src/kysely.pool-defaults.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Pool as PgPool, PoolConfig } from 'pg';
+
+/**
+ * Pool sizing on the connection-string path of `createKyselyClients`.
+ *
+ * The factory used to hand `poolConfig` straight to `new Pool(...)`, so a caller that passed only a
+ * connection string inherited pg's own defaults — including `connectionTimeoutMillis: 0`, which
+ * means "queue forever": an exhausted pool then hangs every subsequent caller instead of erroring.
+ *
+ * These assertions read the CONSTRUCTED pool's own `options`, not the factory's source. The mock
+ * below is not a stand-in for `pg`: it re-exports the real module and only subclasses `Pool` to keep
+ * a reference to each instance, so `options` is pg's own resolved config — what the pool would
+ * actually use at connect time, with pg's defaults already applied to anything we left unset.
+ * Constructing a Pool opens no socket (pg connects lazily on first query), so nothing here needs a
+ * database.
+ */
+const { createdPools } = vi.hoisted(() => ({ createdPools: [] as PgPool[] }));
+
+vi.mock('pg', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('pg')>();
+  class RecordingPool extends actual.Pool {
+    constructor(config?: PoolConfig) {
+      super(config);
+      createdPools.push(this);
+    }
+  }
+  return { ...actual, Pool: RecordingPool };
+});
+
+const { createKyselyClients } = await import('./kysely');
+const { Pool } = await import('pg');
+
+type TestDB = { widget: { id: number } };
+
+const PRIMARY_URL = 'postgresql://user:pass@primary.example.test:5432/appdb';
+const REPLICA_URL = 'postgresql://user:pass@replica.example.test:5432/appdb';
+
+// pg's own defaults, for reference: max 10, idleTimeoutMillis 10_000, connectionTimeoutMillis
+// undefined (treated as 0 = no timeout). Every fixture value below is chosen to differ from BOTH
+// those and our defaults, so no assertion can pass by landing on a value it did not come from.
+beforeEach(() => {
+  createdPools.length = 0;
+});
+
+describe('createKyselyClients applies pool defaults', () => {
+  it('sets max, idle timeout and a finite connect timeout when the caller passes only a connection string', () => {
+    createKyselyClients<TestDB>({ connectionString: PRIMARY_URL, singleClient: true });
+
+    expect(createdPools).toHaveLength(1);
+    const [pool] = createdPools;
+    expect(pool.options.connectionString).toBe(PRIMARY_URL);
+    expect(pool.options.max).toBe(20);
+    expect(pool.options.idleTimeoutMillis).toBe(30_000);
+    expect(pool.options.connectionTimeoutMillis).toBe(5_000);
+  });
+
+  it('lets an explicit caller value override each default', () => {
+    createKyselyClients<TestDB>({
+      connectionString: PRIMARY_URL,
+      max: 3,
+      idleTimeoutMillis: 1_234,
+      connectionTimeoutMillis: 777,
+      singleClient: true,
+    });
+
+    expect(createdPools).toHaveLength(1);
+    const [pool] = createdPools;
+    // Pins the SPREAD ORDER: caller config must be spread after the defaults, not before.
+    expect(pool.options.max).toBe(3);
+    expect(pool.options.idleTimeoutMillis).toBe(1_234);
+    expect(pool.options.connectionTimeoutMillis).toBe(777);
+  });
+
+  it('applies the defaults to the replica pool as well as the primary', () => {
+    createKyselyClients<TestDB>({
+      connectionString: PRIMARY_URL,
+      replicaConnectionString: REPLICA_URL,
+    });
+
+    expect(createdPools).toHaveLength(2);
+    const [primary, replica] = createdPools;
+    // Identify the pools by their connection string, so a replica assertion cannot be satisfied by
+    // accidentally reading the primary.
+    expect(primary.options.connectionString).toBe(PRIMARY_URL);
+    expect(replica.options.connectionString).toBe(REPLICA_URL);
+
+    expect(replica.options.max).toBe(20);
+    expect(replica.options.idleTimeoutMillis).toBe(30_000);
+    expect(replica.options.connectionTimeoutMillis).toBe(5_000);
+  });
+
+  it('leaves a pre-built pool untouched and builds no pool of its own', () => {
+    // The main app takes this branch: it hands in its existing pools, so the defaults above must be
+    // inert there. 7 is neither pg's default (10) nor ours (20), so "unchanged" is distinguishable
+    // from either default having been written over it.
+    const prebuilt = new Pool({ connectionString: PRIMARY_URL, max: 7 });
+    createdPools.length = 0; // discard the fixture; count only what the factory constructs
+
+    const { dbRead, dbWrite } = createKyselyClients<TestDB>({
+      pool: prebuilt,
+      readPool: prebuilt,
+    });
+
+    expect(createdPools).toHaveLength(0);
+    expect(prebuilt.options.max).toBe(7);
+    expect(prebuilt.options.connectionTimeoutMillis).toBeUndefined();
+    expect(dbRead).toBeDefined();
+    expect(dbWrite).toBeDefined();
+  });
+});

--- a/packages/civitai-db/src/kysely.pool-defaults.test.ts
+++ b/packages/civitai-db/src/kysely.pool-defaults.test.ts
@@ -108,4 +108,33 @@ describe('createKyselyClients applies pool defaults', () => {
     expect(dbRead).toBeDefined();
     expect(dbWrite).toBeDefined();
   });
+
+  it('forces sslmode=no-verify on both pools, and still applies the defaults', () => {
+    // Pins an ORDER DEPENDENCY that the defaults object introduced. `config` snapshots
+    // `poolConfig.connectionString`, so the sslNoVerify rewrite has to run BEFORE that snapshot.
+    // Move it after and the primary pool connects without `sslmode=no-verify` — rejected by the
+    // pooler's self-signed cert, i.e. dead in production — while every other test here stays green,
+    // because no other case passes sslNoVerify at all.
+    createKyselyClients<TestDB>({
+      connectionString: PRIMARY_URL,
+      replicaConnectionString: REPLICA_URL,
+      sslNoVerify: true,
+    });
+
+    expect(createdPools).toHaveLength(2);
+    const [primary, replica] = createdPools;
+
+    // Assert host AND sslmode together: host alone cannot see a missing rewrite, and sslmode alone
+    // could be satisfied by reading the wrong pool.
+    expect(primary.options.connectionString).toContain('primary.example.test');
+    expect(primary.options.connectionString).toContain('sslmode=no-verify');
+    expect(replica.options.connectionString).toContain('replica.example.test');
+    expect(replica.options.connectionString).toContain('sslmode=no-verify');
+
+    // The SSL path must not bypass the defaults.
+    expect(primary.options.max).toBe(20);
+    expect(primary.options.connectionTimeoutMillis).toBe(5_000);
+    expect(replica.options.max).toBe(20);
+    expect(replica.options.connectionTimeoutMillis).toBe(5_000);
+  });
 });

--- a/packages/civitai-db/src/kysely.ts
+++ b/packages/civitai-db/src/kysely.ts
@@ -115,14 +115,28 @@ export function createKyselyClients<DB>(
     ? forceSslNoVerify(replicaConnectionString)
     : replicaConnectionString;
 
+  // Pool sizing defaults for the connection-string path. Callers that pass only a connection string
+  // otherwise inherit pg's own defaults, and one of those is actively harmful: pg's
+  // `connectionTimeoutMillis` is 0, meaning "wait forever" — once the pool is exhausted, every
+  // further caller queues indefinitely with no error, so a pool problem surfaces as an unbounded
+  // hang rather than a fast, visible failure. A finite timeout turns it into a real error we can
+  // see and retry. `max`/`idleTimeoutMillis` match the sibling `createPool` factory's profile.
+  // Caller-supplied values win — `poolConfig` is spread last.
+  const config: PoolConfig = {
+    max: 20,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 5_000,
+    ...poolConfig,
+  };
+
   const make = (p: Pool) => new Kysely<DB>({ dialect: new PostgresDialect({ pool: p }), plugins });
 
-  const primary = make(pool ?? new Pool(poolConfig));
+  const primary = make(pool ?? new Pool(config));
   if (singleClient) return { db: primary };
 
   const dbRead =
     readPool || replicaString
-      ? make(readPool ?? new Pool({ ...poolConfig, connectionString: replicaString }))
+      ? make(readPool ?? new Pool({ ...config, connectionString: replicaString }))
       : primary;
   return { dbRead, dbWrite: primary };
 }

--- a/packages/civitai-db/src/kysely.ts
+++ b/packages/civitai-db/src/kysely.ts
@@ -116,12 +116,21 @@ export function createKyselyClients<DB>(
     : replicaConnectionString;
 
   // Pool sizing defaults for the connection-string path. Callers that pass only a connection string
-  // otherwise inherit pg's own defaults, and one of those is actively harmful: pg's
-  // `connectionTimeoutMillis` is 0, meaning "wait forever" — once the pool is exhausted, every
-  // further caller queues indefinitely with no error, so a pool problem surfaces as an unbounded
-  // hang rather than a fast, visible failure. A finite timeout turns it into a real error we can
-  // see and retry. `max`/`idleTimeoutMillis` match the sibling `createPool` factory's profile.
+  // otherwise inherit pg's own defaults, and one of those is actively harmful: pg leaves
+  // `connectionTimeoutMillis` unset and treats that as "wait forever", so once the pool is exhausted
+  // every further caller queues indefinitely and never errors — a pool problem surfaces as an
+  // unbounded hang rather than a failure. A finite timeout makes it fail fast at the call site.
+  //
+  // These pools carry NO acquire-latency metric and NO retry: the error reaches the caller as-is,
+  // and a caller that wants either has to add it (see the transient-error retry in
+  // apps/notifications). `max`/`idleTimeoutMillis` match the sibling `createPool` factory;
+  // `connectionTimeoutMillis` is deliberately STRICTER than createPool (which defaults it to 0) and
+  // matches the value the monolith already runs in production.
+  //
   // Caller-supplied values win — `poolConfig` is spread last.
+  // ORDER-DEPENDENT: this snapshots `poolConfig.connectionString`, so the `sslNoVerify` rewrite
+  // above must stay ABOVE it — otherwise the primary pool silently connects without
+  // `sslmode=no-verify`. Pinned by the sslNoVerify case in kysely.pool-defaults.test.ts.
   const config: PoolConfig = {
     max: 20,
     idleTimeoutMillis: 30_000,


### PR DESCRIPTION
## What

`createKyselyClients()` in `packages/civitai-db/src/kysely.ts` destructured its options into `poolConfig` and handed that straight to `new Pool(...)` with **no defaults applied**. Callers that pass only a connection string therefore inherited pg's own defaults.

This applies three defaults before the pools are constructed, at **both** call sites — the primary pool and the replica pool:

| option | value | why |
|---|---|---|
| `max` | `20` | matches the sibling `createPool()` factory in `db-helpers.ts` |
| `idleTimeoutMillis` | `30_000` | matches `createPool()` |
| `connectionTimeoutMillis` | `5_000` | pg's default is `0` — see below |

Caller-supplied values still win: the caller's config is spread **last**.

`apps/auth` builds its own `pg.Pool` directly instead of going through the factory, so it gets the same three values inline.

## Why `connectionTimeoutMillis` matters most

pg's default is `0`, which it reads as **"wait forever"**. Once the pool is exhausted, every further caller is queued indefinitely and never errors — so a pool problem surfaces as an unbounded silent hang instead of a fast, visible failure that we can see, alert on and retry. A finite timeout converts that failure mode into a real error.

`max` and `idleTimeoutMillis` are the smaller half of this: they simply bring the Kysely path onto the same profile the `createPool()` factory has always used. The Kysely path was just bypassing it.

## Blast radius

- **Affected**: `apps/creator-studio` and `apps/moderator` (each passes a connection string plus a replica connection string, so each builds two pools), and `apps/auth`.
- **No-op for the main app**: `src/server/db/kyselyDb.ts` passes **pre-built pools**, so `poolConfig` is unused there and the connection-string branch never runs. There is a test asserting a pre-built pool is returned untouched and that the factory constructs no pool of its own.

## Explicitly not included

A `statement_timeout` default is **deliberately not** part of this. The straightforward version of that does not behave as expected through our connection pooler, and the right approach is still open — it is being handled separately rather than bundled in here.

## Tests

New unit test `packages/civitai-db/src/kysely.pool-defaults.test.ts`, asserting against the **constructed pool's own resolved `options`** (not by re-reading the source). It re-exports the real `pg` module and only subclasses `Pool` to keep a reference to each instance, so the values read are pg's own — with pg's defaults already applied to anything left unset. Constructing a pool opens no socket, so it needs no database.

It covers: the three defaults on a connection-string-only call; an explicit caller value overriding each default (pinning the spread order); the replica pool getting the defaults too; and a pre-built pool being left alone.

Each assertion was watched fail on pre-change code, with pg's real defaults as the received values — `max` 10 vs 20, `idleTimeoutMillis` 10000 vs 30000, `connectionTimeoutMillis` undefined vs 5000, on the primary and the replica independently. Two mutation controls were also run: reversing the spread order kills only the override test (`expected 20 to be 3`), and reverting just the replica call site kills only the replica test — so each assertion is attributable to the thing it names.

`pnpm typecheck` is unchanged at 12 pre-existing errors (identical error set before and after; all in `event-engine-common` imports, unrelated to these files). `svelte-check` on `apps/auth` is unchanged at 2 pre-existing errors, verified to actually cover the edited file via a planted type error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
