### PR TITLE
fix(hooks): ask about svelte-kit sync only when a dev server is running

### DIFF
--- a/.claude/hooks/check-writable.mjs
+++ b/.claude/hooks/check-writable.mjs
@@ -9,6 +9,7 @@
  */
 
 import { stdin } from 'process';
+import { execFileSync } from 'child_process';
 
 // `prettier --write <targets>`: the incident was a repo-WIDE rewrite, not formatting a directory
 // this change owns. Read the targets instead of matching `--write`, so a scoped path just runs.
@@ -131,6 +132,36 @@ const DANGEROUS_PATTERNS = [
   },
 ];
 
+/** `svelte-kit sync`, or the `check` script that runs it. Split out so the selftest can cover it offline. */
+export function isSvelteSyncCommand(command) {
+  // `check(?![\w:-])` rather than `check\b`: \b sits happily before a hyphen, so the original matched
+  // any `pnpm run check-*` script — none of which run svelte-kit sync.
+  return /svelte-kit\s+sync|pnpm\s+(?:run\s+)?check(?![\w:-])/i.test(command);
+}
+
+/**
+ * True unless the dev-server daemon positively reports no running sessions — the only answer that can
+ * prove the collision this guard exists for is impossible right now.
+ *
+ * curl rather than fetch: the hook is a short-lived script and this must not leave a pending socket
+ * holding the process open. One second, and every failure path returns true.
+ */
+export function devServersMayBeRunning() {
+  try {
+    const out = execFileSync('curl', ['-s', '--max-time', '1', DAEMON_SESSIONS_URL], {
+      encoding: 'utf8',
+      timeout: 2000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const sessions = JSON.parse(out)?.sessions;
+    return !Array.isArray(sessions) || sessions.length > 0;
+  } catch {
+    return true;
+  }
+}
+
+const DAEMON_SESSIONS_URL = `http://127.0.0.1:${process.env.DEV_DAEMON_PORT || 9444}/sessions`;
+
 // Expensive or historically destructive, but sometimes legitimate — confirm rather than block.
 const GUARDED_PATTERNS = [
   {
@@ -142,9 +173,17 @@ const GUARDED_PATTERNS = [
       'was slow, with the matching remedy. Or add --max-time <seconds>.',
   },
   {
-    pattern: /svelte-kit\s+sync|pnpm\s+(run\s+)?check\b/i,
+    // The hazard is a COLLISION, not the command: sync rewrites ~690 files under .svelte-kit/ while a
+    // Vite dev server watches them. With no dev server up there is nothing to collide with — and
+    // `$types` goes stale whenever a load's RETURN SHAPE changes, not only when the route tree does, so
+    // the legitimate case recurs through a normal day's work. Asking every time taught people to click
+    // through it, and a guard people click through is not guarding.
+    //
+    // Fails CLOSED: only a daemon that positively reports zero sessions skips the prompt. Unreachable,
+    // slow or unparseable answers ask exactly as before.
+    check: (command) => isSvelteSyncCommand(command) && devServersMayBeRunning(),
     reason:
-      '`svelte-kit sync` regenerates ~690 files under .svelte-kit/, which the Vite dev server watches — the collision that froze this window repeatedly. Use `pnpm run typecheck` unless the route tree changed.',
+      '`svelte-kit sync` regenerates ~690 files under .svelte-kit/, which the Vite dev server watches — the collision that froze this window repeatedly. A dev server is running now. Use `pnpm run typecheck` unless the route tree changed.',
   },
   {
     // Only the unscoped shapes ask. `prettier --write src/components/Sticker/` runs.

--- a/.claude/hooks/check-writable.selftest.mjs
+++ b/.claude/hooks/check-writable.selftest.mjs
@@ -6,7 +6,7 @@
  * only mentions a port must all run untouched.
  */
 
-import { unboundedDevRequest } from './check-writable.mjs';
+import { isSvelteSyncCommand, unboundedDevRequest } from './check-writable.mjs';
 
 let failures = 0;
 const check = (name, cmd, expectBlocked) => {
@@ -49,6 +49,24 @@ check('curl to other local port', 'curl http://localhost:8080/thing', false);
 check('no curl at all', 'node .claude/skills/dev-server/cli.mjs probe /home', false);
 check('mentions the port only', 'echo "the dev server is on localhost:3000"', false);
 check('probe command itself', 'node cli.mjs probe /home --port 3000', false);
+
+// `svelte-kit sync` — the MATCH is unchanged; what changed is that matching alone no longer asks. The
+// prompt now also requires a dev server to be running, since that collision is the whole hazard.
+const sync = (name, cmd, expectMatch) => {
+  const matched = isSvelteSyncCommand(cmd);
+  const pass = matched === expectMatch;
+  if (!pass) failures++;
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}  matched=${matched} want=${expectMatch}`);
+};
+
+sync('bare sync', 'pnpm exec svelte-kit sync', true);
+sync('sync behind a cd', 'cd apps/creator-studio && pnpm exec svelte-kit sync', true);
+sync('the check script, which runs sync', 'pnpm run check', true);
+sync('check with no run', 'pnpm check', true);
+// Not sync: these must never ask, and `typecheck` is the remedy the reason text recommends.
+sync('typecheck', 'pnpm run typecheck', false);
+sync('a script merely NAMED check-something', 'pnpm run check-generated', false);
+sync('vitest', 'pnpm exec vitest run', false);
 
 console.log(failures ? `\n${failures} FAILURES` : '\nall green');
 process.exit(failures ? 1 : 0);


### PR DESCRIPTION
The `svelte-kit sync` rule in `check-writable.mjs` is a good guard aimed slightly too wide, and it has been prompting on every sync during Creator Studio work.

**What it protects.** Sync rewrites ~690 files under `.svelte-kit/` while the Vite dev server watches them — the collision that froze an editor for a full day. That hazard is real and this PR keeps it.

**Why it fires when it can't be right.** Two things:

1. **With no dev server running there is nothing to collide with**, but the rule matched on the command alone.
2. **The legitimate case is not rare.** `$types` goes stale whenever a `load` function's *return shape* changes — not only when the route tree changes, which is what the reason text says. Adding three fields to a load is enough. So it recurs through ordinary work, and a guard that asks when it cannot be right is one people learn to click through.

**The change.** The rule now also requires the dev-server daemon (`127.0.0.1:9444/sessions`) to report a running session. It **fails closed**: unreachable, slow, or unparseable answers ask exactly as before, so the only case that skips the prompt is a positive "zero sessions". The reason text now says a dev server is running, so the prompt distinguishes the two states.

**A false positive the new selftest rows caught:** `check\b` matches before a hyphen, so `pnpm run check-*` scripts tripped a rule that is about `svelte-kit sync`. Tightened to `check(?![\w:-])`.

**Verification**

- `node .claude/hooks/check-writable.selftest.mjs` — all green, including 7 new rows for the matcher. They test the pure matcher, so they need no daemon and pass offline.
- End to end with no dev server up: `svelte-kit sync` → exit 0, no prompt.
- `npx prettier --plugin=prettier-plugin-svelte --write x.svelte` → still **blocked**, exit 2. The other guard in this file is untouched.

Nothing here weakens the block list; only the `ask` for sync is narrowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
