### PR TITLE
fix(apps): take the WIDER of a caller scope and the public catalog floor (#4048)

### DIFF
--- a/src/server/prom/store-scope.metrics.ts
+++ b/src/server/prom/store-scope.metrics.ts
@@ -109,12 +109,16 @@ const metrics =
       name: PROM_PREFIX + 'store_public_catalog_decisions_total',
       help:
         'Cumulative PUBLIC App-catalog grant decisions at the /api/v1/apps REST endpoints, ' +
-        'by outcome and entrypoint. `granted` = a caller who resolved no scope of their own ' +
-        'was served the public catalog (the intended steady state); `withheld` = the ' +
-        'apps-public-catalog-disabled kill switch was on; `privileged` = the caller resolved ' +
-        'a real scope and was passed through untouched. This is the ONLY signal that says ' +
-        'whether the public catalog is actually open — a `withheld` rate rising from zero is ' +
-        'the kill switch having been thrown, deliberately or not.',
+        'by outcome and entrypoint. `granted` = the caller was LIFTED to the public catalog ' +
+        'floor because their own scope was narrower than it (the intended steady state, and ' +
+        'the anonymous case); `withheld` = the apps-public-catalog-disabled kill switch was ' +
+        'on, so the caller kept THEIR OWN resolved scope and nothing more — that is `none` ' +
+        'for an anonymous caller but NOT necessarily nothing, a cohort caller still reads ' +
+        'their own scope through it; `privileged` = the caller was already at or above the ' +
+        'floor and was passed through untouched, without the switch even being evaluated. ' +
+        'This is the ONLY signal that says whether the public catalog is actually open — a ' +
+        '`withheld` rate rising from zero is the kill switch having been thrown, ' +
+        'deliberately or not.',
       labelNames: ['outcome', 'entrypoint'],
     }),
   });
@@ -174,6 +178,16 @@ export type PublicCatalogOutcome = 'granted' | 'withheld' | 'privileged';
  * it. `applied{scope="absent"}` with `decisions{outcome="granted"}` is the known,
  * open #3983 resolver defect being absorbed by the deliberate grant — not a new
  * exposure, because `absent` and a resolved `none` take the identical branch.
+ *
+ * 🔴 `withheld` DOES NOT MEAN THE CALLER GOT NOTHING — read the name as "the public
+ * GRANT was withheld", not "the response was empty". Since civitai#4048 the withheld
+ * branch returns the caller's OWN resolved scope, so a caller in the external-only
+ * cohort still reads `public-external` while the switch is on; only a caller who
+ * resolved `none` of their own (every anonymous one) actually goes dark. The three
+ * outcomes partition callers by what the grant DID to them — lifted them
+ * (`granted`), was withdrawn from them (`withheld`), or had nothing to offer them
+ * because they were already at or above the floor (`privileged`) — not by what they
+ * ended up being able to read.
  */
 export function recordPublicCatalogDecision(
   outcome: PublicCatalogOutcome,

--- a/src/server/services/__tests__/public-apps-catalog.kill-switch.seam.test.ts
+++ b/src/server/services/__tests__/public-apps-catalog.kill-switch.seam.test.ts
@@ -1,0 +1,399 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import promClient from 'prom-client';
+
+/**
+ * 🔴 THE KILL SWITCH, PROVEN — civitai#4048 follow-up 2.
+ *
+ * `civitai_app_store_public_catalog_decisions_total` has only ever recorded
+ * `outcome="granted"` in production. **`withheld` has never moved.** The switch that
+ * takes a public REST endpoint dark has therefore never been exercised by anything
+ * except a test that mocked it away, and "the flag is a DISABLE flag so an absent
+ * flag means public access stays ON" has, until this file, been a claim in a
+ * docstring rather than a measurement.
+ *
+ * ⚠️ WHY THIS IS NOT ANOTHER `vi.mock('~/server/flipt/client')` SUITE. Every existing
+ * suite that touches the switch — `blocks/__tests__/public-apps-catalog.test.ts`,
+ * `public-apps-catalog.page-gate.seam.test.ts`, `src/tests/api/v1/apps/*` — replaces
+ * `isFlipt` with a `vi.fn()` or a hand-written truth table. Each is then a fact about
+ * that double, and the ONE property an operator has to bet on lives BELOW it: what
+ * the real `isFlipt` does with a flag that is not in the Flipt config at all. A
+ * hand-written double answers `false` there because its author wrote `?? false`; the
+ * real one answers `false` because the wasm engine THROWS "flag not found", the
+ * factory catches it and fails closed — a completely different mechanism that a
+ * double cannot attest to.
+ *
+ * So the fake here is pushed one layer down, at `@flipt-io/flipt-client-js`: the
+ * evaluation ENGINE is faked over a declared flag CONFIG, and everything above it is
+ * real —
+ *
+ *   real `~/server/flipt/client`            (the app's isFlipt, its cache-bypass set,
+ *                                            its connection resolution, its
+ *                                            fail-closed init handling)
+ *   real `@civitai/flipt` createFliptClient (localOverrides, eval cache, the
+ *                                            try/catch that turns an engine throw
+ *                                            into `false`)
+ *   real `resolveStoreVisibilityScope`      (the caller's own scope)
+ *   real `resolvePublicAppsCatalogScope`    (the decision under test)
+ *   real `prom-client` counters             (asserted by VALUE, not by call count)
+ *
+ * 🔴 LABEL, honestly: this file is GREEN AT `origin/main` (15/15). It is COVERAGE for
+ * a branch nothing exercised, not a regression test — the kill switch worked, nobody
+ * had ever proved it end-to-end, and its `withheld` counter had never moved anywhere
+ * outside a mock. The civitai#4048 REGRESSION coverage (a `public-external` caller is
+ * widened while the grant is active) is red at base and lives in
+ * `blocks/__tests__/public-apps-catalog.test.ts` and `src/tests/api/v1/apps/*`. The
+ * one #4048 property asserted here — the never-narrows invariant at the seam — is
+ * green at base too, because the code it replaces got that property for free from a
+ * short-circuit this change removes; it is here so the restructure cannot silently
+ * lose it.
+ *
+ * ## What this file structurally CANNOT see
+ *
+ * - Whether the flag, once created in flipt-state, is shaped the way the module doc
+ *   requires (plain base boolean, no segments). The engine fake models a base
+ *   boolean and an entity/context-sensitive shape, but the real Flipt config is not
+ *   under test here.
+ * - Whether the live endpoints serve anything. Handler rendering (empty page / 404)
+ *   is `src/tests/api/v1/apps/apps.test.ts`; this file asserts the SCOPE both
+ *   handlers branch on, for both entrypoint labels, which is the value that decides
+ *   it.
+ */
+
+// Read at module-evaluation time by @civitai/flipt's `loadFliptTuning` and by the
+// connection fallback. Set in `vi.hoisted` so they are in place before
+// `~/server/flipt/client` constructs its singleton.
+//
+// 🔴 `FLIPT_EVAL_CACHE_TTL_MS=0` is load-bearing, not tidiness. The real client
+// memoizes an evaluation for 10s by default and this flag is NOT in the
+// cache-bypass set, so with the default TTL the FIRST answer in this file would be
+// replayed for every later case and the whole matrix would be one measurement
+// wearing many hats — green, and about nothing.
+vi.hoisted(() => {
+  process.env.FLIPT_EVAL_CACHE_TTL_MS = '0';
+  process.env.FLIPT_URL = 'http://flipt.test';
+  process.env.FLIPT_FETCHER_SECRET = 'test-token';
+  delete process.env.FLIPT_LOCAL_OVERRIDES;
+});
+
+/** How a flag behaves in the faked engine. `absent` = not in the config at all. */
+type FlagShape =
+  | { kind: 'absent' }
+  | { kind: 'base'; enabled: boolean }
+  | { kind: 'segment'; base: boolean; match: (ctx: Record<string, string>) => boolean };
+
+const { flagState, engineCalls } = vi.hoisted(() => ({
+  flagState: { flags: {} as Record<string, unknown> },
+  engineCalls: { keys: [] as string[] },
+}));
+
+/**
+ * The evaluation ENGINE, faked — and faked at the layer where its ERROR behaviour is
+ * what matters.
+ *
+ * 🔴 An unknown flag THROWS. That is what the real wasm engine does ("failed to get
+ * flag"), it is what `@civitai/flipt`'s own comment on `isEnabledSync` documents
+ * ("Swallow eval errors (incl. 'flag not found')"), and it is the entire mechanism
+ * behind the polarity claim on `PUBLIC_APPS_CATALOG_DISABLED_FLAG`. A fake that
+ * returned `{ enabled: false }` for an unknown flag would make the polarity test
+ * pass by construction and prove nothing.
+ */
+vi.mock('@flipt-io/flipt-client-js', () => {
+  class FliptClient {
+    static async init() {
+      return new FliptClient();
+    }
+    async refresh() {
+      return undefined;
+    }
+    evaluateBoolean({
+      flagKey,
+      context = {},
+    }: {
+      flagKey: string;
+      entityId: string;
+      context?: Record<string, string>;
+    }) {
+      engineCalls.keys.push(flagKey);
+      const shape = (flagState.flags[flagKey] as FlagShape | undefined) ?? { kind: 'absent' };
+      switch (shape.kind) {
+        case 'absent':
+          throw new Error(`invalid request: failed to get flag information ${flagKey}`);
+        case 'base':
+          return { enabled: shape.enabled };
+        case 'segment':
+          return { enabled: shape.match(context) ? true : shape.base };
+      }
+    }
+    evaluateVariant() {
+      return { match: false, variantKey: '' };
+    }
+  }
+  return { FliptClient };
+});
+
+import { isFlipt } from '~/server/flipt/client';
+import { resolveStoreVisibilityScope } from '../app-blocks-flag';
+import {
+  PUBLIC_APPS_CATALOG_DISABLED_FLAG,
+  PUBLIC_APPS_CATALOG_SCOPE,
+  resolvePublicAppsCatalogScope,
+} from '../blocks/public-apps-catalog';
+import type { StoreScopeEntrypoint } from '~/server/prom/store-scope.metrics';
+import type { SessionUser } from '~/types/session';
+
+const EXTERNAL = 'app-listings-public-external';
+const LISTINGS = 'app-listings';
+const DECISIONS = 'civitai_app_store_public_catalog_decisions_total';
+
+function makeUser(over: Partial<SessionUser> = {}): SessionUser {
+  return {
+    id: 100,
+    username: 'u',
+    isModerator: false,
+    tier: 'free',
+    permissions: [],
+    onboarding: 0,
+    ...over,
+  } as SessionUser;
+}
+
+/**
+ * Read one series off the REAL prom-client registry.
+ *
+ * 🔴 Returns `null` — not `0` — when the metric is not registered at all. A reassuring
+ * zero is indistinguishable from a probe wired to nothing, and this file's headline
+ * claim is that a counter which has never moved in production CAN move. The
+ * instrument control below asserts the handle exists before any zero is believed.
+ */
+async function decisions(
+  outcome: string,
+  entrypoint: StoreScopeEntrypoint
+): Promise<number | null> {
+  const metric = promClient.register.getSingleMetric(DECISIONS) as
+    | promClient.Counter<string>
+    | undefined;
+  if (!metric) return null;
+  const snapshot = await metric.get();
+  const hit = snapshot.values.find(
+    (v) => v.labels.outcome === outcome && v.labels.entrypoint === entrypoint
+  );
+  return hit?.value ?? 0;
+}
+
+/** The caller's own scope, then the public decision — both surfaces of the seam. */
+async function measure(user?: SessionUser, entrypoint: StoreScopeEntrypoint = 'rest-list') {
+  const own = await resolveStoreVisibilityScope({ user });
+  const served = await resolvePublicAppsCatalogScope(own, entrypoint);
+  return { own, served };
+}
+
+/**
+ * `~/server/flipt/client` passes no `onEvalError`, so @civitai/flipt's default logs
+ * every "flag not found" throw to `console.error`. Absent flags are the NORMAL,
+ * as-merged state this file measures, so that is ~40 lines of expected stderr per
+ * run. Filtered — not silenced: anything that is not that exact line still reaches
+ * the console, so a real error here is not swallowed by the noise reduction.
+ */
+const realConsoleError = console.error;
+beforeAll(() => {
+  vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    if (args[0] === '[flipt] evaluation error:') return;
+    realConsoleError(...args);
+  });
+});
+afterAll(() => {
+  vi.mocked(console.error).mockRestore();
+});
+
+beforeEach(() => {
+  flagState.flags = {};
+  engineCalls.keys = [];
+});
+
+// ---------------------------------------------------------------------------
+// Instrument controls — a verdict from an unvalidated harness is worthless
+// ---------------------------------------------------------------------------
+
+describe('the harness (validate the instrument before reading its verdict)', () => {
+  it('🔴 the REAL evaluation path is live: the engine is actually reached', async () => {
+    // Without this, every "the flag is off" result below is indistinguishable from a
+    // client that failed to initialize and is answering `false` to everything.
+    flagState.flags[PUBLIC_APPS_CATALOG_DISABLED_FLAG] = {
+      kind: 'base',
+      enabled: true,
+    } satisfies FlagShape;
+    await expect(isFlipt(PUBLIC_APPS_CATALOG_DISABLED_FLAG)).resolves.toBe(true);
+    expect(engineCalls.keys).toContain(PUBLIC_APPS_CATALOG_DISABLED_FLAG);
+  });
+
+  it('🔴 the eval cache is DISABLED: a config change is observed immediately', async () => {
+    // The 10s default TTL would replay the first answer for the rest of the file.
+    flagState.flags[PUBLIC_APPS_CATALOG_DISABLED_FLAG] = {
+      kind: 'base',
+      enabled: false,
+    } satisfies FlagShape;
+    await expect(isFlipt(PUBLIC_APPS_CATALOG_DISABLED_FLAG)).resolves.toBe(false);
+    flagState.flags[PUBLIC_APPS_CATALOG_DISABLED_FLAG] = {
+      kind: 'base',
+      enabled: true,
+    } satisfies FlagShape;
+    await expect(isFlipt(PUBLIC_APPS_CATALOG_DISABLED_FLAG)).resolves.toBe(true);
+  });
+
+  it('🔴 the decision COUNTER exists in the real registry (a zero below is a value, not a miss)', async () => {
+    expect(await decisions('withheld', 'rest-list')).not.toBeNull();
+    expect(await decisions('granted', 'rest-list')).not.toBeNull();
+  });
+
+  it('🔴 POSITIVE CONTROL: the counter MOVES — `granted` increments by exactly one call', async () => {
+    // The half that a probe wired to nothing cannot fake. Assert the DELTA, because
+    // the registry is process-global and other cases in this file have already
+    // incremented it.
+    const before = (await decisions('granted', 'rest-detail')) ?? -1;
+    await resolvePublicAppsCatalogScope('none', 'rest-detail');
+    expect(await decisions('granted', 'rest-detail')).toBe(before + 1);
+  });
+
+  it('🔴 NEGATIVE CONTROL: the `withheld` series does NOT move when the switch is off', async () => {
+    const before = (await decisions('withheld', 'rest-detail')) ?? -1;
+    await resolvePublicAppsCatalogScope('none', 'rest-detail');
+    expect(await decisions('withheld', 'rest-detail')).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The polarity claim, measured through the real client
+// ---------------------------------------------------------------------------
+
+describe('🔴 FLAG POLARITY: an ABSENT flag means public access stays ON', () => {
+  it('the real `isFlipt` returns false for a flag that is not in the config', async () => {
+    // The engine THROWS for an unknown flag; `@civitai/flipt` catches and fails
+    // closed. This is the mechanism the module doc's polarity paragraph asserts, and
+    // nothing pinned it before — every other suite replaced `isFlipt` outright.
+    expect(flagState.flags[PUBLIC_APPS_CATALOG_DISABLED_FLAG]).toBeUndefined();
+    await expect(isFlipt(PUBLIC_APPS_CATALOG_DISABLED_FLAG)).resolves.toBe(false);
+    // …and the throw really happened, so this is the fail-closed path rather than a
+    // flag that quietly evaluated to `false`.
+    expect(engineCalls.keys).toContain(PUBLIC_APPS_CATALOG_DISABLED_FLAG);
+  });
+
+  it('so the as-merged configuration serves the public floor to an anonymous caller', async () => {
+    const before = (await decisions('granted', 'rest-list')) ?? -1;
+    const m = await measure(undefined);
+    expect(m.own).toBe('none');
+    expect(m.served).toBe(PUBLIC_APPS_CATALOG_SCOPE);
+    expect(await decisions('granted', 'rest-list')).toBe(before + 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The switch itself — the branch production has never taken
+// ---------------------------------------------------------------------------
+
+describe('🔴 the kill switch ENABLED: `withheld` moves, and both REST surfaces go dark', () => {
+  beforeEach(() => {
+    flagState.flags[PUBLIC_APPS_CATALOG_DISABLED_FLAG] = {
+      kind: 'base',
+      enabled: true,
+    } satisfies FlagShape;
+  });
+
+  it.each(['rest-list', 'rest-detail'] as StoreScopeEntrypoint[])(
+    'an anonymous caller at `%s` is served `none` AND the withheld counter increments',
+    async (entrypoint) => {
+      const before = (await decisions('withheld', entrypoint)) ?? -1;
+      const m = await measure(undefined, entrypoint);
+
+      // `none` is exactly what `/api/v1/apps` renders as an empty page and
+      // `/api/v1/apps/{slug}` renders as a 404 — both handlers branch on this value.
+      expect(m.own).toBe('none');
+      expect(m.served).toBe('none');
+      // 🔴 The counter, by VALUE. Asserting only the return value would pass on a
+      // decision that took the right branch and recorded the wrong outcome — which
+      // is the exact thing an operator watching this series would then misread.
+      expect(await decisions('withheld', entrypoint)).toBe(before + 1);
+    }
+  );
+
+  it('the two entrypoints are counted SEPARATELY (the label is not inert)', async () => {
+    const beforeList = (await decisions('withheld', 'rest-list')) ?? -1;
+    const beforeDetail = (await decisions('withheld', 'rest-detail')) ?? -1;
+    await resolvePublicAppsCatalogScope('none', 'rest-list');
+    expect(await decisions('withheld', 'rest-list')).toBe(beforeList + 1);
+    expect(await decisions('withheld', 'rest-detail')).toBe(beforeDetail);
+  });
+
+  it('`granted` does NOT move while the switch is on (the branches are exclusive)', async () => {
+    const before = (await decisions('granted', 'rest-list')) ?? -1;
+    await measure(undefined);
+    expect(await decisions('granted', 'rest-list')).toBe(before);
+  });
+
+  /**
+   * 🔴 THE NEVER-NARROWS INVARIANT, AT THE SEAM (civitai#4048).
+   *
+   * The withheld branch withdraws the public FLOOR; it must not revoke an
+   * entitlement the caller resolved for themselves. Driven end-to-end here — the
+   * cohort membership comes from the real `resolveStoreVisibilityScope` reading the
+   * real flag through the real client, not from a scope string handed to the
+   * decision.
+   */
+  it('a `public-external` caller KEEPS `public-external` through the enabled switch', async () => {
+    flagState.flags[EXTERNAL] = {
+      kind: 'segment',
+      base: false,
+      match: (ctx) => ctx.userId === '777',
+    } satisfies FlagShape;
+
+    const m = await measure(makeUser({ id: 777 }));
+    expect(m.own).toBe('public-external');
+    expect(m.served).toBe('public-external');
+  });
+
+  it('a `full` caller keeps `full`, and never even reads the switch', async () => {
+    flagState.flags[LISTINGS] = { kind: 'base', enabled: true } satisfies FlagShape;
+    const user = makeUser({ id: 888 });
+    const own = await resolveStoreVisibilityScope({ user });
+    expect(own).toBe('full');
+
+    engineCalls.keys = [];
+    await expect(resolvePublicAppsCatalogScope(own, 'rest-list')).resolves.toBe('full');
+    expect(engineCalls.keys).not.toContain(PUBLIC_APPS_CATALOG_DISABLED_FLAG);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The discrimination, in one test, against one config
+// ---------------------------------------------------------------------------
+
+describe('🔴 OFF → ON → OFF, through the real client', () => {
+  it('the same anonymous caller flips floor → none → floor as the flag moves', async () => {
+    // Asserting one state proves nothing: a decision that is simply dark satisfies
+    // the ON arm, and one that ignores the flag satisfies the OFF arm. Only the
+    // transition discriminates.
+    expect((await measure(undefined)).served).toBe(PUBLIC_APPS_CATALOG_SCOPE);
+
+    flagState.flags[PUBLIC_APPS_CATALOG_DISABLED_FLAG] = {
+      kind: 'base',
+      enabled: true,
+    } satisfies FlagShape;
+    expect((await measure(undefined)).served).toBe('none');
+
+    flagState.flags[PUBLIC_APPS_CATALOG_DISABLED_FLAG] = {
+      kind: 'base',
+      enabled: false,
+    } satisfies FlagShape;
+    expect((await measure(undefined)).served).toBe(PUBLIC_APPS_CATALOG_SCOPE);
+  });
+
+  it('an explicitly-DISABLED flag is the same as an absent one (a created-but-off switch is safe)', async () => {
+    // Two different mechanisms reaching the same answer — `enabled: false` returns
+    // false, an absent flag throws and is caught. An operator who creates the flag
+    // before flipping it must not take the endpoint dark by doing so.
+    flagState.flags[PUBLIC_APPS_CATALOG_DISABLED_FLAG] = {
+      kind: 'base',
+      enabled: false,
+    } satisfies FlagShape;
+    expect((await measure(undefined)).served).toBe(PUBLIC_APPS_CATALOG_SCOPE);
+  });
+});

--- a/src/server/services/blocks/__tests__/public-apps-catalog.test.ts
+++ b/src/server/services/blocks/__tests__/public-apps-catalog.test.ts
@@ -23,10 +23,16 @@ vi.mock('~/server/flipt/client', async (importOriginal) => ({
 }));
 
 import {
+  decidePublicCatalogScope,
   PUBLIC_APPS_CATALOG_DISABLED_FLAG,
   PUBLIC_APPS_CATALOG_SCOPE,
   resolvePublicAppsCatalogScope,
 } from '~/server/services/blocks/public-apps-catalog';
+import {
+  storeScopeRank,
+  narrowStoreScope,
+  type StoreVisibilityScope,
+} from '~/shared/utils/store-visibility-scope';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -61,24 +67,30 @@ describe('resolvePublicAppsCatalogScope — the public grant', () => {
   });
 });
 
-describe('resolvePublicAppsCatalogScope — a privileged caller is never touched', () => {
-  it.each(['full', 'public-external'] as const)(
-    'passes `%s` through verbatim, and does not even READ the kill switch',
-    async (scope) => {
-      await expect(resolvePublicAppsCatalogScope(scope, 'rest-list')).resolves.toBe(scope);
-      // Short-circuit, proven by absence of the eval: no configuration of the switch
-      // can narrow, widen or slow a caller who resolved a scope of their own.
-      expect(mockIsFlipt).not.toHaveBeenCalled();
-    }
-  );
+describe('resolvePublicAppsCatalogScope — a caller AT OR ABOVE the floor is never touched', () => {
+  // 🔴 "Privileged" is defined by RANK against the floor, not by "resolved something".
+  // With today's `full` floor that is the `full` callers and only them: a
+  // `public-external` caller is BELOW the floor and must meet the grant (see the
+  // truth table), which is civitai#4048 — the old `scope !== 'none'` short-circuit
+  // sent them past a grant that would have widened them.
+  it('passes `full` through verbatim, and does not even READ the kill switch', async () => {
+    await expect(resolvePublicAppsCatalogScope('full', 'rest-list')).resolves.toBe('full');
+    expect(mockIsFlipt).not.toHaveBeenCalled();
+  });
 
-  it.each(['full', 'public-external'] as const)(
-    'still passes `%s` through with the kill switch ON',
-    async (scope) => {
-      mockIsFlipt.mockResolvedValue(true);
-      await expect(resolvePublicAppsCatalogScope(scope, 'rest-list')).resolves.toBe(scope);
-    }
-  );
+  it('still passes `full` through with the kill switch ON', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    await expect(resolvePublicAppsCatalogScope('full', 'rest-list')).resolves.toBe('full');
+  });
+
+  it('a `public-external` caller keeps `public-external` when the switch is ON', async () => {
+    // The withheld branch returns the caller's OWN scope. It withdraws the public
+    // FLOOR; it does not revoke what they resolved for themselves.
+    mockIsFlipt.mockResolvedValue(true);
+    await expect(resolvePublicAppsCatalogScope('public-external', 'rest-list')).resolves.toBe(
+      'public-external'
+    );
+  });
 });
 
 describe('resolvePublicAppsCatalogScope — #4041 narrowing is applied FIRST', () => {
@@ -114,5 +126,188 @@ describe('resolvePublicAppsCatalogScope — #4041 narrowing is applied FIRST', (
     // And that shared answer is the closed one — so an absent scope cannot slip past
     // an operator who has deliberately withheld the catalog.
     expect(absent).toBe('none');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// civitai#4048 — the privilege INVERSION, and the invariant that replaces the
+// short-circuit which used to prevent it for free.
+// ---------------------------------------------------------------------------
+
+/** Every caller shape, including the ones production actually produces. */
+const CALLERS: [string, unknown][] = [
+  ['full', 'full'],
+  ['public-external', 'public-external'],
+  ['none', 'none'],
+  ['undefined (what production carries for an anonymous principal)', undefined],
+  ['garbage', 'not-a-scope'],
+];
+
+describe('🔴 civitai#4048: the FULL truth table — returned scope AND recorded outcome', () => {
+  /** The recorded outcome, read off the decision rather than the counter registry. */
+  async function decide(resolved: unknown, disabled: boolean) {
+    return decidePublicCatalogScope(resolved, PUBLIC_APPS_CATALOG_SCOPE, async () => disabled);
+  }
+
+  // Switch OFF — the as-merged production configuration. The inversion lives in the
+  // `public-external` row: BEFORE this change it returned `public-external`
+  // (outcome `privileged`), so a signed-in cohort member read FEWER listings from
+  // `GET /api/v1/apps` than an anonymous caller did. Measured live: 4 vs 14.
+  it.each([
+    ['full', 'full', 'privileged'],
+    ['public-external', 'full', 'granted'],
+    ['none', 'full', 'granted'],
+    [undefined, 'full', 'granted'],
+    ['not-a-scope', 'full', 'granted'],
+  ] as [unknown, StoreVisibilityScope, string][])(
+    'switch OFF: %s → %s (%s)',
+    async (input, expectedScope, expectedOutcome) => {
+      const d = await decide(input, false);
+      expect(d.scope).toBe(expectedScope);
+      expect(d.outcome).toBe(expectedOutcome);
+    }
+  );
+
+  // Switch ON — the grant is withdrawn, NOT the caller's own entitlement.
+  it.each([
+    ['full', 'full', 'privileged'],
+    ['public-external', 'public-external', 'withheld'],
+    ['none', 'none', 'withheld'],
+    [undefined, 'none', 'withheld'],
+    ['not-a-scope', 'none', 'withheld'],
+  ] as [unknown, StoreVisibilityScope, string][])(
+    'switch ON: %s → %s (%s)',
+    async (input, expectedScope, expectedOutcome) => {
+      const d = await decide(input, true);
+      expect(d.scope).toBe(expectedScope);
+      expect(d.outcome).toBe(expectedOutcome);
+    }
+  );
+
+  // The table above is only meaningful if the two halves DISAGREE somewhere — a
+  // resolver that ignored the switch entirely would satisfy neither half, but a
+  // resolver that ignored the INPUT would satisfy a table nobody re-read. Assert the
+  // discrimination explicitly.
+  it('the two halves are NOT the same table (the switch and the input both matter)', async () => {
+    const off = await Promise.all(CALLERS.map(([, v]) => decide(v, false)));
+    const on = await Promise.all(CALLERS.map(([, v]) => decide(v, true)));
+    expect(off.map((d) => d.scope)).not.toEqual(on.map((d) => d.scope));
+    expect(new Set(off.map((d) => d.outcome)).size).toBeGreaterThan(1);
+    expect(new Set(on.map((d) => d.scope)).size).toBeGreaterThan(1);
+  });
+
+  // …and the same table through the REAL entry point, so the extraction of
+  // `decidePublicCatalogScope` cannot drift from what the handlers actually call.
+  it.each(CALLERS)(
+    'the real resolver agrees with the decision for %s, both switch states',
+    async (_label, value) => {
+      for (const disabled of [false, true]) {
+        mockIsFlipt.mockResolvedValue(disabled);
+        const viaResolver = await resolvePublicAppsCatalogScope(value, 'rest-list');
+        expect(viaResolver, `disabled=${disabled}`).toBe((await decide(value, disabled)).scope);
+      }
+    }
+  );
+});
+
+/**
+ * 🔴 THE NEVER-NARROWS INVARIANT, as its own named property.
+ *
+ * The pre-#4048 code got this for free: it returned early for every non-`none`
+ * scope, so it could not possibly hand back less than it was given. Restructuring
+ * around a floor removes that guarantee — the withheld branch is one keystroke
+ * (`'none'`) away from narrowing the external-only cohort on a surface they are
+ * entitled to read, and that keystroke is what a reader would expect a "kill switch"
+ * to contain. So the invariant is stated, not inferred.
+ */
+describe('🔴 NEVER NARROWS: rank(result) >= rank(input), for every input × switch state', () => {
+  it.each(CALLERS)('%s', async (_label, value) => {
+    const own = narrowStoreScope(value);
+    for (const disabled of [false, true]) {
+      mockIsFlipt.mockResolvedValue(disabled);
+      const out = await resolvePublicAppsCatalogScope(value, 'rest-list');
+      expect(
+        storeScopeRank(out),
+        `input=${own} disabled=${disabled} → ${out}`
+      ).toBeGreaterThanOrEqual(storeScopeRank(own));
+    }
+  });
+
+  // POSITIVE CONTROL for the assertion above: `toBeGreaterThanOrEqual` over ranks is
+  // a real discrimination, not a comparison that can only ever hold. A deliberately
+  // narrowing decision must fail it.
+  it('POSITIVE CONTROL: a narrowing result WOULD fail this assertion', () => {
+    expect(() =>
+      expect(storeScopeRank('none')).toBeGreaterThanOrEqual(storeScopeRank('public-external'))
+    ).toThrow();
+  });
+});
+
+/**
+ * The floor constant is documented as a ONE-LINE product edit ("narrow the public
+ * catalog to `public-external`"). A resolver that named scopes instead of comparing
+ * ranks would break silently under that edit — a `full` caller would stop
+ * short-circuiting, or a `public-external` caller would be "widened" to a narrower
+ * floor. Run the narrowed configuration against the REAL decision function rather
+ * than reasoning about it.
+ */
+describe('🔴 parameterised over the FLOOR: the narrowed-floor configuration still holds', () => {
+  const NARROW: StoreVisibilityScope = 'public-external';
+
+  it('a `full` caller still short-circuits as `privileged` under a `public-external` floor', async () => {
+    const readSwitch = vi.fn(async () => false);
+    const d = await decidePublicCatalogScope('full', NARROW, readSwitch);
+    expect(d).toEqual({ scope: 'full', outcome: 'privileged' });
+    // …and still does not pay for the kill-switch read.
+    expect(readSwitch).not.toHaveBeenCalled();
+  });
+
+  it('a `public-external` caller short-circuits too (at the floor, not above it)', async () => {
+    const readSwitch = vi.fn(async () => false);
+    const d = await decidePublicCatalogScope('public-external', NARROW, readSwitch);
+    expect(d).toEqual({ scope: 'public-external', outcome: 'privileged' });
+    expect(readSwitch).not.toHaveBeenCalled();
+  });
+
+  it('a `none`/absent caller is lifted to the NARROWED floor, not to `full`', async () => {
+    for (const input of ['none', undefined, 'nonsense']) {
+      const d = await decidePublicCatalogScope(input, NARROW, async () => false);
+      expect(d, `input=${String(input)}`).toEqual({
+        scope: 'public-external',
+        outcome: 'granted',
+      });
+    }
+  });
+
+  it('never narrows under the narrowed floor either, in both switch states', async () => {
+    for (const [, value] of CALLERS)
+      for (const disabled of [false, true]) {
+        const own = narrowStoreScope(value);
+        const d = await decidePublicCatalogScope(value, NARROW, async () => disabled);
+        expect(storeScopeRank(d.scope), `input=${own} disabled=${disabled}`).toBeGreaterThanOrEqual(
+          storeScopeRank(own)
+        );
+      }
+  });
+
+  // The floor sweep is the general statement: for EVERY floor in the closed set, and
+  // every caller, the decision never narrows and never exceeds max(own, floor).
+  it('over EVERY floor × EVERY caller × both switch states', async () => {
+    let cases = 0;
+    for (const floor of ['none', 'public-external', 'full'] as StoreVisibilityScope[])
+      for (const [, value] of CALLERS)
+        for (const disabled of [false, true]) {
+          const own = narrowStoreScope(value);
+          const d = await decidePublicCatalogScope(value, floor, async () => disabled);
+          const ceiling = Math.max(storeScopeRank(own), storeScopeRank(floor));
+          expect(storeScopeRank(d.scope), `${own}/${floor}/${disabled}`).toBeGreaterThanOrEqual(
+            storeScopeRank(own)
+          );
+          expect(storeScopeRank(d.scope), `${own}/${floor}/${disabled}`).toBeLessThanOrEqual(
+            ceiling
+          );
+          cases++;
+        }
+    expect(cases).toBe(30);
   });
 });

--- a/src/server/services/blocks/public-apps-catalog.ts
+++ b/src/server/services/blocks/public-apps-catalog.ts
@@ -1,7 +1,13 @@
 import { isFlipt } from '~/server/flipt/client';
-import { narrowStoreScope, type StoreVisibilityScope } from '~/shared/utils/store-visibility-scope';
+import {
+  narrowStoreScope,
+  storeScopeRank,
+  widerStoreScope,
+  type StoreVisibilityScope,
+} from '~/shared/utils/store-visibility-scope';
 import {
   recordPublicCatalogDecision,
+  type PublicCatalogOutcome,
   type StoreScopeEntrypoint,
 } from '~/server/prom/store-scope.metrics';
 
@@ -42,14 +48,23 @@ import {
  *   1. NARROW first ({@link narrowStoreScope}) — #4041's fail-closed rule is
  *      applied unchanged and FIRST, so an absent or uninterpretable value can never
  *      be mistaken for an entitlement.
- *   2. A caller who resolved a real scope (`full` for a moderator / app-dev-tester,
- *      `public-external` for the external-only cohort) is returned VERBATIM. The
- *      public grant is a FLOOR, never a ceiling: it can only ever lift a caller who
- *      resolved `none`, and it short-circuits before the kill switch is even read,
- *      so a privileged caller is unaffected by this module in every configuration.
- *   3. Everyone else — `none` — gets {@link PUBLIC_APPS_CATALOG_SCOPE}, unless the
- *      operator kill switch is on, in which case they get `none` and the endpoints
- *      go back to an empty page / 404.
+ *   2. A caller already AT OR ABOVE the floor — compared by
+ *      {@link storeScopeRank}, never by naming a scope — is returned VERBATIM and
+ *      never pays for the kill-switch eval, because the grant has nothing it could
+ *      add to them. With today's `full` floor that is exactly the `full` callers.
+ *   3. Everyone else meets the grant. If the operator kill switch is ON the grant is
+ *      withheld and the caller gets THEIR OWN resolved scope back — `none` for an
+ *      anonymous caller (empty page / 404), `public-external` for the external-only
+ *      cohort. Otherwise they get the WIDER of their own scope and
+ *      {@link PUBLIC_APPS_CATALOG_SCOPE}.
+ *
+ * 🔴 THE INVARIANT THAT REPLACES THE OLD SHORT-CIRCUIT: this module NEVER returns a
+ * scope narrower than the one the caller resolved, in any configuration of the kill
+ * switch. The pre-#4048 code got that for free by returning early for every non-
+ * `none` scope; the widening restructure has to state it and test it, because the
+ * one edit that would break it — closing the withheld branch to a literal `'none'` —
+ * looks like the obviously-correct thing to write. `widerStoreScope` on one arm and
+ * the caller's own scope on the other are what keep it true.
  *
  * ## The fail-closed invariant this preserves (read this before "simplifying" it)
  *
@@ -64,19 +79,32 @@ import {
  * the two public REST handlers and nothing else imports it.
  *
  * ⚠️ Honest consequence, stated rather than discovered later: while the grant is
- * active, `public-external` is not a narrower answer than the public floor at these
- * two endpoints — the floor is already `full`, so a caller in the external-only
- * cohort and an anonymous caller read the same catalog here. The distinction starts
- * to matter again the moment the kill switch is thrown, and it has always mattered
- * on the tRPC/page surfaces, which this module does not touch.
+ * active and the floor is `full`, a caller in the external-only cohort and an
+ * anonymous caller read the SAME catalog at these two endpoints — the cohort member
+ * is WIDENED to the floor rather than held at `public-external`. That is deliberate.
+ * The floor is public: withholding onsite listings from a signed-in cohort member
+ * that an anonymous caller can read anyway protects nothing, and doing it produced a
+ * live inversion where signing in REDUCED what `GET /api/v1/apps` returned
+ * (civitai#4048 — measured 14 items anonymous vs 4 for the cohort). The distinction
+ * between the two callers reappears the moment the kill switch is thrown — the
+ * cohort member keeps `public-external`, the anonymous caller drops to `none` — and
+ * it has always mattered on the tRPC/page surfaces, which this module does not touch.
  */
 
 /**
- * What the public catalog is readable AS. `full` — both `onsite` and `offsite`
- * approved listings, which is what `GET /api/v1/apps` has been serving publicly all
- * along (measured: 14 items, 10 onsite + 4 offsite). This constant exists so
- * narrowing the public catalog later (e.g. to `public-external`) is a one-line,
- * reviewable product decision rather than an edit threaded through two handlers.
+ * The public catalog FLOOR — what a caller with no scope of their own is lifted to.
+ * `full` — both `onsite` and `offsite` approved listings, which is what
+ * `GET /api/v1/apps` has been serving publicly all along (measured: 14 items,
+ * 10 onsite + 4 offsite). This constant exists so narrowing the public catalog later
+ * (e.g. to `public-external`) is a one-line, reviewable product decision rather than
+ * an edit threaded through two handlers.
+ *
+ * 🔴 THE RESOLVER MUST STAY CORRECT UNDER THAT ONE-LINE EDIT. Nothing below compares
+ * against a named scope; it compares RANKS against whatever this constant holds. Set
+ * it to `public-external` and a `full` caller still short-circuits as `privileged`,
+ * a `public-external` caller short-circuits too, and a `none` caller is lifted to
+ * `public-external`. The suite runs that configuration explicitly rather than
+ * trusting the reading.
  *
  * Approved-only, deploy-gated and maturity-gated filtering still applies inside the
  * listing service — `full` is a KIND predicate, not "everything in the table".
@@ -85,8 +113,12 @@ export const PUBLIC_APPS_CATALOG_SCOPE: StoreVisibilityScope = 'full';
 
 /**
  * Operator KILL SWITCH for the public catalog. Flipt flag; when it resolves TRUE the
- * public grant is withheld and an unauthenticated caller is back to an empty page /
- * 404. Privileged callers are unaffected (they never reach it).
+ * public GRANT is withheld — every caller is left with the scope they resolved for
+ * themselves and nothing more. For an unauthenticated caller that is `none`, i.e. an
+ * empty page / 404, which is the whole point of the switch. It is NOT a global
+ * blackout: a caller in the external-only cohort still reads `public-external`
+ * through it, and a `full` caller never reaches it at all. The switch withdraws the
+ * public floor; it cannot take away an entitlement the caller already had.
  *
  * 🔴 THE POLARITY IS THE WHOLE POINT — it is a DISABLE flag, not an ENABLE flag.
  * `isFlipt` returns `false` for a flag that does not exist and for an unreachable
@@ -119,6 +151,49 @@ async function isPublicAppsCatalogDisabled(): Promise<boolean> {
 }
 
 /**
+ * The decision itself, with the FLOOR and the kill-switch read passed in — the whole
+ * of the policy, and the only copy of it.
+ *
+ * The floor is a PARAMETER rather than a closed-over constant for one reason: the
+ * constant is documented as a one-line product edit, and a test that cannot run the
+ * narrowed-floor configuration against THIS function has to re-implement the policy
+ * to check it, which pins a copy instead of the code. `resolvePublicAppsCatalogScope`
+ * supplies {@link PUBLIC_APPS_CATALOG_SCOPE}; nothing else should.
+ *
+ * @param readKillSwitch a THUNK, not a boolean — the privileged branch must return
+ *   without evaluating it, so a caller at or above the floor pays no Flipt round trip
+ *   in any configuration. Passing an already-awaited boolean would quietly lose that.
+ * @returns the scope to serve AND the outcome to record, so the counter cannot drift
+ *   out of step with the branch that was actually taken.
+ */
+export async function decidePublicCatalogScope(
+  resolved: unknown,
+  floor: StoreVisibilityScope,
+  readKillSwitch: () => Promise<boolean>
+): Promise<{ scope: StoreVisibilityScope; outcome: PublicCatalogOutcome }> {
+  // 1. #4041's rule, first and unchanged: anything uninterpretable becomes `none`.
+  const scope = narrowStoreScope(resolved);
+  // 2. Already at or above the floor ⇒ the grant has nothing to add. Compared by
+  //    RANK, not by naming a scope, so this stays correct if the floor is narrowed —
+  //    and so a privileged caller never pays for the kill-switch read below.
+  if (storeScopeRank(scope) >= storeScopeRank(floor)) {
+    return { scope, outcome: 'privileged' };
+  }
+  // 3. The grant, unless an operator has withheld it. 🔴 WITHHELD RETURNS THE
+  //    CALLER'S OWN SCOPE, NEVER A LITERAL `'none'`: the switch withdraws the public
+  //    FLOOR, it does not revoke an entitlement the caller resolved for themselves.
+  //    Writing `scope: 'none'` here narrows the external-only cohort on a surface
+  //    they are entitled to read, which is the invariant stated in the module doc.
+  if (await readKillSwitch()) {
+    return { scope, outcome: 'withheld' };
+  }
+  // 4. Lift to the floor — `widerStoreScope`, so this can only ever RAISE the
+  //    caller's scope. A plain `scope: floor` would be a NARROWING for any caller
+  //    above a later-narrowed floor.
+  return { scope: widerStoreScope(scope, floor), outcome: 'granted' };
+}
+
+/**
  * Resolve what the PUBLIC REST catalog endpoints may serve this caller.
  *
  * @param resolved the raw value from `resolveStoreVisibilityScope` — typed `unknown`
@@ -131,20 +206,11 @@ export async function resolvePublicAppsCatalogScope(
   resolved: unknown,
   entrypoint: StoreScopeEntrypoint
 ): Promise<StoreVisibilityScope> {
-  // 1. #4041's rule, first and unchanged: anything uninterpretable becomes `none`.
-  const scope = narrowStoreScope(resolved);
-  // 2. A caller who resolved a real scope keeps it verbatim — and never pays for the
-  //    kill-switch eval, so this module cannot narrow, widen or slow a privileged
-  //    read in any configuration.
-  if (scope !== 'none') {
-    recordPublicCatalogDecision('privileged', entrypoint);
-    return scope;
-  }
-  // 3. The public floor, unless an operator has withheld it.
-  if (await isPublicAppsCatalogDisabled()) {
-    recordPublicCatalogDecision('withheld', entrypoint);
-    return 'none';
-  }
-  recordPublicCatalogDecision('granted', entrypoint);
-  return PUBLIC_APPS_CATALOG_SCOPE;
+  const { scope, outcome } = await decidePublicCatalogScope(
+    resolved,
+    PUBLIC_APPS_CATALOG_SCOPE,
+    isPublicAppsCatalogDisabled
+  );
+  recordPublicCatalogDecision(outcome, entrypoint);
+  return scope;
 }

--- a/src/shared/utils/__tests__/store-visibility-scope.test.ts
+++ b/src/shared/utils/__tests__/store-visibility-scope.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   isStoreVisibilityScope,
   narrowStoreScope,
+  storeScopeRank,
+  STORE_VISIBILITY_SCOPE_RANK,
   STORE_VISIBILITY_SCOPES,
+  widerStoreScope,
+  type StoreVisibilityScope,
 } from '~/shared/utils/store-visibility-scope';
 
 /**
@@ -48,4 +52,89 @@ describe('narrowStoreScope — an unrecognized scope resolves to `none`, never t
     for (const value of [undefined, null, '', 'FULL', 0, {}, []])
       expect(isStoreVisibilityScope(value)).toBe(false);
   });
+});
+
+/**
+ * The BREADTH ORDERING (civitai#4048). The bug it replaces was a call site standing
+ * in a hardcoded `scope !== 'none'` for "at least as wide as the public floor": it
+ * short-circuited `public-external` — a NARROWER scope — past a grant that would have
+ * widened it, so signing in REDUCED what a public REST endpoint returned.
+ *
+ * These tests pin the ordering as an ALGEBRA rather than as three remembered
+ * comparisons, because the property the call sites rely on is algebraic: a floor
+ * applied with {@link widerStoreScope} can only ever LIFT.
+ */
+describe('the scope breadth ordering: none ⊂ public-external ⊂ full', () => {
+  const ALL = STORE_VISIBILITY_SCOPES;
+
+  it('ranks the closed set in exactly subset order', () => {
+    expect(storeScopeRank('none')).toBeLessThan(storeScopeRank('public-external'));
+    expect(storeScopeRank('public-external')).toBeLessThan(storeScopeRank('full'));
+  });
+
+  // 🔴 widerStoreScope is commutative ONLY because equal ranks imply equal scopes.
+  // Two scopes sharing a rank would silently make it return whichever came first, so
+  // the injectivity is a load-bearing property, not a coincidence of the literals.
+  it('the ranks are DISTINCT (what makes the tie-break case unreachable)', () => {
+    const ranks = ALL.map((s) => STORE_VISIBILITY_SCOPE_RANK[s]);
+    expect(new Set(ranks).size).toBe(ranks.length);
+  });
+
+  it('the rank map covers the closed set exactly — no extra key, no missing key', () => {
+    expect(Object.keys(STORE_VISIBILITY_SCOPE_RANK).sort()).toEqual([...ALL].sort());
+  });
+
+  it('is TOTAL over the closed set: all 9 pairs return a member of the set', () => {
+    let pairs = 0;
+    for (const a of ALL)
+      for (const b of ALL) {
+        pairs++;
+        expect(isStoreVisibilityScope(widerStoreScope(a, b))).toBe(true);
+      }
+    expect(pairs).toBe(9);
+  });
+
+  it('is COMMUTATIVE over all 9 pairs', () => {
+    for (const a of ALL)
+      for (const b of ALL) expect(widerStoreScope(a, b), `${a}/${b}`).toBe(widerStoreScope(b, a));
+  });
+
+  it('is IDEMPOTENT and ASSOCIATIVE', () => {
+    for (const a of ALL) expect(widerStoreScope(a, a)).toBe(a);
+    for (const a of ALL)
+      for (const b of ALL)
+        for (const c of ALL)
+          expect(widerStoreScope(widerStoreScope(a, b), c), `${a}/${b}/${c}`).toBe(
+            widerStoreScope(a, widerStoreScope(b, c))
+          );
+  });
+
+  // The property every caller actually depends on, asserted directly rather than
+  // inferred from the table below: applying a floor NEVER narrows either operand.
+  it('🔴 NEVER NARROWS: the result is at least as wide as BOTH operands', () => {
+    for (const a of ALL)
+      for (const b of ALL) {
+        const w = widerStoreScope(a, b);
+        expect(storeScopeRank(w), `${a}/${b}`).toBeGreaterThanOrEqual(storeScopeRank(a));
+        expect(storeScopeRank(w), `${a}/${b}`).toBeGreaterThanOrEqual(storeScopeRank(b));
+      }
+  });
+
+  // And the literal table, so an inverted rank map cannot pass every algebraic law
+  // above (it would: reversing the order preserves totality, commutativity,
+  // associativity and idempotence — only the DIRECTION changes).
+  it.each([
+    ['none', 'none', 'none'],
+    ['none', 'public-external', 'public-external'],
+    ['none', 'full', 'full'],
+    ['public-external', 'public-external', 'public-external'],
+    ['public-external', 'full', 'full'],
+    ['full', 'full', 'full'],
+  ] as [StoreVisibilityScope, StoreVisibilityScope, StoreVisibilityScope][])(
+    'wider(%s, %s) === %s',
+    (a, b, expected) => {
+      expect(widerStoreScope(a, b)).toBe(expected);
+      expect(widerStoreScope(b, a)).toBe(expected);
+    }
+  );
 });

--- a/src/shared/utils/store-visibility-scope.ts
+++ b/src/shared/utils/store-visibility-scope.ts
@@ -1,6 +1,7 @@
 /**
- * The App-store read VISIBILITY SCOPE — its closed value set, and the ONE
- * narrowing rule every consumer applies to an untrusted / possibly-absent scope.
+ * The App-store read VISIBILITY SCOPE — its closed value set, the ONE narrowing
+ * rule every consumer applies to an untrusted / possibly-absent scope, and the ONE
+ * breadth ORDERING every consumer compares scopes with.
  *
  * ## Why this lives in its own dependency-free module (civitai#3983)
  *
@@ -72,4 +73,64 @@ export function isStoreVisibilityScope(value: unknown): value is StoreVisibility
  */
 export function narrowStoreScope(value: unknown): StoreVisibilityScope {
   return isStoreVisibilityScope(value) ? value : 'none';
+}
+
+/**
+ * The scopes RANKED BY BREADTH — a subset lattice, not a preference order:
+ *
+ *   none  ⊂  public-external  ⊂  full
+ *    ∅        kind='offsite'     every kind
+ *
+ * `none` is the EMPTY set (the caller sees nothing). `public-external` admits
+ * exactly the `kind='offsite'` approved listings. `full` admits those AND the
+ * `onsite` ones, so it is a STRICT SUPERSET of `public-external`. Every pair is
+ * therefore comparable — the set is TOTALLY ordered, which is what makes
+ * {@link widerStoreScope} well-defined with no tie-break rule to get wrong.
+ *
+ * 🔴 THE ORDER IS DECLARED ONCE, HERE, AND EVERY COMPARISON IS DERIVED FROM IT.
+ * Not because a chain of `===` tests would be ugly, but because such a chain has to
+ * be re-audited at every call site whenever the closed set grows, and one of them
+ * will be missed. civitai#4048 was that bug in its simplest form: `scope !== 'none'`
+ * standing in for "at least as wide as the public floor", which silently made
+ * `public-external` — a NARROWER scope — short-circuit past a grant that would have
+ * widened it, so signing in REDUCED what a public endpoint returned.
+ *
+ * 🔴 The ranks must stay DISTINCT. {@link widerStoreScope} is commutative only
+ * because equal ranks imply equal scopes; two scopes sharing a rank would make it
+ * return whichever argument came first. Pinned by the suite.
+ */
+export const STORE_VISIBILITY_SCOPE_RANK: Readonly<Record<StoreVisibilityScope, number>> = {
+  none: 0,
+  'public-external': 1,
+  full: 2,
+};
+
+/**
+ * How much a scope admits, as a comparable number. Compare RANKS rather than
+ * spelling out which scope is which — see the rank map's note above.
+ *
+ * Takes an already-narrowed scope: run untrusted input through
+ * {@link narrowStoreScope} first, so an uninterpretable value is ranked as the
+ * empty set rather than falling off the map.
+ */
+export function storeScopeRank(scope: StoreVisibilityScope): number {
+  return STORE_VISIBILITY_SCOPE_RANK[scope];
+}
+
+/**
+ * The WIDER of two scopes — the LEAST UPPER BOUND on a totally-ordered set, so it
+ * is total (defined for all 9 pairs), commutative, associative and idempotent.
+ *
+ * Use it wherever a floor is being applied to a caller's own scope: it can only
+ * ever LIFT, never narrow, which is the property a hand-written conditional keeps
+ * losing. It is NOT a union of arbitrary sets — it relies on the subset chain
+ * documented on {@link STORE_VISIBILITY_SCOPE_RANK}, and a future scope that is
+ * incomparable with the existing three (say, onsite-only) would break that
+ * assumption and must not simply be given a rank.
+ */
+export function widerStoreScope(
+  a: StoreVisibilityScope,
+  b: StoreVisibilityScope
+): StoreVisibilityScope {
+  return storeScopeRank(a) >= storeScopeRank(b) ? a : b;
 }

--- a/src/tests/api/v1/apps/apps.absent-scope-fail-closed.test.ts
+++ b/src/tests/api/v1/apps/apps.absent-scope-fail-closed.test.ts
@@ -241,7 +241,20 @@ describe('GET /api/v1/apps — an absent scope must never buy more than a resolv
     expect((res.body as { items: unknown[] }).items).toHaveLength(2);
   });
 
-  it('POSITIVE CONTROL: a resolved `public-external` is threaded through unchanged', async () => {
+  // 🔴 CHANGED BY civitai#4048, deliberately. A `public-external` caller is BELOW the
+  // public floor, so with the grant ACTIVE they are widened to it — before #4048 they
+  // short-circuited past the grant and read FEWER listings than an anonymous caller
+  // did from the same endpoint (measured live: 4 vs 14). The pass-through property
+  // still holds where it means something: with the grant WITHHELD.
+  it('a resolved `public-external` is WIDENED to the public floor while the grant is active', async () => {
+    const res = await callList('public-external');
+    expect(res.serviceCalls).toEqual([expect.objectContaining({ scope: 'full' })]);
+  });
+
+  it('POSITIVE CONTROL: with the switch ON, a resolved `public-external` is threaded through unchanged', async () => {
+    // The never-narrows invariant at the handler: withholding the public FLOOR must
+    // not revoke the scope this caller resolved for themselves.
+    mockIsFlipt.mockResolvedValue(true);
     const res = await callList('public-external');
     expect(res.serviceCalls).toEqual([expect.objectContaining({ scope: 'public-external' })]);
   });

--- a/src/tests/api/v1/apps/apps.test.ts
+++ b/src/tests/api/v1/apps/apps.test.ts
@@ -209,8 +209,26 @@ describe('GET /api/v1/apps (list)', () => {
     expect(opts).toMatchObject({ scope: 'full' });
   });
 
-  it('serves the public-external scope (offsite-only) to a widened caller', async () => {
+  // 🔴 civitai#4048: the external-only cohort is BELOW the public floor, so while the
+  // grant is active they are LIFTED to it rather than held at `public-external`.
+  // Before the fix they short-circuited past the grant, which meant signing in
+  // REDUCED what this public endpoint returned (measured live: 4 items vs 14).
+  it('lifts a `public-external` caller to the public floor while the grant is active', async () => {
     mockResolveScope.mockResolvedValueOnce('public-external');
+    const { req, res } = createMocks();
+    await (listHandler as unknown as Handler)(req, res, undefined);
+    expect(res._status()).toBe(200);
+    const [, opts] = mockList.mock.calls[0];
+    expect(opts).toMatchObject({ scope: 'full' });
+  });
+
+  // …and the other half of the same invariant: the kill switch withdraws the public
+  // FLOOR, it does not revoke what the caller resolved for themselves. A handler that
+  // narrowed this caller to `none` would 200-with-an-empty-page a cohort member who is
+  // entitled to the offsite catalog.
+  it('serves the public-external scope (offsite-only) when the grant is WITHHELD', async () => {
+    mockResolveScope.mockResolvedValueOnce('public-external');
+    mockIsFlipt.mockResolvedValue(true);
     const { req, res } = createMocks();
     await (listHandler as unknown as Handler)(req, res, undefined);
     expect(res._status()).toBe(200);


### PR DESCRIPTION
Both follow-ups from #4048.

## Follow-up 1 — the privilege inversion

`resolvePublicAppsCatalogScope` short-circuited on `scope !== 'none'`, so a caller who
resolved *any* scope of their own was handed it verbatim and never met the public grant.
That is correct for `full`, and wrong for `public-external`: the external-only cohort is
**narrower** than the public floor, so a signed-in cohort member got 4 listings from
`GET /api/v1/apps` while an anonymous caller got 14. Signing in reduced what a public
endpoint returned. Not a leak — the floor is already public — but a real defect.

The grant is a **floor**, so the fix is to take the wider of the two:

- `src/shared/utils/store-visibility-scope.ts` gains a declared breadth rank
  (`none` < `public-external` < `full`) plus `widerStoreScope` — the least upper bound
  over it. Structural, derived from one rank map, and the module stays dependency-free.
  The order is documented as a subset chain: `public-external` is exactly the
  `kind='offsite'` approved listings, `full` is that plus onsite, `none` is the empty set.
- the short-circuit now compares **ranks against the floor**, never a named scope.
- the withheld branch returns the caller's **own** resolved scope.
- the granted branch returns `widerStoreScope(scope, floor)`.
- the policy moved into `decidePublicCatalogScope(resolved, floor, readKillSwitch)` —
  the floor is a parameter so a test can run the narrowed-floor configuration against
  the real code instead of a re-implementation, `readKillSwitch` is a thunk so the
  privileged branch still returns without paying for the Flipt read, and the function
  returns the outcome alongside the scope so the counter cannot drift out of step with
  the branch actually taken.

### Truth table (floor = `full`) — scope returned / outcome recorded

| caller resolved | switch OFF | switch ON |
|---|---|---|
| `full` | `full` / `privileged` (switch never read) | `full` / `privileged` (switch never read) |
| `public-external` | **`full` / `granted`** ← was `public-external` / `privileged` | `public-external` / `withheld` |
| `none` | `full` / `granted` | `none` / `withheld` |
| `undefined` | `full` / `granted` | `none` / `withheld` |
| garbage string | `full` / `granted` | `none` / `withheld` |

#4041's narrowing still runs **first**, so `undefined` and a garbage value remain
indistinguishable from a resolved `none` in both columns.

### The never-narrows invariant

The old code got this for free — it returned early for every non-`none` scope, so it
could not hand back less than it was given. Restructuring around a floor removes that
guarantee, and the one edit that would break it (`return 'none'` in the withheld branch)
is exactly what a reader expects a "kill switch" to contain. So it is stated in the
module doc and asserted as its own named test: for every input scope and both switch
states, `rank(result) >= rank(input)`. Also swept over every floor × every caller ×
both switch states (30 cases), bounded above by `max(rank(own), rank(floor))`.

### Docs rewritten against the implementation

The module's numbered steps and its "⚠️ Honest consequence" paragraph both became false;
so did "kill switch → `none`" in the `PUBLIC_APPS_CATALOG_DISABLED_FLAG` docstring, and
`withheld`'s meaning in `recordPublicCatalogDecision`'s docstring and the Prometheus
`help` string. All rewritten by re-reading the code afterwards. `withheld` now reads as
"the public **grant** was withheld", which no longer implies the caller got nothing.

## Follow-up 2 — prove the kill switch

🔴 **The issue's stated premise for this follow-up is stale, and this PR does not build
on it.** #4048 says the switch depends on "the same async Flipt path whose value goes
missing for anonymous principals". That was #3983, since root-caused to the bundler
dropping branches from the production build and fixed by #4075; anonymous Flipt
evaluation is healthy today. So there is no anonymous evaluation defect to route around
and **no env-var override is added** — this is coverage, not re-plumbing.

What *is* real: `civitai_app_store_public_catalog_decisions_total` has only ever recorded
`outcome="granted"`. `withheld` has never moved. Every existing suite that touches the
switch replaces `isFlipt` with a `vi.fn()` or a hand-written truth table, so the branch
had never executed against the real client.

New: `src/server/services/__tests__/public-apps-catalog.kill-switch.seam.test.ts`. The
fake is pushed one layer **below** `isFlipt`, at `@flipt-io/flipt-client-js`: the
evaluation engine is faked over a declared flag config and everything above it is real —
the app's flag client, `@civitai/flipt`'s cache/localOverrides/try-catch, the real
`resolveStoreVisibilityScope`, the real decision, and real prom-client counters. That
matters for the polarity claim specifically: a hand-written double answers `false` for an
absent flag because its author wrote `?? false`; the real one answers `false` because the
engine **throws** "flag not found" and the factory fails closed. The fake throws, so the
mechanism is what is under test.

Asserted: flag absent → grant on, anonymous caller gets the floor, `granted` increments;
flag enabled → `withheld` increments and an anonymous caller gets `none` at **both**
entrypoint labels (the value both REST handlers branch on for their empty-page / 404);
a `public-external` caller keeps `public-external` under the same enabled switch; a `full`
caller never reads the switch at all; and an explicitly-`enabled: false` flag behaves like
an absent one, so creating the flag before flipping it is safe.

Instrument controls in the same file: the engine is actually reached; the 10s eval cache
is disabled (with the default TTL the whole matrix would be the first answer replayed);
the counter handle exists in the registry, so a zero is a value rather than a miss;
**positive control** — `granted` increments by exactly one per call; **negative control** —
`withheld` does not move while the switch is off; and the two entrypoint labels are
counted separately.

Honest label, in the file: that suite is **green at `main`** (15/15). It is coverage for a
branch nothing exercised, not a regression test. The #4048 regression coverage is red at
base and lives in the unit + handler suites below.

## Verification

| gate | result |
|---|---|
| `pnpm typecheck` | 0 errors in 128s. Positive control: a planted `widerStoreScope(scope, 42)` reported as `public-apps-catalog.ts(193,42): error TS2345`, then removed. |
| node unit project (`vitest run --project 'unit*'`) | **1177 files passed / 1 skipped; 18549 tests passed / 21 skipped.** No timeout panic in the log. |
| touched suites | 8 files, **197 tests**, all green. |
| eslint | clean over all 8 touched files. |
| `pnpm prettier:check` | checked the 8-file dirty set, flagged 2, `prettier:write`, re-check clean. |

### Red at base / green at HEAD

With only the three **source** files reverted to `origin/main` and the new tests kept:
**41 failed / 111 passed (152)** across 4 files. Same tests at HEAD: green.
The two pre-existing assertions the behaviour change invalidates were rewritten rather
than deleted — `apps.test.ts` and `apps.absent-scope-fail-closed.test.ts` each now assert
the widening while the grant is active **and** the pass-through while it is withheld.

### Mutation matrix

Each mutant is the narrowest expression that can be wrong, applied on its own.

| # | mutant | killed by | assertion message |
|---|---|---|---|
| A | restore the pre-#4048 short-circuit: `if (scope !== 'none')` | 4 tests / 3 files — `switch OFF: public-external → full (granted)` | `expected 'public-external' to be 'full'` |
| B | withheld branch returns `{ scope: 'none' }` | 8 tests / 5 files — `🔴 NEVER NARROWS: rank(result) >= rank(input) … > public-external` | `input=public-external disabled=true → none: expected 0 to be greater than or equal to 1` |
| C1 | flip the comparison inside `widerStoreScope` (`>=` → `<=`) | 29 tests / 6 files — `🔴 NEVER NARROWS: the result is at least as wide as BOTH operands` | `full/public-external: expected 1 to be greater than or equal to 2` |
| C2 | invert the rank map (`none: 2 … full: 0`) | 40 tests / 6 files — `ranks the closed set in exactly subset order` | `expected 2 to be less than 1` |
| D | off-by-one on the short-circuit boundary (`>=` → `>`) | 6 tests / 2 files — `passes `full` through verbatim, and does not even READ the kill switch` | `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| E | record a hardcoded `'granted'` instead of the branch's outcome | 4 tests / 1 file — `an anonymous caller at `rest-list` is served `none` AND the withheld counter increments` | `expected +0 to be 1` |

No mutant survived. C1 is worth noting: it satisfies every algebraic law the suite asserts
(totality, commutativity, associativity, idempotence all survive an order inversion) — only
the never-narrows property and the literal pair table discriminate it, which is why both are
there.

## Not done

- The seam suite fakes the evaluation engine, so it says nothing about whether the flag, once
  created in flipt-state, is shaped the way the module doc requires (plain base boolean, no
  segments). The flag still does not exist, and does not need to.
- Handler rendering under the switch (empty page / 404) stays in `src/tests/api/v1/apps/*`;
  the seam suite asserts the scope both handlers branch on, not the response bytes.

Closes neither issue on its own — leaving #4048 open for the parent to triage.
