### PR TITLE
fix(image-detail): let mouse drags leave the carousel

### DIFF
--- a/src/components/EdgeMedia/EdgeImage.tsx
+++ b/src/components/EdgeMedia/EdgeImage.tsx
@@ -2,6 +2,7 @@ import type { SyntheticEvent } from 'react';
 import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
 import styles from './EdgeImage.module.scss';
 import clsx from 'clsx';
+import { setMediaDragData } from '~/components/EdgeMedia/media-drag-data';
 import type { EdgeUrlProps } from '~/client-utils/cf-images-utils';
 import { useEdgeUrl } from '~/client-utils/cf-images-utils';
 
@@ -48,11 +49,7 @@ export const EdgeImage = forwardRef<HTMLImageElement, EdgeImageProps>(
         src={url}
         style={{ maxWidth: options?.width ? options.width : undefined, ...style }}
         onDragStart={(e) => {
-          e.dataTransfer.setData('text/uri-list', url);
-          if (imageId) {
-            e.dataTransfer.setData('application/x-civitai-media-id', String(imageId));
-            e.dataTransfer.setData('application/x-civitai-media-type', 'image');
-          }
+          setMediaDragData(e.dataTransfer, { url, mediaId: imageId || undefined, type: 'image' });
         }}
         {...props}
       />

--- a/src/components/EdgeMedia/EdgeVideo.tsx
+++ b/src/components/EdgeMedia/EdgeVideo.tsx
@@ -24,6 +24,7 @@ import type { EdgeUrlProps } from '~/client-utils/cf-images-utils';
 import { useEdgeUrl } from '~/client-utils/cf-images-utils';
 import { useScrollAreaRef } from '~/components/ScrollArea/ScrollAreaContext';
 import clsx from 'clsx';
+import { setMediaDragData } from '~/components/EdgeMedia/media-drag-data';
 import styles from './EdgeVideo.module.scss';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { useDialogStore } from '~/components/Dialog/dialogStore';
@@ -325,9 +326,11 @@ export const EdgeVideo = forwardRef<EdgeVideoRef, VideoProps>(
           onDragStart={
             draggableEnabled
               ? (e) => {
-                  e.dataTransfer.setData('text/uri-list', videoUrl);
-                  e.dataTransfer.setData('application/x-civitai-media-id', String(imageId));
-                  e.dataTransfer.setData('application/x-civitai-media-type', 'video');
+                  setMediaDragData(e.dataTransfer, {
+                    url: videoUrl,
+                    mediaId: imageId,
+                    type: 'video',
+                  });
                 }
               : undefined
           }

--- a/src/components/EdgeMedia/media-drag-data.ts
+++ b/src/components/EdgeMedia/media-drag-data.ts
@@ -5,7 +5,9 @@ export function setMediaDragData(
   dataTransfer: DataTransfer,
   { url, mediaId, type }: { url: string; mediaId?: number | string; type: 'image' | 'video' }
 ) {
-  dataTransfer.setData('text/uri-list', url);
+  // a <video> resolves to '' until resource selection settles, and writing that
+  // replaces the browser's own entry with nothing a drop target can use
+  if (url) dataTransfer.setData('text/uri-list', url);
   if (mediaId === undefined) return;
   dataTransfer.setData(CIVITAI_MEDIA_ID_MIME, String(mediaId));
   dataTransfer.setData(CIVITAI_MEDIA_TYPE_MIME, type);

--- a/src/components/EdgeMedia/media-drag-data.ts
+++ b/src/components/EdgeMedia/media-drag-data.ts
@@ -1,0 +1,12 @@
+export const CIVITAI_MEDIA_ID_MIME = 'application/x-civitai-media-id';
+export const CIVITAI_MEDIA_TYPE_MIME = 'application/x-civitai-media-type';
+
+export function setMediaDragData(
+  dataTransfer: DataTransfer,
+  { url, mediaId, type }: { url: string; mediaId?: number | string; type: 'image' | 'video' }
+) {
+  dataTransfer.setData('text/uri-list', url);
+  if (mediaId === undefined) return;
+  dataTransfer.setData(CIVITAI_MEDIA_ID_MIME, String(mediaId));
+  dataTransfer.setData(CIVITAI_MEDIA_TYPE_MIME, type);
+}

--- a/src/components/EmblaCarousel/watchTouchDrag.ts
+++ b/src/components/EmblaCarousel/watchTouchDrag.ts
@@ -1,4 +1,5 @@
 import type { EmblaCarouselType } from 'embla-carousel';
+import type { DragEvent } from 'react';
 
 /**
  * Touch and pen drags navigate; mouse drags don't, so click-dragging an image on
@@ -14,4 +15,16 @@ export function watchTouchDrag(
   // correct if it ever moves to pointer events
   if ('pointerType' in event) return event.pointerType !== 'mouse';
   return event.type.startsWith('touch');
+}
+
+/**
+ * `watchTouchDrag` alone does not restore the native HTML5 drag: embla's
+ * DragHandler.init binds `dragstart -> preventDefault()` on the viewport for as
+ * long as `watchDrag` is truthy, and never consults `watchDrag` for that event —
+ * only for mousedown/touchstart. Stopping dragstart in React's capture phase, on
+ * the viewport or an ancestor, keeps it from reaching that listener so the drag
+ * survives. (embla-carousel 8.6.0)
+ */
+export function allowNativeDragStart(event: DragEvent) {
+  event.stopPropagation();
 }

--- a/src/components/EmblaCarousel/watchTouchDrag.ts
+++ b/src/components/EmblaCarousel/watchTouchDrag.ts
@@ -21,9 +21,12 @@ export function watchTouchDrag(
  * `watchTouchDrag` alone does not restore the native HTML5 drag: embla's
  * DragHandler.init binds `dragstart -> preventDefault()` on the viewport for as
  * long as `watchDrag` is truthy, and never consults `watchDrag` for that event —
- * only for mousedown/touchstart. Stopping dragstart in React's capture phase, on
- * the viewport or an ancestor, keeps it from reaching that listener so the drag
- * survives. (embla-carousel 8.6.0)
+ * only for mousedown/touchstart. Stopping dragstart in React's capture phase
+ * keeps it from reaching that listener, so the drag survives. (embla-carousel 8.6.0)
+ *
+ * The stop lands on the native event at React's root container, so the dragged
+ * element's own `onDragStart` never runs either — a caller that needs a payload
+ * has to set it here, as `ImageDetailCarousel` does.
  */
 export function allowNativeDragStart(event: DragEvent) {
   event.stopPropagation();

--- a/src/components/Image/DetailV2/ImageDetailCarousel.tsx
+++ b/src/components/Image/DetailV2/ImageDetailCarousel.tsx
@@ -1,6 +1,7 @@
 import { useLocalStorage } from '@mantine/hooks';
 import { useState, useEffect, useRef, createContext, useContext } from 'react';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
+import { setMediaDragData } from '~/components/EdgeMedia/media-drag-data';
 import { ImageStickerOverlay } from '~/components/Sticker/ImageStickerOverlay';
 import { shouldDisplayHtmlControls } from '~/components/EdgeMedia/EdgeMedia.util';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -203,7 +204,7 @@ export function ImageDetailCarousel({
         withKeyboardEvents={false}
       >
         {/* pan-y keeps vertical page scrolling native while horizontal drags go to embla */}
-        <Embla.Viewport className="h-full touch-pan-y" onDragStartCapture={allowNativeDragStart}>
+        <Embla.Viewport className="h-full touch-pan-y">
           <Embla.Container className="flex h-full">
             {images.map((image, i) => (
               <Embla.Slide key={image.id} index={i} className="flex-[0_0_100%]">
@@ -262,10 +263,24 @@ function ImageContent({
 
   const isVideo = image?.type === 'video';
 
+  const handleDragStart = (event: React.DragEvent) => {
+    allowNativeDragStart(event);
+    const media = event.target as HTMLImageElement | HTMLVideoElement;
+    setMediaDragData(event.dataTransfer, {
+      url: media.currentSrc || media.src,
+      mediaId: image.id,
+      type: isVideo ? 'video' : 'image',
+    });
+  };
+
   return (
     <ImageGuardContent image={image} {...connect}>
       {(safe) => (
-        <div ref={setRef} className="relative flex size-full items-center justify-center">
+        <div
+          ref={setRef}
+          onDragStartCapture={handleDragStart}
+          className="relative flex size-full items-center justify-center"
+        >
           {!safe && width && height ? (
             <div
               className="relative flex max-h-full max-w-full flex-1"

--- a/src/components/Image/DetailV2/ImageDetailCarousel.tsx
+++ b/src/components/Image/DetailV2/ImageDetailCarousel.tsx
@@ -263,7 +263,12 @@ function ImageContent({
 
   const isVideo = image?.type === 'video';
 
+  // dragstart carries no pointerType, and android chrome fires it for a long-press
+  // drag — leaving that one to embla keeps the touch swipe as `watchTouchDrag` has it
+  const pointerType = useRef('mouse');
+
   const handleDragStart = (event: React.DragEvent) => {
+    if (pointerType.current !== 'mouse') return;
     allowNativeDragStart(event);
     const media = event.target;
     if (!(media instanceof HTMLImageElement) && !(media instanceof HTMLVideoElement)) return;
@@ -279,6 +284,7 @@ function ImageContent({
       {(safe) => (
         <div
           ref={setRef}
+          onPointerDownCapture={(event) => (pointerType.current = event.pointerType)}
           onDragStartCapture={handleDragStart}
           className="relative flex size-full items-center justify-center"
         >

--- a/src/components/Image/DetailV2/ImageDetailCarousel.tsx
+++ b/src/components/Image/DetailV2/ImageDetailCarousel.tsx
@@ -265,7 +265,8 @@ function ImageContent({
 
   const handleDragStart = (event: React.DragEvent) => {
     allowNativeDragStart(event);
-    const media = event.target as HTMLImageElement | HTMLVideoElement;
+    const media = event.target;
+    if (!(media instanceof HTMLImageElement) && !(media instanceof HTMLVideoElement)) return;
     setMediaDragData(event.dataTransfer, {
       url: media.currentSrc || media.src,
       mediaId: image.id,

--- a/src/components/Image/DetailV2/ImageDetailCarousel.tsx
+++ b/src/components/Image/DetailV2/ImageDetailCarousel.tsx
@@ -269,9 +269,9 @@ function ImageContent({
 
   const handleDragStart = (event: React.DragEvent) => {
     if (pointerType.current !== 'mouse') return;
-    allowNativeDragStart(event);
     const media = event.target;
     if (!(media instanceof HTMLImageElement) && !(media instanceof HTMLVideoElement)) return;
+    allowNativeDragStart(event);
     setMediaDragData(event.dataTransfer, {
       url: media.currentSrc || media.src,
       mediaId: image.id,

--- a/src/components/Image/DetailV2/ImageDetailCarousel.tsx
+++ b/src/components/Image/DetailV2/ImageDetailCarousel.tsx
@@ -16,7 +16,7 @@ import type { MediaType } from '~/shared/utils/prisma/enums';
 import type { ImageMetadata, VideoMetadata } from '~/server/schema/media.schema';
 import type { EmblaCarouselType } from 'embla-carousel';
 import { Embla } from '~/components/EmblaCarousel/EmblaCarousel';
-import { watchTouchDrag } from '~/components/EmblaCarousel/watchTouchDrag';
+import { allowNativeDragStart, watchTouchDrag } from '~/components/EmblaCarousel/watchTouchDrag';
 
 type ImageDetailCarouselProps = {
   videoRef?: React.ForwardedRef<EdgeVideoRef>;
@@ -203,7 +203,7 @@ export function ImageDetailCarousel({
         withKeyboardEvents={false}
       >
         {/* pan-y keeps vertical page scrolling native while horizontal drags go to embla */}
-        <Embla.Viewport className="h-full touch-pan-y">
+        <Embla.Viewport className="h-full touch-pan-y" onDragStartCapture={allowNativeDragStart}>
           <Embla.Container className="flex h-full">
             {images.map((image, i) => (
               <Embla.Slide key={image.id} index={i} className="flex-[0_0_100%]">

--- a/src/components/generation_v2/inputs/MetadataExtractionPanel.tsx
+++ b/src/components/generation_v2/inputs/MetadataExtractionPanel.tsx
@@ -68,9 +68,8 @@ function getDroppedImageUrl(event: React.DragEvent): string | undefined {
 
 /**
  * Try to extract a Civitai media database ID and type from the drop event's custom drag data.
- * EdgeImage/EdgeVideo
- * set 'application/x-civitai-media-id' and 'application/x-civitai-media-type'
- * when imageId is provided, allowing drop targets to fetch stored metadata server-side.
+ * EdgeImage/EdgeVideo set CIVITAI_MEDIA_ID_MIME and CIVITAI_MEDIA_TYPE_MIME when imageId is
+ * provided, allowing drop targets to fetch stored metadata server-side.
  */
 function getDroppedMediaInfo(
   event: React.DragEvent

--- a/src/components/generation_v2/inputs/MetadataExtractionPanel.tsx
+++ b/src/components/generation_v2/inputs/MetadataExtractionPanel.tsx
@@ -7,6 +7,10 @@
  * can render remix/workflow action buttons.
  */
 
+import {
+  CIVITAI_MEDIA_ID_MIME,
+  CIVITAI_MEDIA_TYPE_MIME,
+} from '~/components/EdgeMedia/media-drag-data';
 import { useEffect, useMemo, useState, useCallback } from 'react';
 import {
   ActionIcon,
@@ -71,11 +75,11 @@ function getDroppedImageUrl(event: React.DragEvent): string | undefined {
 function getDroppedMediaInfo(
   event: React.DragEvent
 ): { id: number; type: 'image' | 'video' } | undefined {
-  const raw = event.dataTransfer.getData('application/x-civitai-media-id');
+  const raw = event.dataTransfer.getData(CIVITAI_MEDIA_ID_MIME);
   if (!raw) return undefined;
   const id = parseInt(raw, 10);
   if (!Number.isFinite(id)) return undefined;
-  const type = event.dataTransfer.getData('application/x-civitai-media-type');
+  const type = event.dataTransfer.getData(CIVITAI_MEDIA_TYPE_MIME);
   return { id, type: type === 'video' ? 'video' : 'image' };
 }
 
@@ -307,7 +311,7 @@ export function MetadataExtractionPanel() {
         onDragOver={(e) => {
           // Allow drop so the event fires for URL-based drags
           if (
-            e.dataTransfer.types.includes('application/x-civitai-media-id') ||
+            e.dataTransfer.types.includes(CIVITAI_MEDIA_ID_MIME) ||
             e.dataTransfer.types.includes('text/uri-list') ||
             e.dataTransfer.types.includes('text/plain')
           ) {


### PR DESCRIPTION
Fixes the drag-out regression on the image detail page reported by SubtleShader (ClickUp 868kttpjh).

## Diagnosis

The page already intends to allow this — `watchTouchDrag` declines mouse drags so a click-drag isn't eaten as a swipe. It wasn't enough.

`embla-carousel` 8.6.0's `DragHandler.init` binds `dragstart -> preventDefault()` on the viewport for as long as `watchDrag` is truthy, and **never consults `watchDrag` for that event** — only for `mousedown`/`touchstart` (`embla-carousel.esm.js`, `initEvents.add(node, 'dragstart', evt => evt.preventDefault(), ...)`). So the native HTML5 drag died no matter what our predicate returned.

Located in a live browser rather than inferred, by dispatching `dragstart` at different nodes on a real image detail page:

| dispatch target | `defaultPrevented` |
|---|---|
| image, non-bubbling | false |
| image, bubbling | **true** |
| the embla viewport itself | **true** |
| the viewport's parent | false |

That isolates the listener to the viewport node — embla's. The other three candidates in the ticket were checked and cleared on the same page: the image is the hit-test target (no overlay swallowing it), `draggable` is true, `-webkit-user-drag` is `auto`, `user-select` is `auto`, and the sticker overlay is `pointer-events-none`.

Corollary worth knowing: `watchDrag={canNavigate && watchTouchDrag}`, so on a single-image page `watchDrag` is falsy, embla binds nothing, and drag-out already worked. The bug only ever existed on multi-image posts — a single-image page is not a reproduction.

## The fix

Stop `dragstart` in React's capture phase so it never reaches embla's listener.

Two consequences that shaped the rest of the change:

1. **The stop lands on the native event at React's root container**, so the dragged element's own `onDragStart` never runs either — the drag would have gone out without `application/x-civitai-media-id`, which is what lets a drop target read stored metadata instead of re-parsing the file. The carousel now sets the payload itself, through a `setMediaDragData` helper that `EdgeImage` and `EdgeVideo` also use so the three sites can't drift.
2. **`dragstart` carries no `pointerType`**, and Android Chrome fires it for a long-press image drag. An unconditional escape hatch would have given touch the opposite answer from `watchTouchDrag`, so the handler tracks the last `pointerdown` and leaves anything but a mouse to embla.

## What was actually exercised

Local dev, real Chromium, same build A/B'd by adding and removing the handler.

- **Mouse — verified.** Without the fix: `dragstart` on the carousel image is `defaultPrevented` (50 slides, carousel live). With it: not prevented, a real Playwright drag emits native `drag`/`dragend` on the image, and `dataTransfer` carries `text/uri-list` + `application/x-civitai-media-id` (correct id) + `application/x-civitai-media-type`.
- **Touch — verified for the guard, partially for the swipe.** A synthetic `pointerdown` of type `touch` followed by `dragstart` is still prevented, i.e. embla keeps the gesture. CDP touch swipes move embla's transform identically with and without the fix; my synthetic swipe never commits a slide change in **either** build, so that half is harness limitation, not a comparison. A long-press image drag on real Android Chrome is the case I could not reach.
- **Pen — not exercised.** No pen device.
- Feed cards (untouched surface) still emit all three types where `imageId` is set, and `text/uri-list` alone where it isn't, matching the previous `if (imageId)` behaviour.

`typecheck` clean. `lint` clean on the touched files. Unit suite: the only failures are the two known Windows-only path guards (`rating-label`, `appListingStatChips`) plus `standalone-boot-graph`; none of them can see a client DOM prop.

**No test.** The honest assertion here is the emitted `dataTransfer`, which needs a real browser — and no CI job in this repo runs the browser lane (`.github/workflows/lint.yml` excludes it, Chromium isn't installed). A `defaultPrevented === false` unit test would pass on the broken form this PR started as, which is exactly the test worth not writing.

## Deliberately not in this PR

- **Pinch zoom** — the ticket's optional half. Not started. `Embla.Viewport`'s `touch-pan-y` precludes it as written; making it work is its own change and the drag is what a creator actually reported.
- **`ImagesAsPostsCard`** — the other `watchTouchDrag` consumer, same latent defect. It sits behind the opt-in `swipeGalleryCards` setting and I could not get that surface to render locally, so I'm not shipping an unverified second surface.
- **Videos on this page** stay non-draggable: `draggableEnabled` is false while controls are shown, and the active slide always shows controls. Unchanged by this PR, called out so it isn't read as covered.
- Other carousels (`ModelCarousel`, `Bounty/ImageCarousel`, `GeneratedOutputLightbox`, `MasonryCarousel`) run embla with the default `watchDrag` and still eat drag-out. This is not site-wide parity.
