### PR TITLE
feat(issues): close Known Issues entries when their ClickUp task completes

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -184,6 +184,9 @@ EMERCHANTPAY_PASSWORD=
 
 # Shopify merch store — Blue Buzz reward loop
 # SHOPIFY_SHOP_DOMAIN = the *.myshopify.com admin domain (e.g. ff1592-5.myshopify.com)
+# ClickUp -> Known Issues board sync (signing secret returned when the webhook is created)
+CLICKUP_WEBHOOK_SECRET=
+
 SHOPIFY_SHOP_DOMAIN=
 SHOPIFY_WEBHOOK_SECRET=
 # Admin auth: client_credentials grant (preferred). Set ADMIN_TOKEN instead only for a static token.

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -723,6 +723,11 @@ export const serverSchema = z
     // verifies orders/* HMAC. Admin auth: the custom app uses the client_credentials
     // grant (CLIENT_ID + CLIENT_SECRET → short-lived token); set SHOPIFY_ADMIN_TOKEN
     // instead only if using a static store custom-app token.
+    // ClickUp -> Known Issues board sync. Signing secret ClickUp returns when the
+    // webhook is created; unset disables the receiver (503) rather than trusting
+    // unsigned deliveries.
+    CLICKUP_WEBHOOK_SECRET: z.string().optional(),
+
     SHOPIFY_SHOP_DOMAIN: z.string().optional(),
     SHOPIFY_WEBHOOK_SECRET: z.string().optional(),
     SHOPIFY_CLIENT_ID: z.string().optional(),

--- a/src/pages/api/webhooks/clickup.ts
+++ b/src/pages/api/webhooks/clickup.ts
@@ -20,10 +20,21 @@ export const config = {
 const log = (data: MixedObject) =>
   logToAxiom({ name: 'clickup-webhook', ...data }, 'webhooks').catch(() => null);
 
+// Next's own 1 MB cap goes away with bodyParser: false, and the body is buffered
+// BEFORE the signature can be checked — so the limit has to be re-imposed here or
+// any unauthenticated caller can size the allocation.
+const MAX_BODY_BYTES = 1_000_000;
+
+class PayloadTooLarge extends Error {}
+
 async function buffer(readable: Readable) {
   const chunks = [];
+  let size = 0;
   for await (const chunk of readable) {
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+    const buf = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+    size += buf.length;
+    if (size > MAX_BODY_BYTES) throw new PayloadTooLarge();
+    chunks.push(buf);
   }
   return Buffer.concat(chunks);
 }
@@ -54,6 +65,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     rawBody = await buffer(req);
   } catch (error: any) {
+    if (error instanceof PayloadTooLarge) {
+      await log({ type: 'error', message: 'Body exceeded the size cap' });
+      return res.status(413).send('Payload Too Large');
+    }
     await log({ type: 'error', message: `Failed to read body: ${error.message}` });
     return res.status(400).send('Bad Request');
   }
@@ -64,27 +79,36 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(401).send('Unauthorized');
   }
 
+  let payload;
   try {
     const parsed = clickupWebhookSchema.safeParse(JSON.parse(rawBody.toString('utf8')));
     if (!parsed.success) {
       await log({ type: 'validation-error', errors: parsed.error.flatten() });
       return res.status(400).json({ error: 'Invalid payload' });
     }
+    payload = parsed.data;
+  } catch (error: any) {
+    await log({ type: 'error', message: `Unparseable body: ${error.message}` });
+    return res.status(400).send('Bad Request');
+  }
 
-    const payload = parsed.data;
-    const taskId = payload.task_id;
-    const doneStatus = clickupDoneStatusFromPayload(payload);
+  const taskId = payload.task_id;
+  const doneStatus = clickupDoneStatusFromPayload(payload);
 
-    // Ack anything we don't act on so ClickUp keeps the webhook healthy.
-    if (!taskId || !doneStatus) return res.status(200).json({ ignored: payload.event });
+  // Ack anything we don't act on so ClickUp keeps the webhook healthy.
+  if (!taskId || !doneStatus) return res.status(200).json({ ignored: payload.event });
 
+  try {
     const result = await resolveBugsByClickupTaskId({ taskId });
-    if (result.resolved.length)
-      await log({ type: 'resolved', taskId, doneStatus, resolved: result.resolved });
+    if (result.resolved.length || result.failed.length)
+      await log({ type: 'resolved', taskId, doneStatus, ...result });
 
     return res.status(200).json({ received: true, taskId, ...result });
   } catch (error: any) {
-    await log({ type: 'error', message: `Webhook error: ${error.message}`, error: error.stack });
-    return res.status(400).send(`Webhook Error: ${error.message}`);
+    // 5xx, NOT 4xx: the request was fine and our side failed, so ClickUp should
+    // retry rather than treat the completion as delivered and drop it. The message
+    // is logged, never echoed — a DB error string can carry query detail.
+    await log({ type: 'error', message: `Failed to sync task ${taskId}`, error: error.stack });
+    return res.status(500).send('Internal Server Error');
   }
 }

--- a/src/pages/api/webhooks/clickup.ts
+++ b/src/pages/api/webhooks/clickup.ts
@@ -1,0 +1,90 @@
+import crypto from 'crypto';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { Readable } from 'node:stream';
+import { env } from '~/env/server';
+import { logToAxiom } from '~/server/logging/client';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
+import { clickupWebhookSchema } from '~/server/schema/bug.schema';
+import {
+  clickupDoneStatusFromPayload,
+  resolveBugsByClickupTaskId,
+} from '~/server/services/bug.service';
+
+// ClickUp signs the raw request body — disable Next's parser.
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+const log = (data: MixedObject) =>
+  logToAxiom({ name: 'clickup-webhook', ...data }, 'webhooks').catch(() => null);
+
+async function buffer(readable: Readable) {
+  const chunks = [];
+  for await (const chunk of readable) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+function isValidSignature(rawBody: Buffer, signatureHeader: string, secret: string) {
+  const digest = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+  try {
+    return crypto.timingSafeEqual(Buffer.from(digest), Buffer.from(signatureHeader));
+  } catch {
+    return false; // length mismatch
+  }
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  instrumentApiResponse(req, res);
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const secret = env.CLICKUP_WEBHOOK_SECRET;
+  if (!secret) {
+    await log({ type: 'error', message: 'CLICKUP_WEBHOOK_SECRET not configured' });
+    return res.status(503).send('ClickUp webhook not configured');
+  }
+
+  let rawBody: Buffer;
+  try {
+    rawBody = await buffer(req);
+  } catch (error: any) {
+    await log({ type: 'error', message: `Failed to read body: ${error.message}` });
+    return res.status(400).send('Bad Request');
+  }
+
+  const signature = req.headers['x-signature'];
+  if (typeof signature !== 'string' || !isValidSignature(rawBody, signature, secret)) {
+    await log({ type: 'error', message: 'Invalid signature' });
+    return res.status(401).send('Unauthorized');
+  }
+
+  try {
+    const parsed = clickupWebhookSchema.safeParse(JSON.parse(rawBody.toString('utf8')));
+    if (!parsed.success) {
+      await log({ type: 'validation-error', errors: parsed.error.flatten() });
+      return res.status(400).json({ error: 'Invalid payload' });
+    }
+
+    const payload = parsed.data;
+    const taskId = payload.task_id;
+    const doneStatus = clickupDoneStatusFromPayload(payload);
+
+    // Ack anything we don't act on so ClickUp keeps the webhook healthy.
+    if (!taskId || !doneStatus) return res.status(200).json({ ignored: payload.event });
+
+    const result = await resolveBugsByClickupTaskId({ taskId });
+    if (result.resolved.length)
+      await log({ type: 'resolved', taskId, doneStatus, resolved: result.resolved });
+
+    return res.status(200).json({ received: true, taskId, ...result });
+  } catch (error: any) {
+    await log({ type: 'error', message: `Webhook error: ${error.message}`, error: error.stack });
+    return res.status(400).send(`Webhook Error: ${error.message}`);
+  }
+}

--- a/src/server/__tests__/clickup-webhook-endpoint.test.ts
+++ b/src/server/__tests__/clickup-webhook-endpoint.test.ts
@@ -1,0 +1,129 @@
+import crypto from 'crypto';
+import { Readable } from 'node:stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as BugService from '~/server/services/bug.service';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const SECRET = 'clickup-test-signing-secret';
+const TASK_ID = '868kfwm3j';
+
+// vi.hoisted: vi.mock factories run before module-level consts exist. Mutable so
+// the "not configured" case can unset the secret without re-importing.
+const { env, resolveBugsByClickupTaskId } = vi.hoisted(() => ({
+  // LOGGING: read at import time by createLogger, which bug.service pulls in
+  // transitively through cache-helpers.
+  env: { CLICKUP_WEBHOOK_SECRET: 'clickup-test-signing-secret', LOGGING: '' } as {
+    CLICKUP_WEBHOOK_SECRET?: string;
+    LOGGING: string;
+  },
+  resolveBugsByClickupTaskId: vi.fn(async () => ({ matched: [1], resolved: [], skipped: [] })),
+}));
+vi.mock('~/env/server', () => ({ env }));
+
+vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
+
+// Only the write is stubbed — `clickupDoneStatusFromPayload` stays real, so these
+// cases exercise the handler's actual decision about what counts as a completion.
+vi.mock('~/server/services/bug.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof BugService>()),
+  resolveBugsByClickupTaskId,
+}));
+
+const handler = (await import('~/pages/api/webhooks/clickup')).default;
+
+const sign = (body: string, secret = SECRET) =>
+  crypto.createHmac('sha256', secret).update(Buffer.from(body)).digest('hex');
+
+function createMocks(body: string, headers: Record<string, string>) {
+  const req = Readable.from([body]) as unknown as Record<string, unknown>;
+  req.method = 'POST';
+  req.headers = headers;
+
+  let statusCode = 0;
+  let payload: unknown;
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(data: unknown) {
+      payload = data;
+      return res;
+    },
+    send(data: unknown) {
+      payload = data;
+      return res;
+    },
+    setHeader: () => res,
+    end: () => res,
+    _status: () => statusCode,
+    _body: () => payload,
+  };
+  return { req, res };
+}
+
+const completion = JSON.stringify({
+  event: 'taskStatusUpdated',
+  task_id: TASK_ID,
+  history_items: [{ field: 'status', after: { status: 'complete', type: 'closed' } }],
+});
+
+const run = (body: string, signature?: string) => {
+  const { req, res } = createMocks(body, signature ? { 'x-signature': signature } : {});
+  return handler(req as never, res as never).then(() => res);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  env.CLICKUP_WEBHOOK_SECRET = SECRET;
+});
+
+describe('clickup webhook endpoint', () => {
+  it('closes the linked entry when a correctly signed completion arrives', async () => {
+    const res = await run(completion, sign(completion));
+
+    expect(res._status()).toBe(200);
+    expect(resolveBugsByClickupTaskId).toHaveBeenCalledWith({ taskId: TASK_ID });
+  });
+
+  it('rejects a body whose signature does not match it', async () => {
+    // Correctly signed — for a DIFFERENT body. This is the forgery case: a valid
+    // signature is not a licence to act on whatever payload accompanies it.
+    const res = await run(completion, sign('{"event":"taskStatusUpdated"}'));
+
+    expect(res._status()).toBe(401);
+    expect(resolveBugsByClickupTaskId).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsigned request', async () => {
+    const res = await run(completion);
+
+    expect(res._status()).toBe(401);
+    expect(resolveBugsByClickupTaskId).not.toHaveBeenCalled();
+  });
+
+  it('refuses to serve at all when no signing secret is configured', async () => {
+    env.CLICKUP_WEBHOOK_SECRET = undefined;
+
+    const res = await run(completion, sign(completion));
+
+    expect(res._status()).toBe(503);
+    expect(resolveBugsByClickupTaskId).not.toHaveBeenCalled();
+  });
+
+  it('acks a signed status change that is not a completion without touching the board', async () => {
+    const body = JSON.stringify({
+      event: 'taskStatusUpdated',
+      task_id: TASK_ID,
+      history_items: [{ field: 'status', after: { status: 'in progress', type: 'custom' } }],
+    });
+
+    const res = await run(body, sign(body));
+
+    expect(res._status()).toBe(200);
+    expect(res._body()).toEqual({ ignored: 'taskStatusUpdated' });
+    expect(resolveBugsByClickupTaskId).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/__tests__/clickup-webhook-endpoint.test.ts
+++ b/src/server/__tests__/clickup-webhook-endpoint.test.ts
@@ -2,8 +2,10 @@ import crypto from 'crypto';
 import { Readable } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as BugService from '~/server/services/bug.service';
-import { loggingMock } from '~/__tests__/mocks/logging.mock';
-import { dbMock } from '~/__tests__/mocks/db.mock';
+// Imported for the side effect: loading these installs the canonical mocks that
+// bug.service's module-scope imports would otherwise reach for real.
+import '~/__tests__/mocks/logging.mock';
+import '~/__tests__/mocks/db.mock';
 
 const SECRET = 'clickup-test-signing-secret';
 const TASK_ID = '868kfwm3j';
@@ -17,7 +19,12 @@ const { env, resolveBugsByClickupTaskId } = vi.hoisted(() => ({
     CLICKUP_WEBHOOK_SECRET?: string;
     LOGGING: string;
   },
-  resolveBugsByClickupTaskId: vi.fn(async () => ({ matched: [1], resolved: [], skipped: [] })),
+  resolveBugsByClickupTaskId: vi.fn(async () => ({
+    matched: [1],
+    resolved: [],
+    skipped: [],
+    failed: [],
+  })),
 }));
 vi.mock('~/env/server', () => ({ env }));
 
@@ -110,6 +117,31 @@ describe('clickup webhook endpoint', () => {
     const res = await run(completion, sign(completion));
 
     expect(res._status()).toBe(503);
+    expect(resolveBugsByClickupTaskId).not.toHaveBeenCalled();
+  });
+
+  // 4xx tells ClickUp the request was bad, so it does not retry — a DB blip
+  // answered 400 would drop the completion permanently and leave the entry public.
+  it('answers 5xx when our own side fails, so ClickUp retries', async () => {
+    resolveBugsByClickupTaskId.mockRejectedValueOnce(
+      new Error('connect ETIMEDOUT 10.0.0.1:5432 while running `SELECT ...`')
+    );
+
+    const res = await run(completion, sign(completion));
+
+    expect(res._status()).toBe(500);
+    // The DB message can carry query/connection detail; it is logged, not echoed.
+    expect(String(res._body())).not.toContain('ETIMEDOUT');
+  });
+
+  it('caps the body it will buffer for an unauthenticated caller', async () => {
+    // bodyParser:false removes Next's 1MB limit, and the body is read BEFORE the
+    // signature can be checked — so the cap is the only thing bounding this.
+    const huge = 'x'.repeat(1_000_001);
+
+    const res = await run(huge, sign(huge));
+
+    expect(res._status()).toBe(413);
     expect(resolveBugsByClickupTaskId).not.toHaveBeenCalled();
   });
 

--- a/src/server/schema/bug.schema.ts
+++ b/src/server/schema/bug.schema.ts
@@ -53,3 +53,25 @@ export type GetBugReportStatsInput = z.infer<typeof getBugReportStatsInput>;
 export const getBugReportStatsInput = z.object({
   bugIds: z.number().int().positive().array().min(1).max(200),
 });
+
+// ClickUp fires this at us on every task event we subscribe to; only the status
+// history items matter here, and every other field is ignored on purpose so a
+// payload shape change upstream cannot fail the request.
+const clickupStatusValue = z.union([
+  z.string(),
+  z.object({ status: z.string().nullish(), type: z.string().nullish() }),
+]);
+
+export type ClickupWebhookPayload = z.infer<typeof clickupWebhookSchema>;
+export const clickupWebhookSchema = z.object({
+  event: z.string(),
+  task_id: z.string().optional(),
+  history_items: z
+    .array(
+      z.object({
+        field: z.string().optional(),
+        after: clickupStatusValue.nullish(),
+      })
+    )
+    .optional(),
+});

--- a/src/server/schema/bug.schema.ts
+++ b/src/server/schema/bug.schema.ts
@@ -54,14 +54,11 @@ export const getBugReportStatsInput = z.object({
   bugIds: z.number().int().positive().array().min(1).max(200),
 });
 
-// ClickUp fires this at us on every task event we subscribe to; only the status
-// history items matter here, and every other field is ignored on purpose so a
-// payload shape change upstream cannot fail the request.
-const clickupStatusValue = z.union([
-  z.string(),
-  z.object({ status: z.string().nullish(), type: z.string().nullish() }),
-]);
-
+// ClickUp fires this at us on every task event we subscribe to. `after` is
+// deliberately `unknown`: it carries an array for tag/watcher edits and a number
+// for priority, and a union that rejected those would fail the WHOLE delivery —
+// dropping any status item beside them, and eventually tripping ClickUp's
+// consecutive-failure webhook disable. Narrowing happens in the service.
 export type ClickupWebhookPayload = z.infer<typeof clickupWebhookSchema>;
 export const clickupWebhookSchema = z.object({
   event: z.string(),
@@ -70,7 +67,7 @@ export const clickupWebhookSchema = z.object({
     .array(
       z.object({
         field: z.string().optional(),
-        after: clickupStatusValue.nullish(),
+        after: z.unknown(),
       })
     )
     .optional(),

--- a/src/server/services/__tests__/clickup-bug-sync.service.test.ts
+++ b/src/server/services/__tests__/clickup-bug-sync.service.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClickupWebhookPayload } from '~/server/schema/bug.schema';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+type BugUpdateArgs = { where: { id: number }; data: { status?: string; resolvedAt?: Date | null } };
+type HistoryItem = NonNullable<ClickupWebhookPayload['history_items']>[number];
+
+/**
+ * Distinct ids throughout: a value arriving in the wrong place cannot pass by
+ * colliding with the right one. TASK_ID is a strict prefix of NEIGHBOUR_TASK_ID
+ * because that is the collision a `contains` lookup makes by itself.
+ */
+const TASK_ID = '868kfwm3j';
+const NEIGHBOUR_TASK_ID = '868kfwm3jx';
+const OPEN_BUG = 41;
+const NEIGHBOUR_BUG = 52;
+const CLOSED_BUG = 63;
+
+const bugFindMany = dbMock.dbRead.bug.findMany;
+const bugFindUnique = dbMock.dbRead.bug.findUnique;
+const bugUpdate = dbMock.dbWrite.bug.update;
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
+
+const { clickupDoneStatusFromPayload, clickupTaskIdFromUrl, resolveBugsByClickupTaskId } =
+  await import('~/server/services/bug.service');
+
+const url = (taskId: string) => `https://app.clickup.com/t/8459928/${taskId}`;
+
+const row = (
+  id: number,
+  taskId: string,
+  over: Partial<{ status: string; resolvedAt: Date }> = {}
+) => ({
+  id,
+  status: 'Open',
+  resolvedAt: null,
+  clickupUrl: url(taskId),
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  bugUpdate.mockImplementation(async ({ where, data }: BugUpdateArgs) => ({
+    id: where.id,
+    ...data,
+  }));
+  bugFindUnique.mockResolvedValue({ status: 'Open', resolvedAt: null });
+});
+
+describe('clickupTaskIdFromUrl', () => {
+  it('reads the task segment, ignoring query and trailing slash', () => {
+    expect(clickupTaskIdFromUrl(url(TASK_ID))).toBe(TASK_ID);
+    expect(clickupTaskIdFromUrl(`${url(TASK_ID)}/?block=abc#c`)).toBe(TASK_ID);
+  });
+
+  // Justin's note on the ticket: entries may carry a bare task id rather than a
+  // full link, so both spellings have to resolve to the same task.
+  it('accepts a bare task id', () => {
+    expect(clickupTaskIdFromUrl(TASK_ID)).toBe(TASK_ID);
+  });
+
+  it('is null when there is no link and when the segment is not an id', () => {
+    expect(clickupTaskIdFromUrl(null)).toBeNull();
+    expect(clickupTaskIdFromUrl('')).toBeNull();
+    expect(clickupTaskIdFromUrl('https://app.clickup.com/t/not an id')).toBeNull();
+  });
+});
+
+describe('clickupDoneStatusFromPayload', () => {
+  const payload = (after: HistoryItem['after'], field = 'status'): ClickupWebhookPayload => ({
+    event: 'taskStatusUpdated',
+    task_id: TASK_ID,
+    history_items: [{ field, after }],
+  });
+
+  it("takes ClickUp's status type as authoritative, whatever the status is named", () => {
+    expect(clickupDoneStatusFromPayload(payload({ status: 'shipped', type: 'closed' }))).toBe(
+      'shipped'
+    );
+    expect(clickupDoneStatusFromPayload(payload({ status: 'shipped', type: 'open' }))).toBeNull();
+  });
+
+  it('falls back to the board closed-status list for a bare status string', () => {
+    expect(clickupDoneStatusFromPayload(payload('complete'))).toBe('complete');
+    expect(clickupDoneStatusFromPayload(payload('in progress'))).toBeNull();
+  });
+
+  it('ignores non-status history items and empty payloads', () => {
+    expect(
+      clickupDoneStatusFromPayload(payload({ status: 'complete', type: 'closed' }, 'assignee'))
+    ).toBeNull();
+    expect(clickupDoneStatusFromPayload({ event: 'taskUpdated' })).toBeNull();
+  });
+});
+
+describe('resolveBugsByClickupTaskId', () => {
+  it('closes the entry linked to the completed task', async () => {
+    bugFindMany.mockResolvedValue([row(OPEN_BUG, TASK_ID)]);
+
+    const result = await resolveBugsByClickupTaskId({ taskId: TASK_ID });
+
+    expect(result.resolved).toEqual([{ id: OPEN_BUG, previousStatus: 'Open' }]);
+    expect(bugUpdate).toHaveBeenCalledTimes(1);
+    const { where, data } = bugUpdate.mock.calls[0][0];
+    expect(where.id).toBe(OPEN_BUG);
+    expect(data.status).toBe('Complete');
+    expect(data.resolvedAt).toBeInstanceOf(Date);
+  });
+
+  it('leaves an entry whose task merely starts with this id alone', async () => {
+    bugFindMany.mockResolvedValue([row(NEIGHBOUR_BUG, NEIGHBOUR_TASK_ID)]);
+
+    const result = await resolveBugsByClickupTaskId({ taskId: TASK_ID });
+
+    expect(result.matched).toEqual([]);
+    expect(result.resolved).toEqual([]);
+    expect(bugUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does not re-stamp an entry that is already closed', async () => {
+    bugFindMany.mockResolvedValue([
+      row(CLOSED_BUG, TASK_ID, { status: 'Complete', resolvedAt: new Date('2026-08-01') }),
+    ]);
+
+    const result = await resolveBugsByClickupTaskId({ taskId: TASK_ID });
+
+    expect(result.skipped).toEqual([CLOSED_BUG]);
+    expect(result.resolved).toEqual([]);
+    expect(bugUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/clickup-bug-sync.service.test.ts
+++ b/src/server/services/__tests__/clickup-bug-sync.service.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clickupWebhookSchema } from '~/server/schema/bug.schema';
 import type { ClickupWebhookPayload } from '~/server/schema/bug.schema';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 
 type BugUpdateArgs = { where: { id: number }; data: { status?: string; resolvedAt?: Date | null } };
-type HistoryItem = NonNullable<ClickupWebhookPayload['history_items']>[number];
 
 /**
  * Distinct ids throughout: a value arriving in the wrong place cannot pass by
@@ -17,6 +17,7 @@ const NEIGHBOUR_BUG = 52;
 const CLOSED_BUG = 63;
 
 const bugFindMany = dbMock.dbRead.bug.findMany;
+const bugWriteFindMany = dbMock.dbWrite.bug.findMany;
 const bugFindUnique = dbMock.dbRead.bug.findUnique;
 const bugUpdate = dbMock.dbWrite.bug.update;
 
@@ -41,6 +42,13 @@ const row = (
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // reset, not clear: `...Once` queues survive clearAllMocks and would otherwise
+  // bleed a previous test's return value into this one.
+  bugFindMany.mockReset();
+  bugWriteFindMany.mockReset();
+  bugUpdate.mockReset();
+  bugFindMany.mockResolvedValue([]);
+  bugWriteFindMany.mockResolvedValue([]);
   bugUpdate.mockImplementation(async ({ where, data }: BugUpdateArgs) => ({
     id: where.id,
     ...data,
@@ -54,10 +62,11 @@ describe('clickupTaskIdFromUrl', () => {
     expect(clickupTaskIdFromUrl(`${url(TASK_ID)}/?block=abc#c`)).toBe(TASK_ID);
   });
 
-  // Justin's note on the ticket: entries may carry a bare task id rather than a
-  // full link, so both spellings have to resolve to the same task.
-  it('accepts a bare task id', () => {
+  // `-`/`_` matter: a ClickUp custom task id (DEV-1234) must parse rather than
+  // read as "no link at all", which is silent.
+  it('accepts a bare task id and a custom task id', () => {
     expect(clickupTaskIdFromUrl(TASK_ID)).toBe(TASK_ID);
+    expect(clickupTaskIdFromUrl('https://app.clickup.com/t/9008/DEV-1234')).toBe('DEV-1234');
   });
 
   it('is null when there is no link and when the segment is not an id', () => {
@@ -68,7 +77,7 @@ describe('clickupTaskIdFromUrl', () => {
 });
 
 describe('clickupDoneStatusFromPayload', () => {
-  const payload = (after: HistoryItem['after'], field = 'status'): ClickupWebhookPayload => ({
+  const payload = (after: unknown, field = 'status'): ClickupWebhookPayload => ({
     event: 'taskStatusUpdated',
     task_id: TASK_ID,
     history_items: [{ field, after }],
@@ -79,6 +88,36 @@ describe('clickupDoneStatusFromPayload', () => {
       'shipped'
     );
     expect(clickupDoneStatusFromPayload(payload({ status: 'shipped', type: 'open' }))).toBeNull();
+  });
+
+  // The trap this guards: a QA flow with Resolved -> Verified -> Closed would
+  // publicly mark the board entry fixed the moment it reached the FIRST of them.
+  it('does not treat a done-SOUNDING name as done when ClickUp typed it otherwise', () => {
+    expect(
+      clickupDoneStatusFromPayload(payload({ status: 'Resolved', type: 'custom' }))
+    ).toBeNull();
+    expect(
+      clickupDoneStatusFromPayload(payload({ status: 'Complete', type: 'custom' }))
+    ).toBeNull();
+  });
+
+  // ClickUp sends an array for tag/watcher edits and a number for priority. A
+  // schema that rejected those would fail the whole delivery, dropping the status
+  // item beside them — and repeated failures disable the webhook at ClickUp.
+  it('reads the status item even when other history items carry other shapes', () => {
+    const mixed = {
+      event: 'taskUpdated',
+      task_id: TASK_ID,
+      history_items: [
+        { field: 'tag', after: [{ name: 'known-issue' }] },
+        { field: 'priority', after: 2 },
+        { field: 'status', after: { status: 'complete', type: 'closed' } },
+      ],
+    };
+    const parsed = clickupWebhookSchema.safeParse(mixed);
+
+    expect(parsed.success).toBe(true);
+    expect(clickupDoneStatusFromPayload(parsed.data as ClickupWebhookPayload)).toBe('complete');
   });
 
   it('falls back to the board closed-status list for a bare status string', () => {
@@ -109,13 +148,39 @@ describe('resolveBugsByClickupTaskId', () => {
   });
 
   it('leaves an entry whose task merely starts with this id alone', async () => {
+    // On BOTH clients, so this proves the segment filter rather than an empty read.
     bugFindMany.mockResolvedValue([row(NEIGHBOUR_BUG, NEIGHBOUR_TASK_ID)]);
+    bugWriteFindMany.mockResolvedValue([row(NEIGHBOUR_BUG, NEIGHBOUR_TASK_ID)]);
 
     const result = await resolveBugsByClickupTaskId({ taskId: TASK_ID });
 
     expect(result.matched).toEqual([]);
     expect(result.resolved).toEqual([]);
     expect(bugUpdate).not.toHaveBeenCalled();
+  });
+
+  // A moderator can link an entry seconds before the task completes; the read
+  // replica may not have it yet, and ClickUp never redelivers a 200.
+  it('re-checks the writer when the replica returns nothing', async () => {
+    bugFindMany.mockResolvedValue([]);
+    bugWriteFindMany.mockResolvedValue([row(OPEN_BUG, TASK_ID)]);
+
+    const result = await resolveBugsByClickupTaskId({ taskId: TASK_ID });
+
+    expect(result.resolved).toEqual([{ id: OPEN_BUG, previousStatus: 'Open' }]);
+  });
+
+  it('closes the remaining entries when one of them cannot be closed', async () => {
+    bugFindMany.mockResolvedValue([
+      row(CLOSED_BUG, TASK_ID, { status: 'Open' }),
+      row(OPEN_BUG, TASK_ID),
+    ]);
+    bugUpdate.mockRejectedValueOnce(new Error('row vanished'));
+
+    const result = await resolveBugsByClickupTaskId({ taskId: TASK_ID });
+
+    expect(result.failed.map((f) => f.id)).toEqual([CLOSED_BUG]);
+    expect(result.resolved).toEqual([{ id: OPEN_BUG, previousStatus: 'Open' }]);
   });
 
   it('does not re-stamp an entry that is already closed', async () => {

--- a/src/server/services/bug.service.ts
+++ b/src/server/services/bug.service.ts
@@ -4,6 +4,7 @@ import { BUG_CLOSED_STATUSES, CacheTTL, isBugClosed } from '~/server/common/cons
 import { dbRead, dbWrite } from '~/server/db/client';
 import { REDIS_KEYS } from '~/server/redis/client';
 import type {
+  ClickupWebhookPayload,
   CreateBugInput,
   DeleteBugInput,
   GetBugByIdInput,
@@ -293,3 +294,69 @@ export const getBugReportStats = async ({
 };
 
 export { BUG_CLOSED_STATUSES };
+
+/** `https://app.clickup.com/t/8459928/868kfwm3j` -> `868kfwm3j` */
+export const clickupTaskIdFromUrl = (url?: string | null) => {
+  if (!url) return null;
+  const last = url.split('?')[0].split('#')[0].replace(/\/+$/, '').split('/').pop();
+  return last && /^[a-z0-9]+$/i.test(last) ? last : null;
+};
+
+const CLICKUP_DONE_TYPES = new Set(['closed', 'done']);
+
+/**
+ * The status a task landed on if this payload moved it into a done state, else null.
+ * ClickUp's own status *type* is authoritative because workspaces rename statuses
+ * ("Shipped", "QA passed"); BUG_CLOSED_STATUSES is the fallback for payloads that
+ * carry a bare status string with no type.
+ */
+export const clickupDoneStatusFromPayload = (payload: ClickupWebhookPayload) => {
+  for (const item of payload.history_items ?? []) {
+    if (item.field !== 'status') continue;
+    const after = item.after;
+    if (!after) continue;
+    const status = typeof after === 'string' ? after : after.status ?? null;
+    const type = typeof after === 'string' ? null : after.type ?? null;
+    if (!status) continue;
+    if ((type && CLICKUP_DONE_TYPES.has(type.trim().toLowerCase())) || isBugClosed(status))
+      return status;
+  }
+  return null;
+};
+
+/**
+ * Close every board entry linked to a completed ClickUp task. Entries already
+ * closed are left alone, so a replayed delivery cannot re-stamp resolvedAt.
+ */
+export const resolveBugsByClickupTaskId = async ({
+  taskId,
+  status = 'Complete',
+}: {
+  taskId: string;
+  status?: string;
+}) => {
+  const candidates = await dbRead.bug.findMany({
+    where: { clickupUrl: { contains: taskId } },
+    select: { id: true, status: true, resolvedAt: true, clickupUrl: true },
+  });
+
+  // `contains` also matches a longer id this one is a prefix of, so an entry is
+  // only ours when its task segment is exactly the task that completed.
+  const linked = candidates.filter((bug) => clickupTaskIdFromUrl(bug.clickupUrl) === taskId);
+  const isClosed = (bug: { status: string; resolvedAt: Date | null }) =>
+    !!bug.resolvedAt || isBugClosed(bug.status);
+  const alreadyClosed = linked.filter(isClosed);
+  const toClose = linked.filter((bug) => !isClosed(bug));
+
+  const resolved: { id: number; previousStatus: string }[] = [];
+  for (const bug of toClose) {
+    await updateBug({ id: bug.id, status });
+    resolved.push({ id: bug.id, previousStatus: bug.status });
+  }
+
+  return {
+    matched: linked.map((bug) => bug.id),
+    resolved,
+    skipped: alreadyClosed.map((bug) => bug.id),
+  };
+};

--- a/src/server/services/bug.service.ts
+++ b/src/server/services/bug.service.ts
@@ -295,31 +295,44 @@ export const getBugReportStats = async ({
 
 export { BUG_CLOSED_STATUSES };
 
-/** `https://app.clickup.com/t/8459928/868kfwm3j` -> `868kfwm3j` */
+/**
+ * `https://app.clickup.com/t/8459928/868kfwm3j` -> `868kfwm3j`. Tolerates `-`/`_`
+ * so a ClickUp custom task id (`DEV-1234`) parses rather than silently reading
+ * as "no link".
+ */
 export const clickupTaskIdFromUrl = (url?: string | null) => {
   if (!url) return null;
   const last = url.split('?')[0].split('#')[0].replace(/\/+$/, '').split('/').pop();
-  return last && /^[a-z0-9]+$/i.test(last) ? last : null;
+  return last && /^[a-z0-9_-]+$/i.test(last) ? last : null;
 };
 
 const CLICKUP_DONE_TYPES = new Set(['closed', 'done']);
 
 /**
  * The status a task landed on if this payload moved it into a done state, else null.
- * ClickUp's own status *type* is authoritative because workspaces rename statuses
- * ("Shipped", "QA passed"); BUG_CLOSED_STATUSES is the fallback for payloads that
- * carry a bare status string with no type.
+ * ClickUp's status *type* is authoritative when present, because workspaces both
+ * rename statuses ("Shipped") and use done-sounding names for intermediate ones
+ * ("Resolved" -> "Verified" -> "Closed"). BUG_CLOSED_STATUSES is consulted only
+ * for a bare status string carrying no type.
  */
 export const clickupDoneStatusFromPayload = (payload: ClickupWebhookPayload) => {
   for (const item of payload.history_items ?? []) {
     if (item.field !== 'status') continue;
+
+    // `after` is unknown by design — see clickupWebhookSchema.
     const after = item.after;
-    if (!after) continue;
-    const status = typeof after === 'string' ? after : after.status ?? null;
-    const type = typeof after === 'string' ? null : after.type ?? null;
+    let status: string | null = null;
+    let type: string | null = null;
+    if (typeof after === 'string') status = after;
+    else if (after && typeof after === 'object') {
+      const shape = after as { status?: unknown; type?: unknown };
+      if (typeof shape.status === 'string') status = shape.status;
+      if (typeof shape.type === 'string') type = shape.type;
+    }
     if (!status) continue;
-    if ((type && CLICKUP_DONE_TYPES.has(type.trim().toLowerCase())) || isBugClosed(status))
-      return status;
+
+    const done = type ? CLICKUP_DONE_TYPES.has(type.trim().toLowerCase()) : isBugClosed(status);
+    if (done) return status;
   }
   return null;
 };
@@ -328,35 +341,45 @@ export const clickupDoneStatusFromPayload = (payload: ClickupWebhookPayload) => 
  * Close every board entry linked to a completed ClickUp task. Entries already
  * closed are left alone, so a replayed delivery cannot re-stamp resolvedAt.
  */
-export const resolveBugsByClickupTaskId = async ({
-  taskId,
-  status = 'Complete',
-}: {
-  taskId: string;
-  status?: string;
-}) => {
-  const candidates = await dbRead.bug.findMany({
-    where: { clickupUrl: { contains: taskId } },
-    select: { id: true, status: true, resolvedAt: true, clickupUrl: true },
-  });
+export const resolveBugsByClickupTaskId = async ({ taskId }: { taskId: string }) => {
+  const findLinked = async (client: typeof dbRead) => {
+    const candidates = await client.bug.findMany({
+      where: { clickupUrl: { contains: taskId } },
+      select: { id: true, status: true, resolvedAt: true, clickupUrl: true },
+    });
+    // `contains` also matches a longer id this one is a prefix of, so an entry is
+    // only ours when its task segment is exactly the task that completed.
+    return candidates.filter((bug) => clickupTaskIdFromUrl(bug.clickupUrl) === taskId);
+  };
 
-  // `contains` also matches a longer id this one is a prefix of, so an entry is
-  // only ours when its task segment is exactly the task that completed.
-  const linked = candidates.filter((bug) => clickupTaskIdFromUrl(bug.clickupUrl) === taskId);
+  // An entry linked moments ago may not have reached the replica yet, and ClickUp
+  // does not redeliver a 200 — so an empty read is re-checked on the writer rather
+  // than reported as "no entry links this task".
+  let linked = await findLinked(dbRead);
+  if (!linked.length) linked = await findLinked(dbWrite);
+
   const isClosed = (bug: { status: string; resolvedAt: Date | null }) =>
     !!bug.resolvedAt || isBugClosed(bug.status);
   const alreadyClosed = linked.filter(isClosed);
   const toClose = linked.filter((bug) => !isClosed(bug));
 
   const resolved: { id: number; previousStatus: string }[] = [];
+  const failed: { id: number; error: string }[] = [];
   for (const bug of toClose) {
-    await updateBug({ id: bug.id, status });
-    resolved.push({ id: bug.id, previousStatus: bug.status });
+    // One unclosable entry (deleted between the read and the write) must not
+    // abandon the others, nor discard the closes already made.
+    try {
+      await updateBug({ id: bug.id, status: 'Complete' });
+      resolved.push({ id: bug.id, previousStatus: bug.status });
+    } catch (error) {
+      failed.push({ id: bug.id, error: error instanceof Error ? error.message : String(error) });
+    }
   }
 
   return {
     matched: linked.map((bug) => bug.id),
     resolved,
     skipped: alreadyClosed.map((bug) => bug.id),
+    failed,
   };
 };


### PR DESCRIPTION
Closes the ClickUp side of the Known Issues board sync. [ClickUp 868ktfupv](https://app.clickup.com/t/868ktfupv), raised by Ellie at the 2026-08-18 standup.

## The problem

Nothing synced the public board (civitai.com/issues) with ClickUp in either direction. `clickupUrl` on an entry was a link, not a binding — completing the task did not close the entry, stamp `resolvedAt`, or take it off the public page. Known Issue #55 stayed published for days after its fix shipped, while the live face-fix problem was already a *different* bug. So the board was actively misinforming people.

## What this does — and deliberately does not

**Completion only.** A signed ClickUp webhook closes any board entry linked to a task that just moved to a done status.

**There is no publish automation, by design.** Entries are still created by hand. Justin's call, and the safe one: the board is public, so an automation that could *publish* on a tag could publish something nobody meant to. This PR can only ever take an entry *off* the public page, and `civitai-issues reopen <id>` puts it back in one command. **If someone tags the wrong task, nothing happens** — there is no tag path.

## What already existed, so it isn't rebuilt here

- **Resolution logic.** `updateBug` already stamps `resolvedAt` from the status string via `isBugClosed`. This PR supplies the *trigger* and the task→entry lookup; closing an entry is the existing call.
- **Drift detection.** `check-known-issues-sync.mjs` in the support-agent repo already reports entries out of step with their task. It stays useful as the backstop — it catches the cases this webhook cannot see (below).
- **The ClickUp skill's watchers** create real webhooks but hardcode the endpoint to webhook.site and need `whcli` locally. Dev scaffolding; not a deployable receiver, so not reused.

## Shape

`src/pages/api/webhooks/clickup.ts` follows the `shopify.ts` receiver pattern: raw body, HMAC-SHA256 over `X-Signature`, `timingSafeEqual`. An unset `CLICKUP_WEBHOOK_SECRET` serves 503 rather than accepting unsigned deliveries. Anything that isn't a completion is acked 200 so ClickUp keeps the webhook healthy — subscribing at the list level means most deliveries are ignored, which is expected and cheap.

Matching is `clickupUrl contains <taskId>` narrowed by an exact URL-segment check, because `contains` alone also matches a longer id this one is a prefix of.

## Known limits, stated rather than implied

- **An entry must store the full ClickUp URL.** `createBugInput.clickupUrl` is `z.url()`, so a bare task id cannot be saved through the moderator UI or the skill. The parser tolerates one, but no current path can produce it. Worth knowing when telling support "put the task id on the entry".
- **An entry linked by ClickUp *custom* id (`DEV-1234`) will not match**, because deliveries carry the internal id. Resolving that needs an API lookup; out of scope here, and `check-known-issues-sync.mjs` still catches it.
- **A task moving back *out* of done does not reopen the entry.** Not asked for; reopening a public entry automatically is a bigger decision than closing one.
- **`pnpm run typecheck` covers neither `scripts/` nor `apps/`.** Everything here is under `src/`, so it is genuinely covered — noting the boundary rather than implying more.

## Verification

`typecheck` 0 errors. Full unit suite 18407 passing, my two files collecting 7 + 13; `blocks.router.workflow.test.ts` collected 350 (submodule present, so the run means what it says). The 3 remaining failures are pre-existing Windows-only path guards (`components\Apps\…` vs `/`, and an `ENOENT` on a doubled `C:\C:\` drive) in files this PR does not touch.

Every guard was mutation-tested — each fails naming the wrong value, not by timing out:

| Mutation | Failure |
|---|---|
| exact-segment check removed | `expected [ 52 ] to deeply equal []` |
| idempotence guard removed | `expected [ { id: 63, …(1) } ] to deeply equal []` |
| status-type authority removed | `expected 'Resolved' to be null` |
| signature verification disabled | `expected 200 to be 401` (×2) |
| 5xx split reverted to 4xx | `expected 400 to be 500` |
| body cap removed | `expected 400 to be 413` |
| writer re-check removed | `expected [] to deeply equal [ { id: 41, … } ]` |
| strict `after` union restored | `expected false to be true` |

The second commit is the fix round from an adversarial review of the first; its message records what each finding would have cost in production.

## To deploy

Create the webhook in ClickUp against the synced team list for `taskStatusUpdated`, pointed at `/api/webhooks/clickup`, and set `CLICKUP_WEBHOOK_SECRET` to the signing secret ClickUp returns. Placeholder is in `.env-example`; nothing secret is committed. Until that var is set the endpoint serves 503 and the board behaves exactly as it does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
