### PR TITLE
feat(feed): make a BitDex-served page distinguishable from a fallback (#3930)

### DIFF
--- a/src/pages/api/internal/bitdex-compare.ts
+++ b/src/pages/api/internal/bitdex-compare.ts
@@ -16,10 +16,7 @@ import { ImageSort } from '~/server/common/enums';
  * GET /api/internal/bitdex-compare?sort=Newest&browsingLevel=1&limit=20
  * GET /api/internal/bitdex-compare?sort=MostReactions&browsingLevel=1&limit=20&cursor=20|1772150400000
  */
-export default PublicEndpoint(async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
+export default PublicEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {
   const q = req.query;
 
   const limit = Number(q.limit) || 20;
@@ -55,7 +52,9 @@ export default PublicEndpoint(async function handler(
     ...(q.postId && { postId: Number(q.postId) }),
     ...(q.modelVersionId && { modelVersionId: Number(q.modelVersionId) }),
     ...(q.baseModels && { baseModels: (q.baseModels as string).split(',') }),
-    ...(q.excludedTagIds && { excludedTagIds: (q.excludedTagIds as string).split(',').map(Number) }),
+    ...(q.excludedTagIds && {
+      excludedTagIds: (q.excludedTagIds as string).split(',').map(Number),
+    }),
     ...(q.period && { period: q.period as string }),
   };
 
@@ -75,6 +74,13 @@ export default PublicEndpoint(async function handler(
   let bitdexResult: any = null;
   let bitdexError: string | undefined;
   try {
+    // No `onFailure` callback ON PURPOSE (#3930). A failure here still counts
+    // toward `bitdex_query_failures_total` — that counter is emitted inside the
+    // client and needs no cooperation — but it contributes nothing to
+    // `bitdex_primary_result_total`, which counts USER-FACING FEED REQUESTS.
+    // This is a hand-driven internal comparison endpoint; folding its calls into
+    // the served/fallback ratio would let an operator running comparisons move
+    // the number a rollout decision is read from.
     bitdexResult = await getImagesFromBitdexPreFilter(input);
   } catch (err: any) {
     bitdexError = err.message || String(err);
@@ -99,9 +105,8 @@ export default PublicEndpoint(async function handler(
     if (commonMeili[i] === commonBitdex[i]) orderMatch++;
   }
 
-  const nextCursor = meiliResult?.nextCursor != null
-    ? `${offset + limit}|${meiliResult.nextCursor}`
-    : null;
+  const nextCursor =
+    meiliResult?.nextCursor != null ? `${offset + limit}|${meiliResult.nextCursor}` : null;
 
   return res.status(200).json({
     query: {
@@ -118,14 +123,15 @@ export default PublicEndpoint(async function handler(
       count: meiliIds.length,
       elapsed_ms: meiliElapsed,
       error: meiliError ?? null,
-      sample: meiliResult?.data?.slice(0, 5)?.map((d: any) => ({
-        id: d.id,
-        sortAtUnix: d.sortAtUnix,
-        reactionCount: d.reactionCount,
-        commentCount: d.commentCount,
-        nsfwLevel: d.nsfwLevel,
-        type: d.type,
-      })) ?? [],
+      sample:
+        meiliResult?.data?.slice(0, 5)?.map((d: any) => ({
+          id: d.id,
+          sortAtUnix: d.sortAtUnix,
+          reactionCount: d.reactionCount,
+          commentCount: d.commentCount,
+          nsfwLevel: d.nsfwLevel,
+          type: d.type,
+        })) ?? [],
     },
     bitdex: {
       ids: bitdexIds,

--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -22,9 +22,17 @@ import '~/server/auth/session-metrics';
 // only consumer is the scrape, and this module is what serves it, so the series
 // are present in every response that could ever observe them.
 import { ensureRegisterGenerationModelSubstitutionMetrics } from '~/server/metrics/generation-model-substitution.metrics';
+// Same reason again (#3930): seeds all 8 (outcome, mode) series of
+// bitdex_primary_result_total and all 6 reasons of bitdex_query_failures_total
+// at 0. `fallback_error` is the series the issue is about, and it is expected to
+// read zero on a healthy day — so an absent series and a healthy zero MUST be
+// distinguishable, or the metric answers nothing. The older bitdex_shadow_*
+// counters skipped this and are `no data` on a live read today.
+import { ensureRegisterBitdexFeedServeMetrics } from '~/server/metrics/bitdex-feed-serve.metrics';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 
 ensureRegisterGenerationModelSubstitutionMetrics();
+ensureRegisterBitdexFeedServeMetrics();
 
 const labels: Record<string, string> = {};
 if (process.env.PODNAME) {

--- a/src/server/bitdex/__tests__/query-bitdex-failure-classification.test.ts
+++ b/src/server/bitdex/__tests__/query-bitdex-failure-classification.test.ts
@@ -115,13 +115,60 @@ describe('queryBitdex classifies every null it returns', () => {
     expect(moved).toEqual(['network']);
   });
 
-  it('an abort → timeout, NOT network', async () => {
+  /**
+   * A real abort rejects with a `DOMException`, not a plain `Error`. A fixture
+   * built from `new Error()` with the name reassigned cannot tell the difference,
+   * so it would keep passing even if the classification depended on a prototype
+   * relationship that does not hold — measured here, `DOMException` IS an `Error`
+   * subclass on this runtime, but that is a WebIDL detail and not something the
+   * classification should rest on. Using the real type is what makes this case
+   * evidence about production rather than about the fixture.
+   */
+  it('a real DOMException abort → timeout, NOT network', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new DOMException('The operation was aborted', 'AbortError'))
+    );
+    const { reasons, moved } = await observe();
+    expect(reasons).toEqual(['timeout']);
+    expect(moved).toEqual(['timeout']);
+  });
+
+  it('a plain Error named AbortError → timeout too (the classification is duck-typed)', async () => {
     const abort = new Error('The operation was aborted');
     abort.name = 'AbortError';
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abort));
     const { reasons, moved } = await observe();
     expect(reasons).toEqual(['timeout']);
     expect(moved).toEqual(['timeout']);
+  });
+
+  it('a non-Error thrown value cannot crash the classifier', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(undefined));
+    const { reasons, moved } = await observe();
+    expect(reasons).toEqual(['network']);
+    expect(moved).toEqual(['network']);
+  });
+
+  /**
+   * 🔴 THE BOUNDARY. The split is `status >= 500`, and fixtures of 503 and 400
+   * sit either side of it without ever landing ON it — so `>= 500` → `> 500`
+   * survived a fully green run, silently reclassifying every HTTP 500 (the single
+   * most common server error) as a client error and pointing an operator at the
+   * wrong team. Exactly 500 is the only value that separates the two operators.
+   */
+  it('exactly 500 → http_5xx, not http_4xx', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(500)));
+    const { reasons, moved } = await observe();
+    expect(reasons).toEqual(['http_5xx']);
+    expect(moved).toEqual(['http_5xx']);
+  });
+
+  it('499 → http_4xx, the other side of the same boundary', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(499)));
+    const { reasons, moved } = await observe();
+    expect(reasons).toEqual(['http_4xx']);
+    expect(moved).toEqual(['http_4xx']);
   });
 
   it('a 2xx whose body will not decode → parse, NOT network', async () => {

--- a/src/server/bitdex/__tests__/query-bitdex-failure-classification.test.ts
+++ b/src/server/bitdex/__tests__/query-bitdex-failure-classification.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `queryBitdex` returns `null` for six distinct reasons and — before #3930 —
+ * nothing outside it could tell them apart. These tests pin the classification
+ * at the boundary where it is still possible to make, because that is the only
+ * place it is still possible to make: after the return there is one `null`.
+ *
+ * Two things are asserted per case, and both are needed:
+ *   - the `onFailure` callback receives the right reason (what the caller uses
+ *     to decide `fallback_error` vs `fallback_empty`), and
+ *   - `bitdex_query_failures_total` moved on that reason and no other.
+ * The second is the positive control for that counter. A zero on
+ * `reason="http_4xx"` is the answer to "did someone ship a filter on a field the
+ * index does not know", and a zero is worth nothing until the series has been
+ * watched to move.
+ */
+
+// `BITDEX_URL` is read at MODULE LOAD from `process.env`, and ES imports are
+// hoisted above ordinary statements — so a plain assignment at the top of this
+// file runs too late and every case would classify as `unconfigured`. `vi.hoisted`
+// is what runs before the imports.
+vi.hoisted(() => {
+  process.env.BITDEX_URL = 'http://bitdex.test';
+});
+
+vi.mock('~/server/utils/otel-helpers', () => ({
+  // Supports both call shapes used in this file: (name, fn) and (name, attrs, fn).
+  withSpan: (_name: string, a: unknown, b?: unknown) =>
+    typeof a === 'function' ? (a as () => unknown)() : (b as () => unknown)(),
+  safeUrl: (url: string) => url,
+}));
+
+import { queryBitdex } from '../client';
+import {
+  BITDEX_QUERY_FAILURE_REASONS,
+  ensureRegisterBitdexFeedServeMetrics,
+  type BitdexQueryFailureReason,
+} from '~/server/metrics/bitdex-feed-serve.metrics';
+
+type FailureSnapshot = Record<string, number>;
+
+async function readFailures(): Promise<FailureSnapshot> {
+  const { queryFailuresTotal } = ensureRegisterBitdexFeedServeMetrics();
+  const { values } = await (
+    queryFailuresTotal as unknown as {
+      get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }>;
+    }
+  ).get();
+  const snapshot: FailureSnapshot = {};
+  for (const reason of BITDEX_QUERY_FAILURE_REASONS) snapshot[reason] = 0;
+  for (const v of values) snapshot[v.labels.reason] = v.value;
+  return snapshot;
+}
+
+function reasonsThatMoved(before: FailureSnapshot, after: FailureSnapshot): string[] {
+  return Object.keys(after)
+    .filter((k) => (after[k] ?? 0) !== (before[k] ?? 0))
+    .sort();
+}
+
+const okResponse = (json: unknown) => ({
+  ok: true,
+  status: 200,
+  json: async () => json,
+  text: async () => '',
+});
+
+const errorResponse = (status: number) => ({
+  ok: false,
+  status,
+  json: async () => ({}),
+  text: async () => 'boom',
+});
+
+const call = (onFailure?: (reason: BitdexQueryFailureReason) => void) =>
+  queryBitdex('civitai', [], undefined, 10, undefined, undefined, undefined, onFailure);
+
+/** Runs one case and returns both observables. */
+async function observe(): Promise<{ reasons: BitdexQueryFailureReason[]; moved: string[] }> {
+  const before = await readFailures();
+  const reasons: BitdexQueryFailureReason[] = [];
+  await call((reason) => reasons.push(reason));
+  const after = await readFailures();
+  return { reasons, moved: reasonsThatMoved(before, after) };
+}
+
+describe('queryBitdex classifies every null it returns', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('a 5xx → http_5xx', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(503)));
+    const { reasons, moved } = await observe();
+    expect(reasons).toEqual(['http_5xx']);
+    expect(moved).toEqual(['http_5xx']);
+  });
+
+  it('🔴 a 4xx → http_4xx — the "we shipped a filter the index does not know" case', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(400)));
+    const { reasons, moved } = await observe();
+    expect(reasons).toEqual(['http_4xx']);
+    expect(moved).toEqual(['http_4xx']);
+  });
+
+  it('a thrown fetch → network', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    const { reasons, moved } = await observe();
+    expect(reasons).toEqual(['network']);
+    expect(moved).toEqual(['network']);
+  });
+
+  it('an abort → timeout, NOT network', async () => {
+    const abort = new Error('The operation was aborted');
+    abort.name = 'AbortError';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abort));
+    const { reasons, moved } = await observe();
+    expect(reasons).toEqual(['timeout']);
+    expect(moved).toEqual(['timeout']);
+  });
+
+  it('a 2xx whose body will not decode → parse, NOT network', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('Unexpected token < in JSON');
+        },
+        text: async () => '',
+      })
+    );
+    const { reasons, moved } = await observe();
+    expect(reasons).toEqual(['parse']);
+    expect(moved).toEqual(['parse']);
+  });
+
+  it('no endpoint configured → unconfigured, without issuing a request', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.resetModules();
+    const previous = process.env.BITDEX_URL;
+    delete process.env.BITDEX_URL;
+    try {
+      const fresh = await import('../client');
+      const reasons: BitdexQueryFailureReason[] = [];
+      const result = await fresh.queryBitdex(
+        'civitai',
+        [],
+        undefined,
+        10,
+        undefined,
+        undefined,
+        undefined,
+        (r) => reasons.push(r)
+      );
+      expect(result).toBeNull();
+      expect(reasons).toEqual(['unconfigured']);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      process.env.BITDEX_URL = previous;
+      vi.resetModules();
+    }
+  });
+
+  it('NEGATIVE CONTROL: a successful query reports nothing and moves no series', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(okResponse({ ids: [1], total_matched: 1, elapsed_us: 5 }))
+    );
+    const { reasons, moved } = await observe();
+    expect(reasons).toEqual([]);
+    expect(moved).toEqual([]);
+  });
+
+  it('a SUCCESSFUL but EMPTY result is not a failure — the distinction the metric exists for', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(okResponse({ ids: [], total_matched: 0, elapsed_us: 5 }))
+    );
+    const { reasons, moved } = await observe();
+    expect(reasons).toEqual([]);
+    expect(moved).toEqual([]);
+  });
+
+  it('a caller callback that THROWS cannot break the query path', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(500)));
+    await expect(
+      call(() => {
+        throw new Error('a metrics sink fell over');
+      })
+    ).resolves.toBeNull();
+  });
+});
+
+describe('queryBitdex clears its abort timer on the failure path', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * 🔴 THE LEAK. The only `clearTimeout` used to sit after the fetch resolved,
+   * which a thrown fetch skips entirely — leaving a 30s timer holding the
+   * AbortController alive on every failed call, at feed request rate. Asserted
+   * on the pending-timer count rather than on a comment, because a comment
+   * cannot go red.
+   */
+  it('a thrown fetch leaves no pending timer', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+    // Positive control for the instrument itself: the counter must be able to
+    // report a non-zero, or "0 pending timers" would mean nothing.
+    const sentinel = setTimeout(() => undefined, 60_000);
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+    clearTimeout(sentinel);
+    expect(vi.getTimerCount()).toBe(0);
+
+    await call();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('a successful call leaves no pending timer either', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(okResponse({ ids: [], total_matched: 0, elapsed_us: 1 }))
+    );
+
+    await call();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/server/bitdex/__tests__/query-bitdex-failure-classification.test.ts
+++ b/src/server/bitdex/__tests__/query-bitdex-failure-classification.test.ts
@@ -143,6 +143,26 @@ describe('queryBitdex classifies every null it returns', () => {
     expect(moved).toEqual(['timeout']);
   });
 
+  /**
+   * 🔴 THE ONLY FIXTURE THAT SEPARATES `name`-DUCK-TYPING FROM `instanceof Error`.
+   *
+   * `DOMException` IS an `Error` subclass on this runtime, so both the
+   * DOMException case above and the plain-Error case pass under EITHER
+   * implementation — reverting to `err instanceof Error && err.name === …`
+   * survives both. A rejection that is not an Error at all but does carry
+   * `name: 'AbortError'` is what distinguishes them: duck-typing classifies it
+   * `timeout`, `instanceof` falls through to `network`.
+   *
+   * Without this case the duck-typing change is untested by construction — a
+   * change made for robustness that no test can tell was made.
+   */
+  it('a non-Error carrying name AbortError → timeout (this is what duck-typing buys)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue({ name: 'AbortError', message: 'aborted' }));
+    const { reasons, moved } = await observe();
+    expect(reasons).toEqual(['timeout']);
+    expect(moved).toEqual(['timeout']);
+  });
+
   it('a non-Error thrown value cannot crash the classifier', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(undefined));
     const { reasons, moved } = await observe();

--- a/src/server/bitdex/client.ts
+++ b/src/server/bitdex/client.ts
@@ -110,9 +110,14 @@ export interface BitdexQueryResult {
  * are still in scope; once this function returns, that information is gone.
  *
  * Deliberately an OPTIONAL, ADDITIVE last parameter rather than a change of
- * return type: the return contract is depended on by three consumers on the
- * highest-traffic feed path, and a discriminated union would have rewritten
- * every one of them — plus every test mock — in the same commit that changes the
+ * return type. Counting precisely, because two different numbers are true and
+ * conflating them has already caused confusion: `queryBitdex` has exactly TWO
+ * direct call sites, both in `image.service.ts` (the parallel own-content pass
+ * in `fetchBitdexPrimary`, and the one inside `getImagesFromBitdexPreFilter`).
+ * The `null` RETURN CONTRACT, however, is interpreted by THREE consumers, because
+ * `getImagesFromBitdexPreFilter` is itself re-exported and called from
+ * `~/pages/api/internal/bitdex-compare.ts` — so a discriminated union would have
+ * rewritten all three, plus every test mock, in the same commit that changes the
  * behaviour, which is precisely the commit you want to be able to read. It
  * reverts by deleting one argument.
  *
@@ -220,7 +225,13 @@ export async function queryBitdex(
     return result;
   } catch (err) {
     console.error(`[BitDex] Query error:`, err);
-    const aborted = err instanceof Error && err.name === 'AbortError';
+    // Duck-typed on `name` rather than `err instanceof Error`. A real abort here
+    // is a `DOMException`, and while THIS runtime happens to make DOMException an
+    // Error subclass (measured), that is a WebIDL detail we should not be
+    // depending on — if it were ever false, every timeout would silently
+    // reclassify as `network`, which is the wrong team paged and no error
+    // anywhere. The narrowing below cannot throw on null/undefined.
+    const aborted = (err as { name?: unknown } | null | undefined)?.name === 'AbortError';
     return fail(aborted ? 'timeout' : phase === 'parse' ? 'parse' : 'network');
   } finally {
     // 🔴 The leak. Before this, the only `clearTimeout` was the eager one above,

--- a/src/server/bitdex/client.ts
+++ b/src/server/bitdex/client.ts
@@ -1,3 +1,7 @@
+import {
+  recordBitdexQueryFailure,
+  type BitdexQueryFailureReason,
+} from '~/server/metrics/bitdex-feed-serve.metrics';
 import { withSpan, safeUrl } from '~/server/utils/otel-helpers';
 
 export type Value = { Integer: number } | { Bool: boolean } | { String: string };
@@ -96,7 +100,30 @@ export interface BitdexQueryResult {
  * Query BitDex with pre-built filter clauses and sort.
  * Returns null on any error (never throws).
  *
+ * 🔴 THE `null` IS AMBIGUOUS BY CONSTRUCTION, AND `onFailure` IS THE ONLY THING
+ * THAT DISAMBIGUATES IT. Missing config, a non-2xx, a thrown fetch, an abort at
+ * the deadline and a body that would not parse all return the same `null` as a
+ * successful query over an index that genuinely had no match. The caller cannot
+ * tell a degraded backend from an empty one, which is why an empty feed page was
+ * unalertable (#3930). `onFailure` fires ONLY on the failure half, with the
+ * classification made HERE — the one place the status code and the error object
+ * are still in scope; once this function returns, that information is gone.
+ *
+ * Deliberately an OPTIONAL, ADDITIVE last parameter rather than a change of
+ * return type: the return contract is depended on by three consumers on the
+ * highest-traffic feed path, and a discriminated union would have rewritten
+ * every one of them — plus every test mock — in the same commit that changes the
+ * behaviour, which is precisely the commit you want to be able to read. It
+ * reverts by deleting one argument.
+ *
+ * The callback is for the CALLER's per-request attribution. The per-call counter
+ * is emitted here regardless, so a caller that passes nothing still contributes
+ * the failure reason.
+ *
  * @param includeDocs - true to return all fields, or an array of field names
+ * @param onFailure - invoked with the failure classification when this call
+ *   returns null for any reason OTHER than a successful empty result. Never
+ *   invoked on success. Must not throw; it is called on the feed hot path.
  */
 export async function queryBitdex(
   indexName: string,
@@ -106,11 +133,33 @@ export async function queryBitdex(
   cursor?: any,
   offset?: number,
   includeDocs?: boolean | string[],
+  onFailure?: (reason: BitdexQueryFailureReason) => void
 ): Promise<BitdexQueryResult | null> {
-  if (!BITDEX_URL) return null;
+  // Emitting the reason and notifying the caller are one action; splitting them
+  // is how one call site ends up counted and another not.
+  const fail = (reason: BitdexQueryFailureReason): null => {
+    recordBitdexQueryFailure(reason);
+    // The callback is caller-supplied. A throw here would convert an already-
+    // failed BitDex call into a thrown feed request — strictly worse than the
+    // fallback it is reporting.
+    try {
+      onFailure?.(reason);
+    } catch {
+      /* instrument-only */
+    }
+    return null;
+  };
+
+  if (!BITDEX_URL) return fail('unconfigured');
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), BITDEX_TIMEOUT_MS);
+  // Distinguishes a fetch-phase throw from a body-decode throw. Both arrive at
+  // the same `catch` with error objects that are not reliably distinguishable by
+  // type, and `parse` vs `network` is the difference between "the backend is
+  // unreachable" and "the backend answered something we could not read".
+  let phase: 'fetch' | 'parse' = 'fetch';
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), BITDEX_TIMEOUT_MS);
     const body: any = { filters, limit };
     if (sort) body.sort = sort;
     if (cursor) body.cursor = cursor;
@@ -136,12 +185,22 @@ export async function queryBitdex(
           signal: controller.signal,
         })
     );
+    // Cleared EAGERLY here, exactly as before, so the abort deadline still
+    // covers the fetch only and not the body decode below. The `finally` is the
+    // leak fix, not a widening of the budget: `clearTimeout` on an already-
+    // cleared handle is a no-op, so behaviour on this path is unchanged.
     clearTimeout(timeout);
     if (!res.ok) {
       const errText = await res.text().catch(() => '');
       console.error(`[BitDex] Query failed ${res.status} (${Date.now() - start}ms): ${errText.slice(0, 500)}`);
-      return null;
+      // 4xx and 5xx are split because they have different owners: a 4xx is
+      // almost always something this application sent (the field-the-index-does-
+      // not-know case), a 5xx is the backend. A non-2xx below 400 cannot
+      // normally occur here (fetch follows redirects) and is classified with the
+      // client-error half rather than being invented a seventh label.
+      return fail(res.status >= 500 ? 'http_5xx' : 'http_4xx');
     }
+    phase = 'parse';
     const result = await withSpan(
       'bitdex:http:parse',
       {
@@ -161,6 +220,14 @@ export async function queryBitdex(
     return result;
   } catch (err) {
     console.error(`[BitDex] Query error:`, err);
-    return null;
+    const aborted = err instanceof Error && err.name === 'AbortError';
+    return fail(aborted ? 'timeout' : phase === 'parse' ? 'parse' : 'network');
+  } finally {
+    // 🔴 The leak. Before this, the only `clearTimeout` was the eager one above,
+    // which a thrown fetch (connection refused, DNS failure, abort) skips
+    // entirely — leaving a 30s timer holding the AbortController alive on every
+    // failed call, at feed request rate. The sibling `fetchBitdexDocuments`
+    // already used `finally` for this reason.
+    clearTimeout(timeout);
   }
 }

--- a/src/server/bitdex/client.ts
+++ b/src/server/bitdex/client.ts
@@ -129,6 +129,14 @@ export interface BitdexQueryResult {
  * @param onFailure - invoked with the failure classification when this call
  *   returns null for any reason OTHER than a successful empty result. Never
  *   invoked on success. Must not throw; it is called on the feed hot path.
+ *
+ *   🔴 IT IS NOT A GUARANTEE THAT A REQUEST LEFT THE PROCESS. The
+ *   `unconfigured` arm fires it before any `fetch` — no endpoint means no call
+ *   to make — which is asserted by the `not.toHaveBeenCalled()` case in the
+ *   client suite. A caller using this as "a call happened" evidence (as
+ *   `fetchBitdexPrimary` does) is therefore also counting the misconfigured
+ *   deployment. That is deliberate there: a missing endpoint is a real
+ *   degradation, and the tripwire should fire on it rather than go quiet.
  */
 export async function queryBitdex(
   indexName: string,
@@ -197,7 +205,9 @@ export async function queryBitdex(
     clearTimeout(timeout);
     if (!res.ok) {
       const errText = await res.text().catch(() => '');
-      console.error(`[BitDex] Query failed ${res.status} (${Date.now() - start}ms): ${errText.slice(0, 500)}`);
+      console.error(
+        `[BitDex] Query failed ${res.status} (${Date.now() - start}ms): ${errText.slice(0, 500)}`
+      );
       // 4xx and 5xx are split because they have different owners: a 4xx is
       // almost always something this application sent (the field-the-index-does-
       // not-know case), a 5xx is the backend. A non-2xx below 400 cannot
@@ -215,13 +225,16 @@ export async function queryBitdex(
       },
       () => res.json()
     );
-    console.log('[BitDex] result:', JSON.stringify({
-      ms: Date.now() - start,
-      matched: result.total_matched,
-      ids: result.ids?.length ?? 0,
-      docs: result.documents?.length ?? 0,
-      elapsed_us: result.elapsed_us,
-    }));
+    console.log(
+      '[BitDex] result:',
+      JSON.stringify({
+        ms: Date.now() - start,
+        matched: result.total_matched,
+        ids: result.ids?.length ?? 0,
+        docs: result.documents?.length ?? 0,
+        elapsed_us: result.elapsed_us,
+      })
+    );
     return result;
   } catch (err) {
     console.error(`[BitDex] Query error:`, err);

--- a/src/server/metrics/__tests__/bitdex-feed-serve.metrics.test.ts
+++ b/src/server/metrics/__tests__/bitdex-feed-serve.metrics.test.ts
@@ -44,6 +44,32 @@ async function seriesOf(name: string): Promise<Array<Record<string, string>>> {
   return values.map((v) => v.labels);
 }
 
+/**
+ * 🔴 SNAPSHOT EAGERLY. `Counter.get()` returns `Object.values(this.hashMap)` —
+ * the LIVE child objects — and `inc` mutates `hashMap[hash].value` IN PLACE. So a
+ * "before" handle that is only `.map()`ed AFTER the mutation reads post-increment
+ * state, and every value comparison built on it is vacuously equal.
+ *
+ * That is not hypothetical: the first version of the relabel case below did
+ * exactly that and the relabel mutant SURVIVED a fully green run — a test
+ * certifying a guarantee it structurally could not observe, which is worse than
+ * no test because it reads as coverage. The `Number(...)` copy here is the whole
+ * fix, and the sibling suite (`bitdex-feed-source.test.ts`) already snapshots
+ * this way.
+ */
+async function valuesByLabelKey(name: string): Promise<Record<string, number>> {
+  const metric = client.register.getSingleMetric(name) as unknown as Readable | undefined;
+  if (!metric) return {};
+  const { values } = await metric.get();
+  const snapshot: Record<string, number> = {};
+  for (const v of values) {
+    snapshot[`${v.labels.outcome ?? ''}|${v.labels.mode ?? ''}|${v.labels.reason ?? ''}`] = Number(
+      v.value
+    );
+  }
+  return snapshot;
+}
+
 const EXPECTED_RESULT_SERIES = BITDEX_SERVE_OUTCOMES.length * BITDEX_SERVE_MODES.length;
 
 describe('the record functions drop label values outside their union', () => {
@@ -53,11 +79,36 @@ describe('the record functions drop label values outside their union', () => {
     ensureRegisterBitdexFeedServeMetrics();
   });
 
-  it('POSITIVE CONTROL: a legal call DOES create/keep its series', async () => {
+  /**
+   * 🔴 A POSITIVE CONTROL THAT CANNOT FAIL IS NOT ONE. The first version of this
+   * asserted the `served|primary` SERIES EXISTS after a legal call — but
+   * `seedAllSeries` pre-creates all 8 at registration, so it was true before the
+   * call and stayed true with the `inc` deleted. Inert.
+   *
+   * Assert the VALUE MOVED instead. That is the property every "…is dropped"
+   * case below depends on: they all conclude from a value NOT moving, which
+   * means nothing until a value has been watched to move through this exact
+   * read path.
+   */
+  it('POSITIVE CONTROL: a legal call MOVES its series value by exactly 1', async () => {
+    const before = await valuesByLabelKey('bitdex_primary_result_total');
+
     recordBitdexPrimaryResult('served', 'primary');
-    const labels = await seriesOf('bitdex_primary_result_total');
-    expect(labels).toHaveLength(EXPECTED_RESULT_SERIES);
-    expect(labels.some((l) => l.outcome === 'served' && l.mode === 'primary')).toBe(true);
+
+    const after = await valuesByLabelKey('bitdex_primary_result_total');
+    expect(after['served|primary|'] - before['served|primary|']).toBe(1);
+    // And nothing else moved, so the read path resolves the right child.
+    const moved = Object.keys(after).filter((k) => after[k] !== before[k]);
+    expect(moved).toEqual(['served|primary|']);
+  });
+
+  it('POSITIVE CONTROL: a legal failure-reason call moves its series too', async () => {
+    const before = await valuesByLabelKey('bitdex_query_failures_total');
+
+    recordBitdexQueryFailure('http_4xx');
+
+    const after = await valuesByLabelKey('bitdex_query_failures_total');
+    expect(after['||http_4xx'] - before['||http_4xx']).toBe(1);
   });
 
   it('an unknown OUTCOME with a valid mode is dropped — no new series', async () => {
@@ -92,21 +143,36 @@ describe('the record functions drop label values outside their union', () => {
     expect(labels.some((l) => l.reason === 'http_418')).toBe(false);
   });
 
+  /**
+   * 🔴 THE CASE THE SERIES-COUNT CHECKS CANNOT MAKE. Relabelling a rejected value
+   * to a plausible default — `if (!isBitdexServeOutcome(outcome)) outcome =
+   * 'served'` — keeps the series count at exactly 8, so every `toHaveLength`
+   * assertion above passes. It shows up ONLY as a moved VALUE on an existing
+   * child, which is why this case reads values and why they must be snapshotted
+   * eagerly (see `valuesByLabelKey`).
+   */
   it('a dropped label value is NOT silently relabelled to a plausible default', async () => {
-    const before = await seriesOf('bitdex_primary_result_total');
-    const beforeCounts = await (
-      client.register.getSingleMetric('bitdex_primary_result_total') as unknown as Readable
-    ).get();
+    const before = await valuesByLabelKey('bitdex_primary_result_total');
 
     recordBitdexPrimaryResult('bogus' as BitdexServeOutcome, 'primary');
 
-    const afterCounts = await (
-      client.register.getSingleMetric('bitdex_primary_result_total') as unknown as Readable
-    ).get();
-    // Neither a new series NOR an increment on an existing one. Relabelling to
-    // e.g. `served` would keep the series count identical and only show up as a
-    // moved VALUE, so the count check alone would miss it.
-    expect(await seriesOf('bitdex_primary_result_total')).toHaveLength(before.length);
-    expect(afterCounts.values.map((v) => v.value)).toEqual(beforeCounts.values.map((v) => v.value));
+    const after = await valuesByLabelKey('bitdex_primary_result_total');
+    // No new series...
+    expect(Object.keys(after).sort()).toEqual(Object.keys(before).sort());
+    expect(Object.keys(after)).toHaveLength(EXPECTED_RESULT_SERIES);
+    // ...AND no existing series moved. A relabel to `served` would satisfy the
+    // first check and fail this one, which is the whole point of the case.
+    const moved = Object.keys(after).filter((k) => after[k] !== before[k]);
+    expect(moved).toEqual([]);
+  });
+
+  it('an unknown REASON is not relabelled either', async () => {
+    const before = await valuesByLabelKey('bitdex_query_failures_total');
+
+    recordBitdexQueryFailure('http_418' as (typeof BITDEX_QUERY_FAILURE_REASONS)[number]);
+
+    const after = await valuesByLabelKey('bitdex_query_failures_total');
+    expect(Object.keys(after)).toHaveLength(BITDEX_QUERY_FAILURE_REASONS.length);
+    expect(Object.keys(after).filter((k) => after[k] !== before[k])).toEqual([]);
   });
 });

--- a/src/server/metrics/__tests__/bitdex-feed-serve.metrics.test.ts
+++ b/src/server/metrics/__tests__/bitdex-feed-serve.metrics.test.ts
@@ -1,0 +1,112 @@
+import client from 'prom-client';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  BITDEX_QUERY_FAILURE_REASONS,
+  BITDEX_SERVE_MODES,
+  BITDEX_SERVE_OUTCOMES,
+  ensureRegisterBitdexFeedServeMetrics,
+  recordBitdexPrimaryResult,
+  recordBitdexQueryFailure,
+  type BitdexServeMode,
+  type BitdexServeOutcome,
+} from '../bitdex-feed-serve.metrics';
+
+/**
+ * 🔴 THE RUNTIME LABEL-NARROWING GUARDS, WHICH NOTHING ELSE REACHES.
+ *
+ * The module's header claims a hard cardinality bound of 14 series and says the
+ * bound "rests on CODE, not on the erased types". That claim is only true if the
+ * `is…` checks in the two `record…` functions actually run and actually drop an
+ * unrecognised value. Nothing else in the suite can test them: every other caller
+ * is type-checked, so it can only ever pass legal values, and BOTH guards
+ * therefore survived deletion outright and survived `||` → `&&` on a fully green
+ * run. A guard no test can reach is not a guard, it is a comment.
+ *
+ * These cases defeat the types deliberately — which is the only way in, and
+ * exactly what a future refactor passing an un-narrowed string would do by
+ * accident.
+ *
+ * The `||` → `&&` mutant needs BOTH single-bad-argument cases to die: under
+ * `&&`, a call is dropped only when EVERY label is invalid, so a case with one
+ * bad and one good label is the one that separates the two operators. Testing
+ * only the both-invalid case would leave that mutant alive.
+ */
+
+type Readable = {
+  get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }>;
+};
+
+async function seriesOf(name: string): Promise<Array<Record<string, string>>> {
+  const metric = client.register.getSingleMetric(name) as unknown as Readable | undefined;
+  if (!metric) return [];
+  const { values } = await metric.get();
+  return values.map((v) => v.labels);
+}
+
+const EXPECTED_RESULT_SERIES = BITDEX_SERVE_OUTCOMES.length * BITDEX_SERVE_MODES.length;
+
+describe('the record functions drop label values outside their union', () => {
+  beforeEach(() => {
+    // Registration is idempotent, so this only ensures the seeded baseline
+    // exists before each case rather than resetting anything.
+    ensureRegisterBitdexFeedServeMetrics();
+  });
+
+  it('POSITIVE CONTROL: a legal call DOES create/keep its series', async () => {
+    recordBitdexPrimaryResult('served', 'primary');
+    const labels = await seriesOf('bitdex_primary_result_total');
+    expect(labels).toHaveLength(EXPECTED_RESULT_SERIES);
+    expect(labels.some((l) => l.outcome === 'served' && l.mode === 'primary')).toBe(true);
+  });
+
+  it('an unknown OUTCOME with a valid mode is dropped — no new series', async () => {
+    recordBitdexPrimaryResult('totally_made_up' as BitdexServeOutcome, 'primary');
+
+    const labels = await seriesOf('bitdex_primary_result_total');
+    expect(labels).toHaveLength(EXPECTED_RESULT_SERIES);
+    expect(labels.some((l) => l.outcome === 'totally_made_up')).toBe(false);
+  });
+
+  it('an unknown MODE with a valid outcome is dropped — no new series', async () => {
+    recordBitdexPrimaryResult('served', 'canary' as BitdexServeMode);
+
+    const labels = await seriesOf('bitdex_primary_result_total');
+    expect(labels).toHaveLength(EXPECTED_RESULT_SERIES);
+    expect(labels.some((l) => l.mode === 'canary')).toBe(false);
+  });
+
+  it('both labels unknown is dropped too', async () => {
+    recordBitdexPrimaryResult('nope' as BitdexServeOutcome, 'nope' as BitdexServeMode);
+
+    const labels = await seriesOf('bitdex_primary_result_total');
+    expect(labels).toHaveLength(EXPECTED_RESULT_SERIES);
+    expect(labels.some((l) => l.outcome === 'nope' || l.mode === 'nope')).toBe(false);
+  });
+
+  it('an unknown failure REASON is dropped — the cardinality bound rests here', async () => {
+    recordBitdexQueryFailure('http_418' as (typeof BITDEX_QUERY_FAILURE_REASONS)[number]);
+
+    const labels = await seriesOf('bitdex_query_failures_total');
+    expect(labels).toHaveLength(BITDEX_QUERY_FAILURE_REASONS.length);
+    expect(labels.some((l) => l.reason === 'http_418')).toBe(false);
+  });
+
+  it('a dropped label value is NOT silently relabelled to a plausible default', async () => {
+    const before = await seriesOf('bitdex_primary_result_total');
+    const beforeCounts = await (
+      client.register.getSingleMetric('bitdex_primary_result_total') as unknown as Readable
+    ).get();
+
+    recordBitdexPrimaryResult('bogus' as BitdexServeOutcome, 'primary');
+
+    const afterCounts = await (
+      client.register.getSingleMetric('bitdex_primary_result_total') as unknown as Readable
+    ).get();
+    // Neither a new series NOR an increment on an existing one. Relabelling to
+    // e.g. `served` would keep the series count identical and only show up as a
+    // moved VALUE, so the count check alone would miss it.
+    expect(await seriesOf('bitdex_primary_result_total')).toHaveLength(before.length);
+    expect(afterCounts.values.map((v) => v.value)).toEqual(beforeCounts.values.map((v) => v.value));
+  });
+});

--- a/src/server/metrics/__tests__/bitdex-feed-serve.metrics.test.ts
+++ b/src/server/metrics/__tests__/bitdex-feed-serve.metrics.test.ts
@@ -64,11 +64,23 @@ async function valuesByLabelKey(name: string): Promise<Record<string, number>> {
   const snapshot: Record<string, number> = {};
   for (const v of values) {
     snapshot[`${v.labels.outcome ?? ''}|${v.labels.mode ?? ''}|${v.labels.reason ?? ''}`] = Number(
-      v.value
+      v.value ?? 0
     );
   }
   return snapshot;
 }
+
+/**
+ * Reads a possibly-ABSENT key as 0.
+ *
+ * This is what removes the dependency on `seedAllSeries` having materialised
+ * every series — not a `??` on the value above, which would be a no-op, since
+ * `Number()` returns `NaN` rather than anything nullish. Absent-vs-zero is the
+ * distinction that matters here: without this, a not-yet-materialised child
+ * compares `undefined !== 0` and reads as "moved". The `beforeEach` makes that
+ * unreachable today; the sibling suite decouples anyway and so does this.
+ */
+const at = (snapshot: Record<string, number>, k: string) => snapshot[k] ?? 0;
 
 const EXPECTED_RESULT_SERIES = BITDEX_SERVE_OUTCOMES.length * BITDEX_SERVE_MODES.length;
 
@@ -96,9 +108,9 @@ describe('the record functions drop label values outside their union', () => {
     recordBitdexPrimaryResult('served', 'primary');
 
     const after = await valuesByLabelKey('bitdex_primary_result_total');
-    expect(after['served|primary|'] - before['served|primary|']).toBe(1);
+    expect(at(after, 'served|primary|') - at(before, 'served|primary|')).toBe(1);
     // And nothing else moved, so the read path resolves the right child.
-    const moved = Object.keys(after).filter((k) => after[k] !== before[k]);
+    const moved = Object.keys(after).filter((k) => at(after, k) !== at(before, k));
     expect(moved).toEqual(['served|primary|']);
   });
 
@@ -108,7 +120,7 @@ describe('the record functions drop label values outside their union', () => {
     recordBitdexQueryFailure('http_4xx');
 
     const after = await valuesByLabelKey('bitdex_query_failures_total');
-    expect(after['||http_4xx'] - before['||http_4xx']).toBe(1);
+    expect(at(after, '||http_4xx') - at(before, '||http_4xx')).toBe(1);
   });
 
   it('an unknown OUTCOME with a valid mode is dropped — no new series', async () => {
@@ -162,7 +174,7 @@ describe('the record functions drop label values outside their union', () => {
     expect(Object.keys(after)).toHaveLength(EXPECTED_RESULT_SERIES);
     // ...AND no existing series moved. A relabel to `served` would satisfy the
     // first check and fail this one, which is the whole point of the case.
-    const moved = Object.keys(after).filter((k) => after[k] !== before[k]);
+    const moved = Object.keys(after).filter((k) => at(after, k) !== at(before, k));
     expect(moved).toEqual([]);
   });
 
@@ -173,6 +185,6 @@ describe('the record functions drop label values outside their union', () => {
 
     const after = await valuesByLabelKey('bitdex_query_failures_total');
     expect(Object.keys(after)).toHaveLength(BITDEX_QUERY_FAILURE_REASONS.length);
-    expect(Object.keys(after).filter((k) => after[k] !== before[k])).toEqual([]);
+    expect(Object.keys(after).filter((k) => at(after, k) !== at(before, k))).toEqual([]);
   });
 });

--- a/src/server/metrics/__tests__/metrics-endpoint-seeds-bitdex-feed-serve.test.ts
+++ b/src/server/metrics/__tests__/metrics-endpoint-seeds-bitdex-feed-serve.test.ts
@@ -1,0 +1,108 @@
+import client from 'prom-client';
+import { describe, expect, it, vi } from 'vitest';
+// Registers the db mock; `/api/metrics` pulls in `~/server/db/client` at module
+// load. Imported for the side effect, exactly as the sibling seam test does.
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * 🔴 THE SEAM: does loading the module that SERVES the scrape actually register
+ * and seed `bitdex_primary_result_total` and `bitdex_query_failures_total`?
+ * (#3930)
+ *
+ * Seeding every label combination to 0 is inert on its own.
+ * `ensureRegisterBitdexFeedServeMetrics` has no caller outside its own module,
+ * and the only production paths in are `recordBitdexPrimaryResult` /
+ * `recordBitdexQueryFailure` — which by definition run only AFTER the event has
+ * happened. So without a module-scope call from `src/pages/api/metrics.ts`,
+ * `…{outcome="fallback_error"}` reads `no data` on a process until its first
+ * failure: indistinguishable from an unwired instrument, on the exact series
+ * this issue exists to create and whose healthy value is zero. Two components,
+ * each fine alone, broken together — which is why this test loads the endpoint
+ * module rather than the metrics module.
+ *
+ * That failure is not hypothetical for this metric family. The older
+ * `bitdex_shadow_*` counters in `~/server/bitdex/compare.ts` use the bare
+ * registration pattern with no seeding and no endpoint call, and a current read
+ * of them returns `no data` despite history in the index.
+ *
+ * Modelled on `metrics-endpoint-seeds-substitutions.test.ts`, including the
+ * reason it asserts BEHAVIOURALLY (does the series exist after the module
+ * loads?) rather than by parsing `metrics.ts` for a call: a source check
+ * false-fails correct refactors (`void f()`, an aliased import, a relative
+ * specifier) while passing an `import type` plus a call.
+ */
+
+// `endpoint-helpers` spreads `env.TRPC_ORIGINS` at module load; stub the wrapper
+// itself so none of that graph is needed.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: unknown) => handler,
+}));
+
+const RESULT_METRIC = 'bitdex_primary_result_total';
+const FAILURES_METRIC = 'bitdex_query_failures_total';
+
+type Readable = {
+  get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }>;
+};
+
+describe('/api/metrics registers + seeds the BitDex serve-outcome counters at module load', () => {
+  it('NEGATIVE CONTROL: both counters are absent before the page module is loaded', () => {
+    expect(client.register.getSingleMetric(RESULT_METRIC)).toBeUndefined();
+    expect(client.register.getSingleMetric(FAILURES_METRIC)).toBeUndefined();
+  });
+
+  it('🔴 after loading the page module, all 8 outcome × mode series exist at 0', async () => {
+    await import('~/pages/api/metrics');
+
+    const metric = client.register.getSingleMetric(RESULT_METRIC) as unknown as
+      | Readable
+      | undefined;
+    expect(metric).toBeDefined();
+
+    const { values } = await metric!.get();
+    // Derived from the unions, not hardcoded: a 5th outcome or a 3rd mode must
+    // be seeded too, and this must fail until it is.
+    const { BITDEX_SERVE_MODES, BITDEX_SERVE_OUTCOMES } = await import(
+      '~/server/metrics/bitdex-feed-serve.metrics'
+    );
+    expect(values).toHaveLength(BITDEX_SERVE_OUTCOMES.length * BITDEX_SERVE_MODES.length);
+    expect(values.every((v) => v.value === 0)).toBe(true);
+
+    // Named explicitly. `fallback_error` is the series #3930 adds and the one an
+    // alert queries first; its presence-at-zero is the entire point, because its
+    // healthy value and its unwired value are the same number.
+    for (const mode of BITDEX_SERVE_MODES) {
+      expect(
+        values.some((v) => v.labels.outcome === 'fallback_error' && v.labels.mode === mode)
+      ).toBe(true);
+    }
+    // Every declared combination present, so a partially-seeded loop fails here
+    // rather than at whichever combination happened to be checked by hand.
+    for (const outcome of BITDEX_SERVE_OUTCOMES) {
+      for (const mode of BITDEX_SERVE_MODES) {
+        expect(values.some((v) => v.labels.outcome === outcome && v.labels.mode === mode)).toBe(
+          true
+        );
+      }
+    }
+  });
+
+  it('🔴 and all 6 failure-reason series exist at 0', async () => {
+    await import('~/pages/api/metrics');
+
+    const metric = client.register.getSingleMetric(FAILURES_METRIC) as unknown as
+      | Readable
+      | undefined;
+    expect(metric).toBeDefined();
+
+    const { values } = await metric!.get();
+    const { BITDEX_QUERY_FAILURE_REASONS } = await import(
+      '~/server/metrics/bitdex-feed-serve.metrics'
+    );
+    expect(values).toHaveLength(BITDEX_QUERY_FAILURE_REASONS.length);
+    expect(values.every((v) => v.value === 0)).toBe(true);
+    for (const reason of BITDEX_QUERY_FAILURE_REASONS) {
+      expect(values.some((v) => v.labels.reason === reason)).toBe(true);
+    }
+  });
+});

--- a/src/server/metrics/bitdex-feed-serve.metrics.ts
+++ b/src/server/metrics/bitdex-feed-serve.metrics.ts
@@ -44,17 +44,28 @@
 // moderator opened a queue. The consequence to hold onto: `sum(…)` here is the
 // count of requests that ENGAGED the backend, not the count of feed requests.
 //
-// The same exclusion covers every OTHER way a request can reach the empty-result
-// guard without contacting the backend — and there are more of them than the one
-// that prompted the guard. `fetchBitdexPrimary` gates on evidence that a call
-// actually happened (see `bitdexCallsObserved` there), so ALL of these are out:
-// a `limit` that collapses the fetch loop before its first iteration; and the
-// query builder's own early returns — hidden-with-no-hidden-images, an
-// unresolvable username, followed-with-zero-follows, newCreators-with-none. That
-// last one is a brand-new account opening the Following feed, i.e. ordinary
-// traffic, not an exotic input. The hand-driven internal comparison endpoint is
-// outside it too, by passing no callback: its calls reach
-// `bitdex_query_failures_total` but never this counter.
+// The same exclusion covers other ways a request can reach the empty-result
+// guard without contacting the backend. `fetchBitdexPrimary` gates on evidence
+// that a call actually happened (see `bitdexCallsObserved` there), which covers
+// a `limit` that collapses the fetch loop before its first iteration, and the
+// query builder's five early returns — `hidden` with no signed-in user, `hidden`
+// with no hidden images, an unresolvable username, followed-with-zero-follows,
+// newCreators-with-none.
+//
+// ⚠️ BUT ONLY WHEN THE FEED QUERY IS THE REQUEST'S ONLY QUERY, i.e. an anonymous
+// caller or any paginated request. An earlier revision of this note claimed all
+// five doors are excluded outright; MEASUREMENT REFUTED THAT. A signed-in caller
+// on the FIRST page also issues the own-content pass, which goes out regardless
+// of what the feed query does — so that request made a call and IS counted, even
+// though its feed query never left the process. `currentUserId` is in fact a
+// PRECONDITION of two of the five doors, so for those the exclusion can never
+// apply. Counting such a request is correct under "requests that ENGAGED the
+// backend"; it simply is not the same set as "requests whose FEED query went
+// out", and a dashboard must not read it as the latter.
+//
+// The hand-driven internal comparison endpoint is outside the denominator too,
+// by passing no callback: its calls reach `bitdex_query_failures_total` but
+// never this counter.
 //
 // ⚠️ SCOPE OF THAT GUARANTEE, stated precisely because it is an invariant now.
 // It covers `served`, `fallback_empty` and `fallback_error` — the three outcomes
@@ -248,6 +259,8 @@ export function ensureRegisterBitdexFeedServeMetrics(
     'APP-EMITTED (the web application, not the BitDex service, which exports its own bitdex_* families from a different scrape target). ' +
       'Feed requests that issued at least one query against BitDex, by what the application then did with the answer. ' +
       'One increment = one request, NOT one page shown to a user (shadow requests reach nobody) and NOT every request routed to the primary path: the moderator queues declined before any query is issued are deliberately outside this denominator. ' +
+      'TWO documented exceptions to that denominator, both deliberate: outcome=fallback_exception is emitted from the caller catch arms and is NOT gated on a query having been issued (it means the application threw on this path, which is worth paging on even if it threw before the first call); and a deployment with no endpoint configured reports a failure without a request leaving the process, so it records fallback_error rather than going quiet. ' +
+      'Also note a request whose FEED query returned early can still be counted when a signed-in first-page caller issued the parallel own-content query, so this is "requests that engaged the backend", not "requests whose feed query went out". ' +
       'outcome (served = BitDex answered and its documents were returned; fallback_empty = every query succeeded and the merged post-filtered result was still empty, so the index genuinely had nothing — not a defect; fallback_error = the result was empty AND at least one query in the request failed, so the emptiness is untrustworthy; fallback_exception = the application code itself threw while handling the response — page the app team, not the backend team). ' +
       'mode (primary = BitDex served the user or its failure sent the request to Meilisearch; shadow = the same path ran in the background for comparison and Meilisearch served the user regardless).',
     ['outcome', 'mode']

--- a/src/server/metrics/bitdex-feed-serve.metrics.ts
+++ b/src/server/metrics/bitdex-feed-serve.metrics.ts
@@ -1,0 +1,275 @@
+// BitDex feed SERVE-OUTCOME counters (issue #3930).
+//
+// The image feed can be answered by two different backends. When the primary
+// backend is selected for a request it either serves the page or the request
+// falls through to the search-index path — and until this module existed those
+// two were indistinguishable from outside the process. Every reason the primary
+// path declines collapses into a single `null` return: an unset config value, a
+// non-2xx response, a thrown fetch, an abort at the timeout, a body that failed
+// to parse, a 200 carrying zero documents, and a page the post-filter emptied
+// all produce exactly the same observable. So "the feed is degraded" and "the
+// index legitimately has nothing for this query" read identically, and neither
+// can be alerted on.
+//
+// 🔴 NAMESPACE NOTE, and it matters for whoever reads this in a query editor:
+// `bitdex_*` is ALSO the metric namespace of the backend service itself, which
+// exports its own `bitdex_…` families from its own process. This family is
+// APP-EMITTED — it is produced by the web application, on the request path, and
+// describes what the APPLICATION did with the backend's answer. The two are
+// scraped from different targets and are not comparable series. The `help`
+// strings below say so as well, because a help string is the only thing that
+// travels with the metric into a dashboard.
+//
+// TWO counters, because they answer questions with different owners:
+//
+//   `bitdex_primary_result_total{outcome, mode}` — per REQUEST, emitted from the
+//   feed service. This is the served/fallback ratio: the number a decision about
+//   rolling the primary path forward or back is actually made on.
+//
+//   `bitdex_query_failures_total{reason}` — per CALL, emitted from inside the
+//   client. This is the "why", and it is unavailable from any other source: the
+//   backend's own request metric carries no status-code label, so a 4xx caused
+//   by shipping a filter on a field the index does not know is invisible
+//   everywhere else. One request makes 1–4 calls, so these two counters have
+//   DIFFERENT denominators and must not be divided by each other.
+//
+// 🔴 WHAT ONE `bitdex_primary_result_total` INCREMENT MEANS: one request that
+// issued at least one query against the primary backend. It is NOT one page
+// shown to a user (shadow-mode requests never reach a user), and it is NOT every
+// request that had the primary path selected: the moderator queues the feed
+// service declines BEFORE issuing any query (the scheduled / not-published
+// queues, which the primary backend answers a different question for) are
+// deliberately OUTSIDE this denominator. That decline is a policy choice, not a
+// failure, and counting it as one would make the served ratio sag whenever a
+// moderator opened a queue. The consequence to hold onto: `sum(…)` here is the
+// count of requests that ENGAGED the backend, not the count of feed requests.
+//
+// `mode` is free signal rather than a second metric. The same code path runs in
+// shadow, where the outcome previews what selecting the primary path for that
+// cohort would have done — a shadow-blind counter can only measure an exposure
+// after it has been taken. Folding the two into one series instead would make an
+// alert threshold mean two different things depending on which cohort was
+// flipped: a number that changes meaning without changing its name.
+//
+// 🔴 `fallback_exception` earns its own value rather than folding into
+// `fallback_error`, because the two demand OPPOSITE responses. `fallback_error`
+// means the backend or the network under it is unhealthy. `fallback_exception`
+// means the application's own mapping/merge/sort code threw — page the app team,
+// not the backend team. It reads a flat zero today, which makes it a clean
+// tripwire rather than a redundant series.
+//
+// 🔴 CARDINALITY: 4 outcomes × 2 modes = 8 series, plus 6 failure reasons = 14
+// series per process, TOTAL, and the bound rests on CODE — every label value is
+// narrowed at runtime against a closed union declared once in this file, and an
+// unrecognised value is DROPPED rather than passed through or relabelled to a
+// plausible default (either would make the "14 series" claim a wish). Explicitly
+// disqualified as labels: user id, cursor, filter shape, sort, model/post ids,
+// and the raw status code — this fires once per feed request on the highest-
+// traffic path in the application, nothing caches it, and prom-client retains
+// every distinct label set in the Node heap for the life of the process. A
+// `sort` label was considered and rejected for v1 (×5 → 40 series; the same
+// question is answerable from the existing comparison metrics).
+//
+// prom-client GOTCHA (same as ~/server/metrics/generation-model-substitution.metrics.ts):
+// Next.js can import a module twice (hot reload / route bundling) and prom-client
+// throws if a metric name is registered twice, so the getters below are
+// get-or-create guards against the DEFAULT global registry.
+import client, { type Counter, type Registry } from 'prom-client';
+
+/**
+ * Per-REQUEST outcome of the primary feed path.
+ *
+ * - `served`      — the primary backend answered and its documents were returned.
+ * - `fallback_empty` — every query in the request succeeded and the merged,
+ *   post-filtered result was still empty. The index genuinely had nothing (or
+ *   the post-filter removed everything). NOT a defect.
+ * - `fallback_error` — the result was empty AND at least one query in the
+ *   request failed. The empty result is UNTRUSTWORTHY: an own-content pass that
+ *   failed while the main pass came back empty means you do not know whether the
+ *   page was empty. This is the value this issue exists to make observable.
+ * - `fallback_exception` — the application's own code threw while handling the
+ *   response. Distinct owner, distinct response.
+ */
+export const BITDEX_SERVE_OUTCOMES = [
+  'served',
+  'fallback_empty',
+  'fallback_error',
+  'fallback_exception',
+] as const;
+export type BitdexServeOutcome = (typeof BITDEX_SERVE_OUTCOMES)[number];
+
+/**
+ * Which cohort the request ran in.
+ *
+ * - `primary` — the primary backend's answer was served to the user (or its
+ *   failure sent the request to the fallback backend).
+ * - `shadow`  — the same path ran in the background for comparison; the fallback
+ *   backend served the user regardless of the outcome recorded here.
+ */
+export const BITDEX_SERVE_MODES = ['primary', 'shadow'] as const;
+export type BitdexServeMode = (typeof BITDEX_SERVE_MODES)[number];
+
+/**
+ * Per-CALL failure classification, assigned at the client boundary where the
+ * status code and the error object are still in scope. Once the call returns,
+ * every one of these is the same `null`.
+ *
+ * - `unconfigured` — no endpoint configured; the call never left the process.
+ * - `http_4xx` — the request was rejected. The tail-risk case: a filter on a
+ *   field the index does not know is a 400, and it looks exactly like an empty
+ *   index from every other vantage point.
+ * - `http_5xx` — the backend failed to answer.
+ * - `timeout` — the request was aborted at the client deadline.
+ * - `network` — the fetch itself threw (DNS, connection refused, reset).
+ * - `parse` — a 2xx whose body could not be decoded.
+ */
+export const BITDEX_QUERY_FAILURE_REASONS = [
+  'unconfigured',
+  'http_4xx',
+  'http_5xx',
+  'timeout',
+  'network',
+  'parse',
+] as const;
+export type BitdexQueryFailureReason = (typeof BITDEX_QUERY_FAILURE_REASONS)[number];
+
+export function isBitdexServeOutcome(value: unknown): value is BitdexServeOutcome {
+  return BITDEX_SERVE_OUTCOMES.includes(value as BitdexServeOutcome);
+}
+
+export function isBitdexServeMode(value: unknown): value is BitdexServeMode {
+  return BITDEX_SERVE_MODES.includes(value as BitdexServeMode);
+}
+
+export function isBitdexQueryFailureReason(value: unknown): value is BitdexQueryFailureReason {
+  return BITDEX_QUERY_FAILURE_REASONS.includes(value as BitdexQueryFailureReason);
+}
+
+type MetricsBundle = {
+  primaryResultTotal: Counter<string>;
+  queryFailuresTotal: Counter<string>;
+};
+
+/**
+ * Initialise all 14 series to 0 at registration.
+ *
+ * 🔴 WHY, AND WHY IT IS NOT COSMETIC. prom-client only materialises a child
+ * series on its first `inc()`, so without this a process exposes NOTHING for a
+ * label combination until that combination occurs on that process. A read of
+ * `…{outcome="fallback_error"}` then returns `no data`, which is
+ * indistinguishable from "the instrument is not wired" — on the exact series
+ * this issue exists to create, whose whole job is to be believed when it reads
+ * zero.
+ *
+ * That is not hypothetical here. The older `bitdex_shadow_*` counters in
+ * `~/server/bitdex/compare.ts` use the bare-registration pattern with no
+ * seeding, and the consequence is live: they are present in the metric-name
+ * index with history, and a current read of them returns `no data`. A real zero
+ * and an absent series must be distinguishable, and today for those they are
+ * not.
+ *
+ * Free by construction: 14 series is this family's whole cardinality budget, so
+ * seeding costs exactly what a fully-exercised process already costs and cannot
+ * grow.
+ *
+ * 🔴 SEEDING ALONE IS INERT. `ensureRegisterBitdexFeedServeMetrics` has no
+ * caller outside this module, and the only production paths in are the two
+ * `record…` functions below — which by definition run only once the event has
+ * already happened. The missing half is the side-effect call in
+ * `src/pages/api/metrics.ts` (which already documents this for the substitution
+ * counter two imports above it). Both halves are required; neither works alone.
+ *
+ * Idempotent — `getOrCreateCounter` returns the EXISTING counter on re-entry and
+ * `inc(…, 0)` is a no-op on an already-materialised series, so calling this on
+ * every request cannot reset or double-count anything.
+ */
+function seedAllSeries(bundle: MetricsBundle): void {
+  for (const outcome of BITDEX_SERVE_OUTCOMES) {
+    for (const mode of BITDEX_SERVE_MODES) bundle.primaryResultTotal.inc({ outcome, mode }, 0);
+  }
+  for (const reason of BITDEX_QUERY_FAILURE_REASONS) bundle.queryFailuresTotal.inc({ reason }, 0);
+}
+
+function getOrCreateCounter(
+  reg: Registry,
+  name: string,
+  help: string,
+  labelNames: string[]
+): Counter<string> {
+  const existing = reg.getSingleMetric(name) as Counter<string> | undefined;
+  if (existing) return existing;
+  return new client.Counter({ name, help, labelNames, registers: [reg] });
+}
+
+/**
+ * Idempotent: safe to call on every request. Returns the counter instances
+ * (existing or newly created) from the default registry that /api/metrics
+ * scrapes.
+ */
+export function ensureRegisterBitdexFeedServeMetrics(
+  reg: Registry = client.register
+): MetricsBundle {
+  const primaryResultTotal = getOrCreateCounter(
+    reg,
+    'bitdex_primary_result_total',
+    'APP-EMITTED (the web application, not the BitDex service, which exports its own bitdex_* families from a different scrape target). ' +
+      'Feed requests that issued at least one query against BitDex, by what the application then did with the answer. ' +
+      'One increment = one request, NOT one page shown to a user (shadow requests reach nobody) and NOT every request routed to the primary path: the moderator queues declined before any query is issued are deliberately outside this denominator. ' +
+      'outcome (served = BitDex answered and its documents were returned; fallback_empty = every query succeeded and the merged post-filtered result was still empty, so the index genuinely had nothing — not a defect; fallback_error = the result was empty AND at least one query in the request failed, so the emptiness is untrustworthy; fallback_exception = the application code itself threw while handling the response — page the app team, not the backend team). ' +
+      'mode (primary = BitDex served the user or its failure sent the request to Meilisearch; shadow = the same path ran in the background for comparison and Meilisearch served the user regardless).',
+    ['outcome', 'mode']
+  );
+
+  const queryFailuresTotal = getOrCreateCounter(
+    reg,
+    'bitdex_query_failures_total',
+    'APP-EMITTED (the web application, not the BitDex service). Individual BitDex query CALLS that failed, classified at the client boundary where the status code and error object are still in scope — after the call returns they are all the same null. ' +
+      'One increment = one CALL, and one feed request makes 1-4 calls, so this counter has a DIFFERENT denominator from bitdex_primary_result_total and the two must not be divided by each other. ' +
+      'reason (unconfigured = no endpoint configured, the call never left the process; http_4xx = the request was rejected, e.g. a filter naming a field the index does not know — invisible from every other vantage point because the service-side request metric carries no status-code label; http_5xx = the backend failed to answer; timeout = aborted at the client deadline; network = the fetch threw; parse = a 2xx whose body could not be decoded).',
+    ['reason']
+  );
+
+  const bundle = { primaryResultTotal, queryFailuresTotal };
+  seedAllSeries(bundle);
+  return bundle;
+}
+
+/**
+ * Fail-soft emit of one request-level serve outcome.
+ *
+ * 🔴 TOTAL, like every emitter in the sibling metrics modules. This instruments
+ * the highest-traffic feed path in the application: a metrics error (registry
+ * collision, label mismatch) must never propagate, or observing a successful
+ * fallback would turn it into a failed feed request — the observability
+ * converting a working request into an outage.
+ */
+export function recordBitdexPrimaryResult(
+  outcome: BitdexServeOutcome,
+  mode: BitdexServeMode
+): void {
+  try {
+    // 🔴 The cardinality bound rests HERE, on code, not on the erased types
+    // above. An unknown outcome or mode is DROPPED, not passed through and not
+    // relabelled to a plausible default. Reachable today only by defeating the
+    // types.
+    if (!isBitdexServeOutcome(outcome) || !isBitdexServeMode(mode)) return;
+    const { primaryResultTotal } = ensureRegisterBitdexFeedServeMetrics();
+    primaryResultTotal.inc({ outcome, mode });
+  } catch {
+    /* instrument-only — never let a metrics error touch the feed path */
+  }
+}
+
+/**
+ * Fail-soft emit of one failed BitDex query call. Called from the client, which
+ * is the only place the failure is still classifiable.
+ */
+export function recordBitdexQueryFailure(reason: BitdexQueryFailureReason): void {
+  try {
+    if (!isBitdexQueryFailureReason(reason)) return;
+    const { queryFailuresTotal } = ensureRegisterBitdexFeedServeMetrics();
+    queryFailuresTotal.inc({ reason });
+  } catch {
+    /* instrument-only — never let a metrics error touch the feed path */
+  }
+}

--- a/src/server/metrics/bitdex-feed-serve.metrics.ts
+++ b/src/server/metrics/bitdex-feed-serve.metrics.ts
@@ -43,6 +43,21 @@
 // failure, and counting it as one would make the served ratio sag whenever a
 // moderator opened a queue. The consequence to hold onto: `sum(…)` here is the
 // count of requests that ENGAGED the backend, not the count of feed requests.
+// Two other populations are outside it for the same reason: a request whose
+// `limit` collapses the fetch loop before it runs (externally reachable, and
+// explicitly guarded in `fetchBitdexPrimary`), and the hand-driven internal
+// comparison endpoint, which passes no callback so its calls reach
+// `bitdex_query_failures_total` but never this counter.
+//
+// 🔴 THIS COUNTER ALONE CANNOT SEE EVERY DEGRADATION, AND AN ALERT BUILT ON IT
+// ALONE WILL BE GREEN THROUGH ONE OF THEM. A request whose own-content pass
+// fails while the main pass stays healthy still SERVES A PAGE — so it is
+// recorded, correctly, as `served` — but the user has silently lost their own
+// private/blocked/unpublished content from that page. The served ratio reads
+// 100% throughout; only `bitdex_query_failures_total` moves. Demoting such a
+// request was considered and rejected: it would make `served` mean "served and
+// perfect", which no threshold can interpret. ⇒ ANY dashboard or alert over this
+// family MUST read BOTH counters.
 //
 // `mode` is free signal rather than a second metric. The same code path runs in
 // shadow, where the outcome previews what selecting the primary path for that

--- a/src/server/metrics/bitdex-feed-serve.metrics.ts
+++ b/src/server/metrics/bitdex-feed-serve.metrics.ts
@@ -43,11 +43,29 @@
 // failure, and counting it as one would make the served ratio sag whenever a
 // moderator opened a queue. The consequence to hold onto: `sum(…)` here is the
 // count of requests that ENGAGED the backend, not the count of feed requests.
-// Two other populations are outside it for the same reason: a request whose
-// `limit` collapses the fetch loop before it runs (externally reachable, and
-// explicitly guarded in `fetchBitdexPrimary`), and the hand-driven internal
-// comparison endpoint, which passes no callback so its calls reach
+//
+// The same exclusion covers every OTHER way a request can reach the empty-result
+// guard without contacting the backend — and there are more of them than the one
+// that prompted the guard. `fetchBitdexPrimary` gates on evidence that a call
+// actually happened (see `bitdexCallsObserved` there), so ALL of these are out:
+// a `limit` that collapses the fetch loop before its first iteration; and the
+// query builder's own early returns — hidden-with-no-hidden-images, an
+// unresolvable username, followed-with-zero-follows, newCreators-with-none. That
+// last one is a brand-new account opening the Following feed, i.e. ordinary
+// traffic, not an exotic input. The hand-driven internal comparison endpoint is
+// outside it too, by passing no callback: its calls reach
 // `bitdex_query_failures_total` but never this counter.
+//
+// ⚠️ SCOPE OF THAT GUARANTEE, stated precisely because it is an invariant now.
+// It covers `served`, `fallback_empty` and `fallback_error` — the three outcomes
+// emitted from inside `fetchBitdexPrimary`, where the evidence lives.
+// `fallback_exception` is emitted from the CALLER's catch arms and is
+// deliberately NOT gated: it means "the application threw on the BitDex path",
+// and whether a query had been issued first is irrelevant to that meaning — an
+// app-side throw before the first call is still an app-side throw worth paging
+// on, and suppressing it would blind the tripwire in the case where the code
+// broke earliest. So `fallback_exception` has a deliberately different
+// denominator from its three siblings. It reads a flat zero today.
 //
 // 🔴 THIS COUNTER ALONE CANNOT SEE EVERY DEGRADATION, AND AN ALERT BUILT ON IT
 // ALONE WILL BE GREEN THROUGH ONE OF THEM. A request whose own-content pass

--- a/src/server/metrics/bitdex-feed-serve.metrics.ts
+++ b/src/server/metrics/bitdex-feed-serve.metrics.ts
@@ -52,16 +52,24 @@
 // with no hidden images, an unresolvable username, followed-with-zero-follows,
 // newCreators-with-none.
 //
-// ⚠️ BUT ONLY WHEN THE FEED QUERY IS THE REQUEST'S ONLY QUERY, i.e. an anonymous
-// caller or any paginated request. An earlier revision of this note claimed all
-// five doors are excluded outright; MEASUREMENT REFUTED THAT. A signed-in caller
-// on the FIRST page also issues the own-content pass, which goes out regardless
-// of what the feed query does — so that request made a call and IS counted, even
-// though its feed query never left the process. `currentUserId` is in fact a
-// PRECONDITION of two of the five doors, so for those the exclusion can never
-// apply. Counting such a request is correct under "requests that ENGAGED the
-// backend"; it simply is not the same set as "requests whose FEED query went
-// out", and a dashboard must not read it as the latter.
+// ⚠️ BUT ONLY WHEN NO SECOND QUERY GOES OUT — AND THAT IS A PREDICATE, NOT A
+// DESCRIPTION. Two successive hand-written glosses of it were each refuted by
+// measurement ("all five doors are excluded"; "an anonymous caller or any
+// paginated request"), so do not paraphrase it a third time. The condition is
+// `skipOwnExcluded` in `fetchBitdexPrimary` (image.service.ts, declared beside
+// the own-content pass), whose three disjuncts are exactly:
+//   1. anonymous caller (`!input.currentUserId`)
+//   2. a `bdx:` cursor — i.e. a BITDEX-paginated request, which is NOT the same
+//      as any paginated request: a request that fell back to Meilisearch carries
+//      a Meilisearch cursor on its next page and does NOT match
+//   3. signed-in caller viewing ANOTHER user's profile
+// When none holds, the own-content query goes out regardless of what the feed
+// query did, so the request made a call and IS counted even though its feed
+// query never left the process.
+//
+// Counting it is correct under "requests that ENGAGED the backend". It is simply
+// not the same set as "requests whose FEED query went out", and a dashboard must
+// not read it as the latter.
 //
 // The hand-driven internal comparison endpoint is outside the denominator too,
 // by passing no callback: its calls reach `bitdex_query_failures_total` but
@@ -259,8 +267,8 @@ export function ensureRegisterBitdexFeedServeMetrics(
     'APP-EMITTED (the web application, not the BitDex service, which exports its own bitdex_* families from a different scrape target). ' +
       'Feed requests that issued at least one query against BitDex, by what the application then did with the answer. ' +
       'One increment = one request, NOT one page shown to a user (shadow requests reach nobody) and NOT every request routed to the primary path: the moderator queues declined before any query is issued are deliberately outside this denominator. ' +
-      'TWO documented exceptions to that denominator, both deliberate: outcome=fallback_exception is emitted from the caller catch arms and is NOT gated on a query having been issued (it means the application threw on this path, which is worth paging on even if it threw before the first call); and a deployment with no endpoint configured reports a failure without a request leaving the process, so it records fallback_error rather than going quiet. ' +
-      'Also note a request whose FEED query returned early can still be counted when a signed-in first-page caller issued the parallel own-content query, so this is "requests that engaged the backend", not "requests whose feed query went out". ' +
+      'Deliberate exceptions to that denominator include: outcome=fallback_exception, which is emitted from the caller catch arms and is NOT gated on a query having been issued (it means the application threw on this path, which is worth paging on even if it threw before the first call); and a deployment with no endpoint configured, which reports a failure without a request leaving the process and so records fallback_error rather than going quiet. ' +
+      'Also note a request whose FEED query returned early can still be counted, because the parallel own-content query may have gone out regardless (the condition is the skipOwnExcluded predicate in the feed service, not a property of the feed query). So this is "requests that engaged the backend", NOT "requests whose feed query went out", and must not be read as the latter. ' +
       'outcome (served = BitDex answered and its documents were returned; fallback_empty = every query succeeded and the merged post-filtered result was still empty, so the index genuinely had nothing — not a defect; fallback_error = the result was empty AND at least one query in the request failed, so the emptiness is untrustworthy; fallback_exception = the application code itself threw while handling the response — page the app team, not the backend team). ' +
       'mode (primary = BitDex served the user or its failure sent the request to Meilisearch; shadow = the same path ran in the background for comparison and Meilisearch served the user regardless).',
     ['outcome', 'mode']

--- a/src/server/services/__tests__/bitdex-feed-source.test.ts
+++ b/src/server/services/__tests__/bitdex-feed-source.test.ts
@@ -117,6 +117,36 @@ const baseInput = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ImageSearchInput isn't exported
 } as any;
 
+const CURRENT_USER_ID = 42;
+
+/**
+ * Both BitDex passes go through the same `queryBitdex`, so a fake has to tell
+ * them apart from their arguments or it answers the same thing to both and every
+ * assertion keyed on the difference is meaningless.
+ *
+ * The main pass filters availability with `Not(Eq(availability, Private))`; the
+ * own-content pass asks for the OPPOSITE inside an `Or`. Keying on that `Or`
+ * distinguishes them STRUCTURALLY rather than by call order or argument
+ * position, both of which are incidental and would silently stop discriminating
+ * if the parallel pass were reordered. Same discriminator as
+ * `bitdex-empty-fallback.test.ts`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw BitDex filter clauses
+type Clause = any;
+function isOwnExcludedQuery(filters: unknown): boolean {
+  if (!Array.isArray(filters)) return false;
+  return filters.some(
+    (clause: Clause) =>
+      Array.isArray(clause?.Or) &&
+      clause.Or.some(
+        (member: Clause) =>
+          Array.isArray(member?.Eq) &&
+          member.Eq[0] === 'availability' &&
+          member.Eq[1]?.String === 'Private'
+      )
+  );
+}
+
 describe('getImagesFromSearch — reported source names the backend that served the page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -266,6 +296,84 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
     const after = await readOutcomes();
     expect(result.source).toBe('meili');
     expect(seriesThatMoved(before, after)).toEqual([key('fallback_exception', 'primary')]);
+  });
+
+  /**
+   * 🔴 THE SEAM THE OTHER CASES CANNOT REACH, AND THE REASON THEY CANNOT.
+   *
+   * Every case above runs ANONYMOUSLY (`currentUserId: undefined`), which makes
+   * `skipOwnExcluded` true — so the parallel own-content pass is NEVER ISSUED and
+   * exactly one BitDex call happens per request. With one call in play, "any call
+   * in this request failed" and "the main call failed" are byte-identical in
+   * behaviour, so the whole justification for the per-request predicate sat
+   * unexercised and a mutant that stopped threading the callback into the
+   * own-content pass survived a fully green run. Fixture collapse: the fixture
+   * could not distinguish the two implementations because it only ever built one
+   * of the two states.
+   *
+   * This case builds the state that separates them: a SIGNED-IN caller, whose
+   * own-content pass FAILS while the main pass succeeds and legitimately returns
+   * nothing. The main call reports no failure at all — so an implementation that
+   * only watched the main call would record `fallback_empty` and declare the page
+   * genuinely empty, when the documents that would have filled it are exactly the
+   * ones the failed call was fetching.
+   */
+  it('🔴 PRIMARY, signed-in, the OWN-CONTENT pass fails while the main pass is empty → fallback_error', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+
+    const calls: Array<{ ownExcluded: boolean; failed: boolean }> = [];
+    queryBitdexMock.mockImplementation(async (...args: unknown[]) => {
+      const ownExcluded = isOwnExcludedQuery(args[1]);
+      const onFailure = args.find((a) => typeof a === 'function') as
+        | ((reason: string) => void)
+        | undefined;
+      calls.push({ ownExcluded, failed: ownExcluded });
+      if (ownExcluded) {
+        // Only the own-content pass fails. The main pass below succeeds.
+        onFailure?.('http_5xx');
+        return null;
+      }
+      return { documents: [], cursor: undefined };
+    });
+
+    const before = await readOutcomes();
+    const result = await getImagesFromSearch({ ...baseInput, currentUserId: CURRENT_USER_ID });
+    const after = await readOutcomes();
+
+    // The fixture is only meaningful if BOTH passes actually ran and only the
+    // own-content one failed — assert the state was built before reading the
+    // conclusion off it, or a silently-skipped second pass would make this case
+    // pass for the same reason the anonymous ones do.
+    expect(calls.filter((c) => c.ownExcluded)).toHaveLength(1);
+    expect(calls.filter((c) => !c.ownExcluded).length).toBeGreaterThanOrEqual(1);
+    expect(calls.filter((c) => !c.ownExcluded).every((c) => !c.failed)).toBe(true);
+
+    expect(result.source).toBe('meili');
+    expect(seriesThatMoved(before, after)).toEqual([key('fallback_error', 'primary')]);
+  });
+
+  /**
+   * The denominator this counter's help string claims — "requests that issued at
+   * least one query" — has to be true of the code, not just of the sentence.
+   * `limit: 0` is externally reachable (the feed schema accepts `min(0)`) and
+   * collapses the pass loop before its first iteration; anonymously, the
+   * own-content pass is skipped too, so BitDex is never contacted. The empty
+   * result must NOT be recorded as a fallback, or the served ratio a rollout
+   * decision reads is biased downward by requests that asked BitDex nothing.
+   */
+  it('🔴 PRIMARY with limit 0 issues NO BitDex query, so nothing is recorded', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+    const before = await readOutcomes();
+
+    const result = await getImagesFromSearch({ ...baseInput, limit: 0 });
+
+    const after = await readOutcomes();
+    // Positive control on the premise: this asserts the zero-query state was
+    // actually built. Without it, "no series moved" would also be satisfied by a
+    // counter that had simply stopped working.
+    expect(queryBitdexMock).not.toHaveBeenCalled();
+    expect(result.source).toBe('meili');
+    expect(seriesThatMoved(before, after)).toEqual([]);
   });
 
   it('SHADOW, BitDex answers with documents → served{mode="shadow"} +1 (Meili still serves the user)', async () => {

--- a/src/server/services/__tests__/bitdex-feed-source.test.ts
+++ b/src/server/services/__tests__/bitdex-feed-source.test.ts
@@ -321,15 +321,24 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
   it('🔴 PRIMARY, signed-in, the OWN-CONTENT pass fails while the main pass is empty → fallback_error', async () => {
     getFliptVariantMock.mockResolvedValue('primary');
 
-    const calls: Array<{ ownExcluded: boolean; failed: boolean }> = [];
+    // Two INDEPENDENTLY-RECORDED ledgers: which passes ran, and which passes
+    // actually reported a failure. An earlier revision derived the second from
+    // the first (`failed: ownExcluded`), which made the "the main pass did not
+    // fail" assertion below restate its own fixture instead of observing
+    // anything. `reportedFailure` is now pushed from INSIDE the branch that
+    // invokes the callback, so it records what happened rather than what was
+    // intended.
+    const callsRun: Array<{ ownExcluded: boolean }> = [];
+    const reportedFailure: Array<{ ownExcluded: boolean }> = [];
     queryBitdexMock.mockImplementation(async (...args: unknown[]) => {
       const ownExcluded = isOwnExcludedQuery(args[1]);
       const onFailure = args.find((a) => typeof a === 'function') as
         | ((reason: string) => void)
         | undefined;
-      calls.push({ ownExcluded, failed: ownExcluded });
+      callsRun.push({ ownExcluded });
       if (ownExcluded) {
         // Only the own-content pass fails. The main pass below succeeds.
+        reportedFailure.push({ ownExcluded });
         onFailure?.('http_5xx');
         return null;
       }
@@ -344,9 +353,13 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
     // own-content one failed — assert the state was built before reading the
     // conclusion off it, or a silently-skipped second pass would make this case
     // pass for the same reason the anonymous ones do.
-    expect(calls.filter((c) => c.ownExcluded)).toHaveLength(1);
-    expect(calls.filter((c) => !c.ownExcluded).length).toBeGreaterThanOrEqual(1);
-    expect(calls.filter((c) => !c.ownExcluded).every((c) => !c.failed)).toBe(true);
+    expect(callsRun.filter((c) => c.ownExcluded)).toHaveLength(1);
+    expect(callsRun.filter((c) => !c.ownExcluded).length).toBeGreaterThanOrEqual(1);
+    // Exactly one failure was reported, and it came from the own-content pass —
+    // observed, not restated. If the main pass had also failed, `fallback_error`
+    // would be reachable without the own-content seam and the case would prove
+    // nothing.
+    expect(reportedFailure).toEqual([{ ownExcluded: true }]);
 
     expect(result.source).toBe('meili');
     expect(seriesThatMoved(before, after)).toEqual([key('fallback_error', 'primary')]);
@@ -371,6 +384,40 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
     // Positive control on the premise: this asserts the zero-query state was
     // actually built. Without it, "no series moved" would also be satisfied by a
     // counter that had simply stopped working.
+    expect(queryBitdexMock).not.toHaveBeenCalled();
+    expect(result.source).toBe('meili');
+    expect(seriesThatMoved(before, after)).toEqual([]);
+  });
+
+  /**
+   * 🔴 THE SAME DEFECT ONE DOOR DOWN, AND THE LIKELIER ONE.
+   *
+   * `limit: 0` is not the only way to reach the empty-result guard without
+   * contacting BitDex. `getImagesFromBitdexPreFilter` has FIVE early
+   * `return null` paths that never reach the client at all —
+   * hidden-with-no-hidden-images, an unresolvable username,
+   * followed-with-zero-follows, newCreators-with-none. A guard that counted LOOP
+   * ENTRY rather than evidence of an actual call passed the `limit: 0` test and
+   * still over-counted every one of these.
+   *
+   * That matters more than the case that prompted the guard: a brand-new account
+   * opening the Following feed walks one of these doors, which is ordinary
+   * traffic, not an exotic input.
+   *
+   * `hidden` with an anonymous caller is the cleanest of them to drive — it
+   * returns at the first line of that block with no database round trip — and it
+   * exercises the same `return null` shape as the other four.
+   */
+  it('🔴 PRIMARY where the query builder returns early issues NO BitDex query, so nothing is recorded', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+    const before = await readOutcomes();
+
+    // Anonymous + `hidden` → `if (!currentUserId) return null` before any client
+    // call. Anonymous also skips the own-content pass, so the request contacts
+    // BitDex exactly zero times.
+    const result = await getImagesFromSearch({ ...baseInput, hidden: true });
+
+    const after = await readOutcomes();
     expect(queryBitdexMock).not.toHaveBeenCalled();
     expect(result.source).toBe('meili');
     expect(seriesThatMoved(before, after)).toEqual([]);

--- a/src/server/services/__tests__/bitdex-feed-source.test.ts
+++ b/src/server/services/__tests__/bitdex-feed-source.test.ts
@@ -69,6 +69,13 @@ vi.mock('~/server/flipt/client', async (importOriginal) => ({
 }));
 
 import { getImagesFromSearch } from '../image.service';
+import {
+  BITDEX_SERVE_MODES,
+  BITDEX_SERVE_OUTCOMES,
+  ensureRegisterBitdexFeedServeMetrics,
+  type BitdexServeMode,
+  type BitdexServeOutcome,
+} from '~/server/metrics/bitdex-feed-serve.metrics';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
 redisMock.redis.get.mockResolvedValue('[]');
@@ -139,5 +146,141 @@ describe('getImagesFromSearch — reported source names the backend that served 
     const result = await getImagesFromSearch(baseInput);
 
     expect(result.source).toBe('meili');
+  });
+});
+
+/**
+ * 🔴 POSITIVE CONTROL FOR `bitdex_primary_result_total` (#3930).
+ *
+ * The whole value of this counter is that a ZERO on `outcome="fallback_error"`
+ * can be believed. A counter that is never incremented reads zero too, and the
+ * two are indistinguishable from a dashboard — so a zero is worthless until
+ * something has been watched to move.
+ *
+ * Every case below asserts on the DELTA and asserts that EXACTLY ONE series
+ * moved, naming which. Two properties fall out of that shape:
+ *   - an emit line deleted anywhere makes the corresponding case fail on the
+ *     COUNTER's assertion (0 series moved), not on the `source` assertion in the
+ *     sibling describe above — the pre-existing assertion would still pass, and
+ *     a green-for-the-wrong-reason is exactly what this control has to exclude;
+ *   - the labels cannot be swapped, transposed, or collapsed onto one series
+ *     without a different case going red, because a different one is named in
+ *     each.
+ *
+ * 🔴 On the "BitDex throws" arm in the describe above: it drives a path
+ * PRODUCTION CANNOT REACH. `queryBitdex` documents that it never throws and
+ * returns `null` on every failure, so the mock replacing it with a rejection is
+ * exercising the application-error arm (`fallback_exception`), not a BitDex
+ * outage. The reachable version of a BitDex outage is a `null` return WITH the
+ * failure callback invoked, which is what the `fallback_error` case below
+ * drives — through the collector, the way the client actually reports it.
+ */
+type OutcomeSnapshot = Record<string, number>;
+
+async function readOutcomes(): Promise<OutcomeSnapshot> {
+  const { primaryResultTotal } = ensureRegisterBitdexFeedServeMetrics();
+  const { values } = await (
+    primaryResultTotal as unknown as {
+      get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }>;
+    }
+  ).get();
+  // Every combination pre-populated at 0, derived from the unions rather than
+  // listed: a series that is absent and a series that is zero must compare
+  // equal here, or the delta below would report "moved" for a first-ever emit
+  // on some other test's behalf.
+  const snapshot: OutcomeSnapshot = {};
+  for (const outcome of BITDEX_SERVE_OUTCOMES)
+    for (const mode of BITDEX_SERVE_MODES) snapshot[`${outcome}|${mode}`] = 0;
+  for (const v of values) snapshot[`${v.labels.outcome}|${v.labels.mode}`] = v.value;
+  return snapshot;
+}
+
+function seriesThatMoved(before: OutcomeSnapshot, after: OutcomeSnapshot): string[] {
+  return Object.keys(after)
+    .filter((key) => (after[key] ?? 0) !== (before[key] ?? 0))
+    .sort();
+}
+
+const key = (outcome: BitdexServeOutcome, mode: BitdexServeMode) => `${outcome}|${mode}`;
+
+describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per outcome', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryBitdexMock.mockResolvedValue(bitdexPage);
+  });
+
+  it('PRIMARY, BitDex answers with documents → served{mode="primary"} +1, and nothing else', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+    const before = await readOutcomes();
+
+    const result = await getImagesFromSearch(baseInput);
+
+    const after = await readOutcomes();
+    expect(result.source).toBe('bitdex');
+    expect(seriesThatMoved(before, after)).toEqual([key('served', 'primary')]);
+    expect(after[key('served', 'primary')] - before[key('served', 'primary')]).toBe(1);
+  });
+
+  it('PRIMARY, every call SUCCEEDS but the index has nothing → fallback_empty{mode="primary"} +1', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+    // A successful, genuinely empty page: no failure callback is invoked.
+    queryBitdexMock.mockResolvedValue({ documents: [], cursor: undefined });
+    const before = await readOutcomes();
+
+    const result = await getImagesFromSearch(baseInput);
+
+    const after = await readOutcomes();
+    expect(result.source).toBe('meili');
+    expect(seriesThatMoved(before, after)).toEqual([key('fallback_empty', 'primary')]);
+  });
+
+  it('🔴 PRIMARY, a call FAILS and the result is empty → fallback_error{mode="primary"} +1, NOT fallback_empty', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+    // The reachable shape of a BitDex outage: the client returns `null` — it
+    // never throws — and reports the classification through the callback it was
+    // handed. Driven through the collector rather than asserted on the mock, so
+    // this fails if the service stops passing the callback down.
+    queryBitdexMock.mockImplementation(async (...args: unknown[]) => {
+      const onFailure = args.find((a) => typeof a === 'function') as
+        | ((reason: string) => void)
+        | undefined;
+      onFailure?.('http_5xx');
+      return null;
+    });
+    const before = await readOutcomes();
+
+    const result = await getImagesFromSearch(baseInput);
+
+    const after = await readOutcomes();
+    expect(result.source).toBe('meili');
+    expect(seriesThatMoved(before, after)).toEqual([key('fallback_error', 'primary')]);
+  });
+
+  it('PRIMARY, the application itself throws → fallback_exception{mode="primary"} +1', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+    queryBitdexMock.mockRejectedValue(new Error('bitdex is down'));
+    const before = await readOutcomes();
+
+    const result = await getImagesFromSearch(baseInput);
+
+    const after = await readOutcomes();
+    expect(result.source).toBe('meili');
+    expect(seriesThatMoved(before, after)).toEqual([key('fallback_exception', 'primary')]);
+  });
+
+  it('SHADOW, BitDex answers with documents → served{mode="shadow"} +1 (Meili still serves the user)', async () => {
+    getFliptVariantMock.mockResolvedValue('shadow');
+    const before = await readOutcomes();
+
+    const result = await getImagesFromSearch(baseInput);
+    expect(result.source).toBe('meili');
+
+    // Shadow work is deliberately detached and outlives the user-facing return,
+    // so the emit lands after the awaited call resolves. Waiting is the only
+    // honest read; a bare read here would be a race that passes by luck.
+    await vi.waitFor(async () => {
+      const after = await readOutcomes();
+      expect(seriesThatMoved(before, after)).toEqual([key('served', 'shadow')]);
+    });
   });
 });

--- a/src/server/services/__tests__/bitdex-feed-source.test.ts
+++ b/src/server/services/__tests__/bitdex-feed-source.test.ts
@@ -390,23 +390,26 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
   });
 
   /**
-   * 🔴 THE SAME DEFECT ONE DOOR DOWN, AND THE LIKELIER ONE.
+   * 🔴 THE SAME DEFECT ONE DOOR DOWN — FOR AN ANONYMOUS CALLER.
    *
    * `limit: 0` is not the only way to reach the empty-result guard without
    * contacting BitDex. `getImagesFromBitdexPreFilter` has FIVE early
-   * `return null` paths that never reach the client at all —
-   * hidden-with-no-hidden-images, an unresolvable username,
-   * followed-with-zero-follows, newCreators-with-none. A guard that counted LOOP
-   * ENTRY rather than evidence of an actual call passed the `limit: 0` test and
-   * still over-counted every one of these.
+   * `return null` paths that never reach the client at all: `hidden` with no
+   * signed-in user, `hidden` with no hidden images, an unresolvable username,
+   * followed-with-zero-follows, and newCreators-with-none. A guard that counted
+   * LOOP ENTRY rather than evidence of an actual call over-counted all of them.
    *
-   * That matters more than the case that prompted the guard: a brand-new account
-   * opening the Following feed walks one of these doors, which is ordinary
-   * traffic, not an exotic input.
+   * ⚠️ READ THE SCOPE, because an earlier revision of this comment overstated it
+   * and the case below is the one that flatters the claim. The exclusion holds
+   * when the FEED query is the only query the request makes — i.e. an anonymous
+   * caller, or any paginated request — because `skipOwnExcluded` is then true.
+   * For a SIGNED-IN caller on the first page the own-content pass is issued
+   * regardless, so a call does go out and the request IS recorded. The sibling
+   * case below pins exactly that, so this pair cannot drift back into the
+   * absolute claim.
    *
-   * `hidden` with an anonymous caller is the cleanest of them to drive — it
-   * returns at the first line of that block with no database round trip — and it
-   * exercises the same `return null` shape as the other four.
+   * Anonymous `hidden` is the cleanest of the five to drive — it returns at the
+   * first line of that block with no database round trip.
    */
   it('🔴 PRIMARY where the query builder returns early issues NO BitDex query, so nothing is recorded', async () => {
     getFliptVariantMock.mockResolvedValue('primary');
@@ -421,6 +424,53 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
     expect(queryBitdexMock).not.toHaveBeenCalled();
     expect(result.source).toBe('meili');
     expect(seriesThatMoved(before, after)).toEqual([]);
+  });
+
+  /**
+   * 🔴 THE CASE THAT REFUTES THE ABSOLUTE VERSION OF THE CLAIM ABOVE, PINNED SO
+   * IT CANNOT BE RE-ASSERTED.
+   *
+   * A signed-in caller on the first page opening the Following feed with zero
+   * follows: the FEED query returns early inside the builder and never reaches
+   * the client — but `skipOwnExcluded` is false for any signed-in first-page
+   * request, so the own-content pass IS issued, completes, and counts. One call
+   * went out, so the request is recorded as `fallback_empty`.
+   *
+   * That is defensible under the stated denominator — "requests that ENGAGED the
+   * backend" — and it is deliberately NOT changed here. What was wrong was the
+   * claim that all five doors are excluded: `currentUserId` is a PRECONDITION of
+   * two of them (`hidden`-with-no-hidden-images, followed-with-zero-follows), so
+   * for those two the exclusion can never apply at all.
+   *
+   * Measured before being written: `calls=1 ownCalls=1
+   * moved=["fallback_empty|primary"]`.
+   *
+   * 🔴 This is also the ONLY killing case for `if (ownExcluded)
+   * bitdexCallsObserved++` — the third observation site, which had no mutation
+   * killing it. Delete that line and this case goes red, because the request then
+   * looks like it made no calls at all.
+   */
+  it('🔴 PRIMARY, signed-in, followed-with-zero-follows: the own-content pass still counts', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+    queryBitdexMock.mockResolvedValue({ documents: [], cursor: undefined });
+    const before = await readOutcomes();
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: CURRENT_USER_ID,
+      followed: true,
+    });
+
+    const after = await readOutcomes();
+    // The state this case exists to build: exactly ONE call went out, and it was
+    // the own-content pass — the feed query returned early inside the builder.
+    // Asserting the shape, not just the count, so a fixture that accidentally
+    // issued a feed query could not satisfy it.
+    expect(queryBitdexMock.mock.calls).toHaveLength(1);
+    expect(isOwnExcludedQuery(queryBitdexMock.mock.calls[0][1])).toBe(true);
+
+    expect(result.source).toBe('meili');
+    expect(seriesThatMoved(before, after)).toEqual([key('fallback_empty', 'primary')]);
   });
 
   it('SHADOW, BitDex answers with documents → served{mode="shadow"} +1 (Meili still serves the user)', async () => {

--- a/src/server/services/__tests__/bitdex-feed-source.test.ts
+++ b/src/server/services/__tests__/bitdex-feed-source.test.ts
@@ -399,17 +399,21 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
    * followed-with-zero-follows, and newCreators-with-none. A guard that counted
    * LOOP ENTRY rather than evidence of an actual call over-counted all of them.
    *
-   * ⚠️ READ THE SCOPE, because an earlier revision of this comment overstated it
-   * and the case below is the one that flatters the claim. The exclusion holds
-   * when the FEED query is the only query the request makes — i.e. an anonymous
-   * caller, or any paginated request — because `skipOwnExcluded` is then true.
-   * For a SIGNED-IN caller on the first page the own-content pass is issued
-   * regardless, so a call does go out and the request IS recorded. The sibling
-   * case below pins exactly that, so this pair cannot drift back into the
-   * absolute claim.
+   * ⚠️ READ THE SCOPE FROM THE PREDICATE, NOT FROM A SENTENCE. Two revisions of
+   * this comment glossed it and both were refuted by measurement. The exclusion
+   * holds exactly when `skipOwnExcluded` (image.service.ts, declared beside the
+   * own-content pass) is true, i.e. one of: anonymous caller; a `bdx:` cursor;
+   * signed-in caller viewing another user's profile. A NON-`bdx:` cursor does
+   * NOT qualify — and that is the common case, since a request that fell back to
+   * Meilisearch carries a Meilisearch cursor on its next page.
    *
-   * Anonymous `hidden` is the cleanest of the five to drive — it returns at the
-   * first line of that block with no database round trip.
+   * This case drives an ANONYMOUS caller, which is the disjunct that makes the
+   * exclusion apply — so on its own it flatters the claim. The sibling case below
+   * pins a request where a call DOES go out, and the two together are what stop
+   * this drifting back into an absolute.
+   *
+   * Anonymous `hidden` is the cleanest of the five doors to drive — it returns at
+   * the first line of that block with no database round trip.
    */
   it('🔴 PRIMARY where the query builder returns early issues NO BitDex query, so nothing is recorded', async () => {
     getFliptVariantMock.mockResolvedValue('primary');
@@ -432,9 +436,10 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
    *
    * A signed-in caller on the first page opening the Following feed with zero
    * follows: the FEED query returns early inside the builder and never reaches
-   * the client — but `skipOwnExcluded` is false for any signed-in first-page
-   * request, so the own-content pass IS issued, completes, and counts. One call
-   * went out, so the request is recorded as `fallback_empty`.
+   * the client — but no disjunct of `skipOwnExcluded` holds here (signed in, no
+   * `bdx:` cursor, not viewing another user's profile), so the own-content pass
+   * IS issued, completes, and counts. One call went out, so the request is
+   * recorded as `fallback_empty`.
    *
    * That is defensible under the stated denominator — "requests that ENGAGED the
    * backend" — and it is deliberately NOT changed here. What was wrong was the

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3233,18 +3233,35 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   // followed-with-zero-follows, and newCreators-with-none. Counting on entry
   // re-created the same overcount one door down.
   //
-  // ⚠️ SCOPE, because an earlier revision of this comment claimed all five are
-  // excluded and MEASUREMENT REFUTED IT. The exclusion holds only when the feed
-  // query is the request's ONLY query — an anonymous caller, or any paginated
-  // request — because `skipOwnExcluded` is true there. For a SIGNED-IN caller on
-  // the first page the own-content pass is issued regardless of what the feed
-  // query does, so a call goes out and the request IS recorded. Measured on
-  // signed-in + `followed` with zero follows: one call, `fallback_empty`
-  // recorded. Worse for the old claim, `currentUserId` is a PRECONDITION of two
-  // of the five doors, so for those the exclusion can never apply at all.
-  // Counting that request is defensible — a call did go out — and is deliberately
-  // left as is. Both cases are pinned in bitdex-feed-source.test.ts so this
-  // cannot drift back to the absolute.
+  // ⚠️ SCOPE. Do NOT paraphrase this — READ THE PREDICATE. Three successive
+  // hand-written glosses of it were each refuted by measurement ("all five doors
+  // are excluded"; "an anonymous caller, or any paginated request"), so the rule
+  // here is to name the predicate and enumerate it exactly, never to describe it.
+  //
+  // A door-walking request is excluded from this counter exactly when
+  // `skipOwnExcluded` (declared below, next to the own-content pass) is TRUE,
+  // because that is what decides whether a SECOND query goes out. Its three
+  // disjuncts, verbatim from that line:
+  //   1. `!input.currentUserId`                                  — anonymous caller
+  //   2. `bitdexCursor`                — a `bdx:` cursor, i.e. a BitDex-paginated
+  //                                      request (NOT any paginated request)
+  //   3. `input.userId && input.userId !== input.currentUserId`
+  //                                    — signed-in, viewing another user's profile
+  // If none holds, the own-content pass is issued regardless of what the feed
+  // query did, a call goes out, and the request IS counted.
+  //
+  // Measured, driving the real path (each row is a request that walks a door):
+  //   signed-in, other user's profile        → 0 calls, nothing recorded
+  //   signed-in, `bdx:` cursor               → 0 calls, nothing recorded
+  //   signed-in, NON-`bdx:` cursor           → 1 call,  `fallback_empty` recorded
+  //   signed-in, first page                  → 1 call,  `fallback_empty` recorded
+  // The third row is why "any paginated request" was wrong, and it is the NORMAL
+  // shape: a request that walks a door falls back to Meili, so its next page
+  // carries a MEILI cursor, which the `bdx:` decode above does not accept.
+  //
+  // Counting those requests is correct under the stated denominator — a call did
+  // go out — and is deliberately left as is. Both shapes are pinned in
+  // bitdex-feed-source.test.ts.
   //
   // The two observations that mean "a call was made": the client reported a
   // FAILURE, or it handed back a NON-NULL result (it returns null on every
@@ -3257,12 +3274,16 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   //     misconfigured deployment counts as a call and records `fallback_error`.
   //     Deliberate: a missing endpoint is a real degradation and that is exactly
   //     when the tripwire should fire, not go quiet.
-  //   • A completed call whose body decodes to a FALSY value (`0`, `""`, `null`
-  //     via `res.json()`, which is returned unfiltered) is non-null-by-contract
-  //     but falsy here, so neither observation fires and the call is NOT counted.
-  //     That is an UNDER-count, the worse direction, since the served ratio
-  //     silently improves. Not reachable against a backend that returns an
-  //     object; noted because the converse was previously stated as absolute.
+  //   • A completed call whose body decodes to a value that is FALSY BUT SURVIVES
+  //     A PROPERTY READ (`0`, `""`, `false`, `NaN`) is returned unfiltered by the
+  //     client, so it is falsy here and neither observation fires — the call is
+  //     NOT counted. An UNDER-count, the worse direction, since the served ratio
+  //     silently improves. Measured. `null` is NOT in that set: the client
+  //     dereferences `.total_matched` on the parsed body, which THROWS on null,
+  //     so a null body is classified `parse` and IS counted — an earlier revision
+  //     of this comment listed it here and was wrong. Whether a falsy body throws
+  //     on that dereference is the whole distinction. Not reachable against a
+  //     backend that returns an object.
   //
   // Why it matters: recording a request that never contacted BitDex inflates the
   // FALLBACK side of the exact ratio a roll-forward/rollback decision is read
@@ -3406,8 +3427,10 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
       : getImagesFromBitdexPreFilter(input, true, lastCursor, noteQueryFailure));
     // Non-null ⇒ the client completed a call (it returns null on every failure,
     // and the wrapper returns null without calling it at all on its early-return
-    // paths). A failed call is counted by `noteQueryFailure` instead, so exactly
-    // one of the two fires per call.
+    // paths). A failed call is counted by `noteQueryFailure` instead, so AT MOST
+    // one of the two fires per call — not exactly one. For a body that decodes
+    // falsy-but-non-throwing, NEITHER fires; see the exhaustiveness note at
+    // `bitdexCallsObserved`, which is the single place that scope is stated.
     if (result) bitdexCallsObserved++;
     if (skipBudgetStartedAt === 0) skipBudgetStartedAt = Date.now();
     firstPage = false;

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3221,31 +3221,39 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   //
   // Read AFTER `await ownExcludedPromise` below, which is where both passes have
   // settled and which already precedes the `!data.length` guard.
+  // 🔴 DID THIS REQUEST ACTUALLY REACH BITDEX AT ALL? It can be ZERO, and the
+  // empty-result guard below cannot tell — an empty page and a page nobody asked
+  // for are the same `data.length === 0`.
+  //
+  // COUNTED FROM EVIDENCE THAT A CALL HAPPENED, NOT FROM LOOP ENTRY. An earlier
+  // revision incremented just before calling `getImagesFromBitdexPreFilter`,
+  // which was wrong in a way that looked right: that function has FIVE early
+  // `return null` paths that never reach `queryBitdex` — hidden-with-no-hidden-
+  // images, an unresolvable username, followed-with-zero-follows, and
+  // newCreators-with-none. A brand-new account opening the Following feed walks
+  // one of them, which is a great deal more likely than the `limit: 0` case that
+  // prompted the guard. Counting on entry re-created the same overcount one door
+  // down.
+  //
+  // The two observations that together mean "a call was made", and nothing else
+  // does: the client reported a FAILURE (it only does so from inside a call), or
+  // it handed back a NON-NULL result (it returns null on every failure, so
+  // non-null implies a completed call). Exactly one of the two fires per call, so
+  // this cannot double-count, and neither fires on an early return.
+  //
+  // Why it matters: recording a request that never contacted BitDex inflates the
+  // FALLBACK side of the exact ratio a roll-forward/rollback decision is read
+  // from, and contradicts this metric's own help string. (Reachability is
+  // measured; organic frequency is NOT.)
+  let bitdexCallsObserved = 0;
+
   let anyQueryFailed = false;
   const noteQueryFailure = () => {
     anyQueryFailed = true;
+    // A failure report is proof a call was made — it is emitted from inside the
+    // client, past every early return above it.
+    bitdexCallsObserved++;
   };
-
-  // 🔴 HOW MANY QUERIES THIS REQUEST ACTUALLY ISSUED, because it can be ZERO and
-  // the empty-result guard below cannot tell.
-  //
-  // `limit: 0` is externally reachable — the feed schema accepts it
-  // (`z.number().min(0)`) — and it collapses the pass loop's
-  // `accumulated.length < limit` condition on the FIRST evaluation, so the loop
-  // body never runs. With `skipOwnExcluded` also true (an anonymous caller),
-  // BitDex is never contacted at all, and yet `data` is empty, so the
-  // `!data.length` guard fires and would record a `fallback_empty` for a request
-  // that asked BitDex nothing.
-  //
-  // That is not a rounding error in the wrong direction: it inflates the
-  // FALLBACK side of the exact ratio a roll-forward/rollback decision is made
-  // on, and it would silently contradict this metric's own help string, which
-  // states the denominator as "requests that issued at least one query". A
-  // metric whose stated meaning and behaviour disagree is worse than no metric,
-  // so the behaviour is fixed here rather than the sentence being softened to
-  // match. (Reachability is measured; organic frequency is NOT — this is a
-  // correctness fix, not a claim about how often it happens.)
-  let queriesIssued = 0;
 
   const limit = input.limit ?? 100;
   // Opt-in to one's own not-yet-published content. Read once so the main
@@ -3352,7 +3360,6 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
       true,
       noteQueryFailure
     );
-    queriesIssued++;
   }
 
   // Main loop: fetch pages, post-filter, accumulate until we have enough.
@@ -3373,10 +3380,14 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   const stats: PostFilterStats = { publicationHolds: 0, sortAtOnlyIds: new Set<number>() };
 
   while (pass < MAX_PASSES && accumulated.length < limit) {
-    queriesIssued++;
     const result = await (firstPage
       ? getImagesFromBitdexPreFilter(input, true, bitdexCursor, noteQueryFailure)
       : getImagesFromBitdexPreFilter(input, true, lastCursor, noteQueryFailure));
+    // Non-null ⇒ the client completed a call (it returns null on every failure,
+    // and the wrapper returns null without calling it at all on its early-return
+    // paths). A failed call is counted by `noteQueryFailure` instead, so exactly
+    // one of the two fires per call.
+    if (result) bitdexCallsObserved++;
     if (skipBudgetStartedAt === 0) skipBudgetStartedAt = Date.now();
     firstPage = false;
 
@@ -3453,6 +3464,10 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   // Since the second pass is unscoped (for cacheability), we apply content-scoping
   // filters here to match the current view.
   const ownExcluded = await ownExcludedPromise;
+  // Same rule as the main pass. `ownExcludedPromise` is null when the pass was
+  // skipped entirely, and `await null` is null, so this counts only a pass that
+  // both ran and completed.
+  if (ownExcluded) bitdexCallsObserved++;
   if (ownExcluded?.documents?.length) {
     const mainIds = new Set(data.map((d) => d.id));
     let ownDocs = ownExcluded.documents
@@ -3599,11 +3614,11 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
     // knows what was in the index. Before this line the two were the same
     // observable, which is why a BitDex outage looked exactly like a quiet index.
     //
-    // Gated on `queriesIssued` for the reason given at its declaration: a
+    // Gated on `bitdexCallsObserved` for the reason given at its declaration: a
     // request that never contacted BitDex is neither of these things, and
     // recording it would make this counter's denominator disagree with its own
     // help string.
-    if (queriesIssued > 0)
+    if (bitdexCallsObserved > 0)
       recordBitdexPrimaryResult(anyQueryFailed ? 'fallback_error' : 'fallback_empty', serveMode);
 
     // ⚠️ A cursored request does not fall back cleanly — the Meili path parses

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -239,6 +239,10 @@ import {
   recordBitdexError,
   recordSortAtOnlyHolds,
 } from '~/server/bitdex/compare';
+import {
+  recordBitdexPrimaryResult,
+  type BitdexQueryFailureReason,
+} from '~/server/metrics/bitdex-feed-serve.metrics';
 
 // --- BitDex native filter helpers ---
 const _int = (v: number): Value => ({ Integer: v });
@@ -3126,6 +3130,13 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   // queue and is shown a different population, with nothing signalling that the
   // wrong question was answered. Declining is the honest containment; answering
   // properly means changing what the query asks for, which is not this PR.
+  // 🔴 Deliberately BEFORE any outcome is recorded, and deliberately not
+  // recorded itself. This declines the request without issuing a single BitDex
+  // query, so it is not a served page, not an empty index and not a failure — it
+  // is a policy choice. Counting it as a fallback would make the served ratio
+  // sag every time a moderator opened one of these queues. The denominator of
+  // `bitdex_primary_result_total` is therefore "requests that engaged BitDex",
+  // which the metric's help string states.
   if (input.isModerator && (input.scheduled || input.notPublished)) return null;
 
   // Resolve `username` → `userId` BEFORE anything reads the creator scope.
@@ -3191,6 +3202,29 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
     // every username-addressed request. Pinned by a test.
     input = { ...input, userId: targetUser.id };
   }
+
+  // Which cohort this run belongs to. Read once so the three emit points below
+  // cannot disagree, and computed here rather than at each call so a later
+  // caller-mode cannot be added to one of them and missed by the others.
+  const serveMode = opts.serving ? ('primary' as const) : ('shadow' as const);
+
+  // 🔴 THE PER-REQUEST PREDICATE: did ANY BitDex call in this request fail?
+  //
+  // Not "did the last call fail" and not "did the main pass fail". A request
+  // issues 1-4 calls — the paginating main pass plus, for a signed-in caller on
+  // the first page, an own-content pass that runs in PARALLEL. If the
+  // own-content pass failed while the main pass legitimately came back empty,
+  // the page is not known to be empty: the documents that would have filled it
+  // are exactly the ones the failed call was fetching. Collapsing that into
+  // `fallback_empty` would report the one case this instrument exists to find as
+  // the healthy one.
+  //
+  // Read AFTER `await ownExcludedPromise` below, which is where both passes have
+  // settled and which already precedes the `!data.length` guard.
+  let anyQueryFailed = false;
+  const noteQueryFailure = () => {
+    anyQueryFailed = true;
+  };
 
   const limit = input.limit ?? 100;
   // Opt-in to one's own not-yet-published content. Read once so the main
@@ -3294,7 +3328,8 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
       500,
       undefined,
       undefined,
-      true
+      true,
+      noteQueryFailure
     );
   }
 
@@ -3317,8 +3352,8 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
 
   while (pass < MAX_PASSES && accumulated.length < limit) {
     const result = await (firstPage
-      ? getImagesFromBitdexPreFilter(input, true, bitdexCursor)
-      : getImagesFromBitdexPreFilter(input, true, lastCursor));
+      ? getImagesFromBitdexPreFilter(input, true, bitdexCursor, noteQueryFailure)
+      : getImagesFromBitdexPreFilter(input, true, lastCursor, noteQueryFailure));
     if (skipBudgetStartedAt === 0) skipBudgetStartedAt = Date.now();
     firstPage = false;
 
@@ -3533,6 +3568,15 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
     // cost the user nothing.
     recordSortAtOnlyHolds(stats.sortAtOnlyIds.size, 'fallback');
 
+    // 🔴 THE SPLIT THIS PR EXISTS FOR. Both branches return the same `null` and
+    // land the user on the same Meilisearch page; what differs is whether the
+    // emptiness is TRUSTWORTHY. `fallback_empty` says every call succeeded and
+    // the index had nothing — routine, and the bulk of today's fallback volume.
+    // `fallback_error` says at least one call in this request failed, so nobody
+    // knows what was in the index. Before this line the two were the same
+    // observable, which is why a BitDex outage looked exactly like a quiet index.
+    recordBitdexPrimaryResult(anyQueryFailed ? 'fallback_error' : 'fallback_empty', serveMode);
+
     // ⚠️ A cursored request does not fall back cleanly — the Meili path parses
     // cursors as `offset|entryTimestamp` (:2594) and a `bdx:{…}` cursor fails
     // both `isNumber` guards, so offset degrades to 0. An earlier revision of
@@ -3548,6 +3592,12 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   data = data.slice(0, limit);
 
   recordSortAtOnlyHolds(stats.sortAtOnlyIds.size, opts.serving ? 'serving' : 'shadow');
+
+  // Recorded on the RESULT, not on the flag: a request can serve a full page
+  // while one of its calls failed (a failed own-content pass alongside a healthy
+  // main pass), and that is a served page. `anyQueryFailed` only decides which
+  // KIND of empty an empty result is; it never demotes a page that exists.
+  recordBitdexPrimaryResult('served', serveMode);
 
   const nextCursor = lastCursor ? `bdx:${JSON.stringify(lastCursor)}` : undefined;
   console.log(
@@ -3608,6 +3658,12 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
     } catch (err) {
       console.error('[BitDex] PRIMARY error, falling through to Meili:', err);
       recordBitdexError(err);
+      // Distinct from `fallback_error`, and the distinction is the point: the
+      // client never throws, so nothing that reaches here came from BitDex being
+      // unhealthy. This is the application's own map/merge/sort code throwing —
+      // a different team's page. It reads a flat zero today, which is what makes
+      // it a usable tripwire rather than a redundant series.
+      recordBitdexPrimaryResult('fallback_exception', 'primary');
     }
     // Fall through to Meili if BitDex fails
   }
@@ -3650,7 +3706,13 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
             });
           }
         })
-        .catch((err) => recordBitdexError(err))
+        .catch((err) => {
+          recordBitdexError(err);
+          // Same meaning as the primary arm above, in the cohort where nothing
+          // reaches a user. Recorded so an app-side throw is visible BEFORE the
+          // cohort is flipped, rather than only once it is serving.
+          recordBitdexPrimaryResult('fallback_exception', 'shadow');
+        })
     );
   }
 
@@ -4547,7 +4609,12 @@ export function mapBitdexDoc(doc: Record<string, unknown>) {
 export async function getImagesFromBitdexPreFilter(
   input: ImageSearchInput,
   includeDocs?: boolean | string[],
-  cursor?: any
+  cursor?: any,
+  // Threaded through to the client so the per-request outcome in
+  // fetchBitdexPrimary can tell "this page is empty" from "we do not know
+  // whether this page is empty" (#3930). Optional: the internal comparison
+  // endpoint calls this with `input` alone and is unaffected.
+  onFailure?: (reason: BitdexQueryFailureReason) => void
 ) {
   let { postIds = [] } = input;
   const {
@@ -4780,7 +4847,8 @@ export async function getImagesFromBitdexPreFilter(
     limit,
     cursor,
     cursor ? undefined : offset,
-    includeDocs
+    includeDocs,
+    onFailure
   );
   return result;
 }

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3226,6 +3226,27 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
     anyQueryFailed = true;
   };
 
+  // 🔴 HOW MANY QUERIES THIS REQUEST ACTUALLY ISSUED, because it can be ZERO and
+  // the empty-result guard below cannot tell.
+  //
+  // `limit: 0` is externally reachable — the feed schema accepts it
+  // (`z.number().min(0)`) — and it collapses the pass loop's
+  // `accumulated.length < limit` condition on the FIRST evaluation, so the loop
+  // body never runs. With `skipOwnExcluded` also true (an anonymous caller),
+  // BitDex is never contacted at all, and yet `data` is empty, so the
+  // `!data.length` guard fires and would record a `fallback_empty` for a request
+  // that asked BitDex nothing.
+  //
+  // That is not a rounding error in the wrong direction: it inflates the
+  // FALLBACK side of the exact ratio a roll-forward/rollback decision is made
+  // on, and it would silently contradict this metric's own help string, which
+  // states the denominator as "requests that issued at least one query". A
+  // metric whose stated meaning and behaviour disagree is worse than no metric,
+  // so the behaviour is fixed here rather than the sentence being softened to
+  // match. (Reachability is measured; organic frequency is NOT — this is a
+  // correctness fix, not a claim about how often it happens.)
+  let queriesIssued = 0;
+
   const limit = input.limit ?? 100;
   // Opt-in to one's own not-yet-published content. Read once so the main
   // post-filter and the own-excluded merge below cannot disagree about it.
@@ -3331,6 +3352,7 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
       true,
       noteQueryFailure
     );
+    queriesIssued++;
   }
 
   // Main loop: fetch pages, post-filter, accumulate until we have enough.
@@ -3351,6 +3373,7 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   const stats: PostFilterStats = { publicationHolds: 0, sortAtOnlyIds: new Set<number>() };
 
   while (pass < MAX_PASSES && accumulated.length < limit) {
+    queriesIssued++;
     const result = await (firstPage
       ? getImagesFromBitdexPreFilter(input, true, bitdexCursor, noteQueryFailure)
       : getImagesFromBitdexPreFilter(input, true, lastCursor, noteQueryFailure));
@@ -3575,7 +3598,13 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
     // `fallback_error` says at least one call in this request failed, so nobody
     // knows what was in the index. Before this line the two were the same
     // observable, which is why a BitDex outage looked exactly like a quiet index.
-    recordBitdexPrimaryResult(anyQueryFailed ? 'fallback_error' : 'fallback_empty', serveMode);
+    //
+    // Gated on `queriesIssued` for the reason given at its declaration: a
+    // request that never contacted BitDex is neither of these things, and
+    // recording it would make this counter's denominator disagree with its own
+    // help string.
+    if (queriesIssued > 0)
+      recordBitdexPrimaryResult(anyQueryFailed ? 'fallback_error' : 'fallback_empty', serveMode);
 
     // ⚠️ A cursored request does not fall back cleanly — the Meili path parses
     // cursors as `offset|entryTimestamp` (:2594) and a `bdx:{…}` cursor fails
@@ -3597,6 +3626,19 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   // while one of its calls failed (a failed own-content pass alongside a healthy
   // main pass), and that is a served page. `anyQueryFailed` only decides which
   // KIND of empty an empty result is; it never demotes a page that exists.
+  //
+  // 🔴 THE CONSEQUENCE, STATED SO NOBODY HAS TO REDERIVE IT FROM AN ALERT THAT
+  // LOOKS FINE. If the own-content pass fails PERSISTENTLY while the main pass
+  // stays healthy, users silently lose their own private / blocked / unpublished
+  // content from their feed — a real, user-visible degradation — and THIS
+  // counter reads 100% `served` throughout, because a page was in fact served.
+  // That is a deliberate choice (a served page is a served page; demoting it
+  // would make `served` mean "served and perfect", which no threshold could then
+  // interpret), but it means `bitdex_primary_result_total` ALONE cannot see this
+  // failure. `bitdex_query_failures_total` is the only counter that moves.
+  //
+  // ⇒ Any dashboard or alert built on this family MUST watch BOTH counters. One
+  // keyed on the served ratio alone will stay green straight through this.
   recordBitdexPrimaryResult('served', serveMode);
 
   const nextCursor = lastCursor ? `bdx:${JSON.stringify(lastCursor)}` : undefined;

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3228,30 +3228,51 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   // COUNTED FROM EVIDENCE THAT A CALL HAPPENED, NOT FROM LOOP ENTRY. An earlier
   // revision incremented just before calling `getImagesFromBitdexPreFilter`,
   // which was wrong in a way that looked right: that function has FIVE early
-  // `return null` paths that never reach `queryBitdex` — hidden-with-no-hidden-
-  // images, an unresolvable username, followed-with-zero-follows, and
-  // newCreators-with-none. A brand-new account opening the Following feed walks
-  // one of them, which is a great deal more likely than the `limit: 0` case that
-  // prompted the guard. Counting on entry re-created the same overcount one door
-  // down.
+  // `return null` paths that never reach `queryBitdex` — `hidden` with no
+  // signed-in user, `hidden` with no hidden images, an unresolvable username,
+  // followed-with-zero-follows, and newCreators-with-none. Counting on entry
+  // re-created the same overcount one door down.
   //
-  // The two observations that together mean "a call was made", and nothing else
-  // does: the client reported a FAILURE (it only does so from inside a call), or
-  // it handed back a NON-NULL result (it returns null on every failure, so
-  // non-null implies a completed call). Exactly one of the two fires per call, so
-  // this cannot double-count, and neither fires on an early return.
+  // ⚠️ SCOPE, because an earlier revision of this comment claimed all five are
+  // excluded and MEASUREMENT REFUTED IT. The exclusion holds only when the feed
+  // query is the request's ONLY query — an anonymous caller, or any paginated
+  // request — because `skipOwnExcluded` is true there. For a SIGNED-IN caller on
+  // the first page the own-content pass is issued regardless of what the feed
+  // query does, so a call goes out and the request IS recorded. Measured on
+  // signed-in + `followed` with zero follows: one call, `fallback_empty`
+  // recorded. Worse for the old claim, `currentUserId` is a PRECONDITION of two
+  // of the five doors, so for those the exclusion can never apply at all.
+  // Counting that request is defensible — a call did go out — and is deliberately
+  // left as is. Both cases are pinned in bitdex-feed-source.test.ts so this
+  // cannot drift back to the absolute.
+  //
+  // The two observations that mean "a call was made": the client reported a
+  // FAILURE, or it handed back a NON-NULL result (it returns null on every
+  // failure). At most one fires per call, so this cannot double-count.
+  //
+  // ⚠️ Neither is exhaustive, in opposite directions, and both are accepted:
+  //   • `unconfigured` fires the failure callback WITHOUT a request leaving the
+  //     process (the client returns before any fetch — pinned by the
+  //     `not.toHaveBeenCalled()` assertion in the client suite). So a
+  //     misconfigured deployment counts as a call and records `fallback_error`.
+  //     Deliberate: a missing endpoint is a real degradation and that is exactly
+  //     when the tripwire should fire, not go quiet.
+  //   • A completed call whose body decodes to a FALSY value (`0`, `""`, `null`
+  //     via `res.json()`, which is returned unfiltered) is non-null-by-contract
+  //     but falsy here, so neither observation fires and the call is NOT counted.
+  //     That is an UNDER-count, the worse direction, since the served ratio
+  //     silently improves. Not reachable against a backend that returns an
+  //     object; noted because the converse was previously stated as absolute.
   //
   // Why it matters: recording a request that never contacted BitDex inflates the
   // FALLBACK side of the exact ratio a roll-forward/rollback decision is read
-  // from, and contradicts this metric's own help string. (Reachability is
-  // measured; organic frequency is NOT.)
+  // from. (Reachability is measured; organic frequency is NOT.)
   let bitdexCallsObserved = 0;
 
   let anyQueryFailed = false;
   const noteQueryFailure = () => {
     anyQueryFailed = true;
-    // A failure report is proof a call was made — it is emitted from inside the
-    // client, past every early return above it.
+    // Evidence of a call, with the `unconfigured` exception noted above.
     bitdexCallsObserved++;
   };
 


### PR DESCRIPTION
Closes #3930.

> **Revision note (`f71eb02` → `8becf104` → `9b7b4d27` → `7bed730d` → `e2043c60`).**
> Four adversarial audit rounds. The code has been settled since `7bed730d`; the
> last round was docs-only. **Three successive hand-written glosses of one
> three-disjunct predicate were each refuted by measurement**, so the prose now
> names and enumerates that predicate rather than describing it. Every claim that
> turned out to be wrong is listed at the bottom — including two this description
> asserted.

## The problem

Nothing distinguishes a feed page served by BitDex from one that fell through to
Meilisearch. `queryBitdex` returns `null` on **every** failure — missing config, a
non-2xx, a thrown fetch, an abort at the deadline, an unparseable body — and also
on a perfectly successful query over an index that genuinely had no match. Eight
mechanisms, one observable. A backend outage and a quiet index look identical, so
neither is alertable and neither is measurable.

## What this adds

A new `src/server/metrics/bitdex-feed-serve.metrics.ts`, following the newer
metrics-module pattern (`generation-model-substitution.metrics.ts`): idempotent
get-or-create registration, `seedAllSeries()`, runtime label narrowing, a
documented cardinality budget, and every `inc()` inside `try/catch` so a registry
collision can never turn an observability change into a failed feed request.

| metric | labels | series |
|---|---|---|
| `bitdex_primary_result_total` | `outcome` ∈ `served`, `fallback_empty`, `fallback_error`, `fallback_exception` × `mode` ∈ `primary`, `shadow` | 8 |
| `bitdex_query_failures_total` | `reason` ∈ `unconfigured`, `http_4xx`, `http_5xx`, `timeout`, `network`, `parse` | 6 |

14 series total, both label sets closed unions narrowed at runtime, so the bound
rests on code rather than on erased types. Explicitly disqualified as labels:
user id, cursor, filter shape, sort, model/post ids, raw status.

`fallback_exception` earns its own value rather than folding into
`fallback_error` because the two demand opposite responses — one is the backend,
the other is this application's own mapping/merge/sort code. `mode` is free
signal: the same path runs in shadow, so the exposure is measurable *before* a
cohort is flipped rather than only after.

**Naming note, deliberate and documented in the `help` strings:** `bitdex_*` is
also the metric namespace of the BitDex service itself. These two are
**app-emitted** — produced by the web application, on the request path,
describing what the *application* did with the backend's answer. Different scrape
target; not comparable with the service's own families.

## The client-boundary change

`queryBitdex` gains an optional `onFailure?: (reason) => void` **last** parameter,
classifying at the one place where the status code and the error object are still
in scope. Strictly additive; it reverts by deleting one argument.

**Two counts are true here and conflating them caused confusion, so both are
stated in the docstring:** `queryBitdex` has exactly **2 direct call sites**, both
in `image.service.ts`. Its `null` **return contract** is interpreted by **3
consumers**, because `getImagesFromBitdexPreFilter` is itself called from
`~/pages/api/internal/bitdex-compare.ts`. A discriminated-union return was
rejected: cleaner semantics, but it rewrites all three plus every mock in the same
commit that changes the behaviour.

The per-request predicate is **"any BitDex call in this request failed"**, read
after the parallel own-content pass settles. If that pass failed while the main
pass came back empty, you do not know whether the page was empty — the documents
that would have filled it are exactly the ones the failed call was fetching.

**Requests that issue zero queries are excluded, counted from evidence a call
actually happened.** A request can reach the empty-result guard without ever
contacting BitDex, and then a `fallback_empty` is recorded for a request that
asked BitDex nothing — biasing the *fallback* side of the exact ratio a rollout
decision is read from.

`limit: 0` is externally reachable (the feed schema accepts `min(0)`) and
collapses the fetch loop before its first iteration. `getImagesFromBitdexPreFilter`
also has **five early `return null` paths** that never reach the client: `hidden`
with no signed-in user, `hidden` with no hidden images, an unresolvable username,
followed-with-zero-follows, newCreators-with-none.

Counting on *loop entry* passed the `limit: 0` test and still over-counted those.
The gate now counts the two observations that mean a call happened: the client
**reported a failure**, or **returned non-null** (it returns null on every
failure). At most one fires per call, so it cannot double-count.

🔴 **Scope — read the predicate, not this paragraph.** Three glosses of it have
now been refuted by measurement, so here is the rule instead: a door-walking
request is excluded exactly when **`skipOwnExcluded`** (in `fetchBitdexPrimary`,
declared beside the own-content pass) is true, because that is what decides
whether a *second* query goes out. Its three disjuncts:

1. anonymous caller;
2. a **`bdx:` cursor** — a BitDex-paginated request, which is **not** the same as
   any paginated request;
3. signed-in caller viewing **another user's** profile.

Measured, driving the real path — each row walks one of the five doors:

| request | calls | recorded |
|---|---|---|
| signed-in, other user's profile | 0 | nothing |
| signed-in, `bdx:` cursor | 0 | nothing |
| signed-in, **non-`bdx:` cursor** | 1 | `fallback_empty` |
| signed-in, first page | 1 | `fallback_empty` |

Row 3 is why "any paginated request" was wrong, and **it is the normal shape**: a
request that walks a door falls back to Meilisearch, so its next page carries a
*Meilisearch* cursor, which the `bdx:` decode does not accept. Row 1 is why
"signed-in first page ⇒ counted" was also wrong.

Counting rows 3–4 is correct under the stated denominator — a call did go out —
and is deliberately **left as is**. The defect was the claim, not the code. Both
shapes are pinned as tests.

⚠️ **Deliberate exceptions to the denominator:**

- **`unconfigured`** fires the failure callback *without a request leaving the
  process* (asserted by `not.toHaveBeenCalled()` in the client suite), so a
  misconfigured deployment records `fallback_error`. The tripwire working as
  intended: a missing endpoint is a real degradation and should not read as quiet.
  **In the `help` string.**
- **A completed call whose body decodes to a falsy value that survives a property
  read** (`0`, `""`, `false`, `NaN`) is *not* counted — an **under-count**, the
  worse direction, since the ratio silently improves. **`null` is not in that
  set:** the client dereferences `.total_matched`, which throws on null, so a null
  body classifies `parse` and *is* counted. Measured; an earlier revision of this
  description listed `null` here and was wrong. Not reachable against a backend
  returning an object, so this one is **code-comment only, not in the `help`
  string**.

⚠️ **Scope, stated precisely because it is now an invariant:** this covers
`served`, `fallback_empty` and `fallback_error` — the three emitted from inside
`fetchBitdexPrimary`, where the evidence lives. **`fallback_exception` is
deliberately not gated.** It means "the application threw on the BitDex path", and
whether a query had been issued first is irrelevant to that meaning; suppressing
it would blind the tripwire in the case where the code broke earliest. Its
denominator differs from its siblings on purpose.

The moderator queues declined before any query, and the internal comparison
endpoint (which passes no callback), are outside the denominator for the same
reason.

## ⚠️ This counter alone cannot see every degradation

If the own-content pass fails **persistently** while the main pass stays healthy,
users silently lose their own private/blocked/unpublished content from their feed
— a real, user-visible degradation — and `bitdex_primary_result_total` reads
**100% `served`** throughout, because a page genuinely was served. Only
`bitdex_query_failures_total` moves.

That is a deliberate choice: demoting such a request would make `served` mean
"served and perfect", which no threshold can interpret. **The consequence is that
any dashboard or alert over this family MUST read both counters.** One keyed on
the served ratio alone will stay green straight through this failure. Stated in
the module header and next to the emit, not only here.

## Also bundled: an abort-timer leak

The only `clearTimeout` sat after the fetch resolved, which a thrown fetch skips
entirely — leaving a 30s timer holding the `AbortController` alive on every
failed call, at feed request rate. The eager clear is **kept**, so the abort
deadline still covers the fetch only: behaviour unchanged, leak closed.

## Seeding + the endpoint call

Both halves, because neither works alone. Without the module-scope call from
`src/pages/api/metrics.ts`, `…{outcome="fallback_error"}` reads `no data` until
the first failure — and that series' healthy value **is** zero, so an absent
series and a real zero must be distinguishable. The older `bitdex_shadow_*`
counters have neither half and return `no data` today despite having history.

## Positive control — measured, and honest about what kind

**Mutation classes actually run:** deletion, label swap, **stale re-binding at a
seam**, **operator swap in a guard**, and **boundary shift**. The first two were
all the original round had, which is why the last three found **5 survivors**
under audit. All five now die; each was applied to a clean tree, run, reverted.

| mutation | class | result |
|---|---|---|
| delete the `served` emit | deletion | 2 red. **Both are the counter's assertion** — the preceding `expect(result.source).toBe('bitdex')` passed and all 3 pre-existing `source` tests stayed green |
| delete the fallback emit | deletion | 1 red |
| swap `fallback_empty` ↔ `fallback_error` | label swap | 2 red, both directions |
| drop the callback on the **main** pass | seam | 1 red |
| drop the callback on the **own-content** pass | seam | *r1 survivor* → 1 red: `expected [ 'fallback_empty\|primary' ] to deeply equal [ 'fallback_error\|primary' ]` |
| remove the zero-call gate | guard removal | 2 red (`limit: 0` **and** the early-return case) |
| **count on LOOP ENTRY instead of evidence** | stale re-binding | *r2 finding* → 1 red: `expected [ 'fallback_empty\|primary' ] to deeply equal []` — and note it leaves the `limit: 0` case **green**, which is exactly how the first fix passed while still over-counting five doors |
| delete both label-narrowing guards | deletion | *r1 survivor* → 5 red |
| `\|\|` → `&&` in the outcome/mode guard | operator swap | *r1 survivor* → 4 red |
| **relabel a rejected value to `served`** | relabel | *r2 survivor* → 1 red: `expected [ 'served\|primary\|' ] to deeply equal []` |
| **delete the `inc` in `recordBitdexPrimaryResult`** | deletion | *r2 finding* → 1 red: `expected +0 to be 1` (the positive control was previously **inert** — seeding pre-creates all 8 series, so asserting existence passed with the emit gone) |
| `>= 500` → `> 500` | boundary shift | *r1 survivor* → 1 red |
| **revert duck-typing to `instanceof Error`** | type-narrowing | *r2 finding* → 1 red: `expected [ 'network' ] to deeply equal [ 'timeout' ]` |
| **delete `if (ownExcluded) bitdexCallsObserved++`** | deletion | *r3 finding* → 1 red: `expected [] to deeply equal [ 'fallback_empty\|primary' ]`. Previously the only observation site with **no** killing mutation |
| remove the endpoint seed call | deletion | 2 red |
| restore the pre-fix `clearTimeout` | deletion | 1 red — the leaked timer, counted |

**🔴 The round-2 relabel survivor is worth naming, because the trap is subtle and
general.** `Counter.get()` returns the **live** child objects and `inc` mutates
`value` **in place**, so a "before" handle mapped *after* the mutation reads
post-increment state and every comparison built on it is vacuously equal. The
case passed, named the right mutant, and could not see it. Snapshot eagerly.

**Why the own-content seam survived round 1, since the shape recurs:** every
metric-asserting case ran anonymously, so `skipOwnExcluded` was always true and
the parallel pass was **never issued in any test**. With one call in play, "any
call failed" and "the main call failed" are byte-identical — fixture collapse.

**Seam:** negative control that both counters are `undefined` before
`~/pages/api/metrics` is imported; then 8 and 6 series present at 0, counts
derived from the unions rather than hardcoded.

## What I could **not** verify

⚠️ **`fallback_error` cannot be forced in production.** Config *is* set, so
`unconfigured` is unreachable, and there is no safe lever to make a live BitDex
call fail on the highest-traffic feed path. Its production zero is therefore still
unconfirmed *in production* — it is confirmed in test, through the collector, in
both directions, and now via both the main and own-content passes. The honest
close is a non-production environment pointed at a closed port.

Also unverified: the live flag-variant distribution; behaviour under real scrape
cadence; and the **organic frequency** of any zero-call path (reachability is measured
for all six; prevalence is not measured for any of them, including the
Following-feed one I argue is the likeliest).

## Gates

- `pnpm typecheck` — **0 errors**; instrument previously validated by planting a type error in the new metrics module and watching it report `TS2322` naming that file.
- `tsc -p tsconfig.tests.json` — **823 at this branch vs 823 at `origin/main`**, sorted `file(line,col): error TSxxxx` key sets **identical**; **0** errors in any touched file. Baseline re-measured against `origin/main` for this revision.
- Full unit suite — **1186 files passed / 1 skipped; 18703 tests passed / 21 skipped**, rc=0, 0 timeout panics.
- ESLint on touched files — **0 new errors; 3 pre-existing** in `image.service.ts`, same rules at base with lines shifted.

## Corrections to earlier revisions of this description

Round 1:

1. ~~"ESLint on all touched files: 0 errors"~~ — **false.** `image.service.ts` carries 3, pre-existing; correct phrasing is "0 new; 3 pre-existing".
2. ~~"Unit suite: 276 files, 3870 passed"~~ — a **subset I selected**, described as the unit suite. Full figure above.
3. ~~"mutation-verified"~~ unqualified — the round-1 table was only deletion and label-swap mutants; three further classes then found 5 survivors.

Round 2:

4. ~~"Requests that issue zero queries are excluded … **enforced in code**"~~ — **true only for `limit: 0`** when written; the gate counted loop entry, so five early-return paths still over-counted. The counting was fixed in `9b7b4d27` — but see 7, because the *claim* attached to that fix was itself wrong.
5. The round-1 relabel test **could not observe its own mutant** (live prom-client objects, mapped post-mutation). It read as coverage while proving nothing.
6. The round-1 "positive control" was **inert** — seeding pre-creates all 8 series, so asserting existence passed with the emit deleted.

Round 3:

7. ~~"the query builder's early returns are **ALL** out … a brand-new account opening the Following feed, i.e. ordinary traffic"~~ — **refuted by measurement.** The Following-feed case I named as the headline motivation is one where a call *is* made and the request *is* recorded.
8. ~~"a failure report is proof a call was made"~~ — **false**; this repo's own suite pins the counter-example (`unconfigured` fires before any fetch).
9. The round-2 fix for the tautological assertion is **cosmetic only** — it adds no independent killing power, and is not cited as coverage anywhere.

Round 4:

10. ~~"an anonymous caller, or any paginated request"~~ — **refuted, and wrong in both directions.** A signed-in caller on another user's profile *is* excluded; a signed-in caller with a non-`bdx:` cursor is *not* — and that is the common shape, since falling back to Meilisearch is what produces the cursor. This was the **third** failed paraphrase of the same predicate, which is why the prose now enumerates it and points at the code.
11. ~~"a body decoding to `0`, `""`, `null` … neither observation fires"~~ — **wrong for `null`**, which throws on the `.total_matched` dereference and is counted as `parse`. Corrected and restated by mechanism rather than as a hand-kept list.
12. ~~"Two documented exceptions … both now in the `help` string"~~ — the falsy-body under-count was **never** in the help string, and there are three exceptions, not two. The count claim is dropped and each exception now says where it is documented.

## Follow-up — must land *after* this deploys

The consuming dashboard row and alert rules are a **separate infra-repo change**.
They must not land before this is deployed and the series are confirmed present,
or they are red-on-nothing. **They must read both counters** — see the degradation
note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



