### PR TITLE
fix(block): enforce blocking on legacy model comments and review edits

### DIFF
--- a/docs/testing/shared-module-mocks.md
+++ b/docs/testing/shared-module-mocks.md
@@ -245,6 +245,29 @@ because the failing set is order-dependent — 1574 failures at 8 workers agains
 Do not read a suite result through `| tail` or `| grep`; that reports the pipe's exit
 code. Redirect to a file and read the file.
 
+🔴 **Never run two vitest runs in one worktree — the second one's result is not evidence.**
+
+A targeted run and a full suite sharing a checkout produce assertion failures in the targeted
+run that the code does not explain. Measured on one frozen SHA, five files, identical bytes on
+disk for every run: **10/10 green** with nothing else in the tree, **1/5 red** with a full suite
+running concurrently in the same worktree, and earlier the same day 5/10 and 4/5 red under that
+condition. A control rules out load as the cause: 6/6 green under 24 spinning CPU processes with
+no rival vitest.
+
+The failure reads as a test bug, which is what makes it expensive. The symptom is that a `dbRead`
+lookup the test configured returns the canonical mock's **empty default** instead — so the code
+under test resolves nothing, a guard finds no owner, and an assertion that something is refused
+fails as "resolved instead of rejecting". It is not a consumed `…Once` queue: it reproduces on
+plain `mockResolvedValue` too. The mechanism is unproven; the shared `node_modules/.vite` cache
+is the obvious suspect and has not been demonstrated. CI runs one suite at a time, so this is a
+local hazard.
+
+Two rules follow. Anyone's flakiness number measured in a shared worktree — including a green one
+— says nothing, so re-measure alone before believing it. And before attributing a red run to the
+diff, check whether anything else was running in that checkout: this condition sent two separate
+diagnoses the wrong way in one afternoon, once at a test file and once at run contention, and a
+tree that moves underneath a probe will do the same.
+
 ## Not covered here
 
 `~/server/services/buzz.service` (98 sites) and `~/server/services/image.service` (88) lead

--- a/src/server/controllers/__tests__/comment.controller.block-check.test.ts
+++ b/src/server/controllers/__tests__/comment.controller.block-check.test.ts
@@ -49,15 +49,37 @@ import { upsertCommentHandler } from '../comment.controller';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 
 const mockDb = dbMock.dbRead;
-const MODEL_OWNER = 100;
+const REQUEST_MODEL_OWNER = 100;
+const STORED_MODEL_OWNER = 101;
 const PARENT_AUTHOR = 55;
 const COMMENTER = 7;
-const MODEL_ID = 10;
+const REQUEST_MODEL = 10;
+const STORED_MODEL = 11;
+const PARENT_ID = 9;
+const COMMENT_ID = 5;
 
-// The model lookup the handler makes for version access — distinct from the `findMany` the block
-// resolver uses, so neither can stand in for the other.
-function modelHasOneVersion() {
-  mockDb.model.findUnique.mockResolvedValue({ id: MODEL_ID, modelVersions: [{ id: 1 }] });
+/**
+ * Keyed on the id asked for, not on call order. The handler's own version-access lookup and the
+ * guard's owner lookup are both `model.findUnique` on the same table, so a `…Once` queue would be
+ * consumed by whichever ran first and the guard would silently resolve nobody.
+ */
+function arrange({ storedComment = false }: { storedComment?: boolean } = {}) {
+  const modelOwners: Record<number, number> = {
+    [REQUEST_MODEL]: REQUEST_MODEL_OWNER,
+    [STORED_MODEL]: STORED_MODEL_OWNER,
+  };
+  mockDb.model.findUnique.mockImplementation(async (args: unknown) => {
+    const id = (args as { where: { id: number } }).where.id;
+    return modelOwners[id] ? { id, userId: modelOwners[id], modelVersions: [{ id: 1 }] } : null;
+  });
+  mockDb.comment.findUnique.mockImplementation(async (args: unknown) => {
+    const id = (args as { where: { id: number } }).where.id;
+    if (id === PARENT_ID) return { userId: PARENT_AUTHOR, modelId: REQUEST_MODEL };
+    // The comment being edited lives on a DIFFERENT model than the request names, so an assertion
+    // about the stored owner cannot be satisfied by the requested one.
+    if (id === COMMENT_ID && storedComment) return { modelId: STORED_MODEL, parentId: null };
+    return null;
+  });
 }
 
 function ctx({ isModerator = false }: { isModerator?: boolean } = {}) {
@@ -70,26 +92,30 @@ function ctx({ isModerator = false }: { isModerator?: boolean } = {}) {
 }
 
 const baseInput = {
-  modelId: MODEL_ID,
+  modelId: REQUEST_MODEL,
   content: '<p>hello</p>',
 } as Parameters<typeof upsertCommentHandler>[0]['input'];
+
+const blockedBy = (...userIds: number[]) =>
+  amIBlockedByUser.mockImplementation(async (args) =>
+    userIds.includes((args as { targetUserId: number }).targetUserId)
+  );
 
 beforeEach(() => {
   vi.clearAllMocks();
   amIBlockedByUser.mockResolvedValue(false);
   mockHasEntityAccess.mockResolvedValue([{ hasAccess: true }]);
-  modelHasOneVersion();
-  mockDb.model.findMany.mockResolvedValue([{ userId: MODEL_OWNER }]);
+  arrange();
 });
 
 describe('upsertCommentHandler — block enforcement', () => {
   it('throws and never writes when the commenter is blocked by the model owner', async () => {
-    amIBlockedByUser.mockResolvedValue(true);
+    blockedBy(REQUEST_MODEL_OWNER);
 
     await expect(upsertCommentHandler({ ctx: ctx(), input: baseInput })).rejects.toThrow();
     expect(amIBlockedByUser).toHaveBeenCalledWith({
       userId: COMMENTER,
-      targetUserId: MODEL_OWNER,
+      targetUserId: REQUEST_MODEL_OWNER,
     });
     expect(mockCreateOrUpdateComment).not.toHaveBeenCalled();
   });
@@ -100,29 +126,38 @@ describe('upsertCommentHandler — block enforcement', () => {
     // The control for the negative case above: same setup, block flag flipped, write happens.
     expect(amIBlockedByUser).toHaveBeenCalledWith({
       userId: COMMENTER,
-      targetUserId: MODEL_OWNER,
+      targetUserId: REQUEST_MODEL_OWNER,
     });
     expect(mockCreateOrUpdateComment).toHaveBeenCalledTimes(1);
   });
 
   it('throws and never writes when a blocked user edits a comment written before the block', async () => {
-    mockDb.comment.findUnique.mockResolvedValue({ modelId: MODEL_ID, parentId: null });
-    amIBlockedByUser.mockResolvedValue(true);
+    // Only the model the comment is STORED on blocks, so this fails if the edit trusts the request.
+    arrange({ storedComment: true });
+    blockedBy(STORED_MODEL_OWNER);
 
     await expect(
-      upsertCommentHandler({ ctx: ctx(), input: { ...baseInput, id: 5 } })
+      upsertCommentHandler({ ctx: ctx(), input: { ...baseInput, id: COMMENT_ID } })
     ).rejects.toThrow();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({
+      userId: COMMENTER,
+      targetUserId: STORED_MODEL_OWNER,
+    });
     expect(mockCreateOrUpdateComment).not.toHaveBeenCalled();
   });
 
+  it('lets a non-blocked author edit', async () => {
+    arrange({ storedComment: true });
+
+    await upsertCommentHandler({ ctx: ctx(), input: { ...baseInput, id: COMMENT_ID } });
+    expect(mockCreateOrUpdateComment).toHaveBeenCalledTimes(1);
+  });
+
   it('checks the parent author on a reply, not only the model owner', async () => {
-    mockDb.comment.findMany.mockResolvedValue([{ userId: PARENT_AUTHOR }]);
-    amIBlockedByUser.mockImplementation(
-      async (args) => (args as { targetUserId: number }).targetUserId === PARENT_AUTHOR
-    );
+    blockedBy(PARENT_AUTHOR);
 
     await expect(
-      upsertCommentHandler({ ctx: ctx(), input: { ...baseInput, parentId: 9 } })
+      upsertCommentHandler({ ctx: ctx(), input: { ...baseInput, parentId: PARENT_ID } })
     ).rejects.toThrow();
     expect(amIBlockedByUser).toHaveBeenCalledWith({
       userId: COMMENTER,
@@ -132,7 +167,7 @@ describe('upsertCommentHandler — block enforcement', () => {
   });
 
   it('exempts moderators', async () => {
-    amIBlockedByUser.mockResolvedValue(true);
+    blockedBy(REQUEST_MODEL_OWNER);
 
     await upsertCommentHandler({ ctx: ctx({ isModerator: true }), input: baseInput });
     expect(amIBlockedByUser).not.toHaveBeenCalled();

--- a/src/server/controllers/__tests__/comment.controller.block-check.test.ts
+++ b/src/server/controllers/__tests__/comment.controller.block-check.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Block enforcement on the legacy model-comment write path (`comment.upsert`).
+ *
+ * The handler's `ctx.ownerId` is the COMMENT's author — the caller themselves on a create — so the
+ * check it fed resolved to "am I blocked by me", which is never true: the model owner's block was
+ * never evaluated and a blocked user could post on the model they were blocked from. Enforcement
+ * now resolves the model owner (and, for a reply, the parent author) through the shared guard, on
+ * edits as well as creates.
+ */
+
+const { amIBlockedByUser, mockCreateOrUpdateComment, mockHasEntityAccess } = vi.hoisted(() => ({
+  amIBlockedByUser: vi.fn(async (..._a: unknown[]): Promise<boolean> => false),
+  mockCreateOrUpdateComment: vi.fn(
+    async (..._a: unknown[]): Promise<unknown> => ({
+      id: 1,
+      modelId: 10,
+      content: 'hi',
+      nsfw: false,
+    })
+  ),
+  mockHasEntityAccess: vi.fn(async (..._a: unknown[]): Promise<unknown> => [{ hasAccess: true }]),
+}));
+
+vi.mock('~/server/services/user.service', () => ({ amIBlockedByUser }));
+vi.mock('~/server/services/blocklist.service', () => ({
+  throwOnBlockedLinkDomain: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/rewards', () => ({ reportAcceptedReward: { apply: vi.fn() } }));
+vi.mock('~/server/services/common.service', () => ({
+  hasEntityAccess: (...a: unknown[]) => mockHasEntityAccess(...(a as [])),
+}));
+vi.mock('~/server/services/comment.service', () => ({
+  createOrUpdateComment: (...a: unknown[]) => mockCreateOrUpdateComment(...(a as [])),
+  deleteCommentById: vi.fn(),
+  getCommentById: vi.fn(),
+  getCommentReactions: vi.fn(),
+  getComments: vi.fn(),
+  getPinnedComments: vi.fn(),
+  toggleHideComment: vi.fn(),
+  togglePinComment: vi.fn(),
+  updateCommentById: vi.fn(),
+  updateCommentReportStatusByReason: vi.fn(),
+}));
+
+import { upsertCommentHandler } from '../comment.controller';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const mockDb = dbMock.dbRead;
+const MODEL_OWNER = 100;
+const PARENT_AUTHOR = 55;
+const COMMENTER = 7;
+const MODEL_ID = 10;
+
+// The model lookup the handler makes for version access — distinct from the `findMany` the block
+// resolver uses, so neither can stand in for the other.
+function modelHasOneVersion() {
+  mockDb.model.findUnique.mockResolvedValue({ id: MODEL_ID, modelVersions: [{ id: 1 }] });
+}
+
+function ctx({ isModerator = false }: { isModerator?: boolean } = {}) {
+  return {
+    user: { id: COMMENTER, isModerator },
+    ownerId: COMMENTER,
+    locked: false,
+    track: { comment: vi.fn(), commentEvent: vi.fn() },
+  } as unknown as Parameters<typeof upsertCommentHandler>[0]['ctx'];
+}
+
+const baseInput = {
+  modelId: MODEL_ID,
+  content: '<p>hello</p>',
+} as Parameters<typeof upsertCommentHandler>[0]['input'];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  amIBlockedByUser.mockResolvedValue(false);
+  mockHasEntityAccess.mockResolvedValue([{ hasAccess: true }]);
+  modelHasOneVersion();
+  mockDb.model.findMany.mockResolvedValue([{ userId: MODEL_OWNER }]);
+});
+
+describe('upsertCommentHandler — block enforcement', () => {
+  it('throws and never writes when the commenter is blocked by the model owner', async () => {
+    amIBlockedByUser.mockResolvedValue(true);
+
+    await expect(upsertCommentHandler({ ctx: ctx(), input: baseInput })).rejects.toThrow();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({
+      userId: COMMENTER,
+      targetUserId: MODEL_OWNER,
+    });
+    expect(mockCreateOrUpdateComment).not.toHaveBeenCalled();
+  });
+
+  it('lets a non-blocked commenter write, having actually asked about the model owner', async () => {
+    await upsertCommentHandler({ ctx: ctx(), input: baseInput });
+
+    // The control for the negative case above: same setup, block flag flipped, write happens.
+    expect(amIBlockedByUser).toHaveBeenCalledWith({
+      userId: COMMENTER,
+      targetUserId: MODEL_OWNER,
+    });
+    expect(mockCreateOrUpdateComment).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws and never writes when a blocked user edits a comment written before the block', async () => {
+    mockDb.comment.findUnique.mockResolvedValue({ modelId: MODEL_ID, parentId: null });
+    amIBlockedByUser.mockResolvedValue(true);
+
+    await expect(
+      upsertCommentHandler({ ctx: ctx(), input: { ...baseInput, id: 5 } })
+    ).rejects.toThrow();
+    expect(mockCreateOrUpdateComment).not.toHaveBeenCalled();
+  });
+
+  it('checks the parent author on a reply, not only the model owner', async () => {
+    mockDb.comment.findMany.mockResolvedValue([{ userId: PARENT_AUTHOR }]);
+    amIBlockedByUser.mockImplementation(
+      async (args) => (args as { targetUserId: number }).targetUserId === PARENT_AUTHOR
+    );
+
+    await expect(
+      upsertCommentHandler({ ctx: ctx(), input: { ...baseInput, parentId: 9 } })
+    ).rejects.toThrow();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({
+      userId: COMMENTER,
+      targetUserId: PARENT_AUTHOR,
+    });
+    expect(mockCreateOrUpdateComment).not.toHaveBeenCalled();
+  });
+
+  it('exempts moderators', async () => {
+    amIBlockedByUser.mockResolvedValue(true);
+
+    await upsertCommentHandler({ ctx: ctx({ isModerator: true }), input: baseInput });
+    expect(amIBlockedByUser).not.toHaveBeenCalled();
+    expect(mockCreateOrUpdateComment).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/controllers/__tests__/resourceReview.controller.block-check.test.ts
+++ b/src/server/controllers/__tests__/resourceReview.controller.block-check.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The review handlers are the half of the block fix that makes it reach production: the guard lives
+ * in the service, but the service only knows who is acting because the handler passes it. Dropping
+ * `userId` leaves the guard asking whether an undefined user is blocked — a silent no-op on the
+ * exact path the guard exists to close — and no service-level test can see that.
+ */
+
+const { mockCreate, mockUpdate, mockUpsert, mockHasEntityAccess } = vi.hoisted(() => ({
+  mockCreate: vi.fn(
+    async (..._a: unknown[]): Promise<unknown> => ({
+      id: 1,
+      modelId: 10,
+      modelVersionId: 20,
+      recommended: true,
+    })
+  ),
+  mockUpdate: vi.fn(
+    async (..._a: unknown[]): Promise<unknown> => ({
+      id: 1,
+      modelId: 10,
+      modelVersionId: 20,
+      rating: 5,
+      nsfw: false,
+    })
+  ),
+  mockUpsert: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 1 })),
+  mockHasEntityAccess: vi.fn(async (..._a: unknown[]): Promise<unknown> => [{ hasAccess: true }]),
+}));
+
+vi.mock('~/server/services/resourceReview.service', () => ({
+  createResourceReview: (...a: unknown[]) => mockCreate(...(a as [])),
+  updateResourceReview: (...a: unknown[]) => mockUpdate(...(a as [])),
+  upsertResourceReview: (...a: unknown[]) => mockUpsert(...(a as [])),
+  deleteResourceReview: vi.fn(),
+  getUserRatingTotals: vi.fn(),
+  toggleExcludeResourceReview: vi.fn(),
+}));
+vi.mock('~/server/services/common.service', () => ({
+  hasEntityAccess: (...a: unknown[]) => mockHasEntityAccess(...(a as [])),
+}));
+import {
+  createResourceReviewHandler,
+  updateResourceReviewHandler,
+  upsertResourceReviewHandler,
+} from '../resourceReview.controller';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+const USER_ID = 7;
+
+const ctx = ({ isModerator = false } = {}) =>
+  ({
+    user: { id: USER_ID, isModerator },
+    track: { resourceReview: vi.fn() },
+  } as unknown as Parameters<typeof createResourceReviewHandler>[0]['ctx']);
+
+const createInput = {
+  modelId: 10,
+  modelVersionId: 20,
+  rating: 5,
+  recommended: true,
+  details: null,
+} as Parameters<typeof createResourceReviewHandler>[0]['input'];
+
+const updateInput = { id: 1, rating: 5, details: null } as Parameters<
+  typeof updateResourceReviewHandler
+>[0]['input'];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockHasEntityAccess.mockResolvedValue([{ hasAccess: true }]);
+});
+
+describe('resource review handlers — who the guard is told is acting', () => {
+  it('create passes the caller and their moderator status', async () => {
+    await createResourceReviewHandler({ input: createInput, ctx: ctx() });
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID, isModerator: false })
+    );
+  });
+
+  it('update passes the caller and their moderator status', async () => {
+    await updateResourceReviewHandler({ input: updateInput, ctx: ctx() });
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, userId: USER_ID, isModerator: false })
+    );
+  });
+
+  it('upsert passes the caller and their moderator status', async () => {
+    await upsertResourceReviewHandler({ input: createInput, ctx: ctx() });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID, isModerator: false })
+    );
+  });
+
+  // A moderator must arrive as one, or the guard refuses them wherever a creator has blocked them.
+  it('carries moderator status through every handler', async () => {
+    await createResourceReviewHandler({ input: createInput, ctx: ctx({ isModerator: true }) });
+    await updateResourceReviewHandler({ input: updateInput, ctx: ctx({ isModerator: true }) });
+    await upsertResourceReviewHandler({ input: createInput, ctx: ctx({ isModerator: true }) });
+
+    for (const mock of [mockCreate, mockUpdate, mockUpsert])
+      expect(mock).toHaveBeenCalledWith(expect.objectContaining({ isModerator: true }));
+  });
+});

--- a/src/server/controllers/comment.controller.ts
+++ b/src/server/controllers/comment.controller.ts
@@ -25,7 +25,10 @@ import {
   updateCommentReportStatusByReason,
 } from '~/server/services/comment.service';
 import { createNotification } from '~/server/services/notification.service';
-import { throwIfBlockedByOwners } from '~/server/services/block-check.service';
+import {
+  getBlockCheckOwnerIdsForModelComment,
+  throwIfBlockedByOwners,
+} from '~/server/services/block-check.service';
 import { amIBlockedByUser } from '~/server/services/user.service';
 import {
   throwAuthorizationError,
@@ -113,20 +116,18 @@ export const upsertCommentHandler = async ({
     const { ownerId, locked } = ctx;
     const { modelId } = input;
 
-    if (!input.id) {
-      const parentAuthorId = input.parentId
-        ? (
-            await dbRead.comment.findUnique({
-              where: { id: input.parentId },
-              select: { userId: true },
-            })
-          )?.userId
-        : undefined;
-      await throwIfBlockedByOwners({
-        userId: ctx.user.id,
-        ownerIds: [ownerId, parentAuthorId],
-      });
-    }
+    // `ownerId` is the comment's author (the caller on a create), never the model's owner, so it
+    // can't stand in for the block target. Edits are checked too: a comment written before a block
+    // is otherwise editable into anything afterwards.
+    await throwIfBlockedByOwners({
+      userId: ctx.user.id,
+      ownerIds: await getBlockCheckOwnerIdsForModelComment({
+        commentId: input.id,
+        modelId: input.modelId,
+        parentId: input.parentId,
+      }),
+      isModerator: ctx.user.isModerator,
+    });
 
     // Get model and at least 2 version to confirm access.
     // If model has 1 version, check access to that version. Otherwise, ignore.

--- a/src/server/controllers/resourceReview.controller.ts
+++ b/src/server/controllers/resourceReview.controller.ts
@@ -71,7 +71,11 @@ export const createResourceReviewHandler = async ({
       throw throwAuthorizationError('You do not have access to this model version.');
     }
 
-    const result = await createResourceReview({ ...input, userId: ctx.user.id });
+    const result = await createResourceReview({
+      ...input,
+      userId: ctx.user.id,
+      isModerator: ctx.user.isModerator,
+    });
     await ctx.track.resourceReview({
       type: 'Create',
       modelId: result.modelId,
@@ -96,7 +100,11 @@ export const updateResourceReviewHandler = async ({
   ctx: ProtectedContext;
 }) => {
   try {
-    const result = await updateResourceReview({ ...input });
+    const result = await updateResourceReview({
+      ...input,
+      userId: ctx.user.id,
+      isModerator: ctx.user.isModerator,
+    });
     await ctx.track.resourceReview({
       type: 'Update',
       modelId: result.modelId,

--- a/src/server/services/__tests__/block-check.service.test.ts
+++ b/src/server/services/__tests__/block-check.service.test.ts
@@ -18,6 +18,7 @@ vi.mock('~/server/services/user.service', () => ({ amIBlockedByUser }));
 
 import {
   getBlockCheckOwnerIds,
+  getBlockCheckOwnerIdsForModelComment,
   throwIfBlockedByEntityOwner,
   throwIfBlockedByOwners,
 } from '~/server/services/block-check.service';
@@ -169,6 +170,68 @@ describe('getBlockCheckOwnerIds — owner resolution per entity type', () => {
   it('returns [] when the entity does not exist', async () => {
     mockDb.image.findUnique.mockResolvedValueOnce(null);
     expect(await getBlockCheckOwnerIds({ entityType: 'image', entityId: 1 })).toEqual([]);
+  });
+});
+
+describe('getBlockCheckOwnerIdsForModelComment — legacy model comments', () => {
+  const PARENT_AUTHOR = 55;
+  const OTHER_OWNER = 200;
+
+  it('resolves the model owner for a new top-level comment', async () => {
+    mockDb.model.findMany.mockResolvedValueOnce([{ userId: OWNER }]);
+    expect(await getBlockCheckOwnerIdsForModelComment({ modelId: 1 })).toEqual([OWNER]);
+    expect(mockDb.model.findMany).toHaveBeenCalledWith({
+      where: { id: { in: [1] } },
+      select: { userId: true },
+    });
+  });
+
+  it('resolves the parent author as well as the model owner for a reply', async () => {
+    mockDb.model.findMany.mockResolvedValueOnce([{ userId: OWNER }]);
+    mockDb.comment.findMany.mockResolvedValueOnce([{ userId: PARENT_AUTHOR }]);
+    expect(await getBlockCheckOwnerIdsForModelComment({ modelId: 1, parentId: 9 })).toEqual([
+      OWNER,
+      PARENT_AUTHOR,
+    ]);
+  });
+
+  it('resolves an edit target from the stored comment, not only the request', async () => {
+    // The stored comment lives on model 1; the request re-homes it onto model 2.
+    mockDb.comment.findUnique.mockResolvedValueOnce({ modelId: 1, parentId: null });
+    mockDb.model.findMany.mockResolvedValueOnce([{ userId: OTHER_OWNER }, { userId: OWNER }]);
+
+    expect(await getBlockCheckOwnerIdsForModelComment({ commentId: 5, modelId: 2 })).toEqual([
+      OTHER_OWNER,
+      OWNER,
+    ]);
+    expect(mockDb.comment.findUnique).toHaveBeenCalledWith({
+      where: { id: 5 },
+      select: { modelId: true, parentId: true },
+    });
+    // Both ends of the move are looked up — dropping either would let a re-home escape the block.
+    expect(mockDb.model.findMany).toHaveBeenCalledWith({
+      where: { id: { in: [2, 1] } },
+      select: { userId: true },
+    });
+  });
+
+  it('resolves the stored parent author on an edit', async () => {
+    mockDb.comment.findUnique.mockResolvedValueOnce({ modelId: 1, parentId: 9 });
+    mockDb.model.findMany.mockResolvedValueOnce([{ userId: OWNER }]);
+    mockDb.comment.findMany.mockResolvedValueOnce([{ userId: PARENT_AUTHOR }]);
+
+    expect(await getBlockCheckOwnerIdsForModelComment({ commentId: 5, modelId: 1 })).toEqual([
+      OWNER,
+      PARENT_AUTHOR,
+    ]);
+    expect(mockDb.comment.findMany).toHaveBeenCalledWith({
+      where: { id: { in: [9] } },
+      select: { userId: true },
+    });
+  });
+
+  it('returns [] when nothing resolves', async () => {
+    expect(await getBlockCheckOwnerIdsForModelComment({ commentId: 5 })).toEqual([]);
   });
 });
 

--- a/src/server/services/__tests__/block-check.service.test.ts
+++ b/src/server/services/__tests__/block-check.service.test.ts
@@ -278,6 +278,33 @@ describe('throwIfBlockedByEntityOwner — enforcement', () => {
     expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: VIEWER, targetUserId: OWNER });
   });
 
+  // `commentOld` has one consumer, `toggleReaction` (reaction.service.ts) — the legacy comment
+  // surface has no reaction of its own. Widening the arm to the model owner therefore changes
+  // reaction behaviour: reacting to somebody else's comment under a blocker's model now refuses.
+  it('refuses a reaction on a legacy comment when the MODEL owner blocks, not just the author', async () => {
+    const COMMENT_AUTHOR = 55;
+    mockDb.comment.findUnique.mockResolvedValue({ userId: COMMENT_AUTHOR, modelId: 3 });
+    mockDb.model.findUnique.mockResolvedValue({ userId: OWNER });
+    amIBlockedByUser.mockImplementation(
+      async (args) => (args as { targetUserId: number }).targetUserId === OWNER
+    );
+
+    await expect(
+      throwIfBlockedByEntityOwner({ userId: VIEWER, entityType: 'commentOld', entityId: 1 })
+    ).rejects.toThrow();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: VIEWER, targetUserId: OWNER });
+  });
+
+  it('allows that reaction when neither the author nor the model owner blocks', async () => {
+    mockDb.comment.findUnique.mockResolvedValue({ userId: 55, modelId: 3 });
+    mockDb.model.findUnique.mockResolvedValue({ userId: OWNER });
+
+    await expect(
+      throwIfBlockedByEntityOwner({ userId: VIEWER, entityType: 'commentOld', entityId: 1 })
+    ).resolves.toBeUndefined();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: VIEWER, targetUserId: OWNER });
+  });
+
   it('rejects a blocked user creating a model3d comment', async () => {
     mockDb.model3D.findUnique.mockResolvedValueOnce({ userId: OWNER });
     amIBlockedByUser.mockResolvedValueOnce(true);

--- a/src/server/services/__tests__/block-check.service.test.ts
+++ b/src/server/services/__tests__/block-check.service.test.ts
@@ -61,8 +61,8 @@ describe('getBlockCheckOwnerIds — owner resolution per entity type', () => {
   // reaction path (the only `commentOld` consumer) open under a blocker's model.
   it('resolves the legacy comment (commentOld) author and the model owner', async () => {
     const COMMENT_AUTHOR = 55;
-    mockDb.comment.findUnique.mockResolvedValue({ userId: COMMENT_AUTHOR, modelId: 3 });
-    mockDb.model.findUnique.mockResolvedValue({ userId: OWNER });
+    mockDb.comment.findUnique.mockResolvedValueOnce({ userId: COMMENT_AUTHOR, modelId: 3 });
+    mockDb.model.findUnique.mockResolvedValueOnce({ userId: OWNER });
 
     expect(await getBlockCheckOwnerIds({ entityType: 'commentOld', entityId: 1 })).toEqual([
       COMMENT_AUTHOR,
@@ -75,7 +75,7 @@ describe('getBlockCheckOwnerIds — owner resolution per entity type', () => {
   });
 
   it('resolves nothing for a legacy comment that no longer exists', async () => {
-    mockDb.comment.findUnique.mockResolvedValue(null);
+    mockDb.comment.findUnique.mockResolvedValueOnce(null);
     expect(await getBlockCheckOwnerIds({ entityType: 'commentOld', entityId: 1 })).toEqual([]);
   });
 

--- a/src/server/services/__tests__/block-check.service.test.ts
+++ b/src/server/services/__tests__/block-check.service.test.ts
@@ -57,9 +57,26 @@ describe('getBlockCheckOwnerIds — owner resolution per entity type', () => {
     ]);
   });
 
-  it('resolves the legacy comment (commentOld) author', async () => {
-    mockDb.comment.findUnique.mockResolvedValueOnce({ userId: OWNER });
-    expect(await getBlockCheckOwnerIds({ entityType: 'commentOld', entityId: 1 })).toEqual([OWNER]);
+  // Author AND the model owner, matching the `comment` branch below. Author alone left the
+  // reaction path (the only `commentOld` consumer) open under a blocker's model.
+  it('resolves the legacy comment (commentOld) author and the model owner', async () => {
+    const COMMENT_AUTHOR = 55;
+    mockDb.comment.findUnique.mockResolvedValue({ userId: COMMENT_AUTHOR, modelId: 3 });
+    mockDb.model.findUnique.mockResolvedValue({ userId: OWNER });
+
+    expect(await getBlockCheckOwnerIds({ entityType: 'commentOld', entityId: 1 })).toEqual([
+      COMMENT_AUTHOR,
+      OWNER,
+    ]);
+    expect(mockDb.model.findUnique).toHaveBeenCalledWith({
+      where: { id: 3 },
+      select: { userId: true },
+    });
+  });
+
+  it('resolves nothing for a legacy comment that no longer exists', async () => {
+    mockDb.comment.findUnique.mockResolvedValue(null);
+    expect(await getBlockCheckOwnerIds({ entityType: 'commentOld', entityId: 1 })).toEqual([]);
   });
 
   it('reply target (comment): resolves BOTH parent author and root content owner', async () => {
@@ -176,61 +193,77 @@ describe('getBlockCheckOwnerIds — owner resolution per entity type', () => {
 describe('getBlockCheckOwnerIdsForModelComment — legacy model comments', () => {
   const PARENT_AUTHOR = 55;
   const OTHER_OWNER = 200;
+  const STORED_MODEL = 1;
+  const REQUEST_MODEL = 2;
+  const PARENT_ID = 9;
+
+  // Keyed on the id asked for rather than on call order: the resolver reads models and comments
+  // through the shared switch, so a `…Once` queue here would be consumed by whichever lookup ran
+  // first and the assertion would pass on an empty answer.
+  const owners = ({
+    models = {},
+    comments = {},
+  }: {
+    models?: Record<number, number>;
+    comments?: Record<number, { userId: number; modelId: number }>;
+  }) => {
+    mockDb.model.findUnique.mockImplementation(async (args: unknown) => {
+      const id = (args as { where: { id: number } }).where.id;
+      return models[id] ? { userId: models[id] } : null;
+    });
+    mockDb.comment.findUnique.mockImplementation(async (args: unknown) => {
+      const id = (args as { where: { id: number } }).where.id;
+      return comments[id] ?? null;
+    });
+  };
 
   it('resolves the model owner for a new top-level comment', async () => {
-    mockDb.model.findMany.mockResolvedValueOnce([{ userId: OWNER }]);
-    expect(await getBlockCheckOwnerIdsForModelComment({ modelId: 1 })).toEqual([OWNER]);
-    expect(mockDb.model.findMany).toHaveBeenCalledWith({
-      where: { id: { in: [1] } },
-      select: { userId: true },
-    });
+    owners({ models: { [REQUEST_MODEL]: OWNER } });
+    expect(await getBlockCheckOwnerIdsForModelComment({ modelId: REQUEST_MODEL })).toEqual([OWNER]);
   });
 
   it('resolves the parent author as well as the model owner for a reply', async () => {
-    mockDb.model.findMany.mockResolvedValueOnce([{ userId: OWNER }]);
-    mockDb.comment.findMany.mockResolvedValueOnce([{ userId: PARENT_AUTHOR }]);
-    expect(await getBlockCheckOwnerIdsForModelComment({ modelId: 1, parentId: 9 })).toEqual([
-      OWNER,
-      PARENT_AUTHOR,
-    ]);
+    owners({
+      models: { [REQUEST_MODEL]: OWNER },
+      comments: { [PARENT_ID]: { userId: PARENT_AUTHOR, modelId: REQUEST_MODEL } },
+    });
+    expect(
+      await getBlockCheckOwnerIdsForModelComment({ modelId: REQUEST_MODEL, parentId: PARENT_ID })
+    ).toEqual([OWNER, PARENT_AUTHOR]);
   });
 
   it('resolves an edit target from the stored comment, not only the request', async () => {
-    // The stored comment lives on model 1; the request re-homes it onto model 2.
-    mockDb.comment.findUnique.mockResolvedValueOnce({ modelId: 1, parentId: null });
-    mockDb.model.findMany.mockResolvedValueOnce([{ userId: OTHER_OWNER }, { userId: OWNER }]);
+    // Stored on a model owned by OTHER_OWNER; the request re-homes it onto one owned by OWNER.
+    owners({
+      models: { [STORED_MODEL]: OTHER_OWNER, [REQUEST_MODEL]: OWNER },
+      comments: { 5: { userId: 42, modelId: STORED_MODEL } },
+    });
 
-    expect(await getBlockCheckOwnerIdsForModelComment({ commentId: 5, modelId: 2 })).toEqual([
-      OTHER_OWNER,
-      OWNER,
-    ]);
+    expect(
+      await getBlockCheckOwnerIdsForModelComment({ commentId: 5, modelId: REQUEST_MODEL })
+    ).toEqual([OWNER, OTHER_OWNER]);
     expect(mockDb.comment.findUnique).toHaveBeenCalledWith({
       where: { id: 5 },
       select: { modelId: true, parentId: true },
     });
-    // Both ends of the move are looked up — dropping either would let a re-home escape the block.
-    expect(mockDb.model.findMany).toHaveBeenCalledWith({
-      where: { id: { in: [2, 1] } },
-      select: { userId: true },
-    });
   });
 
   it('resolves the stored parent author on an edit', async () => {
-    mockDb.comment.findUnique.mockResolvedValueOnce({ modelId: 1, parentId: 9 });
-    mockDb.model.findMany.mockResolvedValueOnce([{ userId: OWNER }]);
-    mockDb.comment.findMany.mockResolvedValueOnce([{ userId: PARENT_AUTHOR }]);
-
-    expect(await getBlockCheckOwnerIdsForModelComment({ commentId: 5, modelId: 1 })).toEqual([
-      OWNER,
-      PARENT_AUTHOR,
-    ]);
-    expect(mockDb.comment.findMany).toHaveBeenCalledWith({
-      where: { id: { in: [9] } },
-      select: { userId: true },
+    owners({
+      models: { [STORED_MODEL]: OWNER },
+      comments: {
+        5: { userId: 42, modelId: STORED_MODEL, parentId: PARENT_ID } as never,
+        [PARENT_ID]: { userId: PARENT_AUTHOR, modelId: STORED_MODEL },
+      },
     });
+
+    expect(
+      await getBlockCheckOwnerIdsForModelComment({ commentId: 5, modelId: STORED_MODEL })
+    ).toEqual([OWNER, PARENT_AUTHOR]);
   });
 
   it('returns [] when nothing resolves', async () => {
+    owners({});
     expect(await getBlockCheckOwnerIdsForModelComment({ commentId: 5 })).toEqual([]);
   });
 });

--- a/src/server/services/__tests__/model3d-review.block-check.service.test.ts
+++ b/src/server/services/__tests__/model3d-review.block-check.service.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A 3D-model review is user-authored text on someone else's model, the same shape as a resource
+ * review — but it called no block guard on either branch, so a blocked user could review, and keep
+ * editing a review of, a model whose owner had blocked them. Comment threads hanging off such a
+ * review were already guarded, which made the surface look covered.
+ */
+
+const { amIBlockedByUser } = vi.hoisted(() => ({
+  amIBlockedByUser: vi.fn(async (..._a: unknown[]): Promise<boolean> => false),
+}));
+
+vi.mock('~/server/services/user.service', () => ({ amIBlockedByUser }));
+
+import { upsertModel3DReview } from '../model3d-review.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const OWNER = 100;
+const REVIEWER = 7;
+const MODEL_3D_ID = 3;
+const REVIEW_ID = 5;
+
+const user = ({ isModerator = false } = {}) =>
+  ({ id: REVIEWER, isModerator } as unknown as Parameters<typeof upsertModel3DReview>[0]['user']);
+
+const input = { model3dId: MODEL_3D_ID, recommended: true, details: null } as Parameters<
+  typeof upsertModel3DReview
+>[0]['input'];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  amIBlockedByUser.mockResolvedValue(false);
+  // Published model owned by OWNER. `status` matches the published check the service makes.
+  dbMock.dbRead.model3D.findUnique.mockResolvedValue({
+    id: MODEL_3D_ID,
+    userId: OWNER,
+    status: 'Published',
+    deletedAt: null,
+  });
+  dbMock.dbRead.model3DReview.findUnique.mockResolvedValue(null);
+  dbMock.dbWrite.model3DReview.findUnique.mockResolvedValue({
+    id: REVIEW_ID,
+    userId: REVIEWER,
+    model3dId: MODEL_3D_ID,
+  });
+  dbMock.dbWrite.model3DReview.create.mockResolvedValue({ id: REVIEW_ID });
+  dbMock.dbWrite.model3DReview.update.mockResolvedValue({ id: REVIEW_ID });
+});
+
+describe('upsertModel3DReview — block enforcement', () => {
+  it('refuses a new review when the 3D model owner blocks the reviewer', async () => {
+    amIBlockedByUser.mockResolvedValue(true);
+
+    await expect(upsertModel3DReview({ input, user: user() })).rejects.toThrow();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: REVIEWER, targetUserId: OWNER });
+    expect(dbMock.dbWrite.model3DReview.create).not.toHaveBeenCalled();
+  });
+
+  it('writes the review when nobody blocks', async () => {
+    await expect(upsertModel3DReview({ input, user: user() })).resolves.toBeDefined();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: REVIEWER, targetUserId: OWNER });
+    expect(dbMock.dbWrite.model3DReview.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses an edit of a review written before the block', async () => {
+    amIBlockedByUser.mockResolvedValue(true);
+
+    await expect(
+      upsertModel3DReview({ input: { ...input, id: REVIEW_ID }, user: user() })
+    ).rejects.toThrow();
+    expect(dbMock.dbWrite.model3DReview.update).not.toHaveBeenCalled();
+  });
+
+  it('lets a non-blocked author edit', async () => {
+    await expect(
+      upsertModel3DReview({ input: { ...input, id: REVIEW_ID }, user: user() })
+    ).resolves.toBeDefined();
+    expect(dbMock.dbWrite.model3DReview.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('exempts moderators', async () => {
+    amIBlockedByUser.mockResolvedValue(true);
+
+    await expect(
+      upsertModel3DReview({ input, user: user({ isModerator: true }) })
+    ).resolves.toBeDefined();
+    expect(amIBlockedByUser).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.model3DReview.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/__tests__/resourceReview.idempotent.service.test.ts
+++ b/src/server/services/__tests__/resourceReview.idempotent.service.test.ts
@@ -9,7 +9,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { Prisma } from '@prisma/client';
 
-const { mockDb } = vi.hoisted(() => ({
+const { mockDb, amIBlockedByUser } = vi.hoisted(() => ({
+  amIBlockedByUser: vi.fn(async (..._a: unknown[]): Promise<boolean> => false),
   mockDb: {
     user: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     // createResourceReviewNotification (fired best-effort after the create
@@ -19,6 +20,8 @@ const { mockDb } = vi.hoisted(() => ({
     model: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ userId: 1 })) },
     imageResourceNew: { count: vi.fn(async (..._a: unknown[]): Promise<number> => 0) },
     resourceReview: {
+      // The edit branch resolves the review's stored model before the block check.
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
       update: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
       findUniqueOrThrow: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
@@ -49,7 +52,7 @@ vi.mock('~/server/services/user-preferences.service', () => ({
   HiddenUsers: { getCached: vi.fn(async () => []) },
 }));
 vi.mock('~/server/services/user.service', () => ({
-  amIBlockedByUser: vi.fn(async () => false),
+  amIBlockedByUser,
   getBasicDataForUsers: vi.fn(async () => new Map()),
   getCosmeticsForUsers: vi.fn(async () => ({})),
   getProfilePicturesForUsers: vi.fn(async () => ({})),
@@ -78,6 +81,9 @@ const baseInput = {
 beforeEach(() => {
   vi.clearAllMocks();
   mockDb.user.findFirst.mockResolvedValue({ username: 'tester' });
+  amIBlockedByUser.mockResolvedValue(false);
+  mockDb.model.findUnique.mockResolvedValue({ userId: 1 });
+  mockDb.resourceReview.findUnique.mockResolvedValue(null);
 });
 
 describe('createResourceReview — idempotent on P2002 race', () => {
@@ -117,5 +123,49 @@ describe('upsertResourceReview (create branch) — idempotent on P2002 race', ()
         where: { modelVersionId_userId: { modelVersionId: 20, userId: 42 } },
       })
     );
+  });
+});
+
+/**
+ * A review written before a block stayed editable afterwards: the guard ran on create only, and an
+ * edit writes `modelId` through from the request while being scoped by review id — so it could also
+ * be re-homed onto a model whose owner had blocked the author.
+ */
+describe('upsertResourceReview (edit branch) — block enforcement', () => {
+  const OWNER = 1;
+  const OTHER_OWNER = 2;
+  const AUTHOR = 42;
+
+  it('throws and never updates when the author is blocked by the stored model owner', async () => {
+    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: 10 });
+    amIBlockedByUser.mockResolvedValue(true);
+
+    await expect(upsertResourceReview({ ...baseInput, id: 7, userId: AUTHOR })).rejects.toThrow();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: AUTHOR, targetUserId: OWNER });
+    expect(mockDb.resourceReview.update).not.toHaveBeenCalled();
+  });
+
+  it('updates when the author is not blocked', async () => {
+    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: 10 });
+    mockDb.resourceReview.update.mockResolvedValueOnce({ id: 7, modelId: 10, modelVersionId: 20 });
+
+    await upsertResourceReview({ ...baseInput, id: 7, userId: AUTHOR });
+
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: AUTHOR, targetUserId: OWNER });
+    expect(mockDb.resourceReview.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks the model the edit points at, not only the one it is stored on', async () => {
+    // Stored on model 11 (owner 1, no block); the request re-homes it onto model 10 (owner 2).
+    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: 11 });
+    mockDb.model.findUnique.mockImplementation(async (args: unknown) => ({
+      userId: (args as { where: { id: number } }).where.id === 10 ? OTHER_OWNER : OWNER,
+    }));
+    amIBlockedByUser.mockImplementation(
+      async (args) => (args as { targetUserId: number }).targetUserId === OTHER_OWNER
+    );
+
+    await expect(upsertResourceReview({ ...baseInput, id: 7, userId: AUTHOR })).rejects.toThrow();
+    expect(mockDb.resourceReview.update).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/resourceReview.idempotent.service.test.ts
+++ b/src/server/services/__tests__/resourceReview.idempotent.service.test.ts
@@ -141,6 +141,9 @@ describe('resource review writes — block enforcement', () => {
 
   // Keyed on the model asked for, so an assertion about the stored model cannot be satisfied by a
   // lookup of the requested one.
+  // This file aliases dbRead and dbWrite to one object, so nothing here can tell which client the
+  // stored-review lookup uses. It reads through the writer on purpose — see the comment there — and
+  // that choice is untested.
   const owners = (byModelId: Record<number, number>) =>
     mockDb.model.findUnique.mockImplementation(async (args: unknown) => {
       const id = (args as { where: { id: number } }).where.id;
@@ -245,6 +248,40 @@ describe('resource review writes — block enforcement', () => {
       userId: AUTHOR,
       isModerator: true,
     });
+    // The upsert branch too — it is the one with two model ids to resolve, so it is the one where
+    // a dropped `isModerator` would refuse a moderator twice over.
+    await upsertResourceReview({
+      ...baseInput,
+      id: 7,
+      modelId: REQUEST_MODEL,
+      userId: AUTHOR,
+      isModerator: true,
+    });
     expect(amIBlockedByUser).not.toHaveBeenCalled();
+  });
+
+  // `userId` and `isModerator` are guard inputs, not columns. They reach these functions as part of
+  // one object, so a destructure that stops pulling them out sends them into the Prisma payload:
+  // on `update` that rewrites the review's author, since the row is scoped by id alone and a
+  // moderator may edit someone else's review.
+  it('keeps the guard inputs out of the Prisma payload', async () => {
+    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: STORED_MODEL });
+    mockDb.resourceReview.update.mockResolvedValue({ id: 7, modelId: 11, modelVersionId: 20 });
+
+    await updateResourceReview({ id: 7, rating: 5, details: null, userId: AUTHOR });
+    const updateArgs = mockDb.resourceReview.update.mock.calls[0][0] as { data: object };
+    expect(updateArgs.data).not.toHaveProperty('userId');
+    expect(updateArgs.data).not.toHaveProperty('isModerator');
+
+    await createResourceReview({
+      ...baseInput,
+      modelId: REQUEST_MODEL,
+      userId: AUTHOR,
+      isModerator: true,
+    });
+    const createArgs = mockDb.resourceReview.create.mock.calls[0][0] as { data: object };
+    // `userId` IS a column on create — the review's author. `isModerator` never is.
+    expect(createArgs.data).toHaveProperty('userId', AUTHOR);
+    expect(createArgs.data).not.toHaveProperty('isModerator');
   });
 });

--- a/src/server/services/__tests__/resourceReview.idempotent.service.test.ts
+++ b/src/server/services/__tests__/resourceReview.idempotent.service.test.ts
@@ -60,6 +60,7 @@ vi.mock('~/server/services/user.service', () => ({
 
 import {
   createResourceReview,
+  updateResourceReview,
   upsertResourceReview,
 } from '~/server/services/resourceReview.service';
 
@@ -127,45 +128,123 @@ describe('upsertResourceReview (create branch) — idempotent on P2002 race', ()
 });
 
 /**
- * A review written before a block stayed editable afterwards: the guard ran on create only, and an
- * edit writes `modelId` through from the request while being scoped by review id — so it could also
- * be re-homed onto a model whose owner had blocked the author.
+ * Blocking on the review write paths. `upsertResourceReview` guarded creates only, so a review
+ * written before a block stayed editable afterwards — and the two procedures the review UI actually
+ * calls, `create` and `update`, had no check at all.
  */
-describe('upsertResourceReview (edit branch) — block enforcement', () => {
-  const OWNER = 1;
-  const OTHER_OWNER = 2;
+describe('resource review writes — block enforcement', () => {
+  const STORED_OWNER = 1;
+  const REQUEST_OWNER = 2;
   const AUTHOR = 42;
+  const STORED_MODEL = 11;
+  const REQUEST_MODEL = 10;
 
-  it('throws and never updates when the author is blocked by the stored model owner', async () => {
-    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: 10 });
-    amIBlockedByUser.mockResolvedValue(true);
+  // Keyed on the model asked for, so an assertion about the stored model cannot be satisfied by a
+  // lookup of the requested one.
+  const owners = (byModelId: Record<number, number>) =>
+    mockDb.model.findUnique.mockImplementation(async (args: unknown) => {
+      const id = (args as { where: { id: number } }).where.id;
+      return byModelId[id] ? { userId: byModelId[id] } : null;
+    });
 
-    await expect(upsertResourceReview({ ...baseInput, id: 7, userId: AUTHOR })).rejects.toThrow();
-    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: AUTHOR, targetUserId: OWNER });
+  const blockedBy = (...userIds: number[]) =>
+    amIBlockedByUser.mockImplementation(async (args) =>
+      userIds.includes((args as { targetUserId: number }).targetUserId)
+    );
+
+  beforeEach(() => {
+    owners({ [REQUEST_MODEL]: REQUEST_OWNER, [STORED_MODEL]: STORED_OWNER });
+  });
+
+  it('refuses an upsert edit when the review is stored on a model whose owner blocks', async () => {
+    // Only the STORED model's owner blocks — this passes if the edit trusts the request's modelId.
+    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: STORED_MODEL });
+    blockedBy(STORED_OWNER);
+
+    await expect(
+      upsertResourceReview({ ...baseInput, id: 7, modelId: REQUEST_MODEL, userId: AUTHOR })
+    ).rejects.toThrow();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: AUTHOR, targetUserId: STORED_OWNER });
     expect(mockDb.resourceReview.update).not.toHaveBeenCalled();
   });
 
-  it('updates when the author is not blocked', async () => {
-    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: 10 });
+  it('refuses an upsert edit re-homing onto a model whose owner blocks', async () => {
+    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: STORED_MODEL });
+    blockedBy(REQUEST_OWNER);
+
+    await expect(
+      upsertResourceReview({ ...baseInput, id: 7, modelId: REQUEST_MODEL, userId: AUTHOR })
+    ).rejects.toThrow();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: AUTHOR, targetUserId: REQUEST_OWNER });
+    expect(mockDb.resourceReview.update).not.toHaveBeenCalled();
+  });
+
+  it('lets a non-blocked author edit', async () => {
+    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: STORED_MODEL });
     mockDb.resourceReview.update.mockResolvedValueOnce({ id: 7, modelId: 10, modelVersionId: 20 });
 
-    await upsertResourceReview({ ...baseInput, id: 7, userId: AUTHOR });
+    await upsertResourceReview({ ...baseInput, id: 7, modelId: REQUEST_MODEL, userId: AUTHOR });
 
-    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: AUTHOR, targetUserId: OWNER });
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: AUTHOR, targetUserId: STORED_OWNER });
     expect(mockDb.resourceReview.update).toHaveBeenCalledTimes(1);
   });
 
-  it('checks the model the edit points at, not only the one it is stored on', async () => {
-    // Stored on model 11 (owner 1, no block); the request re-homes it onto model 10 (owner 2).
-    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: 11 });
-    mockDb.model.findUnique.mockImplementation(async (args: unknown) => ({
-      userId: (args as { where: { id: number } }).where.id === 10 ? OTHER_OWNER : OWNER,
-    }));
-    amIBlockedByUser.mockImplementation(
-      async (args) => (args as { targetUserId: number }).targetUserId === OTHER_OWNER
-    );
+  // `resourceReview.create` / `.update` are the procedures the review UI calls; `upsert` is only
+  // reached from the edit-review modal. Guarding upsert alone left the ordinary path open.
+  it('refuses a create on a model whose owner blocks', async () => {
+    blockedBy(REQUEST_OWNER);
 
-    await expect(upsertResourceReview({ ...baseInput, id: 7, userId: AUTHOR })).rejects.toThrow();
+    await expect(
+      createResourceReview({ ...baseInput, modelId: REQUEST_MODEL, userId: AUTHOR })
+    ).rejects.toThrow();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: AUTHOR, targetUserId: REQUEST_OWNER });
+    expect(mockDb.resourceReview.create).not.toHaveBeenCalled();
+  });
+
+  it('allows a create when nobody blocks', async () => {
+    await createResourceReview({ ...baseInput, modelId: REQUEST_MODEL, userId: AUTHOR });
+    expect(mockDb.resourceReview.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses an update, resolving the model from the stored review', async () => {
+    // `update` carries no modelId at all, so the stored review is the only place the target can
+    // come from.
+    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: STORED_MODEL });
+    blockedBy(STORED_OWNER);
+
+    await expect(
+      updateResourceReview({ id: 7, rating: 5, details: null, userId: AUTHOR })
+    ).rejects.toThrow();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: AUTHOR, targetUserId: STORED_OWNER });
     expect(mockDb.resourceReview.update).not.toHaveBeenCalled();
+  });
+
+  it('allows an update when nobody blocks', async () => {
+    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: STORED_MODEL });
+    mockDb.resourceReview.update.mockResolvedValueOnce({ id: 7, modelId: 11, modelVersionId: 20 });
+
+    await updateResourceReview({ id: 7, rating: 5, details: null, userId: AUTHOR });
+    expect(mockDb.resourceReview.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('exempts moderators on every branch', async () => {
+    mockDb.resourceReview.findUnique.mockResolvedValue({ modelId: STORED_MODEL });
+    mockDb.resourceReview.update.mockResolvedValue({ id: 7, modelId: 11, modelVersionId: 20 });
+    blockedBy(STORED_OWNER, REQUEST_OWNER);
+
+    await updateResourceReview({
+      id: 7,
+      rating: 5,
+      details: null,
+      userId: AUTHOR,
+      isModerator: true,
+    });
+    await createResourceReview({
+      ...baseInput,
+      modelId: REQUEST_MODEL,
+      userId: AUTHOR,
+      isModerator: true,
+    });
+    expect(amIBlockedByUser).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/block-check.service.ts
+++ b/src/server/services/block-check.service.ts
@@ -205,6 +205,58 @@ export async function getBlockCheckOwnerIdsForComment(commentId: number): Promis
   return [...ids];
 }
 
+/**
+ * Owners to check for a write on the legacy model-comment surface (`Comment`).
+ *
+ * A create is aimed by the request; an edit writes `modelId`/`parentId` through from the request
+ * while being scoped by comment id alone, so an edit can re-home a comment onto another model or
+ * under another parent. Both the comment's stored home and the one the request names are resolved,
+ * so neither end of a move escapes the block. The writer's own id may come back among them —
+ * `throwIfBlockedByOwners` skips self.
+ */
+export async function getBlockCheckOwnerIdsForModelComment({
+  commentId,
+  modelId,
+  parentId,
+}: {
+  commentId?: number | null;
+  modelId?: number | null;
+  parentId?: number | null;
+}): Promise<number[]> {
+  const modelIds = new Set<number>();
+  const parentIds = new Set<number>();
+  if (modelId) modelIds.add(modelId);
+  if (parentId) parentIds.add(parentId);
+
+  if (commentId) {
+    const stored = await dbRead.comment.findUnique({
+      where: { id: commentId },
+      select: { modelId: true, parentId: true },
+    });
+    if (stored) {
+      modelIds.add(stored.modelId);
+      if (stored.parentId) parentIds.add(stored.parentId);
+    }
+  }
+
+  const ids = new Set<number>();
+  if (modelIds.size) {
+    const models = await dbRead.model.findMany({
+      where: { id: { in: [...modelIds] } },
+      select: { userId: true },
+    });
+    for (const model of models) ids.add(model.userId);
+  }
+  if (parentIds.size) {
+    const parents = await dbRead.comment.findMany({
+      where: { id: { in: [...parentIds] } },
+      select: { userId: true },
+    });
+    for (const parent of parents) ids.add(parent.userId);
+  }
+  return [...ids];
+}
+
 // Resolves the content owner user id(s) relevant to an interaction on a given
 // entity, so we can enforce user-blocking on write paths (comment/reaction).
 export async function getBlockCheckOwnerIds({

--- a/src/server/services/block-check.service.ts
+++ b/src/server/services/block-check.service.ts
@@ -239,21 +239,15 @@ export async function getBlockCheckOwnerIdsForModelComment({
     }
   }
 
+  // Resolved through the switch rather than by reading the rows here, so a rule added to either
+  // entity type (a deleted model, a transferred owner) reaches this path too. At most two ids each.
   const ids = new Set<number>();
-  if (modelIds.size) {
-    const models = await dbRead.model.findMany({
-      where: { id: { in: [...modelIds] } },
-      select: { userId: true },
-    });
-    for (const model of models) ids.add(model.userId);
-  }
-  if (parentIds.size) {
-    const parents = await dbRead.comment.findMany({
-      where: { id: { in: [...parentIds] } },
-      select: { userId: true },
-    });
-    for (const parent of parents) ids.add(parent.userId);
-  }
+  for (const id of modelIds)
+    for (const owner of await getBlockCheckOwnerIds({ entityType: 'model', entityId: id }))
+      ids.add(owner);
+  for (const id of parentIds)
+    for (const owner of await getBlockCheckOwnerIds({ entityType: 'commentOld', entityId: id }))
+      ids.add(owner);
   return [...ids];
 }
 
@@ -329,11 +323,21 @@ export async function getBlockCheckOwnerIds({
       return r?.userId ? [r.userId] : [];
     }
     case 'commentOld': {
+      // Author AND the owner of the model the comment hangs off, mirroring `comment` above. The
+      // author alone still let a blocked user interact under a blocker's model, as long as the
+      // comment they aimed at belonged to somebody else.
       const r = await dbRead.comment.findUnique({
         where: { id: entityId },
+        select: { userId: true, modelId: true },
+      });
+      if (!r) return [];
+      const ids = new Set<number>([r.userId]);
+      const model = await dbRead.model.findUnique({
+        where: { id: r.modelId },
         select: { userId: true },
       });
-      return r ? [r.userId] : [];
+      if (model) ids.add(model.userId);
+      return [...ids];
     }
     case 'model3d': {
       const r = await dbRead.model3D.findUnique({

--- a/src/server/services/block-check.service.ts
+++ b/src/server/services/block-check.service.ts
@@ -332,11 +332,8 @@ export async function getBlockCheckOwnerIds({
       });
       if (!r) return [];
       const ids = new Set<number>([r.userId]);
-      const model = await dbRead.model.findUnique({
-        where: { id: r.modelId },
-        select: { userId: true },
-      });
-      if (model) ids.add(model.userId);
+      for (const owner of await getBlockCheckOwnerIds({ entityType: 'model', entityId: r.modelId }))
+        ids.add(owner);
       return [...ids];
     }
     case 'model3d': {

--- a/src/server/services/model3d-review.service.ts
+++ b/src/server/services/model3d-review.service.ts
@@ -115,7 +115,7 @@ export const upsertModel3DReview = async ({
   await throwIfBlockedByOwners({
     userId: user.id,
     ownerIds: [model3d.userId],
-    isModerator: false,
+    isModerator: !!user.isModerator,
   });
 
   // If a postId is provided, validate it actually exists + belongs to this user

--- a/src/server/services/model3d-review.service.ts
+++ b/src/server/services/model3d-review.service.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { throwIfBlockedByOwners } from '~/server/services/block-check.service';
 import {
   throwAuthorizationError,
   throwBadRequestError,
@@ -107,6 +108,15 @@ export const upsertModel3DReview = async ({
   ) {
     throw throwBadRequestError('Cannot review a 3D model that has not been published.');
   }
+
+  // A review is content on someone else's model, so the owner's block applies here as it does on
+  // comments and resource reviews. Edits included — a review written before a block would otherwise
+  // stay editable into anything afterwards; re-homing is already refused below.
+  await throwIfBlockedByOwners({
+    userId: user.id,
+    ownerIds: [model3d.userId],
+    isModerator: !!user.isModerator,
+  });
 
   // If a postId is provided, validate it actually exists + belongs to this user
   // (or a mod). Post.model3dReviewId is @unique, so we have to be careful to

--- a/src/server/services/model3d-review.service.ts
+++ b/src/server/services/model3d-review.service.ts
@@ -115,7 +115,7 @@ export const upsertModel3DReview = async ({
   await throwIfBlockedByOwners({
     userId: user.id,
     ownerIds: [model3d.userId],
-    isModerator: !!user.isModerator,
+    isModerator: false,
   });
 
   // If a postId is provided, validate it actually exists + belongs to this user

--- a/src/server/services/resourceReview.service.ts
+++ b/src/server/services/resourceReview.service.ts
@@ -340,7 +340,6 @@ async function throwIfBlockedByModelOwners({
   isModerator?: boolean;
   modelIds: Array<number | null | undefined>;
 }) {
-  if (isModerator) return;
   const ids = [...new Set(modelIds.filter((x): x is number => !!x))];
   const ownerIds = (
     await Promise.all(

--- a/src/server/services/resourceReview.service.ts
+++ b/src/server/services/resourceReview.service.ts
@@ -324,13 +324,26 @@ export const upsertResourceReview = async ({
   ...data
 }: UpsertResourceReviewInput & { userId: number; isModerator?: boolean }) => {
   if (data.details) await throwOnBlockedLinkDomain(data.details);
-  if (!data.id) {
+  // Edits too, not just creates — a review written before a block would otherwise stay editable
+  // into anything afterwards. An edit writes `modelId` through from the request while being scoped
+  // by review id, so the review's stored model is checked alongside the one the request names.
+  const storedModelId = data.id
+    ? (
+        await dbRead.resourceReview.findUnique({
+          where: { id: data.id },
+          select: { modelId: true },
+        })
+      )?.modelId
+    : undefined;
+  for (const modelId of new Set([data.modelId, storedModelId].filter((x): x is number => !!x)))
     await throwIfBlockedByEntityOwner({
       userId,
       entityType: 'model',
-      entityId: data.modelId,
+      entityId: modelId,
       isModerator,
     });
+
+  if (!data.id) {
     const ret = await dbWrite.resourceReview
       .create({
         data: { ...data, userId, thread: { create: {} } },

--- a/src/server/services/resourceReview.service.ts
+++ b/src/server/services/resourceReview.service.ts
@@ -13,7 +13,10 @@ import {
 } from '~/server/selectors/resourceReview.selector';
 import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import { throwOnBlockedLinkDomain } from '~/server/services/blocklist.service';
-import { throwIfBlockedByEntityOwner } from '~/server/services/block-check.service';
+import {
+  getBlockCheckOwnerIds,
+  throwIfBlockedByOwners,
+} from '~/server/services/block-check.service';
 import { createNotification } from '~/server/services/notification.service';
 import {
   BlockedByUsers,
@@ -318,6 +321,33 @@ const createResourceReviewNotification = async ({
   }).catch();
 };
 
+const storedReviewModelId = async (id: number) =>
+  (await dbRead.resourceReview.findUnique({ where: { id }, select: { modelId: true } }))?.modelId;
+
+/**
+ * A review is content on someone else's model, so the model's owner is the block target. Resolved
+ * through the shared owner map and refused in one call, the way the comment paths do it — a
+ * throw-per-id loop would skip the self-and-duplicate handling that lives in `throwIfBlockedByOwners`.
+ */
+async function throwIfBlockedByModelOwners({
+  userId,
+  isModerator,
+  modelIds,
+}: {
+  userId: number;
+  isModerator?: boolean;
+  modelIds: Array<number | null | undefined>;
+}) {
+  if (isModerator) return;
+  const ids = [...new Set(modelIds.filter((x): x is number => !!x))];
+  const ownerIds = (
+    await Promise.all(
+      ids.map((entityId) => getBlockCheckOwnerIds({ entityType: 'model', entityId }))
+    )
+  ).flat();
+  await throwIfBlockedByOwners({ userId, ownerIds, isModerator });
+}
+
 export const upsertResourceReview = async ({
   userId,
   isModerator,
@@ -327,21 +357,11 @@ export const upsertResourceReview = async ({
   // Edits too, not just creates — a review written before a block would otherwise stay editable
   // into anything afterwards. An edit writes `modelId` through from the request while being scoped
   // by review id, so the review's stored model is checked alongside the one the request names.
-  const storedModelId = data.id
-    ? (
-        await dbRead.resourceReview.findUnique({
-          where: { id: data.id },
-          select: { modelId: true },
-        })
-      )?.modelId
-    : undefined;
-  for (const modelId of new Set([data.modelId, storedModelId].filter((x): x is number => !!x)))
-    await throwIfBlockedByEntityOwner({
-      userId,
-      entityType: 'model',
-      entityId: modelId,
-      isModerator,
-    });
+  await throwIfBlockedByModelOwners({
+    userId,
+    isModerator,
+    modelIds: [data.modelId, data.id ? await storedReviewModelId(data.id) : undefined],
+  });
 
   if (!data.id) {
     const ret = await dbWrite.resourceReview
@@ -431,9 +451,15 @@ export async function deleteResourceReviews({ ids }: { ids: number[] }) {
   return { count: result.count };
 }
 
-export const createResourceReview = async (
-  data: CreateResourceReviewInput & { userId: number }
-) => {
+export const createResourceReview = async ({
+  isModerator,
+  ...data
+}: CreateResourceReviewInput & { userId: number; isModerator?: boolean }) => {
+  await throwIfBlockedByModelOwners({
+    userId: data.userId,
+    isModerator,
+    modelIds: [data.modelId],
+  });
   const ret = await dbWrite.resourceReview
     .create({ data, select: resourceReviewSimpleSelect })
     .catch(async (err) => {
@@ -458,7 +484,18 @@ export const createResourceReview = async (
   return ret;
 };
 
-export const updateResourceReview = async ({ id, ...data }: UpdateResourceReviewInput) => {
+export const updateResourceReview = async ({
+  id,
+  userId,
+  isModerator,
+  ...data
+}: UpdateResourceReviewInput & { userId: number; isModerator?: boolean }) => {
+  // The request carries no modelId, so the review's stored model is the only target.
+  await throwIfBlockedByModelOwners({
+    userId,
+    isModerator,
+    modelIds: [await storedReviewModelId(id)],
+  });
   const ret = await dbWrite.resourceReview.update({
     where: { id },
     data,

--- a/src/server/services/resourceReview.service.ts
+++ b/src/server/services/resourceReview.service.ts
@@ -321,8 +321,10 @@ const createResourceReviewNotification = async ({
   }).catch();
 };
 
+// Read through the writer: on the replica a review created seconds ago resolves no model, the
+// guard finds no owner to refuse against, and the write it guards then succeeds anyway.
 const storedReviewModelId = async (id: number) =>
-  (await dbRead.resourceReview.findUnique({ where: { id }, select: { modelId: true } }))?.modelId;
+  (await dbWrite.resourceReview.findUnique({ where: { id }, select: { modelId: true } }))?.modelId;
 
 /**
  * A review is content on someone else's model, so the model's owner is the block target. Resolved


### PR DESCRIPTION
Follow-up to `f935f6e24f`, which wired the CommentsV2 surfaces into the shared block guard. Several write paths were not covered by it.

**Legacy model comments** (`comment.upsert`, the model discussion). The value the handler passed as the block target is the comment's own author â€” which on a create is the caller â€” so the model owner's block was never part of the check, and a reply consulted only the parent comment's author. The owner is now resolved through `block-check.service`, on edits as well as creates. An edit is scoped by comment id while writing `modelId`/`parentId` through from the request, so both the comment's stored home and the one the request names are resolved. Refused writes 404, matching the other write paths.

**Resource reviews.** `upsert` had the create-only half of the same shape, and `create`/`update` â€” the procedures the review UI actually calls â€” had no check at all, so an author refused on one had an unguarded path to the same row. All three are guarded; `update` resolves its model from the stored review, since the request carries no `modelId`.

**3D model reviews** had no check on either branch, while comment threads hanging off such a review were already guarded. One check against the target model covers both branches, and deliberately without the stored-vs-requested union the other two paths need: that path refuses a re-home outright and an edit writes only `recommended`/`details`, so requested and stored can never diverge past the guard. The guard also runs before the re-home refusal, so a blocked user aiming at another model gets the 404 rather than the 400 — the block answer should not be distinguishable from "no such review".

**`commentOld` owner resolution** now returns the model owner alongside the comment author, matching its CommentsV2 counterpart. Author alone left the reaction path with the shape this PR is closing.

Reads are unchanged â€” left open by the decision recorded in `docs/creator-tools-backlog.md`.

**Direction.** Blocking stays one-directional for writes, which is the existing decision (`docs/creator-tools-backlog.md`): the blocked user cannot write on the blocker's content; the blocker can still write on theirs, and reciprocity is the other user's to choose by blocking back. Notification filtering is bidirectional; the write guard is not. Stated here because the report asked which party's block is evaluated.

**Stated assumption.** Owner resolution returning nothing means "allow". Every guarded path here requires the target id and fails its own existence check when the row is missing, so a missing row cannot become a silent permit â€” but making one of those ids optional later would remove the guard quietly. The review guard resolves its stored target through the writer rather than the replica for the same reason: on a lagged read a review created seconds earlier resolves no owner, and the write it guards would then succeed rather than fail as not-found.

## Tests

- `comment.controller.block-check.test.ts` (new) â€” create, edit against a comment stored on a different model than the request names, reply, moderator exemption.
- `model3d-review.block-check.service.test.ts` (new) â€” create, edit, moderator exemption.
- `block-check.service.test.ts` â€” the owner resolver, including that an edit resolves the stored comment and not only the request, and the widened `commentOld` case.
- `resourceReview.idempotent.service.test.ts` â€” create, update and upsert-edit enforcement, including an edit re-pointing `modelId`.

Every guard was mutation-checked individually: deleting one fails its own tests and only its own, each in well under a second. Mocks key on the id being asked for rather than on call order, after identical reply-resolution failures under load turned out to be an empty mock default being indistinguishable from a real answer.

## Verification

`pnpm run typecheck` (0 errors), `pnpm run lint` (0 errors in changed files), `pnpm run prettier:write`, `pnpm run test:unit:run` (1150 files / 18133 tests passed), `pnpm run test:lint-rules` (243 passed).

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

