### PR TITLE
flake: own the dev toolchain, guard the pins, one command to a running app

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -31,6 +31,42 @@ node .claude/skills/dev-server/cli.mjs stop <session-id>
 
 **Checking if server is ready:** After starting, poll the session status to check `ready: true`. The daemon marks sessions ready either via configured health check endpoint or by detecting "Ready" patterns in logs.
 
+## Which node the daemon runs on — and why it is sticky
+
+The daemon is spawned with `process.execPath` (`cli.mjs:66`, `console.mjs:87`), i.e. **whatever node ran
+the CLI verb that first started it**. It then passes its own environment down to every `next dev` it
+supervises. So the node you happened to have on `PATH` the first time you typed any command above is the
+node the whole tree runs on, until someone shuts the daemon down — and nothing records which one that was.
+
+That is not academic. Measured on a dev box: the daemon was running on ambient node **26.7.0**, while
+`.nvmrc` pins **24.19.0**, `package.json` declares `engines.node: ">=24.0.0 <25"`, and production is built
+on `node:24.19.0-alpine3.24`. It had been started from a shell outside the dev shell, and that shell also
+had no `pnpm` at all — which silently disables the daemon's own auto-install path (it shells out to
+`pnpm install` / `pnpm run db:generate` when it sees the lockfile or the schema move).
+
+**Start it through the flake and this cannot happen:**
+
+```bash
+nix run .#dev-server -- status
+nix run .#dev-server -- start
+nix run .#dev-server -- logs <session-id>
+```
+
+That wrapper pins node to the flake's (the same one `.nvmrc` names), puts pnpm on `PATH`, and exports the
+Prisma engine paths NixOS needs. Every `node .claude/skills/dev-server/cli.mjs …` invocation elsewhere in
+this document takes the same subcommands — the wrapper only decides which node runs them.
+
+If you are not using Nix, run the CLI from a shell where `node --version` matches `.nvmrc` and `pnpm` is on
+`PATH`. Either way, **check what you have got** before trusting a session:
+
+```bash
+# the daemon's real interpreter, not the one you assume
+readlink -f /proc/$(cat .claude/skills/dev-server/daemon.pid)/exe
+```
+
+Changing node means restarting the daemon — `cli.mjs shutdown`, then start it again from the right shell.
+A running daemon will not pick up a new `PATH`.
+
 ## Never curl a dev port — `probe` instead
 
 ```bash
@@ -314,7 +350,7 @@ Log levels: `stdout`, `stderr`, `error`, `warn`, `info`
 
 ## Dashboard TUI
 
-Run `node .claude/skills/dev-server/console.mjs` (or `npm run dev:daemon`) for a live terminal dashboard.
+Run `node .claude/skills/dev-server/console.mjs` (or `pnpm run dev:daemon`) for a live terminal dashboard.
 
 | Key | Action |
 |-----|--------|

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -44,7 +44,11 @@ on `node:24.19.0-alpine3.24`. It had been started from a shell outside the dev s
 had no `pnpm` at all — which silently disables the daemon's own auto-install path (it shells out to
 `pnpm install` / `pnpm run db:generate` when it sees the lockfile or the schema move).
 
-**Start it through the flake and this cannot happen:**
+**The fix, whatever your setup: start it from a shell whose `node --version` matches `.nvmrc` and which
+has `pnpm` on `PATH`.** `nvm use` at the repo root gives you both.
+
+**On NixOS (optional)** the flake wrapper does that for you — it pins node to the same version `.nvmrc`
+names, puts pnpm on `PATH`, and exports the Prisma engine paths NixOS needs:
 
 ```bash
 nix run .#dev-server -- status
@@ -52,12 +56,10 @@ nix run .#dev-server -- start
 nix run .#dev-server -- logs <session-id>
 ```
 
-That wrapper pins node to the flake's (the same one `.nvmrc` names), puts pnpm on `PATH`, and exports the
-Prisma engine paths NixOS needs. Every `node .claude/skills/dev-server/cli.mjs …` invocation elsewhere in
-this document takes the same subcommands — the wrapper only decides which node runs them.
+Every `node .claude/skills/dev-server/cli.mjs …` invocation elsewhere in this document takes the same
+subcommands — the wrapper only decides which node runs them, so nothing here depends on having Nix.
 
-If you are not using Nix, run the CLI from a shell where `node --version` matches `.nvmrc` and `pnpm` is on
-`PATH`. Either way, **check what you have got** before trusting a session:
+Either way, **check what you have got** before trusting a session:
 
 ```bash
 # the daemon's real interpreter, not the one you assume

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,33 @@
+# Example direnv config. Copy to `.envrc` (which is gitignored) and run
+# `direnv allow`. With nix-direnv installed, entering the repo then gives you the
+# flake's toolchain automatically -- the same node and pnpm `nix run .#dev` uses.
+#
+#   cp .envrc.example .envrc && direnv allow
+#
+# ADDING to an existing .envrc? Keep the lines you already have. This file is a
+# starting point to copy, not something to overwrite a working .envrc with:
+# personal direnv lines (extra `use` directives, machine-local exports) are yours
+# and nothing here replaces them.
+#
+# Application configuration does NOT belong here -- it goes in `.env.development`,
+# which `nix run .#dev` creates for you from `.env-example`. The only reason to
+# export anything in this file is if you want it in your interactive shell too.
+#
+# NEVER commit a real .envrc. It is gitignored on purpose, and the secrets below
+# are placeholders.
+
+use flake
+
+# Optional: makes flake.lock changes reload the shell instead of serving a stale
+# cached one.
+watch_file flake.lock
+
+# Optional overrides. Everything here has a working default in .env.development,
+# so you only need these if you want them visible outside the app as well --
+# e.g. to run a one-off script or psql against the same database.
+#
+# export DATABASE_URL=postgresql://postgres:postgres@localhost:15432/civitai
+#
+# Mint these at http://localhost:9001 (minioadmin / minioadmin) -> Access Keys.
+# export S3_UPLOAD_KEY=<your-minio-access-key>
+# export S3_UPLOAD_SECRET=<your-minio-secret-key>

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ yarn-error.log*
 .env*
 !.env-example
 !.env.example
+# `.env*` also matches `.envrc`, which is how the flake gets loaded. The real
+# .envrc stays ignored (it holds machine-local secrets); the example is tracked
+# so the flake is discoverable from a clean clone.
+!.envrc.example
 
 # vercel
 .vercel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,7 +372,19 @@ declares `engines.node: ">=24.0.0 <25"`. On NixOS the flake owns both — it der
 its node major from `.nvmrc` instead of naming one, and `nix flake check` fails if
 they disagree.
 
-From nothing to a running app, one command:
+From nothing to a running app (the default path — no Nix):
+
+```bash
+nvm use                                        # .nvmrc -> 24.19.0
+corepack enable
+git submodule update --init event-engine-common
+cp .env-example .env.development
+docker compose -f docker-compose.base.yml up -d
+pnpm install && pnpm dev
+```
+
+**Optional, NixOS only** — the flake does the same in one command. Nothing requires
+it, and it is used by one maintainer; do not assume a contributor has it:
 
 ```bash
 nix run .#dev          # docker preflight, submodule, .env.development, compose up,
@@ -385,10 +397,10 @@ In an existing checkout that already works:
 1. Install dependencies: `pnpm install`
 2. Generate Prisma client: `pnpm run db:generate`
 3. Start the services if they are down: `make start`
-4. Start dev server: use the `/dev-server` skill — and start its daemon through
-   `nix run .#dev-server` so it lands on the flake's node. The daemon is spawned
-   with `process.execPath`, so whichever node first ran a CLI verb is the node it
-   keeps until it is shut down.
+4. Start dev server: use the `/dev-server` skill. The daemon is spawned with
+   `process.execPath`, so whichever node first ran a CLI verb is the node it keeps
+   until it is shut down — run it under the node from `.nvmrc`. (On NixOS,
+   `nix run .#dev-server` does that for you.)
 
 ### Git Worktrees
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,9 +365,30 @@ Comments are not type-checked, so they rot silently and become misleading. Write
 - Search service endpoints
 
 ### Local Development
+
+**Toolchain: node `24.19.0` and pnpm 10.x.** `.nvmrc` is the authority (CI reads it
+via `node-version-file:`, and the Dockerfile base image tracks it); `package.json`
+declares `engines.node: ">=24.0.0 <25"`. On NixOS the flake owns both — it derives
+its node major from `.nvmrc` instead of naming one, and `nix flake check` fails if
+they disagree.
+
+From nothing to a running app, one command:
+
+```bash
+nix run .#dev          # docker preflight, submodule, .env.development, compose up,
+                       # wait for postgres, pnpm install, next dev on :3000
+nix run .#dev -- --no-start   # bootstrap only
+nix run .#doctor              # are the flake's pins still in step with the repo?
+```
+
+In an existing checkout that already works:
 1. Install dependencies: `pnpm install`
 2. Generate Prisma client: `pnpm run db:generate`
-3. Start dev server: Use `/dev-server` skill
+3. Start the services if they are down: `make start`
+4. Start dev server: use the `/dev-server` skill — and start its daemon through
+   `nix run .#dev-server` so it lands on the flake's node. The daemon is spawned
+   with `process.execPath`, so whichever node first ran a CLI verb is the node it
+   keeps until it is shut down.
 
 ### Git Worktrees
 
@@ -420,10 +441,14 @@ that file collected a nonzero count** — it was 308 tests on one base. If it re
 about your change, whatever the summary says.
 
 **A fresh worktree also has no `.envrc`.** It's gitignored, so it never comes with the checkout, and you silently
-get system Node instead of the flake's pinned version. Measured: system Node **26.5.0** against the flake's
-**22.22.2** produced 7 spurious `window.localStorage is undefined` failures under happy-dom plus 8 Prisma
-`linux-nixos` engine errors — every one a false red that got attributed to the code under test. Create a minimal
-`.envrc` containing `use flake` and `direnv allow` it. **Then confirm your cwd is actually the worktree**: one run
+get system Node instead of the flake's pinned version. Measured (when the flake still shipped node 22): system
+Node **26.5.0** against the flake's **22.22.2** produced 7 spurious `window.localStorage is undefined` failures
+under happy-dom plus 8 Prisma `linux-nixos` engine errors — every one a false red that got attributed to the code
+under test. The flake now ships **24.19.0**, matching `.nvmrc`, so the version gap is smaller — but the *Prisma*
+half is unchanged and does not care about the gap: without the flake's env there are no `PRISMA_*_ENGINE_*` paths
+at all, and prisma goes looking for a `linux-nixos` engine that has never been published.
+`cp .envrc.example <worktree>/.envrc && direnv allow`, or run commands through `nix develop`.
+**Then confirm your cwd is actually the worktree**: one run
 whose cwd was set to a different repo lost two suites to collection failures and **77 tests silently never ran**
 (10849 → 10772) while the output otherwise looked entirely normal.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,18 @@ every existing and future worktree of that clone inherits it until you sync.
 
 ## Verifying locally
 
+All of these need the repo's own toolchain — node `24.19.0` (the version in
+`.nvmrc`) and pnpm 10.x. **Nothing stops you running them on the wrong node**:
+`engines.node` is advisory, so `pnpm install` prints `WARN Unsupported engine`
+and continues. That is why this is worth stating rather than leaving to the
+tooling — the wrong major shows up as spurious test failures attributed to your
+branch, not as an error at install time. On NixOS there is a second, louder
+failure: outside the dev shell there are no `PRISMA_*_ENGINE_*` paths, so Prisma
+goes looking for a `linux-nixos` engine that has never been published.
+
+`nvm use` picks the right node up from `.nvmrc`; with Nix, prefix any of these
+with `nix develop -c`, or use direnv (`cp .envrc.example .envrc && direnv allow`).
+
 ```bash
 pnpm typecheck                 # full repo
 pnpm test:unit:run             # ~8,900 unit tests, node env

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,25 @@
+# Compose derives its project name from the directory it runs in, so each git
+# worktree would otherwise get its own stack -- and the second one to start dies
+# on the port binds ("Bind for :::15434 failed: port is already allocated").
+# Pinning it means every worktree shares the one local stack and the one local
+# database, which is what the primary clone's directory name already produced.
+# Override it if you genuinely want a second, isolated stack.
+export COMPOSE_PROJECT_NAME ?= civitai
+
 # Start the containers in the background
 .PHONY: start
 start:
-	docker-compose up -d
+	docker compose up -d
 
 # Stop all containers
 .PHONY: stop
 stop:
-	docker-compose stop
+	docker compose stop
 
 # Remove containers
 .PHONY: down
 down:
-	docker-compose down
+	docker compose down
 
 # Restart containers
 .PHONY: restart
@@ -20,14 +28,14 @@ restart: stop start
 # Rebuild the containers
 .PHONY: rebuild
 rebuild:
-	docker-compose down \
-		&& docker-compose up --build -d
+	docker compose down \
+		&& docker compose up --build -d
 
 # Stop and remove all containers, networks, images, and volumes
 .PHONY: burn
 burn:
-	docker-compose down \
-		&& docker-compose down --volumes
+	docker compose down \
+		&& docker compose down --volumes
 
 ROWS ?= 1000
 TRUNC_QUEUE ?= true
@@ -50,18 +58,31 @@ bootstrap-metrics:
 copy-env:
 	cp -u ./.env-example ./.env.development
 
-.PHONY: npm-install
-npm-install:
-	# TODO fix postinstall on git bash
-	npm i
+# `npm i` cannot work here: package.json's `preinstall` runs `npx only-allow pnpm`,
+# which exits 1 under npm. `make init` was dead on that line.
+.PHONY: install
+install:
+	pnpm install
 
+# Kept so `make npm-install` still does the right thing for anyone with it in
+# their fingers. It installs with pnpm, because npm is refused.
+.PHONY: npm-install
+npm-install: install
+
+# Must go through `db:generate`, not a bare `prisma generate`: the generate step
+# reads packages/civitai-db-schema/prisma/schema.prisma, which is gitignored and
+# produced by scripts/generate-slim-schema.js. On a fresh clone that file does
+# not exist yet, so `prisma generate` alone has nothing to read. Going through
+# pnpm also puts node_modules/.bin on PATH, which a bare `prisma` needs.
 .PHONY: gen-prisma
 gen-prisma:
-	prisma generate --no-hints
+	pnpm run db:generate
 
+# Through `pnpm exec` so cross-env and next resolve from node_modules/.bin
+# without the caller having to add it to PATH by hand.
 .PHONY: dev
 dev:
-	cross-env NODE_OPTIONS=\"--disable-warning=ExperimentalWarning\" next dev
+	pnpm exec cross-env NODE_OPTIONS=--disable-warning=ExperimentalWarning next dev
 
 .PHONY: run
 run: gen-prisma dev
@@ -70,13 +91,13 @@ run: gen-prisma dev
 reseed: bootstrap-db bootstrap-metrics
 
 .PHONY: init
-init: copy-env npm-install start run-migrations reseed run
+init: copy-env install start run-migrations reseed run
 
 .PHONY: rerun
 rerun: start reseed dev
 
 .PHONY: init-devcontainer
-init-devcontainer: copy-env npm-install run-migrations reseed
+init-devcontainer: copy-env install run-migrations reseed
 
 .PHONY: default
 default: start

--- a/README.md
+++ b/README.md
@@ -69,7 +69,27 @@ for the database. By leveraging these tools, we've been able to create a scalabl
 
 ### Installation
 
-#### With Nix (recommended on NixOS, works on any Linux with flakes enabled)
+#### Standard setup
+
+```sh
+git clone https://github.com/civitai/civitai.git
+cd civitai
+nvm use                                              # reads .nvmrc -> 24.19.0
+corepack enable
+git submodule update --init event-engine-common
+cp .env-example .env.development
+docker compose -f docker-compose.base.yml up -d
+pnpm install
+pnpm dev
+```
+
+#### Optional: Nix flake
+
+> **Optional, and not the supported default.** The standard setup above is what the
+> project expects and what CI builds; nothing in the repo requires Nix, and you can
+> ignore this section entirely. It exists because NixOS cannot use Prisma's published
+> engines (there is no `linux-nixos` build), so a flake is the practical way to work on
+> this repo there. If you are not on NixOS and not already a flakes user, skip it.
 
 The flake owns the toolchain, so you do not install Node or pnpm yourself:
 
@@ -100,20 +120,6 @@ For an interactive shell with the same toolchain, use `nix develop`, or copy
 [`.envrc.example`](.envrc.example) to `.envrc` and run `direnv allow` to get it
 automatically on `cd`.
 
-#### Without Nix
-
-```sh
-git clone https://github.com/civitai/civitai.git
-cd civitai
-nvm use                                              # reads .nvmrc -> 24.19.0
-corepack enable
-git submodule update --init event-engine-common
-cp .env-example .env.development
-docker compose -f docker-compose.base.yml up -d
-pnpm install
-pnpm dev
-```
-
 #### With devcontainers
 
 > ⚠️ **Known out of step:** `.devcontainer/public/docker-compose.yml` pins
@@ -135,15 +141,15 @@ command. Otherwise, you will see performance issues.
 
 #### The signals and buzz services
 
-`docker-compose.base.yml` holds everything a contributor needs, and is what
-`nix run .#dev` starts. The extra services in `docker-compose.yml`
+`docker-compose.base.yml` holds everything a contributor needs (and is also what
+`nix run .#dev` starts). The extra services in `docker-compose.yml`
 (signals, buzz) come from private `ghcr.io` images, so they only work for
 internal members:
 
 - create a GitHub personal access token with `read:packages`
 - set it as `CR_PAT`
 - `echo $CR_PAT | docker login ghcr.io -u USERNAME --password-stdin`
-- then `nix run .#dev -- --full`, or `docker compose up -d`
+- then `docker compose up -d` (or, with the flake, `nix run .#dev -- --full`)
 
 ### After the first start
 

--- a/README.md
+++ b/README.md
@@ -52,61 +52,121 @@ for the database. By leveraging these tools, we've been able to create a scalabl
 
 ### Prerequisites
 
-First, make sure that you have the following installed on your machine:
-
-- [Docker](https://www.docker.com/) (for running the database and services)
-- If using devcontainers
-    - An IDE that supports them (VS Code with devcontainers extension, Jetbrains, etc.)
-- If running directly
-    - Node.js (version 20 or later)
-        - We recommend you have installed `nvm` in order to set the right node version to run this project
-          ```sh
-          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-          ```
-    - Make (optional, for easier initial setup)
+- [Docker](https://www.docker.com/), with Compose v2 (`docker compose`, not the
+  retired hyphenated `docker-compose`). The database, Redis, MinIO, Meilisearch,
+  ClickHouse and the mail catcher all run as containers.
+- **Node.js `24.19.0`.** Not "20 or later" — `package.json` declares
+  `engines.node: ">=24.0.0 <25"`. The exact version lives in [`.nvmrc`](.nvmrc);
+  CI installs that file's version and the production image is built on the same
+  one, so `nvm use` (or any tool that reads `.nvmrc`) is the right way to get it.
+  Note that nothing stops you: `pnpm install` only prints
+  `WARN Unsupported engine` and carries on, so the wrong major surfaces later as
+  odd test failures rather than as a refusal at install time.
+- **pnpm.** This repo is pnpm-only, and this one *is* enforced — `npm install`
+  exits 1 via the `preinstall` `only-allow pnpm` hook. `corepack enable` will
+  pick up the `packageManager` field for you.
+- Make (optional).
 
 ### Installation
 
-1. Follow the [Prerequisites](#prerequisites) steps above
-2. Clone the repository to your local machine
-3. Choose one method:
-    - a) Use devcontainers
-      > ⚠️ Important Warning for Windows Users: Either clone this repo onto a WSL volume, or use the "clone repository in named container volume"
-      command. Otherwise, you will see performance issues.
-        - Open the directory up in your IDE of choice
-            - VS Code should prompt you to "Open in container"
-                - If not, you may need to manually run `Dev Containers: Open Folder in Container`
-            - For other IDEs, you may need to open the `.devcontainer/devcontainer.json` file, and click "Create devcontainer and mount sources"
-            - _Note: this may take some time to run initially_
-        - Run `make run` or `npm run dev`
-    - b) Run `make init`
-        - This command will do a few things:
-            - Creates a starter `env` file
-            - Installs npm packages
-            - Spins up docker containers
-            - Runs any additional database migrations
-            - Creates some dummy seed data
-            - Populates metrics and meilisearch
-            - Initializes prisma
-            - Runs the server
-        - If you see an error about an app not being found, make sure `node_modules/.bin` is added to your path:
-            - `export PATH="$PATH:$(realpath node_modules/.bin)"`
-        - If you are an internal member, you can use the buzz and signals service
-            - Set this up once by creating a personal access token in github (with read package permissions)
-            - Set that to `CR_PAT` env
-            - Run `echo $CR_PAT | docker login ghcr.io -u USERNAME --password-stdin`
-    - Please report any issues with these commands to us on [discord][discord-url]
-4. Edit the `.env.development` file
-    - Most default values are configured to work out of the box, except the S3 upload key and secret. To generate those, navigate to
-      the minio web interface at [http://localhost:9000](http://localhost:9000) with the default username and password `minioadmin`, and then navigate
-      to the "Access Keys" tab. Click "Create Access Key" and copy the generated key and secret into the `.env` file (`S3_UPLOAD_KEY` and `S3_UPLOAD_SECRET`, `S3_IMAGE_UPLOAD_KEY` and `S3_IMAGE_UPLOAD_SECRET`).
-    - Set `WEBHOOK_TOKEN` to a random string of your choice. This will be used to authenticate requests to the webhook endpoint.
-    - Add a random string of your choice to the email properties to allow user registration
-        - `EMAIL_USER`
-        - `EMAIL_PASS`
-        - `EMAIL_FROM` (Valid email format needed)
-5. Run `git submodule update --recursive`
-6. Finally, visit [http://localhost:3000](http://localhost:3000) to see the website.
+#### With Nix (recommended on NixOS, works on any Linux with flakes enabled)
+
+The flake owns the toolchain, so you do not install Node or pnpm yourself:
+
+```sh
+git clone https://github.com/civitai/civitai.git
+cd civitai
+nix run .#dev
+```
+
+That single command checks Docker is usable, checks out the
+`event-engine-common` submodule, creates `.env.development` from `.env-example`
+if you do not already have one, starts the container stack, waits for Postgres,
+runs `pnpm install`, and then starts the dev server on
+[http://localhost:3000](http://localhost:3000). Every step is idempotent — it is
+safe to re-run in a checkout that already works, and it will not overwrite your
+`.env.development` or touch your data.
+
+Useful variants:
+
+```sh
+nix run .#dev -- --no-start   # bootstrap only, leave the services running
+nix run .#dev -- --full       # also start the signals/buzz containers (see below)
+nix run .#doctor              # check the flake's pins against the repo
+nix flake check               # the same checks, plus their own self-test
+```
+
+For an interactive shell with the same toolchain, use `nix develop`, or copy
+[`.envrc.example`](.envrc.example) to `.envrc` and run `direnv allow` to get it
+automatically on `cd`.
+
+#### Without Nix
+
+```sh
+git clone https://github.com/civitai/civitai.git
+cd civitai
+nvm use                                              # reads .nvmrc -> 24.19.0
+corepack enable
+git submodule update --init event-engine-common
+cp .env-example .env.development
+docker compose -f docker-compose.base.yml up -d
+pnpm install
+pnpm dev
+```
+
+#### With devcontainers
+
+> ⚠️ **Known out of step:** `.devcontainer/public/docker-compose.yml` pins
+> `mcr.microsoft.com/devcontainers/typescript-node:1-22`, i.e. Node 22, which is
+> outside this repo's `engines.node` range. `pnpm install` will warn rather than
+> stop, so the container comes up and then misbehaves in ways that look like your
+> branch. There is no `1-24` tag (the template major moved on); `3-24` is the
+> closest equivalent. Not changed here because it could not be exercised.
+
+> ⚠️ Important Warning for Windows Users: Either clone this repo onto a WSL volume, or use the "clone repository in named container volume"
+command. Otherwise, you will see performance issues.
+
+- Open the directory up in your IDE of choice
+    - VS Code should prompt you to "Open in container"
+        - If not, you may need to manually run `Dev Containers: Open Folder in Container`
+    - For other IDEs, you may need to open the `.devcontainer/devcontainer.json` file, and click "Create devcontainer and mount sources"
+    - _Note: this may take some time to run initially_
+- Run `make run`
+
+#### The signals and buzz services
+
+`docker-compose.base.yml` holds everything a contributor needs, and is what
+`nix run .#dev` starts. The extra services in `docker-compose.yml`
+(signals, buzz) come from private `ghcr.io` images, so they only work for
+internal members:
+
+- create a GitHub personal access token with `read:packages`
+- set it as `CR_PAT`
+- `echo $CR_PAT | docker login ghcr.io -u USERNAME --password-stdin`
+- then `nix run .#dev -- --full`, or `docker compose up -d`
+
+### After the first start
+
+1. Edit `.env.development`. Most defaults work out of the box; these do not:
+    - **S3 upload credentials.** Open the MinIO console at
+      [http://localhost:9001](http://localhost:9001) (username and password both
+      `minioadmin`) — note it is port **9001**, port 9000 is the S3 API itself —
+      go to "Access Keys", click "Create Access Key", and copy the key and secret
+      into `S3_UPLOAD_KEY` / `S3_UPLOAD_SECRET` and `S3_IMAGE_UPLOAD_KEY` /
+      `S3_IMAGE_UPLOAD_SECRET`.
+    - `WEBHOOK_TOKEN` — any random string; it authenticates requests to the
+      webhook endpoint.
+    - `EMAIL_USER`, `EMAIL_PASS`, and `EMAIL_FROM` (a valid email format) — any
+      values, but they must be set for user registration to work.
+2. On an empty database, populate it. These are slow and destructive, which is
+   why no bootstrap runs them for you:
+    ```sh
+    make run-migrations
+    make reseed
+    ```
+3. Visit [http://localhost:3000](http://localhost:3000).
+
+Please report any issues with these commands to us on [discord][discord-url].
 
 _&ast; Note that account creation will run emails through maildev, which can be accessed at [http://localhost:1080](http://localhost:1080)._
 
@@ -148,7 +208,10 @@ see [Calling All Developers: Join Civitai's Community Development Team](https://
 
 Over the course of development, you may need to change the structure of the database. To do this:
 
-1. Make your changes to the `packages/civitai-db-schema/prisma/schema.prisma` file
+1. Make your changes to the `packages/civitai-db-schema/prisma/schema.full.prisma` file.
+   **Not `schema.prisma`** — that one is gitignored and regenerated from
+   `schema.full.prisma` by `scripts/generate-slim-schema.js` on every
+   `pnpm run db:generate`, so edits to it are silently overwritten.
 2. Run `pnpm run db:migrate:empty "brief description here"`. This creates
    `packages/civitai-db-schema/prisma/migrations/YYYYMMDDHHmmss_brief_description_here/migration.sql`
    for you, in the one directory Prisma reads.

--- a/docs/pnpm-migration.md
+++ b/docs/pnpm-migration.md
@@ -6,7 +6,10 @@ We've migrated from npm to pnpm for package management. Follow these steps to up
 
 ## Prerequisites
 
-- **Node.js 18.x or later** (required)
+- **Node.js `24.19.0`** — the exact version in [`.nvmrc`](../.nvmrc). `package.json`
+  declares `engines.node: ">=24.0.0 <25"`, so anything outside that major is
+  refused at install time. (This line used to say "18.x or later", which has not
+  been true for a long time.)
 - **pnpm 10.28.1** (the version specified in `package.json`)
 
 Install pnpm globally:

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776949667,
-        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "lastModified": 1787052956,
+        "narHash": "sha256-fZt7Au28AduGpt7vRfIOcpsHKJ+9cEnuQ2NdWuh0KVc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "rev": "b47ad65d73ab65ded9ab408fe558866d71defee8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Civitai development shell (NixOS)";
+  description = "Civitai local development environment (NixOS, x86_64-linux)";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
@@ -9,18 +9,71 @@
     let
       system = "x86_64-linux";
       pkgs = import nixpkgs { inherit system; };
+      inherit (pkgs) lib;
 
-      # Prisma engines must match the npm @prisma/client version EXACTLY (engine
-      # commit is embedded in the client and verified at runtime). The project
-      # pins @prisma/client 6.13.0, but nixpkgs never packaged 6.13.0
-      # (prisma-engines jumps 6.7 -> 6.18), so we fetch Prisma's official
-      # prebuilt 6.13.0 engines and patchelf them onto NixOS instead of building
-      # from source or drifting the repo's pinned client version.
+      # =====================================================================
+      # Toolchain
       #
-      # Commit comes from node_modules/@prisma/engines-version
-      # (6.13.0-35.<commit>). Bump both together if @prisma/client changes.
+      # Nothing here hardcodes a version the repo already declares elsewhere.
+      # `.nvmrc` and `package.json` are read directly, so the flake cannot
+      # silently drift from what CI installs and what production runs. The
+      # residual drift a derivation cannot prevent -- nixpkgs moving the patch
+      # version under us -- is caught by `checks.toolchain-pins` below, so it
+      # surfaces as a red `nix flake check` rather than as a mystery at runtime.
+      #
+      # Authorities, for the record:
+      #   node    .nvmrc        (every GitHub workflow: node-version-file: .nvmrc)
+      #                         (Dockerfile FROM node:<same>)
+      #   pnpm    package.json  packageManager field
+      #   prisma  pnpm-lock.yaml resolved @prisma/client (see prisma-engines)
+      # =====================================================================
+
+      nodeVersion = lib.trim (builtins.readFile ./.nvmrc);
+      nodeMajor = lib.head (lib.splitString "." nodeVersion);
+      nodejs = pkgs."nodejs_${nodeMajor}";
+
+      packageJson = builtins.fromJSON (builtins.readFile ./package.json);
+
+      # "pnpm@10.28.1" -> "10". nixpkgs will not carry every patch release and
+      # does not need to: the lockfile format is tied to the major. Pinning the
+      # major attribute (rather than the unversioned `pkgs.pnpm`) is what stops
+      # a `nix flake update` silently handing everyone pnpm 11 -- which is
+      # exactly what the unversioned attribute did between this flake's old lock
+      # and its new one.
+      pnpmMajor = lib.head (lib.splitString "."
+        (lib.last (lib.splitString "@" packageJson.packageManager)));
+      # `nodejs-slim`, not `nodejs`: pnpm's own launcher only needs a runtime,
+      # and nixpkgs warns if you override the full package here. This keeps
+      # pnpm's shebang node on the same major as the shell's node.
+      pnpm = pkgs."pnpm_${pnpmMajor}".override {
+        nodejs-slim = pkgs."nodejs-slim_${nodeMajor}";
+      };
+
+      # =====================================================================
+      # Prisma engines
+      #
+      # `@prisma/client` embeds an engine commit and verifies it against the
+      # engine binary at runtime, so the engines must match the client EXACTLY.
+      # nixpkgs never packaged 6.13.0 (prisma-engines jumps 6.7 -> 6.18), so we
+      # fetch Prisma's official prebuilt engines for one commit and patchelf
+      # them onto NixOS rather than building from source or drifting the repo's
+      # pinned client.
+      #
+      # Both values below are duplicates of information that lives in
+      # pnpm-lock.yaml, which Nix cannot parse. `checks.prisma-pin` re-derives
+      # them from the lockfile and fails if they have diverged -- package.json
+      # declares `@prisma/client: ^6.3.0`, a caret range, so a routine lockfile
+      # refresh is all it takes.
+      #
+      # To bump: change prismaVersion + engineCommit (from the lockfile's
+      # `@prisma/engines-version@<version>-<n>.<commit>`), set the three sha256s
+      # to lib.fakeSha256, build once, and paste in what nix reports.
+      # =====================================================================
+
+      prismaVersion = "6.13.0";
       engineCommit = "361e86d0ea4987e9f53a565309b3eed797a6bcbd";
       enginePlatform = "debian-openssl-3.0.x"; # links libssl/libcrypto .so.3, satisfied by pkgs.openssl
+
       fetchEngine = file: sha256: pkgs.fetchurl {
         url = "https://binaries.prisma.sh/all_commits/${engineCommit}/${enginePlatform}/${file}.gz";
         inherit sha256;
@@ -28,7 +81,7 @@
 
       prisma-engines = pkgs.stdenvNoCC.mkDerivation {
         pname = "prisma-engines";
-        version = "6.13.0";
+        version = prismaVersion;
         dontUnpack = true;
         nativeBuildInputs = [ pkgs.autoPatchelfHook pkgs.gzip ];
         buildInputs = [ pkgs.openssl pkgs.stdenv.cc.cc.lib pkgs.zlib ];
@@ -40,29 +93,203 @@
 
         buildPhase = ''
           mkdir -p $out/lib $out/bin
-          gzip -dc $queryLib    > $out/lib/libquery_engine.node
+          gzip -dc $queryLib     > $out/lib/libquery_engine.node
           gzip -dc $schemaEngine > $out/bin/schema-engine
           gzip -dc $queryEngine  > $out/bin/query-engine
           chmod +x $out/bin/schema-engine $out/bin/query-engine
         '';
       };
-    in {
-      packages.${system}.prisma-engines = prisma-engines;
+
+      prismaEnv = {
+        PRISMA_QUERY_ENGINE_LIBRARY = "${prisma-engines}/lib/libquery_engine.node";
+        PRISMA_QUERY_ENGINE_BINARY = "${prisma-engines}/bin/query-engine";
+        PRISMA_SCHEMA_ENGINE_BINARY = "${prisma-engines}/bin/schema-engine";
+      };
+
+      # =====================================================================
+      # Service stack
+      #
+      # The SERVERS are docker-compose's job (docker-compose.base.yml), not
+      # nix's -- postgres x4, redis x2, minio, meilisearch, clickhouse, maildev.
+      # What the shell provides is the matching CLIENTS, because you talk to
+      # those containers by hand constantly:
+      #
+      #   psql              -> the `db` container (postgres 17) on :15432
+      #   redis-cli         -> the `redis` container on :6379
+      #   clickhouse client -> the `clickhouse` container on :18123
+      #
+      # postgresql_17 (not _16) because the primary `db` container is
+      # postgres:17 and a client older than its server is the one direction
+      # libpq does not promise to work.
+      # =====================================================================
+
+      serviceClients = [
+        pkgs.postgresql_17
+        pkgs.redis
+        pkgs.clickhouse
+      ];
+
+      # =====================================================================
+      # Checks
+      #
+      # Deterministic, sandboxed, no network. Two python helpers live in
+      # scripts/nix/ rather than inline here so they can be read, and run,
+      # without going through nix (`nix run .#doctor` does exactly that).
+      # =====================================================================
+
+      checkPython = pkgs.python3.withPackages (ps: with ps; [ pyyaml node-semver ]);
+
+      nodeCheckArgs = lib.escapeShellArgs [
+        "--nvmrc" "${./.nvmrc}"
+        "--package-json" "${./package.json}"
+        "--flake-node" nodejs.version
+        "--flake-pnpm" pnpm.version
+      ];
+
+      prismaCheckArgs = lib.escapeShellArgs [
+        "--package-json" "${./package.json}"
+        "--lockfile" "${./pnpm-lock.yaml}"
+        "--flake-prisma-version" prismaVersion
+        "--flake-engine-commit" engineCommit
+      ];
+
+      # =====================================================================
+      # Entrypoints
+      # =====================================================================
+
+      dev = pkgs.writeShellApplication {
+        name = "dev";
+        # Docker is deliberately absent: the CLI has to match the daemon the
+        # developer is already running, so it comes from the host PATH.
+        runtimeInputs = [ nodejs pnpm pkgs.git pkgs.postgresql_17 pkgs.coreutils ];
+        text = builtins.readFile ./scripts/nix/dev-up.sh;
+        meta.description = "Bootstrap and run the civitai local dev environment";
+      };
+
+      dev-server = pkgs.writeShellApplication {
+        name = "dev-server";
+        runtimeInputs = [ nodejs pnpm pkgs.git ];
+        text = ''
+          # The dev-server daemon re-execs itself with process.execPath, so
+          # whatever node launches the CLI is the node the daemon runs on
+          # forever. Launching it through this wrapper is what pins it to the
+          # flake's node instead of whatever happened to be on PATH.
+          ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+          if [ -z "$ROOT" ] || [ ! -d "$ROOT" ]; then
+            echo "dev-server: not inside a git checkout." >&2
+            exit 1
+          fi
+          cd "$ROOT"
+          exec node .claude/skills/dev-server/cli.mjs "$@"
+        '';
+        meta.description = "Run the dev-server CLI on the flake's node";
+      };
+
+      doctor = pkgs.writeShellApplication {
+        name = "doctor";
+        runtimeInputs = [ checkPython pkgs.git ];
+        text = ''
+          # Same assertions `nix flake check` makes, but against your working
+          # tree rather than the committed source, so you can see the effect of
+          # an edit before committing it.
+          ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+          if [ -z "$ROOT" ] || [ ! -d "$ROOT" ]; then
+            echo "doctor: not inside a git checkout." >&2
+            exit 1
+          fi
+          cd "$ROOT"
+          rc=0
+          python3 scripts/nix/check-node-pin.py \
+            --nvmrc .nvmrc --package-json package.json \
+            --flake-node ${nodejs.version} --flake-pnpm ${pnpm.version} || rc=1
+          echo
+          python3 scripts/nix/check-prisma-pin.py \
+            --package-json package.json --lockfile pnpm-lock.yaml \
+            --flake-prisma-version ${prismaVersion} \
+            --flake-engine-commit ${engineCommit} || rc=1
+          exit "$rc"
+        '';
+        meta.description = "Check the flake's pins against the working tree";
+      };
+    in
+    {
+      packages.${system} = {
+        inherit prisma-engines dev dev-server doctor;
+        default = dev;
+      };
+
+      apps.${system} = {
+        dev = { type = "app"; program = lib.getExe dev; meta = dev.meta; };
+        dev-server = { type = "app"; program = lib.getExe dev-server; meta = dev-server.meta; };
+        doctor = { type = "app"; program = lib.getExe doctor; meta = doctor.meta; };
+        default = { type = "app"; program = lib.getExe dev; meta = dev.meta; };
+      };
+
+      # `nix flake check` BUILDS checks.* but only EVALUATES packages.* and
+      # devShells.* -- measured, not assumed. So the three writeShellApplications
+      # are re-exposed as a check below; without that, their build-time
+      # shellcheck would never run under `nix flake check`.
+      checks.${system} = {
+        # writeShellApplication runs shellcheck + `bash -n` at build time, so
+        # building these IS the lint.
+        dev-scripts = pkgs.symlinkJoin {
+          name = "check-dev-scripts";
+          paths = [ dev dev-server doctor ];
+        };
+
+        toolchain-pins = pkgs.runCommand "check-toolchain-pins"
+          { nativeBuildInputs = [ checkPython ]; }
+          ''
+            python3 ${./scripts/nix/check-node-pin.py} ${nodeCheckArgs}
+            touch $out
+          '';
+
+        prisma-pin = pkgs.runCommand "check-prisma-pin"
+          { nativeBuildInputs = [ checkPython ]; }
+          ''
+            python3 ${./scripts/nix/check-prisma-pin.py} ${prismaCheckArgs}
+            touch $out
+          '';
+
+        # The two guards above only assert that today's pins agree. This one
+        # asserts the guards can still SEE a disagreement: it breaks each pin on
+        # purpose and requires the specific guard that owns it to fire, and the
+        # others to stay silent. Without it, either guard could rot into a
+        # constant `true` and every check would stay green.
+        pin-guards-selftest = pkgs.runCommand "check-pin-guards-selftest"
+          {
+            nativeBuildInputs = [ checkPython pkgs.bash pkgs.gnused pkgs.gnugrep ];
+            NODE_SCRIPT = "${./scripts/nix/check-node-pin.py}";
+            PRISMA_SCRIPT = "${./scripts/nix/check-prisma-pin.py}";
+            NVMRC = "${./.nvmrc}";
+            PACKAGE_JSON = "${./package.json}";
+            LOCKFILE = "${./pnpm-lock.yaml}";
+          }
+          ''
+            bash ${./scripts/nix/test-pins.sh}
+            touch $out
+          '';
+      };
 
       devShells.${system}.default = pkgs.mkShell {
-        buildInputs = with pkgs; [
-          nodejs_22
-          pnpm
-          openssl
-          clickhouse
-          postgresql_16
-          redis
-        ];
-        env = {
-          PRISMA_QUERY_ENGINE_LIBRARY = "${prisma-engines}/lib/libquery_engine.node";
-          PRISMA_QUERY_ENGINE_BINARY = "${prisma-engines}/bin/query-engine";
-          PRISMA_SCHEMA_ENGINE_BINARY = "${prisma-engines}/bin/schema-engine";
+        buildInputs = [ nodejs pnpm pkgs.openssl ] ++ serviceClients;
+
+        # `env` is baked into the cached shell profile, so direnv reloads pay
+        # nothing for it. Keep anything expensive out of shellHook: nix-direnv
+        # re-runs the hook on every reload even when the shell itself is cached.
+        env = prismaEnv // {
+          # pnpm 10 will otherwise download and exec the exact version named in
+          # package.json's packageManager field, quietly replacing the pnpm this
+          # flake just pinned. Turning it off is what makes the flake's pnpm the
+          # one that actually runs.
+          npm_config_manage_package_manager_versions = "false";
         };
+
+        shellHook = ''
+          echo "civitai dev shell: node $(node --version), pnpm $(pnpm --version)"
+          echo "  nix run .#dev     bootstrap services + run the app"
+          echo "  nix run .#doctor  check toolchain pins"
+        '';
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -136,17 +136,19 @@
       # Service stack
       #
       # The SERVERS are docker-compose's job (docker-compose.base.yml), not
-      # nix's -- postgres x4, redis x2, minio, meilisearch, clickhouse, maildev.
-      # What the shell provides is the matching CLIENTS, because you talk to
-      # those containers by hand constantly:
+      # nix's -- four postgres, two redis, minio, meilisearch, clickhouse and
+      # maildev. What the shell provides is the matching CLIENTS, because you
+      # talk to those containers by hand constantly:
       #
-      #   psql              -> the `db` container (postgres 17) on :15432
+      #   psql              -> the `db` container on :15432
       #   redis-cli         -> the `redis` container on :6379
       #   clickhouse client -> the `clickhouse` container on :18123
       #
-      # postgresql_17 (not _16) because the primary `db` container is
-      # postgres:17 and a client older than its server is the one direction
-      # libpq does not promise to work.
+      # postgresql_17 rather than _16 because the postgres containers are NOT
+      # all one version: `prisma-pit` and `db` are postgres 17, while
+      # `notification-db` and `logical-db` are postgres 15. A newer client talks
+      # to an older server fine; the other direction is the one libpq does not
+      # promise, so the client tracks the NEWEST server, not the oldest.
       # =====================================================================
 
       serviceClients = [

--- a/flake.nix
+++ b/flake.nix
@@ -100,11 +100,37 @@
         '';
       };
 
-      prismaEnv = {
+      # =====================================================================
+      # The environment the toolchain needs in order to behave
+      #
+      # ONE definition, consumed by BOTH the devShell and the `nix run` apps.
+      # Keeping it devShell-only is not a smaller version of this -- it is
+      # broken, and measurably so. `nix run .#dev` on a clean checkout got as far
+      # as `pnpm install`, whose postinstall runs `prisma generate`, which then
+      # tried to download an engine for platform `linux-nixos` and died on a 404.
+      # The same omission let pnpm re-exec itself as 10.28.1 inside an app whose
+      # PATH pointed at the flake's 10.34.5.
+      # =====================================================================
+
+      devEnv = {
+        # Prisma publishes no NixOS engine build, so point it at the patchelf'd
+        # ones above instead of letting it try to fetch a `linux-nixos` binary
+        # that has never existed.
         PRISMA_QUERY_ENGINE_LIBRARY = "${prisma-engines}/lib/libquery_engine.node";
         PRISMA_QUERY_ENGINE_BINARY = "${prisma-engines}/bin/query-engine";
         PRISMA_SCHEMA_ENGINE_BINARY = "${prisma-engines}/bin/schema-engine";
+
+        # pnpm 10 otherwise downloads and re-execs the exact version named in
+        # package.json's packageManager field, quietly replacing the pnpm this
+        # flake pinned. Measured: `pnpm --version` reports 10.28.1 without this
+        # and 10.34.5 with it, from the same binary on PATH.
+        npm_config_manage_package_manager_versions = "false";
       };
+
+      # The same attrset rendered as shell `export` lines, so an app and the
+      # shell cannot drift apart.
+      envPreamble = lib.concatStringsSep "\n"
+        (lib.mapAttrsToList (k: v: "export ${k}=${lib.escapeShellArg v}") devEnv);
 
       # =====================================================================
       # Service stack
@@ -162,14 +188,18 @@
         # Docker is deliberately absent: the CLI has to match the daemon the
         # developer is already running, so it comes from the host PATH.
         runtimeInputs = [ nodejs pnpm pkgs.git pkgs.postgresql_17 pkgs.coreutils ];
-        text = builtins.readFile ./scripts/nix/dev-up.sh;
+        text = envPreamble + "\n" + builtins.readFile ./scripts/nix/dev-up.sh;
         meta.description = "Bootstrap and run the civitai local dev environment";
       };
 
       dev-server = pkgs.writeShellApplication {
         name = "dev-server";
         runtimeInputs = [ nodejs pnpm pkgs.git ];
-        text = ''
+        # The daemon runs `pnpm install` and `pnpm run db:generate` itself when
+        # it sees the lockfile or the schema move, so it needs the same env the
+        # shell has or those background installs hit the identical prisma 404.
+        text = envPreamble + ''
+
           # The dev-server daemon re-execs itself with process.execPath, so
           # whatever node launches the CLI is the node the daemon runs on
           # forever. Launching it through this wrapper is what pins it to the
@@ -277,13 +307,7 @@
         # `env` is baked into the cached shell profile, so direnv reloads pay
         # nothing for it. Keep anything expensive out of shellHook: nix-direnv
         # re-runs the hook on every reload even when the shell itself is cached.
-        env = prismaEnv // {
-          # pnpm 10 will otherwise download and exec the exact version named in
-          # package.json's packageManager field, quietly replacing the pnpm this
-          # flake just pinned. Turning it off is what makes the flake's pnpm the
-          # one that actually runs.
-          npm_config_manage_package_manager_versions = "false";
-        };
+        env = devEnv;
 
         shellHook = ''
           echo "civitai dev shell: node $(node --version), pnpm $(pnpm --version)"

--- a/scripts/generate-slim-schema.js
+++ b/scripts/generate-slim-schema.js
@@ -157,7 +157,7 @@ function generateSlimSchema() {
   // Add header comment
   const header = `// ⚠️  AUTO-GENERATED FILE - DO NOT EDIT DIRECTLY
 // This file is generated from schema.full.prisma by scripts/generate-slim-schema.js
-// Edit schema.full.prisma instead, then run: npm run db:generate
+// Edit schema.full.prisma instead, then run: pnpm run db:generate
 // Models/enums marked with // @no-type in schema.full.prisma are excluded
 // Generated on: ${new Date().toISOString()}
 

--- a/scripts/nix/check-node-pin.py
+++ b/scripts/nix/check-node-pin.py
@@ -82,10 +82,14 @@ def main() -> int:
 
     failures: list[str] = []
 
-    # N1 - the flake's node must satisfy the repo's own engines range. pnpm
-    # enforces that range on install, so a flake outside it hands the developer a
-    # shell that cannot install the project. This is the assertion that was
-    # failing before the flake moved to node 24.
+    # N1 - the flake's node must satisfy the repo's own engines range.
+    #
+    # Worth being precise about why this needs a guard at all: engines.node is
+    # ADVISORY. Measured with both controls, pnpm 10.34.5 under node 26.7.0
+    # against `>=24.0.0 <25` prints `WARN Unsupported engine` and exits 0. So
+    # nothing in the install path was ever going to catch this, which is exactly
+    # how the flake sat two majors below the declared range without complaint.
+    # This is the assertion that was red before the flake moved to node 24.
     if not engines_node:
         failures.append("N1: package.json has no engines.node; nothing to check the flake against")
     elif not nodesemver.satisfies(args.flake_node, engines_node, loose=False):

--- a/scripts/nix/check-node-pin.py
+++ b/scripts/nix/check-node-pin.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Assert the Nix devShell's node and pnpm agree with what the repo declares.
+
+Scope, stated narrowly on purpose
+---------------------------------
+There are four independent declarations of "the Node version":
+
+  .nvmrc                  what CI installs (every workflow uses
+                          `actions/setup-node` with `node-version-file: .nvmrc`)
+  Dockerfile FROM node:   what production actually runs
+  package.json engines    the declared supported range
+  flake.nix devShell      what a NixOS developer actually runs
+
+The first three are already owned by `src/__tests__/node-version-consistency.test.ts`,
+which checks them far more carefully than this script could (extractor controls,
+two independent readers, fixture-driven predicates). This script deliberately does
+NOT re-check that triangle -- a predicate open-coded at two sites is the way it
+starts disagreeing with itself.
+
+What this script owns is the FOURTH declaration, the one a Vitest suite cannot
+reach because answering it means evaluating Nix: does the node the flake hands a
+developer match the node the rest of the repo declares? `.nvmrc` is the authority,
+because it is the one CI reads directly.
+
+Run it via `nix flake check` or `nix run .#doctor`, or directly:
+
+    python3 scripts/nix/check-node-pin.py \
+      --nvmrc .nvmrc --package-json package.json \
+      --flake-node 24.19.0 --flake-pnpm 10.34.5
+
+Every failure is tagged with a stable id (N1..N3) so a test can assert that a
+specific guard fired rather than merely that *something* failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+try:
+    import nodesemver
+except ImportError:  # pragma: no cover - only reachable outside the nix check
+    sys.exit(
+        "check-node-pin: the `nodesemver` module is missing. This script is meant to "
+        "run inside the flake's check environment: `nix flake check`, or "
+        "`nix run .#doctor`."
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--nvmrc", required=True)
+    p.add_argument("--package-json", required=True)
+    p.add_argument("--flake-node", required=True, help="node version the flake devShell provides")
+    p.add_argument("--flake-pnpm", required=True, help="pnpm version the flake devShell provides")
+    return p.parse_args()
+
+
+def major(version: str) -> str:
+    return version.split(".", 1)[0]
+
+
+def main() -> int:
+    args = parse_args()
+
+    with open(args.nvmrc, encoding="utf-8") as fh:
+        nvmrc = fh.read().strip()
+    with open(args.package_json, encoding="utf-8") as fh:
+        pkg = json.load(fh)
+
+    engines_node = pkg.get("engines", {}).get("node")
+    package_manager = pkg.get("packageManager")
+
+    print("node/pnpm: flake vs repo")
+    print(f"  .nvmrc                    {nvmrc}")
+    print(f"  package.json engines.node {engines_node}")
+    print(f"  package.json packageMgr   {package_manager}")
+    print(f"  flake devShell node       {args.flake_node}")
+    print(f"  flake devShell pnpm       {args.flake_pnpm}")
+    print()
+
+    failures: list[str] = []
+
+    # N1 - the flake's node must satisfy the repo's own engines range. pnpm
+    # enforces that range on install, so a flake outside it hands the developer a
+    # shell that cannot install the project. This is the assertion that was
+    # failing before the flake moved to node 24.
+    if not engines_node:
+        failures.append("N1: package.json has no engines.node; nothing to check the flake against")
+    elif not nodesemver.satisfies(args.flake_node, engines_node, loose=False):
+        failures.append(
+            f"N1: flake devShell node {args.flake_node} does NOT satisfy "
+            f"package.json engines.node {engines_node!r}"
+        )
+
+    # N2 - exact agreement with the authority. This is stable: nixpkgs is pinned
+    # by flake.lock, so only a deliberate `nix flake update` can move it, and
+    # when it does the remedy is a decision rather than a surprise at runtime.
+    if args.flake_node != nvmrc:
+        failures.append(
+            f"N2: flake devShell node {args.flake_node} != .nvmrc {nvmrc}. "
+            f"Either bump .nvmrc + Dockerfile to {args.flake_node} (CI and prod follow "
+            f".nvmrc, and node-version-consistency.test.ts enforces that triangle), "
+            f"or hold flake.lock at a nixpkgs rev whose nodejs_{major(nvmrc)} is {nvmrc}."
+        )
+
+    # N3 - pnpm major. nixpkgs will not carry the exact patch the packageManager
+    # field names, and does not need to: the lockfile FORMAT is tied to the
+    # major. A major mismatch rewrites pnpm-lock.yaml on the next install.
+    if not package_manager or "@" not in package_manager:
+        failures.append("N3: package.json has no usable packageManager field")
+    else:
+        declared = package_manager.rsplit("@", 1)[1]
+        if major(args.flake_pnpm) != major(declared):
+            failures.append(
+                f"N3: flake devShell pnpm {args.flake_pnpm} is a different MAJOR than "
+                f"package.json packageManager {package_manager!r}. A pnpm major bump "
+                f"rewrites pnpm-lock.yaml."
+            )
+        elif args.flake_pnpm != declared:
+            print(
+                f"note: flake pnpm {args.flake_pnpm} != packageManager {declared} "
+                f"(same major, lockfile format compatible - not an error)"
+            )
+
+    if failures:
+        print("FAIL: the flake's toolchain disagrees with the repo", file=sys.stderr)
+        for f in failures:
+            print(f"  {f}", file=sys.stderr)
+        return 1
+
+    print("OK: the flake's node and pnpm agree with .nvmrc and package.json")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/nix/check-prisma-pin.py
+++ b/scripts/nix/check-prisma-pin.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Assert the flake's hand-pinned Prisma engines match the lockfile's Prisma client.
+
+Why this exists
+---------------
+`@prisma/client` embeds an engine commit hash and verifies it against the engine
+binary it loads at runtime. nixpkgs does not carry every Prisma release (it
+jumps 6.7 -> 6.18), so `flake.nix` fetches Prisma's official prebuilt engines for
+one exact commit and points `PRISMA_QUERY_ENGINE_LIBRARY` & friends at them.
+
+That makes the flake's `engineCommit` a hardcoded mirror of a value that lives in
+`pnpm-lock.yaml`. `package.json` declares `@prisma/client: ^6.3.0` - a caret
+range - so any lockfile refresh can move the resolved client while the flake's
+engines stay pinned. Nothing would fail at build time; it fails at runtime, in
+every developer's shell, with an engine-mismatch error.
+
+This check closes that loop by re-deriving both values from the lockfile and
+comparing them to what the flake passes in.
+
+Run via `nix flake check`, or directly:
+
+    python3 scripts/nix/check-prisma-pin.py \
+      --package-json package.json --lockfile pnpm-lock.yaml \
+      --flake-prisma-version 6.13.0 \
+      --flake-engine-commit 361e86d0ea4987e9f53a565309b3eed797a6bcbd
+
+Failures are tagged P1..P4 so a test can assert which guard fired.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - only reachable outside the nix check
+    sys.exit(
+        "check-prisma-pin: the `yaml` module is missing. This script is meant to run "
+        "inside the flake's check environment: `nix flake check`, or `nix run .#doctor`."
+    )
+
+try:
+    Loader = yaml.CSafeLoader
+except AttributeError:  # pragma: no cover
+    Loader = yaml.SafeLoader
+
+ROOT_IMPORTER = "."
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--package-json", required=True)
+    p.add_argument("--lockfile", required=True)
+    p.add_argument("--flake-prisma-version", required=True)
+    p.add_argument("--flake-engine-commit", required=True)
+    return p.parse_args()
+
+
+def bare_version(resolved: str) -> str:
+    """`6.13.0(prisma@6.13.0(typescript@5.9.2))(typescript@5.9.2)` -> `6.13.0`."""
+    return resolved.split("(", 1)[0]
+
+
+def main() -> int:
+    args = parse_args()
+
+    with open(args.package_json, encoding="utf-8") as fh:
+        pkg = json.load(fh)
+    with open(args.lockfile, encoding="utf-8") as fh:
+        lock = yaml.load(fh, Loader=Loader)
+
+    declared_range = pkg.get("dependencies", {}).get("@prisma/client")
+    importers = lock.get("importers", {})
+    snapshots = lock.get("snapshots", {})
+
+    failures: list[str] = []
+
+    root = importers.get(ROOT_IMPORTER)
+    if root is None:
+        print(
+            f"FAIL: pnpm-lock.yaml has no {ROOT_IMPORTER!r} importer - the lockfile "
+            f"shape changed and this guard is no longer measuring anything",
+            file=sys.stderr,
+        )
+        return 1
+
+    client_entry = root.get("dependencies", {}).get("@prisma/client")
+    cli_entry = root.get("devDependencies", {}).get("prisma")
+    if client_entry is None:
+        print(
+            "FAIL: pnpm-lock.yaml root importer has no @prisma/client dependency",
+            file=sys.stderr,
+        )
+        return 1
+
+    locked_client = bare_version(client_entry["version"])
+    locked_cli = bare_version(cli_entry["version"]) if cli_entry else None
+
+    # The engine commit is not stored on the client package; it is the version
+    # suffix of the @prisma/engines-version package that @prisma/engines@<v>
+    # depends on. Derive it rather than trusting a second hardcoded copy.
+    engines_key = f"@prisma/engines@{locked_client}"
+    engines_snapshot = snapshots.get(engines_key)
+    locked_engine_commit = None
+    engines_version = None
+    if engines_snapshot is not None:
+        engines_version = engines_snapshot.get("dependencies", {}).get("@prisma/engines-version")
+        if engines_version and "." in engines_version:
+            # `6.13.0-35.361e86d0...` -> `361e86d0...`
+            locked_engine_commit = engines_version.rsplit(".", 1)[1]
+
+    print("prisma engine pin")
+    print(f"  package.json @prisma/client range   {declared_range}")
+    print(f"  pnpm-lock @prisma/client resolved   {locked_client}")
+    print(f"  pnpm-lock prisma (CLI) resolved     {locked_cli}")
+    print(f"  pnpm-lock @prisma/engines-version   {engines_version}")
+    print(f"  pnpm-lock engine commit             {locked_engine_commit}")
+    print(f"  flake.nix prismaVersion             {args.flake_prisma_version}")
+    print(f"  flake.nix engineCommit              {args.flake_engine_commit}")
+    print()
+
+    # P1 - the flake downloads engines for one exact client version.
+    if locked_client != args.flake_prisma_version:
+        failures.append(
+            f"P1: pnpm-lock.yaml resolves @prisma/client to {locked_client} but flake.nix "
+            f"pins prisma-engines to {args.flake_prisma_version}. package.json declares the "
+            f"caret range {declared_range!r}, so a lockfile refresh moved the client without "
+            f"the flake following. Update prismaVersion, engineCommit and all three sha256s "
+            f"in flake.nix together."
+        )
+
+    # P2 - the engine commit is what @prisma/client verifies at runtime.
+    if locked_engine_commit is None:
+        failures.append(
+            f"P2: could not derive an engine commit from pnpm-lock.yaml. Expected a "
+            f"snapshot {engines_key!r} with a @prisma/engines-version dependency; this guard "
+            f"is no longer measuring anything."
+        )
+    elif locked_engine_commit != args.flake_engine_commit:
+        failures.append(
+            f"P2: pnpm-lock.yaml engine commit {locked_engine_commit} != flake.nix "
+            f"engineCommit {args.flake_engine_commit}. The engine binaries the flake exports "
+            f"via PRISMA_QUERY_ENGINE_LIBRARY would be rejected by @prisma/client at runtime."
+        )
+
+    # P3 - the CLI (`prisma generate`, `prisma migrate`) uses the schema-engine
+    # binary the flake exports, so it must be the same version as the client.
+    if locked_cli is None:
+        failures.append("P3: pnpm-lock.yaml root importer has no `prisma` devDependency")
+    elif locked_cli != locked_client:
+        failures.append(
+            f"P3: pnpm-lock.yaml resolves the prisma CLI to {locked_cli} but @prisma/client "
+            f"to {locked_client}; the flake exports one schema-engine for both."
+        )
+
+    if failures:
+        print("FAIL: prisma engine pin has drifted", file=sys.stderr)
+        for f in failures:
+            print(f"  {f}", file=sys.stderr)
+        return 1
+
+    print("OK: flake prisma-engines pin matches the lockfile's resolved @prisma/client")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/nix/dev-up.sh
+++ b/scripts/nix/dev-up.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# One-command local dev entrypoint. Invoked as `nix run .#dev` -- flake.nix wraps
+# this file with `pkgs.writeShellApplication`, which supplies
+# `set -o errexit -o nounset -o pipefail` and puts the flake's node, pnpm, git
+# and postgresql client on PATH ahead of anything ambient. Docker deliberately
+# comes from the host, not from nix: the CLI must match the daemon you are
+# already running.
+#
+# Every step is idempotent and non-destructive. It will not overwrite an
+# existing .env.development, will not recreate volumes, and will not reseed.
+# Running it in a checkout that already works should change nothing except
+# starting containers that were stopped.
+
+usage() {
+  cat <<'EOF'
+Usage: nix run .#dev [--full] [--no-start] [--skip-install]
+
+  (default)       base services + install + `next dev` on http://localhost:3000
+  --full          also start the signals/buzz containers from ghcr.io. These are
+                  private images; you need `docker login ghcr.io` first.
+  --no-start      do the bootstrap, then stop. Leaves services running.
+  --skip-install  skip `pnpm install` (use when you know node_modules is current)
+  -h, --help      this message
+
+Not done for you, because both are destructive and slow:
+  migrations      `make run-migrations`
+  seed data       `make reseed`
+EOF
+}
+
+COMPOSE_FILE=docker-compose.base.yml
+START_DEV=1
+RUN_INSTALL=1
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --full) COMPOSE_FILE=docker-compose.yml ;;
+    --no-start) START_DEV=0 ;;
+    --skip-install) RUN_INSTALL=0 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "dev: unknown argument '$1'" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+step() { printf '\n\033[1m==> %s\033[0m\n' "$1"; }
+
+# --- locate the repo ---------------------------------------------------------
+# Guard the VALUE, not just the `cd`: `cd ""` is a no-op returning 0 on bash
+# <= 5.2, so `cd "$ROOT" || exit` sails past an empty ROOT and runs against
+# whatever cwd it inherited.
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$ROOT" ] || [ ! -d "$ROOT" ]; then
+  echo "dev: not inside a git checkout. Run this from the civitai repo." >&2
+  exit 1
+fi
+if [ ! -f "$ROOT/$COMPOSE_FILE" ] || [ ! -f "$ROOT/package.json" ]; then
+  echo "dev: $ROOT does not look like the civitai repo (no $COMPOSE_FILE)." >&2
+  exit 1
+fi
+cd "$ROOT"
+
+# Compose derives its project name from the directory it is run in, so every
+# git worktree would otherwise get its OWN stack -- and the second one to start
+# fails on the port binds, which reads as this script being broken. Pin the
+# project so all worktrees share the one local stack (and the one local
+# database), which is what the primary clone's directory name already produces.
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-civitai}"
+
+step "toolchain (from the flake, not from your PATH)"
+echo "  node   $(node --version)  ($(command -v node))"
+echo "  pnpm   $(pnpm --version)  ($(command -v pnpm))"
+
+# --- docker ------------------------------------------------------------------
+step "docker"
+if ! command -v docker >/dev/null 2>&1; then
+  echo "dev: docker is not on PATH. The service stack is docker-compose; install" >&2
+  echo "     docker and make sure your user can talk to the daemon." >&2
+  exit 1
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  echo "dev: 'docker compose' is unavailable (compose v2 is required)." >&2
+  exit 1
+fi
+if ! docker info >/dev/null 2>&1; then
+  echo "dev: the docker daemon is not reachable. Start it, or add yourself to the" >&2
+  echo "     docker group, then re-run." >&2
+  exit 1
+fi
+echo "  $(docker --version)"
+echo "  $(docker compose version)"
+
+# --- submodule ---------------------------------------------------------------
+# Worktrees and fresh clones do not check this out for you, and without it
+# `pnpm typecheck` produces a wall of 'Cannot find module' that looks like a
+# broken branch.
+step "event-engine-common submodule"
+if [ -f event-engine-common/package.json ]; then
+  echo "  already checked out"
+else
+  git submodule update --init event-engine-common
+fi
+
+# --- env file ----------------------------------------------------------------
+step ".env.development"
+if [ -f .env.development ]; then
+  echo "  exists, leaving it alone"
+else
+  cp .env-example .env.development
+  echo "  created from .env-example."
+  echo "  S3_UPLOAD_KEY / S3_UPLOAD_SECRET are placeholders: mint real ones at"
+  echo "  http://localhost:9001 (minioadmin/minioadmin) -> Access Keys."
+fi
+
+# --- services ----------------------------------------------------------------
+step "services ($COMPOSE_FILE, project $COMPOSE_PROJECT_NAME)"
+docker compose -f "$COMPOSE_FILE" up -d
+
+step "waiting for postgres on localhost:15432"
+ready=0
+for _ in $(seq 1 60); do
+  if pg_isready -h localhost -p 15432 -q; then
+    ready=1
+    break
+  fi
+  sleep 2
+done
+if [ "$ready" -eq 1 ]; then
+  echo "  ready"
+else
+  echo "dev: postgres did not accept connections within 120s." >&2
+  echo "     Check: docker compose -f $COMPOSE_FILE logs db" >&2
+  exit 1
+fi
+
+# --- dependencies ------------------------------------------------------------
+if [ "$RUN_INSTALL" -eq 1 ]; then
+  step "pnpm install"
+  pnpm install
+else
+  step "pnpm install (skipped)"
+fi
+
+# --- done --------------------------------------------------------------------
+cat <<EOF
+
+Environment is up.
+
+  app          http://localhost:3000   (once next dev finishes compiling)
+  minio        http://localhost:9001   minioadmin / minioadmin
+  maildev      http://localhost:1080
+  postgres     localhost:15432         psql -h localhost -p 15432 -U postgres civitai
+  meilisearch  http://localhost:7700
+
+First time on an empty database? Run these once, they are slow and destructive:
+
+  make run-migrations
+  make reseed
+
+EOF
+
+if [ "$START_DEV" -eq 0 ]; then
+  echo "--no-start given; not launching the dev server."
+  exit 0
+fi
+
+step "next dev"
+exec pnpm dev

--- a/scripts/nix/test-pins.sh
+++ b/scripts/nix/test-pins.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Mutation battery for the two flake pin guards.
+#
+# A guard nobody has watched FAIL is a claim, not coverage. Each case below
+# breaks one thing on purpose and asserts (a) the exit status and (b) that the
+# SPECIFIC guard id fired -- and, where the guards are independently reachable,
+# that the OTHER ids stayed silent. A red for the wrong reason is scored as a
+# failure here, because a mutant that dies to a neighbouring guard proves
+# nothing about the one under test.
+#
+# Everything runs against COPIES in a scratch dir, so this can never touch the
+# working tree. Run it directly, or let `nix flake check` run it:
+#
+#     nix develop -c bash scripts/nix/test-pins.sh
+#     nix flake check
+#
+# The python deps (pyyaml, node-semver) come from the flake's check environment.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="${REPO:-$(cd "$HERE/../.." && pwd)}"
+
+NODE_SCRIPT="${NODE_SCRIPT:-$HERE/check-node-pin.py}"
+PRISMA_SCRIPT="${PRISMA_SCRIPT:-$HERE/check-prisma-pin.py}"
+NVMRC="${NVMRC:-$REPO/.nvmrc}"
+PACKAGE_JSON="${PACKAGE_JSON:-$REPO/package.json}"
+LOCKFILE="${LOCKFILE:-$REPO/pnpm-lock.yaml}"
+
+for f in "$NODE_SCRIPT" "$PRISMA_SCRIPT" "$NVMRC" "$PACKAGE_JSON" "$LOCKFILE"; do
+  if [ ! -f "$f" ]; then
+    echo "test-pins: input not found: $f" >&2
+    exit 2
+  fi
+done
+
+RUN="$(mktemp -d)"
+trap 'rm -rf "$RUN"' EXIT
+
+pass=0
+fail=0
+
+# run_case <name> <expected-rc> <must-contain,...> <must-NOT-contain,...> -- cmd...
+run_case() {
+  local name="$1" want_rc="$2" want="$3" nowant="$4"
+  shift 4
+  [ "$1" = "--" ] && shift
+  local out rc ok=1 tok
+  out="$("$@" 2>&1)"
+  rc=$?
+  [ "$rc" != "$want_rc" ] && ok=0
+  # `grep -a`: these are tool logs, and grep returns NOTHING on a stream it
+  # decides is binary -- which reads identically to "no match".
+  if [ -n "$want" ]; then
+    for tok in ${want//,/ }; do
+      grep -qa -- "$tok" <<<"$out" || ok=0
+    done
+  fi
+  if [ -n "$nowant" ]; then
+    for tok in ${nowant//,/ }; do
+      grep -qa -- "$tok" <<<"$out" && ok=0
+    done
+  fi
+  if [ "$ok" = 1 ]; then
+    printf 'PASS  %-48s rc=%s\n' "$name" "$rc"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL  %-48s rc=%s (wanted rc=%s, contains[%s], not[%s])\n' \
+      "$name" "$rc" "$want_rc" "$want" "$nowant"
+    printf '%s\n' "$out" | sed 's/^/        | /'
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------- fixtures ---
+mkdir -p "$RUN/base"
+cp "$NVMRC" "$RUN/base/.nvmrc"
+cp "$PACKAGE_JSON" "$RUN/base/package.json"
+cp "$LOCKFILE" "$RUN/base/pnpm-lock.yaml"
+
+# .nvmrc moved one patch. Doubles as the positive control that the script READS
+# .nvmrc rather than comparing two constants that happen to agree.
+mkdir -p "$RUN/nvmrc-moved"
+cp "$PACKAGE_JSON" "$RUN/nvmrc-moved/package.json"
+printf '24.20.0\n' >"$RUN/nvmrc-moved/.nvmrc"
+
+# engines.node raised past the flake's node, .nvmrc untouched -- reaches N1
+# without reaching N2.
+mkdir -p "$RUN/engines-26"
+cp "$NVMRC" "$RUN/engines-26/.nvmrc"
+python3 - "$PACKAGE_JSON" "$RUN/engines-26/package.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+d['engines']['node'] = '>=26.0.0 <27'
+json.dump(d, open(sys.argv[2], 'w'), indent=2)
+PY
+
+# packageManager moved to a different pnpm MAJOR.
+mkdir -p "$RUN/pm-11"
+cp "$NVMRC" "$RUN/pm-11/.nvmrc"
+python3 - "$PACKAGE_JSON" "$RUN/pm-11/package.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+d['packageManager'] = 'pnpm@11.0.0'
+json.dump(d, open(sys.argv[2], 'w'), indent=2)
+PY
+
+# The realistic prisma mutation: `@prisma/client` is declared as a CARET range,
+# so a routine lockfile refresh can move the resolved client -- and with it the
+# engine commit -- while flake.nix stays where it is. Both the client and the
+# CLI move together, which is what a real refresh does.
+mkdir -p "$RUN/lock-refreshed"
+cp "$PACKAGE_JSON" "$RUN/lock-refreshed/package.json"
+python3 - "$LOCKFILE" "$RUN/lock-refreshed/pnpm-lock.yaml" <<'PY'
+import sys, yaml
+d = yaml.load(open(sys.argv[1]), Loader=yaml.CSafeLoader)
+root = d['importers']['.']
+root['dependencies']['@prisma/client']['version'] = '6.19.3(prisma@6.19.3(typescript@5.9.2))(typescript@5.9.2)'
+root['devDependencies']['prisma']['version'] = '6.19.3(typescript@5.9.2)'
+yaml.dump(d, open(sys.argv[2], 'w'), Dumper=yaml.CSafeDumper)
+PY
+
+# Only the CLI moves -- reaches P3 without reaching P1 or P2.
+mkdir -p "$RUN/lock-cli-skew"
+cp "$PACKAGE_JSON" "$RUN/lock-cli-skew/package.json"
+python3 - "$LOCKFILE" "$RUN/lock-cli-skew/pnpm-lock.yaml" <<'PY'
+import sys, yaml
+d = yaml.load(open(sys.argv[1]), Loader=yaml.CSafeLoader)
+d['importers']['.']['devDependencies']['prisma']['version'] = '6.19.3(typescript@5.9.2)'
+yaml.dump(d, open(sys.argv[2], 'w'), Dumper=yaml.CSafeDumper)
+PY
+
+# The snapshot the engine commit is derived from is gone. This must report that
+# the guard STOPPED MEASURING, not quietly pass.
+mkdir -p "$RUN/lock-no-engines"
+cp "$PACKAGE_JSON" "$RUN/lock-no-engines/package.json"
+python3 - "$LOCKFILE" "$RUN/lock-no-engines/pnpm-lock.yaml" <<'PY'
+import sys, yaml
+d = yaml.load(open(sys.argv[1]), Loader=yaml.CSafeLoader)
+d['snapshots'] = {k: v for k, v in d['snapshots'].items() if not k.startswith('@prisma/engines@')}
+yaml.dump(d, open(sys.argv[2], 'w'), Dumper=yaml.CSafeDumper)
+PY
+
+node_check() { # <dir> <flake-node> <flake-pnpm>
+  python3 "$NODE_SCRIPT" --nvmrc "$1/.nvmrc" --package-json "$1/package.json" \
+    --flake-node "$2" --flake-pnpm "$3"
+}
+prisma_check() { # <dir> <flake-prisma-version> <flake-engine-commit>
+  python3 "$PRISMA_SCRIPT" --package-json "$1/package.json" --lockfile "$1/pnpm-lock.yaml" \
+    --flake-prisma-version "$2" --flake-engine-commit "$3"
+}
+
+# The values the flake currently supplies. Kept as literals rather than read
+# back out of flake.nix on purpose: a test that derives its expectation from the
+# thing under test cannot fail.
+REAL_NODE=24.19.0
+REAL_PNPM=10.34.5
+REAL_PRISMA=6.13.0
+REAL_COMMIT=361e86d0ea4987e9f53a565309b3eed797a6bcbd
+
+echo "=== node/pnpm guard ==="
+run_case "baseline (current flake) is GREEN" 0 "OK:" "N1:,N2:,N3:" -- \
+  node_check "$RUN/base" "$REAL_NODE" "$REAL_PNPM"
+
+run_case "N1 alone: engines raised past the flake's node" 1 "N1:" "N2:,N3:" -- \
+  node_check "$RUN/engines-26" "$REAL_NODE" "$REAL_PNPM"
+
+run_case "N2 alone: nixpkgs moves node one patch" 1 "N2:" "N1:,N3:" -- \
+  node_check "$RUN/base" 24.20.0 "$REAL_PNPM"
+
+run_case "N2 alone: .nvmrc moves, the flake does not" 1 "N2:" "N1:,N3:" -- \
+  node_check "$RUN/nvmrc-moved" "$REAL_NODE" "$REAL_PNPM"
+
+# 11.21.0 is not hypothetical: it is what the UNVERSIONED `pkgs.pnpm` resolves
+# to at the nixpkgs rev this flake now locks. Using `pnpm_10` is what prevents it.
+run_case "N3 alone: unversioned pkgs.pnpm would give 11.21.0" 1 "N3:" "N1:,N2:" -- \
+  node_check "$RUN/base" "$REAL_NODE" 11.21.0
+
+run_case "N3 alone: packageManager moves to pnpm 11" 1 "N3:" "N1:,N2:" -- \
+  node_check "$RUN/pm-11" "$REAL_NODE" "$REAL_PNPM"
+
+# The state this branch fixed: the flake shipped nodejs_22 (22.22.2) against
+# engines.node ">=24.0.0 <25". Red here, green at the top of this file.
+run_case "PRE-CHANGE flake (nodejs_22) is red on N1 and N2" 1 "N1:,N2:" "N3:" -- \
+  node_check "$RUN/base" 22.22.2 10.33.0
+
+echo
+echo "=== prisma guard ==="
+run_case "baseline (current flake) is GREEN" 0 "OK:" "P1:,P2:,P3:" -- \
+  prisma_check "$RUN/base" "$REAL_PRISMA" "$REAL_COMMIT"
+
+run_case "P1 alone: flake pins a client the lock does not" 1 "P1:" "P2:,P3:" -- \
+  prisma_check "$RUN/base" 6.14.0 "$REAL_COMMIT"
+
+run_case "P2 alone: engine commit wrong in the flake" 1 "P2:" "P1:,P3:" -- \
+  prisma_check "$RUN/base" "$REAL_PRISMA" 0000000000000000000000000000000000000000
+
+run_case "P3 alone: lockfile CLI/client skew" 1 "P3:" "P1:,P2:" -- \
+  prisma_check "$RUN/lock-cli-skew" "$REAL_PRISMA" "$REAL_COMMIT"
+
+# P3 must stay SILENT: client and CLI moved together, so there is no skew.
+run_case "lockfile refresh moves client 6.13.0 -> 6.19.3" 1 "P1:,P2:" "P3:" -- \
+  prisma_check "$RUN/lock-refreshed" "$REAL_PRISMA" "$REAL_COMMIT"
+
+run_case "engines snapshot gone -> says it stopped measuring" 1 "P2:,no longer measuring" "" -- \
+  prisma_check "$RUN/lock-no-engines" "$REAL_PRISMA" "$REAL_COMMIT"
+
+echo
+echo "=== controls: the scripts read the FILES, and cannot pass vacuously ==="
+run_case "reported .nvmrc value MOVES with the file" 1 "24.20.0" "" -- \
+  node_check "$RUN/nvmrc-moved" "$REAL_NODE" "$REAL_PNPM"
+
+run_case "reported locked client MOVES with the lockfile" 1 "6.19.3" "" -- \
+  prisma_check "$RUN/lock-refreshed" "$REAL_PRISMA" "$REAL_COMMIT"
+
+run_case "a missing input is an ERROR, never a silent OK" 1 "FileNotFoundError" "OK:" -- \
+  node_check "$RUN/does-not-exist" "$REAL_NODE" "$REAL_PNPM"
+
+echo
+echo "TOTAL: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/src/__tests__/node-version-consistency.test.ts
+++ b/src/__tests__/node-version-consistency.test.ts
@@ -31,13 +31,27 @@ import { describe, expect, it } from 'vitest';
  *     `containers/` build separate images on separate release cadences and float
  *     today; pinning them changes what those services run, so it belongs in its own
  *     change rather than riding along in a no-op.
- *   - `flake.nix`, which is a FOURTH declaration (the NixOS dev shell) and is on a
- *     different major. It cannot be brought into line by editing one line: the
- *     pinned nixpkgs' newest Node 24 is older than the version pinned here, so
- *     agreeing would mean moving the nixpkgs pin as well. Asserting it here would
- *     only produce a red gate nobody can fix in the change that trips it.
- *     `engines.node` is bracketed at MAJOR granularity partly for this reason: a
- *     patch-exact floor would be violated by every dev shell on day one.
+ *   - `flake.nix`, which is a FOURTH declaration (the NixOS dev shell). It is no
+ *     longer on a different major, and it is no longer unchecked — but it is still
+ *     out of scope HERE, for a reason that has changed.
+ *
+ *     What used to be true: the pinned nixpkgs' newest Node 24 was older than the
+ *     version pinned here, so agreeing would have meant moving the nixpkgs pin too,
+ *     and asserting it would have produced a red gate nobody could fix in the change
+ *     that tripped it. That is no longer the case. The flake.lock bump to the
+ *     2026-08-18 nixpkgs made `nodejs_24` exactly 24.19.0, and `flake.nix` now
+ *     DERIVES its Node major by reading this `.nvmrc` rather than naming one.
+ *
+ *     Why it still does not belong in this file: answering "which Node does the dev
+ *     shell provide?" means evaluating Nix, which a Vitest suite cannot do. The
+ *     assertion lives where it can be made — `checks.toolchain-pins` in `flake.nix`,
+ *     run by `nix flake check` and by `nix run .#doctor`, implemented in
+ *     `scripts/nix/check-node-pin.py`. That guard deliberately does NOT re-check the
+ *     three declarations below; this file owns them, and a predicate open-coded at
+ *     two sites is how the two start disagreeing.
+ *
+ *     `engines.node` is still bracketed at MAJOR granularity, but no longer because
+ *     the dev shell would violate a patch-exact floor — it does not any more.
  */
 
 const REPO_ROOT = path.resolve(__dirname, '../..');


### PR DESCRIPTION
## What this is

The Nix flake shipped `nodejs_22`. `package.json` declares `engines.node: ">=24.0.0 <25"`, `.nvmrc` pins `24.19.0`, and the Dockerfile builds production on `node:24.19.0-alpine3.24`. A NixOS developer was running a major the repo does not support, and nothing anywhere said so — `engines.node` is advisory, so `pnpm install` prints `WARN Unsupported engine` and carries on.

This makes the flake own the toolchain, guards the pins that a derivation cannot enforce on its own, and adds one command that takes a fresh clone to a running app.

**Left open deliberately for review.** Nothing here is urgent and the flake bump touches every NixOS developer's shell.

---

## The drift, and who is authoritative for each pin

| Pin | Authority | Was | Now |
|---|---|---|---|
| node | `.nvmrc` (every workflow reads it via `node-version-file:`; the Dockerfile base image tracks it) | flake `nodejs_22` = **22.22.2**; the dev-server daemon on ambient **26.7.0** | flake derives the major from `.nvmrc` → **24.19.0**, exactly |
| pnpm | `package.json` `packageManager` (`pnpm@10.28.1`) | unversioned `pkgs.pnpm` | `pnpm_10` (10.34.5), major-pinned |
| prisma engines | `pnpm-lock.yaml`'s resolved `@prisma/client` and its `@prisma/engines-version` suffix | correct, but hardcoded in `flake.nix` with nothing checking it | unchanged values, now re-derived from the lockfile by a check |
| postgres client | `docker-compose.base.yml`'s `db` container (postgres 17) | `postgresql_16` | `postgresql_17` |

**`flake.lock` was 117 days stale** (2026-04-23 → 2026-08-18). Two things materially changed, and one of them is the reason this PR is possible at all:

- `nodejs_24` at the new rev is **exactly 24.19.0**. At the old rev it was 24.14.1, which is why `src/__tests__/node-version-consistency.test.ts` correctly documented the flake as unalignable. That comment is updated rather than deleted.
- The unversioned `pkgs.pnpm` goes **10.33.0 → 11.21.0**. A pnpm major rewrites `pnpm-lock.yaml`. Bumping the lock without switching to `pnpm_10` would have shipped pnpm 11 to every dev shell silently — the single most dangerous thing in this bump, and it is now covered by a guard.

Other movements at the new rev: openssl 3.6.3, clickhouse 26.7.3, redis 8.8.1, postgresql_17 17.11.

**The postgres/redis/clickhouse entries were undocumented; the answer is that they are deliberate.** They are *clients* for the compose-hosted servers (`psql` against `:15432`, `redis-cli`, `clickhouse client`). The servers stay in docker-compose. That is now stated in `flake.nix` instead of left to be guessed.

---

## Guards, and the evidence each one fires

`nix flake check` runs four checks. Implementations are in `scripts/nix/`, deliberately runnable outside Nix.

**`toolchain-pins`** — the flake's node satisfies `engines.node` (N1) and equals `.nvmrc` (N2); its pnpm shares a major with `packageManager` (N3). It deliberately does **not** re-check the `.nvmrc` / Dockerfile / `engines.node` triangle — `node-version-consistency.test.ts` already owns that, and a predicate open-coded at two sites is how the two start disagreeing.

**`prisma-pin`** — the highest-value addition, and the one that was *correct by luck*. `flake.nix` hardcodes `prismaVersion` and `engineCommit` because Nix cannot parse YAML, and `@prisma/client` verifies that engine commit at runtime. `package.json` declares `^6.3.0`, a **caret range**, so any lockfile refresh can move the client while the flake's engines stay put. This check re-derives both values from `pnpm-lock.yaml` and compares.

**`pin-guards-selftest`** — breaks each pin on purpose and requires the guard that owns it to fire *and the others to stay silent*. Committed as `scripts/nix/test-pins.sh`, so the guards cannot rot into a constant `true`.

**`dev-scripts`** — builds the three shell entrypoints, which is what runs their `shellcheck`. Needed because `nix flake check` builds `checks.*` but only *evaluates* `packages.*` (measured — an earlier revision of this PR claimed shellcheck coverage it did not have).

### Mutation matrix — 16/16, each mutant isolated

```
=== node/pnpm guard ===
PASS  baseline (current flake) is GREEN                rc=0
PASS  N1 alone: engines raised past the flake's node   rc=1
PASS  N2 alone: nixpkgs moves node one patch           rc=1
PASS  N2 alone: .nvmrc moves, the flake does not       rc=1
PASS  N3 alone: unversioned pkgs.pnpm would give 11.21.0 rc=1
PASS  N3 alone: packageManager moves to pnpm 11        rc=1
PASS  PRE-CHANGE flake (nodejs_22) is red on N1 and N2 rc=1
=== prisma guard ===
PASS  baseline (current flake) is GREEN                rc=0
PASS  P1 alone: flake pins a client the lock does not  rc=1
PASS  P2 alone: engine commit wrong in the flake       rc=1
PASS  P3 alone: lockfile CLI/client skew               rc=1
PASS  lockfile refresh moves client 6.13.0 -> 6.19.3   rc=1
PASS  engines snapshot gone -> says it stopped measuring rc=1
=== controls: the scripts read the FILES, and cannot pass vacuously ===
PASS  reported .nvmrc value MOVES with the file        rc=1
PASS  reported locked client MOVES with the lockfile   rc=1
PASS  a missing input is an ERROR, never a silent OK   rc=1
TOTAL: 16 passed, 0 failed
```

Two of these are genuine **regression** coverage, red at the base commit: `N1`/`N2` fail on the flake as it exists on `main` today (node 22.22.2). The prisma cases are guards on a coupling that is currently correct — labelled as such, not claimed as a bug fixed.

**The battery was itself validated against mutants of the guards**, so it is not a green nobody has watched fail:

| Mutant (narrowest expression) | Result |
|---|---|
| `check-node-pin.py`: N2's `flake_node != nvmrc` → `False` | selftest **12 passed, 4 failed**, rc=1 |
| `check-prisma-pin.py`: P2's commit comparison → `False` | selftest **14 passed, 2 failed**, rc=1 |
| `dev-up.sh`: append an unquoted `rm -rf $ROOT/...` (SC2086) | `nix flake check` **rc=1**, `SC2086`; rc=0 again on restore |

Two harness expectations were wrong on the first run and were corrected against the output, not the other way round.

---

## Entrypoints

```bash
nix run .#dev            # docker preflight → submodule → .env.development → compose up
                         # → wait for postgres → pnpm install → next dev on :3000
nix run .#dev -- --no-start --full --skip-install
nix run .#dev-server     # the dev-server CLI, on the flake's node
nix run .#doctor         # the pin checks, against your working tree
```

Every step is idempotent and non-destructive: `.env.development` is never overwritten, no volume is recreated, migrations and seeding stay opt-in.

`COMPOSE_PROJECT_NAME` is pinned to `civitai` in both the entrypoint and the `Makefile`. Reproduced first: `make start` from a worktree died with `Bind for :::15434 failed: port is already allocated`, because compose names the project after the directory, so every worktree tried to stand up its own stack.

### The dev-server daemon is now pinnable

The daemon is spawned with `process.execPath` (`cli.mjs:66`, `console.mjs:87`) and hands its environment to every `next dev` it supervises — so whichever shell first ran a CLI verb decides the node for everything, indefinitely, with nothing recording which one that was.

Measured before / after, on the live daemon:

| | before | after (`nix run .#dev-server`) |
|---|---|---|
| interpreter | `nodejs-slim-26.7.0` | `nodejs-slim-24.19.0` |
| pnpm on `PATH` | **absent entirely** | `pnpm-10.34.5` |
| `PRISMA_*_ENGINE_*` | 0 vars | 3 vars |

The missing pnpm is not cosmetic: the daemon shells out to `pnpm install` / `pnpm run db:generate` when it sees the lockfile or schema move.

---

## Fresh-clone bootstrap, actually performed

A pristine worktree — no `.envrc`, no `node_modules`, no `.env.development`, submodule not checked out, ambient `node` 26.7.0 and **no `pnpm` on `PATH` at all** — then one command:

```
==> toolchain (from the flake, not from your PATH)
  node   v24.19.0  (/nix/store/…-nodejs-24.19.0/bin/node)
  pnpm   10.34.5   (/nix/store/…-pnpm-10.34.5/bin/pnpm)
==> docker
==> event-engine-common submodule
  Submodule path 'event-engine-common': checked out 'e796afee…'
==> .env.development
  created from .env-example.
==> services (docker-compose.base.yml, project civitai)
==> waiting for postgres on localhost:15432
  ready
==> pnpm install
  Done in 26.5s using pnpm v10.34.5
==> next dev
  ▲ Next.js 16.3.1 (Turbopack)
  - Local: http://localhost:3000
  ✓ Ready in 308ms
```

`GET / → 200`, `GET /login → 307`, 10 containers running. Note the app is served against an **un-migrated** database — `make run-migrations` / `make reseed` are deliberately not run for you.

**The first run of this failed, and that is why it is in the PR.** `mkShell`'s `env` applies to `nix develop` only, so `nix run .#dev` had neither the Prisma engine paths (postinstall's `prisma generate` died on `404 …/linux-nixos/libquery_engine.so.node.sha256`) nor the pnpm setting (pnpm re-execed itself as 10.28.1 from a `PATH` pointing at 10.34.5). The env is now one attrset rendered two ways.

---

## Docs: which claims were wrong before this

Every one verified against the code first.

| Claim | Truth |
|---|---|
| `README` "Node.js (version 20 or later)" | `>=24.0.0 <25`; `.nvmrc` 24.19.0 |
| `README` `make init` / `make run` as the bootstrap | **dead** — `make init` → `npm i` → `preinstall`'s `only-allow pnpm` → exit 1 (measured, with the pnpm-user-agent control at exit 0) |
| `README` MinIO console at `:9000` | `:9001`; `:9000` is the S3 API. It sent people to the wrong port to mint keys the next step needs |
| `README` `git submodule update --recursive` | needs `--init`; without it it is a no-op on a fresh clone, which is exactly when it runs |
| `README` "edit `schema.prisma`" | gitignored and regenerated from `schema.full.prisma`; edits are silently discarded |
| `Makefile` `gen-prisma` = bare `prisma generate` | reads the gitignored slim schema, which does not exist on a fresh clone |
| `Makefile` `docker-compose` | compose v1 is EOL |
| `docs/pnpm-migration.md` "Node.js 18.x or later" | `>=24.0.0 <25` |
| `generate-slim-schema.js` emits "run `npm run db:generate`" | npm is banned in this repo |
| `dev-server/SKILL.md` — silent on node entirely | the daemon's node is sticky and was 26.7.0; also offered `npm run dev:daemon` |
| `CLAUDE.md` "the flake's 22.22.2" | now 24.19.0 |
| `node-version-consistency.test.ts` "flake is on a different major / cannot be aligned" | both halves now false |
| **nothing tracked mentioned the flake at all** | `.gitignore`'s `.env*` swallowed `.envrc`; the only reference was one line of `CLAUDE.md` under worktree hygiene. `.envrc.example` is now tracked (placeholders only) |

---

## For developers who already have a working env

Nothing here is destructive, but the dev shell's node moves 22.22.2 -> 24.19.0, so a
`node_modules` populated under node 22 is now used by node 24. Almost everything native in
this tree is N-API (ABI-stable across majors) -- `@swc/core`, `sharp`, `lightningcss`,
`rollup`, `@tailwindcss/oxide`, `@parcel/watcher`, `@unrs/resolver` -- and a fresh install
under 24 was exercised end to end. If something native does complain, `pnpm rebuild` is the
fix; a full wipe should not be necessary.

Two behaviour changes to know about, both intentional:

- `pnpm --version` in the dev shell now reports **10.34.5** instead of 10.28.1, because pnpm
  is no longer allowed to fetch and re-exec the `packageManager` version. Same major, same
  lockfile format.
- `make start` and `nix run .#dev` now use the compose project `civitai` regardless of which
  worktree you run them from. If you were relying on per-worktree stacks, set
  `COMPOSE_PROJECT_NAME` yourself.

## What I deliberately did not do

- **No `devenv` / `services-flake` / `flake-parts` / `numtide-devshell`.** For one system, one devShell and a thin wrapper over an existing compose stack, each adds a lock input and an authoring style for no benefit. `services-flake` in particular exists to *replace* docker-compose, which is the opposite of the intent here.
- **No nix-native services.** The compose stack is untouched.
- **No `flake-utils`.** Single system; it would be pure ceremony.
- **No corepack.** It resolves versions over the network on first use, which fights "the flake owns the toolchain".
- **Did not pin pnpm to the exact `10.28.1`.** nixpkgs has no such attribute (it carries `pnpm_10`, `pnpm_10_29_2`, `pnpm_10_34_0`, `pnpm_11` — enumerated, not sampled). The guard therefore asserts the major and reports both versions. **This is the one deliberate trade-off worth a second opinion:** `npm_config_manage_package_manager_versions=false` means a Nix developer gets 10.34.5 while CI and Docker get 10.28.1. The alternative — letting pnpm fetch 10.28.1 itself — gives exact parity but puts a network-fetched, non-Nix binary in charge, and is what was silently happening before.
- **Did not touch the devcontainer.** It pins `typescript-node:1-22` (Node 22, outside `engines.node`) and I have no way to exercise a devcontainer here. Flagged in the README with the tag to use — there is no `1-24`, the template major moved on, so `3-24`.
- **Did not convert the ~30 `node .claude/skills/dev-server/cli.mjs …` lines** in the skill to `nix run`. They are correct for non-Nix users; one section explains which node you get and how to pin it.

## Not verified

- The devcontainer path, at all.
- `make run-migrations` / `make reseed` — slow and destructive; not run, and left unchanged.
- macOS/other systems — `x86_64-linux` only, unchanged.
- Separately noticed, **not** fixed here: `cli.mjs:30` says `DEV_DAEMON_PORT` is "overridable so a second daemon can be exercised", but `scripts/daemon.mjs:38` hardcodes `DEFAULT_DAEMON_PORT = 9444` and never reads that variable. A second daemon cannot actually be started.
