### PR TITLE
fix(buzz): show one decimal in the header balance

### DIFF
--- a/src/components/User/UserBuzz.tsx
+++ b/src/components/User/UserBuzz.tsx
@@ -97,7 +97,7 @@ export function UserBuzz({
               className={clsx(classes.buzzLoader, gradient && classes.withGradient)}
             />
           ) : withAbbreviation ? (
-            abbreviateNumber(balance, { floor: true })
+            abbreviateNumber(balance, { floor: true, decimals: 1 })
           ) : (
             balance.toLocaleString()
           )}

--- a/src/utils/__tests__/number-helpers.test.ts
+++ b/src/utils/__tests__/number-helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { abbreviateNumber } from '~/utils/number-helpers';
+
+describe('abbreviateNumber', () => {
+  it('floors at the requested precision instead of at whole units', () => {
+    expect(abbreviateNumber(10_600_000, { floor: true, decimals: 1 })).toBe('10.6m');
+    expect(abbreviateNumber(10_699_999, { floor: true, decimals: 1 })).toBe('10.6m');
+  });
+
+  it('still floors to whole units when no decimals are requested', () => {
+    expect(abbreviateNumber(10_600_000, { floor: true })).toBe('10m');
+  });
+
+  it('floors from the undivided value, so no tick is lost to float error', () => {
+    expect(abbreviateNumber(1130, { floor: true, decimals: 2 })).toBe('1.13k');
+    expect(abbreviateNumber(1_130_000, { floor: true, decimals: 2 })).toBe('1.13m');
+  });
+
+  it('never reads higher than the true value, in either direction', () => {
+    expect(abbreviateNumber(10_990_000, { floor: true, decimals: 1 })).toBe('10.9m');
+    // Floored toward negative infinity: a debt must not render as less debt.
+    expect(abbreviateNumber(-10_690_000, { floor: true, decimals: 1 })).toBe('-10.7m');
+  });
+
+  it('leaves the rounding path alone', () => {
+    expect(abbreviateNumber(10_690_000)).toBe('10.7m');
+    expect(abbreviateNumber(-10_690_000)).toBe('-10.7m');
+  });
+});

--- a/src/utils/number-helpers.ts
+++ b/src/utils/number-helpers.ts
@@ -79,9 +79,8 @@ export function abbreviateNumber(
   const suffixes = ['', 'k', 'm', 'b', 't'];
   let index = 0;
 
-  // Abbreviate on magnitude, then re-apply the sign — negative scores (e.g. a
-  // reportsAgainst-heavy user) are valid and must abbreviate like positives.
-  const sign = value < 0 ? '-' : '';
+  // Abbreviate on magnitude — negative scores (e.g. a reportsAgainst-heavy user)
+  // are valid and must abbreviate like positives.
   let magnitude = Math.abs(value);
 
   while (magnitude >= 1000 && index < suffixes.length - 1) {
@@ -89,12 +88,19 @@ export function abbreviateNumber(
     index++;
   }
 
+  let signed = value < 0 ? -magnitude : magnitude;
   if (floor) {
-    magnitude = Math.floor(magnitude);
+    // Floor at the requested precision, and from the undivided value: `magnitude`
+    // has already lost ticks to the `/= 1000` chain, so flooring it reads a whole
+    // tick low (1130 renders 1.12k at `decimals: 2`). Signed, so a negative
+    // balance never reads as less debt than it is.
+    const factor = Math.pow(10, decimals ?? 0);
+    signed = Math.floor((value * factor) / Math.pow(1000, index)) / factor;
   }
 
+  const sign = signed < 0 ? '-' : '';
   const formattedValue =
-    Math.round(magnitude * Math.pow(10, decimals ?? 0)) / Math.pow(10, decimals ?? 0);
+    Math.round(Math.abs(signed) * Math.pow(10, decimals ?? 0)) / Math.pow(10, decimals ?? 0);
 
   return `${sign}${formattedValue}${suffixes[index]}`;
 }


### PR DESCRIPTION
Closes ClickUp 868ktk1dw.

**Rebased and narrowed.** This PR originally carried a second change — the owner-visible download price badge (868ktk1ef). `ce1428c09c` landed that on `main` while this was open, with wider scope (download *and* generation price, via a `listedPrice` prop with a "Buyers pay N Buzz" tooltip). I dropped my version rather than ship a second mechanism for one badge. What is left is the buzz decimal fix alone, one commit, rebased onto current `main`.

## The bug

`UserBuzz` called `abbreviateNumber(balance, { floor: true })`, and `decimals` defaults to 0, so every balance from 10,000,000 to 10,999,999 rendered "10m". MNeMiC could not patch it client-side because the abbreviation happens before render, so his userscript reads `buzz.getBuzzAccount` for the raw number instead.

## The fix

Passing `decimals: 1` alone would not have worked: `floor` floored the magnitude to a whole unit *before* the decimal rounding, so `{ floor: true, decimals: 1 }` still produced "10m". `floor` now floors at the requested precision, from the undivided value, on the signed number:

- **At the requested precision** — `decimals: 1` shows 10.6m. At `decimals: 0`, every other caller, the output is byte-identical.
- **From the undivided value** — flooring `magnitude` after the `/= 1000` chain drops a whole tick to float error: 1130 rendered `1.12k` at `decimals: 2`. Measured against BigInt-exact expectations over every tick in the k/m/b/t ranges: 4,583 of 99,900 values wrong at `decimals: 2` before, 0 after. No shipped caller passes `decimals: 2` today — this was a trap for the next one.
- **Signed** — a negative balance renders `-10.7m` rather than `-10.6m`. Flooring the magnitude truncated toward zero, so a debt read as less debt than it was.

The only other `floor: true` caller is `YellowBuzzMigrationNotice.tsx:85`, which passes no `decimals` → factor 1 → byte-identical output.

`src/utils/__tests__/number-helpers.test.ts` covers all three properties. Mutation-checked on the rebased branch: restoring `Math.floor(magnitude)` fails 3 of 5 cases (`expected '10m' to be '10.6m'`, `expected '1k' to be '1.13k'`, `expected '10m' to be '10.9m'`).

**Width:** `decimals: 1` is unconditional inside `UserBuzz`, and `withAbbreviation` defaults to true, so the two extra characters land at every `UserBuzz` site, not only the header — `UserMenu.tsx:89` (header, `@max-md:hidden`, desktop only), the two side-by-side balances in the open menu row (the tightest of the set, a 260px popover next to a Buy button), `AvailableBuzzBadge`, `BuzzTopUpCard`, `BuzzDashboardOverview`, `SendTipModal`. All flex rows that size to their content. Saying it out loud rather than pre-emptively reverting, per the task: if it does crowd one, the fix is a per-site decision about decimals, not dropping them everywhere.

## Verification (on the rebased head)
- `pnpm run typecheck` — 0 errors. Note this needed `pnpm run db:generate` first: `main` moved the Prisma schema today (app-blocks `sourceCommit`, collections `rejectionReason`) and a stale generated client reports 8 errors in files this PR does not touch.
- `pnpm run lint` — no new issues (2 pre-existing unused-var warnings on unrelated lines)
- `pnpm run prettier:write` — applied
- `pnpm run test:unit:run` — 1159 passed / 1 skipped of 1162 files. Two files fail **on Windows only**, both from `833cb30815` (merged to `main` today, untouched by this PR): `rating-label.test.ts` and `appListingStatChips.test.ts` are source-scanning guards that compare `components/Foo.ts` against Windows' `components\Foo.ts`. Linux CI does not hit it. Recording it rather than quietly re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
