### PR TITLE
feat(feedback): add an `apps-marketplace` feedback area and mount it on /apps

### DIFF
--- a/src/components/Apps/__tests__/appsStoreFeedbackContext.test.ts
+++ b/src/components/Apps/__tests__/appsStoreFeedbackContext.test.ts
@@ -111,6 +111,86 @@ describe('buildAppsStoreFeedbackContext', () => {
     });
 
     /**
+     * 🔴 THE SURROGATE CASE. Every fixture above is ASCII, and a fixture that cannot
+     * contain a surrogate pair cannot observe a surrogate bug — which is exactly why
+     * this shipped.
+     *
+     * `slice` cuts on UTF-16 CODE UNITS, not characters. An astral-plane character
+     * (any emoji) is a pair of units, so a clip point that lands between them leaves
+     * a LONE HIGH SURROGATE as the last unit. That string is a legal JS value and
+     * passes `z.string().max()` untouched, so the schema round-trip below cannot see
+     * it either — it breaks one layer further down, where the context is written to
+     * the `Feedback.context` JSON column: `JSON.stringify` emits a bare `\ud83d`
+     * escape, which Postgres rejects (`Unicode low surrogate must follow a high
+     * surrogate`) and Prisma's serde layer rejects before that. So the clip added to
+     * keep a long search term from failing the submission ends up failing the
+     * submission itself, on the one surface that exists to accept reports.
+     *
+     * Asserted as a STATE (`isWellFormed`, plus a real UTF-8 encode round-trip)
+     * rather than by looking for an escape sequence in the output: a well-formed
+     * string is the property the downstream write actually needs, and a lone
+     * surrogate is the only way to lose it.
+     */
+    const EMOJI = '\u{1F600}'; // U+1F600, two UTF-16 units: \uD83D \uDE00
+
+    /** Encoding to UTF-8 and back is lossless iff the string has no lone surrogate. */
+    const survivesUtf8 = (value: string) =>
+      new TextDecoder().decode(new TextEncoder().encode(value)) === value;
+
+    it('does not leave a lone surrogate when the bound falls inside an emoji', () => {
+      // 199 ASCII + one emoji = 201 units, so unit 200 is the emoji's HIGH surrogate.
+      const query = 'q'.repeat(FEEDBACK_FILTER_VALUE_MAX_LENGTH - 1) + EMOJI;
+      expect(query).toHaveLength(FEEDBACK_FILTER_VALUE_MAX_LENGTH + 1);
+
+      const context = buildAppsStoreFeedbackContext({ path: '/apps', filters: filters({ query }) });
+      const clipped = context?.filters?.query as string;
+
+      expect(clipped.isWellFormed()).toBe(true);
+      expect(survivesUtf8(clipped)).toBe(true);
+      // Exactly the orphaned unit is dropped — the whole pair, and nothing more.
+      expect(clipped).toHaveLength(FEEDBACK_FILTER_VALUE_MAX_LENGTH - 1);
+      expect(clipped).toBe('q'.repeat(FEEDBACK_FILTER_VALUE_MAX_LENGTH - 1));
+      expect(throughSchema(context)?.filters?.query).toBe(clipped);
+    });
+
+    it('does not leave a lone surrogate for a term that is mostly emoji', () => {
+      // One ASCII char shifts every pair onto an odd offset, so the clip at 200 lands
+      // mid-pair. (A term of ONLY emoji does not break at this bound: 200 is even, so
+      // the cut falls exactly on a pair boundary — which is why the fixture is mixed.)
+      const query = 'q' + EMOJI.repeat(150);
+      const context = buildAppsStoreFeedbackContext({ path: '/apps', filters: filters({ query }) });
+      const clipped = context?.filters?.query as string;
+
+      expect(clipped.isWellFormed()).toBe(true);
+      expect(survivesUtf8(clipped)).toBe(true);
+      expect(clipped).toHaveLength(FEEDBACK_FILTER_VALUE_MAX_LENGTH - 1);
+      expect(clipped.endsWith(EMOJI)).toBe(true);
+      expect(throughSchema(context)?.filters?.query).toBe(clipped);
+    });
+
+    /**
+     * The control for the two above: when the clip point does NOT fall inside a pair,
+     * nothing extra may be trimmed. Without it, a guard that simply dropped the last
+     * unit of every clipped term would pass both cases above.
+     */
+    it('trims nothing extra when the bound falls on a character boundary', () => {
+      const query = 'q'.repeat(FEEDBACK_FILTER_VALUE_MAX_LENGTH) + EMOJI;
+      const context = buildAppsStoreFeedbackContext({ path: '/apps', filters: filters({ query }) });
+
+      expect(context?.filters?.query).toBe('q'.repeat(FEEDBACK_FILTER_VALUE_MAX_LENGTH));
+      expect(context?.filters?.query).toHaveLength(FEEDBACK_FILTER_VALUE_MAX_LENGTH);
+    });
+
+    /** And an emoji comfortably inside the bound is not touched at all. */
+    it('leaves an emoji inside the bound intact', () => {
+      const query = `upscale ${EMOJI}`;
+      const context = buildAppsStoreFeedbackContext({ path: '/apps', filters: filters({ query }) });
+
+      expect(context?.filters?.query).toBe(query);
+      expect(throughSchema(context)?.filters?.query).toBe(query);
+    });
+
+    /**
      * The control for the two cases above: an UNCLIPPED value of the same shape is
      * genuinely rejected. Without this, "does not throw" would be indistinguishable
      * from a schema that has no bound at all.

--- a/src/components/Apps/__tests__/appsStoreFeedbackContext.test.ts
+++ b/src/components/Apps/__tests__/appsStoreFeedbackContext.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { buildAppsStoreFeedbackContext } from '~/components/Apps/appsStoreFeedbackContext';
+import { APPS_STORE_DEFAULTS } from '~/components/Apps/appsStoreQueryParams';
+import { createFeedbackSchema } from '~/server/schema/feedback.schema';
+import { FEEDBACK_FILTER_VALUE_MAX_LENGTH } from '~/shared/constants/feedback.constants';
+
+/**
+ * The triage payload the `/apps` marketplace prompt attaches to a report.
+ *
+ * The load-bearing case is the LAST describe block. `context.filters` bounds every
+ * value at `FEEDBACK_FILTER_VALUE_MAX_LENGTH` and a zod `max()` REJECTS rather than
+ * truncates, so an unclipped search term does not arrive shortened — it fails the
+ * whole submission. That is why the clip is a real guard and not tidiness, and why
+ * these assertions drive the built context through `createFeedbackSchema` rather
+ * than merely reading the returned string's length: a length assertion alone would
+ * still pass if the schema's bound moved away from the constant the builder clips to.
+ */
+describe('buildAppsStoreFeedbackContext', () => {
+  const filters = (over: Partial<typeof APPS_STORE_DEFAULTS> = {}) => ({
+    ...APPS_STORE_DEFAULTS,
+    ...over,
+  });
+
+  /** Round-trip through the real boundary schema — this is what "carried" means. */
+  const throughSchema = (context: ReturnType<typeof buildAppsStoreFeedbackContext>) =>
+    createFeedbackSchema.parse({
+      area: 'apps-marketplace',
+      message: 'the store looked wrong',
+      context,
+    }).context;
+
+  it('reports the path and every store control', () => {
+    const context = buildAppsStoreFeedbackContext({
+      path: '/apps',
+      filters: filters({
+        kind: 'offsite',
+        category: 'generation',
+        sort: 'newest',
+        query: 'upscale',
+      }),
+    });
+
+    expect(context?.path).toBe('/apps');
+    expect(context?.filters).toEqual({
+      kind: 'offsite',
+      category: 'generation',
+      sort: 'newest',
+      query: 'upscale',
+    });
+  });
+
+  // Literal defaults, hand-typed rather than read back out of APPS_STORE_DEFAULTS, so
+  // a change to the store's defaults surfaces here instead of being followed silently.
+  it('reports the DEFAULT view rather than an empty object', () => {
+    const context = buildAppsStoreFeedbackContext({ path: '/apps', filters: filters() });
+    expect(context?.filters).toEqual({
+      kind: 'all',
+      category: 'none',
+      sort: 'top-rated',
+      query: '',
+    });
+  });
+
+  it("says 'none' for no category instead of dropping the key", () => {
+    const context = buildAppsStoreFeedbackContext({ path: '/apps', filters: filters() });
+    expect(context?.filters).toHaveProperty('category');
+    expect(context?.filters?.category).toBe('none');
+  });
+
+  // SSR: the builder runs during the server render too, where there is no `window`.
+  it('carries an absent path without failing the boundary schema', () => {
+    const context = buildAppsStoreFeedbackContext({ filters: filters() });
+    expect(context?.path).toBeUndefined();
+    expect(throughSchema(context)?.filters?.kind).toBe('all');
+  });
+
+  describe('the search term is CLIPPED to the schema bound, not passed through', () => {
+    it('pins the bound this file is written against', () => {
+      expect(FEEDBACK_FILTER_VALUE_MAX_LENGTH).toBe(200);
+    });
+
+    it('leaves a term inside the bound untouched', () => {
+      const query = 'q'.repeat(FEEDBACK_FILTER_VALUE_MAX_LENGTH);
+      const context = buildAppsStoreFeedbackContext({ path: '/apps', filters: filters({ query }) });
+      expect(context?.filters?.query).toBe(query);
+      expect(throughSchema(context)?.filters?.query).toBe(query);
+    });
+
+    /**
+     * THE REGRESSION CASE. Without the clip this parse THROWS, and the reporter gets
+     * a validation error instead of a filed report. Asserted through the schema, at
+     * one character over the bound and again far over it.
+     */
+    it('clips a term one character past the bound so the submission still parses', () => {
+      const context = buildAppsStoreFeedbackContext({
+        path: '/apps',
+        filters: filters({ query: 'q'.repeat(FEEDBACK_FILTER_VALUE_MAX_LENGTH + 1) }),
+      });
+      expect(context?.filters?.query).toHaveLength(FEEDBACK_FILTER_VALUE_MAX_LENGTH);
+      expect(() => throughSchema(context)).not.toThrow();
+      expect(throughSchema(context)?.filters?.query).toHaveLength(FEEDBACK_FILTER_VALUE_MAX_LENGTH);
+    });
+
+    it('clips a pathologically long term the same way', () => {
+      const context = buildAppsStoreFeedbackContext({
+        path: '/apps',
+        filters: filters({ query: 'x'.repeat(20_000) }),
+      });
+      expect(context?.filters?.query).toHaveLength(FEEDBACK_FILTER_VALUE_MAX_LENGTH);
+      expect(() => throughSchema(context)).not.toThrow();
+    });
+
+    /**
+     * The control for the two cases above: an UNCLIPPED value of the same shape is
+     * genuinely rejected. Without this, "does not throw" would be indistinguishable
+     * from a schema that has no bound at all.
+     */
+    it('and the unclipped value really is rejected (negative control)', () => {
+      expect(() =>
+        createFeedbackSchema.parse({
+          area: 'apps-marketplace',
+          message: 'the store looked wrong',
+          context: { filters: { query: 'q'.repeat(FEEDBACK_FILTER_VALUE_MAX_LENGTH + 1) } },
+        })
+      ).toThrow();
+    });
+  });
+});

--- a/src/components/Apps/appsStoreFeedbackContext.ts
+++ b/src/components/Apps/appsStoreFeedbackContext.ts
@@ -1,0 +1,49 @@
+import type { AppsStoreFilters } from '~/components/Apps/appsStoreQueryParams';
+import type { CreateFeedbackInput } from '~/server/schema/feedback.schema';
+import { FEEDBACK_FILTER_VALUE_MAX_LENGTH } from '~/shared/constants/feedback.constants';
+
+/**
+ * The triage payload the `/apps` marketplace feedback prompt sends with a report.
+ *
+ * A one-line report ("the list is empty") is only actionable next to the view it was
+ * written about, and on this page the view is entirely determined by the URL — kind,
+ * category, sort and the free-text search box all live in the query string (see
+ * `useAppsStoreQueryParams`). So the context is a straight read of the resolved
+ * filter state, and it is deliberately built HERE rather than inline in the page:
+ * the clipping below is load-bearing and needs to be reachable by a test.
+ *
+ * 🔴 WHY `query` IS CLIPPED. `feedbackContextSchema.filters` bounds each value at
+ * `FEEDBACK_FILTER_VALUE_MAX_LENGTH`, and a zod `max()` REJECTS — it does not
+ * truncate. `query` is whatever the viewer typed into the search box (echoed into
+ * `?query=`, and hand-editable in the address bar), so passing it through unclipped
+ * makes a long search term fail the whole submission with a validation error the
+ * reporter cannot act on, on the one surface that exists to accept reports. The
+ * report is worth more than the tail of a search term.
+ *
+ * Everything else is a closed set (`kind`, `sort`) or a known enum member
+ * (`category`), so none of them can exceed the bound.
+ */
+export function buildAppsStoreFeedbackContext({
+  filters,
+  path,
+}: {
+  filters: AppsStoreFilters;
+  /** `window.location.pathname`, or undefined during SSR. */
+  path?: string;
+}): CreateFeedbackInput['context'] {
+  return {
+    path,
+    filters: {
+      kind: filters.kind,
+      // `null` is the "no category selected" state, and the context schema's value
+      // union is string | number | boolean — so this cannot be passed through, and
+      // `?? undefined` is not a fix either: an explicit `undefined` is a RECORD
+      // VALUE here and fails the union, taking the whole submission with it. Said in
+      // words instead: a missing key would read as "we don't know" in triage, which
+      // is a different claim from "the viewer had no category selected".
+      category: filters.category ?? 'none',
+      sort: filters.sort,
+      query: filters.query.slice(0, FEEDBACK_FILTER_VALUE_MAX_LENGTH),
+    },
+  };
+}

--- a/src/components/Apps/appsStoreFeedbackContext.ts
+++ b/src/components/Apps/appsStoreFeedbackContext.ts
@@ -23,6 +23,27 @@ import { FEEDBACK_FILTER_VALUE_MAX_LENGTH } from '~/shared/constants/feedback.co
  * Everything else is a closed set (`kind`, `sort`) or a known enum member
  * (`category`), so none of them can exceed the bound.
  */
+
+/**
+ * Clip `value` to the schema bound WITHOUT splitting a surrogate pair.
+ *
+ * 🔴 `slice` cuts on UTF-16 code units, not characters, and the bound is a unit count.
+ * An astral-plane character (any emoji) occupies two units, so a clip point that falls
+ * between them leaves a LONE HIGH SURROGATE as the final unit. That value is a legal JS
+ * string and passes `z.string().max()` untouched — nothing on the request path notices.
+ * It breaks at the write: `Feedback.context` is a JSON column, `JSON.stringify` emits a
+ * bare `\ud83d` escape, and both Prisma's serde layer and Postgres reject it
+ * (`Unicode low surrogate must follow a high surrogate`). So the clip that exists to stop
+ * a long search term from failing the submission would itself fail the submission — the
+ * same class of break, on the same surface, for a term with an emoji near the bound.
+ *
+ * A high surrogate that survives the slice as the LAST unit is necessarily unpaired: its
+ * low surrogate could only have followed it, and the slice removed everything after.
+ * Dropping it is therefore the whole fix, and it cannot touch a well-formed clip.
+ */
+const clipFilterValue = (value: string) =>
+  value.slice(0, FEEDBACK_FILTER_VALUE_MAX_LENGTH).replace(/[\uD800-\uDBFF]$/, '');
+
 export function buildAppsStoreFeedbackContext({
   filters,
   path,
@@ -43,7 +64,7 @@ export function buildAppsStoreFeedbackContext({
       // is a different claim from "the viewer had no category selected".
       category: filters.category ?? 'none',
       sort: filters.sort,
-      query: filters.query.slice(0, FEEDBACK_FILTER_VALUE_MAX_LENGTH),
+      query: clipFilterValue(filters.query),
     },
   };
 }

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -1,8 +1,12 @@
+import { useRouter } from 'next/router';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { AppListingsMarketplaceBody } from '~/components/Apps/AppListingsMarketplaceBody';
 import { LISTING_STORE_CONTAINER_SIZE } from '~/components/Apps/appListingGrid';
+import { buildAppsStoreFeedbackContext } from '~/components/Apps/appsStoreFeedbackContext';
+import { parseAppsStoreFilters } from '~/components/Apps/appsStoreQueryParams';
 import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
+import { FeedbackPrompt } from '~/components/Feedback/FeedbackPrompt';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -19,6 +23,20 @@ export const getServerSideProps = createServerSideProps({
 
 export default function AppsPage() {
   const features = useFeatureFlags();
+  const router = useRouter();
+
+  // The store's filter/sort/search state, read straight off the URL. The controls
+  // themselves live inside `AppListingsMarketplaceBody`, but they WRITE the query
+  // string (`useAppsStoreQueryParams`), so the URL is the shared source both this
+  // prompt and that body resolve through the same `parseAppsStoreFilters` — no
+  // lifted state, no second copy of the defaults, and a report therefore names the
+  // view the reporter was actually looking at.
+  //
+  // ⚠️ One known lag: the search box only echoes into the URL after its 300ms
+  // debounce, so a report submitted mid-keystroke carries the previous term. The
+  // grid the reporter is looking at is filtered by that same debounced value, so
+  // this matches what they see rather than what they have typed.
+  const storeFilters = parseAppsStoreFilters(router.query);
 
   // W13 (PR-W1a/D8): store-visibility gate = dedicated `appListings` OR-falling-
   // back to `appBlocks`. The SHARED predicate, so this body and the SSR
@@ -54,6 +72,36 @@ export default function AppsPage() {
           a separate post-deploy op step) — the empty state renders sanely
           ("No apps yet"); expected + fine while dark. */}
       <AppsPageLayout size={LISTING_STORE_CONTAINER_SIZE}>
+        {/* FEEDBACK PROMPT — above the store controls, mirroring where the images
+            feed mounts it (above the grid rather than after it).
+
+            It costs no vertical space in the ordinary case: `FeedbackPrompt`
+            returns null unless the viewer is signed in, has not dismissed it this
+            tab, AND `feedback-area-apps-marketplace` resolves on for them — so for
+            everyone outside the segment the page is byte-identical to before and
+            nothing is pushed down. For a viewer inside it, the prompt is one
+            collapsed line above the search/sort row; the grid stays in view.
+
+            `active` is deliberately UNCONDITIONAL. The images-feed mount gates on
+            `feedSnapshot.source === 'bitdex'` because that prompt asks about one
+            specific backend and would misattribute reports about any other. This
+            one asks about the marketplace page as a whole, so there is no
+            equivalent condition and inventing one would only make the surface
+            silently dark. The Flipt flag is the rollout control. */}
+        <FeedbackPrompt
+          area="apps-marketplace"
+          active
+          notice="Apps are new here. If something's missing or looks off, tell us."
+          placeholder="What were you trying to do? Missing apps, broken listings, confusing pages, anything."
+          // The view the report is ABOUT — kind/category/sort/search, all read back
+          // out of the URL. Built by a named function (not inline) because the
+          // search term has to be CLIPPED to the context schema's per-value bound
+          // and that clip needs to be reachable by a test; see that file.
+          context={buildAppsStoreFeedbackContext({
+            filters: storeFilters,
+            path: typeof window !== 'undefined' ? window.location.pathname : undefined,
+          })}
+        />
         {/* Widened past the default `xl` (1320px) token. The width is UNCHANGED by
             the larger-cover pass — the store now runs a 4-across grid at `xl` (see
             `LISTING_GRID_SPAN`), and the container/grid pair is pinned together in

--- a/src/server/routers/__tests__/feedback.router.flag-context.test.ts
+++ b/src/server/routers/__tests__/feedback.router.flag-context.test.ts
@@ -31,11 +31,11 @@ const USER_ID = 42;
  * `isEarlyAdopter` is the ONLY thing that varies between the two callers below, so a
  * difference in outcome can only be the cohort property — not tier, mute or onboarding.
  */
-const caller = (isEarlyAdopter: boolean) =>
+const caller = (isEarlyAdopter: boolean, isModerator = false) =>
   feedbackRouter.createCaller({
     user: {
       id: USER_ID,
-      isModerator: false,
+      isModerator,
       muted: false,
       onboarding: OnboardingSteps.Buzz,
       isEarlyAdopter,
@@ -109,5 +109,99 @@ describe('feedback flag gate — read and write evaluate the flag identically', 
       message: 'Feedback is not being collected here right now.',
     });
     expect(dbMock.dbWrite.feedback.create).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The SAME seam for the `/apps` marketplace area, driven through the real router.
+ *
+ * Worth its own block rather than a parameter on the one above for two reasons. First
+ * the flag key: it is derived (`feedback-area-<slug>`) and never written down in the
+ * app, so the literal below is the only in-repo statement of what flipt-state must
+ * hold — and an unknown flag resolves FALSE, so a mismatch reads as "nobody can leave
+ * feedback" rather than as an error. Second the rollout differs: this area targets
+ * `early-adopters` OR `testers`, and the `testers` half is ANY_MATCH_TYPE with an
+ * `isModerator = "true"` constraint, so a moderator who never opted into the
+ * early-adopter program must get through BOTH doors. That is deliberate, not an
+ * accident, and it is the case the bitdex block cannot reach.
+ */
+describe('apps-marketplace — read and write agree, for both segments of its rollout', () => {
+  const marketplace = {
+    area: 'apps-marketplace' as const,
+    message: 'the store showed no apps',
+    context: { path: '/apps', filters: { kind: 'offsite', sort: 'newest' } },
+  };
+
+  /** What the live rollout does: early-adopters OR testers, the latter incl. mods. */
+  const appsMarketplaceRollout = async (
+    _flag: string,
+    _entityId: string,
+    context?: Record<string, string>
+  ) => context?.isEarlyAdopter === 'true' || context?.isModerator === 'true';
+
+  beforeEach(() => {
+    mockIsFlipt.mockImplementation(appsMarketplaceRollout);
+  });
+
+  it('hands Flipt the apps-marketplace flag key from both procedures', async () => {
+    await caller(true).getArea({ area: marketplace.area });
+    await caller(true).create(marketplace);
+
+    expect(evalCalls()).toHaveLength(2);
+    const [read, write] = evalCalls();
+    // The hand-typed contract with flipt-state's features.yaml.
+    expect(read[0]).toBe('feedback-area-apps-marketplace');
+    expect(write[0]).toBe(read[0]);
+    expect(write[1]).toBe(read[1]);
+    expect(write[2]).toEqual(read[2]);
+    expect(read[1]).toBe('42');
+  });
+
+  it('lets an early adopter see the notice AND submit, storing the store view', async () => {
+    await expect(caller(true).getArea({ area: marketplace.area })).resolves.toEqual({
+      enabled: true,
+    });
+    await expect(caller(true).create(marketplace)).resolves.toEqual({ id: 1 });
+    expect(dbMock.dbWrite.feedback.create.mock.calls[0][0].data).toMatchObject({
+      area: 'apps-marketplace',
+      context: { path: '/apps', filters: { kind: 'offsite', sort: 'newest' } },
+    });
+  });
+
+  // The `testers` arm: a moderator who never opted in. INTENDED — every moderator is
+  // in scope for this area.
+  it('lets a moderator who is NOT an early adopter see the notice AND submit', async () => {
+    await expect(caller(false, true).getArea({ area: marketplace.area })).resolves.toEqual({
+      enabled: true,
+    });
+    await expect(caller(false, true).create(marketplace)).resolves.toEqual({ id: 1 });
+  });
+
+  it('refuses a user in neither segment at both doors', async () => {
+    await expect(caller(false).getArea({ area: marketplace.area })).resolves.toEqual({
+      enabled: false,
+    });
+    await expect(caller(false).create(marketplace)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Feedback is not being collected here right now.',
+    });
+    expect(dbMock.dbWrite.feedback.create).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The two areas are SEPARATE flags, so switching one on cannot switch the other on.
+   * Asserted against a stub that answers only for the marketplace key — a service that
+   * ignored `area` when building the key would light both surfaces at once.
+   */
+  it('is gated independently of the bitdex area', async () => {
+    mockIsFlipt.mockImplementation(
+      async (flag: string) => flag === 'feedback-area-apps-marketplace'
+    );
+    await expect(caller(true).getArea({ area: 'apps-marketplace' })).resolves.toEqual({
+      enabled: true,
+    });
+    await expect(caller(true).getArea({ area: 'bitdex-image-feed' })).resolves.toEqual({
+      enabled: false,
+    });
   });
 });

--- a/src/server/schema/__tests__/feedback.schema.test.ts
+++ b/src/server/schema/__tests__/feedback.schema.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { createFeedbackSchema } from '~/server/schema/feedback.schema';
+import { createFeedbackSchema, getFeedbackAreaSchema } from '~/server/schema/feedback.schema';
 import {
+  FEEDBACK_AREAS,
+  FEEDBACK_FILTER_VALUE_MAX_LENGTH,
   FEEDBACK_IMAGE_ID_MAX_LENGTH,
   FEEDBACK_IMAGE_MAX_COUNT,
   FEEDBACK_SESSION_ID_MAX_LENGTH,
+  feedbackAreaFlagKey,
 } from '~/shared/constants/feedback.constants';
 
 /**
@@ -167,5 +170,89 @@ describe('feedback schema — context bounds', () => {
     it('still rejects a message past 2000 characters', () => {
       expect(() => createFeedbackSchema.parse({ ...base, message: 'x'.repeat(2001) })).toThrow();
     });
+  });
+});
+
+/**
+ * The AREA enum is the boundary that decides whether a new feedback surface exists at
+ * all. `feedbackAreaSchema` is `z.enum(FEEDBACK_AREAS)`, so an area missing from that
+ * constant is not a stripped field — it is a REJECTED submission on both procedures,
+ * and the surface is dead in a way no amount of Flipt configuration can revive.
+ *
+ * Areas are plain strings (no Prisma enum, no migration), which is exactly why this
+ * needs a test: nothing else in the stack would notice the omission until a user's
+ * report bounced.
+ */
+describe('feedback areas', () => {
+  const areas = ['bitdex-image-feed', 'apps-marketplace'];
+
+  // Both halves hand-typed. Reading the expectation out of FEEDBACK_AREAS would make
+  // this test follow any future edit instead of pinning the set.
+  it('are exactly the two declared surfaces', () => {
+    expect([...FEEDBACK_AREAS]).toEqual(areas);
+  });
+
+  it.each(areas)('accepts %s on the submit schema', (area) => {
+    const parsed = createFeedbackSchema.parse({ area, message: 'something looked wrong' });
+    expect(parsed.area).toBe(area);
+  });
+
+  it.each(areas)('accepts %s on the getArea schema', (area) => {
+    expect(getFeedbackAreaSchema.parse({ area }).area).toBe(area);
+  });
+
+  it('rejects an area that is not declared', () => {
+    expect(() =>
+      createFeedbackSchema.parse({ area: 'apps-markteplace', message: 'typo in the slug' })
+    ).toThrow();
+    expect(() => getFeedbackAreaSchema.parse({ area: 'models-feed' })).toThrow();
+  });
+
+  /**
+   * The flag key is DERIVED from the slug, so it is never written down anywhere in the
+   * app — but it IS written down by hand in flipt-state's `features.yaml`. These two
+   * literals are that contract. A mismatch fails as "the area is off for everybody",
+   * silently, because an unknown flag resolves false.
+   */
+  it('derive their Flipt flag keys from the slug', () => {
+    expect(feedbackAreaFlagKey('bitdex-image-feed')).toBe('feedback-area-bitdex-image-feed');
+    expect(feedbackAreaFlagKey('apps-marketplace')).toBe('feedback-area-apps-marketplace');
+  });
+});
+
+/**
+ * `context.filters` — the generic per-view bag, and the one place `/apps` reports
+ * user-typed text (its search box). The bound is exported so a caller can clip to it;
+ * these pin that the exported number IS the enforced one.
+ */
+describe('feedback schema — filter value bounds', () => {
+  const parseFilters = (filters: Record<string, unknown>) =>
+    createFeedbackSchema.parse({
+      area: 'apps-marketplace' as const,
+      message: 'the store looked wrong',
+      context: { filters },
+    });
+
+  it('is a 200-character ceiling per value', () => {
+    expect(FEEDBACK_FILTER_VALUE_MAX_LENGTH).toBe(200);
+  });
+
+  it('carries the marketplace view through instead of stripping it', () => {
+    const parsed = parseFilters({ kind: 'offsite', category: 'generation', sort: 'newest' });
+    expect(parsed.context?.filters).toEqual({
+      kind: 'offsite',
+      category: 'generation',
+      sort: 'newest',
+    });
+  });
+
+  it('accepts a value of exactly 200 characters', () => {
+    const parsed = parseFilters({ query: 'q'.repeat(200) });
+    expect(parsed.context?.filters?.query).toHaveLength(200);
+  });
+
+  // REJECTS, does not truncate — the reason the caller has to clip.
+  it('rejects a value of 201 characters rather than clipping it', () => {
+    expect(() => parseFilters({ query: 'q'.repeat(201) })).toThrow();
   });
 });

--- a/src/server/schema/feedback.schema.ts
+++ b/src/server/schema/feedback.schema.ts
@@ -1,6 +1,7 @@
 import * as z from 'zod';
 import {
   FEEDBACK_AREAS,
+  FEEDBACK_FILTER_VALUE_MAX_LENGTH,
   FEEDBACK_IMAGE_ID_MAX_LENGTH,
   FEEDBACK_IMAGE_MAX_COUNT,
   FEEDBACK_MESSAGE_MAX_LENGTH,
@@ -26,8 +27,16 @@ const feedbackContextSchema = z.object({
   reportedSource: z.string().max(50).optional(),
   reportedPageSources: z.array(z.string().max(50)).max(500).optional(),
   pagesLoaded: z.number().int().min(0).max(10_000).optional(),
+  // The value bound is now the exported `FEEDBACK_FILTER_VALUE_MAX_LENGTH` rather than
+  // an inline literal: `/apps` reports its URL-backed free-text search term here, so a
+  // caller has to clip to this number and the two must not be able to drift. Same
+  // value (200), no widening — a `max()` REJECTS rather than truncates, so clipping is
+  // the caller's job either way.
   filters: z
-    .record(z.string().max(50), z.union([z.string().max(200), z.number(), z.boolean()]))
+    .record(
+      z.string().max(50),
+      z.union([z.string().max(FEEDBACK_FILTER_VALUE_MAX_LENGTH), z.number(), z.boolean()])
+    )
     .refine((val) => Object.keys(val).length <= 20, 'Too many filter keys')
     .optional(),
   /** Cloudflare image ids for files the user attached by hand. */

--- a/src/server/services/__tests__/feedback.service.test.ts
+++ b/src/server/services/__tests__/feedback.service.test.ts
@@ -113,6 +113,34 @@ describe('createFeedback — extended context', () => {
     await createFeedback(args);
     expect(writtenContext()).toEqual({});
   });
+
+  /**
+   * THE SECOND AREA, END TO END through the boundary schema — the marketplace prompt's
+   * payload, parsed and then written.
+   *
+   * Same seam argument as the case above: the schema strips undeclared keys, so a
+   * context the page builds and the service happily forwards can still arrive at the
+   * column with the interesting half missing. Parsing first is what makes "the page
+   * sends it" and "the column stores it" meet, and `area` is asserted on the write
+   * because that value is what a triager filters by.
+   */
+  it('writes an apps-marketplace submission with the store view it was sent with', async () => {
+    const parsed = createFeedbackSchema.parse({
+      area: 'apps-marketplace',
+      message: 'the store showed no apps',
+      context: {
+        path: '/apps',
+        filters: { kind: 'offsite', category: 'generation', sort: 'newest', query: 'upscale' },
+      },
+    });
+    await createFeedback({ ...parsed, userId: 7 });
+
+    expect(dbMock.dbWrite.feedback.create.mock.calls[0][0].data.area).toBe('apps-marketplace');
+    expect(writtenContext()).toEqual({
+      path: '/apps',
+      filters: { kind: 'offsite', category: 'generation', sort: 'newest', query: 'upscale' },
+    });
+  });
 });
 
 /**
@@ -185,6 +213,67 @@ describe('isFeedbackAreaEnabled — the Flipt evaluation context', () => {
     });
 
     expect(evalCall()[2]?.isEarlyAdopter).toBe('false');
+  });
+
+  /**
+   * THE SECOND AREA. `feedbackAreaFlagKey` is a template literal, so a per-area flag
+   * key is never written down in the app — the only hand-written copy is the flag in
+   * flipt-state's `features.yaml`. If the service derived, say, the wrong slug, every
+   * evaluation would resolve an UNKNOWN flag, and an unknown flag reads false: the
+   * area would be off for everyone with nothing logged and no error raised.
+   *
+   * The literal on the right is the contract with that file, typed out rather than
+   * built from the area, so this fails if either side moves alone.
+   */
+  it('derives the apps-marketplace flag key, with the same context as any other area', async () => {
+    await isFeedbackAreaEnabled({
+      area: 'apps-marketplace',
+      user: sessionUser({ isEarlyAdopter: true, isModerator: true }),
+    });
+
+    const [flag, entityId, context] = evalCall();
+    expect(flag).toBe('feedback-area-apps-marketplace');
+    expect(entityId).toBe('7');
+    expect(context?.userId).toBe('7');
+    // The two properties the live rollout's segments constrain — `early-adopters`
+    // matches on isEarlyAdopter, `testers` on isModerator. Both are STRINGS; a
+    // boolean here fails the constraint as "nobody matches", not as an error.
+    expect(context?.isEarlyAdopter).toBe('true');
+    expect(context?.isModerator).toBe('true');
+  });
+
+  /**
+   * The `testers` arm of the apps-marketplace rollout, behaviourally. That segment is
+   * ANY_MATCH_TYPE over `isModerator = "true"` OR a userId allowlist, so a moderator
+   * who never opted into the early-adopter program is IN SCOPE — intended, and the
+   * half that the early-adopters stub above cannot see.
+   */
+  describe('against a stub that behaves like the testers segment', () => {
+    beforeEach(() => {
+      mocks.isFlipt.mockImplementation(
+        async (_flag: string, _entityId: string, context?: Record<string, string>) =>
+          context?.isModerator === 'true'
+      );
+    });
+
+    it('is ON for a moderator who is NOT an early adopter', async () => {
+      await expect(
+        isFeedbackAreaEnabled({
+          area: 'apps-marketplace',
+          user: sessionUser({ isModerator: true, isEarlyAdopter: false }),
+        })
+      ).resolves.toBe(true);
+    });
+
+    it('and OFF for a non-moderator', async () => {
+      await expect(
+        isFeedbackAreaEnabled({ area: 'apps-marketplace', user: sessionUser() })
+      ).resolves.toBe(false);
+    });
+
+    it('and OFF for an anonymous request', async () => {
+      await expect(isFeedbackAreaEnabled({ area: 'apps-marketplace' })).resolves.toBe(false);
+    });
   });
 
   it('evaluates an anonymous request with an anonymous context that carries no cohort property', async () => {

--- a/src/shared/constants/feedback.constants.ts
+++ b/src/shared/constants/feedback.constants.ts
@@ -1,6 +1,6 @@
 // Plain strings, not a Prisma enum: adding an area costs a constant here and no
 // migration, and its Flipt flag is derived from the slug.
-export const FEEDBACK_AREAS = ['bitdex-image-feed'] as const;
+export const FEEDBACK_AREAS = ['bitdex-image-feed', 'apps-marketplace'] as const;
 
 export type FeedbackArea = (typeof FEEDBACK_AREAS)[number];
 
@@ -33,5 +33,20 @@ export const FEEDBACK_IMAGE_ID_MAX_LENGTH = 100;
 
 /** Faro session ids are short opaque strings; bounded because it is still client-supplied. */
 export const FEEDBACK_SESSION_ID_MAX_LENGTH = 64;
+
+/**
+ * Length ceiling on ONE value inside `context.filters`.
+ *
+ * Named rather than left inline in the schema because a caller has to TRUNCATE to it,
+ * and a caller truncating to a number the schema does not publish is a drift waiting
+ * to happen. The concrete case: `/apps` puts its free-text search box in the URL
+ * (`?query=…`), so the value the marketplace prompt reports is user-typed and
+ * unbounded. `feedbackContextSchema` REJECTS an over-long value — it does not clip it
+ * — so an untruncated report would fail the whole submission with a validation error
+ * the reporter cannot act on, on the exact surface that exists to collect reports.
+ * Same reading as every other bound here: `context` is a JSONB column and everything
+ * in it is client-supplied.
+ */
+export const FEEDBACK_FILTER_VALUE_MAX_LENGTH = 200;
 
 export const feedbackAreaFlagKey = (area: FeedbackArea) => `feedback-area-${area}`;


### PR DESCRIPTION
## What

Adds a second feedback surface — the **`apps-marketplace`** area — and mounts it at the top of `/apps`.

The per-area machinery already exists, so this is small by design: `FEEDBACK_AREAS` is a plain string union (no Prisma enum, no migration) and the Flipt flag key is derived from the slug, so the change is one constant, one mount, and the flag itself (added separately in the flag-state repo as `feedback-area-apps-marketplace`).

| | |
|---|---|
| notice | "Apps are new here. If something's missing or looks off, tell us." |
| placeholder | "What were you trying to do? Missing apps, broken listings, confusing pages, anything." |
| flag | `feedback-area-apps-marketplace` (derived) |

## What the report carries

`/apps` keeps its kind / category / sort / search state in the query string, so the context is a straight read of the URL through the same `parseAppsStoreFilters` the store body uses — one source, no lifted state, no second copy of the defaults. A one-line report ("the list is empty") arrives next to the view it was written about rather than just a path.

🔴 **The search term is CLIPPED.** `context.filters` bounds each value and a zod `max()` **rejects** rather than truncates, so passing a long search term through would fail the whole submission with a validation error the reporter cannot act on — on the one surface whose job is to accept reports. The clip lives in a named function (`buildAppsStoreFeedbackContext`) rather than inline in the page precisely so it is reachable by a test, and the bound it clips to is now the exported `FEEDBACK_FILTER_VALUE_MAX_LENGTH` (same value, 200, no widening) so the caller and the schema cannot drift apart.

`category: null` is reported as the string `'none'` rather than dropped — a missing key reads as "we don't know" in triage, which is a different claim from "no category was selected". `?? undefined` is not an alternative: an explicit `undefined` is a record *value* here and fails the union.

## Two decisions worth a look

- **`active` is unconditional.** The images-feed mount gates on `feedSnapshot.source === 'bitdex'` because that prompt asks about one specific backend and would misattribute reports about any other. This one asks about the page as a whole, so there is no equivalent condition; inventing one would only make the surface silently dark. Rollout is the flag's job.
- **Placement.** Above the store's search/sort row, mirroring where the images feed mounts it (above the grid, not after it). It costs no vertical space in the ordinary case — `FeedbackPrompt` already requires a signed-in user and returns null when the area resolves off, so for everyone outside the flag's segments the page is byte-identical to before and nothing is pushed below the fold.

## Tests

Extended the three existing feedback suites and added one for the context builder. 96 assertions green across the six touched/related files.

**Every new guard was watched to fail with the change reverted, for its own reason:**

| mutation | result |
|---|---|
| drop `'apps-marketplace'` from `FEEDBACK_AREAS` | **15 red** across all four files — `ZodError: invalid_value, values: ["bitdex-image-feed"]` |
| make the service ignore its `area` argument when deriving the flag key | **3 red** — `expected 'feedback-area-bitdex-image-feed' to be 'feedback-area-apps-marketplace'`; the bitdex cases stay green, which is what makes it an isolated kill |
| drop the `.slice(...)` clip (narrowest expression) | **2 red** — `expected … to have a length of 200 but got 201`; a negative control in the same block proves the unclipped value really is rejected by the schema, so "does not throw" is not vacuous |
| drop the `?? 'none'` category fallback | its own test red — `expected undefined to be 'none'` |

Typecheck: **94 pre-existing errors on this branch and 94 on `origin/main`, the same set byte for byte** (all in unrelated files, a stale generated client against unrelated schema changes) — zero introduced. Lint and prettier clean on all eight files.

## Not done, on purpose

- **No read endpoint.** The feedback system is write-only today and that is out of scope here.
- **No test on the page mount itself.** The context *builder* is covered, the area and flag key are covered end-to-end through the real router, but nothing asserts that `/apps` actually renders a `<FeedbackPrompt area="apps-marketplace">`. A structural scan of the page source would be a spelled guard rather than a behavioural one; a real render test of a `getServerSideProps` page is a bigger piece of scaffolding than this change warrants. Flagging it rather than pretending it is covered.
- The flag lands in the flag-state repo, in its own PR. Neither order breaks anything: with the flag on and this code absent nothing renders, and with this code present and the flag absent the prompt is simply dark.
