### PR TITLE
fix(image-page): stop the LoRA strength badge being pushed out of the panel

### DIFF
--- a/src/components/Image/DetailV2/ImageResources.browser.test.tsx
+++ b/src/components/Image/DetailV2/ImageResources.browser.test.tsx
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import type * as Trpc from '~/utils/trpc';
+
+// The component project loads no global stylesheet, so both halves of this
+// layout are inert unless a test imports them: Tailwind supplies `min-w-0` /
+// `shrink-0`, and Mantine supplies the `lineClamp` rule. Without the Mantine
+// sheet the name WRAPS to three lines instead of truncating, the row grows
+// tall enough that nothing has to give sideways, and every measurement below
+// passes on a layout that does not ship.
+import '~/styles/globals.css';
+import '@mantine/core/styles.layer.css';
+
+// Two names, because the two classes this file guards fail on different inputs.
+// A spaced name pins `shrink-0`: the badge group is the only thing that can
+// give. An unbroken one pins `min-w-0`: the link's content-based minimum is the
+// whole token, so the row overflows no matter how firmly the badges hold. Both
+// shapes are ordinary model names.
+const SPACED_NAME = 'Rocket Raccoon - Marvel Cinematic Universe - Guardians of the Galaxy';
+const UNBROKEN_NAME = 'Rocket_Raccoon_Marvel_Cinematic_Universe_Guardians_Of_The_Galaxy_v2';
+
+let modelName = SPACED_NAME;
+
+const generationData = {
+  get resources() {
+    return [
+      {
+        imageId: 1,
+        versionId: 10,
+        modelVersionId: 10,
+        modelId: 100,
+        modelName,
+        modelType: 'LORA',
+        versionName: 'v1.0',
+        strength: 0.8,
+      },
+    ];
+  },
+};
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof Trpc>()),
+  trpc: {
+    image: {
+      getGenerationData: { useQuery: () => ({ data: generationData, isLoading: false }) },
+      removeResource: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
+    useUtils: () => ({ image: { getGenerationData: { setData: vi.fn() } } }),
+  },
+}));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, isModerator: false }),
+}));
+
+import { ImageResources } from './ImageResources';
+import { renderWithProviders } from '../../../../test/component-setup';
+
+// The generation-data panel on the image page. 320px is the narrow end of it;
+// the bug reproduces wherever the row is tight enough to force a choice.
+const PANEL_WIDTH = 320;
+
+afterEach(() => {
+  modelName = SPACED_NAME;
+});
+
+async function renderPanel() {
+  renderWithProviders(
+    <div style={{ width: PANEL_WIDTH }}>
+      <ImageResources imageId={1} />
+    </div>
+  );
+  await vi.waitFor(() => {
+    expect(document.body.querySelector('li')).toBeTruthy();
+  });
+}
+
+function row() {
+  return document.body.querySelector('li > div') as HTMLElement;
+}
+
+function strengthBadge() {
+  const badges = Array.from(document.body.querySelectorAll('li .mantine-Badge-root'));
+  const badge = badges.find((b) => b.textContent?.trim() === '0.8');
+  // Without this, a reformatted value (`0.80`) or a Mantine class rename turns
+  // every measurement below into `Cannot read properties of undefined`, with
+  // none of the numbers this file exists to print.
+  expect(badge, 'no badge rendering the strength value').toBeTruthy();
+  return badge as HTMLElement;
+}
+
+function nameText() {
+  // A resource with no `modelId` renders no link, so the Text sits directly
+  // under the `min-w-0` div instead of under an `<a>`.
+  return document.body.querySelector('li a p, li div > p') as HTMLElement;
+}
+
+// ⚠️ Nothing here gates `main`: `*.browser.test.tsx` runs in no blocking CI job
+// (lint.yml keeps the unit job Node-only), only in the preview pipeline's
+// report-only `component-tests`. A revert of either class below merges green.
+//
+// Reported 2026-08-17 (ClickUp 868ktabp0): in "Resources used" a strength of `1`
+// rendered whole while `0.8` rendered as `0.`, clipped at the panel edge — on
+// Chrome and Firefox both. The row is `justify-between` with two shrinkable
+// children, and the name side would not shrink past its longest word, because
+// `lineClamp`'s `overflow: hidden` sits on the Text and not on the link
+// wrapping it. So the badge group was the one that gave.
+describe('ImageResources row at a narrow panel width', () => {
+  test('keeps the strength badge inside the panel', async () => {
+    await renderPanel();
+
+    // The badge is never clipped INTERNALLY — measured on the broken layout it
+    // is a full-width 36px box sitting 42px past the panel edge, so its own
+    // scrollWidth/clientWidth match and asserting on those passes for free.
+    // What breaks is where it sits.
+    expect(strengthBadge().getBoundingClientRect().right).toBeLessThanOrEqual(
+      row().getBoundingClientRect().right + 1
+    );
+  });
+
+  test('does not overflow the row', async () => {
+    await renderPanel();
+
+    // Same failure read off the container: 362 against a 320px row before the
+    // fix. A revert prints both numbers.
+    expect(row().scrollWidth).toBeLessThanOrEqual(row().clientWidth + 1);
+  });
+
+  test('keeps it inside for a name with no spaces to break on', async () => {
+    modelName = UNBROKEN_NAME;
+    await renderPanel();
+
+    // `shrink-0` alone holds the SPACED name — the badge group stops giving and
+    // the name wraps instead. It does nothing here: an unbroken token is the
+    // link's content-based minimum, so without `min-w-0` the link refuses to
+    // shrink and the row overruns with the badges still at full width. Deleting
+    // `min-w-0` fails this and nothing else in the file.
+    expect(row().scrollWidth).toBeLessThanOrEqual(row().clientWidth + 1);
+    expect(strengthBadge().getBoundingClientRect().right).toBeLessThanOrEqual(
+      row().getBoundingClientRect().right + 1
+    );
+  });
+
+  test('truncates the resource name, so the row really is constrained', async () => {
+    await renderPanel();
+
+    // Control. The assertions above are all "X fits inside Y", which is also
+    // true of a panel wide enough that nothing has to give — and a panel that
+    // wide is precisely what a missing stylesheet produces here. This pins that
+    // the row really is constrained. It is not describing a wider render: the
+    // width is the same 320px, and widening it to match this comment would kill
+    // the assertion. `lineClamp` is a one-line `-webkit-box`, so the overflow
+    // it produces is VERTICAL — scrollWidth stays equal to clientWidth.
+    const name = nameText();
+    expect(name.scrollHeight).toBeGreaterThan(name.clientHeight);
+  });
+});

--- a/src/components/Image/DetailV2/ImageResources.tsx
+++ b/src/components/Image/DetailV2/ImageResources.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Alert, Badge, Skeleton, Stack, Text } from '@mantine/core';
+import { Alert, Badge, Skeleton, Stack, Text } from '@mantine/core';
 import { useSessionStorage } from '@mantine/hooks';
 import { openConfirmModal } from '@mantine/modals';
 import { IconX } from '@tabler/icons-react';
@@ -58,26 +58,21 @@ export function ImageResources({ imageId }: { imageId: number }) {
       ) : (
         <ul className="flex list-none flex-col gap-0.5">
           {(showAll ? resourcesSorted : resourcesSorted.slice(0, LIMIT)).map((resource) => {
-            const href = resource.modelId
-              ? getModelUrl({
-                  modelId: resource.modelId,
-                  modelName: resource.modelName,
-                  modelVersionId: resource.versionId,
-                })
-              : undefined;
             return (
               <li key={`${resource.imageId}_${resource.modelVersionId}`} className="flex flex-col">
                 <div className="flex items-center justify-between gap-3">
-                  <Wrapper resource={resource}>
-                    <Text
-                      lineClamp={1}
-                      className={`${resource.modelId ? 'cursor-pointer underline' : ''}`}
-                    >
-                      {resource.modelName}
-                    </Text>
-                  </Wrapper>
+                  <div className="min-w-0">
+                    <Wrapper resource={resource}>
+                      <Text
+                        lineClamp={1}
+                        className={`${resource.modelId ? 'cursor-pointer underline' : ''}`}
+                      >
+                        {resource.modelName}
+                      </Text>
+                    </Wrapper>
+                  </div>
                   {resource.modelType && (
-                    <div className="flex gap-1">
+                    <div className="flex shrink-0 gap-1">
                       <Badge color="blue">{getDisplayName(resource.modelType)}</Badge>
                       {!!resource.strength && (
                         <Badge color="gray" variant="filled">


### PR DESCRIPTION
Closes ClickUp [868ktabp0](https://app.clickup.com/t/868ktabp0).

## The bug

In the image detail page's **Resources used** list, a LoRA strength of `1` rendered whole while `0.8` rendered as `0.` — the rest clipped at the panel's right edge, so the actual weight was unreadable. Reported on Chrome and Firefox both, so not browser-specific.

## What was actually happening

Close to the reporter's diagnosis, but not quite it — worth stating because it changes the fix.

The row is `justify-between` with two shrinkable children: the resource name and the badge group. `lineClamp`'s `overflow: hidden` sits on the Mantine `Text`, **not** on the `<a>` wrapping it, so the link kept a content-based minimum width and would not shrink past its longest word. The badge group absorbed the entire shortfall, and the trailing strength badge was the part pushed out.

Measured in a real browser at a 320px panel:

| | badge group | strength badge right edge |
|---|---|---|
| before | 94px → squeezed to **49px** | **362px**, i.e. 42px past the 320px panel |
| after | 94px | 320px |

So `shrink-0` on the badge group (the suggested fix) is half of it. Without `min-w-0` on the name side there is nothing to shrink *instead*, and a name with no spaces to break on overruns the row with the badges still at full width. Both classes ship.

`min-w-0` sits on a wrapper div rather than on the link, so it also covers rows whose resource has no `modelId` and therefore render no link at all.

## Test

`ImageResources.browser.test.tsx`. The two classes fail on **different inputs**, so the file carries a name of each shape and each class is pinned by mutation:

| mutation | result |
|---|---|
| drop `shrink-0` | 3 failed — `expected 362.390625 to be less than or equal to 321` |
| drop `min-w-0` | 1 failed, the unbroken-name case — `expected 629 to be less than or equal to 321` |

A spaced name never needs `min-w-0` (the badge group holding firm is enough), so a single name would have left half this change unguarded and green. An unbroken token like `Rocket_Raccoon_..._v2` is the link's content-based minimum, and that is the case `min-w-0` exists for.

The assertions are about **placement**, not the badge's own overflow. The badge is a full-width 36px box either way — never clipped internally, just sitting outside the panel — so `badge.scrollWidth <= badge.clientWidth` **passes on the broken layout**. What discriminates is `badge.right <= row.right` and `row.scrollWidth <= row.clientWidth`. A fourth test is a control: the name must be clamped, proving the row is genuinely constrained rather than a panel wide enough that nothing has to give.

The test imports `@mantine/core/styles.layer.css` on top of `~/styles/globals.css`. With only the latter (what `ImageCard.browser.test.tsx` does) Mantine's `lineClamp` rule is inert, the name wraps to three lines, the row grows tall instead of tight, and every assertion passes on a layout that does not ship.

⚠️ `*.browser.test.tsx` **runs in no CI job** — `lint.yml` keeps the unit job Node-only because the component project needs Chromium it does not install. This is a local check on whoever runs it by hand, not a gate on `main`.

## Verification

- `pnpm run typecheck` — 0 errors (211s, unfiltered)
- `pnpm exec eslint` on both files — 0 errors; the 2 warnings in `ImageResources.tsx` are pre-existing (identical on the stashed file)
- `pnpm exec prettier --write` on both files
- `pnpm run test:unit:run` — 18387 passed, 5 failed in 3 files, all pre-existing: re-running those three files with this change stashed produces the identical 5. They are source-scanning guards that trip on Windows path separators, plus `standalone-boot-graph`. `blocks.router.workflow.test.ts` collected 350 tests, so the submodule is real.
- `vitest --project component ImageResources.browser.test.tsx` — 4 passed

Two rounds of `/code-review high` ran over this diff. The first caught a real one: `min-w-0` was unguarded and the commit message claimed otherwise — a spaced name never needs it, so the second name shape exists because of that finding. The second round re-verified both classes by mutation and found four low items, all applied: a dead fallback selector in the test, a control comment that described a wider panel than it renders, the report-only-CI caveat now stated in the test file itself, and the dead `href` / `ActionIcon` in the block being edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
