### PR TITLE
feat(notices): wire feature notices to audience targeting

### DIFF
--- a/src/components/Alerts/__tests__/feature-notice.characterization.browser.test.tsx
+++ b/src/components/Alerts/__tests__/feature-notice.characterization.browser.test.tsx
@@ -125,6 +125,11 @@ vi.mock('~/hooks/useCurrentUser', () => ({
 
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => mocks.state.features,
+  // Required by `useFeatureNotice` for `audience`. None of the notices
+  // characterized here declares one, so this changes nothing about what they
+  // render — but omitting an export a consumer imports fails the file at
+  // COLLECTION, which reads as "no tests" rather than as a failure.
+  useOptionalFeatureFlags: () => mocks.state.features,
   useFeatureFlagsReady: () => mocks.state.flagsReady,
 }));
 

--- a/src/components/Alerts/__tests__/notice-callsite-composition.test.ts
+++ b/src/components/Alerts/__tests__/notice-callsite-composition.test.ts
@@ -1,0 +1,243 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import * as React from 'react';
+import type { act as actType } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import type * as Trpc from '~/utils/trpc';
+
+const act = (React as unknown as { act: typeof actType }).act;
+
+// Tells React this is an act-aware environment, so the renders below don't each
+// log "not configured to support act(...)". Purely output noise.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * 🔴 THE CALL SITE'S COMPOSITION, RENDERED — in the `unit` project, which is the
+ * only one CI runs.
+ *
+ * WHY THIS FILE EXISTS. Three suites already cover audience targeting and none
+ * of them could see the defect this one is for:
+ *
+ * - `useFeatureNotice.audience.test.ts` asserts the HOOK'S RETURN VALUE. A hook
+ *   can only offer an answer; it says nothing about whether a call site applies
+ *   it.
+ * - `notice-callsite-coverage.test.ts` greps the call site for the token
+ *   `isInAudience`. That is a SPELLED guard — it is satisfied by the
+ *   destructure alone, so deleting `&& !isInAudience` from the render condition
+ *   while leaving `isInAudience` bound at line 38 keeps it green. The audience
+ *   is then computed and thrown away, and every notice ships to every user who
+ *   reaches the component.
+ * - `notice-callsite.browser.test.tsx` does assert the rendered DOM, but it is
+ *   in the `component` project, which CI does NOT run. It is corroboration.
+ *
+ * The verified surviving mutant was exactly that: destructure kept, `&&
+ * !isInAudience` removed from `RemixGalleryExplainer`'s render guard, whole
+ * `unit` project green. This file renders the REAL component through the REAL
+ * hook and the REAL registry entry and asserts what reached the DOM, so the
+ * behaviour — not the word — is what is pinned.
+ *
+ * WHY `.test.ts` AND NOT `.test.tsx`: the `unit` project's include is
+ * `src/**\/*.test.ts`, so a `.tsx` file is silently not collected. Hence
+ * `React.createElement` rather than JSX. `happy-dom` + `react-dom/client` is the
+ * pattern this repo already uses to render in the node project (see
+ * `useDailyBoostReward.test.ts` and `useFeatureNotice.audience.test.ts`).
+ *
+ * FIXTURE HONESTY: `remixGallery` here is NOT a free choice — it is the flag the
+ * registry names for this notice, and asserting against the real registry entry
+ * is the point of a composition test. The "unrelated flag" case below uses a
+ * different flag so that "reads its own audience" stays separable from "some
+ * flag was on".
+ */
+
+let dismissedAlerts: string[] | undefined;
+let settingsResolved = true;
+let flags: Record<string, boolean> | null;
+let flagsReady: boolean;
+let currentUser: { id: number } | null;
+const dismissMutate = vi.fn();
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof Trpc>()),
+  trpc: {
+    useUtils: () => ({
+      user: {
+        getSettings: {
+          cancel: vi.fn(),
+          getData: vi.fn(),
+          setData: vi.fn(),
+          invalidate: vi.fn(),
+        },
+      },
+    }),
+    user: {
+      getSettings: {
+        // `enabled` honoured, not ignored: the hook disables this query without
+        // a signed-in user, so an always-answering mock would hand the
+        // signed-out case a `hasSettings` production never gives it.
+        useQuery: (_input?: unknown, opts?: { enabled?: boolean }) => ({
+          data: settingsResolved && (opts?.enabled ?? true) ? { dismissedAlerts } : undefined,
+          isLoading: false,
+        }),
+      },
+      dismissAlert: { useMutation: () => ({ mutate: dismissMutate }) },
+    },
+  },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => currentUser }));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useOptionalFeatureFlags: () => flags,
+  useFeatureFlagsReady: () => flagsReady,
+}));
+
+const { RemixGalleryExplainer } = await import('~/components/RemixGallery/RemixGalleryExplainer');
+const { MantineProvider } = await import('@mantine/core');
+
+/**
+ * A fragment of the explainer's own copy. Hand-typed rather than imported, so a
+ * rewrite of the component's markup cannot make this agree with itself.
+ */
+const NOTICE_COPY = "What's a remix gallery?";
+
+/** Marks the tree as having mounted at all. */
+const SENTINEL_ID = 'composition-sentinel';
+
+type Rendered = {
+  /** Dismiss affordances the notice rendered. 1 when shown, 0 when withheld. */
+  dismissControls: number;
+  /** Whether the notice's own copy reached the DOM. */
+  showsCopy: boolean;
+  /**
+   * Whether the surrounding tree mounted. Without this, "the notice is absent"
+   * is indistinguishable from "the render threw and nothing exists" — an
+   * assertion that would pass for the wrong reason forever.
+   */
+  mounted: boolean;
+};
+
+function renderCallSite(): Rendered {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() =>
+    root.render(
+      React.createElement(
+        MantineProvider,
+        null,
+        React.createElement(RemixGalleryExplainer),
+        React.createElement('span', { 'data-testid': SENTINEL_ID }, 'mounted')
+      )
+    )
+  );
+  const result: Rendered = {
+    dismissControls: container.querySelectorAll('[aria-label="Dismiss"]').length,
+    showsCopy: (container.textContent ?? '').includes(NOTICE_COPY),
+    mounted: !!container.querySelector(`[data-testid="${SENTINEL_ID}"]`),
+  };
+  act(() => root.unmount());
+  container.remove();
+  return result;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dismissedAlerts = [];
+  settingsResolved = true;
+  currentUser = { id: 91 };
+  flags = { remixGallery: true };
+  flagsReady = true;
+});
+
+describe('RemixGalleryExplainer applies its audience to what it renders', () => {
+  test('renders for a user the notice’s flag is ON for', () => {
+    // 🔴 The positive control, and it comes first deliberately: every assertion
+    // below is "the notice is absent", which a component that renders nothing
+    // ever would also satisfy.
+    const { dismissControls, showsCopy, mounted } = renderCallSite();
+    expect(mounted).toBe(true);
+    expect(showsCopy).toBe(true);
+    expect(dismissControls).toBe(1);
+  });
+
+  test('renders NOTHING for a user the notice’s flag is OFF for', () => {
+    // 🔴 THE MUTANT-KILLING CASE. Deleting `&& !isInAudience` from the render
+    // guard — while leaving `isInAudience` destructured, which is what keeps the
+    // token-scanning ledger green — makes this render the full notice.
+    flags = { remixGallery: false };
+    const { dismissControls, showsCopy, mounted } = renderCallSite();
+    expect(mounted, 'the tree did not mount at all, so an absent notice proves nothing here').toBe(
+      true
+    );
+    expect(
+      showsCopy,
+      'the explainer announced the remix gallery to a user the `remixGallery` flag is OFF for. ' +
+        'The hook computed `isInAudience`, and the call site did not APPLY it — AND ' +
+        '`!isInAudience` back into the render condition in RemixGalleryExplainer.tsx.'
+    ).toBe(false);
+    expect(dismissControls).toBe(0);
+  });
+
+  test('a flag absent from the overlay is not an audience', () => {
+    // Absent, not false. `undefined` must not read as membership.
+    flags = {};
+    const { showsCopy, mounted } = renderCallSite();
+    expect(mounted).toBe(true);
+    expect(showsCopy).toBe(false);
+  });
+
+  test('an unrelated flag being ON does not put a user in the audience', () => {
+    // Separates "reads its own audience" from "some flag was on". A mutant that
+    // ignores `audience.feature` passes the case above and fails this one.
+    flags = { remixGallery: false, imageCardInfoButton: true };
+    const { showsCopy, dismissControls } = renderCallSite();
+    expect(showsCopy).toBe(false);
+    expect(dismissControls).toBe(0);
+  });
+});
+
+describe('RemixGalleryExplainer fails CLOSED while the audience is unknown', () => {
+  test('renders nothing before the per-user flag overlay has resolved', () => {
+    // The flags present are the anonymous server snapshot until `ready`.
+    // Announcing against those and retracting is the flash the notice machinery
+    // exists to avoid.
+    flagsReady = false;
+    const { showsCopy, mounted } = renderCallSite();
+    expect(mounted).toBe(true);
+    expect(showsCopy).toBe(false);
+  });
+
+  test('renders nothing when there is no flag provider at all', () => {
+    flags = null;
+    const { showsCopy, mounted } = renderCallSite();
+    expect(mounted).toBe(true);
+    expect(showsCopy).toBe(false);
+  });
+});
+
+describe('the audience gate is independent of the other two', () => {
+  test('membership does not resurrect a dismissed notice', () => {
+    dismissedAlerts = ['remix-gallery-explainer'];
+    const { showsCopy, mounted } = renderCallSite();
+    expect(mounted).toBe(true);
+    expect(showsCopy).toBe(false);
+  });
+
+  test('membership does not render against an unresolved settings object', () => {
+    // `hasSettings`, not `isLoading`: the query has settled with no data, which
+    // is the errored-fetch shape.
+    settingsResolved = false;
+    const { showsCopy, mounted } = renderCallSite();
+    expect(mounted).toBe(true);
+    expect(showsCopy).toBe(false);
+  });
+
+  test('membership does not show the notice to a signed-out visitor', () => {
+    // Signed out there is nowhere to record a dismissal, so showing it would
+    // mean showing it forever.
+    currentUser = null;
+    const { showsCopy, mounted } = renderCallSite();
+    expect(mounted).toBe(true);
+    expect(showsCopy).toBe(false);
+  });
+});

--- a/src/components/Alerts/__tests__/notice-callsite-coverage.test.ts
+++ b/src/components/Alerts/__tests__/notice-callsite-coverage.test.ts
@@ -153,3 +153,80 @@ describe('feature-notice call-site ledger', () => {
     ).toEqual([]);
   });
 });
+
+/**
+ * 🔴 THE AUDIENCE LEDGER — a second population gate, for the same reason as the
+ * first.
+ *
+ * `useFeatureNotice` computes `isInAudience`, but a hook can only OFFER an
+ * answer; a call site that never reads it renders the notice to everyone and
+ * the suite stays green. That is phase 1's warning one level up — the field is
+ * read by the hook, and then the hook's answer is the thing nothing reads.
+ *
+ * WHAT THIS IS NOT: it is structural, and structural is weak. It cannot tell
+ * `if (!isInAudience) return null` from `if (isInAudience) return null`. The
+ * BEHAVIOURAL claim — a targeted notice is withheld from a non-member — is
+ * asserted against the hook's return value in
+ * `useFeatureNotice.audience.test.ts`, in this same project, and was
+ * mutation-checked. This gate exists only so that claim's population cannot
+ * silently grow a member that skips it.
+ */
+describe('feature-notice audience ledger', () => {
+  const actual = scanCallSites();
+
+  // 🔴 Hand-typed, like CALL_SITE_LEDGER above. Deriving this from the registry
+  // would make it agree with a notice that silently loses its audience.
+  const TARGETED_KEYS = ['remixGalleryExplainer'];
+
+  /** Files that must read the hook's audience answer, derived from the ledger. */
+  const filesReferencing = (key: string) =>
+    Object.keys(CALL_SITE_LEDGER).filter((f) => CALL_SITE_LEDGER[f].includes(key));
+
+  const readsAudience = (relFile: string) =>
+    /\bisInAudience\b/.test(stripComments(readFileSync(path.join(SRC, relFile), 'utf8')));
+
+  test('the hand-typed targeted set matches the registry', () => {
+    // Both directions. A notice gaining an audience with no row here would
+    // otherwise be unguarded; a notice LOSING one silently would leave this
+    // demanding a gate that no longer exists.
+    const fromRegistry = Object.entries(FEATURE_NOTICES)
+      .filter(([, notice]) => (notice as { audience?: unknown }).audience !== undefined)
+      .map(([key]) => key)
+      .sort();
+    expect(
+      fromRegistry,
+      'A notice gained or lost an `audience`. Update TARGETED_KEYS here, and make sure every ' +
+        'call site for it reads `isInAudience` from useFeatureNotice.'
+    ).toEqual([...TARGETED_KEYS].sort());
+  });
+
+  test('the audience scanner can see a consumer at all', () => {
+    // Positive control, and a real one: it names a file that DOES read the
+    // field and a file that legitimately does not. Without the second half a
+    // detector wired to `true` would pass.
+    expect(readsAudience('components/RemixGallery/RemixGalleryExplainer.tsx')).toBe(true);
+    expect(readsAudience('components/Alerts/NavTidyNotice.tsx')).toBe(false);
+  });
+
+  test('every call site of a TARGETED notice reads isInAudience', () => {
+    const unguarded = TARGETED_KEYS.flatMap((key) =>
+      filesReferencing(key)
+        .filter((file) => !readsAudience(file))
+        .map((file) => `${file} (notice: ${key})`)
+    );
+    expect(
+      unguarded,
+      'A call site renders a notice that declares an `audience` without reading `isInAudience` ' +
+        'from useFeatureNotice, so it would announce the feature to users who do not have it. ' +
+        'AND `isInAudience` into its render condition.'
+    ).toEqual([]);
+  });
+
+  test('a targeted notice actually has call sites to guard', () => {
+    // Positive control on the test above: `filesReferencing` returning [] would
+    // make an empty `unguarded` prove nothing.
+    for (const key of TARGETED_KEYS) {
+      expect(filesReferencing(key).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/components/Alerts/__tests__/notice-callsite.browser.test.tsx
+++ b/src/components/Alerts/__tests__/notice-callsite.browser.test.tsx
@@ -125,6 +125,11 @@ vi.mock('~/hooks/useCurrentUser', () => ({
 
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => mocks.state.features,
+  // `useFeatureNotice` imports this to answer a notice's `audience`. It must be
+  // present here even for the sites that declare none: an omitted export fails
+  // the whole file at COLLECTION, which reports as "no tests" rather than as a
+  // red test — see the AppProvider note below.
+  useOptionalFeatureFlags: () => mocks.state.features,
   useFeatureFlagsReady: () => true,
 }));
 
@@ -163,7 +168,10 @@ import { ReferralDashboardFull } from '~/components/Referrals/ReferralDashboardF
 beforeEach(() => {
   mocks.state.settings = { dismissedAlerts: [] };
   mocks.state.currentUser = { id: 1 };
-  mocks.state.features = {};
+  // `remixGallery` on by default: `remixGalleryExplainer` declares it as its
+  // `audience`, so a user without it is — correctly — not shown the notice at
+  // all, and every dismissal case below would have nothing to click.
+  mocks.state.features = { remixGallery: true };
   mocks.state.mutateCalls = [];
 });
 
@@ -315,6 +323,60 @@ describe('RemixGallery / RemixGalleryExplainer', () => {
     );
 
     await expect.element(page.getByTestId('remix-sentinel')).toBeVisible();
+    expect(document.querySelectorAll('[aria-label="Dismiss"]')).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // AUDIENCE. This notice is the first to declare one, so these two cases are
+  // the rendered-DOM statement of the whole feature: the announcement reaches
+  // the people who have the thing and nobody else.
+  //
+  // 🔴 They are NOT the gate. This project (`component`) is not what CI runs;
+  // the same claim is asserted against the hook's return value in
+  // `useFeatureNotice.audience.test.ts`, in the `unit` project, and THAT is the
+  // one that blocks a merge. These exist because a real render through the real
+  // component is the only place the composition
+  // `hasSettings && !isDismissed && isInAudience` is exercised end to end.
+  // ---------------------------------------------------------------------------
+  test('renders nothing for a user outside the `remixGallery` rollout', async () => {
+    // Nothing else changes: settings resolved, notice never dismissed. The flag
+    // is the only variable, which is what makes this attributable to it.
+    mocks.state.features = { remixGallery: false };
+    renderWithProviders(
+      <>
+        <RemixGalleryExplainer />
+        <span data-testid="remix-audience-sentinel">mounted</span>
+      </>
+    );
+
+    await expect.element(page.getByTestId('remix-audience-sentinel')).toBeVisible();
+    expect(document.querySelectorAll('[aria-label="Dismiss"]')).toHaveLength(0);
+    expect(document.body.textContent).not.toContain('remix gallery');
+  });
+
+  test('renders for a user inside the `remixGallery` rollout', async () => {
+    // The positive control for the case above. Without it, "nothing rendered"
+    // is indistinguishable from a component that renders nothing ever.
+    mocks.state.features = { remixGallery: true };
+    renderWithProviders(<RemixGalleryExplainer />);
+
+    await expect.element(page.getByRole('button', { name: 'Dismiss' })).toBeVisible();
+    expect(document.body.textContent).toContain('remix gallery');
+  });
+
+  test('an unrelated flag being on does not put a user in the audience', async () => {
+    // Pins that the gate reads `remixGallery` specifically rather than "some
+    // flag is set" — a distinct fixture flag, and one that is not the constant
+    // the assertion names.
+    mocks.state.features = { remixGallery: false, imageCardInfoButton: true };
+    renderWithProviders(
+      <>
+        <RemixGalleryExplainer />
+        <span data-testid="remix-unrelated-sentinel">mounted</span>
+      </>
+    );
+
+    await expect.element(page.getByTestId('remix-unrelated-sentinel')).toBeVisible();
     expect(document.querySelectorAll('[aria-label="Dismiss"]')).toHaveLength(0);
   });
 });

--- a/src/components/Alerts/__tests__/notice-registry.test.ts
+++ b/src/components/Alerts/__tests__/notice-registry.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'vitest';
+import type { FeatureNotice } from '~/components/Alerts/notice-registry';
 import {
   FEATURE_NOTICES,
   FEATURE_NOTICE_IDS,
+  isNoticeAudienceMatched,
   isNoticeDismissed,
 } from '~/components/Alerts/notice-registry';
 
@@ -121,5 +123,100 @@ describe('isNoticeDismissed', () => {
       isNoticeDismissed(['crypto-onramp-guidance'], FEATURE_NOTICES.cryptoOnrampGuidance)
     ).toBe(true);
     expect(isNoticeDismissed(['crypto-onramp-guidance'], FEATURE_NOTICES.navTidy)).toBe(false);
+  });
+});
+
+// =============================================================================
+// AUDIENCE TARGETING — the returned-value half.
+//
+// This is the gate itself, as a pure function, so the blocking `unit` project
+// can execute it. The hook that consumes it is covered by
+// `useFeatureNotice.audience.test.ts` (also `unit`, via happy-dom), and the
+// rendered component by `notice-callsite.browser.test.tsx` (project
+// `component`, which CI does NOT run). All three assert behaviour; none of them
+// asserts that the field exists.
+//
+// Fixtures name flags that are NOT `remixGallery`, the only audience the
+// registry currently declares — a fixture that could only ever produce the
+// production value cannot catch a mutant that hardcodes the production value.
+// The two targeted fixtures name DIFFERENT flags and are given DIFFERENT
+// answers, so "reads its own audience" is separable from "some flag was on".
+// =============================================================================
+
+describe('isNoticeAudienceMatched', () => {
+  const targetedAlpha: FeatureNotice = {
+    id: 'fixture-audience-alpha',
+    audience: { feature: 'imageCardInfoButton' },
+  };
+  const targetedBeta: FeatureNotice = {
+    id: 'fixture-audience-beta',
+    audience: { feature: 'appReviewPage' },
+  };
+  const untargeted: FeatureNotice = { id: 'fixture-audience-gamma' };
+
+  /** Alpha's flag on, beta's off — one map, two opposite answers. */
+  const flags = { imageCardInfoButton: true, appReviewPage: false };
+
+  describe('a notice with no audience', () => {
+    // 🔴 INVARIANT guards: they pin that the eight untargeted notices are
+    // unaffected by targeting existing. They pass with the audience branch
+    // deleted, by design, so they are not the mutation evidence.
+    test('matches even when every flag is off', () => {
+      expect(isNoticeAudienceMatched(untargeted, { imageCardInfoButton: false }, true)).toBe(true);
+    });
+
+    test('matches before the flag overlay is ready', () => {
+      expect(isNoticeAudienceMatched(untargeted, flags, false)).toBe(true);
+    });
+
+    test('matches with no flags at all', () => {
+      expect(isNoticeAudienceMatched(untargeted, null, true)).toBe(true);
+      expect(isNoticeAudienceMatched(untargeted, undefined, true)).toBe(true);
+    });
+  });
+
+  describe('a notice with an audience', () => {
+    test('matches a user its own flag is on for', () => {
+      expect(isNoticeAudienceMatched(targetedAlpha, flags, true)).toBe(true);
+    });
+
+    test('does NOT match a user its own flag is off for', () => {
+      expect(isNoticeAudienceMatched(targetedBeta, flags, true)).toBe(false);
+    });
+
+    test('reads ITS OWN flag, not whichever flag happens to be on', () => {
+      // Same map, same readiness, opposite results. A body that ignored
+      // `audience.feature` could not produce both.
+      expect(isNoticeAudienceMatched(targetedAlpha, flags, true)).toBe(true);
+      expect(isNoticeAudienceMatched(targetedBeta, flags, true)).toBe(false);
+      // …and swapping the answers swaps the results, so neither is a constant.
+      const swapped = { imageCardInfoButton: false, appReviewPage: true };
+      expect(isNoticeAudienceMatched(targetedAlpha, swapped, true)).toBe(false);
+      expect(isNoticeAudienceMatched(targetedBeta, swapped, true)).toBe(true);
+    });
+
+    test('a flag missing from the overlay is not membership', () => {
+      // Absent is not the same as false, and must not read as "in".
+      expect(isNoticeAudienceMatched(targetedAlpha, {}, true)).toBe(false);
+    });
+
+    test('fails closed before the per-user overlay resolves', () => {
+      // The map here says the user IS in the audience; readiness is what
+      // withholds it. Announcing against the anonymous snapshot and retracting
+      // is the flash this exists to avoid.
+      expect(isNoticeAudienceMatched(targetedAlpha, flags, false)).toBe(false);
+    });
+
+    test('fails closed with no flags at all', () => {
+      expect(isNoticeAudienceMatched(targetedAlpha, null, true)).toBe(false);
+      expect(isNoticeAudienceMatched(targetedAlpha, undefined, true)).toBe(false);
+    });
+
+    test('a non-boolean-true value is not membership', () => {
+      // The overlay is `Record<key, boolean>`, but it is assembled server-side
+      // and merged with an SSR snapshot; a truthy non-`true` must not pass.
+      const dirty = { imageCardInfoButton: 'yes' } as unknown as Record<string, boolean>;
+      expect(isNoticeAudienceMatched(targetedAlpha, dirty, true)).toBe(false);
+    });
   });
 });

--- a/src/components/Alerts/__tests__/useFeatureNotice.audience.test.ts
+++ b/src/components/Alerts/__tests__/useFeatureNotice.audience.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import * as React from 'react';
+import type { act as actType } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import type * as Trpc from '~/utils/trpc';
+import type { FeatureNotice } from '~/components/Alerts/notice-registry';
+
+const act = (React as unknown as { act: typeof actType }).act;
+
+// Tells React this is an act-aware environment, so the renders below don't each
+// log "not configured to support act(...)". Purely output noise; nothing about
+// what is asserted depends on it.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * 🔴 AUDIENCE TARGETING, ASSERTED AS RETURNED BEHAVIOUR — and asserted HERE, in
+ * the `unit` project, deliberately.
+ *
+ * The notice components are covered by `*.browser.test.tsx` files, which are a
+ * separate Vitest project (`component`, real Chromium). CI runs
+ * `vitest run --project unit`. A browser-only assertion is therefore reassurance
+ * and not a gate, so the load-bearing claim — *a targeted notice is not offered
+ * to a non-member and is offered to a member* — lives in a `.test.ts` that the
+ * blocking job executes. `happy-dom` + `react-dom/client` is the pattern this
+ * repo already uses to render a hook in the node project (see
+ * `useDailyBoostReward.test.ts`).
+ *
+ * What every test below reads is the hook's RETURN VALUE, never the registry
+ * field. `notice.audience` existing proves nothing; phase 1's warning was
+ * precisely that "an unread field on a definition looks like a gate and gates
+ * nothing". Deleting the branch in `isNoticeAudienceMatched` has to turn these
+ * red, and the mutation was run: see the PR description.
+ *
+ * FIXTURES. The notices are hand-built rather than taken from the registry, so
+ * the cases stay pairwise distinct and stay distinct from `remixGallery` — the
+ * one constant the registry names. A fixture that could only ever be the
+ * production value cannot catch a mutant that hardcodes the production value.
+ * `TARGETED_ON` and `TARGETED_OFF` name DIFFERENT flags, and the flag map below
+ * gives them DIFFERENT answers, so an implementation that ignores
+ * `audience.feature` and returns "some flag was true" fails.
+ */
+
+let dismissedAlerts: string[] | undefined;
+let settingsResolved = true;
+let flags: Record<string, boolean> | null;
+let flagsReady: boolean;
+const dismissMutate = vi.fn();
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof Trpc>()),
+  trpc: {
+    useUtils: () => ({
+      user: {
+        getSettings: {
+          cancel: vi.fn(),
+          getData: vi.fn(),
+          setData: vi.fn(),
+          invalidate: vi.fn(),
+        },
+      },
+    }),
+    user: {
+      getSettings: {
+        useQuery: () => ({
+          data: settingsResolved ? { dismissedAlerts } : undefined,
+          isLoading: false,
+        }),
+      },
+      dismissAlert: { useMutation: () => ({ mutate: dismissMutate }) },
+    },
+  },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 91 }) }));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useOptionalFeatureFlags: () => flags,
+  useFeatureFlagsReady: () => flagsReady,
+}));
+
+const { useFeatureNotice } = await import('~/components/Alerts/useFeatureNotice');
+
+/** Two targeted notices naming DIFFERENT flags, and one that names none. */
+const TARGETED_ON: FeatureNotice = {
+  id: 'fixture-notice-alpha',
+  audience: { feature: 'imageCardInfoButton' },
+};
+const TARGETED_OFF: FeatureNotice = {
+  id: 'fixture-notice-beta',
+  audience: { feature: 'appReviewPage' },
+};
+const UNTARGETED: FeatureNotice = { id: 'fixture-notice-gamma' };
+
+/**
+ * The flag answers. `imageCardInfoButton` on, `appReviewPage` off — so "is the
+ * user in THIS notice's audience" and "is the user in ANY audience" give
+ * different answers, and only the first one passes.
+ */
+const FLAGS = { imageCardInfoButton: true, appReviewPage: false };
+
+function readHook(notice: FeatureNotice) {
+  let result: ReturnType<typeof useFeatureNotice> | undefined;
+  const Probe = () => {
+    result = useFeatureNotice(notice);
+    return null;
+  };
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  act(() => root.render(React.createElement(Probe)));
+  act(() => root.unmount());
+  return result!;
+}
+
+/** What a call site actually composes. This is the claim that matters. */
+const wouldRender = (notice: FeatureNotice) => {
+  const { hasSettings, isDismissed, isInAudience } = readHook(notice);
+  return hasSettings && !isDismissed && isInAudience;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dismissedAlerts = [];
+  settingsResolved = true;
+  flags = { ...FLAGS };
+  flagsReady = true;
+});
+
+describe('a targeted notice reaches its audience and nobody else', () => {
+  test('NOT offered to a user the notice’s flag is off for', () => {
+    expect(wouldRender(TARGETED_OFF)).toBe(false);
+    expect(readHook(TARGETED_OFF).isInAudience).toBe(false);
+  });
+
+  test('offered to a user the notice’s flag is on for', () => {
+    expect(wouldRender(TARGETED_ON)).toBe(true);
+    expect(readHook(TARGETED_ON).isInAudience).toBe(true);
+  });
+
+  test('the SAME user gets opposite answers for the two notices', () => {
+    // One render pass, one flag map, two notices. An implementation that
+    // ignores `audience.feature` — returning a constant, or "any flag is on" —
+    // cannot produce two different answers here.
+    expect(readHook(TARGETED_ON).isInAudience).toBe(true);
+    expect(readHook(TARGETED_OFF).isInAudience).toBe(false);
+  });
+
+  test('a flag absent from the overlay is not an audience', () => {
+    // Absent, not false. `undefined` must not read as membership.
+    flags = { imageCardInfoButton: true };
+    expect(wouldRender(TARGETED_OFF)).toBe(false);
+  });
+
+  test('membership does not resurrect a dismissed notice', () => {
+    // The two gates are independent: being in the audience is not permission to
+    // re-show something the user closed.
+    dismissedAlerts = ['fixture-notice-alpha'];
+    expect(wouldRender(TARGETED_ON)).toBe(false);
+    expect(readHook(TARGETED_ON).isInAudience).toBe(true);
+  });
+});
+
+describe('a targeted notice fails CLOSED while the answer is unknown', () => {
+  test('not offered before the per-user flag overlay has resolved', () => {
+    // The flags present are the anonymous server snapshot until `ready`.
+    // Announcing against those and retracting is the flash the notice
+    // machinery exists to avoid.
+    flagsReady = false;
+    expect(wouldRender(TARGETED_ON)).toBe(false);
+  });
+
+  test('not offered when there is no flag provider at all', () => {
+    flags = null;
+    expect(wouldRender(TARGETED_ON)).toBe(false);
+  });
+});
+
+describe('an untargeted notice behaves exactly as it did before targeting existed', () => {
+  // 🔴 SCOPE HONESTY: these are INVARIANT guards, not regression tests. They
+  // pin that the eight notices carrying no `audience` are untouched by the
+  // field's introduction. They stay green with the audience branch deleted —
+  // that is the point of them, and it is why they are not the mutation
+  // evidence.
+  test('offered even though every flag in the overlay is off', () => {
+    flags = { imageCardInfoButton: false, appReviewPage: false };
+    expect(wouldRender(UNTARGETED)).toBe(true);
+  });
+
+  test('offered before the flag overlay resolves', () => {
+    flagsReady = false;
+    expect(wouldRender(UNTARGETED)).toBe(true);
+  });
+
+  test('offered with no flag provider at all', () => {
+    flags = null;
+    expect(wouldRender(UNTARGETED)).toBe(true);
+  });
+
+  test('still hidden once dismissed, and still hidden before settings resolve', () => {
+    dismissedAlerts = ['fixture-notice-gamma'];
+    expect(wouldRender(UNTARGETED)).toBe(false);
+
+    dismissedAlerts = [];
+    settingsResolved = false;
+    expect(wouldRender(UNTARGETED)).toBe(false);
+    // `hasSettings`, not `isLoading`: the query has settled (isLoading false)
+    // with no data, which is the errored-fetch shape. It must not render.
+    expect(readHook(UNTARGETED).isLoading).toBe(false);
+    expect(readHook(UNTARGETED).hasSettings).toBe(false);
+  });
+});
+
+describe('the dismissal path is unchanged by targeting', () => {
+  test('dismiss sends the notice’s own id', () => {
+    readHook(TARGETED_ON).dismiss();
+    expect(dismissMutate).toHaveBeenCalledWith({ alertId: 'fixture-notice-alpha' });
+  });
+
+  test('restore sends the notice’s own id with dismiss false', () => {
+    readHook(TARGETED_OFF).restore();
+    expect(dismissMutate).toHaveBeenCalledWith({
+      alertId: 'fixture-notice-beta',
+      dismiss: false,
+    });
+  });
+});

--- a/src/components/Alerts/__tests__/useFeatureNotice.audience.test.ts
+++ b/src/components/Alerts/__tests__/useFeatureNotice.audience.test.ts
@@ -45,6 +45,7 @@ let dismissedAlerts: string[] | undefined;
 let settingsResolved = true;
 let flags: Record<string, boolean> | null;
 let flagsReady: boolean;
+let currentUser: { id: number } | null;
 const dismissMutate = vi.fn();
 
 vi.mock('~/utils/trpc', async (importOriginal) => ({
@@ -62,8 +63,12 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
     }),
     user: {
       getSettings: {
-        useQuery: () => ({
-          data: settingsResolved ? { dismissedAlerts } : undefined,
+        // `enabled` is honoured rather than ignored: the hook disables this
+        // query without a signed-in user, so a mock that always returns data
+        // would report `hasSettings: true` for a visitor production leaves at
+        // `false` — and the signed-out case below asserts against it.
+        useQuery: (_input?: unknown, opts?: { enabled?: boolean }) => ({
+          data: settingsResolved && (opts?.enabled ?? true) ? { dismissedAlerts } : undefined,
           isLoading: false,
         }),
       },
@@ -72,7 +77,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   },
 }));
 
-vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 91 }) }));
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => currentUser }));
 
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useOptionalFeatureFlags: () => flags,
@@ -122,6 +127,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   dismissedAlerts = [];
   settingsResolved = true;
+  currentUser = { id: 91 };
   flags = { ...FLAGS };
   flagsReady = true;
 });
@@ -172,6 +178,27 @@ describe('a targeted notice fails CLOSED while the answer is unknown', () => {
   test('not offered when there is no flag provider at all', () => {
     flags = null;
     expect(wouldRender(TARGETED_ON)).toBe(false);
+  });
+
+  test('a SIGNED-OUT visitor is in no audience, however ready the flags claim to be', () => {
+    // 🔴 `flagsReady` cannot close this one. It is
+    // `!session.data || isSuccess || isError`, so logged out it is `true` BY
+    // CONSTRUCTION — against the anonymous snapshot. A pure
+    // `isNoticeAudienceMatched` handed those two arguments cannot tell that
+    // apart from a resolved per-user answer, so the hook ANDs in `!!currentUser`
+    // and this pins it.
+    //
+    // Belt-and-braces rather than the only guard: `hasSettings` is already
+    // false signed out (the settings query is disabled without a user), which
+    // is why this changes nothing at any call site composing as documented.
+    currentUser = null;
+    flags = { imageCardInfoButton: true };
+    flagsReady = true;
+    expect(readHook(TARGETED_ON).isInAudience).toBe(false);
+    expect(wouldRender(TARGETED_ON)).toBe(false);
+    // The other gate that already covered this, asserted separately so the two
+    // claims do not collapse into one.
+    expect(readHook(TARGETED_ON).hasSettings).toBe(false);
   });
 });
 

--- a/src/components/Alerts/__tests__/useFeatureNotice.browser.test.tsx
+++ b/src/components/Alerts/__tests__/useFeatureNotice.browser.test.tsx
@@ -25,6 +25,9 @@ const mocks = vi.hoisted(() => {
     invalidateCount: 0,
     mutateCalls: [] as Array<{ alertId: string; dismiss?: boolean }>,
     queryEnabledSeen: [] as (boolean | undefined)[],
+    /** The per-user flag overlay a notice's `audience` is resolved against. */
+    features: {} as Record<string, boolean> | null,
+    flagsReady: true,
   };
 
   const listeners = new Set<() => void>();
@@ -94,6 +97,17 @@ vi.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => mocks.state.currentUser,
 }));
 
+// `useFeatureNotice` reads the per-user flag overlay to answer a notice's
+// `audience`. Mocked rather than left to the real provider so this file keeps
+// controlling every input it asserts on — and because an export a consumer
+// imports must exist in the factory or the file fails at COLLECTION, which
+// reports as "no tests" instead of as a failure.
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => mocks.state.features,
+  useOptionalFeatureFlags: () => mocks.state.features,
+  useFeatureFlagsReady: () => mocks.state.flagsReady,
+}));
+
 import { renderWithProviders } from '../../../../test/component-setup';
 import { FEATURE_NOTICES } from '~/components/Alerts/notice-registry';
 import { useFeatureNotice } from '~/components/Alerts/useFeatureNotice';
@@ -108,7 +122,7 @@ function Probe({
   enabled?: boolean;
   testId?: string;
 }) {
-  const { isDismissed, hasSettings, isLoading, dismiss, restore } = useFeatureNotice(
+  const { isDismissed, hasSettings, isLoading, isInAudience, dismiss, restore } = useFeatureNotice(
     notice,
     enabled === undefined ? undefined : { enabled }
   );
@@ -120,6 +134,7 @@ function Probe({
       data-dismissed={String(isDismissed)}
       data-has-settings={String(hasSettings)}
       data-loading={String(isLoading)}
+      data-in-audience={String(isInAudience)}
     >
       <button type="button" onClick={dismiss} aria-label={`dismiss-${testId}`}>
         dismiss
@@ -140,6 +155,7 @@ const probeState = async (testId = 'probe') => {
     dismissed: el.getAttribute('data-dismissed'),
     hasSettings: el.getAttribute('data-has-settings'),
     loading: el.getAttribute('data-loading'),
+    inAudience: el.getAttribute('data-in-audience'),
   };
 };
 
@@ -151,6 +167,8 @@ beforeEach(() => {
   mocks.state.invalidateCount = 0;
   mocks.state.mutateCalls = [];
   mocks.state.queryEnabledSeen = [];
+  mocks.state.features = {};
+  mocks.state.flagsReady = true;
 });
 
 describe('useFeatureNotice — reading dismissed state', () => {
@@ -160,6 +178,7 @@ describe('useFeatureNotice — reading dismissed state', () => {
       dismissed: 'false',
       hasSettings: 'true',
       loading: 'false',
+      inAudience: 'true',
     });
   });
 
@@ -194,6 +213,7 @@ describe('useFeatureNotice — hasSettings vs isLoading', () => {
       dismissed: 'false',
       hasSettings: 'false',
       loading: 'false',
+      inAudience: 'true',
     });
   });
 
@@ -205,6 +225,7 @@ describe('useFeatureNotice — hasSettings vs isLoading', () => {
       dismissed: 'false',
       hasSettings: 'false',
       loading: 'true',
+      inAudience: 'true',
     });
   });
 
@@ -215,6 +236,7 @@ describe('useFeatureNotice — hasSettings vs isLoading', () => {
       dismissed: 'false',
       hasSettings: 'true',
       loading: 'false',
+      inAudience: 'true',
     });
   });
 });
@@ -327,5 +349,75 @@ describe('useFeatureNotice — writing', () => {
       expect(mocks.state.settings).toEqual({ dismissedAlerts: ['nav-tidy-notice'] });
       expect(mocks.state.invalidateCount).toBe(1);
     });
+  });
+});
+
+describe('useFeatureNotice — audience targeting', () => {
+  // 🔴 The same claim as `useFeatureNotice.audience.test.ts`, driven through a
+  // real browser render instead of happy-dom. That file is the GATE (project
+  // `unit`, which is what CI runs); this is the corroborating end-to-end pass.
+  //
+  // `remixGalleryExplainer` is the only registry entry that declares an
+  // audience, and `navTidy` declares none — so the pair below moves BOTH ways
+  // from one flag map, which a constant cannot do.
+  const TARGETED = FEATURE_NOTICES.remixGalleryExplainer;
+  const UNTARGETED = FEATURE_NOTICES.navTidy;
+
+  test('a targeted notice is out of audience when its flag is off', async () => {
+    mocks.state.features = { remixGallery: false };
+    renderWithProviders(<Probe notice={TARGETED} testId="targeted" />);
+    expect((await probeState('targeted')).inAudience).toBe('false');
+  });
+
+  test('a targeted notice is in audience when its flag is on', async () => {
+    mocks.state.features = { remixGallery: true };
+    renderWithProviders(<Probe notice={TARGETED} testId="targeted" />);
+    expect((await probeState('targeted')).inAudience).toBe('true');
+  });
+
+  test('targeted and untargeted notices disagree under ONE flag map', async () => {
+    // The strongest shape available here: one render, one set of flags, two
+    // notices, opposite answers. An implementation that returned a constant —
+    // or that read "is any flag on" — cannot produce this.
+    mocks.state.features = { remixGallery: false, imageCardInfoButton: true };
+    renderWithProviders(
+      <>
+        <Probe notice={TARGETED} testId="targeted" />
+        <Probe notice={UNTARGETED} testId="untargeted" />
+      </>
+    );
+    expect((await probeState('targeted')).inAudience).toBe('false');
+    expect((await probeState('untargeted')).inAudience).toBe('true');
+  });
+
+  test('a targeted notice fails closed until the per-user overlay is ready', async () => {
+    // The flags say the user IS in the audience; readiness is the only
+    // variable. Announcing against the anonymous snapshot then retracting is
+    // the flash this withholding exists to prevent.
+    mocks.state.features = { remixGallery: true };
+    mocks.state.flagsReady = false;
+    renderWithProviders(<Probe notice={TARGETED} testId="targeted" />);
+    expect((await probeState('targeted')).inAudience).toBe('false');
+  });
+
+  test('an untargeted notice is unaffected by readiness or by missing flags', async () => {
+    // INVARIANT guard: pins that the eight untargeted notices are untouched by
+    // targeting existing. Stays green if the audience branch is deleted.
+    mocks.state.features = null;
+    mocks.state.flagsReady = false;
+    renderWithProviders(<Probe notice={UNTARGETED} testId="untargeted" />);
+    expect((await probeState('untargeted')).inAudience).toBe('true');
+  });
+
+  test('audience does not disturb dismissal state', async () => {
+    // The two gates are independent: out of audience is not "dismissed", and a
+    // dismissal is still recorded against the notice's own id.
+    mocks.state.features = { remixGallery: false };
+    mocks.state.settings = { dismissedAlerts: [] };
+    renderWithProviders(<Probe notice={TARGETED} testId="targeted" />);
+    const state = await probeState('targeted');
+    expect(state.inAudience).toBe('false');
+    expect(state.dismissed).toBe('false');
+    expect(state.hasSettings).toBe('true');
   });
 });

--- a/src/components/Alerts/notice-registry.ts
+++ b/src/components/Alerts/notice-registry.ts
@@ -47,10 +47,40 @@ import type { FeatureFlagKey } from '~/server/services/feature-flags.service';
  *    early-adopter cohort is announceable") would conflate *who can see a
  *    feature* with *who should be told about it*, and leave no way to roll out
  *    quietly to that cohort — which is most of what a staged cohort is for.
- * 2. The value is read from the per-user flag overlay, which is computed from
- *    the caller's real session. That is the only path on which a
- *    segment-scoped flag can match; a keyed evaluation with no context
- *    silently answers "not in the segment" for everyone.
+ * 2. The value is read through `useOptionalFeatureFlags`, i.e. whatever
+ *    `FeatureFlagsProvider` resolved for THIS session. Never a keyed
+ *    evaluation, which has no context and so silently answers "not in the
+ *    segment" for everyone.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🔴 WHICH PATH A FLAG ARRIVES ON — read this before adding a second audience.
+ *
+ * `FeatureFlagsProvider` hands consumers `{ ...ssrFlags, ...toggleableOverlay }`.
+ * BOTH halves are computed server-side from the caller's real session, so a
+ * segment-scoped flag can match on either; which one carries a given flag is
+ * decided solely by whether its definition in `feature-flags.service.ts` sets
+ * `toggleable: true`:
+ *
+ * - NOT `toggleable` (the `flags` prop, seeded at SSR by `getFeatureFlagsAsync`
+ *   → `_app`). Resolved once per request against the user's identity, tier,
+ *   cohort, host and region, INCLUDING Flipt segment evaluation, and present
+ *   from the first client frame. `remixGallery` — the only flag any notice
+ *   names today — is this kind: `{ availability: ['mod'], fliptKey:
+ *   'remix-gallery' }`, no `toggleable`.
+ * - `toggleable: true` (the `userFlags` overlay, from `user.getFeatureFlags` /
+ *   `computeUserFeatureFlagsOverlay`). The user's own on/off CHOICE, layered
+ *   over the SSR flags. `computeUserFeatureFlagsOverlay` filters to toggleable
+ *   keys, so a non-toggleable flag never appears in it at all.
+ *
+ * The consequence worth knowing, because it is invisible from here: for a
+ * non-toggleable flag the `flagsReady` guard in `isNoticeAudienceMatched` can
+ * DEFER a render but cannot change its answer — the SSR flags already hold the
+ * per-user verdict and the overlay resolving does not revise it. So today, for
+ * the one notice that ships, that guard costs at most a frame and buys nothing.
+ * It becomes load-bearing the moment a notice names a `toggleable` flag, which
+ * is the case it was written for. It is deliberately not deleted for that
+ * reason — but do not read the shipped notice as evidence that it works.
+ * ─────────────────────────────────────────────────────────────────────────────
  */
 export type NoticeAudience = {
   /**
@@ -148,15 +178,33 @@ export function isNoticeDismissed(
  * to someone who has it is a missed nudge, announcing one to someone who does
  * not have it is a broken promise.
  *
- * - `flagsReady` false → the per-user flag overlay has not resolved, so `flags`
- *   is still the anonymous server-rendered snapshot. Reading it would announce
- *   against defaults and then retract, which is the flash the notice machinery
- *   exists to avoid.
+ * - `flagsReady` false → the toggleable overlay query has not settled, so a
+ *   toggleable flag's value is still whatever the SSR snapshot defaulted it to.
+ *   Reading it would announce against defaults and then retract, which is the
+ *   flash the notice machinery exists to avoid.
  * - `flags` null → rendered outside the flag provider, so there is no answer at
  *   all. Treat that as "not in the audience" rather than as "no gate".
  *
- * @param flags      The resolved per-user overlay, or null outside a provider.
- * @param flagsReady Whether that overlay is the user's, not the anon snapshot.
+ * 🔴 `flagsReady` IS NOT A CLAIM THAT THE FLAGS ARE THIS USER'S. It is
+ * `!session.data || isSuccess || isError` (see `FeatureFlagsProvider`), and it
+ * is `true` in two states where the overlay is NOT the user's:
+ *
+ * - the `isError` arm — the overlay query FAILED (`retry: 0`), `userFeatures`
+ *   falls back to `{}`, and the merged flags are host-level SSR only;
+ * - logged out — no session, so `ready` is true against the anonymous snapshot.
+ *
+ * Both are harmless for a NON-toggleable flag, whose SSR value is already the
+ * per-user verdict. For a toggleable one they mean this function can be handed
+ * a default and told it is resolved, i.e. it FAILS OPEN in exactly the case the
+ * `flagsReady` argument exists to close. Anyone giving a notice a `toggleable`
+ * audience has to close that here — the anon half is already closed one level
+ * up, where `useFeatureNotice` ANDs in `!!currentUser`.
+ *
+ * @param flags      The provider's resolved flags (SSR flags + toggleable
+ *                   overlay), or null outside a provider.
+ * @param flagsReady Whether the toggleable overlay query has SETTLED — success,
+ *                   error, or no session at all. See the warning above: this is
+ *                   weaker than "the overlay is the user's".
  */
 export function isNoticeAudienceMatched(
   notice: FeatureNotice,

--- a/src/components/Alerts/notice-registry.ts
+++ b/src/components/Alerts/notice-registry.ts
@@ -25,13 +25,40 @@
  * reason.
  * ─────────────────────────────────────────────────────────────────────────────
  *
- * WHERE AUDIENCE TARGETING GOES (deliberately not here yet): add an optional
- * `audience` field to `FeatureNotice` below and branch on it inside
- * `useFeatureNotice`'s returned `isDismissed`/visibility. It is omitted today
- * because nothing reads it — an unread field on a definition looks like a gate
- * and gates nothing. The early-adopter session flag it would consume is being
- * added separately; wiring the two together is a follow-up.
+ * AUDIENCE TARGETING (the follow-up this header used to describe as pending, now
+ * built). A notice may name the feature flag it announces via `audience`, and
+ * `useFeatureNotice` returns `isInAudience` off it. The rule the header laid
+ * down still holds and is what the tests enforce: the field is READ, and it
+ * changes what renders. `isNoticeAudienceMatched` below is that read, and
+ * `useFeatureNotice.audience.test.ts` asserts the hook's returned value moves
+ * with it rather than asserting the field exists.
  */
+
+import type { FeatureFlagKey } from '~/server/services/feature-flags.service';
+
+/**
+ * Who a notice is FOR — as opposed to who can see the feature it describes.
+ *
+ * Deliberately a resolved feature-flag key rather than a cohort name or a
+ * naming convention. Two properties come out of that choice:
+ *
+ * 1. "Is this flag worth announcing?" is a LOOKUP in this file, so it is
+ *    reviewed like any other code change. A convention ("anything targeting the
+ *    early-adopter cohort is announceable") would conflate *who can see a
+ *    feature* with *who should be told about it*, and leave no way to roll out
+ *    quietly to that cohort — which is most of what a staged cohort is for.
+ * 2. The value is read from the per-user flag overlay, which is computed from
+ *    the caller's real session. That is the only path on which a
+ *    segment-scoped flag can match; a keyed evaluation with no context
+ *    silently answers "not in the segment" for everyone.
+ */
+export type NoticeAudience = {
+  /**
+   * The flag whose holders should be told. The notice renders only for a user
+   * this flag is ON for, as resolved for their own session.
+   */
+  readonly feature: FeatureFlagKey;
+};
 
 export type FeatureNotice = {
   /**
@@ -39,6 +66,11 @@ export type FeatureNotice = {
    * 🔴 Production data — see the file header before touching one.
    */
   readonly id: string;
+  /**
+   * Optional. Omitted means "everyone who reaches the call site" — the
+   * behaviour every notice had before targeting existed, and still has.
+   */
+  readonly audience?: NoticeAudience;
 };
 
 export const FEATURE_NOTICES = {
@@ -50,8 +82,22 @@ export const FEATURE_NOTICES = {
   cryptoOnrampGuidance: { id: 'crypto-onramp-guidance' },
   /** Blue-buzz rewards banner inside the buy-buzz modal. */
   earnBlueBuzzRewards: { id: 'earn-blue-buzz-rewards' },
-  /** Inline explainer at the top of a remix gallery. */
-  remixGalleryExplainer: { id: 'remix-gallery-explainer' },
+  /**
+   * Inline explainer at the top of a remix gallery.
+   *
+   * The first targeted notice. The remix gallery is a staged rollout — a
+   * feature a user could not previously see — so the explainer announcing it is
+   * only ever news to someone the `remixGallery` flag is on for.
+   *
+   * Its mount site gates on the same flag today, so in production this is
+   * defence in depth rather than a change in who sees it. What it buys is that
+   * the gate now travels with the NOTICE instead of living in one parent: a
+   * second mount site cannot forget it, because the hook applies it.
+   */
+  remixGalleryExplainer: {
+    id: 'remix-gallery-explainer',
+    audience: { feature: 'remixGallery' },
+  },
   /** Referral dashboard (lite): the 3-card onboarding stepper. */
   referralLiteOnboarding: { id: 'referral-lite-onboarding' },
   /**
@@ -89,4 +135,36 @@ export function isNoticeDismissed(
   notice: FeatureNotice
 ): boolean {
   return (dismissedAlerts ?? []).includes(notice.id);
+}
+
+/**
+ * Is this user in the notice's audience?
+ *
+ * `true` for every notice with no `audience` — that is the pre-targeting
+ * behaviour, and it must stay exactly that for the eight untargeted notices.
+ *
+ * For a targeted notice this FAILS CLOSED in both of the ways it can be unsure,
+ * because the cost of the two errors is not symmetric: not announcing a feature
+ * to someone who has it is a missed nudge, announcing one to someone who does
+ * not have it is a broken promise.
+ *
+ * - `flagsReady` false → the per-user flag overlay has not resolved, so `flags`
+ *   is still the anonymous server-rendered snapshot. Reading it would announce
+ *   against defaults and then retract, which is the flash the notice machinery
+ *   exists to avoid.
+ * - `flags` null → rendered outside the flag provider, so there is no answer at
+ *   all. Treat that as "not in the audience" rather than as "no gate".
+ *
+ * @param flags      The resolved per-user overlay, or null outside a provider.
+ * @param flagsReady Whether that overlay is the user's, not the anon snapshot.
+ */
+export function isNoticeAudienceMatched(
+  notice: FeatureNotice,
+  flags: Partial<Record<FeatureFlagKey, boolean>> | null | undefined,
+  flagsReady: boolean
+): boolean {
+  const { audience } = notice;
+  if (!audience) return true;
+  if (!flagsReady) return false;
+  return flags?.[audience.feature] === true;
 }

--- a/src/components/Alerts/useFeatureNotice.ts
+++ b/src/components/Alerts/useFeatureNotice.ts
@@ -21,11 +21,18 @@ export type UseFeatureNoticeResult = {
   /**
    * This user is in the notice's `audience`.
    *
-   * Always `true` for a notice that declares no audience, so an untargeted
-   * notice is unaffected by targeting existing. For a targeted one it is the
-   * per-user answer to the flag the notice names, and it fails closed while the
-   * flag overlay is unresolved — AND it into the render condition exactly like
-   * `hasSettings`.
+   * `true` for a notice that declares no audience whenever there is a signed-in
+   * user, so an untargeted notice is unaffected by targeting existing. For a
+   * targeted one it is the per-user answer to the flag the notice names, and it
+   * fails closed while that answer is unknown — AND it into the render condition
+   * exactly like `hasSettings`.
+   *
+   * 🔴 `false` for a SIGNED-OUT visitor, for every notice. There is no user to
+   * be in an audience, and `flagsReady` does NOT say otherwise — it is `true`
+   * for a logged-out visitor by construction (see `FeatureFlagsProvider`), so
+   * the flags on offer there are the anonymous snapshot. That costs nothing at
+   * any call site that composes as documented: `hasSettings` is already `false`
+   * signed out, because the settings query is disabled without a user.
    */
   isInAudience: boolean;
   /** Persist a dismissal, optimistically. */
@@ -79,10 +86,13 @@ export function useFeatureNotice(
   const currentUser = useCurrentUser();
   const queryEnabled = enabled && !!currentUser;
 
-  // 🔴 The per-user overlay, NOT a keyed flag evaluation. This is the only read
-  // that carries the caller's own session, and therefore the only one on which a
-  // segment-scoped flag can match at all — an evaluation with no context answers
-  // "not in the segment" for every user, uniformly and silently.
+  // 🔴 The provider's RESOLVED flags, NOT a keyed flag evaluation. What the
+  // provider hands out is `{ ...ssrFlags, ...toggleableOverlay }`, and BOTH
+  // halves are computed server-side from the caller's own session — which is
+  // what makes a segment-scoped flag able to match at all. A keyed evaluation
+  // with no context answers "not in the segment" for every user, uniformly and
+  // silently. Which half a given flag arrives on depends only on whether it is
+  // declared `toggleable`; see `NoticeAudience` in the registry.
   const featureFlags = useOptionalFeatureFlags();
   const flagsReady = useFeatureFlagsReady();
 
@@ -119,7 +129,13 @@ export function useFeatureNotice(
     isDismissed: isNoticeDismissed(settings?.dismissedAlerts, notice),
     hasSettings: !!settings,
     isLoading,
-    isInAudience: isNoticeAudienceMatched(notice, featureFlags, flagsReady),
+    // 🔴 `!!currentUser` is a gate `isNoticeAudienceMatched` cannot apply for
+    // itself: it is handed `flagsReady`, which is TRUE for a logged-out visitor
+    // (`!session.data` — see `FeatureFlagsProvider`), so from inside the pure
+    // function the anonymous snapshot is indistinguishable from a resolved
+    // per-user one. Answering "in the audience" for someone with no session is
+    // the one thing this must never do.
+    isInAudience: !!currentUser && isNoticeAudienceMatched(notice, featureFlags, flagsReady),
     // `dismiss` omits the flag and `restore` sends `false`, matching the wire
     // payloads these call sites have always sent.
     dismiss: () => mutation.mutate({ alertId: notice.id }),

--- a/src/components/Alerts/useFeatureNotice.ts
+++ b/src/components/Alerts/useFeatureNotice.ts
@@ -1,7 +1,8 @@
 import { trpc } from '~/utils/trpc';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import type { FeatureNotice } from '~/components/Alerts/notice-registry';
-import { isNoticeDismissed } from '~/components/Alerts/notice-registry';
+import { isNoticeAudienceMatched, isNoticeDismissed } from '~/components/Alerts/notice-registry';
+import { useFeatureFlagsReady, useOptionalFeatureFlags } from '~/providers/FeatureFlagsProvider';
 
 export type UseFeatureNoticeResult = {
   /** The notice's id is present in the user's stored `dismissedAlerts`. */
@@ -17,6 +18,16 @@ export type UseFeatureNoticeResult = {
   hasSettings: boolean;
   /** The settings query is in flight. Weaker than `!hasSettings` — see below. */
   isLoading: boolean;
+  /**
+   * This user is in the notice's `audience`.
+   *
+   * Always `true` for a notice that declares no audience, so an untargeted
+   * notice is unaffected by targeting existing. For a targeted one it is the
+   * per-user answer to the flag the notice names, and it fails closed while the
+   * flag overlay is unresolved — AND it into the render condition exactly like
+   * `hasSettings`.
+   */
+  isInAudience: boolean;
   /** Persist a dismissal, optimistically. */
   dismiss: () => void;
   /** Undo a dismissal, optimistically. Only meaningful where UI offers it. */
@@ -44,10 +55,17 @@ export type UseFeatureNoticeResult = {
  * means showing it to someone who already dismissed it. Prefer `hasSettings`
  * for anything a user can dismiss.
  *
- * Deliberately NOT owned here: WHEN a notice should be shown. Visibility is
- * per-site (a feature flag, a balance, a mount context) and folding it in would
- * mean every site paying for every other site's conditions. Sites compose
- * `hasSettings && !isDismissed && <their own condition>`.
+ * Still NOT owned here: WHEN a notice should be shown. Visibility is per-site (a
+ * balance, a mount context, a layout state) and folding it in would mean every
+ * site paying for every other site's conditions. Sites compose
+ * `hasSettings && !isDismissed && isInAudience && <their own condition>`.
+ *
+ * The ONE condition that did move in is `audience`, and the distinction is
+ * worth keeping straight: a per-site condition describes the moment, while an
+ * audience describes the NOTICE — it is the same answer at every site that
+ * shows it, so leaving it to the sites means N chances to get it wrong and no
+ * way to enumerate who is being told what. It is declared in the registry and
+ * applied here; `isInAudience` is the result.
  *
  * @param notice  A registry entry, never a bare string — that is what keeps the
  *                persisted id set enumerable and collision-checkable.
@@ -60,6 +78,13 @@ export function useFeatureNotice(
 ): UseFeatureNoticeResult {
   const currentUser = useCurrentUser();
   const queryEnabled = enabled && !!currentUser;
+
+  // 🔴 The per-user overlay, NOT a keyed flag evaluation. This is the only read
+  // that carries the caller's own session, and therefore the only one on which a
+  // segment-scoped flag can match at all — an evaluation with no context answers
+  // "not in the segment" for every user, uniformly and silently.
+  const featureFlags = useOptionalFeatureFlags();
+  const flagsReady = useFeatureFlagsReady();
 
   const { data: settings, isLoading } = trpc.user.getSettings.useQuery(undefined, {
     enabled: queryEnabled,
@@ -94,6 +119,7 @@ export function useFeatureNotice(
     isDismissed: isNoticeDismissed(settings?.dismissedAlerts, notice),
     hasSettings: !!settings,
     isLoading,
+    isInAudience: isNoticeAudienceMatched(notice, featureFlags, flagsReady),
     // `dismiss` omits the flag and `restore` sends `false`, matching the wire
     // payloads these call sites have always sent.
     dismiss: () => mutation.mutate({ alertId: notice.id }),

--- a/src/components/RemixGallery/RemixGalleryExplainer.tsx
+++ b/src/components/RemixGallery/RemixGalleryExplainer.tsx
@@ -1,11 +1,8 @@
 import { Anchor, CloseButton, Text } from '@mantine/core';
 import { IconHierarchy } from '@tabler/icons-react';
 import { FEATURE_NOTICES } from '~/components/Alerts/notice-registry';
+import { useFeatureNotice } from '~/components/Alerts/useFeatureNotice';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { trpc } from '~/utils/trpc';
-
-// Declared in the notice registry so the persisted-id set stays enumerable.
-const ALERT_ID = FEATURE_NOTICES.remixGalleryExplainer.id;
 
 /**
  * Where the reasoning lives in full, for anyone who wants it.
@@ -27,41 +24,26 @@ const EARNINGS_ARTICLE =
  * `DismissibleAlert` would have given us: this explains a feature, not a
  * one-off event, and someone who has read it should not meet it again on their
  * phone. Same pattern as {@link ../Alerts/NavTidyNotice}, down to the
- * optimistic update and the `!!settings` guard.
+ * optimistic update and the resolved-settings guard.
+ *
+ * 🔴 The first site to consume a notice `audience`. The registry marks this
+ * notice as announcing the `remixGallery` rollout, so `isInAudience` is the
+ * per-user answer to that flag and is ANDed into the render condition below.
+ * Its parent gates on the same flag, so this does not narrow who sees it today
+ * — it makes the notice carry its own gate, so a future mount site cannot show
+ * an announcement to someone who does not have the thing being announced.
  */
 export function RemixGalleryExplainer() {
   const currentUser = useCurrentUser();
-  const utils = trpc.useUtils();
+  const { isDismissed, hasSettings, isInAudience, dismiss } = useFeatureNotice(
+    FEATURE_NOTICES.remixGalleryExplainer
+  );
 
-  const { data: settings } = trpc.user.getSettings.useQuery(undefined, {
-    enabled: !!currentUser,
-  });
-
-  const dismiss = trpc.user.dismissAlert.useMutation({
-    onMutate: async () => {
-      await utils.user.getSettings.cancel();
-      const prev = utils.user.getSettings.getData();
-      utils.user.getSettings.setData(undefined, (old) => ({
-        ...old,
-        dismissedAlerts: [...(old?.dismissedAlerts ?? []), ALERT_ID],
-      }));
-      return { prev };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.prev) utils.user.getSettings.setData(undefined, ctx.prev);
-    },
-    // The optimistic write spreads `...old`, so a cache seeded from a failed SSR
-    // snapshot could persist a truncated settings object. One refetch per
-    // dismiss, which is rare — not one per mount.
-    onSettled: () => {
-      utils.user.getSettings.invalidate();
-    },
-  });
-
-  const isDismissed = (settings?.dismissedAlerts ?? []).includes(ALERT_ID);
   // Signed out there is nowhere to record a dismissal, so showing it would mean
-  // showing it forever.
-  if (!currentUser || !settings || isDismissed) return null;
+  // showing it forever. `hasSettings` (not `isLoading`) is what proves a
+  // settings object resolved, so an errored fetch cannot flash this at someone
+  // who already dismissed it.
+  if (!currentUser || !hasSettings || isDismissed || !isInAudience) return null;
 
   return (
     <div className="flex gap-2 rounded-md border border-blue-2 bg-blue-0 p-2 dark:border-blue-9/30 dark:bg-blue-9/20">
@@ -86,7 +68,7 @@ export function RemixGalleryExplainer() {
         radius="xl"
         className="ml-auto shrink-0"
         aria-label="Dismiss"
-        onClick={() => dismiss.mutate({ alertId: ALERT_ID })}
+        onClick={() => dismiss()}
       />
     </div>
   );

--- a/src/providers/FeatureFlagsProvider.tsx
+++ b/src/providers/FeatureFlagsProvider.tsx
@@ -18,6 +18,17 @@ export const useFeatureFlags = () => {
   return context;
 };
 /**
+ * The resolved flags, or `null` outside the provider.
+ *
+ * `useFeatureFlags` throws there, which is right for a component that cannot do
+ * its job without flags. It is wrong for shared machinery that merely wants to
+ * ASK — `useFeatureNotice` runs at every notice call site, and making it throw
+ * would turn "this notice has no audience, so flags are irrelevant" into a
+ * crash. Callers must decide what a `null` means for them; the notice hook
+ * fails closed (see `isNoticeAudienceMatched`).
+ */
+export const useOptionalFeatureFlags = () => useContext(FeatureFlagsCtx);
+/**
  * True once the per-user feature-flag overlay is known (or there is no logged-in
  * user). Use to defer rendering UI whose visibility depends on user flags, so it
  * doesn't flash against the anonymous SSR snapshot.


### PR DESCRIPTION
Phase 2 of the in-product "you have access to a new feature" notice. Phase 1 (#3943) built the `FeatureNotice` primitive + registry and deliberately stopped, leaving instructions in the registry's file header:

> add an optional `audience` field to `FeatureNotice` below and branch on it inside `useFeatureNotice`'s returned `isDismissed`/visibility. It is omitted today because nothing reads it — **an unread field on a definition looks like a gate and gates nothing**.

That last sentence is this PR's acceptance criterion, and it is what the tests are built around.

## What landed

1. **`audience` on `FeatureNotice`** — optional, `{ feature: FeatureFlagKey }`.
2. **`useFeatureNotice` branches on it**, returning `isInAudience`.
3. **A real call site consumes it**: `RemixGalleryExplainer`.

No `id` in `FEATURE_NOTICES` changed. Those strings are live in real users' `dismissedAlerts`, and `notice-registry.test.ts` still pins all nine as hand-written literals.

## The design, and why

**`audience` is a resolved feature-flag key, not a cohort name and not a naming convention.**

"Is this flag worth announcing?" becomes a *lookup* in the registry, so it is reviewed like any other code change. The two alternatives were considered and rejected:

- **Flag metadata carried alongside the flag definitions.** Lets a flag owner self-serve without a deploy, but there is effectively no review gate on that surface, so an unreviewed UI click could publish user-facing copy to everyone. Wrong trade.
- **A convention** ("any flag targeting the early-adopter cohort is announceable"). Zero new mechanism, but it conflates *who can see a feature* with *who should be told about it*, and leaves no way to roll out quietly to a cohort — which is most of what a staged cohort is for.

Accepted cost: a notice requires a deploy. That is the price of the review gate, and it is the right way round.

**Flag evaluation goes through the context-carrying path.** `useFeatureNotice` reads whatever `FeatureFlagsProvider` resolved for this session (`useOptionalFeatureFlags`) rather than performing a keyed evaluation — a keyed evaluation has no context and answers "not in the segment" for every user, uniformly and silently. This PR adds no direct keyed evaluation.

🔴 **Correction (post-review).** An earlier draft of this paragraph called the per-user *toggleable overlay* "the only path on which a segment-scoped flag can match", and `remixGallery` — the one flag this PR actually targets — is the counter-example. The provider hands consumers `{ ...ssrFlags, ...toggleableOverlay }`, and **both halves are session-resolved server-side**; which half carries a given flag is decided solely by whether its definition sets `toggleable: true`.

- **Not toggleable → the SSR `flags` prop.** `getFeatureFlagsAsync` resolves it per request against the user's identity, tier, cohort, host and region, *including* Flipt segment evaluation (`buildFliptContext(user)`), and it is present from the first client frame. `remixGallery` is this kind: `{ availability: ['mod'], fliptKey: 'remix-gallery' }`, no `toggleable`.
- **`toggleable: true` → the `user.getFeatureFlags` overlay.** `computeUserFeatureFlagsOverlay` filters to toggleable keys, so a non-toggleable flag never appears in it at all.

The consequence, stated plainly because it was not: the `if (!flagsReady) return false` guard **cannot change the answer for the only notice that ships**. For a non-toggleable flag the SSR flags already hold the per-user verdict, so that guard can defer a render by a frame and nothing more. It becomes load-bearing the first time a notice names a `toggleable` flag, which is the case it was written for — so it stays, but the shipped notice is not evidence that it works. Both test fixtures are non-toggleable too, so nothing here exercises the overlay path either. All of this now lives in the registry's own doc rather than in a PR description.

**It fails closed, in both directions it can be unsure**: before the toggleable overlay has settled (otherwise the notice announces against the anonymous snapshot and then retracts — the flash the notice machinery exists to prevent), and when there is no flag provider at all. The asymmetry is deliberate: not announcing a feature to someone who has it is a missed nudge; announcing one to someone who does *not* have it is a broken promise.

**`hasSettings` vs `isLoading` is untouched.** `isInAudience` is a third, independent gate — being in an audience is not permission to re-show something the user dismissed, and being out of one is not "dismissed". Asserted both ways.

### New export: `useOptionalFeatureFlags`

`useFeatureFlags` throws outside the provider, which is right for a component that cannot do its job without flags and wrong for shared machinery that merely wants to *ask*. `useFeatureNotice` runs at every notice call site, including the eight that declare no audience, so making it throw would turn "flags are irrelevant here" into a crash.

## The consuming call site

`RemixGalleryExplainer` — the inline explainer at the top of a remix gallery, announcing the `remixGallery` staged rollout. It is exactly the shape this feature is for: a feature a user could not previously see, so the explainer is only ever *news* to someone the flag is on for.

Two honest notes:

- **This does not narrow who sees it today.** Its mount site (`RemixGalleryCard`) already gates on the same flag, so in production this is defence in depth. What it buys is that the gate now travels with the *notice* rather than living in one parent, so a second mount site cannot forget it.
- **It does change one thing**: the explainer now also waits for the per-user flag overlay to resolve before rendering. Previously it rendered as soon as settings resolved. That is the fail-closed behaviour above, and it is intended.

The component was also migrated from its hand-rolled copy of the dismissal logic to `useFeatureNotice` (it was one of three sites phase 1 left on constants-only). Net −40 lines of duplicated optimistic-update/rollback/reconcile code, and the wire payload is unchanged — pinned by the existing call-site test.

## Which suite the gate actually runs

🔴 **CI runs `vitest run --project unit`.** The `component` project (browser-mode, real Chromium) is **not** run by the gate. So the load-bearing assertions are deliberately placed in the `unit` project:

| Suite | Project | Runs in CI | Covers |
|---|---|---|---|
| `useFeatureNotice.audience.test.ts` **(new)** | `unit` (happy-dom) | ✅ | **The load-bearing claim.** Renders the hook and asserts its returned values: a targeted notice is not offered to a non-member, is offered to a member, fails closed while unresolved, and untargeted notices are unchanged. |
| `notice-registry.test.ts` | `unit` | ✅ | `isNoticeAudienceMatched` as returned behaviour — membership, absence, fail-closed, reads-its-own-flag. Plus the unchanged id table. |
| `notice-callsite-composition.test.ts` **(new)** | `unit` (happy-dom) | ✅ | **The call site's composition, rendered.** Mounts the real `RemixGalleryExplainer` through the real hook and the real registry entry and asserts what reached the DOM. This is what kills the destructured-but-unused mutant below. |
| `notice-callsite-coverage.test.ts` | `unit` | ✅ | Extended #3987 ledger: every call site of a notice that declares an `audience` must read `isInAudience`. Population gate — see limits below. |
| `useFeatureNotice.browser.test.tsx` | `component` | ❌ | Same claims through a real browser render. Corroboration, not a gate. |
| `notice-callsite.browser.test.tsx` | `component` | ❌ | Rendered DOM: the explainer is absent for a non-member, present for a member. |

The happy-dom hook-render pattern is not new here — `useDailyBoostReward.test.ts` already does it, which is how a React hook can be asserted inside the node project.

## Red → green and mutation evidence

Every new assertion was watched fail. The mutations below restore exactly the pre-change state, so they are simultaneously the red→green evidence and the mutation check.

**Mutation 1 — make the audience branch inert** (the exact defect phase 1 warned about). Replaced the body of `isNoticeAudienceMatched` with `return true`:

```
Tests  11 failed | 33 passed (44)

FAIL notice-registry.test.ts > isNoticeAudienceMatched > a notice with an audience > does NOT match a user its own flag is off for
AssertionError: expected true to be false // Object.is equality
FAIL useFeatureNotice.audience.test.ts > a targeted notice reaches its audience and nobody else > NOT offered to a user the notice's flag is off for
AssertionError: expected true to be false // Object.is equality
```

11 tests across **both** suites go red. The untargeted-notice cases stay green — by design; they are labelled in-file as invariant guards, not regression coverage.

**Mutation 2 — the seam.** Left the function intact and replaced the hook's use of it with `isInAudience: true`:

```
Tests  5 failed | 39 passed (44)

FAIL useFeatureNotice.audience.test.ts > a targeted notice fails CLOSED while the answer is unknown > not offered when there is no flag provider at all
AssertionError: expected true to be false // Object.is equality
```

Only the hook suite goes red; the pure-function suite stays green, which is the correct signature for a broken seam rather than a broken function. This is what proves the hook actually consumes the gate rather than the two being tested in isolation.

**Mutation 3 — the call site's BINDING.** Removed `isInAudience` from `RemixGalleryExplainer`'s destructure *and* from its render condition:

```
Tests  2 failed | 7 passed (9)

FAIL notice-callsite-coverage.test.ts > feature-notice audience ledger > every call site of a TARGETED notice reads isInAudience
AssertionError: A call site renders a notice that declares an `audience` without reading `isInAudience`
from useFeatureNotice, so it would announce the feature to users who do not have it.
  + [ "components/RemixGallery/RemixGalleryExplainer.tsx (notice: remixGalleryExplainer)" ]
```

Note the doc comment in that file still contained the word `isInAudience` while the code did not, and the gate correctly did **not** count it — the scanner strips comments first.

🔴 **Correction (post-review): this mutation is about the BINDING, not the condition.** The ledger is a token scan, so it trips only when `isInAudience` stops appearing in the file at all. Dropping the *condition* alone leaves the destructure in place, and the token with it. That narrower mutant is the next one.

**Mutation 4 — the call site's CONDITION only** (the surviving mutant this PR was audited for). Deleted `|| !isInAudience` from the render guard and **kept** the destructure at line 38:

```diff
-  if (!currentUser || !hasSettings || isDismissed || !isInAudience) return null;
+  if (!currentUser || !hasSettings || isDismissed) return null;
```

Before `notice-callsite-composition.test.ts` existed this **survived**: the token was still present, the ledger passed, and the whole `unit` project stayed green. The audience was computed and then thrown away, and the only automated signal was an ESLint `no-unused-vars` **warning** — `eslint` exits 0. The two backstops the ledger names did not cover it either: `useFeatureNotice.audience.test.ts` asserts the *hook's* return value, not the call site's composition, and `notice-callsite.browser.test.tsx` is in the `component` project CI does not run.

With the new suite in place it dies, and the other three suites still pass — which is the point: the failure is attributed to the call site, not smeared across the feature.

```
 ✓  unit  notice-registry.test.ts (31 tests)
 ✓  unit  notice-callsite-coverage.test.ts (9 tests)      ← the ledger: still GREEN, as diagnosed
 ❯  unit  notice-callsite-composition.test.ts (9 tests | 5 failed)
 ✓  unit  useFeatureNotice.audience.test.ts (14 tests)

 Test Files  1 failed | 3 passed (4)
      Tests  5 failed | 57 passed (62)

FAIL notice-callsite-composition.test.ts > RemixGalleryExplainer applies its audience to what it renders
   > renders NOTHING for a user the notice's flag is OFF for
AssertionError: the explainer announced the remix gallery to a user the `remixGallery` flag is OFF for.
The hook computed `isInAudience`, and the call site did not APPLY it — AND `!isInAudience` back into the
render condition in RemixGalleryExplainer.tsx.: expected true to be false // Object.is equality
```

Restored, and green again:

```
 Test Files  4 passed (4)
      Tests  63 passed (63)
```

All four mutations restored.

Fixtures in the new suites are hand-built and pairwise distinct, and deliberately name flags **other than** `remixGallery` — the one constant the registry names — so a mutant that hardcodes the production value cannot survive. The two targeted fixtures name different flags and are given opposite answers from one flag map, so "reads its own audience" is separable from "some flag was on".

## Verification

- **`pnpm exec vitest run --project unit` (the gate): 1166 files / 18345 tests, 0 failures.** The four suites above are confirmed to have *executed* in that run — `notice-callsite-composition.test.ts (9 tests)`, `useFeatureNotice.audience.test.ts (14 tests)`, `notice-callsite-coverage.test.ts (9 tests)`, `notice-registry.test.ts (31 tests)` — rather than inferred from the absence of failures.
- **`pnpm typecheck`: 0 errors.**

## Known limits

- **The ledger gate is structural, and weaker than it first looks.** It cannot tell `if (!isInAudience)` from `if (isInAudience)` — and, as mutation 4 shows, it cannot tell a *read* from a *binding* either: a destructure alone satisfies it. It exists only to keep the *population* of the behavioural tests complete. The behavioural claim is asserted twice in the `unit` project — against the hook's return value (`useFeatureNotice.audience.test.ts`) and against the rendered call site (`notice-callsite-composition.test.ts`) — and both are mutation-checked. Stated as such in both files.
- 🔴 **The `component` (browser) suites could not be run locally, so the browser-mode edits in this PR are unexecuted.** The browser project fails to launch on this machine for an environment reason unrelated to this change: a clean control on an untouched browser test file (`src/hooks/useScrollMargin.browser.test.tsx`) fails identically, reporting `Tests no tests`. So those edits are **verified by review and typecheck only**. They are not the gate and every gate suite passes, but it is a real gap — and it is exactly why the load-bearing assertions were put in `unit` rather than left in browser mode.
- Three browser mock factories needed `useOptionalFeatureFlags` added. An omitted export fails those files at **collection**, which reports as "no tests" rather than as a failure — worth knowing since I could not execute them here.

