### PR TITLE
fix(apps): keep the listing Report action from re-arming after a report

### DIFF
--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -106,8 +106,17 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
       upsertReview: {
         useMutation: () => ({ mutate: mocks.upsertMutate, isPending: false }),
       },
+      // 🔴 This one INVOKES the caller's `onSuccess`, unlike its siblings. The thing
+      // under test below is what the detail page does AFTER a report lands (its menu
+      // item has to go spent), and a `mutate` that never resolves can never show it.
       reportListing: {
-        useMutation: () => ({ mutate: mocks.reportMutate, isPending: false }),
+        useMutation: (opts?: { onSuccess?: () => void }) => ({
+          mutate: (input: unknown) => {
+            mocks.reportMutate(input);
+            opts?.onSuccess?.();
+          },
+          isPending: false,
+        }),
       },
     },
     // The SmartCreatorCard's own fetch. 🔴 VERIFIED PUBLIC: `user.getCreator` is a
@@ -381,6 +390,55 @@ describe('AppListingDetailBody', () => {
     const item = dropdown.querySelector('[data-testid="apps-listing-report-action"]') as HTMLElement;
     await userEvent.click(item);
     await expect.element(page.getByRole('button', { name: 'Submit report' })).toBeInTheDocument();
+  });
+
+  test('🔴 REGRESSION: after a successful report the menu item is DISABLED and reads "Reported"', async () => {
+    // The shipped defect: the modal's `onReported` callback existed and was wired
+    // only in a standalone `ReportListingButton` that nothing rendered, while THIS —
+    // the live path — mounted the modal without it. The item stayed clickable, so a
+    // second report hit the server's one-open-report-per-reporter CONFLICT and the
+    // user got an ERROR where they expected a confirmation.
+    //
+    // 🔴 Asserted on the STATE, never on the word: `disabled` + Mantine's
+    // `data-disabled` on the item itself. "Reported" as text is checked too, but it
+    // is the weakest half of the claim — any feature can spell a word.
+    mocks.currentUser = { id: 999, username: 'bob' };
+    const { within } = await renderScoped(<AppListingDetailBody detail={base({})} />);
+
+    const item = () =>
+      document.querySelector(
+        '[data-testid="apps-listing-report-action"]'
+      ) as HTMLButtonElement | null;
+
+    // POSITIVE CONTROL, from the same element: it is LIVE before the report, so the
+    // disabled state below is about the report and not about how the item renders.
+    await openMenu(within);
+    const before = item() as HTMLButtonElement;
+    expect(before).not.toBeNull();
+    expect(before.disabled).toBe(false);
+    expect(before.getAttribute('data-disabled')).toBeNull();
+    expect(before.textContent).toContain('Report');
+    expect(before.textContent).not.toContain('Reported');
+
+    await userEvent.click(before);
+    await page.getByRole('radio', { name: 'Spam' }).click();
+    await page.getByRole('button', { name: 'Submit report' }).click();
+    expect(mocks.reportMutate).toHaveBeenCalledTimes(1);
+    expect(mocks.reportMutate.mock.calls[0][0]).toMatchObject({
+      appListingId: 'l1',
+      reason: 'spam',
+    });
+
+    // Re-open the menu (the dropdown UNMOUNTS on close, so this is a fresh element).
+    await openMenu(within);
+    await vi.waitFor(() => {
+      const spent = item();
+      expect(spent).not.toBeNull();
+      expect((spent as HTMLButtonElement).disabled).toBe(true);
+    });
+    const spent = item() as HTMLButtonElement;
+    expect(spent.getAttribute('data-disabled')).toBe('true');
+    expect(spent.textContent).toContain('Reported');
   });
 
   // ── Header stat chips ──────────────────────────────────────────────────────

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -212,7 +212,12 @@ function base(over: Partial<ListingDetail>): ListingDetail {
     installCount: 4213,
     updatedAt: '2026-03-04T05:06:07.000Z',
     screenshots: [],
-    kindData: { kind: 'onsite', appBlockId: 'blk-1', hasPage: true, liveUrl: 'https://my-app.civit.ai' },
+    kindData: {
+      kind: 'onsite',
+      appBlockId: 'blk-1',
+      hasPage: true,
+      liveUrl: 'https://my-app.civit.ai',
+    },
     ...over,
   };
 }
@@ -376,18 +381,24 @@ describe('AppListingDetailBody', () => {
     mocks.currentUser = { id: 999, username: 'bob' };
     const { within } = await renderScoped(<AppListingDetailBody detail={base({})} />);
     const dropdown = (await openMenu(within)) as HTMLElement;
-    const item = dropdown.querySelector('[data-testid="apps-listing-review-action"]') as HTMLElement;
+    const item = dropdown.querySelector(
+      '[data-testid="apps-listing-review-action"]'
+    ) as HTMLElement;
     expect(item).not.toBeNull();
     await userEvent.click(item);
     // The modal is portalled to the body. Its own copy is the REAL component.
-    await expect.element(page.getByText('Would you recommend this app to others?')).toBeInTheDocument();
+    await expect
+      .element(page.getByText('Would you recommend this app to others?'))
+      .toBeInTheDocument();
   });
 
   test('🔴 the Report menu item opens the report modal', async () => {
     mocks.currentUser = { id: 999, username: 'bob' };
     const { within } = await renderScoped(<AppListingDetailBody detail={base({})} />);
     const dropdown = (await openMenu(within)) as HTMLElement;
-    const item = dropdown.querySelector('[data-testid="apps-listing-report-action"]') as HTMLElement;
+    const item = dropdown.querySelector(
+      '[data-testid="apps-listing-report-action"]'
+    ) as HTMLElement;
     await userEvent.click(item);
     await expect.element(page.getByRole('button', { name: 'Submit report' })).toBeInTheDocument();
   });
@@ -517,7 +528,9 @@ describe('AppListingDetailBody', () => {
     await expect.element(within.getByText('My App')).toBeInTheDocument();
 
     const cols = Array.from(
-      container.querySelectorAll('[data-testid="apps-listing-main-col"], [data-testid="apps-listing-rail-col"]')
+      container.querySelectorAll(
+        '[data-testid="apps-listing-main-col"], [data-testid="apps-listing-rail-col"]'
+      )
     );
     expect(cols).toHaveLength(2);
     // 🔴 RAIL FIRST, MAIN SECOND — the same source order `ModelVersionDetails` uses,
@@ -547,7 +560,9 @@ describe('AppListingDetailBody', () => {
     expect(container.querySelectorAll('[data-testid="apps-listing-rail-col"]')).toHaveLength(1);
     // …and the rail's contents came with it, rather than being dropped on mobile.
     expect(container.querySelectorAll('[data-testid="apps-listing-action-card"]')).toHaveLength(1);
-    expect(container.querySelectorAll('[data-testid="apps-listing-details-accordion"]')).toHaveLength(1);
+    expect(
+      container.querySelectorAll('[data-testid="apps-listing-details-accordion"]')
+    ).toHaveLength(1);
   });
 
   test('🔴 the rail holds the action card, the creator card and the details accordion; the main column holds About', async () => {
@@ -719,7 +734,10 @@ describe('AppListingDetailBody', () => {
         testid === 'apps-listing-stat-chips'
           ? live.container.querySelectorAll('[data-listing-stat]').length
           : live.container.querySelectorAll(`[data-testid="${testid}"]`).length;
-      expect(liveCount, `positive control: ${what} must be findable in the live arm`).toBeGreaterThan(0);
+      expect(
+        liveCount,
+        `positive control: ${what} must be findable in the live arm`
+      ).toBeGreaterThan(0);
 
       // …and now the preview arm. `canOpenPage` stays TRUE so the ONLY thing
       // suppressing anything is `preview`.
@@ -748,10 +766,12 @@ describe('AppListingDetailBody', () => {
     const prev = await renderScoped(
       <AppListingDetailBody detail={base({ contentRating: 'PG' })} preview />
     );
-    await expect.element(prev.within.getByTestId('apps-listing-details-accordion')).toBeInTheDocument();
-    const rows = Array.from(
-      prev.container.querySelectorAll('[data-listing-detail-row]')
-    ).map((r) => r.getAttribute('data-listing-detail-row'));
+    await expect
+      .element(prev.within.getByTestId('apps-listing-details-accordion'))
+      .toBeInTheDocument();
+    const rows = Array.from(prev.container.querySelectorAll('[data-listing-detail-row]')).map((r) =>
+      r.getAttribute('data-listing-detail-row')
+    );
     // Control: the live arm has 6 rows including `reviews` (asserted above).
     expect(rows).toEqual(['kind', 'category', 'rating', 'installs', 'updated']);
   });
@@ -1087,8 +1107,9 @@ describe('AppListingDetailBody', () => {
     // Two related cards, not three — self was dropped.
     expect(container.querySelectorAll('[data-testid="apps-related-grid-col"]')).toHaveLength(2);
     // No related card links back to this very listing.
-    const hrefs = Array.from(container.querySelectorAll('[data-testid="apps-related-grid-col"]'))
-      .flatMap((col) => Array.from(col.querySelectorAll('a')).map((a) => a.getAttribute('href')));
+    const hrefs = Array.from(
+      container.querySelectorAll('[data-testid="apps-related-grid-col"]')
+    ).flatMap((col) => Array.from(col.querySelectorAll('a')).map((a) => a.getAttribute('href')));
     expect(hrefs).not.toContain('/apps/store-preview/my-app');
   });
 
@@ -1315,11 +1336,21 @@ describe('AppListingDetailBody — the public collaborator byline (anonymous vie
     );
     // The page itself rendered (so this zero is not "nothing rendered at all").
     await expect.element(within.getByText('My App')).toBeInTheDocument();
-    expect(container.querySelectorAll('[data-testid="apps-listing-collaborators"]')).toHaveLength(0);
+    expect(container.querySelectorAll('[data-testid="apps-listing-collaborators"]')).toHaveLength(
+      0
+    );
   });
 
   test('the byline is rendered alongside — not instead of — the creator card', async () => {
-    mocks.creator = { id: 5, username: 'alice', image: null, rank: null, links: [], cosmetics: [], stats: null };
+    mocks.creator = {
+      id: 5,
+      username: 'alice',
+      image: null,
+      rank: null,
+      links: [],
+      cosmetics: [],
+      stats: null,
+    };
     const { container, within } = await renderScoped(
       <AppListingDetailBody
         detail={base({ collaborators: [{ id: 42, username: 'bob', image: null }] })}

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -52,7 +52,11 @@ import { TruncatedText } from '~/components/Apps/AppListingTruncate';
 import { ListingCollaboratorByline } from '~/components/Apps/ListingCollaboratorByline';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { AppListingComments } from '~/components/Apps/AppListingComments';
-import { ReportListingModal, useCanReportListing } from '~/components/Apps/ReportListingButton';
+import {
+  ReportListingModal,
+  useCanReportListing,
+  useReportListingAffordance,
+} from '~/components/Apps/ReportListingModal';
 import { ReviewListingModal, useCanReviewListing } from '~/components/Apps/ReviewListingButton';
 import { AppListingReviews } from '~/components/Apps/AppListingReviews';
 import {
@@ -648,13 +652,22 @@ export function AppListingDetailBody({
   // 🔴 The review / report modals are owned HERE, not by their trigger. A Mantine
   // `Menu.Dropdown` is unmounted when the menu closes, so a modal rendered as a
   // sibling of its `Menu.Item` would be destroyed by the click that opens it. The
-  // gates are the SAME predicates the standalone buttons use (`useCanReviewListing`
-  // / `useCanReportListing`), imported rather than re-derived, so the menu cannot
+  // gates are the SAME predicates each affordance defines (`useCanReviewListing` /
+  // `useCanReportListing`), imported rather than re-derived, so the menu cannot
   // disagree with them about who may act.
+  //
+  // 🔴 The report affordance's STATE comes from `useReportListingAffordance` rather
+  // than a bare `useDisclosure` here, and that is the fix for a shipped defect: the
+  // server allows one open report per reporter, so once a report lands the trigger
+  // has to go spent ("Reported", disabled) or the next click returns a CONFLICT the
+  // user reads as a failure. That rule used to live in a standalone `ReportListingButton`
+  // nothing rendered, while this — the live path — mounted the modal with no
+  // `onReported` and kept its menu item live. Spread BOTH bags; do not hand-roll
+  // either half.
   const canReview = useCanReviewListing({ ownerUserId: detail.creator?.id ?? null });
   const canReport = useCanReportListing();
+  const report = useReportListingAffordance();
   const [reviewOpened, reviewModal] = useDisclosure(false);
-  const [reportOpened, reportModal] = useDisclosure(false);
 
   // Hero click-to-launch — the banner is an affordance for the SAME destination
   // as the primary CTA, derived FROM that CTA (`getDetailPrimaryAction`) rather
@@ -794,15 +807,19 @@ export function AppListingDetailBody({
                     </Menu.Item>
                   )}
                   {/* Report affordance — dark behind the mod-only store surface; the
-                      proc is protected + rate-limited + reporter-bound server-side. */}
+                      proc is protected + rate-limited + reporter-bound server-side.
+                      🔴 `triggerProps` carries BOTH the click and the spent `disabled`
+                      state; the modal below carries its `onReported` counterpart. The
+                      pair is what stops a second report from returning the server's
+                      one-open-report-per-reporter CONFLICT as an error toast. */}
                   {canReport && (
                     <Menu.Item
                       color="red"
                       leftSection={<IconFlag size={14} stroke={1.5} />}
-                      onClick={reportModal.open}
+                      {...report.triggerProps}
                       data-testid="apps-listing-report-action"
                     >
-                      Report
+                      {report.label}
                     </Menu.Item>
                   )}
                 </Menu.Dropdown>
@@ -971,11 +988,7 @@ export function AppListingDetailBody({
         />
       )}
       {!preview && canReport && (
-        <ReportListingModal
-          appListingId={detail.id}
-          opened={reportOpened}
-          onClose={reportModal.close}
-        />
+        <ReportListingModal appListingId={detail.id} {...report.modalProps} />
       )}
     </Stack>
   );

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -59,10 +59,7 @@ import {
 } from '~/components/Apps/ReportListingModal';
 import { ReviewListingModal, useCanReviewListing } from '~/components/Apps/ReviewListingButton';
 import { AppListingReviews } from '~/components/Apps/AppListingReviews';
-import {
-  CATEGORY_ICONS,
-  FALLBACK_CATEGORY_ICON,
-} from '~/components/Apps/marketplaceCategoryIcons';
+import { CATEGORY_ICONS, FALLBACK_CATEGORY_ICON } from '~/components/Apps/marketplaceCategoryIcons';
 import { ContainerGrid2 } from '~/components/ContainerGrid/ContainerGrid';
 import { ContentClamp } from '~/components/ContentClamp/ContentClamp';
 import { SmartCreatorCard } from '~/components/CreatorCard/CreatorCard';

--- a/src/components/Apps/ReportListingModal.browser.test.tsx
+++ b/src/components/Apps/ReportListingModal.browser.test.tsx
@@ -2,11 +2,22 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
 
 /**
  * W13 P3b — the off-site listing REPORT modal. Browser-mode surface test
- * (report-only in Tekton): the Report button opens a modal that renders the 6
- * schema reasons + submits the picked reason via `appListings.reportListing`.
+ * (report-only in Tekton): the modal renders the 6 schema reasons + submits the
+ * picked reason via `appListings.reportListing`.
+ *
+ * 🔴 THIS FILE USED TO DRIVE `ReportListingButton`, a self-contained button that
+ * NOTHING in the app rendered — so these three tests were the component's only
+ * consumer. The button is gone (its "already reported" state moved into
+ * `useReportListingAffordance`, which the live `⋮` menu on the listing detail
+ * page now uses); the modal itself is unchanged, so the tests are retargeted at
+ * it directly and simply mount it `opened`. The live trigger → modal → spent
+ * trigger path is covered in `AppListingDetailBody.browser.test.tsx`, and the
+ * blocking wiring gate is `__tests__/appListingReportCallSites.test.ts` in the
+ * node `unit` project.
  *
  * Network-free: the reportListing mutation + useCurrentUser + notifications are
  * mocked. The blocking correctness gate for the reason options lives in the node
@@ -18,7 +29,12 @@ const mocks = vi.hoisted(() => ({
   isPending: false,
 }));
 
-vi.mock('~/utils/trpc', () => ({
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-
+// mock): a hand-written replacement silently breaks every importer the day
+// '~/utils/trpc' grows an export this factory omits — as 0 collected tests, not as a
+// failure.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
   trpc: {
     appListings: {
       reportListing: {
@@ -37,17 +53,23 @@ vi.mock('~/utils/notifications', () => ({
   showErrorNotification: vi.fn(),
 }));
 
-const { ReportListingButton } = await import('./ReportListingButton');
+const { ReportListingModal } = await import('./ReportListingModal');
 
 beforeEach(() => {
   mocks.mutate.mockClear();
   mocks.isPending = false;
 });
 
-describe('ReportListingButton', () => {
+/** The modal renders no trigger — the caller owns `opened`. Mount it open. */
+function renderOpenModal() {
+  renderWithProviders(
+    <ReportListingModal appListingId="apl_target" opened onClose={() => undefined} />
+  );
+}
+
+describe('ReportListingModal', () => {
   test('opens the modal and renders the 6 report reasons', async () => {
-    renderWithProviders(<ReportListingButton appListingId="apl_target" />);
-    await page.getByRole('button', { name: 'Report' }).click();
+    renderOpenModal();
 
     await expect
       .element(page.getByText('Impersonation — not the real app or owner'))
@@ -60,16 +82,14 @@ describe('ReportListingButton', () => {
   });
 
   test('submitting without a reason surfaces an inline error (mutation NOT called)', async () => {
-    renderWithProviders(<ReportListingButton appListingId="apl_target" />);
-    await page.getByRole('button', { name: 'Report' }).click();
+    renderOpenModal();
     await page.getByRole('button', { name: 'Submit report' }).click();
     await expect.element(page.getByText('Please choose a reason.')).toBeInTheDocument();
     expect(mocks.mutate).not.toHaveBeenCalled();
   });
 
   test('picking a reason + submitting calls reportListing with the listing id + reason', async () => {
-    renderWithProviders(<ReportListingButton appListingId="apl_target" />);
-    await page.getByRole('button', { name: 'Report' }).click();
+    renderOpenModal();
     await page.getByRole('radio', { name: 'Spam' }).click();
     await page.getByRole('button', { name: 'Submit report' }).click();
 

--- a/src/components/Apps/ReportListingModal.tsx
+++ b/src/components/Apps/ReportListingModal.tsx
@@ -7,6 +7,7 @@ import {
   APP_LISTING_REPORT_REASON_OPTIONS,
   isReportReason,
   reportErrorMessage,
+  reportTriggerState,
 } from '~/components/Apps/appListingReportView';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import {
@@ -19,9 +20,10 @@ import { trpc } from '~/utils/trpc';
 /**
  * App Store Listings (W13) — P3b USER REPORT affordance for an off-site listing.
  *
- * A small "Report" button that opens a modal with a reason picker (the 6 schema
- * reasons, human-labelled via the pure `appListingReportView` helper) + an
- * optional details textarea → `trpc.appListings.reportListing`. The reporter is
+ * A "Report" trigger (today the `⋮` menu item on the listing detail page) opens a
+ * modal with a reason picker (the 6 schema reasons, human-labelled via the pure
+ * `appListingReportView` helper) + an optional details textarea →
+ * `trpc.appListings.reportListing`. The reporter is
  * bound server-side to the authenticated caller (IDOR-safe); the DB partial-unique
  * dedups a duplicate open report, surfaced inline as a friendly "already reported"
  * message (mapped by `reportErrorMessage`).
@@ -31,12 +33,23 @@ import { trpc } from '~/utils/trpc';
  * until the store widens. Hidden entirely for a signed-out viewer (the proc is
  * `protectedProcedure`).
  *
- * 🔴 SPLIT INTO GATE + MODAL + BUTTON for the same structural reason as
+ * 🔴 SPLIT INTO GATE + STATE HOOK + MODAL for the same structural reason as
  * `ReviewListingButton` — see that file's header. Short version: the listing detail's
  * secondary actions moved into a `⋮` Menu, a Mantine `Menu.Dropdown` UNMOUNTS on
  * close, and a modal rendered as a sibling of a `Menu.Item` trigger would therefore
  * be destroyed by the very click meant to open it. The trigger goes inside the
  * dropdown, the modal outside, so `opened` has to be the caller's state.
+ *
+ * 🔴 WHICH IS EXACTLY HOW THE "ALREADY REPORTED" GUARD WENT MISSING. This file used
+ * to ALSO export a self-contained `ReportListingButton` that owned a local
+ * `done` flag, disabled its own trigger and read "Reported" once the mutation
+ * succeeded. Nothing ever rendered it — the live detail page mounted the modal
+ * itself and never passed `onReported` — so the guard sat in dead code while the
+ * real `⋮` menu item stayed live, and a second report attempt hit the server's
+ * one-open-report-per-reporter CONFLICT and surfaced an ERROR instead of the
+ * "Reported" state. The button is gone; the state it owned now lives in
+ * {@link useReportListingAffordance}, which hands the caller BOTH halves as
+ * pre-wired prop bags so a trigger cannot be mounted without its `onReported`.
  */
 
 /**
@@ -54,8 +67,9 @@ export function useCanReportListing(): boolean {
 /**
  * The report form modal. Renders NO trigger — the caller owns `opened`.
  *
- * `onReported` fires once the mutation succeeds, so a caller can mark its own trigger
- * as spent (the standalone Button below disables itself and reads "Reported").
+ * `onReported` fires once the mutation succeeds, so the caller can mark its own trigger
+ * as spent. Callers get that wiring from {@link useReportListingAffordance} rather than
+ * assembling it by hand — see its comment for why the prop bags exist.
  */
 export function ReportListingModal({
   appListingId,
@@ -94,9 +108,9 @@ export function ReportListingModal({
     setInlineError(null);
   };
 
-  // Clear the form on every OPEN. The standalone Button used to do this in its own
-  // click handler (`reset(); open();`); with the trigger now living outside this
-  // component, the reset has to key on the transition instead so BOTH triggers get it.
+  // Clear the form on every OPEN. The retired standalone button used to do this in its
+  // own click handler (`reset(); open();`); with the trigger living outside this
+  // component, the reset keys on the transition instead so every trigger gets it.
   useEffect(() => {
     if (opened) reset();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -172,38 +186,42 @@ export function ReportListingModal({
   );
 }
 
+export type ReportListingAffordance = {
+  /** Trigger copy — "Report", or "Reported" once this viewer has reported. */
+  label: string;
+  /** Has this viewer already reported the listing IN THIS SESSION? */
+  reported: boolean;
+  /** Spread onto the trigger (a `Menu.Item`, a `Button`, …). */
+  triggerProps: { disabled: boolean; onClick: () => void };
+  /** Spread onto {@link ReportListingModal}. Carries the `onReported` wiring. */
+  modalProps: { opened: boolean; onClose: () => void; onReported: () => void };
+};
+
 /**
- * The standalone report affordance: gate + a small Button + the modal.
+ * The report affordance's STATE, owned in one place: disclosure + the spent flag.
  *
- * UNCHANGED public API and unchanged behaviour — composed from the two exports above
- * rather than inlining them. `ReportListingButton.browser.test.tsx` is the guard.
+ * 🔴 THE POINT OF THE PROP BAGS is that they cannot be half-wired. The server allows
+ * one open report per reporter, so a second attempt is a CONFLICT — a friendly error,
+ * but an error, where the user expects a confirmation. The only way to keep that off
+ * the screen is for the trigger that opened the modal to go disabled when the modal
+ * reports success, and the two live in different subtrees (see the header: the
+ * trigger is inside a `Menu.Dropdown` that unmounts, the modal is outside it). A
+ * caller that spreads `triggerProps` and `modalProps` gets that link for free; a
+ * caller that hand-rolls either half is what shipped the bug. `disabled` / `label`
+ * come from the pure {@link reportTriggerState} so the rule has exactly one
+ * definition, and it is pinned in the blocking node `unit` project
+ * (`__tests__/appListingReportView.test.ts` for the rule,
+ * `__tests__/appListingReportCallSites.test.ts` for the wiring).
  */
-export function ReportListingButton({ appListingId }: { appListingId: string }) {
-  const canReport = useCanReportListing();
+export function useReportListingAffordance(): ReportListingAffordance {
   const [opened, { open, close }] = useDisclosure(false);
-  const [done, setDone] = useState(false);
+  const [reported, setReported] = useState(false);
+  const { label, disabled } = reportTriggerState(reported);
 
-  // The report proc is protected — never offer it to a signed-out viewer.
-  if (!canReport) return null;
-
-  return (
-    <>
-      <Button
-        variant="subtle"
-        color="gray"
-        size="xs"
-        leftSection={<IconFlag size={14} />}
-        onClick={open}
-        disabled={done}
-      >
-        {done ? 'Reported' : 'Report'}
-      </Button>
-      <ReportListingModal
-        appListingId={appListingId}
-        opened={opened}
-        onClose={close}
-        onReported={() => setDone(true)}
-      />
-    </>
-  );
+  return {
+    label,
+    reported,
+    triggerProps: { disabled, onClick: open },
+    modalProps: { opened, onClose: close, onReported: () => setReported(true) },
+  };
 }

--- a/src/components/Apps/ReportListingModal.tsx
+++ b/src/components/Apps/ReportListingModal.tsx
@@ -160,7 +160,9 @@ export function ReportListingModal({
             label="Details (optional)"
             placeholder="Add any context that will help a moderator."
             value={details}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setDetails(e.currentTarget.value)}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+              setDetails(e.currentTarget.value)
+            }
             maxLength={OFFSITE_REPORT_DETAILS_MAX}
             autosize
             minRows={3}

--- a/src/components/Apps/__tests__/appListingReportCallSites.test.ts
+++ b/src/components/Apps/__tests__/appListingReportCallSites.test.ts
@@ -1,0 +1,289 @@
+import fs from 'fs';
+import path from 'path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 🔒 THE CALL-SITE LEDGER for the listing REPORT affordance.
+ *
+ * WHY THIS FILE EXISTS — measured, not hypothetical. `ReportListingModal` accepts an
+ * `onReported` callback so its trigger can go spent once a report lands; the server
+ * keeps at most ONE open report per reporter, so a second submission comes back as a
+ * CONFLICT and the user sees an error where they expect a confirmation. The guard was
+ * written — and lived in a standalone `ReportListingButton` that NOTHING rendered.
+ * The live listing-detail page mounted the modal itself, passed no `onReported`, and
+ * left its `⋮` menu item permanently clickable. Every existing test was green: the
+ * button's own suite drove the dead component, and the detail page's suite only ever
+ * asserted that the menu item OPENS the modal.
+ *
+ * So this pins the RELATIONSHIP rather than either component: the exact set of sites
+ * that mount the report modal or render its trigger, that each mount is wired to the
+ * spent-state callback, and that each trigger takes its disabled state and its label
+ * FROM that state rather than hardcoding them. It fails when the ledger GROWS (a new
+ * report surface that forgot the wiring) and when it SHRINKS (a site that dropped it,
+ * or a testid rename that makes a trigger invisible to this check).
+ *
+ * 🔴 A STRUCTURAL CHECK IS NOT A BEHAVIOURAL ONE. This proves each site receives the
+ * wiring; it cannot prove the wiring does the right thing at runtime. That claim is
+ * made by two other suites, and this file deliberately does not replace them:
+ *   - `AppListingDetailBody.browser.test.tsx` — reports through the REAL `⋮` menu and
+ *     asserts the item comes back `disabled` + reading "Reported" (browser project).
+ *   - `__tests__/appListingReportView.test.ts` — the pure `reportTriggerState` rule.
+ *
+ * 🔴 AND THE SCOPE THAT MATTERS IN CI: the browser `component` suite is REPORT-ONLY
+ * (it always exits 0, is not a required check, and is not published at all when the
+ * preview deploy fails). This unit-project ledger BLOCKS. So in CI the live path's
+ * wiring is pinned structurally, by this file, and behaviourally only by a suite that
+ * cannot fail a build.
+ *
+ * 🔴 KNOWN LIMITS, stated rather than implied:
+ *   1. Detection is per-FILE and syntactic. A site that mounts the modal through an
+ *      indirection (a wrapper component, a `React.createElement` call, a renamed
+ *      import) is invisible here — the ledger would silently SHRINK, which the EXACT
+ *      set assertion catches, but a wrapper ADDED beside an existing correct site
+ *      would not be seen at all.
+ *   2. Test files are excluded (they legitimately mount the modal bare, with no
+ *      trigger, to exercise the form) — so this makes no claim about them.
+ */
+
+const SRC = path.resolve(__dirname, '../../..');
+
+/** Path (relative to `src/`) of the modal component itself — never a call site. */
+const MODAL_MODULE = 'components/Apps/ReportListingModal.tsx';
+
+/**
+ * Every PRODUCTION site that mounts `ReportListingModal`. One today: the listing
+ * detail body, which is the live store surface. Adding a second report surface means
+ * adding it here — that is the point, not an inconvenience.
+ */
+const MODAL_MOUNT_SITES = ['components/Apps/AppListingDetailBody.tsx'] as const;
+
+/**
+ * Every PRODUCTION site that renders the report TRIGGER, identified by the stable
+ * `data-testid` the existing browser tests already select on. Same ledger discipline:
+ * a rename shows up here as a SHRINK, not as a silent hole.
+ */
+const TRIGGER_TEST_ID = 'apps-listing-report-action';
+const TRIGGER_SITES = ['components/Apps/AppListingDetailBody.tsx'] as const;
+
+type MountSite = { file: string; onReportedWired: boolean };
+type TriggerSite = { file: string; disabledFromState: boolean; labelFromState: boolean };
+
+function parseTsx(fileName: string, text: string): ts.SourceFile {
+  return ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+function attributeNames(node: ts.JsxOpeningLikeElement): string[] {
+  return node.attributes.properties
+    .filter(ts.isJsxAttribute)
+    .map((attr) => attr.name.getText(node.getSourceFile()));
+}
+
+/** Does this element spread a bag whose property name is `prop` (e.g. `{...x.modalProps}`)? */
+function spreadsProp(node: ts.JsxOpeningLikeElement, prop: string): boolean {
+  return node.attributes.properties.some(
+    (attr) =>
+      ts.isJsxSpreadAttribute(attr) &&
+      ts.isPropertyAccessExpression(attr.expression) &&
+      attr.expression.name.getText(node.getSourceFile()) === prop
+  );
+}
+
+function stringAttribute(node: ts.JsxOpeningLikeElement, name: string): string | null {
+  for (const attr of node.attributes.properties) {
+    if (!ts.isJsxAttribute(attr)) continue;
+    if (attr.name.getText(node.getSourceFile()) !== name) continue;
+    const init = attr.initializer;
+    if (init && ts.isStringLiteral(init)) return init.text;
+  }
+  return null;
+}
+
+/**
+ * Are this element's children a live EXPRESSION rather than literal text? That is what
+ * separates `{report.label}` (reads "Reported" once spent) from a hardcoded `Report`,
+ * which is the mutant a `disabled`-only check would sail past.
+ */
+function childrenAreExpression(node: ts.JsxOpeningLikeElement): boolean {
+  const parent = node.parent;
+  if (!ts.isJsxElement(parent)) return false;
+  const meaningful = parent.children.filter(
+    (child) => !(ts.isJsxText(child) && child.getText(parent.getSourceFile()).trim() === '')
+  );
+  return (
+    meaningful.length > 0 &&
+    meaningful.every((child) => ts.isJsxExpression(child) && !!child.expression)
+  );
+}
+
+/** Analyse ONE source text. Exported shape is what the fixtures below assert against. */
+function analyze(
+  fileName: string,
+  text: string
+): { mounts: MountSite[]; triggers: TriggerSite[] } {
+  const sf = parseTsx(fileName, text);
+  const mounts: MountSite[] = [];
+  const triggers: TriggerSite[] = [];
+
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const tag = node.tagName.getText(sf);
+      const attrs = attributeNames(node);
+
+      if (tag === 'ReportListingModal') {
+        mounts.push({
+          file: fileName,
+          onReportedWired: attrs.includes('onReported') || spreadsProp(node, 'modalProps'),
+        });
+      }
+
+      if (stringAttribute(node, 'data-testid') === TRIGGER_TEST_ID) {
+        triggers.push({
+          file: fileName,
+          disabledFromState: attrs.includes('disabled') || spreadsProp(node, 'triggerProps'),
+          labelFromState: childrenAreExpression(node),
+        });
+      }
+    }
+    node.forEachChild(visit);
+  };
+  visit(sf);
+
+  return { mounts, triggers };
+}
+
+/** Every non-test `.tsx` under `src/`, relative to `src/`. */
+function productionTsxFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+        walk(full);
+        continue;
+      }
+      if (!entry.name.endsWith('.tsx')) continue;
+      if (entry.name.includes('.test.')) continue;
+      out.push(path.relative(SRC, full).split(path.sep).join('/'));
+    }
+  };
+  walk(SRC);
+  return out.sort();
+}
+
+const scanned = productionTsxFiles().map((file) => ({
+  file,
+  ...analyze(file, fs.readFileSync(path.join(SRC, file), 'utf8')),
+}));
+
+describe('report affordance call-site ledger', () => {
+  it('the instrument can SEE a site at all (positive control)', () => {
+    // A reassuring zero from a scanner nobody has watched find something is
+    // indistinguishable from a scanner wired to nothing.
+    expect(scanned.length).toBeGreaterThan(500);
+    expect(scanned.some((f) => f.file === MODAL_MOUNT_SITES[0])).toBe(true);
+    expect(scanned.flatMap((f) => f.mounts).length).toBeGreaterThan(0);
+    expect(scanned.flatMap((f) => f.triggers).length).toBeGreaterThan(0);
+  });
+
+  it('the EXACT set of modal mount sites is the ledger (fails on GROW or SHRINK)', () => {
+    const found = scanned
+      .filter((f) => f.mounts.length > 0 && f.file !== MODAL_MODULE)
+      .map((f) => f.file);
+    expect(found).toEqual([...MODAL_MOUNT_SITES]);
+  });
+
+  it('the EXACT set of trigger sites is the ledger (fails on GROW, SHRINK or testid rename)', () => {
+    const found = scanned.filter((f) => f.triggers.length > 0).map((f) => f.file);
+    expect(found).toEqual([...TRIGGER_SITES]);
+  });
+
+  it('🔴 EVERY modal mount is wired to the spent-state callback', () => {
+    // THE REGRESSION. Pre-fix, `AppListingDetailBody` mounted the modal with
+    // `opened` / `onClose` only, so a successful report left its menu item live and
+    // the next click returned the server's one-open-report-per-reporter CONFLICT.
+    const unwired = scanned
+      .flatMap((f) => f.mounts.map((m) => ({ ...m, file: f.file })))
+      .filter((m) => m.file !== MODAL_MODULE && !m.onReportedWired)
+      .map((m) => m.file);
+    expect(unwired).toEqual([]);
+  });
+
+  it('🔴 EVERY trigger takes BOTH its disabled state and its label from that state', () => {
+    const triggers = scanned.flatMap((f) => f.triggers.map((t) => ({ ...t, file: f.file })));
+    expect(triggers.filter((t) => !t.disabledFromState).map((t) => t.file)).toEqual([]);
+    expect(triggers.filter((t) => !t.labelFromState).map((t) => t.file)).toEqual([]);
+  });
+});
+
+describe('the ledger analyser itself (negative controls)', () => {
+  // Realistic fixtures, in the two shapes that actually shipped — not textbook ones.
+  const PRE_FIX = `
+    export function Body() {
+      return (
+        <>
+          <Menu.Item onClick={reportModal.open} data-testid="${TRIGGER_TEST_ID}">
+            Report
+          </Menu.Item>
+          <ReportListingModal appListingId={detail.id} opened={reportOpened} onClose={reportModal.close} />
+        </>
+      );
+    }
+  `;
+  const FIXED = `
+    export function Body() {
+      return (
+        <>
+          <Menu.Item {...report.triggerProps} data-testid="${TRIGGER_TEST_ID}">
+            {report.label}
+          </Menu.Item>
+          <ReportListingModal appListingId={detail.id} {...report.modalProps} />
+        </>
+      );
+    }
+  `;
+
+  it('flags the pre-fix shape (unwired mount, hardcoded live trigger)', () => {
+    const { mounts, triggers } = analyze('probe.tsx', PRE_FIX);
+    expect(mounts).toHaveLength(1);
+    expect(mounts[0].onReportedWired).toBe(false);
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].disabledFromState).toBe(false);
+    expect(triggers[0].labelFromState).toBe(false);
+  });
+
+  it('passes the fixed shape', () => {
+    const { mounts, triggers } = analyze('probe.tsx', FIXED);
+    expect(mounts[0].onReportedWired).toBe(true);
+    expect(triggers[0].disabledFromState).toBe(true);
+    expect(triggers[0].labelFromState).toBe(true);
+  });
+
+  it('accepts an explicit `onReported` / `disabled` too, not only the prop bags', () => {
+    const explicit = `
+      <>
+        <Menu.Item disabled={reported} onClick={open} data-testid="${TRIGGER_TEST_ID}">
+          {label}
+        </Menu.Item>
+        <ReportListingModal appListingId={id} opened={opened} onClose={close} onReported={mark} />
+      </>
+    `;
+    const { mounts, triggers } = analyze('probe.tsx', explicit);
+    expect(mounts[0].onReportedWired).toBe(true);
+    expect(triggers[0].disabledFromState).toBe(true);
+    expect(triggers[0].labelFromState).toBe(true);
+  });
+
+  it('a spread of some OTHER bag does not count as wiring', () => {
+    const wrong = `
+      <>
+        <Menu.Item {...someOtherProps} data-testid="${TRIGGER_TEST_ID}">{label}</Menu.Item>
+        <ReportListingModal appListingId={id} {...someOtherProps} />
+      </>
+    `;
+    const { mounts, triggers } = analyze('probe.tsx', wrong);
+    expect(mounts[0].onReportedWired).toBe(false);
+    expect(triggers[0].disabledFromState).toBe(false);
+  });
+});

--- a/src/components/Apps/__tests__/appListingReportCallSites.test.ts
+++ b/src/components/Apps/__tests__/appListingReportCallSites.test.ts
@@ -117,10 +117,7 @@ function childrenAreExpression(node: ts.JsxOpeningLikeElement): boolean {
 }
 
 /** Analyse ONE source text. Exported shape is what the fixtures below assert against. */
-function analyze(
-  fileName: string,
-  text: string
-): { mounts: MountSite[]; triggers: TriggerSite[] } {
+function analyze(fileName: string, text: string): { mounts: MountSite[]; triggers: TriggerSite[] } {
   const sf = parseTsx(fileName, text);
   const mounts: MountSite[] = [];
   const triggers: TriggerSite[] = [];

--- a/src/components/Apps/__tests__/appListingReportView.test.ts
+++ b/src/components/Apps/__tests__/appListingReportView.test.ts
@@ -5,6 +5,7 @@ import {
   getReportReasonLabel,
   isReportReason,
   reportErrorMessage,
+  reportTriggerState,
 } from '~/components/Apps/appListingReportView';
 import { APP_LISTING_REPORT_REASONS } from '~/server/schema/blocks/offsite-moderation.schema';
 
@@ -82,5 +83,32 @@ describe('reportErrorMessage', () => {
   it('handles a null/undefined error', () => {
     expect(reportErrorMessage(null).length).toBeGreaterThan(0);
     expect(reportErrorMessage(undefined).length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The "already reported" trigger rule. 🔴 THIS IS AN INVARIANT GUARD, NOT A REGRESSION
+ * TEST: the shipped defect was never that this mapping was wrong, it was that the LIVE
+ * `⋮` menu item never learned the report had landed (the rule lived in a
+ * `ReportListingButton` nothing rendered). The regression cover for that is
+ * `__tests__/appListingReportCallSites.test.ts` (wiring, blocking) plus the
+ * report-through-the-menu case in `AppListingDetailBody.browser.test.tsx`
+ * (behaviour, report-only). What this pins is that the rule keeps exactly one
+ * definition and both halves move together.
+ */
+describe('reportTriggerState', () => {
+  it('offers the report before one has been made', () => {
+    expect(reportTriggerState(false)).toEqual({ label: 'Report', disabled: false });
+  });
+
+  it('goes SPENT once reported — disabled AND relabelled, not one or the other', () => {
+    expect(reportTriggerState(true)).toEqual({ label: 'Reported', disabled: true });
+  });
+
+  it('never leaves an enabled trigger reading "Reported" (the pair cannot drift)', () => {
+    for (const reported of [false, true]) {
+      const { label, disabled } = reportTriggerState(reported);
+      expect(disabled).toBe(label === 'Reported');
+    }
   });
 });

--- a/src/components/Apps/__tests__/appListingReportView.test.ts
+++ b/src/components/Apps/__tests__/appListingReportView.test.ts
@@ -67,15 +67,21 @@ describe('reportErrorMessage', () => {
 
   it('surfaces the server message for a BAD_REQUEST / NOT_FOUND', () => {
     expect(
-      reportErrorMessage({ data: { code: 'BAD_REQUEST' }, message: 'only an approved listing can be reported' })
+      reportErrorMessage({
+        data: { code: 'BAD_REQUEST' },
+        message: 'only an approved listing can be reported',
+      })
     ).toContain('approved listing');
-    expect(reportErrorMessage({ data: { code: 'NOT_FOUND' }, message: 'listing not found' })).toContain(
-      'not found'
-    );
+    expect(
+      reportErrorMessage({ data: { code: 'NOT_FOUND' }, message: 'listing not found' })
+    ).toContain('not found');
   });
 
   it('gives a generic fallback for an unknown / internal error (never a raw leak)', () => {
-    const msg = reportErrorMessage({ data: { code: 'INTERNAL_SERVER_ERROR' }, message: 'ECONNREFUSED' });
+    const msg = reportErrorMessage({
+      data: { code: 'INTERNAL_SERVER_ERROR' },
+      message: 'ECONNREFUSED',
+    });
     expect(msg).not.toContain('ECONNREFUSED');
     expect(msg.length).toBeGreaterThan(0);
   });

--- a/src/components/Apps/appListingReportView.ts
+++ b/src/components/Apps/appListingReportView.ts
@@ -37,6 +37,22 @@ const REASON_LABELS: Record<AppListingReportReason, string> = {
 export const APP_LISTING_REPORT_REASON_OPTIONS: ReportReasonOption[] =
   APP_LISTING_REPORT_REASONS.map((value) => ({ value, label: REASON_LABELS[value] }));
 
+/** How the report TRIGGER presents itself, given whether this viewer already reported. */
+export type ReportTriggerState = { label: string; disabled: boolean };
+
+/**
+ * The "already reported" rule, in ONE place.
+ *
+ * The server keeps at most one OPEN report per reporter per listing, so a second
+ * submission comes back as a friendly CONFLICT — which reads as an error toast where
+ * the user expects a confirmation. The affordance therefore has to go spent: the
+ * trigger is DISABLED and reads "Reported". Pure + React-free so the blocking node
+ * `unit` project owns it (the browser `component` project is report-only).
+ */
+export function reportTriggerState(reported: boolean): ReportTriggerState {
+  return reported ? { label: 'Reported', disabled: true } : { label: 'Report', disabled: false };
+}
+
 /** Human label for a stored reason value (falls back to the raw value). */
 export function getReportReasonLabel(reason: string): string {
   return (REASON_LABELS as Record<string, string>)[reason] ?? reason;


### PR DESCRIPTION
## The bug

On the App Blocks store listing detail page, the `⋮` → **Report** item stayed live after a
report was submitted. A second attempt therefore came back as the server's
one-open-report-per-reporter `CONFLICT` — a friendly message, but an **error toast where the
user expects a confirmation**. Server behaviour is correct and unchanged; this is a UX defect.

## Mechanism

`ReportListingModal` already accepted an `onReported?: () => void` callback for exactly this,
and the "already reported" state (`done` → trigger `disabled`, label `"Reported"`) was
implemented — in `ReportListingButton`, a self-contained button that **nothing in the app
rendered**. Its only references were its own file and its own test.

The live path, `AppListingDetailBody`, imported only `ReportListingModal` /
`useCanReportListing`, rendered its own `⋮` menu item, and mounted the modal with
`opened` / `onClose` and **no `onReported`**. So the guard lived in dead code while the shipping
path had none, and every test was green: the button's suite drove the dead component, and the
detail page's suite only asserted that the menu item *opens* the modal.

## The fix — consolidation, not duplication

**Deleted the dead `ReportListingButton` and moved its guard into the live path**, rather than
lifting a shared button/component. Reasons:

- With the button gone there is exactly **one** report surface, so a shared component would have
  had a single consumer — indirection without a second caller to justify it.
- Copying `done` / `setDone` into `AppListingDetailBody` would have recreated the split that
  caused this, so the rule itself is now single-sourced in two pieces:
  - `reportTriggerState(reported)` in the pure, React-free `appListingReportView.ts` — the one
    definition of "disabled + reads *Reported*", owned by the blocking node `unit` project.
  - `useReportListingAffordance()` in `ReportListingModal.tsx` — owns disclosure + the spent
    flag and hands the caller **two pre-wired prop bags**, `triggerProps` and `modalProps`.
    `modalProps` carries `onReported`, so a caller cannot mount the trigger and forget the
    callback the way this page did; that is the structural half of the fix.

`AppListingDetailBody` now spreads both bags. Behaviour is the one that was always intended:
after a successful report the trigger is `disabled` and reads **"Reported"**. No server change,
and the modal's public API is untouched (`onReported` was already there).

The file was renamed `ReportListingButton.tsx` → `ReportListingModal.tsx` (it no longer contains
a button), and its test moved with it and was retargeted at the modal directly — it used to be
the dead component's only consumer. Its `vi.mock('~/utils/trpc')` was also converted to the
`importOriginal` spread the repo's `local-rules/no-wholesale-module-mock` requires (it was
failing that rule before the rename).

## Coverage

The browser `component` tier is report-only in CI (always exits 0, not a required check, not
published when the preview deploy fails), so the load-bearing guard is in the node `unit`
project:

| Test | Project | What it pins |
|---|---|---|
| `__tests__/appListingReportCallSites.test.ts` (new) | `unit` (**blocking**) | Call-site ledger: the exact set of modal mounts + report triggers, that every mount is wired to `onReported`/`modalProps`, and that every trigger takes **both** its `disabled` state and its label from that state. Fails on GROW and on SHRINK. |
| `AppListingDetailBody.browser.test.tsx` (new case) | `component` (report-only) | Behaviour through the REAL `⋮` menu: report → reopen menu → the item is `disabled` + `data-disabled` and reads "Reported". Asserted on **state**, with a live-before positive control on the same element. |
| `__tests__/appListingReportView.test.ts` (new cases) | `unit` | The `reportTriggerState` rule. **Labelled an invariant guard, not regression coverage** — the mapping was never wrong; the wiring was. |

The ledger analyser is validated in-suite against realistic fixtures of both the pre-fix and the
fixed shape (and against a spread of some *other* bag), plus a positive control asserting it can
see any site at all — a scanner nobody has watched find something is indistinguishable from one
wired to nothing.

### Test matrix (measured, not assumed)

- **RED at `origin/main`** (both new tests copied into a clean `origin/main` worktree):
  - `vitest run --project unit src/components/Apps/__tests__/appListingReportCallSites.test.ts`
    → **3 failed | 6 passed**; the two load-bearing failures name
    `components/Apps/AppListingDetailBody.tsx` as an unwired mount and as a trigger with neither
    `disabled` nor a state-derived label (the third is the mount ledger flagging the dead
    `ReportListingButton.tsx` as an extra site).
  - `vitest run --project component src/components/Apps/AppListingDetailBody.browser.test.tsx -t REGRESSION`
    → **1 failed** on the `disabled` assertion.
- **GREEN at HEAD**: same commands → `22 passed` (unit, both files) and `66 passed` (component,
  both files, 63 + 3).
- **Mutation checks at HEAD**: making the hook's `onReported` a no-op kills the browser test
  (and, as documented in the ledger's stated limits, is invisible to the structural check);
  flipping `reportTriggerState(true).disabled` to `false` kills two `reportTriggerState` cases.
- `pnpm typecheck` → 0 errors. `eslint` clean on every touched file.
  `vitest run --project unit src/components/Apps` → 917 passed.
