### PR TITLE
fix(apps): key the Recently-opened rail by account id (#4048 follow-up 3)

### DIFF
--- a/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
@@ -6,6 +6,15 @@ import { page } from 'vitest/browser';
 // useCurrentUser → useCivitaiSessionContext throws "missing CivitaiSessionContext"
 // with no provider. Mock it to a stable anon (non-mod) viewer so these
 // pre-existing chrome/breadcrumb assertions keep rendering network-free.
+/**
+ * This suite mounts ANONYMOUSLY (`useCurrentUser` is mocked to null below), and
+ * recents are ACCOUNT-scoped (#4048): the store hands a component back only the
+ * entries recorded by the SAME viewer, with `null` (signed out) as its own
+ * bucket. So every seed here must be written as `null` or the chrome's read
+ * returns nothing and the assertions below go red for the wrong reason.
+ */
+const SESSION_OWNER_ID: number | null = null;
+
 vi.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => null,
 }));
@@ -308,14 +317,23 @@ describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => 
 
   test('renders recents (icon + name), EXCLUDES the current app, links to /apps/run/<blockId>', async () => {
     // Seed newest-last so the resulting order is [other, noicon, current].
-    recordRecentlyOpenedApp({ id: 'current', blockId: 'current-block', name: 'Current App' });
-    recordRecentlyOpenedApp({ id: 'noicon', blockId: 'noicon-block', name: 'No Icon App' });
-    recordRecentlyOpenedApp({
-      id: 'other',
-      blockId: 'other-block',
-      name: 'Other App',
-      iconUrl: LOADABLE_IMAGE_DATA_URI,
-    });
+    recordRecentlyOpenedApp(
+      { id: 'current', blockId: 'current-block', name: 'Current App' },
+      SESSION_OWNER_ID
+    );
+    recordRecentlyOpenedApp(
+      { id: 'noicon', blockId: 'noicon-block', name: 'No Icon App' },
+      SESSION_OWNER_ID
+    );
+    recordRecentlyOpenedApp(
+      {
+        id: 'other',
+        blockId: 'other-block',
+        name: 'Other App',
+        iconUrl: LOADABLE_IMAGE_DATA_URI,
+      },
+      SESSION_OWNER_ID
+    );
 
     renderWithProviders(
       <AppBlockChrome
@@ -357,7 +375,10 @@ describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => 
     // `canOpenPage` is ON so the absence below is caused by SELF-EXCLUSION, not
     // by the fail-closed gate. Mutation-sanity: deleting the `r.id !==
     // currentAppBlockId` filter in selectChromeRecentApps makes this red.
-    recordRecentlyOpenedApp({ id: 'solo', blockId: 'solo-block', name: 'Solo App' });
+    recordRecentlyOpenedApp(
+      { id: 'solo', blockId: 'solo-block', name: 'Solo App' },
+      SESSION_OWNER_ID
+    );
 
     renderWithProviders(
       <AppBlockChrome
@@ -402,8 +423,14 @@ describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => 
   // store is what makes it a real assertion — the same seed with `canOpenPage`
   // renders two items (asserted in the first test above).
   test('OMITTING canOpenPage hides the section even with offerable recents (fail-closed)', async () => {
-    recordRecentlyOpenedApp({ id: 'other', blockId: 'other-block', name: 'Other App' });
-    recordRecentlyOpenedApp({ id: 'third', blockId: 'third-block', name: 'Third App' });
+    recordRecentlyOpenedApp(
+      { id: 'other', blockId: 'other-block', name: 'Other App' },
+      SESSION_OWNER_ID
+    );
+    recordRecentlyOpenedApp(
+      { id: 'third', blockId: 'third-block', name: 'Third App' },
+      SESSION_OWNER_ID
+    );
 
     renderWithProviders(
       <AppBlockChrome
@@ -435,7 +462,10 @@ describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => 
     // RLO override + zero-width space + a long tail well past APP_CHROME_NAME_MAX
     // (64). sanitizeAppChromeName strips the bidi/format chars and caps length.
     const rawName = 'Evil‮Hack​App' + 'X'.repeat(200);
-    recordRecentlyOpenedApp({ id: 'hostile', blockId: 'hostile-block', name: rawName });
+    recordRecentlyOpenedApp(
+      { id: 'hostile', blockId: 'hostile-block', name: rawName },
+      SESSION_OWNER_ID
+    );
 
     renderWithProviders(
       <AppBlockChrome
@@ -483,10 +513,11 @@ describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => 
     // Close the menu (Escape), then a NEW app is recorded mid-session (simulating
     // the viewer running another app via client-nav elsewhere in the SPA).
     await page.getByRole('button', { name: 'Apps menu' }).click();
-    await expect
-      .element(page.getByRole('menuitem', { name: 'Apps home' }))
-      .not.toBeInTheDocument();
-    recordRecentlyOpenedApp({ id: 'fresh', blockId: 'fresh-block', name: 'Fresh App' });
+    await expect.element(page.getByRole('menuitem', { name: 'Apps home' })).not.toBeInTheDocument();
+    recordRecentlyOpenedApp(
+      { id: 'fresh', blockId: 'fresh-block', name: 'Fresh App' },
+      SESSION_OWNER_ID
+    );
 
     // Re-open — the open-refresh read must surface the newly-recorded app.
     await openPlatformNav();

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -244,9 +244,13 @@ export function AppBlockChrome({
   // Excludes the app currently being viewed (matched by appBlockId — the store's
   // stable id) and is capped to a short list for the compact dropdown.
   const [recents, setRecents] = useState<RecentApp[]>([]);
+  // 🔴 Keyed by ACCOUNT (#4048) — localStorage is per browser profile, so the
+  // store hands back only what the CURRENT viewer recorded (`null` = signed
+  // out, its own bucket). In the dep list so an in-SPA account change re-reads.
+  const recentsOwnerId = currentUser?.id ?? null;
   useEffect(() => {
-    setRecents(getRecentlyOpenedApps());
-  }, []);
+    setRecents(getRecentlyOpenedApps(recentsOwnerId));
+  }, [recentsOwnerId]);
   // Which of those entries this menu may offer. The rules (off-site exclusion,
   // the `appBlocksPages` gate that keeps a dark-flag viewer off guaranteed-404
   // `/apps/run/` links, self-exclusion, the cap) live in the pure
@@ -263,10 +267,13 @@ export function AppBlockChrome({
   // store on the transition to open, so the "Recently run" list is fresh within
   // an SPA session. Still SSR-safe — the read only happens on a user-driven open
   // (never during render) and getRecentlyOpenedApps() self-guards `isClient`.
-  const handleMenuChange = useCallback((opened: boolean) => {
-    setMenuOpened(opened);
-    if (opened) setRecents(getRecentlyOpenedApps());
-  }, []);
+  const handleMenuChange = useCallback(
+    (opened: boolean) => {
+      setMenuOpened(opened);
+      if (opened) setRecents(getRecentlyOpenedApps(recentsOwnerId));
+    },
+    [recentsOwnerId]
+  );
   // The full-page run surface (`app.page`) has no model-page slot to hide the
   // block from — the page IS the block — so suppress the "Hide" item there.
   const isPage = slotId != null && isPageSlot(slotId);

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -605,7 +605,11 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
                 // route afterwards that could record it (the on-site path is
                 // recorded by `/apps/run/<slug>` itself). Recording on a detail
                 // VIEW would be wrong: browsing is not opening.
-                onClick={() => recordRecentlyOpenedApp(toRecentAppFromListing(card))}
+                // 🔴 Stamped with the viewer's account id (#4048) — recents are
+                // per-account, not per browser profile.
+                onClick={() =>
+                  recordRecentlyOpenedApp(toRecentAppFromListing(card), currentUser?.id ?? null)
+                }
               >
                 {cta.label}
               </Button>

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -41,7 +41,8 @@ const mocks = vi.hoisted(() => ({
   currentUser: null as null | { id: number; username: string },
   // Items the mocked `appListings.listAvailable` returns to the related rail.
   relatedItems: [] as unknown[],
-  // Every `recordRecentlyOpenedApp(...)` argument seen this test, in order.
+  // Every `recordRecentlyOpenedApp(...)` CALL seen this test, in order —
+  // `{ app, ownerId }`, because the owner is now half the contract (#4048).
   recorded: [] as unknown[],
   // What the mocked `user.getCreator` resolves to (the SmartCreatorCard's data).
   creator: null as null | Record<string, unknown>,
@@ -62,9 +63,12 @@ vi.mock('~/components/Apps/recentlyOpenedAppsStore', async (importOriginal) => {
   const actual = await importOriginal<typeof RecentsMod>();
   return {
     ...actual,
-    recordRecentlyOpenedApp: (app: Parameters<typeof actual.recordRecentlyOpenedApp>[0]) => {
-      mocks.recorded.push(app);
-      return actual.recordRecentlyOpenedApp(app);
+    recordRecentlyOpenedApp: (
+      app: Parameters<typeof actual.recordRecentlyOpenedApp>[0],
+      ownerId: Parameters<typeof actual.recordRecentlyOpenedApp>[1]
+    ) => {
+      mocks.recorded.push({ app, ownerId });
+      return actual.recordRecentlyOpenedApp(app, ownerId);
     },
   };
 });
@@ -166,6 +170,12 @@ vi.mock('~/components/UserAvatar/UserAvatar', () => ({
 
 // Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
 const { AppListingDetailBody } = await import('./AppListingDetailBody');
+// The store itself, through the same partial mock (the readers are the REAL
+// implementations — only the writer is wrapped above), so the owner-scoping
+// assertions below read what the component actually persisted.
+const { clearRecentlyOpenedApps, getRecentlyOpenedApps } = await import(
+  '~/components/Apps/recentlyOpenedAppsStore'
+);
 
 beforeEach(async () => {
   mocks.currentUser = null;
@@ -1189,6 +1199,36 @@ describe('AppListingDetailBody', () => {
     expect(mocks.recorded).toHaveLength(0); // a VIEW records nothing
     await withoutNavigating(() => userEvent.click(cta));
     expect(mocks.recorded).toHaveLength(1);
+  });
+
+  /**
+   * 🔴 BEHAVIOURAL COVER FOR THE CALL-SITE LEDGER (#4048).
+   *
+   * `recentsCallSites.test.ts` proves this module CALLS the store with a
+   * session-shaped owner expression; it cannot prove the expression reads the
+   * VIEWER. This does: a real click, a mounted session, and the entry readable
+   * by that account and by no other.
+   *
+   * The viewer id (77) is deliberately distinct from `base().creator.id` (5) —
+   * the plausible copy-paste is to stamp the listing's CREATOR, and against a
+   * fixture where the two coincide that mutant survives.
+   */
+  test('🔴 the recorded write is OWNED by the mounted session, not by anyone else', async () => {
+    clearRecentlyOpenedApps();
+    mocks.currentUser = { id: 77, username: 'viewer' };
+    const detail = offsite();
+    const { within } = await renderScoped(<AppListingDetailBody detail={detail} />);
+    const cta = within.getByTestId('apps-listing-open-live');
+    await expect.element(cta).toBeInTheDocument();
+    await withoutNavigating(() => userEvent.click(cta));
+
+    expect(mocks.recorded).toHaveLength(1);
+    expect((mocks.recorded[0] as { ownerId: unknown }).ownerId).toBe(77);
+    // …and the store agrees: only that account reads it back.
+    expect(getRecentlyOpenedApps(77).map((r) => r.id)).toEqual([detail.id]);
+    expect(getRecentlyOpenedApps(5)).toEqual([]); // the listing's creator
+    expect(getRecentlyOpenedApps(null)).toEqual([]); // the anonymous bucket
+    clearRecentlyOpenedApps();
   });
 
   test('🔴 the banner records recents exactly as the Open CTA does — i.e. not on click at all', async () => {

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -433,6 +433,11 @@ function ScreenshotGallery({
 /** Kind-aware primary action button + (for info/connect stubs) an inline note. */
 function PrimaryAction({ detail, canOpenPage }: { detail: ListingDetail; canOpenPage: boolean }) {
   const action = getDetailPrimaryAction(detail, { canOpenPage });
+  // The recents store is ACCOUNT-scoped (#4048): every write carries the id of
+  // the viewer who made it, so a later account in the same browser profile does
+  // not inherit this one's history. Read here rather than passed down as a prop
+  // — this is the component that owns the recording click.
+  const recentsOwnerId = useCurrentUser()?.id ?? null;
 
   // 🔴 Resolve the glyph INSIDE each branch, from the mode that branch has
   // already established — never once up front from `action.mode`. `href` is
@@ -476,7 +481,7 @@ function PrimaryAction({ detail, canOpenPage }: { detail: ListingDetail; canOpen
           // following this link IS the moment the app is opened, and it leaves
           // the SPA — so it is the only chance to record the open. A detail-page
           // VIEW never records.
-          onClick={() => recordRecentlyOpenedApp(toRecentAppFromListing(detail))}
+          onClick={() => recordRecentlyOpenedApp(toRecentAppFromListing(detail), recentsOwnerId)}
         >
           {action.label}
         </Button>

--- a/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
@@ -60,6 +60,13 @@ const mocks = vi.hoisted(() => ({
 // CivitaiSessionContext", crashing every card render. Mock a signed-out viewer.
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 
+/**
+ * This suite mounts ANONYMOUSLY (the mock above), and recents are ACCOUNT-scoped
+ * (#4048) with `null` — signed out — as its own bucket, not a wildcard. Seeds
+ * must therefore be written as `null`, or the body reads an empty rail.
+ */
+const SESSION_OWNER_ID: number | null = null;
+
 // Spread the REAL module and override only `trpc` (local-rules/no-wholesale-
 // module-mock): a hand-written replacement silently breaks every importer the
 // day '~/utils/trpc' grows an export this factory omits — the whole FILE then
@@ -408,14 +415,17 @@ describe('AppListingsMarketplaceBody', () => {
   });
 
   test('🔴 a viewer WITH recents sees the rail BELOW the controls and ABOVE the grid (CLS)', async () => {
-    recordRecentlyOpenedApp({
-      id: 'ab_1',
-      blockId: 'gen-matrix',
-      slug: 'gen-matrix',
-      kind: 'onsite',
-      hasPage: true,
-      name: 'Gen Matrix',
-    });
+    recordRecentlyOpenedApp(
+      {
+        id: 'ab_1',
+        blockId: 'gen-matrix',
+        slug: 'gen-matrix',
+        kind: 'onsite',
+        hasPage: true,
+        name: 'Gen Matrix',
+      },
+      SESSION_OWNER_ID
+    );
     renderWithProviders(<AppListingsMarketplaceBody />);
 
     const rail = page.getByTestId('apps-recent-rail');
@@ -443,7 +453,7 @@ describe('AppListingsMarketplaceBody', () => {
   });
 
   test('a LEGACY {id, blockId} recents entry still renders (resolved, not dropped)', async () => {
-    recordRecentlyOpenedApp({ id: 'ab_legacy', blockId: 'legacy-app' });
+    recordRecentlyOpenedApp({ id: 'ab_legacy', blockId: 'legacy-app' }, SESSION_OWNER_ID);
     renderWithProviders(<AppListingsMarketplaceBody />);
     const item = page.getByTestId('apps-recent-rail-item');
     await expect.element(item).toBeInTheDocument();

--- a/src/components/Apps/AppListingsMarketplaceBody.recentsReconcile.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.recentsReconcile.browser.test.tsx
@@ -5,7 +5,10 @@ import { useRouter } from 'next/router';
 import { renderWithProviders } from '../../../test/component-setup';
 import type * as TrpcMod from '~/utils/trpc';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
-import { RECENTLY_OPENED_APPS_KEY } from '~/components/Apps/recentlyOpenedAppsStore';
+import {
+  RECENTLY_OPENED_APPS_KEY,
+  RECENTS_ENVELOPE_VERSION,
+} from '~/components/Apps/recentlyOpenedAppsStore';
 
 /**
  * LEGACY-RECENTS RECONCILIATION — the `/apps` rail's stale-icon defect.
@@ -125,7 +128,24 @@ const router = useRouter();
  * the store's de-dup key). No `kind`, no `hasPage`, no `slug`.
  */
 function seedLegacyRecents(entries: { id: string; blockId: string; name: string }[]) {
-  window.localStorage.setItem(RECENTLY_OPENED_APPS_KEY, JSON.stringify(entries));
+  seedOwnedRecents(entries);
+}
+
+/**
+ * Write a raw entry list into the store as the CURRENT (anonymous) viewer's.
+ *
+ * 🔴 The envelope is the point, not boilerplate. Recents are ACCOUNT-scoped
+ * (#4048): a bare `RecentApp[]` carries no owner, and an unowned blob is
+ * DROPPED on read rather than attributed to whoever reads it next — so seeding
+ * one here would empty the rail and make every reconciliation assertion below
+ * pass vacuously. This suite mounts anonymously (`useCurrentUser` → null), so
+ * the owner it seeds as is `null`.
+ */
+function seedOwnedRecents(entries: unknown[], ownerId: number | null = null) {
+  window.localStorage.setItem(
+    RECENTLY_OPENED_APPS_KEY,
+    JSON.stringify({ v: RECENTS_ENVELOPE_VERSION, ownerId, apps: entries })
+  );
 }
 
 beforeEach(() => {
@@ -229,19 +249,16 @@ describe('the /apps rail reconciles LEGACY recents against the loaded listings',
       makeOnsiteCard({ id: 'lst_pv', slug: 'prompt-vault', name: 'Prompt Vault', hasPage: false }),
     ];
     // A fully-populated, NON-legacy entry that went stale the other way.
-    window.localStorage.setItem(
-      RECENTLY_OPENED_APPS_KEY,
-      JSON.stringify([
-        {
-          id: 'blk_prompt-vault',
-          blockId: 'prompt-vault',
-          slug: 'prompt-vault',
-          kind: 'onsite',
-          hasPage: true,
-          name: 'Prompt Vault',
-        },
-      ])
-    );
+    seedOwnedRecents([
+      {
+        id: 'blk_prompt-vault',
+        blockId: 'prompt-vault',
+        slug: 'prompt-vault',
+        kind: 'onsite',
+        hasPage: true,
+        name: 'Prompt Vault',
+      },
+    ]);
 
     renderWithProviders(<AppListingsMarketplaceBody />);
 
@@ -266,10 +283,7 @@ describe('the /apps rail reconciles LEGACY recents against the loaded listings',
         appBlockId: 'blk_gen-matrix',
       }),
     ];
-    window.localStorage.setItem(
-      RECENTLY_OPENED_APPS_KEY,
-      JSON.stringify([{ id: 'blk_gen-matrix', slug: 'gen-matrix', name: 'Gen Matrix' }])
-    );
+    seedOwnedRecents([{ id: 'blk_gen-matrix', slug: 'gen-matrix', name: 'Gen Matrix' }]);
 
     renderWithProviders(<AppListingsMarketplaceBody />);
 

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -19,6 +19,7 @@ import {
   recordRecentlyOpenedApp,
   type RecentApp,
 } from '~/components/Apps/recentlyOpenedAppsStore';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import type { ListingCard, ListingSort } from '~/server/schema/blocks/app-listing-read.schema';
 import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
@@ -77,6 +78,7 @@ const SORT_OPTIONS: { value: ListingSort; label: string }[] = [
 
 export function AppListingsMarketplaceBody() {
   const features = useFeatureFlags();
+  const currentUser = useCurrentUser();
   const { filters, setFilters, hasPendingWrite } = useAppsStoreQueryParams();
   const { kind, category, sort } = filters;
 
@@ -180,9 +182,17 @@ export function AppListingsMarketplaceBody() {
   // BELOW the search/sort/filter controls precisely because of this one-frame
   // late hydration — see the comment at its render site.
   const [recents, setRecents] = useState<RecentApp[]>([]);
+  // 🔴 Keyed by ACCOUNT (#4048). localStorage is per browser PROFILE, not per
+  // account, and nothing clears it on an account switch — a profile that had
+  // been a moderator session rendered six on-site apps here for a viewer whose
+  // server scope returns none of them, every one of which 404s on its detail
+  // page. The store now returns only what the CURRENT viewer wrote (`null` =
+  // signed out, its own bucket). `ownerId` is in the dep list so an in-SPA
+  // sign-in / sign-out / switch re-reads rather than keeping the stale rail.
+  const ownerId = currentUser?.id ?? null;
   useEffect(() => {
-    setRecents(getRecentlyOpenedApps());
-  }, []);
+    setRecents(getRecentlyOpenedApps(ownerId));
+  }, [ownerId]);
   // The rail's ENTRIES are derived further down — `recentEntries` needs the
   // loaded listings (`items`) to reconcile stale persisted entries against, and
   // those are not available until after the query below. See it there.
@@ -193,16 +203,19 @@ export function AppListingsMarketplaceBody() {
   // store dedups, so double-recording is harmless.
   function handleOpenRecent(entry: ResolvedRecentApp) {
     setRecents(
-      recordRecentlyOpenedApp({
-        id: entry.id,
-        slug: entry.slug,
-        kind: entry.kind,
-        hasPage: entry.hasPage,
-        ...(entry.blockId ? { blockId: entry.blockId } : {}),
-        ...(entry.externalUrl ? { externalUrl: entry.externalUrl } : {}),
-        ...(entry.name ? { name: entry.name } : {}),
-        ...(entry.iconUrl ? { iconUrl: entry.iconUrl } : {}),
-      })
+      recordRecentlyOpenedApp(
+        {
+          id: entry.id,
+          slug: entry.slug,
+          kind: entry.kind,
+          hasPage: entry.hasPage,
+          ...(entry.blockId ? { blockId: entry.blockId } : {}),
+          ...(entry.externalUrl ? { externalUrl: entry.externalUrl } : {}),
+          ...(entry.name ? { name: entry.name } : {}),
+          ...(entry.iconUrl ? { iconUrl: entry.iconUrl } : {}),
+        },
+        ownerId
+      )
     );
   }
 

--- a/src/components/Apps/MarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/MarketplaceBody.browser.test.tsx
@@ -117,8 +117,21 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: mocks.appBlocksPages }),
 }));
 
+/**
+ * The signed-in viewer this suite mounts as. 🔴 Load-bearing, not a detail:
+ * recents are ACCOUNT-scoped (#4048), so every store read below must use THIS
+ * id — a read with any other id has to come back empty, which is what the
+ * `records it OWNED` case at the bottom of this file exercises.
+ *
+ * Hoisted, because a `vi.mock` factory is hoisted above module-scope consts and
+ * would otherwise read it before initialisation.
+ */
+const session = vi.hoisted(() => ({ userId: 1, otherUserId: 2 }));
+const SESSION_USER_ID = session.userId;
+const OTHER_USER_ID = session.otherUserId;
+
 vi.mock('~/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => ({ id: 1, username: 'tester', isModerator: false }),
+  useCurrentUser: () => ({ id: session.userId, username: 'tester', isModerator: false }),
 }));
 
 // The settings modal is a global side-effecting opener — stub it to a spy so we
@@ -208,7 +221,7 @@ describe('/apps marketplace body (explore-all CTA clears filters)', () => {
 
 describe('/apps marketplace body (opening an app records it to recents)', () => {
   test('opening an app writes it to the recents localStorage list and surfaces the section', async () => {
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    expect(getRecentlyOpenedApps(SESSION_USER_ID)).toEqual([]);
     renderWithProviders(<MarketplaceBody />);
 
     // Each grid card exposes an "Open app" / settings open affordance. The
@@ -225,8 +238,14 @@ describe('/apps marketplace body (opening an app records it to recents)', () => 
     // handleOpen fired the settings opener…
     expect(mocks.openSettings).toHaveBeenCalledTimes(1);
     // …and recorded the app to localStorage (newest-first, the helper's job).
-    const recents = getRecentlyOpenedApps();
+    const recents = getRecentlyOpenedApps(SESSION_USER_ID);
     expect(recents.length).toBeGreaterThanOrEqual(1);
+    // 🔴 BEHAVIOURAL: the write landed OWNED by the mounted session (#4048).
+    // A call site that passed `null` — or dropped the owner entirely — still
+    // satisfies the line above and fails this one, because the entry would then
+    // sit in the anonymous bucket instead of this viewer's.
+    expect(getRecentlyOpenedApps(OTHER_USER_ID)).toEqual([]);
+    expect(getRecentlyOpenedApps(null)).toEqual([]);
     // The raw store is populated under the documented key.
     expect(window.localStorage.getItem(RECENTLY_OPENED_APPS_KEY)).toBeTruthy();
 
@@ -254,7 +273,7 @@ describe('/apps marketplace body — PAGE app open records to recents (M1)', () 
   test('clicking "Open app" (route link) on a PAGE app records it to recents', async () => {
     mocks.appBlocksPages = true; // unlock the "Open app" route link
     mocks.listAvailableItems = [makePageBlock('p', 'Page App')];
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    expect(getRecentlyOpenedApps(SESSION_USER_ID)).toEqual([]);
 
     renderWithProviders(<MarketplaceBody />);
     await expect.element(page.getByText('Page App')).toBeInTheDocument();
@@ -267,7 +286,7 @@ describe('/apps marketplace body — PAGE app open records to recents (M1)', () 
     // The install/settings opener did NOT fire (page app has no install) —
     // recents was populated purely by the route open.
     expect(mocks.openSettings).not.toHaveBeenCalled();
-    const recents = getRecentlyOpenedApps();
+    const recents = getRecentlyOpenedApps(SESSION_USER_ID);
     expect(recents.map((r) => r.id)).toContain('p');
     expect(window.localStorage.getItem(RECENTLY_OPENED_APPS_KEY)).toBeTruthy();
     // The "Recently opened" section renders for the page app.
@@ -278,7 +297,7 @@ describe('/apps marketplace body — PAGE app open records to recents (M1)', () 
     // Title link is present regardless of the pages flag — assert it records too.
     mocks.appBlocksPages = false;
     mocks.listAvailableItems = [makePageBlock('p', 'Page App')];
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    expect(getRecentlyOpenedApps(SESSION_USER_ID)).toEqual([]);
 
     renderWithProviders(<MarketplaceBody />);
     // The card title links to the detail page; it is the open path here.
@@ -287,8 +306,10 @@ describe('/apps marketplace body — PAGE app open records to recents (M1)', () 
     await userEvent.click(titleLink.element());
 
     expect(mocks.openSettings).not.toHaveBeenCalled();
-    expect(getRecentlyOpenedApps().map((r) => r.id)).toContain('p');
-    await expect.element(page.getByRole('heading', { name: 'Recently opened' })).toBeInTheDocument();
+    expect(getRecentlyOpenedApps(SESSION_USER_ID).map((r) => r.id)).toContain('p');
+    await expect
+      .element(page.getByRole('heading', { name: 'Recently opened' }))
+      .toBeInTheDocument();
   });
 });
 

--- a/src/components/Apps/MarketplaceBody.tsx
+++ b/src/components/Apps/MarketplaceBody.tsx
@@ -69,9 +69,14 @@ export function MarketplaceBody() {
   // hydration mismatch); the real list is loaded in an effect after mount, and
   // updated whenever the viewer opens an app via handleOpen.
   const [recents, setRecents] = useState<RecentApp[]>([]);
+  // 🔴 Keyed by ACCOUNT (#4048): localStorage is per browser profile, so the
+  // store only hands back entries the CURRENT viewer wrote. `ownerId` is in the
+  // dep list so a sign-in / sign-out / account switch inside the SPA re-reads
+  // the (now different, usually empty) bucket instead of keeping the old rail.
+  const ownerId = currentUser?.id ?? null;
   useEffect(() => {
-    setRecents(getRecentlyOpenedApps());
-  }, []);
+    setRecents(getRecentlyOpenedApps(ownerId));
+  }, [ownerId]);
 
   // The marketplace listing is anon-CAPABLE (publicProcedure) — it fires for
   // any viewer who has the appBlocks flag, including a session-less one once
@@ -234,12 +239,15 @@ export function MarketplaceBody() {
     // optional in the store, so a null coverUrl/appName just falls back to the
     // generic icon / blockId handle.
     setRecents(
-      recordRecentlyOpenedApp({
-        id: block.id,
-        blockId: block.blockId,
-        name: block.appName ?? undefined,
-        iconUrl: block.coverUrl ?? undefined,
-      })
+      recordRecentlyOpenedApp(
+        {
+          id: block.id,
+          blockId: block.blockId,
+          name: block.appName ?? undefined,
+          iconUrl: block.coverUrl ?? undefined,
+        },
+        ownerId
+      )
     );
   }
 

--- a/src/components/Apps/__tests__/recentlyOpenedAppsStore.test.ts
+++ b/src/components/Apps/__tests__/recentlyOpenedAppsStore.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_RECENTS_TOTAL,
   recordRecentlyOpenedApp,
   RECENTLY_OPENED_APPS_KEY,
+  RECENTS_ENVELOPE_VERSION,
   type RecentApp,
 } from '~/components/Apps/recentlyOpenedAppsStore';
 import { resolveRecentApp } from '~/components/Apps/recentAppsRail';
@@ -56,6 +57,15 @@ class MemoryStorage {
 
 let storage: MemoryStorage;
 
+/**
+ * The account every test below reads/writes as, unless it is specifically about
+ * a second viewer. An arbitrary non-zero id — the point is only that it differs
+ * from `OTHER_OWNER` and from `null` (the signed-out bucket).
+ */
+const OWNER = 7;
+/** A DIFFERENT signed-in account, for the cross-account cases. */
+const OTHER_OWNER = 8;
+
 /** Write a RAW blob straight into the store, bypassing the write gate — this is
  *  the shape a hand-edited / legacy localStorage actually presents on read. */
 function seedRaw(value: unknown) {
@@ -63,6 +73,16 @@ function seedRaw(value: unknown) {
     RECENTLY_OPENED_APPS_KEY,
     typeof value === 'string' ? value : JSON.stringify(value)
   );
+}
+
+/**
+ * Seed a well-formed v4 envelope owned by `ownerId`, bypassing the write gate.
+ * Used by the entry-validation cases so they exercise `coerce` (the entry gate)
+ * rather than tripping the envelope gate on the way in — a bare array is now
+ * dropped wholesale, which would make every one of them pass vacuously.
+ */
+function seedOwned(apps: unknown, ownerId: number | null = OWNER) {
+  seedRaw({ v: RECENTS_ENVELOPE_VERSION, ownerId, apps });
 }
 
 beforeEach(() => {
@@ -77,8 +97,8 @@ afterEach(() => {
 describe('SSR safety', () => {
   it('every entry point no-ops with no window (the /apps page renders server-side first)', () => {
     delete (globalThis as { window?: unknown }).window;
-    expect(getRecentlyOpenedApps()).toEqual([]);
-    expect(recordRecentlyOpenedApp({ id: 'a', blockId: 'a' })).toEqual([]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+    expect(recordRecentlyOpenedApp({ id: 'a', blockId: 'a' }, OWNER)).toEqual([]);
     expect(() => clearRecentlyOpenedApps()).not.toThrow();
   });
 });
@@ -87,42 +107,42 @@ describe('coerce — the untrusted-input validation layer', () => {
   it('a non-array blob reads as [] (object / string / number / null)', () => {
     for (const bad of [{ id: 'a' }, '"a string"', '42', 'null']) {
       seedRaw(bad);
-      expect(getRecentlyOpenedApps()).toEqual([]);
+      expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
     }
   });
 
   it('unparseable JSON reads as [] (fail-soft, never throws into the page)', () => {
     seedRaw('{ not valid json');
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
   });
 
   it('drops non-object array members without dropping their neighbours', () => {
-    seedRaw([null, 'str', 7, { id: 'ok', blockId: 'ok' }, undefined]);
-    expect(getRecentlyOpenedApps().map((e) => e.id)).toEqual(['ok']);
+    seedOwned([null, 'str', 7, { id: 'ok', blockId: 'ok' }, undefined]);
+    expect(getRecentlyOpenedApps(OWNER).map((e) => e.id)).toEqual(['ok']);
   });
 
   it('requires a STRING id', () => {
-    seedRaw([{ id: 1, blockId: 'x' }, { id: null, blockId: 'x' }, { blockId: 'x' }]);
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    seedOwned([{ id: 1, blockId: 'x' }, { id: null, blockId: 'x' }, { blockId: 'x' }]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
   });
 
   it('drops an entry with no navigable handle at all', () => {
-    seedRaw([{ id: 'a' }, { id: 'b', blockId: '' }, { id: 'c', slug: '' }]);
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    seedOwned([{ id: 'a' }, { id: 'b', blockId: '' }, { id: 'c', slug: '' }]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
   });
 
   it('carries a LEGACY v1 {id, blockId} entry through untouched', () => {
-    seedRaw([{ id: 'ab_9', blockId: 'legacy-app' }]);
-    expect(getRecentlyOpenedApps()).toEqual([{ id: 'ab_9', blockId: 'legacy-app' }]);
+    seedOwned([{ id: 'ab_9', blockId: 'legacy-app' }]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([{ id: 'ab_9', blockId: 'legacy-app' }]);
   });
 
   it('an unknown `kind` value degrades to "no kind" rather than flowing into link logic', () => {
-    seedRaw([{ id: 'a', blockId: 'a', kind: 'sideways' }]);
-    expect(getRecentlyOpenedApps()[0].kind).toBeUndefined();
+    seedOwned([{ id: 'a', blockId: 'a', kind: 'sideways' }]);
+    expect(getRecentlyOpenedApps(OWNER)[0].kind).toBeUndefined();
   });
 
   it('wrong-typed enrichment fields are dropped, not carried (no crash, less enrichment)', () => {
-    seedRaw([
+    seedOwned([
       {
         id: 'a',
         blockId: 'a',
@@ -132,13 +152,13 @@ describe('coerce — the untrusted-input validation layer', () => {
         iconUrl: ['x'],
       },
     ]);
-    expect(getRecentlyOpenedApps()).toEqual([{ id: 'a', blockId: 'a' }]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([{ id: 'a', blockId: 'a' }]);
   });
 
   it('🔴 a stringy `hasPage` cannot survive into the rail as "this app has a page"', () => {
     // End-to-end version of the same guard: user-writable value → store → rail.
-    seedRaw([{ id: 'a', blockId: 'gen', slug: 'gen', kind: 'onsite', hasPage: 'true' }]);
-    const [entry] = getRecentlyOpenedApps();
+    seedOwned([{ id: 'a', blockId: 'gen', slug: 'gen', kind: 'onsite', hasPage: 'true' }]);
+    const [entry] = getRecentlyOpenedApps(OWNER);
     expect(entry.hasPage).toBeUndefined();
     expect(resolveRecentApp(entry)!.hasPage).toBe(false);
   });
@@ -149,18 +169,21 @@ describe('🔴 the write gate and the read gate are the SAME gate', () => {
   // `resolveRecentApp` requires a `slug` for an off-site entry — so the value
   // persisted and then silently vanished on the next read.
   it('rejects an off-site entry with no slug on WRITE (blockId cannot stand in)', () => {
-    const next = recordRecentlyOpenedApp({
-      id: 'x',
-      blockId: 'not-a-listing-slug',
-      kind: 'offsite',
-    });
+    const next = recordRecentlyOpenedApp(
+      {
+        id: 'x',
+        blockId: 'not-a-listing-slug',
+        kind: 'offsite',
+      },
+      OWNER
+    );
     expect(next).toEqual([]);
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
   });
 
   it('drops the same shape on READ', () => {
-    seedRaw([{ id: 'x', blockId: 'not-a-listing-slug', kind: 'offsite' }]);
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    seedOwned([{ id: 'x', blockId: 'not-a-listing-slug', kind: 'offsite' }]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
   });
 
   it('anything the store ACCEPTS is resolvable by the rail — no silent read-side drop', () => {
@@ -174,7 +197,7 @@ describe('🔴 the write gate and the read gate are the SAME gate', () => {
     ];
     for (const candidate of candidates) {
       clearRecentlyOpenedApps();
-      const accepted = recordRecentlyOpenedApp(candidate);
+      const accepted = recordRecentlyOpenedApp(candidate, OWNER);
       if (accepted.length === 0) continue; // rejected on write — fine
       expect(
         resolveRecentApp(accepted[0]),
@@ -184,13 +207,16 @@ describe('🔴 the write gate and the read gate are the SAME gate', () => {
   });
 
   it('an off-site entry WITH a slug round-trips (write → read → resolve)', () => {
-    recordRecentlyOpenedApp({
-      id: 'lst_1',
-      slug: 'ext-app',
-      kind: 'offsite',
-      externalUrl: 'https://ext.example/app',
-    });
-    const [entry] = getRecentlyOpenedApps();
+    recordRecentlyOpenedApp(
+      {
+        id: 'lst_1',
+        slug: 'ext-app',
+        kind: 'offsite',
+        externalUrl: 'https://ext.example/app',
+      },
+      OWNER
+    );
+    const [entry] = getRecentlyOpenedApps(OWNER);
     expect(entry.slug).toBe('ext-app');
     expect(resolveRecentApp(entry)).toMatchObject({ slug: 'ext-app', kind: 'offsite' });
   });
@@ -215,27 +241,27 @@ describe('🔴 per-kind budget — one kind can never starve the other', () => {
     // The regression: with a single flat cap, opening MAX_RECENTS off-site apps
     // emptied the app-chrome "Recently run" menu, which can only render on-site
     // entries — an unflagged behaviour change to a pre-existing feature.
-    recordRecentlyOpenedApp(onsite(1));
-    for (let i = 0; i < MAX_RECENTS + 4; i++) recordRecentlyOpenedApp(offsite(i));
+    recordRecentlyOpenedApp(onsite(1), OWNER);
+    for (let i = 0; i < MAX_RECENTS + 4; i++) recordRecentlyOpenedApp(offsite(i), OWNER);
 
-    const list = getRecentlyOpenedApps();
+    const list = getRecentlyOpenedApps(OWNER);
     const onsiteEntries = list.filter((e) => e.kind !== 'offsite' && !!e.blockId);
     expect(onsiteEntries.map((e) => e.id)).toEqual(['on-1']);
   });
 
   it('and symmetrically: on-site traffic does not evict off-site entries', () => {
-    recordRecentlyOpenedApp(offsite(1));
-    for (let i = 0; i < MAX_RECENTS + 4; i++) recordRecentlyOpenedApp(onsite(i));
+    recordRecentlyOpenedApp(offsite(1), OWNER);
+    for (let i = 0; i < MAX_RECENTS + 4; i++) recordRecentlyOpenedApp(onsite(i), OWNER);
     expect(
-      getRecentlyOpenedApps()
+      getRecentlyOpenedApps(OWNER)
         .filter((e) => e.kind === 'offsite')
         .map((e) => e.id)
     ).toEqual(['off-1']);
   });
 
   it('each kind is still capped at MAX_RECENTS, oldest-first eviction', () => {
-    for (let i = 0; i < MAX_RECENTS + 3; i++) recordRecentlyOpenedApp(onsite(i));
-    const ids = getRecentlyOpenedApps().map((e) => e.id);
+    for (let i = 0; i < MAX_RECENTS + 3; i++) recordRecentlyOpenedApp(onsite(i), OWNER);
+    const ids = getRecentlyOpenedApps(OWNER).map((e) => e.id);
     expect(ids).toHaveLength(MAX_RECENTS);
     expect(ids[0]).toBe(`on-${MAX_RECENTS + 2}`); // newest first
     expect(ids).not.toContain('on-0');
@@ -243,22 +269,22 @@ describe('🔴 per-kind budget — one kind can never starve the other', () => {
 
   it('the whole list is bounded by MAX_RECENTS_TOTAL', () => {
     for (let i = 0; i < MAX_RECENTS + 5; i++) {
-      recordRecentlyOpenedApp(onsite(i));
-      recordRecentlyOpenedApp(offsite(i));
+      recordRecentlyOpenedApp(onsite(i), OWNER);
+      recordRecentlyOpenedApp(offsite(i), OWNER);
     }
-    expect(getRecentlyOpenedApps().length).toBe(MAX_RECENTS_TOTAL);
+    expect(getRecentlyOpenedApps(OWNER).length).toBe(MAX_RECENTS_TOTAL);
     expect(MAX_RECENTS_TOTAL).toBe(MAX_RECENTS * 2);
   });
 
   it('a legacy entry with NO kind counts against the ON-SITE budget (it is on-site by construction)', () => {
-    seedRaw(
+    seedOwned(
       Array.from({ length: MAX_RECENTS + 3 }, (_, i) => ({ id: `l-${i}`, blockId: `l-${i}` }))
     );
-    expect(getRecentlyOpenedApps()).toHaveLength(MAX_RECENTS);
+    expect(getRecentlyOpenedApps(OWNER)).toHaveLength(MAX_RECENTS);
   });
 
   it('the READ caps too, so a blob written by an older (flat-cap) build is still bounded', () => {
-    seedRaw([
+    seedOwned([
       ...Array.from({ length: 20 }, (_, i) => ({
         id: `on-${i}`,
         blockId: `on-${i}`,
@@ -270,7 +296,7 @@ describe('🔴 per-kind budget — one kind can never starve the other', () => {
         kind: 'offsite',
       })),
     ]);
-    const list = getRecentlyOpenedApps();
+    const list = getRecentlyOpenedApps(OWNER);
     expect(list.filter((e) => e.kind === 'onsite')).toHaveLength(MAX_RECENTS);
     expect(list.filter((e) => e.kind === 'offsite')).toHaveLength(MAX_RECENTS);
   });
@@ -280,29 +306,175 @@ describe('ordering + dedupe + fail-soft write', () => {
   const app = (id: string): RecentApp => ({ id, blockId: `block-${id}` });
 
   it('prepends newest-first', () => {
-    recordRecentlyOpenedApp(app('a'));
-    recordRecentlyOpenedApp(app('b'));
-    expect(getRecentlyOpenedApps().map((e) => e.id)).toEqual(['b', 'a']);
+    recordRecentlyOpenedApp(app('a'), OWNER);
+    recordRecentlyOpenedApp(app('b'), OWNER);
+    expect(getRecentlyOpenedApps(OWNER).map((e) => e.id)).toEqual(['b', 'a']);
   });
 
   it('re-recording moves to the front without duplicating', () => {
-    recordRecentlyOpenedApp(app('a'));
-    recordRecentlyOpenedApp(app('b'));
-    recordRecentlyOpenedApp(app('a'));
-    expect(getRecentlyOpenedApps().map((e) => e.id)).toEqual(['a', 'b']);
+    recordRecentlyOpenedApp(app('a'), OWNER);
+    recordRecentlyOpenedApp(app('b'), OWNER);
+    recordRecentlyOpenedApp(app('a'), OWNER);
+    expect(getRecentlyOpenedApps(OWNER).map((e) => e.id)).toEqual(['a', 'b']);
   });
 
   it('a quota / private-mode write throw is swallowed and still returns the in-memory list', () => {
     storage.throwOnSet = true;
-    expect(recordRecentlyOpenedApp(app('a')).map((e) => e.id)).toEqual(['a']);
+    expect(recordRecentlyOpenedApp(app('a'), OWNER).map((e) => e.id)).toEqual(['a']);
     // …but nothing was persisted.
     storage.throwOnSet = false;
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
   });
 
   it('clear empties the store', () => {
-    recordRecentlyOpenedApp(app('a'));
+    recordRecentlyOpenedApp(app('a'), OWNER);
     clearRecentlyOpenedApps();
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+  });
+});
+
+/**
+ * 🔴 ACCOUNT SCOPING (#4048) — the defect this envelope exists for.
+ *
+ * OBSERVED, not hypothetical: a browser profile used first by a moderator
+ * session and later signed in as a lower-privileged cohort account rendered a
+ * "Recently opened" rail of six on-site apps that account cannot see. The rail
+ * fetches nothing (the entries carry their own name/icon/slug), so nothing
+ * reconciled them away, and every detail page behind them 404s for that viewer.
+ * localStorage is per BROWSER PROFILE; identity is per ACCOUNT; nothing cleared
+ * it on the switch.
+ */
+describe('🔴 recents are scoped to the account that recorded them', () => {
+  const app = (id: string): RecentApp => ({ id, blockId: `block-${id}` });
+
+  it('a viewer reads back what THEY recorded (positive control — the rest is not vacuous)', () => {
+    recordRecentlyOpenedApp(app('mine'), OWNER);
+    expect(getRecentlyOpenedApps(OWNER).map((e) => e.id)).toEqual(['mine']);
+  });
+
+  it('🔴 a DIFFERENT signed-in account reads an EMPTY rail', () => {
+    recordRecentlyOpenedApp(app('mod-only'), OWNER);
+    expect(getRecentlyOpenedApps(OTHER_OWNER)).toEqual([]);
+  });
+
+  it('🔴 a SIGNED-OUT viewer cannot read a signed-in account’s recents', () => {
+    recordRecentlyOpenedApp(app('mod-only'), OWNER);
+    expect(getRecentlyOpenedApps(null)).toEqual([]);
+  });
+
+  it('🔴 and the reverse: a signed-in viewer cannot read the ANONYMOUS bucket', () => {
+    // `ownerId: null` is a bucket, not a wildcard. A guard written as
+    // "no owner recorded → anyone may read it" passes the test above and fails
+    // this one.
+    recordRecentlyOpenedApp(app('anon-app'), null);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+  });
+
+  it('the anonymous viewer reads back their OWN bucket (null is a real owner)', () => {
+    recordRecentlyOpenedApp(app('anon-app'), null);
+    expect(getRecentlyOpenedApps(null).map((e) => e.id)).toEqual(['anon-app']);
+  });
+
+  it('owner id 0 is a real account, not "signed out" (falsy-check guard)', () => {
+    // `currentUser?.id ?? null` yields the number 0 for a hypothetical user 0; a
+    // guard written with `!ownerId` would merge that account with the anonymous
+    // bucket. Only `=== null` / `typeof === number` separates them.
+    recordRecentlyOpenedApp(app('zero'), 0);
+    expect(getRecentlyOpenedApps(0).map((e) => e.id)).toEqual(['zero']);
+    expect(getRecentlyOpenedApps(null)).toEqual([]);
+  });
+
+  it('a read by a foreign owner does not DESTROY the owner’s blob (read ≠ write)', () => {
+    recordRecentlyOpenedApp(app('mine'), OWNER);
+    expect(getRecentlyOpenedApps(OTHER_OWNER)).toEqual([]);
+    expect(getRecentlyOpenedApps(OWNER).map((e) => e.id)).toEqual(['mine']);
+  });
+
+  it('a write by a second account starts a FRESH list — it never inherits entries', () => {
+    recordRecentlyOpenedApp(app('mine'), OWNER);
+    const next = recordRecentlyOpenedApp(app('theirs'), OTHER_OWNER);
+    expect(next.map((e) => e.id)).toEqual(['theirs']);
+    expect(getRecentlyOpenedApps(OTHER_OWNER).map((e) => e.id)).toEqual(['theirs']);
+    // …and the first account's blob is gone: one bucket is persisted at a time.
+    // Documented tradeoff, not an oversight (see the module header).
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+  });
+
+  it('the persisted blob is an owner-stamped envelope (the on-disk contract)', () => {
+    recordRecentlyOpenedApp(app('mine'), OWNER);
+    const raw = JSON.parse(storage.getItem(RECENTLY_OPENED_APPS_KEY) as string);
+    expect(raw.v).toBe(RECENTS_ENVELOPE_VERSION);
+    expect(raw.ownerId).toBe(OWNER);
+    expect(raw.apps.map((a: RecentApp) => a.id)).toEqual(['mine']);
+  });
+
+  it('an anonymous write stamps ownerId: null, not a missing key', () => {
+    recordRecentlyOpenedApp(app('anon-app'), null);
+    const raw = JSON.parse(storage.getItem(RECENTLY_OPENED_APPS_KEY) as string);
+    expect('ownerId' in raw).toBe(true);
+    expect(raw.ownerId).toBeNull();
+  });
+});
+
+/**
+ * 🔴 THE ONE-TIME RESET, MADE EXPLICIT.
+ *
+ * A pre-v4 blob is a BARE `RecentApp[]` with no owner recorded. That owner is
+ * unknowable — the browser holds no evidence of who wrote it — so it is DROPPED
+ * rather than attributed to whoever reads it next. Attributing it is precisely
+ * the bug. The cost is one rail reset per existing viewer (it repopulates on the
+ * next app open, capped at MAX_RECENTS per kind, pure personalisation); the cost
+ * of the alternative is showing one account's history to another.
+ */
+describe('🔴 a legacy (pre-owner) blob is dropped, never attributed', () => {
+  const legacy = [
+    { id: 'ab_1', blockId: 'moderator-only-app', name: 'Moderator Only App' },
+    { id: 'ab_2', blockId: 'another-app', name: 'Another App' },
+  ];
+
+  it('a signed-in viewer inherits NOTHING from an un-owned blob', () => {
+    seedRaw(legacy);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+  });
+
+  it('nor does a signed-out one (there is no owner it could belong to)', () => {
+    seedRaw(legacy);
+    expect(getRecentlyOpenedApps(null)).toEqual([]);
+  });
+
+  it('the very next recorded open repopulates the rail (the reset is one-time)', () => {
+    seedRaw(legacy);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+    recordRecentlyOpenedApp({ id: 'fresh', blockId: 'fresh' }, OWNER);
+    expect(getRecentlyOpenedApps(OWNER).map((e) => e.id)).toEqual(['fresh']);
+  });
+
+  it('an UNRECOGNISED envelope version is dropped too (rollback after a newer build)', () => {
+    seedRaw({ v: RECENTS_ENVELOPE_VERSION + 1, ownerId: OWNER, apps: legacy });
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+    seedRaw({ ownerId: OWNER, apps: legacy }); // no version at all
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+  });
+
+  it('an envelope whose ownerId is not a number-or-null is unownable → dropped', () => {
+    for (const owner of ['7', undefined, {}, [], true]) {
+      seedRaw({ v: RECENTS_ENVELOPE_VERSION, ownerId: owner, apps: legacy });
+      expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+      expect(getRecentlyOpenedApps(null)).toEqual([]);
+    }
+  });
+
+  it('a recognised envelope with a corrupt `apps` field degrades to [] (fail-soft, no throw)', () => {
+    for (const apps of ['nope', 42, null, { id: 'a' }]) {
+      seedRaw({ v: RECENTS_ENVELOPE_VERSION, ownerId: OWNER, apps });
+      expect(() => getRecentlyOpenedApps(OWNER)).not.toThrow();
+      expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+    }
+  });
+
+  it('clear() removes a FOREIGN blob too (owner-agnostic by design)', () => {
+    recordRecentlyOpenedApp({ id: 'theirs', blockId: 'theirs' }, OTHER_OWNER);
+    clearRecentlyOpenedApps();
+    expect(storage.getItem(RECENTLY_OPENED_APPS_KEY)).toBeNull();
   });
 });

--- a/src/components/Apps/__tests__/recentsCallSites.test.ts
+++ b/src/components/Apps/__tests__/recentsCallSites.test.ts
@@ -35,8 +35,12 @@ import { describe, it, expect } from 'vitest';
  *     own owner matching, the legacy drop, and that a write persists the owner.
  *   - `AppListingDetailBody.browser.test.tsx` (browser, preview-only) — a REAL
  *     component click reaching the store with the mounted session's id.
- * Five of the six sites have no behavioural cover at all in the node project;
- * they are pinned against REVERSION here, not against a wrong-argument call.
+ * Stated exactly, because the gap is the point: NONE of the six sites has
+ * behavioural cover in the node project. Two of them — `MarketplaceBody` and
+ * `AppListingDetailBody` — have it in the BROWSER project, which is
+ * preview-only and does not block a merge. So in CI all six are pinned by this
+ * file alone, against REVERSION and against a hardcoded owner, never against a
+ * wrong-argument call that still has the right shape.
  */
 
 const SRC = path.resolve(__dirname, '../../..');

--- a/src/components/Apps/__tests__/recentsCallSites.test.ts
+++ b/src/components/Apps/__tests__/recentsCallSites.test.ts
@@ -1,0 +1,288 @@
+import fs from 'fs';
+import path from 'path';
+import ts from 'typescript';
+import { describe, it, expect } from 'vitest';
+
+/**
+ * 🔒 THE CALL-SITE LEDGER for the account-scoped recents store (#4048).
+ *
+ * WHY THIS FILE EXISTS. `recentlyOpenedApps` lives in localStorage, which is
+ * per BROWSER PROFILE, while identity is per ACCOUNT — so every write has to
+ * carry the id of the account that made it, or the next account to use that
+ * browser inherits the previous one's list. That is not a hypothetical: a
+ * profile used first by a moderator session and later signed in as a
+ * lower-privileged cohort account rendered a rail of six apps whose detail pages
+ * 404 for that viewer.
+ *
+ * The store cannot defend itself here. It is deliberately React-free (so it can
+ * be unit-tested in the node project and imported anywhere), which means the
+ * owner id is PASSED IN — and a call site that forgets is a call site that
+ * regenerates the bug locally. There are six of them, in three directories, and
+ * five have no test that mounts them in the node project. So this asserts the
+ * RELATIONSHIP: the exact set of modules allowed to touch the store, and that
+ * each one derives the owner from the current session rather than hardcoding it.
+ *
+ * It fails when the set GROWS (a new surface that reads/writes recents) and when
+ * it SHRINKS (a site deleted or renamed without updating the ledger).
+ *
+ * 🔴 A STRUCTURAL CHECK IS NOT A BEHAVIOURAL ONE. TypeScript already guarantees
+ * an owner ARGUMENT exists (the parameter is required and un-defaulted); what it
+ * cannot see is a WRONG one — `recordRecentlyOpenedApp(app, null)` type-checks
+ * perfectly and silently rebuilds the shared-bucket defect for every signed-in
+ * viewer. That is the case `ownerExpressionOf` below is aimed at, and it is
+ * still only a check on the SHAPE of the expression. The behavioural half:
+ *   - `recentlyOpenedAppsStore.test.ts` (node, runs on every PR) — the store's
+ *     own owner matching, the legacy drop, and that a write persists the owner.
+ *   - `AppListingDetailBody.browser.test.tsx` (browser, preview-only) — a REAL
+ *     component click reaching the store with the mounted session's id.
+ * Five of the six sites have no behavioural cover at all in the node project;
+ * they are pinned against REVERSION here, not against a wrong-argument call.
+ */
+
+const SRC = path.resolve(__dirname, '../../..');
+
+/** The store module, as every call site spells it. */
+const STORE_MODULE = '~/components/Apps/recentlyOpenedAppsStore';
+
+/** The two owner-scoped entry points. `clearRecentlyOpenedApps` is deliberately
+ *  NOT here: it is owner-agnostic (it removes whatever bucket is stored), so a
+ *  caller of it cannot get the owner wrong. */
+const SCOPED_FNS = ['getRecentlyOpenedApps', 'recordRecentlyOpenedApp'] as const;
+
+/**
+ * Every module under {@link SCAN_ROOTS} that reads or writes the recents store.
+ *
+ * Adding a surface that shows or records recents means adding it here — that is
+ * the point, not an inconvenience. Each entry is a place the owner id has to be
+ * threaded through from the session.
+ */
+const RECENTS_CALL_SITES = [
+  'components/AppBlocks/IframeHost.tsx', // app-chrome "Recently run" menu (read)
+  'components/Apps/AppListingCard.tsx', // off-site "Visit" CTA (write)
+  'components/Apps/AppListingDetailBody.tsx', // detail "Visit" / "Open live" (write)
+  'components/Apps/AppListingsMarketplaceBody.tsx', // the /apps store rail (read + write)
+  'components/Apps/MarketplaceBody.tsx', // legacy /apps grid (read + write)
+  'pages/apps/run/[slug]/[[...path]].tsx', // the on-site run page (write)
+] as const;
+
+/**
+ * Directories walked. Three, because the recents feature spans three: the store
+ * UI (`components/Apps`), the app-block chrome that offers "Recently run"
+ * (`components/AppBlocks`), and the run route that records an open
+ * (`pages/apps`). A recents call site OUTSIDE these is invisible here — that is
+ * the scoping limit of the ledger, stated rather than implied.
+ */
+const SCAN_ROOTS = ['components/AppBlocks', 'components/Apps', 'pages/apps'];
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(SRC, rel), 'utf8');
+}
+
+function parseTsx(fileName: string, text: string): ts.SourceFile {
+  return ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Does this file IMPORT one of the scoped entry points from the store?
+ *
+ * Read off the AST rather than a regex, so a mention in a comment or a string
+ * cannot register as an importer (this file's own prose names every symbol) and
+ * a prettier-wrapped multi-line import specifier list cannot hide one.
+ */
+function importsScopedFn(sf: ts.SourceFile): boolean {
+  let found = false;
+  sf.forEachChild((node) => {
+    if (!ts.isImportDeclaration(node)) return;
+    if (!ts.isStringLiteral(node.moduleSpecifier)) return;
+    if (node.moduleSpecifier.text !== STORE_MODULE) return;
+    const bindings = node.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) return;
+    for (const el of bindings.elements) {
+      if ((SCOPED_FNS as readonly string[]).includes(el.name.text)) found = true;
+    }
+  });
+  return found;
+}
+
+/** Every call to a scoped entry point in this file, with its arguments. */
+function scopedCalls(sf: ts.SourceFile): ts.CallExpression[] {
+  const calls: ts.CallExpression[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      (SCOPED_FNS as readonly string[]).includes(node.expression.text)
+    ) {
+      calls.push(node);
+    }
+    node.forEachChild(visit);
+  };
+  visit(sf);
+  return calls;
+}
+
+/**
+ * The owner argument's expression TEXT, resolved one hop through a local
+ * `const` binding.
+ *
+ * Every real call site either inlines `currentUser?.id ?? null` or hoists it to
+ * a `const ownerId = …` used in a hook dependency array, so one hop is enough —
+ * and one hop is all a same-file lexical lookup can honestly do. A call whose
+ * owner argument is an identifier bound OUTSIDE the file resolves to the
+ * identifier's own text and will fail the shape assertion loudly rather than
+ * pass quietly.
+ */
+function ownerExpressionOf(sf: ts.SourceFile, call: ts.CallExpression): string {
+  const index = call.expression.getText(sf) === 'recordRecentlyOpenedApp' ? 1 : 0;
+  const arg = call.arguments[index];
+  if (!arg) return '<missing>';
+  if (!ts.isIdentifier(arg)) return arg.getText(sf);
+  let resolved: string | null = null;
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === arg.getText(sf) &&
+      node.initializer
+    ) {
+      resolved = node.initializer.getText(sf);
+    }
+    node.forEachChild(visit);
+  };
+  visit(sf);
+  return resolved ?? arg.getText(sf);
+}
+
+/**
+ * The owner argument must be derived from the CURRENT SESSION.
+ *
+ * `<something>?.id ?? null` is the one shape every site uses
+ * (`useCurrentUser()?.id ?? null`, directly or via a local const). A literal
+ * `null`, a hardcoded number, or an id taken from the LISTING rather than the
+ * viewer all fail it — and those are the wrong-argument mistakes that
+ * type-check.
+ */
+const OWNER_FROM_SESSION = /\?\.id\s*\?\?\s*null\b/;
+
+const SCANNED = SCAN_ROOTS.flatMap((root) => walk(path.join(SRC, root))).map((file) => {
+  const raw = fs.readFileSync(file, 'utf8');
+  const rel = path.relative(SRC, file).split(path.sep).join('/');
+  return { rel, sf: parseTsx(file, raw) };
+});
+
+describe('the scan itself (a zero must be earned, not assumed)', () => {
+  it('walked a plausible number of modules', () => {
+    // A floor well below the live count: the point is that the walk is not
+    // returning an empty set, which is how every assertion below would pass
+    // while checking nothing.
+    expect(SCANNED.length).toBeGreaterThanOrEqual(40);
+  });
+
+  it('every ledger site was actually reached by the walk', () => {
+    const seen = new Set(SCANNED.map((f) => f.rel));
+    expect(RECENTS_CALL_SITES.filter((s) => !seen.has(s))).toEqual([]);
+  });
+
+  it('🔴 POSITIVE CONTROL: the importer detector fires on a real import, and only then', () => {
+    const yes = parseTsx(
+      'probe.tsx',
+      `import { recordRecentlyOpenedApp } from '${STORE_MODULE}';\nrecordRecentlyOpenedApp(a, b);`
+    );
+    expect(importsScopedFn(yes)).toBe(true);
+    // A type-only companion import is not a call site — `RecentApp` alone must
+    // not enrol a module in the ledger.
+    const typeOnly = parseTsx(
+      'probe.tsx',
+      `import { type RecentApp } from '${STORE_MODULE}';\nconst a: RecentApp[] = [];`
+    );
+    expect(importsScopedFn(typeOnly)).toBe(false);
+    // …nor may prose. This file names every symbol in its own comments.
+    const prose = parseTsx(
+      'probe.tsx',
+      `// getRecentlyOpenedApps from '${STORE_MODULE}'\nconst s = "recordRecentlyOpenedApp";`
+    );
+    expect(importsScopedFn(prose)).toBe(false);
+  });
+});
+
+describe('🔒 the recents call-site ledger is EXACT (grows AND shrinks)', () => {
+  it('exactly these modules read or write the recents store', () => {
+    const importers = SCANNED.filter((f) => importsScopedFn(f.sf))
+      .map((f) => f.rel)
+      .sort();
+    // Deliberately a set EQUALITY, not a superset check. A new surface that
+    // forgets to thread the owner fails here (GROWS); a site silently removed or
+    // renamed fails here too (SHRINKS), which is what stops the ledger decaying
+    // into a stale list nobody notices is wrong.
+    expect(importers).toEqual([...RECENTS_CALL_SITES].sort());
+  });
+});
+
+describe('🔴 every call site derives the owner from the current session', () => {
+  for (const rel of RECENTS_CALL_SITES) {
+    it(`${rel} passes a session-derived owner to every scoped call`, () => {
+      const sf = parseTsx(rel, read(rel));
+      const calls = scopedCalls(sf);
+      // Non-zero, or the loop below asserts nothing (a ledger entry whose calls
+      // all vanished would otherwise pass this test in silence).
+      expect(calls.length, `no scoped calls found in ${rel}`).toBeGreaterThan(0);
+      for (const call of calls) {
+        const owner = ownerExpressionOf(sf, call);
+        expect(owner, `${rel}: ${call.getText(sf).slice(0, 80)}`).toMatch(OWNER_FROM_SESSION);
+      }
+    });
+  }
+
+  it('🔴 POSITIVE CONTROL: the owner-shape check rejects the mistakes that type-check', () => {
+    const probe = (body: string) => {
+      const sf = parseTsx('probe.tsx', body);
+      const calls = scopedCalls(sf);
+      expect(calls).toHaveLength(1);
+      return ownerExpressionOf(sf, calls[0]);
+    };
+    // The real shapes — inline and hoisted-through-a-const — must PASS.
+    expect(probe('recordRecentlyOpenedApp(app, currentUser?.id ?? null);')).toMatch(
+      OWNER_FROM_SESSION
+    );
+    expect(
+      probe('const ownerId = useCurrentUser()?.id ?? null;\nrecordRecentlyOpenedApp(app, ownerId);')
+    ).toMatch(OWNER_FROM_SESSION);
+    expect(
+      probe('const ownerId = currentUser?.id ?? null;\ngetRecentlyOpenedApps(ownerId);')
+    ).toMatch(OWNER_FROM_SESSION);
+    // …and the wrong-argument shapes must FAIL. Every one of these compiles.
+    expect(probe('recordRecentlyOpenedApp(app, null);')).not.toMatch(OWNER_FROM_SESSION);
+    expect(probe('recordRecentlyOpenedApp(app, 7);')).not.toMatch(OWNER_FROM_SESSION);
+    expect(probe('const ownerId = null;\nrecordRecentlyOpenedApp(app, ownerId);')).not.toMatch(
+      OWNER_FROM_SESSION
+    );
+    // The listing's creator instead of the viewer — the plausible copy-paste.
+    expect(probe('recordRecentlyOpenedApp(app, card.creator?.id ?? null);')).toMatch(
+      OWNER_FROM_SESSION
+    );
+    // ⚠️ That last one PASSES, and is recorded as a known limit rather than
+    // hidden: the check pins the SHAPE of the expression, not which object it
+    // reads. Only a behavioural test can separate the viewer from the creator.
+  });
+
+  it('🔴 POSITIVE CONTROL: the argument INDEX is right for each function', () => {
+    // Reading argument 0 of `recordRecentlyOpenedApp` would inspect the app
+    // object and pass/fail for reasons unrelated to the owner.
+    const sf = parseTsx(
+      'probe.tsx',
+      'recordRecentlyOpenedApp({ id: currentUser?.id ?? null }, 7);\ngetRecentlyOpenedApps(9);'
+    );
+    const [record, get] = scopedCalls(sf);
+    expect(ownerExpressionOf(sf, record)).toBe('7');
+    expect(ownerExpressionOf(sf, get)).toBe('9');
+  });
+});

--- a/src/components/Apps/recentlyOpenedAppsStore.ts
+++ b/src/components/Apps/recentlyOpenedAppsStore.ts
@@ -30,9 +30,58 @@
  *    acceptance rule; the write path runs the same gate, and the rail's
  *    `resolveRecentApp` applies exactly the same rule on read, so nothing that
  *    is accepted for write can be silently dropped on read.
+ *  - ACCOUNT-SCOPED: the stored blob carries the id of the account that wrote
+ *    it, and a read by any OTHER viewer returns `[]`. See below.
+ *
+ * 🔴 ACCOUNT SCOPING — WHY THE OWNER ID IS PERSISTED (#4048)
+ *
+ * localStorage is per BROWSER PROFILE, not per ACCOUNT, and nothing clears it on
+ * a sign-in / sign-out / account switch. Observed in production: a browser
+ * profile used first by a moderator session and later signed in as a
+ * lower-privileged cohort account rendered a "Recently opened" rail of six apps
+ * that account cannot see — the entries carry `name`/`iconUrl`/`slug`
+ * themselves, so the rail renders them without fetching anything, and every
+ * detail page behind them 404s for that viewer. Not a disclosure (the names were
+ * already in that browser), but stale and dead-ended.
+ *
+ * So a stored blob is an ENVELOPE stamped with its owner:
+ * `{ v, ownerId, apps }`. `ownerId` is the numeric user id, or `null` for the
+ * SIGNED-OUT viewer — which is that viewer's OWN bucket, not a wildcard: an
+ * anonymous blob is not readable by a signed-in viewer and vice versa. A read
+ * whose `ownerId` does not match returns `[]`.
+ *
+ * 🔴 DELIBERATE ONE-TIME RESET. A pre-v4 blob is a BARE `RecentApp[]` with no
+ * owner recorded, and that owner is unknowable — the browser holds no evidence
+ * of who wrote it. It is therefore DROPPED on read rather than attributed to
+ * whoever reads it next, because attributing it IS the bug above. Every existing
+ * viewer's rail resets once and repopulates on their next app open; the list is
+ * capped at `MAX_RECENTS` per kind and is pure personalisation, so the cost of
+ * the reset is one lost convenience shortcut and the cost of guessing is showing
+ * one account's history to another. (Same reasoning for a blob whose `v` we do
+ * not recognise, e.g. one written by a NEWER build after a rollback.)
+ *
+ * The owner id is passed IN by each caller (`useCurrentUser()?.id ?? null`) —
+ * this module stays React-free and session-free, so it can be unit-tested in the
+ * node project and imported from anywhere. `recentsCallSites.test.ts` is the
+ * ledger that pins the exact set of modules allowed to call it.
  */
 
 export const RECENTLY_OPENED_APPS_KEY = 'recentlyOpenedApps';
+
+/**
+ * Persisted envelope version. Bumped from the implicit "bare array" v3 shape to
+ * carry `ownerId`; a blob at any other version is dropped (see the header).
+ */
+export const RECENTS_ENVELOPE_VERSION = 4;
+
+/**
+ * The account a recents blob belongs to: a numeric user id, or `null` for the
+ * signed-out viewer.
+ *
+ * 🔴 `null` is a REAL bucket, not "unknown" and not "any". The anonymous
+ * viewer's recents are readable only by the anonymous viewer.
+ */
+export type RecentsOwnerId = number | null;
 
 /**
  * Max distinct apps retained PER KIND (newest-first).
@@ -64,9 +113,13 @@ export type RecentAppKind = 'onsite' | 'offsite';
  * previously-shipped version are still in the wild and must keep parsing:
  *   - v1 wrote `{id, blockId}`.
  *   - v2 added `{name?, iconUrl?}`.
- *   - v3 (this) adds `{slug?, kind?, hasPage?, externalUrl?}` so an entry can
- *     link to the unified store detail (`/apps/store-preview/<slug>`) and so an
- *     OFF-SITE listing — which has NO `blockId` at all — is representable.
+ *   - v3 adds `{slug?, kind?, hasPage?, externalUrl?}` so an entry can link to
+ *     the unified store detail (`/apps/store-preview/<slug>`) and so an OFF-SITE
+ *     listing — which has NO `blockId` at all — is representable.
+ *   - v4 (this) leaves the ENTRY shape untouched and wraps the LIST in an
+ *     owner-stamped envelope (see the module header). v1–v3 wrote a bare array,
+ *     which is why the entry tolerance below still matters: a v3 entry inside a
+ *     v4 envelope is exactly a v3 entry.
  * The single hard invariant a stored entry must satisfy to survive a read is
  * "it has a handle that is navigable FOR ITS KIND" — `slug` for an off-site
  * entry (it has no AppBlock, so `blockId` cannot stand in), `blockId` OR `slug`
@@ -182,38 +235,90 @@ function capPerKind(entries: RecentApp[]): RecentApp[] {
 }
 
 /**
- * Read the recents list (newest-first, capped per kind). Returns `[]` on the
- * server, an empty store, a parse error, or any localStorage access throw.
+ * Type-guard a parsed blob down to the v4 owner-stamped envelope, or `null` when
+ * it is not one.
+ *
+ * `null` (i.e. "there are no recents for anybody here") is returned for:
+ *  - a BARE ARRAY — the pre-v4 shape. It records no owner and the owner cannot
+ *    be recovered, so it is dropped rather than attributed to the current reader
+ *    (see the module header: attributing it is the defect this change fixes).
+ *  - any other `v`, including a FUTURE one written by a newer build before a
+ *    rollback — we cannot know what its fields mean.
+ *  - an `ownerId` that is neither `null` nor a finite number: hand-edited, so
+ *    "whose is this?" has no answer.
+ *
+ * A recognised envelope whose `apps` is missing / not an array degrades to an
+ * empty list via `coerce`, not to a throw — fail-soft, like everything else here.
  */
-export function getRecentlyOpenedApps(): RecentApp[] {
+function coerceEnvelope(raw: unknown): { ownerId: RecentsOwnerId; apps: RecentApp[] } | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const src = raw as Record<string, unknown>;
+  if (src.v !== RECENTS_ENVELOPE_VERSION) return null;
+  const owner = src.ownerId;
+  const ownerIsValid = owner === null || (typeof owner === 'number' && Number.isFinite(owner));
+  if (!ownerIsValid) return null;
+  return { ownerId: owner as RecentsOwnerId, apps: coerce(src.apps) };
+}
+
+/**
+ * Read `ownerId`'s recents list (newest-first, capped per kind). Returns `[]` on
+ * the server, an empty store, a parse error, any localStorage access throw — and,
+ * 🔴 crucially, whenever the stored blob belongs to a DIFFERENT viewer (a
+ * different account, or the signed-out bucket vs a signed-in one, in either
+ * direction).
+ *
+ * @param ownerId the CURRENT viewer's user id, or `null` if signed out. Callers
+ *   pass `useCurrentUser()?.id ?? null`; this module deliberately does not know
+ *   how to obtain it (it must stay React-free and server-safe).
+ */
+export function getRecentlyOpenedApps(ownerId: RecentsOwnerId): RecentApp[] {
   if (!isClient()) return [];
   try {
     const raw = window.localStorage.getItem(RECENTLY_OPENED_APPS_KEY);
     if (!raw) return [];
+    const envelope = coerceEnvelope(JSON.parse(raw));
+    // Unownable blob (legacy / unknown version / corrupt owner) → no recents.
+    if (!envelope) return [];
+    // Someone else's recents. `!==` on `number | null` is what makes the
+    // anonymous bucket a bucket rather than a wildcard.
+    if (envelope.ownerId !== ownerId) return [];
     // Cap on READ too, so a blob written by an older build (flat cap) or by hand
     // can't hand a consumer more than the budget.
-    return capPerKind(coerce(JSON.parse(raw)));
+    return capPerKind(envelope.apps);
   } catch {
     return [];
   }
 }
 
 /**
- * Record that `app` was just opened: prepend it (newest-first), de-dup by `id`
- * (an existing entry moves to the front, not duplicated), and cap to
- * `MAX_RECENTS` PER KIND. Returns the new list (or `[]` on the server).
+ * Record that `app` was just opened BY `ownerId`: prepend it (newest-first),
+ * de-dup by `id` (an existing entry moves to the front, not duplicated), and cap
+ * to `MAX_RECENTS` PER KIND. Returns the new list (or `[]` on the server).
  * Fail-soft: a write throw (quota / private mode) is swallowed.
+ *
+ * The write is always stamped with `ownerId`, and it starts from what THAT owner
+ * can read — so an app opened after an account switch replaces the previous
+ * account's blob rather than appending to it. One bucket is persisted at a time;
+ * switching back does not restore the earlier account's list, which is the
+ * accepted cost of not keeping several accounts' browsing histories side by side
+ * in one browser profile.
  */
-export function recordRecentlyOpenedApp(app: RecentApp): RecentApp[] {
+export function recordRecentlyOpenedApp(app: RecentApp, ownerId: RecentsOwnerId): RecentApp[] {
   if (!isClient()) return [];
   // Run the WRITE through the same acceptance gate the READ applies, so a caller
   // can never persist an entry the reader would silently drop. One gate, two
   // directions — they cannot drift.
   const [clean] = coerce([app]);
-  if (!clean) return getRecentlyOpenedApps();
-  const next = capPerKind([clean, ...getRecentlyOpenedApps().filter((a) => a.id !== clean.id)]);
+  if (!clean) return getRecentlyOpenedApps(ownerId);
+  const next = capPerKind([
+    clean,
+    ...getRecentlyOpenedApps(ownerId).filter((a) => a.id !== clean.id),
+  ]);
   try {
-    window.localStorage.setItem(RECENTLY_OPENED_APPS_KEY, JSON.stringify(next));
+    window.localStorage.setItem(
+      RECENTLY_OPENED_APPS_KEY,
+      JSON.stringify({ v: RECENTS_ENVELOPE_VERSION, ownerId, apps: next })
+    );
   } catch {
     // Quota / private-mode / serialization failure — degrade silently; the
     // in-memory `next` is still returned so a caller can update local state.
@@ -221,7 +326,13 @@ export function recordRecentlyOpenedApp(app: RecentApp): RecentApp[] {
   return next;
 }
 
-/** Clear the recents list (used by tests + a potential "clear" affordance). */
+/**
+ * Clear the recents list (used by tests + a potential "clear" affordance).
+ *
+ * Owner-AGNOSTIC by design: it removes the whole key, whoever owns it. There is
+ * only ever one bucket persisted, and "forget my recents" must work even when
+ * what is stored belongs to a previous account.
+ */
 export function clearRecentlyOpenedApps(): void {
   if (!isClient()) return;
   try {

--- a/src/components/Apps/recents-helper.browser.test.tsx
+++ b/src/components/Apps/recents-helper.browser.test.tsx
@@ -5,6 +5,7 @@ import {
   MAX_RECENTS,
   recordRecentlyOpenedApp,
   RECENTLY_OPENED_APPS_KEY,
+  RECENTS_ENVELOPE_VERSION,
   type RecentApp,
 } from '~/components/Apps/recentlyOpenedAppsStore';
 
@@ -22,27 +23,43 @@ import {
 
 const app = (id: string): RecentApp => ({ id, blockId: `block-${id}` });
 
+/** The account these cases read/write as. Recents are ACCOUNT-scoped (#4048),
+ *  so every entry point takes the viewer's id (`null` = signed out). */
+const OWNER = 42;
+const OTHER_OWNER = 43;
+
+/** Seed a well-formed owner-stamped blob, bypassing the write gate — the shape
+ *  a hand-edited localStorage presents on read. A BARE array is the pre-owner
+ *  shape and is dropped wholesale, so seeding one would make these cases pass
+ *  vacuously. */
+function seedOwned(apps: unknown, ownerId: number | null = OWNER) {
+  window.localStorage.setItem(
+    RECENTLY_OPENED_APPS_KEY,
+    JSON.stringify({ v: RECENTS_ENVELOPE_VERSION, ownerId, apps })
+  );
+}
+
 beforeEach(() => {
   clearRecentlyOpenedApps();
 });
 
 describe('recentlyOpenedApps helper', () => {
   test('empty store reads as []', () => {
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
   });
 
   test('record prepends newest-first', () => {
-    recordRecentlyOpenedApp(app('a'));
-    recordRecentlyOpenedApp(app('b'));
-    recordRecentlyOpenedApp(app('c'));
-    expect(getRecentlyOpenedApps().map((r) => r.id)).toEqual(['c', 'b', 'a']);
+    recordRecentlyOpenedApp(app('a'), OWNER);
+    recordRecentlyOpenedApp(app('b'), OWNER);
+    recordRecentlyOpenedApp(app('c'), OWNER);
+    expect(getRecentlyOpenedApps(OWNER).map((r) => r.id)).toEqual(['c', 'b', 'a']);
   });
 
   test('re-recording an existing id de-dups and moves it to the front (no duplicate)', () => {
-    recordRecentlyOpenedApp(app('a'));
-    recordRecentlyOpenedApp(app('b'));
-    recordRecentlyOpenedApp(app('a')); // re-open 'a'
-    const ids = getRecentlyOpenedApps().map((r) => r.id);
+    recordRecentlyOpenedApp(app('a'), OWNER);
+    recordRecentlyOpenedApp(app('b'), OWNER);
+    recordRecentlyOpenedApp(app('a'), OWNER); // re-open 'a'
+    const ids = getRecentlyOpenedApps(OWNER).map((r) => r.id);
     expect(ids).toEqual(['a', 'b']);
     // exactly one 'a' (deduped)
     expect(ids.filter((x) => x === 'a')).toHaveLength(1);
@@ -50,9 +67,9 @@ describe('recentlyOpenedApps helper', () => {
 
   test('caps the list at MAX_RECENTS, dropping the oldest', () => {
     for (let i = 0; i < MAX_RECENTS + 5; i++) {
-      recordRecentlyOpenedApp(app(`app-${i}`));
+      recordRecentlyOpenedApp(app(`app-${i}`), OWNER);
     }
-    const list = getRecentlyOpenedApps();
+    const list = getRecentlyOpenedApps(OWNER);
     expect(list).toHaveLength(MAX_RECENTS);
     // newest (last recorded) is at the front; the first MAX_RECENTS-5 are dropped
     expect(list[0].id).toBe(`app-${MAX_RECENTS + 4}`);
@@ -60,32 +77,32 @@ describe('recentlyOpenedApps helper', () => {
   });
 
   test('record returns the updated list', () => {
-    const next = recordRecentlyOpenedApp(app('x'));
+    const next = recordRecentlyOpenedApp(app('x'), OWNER);
     expect(next.map((r) => r.id)).toEqual(['x']);
   });
 
   test('a corrupt store value reads as [] (fail-soft)', () => {
     window.localStorage.setItem(RECENTLY_OPENED_APPS_KEY, '{ not valid json');
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
   });
 
   test('malformed entries are dropped on read', () => {
-    window.localStorage.setItem(
-      RECENTLY_OPENED_APPS_KEY,
-      JSON.stringify([{ id: 'ok', blockId: 'b-ok' }, { id: 123 }, null, 'nope'])
-    );
-    expect(getRecentlyOpenedApps()).toEqual([{ id: 'ok', blockId: 'b-ok' }]);
+    seedOwned([{ id: 'ok', blockId: 'b-ok' }, { id: 123 }, null, 'nope']);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([{ id: 'ok', blockId: 'b-ok' }]);
   });
 
   // Display-enrichment fields (name/iconUrl) — round-trip + backward-compat.
   test('name + iconUrl are persisted and round-tripped', () => {
-    recordRecentlyOpenedApp({
-      id: 'rich',
-      blockId: 'block-rich',
-      name: 'Background Remover',
-      iconUrl: 'https://cdn.example/icon.png',
-    });
-    expect(getRecentlyOpenedApps()).toEqual([
+    recordRecentlyOpenedApp(
+      {
+        id: 'rich',
+        blockId: 'block-rich',
+        name: 'Background Remover',
+        iconUrl: 'https://cdn.example/icon.png',
+      },
+      OWNER
+    );
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([
       {
         id: 'rich',
         blockId: 'block-rich',
@@ -99,28 +116,25 @@ describe('recentlyOpenedApps helper', () => {
     // Simulate an entry written BEFORE name/iconUrl existed — it must survive a
     // read unchanged (no name/iconUrl keys invented), proving the widened type
     // is backward-compatible with already-persisted data.
-    window.localStorage.setItem(
-      RECENTLY_OPENED_APPS_KEY,
-      JSON.stringify([{ id: 'legacy', blockId: 'block-legacy' }])
-    );
-    const list = getRecentlyOpenedApps();
+    seedOwned([{ id: 'legacy', blockId: 'block-legacy' }]);
+    const list = getRecentlyOpenedApps(OWNER);
     expect(list).toEqual([{ id: 'legacy', blockId: 'block-legacy' }]);
     expect(list[0]).not.toHaveProperty('name');
     expect(list[0]).not.toHaveProperty('iconUrl');
   });
 
   test('wrong-typed name/iconUrl are dropped, id/blockId still parse (fail-soft)', () => {
-    window.localStorage.setItem(
-      RECENTLY_OPENED_APPS_KEY,
-      JSON.stringify([{ id: 'x', blockId: 'b-x', name: 42, iconUrl: { bad: true } }])
-    );
-    expect(getRecentlyOpenedApps()).toEqual([{ id: 'x', blockId: 'b-x' }]);
+    seedOwned([{ id: 'x', blockId: 'b-x', name: 42, iconUrl: { bad: true } }]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([{ id: 'x', blockId: 'b-x' }]);
   });
 
   test('re-recording upgrades a legacy entry to the richer shape (dedup keeps newest)', () => {
-    recordRecentlyOpenedApp({ id: 'up', blockId: 'block-up' });
-    recordRecentlyOpenedApp({ id: 'up', blockId: 'block-up', name: 'Upgraded', iconUrl: 'i.png' });
-    const list = getRecentlyOpenedApps();
+    recordRecentlyOpenedApp({ id: 'up', blockId: 'block-up' }, OWNER);
+    recordRecentlyOpenedApp(
+      { id: 'up', blockId: 'block-up', name: 'Upgraded', iconUrl: 'i.png' },
+      OWNER
+    );
+    const list = getRecentlyOpenedApps(OWNER);
     expect(list).toHaveLength(1);
     expect(list[0]).toEqual({ id: 'up', blockId: 'block-up', name: 'Upgraded', iconUrl: 'i.png' });
   });
@@ -131,14 +145,17 @@ describe('recentlyOpenedApps helper', () => {
   // AppBlock and therefore NO blockId at all — is representable.
 
   test('an OFF-SITE entry (slug, no blockId) round-trips', () => {
-    recordRecentlyOpenedApp({
-      id: 'lst_1',
-      slug: 'ext-app',
-      kind: 'offsite',
-      externalUrl: 'https://ext.example/app',
-      name: 'Ext App',
-    });
-    expect(getRecentlyOpenedApps()).toEqual([
+    recordRecentlyOpenedApp(
+      {
+        id: 'lst_1',
+        slug: 'ext-app',
+        kind: 'offsite',
+        externalUrl: 'https://ext.example/app',
+        name: 'Ext App',
+      },
+      OWNER
+    );
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([
       {
         id: 'lst_1',
         slug: 'ext-app',
@@ -150,15 +167,18 @@ describe('recentlyOpenedApps helper', () => {
   });
 
   test('an ON-SITE entry round-trips slug + kind + hasPage', () => {
-    recordRecentlyOpenedApp({
-      id: 'ab_1',
-      blockId: 'gen-matrix',
-      slug: 'gen-matrix',
-      kind: 'onsite',
-      hasPage: true,
-      name: 'Gen Matrix',
-    });
-    expect(getRecentlyOpenedApps()[0]).toEqual({
+    recordRecentlyOpenedApp(
+      {
+        id: 'ab_1',
+        blockId: 'gen-matrix',
+        slug: 'gen-matrix',
+        kind: 'onsite',
+        hasPage: true,
+        name: 'Gen Matrix',
+      },
+      OWNER
+    );
+    expect(getRecentlyOpenedApps(OWNER)[0]).toEqual({
       id: 'ab_1',
       blockId: 'gen-matrix',
       slug: 'gen-matrix',
@@ -169,34 +189,59 @@ describe('recentlyOpenedApps helper', () => {
   });
 
   test('an entry with NO navigable handle (no blockId, no slug) is dropped on read', () => {
-    window.localStorage.setItem(
-      RECENTLY_OPENED_APPS_KEY,
-      JSON.stringify([{ id: 'handleless', name: 'Nowhere' }, { id: 'ok', slug: 'somewhere' }])
-    );
-    expect(getRecentlyOpenedApps()).toEqual([{ id: 'ok', slug: 'somewhere' }]);
+    seedOwned([
+      { id: 'handleless', name: 'Nowhere' },
+      { id: 'ok', slug: 'somewhere' },
+    ]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([{ id: 'ok', slug: 'somewhere' }]);
   });
 
   test('the WRITE path applies the same gate — a handleless entry is not persisted', () => {
-    recordRecentlyOpenedApp({ id: 'ok', slug: 'somewhere' });
+    recordRecentlyOpenedApp({ id: 'ok', slug: 'somewhere' }, OWNER);
     // A caller that forgot the handle — type-legal (every field but `id` is
     // optional), so only this runtime gate stops it becoming an unreadable row.
-    recordRecentlyOpenedApp({ id: 'handleless', name: 'Nowhere' });
-    expect(getRecentlyOpenedApps().map((r) => r.id)).toEqual(['ok']);
+    recordRecentlyOpenedApp({ id: 'handleless', name: 'Nowhere' }, OWNER);
+    expect(getRecentlyOpenedApps(OWNER).map((r) => r.id)).toEqual(['ok']);
   });
 
   test('a wrong-typed / unknown kind degrades to "no kind" (never flows on as a discriminant)', () => {
-    window.localStorage.setItem(
-      RECENTLY_OPENED_APPS_KEY,
-      JSON.stringify([{ id: 'x', slug: 's', kind: 'martian', hasPage: 'yes' }])
-    );
-    expect(getRecentlyOpenedApps()).toEqual([{ id: 'x', slug: 's' }]);
+    seedOwned([{ id: 'x', slug: 's', kind: 'martian', hasPage: 'yes' }]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([{ id: 'x', slug: 's' }]);
   });
 
   test('empty-string handles do not count as handles', () => {
+    seedOwned([{ id: 'x', blockId: '', slug: '' }]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+  });
+});
+
+/**
+ * 🔴 The account-scoping guarantee against a REAL `window.localStorage` (#4048).
+ * The node suite covers the same rules against an in-memory Storage; this is the
+ * one that proves nothing in the browser's own implementation (serialization,
+ * key handling) changes the answer.
+ */
+describe('account-scoped recents (real localStorage)', () => {
+  test('a second account reads an empty list, and its own write does not merge', () => {
+    recordRecentlyOpenedApp(app('mine'), OWNER);
+    expect(getRecentlyOpenedApps(OTHER_OWNER)).toEqual([]);
+    recordRecentlyOpenedApp(app('theirs'), OTHER_OWNER);
+    expect(getRecentlyOpenedApps(OTHER_OWNER).map((r) => r.id)).toEqual(['theirs']);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+  });
+
+  test('the signed-out bucket and a signed-in one are mutually invisible', () => {
+    recordRecentlyOpenedApp(app('anon'), null);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+    expect(getRecentlyOpenedApps(null).map((r) => r.id)).toEqual(['anon']);
+  });
+
+  test('a pre-owner BARE ARRAY blob is dropped rather than inherited', () => {
     window.localStorage.setItem(
       RECENTLY_OPENED_APPS_KEY,
-      JSON.stringify([{ id: 'x', blockId: '', slug: '' }])
+      JSON.stringify([{ id: 'inherited', blockId: 'moderator-only' }])
     );
-    expect(getRecentlyOpenedApps()).toEqual([]);
+    expect(getRecentlyOpenedApps(OWNER)).toEqual([]);
+    expect(getRecentlyOpenedApps(null)).toEqual([]);
   });
 });

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -116,16 +116,25 @@ export default function AppPage(props: PageProps) {
   // `iconUrl` is omitted — consumers fall back to the seeded monogram / a
   // generic app icon. Fires once per mount; the store dedups, so revisiting just
   // moves the entry to the front.
+  //
+  // 🔴 STAMPED WITH THE VIEWER'S ACCOUNT (#4048). localStorage is per browser
+  // PROFILE, so without an owner the next account to use this browser inherits
+  // these entries — which is how a rail of apps that 404 for the viewer got
+  // rendered. `ownerId` is `null` for a signed-out run, which is its own bucket.
+  const recentsOwnerId = currentUser?.id ?? null;
   useEffect(() => {
-    recordRecentlyOpenedApp({
-      id: appBlockId,
-      blockId,
-      slug: blockId,
-      kind: 'onsite',
-      hasPage: true,
-      name: appName,
-    });
-  }, [appBlockId, blockId, appName]);
+    recordRecentlyOpenedApp(
+      {
+        id: appBlockId,
+        blockId,
+        slug: blockId,
+        kind: 'onsite',
+        hasPage: true,
+        name: appName,
+      },
+      recentsOwnerId
+    );
+  }, [appBlockId, blockId, appName, recentsOwnerId]);
 
   // Synthetic page instance id — the mint resolves `page_<appBlockId>` directly
   // from the approved AppBlock (no install row).


### PR DESCRIPTION
Third follow-up to #4048.

## The defect

The `/apps` "Recently opened" rail rendered **6 on-site apps** for a viewer in the
external-only cohort whose server scope returns **zero** on-site rows, and whose
`getAppDetail` **404s** every one of those slugs.

Root cause, confirmed by reading the browser's storage rather than inferred:
the rail renders from `localStorage.recentlyOpenedApps`, which held those
entries verbatim (`id` / `blockId` / `slug` / `kind` / `hasPage` / `name` —
everything the rail displays), so it fetches nothing and nothing reconciles them
away. **localStorage is per browser PROFILE; identity is per ACCOUNT.** The
entries had been written by a moderator session in that browser profile; the
profile later signed in as a different, less-privileged account and inherited
them.

Impact: not a data exposure — the names were already in that browser — and not a
blocker; a tester on their own browser sees an empty rail. But recents are not
cleared on an account switch, so a switched account sees stale app names whose
detail pages 404.

## The fix: key recents by account id

The stored blob is now an owner-stamped envelope, `{ v: 4, ownerId, apps }`.
`ownerId` is the viewer's numeric user id, or `null` for the **signed-out**
viewer — which is that viewer's own bucket, not a wildcard: an anonymous blob is
not readable by a signed-in viewer, and vice versa. A read whose `ownerId` does
not match returns `[]`.

Deterministic, no server round-trip, and it fixes the cause rather than the
symptom. Deliberately **not** paired with a second "also filter by the viewer's
scope/kind" gate — that would hide the symptom for one cohort while leaving the
shared bucket in place for everyone else.

The store stays React-free and session-free: the owner id is **passed in** by
each call site (`useCurrentUser()?.id ?? null`), so it remains unit-testable in
the node project and importable anywhere.

### The deliberate one-time rail reset

A pre-v4 blob is a bare `RecentApp[]` with **no owner recorded**, and that owner
is unknowable — the browser holds no evidence of who wrote it. It is therefore
**dropped** on read, not attributed to whoever reads it next, because attributing
it is exactly the bug. Every existing viewer's rail resets once and repopulates
on their next app open; the list is capped at 8 per kind and is pure
personalisation. The cost of the reset is one lost convenience shortcut; the cost
of guessing is showing one account's history to another. Same reasoning for a
blob whose `v` we do not recognise (e.g. one written by a newer build before a
rollback). Documented in the module docstring and pinned by named tests.

## Call sites changed (all 6)

| Module | What it does |
|---|---|
| `src/components/Apps/MarketplaceBody.tsx` | legacy `/apps` grid — read + write |
| `src/components/Apps/AppListingsMarketplaceBody.tsx` | the live `/apps` store rail — read + write |
| `src/components/AppBlocks/IframeHost.tsx` | app-chrome "Recently run" menu — 2 reads |
| `src/components/Apps/AppListingCard.tsx` | off-site "Visit" CTA — write |
| `src/components/Apps/AppListingDetailBody.tsx` | detail "Visit" / "Open live" — write |
| `src/pages/apps/run/[slug]/[[...path]].tsx` | on-site run page mount effect — write |

Each read effect now carries `ownerId` in its dependency array, so an in-SPA
sign-in / sign-out / account switch re-reads the (now different, usually empty)
bucket instead of keeping the previous account's rail on screen.

Rendering, the per-kind cap, dedupe, reconciliation and link-target logic are
untouched.

## The call-site ledger

`src/components/Apps/__tests__/recentsCallSites.test.ts` (node `unit` project,
modelled on the existing `appsStoreAccessCallSites.test.ts`) asserts the exact
set of modules that read or write the store, off the TypeScript AST rather than a
regex. It fails when the set **grows** (a new surface that forgot to thread the
owner) and when it **shrinks** (a site reverted or renamed), and it additionally
requires every scoped call to pass a **session-derived** owner expression —
`recordRecentlyOpenedApp(app, null)` type-checks perfectly and would silently
rebuild the shared bucket.

Its limits are stated in the file rather than implied: it pins the *shape* of the
expression, not which object it reads, so `detail.creator?.id ?? null` would pass
it. That case is covered behaviourally instead (below), and the mutation table
shows the structural check missing it and the behavioural one catching it.

## Verification

**Instruments validated before their verdicts were read.**

- `pnpm typecheck`: **0 errors**. Positive control: a planted `'not-a-user-id'`
  argument produced exactly one error at the planted line
  (`MarketplaceBody.tsx(249,9): error TS2345`), then was removed.
- node `unit` project, full run: **1170 passed / 1 failed / 1 skipped files,
  18381 passed / 1 failed / 21 skipped tests**. The one failure is
  `eventloop-watchdog.capture.test.ts` — a 10s-deadline starvation-classifier
  test in unrelated code that ran while a Chromium suite was saturating the box;
  re-run alone it is **9/9 green**. `blocks.router.workflow.test.ts` collected
  **350 tests** (the submodule-missing tell), so the run is real.
- Recents suites, node `unit`: **4 files / 145 tests passed**.
- browser `component` project (preview-only in CI, run locally): **10 files /
  201 tests passed**.
- Prettier: clean on the added file (the blocking case). Instrument controlled by
  mixing a deliberately misformatted probe into the same 15-file invocation —
  exactly one `[warn]` came back, naming the probe.
- ESLint: 3 errors + 4 warnings on touched files, **all pre-existing** — the
  identical rules fire on the `origin/main` copies of the same files
  (`no-wholesale-module-mock`, two `no-unloadable-image-fixture`, four
  `react-hooks/exhaustive-deps`). Delta: zero.
- Formatting: modified files are deliberately **not** blanket-reformatted; a
  `prettier --write` pass was reverted down to the logical hunks, per this repo's
  policy that a formatter turns a small fix into a 200-line reformat.

**Regression matrix.** New tests run against the `origin/main` sources with the
new test files in place: **24 failed / 29 passed**. Every account-scoping and
legacy-drop case fails at base, as do all 6 per-site ledger checks. Green at HEAD.

**Mutation matrix** (each mutant is the narrowest expression that can be wrong):

| # | Mutation | Result | Killing test / assertion |
|---|---|---|---|
| A | read ignores `ownerId` (`if (false) return []`) | **killed**, 6 tests | `a DIFFERENT signed-in account reads an EMPTY rail` — `expected [ { id: 'mod-only', … } ] to deeply equal []` |
| B | legacy bare array accepted and attributed to the reader | **killed**, 3 tests | `a signed-in viewer inherits NOTHING from an un-owned blob` — `expected [ { id: 'ab_1', … }, …(1) ] to deeply equal []` |
| C | `ownerId: null` treated as matching any owner | **killed**, 1 test | `and the reverse: a signed-in viewer cannot read the ANONYMOUS bucket` — `expected [ { id: 'anon-app', … } ] to deeply equal []` |
| D1 | one entry deleted from the ledger constant | **killed** | `exactly these modules read or write the recents store` — `expected [ …(6) ] to deeply equal [ …(5) ]` |
| D2 | a new unlisted module imports the store (**grow**) | **killed** | same test — the extra importer appears in the received set |
| D3 | a real call site's import + call removed (**shrink**) | **killed**, 2 tests | same test, plus `AppListingCard.tsx passes a session-derived owner to every scoped call` |
| E | a call site hardcodes `null` as the owner | **killed** | `MarketplaceBody.tsx passes a session-derived owner to every scoped call` |
| F | the write always stamps `ownerId: null` | **killed**, 14 tests | incl. `the persisted blob is an owner-stamped envelope` |
| G | a call site stamps the **listing's creator** id instead of the viewer's | **killed** by the behavioural test only — the structural ledger passes it, as documented | `the recorded write is OWNED by the mounted session, not by anyone else` — `expected 5 to be 77` |

No surviving mutant. Mutant A was re-run on the final tree after the
formatting-revert pass and is still killed.

**Behavioural cover for the seam** (a structural check type-checks past a wrong
argument): `MarketplaceBody.browser.test.tsx` asserts that an open recorded by a
mounted session with id 1 is readable by id 1 and by **neither** id 2 nor the
anonymous bucket; `AppListingDetailBody.browser.test.tsx` clicks the real Visit
CTA with a mounted viewer whose id (77) is deliberately distinct from the
listing's creator id (5) and asserts the entry is readable only by 77. Five of
the six sites have no behavioural cover in the node project and are pinned
against reversion only — stated in the ledger file rather than implied.
