### PR TITLE
feat(posts): add an Oldest sort option

### DIFF
--- a/src/components/Collections/Collection.tsx
+++ b/src/components/Collections/Collection.tsx
@@ -385,12 +385,17 @@ const ImageCollection = ({
     </ImageContextMenuProvider>
   );
 };
+// Contest rotation randomises the sort on each render to spread entry visibility. Oldest is
+// held out of that pool deliberately: it is the only ascending sort, so a roll landing on it
+// pins the earliest submissions to the top of every contest feed for that render.
+const contestPostSorts = Object.values(PostSort).filter((sort) => sort !== PostSort.Oldest);
+
 const PostCollection = ({ collection }: { collection: NonNullable<CollectionByIdModel> }) => {
   const { replace, query } = usePostQueryParams();
   const period = query.period ?? MetricTimeframe.AllTime;
   const isContestCollection = collection.mode === CollectionMode.Contest;
   const sort = isContestCollection
-    ? getRandom(Object.values(PostSort))
+    ? getRandom(contestPostSorts)
     : query.sort ?? PostSort.Newest;
 
   const filters = isContestCollection

--- a/src/pages/user/[username]/posts.tsx
+++ b/src/pages/user/[username]/posts.tsx
@@ -38,6 +38,8 @@ export const getServerSideProps = createServerSideProps({
   },
 });
 
+const draftSorts = [PostSort.Newest, PostSort.Oldest];
+
 function UserPostsPage() {
   const currentUser = useCurrentUser();
   const {
@@ -57,7 +59,9 @@ function UserPostsPage() {
   );
   const viewingDraft = section === 'draft';
   const effectiveScheduled = viewingDraft ? query.scheduled ?? true : query.scheduled;
-  const sort = viewingDraft ? PostSort.Newest : querySort;
+  // Reaction/comment/collected counts are meaningless on unpublished drafts, and those
+  // sorts filter on `count > 0` server-side, so a draft feed under them comes back empty.
+  const sort = viewingDraft && !draftSorts.includes(querySort) ? PostSort.Newest : querySort;
 
   if (!query.username) return <NotFound />;
 
@@ -80,7 +84,10 @@ function UserPostsPage() {
                     replace({
                       section: section as 'published' | 'draft',
                       scheduled: undefined,
-                      sort: section === 'draft' ? PostSort.Newest : undefined,
+                      sort:
+                        section === 'draft' && draftSorts.includes(querySort)
+                          ? querySort
+                          : undefined,
                     });
                   }}
                 />
@@ -91,7 +98,9 @@ function UserPostsPage() {
                   value={sort}
                   onChange={(x) => replace({ sort: x as PostSort })}
                   options={
-                    viewingDraft ? [{ label: PostSort.Newest, value: PostSort.Newest }] : undefined
+                    viewingDraft
+                      ? draftSorts.map((value) => ({ label: value, value }))
+                      : undefined
                   }
                 />
                 <PostFiltersDropdown

--- a/src/pages/user/[username]/posts.tsx
+++ b/src/pages/user/[username]/posts.tsx
@@ -80,14 +80,17 @@ function UserPostsPage() {
                   size="xs"
                   value={section}
                   onChange={(section) => {
-                    setSection(section as 'published' | 'draft');
+                    const nextSection = section as 'published' | 'draft';
+                    setSection(nextSection);
                     replace({
-                      section: section as 'published' | 'draft',
+                      section: nextSection,
                       scheduled: undefined,
+                      // Carry the sort across the toggle. Only a count sort has to be
+                      // dropped, and only into drafts, where it would filter to nothing.
                       sort:
-                        section === 'draft' && draftSorts.includes(querySort)
-                          ? querySort
-                          : undefined,
+                        nextSection === 'draft' && !draftSorts.includes(querySort)
+                          ? undefined
+                          : querySort,
                     });
                   }}
                 />

--- a/src/server/common/enums.ts
+++ b/src/server/common/enums.ts
@@ -61,6 +61,7 @@ export enum PostSort {
   MostComments = 'Most Comments',
   MostCollected = 'Most Collected',
   Newest = 'Newest',
+  Oldest = 'Oldest',
 }
 
 export enum ImageType {

--- a/src/server/services/__tests__/post-sort-keyset.test.ts
+++ b/src/server/services/__tests__/post-sort-keyset.test.ts
@@ -1,0 +1,327 @@
+import type { Prisma } from '@prisma/client';
+import { describe, expect, it } from 'vitest';
+import { PostSort } from '~/server/common/enums';
+import {
+  buildPostCursorClause,
+  encodePostCursor,
+  getPostSortClauses,
+} from '~/server/services/post-sort';
+
+// `PostSort.Oldest` is the first ascending sort in `getPostsInfinite`. Every other sort is
+// DESC, and the keyset cursor was written for DESC only, so an ORDER BY and a comparison
+// that disagree do not error — they re-serve page 1 forever, or skip the backlog. These
+// tests drive the real clause builders through a bounded in-memory pager so that flipping
+// either half back to DESC fails on the first repeated row instead of hanging the runner.
+
+type Row = { id: number; publishedAt: Date | null; createdAt: Date };
+
+const d = (iso: string) => new Date(iso);
+
+const plusCentury = (date: Date) => {
+  const out = new Date(date);
+  out.setUTCFullYear(out.getUTCFullYear() + 100);
+  return out;
+};
+
+// Drafts (publishedAt null) interleaved with scheduled posts (publishedAt in the future),
+// plus a createdAt tie on 102/103 so the id tiebreaker is actually exercised.
+const draftFeed: Row[] = [
+  { id: 101, publishedAt: null, createdAt: d('2021-01-01T00:00:00.000Z') },
+  { id: 102, publishedAt: null, createdAt: d('2021-06-01T00:00:00.000Z') },
+  { id: 103, publishedAt: null, createdAt: d('2021-06-01T00:00:00.000Z') },
+  { id: 104, publishedAt: null, createdAt: d('2022-01-01T00:00:00.000Z') },
+  { id: 105, publishedAt: null, createdAt: d('2023-01-01T00:00:00.000Z') },
+  { id: 106, publishedAt: null, createdAt: d('2024-01-01T00:00:00.000Z') },
+  { id: 107, publishedAt: null, createdAt: d('2025-01-01T00:00:00.000Z') },
+  { id: 108, publishedAt: null, createdAt: d('2026-01-01T00:00:00.000Z') },
+  { id: 201, publishedAt: d('2026-09-01T00:00:00.000Z'), createdAt: d('2026-08-01T00:00:00.000Z') },
+  { id: 202, publishedAt: d('2026-10-01T00:00:00.000Z'), createdAt: d('2026-08-02T00:00:00.000Z') },
+  { id: 203, publishedAt: d('2026-11-01T00:00:00.000Z'), createdAt: d('2026-08-03T00:00:00.000Z') },
+  { id: 204, publishedAt: d('2026-12-01T00:00:00.000Z'), createdAt: d('2026-08-04T00:00:00.000Z') },
+];
+
+const publishedFeed: Row[] = [
+  { id: 1, publishedAt: d('2019-03-04T10:00:00.000Z'), createdAt: d('2019-03-04T09:00:00.000Z') },
+  { id: 2, publishedAt: d('2020-07-19T10:00:00.000Z'), createdAt: d('2020-07-19T09:00:00.000Z') },
+  { id: 3, publishedAt: d('2020-07-19T10:00:00.000Z'), createdAt: d('2020-07-19T09:30:00.000Z') },
+  { id: 4, publishedAt: d('2021-11-02T10:00:00.000Z'), createdAt: d('2021-11-02T09:00:00.000Z') },
+  { id: 5, publishedAt: d('2023-02-14T10:00:00.000Z'), createdAt: d('2023-02-14T09:00:00.000Z') },
+  { id: 6, publishedAt: d('2024-05-30T10:00:00.000Z'), createdAt: d('2024-05-30T09:00:00.000Z') },
+  { id: 7, publishedAt: d('2025-01-09T10:00:00.000Z'), createdAt: d('2025-01-09T09:00:00.000Z') },
+];
+
+/**
+ * Evaluate one of the sort expressions the module emits against an in-memory row. The
+ * `default` throw is deliberate: if `getPostSortClauses` starts emitting an expression this
+ * pager cannot evaluate, the suite must fail loudly rather than silently pass on a stale
+ * simulation.
+ */
+const evalSortKey = (expr: string, row: Row): number => {
+  switch (expr) {
+    case 'p."publishedAt"':
+      if (!row.publishedAt) throw new Error(`row ${row.id} has a null publishedAt under ${expr}`);
+      return row.publishedAt.getTime();
+    case 'COALESCE(p."publishedAt", p."createdAt")':
+      return (row.publishedAt ?? row.createdAt).getTime();
+    case `COALESCE(p."publishedAt", p."createdAt" + interval '100 years')`:
+      return (row.publishedAt ?? plusCentury(row.createdAt)).getTime();
+    default:
+      throw new Error(`post-sort pager cannot evaluate sort expression: ${expr}`);
+  }
+};
+
+const parseDirection = (orderBy: string) => {
+  const match = orderBy.match(/^(.+?)\s+(ASC|DESC),\s*p\.id\s+(ASC|DESC)$/);
+  if (!match) throw new Error(`unparseable orderBy: ${orderBy}`);
+  const [, , primaryDir, idDir] = match;
+  if (primaryDir !== idDir)
+    throw new Error(`orderBy mixes directions, keyset cursor cannot be single-tuple: ${orderBy}`);
+  return primaryDir === 'ASC' ? 1 : -1;
+};
+
+type ParsedCursor =
+  | { kind: 'composite'; operator: '>=' | '<='; value: number; id: number }
+  | { kind: 'legacy'; operator: '>' | '<'; value: number };
+
+const toNumber = (value: unknown) => (value instanceof Date ? value.getTime() : Number(value));
+
+const parseCursorClause = (clause: Prisma.Sql): ParsedCursor => {
+  const composite = clause.text.match(/\)\s*(>=|<=)\s*\(/);
+  if (composite)
+    return {
+      kind: 'composite',
+      operator: composite[1] as '>=' | '<=',
+      value: toNumber(clause.values[0]),
+      id: Number(clause.values[1]),
+    };
+
+  const legacy = clause.text.match(/\s(>|<)\s\$1$/);
+  if (!legacy) throw new Error(`unparseable cursor clause: ${clause.text}`);
+  return { kind: 'legacy', operator: legacy[1] as '>' | '<', value: toNumber(clause.values[0]) };
+};
+
+const cmpTuple = (a: [number, number], b: [number, number]) => a[0] - b[0] || a[1] - b[1];
+
+/** One page of `getPostsInfinite`, driven entirely by the real clause builders. */
+const fetchPage = ({
+  rows,
+  sort,
+  draftOnly,
+  limit,
+  cursor,
+}: {
+  rows: Row[];
+  sort: PostSort;
+  draftOnly?: boolean;
+  limit: number;
+  cursor?: string;
+}) => {
+  const { orderBy, primarySortProp, isDateSort, ascending } = getPostSortClauses({
+    sort,
+    draftOnly,
+  });
+  const direction = parseDirection(orderBy);
+  const cursorClause = buildPostCursorClause({ cursor, primarySortProp, isDateSort, ascending });
+
+  let candidates = rows.map((row) => ({ row, key: evalSortKey(primarySortProp, row) }));
+
+  if (cursorClause) {
+    const parsed = parseCursorClause(cursorClause);
+    candidates = candidates.filter(({ row, key }) => {
+      if (parsed.kind === 'legacy')
+        return parsed.operator === '>' ? key > parsed.value : key < parsed.value;
+      const cmp = cmpTuple([key, row.id], [parsed.value, parsed.id]);
+      return parsed.operator === '>=' ? cmp >= 0 : cmp <= 0;
+    });
+  }
+
+  candidates.sort((a, b) => direction * cmpTuple([a.key, a.row.id], [b.key, b.row.id]));
+
+  const slice = candidates.slice(0, limit + 1);
+  if (slice.length <= limit) return { items: slice.map((c) => c.row.id), nextCursor: undefined };
+
+  const nextItem = slice.pop();
+  if (!nextItem) throw new Error('unreachable: slice longer than limit but pop returned nothing');
+  const nextCursor = encodePostCursor({
+    id: nextItem.row.id,
+    cursorId: isDateSort ? new Date(nextItem.key) : nextItem.key,
+  });
+  return { items: slice.map((c) => c.row.id), nextCursor };
+};
+
+const PAGE_CAP = 20;
+
+/**
+ * Page to exhaustion. Bounded by construction: the loop can run at most PAGE_CAP times and
+ * throws on the way out, so a cursor that never advances surfaces as a failed assertion or a
+ * thrown error in milliseconds — never as a runner hang.
+ */
+const drain = ({
+  rows,
+  sort,
+  draftOnly,
+  limit,
+}: {
+  rows: Row[];
+  sort: PostSort;
+  draftOnly?: boolean;
+  limit: number;
+}) => {
+  const seen: number[] = [];
+  let cursor: string | undefined;
+  let pages = 0;
+
+  while (pages < PAGE_CAP) {
+    const { items, nextCursor } = fetchPage({ rows, sort, draftOnly, limit, cursor });
+    pages += 1;
+    for (const id of items) {
+      // A comparison pointing against the ORDER BY re-serves rows it already served. Fail on
+      // the first repeat rather than letting the pager spin.
+      expect(seen, `page ${pages} re-served post ${id}`).not.toContain(id);
+      seen.push(id);
+    }
+    if (!nextCursor) return { seen, pages };
+    cursor = nextCursor;
+  }
+
+  throw new Error(
+    `pagination did not terminate within ${PAGE_CAP} pages (collected ${seen.length} of ${rows.length} rows)`
+  );
+};
+
+describe('getPostSortClauses', () => {
+  it('orders the published feed ascending under Oldest', () => {
+    expect(getPostSortClauses({ sort: PostSort.Oldest })).toMatchObject({
+      orderBy: 'p."publishedAt" ASC, p.id ASC',
+      primarySortProp: 'p."publishedAt"',
+      isDateSort: true,
+      ascending: true,
+    });
+  });
+
+  it('keeps every other sort descending', () => {
+    expect(getPostSortClauses({ sort: PostSort.Newest }).orderBy).toBe(
+      'p."publishedAt" DESC, p.id DESC'
+    );
+    for (const sort of [PostSort.MostReactions, PostSort.MostComments, PostSort.MostCollected]) {
+      const clauses = getPostSortClauses({ sort });
+      expect(clauses.ascending).toBe(false);
+      expect(clauses.orderBy).toContain('DESC');
+    }
+  });
+
+  it('drops the +100 years draft offset under Oldest so old drafts outrank scheduled posts', () => {
+    const oldest = getPostSortClauses({ sort: PostSort.Oldest, draftOnly: true });
+    expect(oldest.primarySortProp).toBe('COALESCE(p."publishedAt", p."createdAt")');
+    expect(oldest.orderBy).toBe('COALESCE(p."publishedAt", p."createdAt") ASC, p.id ASC');
+
+    // Newest still needs the offset to pin drafts ahead of scheduled posts.
+    expect(getPostSortClauses({ sort: PostSort.Newest, draftOnly: true }).primarySortProp).toBe(
+      `COALESCE(p."publishedAt", p."createdAt" + interval '100 years')`
+    );
+  });
+
+  it('adds no `> 0` filter for Oldest — it is a date sort, not a count sort', () => {
+    expect(getPostSortClauses({ sort: PostSort.Oldest }).filter).toBeUndefined();
+    expect(getPostSortClauses({ sort: PostSort.Oldest, draftOnly: true }).filter).toBeUndefined();
+    expect(getPostSortClauses({ sort: PostSort.MostReactions }).filter?.text).toBe(
+      'p."reactionCount" > 0'
+    );
+  });
+});
+
+describe('buildPostCursorClause', () => {
+  const primarySortProp = 'p."publishedAt"';
+
+  it('compares forward for an ascending sort and backward for a descending one', () => {
+    const asc = buildPostCursorClause({
+      cursor: '2021-01-01T00:00:00.000Z|42',
+      primarySortProp,
+      isDateSort: true,
+      ascending: true,
+    });
+    const desc = buildPostCursorClause({
+      cursor: '2021-01-01T00:00:00.000Z|42',
+      primarySortProp,
+      isDateSort: true,
+      ascending: false,
+    });
+
+    expect(asc?.text).toBe('(p."publishedAt", p.id) >= ($1, $2)');
+    expect(desc?.text).toBe('(p."publishedAt", p.id) <= ($1, $2)');
+    expect(asc?.values).toEqual([d('2021-01-01T00:00:00.000Z'), 42]);
+  });
+
+  it('flips the strict legacy single-value comparison too', () => {
+    const asc = buildPostCursorClause({
+      cursor: '2021-01-01T00:00:00.000Z',
+      primarySortProp,
+      isDateSort: true,
+      ascending: true,
+    });
+    const desc = buildPostCursorClause({
+      cursor: '2021-01-01T00:00:00.000Z',
+      primarySortProp,
+      isDateSort: true,
+      ascending: false,
+    });
+
+    expect(asc?.text).toBe('p."publishedAt" > $1');
+    expect(desc?.text).toBe('p."publishedAt" < $1');
+  });
+
+  it('returns no clause without a cursor', () => {
+    expect(
+      buildPostCursorClause({ primarySortProp, isDateSort: true, ascending: true })
+    ).toBeUndefined();
+  });
+});
+
+describe('keyset pagination', () => {
+  it('walks the published feed oldest-first with no repeats and no skips', () => {
+    const { seen, pages } = drain({ rows: publishedFeed, sort: PostSort.Oldest, limit: 3 });
+
+    expect(seen).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(pages).toBe(3);
+    expect(pages).toBeLessThan(PAGE_CAP);
+  });
+
+  it('walks the draft feed oldest-first, drafts ahead of scheduled posts', () => {
+    const { seen, pages } = drain({
+      rows: draftFeed,
+      sort: PostSort.Oldest,
+      draftOnly: true,
+      limit: 4,
+    });
+
+    expect(seen).toEqual([101, 102, 103, 104, 105, 106, 107, 108, 201, 202, 203, 204]);
+    expect(pages).toBe(3);
+    expect(pages).toBeLessThan(PAGE_CAP);
+  });
+
+  it('still walks the draft feed newest-first under Newest (unchanged behaviour)', () => {
+    const { seen, pages } = drain({
+      rows: draftFeed,
+      sort: PostSort.Newest,
+      draftOnly: true,
+      limit: 4,
+    });
+
+    expect(seen).toEqual([108, 107, 106, 105, 104, 103, 102, 101, 204, 203, 202, 201]);
+    expect(pages).toBe(3);
+  });
+
+  it('does not stall on a createdAt tie — the id tiebreaker carries the page boundary', () => {
+    // limit 2 lands the page boundary exactly between 102 and 103, which share a createdAt.
+    const { seen, pages } = drain({
+      rows: draftFeed,
+      sort: PostSort.Oldest,
+      draftOnly: true,
+      limit: 2,
+    });
+
+    expect(seen.slice(0, 4)).toEqual([101, 102, 103, 104]);
+    expect(seen).toHaveLength(draftFeed.length);
+    expect(pages).toBe(6);
+  });
+});

--- a/src/server/services/post-sort.ts
+++ b/src/server/services/post-sort.ts
@@ -1,0 +1,129 @@
+import { Prisma } from '@prisma/client';
+import { PostSort } from '~/server/common/enums';
+
+export type PostSortClauses = {
+  orderBy: string;
+  primarySortProp: string;
+  isDateSort: boolean;
+  ascending: boolean;
+  filter?: Prisma.Sql;
+};
+
+/**
+ * ORDER BY / keyset-sort-key selection for `getPostsInfinite`.
+ *
+ * Kept in a standalone (import-light) module so the keyset pagination contract is
+ * unit-testable without the full post.service dependency graph — same reasoning as
+ * post-collection-visibility.ts.
+ */
+export const getPostSortClauses = ({
+  sort,
+  draftOnly,
+}: {
+  sort: PostSort;
+  draftOnly?: boolean;
+}): PostSortClauses => {
+  switch (sort) {
+    case PostSort.MostComments:
+      return {
+        orderBy: 'p."commentCount" DESC, p.id DESC',
+        primarySortProp: 'p."commentCount"',
+        isDateSort: false,
+        ascending: false,
+        filter: Prisma.sql`p."commentCount" > 0`,
+      };
+    case PostSort.MostReactions:
+      return {
+        orderBy: 'p."reactionCount" DESC, p.id DESC',
+        primarySortProp: 'p."reactionCount"',
+        isDateSort: false,
+        ascending: false,
+        filter: Prisma.sql`p."reactionCount" > 0`,
+      };
+    case PostSort.MostCollected:
+      return {
+        orderBy: 'p."collectedCount" DESC, p.id DESC',
+        primarySortProp: 'p."collectedCount"',
+        isDateSort: false,
+        ascending: false,
+        filter: Prisma.sql`p."collectedCount" > 0`,
+      };
+    default:
+      break;
+  }
+
+  const ascending = sort === PostSort.Oldest;
+  const direction = ascending ? 'ASC' : 'DESC';
+
+  // draftOnly mixes drafts (publishedAt IS NULL) with scheduled (publishedAt > NOW()).
+  // Descending, the +100 years offset keeps drafts ahead of any scheduled post while
+  // preserving createdAt order among themselves. Ascending it would do the opposite and
+  // bury drafts behind every scheduled post, so Oldest drops the offset and orders both
+  // partitions on one true timeline — reaching old drafts is the point of the sort.
+  const primarySortProp = draftOnly
+    ? ascending
+      ? `COALESCE(p."publishedAt", p."createdAt")`
+      : `COALESCE(p."publishedAt", p."createdAt" + interval '100 years')`
+    : 'p."publishedAt"';
+
+  return {
+    orderBy: `${primarySortProp} ${direction}, p.id ${direction}`,
+    primarySortProp,
+    isDateSort: true,
+    ascending,
+  };
+};
+
+/**
+ * Keyset cursor predicate. `ascending` MUST come from the same
+ * `getPostSortClauses` call that produced `primarySortProp` — a comparison
+ * pointing against the ORDER BY either re-serves page 1 forever or skips
+ * straight past the backlog.
+ */
+export const buildPostCursorClause = ({
+  cursor,
+  primarySortProp,
+  isDateSort,
+  ascending,
+}: {
+  cursor?: string | number;
+  primarySortProp: string;
+  isDateSort: boolean;
+  ascending: boolean;
+}): Prisma.Sql | undefined => {
+  if (!cursor) return undefined;
+
+  let primaryValue: Date | number;
+  let cursorId: number | null = null;
+
+  // Composite cursor (format: "value|id"), or a legacy single value.
+  if (typeof cursor === 'string' && cursor.includes('|')) {
+    const [valueStr, idStr] = cursor.split('|');
+    primaryValue = isDateSort ? new Date(valueStr) : Number(valueStr);
+    cursorId = Number(idStr);
+  } else {
+    primaryValue = isDateSort ? new Date(cursor) : Number(cursor);
+  }
+
+  const sortProp = Prisma.raw(primarySortProp);
+
+  if (cursorId !== null) {
+    // Row-comparison form lets postgres push the predicate into Index Cond on a
+    // (primarySortProp, id) index. Equivalent to
+    // (primary < cursor) OR (primary = cursor AND id <= cursorId), mirrored for ASC.
+    return ascending
+      ? Prisma.sql`(${sortProp}, p.id) >= (${primaryValue}, ${cursorId})`
+      : Prisma.sql`(${sortProp}, p.id) <= (${primaryValue}, ${cursorId})`;
+  }
+
+  return ascending
+    ? Prisma.sql`${sortProp} > ${primaryValue}`
+    : Prisma.sql`${sortProp} < ${primaryValue}`;
+};
+
+export const encodePostCursor = (row: { id: number; cursorId: Date | number | null }) => {
+  if (row.cursorId === null || row.cursorId === undefined) return undefined;
+  const cursorValue =
+    row.cursorId instanceof Date ? row.cursorId.toISOString() : String(row.cursorId);
+  return `${cursorValue}|${row.id}`;
+};

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -4,7 +4,7 @@ import type { SessionUser } from '~/types/session';
 import * as z from 'zod';
 import { isImageMetaOnSite } from '~/server/utils/image-onsite';
 import { env } from '~/env/server';
-import { BlockedReason, PostSort, SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { BlockedReason, SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
 import {
   getDbWithoutLag,
@@ -32,6 +32,11 @@ import type { PostImageEditProps, PostImageEditSelect } from '~/server/selectors
 import { editPostImageSelect, postSelect } from '~/server/selectors/post.selector';
 import { simpleTagSelect } from '~/server/selectors/tag.selector';
 import { throwOnBlockedLinkDomain } from '~/server/services/blocklist.service';
+import {
+  buildPostCursorClause,
+  encodePostCursor,
+  getPostSortClauses,
+} from '~/server/services/post-sort';
 import { withSpan } from '~/server/utils/otel-helpers';
 import {
   getCollectionById,
@@ -354,62 +359,14 @@ export const getPostsInfinite = async ({
   }
 
   // sorting - always include id as tiebreaker for stable pagination
-  // draftOnly mixes drafts (publishedAt IS NULL) with scheduled (publishedAt > NOW()).
-  // Offsetting drafts by +100 years on the sort key keeps them ahead of any
-  // scheduled post (DESC) while preserving createdAt order among themselves;
-  // scheduled posts continue to sort by their publishedAt within that partition.
-  let orderBy = draftOnly
-    ? `COALESCE(p."publishedAt", p."createdAt" + interval '100 years') DESC, p.id DESC`
-    : 'p."publishedAt" DESC, p.id DESC';
-  let primarySortProp = draftOnly
-    ? `COALESCE(p."publishedAt", p."createdAt" + interval '100 years')`
-    : 'p."publishedAt"';
-  let isDateSort = true;
+  const { orderBy, primarySortProp, isDateSort, ascending, filter } = getPostSortClauses({
+    sort,
+    draftOnly,
+  });
+  if (filter) AND.push(filter);
 
-  if (sort === PostSort.MostComments) {
-    orderBy = `p."commentCount" DESC, p.id DESC`;
-    primarySortProp = 'p."commentCount"';
-    isDateSort = false;
-    AND.push(Prisma.sql`p."commentCount" > 0`);
-  } else if (sort === PostSort.MostReactions) {
-    orderBy = `p."reactionCount" DESC, p.id DESC`;
-    primarySortProp = 'p."reactionCount"';
-    isDateSort = false;
-    AND.push(Prisma.sql`p."reactionCount" > 0`);
-  } else if (sort === PostSort.MostCollected) {
-    orderBy = `p."collectedCount" DESC, p.id DESC`;
-    primarySortProp = 'p."collectedCount"';
-    isDateSort = false;
-    AND.push(Prisma.sql`p."collectedCount" > 0`);
-  }
-
-  // cursor - supports composite cursor format "value|id" for keyset pagination
-  if (cursor) {
-    let primaryValue: Date | number;
-    let cursorId: number | null = null;
-
-    // Parse composite cursor (format: "value|id") or legacy single value
-    if (typeof cursor === 'string' && cursor.includes('|')) {
-      const [valueStr, idStr] = cursor.split('|');
-      primaryValue = isDateSort ? new Date(valueStr) : Number(valueStr);
-      cursorId = Number(idStr);
-    } else {
-      // Legacy single-value cursor (backward compatibility)
-      primaryValue = isDateSort ? new Date(cursor) : Number(cursor);
-    }
-
-    if (cursorId !== null) {
-      // Composite cursor: row-comparison form lets postgres push the predicate
-      // into Index Cond on (primarySortProp DESC, id DESC) indexes. Equivalent
-      // to (primary < cursor) OR (primary = cursor AND id <= cursor_id).
-      AND.push(
-        Prisma.sql`(${Prisma.raw(primarySortProp)}, p.id) <= (${primaryValue}, ${cursorId})`
-      );
-    } else {
-      // Legacy single cursor
-      AND.push(Prisma.sql`${Prisma.raw(primarySortProp)} < ${primaryValue}`);
-    }
-  }
+  const cursorClause = buildPostCursorClause({ cursor, primarySortProp, isDateSort, ascending });
+  if (cursorClause) AND.push(cursorClause);
 
   const postsRawQuery = Prisma.sql`
     SELECT
@@ -447,14 +404,7 @@ export const getPostsInfinite = async ({
   let nextCursor: string | undefined;
   if (postsRaw.length > limit) {
     const nextItem = postsRaw.pop();
-    if (nextItem?.cursorId !== null && nextItem?.cursorId !== undefined) {
-      // Return composite cursor format: "value|id"
-      const cursorValue =
-        nextItem.cursorId instanceof Date
-          ? nextItem.cursorId.toISOString()
-          : String(nextItem.cursorId);
-      nextCursor = `${cursorValue}|${nextItem.id}`;
-    }
+    if (nextItem) nextCursor = encodePostCursor(nextItem);
   }
 
   // Filter to published model versions:


### PR DESCRIPTION
Adds an **Oldest** option to the post sort, so users with large backlogs can reach their earliest posts — published or draft — to review, publish, or clean up.

ClickUp: [868ktfjn7](https://app.clickup.com/t/868ktfjn7) · Source: Freshdesk 69647

## Why this is more than an enum member

Every existing `PostSort` is `DESC`, and the keyset cursor in `getPostsInfinite` was written for `DESC` only. An ascending sort needs **both** halves flipped — the `ORDER BY` and the cursor comparison. Flip one without the other and there is no error: the query either re-serves the same page forever or skips most of the backlog.

## Changes

**`src/server/common/enums.ts`** — `PostSort.Oldest`. `SortFilter` (`Object.values(PostSort)`) and `postsQuerySchema` (`z.enum(PostSort)`) both derive from the enum, so the filter UI and the input contract wire themselves.

**`src/server/services/post-sort.ts`** (new) — sort-clause and keyset-cursor construction extracted out of `getPostsInfinite`: `getPostSortClauses`, `buildPostCursorClause`, `encodePostCursor`. Ascending emits `ORDER BY … ASC, p.id ASC`, a composite cursor of `>=`, and a legacy single-value cursor of `>`. Oldest adds no `count > 0` filter — that pattern belongs to the three count sorts, not to a date sort.

This follows the precedent already in the tree: `post-collection-visibility.ts` was extracted from this same function for this same reason, so the seam could be unit-tested without dragging in the 5k-line service's dependency graph. The block in `post.service.ts` goes from 78 lines to 14.

**Draft ordering** — `draftOnly` sorts on `COALESCE(p."publishedAt", p."createdAt" + interval '100 years')`, where the offset pins drafts ahead of scheduled posts under `DESC`. Ascending, that same offset does the exact inverse: it buries every draft behind every scheduled post, which is the opposite of what was asked for. Under Oldest the offset is dropped and both partitions order on one true timeline. Newest is untouched.

**`src/pages/user/[username]/posts.tsx`** — the drafts view hard-locked `sort` to `Newest` and passed `SortFilter` a one-item options array, so the priority case could not select Oldest at all. Drafts now offer Newest + Oldest, and switching sections preserves Oldest instead of resetting it. The count sorts stay excluded there: they filter on `count > 0` server-side, so a draft feed under them returns empty.

**`src/components/Collections/Collection.tsx`** — contest collections randomise the sort per render via `getRandom(Object.values(PostSort))`, which would have silently swept Oldest into that pool. Held out explicitly.

## Caching

`getPostsInfinite` runs through `queryCache(dbRead, 'getPostsInfinite', 'v1')`, so a new sort serving another sort's cached page would be a nasty intermittent bug. It cannot happen: `hashifyObject` JSON-stringifies the `Prisma.Sql`, including its `strings`, and `Prisma.raw(orderBy)` flattens into those — verified directly that the ASC and DESC queries hash to different keys. `cacheTags` stay user/modelVersion-scoped and are unaffected by sort. The own-profile and drafts paths set `cacheTime = 0` via `isOwnerRequest` and never cache at all.

## Tests

`src/server/services/__tests__/post-sort-keyset.test.ts` — 11 tests. The pagination cases drive the real clause builders through a bounded in-memory pager, so a cursor that stops advancing fails on the **first repeated row** rather than spinning.

Both reverts were mutated and measured rather than assumed:

| Mutation | Result |
|---|---|
| composite comparison back to `<=` | 4 failed in **1.29s** — `page 2 re-served post 1: expected [ 1, 2, 3 ] to not include 1` |
| `ORDER BY` back to `DESC` | 5 failed in **282ms** |

The pager caps at 20 pages and throws on the way out, so no revert of this can wedge the runner.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run test:unit:run` — 1161 files passed / 1 skipped, 18341 tests passed / 22 skipped
- `blocks.router.workflow.test.ts` collected **350** tests (worktree submodule check)
- Exercised in a browser against the dev database (fingerprinted by liveness, not by host), as a user with 514 drafts + 406 scheduled posts. Drafts/Oldest drained **4 pages, 80 posts, 80 unique, 0 duplicates**; the first 12 ids match SQL exactly; the page-1→page-2 seam is rows 20→21 with no gap. Published/Oldest head matches SQL exactly. Newest and Most Reactions re-checked unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
