### PR TITLE
fix(models): make the file dropzone selectable on iOS

### DIFF
--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -180,8 +180,10 @@ export function Files({ showRenameOnPrimary }: { showRenameOnPrimary?: boolean }
     onDrop(droppedFiles, defaultType, skipInference);
   };
 
-  const primaryAccept = { 'mime/type': primary.extensions };
-  const additionalAccept = { 'mime/type': additional.extensions };
+  // iOS resolves `accept` entries to UTIs with no extension fallback, so a bare
+  // `.safetensors` greys out every file in the picker; octet-stream maps to `public.data`.
+  const primaryAccept = { 'application/octet-stream': primary.extensions };
+  const additionalAccept = { 'application/octet-stream': additional.extensions };
   const makeRejectHandler =
     (section: 'primary' | 'additional') => (rejectedFiles: FileRejection[]) => {
       const sectionConfig = section === 'primary' ? primary : additional;

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -225,6 +225,31 @@ export function Files({ showRenameOnPrimary }: { showRenameOnPrimary?: boolean }
   const handleRejectPrimary = makeRejectHandler('primary');
   const handleRejectAdditional = makeRejectHandler('additional');
 
+  // `application/octet-stream` is what makes the picker usable on iOS, but it also matches
+  // any file the OS reports as octet-stream, whatever its extension. react-dropzone's
+  // attr-accept is the only other client-side type check and the upload API only screens
+  // against a denylist, so re-check the extension here before anything reaches onDrop.
+  const withExtensionGuard =
+    (section: 'primary' | 'additional', handle: (files: File[]) => void) =>
+    (droppedFiles: File[]) => {
+      const { extensions } = section === 'primary' ? primary : additional;
+      const accepted = droppedFiles.filter((file) =>
+        extensions.includes(`.${getFileExtension(file.name).toLowerCase()}`)
+      );
+      const rejected = droppedFiles.filter((file) => !accepted.includes(file));
+
+      if (rejected.length)
+        makeRejectHandler(section)(
+          rejected.map((file) => ({
+            file,
+            errors: [
+              { code: 'file-invalid-type', message: `${file.name} has an unsupported type` },
+            ],
+          }))
+        );
+      if (accepted.length) handle(accepted);
+    };
+
   const handleLinkResource = (resource: GenerationResource) => {
     const componentType = modelTypeToComponentType(resource.model.type);
 
@@ -312,14 +337,14 @@ export function Files({ showRenameOnPrimary }: { showRenameOnPrimary?: boolean }
               ))}
               <InlineDropzone
                 label="Add another model file variant"
-                onDrop={(dropped) =>
+                onDrop={withExtensionGuard('primary', (dropped) =>
                   handleInlineDrop(
                     dropped,
                     modelFiles,
                     primary.maxFiles,
                     primaryTypes.length === 1 ? primaryTypes[0] : undefined
                   )
-                }
+                )}
                 accept={primaryAccept}
                 maxFiles={primary.maxFiles}
                 onReject={handleRejectPrimary}
@@ -328,12 +353,12 @@ export function Files({ showRenameOnPrimary }: { showRenameOnPrimary?: boolean }
           ) : (
             <Dropzone
               accept={primaryAccept}
-              onDrop={(droppedFiles) => {
+              onDrop={withExtensionGuard('primary', (droppedFiles) => {
                 if (modelFiles.length + droppedFiles.length > primary.maxFiles) return;
                 if (files.length + droppedFiles.length > totalMaxFiles) return;
                 const defaultType = primaryTypes.length === 1 ? primaryTypes[0] : undefined;
                 onDrop(droppedFiles, defaultType);
-              }}
+              })}
               maxFiles={primary.maxFiles}
               onReject={handleRejectPrimary}
               className={classes.dropzone}
@@ -411,7 +436,7 @@ export function Files({ showRenameOnPrimary }: { showRenameOnPrimary?: boolean }
           <InlineDropzone
             label="Upload a component file"
             description={`Supports ${additional.extensions.join(', ')} files`}
-            onDrop={(dropped) =>
+            onDrop={withExtensionGuard('additional', (dropped) =>
               handleInlineDrop(
                 dropped,
                 additionalFiles,
@@ -419,7 +444,7 @@ export function Files({ showRenameOnPrimary }: { showRenameOnPrimary?: boolean }
                 additionalFileTypes.length === 1 ? additionalFileTypes[0] : undefined,
                 true
               )
-            }
+            )}
             accept={additionalAccept}
             maxFiles={additional.maxFiles}
             onReject={handleRejectAdditional}


### PR DESCRIPTION
Fixes the iOS model-file upload block reported in [CU-868kt75xj](https://app.clickup.com/t/8459928/868kt75xj).

Creators on iPhone/iPad cannot upload a model file at all — the iOS Files picker greys out every file, so the upload never starts. There is no in-product workaround. The reporting creator has been making a separate model page per version for two months to get around it, which fragments his downloads, ratings and stats.

## The bug

`src/components/Resource/Files.tsx` declared both dropzones' accept map with a placeholder MIME key that was never filled in:

```ts
const primaryAccept    = { 'mime/type': primary.extensions };
const additionalAccept = { 'mime/type': additional.extensions };
```

react-dropzone flattens that map into the input's `accept` attribute, and its `isMIMEType` guard is `/\w+\/[-+.\w]+/g.test(v)` — which **`'mime/type'` passes**. So the placeholder is not filtered out; the rendered attribute really is:

```
accept="mime/type,.ckpt,.pt,.safetensors,.sft,.bin,.gguf"
```

Desktop browsers match on the extension entries and are unaffected, which is why this survived since #1964 (2026-04-22). iOS resolves every accept entry to a UTI and does **not** fall back to extension matching — neither `mime/type` nor a bare `.safetensors` resolves to anything it knows, so the picker has no usable type to allow and greys out everything.

`useFsAccessApi={!isAndroidDevice()}` is a red herring here: `canUseFileSystemAccessAPI()` is `"showOpenFilePicker" in window`, which iOS Safari does not have, so iOS always takes the `<input type="file" accept=...>` path regardless.

## The fix

Use `application/octet-stream`, which maps to `public.data` — a UTI iOS understands. This matches `BountyEntryUpsertForm.tsx:55-69`, which already accepts the same extensions and declares them correctly.

Both dropzones are covered: these two values feed all three call sites (primary inline, primary empty-state, additional inline). `FilesEditModal` renders the same component, so it is fixed too. No `mime/type` remains anywhere in the repo.

Deliberately **not** adding an `isIosDevice` helper — the one-key change fixes every platform at once, where a UA branch would be a second thing to keep correct.

## Desktop does not regress

Ran the real `attr-accept` matcher from the installed `react-dropzone-esm@15.2.0` against the old and new accept strings:

| file | OLD primary | NEW primary | NEW additional |
|---|---|---|---|
| `V1.safetensors` (type `""`) | accept | accept | accept |
| `model.ckpt` (type `""`) | accept | accept | accept |
| `weights.bin` (octet-stream) | accept | accept | accept |
| `notes.txt` (text/plain) | reject | reject | accept |
| `photo.jpg` (image/jpeg) | reject | reject | reject |
| `archive.zip` (application/zip) | reject | reject | accept |
| `setup.exe` (x-msdownload) | reject | reject | reject |
| `blob.iso` (octet-stream) | reject | **accept** | **accept** |

Every realistic case keeps its old verdict. A wrong file type still reaches `makeRejectHandler`, which is not a silent no-op — it calls `showErrorNotification`, which renders `error.message`, producing `This section accepts: .ckpt, .pt, .safetensors, .sft, .bin, .gguf.`

**Update — an extension guard was added in 7dd8fbf after review.** The accept key alone left a gap: a file whose OS-reported MIME is *exactly* `application/octet-stream` but whose extension is not listed (the `.iso` row) got past `attr-accept`. That gap was not inert, and my original description of it here was wrong in two ways, both caught by Copilot:

- I said such a file "lands in the list with no inferred type and `handleUpload` early-returns on `!type`". True only of the **primary** section (`inferFileType` returns `undefined` by default). The **additional** section uses `inferComponentFileType`, which falls through to `pick('Other') ?? allowedTypes[0]` and always returns a type — so the file proceeded into the upload flow.
- I said "server-side validation remains the real gate". Overstated. `src/pages/api/upload/index.ts:34` screens only against the `UPLOAD_PROHIBITED_EXTENSIONS` denylist, which is `.optional()` with no default — unset, the check short-circuits. There is no server-side allow-list.

There is likely an iOS-specific amplification too: iOS reports `application/octet-stream` for extensions with no registered UTI, which is exactly the mechanism that makes `.safetensors` selectable. If so, on iOS *every* unknown-extension file would clear `attr-accept` — the extension filter would be largely defeated on the platform this PR fixes. Reasoned, not observed; there is a device-test step for it below.

`withExtensionGuard(section, handle)` now re-checks each file's extension against its section's list before anything reaches `onDrop`, routing failures through the existing `makeRejectHandler` so the message and misplaced-file hint are unchanged. Applied at all three drop sites. With it:

| file | attr-accept | + guard | reaches onDrop |
|---|---|---|---|
| `V1.safetensors` / `V1.SAFETENSORS` | pass | pass | ✅ |
| `weights.bin` (octet-stream) | pass | pass | ✅ |
| `blob.iso` (octet-stream) | pass | **reject** | ❌ error shown |
| `sneaky.exe` (octet-stream) | pass | **reject** | ❌ error shown |
| `noextension` (octet-stream) | pass | **reject** | ❌ error shown |
| `ios-unknown.foo` (octet-stream) | pass | **reject** | ❌ error shown |

Filtering is now purely extension-based in both sections — exactly the pre-change behaviour — so **the PR is behaviour-preserving on desktop, with the iOS unblock as the only intended delta.**

To be clear about what this guard is: protection against *accidental* uploads and data hygiene, not a security boundary. The accept attribute never was one — renaming a file or calling the API directly bypasses it, and `.ckpt`/`.pt` are arbitrary pickle payloads regardless.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run test:unit:run` — 1170 files / 18447 tests passed, 0 failures
- `blocks.router.workflow.test.ts` collected 350 tests (not 0), confirming the worktree submodule is intact and the suite run is meaningful

**Not verified on a physical iOS device.** This PR exists so a preview environment can be deployed and tested from a real iPhone. The causal link is confirmed *in code* — the bad attribute provably reaches the input, and iOS provably uses that input — but the last hop (that UTI resolution is what greys the file, and that `public.data` un-greys it) has not been observed. Please do not merge on the strength of the reasoning alone.

### Device test script

On a real iPhone/iPad in **Safari**, against the preview:

1. Open a model you own → `+` add a version → **Upload files** step (`/models/{modelId}/model-versions/{versionId}/wizard?step=2`).
2. Tap the **Model Files** dropzone. Fixed = `.safetensors` in normal white text and tappable. Still broken = dimmed grey with a blank-page icon.
3. Repeat on **Additional Components** — separate accept value, separate call site.
4. Negative control: pick a `.jpg`. Expect a red "File not accepted" notification. If a `.jpg` is silently accepted, the extension gate is not doing its job and one key is not enough.
5. Rename any random file to something unlisted (e.g. `test.iso`) and try to pick it in **Additional Components**. Expect "File not accepted". If it is accepted, the guard is not firing. If it was *greyed out* in the picker rather than rejected after selection, that tells us iOS does not report octet-stream for unknown extensions and the amplification above does not apply — useful either way.
6. **Android** Chrome: same steps. Android also takes the `<input>` path, so it plausibly shared the bug and is fixed by the same change — neither half confirmed. Worth checking whether it was broken before, since that would widen the reported impact beyond iOS.

## No test added

Deliberate. A unit test asserting the accept map's shape would be close to tautological and — critically — **would not have caught this bug**, since `'mime/type'` passes react-dropzone's own `isMIMEType` check. The failure lives in how iOS resolves the attribute, which no runner in this repo can observe. A component test rendering `Files` would need the full `FilesProvider` + tRPC + Mantine harness to assert one attribute string, against CLAUDE.md's warning about mocks that drag in a transitive import graph. The guard that would actually work is a convention check that dropzone `accept` keys are *registered* MIME types rather than merely well-formed — a better fit for `test:lint-rules` as its own piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
