### PR TITLE
fix(blocks): default BlockSpendAttribution.status to a status backpay reads

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260818210000_block_spend_attribution_tracked_default/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260818210000_block_spend_attribution_tracked_default/migration.sql
@@ -1,0 +1,26 @@
+-- Record the 'tracked' status default and widened CHECK that production and dev already have.
+--
+-- HISTORY BACKFILL — already applied by hand in prod and dev. Verified on the prod replica:
+-- the column default is 'tracked' and the CHECK list includes it. This migration exists so a
+-- database provisioned from prisma/migrations matches them.
+--
+-- Without it, the committed history still declares DEFAULT 'pending' and a CHECK list that omits
+-- 'tracked' (20260618130000_block_spend_attribution, lines 86 and 103-104), so a fresh local, CI or
+-- new-environment database rejects EVERY spend-attribution insert with SQLSTATE 23514 — the writer
+-- at buzz-attribution.service.ts sends status: 'tracked' explicitly.
+--
+-- 'pending' stays in the CHECK list: the partial index bsa_pending_aging_idx is built on it for a
+-- contemplated confirm-pending cron, and dropping it from the list is a separate decision.
+--
+-- Written idempotently so applying it to an environment that already has the hand-applied state is
+-- a no-op. Table is small (68 rows in prod); the CHECK revalidation is not a concern.
+
+ALTER TABLE "block_spend_attribution"
+  ALTER COLUMN "status" SET DEFAULT 'tracked';
+
+ALTER TABLE "block_spend_attribution"
+  DROP CONSTRAINT IF EXISTS "block_spend_attribution_status_check";
+
+ALTER TABLE "block_spend_attribution"
+  ADD CONSTRAINT "block_spend_attribution_status_check"
+    CHECK ("status" IN ('tracked', 'pending', 'confirmed', 'voided', 'paid_out', 'held'));

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -3488,7 +3488,10 @@ model BlockSpendAttribution {
   /// (bounded, app-owned). NULL when the app supplied none.
   sharedContentKey    String? @map("shared_content_key")
 
-  status             String   @default("pending")
+  // Must stay equal to the column default in Postgres and to what backpay selects: Prisma supplies
+  // this itself on create, so a value backpay does not read makes an omitted-status row invisible to
+  // payout forever. Pinned by block-spend-attribution-status-default.test.ts.
+  status             String   @default("tracked")
   /// 'self_spend' / 'internal_owner' / 'manual_review'. Spend has no
   /// refund path, so this is never 'refund'/'chargeback'.
   voidedReason       String?  @map("voided_reason")

--- a/src/server/services/blocks/__tests__/block-spend-attribution-status-default.test.ts
+++ b/src/server/services/blocks/__tests__/block-spend-attribution-status-default.test.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Prisma supplies its own @default on create, so the Postgres column default never applies. A
+// default here that backpay's selector does not match makes an omitted-status row invisible to
+// payout with no error and no drift — the shape that hid a wrong licence on ~65k models for two
+// and a half years (#4036). This pins the schema default against the selector that has to see it.
+
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+const SCHEMA = path.join(REPO_ROOT, 'packages/civitai-db-schema/prisma/schema.full.prisma');
+const BACKPAY = path.join(REPO_ROOT, 'src/server/services/blocks/backpay.service.ts');
+
+function readOrThrow(file: string) {
+  if (!fs.existsSync(file)) throw new Error(`guard cannot run: ${file} not found`);
+  // Normalise CRLF: the anchored model-block match below is line-based, and a checkout with
+  // Windows line endings would otherwise make this guard fail on Windows only.
+  const src = fs.readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
+  if (src.trim() === '') throw new Error(`guard cannot run: ${file} is empty`);
+  return src;
+}
+
+function schemaDefaultFor(model: string, field: string) {
+  const src = readOrThrow(SCHEMA);
+  const block = src.match(new RegExp(`^model ${model} \\{([\\s\\S]*?)^\\}`, 'm'));
+  if (!block) throw new Error(`guard cannot run: model ${model} not found in schema.full.prisma`);
+  const line = block[1]
+    .split('\n')
+    .find((l) => new RegExp(`^\\s*${field}\\s`).test(l) && !l.trim().startsWith('//'));
+  if (!line) throw new Error(`guard cannot run: ${model}.${field} not found`);
+  const def = line.match(/@default\("([^"]+)"\)/);
+  if (!def) throw new Error(`guard cannot run: ${model}.${field} has no string @default`);
+  return def[1];
+}
+
+// Every status literal backpay filters blockSpendAttribution rows on.
+function backpaySelectedStatuses() {
+  const src = readOrThrow(BACKPAY);
+  const statuses = new Set<string>();
+  const calls = src.matchAll(
+    /db(?:Read|Write)\.blockSpendAttribution\.\w+\(\{([\s\S]*?)\n {4}\}\)/g
+  );
+  for (const call of calls) {
+    const where = call[1].match(/where:\s*\{([^}]*)\}/);
+    if (!where) continue;
+    const status = where[1].match(/status:\s*'([^']+)'/);
+    if (status) statuses.add(status[1]);
+  }
+  if (statuses.size === 0)
+    throw new Error(
+      'guard cannot run: found no blockSpendAttribution status filter in backpay.service.ts'
+    );
+  return statuses;
+}
+
+describe('BlockSpendAttribution.status default', () => {
+  it('is a status the backpay selector actually reads', () => {
+    const fallback = schemaDefaultFor('BlockSpendAttribution', 'status');
+    const selected = backpaySelectedStatuses();
+
+    expect(
+      selected.has(fallback),
+      `schema @default("${fallback}") is not selected by backpay (it reads ${[...selected]
+        .map((s) => `'${s}'`)
+        .join(', ')}). A row created without an explicit status would never be paid out.`
+    ).toBe(true);
+  });
+
+  it('is not the sibling tables’ vocabulary', () => {
+    // 'pending' belongs to BlockBuzzAttribution / BlockSubscriptionAttribution. It was copied here,
+    // where nothing reads it.
+    expect(schemaDefaultFor('BlockSpendAttribution', 'status')).not.toBe('pending');
+  });
+});

--- a/src/server/services/blocks/__tests__/block-spend-attribution-status-default.test.ts
+++ b/src/server/services/blocks/__tests__/block-spend-attribution-status-default.test.ts
@@ -3,21 +3,43 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 // Prisma supplies its own @default on create, so the Postgres column default never applies. A
-// default here that backpay's selector does not match makes an omitted-status row invisible to
-// payout with no error and no drift — the shape that hid a wrong licence on ~65k models for two
-// and a half years (#4036). This pins the schema default against the selector that has to see it.
+// default the payout read does not select makes an omitted-status row invisible to payout with no
+// error and no drift — the shape that hid a wrong licence on ~65k models for two and a half years
+// (#4036). Two halves have to agree with the Prisma default: the read backpay pays out from, and
+// the column default committed in prisma/migrations.
 
 const REPO_ROOT = path.resolve(__dirname, '../../../../..');
 const SCHEMA = path.join(REPO_ROOT, 'packages/civitai-db-schema/prisma/schema.full.prisma');
 const BACKPAY = path.join(REPO_ROOT, 'src/server/services/blocks/backpay.service.ts');
+const MIGRATIONS = path.join(REPO_ROOT, 'packages/civitai-db-schema/prisma/migrations');
+
+const TABLE = 'block_spend_attribution';
 
 function readOrThrow(file: string) {
   if (!fs.existsSync(file)) throw new Error(`guard cannot run: ${file} not found`);
-  // Normalise CRLF: the anchored model-block match below is line-based, and a checkout with
-  // Windows line endings would otherwise make this guard fail on Windows only.
+  // Normalise CRLF: the matches below are line-anchored, and a checkout with Windows line endings
+  // would otherwise make this guard fail on Windows only.
   const src = fs.readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
   if (src.trim() === '') throw new Error(`guard cannot run: ${file} is empty`);
   return src;
+}
+
+// Slice from `start` (the index of an opening brace/paren) to its balanced partner, so a nested
+// object cannot end the slice early and an unbalanced source throws rather than returning a
+// truncated fragment.
+function balancedSlice(src: string, start: number) {
+  const open = src[start];
+  const close = open === '{' ? '}' : ')';
+  let depth = 0;
+  for (let i = start; i < src.length; i++) {
+    const c = src[i];
+    if (c === open) depth++;
+    else if (c === close) {
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  throw new Error(`guard cannot run: unbalanced ${open} at index ${start}`);
 }
 
 function schemaDefaultFor(model: string, field: string) {
@@ -33,42 +55,93 @@ function schemaDefaultFor(model: string, field: string) {
   return def[1];
 }
 
-// Every status literal backpay filters blockSpendAttribution rows on.
-function backpaySelectedStatuses() {
+// The status the payout READ selects on. Update filters are deliberately excluded: a row the read
+// never returns is never paid, whatever the updates match.
+function payoutReadStatus() {
   const src = readOrThrow(BACKPAY);
-  const statuses = new Set<string>();
-  const calls = src.matchAll(
-    /db(?:Read|Write)\.blockSpendAttribution\.\w+\(\{([\s\S]*?)\n {4}\}\)/g
-  );
-  for (const call of calls) {
-    const where = call[1].match(/where:\s*\{([^}]*)\}/);
-    if (!where) continue;
-    const status = where[1].match(/status:\s*'([^']+)'/);
-    if (status) statuses.add(status[1]);
-  }
-  if (statuses.size === 0)
+  const marker = `dbRead.blockSpendAttribution.findMany(`;
+  const at = src.indexOf(marker);
+  if (at < 0)
+    throw new Error(`guard cannot run: no dbRead.blockSpendAttribution.findMany in ${BACKPAY}`);
+  if (src.indexOf(marker, at + 1) >= 0)
     throw new Error(
-      'guard cannot run: found no blockSpendAttribution status filter in backpay.service.ts'
+      'guard cannot run: more than one dbRead.blockSpendAttribution.findMany — this guard assumes ' +
+        'a single payout read and can no longer tell which one pays out'
     );
-  return statuses;
+
+  const call = balancedSlice(src, at + marker.length);
+  const whereAt = call.indexOf('where:');
+  if (whereAt < 0) throw new Error('guard cannot run: payout read has no where clause');
+  const where = balancedSlice(call, call.indexOf('{', whereAt));
+
+  const status = where.match(/status:\s*'([^']+)'/);
+  if (!status)
+    throw new Error(
+      `guard cannot run: payout read filters on no status literal (where was ${where})`
+    );
+  return status[1];
+}
+
+// The column default the committed migrations would provision, and the CHECK list that bounds it.
+function migrationColumnState() {
+  if (!fs.existsSync(MIGRATIONS)) throw new Error(`guard cannot run: ${MIGRATIONS} not found`);
+  const files = fs
+    .readdirSync(MIGRATIONS)
+    .filter((d) => /^\d/.test(d))
+    .sort()
+    .map((d) => path.join(MIGRATIONS, d, 'migration.sql'))
+    .filter((f) => fs.existsSync(f));
+  if (files.length === 0) throw new Error('guard cannot run: no migration.sql files found');
+
+  let columnDefault: string | null = null;
+  let checkList: string[] | null = null;
+
+  for (const file of files) {
+    const sql = readOrThrow(file);
+    if (!sql.includes(TABLE)) continue;
+
+    for (const m of sql.matchAll(/"status"\s+TEXT[^,\n]*DEFAULT\s+'([^']+)'/g))
+      columnDefault = m[1];
+    for (const m of sql.matchAll(/ALTER\s+COLUMN\s+"status"\s+SET\s+DEFAULT\s+'([^']+)'/gi))
+      columnDefault = m[1];
+    for (const m of sql.matchAll(/CHECK\s*\(\s*"status"\s+IN\s*\(([^)]*)\)/gi))
+      checkList = [...m[1].matchAll(/'([^']+)'/g)].map((x) => x[1]);
+  }
+
+  if (columnDefault === null)
+    throw new Error(`guard cannot run: no status column default for ${TABLE} in prisma/migrations`);
+  if (checkList === null)
+    throw new Error(`guard cannot run: no status CHECK for ${TABLE} in prisma/migrations`);
+  return { columnDefault, checkList };
 }
 
 describe('BlockSpendAttribution.status default', () => {
-  it('is a status the backpay selector actually reads', () => {
+  it('is the status the payout read selects', () => {
     const fallback = schemaDefaultFor('BlockSpendAttribution', 'status');
-    const selected = backpaySelectedStatuses();
+    const read = payoutReadStatus();
 
     expect(
-      selected.has(fallback),
-      `schema @default("${fallback}") is not selected by backpay (it reads ${[...selected]
-        .map((s) => `'${s}'`)
-        .join(', ')}). A row created without an explicit status would never be paid out.`
-    ).toBe(true);
+      fallback,
+      `schema @default("${fallback}") is not what the payout read selects ('${read}'). A row ` +
+        'created without an explicit status would never be paid out.'
+    ).toBe(read);
   });
 
-  it('is not the sibling tables’ vocabulary', () => {
-    // 'pending' belongs to BlockBuzzAttribution / BlockSubscriptionAttribution. It was copied here,
-    // where nothing reads it.
-    expect(schemaDefaultFor('BlockSpendAttribution', 'status')).not.toBe('pending');
+  it('matches the column default the committed migrations provision', () => {
+    const fallback = schemaDefaultFor('BlockSpendAttribution', 'status');
+    const { columnDefault, checkList } = migrationColumnState();
+
+    expect(
+      columnDefault,
+      `prisma/migrations provisions DEFAULT '${columnDefault}' for ${TABLE}.status while the schema ` +
+        `says @default("${fallback}"). A database built from the committed history disagrees with ` +
+        'the one this code runs against.'
+    ).toBe(fallback);
+
+    expect(
+      checkList,
+      `the committed CHECK for ${TABLE}.status does not allow '${fallback}', so every insert into a ` +
+        'database built from prisma/migrations fails with SQLSTATE 23514.'
+    ).toContain(fallback);
   });
 });


### PR DESCRIPTION
## What

`BlockSpendAttribution.status` had Prisma `@default("pending")` while the column default is `'tracked'`. Prisma supplies its own default on create, so the column default never applies — and `'pending'` belongs to the *sibling* tables (`BlockBuzzAttribution`, `BlockSubscriptionAttribution`). Nothing queries `block_spend_attribution` for it: backpay reads `status: 'tracked'` exclusively.

A row created without an explicit status would therefore be **invisible to payout forever** — never paid, never voided, never reported, with no error and no drift to notice.

**No backfill.** Every existing row was written with an explicit status: **8 tracked, 60 voided, 0 pending**. There is nothing to repair, and a defensive `UPDATE` would only add risk.

## Also here: the missing migration

The committed history still declares `DEFAULT 'pending'` and a CHECK that omits `'tracked'` (`20260618130000_block_spend_attribution`, lines 86 and 103-104). Prod and dev both have the `'tracked'` default and the widened CHECK **hand-applied, with nothing in the repo recording it** — verified on the prod replica.

So any database provisioned from `prisma/migrations` — a fresh local DB, a new environment, CI — rejects **every** spend-attribution insert with SQLSTATE 23514, because the writer sends `status: 'tracked'` explicitly. `20260818210000_block_spend_attribution_tracked_default` records what prod and dev already have. It is written idempotently.

🔴 **Needs applying by hand, as usual.** It is already applied in prod and dev, so it is a history backfill and a no-op there.

## The test

It pins the Prisma default against **backpay's own payout read** rather than a literal, and against the **column default the committed migrations provision** — the two things that have to agree. It extracts the payout read by brace balance and refuses to run (rather than guessing) if there is ever more than one such read.

Verified by mutation, each case mutating one real file and requiring a red:

| mutation | guard |
|---|---|
| payout read selects a different status | ✅ fails |
| schema default reverted to `"pending"` | ✅ fails |
| committed migration default disagrees | ✅ fails |
| committed CHECK omits the default | ✅ fails |

Baseline green before and after. It throws rather than passing if a source file goes missing, is empty, or changes shape.

The first version of this test **passed under the exact regression it named** — it unioned statuses from all three call sites and asserted membership in that union, so changing the payout read to `'pending'` left it green. Caught in review; the rewrite is the second commit.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` / `eslint` on changed files — clean
- `pnpm run prettier` — clean
- `pnpm run test:unit:run` — 18,389 passed, 5 failed, **all 5 pre-existing** (`rating-label`, `appListingStatChips`, `standalone-boot-graph` — Windows-path source guards). Confirmed by rerunning those three files on clean `origin/main` in the same worktree: identical failures with none of these changes present.
- `blocks.router.workflow.test.ts` collects 350
- `db:check-generated` — exit 0

## Where it came from

The audit of every Prisma `@default` against its Postgres column default — ClickUp [868kt9qye](https://app.clickup.com/t/868kt9qye). 1,274 defaults checked, 3 real mismatches. Same class as #4036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)