### PR TITLE
fix(images): store blocked-image hashes at full 64-bit width

### DIFF
--- a/src/server/clickhouse/__tests__/int64.test.ts
+++ b/src/server/clickhouse/__tests__/int64.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fromClickhouseInt64, toClickhouseInt64 } from '../int64';
+import { toClickhouseInt64 } from '../int64';
 
 // ClickUp 868kta7p0 — the helper the blocked-hash writers use. A JS number holds 53 bits,
 // so anything past that has to move as text in both directions.
@@ -14,21 +14,7 @@ describe('toClickhouseInt64', () => {
     expect(toClickhouseInt64(decimal)).toBe(decimal);
   });
 
-  it('accepts a number that is still exact', () => {
-    expect(toClickhouseInt64(9007199254740991)).toBe('9007199254740991');
-  });
-
-  it('refuses a number that has already lost precision rather than storing it', () => {
-    expect(() => toClickhouseInt64(Number(-4276845791567733103n))).toThrow(/lost precision/);
-  });
-});
-
-describe('fromClickhouseInt64', () => {
-  it('reads the text form back exactly', () => {
-    expect(fromClickhouseInt64('-4276845791567733103')).toBe(-4276845791567733103n);
-  });
-
-  it('refuses a value that arrived as a rounded number', () => {
-    expect(() => fromClickhouseInt64(Number(-4276845791567733103n))).toThrow(/toString/);
+  it('refuses a value that is not an integer rather than storing something else', () => {
+    expect(() => toClickhouseInt64('4276845791567733103.5')).toThrow();
   });
 });

--- a/src/server/clickhouse/__tests__/int64.test.ts
+++ b/src/server/clickhouse/__tests__/int64.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { fromClickhouseInt64, toClickhouseInt64 } from '../int64';
+
+// ClickUp 868kta7p0 — the helper the blocked-hash writers use. A JS number holds 53 bits,
+// so anything past that has to move as text in both directions.
+describe('toClickhouseInt64', () => {
+  it.each([
+    ['-4276845791567733103'],
+    ['9223372036854775783'],
+    ['-9223372036854775783'],
+    ['9007199254740993'], // 2^53 + 1: the first integer a double cannot hold
+  ])('round-trips %s exactly', (decimal) => {
+    expect(toClickhouseInt64(BigInt(decimal))).toBe(decimal);
+    expect(toClickhouseInt64(decimal)).toBe(decimal);
+  });
+
+  it('accepts a number that is still exact', () => {
+    expect(toClickhouseInt64(9007199254740991)).toBe('9007199254740991');
+  });
+
+  it('refuses a number that has already lost precision rather than storing it', () => {
+    expect(() => toClickhouseInt64(Number(-4276845791567733103n))).toThrow(/lost precision/);
+  });
+});
+
+describe('fromClickhouseInt64', () => {
+  it('reads the text form back exactly', () => {
+    expect(fromClickhouseInt64('-4276845791567733103')).toBe(-4276845791567733103n);
+  });
+
+  it('refuses a value that arrived as a rounded number', () => {
+    expect(() => fromClickhouseInt64(Number(-4276845791567733103n))).toThrow(/toString/);
+  });
+});

--- a/src/server/clickhouse/int64.ts
+++ b/src/server/clickhouse/int64.ts
@@ -1,0 +1,21 @@
+/**
+ * Int64 columns are written and read as JSON, where a JS `number` holds only 53 bits —
+ * a 64-bit value silently arrives rounded and nothing errors. Move these as decimal
+ * strings: the server parses them exactly
+ * (`input_format_json_read_numbers_as_strings`), and reads must ask for `toString(col)`
+ * because the client sets `output_format_json_quote_64bit_integers: 0`.
+ */
+export function toClickhouseInt64(value: bigint | number | string): string {
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'string') return BigInt(value).toString();
+  if (!Number.isInteger(value)) throw new Error(`Not an integer: ${value}`);
+  if (!Number.isSafeInteger(value))
+    throw new Error(`Value has already lost precision as a number: ${value}`);
+  return value.toString();
+}
+
+export function fromClickhouseInt64(value: string | number | bigint): bigint {
+  if (typeof value === 'number' && !Number.isSafeInteger(value))
+    throw new Error(`Value arrived as a rounded number; select toString(col) instead: ${value}`);
+  return BigInt(value);
+}

--- a/src/server/clickhouse/int64.ts
+++ b/src/server/clickhouse/int64.ts
@@ -1,21 +1,11 @@
 /**
  * Int64 columns are written and read as JSON, where a JS `number` holds only 53 bits —
  * a 64-bit value silently arrives rounded and nothing errors. Move these as decimal
- * strings: the server parses them exactly
- * (`input_format_json_read_numbers_as_strings`), and reads must ask for `toString(col)`
- * because the client sets `output_format_json_quote_64bit_integers: 0`.
+ * strings: ClickHouse's JSON number parser accepts a quoted integer for a numeric column
+ * and stores it exactly. Reads need the same care in reverse, because the client sets
+ * `output_format_json_quote_64bit_integers: 0` — select `toString(col)` rather than the
+ * bare column, or the value is rounded before any of this can help.
  */
-export function toClickhouseInt64(value: bigint | number | string): string {
-  if (typeof value === 'bigint') return value.toString();
-  if (typeof value === 'string') return BigInt(value).toString();
-  if (!Number.isInteger(value)) throw new Error(`Not an integer: ${value}`);
-  if (!Number.isSafeInteger(value))
-    throw new Error(`Value has already lost precision as a number: ${value}`);
-  return value.toString();
-}
-
-export function fromClickhouseInt64(value: string | number | bigint): bigint {
-  if (typeof value === 'number' && !Number.isSafeInteger(value))
-    throw new Error(`Value arrived as a rounded number; select toString(col) instead: ${value}`);
-  return BigInt(value);
+export function toClickhouseInt64(value: bigint | string): string {
+  return (typeof value === 'bigint' ? value : BigInt(value)).toString();
 }

--- a/src/server/services/__tests__/blocked-image-hash-precision.test.ts
+++ b/src/server/services/__tests__/blocked-image-hash-precision.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Regression guard for ClickUp 868kta7p0. The blocked-hash writers moved their values
+// through a JS `number`, which holds 53 bits — every 64-bit hash was silently rounded on
+// the way in, while both readers pass the value through at full precision. Nothing errors
+// and the row count looks right, so the only thing that catches it is asserting the exact
+// value at the clickhouse boundary.
+//
+// image.service is the graph root; the mock scaffold mirrors the established recipe
+// (unblock-image-nsfwlevel-reset.test.ts) so importing it boots no real infra.
+
+const capturedInserts: Array<{ table: string; values: any[] }> = [];
+const capturedQueries: string[] = [];
+let queryResult: any[] = [];
+
+function makePermissive(overrides: Record<string, unknown> = {}): any {
+  const handler: ProxyHandler<any> = {
+    get(target, prop) {
+      if (prop === 'then') return undefined;
+      if (typeof prop === 'symbol') return undefined;
+      if (prop in overrides) return overrides[prop as string];
+      if (!(prop in target)) target[prop as string] = makePermissive();
+      return target[prop as string];
+    },
+    apply() {
+      return Promise.resolve([]);
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  return new Proxy(function () {}, handler);
+}
+
+vi.mock('~/server/db/client', () => ({ dbRead: makePermissive(), dbWrite: makePermissive() }));
+
+// event-engine-common is a git submodule, not checked out by default.
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+// Real env validation throws in test; a Proxy hands back safe defaults for whatever
+// image.service reads at import time.
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: makePermissive({
+    insert: async (args: { table: string; values: any[] }) => {
+      capturedInserts.push({ table: args.table, values: args.values });
+    },
+    $query: (strings: TemplateStringsArray, ...values: unknown[]) => {
+      capturedQueries.push(
+        Array.isArray(strings)
+          ? strings.reduce((acc, part, i) => acc + part + (values[i] ?? ''), '')
+          : String(strings)
+      );
+      return Promise.resolve(queryResult);
+    },
+  }),
+}));
+
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: makePermissive({ packed: makePermissive() }),
+    sysRedis: makePermissive(),
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+    REDIS_SUB_KEYS: keyProxy,
+  };
+});
+
+const { addBlockedImage, bulkAddBlockedImages, bulkRemoveBlockedImages } = await import(
+  '../image.service'
+);
+
+// A real 64-bit pHash: past 2^53, and one whose rounded form is visibly different so a
+// revert prints the wrong value beside the right one rather than timing out.
+const HASH = -4276845791567733103n;
+const ROUNDED = String(Number(HASH)); // '-4276845791567733000'
+
+describe('blocked-image hashes keep all 64 bits (ClickUp 868kta7p0)', () => {
+  beforeEach(() => {
+    capturedInserts.length = 0;
+    capturedQueries.length = 0;
+    queryResult = [];
+  });
+
+  it('addBlockedImage writes the exact hash', async () => {
+    await addBlockedImage({ hash: HASH, reason: 'TOS' as any });
+
+    expect(capturedInserts).toHaveLength(1);
+    expect(String(capturedInserts[0].values[0].hash)).toBe(HASH.toString());
+  });
+
+  it('bulkAddBlockedImages writes the exact hash', async () => {
+    await bulkAddBlockedImages({ data: [{ hash: HASH, reason: 'TOS' as any }] });
+
+    expect(capturedInserts).toHaveLength(1);
+    expect(String(capturedInserts[0].values[0].hash)).toBe(HASH.toString());
+  });
+
+  it('bulkRemoveBlockedImages selects the hash as text and re-writes it exactly', async () => {
+    // The client sets output_format_json_quote_64bit_integers: 0, so an unquoted Int64
+    // comes back already rounded — the disable row must be built from text.
+    queryResult = [{ hash: HASH.toString(), reason: 'TOS' }];
+
+    await bulkRemoveBlockedImages([HASH]);
+
+    expect(capturedQueries[0]).toContain('toString(hash)');
+    expect(capturedQueries[0]).toContain(HASH.toString());
+    expect(capturedInserts).toHaveLength(1);
+    expect(capturedInserts[0].values[0]).toMatchObject({ hash: HASH.toString(), disabled: true });
+  });
+
+  it('the rounded form these guards exclude really is a different value', () => {
+    expect(ROUNDED).not.toBe(HASH.toString());
+  });
+});

--- a/src/server/services/__tests__/blocked-image-hash-precision.test.ts
+++ b/src/server/services/__tests__/blocked-image-hash-precision.test.ts
@@ -6,8 +6,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 // and the row count looks right, so the only thing that catches it is asserting the exact
 // value at the clickhouse boundary.
 //
-// image.service is the graph root; the mock scaffold mirrors the established recipe
-// (unblock-image-nsfwlevel-reset.test.ts) so importing it boots no real infra.
+// image.service is the graph root. db/redis/logging come from the canonical shared mocks
+// registered in setup; what is left here is the clickhouse boundary this asserts on, plus
+// the env and submodule stubs image.service needs to import at all.
 
 const capturedInserts: Array<{ table: string; values: any[] }> = [];
 const capturedQueries: string[] = [];
@@ -29,8 +30,6 @@ function makePermissive(overrides: Record<string, unknown> = {}): any {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   return new Proxy(function () {}, handler);
 }
-
-vi.mock('~/server/db/client', () => ({ dbRead: makePermissive(), dbWrite: makePermissive() }));
 
 // event-engine-common is a git submodule, not checked out by default.
 vi.mock('../../../../event-engine-common/services/metrics', () => ({
@@ -74,18 +73,6 @@ vi.mock('~/server/clickhouse/client', () => ({
     },
   }),
 }));
-
-vi.mock('~/server/redis/client', () => {
-  const make = (): any => new Proxy(() => 'k', { get: () => make() });
-  const keyProxy = make();
-  return {
-    redis: makePermissive({ packed: makePermissive() }),
-    sysRedis: makePermissive(),
-    REDIS_KEYS: keyProxy,
-    REDIS_SYS_KEYS: keyProxy,
-    REDIS_SUB_KEYS: keyProxy,
-  };
-});
 
 const { addBlockedImage, bulkAddBlockedImages, bulkRemoveBlockedImages } = await import(
   '../image.service'

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -8449,13 +8449,7 @@ export async function getImagesByUserIdForModeration(userId: number) {
   });
 }
 
-export function addBlockedImage({
-  hash,
-  reason,
-}: {
-  hash: bigint | number;
-  reason: BlockImageReason;
-}) {
+export function addBlockedImage({ hash, reason }: { hash: bigint; reason: BlockImageReason }) {
   return clickhouse?.insert({
     table: 'blocked_images',
     values: [{ hash: toClickhouseInt64(hash), reason }],
@@ -8466,7 +8460,7 @@ export function addBlockedImage({
 export function bulkAddBlockedImages({
   data,
 }: {
-  data: { hash: bigint | number; reason: BlockImageReason }[];
+  data: { hash: bigint; reason: BlockImageReason }[];
 }) {
   if (data.length === 0) return;
 
@@ -8482,7 +8476,7 @@ export function bulkAddBlockedImages({
   });
 }
 
-export async function bulkRemoveBlockedImages(hashes: Array<bigint | number>) {
+export async function bulkRemoveBlockedImages(hashes: bigint[]) {
   if (hashes.length === 0 || !clickhouse) return;
   const blocked = await clickhouse.$query<{ hash: string; reason: string }>`
     SELECT toString(hash) AS hash, reason

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -11,6 +11,7 @@ import { isDev, isProd } from '~/env/other';
 import { env } from '~/env/server';
 import type { VotableTagModel } from '~/libs/tags';
 import { clickhouse } from '~/server/clickhouse/client';
+import { toClickhouseInt64 } from '~/server/clickhouse/int64';
 import { purgeCache } from '~/server/cloudflare/client';
 import {
   CacheTTL,
@@ -8457,7 +8458,7 @@ export function addBlockedImage({
 }) {
   return clickhouse?.insert({
     table: 'blocked_images',
-    values: [{ hash: Number(hash), reason }],
+    values: [{ hash: toClickhouseInt64(hash), reason }],
     format: 'JSONEachRow',
   });
 }
@@ -8470,7 +8471,7 @@ export function bulkAddBlockedImages({
   if (data.length === 0) return;
 
   const values = data.map(({ hash, reason }) => ({
-    hash: Number(hash),
+    hash: toClickhouseInt64(hash),
     reason: reason.toString(),
   }));
 
@@ -8483,14 +8484,14 @@ export function bulkAddBlockedImages({
 
 export async function bulkRemoveBlockedImages(hashes: Array<bigint | number>) {
   if (hashes.length === 0 || !clickhouse) return;
-  const blocked = await clickhouse.$query<{ hash: bigint; reason: string }>`
-    SELECT hash, reason
+  const blocked = await clickhouse.$query<{ hash: string; reason: string }>`
+    SELECT toString(hash) AS hash, reason
     FROM "blocked_images"
-    WHERE hash IN (${hashes.join(',')}) AND disabled = false
+    WHERE hash IN (${hashes.map(toClickhouseInt64).join(',')}) AND disabled = false
   `;
 
   const values = blocked.map(({ hash, reason }) => ({
-    hash: Number(hash),
+    hash: toClickhouseInt64(hash),
     reason,
     disabled: true,
   }));


### PR DESCRIPTION
`blocked_images.hash` is an `Int64`. The three writers in `image.service.ts` moved the value through a JS `number` on the way in, and a `number` holds 53 bits — so any hash wider than that was rounded before it reached ClickHouse. Nothing errored, rows were written, counts looked right.

Both readers pass the hash through at full precision, so the write side was the only lossy step and fixing it on its own is correct rather than a behaviour change.

The read-back needed the same treatment. The client sets `output_format_json_quote_64bit_integers: 0`, so an `Int64` selected as a bare column arrives as a JS number, already rounded — and `bulkRemoveBlockedImages` reads then re-writes, so it would have started writing the wrong value the moment the insert side went exact. It now selects `toString(hash)`.

## Changes

- `src/server/clickhouse/int64.ts` — `toClickhouseInt64`. Values move as decimal text; ClickHouse's JSON number parser accepts a quoted integer for a numeric column and stores it exactly.
- `addBlockedImage`, `bulkAddBlockedImages`, `bulkRemoveBlockedImages` use it, and now take `bigint` rather than `bigint | number` — every caller passes a Prisma `BigInt`, so the type says so instead of a runtime check inside a batch.
- Guards at both levels. The service-level one asserts the exact value at the clickhouse boundary; reverting any of the three sites prints the rounded value beside the real one.

No schema change and no migration — the column was always 64 bits wide; the app narrowed the value before it got there. Existing rows are left as they are; what to do about them is being tracked on the ticket.

ClickUp: https://app.clickup.com/t/868kta7p0

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — no new errors in the changed files
- `pnpm run test:unit:run` — 18,399 passed. 5 failures in 3 files, all reproduced identically on a clean `origin/main` in the same tree (Windows-only source-scanning guards, unrelated).
- Each of the three sites reverted in turn; every one fails with an assertion naming the wrong value.
- The quoted form was parsed against the live cluster before merge: `SELECT hash, toTypeName(hash) FROM format(JSONEachRow, 'hash Int64', '{"hash":"-4276845791567733103"}')` returns the value unchanged as `Int64`. Worth checking because inserts run `async_insert` with `wait_for_async_insert: 0`, so a server-side parse rejection would not surface at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)