### PR TITLE
feat(placement): tell a sticker placer when their placement is accepted

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260818220000_placement_resolved_notification_index/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260818220000_placement_resolved_notification_index/migration.sql
@@ -14,6 +14,23 @@
 -- and a cancelled build leaves an INVALID index behind that will not be used and
 -- must be dropped before retrying —
 --   SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+--
+-- IF NOT EXISTS matches on the NAME, so if that invalid index is still there this
+-- statement reports success and creates nothing. Drop it first (DROP INDEX
+-- CONCURRENTLY); a clean re-run is the only way this file is idempotent. The
+-- planner ignores an invalid index while every write still maintains it, so the
+-- state costs writes and buys nothing.
+--
+-- Measured on this table 2026-08-14: a concurrent build takes ~33s, and the
+-- postgres-query skill defaults to a 30s timeout. So applying this through that
+-- skill without an explicit --timeout is cancelled BY ARITHMETIC, not by bad luck,
+-- and lands in exactly the state above on the first attempt. Pass a timeout well
+-- above 33s.
+--
+-- Verify against the PRIMARY, not a replica, and by the flag rather than by the
+-- exit code -- a sibling migration having been applied is not evidence this one
+-- was:
+--   SELECT indisvalid FROM pg_index WHERE indexrelid = '"Placement_resolvedAt_approved_idx"'::regclass;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "Placement_resolvedAt_approved_idx"
   ON "Placement" ("resolvedAt")
   WHERE "targetType" = 'image' AND status = 'approved';

--- a/packages/civitai-db-schema/prisma/migrations/20260818220000_placement_resolved_notification_index/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260818220000_placement_resolved_notification_index/migration.sql
@@ -1,0 +1,19 @@
+-- The resolved-placement notification processors read this table once a minute,
+-- and nothing serves them. `Placement_resolvedAt_idx` looks like it should: it is
+-- keyed on "resolvedAt" and its predicate includes both `targetType = 'image'`
+-- and the status, but it is ALSO predicated on `metricCountedAt IS NULL`, which
+-- the notification query does not supply and must not — the metric sweep stamps
+-- that column on its own schedule, so adding it here would silently drop the
+-- notification for every placement the sweep reached first.
+--
+-- Without this, each run falls back to a scan over every approved placement ever
+-- made, which grows monotonically and is read 1,440 times a day.
+--
+-- CONCURRENTLY, so it cannot lock out placement writes while it builds. Two
+-- consequences when running it by hand: it must NOT be wrapped in a transaction,
+-- and a cancelled build leaves an INVALID index behind that will not be used and
+-- must be dropped before retrying —
+--   SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Placement_resolvedAt_approved_idx"
+  ON "Placement" ("resolvedAt")
+  WHERE "targetType" = 'image' AND status = 'approved';

--- a/src/server/notifications/__tests__/notification-settings-polarity.test.ts
+++ b/src/server/notifications/__tests__/notification-settings-polarity.test.ts
@@ -27,6 +27,18 @@ const queryFor = async (type: string) => {
 };
 
 const OPT_OUT_CLAUSE = 'NOT EXISTS (SELECT 1 FROM "UserNotificationSettings"';
+
+/**
+ * Types that render a toggle and ignore it, left as they are.
+ *
+ * `cosmetic-shop-item-sold` is a pre-existing defect this guard found, not one
+ * introduced with it: it draws a checkbox under System and its query never reads
+ * the settings table, so the switch has never done anything. Left alone because
+ * fixing it silences an earnings notification for whoever already tried to mute
+ * it, which is a product decision on someone else's surface rather than part of
+ * the placement work that added this check.
+ */
+const KNOWN_INERT = ['cosmetic-shop-item-sold'];
 /** A LEFT JOIN would satisfy a bare `JOIN` substring test while restricting nothing. */
 const DERIVES_RECIPIENTS = /(?<!LEFT )(?<!LEFT OUTER )JOIN "UserNotificationSettings"/;
 
@@ -58,6 +70,44 @@ describe('notification settings polarity', () => {
         );
       }
     }
+  });
+
+  /**
+   * The test above branches on the query MENTIONING the table, so a processor
+   * that omits the clause entirely matches neither arm and passes vacuously.
+   * That is how `remix-gallery-resolved` shipped unmuteable: it rendered a
+   * checkbox, saved the row, and kept sending, because nothing on this path
+   * filters recipients centrally — `createNotificationsBulk` does no settings
+   * lookup at all, unlike the event path's `create.ts`.
+   *
+   * Scoped to types that RENDER a toggle. A processor with `toggleable: false`
+   * is entitled to ignore the table; one that draws a checkbox is not.
+   */
+  it('a rendered toggle is never inert', async () => {
+    const inert: string[] = [];
+    for (const type of notificationTypes) {
+      const query = await queryFor(type);
+      // No query means the event path, where create.ts applies the filter.
+      if (!query) continue;
+      if (!query.includes(OPT_OUT_CLAUSE)) inert.push(type);
+    }
+
+    // Joined rather than compared as an array: vitest truncates a long array in
+    // the failure line, and the whole value of this guard is naming every type
+    // that is inert rather than the first one or two.
+    //
+    // Pinned to the exact known set rather than allowed to grow, so this fails
+    // in both directions — a new inert type appears, or a listed one is fixed
+    // and must be struck off here.
+    expect(inert.join(', ')).toBe(KNOWN_INERT.join(', '));
+  });
+
+  it('that check is capable of failing', () => {
+    // Guards the loop above from passing because the predicate is unsatisfiable
+    // — the shape it must reject, which is what the real defect looked like.
+    const clauseless = `SELECT 'x' "key", u.id "userId" FROM "User" u`;
+
+    expect(clauseless.includes(OPT_OUT_CLAUSE)).toBe(false);
   });
 
   it('actually reaches the async processors', async () => {

--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { placementNotifications } from '~/server/notifications/placement.notifications';
+
+/**
+ * What a placer is told once someone acts on their placement.
+ *
+ * Approval only, on both surfaces, plus the owner-removal the remix type
+ * already had. These assert the SQL as text — the queries are built as strings
+ * and never parsed in a unit run — so what they can catch is the scope of each
+ * processor, which is exactly what changed here and exactly what is invisible
+ * in production when it is wrong.
+ */
+type Def = (typeof placementNotifications)['sticker-placement-pending'];
+const defs = placementNotifications as Record<string, Def>;
+
+const LAST_SENT = '2026-08-16 00:00:00';
+const query = async (type: string) =>
+  (await defs[type].prepareQuery!({
+    lastSent: LAST_SENT,
+    lastSentDate: new Date(0),
+    clickhouse: undefined,
+  })) as string;
+
+/**
+ * Every placement status the query can select, read back out of the SQL.
+ *
+ * A set comparison rather than a pair of contains/not-contains assertions: it
+ * fails with both sides printed, so putting `declined` back reads as
+ * `'approved,declined' to be 'approved'` rather than as an anonymous false. It
+ * also cannot pass by the processor having stopped selecting anything at all —
+ * an empty set fails against a non-empty expectation, which is the failure mode
+ * a bare "declined is absent" assertion would sail through.
+ *
+ * Comments are stripped first: these queries carry a lot of prose, and a status
+ * named in one would otherwise read as a status selected.
+ */
+const statusesSelectedBy = (sql: string) =>
+  [
+    ...new Set(
+      [
+        ...sql.replace(/--[^\n]*/g, '').matchAll(/'(pending|approved|declined|expired|removed)'/g),
+      ].map((m) => m[1])
+    ),
+  ]
+    .sort()
+    .join(',');
+
+describe('the sticker placer hears about an acceptance', () => {
+  it('is registered, toggleable, and not opt-in', () => {
+    const def = defs['sticker-placement-resolved'];
+
+    expect(def).toBeTruthy();
+    expect(def.category).toBe('Creator');
+    // `optIn` inverts what a settings row MEANS, and may only be set by a
+    // processor that derives recipients by joining that table. This one excludes
+    // with NOT EXISTS, so opting in here would ship it on while the UI drew it off.
+    expect(def.optIn).toBeUndefined();
+  });
+
+  it('names the owner and links to the image', () => {
+    const message = defs['sticker-placement-resolved'].prepareMessage({
+      type: 'sticker-placement-resolved',
+      details: { imageId: 74, ownerUsername: 'somebody', status: 'approved' },
+    } as Parameters<Def['prepareMessage']>[0])!;
+
+    expect(message.message).toBe('somebody accepted your sticker');
+    expect(message.url).toBe('/images/74');
+  });
+
+  it('selects approvals and nothing else', async () => {
+    expect(statusesSelectedBy(await query('sticker-placement-resolved'))).toBe('approved');
+  });
+
+  it('reads the moment the owner acted, not the moment the placement was made', async () => {
+    const sql = await query('sticker-placement-resolved');
+
+    // A placement made before the last run and accepted after it is missed
+    // entirely by a createdAt window — the failure is a notification that never
+    // arrives for exactly the placements that waited longest.
+    expect(sql).toContain('p."resolvedAt" > \'2026-08-16 00:00:00\'');
+    expect(sql).not.toContain('p."createdAt" >');
+  });
+
+  it('carries the status in the dedupe key', async () => {
+    // Keying on the id alone means a later branch — a removal, say — collides
+    // with the approval's key and is deduped away in silence.
+    expect(await query('sticker-placement-resolved')).toContain(
+      'CONCAT(\'sticker-placement-resolved:\',"status",\':\',"placementId")'
+    );
+  });
+
+  it('covers free placements as well as paid', async () => {
+    // The pending pair splits on `free` because their messages quote an amount.
+    // This one names none, so one type serves both — and a `free` clause here
+    // would silence exactly the tier that ships at daily volume.
+    expect(await query('sticker-placement-resolved')).not.toMatch(/p\.free/);
+  });
+});
+
+describe('the remix type stops announcing declines', () => {
+  /**
+   * Both halves in one run, deliberately. "Declines produce nothing" also passes
+   * when the processor produces nothing at all, so the approval assertion beside
+   * it is what makes this legible on revert rather than merely green.
+   */
+  it('selects approvals and owner-removals, not declines', async () => {
+    const sql = await query('remix-gallery-resolved');
+
+    expect(statusesSelectedBy(sql)).toBe('approved,removed');
+    // The removal half is scoped to the owner's own action: a moderator takedown
+    // is not something to announce to the person it was taken from.
+    expect(sql).toContain('p."removedBy" = \'owner\'');
+  });
+
+  it('still renders a decline that was already delivered', () => {
+    // The message is built at READ time from stored details, so the rows sent
+    // before this change would blank out if the branch were deleted with the
+    // query clause.
+    const message = defs['remix-gallery-resolved'].prepareMessage({
+      type: 'remix-gallery-resolved',
+      details: { imageId: 7, ownerUsername: 'somebody', status: 'declined' },
+    } as Parameters<Def['prepareMessage']>[0])!;
+
+    expect(message.message).toBe('somebody declined your remix submission');
+  });
+});
+
+describe('both resolved types honour their own setting', () => {
+  // There is no global opt-out filter on this path — createNotificationsBulk
+  // does no settings lookup — so a processor that omits this clause cannot be
+  // muted at all, however its toggle renders.
+  it.each(['sticker-placement-resolved', 'remix-gallery-resolved'])('%s', async (type) => {
+    expect(await query(type)).toContain(
+      `WHERE NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = data."userId" AND type = '${type}')`
+    );
+  });
+});

--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -57,7 +57,28 @@ describe('the sticker placer hears about an acceptance', () => {
     expect(def.optIn).toBeUndefined();
   });
 
-  it('names the owner and links to the image', () => {
+  it('goes to the placer, not to the owner who just accepted it', async () => {
+    const sql = await query('sticker-placement-resolved');
+
+    // The whole point of the type. Selecting `ownerId` here sends the creator
+    // who clicked Accept a message naming themselves, and sends the placer —
+    // the only person this exists for — nothing at all. Both directions
+    // asserted: the recipient is the placer AND is not the owner.
+    expect(sql).toMatch(/p\."placerId"\s+"userId"/);
+    expect(sql).not.toMatch(/p\."ownerId"\s+"userId"/);
+  });
+
+  it('reads the sticker surface', async () => {
+    // The likeliest mistake in a processor written beside three others: every
+    // other assertion here passes with `remixGallery` in this clause, which
+    // would announce remix approvals as stickers and stickers not at all.
+    const sql = await query('sticker-placement-resolved');
+
+    expect(sql).toContain("p.surface = 'sticker'");
+    expect(sql).not.toContain("p.surface = 'remixGallery'");
+  });
+
+  it('names the owner and links to the image', async () => {
     const message = defs['sticker-placement-resolved'].prepareMessage({
       type: 'sticker-placement-resolved',
       details: { imageId: 74, ownerUsername: 'somebody', status: 'approved' },
@@ -65,6 +86,10 @@ describe('the sticker placer hears about an acceptance', () => {
 
     expect(message.message).toBe('somebody accepted your sticker');
     expect(message.url).toBe('/images/74');
+    // The message test hand-builds its details, so it cannot see where imageId
+    // comes from. Sourcing it from `p.id` instead links every notification to
+    // /images/<placementId> — a dead link, and one nothing above would catch.
+    expect(await query('sticker-placement-resolved')).toContain('\'imageId\', p."targetId"');
   });
 
   it('selects approvals and nothing else', async () => {
@@ -93,7 +118,13 @@ describe('the sticker placer hears about an acceptance', () => {
     // The pending pair splits on `free` because their messages quote an amount.
     // This one names none, so one type serves both — and a `free` clause here
     // would silence exactly the tier that ships at daily volume.
-    expect(await query('sticker-placement-resolved')).not.toMatch(/p\.free/);
+    //
+    // Matched as a word rather than as `p.free`, which the quoted spelling
+    // `p."free"` walks straight past. Comments are stripped first because the
+    // one above this clause says the word.
+    const sql = (await query('sticker-placement-resolved')).replace(/--[^\n]*/g, '');
+
+    expect(sql).not.toMatch(/\bfree\b/i);
   });
 });
 
@@ -110,6 +141,10 @@ describe('the remix type stops announcing declines', () => {
     // The removal half is scoped to the owner's own action: a moderator takedown
     // is not something to announce to the person it was taken from.
     expect(sql).toContain('p."removedBy" = \'owner\'');
+    // Same two mutations the sticker type is guarded against, and they survive
+    // every assertion above on this one too.
+    expect(sql).toMatch(/p\."placerId"\s+"userId"/);
+    expect(sql).toContain("p.surface = 'remixGallery'");
   });
 
   it('still renders a decline that was already delivered', () => {

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -250,12 +250,16 @@ export const placementNotifications = createNotificationProcessor({
    * The submitter's side of the same decision. They paid and then waited, and
    * without this the only signal that anything happened is their Buzz balance.
    *
-   * Approve and decline share one type so the two cannot disagree about what
-   * counts as resolved — the message branches on the stored status instead.
+   * Announces an outcome the submitter benefits from hearing and stays silent on
+   * the ones they don't: approval, and an owner removing an entry that was
+   * already live in their gallery. A decline is deliberately not announced —
+   * Justin's call, 2026-08-18 — on the grounds that "X declined you" mostly buys
+   * the placer a grudge against a creator who is entitled to say no. The
+   * placements page still shows it.
    *
-   * Deliberately excludes `expired`: nobody decided anything, the refund is
-   * full, and telling someone their submission was rejected when the owner
-   * simply never looked is both wrong and worse.
+   * Also excludes `expired`, for a different reason: nobody decided anything and
+   * the refund is full, so any message here would describe a decision that was
+   * never made.
    */
   'remix-gallery-resolved': {
     displayName: 'Your remix submission was answered',
@@ -273,6 +277,10 @@ export const placementNotifications = createNotificationProcessor({
           message: `${details.ownerUsername} removed your remix from their gallery`,
           url,
         };
+      // Unreachable for anything sent from now on -- the query stopped selecting
+      // declines. Kept because the message is rendered at READ time from the
+      // stored details, so deleting this branch would blank the notifications
+      // already delivered to people who were declined before that changed.
       return { message: `${details.ownerUsername} declined your remix submission`, url };
     },
     prepareQuery: async ({ lastSent }) => `
@@ -304,7 +312,7 @@ export const placementNotifications = createNotificationProcessor({
           -- approval trail.
           AND (
             (
-              p.status IN ('approved', 'declined')
+              p.status = 'approved'
               AND p."resolvedAt" IS NOT NULL
               AND p."resolvedAt" > '${lastSent}'
             )
@@ -326,6 +334,75 @@ export const placementNotifications = createNotificationProcessor({
         'remix-gallery-resolved' "type",
         details
       FROM data
+      -- A row means opted OUT. This type shipped without the clause, so its
+      -- toggle rendered, saved, and changed nothing -- there is no global filter
+      -- on this path (createNotificationsBulk does no settings lookup), so a
+      -- processor that omits it is unmuteable. Kept on one line because the
+      -- polarity guard matches the clause as a literal.
+      WHERE NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = data."userId" AND type = 'remix-gallery-resolved')
+    `,
+  },
+
+  /**
+   * The sticker placer's side, and the gap Ellie reported: a placement could be
+   * accepted and the only signal was the placer's Buzz balance moving.
+   *
+   * Approval only — Justin's call, 2026-08-18. No decline, no expiry, no
+   * removal of any kind. The asymmetry with the remix type, which also announces
+   * an owner removal, is deliberate: a remix that is removed was already live in
+   * someone's gallery, where a declined sticker never appeared anywhere.
+   *
+   * Covers free placements as well as paid, unlike the pending pair, which split
+   * because their messages quote an amount and a free row's is 0. This one names
+   * no amount, so one type serves both and a creator muting it mutes both.
+   *
+   * An `auto` space approves at the call site, so its placer gets this seconds
+   * after placing, confirming something they watched happen. Left that way on
+   * purpose: no column distinguishes an auto approval from a fast one, and the
+   * only discriminator available -- the gap between `createdAt` and
+   * `resolvedAt` -- would be a rule we invented and would have to keep true.
+   */
+  'sticker-placement-resolved': {
+    displayName: 'Your sticker placement was accepted',
+    category: NotificationCategory.Creator,
+    prepareMessage: ({ details }) => ({
+      message: `${details.ownerUsername} accepted your sticker`,
+      url: `/images/${details.imageId}`,
+    }),
+    prepareQuery: async ({ lastSent }) => `
+      WITH data AS (
+        SELECT
+          p."placerId" "userId",
+          p.id "placementId",
+          p.status "status",
+          jsonb_build_object(
+            'placementId', p.id,
+            'imageId', p."targetId",
+            'ownerId', p."ownerId",
+            'ownerUsername', u.username,
+            'status', p.status
+          ) as "details"
+        FROM "Placement" p
+        JOIN "User" u ON u.id = p."ownerId"
+        WHERE p.surface = 'sticker'
+          AND p."targetType" = 'image'
+          AND p.status = 'approved'
+          -- Keyed off when the owner acted, never off createdAt: a placement
+          -- made before the last run and accepted after it would be missed
+          -- entirely by a createdAt window.
+          AND p."resolvedAt" IS NOT NULL
+          AND p."resolvedAt" > '${lastSent}'
+      )
+      SELECT
+        -- The status is in the key even though only one status can reach here.
+        -- It costs nothing now and is what stops a later branch -- a removal,
+        -- say -- from being deduped away silently against the approval's key.
+        CONCAT('sticker-placement-resolved:',"status",':',"placementId") "key",
+        "userId",
+        'sticker-placement-resolved' "type",
+        details
+      FROM data
+      WHERE NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = data."userId" AND type = 'sticker-placement-resolved')
     `,
   },
 });


### PR DESCRIPTION
Ellie reported that stickers send no notification when they are accepted. They don't, and the audit behind this PR found the gap is wider than that: **the sticker surface notifies the placer about nothing at all** — not approval, not decline, not removal. Remixes do. The two surfaces simply diverged, because `remix-gallery-resolved` was written and a sticker equivalent never was.

ClickUp: https://app.clickup.com/t/868ktuz2z (the report) and https://app.clickup.com/t/868ktv3cn (the toggle bug, filed separately so it isn't hostage to a product question).

## What the audit measured, before changing anything

Prod, at the time of the audit:

| type | deliveries | distinct users | last sent |
|---|---|---|---|
| `sticker-placement-pending` | 27 | 12 | 2026-08-18 21:23 UTC |
| `remix-gallery-pending` | 3 | 2 | 2026-08-14 06:49 |
| `remix-gallery-resolved` | 2 | 2 | 2026-08-12 17:45 |

That third row is the important one: a **resolved-side** notification demonstrably fires in this exact domain. So "stickers notify nobody on acceptance" is an absence measured against a working reference, not a guess about a path that might be dead.

Against that, 30 `Placement` rows exist in total — 14 of them sticker/approved. Fourteen accepted placements, zero messages.

## What this changes

**1. New `sticker-placement-resolved` — approvals only.**

Justin's call (2026-08-18), asked directly: *"Approve only."* So no decline, no expiry, no removal of any kind. The reasoning he was choosing between is worth recording: announcing a decline mostly buys the placer a grudge against a creator who is entitled to say no, and the placements page already shows the outcome to anyone who looks.

It covers **free and paid** in one type, unlike the pending pair which split because their messages quote an amount and a free row's amount is 0. This message names no amount, so one type serves both — and given free sticker placements ship at one per user per day, a `free` clause here would have silenced the tier with all the volume.

**2. `remix-gallery-resolved` stops announcing declines.**

Also Justin's, asked as a follow-up because his first answer did not settle it: *"Yes, let's also remove the decline from remixes as well."*

It **keeps** approved and owner-removal. That asymmetry with the sticker type is deliberate, not an oversight: he answered a question about *declines*, and the removal message concerns a remix that was already live in someone's gallery — content disappearing is a different event from an application being turned down. If he wants that gone too it is a one-line follow-up.

⚠️ **This removes a live behaviour.** A remix placer declined before this deploys gets the old message; after it, nothing. No migration is involved — the processor simply stops selecting those rows, and nothing already delivered is touched. A gap in the notification log starting at this deploy is this change, not a bug.

The `declined` branch of `prepareMessage` stays. Messages are rendered at **read** time from stored details, so deleting it would blank out the notifications already sitting in the inboxes of people who were declined last week.

**3. `remix-gallery-resolved` was unmuteable. Now it isn't.**

Its query had no `NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" …)` clause. There is no global opt-out filter on this path — `createNotificationsBulk` in `apps/notifications` does no settings lookup at all, unlike the event path's `create.ts` — so a processor that omits the clause cannot be muted by anyone, however its toggle renders. It drew a checkbox, saved the row, and kept sending.

**4. The polarity guard couldn't have caught that, and now can.**

`notification-settings-polarity.test.ts` branched on the query *mentioning* the settings table. A processor with no clause at all matched neither arm and passed vacuously. The new check — "a rendered toggle is never inert" — is scoped to types that actually render a checkbox, since `toggleable: false` is entitled to ignore the table.

**It was verified by watching it fail.** Run against the unmodified file, it reports:

```
AssertionError: expected 'remix-gallery-resolved, cosmetic-shop…' to be 'cosmetic-shop-item-sold'
```

**It also found a second one.** `cosmetic-shop-item-sold` renders a checkbox under System and its query never reads the settings table either — a pre-existing defect on someone else's surface, not introduced here. It is pinned in `KNOWN_INERT` rather than fixed, because fixing it silences an earnings notification for whoever already tried to mute it, and that is a product decision for the shop owner to make. The pin is exact-match, so the guard fails both if a new inert type appears *and* if this one is fixed without striking it off the list.

## Tests

`placement-resolved-notification.test.ts`, plus the guard above.

The status assertions compare a **set of statuses extracted from the SQL** rather than asserting "declined is absent". Putting the decline back fails as:

```
AssertionError: expected 'approved,declined,removed' to be 'approved,removed'
```

— verified by actually doing it. That shape matters because a bare "declined produces nothing" assertion also passes when the processor produces nothing at all; pinning the approvals in the same test means a wholly broken processor cannot masquerade as the intended change.

## One judgement call to know about

An `auto`-mode space approves at the call site, so its placer receives "accepted your sticker" seconds after placing — confirming something they watched happen. Left that way deliberately: no column distinguishes an auto approval from a fast manual one, and the only available discriminator, the gap between `createdAt` and `resolvedAt`, would be a rule we invented and would then have to keep true forever. Easy to revisit if it reads as noise once free placements are live.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint`
- `pnpm run test:unit:run`
- `src/server/notifications/__tests__/` — 212 passing
- Guard proven to fail on the pre-fix file; decline-removal proven to fail on revert
