### PR TITLE
fix(models): stamp the unpublish keys only on versions being taken down

### DIFF
--- a/src/pages/api/internal/restore-models.ts
+++ b/src/pages/api/internal/restore-models.ts
@@ -25,7 +25,11 @@ export default JobEndpoint(async function (req: NextApiRequest, res: NextApiResp
     WHERE mv."modelId" IN (${modelIds.join(',')})
     AND jsonb_typeof(mv.meta->'unpublishedAt') != 'undefined'
     AND (mv.meta->>'unpublishedReason') = 'duplicate'
-    AND mv."status" = 'Unpublished'
+    -- Both encodings: take-downs before the single-statement rewrite left the version at
+    -- 'Unpublished' with a reason in meta; after it, a reasoned take-down writes
+    -- 'UnpublishedViolation'. Matching only the first silently restores an arbitrary subset —
+    -- the older rows — and reports 200 either way.
+    AND mv."status" IN ('Unpublished', 'UnpublishedViolation')
     GROUP BY 1, 2
   `);
 

--- a/src/server/services/__tests__/model-early-access-refund.service.test.ts
+++ b/src/server/services/__tests__/model-early-access-refund.service.test.ts
@@ -11,7 +11,7 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
 // default hands the callback `dbMock.dbWrite`, which would collapse that into the direct calls.
 const { mockTx } = vi.hoisted(() => ({
   mockTx: {
-    modelVersion: { findMany: vi.fn() },
+    $queryRaw: vi.fn(),
     model: {
       findFirst: vi.fn(),
       findUnique: vi.fn(),
@@ -187,7 +187,7 @@ function setupUnpublishWrites({
   allVersionIds = [VERSION_ID, OTHER_VERSION_ID],
   transitioningVersionIds = [VERSION_ID],
 }: { allVersionIds?: number[]; transitioningVersionIds?: number[] } = {}) {
-  mockTx.modelVersion.findMany.mockResolvedValue(transitioningVersionIds.map((id) => ({ id })));
+  mockTx.$queryRaw.mockResolvedValue(transitioningVersionIds.map((id) => ({ id })));
   mockTx.model.update.mockResolvedValue({
     userId: OWNER_ID,
     modelVersions: allVersionIds.map((id) => ({ id })),
@@ -590,52 +590,54 @@ describe('unpublishModelById — early access refund gate', () => {
   // and this is the one operation that used to destroy it: the version rows were written with the
   // MODEL's meta object, replacing the column. An owner could unpublish, shedding the flag, and then
   // delete the version with every guard that reads it gone.
-  // The transaction runs more than one $executeRaw — the Post metadata update is unconditional — so
-  // an assertion on the spy alone passes with the meta merge deleted entirely. These read the
-  // statement.
-  const metaMergeCall = () =>
-    mockTx.$executeRaw.mock.calls.find(([strings]) =>
-      (strings as unknown as string[]).join('').includes('UPDATE "ModelVersion"')
-    );
+  // The take-down is one raw statement: status and meta together, scoped by the model and the two
+  // statuses. These read the SQL itself, because the two properties that matter — that meta is
+  // MERGED rather than replaced, and that the WHERE picks the transitioning rows — live entirely in
+  // the static template segments. An assertion on the interpolated payload is byte-identical under
+  // `meta = COALESCE(meta,'{}') || payload` and under `meta = payload`, which is the bug this code
+  // exists to prevent.
+  const takeDownSql = () =>
+    ((mockTx.$queryRaw.mock.calls[0]?.[0] ?? []) as unknown as string[])
+      .join('?')
+      .replace(/\s+/g, ' ');
+  const takeDownParams = () => mockTx.$queryRaw.mock.calls[0]?.slice(1) ?? [];
 
   it('merges the unpublish keys into each version meta instead of replacing it', async () => {
     setupRefundData({ accessRows: [] });
     setupUnpublishWrites();
 
-    await unpublishModelById({ id: MODEL_ID, userId: OWNER_ID });
-
-    // The Prisma updateMany must not carry meta at all — a version's own meta cannot come from the
-    // model, and updateMany cannot write a different value per row.
-    const modelUpdate = mockTx.model.update.mock.calls[0][0];
-    expect(modelUpdate.data.modelVersions.updateMany.data).toEqual({ status: 'Unpublished' });
-    expect(modelUpdate.data.modelVersions.updateMany.data).not.toHaveProperty('meta');
-
-    // And the merge statement has to exist, carrying the keys. Dropping it leaves every version
-    // with no unpublishedAt, which is silent: no notification fires and nothing else reads it.
-    const call = metaMergeCall();
-    expect(call).toBeDefined();
-    expect(JSON.stringify(call)).toContain('unpublishedAt');
-  });
-
-  // The keys are what unpublish.notifications.ts selects on — meta only, no status predicate, keyed
-  // per version — so stamping them onto versions that were not taken down sends the creator one
-  // "version unpublished" notification per version of the model, drafts included.
-  it('stamps the keys only on the versions being taken down, not on every version', async () => {
-    setupRefundData({ accessRows: [] });
-    setupUnpublishWrites({
-      allVersionIds: [VERSION_ID, OTHER_VERSION_ID],
-      transitioningVersionIds: [VERSION_ID],
-    });
-
     await unpublishModelById({ id: MODEL_ID, userId: OWNER_ID, reason: 'duplicate' });
 
-    expect(mockTx.modelVersion.findMany).toHaveBeenCalledWith({
-      where: { modelId: MODEL_ID, status: { in: ['Published', 'Scheduled'] } },
-      select: { id: true },
+    expect(takeDownSql()).toContain(
+      `SET "status" = ?::"ModelStatus", "meta" = COALESCE("meta", '{}'::jsonb) ||`
+    );
+    // Every key the notification and the audit trail read, not just the one that is easiest to find.
+    expect(JSON.parse(takeDownParams()[1] as string)).toEqual({
+      unpublishedReason: 'duplicate',
+      customMessage: undefined,
+      unpublishedAt: expect.any(String),
+      unpublishedBy: OWNER_ID,
     });
-    const params = JSON.stringify(metaMergeCall()?.slice(1));
-    expect(params).toContain(String(VERSION_ID));
-    expect(params).not.toContain(String(OTHER_VERSION_ID));
+  });
+
+  it('takes down only the versions that were published or scheduled', async () => {
+    setupRefundData({ accessRows: [] });
+    setupUnpublishWrites();
+
+    await unpublishModelById({ id: MODEL_ID, userId: OWNER_ID });
+
+    const sql = takeDownSql();
+    expect(sql).toContain('WHERE "modelId" = ?');
+    expect(sql).toContain('AND "status" IN (?::"ModelStatus", ?::"ModelStatus") RETURNING id');
+    // Exact, not substring: the params carry an ISO timestamp whose millisecond field makes a
+    // substring search on a 3-digit id both flaky and misleading.
+    expect(takeDownParams()).toEqual([
+      'Unpublished',
+      expect.any(String),
+      MODEL_ID,
+      'Published',
+      'Scheduled',
+    ]);
   });
 
   it('does not gate or refund on a moderator unpublish', async () => {

--- a/src/server/services/__tests__/model-early-access-refund.service.test.ts
+++ b/src/server/services/__tests__/model-early-access-refund.service.test.ts
@@ -11,6 +11,7 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
 // default hands the callback `dbMock.dbWrite`, which would collapse that into the direct calls.
 const { mockTx } = vi.hoisted(() => ({
   mockTx: {
+    modelVersion: { findMany: vi.fn() },
     model: {
       findFirst: vi.fn(),
       findUnique: vi.fn(),
@@ -179,10 +180,17 @@ function setupRefundData({
   ]);
 }
 
-function setupUnpublishWrites() {
+function setupUnpublishWrites({
+  // What the model update reports back: EVERY version of the model, drafts included — it carries no
+  // where clause. Distinct from the transitioning set below, and conflating the two is the bug this
+  // fixture exists to expose.
+  allVersionIds = [VERSION_ID, OTHER_VERSION_ID],
+  transitioningVersionIds = [VERSION_ID],
+}: { allVersionIds?: number[]; transitioningVersionIds?: number[] } = {}) {
+  mockTx.modelVersion.findMany.mockResolvedValue(transitioningVersionIds.map((id) => ({ id })));
   mockTx.model.update.mockResolvedValue({
     userId: OWNER_ID,
-    modelVersions: [{ id: VERSION_ID }],
+    modelVersions: allVersionIds.map((id) => ({ id })),
   });
   mockDbWrite.model.findUniqueOrThrow.mockResolvedValue({ name: 'Test Model', userId: OWNER_ID });
   mockDbWrite.post.findMany.mockResolvedValue([]);
@@ -582,6 +590,14 @@ describe('unpublishModelById — early access refund gate', () => {
   // and this is the one operation that used to destroy it: the version rows were written with the
   // MODEL's meta object, replacing the column. An owner could unpublish, shedding the flag, and then
   // delete the version with every guard that reads it gone.
+  // The transaction runs more than one $executeRaw — the Post metadata update is unconditional — so
+  // an assertion on the spy alone passes with the meta merge deleted entirely. These read the
+  // statement.
+  const metaMergeCall = () =>
+    mockTx.$executeRaw.mock.calls.find(([strings]) =>
+      (strings as unknown as string[]).join('').includes('UPDATE "ModelVersion"')
+    );
+
   it('merges the unpublish keys into each version meta instead of replacing it', async () => {
     setupRefundData({ accessRows: [] });
     setupUnpublishWrites();
@@ -593,8 +609,33 @@ describe('unpublishModelById — early access refund gate', () => {
     const modelUpdate = mockTx.model.update.mock.calls[0][0];
     expect(modelUpdate.data.modelVersions.updateMany.data).toEqual({ status: 'Unpublished' });
     expect(modelUpdate.data.modelVersions.updateMany.data).not.toHaveProperty('meta');
-    // The keys land through a jsonb merge instead.
-    expect(mockTx.$executeRaw).toHaveBeenCalled();
+
+    // And the merge statement has to exist, carrying the keys. Dropping it leaves every version
+    // with no unpublishedAt, which is silent: no notification fires and nothing else reads it.
+    const call = metaMergeCall();
+    expect(call).toBeDefined();
+    expect(JSON.stringify(call)).toContain('unpublishedAt');
+  });
+
+  // The keys are what unpublish.notifications.ts selects on — meta only, no status predicate, keyed
+  // per version — so stamping them onto versions that were not taken down sends the creator one
+  // "version unpublished" notification per version of the model, drafts included.
+  it('stamps the keys only on the versions being taken down, not on every version', async () => {
+    setupRefundData({ accessRows: [] });
+    setupUnpublishWrites({
+      allVersionIds: [VERSION_ID, OTHER_VERSION_ID],
+      transitioningVersionIds: [VERSION_ID],
+    });
+
+    await unpublishModelById({ id: MODEL_ID, userId: OWNER_ID, reason: 'duplicate' });
+
+    expect(mockTx.modelVersion.findMany).toHaveBeenCalledWith({
+      where: { modelId: MODEL_ID, status: { in: ['Published', 'Scheduled'] } },
+      select: { id: true },
+    });
+    const params = JSON.stringify(metaMergeCall()?.slice(1));
+    expect(params).toContain(String(VERSION_ID));
+    expect(params).not.toContain(String(OTHER_VERSION_ID));
   });
 
   it('does not gate or refund on a moderator unpublish', async () => {

--- a/src/server/services/__tests__/model-early-access-refund.service.test.ts
+++ b/src/server/services/__tests__/model-early-access-refund.service.test.ts
@@ -187,7 +187,7 @@ function setupUnpublishWrites({
   allVersionIds = [VERSION_ID, OTHER_VERSION_ID],
   transitioningVersionIds = [VERSION_ID],
 }: { allVersionIds?: number[]; transitioningVersionIds?: number[] } = {}) {
-  mockTx.$queryRaw.mockResolvedValue(transitioningVersionIds.map((id) => ({ id })));
+  mockTx.$executeRaw.mockResolvedValue(transitioningVersionIds.length);
   mockTx.model.update.mockResolvedValue({
     userId: OWNER_ID,
     modelVersions: allVersionIds.map((id) => ({ id })),
@@ -596,11 +596,15 @@ describe('unpublishModelById — early access refund gate', () => {
   // the static template segments. An assertion on the interpolated payload is byte-identical under
   // `meta = COALESCE(meta,'{}') || payload` and under `meta = payload`, which is the bug this code
   // exists to prevent.
+  // The take-down is the first $executeRaw in the transaction; the Post metadata update is the
+  // second. Found by its SQL rather than by position, so reordering cannot silently repoint these.
+  const takeDownCall = () =>
+    mockTx.$executeRaw.mock.calls.find(([strings]) =>
+      (strings as unknown as string[]).join('').includes('UPDATE "ModelVersion"')
+    );
   const takeDownSql = () =>
-    ((mockTx.$queryRaw.mock.calls[0]?.[0] ?? []) as unknown as string[])
-      .join('?')
-      .replace(/\s+/g, ' ');
-  const takeDownParams = () => mockTx.$queryRaw.mock.calls[0]?.slice(1) ?? [];
+    ((takeDownCall()?.[0] ?? []) as unknown as string[]).join('?').replace(/\s+/g, ' ');
+  const takeDownParams = () => takeDownCall()?.slice(1) ?? [];
 
   it('merges the unpublish keys into each version meta instead of replacing it', async () => {
     setupRefundData({ accessRows: [] });
@@ -618,6 +622,13 @@ describe('unpublishModelById — early access refund gate', () => {
       unpublishedAt: expect.any(String),
       unpublishedBy: OWNER_ID,
     });
+    // A reasoned take-down puts the VERSION at UnpublishedViolation, which the nested updateMany
+    // this replaced did not do — it always wrote plain Unpublished. That difference decides whether
+    // an owner can republish the version afterwards, and it is what restore-models has to match.
+    expect(takeDownParams()[0]).toBe('UnpublishedViolation');
+    expect(mockTx.model.update.mock.calls[0][0].data.status).toBe('UnpublishedViolation');
+    // And the version's updatedAt is stamped — raw SQL gets no @updatedAt.
+    expect(takeDownSql()).toContain('"updatedAt" = NOW()');
   });
 
   it('takes down only the versions that were published or scheduled', async () => {
@@ -628,7 +639,7 @@ describe('unpublishModelById — early access refund gate', () => {
 
     const sql = takeDownSql();
     expect(sql).toContain('WHERE "modelId" = ?');
-    expect(sql).toContain('AND "status" IN (?::"ModelStatus", ?::"ModelStatus") RETURNING id');
+    expect(sql).toContain('AND "status" IN (?::"ModelStatus", ?::"ModelStatus")');
     // Exact, not substring: the params carry an ISO timestamp whose millisecond field makes a
     // substring search on a 3-digit id both flaky and misleading.
     expect(takeDownParams()).toEqual([

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2814,6 +2814,17 @@ export const unpublishModelById = async ({
         unpublishedAt,
         unpublishedBy: userId,
       };
+      // The ids actually transitioning, captured BEFORE the update while the statuses still say so.
+      // `updatedModel.modelVersions` is every version of the model — drafts, training rows, versions
+      // taken down months ago — and stamping the unpublish keys onto those sends the creator a
+      // "version unpublished" notification for each one: unpublish.notifications.ts selects on the
+      // meta alone, with no status predicate, keyed per modelVersionId.
+      const transitioningVersions = await tx.modelVersion.findMany({
+        where: { modelId: id, status: { in: [ModelStatus.Published, ModelStatus.Scheduled] } },
+        select: { id: true },
+      });
+      const transitioningVersionIds = transitioningVersions.map((x) => x.id);
+
       const updatedModel = await tx.model.update({
         where: { id },
         data: {
@@ -2836,8 +2847,9 @@ export const unpublishModelById = async ({
       // meta wholesale, and `hadEarlyAccessPurchase` went with it. That flag is the only pre-filter
       // on the refund requirement and the guard on both delete paths, so wiping it turned an
       // unpublish into a way to shed the refund obligation and then delete the version freely.
-      // updateMany cannot write a different value per row, hence raw SQL.
-      if (versionIds.length > 0) {
+      // updateMany cannot write a different value per row, hence raw SQL. Scoped to the versions
+      // this call is actually taking down, not to every version on the model.
+      if (transitioningVersionIds.length > 0) {
         await tx.$executeRaw`
           UPDATE "ModelVersion"
           SET "meta" = COALESCE("meta", '{}'::jsonb) || ${JSON.stringify({
@@ -2845,7 +2857,7 @@ export const unpublishModelById = async ({
             unpublishedAt,
             unpublishedBy: userId,
           })}::jsonb
-          WHERE id IN (${Prisma.join(versionIds)})
+          WHERE id IN (${Prisma.join(transitioningVersionIds)})
         `;
       }
       await tx.$executeRaw`

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2814,52 +2814,52 @@ export const unpublishModelById = async ({
         unpublishedAt,
         unpublishedBy: userId,
       };
-      // The ids actually transitioning, captured BEFORE the update while the statuses still say so.
-      // `updatedModel.modelVersions` is every version of the model — drafts, training rows, versions
-      // taken down months ago — and stamping the unpublish keys onto those sends the creator a
-      // "version unpublished" notification for each one: unpublish.notifications.ts selects on the
-      // meta alone, with no status predicate, keyed per modelVersionId.
-      const transitioningVersions = await tx.modelVersion.findMany({
-        where: { modelId: id, status: { in: [ModelStatus.Published, ModelStatus.Scheduled] } },
-        select: { id: true },
-      });
-      const transitioningVersionIds = transitioningVersions.map((x) => x.id);
-
       const updatedModel = await tx.model.update({
         where: { id },
         data: {
           status: reason ? ModelStatus.UnpublishedViolation : ModelStatus.Unpublished,
           meta: updatedMeta,
-          modelVersions: {
-            updateMany: {
-              where: { status: { in: [ModelStatus.Published, ModelStatus.Scheduled] } },
-              data: { status: ModelStatus.Unpublished },
-            },
-          },
         },
         select: { userId: true, modelVersions: { select: { id: true } } },
       });
 
       const versionIds = updatedModel.modelVersions.map((x) => x.id);
 
-      // 🔴 MERGE the unpublish keys into each version's own meta. Writing the model's meta object
-      // over the column — which is what `updateMany` above used to do — replaced every version's
-      // meta wholesale, and `hadEarlyAccessPurchase` went with it. That flag is the only pre-filter
-      // on the refund requirement and the guard on both delete paths, so wiping it turned an
-      // unpublish into a way to shed the refund obligation and then delete the version freely.
-      // updateMany cannot write a different value per row, hence raw SQL. Scoped to the versions
-      // this call is actually taking down, not to every version on the model.
-      if (transitioningVersionIds.length > 0) {
-        await tx.$executeRaw`
-          UPDATE "ModelVersion"
-          SET "meta" = COALESCE("meta", '{}'::jsonb) || ${JSON.stringify({
-            ...(reason ? { unpublishedReason: reason, customMessage } : {}),
-            unpublishedAt,
-            unpublishedBy: userId,
-          })}::jsonb
-          WHERE id IN (${Prisma.join(transitioningVersionIds)})
-        `;
-      }
+      // One statement for the version take-down, and it has to stay one.
+      //
+      // 🔴 MERGE the keys into each version's own meta rather than writing an object over the
+      // column. Overwriting replaced every version's meta wholesale and `hadEarlyAccessPurchase`
+      // went with it — that flag is the only pre-filter on the refund requirement and the guard on
+      // both delete paths, so losing it turns an unpublish into a way to shed the refund obligation
+      // and then delete the version past every guard. `updateMany` cannot write a different value
+      // per row, hence raw SQL.
+      //
+      // 🔴 And the keys must land on exactly the versions this call takes down. They are what
+      // unpublish.notifications.ts selects on — meta alone, no status predicate, keyed per version —
+      // so stamping a draft tells the creator a version they never published was unpublished.
+      // Status and meta move together under one snapshot, which makes "stamped iff transitioned"
+      // structural rather than two predicates someone has to keep in step.
+      const transitioned = await tx.$queryRaw<{ id: number }[]>`
+        UPDATE "ModelVersion"
+        SET "status" = ${
+          reason ? ModelStatus.UnpublishedViolation : ModelStatus.Unpublished
+        }::"ModelStatus",
+            "meta" = COALESCE("meta", '{}'::jsonb) || ${JSON.stringify({
+              ...(reason ? { unpublishedReason: reason, customMessage } : {}),
+              unpublishedAt,
+              unpublishedBy: userId,
+            })}::jsonb
+        WHERE "modelId" = ${id}
+          AND "status" IN (${ModelStatus.Published}::"ModelStatus", ${
+        ModelStatus.Scheduled
+      }::"ModelStatus")
+        RETURNING id
+      `;
+      const transitionedVersionIds = transitioned.map((x) => x.id);
+
+      // Deliberately the WIDE id list, unlike the statement above: a post attached to a version that
+      // was already down can still be published, and `publishedAt IS NOT NULL` is what scopes this —
+      // not the id set. Narrowing it to the transitioned versions would leave those posts public.
       await tx.$executeRaw`
         UPDATE "Post"
         SET "metadata"    = "metadata" || jsonb_build_object(

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2839,7 +2839,7 @@ export const unpublishModelById = async ({
       // so stamping a draft tells the creator a version they never published was unpublished.
       // Status and meta move together under one snapshot, which makes "stamped iff transitioned"
       // structural rather than two predicates someone has to keep in step.
-      const transitioned = await tx.$queryRaw<{ id: number }[]>`
+      await tx.$executeRaw`
         UPDATE "ModelVersion"
         SET "status" = ${
           reason ? ModelStatus.UnpublishedViolation : ModelStatus.Unpublished
@@ -2848,18 +2848,20 @@ export const unpublishModelById = async ({
               ...(reason ? { unpublishedReason: reason, customMessage } : {}),
               unpublishedAt,
               unpublishedBy: userId,
-            })}::jsonb
+            })}::jsonb,
+            -- Prisma's @updatedAt does not apply to raw SQL, and there is no DB default or trigger.
+            -- Without this a taken-down version keeps a pre-take-down updatedAt, which is on the
+            -- public v1 payload via modelVersion.selector.
+            "updatedAt" = NOW()
         WHERE "modelId" = ${id}
           AND "status" IN (${ModelStatus.Published}::"ModelStatus", ${
         ModelStatus.Scheduled
       }::"ModelStatus")
-        RETURNING id
       `;
-      const transitionedVersionIds = transitioned.map((x) => x.id);
 
       // Deliberately the WIDE id list, unlike the statement above: a post attached to a version that
       // was already down can still be published, and `publishedAt IS NOT NULL` is what scopes this —
-      // not the id set. Narrowing it to the transitioned versions would leave those posts public.
+      // not the id set. Narrowing it to the versions this call took down would leave those posts public.
       await tx.$executeRaw`
         UPDATE "Post"
         SET "metadata"    = "metadata" || jsonb_build_object(


### PR DESCRIPTION
**Regression from #4106, caught by review in the same minute that PR merged.** I merged on Justin's go-ahead and the round-6 report landed simultaneously; this is the fix, opened immediately rather than left on main overnight.

## What broke

#4106 moved the version meta write out of Prisma's `updateMany` into raw SQL, so that each version's own meta is merged rather than replaced (`hadEarlyAccessPurchase` was being destroyed). Moving it dropped that statement's `where: { status: { in: [Published, Scheduled] } }` — and the id list used instead, `updatedModel.modelVersions`, carries **no where clause at all**. It is every version of the model: drafts, training rows, versions taken down months ago.

## Why it reaches users

`src/server/notifications/unpublish.notifications.ts:39-41` selects on the meta alone — `jsonb_typeof(mv.meta->'unpublishedReason') = 'string'` plus `unpublishedAt > lastSent` — with no status predicate, and the notification key is per `modelVersionId`.

So a moderator unpublishing a model **with a reason** would send the creator one "version unpublished" notification per version on the model, instead of one per version actually unpublished. A twelve-version model with one published version: twelve notifications.

## The fix

Read the transitioning ids inside the transaction, before the update, while the statuses still say which versions are going down. Two-line change plus the comment explaining why the two id sets are not interchangeable.

## The test that should have caught it

It asserted `expect(mockTx.$executeRaw).toHaveBeenCalled()`. The transaction already runs an unconditional `$executeRaw` for the Post metadata update on the same spy, so **deleting the entire meta-merge block left that assertion green** — it could not detect the fix being removed, let alone mis-scoped.

Now it finds the statement by its SQL text and asserts which ids it targets. Both mutations verified:

| Mutation | Result |
|---|---|
| Merge targets every version again (the regression) | 1 failed / 18 passed |
| Meta-merge block deleted entirely | 2 failed / 17 passed |

The fixture now distinguishes the two id sets by name — `allVersionIds` vs `transitioningVersionIds` — since conflating them is the bug.

## Verification

- `TYPECHECK_HEAP_MB=12288 pnpm run typecheck` — `typecheck: OK — 0 type errors in 274s`
- `pnpm run test:unit:run` — `Test Files 3 failed | 1180 passed | 1 skipped (1184)`, `Tests 5 failed | 18661 passed | 23 skipped (18689)`
- The 5 failures are the three Windows-only source-scanning guards, now **proven** rather than assumed: the same commits pass those files on CI's Linux runners.

Credit where it is due: this was arabella's finding, both halves of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)