### PR TITLE
fix(collections): don't re-validate a featured membership the save doesn't write

### DIFF
--- a/src/server/services/__tests__/collection-save-existing-membership.service.test.ts
+++ b/src/server/services/__tests__/collection-save-existing-membership.service.test.ts
@@ -375,3 +375,91 @@ describe('saveItemInCollections with an existing closed-contest membership', () 
     expect(mockDbWrite.$transaction).not.toHaveBeenCalled();
   });
 });
+
+// The same trap on the sibling validator: a Featured membership riding along in the payload was
+// re-validated, and validateFeaturedCollectionEntry refuses anything already in a contest — so a
+// model in both failed every later save, whole-transaction, however unrelated the actual change.
+const FEATURED_COLLECTION_ID = 17888001;
+
+// Both the featured check and the permission batch go through $queryRaw; route on the SQL so the
+// assertion can say the featured check never ran, rather than counting calls.
+const isFeaturedContestProbe = (strings: unknown) =>
+  Array.isArray((strings as TemplateStringsArray)?.raw) &&
+  (strings as TemplateStringsArray).raw.join('').includes('FROM "CollectionItem" ci');
+
+function arrangeFeatured({ alreadyFeatured }: { alreadyFeatured: boolean }) {
+  vi.clearAllMocks();
+
+  mockDbRead.collection.findMany.mockResolvedValue([
+    collectionRow({ id: FEATURED_COLLECTION_ID, name: 'Featured Models', userId: -1 }),
+    collectionRow({ id: OWN_COLLECTION_ID, name: 'My collection' }),
+  ]);
+  mockDbRead.collectionItem.findMany.mockResolvedValue(
+    alreadyFeatured ? [{ collectionId: FEATURED_COLLECTION_ID, tagId: null }] : []
+  );
+  mockDbRead.collectionItem.count.mockResolvedValue(0);
+  mockDbRead.user.findUnique.mockResolvedValue({ id: USER_ID, meta: {} });
+  mockDbRead.model.findMany.mockResolvedValue([{ id: MODEL_ID, userId: USER_ID }]);
+  mockDbRead.modelVersion.findMany.mockResolvedValue([]);
+
+  mockDbRead.$queryRaw.mockImplementation(async (strings: unknown) =>
+    isFeaturedContestProbe(strings)
+      ? // The model sits in some contest collection — what the featured validator rejects on.
+        [{ id: 1 }]
+      : [
+          {
+            id: FEATURED_COLLECTION_ID,
+            userId: USER_ID,
+            write: 'Private',
+            read: 'Public',
+            type: 'Model',
+          },
+          {
+            id: OWN_COLLECTION_ID,
+            userId: USER_ID,
+            write: 'Private',
+            read: 'Public',
+            type: 'Model',
+          },
+        ]
+  );
+
+  mockDbWrite.$executeRaw.mockReturnValue('insert' as never);
+  mockDbWrite.$transaction.mockResolvedValue([]);
+}
+
+const featuredProbeRan = () =>
+  mockDbRead.$queryRaw.mock.calls.some((call) => isFeaturedContestProbe(call[0]));
+
+const saveFeatured = () =>
+  saveItemInCollections({
+    input: {
+      modelId: MODEL_ID,
+      type: 'Model',
+      userId: USER_ID,
+      collections: [{ collectionId: FEATURED_COLLECTION_ID }, { collectionId: OWN_COLLECTION_ID }],
+      removeFromCollectionIds: [],
+    },
+  } as never);
+
+describe('saveItemInCollections with an existing featured membership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('saves to an unrelated collection without re-validating the featured membership', async () => {
+    arrangeFeatured({ alreadyFeatured: true });
+
+    await expect(saveFeatured()).resolves.toBeDefined();
+    expect(featuredProbeRan()).toBe(false);
+    expect(mockDbWrite.$transaction).toHaveBeenCalled();
+  });
+
+  it('still rejects a NEW featured entry for an item in a contest collection', async () => {
+    arrangeFeatured({ alreadyFeatured: false });
+
+    await expect(saveFeatured()).rejects.toThrow(/already in a contest collection/i);
+    expect(featuredProbeRan()).toBe(true);
+    expect(mockDbWrite.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -845,7 +845,8 @@ export const saveItemInCollections = async ({
 
   // Check if any featured collections are involved and validate ONCE
   const featuredCollections = collections.filter(
-    (c) => c.userId === -1 && !c.mode && c.name.includes('Featured')
+    (c) =>
+      c.userId === -1 && !c.mode && c.name.includes('Featured') && !unwrittenCollectionIds.has(c.id)
   );
   if (featuredCollections.length > 0) {
     // Validate once for all featured collections instead of in the loop
@@ -3664,7 +3665,6 @@ export const setCollectionItemNsfwLevel = async ({
     { id: collectionItem.imageId, action: SearchIndexUpdateQueueAction.Update },
   ]);
 };
-
 
 export type CollectionEntityType = 'image' | 'model' | 'post' | 'article';
 


### PR DESCRIPTION
`7579daf3dc` gave `validateContestCollectionEntry` an early-out for collections an item is already in — a save sends the item's whole desired membership, so unchanged entries ride along in the payload and the gates were re-running against entries nobody was changing.

`validateFeaturedCollectionEntry` was not given the same treatment. It refuses any item that sits in a contest collection, so a model in both a Featured collection and any contest failed every later save, whole-transaction, however unrelated the collection actually being changed. Narrower than the original report — Featured collections are `userId -1` and mod-managed — so it hits moderators and anything that re-sends a full membership set.

One line: the same `unwrittenCollectionIds` filter, on the `featuredCollections` selection.

The other rules inside `validateContestCollectionEntry` (contest bans, `maxItemsPerUser`, own-models-only) are already covered — they run inside that validator, which the contest fix now skips for unchanged memberships.

## Tests

Extended `collection-save-existing-membership.service.test.ts` beside the contest pair it mirrors: the no-op re-submission saves without the featured validator issuing its query at all, and a genuinely new featured entry for an item already in a contest is still rejected with `$transaction` never called. Removing the filter fails the first in 12ms with the exact error creators were seeing.

## Verification

`pnpm run typecheck` (0 errors), `pnpm run lint` (0 errors in changed files), `pnpm run prettier:write`, `pnpm run test:unit:run` (1148 files / 18110 tests passed), `pnpm run test:lint-rules` (243 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)