### PR TITLE
feat(sales): scheduled model sales — the price half

### DIFF
--- a/packages/civitai-buzz/src/paid-access.test.ts
+++ b/packages/civitai-buzz/src/paid-access.test.ts
@@ -23,6 +23,13 @@ import {
   maxPermanentAccessModels,
   tierCapRows,
   type ModelVersionTerms,
+  type ModelVersionSaleWindow,
+  discountedTerms,
+  maxSaleDays,
+  remainingSaleDays,
+  saleDaysCharged,
+  saleDaysUsed,
+  SALE_DAYS_BY_TIER,
 } from './paid-access';
 import {
   MAX_LICENSING_FEE,
@@ -381,5 +388,137 @@ describe('shouldUpsellCap — nudge only when the ceiling is actually in the way
     expect(shouldUpsellCap({ value: 99999, cap: Infinity, tier: 'silver' })).toBe(false);
     expect(shouldUpsellCap({ value: 0, cap: 0, tier: 'free' })).toBe(false);
     expect(shouldUpsellCap({ value: 5, cap: 0, tier: 'free' })).toBe(false);
+  });
+});
+
+describe('scheduled sales — discountedTerms', () => {
+  const at = (iso: string) => new Date(iso);
+  const sale = (over: Partial<ModelVersionSaleWindow> = {}): ModelVersionSaleWindow => ({
+    id: 1,
+    discountType: 'Percent',
+    discountAmount: 20,
+    startsAt: at('2026-03-01T00:00:00Z'),
+    endsAt: at('2026-03-08T00:00:00Z'),
+    canceledAt: null,
+    ...over,
+  });
+  const now = at('2026-03-02T00:00:00Z');
+
+  it('discounts BOTH the download price and a separate generation price', () => {
+    const out = discountedTerms(
+      { download: { price: 500 }, generation: { price: 100 } },
+      [sale()],
+      now
+    );
+    expect(out.download?.price).toBe(400);
+    expect(paidGenerationGrant(out)?.price).toBe(80);
+  });
+
+  it('leaves a generation tier with no price of its own alone, so it keeps following the discounted download price', () => {
+    const terms: ModelVersionTerms = { download: { price: 500 }, generation: { trialLimit: 3 } };
+    const out = discountedTerms(terms, [sale()], now);
+    expect(paidGenerationGrant(out)?.price).toBeUndefined();
+    expect(generationPrice(out)).toBe(400);
+  });
+
+  it('never drives a price below zero when a fixed discount exceeds it', () => {
+    const out = discountedTerms(
+      { download: { price: 500 }, generation: { price: 100 } },
+      [sale({ discountType: 'Fixed', discountAmount: 300 })],
+      now
+    );
+    expect(out.download?.price).toBe(200);
+    expect(paidGenerationGrant(out)?.price).toBe(0);
+  });
+
+  it('rounds a percentage in the buyer’s favour, never charging more than the undiscounted price', () => {
+    const out = discountedTerms({ download: { price: 33 } }, [sale({ discountAmount: 33 })], now);
+    // 33 * 33% = 10.89 -> 10 off, not 11: a rounding error must not take LESS off than advertised.
+    expect(out.download?.price).toBe(23);
+  });
+
+  it('applies the deepest discount when two sales overlap on one version', () => {
+    const out = discountedTerms(
+      { download: { price: 1000 } },
+      [
+        sale({ id: 1, discountAmount: 10 }),
+        sale({ id: 2, discountType: 'Fixed', discountAmount: 250 }),
+      ],
+      now
+    );
+    expect(out.download?.price).toBe(750);
+  });
+
+  it('ignores a sale that has not started, has ended, or was cancelled before now', () => {
+    const terms: ModelVersionTerms = { download: { price: 500 } };
+    const notStarted = sale({ startsAt: at('2026-03-05T00:00:00Z') });
+    const ended = sale({ endsAt: at('2026-03-01T12:00:00Z') });
+    const cancelled = sale({ canceledAt: at('2026-03-01T12:00:00Z') });
+    for (const s of [notStarted, ended, cancelled]) {
+      expect(discountedTerms(terms, [s], now).download?.price).toBe(500);
+    }
+  });
+
+  it('composes OVER cappedTerms: the sale comes off what the buyer is actually billed', () => {
+    // A lapsed gold creator stores 5000 but is billed the free cap of 500. 20% off must be 400 —
+    // discounting first would give 4000, which the cap then flattens back to 500 and the sale vanishes.
+    const stored: ModelVersionTerms = { download: { price: 5000 } };
+    const gate = { permanent: true } as const;
+    const billed = discountedTerms(cappedTerms(stored, 'free', gate), [sale()], now);
+    expect(billed.download?.price).toBe(400);
+
+    const wrongOrder = cappedTerms(discountedTerms(stored, [sale()], now), 'free', gate);
+    expect(wrongOrder.download?.price).toBe(500);
+  });
+});
+
+describe('scheduled sales — the sale-day budget', () => {
+  const at = (iso: string) => new Date(iso);
+  const window = (over: Partial<ModelVersionSaleWindow> = {}): ModelVersionSaleWindow => ({
+    id: 1,
+    discountType: 'Percent',
+    discountAmount: 20,
+    startsAt: at('2026-03-01T00:00:00Z'),
+    endsAt: at('2026-03-08T00:00:00Z'),
+    canceledAt: null,
+    ...over,
+  });
+
+  it('charges the full scheduled length while the sale stands', () => {
+    expect(saleDaysCharged(window())).toBe(7);
+  });
+
+  it('returns everything when a sale is cancelled before it starts', () => {
+    expect(saleDaysCharged(window({ canceledAt: at('2026-02-27T00:00:00Z') }))).toBe(0);
+  });
+
+  it('returns the untaken tail when a sale is cancelled part-way through', () => {
+    expect(saleDaysCharged(window({ canceledAt: at('2026-03-03T00:00:00Z') }))).toBe(2);
+  });
+
+  it('rounds a part-day up, so a run of short sales cannot slice past the budget', () => {
+    const half = window({ endsAt: at('2026-03-01T12:00:00Z') });
+    expect(saleDaysCharged(half)).toBe(1);
+  });
+
+  it('counts a month-crossing sale against the month it STARTS in, and only that month', () => {
+    const crossing = window({
+      startsAt: at('2026-03-30T00:00:00Z'),
+      endsAt: at('2026-04-04T00:00:00Z'),
+    });
+    expect(saleDaysUsed([crossing], at('2026-03-15T00:00:00Z'))).toBe(5);
+    expect(saleDaysUsed([crossing], at('2026-04-15T00:00:00Z'))).toBe(0);
+  });
+
+  it('gives an unknown or lapsed tier the FREE allowance rather than none', () => {
+    expect(maxSaleDays('gold')).toBe(30);
+    expect(maxSaleDays(null)).toBe(SALE_DAYS_BY_TIER.free);
+    expect(maxSaleDays('nonsense')).toBe(SALE_DAYS_BY_TIER.free);
+  });
+
+  it('never reports negative remaining days after a downgrade', () => {
+    const spent = [window({ startsAt: at('2026-03-01T00:00:00Z'), endsAt: at('2026-03-29T00:00:00Z') })];
+    expect(remainingSaleDays('gold', spent, at('2026-03-15T00:00:00Z'))).toBe(2);
+    expect(remainingSaleDays('free', spent, at('2026-03-15T00:00:00Z'))).toBe(0);
   });
 });

--- a/packages/civitai-buzz/src/paid-access.test.ts
+++ b/packages/civitai-buzz/src/paid-access.test.ts
@@ -25,6 +25,7 @@ import {
   type ModelVersionTerms,
   type ModelVersionSaleWindow,
   discountedTerms,
+  bestSaleFor,
   maxSaleDays,
   remainingSaleDays,
   saleDaysCharged,
@@ -520,5 +521,69 @@ describe('scheduled sales — the sale-day budget', () => {
     const spent = [window({ startsAt: at('2026-03-01T00:00:00Z'), endsAt: at('2026-03-29T00:00:00Z') })];
     expect(remainingSaleDays('gold', spent, at('2026-03-15T00:00:00Z'))).toBe(2);
     expect(remainingSaleDays('free', spent, at('2026-03-15T00:00:00Z'))).toBe(0);
+  });
+});
+
+describe('scheduled sales — percent and fixed have no order until applied to a price', () => {
+  const at = (iso: string) => new Date(iso);
+  const now = at('2026-03-02T00:00:00Z');
+  const base = { startsAt: at('2026-03-01T00:00:00Z'), endsAt: at('2026-03-08T00:00:00Z'), canceledAt: null };
+  const percent: ModelVersionSaleWindow = { id: 1, discountType: 'Percent', discountAmount: 20, ...base };
+  const fixed: ModelVersionSaleWindow = { id: 2, discountType: 'Fixed', discountAmount: 250, ...base };
+
+  it('picks the FIXED sale on a cheap version and the PERCENT sale on an expensive one, from the same pair', () => {
+    // 1000: fixed takes 250, percent takes 200 -> fixed wins.
+    expect(discountedTerms({ download: { price: 1000 } }, [percent, fixed], now).download?.price).toBe(750);
+    // 2000: fixed still takes 250, percent takes 400 -> percent wins. The winner INVERTS on base price,
+    // so a comparison done before knowing the price would get one of these two wrong.
+    expect(discountedTerms({ download: { price: 2000 } }, [percent, fixed], now).download?.price).toBe(1600);
+  });
+
+  it('picks per PRICE, not per version: one sale can win the download tier and the other the generation tier', () => {
+    const out = discountedTerms(
+      { download: { price: 2000 }, generation: { price: 1000 } },
+      [percent, fixed],
+      now
+    );
+    expect(out.download?.price).toBe(1600);
+    expect(paidGenerationGrant(out)?.price).toBe(750);
+  });
+});
+
+describe('scheduled sales — the resolver DECLINES to discount', () => {
+  const at = (iso: string) => new Date(iso);
+  const now = at('2026-03-02T00:00:00Z');
+  const terms: ModelVersionTerms = { download: { price: 500 }, generation: { price: 100 } };
+
+  // Negative controls. Without these, every "the discount applied" test above would still pass if the
+  // resolver discounted unconditionally — which is the failure that charges every buyer less, forever.
+  it('returns the terms untouched when there are no sales at all', () => {
+    expect(discountedTerms(terms, [], now)).toEqual(terms);
+    expect(discountedTerms(terms, undefined, now)).toEqual(terms);
+    expect(discountedTerms(terms, null, now)).toEqual(terms);
+  });
+
+  it('returns the terms untouched when every sale is out of window', () => {
+    const over = {
+      id: 1,
+      discountType: 'Percent' as const,
+      discountAmount: 50,
+      startsAt: at('2026-01-01T00:00:00Z'),
+      endsAt: at('2026-01-08T00:00:00Z'),
+      canceledAt: null,
+    };
+    expect(discountedTerms(terms, [over], now)).toEqual(terms);
+  });
+
+  it('bestSaleFor returns nothing rather than a zero-value sale', () => {
+    const zeroOff = {
+      id: 1,
+      discountType: 'Percent' as const,
+      discountAmount: 0,
+      startsAt: at('2026-03-01T00:00:00Z'),
+      endsAt: at('2026-03-08T00:00:00Z'),
+      canceledAt: null,
+    };
+    expect(bestSaleFor(500, [zeroOff], now)).toBeUndefined();
   });
 });

--- a/packages/civitai-buzz/src/paid-access.test.ts
+++ b/packages/civitai-buzz/src/paid-access.test.ts
@@ -422,19 +422,21 @@ describe('scheduled sales — discountedTerms', () => {
     expect(generationPrice(out)).toBe(400);
   });
 
-  it('never drives a price below zero when a fixed discount exceeds it', () => {
+  it('never drives a price below the 1-Buzz floor when a fixed discount exceeds it', () => {
     const out = discountedTerms(
       { download: { price: 500 }, generation: { price: 100 } },
       [sale({ discountType: 'Fixed', discountAmount: 300 })],
       now
     );
     expect(out.download?.price).toBe(200);
-    expect(paidGenerationGrant(out)?.price).toBe(0);
+    // 1, not 0: a zero-Buzz purchase writes no ledger row and the refund path reads amounts back from it.
+    expect(paidGenerationGrant(out)?.price).toBe(1);
   });
 
-  it('rounds a percentage in the buyer’s favour, never charging more than the undiscounted price', () => {
+  it('floors a fractional percentage, leaving the part-Buzz remainder with the seller', () => {
     const out = discountedTerms({ download: { price: 33 } }, [sale({ discountAmount: 33 })], now);
-    // 33 * 33% = 10.89 -> 10 off, not 11: a rounding error must not take LESS off than advertised.
+    // 33 * 33% = 10.89 -> 10 off, so the buyer pays 23 rather than 22. An integer currency has to break
+    // the tie somewhere; this pins WHICH way, so a later switch to Math.round is a visible change.
     expect(out.download?.price).toBe(23);
   });
 
@@ -509,6 +511,21 @@ describe('scheduled sales — the sale-day budget', () => {
     });
     expect(saleDaysUsed([crossing], at('2026-03-15T00:00:00Z'))).toBe(5);
     expect(saleDaysUsed([crossing], at('2026-04-15T00:00:00Z'))).toBe(0);
+  });
+
+  it('does not count the same calendar month of a DIFFERENT year', () => {
+    // Without the year check, March 2025 would spend March 2026's budget.
+    const lastYear = window({
+      startsAt: at('2025-03-01T00:00:00Z'),
+      endsAt: at('2025-03-08T00:00:00Z'),
+    });
+    expect(saleDaysUsed([lastYear], at('2026-03-15T00:00:00Z'))).toBe(0);
+    expect(saleDaysUsed([lastYear], at('2025-03-15T00:00:00Z'))).toBe(7);
+  });
+
+  it('charges the full window when a cancel lands after it had already closed', () => {
+    // A cancel recorded after endsAt returns nothing — the sale ran its length.
+    expect(saleDaysCharged(window({ canceledAt: at('2026-03-20T00:00:00Z') }))).toBe(7);
   });
 
   it('gives an unknown or lapsed tier the FREE allowance rather than none', () => {

--- a/packages/civitai-buzz/src/paid-access.ts
+++ b/packages/civitai-buzz/src/paid-access.ts
@@ -424,3 +424,155 @@ export function migrateTermsForUsageControl(
     },
   };
 }
+
+// ---------------------------------------------------------------------------
+// Scheduled sales (CU 868ktk1ku)
+// ---------------------------------------------------------------------------
+
+export type SaleDiscountKind = 'Fixed' | 'Percent';
+
+/** One scheduled discount over a version. Windows only — an effective price is never stored. */
+export type ModelVersionSaleWindow = {
+  id: number;
+  discountType: SaleDiscountKind;
+  /** Buzz for Fixed, whole percent for Percent. */
+  discountAmount: number;
+  startsAt: Date;
+  endsAt: Date;
+  canceledAt?: Date | null;
+};
+
+/**
+ * Sale-days a tier may have discounted per month. Shared for the same reason the caps above are: Creator
+ * Studio authors sales and the main app prices them, and a limit only one of them knows is not a limit.
+ */
+export const SALE_DAYS_BY_TIER: Record<string, number> = {
+  free: 3,
+  // Legacy paid tier — allowances match bronze.
+  founder: 7,
+  bronze: 7,
+  silver: 14,
+  gold: 30,
+};
+
+/** No sale at all below this creator score, on every tier — a paid membership does not buy past it. */
+export const MIN_CREATOR_SCORE_FOR_SALE = 10_000;
+
+/** How far ahead a sale may be scheduled, so next month's promo can be prepared from the back half of this one. */
+export const MAX_SALE_LEAD_DAYS = 14;
+
+/** Sale-days a tier gets. An unknown or lapsed tier gets the FREE allowance rather than 0, as with access caps. */
+export function maxSaleDays(tier: string | null | undefined): number {
+  return (tier ? SALE_DAYS_BY_TIER[tier] : undefined) ?? SALE_DAYS_BY_TIER.free;
+}
+
+/** Live at `now`: started, not yet ended, not cancelled before this moment. */
+export const isSaleActive = (sale: ModelVersionSaleWindow, now: Date = new Date()): boolean =>
+  sale.startsAt <= now && sale.endsAt > now && (sale.canceledAt == null || sale.canceledAt > now);
+
+/**
+ * What one sale takes off a price. Percent is floored so a rounding error can never charge MORE than the
+ * undiscounted price, and the result floors at 0 — a fixed discount larger than the price makes it free
+ * rather than negative.
+ */
+export function saleDiscountFor(price: number, sale: ModelVersionSaleWindow): number {
+  if (price <= 0) return 0;
+  const off =
+    sale.discountType === 'Percent'
+      ? Math.floor((price * sale.discountAmount) / 100)
+      : sale.discountAmount;
+  return Math.max(0, Math.min(price, off));
+}
+
+/**
+ * The sale a buyer should get at `now`: the one that takes the most off. Sales may overlap — a sale
+ * crossing a month boundary meets the next month's, and both spent their own budget — so the deepest
+ * discount wins rather than whichever row came back first. Percent and fixed are compared at a price,
+ * not against each other, because 20% and 200 Buzz have no order until you know what they apply to.
+ */
+export function bestSaleFor(
+  price: number,
+  sales: ModelVersionSaleWindow[] | undefined | null,
+  now: Date = new Date()
+): ModelVersionSaleWindow | undefined {
+  let best: ModelVersionSaleWindow | undefined;
+  let bestOff = 0;
+  for (const sale of sales ?? []) {
+    if (!isSaleActive(sale, now)) continue;
+    const off = saleDiscountFor(price, sale);
+    if (off > bestOff) {
+      best = sale;
+      bestOff = off;
+    }
+  }
+  return best;
+}
+
+/**
+ * Terms with any active sale applied — what a buyer pays. Compose OVER cappedTerms, never under: the tier
+ * ceiling decides what the creator may charge, and the sale comes off what the buyer would actually have
+ * been billed. The other order lets the cap silently eat the discount (a lapsed gold creator stored at 5000
+ * is billed 500; 20% off must be 400, not 4000 clamped back to 500).
+ *
+ * Applies to BOTH chargeable prices. A generation tier with no price of its own falls back to the download
+ * price, which is discounted here already, so it follows automatically.
+ */
+export function discountedTerms(
+  terms: ModelVersionTerms,
+  sales: ModelVersionSaleWindow[] | undefined | null,
+  now: Date = new Date()
+): ModelVersionTerms {
+  if (!sales?.length) return terms;
+  const paidGen = paidGenerationGrant(terms);
+  const discount = (price: number) => {
+    const sale = bestSaleFor(price, sales, now);
+    return sale ? price - saleDiscountFor(price, sale) : price;
+  };
+  return {
+    ...terms,
+    ...(terms.download ? { download: { ...terms.download, price: discount(terms.download.price) } } : {}),
+    ...(paidGen?.price != null
+      ? { generation: { ...paidGen, price: discount(paidGen.price) } }
+      : {}),
+  };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Whole days a sale takes out of the budget: its scheduled length, shortened to where it was actually
+ * cancelled. A sale reserves its full window when scheduled and RETURNS the untaken tail if it is cancelled
+ * or cut short — cancel before it starts and it costs nothing. Without that return, "you may always cut a
+ * sale short" would cost the creator exactly as much as running it in full, and the permission would be
+ * worth nothing. Rounded up, so a run of half-day sales can't slice past the budget.
+ */
+export function saleDaysCharged(sale: ModelVersionSaleWindow): number {
+  const end = sale.canceledAt != null && sale.canceledAt < sale.endsAt ? sale.canceledAt : sale.endsAt;
+  const ms = end.getTime() - sale.startsAt.getTime();
+  return ms <= 0 ? 0 : Math.ceil(ms / DAY_MS);
+}
+
+/**
+ * Sale-days a creator has spent in the month a sale STARTS in. Counting by start month is what lets a sale
+ * cross a month boundary without costing twice — the alternative refuses a sale for reaching into a month
+ * whose budget is untouched, which reads as a bug to the creator.
+ */
+export function saleDaysUsed(
+  sales: ModelVersionSaleWindow[] | undefined | null,
+  month: Date
+): number {
+  const year = month.getUTCFullYear();
+  const mon = month.getUTCMonth();
+  return (sales ?? [])
+    .filter((s) => s.startsAt.getUTCFullYear() === year && s.startsAt.getUTCMonth() === mon)
+    .reduce((total, s) => total + saleDaysCharged(s), 0);
+}
+
+/** Sale-days left in `month` for a tier. Never negative — a tier downgrade must not read as debt. */
+export function remainingSaleDays(
+  tier: string | null | undefined,
+  sales: ModelVersionSaleWindow[] | undefined | null,
+  month: Date
+): number {
+  return Math.max(0, maxSaleDays(tier) - saleDaysUsed(sales, month));
+}

--- a/packages/civitai-buzz/src/paid-access.ts
+++ b/packages/civitai-buzz/src/paid-access.ts
@@ -144,6 +144,8 @@ export type PaidAccessRow = {
   /** Timed-window length in days; null = permanent. Materialized into endsAt at publish. */
   timeframeDays?: number | null;
   terms: PaidAccessTerms;
+  /** Scheduled sales covering this entity — windows only, never a resolved price. See discountedTerms. */
+  sales?: ModelVersionSaleWindow[];
 };
 
 /**

--- a/packages/civitai-buzz/src/paid-access.ts
+++ b/packages/civitai-buzz/src/paid-access.ts
@@ -463,19 +463,48 @@ export const MIN_CREATOR_SCORE_FOR_SALE = 10_000;
 /** How far ahead a sale may be scheduled, so next month's promo can be prepared from the back half of this one. */
 export const MAX_SALE_LEAD_DAYS = 14;
 
-/** Sale-days a tier gets. An unknown or lapsed tier gets the FREE allowance rather than 0, as with access caps. */
-export function maxSaleDays(tier: string | null | undefined): number {
-  return (tier ? SALE_DAYS_BY_TIER[tier] : undefined) ?? SALE_DAYS_BY_TIER.free;
+/**
+ * KeyValue row both apps read the sale limits from, so a limit can move without a deploy and a pricing page
+ * can state it without hard-coding it. The tables above are the defaults when the row is absent or partial.
+ */
+export const SALE_LIMITS_KEY = 'sale-limits';
+
+export type SaleLimitOverrides = {
+  saleDaysByTier?: Record<string, number>;
+  minCreatorScore?: number;
+  maxLeadDays?: number;
+};
+
+/**
+ * Sale-days a tier gets. An unknown or lapsed tier gets the FREE allowance rather than 0, as with access
+ * caps — a lapse must not retroactively invalidate a scheduled sale.
+ */
+export function maxSaleDays(
+  tier: string | null | undefined,
+  overrides?: SaleLimitOverrides
+): number {
+  const table = { ...SALE_DAYS_BY_TIER, ...(overrides?.saleDaysByTier ?? {}) };
+  return (tier ? table[tier] : undefined) ?? table.free;
 }
+
+export const minCreatorScoreForSale = (overrides?: SaleLimitOverrides): number =>
+  overrides?.minCreatorScore ?? MIN_CREATOR_SCORE_FOR_SALE;
+
+export const maxSaleLeadDays = (overrides?: SaleLimitOverrides): number =>
+  overrides?.maxLeadDays ?? MAX_SALE_LEAD_DAYS;
 
 /** Live at `now`: started, not yet ended, not cancelled before this moment. */
 export const isSaleActive = (sale: ModelVersionSaleWindow, now: Date = new Date()): boolean =>
   sale.startsAt <= now && sale.endsAt > now && (sale.canceledAt == null || sale.canceledAt > now);
 
 /**
- * What one sale takes off a price. Percent is floored so a rounding error can never charge MORE than the
- * undiscounted price, and the result floors at 0 — a fixed discount larger than the price makes it free
- * rather than negative.
+ * What one sale takes off a price. `Math.min(price, off)` is what keeps a fixed discount from making a
+ * price negative; the outer `Math.max(0, …)` floors it at free.
+ *
+ * Percent is FLOORED, which rounds the leftover in the seller's favour — 33% of 33 takes 10 off, not 11,
+ * so the buyer pays 23. That is deliberate (an integer currency has to break the tie somewhere and the
+ * creator is the one being paid), but it is the opposite of what "in the buyer's favour" would mean, so
+ * do not switch this to Math.round on the assumption it is a wash.
  */
 export function saleDiscountFor(price: number, sale: ModelVersionSaleWindow): number {
   if (price <= 0) return 0;
@@ -510,6 +539,28 @@ export function bestSaleFor(
   return best;
 }
 
+/** Buzz a sale can never take a purchase below. */
+export const MIN_SALE_PRICE = 1;
+
+/**
+ * One price with the best active sale applied. The charge and every display path call THIS — the repo has
+ * already paid for the alternative once (see computePackAmountDue: "the button subtracted a discount the
+ * server never applied"), and two implementations of the same arithmetic had already diverged here on the
+ * floor before a review caught it.
+ *
+ * Floors at 1, not 0: a zero-Buzz purchase writes no ledger row, and the 30-day refund path reads amounts
+ * back from the ledger, so a free purchase would be unrefundable and invisible to reporting.
+ */
+export function discountedPrice(
+  price: number,
+  sales: ModelVersionSaleWindow[] | undefined | null,
+  now: Date = new Date()
+): number {
+  const sale = bestSaleFor(price, sales, now);
+  if (!sale) return price;
+  return Math.max(MIN_SALE_PRICE, price - saleDiscountFor(price, sale));
+}
+
 /**
  * Terms with any active sale applied — what a buyer pays. Compose OVER cappedTerms, never under: the tier
  * ceiling decides what the creator may charge, and the sale comes off what the buyer would actually have
@@ -526,10 +577,7 @@ export function discountedTerms(
 ): ModelVersionTerms {
   if (!sales?.length) return terms;
   const paidGen = paidGenerationGrant(terms);
-  const discount = (price: number) => {
-    const sale = bestSaleFor(price, sales, now);
-    return sale ? price - saleDiscountFor(price, sale) : price;
-  };
+  const discount = (price: number) => discountedPrice(price, sales, now);
   return {
     ...terms,
     ...(terms.download ? { download: { ...terms.download, price: discount(terms.download.price) } } : {}),
@@ -574,7 +622,8 @@ export function saleDaysUsed(
 export function remainingSaleDays(
   tier: string | null | undefined,
   sales: ModelVersionSaleWindow[] | undefined | null,
-  month: Date
+  month: Date,
+  overrides?: SaleLimitOverrides
 ): number {
-  return Math.max(0, maxSaleDays(tier) - saleDaysUsed(sales, month));
+  return Math.max(0, maxSaleDays(tier, overrides) - saleDaysUsed(sales, month));
 }

--- a/packages/civitai-db-schema/prisma/migrations/20260819030000_model_version_sales/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260819030000_model_version_sales/migration.sql
@@ -28,6 +28,9 @@ CREATE TABLE "ModelVersionSaleItem" (
 -- The creator's month-to-date sale-day budget is read by (userId, startsAt); the resolver reads by version.
 CREATE INDEX "ModelVersionSale_userId_startsAt_idx" ON "ModelVersionSale"("userId", "startsAt");
 CREATE INDEX "ModelVersionSaleItem_modelVersionId_idx" ON "ModelVersionSaleItem"("modelVersionId");
+-- The resolver filters the sale side on endsAt > now. Rows are never deleted, so without this the scan
+-- grows monotonically while the live set stays small.
+CREATE INDEX "ModelVersionSale_endsAt_idx" ON "ModelVersionSale"("endsAt");
 
 ALTER TABLE "ModelVersionSaleItem"
   ADD CONSTRAINT "ModelVersionSaleItem_saleId_fkey"

--- a/packages/civitai-db-schema/prisma/migrations/20260819030000_model_version_sales/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260819030000_model_version_sales/migration.sql
@@ -1,0 +1,34 @@
+-- Scheduled model sales (CU 868ktk1ku). A sale is an OVERLAY: PaidAccess.terms is never rewritten,
+-- so a creator editing their base price mid-sale cannot lose it.
+
+CREATE TYPE "SaleDiscountType" AS ENUM ('Fixed', 'Percent');
+
+CREATE TABLE "ModelVersionSale" (
+  "id" SERIAL NOT NULL,
+  "userId" INTEGER NOT NULL,
+  "name" TEXT,
+  "discountType" "SaleDiscountType" NOT NULL,
+  "discountAmount" INTEGER NOT NULL,
+  "startsAt" TIMESTAMP(3) NOT NULL,
+  "endsAt" TIMESTAMP(3) NOT NULL,
+  "canceledAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "ModelVersionSale_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "ModelVersionSaleItem" (
+  "saleId" INTEGER NOT NULL,
+  "modelVersionId" INTEGER NOT NULL,
+
+  CONSTRAINT "ModelVersionSaleItem_pkey" PRIMARY KEY ("saleId", "modelVersionId")
+);
+
+-- The creator's month-to-date sale-day budget is read by (userId, startsAt); the resolver reads by version.
+CREATE INDEX "ModelVersionSale_userId_startsAt_idx" ON "ModelVersionSale"("userId", "startsAt");
+CREATE INDEX "ModelVersionSaleItem_modelVersionId_idx" ON "ModelVersionSaleItem"("modelVersionId");
+
+ALTER TABLE "ModelVersionSaleItem"
+  ADD CONSTRAINT "ModelVersionSaleItem_saleId_fkey"
+  FOREIGN KEY ("saleId") REFERENCES "ModelVersionSale"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -5072,6 +5072,42 @@ model PaidAccess {
   @@index([entityType, endsAt]) // expiry-job + early-access-complete notification scan by end time
 }
 
+enum SaleDiscountType {
+  Fixed
+  Percent
+}
+
+// A scheduled discount laid OVER a version's PaidAccess price. The gate's own `terms` is never
+// rewritten, so a creator editing their base price mid-sale cannot lose it, and "what did this cost
+// on the day" stays answerable. Effective price is resolved at read time — see discountedTerms in
+// @civitai/buzz. Sales cover permanent paid access only, never a timed early-access window.
+model ModelVersionSale {
+  id             Int                   @id @default(autoincrement())
+  userId         Int
+  // Optional: naming a sale is a creator's choice, not a requirement.
+  name           String?
+  discountType   SaleDiscountType
+  // Buzz for Fixed, whole percent for Percent. Never a float — this reaches a price.
+  discountAmount Int
+  startsAt       DateTime
+  endsAt         DateTime
+  canceledAt     DateTime?
+  createdAt      DateTime              @default(now())
+  updatedAt      DateTime              @updatedAt
+  versions       ModelVersionSaleItem[]
+
+  @@index([userId, startsAt])
+}
+
+model ModelVersionSaleItem {
+  saleId         Int
+  modelVersionId Int
+  sale           ModelVersionSale @relation(fields: [saleId], references: [id], onDelete: Cascade)
+
+  @@id([saleId, modelVersionId])
+  @@index([modelVersionId])
+}
+
 enum EntityCollaboratorStatus {
   Pending
   Approved

--- a/packages/civitai-db-schema/src/enums.ts
+++ b/packages/civitai-db-schema/src/enums.ts
@@ -791,6 +791,13 @@ export const PaidAccessEntityType = {
 
 export type PaidAccessEntityType = (typeof PaidAccessEntityType)[keyof typeof PaidAccessEntityType];
 
+export const SaleDiscountType = {
+  Fixed: 'Fixed',
+  Percent: 'Percent',
+} as const;
+
+export type SaleDiscountType = (typeof SaleDiscountType)[keyof typeof SaleDiscountType];
+
 export const EntityCollaboratorStatus = {
   Pending: 'Pending',
   Approved: 'Approved',

--- a/packages/civitai-db-schema/src/kysely/enums.ts
+++ b/packages/civitai-db-schema/src/kysely/enums.ts
@@ -646,6 +646,11 @@ export const PaidAccessEntityType = {
   ComicChapter: 'ComicChapter',
 } as const;
 export type PaidAccessEntityType = (typeof PaidAccessEntityType)[keyof typeof PaidAccessEntityType];
+export const SaleDiscountType = {
+  Fixed: 'Fixed',
+  Percent: 'Percent',
+} as const;
+export type SaleDiscountType = (typeof SaleDiscountType)[keyof typeof SaleDiscountType];
 export const EntityCollaboratorStatus = {
   Pending: 'Pending',
   Approved: 'Approved',

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -86,6 +86,7 @@ import type {
   CsamReportType,
   Availability,
   PaidAccessEntityType,
+  SaleDiscountType,
   EntityCollaboratorStatus,
   ClubAdminPermission,
   ChatMemberStatus,
@@ -2934,6 +2935,22 @@ export type ModelVersionMonetization = {
   currency: Generated<Currency>;
   unitAmount: number | null;
 };
+export type ModelVersionSale = {
+  id: Generated<number>;
+  userId: number;
+  name: string | null;
+  discountType: SaleDiscountType;
+  discountAmount: number;
+  startsAt: Timestamp;
+  endsAt: Timestamp;
+  canceledAt: Timestamp | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Timestamp;
+};
+export type ModelVersionSaleItem = {
+  saleId: number;
+  modelVersionId: number;
+};
 export type ModelVersionSponsorshipSettings = {
   id: Generated<number>;
   modelVersionMonetizationId: number;
@@ -4446,6 +4463,8 @@ export type DB = {
   ModelVersionExploration: ModelVersionExploration;
   ModelVersionMetric: ModelVersionMetric;
   ModelVersionMonetization: ModelVersionMonetization;
+  ModelVersionSale: ModelVersionSale;
+  ModelVersionSaleItem: ModelVersionSaleItem;
   ModelVersionSponsorshipSettings: ModelVersionSponsorshipSettings;
   ModerationRule: ModerationRule;
   NewOrderPlayer: NewOrderPlayer;

--- a/packages/civitai-db-schema/src/kysely/updated-at-tables.ts
+++ b/packages/civitai-db-schema/src/kysely/updated-at-tables.ts
@@ -55,6 +55,7 @@ export const UPDATED_AT_TABLES = new Set<keyof DB>([
   'Model3D',
   'Model3DReview',
   'ModelVersion',
+  'ModelVersionSale',
   'ModerationRule',
   'NewOrderRank',
   'OauthClient',

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -162,6 +162,8 @@ export type Availability = "Public" | "Unsearchable" | "Private" | "EarlyAccess"
 
 export type PaidAccessEntityType = "ModelVersion" | "ComicChapter";
 
+export type SaleDiscountType = "Fixed" | "Percent";
+
 export type EntityCollaboratorStatus = "Pending" | "Approved" | "Rejected";
 
 export type ClubAdminPermission = "ManageMemberships" | "ManageTiers" | "ManagePosts" | "ManageClub" | "ManageResources" | "ViewRevenue" | "WithdrawRevenue";
@@ -3285,6 +3287,26 @@ export interface PaidAccess {
   terms: JsonValue;
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface ModelVersionSale {
+  id: number;
+  userId: number;
+  name: string | null;
+  discountType: SaleDiscountType;
+  discountAmount: number;
+  startsAt: Date;
+  endsAt: Date;
+  canceledAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  versions?: ModelVersionSaleItem[];
+}
+
+export interface ModelVersionSaleItem {
+  saleId: number;
+  modelVersionId: number;
+  sale?: ModelVersionSale;
 }
 
 export interface EntityCollaborator {

--- a/packages/civitai-db/src/kysely.ts
+++ b/packages/civitai-db/src/kysely.ts
@@ -27,6 +27,14 @@ function registerNumericTypeParsers() {
   if (numericParsersRegistered) return;
   types.setTypeParser(types.builtins.NUMERIC, (val) => parseFloat(val));
   types.setTypeParser(types.builtins.INT8, (val) => parseFloat(val));
+  // TIMESTAMP (oid 1114) is `timestamp without time zone`, which pg's default parser reads as LOCAL
+  // time. db-helpers.ts registers a UTC parser for the same oid, so the main app and any Kysely app
+  // read the SAME COLUMN hours apart — which is how a scheduled sale twice appeared to start in the
+  // future to one app and in the past to the other. These columns are written as UTC instants; read
+  // them that way everywhere.
+  // Byte-identical to db-helpers.ts's parser on purpose: two near-copies of a date transform is how
+  // the two apps disagreed in the first place.
+  types.setTypeParser(types.builtins.TIMESTAMP, (val) => new Date(val.replace(' ', 'T') + 'Z'));
   numericParsersRegistered = true;
 }
 

--- a/src/__tests__/pages/api/v1/model-versions/mini-download-url-file-match.test.ts
+++ b/src/__tests__/pages/api/v1/model-versions/mini-download-url-file-match.test.ts
@@ -59,6 +59,7 @@ vi.mock('~/server/services/model.service', () => ({
 
 vi.mock('~/server/services/paid-access.service', () => ({
   getCapTiers: mockGetCapTiers,
+  bustModelSaleCache: vi.fn(),
 }));
 
 // MixedAuthEndpoint resolves the (optional) session and passes it as the 3rd

--- a/src/components/Cards/ModelCard.tsx
+++ b/src/components/Cards/ModelCard.tsx
@@ -22,8 +22,8 @@ import {
 import cardClasses from '~/components/Cards/Cards.module.css';
 import HoverActionButton from '~/components/Cards/components/HoverActionButton';
 import { RemixButton } from '~/components/Cards/components/RemixButton';
-import { useModelCardContext } from '~/components/Cards/ModelCardContext';
-import { saleDiscountLabel } from '~/components/Model/ModelVersions/ModelVersionSaleBadge';
+import { useModelCardContext, useModelSaleBadge } from '~/components/Cards/ModelCardContext';
+import { SaleDiscountLabel } from '~/components/Model/ModelVersions/ModelVersionSaleBadge';
 import { ModelCardContextMenu } from '~/components/Cards/ModelCardContextMenu';
 import { getCardBaseModels } from '~/components/Cards/model-card.utils';
 import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
@@ -101,7 +101,10 @@ function ModelCardContent({ data }: Props) {
   const { useModelVersionRedirect, activeBaseModels, salesByModelId } = useModelCardContext();
   // Absent until the batched lookup lands, so the badge appears a beat after the card — deliberate: a
   // sale is worth an extra request, not a slower feed.
-  const sale = salesByModelId?.[data.id];
+  // The feed passes a map down; every other surface (home blocks, collections, related models, search)
+  // asks for its own, which tRPC batches into one request per render burst.
+  const ownSale = useModelSaleBadge(data.id, !!salesByModelId);
+  const sale = salesByModelId?.[data.id] ?? ownSale;
   const cardBaseModels = getCardBaseModels(
     data as Parameters<typeof getCardBaseModels>[0],
     activeBaseModels
@@ -169,8 +172,8 @@ function ModelCardContent({ data }: Props) {
 
             {sale && (
               <Badge className={cardClasses.chip} variant="filled" radius="xl" color="green">
-                <Text c="white" size="xs">
-                  {saleDiscountLabel(sale)}
+                <Text c="white" size="xs" tt="capitalize">
+                  <SaleDiscountLabel sale={sale} />
                 </Text>
               </Badge>
             )}

--- a/src/components/Cards/ModelCard.tsx
+++ b/src/components/Cards/ModelCard.tsx
@@ -23,6 +23,7 @@ import cardClasses from '~/components/Cards/Cards.module.css';
 import HoverActionButton from '~/components/Cards/components/HoverActionButton';
 import { RemixButton } from '~/components/Cards/components/RemixButton';
 import { useModelCardContext } from '~/components/Cards/ModelCardContext';
+import { saleDiscountLabel } from '~/components/Model/ModelVersions/ModelVersionSaleBadge';
 import { ModelCardContextMenu } from '~/components/Cards/ModelCardContextMenu';
 import { getCardBaseModels } from '~/components/Cards/model-card.utils';
 import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
@@ -100,7 +101,7 @@ function ModelCardContent({ data }: Props) {
   const { useModelVersionRedirect, activeBaseModels, salesByModelId } = useModelCardContext();
   // Absent until the batched lookup lands, so the badge appears a beat after the card — deliberate: a
   // sale is worth an extra request, not a slower feed.
-  const onSale = !!salesByModelId?.[data.id];
+  const sale = salesByModelId?.[data.id];
   const cardBaseModels = getCardBaseModels(
     data as Parameters<typeof getCardBaseModels>[0],
     activeBaseModels
@@ -166,10 +167,10 @@ function ModelCardContent({ data }: Props) {
               baseModels={cardBaseModels}
             />
 
-            {onSale && (
+            {sale && (
               <Badge className={cardClasses.chip} variant="filled" radius="xl" color="green">
-                <Text c="white" size="xs" tt="capitalize">
-                  On sale
+                <Text c="white" size="xs">
+                  {saleDiscountLabel(sale)}
                 </Text>
               </Badge>
             )}

--- a/src/components/Cards/ModelCard.tsx
+++ b/src/components/Cards/ModelCard.tsx
@@ -98,12 +98,15 @@ function ModelCardContent({ data }: Props) {
     [isEarlyAccess, isUpdated, theme, colorScheme]
   );
 
-  const { useModelVersionRedirect, activeBaseModels, salesByModelId } = useModelCardContext();
+  const { useModelVersionRedirect, activeBaseModels, salesByModelId, hasSaleProvider } =
+    useModelCardContext();
   // Absent until the batched lookup lands, so the badge appears a beat after the card — deliberate: a
   // sale is worth an extra request, not a slower feed.
-  // The feed passes a map down; every other surface (home blocks, collections, related models, search)
-  // asks for its own, which tRPC batches into one request per render burst.
-  const ownSale = useModelSaleBadge(data.id, !!salesByModelId);
+  // The feed passes a map down; surfaces that cannot ask for their own. `hasSaleProvider` is set by the
+  // provider itself, so a card does not fire its own query during the render before the map resolves —
+  // reading `!!salesByModelId` fired every card once on first paint and the requests were already gone
+  // by the time the flag flipped.
+  const ownSale = useModelSaleBadge(data.id, !!hasSaleProvider);
   const sale = salesByModelId?.[data.id] ?? ownSale;
   const cardBaseModels = getCardBaseModels(
     data as Parameters<typeof getCardBaseModels>[0],

--- a/src/components/Cards/ModelCard.tsx
+++ b/src/components/Cards/ModelCard.tsx
@@ -97,7 +97,10 @@ function ModelCardContent({ data }: Props) {
     [isEarlyAccess, isUpdated, theme, colorScheme]
   );
 
-  const { useModelVersionRedirect, activeBaseModels } = useModelCardContext();
+  const { useModelVersionRedirect, activeBaseModels, salesByModelId } = useModelCardContext();
+  // Absent until the batched lookup lands, so the badge appears a beat after the card — deliberate: a
+  // sale is worth an extra request, not a slower feed.
+  const onSale = !!salesByModelId?.[data.id];
   const cardBaseModels = getCardBaseModels(
     data as Parameters<typeof getCardBaseModels>[0],
     activeBaseModels
@@ -162,6 +165,14 @@ function ModelCardContent({ data }: Props) {
               baseModel={data.version.baseModel}
               baseModels={cardBaseModels}
             />
+
+            {onSale && (
+              <Badge className={cardClasses.chip} variant="filled" radius="xl" color="green">
+                <Text c="white" size="xs" tt="capitalize">
+                  On sale
+                </Text>
+              </Badge>
+            )}
 
             {(isNew || isUpdated || isEarlyAccess) && (
               <Badge

--- a/src/components/Cards/ModelCardContext.tsx
+++ b/src/components/Cards/ModelCardContext.tsx
@@ -24,6 +24,21 @@ export const useModelCardContext = () => {
  * query is a hot path and a sale is time-varying, so indexing it would mean re-indexing at every window
  * edge. Same shape as how cosmetics and version images are already fetched after the fact.
  */
+/**
+ * The sale for ONE model, for a card rendered outside any provider — home blocks, collections, related
+ * models, search results. tRPC batches concurrent queries into a single HTTP request, so a grid of cards
+ * still costs one round trip, and the per-model result is cached by react-query for the whole page.
+ *
+ * A container that already has the map (the main feed) passes it down instead, and this stays disabled.
+ */
+export const useModelSaleBadge = (modelId: number, skip: boolean) => {
+  const { data } = trpc.model.getActiveSales.useQuery(
+    { ids: [modelId] },
+    { enabled: !skip, staleTime: 60_000 }
+  );
+  return data?.[modelId];
+};
+
 export const useModelSaleBadges = (modelIds: number[]) => {
   const ids = useMemo(() => [...new Set(modelIds)].sort((a, b) => a - b), [modelIds]);
   const { data } = trpc.model.getActiveSales.useQuery(

--- a/src/components/Cards/ModelCardContext.tsx
+++ b/src/components/Cards/ModelCardContext.tsx
@@ -5,8 +5,11 @@ import { trpc } from '~/utils/trpc';
 type Context = {
   useModelVersionRedirect?: boolean;
   activeBaseModels?: string[];
-  /** modelId -> when its running sale ends. Absent means no sale. */
-  salesByModelId?: Record<number, { endsAt: Date }>;
+  /** modelId -> its running sale. Absent means no sale. */
+  salesByModelId?: Record<
+    number,
+    { endsAt: Date; discountType: 'Fixed' | 'Percent'; discountAmount: number }
+  >;
 };
 
 const ModelCardContext = createContext<Context | null>(null);

--- a/src/components/Cards/ModelCardContext.tsx
+++ b/src/components/Cards/ModelCardContext.tsx
@@ -5,6 +5,8 @@ import { trpc } from '~/utils/trpc';
 type Context = {
   useModelVersionRedirect?: boolean;
   activeBaseModels?: string[];
+  /** Set by a container that supplies the map, so cards do not each fetch their own. */
+  hasSaleProvider?: boolean;
   /** modelId -> its running sale. Absent means no sale. */
   salesByModelId?: Record<
     number,
@@ -26,10 +28,12 @@ export const useModelCardContext = () => {
  */
 /**
  * The sale for ONE model, for a card rendered outside any provider — home blocks, collections, related
- * models, search results. tRPC batches concurrent queries into a single HTTP request, so a grid of cards
- * still costs one round trip, and the per-model result is cached by react-query for the whole page.
+ * models, search results.
  *
- * A container that already has the map (the main feed) passes it down instead, and this stays disabled.
+ * ⚠️ This is one request PER CARD. tRPC only batches for an authenticated browser (see shouldBatch in
+ * utils/trpc.ts), so an anonymous grid issues one XHR each, and even when batched the URL cap fits about
+ * 24 ops. A container that can supply the map should pass `salesByModelId` and skip this entirely —
+ * that is why the skip flag is "a provider owns this", not "the provider's data has arrived".
  */
 export const useModelSaleBadge = (modelId: number, skip: boolean) => {
   const { data } = trpc.model.getActiveSales.useQuery(
@@ -53,10 +57,11 @@ export const ModelCardContextProvider = ({
   useModelVersionRedirect,
   activeBaseModels,
   salesByModelId,
+  hasSaleProvider,
 }: Context & { children: ReactNode }) => {
   const value = useMemo(
-    () => ({ useModelVersionRedirect, activeBaseModels, salesByModelId }),
-    [useModelVersionRedirect, activeBaseModels, salesByModelId]
+    () => ({ useModelVersionRedirect, activeBaseModels, salesByModelId, hasSaleProvider }),
+    [useModelVersionRedirect, activeBaseModels, salesByModelId, hasSaleProvider]
   );
   return <ModelCardContext.Provider value={value}>{children}</ModelCardContext.Provider>;
 };

--- a/src/components/Cards/ModelCardContext.tsx
+++ b/src/components/Cards/ModelCardContext.tsx
@@ -1,9 +1,12 @@
 import type { ReactNode } from 'react';
 import { createContext, useContext, useMemo } from 'react';
+import { trpc } from '~/utils/trpc';
 
 type Context = {
   useModelVersionRedirect?: boolean;
   activeBaseModels?: string[];
+  /** modelId -> when its running sale ends. Absent means no sale. */
+  salesByModelId?: Record<number, { endsAt: Date }>;
 };
 
 const ModelCardContext = createContext<Context | null>(null);
@@ -12,14 +15,30 @@ export const useModelCardContext = () => {
   const context = useContext(ModelCardContext);
   return context ?? {};
 };
+
+/**
+ * One lookup per page of cards, not one per card, and deliberately not part of the model query: the feed
+ * query is a hot path and a sale is time-varying, so indexing it would mean re-indexing at every window
+ * edge. Same shape as how cosmetics and version images are already fetched after the fact.
+ */
+export const useModelSaleBadges = (modelIds: number[]) => {
+  const ids = useMemo(() => [...new Set(modelIds)].sort((a, b) => a - b), [modelIds]);
+  const { data } = trpc.model.getActiveSales.useQuery(
+    { ids },
+    { enabled: ids.length > 0, staleTime: 60_000, placeholderData: (prev) => prev }
+  );
+  return data;
+};
+
 export const ModelCardContextProvider = ({
   children,
   useModelVersionRedirect,
   activeBaseModels,
+  salesByModelId,
 }: Context & { children: ReactNode }) => {
   const value = useMemo(
-    () => ({ useModelVersionRedirect, activeBaseModels }),
-    [useModelVersionRedirect, activeBaseModels]
+    () => ({ useModelVersionRedirect, activeBaseModels, salesByModelId }),
+    [useModelVersionRedirect, activeBaseModels, salesByModelId]
   );
   return <ModelCardContext.Provider value={value}>{children}</ModelCardContext.Provider>;
 };

--- a/src/components/Model/Infinite/ModelsInfinite.tsx
+++ b/src/components/Model/Infinite/ModelsInfinite.tsx
@@ -56,6 +56,7 @@ export function ModelsInfinite({
       useModelVersionRedirect={(filters?.baseModels ?? []).length > 0}
       activeBaseModels={filters?.baseModels}
       salesByModelId={salesByModelId}
+      hasSaleProvider
     >
       {!models.length && isFetching ? (
         <Center p="xl">

--- a/src/components/Model/Infinite/ModelsInfinite.tsx
+++ b/src/components/Model/Infinite/ModelsInfinite.tsx
@@ -4,7 +4,7 @@ import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { useRef } from 'react';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { ModelCard } from '~/components/Cards/ModelCard';
-import { ModelCardContextProvider } from '~/components/Cards/ModelCardContext';
+import { ModelCardContextProvider, useModelSaleBadges } from '~/components/Cards/ModelCardContext';
 import { EndOfFeed } from '~/components/EndOfFeed/EndOfFeed';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { MasonryGridVirtual } from '~/components/MasonryColumns/MasonryGridVirtual';
@@ -49,11 +49,13 @@ export function ModelsInfinite({
     ...filters,
     browsingLevel,
   });
+  const salesByModelId = useModelSaleBadges(models.map((m) => m.id));
 
   return (
     <ModelCardContextProvider
       useModelVersionRedirect={(filters?.baseModels ?? []).length > 0}
       activeBaseModels={filters?.baseModels}
+      salesByModelId={salesByModelId}
     >
       {!models.length && isFetching ? (
         <Center p="xl">

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -290,6 +290,11 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
   // Owners see it too, worded differently: they are quoted their stored price, but their own live sale
   // should not be invisible on their own model page.
   const saleForViewer = version?.paidAccess?.sale ?? null;
+  // What the PAGE shows. `paidAccess.terms` stays the stored value because the version edit form
+  // initialises from it and would otherwise save a discounted price back over the creator's own — the
+  // same reason the tier cap is never folded into it. That rule protects an editor, not a button: an
+  // owner reading their own model page should see the price a buyer is quoted, like everyone else.
+  const displayTerms = saleForViewer?.buyerTerms ?? paidAccessTerms;
   const isDraft = version?.status === ModelStatus.Draft;
 
   // const shouldOmit = [1562709, 1672021, 1669468].includes(model.id) && !user?.isModerator;
@@ -555,13 +560,13 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
           onSelectFileId={setSelectedFileId}
           canDownload={canDownload}
           downloadPrice={
-            !hasDownloadPermissions && !isLoadingAccess && paidAccessTerms?.download
-              ? paidAccessTerms.download.price
+            !hasDownloadPermissions && !isLoadingAccess && displayTerms?.download
+              ? displayTerms.download.price
               : undefined
           }
           listedPrice={
-            hasDownloadPermissions && isOwnerOrMod && paidAccessTerms?.download
-              ? paidAccessTerms.download.price
+            hasDownloadPermissions && isOwnerOrMod && displayTerms?.download
+              ? displayTerms.download.price
               : undefined
           }
           isLoadingAccess={isLoadingAccess}
@@ -728,13 +733,13 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                       data-activity="create:model"
                       disabled={isLoadingAccess || !!model.mode}
                       generationPrice={
-                        generationRequiresPurchase && !isLoadingAccess && paidAccessTerms
-                          ? generationPrice(paidAccessTerms)
+                        generationRequiresPurchase && !isLoadingAccess && displayTerms
+                          ? generationPrice(displayTerms)
                           : undefined
                       }
                       listedPrice={
-                        !generationRequiresPurchase && isOwnerOrMod && paidAccessTerms
-                          ? generationPrice(paidAccessTerms) || undefined
+                        !generationRequiresPurchase && isOwnerOrMod && displayTerms
+                          ? generationPrice(displayTerms) || undefined
                           : undefined
                       }
                       onPurchase={() => onPurchase('generation')}

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -287,9 +287,9 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
   const paidAccessEndsAt = version?.paidAccess?.endsAt;
   const isEarlyAccess = !!paidAccessEndsAt && paidAccessEndsAt > new Date();
   const paidAccessTerms = version?.paidAccess?.terms as ModelVersionTerms | undefined;
-  // Only shown to someone who is actually quoted the sale price: the server reports no sale to an
-  // owner or moderator, who are shown the stored terms their editors write back.
-  const saleForViewer = !hasDownloadPermissions ? version?.paidAccess?.sale : null;
+  // Owners see it too, worded differently: they are quoted their stored price, but their own live sale
+  // should not be invisible on their own model page.
+  const saleForViewer = version?.paidAccess?.sale ?? null;
   const isDraft = version?.status === ModelStatus.Draft;
 
   // const shouldOmit = [1562709, 1672021, 1669468].includes(model.id) && !user?.isModerator;
@@ -547,7 +547,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
       </Card.Section>
       {saleForViewer ? (
         <Card.Section className="px-4 pt-2">
-          <ModelVersionSaleBadge sale={saleForViewer} />
+          <ModelVersionSaleBadge sale={saleForViewer} isOwner={isOwnerOrMod} />
         </Card.Section>
       ) : null}
       <Card.Section>

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -97,6 +97,7 @@ import {
 } from '~/components/Model/ModelVersions/model-version.utils';
 import { getModelVersionActionLayout } from '~/components/Model/ModelVersions/model-version-layout';
 import ModelVersionDonationGoal from '~/components/Model/ModelVersions/ModelVersionDonationGoal';
+import { ModelVersionSaleBadge } from '~/components/Model/ModelVersions/ModelVersionSaleBadge';
 import { ModelVersionEarlyAccessPurchase } from '~/components/Model/ModelVersions/ModelVersionEarlyAccessPurchase';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { PermissionIndicator } from '~/components/PermissionIndicator/PermissionIndicator';
@@ -286,6 +287,9 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
   const paidAccessEndsAt = version?.paidAccess?.endsAt;
   const isEarlyAccess = !!paidAccessEndsAt && paidAccessEndsAt > new Date();
   const paidAccessTerms = version?.paidAccess?.terms as ModelVersionTerms | undefined;
+  // Only shown to someone who is actually quoted the sale price: the server reports no sale to an
+  // owner or moderator, who are shown the stored terms their editors write back.
+  const saleForViewer = !hasDownloadPermissions ? version?.paidAccess?.sale : null;
   const isDraft = version?.status === ModelStatus.Draft;
 
   // const shouldOmit = [1562709, 1672021, 1669468].includes(model.id) && !user?.isModerator;
@@ -541,6 +545,11 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
           </Group>
         </Group>
       </Card.Section>
+      {saleForViewer ? (
+        <Card.Section className="px-4 pt-2">
+          <ModelVersionSaleBadge sale={saleForViewer} />
+        </Card.Section>
+      ) : null}
       <Card.Section>
         <DownloadVariantDropdown
           files={filesVisible}

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -696,7 +696,11 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                   </Group>
                 </Stack>
               )}
-              <ModelVersionSaleBanner sale={saleForViewer} isOwner={isOwnerOrMod} />
+              <ModelVersionSaleBanner
+                sale={saleForViewer}
+                isOwner={isOwner}
+                isModerator={!!user?.isModerator}
+              />
               {downloadSection}
             </Stack>
           ) : (
@@ -969,7 +973,11 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                 </AlertWithIcon>
               )}
               {/* Download Section */}
-              <ModelVersionSaleBanner sale={saleForViewer} isOwner={isOwnerOrMod} />
+              <ModelVersionSaleBanner
+                sale={saleForViewer}
+                isOwner={isOwner}
+                isModerator={!!user?.isModerator}
+              />
               {downloadSection}
             </Stack>
           )}

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -97,7 +97,7 @@ import {
 } from '~/components/Model/ModelVersions/model-version.utils';
 import { getModelVersionActionLayout } from '~/components/Model/ModelVersions/model-version-layout';
 import ModelVersionDonationGoal from '~/components/Model/ModelVersions/ModelVersionDonationGoal';
-import { ModelVersionSaleBadge } from '~/components/Model/ModelVersions/ModelVersionSaleBadge';
+import { ModelVersionSaleBanner } from '~/components/Model/ModelVersions/ModelVersionSaleBadge';
 import { ModelVersionEarlyAccessPurchase } from '~/components/Model/ModelVersions/ModelVersionEarlyAccessPurchase';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { PermissionIndicator } from '~/components/PermissionIndicator/PermissionIndicator';
@@ -545,11 +545,6 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
           </Group>
         </Group>
       </Card.Section>
-      {saleForViewer ? (
-        <Card.Section className="px-4 pt-2">
-          <ModelVersionSaleBadge sale={saleForViewer} isOwner={isOwnerOrMod} />
-        </Card.Section>
-      ) : null}
       <Card.Section>
         <DownloadVariantDropdown
           files={filesVisible}
@@ -701,6 +696,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                   </Group>
                 </Stack>
               )}
+              <ModelVersionSaleBanner sale={saleForViewer} isOwner={isOwnerOrMod} />
               {downloadSection}
             </Stack>
           ) : (
@@ -973,6 +969,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                 </AlertWithIcon>
               )}
               {/* Download Section */}
+              <ModelVersionSaleBanner sale={saleForViewer} isOwner={isOwnerOrMod} />
               {downloadSection}
             </Stack>
           )}

--- a/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
@@ -4,20 +4,41 @@ import clsx from 'clsx';
 import type { ModelVersionTerms } from '@civitai/buzz';
 import { formatDate } from '~/utils/date-helpers';
 
+export type SaleDisplay = {
+  listTerms: ModelVersionTerms;
+  endsAt: Date | string;
+  discountType: 'Fixed' | 'Percent';
+  discountAmount: number;
+};
+
+/** "25% off" / "300 Buzz off" — the discount as the creator set it, not a figure derived on the client. */
+export const saleDiscountLabel = (sale: {
+  discountType: 'Fixed' | 'Percent';
+  discountAmount: number;
+}) =>
+  sale.discountType === 'Percent'
+    ? `${sale.discountAmount}% off`
+    : `${sale.discountAmount.toLocaleString()} Buzz off`;
+
 /**
- * The strikethrough is drawn from `sale.listTerms`, which the server sends alongside the already-
- * discounted `terms`. Recomputing it on the client would be a second implementation of the discount,
- * and the two would be free to disagree about the price the buyer is about to be charged.
+ * The struck-through price comes from `sale.listTerms`, which the server sends beside the already
+ * discounted `terms`. Recomputing it here would be a second implementation of the discount, free to
+ * disagree with the one that charges.
+ *
+ * `isOwner` only changes the wording: an owner is quoted their stored price, so "your sale" reads
+ * correctly where "on sale" would imply they are being charged it.
  */
 export function ModelVersionSaleBadge({
   sale,
+  isOwner,
   className,
 }: {
-  sale: { listTerms: ModelVersionTerms; endsAt: Date | string } | null | undefined;
+  sale: SaleDisplay | null | undefined;
+  isOwner?: boolean;
   className?: string;
 }) {
   const listPrice = sale?.listTerms.download?.price;
-  if (!sale || listPrice == null) return null;
+  if (!sale) return null;
 
   const endsAt = new Date(sale.endsAt);
 
@@ -26,10 +47,15 @@ export function ModelVersionSaleBadge({
       <Group gap={6} wrap="nowrap" className={clsx('items-center', className)}>
         <IconTag size={16} className="text-green-6" />
         <Text size="xs" fw={600} className="text-green-6">
-          On sale
+          {isOwner ? `Your sale — ${saleDiscountLabel(sale)}` : saleDiscountLabel(sale)}
         </Text>
-        <Text size="xs" c="dimmed" td="line-through">
-          {listPrice.toLocaleString()} Buzz
+        {listPrice != null && !isOwner && (
+          <Text size="xs" c="dimmed" td="line-through">
+            {listPrice.toLocaleString()} Buzz
+          </Text>
+        )}
+        <Text size="xs" c="dimmed">
+          until {formatDate(endsAt, 'MMM D')}
         </Text>
       </Group>
     </Tooltip>

--- a/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
@@ -110,11 +110,10 @@ export function ModelVersionSaleBanner({
   if (!sale) return null;
 
   const listPrice = sale.listTerms.download?.price;
-  const buyerPrice = sale.buyerTerms.download?.price;
   const endsAt = new Date(sale.endsAt);
-  // Owner and moderator are both quoted the STORED price everywhere else on the page, so instead of a
-  // strikethrough over a number that is not moving, they are told what a BUYER pays. Without that, the
-  // banner announces a discount whose actual price appears nowhere — which is how Justin read it.
+  // The page now shows the sale price to everyone, owner included, so the strikethrough beside it would
+  // repeat what this line already says. An owner instead gets the number that vanished from the page:
+  // their own list price, which is what the sale is discounting FROM.
   const quotedStoredPrice = isOwner || isModerator;
 
   return (
@@ -128,14 +127,8 @@ export function ModelVersionSaleBanner({
               <SaleDiscountLabel sale={sale} size="sm" />
             </Text>
             <Text size="xs" c="dimmed">
-              {quotedStoredPrice && buyerPrice != null && listPrice != null && (
-                <>
-                  Buyers pay{' '}
-                  <Text span fw={600} c="green.7">
-                    {buyerPrice.toLocaleString()}
-                  </Text>{' '}
-                  instead of {listPrice.toLocaleString()} Buzz ·{' '}
-                </>
+              {quotedStoredPrice && listPrice != null && (
+                <>Your list price is {listPrice.toLocaleString()} Buzz · </>
               )}
               Ends {formatDate(endsAt, 'MMM D, YYYY h:mm A')}
               {isOwner && (

--- a/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
@@ -1,9 +1,10 @@
-import { Card, Group, Text, Tooltip } from '@mantine/core';
+import { Anchor, Card, Group, Text, Tooltip } from '@mantine/core';
 import { IconTag } from '@tabler/icons-react';
 import clsx from 'clsx';
 import type { ModelVersionTerms } from '@civitai/buzz';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { Currency } from '~/shared/utils/prisma/enums';
+import { CREATOR_STUDIO_URL } from '~/shared/constants/creator-studio.constants';
 import { formatDate } from '~/utils/date-helpers';
 
 export type SaleDisplay = {
@@ -98,14 +99,20 @@ export function ModelVersionSaleBadge({
 export function ModelVersionSaleBanner({
   sale,
   isOwner,
+  isModerator,
 }: {
   sale: SaleDisplay | null | undefined;
+  /** True ownership only. A moderator is not the seller and must not be told "your sale". */
   isOwner?: boolean;
+  isModerator?: boolean;
 }) {
   if (!sale) return null;
 
   const listPrice = sale.listTerms.download?.price;
   const endsAt = new Date(sale.endsAt);
+  // Owner and moderator are both quoted the STORED price, so neither gets a strikethrough — striking
+  // through the same number the page already shows reads as a rendering fault, not a discount.
+  const quotedStoredPrice = isOwner || isModerator;
 
   return (
     <Card withBorder p="sm" className="border-green-6 bg-green-0 dark:bg-green-9/20">
@@ -114,16 +121,28 @@ export function ModelVersionSaleBanner({
           <IconTag size={20} className="text-green-7 dark:text-green-4" />
           <div>
             <Text size="sm" fw={700} className="text-green-7 dark:text-green-4">
-              {isOwner ? 'Your sale is running' : 'On sale'} —{' '}
+              {isOwner ? 'Your sale is running' : isModerator ? 'Sale running' : 'On sale'} —{' '}
               <SaleDiscountLabel sale={sale} size="sm" />
             </Text>
             <Text size="xs" c="dimmed">
-              {isOwner ? 'Ends ' : 'Ends '}
-              {formatDate(endsAt, 'MMM D, YYYY h:mm A')}
+              Ends {formatDate(endsAt, 'MMM D, YYYY h:mm A')}
+              {isOwner && (
+                <>
+                  {' · '}
+                  <Anchor
+                    href={`${CREATOR_STUDIO_URL}/sales`}
+                    target="_blank"
+                    rel="noreferrer"
+                    inherit
+                  >
+                    Manage in Creator Studio
+                  </Anchor>
+                </>
+              )}
             </Text>
           </div>
         </Group>
-        {!isOwner && listPrice != null && (
+        {!quotedStoredPrice && listPrice != null && (
           <Text size="sm" c="dimmed" td="line-through" className="whitespace-nowrap">
             {listPrice.toLocaleString()} Buzz
           </Text>

--- a/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
@@ -1,4 +1,4 @@
-import { Group, Text, Tooltip } from '@mantine/core';
+import { Card, Group, Text, Tooltip } from '@mantine/core';
 import { IconTag } from '@tabler/icons-react';
 import clsx from 'clsx';
 import type { ModelVersionTerms } from '@civitai/buzz';
@@ -88,5 +88,47 @@ export function ModelVersionSaleBadge({
         </Text>
       </Group>
     </Tooltip>
+  );
+}
+
+/**
+ * The prominent form, for the model page: a sale is a reason to act now, so it sits above the download
+ * card rather than inside it, where it read as one more line of card furniture.
+ */
+export function ModelVersionSaleBanner({
+  sale,
+  isOwner,
+}: {
+  sale: SaleDisplay | null | undefined;
+  isOwner?: boolean;
+}) {
+  if (!sale) return null;
+
+  const listPrice = sale.listTerms.download?.price;
+  const endsAt = new Date(sale.endsAt);
+
+  return (
+    <Card withBorder p="sm" className="border-green-6 bg-green-0 dark:bg-green-9/20">
+      <Group gap="xs" wrap="nowrap" justify="space-between">
+        <Group gap={8} wrap="nowrap">
+          <IconTag size={20} className="text-green-7 dark:text-green-4" />
+          <div>
+            <Text size="sm" fw={700} className="text-green-7 dark:text-green-4">
+              {isOwner ? 'Your sale is running' : 'On sale'} —{' '}
+              <SaleDiscountLabel sale={sale} size="sm" />
+            </Text>
+            <Text size="xs" c="dimmed">
+              {isOwner ? 'Ends ' : 'Ends '}
+              {formatDate(endsAt, 'MMM D, YYYY h:mm A')}
+            </Text>
+          </div>
+        </Group>
+        {!isOwner && listPrice != null && (
+          <Text size="sm" c="dimmed" td="line-through" className="whitespace-nowrap">
+            {listPrice.toLocaleString()} Buzz
+          </Text>
+        )}
+      </Group>
+    </Card>
   );
 }

--- a/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
@@ -2,6 +2,8 @@ import { Group, Text, Tooltip } from '@mantine/core';
 import { IconTag } from '@tabler/icons-react';
 import clsx from 'clsx';
 import type { ModelVersionTerms } from '@civitai/buzz';
+import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
+import { Currency } from '~/shared/utils/prisma/enums';
 import { formatDate } from '~/utils/date-helpers';
 
 export type SaleDisplay = {
@@ -11,8 +13,29 @@ export type SaleDisplay = {
   discountAmount: number;
 };
 
-/** "25% off" / "300 Buzz off" — the discount as the creator set it, not a figure derived on the client. */
-export const saleDiscountLabel = (sale: {
+/**
+ * The discount as the creator set it, never derived on the client. A fixed discount is rendered as the
+ * Buzz bolt plus the number rather than the word "Buzz", which is how currency reads everywhere else and
+ * keeps the chip short enough to sit beside Early Access and New.
+ */
+export function SaleDiscountLabel({
+  sale,
+  size = 'xs',
+}: {
+  sale: { discountType: 'Fixed' | 'Percent'; discountAmount: number };
+  size?: 'xs' | 'sm';
+}) {
+  if (sale.discountType === 'Percent') return <>{sale.discountAmount}% off</>;
+  return (
+    <span className="inline-flex items-center gap-0.5">
+      <CurrencyIcon currency={Currency.BUZZ} size={size === 'xs' ? 12 : 14} stroke={2.5} />
+      {sale.discountAmount.toLocaleString()} off
+    </span>
+  );
+}
+
+/** Plain-text form, for a tooltip or an aria-label where a component cannot go. */
+export const saleDiscountText = (sale: {
   discountType: 'Fixed' | 'Percent';
   discountAmount: number;
 }) =>
@@ -47,7 +70,13 @@ export function ModelVersionSaleBadge({
       <Group gap={6} wrap="nowrap" className={clsx('items-center', className)}>
         <IconTag size={16} className="text-green-6" />
         <Text size="xs" fw={600} className="text-green-6">
-          {isOwner ? `Your sale — ${saleDiscountLabel(sale)}` : saleDiscountLabel(sale)}
+          {isOwner ? (
+            <>
+              Your sale — <SaleDiscountLabel sale={sale} />
+            </>
+          ) : (
+            <SaleDiscountLabel sale={sale} />
+          )}
         </Text>
         {listPrice != null && !isOwner && (
           <Text size="xs" c="dimmed" td="line-through">

--- a/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
@@ -36,63 +36,6 @@ export function SaleDiscountLabel({
   );
 }
 
-/** Plain-text form, for a tooltip or an aria-label where a component cannot go. */
-export const saleDiscountText = (sale: {
-  discountType: 'Fixed' | 'Percent';
-  discountAmount: number;
-}) =>
-  sale.discountType === 'Percent'
-    ? `${sale.discountAmount}% off`
-    : `${sale.discountAmount.toLocaleString()} Buzz off`;
-
-/**
- * The struck-through price comes from `sale.listTerms`, which the server sends beside the already
- * discounted `terms`. Recomputing it here would be a second implementation of the discount, free to
- * disagree with the one that charges.
- *
- * `isOwner` only changes the wording: an owner is quoted their stored price, so "your sale" reads
- * correctly where "on sale" would imply they are being charged it.
- */
-export function ModelVersionSaleBadge({
-  sale,
-  isOwner,
-  className,
-}: {
-  sale: SaleDisplay | null | undefined;
-  isOwner?: boolean;
-  className?: string;
-}) {
-  const listPrice = sale?.listTerms.download?.price;
-  if (!sale) return null;
-
-  const endsAt = new Date(sale.endsAt);
-
-  return (
-    <Tooltip label={`Sale ends ${formatDate(endsAt, 'MMM D, YYYY h:mm A')}`} withArrow>
-      <Group gap={6} wrap="nowrap" className={clsx('items-center', className)}>
-        <IconTag size={16} className="text-green-6" />
-        <Text size="xs" fw={600} className="text-green-6">
-          {isOwner ? (
-            <>
-              Your sale — <SaleDiscountLabel sale={sale} />
-            </>
-          ) : (
-            <SaleDiscountLabel sale={sale} />
-          )}
-        </Text>
-        {listPrice != null && !isOwner && (
-          <Text size="xs" c="dimmed" td="line-through">
-            {listPrice.toLocaleString()} Buzz
-          </Text>
-        )}
-        <Text size="xs" c="dimmed">
-          until {formatDate(endsAt, 'MMM D')}
-        </Text>
-      </Group>
-    </Tooltip>
-  );
-}
-
 /**
  * The prominent form, for the model page: a sale is a reason to act now, so it sits above the download
  * card rather than inside it, where it read as one more line of card furniture.
@@ -111,10 +54,10 @@ export function ModelVersionSaleBanner({
 
   const listPrice = sale.listTerms.download?.price;
   const endsAt = new Date(sale.endsAt);
-  // The page now shows the sale price to everyone, owner included, so the strikethrough beside it would
-  // repeat what this line already says. An owner instead gets the number that vanished from the page:
-  // their own list price, which is what the sale is discounting FROM.
-  const quotedStoredPrice = isOwner || isModerator;
+  // The page shows the sale price to everyone now, so a strikethrough would repeat the line below it.
+  // The OWNER instead gets the number that vanished from the page — their own list price. A moderator
+  // gets neither: it is not their price, and not their sale.
+  const showStrikethrough = !isOwner && !isModerator;
 
   return (
     <Card withBorder p="sm" className="border-green-6 bg-green-0 dark:bg-green-9/20">
@@ -127,7 +70,7 @@ export function ModelVersionSaleBanner({
               <SaleDiscountLabel sale={sale} size="sm" />
             </Text>
             <Text size="xs" c="dimmed">
-              {quotedStoredPrice && listPrice != null && (
+              {isOwner && listPrice != null && (
                 <>Your list price is {listPrice.toLocaleString()} Buzz · </>
               )}
               Ends {formatDate(endsAt, 'MMM D, YYYY h:mm A')}
@@ -147,7 +90,7 @@ export function ModelVersionSaleBanner({
             </Text>
           </div>
         </Group>
-        {!quotedStoredPrice && listPrice != null && (
+        {showStrikethrough && listPrice != null && (
           <Text size="sm" c="dimmed" td="line-through" className="whitespace-nowrap">
             {listPrice.toLocaleString()} Buzz
           </Text>

--- a/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
@@ -1,0 +1,37 @@
+import { Group, Text, Tooltip } from '@mantine/core';
+import { IconTag } from '@tabler/icons-react';
+import clsx from 'clsx';
+import type { ModelVersionTerms } from '@civitai/buzz';
+import { formatDate } from '~/utils/date-helpers';
+
+/**
+ * The strikethrough is drawn from `sale.listTerms`, which the server sends alongside the already-
+ * discounted `terms`. Recomputing it on the client would be a second implementation of the discount,
+ * and the two would be free to disagree about the price the buyer is about to be charged.
+ */
+export function ModelVersionSaleBadge({
+  sale,
+  className,
+}: {
+  sale: { listTerms: ModelVersionTerms; endsAt: Date | string } | null | undefined;
+  className?: string;
+}) {
+  const listPrice = sale?.listTerms.download?.price;
+  if (!sale || listPrice == null) return null;
+
+  const endsAt = new Date(sale.endsAt);
+
+  return (
+    <Tooltip label={`Sale ends ${formatDate(endsAt, 'MMM D, YYYY h:mm A')}`} withArrow>
+      <Group gap={6} wrap="nowrap" className={clsx('items-center', className)}>
+        <IconTag size={16} className="text-green-6" />
+        <Text size="xs" fw={600} className="text-green-6">
+          On sale
+        </Text>
+        <Text size="xs" c="dimmed" td="line-through">
+          {listPrice.toLocaleString()} Buzz
+        </Text>
+      </Group>
+    </Tooltip>
+  );
+}

--- a/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionSaleBadge.tsx
@@ -9,6 +9,7 @@ import { formatDate } from '~/utils/date-helpers';
 
 export type SaleDisplay = {
   listTerms: ModelVersionTerms;
+  buyerTerms: ModelVersionTerms;
   endsAt: Date | string;
   discountType: 'Fixed' | 'Percent';
   discountAmount: number;
@@ -109,9 +110,11 @@ export function ModelVersionSaleBanner({
   if (!sale) return null;
 
   const listPrice = sale.listTerms.download?.price;
+  const buyerPrice = sale.buyerTerms.download?.price;
   const endsAt = new Date(sale.endsAt);
-  // Owner and moderator are both quoted the STORED price, so neither gets a strikethrough — striking
-  // through the same number the page already shows reads as a rendering fault, not a discount.
+  // Owner and moderator are both quoted the STORED price everywhere else on the page, so instead of a
+  // strikethrough over a number that is not moving, they are told what a BUYER pays. Without that, the
+  // banner announces a discount whose actual price appears nowhere — which is how Justin read it.
   const quotedStoredPrice = isOwner || isModerator;
 
   return (
@@ -125,6 +128,15 @@ export function ModelVersionSaleBanner({
               <SaleDiscountLabel sale={sale} size="sm" />
             </Text>
             <Text size="xs" c="dimmed">
+              {quotedStoredPrice && buyerPrice != null && listPrice != null && (
+                <>
+                  Buyers pay{' '}
+                  <Text span fw={600} c="green.7">
+                    {buyerPrice.toLocaleString()}
+                  </Text>{' '}
+                  instead of {listPrice.toLocaleString()} Buzz ·{' '}
+                </>
+              )}
               Ends {formatDate(endsAt, 'MMM D, YYYY h:mm A')}
               {isOwner && (
                 <>

--- a/src/components/Profile/Sections/OnSaleSection.tsx
+++ b/src/components/Profile/Sections/OnSaleSection.tsx
@@ -2,6 +2,7 @@ import { Button, Text } from '@mantine/core';
 import { IconArrowRight, IconTag } from '@tabler/icons-react';
 import React from 'react';
 import { ModelCard } from '~/components/Cards/ModelCard';
+import { ModelCardContextProvider, useModelSaleBadges } from '~/components/Cards/ModelCardContext';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { useInViewDynamic } from '~/components/IntersectionObserver/IntersectionObserverProvider';
 import { useQueryModels } from '~/components/Model/model.utils';
@@ -30,6 +31,10 @@ export const OnSaleSection = ({ user }: ProfileSectionProps) => {
     { keepPreviousData: true, enabled: inView }
   );
 
+  // Every card in this section is on sale by definition, so without the shared map it was the worst
+  // offender: one request per card, 32 of them.
+  const salesByModelId = useModelSaleBadges(models.map((m) => m.id));
+
   const isNullState = !isLoading && !models.length;
 
   if (isNullState) return null;
@@ -54,7 +59,7 @@ export const OnSaleSection = ({ user }: ProfileSectionProps) => {
             title="On sale"
             icon={<IconTag />}
             action={
-              <Link legacyBehavior href={`/user/${user.username}/models`} passHref>
+              <Link legacyBehavior href={`/user/${user.username}/models?onSale=true`} passHref>
                 <Button
                   h={34}
                   component="a"
@@ -66,11 +71,13 @@ export const OnSaleSection = ({ user }: ProfileSectionProps) => {
               </Link>
             }
           >
-            <ShowcaseGrid itemCount={models.length} rows={2}>
-              {models.map((model) => (
-                <ModelCard data={model} key={model.id} />
-              ))}
-            </ShowcaseGrid>
+            <ModelCardContextProvider hasSaleProvider salesByModelId={salesByModelId}>
+              <ShowcaseGrid itemCount={models.length} rows={2}>
+                {models.map((model) => (
+                  <ModelCard data={model} key={model.id} />
+                ))}
+              </ShowcaseGrid>
+            </ModelCardContextProvider>
           </ProfileSection>
         ))}
     </div>

--- a/src/components/Profile/Sections/OnSaleSection.tsx
+++ b/src/components/Profile/Sections/OnSaleSection.tsx
@@ -1,0 +1,78 @@
+import { Button, Text } from '@mantine/core';
+import { IconArrowRight, IconTag } from '@tabler/icons-react';
+import React from 'react';
+import { ModelCard } from '~/components/Cards/ModelCard';
+import { NextLink as Link } from '~/components/NextLink/NextLink';
+import { useInViewDynamic } from '~/components/IntersectionObserver/IntersectionObserverProvider';
+import { useQueryModels } from '~/components/Model/model.utils';
+import type { ProfileSectionProps } from '~/components/Profile/ProfileSection';
+import { ProfileSection, ProfileSectionPreview } from '~/components/Profile/ProfileSection';
+import classes from '~/components/Profile/ProfileSection.module.css';
+import { ShowcaseGrid } from '~/components/Profile/Sections/ShowcaseGrid';
+import { ModelSort } from '~/server/common/enums';
+
+const ON_SALE_DISPLAY = 32;
+
+/**
+ * Opt-in, and off by default: a creator running no sales would otherwise get an empty section on their
+ * profile, and one who runs them rarely would get a section that appears and vanishes without them
+ * touching anything.
+ */
+export const OnSaleSection = ({ user }: ProfileSectionProps) => {
+  const [ref, inView] = useInViewDynamic({ id: 'profile-on-sale-section' });
+  const { models, isLoading } = useQueryModels(
+    {
+      limit: ON_SALE_DISPLAY,
+      username: user.username,
+      onSale: true,
+      sort: ModelSort.Newest,
+    },
+    { keepPreviousData: true, enabled: inView }
+  );
+
+  const isNullState = !isLoading && !models.length;
+
+  if (isNullState) return null;
+
+  return (
+    <div
+      ref={ref}
+      className={isNullState ? undefined : classes.profileSection}
+      style={
+        {
+          '--count': models.length,
+          '--row-count': 2,
+          '--width-grid': '280px',
+        } as React.CSSProperties
+      }
+    >
+      {inView &&
+        (isLoading ? (
+          <ProfileSectionPreview rowCount={2} />
+        ) : (
+          <ProfileSection
+            title="On sale"
+            icon={<IconTag />}
+            action={
+              <Link legacyBehavior href={`/user/${user.username}/models`} passHref>
+                <Button
+                  h={34}
+                  component="a"
+                  variant="subtle"
+                  rightSection={<IconArrowRight size={16} />}
+                >
+                  <Text inherit> View all models</Text>
+                </Button>
+              </Link>
+            }
+          >
+            <ShowcaseGrid itemCount={models.length} rows={2}>
+              {models.map((model) => (
+                <ModelCard data={model} key={model.id} />
+              ))}
+            </ShowcaseGrid>
+          </ProfileSection>
+        ))}
+    </div>
+  );
+};

--- a/src/components/Profile/profile.utils.ts
+++ b/src/components/Profile/profile.utils.ts
@@ -4,6 +4,7 @@ import { MyModelsSection } from '~/components/Profile/Sections/MyModelsSection';
 import { PopularArticlesSection } from '~/components/Profile/Sections/PopularArticlesSection';
 import { PopularModelsSection } from '~/components/Profile/Sections/PopularModelsSection';
 import { RecentReviewsSection } from '~/components/Profile/Sections/RecentReviewsSection';
+import { OnSaleSection } from '~/components/Profile/Sections/OnSaleSection';
 import { ShopSection } from '~/components/Profile/Sections/ShopSection';
 import { ShowcaseSection } from '~/components/Profile/Sections/ShowcaseSection';
 import type {
@@ -24,6 +25,8 @@ export const defaultProfileSectionStatus: Record<ProfileSectionType, boolean> = 
   imagesOverview: true,
   recentReviews: true,
   shop: false,
+  // Off by default: a creator running no sales should not get an empty section they never asked for.
+  onSale: false,
 } as const;
 
 export const ProfileSectionComponent: Record<
@@ -37,6 +40,7 @@ export const ProfileSectionComponent: Record<
   imagesOverview: MyImagesSection,
   recentReviews: RecentReviewsSection,
   shop: ShopSection,
+  onSale: OnSaleSection,
 } as const;
 
 export const profileSectionLabels: Record<ProfileSectionType, string> = {
@@ -47,6 +51,7 @@ export const profileSectionLabels: Record<ProfileSectionType, string> = {
   imagesOverview: 'Images overview',
   recentReviews: 'Recent reviews',
   shop: 'Shop',
+  onSale: 'On sale',
 } as const;
 export const getAllAvailableProfileSections = (userSections: ProfileSectionSchema[] = []) => {
   const sections: ProfileSectionSchema[] = [

--- a/src/pages/search/models.tsx
+++ b/src/pages/search/models.tsx
@@ -11,7 +11,7 @@ import {
 } from '~/components/Search/CustomSearchComponents';
 import { useEffect } from 'react';
 import { ModelCard } from '~/components/Cards/ModelCard';
-import { ModelCardContextProvider } from '~/components/Cards/ModelCardContext';
+import { ModelCardContextProvider, useModelSaleBadges } from '~/components/Cards/ModelCardContext';
 import { SearchHeader } from '~/components/Search/SearchHeader';
 import { TimeoutLoader } from '~/components/Search/TimeoutLoader';
 import { IconCloudOff } from '@tabler/icons-react';
@@ -194,6 +194,8 @@ export function ModelsHitList() {
     );
   }
 
+  const salesByModelId = useModelSaleBadges((items as { id: number }[]).map((x) => x.id));
+
   return (
     <Stack>
       {hiddenCount > 0 && (
@@ -202,6 +204,8 @@ export function ModelsHitList() {
       <ModelCardContextProvider
         activeBaseModels={activeBaseModels}
         useModelVersionRedirect={activeBaseModels.length > 0}
+        hasSaleProvider
+        salesByModelId={salesByModelId}
       >
         <MasonryGrid
           data={items as any}

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -302,7 +302,7 @@ const loadModelVersion = async ({
     // The donationGoal seeds ONLY the owner's edit form, so use the RAW owner read (unfiltered by the
     // public EA-window/opt-out) and never hand it to a non-owner — public display reads the goal from
     // modelVersion.donationGoal instead.
-    const { paidAccess, licensingFee } = (
+    const { paidAccess, licensingFee, sale } = (
       await getViewerMonetization({
         versions: [
           {
@@ -328,7 +328,7 @@ const loadModelVersion = async ({
       licensingFee,
       canGenerate,
       wildcardSetId,
-      paidAccess: toModelVersionPaidAccessDto(paidAccess),
+      paidAccess: toModelVersionPaidAccessDto(paidAccess, sale),
       donationGoal: eaDonationGoal ? { goalAmount: eaDonationGoal.goalAmount } : null,
       baseModel: version.baseModel as BaseModel,
       baseModelType: version.baseModelType as BaseModelType,

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -368,7 +368,8 @@ export const getModelHandler = async ({
     const hideIf = (hidden: boolean, value: number) => (hidden ? null : value);
 
     const mappedVersions = filteredVersions.map((version) => {
-      const { paidAccess, licensingFee, effectiveLicensingFee } = monetizationByVersion[version.id];
+      const { paidAccess, licensingFee, effectiveLicensingFee, sale } =
+        monetizationByVersion[version.id];
       const eaDonationGoal = donationGoalsByVersion[version.id] ?? null;
       const paidAccessGated =
         features.earlyAccessModel && !!paidAccess && isPaidAccessActive(paidAccess);
@@ -450,7 +451,7 @@ export const getModelHandler = async ({
         posts: posts.filter((x) => x.modelVersionId === version.id).map((x) => ({ id: x.id })),
         hashes,
         earlyAccessDeadline,
-        paidAccess: toModelVersionPaidAccessDto(paidAccess),
+        paidAccess: toModelVersionPaidAccessDto(paidAccess, sale),
         donationGoal: eaDonationGoal ? { goalAmount: eaDonationGoal.goalAmount } : null,
         canDownload,
         canGenerate,

--- a/src/server/routers/model.router.ts
+++ b/src/server/routers/model.router.ts
@@ -201,7 +201,9 @@ export const modelRouter = router({
   // a sale turns on and off at a wall-clock moment, so indexing it would mean re-indexing at every edge.
   getActiveSales: publicProcedure
     .meta({ requiredScope: TokenScope.ModelsRead })
-    .input(getByIdsSchema)
+    // Bounded on its own schema: this is a public procedure reaching raw SQL, and the shared
+    // getByIdsSchema has no cap.
+    .input(z.object({ ids: z.number().array().max(500) }))
     .query(({ input }) => getActiveSalesForModels(input.ids)),
   getResourceSelect: publicProcedure
     .meta({ requiredScope: TokenScope.ModelsRead })

--- a/src/server/routers/model.router.ts
+++ b/src/server/routers/model.router.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod';
+import { getActiveSalesForModels } from '~/server/services/paid-access.service';
 import { env } from '~/env/server';
 import { CacheTTL } from '~/server/common/constants';
 import {
@@ -196,6 +197,12 @@ export const modelRouter = router({
   getFeaturedModels: publicProcedure
     .meta({ requiredScope: TokenScope.ModelsRead })
     .query(() => getFeaturedModels()),
+  // Which of the cards on screen are on sale. Kept off the feed query and out of the search document:
+  // a sale turns on and off at a wall-clock moment, so indexing it would mean re-indexing at every edge.
+  getActiveSales: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getByIdsSchema)
+    .query(({ input }) => getActiveSalesForModels(input.ids)),
   getResourceSelect: publicProcedure
     .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getResourceSelectSchema)

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -397,7 +397,13 @@ export const donationGoalInputSchema = z.object({
 export type ModelVersionPaidAccessDto = {
   endsAt: Date | null;
   timeframeDays: number | null;
+  /** Already discounted when a sale is live — `sale.listTerms` carries what it was before. */
   terms: ModelVersionTerms;
+  /**
+   * Present only while a sale is actually discounting this viewer's price. `listTerms` is the
+   * pre-sale price so the UI can strike it through; `endsAt` is what a countdown reads.
+   */
+  sale: { listTerms: ModelVersionTerms; endsAt: Date } | null;
 };
 
 // Narrow input for editing only a version's paid access (e.g. from the creator studio) without

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -403,7 +403,12 @@ export type ModelVersionPaidAccessDto = {
    * Present only while a sale is actually discounting this viewer's price. `listTerms` is the
    * pre-sale price so the UI can strike it through; `endsAt` is what a countdown reads.
    */
-  sale: { listTerms: ModelVersionTerms; endsAt: Date } | null;
+  sale: {
+    listTerms: ModelVersionTerms;
+    endsAt: Date;
+    discountType: 'Fixed' | 'Percent';
+    discountAmount: number;
+  } | null;
 };
 
 // Narrow input for editing only a version's paid access (e.g. from the creator studio) without

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -405,6 +405,8 @@ export type ModelVersionPaidAccessDto = {
    */
   sale: {
     listTerms: ModelVersionTerms;
+    /** What a buyer is quoted, so an owner can be shown it without recomputing the discount. */
+    buyerTerms: ModelVersionTerms;
     endsAt: Date;
     discountType: 'Fixed' | 'Percent';
     discountAmount: number;

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -111,6 +111,8 @@ export const getAllModelsSchema = z.object({
   needsReview: booleanString().optional(),
   earlyAccess: booleanString().optional(),
   paidAccess: booleanString().optional(),
+  /** Models with a live scheduled sale on a permanent paid-access version. */
+  onSale: booleanString().optional(),
   ids: commaDelimitedNumberArray().optional(),
   modelVersionIds: commaDelimitedNumberArray().optional(),
   supportsGeneration: booleanString().optional(),

--- a/src/server/schema/user-profile.schema.ts
+++ b/src/server/schema/user-profile.schema.ts
@@ -27,6 +27,7 @@ export const ProfileSectionTypeDef = {
   ImagesOverview: 'imagesOverview',
   RecentReviews: 'recentReviews',
   Shop: 'shop',
+  OnSale: 'onSale',
 } as const;
 
 export type ProfileSectionType = (typeof ProfileSectionTypeDef)[keyof typeof ProfileSectionTypeDef];

--- a/src/server/services/__tests__/donation-goal.service.test.ts
+++ b/src/server/services/__tests__/donation-goal.service.test.ts
@@ -42,6 +42,7 @@ vi.mock('~/server/services/paid-access.service', () => ({
   getPaidAccess: mockGetPaidAccess,
   bustPaidAccessCache: mockBustPaidAccess,
   endPaidAccessNow: mockEndPaidAccessNow,
+  bustModelSaleCache: vi.fn(),
 }));
 
 import { checkDonationGoalComplete } from '~/server/services/donation-goal.service';

--- a/src/server/services/__tests__/donation-goals-accessor.test.ts
+++ b/src/server/services/__tests__/donation-goals-accessor.test.ts
@@ -23,6 +23,7 @@ vi.mock('~/server/redis/caches', () => ({
 vi.mock('~/server/services/paid-access.service', () => ({
   getPaidAccess: mockGetPaidAccess,
   bustPaidAccessCache: vi.fn(),
+  bustModelSaleCache: vi.fn(),
 }));
 vi.mock('~/server/services/creator-membership.service', () => ({
   getValidCreatorMembershipMap: mockMembership,

--- a/src/server/services/__tests__/entity-access-unresolved.service.test.ts
+++ b/src/server/services/__tests__/entity-access-unresolved.service.test.ts
@@ -55,6 +55,7 @@ vi.mock('~/server/redis/caches', () => ({
 const getPaidAccessMock = vi.fn();
 vi.mock('~/server/services/paid-access.service', () => ({
   getPaidAccess: (...args: unknown[]) => getPaidAccessMock(...args),
+  bustModelSaleCache: vi.fn(),
 }));
 
 import { hasEntityAccess } from '~/server/services/common.service';

--- a/src/server/services/__tests__/file-download-lookup.test.ts
+++ b/src/server/services/__tests__/file-download-lookup.test.ts
@@ -73,6 +73,7 @@ vi.mock('~/server/services/bountyEntry.service', () => ({
 const getPaidAccessMock = vi.fn();
 vi.mock('~/server/services/paid-access.service', () => ({
   getPaidAccess: getPaidAccessMock,
+  bustModelSaleCache: vi.fn(),
 }));
 
 // Control whether the delivery URL resolves. A throw here is the

--- a/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
+++ b/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
@@ -65,6 +65,7 @@ vi.mock('~/server/services/paid-access.service', () => ({
   getFreshSalesForVersion: mockGetFreshSalesForVersion,
   getFreshSalesForPermanentGate: mockGetFreshSalesForPermanentGate,
   getCachedCapTier: mockGetCachedCapTier,
+  bustModelSaleCache: vi.fn(),
 }));
 vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));
 vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));

--- a/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
+++ b/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
@@ -17,6 +17,8 @@ const {
   mockCreateMultiAccountBuzzTransaction,
   mockGetPaidAccess,
   mockGetFreshSalesForVersion,
+  mockGetCachedCapTier,
+  mockGetFreshSalesForPermanentGate,
   mockGetOwnerDonationGoals,
   mockHasEntityAccess,
   mockCheckDonationGoalComplete,
@@ -24,6 +26,8 @@ const {
   mockCreateMultiAccountBuzzTransaction: vi.fn(),
   mockGetPaidAccess: vi.fn(),
   mockGetFreshSalesForVersion: vi.fn(),
+  mockGetCachedCapTier: vi.fn(),
+  mockGetFreshSalesForPermanentGate: vi.fn(),
   mockGetOwnerDonationGoals: vi.fn(),
   mockHasEntityAccess: vi.fn(),
   mockCheckDonationGoalComplete: vi.fn(),
@@ -59,6 +63,8 @@ vi.mock('~/server/services/paid-access.service', () => ({
   writePaidAccessForModelVersion: vi.fn(),
   getPaidAccess: mockGetPaidAccess,
   getFreshSalesForVersion: mockGetFreshSalesForVersion,
+  getFreshSalesForPermanentGate: mockGetFreshSalesForPermanentGate,
+  getCachedCapTier: mockGetCachedCapTier,
 }));
 vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));
 vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));
@@ -131,6 +137,8 @@ const seed = ({
     transactionIds: [],
   });
   mockGetFreshSalesForVersion.mockResolvedValue([]);
+  mockGetFreshSalesForPermanentGate.mockResolvedValue([]);
+  mockGetCachedCapTier.mockResolvedValue(null);
 };
 
 beforeEach(() => {
@@ -227,7 +235,7 @@ describe('earlyAccessPurchase — a scheduled sale is priced from the PRIMARY, n
 
   it('charges the discounted price when a sale is live', async () => {
     seed();
-    mockGetFreshSalesForVersion.mockResolvedValue([liveSale]);
+    mockGetFreshSalesForPermanentGate.mockResolvedValue([liveSale]);
 
     await earlyAccessPurchase({
       userId: BUYER,
@@ -239,6 +247,8 @@ describe('earlyAccessPurchase — a scheduled sale is priced from the PRIMARY, n
     expect(charged()).toBe(400);
     // Exactly one charge. Asserting only the amount would stay green if the buyer were billed twice.
     expect(mockCreateMultiAccountBuzzTransaction).toHaveBeenCalledTimes(1);
+    // These fixtures are a TIMED gate, where sales must not apply — pin that the charge says so.
+    expect(mockGetFreshSalesForPermanentGate).toHaveBeenCalledWith(VERSION_ID, false, OWNER);
   });
 
   it('charges full price the moment a sale is cancelled, even though the cached gate still carries it', async () => {
@@ -257,7 +267,7 @@ describe('earlyAccessPurchase — a scheduled sale is priced from the PRIMARY, n
         sales: [liveSale],
       },
     });
-    mockGetFreshSalesForVersion.mockResolvedValue([]);
+    mockGetFreshSalesForPermanentGate.mockResolvedValue([]);
 
     await earlyAccessPurchase({
       userId: BUYER,
@@ -274,7 +284,7 @@ describe('earlyAccessPurchase — a scheduled sale is priced from the PRIMARY, n
     // The negative control for the two above: a live sale must not become a reason money moves. Without
     // this, a resolver that charged before validating would pass every assertion in this file.
     seed();
-    mockGetFreshSalesForVersion.mockResolvedValue([liveSale]);
+    mockGetFreshSalesForPermanentGate.mockResolvedValue([liveSale]);
     mockDbWrite.modelVersion.findUnique.mockResolvedValue({
       id: VERSION_ID,
       status: 'Draft',
@@ -295,5 +305,100 @@ describe('earlyAccessPurchase — a scheduled sale is priced from the PRIMARY, n
 
     expect(mockCreateMultiAccountBuzzTransaction).not.toHaveBeenCalled();
     expect(mockDbWrite.entityAccess.upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('earlyAccessPurchase — a sale on a PERMANENT gate, where the price ceiling actually applies', () => {
+  const liveSale = {
+    id: 1,
+    discountType: 'Percent' as const,
+    discountAmount: 20,
+    startsAt: new Date(Date.now() - 86_400_000),
+    endsAt: new Date(Date.now() + 86_400_000),
+    canceledAt: null,
+  };
+
+  const seedPermanent = (terms: Record<string, unknown> = { download: { price: 5000 } }) => {
+    seed();
+    // Every other sale fixture in this file uses a TIMED gate, where effectivePaidAccessPrice returns the
+    // stored price untouched — so cap-then-discount is a no-op there and the ordering is unpinned. A
+    // permanent gate with a lapsed owner is the only shape where the two orders differ.
+    mockGetPaidAccess.mockResolvedValue({
+      [VERSION_ID]: {
+        entityType: 'ModelVersion',
+        entityId: VERSION_ID,
+        ownerId: OWNER,
+        endsAt: null,
+        timeframeDays: null,
+        terms,
+      },
+    });
+    mockGetCachedCapTier.mockResolvedValue(null);
+  };
+
+  const charged = () => mockCreateMultiAccountBuzzTransaction.mock.calls[0][0].amount;
+
+  it('takes the sale off the CAPPED price, not the stored one', async () => {
+    seedPermanent();
+    mockGetFreshSalesForPermanentGate.mockResolvedValue([liveSale]);
+
+    await earlyAccessPurchase({
+      userId: BUYER,
+      modelVersionId: VERSION_ID,
+      type: 'download',
+      buzzType: 'yellow',
+    });
+
+    // 5000 stored -> 500 at the free cap -> 20% off -> 400. Discounting first gives 4000, which the cap
+    // flattens back to 500 and the sale vanishes.
+    expect(charged()).toBe(400);
+    expect(mockCreateMultiAccountBuzzTransaction).toHaveBeenCalledTimes(1);
+    // The gate type is what decides whether sales are consulted at all, so pin that it is passed.
+    expect(mockGetFreshSalesForPermanentGate).toHaveBeenCalledWith(VERSION_ID, true, OWNER);
+  });
+
+  it('bills the capped price untouched when no sale is live', async () => {
+    seedPermanent();
+
+    await earlyAccessPurchase({
+      userId: BUYER,
+      modelVersionId: VERSION_ID,
+      type: 'download',
+      buzzType: 'yellow',
+    });
+
+    expect(charged()).toBe(500);
+  });
+
+  it('discounts a GENERATION purchase too, not only a download', async () => {
+    seedPermanent({ download: { price: 5000 }, generation: { price: 200 } });
+    mockGetFreshSalesForPermanentGate.mockResolvedValue([liveSale]);
+
+    await earlyAccessPurchase({
+      userId: BUYER,
+      modelVersionId: VERSION_ID,
+      type: 'generation',
+      buzzType: 'yellow',
+    });
+
+    // 200 is under the free cap, so the cap is a no-op and the sale takes 20%.
+    expect(charged()).toBe(160);
+  });
+
+  it('never bills zero: the floor holds when a discount reaches the whole price', async () => {
+    seedPermanent({ download: { price: 400 } });
+    mockGetFreshSalesForPermanentGate.mockResolvedValue([
+      { ...liveSale, discountType: 'Fixed' as const, discountAmount: 100_000 },
+    ]);
+
+    await earlyAccessPurchase({
+      userId: BUYER,
+      modelVersionId: VERSION_ID,
+      type: 'download',
+      buzzType: 'yellow',
+    });
+
+    // A zero-Buzz purchase writes no ledger row, and the 30-day refund path reads amounts back from it.
+    expect(charged()).toBe(1);
   });
 });

--- a/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
+++ b/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
@@ -237,6 +237,8 @@ describe('earlyAccessPurchase — a scheduled sale is priced from the PRIMARY, n
     });
 
     expect(charged()).toBe(400);
+    // Exactly one charge. Asserting only the amount would stay green if the buyer were billed twice.
+    expect(mockCreateMultiAccountBuzzTransaction).toHaveBeenCalledTimes(1);
   });
 
   it('charges full price the moment a sale is cancelled, even though the cached gate still carries it', async () => {
@@ -265,5 +267,33 @@ describe('earlyAccessPurchase — a scheduled sale is priced from the PRIMARY, n
     });
 
     expect(charged()).toBe(500);
+    expect(mockCreateMultiAccountBuzzTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves NO money when a sale is live but the purchase is refused', async () => {
+    // The negative control for the two above: a live sale must not become a reason money moves. Without
+    // this, a resolver that charged before validating would pass every assertion in this file.
+    seed();
+    mockGetFreshSalesForVersion.mockResolvedValue([liveSale]);
+    mockDbWrite.modelVersion.findUnique.mockResolvedValue({
+      id: VERSION_ID,
+      status: 'Draft',
+      name: 'v1',
+      meta: {},
+      baseModel: 'SDXL 1.0',
+      model: { id: 1, name: 'Model', userId: OWNER, nsfw: false },
+    });
+
+    await expect(
+      earlyAccessPurchase({
+        userId: BUYER,
+        modelVersionId: VERSION_ID,
+        type: 'download',
+        buzzType: 'yellow',
+      })
+    ).rejects.toThrow();
+
+    expect(mockCreateMultiAccountBuzzTransaction).not.toHaveBeenCalled();
+    expect(mockDbWrite.entityAccess.upsert).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
+++ b/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
@@ -16,12 +16,14 @@ const { mockDbWrite } = vi.hoisted(() => ({
 const {
   mockCreateMultiAccountBuzzTransaction,
   mockGetPaidAccess,
+  mockGetFreshSalesForVersion,
   mockGetOwnerDonationGoals,
   mockHasEntityAccess,
   mockCheckDonationGoalComplete,
 } = vi.hoisted(() => ({
   mockCreateMultiAccountBuzzTransaction: vi.fn(),
   mockGetPaidAccess: vi.fn(),
+  mockGetFreshSalesForVersion: vi.fn(),
   mockGetOwnerDonationGoals: vi.fn(),
   mockHasEntityAccess: vi.fn(),
   mockCheckDonationGoalComplete: vi.fn(),
@@ -56,6 +58,7 @@ vi.mock('~/server/services/paid-access.service', () => ({
   materializePaidAccessEndsAt: vi.fn(),
   writePaidAccessForModelVersion: vi.fn(),
   getPaidAccess: mockGetPaidAccess,
+  getFreshSalesForVersion: mockGetFreshSalesForVersion,
 }));
 vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));
 vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));
@@ -127,6 +130,7 @@ const seed = ({
     transactionCount: 1,
     transactionIds: [],
   });
+  mockGetFreshSalesForVersion.mockResolvedValue([]);
 };
 
 beforeEach(() => {
@@ -206,5 +210,60 @@ describe('earlyAccessPurchase — Blue Buzz', () => {
     });
 
     expect(mockDbWrite.donation.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('earlyAccessPurchase — a scheduled sale is priced from the PRIMARY, not the cached gate', () => {
+  const liveSale = {
+    id: 1,
+    discountType: 'Percent' as const,
+    discountAmount: 20,
+    startsAt: new Date(Date.now() - 86_400_000),
+    endsAt: new Date(Date.now() + 86_400_000),
+    canceledAt: null,
+  };
+
+  const charged = () => mockCreateMultiAccountBuzzTransaction.mock.calls[0][0].amount;
+
+  it('charges the discounted price when a sale is live', async () => {
+    seed();
+    mockGetFreshSalesForVersion.mockResolvedValue([liveSale]);
+
+    await earlyAccessPurchase({
+      userId: BUYER,
+      modelVersionId: VERSION_ID,
+      type: 'download',
+      buzzType: 'yellow',
+    });
+
+    expect(charged()).toBe(400);
+  });
+
+  it('charges full price the moment a sale is cancelled, even though the cached gate still carries it', async () => {
+    // The gate row is cached for an hour and Creator Studio's bust is fire-and-forget, so the cached copy
+    // can still describe a sale the creator has already ended. The charge reads the primary instead —
+    // this test fails if the purchase path is ever repointed at the cached window.
+    seed();
+    mockGetPaidAccess.mockResolvedValue({
+      [VERSION_ID]: {
+        entityType: 'ModelVersion',
+        entityId: VERSION_ID,
+        ownerId: OWNER,
+        endsAt: new Date(Date.now() + 86_400_000),
+        timeframeDays: 3,
+        terms: { download: { price: 500 } },
+        sales: [liveSale],
+      },
+    });
+    mockGetFreshSalesForVersion.mockResolvedValue([]);
+
+    await earlyAccessPurchase({
+      userId: BUYER,
+      modelVersionId: VERSION_ID,
+      type: 'download',
+      buzzType: 'yellow',
+    });
+
+    expect(charged()).toBe(500);
   });
 });

--- a/src/server/services/__tests__/model-version.deregister.service.test.ts
+++ b/src/server/services/__tests__/model-version.deregister.service.test.ts
@@ -52,6 +52,7 @@ vi.mock('~/server/services/paid-access.service', () => ({
   paidAccessInputFromLegacyConfig: vi.fn(() => null),
   earlyAccessDonationGoalFromLegacyConfig: vi.fn(() => null),
   earlyAccessConfigFromPaidAccess: vi.fn(),
+  bustModelSaleCache: vi.fn(),
 }));
 vi.mock('~/server/services/model-file.service', () => ({
   deleteFilesForModelVersionCache: vi.fn(),

--- a/src/server/services/__tests__/model-version.idempotent.service.test.ts
+++ b/src/server/services/__tests__/model-version.idempotent.service.test.ts
@@ -58,6 +58,7 @@ vi.mock('~/server/services/paid-access.service', () => ({
   materializePaidAccessEndsAt: mockMaterialize,
   writePaidAccessForModelVersion: vi.fn(),
   getPaidAccess: vi.fn().mockResolvedValue({}),
+  bustModelSaleCache: vi.fn(),
 }));
 vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));
 vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));

--- a/src/server/services/__tests__/model-version.linked-component.service.test.ts
+++ b/src/server/services/__tests__/model-version.linked-component.service.test.ts
@@ -62,6 +62,7 @@ vi.mock('~/server/services/paid-access.service', () => ({
   paidAccessInputFromLegacyConfig: vi.fn(() => null),
   earlyAccessDonationGoalFromLegacyConfig: vi.fn(() => null),
   earlyAccessConfigFromPaidAccess: vi.fn(),
+  bustModelSaleCache: vi.fn(),
 }));
 
 import { addLinkedComponent } from '~/server/services/model-version.service';

--- a/src/server/services/__tests__/model-version.purge-by-hash.service.test.ts
+++ b/src/server/services/__tests__/model-version.purge-by-hash.service.test.ts
@@ -108,6 +108,7 @@ vi.mock('~/server/services/paid-access.service', () => ({
   paidAccessInputFromLegacyConfig: vi.fn(() => null),
   earlyAccessDonationGoalFromLegacyConfig: vi.fn(() => null),
   earlyAccessConfigFromPaidAccess: vi.fn(),
+  bustModelSaleCache: vi.fn(),
 }));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
 vi.mock('~/server/db/db-lag-helpers', async (importOriginal) => {

--- a/src/server/services/__tests__/model-version.unpublish-refund.service.test.ts
+++ b/src/server/services/__tests__/model-version.unpublish-refund.service.test.ts
@@ -50,6 +50,8 @@ vi.mock('~/server/services/paid-access.service', () => ({
   writePaidAccessForModelVersion: vi.fn(),
   getPaidAccess: vi.fn(),
   assertPaidAccessInput: vi.fn(),
+  getFreshSalesForPermanentGate: vi.fn().mockResolvedValue([]),
+  bustModelSaleCache: vi.fn(),
 }));
 vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));
 vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));

--- a/src/server/services/__tests__/model-version.unpublish-scope.service.test.ts
+++ b/src/server/services/__tests__/model-version.unpublish-scope.service.test.ts
@@ -30,6 +30,7 @@ vi.mock('~/server/services/paid-access.service', () => ({
   writePaidAccessForModelVersion: vi.fn(),
   getPaidAccess: vi.fn(),
   assertPaidAccessInput: vi.fn(),
+  bustModelSaleCache: vi.fn(),
 }));
 vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));
 vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));

--- a/src/server/services/__tests__/model.service.vae-append-no-mutation.test.ts
+++ b/src/server/services/__tests__/model.service.vae-append-no-mutation.test.ts
@@ -75,6 +75,7 @@ vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
 vi.mock('~/server/services/paid-access.service', () => ({
   getPaidAccess: vi.fn(),
   getPublicPaidAccessForModelVersions: vi.fn().mockResolvedValue({}),
+  bustModelSaleCache: vi.fn(),
 }));
 vi.mock('~/server/services/creator-program.service', () => ({
   getValidCreatorMembershipMap: vi.fn().mockResolvedValue(new Map()),

--- a/src/server/services/__tests__/paid-access.model-sales.service.test.ts
+++ b/src/server/services/__tests__/paid-access.model-sales.service.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+// The card badge runs on a raw $queryRaw that no other suite reaches: the sales-query suite drives the
+// Prisma findMany path, and both the service suite and the purchase suite stub the layer above. A review
+// found the badge advertising sales up to 14 days before they start, because nothing here could see the
+// query's time predicates. This drives the real function and reads the SQL it builds.
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600, xs: 60 } }));
+vi.mock('~/server/redis/client', () => ({
+  REDIS_KEYS: {
+    CACHES: { PAID_ACCESS: 'test:paid-access', PAID_ACCESS_CAP_TIER: 'test:cap-tier' },
+  },
+}));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  createCachedObject: ({
+    lookupFn,
+  }: {
+    lookupFn: (ids: number[]) => Promise<Record<string, unknown>>;
+  }) => ({
+    fetch: (ids: number[]) => lookupFn(ids),
+    bust: vi.fn(),
+  }),
+}));
+
+import { getActiveSalesForModels } from '~/server/services/paid-access.service';
+
+const queryRaw = dbMock.dbRead.$queryRaw;
+
+const row = (over: Record<string, unknown> = {}) => ({
+  modelId: 7,
+  startsAt: new Date('2026-03-01T00:00:00.000Z'),
+  endsAt: new Date('2026-03-08T00:00:00.000Z'),
+  discountType: 'Percent',
+  discountAmount: 25,
+  ...over,
+});
+
+const sqlText = () => {
+  const call = queryRaw.mock.calls[0][0] as { strings?: string[] } | string[];
+  const strings = Array.isArray(call) ? call : call.strings ?? [];
+  return strings.join(' ');
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryRaw.mockResolvedValue([]);
+});
+
+describe('getActiveSalesForModels — the card badge', () => {
+  const now = new Date('2026-03-02T00:00:00.000Z');
+
+  it('reports a running sale with its discount', async () => {
+    queryRaw.mockResolvedValue([row()]);
+
+    const out = await getActiveSalesForModels([7], now);
+
+    expect(out[7]).toEqual({
+      endsAt: new Date('2026-03-08T00:00:00.000Z'),
+      discountType: 'Percent',
+      discountAmount: 25,
+    });
+  });
+
+  it('does NOT badge a sale that has not started yet', async () => {
+    // The badge is model-level and the page is version-level, so a sale advertised before it starts is
+    // a card promising a discount the model page and the charge both refuse. Lead time is up to 14 days.
+    queryRaw.mockResolvedValue([row({ startsAt: new Date('2026-03-10T00:00:00.000Z') })]);
+
+    const out = await getActiveSalesForModels([7], now);
+
+    expect(out[7]).toBeUndefined();
+  });
+
+  it('does NOT badge a sale whose window has closed', async () => {
+    queryRaw.mockResolvedValue([row({ endsAt: new Date('2026-03-01T12:00:00.000Z') })]);
+
+    const out = await getActiveSalesForModels([7], now);
+
+    expect(out[7]).toBeUndefined();
+  });
+
+  it('asks the database for the ownership and gate predicates it must not lose', async () => {
+    await getActiveSalesForModels([7], now);
+
+    const sql = sqlText();
+    // A sale may only price versions its author owns — the create path lives in another application.
+    expect(sql).toContain('s."userId" = m."userId"');
+    // Sales cover permanent paid access only, never a timed early-access window.
+    expect(sql).toContain('pa."timeframeDays" IS NULL');
+    expect(sql).toContain(`mv.status = 'Published'`);
+    expect(sql).toContain('s."canceledAt" IS NULL');
+  });
+
+  it('never queries at all for an empty id list', async () => {
+    const out = await getActiveSalesForModels([], now);
+
+    expect(out).toEqual({});
+    expect(queryRaw).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/paid-access.model-sales.service.test.ts
+++ b/src/server/services/__tests__/paid-access.model-sales.service.test.ts
@@ -5,12 +5,9 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
 // Prisma findMany path, and both the service suite and the purchase suite stub the layer above. A review
 // found the badge advertising sales up to 14 days before they start, because nothing here could see the
 // query's time predicates. This drives the real function and reads the SQL it builds.
-vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600, xs: 60 } }));
-vi.mock('~/server/redis/client', () => ({
-  REDIS_KEYS: {
-    CACHES: { PAID_ACCESS: 'test:paid-access', PAID_ACCESS_CAP_TIER: 'test:cap-tier' },
-  },
-}));
+// constants and redis/client have canonical mocks registered globally, so this file must not mock them
+// itself — a per-file mock of a shared module leaks into other files under --no-isolate. cache-helpers
+// is mocked deliberately: running lookupFn is the whole point here, and the canonical fake never calls it.
 vi.mock('~/server/utils/cache-helpers', () => ({
   createCachedObject: ({
     lookupFn,

--- a/src/server/services/__tests__/paid-access.sales-query.service.test.ts
+++ b/src/server/services/__tests__/paid-access.sales-query.service.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The sale query in getSalesFor decides which sales apply to which version and which are live enough to
+// cache. Every other suite stubs createCachedObject with a fake that never calls lookupFn, so the query is
+// unobservable there: the fake hands back a sale list by construction. This one drives the real lookup and
+// lets the database mock answer, so replacing the filter with `where: {}` goes red instead of green.
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    paidAccess: { findMany: vi.fn() },
+    modelVersionSaleItem: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600, xs: 60 } }));
+vi.mock('~/server/redis/client', () => ({
+  REDIS_KEYS: {
+    CACHES: { PAID_ACCESS: 'test:paid-access', PAID_ACCESS_CAP_TIER: 'test:cap-tier' },
+  },
+}));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  createCachedObject: ({
+    lookupFn,
+  }: {
+    lookupFn: (ids: number[], fromWrite?: boolean) => Promise<Record<string, unknown>>;
+  }) => ({
+    fetch: (ids: number[]) => lookupFn(ids, false),
+    bust: vi.fn(),
+  }),
+}));
+
+import { getPaidAccess } from '~/server/services/paid-access.service';
+
+const PERMANENT = { entityId: 1, ownerId: 9, endsAt: null, timeframeDays: null, terms: { download: { price: 500 } } };
+const ALSO_PERMANENT = { ...PERMANENT, entityId: 2 };
+const TIMED = { ...PERMANENT, entityId: 3, timeframeDays: 7, endsAt: new Date('2099-01-01T00:00:00.000Z') };
+
+const saleRow = (modelVersionId: number, id: number, userId = 9) => ({
+  modelVersionId,
+  sale: {
+    id,
+    userId,
+    discountType: 'Percent',
+    discountAmount: 20,
+    startsAt: new Date('2026-03-01T00:00:00.000Z'),
+    endsAt: new Date('2099-01-01T00:00:00.000Z'),
+    canceledAt: null,
+  },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.modelVersionSaleItem.findMany.mockResolvedValue([]);
+});
+
+describe('getSalesFor — which sales reach which version', () => {
+  it('attributes each sale only to the version it covers', async () => {
+    mockDb.paidAccess.findMany.mockResolvedValue([PERMANENT, ALSO_PERMANENT]);
+    mockDb.modelVersionSaleItem.findMany.mockResolvedValue([saleRow(1, 11), saleRow(2, 22)]);
+
+    const out = await getPaidAccess('ModelVersion', [1, 2]);
+
+    expect(out[1]?.sales?.map((s) => s.id)).toEqual([11]);
+    expect(out[2]?.sales?.map((s) => s.id)).toEqual([22]);
+  });
+
+  it('scopes the query to the requested versions and to live-or-upcoming, uncancelled sales', async () => {
+    mockDb.paidAccess.findMany.mockResolvedValue([PERMANENT]);
+
+    await getPaidAccess('ModelVersion', [1]);
+
+    const where = mockDb.modelVersionSaleItem.findMany.mock.calls[0][0].where;
+    expect(where.modelVersionId).toEqual({ in: [1] });
+    expect(where.sale.endsAt.gt).toBeInstanceOf(Date);
+    expect(where.sale.OR).toEqual([{ canceledAt: null }, { canceledAt: { gt: expect.any(Date) } }]);
+  });
+
+  it('never asks for sales on a TIMED early-access gate — sales are paid-access only', async () => {
+    mockDb.paidAccess.findMany.mockResolvedValue([TIMED]);
+
+    const out = await getPaidAccess('ModelVersion', [3]);
+
+    // The gate type is mutable after a sale is authored, so this cannot be left to the authoring refusal.
+    expect(mockDb.modelVersionSaleItem.findMany).not.toHaveBeenCalled();
+    expect(out[3]?.sales).toEqual([]);
+  });
+
+  it('asks only about gated versions, and not at all when a batch is entirely free', async () => {
+    mockDb.paidAccess.findMany.mockResolvedValue([PERMANENT]);
+
+    await getPaidAccess('ModelVersion', [1, 404, 405]);
+
+    expect(mockDb.modelVersionSaleItem.findMany.mock.calls[0][0].where.modelVersionId).toEqual({ in: [1] });
+
+    vi.clearAllMocks();
+    mockDb.paidAccess.findMany.mockResolvedValue([]);
+    await getPaidAccess('ModelVersion', [500, 501]);
+    expect(mockDb.modelVersionSaleItem.findMany).not.toHaveBeenCalled();
+  });
+
+  it('asks for no sales on a ComicChapter gate', async () => {
+    mockDb.paidAccess.findMany.mockResolvedValue([{ ...PERMANENT, terms: { access: { price: 10 } } }]);
+
+    await getPaidAccess('ComicChapter', [1]);
+
+    expect(mockDb.modelVersionSaleItem.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('getSalesFor — a sale may only price its own author’s versions', () => {
+  it('drops a sale whose author does not own the version it names', async () => {
+    // Sales are authored in a different application. Without this re-check the main app would treat any
+    // sale row as authoritative over any version id it names, and the only ownership guard would live
+    // outside this codebase entirely.
+    mockDb.paidAccess.findMany.mockResolvedValue([PERMANENT]);
+    mockDb.modelVersionSaleItem.findMany.mockResolvedValue([saleRow(1, 11, 999)]);
+
+    const out = await getPaidAccess('ModelVersion', [1]);
+
+    expect(out[1]?.sales).toEqual([]);
+  });
+
+  it('keeps a sale authored by the version’s own owner', async () => {
+    mockDb.paidAccess.findMany.mockResolvedValue([PERMANENT]);
+    mockDb.modelVersionSaleItem.findMany.mockResolvedValue([saleRow(1, 11, PERMANENT.ownerId)]);
+
+    const out = await getPaidAccess('ModelVersion', [1]);
+
+    expect(out[1]?.sales?.map((s) => s.id)).toEqual([11]);
+  });
+});

--- a/src/server/services/__tests__/paid-access.sales-query.service.test.ts
+++ b/src/server/services/__tests__/paid-access.sales-query.service.test.ts
@@ -1,23 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
 
 // The sale query in getSalesFor decides which sales apply to which version and which are live enough to
 // cache. Every other suite stubs createCachedObject with a fake that never calls lookupFn, so the query is
 // unobservable there: the fake hands back a sale list by construction. This one drives the real lookup and
 // lets the database mock answer, so replacing the filter with `where: {}` goes red instead of green.
-const { mockDb } = vi.hoisted(() => ({
-  mockDb: {
-    paidAccess: { findMany: vi.fn() },
-    modelVersionSaleItem: { findMany: vi.fn() },
-  },
-}));
-
-vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
-vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600, xs: 60 } }));
-vi.mock('~/server/redis/client', () => ({
-  REDIS_KEYS: {
-    CACHES: { PAID_ACCESS: 'test:paid-access', PAID_ACCESS_CAP_TIER: 'test:cap-tier' },
-  },
-}));
+//
+// cache-helpers is mocked directly and deliberately — the point of this file is to run lookupFn, which the
+// canonical fake never calls.
 vi.mock('~/server/utils/cache-helpers', () => ({
   createCachedObject: ({
     lookupFn,
@@ -29,11 +19,25 @@ vi.mock('~/server/utils/cache-helpers', () => ({
   }),
 }));
 
+const paidAccessFindMany = dbMock.dbRead.paidAccess.findMany;
+const saleItemFindMany = dbMock.dbRead.modelVersionSaleItem.findMany;
+
 import { getPaidAccess } from '~/server/services/paid-access.service';
 
-const PERMANENT = { entityId: 1, ownerId: 9, endsAt: null, timeframeDays: null, terms: { download: { price: 500 } } };
+const PERMANENT = {
+  entityId: 1,
+  ownerId: 9,
+  endsAt: null,
+  timeframeDays: null,
+  terms: { download: { price: 500 } },
+};
 const ALSO_PERMANENT = { ...PERMANENT, entityId: 2 };
-const TIMED = { ...PERMANENT, entityId: 3, timeframeDays: 7, endsAt: new Date('2099-01-01T00:00:00.000Z') };
+const TIMED = {
+  ...PERMANENT,
+  entityId: 3,
+  timeframeDays: 7,
+  endsAt: new Date('2099-01-01T00:00:00.000Z'),
+};
 
 const saleRow = (modelVersionId: number, id: number, userId = 9) => ({
   modelVersionId,
@@ -50,13 +54,13 @@ const saleRow = (modelVersionId: number, id: number, userId = 9) => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockDb.modelVersionSaleItem.findMany.mockResolvedValue([]);
+  saleItemFindMany.mockResolvedValue([]);
 });
 
 describe('getSalesFor — which sales reach which version', () => {
   it('attributes each sale only to the version it covers', async () => {
-    mockDb.paidAccess.findMany.mockResolvedValue([PERMANENT, ALSO_PERMANENT]);
-    mockDb.modelVersionSaleItem.findMany.mockResolvedValue([saleRow(1, 11), saleRow(2, 22)]);
+    paidAccessFindMany.mockResolvedValue([PERMANENT, ALSO_PERMANENT]);
+    saleItemFindMany.mockResolvedValue([saleRow(1, 11), saleRow(2, 22)]);
 
     const out = await getPaidAccess('ModelVersion', [1, 2]);
 
@@ -65,45 +69,49 @@ describe('getSalesFor — which sales reach which version', () => {
   });
 
   it('scopes the query to the requested versions and to live-or-upcoming, uncancelled sales', async () => {
-    mockDb.paidAccess.findMany.mockResolvedValue([PERMANENT]);
+    paidAccessFindMany.mockResolvedValue([PERMANENT]);
 
     await getPaidAccess('ModelVersion', [1]);
 
-    const where = mockDb.modelVersionSaleItem.findMany.mock.calls[0][0].where;
+    const where = saleItemFindMany.mock.calls[0][0].where;
     expect(where.modelVersionId).toEqual({ in: [1] });
     expect(where.sale.endsAt.gt).toBeInstanceOf(Date);
     expect(where.sale.OR).toEqual([{ canceledAt: null }, { canceledAt: { gt: expect.any(Date) } }]);
   });
 
   it('never asks for sales on a TIMED early-access gate — sales are paid-access only', async () => {
-    mockDb.paidAccess.findMany.mockResolvedValue([TIMED]);
+    paidAccessFindMany.mockResolvedValue([TIMED]);
 
     const out = await getPaidAccess('ModelVersion', [3]);
 
     // The gate type is mutable after a sale is authored, so this cannot be left to the authoring refusal.
-    expect(mockDb.modelVersionSaleItem.findMany).not.toHaveBeenCalled();
+    expect(saleItemFindMany).not.toHaveBeenCalled();
     expect(out[3]?.sales).toEqual([]);
   });
 
   it('asks only about gated versions, and not at all when a batch is entirely free', async () => {
-    mockDb.paidAccess.findMany.mockResolvedValue([PERMANENT]);
+    paidAccessFindMany.mockResolvedValue([PERMANENT]);
 
     await getPaidAccess('ModelVersion', [1, 404, 405]);
 
-    expect(mockDb.modelVersionSaleItem.findMany.mock.calls[0][0].where.modelVersionId).toEqual({ in: [1] });
+    expect(saleItemFindMany.mock.calls[0][0].where.modelVersionId).toEqual({
+      in: [1],
+    });
 
     vi.clearAllMocks();
-    mockDb.paidAccess.findMany.mockResolvedValue([]);
+    paidAccessFindMany.mockResolvedValue([]);
     await getPaidAccess('ModelVersion', [500, 501]);
-    expect(mockDb.modelVersionSaleItem.findMany).not.toHaveBeenCalled();
+    expect(saleItemFindMany).not.toHaveBeenCalled();
   });
 
   it('asks for no sales on a ComicChapter gate', async () => {
-    mockDb.paidAccess.findMany.mockResolvedValue([{ ...PERMANENT, terms: { access: { price: 10 } } }]);
+    paidAccessFindMany.mockResolvedValue([
+      { ...PERMANENT, terms: { access: { price: 10 } } },
+    ]);
 
     await getPaidAccess('ComicChapter', [1]);
 
-    expect(mockDb.modelVersionSaleItem.findMany).not.toHaveBeenCalled();
+    expect(saleItemFindMany).not.toHaveBeenCalled();
   });
 });
 
@@ -112,8 +120,8 @@ describe('getSalesFor — a sale may only price its own author’s versions', ()
     // Sales are authored in a different application. Without this re-check the main app would treat any
     // sale row as authoritative over any version id it names, and the only ownership guard would live
     // outside this codebase entirely.
-    mockDb.paidAccess.findMany.mockResolvedValue([PERMANENT]);
-    mockDb.modelVersionSaleItem.findMany.mockResolvedValue([saleRow(1, 11, 999)]);
+    paidAccessFindMany.mockResolvedValue([PERMANENT]);
+    saleItemFindMany.mockResolvedValue([saleRow(1, 11, 999)]);
 
     const out = await getPaidAccess('ModelVersion', [1]);
 
@@ -121,8 +129,8 @@ describe('getSalesFor — a sale may only price its own author’s versions', ()
   });
 
   it('keeps a sale authored by the version’s own owner', async () => {
-    mockDb.paidAccess.findMany.mockResolvedValue([PERMANENT]);
-    mockDb.modelVersionSaleItem.findMany.mockResolvedValue([saleRow(1, 11, PERMANENT.ownerId)]);
+    paidAccessFindMany.mockResolvedValue([PERMANENT]);
+    saleItemFindMany.mockResolvedValue([saleRow(1, 11, PERMANENT.ownerId)]);
 
     const out = await getPaidAccess('ModelVersion', [1]);
 

--- a/src/server/services/__tests__/paid-access.sales-query.service.test.ts
+++ b/src/server/services/__tests__/paid-access.sales-query.service.test.ts
@@ -105,9 +105,7 @@ describe('getSalesFor — which sales reach which version', () => {
   });
 
   it('asks for no sales on a ComicChapter gate', async () => {
-    paidAccessFindMany.mockResolvedValue([
-      { ...PERMANENT, terms: { access: { price: 10 } } },
-    ]);
+    paidAccessFindMany.mockResolvedValue([{ ...PERMANENT, terms: { access: { price: 10 } } }]);
 
     await getPaidAccess('ComicChapter', [1]);
 

--- a/src/server/services/__tests__/paid-access.sales-query.service.test.ts
+++ b/src/server/services/__tests__/paid-access.sales-query.service.test.ts
@@ -76,6 +76,9 @@ describe('getSalesFor — which sales reach which version', () => {
     const where = saleItemFindMany.mock.calls[0][0].where;
     expect(where.modelVersionId).toEqual({ in: [1] });
     expect(where.sale.endsAt.gt).toBeInstanceOf(Date);
+    // The BOUND, not just its shape: asserting instanceof passed for `new Date(0)`, which loads and
+    // caches every sale ever run.
+    expect(Math.abs(where.sale.endsAt.gt.getTime() - Date.now())).toBeLessThan(5_000);
     expect(where.sale.OR).toEqual([{ canceledAt: null }, { canceledAt: { gt: expect.any(Date) } }]);
   });
 

--- a/src/server/services/__tests__/paid-access.service.test.ts
+++ b/src/server/services/__tests__/paid-access.service.test.ts
@@ -638,6 +638,7 @@ describe('getViewerMonetization — what the UI is told about a sale', () => {
 
     expect(out[1].paidAccess?.terms).toEqual({ download: { price: 800 } });
     expect(out[1].sale?.listTerms).toEqual({ download: { price: 1000 } });
+    expect(out[1].sale?.buyerTerms).toEqual({ download: { price: 800 } });
     expect(out[1].sale?.endsAt).toEqual(FUTURE);
     // The discount travels with the sale so a badge can say "20% off" without deriving it client-side.
     expect(out[1].sale?.discountType).toBe('Percent');
@@ -655,6 +656,9 @@ describe('getViewerMonetization — what the UI is told about a sale', () => {
     expect(out[1].sale?.discountType).toBe('Percent');
     expect(out[1].sale?.discountAmount).toBe(20);
     expect(out[1].sale?.endsAt).toEqual(FUTURE);
+    // And the buyer price, or the owner is shown a page of stored prices with a banner claiming a
+    // discount whose actual number appears nowhere.
+    expect(out[1].sale?.buyerTerms).toEqual({ download: { price: 800 } });
   });
 
   it('reports no sale when there is none', async () => {

--- a/src/server/services/__tests__/paid-access.service.test.ts
+++ b/src/server/services/__tests__/paid-access.service.test.ts
@@ -415,6 +415,7 @@ describe('getViewerMonetization — an unset gate/fee is never invented', () => 
 
     expect(out[1]).toEqual({
       paidAccess: undefined,
+      sale: null,
       licensingFee: null,
       effectiveLicensingFee: null,
     });
@@ -597,5 +598,72 @@ describe('getViewerMonetization — a scheduled sale on top of the gate price', 
     const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: OWNER } });
 
     expect(out[1].paidAccess?.terms).toEqual({ download: { price: 1000 } });
+  });
+});
+
+describe('getViewerMonetization — what the UI is told about a sale', () => {
+  const OWNER = 7;
+  const FUTURE = new Date('2099-01-01T00:00:00.000Z');
+  const PAST = new Date('2020-01-01T00:00:00.000Z');
+
+  const sale = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    discountType: 'Percent',
+    discountAmount: 20,
+    startsAtMs: PAST.getTime(),
+    endsAtMs: FUTURE.getTime(),
+    canceledAtMs: null,
+    ...over,
+  });
+
+  const row = (over: Record<string, unknown> = {}) => ({
+    entityId: 1,
+    ownerId: OWNER,
+    endsAtMs: FUTURE.getTime(),
+    timeframeDays: null,
+    terms: { download: { price: 1000 } },
+    sales: [],
+    ...over,
+  });
+
+  const drive = (gates: Record<string, unknown>, tier: string | null = 'gold') =>
+    mockCacheFetch.mockImplementation(async (key: string) =>
+      key === 'test:cap-tier' ? { [OWNER]: { userId: OWNER, tier } } : gates
+    );
+
+  it('reports the pre-sale price and the end date, so the UI never recomputes the discount', async () => {
+    drive({ 1: row({ sales: [sale()] }) });
+
+    const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: 2 } });
+
+    expect(out[1].paidAccess?.terms).toEqual({ download: { price: 800 } });
+    expect(out[1].sale?.listTerms).toEqual({ download: { price: 1000 } });
+    expect(out[1].sale?.endsAt).toEqual(FUTURE);
+  });
+
+  it('reports no sale to the owner, who is shown the stored price', async () => {
+    drive({ 1: row({ sales: [sale()] }) });
+
+    const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: OWNER } });
+
+    expect(out[1].sale).toBeNull();
+  });
+
+  it('reports no sale when there is none', async () => {
+    drive({ 1: row() });
+
+    const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: 2 } });
+
+    expect(out[1].sale).toBeNull();
+  });
+
+  it('reports no sale when the discount rounds away to nothing', async () => {
+    // 1% of 50 floors to 0. Drawing a strikethrough over an unchanged number would read as a broken page.
+    drive({ 1: row({ terms: { download: { price: 50 } }, sales: [sale({ discountAmount: 1 })] }) });
+
+    const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: 2 } });
+
+    expect(out[1].paidAccess?.terms).toEqual({ download: { price: 50 } });
+    expect(out[1].sale).toBeNull();
   });
 });

--- a/src/server/services/__tests__/paid-access.service.test.ts
+++ b/src/server/services/__tests__/paid-access.service.test.ts
@@ -669,6 +669,28 @@ describe('getViewerMonetization — what the UI is told about a sale', () => {
     expect(out[1].sale).toBeNull();
   });
 
+  it('reports a sale on a GENERATION-ONLY gate, which has no download price at all', async () => {
+    // Every other fixture here has a download tier. A review found that both branches decided "is there
+    // a sale" from the download price alone, so a gen-only gate reported NO sale to anyone while the
+    // charge discounted it — and the card badged it, promising what the page then denied.
+    drive({ 1: row({ terms: { generation: { price: 1000, trialLimit: 5 } }, sales: [sale()] }) });
+
+    const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: 2 } });
+
+    expect(out[1].paidAccess?.terms).toEqual({ generation: { price: 800, trialLimit: 5 } });
+    expect(out[1].sale?.discountAmount).toBe(20);
+    expect(out[1].sale?.buyerTerms).toEqual({ generation: { price: 800, trialLimit: 5 } });
+  });
+
+  it('still reports nothing on a gen-only gate when no sale is running', async () => {
+    drive({ 1: row({ terms: { generation: { price: 1000, trialLimit: 5 } } }) });
+
+    const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: 2 } });
+
+    expect(out[1].sale).toBeNull();
+    expect(out[1].paidAccess?.terms).toEqual({ generation: { price: 1000, trialLimit: 5 } });
+  });
+
   it('reports no sale when the discount rounds away to nothing', async () => {
     // 1% of 50 floors to 0. Drawing a strikethrough over an unchanged number would read as a broken page.
     drive({ 1: row({ terms: { download: { price: 50 } }, sales: [sale({ discountAmount: 1 })] }) });

--- a/src/server/services/__tests__/paid-access.service.test.ts
+++ b/src/server/services/__tests__/paid-access.service.test.ts
@@ -519,3 +519,83 @@ describe('assertPaidAccessCaps — the price ceiling is permanent-only', () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe('getViewerMonetization — a scheduled sale on top of the gate price', () => {
+  const OWNER = 7;
+  const FUTURE = new Date('2099-01-01T00:00:00.000Z');
+  const PAST = new Date('2020-01-01T00:00:00.000Z');
+
+  const sale = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    discountType: 'Percent',
+    discountAmount: 20,
+    startsAtMs: PAST.getTime(),
+    endsAtMs: FUTURE.getTime(),
+    canceledAtMs: null,
+    ...over,
+  });
+
+  const row = (over: Record<string, unknown> = {}) => ({
+    entityId: 1,
+    ownerId: OWNER,
+    endsAtMs: FUTURE.getTime(),
+    timeframeDays: null,
+    terms: { download: { price: 1000 } },
+    sales: [],
+    ...over,
+  });
+
+  const drive = (
+    gates: Record<string, unknown>,
+    tiers: Record<number, string | null> = { [OWNER]: 'gold' }
+  ) =>
+    mockCacheFetch.mockImplementation(async (key: string) =>
+      key === 'test:cap-tier'
+        ? Object.fromEntries(
+            Object.entries(tiers).map(([id, tier]) => [id, { userId: Number(id), tier }])
+          )
+        : gates
+    );
+
+  it('discounts the price a buyer is shown', async () => {
+    drive({ 1: row({ sales: [sale()] }) });
+
+    const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: 2 } });
+
+    expect(out[1].paidAccess?.terms).toEqual({ download: { price: 800 } });
+  });
+
+  it('takes the sale off the CAPPED price, not the stored one', async () => {
+    // Lapsed owner: 5000 stored is billed at the free cap of 500, so 20% off must be 400. Discounting
+    // the stored price first would give 4000, which the cap flattens back to 500 and the sale vanishes.
+    drive({ 1: row({ terms: { download: { price: 5000 } }, sales: [sale()] }) }, { [OWNER]: null });
+
+    const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: 2 } });
+
+    expect(out[1].paidAccess?.terms).toEqual({ download: { price: 400 } });
+  });
+
+  it('ignores a sale that has been cancelled, even while its window is still open', async () => {
+    drive({ 1: row({ sales: [sale({ canceledAtMs: PAST.getTime() })] }) });
+
+    const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: 2 } });
+
+    expect(out[1].paidAccess?.terms).toEqual({ download: { price: 1000 } });
+  });
+
+  it('ignores a sale whose window has not opened yet', async () => {
+    drive({ 1: row({ sales: [sale({ startsAtMs: FUTURE.getTime() })] }) });
+
+    const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: 2 } });
+
+    expect(out[1].paidAccess?.terms).toEqual({ download: { price: 1000 } });
+  });
+
+  it('leaves the OWNER the undiscounted stored price, as with the cap', async () => {
+    drive({ 1: row({ sales: [sale()] }) });
+
+    const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: OWNER } });
+
+    expect(out[1].paidAccess?.terms).toEqual({ download: { price: 1000 } });
+  });
+});

--- a/src/server/services/__tests__/paid-access.service.test.ts
+++ b/src/server/services/__tests__/paid-access.service.test.ts
@@ -639,14 +639,22 @@ describe('getViewerMonetization — what the UI is told about a sale', () => {
     expect(out[1].paidAccess?.terms).toEqual({ download: { price: 800 } });
     expect(out[1].sale?.listTerms).toEqual({ download: { price: 1000 } });
     expect(out[1].sale?.endsAt).toEqual(FUTURE);
+    // The discount travels with the sale so a badge can say "20% off" without deriving it client-side.
+    expect(out[1].sale?.discountType).toBe('Percent');
+    expect(out[1].sale?.discountAmount).toBe(20);
   });
 
-  it('reports no sale to the owner, who is shown the stored price', async () => {
+  it('tells the OWNER about their own sale, while still quoting them the stored price', async () => {
+    // Their editors write the stored terms back, so those must not be discounted — but suppressing the
+    // sale entirely made a creator's own model page the one place their live sale was invisible.
     drive({ 1: row({ sales: [sale()] }) });
 
     const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: OWNER } });
 
-    expect(out[1].sale).toBeNull();
+    expect(out[1].paidAccess?.terms).toEqual({ download: { price: 1000 } });
+    expect(out[1].sale?.discountType).toBe('Percent');
+    expect(out[1].sale?.discountAmount).toBe(20);
+    expect(out[1].sale?.endsAt).toEqual(FUTURE);
   });
 
   it('reports no sale when there is none', async () => {

--- a/src/server/services/generation/__tests__/paid-access-gating.test.ts
+++ b/src/server/services/generation/__tests__/paid-access-gating.test.ts
@@ -11,6 +11,7 @@ const { mockGetPaidAccess, mockHasEntityAccess, mockGetViewerMonetization } = vi
 // rows so these tests stay about the ACCESS decision. Pricing has its own tests in paid-access.service.
 vi.mock('~/server/services/paid-access.service', () => ({
   getViewerMonetization: mockGetViewerMonetization,
+  bustModelSaleCache: vi.fn(),
 }));
 vi.mock('~/server/services/common.service', () => ({ hasEntityAccess: mockHasEntityAccess }));
 

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -81,6 +81,7 @@ import {
   assertPaidAccessInput,
   getCachedCapTier,
   getPaidAccess,
+  getFreshSalesForVersion,
   materializePaidAccessEndsAt,
   writePaidAccessForModelVersion,
 } from '~/server/services/paid-access.service';
@@ -88,6 +89,8 @@ import {
   type ModelVersionTerms,
   capMediaType,
   effectivePaidAccessPrice,
+  bestSaleFor,
+  saleDiscountFor,
   isPermanentGate,
   acceptsBlueBuzz,
   generationPrice,
@@ -2230,10 +2233,19 @@ export const earlyAccessPurchase = async ({
   const permanent = isPermanentGate(paidAccess);
   // Skipped for a timed gate: there's nothing to clamp against, so no reason to pay for the lookup.
   const ownerTier = permanent ? await getCachedCapTier(modelVersion.model.userId) : null;
-  const amount = effectivePaidAccessPrice(storedPrice, ownerTier, {
+  const cappedAmount = effectivePaidAccessPrice(storedPrice, ownerTier, {
     permanent,
     mediaType: capMediaType(modelVersion.baseModel),
   });
+  // Sales are read from the PRIMARY, not the cached gate: a cancelled sale must stop discounting the moment
+  // the creator ends it, and the cache is an hour behind with a fire-and-forget bust. Applied after the cap
+  // for the same reason getViewerMonetization does — the two must agree or buyers are billed a price they
+  // were never shown. The floor at 1 is a backstop, not the rule: Creator Studio refuses a sale that would
+  // take any covered version to zero, because a free purchase writes no ledger row and the 30-day refund
+  // path reads amounts back from the ledger. This keeps the money path safe if that refusal is ever missed.
+  const sales = await getFreshSalesForVersion(modelVersionId);
+  const sale = bestSaleFor(cappedAmount, sales);
+  const amount = sale ? Math.max(1, cappedAmount - saleDiscountFor(cappedAmount, sale)) : cappedAmount;
 
   const accessRecord = await dbWrite.entityAccess.findFirst({
     where: {

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -2575,7 +2575,11 @@ export const bustMvCache = async (
   await resourceDataCache.bust(versionIds);
   // The sale badge is cached per MODEL and reached only from here — Creator Studio's bust POSTs to the
   // endpoint that calls this, so without it a cancelled sale stayed advertised for the whole TTL.
-  await bustModelSaleCache(versionIds).catch(() => undefined);
+  try {
+    await bustModelSaleCache(versionIds);
+  } catch {
+    // Best-effort, like the busts around it: a stale badge is not worth failing an unpublish over.
+  }
   await bustOrchestratorModelCache(versionIds, userId);
   await modelVersionAccessCache.refresh(versionIds);
   // Refresh imagesForModelVersionsCache too — TTL is up to 1 day on Datapacket,

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -81,7 +81,7 @@ import {
   assertPaidAccessInput,
   getCachedCapTier,
   getPaidAccess,
-  getFreshSalesForVersion,
+  getFreshSalesForPermanentGate,
   materializePaidAccessEndsAt,
   writePaidAccessForModelVersion,
 } from '~/server/services/paid-access.service';
@@ -89,8 +89,7 @@ import {
   type ModelVersionTerms,
   capMediaType,
   effectivePaidAccessPrice,
-  bestSaleFor,
-  saleDiscountFor,
+  discountedPrice,
   isPermanentGate,
   acceptsBlueBuzz,
   generationPrice,
@@ -2240,12 +2239,10 @@ export const earlyAccessPurchase = async ({
   // Sales are read from the PRIMARY, not the cached gate: a cancelled sale must stop discounting the moment
   // the creator ends it, and the cache is an hour behind with a fire-and-forget bust. Applied after the cap
   // for the same reason getViewerMonetization does — the two must agree or buyers are billed a price they
-  // were never shown. The floor at 1 is a backstop, not the rule: Creator Studio refuses a sale that would
-  // take any covered version to zero, because a free purchase writes no ledger row and the 30-day refund
-  // path reads amounts back from the ledger. This keeps the money path safe if that refusal is ever missed.
-  const sales = await getFreshSalesForVersion(modelVersionId);
-  const sale = bestSaleFor(cappedAmount, sales);
-  const amount = sale ? Math.max(1, cappedAmount - saleDiscountFor(cappedAmount, sale)) : cappedAmount;
+  // were never shown — so both call the SAME discountedPrice, which also owns the floor. Two copies of this
+  // arithmetic had already drifted apart on that floor once.
+  const sales = await getFreshSalesForPermanentGate(modelVersionId, permanent, paidAccess.ownerId);
+  const amount = discountedPrice(cappedAmount, sales);
 
   const accessRecord = await dbWrite.entityAccess.findFirst({
     where: {

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -82,6 +82,7 @@ import {
   getCachedCapTier,
   getPaidAccess,
   getFreshSalesForPermanentGate,
+  bustModelSaleCache,
   materializePaidAccessEndsAt,
   writePaidAccessForModelVersion,
 } from '~/server/services/paid-access.service';
@@ -2572,6 +2573,9 @@ export const bustMvCache = async (
 ) => {
   const versionIds = Array.isArray(ids) ? ids : [ids];
   await resourceDataCache.bust(versionIds);
+  // The sale badge is cached per MODEL and reached only from here — Creator Studio's bust POSTs to the
+  // endpoint that calls this, so without it a cancelled sale stayed advertised for the whole TTL.
+  await bustModelSaleCache(versionIds).catch(() => undefined);
   await bustOrchestratorModelCache(versionIds, userId);
   await modelVersionAccessCache.refresh(versionIds);
   // Refresh imagesForModelVersionsCache too — TTL is up to 1 day on Datapacket,

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -379,6 +379,7 @@ export const getModelsRaw = async ({
     ids,
     earlyAccess,
     paidAccess,
+    onSale,
     supportsGeneration,
     fromPlatform,
     needsReview,
@@ -760,6 +761,26 @@ export const getModelsRaw = async ({
         JOIN "ModelVersion" pamv ON pamv.id = pa."entityId"
         WHERE pa."entityType" = 'ModelVersion' AND pamv."modelId" = m.id
           AND pamv.status = 'Published'::"ModelStatus" AND pa."timeframeDays" IS NULL
+      )`
+    );
+  }
+  if (onSale) {
+    // A sale prices a PERMANENT gate only (timeframeDays IS NULL), matching the resolver — a version in a
+    // timed early-access window is never discounted, so listing it as on sale would be a lie the price
+    // page then contradicts. Ownership is re-checked here for the same reason the resolver does it: sales
+    // are authored in another application.
+    AND.push(
+      Prisma.sql`EXISTS (
+        SELECT 1 FROM "ModelVersionSaleItem" si
+        JOIN "ModelVersionSale" s ON s.id = si."saleId"
+        JOIN "ModelVersion" smv ON smv.id = si."modelVersionId"
+        JOIN "PaidAccess" spa ON spa."entityType" = 'ModelVersion' AND spa."entityId" = smv.id
+        WHERE smv."modelId" = m.id
+          AND smv.status = 'Published'::"ModelStatus"
+          AND spa."timeframeDays" IS NULL
+          AND s."userId" = m."userId"
+          AND s."startsAt" <= NOW() AND s."endsAt" > NOW()
+          AND (s."canceledAt" IS NULL OR s."canceledAt" > NOW())
       )`
     );
   }

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -92,7 +92,8 @@ type PaidAccessCacheRow = {
 async function getSalesFor(
   db: typeof dbRead | typeof dbWrite,
   entityType: PaidAccessEntityType,
-  entityIds: number[]
+  entityIds: number[],
+  ownerByEntityId: Map<number, number> = new Map()
 ): Promise<Map<number, CachedSale[]>> {
   const out = new Map<number, CachedSale[]>();
   if (entityType !== 'ModelVersion' || !entityIds.length) return out;
@@ -107,6 +108,7 @@ async function getSalesFor(
       sale: {
         select: {
           id: true,
+          userId: true,
           discountType: true,
           discountAmount: true,
           startsAt: true,
@@ -116,7 +118,14 @@ async function getSalesFor(
       },
     },
   });
+  // Who may reprice a version is re-checked HERE, not trusted from the row. Sales are authored in a
+  // different application, so without this the main app treats any sale row as authoritative over any
+  // version id it names — a mutation whose only ownership guard lives outside this codebase.
+  const ownerOfVersion = new Map(
+    entityIds.map((id) => [id, ownerByEntityId.get(id) ?? null] as const)
+  );
   for (const item of items) {
+    if (item.sale.userId !== ownerOfVersion.get(item.modelVersionId)) continue;
     const list = out.get(item.modelVersionId) ?? [];
     list.push({
       id: item.sale.id,
@@ -157,7 +166,18 @@ function createPaidAccessCache(entityType: PaidAccessEntityType) {
         where: { entityType, entityId: { in: entityIds } },
         select: { entityId: true, ownerId: true, endsAt: true, timeframeDays: true, terms: true },
       });
-      const salesByVersion = await getSalesFor(db, entityType, entityIds);
+      // Sales cover PERMANENT paid access only, never a timed early-access window. Enforced here rather
+      // than at authoring because the gate type is mutable after a sale exists — a creator can switch a
+      // permanent gate to a timed one, so an authoring-time refusal cannot hold this invariant.
+      // Passing gated ids rather than every requested id also keeps the query off the ~99.6% of versions
+      // that carry no gate at all, and skips it entirely for an all-free batch.
+      const permanentIds = rows.filter((r) => r.timeframeDays == null).map((r) => r.entityId);
+      const salesByVersion = await getSalesFor(
+        db,
+        entityType,
+        permanentIds,
+        new Map(rows.map((r) => [r.entityId, r.ownerId]))
+      );
       return rows.reduce((acc, r) => {
         acc[r.entityId.toString()] = {
           entityId: r.entityId,
@@ -189,10 +209,25 @@ function paidAccessCache(entityType: PaidAccessEntityType) {
  * could otherwise keep discounting real purchases long after the creator ended it.
  */
 export async function getFreshSalesForVersion(
-  modelVersionId: number
+  modelVersionId: number,
+  ownerId: number
 ): Promise<ModelVersionSaleWindow[]> {
-  const byVersion = await getSalesFor(dbWrite, 'ModelVersion', [modelVersionId]);
+  const byVersion = await getSalesFor(
+    dbWrite,
+    'ModelVersion',
+    [modelVersionId],
+    new Map([[modelVersionId, ownerId]])
+  );
   return (byVersion.get(modelVersionId) ?? []).map(hydrateSale);
+}
+
+/** Sales that may price a gate: none at all unless the gate is permanent. See getSalesFor's note. */
+export async function getFreshSalesForPermanentGate(
+  modelVersionId: number,
+  permanent: boolean,
+  ownerId: number
+): Promise<ModelVersionSaleWindow[]> {
+  return permanent ? getFreshSalesForVersion(modelVersionId, ownerId) : [];
 }
 
 /** Decorate a bounded set of entity ids with their PaidAccess row (absent = free). */

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -218,10 +218,16 @@ function paidAccessCache(entityType: PaidAccessEntityType) {
 export async function getActiveSalesForModels(
   modelIds: number[],
   now: Date = new Date()
-): Promise<Record<number, { endsAt: Date }>> {
+): Promise<
+  Record<number, { endsAt: Date; discountType: SaleDiscountKind; discountAmount: number }>
+> {
   if (!modelIds.length) return {};
-  const rows = await dbRead.$queryRaw<{ modelId: number; endsAt: Date }[]>`
-    SELECT mv."modelId" AS "modelId", MIN(s."endsAt") AS "endsAt"
+  const rows = await dbRead.$queryRaw<
+    { modelId: number; endsAt: Date; discountType: SaleDiscountKind; discountAmount: number }[]
+  >`
+    SELECT DISTINCT ON (mv."modelId")
+      mv."modelId" AS "modelId", s."endsAt" AS "endsAt",
+      s."discountType" AS "discountType", s."discountAmount" AS "discountAmount"
     FROM "ModelVersionSaleItem" si
     JOIN "ModelVersionSale" s ON s.id = si."saleId"
     JOIN "ModelVersion" mv ON mv.id = si."modelVersionId"
@@ -233,9 +239,14 @@ export async function getActiveSalesForModels(
       AND s."userId" = m."userId"
       AND s."startsAt" <= ${now} AND s."endsAt" > ${now}
       AND (s."canceledAt" IS NULL OR s."canceledAt" > ${now})
-    GROUP BY mv."modelId"
+    ORDER BY mv."modelId", s."endsAt"
   `;
-  return Object.fromEntries(rows.map((r) => [Number(r.modelId), { endsAt: r.endsAt }]));
+  return Object.fromEntries(
+    rows.map((r) => [
+      Number(r.modelId),
+      { endsAt: r.endsAt, discountType: r.discountType, discountAmount: r.discountAmount },
+    ])
+  );
 }
 
 /**
@@ -380,7 +391,12 @@ export type ViewerMonetization = {
    * pre-sale terms so a surface can show what the price was without recomputing the discount — and so
    * nothing downstream has to know how a sale is resolved to be able to draw one.
    */
-  sale: { listTerms: ModelVersionTerms; endsAt: Date } | null;
+  sale: {
+    listTerms: ModelVersionTerms;
+    endsAt: Date;
+    discountType: SaleDiscountKind;
+    discountAmount: number;
+  } | null;
   /** What THIS viewer is quoted. The owner and moderators see the stored value, not the capped one. */
   licensingFee: number | null;
   /**
@@ -446,9 +462,23 @@ export async function getViewerMonetization({
           )
         : null;
     if (!cappableIds.has(v.id)) {
+      // An owner or moderator is shown the STORED price — their editors write it back — but they are still
+      // told a sale is running. Suppressing it here made a creator's own model page the one place their
+      // own live sale was invisible.
+      const ownerSale = row?.sales?.length
+        ? bestSaleFor(gatePrices(row.terms as ModelVersionTerms).download, row.sales)
+        : undefined;
       out[v.id] = {
         paidAccess: row,
-        sale: null,
+        sale:
+          ownerSale && row
+            ? {
+                listTerms: row.terms as ModelVersionTerms,
+                endsAt: ownerSale.endsAt,
+                discountType: ownerSale.discountType,
+                discountAmount: ownerSale.discountAmount,
+              }
+            : null,
         licensingFee: storedFee,
         effectiveLicensingFee: effectiveFee,
       };
@@ -481,7 +511,12 @@ export async function getViewerMonetization({
         listTerms &&
         saleTerms &&
         gatePrices(saleTerms).download < gatePrices(listTerms).download
-          ? { listTerms, endsAt: activeSale.endsAt }
+          ? {
+              listTerms,
+              endsAt: activeSale.endsAt,
+              discountType: activeSale.discountType,
+              discountAmount: activeSale.discountAmount,
+            }
           : null,
       licensingFee:
         storedFee != null ? effectiveLicensingFee(storedFee, tier, v.modelType, mediaType) : null,

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -215,13 +215,39 @@ function paidAccessCache(entityType: PaidAccessEntityType) {
  * Same predicate as the resolver, for the same reasons: permanent gates only (a timed early-access
  * window is never discounted), and the sale's author must own the model.
  */
-export async function getActiveSalesForModels(
-  modelIds: number[],
-  now: Date = new Date()
-): Promise<
-  Record<number, { endsAt: Date; discountType: SaleDiscountKind; discountAmount: number }>
-> {
-  if (!modelIds.length) return {};
+type CachedModelSale = {
+  modelId: number;
+  endsAtMs: number;
+  discountType: SaleDiscountKind;
+  discountAmount: number;
+};
+
+// Same bucket-per-entity pattern as the other model-side caches, and the same rule as the gate cache:
+// what is cached is the sale WINDOW, never "is on sale". A boolean would go stale at exactly the two
+// moments that matter. Short TTL because a creator cancelling wants the badge gone quickly, and unlike
+// the price this is only a label — the charge never reads it.
+function createModelSaleCache() {
+  return createCachedObject<CachedModelSale>({
+    key: `${REDIS_KEYS.CACHES.PAID_ACCESS}:ModelSales`,
+    idKey: 'modelId',
+    ttl: CacheTTL.xs,
+    staleWhileRevalidate: false,
+    lookupFn: async (ids) => {
+      const modelIds = (Array.isArray(ids) ? ids : [ids]).filter((id) => id != null);
+      const rows = await querySalesForModels(modelIds);
+      return Object.fromEntries(rows.map((r) => [String(r.modelId), r]));
+    },
+  });
+}
+
+let modelSaleCacheInstance: ReturnType<typeof createModelSaleCache> | undefined;
+function modelSaleCache() {
+  return (modelSaleCacheInstance ??= createModelSaleCache());
+}
+
+async function querySalesForModels(modelIds: number[]): Promise<CachedModelSale[]> {
+  if (!modelIds.length) return [];
+  const now = new Date();
   const rows = await dbRead.$queryRaw<
     { modelId: number; endsAt: Date; discountType: SaleDiscountKind; discountAmount: number }[]
   >`
@@ -237,16 +263,41 @@ export async function getActiveSalesForModels(
       AND mv.status = 'Published'::"ModelStatus"
       AND pa."timeframeDays" IS NULL
       AND s."userId" = m."userId"
-      AND s."startsAt" <= ${now} AND s."endsAt" > ${now}
+      AND s."endsAt" > ${now}
       AND (s."canceledAt" IS NULL OR s."canceledAt" > ${now})
     ORDER BY mv."modelId", s."endsAt"
   `;
-  return Object.fromEntries(
-    rows.map((r) => [
-      Number(r.modelId),
-      { endsAt: r.endsAt, discountType: r.discountType, discountAmount: r.discountAmount },
-    ])
-  );
+  return rows.map((r) => ({
+    modelId: Number(r.modelId),
+    endsAtMs: r.endsAt.getTime(),
+    discountType: r.discountType,
+    discountAmount: r.discountAmount,
+  }));
+}
+
+export async function getActiveSalesForModels(
+  modelIds: number[],
+  now: Date = new Date()
+): Promise<
+  Record<number, { endsAt: Date; discountType: SaleDiscountKind; discountAmount: number }>
+> {
+  if (!modelIds.length) return {};
+  const cached = await modelSaleCache().fetch(modelIds);
+  const out: Record<
+    number,
+    { endsAt: Date; discountType: SaleDiscountKind; discountAmount: number }
+  > = {};
+  for (const row of Object.values(cached)) {
+    if (!row) continue;
+    // Evaluated per request, not baked into the cached value: the window is the durable fact.
+    if (row.endsAtMs <= now.getTime()) continue;
+    out[row.modelId] = {
+      endsAt: new Date(row.endsAtMs),
+      discountType: row.discountType,
+      discountAmount: row.discountAmount,
+    };
+  }
+  return out;
 }
 
 /**

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -217,6 +217,7 @@ function paidAccessCache(entityType: PaidAccessEntityType) {
  */
 type CachedModelSale = {
   modelId: number;
+  startsAtMs: number;
   endsAtMs: number;
   discountType: SaleDiscountKind;
   discountAmount: number;
@@ -249,10 +250,16 @@ async function querySalesForModels(modelIds: number[]): Promise<CachedModelSale[
   if (!modelIds.length) return [];
   const now = new Date();
   const rows = await dbRead.$queryRaw<
-    { modelId: number; endsAt: Date; discountType: SaleDiscountKind; discountAmount: number }[]
+    {
+      modelId: number;
+      startsAt: Date;
+      endsAt: Date;
+      discountType: SaleDiscountKind;
+      discountAmount: number;
+    }[]
   >`
     SELECT DISTINCT ON (mv."modelId")
-      mv."modelId" AS "modelId", s."endsAt" AS "endsAt",
+      mv."modelId" AS "modelId", s."startsAt" AS "startsAt", s."endsAt" AS "endsAt",
       s."discountType" AS "discountType", s."discountAmount" AS "discountAmount"
     FROM "ModelVersionSaleItem" si
     JOIN "ModelVersionSale" s ON s.id = si."saleId"
@@ -269,6 +276,7 @@ async function querySalesForModels(modelIds: number[]): Promise<CachedModelSale[
   `;
   return rows.map((r) => ({
     modelId: Number(r.modelId),
+    startsAtMs: r.startsAt.getTime(),
     endsAtMs: r.endsAt.getTime(),
     discountType: r.discountType,
     discountAmount: r.discountAmount,
@@ -289,8 +297,10 @@ export async function getActiveSalesForModels(
   > = {};
   for (const row of Object.values(cached)) {
     if (!row) continue;
-    // Evaluated per request, not baked into the cached value: the window is the durable fact.
-    if (row.endsAtMs <= now.getTime()) continue;
+    // BOTH edges, evaluated per request against the cached window. Without the start bound a sale
+    // scheduled up to MAX_SALE_LEAD_DAYS out was badged from the moment it was saved, while the model
+    // page and the charge correctly showed full price — the one thing the spec says must never happen.
+    if (row.startsAtMs > now.getTime() || row.endsAtMs <= now.getTime()) continue;
     out[row.modelId] = {
       endsAt: new Date(row.endsAtMs),
       discountType: row.discountType,
@@ -435,6 +445,12 @@ const hasChargeablePrice = (terms: PaidAccessTerms | undefined) => {
   return download > 0 || generation > 0;
 };
 
+/** The price a sale is resolved against: whichever chargeable tier this gate actually has. */
+const saleAnchorPrice = (terms: ModelVersionTerms | undefined): number => {
+  const { download, generation } = gatePrices(terms);
+  return Math.max(download, generation);
+};
+
 export type ViewerMonetization = {
   paidAccess: PaidAccessRow | undefined;
   /**
@@ -524,20 +540,20 @@ export async function getViewerMonetization({
       // An owner or moderator is shown the STORED price — their editors write it back — but they are still
       // told a sale is running. Suppressing it here made a creator's own model page the one place their
       // own live sale was invisible.
-      const ownerSale = row?.sales?.length
-        ? bestSaleFor(gatePrices(row.terms as ModelVersionTerms).download, row.sales)
+      const ownerTier = row?.sales?.length ? capTiers.get(ownerOf(v) as number) ?? null : null;
+      const ownerCapped = row?.sales?.length
+        ? cappedTerms(row.terms as ModelVersionTerms, ownerTier, {
+            permanent: isPermanentGate(row),
+            mediaType: capMediaType(v.baseModel),
+          })
         : undefined;
-      const ownerTier = ownerSale ? capTiers.get(ownerOf(v) as number) ?? null : null;
+      // Resolved against the CAPPED price, the same one discountedTerms will re-pick at. Anchoring on
+      // the stored price let the banner name one sale ("50% off") beside a price produced by another.
+      const ownerSale = ownerCapped
+        ? bestSaleFor(saleAnchorPrice(ownerCapped), row?.sales)
+        : undefined;
       const ownerBuyerTerms =
-        ownerSale && row
-          ? discountedTerms(
-              cappedTerms(row.terms as ModelVersionTerms, ownerTier, {
-                permanent: isPermanentGate(row),
-                mediaType: capMediaType(v.baseModel),
-              }),
-              row.sales
-            )
-          : undefined;
+        ownerSale && ownerCapped ? discountedTerms(ownerCapped, row?.sales) : undefined;
       out[v.id] = {
         paidAccess: row,
         sale:
@@ -571,7 +587,7 @@ export async function getViewerMonetization({
       : undefined;
     const saleTerms = listTerms ? discountedTerms(listTerms, row?.sales) : undefined;
     const activeSale = row?.sales?.length
-      ? bestSaleFor(gatePrices(listTerms).download, row.sales)
+      ? bestSaleFor(saleAnchorPrice(listTerms), row.sales)
       : undefined;
     out[v.id] = {
       paidAccess: row && saleTerms ? { ...row, terms: saleTerms } : undefined,
@@ -581,7 +597,7 @@ export async function getViewerMonetization({
         activeSale &&
         listTerms &&
         saleTerms &&
-        gatePrices(saleTerms).download < gatePrices(listTerms).download
+        saleAnchorPrice(saleTerms) < saleAnchorPrice(listTerms)
           ? {
               listTerms,
               buyerTerms: saleTerms,
@@ -699,6 +715,21 @@ export async function getPublicPaidAccessForModelVersions(
 
 export async function bustPaidAccessCache(entityType: PaidAccessEntityType, entityIds: number[]) {
   if (entityIds.length) await paidAccessCache(entityType).bust(entityIds);
+}
+
+/**
+ * Bust the badge cache for the models these versions belong to. Separate from the gate cache because it
+ * is keyed by MODEL, and it had no bust path at all until a review pointed out that a cancelled sale
+ * therefore stayed advertised for the full TTL every time rather than only when a bust failed.
+ */
+export async function bustModelSaleCache(modelVersionIds: number[]) {
+  if (!modelVersionIds.length) return;
+  const rows = await dbWrite.modelVersion.findMany({
+    where: { id: { in: modelVersionIds } },
+    select: { modelId: true },
+  });
+  const modelIds = [...new Set(rows.map((r) => r.modelId))];
+  if (modelIds.length) await modelSaleCache().bust(modelIds);
 }
 
 /**

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -5,6 +5,9 @@ import {
   capMediaType,
   effectiveLicensingFee,
   gatePrices,
+  discountedTerms,
+  type ModelVersionSaleWindow,
+  type SaleDiscountKind,
   isPaidAccessActive,
   isPermanentGate,
   maxPaidAccessPrice,
@@ -58,13 +61,84 @@ export function assertPaidAccessInput(input: ModelVersionPaidAccessInputSchema |
 // Cache the ROW, not the verdict: endsAt is materialized, so active-ness is derived live and the
 // cache never goes stale on time passing — only on config change / removal (see bustPaidAccessCache).
 
+type CachedSale = {
+  id: number;
+  discountType: SaleDiscountKind;
+  discountAmount: number;
+  startsAtMs: number;
+  endsAtMs: number;
+  canceledAtMs: number | null;
+};
+
 type PaidAccessCacheRow = {
   entityId: number;
   ownerId: number;
   endsAtMs: number | null; // epoch ms (safe to serialize); null = permanent
   timeframeDays: number | null;
   terms: PaidAccessTerms;
+  // Sale WINDOWS, never a discounted price: the row is cached for an hour and a sale turns on and off at a
+  // wall-clock moment, so what's cached has to be the fact that doesn't change while the cache is warm.
+  sales: CachedSale[];
 };
+
+/**
+ * Sales covering a set of versions: live now OR still to come. Upcoming ones are included deliberately —
+ * the row is cached for an hour, so a sale that starts inside that hour has to already be in the cached
+ * value or it would not apply until the entry expired. Cancelled and finished sales are dropped; they can
+ * never become active again.
+ *
+ * Only ModelVersion carries sales; a ComicChapter gate has no discount concept.
+ */
+async function getSalesFor(
+  db: typeof dbRead | typeof dbWrite,
+  entityType: PaidAccessEntityType,
+  entityIds: number[]
+): Promise<Map<number, CachedSale[]>> {
+  const out = new Map<number, CachedSale[]>();
+  if (entityType !== 'ModelVersion' || !entityIds.length) return out;
+  const now = new Date();
+  const items = await db.modelVersionSaleItem.findMany({
+    where: {
+      modelVersionId: { in: entityIds },
+      sale: { endsAt: { gt: now }, OR: [{ canceledAt: null }, { canceledAt: { gt: now } }] },
+    },
+    select: {
+      modelVersionId: true,
+      sale: {
+        select: {
+          id: true,
+          discountType: true,
+          discountAmount: true,
+          startsAt: true,
+          endsAt: true,
+          canceledAt: true,
+        },
+      },
+    },
+  });
+  for (const item of items) {
+    const list = out.get(item.modelVersionId) ?? [];
+    list.push({
+      id: item.sale.id,
+      discountType: item.sale.discountType as SaleDiscountKind,
+      discountAmount: item.sale.discountAmount,
+      startsAtMs: item.sale.startsAt.getTime(),
+      endsAtMs: item.sale.endsAt.getTime(),
+      canceledAtMs: item.sale.canceledAt ? item.sale.canceledAt.getTime() : null,
+    });
+    out.set(item.modelVersionId, list);
+  }
+  return out;
+}
+
+const hydrateSale = (s: CachedSale): ModelVersionSaleWindow => ({
+  id: s.id,
+  discountType: s.discountType,
+  discountAmount: s.discountAmount,
+  startsAt: new Date(s.startsAtMs),
+  endsAt: new Date(s.endsAtMs),
+  canceledAt: s.canceledAtMs != null ? new Date(s.canceledAtMs) : null,
+});
 
 function createPaidAccessCache(entityType: PaidAccessEntityType) {
   return createCachedObject<PaidAccessCacheRow>({
@@ -83,6 +157,7 @@ function createPaidAccessCache(entityType: PaidAccessEntityType) {
         where: { entityType, entityId: { in: entityIds } },
         select: { entityId: true, ownerId: true, endsAt: true, timeframeDays: true, terms: true },
       });
+      const salesByVersion = await getSalesFor(db, entityType, entityIds);
       return rows.reduce((acc, r) => {
         acc[r.entityId.toString()] = {
           entityId: r.entityId,
@@ -90,6 +165,7 @@ function createPaidAccessCache(entityType: PaidAccessEntityType) {
           endsAtMs: r.endsAt ? r.endsAt.getTime() : null,
           timeframeDays: r.timeframeDays,
           terms: (r.terms ?? {}) as PaidAccessTerms,
+          sales: salesByVersion.get(r.entityId) ?? [],
         };
         return acc;
       }, {} as Record<string, PaidAccessCacheRow>);
@@ -105,6 +181,18 @@ const paidAccessCaches: Partial<
 > = {};
 function paidAccessCache(entityType: PaidAccessEntityType) {
   return (paidAccessCaches[entityType] ??= createPaidAccessCache(entityType));
+}
+
+/**
+ * Sales for ONE version, read from the PRIMARY. The charge path must never price from the cached window:
+ * entries live an hour with SWR off and Creator Studio's cache bust is fire-and-forget, so a cancelled sale
+ * could otherwise keep discounting real purchases long after the creator ended it.
+ */
+export async function getFreshSalesForVersion(
+  modelVersionId: number
+): Promise<ModelVersionSaleWindow[]> {
+  const byVersion = await getSalesFor(dbWrite, 'ModelVersion', [modelVersionId]);
+  return (byVersion.get(modelVersionId) ?? []).map(hydrateSale);
 }
 
 /** Decorate a bounded set of entity ids with their PaidAccess row (absent = free). */
@@ -124,6 +212,7 @@ export async function getPaidAccess(
       endsAt: c.endsAtMs != null ? new Date(c.endsAtMs) : null,
       timeframeDays: c.timeframeDays,
       terms: c.terms,
+      sales: (c.sales ?? []).map(hydrateSale),
     };
   }
   return out;
@@ -293,10 +382,16 @@ export async function getViewerMonetization({
       paidAccess: row
         ? {
             ...row,
-            terms: cappedTerms(row.terms as ModelVersionTerms, tier, {
-              permanent: isPermanentGate(row),
-              mediaType,
-            }),
+            // Sale AFTER cap, never before: the ceiling decides what the creator may charge and the
+            // discount comes off what this buyer would actually be billed. Discounting first lets the
+            // cap swallow the sale whole for a lapsed creator.
+            terms: discountedTerms(
+              cappedTerms(row.terms as ModelVersionTerms, tier, {
+                permanent: isPermanentGate(row),
+                mediaType,
+              }),
+              row.sales
+            ),
           }
         : undefined,
       licensingFee:

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -5,6 +5,7 @@ import {
   capMediaType,
   effectiveLicensingFee,
   gatePrices,
+  bestSaleFor,
   discountedTerms,
   type ModelVersionSaleWindow,
   type SaleDiscountKind,
@@ -340,6 +341,12 @@ const hasChargeablePrice = (terms: PaidAccessTerms | undefined) => {
 
 export type ViewerMonetization = {
   paidAccess: PaidAccessRow | undefined;
+  /**
+   * The live sale behind `paidAccess.terms`, when one is discounting THIS viewer's price. Carries the
+   * pre-sale terms so a surface can show what the price was without recomputing the discount — and so
+   * nothing downstream has to know how a sale is resolved to be able to draw one.
+   */
+  sale: { listTerms: ModelVersionTerms; endsAt: Date } | null;
   /** What THIS viewer is quoted. The owner and moderators see the stored value, not the capped one. */
   licensingFee: number | null;
   /**
@@ -405,7 +412,12 @@ export async function getViewerMonetization({
           )
         : null;
     if (!cappableIds.has(v.id)) {
-      out[v.id] = { paidAccess: row, licensingFee: storedFee, effectiveLicensingFee: effectiveFee };
+      out[v.id] = {
+        paidAccess: row,
+        sale: null,
+        licensingFee: storedFee,
+        effectiveLicensingFee: effectiveFee,
+      };
       continue;
     }
     const tier = capTiers.get(ownerOf(v) as number) ?? null;
@@ -413,22 +425,30 @@ export async function getViewerMonetization({
     // cappedTerms no-ops for a timed window: its price isn't ceilinged, so what's stored is what buyers
     // pay. The licensing fee below is capped either way — charged per generation forever, not for the
     // length of a window.
+    // Sale AFTER cap, never before: the ceiling decides what the creator may charge and the discount comes
+    // off what this buyer would actually be billed. Discounting first lets the cap swallow the sale whole
+    // for a lapsed creator.
+    const listTerms = row
+      ? cappedTerms(row.terms as ModelVersionTerms, tier, {
+          permanent: isPermanentGate(row),
+          mediaType,
+        })
+      : undefined;
+    const saleTerms = listTerms ? discountedTerms(listTerms, row?.sales) : undefined;
+    const activeSale = row?.sales?.length
+      ? bestSaleFor(gatePrices(listTerms).download, row.sales)
+      : undefined;
     out[v.id] = {
-      paidAccess: row
-        ? {
-            ...row,
-            // Sale AFTER cap, never before: the ceiling decides what the creator may charge and the
-            // discount comes off what this buyer would actually be billed. Discounting first lets the
-            // cap swallow the sale whole for a lapsed creator.
-            terms: discountedTerms(
-              cappedTerms(row.terms as ModelVersionTerms, tier, {
-                permanent: isPermanentGate(row),
-                mediaType,
-              }),
-              row.sales
-            ),
-          }
-        : undefined,
+      paidAccess: row && saleTerms ? { ...row, terms: saleTerms } : undefined,
+      // Only report a sale that actually moved a price this viewer is quoted: a sale whose discount
+      // rounds to nothing must not draw a strikethrough over an unchanged number.
+      sale:
+        activeSale &&
+        listTerms &&
+        saleTerms &&
+        gatePrices(saleTerms).download < gatePrices(listTerms).download
+          ? { listTerms, endsAt: activeSale.endsAt }
+          : null,
       licensingFee:
         storedFee != null ? effectiveLicensingFee(storedFee, tier, v.modelType, mediaType) : null,
       effectiveLicensingFee: effectiveFee,
@@ -497,13 +517,15 @@ export async function assertPaidAccessCaps({
  * whatever the owner stored.
  */
 export function toModelVersionPaidAccessDto(
-  row: PaidAccessRow | undefined
+  row: PaidAccessRow | undefined,
+  sale: ViewerMonetization['sale'] = null
 ): ModelVersionPaidAccessDto | null {
   if (!row) return null;
   return {
     endsAt: row.endsAt,
     timeframeDays: row.timeframeDays ?? null,
     terms: row.terms as ModelVersionTerms,
+    sale,
   };
 }
 

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -444,6 +444,11 @@ export type ViewerMonetization = {
    */
   sale: {
     listTerms: ModelVersionTerms;
+    /**
+     * What a BUYER is quoted — capped then discounted. Sent even to an owner, who is otherwise shown a
+     * page full of their stored price while a banner claims a discount, with the actual number nowhere.
+     */
+    buyerTerms: ModelVersionTerms;
     endsAt: Date;
     discountType: SaleDiscountKind;
     discountAmount: number;
@@ -496,7 +501,10 @@ export async function getViewerMonetization({
     );
   });
   const feeBearing = versions.filter((v) => (v.licensingFee ?? 0) > 0 && ownerOf(v) != null);
-  const capTiers = await getCapTiers([...cappable, ...feeBearing].map(ownerOf));
+  // Owners of sale-covered versions join the batch too: they are not "cappable" (they see stored terms)
+  // but the buyer price we show them has to be capped against their own tier, like a buyer's would be.
+  const saleBearing = versions.filter((v) => rows[v.id]?.sales?.length && ownerOf(v) != null);
+  const capTiers = await getCapTiers([...cappable, ...feeBearing, ...saleBearing].map(ownerOf));
   const cappableIds = new Set(cappable.map((v) => v.id));
 
   const out: Record<number, ViewerMonetization> = {};
@@ -519,12 +527,24 @@ export async function getViewerMonetization({
       const ownerSale = row?.sales?.length
         ? bestSaleFor(gatePrices(row.terms as ModelVersionTerms).download, row.sales)
         : undefined;
+      const ownerTier = ownerSale ? capTiers.get(ownerOf(v) as number) ?? null : null;
+      const ownerBuyerTerms =
+        ownerSale && row
+          ? discountedTerms(
+              cappedTerms(row.terms as ModelVersionTerms, ownerTier, {
+                permanent: isPermanentGate(row),
+                mediaType: capMediaType(v.baseModel),
+              }),
+              row.sales
+            )
+          : undefined;
       out[v.id] = {
         paidAccess: row,
         sale:
           ownerSale && row
             ? {
                 listTerms: row.terms as ModelVersionTerms,
+                buyerTerms: (ownerBuyerTerms ?? row.terms) as ModelVersionTerms,
                 endsAt: ownerSale.endsAt,
                 discountType: ownerSale.discountType,
                 discountAmount: ownerSale.discountAmount,
@@ -564,6 +584,7 @@ export async function getViewerMonetization({
         gatePrices(saleTerms).download < gatePrices(listTerms).download
           ? {
               listTerms,
+              buyerTerms: saleTerms,
               endsAt: activeSale.endsAt,
               discountType: activeSale.discountType,
               discountAmount: activeSale.discountAmount,

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -205,6 +205,40 @@ function paidAccessCache(entityType: PaidAccessEntityType) {
 }
 
 /**
+ * Which of these models currently have a sale running, and when the soonest one ends.
+ *
+ * Fetched separately from the models themselves. The feed query has several FROM variants and is a hot
+ * path, and a sale is time-varying data that would have to be re-indexed at every window edge to ride
+ * along in the search document — so it rides in neither. One batched lookup keyed by the ids already on
+ * screen, the way cosmetics and version images are already fetched.
+ *
+ * Same predicate as the resolver, for the same reasons: permanent gates only (a timed early-access
+ * window is never discounted), and the sale's author must own the model.
+ */
+export async function getActiveSalesForModels(
+  modelIds: number[],
+  now: Date = new Date()
+): Promise<Record<number, { endsAt: Date }>> {
+  if (!modelIds.length) return {};
+  const rows = await dbRead.$queryRaw<{ modelId: number; endsAt: Date }[]>`
+    SELECT mv."modelId" AS "modelId", MIN(s."endsAt") AS "endsAt"
+    FROM "ModelVersionSaleItem" si
+    JOIN "ModelVersionSale" s ON s.id = si."saleId"
+    JOIN "ModelVersion" mv ON mv.id = si."modelVersionId"
+    JOIN "Model" m ON m.id = mv."modelId"
+    JOIN "PaidAccess" pa ON pa."entityType" = 'ModelVersion' AND pa."entityId" = mv.id
+    WHERE mv."modelId" IN (${Prisma.join(modelIds)})
+      AND mv.status = 'Published'::"ModelStatus"
+      AND pa."timeframeDays" IS NULL
+      AND s."userId" = m."userId"
+      AND s."startsAt" <= ${now} AND s."endsAt" > ${now}
+      AND (s."canceledAt" IS NULL OR s."canceledAt" > ${now})
+    GROUP BY mv."modelId"
+  `;
+  return Object.fromEntries(rows.map((r) => [Number(r.modelId), { endsAt: r.endsAt }]));
+}
+
+/**
  * Sales for ONE version, read from the PRIMARY. The charge path must never price from the cached window:
  * entries live an hour with SWR off and Creator Studio's cache bust is fire-and-forget, so a cancelled sale
  * could otherwise keep discounting real purchases long after the creator ended it.

--- a/src/shared/constants/creator-studio.constants.ts
+++ b/src/shared/constants/creator-studio.constants.ts
@@ -1,0 +1,3 @@
+// The Creator Studio spoke. Hard-coded in a couple of places already (creator-program, the app header);
+// this is the one name to import so a fourth copy does not appear.
+export const CREATOR_STUDIO_URL = 'https://creator-studio.civitai.com';

--- a/src/tests/api/v1/model-versions/id-file-download-url.test.ts
+++ b/src/tests/api/v1/model-versions/id-file-download-url.test.ts
@@ -48,6 +48,7 @@ vi.mock('~/server/services/image.service', () => ({
 vi.mock('~/server/services/paid-access.service', () => ({
   getPaidAccess: mockGetPaidAccess,
   toPublicPaidAccessDto: () => null,
+  bustModelSaleCache: vi.fn(),
 }));
 vi.mock('~/server/services/creator-program.service', () => ({
   hasValidCreatorMembershipCached: async () => false,


### PR DESCRIPTION
Scheduled model sales (ClickUp 868ktk1ku), **the price half**. Authoring is a separate branch (Creator Studio), built in parallel.

Scoped with Justin card-by-card; the full design doc is a comment on the ticket.

## What a sale is

An **overlay**, never a write to the base price. `PaidAccess.terms` is untouched, so a creator who edits their price mid-sale cannot lose it, and what a version cost on a given day stays answerable.

- `discountedPrice` / `discountedTerms` in `@civitai/buzz`, beside `cappedTerms` — the function they compose with.
- **Cap first, then discount.** A lapsed gold creator stored at 5000 is billed 500; 20% off is 400, not 4000 clamped back to 500.
- Applies to the download price **and** a separate generation price. Blue Buzz inherits it — same price, different currency.
- Overlapping sales are allowed (one crossing a month boundary meets the next month's), so the **deepest discount wins**. Percent and fixed have no order until applied to a price, which the tests pin with a pair that inverts across two base prices.
- Floors at **1 Buzz**: a free purchase writes no ledger row, and the 30-day refund path reads amounts back from the ledger.

## The two rules that decide whether this is correct

**The charge never reads the price cache.** Gate rows cache for an hour with SWR off, and Creator Studio's bust is fire-and-forget across apps, so a cancelled sale in cache would keep discounting real purchases. The charge reads the primary. A test fails if that is ever repointed at the cached window.

**Cache the window, never the answer.** A sale turns on and off at a wall-clock moment; the cached row carries the window and active-ness is evaluated per request. Upcoming sales are cached too, or a sale starting inside the hour would not apply until the entry expired.

## Caps

A monthly **sale-day budget** — free 3 / bronze 7 / silver 14 / gold 30 — counted against the month a sale starts in, gated on creator score ≥ 10,000 at every tier. A sale reserves its full window and **returns the untaken tail** when cancelled or shortened, so "you may always cut a sale short" costs the creator nothing.

The tier tables are defaults behind a `sale-limits` KeyValue row, so a limit can move without a deploy and a pricing page can state it without a second copy. **Enforcement lives in Creator Studio**, the authoring app.

## Display

Model page badge (pre-sale price struck through, end date) and an opt-in "On sale" profile section, off by default. The client never recomputes the discount — the server sends the pre-sale price alongside the discounted one.

## Adversarial review

Five lanes at a frozen SHA. It found four things that would have shipped, all fixed here:

- Sales reached **timed Early Access gates**, which the spec forbids and my schema comment asserted as though something enforced it. Now enforced in the read — the gate type is mutable *after* a sale exists, so an authoring-time refusal could never hold it.
- **Two floors**: the resolver floored at 0, the charge at 1, so a 100%-off sale displayed free and billed 1. One shared function now owns it.
- **Sale ownership was never re-checked**, so a sale row was authoritative over any version id it named, with the only guard in another application.
- **The sale query was invisible to every test** — replacing its whole `WHERE` with `{}` printed 55 passed.

Three charge-path tests could not fail and now do: cap-before-discount was pinned only on timed gates where the cap is a no-op, the floor had no fixture reaching it, and no sale test used a generation purchase.

## Not in this PR, deliberately

- **The per-card sale badge across listings.** It needs a select in the multi-variant raw feed query *and* a search-index field with a sync trigger for sale start/end — a second slice, and the hot feed path is the wrong place to be hasty. The `onSale` filter that backs the profile section is here.
- **A feature flag on the main app.** The flag gates authoring, which is what makes sale rows possible at all; a per-viewer flag on a **shared cached row** would poison the cache for other viewers. See the PR discussion.
- **Display-vs-charge staleness after a cancel.** Busting on every sale write narrows it; the bust is fire-and-forget, so the belt-and-braces version is the charge honouring its quote. Recorded as open.

## Migration

`20260819030000_model_version_sales` — applied by hand, as this repo requires. Both tables are created empty in the same migration, so the indexes are deliberately not `CONCURRENTLY`, and the only FK is item→sale, so applying it takes no lock on `ModelVersion` or `User`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
