### PR TITLE
fix(dev-server): one exit-code rule for both test-queue waiters, and a log that admits when it was clipped

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -269,6 +269,13 @@ Things worth knowing before you rely on it:
   nonzero telling you to re-request — it will not poll forever against a daemon that has forgotten
   you.
 - **Position is exact**, not an estimate: it is the index in one ordered list.
+- **The log window holds the last 2000 lines, and says when it clipped.** A run that emits
+  more than that loses its oldest lines, so a late `test wait` or a `test logs` read can be a
+  fragment. Both waiters print `WARNING: this log is INCOMPLETE …` naming how many lines went,
+  and `logsDropped` is on the run view — a non-zero value means do not quote what you see as
+  the whole run. A live waiter that has been streaming from the start is unaffected.
+- **The exit code is `exitCodeFor`'s, in both waiters.** `test wait` and `pnpm run test:unit:run`
+  read the same rule, so a run killed by a signal reports 1 from either, never a shell 255.
 
 ## Session Object
 

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -450,6 +450,14 @@ async function cmdTestWait(id) {
     }
 
     if (isTerminalStatus(run.status)) {
+      // Both waiters say this, in the same place, for the same reason: a truncated log that does
+      // not announce itself is read as a whole one. See `warnIfLogsDropped` in test-unit-run.mjs.
+      if (run.logsDropped) {
+        console.error(
+          `WARNING: this log is INCOMPLETE — the queue dropped the oldest ${run.logsDropped} of ` +
+            `${run.logIndex} output lines. Do not read the text above as the whole run.`
+        );
+      }
       console.log(`Run ${id} ${run.status}${run.error ? ` (${run.error})` : ''}`);
       process.exit(exitCodeFor(run));
     }

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -2150,7 +2150,10 @@ async function main() {
               return;
             }
             res.writeHead(200);
-            res.end(JSON.stringify({ logs }));
+            // `dropped` rides along so a caller reading logs directly — `test logs`, a pasted
+            // excerpt — can tell a fragment from a whole run. The waiters warn; this is the same
+            // fact for everyone else.
+            res.end(JSON.stringify({ logs, dropped: testQueue.droppedFor(runId) }));
             return;
           }
 

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -166,6 +166,9 @@ export class TestQueue {
       timedOut: false,
       logs: [],
       logIndex: 0,
+      // Counted, not just done. A reader cannot tell a clipped log from a whole one, so the
+      // number of lines the window threw away has to travel with the run.
+      logsDropped: 0,
     };
     this.runs.set(run.id, run);
     this.order.push(run.id);
@@ -190,6 +193,11 @@ export class TestQueue {
     if (!run) return null;
     run.touchedAt = this.now();
     return run.logs.filter((entry) => entry.index > since);
+  }
+
+  /** How many of a run's lines the window has thrown away, for readers that fetch logs directly. */
+  droppedFor(id) {
+    return this.runs.get(id)?.logsDropped ?? 0;
   }
 
   cancel(id, reason = 'cancelled') {
@@ -357,7 +365,10 @@ export class TestQueue {
 
   addLog(run, level, message) {
     run.logs.push({ index: run.logIndex++, level, message, at: this.now() });
-    if (run.logs.length > MAX_LOG_LINES) run.logs.shift();
+    if (run.logs.length > MAX_LOG_LINES) {
+      run.logs.shift();
+      run.logsDropped += 1;
+    }
   }
 
   positionOf(id) {
@@ -385,6 +396,9 @@ export class TestQueue {
       exitCode: run.exitCode,
       error: run.error,
       logIndex: run.logIndex,
+      // How many lines this run emitted that the window no longer holds. Non-zero means every
+      // reader of these logs — waiter, `test logs`, a pasted excerpt — is looking at a fragment.
+      logsDropped: run.logsDropped,
       waitCommand: `${this.waitCommand} ${run.id}`,
     };
   }

--- a/scripts/__tests__/dev-server-test-queue.test.ts
+++ b/scripts/__tests__/dev-server-test-queue.test.ts
@@ -421,3 +421,51 @@ describe('dev-server test queue', () => {
     expect(run.waitCommand).toBe(`node cli.mjs test wait ${run.id}`);
   });
 });
+
+/**
+ * A run's log window is bounded, and it has to be. What is not acceptable is dropping lines
+ * without saying so: a clipped log is byte-for-byte indistinguishable from a whole one, which is
+ * how a fragment gets read — and quoted — as a complete run.
+ *
+ * Measured through the real queue before this counter existed: a child that wrote 5,000 lines
+ * produced 1,998 in the window, and neither the run view nor the log response said a word.
+ */
+describe('a clipped log announces itself', () => {
+  const drive = (lines: number) => {
+    const { startRun } = makeRunner();
+    const queue = new TestQueue({ startRun });
+    const view = queue.request({ worktree: '/repo' });
+    const run = queue.runs.get(view.id);
+    for (let i = 0; i < lines; i++) queue.addLog(run, 'stdout', `line ${i}`);
+    return queue.get(view.id);
+  };
+
+  it('reports nothing dropped while the window still holds everything', () => {
+    const state = drive(10);
+    expect(state.logIndex).toBe(10);
+    expect(state.logsDropped).toBe(0);
+  });
+
+  // The count is the difference between what was emitted and what survives, so a reader can tell
+  // exactly how much of the run is missing rather than only that some of it is.
+  it('counts every line the window threw away', () => {
+    const state = drive(5000);
+    expect(state.logIndex).toBe(5000);
+    expect(state.logsDropped).toBe(3000);
+    expect(state.logIndex - state.logsDropped).toBe(2000);
+  });
+
+  // The waiters warn, but `test logs` fetches the window directly and would otherwise get a
+  // fragment with nothing attached to it. The daemon's log route reads this.
+  it('offers the same count to a caller reading logs directly', () => {
+    const { startRun } = makeRunner();
+    const queue = new TestQueue({ startRun });
+    const { id } = queue.request({ worktree: '/repo' });
+    const run = queue.runs.get(id);
+    for (let i = 0; i < 2500; i++) queue.addLog(run, 'stdout', `line ${i}`);
+    expect(queue.droppedFor(id)).toBe(500);
+    expect(queue.logs(id, -1)).toHaveLength(2000);
+    // An unknown run is 0 dropped, not a throw: the route answers 404 on its own terms.
+    expect(queue.droppedFor('nope')).toBe(0);
+  });
+});

--- a/scripts/__tests__/test-unit-run.test.ts
+++ b/scripts/__tests__/test-unit-run.test.ts
@@ -1,3 +1,8 @@
+import { spawn } from 'child_process';
+import { createServer } from 'http';
+import type { AddressInfo } from 'net';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 
 // The wrapper `pnpm run test:unit:run` now points at. Imported by path for the same reason the
@@ -40,5 +45,109 @@ describe('test:unit:run — when the queue is used', () => {
     // A trailing slash is a directory, and `--exclude '**/*.test.ts'` is a glob, not a target.
     expect(queueDecision(['--dir', 'src/x.test.ts/'], env).queue).toBe(true);
     expect(queueDecision(['--reporter=verbose'], env).queue).toBe(true);
+  });
+});
+
+/**
+ * The verdict a queued run reports to its caller.
+ *
+ * These drive the real script as a child process against a stub daemon, because the bug this
+ * pins was invisible to any test that imported a function: the decision lived inline in the poll
+ * loop, so the only thing that ever evaluated it was the process exiting. `DEV_DAEMON_PORT` (the
+ * override the CLI already honoured) is what lets a fake daemon stand beside the shared one.
+ */
+describe('test:unit:run — the exit code a queued run reports', () => {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+  const script = resolve(repoRoot, 'scripts/test-unit-run.mjs');
+
+  /** A daemon that hands back one fixed run view, whatever is asked of it. */
+  async function stubDaemon(view: Record<string, unknown>) {
+    const server = createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        req.url?.includes('/logs')
+          ? JSON.stringify({ logs: [] })
+          : JSON.stringify({ id: 'stub', position: 0, queueLength: 0, logIndex: 0, ...view })
+      );
+    });
+    await new Promise<void>((done) => server.listen(0, '127.0.0.1', done));
+    const { port } = server.address() as AddressInfo;
+    return { port, close: () => new Promise<void>((done) => server.close(() => done())) };
+  }
+
+  async function runAgainst(view: Record<string, unknown>) {
+    const daemon = await stubDaemon(view);
+    try {
+      return await new Promise<{ code: number | null; stderr: string }>((done) => {
+        const child = spawn(process.execPath, [script], {
+          cwd: repoRoot,
+          env: {
+            ...process.env,
+            CI: '',
+            CIVITAI_TEST_QUEUE: '1',
+            DEV_DAEMON_PORT: String(daemon.port),
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let stderr = '';
+        child.stderr.on('data', (d) => (stderr += d.toString()));
+        child.stdout.resume();
+        child.on('exit', (code) => done({ code, stderr }));
+      });
+    } finally {
+      await daemon.close();
+    }
+  }
+
+  /**
+   * The regression. A run killed by a signal records no exit code of its own, which the queue
+   * stores as -1. The waiter used to pass that straight to `process.exit`, and `process.exit(-1)`
+   * hands the shell 255 — a number that means nothing here, that `[ $? -eq 1 ]` misreads, and
+   * that `exitCodeFor` was written to prevent. Measured at 255 before this changed.
+   */
+  it.each([
+    ['cancelled', -1],
+    ['timeout', -1],
+    ['error', -1],
+  ])('reports 1, not 255, for a %s run the queue recorded as %i', async (status, exitCode) => {
+    const { code } = await runAgainst({ status, exitCode });
+    expect(code).toBe(1);
+  });
+
+  // Invariant guards, not regression coverage: these already held. They are here so a later
+  // "simplification" of the verdict cannot quietly change what a pass and a fail mean.
+  it.each([
+    ['completed', 0, 0],
+    ['failed', 1, 1],
+    ['failed', 3, 3],
+    // A cancelled run can carry a 0: the child exited cleanly in the window between the kill
+    // being issued and it landing. That is not a pass.
+    ['cancelled', 0, 1],
+  ])('maps %s/%i to %i', async (status, exitCode, expected) => {
+    const { code } = await runAgainst({ status, exitCode });
+    expect(code).toBe(expected);
+  });
+
+  /**
+   * The other half of "green means nothing": a log the queue clipped reads exactly like a whole
+   * one. The sentence is pinned in full rather than by keyword, because a reworded warning that
+   * still omits the number would walk a `toContain('INCOMPLETE')` check.
+   */
+  it('says so, in full, when the log it printed is a fragment', async () => {
+    const { stderr } = await runAgainst({
+      status: 'failed',
+      exitCode: 1,
+      logIndex: 5000,
+      logsDropped: 3002,
+    });
+    expect(stderr.replace(/\s+/g, ' ')).toContain(
+      'WARNING: this log is INCOMPLETE — the queue dropped the oldest 3002 of 5000 output lines. ' +
+        'Do not read the text above as the whole run.'
+    );
+  });
+
+  it('stays quiet when nothing was dropped — the warning must mean something', async () => {
+    const { stderr } = await runAgainst({ status: 'failed', exitCode: 1, logsDropped: 0 });
+    expect(stderr).not.toContain('INCOMPLETE');
   });
 });

--- a/scripts/test-unit-run.mjs
+++ b/scripts/test-unit-run.mjs
@@ -14,11 +14,17 @@
 import { spawn } from 'child_process';
 import { existsSync } from 'fs';
 import { dirname, resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const CLI = resolve(repoRoot, '.claude/skills/dev-server/cli.mjs');
-const DAEMON = 'http://127.0.0.1:9444';
+// The queue module owns the one rule that decides pass from fail. It is imported dynamically
+// rather than at the top of the file because it lives under `.claude/`, which the direct path
+// must keep working without: a static import would fail the whole script when the skill is absent.
+const QUEUE = resolve(repoRoot, '.claude/skills/dev-server/scripts/test-queue.mjs');
+// Same override the CLI honours. Without it this file can only ever talk to the shared daemon,
+// which is why the verdict below had no test: there was no way to stand a fake one up beside it.
+const DAEMON = `http://127.0.0.1:${parseInt(process.env.DEV_DAEMON_PORT || '9444', 10)}`;
 const POLL_MS = 2000;
 
 const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
@@ -74,7 +80,24 @@ function ensureDaemon() {
   });
 }
 
+/**
+ * The queue keeps a bounded window of a run's output. Dropping the oldest lines is fine; dropping
+ * them SILENTLY is not, because a truncated log is indistinguishable from a complete one — that is
+ * how a clipped log gets quoted as a full-suite pass. Say the number out loud instead.
+ */
+function warnIfLogsDropped(state) {
+  if (!state.logsDropped) return;
+  console.error(
+    `WARNING: this log is INCOMPLETE — the queue dropped the oldest ${state.logsDropped} of ` +
+      `${state.logIndex} output lines. Do not read the text above as the whole run.`
+  );
+}
+
 async function runQueued(args) {
+  // Resolved once, up front: this is the module that decides pass from fail, and a waiter that
+  // discovers it cannot load that rule at the moment it must apply it has no verdict to give.
+  const { exitCodeFor } = await import(pathToFileURL(QUEUE).href);
+
   let run;
   try {
     run = await post('/test-runs', { worktree: repoRoot, args });
@@ -123,8 +146,12 @@ async function runQueued(args) {
     if (state.status !== 'queued' && state.status !== 'running') {
       if (state.status !== 'completed')
         console.error(`Run ${state.status}${state.error ? `: ${state.error}` : ''}`);
-      // Only a completed run that exited 0 is a pass; a cancelled or timed-out run can carry a 0.
-      process.exit(state.status === 'completed' && state.exitCode === 0 ? 0 : state.exitCode || 1);
+      warnIfLogsDropped(state);
+      // The verdict comes from the queue's own `exitCodeFor`, never from a second copy of the rule
+      // here. The copy that used to live on this line read `state.exitCode || 1`, which passes a
+      // signal-killed run's recorded -1 straight through: `process.exit(-1)` gives the shell 255,
+      // the exact number `exitCodeFor` exists to avoid, and `[ $? -eq 1 ]` misreads it.
+      process.exit(exitCodeFor(state));
     }
     await new Promise((r) => setTimeout(r, POLL_MS));
   }
@@ -136,6 +163,6 @@ if (
 ) {
   const args = process.argv.slice(2);
   const decision = queueDecision(args, process.env);
-  if (decision.queue && existsSync(CLI)) runQueued(args);
+  if (decision.queue && existsSync(CLI) && existsSync(QUEUE)) runQueued(args);
   else runDirect(args);
 }


### PR DESCRIPTION
## What this fixes

Two ways the dev-server test queue could hand a caller a verdict that does not mean what it says.

### 1. The queued waiter kept its own copy of the pass/fail rule, and it had drifted

`.claude/skills/dev-server/scripts/test-queue.mjs` exports `exitCodeFor`, whose whole job is to
turn a run record into a shell exit code — including the case its comment calls out by name:

> a child killed by a signal reports no code at all (recorded as `-1`), and exiting `-1` gives a
> shell 255 — a number that means nothing here and that `[ $? -eq 1 ]` misreads.

`test wait` used it. `scripts/test-unit-run.mjs` — the wrapper `pnpm run test:unit:run` routes
through — did not. It open-coded the same decision as `state.exitCode || 1`, which passes that
`-1` straight to `process.exit`.

Measured on this branch's base, through a real daemon: a run cancelled mid-flight was recorded as
`status: cancelled, exitCode: -1`, and `pnpm run test:unit:run` exited **255**. Same scenario after
the change: **1**.

Two call sites, one rule, wrong at one of them. The fix is to delete the copy: the wrapper imports
`exitCodeFor` and uses it. The import is dynamic and resolved once at the top of the queued path,
because the module lives under `.claude/`, which the direct (unqueued) path must keep working
without — and the entry condition now checks for it alongside the CLI.

### 2. A clipped log looked exactly like a complete one

The queue keeps the last 2,000 lines of a run and dropped the rest silently. Nothing in the run
view, the log response, or either waiter's output said a line had been lost, so a fragment read as
a whole run — which is how a partial log gets quoted as a full-suite pass.

Measured end to end: a child that wrote 5,000 lines produced 1,998 through `test wait`, with no
indication that 3,002 were gone. Now the queue counts them (`logsDropped` on the run view) and
both waiters print, on stderr, at the moment the verdict lands:

```
WARNING: this log is INCOMPLETE — the queue dropped the oldest 3005 of 5005 output lines. Do not
read the text above as the whole run.
```

The window itself is unchanged — this makes the loss visible rather than pretending it does not
happen. A waiter that streamed from the start is unaffected and stays quiet; verified that a run
with nothing dropped prints no warning. `test logs` fetches the window directly rather than through
a waiter, so its response carries the same count as `dropped`.

### Incidental: `DEV_DAEMON_PORT`

`scripts/test-unit-run.mjs` hardcoded the daemon port while `cli.mjs` already honoured
`DEV_DAEMON_PORT`. It now honours it too. This is not cosmetic — it is why the verdict above had no
test: with the port fixed, there was no way to stand a stub daemon beside the shared one, so the
only thing that ever evaluated the rule was a process exiting for real.

## Tests

Red at base, green at HEAD. The base measurements were taken at `a55fe05f3c`; the branch has since
been rebased onto `41df23b07b`, and all six touched files are byte-identical between the two, so the
matrix carries over unchanged.

| Test | At base | At HEAD |
|---|---|---|
| `reports 1, not 255, for a cancelled run the queue recorded as -1` | ✗ `expected 255 to be 1` | ✓ |
| `reports 1, not 255, for a timeout run the queue recorded as -1` | ✗ `expected 255 to be 1` | ✓ |
| `reports 1, not 255, for a error run the queue recorded as -1` | ✗ `expected 255 to be 1` | ✓ |
| `says so, in full, when the log it printed is a fragment` | ✗ `expected 'Run failed ' to contain …` | ✓ |
| `reports nothing dropped while the window still holds everything` | ✗ `expected undefined to be +0` | ✓ |
| `counts every line the window threw away` | ✗ `expected undefined to be 3000` | ✓ |
| `offers the same count to a caller reading logs directly` | ✗ `TypeError: queue.droppedFor is not a function` | ✓ |

The exit-code tests drive the real script as a child process against a stub daemon and assert on
its exit code, because that is the only thing that evaluates the decision. Watching them fail at
base needed the `DEV_DAEMON_PORT` change applied on its own first (otherwise they talk to the
shared daemon and measure nothing); the verdict expression was left untouched for that run, and the
255s above are from it.

The remaining cases in that block — `completed/0 → 0`, `failed/1 → 1`, `failed/3 → 3`,
`cancelled/0 → 1` — already passed at base. They are invariant guards, not regression coverage, and
are labelled as such in the file.

The truncation warning is pinned as a whole normalised sentence rather than by keyword, so a
reworded warning that drops the line counts cannot walk it.

## What this does not claim

This does **not** reproduce the "notification reports exit 0 over a run that exited 1" symptom that
prompted the investigation. Four shapes were measured, and every one reported the correct non-zero
code, matching what the queue's own record said:

1. a full unit suite backgrounded through the queue — 123 test files failing, wrapper exited 1;
2. a fast failing queued run backgrounded — exited 1;
3. the same run started in the foreground and handed off to the background mid-flight while it sat
   queued behind another — exited 1;
4. a run cancelled mid-flight — exited 255 before this change, 1 after.

Only (4) was ever wrong, and 255 is not a false green. The exit-0 report is unexplained by anything
found here, and these changes should not be read as closing it.

For the record, the full unit suite is green on this branch: 1,176 files / 18,505 tests, 0 failures.
The failures in (1) came from an uninitialised `event-engine-common` submodule in the throwaway
worktree, not from the three source guards the report expected to be failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
