### PR TITLE
fix(comics): stop losing ~half of comic views to the loading gate

### DIFF
--- a/src/components/TrackView/TrackView.tsx
+++ b/src/components/TrackView/TrackView.tsx
@@ -29,15 +29,9 @@ function sendView(input: AddViewSchema) {
 }
 
 /**
- * `delayMs` is the intent filter: a page the viewer bounced off within the window is not a view.
- * The 1s default is right when the component mounts with the page. It is too long when the
- * component is gated behind a slow query — that wait already filters bounces, and charging another
- * second on top pushed the effective threshold to ~5-6s on the comic reader and silently lost ~50%
- * of its views. Lower it at that call site rather than for everyone.
- *
- * ⚠️ Lower, not zero. The query wait only filters the FIRST render; an entityId change within an
- * already-mounted component (a shallow route change over data that is already loaded) has no wait
- * in front of it at all, so 0 counts every keypress of a held arrow key as a view.
+ * `delayMs` is the intent filter. Lower it where the component is already gated behind a slow
+ * query, which filters bounces on its own — but never to 0, because that gate only covers the
+ * first render, not a later entityId change within the same mount.
  */
 export function TrackView({
   type,

--- a/src/components/TrackView/TrackView.tsx
+++ b/src/components/TrackView/TrackView.tsx
@@ -28,6 +28,13 @@ function sendView(input: AddViewSchema) {
   });
 }
 
+/**
+ * `delayMs` is the intent filter: a page the viewer bounced off within the window is not a view.
+ * The 1s default is right when the component mounts with the page. It is WRONG when the component
+ * is gated behind a slow query — the wait itself already proves intent, and charging another
+ * second on top pushed the effective threshold to ~5-6s on the comic reader and silently lost
+ * ~50% of its views. Pass 0 there rather than lowering it for everyone.
+ */
 export function TrackView({
   type,
   entityType,
@@ -35,7 +42,8 @@ export function TrackView({
   details,
   nsfw: nsfwOverride,
   nsfwLevel,
-}: AddViewSchema) {
+  delayMs = 1000,
+}: AddViewSchema & { delayMs?: number }) {
   const observedEntityId = useRef<number | null>(null);
   const { adsEnabled, adsBlocked, useDirectAds } = useAdsContext();
 
@@ -58,11 +66,11 @@ export function TrackView({
           nsfwLevel,
         });
       }
-    }, 1000);
+    }, delayMs);
     return () => {
       clearTimeout(timeout);
     };
-  }, [entityId, type, entityType, details]);
+  }, [entityId, type, entityType, details, delayMs]);
 
   return null;
 }

--- a/src/components/TrackView/TrackView.tsx
+++ b/src/components/TrackView/TrackView.tsx
@@ -30,10 +30,14 @@ function sendView(input: AddViewSchema) {
 
 /**
  * `delayMs` is the intent filter: a page the viewer bounced off within the window is not a view.
- * The 1s default is right when the component mounts with the page. It is WRONG when the component
- * is gated behind a slow query — the wait itself already proves intent, and charging another
- * second on top pushed the effective threshold to ~5-6s on the comic reader and silently lost
- * ~50% of its views. Pass 0 there rather than lowering it for everyone.
+ * The 1s default is right when the component mounts with the page. It is too long when the
+ * component is gated behind a slow query — that wait already filters bounces, and charging another
+ * second on top pushed the effective threshold to ~5-6s on the comic reader and silently lost ~50%
+ * of its views. Lower it at that call site rather than for everyone.
+ *
+ * ⚠️ Lower, not zero. The query wait only filters the FIRST render; an entityId change within an
+ * already-mounted component (a shallow route change over data that is already loaded) has no wait
+ * in front of it at all, so 0 counts every keypress of a held arrow key as a view.
  */
 export function TrackView({
   type,

--- a/src/pages/comics/[id]/[[...slug]].tsx
+++ b/src/pages/comics/[id]/[[...slug]].tsx
@@ -123,16 +123,33 @@ function PublicComicReader() {
     { id: projectId },
     { enabled: !isNaN(projectId) && projectId > 0 }
   );
+  // Emitted from HERE, above the loading gate, rather than from inside ComicOverview. The project
+  // id comes from the URL, so nothing about a project view needs `getPublicProjectForReader` — and
+  // that query pulls every chapter, panel and image, so waiting on it put the effective threshold
+  // for a view at ~5-6s. 47% of comic visits are shorter than that, and measured against pageViews
+  // roughly half of all comic views were being lost. Articles and posts sit at parity because they
+  // render TrackView off server-side props with no data gate.
+  //
+  // 🔴 It is mounted ONCE, outside the branches, on purpose. Rendering it in both the loading
+  // branch and the loaded branch remounts it when the query resolves — and a remount resets
+  // TrackView's `observedEntityId` ref, so a slow query would fire the beacon TWICE while a fast
+  // one fired once. That turns an undercount into a load-dependent overcount, which is worse:
+  // wrong in a way that varies with the viewer's connection.
+  //
+  // The cost of firing before the query is that a view now also counts a load of a project that
+  // turns out not to exist, or one blocked on the green domain — neither knowable beforehand. Both
+  // are tiny (2 unresolvable project ids across 6 months of pageViews) against the ~50% recovered.
+  const trackProjectView = chapterDbPos == null && projectId > 0;
+
+  let body: React.ReactNode;
   if (isLoading) {
-    return (
+    body = (
       <div className={styles.loadingCenter} style={{ minHeight: '60vh' }}>
         <div className={styles.spinner} />
       </div>
     );
-  }
-
-  if (isError || !project) {
-    return (
+  } else if (isError || !project) {
+    body = (
       <div className={styles.notFound}>
         <IconPhotoOff size={48} />
         <p>{isError ? 'Failed to load comic' : 'Comic not found'}</p>
@@ -142,27 +159,32 @@ function PublicComicReader() {
         </Link>
       </div>
     );
-  }
-
-  // Block NSFW comics on green domain.
-  // Project nsfwLevel is bit_or of all chapters, so check for ANY NSFW bits.
-  if (
+  } else if (
+    // Block NSFW comics on green domain. Project nsfwLevel is bit_or of all chapters, so check
+    // for ANY NSFW bits.
     features.isGreen &&
     project.nsfwLevel !== 0 &&
     Flags.intersects(project.nsfwLevel, nsfwBrowsingLevelsFlag)
   ) {
-    return (
+    body = (
       <div className="absolute inset-0 flex items-center justify-center">
         <Text>This content is not available on this site</Text>
       </div>
     );
+  } else if (chapterDbPos == null) {
+    body = <ComicOverview project={project} />;
+  } else {
+    body = <ChapterReader project={project} chapterDbPos={chapterDbPos} />;
   }
 
-  if (chapterDbPos == null) {
-    return <ComicOverview project={project} />;
-  }
-
-  return <ChapterReader project={project} chapterDbPos={chapterDbPos} />;
+  return (
+    <>
+      {trackProjectView && (
+        <TrackView entityId={projectId} entityType="ComicProject" type="ComicProjectView" />
+      )}
+      {body}
+    </>
+  );
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -399,7 +421,6 @@ function ComicOverview({ project }: { project: Project }) {
   return (
     <>
       <Meta title={`${project.name} - Civitai Comics`} canonical={`/comics/${project.id}`} />
-      <TrackView entityId={project.id} entityType="ComicProject" type="ComicProjectView" />
 
       <div className={styles.overviewRoot}>
         {/* Hero image */}
@@ -1084,7 +1105,14 @@ function ChapterReader({ project, chapterDbPos }: { project: Project; chapterDbP
       {/* Gated on canRead so this counts the same event ComicChapterRead does —
           a paywalled chapter the viewer cannot open is not a read. */}
       {activeChapter && canRead && (
-        <TrackView entityId={activeChapter.id} entityType="ComicChapter" type="ComicChapterView" />
+        <TrackView
+          entityId={activeChapter.id}
+          entityType="ComicChapter"
+          type="ComicChapterView"
+          // The query wait already proved intent; charging another second on top is what lost
+          // ~half of chapter reads.
+          delayMs={0}
+        />
       )}
 
       <div className={styles.readerRoot}>

--- a/src/pages/comics/[id]/[[...slug]].tsx
+++ b/src/pages/comics/[id]/[[...slug]].tsx
@@ -123,24 +123,10 @@ function PublicComicReader() {
     { id: projectId },
     { enabled: !isNaN(projectId) && projectId > 0 }
   );
-  // Emitted from HERE, above the loading gate, rather than from inside ComicOverview. The project
-  // id comes from the URL, so nothing about a project view needs `getPublicProjectForReader` — and
-  // that query pulls every chapter, panel and image, so waiting on it put the effective threshold
-  // for a view at ~5-6s. 47% of comic visits are shorter than that, and measured against pageViews
-  // roughly half of all comic views were being lost. Articles and posts sit at parity because they
-  // render TrackView off server-side props with no data gate.
-  //
-  // 🔴 It is mounted ONCE, outside the branches, on purpose. Rendering it in both the loading
-  // branch and the loaded branch remounts it when the query resolves — and a remount resets
-  // TrackView's `observedEntityId` ref, so a slow query would fire the beacon TWICE while a fast
-  // one fired once. That turns an undercount into a load-dependent overcount, which is worse:
-  // wrong in a way that varies with the viewer's connection.
-  //
-  // The cost of firing before the query is that a view now also counts a load of a project that
-  // turns out not to exist (2 unresolvable ids across 6 months of pageViews), or one blocked on the
-  // green domain — which is UNMEASURED, and on green every NSFW comic is blocked. Note this also
-  // moves toward, not away from, the baseline the fix is validated against: pageViews counts those
-  // same loads, so including them makes the two sources more comparable, not less.
+  // Above the loading gate on purpose: the project id is in the URL, so a project view never
+  // needed getPublicProjectForReader — and waiting on it put the threshold for a view at ~5-6s.
+  // Mounted ONCE, outside the branches: a remount resets TrackView's ref, so rendering it per
+  // branch would fire twice on slow connections and once on fast ones.
   const trackProjectView = chapterDbPos == null && projectId > 0;
 
   let body: React.ReactNode;
@@ -1111,12 +1097,8 @@ function ChapterReader({ project, chapterDbPos }: { project: Project; chapterDbP
           entityId={activeChapter.id}
           entityType="ComicChapter"
           type="ComicChapterView"
-          // Short, not zero. The query wait proves intent for the FIRST chapter render only —
-          // chapter-to-chapter navigation is a shallow router.replace against already-loaded
-          // data, so there is no second wait and nothing else filtering it. Prev/Next is bound to
-          // the arrow keys, so at 0ms a reader holding ArrowRight through a 20-chapter comic
-          // books 20 reads in three seconds. 250ms kills held-key skimming and is noise against
-          // the ~5-6s this fix removes.
+          // Not 0: chapter-to-chapter is a shallow replace over loaded data with no wait in
+          // front of it, and Prev/Next is on the arrow keys, so 0 counts held-key skimming.
           delayMs={250}
         />
       )}

--- a/src/pages/comics/[id]/[[...slug]].tsx
+++ b/src/pages/comics/[id]/[[...slug]].tsx
@@ -137,8 +137,10 @@ function PublicComicReader() {
   // wrong in a way that varies with the viewer's connection.
   //
   // The cost of firing before the query is that a view now also counts a load of a project that
-  // turns out not to exist, or one blocked on the green domain — neither knowable beforehand. Both
-  // are tiny (2 unresolvable project ids across 6 months of pageViews) against the ~50% recovered.
+  // turns out not to exist (2 unresolvable ids across 6 months of pageViews), or one blocked on the
+  // green domain — which is UNMEASURED, and on green every NSFW comic is blocked. Note this also
+  // moves toward, not away from, the baseline the fix is validated against: pageViews counts those
+  // same loads, so including them makes the two sources more comparable, not less.
   const trackProjectView = chapterDbPos == null && projectId > 0;
 
   let body: React.ReactNode;
@@ -1109,9 +1111,13 @@ function ChapterReader({ project, chapterDbPos }: { project: Project; chapterDbP
           entityId={activeChapter.id}
           entityType="ComicChapter"
           type="ComicChapterView"
-          // The query wait already proved intent; charging another second on top is what lost
-          // ~half of chapter reads.
-          delayMs={0}
+          // Short, not zero. The query wait proves intent for the FIRST chapter render only —
+          // chapter-to-chapter navigation is a shallow router.replace against already-loaded
+          // data, so there is no second wait and nothing else filtering it. Prev/Next is bound to
+          // the arrow keys, so at 0ms a reader holding ArrowRight through a 20-chapter comic
+          // books 20 reads in three seconds. 250ms kills held-key skimming and is noise against
+          // the ~5-6s this fix removes.
+          delayMs={250}
         />
       )}
 


### PR DESCRIPTION
Comic view tracking shipped today undercounting by **~2x**. This fixes the cause.

## Evidence

Measured against `pageViews` in the same window, first hours after deploy:

| surface | pageViews | live views | ratio |
|---|---|---|---|
| comic project | 623 | 297 | **0.48** |
| comic chapter | 569 | 307 | **0.54** |
| articles *(control)* | 4,011 | 4,326 | 1.08 |
| posts *(control)* | 26,253 | 27,834 | 1.06 |

Controls at parity in the same window, so it is comics-specific. Stable at ~0.50 across four hours, so not a deploy transient.

## Cause

`<TrackView>` lived inside `ComicOverview`/`ChapterReader`, which do not render until `getPublicProjectForReader` resolves — and that query pulls the project, every chapter, every panel and its images. Only then did `TrackView` mount and start its **own 1s timer**. Effective threshold: query time + 1s, ~5-6s.

| | <2s | <4s | **<6s** | <10s |
|---|---|---|---|---|
| comics | 13.1% | 35.0% | **47.3%** | 60.6% |
| articles | 5.5% | 14.7% | 21.5% | 31.5% |

**47.3% of comic visits are under 6 seconds; the loss was 50%.** Articles render `TrackView` off server-side props with no data gate.

## Ruled out first, each by measurement

- per-user gating — 103 of 120 users with comic pageViews *do* appear in `views`
- project / NSFW / green-domain gating — ratio uniform across projects, not bimodal
- anon users — both sources ~98% authed
- repeat suppression by the ref — views fall *below* distinct user-project pairs (297 vs 409)
- `pageViews` double-firing — comics repeat **less** than articles (1.26 vs 1.95 rows per user-page pair)
- navigation / shallow `router.replace` — ratio is flat at ~0.5 across browsing depth, **including users who viewed exactly one page** (0.426)

## The fix

The project id is in the URL, so a project view never needed the query. It now fires from `PublicComicReader` above the loading gate.

🔴 **Mounted once, outside the branches.** Rendering it in both the loading and loaded branches remounts it when the query resolves, and a remount resets `observedEntityId` — a slow connection would fire twice, a fast one once. That is worse than the original bug: a load-dependent overcount biased toward users on worse connections, which would have *looked* like the fix working.

Chapter reads still need the chapter id from the query, so they keep the gate but no longer pay an extra second on top. `TrackView` takes an optional `delayMs` (default 1000 — **every existing caller unchanged**) and the chapter reader passes 0.

**Cost:** a project view now also counts a load of a project that does not exist, or one blocked on the green domain — neither knowable before the query. Two unresolvable project ids appeared across six months of `pageViews`.

## Verification

`typecheck` 0 errors · `test:unit:run` **1148 passed | 1 skipped (1149)**, **18,097 tests (18,120)**, log verified by tree path and size · prettier applied.

**After deploy**, re-measure comic views against `pageViews`; it should approach the 1.06-1.08 the controls show. The backfilled history is the more accurate span, so the step at `2026-08-17` should close on its own — which unblocks the Creator Studio comic views tab (currently held for exactly this reason).