### PR TITLE
feat(collections): group liked and bookmarked collections in their own sidebar section

### DIFF
--- a/src/components/Collections/__tests__/collection-list.utils.test.ts
+++ b/src/components/Collections/__tests__/collection-list.utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { CollectionMode } from '~/shared/utils/prisma/enums';
 import {
   buildCollectionSections,
   getMembership,
@@ -22,6 +23,31 @@ describe('getMembership', () => {
 
   it('falls back to following when permissions have not loaded yet', () => {
     expect(getMembership({ isOwner: false }, undefined)).toBe('following');
+  });
+
+  // Bookmark collections are owned, so ownership alone must not decide the section.
+  it('classifies an owned bookmark collection as bookmarks, not owned', () => {
+    expect(getMembership({ isOwner: true, mode: CollectionMode.Bookmark }, undefined)).toBe(
+      'bookmarks'
+    );
+  });
+
+  it('leaves an owned collection in another mode under owned', () => {
+    expect(getMembership({ isOwner: true, mode: CollectionMode.Contest }, undefined)).toBe('owned');
+  });
+
+  it('leaves an owned collection with no mode under owned', () => {
+    expect(getMembership({ isOwner: true, mode: null }, undefined)).toBe('owned');
+  });
+
+  // The bookmark section holds the user's own bookmark collections. Someone else's is theirs.
+  it('classifies a non-owned bookmark collection by permissions', () => {
+    expect(getMembership({ isOwner: false, mode: CollectionMode.Bookmark }, undefined)).toBe(
+      'following'
+    );
+    expect(
+      getMembership({ isOwner: false, mode: CollectionMode.Bookmark }, { isCollaborator: true })
+    ).toBe('shared');
   });
 });
 
@@ -68,8 +94,9 @@ describe('buildCollectionSections', () => {
     ]);
   });
 
-  it('always emits all three sections so none can be filtered away', () => {
+  it('always emits every section, in order, so none can be filtered away', () => {
     expect(buildCollectionSections([], new Map()).map((s) => s.key)).toEqual([
+      'bookmarks',
       'owned',
       'shared',
       'following',
@@ -97,6 +124,55 @@ describe('buildCollectionSections', () => {
     );
     const sections = buildCollectionSections(sorted, new Map());
     expect(sections.find((s) => s.key === 'following')?.rows.map((r) => r.id)).toEqual([5, 4]);
+  });
+});
+
+describe('buildCollectionSections bookmarks', () => {
+  const made = { id: 1, isOwner: true };
+  const likedModels = { id: 2, isOwner: true, mode: CollectionMode.Bookmark };
+  const bookmarkedArticles = { id: 3, isOwner: true, mode: CollectionMode.Bookmark };
+  const someoneElses = { id: 4, isOwner: false, mode: CollectionMode.Bookmark };
+  const rows = [made, likedModels, bookmarkedArticles, someoneElses];
+
+  // Reporting the section a row landed in — rather than a section's contents — names the bucket a
+  // regression put it in, so a bookmark row falling back into `owned` reads as exactly that.
+  const sectionOf = (
+    sections: ReturnType<typeof buildCollectionSections>,
+    id: number
+  ): string | undefined => sections.find((s) => s.rows.some((r) => r.id === id))?.key;
+
+  it('files every owned bookmark collection under bookmarks', () => {
+    const sections = buildCollectionSections(rows, new Map());
+    expect(sectionOf(sections, likedModels.id)).toBe('bookmarks');
+    expect(sectionOf(sections, bookmarkedArticles.id)).toBe('bookmarks');
+  });
+
+  it('leaves the collections the user made in owned', () => {
+    const sections = buildCollectionSections(rows, new Map());
+    expect(sectionOf(sections, made.id)).toBe('owned');
+    expect(sections.find((s) => s.key === 'owned')?.rows.map((r) => r.id)).toEqual([made.id]);
+  });
+
+  it("keeps someone else's bookmark collection out of the bookmarks section", () => {
+    const sections = buildCollectionSections(rows, new Map());
+    expect(sectionOf(sections, someoneElses.id)).toBe('following');
+  });
+
+  it('still places each row in exactly one section', () => {
+    const sections = buildCollectionSections(rows, new Map());
+    expect(sections.flatMap((s) => s.rows.map((r) => r.id)).sort()).toEqual([1, 2, 3, 4]);
+  });
+
+  it('preserves the incoming order inside the bookmarks section', () => {
+    const sorted = sortCollections(
+      [
+        { id: 2, isOwner: true, mode: CollectionMode.Bookmark, name: 'Liked Models' },
+        { id: 3, isOwner: true, mode: CollectionMode.Bookmark, name: 'Bookmarked Articles' },
+      ],
+      'name-asc'
+    );
+    const sections = buildCollectionSections(sorted, new Map());
+    expect(sections.find((s) => s.key === 'bookmarks')?.rows.map((r) => r.id)).toEqual([3, 2]);
   });
 });
 

--- a/src/components/Collections/collection-list.utils.ts
+++ b/src/components/Collections/collection-list.utils.ts
@@ -1,8 +1,11 @@
+import { CollectionMode } from '~/shared/utils/prisma/enums';
+
 export type CollectionListView = 'default' | 'compact';
 export type CollectionSort = 'name-asc' | 'name-desc' | 'recently-added' | 'recently-updated';
-export type CollectionMembership = 'owned' | 'shared' | 'following';
+export type CollectionMembership = 'bookmarks' | 'owned' | 'shared' | 'following';
 
 type PermissionFlags = { isCollaborator?: boolean; manage?: boolean } | undefined;
+type SectionCollection = { isOwner: boolean; mode?: CollectionMode | null };
 
 export const SORT_OPTIONS: { value: CollectionSort; label: string }[] = [
   { value: 'name-asc', label: 'Name A–Z' },
@@ -14,15 +17,20 @@ export const SORT_OPTIONS: { value: CollectionSort; label: string }[] = [
 // `isCollaborator` is the server's "elevated beyond the collection's free grant" test
 // (collection.service.ts). CollectionContributor also stores follow rows, so a row alone
 // never means shared — only that flag does.
+// Bookmark collections are owned by the user, so they must be picked off before the ownership
+// branch or they fall in with the collections the user made themselves. Still gated on ownership:
+// someone else's Bookmark collection is not one of yours.
 export function getMembership(
-  collection: { isOwner: boolean },
+  collection: SectionCollection,
   permissions: PermissionFlags
 ): CollectionMembership {
+  if (collection.mode === CollectionMode.Bookmark && collection.isOwner) return 'bookmarks';
   if (collection.isOwner) return 'owned';
   return permissions?.isCollaborator ? 'shared' : 'following';
 }
 
 const SECTION_LABELS: Record<CollectionMembership, string> = {
+  bookmarks: 'Likes & bookmarks',
   owned: 'Owned',
   shared: 'Shared with me',
   following: 'Following',
@@ -31,16 +39,21 @@ const SECTION_LABELS: Record<CollectionMembership, string> = {
 // Every row lands in exactly one section, so nothing can be filtered out of the rendered set.
 // `permissions` is empty whenever the collaborative flag is off or its query hasn't resolved,
 // which classifies non-owned rows as following rather than dropping them.
-export function buildCollectionSections<T extends { id: number; isOwner: boolean }>(
+export function buildCollectionSections<T extends { id: number } & SectionCollection>(
   collections: T[],
   permissions: ReadonlyMap<number, PermissionFlags>
 ): { key: CollectionMembership; label: string; rows: T[] }[] {
-  const rows: Record<CollectionMembership, T[]> = { owned: [], shared: [], following: [] };
+  const rows: Record<CollectionMembership, T[]> = {
+    bookmarks: [],
+    owned: [],
+    shared: [],
+    following: [],
+  };
   for (const collection of collections) {
     rows[getMembership(collection, permissions.get(collection.id))].push(collection);
   }
 
-  return (['owned', 'shared', 'following'] as const).map((key) => ({
+  return (['bookmarks', 'owned', 'shared', 'following'] as const).map((key) => ({
     key,
     label: SECTION_LABELS[key],
     rows: rows[key],


### PR DESCRIPTION
Resolves [CU 868ktfjua](https://app.clickup.com/t/868ktfjua) (Freshdesk 69638).

## Why

The built-in bookmark collections — `Liked Models` / `Favorite Models`, `Bookmarked Articles` — are created for the user and owned by them, so they sat mixed in with the collections the user made themselves. The reporter organizes favorites into their own per-category collections and asked for a way to delete or hide the default one.

We are **not** adding a delete or hide path. Those collections back the like and bookmark buttons; `deleteCollectionById` refuses them and `CollectionContextMenu` already hides Delete, both deliberately. Instead they now lead the sidebar in their own collapsible section, which resolves the actual complaint — an unused default cluttering the list — without handing anyone a delete path to a system collection. Section collapse state already persists per user, so anyone who never uses them collapses it once and it stays that way.

## What changed

One file, `src/components/Collections/collection-list.utils.ts`:

- `CollectionMembership` gains a `'bookmarks'` member; section order is Likes & bookmarks → Owned → Shared with me → Following.
- `getMembership` tests `mode === CollectionMode.Bookmark` **before** the ownership branch — these collections are owned, so an ownership-first branch would swallow them — and still requires ownership, so someone else's bookmark collection is not filed as yours.

Classification is on `mode`, never the name. Legacy accounts carry a collection literally named `Favorite Models` (from `migrate-likes.ts`) while newer ones get `Liked Models` (from `user.service.ts`); both are `mode: Bookmark`, so keying on mode makes the naming split irrelevant.

The label is **"Likes & bookmarks"** rather than the mode name: users never pick Bookmark mode, and by row count roughly half of what lands there arrives via the like action on a model (`Liked Models` 7.07M + `Favorite Models` 545K) rather than a bookmark (`Bookmarked Articles` 7.6M). "Saved" was rejected because the Save button on images and models already means "add to a collection you pick" (`AddToCollectionModal`).

**No server, schema or migration work.** `getUserCollectionsWithPermissions` already selects `c."mode"`, and it reaches the client through `CollectionGetAllUserModel`. `MyCollections.tsx` and `CollectionsLayout.tsx` are untouched — they render whatever sections the helper returns. Collapse-state storage needed no migration either: it stores an array of section keys, so a new key is additive.

## Testing

- `pnpm run typecheck` — 0 errors.
- `pnpm run test:unit:run` — 1160 files / 18339 tests passed.
- 12 new/updated cases in `collection-list.utils.test.ts`.

Per CLAUDE.md, the tests were checked for how they **fail**, not just that they pass: reverting to an ownership-first branch produces 5 failures reading `expected 'owned' to be 'bookmarks'`, rather than a silent pass.

Checked in the browser on the dev DB as user 4 — an account that is a good witness for the naming split, since it holds both `Favorite Models` (mode Bookmark) and a user-made `My favorite models` (mode null). The first moved into the new section; the second stayed in Owned. At the 300px sidebar the longer label renders on one line, 135px of the 298px header, no wrap or clipping, same 29px header height as the other sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)