### PR TITLE
docs(tests): correct the "CI does not run the component suite" claim in 11 comments

### DIFF
--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -135,8 +135,9 @@ import type {
  * not, and must not become, an embedded runtime.
  *
  * Structurally pinned in the node `unit` project
- * (`__tests__/appListingDetailView.test.ts`, "no raw `<iframe>` may return"), because
- * CI does not run the browser `component` suite.
+ * (`__tests__/appListingDetailView.test.ts`, "no raw `<iframe>` may return"), because the
+ * browser `component` suite runs only in the PR preview pipeline — report-only, and not a
+ * required check — so a guard pinned only there is not reliably exercised.
  *
  * XSS / encoding discipline (mirrors P2b): external hrefs are https-guarded in the
  * pure view-model (`safeExternalHref`) + rendered with rel="noopener noreferrer"
@@ -294,8 +295,10 @@ function HeroCover({
  * 🔴 THE WIRING IS NOT — do not read the line above as licence to skip the browser
  * tier. That this component hands the view-model the REAL `preview` value, rather than
  * a literal or an inverted one, is pinned ONLY in `AppListingDetailBody.browser.test.tsx`,
- * which CI does not run. Mutating the call site to `{ preview: false }` leaves the whole
- * node suite green. Rule and wiring are separate claims; only the first one is gated.
+ * which runs solely as `preview / component-tests` in the PR preview pipeline — report-only,
+ * not a required check, and not reported at all when the preview build fails. Mutating the
+ * call site to `{ preview: false }` leaves the whole node suite green. Rule and wiring are
+ * separate claims; only the first one is gated.
  *
  * 🔴 The hover MESSAGE is likewise decided there and passed through UNCONDITIONALLY.
  * `StatHoverCard` renders `message` INSTEAD of `value`, so a ternary that supplied the

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -415,9 +415,10 @@ describe('getDetailPrimaryAction — off-site', () => {
  *
  * `AppListingDetailBody`'s docstring states this in 🔴 terms, and the ONLY other
  * check on it is an absence assertion in `AppListingDetailBody.browser.test.tsx`
- * — which lives in the browser `component` project, **which CI does not run**
- * (see this file's header and `recentAppsRail.test.ts`). Without the check
- * below, re-adding `<iframe src={liveUrl}>` would pass every gate that runs.
+ * — which lives in the browser `component` project, **run only by the PR preview
+ * pipeline, report-only and not a required check** (see this file's header and
+ * `recentAppsRail.test.ts`). Without the check below, re-adding
+ * `<iframe src={liveUrl}>` would pass every gate that actually blocks.
  *
  * This replaces the equivalent gate that lived in the now-deleted
  * `appListingPreview.test.ts` — that one pinned the frame's hardening

--- a/src/components/Apps/__tests__/appsStoreQueryParams.test.ts
+++ b/src/components/Apps/__tests__/appsStoreQueryParams.test.ts
@@ -13,8 +13,9 @@ import {
  *
  * The browser-mode suite covers the wiring (does the dropdown write the param,
  * does a seeded mount drive the query); this covers the DECISIONS — what an
- * invalid param does, what reaches the URL, and what the badge counts. CI does
- * not run the browser project, so these are the ones that actually gate a PR.
+ * invalid param does, what reaches the URL, and what the badge counts. The
+ * browser project runs only in the PR preview pipeline and is report-only, so
+ * these are the ones that actually gate a PR.
  */
 
 describe('parseAppsStoreFilters — a bare /apps', () => {

--- a/src/components/Apps/__tests__/recentAppsRail.test.ts
+++ b/src/components/Apps/__tests__/recentAppsRail.test.ts
@@ -366,8 +366,9 @@ describe('selectChromeRecentApps — the app-chrome "Recently run" menu', () => 
    * in isolation; none of it would fail if `AppBlockChrome` went back to
    * filtering inline, or if the fail-closed default flipped. The only test that
    * exercises the real menu lives in the browser (`component`) project, which
-   * CI does not run — so the wiring is pinned HERE, structurally, in the suite
-   * that does run.
+   * only the PR preview pipeline runs — report-only, not a required check, and
+   * skipped whenever the preview build fails — so the wiring is pinned HERE,
+   * structurally, in the suite that runs on every PR.
    */
   describe('AppBlockChrome is actually WIRED to this gate', () => {
     const SRC = path.resolve(__dirname, '../../..');

--- a/src/components/Apps/__tests__/recentlyOpenedAppsStore.test.ts
+++ b/src/components/Apps/__tests__/recentlyOpenedAppsStore.test.ts
@@ -18,9 +18,10 @@ import { resolveRecentApp } from '~/components/Apps/recentAppsRail';
  * whole v3 validation layer (`coerce`) exists because anybody can hand-edit
  * `localStorage.recentlyOpenedApps` and every previously-shipped entry shape is
  * still in the wild. The existing coverage lived only in
- * `recents-helper.browser.test.tsx` — and CI does not run the browser
- * (`component`) project AT ALL (no Chromium), so on a PR nothing was watching
- * that validation. The `unit` project at least runs on every PR
+ * `recents-helper.browser.test.tsx` — and the browser (`component`) project runs
+ * only in the PR preview pipeline, report-only and behind a preview build that
+ * fails intermittently, so on a PR very little was reliably watching that
+ * validation. The `unit` project at least runs on every PR
  * (`.github/workflows/lint.yml`), which is why behavioural coverage belongs
  * here; the browser suite keeps its real-`window` prepend/dedup/cap coverage.
  *

--- a/src/components/Apps/appListingDetailView.ts
+++ b/src/components/Apps/appListingDetailView.ts
@@ -4,9 +4,11 @@
  * The kind-aware PRIMARY-ACTION logic for the unified listing detail
  * (`AppListingDetailBody`), extracted into a pure function so the correctness
  * coverage lives in the node `unit` project — the fast, deterministic suite,
- * which CI runs `continue-on-error` while not running the browser-mode component
- * suites at all. Neither BLOCKS a merge; this is simply where the detail action
- * matrix is actually pinned, mirroring `appListingCardView`.
+ * which CI runs `continue-on-error` on every PR, whereas the browser-mode
+ * component suites run only in the PR preview pipeline, report-only and behind a
+ * preview build that fails intermittently. Neither BLOCKS a merge; this is simply
+ * where the detail action matrix is actually pinned, mirroring
+ * `appListingCardView`.
  *
  * DARK / parallel-run: consumed by the mod-only `/apps/store-preview/<slug>`
  * detail surface (`AppListingDetailBody`) AND by `MySubmissionsList`'s owner

--- a/src/components/Apps/appsStoreQueryParams.ts
+++ b/src/components/Apps/appsStoreQueryParams.ts
@@ -20,9 +20,10 @@ import {
  * a zod schema over `router.query`, read through `useZodRouteParams` (see
  * `useAppsStoreQueryParams.ts`, and `useModelQueryParams2` for the precedent).
  *
- * REACT-FREE ON PURPOSE. CI does not run the browser-mode (`component`) suites
- * at all, so the parse/serialise decisions that decide whether a shared link
- * works have to be coverable by the node `unit` project — same split as
+ * REACT-FREE ON PURPOSE. The browser-mode (`component`) suites run only in the PR
+ * preview pipeline, report-only and not a required check, so the parse/serialise
+ * decisions that decide whether a shared link works have to be coverable by the
+ * node `unit` project — same split as
  * `appListingCardView` / `recentAppsRail` / `appListingGrid`.
  *
  * 🔴 EVERY FIELD DEGRADES INDEPENDENTLY (`.catch(...)` per field, not one

--- a/src/components/Apps/recentAppsRail.ts
+++ b/src/components/Apps/recentAppsRail.ts
@@ -3,9 +3,10 @@
  *
  * Turns the tolerant localStorage `RecentApp[]` (see `recentlyOpenedAppsStore`)
  * into the exact list the `/apps` store rail renders, and decides each entry's
- * link target. Extracted as a pure module on purpose: CI does not run the
- * civitai browser-mode (`component`) suites at all (they need Chromium), so the
- * coverage that actually runs on a PR has to live in the node `unit` project —
+ * link target. Extracted as a pure module on purpose: the browser-mode
+ * (`component`) suites run only in the PR preview pipeline — report-only, not a
+ * required check, and skipped whenever the preview build fails — so the coverage
+ * that runs on every PR has to live in the node `unit` project —
  * mirroring `appListingCardView` / `appListingDetailView`. (Neither project
  * BLOCKS a merge — the `Unit tests` job is `continue-on-error` — so "runs on
  * every PR" is the whole of the claim.)

--- a/src/components/Feedback/selectAttachments.ts
+++ b/src/components/Feedback/selectAttachments.ts
@@ -5,7 +5,8 @@
  * count cap and the size cap are applied, so having one function makes "the rules"
  * a single object rather than a predicate open-coded across handlers. And it lives
  * in the `unit` test project, which is the tier that actually gates — a rule pinned
- * only by a browser-mode component test is a rule nobody's CI reads.
+ * only by a browser-mode component test rides on the PR preview pipeline, which is
+ * report-only and skipped whenever the preview build fails.
  */
 export type AttachmentSelection = {
   /** In picked order, already trimmed to the remaining slots. */

--- a/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
@@ -311,9 +311,9 @@ describe('getMyRevenue — dark-flag short-circuit', () => {
     // 🔴 THE POINT OF THE CHANGE, and the only assertion in CI that sits at the proc
     // boundary this contract actually ships through. Without it, the zeroed buckets
     // above are byte-identical to a publisher who genuinely earned nothing — which is
-    // exactly the bug. The renderer guards live in the `component` project, which CI
-    // does not run at all, so do not delete this on the grounds that a panel test
-    // covers it.
+    // exactly the bug. The renderer guards live in the `component` project, which only
+    // the PR preview pipeline runs — report-only and not a required check — so do not
+    // delete this on the grounds that a panel test covers it.
     expect(result.unavailable).toBe('notEntitled');
   });
 


### PR DESCRIPTION
## The wrong claim

Eleven comments across ten files assert, in various wordings, that **"CI does not run the browser `component` suite"** — and that assertion is cited as the justification for where load-bearing guards get placed. Sample wordings:

- `AppListingDetailBody.tsx` — "…because CI does not run the browser `component` suite."
- `appListingDetailView.test.ts` — "…which lives in the browser `component` project, **which CI does not run**"
- `recentAppsRail.ts` — "CI does not run the civitai browser-mode (`component`) suites at all (they need Chromium)"
- `selectAttachments.ts` — "a rule pinned only by a browser-mode component test is a rule nobody's CI reads"

Someone reading that concludes the browser suite is never exercised by anything. It is false, and it would lead them to distrust a suite that does provide signal.

## What is actually true — measured

**1. The GitHub Actions tier does not run it.** This half of the claim is correct. The Actions check-runs on `670e8a2028` are exactly: `ESLint + Prettier (changed files)`, `Schema drift gate`, `event-engine-common pin`, `Unit tests`, `Package unit tests`, `App unit tests` (plus `Typecheck (fork PRs / non-main base)`, skipped). No component job.

**2. The PR preview pipeline does run it**, as a check named `preview / component-tests`. On commit `670e8a2028` of #4058 it reported **`success`**, alongside `preview / unit-tests`, `preview / auth-tests`, `preview / packages-tests`, `preview / apps-tests` and `preview / smoke-tests`. That tree contained `AppListingDetailBody.browser.test.tsx` — one of the very files these comments describe as never executed.

**3. But it is weak as a gate, in four ways** — which is why the *guidance* survives even though the *reason* did not:

- **It is report-only.** The suite runs under a report-only contract that always exits 0, so a red component suite cannot fail the pipeline. The commit status does flip to `failure`, but nothing acts on it.
- **No status checks are required on `main`.** `GET /repos/civitai/civitai/branches/main/protection/required_status_checks` returns `404 Required status checks not enabled`, so a red check does not block a merge.
- **Its verdict is only published once the preview deploy has succeeded.** The task that posts the `preview / component-tests` status also depends on the preview-verification step, so a failed build means the status never appears at all. Observed on this same PR: the final head commit `f5a707b512` carries `preview / deploy` = `failure` and **no suite statuses whatsoever**.
- **The preview build fails intermittently**, on an unrelated Turbopack chunk-hash collision — see `claudedocs/turbopack-chunk-hash-collision-2026-08-18.md` (#4084). In practice the suite is skipped often.

### One correction to how this was originally framed

It is tempting to say the component suite "runs after the preview deploy, so a build failure means it never executes." That is not the mechanism. The suite sits on a chain parallel to the image build, so it can and does execute while the build is failing. What depends on the deploy is **publication of its verdict** — the status-posting step. The practical consequence is the same (a failed build means no component-tests signal on the PR), but the accurate statement is about reporting, not execution.

## Why the guidance was still right

"Put load-bearing guards in the node `unit` project" remains correct. A guard pinned only in the browser project rides on a report-only, non-required check whose result is frequently never posted — so it can silently stop being exercised without anyone noticing. The conclusion was sound; only the stated reason was wrong, and the wrong reason is the more damaging thing to leave in place, because it tells the next reader the suite is worthless rather than merely weak.

Note the repo already had accurate wording elsewhere — `AppsPageLayout.geometry.browser.test.tsx` and the `appListingCardView` / `appListingModerationView` / `offsiteOwnerControls` family already describe the suite as "report-only" / "non-blocking". This PR brings the outliers into line with those.

## Sites corrected (11 across 10 files)

| File | Line |
|---|---|
| `src/components/Apps/AppListingDetailBody.tsx` | 139, 297 |
| `src/components/Apps/__tests__/appListingDetailView.test.ts` | 418 |
| `src/components/Apps/__tests__/recentAppsRail.test.ts` | 369 |
| `src/components/Apps/__tests__/recentlyOpenedAppsStore.test.ts` | 21 |
| `src/components/Apps/__tests__/appsStoreQueryParams.test.ts` | 17 |
| `src/components/Apps/appsStoreQueryParams.ts` | 23 |
| `src/components/Apps/recentAppsRail.ts` | 6 |
| `src/components/Apps/appListingDetailView.ts` | 7 |
| `src/components/Feedback/selectAttachments.ts` | 8 |
| `src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts` | 315 |

Four of these were beyond the originally-identified set (`appsStoreQueryParams.test.ts`, `appListingDetailView.ts`, `selectAttachments.ts`, `blocks.router.getMyAppAnalytics.test.ts`). Wording is varied per site rather than pasted, and each surrounding argument was re-read so it still follows after the edit.

`.claude/skills/**`, `docs/` and `claudedocs/` were swept for the same assertion — no occurrences.

## Verification

Comments-only, so the regression surface is nil — but proven rather than asserted:

- **No executable change.** Every added/removed line in the diff begins with `*` or `//`. Confirmed independently by stripping all comments and whitespace from both the `HEAD` and working-tree version of all ten files and comparing: **10 files, 0 code-changed**. The comparator was validated with a positive control — planting a real statement made it report `CODE-CHANGED`, and restoring returned it to `CODE-IDENTICAL`.
- **Two touched files are test files whose comments describe what they guard**; the comment-stripped comparison above covers them, so no assertion changed.
- `node scripts/typecheck.mjs` → **0 type errors** in 75s.
- Node `unit` project over the touched directories (`src/components/Apps`, `src/components/Feedback`, `src/server/routers`) → **97 test files passed (97), 2014 tests passed (2014)**.
- **ESLint** on the 10 changed files → **0 errors**, 4 warnings, all pre-existing `no-unused-vars` at lines 127–130 of `blocks.router.getMyAppAnalytics.test.ts`, far from the edit.
- **Prettier** on the 10 changed files → 2 files flagged. **Pre-existing**: restoring the `HEAD` version of those two files in place and re-running gives the identical 2 warnings, so this change introduces no formatting regression. (Both are modified, not added, so Prettier is report-only for them in the Lint workflow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
