### PR TITLE
fix(models): compute the model unpublish refund total fresh

### DIFF
--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -521,7 +521,14 @@ export default function ModelDetailsV2({
   });
   const handleUnpublishModel = async () => {
     try {
-      const refund = await queryUtils.model.getEarlyAccessRefundRequirement.fetch({ id });
+      // staleTime 0: this is the number of buyers and the amount of Buzz the owner is consenting to
+      // move out of their account, so it is computed fresh. `fetch` serves a cached entry otherwise,
+      // and a purchase landing between two openings of this dialog would have them confirm one
+      // figure while the server acts on another.
+      const refund = await queryUtils.model.getEarlyAccessRefundRequirement.fetch(
+        { id },
+        { staleTime: 0 }
+      );
       const exemptNote =
         refund.exemptBuyerCount > 0
           ? ` ${refund.exemptBuyerCount} earlier buyer(s) bought more than ${PAID_ACCESS_REFUND_WINDOW_DAYS} days ago; they lose access and are not refunded.`

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -521,10 +521,8 @@ export default function ModelDetailsV2({
   });
   const handleUnpublishModel = async () => {
     try {
-      // staleTime 0: this is the number of buyers and the amount of Buzz the owner is consenting to
-      // move out of their account, so it is computed fresh. `fetch` serves a cached entry otherwise,
-      // and a purchase landing between two openings of this dialog would have them confirm one
-      // figure while the server acts on another.
+      // The client's global default is `staleTime: Infinity` (`src/utils/trpc.ts`), and `fetchQuery`
+      // applies it — so without this the dialog can show a Buzz figure cached from an earlier open.
       const refund = await queryUtils.model.getEarlyAccessRefundRequirement.fetch(
         { id },
         { staleTime: 0 }


### PR DESCRIPTION
Follow-up to #4106, requested by Justin. Based on `main`, not on that branch.

## What

The model unpublish dialog tells a creator how many buyers will be refunded and how much Buzz leaves their account, then acts on their confirmation. It read that figure through `queryUtils.model.getEarlyAccessRefundRequirement.fetch({ id })` with no `staleTime`, so React Query serves a cached entry — a purchase landing between two openings of the dialog has the creator confirm one number while the server acts on another.

Now `{ staleTime: 0 }`, matching the version path added in #4106.

## Scope

**This is the dialog telling the truth, not a money bug.** The server recomputes the requirement inside `unpublishModelById` and throws without `refundEarlyAccess`, so the amount actually moved is always correct. What was wrong was the number the creator consented to.

One line plus the comment saying why, on a route that predates #4106. No test: the change is a query option on a call site whose behaviour is React Query's, and a test asserting "we passed staleTime 0" would restate the diff rather than catch anything.

## Verification

- `TYPECHECK_HEAP_MB=12288 pnpm run typecheck` — `typecheck: OK — 0 type errors in 237s`
- eslint on the changed file — 0 errors; the 3 unused-var warnings are pre-existing at lines 236-238 and untouched here
- Full unit suite not re-run for a one-line query option on a page component; #4106's runs cover the service and router this calls into

## Noticed, not fixed

`apps.storage.getQuota.fetch({ blockToken })` in `IframeHost.tsx:1852` and `PageBlockHost.tsx:2375` has the same shape — a quota read served from cache and then acted on. Different subsystem and different owner; flagging rather than widening this PR. Worth someone checking whether a stale quota can over-permit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review (five lanes) — no defects in the diff; two corrections to what this PR *said*

**1. The original comment named the wrong mechanism.** It claimed `fetch` serves a cached entry by default. It does not — stock `fetchQuery` defaults `staleTime` to 0, and what makes this option load-bearing is *our own* global `staleTime: Infinity` in `src/utils/trpc.ts`. A reader checking the React Query docs would have concluded the option was redundant and deleted it — correctly by the docs, wrongly here, with nothing going red. Since there is no test on this line, **the comment is the only guard it has**, so it now names the default it depends on, matching the two sibling call sites that already did (`RemixGallerySubmitModal.tsx`, `Sticker/placement.util.ts`).

**2. The "no test" rationale on record was wrong in its load-bearing half.** I wrote that the behaviour is React Query's; it is actually the composition of this call site with a first-party default a future PR could change. And the assertion I claimed could not exist does exist in this repo (`RemixGallerySubmitModal.browser.test.tsx:334-345`).

The real reason not to write one is stronger: **the browser/`component` project runs in no CI job** — `.github/workflows/lint.yml` invokes only `pnpm run test:unit:run` — so a browser test in the only constructible shape would gate nothing, on this PR or on a future revert. Add ~150-250 lines of fixture for a handler inline in a 1576-line page component with no existing coverage, and the call is clear. (If one is ever written: both real-`QueryClient` fixtures in the repo omit `staleTime` and so inherit React Query's 0 — a fixture copied from either passes identically with the option deleted.)

## Cost this change carries, stated rather than implied

`getEarlyAccessRefundRequirement` issues **one buzz-service HTTP call per buzz transaction id at `pLimit(5)`**. Measured across prod over the 1,300 models that reach the fan-out: **p50 = 1, p95 = 35, worst = 563 calls** — roughly 113 sequential batches at that concurrency.

`staleTime: Infinity` was acting as an accidental damper: the fan-out previously ran once per page mount however many times Unpublish was clicked, and now runs once per click. Still the right trade for a figure a creator is about to act on, but the cheap mitigation if it bites is a spinner or a disabled control during the fetch — **not** restoring the cache. `disabled={unpublishModelMutation.isPending}` covers only the post-confirm window.

## Behaviour change not previously noted

The fetch is inside the `try`, so a throw now skips all three dialog branches to the catch: error notification, no dialog, no unpublish. Fails closed, which is the right direction, but it is a real change from "dialog opens on a cached figure".

## Dedupe caveat for the next editor

`Query.fetch` returns the in-flight promise when one exists. Harmless today because this dialog is the sole consumer of the key — but **adding any `useQuery` or hover-prefetch on it would silently defeat this line**, since the dialog would join the older request rather than start its own.

## Filed separately, not fixed here

The AppBlocks `.fetch(` cluster is **fourteen sites, not the two I originally flagged**, and `invalidate|setData|resetQueries|removeQueries` returns zero matches across `src/components/AppBlocks` while the writes are bare mutations with no `onSuccess`. A third-party block that writes a key and reads it back gets the pre-write value — data integrity on the app-storage surface, where this diff's equivalent was display-only. Different subsystem and owner; raised with Justin as its own item.
