### PR TITLE
fix(notifications): match the opt-out clause by pattern, not by layout

### DIFF
--- a/src/server/notifications/__tests__/notification-settings-polarity.test.ts
+++ b/src/server/notifications/__tests__/notification-settings-polarity.test.ts
@@ -23,10 +23,17 @@ const queryFor = async (type: string) => {
     lastSentDate: new Date('2026-01-01'),
     clickhouse: undefined,
   });
-  return typeof q === 'string' ? q : undefined;
+  // Collapsed so DERIVES_RECIPIENTS' literal spaces and `LEFT ` lookbehinds survive a line break.
+  return typeof q === 'string' ? q.replace(/\s+/g, ' ') : undefined;
 };
 
-const OPT_OUT_CLAUSE = 'NOT EXISTS (SELECT 1 FROM "UserNotificationSettings"';
+/**
+ * A pattern rather than a literal substring. Matched literally it was an assertion about SQL
+ * FORMATTING: the same correct clause passed on one line and failed split across two, while a wrong
+ * clause written on one line passed. Both verdicts were then silent about polarity, which is the
+ * only thing this file checks.
+ */
+const OPT_OUT_CLAUSE = /NOT\s+EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+"UserNotificationSettings"/;
 
 /**
  * Types that render a toggle and ignore it, left as they are.
@@ -57,11 +64,11 @@ describe('notification settings polarity', () => {
         expect(query, `${type} is optIn, so it must derive recipients by joining`).toMatch(
           DERIVES_RECIPIENTS
         );
-        expect(query, `${type} is optIn, so a row must not also mean opted-out`).not.toContain(
+        expect(query, `${type} is optIn, so a row must not also mean opted-out`).not.toMatch(
           OPT_OUT_CLAUSE
         );
       } else if (query?.includes('"UserNotificationSettings"')) {
-        expect(query, `${type} is not optIn, so it must gate on NOT EXISTS`).toContain(
+        expect(query, `${type} is not optIn, so it must gate on NOT EXISTS`).toMatch(
           OPT_OUT_CLAUSE
         );
         // ...and must not ALSO derive recipients from the table, which would make a row mean both.
@@ -89,7 +96,7 @@ describe('notification settings polarity', () => {
       const query = await queryFor(type);
       // No query means the event path, where create.ts applies the filter.
       if (!query) continue;
-      if (!query.includes(OPT_OUT_CLAUSE)) inert.push(type);
+      if (!OPT_OUT_CLAUSE.test(query)) inert.push(type);
     }
 
     // Joined rather than compared as an array: vitest truncates a long array in
@@ -107,7 +114,7 @@ describe('notification settings polarity', () => {
     // — the shape it must reject, which is what the real defect looked like.
     const clauseless = `SELECT 'x' "key", u.id "userId" FROM "User" u`;
 
-    expect(clauseless.includes(OPT_OUT_CLAUSE)).toBe(false);
+    expect(OPT_OUT_CLAUSE.test(clauseless)).toBe(false);
   });
 
   it('actually reaches the async processors', async () => {
@@ -149,7 +156,7 @@ describe('notification settings polarity', () => {
       'new-3d-model-comment-nested',
     ]) {
       expect(notificationProcessors[type].optIn).toBeFalsy();
-      expect(await queryFor(type)).toContain(OPT_OUT_CLAUSE);
+      expect(await queryFor(type)).toMatch(OPT_OUT_CLAUSE);
     }
   });
 

--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -164,9 +164,17 @@ describe('both resolved types honour their own setting', () => {
   // There is no global opt-out filter on this path — createNotificationsBulk
   // does no settings lookup — so a processor that omits this clause cannot be
   // muted at all, however its toggle renders.
-  it.each(['sticker-placement-resolved', 'remix-gallery-resolved'])('%s', async (type) => {
-    expect(await query(type)).toContain(
-      `WHERE NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = data."userId" AND type = '${type}')`
+  // String.raw, because a plain template literal eats every backslash — `\s` becomes `s` and the
+  // pattern silently stops meaning what it reads as.
+  const gate = (type: string) =>
+    new RegExp(
+      String.raw`WHERE\s+NOT\s+EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+"UserNotificationSettings"` +
+        String.raw`\s+WHERE\s+"userId"\s*=\s*data\."userId"\s+AND\s+type\s*=\s*'${type}'\s*\)`
     );
+
+  it.each(['sticker-placement-resolved', 'remix-gallery-resolved'])('%s', async (type) => {
+    // Whitespace-tolerant, because a literal pins the clause's LAYOUT: the same correct SQL passed
+    // on one line and failed split across two, so both verdicts said nothing about the gate.
+    expect(await query(type)).toMatch(gate(type));
   });
 });

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -67,8 +67,7 @@ export const placementNotifications = createNotificationProcessor({
       FROM data
       -- A row means opted OUT. There is no global filter — every processor that
       -- honours its own toggle writes this clause itself — so without it the
-      -- setting renders, saves, and does nothing. Kept on one line because the
-      -- notification-settings-polarity guard matches the clause as a literal.
+      -- setting renders, saves, and does nothing.
       WHERE NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = data."userId" AND type = 'sticker-placement-pending')
     `,
   },
@@ -180,8 +179,7 @@ export const placementNotifications = createNotificationProcessor({
           --
           -- Inside the CTE and against p."ownerId", which is the recipient; the
           -- projected "userId" outside the CTE is the same value and would work
-          -- there too. Kept on one line either way, because the polarity guard
-          -- matches the clause as a literal.
+          -- there too.
           AND NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = p."ownerId" AND type = 'remix-gallery-pending')
       )
       SELECT
@@ -337,9 +335,11 @@ export const placementNotifications = createNotificationProcessor({
       -- A row means opted OUT. This type shipped without the clause, so its
       -- toggle rendered, saved, and changed nothing -- there is no global filter
       -- on this path (createNotificationsBulk does no settings lookup), so a
-      -- processor that omits it is unmuteable. Kept on one line because the
-      -- polarity guard matches the clause as a literal.
-      WHERE NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = data."userId" AND type = 'remix-gallery-resolved')
+      -- processor that omits it is unmuteable.
+      WHERE NOT EXISTS (
+        SELECT 1 FROM "UserNotificationSettings"
+        WHERE "userId" = data."userId" AND type = 'remix-gallery-resolved'
+      )
     `,
   },
 


### PR DESCRIPTION
Two notification guards pinned `NOT EXISTS (SELECT 1 FROM "UserNotificationSettings"` as a raw substring of the generated SQL. That made them assertions about the clause's **formatting** rather than its polarity: a correct clause split across two lines failed, and a wrong clause written on one line passed. Neither the red nor the green said anything about the only property the guards exist to check.

Found by @scarlet while adding `creator-announcement.notifications.ts` — a correctly-gated query failed the guard, and the cheap way out was to conform the SQL to the one-line spelling. Three comments in `placement.notifications.ts` record earlier authors doing exactly that.

## Why this guard is load-bearing rather than tidy

`createNotificationsBulk` (`apps/notifications/src/lib/server/operations.ts`) does **no** settings lookup at all — only the event path's `create.ts` filters recipients. So on the scheduled-query path the SQL clause is the *only* enforcement of a user's opt-out, and a processor that omits it is unmuteable however its toggle renders.

## The fix

`OPT_OUT_CLAUSE` is a pattern now:

```ts
const OPT_OUT_CLAUSE = /NOT\s+EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+"UserNotificationSettings"/;
```

Collapsing whitespace is **not** sufficient on its own, which is worth knowing before reaching for the small fix: collapsing runs to a single space turns a multi-line clause into `NOT EXISTS ( SELECT 1 FROM …`, and the literal is spelled `(SELECT`. The collapse stays in `queryFor` anyway, because `DERIVES_RECIPIENTS` contains a literal space and two `LEFT ` lookbehinds that a line break defeats.

Reformatting one clause across lines to demonstrate the fix then exposed a **second guard with the identical defect** — `placement-resolved-notification.test.ts` pinned the whole clause, alias included, as a one-line template literal. Fixed the same way, via `String.raw`: in a plain template literal `\s` collapses to `s`, so the pattern would have read correctly and matched nothing. A pattern that looks right and matches nothing reports green forever.

Also deleted the three "kept on one line because the guard matches the clause as a literal" comments, which now describe a constraint that does not exist.

## What this does NOT detect

A clause that is **present but non-restricting** — `AND (TRUE OR NOT EXISTS (…))` — passes both before and after. The fix removes false reds without widening or narrowing real detection, so a green run here is not proof that every gate restricts anything.

## Mutation evidence

| mutation | result |
|---|---|
| correct clause split across lines, **old** guard | 🔴 "must gate on NOT EXISTS" + inert-list mismatch |
| same source, **new** guard | ✅ 12/12 |
| clause deleted from `sticker-placement-pending` | 🔴 inert-list mismatch |
| `NOT EXISTS` → `EXISTS` | 🔴 2 failures |
| inverted **and** split across lines | 🔴 2 failures |
| resolved gate scoped to the wrong type | 🔴 second guard fails |

## Coverage sweep

Every toggleable processor with a `prepareQuery` was re-checked against the fixed matcher. The inert set is unchanged: one type, `cosmetic-shop-item-sold`, already named and pinned in `KNOWN_INERT` on main as a deliberate hold. No new unmuteable notification turned up.

## Verification

`typecheck` 0 errors · `lint`/`prettier` clean on all three files · notifications suite 214 passed · full `test:unit:run` 18636 passed, with the 5 pre-existing Windows path-separator failures in `rating-label`, `appListingStatChips` and `standalone-boot-graph` · `blocks.router.workflow.test.ts` collected 350 tests, so the worktree submodule is initialised and the run is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
