### PR TITLE
feat(event-engine): count comments on every surface toward the owner

### DIFF
--- a/apps/event-engine/scripts/backfill-user-comment-count.mjs
+++ b/apps/event-engine/scripts/backfill-user-comment-count.mjs
@@ -8,26 +8,40 @@
  *   - Post / Image / Article / Bounty  -> event-engine v1.9.13 (#4002)
  *   - every other surface              -> the release carrying #4067
  * Backfilling both to one boundary either double-counts the first group or loses everything the
- * second group received between the run and its own release. Both boundaries are required.
+ * second group received between the run and its own release.
  *
  * Totals are read from daily aggregates, not from the event stream: entityMetricDaily_today_v2_mv
- * only ever looks at `createdAt >= today() - 1`, so historically-dated rows written into
- * entityMetricEvents_month would be invisible to every total. The backfill therefore writes day
- * totals into entityMetricDailyAgg_history_v2 and marks each entity dirty so the additive
- * refresher recomputes it.
+ * and entityMetricDailySeal_v2_mv both filter `createdAt >= today() - 1`, so historically-dated
+ * rows written into entityMetricEvents_month would be invisible to every total. The backfill
+ * therefore writes day totals into entityMetricDailyAgg_history_v2 and marks each entity dirty so
+ * entityMetricTotal_v3_refresher_additive recomputes it.
  *
  * That table is a ReplacingMergeTree versioned by `sealedAt`, keyed
- * (entityType, entityId, metricType, day) — a written row REPLACES that day rather than adding to
- * it. Days that already carry live events are therefore reported, not written.
+ * (entityType, entityId, metricType, day), and history rows carry NO surface dimension. A written
+ * row REPLACES that day for that user rather than adding to it. Every day from the first live
+ * event onward already holds sealed live totals for the four old surfaces, so writing a
+ * new-surface-only total over it would destroy both halves. All such days are excluded here and
+ * need an explicit merge (backfill total + sealed total, written with a fresh sealedAt).
+ *
+ * This is only readable while ('User','commentCount') is registered `additive` in
+ * entityMetricKind, which the script asserts before writing. Flip that row and the presence-based
+ * refresher recomputes the total from entityMetricUserState_v3 — which holds only live events —
+ * and silently overwrites every backfilled total with a much smaller number.
+ *
+ * Known and accepted divergences from the live path, both small: a comment created before the
+ * cutover and deleted during the run is subtracted twice; and two comments from the same commenter
+ * to the same owner in the same second collapse to one live (ReplacingMergeTree key) but count as
+ * two here.
  *
  * Usage:
  *   node scripts/backfill-user-comment-count.mjs --new-cutover 2026-08-18T12:00:00Z
  *   node scripts/backfill-user-comment-count.mjs --new-cutover ... --execute
  *
  * Options:
- *   --new-cutover <iso>  When the release carrying #4067 went live. Required.
+ *   --new-cutover <iso>  When the release carrying #4067 went live. Required, must be in the past.
  *   --execute            Actually write. Default is a dry run that writes nothing.
- *   --limit <n>          Only write the first n day rows (smoke test).
+ *   --limit <n>          Write only the first n day rows. Smoke test only: it marks those owners
+ *                        dirty too, so their live totals go WRONG until a full run lands.
  */
 
 import { createClient } from '@clickhouse/client';
@@ -59,9 +73,13 @@ const EXECUTE = args.includes('--execute');
 const LIMIT = args.includes('--limit') ? Number(args[args.indexOf('--limit') + 1]) : null;
 const NEW_CUTOVER = args.includes('--new-cutover') ? args[args.indexOf('--new-cutover') + 1] : null;
 
-// The four surfaces already emitting since #4002. Their boundary is read from ClickHouse rather
-// than hardcoded: comments after the first live event are already counted, and the run is only
-// safe if that is the real first event rather than the one a ticket recorded.
+// Rows per dirty-flag batch, and the pause between batches. The additive refresher reprocesses a
+// rolling 10 minute window every minute, so 104k rows enqueued at one instant are re-read on ten
+// consecutive refreshes of a job that normally finishes in seconds — enough to delay every other
+// additive metric platform-wide against a 10 minute staleness alert.
+const DIRTY_CHUNK = 5000;
+const DIRTY_PAUSE_MS = 30000;
+
 const OLD_SURFACES = new Set(['post', 'image', 'article', 'bounty']);
 
 const SURFACES = [
@@ -88,18 +106,28 @@ const SURFACES = [
   },
 ];
 
+// `createdAt` is `timestamp without time zone` holding UTC. node-pg serialises a JS Date with the
+// HOST's offset and Postgres then drops that offset, so binding a Date silently moves the boundary
+// by the host's timezone — measured at 847 comments through a 6 hour shift, each of them skipped by
+// the backfill and never emitted by the forward path. Bind the wall-clock UTC string instead.
+const asUtcTimestamp = (date) => date.toISOString().slice(0, 19).replace('T', ' ');
+
+// `day` comes back as a string from `to_char`: a DATE would be parsed into a LOCAL-midnight Date,
+// and `toISOString()` on that shifts the day on any UTC+ host. A day shifted onto today or
+// yesterday is dropped from every total, because entityMetricDailyAgg_v2_prev reads history only
+// for `day < today() - 1`.
 function commentV2Sql(surface) {
   return `
     SELECT owner AS "ownerId", day, count(*)::int AS total
     FROM (
       SELECT ${surface.owner} AS owner,
-             (c."createdAt" AT TIME ZONE 'UTC')::date AS day,
+             to_char(c."createdAt", 'YYYY-MM-DD') AS day,
              c."userId" AS commenter
       FROM "CommentV2" c
       JOIN "Thread" t ON t.id = c."threadId"
       LEFT JOIN "Thread" r ON r.id = t."rootThreadId"
       JOIN ${surface.table} e ON ${surface.idCol ?? 'e.id'} = COALESCE(r."${surface.fk}", t."${surface.fk}")
-      WHERE c."createdAt" < $1
+      WHERE c."createdAt" < $1::timestamp AND c."userId" <> ALL($2::int[])
     ) s
     WHERE owner IS NOT NULL AND owner <> commenter
     GROUP BY 1, 2`;
@@ -107,12 +135,26 @@ function commentV2Sql(surface) {
 
 const LEGACY_MODEL_SQL = `
   SELECT m."userId" AS "ownerId",
-         (c."createdAt" AT TIME ZONE 'UTC')::date AS day,
+         to_char(c."createdAt", 'YYYY-MM-DD') AS day,
          count(*)::int AS total
   FROM "Comment" c
   JOIN "Model" m ON m.id = c."modelId"
-  WHERE c."createdAt" < $1 AND m."userId" <> c."userId"
+  WHERE c."createdAt" < $1::timestamp
+    AND c."userId" <> ALL($2::int[])
+    AND m."userId" <> c."userId"
   GROUP BY 1, 2`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function daysBetween(fromDay, toDay) {
+  const days = [];
+  for (let d = new Date(`${fromDay}T00:00:00Z`); ; d.setUTCDate(d.getUTCDate() + 1)) {
+    const day = d.toISOString().slice(0, 10);
+    days.push(day);
+    if (day >= toDay) break;
+  }
+  return days;
+}
 
 async function main() {
   if (!NEW_CUTOVER) {
@@ -126,9 +168,21 @@ async function main() {
     console.error(`Error: --new-cutover "${NEW_CUTOVER}" is not a date`);
     process.exit(1);
   }
+  if (newCutover > new Date()) {
+    console.error(`Error: --new-cutover ${newCutover.toISOString()} is in the future. Run this`);
+    console.error('AFTER the release: comments created between the boundary and the real release');
+    console.error('are counted by neither path.');
+    process.exit(1);
+  }
 
-  // The app is configured with a single credentialed CLICKHOUSE_URL; the query skill splits it into
-  // host/username/password. Either is accepted so this runs both in a pod and from a workstation.
+  const replicaUrl = process.env.DATABASE_REPLICA_URL ?? pgEnv.DATABASE_REPLICA_URL;
+  if (!replicaUrl) {
+    console.error('Error: DATABASE_REPLICA_URL is required. This is 16 sequential full scans of');
+    console.error('CommentV2 driving ~34M index probes; it does not belong on the primary, so');
+    console.error('there is deliberately no fallback to DATABASE_URL.');
+    process.exit(1);
+  }
+
   const chUrl = process.env.CLICKHOUSE_URL ?? chEnv.CLICKHOUSE_URL;
   const ch = createClient(
     chUrl
@@ -145,16 +199,23 @@ async function main() {
         }
   );
 
-  const firstEventRows = await (
-    await ch.query({
-      query: `SELECT min(createdAt) AS firstEvent, count() AS events
-              FROM default.entityMetricEvents_month
-              WHERE entityType = 'User' AND metricType = 'commentCount'`,
-      format: 'JSONEachRow',
-    })
-  ).json();
-  const hasEvents = Number(firstEventRows[0]?.events ?? 0) > 0;
-  const firstEvent = hasEvents ? new Date(`${firstEventRows[0].firstEvent}Z`) : null;
+  const query = async (sql) => (await ch.query({ query: sql, format: 'JSONEachRow' })).json();
+
+  const kind = await query(`SELECT kind FROM default.entityMetricKind FINAL
+                            WHERE entityType = 'User' AND metricType = 'commentCount'`);
+  if (kind[0]?.kind !== 'additive') {
+    console.error(`Error: entityMetricKind for User/commentCount is "${kind[0]?.kind ?? 'missing'}",`);
+    console.error('not "additive". Day totals are only readable through the additive refresher;');
+    console.error('under any other kind the total is recomputed from live events alone and every');
+    console.error('backfilled value is silently replaced by a much smaller one.');
+    process.exit(1);
+  }
+
+  const firstEventRows = await query(`SELECT min(createdAt) AS firstEvent, count() AS events
+                                      FROM default.entityMetricEvents_month
+                                      WHERE entityType = 'User' AND metricType = 'commentCount'`);
+  const firstEvent =
+    Number(firstEventRows[0]?.events ?? 0) > 0 ? new Date(`${firstEventRows[0].firstEvent}Z`) : null;
 
   if (!firstEvent) {
     console.error('Error: no User.commentCount events in ClickHouse. The forward path is not live,');
@@ -167,17 +228,17 @@ async function main() {
     process.exit(1);
   }
 
+  const excluded = await query(`SELECT userId FROM default.metricExcludedUsers FINAL
+                                WHERE active = 1`);
+  const excludedIds = excluded.map((row) => Number(row.userId));
+
   console.log(`ClickHouse first User.commentCount event: ${firstEvent.toISOString()}`);
   console.log(`  boundary for post/image/article/bounty: ${firstEvent.toISOString()}`);
   console.log(`  boundary for every other surface:       ${newCutover.toISOString()}`);
+  console.log(`  excluded commenters (metricExcludedUsers): ${excludedIds.length}`);
   console.log(EXECUTE ? '\nMODE: EXECUTE, this will write.\n' : '\nMODE: dry run, nothing is written.\n');
 
-  const pool = new pg.Pool({
-    connectionString:
-      process.env.DATABASE_REPLICA_URL ?? pgEnv.DATABASE_REPLICA_URL ?? pgEnv.DATABASE_URL,
-    connectionTimeoutMillis: 30000,
-    max: 4,
-  });
+  const pool = new pg.Pool({ connectionString: replicaUrl, connectionTimeoutMillis: 30000, max: 4 });
 
   const byOwner = new Map();
   let grandTotal = 0;
@@ -199,15 +260,18 @@ async function main() {
   for (const surface of SURFACES) {
     const boundary = OLD_SURFACES.has(surface.key) ? firstEvent : newCutover;
     const started = Date.now();
-    const { rows } = await pool.query(commentV2Sql(surface), [boundary]);
-    for (const row of rows) add(row.ownerId, row.day.toISOString().slice(0, 10), row.total);
+    const { rows } = await pool.query(commentV2Sql(surface), [
+      asUtcTimestamp(boundary),
+      excludedIds,
+    ]);
+    for (const row of rows) add(row.ownerId, row.day, row.total);
     report(surface.key, rows, started);
   }
 
   {
     const started = Date.now();
-    const { rows } = await pool.query(LEGACY_MODEL_SQL, [newCutover]);
-    for (const row of rows) add(row.ownerId, row.day.toISOString().slice(0, 10), row.total);
+    const { rows } = await pool.query(LEGACY_MODEL_SQL, [asUtcTimestamp(newCutover), excludedIds]);
+    for (const row of rows) add(row.ownerId, row.day, row.total);
     report('model (legacy)', rows, started);
   }
 
@@ -228,21 +292,23 @@ async function main() {
 
   console.log(`\n${grandTotal} comments across ${byOwner.size} owners -> ${rowsToWrite.length} day rows`);
 
-  // A day that also carries live events would be REPLACED rather than added to, so the overlap is
-  // reported rather than written. It is small by construction (the boundary day of each group) and
-  // wrong to guess at.
-  const boundaryDays = new Set([
-    firstEvent.toISOString().slice(0, 10),
-    newCutover.toISOString().slice(0, 10),
-  ]);
-  const overlap = rowsToWrite.filter((row) => boundaryDays.has(row.day));
-  const safeRows = rowsToWrite.filter((row) => !boundaryDays.has(row.day));
-  if (overlap.length) {
-    const overlapTotal = overlap.reduce((sum, row) => sum + row.total, 0);
+  // Every day from the first live event onward already carries sealed totals for the four old
+  // surfaces, and a history row has no surface dimension — so writing a new-surface-only total over
+  // one of those days destroys the live half AND the old-surface half in a single stroke. It is not
+  // just the two endpoint days: the whole span between them is live for four surfaces and
+  // backfilled for twelve, and it grows by a day for every day the release slips.
+  const mergeDays = new Set(
+    daysBetween(firstEvent.toISOString().slice(0, 10), newCutover.toISOString().slice(0, 10))
+  );
+  const needsMerge = rowsToWrite.filter((row) => mergeDays.has(row.day));
+  const safeRows = rowsToWrite.filter((row) => !mergeDays.has(row.day));
+  if (needsMerge.length) {
+    const mergeTotal = needsMerge.reduce((sum, row) => sum + row.total, 0);
     console.log(
-      `\n${overlap.length} rows fall on a boundary day (${[...boundaryDays].join(', ')}) holding ` +
-        `${overlapTotal} comments. Those days already carry live totals, so writing them would ` +
-        `replace the live value. Excluded here; they need an explicit merge.`
+      `\n${needsMerge.length} rows fall on a day that already holds live totals ` +
+        `(${[...mergeDays].join(', ')}), carrying ${mergeTotal} comments. Writing them would ` +
+        `REPLACE the sealed live value rather than add to it, so they are excluded. They need an ` +
+        `explicit merge: backfill total + existing sealed total, written with a fresh sealedAt.`
     );
   }
 
@@ -256,7 +322,7 @@ async function main() {
   if (!EXECUTE) {
     console.log(`\nDry run complete. ${safeRows.length} rows would be written to`);
     console.log('entityMetricDailyAgg_history_v2, then one entityMetricDirty_v3 row per owner');
-    console.log(`(${byOwner.size}) so the additive refresher recomputes each total.`);
+    console.log(`(${byOwner.size}) in chunks of ${DIRTY_CHUNK} every ${DIRTY_PAUSE_MS / 1000}s.`);
     console.log('\nSample:');
     for (const row of safeRows.slice(0, 5)) console.log(' ', JSON.stringify(row));
     await ch.close();
@@ -279,14 +345,15 @@ async function main() {
     entityId,
     metricType: 'commentCount',
   }));
-  for (let i = 0; i < dirty.length; i += BATCH) {
+  for (let i = 0; i < dirty.length; i += DIRTY_CHUNK) {
+    if (i > 0) await sleep(DIRTY_PAUSE_MS);
     await ch.insert({
       table: 'entityMetricDirty_v3',
-      values: dirty.slice(i, i + BATCH),
+      values: dirty.slice(i, i + DIRTY_CHUNK),
       format: 'JSONEachRow',
     });
+    console.log(`marked ${Math.min(i + DIRTY_CHUNK, dirty.length)}/${dirty.length} owners dirty`);
   }
-  console.log(`marked ${dirty.length} owners dirty`);
 
   await ch.close();
 }

--- a/apps/event-engine/scripts/backfill-user-comment-count.mjs
+++ b/apps/event-engine/scripts/backfill-user-comment-count.mjs
@@ -40,8 +40,13 @@
  * Options:
  *   --new-cutover <iso>  When the release carrying #4067 went live. Required, must be in the past.
  *   --execute            Actually write. Default is a dry run that writes nothing.
+ *   --no-dirty           Write history, flag nothing. History rows are invisible to every total
+ *                        until their entity is dirtied, so this is a full-scale, fully reversible
+ *                        rehearsal: verify sampled owners against Postgres, then run --dirty-only.
+ *   --dirty-only         Flag the owners, write no history. The second half of that pair.
  *   --limit <n>          Write only the first n day rows. Smoke test only: it marks those owners
- *                        dirty too, so their live totals go WRONG until a full run lands.
+ *                        dirty too, so their live totals go WRONG until a full run lands. Prefer
+ *                        --no-dirty, which is wrong for nobody.
  */
 
 import { createClient } from '@clickhouse/client';
@@ -70,15 +75,19 @@ const pgEnv = loadEnvFile(resolve(__dirname, '../.claude/skills/postgres-query/.
 
 const args = process.argv.slice(2);
 const EXECUTE = args.includes('--execute');
+const NO_DIRTY = args.includes('--no-dirty');
+const DIRTY_ONLY = args.includes('--dirty-only');
 const LIMIT = args.includes('--limit') ? Number(args[args.indexOf('--limit') + 1]) : null;
 const NEW_CUTOVER = args.includes('--new-cutover') ? args[args.indexOf('--new-cutover') + 1] : null;
 
-// Rows per dirty-flag batch, and the pause between batches. The additive refresher reprocesses a
-// rolling 10 minute window every minute, so 104k rows enqueued at one instant are re-read on ten
-// consecutive refreshes of a job that normally finishes in seconds — enough to delay every other
-// additive metric platform-wide against a 10 minute staleness alert.
-const DIRTY_CHUNK = 5000;
-const DIRTY_PAUSE_MS = 30000;
+// Rows per dirty-flag batch, and the pause between batches. The refresher's window is a ROLLING ten
+// minutes, so every row sits in it for ten minutes whenever it arrives and the total re-reads are
+// the same either way — chunking caps the OCCUPANCY, and only if the rate stays under
+// target/10min. At 2,500/min the extra occupancy tops out around 25k, roughly one baseline against
+// the platform's normal 2,500-3,000/min. Faster than that (5,000 per 30s parks ~100k in the window)
+// is the un-chunked flood arriving ten minutes late. ~42 minutes for 104k owners.
+const DIRTY_CHUNK = 2500;
+const DIRTY_PAUSE_MS = 60000;
 
 const OLD_SURFACES = new Set(['post', 'image', 'article', 'bounty']);
 
@@ -211,6 +220,15 @@ async function main() {
     process.exit(1);
   }
 
+  if (EXECUTE) {
+    // Writes nothing, but fails now rather than after ~20 minutes of Postgres scans if the
+    // credential turns out to be read-only.
+    await ch.command({
+      query: `INSERT INTO default.entityMetricDailyAgg_history_v2
+              SELECT * FROM default.entityMetricDailyAgg_history_v2 WHERE 0`,
+    });
+  }
+
   const firstEventRows = await query(`SELECT min(createdAt) AS firstEvent, count() AS events
                                       FROM default.entityMetricEvents_month
                                       WHERE entityType = 'User' AND metricType = 'commentCount'`);
@@ -335,13 +353,23 @@ async function main() {
 
   const limited = LIMIT ? safeRows.slice(0, LIMIT) : safeRows;
   const BATCH = 50000;
-  for (let i = 0; i < limited.length; i += BATCH) {
-    await ch.insert({
-      table: 'entityMetricDailyAgg_history_v2',
-      values: limited.slice(i, i + BATCH),
-      format: 'JSONEachRow',
-    });
-    console.log(`wrote ${Math.min(i + BATCH, limited.length)}/${limited.length} day rows`);
+  if (DIRTY_ONLY) {
+    console.log('--dirty-only: skipping the history write');
+  } else {
+    for (let i = 0; i < limited.length; i += BATCH) {
+      await ch.insert({
+        table: 'entityMetricDailyAgg_history_v2',
+        values: limited.slice(i, i + BATCH),
+        format: 'JSONEachRow',
+      });
+      console.log(`wrote ${Math.min(i + BATCH, limited.length)}/${limited.length} day rows`);
+    }
+  }
+
+  if (NO_DIRTY) {
+    console.log('--no-dirty: history written, nothing flagged. No total moves until --dirty-only.');
+    await ch.close();
+    return;
   }
 
   const dirty = [...new Set(limited.map((row) => row.entityId))].map((entityId) => ({

--- a/apps/event-engine/scripts/backfill-user-comment-count.mjs
+++ b/apps/event-engine/scripts/backfill-user-comment-count.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+
+/**
+ * Backfill User.commentCount from Postgres
+ *
+ * Postgres is the source of truth up to the moment the forward path started emitting, and the
+ * forward path started at a DIFFERENT moment for each group of surfaces:
+ *   - Post / Image / Article / Bounty  -> event-engine v1.9.13 (#4002)
+ *   - every other surface              -> the release carrying #4067
+ * Backfilling both to one boundary either double-counts the first group or loses everything the
+ * second group received between the run and its own release. Both boundaries are required.
+ *
+ * Totals are read from daily aggregates, not from the event stream: entityMetricDaily_today_v2_mv
+ * only ever looks at `createdAt >= today() - 1`, so historically-dated rows written into
+ * entityMetricEvents_month would be invisible to every total. The backfill therefore writes day
+ * totals into entityMetricDailyAgg_history_v2 and marks each entity dirty so the additive
+ * refresher recomputes it.
+ *
+ * That table is a ReplacingMergeTree versioned by `sealedAt`, keyed
+ * (entityType, entityId, metricType, day) — a written row REPLACES that day rather than adding to
+ * it. Days that already carry live events are therefore reported, not written.
+ *
+ * Usage:
+ *   node scripts/backfill-user-comment-count.mjs --new-cutover 2026-08-18T12:00:00Z
+ *   node scripts/backfill-user-comment-count.mjs --new-cutover ... --execute
+ *
+ * Options:
+ *   --new-cutover <iso>  When the release carrying #4067 went live. Required.
+ *   --execute            Actually write. Default is a dry run that writes nothing.
+ *   --limit <n>          Only write the first n day rows (smoke test).
+ */
+
+import { createClient } from '@clickhouse/client';
+import pg from 'pg';
+import { readFileSync, existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadEnvFile(path) {
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const line of readFileSync(path, 'utf-8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    out[trimmed.slice(0, eq)] = trimmed.slice(eq + 1).replace(/^["']|["']$/g, '');
+  }
+  return out;
+}
+
+const chEnv = loadEnvFile(resolve(__dirname, '../.claude/skills/clickhouse-query/.env'));
+const pgEnv = loadEnvFile(resolve(__dirname, '../.claude/skills/postgres-query/.env'));
+
+const args = process.argv.slice(2);
+const EXECUTE = args.includes('--execute');
+const LIMIT = args.includes('--limit') ? Number(args[args.indexOf('--limit') + 1]) : null;
+const NEW_CUTOVER = args.includes('--new-cutover') ? args[args.indexOf('--new-cutover') + 1] : null;
+
+// The four surfaces already emitting since #4002. Their boundary is read from ClickHouse rather
+// than hardcoded: comments after the first live event are already counted, and the run is only
+// safe if that is the real first event rather than the one a ticket recorded.
+const OLD_SURFACES = new Set(['post', 'image', 'article', 'bounty']);
+
+const SURFACES = [
+  { key: 'post', fk: 'postId', table: '"Post"', owner: 'e."userId"' },
+  { key: 'image', fk: 'imageId', table: '"Image"', owner: 'e."userId"' },
+  { key: 'article', fk: 'articleId', table: '"Article"', owner: 'e."userId"' },
+  { key: 'bounty', fk: 'bountyId', table: '"Bounty"', owner: 'e."userId"' },
+  { key: 'review', fk: 'reviewId', table: '"ResourceReview"', owner: 'e."userId"' },
+  { key: 'bountyEntry', fk: 'bountyEntryId', table: '"BountyEntry"', owner: 'e."userId"' },
+  { key: 'challenge', fk: 'challengeId', table: '"Challenge"', owner: 'e."createdById"' },
+  { key: 'comic', fk: 'comicProjectId', table: '"ComicProject"', owner: 'e."userId"' },
+  { key: 'clubPost', fk: 'clubPostId', table: '"ClubPost"', owner: 'e."createdById"' },
+  { key: 'model3d', fk: 'model3dId', table: '"Model3D"', owner: 'e."userId"' },
+  { key: 'model3dReview', fk: 'model3dReviewId', table: '"Model3DReview"', owner: 'e."userId"' },
+  { key: 'modelV2', fk: 'modelId', table: '"Model"', owner: 'e."userId"' },
+  { key: 'question', fk: 'questionId', table: '"Question"', owner: 'e."userId"' },
+  { key: 'answer', fk: 'answerId', table: '"Answer"', owner: 'e."userId"' },
+  {
+    key: 'appListing',
+    fk: 'appListingId',
+    table: 'app_listings',
+    owner: 'e.user_id',
+    idCol: 'e.serial_id',
+  },
+];
+
+function commentV2Sql(surface) {
+  return `
+    SELECT owner AS "ownerId", day, count(*)::int AS total
+    FROM (
+      SELECT ${surface.owner} AS owner,
+             (c."createdAt" AT TIME ZONE 'UTC')::date AS day,
+             c."userId" AS commenter
+      FROM "CommentV2" c
+      JOIN "Thread" t ON t.id = c."threadId"
+      LEFT JOIN "Thread" r ON r.id = t."rootThreadId"
+      JOIN ${surface.table} e ON ${surface.idCol ?? 'e.id'} = COALESCE(r."${surface.fk}", t."${surface.fk}")
+      WHERE c."createdAt" < $1
+    ) s
+    WHERE owner IS NOT NULL AND owner <> commenter
+    GROUP BY 1, 2`;
+}
+
+const LEGACY_MODEL_SQL = `
+  SELECT m."userId" AS "ownerId",
+         (c."createdAt" AT TIME ZONE 'UTC')::date AS day,
+         count(*)::int AS total
+  FROM "Comment" c
+  JOIN "Model" m ON m.id = c."modelId"
+  WHERE c."createdAt" < $1 AND m."userId" <> c."userId"
+  GROUP BY 1, 2`;
+
+async function main() {
+  if (!NEW_CUTOVER) {
+    console.error('Error: --new-cutover <iso> is required. It is when the release carrying #4067');
+    console.error('went live. Without it the new surfaces get an arbitrary boundary and every');
+    console.error('comment between that boundary and the release is lost.');
+    process.exit(1);
+  }
+  const newCutover = new Date(NEW_CUTOVER);
+  if (Number.isNaN(newCutover.getTime())) {
+    console.error(`Error: --new-cutover "${NEW_CUTOVER}" is not a date`);
+    process.exit(1);
+  }
+
+  // The app is configured with a single credentialed CLICKHOUSE_URL; the query skill splits it into
+  // host/username/password. Either is accepted so this runs both in a pod and from a workstation.
+  const chUrl = process.env.CLICKHOUSE_URL ?? chEnv.CLICKHOUSE_URL;
+  const ch = createClient(
+    chUrl
+      ? { url: chUrl, request_timeout: 300000 }
+      : {
+          url: process.env.CLICKHOUSE_HOST ?? chEnv.CLICKHOUSE_HOST,
+          username:
+            process.env.CLICKHOUSE_USERNAME ??
+            process.env.CLICKHOUSE_USER ??
+            chEnv.CLICKHOUSE_USERNAME ??
+            chEnv.CLICKHOUSE_USER,
+          password: process.env.CLICKHOUSE_PASSWORD ?? chEnv.CLICKHOUSE_PASSWORD,
+          request_timeout: 300000,
+        }
+  );
+
+  const firstEventRows = await (
+    await ch.query({
+      query: `SELECT min(createdAt) AS firstEvent, count() AS events
+              FROM default.entityMetricEvents_month
+              WHERE entityType = 'User' AND metricType = 'commentCount'`,
+      format: 'JSONEachRow',
+    })
+  ).json();
+  const hasEvents = Number(firstEventRows[0]?.events ?? 0) > 0;
+  const firstEvent = hasEvents ? new Date(`${firstEventRows[0].firstEvent}Z`) : null;
+
+  if (!firstEvent) {
+    console.error('Error: no User.commentCount events in ClickHouse. The forward path is not live,');
+    console.error('so there is no boundary to back off from and nothing to backfill up to.');
+    process.exit(1);
+  }
+  if (newCutover < firstEvent) {
+    console.error(`Error: --new-cutover ${newCutover.toISOString()} is before the first live event`);
+    console.error(`(${firstEvent.toISOString()}). One of the two is wrong; refusing to guess.`);
+    process.exit(1);
+  }
+
+  console.log(`ClickHouse first User.commentCount event: ${firstEvent.toISOString()}`);
+  console.log(`  boundary for post/image/article/bounty: ${firstEvent.toISOString()}`);
+  console.log(`  boundary for every other surface:       ${newCutover.toISOString()}`);
+  console.log(EXECUTE ? '\nMODE: EXECUTE, this will write.\n' : '\nMODE: dry run, nothing is written.\n');
+
+  const pool = new pg.Pool({
+    connectionString:
+      process.env.DATABASE_REPLICA_URL ?? pgEnv.DATABASE_REPLICA_URL ?? pgEnv.DATABASE_URL,
+    connectionTimeoutMillis: 30000,
+    max: 4,
+  });
+
+  const byOwner = new Map();
+  let grandTotal = 0;
+
+  const add = (ownerId, day, total) => {
+    if (!byOwner.has(ownerId)) byOwner.set(ownerId, new Map());
+    const days = byOwner.get(ownerId);
+    days.set(day, (days.get(day) ?? 0) + total);
+    grandTotal += total;
+  };
+
+  const report = (label, rows, started) => {
+    const total = rows.reduce((sum, row) => sum + row.total, 0);
+    console.log(
+      `${label.padEnd(14)} ${String(total).padStart(9)} comments  ${String(rows.length).padStart(7)} owner-days  ${Date.now() - started}ms`
+    );
+  };
+
+  for (const surface of SURFACES) {
+    const boundary = OLD_SURFACES.has(surface.key) ? firstEvent : newCutover;
+    const started = Date.now();
+    const { rows } = await pool.query(commentV2Sql(surface), [boundary]);
+    for (const row of rows) add(row.ownerId, row.day.toISOString().slice(0, 10), row.total);
+    report(surface.key, rows, started);
+  }
+
+  {
+    const started = Date.now();
+    const { rows } = await pool.query(LEGACY_MODEL_SQL, [newCutover]);
+    for (const row of rows) add(row.ownerId, row.day.toISOString().slice(0, 10), row.total);
+    report('model (legacy)', rows, started);
+  }
+
+  await pool.end();
+
+  const rowsToWrite = [];
+  for (const [ownerId, days] of byOwner) {
+    for (const [day, total] of days) {
+      rowsToWrite.push({
+        entityType: 'User',
+        entityId: ownerId,
+        metricType: 'commentCount',
+        day,
+        total,
+      });
+    }
+  }
+
+  console.log(`\n${grandTotal} comments across ${byOwner.size} owners -> ${rowsToWrite.length} day rows`);
+
+  // A day that also carries live events would be REPLACED rather than added to, so the overlap is
+  // reported rather than written. It is small by construction (the boundary day of each group) and
+  // wrong to guess at.
+  const boundaryDays = new Set([
+    firstEvent.toISOString().slice(0, 10),
+    newCutover.toISOString().slice(0, 10),
+  ]);
+  const overlap = rowsToWrite.filter((row) => boundaryDays.has(row.day));
+  const safeRows = rowsToWrite.filter((row) => !boundaryDays.has(row.day));
+  if (overlap.length) {
+    const overlapTotal = overlap.reduce((sum, row) => sum + row.total, 0);
+    console.log(
+      `\n${overlap.length} rows fall on a boundary day (${[...boundaryDays].join(', ')}) holding ` +
+        `${overlapTotal} comments. Those days already carry live totals, so writing them would ` +
+        `replace the live value. Excluded here; they need an explicit merge.`
+    );
+  }
+
+  const top = [...byOwner.entries()]
+    .map(([ownerId, days]) => [ownerId, [...days.values()].reduce((a, b) => a + b, 0)])
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+  console.log('\nTop owners by backfilled comments:');
+  for (const [ownerId, total] of top) console.log(`  ${String(ownerId).padStart(10)}  ${total}`);
+
+  if (!EXECUTE) {
+    console.log(`\nDry run complete. ${safeRows.length} rows would be written to`);
+    console.log('entityMetricDailyAgg_history_v2, then one entityMetricDirty_v3 row per owner');
+    console.log(`(${byOwner.size}) so the additive refresher recomputes each total.`);
+    console.log('\nSample:');
+    for (const row of safeRows.slice(0, 5)) console.log(' ', JSON.stringify(row));
+    await ch.close();
+    return;
+  }
+
+  const limited = LIMIT ? safeRows.slice(0, LIMIT) : safeRows;
+  const BATCH = 50000;
+  for (let i = 0; i < limited.length; i += BATCH) {
+    await ch.insert({
+      table: 'entityMetricDailyAgg_history_v2',
+      values: limited.slice(i, i + BATCH),
+      format: 'JSONEachRow',
+    });
+    console.log(`wrote ${Math.min(i + BATCH, limited.length)}/${limited.length} day rows`);
+  }
+
+  const dirty = [...new Set(limited.map((row) => row.entityId))].map((entityId) => ({
+    entityType: 'User',
+    entityId,
+    metricType: 'commentCount',
+  }));
+  for (let i = 0; i < dirty.length; i += BATCH) {
+    await ch.insert({
+      table: 'entityMetricDirty_v3',
+      values: dirty.slice(i, i + BATCH),
+      format: 'JSONEachRow',
+    });
+  }
+  console.log(`marked ${dirty.length} owners dirty`);
+
+  await ch.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/event-engine/scripts/backfill-user-comment-count.mjs
+++ b/apps/event-engine/scripts/backfill-user-comment-count.mjs
@@ -215,7 +215,11 @@ async function main() {
                                       FROM default.entityMetricEvents_month
                                       WHERE entityType = 'User' AND metricType = 'commentCount'`);
   const firstEvent =
-    Number(firstEventRows[0]?.events ?? 0) > 0 ? new Date(`${firstEventRows[0].firstEvent}Z`) : null;
+    Number(firstEventRows[0]?.events ?? 0) > 0
+      ? // ClickHouse returns `YYYY-MM-DD HH:MM:SS` with no zone. Parsed as-is that is a LOCAL time,
+        // which would move the boundary by the host's offset — the same bug as binding a Date.
+        new Date(`${firstEventRows[0].firstEvent.replace(' ', 'T')}Z`)
+      : null;
 
   if (!firstEvent) {
     console.error('Error: no User.commentCount events in ClickHouse. The forward path is not live,');

--- a/apps/event-engine/src/__tests__/comment-handlers.test.ts
+++ b/apps/event-engine/src/__tests__/comment-handlers.test.ts
@@ -19,19 +19,19 @@ function recorder() {
 }
 
 // The handler's owner resolution lives in SQL, so a fake `pg` cannot tell a correct join from one
-// naming a column that does not exist — that half is verified by running the query against the
-// real database. What these tests pin is everything downstream of the row: which metrics are
-// emitted, for whom, and the self-authored exclusion.
+// naming a column that does not exist — that half is verified by running the query against the real
+// database, which nothing here re-runs. What these tests pin is everything downstream of the row:
+// which metrics are emitted, for whom, with what sign, and off which bound parameter.
 function pgReturning(row: unknown) {
-  const seen: string[] = [];
+  const calls: { sql: string; params: unknown[] }[] = [];
   return {
     pg: {
-      queryOne: async (sql: string) => {
-        seen.push(sql);
+      queryOne: async (sql: string, params: unknown[]) => {
+        calls.push({ sql, params });
         return row;
       },
     },
-    seen,
+    calls,
   };
 }
 
@@ -41,6 +41,30 @@ const noEntity = {
   articleId: null,
   bountyId: null,
 };
+
+function expectAdds(adds: Add[], expected: Add[]) {
+  // Order between the entity emit and the owner emit is incidental, so it is not asserted — a
+  // refactor that reorders them is not a regression. The length is, otherwise arrayContaining
+  // would pass on a handler that emitted extra metrics.
+  expect(adds).toHaveLength(expected.length);
+  expect(adds).toEqual(expect.arrayContaining(expected));
+}
+
+const user = (entityId: number, as: number, value: number): Add => ({
+  entityType: 'User',
+  entityId,
+  as,
+  metric: 'commentCount',
+  value,
+});
+
+const entity = (entityType: string, entityId: number, as: number, value: number): Add => ({
+  entityType,
+  entityId,
+  as,
+  metric: 'commentCount',
+  value,
+});
 
 test('a comment on a surface with no entity metric still counts toward its owner', async () => {
   const { adds, actions } = recorder();
@@ -55,9 +79,7 @@ test('a comment on a surface with no entity metric still counts toward its owner
 
   // A review/model/challenge/comic thread resolves no Post/Image/Article/Bounty id at all, so this
   // is the whole emission for those surfaces — the 45% the metric used to miss.
-  expect(adds).toEqual([
-    { entityType: 'User', entityId: 555, as: 42, metric: 'commentCount', value: 1 },
-  ]);
+  expectAdds(adds, [user(555, 42, 1)]);
 });
 
 test('self-authored comments are excluded', async () => {
@@ -88,7 +110,42 @@ test('an unresolved owner emits nothing rather than a metric keyed on null', asy
   expect(adds).toEqual([]);
 });
 
-test('an image comment counts for both the image and its owner, and a delete backs both out', async () => {
+test('a thread that no longer exists is skipped without throwing', async () => {
+  const { adds, actions } = recorder();
+  const { pg } = pgReturning(null);
+
+  // A deleted thread is a live case, not a hypothetical: the CDC delete for a comment can arrive
+  // after its thread is gone. Throwing here poisons the Kafka message rather than dropping a metric.
+  await commentV2Handler.process({
+    operation: 'delete',
+    record: { userId: 42, threadId: 1 },
+    actions,
+    pg,
+  } as never);
+
+  expect(adds).toEqual([]);
+});
+
+test.each([
+  ['post', 'postId', 'Post'],
+  ['image', 'imageId', 'Image'],
+  ['article', 'articleId', 'Article'],
+  ['bounty', 'bountyId', 'Bounty'],
+])('a %s comment counts for the entity and its owner', async (_name, idField, entityType) => {
+  const { adds, actions } = recorder();
+  const { pg } = pgReturning({ ...noEntity, [idField]: 77, ownerId: 555 });
+
+  await commentV2Handler.process({
+    operation: 'create',
+    record: { userId: 42, threadId: 1 },
+    actions,
+    pg,
+  } as never);
+
+  expectAdds(adds, [user(555, 42, 1), entity(entityType, 77, 42, 1)]);
+});
+
+test('a delete backs out both the entity and the owner', async () => {
   const { adds, actions } = recorder();
   const { pg } = pgReturning({ ...noEntity, imageId: 77, ownerId: 555 });
 
@@ -99,15 +156,28 @@ test('an image comment counts for both the image and its owner, and a delete bac
     pg,
   } as never);
 
-  expect(adds).toEqual([
-    { entityType: 'User', entityId: 555, as: 42, metric: 'commentCount', value: -1 },
-    { entityType: 'Image', entityId: 77, as: 42, metric: 'commentCount', value: -1 },
-  ]);
+  expectAdds(adds, [user(555, 42, -1), entity('Image', 77, 42, -1)]);
 });
 
-test('every commentable Thread column is resolved by the owner query', async () => {
+test('the owner is looked up by thread, not by commenter', async () => {
   const { actions } = recorder();
-  const { pg, seen } = pgReturning({ ...noEntity, ownerId: 1 });
+  const { pg, calls } = pgReturning({ ...noEntity, ownerId: 555 });
+
+  await commentV2Handler.process({
+    operation: 'create',
+    record: { userId: 42, threadId: 1234 },
+    actions,
+    pg,
+  } as never);
+
+  // Binding the wrong record field resolves a real row for the wrong entity, which is invisible in
+  // the emissions above — every metric still looks well-formed, just attributed to a stranger.
+  expect(calls[0].params).toEqual([1234]);
+});
+
+test('every commentable Thread column is resolved through the root thread', async () => {
+  const { actions } = recorder();
+  const { pg, calls } = pgReturning({ ...noEntity, ownerId: 1 });
 
   await commentV2Handler.process({
     operation: 'create',
@@ -116,8 +186,11 @@ test('every commentable Thread column is resolved by the owner query', async () 
     pg,
   } as never);
 
-  // Dropping an arm from the query is invisible to the assertions above — they feed the handler a
-  // row it never had to derive. This is the check that fails when a surface stops being resolved.
+  const sql = calls[0].sql;
+
+  // Asserted as the whole COALESCE rather than as a bare column name: a reply carries no entity FK
+  // of its own, so collapsing `COALESCE(r.x, t.x)` to `t.x` silently drops every reply — while the
+  // column name it was named after is still right there in the string.
   for (const column of [
     'postId',
     'imageId',
@@ -135,13 +208,24 @@ test('every commentable Thread column is resolved by the owner query', async () 
     'answerId',
     'appListingId',
   ]) {
-    expect(seen[0]).toContain(`"${column}"`);
+    expect(sql).toContain(`= COALESCE(r."${column}", t."${column}")`);
   }
+
+  // The four ids that are also selected carry the same fallback twice — once to find the owner and
+  // once to decide which entity metric to emit. Asserting only the join form leaves the selected
+  // half free to collapse to `t.x`, which drops every reply from the entity counts alone.
+  for (const column of ['postId', 'imageId', 'articleId', 'bountyId']) {
+    expect(sql).toContain(`COALESCE(r."${column}", t."${column}") AS "${column}"`);
+  }
+
+  // And the root thread has to be joined on rootThreadId — joined on anything else, every COALESCE
+  // above resolves against the reply's own empty columns.
+  expect(sql).toContain('LEFT JOIN "Thread" r ON r.id = t."rootThreadId"');
 });
 
 test('a model comment counts for the model and its creator', async () => {
   const { adds, actions } = recorder();
-  const { pg } = pgReturning({ userId: 555 });
+  const { pg, calls } = pgReturning({ userId: 555 });
 
   await commentHandler.process({
     operation: 'create',
@@ -150,10 +234,24 @@ test('a model comment counts for the model and its creator', async () => {
     pg,
   } as never);
 
-  expect(adds).toEqual([
-    { entityType: 'Model', entityId: 9, as: 42, metric: 'commentCount', value: 1 },
-    { entityType: 'User', entityId: 555, as: 42, metric: 'commentCount', value: 1 },
-  ]);
+  expectAdds(adds, [entity('Model', 9, 42, 1), user(555, 42, 1)]);
+  expect(calls[0].params).toEqual([9]);
+});
+
+test('deleting a model comment backs out both counts', async () => {
+  const { adds, actions } = recorder();
+  const { pg } = pgReturning({ userId: 555 });
+
+  // Without this, a sign flip on the delete path inflates the largest comment surface on the site
+  // forever — nothing replays these events to repair it.
+  await commentHandler.process({
+    operation: 'delete',
+    record: { userId: 42, modelId: 9 },
+    actions,
+    pg,
+  } as never);
+
+  expectAdds(adds, [entity('Model', 9, 42, -1), user(555, 42, -1)]);
 });
 
 test('a creator commenting on their own model counts for the model but not for themselves', async () => {
@@ -167,7 +265,5 @@ test('a creator commenting on their own model counts for the model but not for t
     pg,
   } as never);
 
-  expect(adds).toEqual([
-    { entityType: 'Model', entityId: 9, as: 42, metric: 'commentCount', value: 1 },
-  ]);
+  expectAdds(adds, [entity('Model', 9, 42, 1)]);
 });

--- a/apps/event-engine/src/__tests__/comment-handlers.test.ts
+++ b/apps/event-engine/src/__tests__/comment-handlers.test.ts
@@ -221,6 +221,29 @@ test('every commentable Thread column is resolved through the root thread', asyn
   // And the root thread has to be joined on rootThreadId — joined on anything else, every COALESCE
   // above resolves against the reply's own empty columns.
   expect(sql).toContain('LEFT JOIN "Thread" r ON r.id = t."rootThreadId"');
+
+  // The owner expressions are asserted separately from the column names because a surface can be
+  // joined and still resolve nobody: drop `al.user_id` from the owner COALESCE and every FK name
+  // above is still present, the join is still there, and app listings silently stop counting.
+  for (const owner of [
+    'p."userId"',
+    'i."userId"',
+    'a."userId"',
+    'b."userId"',
+    'rev."userId"',
+    'be."userId"',
+    'ch."createdById"',
+    'cp."userId"',
+    'clp."createdById"',
+    'm3d."userId"',
+    'm3dr."userId"',
+    'mdl."userId"',
+    'q."userId"',
+    'ans."userId"',
+    'al.user_id',
+  ]) {
+    expect(sql).toContain(owner);
+  }
 });
 
 test('a model comment counts for the model and its creator', async () => {

--- a/apps/event-engine/src/__tests__/comment-handlers.test.ts
+++ b/apps/event-engine/src/__tests__/comment-handlers.test.ts
@@ -270,6 +270,8 @@ test('a model comment counts for the model and its creator', async () => {
 
   expectAdds(adds, [entity('Model', 9, 42, 1), user(555, 42, 1)]);
   expect(calls[0].params).toEqual([9]);
+  // One round trip per event, on the highest-volume comment surface.
+  expect(calls).toHaveLength(1);
 });
 
 test('deleting a model comment backs out both counts', async () => {
@@ -286,6 +288,29 @@ test('deleting a model comment backs out both counts', async () => {
   } as never);
 
   expectAdds(adds, [entity('Model', 9, 42, -1), user(555, 42, -1)]);
+});
+
+test.each([
+  ['commentV2Handler', commentV2Handler, { userId: 42, threadId: 1 }],
+  ['commentHandler', commentHandler, { userId: 42, modelId: 9 }],
+])('%s emits nothing when the owner lookup fails', async (_name, handler, record) => {
+  const { adds, actions } = recorder();
+  const pg = {
+    queryOne: async () => {
+      throw new Error('connection terminated');
+    },
+  };
+
+  // Both halves matter and neither is visible with a resolving fake. The throw has to propagate or
+  // the Kafka offset commits over a message whose metrics were never queued; and nothing may be
+  // emitted before it, because the batcher and Redis dedupe a replayed metric but
+  // `metricSignals.sendDelta` does not — an emit above the await double-fires the live delta on
+  // every retry. Moving an emit back above the query is otherwise invisible: with a resolving fake
+  // both orderings produce identical output.
+  await expect(
+    handler.process({ operation: 'create', record, actions, pg } as never)
+  ).rejects.toThrow('connection terminated');
+  expect(adds).toEqual([]);
 });
 
 test('a creator commenting on their own model counts for the model but not for themselves', async () => {

--- a/apps/event-engine/src/__tests__/comment-handlers.test.ts
+++ b/apps/event-engine/src/__tests__/comment-handlers.test.ts
@@ -1,0 +1,173 @@
+import { expect, test } from 'vitest';
+import { commentV2Handler } from '@/handlers/comment-v2';
+import { commentHandler } from '@/handlers/comments';
+
+type Add = { entityType: string; entityId: number; as: number; metric: string; value: number };
+
+function recorder() {
+  const adds: Add[] = [];
+  const actions = {
+    forMetric: (entityType: string, entityId: number) => ({
+      as: (as: number) => ({
+        add: (metric: string, value: number) => {
+          adds.push({ entityType, entityId, as, metric, value });
+        },
+      }),
+    }),
+  };
+  return { adds, actions };
+}
+
+// The handler's owner resolution lives in SQL, so a fake `pg` cannot tell a correct join from one
+// naming a column that does not exist — that half is verified by running the query against the
+// real database. What these tests pin is everything downstream of the row: which metrics are
+// emitted, for whom, and the self-authored exclusion.
+function pgReturning(row: unknown) {
+  const seen: string[] = [];
+  return {
+    pg: {
+      queryOne: async (sql: string) => {
+        seen.push(sql);
+        return row;
+      },
+    },
+    seen,
+  };
+}
+
+const noEntity = {
+  postId: null,
+  imageId: null,
+  articleId: null,
+  bountyId: null,
+};
+
+test('a comment on a surface with no entity metric still counts toward its owner', async () => {
+  const { adds, actions } = recorder();
+  const { pg } = pgReturning({ ...noEntity, ownerId: 555 });
+
+  await commentV2Handler.process({
+    operation: 'create',
+    record: { userId: 42, threadId: 1 },
+    actions,
+    pg,
+  } as never);
+
+  // A review/model/challenge/comic thread resolves no Post/Image/Article/Bounty id at all, so this
+  // is the whole emission for those surfaces — the 45% the metric used to miss.
+  expect(adds).toEqual([
+    { entityType: 'User', entityId: 555, as: 42, metric: 'commentCount', value: 1 },
+  ]);
+});
+
+test('self-authored comments are excluded', async () => {
+  const { adds, actions } = recorder();
+  const { pg } = pgReturning({ ...noEntity, ownerId: 42 });
+
+  await commentV2Handler.process({
+    operation: 'create',
+    record: { userId: 42, threadId: 1 },
+    actions,
+    pg,
+  } as never);
+
+  expect(adds).toEqual([]);
+});
+
+test('an unresolved owner emits nothing rather than a metric keyed on null', async () => {
+  const { adds, actions } = recorder();
+  const { pg } = pgReturning({ ...noEntity, ownerId: null });
+
+  await commentV2Handler.process({
+    operation: 'create',
+    record: { userId: 42, threadId: 1 },
+    actions,
+    pg,
+  } as never);
+
+  expect(adds).toEqual([]);
+});
+
+test('an image comment counts for both the image and its owner, and a delete backs both out', async () => {
+  const { adds, actions } = recorder();
+  const { pg } = pgReturning({ ...noEntity, imageId: 77, ownerId: 555 });
+
+  await commentV2Handler.process({
+    operation: 'delete',
+    record: { userId: 42, threadId: 1 },
+    actions,
+    pg,
+  } as never);
+
+  expect(adds).toEqual([
+    { entityType: 'User', entityId: 555, as: 42, metric: 'commentCount', value: -1 },
+    { entityType: 'Image', entityId: 77, as: 42, metric: 'commentCount', value: -1 },
+  ]);
+});
+
+test('every commentable Thread column is resolved by the owner query', async () => {
+  const { actions } = recorder();
+  const { pg, seen } = pgReturning({ ...noEntity, ownerId: 1 });
+
+  await commentV2Handler.process({
+    operation: 'create',
+    record: { userId: 42, threadId: 1 },
+    actions,
+    pg,
+  } as never);
+
+  // Dropping an arm from the query is invisible to the assertions above — they feed the handler a
+  // row it never had to derive. This is the check that fails when a surface stops being resolved.
+  for (const column of [
+    'postId',
+    'imageId',
+    'articleId',
+    'bountyId',
+    'reviewId',
+    'bountyEntryId',
+    'challengeId',
+    'comicProjectId',
+    'clubPostId',
+    'model3dId',
+    'model3dReviewId',
+    'modelId',
+    'questionId',
+    'answerId',
+    'appListingId',
+  ]) {
+    expect(seen[0]).toContain(`"${column}"`);
+  }
+});
+
+test('a model comment counts for the model and its creator', async () => {
+  const { adds, actions } = recorder();
+  const { pg } = pgReturning({ userId: 555 });
+
+  await commentHandler.process({
+    operation: 'create',
+    record: { userId: 42, modelId: 9 },
+    actions,
+    pg,
+  } as never);
+
+  expect(adds).toEqual([
+    { entityType: 'Model', entityId: 9, as: 42, metric: 'commentCount', value: 1 },
+    { entityType: 'User', entityId: 555, as: 42, metric: 'commentCount', value: 1 },
+  ]);
+});
+
+test('a creator commenting on their own model counts for the model but not for themselves', async () => {
+  const { adds, actions } = recorder();
+  const { pg } = pgReturning({ userId: 42 });
+
+  await commentHandler.process({
+    operation: 'create',
+    record: { userId: 42, modelId: 9 },
+    actions,
+    pg,
+  } as never);
+
+  expect(adds).toEqual([
+    { entityType: 'Model', entityId: 9, as: 42, metric: 'commentCount', value: 1 },
+  ]);
+});

--- a/apps/event-engine/src/__tests__/comment-handlers.test.ts
+++ b/apps/event-engine/src/__tests__/comment-handlers.test.ts
@@ -45,7 +45,9 @@ const noEntity = {
 function expectAdds(adds: Add[], expected: Add[]) {
   // Order between the entity emit and the owner emit is incidental, so it is not asserted — a
   // refactor that reorders them is not a regression. The length is, otherwise arrayContaining
-  // would pass on a handler that emitted extra metrics.
+  // would pass on a handler that emitted extra metrics. Note the pair only holds while `expected`
+  // has no duplicate members: two identical Adds would both be satisfied by one, leaving the
+  // length as the sole check.
   expect(adds).toHaveLength(expected.length);
   expect(adds).toEqual(expect.arrayContaining(expected));
 }
@@ -173,9 +175,18 @@ test('the owner is looked up by thread, not by commenter', async () => {
   // Binding the wrong record field resolves a real row for the wrong entity, which is invisible in
   // the emissions above — every metric still looks well-formed, just attributed to a stranger.
   expect(calls[0].params).toEqual([1234]);
+  // One round trip per event, on a Kafka-rate path.
+  expect(calls).toHaveLength(1);
 });
 
-test('every commentable Thread column is resolved through the root thread', async () => {
+// A tripwire for accidental deletion, and nothing more. It checks that the query still MENTIONS
+// every surface; it cannot check that the query resolves one. An adversarial pass walked straight
+// through it while leaving every string below intact — deleting `i."userId"` from the owner
+// COALESCE and adding `AND i."userId" IS NOT NULL` to the Image join stops every image comment
+// counting toward its creator and this test still passes, as do `AND false` on a join, restricting
+// to non-reply threads, and `LIMIT 0`. Adding more substrings cannot close that: the mutation works
+// by keeping the substring. Only executing the query against a seeded database would.
+test('the owner query still mentions every commentable surface', async () => {
   const { actions } = recorder();
   const { pg, calls } = pgReturning({ ...noEntity, ownerId: 1 });
 

--- a/apps/event-engine/src/handlers/comment-v2.ts
+++ b/apps/event-engine/src/handlers/comment-v2.ts
@@ -1,4 +1,4 @@
-import { createEventHandler } from './base'
+import { createEventHandler } from './base';
 
 /**
 ## Metrics driven by commentv2 table:
@@ -6,111 +6,126 @@ import { createEventHandler } from './base'
 - ImageMetric.commentCount (create/delete)
 - ArticleMetric.commentCount (create/delete)
 - BountyMetric.commentCount (create/delete)
-- UserMetric.commentCount (create/delete) — comments *received* by the owner of the commented-on entity
+- UserMetric.commentCount (create/delete) — comments *received* by the owner of the commented-on
+  entity, across every surface CommentsV2 serves, not just the four with their own entity metric.
 */
 
 interface CommentV2Record {
-  userId: number
-  threadId: number
+  userId: number;
+  threadId: number;
 }
 
 export const commentV2Handler = createEventHandler<CommentV2Record>({
   tables: ['CommentV2'],
   operations: ['create', 'delete'],
   processor: async ({ operation, record, actions, pg }) => {
-    const value = operation === 'create' ? 1 : -1
+    const value = operation === 'create' ? 1 : -1;
 
     // One query for the entity *and* its owner: the owner columns are what make a per-creator comment
     // count possible at all. Without them the only route from a creator to their comments is a join
     // over the whole image space, which is why Creator Studio reads Postgres for this today.
+    //
+    // A Thread carries exactly one entity FK, so the owner COALESCE has at most one non-null input
+    // and its argument order carries no meaning. Owner column names are not uniform — Challenge and
+    // ClubPost record `createdById`, app_listings is snake_cased, and a comic thread points at the
+    // chapter's project rather than at an owner directly.
     const thread = await pg.queryOne<{
-      postId: number | null
-      imageId: number | null
-      articleId: number | null
-      bountyId: number | null
-      postOwnerId: number | null
-      imageOwnerId: number | null
-      articleOwnerId: number | null
-      bountyOwnerId: number | null
+      postId: number | null;
+      imageId: number | null;
+      articleId: number | null;
+      bountyId: number | null;
+      ownerId: number | null;
     }>(
       `SELECT
         COALESCE(r."postId", t."postId") AS "postId",
         COALESCE(r."imageId", t."imageId") AS "imageId",
         COALESCE(r."articleId", t."articleId") AS "articleId",
         COALESCE(r."bountyId", t."bountyId") AS "bountyId",
-        p."userId" AS "postOwnerId",
-        i."userId" AS "imageOwnerId",
-        a."userId" AS "articleOwnerId",
-        b."userId" AS "bountyOwnerId"
+        COALESCE(
+          p."userId", i."userId", a."userId", b."userId",
+          rev."userId", be."userId", ch."createdById", cp."userId", clp."createdById",
+          m3d."userId", m3dr."userId", mdl."userId", q."userId", ans."userId", al.user_id
+        ) AS "ownerId"
       FROM "Thread" t
       LEFT JOIN "Thread" r ON r.id = t."rootThreadId"
       LEFT JOIN "Post" p ON p.id = COALESCE(r."postId", t."postId")
       LEFT JOIN "Image" i ON i.id = COALESCE(r."imageId", t."imageId")
       LEFT JOIN "Article" a ON a.id = COALESCE(r."articleId", t."articleId")
       LEFT JOIN "Bounty" b ON b.id = COALESCE(r."bountyId", t."bountyId")
+      LEFT JOIN "ResourceReview" rev ON rev.id = COALESCE(r."reviewId", t."reviewId")
+      LEFT JOIN "BountyEntry" be ON be.id = COALESCE(r."bountyEntryId", t."bountyEntryId")
+      LEFT JOIN "Challenge" ch ON ch.id = COALESCE(r."challengeId", t."challengeId")
+      LEFT JOIN "ComicProject" cp ON cp.id = COALESCE(r."comicProjectId", t."comicProjectId")
+      LEFT JOIN "ClubPost" clp ON clp.id = COALESCE(r."clubPostId", t."clubPostId")
+      LEFT JOIN "Model3D" m3d ON m3d.id = COALESCE(r."model3dId", t."model3dId")
+      LEFT JOIN "Model3DReview" m3dr ON m3dr.id = COALESCE(r."model3dReviewId", t."model3dReviewId")
+      LEFT JOIN "Model" mdl ON mdl.id = COALESCE(r."modelId", t."modelId")
+      LEFT JOIN "Question" q ON q.id = COALESCE(r."questionId", t."questionId")
+      LEFT JOIN "Answer" ans ON ans.id = COALESCE(r."answerId", t."answerId")
+      LEFT JOIN app_listings al ON al.serial_id = COALESCE(r."appListingId", t."appListingId")
       WHERE t.id = $1`,
       [record.threadId]
-    )
+    );
 
-    if (!thread) return
+    if (!thread) return;
 
     // A creator answering their own commenters is not engagement received. Left in, it dominates:
     // 71.4% / 60.9% / 57.6% of the raw total for userIds 1421581 / 2895 / 1279061. Keep this in step
     // with `reactions_owner_scores`, which excludes self-reactions for the same reason, and with
     // Creator Studio's tile, which excludes self-comments — a metric named the same thing on two
     // surfaces must not mean two things.
-    const addOwnerCount = (ownerId: number | null) => {
-      if (!ownerId || ownerId === record.userId) return
-      actions.forMetric('User', ownerId).as(record.userId).add('commentCount', value)
+    if (thread.ownerId && thread.ownerId !== record.userId) {
+      actions.forMetric('User', thread.ownerId).as(record.userId).add('commentCount', value);
     }
 
-    // Update the appropriate entity metric
+    // Entity metrics stay at the four surfaces that already have a registered
+    // (entityType, metricType) row in default.entityMetricKind. An unregistered pair falls into the
+    // presence path and would silently count distinct commenters instead of comments.
     if (thread.postId) {
-      const postMetric = actions.forMetric('Post', thread.postId).as(record.userId)
-      postMetric.add('commentCount', value)
-      addOwnerCount(thread.postOwnerId)
+      const postMetric = actions.forMetric('Post', thread.postId).as(record.userId);
+      postMetric.add('commentCount', value);
     }
 
     if (thread.imageId) {
-      const imageMetric = actions.forMetric('Image', thread.imageId).as(record.userId)
-      imageMetric.add('commentCount', value)
-      addOwnerCount(thread.imageOwnerId)
+      const imageMetric = actions.forMetric('Image', thread.imageId).as(record.userId);
+      imageMetric.add('commentCount', value);
     }
 
     if (thread.articleId) {
-      const articleMetric = actions.forMetric('Article', thread.articleId).as(record.userId)
-      articleMetric.add('commentCount', value)
-      addOwnerCount(thread.articleOwnerId)
+      const articleMetric = actions.forMetric('Article', thread.articleId).as(record.userId);
+      articleMetric.add('commentCount', value);
     }
 
     if (thread.bountyId) {
-      const bountyMetric = actions.forMetric('Bounty', thread.bountyId).as(record.userId)
-      bountyMetric.add('commentCount', value)
-      addOwnerCount(thread.bountyOwnerId)
+      const bountyMetric = actions.forMetric('Bounty', thread.bountyId).as(record.userId);
+      bountyMetric.add('commentCount', value);
     }
   },
   debug: (faker) => ({
     sample: () => ({
       userId: faker.number.int({ min: 1, max: 1000 }),
-      threadId: faker.number.int({ min: 1, max: 5000 })
+      threadId: faker.number.int({ min: 1, max: 5000 }),
     }),
     pg: (sql: string) => {
       if (sql.includes('Thread')) {
-        const entityType = faker.helpers.arrayElement(['post', 'image', 'article', 'bounty'])
-        const ownerId = faker.number.int({ min: 1, max: 1000 })
+        const entityType = faker.helpers.arrayElement([
+          'post',
+          'image',
+          'article',
+          'bounty',
+          'review',
+          'model',
+        ]);
 
         return {
           postId: entityType === 'post' ? faker.number.int({ min: 1, max: 5000 }) : null,
           imageId: entityType === 'image' ? faker.number.int({ min: 1, max: 5000 }) : null,
           articleId: entityType === 'article' ? faker.number.int({ min: 1, max: 5000 }) : null,
           bountyId: entityType === 'bounty' ? faker.number.int({ min: 1, max: 5000 }) : null,
-          postOwnerId: entityType === 'post' ? ownerId : null,
-          imageOwnerId: entityType === 'image' ? ownerId : null,
-          articleOwnerId: entityType === 'article' ? ownerId : null,
-          bountyOwnerId: entityType === 'bounty' ? ownerId : null
-        }
+          ownerId: faker.number.int({ min: 1, max: 1000 }),
+        };
       }
-      return null
-    }
-  })
-})
+      return null;
+    },
+  }),
+});

--- a/apps/event-engine/src/handlers/comment-v2.ts
+++ b/apps/event-engine/src/handlers/comment-v2.ts
@@ -26,9 +26,7 @@ export const commentV2Handler = createEventHandler<CommentV2Record>({
     // over the whole image space, which is why Creator Studio reads Postgres for this today.
     //
     // A Thread carries exactly one entity FK, so the owner COALESCE has at most one non-null input
-    // and its argument order carries no meaning. Owner column names are not uniform — Challenge and
-    // ClubPost record `createdById`, app_listings is snake_cased, and a comic thread points at the
-    // chapter's project rather than at an owner directly.
+    // and its argument order carries no meaning.
     const thread = await pg.queryOne<{
       postId: number | null;
       imageId: number | null;
@@ -78,9 +76,8 @@ export const commentV2Handler = createEventHandler<CommentV2Record>({
       actions.forMetric('User', thread.ownerId).as(record.userId).add('commentCount', value);
     }
 
-    // Entity metrics stay at the four surfaces that already have a registered
-    // (entityType, metricType) row in default.entityMetricKind. An unregistered pair falls into the
-    // presence path and would silently count distinct commenters instead of comments.
+    // Entity metrics stay at the four surfaces with a registered (entityType, metricType) row in
+    // default.entityMetricKind — an unregistered pair silently counts distinct commenters instead.
     if (thread.postId) {
       const postMetric = actions.forMetric('Post', thread.postId).as(record.userId);
       postMetric.add('commentCount', value);

--- a/apps/event-engine/src/handlers/comments.ts
+++ b/apps/event-engine/src/handlers/comments.ts
@@ -3,7 +3,6 @@ import { createEventHandler } from './base';
 /**
 ## Metrics driven by comment table:
 - ModelMetric.commentCount (create/delete)
-- ModelVersionMetric.commentCount (create/delete)
 - UserMetric.commentCount (create/delete) — comments *received* by the model's creator
 */
 
@@ -18,14 +17,19 @@ export const commentHandler = createEventHandler<CommentRecord>({
   processor: async ({ operation, record, actions, pg }) => {
     const value = operation === 'create' ? 1 : -1;
 
-    const modelMetric = actions.forMetric('Model', record.modelId).as(record.userId);
-    modelMetric.add('commentCount', value);
-
+    // Queried before anything is emitted. A throw here leaves the Kafka offset uncommitted and the
+    // message redelivered; the batcher and Redis dedupe a replayed metric, but
+    // `metricSignals.sendDelta` is fire-and-forget, so an emit placed before this await double-fires
+    // the live UI delta once per retry.
+    //
     // Model comments never reach CommentsV2, so this lookup is the only path to their owner.
     const model = await pg.queryOne<{ userId: number | null }>(
       `SELECT "userId" FROM "Model" WHERE id = $1`,
       [record.modelId]
     );
+
+    const modelMetric = actions.forMetric('Model', record.modelId).as(record.userId);
+    modelMetric.add('commentCount', value);
 
     // Self-authored excluded, matching commentV2Handler.
     if (model?.userId && model.userId !== record.userId) {

--- a/apps/event-engine/src/handlers/comments.ts
+++ b/apps/event-engine/src/handlers/comments.ts
@@ -1,30 +1,50 @@
-import { createEventHandler } from './base'
+import { createEventHandler } from './base';
 
 /**
 ## Metrics driven by comment table:
 - ModelMetric.commentCount (create/delete)
 - ModelVersionMetric.commentCount (create/delete)
+- UserMetric.commentCount (create/delete) — comments *received* by the model's creator
 */
 
 interface CommentRecord {
-  userId: number
-  modelId: number
+  userId: number;
+  modelId: number;
 }
 
 export const commentHandler = createEventHandler<CommentRecord>({
   tables: ['Comment'],
   operations: ['create', 'delete'],
-  processor: async ({ operation, record, actions }) => {
-    const value = operation === 'create' ? 1 : -1
+  processor: async ({ operation, record, actions, pg }) => {
+    const value = operation === 'create' ? 1 : -1;
 
     // Update model metric
-    const modelMetric = actions.forMetric('Model', record.modelId).as(record.userId)
-    modelMetric.add('commentCount', value)
+    const modelMetric = actions.forMetric('Model', record.modelId).as(record.userId);
+    modelMetric.add('commentCount', value);
+
+    // Model comments are the largest single surface (1.17M), and they never reach CommentsV2, so
+    // the owner has to be resolved here or User.commentCount stays a minority of the real total.
+    const model = await pg.queryOne<{ userId: number | null }>(
+      `SELECT "userId" FROM "Model" WHERE id = $1`,
+      [record.modelId]
+    );
+
+    // Self-authored comments excluded, matching commentV2Handler — a creator replying under their
+    // own model is not engagement received.
+    if (model?.userId && model.userId !== record.userId) {
+      actions.forMetric('User', model.userId).as(record.userId).add('commentCount', value);
+    }
   },
   debug: (faker) => ({
     sample: () => ({
       userId: faker.number.int({ min: 1, max: 1000 }),
-      modelId: faker.number.int({ min: 1, max: 1000 })
-    })
-  })
-})
+      modelId: faker.number.int({ min: 1, max: 1000 }),
+    }),
+    pg: (sql: string) => {
+      if (sql.includes('"Model"')) {
+        return { userId: faker.number.int({ min: 1, max: 1000 }) };
+      }
+      return null;
+    },
+  }),
+});

--- a/apps/event-engine/src/handlers/comments.ts
+++ b/apps/event-engine/src/handlers/comments.ts
@@ -18,19 +18,16 @@ export const commentHandler = createEventHandler<CommentRecord>({
   processor: async ({ operation, record, actions, pg }) => {
     const value = operation === 'create' ? 1 : -1;
 
-    // Update model metric
     const modelMetric = actions.forMetric('Model', record.modelId).as(record.userId);
     modelMetric.add('commentCount', value);
 
-    // Model comments are the largest single surface (1.17M), and they never reach CommentsV2, so
-    // the owner has to be resolved here or User.commentCount stays a minority of the real total.
+    // Model comments never reach CommentsV2, so this lookup is the only path to their owner.
     const model = await pg.queryOne<{ userId: number | null }>(
       `SELECT "userId" FROM "Model" WHERE id = $1`,
       [record.modelId]
     );
 
-    // Self-authored comments excluded, matching commentV2Handler — a creator replying under their
-    // own model is not engagement received.
+    // Self-authored excluded, matching commentV2Handler.
     if (model?.userId && model.userId !== record.userId) {
       actions.forMetric('User', model.userId).as(record.userId).add('commentCount', value);
     }


### PR DESCRIPTION
Completes the forward path for `User.commentCount` before any backfill runs. ClickUp `868ktbka8`.

## Why

`User.commentCount` shipped in #4002 covering Post / Image / Article / Bounty owners — **55% of comments**. Backfilling a complete history into a metric that goes incomplete from tonight onward is harder to spot than one that is wrong everywhere, so the emit surface goes first.

Measured on prod (root-resolved, matching the shipped handler):

| surface | comments | emitted before | now |
|---|---|---|---|
| Image | 1,442,746 | ✅ | ✅ |
| Model (legacy `Comment`) | 1,166,296 | ❌ | ✅ |
| Article | 222,325 | ✅ | ✅ |
| Post | 163,048 | ✅ | ✅ |
| Review | 109,521 | ❌ | ✅ |
| Bounty | 40,443 | ✅ | ✅ |
| BountyEntry | 32,460 | ❌ | ✅ |
| Challenge | 8,210 | ❌ | ✅ |
| Comic | 847 | ❌ | ✅ |
| Answer | 554 | ❌ | ✅ |
| ClubPost | 288 | ❌ | ✅ |
| Model3D | 161 | ❌ | ✅ |
| Question | 78 | ❌ | ✅ |
| Model (CommentsV2) | 16 | ❌ | ✅ |
| Model3DReview / AppListing | 0 | ❌ | ✅ |

Answer, Question and the CommentsV2 model arm were not on the ticket's table — they turned up when I counted every `Thread` FK rather than the listed ones. All small, all wired anyway.

## What changed

- **`comment-v2.ts`** — one query now resolves the entity *and* its owner across all fifteen commentable `Thread` columns. Owner columns are not uniform: `Challenge` and `ClubPost` record `createdById`, `app_listings` is snake-cased, and a comic thread points at the chapter's project rather than at an owner.
- **`comments.ts`** — legacy model comments look up `Model.userId` and emit for the creator. This is the single largest gap.
- **New tests** — emission, self-exclusion, the null-owner control, and a check that every `Thread` FK is still named in the query.

**Entity metrics deliberately stay at the four surfaces that already have them.** A new `(entityType, metricType)` pair needs a hand-applied `entityMetricKind` row; without one it falls into the presence path and counts *distinct commenters* instead of comments. Nothing in CI can catch that — `grep -r entityMetricKind` over the repo returns 0 hits. This PR introduces **no new pair**: `('User','commentCount','additive')` is already registered.

Both invariants from #4002 hold on every new arm: self-authored comments excluded, replies attributed to the root entity via `COALESCE(r.<id>, t.<id>)`.

## Verification

`apps/*` is outside the root tsconfig `include`, so `tekton / typecheck` never reads this code and `pnpm lint` / `pnpm test` are the only gates.

- `pnpm --filter @civitai/event-engine typecheck` — clean. **Proved it can fail on this file first** by planting a deliberate type error (`TS2322` at `comment-v2.ts:133`), then removing it.
- `pnpm run lint` — no issues on the three changed files.
- `pnpm run test` — 11 passed. Four of the assertions are negative (nothing was emitted), which pass for free unless proven otherwise, so each was mutation-tested:

| mutation | result |
|---|---|
| drop self-exclusion in `comment-v2` | red |
| drop null-owner guard | red |
| drop the `ResourceReview` join arm | red |
| drop self-exclusion in `comments.ts` | red |
| restored | green |

- **Against prod**: all fifteen surfaces resolve a real owner (one sample thread each, including a reply through `rootThreadId`). `EXPLAIN ANALYZE` on the widened query is index scans skipped on null — **0.23 ms execution, 4.2 ms planning**. The one seq scan is `app_listings` at 29 rows.

A note on `userId = -1`: it is the real `civitai` account, not a null placeholder, and it owns 7,574 models carrying 13,650 comments. Those count toward it. `entityId` is `Int32` in ClickHouse so the negative id is safe; the existing Download → Kafka filter excludes `-1` deliberately, which is a different decision for a different metric.

## Not in this PR

Backfill (work item 2) and the Creator Studio switch (`868krw7jf` steps 4-6). Justin decided the backfill runs from Postgres only: history loses the ~305k comments on deleted content whose threads have no recoverable owner, and the forward path never decrements, so deleted content keeps its comments from here on. The two halves are inconsistent by construction and that is accepted — maintaining deletes forward is not worth the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
