### PR TITLE
ci(lint): narrow unit/packages/apps to the paths our other CI does not reach

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -242,8 +242,55 @@ jobs:
         run: pnpm run typecheck
 
   unit:
-    name: Unit tests
+    name: Unit tests (fork PRs / non-main base)
     runs-on: ubuntu-latest
+    # 🔴 NARROWED, not retired. The `if:` below is BYTE-IDENTICAL to the one on
+    # `typecheck` above, deliberately: same two disjuncts, same complement of what
+    # the in-cluster Tekton side covers. The Tekton PR preview pipeline runs
+    # `pnpm run test:unit:run` and posts the verdict as the `preview / unit-tests`
+    # commit status, so where that runs, this job is a second execution of the
+    # same command on the same tree — paying its own checkout and its own
+    # `pnpm install --frozen-lockfile`, which the Tekton copy does not (it reuses
+    # the node_modules an earlier task in the same workspace already installed).
+    #
+    # The two disjuncts:
+    #
+    #   fork PR — the preview pipeline requires repo-write author association, so
+    #     a fork PR gets none of its five suites. This job is the only unit run a
+    #     fork PR can get. ⚠️ DORMANT IN PRACTICE, for a reason unrelated to this
+    #     expression: GitHub holds fork-originated workflow runs at
+    #     `action_required` until a maintainer approves them. Enumerated (not
+    #     sampled) 2026-08-18 across all 337 PRs created since the `typecheck`
+    #     narrowing: exactly two are fork-headed, #3763 and #3920, and all six of
+    #     their workflow runs sit at `action_required`. Keep the arm; it is where
+    #     fork coverage lands the moment a maintainer approves. Do not cite it as
+    #     active fork protection.
+    #
+    #   base != main — the Tekton side only polls PRs targeting `main`. This
+    #     workflow's `on:` accepts `main` and `release`, so this disjunct means
+    #     "base is `release`" — a shape the Tekton side never sees.
+    #
+    # 🔴 PRECONDITION — MEASURED, AND NOT MET AS OF 2026-08-18. This narrowing is
+    # sound only while the Tekton side actually runs these suites on ordinary
+    # internal PRs. It does not. All five preview suites are gated on an
+    # authorization task that requires repo-write association AND (an auto-deploy
+    # author OR the `preview` label). Measured over the 40 most recently merged
+    # internal PRs targeting `main`: 11 carried `preview / unit-tests`, and all 11
+    # were from the single auto-deploy author — 0 of the 24 PRs by the other three
+    # authors got any Tekton unit/packages/apps run. Discriminating control:
+    # `tekton / typecheck`, posted by a DIFFERENT and ungated pipeline, was
+    # present on 38 of the same 40, so the absence is a gate and not status
+    # retention. Positive control: #4080, from a non-auto-deploy author, carries
+    # the `preview` label and got all five suites.
+    #
+    # That asymmetry is exactly why `typecheck` could be narrowed and these three
+    # cannot be yet, on otherwise identical reasoning. Enabling this `if:` before
+    # the Tekton suites run unconditionally removes the ONLY unit / packages / apps
+    # CI from the majority of internal PRs. The prerequisite is to host the suites
+    # in the always-on pipeline; until that lands, do not enable this gate.
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository
+      || github.event.pull_request.base.ref != 'main'
     # ~8,000 tests that until now only ran on whoever remembered to run them.
     # Node env, no browser — component tests (`*.browser.test.tsx`) are not here
     # on purpose: they need Chromium, which this job does not install. That is
@@ -286,8 +333,19 @@ jobs:
         run: pnpm run test:unit:run
 
   packages:
-    name: Package unit tests
+    name: Package unit tests (fork PRs / non-main base)
     runs-on: ubuntu-latest
+    # 🔴 NARROWED, not retired — same `if:`, same two disjuncts and the SAME UNMET
+    # PRECONDITION as the `unit` job above. Read that comment before touching this
+    # one; it is not repeated here. The Tekton counterpart is `preview /
+    # packages-tests`, and it is a command-for-command mirror of this job: it runs
+    # `assert-next-svg-patch-applied.mjs`, then the identical
+    # `pnpm run test:packages:run`, then the same `assert-workspace-suites-ran.mjs`
+    # ledger assertion. So all three steps below are duplicated, not just the
+    # suite — and all three are behind the same unmet precondition.
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository
+      || github.event.pull_request.base.ref != 'main'
     # The nine `packages/*` suites — 616 tests that, until this job existed, NO CI job ran.
     # The `unit` job above runs `vitest run --project unit`, whose `include` is root-relative
     # (`src/**`, `scripts/**`), so nothing in this repo ever invoked a workspace package's
@@ -358,8 +416,17 @@ jobs:
         run: node scripts/ci/assert-workspace-suites-ran.mjs packages-report.json packages
 
   apps:
-    name: App unit tests
+    name: App unit tests (fork PRs / non-main base)
     runs-on: ubuntu-latest
+    # 🔴 NARROWED, not retired — same `if:`, same two disjuncts and the SAME UNMET
+    # PRECONDITION as the `unit` job above. Read that comment before touching this
+    # one; it is not repeated here. The Tekton counterpart is `preview /
+    # apps-tests`, a command-for-command mirror of this job: the identical
+    # `pnpm run test:apps:run` followed by the same `assert-workspace-suites-ran.mjs`
+    # ledger assertion.
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository
+      || github.event.pull_request.base.ref != 'main'
     # The `apps/*` suites — the same gap as `packages` above, in the sibling directory, and
     # missed when that one was closed: the root config registered `packages/*/vitest.config.*`
     # as projects and nothing for `apps/*`, so 369 tests across five apps had never once run


### PR DESCRIPTION
## What this does

Applies the narrowing `typecheck` already got in #3721 to the three remaining duplicated test jobs — `unit`, `packages` and `apps`. Narrowing, not deletion: the Actions copies survive for the population the in-cluster Tekton side structurally cannot serve.

The `if:` is **byte-identical** to `typecheck`'s (verified by hash — all four blocks are the same 4 lines):

```
github.event.pull_request.head.repo.full_name != github.repository
|| github.event.pull_request.base.ref != 'main'
```

Note it compares `head.repo.full_name` against `github.repository` rather than reading `head.repo.fork`. That is the existing form and it is the better one: when a head repo has been deleted, `head.repo` is null, and the `full_name` comparison then evaluates **true** (job runs — fails safe), where a `.fork` read would evaluate false and silently skip.

**Out of scope, untouched:** `eslint`, `schema-drift.yml`, `submodule-pin-guard.yml`, and — deliberately — the `component` and `auth` suites, which run in no other CI.

**No blocking status was changed.** `unit` keeps `continue-on-error: true`; `packages` and `apps` stay blocking-shaped. Recommendation on that below.

---

## 🔴 Do not merge this yet — the premise it rests on is not true today

The ticket's framing is that these three suites "already run in Tekton on every internal PR". **They do not**, and I measured it before shipping rather than after.

All five Tekton suites hang off a single authorization result that requires repo-write association **AND** (an auto-deploy author **OR** the `preview` label). The `preview` label is essentially unused, so in practice the suites run for one author.

Measured over the 40 most recently merged internal PRs targeting `main`:

| | count |
|---|---|
| carried `preview / unit-tests` | **11 / 40** |
| …of which from the single auto-deploy author | **11 / 11** |
| from the other three authors, with any Tekton unit/packages/apps run | **0 / 24** |
| carried `tekton / typecheck` | 38 / 40 |

Two controls, because an absence has many causes:

- **Discriminating control.** `tekton / typecheck` is posted by a *different*, ungated pipeline and was present on 38 of the same 40 PRs. So statuses persist on merged PRs and the missing `preview / *` is a real gate, not status retention.
- **Positive control.** #4080, from a non-auto-deploy author, carries the `preview` label — and got all five suites. So the label is the discriminator, mechanically.

That asymmetry is exactly why `typecheck` **could** be narrowed on this reasoning and these three **cannot be yet**: `tekton / typecheck` runs unconditionally, `preview / unit-tests` does not. Merging this today takes the majority of internal PRs — and 100% of PRs from every author except one — to **zero** unit/packages/apps coverage.

**The prerequisite already exists as an open PR on the infra side** (ClickUp 868krm9cu), which splits test authorization from deploy authorization so the suites run on every member PR. It independently measured the same thing (10/60, ZacxDev 10/10, JustMaier 0/43) and says in its own body: *"Do NOT retire the Actions unit jobs in this change. Keep them until Tekton tests are observed green on 100% of PRs for a sustained period."*

**So the merge order is:** that PR lands → the five `preview / *-tests` statuses are observed on 100% of PRs for a sustained period → this merges. I have left this as a **draft** for that reason.

---

## Verification

### Positive control — the expression is shown to RUN

This is the strongest evidence available, and it is GitHub executing the byte-identical expression rather than me reasoning about it. #3722 was opened as the deliberate positive control for #3721: same `lint.yml`, base `release`, so the second disjunct is true.

- **#3722**, base `release`, internal head, head sha carrying this exact `if:` → `Typecheck (fork PRs / non-main base)` = **`success`**. It ran.

### Negative control — the expression is shown to SKIP

Four recent ordinary internal→`main` PRs, on the live identical expression:

- **#4091, #4090, #4085, #4083** → typecheck = **`skipped`**, all four. And the enclosing workflow run concluded **`success`** in all four, which is the answer to "does a skipped job red anything": it does not.

### What I could NOT execute, stated plainly

- **The fork disjunct has no live observation, and cannot have one right now.** GitHub holds fork-originated runs at `action_required` until a maintainer approves. Enumerated (not sampled) across all 337 PRs created since #3721 merged: exactly two are fork-headed — #3763 and #3920 — and all six of their workflow runs sit at `action_required`. So the fork arm is real in configuration and **dormant in practice**, and this PR must not be read as adding active fork protection. It is where fork coverage lands the moment a maintainer approves a run.
- **I did not evaluate GitHub expression semantics locally.** No offline evaluator was used, so I am not claiming an executed check of `head.repo.full_name` / `base.ref` resolution. The evidence is GitHub's own execution of the byte-identical expression at both control points above, plus the hash equality showing what I wrote is that same expression.
- **`actionlint` validates only half of it.** Clean (rc=0) on this file; and as a negative control, a planted `github.repositoryX` made it exit 1 flagging all four sites — so it is genuinely inspecting these expressions. But `github.event` is typed as a loose `object`, so it does **not** type-check the `github.event.pull_request.*` half. A typo there would pass lint.
### Negative control on *this* change, not just on `typecheck`'s copy

The controls above exercise the byte-identical expression, but on the `typecheck` job. This PR is itself the negative-control shape (internal branch → `main`), so it tests the three new `if:` blocks directly. Observed on run `32195957216`:

```
ESLint + Prettier (changed files)         -> success
Typecheck (fork PRs / non-main base)      -> skipped
Unit tests (fork PRs / non-main base)     -> skipped
Package unit tests (fork PRs / non-main base) -> skipped
App unit tests (fork PRs / non-main base) -> skipped

RUN CONCLUSION = success
```

All three narrowed jobs skip as intended, and the run still concludes `success` — three skipped jobs red nothing.

What this run does **not** show is the positive direction for these three specific blocks; for that the evidence remains #3722's execution of the identical expression. If someone wants the direct proof, the cheap way is the one #3721 used: open a throwaway `[DO NOT MERGE]` PR from this branch targeting `release` and confirm all three jobs report `success`, then close it. I did not open one — say the word and I will.

---

## The blocking sub-question, answered

**Recommendation: do not flip Actions `unit` to blocking. Promote the Tekton copy instead — after the coverage prerequisite lands.**

`unit`'s comment says to remove `continue-on-error` once a clean pass rate shows. But if Tekton is authoritative for internal PRs, then narrowing this job to forks-and-`release`-only makes it a gate that runs on ~2 PRs a month, all of which sit unapproved anyway. Flipping *that* to blocking buys nothing and costs a confusing red on the rare PR it does run.

The copy worth promoting is the Tekton one, which is one line (`exit "$RC"` on the unit-tests step). It should be promoted only after coverage is fixed — and note the infra-side scope doc already flags the trap: a required check that never reports blocks the PR forever, so enforcement must follow coverage, never lead it.

I changed nothing here. `unit` is still `continue-on-error: true`.

---

## Two notes for whoever picks this up

- **`required_status_checks` trap.** `main` has branch protection but no required status checks, so nothing here blocks a merge and this needs no branch-protection change. If required checks are ever enabled, these three jobs — and `typecheck` — report **neutral/skipped** when narrowed out, and a required check that does not report sits "Expected — waiting for status" forever. They would each need a same-named no-op counterpart. I confirmed nothing in this repo consumes these jobs today: there are no `needs:` edges in any of the three workflows, and no other workflow references these job names. The job names change in this PR (`Unit tests` → `Unit tests (fork PRs / non-main base)`, and likewise for the other two), following #3721's precedent of making the checks list explain its own absence — safe precisely because no required check keys on the old names.
- **Stale comment in the `typecheck` job, out of scope here.** Its comment says the Tekton side "gates fork-authored PRs away by author association". That is true of the *preview* pipeline (which is what my new comments describe, and it is why the fork arm matters for these three jobs) but it was **retracted on the infra side on 2026-08-09** for the pipeline that actually posts `tekton / typecheck` — that one has no fork or author gate at any layer. Worth a follow-up correction; I did not touch it because it is outside this ticket.

Refs ClickUp 868ktvjvn
