### PR TITLE
feat(models): unpublishing the last published version takes the model down

### DIFF
--- a/src/components/Model/ModelVersions/ModelVersionMenu.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionMenu.tsx
@@ -166,25 +166,34 @@ export function ModelVersionMenu({
   const handleUnpublishVersion = async () => {
     try {
       // staleTime 0: the cached figure is what the owner is consenting to move Buzz over, and a
-      // purchase can land between opening the menu twice.
-      const refund = await queryUtils.modelVersion.getEarlyAccessRefundRequirement.fetch(
+      // purchase can land between opening the menu twice. The server prices this at the scope the
+      // unpublish will actually run at — taking down the last published version takes the model —
+      // so `scope` decides the wording rather than the caller assuming.
+      const impact = await queryUtils.modelVersion.getUnpublishImpact.fetch(
         { id: modelVersionId },
         { staleTime: 0 }
       );
+      const cascades = impact.scope === 'model';
+      const subject = cascades ? 'this model' : 'this version';
       const exemptNote =
-        refund.exemptBuyerCount > 0
-          ? ` ${refund.exemptBuyerCount} earlier buyer(s) bought more than ${PAID_ACCESS_REFUND_WINDOW_DAYS} days ago; they lose access to this version and are not refunded.`
+        impact.exemptBuyerCount > 0
+          ? ` ${impact.exemptBuyerCount} earlier buyer(s) bought more than ${PAID_ACCESS_REFUND_WINDOW_DAYS} days ago; they lose access and are not refunded.`
           : '';
+      // Said before the money, because it is the part that surprises: the creator opened a menu on
+      // one version.
+      const cascadeNote = cascades
+        ? 'This is the only published version, so unpublishing it takes the whole model down with it — every version, its posts, and any active auction bids. '
+        : '';
 
-      if (refund.purchaseCount > 0) {
+      if (impact.purchaseCount > 0) {
         dialogStore.trigger({
           id: 'unpublish-version-refund',
           component: ConfirmDialog,
           props: {
-            title: 'Refund early access buyers',
-            message: `${
-              refund.buyerCount
-            } member(s) bought access to this version in the last ${PAID_ACCESS_REFUND_WINDOW_DAYS} days. Unpublishing it now will refund them a total of ${refund.totalBuzz.toLocaleString()} Buzz from your account and revoke their access to it.${exemptNote} Do you want to continue?`,
+            title: cascades ? 'Unpublish model & refund buyers' : 'Refund early access buyers',
+            message: `${cascadeNote}${
+              impact.buyerCount
+            } member(s) bought access to ${subject} in the last ${PAID_ACCESS_REFUND_WINDOW_DAYS} days. Unpublishing now will refund them a total of ${impact.totalBuzz.toLocaleString()} Buzz from your account and revoke their access.${exemptNote} Do you want to continue?`,
             labels: { cancel: 'Cancel', confirm: 'Refund & Unpublish' },
             confirmProps: { color: 'yellow' },
             onConfirm: () =>
@@ -198,10 +207,12 @@ export function ModelVersionMenu({
         id: 'unpublish-version',
         component: ConfirmDialog,
         props: {
-          title: 'Unpublish version',
+          title: cascades ? 'Unpublish model' : 'Unpublish version',
           message:
-            refund.exemptBuyerCount > 0
-              ? `${refund.exemptBuyerCount} member(s) bought access to this version, all more than ${PAID_ACCESS_REFUND_WINDOW_DAYS} days ago. They lose access to it and are not refunded, and nothing is taken from your account. Do you want to continue?`
+            impact.exemptBuyerCount > 0
+              ? `${cascadeNote}${impact.exemptBuyerCount} member(s) bought access to ${subject}, all more than ${PAID_ACCESS_REFUND_WINDOW_DAYS} days ago. They lose access and are not refunded, and nothing is taken from your account. Do you want to continue?`
+              : cascades
+              ? `${cascadeNote}Do you want to continue?`
               : 'This version will be hidden from the model page and can be published again later. Do you want to continue?',
           labels: { cancel: 'Cancel', confirm: 'Unpublish' },
           confirmProps: { color: 'yellow' },

--- a/src/components/Model/ModelVersions/ModelVersionMenu.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionMenu.tsx
@@ -196,8 +196,14 @@ export function ModelVersionMenu({
             } member(s) bought access to ${subject} in the last ${PAID_ACCESS_REFUND_WINDOW_DAYS} days. Unpublishing now will refund them a total of ${impact.totalBuzz.toLocaleString()} Buzz from your account and revoke their access.${exemptNote} Do you want to continue?`,
             labels: { cancel: 'Cancel', confirm: 'Refund & Unpublish' },
             confirmProps: { color: 'yellow' },
+            // Echo back what this dialog priced. The server refuses if the scope widened or the
+            // debit grew while the dialog was open, rather than acting on a stale yes.
             onConfirm: () =>
-              unpublishVersionMutation.mutate({ id: modelVersionId, refundEarlyAccess: true }),
+              unpublishVersionMutation.mutate({
+                id: modelVersionId,
+                refundEarlyAccess: true,
+                expected: { scope: impact.scope, totalBuzz: impact.totalBuzz },
+              }),
           },
         });
         return;
@@ -216,7 +222,11 @@ export function ModelVersionMenu({
               : 'This version will be hidden from the model page and can be published again later. Do you want to continue?',
           labels: { cancel: 'Cancel', confirm: 'Unpublish' },
           confirmProps: { color: 'yellow' },
-          onConfirm: () => unpublishVersionMutation.mutate({ id: modelVersionId }),
+          onConfirm: () =>
+            unpublishVersionMutation.mutate({
+              id: modelVersionId,
+              expected: { scope: impact.scope, totalBuzz: impact.totalBuzz },
+            }),
         },
       });
     } catch (error) {

--- a/src/server/controllers/__tests__/model-version.controller.publish-guards.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.publish-guards.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
 
 /**
  * Publishing a version is allowed only when both the version and its parent model are in a state an
@@ -31,7 +32,10 @@ vi.mock('~/server/services/model.service', () => ({
 vi.mock('~/server/services/training.service', () => ({}));
 vi.mock('~/server/redis/caches', () => ({ dataForModelsCache: { refresh: vi.fn() } }));
 
-import { publishModelVersionHandler } from '~/server/controllers/model-version.controller';
+import {
+  publishModelVersionHandler,
+  publishPrivateModelVersionHandler,
+} from '~/server/controllers/model-version.controller';
 
 const VERSION_ID = 100;
 const OWNER_ID = 7;
@@ -91,5 +95,66 @@ describe('publishModelVersionHandler — publishable state', () => {
     await call('UnpublishedViolation', 'UnpublishedViolation', true);
 
     expect(mockPublishModelVersionById).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('publishPrivateModelVersionHandler — the same publishable state', () => {
+  const callPrivate = (versionStatus: string, modelStatus: string, isModerator = false) => {
+    mockGetVersionById.mockResolvedValue({
+      id: VERSION_ID,
+      status: versionStatus,
+      uploadType: 'Trained',
+      model: {
+        id: 42,
+        publishedAt: new Date(),
+        availability: 'Private',
+        userId: OWNER_ID,
+        status: modelStatus,
+      },
+      files: [{ id: 1, metadata: {} }],
+      posts: [{ id: 5 }],
+    });
+
+    return publishPrivateModelVersionHandler({
+      input: { id: VERSION_ID },
+      ctx: { user: { id: OWNER_ID, isModerator } },
+    } as never);
+  };
+
+  it.each(['UnpublishedViolation', 'Deleted'])(
+    'refuses an owner when the VERSION is at %s',
+    async (status) => {
+      await expect(callPrivate(status, 'Published')).rejects.toThrowError(/not authorized/);
+      expect(dbMock.dbWrite.modelFile.findMany).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['UnpublishedViolation', 'Deleted'])(
+    'refuses an owner when the parent MODEL is at %s',
+    async (status) => {
+      await expect(callPrivate('Unpublished', status)).rejects.toThrowError(/not authorized/);
+      expect(dbMock.dbWrite.modelFile.findMany).not.toHaveBeenCalled();
+    }
+  );
+
+  // Negative control. This handler does a great deal after the guard, so rather than mocking all of
+  // it, the assertion is that the call gets PAST the guard — it reads the version's files, and
+  // whatever it fails on afterwards is not an authorization refusal.
+  it('lets an ordinary publish through the guard', async () => {
+    dbMock.dbWrite.modelFile.findMany.mockResolvedValue([]);
+
+    await expect(callPrivate('Unpublished', 'Published')).rejects.not.toThrowError(
+      /not authorized/
+    );
+    expect(dbMock.dbWrite.modelFile.findMany).toHaveBeenCalled();
+  });
+
+  it('lets a moderator past it', async () => {
+    dbMock.dbWrite.modelFile.findMany.mockResolvedValue([]);
+
+    await expect(
+      callPrivate('UnpublishedViolation', 'UnpublishedViolation', true)
+    ).rejects.not.toThrowError(/not authorized/);
+    expect(dbMock.dbWrite.modelFile.findMany).toHaveBeenCalled();
   });
 });

--- a/src/server/controllers/__tests__/model-version.controller.publish-guards.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.publish-guards.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Publishing a version is allowed only when both the version and its parent model are in a state an
+ * owner may publish from. The two statuses are set independently, and the private-model publish path
+ * takes the same rules as the public one — a different audience, not a different rulebook.
+ */
+
+const {
+  mockGetVersionById,
+  mockPublishModelVersionById,
+  mockUpdateModelVersionById,
+  mockGetModel,
+} = vi.hoisted(() => ({
+  mockGetVersionById: vi.fn(),
+  mockPublishModelVersionById: vi.fn(),
+  mockUpdateModelVersionById: vi.fn(),
+  mockGetModel: vi.fn(),
+}));
+
+vi.mock('~/server/services/model-version.service', () => ({
+  getVersionById: mockGetVersionById,
+  publishModelVersionById: mockPublishModelVersionById,
+  updateModelVersionById: mockUpdateModelVersionById,
+}));
+vi.mock('~/server/services/model.service', () => ({
+  getModel: mockGetModel,
+  queueModelEarlyAccessReindex: vi.fn().mockResolvedValue(undefined),
+}));
+// Reached at import through the orchestrator caller, which throws without a token.
+vi.mock('~/server/services/training.service', () => ({}));
+vi.mock('~/server/redis/caches', () => ({ dataForModelsCache: { refresh: vi.fn() } }));
+
+import { publishModelVersionHandler } from '~/server/controllers/model-version.controller';
+
+const VERSION_ID = 100;
+const OWNER_ID = 7;
+
+const call = (versionStatus: string, modelStatus: string, isModerator = false) => {
+  mockGetVersionById.mockResolvedValue({
+    id: VERSION_ID,
+    status: versionStatus,
+    meta: null,
+    baseModel: 'SDXL 1.0',
+    model: { userId: OWNER_ID, nsfw: false, status: modelStatus },
+  });
+
+  return publishModelVersionHandler({
+    input: { id: VERSION_ID },
+    ctx: {
+      user: { id: OWNER_ID, isModerator },
+      // Fire-and-forget with a .catch, so the mock has to be thenable.
+      track: { modelVersionEvent: vi.fn().mockResolvedValue(undefined) },
+    },
+  } as never);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPublishModelVersionById.mockResolvedValue({ id: VERSION_ID, modelId: 42, model: {} });
+});
+
+describe('publishModelVersionHandler — publishable state', () => {
+  it.each(['UnpublishedViolation', 'Deleted'])(
+    'refuses an owner when the VERSION is at %s',
+    async (status) => {
+      await expect(call(status, 'Published')).rejects.toThrowError(/not authorized/);
+      expect(mockPublishModelVersionById).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['UnpublishedViolation', 'Deleted'])(
+    'refuses an owner when the parent MODEL is at %s',
+    async (status) => {
+      // The two statuses are written independently, so a version can sit at an owner-publishable
+      // status under a model that is not. Checking the version alone leaves that unenforced.
+      await expect(call('Unpublished', status)).rejects.toThrowError(/not authorized/);
+      expect(mockPublishModelVersionById).not.toHaveBeenCalled();
+    }
+  );
+
+  // Negative control: a check that refused on any non-Published status would block every ordinary
+  // republish, and both assertions above would still pass.
+  it('lets an owner publish an ordinary unpublished version of a published model', async () => {
+    await call('Unpublished', 'Published');
+
+    expect(mockPublishModelVersionById).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a moderator through either way', async () => {
+    await call('UnpublishedViolation', 'UnpublishedViolation', true);
+
+    expect(mockPublishModelVersionById).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/controllers/__tests__/model-version.controller.unpublish-cascade.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.unpublish-cascade.test.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 /**
  * Unpublishing a model's last published version would otherwise leave the model published with
  * nothing under it — a state the model page, the listings and search all have to render, and one
- * nobody chose. The handler delegates to the model unpublish instead of doing both in turn, so the
- * model-scoped refund gate decides before anything moves: a refusal cannot leave the version down
- * and the model up.
+ * nobody chose. The handler delegates to the model unpublish instead of doing both in turn.
+ *
+ * Scope note: `unpublishModelById` is mocked here, so this file is evidence about DELEGATION and
+ * about the consent re-check — not about the refund gate itself, which is covered in
+ * model-early-access-refund.service.test.ts.
  */
 
 const {
@@ -14,12 +16,16 @@ const {
   mockGetVersionById,
   mockGetModel,
   mockResolveUnpublishScope,
+  mockModelRequirement,
+  mockVersionRequirement,
 } = vi.hoisted(() => ({
   mockUnpublishModelById: vi.fn(),
   mockUnpublishModelVersionById: vi.fn(),
   mockGetVersionById: vi.fn(),
   mockGetModel: vi.fn(),
   mockResolveUnpublishScope: vi.fn(),
+  mockModelRequirement: vi.fn(),
+  mockVersionRequirement: vi.fn(),
 }));
 
 vi.mock('~/server/services/model-version.service', () => ({
@@ -31,6 +37,10 @@ vi.mock('~/server/services/model.service', () => ({
   getModel: mockGetModel,
   queueModelEarlyAccessReindex: vi.fn(),
   unpublishModelById: mockUnpublishModelById,
+}));
+vi.mock('~/server/services/model-early-access-refund.service', () => ({
+  getModelEarlyAccessRefundRequirement: mockModelRequirement,
+  getModelVersionEarlyAccessRefundRequirement: mockVersionRequirement,
 }));
 // Reached at import through the orchestrator caller, which throws without a token. Nothing on this
 // path calls it.
@@ -50,14 +60,14 @@ const call = (input: Record<string, unknown> = {}, isModerator = false) =>
     input: { id: VERSION_ID, ...input },
     ctx: {
       user: { id: OWNER_ID, isModerator },
-      track: { modelVersionEvent: vi.fn() },
+      track: { modelVersionEvent: vi.fn(), modelEvent: vi.fn() },
     },
   } as never);
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetVersionById.mockResolvedValue({ id: VERSION_ID, meta: null, modelId: MODEL_ID });
-  mockGetModel.mockResolvedValue({ meta: null });
+  mockGetModel.mockResolvedValue({ meta: null, nsfw: true, status: 'Published' });
   mockUnpublishModelVersionById.mockResolvedValue({
     id: VERSION_ID,
     model: { id: MODEL_ID, userId: OWNER_ID, nsfw: false },
@@ -66,6 +76,8 @@ beforeEach(() => {
   // Reset the implementation, not just the calls: vi.clearAllMocks() leaves a mockRejectedValue in
   // place, so the refusal test below would otherwise poison every test declared after it.
   mockUnpublishModelById.mockResolvedValue(undefined);
+  mockModelRequirement.mockResolvedValue({ totalBuzz: 900 });
+  mockVersionRequirement.mockResolvedValue({ totalBuzz: 300 });
 });
 
 describe('unpublishModelVersionHandler — last published version', () => {
@@ -86,7 +98,7 @@ describe('unpublishModelVersionHandler — last published version', () => {
     expect(mockUnpublishModelVersionById).not.toHaveBeenCalled();
   });
 
-  it('carries the moderator flag through, so a mod take-down still bypasses the gate', async () => {
+  it('carries the moderator flag and the reason through to the model unpublish', async () => {
     await call({ reason: 'duplicate' }, true);
 
     expect(mockUnpublishModelById).toHaveBeenCalledWith(
@@ -123,17 +135,68 @@ describe('unpublishModelVersionHandler — last published version', () => {
     expect(mockUnpublishModelVersionById).not.toHaveBeenCalled();
   });
 
+  // `refundEarlyAccess: true` is a yes with no ceiling. Between pricing the dialog and confirming
+  // it, a sibling can go down — widening a version take-down into a whole model, and debiting the
+  // creator against a figure they never saw.
+  it('refuses when the scope widened while the dialog was open', async () => {
+    await expect(
+      call({ refundEarlyAccess: true, expected: { scope: 'version', totalBuzz: 300 } })
+    ).rejects.toThrowError(/takes the whole model with it/);
+
+    expect(mockUnpublishModelById).not.toHaveBeenCalled();
+    expect(mockUnpublishModelVersionById).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the refund owed grew beyond what was shown', async () => {
+    await expect(
+      call({ refundEarlyAccess: true, expected: { scope: 'model', totalBuzz: 500 } })
+    ).rejects.toThrowError(/refund owed has changed/);
+
+    expect(mockUnpublishModelById).not.toHaveBeenCalled();
+  });
+
+  // Negative control: a check that refused whenever `expected` was present would block every
+  // ordinary unpublish, and both assertions above would still pass.
+  it('proceeds when the priced figure still holds', async () => {
+    await call({ refundEarlyAccess: true, expected: { scope: 'model', totalBuzz: 900 } });
+
+    expect(mockUnpublishModelById).toHaveBeenCalledTimes(1);
+  });
+
+  it('proceeds when the debit shrank — the copy was pessimistic, nothing extra is taken', async () => {
+    mockModelRequirement.mockResolvedValue({ totalBuzz: 100 });
+
+    await call({ refundEarlyAccess: true, expected: { scope: 'model', totalBuzz: 900 } });
+
+    expect(mockUnpublishModelById).toHaveBeenCalledTimes(1);
+  });
+
   it('still reports the take-down to analytics', async () => {
-    const track = vi.fn();
+    const modelVersionEvent = vi.fn();
+    const modelEvent = vi.fn();
     await unpublishModelVersionHandler({
       input: { id: VERSION_ID },
-      ctx: { user: { id: OWNER_ID, isModerator: false }, track: { modelVersionEvent: track } },
+      ctx: {
+        user: { id: OWNER_ID, isModerator: false },
+        track: { modelVersionEvent, modelEvent },
+      },
     } as never);
 
-    // The cascade branch returns early; without an explicit event a last-version take-down is
-    // invisible to analytics, because unpublishModelById fires no version event of its own.
-    expect(track).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'Unpublish', modelVersionId: VERSION_ID })
-    );
+    // The cascade branch returns early; without explicit events a last-version take-down is
+    // invisible to analytics, because unpublishModelById fires none of its own. Every field is
+    // pinned: objectContaining on type alone left a wrong modelId and a hardcoded nsfw green.
+    expect(modelVersionEvent).toHaveBeenCalledWith({
+      type: 'Unpublish',
+      modelVersionId: VERSION_ID,
+      modelId: MODEL_ID,
+      nsfw: true,
+    });
+    // The identical effect through unpublishModelHandler emits a model event, so a model unpublish
+    // reached from the version menu must appear in the same count.
+    expect(modelEvent).toHaveBeenCalledWith({
+      type: 'Unpublish',
+      modelId: MODEL_ID,
+      nsfw: true,
+    });
   });
 });

--- a/src/server/controllers/__tests__/model-version.controller.unpublish-cascade.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.unpublish-cascade.test.ts
@@ -119,6 +119,26 @@ describe('unpublishModelVersionHandler — last published version', () => {
     );
   });
 
+  // 🔴 On the preserve path the service writes back exactly what this controller hands it, so the
+  // hand-off is load-bearing for the whole guard: `meta: {}` here erases the moderator's reason,
+  // explanation, timestamp and actor while leaving the status at UnpublishedViolation — record
+  // gone, flag intact.
+  it('hands the model meta through intact', async () => {
+    const moderatorRecord = {
+      unpublishedReason: 'other',
+      customMessage: 'Reviewed by a human',
+      unpublishedAt: '2020-01-01T00:00:00.000Z',
+      unpublishedBy: 999,
+    };
+    mockGetModel.mockResolvedValue({ meta: { ...moderatorRecord }, nsfw: true });
+
+    await call();
+
+    expect(mockUnpublishModelById).toHaveBeenCalledWith(
+      expect.objectContaining({ meta: moderatorRecord })
+    );
+  });
+
   it('does not report a version take-down as a model unpublish', async () => {
     // The doubled-count shape: emitting the model event on the version path too would make every
     // single-version take-down arrive in analytics as a model unpublish.
@@ -196,7 +216,7 @@ describe('unpublishModelVersionHandler — last published version', () => {
     expect(mockUnpublishModelById).toHaveBeenCalledTimes(1);
   });
 
-  it('refuses a version-scoped confirm whose figure grew, without over-pricing it', async () => {
+  it('proceeds on a version-scoped confirm, pricing the version and not the model', async () => {
     // The version branch of the check was never exercised. Pricing it against the MODEL total would
     // refuse legitimate version-only unpublishes whenever the model owes more — the common case.
     mockResolveUnpublishScope.mockResolvedValue({ kind: 'version', modelId: MODEL_ID });

--- a/src/server/controllers/__tests__/model-version.controller.unpublish-cascade.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.unpublish-cascade.test.ts
@@ -82,7 +82,7 @@ beforeEach(() => {
 
 describe('unpublishModelVersionHandler — last published version', () => {
   it('takes the model down with it, and does not also unpublish the version separately', async () => {
-    await call({ refundEarlyAccess: true });
+    await call({ refundEarlyAccess: true, expected: { scope: 'model', totalBuzz: 900 } });
 
     expect(mockUnpublishModelById).toHaveBeenCalledTimes(1);
     expect(mockUnpublishModelById).toHaveBeenCalledWith(
@@ -117,6 +117,31 @@ describe('unpublishModelVersionHandler — last published version', () => {
     expect(mockUnpublishModelVersionById).toHaveBeenCalledWith(
       expect.objectContaining({ id: VERSION_ID })
     );
+  });
+
+  it('does not report a version take-down as a model unpublish', async () => {
+    // The doubled-count shape: emitting the model event on the version path too would make every
+    // single-version take-down arrive in analytics as a model unpublish.
+    mockResolveUnpublishScope.mockResolvedValue({ kind: 'version', modelId: MODEL_ID });
+    const modelEvent = vi.fn();
+
+    await unpublishModelVersionHandler({
+      input: { id: VERSION_ID },
+      ctx: {
+        user: { id: OWNER_ID, isModerator: false },
+        track: { modelVersionEvent: vi.fn(), modelEvent },
+      },
+    } as never);
+
+    expect(modelEvent).not.toHaveBeenCalled();
+  });
+
+  it('throws rather than silently wiping the model meta when the model is gone', async () => {
+    mockGetModel.mockResolvedValue(null);
+
+    await expect(call()).rejects.toThrowError(/No model with id/);
+
+    expect(mockUnpublishModelById).not.toHaveBeenCalled();
   });
 
   it('lets the model-level refund refusal through instead of unpublishing the version', async () => {
@@ -171,6 +196,44 @@ describe('unpublishModelVersionHandler — last published version', () => {
     expect(mockUnpublishModelById).toHaveBeenCalledTimes(1);
   });
 
+  it('refuses a version-scoped confirm whose figure grew, without over-pricing it', async () => {
+    // The version branch of the check was never exercised. Pricing it against the MODEL total would
+    // refuse legitimate version-only unpublishes whenever the model owes more — the common case.
+    mockResolveUnpublishScope.mockResolvedValue({ kind: 'version', modelId: MODEL_ID });
+
+    await call({ refundEarlyAccess: true, expected: { scope: 'version', totalBuzz: 300 } });
+
+    expect(mockUnpublishModelVersionById).toHaveBeenCalledTimes(1);
+    expect(mockModelRequirement).not.toHaveBeenCalled();
+  });
+
+  it('refuses when a version-scoped figure grew', async () => {
+    mockResolveUnpublishScope.mockResolvedValue({ kind: 'version', modelId: MODEL_ID });
+    mockVersionRequirement.mockResolvedValue({ totalBuzz: 400 });
+
+    await expect(
+      call({ refundEarlyAccess: true, expected: { scope: 'version', totalBuzz: 300 } })
+    ).rejects.toThrowError(/refund owed has changed/);
+
+    expect(mockUnpublishModelVersionById).not.toHaveBeenCalled();
+  });
+
+  it('requires the owner to say what they agreed to before moving Buzz', async () => {
+    // Optional would make the check advisory: any caller omitting `expected` — a stale tab mid
+    // deploy, the moderator modal, a direct tRPC call — gets an unbounded yes.
+    await expect(call({ refundEarlyAccess: true })).rejects.toThrowError(
+      /reopen the unpublish menu/
+    );
+
+    expect(mockUnpublishModelById).not.toHaveBeenCalled();
+  });
+
+  it('does not require it of a moderator, who bypasses the refund gate anyway', async () => {
+    await call({ refundEarlyAccess: true, reason: 'duplicate' }, true);
+
+    expect(mockUnpublishModelById).toHaveBeenCalledTimes(1);
+  });
+
   it('still reports the take-down to analytics', async () => {
     const modelVersionEvent = vi.fn();
     const modelEvent = vi.fn();
@@ -198,5 +261,7 @@ describe('unpublishModelVersionHandler — last published version', () => {
       modelId: MODEL_ID,
       nsfw: true,
     });
+    expect(modelEvent).toHaveBeenCalledTimes(1);
+    expect(modelVersionEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/controllers/__tests__/model-version.controller.unpublish-cascade.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.unpublish-cascade.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Unpublishing a model's last published version would otherwise leave the model published with
+ * nothing under it — a state the model page, the listings and search all have to render, and one
+ * nobody chose. The handler delegates to the model unpublish instead of doing both in turn, so the
+ * model-scoped refund gate decides before anything moves: a refusal cannot leave the version down
+ * and the model up.
+ */
+
+const {
+  mockUnpublishModelById,
+  mockUnpublishModelVersionById,
+  mockGetVersionById,
+  mockGetModel,
+  mockResolveUnpublishScope,
+} = vi.hoisted(() => ({
+  mockUnpublishModelById: vi.fn(),
+  mockUnpublishModelVersionById: vi.fn(),
+  mockGetVersionById: vi.fn(),
+  mockGetModel: vi.fn(),
+  mockResolveUnpublishScope: vi.fn(),
+}));
+
+vi.mock('~/server/services/model-version.service', () => ({
+  getVersionById: mockGetVersionById,
+  unpublishModelVersionById: mockUnpublishModelVersionById,
+  resolveUnpublishScope: mockResolveUnpublishScope,
+}));
+vi.mock('~/server/services/model.service', () => ({
+  getModel: mockGetModel,
+  queueModelEarlyAccessReindex: vi.fn(),
+  unpublishModelById: mockUnpublishModelById,
+}));
+// Reached at import through the orchestrator caller, which throws without a token. Nothing on this
+// path calls it.
+vi.mock('~/server/services/training.service', () => ({}));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: { refresh: vi.fn() },
+}));
+
+import { unpublishModelVersionHandler } from '~/server/controllers/model-version.controller';
+
+const VERSION_ID = 100;
+const MODEL_ID = 42;
+const OWNER_ID = 7;
+
+const call = (input: Record<string, unknown> = {}, isModerator = false) =>
+  unpublishModelVersionHandler({
+    input: { id: VERSION_ID, ...input },
+    ctx: {
+      user: { id: OWNER_ID, isModerator },
+      track: { modelVersionEvent: vi.fn() },
+    },
+  } as never);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetVersionById.mockResolvedValue({ id: VERSION_ID, meta: null, modelId: MODEL_ID });
+  mockGetModel.mockResolvedValue({ meta: null });
+  mockUnpublishModelVersionById.mockResolvedValue({
+    id: VERSION_ID,
+    model: { id: MODEL_ID, userId: OWNER_ID, nsfw: false },
+  });
+  mockResolveUnpublishScope.mockResolvedValue({ kind: 'model', modelId: MODEL_ID });
+  // Reset the implementation, not just the calls: vi.clearAllMocks() leaves a mockRejectedValue in
+  // place, so the refusal test below would otherwise poison every test declared after it.
+  mockUnpublishModelById.mockResolvedValue(undefined);
+});
+
+describe('unpublishModelVersionHandler — last published version', () => {
+  it('takes the model down with it, and does not also unpublish the version separately', async () => {
+    await call({ refundEarlyAccess: true });
+
+    expect(mockUnpublishModelById).toHaveBeenCalledTimes(1);
+    expect(mockUnpublishModelById).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: MODEL_ID,
+        refundEarlyAccess: true,
+        userId: OWNER_ID,
+        isModerator: false,
+      })
+    );
+    // Delegated, not doubled: unpublishModelById already unpublishes every published version, and
+    // running the version path too would take the refund gate twice over the same buyers.
+    expect(mockUnpublishModelVersionById).not.toHaveBeenCalled();
+  });
+
+  it('carries the moderator flag through, so a mod take-down still bypasses the gate', async () => {
+    await call({ reason: 'duplicate' }, true);
+
+    expect(mockUnpublishModelById).toHaveBeenCalledWith(
+      expect.objectContaining({ isModerator: true, reason: 'duplicate' })
+    );
+  });
+
+  // Negative control. Without it, a cascade that fired unconditionally — taking a whole model down
+  // because one of its twelve versions was retired — passes every assertion above.
+  it('leaves the model alone while another published version remains', async () => {
+    mockResolveUnpublishScope.mockResolvedValue({ kind: 'version', modelId: MODEL_ID });
+
+    await call();
+
+    expect(mockUnpublishModelById).not.toHaveBeenCalled();
+    expect(mockUnpublishModelVersionById).toHaveBeenCalledWith(
+      expect.objectContaining({ id: VERSION_ID })
+    );
+  });
+
+  it('lets the model-level refund refusal through instead of unpublishing the version', async () => {
+    const { TRPCError } = await import('@trpc/server');
+    mockUnpublishModelById.mockRejectedValue(
+      new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Cannot unpublish … without refunding buyers.',
+      })
+    );
+
+    // A plain Error would be routed through throwDbError into a generic 500, and a bare
+    // rejects.toThrow() would pass on either — so the matcher has to name the refusal.
+    await expect(call()).rejects.toThrowError(/without refunding buyers/);
+
+    expect(mockUnpublishModelVersionById).not.toHaveBeenCalled();
+  });
+
+  it('still reports the take-down to analytics', async () => {
+    const track = vi.fn();
+    await unpublishModelVersionHandler({
+      input: { id: VERSION_ID },
+      ctx: { user: { id: OWNER_ID, isModerator: false }, track: { modelVersionEvent: track } },
+    } as never);
+
+    // The cascade branch returns early; without an explicit event a last-version take-down is
+    // invisible to analytics, because unpublishModelById fires no version event of its own.
+    expect(track).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'Unpublish', modelVersionId: VERSION_ID })
+    );
+  });
+});

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -33,7 +33,11 @@ import type {
   RecommendedSettingsSchema,
   TrainingDetailsObj,
 } from '~/server/schema/model-version.schema';
-import type { DeclineReviewSchema, UnpublishModelSchema } from '~/server/schema/model.schema';
+import type {
+  DeclineReviewSchema,
+  ModelMeta,
+  UnpublishModelSchema,
+} from '~/server/schema/model.schema';
 import type { ModelFileModel } from '~/server/selectors/modelFile.selector';
 import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import { getStaticContent } from '~/server/services/content.service';
@@ -53,11 +57,16 @@ import {
   publishModelVersionById,
   queryModelVersions,
   toggleNotifyModelVersion,
+  resolveUnpublishScope,
   unpublishModelVersionById,
   updateModelVersionById,
   upsertModelVersion,
 } from '~/server/services/model-version.service';
-import { getModel, queueModelEarlyAccessReindex } from '~/server/services/model.service';
+import {
+  getModel,
+  queueModelEarlyAccessReindex,
+  unpublishModelById,
+} from '~/server/services/model.service';
 import { trackModActivity } from '~/server/services/moderator.service';
 import {
   handleLogError,
@@ -754,6 +763,32 @@ export const unpublishModelVersionHandler = async ({
     if (!version) throw throwNotFoundError(`No model version with id ${input.id}`);
 
     const meta = (version.meta as ModelVersionMeta | null) || {};
+
+    // The last published version takes the model with it, rather than leaving a model published with
+    // nothing under it. Delegating instead of unpublishing both in turn is what keeps it whole:
+    // unpublishModelById already unpublishes every published version and runs the model-scoped
+    // refund gate, so a refusal happens before anything moves. Same resolver the dialog priced
+    // itself from, read from the primary, so consent and effect cannot diverge.
+    const scope = await resolveUnpublishScope(id);
+    if (scope.kind === 'model') {
+      const model = await getModel({ id: scope.modelId, select: { meta: true } });
+      await unpublishModelById({
+        ...input,
+        id: scope.modelId,
+        meta: (model?.meta as ModelMeta | null) ?? undefined,
+        userId: ctx.user.id,
+        isModerator: ctx.user.isModerator,
+      });
+
+      ctx.track.modelVersionEvent({
+        type: 'Unpublish',
+        modelVersionId: id,
+        modelId: scope.modelId,
+        nsfw: false,
+      });
+      await dataForModelsCache.refresh(scope.modelId);
+      return getVersionById({ id, select: { id: true, status: true, modelId: true } });
+    }
 
     const updatedVersion = await unpublishModelVersionById({ ...input, meta, user: ctx.user });
 

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -689,7 +689,7 @@ export const publishModelVersionHandler = async ({
         status: true,
         modelId: true,
         baseModel: true,
-        model: { select: { userId: true, nsfw: true } },
+        model: { select: { userId: true, nsfw: true, status: true } },
       },
     });
 
@@ -706,8 +706,13 @@ export const publishModelVersionHandler = async ({
 
     const versionMeta = version.meta as ModelVersionMeta | null;
 
-    // Prevent non-moderators from re-publishing versions unpublished for violations
-    if (!ctx.user.isModerator && constants.modPublishOnlyStatuses.includes(version.status)) {
+    // A version is publishable only if BOTH it and its parent model are. Checking the version
+    // alone leaves the model's status unenforced, and the two are set independently.
+    if (
+      !ctx.user.isModerator &&
+      (constants.modPublishOnlyStatuses.includes(version.status) ||
+        constants.modPublishOnlyStatuses.includes(version.model.status))
+    ) {
       throw throwAuthorizationError('You are not authorized to publish this model version');
     }
 
@@ -1261,8 +1266,11 @@ export async function publishPrivateModelVersionHandler({
     ...input,
     select: {
       id: true,
+      status: true,
       uploadType: true,
-      model: { select: { id: true, publishedAt: true, availability: true, userId: true } },
+      model: {
+        select: { id: true, publishedAt: true, availability: true, userId: true, status: true },
+      },
       files: {
         select: {
           id: true,
@@ -1286,6 +1294,16 @@ export async function publishPrivateModelVersionHandler({
 
   if (version.model.availability !== Availability.Private) {
     throw throwBadRequestError('Model is not private');
+  }
+
+  // The same status check the public publish path performs, on both the version and its model. A
+  // private model is a different audience, not a different set of publishing rules.
+  if (
+    !ctx.user.isModerator &&
+    (constants.modPublishOnlyStatuses.includes(version.status) ||
+      constants.modPublishOnlyStatuses.includes(version.model.status))
+  ) {
+    throw throwAuthorizationError('You are not authorized to publish this model version');
   }
 
   // TODO(replica-toast): overlay is a workaround for data-packet logical subscriber dropping TOASTed jsonb. Remove once replication is fixed.

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -778,10 +778,22 @@ export const unpublishModelVersionHandler = async ({
     // dialog's read and this one, which is what `expected` below is for.
     const scope = await resolveUnpublishScope(id);
 
+    // A consent check, NOT atomicity: the window between the dialog's read and this one is still
+    // unguarded. What it refuses is proceeding on a figure the creator never saw.
     // Refuse rather than proceed when the world moved between pricing and confirming. Only the
     // directions that cost the creator something are refused: a widening scope (one version becomes
     // the whole model) or a larger debit than they saw. Narrowing is harmless — the copy was
     // pessimistic, nothing extra is taken.
+    if (!ctx.user.isModerator && input.refundEarlyAccess && !input.expected) {
+      // Optional `expected` would make this advisory rather than a control: any caller omitting it —
+      // a tab holding the pre-deploy bundle, the moderator modal, a direct tRPC call — gets an
+      // unbounded yes with the scope free to widen. Stale clients are the normal state during a
+      // deploy, which is exactly when this ships.
+      throw throwBadRequestError(
+        'Please reopen the unpublish menu and confirm again — this request did not say what refund it was agreeing to.'
+      );
+    }
+
     if (input.expected && !ctx.user.isModerator) {
       const priced = input.expected;
       if (priced.scope === 'version' && scope.kind === 'model') {
@@ -803,23 +815,14 @@ export const unpublishModelVersionHandler = async ({
     if (scope.kind === 'model') {
       const model = await getModel({
         id: scope.modelId,
-        select: { meta: true, nsfw: true, status: true },
+        select: { meta: true, nsfw: true },
       });
       if (!model) throw throwNotFoundError(`No model with id ${scope.modelId}`);
 
-      // 🔴 Never downgrade a status this call did not set. An owner-initiated unpublish carries no
-      // reason, so writing the status unconditionally would overwrite a moderator's
-      // UnpublishedViolation with a plain Unpublished — and `model.controller.ts` only blocks an
-      // owner republish while the status IS UnpublishedViolation. That is an owner-reachable path to
-      // clear a moderation flag, via a draft published under a model a moderator already took down.
-      const preserveViolation =
-        !input.reason && (model.status as ModelStatus) === ModelStatus.UnpublishedViolation;
-
+      // A model already at UnpublishedViolation keeps that status and the moderator's record —
+      // unpublishModelById decides that from the status it reads, so both callers get it.
       await unpublishModelById({
         ...input,
-        ...(preserveViolation
-          ? { reason: (model.meta as ModelMeta | null)?.unpublishedReason }
-          : {}),
         id: scope.modelId,
         meta: (model.meta as ModelMeta | null) ?? undefined,
         userId: ctx.user.id,

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -67,6 +67,10 @@ import {
   queueModelEarlyAccessReindex,
   unpublishModelById,
 } from '~/server/services/model.service';
+import {
+  getModelEarlyAccessRefundRequirement,
+  getModelVersionEarlyAccessRefundRequirement,
+} from '~/server/services/model-early-access-refund.service';
 import { trackModActivity } from '~/server/services/moderator.service';
 import {
   handleLogError,
@@ -764,18 +768,60 @@ export const unpublishModelVersionHandler = async ({
 
     const meta = (version.meta as ModelVersionMeta | null) || {};
 
-    // The last published version takes the model with it, rather than leaving a model published with
+    // The last live version takes the model with it, rather than leaving a model published with
     // nothing under it. Delegating instead of unpublishing both in turn is what keeps it whole:
     // unpublishModelById already unpublishes every published version and runs the model-scoped
-    // refund gate, so a refusal happens before anything moves. Same resolver the dialog priced
-    // itself from, read from the primary, so consent and effect cannot diverge.
+    // refund gate, so a refusal happens before anything moves.
+    //
+    // The resolver is the same one the dialog priced itself from and reads the primary, so the two
+    // agree for a fixed database state — NOT unconditionally: a sibling can go down between the
+    // dialog's read and this one, which is what `expected` below is for.
     const scope = await resolveUnpublishScope(id);
+
+    // Refuse rather than proceed when the world moved between pricing and confirming. Only the
+    // directions that cost the creator something are refused: a widening scope (one version becomes
+    // the whole model) or a larger debit than they saw. Narrowing is harmless — the copy was
+    // pessimistic, nothing extra is taken.
+    if (input.expected && !ctx.user.isModerator) {
+      const priced = input.expected;
+      if (priced.scope === 'version' && scope.kind === 'model') {
+        throw throwBadRequestError(
+          'Another version was taken down while this dialog was open, so unpublishing this one now takes the whole model with it. Please reopen the menu to see what that costs.'
+        );
+      }
+      const requirement =
+        scope.kind === 'model'
+          ? await getModelEarlyAccessRefundRequirement({ id: scope.modelId })
+          : await getModelVersionEarlyAccessRefundRequirement({ id });
+      if (requirement.totalBuzz > priced.totalBuzz) {
+        throw throwBadRequestError(
+          `The refund owed has changed since this dialog was opened — ${requirement.totalBuzz.toLocaleString()} Buzz rather than ${priced.totalBuzz.toLocaleString()}. Please reopen the menu to confirm the new amount.`
+        );
+      }
+    }
+
     if (scope.kind === 'model') {
-      const model = await getModel({ id: scope.modelId, select: { meta: true } });
+      const model = await getModel({
+        id: scope.modelId,
+        select: { meta: true, nsfw: true, status: true },
+      });
+      if (!model) throw throwNotFoundError(`No model with id ${scope.modelId}`);
+
+      // 🔴 Never downgrade a status this call did not set. An owner-initiated unpublish carries no
+      // reason, so writing the status unconditionally would overwrite a moderator's
+      // UnpublishedViolation with a plain Unpublished — and `model.controller.ts` only blocks an
+      // owner republish while the status IS UnpublishedViolation. That is an owner-reachable path to
+      // clear a moderation flag, via a draft published under a model a moderator already took down.
+      const preserveViolation =
+        !input.reason && (model.status as ModelStatus) === ModelStatus.UnpublishedViolation;
+
       await unpublishModelById({
         ...input,
+        ...(preserveViolation
+          ? { reason: (model.meta as ModelMeta | null)?.unpublishedReason }
+          : {}),
         id: scope.modelId,
-        meta: (model?.meta as ModelMeta | null) ?? undefined,
+        meta: (model.meta as ModelMeta | null) ?? undefined,
         userId: ctx.user.id,
         isModerator: ctx.user.isModerator,
       });
@@ -784,7 +830,14 @@ export const unpublishModelVersionHandler = async ({
         type: 'Unpublish',
         modelVersionId: id,
         modelId: scope.modelId,
-        nsfw: false,
+        nsfw: model.nsfw,
+      });
+      // The identical effect arriving through unpublishModelHandler emits this, so without it a
+      // model unpublish reached from the version menu is missing from any count of model unpublishes.
+      ctx.track.modelEvent({
+        type: 'Unpublish',
+        modelId: scope.modelId,
+        nsfw: model.nsfw,
       });
       await dataForModelsCache.refresh(scope.modelId);
       return getVersionById({ id, select: { id: true, status: true, modelId: true } });

--- a/src/server/routers/__tests__/model-version.unpublish-impact.router.test.ts
+++ b/src/server/routers/__tests__/model-version.unpublish-impact.router.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * `getUnpublishImpact` is the branch the cascade design rests on: it prices the refund at the scope
+ * the unpublish will actually run at, and returns that scope so the dialog words itself from it.
+ * Pricing per-version while the server unpublishes the whole model is the show-one-figure,
+ * debit-another divergence the design exists to prevent — and it is invisible to the controller
+ * suite, which mocks the resolver.
+ */
+
+const { mockResolveUnpublishScope, mockModelRequirement, mockVersionRequirement } = vi.hoisted(
+  () => ({
+    mockResolveUnpublishScope: vi.fn(),
+    mockModelRequirement: vi.fn(),
+    mockVersionRequirement: vi.fn(),
+  })
+);
+
+vi.mock('~/server/services/model-version.service', () => ({
+  resolveUnpublishScope: mockResolveUnpublishScope,
+}));
+vi.mock('~/server/services/model-early-access-refund.service', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getModelEarlyAccessRefundRequirement: mockModelRequirement,
+    getModelVersionEarlyAccessRefundRequirement: mockVersionRequirement,
+  };
+});
+
+import { getUnpublishImpact } from '~/server/routers/model-version.unpublish-impact';
+
+const VERSION_ID = 100;
+const MODEL_ID = 42;
+
+const requirement = (totalBuzz: number, buyerCount = 1) => ({
+  purchases: Array.from({ length: buyerCount }, (_, i) => ({
+    modelVersionId: VERSION_ID,
+    buyerId: 500 + i,
+    buzzTransactionIds: [`tx-${i}`],
+  })),
+  buyerCount,
+  totalBuzz,
+  totalsByAccount: { yellow: totalBuzz },
+  exemptBuyerCount: 0,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockModelRequirement.mockResolvedValue(requirement(900, 3));
+  mockVersionRequirement.mockResolvedValue(requirement(300, 1));
+});
+
+describe('getUnpublishImpact', () => {
+  it('prices the whole model when the take-down will cascade', async () => {
+    mockResolveUnpublishScope.mockResolvedValue({ kind: 'model', modelId: MODEL_ID });
+
+    const impact = await getUnpublishImpact(VERSION_ID);
+
+    expect(impact.scope).toBe('model');
+    expect(impact.totalBuzz).toBe(900);
+    expect(mockModelRequirement).toHaveBeenCalledWith({ id: MODEL_ID });
+    // The divergence this exists to prevent: pricing one version while the server takes the model.
+    expect(mockVersionRequirement).not.toHaveBeenCalled();
+  });
+
+  it('prices the version alone when the model stays up', async () => {
+    mockResolveUnpublishScope.mockResolvedValue({ kind: 'version', modelId: MODEL_ID });
+
+    const impact = await getUnpublishImpact(VERSION_ID);
+
+    expect(impact.scope).toBe('version');
+    expect(impact.totalBuzz).toBe(300);
+    expect(mockVersionRequirement).toHaveBeenCalledWith({ id: VERSION_ID });
+    // The mirror direction: over-pricing a version take-down as if the model were coming down would
+    // quote a creator for buyers who keep their access.
+    expect(mockModelRequirement).not.toHaveBeenCalled();
+  });
+
+  it('returns counts only, never a buyer identity', async () => {
+    mockResolveUnpublishScope.mockResolvedValue({ kind: 'model', modelId: MODEL_ID });
+
+    const impact = await getUnpublishImpact(VERSION_ID);
+
+    expect(impact).toEqual({
+      scope: 'model',
+      purchaseCount: 3,
+      buyerCount: 3,
+      totalBuzz: 900,
+      exemptBuyerCount: 0,
+    });
+  });
+});

--- a/src/server/routers/model-version.router.ts
+++ b/src/server/routers/model-version.router.ts
@@ -22,9 +22,12 @@ import {
 import { getByIdSchema } from '~/server/schema/base.schema';
 import type { EarlyAccessRefundSummary } from '~/server/services/model-early-access-refund.service';
 import {
+  getModelEarlyAccessRefundRequirement,
   getModelVersionEarlyAccessRefundRequirement,
   toEarlyAccessRefundSummary,
 } from '~/server/services/model-early-access-refund.service';
+import type { UnpublishScope } from '~/server/services/model-version.service';
+import { resolveUnpublishScope } from '~/server/services/model-version.service';
 import {
   mergeVersionsSchema,
   deleteExplorationPromptSchema,
@@ -188,14 +191,24 @@ export const modelVersionRouter = router({
     .input(unpublishModelSchema)
     .use(isOwnerOrModerator)
     .mutation(unpublishModelVersionHandler),
-  getEarlyAccessRefundRequirement: protectedProcedure
+  // Priced at the scope the unpublish will ACTUALLY run at. Taking down the last published version
+  // takes the model with it, and the model-scoped requirement covers every version — including
+  // siblings already down that still hold refundable grants, which a moderator take-down leaves in
+  // place. A dialog priced per-version there would show a creator one figure and debit another, and
+  // when the version figure is zero and the model figure is not, the mutation refuses with no way
+  // to consent. `scope` is what the dialog words itself from; it is not decoration.
+  getUnpublishImpact: protectedProcedure
     .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
-    .query(
-      async ({ input }): Promise<EarlyAccessRefundSummary> =>
-        toEarlyAccessRefundSummary(await getModelVersionEarlyAccessRefundRequirement(input))
-    ),
+    .query(async ({ input }): Promise<EarlyAccessRefundSummary & { scope: UnpublishScope }> => {
+      const scope = await resolveUnpublishScope(input.id);
+      const requirement =
+        scope.kind === 'model'
+          ? await getModelEarlyAccessRefundRequirement({ id: scope.modelId })
+          : await getModelVersionEarlyAccessRefundRequirement(input);
+      return { ...toEarlyAccessRefundSummary(requirement), scope: scope.kind };
+    }),
   upsertExplorationPrompt: protectedProcedure
     .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(upsertExplorationPromptSchema)

--- a/src/server/routers/model-version.router.ts
+++ b/src/server/routers/model-version.router.ts
@@ -20,14 +20,7 @@ import {
   upsertModelVersionHandler,
 } from '~/server/controllers/model-version.controller';
 import { getByIdSchema } from '~/server/schema/base.schema';
-import type { EarlyAccessRefundSummary } from '~/server/services/model-early-access-refund.service';
-import {
-  getModelEarlyAccessRefundRequirement,
-  getModelVersionEarlyAccessRefundRequirement,
-  toEarlyAccessRefundSummary,
-} from '~/server/services/model-early-access-refund.service';
-import type { UnpublishScope } from '~/server/services/model-version.service';
-import { resolveUnpublishScope } from '~/server/services/model-version.service';
+import { getUnpublishImpact } from '~/server/routers/model-version.unpublish-impact';
 import {
   mergeVersionsSchema,
   deleteExplorationPromptSchema,
@@ -201,14 +194,7 @@ export const modelVersionRouter = router({
     .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
-    .query(async ({ input }): Promise<EarlyAccessRefundSummary & { scope: UnpublishScope }> => {
-      const scope = await resolveUnpublishScope(input.id);
-      const requirement =
-        scope.kind === 'model'
-          ? await getModelEarlyAccessRefundRequirement({ id: scope.modelId })
-          : await getModelVersionEarlyAccessRefundRequirement(input);
-      return { ...toEarlyAccessRefundSummary(requirement), scope: scope.kind };
-    }),
+    .query(({ input }) => getUnpublishImpact(input.id)),
   upsertExplorationPrompt: protectedProcedure
     .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(upsertExplorationPromptSchema)

--- a/src/server/routers/model-version.unpublish-impact.ts
+++ b/src/server/routers/model-version.unpublish-impact.ts
@@ -1,0 +1,34 @@
+import {
+  getModelEarlyAccessRefundRequirement,
+  getModelVersionEarlyAccessRefundRequirement,
+  toEarlyAccessRefundSummary,
+  type EarlyAccessRefundSummary,
+} from '~/server/services/model-early-access-refund.service';
+import {
+  resolveUnpublishScope,
+  type UnpublishScope,
+} from '~/server/services/model-version.service';
+
+/**
+ * What unpublishing this version will actually do, priced at the scope it will run at.
+ *
+ * Taking down the last live version takes the model with it, and the model-scoped requirement
+ * covers every version — including siblings already down that still hold refundable grants, which a
+ * moderator take-down leaves in place. Pricing per-version there would show a creator one figure and
+ * debit another; and where the version figure is zero and the model figure is not, the mutation
+ * refuses with nothing in the UI able to consent. `scope` is what the dialog words itself from.
+ *
+ * Lives outside the router so it can be tested without the router's import graph — the branch here
+ * is the one the whole cascade design rests on.
+ */
+export const getUnpublishImpact = async (
+  id: number
+): Promise<EarlyAccessRefundSummary & { scope: UnpublishScope }> => {
+  const scope = await resolveUnpublishScope(id);
+  const requirement =
+    scope.kind === 'model'
+      ? await getModelEarlyAccessRefundRequirement({ id: scope.modelId })
+      : await getModelVersionEarlyAccessRefundRequirement({ id });
+
+  return { ...toEarlyAccessRefundSummary(requirement), scope: scope.kind };
+};

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -260,6 +260,16 @@ export const unpublishModelSchema = z.object({
   // Owner's explicit consent to refund all active early access purchases (debited from their
   // account) as part of unpublishing. Ignored for moderator unpublishes.
   refundEarlyAccess: z.boolean().optional(),
+  // What the confirm dialog priced, echoed back so the server can refuse when the world moved
+  // underneath it. `refundEarlyAccess: true` is a yes with no ceiling on its own: a sibling going
+  // down between the dialog's read and the mutation widens an unpublish from one version to a whole
+  // model and can debit the owner more Buzz than the figure they agreed to.
+  expected: z
+    .object({
+      scope: z.enum(['model', 'version']),
+      totalBuzz: z.number().int().nonnegative(),
+    })
+    .optional(),
 });
 
 export type ToggleModelLockInput = z.infer<typeof toggleModelLockSchema>;

--- a/src/server/services/__tests__/model-early-access-refund.service.test.ts
+++ b/src/server/services/__tests__/model-early-access-refund.service.test.ts
@@ -775,6 +775,12 @@ describe('unpublishModelById — early access refund gate', () => {
         unpublishModelById({ id: MODEL_ID, userId: OWNER_ID, reason: 'duplicate' })
       ).rejects.toThrowError(/Only a moderator/);
 
+      // customMessage alone is refused too — it is the conjunct a later simplification deletes for
+      // free, and it is the field that carries the explanation for reason 'other'.
+      await expect(
+        unpublishModelById({ id: MODEL_ID, userId: OWNER_ID, customMessage: 'mine now' })
+      ).rejects.toThrowError(/Only a moderator/);
+
       expect(mockTx.model.update).not.toHaveBeenCalled();
     });
 

--- a/src/server/services/__tests__/model-early-access-refund.service.test.ts
+++ b/src/server/services/__tests__/model-early-access-refund.service.test.ts
@@ -616,7 +616,13 @@ describe('unpublishModelById — early access refund gate', () => {
     setupRefundData({ accessRows: [] });
     setupUnpublishWrites();
 
-    await unpublishModelById({ id: MODEL_ID, userId: OWNER_ID, reason: 'duplicate' });
+    // A reason means a moderator now — an owner supplying one is refused outright.
+    await unpublishModelById({
+      id: MODEL_ID,
+      userId: OWNER_ID,
+      isModerator: true,
+      reason: 'duplicate',
+    });
 
     expect(takeDownSql()).toContain(
       `SET "status" = ?::"ModelStatus", "meta" = COALESCE("meta", '{}'::jsonb) ||`
@@ -716,6 +722,62 @@ describe('unpublishModelById — early access refund gate', () => {
       );
     });
 
+    // The too-wide direction. A guard that also fired on a stale `meta.unpublishedReason` would
+    // escalate ordinary owner unpublishes to UnpublishedViolation for any model taken down once and
+    // republished since — and every assertion above would still pass.
+    it('does not escalate a published model carrying a stale reason in meta', async () => {
+      setupRefundData({ accessRows: [] });
+      setupUnpublishWrites();
+      setupModelStatus('Published');
+
+      await unpublishModelById({
+        id: MODEL_ID,
+        userId: OWNER_ID,
+        meta: { unpublishedReason: 'duplicate', customMessage: 'from a previous take-down' },
+      });
+
+      expect(mockTx.model.update.mock.calls[0][0].data.status).toBe('Unpublished');
+    });
+
+    it('preserves Deleted too, not UnpublishedViolation alone', async () => {
+      // Deleted is the other moderator-only status; clearing it clears the republish gate and
+      // publishModelById then nulls deletedAt, completing an owner-driven restore.
+      setupRefundData({ accessRows: [] });
+      setupUnpublishWrites();
+      setupModelStatus('Deleted');
+
+      await unpublishModelById({ id: MODEL_ID, userId: OWNER_ID });
+
+      expect(mockTx.model.update.mock.calls[0][0].data.status).toBe('Deleted');
+    });
+
+    it('takes the versions down without restamping their meta', async () => {
+      // The version rows are what unpublish.notifications.ts selects on, per version, with no
+      // status predicate. Merging unpublishedAt into them on a preserved take-down re-fires the
+      // notification with the owner named as the actor of a moderator's decision.
+      setupRefundData({ accessRows: [] });
+      setupUnpublishWrites();
+      setupModelStatus('UnpublishedViolation');
+
+      await unpublishModelById({ id: MODEL_ID, userId: OWNER_ID });
+
+      expect(takeDownParams()[0]).toBe('UnpublishedViolation');
+      expect(JSON.parse(takeDownParams()[1] as string)).toEqual({});
+    });
+
+    it('refuses a reason from someone who is not a moderator', async () => {
+      // Otherwise the guard's precondition — "an owner-initiated unpublish carries no reason" — is
+      // an assumption, and an owner can rewrite the moderator's verdict by supplying one.
+      setupRefundData({ accessRows: [] });
+      setupUnpublishWrites();
+
+      await expect(
+        unpublishModelById({ id: MODEL_ID, userId: OWNER_ID, reason: 'duplicate' })
+      ).rejects.toThrowError(/Only a moderator/);
+
+      expect(mockTx.model.update).not.toHaveBeenCalled();
+    });
+
     // A moderator acting deliberately still writes their own verdict over the old one.
     it('lets a moderator restate the violation with a new reason', async () => {
       setupRefundData({ accessRows: [] });
@@ -727,14 +789,20 @@ describe('unpublishModelById — early access refund gate', () => {
         userId: 999,
         isModerator: true,
         reason: 'duplicate',
+        customMessage: 'new note',
         meta: { unpublishedReason: 'other', customMessage: 'old' },
       });
 
       const data = mockTx.model.update.mock.calls[0][0].data;
       expect(data.status).toBe('UnpublishedViolation');
-      expect(data.meta).toEqual(
-        expect.objectContaining({ unpublishedReason: 'duplicate', unpublishedBy: 999 })
-      );
+      // All four, not two: a customMessage falling back to the stored one leaves a new verdict
+      // carrying the old explanation.
+      expect(data.meta).toEqual({
+        unpublishedReason: 'duplicate',
+        customMessage: 'new note',
+        unpublishedAt: expect.any(String),
+        unpublishedBy: 999,
+      });
     });
   });
 

--- a/src/server/services/__tests__/model-early-access-refund.service.test.ts
+++ b/src/server/services/__tests__/model-early-access-refund.service.test.ts
@@ -180,6 +180,10 @@ function setupRefundData({
   ]);
 }
 
+function setupModelStatus(status: string) {
+  mockTx.model.findUniqueOrThrow.mockResolvedValue({ status });
+}
+
 function setupUnpublishWrites({
   // What the model update reports back: EVERY version of the model, drafts included — it carries no
   // where clause. Distinct from the transitioning set below, and conflating the two is the bug this
@@ -188,6 +192,8 @@ function setupUnpublishWrites({
   transitioningVersionIds = [VERSION_ID],
 }: { allVersionIds?: number[]; transitioningVersionIds?: number[] } = {}) {
   mockTx.$executeRaw.mockResolvedValue(transitioningVersionIds.length);
+  // Default: an ordinary published model. The violation cases override it.
+  setupModelStatus('Published');
   mockTx.model.update.mockResolvedValue({
     userId: OWNER_ID,
     modelVersions: allVersionIds.map((id) => ({ id })),
@@ -649,6 +655,87 @@ describe('unpublishModelById — early access refund gate', () => {
       'Published',
       'Scheduled',
     ]);
+  });
+
+  // 🔴 An owner-initiated unpublish carries no reason. Writing the status unconditionally would put
+  // a model a moderator took down back to plain Unpublished — and owner republish is blocked only
+  // WHILE the status is UnpublishedViolation, so that is an owner-reachable way to clear the flag.
+  describe('a model already taken down for a violation', () => {
+    it('keeps the violation status through a reasonless unpublish', async () => {
+      setupRefundData({ accessRows: [] });
+      setupUnpublishWrites();
+      setupModelStatus('UnpublishedViolation');
+
+      await unpublishModelById({ id: MODEL_ID, userId: OWNER_ID });
+
+      expect(mockTx.model.update.mock.calls[0][0].data.status).toBe('UnpublishedViolation');
+    });
+
+    it('decides from the STATUS, not from a reason in meta', async () => {
+      // 2,327 of 43,492 violation rows in prod carry no reason in meta. Keying the guard on meta
+      // fails open for exactly the rows nobody wrote through this code.
+      setupRefundData({ accessRows: [] });
+      setupUnpublishWrites();
+      setupModelStatus('UnpublishedViolation');
+
+      await unpublishModelById({ id: MODEL_ID, userId: OWNER_ID, meta: {} });
+
+      expect(mockTx.model.update.mock.calls[0][0].data.status).toBe('UnpublishedViolation');
+    });
+
+    it('leaves the moderator record intact — actor, explanation and timestamp', async () => {
+      // customMessage is the ONLY explanation rendered when the reason is 'other', which is the
+      // largest bucket in prod; and refreshing unpublishedAt re-fires the take-down notification.
+      setupRefundData({ accessRows: [] });
+      setupUnpublishWrites();
+      setupModelStatus('UnpublishedViolation');
+      const moderatorRecord = {
+        unpublishedReason: 'other',
+        customMessage: 'Reviewed by a human',
+        unpublishedAt: '2020-01-01T00:00:00.000Z',
+        unpublishedBy: 999,
+      };
+
+      await unpublishModelById({ id: MODEL_ID, userId: OWNER_ID, meta: { ...moderatorRecord } });
+
+      expect(mockTx.model.update.mock.calls[0][0].data.meta).toEqual(moderatorRecord);
+    });
+
+    // Negative control: a guard that preserved unconditionally would leave every ordinary unpublish
+    // unrecorded, and each assertion above would still pass.
+    it('still stamps an ordinary unpublish of a model that carries no violation', async () => {
+      setupRefundData({ accessRows: [] });
+      setupUnpublishWrites();
+
+      await unpublishModelById({ id: MODEL_ID, userId: OWNER_ID });
+
+      const data = mockTx.model.update.mock.calls[0][0].data;
+      expect(data.status).toBe('Unpublished');
+      expect(data.meta).toEqual(
+        expect.objectContaining({ unpublishedBy: OWNER_ID, unpublishedAt: expect.any(String) })
+      );
+    });
+
+    // A moderator acting deliberately still writes their own verdict over the old one.
+    it('lets a moderator restate the violation with a new reason', async () => {
+      setupRefundData({ accessRows: [] });
+      setupUnpublishWrites();
+      setupModelStatus('UnpublishedViolation');
+
+      await unpublishModelById({
+        id: MODEL_ID,
+        userId: 999,
+        isModerator: true,
+        reason: 'duplicate',
+        meta: { unpublishedReason: 'other', customMessage: 'old' },
+      });
+
+      const data = mockTx.model.update.mock.calls[0][0].data;
+      expect(data.status).toBe('UnpublishedViolation');
+      expect(data.meta).toEqual(
+        expect.objectContaining({ unpublishedReason: 'duplicate', unpublishedBy: 999 })
+      );
+    });
   });
 
   it('does not gate or refund on a moderator unpublish', async () => {

--- a/src/server/services/__tests__/model-version.purge-by-hash.service.test.ts
+++ b/src/server/services/__tests__/model-version.purge-by-hash.service.test.ts
@@ -236,6 +236,8 @@ describe('unpublishModelVersionById — by-hash edge-cache purge', () => {
     // Nothing was ever bought here, so the refund gate finds no obligation and lets the
     // unpublish through — this file is about the cache purge, not the gate.
     mockDb.modelVersion.findMany.mockResolvedValue([{ id: VERSION_ID, meta: null }]);
+    // An ordinary published version, so the moderator-status guard does not preserve anything.
+    mockDb.modelVersion.findUniqueOrThrow.mockResolvedValue({ status: 'Published' });
   }
 
   it('resolves the version hashes and purges the by-hash URL(s)', async () => {

--- a/src/server/services/__tests__/model-version.unpublish-refund.service.test.ts
+++ b/src/server/services/__tests__/model-version.unpublish-refund.service.test.ts
@@ -14,7 +14,7 @@ const { mockTx } = vi.hoisted(() => ({
   // Separate from the write client on purpose: modelVersion.update is asserted as "inside the
   // transaction", which collapses if $transaction hands back dbWrite itself.
   mockTx: {
-    modelVersion: { update: vi.fn() },
+    modelVersion: { update: vi.fn(), findUniqueOrThrow: vi.fn() },
     $executeRaw: vi.fn(),
   },
 }));
@@ -144,6 +144,8 @@ function seedPurchase({
 }
 
 function seedUnpublishWrites() {
+  // Read inside the transaction, so it is the tx client and not dbWrite.
+  mockTx.modelVersion.findUniqueOrThrow.mockResolvedValue({ status: 'Published' });
   mockTx.modelVersion.update.mockResolvedValue({
     id: VERSION_ID,
     model: { id: MODEL_ID, userId: OWNER_ID, nsfw: false },
@@ -266,6 +268,62 @@ describe('toEarlyAccessRefundSummary', () => {
       totalBuzz: 300,
       exemptBuyerCount: 0,
     });
+  });
+});
+
+// 🔴 The shorter path to the same bypass the model-level guard closes: a moderator takes ONE
+// version down, the owner unpublishes that version with no reason, and without this it lands at
+// plain Unpublished with the owner as the actor — which is all the status-keyed republish gate
+// checks. One call, no setup.
+describe('unpublishModelVersionById — a version already taken down by a moderator', () => {
+  const seedStatus = (status: string) => {
+    dbMock.dbWrite.modelVersion.findMany.mockResolvedValue([]);
+    mockTx.modelVersion.update.mockResolvedValue({
+      id: VERSION_ID,
+      model: { id: MODEL_ID, userId: OWNER_ID, nsfw: false },
+    });
+    mockTx.modelVersion.findUniqueOrThrow.mockResolvedValue({ status });
+    dbMock.dbWrite.post.findMany.mockResolvedValue([]);
+    dbMock.dbWrite.image.findMany.mockResolvedValue([]);
+  };
+
+  it.each(['UnpublishedViolation', 'Deleted'])(
+    'keeps %s through a reasonless owner unpublish',
+    async (status) => {
+      seedStatus(status);
+
+      await unpublishModelVersionById({ id: VERSION_ID, user: owner });
+
+      expect(mockTx.modelVersion.update.mock.calls[0][0].data.status).toBe(status);
+    }
+  );
+
+  it('leaves the moderator record intact rather than restamping it', async () => {
+    seedStatus('UnpublishedViolation');
+    const moderatorRecord = {
+      unpublishedReason: 'other',
+      customMessage: 'Reviewed by a human',
+      unpublishedAt: '2020-01-01T00:00:00.000Z',
+      unpublishedBy: 999,
+    };
+
+    await unpublishModelVersionById({ id: VERSION_ID, user: owner, meta: { ...moderatorRecord } });
+
+    expect(mockTx.modelVersion.update.mock.calls[0][0].data.meta).toEqual(moderatorRecord);
+  });
+
+  // Negative control: preserving unconditionally would leave every ordinary version unpublish
+  // unrecorded, and each assertion above would still pass.
+  it('still stamps an ordinary unpublish of a published version', async () => {
+    seedStatus('Published');
+
+    await unpublishModelVersionById({ id: VERSION_ID, user: owner });
+
+    const data = mockTx.modelVersion.update.mock.calls[0][0].data;
+    expect(data.status).toBe('Unpublished');
+    expect(data.meta).toEqual(
+      expect.objectContaining({ unpublishedBy: OWNER_ID, unpublishedAt: expect.any(String) })
+    );
   });
 });
 

--- a/src/server/services/__tests__/model-version.unpublish-refund.service.test.ts
+++ b/src/server/services/__tests__/model-version.unpublish-refund.service.test.ts
@@ -312,6 +312,52 @@ describe('unpublishModelVersionById — a version already taken down by a modera
     expect(mockTx.modelVersion.update.mock.calls[0][0].data.meta).toEqual(moderatorRecord);
   });
 
+  // 🔴 The `!reason` conjunct. Without it a moderator restating a verdict on an
+  // already-UnpublishedViolation version — or taking a Deleted one down with a fresh reason — has
+  // their new verdict silently discarded: old status kept, meta untouched, no error.
+  it('lets a moderator restate the verdict on a version already taken down', async () => {
+    seedStatus('UnpublishedViolation');
+
+    await unpublishModelVersionById({
+      id: VERSION_ID,
+      user: moderator,
+      reason: 'duplicate',
+      customMessage: 'new note',
+      meta: { unpublishedReason: 'other', customMessage: 'old' },
+    });
+
+    const data = mockTx.modelVersion.update.mock.calls[0][0].data;
+    expect(data.status).toBe('UnpublishedViolation');
+    expect(data.meta).toEqual({
+      unpublishedReason: 'duplicate',
+      customMessage: 'new note',
+      unpublishedAt: expect.any(String),
+      unpublishedBy: moderator.id,
+    });
+  });
+
+  it('refuses a reason from someone who is not a moderator', async () => {
+    // Otherwise the preserve guard's precondition holds on the model half and is merely assumed
+    // here — and this is the half whose meta the per-version notification selects on.
+    seedStatus('UnpublishedViolation');
+
+    await expect(
+      unpublishModelVersionById({ id: VERSION_ID, user: owner, reason: 'duplicate' })
+    ).rejects.toThrowError(/Only a moderator/);
+
+    expect(mockTx.modelVersion.update).not.toHaveBeenCalled();
+  });
+
+  it('writes no meta at all when the caller passed none', async () => {
+    // Pins the `?? undefined` on the preserve path: `?? {}` would write an empty object over the
+    // moderator's record rather than leaving the column alone.
+    seedStatus('UnpublishedViolation');
+
+    await unpublishModelVersionById({ id: VERSION_ID, user: owner });
+
+    expect(mockTx.modelVersion.update.mock.calls[0][0].data.meta).toBeUndefined();
+  });
+
   // Negative control: preserving unconditionally would leave every ordinary version unpublish
   // unrecorded, and each assertion above would still pass.
   it('still stamps an ordinary unpublish of a published version', async () => {

--- a/src/server/services/__tests__/model-version.unpublish-scope.service.test.ts
+++ b/src/server/services/__tests__/model-version.unpublish-scope.service.test.ts
@@ -99,13 +99,20 @@ describe('resolveUnpublishScope', () => {
     });
   });
 
-  it('counts only OTHER published versions of the same model', async () => {
+  it('counts a Scheduled sibling as live, so a pending release is never taken down', async () => {
     dbMock.dbWrite.modelVersion.count.mockResolvedValue(0);
 
     await resolveUnpublishScope(VERSION_ID);
 
+    // unpublishModelById takes Published AND Scheduled versions down, so counting only Published
+    // would cascade past a pending release and unpublish tomorrow's launch on a confirm whose copy
+    // said "this is the only published version".
     expect(dbMock.dbWrite.modelVersion.count).toHaveBeenCalledWith({
-      where: { modelId: MODEL_ID, status: 'Published', id: { not: VERSION_ID } },
+      where: {
+        modelId: MODEL_ID,
+        status: { in: ['Published', 'Scheduled'] },
+        id: { not: VERSION_ID },
+      },
     });
   });
 

--- a/src/server/services/__tests__/model-version.unpublish-scope.service.test.ts
+++ b/src/server/services/__tests__/model-version.unpublish-scope.service.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * `resolveUnpublishScope` decides whether unpublishing one version takes the whole model down. Both
+ * the confirm dialog and the mutation call it, so what a creator consents to and what the server
+ * does come from one answer — and it reads the PRIMARY, because deciding a take-down against a
+ * lagged replica either drops a model whose sibling has just gone live, or leaves a model published
+ * with nothing published under it.
+ */
+
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, dbReadFallbackCounter: { inc: vi.fn() } };
+});
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
+vi.mock('~/server/redis/caches', () => ({
+  modelVersionPublicDonationGoalsCache: { fetch: vi.fn(), bust: vi.fn() },
+  dataForModelsCache: { refresh: vi.fn() },
+  modelVersionAccessCache: { refresh: vi.fn() },
+}));
+vi.mock('~/server/redis/resource-data.redis', () => ({ resourceDataCache: { bust: vi.fn() } }));
+vi.mock('~/server/search-index', () => ({
+  modelsSearchIndex: { queueUpdate: vi.fn() },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+  imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
+}));
+vi.mock('~/server/services/paid-access.service', () => ({
+  materializePaidAccessEndsAt: vi.fn(),
+  writePaidAccessForModelVersion: vi.fn(),
+  getPaidAccess: vi.fn(),
+  assertPaidAccessInput: vi.fn(),
+}));
+vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));
+vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));
+vi.mock('~/server/services/buzz.service', () => ({
+  createMultiAccountBuzzTransaction: vi.fn(),
+  getMultiAccountTransactionsByPrefix: vi.fn(),
+  getUserBuzzAccountByAccountTypes: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+}));
+vi.mock('~/server/services/common.service', () => ({ hasEntityAccess: vi.fn() }));
+vi.mock('~/server/services/donation-goal.service', () => ({
+  checkDonationGoalComplete: vi.fn(),
+  ensureDonationGoal: vi.fn(),
+  getDonationGoals: vi.fn(),
+  getOwnerDonationGoals: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', () => ({
+  imagesForModelVersionsCache: { refresh: vi.fn() },
+  uploadImageFromUrl: vi.fn(),
+}));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
+vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
+vi.mock('~/server/services/model.service', () => ({
+  ingestModelById: vi.fn().mockResolvedValue(undefined),
+  updateModelLastVersionAt: vi.fn(),
+}));
+vi.mock('~/server/services/model-file.service', () => ({
+  deleteFilesForModelVersionCache: vi.fn(),
+  findOfficialFileByHash: vi.fn(),
+}));
+vi.mock('~/server/services/monetization-rights.service', () => ({
+  resolveRightsAffirmation: vi.fn(),
+}));
+
+import { resolveUnpublishScope } from '~/server/services/model-version.service';
+
+const VERSION_ID = 100;
+const MODEL_ID = 42;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMock.dbWrite.modelVersion.findUniqueOrThrow.mockResolvedValue({
+    modelId: MODEL_ID,
+    status: 'Published',
+  });
+});
+
+describe('resolveUnpublishScope', () => {
+  it('cascades to the model when no other published version remains', async () => {
+    dbMock.dbWrite.modelVersion.count.mockResolvedValue(0);
+
+    await expect(resolveUnpublishScope(VERSION_ID)).resolves.toEqual({
+      kind: 'model',
+      modelId: MODEL_ID,
+    });
+  });
+
+  // Negative control: a resolver that always cascaded would take a twelve-version model down over
+  // one retired version, and would satisfy the assertion above.
+  it('stays version-scoped while another published version remains', async () => {
+    dbMock.dbWrite.modelVersion.count.mockResolvedValue(1);
+
+    await expect(resolveUnpublishScope(VERSION_ID)).resolves.toEqual({
+      kind: 'version',
+      modelId: MODEL_ID,
+    });
+  });
+
+  it('counts only OTHER published versions of the same model', async () => {
+    dbMock.dbWrite.modelVersion.count.mockResolvedValue(0);
+
+    await resolveUnpublishScope(VERSION_ID);
+
+    expect(dbMock.dbWrite.modelVersion.count).toHaveBeenCalledWith({
+      where: { modelId: MODEL_ID, status: 'Published', id: { not: VERSION_ID } },
+    });
+  });
+
+  it('never cascades off a version that is not itself published', async () => {
+    // Otherwise saving a draft on a model with nothing published runs a full model unpublish.
+    dbMock.dbWrite.modelVersion.findUniqueOrThrow.mockResolvedValue({
+      modelId: MODEL_ID,
+      status: 'Draft',
+    });
+    dbMock.dbWrite.modelVersion.count.mockResolvedValue(0);
+
+    await expect(resolveUnpublishScope(VERSION_ID)).resolves.toEqual({
+      kind: 'version',
+      modelId: MODEL_ID,
+    });
+    // And it does not even ask — the count is what a replica read would have raced on.
+    expect(dbMock.dbWrite.modelVersion.count).not.toHaveBeenCalled();
+  });
+
+  it('decides on the primary, never the replica', async () => {
+    dbMock.dbWrite.modelVersion.count.mockResolvedValue(0);
+
+    await resolveUnpublishScope(VERSION_ID);
+
+    // Replica lag here either takes down a model whose sibling has just been published, or leaves
+    // the empty published model this cascade exists to prevent.
+    expect(dbMock.dbRead.modelVersion.count).not.toHaveBeenCalled();
+    expect(dbMock.dbRead.modelVersion.findUniqueOrThrow).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -120,6 +120,7 @@ import { addPostImage, createPost } from '~/server/services/post.service';
 import { createCachedArray } from '~/server/utils/cache-helpers';
 import {
   sleep,
+  throwAuthorizationError,
   throwBadRequestError,
   throwDbError,
   throwNotFoundError,
@@ -1715,6 +1716,13 @@ export const unpublishModelVersionById = async ({
   // revokes its buyers' access, so recent purchases have to be refunded first. Moderators bypass it
   // exactly as they do in unpublishModelById.
   if (!user.isModerator) {
+    // Same rule as unpublishModelById: only a moderator gives a reason. Without it the preserve
+    // guard below has a precondition rather than an assumption on one half and not the other — an
+    // owner supplying a reason takes the non-preserve branch, overwrites a moderator's verdict and
+    // attribution on the version they took down, and re-fires the per-version notification.
+    if (reason || customMessage)
+      throw throwAuthorizationError('Only a moderator can give a reason for unpublishing.');
+
     const requirement = await getModelVersionEarlyAccessRefundRequirement({ id });
     if (requirement.purchases.length > 0) {
       if (!refundEarlyAccess) {

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -1659,6 +1659,36 @@ export const publishModelVersionById = async ({
   return version;
 };
 
+/**
+ * Whether unpublishing this version takes the whole model down with it.
+ *
+ * 🔴 Read from the PRIMARY. On a replica this decides a take-down against lagged rows: stale-low
+ * unpublishes a model whose sibling has just been published, and stale-high leaves a model
+ * Published with nothing published under it — the state the cascade exists to prevent.
+ *
+ * The dialog and the mutation both call this, so what a creator consents to and what the server
+ * does come from one answer rather than two that have to agree.
+ */
+export type UnpublishScope = 'model' | 'version';
+
+export const resolveUnpublishScope = async (
+  id: number
+): Promise<{ kind: UnpublishScope; modelId: number }> => {
+  const version = await dbWrite.modelVersion.findUniqueOrThrow({
+    where: { id },
+    select: { modelId: true, status: true },
+  });
+  // A version that is not itself published cannot be the last published one; treating it as such
+  // would run a full model unpublish off an edit to a draft.
+  if (version.status !== ModelStatus.Published)
+    return { kind: 'version', modelId: version.modelId };
+
+  const publishedSiblings = await dbWrite.modelVersion.count({
+    where: { modelId: version.modelId, status: ModelStatus.Published, id: { not: id } },
+  });
+  return { kind: publishedSiblings === 0 ? 'model' : 'version', modelId: version.modelId };
+};
+
 export const unpublishModelVersionById = async ({
   id,
   reason,

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -1662,6 +1662,11 @@ export const publishModelVersionById = async ({
 /**
  * Whether unpublishing this version takes the whole model down with it.
  *
+ * It removes the SURPRISE, not the state: unpublishing a Published version while a Scheduled one
+ * waits leaves the model up (correct — a release is coming), and unpublishing that scheduled version
+ * afterwards takes the early return, so a model can still end up published with nothing live under
+ * it in two ordinary steps. Closing that needs a rule about scheduled versions, not a bigger count.
+ *
  * 🔴 Read from the PRIMARY. On a replica this decides a take-down against lagged rows: stale-low
  * unpublishes a model whose sibling has just been published, and stale-high leaves a model
  * Published with nothing published under it — the state the cascade exists to prevent.

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -1733,22 +1733,45 @@ export const unpublishModelVersionById = async ({
   const unpublishedAt = new Date().toISOString();
   const version = await dbWrite.$transaction(
     async (tx) => {
+      // 🔴 Same rule as unpublishModelById, and this is the SHORTER path to the same place: a
+      // moderator takes one version down, the owner calls unpublish on it with no reason, and
+      // without this it lands at plain Unpublished with the owner as the actor — which is all the
+      // status-keyed republish gate checks. One call, no setup.
+      //
+      // Preserves any moderator-only status, not UnpublishedViolation alone: Deleted is the other
+      // one, and clearing it lets an owner republish a soft-deleted version.
+      const existing = await tx.modelVersion.findUniqueOrThrow({
+        where: { id },
+        select: { status: true },
+      });
+      const preserveModStatus =
+        !reason && constants.modPublishOnlyStatuses.includes(existing.status);
+
       const updatedVersion = await tx.modelVersion.update({
         where: { id },
         data: {
-          status: reason ? ModelStatus.UnpublishedViolation : ModelStatus.Unpublished,
+          status: reason
+            ? ModelStatus.UnpublishedViolation
+            : preserveModStatus
+            ? existing.status
+            : ModelStatus.Unpublished,
 
-          meta: {
-            ...meta,
-            ...(reason
-              ? {
-                  unpublishedReason: reason,
-                  customMessage,
-                }
-              : {}),
-            unpublishedAt,
-            unpublishedBy: user.id,
-          },
+          // Untouched on the preserve path: the moderator's explanation is what the take-down
+          // notification and the model-page banner render, and refreshing unpublishedAt re-fires
+          // that notification against the creator with the owner named as the actor.
+          meta: preserveModStatus
+            ? (meta as Prisma.ModelVersionUpdateInput['meta']) ?? undefined
+            : {
+                ...meta,
+                ...(reason
+                  ? {
+                      unpublishedReason: reason,
+                      customMessage,
+                    }
+                  : {}),
+                unpublishedAt,
+                unpublishedBy: user.id,
+              },
         },
         select: { id: true, model: { select: { id: true, userId: true, nsfw: true } } },
       });

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -1683,10 +1683,19 @@ export const resolveUnpublishScope = async (
   if (version.status !== ModelStatus.Published)
     return { kind: 'version', modelId: version.modelId };
 
-  const publishedSiblings = await dbWrite.modelVersion.count({
-    where: { modelId: version.modelId, status: ModelStatus.Published, id: { not: id } },
+  // Scheduled counts as a sibling. unpublishModelById takes Published AND Scheduled versions down,
+  // so cascading past a pending release would silently unpublish tomorrow's launch on a confirm
+  // whose copy said "this is the only published version" — true, and not what the creator agreed to.
+  // Leaving the model published with a scheduled release under it is the correct outcome: something
+  // is coming.
+  const liveSiblings = await dbWrite.modelVersion.count({
+    where: {
+      modelId: version.modelId,
+      status: { in: [ModelStatus.Published, ModelStatus.Scheduled] },
+      id: { not: id },
+    },
   });
-  return { kind: publishedSiblings === 0 ? 'model' : 'version', modelId: version.modelId };
+  return { kind: liveSiblings === 0 ? 'model' : 'version', modelId: version.modelId };
 };
 
 export const unpublishModelVersionById = async ({

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2789,6 +2789,14 @@ export const unpublishModelById = async ({
   isModerator?: boolean;
 }) => {
   if (!isModerator) {
+    // The guard below reasons from "an owner-initiated unpublish carries no reason". `reason` is a
+    // plain optional input, so without this that is an assumption rather than a precondition: an
+    // owner supplying one takes the non-preserve branch and overwrites the moderator's verdict,
+    // explanation and attribution — no republish escape, but the record destroyed by the person it
+    // is against, and the take-down notification re-fired.
+    if (reason || customMessage)
+      throw throwAuthorizationError('Only a moderator can give a reason for unpublishing.');
+
     const requirement = await getModelEarlyAccessRefundRequirement({ id });
     if (requirement.purchases.length > 0) {
       if (!refundEarlyAccess) {
@@ -2816,10 +2824,13 @@ export const unpublishModelById = async ({
         where: { id },
         select: { status: true },
       });
-      const preserveViolation = !reason && existing.status === ModelStatus.UnpublishedViolation;
+      // Any moderator-only status, not UnpublishedViolation alone: Deleted is the other one, and
+      // clearing it lets an owner republish a soft-deleted model.
+      const preserveModStatus =
+        !reason && constants.modPublishOnlyStatuses.includes(existing.status);
 
       const unpublishedAt = new Date().toISOString();
-      const updatedMeta = preserveViolation
+      const updatedMeta = preserveModStatus
         ? meta
         : {
             ...meta,
@@ -2835,10 +2846,11 @@ export const unpublishModelById = async ({
       const updatedModel = await tx.model.update({
         where: { id },
         data: {
-          status:
-            reason || preserveViolation
-              ? ModelStatus.UnpublishedViolation
-              : ModelStatus.Unpublished,
+          status: reason
+            ? ModelStatus.UnpublishedViolation
+            : preserveModStatus
+            ? existing.status
+            : ModelStatus.Unpublished,
           meta: updatedMeta,
         },
         select: { userId: true, modelVersions: { select: { id: true } } },
@@ -2855,6 +2867,11 @@ export const unpublishModelById = async ({
       // and then delete the version past every guard. `updateMany` cannot write a different value
       // per row, hence raw SQL.
       //
+      // On a preserved take-down the status follows the model but the NARRATIVE does not: merging
+      // unpublishedAt into version meta re-fires the per-version notification —
+      // unpublish.notifications.ts selects on that meta with no status predicate — naming the owner
+      // as the actor of a moderator's decision.
+      //
       // 🔴 And the keys must land on exactly the versions this call takes down. They are what
       // unpublish.notifications.ts selects on — meta alone, no status predicate, keyed per version —
       // so stamping a draft tells the creator a version they never published was unpublished.
@@ -2863,13 +2880,21 @@ export const unpublishModelById = async ({
       await tx.$executeRaw`
         UPDATE "ModelVersion"
         SET "status" = ${
-          reason ? ModelStatus.UnpublishedViolation : ModelStatus.Unpublished
+          reason
+            ? ModelStatus.UnpublishedViolation
+            : preserveModStatus
+            ? existing.status
+            : ModelStatus.Unpublished
         }::"ModelStatus",
-            "meta" = COALESCE("meta", '{}'::jsonb) || ${JSON.stringify({
-              ...(reason ? { unpublishedReason: reason, customMessage } : {}),
-              unpublishedAt,
-              unpublishedBy: userId,
-            })}::jsonb,
+            "meta" = COALESCE("meta", '{}'::jsonb) || ${JSON.stringify(
+              preserveModStatus
+                ? {}
+                : {
+                    ...(reason ? { unpublishedReason: reason, customMessage } : {}),
+                    unpublishedAt,
+                    unpublishedBy: userId,
+                  }
+            )}::jsonb,
             -- Prisma's @updatedAt does not apply to raw SQL, and there is no DB default or trigger.
             -- Without this a taken-down version keeps a pre-take-down updatedAt, which is on the
             -- public v1 payload via modelVersion.selector.

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2802,22 +2802,43 @@ export const unpublishModelById = async ({
 
   const model = await dbWrite.$transaction(
     async (tx) => {
+      // 🔴 Never write a moderator's verdict down. A reasonless unpublish — every owner-initiated
+      // one — would otherwise overwrite an existing UnpublishedViolation with plain Unpublished and
+      // restamp the record, and `model.controller.ts` blocks an owner republish only WHILE the
+      // status is UnpublishedViolation. That is an owner-reachable way to clear a moderation flag.
+      //
+      // Decided from the STATUS, not from `meta.unpublishedReason`: 2,327 of 43,492 violation rows
+      // in prod carry no reason in meta, and keying on meta fails open for exactly those. The
+      // moderator's explanation, timestamp and actor are all left untouched — refreshing
+      // `unpublishedAt` alone re-fires the take-down notification, and `customMessage` is the ONLY
+      // explanation rendered when the reason is 'other', which is the largest bucket.
+      const existing = await tx.model.findUniqueOrThrow({
+        where: { id },
+        select: { status: true },
+      });
+      const preserveViolation = !reason && existing.status === ModelStatus.UnpublishedViolation;
+
       const unpublishedAt = new Date().toISOString();
-      const updatedMeta = {
-        ...meta,
-        ...(reason
-          ? {
-              unpublishedReason: reason,
-              customMessage,
-            }
-          : {}),
-        unpublishedAt,
-        unpublishedBy: userId,
-      };
+      const updatedMeta = preserveViolation
+        ? meta
+        : {
+            ...meta,
+            ...(reason
+              ? {
+                  unpublishedReason: reason,
+                  customMessage,
+                }
+              : {}),
+            unpublishedAt,
+            unpublishedBy: userId,
+          };
       const updatedModel = await tx.model.update({
         where: { id },
         data: {
-          status: reason ? ModelStatus.UnpublishedViolation : ModelStatus.Unpublished,
+          status:
+            reason || preserveViolation
+              ? ModelStatus.UnpublishedViolation
+              : ModelStatus.Unpublished,
           meta: updatedMeta,
         },
         select: { userId: true, modelVersions: { select: { id: true } } },


### PR DESCRIPTION
Justin's decision, split out of #4106 after review found the cascade unsafe beside the refund-predicate change in that PR. That interaction is fixed and merged (#4106, #4113); the three findings against the cascade itself are addressed here.

## The state this removes

Unpublishing a model's only published version left the model **published with nothing published under it** — a state the model page, the listings and search all have to render, and one nobody chose.

## One decision, read from the primary

`resolveUnpublishScope` answers "does taking this version down take the model with it", and **both the confirm dialog and the mutation call it**, so what a creator consents to and what the server does come from one answer rather than two that have to agree.

It reads `dbWrite`. On a replica, stale-low takes down a model whose sibling has just been published; stale-high — or two concurrent version unpublishes each seeing the other — leaves exactly the empty model this exists to prevent. A version that is not itself `Published` never cascades, so saving a draft on a model with nothing published cannot run a model unpublish.

## Delegation, not two take-downs

The handler calls `unpublishModelById` rather than unpublishing the version and then the model. That already unpublishes every published version and runs the model-scoped refund gate, so **a refusal happens before anything moves** instead of leaving the version down and the model up.

## The dialog is priced at the scope that will run

This was the sharpest review finding against the original cascade. A model-scoped requirement covers **every** version — including siblings already down that still hold refundable grants, which a moderator take-down leaves in place. So a version-priced dialog could show a creator one figure and debit another, with a sibling's buyers revoked and never mentioned. Worse: where the version figure is zero and the model figure is not, the mutation refused and the menu offered **no way to consent at all**.

`modelVersion.getUnpublishImpact` returns the scope it priced. The copy leads with the cascade — *"This is the only published version, so unpublishing it takes the whole model down with it — every version, its posts, and any active auction bids"* — before it mentions money, because that is the part that surprises.

## Tests

`model-version.unpublish-scope.service.test.ts` (5) and `model-version.controller.unpublish-cascade.test.ts` (5). Mutations, each committed-then-mutated so the restore cannot revert the fix:

| Mutation | Result |
|---|---|
| Decision read from the replica | 3 failed |
| Draft guard removed (a non-published version cascades) | 1 failed |
| Cascade fires unconditionally | covered by the negative control |
| Model refusal replaced by a plain `Error` | matcher names the refusal, so a generic 500 fails it |

Both suites carry a negative control, and the analytics event is pinned — the cascade branch returns early and `unpublishModelById` fires no version event, so without it a last-version take-down is invisible to analytics.

## Deliberately not here

The by-hash edge purge: `unpublishModelById` has no equivalent to `purgeModelVersionByHashCacheById`, so a cascaded take-down stays resolvable by hash from the edge for up to ~1.5h. **Justin has accepted that delay explicitly.** `requestReview` remains version-scoped after a cascading violation take-down — carried forward, not addressed here.

## Verification

- `TYPECHECK_HEAP_MB=12288 pnpm run typecheck` — `OK — 0 type errors in 45s`
- `pnpm run test:lint-rules` — `Tests 243 passed (243)`
- `pnpm run test:unit:run` — `Test Files 3 failed | 1182 passed | 1 skipped (1186)`, `Tests 5 failed | 18671 passed | 23 skipped (18699)`. The 5 are the three Windows-only source-scanning guards, proven by the same files passing on CI's Linux runners.
- eslint on the changed files — 0 errors; the 4 warnings in the controller are pre-existing symbols at lines 84–695.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 2 — four blockers, fixed

**1. An owner could clear a moderator's violation flag.** An owner-initiated unpublish carries no reason, so delegating to `unpublishModelById` overwrote `Model.status` — including an existing `UnpublishedViolation` — with plain `Unpublished`, and rewrote `meta.unpublishedBy` to the owner over the moderator. Owner republish is blocked *only while* the status is `UnpublishedViolation`, and a moderator take-down leaves `Draft` versions unstamped, so the route was: publish a draft under a taken-down model → unpublish it → cascade clears the flag → republish. The cascade now preserves a violation status it did not set.

**2. A scheduled release could be taken down silently.** The resolver counted only `Published` siblings; `unpublishModelById` unpublishes `Published` **and** `Scheduled`. A model with one published version and one scheduled release would have had tomorrow's launch unpublished by a confirm whose copy said "this is the only published version" — true, and not what the creator agreed to. `Scheduled` now counts as a live sibling, so a model with a pending release stays up.

**3. Consent had no ceiling.** `refundEarlyAccess: true` was an unbounded yes. A sibling going down between pricing the dialog and confirming it widens a version take-down into a model one, and `unpublishModelById` prices every version — so the creator could be debited well past the figure they agreed to. The dialog now echoes the scope and total it priced; the mutation refuses when either moved against the creator, and proceeds when the debit shrank (the copy was merely pessimistic).

**4. The branch the design rests on had no test.** `getUnpublishImpact` was exercised nowhere — the controller suite mocks the resolver, so swapping the router's ternary to always price the version turned nothing red. That is exactly the show-one-figure-debit-another divergence this design exists to prevent. It is now its own module with its own suite covering both branches and the returned scope.

Also fixed: the model event a version-menu cascade should emit (the identical effect through `unpublishModelHandler` emits one, so these were missing from any count of model unpublishes), the real `nsfw` value rather than a hardcoded `false`, a NotFound instead of silently wiping the model's meta when `getModel` returns null, and two test claims trimmed to what a suite mocking `unpublishModelById` can actually observe.

## Two accepted consequences, decided by Justin rather than assumed

- **The moderator "Unpublish as Violation" flow cascades too.** A moderator taking down the last live version issues a **model-level** violation, covering versions they never judged, and the creator's route back becomes model-level review rather than per-version. Reviewed and accepted as intended.
- **The by-hash edge window now applies to the version route.** A cascading take-down returns before `purgeModelVersionByHashCacheById`, and `unpublishModelById` has no equivalent, so the file stays resolvable by hash from the edge for up to ~1.5h — **including a moderator take-down of violating content**. Re-confirmed with that framing attached, and accepted.

## Carried forward, not addressed here

`requestReview` remains version-scoped after a cascading violation take-down. The impact endpoint can issue a few hundred ledger calls on one menu click at `staleTime: 0` (pre-existing; `totalBuzz` needs no per-prefix reads and a summed query would collapse it). The cascade branch re-implements `unpublishModelHandler` and could delegate to it instead. Removing `modelVersion.getEarlyAccessRefundRequirement` has no internal callers but was reachable by OAuth-scoped tokens with no deprecation window.
