### PR TITLE
fix(creator-studio): version name legibility on model rows + a real sales count

### DIFF
--- a/apps/creator-studio/src/lib/earnings.ts
+++ b/apps/creator-studio/src/lib/earnings.ts
@@ -27,6 +27,11 @@ export const SOURCE_COLOR: Record<EarningsSource, string> = {
   cosmeticSale: '#f783ac',
 };
 
+// The buzz account types the trend series and the sales counts are restricted to. `currencyMeta` treats an
+// UNKNOWN currency as buzz, so filtering on that instead would count a newly-added account type on one side of
+// the /earnings sales line and not the other. Both sides read this list.
+export const SERIES_BUZZ_CURRENCIES = ['yellow', 'blue', 'green', 'club'] as const;
+
 // Currencies are the raw `toAccountType` values, never converted or merged (B8 / D1). `family` only drives visual
 // grouping/formatting (⚡ for buzz), never summing across families.
 export type CurrencyFamily = 'buzz' | 'cash' | 'bank';

--- a/apps/creator-studio/src/lib/earnings.ts
+++ b/apps/creator-studio/src/lib/earnings.ts
@@ -27,10 +27,12 @@ export const SOURCE_COLOR: Record<EarningsSource, string> = {
   cosmeticSale: '#f783ac',
 };
 
-// The buzz account types the trend series and the sales counts are restricted to. `currencyMeta` treats an
-// UNKNOWN currency as buzz, so filtering on that instead would count a newly-added account type on one side of
-// the /earnings sales line and not the other. Both sides read this list.
-export const SERIES_BUZZ_CURRENCIES = ['yellow', 'blue', 'green', 'club'] as const;
+// The buzz account types every buzz-only earnings read is restricted to — the trend series, the monthly table,
+// and the /earnings source cards and sales counts. Filter on this, NOT on `currencyMeta(c).family === 'buzz'`:
+// that treats an UNKNOWN currency as buzz, so a newly-added account type would land in one figure on a card and
+// not in the one beside it.
+export const BUZZ_CURRENCIES = ['yellow', 'blue', 'green', 'club'] as const;
+export const isBuzzCurrency = (c: string) => (BUZZ_CURRENCIES as readonly string[]).includes(c);
 
 // Currencies are the raw `toAccountType` values, never converted or merged (B8 / D1). `family` only drives visual
 // grouping/formatting (⚡ for buzz), never summing across families.

--- a/apps/creator-studio/src/lib/server/earnings.ts
+++ b/apps/creator-studio/src/lib/server/earnings.ts
@@ -1,6 +1,7 @@
 import { getClickhouse } from '$lib/server/clickhouse';
 import { createCache } from '$lib/server/cache';
 import { rangeTtlSeconds } from '$lib/date-range';
+import { SERIES_BUZZ_CURRENCIES } from '$lib/earnings';
 import type { EarningsSource } from '$lib/earnings';
 
 // Earnings by source — A1 **Part 1**. Creators are paid through `default.buzzTransactions`, which is already keyed
@@ -37,6 +38,8 @@ const RECEIVING_TYPES = `(type IN ('tip','compensation','licenseFee','27','sell'
 // exclusive-next-day so it's inclusive of the whole `to` day.
 const whereClause = (uid: number, from: string, to: string) =>
   `toAccountId = ${uid} AND date >= toDate('${from}') AND date < toDate('${to}') + 1 AND ${RECEIVING_TYPES}`;
+
+const CURRENCY_LIST = SERIES_BUZZ_CURRENCIES.map((c) => `'${c}'`).join(',');
 
 const SOURCE_EXPR = `multiIf(type = 'tip', 'tip', type = 'compensation', 'compensation', type IN ('licenseFee','27'), 'licenseFee', type = 'sell', 'cosmeticSale', 'accessSale')`;
 
@@ -80,8 +83,6 @@ async function fetchSeries({
   to: string;
 }): Promise<EarningsPoint[]> {
   const uid = Number(userId);
-  // Widening the currency list below changes `count` too: /earnings prints this per-day count beside a period
-  // count it filters to buzz in the component, so the two would stop agreeing.
   const rows = await getClickhouse().$query<{
     date: string;
     source: EarningsSource;
@@ -90,7 +91,7 @@ async function fetchSeries({
   }>(
     `SELECT toDate(date) AS date, ${SOURCE_EXPR} AS source, sum(amount) AS total, count() AS count
      FROM default.buzzTransactions
-     WHERE ${whereClause(uid, from, to)} AND toAccountType IN ('yellow','blue','green','club')
+     WHERE ${whereClause(uid, from, to)} AND toAccountType IN (${CURRENCY_LIST})
      GROUP BY date, source
      ORDER BY date`
   );

--- a/apps/creator-studio/src/lib/server/earnings.ts
+++ b/apps/creator-studio/src/lib/server/earnings.ts
@@ -1,7 +1,7 @@
 import { getClickhouse } from '$lib/server/clickhouse';
 import { createCache } from '$lib/server/cache';
 import { rangeTtlSeconds } from '$lib/date-range';
-import { SERIES_BUZZ_CURRENCIES } from '$lib/earnings';
+import { BUZZ_CURRENCIES } from '$lib/earnings';
 import type { EarningsSource } from '$lib/earnings';
 
 // Earnings by source — A1 **Part 1**. Creators are paid through `default.buzzTransactions`, which is already keyed
@@ -39,7 +39,7 @@ const RECEIVING_TYPES = `(type IN ('tip','compensation','licenseFee','27','sell'
 const whereClause = (uid: number, from: string, to: string) =>
   `toAccountId = ${uid} AND date >= toDate('${from}') AND date < toDate('${to}') + 1 AND ${RECEIVING_TYPES}`;
 
-const CURRENCY_LIST = SERIES_BUZZ_CURRENCIES.map((c) => `'${c}'`).join(',');
+const CURRENCY_LIST = BUZZ_CURRENCIES.map((c) => `'${c}'`).join(',');
 
 const SOURCE_EXPR = `multiIf(type = 'tip', 'tip', type = 'compensation', 'compensation', type IN ('licenseFee','27'), 'licenseFee', type = 'sell', 'cosmeticSale', 'accessSale')`;
 
@@ -135,7 +135,7 @@ async function fetchMonthly({ userId }: { userId: number }): Promise<MonthlyEarn
      FROM default.buzzTransactions
      WHERE toAccountId = ${uid}
        AND date >= toStartOfMonth(today() - INTERVAL 11 MONTH)
-       AND toAccountType IN ('yellow','blue','green','club')
+       AND toAccountType IN (${CURRENCY_LIST})
        AND ${RECEIVING_TYPES}
      GROUP BY month, currency
      ORDER BY month DESC`

--- a/apps/creator-studio/src/lib/server/earnings.ts
+++ b/apps/creator-studio/src/lib/server/earnings.ts
@@ -21,8 +21,8 @@ export type EarningsBucket = {
 };
 // The trend series is per-source, buzz-only (the chart is a buzz trend; cash lives in the panel). One line per
 // source with toggle chips (E4). Currency detail stays in the by-source×currency summary/table.
-// `count` is the number of transactions behind `total` — for `accessSale` that is the per-day sales count, the
-// only place the product carries one (a sale is not a table, just an `externalTransactionId` prefix).
+// `accessSale`'s `count` is the only sales count the product has — a sale is not a table, just an
+// `externalTransactionId` prefix.
 export type EarningsPoint = { date: string; source: EarningsSource; total: number; count: number };
 
 // Access sales carry one of two id prefixes: `permanent-access-` for a permanent paid-access sale,
@@ -80,6 +80,8 @@ async function fetchSeries({
   to: string;
 }): Promise<EarningsPoint[]> {
   const uid = Number(userId);
+  // Widening the currency list below changes `count` too: /earnings prints this per-day count beside a period
+  // count it filters to buzz in the component, so the two would stop agreeing.
   const rows = await getClickhouse().$query<{
     date: string;
     source: EarningsSource;
@@ -110,7 +112,7 @@ export const getEarningsSummary = createCache({
 // Per-source buzz totals over time — the /earnings trend chart.
 export const getEarningsSeries = createCache({
   // Keys derive from the args, not the payload, so a stored value outlives a change to the returned shape. Bump
-  // the suffix whenever that shape or the numbers change — v2 added `count`.
+  // the suffix whenever that shape or the numbers change.
   name: 'earnings:series:v2',
   fetch: fetchSeries,
   ttlSeconds: ({ from, to }) => rangeTtlSeconds({ from, to }),

--- a/apps/creator-studio/src/lib/server/earnings.ts
+++ b/apps/creator-studio/src/lib/server/earnings.ts
@@ -21,7 +21,9 @@ export type EarningsBucket = {
 };
 // The trend series is per-source, buzz-only (the chart is a buzz trend; cash lives in the panel). One line per
 // source with toggle chips (E4). Currency detail stays in the by-source×currency summary/table.
-export type EarningsPoint = { date: string; source: EarningsSource; total: number };
+// `count` is the number of transactions behind `total` — for `accessSale` that is the per-day sales count, the
+// only place the product carries one (a sale is not a table, just an `externalTransactionId` prefix).
+export type EarningsPoint = { date: string; source: EarningsSource; total: number; count: number };
 
 // Access sales carry one of two id prefixes: `permanent-access-` for a permanent paid-access sale,
 // `early-access-` for a timed window. Rows written before the split are all `early-access-`, whichever
@@ -82,14 +84,20 @@ async function fetchSeries({
     date: string;
     source: EarningsSource;
     total: number | string;
+    count: number | string;
   }>(
-    `SELECT toDate(date) AS date, ${SOURCE_EXPR} AS source, sum(amount) AS total
+    `SELECT toDate(date) AS date, ${SOURCE_EXPR} AS source, sum(amount) AS total, count() AS count
      FROM default.buzzTransactions
      WHERE ${whereClause(uid, from, to)} AND toAccountType IN ('yellow','blue','green','club')
      GROUP BY date, source
      ORDER BY date`
   );
-  return rows.map((r) => ({ date: String(r.date), source: r.source, total: Number(r.total) }));
+  return rows.map((r) => ({
+    date: String(r.date),
+    source: r.source,
+    total: Number(r.total),
+    count: Number(r.count),
+  }));
 }
 
 // By-source × currency totals over the range — the /earnings source cards and the dashboard headline.
@@ -101,7 +109,9 @@ export const getEarningsSummary = createCache({
 
 // Per-source buzz totals over time — the /earnings trend chart.
 export const getEarningsSeries = createCache({
-  name: 'earnings:series',
+  // Keys derive from the args, not the payload, so a stored value outlives a change to the returned shape. Bump
+  // the suffix whenever that shape or the numbers change — v2 added `count`.
+  name: 'earnings:series:v2',
   fetch: fetchSeries,
   ttlSeconds: ({ from, to }) => rangeTtlSeconds({ from, to }),
 }).get;

--- a/apps/creator-studio/src/routes/(app)/analytics/models/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/analytics/models/+page.svelte
@@ -358,7 +358,9 @@
                   Version {m.modelVersionId}
                 </div>
                 {#if m.versionName}
-                  <div class="truncate text-sm text-dark-2">{m.versionName}</div>
+                  <div class="truncate text-sm text-dark-2" title={m.versionName}>
+                    {m.versionName}
+                  </div>
                 {/if}
               {/if}
               <div class="truncate text-xs text-dark-2">

--- a/apps/creator-studio/src/routes/(app)/analytics/models/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/analytics/models/+page.svelte
@@ -336,27 +336,32 @@
               {#if m.modelId}
                 <a
                   href="/analytics/models/{m.modelId}"
-                  class="group flex items-center gap-1 font-medium text-blue-4 hover:text-blue-3"
+                  class="group flex items-start gap-1 font-medium text-blue-4 hover:text-blue-3"
                   title={rowLabel(m)}
                 >
-                  <span
-                    class="min-w-0 truncate underline decoration-blue-4/40 underline-offset-2 group-hover:decoration-blue-3"
-                  >
-                    {m.modelName ?? 'Model ' + m.modelId}
+                  <span class="min-w-0 flex-1">
+                    <span
+                      class="block truncate underline decoration-blue-4/40 underline-offset-2 group-hover:decoration-blue-3"
+                    >
+                      {m.modelName ?? 'Model ' + m.modelId}
+                    </span>
+                    {#if m.versionName}
+                      <span class="block truncate text-sm font-normal text-dark-2"
+                        >{m.versionName}</span
+                      >
+                    {/if}
                   </span>
-                  <IconChevronRight size={14} class="shrink-0" />
+                  <IconChevronRight size={14} class="mt-1 shrink-0" />
                 </a>
               {:else}
                 <div class="truncate text-dark-2" title={rowLabel(m)}>
                   Version {m.modelVersionId}
                 </div>
+                {#if m.versionName}
+                  <div class="truncate text-sm text-dark-2">{m.versionName}</div>
+                {/if}
               {/if}
-              {#if m.versionName}
-                <!-- Own line: on one truncating line with the model name, the version was always the
-                     half that got cut — and it is what tells two rows of the same model apart. -->
-                <div class="truncate text-dark-2" title={m.versionName}>{m.versionName}</div>
-              {/if}
-              <div class="truncate text-xs text-dark-3">
+              <div class="truncate text-xs text-dark-2">
                 {m.modelType ?? '—'}{#if grouping.value === 'model' && m.modelId != null}
                   {@const n = versionCounts.get(m.modelId) ?? 1}
                   · {n} version{n === 1 ? '' : 's'}

--- a/apps/creator-studio/src/routes/(app)/analytics/models/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/analytics/models/+page.svelte
@@ -342,20 +342,19 @@
                   <span
                     class="min-w-0 truncate underline decoration-blue-4/40 underline-offset-2 group-hover:decoration-blue-3"
                   >
-                    {m.modelName ?? 'Model ' + m.modelId}{#if m.versionName}<span
-                        class="text-dark-3"
-                      >
-                        · {m.versionName}</span
-                      >{/if}
+                    {m.modelName ?? 'Model ' + m.modelId}
                   </span>
                   <IconChevronRight size={14} class="shrink-0" />
                 </a>
               {:else}
                 <div class="truncate text-dark-2" title={rowLabel(m)}>
-                  Version {m.modelVersionId}{#if m.versionName}<span class="text-dark-3">
-                      · {m.versionName}</span
-                    >{/if}
+                  Version {m.modelVersionId}
                 </div>
+              {/if}
+              {#if m.versionName}
+                <!-- Own line: on one truncating line with the model name, the version was always the
+                     half that got cut — and it is what tells two rows of the same model apart. -->
+                <div class="truncate text-dark-2" title={m.versionName}>{m.versionName}</div>
               {/if}
               <div class="truncate text-xs text-dark-3">
                 {m.modelType ?? '—'}{#if grouping.value === 'model' && m.modelId != null}

--- a/apps/creator-studio/src/routes/(app)/earnings/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/earnings/+page.server.ts
@@ -45,6 +45,9 @@ export const load: PageServerLoad = async ({ locals, cookies }) => {
       to: compare.range.to,
     },
     through,
+    // `through` is the last ELAPSED day of the selected month, so it is only today when that month is the current
+    // one. The sales line says which, rather than letting a July figure read as a recency signal in August.
+    throughIsToday: through === todayIso,
     cash,
     monthly,
     buzzRatio,

--- a/apps/creator-studio/src/routes/(app)/earnings/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/earnings/+page.svelte
@@ -97,6 +97,26 @@
       .filter((x) => Math.floor(x.total) >= 1)
   );
 
+  // Sales counts (868ktk1k9). Access sales are the one source with a meaningful unit count, and no other surface in
+  // the product exposes one — creators were polling their own transaction ledger to reconstruct it. Buzz rows only,
+  // so the period figure and the per-day figure are drawn from the same population.
+  const salesInPeriod = $derived(
+    (data.summary ?? [])
+      .filter((b) => b.source === 'accessSale' && currencyMeta(b.currency).family === 'buzz')
+      .reduce((n, b) => n + b.count, 0)
+  );
+  const salesOnLastDay = $derived(
+    (data.series ?? [])
+      .filter((p) => p.source === 'accessSale' && p.date === data.through)
+      .reduce((n, p) => n + p.count, 0)
+  );
+  const dayFmt = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+  const formatDay = (iso: string) => dayFmt.format(Date.parse(`${iso}T00:00:00Z`));
+
   // Authoritative Creator Program cash — the buzz-account balance from the service (matches the Buzz dashboard),
   // NOT a ClickHouse period sum. `formatAmount` renders these cash values in USD.
   const cash = $derived(data.cash);
@@ -326,6 +346,12 @@
     {#each sourceTotals as st (st.source)}
       <StatCard label={SOURCE_LABEL[st.source]}>
         <p class="mt-1 text-xl font-semibold text-white"><CurrencyDisplay amount={st.total} /></p>
+        {#if st.source === 'accessSale' && salesInPeriod > 0}
+          <p class="mt-1 text-xs text-dark-2">
+            {salesInPeriod.toLocaleString()} sale{salesInPeriod === 1 ? '' : 's'} · {salesOnLastDay.toLocaleString()}
+            on {formatDay(data.through)}
+          </p>
+        {/if}
         <div class="mt-1">
           <DeltaChip
             current={st.total}

--- a/apps/creator-studio/src/routes/(app)/earnings/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/earnings/+page.svelte
@@ -17,6 +17,7 @@
     SOURCE_LABEL,
     SOURCE_COLOR,
     currencyMeta,
+    SERIES_BUZZ_CURRENCIES,
     currencySort,
     formatAmount,
     hasDisplayValue,
@@ -97,10 +98,15 @@
       .filter((x) => Math.floor(x.total) >= 1)
   );
 
-  // Sales counts (868ktk1k9). Buzz-only here to match the series, which the query already restricts to buzz.
+  // Sales counts (868ktk1k9). Both figures filter on SERIES_BUZZ_CURRENCIES so the period count and the per-day
+  // count cannot drift apart when a new account type ships.
   const salesInPeriod = $derived(
     (data.summary ?? [])
-      .filter((b) => b.source === 'accessSale' && currencyMeta(b.currency).family === 'buzz')
+      .filter(
+        (b) =>
+          b.source === 'accessSale' &&
+          (SERIES_BUZZ_CURRENCIES as readonly string[]).includes(b.currency)
+      )
       .reduce((n, b) => n + b.count, 0)
   );
   const salesOnLastDay = $derived(

--- a/apps/creator-studio/src/routes/(app)/earnings/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/earnings/+page.svelte
@@ -17,7 +17,7 @@
     SOURCE_LABEL,
     SOURCE_COLOR,
     currencyMeta,
-    SERIES_BUZZ_CURRENCIES,
+    isBuzzCurrency,
     currencySort,
     formatAmount,
     hasDisplayValue,
@@ -92,21 +92,16 @@
       .map((s) => ({
         source: s,
         total: (data.summary ?? [])
-          .filter((b) => b.source === s && currencyMeta(b.currency).family === 'buzz')
+          .filter((b) => b.source === s && isBuzzCurrency(b.currency))
           .reduce((acc, b) => acc + b.total, 0),
       }))
       .filter((x) => Math.floor(x.total) >= 1)
   );
 
-  // Sales counts (868ktk1k9). Both figures filter on SERIES_BUZZ_CURRENCIES so the period count and the per-day
-  // count cannot drift apart when a new account type ships.
+  // Sales counts (868ktk1k9).
   const salesInPeriod = $derived(
     (data.summary ?? [])
-      .filter(
-        (b) =>
-          b.source === 'accessSale' &&
-          (SERIES_BUZZ_CURRENCIES as readonly string[]).includes(b.currency)
-      )
+      .filter((b) => b.source === 'accessSale' && isBuzzCurrency(b.currency))
       .reduce((n, b) => n + b.count, 0)
   );
   const salesOnLastDay = $derived(
@@ -362,7 +357,8 @@
             {salesInPeriod.toLocaleString()} sale{salesInPeriod === 1
               ? ''
               : 's'}{#if salesOnLastDay > 0}
-              · {salesOnLastDay.toLocaleString()} on {formatDay(data.through)}{/if}
+              · {salesOnLastDay.toLocaleString()}
+              {data.throughIsToday ? 'today' : `on ${formatDay(data.through)}`}{/if}
           </p>
         {/if}
       </StatCard>

--- a/apps/creator-studio/src/routes/(app)/earnings/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/earnings/+page.svelte
@@ -97,9 +97,7 @@
       .filter((x) => Math.floor(x.total) >= 1)
   );
 
-  // Sales counts (868ktk1k9). Access sales are the one source with a meaningful unit count, and no other surface in
-  // the product exposes one — creators were polling their own transaction ledger to reconstruct it. Buzz rows only,
-  // so the period figure and the per-day figure are drawn from the same population.
+  // Sales counts (868ktk1k9). Buzz-only here to match the series, which the query already restricts to buzz.
   const salesInPeriod = $derived(
     (data.summary ?? [])
       .filter((b) => b.source === 'accessSale' && currencyMeta(b.currency).family === 'buzz')
@@ -346,12 +344,6 @@
     {#each sourceTotals as st (st.source)}
       <StatCard label={SOURCE_LABEL[st.source]}>
         <p class="mt-1 text-xl font-semibold text-white"><CurrencyDisplay amount={st.total} /></p>
-        {#if st.source === 'accessSale' && salesInPeriod > 0}
-          <p class="mt-1 text-xs text-dark-2">
-            {salesInPeriod.toLocaleString()} sale{salesInPeriod === 1 ? '' : 's'} · {salesOnLastDay.toLocaleString()}
-            on {formatDay(data.through)}
-          </p>
-        {/if}
         <div class="mt-1">
           <DeltaChip
             current={st.total}
@@ -359,6 +351,14 @@
             label="vs {data.compare.label}"
           />
         </div>
+        {#if st.source === 'accessSale' && salesInPeriod > 0}
+          <p class="mt-1 text-xs text-dark-2">
+            {salesInPeriod.toLocaleString()} sale{salesInPeriod === 1
+              ? ''
+              : 's'}{#if salesOnLastDay > 0}
+              · {salesOnLastDay.toLocaleString()} on {formatDay(data.through)}{/if}
+          </p>
+        {/if}
       </StatCard>
     {/each}
   </section>


### PR DESCRIPTION
Two Creator Studio analytics items: [868ktk1dt](https://app.clickup.com/t/868ktk1dt) and [868ktk1k9](https://app.clickup.com/t/868ktk1k9).

## 868ktk1dt — the missing version name is NOT in this PR, and needs no code

The tooltip fix already landed on `main` on 2026-08-08 (`6ecac81f9f`). Prod runs `civitai-creator-studio:0.0.38`, whose pods were created 2026-08-07, and `6ecac81f9f` is not an ancestor of tag `creator-studio-v0.0.38`.

Independent confirmation without needing registry access: `https://creator-studio.civitai.com/_app/version.json` returns SvelteKit's build stamp, **2026-08-07T18:15:00.861Z** — 77 seconds after the v0.0.38 release commit, and 26.8 hours *before* the fix commit existed. The code serving the public hostname predates the fix.

The stale-cache theory in the ticket is refuted at the tag itself: at `v0.0.38` the cache is named `models:performance:v2` **and** that same file already selects and maps `versionName`, so no entry the running build can read or write could lack the field. `versionName` is also not null in the data — `ModelVersion.name` is `NOT NULL`, and the reported model (847101, 45 versions) has zero blank names.

So the ticket's "versionName is arriving null" is the part that is wrong. The screenshot is fully explained by the old tooltip plus truncation.

**Justin has said no release is needed — a larger release is coming shortly, and this rides along with it.** Note the ordering: that release ships the tooltip only if this PR is merged before it, since the truncation half lives here.

## What is here

**Defect 2 (real on `main`)** — the model column packed name and version into one `truncate` span at `max-w-55`, so the version was always the half that got cut, for exactly the creator who has many versions of a long-named model. Name and version now each truncate on their own line inside the same link.

**868ktk1k9, small scope** — `count()` added to the per-day earnings series, surfaced on the Access sales card as `42 sales · 3 today`. Cache suffix bumped `earnings:series` → `:v2` because the payload shape changed. The main-app header counter was deliberately not built.

### Caveat on what the number counts

Sales are not modelled as a thing — they are identified only by string-prefix matching `externalTransactionId`. Over 7 days: **6,787 rows vs 6,536 distinct (versionId, buyerId) pairs**, a ~3.7% gap, because a buyer can purchase *download* and *generation* access on the same version separately (365 generation rows, every one paired with a download row). So `count()` counts products sold, not models sold. Every row is positive-amount and buzz-only, so there is no refund or cash skew.

## Verification

- `pnpm run typecheck` — 0 errors over 8,908 files. The 3 warnings are pre-existing, in `packages/civitai-ui`.
- Five review agents: `svelte-correctness-review`, `svelte-idiom-review`, `svelte-abstraction-review`, plus two adversarial passes — one attacking the code, one trying to refute the release claim above. Findings applied in follow-up commits; the release claim survived.

The fix rounds themselves found the most: unifying the two sales counts against a currency allowlist left the buzz *total* they sit under on the old `currencyMeta(...).family === 'buzz'` predicate, which treats an unknown currency as buzz. All three figures on the card now share `isBuzzCurrency`, and `fetchMonthly` stops carrying its own copy of the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)