### PR TITLE
test(moderator-endpoint): use the canonical redis mock (unblocks the shared-mock ratchet on main)

### DIFF
--- a/src/server/utils/__tests__/moderator-endpoint.test.ts
+++ b/src/server/utils/__tests__/moderator-endpoint.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as z from 'zod';
+import { redisMock } from '~/__tests__/mocks';
 
 // Minimal NextApiRequest/Response stand-in (avoids a node-mocks-http dependency).
 function createMocks({
@@ -39,31 +40,26 @@ function createMocks({
   return { req, res };
 }
 
-const { mockGetSession, mockServerSession, mockRedis, mockAudit, mockMultiIncr } = vi.hoisted(
-  () => {
-    const mockMultiIncr = { value: 1 };
-    const multiFactory = () => ({
-      set: vi.fn().mockReturnThis(),
-      incr: vi.fn().mockReturnThis(),
-      exec: vi.fn().mockImplementation(async () => ['OK', mockMultiIncr.value]),
-    });
-    return {
-      mockGetSession: vi.fn(),
-      mockServerSession: vi.fn(),
-      mockRedis: { multi: vi.fn(multiFactory), ttl: vi.fn().mockResolvedValue(60) },
-      mockAudit: vi.fn(),
-      mockMultiIncr,
-    };
-  }
-);
+const { mockGetSession, mockServerSession, mockAudit } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockServerSession: vi.fn(),
+  mockAudit: vi.fn(),
+}));
+
+// `sysRedis` comes from the canonical redis mock, registered globally in
+// src/__tests__/setup.ts — see docs/testing/shared-module-mocks.md. Only the two commands this
+// endpoint uses are stubbed, in `beforeEach`; `REDIS_SYS_KEYS` stays the REAL table, so the
+// rate-limit key this test exercises is the one production builds, and it cannot go stale.
+const mockMultiIncr = { value: 1 };
+const multiFactory = () => ({
+  set: vi.fn().mockReturnThis(),
+  incr: vi.fn().mockReturnThis(),
+  exec: vi.fn().mockImplementation(async () => ['OK', mockMultiIncr.value]),
+});
 
 vi.mock('~/server/auth/bearer-token', () => ({ getSessionFromBearerToken: mockGetSession }));
 vi.mock('~/server/auth/get-server-auth-session', () => ({
   getServerAuthSession: mockServerSession,
-}));
-vi.mock('~/server/redis/client', () => ({
-  sysRedis: mockRedis,
-  REDIS_SYS_KEYS: { RETOOL_ENDPOINT: { RATE_LIMIT: 'retool-endpoint:rate-limit' } },
 }));
 vi.mock('~/server/clickhouse/client', () => ({
   Tracker: class {
@@ -107,7 +103,8 @@ const signedInAs = (user: Partial<typeof MOD>) =>
 beforeEach(() => {
   vi.clearAllMocks();
   mockMultiIncr.value = 1;
-  mockRedis.ttl.mockResolvedValue(60);
+  redisMock.sysRedis.multi.mockImplementation(multiFactory);
+  redisMock.sysRedis.ttl.mockResolvedValue(60);
   signedInAs({});
 });
 


### PR DESCRIPTION
Follow-up to 394b4bc806 ("migrate retool endpoints to moderator endpoints"). That change landed a good test file; it just predates knowing that `~/server/redis/client` is now off-limits to a per-file `vi.mock`.

## The problem

`src/server/services/__tests__/no-direct-shared-module-mock.test.ts` is **red on `main`**, with exactly one violation:

```
AssertionError: These files mock a module that has a canonical mock...
+ [ "src/server/utils/__tests__/moderator-endpoint.test.ts" ]
```

`~/server/redis/client` is in `CANONICAL_SPECIFIERS` — it has a canonical mock at `src/__tests__/mocks/redis.mock.ts`, registered globally in `src/__tests__/setup.ts`. Because the ratchet runs in the shared unit project, this blocks unrelated PRs through the merge commit.

## The fix

Migrate to the canonical mock. Delete the per-file factory and stub the two commands the endpoint actually calls on `redisMock.sysRedis` (`multi`, `ttl`) in `beforeEach`.

`REDIS_SYS_KEYS` now comes from the **real** table, via the global registration's `...(await import('@civitai/redis/client'))`. The removed factory restated `RETOOL_ENDPOINT.RATE_LIMIT` as a literal — that is the wholesale-mock staleness the ratchet exists to prevent: rename the key in the package and the test would keep passing against a string production no longer builds.

**Not allowlisted on purpose.** `direct-mock-allowlist.json` is for pre-existing violations pending migration; recording a newly-landed one would defeat the ratchet.

Nothing else in the file needed touching. The other `vi.mock` calls target `~/server/clickhouse/client` and `~/server/utils/endpoint-helpers` (both `PENDING_SPECIFIERS` — counted, deliberately not enforced) plus the two auth modules and `@civitai/next-axiom`, which are not guarded at all.

## Verification

**The ratchet, red → green** (`vitest run --project 'unit*' src/server/services/__tests__/no-direct-shared-module-mock.test.ts`):

| | Test Files | Tests |
|---|---|---|
| at `origin/main` (6c96682532) | 1 failed | 1 failed \| 2 passed (3) |
| at this branch | 1 passed | 3 passed (3) |

**The migrated file keeps every case** — 18 collected, 18 passing, both ways, and the test-name sets diff clean:

| | Tests |
|---|---|
| before | 18 passed (18) |
| after | 18 passed (18) |

**Both new stubs are load-bearing**, not decoration — mutation-checked:

- remove the `redisMock.sysRedis.multi` wiring → **7 tests fail**
- change `ttl` 60 → 99 → the `Retry-After` case fails with its own assertion: `expected '99' to be '60'`

**Full unit project** (`pnpm test:unit:run`): `1151 passed | 1 skipped (1152)` files, `18144 passed | 21 skipped (18165)` tests, 0 failures, no timeout panics. Also `pnpm typecheck` → 0 errors, eslint clean, prettier clean.
