### PR TITLE
fix(apps): tell the RECIPIENT an ownership offer is dead BEFORE they accept it

### DIFF
--- a/src/components/Apps/AppTransferOffers.tsx
+++ b/src/components/Apps/AppTransferOffers.tsx
@@ -1,4 +1,3 @@
-import type { IncomingTransferRow } from '~/components/Apps/AppTransferOffersView';
 import {
   AppTransferOffersView,
   invalidationsForTransferResponse,
@@ -62,7 +61,16 @@ export function AppTransferOffers() {
 
   return (
     <AppTransferOffersView
-      transfers={(transfersQuery.data ?? []) as IncomingTransferRow[]}
+      /**
+       * 🔴 NO CAST. There used to be an `as IncomingTransferRow[]` here, against a
+       * hand-written structural duplicate of the service's return type — and a cast to a
+       * wider type is LEGAL, so `tsc` could not see the server drifting from the View at
+       * the one hop where that drift is invisible at runtime too. #3935 fixed the same
+       * hole on the owner's page (F3). `IncomingTransferRow` is now derived from
+       * `IncomingTransferView`, so the tRPC output type is checked against it directly and
+       * a field the service stops sending fails HERE.
+       */
+      transfers={transfersQuery.data ?? []}
       isLoading={transfersQuery.isLoading}
       errorMessage={transfersQuery.error?.message ?? null}
       busyTransferId={busyTransferId}

--- a/src/components/Apps/AppTransferOffersView.browser.test.tsx
+++ b/src/components/Apps/AppTransferOffersView.browser.test.tsx
@@ -28,6 +28,12 @@ function offer(over: Partial<IncomingTransferRow> & { transferId: string }): Inc
     fromUserId: 10,
     expiresAt: new Date('2026-08-17T12:00:00Z'),
     createdAt: new Date('2026-08-10T12:00:00Z'),
+    // The default is the TRANSFERABLE offer, so every pre-existing arm below keeps
+    // describing the ordinary case. The blocked branch is driven from the PAGE, in
+    // `src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx` — deliberately not
+    // from a prop here, because a prop-driven arm is exactly what let #3935's owner-side
+    // defect sit green for months.
+    acceptBlockedReason: null,
     ...over,
   };
 }

--- a/src/components/Apps/AppTransferOffersView.tsx
+++ b/src/components/Apps/AppTransferOffersView.tsx
@@ -153,9 +153,31 @@ export function AppTransferOffersView({
          * recipient can neither accept nor understand. Unreachable while the service can
          * only send the constant or `null`, and reachable the moment a second reason is
          * added by someone who has no way to know the two branches differ. `blocked` is
-         * the single test; `!== null` is the one that matches the field's type.
+         * the single test.
+         *
+         * 🔴 LOOSE `!= null`, DELIBERATELY — IT FAILS OPEN ON AN ABSENT FIELD. The two
+         * checks are behaviourally identical for every value the TYPE permits (`string`
+         * or `null`) and differ on one the type does not: `undefined`. `!== null` would
+         * score a MISSING field as blocked, so an older API pool that does not send
+         * `acceptBlockedReason` yet would make this bundle refuse EVERY pending offer,
+         * with an empty explanation and Decline still live. That skew is structural here,
+         * not hypothetical: the bundle and the tRPC API are served by separate pools that
+         * roll independently, so new-client/old-server is a state every deploy passes
+         * through. And because the banner is otherwise unreachable (see the reachability
+         * note in `app-ownership-transfer.service.ts`), a mid-roll false refusal would be
+         * the ONLY way a real user ever sees it.
+         *
+         * Failing OPEN is the right direction: the server refuses an unacceptable
+         * transfer anyway — both gates are unchanged and authoritative — so the cost of
+         * a missed banner is one honest error toast, while the cost of a false banner is
+         * blocking a transfer that would have succeeded.
+         *
+         * This also matches how this file already treats the wire 118 lines up, where
+         * `expiresAt`/`createdAt` are widened because "a component that hard-required
+         * `Date` would be making a claim about the wire that this file cannot settle".
+         * The same is true of a field's presence.
          */
-        const blocked = transfer.acceptBlockedReason !== null;
+        const blocked = transfer.acceptBlockedReason != null;
         const blockedReason = transfer.acceptBlockedReason;
         return (
           <Paper
@@ -204,9 +226,20 @@ export function AppTransferOffersView({
                   the product", so this is gap-closure ahead of traffic.)
 
                   The message is the SERVER's own constant, verbatim, not a paraphrase: the
-                  recipient reads the same sentence the mutation would have returned. It
-                  states a constraint and instructs NOTHING, because there is no unlink
-                  path in the product for them OR the owner to pursue. */}
+                  recipient reads the same sentence the mutation would have returned, and it
+                  instructs nothing.
+
+                  🔴 THE STATED REASON FOR THAT — "there is no unlink path in the product" —
+                  IS REFUTED, and this comment used to repeat it. An owner CAN unlink today,
+                  by deleting the OAuth client: the relation is `onDelete: SetNull` and
+                  `oauth-client.router::delete` has no referencing-listing check. What is
+                  still true is the part that matters HERE: the RECIPIENT cannot do it — they
+                  own neither the listing nor the client — so a remedy addressed to them
+                  would still be a dead end, and the copy stays as it is. Whether the OWNER's
+                  copy should now name that route is a PRODUCT decision, deliberately not
+                  taken in this change; the constant's own rationale in
+                  `shared/constants/app-transfer.constants.ts` rests on the refuted premise
+                  and is flagged rather than edited here. */}
               {blocked ? (
                 <Alert
                   color="yellow"

--- a/src/components/Apps/AppTransferOffersView.tsx
+++ b/src/components/Apps/AppTransferOffersView.tsx
@@ -144,7 +144,18 @@ export function AppTransferOffersView({
          * re-run here and no `connectClientId` is in scope — the service computed this
          * from the SAME `refusesTransferForConnectClient` its two enforcement gates use,
          * so this surface cannot invent a stricter or looser rule of its own.
+         *
+         * 🔴 ONE PREDICATE, READ ONCE, USED BY BOTH BRANCHES. The banner below and the
+         * Accept button used to test this value differently — `blockedReason ? …` for the
+         * banner, `blockedReason != null` for the button — which agree on today's two
+         * possible values and disagree on a third: an EMPTY-STRING reason would have
+         * disabled Accept while rendering no explanation at all, leaving a card the
+         * recipient can neither accept nor understand. Unreachable while the service can
+         * only send the constant or `null`, and reachable the moment a second reason is
+         * added by someone who has no way to know the two branches differ. `blocked` is
+         * the single test; `!== null` is the one that matches the field's type.
          */
+        const blocked = transfer.acceptBlockedReason !== null;
         const blockedReason = transfer.acceptBlockedReason;
         return (
           <Paper
@@ -183,18 +194,20 @@ export function AppTransferOffersView({
               </Group>
 
               {/* 🔴 THE REFUSAL, BEFORE THE CLICK — the recipient half of #3935.
-                  `acceptTransfer` re-asserts the connect-client refusal IN-TRANSACTION
-                  precisely because a revision approve can link an OAuth client while an
-                  offer sits open, so this card can be live, valid and guaranteed to fail.
-                  Without this the recipient learned that only by pressing Accept and
-                  reading a toast — the same learn-it-by-doing-the-work shape the owner's
-                  tab already fixed, on the other side of the wire.
+                  `acceptTransfer` re-asserts the connect-client refusal IN-TRANSACTION, so
+                  a card here can be live, valid-looking and guaranteed to fail. Without
+                  this the recipient learned that only by pressing Accept and reading a
+                  toast — the same learn-it-by-doing-the-work shape the owner's tab already
+                  fixed, on the other side of the wire. (How reachable that state actually
+                  is today is answered honestly at the field's definition in
+                  `app-ownership-transfer.service.ts` — the short version is "not, through
+                  the product", so this is gap-closure ahead of traffic.)
 
                   The message is the SERVER's own constant, verbatim, not a paraphrase: the
                   recipient reads the same sentence the mutation would have returned. It
                   states a constraint and instructs NOTHING, because there is no unlink
                   path in the product for them OR the owner to pursue. */}
-              {blockedReason ? (
+              {blocked ? (
                 <Alert
                   color="yellow"
                   variant="light"
@@ -254,7 +267,7 @@ export function AppTransferOffersView({
                 <Button
                   size="xs"
                   color="red"
-                  disabled={busy || blockedReason != null}
+                  disabled={busy || blocked}
                   loading={busy}
                   data-testid={`apps-transfer-accept-${transfer.transferId}`}
                   onClick={() => onRespond?.(transfer.transferId, true)}

--- a/src/components/Apps/AppTransferOffersView.tsx
+++ b/src/components/Apps/AppTransferOffersView.tsx
@@ -2,6 +2,7 @@ import { Alert, Badge, Button, Group, List, Paper, Stack, Text, Title } from '@m
 import { IconAlertTriangle, IconArrowsExchange } from '@tabler/icons-react';
 import type { ReactNode } from 'react';
 
+import type { IncomingTransferView } from '~/server/services/blocks/app-ownership-transfer.service';
 import type { ListingKind } from '~/shared/constants/app-capabilities.constants';
 import { capabilitiesForKind } from '~/shared/constants/app-capabilities.constants';
 
@@ -24,15 +25,27 @@ import { capabilitiesForKind } from '~/shared/constants/app-capabilities.constan
  * directly renderable in a component test.
  */
 
-export type IncomingTransferRow = {
-  transferId: string;
-  appListingId: string;
-  slug: string;
-  name: string;
-  kind: ListingKind;
-  appBlockId: string | null;
-  iconUrl: string | null;
-  fromUserId: number;
+/**
+ * 🔴 DERIVED FROM THE SERVICE'S OWN RETURN TYPE, not hand-written beside it.
+ *
+ * This used to be a structural duplicate of {@link IncomingTransferView}, and the
+ * container's `as IncomingTransferRow[]` cast made the duplication INVISIBLE to `tsc`: a
+ * cast to a wider type is legal, so a field the service stopped sending — or never started
+ * sending — compiled clean at exactly the hop where the defect lives. #3935 hit the same
+ * hole on `edit.tsx` and fixed it the same way; the container's cast is now GONE as well,
+ * so the tRPC output type is checked against this one directly.
+ *
+ * The two date fields are deliberately WIDENED rather than inherited. The service types
+ * them `Date`; what actually arrives depends on the tRPC transformer, and a component that
+ * hard-required `Date` would be making a claim about the wire that this file cannot settle.
+ * {@link formatTransferExpiry} accepts either, so the widening costs nothing and the other
+ * fields — including `acceptBlockedReason`, the point of this change — stay pinned to the
+ * server's shape.
+ *
+ * A type-only import is erased at build time, so nothing of the service's module graph
+ * reaches the client bundle.
+ */
+export type IncomingTransferRow = Omit<IncomingTransferView, 'expiresAt' | 'createdAt'> & {
   expiresAt: Date | string;
   createdAt: Date | string;
 };
@@ -126,6 +139,13 @@ export function AppTransferOffersView({
       <Title order={4}>Ownership transfers</Title>
       {transfers.map((transfer) => {
         const busy = busyTransferId === transfer.transferId;
+        /**
+         * 🔴 THE VERDICT ARRIVES ON THE PAYLOAD, ALREADY DECIDED. No predicate is
+         * re-run here and no `connectClientId` is in scope — the service computed this
+         * from the SAME `refusesTransferForConnectClient` its two enforcement gates use,
+         * so this surface cannot invent a stricter or looser rule of its own.
+         */
+        const blockedReason = transfer.acceptBlockedReason;
         return (
           <Paper
             key={transfer.transferId}
@@ -162,8 +182,43 @@ export function AppTransferOffersView({
                 </Group>
               </Group>
 
+              {/* 🔴 THE REFUSAL, BEFORE THE CLICK — the recipient half of #3935.
+                  `acceptTransfer` re-asserts the connect-client refusal IN-TRANSACTION
+                  precisely because a revision approve can link an OAuth client while an
+                  offer sits open, so this card can be live, valid and guaranteed to fail.
+                  Without this the recipient learned that only by pressing Accept and
+                  reading a toast — the same learn-it-by-doing-the-work shape the owner's
+                  tab already fixed, on the other side of the wire.
+
+                  The message is the SERVER's own constant, verbatim, not a paraphrase: the
+                  recipient reads the same sentence the mutation would have returned. It
+                  states a constraint and instructs NOTHING, because there is no unlink
+                  path in the product for them OR the owner to pursue. */}
+              {blockedReason ? (
+                <Alert
+                  color="yellow"
+                  variant="light"
+                  icon={<IconAlertTriangle size={16} />}
+                  title="This offer can no longer be accepted"
+                  data-testid={`apps-transfer-blocked-${transfer.transferId}`}
+                >
+                  {blockedReason}
+                </Alert>
+              ) : null}
+
               {/* 🔴 RED, not the seat invite's yellow, and it names the consequences
-                  BEFORE the button rather than after the click. */}
+                  BEFORE the button rather than after the click.
+
+                  🔴 RETAINED ON A BLOCKED CARD, DELIBERATELY, and this diverges from the
+                  owner-side treatment in #3935 (which suppressed its equivalent copy).
+                  Two reasons. It is a load-bearing IDENTITY marker: the pair test in
+                  `AppTransferOffersView.browser.test.tsx` names this panel as one of three
+                  things stopping an irreversible ownership transfer from reading like a
+                  reversible seat invite, and dropping it on some cards makes that property
+                  conditional. And unlike the owner's suppressed copy — which described
+                  MECHANICS of a transfer that can never start — this describes what the
+                  offer WAS FOR, which is exactly what the recipient still needs in order
+                  to decide to decline it. */}
               <Alert
                 color="red"
                 variant="light"
@@ -187,10 +242,19 @@ export function AppTransferOffersView({
               </Text>
 
               <Group gap="xs">
+                {/* 🔴 ACCEPT IS DISABLED, DECLINE IS NOT, and the asymmetry is the point.
+                    `acceptTransfer` refuses this offer every time; `cancelTransfer` — which
+                    is how a recipient DECLINES — carries no connect-client gate at all and
+                    admits either party. So getting out of a dead offer is exactly the
+                    action that must still work, and disabling both would strand the
+                    recipient with a card they can neither accept nor clear.
+
+                    DISABLED, NOT HIDDEN, for the same reason the owner's control is: a
+                    vanished button leaves them wondering whether the offer is real. */}
                 <Button
                   size="xs"
                   color="red"
-                  disabled={busy}
+                  disabled={busy || blockedReason != null}
                   loading={busy}
                   data-testid={`apps-transfer-accept-${transfer.transferId}`}
                   onClick={() => onRespond?.(transfer.transferId, true)}

--- a/src/server/services/blocks/__tests__/app-ownership-transfer.inbox.test.ts
+++ b/src/server/services/blocks/__tests__/app-ownership-transfer.inbox.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { CONNECT_CLIENT_TRANSFER_REFUSAL } from '~/shared/constants/app-transfer.constants';
+
 /**
  * App Listing COLLABORATORS — the RECIPIENT INBOX (`listMyPendingTransfers`).
  *
@@ -20,6 +22,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * `findMany` fake that ignored the clause would return every row to every caller, which
  * makes the leak test — the one that matters most here — pass no matter what the service
  * queries. `the fake CAN filter` below is the positive control for exactly that.
+ *
+ * 🔴 AND IT NOW HONOURS ITS `select`, WHICH IT DID NOT. Until #3952 the fake filtered on
+ * `where` and then handed back the WHOLE fixture row — so a column the service's `select`
+ * never asked for was present anyway, and the mutant that DELETES `connectClientId: true`
+ * from that select survived this entire suite. A canned fixture cannot observe a `select`,
+ * by construction; only projection can. `the fake honours its select (positive control)`
+ * below proves an unselected column really is absent, modelled on the identical control in
+ * `app-access.authoring-context-connect-client.test.ts`.
  */
 
 const { mockDb } = vi.hoisted(() => ({
@@ -56,6 +66,13 @@ type Row = {
     name: string;
     kind: string;
     appBlockId: string | null;
+    /**
+     * 🔴 IN THE FIXTURE TABLE, NEVER IN THE SERVICE'S OUTPUT. The column is what
+     * `refusesTransferForConnectClient` reads; the recipient receives only the derived
+     * `acceptBlockedReason`. The leak assertion in `listMyPendingTransfers` below pins
+     * that, and it can only mean anything because the column is genuinely present here.
+     */
+    connectClientId: string | null;
     icon: { url: string } | null;
   } | null;
 };
@@ -79,6 +96,7 @@ function transferTable(): Row[] {
         name: 'Shiny Thing',
         kind: 'onsite',
         appBlockId: 'ab_shiny',
+        connectClientId: null,
         icon: { url: 'https://img.example/shiny.png' },
       },
     },
@@ -95,6 +113,30 @@ function transferTable(): Row[] {
         name: 'External Thing',
         kind: 'offsite',
         appBlockId: null,
+        connectClientId: null,
+        icon: null,
+      },
+    },
+    /**
+     * 🔴 THE BLOCKED OFFER — off-site AND connect-linked, so `acceptTransfer` refuses it
+     * in-transaction every time. Live, `pending`, in date, addressed to ME: indistinguish-
+     * able from the row above on every other axis, which is precisely why the recipient
+     * could not tell them apart until `acceptBlockedReason` existed.
+     */
+    {
+      id: 'aot_mine_offsite_linked',
+      appListingId: 'apl_offsite_linked',
+      fromUserId: 17,
+      toUserId: ME,
+      status: 'pending',
+      expiresAt: FUTURE,
+      createdAt: new Date('2026-08-07T00:00:00Z'),
+      appListing: {
+        slug: 'connected-thing',
+        name: 'Connected Thing',
+        kind: 'offsite',
+        appBlockId: null,
+        connectClientId: 'oc_linked',
         icon: null,
       },
     },
@@ -112,6 +154,7 @@ function transferTable(): Row[] {
         name: 'Someone Else’s App',
         kind: 'onsite',
         appBlockId: 'ab_secret',
+        connectClientId: null,
         icon: null,
       },
     },
@@ -129,6 +172,7 @@ function transferTable(): Row[] {
         name: 'Already Taken',
         kind: 'onsite',
         appBlockId: 'ab_done',
+        connectClientId: null,
         icon: null,
       },
     },
@@ -144,7 +188,10 @@ function transferTable(): Row[] {
         slug: 'withdrawn',
         name: 'Withdrawn',
         kind: 'offsite',
+        // A CANCELLED offer on a connect-linked listing: the blocked branch must never be
+        // reached for it, because the status filter removes the row first.
         appBlockId: null,
+        connectClientId: 'oc_withdrawn',
         icon: null,
       },
     },
@@ -162,6 +209,7 @@ function transferTable(): Row[] {
         name: 'Lapsed Offer',
         kind: 'onsite',
         appBlockId: 'ab_stale',
+        connectClientId: null,
         icon: null,
       },
     },
@@ -170,16 +218,44 @@ function transferTable(): Row[] {
 
 let ROWS: Row[];
 
+type Select = Record<string, unknown>;
+
+/**
+ * Project one fixture row through a Prisma-style `select`, RECURSIVELY — a nested
+ * `{ select: … }` on a relation narrows that relation the same way, and a `null` relation
+ * stays `null`.
+ *
+ * 🔴 COLUMNS THE SELECT DID NOT ASK FOR ARE ABSENT, not merely undefined, because that is
+ * what Prisma does and it is the only thing that makes the service's `select` OBSERVABLE.
+ * The previous fake returned the whole fixture row after filtering, so deleting a line from
+ * the service's `select` changed nothing here — the mutant survived a fully green suite.
+ * No `select` at all still returns everything, which keeps the raw-fixture control below
+ * able to read the table directly.
+ */
+function project(row: unknown, select: Select | undefined): unknown {
+  if (row === null || row === undefined) return row;
+  if (!select) return row;
+  const source = row as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [key, spec] of Object.entries(select)) {
+    if (!spec) continue;
+    const nested = (spec as { select?: Select }).select;
+    out[key] = nested ? project(source[key], nested) : source[key];
+  }
+  return out;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   ROWS = transferTable();
   mockDb.appOwnershipTransfer.findMany.mockImplementation(async (args: unknown) => {
-    const where = (args as { where?: { toUserId?: number; status?: string } }).where ?? {};
+    const a = (args ?? {}) as { where?: { toUserId?: number; status?: string }; select?: Select };
+    const where = a.where ?? {};
     return ROWS.filter(
       (r) =>
         (where.toUserId === undefined || r.toUserId === where.toUserId) &&
         (where.status === undefined || r.status === where.status)
-    );
+    ).map((r) => project(r, a.select));
   });
 });
 
@@ -208,10 +284,71 @@ describe('listMyPendingTransfers — the fake', () => {
   });
 });
 
+describe('the fake honours its select (positive control)', () => {
+  /**
+   * 🔴 BEFORE BELIEVING ANY `select`-SENSITIVE ASSERTION BELOW: prove the fake can return
+   * BOTH shapes, and that an unselected column really is ABSENT rather than merely
+   * undefined. Without this, "the field came back" and "the fake returns everything
+   * regardless" are indistinguishable — which is exactly the state this suite was in
+   * before #3952, and why the `connectClientId` deletion mutant survived it.
+   *
+   * The nested arm matters as much as the flat one: the column the service reads lives on
+   * the JOINED listing, so a projector that narrowed only the top level would be just as
+   * blind as no projector at all.
+   */
+  it('omits a column the select did not ask for, and returns one it did', async () => {
+    const asked = (await mockDb.appOwnershipTransfer.findMany({
+      where: { toUserId: ME, status: 'pending' },
+      select: { id: true, appListing: { select: { slug: true, connectClientId: true } } },
+    })) as Array<Record<string, unknown>>;
+    expect(asked[0]).toEqual({
+      id: 'aot_mine_onsite',
+      appListing: { slug: 'shiny-thing', connectClientId: null },
+    });
+    // The column IS on the fixture row — so its absence below is the projection, not a
+    // hole in the table.
+    expect('connectClientId' in (asked[0].appListing as object)).toBe(true);
+
+    const notAsked = (await mockDb.appOwnershipTransfer.findMany({
+      where: { toUserId: ME, status: 'pending' },
+      select: { id: true, appListing: { select: { slug: true } } },
+    })) as Array<Record<string, unknown>>;
+    expect(notAsked[0]).toEqual({ id: 'aot_mine_onsite', appListing: { slug: 'shiny-thing' } });
+    expect('connectClientId' in (notAsked[0].appListing as object)).toBe(false);
+    // …and the top level narrows too: `fromUserId` was never asked for.
+    expect('fromUserId' in notAsked[0]).toBe(false);
+  });
+
+  /** A `null` relation survives projection as `null`, not as an empty object. */
+  it('a null relation stays null', async () => {
+    ROWS = [
+      {
+        id: 'aot_orphan_probe',
+        appListingId: 'apl_vanished',
+        fromUserId: 16,
+        toUserId: ME,
+        status: 'pending',
+        expiresAt: FUTURE,
+        createdAt: NOW,
+        appListing: null,
+      },
+    ];
+    const rows = (await mockDb.appOwnershipTransfer.findMany({
+      where: { toUserId: ME, status: 'pending' },
+      select: { id: true, appListing: { select: { slug: true } } },
+    })) as Array<Record<string, unknown>>;
+    expect(rows).toEqual([{ id: 'aot_orphan_probe', appListing: null }]);
+  });
+});
+
 describe('listMyPendingTransfers', () => {
   it('returns the caller’s LIVE pending offers', async () => {
     const rows = await listMyPendingTransfers(ME, NOW);
-    expect(rows.map((r) => r.transferId)).toEqual(['aot_mine_onsite', 'aot_mine_offsite']);
+    expect(rows.map((r) => r.transferId)).toEqual([
+      'aot_mine_onsite',
+      'aot_mine_offsite',
+      'aot_mine_offsite_linked',
+    ]);
   });
 
   /**
@@ -282,6 +419,9 @@ describe('listMyPendingTransfers', () => {
       fromUserId: OWNER,
       expiresAt: FUTURE,
       createdAt: new Date('2026-08-09T00:00:00Z'),
+      // 🔴 EXHAUSTIVE `toEqual`, so a NEW field on the view has to be declared here — and
+      // so this row is pinned as carrying the raw column NOWHERE. See the leak test below.
+      acceptBlockedReason: null,
     });
     // An OFF-SITE offer legitimately carries no block and no icon — absent, not missing.
     expect(offsite.kind).toBe('offsite');
@@ -292,10 +432,10 @@ describe('listMyPendingTransfers', () => {
 
   it('names the OFFERING user, so the recipient can see who is handing it over', async () => {
     const rows = await listMyPendingTransfers(ME, NOW);
-    expect(rows.map((r) => r.fromUserId)).toEqual([OWNER, 11]);
+    expect(rows.map((r) => r.fromUserId)).toEqual([OWNER, 11, 17]);
     // POSITIVE CONTROL: the offerers are distinct from each other and from the recipient,
     // so a mixed-up column is observable.
-    expect(new Set([OWNER, 11, ME]).size).toBe(3);
+    expect(new Set([OWNER, 11, 17, ME]).size).toBe(4);
   });
 
   it('a row whose listing relation is missing is DROPPED, not rendered blank', async () => {
@@ -312,10 +452,108 @@ describe('listMyPendingTransfers', () => {
     const ids = (await listMyPendingTransfers(ME, NOW)).map((r) => r.transferId);
     expect(ids).not.toContain('aot_orphan');
     // POSITIVE CONTROL: the other rows still come back, so the drop is targeted.
-    expect(ids).toEqual(['aot_mine_onsite', 'aot_mine_offsite']);
+    expect(ids).toEqual(['aot_mine_onsite', 'aot_mine_offsite', 'aot_mine_offsite_linked']);
   });
 
   it('an empty inbox is an empty array, not a throw', async () => {
     await expect(listMyPendingTransfers(999, NOW)).resolves.toEqual([]);
+  });
+});
+
+/**
+ * 🔴 `acceptBlockedReason` — WHY AN OFFER CANNOT BE ACCEPTED, decided server-side.
+ *
+ * `acceptTransfer` re-asserts the connect-client refusal IN-TRANSACTION, so a live offer on
+ * a connect-linked off-site listing is guaranteed to fail on accept. Until this field
+ * existed the recipient's inbox had no way to know: `listMyPendingTransfers` did not read
+ * the column, so the fact could not cross the wire at all, and the addressee met the
+ * refusal only by pressing Accept.
+ *
+ * These pin the FIELD. The BRANCH that reads it lives in `AppTransferOffersView`, pinned by
+ * `src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx` — a field is not a guard.
+ */
+describe('🔴 listMyPendingTransfers — acceptBlockedReason', () => {
+  it('an OFF-SITE offer on a connect-linked listing carries the server’s refusal, verbatim', async () => {
+    const rows = await listMyPendingTransfers(ME, NOW);
+    const blocked = rows.find((r) => r.transferId === 'aot_mine_offsite_linked');
+    expect(blocked).toBeDefined();
+    // VERBATIM against the constant the two server gates throw — a paraphrase here would
+    // let the recipient's sentence drift out from under the owner's and the API's.
+    expect(blocked?.acceptBlockedReason).toBe(CONNECT_CLIENT_TRANSFER_REFUSAL);
+  });
+
+  /**
+   * 🔴 THE CONTROL, AND IT IS THE ARM THAT KILLS "block every offer". Without it, returning
+   * the refusal unconditionally satisfies the test above and ships an inbox where nothing
+   * can ever be accepted. The unblocked row is off-site too, so `kind` alone cannot explain
+   * the difference — only the client id can.
+   */
+  it('🔴 CONTROL — an OFF-SITE offer with NO client is null, and an ON-SITE one is too', async () => {
+    const rows = await listMyPendingTransfers(ME, NOW);
+    const byId = Object.fromEntries(rows.map((r) => [r.transferId, r.acceptBlockedReason]));
+    expect(byId).toEqual({
+      aot_mine_onsite: null,
+      aot_mine_offsite: null,
+      aot_mine_offsite_linked: CONNECT_CLIENT_TRANSFER_REFUSAL,
+    });
+    // POSITIVE CONTROL on the fixture: the two off-site rows differ ONLY in the client id.
+    const linked = ROWS.find((r) => r.id === 'aot_mine_offsite_linked');
+    const unlinked = ROWS.find((r) => r.id === 'aot_mine_offsite');
+    expect(linked?.appListing?.kind).toBe(unlinked?.appListing?.kind);
+    expect(linked?.appListing?.connectClientId).toBe('oc_linked');
+    expect(unlinked?.appListing?.connectClientId).toBeNull();
+  });
+
+  /**
+   * 🔴 THE `kind` ARM OF THE PREDICATE, pinned against the SERVER's rule rather than a
+   * guess. `refusesTransferForConnectClient` requires `kind === 'offsite'`, so an on-site
+   * row carrying a client id is still transferable server-side and the inbox must agree —
+   * blocking it here would refuse an offer `acceptTransfer` would have honoured.
+   */
+  it('an ON-SITE row carrying a client id is NOT blocked — the predicate needs both', async () => {
+    const onsite = ROWS.find((r) => r.id === 'aot_mine_onsite');
+    onsite!.appListing!.connectClientId = 'oc_onsite';
+    const rows = await listMyPendingTransfers(ME, NOW);
+    expect(rows.find((r) => r.transferId === 'aot_mine_onsite')?.acceptBlockedReason).toBeNull();
+    // POSITIVE CONTROL: the same client id on the OFF-SITE row does block, so the value is
+    // not simply being ignored.
+    expect(rows.find((r) => r.transferId === 'aot_mine_offsite_linked')?.acceptBlockedReason).toBe(
+      CONNECT_CLIENT_TRANSFER_REFUSAL
+    );
+  });
+
+  /**
+   * 🔴 THE RAW COLUMN NEVER CROSSES THE WIRE. A pending offeree holds no role on the
+   * listing and this read imposes no status gate, so an offer can sit on a `draft`
+   * listing whose client id the public listing-detail read does not expose. The derived
+   * sentence is all they can act on, and all they get.
+   */
+  it('🔴 does NOT return the raw connectClientId to the recipient', async () => {
+    const rows = await listMyPendingTransfers(ME, NOW);
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) expect('connectClientId' in row).toBe(false);
+    // POSITIVE CONTROL: the value IS in the fixture and DID reach the predicate — the row
+    // it belongs to came back blocked. So its absence above is suppression, not a hole.
+    expect(ROWS.find((r) => r.id === 'aot_mine_offsite_linked')?.appListing?.connectClientId).toBe(
+      'oc_linked'
+    );
+    expect(rows.find((r) => r.transferId === 'aot_mine_offsite_linked')?.acceptBlockedReason).toBe(
+      CONNECT_CLIENT_TRANSFER_REFUSAL
+    );
+  });
+
+  /**
+   * 🔴 THE `select` MUST ASK FOR THE COLUMN. This is the assertion the old whole-row fake
+   * could not make: with projection in place, deleting `connectClientId: true` from the
+   * service's select makes the row come back without it and the verdict silently becomes
+   * `null` for everybody. Pinned on the ARGUMENTS as well, so the reason a failure happened
+   * is legible rather than "one offer stopped being blocked".
+   */
+  it('🔴 the query SELECTS connectClientId off the joined listing', async () => {
+    await listMyPendingTransfers(ME, NOW);
+    const args = mockDb.appOwnershipTransfer.findMany.mock.calls[0][0] as {
+      select: { appListing: { select: Record<string, unknown> } };
+    };
+    expect(args.select.appListing.select).toMatchObject({ connectClientId: true, kind: true });
   });
 });

--- a/src/server/services/blocks/app-ownership-transfer.service.ts
+++ b/src/server/services/blocks/app-ownership-transfer.service.ts
@@ -707,18 +707,42 @@ export type IncomingTransferView = {
    * saying "a revision approve can LINK an OAuth client while the offer is open". That
    * sentence was inherited rather than checked, and an enumeration of every writer of
    * `AppListing.connectClientId` does not support it:
-   *   - the ONLY non-null write is `submitExternalListing`'s `create` of a BRAND-NEW row,
-   *     where the schema makes the field required — a listing is BORN linked;
+   *   - the ONLY non-null write is `submitExternalListing`'s `create` of a BRAND-NEW row.
+   *     What makes it mandatory there is the ZOD INPUT (`submitExternalListingSchema`'s
+   *     `connectClientId: z.string().min(1).max(64)`), NOT the database: the Prisma column
+   *     is `connectClientId String?` — NULLABLE, no default. Worth stating precisely,
+   *     because a reader who believes the column is NOT NULL concludes it can never become
+   *     null, and the next bullet is exactly that happening. Either way: a listing is BORN
+   *     linked;
    *   - `beginListingRevision` copies `parent.connectClientId` onto the shadow, the approve
    *     merge copies `shadow.connectClientId` back onto the parent, and in between
    *     `buildListingPatchData` never assigns the column and `updateListingPatchSchema` has
    *     no such key — so the revision round trip returns the value it started with;
-   *   - no raw SQL, nested relation write, or spread writes it.
+   *   - no raw SQL, nested relation write, or spread writes it — but see the caveat below,
+   *     because that list is about STATEMENTS and does not exhaust WRITERS.
    * So a listing cannot ACQUIRE a link, and `initiateTransfer` refuses to open an offer on
    * one that was born with it. The blocked state is therefore not producible through the
-   * product as it stands — it needs a direct DB write, a migration, or a future unlink/link
-   * flow. (Caveat: that enumeration is textual plus call-site based; a fully dynamic key or
-   * a runtime-assembled raw UPDATE would evade it. None was found.)
+   * product as it stands — it needs a direct DB write, a migration, or a future LINK flow.
+   *
+   * 🔴 CAVEAT, AND IT IS A CLASS THE ENUMERATION STRUCTURALLY CANNOT SEE: A WRITER CAN LIVE
+   * IN THE SCHEMA RATHER THAN AT A CALL SITE. The relation is declared
+   * `onDelete: SetNull`, so deleting the `OauthClient` row issues
+   * `UPDATE app_listings SET connect_client_id = NULL` on every listing referencing it —
+   * and `oauth-client.router::delete` performs exactly that delete with NO check for a
+   * referencing `AppListing` (its only guard, `rejectAppBlockClient`, covers App*Block*
+   * clients, which these are not). That is a product-reachable, OWNER-INITIATED UNLINK
+   * that exists today, and no grep over `data:` payloads or raw SQL would ever find it.
+   *
+   * It does NOT change the conclusion above: a referential SetNull only ever moves the
+   * column non-null → null, so it can only UNBLOCK. What it does change is a consequence
+   * worth knowing: `acceptBlockedReason` can go STALE IN THE SAFE DIRECTION — an offer
+   * rendered blocked whose client was deleted since the read would now succeed on accept.
+   * The recipient sees a stale refusal until the query refetches; the server, which is the
+   * enforcement, correctly allows it. A stale block is a delay; a stale allow would be a
+   * lie, and this cascade cannot produce one.
+   *
+   * (The enumeration is otherwise textual plus call-site based, so it would also miss a
+   * fully dynamic key or a runtime-assembled raw UPDATE. Neither construct exists.)
    *
    * 🔴 WHICH IS A REASON TO SHIP THIS, NOT TO SKIP IT — but as GAP-CLOSURE AHEAD OF
    * TRAFFIC, not as a live bug fix, and it should not be described as one. The accept-time

--- a/src/server/services/blocks/app-ownership-transfer.service.ts
+++ b/src/server/services/blocks/app-ownership-transfer.service.ts
@@ -692,6 +692,33 @@ export type IncomingTransferView = {
   fromUserId: number;
   expiresAt: Date;
   createdAt: Date;
+  /**
+   * 🔴 WHY THIS OFFER CANNOT BE ACCEPTED, or `null` when it can — the recipient half of
+   * the up-front refusal #3935 gave the owner.
+   *
+   * A connect-linked off-site listing is refused at initiate AND re-asserted
+   * IN-TRANSACTION at accept ({@link refusesTransferForConnectClient}), and that second
+   * gate exists because a revision approve can link an OAuth client while an offer sits
+   * open. So a live, valid-looking offer in this inbox can be guaranteed to fail on
+   * accept, and until this field existed the inbox could not know: the recipient met the
+   * refusal only by clicking Accept.
+   *
+   * 🔴 A DERIVED REASON, NOT THE RAW `connectClientId`, and the distinction is a
+   * disclosure boundary rather than style. #3935 carried the raw column to the OWNER's
+   * authoring context, arguing it is public via the approved listing-detail read. That
+   * argument does NOT carry over here: a pending offeree holds NO role on the listing
+   * (`resolveListingAccess` gives them nothing), and this read imposes no status gate, so
+   * an offer can sit on a `draft`/`pending` listing whose client id the public read never
+   * exposes. Shipping the column would be a NEW disclosure on exactly those rows, to the
+   * least privileged reader in the feature — for a value they cannot act on. They can only
+   * read the sentence, so the sentence is what crosses the wire.
+   *
+   * It is not a second copy of the rule: this is the SAME predicate and the SAME
+   * {@link CONNECT_CLIENT_TRANSFER_REFUSAL} constant both server gates use. Those gates are
+   * UNCHANGED and remain the enforcement — this is an addition in front of them, never a
+   * replacement, and it runs on data the client could lie to itself about.
+   */
+  acceptBlockedReason: string | null;
 };
 
 /**
@@ -733,6 +760,12 @@ export async function listMyPendingTransfers(
           name: true,
           kind: true,
           appBlockId: true,
+          // 🔴 READ, BUT NEVER RETURNED. It is the input to
+          // {@link refusesTransferForConnectClient} and is consumed entirely here, into
+          // `acceptBlockedReason` below — see that field for why the raw column must not
+          // reach a pending offeree. Deleting this line silently turns every blocked offer
+          // back into an ordinary-looking one, which is the defect this closes.
+          connectClientId: true,
           icon: { select: { url: true } },
         },
       },
@@ -745,6 +778,7 @@ export async function listMyPendingTransfers(
         name: string;
         kind: string;
         appBlockId: string | null;
+        connectClientId: string | null;
         icon: { url: string } | null;
       } | null;
     }
@@ -765,6 +799,14 @@ export async function listMyPendingTransfers(
       fromUserId: row.fromUserId,
       expiresAt: row.expiresAt,
       createdAt: row.createdAt,
+      // 🔴 THE VERDICT, COMPUTED HERE AND CROSSED AS PROSE. The raw `connectClientId`
+      // stops at this line — see {@link IncomingTransferView.acceptBlockedReason}.
+      acceptBlockedReason: refusesTransferForConnectClient({
+        kind: row.appListing.kind,
+        connectClientId: row.appListing.connectClientId,
+      })
+        ? CONNECT_CLIENT_TRANSFER_REFUSAL
+        : null,
     });
   }
   return out;

--- a/src/server/services/blocks/app-ownership-transfer.service.ts
+++ b/src/server/services/blocks/app-ownership-transfer.service.ts
@@ -697,11 +697,35 @@ export type IncomingTransferView = {
    * the up-front refusal #3935 gave the owner.
    *
    * A connect-linked off-site listing is refused at initiate AND re-asserted
-   * IN-TRANSACTION at accept ({@link refusesTransferForConnectClient}), and that second
-   * gate exists because a revision approve can link an OAuth client while an offer sits
-   * open. So a live, valid-looking offer in this inbox can be guaranteed to fail on
-   * accept, and until this field existed the inbox could not know: the recipient met the
+   * IN-TRANSACTION at accept ({@link refusesTransferForConnectClient}). So an offer in
+   * this inbox can in principle be live, valid-looking and guaranteed to fail on accept,
+   * and until this field existed the inbox could not know it: the recipient met the
    * refusal only by clicking Accept.
+   *
+   * 🔴 HOW REACHABLE IS THAT, HONESTLY: NOT, THROUGH THE PRODUCT, TODAY. Several comments
+   * in this file and in `AppCollaboratorsPanelView` justify the accept-time re-assert by
+   * saying "a revision approve can LINK an OAuth client while the offer is open". That
+   * sentence was inherited rather than checked, and an enumeration of every writer of
+   * `AppListing.connectClientId` does not support it:
+   *   - the ONLY non-null write is `submitExternalListing`'s `create` of a BRAND-NEW row,
+   *     where the schema makes the field required — a listing is BORN linked;
+   *   - `beginListingRevision` copies `parent.connectClientId` onto the shadow, the approve
+   *     merge copies `shadow.connectClientId` back onto the parent, and in between
+   *     `buildListingPatchData` never assigns the column and `updateListingPatchSchema` has
+   *     no such key — so the revision round trip returns the value it started with;
+   *   - no raw SQL, nested relation write, or spread writes it.
+   * So a listing cannot ACQUIRE a link, and `initiateTransfer` refuses to open an offer on
+   * one that was born with it. The blocked state is therefore not producible through the
+   * product as it stands — it needs a direct DB write, a migration, or a future unlink/link
+   * flow. (Caveat: that enumeration is textual plus call-site based; a fully dynamic key or
+   * a runtime-assembled raw UPDATE would evade it. None was found.)
+   *
+   * 🔴 WHICH IS A REASON TO SHIP THIS, NOT TO SKIP IT — but as GAP-CLOSURE AHEAD OF
+   * TRAFFIC, not as a live bug fix, and it should not be described as one. The accept-time
+   * gate is correct defence-in-depth whether or not today's writers can reach it, and the
+   * two stale comments at :2273 and :2573 of `offsite-listing.service.ts` show a link flow
+   * is anticipated. When one lands, this field is already the channel that tells the
+   * recipient — rather than a second learn-it-by-clicking defect to find later.
    *
    * 🔴 A DERIVED REASON, NOT THE RAW `connectClientId`, and the distinction is a
    * disclosure boundary rather than style. #3935 carried the raw column to the OWNER's
@@ -717,6 +741,26 @@ export type IncomingTransferView = {
    * {@link CONNECT_CLIENT_TRANSFER_REFUSAL} constant both server gates use. Those gates are
    * UNCHANGED and remain the enforcement — this is an addition in front of them, never a
    * replacement, and it runs on data the client could lie to itself about.
+   *
+   * 🔴 SCOPE — `null` MEANS "NO KNOWN-IN-ADVANCE BLOCKER", NOT "THIS WILL SUCCEED". The
+   * name reads as an exhaustive verdict and is not one. `acceptTransfer` also refuses:
+   *   - a BANNED recipient (`'That account cannot receive app ownership'`);
+   *   - an on-site listing whose `AppBlock.appId` is missing;
+   *   - ownership having already moved out from under the offer, on either the
+   *     `OauthClient` row or the listing row (two separate `count === 0` guards);
+   *   - the transfer no longer being `pending` when the close runs.
+   * NONE of those are encoded here, deliberately. Every one of them is either a property
+   * of ANOTHER row this read does not touch, or a race that only exists at accept time —
+   * so a read-time answer would be a guess that goes stale between the render and the
+   * click, which is the failure mode this field exists to remove rather than relocate.
+   * What belongs here is exactly what is stable and knowable from the offer plus its
+   * listing; the connect-client refusal is the only such blocker today.
+   *
+   * The name is kept GENERAL on purpose. A second stable read-time blocker would join this
+   * field rather than add another one, so narrowing it to name the connect client would
+   * force a wire-contract rename the first time that happens. If you add one: put it here,
+   * extend this list, and extend `app-ownership-transfer.inbox.test.ts` — do NOT let a
+   * client-side branch decide which reasons count.
    */
   acceptBlockedReason: string | null;
 };

--- a/src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx
+++ b/src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../../test/component-setup';
+import type { IncomingTransferRow } from '~/components/Apps/AppTransferOffersView';
 import { CONNECT_CLIENT_TRANSFER_REFUSAL } from '~/shared/constants/app-transfer.constants';
 import type * as TrpcModule from '~/utils/trpc';
 
@@ -18,40 +19,59 @@ import type * as TrpcModule from '~/utils/trpc';
  * container forwards the rows uncast, and the View decides what to render.
  *
  * WHAT IT PINS: a connect-linked off-site listing is refused at initiate AND re-asserted
- * IN-TRANSACTION at accept, because a revision approve can link an OAuth client while an
- * offer sits open. The recipient's card was therefore live, valid-looking, and guaranteed
- * to fail — the refusal reached them only as a toast, after the click.
+ * IN-TRANSACTION at accept, so a card in this inbox can be live, valid-looking and
+ * guaranteed to fail — and the refusal reached the recipient only as a toast, after the
+ * click. 🔴 That state is NOT reachable through the product today (a listing is born
+ * connect-linked or never becomes one, and `initiateTransfer` refuses to open an offer on
+ * one that was born linked) — see the honest reachability note on `acceptBlockedReason` in
+ * `app-ownership-transfer.service.ts`. This suite is gap-closure ahead of traffic, and the
+ * arms below drive the state from the payload precisely BECAUSE nothing else can.
  *
- * 🔴 WHAT IT DOES **NOT** COVER, stated exactly rather than implied. The payload comes from
- * the local `offer()` fixture below, NOT from the server, so the `tRPC proc → payload` hop
- * is OUT of frame: deleting `connectClientId: true` from `listMyPendingTransfers`'s select,
- * or dropping the derived field entirely, leaves this file green. That hop is covered by
- * `src/server/services/blocks/__tests__/app-ownership-transfer.inbox.test.ts` (whose Prisma
- * fake projects through the `select`) and, now that `IncomingTransferRow` is derived from
- * the service's `IncomingTransferView` and the container's cast is gone, by `tsc`. Three
- * instruments, three hops; no one of them sees all of it.
+ * 🔴 WHAT IT DOES **NOT** COVER, stated exactly rather than implied, and MEASURED rather
+ * than reasoned. The payload comes from the local `offer()` fixture below, NOT from the
+ * server, so the `tRPC proc → payload` hop is OUT of frame at RUNTIME: deleting
+ * `connectClientId: true` from `listMyPendingTransfers`'s select leaves every test in this
+ * file green. That hop belongs to
+ * `src/server/services/blocks/__tests__/app-ownership-transfer.inbox.test.ts`, whose Prisma
+ * fake projects through the `select`.
+ *
+ * The SHAPE of the payload is not out of frame, though — not any more. `TransferRow` is
+ * `IncomingTransferRow`, so deleting `acceptBlockedReason` from the service's
+ * `IncomingTransferView` is now 9 `tsc` errors IN THIS FILE (measured; it was ZERO while
+ * the fixture carried its own hand-written type, which is the anti-pattern this PR removes
+ * from the container). Two instruments, two different hops — a `select` line and a field —
+ * and neither sees the other's.
  *
  * 🔴 THE SERVER GATES ARE UNCHANGED AND REMAIN THE ENFORCEMENT. Everything below is an
  * addition in front of them, running on data the client could lie to itself about.
  */
 
-type TransferRow = {
-  transferId: string;
-  appListingId: string;
-  slug: string;
-  name: string;
-  kind: 'onsite' | 'offsite';
-  appBlockId: string | null;
-  iconUrl: string | null;
-  fromUserId: number;
-  expiresAt: Date;
-  createdAt: Date;
-  acceptBlockedReason: string | null;
-};
+/**
+ * 🔴 THE FIXTURE'S SHAPE IS THE PAYLOAD'S SHAPE, not a hand-written lookalike.
+ *
+ * This started life as its own structural duplicate, which is precisely the hole this PR
+ * closes in the container — and it was measurably the same hole: deleting
+ * `acceptBlockedReason` from the service produced `tsc` errors in the View, in the View's
+ * own suite and in the service, and NOTHING here, in the file whose entire purpose is to
+ * prove the seam. A suite that claims to drive the real payload has to be pinned to it, or
+ * it is testing a shape nobody ships.
+ *
+ * Derived from {@link IncomingTransferRow} — the View's row type, itself derived from the
+ * service's `IncomingTransferView` — so this fixture sits at the END of the same chain the
+ * production code does. A type-only import is erased at build time.
+ */
+type TransferRow = IncomingTransferRow;
 
 const state = vi.hoisted(() => ({
-  /** The `listMyPendingTransfers` payload — THE ONLY THING ANY ARM VARIES. */
-  transfers: [] as unknown[],
+  /**
+   * The `listMyPendingTransfers` payload — THE ONLY THING ANY ARM VARIES.
+   *
+   * Typed as the real row rather than `unknown[]`: it is what the mocked query hands the
+   * container, so this is the assignment `tsc` has to see in order for the fixture to be
+   * pinned at all. (Declared inside `vi.hoisted`, whose factory is hoisted above the
+   * imports — the TYPE reference is erased, so there is nothing left to hoist.)
+   */
+  transfers: [] as TransferRow[],
   /** Seat invites. Empty everywhere here; the transfer half is the subject. */
   invites: [] as unknown[],
   /** 🔴 Recorded and asserted EMPTY on every blocked arm. A blocked card must not submit. */
@@ -297,6 +317,32 @@ describe('🔴 AN OFFER THE SERVER WILL REFUSE — said so before the click', ()
    * action, and leaves the owner's own tab (which still shows the offer) disagreeing with
    * this one about whether an offer exists.
    */
+  /**
+   * 🔴 ONE PREDICATE, PINNED BEHAVIOURALLY — the two branches must agree on EVERY value of
+   * the field, not just on the two the service can send today.
+   *
+   * They used to disagree: the banner tested `blockedReason ? …` and the button tested
+   * `blockedReason != null`. Both agree on the constant and on `null`, and they diverge on
+   * `''` — Accept disabled with NO explanation rendered, a card the recipient can neither
+   * accept nor understand. Unreachable while there is exactly one reason, and reachable the
+   * moment someone adds a second without knowing the branches differ.
+   *
+   * So the empty string is the discriminating input, and it is fed on the PAYLOAD like
+   * every other arm. The assertion is that the two branches move TOGETHER: the banner
+   * element is present (its `title` still explains the card even with an empty body) AND
+   * Accept is disabled. A comment could not have held this; this arm goes red the moment
+   * the predicates are re-split.
+   */
+  test('🔴 an EMPTY reason still renders the banner AND disables Accept — one predicate', async () => {
+    state.transfers = [offer({ transferId: 'aot_empty', acceptBlockedReason: '' })];
+    renderWithProviders(<AppInvitesPage />);
+
+    await expect.element(page.getByTestId('apps-transfer-blocked-aot_empty')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-transfer-accept-aot_empty')).toBeDisabled();
+    // …and Decline stays the way out, exactly as on a normally-blocked card.
+    await expect.element(page.getByTestId('apps-transfer-decline-aot_empty')).toBeEnabled();
+  });
+
   test('the offer still renders as an offer — name, deadline and all', async () => {
     state.transfers = [
       offer({
@@ -316,24 +362,18 @@ describe('🔴 AN OFFER THE SERVER WILL REFUSE — said so before the click', ()
     await expect.element(page.getByTestId('apps-transfer-offerer-aot_blocked')).toBeInTheDocument();
   });
 
-  /**
-   * 🔴 THE RAW COLUMN NEVER REACHES THIS SURFACE. The recipient holds no role on the
-   * listing and the inbox read has no status gate, so an offer can sit on a `draft` listing
-   * whose `connectClientId` the public read does not expose. The derived sentence is all
-   * that crosses; this pins the fixture ITSELF as shaped that way, so a future widening of
-   * the payload has to change this line and say why.
+  /*
+   * 🔴 THERE IS DELIBERATELY NO LEAK TEST HERE, and its absence is a correction rather
+   * than a gap. An earlier revision asserted `'connectClientId' in row` against this
+   * file's OWN `offer()` factory — no render, no production code — so it could not fail
+   * for any change under `src/`. A test that cannot go red is worse than no test, because
+   * it reads as coverage. The real guard is in
+   * `src/server/services/blocks/__tests__/app-ownership-transfer.inbox.test.ts`, which
+   * asserts the property on what the SERVICE actually returns, with the fixture's column
+   * present as its positive control. The shape claim this file can honestly make is now
+   * made by `tsc` instead: `TransferRow` IS `IncomingTransferRow`, so a `connectClientId`
+   * appearing on the payload would have to appear in the service's own type first.
    */
-  test('🔴 the payload carries a REASON, never the raw connectClientId', () => {
-    const row = offer({
-      transferId: 'aot_blocked',
-      acceptBlockedReason: CONNECT_CLIENT_TRANSFER_REFUSAL,
-    });
-    expect('connectClientId' in row).toBe(false);
-    // POSITIVE CONTROL: the field that DID replace it is present and non-empty, so the
-    // absence above is a shape claim rather than an empty object.
-    expect('acceptBlockedReason' in row).toBe(true);
-    expect(row.acceptBlockedReason).toBe(CONNECT_CLIENT_TRANSFER_REFUSAL);
-  });
 });
 
 describe('🔴 THE CONTROL ARM — an offer with no reason is untouched', () => {

--- a/src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx
+++ b/src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx
@@ -1,0 +1,425 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+import { CONNECT_CLIENT_TRANSFER_REFUSAL } from '~/shared/constants/app-transfer.constants';
+import type * as TrpcModule from '~/utils/trpc';
+
+/**
+ * `/apps/invites` — THE RECIPIENT'S OWNERSHIP-OFFER INBOX, DRIVEN FROM THE PAYLOAD.
+ *
+ * 🔴 THIS SUITE EXISTS BECAUSE THE VIEW WAS VERIFIED IN ISOLATION AND THE DEFECT LIVES IN
+ * THE SEAM. `AppTransferOffersView.browser.test.tsx` renders that component with hand-built
+ * props and proves every branch of it; #3935's owner-side equivalent did the same and
+ * stayed green for months while the app could never reach the state it asserted, because
+ * the refusal was passed IN AS A PROP. So nothing here passes a blocked prop. Every arm
+ * varies exactly ONE field on the `listMyPendingTransfers` payload — `acceptBlockedReason`
+ * — and the chain from there down is real: the page mounts `AppTransferOffers`, the
+ * container forwards the rows uncast, and the View decides what to render.
+ *
+ * WHAT IT PINS: a connect-linked off-site listing is refused at initiate AND re-asserted
+ * IN-TRANSACTION at accept, because a revision approve can link an OAuth client while an
+ * offer sits open. The recipient's card was therefore live, valid-looking, and guaranteed
+ * to fail — the refusal reached them only as a toast, after the click.
+ *
+ * 🔴 WHAT IT DOES **NOT** COVER, stated exactly rather than implied. The payload comes from
+ * the local `offer()` fixture below, NOT from the server, so the `tRPC proc → payload` hop
+ * is OUT of frame: deleting `connectClientId: true` from `listMyPendingTransfers`'s select,
+ * or dropping the derived field entirely, leaves this file green. That hop is covered by
+ * `src/server/services/blocks/__tests__/app-ownership-transfer.inbox.test.ts` (whose Prisma
+ * fake projects through the `select`) and, now that `IncomingTransferRow` is derived from
+ * the service's `IncomingTransferView` and the container's cast is gone, by `tsc`. Three
+ * instruments, three hops; no one of them sees all of it.
+ *
+ * 🔴 THE SERVER GATES ARE UNCHANGED AND REMAIN THE ENFORCEMENT. Everything below is an
+ * addition in front of them, running on data the client could lie to itself about.
+ */
+
+type TransferRow = {
+  transferId: string;
+  appListingId: string;
+  slug: string;
+  name: string;
+  kind: 'onsite' | 'offsite';
+  appBlockId: string | null;
+  iconUrl: string | null;
+  fromUserId: number;
+  expiresAt: Date;
+  createdAt: Date;
+  acceptBlockedReason: string | null;
+};
+
+const state = vi.hoisted(() => ({
+  /** The `listMyPendingTransfers` payload — THE ONLY THING ANY ARM VARIES. */
+  transfers: [] as unknown[],
+  /** Seat invites. Empty everywhere here; the transfer half is the subject. */
+  invites: [] as unknown[],
+  /** 🔴 Recorded and asserted EMPTY on every blocked arm. A blocked card must not submit. */
+  acceptCalls: [] as unknown[],
+  /** Recorded so DECLINE can be pinned as still wired, not merely still enabled. */
+  cancelCalls: [] as unknown[],
+}));
+
+// The page's `getServerSideProps` calls `createServerSideProps` at module top — stub it so
+// importing the page in a browser test doesn't pull the server graph (and `sharp`).
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  createServerSideProps: () => async () => ({ props: {} }),
+}));
+
+// `Meta` reads the app-wide BrowserRouter context, which `renderWithProviders` deliberately
+// does not mount. It contributes nothing to this suite's subject.
+vi.mock('~/components/Meta/Meta', () => ({
+  Meta: () => null,
+}));
+
+// Page chrome. `AppsSubNav` runs its own `blocks.getNavSummary` query, a session read and
+// the IsClient provider — none of which this suite is about.
+vi.mock('~/components/Apps/AppsSubNav', () => ({
+  AppsSubNav: () => <div data-testid="stub-subnav" />,
+}));
+
+// `UserAvatar` self-fetches over tRPC. Stubbed to a plain span so the offerer slot renders
+// without a data layer, exactly as the sibling suites do.
+vi.mock('~/components/UserAvatar/UserAvatar', () => ({
+  UserAvatar: ({ userId }: { userId: number }) => <span>user:{userId}</span>,
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+// Spread the REAL module and override only `trpc` (per `local-rules/no-wholesale-module-mock`):
+// a hand-written replacement silently drops any export a transitive importer needs, and the
+// whole file then fails to load as "0 tests collected" — green for the worst possible reason.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
+  const mutation = (record?: (args: unknown) => void) => ({
+    useMutation: () => ({
+      mutate: (args: unknown) => record?.(args),
+      isPending: false,
+      variables: undefined,
+    }),
+  });
+  return {
+    ...actual,
+    trpc: {
+      useUtils: () => ({
+        appCollaborators: {
+          listMyPendingTransfers: { invalidate: vi.fn().mockResolvedValue(undefined) },
+          listMyPendingInvites: { invalidate: vi.fn().mockResolvedValue(undefined) },
+        },
+        appListings: { listMine: { invalidate: vi.fn().mockResolvedValue(undefined) } },
+        blocks: { getNavSummary: { invalidate: vi.fn().mockResolvedValue(undefined) } },
+      }),
+      appCollaborators: {
+        listMyPendingTransfers: {
+          useQuery: () => ({ data: state.transfers, isLoading: false, error: null }),
+        },
+        listMyPendingInvites: {
+          useQuery: () => ({ data: state.invites, isLoading: false, error: null }),
+        },
+        // 🔴 Recorded, and asserted EMPTY on every blocked arm.
+        acceptTransfer: mutation((args) => state.acceptCalls.push(args)),
+        // DECLINE is `cancelTransfer` — either party may withdraw a pending offer.
+        cancelTransfer: mutation((args) => state.cancelCalls.push(args)),
+        respondToInvite: mutation(),
+      },
+    },
+  };
+});
+
+const AppInvitesPage = (await import('~/pages/apps/invites')).default;
+
+function offer(over: Partial<TransferRow> & { transferId: string }): TransferRow {
+  return {
+    appListingId: `apl-${over.transferId}`,
+    slug: `slug-${over.transferId}`,
+    name: `Name ${over.transferId}`,
+    kind: 'offsite',
+    appBlockId: null,
+    iconUrl: null,
+    fromUserId: 10,
+    expiresAt: new Date('2026-08-17T12:00:00Z'),
+    createdAt: new Date('2026-08-10T12:00:00Z'),
+    acceptBlockedReason: null,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  state.transfers = [];
+  state.invites = [];
+  state.acceptCalls = [];
+  state.cancelCalls = [];
+});
+
+describe('the payload fake honours its input (positive control)', () => {
+  /**
+   * 🔴 THE FAKE'S OWN CONTROL, deliberately NOT read through the feature under test. Every
+   * arm below distinguishes itself by ONE field on the payload this mock returns; if the
+   * mock served a frozen list regardless, the positive arm and the control arm would be
+   * reading the same rows and both could pass for reasons unrelated to the code.
+   *
+   * So: prove the payload REACHES the page and VARIES, using a rendered fact this change
+   * does not touch — the card is named after the listing, and the `kind` badge differs
+   * between an on-site and an off-site offer. Two payloads in, two different renders out.
+   */
+  test('the payload reaches the page and names the listing it carries', async () => {
+    state.transfers = [offer({ transferId: 'aot_1', name: 'Shiny Thing', kind: 'onsite' })];
+    renderWithProviders(<AppInvitesPage />);
+    const card = page.getByTestId('apps-transfer-aot_1');
+    await expect.element(card).toBeInTheDocument();
+    await expect.element(card).toHaveTextContent('Shiny Thing');
+    await expect.element(card).toHaveTextContent(/On-site app/i);
+  });
+
+  test('…and a different payload renders differently (same assertion, other shape)', async () => {
+    state.transfers = [offer({ transferId: 'aot_2', name: 'Other Thing', kind: 'offsite' })];
+    renderWithProviders(<AppInvitesPage />);
+    const card = page.getByTestId('apps-transfer-aot_2');
+    await expect.element(card).toBeInTheDocument();
+    await expect.element(card).toHaveTextContent('Other Thing');
+    await expect.element(card).toHaveTextContent(/External app/i);
+    // The card the OTHER arm rendered is not in this tree, so the two are genuinely
+    // distinct renders rather than one cached DOM read twice.
+    expect(page.getByTestId('apps-transfer-aot_1').elements()).toHaveLength(0);
+  });
+});
+
+describe('🔴 AN OFFER THE SERVER WILL REFUSE — said so before the click', () => {
+  /**
+   * The regression test. NO blocked prop is passed anywhere: the only input is
+   * `acceptBlockedReason` on the payload the page fetches.
+   */
+  test('the refusal is on screen, with the server’s reason intact', async () => {
+    state.transfers = [
+      offer({ transferId: 'aot_blocked', acceptBlockedReason: CONNECT_CLIENT_TRANSFER_REFUSAL }),
+    ];
+    renderWithProviders(<AppInvitesPage />);
+
+    const blocked = page.getByTestId('apps-transfer-blocked-aot_blocked');
+    await expect.element(blocked).toBeInTheDocument();
+    // VERBATIM against the SERVER's own constant — a paraphrase here would let the two
+    // sides drift, which is the whole reason the string lives in `shared/`.
+    await expect.element(blocked).toHaveTextContent(CONNECT_CLIENT_TRANSFER_REFUSAL);
+    // 🔴 `/split ownership/i`, and NOT `/cannot be transferred/i`. #3935 caught that
+    // tautology TWICE: the Alert chrome spells the "cannot be transferred" phrasing, so
+    // such a regex matches whatever the message body says. Assert on the BODY, which the
+    // title cannot supply.
+    await expect.element(blocked).toHaveTextContent(/split ownership/i);
+    // 🔴 AND IT INSTRUCTS NOTHING. There is no unlink path in the product — for the
+    // recipient least of all, who does not own the listing — so a remedy here would be a
+    // permanent dead end. Pinned on the RENDERED text, not just on the constant.
+    await expect.element(blocked).not.toHaveTextContent(/unlink/i);
+  });
+
+  /**
+   * 🔴 STATE, NOT SPELLING. A text match would be satisfied by any copy that happens to
+   * mention a refusal; this asserts the actual `disabled` attribute on the actual button.
+   */
+  test('Accept is DISABLED and Decline is NOT — the way out must stay open', async () => {
+    state.transfers = [
+      offer({ transferId: 'aot_blocked', acceptBlockedReason: CONNECT_CLIENT_TRANSFER_REFUSAL }),
+    ];
+    renderWithProviders(<AppInvitesPage />);
+
+    await expect.element(page.getByTestId('apps-transfer-accept-aot_blocked')).toBeDisabled();
+    // `cancelTransfer` carries no connect-client gate and admits either party, so
+    // withdrawing a dead offer is exactly the action that should still work. Disabling both
+    // would strand the recipient with a card they can neither accept nor clear.
+    await expect.element(page.getByTestId('apps-transfer-decline-aot_blocked')).toBeEnabled();
+  });
+
+  /**
+   * …and Decline is WIRED, not merely enabled. An enabled button that calls nothing looks
+   * identical in the DOM, so the mutation call is pinned by id.
+   */
+  test('clicking Decline calls cancelTransfer with THIS offer’s id, and never accepts', async () => {
+    state.transfers = [
+      offer({ transferId: 'aot_blocked', acceptBlockedReason: CONNECT_CLIENT_TRANSFER_REFUSAL }),
+    ];
+    renderWithProviders(<AppInvitesPage />);
+
+    const decline = page.getByTestId('apps-transfer-decline-aot_blocked');
+    await expect.element(decline).toBeInTheDocument();
+    await userEvent.click(decline.element());
+
+    expect(state.cancelCalls).toEqual([{ transferId: 'aot_blocked' }]);
+    expect(state.acceptCalls).toEqual([]);
+  });
+
+  /**
+   * 🔴 THE DISCLOSURE PANEL IS RETAINED ON A BLOCKED CARD — an operator decision, and a
+   * deliberate divergence from #3935, which suppressed the owner-side equivalent.
+   *
+   * Two reasons. It is a load-bearing IDENTITY marker: the pair test in
+   * `src/components/Apps/AppTransferOffersView.browser.test.tsx` names this panel as one of
+   * three things stopping an irreversible ownership transfer from reading like a reversible
+   * seat invite, and dropping it on some cards makes that property conditional on data.
+   * And unlike the owner's suppressed copy — which described MECHANICS of a transfer that
+   * can never start — this describes what the offer WAS FOR, which is precisely what the
+   * recipient still needs in order to decide to decline it.
+   *
+   * INVARIANT GUARD, labelled: this passes on `origin/main` too, because main renders the
+   * panel on every card. It is here to pin the KEEP decision against a future "tidy up the
+   * blocked card", not as regression coverage for the shipped defect — the three tests
+   * above are that.
+   */
+  test('the "what accepting does" disclosure is STILL SHOWN on a blocked card', async () => {
+    state.transfers = [
+      offer({
+        transferId: 'aot_blocked',
+        kind: 'onsite',
+        appBlockId: 'ab_1',
+        acceptBlockedReason: CONNECT_CLIENT_TRANSFER_REFUSAL,
+      }),
+    ];
+    renderWithProviders(<AppInvitesPage />);
+
+    const warning = page.getByTestId('apps-transfer-warning-aot_blocked');
+    await expect.element(warning).toBeInTheDocument();
+    await expect.element(warning).toHaveTextContent(/current owner loses ownership/i);
+    await expect.element(warning).toHaveTextContent(/become the owner/i);
+    // The badge and section that complete the same identity trio are still there too.
+    await expect
+      .element(page.getByTestId('apps-transfer-badge-aot_blocked'))
+      .toHaveTextContent(/Ownership transfer/i);
+    await expect
+      .element(page.getByTestId('apps-transfers-section'))
+      .toHaveTextContent(/Ownership transfers/i);
+  });
+
+  /**
+   * 🔴 THE CARD IS BLOCKED, NOT HIDDEN. Suppressing the row was considered and rejected:
+   * `initiateTransfer` fires a notification pointing at `/apps/invites`, so hiding it makes
+   * that notification land on a page rendering nothing, removes the recipient's only
+   * action, and leaves the owner's own tab (which still shows the offer) disagreeing with
+   * this one about whether an offer exists.
+   */
+  test('the offer still renders as an offer — name, deadline and all', async () => {
+    state.transfers = [
+      offer({
+        transferId: 'aot_blocked',
+        name: 'Connected Thing',
+        acceptBlockedReason: CONNECT_CLIENT_TRANSFER_REFUSAL,
+      }),
+    ];
+    renderWithProviders(<AppInvitesPage />);
+
+    const card = page.getByTestId('apps-transfer-aot_blocked');
+    await expect.element(card).toBeInTheDocument();
+    await expect.element(card).toHaveTextContent('Connected Thing');
+    await expect
+      .element(page.getByTestId('apps-transfer-expiry-aot_blocked'))
+      .toHaveTextContent('Aug 17, 2026');
+    await expect.element(page.getByTestId('apps-transfer-offerer-aot_blocked')).toBeInTheDocument();
+  });
+
+  /**
+   * 🔴 THE RAW COLUMN NEVER REACHES THIS SURFACE. The recipient holds no role on the
+   * listing and the inbox read has no status gate, so an offer can sit on a `draft` listing
+   * whose `connectClientId` the public read does not expose. The derived sentence is all
+   * that crosses; this pins the fixture ITSELF as shaped that way, so a future widening of
+   * the payload has to change this line and say why.
+   */
+  test('🔴 the payload carries a REASON, never the raw connectClientId', () => {
+    const row = offer({
+      transferId: 'aot_blocked',
+      acceptBlockedReason: CONNECT_CLIENT_TRANSFER_REFUSAL,
+    });
+    expect('connectClientId' in row).toBe(false);
+    // POSITIVE CONTROL: the field that DID replace it is present and non-empty, so the
+    // absence above is a shape claim rather than an empty object.
+    expect('acceptBlockedReason' in row).toBe(true);
+    expect(row.acceptBlockedReason).toBe(CONNECT_CLIENT_TRANSFER_REFUSAL);
+  });
+});
+
+describe('🔴 THE CONTROL ARM — an offer with no reason is untouched', () => {
+  /**
+   * 🔴 AS IMPORTANT AS THE POSITIVE ARM. Without it, "disable every Accept" and "render the
+   * banner always" trivially satisfy everything above and ship an inbox where no offer can
+   * ever be accepted.
+   *
+   * PASSES ON `origin/main` TOO, and that is what a control arm is FOR rather than a
+   * weakness in it — main also rendered an enabled Accept here. Its job is to go red the
+   * moment the fix over-reaches, which the mutation battery confirms it does.
+   */
+  test('Accept is ENABLED, and no refusal banner is rendered', async () => {
+    state.transfers = [offer({ transferId: 'aot_ok', acceptBlockedReason: null })];
+    renderWithProviders(<AppInvitesPage />);
+
+    const accept = page.getByTestId('apps-transfer-accept-aot_ok');
+    await expect.element(accept).toBeInTheDocument();
+    await expect.element(accept).toBeEnabled();
+    // Absence, with the awaited present element above as its positive control —
+    // `locator.elements()` is SYNCHRONOUS, so an emptiness asserted straight after render
+    // passes whatever the component does.
+    expect(page.getByTestId('apps-transfer-blocked-aot_ok').elements()).toHaveLength(0);
+  });
+
+  /** …and Accept is WIRED, so "enabled" is not a button that quietly does nothing. */
+  test('clicking Accept calls acceptTransfer with THIS offer’s id', async () => {
+    state.transfers = [offer({ transferId: 'aot_ok', acceptBlockedReason: null })];
+    renderWithProviders(<AppInvitesPage />);
+
+    const accept = page.getByTestId('apps-transfer-accept-aot_ok');
+    await expect.element(accept).toBeInTheDocument();
+    await userEvent.click(accept.element());
+
+    expect(state.acceptCalls).toEqual([{ transferId: 'aot_ok' }]);
+  });
+});
+
+describe('🔴 A MIXED INBOX — the arm that kills "disable every Accept"', () => {
+  /**
+   * 🔴 THE DECISIVE ARM. Every other test here renders ONE card, and a fix that blocked the
+   * whole section rather than the offending row would satisfy the positive arms and the
+   * control arms alike, each in its own render. Only both rows in ONE tree can tell
+   * "per-offer" from "per-page".
+   *
+   * The two rows differ in EXACTLY one field. Same kind, same offerer, same deadline — so
+   * nothing else in the payload can explain a difference in what renders.
+   */
+  test('the blocked offer is refused and the healthy one beside it is not', async () => {
+    state.transfers = [
+      offer({ transferId: 'aot_blocked', acceptBlockedReason: CONNECT_CLIENT_TRANSFER_REFUSAL }),
+      offer({ transferId: 'aot_ok', acceptBlockedReason: null }),
+    ];
+    renderWithProviders(<AppInvitesPage />);
+
+    // Both cards are in this ONE tree — the combined state, not two isolated renders.
+    await expect.element(page.getByTestId('apps-transfer-aot_blocked')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-transfer-aot_ok')).toBeInTheDocument();
+
+    await expect.element(page.getByTestId('apps-transfer-blocked-aot_blocked')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-transfer-accept-aot_blocked')).toBeDisabled();
+
+    await expect.element(page.getByTestId('apps-transfer-accept-aot_ok')).toBeEnabled();
+    expect(page.getByTestId('apps-transfer-blocked-aot_ok').elements()).toHaveLength(0);
+  });
+
+  /**
+   * …and the healthy one is still SUBMITTABLE from that same tree, while the blocked one
+   * contributes nothing. `toBeEnabled()` is a DOM state; this is the behaviour.
+   */
+  test('the healthy offer still submits, and the blocked one never does', async () => {
+    state.transfers = [
+      offer({ transferId: 'aot_blocked', acceptBlockedReason: CONNECT_CLIENT_TRANSFER_REFUSAL }),
+      offer({ transferId: 'aot_ok', acceptBlockedReason: null }),
+    ];
+    renderWithProviders(<AppInvitesPage />);
+
+    const okAccept = page.getByTestId('apps-transfer-accept-aot_ok');
+    await expect.element(okAccept).toBeInTheDocument();
+    await userEvent.click(okAccept.element());
+    // Clicking the disabled one is a no-op in a real browser; asserting it explicitly is
+    // what makes "disabled" mean "cannot submit" rather than "looks greyed out".
+    await userEvent.click(page.getByTestId('apps-transfer-accept-aot_blocked').element(), {
+      force: true,
+    });
+
+    expect(state.acceptCalls).toEqual([{ transferId: 'aot_ok' }]);
+  });
+});

--- a/src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx
+++ b/src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx
@@ -37,10 +37,14 @@ import type * as TrpcModule from '~/utils/trpc';
  *
  * The SHAPE of the payload is not out of frame, though — not any more. `TransferRow` is
  * `IncomingTransferRow`, so deleting `acceptBlockedReason` from the service's
- * `IncomingTransferView` is now 9 `tsc` errors IN THIS FILE (measured; it was ZERO while
- * the fixture carried its own hand-written type, which is the anti-pattern this PR removes
- * from the container). Two instruments, two different hops — a `select` line and a field —
- * and neither sees the other's.
+ * `IncomingTransferView` now FAILS TO COMPILE IN THIS FILE, under BOTH `tsconfig.json` and
+ * `tsconfig.tests.json`. Measured, and the load-bearing part is the transition rather than
+ * the size: it was ZERO errors here while the fixture carried its own hand-written type —
+ * the anti-pattern this PR removes from the container. (An earlier version of this comment
+ * quoted an exact count. It rotted within one commit, which is the argument against putting
+ * a number here at all: the invariant is "this file notices", not "this file emits N".)
+ * Two instruments, two different hops — a `select` line and a field — and neither sees the
+ * other's.
  *
  * 🔴 THE SERVER GATES ARE UNCHANGED AND REMAIN THE ENFORCEMENT. Everything below is an
  * addition in front of them, running on data the client could lie to itself about.
@@ -228,9 +232,11 @@ describe('🔴 AN OFFER THE SERVER WILL REFUSE — said so before the click', ()
     // such a regex matches whatever the message body says. Assert on the BODY, which the
     // title cannot supply.
     await expect.element(blocked).toHaveTextContent(/split ownership/i);
-    // 🔴 AND IT INSTRUCTS NOTHING. There is no unlink path in the product — for the
-    // recipient least of all, who does not own the listing — so a remedy here would be a
-    // permanent dead end. Pinned on the RENDERED text, not just on the constant.
+    // 🔴 AND IT INSTRUCTS NOTHING. Note the reason is NOT "no unlink path exists" — one
+    // does (deleting the OAuth client cascades `SetNull`); that premise is refuted and the
+    // View's comment records it. The reason is that the RECIPIENT cannot take it: they own
+    // neither the listing nor the client, so a remedy addressed to them is a dead end
+    // whatever the owner can do. Pinned on the RENDERED text, not just on the constant.
     await expect.element(blocked).not.toHaveTextContent(/unlink/i);
   });
 
@@ -341,6 +347,51 @@ describe('🔴 AN OFFER THE SERVER WILL REFUSE — said so before the click', ()
     await expect.element(page.getByTestId('apps-transfer-accept-aot_empty')).toBeDisabled();
     // …and Decline stays the way out, exactly as on a normally-blocked card.
     await expect.element(page.getByTestId('apps-transfer-decline-aot_empty')).toBeEnabled();
+  });
+
+  /**
+   * 🔴 A MISSING FIELD MUST FAIL **OPEN** — the deploy-skew arm, and the one case the type
+   * system cannot describe, which is exactly why it needs a test.
+   *
+   * The bundle and the tRPC API are served by pools that roll INDEPENDENTLY, so every
+   * deploy passes through a window where this component runs against an API that predates
+   * `acceptBlockedReason`. The field then arrives ABSENT, not `null`. Under a strict
+   * `!== null` the card scores as BLOCKED: every pending offer refused, with an empty
+   * explanation, for offers that are perfectly fine — and since the banner is otherwise
+   * unreachable, that mid-roll false refusal would be the only time a real user ever saw
+   * it. Under `!= null` the card is ordinary and the server stays the enforcement, which
+   * is the direction that cannot invent a refusal.
+   *
+   * 🔴 THE CAST IS THE POINT, not a shortcut. `TransferRow` correctly forbids a missing
+   * field, so the only way to express "what an older server actually sends" is to step
+   * outside the type — a payload the CURRENT contract cannot produce and a PREVIOUS one
+   * did. Deleting the cast would delete the scenario.
+   *
+   * 🔴 CONTROL / INVARIANT GUARD, LABELLED — this PASSES at `origin/main`, and measured so
+   * rather than assumed (5 failed / 8 passed at base; this arm is one of the 8). It passes
+   * there for a trivial reason: base has no banner and no disable at all, so an absent
+   * field is acceptable by construction. It is therefore NOT regression coverage for the
+   * shipped defect — the arms above are. Its job is to hold the fail-OPEN direction against
+   * a future tightening, and mutant (q) (`!= null` → `!== null`) is what earns it: (q) dies
+   * here and NOWHERE else in the suite.
+   */
+  test('🔴 an ABSENT reason (old API, new bundle) leaves the offer ACCEPTABLE — fail open', async () => {
+    const legacyRow = offer({ transferId: 'aot_legacy' }) as Partial<TransferRow>;
+    delete legacyRow.acceptBlockedReason;
+    expect('acceptBlockedReason' in legacyRow).toBe(false);
+    state.transfers = [legacyRow as TransferRow];
+    renderWithProviders(<AppInvitesPage />);
+
+    // Positive control FIRST: the card rendered at all, so the absences below are real
+    // absences and not an un-awaited render (`elements()` is synchronous).
+    const accept = page.getByTestId('apps-transfer-accept-aot_legacy');
+    await expect.element(accept).toBeInTheDocument();
+    await expect.element(accept).toBeEnabled();
+    expect(page.getByTestId('apps-transfer-blocked-aot_legacy').elements()).toHaveLength(0);
+
+    // …and it genuinely submits, so "enabled" is not a button that quietly does nothing.
+    await userEvent.click(accept.element());
+    expect(state.acceptCalls).toEqual([{ transferId: 'aot_legacy' }]);
   });
 
   test('the offer still renders as an offer — name, deadline and all', async () => {


### PR DESCRIPTION
> **What this is, stated up front: CHEAP GAP-CLOSURE AHEAD OF TRAFFIC, not a live bug fix.**
> There are **zero rows in the transfers table in production — not zero pending, zero ever** —
> and the blocked state this PR surfaces is **not reachable through the product today** (see
> *Reachability*, below, which corrects an earlier claim in this description). What it closes
> is a gap #3935 recorded in a code comment, on the cheap, while that PR's template is fresh
> and before the feature gets traffic.

The owner half shipped in #3935. The recipient half was recorded there as an explicitly OPEN
gap, in a comment on `AppCollaboratorsPanelView`: *"the RECIPIENT's surfaces carry no
connect-client awareness at all, so an addressee still sees a normal-looking offer and meets
the refusal only on clicking accept"*. This closes it.

A connect-linked off-site listing can never have its ownership transferred.
`initiateTransfer` refuses it, and `acceptTransfer` re-asserts the same predicate
IN-TRANSACTION. So an offer in `/apps/invites` can in principle be live, in date, addressed
to you, indistinguishable from any other, and guaranteed to fail — and the inbox could not
know, because `listMyPendingTransfers` did not read the column, so the fact could not cross
the wire at all.

## The fix

- `listMyPendingTransfers` selects `connectClientId` off the joined listing and derives
  `acceptBlockedReason: string | null` from it, using the SAME
  `refusesTransferForConnectClient` and the SAME `CONNECT_CLIENT_TRANSFER_REFUSAL` the two
  server gates use. One rule, now four callers.
- The View renders that reason as a warning Alert on the card, disables Accept, and leaves
  Decline enabled and wired.
- Both server gates are UNCHANGED and remain the enforcement. This is an addition in front
  of them, never a replacement, and it runs on data the client could lie to itself about.

🔴 **A DERIVED REASON, NOT THE RAW COLUMN** — deliberately diverging from #3935's owner-side
shape. That change carried `connectClientId` itself, arguing it is public via the approved
listing-detail read. The argument does not carry over: a pending offeree holds NO role on
the listing, and this read imposes no status gate, so an offer can sit on a draft/pending
listing whose client id the public read never exposes. Shipping the column would be a NEW
disclosure on exactly those rows, to the least privileged reader in the feature, for a value
they cannot act on. They can only read the sentence, so the sentence is what crosses.

🔴 **ACCEPT DISABLED, DECLINE ENABLED.** `cancelTransfer` — which is how a recipient declines
— carries no connect-client gate and admits either party, so getting out of a dead offer is
exactly the action that must still work. Disabling both would strand them with a card they
can neither accept nor clear. Blocked, not hidden: suppressing the row would make the
`initiateTransfer` notification land on a page rendering nothing, and would leave the owner's
tab (which still shows the offer) disagreeing with this one about whether it exists.

🔴 **THE DISCLOSURE PANEL IS KEPT ON A BLOCKED CARD**, unlike the owner-side equivalent #3935
suppressed. Operator decision; provenance and reasoning are in a separate comment on this PR.
It is a load-bearing identity marker — the existing pair test names it as one of three things
stopping an irreversible transfer from reading like a reversible seat invite — and unlike the
owner's suppressed copy, which described MECHANICS of a transfer that can never start, it
describes what the offer WAS FOR, which is what the recipient needs in order to decide to
decline.

🔴 **ONE PREDICATE FOR THE TWO BRANCHES, AND IT FAILS OPEN.** The banner and the Accept
button read `acceptBlockedReason` through a single `blocked` test. They previously used
`? …` and `!= null` respectively, which agree on today's two values and diverge on `''` —
Accept disabled with no explanation rendered. Pinned behaviourally by an arm that feeds the
empty string on the payload, not by a comment.

The test is the **loose** `!= null`, deliberately. Strict `!== null` scores an **absent**
field as blocked, and the bundle and the tRPC API are served by pools that **roll
independently** — so every deploy passes through a window where this component runs against
an API that predates the field. Under strict, that window refuses *every* pending offer with
an empty explanation; and since the banner is otherwise unreachable, it would be the only
time a real user ever saw it. Failing open is the right direction: the server refuses an
unacceptable transfer regardless, so a missed banner costs one honest error toast while a
false banner blocks a transfer that would have succeeded. Pinned by an arm that deletes the
field from the row, and by a mutant that re-tightens the comparison.

## Reachability — CORRECTED

An earlier version of this description (and of the issue) said the blocked state arises
because **a revision approve can link an OAuth client while an offer sits open**. That was
inherited prose and it is **not substantiated by the code**. An enumeration of every writer of
`AppListing.connectClientId` across `src/`, `packages/` and `apps/`:

- the only non-null write is `submitExternalListing`'s `create` of a **brand-new row**. What
  makes it mandatory there is the **zod input** (`submitExternalListingSchema`), **not the
  database** — the Prisma column is `connectClientId String?`, nullable with no default.
  (An earlier version of this description said "the schema makes the field required", which
  reads as `schema.prisma` and is false; it also points a reader the wrong way, per the next
  paragraph.) Either way: a listing is **born** linked;
- `beginListingRevision` copies parent → shadow and the approve merge copies shadow → parent;
  in between, `buildListingPatchData` never assigns the column and `updateListingPatchSchema`
  has no such key, so the round trip returns the value it started with;
- no raw SQL, no nested relation write, no spread writes it (each checked; zero hits).

So a listing cannot **acquire** a link, and `initiateTransfer` refuses to open an offer on one
born with it. **The blocked state is not producible through the product as it stands** — it
needs a direct DB write, a migration, or a future **link** flow.

### …but there is a fifth writer, and it lives in the schema

A later review found one the enumeration above **structurally cannot see**. The relation is
declared `onDelete: SetNull`, so deleting the `OauthClient` row issues
`UPDATE app_listings SET connect_client_id = NULL` on every listing referencing it — and
`oauth-client.router::delete` performs exactly that delete with **no referencing-listing
check** (its only guard, `rejectAppBlockClient`, covers AppBlock clients, which these are
not). That is a **product-reachable, owner-initiated unlink that exists today**, and no grep
over `data:` payloads or raw SQL would ever find it, because the writer is a **referential
action in the schema**, not a call site.

It does **not** change the conclusion: a `SetNull` only moves the column non-null → null, so
it can only ever *unblock*. Two consequences worth recording:

- "it needs … a future **unlink**/link flow" was wrong — an unlink route already exists.
- `acceptBlockedReason` can go **stale in the safe direction**: an offer rendered blocked
  whose client was deleted since the read would now succeed on accept. A stale block is a
  delay; a stale allow would be a lie, and this cascade cannot produce one.

*(Remaining caveat: the enumeration is otherwise textual plus call-site based, so it would
also miss a fully dynamic key or a runtime-assembled raw `UPDATE`. Neither construct exists.)*

### 🔴 A premise this PR inherited is refuted — flagging, not fixing

`CONNECT_CLIENT_TRANSFER_REFUSAL`'s rationale in `src/shared/constants/app-transfer.constants.ts`
says *"there is no unlink path"*, and that is the stated reason #3935 dropped
"Unlink the OAuth client first" from the user-facing string. The fifth writer above disproves
it: an owner **can** unlink, by deleting the client.

**No user-facing copy is changed in this PR.** Whether the owner's message should now name
that route is a product decision, and it should be made deliberately rather than inherited
from a premise that turned out to be false. What is still true — and is why the recipient's
copy stands either way — is that the **recipient** cannot unlink: they own neither the listing
nor the client, so a remedy addressed to them remains a dead end. My own two comments that
repeated the false premise are corrected; the constant's is left in place and flagged here.

That is a reason to ship this as gap-closure, not a reason to skip it: the accept-time
re-assert is correct defence-in-depth either way, and `offsite-listing.service.ts` already
anticipates a link flow in two (now-stale) comments at `:2273` and `:2573`. When one lands,
this field is already the channel that tells the recipient — instead of a second
learn-it-by-clicking defect to find later. Those two inherited comments are deliberately left
alone here and flagged as a follow-up.

## Two prerequisites, without which the new tests would have been vacuous

**1. The container cast.** `AppTransferOffers.tsx` cast `as IncomingTransferRow[]` against a
hand-written structural duplicate. A cast to a wider type is legal, so a field the service
never sends compiled clean at exactly the hop where the drift is invisible at runtime too —
the same hole #3935 fixed on `edit.tsx` (F3). `IncomingTransferRow` is now
`Omit<IncomingTransferView, 'expiresAt'|'createdAt'>` plus the two widened date fields, and
the cast is gone.

Measured both ways: deleting `acceptBlockedReason` from the service is now **15 `tsc` errors**
(TS2339 at the View, plus 9 in the new browser suite once its fixture was pinned too), and
compiled with **zero** type errors under the old duplicate-plus-cast shape.

The dates are widened rather than inherited because what arrives depends on the union
transformer. Probed rather than assumed: `transfersQuery.data[0].expiresAt` types as `Date` at
the client (assigning it to `Date` compiles, to `string` is TS2322), so the widening is a
superset that costs nothing and forced no change of shape.

**2. The inbox test fake.** It filtered on `where` and returned the WHOLE fixture row, so a
`select` was unobservable and the mutant deleting `connectClientId: true` survived the suite.
It now projects recursively through `select` — an unselected column is ABSENT, the way Prisma
returns it — with its own positive control, including a nested-relation arm. Measured: with
the old non-projecting fake, that deletion leaves all four `acceptBlockedReason` verdict tests
**green**.

## Coverage

The new browser suite drives from the PAYLOAD, never from a prop. #3935's pre-existing panel
test passed the refusal in as `transferErrorMessage` and stayed green while the app could not
reach that state; every arm here varies exactly one field on the `listMyPendingTransfers`
payload and renders the real page, so page → container → View is real. The Alert is asserted
on its message BODY (`/split ownership/i`), never on `/cannot be transferred/i` which the
Alert's own chrome would spell.

- **Red at base** (`242cd0bfc4`): 5 of 13 browser tests, 6 of 18 inbox tests.
- **17 mutants, 17 killed.** The decisive one is the SEAM — the container stops forwarding the
  field — which the browser suite kills (5 failures) and the server suite cannot see by
  construction (18/18 green). The disclosure-retention guard is likewise invisible to the
  isolated View suite (15/15 green) and killed only by the page-level one.
- The control arms (`acceptBlockedReason: null` → Accept enabled, no banner; the disclosure
  panel present) PASS at base by design and are labelled as controls, not counted as
  regression coverage. Mutants (h), (i), (j) and (k) are what earn them their place.

Full measured matrix, gate results and an explicit "not verified" list are in the comments.
