### PR TITLE
fix(apps): notify the owner when a moderator delists an on-site listing

### DIFF
--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -315,6 +315,11 @@ describe('delistListing', () => {
     const OFFSITE_OWNER = 722;
     const OFFSITE_REASON = 'destination page collects card details';
 
+    const LOCKED_ID = 'apl_locked_target';
+    const LOCKED_SLUG = 'self-pulled-widget';
+    const LOCKED_OWNER = 833;
+    const LOCKED_REASON = 'confirmed trademark impersonation';
+
     it('ON-SITE: notifies the owner with app-listing-hidden carrying the mod reason', async () => {
       mockRead.appListing.findUnique.mockResolvedValueOnce({
         ...onsiteListing('approved'),
@@ -355,6 +360,42 @@ describe('delistListing', () => {
         where: { id: BLOCK_ID, status: 'approved' },
         data: { status: 'suspended' },
       });
+    });
+
+    /**
+     * 🔴 The pre-state is `removed`, NOT `approved` — this is the ENFORCED-TAKEDOWN
+     * variant: the owner had self-unpublished, and this delist makes the last event a
+     * mod takedown, which is what permanently forbids `republishOwnListing`. It is the
+     * delist the owner most needs told about, and it is the case a status-gated notify
+     * would silently skip while every `approved`-pre-state test stayed green.
+     */
+    it('ON-SITE, already REMOVED: the enforced-takedown delist still notifies the owner', async () => {
+      mockRead.appListing.findUnique.mockResolvedValueOnce({
+        ...onsiteListing('removed'),
+        id: LOCKED_ID,
+        slug: LOCKED_SLUG,
+        name: 'Self Pulled Widget',
+        userId: LOCKED_OWNER,
+      });
+
+      await delistListing({
+        input: { appListingId: LOCKED_ID, reason: LOCKED_REASON },
+        reviewerUserId: REVIEWER,
+      });
+
+      expect(mockNotify).toHaveBeenCalledTimes(1);
+      expect(mockNotify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'app-listing-hidden',
+          userId: LOCKED_OWNER,
+          details: expect.objectContaining({
+            slug: LOCKED_SLUG,
+            name: 'Self Pulled Widget',
+            listingId: LOCKED_ID,
+            reason: LOCKED_REASON,
+          }),
+        })
+      );
     });
 
     it('OFF-SITE: still notifies its own owner with its own reason (pinned, not dropped)', async () => {

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -261,7 +261,7 @@ describe('delistListing', () => {
     expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
   });
 
-  it('ON-SITE delist flips BOTH app_listings AND the backing app_blocks in one tx (no owner notif)', async () => {
+  it('ON-SITE delist flips BOTH app_listings AND the backing app_blocks in one tx (+ notifies the owner)', async () => {
     mockRead.appListing.findUnique.mockResolvedValueOnce(onsiteListing('approved'));
     const res = await delistListing({
       input: { appListingId: APP_ID, reason: GOOD_REASON },
@@ -281,8 +281,131 @@ describe('delistListing', () => {
     // Still exactly one audit event.
     expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
     expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data.action).toBe('delist');
-    // ON-SITE owners are NOT notified in Phase 1.
-    expect(mockNotify).not.toHaveBeenCalled();
+    // ON-SITE hide → the owner is notified too (the block was just suspended, so the
+    // hosted app went dark — that is the case that most needs a signal).
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'app-listing-hidden',
+        userId: OWNER,
+        details: expect.objectContaining({ slug: SLUG, reason: GOOD_REASON }),
+      })
+    );
+  });
+
+  /**
+   * 🔴 REGRESSION (owner-notified-on-delist, both kinds).
+   *
+   * A mod delist used to notify the OFF-SITE owner only; an on-site delist fired zero
+   * notifications while ALSO suspending the backing block, so the author's hosted app
+   * went dark with no signal. Both kinds now notify.
+   *
+   * The two cases carry pairwise-DISTINCT listing ids, slugs, owners and reasons so a
+   * mutant that hardcodes either kind's payload (or re-notifies the wrong owner) cannot
+   * satisfy both assertions.
+   */
+  describe('🔴 the owner is notified on delist — for BOTH kinds', () => {
+    const ONSITE_ID = 'apl_onsite_target';
+    const ONSITE_SLUG = 'hosted-widget';
+    const ONSITE_OWNER = 611;
+    const ONSITE_REASON = 'ships an unreviewed third-party payload';
+
+    const OFFSITE_ID = 'apl_offsite_target';
+    const OFFSITE_SLUG = 'external-tool';
+    const OFFSITE_OWNER = 722;
+    const OFFSITE_REASON = 'destination page collects card details';
+
+    it('ON-SITE: notifies the owner with app-listing-hidden carrying the mod reason', async () => {
+      mockRead.appListing.findUnique.mockResolvedValueOnce({
+        ...onsiteListing('approved'),
+        id: ONSITE_ID,
+        slug: ONSITE_SLUG,
+        name: 'Hosted Widget',
+        userId: ONSITE_OWNER,
+      });
+
+      await delistListing({
+        input: { appListingId: ONSITE_ID, reason: ONSITE_REASON },
+        reviewerUserId: REVIEWER,
+      });
+
+      expect(mockNotify).toHaveBeenCalledTimes(1);
+      expect(mockNotify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'app-listing-hidden',
+          userId: ONSITE_OWNER,
+          details: expect.objectContaining({
+            slug: ONSITE_SLUG,
+            name: 'Hosted Widget',
+            listingId: ONSITE_ID,
+            reason: ONSITE_REASON,
+          }),
+        })
+      );
+      // Same-event idempotency key, so a repeat of the SAME hide notifies once.
+      const { key } = mockNotify.mock.calls[0][0];
+      expect(key).toMatch(/^app-listing-hidden:/);
+      // The key is bound to the audit event this delist wrote, not to a fresh nonce.
+      expect(key).toBe(
+        `app-listing-hidden:${mockWrite.appListingModerationEvent.create.mock.calls[0][0].data.id}`
+      );
+      // The backing block really was suspended in the same action (this is WHY the
+      // on-site owner needs the notification).
+      expect(mockWrite.appBlock.updateMany).toHaveBeenCalledWith({
+        where: { id: BLOCK_ID, status: 'approved' },
+        data: { status: 'suspended' },
+      });
+    });
+
+    it('OFF-SITE: still notifies its own owner with its own reason (pinned, not dropped)', async () => {
+      mockRead.appListing.findUnique.mockResolvedValueOnce({
+        ...offsiteListing('approved'),
+        id: OFFSITE_ID,
+        slug: OFFSITE_SLUG,
+        name: 'External Tool',
+        userId: OFFSITE_OWNER,
+      });
+
+      await delistListing({
+        input: { appListingId: OFFSITE_ID, reason: OFFSITE_REASON },
+        reviewerUserId: REVIEWER,
+      });
+
+      expect(mockNotify).toHaveBeenCalledTimes(1);
+      expect(mockNotify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'app-listing-hidden',
+          userId: OFFSITE_OWNER,
+          details: expect.objectContaining({
+            slug: OFFSITE_SLUG,
+            name: 'External Tool',
+            listingId: OFFSITE_ID,
+            reason: OFFSITE_REASON,
+          }),
+        })
+      );
+      // No backing block on the off-site path.
+      expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('a guarded (0-count) ON-SITE delist notifies NOBODY — the rollback covers the notification', async () => {
+      mockRead.appListing.findUnique.mockResolvedValueOnce({
+        ...onsiteListing('approved'),
+        id: ONSITE_ID,
+        slug: ONSITE_SLUG,
+        userId: ONSITE_OWNER,
+      });
+      mockWrite.appListing.updateMany.mockResolvedValueOnce({ count: 0 });
+
+      await expect(
+        delistListing({
+          input: { appListingId: ONSITE_ID, reason: ONSITE_REASON },
+          reviewerUserId: REVIEWER,
+        })
+      ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'NOT_TRANSITIONABLE' });
+
+      expect(mockNotify).not.toHaveBeenCalled();
+    });
   });
 
   it('a status-guarded 0-count (concurrently moved out of {approved,removed}, e.g. to draft/pending) → NOT_TRANSITIONABLE, ZERO events', async () => {

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -304,7 +304,7 @@ async function classifyOffsiteListing(
  * BOTH kinds, unlike claim/purge which stay offsite-only via `classifyOffsiteListing`).
  * Returns the fields those actions need: kind (to branch the on-site dual-table flip),
  * status/slug, the backing `appBlockId` (on-site: flip the block's status too), and
- * the owner `userId` (the off-site hide notification target). A missing listing →
+ * the owner `userId` (the hide-notification target, for either kind). A missing listing →
  * generic NOT_FOUND (no kind guard here — both kinds are valid targets).
  */
 async function classifyListingForAction(appListingId: string): Promise<{
@@ -377,16 +377,20 @@ export type DelistListingResult = { appListingId: string; status: 'removed' };
  * post-approval mgmt). The store read path is approved-only, so a `removed` listing
  * drops out of `listAvailableListings` + `getListingDetail` automatically.
  *
- *   - OFF-SITE: flip only `app_listings.status` approved → removed, then notify the
- *     owner their app was hidden (post-commit, carrying the mod reason).
+ *   - OFF-SITE: flip only `app_listings.status` approved → removed.
  *   - ON-SITE: flip BOTH `app_listings.status` (approved → removed) AND the backing
  *     `app_blocks.status` (approved → suspended) in the SAME tx — a hosted block's
  *     runtime serving gate reads `app_blocks.status`, so hiding it from the store
- *     WITHOUT suspending the block would leave `<slug>.civit.ai` still serving. No
- *     owner notification on the on-site path (out of Phase-1 scope). The listing
- *     flip is the authoritative guard; the block flip is status-guarded to avoid
- *     clobbering a drifted state but is non-fatal on a 0-count (the store status is
- *     the source of truth for visibility).
+ *     WITHOUT suspending the block would leave the hosted app still serving. The
+ *     listing flip is the authoritative guard; the block flip is status-guarded to
+ *     avoid clobbering a drifted state but is non-fatal on a 0-count (the store
+ *     status is the source of truth for visibility).
+ *
+ * BOTH kinds then notify the owner their app was hidden (post-commit, carrying the
+ * mod reason). The on-site owner is notified for the SAME reason the off-site one is,
+ * and more urgently: an on-site delist also suspends the backing block, so the hosted
+ * app goes dark. The owner's submissions/history view already renders the mod reason
+ * for both kinds — the notification is what tells them to go look.
  *
  * STATUS: a delist is allowed on an `approved` OR an already-`removed` listing. The
  * `removed → removed` case is the 🔴 "convert an owner-hide into an ENFORCED takedown"
@@ -463,18 +467,19 @@ export async function delistListing(opts: {
     }
   });
 
-  // OFF-SITE only: post-commit, best-effort — notify the owner their app was hidden,
-  // carrying the mod reason. (On-site owners aren't notified in Phase 1.)
-  if (!isOnsite) {
-    await notifyAppListingOwner({
-      type: 'app-listing-hidden',
-      userId: listing.userId,
-      // Keyed by the audit event id so each distinct hide (delist→relist→delist)
-      // notifies once, without a fresh nonce.
-      key: `app-listing-hidden:${eventId}`,
-      details: { slug: listing.slug, name: listing.name, listingId: input.appListingId, reason },
-    });
-  }
+  // BOTH KINDS: post-commit, best-effort — notify the owner their app was hidden,
+  // carrying the mod reason. An on-site delist is the MORE adverse of the two (it also
+  // suspends the backing block, so the hosted app stops serving), so withholding the
+  // notification there left the owner with no signal at all that their app went dark.
+  // The reason is mandatory on delist and is what makes the message actionable.
+  await notifyAppListingOwner({
+    type: 'app-listing-hidden',
+    userId: listing.userId,
+    // Keyed by the audit event id so each distinct hide (delist→relist→delist)
+    // notifies once, without a fresh nonce.
+    key: `app-listing-hidden:${eventId}`,
+    details: { slug: listing.slug, name: listing.name, listingId: input.appListingId, reason },
+  });
 
   return { appListingId: input.appListingId, status: 'removed' };
 }


### PR DESCRIPTION
## Today

When a moderator delists an app store listing, `delistListing` notifies the owner (`app-listing-hidden`, carrying the mandatory moderator reason) **only if the listing is off-site**:

```ts
// OFF-SITE only: post-commit, best-effort — notify the owner their app was hidden,
// carrying the mod reason. (On-site owners aren't notified in Phase 1.)
if (!isOnsite) { await notifyAppListingOwner({ type: 'app-listing-hidden', ... }); }
```

An **on-site** delist fires **zero** notifications — while the same transaction also flips the backing `AppBlock` to `suspended`, which is what actually stops the hosted app from serving. So the more damaging of the two cases is the silent one: the author's app goes dark and nothing tells them, or tells them why.

## After

Both kinds notify. Same type, same idempotency key (bound to the moderation event id, so a delist → relist → delist cycle notifies once per hide), same payload including the moderator's reason.

The two comments that described the old behaviour (the `delistListing` doc block and the inline comment) are rewritten — a comment that contradicts the code is its own defect, and the stale one said on-site owners are deliberately not notified.

## Why the exclusion no longer holds

It was a scoping note from the change that introduced these notifications (Phase 1 of the post-approval listing management work), not a policy. Three things establish that:

1. **The same service already notifies on-site owners.** `resetOnsiteListingToPending` (`offsite-moderation.service.ts:1172`) is the **on-site** reset procedure — its listing flip is guarded on `kind: 'onsite'` (:1246) and it suspends the very same backing block — and it calls `notifyAppListingOwner` unconditionally (:1337). So on-site owners are already a valid audience for the `app-listing-*` types; there was never a rule against reaching them.
2. **The linked page works for them.** `app-listing-hidden` renders through `withReason(...)` (`"<name>" was hidden from the app store by a moderator: <reason>.`) and links to `/apps/my-submissions`. A later change widened that page's owner controls to on-site listings — status badge, the "removed by a moderator" distinction, and the owner moderation-history modal that renders the reason. So an on-site owner can reach the page the notification points at and read the rationale there.
3. **It is not a duplicate.** The on-site block-suspend path emits no owner notification of its own. The only other owner-facing block types (`app-block-approved` / `app-block-rejected`) are emitted from the publish-request approve/reject flow, never on a delist or a suspend.

No migration and no new notification type — `app-listing-hidden` is already registered and already used.

## Test matrix — red at base, green at HEAD

Extended the existing suite that covers `delistListing` rather than adding a new harness. One existing case flipped from asserting the absence of a notification to asserting its presence; a new regression block pins **both** kinds with **pairwise-distinct** listing ids, slugs, owners and reasons, so a mutant that hardcodes either kind's payload (or notifies the wrong owner) fails the other case. A third case pins that a status-guarded (0-count) on-site delist still notifies nobody.

Command (same file both runs; only the service file differs):

```
npx vitest run --project 'unit*' \
  src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
```

**RED — new tests against the pre-change service:**

```
FAIL  delistListing > ON-SITE delist flips BOTH app_listings AND the backing app_blocks in one tx (+ notifies the owner)
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times

FAIL  delistListing > the owner is notified on delist - for BOTH kinds > ON-SITE: notifies the owner with app-listing-hidden carrying the mod reason
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times

Test Files  1 failed (1)
     Tests  2 failed | 80 passed (82)
```

The off-site case passes at base, as it should — it pins behaviour that already exists so a future edit cannot silently drop it.

**GREEN — at this branch's HEAD:**

```
Test Files  1 passed (1)
     Tests  82 passed (82)
```

## Verification

- `pnpm typecheck` → `typecheck: OK — 0 type errors in 77s (heap cap 8192 MB).`
- `npx vitest run --project 'unit*' src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts src/server/notifications/__tests__ src/server/services/blocks/__tests__` → `Test Files 150 passed (150)` / `Tests 3317 passed (3317)`
- `npx eslint` on both touched files → 0 errors, 1 warning, and that warning is pre-existing at `origin/main` (an unused `_a` at line 100 of the test file, outside the changed regions).
- `npx prettier --check` flags both files — also pre-existing. Controlled by re-running prettier over the `origin/main` content of both files at their real in-repo paths: the drift is **9 lines (service) / 228 lines (test)** at base and **identical 9 / 228** at HEAD, i.e. this change introduces no new formatting drift. Not reformatted here, to keep the diff reviewable.

