### PR TITLE
fix(creator-shop): keep a rejection terminal when the artwork changes

### DIFF
--- a/src/components/CreatorShop/HistoryCard.tsx
+++ b/src/components/CreatorShop/HistoryCard.tsx
@@ -3,24 +3,13 @@ import { IconAlertTriangle, IconArrowRight, IconHistory } from '@tabler/icons-re
 import { ChecksCard } from '~/components/CreatorShop/ChecksCard';
 import { CosmeticThumb } from '~/components/CreatorShop/CosmeticThumb';
 import { CREATOR_SHOP_BORDER } from '~/components/CreatorShop/creator-shop.constants';
+import { HISTORY_FIELD_LABELS } from '~/components/CreatorShop/review-history';
 import type {
   CosmeticShopItemHistoryChange,
   CosmeticShopItemHistoryEntry,
 } from '~/server/schema/cosmetic-shop.schema';
 import { formatDate } from '~/utils/date-helpers';
 import { numberWithCommas } from '~/utils/number-helpers';
-
-const fieldLabels: Record<string, string> = {
-  name: 'Name',
-  description: 'Description',
-  artwork: 'Artwork',
-  offsets: 'Fit offsets',
-  slug: 'Slug',
-  uses: 'Uses per purchase',
-  pricePerUse: 'Price per extra use',
-  price: 'Price',
-  quantity: 'Quantity',
-};
 
 const actionLabels: Record<string, string> = {
   approve: 'Approved & published',
@@ -41,7 +30,7 @@ const valueText = (value: CosmeticShopItemHistoryChange['from'], field: string) 
 };
 
 const changeText = (change: CosmeticShopItemHistoryChange) => {
-  const label = fieldLabels[change.field] ?? change.field;
+  const label = HISTORY_FIELD_LABELS[change.field] ?? change.field;
   if (change.field === 'artwork') return 'Artwork replaced';
   return `${label} ${valueText(change.from, change.field)} → ${valueText(change.to, change.field)}`;
 };

--- a/src/components/CreatorShop/Manage/ManageRowActions.browser.test.tsx
+++ b/src/components/CreatorShop/Manage/ManageRowActions.browser.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * A rejection is terminal, and the creator's row menu has to say so: editing,
+ * listing and archiving a rejected item are all refused server-side, and
+ * archiving used to be the two-click way around it (restore re-entered the queue
+ * with the verdict cleared).
+ */
+import { MantineProvider } from '@mantine/core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import type { CreatorShopManageItem } from '~/components/CreatorShop/creator-shop.util';
+import { theme } from '~/providers/ThemeProvider';
+import { CosmeticShopItemStatus } from '~/shared/utils/prisma/enums';
+import type * as TrpcModule from '~/utils/trpc';
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    creatorShop: {
+      getItemResellers: { useQuery: () => ({ data: [], isLoading: false }) },
+    },
+  },
+}));
+
+// The real hook throws without CivitaiSessionProvider; a non-moderator is the
+// case that matters here (a moderator also sees Delete).
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+const { ManageItemsTable } = await import('~/components/CreatorShop/Manage/ManageItemsTable');
+
+const noopMutation = { mutate: vi.fn(), isPending: false } as never;
+
+const item = (status: CosmeticShopItemStatus, history?: unknown[]) =>
+  ({
+    id: 1,
+    title: 'Pastel Shooting Star',
+    cosmetic: { id: 9, name: 'Pastel Shooting Star', type: 'Badge', data: { url: 'art' } },
+    meta: { history },
+    resellerCount: 0,
+    status,
+    purchases: 0,
+    unitAmount: 500,
+    createdAt: new Date(),
+    listed: false,
+    rejectionReason: status === CosmeticShopItemStatus.Rejected ? 'not a fit' : null,
+  } as unknown as CreatorShopManageItem);
+
+async function openRowMenu(status: CosmeticShopItemStatus, history?: unknown[]) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  const { container } = await render(
+    <ManageItemsTable
+      items={[item(status, history)]}
+      archiveItem={noopMutation}
+      setItemListed={noopMutation}
+      unarchiveItem={noopMutation}
+      deleteItem={noopMutation}
+    />,
+    {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          <MantineProvider theme={theme}>{children}</MantineProvider>
+        </QueryClientProvider>
+      ),
+    }
+  );
+
+  const trigger = container.querySelector('.mantine-ActionIcon-root') as HTMLElement;
+  expect(trigger, 'no row actions trigger rendered').not.toBeNull();
+  await page.elementLocator(trigger).click();
+
+  // The dropdown is portalled out of the table, so it is found on the document.
+  const dropdown = await vi.waitUntil(() => document.querySelector('.mantine-Menu-dropdown'));
+  return dropdown as HTMLElement;
+}
+
+describe('manage row actions', () => {
+  test('a rejected item offers nothing to change — only why', async () => {
+    const dropdown = await openRowMenu(CosmeticShopItemStatus.Rejected);
+    expect(dropdown.textContent).toContain('this item is final');
+    expect(dropdown.textContent).not.toContain('Edit');
+    expect(dropdown.textContent).not.toContain('Archive');
+    expect(dropdown.textContent).not.toContain('Restore');
+  });
+
+  // Archiving a rejected item is refused now, but rows archived while it was
+  // allowed still exist — and restoring one is refused server-side, so the menu
+  // must not offer it.
+  test('an item archived after a rejection offers no Restore', async () => {
+    const dropdown = await openRowMenu(CosmeticShopItemStatus.Archived, [
+      { at: '2026-08-02T00:00:00.000Z', userId: 99, kind: 'reviewed', action: 'reject' },
+    ]);
+    expect(dropdown.textContent).toContain('this item is final');
+    expect(dropdown.textContent).not.toContain('Restore');
+  });
+
+  // Control: an item archived after anything else still restores.
+  test('an item archived after a change request still offers Restore', async () => {
+    const dropdown = await openRowMenu(CosmeticShopItemStatus.Archived, [
+      { at: '2026-08-02T00:00:00.000Z', userId: 99, kind: 'reviewed', action: 'request-changes' },
+    ]);
+    expect(dropdown.textContent).toContain('Restore');
+    expect(dropdown.textContent).not.toContain('this item is final');
+  });
+
+  // Control: the same queries DO find those items on an item that was only sent
+  // back for changes, so the assertions above are capable of failing.
+  test('an item sent back for changes still offers Edit and Archive', async () => {
+    const dropdown = await openRowMenu(CosmeticShopItemStatus.RequestedChanges);
+    expect(dropdown.textContent).toContain('Edit & resubmit');
+    expect(dropdown.textContent).toContain('Archive');
+    expect(dropdown.textContent).not.toContain('this item is final');
+  });
+});

--- a/src/components/CreatorShop/Manage/manage.columns.tsx
+++ b/src/components/CreatorShop/Manage/manage.columns.tsx
@@ -24,6 +24,7 @@ import { CosmeticThumb } from '~/components/CreatorShop/CosmeticThumb';
 import { ItemResellersPopover } from '~/components/CreatorShop/Manage/ItemResellersPopover';
 import { statusMeta } from '~/components/CreatorShop/Manage/manage.constants';
 import { dialogStore } from '~/components/Dialog/dialogStore';
+import { wasLastReviewARejection } from '~/server/services/creator-shop.data';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { CosmeticShopItemStatus } from '~/shared/utils/prisma/enums';
 import { formatDate } from '~/utils/date-helpers';
@@ -105,6 +106,11 @@ function ItemActionsMenu({
 }) {
   const currentUser = useCurrentUser();
   const isArchived = item.status === CosmeticShopItemStatus.Archived;
+  // Archiving overwrites the status, so an item archived back when that was
+  // allowed still has to read as rejected — restoring one is refused server-side.
+  const isRejected =
+    item.status === CosmeticShopItemStatus.Rejected ||
+    (isArchived && wasLastReviewARejection(((item.meta ?? {}) as CosmeticShopItemMeta).history));
 
   const confirmDelete = () =>
     openConfirmModal({
@@ -163,7 +169,12 @@ function ItemActionsMenu({
         </ActionIcon>
       </Menu.Target>
       <Menu.Dropdown>
-        {isArchived ? (
+        {isRejected ? (
+          // Editing, listing and archiving a rejected item are all refused
+          // server-side — archiving because restoring afterwards used to put it
+          // back in the queue with the verdict cleared.
+          <Menu.Label>Rejected — this item is final and can&apos;t be changed.</Menu.Label>
+        ) : isArchived ? (
           <Menu.Item
             leftSection={<IconArchiveOff size={16} />}
             disabled={unarchiveItem.isPending}
@@ -180,8 +191,6 @@ function ItemActionsMenu({
           <>
             <Menu.Item
               leftSection={<IconEdit size={16} />}
-              // Rejected is terminal — nothing more can be changed.
-              disabled={item.status === CosmeticShopItemStatus.Rejected}
               onClick={() =>
                 dialogStore.trigger({
                   // A pack has no cosmetic to edit — its contents and price live

--- a/src/components/CreatorShop/PriorReviewCard.browser.test.tsx
+++ b/src/components/CreatorShop/PriorReviewCard.browser.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderWithProviders } from '../../../test/component-setup';
+import { PriorReviewCard } from '~/components/CreatorShop/PriorReviewCard';
+import type { PriorReview } from '~/components/CreatorShop/review-history';
+
+const PRIOR: PriorReview = {
+  action: 'request-changes',
+  note: 'Visual quality - your badge is very very tiny',
+  at: '2026-08-11T23:28:00.000Z',
+  reviewerId: 99,
+  artworkSwaps: 0,
+  editedFields: [],
+};
+
+// Scoped to this mount's container, so a second render inside one test can't be
+// matched by the first one's locator.
+async function renderCard(prior: PriorReview) {
+  const { container } = await renderWithProviders(<PriorReviewCard prior={prior} />);
+  return { container, within: page.elementLocator(container) };
+}
+
+describe('PriorReviewCard', () => {
+  test('shows the previous verdict and the note the last reviewer left', async () => {
+    const { within } = await renderCard(PRIOR);
+    await expect.element(within.getByText(/previously: changes requested/i)).toBeInTheDocument();
+    await expect.element(within.getByText(PRIOR.note as string)).toBeInTheDocument();
+  });
+
+  test('warns that the artwork was replaced since, and does not when it was not', async () => {
+    const swapped = await renderCard({ ...PRIOR, artworkSwaps: 2 });
+    await expect
+      .element(swapped.within.getByText(/artwork replaced 2 times since/i))
+      .toBeInTheDocument();
+
+    // Negative control: the same card with no swaps must not claim any.
+    const unswapped = await renderCard(PRIOR);
+    expect(unswapped.container.textContent).not.toMatch(/artwork replaced/i);
+  });
+
+  test('names the other fields moved since the verdict', async () => {
+    const { container } = await renderCard({ ...PRIOR, editedFields: ['price', 'quantity'] });
+    expect(container.textContent).toContain('Also changed since: Price, Quantity');
+  });
+});

--- a/src/components/CreatorShop/PriorReviewCard.tsx
+++ b/src/components/CreatorShop/PriorReviewCard.tsx
@@ -1,0 +1,45 @@
+import { Alert, Stack, Text } from '@mantine/core';
+import { IconAlertTriangle, IconHistory } from '@tabler/icons-react';
+import {
+  HISTORY_FIELD_LABELS,
+  PRIOR_REVIEW_LABELS,
+  type PriorReview,
+} from '~/components/CreatorShop/review-history';
+import { formatDate } from '~/utils/date-helpers';
+
+/**
+ * The unanswered verdict this item already carries, above the fold in the review
+ * panel. The History card below has the same facts, but it sits under the price,
+ * checks and similarity panels — a reviewer can approve without ever reaching it.
+ */
+export function PriorReviewCard({ prior }: { prior: PriorReview }) {
+  const swapped = prior.artworkSwaps > 0;
+  return (
+    <Alert
+      variant="light"
+      color={swapped ? 'orange' : 'yellow'}
+      icon={swapped ? <IconAlertTriangle size={18} /> : <IconHistory size={18} />}
+      title={`Previously: ${PRIOR_REVIEW_LABELS[prior.action].toLowerCase()}`}
+    >
+      <Stack gap={4}>
+        {!!prior.note && <Text size="sm">“{prior.note}”</Text>}
+        <Text size="xs" c="dimmed">
+          user #{prior.reviewerId} · {formatDate(prior.at, 'MMM D, YYYY h:mm A')}
+        </Text>
+        {swapped && (
+          <Text size="sm" fw={600}>
+            Artwork replaced {prior.artworkSwaps} time{prior.artworkSwaps === 1 ? '' : 's'} since —
+            check the History card that this is a revision of what was reviewed, not a different
+            piece on the same paid slot.
+          </Text>
+        )}
+        {!!prior.editedFields.length && (
+          <Text size="xs" c="dimmed">
+            Also changed since:{' '}
+            {prior.editedFields.map((f) => HISTORY_FIELD_LABELS[f] ?? f).join(', ')}
+          </Text>
+        )}
+      </Stack>
+    </Alert>
+  );
+}

--- a/src/components/CreatorShop/__tests__/review-history.test.ts
+++ b/src/components/CreatorShop/__tests__/review-history.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import type { CosmeticShopItemHistoryEntry } from '~/server/schema/cosmetic-shop.schema';
+import { priorReviewFromHistory } from '~/components/CreatorShop/review-history';
+
+const submitted: CosmeticShopItemHistoryEntry = {
+  at: '2026-08-01T00:00:00.000Z',
+  userId: 11,
+  kind: 'submitted',
+  status: 'PendingReview',
+};
+
+const requestedChanges: CosmeticShopItemHistoryEntry = {
+  at: '2026-08-02T00:00:00.000Z',
+  userId: 99,
+  kind: 'reviewed',
+  status: 'RequestedChanges',
+  action: 'request-changes',
+  note: 'Visual quality - your badge is very very tiny',
+};
+
+const artworkSwap = (at: string): CosmeticShopItemHistoryEntry => ({
+  at,
+  userId: 11,
+  kind: 'edited',
+  status: 'PendingReview',
+  changes: [{ field: 'artwork', from: 'old.png', to: 'new.png' }],
+});
+
+describe('priorReviewFromHistory', () => {
+  it('returns null for items with no recorded history', () => {
+    expect(priorReviewFromHistory(undefined)).toBeNull();
+    expect(priorReviewFromHistory([])).toBeNull();
+  });
+
+  it('surfaces the note of an unanswered request-changes verdict', () => {
+    const prior = priorReviewFromHistory([submitted, requestedChanges]);
+    expect(prior).toMatchObject({
+      action: 'request-changes',
+      note: requestedChanges.note,
+      reviewerId: 99,
+      at: requestedChanges.at,
+      artworkSwaps: 0,
+      editedFields: [],
+    });
+  });
+
+  it('counts every artwork swap made since that verdict', () => {
+    const prior = priorReviewFromHistory([
+      submitted,
+      requestedChanges,
+      artworkSwap('2026-08-03T00:00:00.000Z'),
+      artworkSwap('2026-08-04T00:00:00.000Z'),
+    ]);
+    expect(prior?.artworkSwaps).toBe(2);
+  });
+
+  it('does not count swaps made before the verdict', () => {
+    const prior = priorReviewFromHistory([
+      submitted,
+      artworkSwap('2026-08-01T12:00:00.000Z'),
+      requestedChanges,
+    ]);
+    expect(prior?.artworkSwaps).toBe(0);
+  });
+
+  it('lists the other fields moved since, deduped and newest first', () => {
+    const edit = (at: string, field: string): CosmeticShopItemHistoryEntry => ({
+      at,
+      userId: 11,
+      kind: 'edited',
+      status: 'PendingReview',
+      changes: [{ field, from: 1, to: 2 }],
+    });
+    const prior = priorReviewFromHistory([
+      submitted,
+      requestedChanges,
+      edit('2026-08-03T00:00:00.000Z', 'price'),
+      edit('2026-08-04T00:00:00.000Z', 'quantity'),
+      edit('2026-08-05T00:00:00.000Z', 'price'),
+    ]);
+    expect(prior?.editedFields).toEqual(['price', 'quantity']);
+  });
+
+  it('goes quiet once an approval answers the verdict', () => {
+    const prior = priorReviewFromHistory([
+      submitted,
+      requestedChanges,
+      artworkSwap('2026-08-03T00:00:00.000Z'),
+      {
+        at: '2026-08-04T00:00:00.000Z',
+        userId: 99,
+        kind: 'reviewed',
+        status: 'Published',
+        action: 'approve',
+      },
+    ]);
+    expect(prior).toBeNull();
+  });
+
+  it('reports only the most recent verdict when there were several', () => {
+    const prior = priorReviewFromHistory([
+      submitted,
+      requestedChanges,
+      artworkSwap('2026-08-03T00:00:00.000Z'),
+      {
+        at: '2026-08-04T00:00:00.000Z',
+        userId: 77,
+        kind: 'reviewed',
+        status: 'RequestedChanges',
+        action: 'request-changes',
+        note: 'the sides are stretched too much',
+      },
+      artworkSwap('2026-08-05T00:00:00.000Z'),
+    ]);
+    expect(prior).toMatchObject({
+      note: 'the sides are stretched too much',
+      reviewerId: 77,
+      artworkSwaps: 1,
+    });
+  });
+
+  it.each(['reject', 'revert'] as const)('treats a %s verdict as unanswered too', (action) => {
+    const prior = priorReviewFromHistory([
+      submitted,
+      {
+        at: '2026-08-02T00:00:00.000Z',
+        userId: 99,
+        kind: 'reviewed',
+        status: 'x',
+        action,
+        note: 'no',
+      },
+    ]);
+    expect(prior?.action).toBe(action);
+  });
+});

--- a/src/components/CreatorShop/review-history.ts
+++ b/src/components/CreatorShop/review-history.ts
@@ -1,0 +1,79 @@
+import type { CosmeticShopItemHistoryEntry } from '~/server/schema/cosmetic-shop.schema';
+import { lastReviewIndex } from '~/server/services/creator-shop.data';
+
+export const HISTORY_FIELD_LABELS: Record<string, string> = {
+  name: 'Name',
+  description: 'Description',
+  artwork: 'Artwork',
+  offsets: 'Fit offsets',
+  slug: 'Slug',
+  uses: 'Uses per purchase',
+  pricePerUse: 'Price per extra use',
+  price: 'Price',
+  quantity: 'Quantity',
+};
+
+const adverseActions = ['reject', 'request-changes', 'revert'] as const;
+export type AdverseReviewAction = (typeof adverseActions)[number];
+
+export const PRIOR_REVIEW_LABELS: Record<AdverseReviewAction, string> = {
+  reject: 'Rejected',
+  'request-changes': 'Changes requested',
+  revert: 'Reverted to pending review',
+};
+
+const isAdverse = (action?: string): action is AdverseReviewAction =>
+  adverseActions.includes(action as AdverseReviewAction);
+
+export type PriorReview = {
+  action: AdverseReviewAction;
+  note?: string;
+  at: string;
+  reviewerId: number;
+  /** Artwork replacements the creator made after that verdict. */
+  artworkSwaps: number;
+  /** Other fields they moved since, newest first, deduped. */
+  editedFields: string[];
+};
+
+/**
+ * The last verdict a moderator gave, if it was adverse and still unanswered by
+ * an approval — plus what the creator changed since.
+ *
+ * A re-review needs this because the item itself no longer carries it: an edit
+ * that puts the item back in the queue clears `rejectionReason`, so the next
+ * reviewer sees a clean item and can approve what a colleague just turned down.
+ * The artwork count matters most — a swap is how an unrelated piece reaches a
+ * slot that was already paid for and already reviewed.
+ *
+ * Returns null once an approval follows the verdict (it was answered), and on
+ * items whose history predates change tracking or whose verdict has aged out of
+ * the capped log.
+ */
+export const priorReviewFromHistory = (
+  history?: CosmeticShopItemHistoryEntry[]
+): PriorReview | null => {
+  const index = lastReviewIndex(history);
+  if (index < 0 || !history) return null;
+
+  const verdict = history[index];
+  if (!isAdverse(verdict.action)) return null;
+
+  let artworkSwaps = 0;
+  const editedFields: string[] = [];
+  for (let i = history.length - 1; i > index; i--) {
+    for (const change of history[i].changes ?? []) {
+      if (change.field === 'artwork') artworkSwaps++;
+      else if (!editedFields.includes(change.field)) editedFields.push(change.field);
+    }
+  }
+
+  return {
+    action: verdict.action,
+    note: verdict.note,
+    at: verdict.at,
+    reviewerId: verdict.userId,
+    artworkSwaps,
+    editedFields,
+  };
+};

--- a/src/pages/moderator/creator-shop.tsx
+++ b/src/pages/moderator/creator-shop.tsx
@@ -56,6 +56,8 @@ import { InViewLoader } from '~/components/InView/InViewLoader';
 import { CheckRow, ChecksCard } from '~/components/CreatorShop/ChecksCard';
 import { CosmeticThumb } from '~/components/CreatorShop/CosmeticThumb';
 import { HistoryCard } from '~/components/CreatorShop/HistoryCard';
+import { PriorReviewCard } from '~/components/CreatorShop/PriorReviewCard';
+import { priorReviewFromHistory } from '~/components/CreatorShop/review-history';
 import { SimilarArtworkCard } from '~/components/CreatorShop/SimilarArtworkCard';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import {
@@ -232,6 +234,8 @@ function CreatorShopReviewPage() {
   // A pack is authored by whoever listed it; a cosmetic by whoever made it.
   const submitter = selected?.cosmetic?.creator ?? selected?.addedBy ?? null;
   const selectedMeta = (selected?.meta ?? {}) as CosmeticShopItemMeta;
+  // The verdict the item stopped carrying the moment the creator edited it.
+  const priorReview = priorReviewFromHistory(selectedMeta.history);
   const checks = selectedMeta.autoChecks ?? [];
   const dims = selectedMeta.imageMeta;
   const isAnimated = !!(selected?.cosmetic?.data as { animated?: boolean } | null)?.animated;
@@ -509,6 +513,11 @@ function CreatorShopReviewPage() {
               <Stack gap={0}>
                 {items.map((item) => {
                   const active = item.id === selectedId;
+                  // Triage is oldest-first regardless of what already happened
+                  // to an item, so the queue has to say which ones are re-reviews.
+                  const itemPrior = priorReviewFromHistory(
+                    ((item.meta ?? {}) as CosmeticShopItemMeta).history
+                  );
                   return (
                     <UnstyledButton
                       key={item.id}
@@ -543,6 +552,16 @@ function CreatorShopReviewPage() {
                             · {item.cosmetic ? getDisplayName(item.cosmetic.type) : 'Pack'}
                           </Text>
                         </Stack>
+                        {itemPrior && item.status === CosmeticShopItemStatus.PendingReview && (
+                          <Badge
+                            size="sm"
+                            variant="light"
+                            radius="sm"
+                            color={itemPrior.artworkSwaps ? 'orange' : 'yellow'}
+                          >
+                            {itemPrior.artworkSwaps ? 'New artwork' : 'Re-review'}
+                          </Badge>
+                        )}
                         {statusFilter === 'all' && (
                           <Badge
                             size="sm"
@@ -611,6 +630,8 @@ function CreatorShopReviewPage() {
                     </Text>
                   </Group>
                 </Stack>
+
+                {!!priorReview && <PriorReviewCard prior={priorReview} />}
 
                 <Group align="flex-start" gap="xl" wrap="nowrap" className="max-md:flex-wrap">
                   {/* Preview */}
@@ -961,7 +982,9 @@ function CreatorShopReviewPage() {
                   </Stack>
                 </Group>
 
-                {/* Actions — archived items are view-only (reviewItem rejects them). */}
+                {/* Actions — archived items are view-only (reviewItem refuses
+                    them). A rejected item keeps its buttons: this panel is the
+                    only way back from a rejection, and it is moderator-only. */}
                 {selected.status === CosmeticShopItemStatus.Archived ? (
                   <Group pt="md" style={{ borderTop: CREATOR_SHOP_BORDER }}>
                     <Text size="sm" c="dimmed">
@@ -970,84 +993,91 @@ function CreatorShopReviewPage() {
                     </Text>
                   </Group>
                 ) : (
-                  <Group
-                    justify="space-between"
-                    wrap="nowrap"
-                    pt="md"
-                    gap="md"
-                    style={{ borderTop: CREATOR_SHOP_BORDER }}
-                    className="max-md:flex-wrap"
-                  >
-                    <TextInput
-                      placeholder="Add a note (required for everything except approval)"
-                      value={reason}
-                      onChange={(e) => setReason(e.currentTarget.value)}
-                      maxLength={1000}
-                      style={{ flex: 1 }}
-                      className="max-md:w-full"
-                    />
-                    <Group gap="sm" wrap="nowrap">
-                      {selected.status === CosmeticShopItemStatus.Published ? (
-                        // Already-live items: review verdicts make no sense —
-                        // the mod either pulls it back into the queue or removes it.
-                        <>
-                          <Button
-                            color="orange"
-                            variant="light"
-                            leftSection={<IconArrowBackUp size={16} />}
-                            loading={reviewItem.isPending}
-                            onClick={() => submitReview('revert')}
-                          >
-                            Revert to pending
-                          </Button>
-                          <Button
-                            color="red"
-                            variant="light"
-                            leftSection={<IconBan size={16} />}
-                            loading={takedownItem.isPending}
-                            onClick={confirmTakedown}
-                          >
-                            Take down
-                          </Button>
-                          <Button
-                            color="red"
-                            leftSection={<IconTrash size={16} />}
-                            loading={deleteItem.isPending}
-                            onClick={confirmDelete}
-                          >
-                            Delete
-                          </Button>
-                        </>
-                      ) : (
-                        <>
-                          <Button
-                            variant="default"
-                            loading={reviewItem.isPending}
-                            onClick={() => submitReview('request-changes')}
-                          >
-                            Request changes
-                          </Button>
-                          <Button
-                            color="red"
-                            variant="light"
-                            leftSection={<IconX size={16} />}
-                            loading={reviewItem.isPending}
-                            onClick={() => submitReview('reject')}
-                          >
-                            Reject
-                          </Button>
-                          <Button
-                            color="green"
-                            leftSection={<IconCheck size={16} />}
-                            loading={reviewItem.isPending}
-                            onClick={handleApprove}
-                          >
-                            Approve &amp; Publish
-                          </Button>
-                        </>
-                      )}
+                  <Stack gap={8} pt="md" style={{ borderTop: CREATOR_SHOP_BORDER }}>
+                    {selected.status === CosmeticShopItemStatus.Rejected && (
+                      <Text size="sm" c="dimmed">
+                        Rejected — the creator can no longer edit, relist or restore this. Bringing
+                        it back is a moderator action: request changes to hand it to them, or
+                        approve to publish it as it stands.
+                      </Text>
+                    )}
+                    <Group
+                      justify="space-between"
+                      wrap="nowrap"
+                      gap="md"
+                      className="max-md:flex-wrap"
+                    >
+                      <TextInput
+                        placeholder="Add a note (required for everything except approval)"
+                        value={reason}
+                        onChange={(e) => setReason(e.currentTarget.value)}
+                        maxLength={1000}
+                        style={{ flex: 1 }}
+                        className="max-md:w-full"
+                      />
+                      <Group gap="sm" wrap="nowrap">
+                        {selected.status === CosmeticShopItemStatus.Published ? (
+                          // Already-live items: review verdicts make no sense —
+                          // the mod either pulls it back into the queue or removes it.
+                          <>
+                            <Button
+                              color="orange"
+                              variant="light"
+                              leftSection={<IconArrowBackUp size={16} />}
+                              loading={reviewItem.isPending}
+                              onClick={() => submitReview('revert')}
+                            >
+                              Revert to pending
+                            </Button>
+                            <Button
+                              color="red"
+                              variant="light"
+                              leftSection={<IconBan size={16} />}
+                              loading={takedownItem.isPending}
+                              onClick={confirmTakedown}
+                            >
+                              Take down
+                            </Button>
+                            <Button
+                              color="red"
+                              leftSection={<IconTrash size={16} />}
+                              loading={deleteItem.isPending}
+                              onClick={confirmDelete}
+                            >
+                              Delete
+                            </Button>
+                          </>
+                        ) : (
+                          <>
+                            <Button
+                              variant="default"
+                              loading={reviewItem.isPending}
+                              onClick={() => submitReview('request-changes')}
+                            >
+                              Request changes
+                            </Button>
+                            <Button
+                              color="red"
+                              variant="light"
+                              leftSection={<IconX size={16} />}
+                              loading={reviewItem.isPending}
+                              onClick={() => submitReview('reject')}
+                            >
+                              Reject
+                            </Button>
+                            <Button
+                              color="green"
+                              leftSection={<IconCheck size={16} />}
+                              loading={reviewItem.isPending}
+                              onClick={handleApprove}
+                            >
+                              Approve &amp; Publish
+                            </Button>
+                          </>
+                        )}
+                      </Group>
                     </Group>
-                  </Group>
+                  </Stack>
                 )}
               </Stack>
             ) : (

--- a/src/server/services/__tests__/creator-shop-rejected-terminal.service.test.ts
+++ b/src/server/services/__tests__/creator-shop-rejected-terminal.service.test.ts
@@ -1,0 +1,281 @@
+/**
+ * A rejection is terminal on every path a creator can reach: they can't edit a
+ * rejected item, list it, archive it, or restore one from the archive.
+ *
+ * The single exception is `reviewCreatorShopItem`, which is moderatorProcedure —
+ * a moderator re-reviewing a rejected item is the way back from a mistaken
+ * rejection, and it is not reachable by the creator.
+ *
+ * Every blocked case asserts BOTH that the call throws and that nothing was
+ * written — a guard that throws after mutating would still leave the item
+ * laundered, and the throw alone can't tell those apart.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as Caches from '~/server/redis/caches';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    shopItemFindUnique: vi.fn(),
+    shopItemUpdate: vi.fn(),
+    refreshOwnedStickerCache: vi.fn(),
+    createNotification: vi.fn(),
+  },
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+  refundTransaction: vi.fn(),
+}));
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: mocks.createNotification,
+}));
+vi.mock('~/server/redis/caches', async (importOriginal) => ({
+  ...(await importOriginal<typeof Caches>()),
+  refreshOwnedStickerCache: mocks.refreshOwnedStickerCache,
+}));
+
+import {
+  archiveCreatorShopItem,
+  reviewCreatorShopItem,
+  setCreatorShopItemListed,
+  unarchiveCreatorShopItem,
+  updateCreatorShopItem,
+} from '../creator-shop.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { wasLastReviewARejection } from '../creator-shop.data';
+
+dbMock.dbRead.cosmeticShopItem.findUnique.mockImplementation((...args: unknown[]) =>
+  (mocks.shopItemFindUnique as (...a: unknown[]) => unknown)(...args)
+);
+dbMock.dbWrite.cosmeticShopItem.update.mockImplementation((...args: unknown[]) =>
+  (mocks.shopItemUpdate as (...a: unknown[]) => unknown)(...args)
+);
+
+const reviewed = (action: string, at: string) => ({
+  at,
+  userId: 99,
+  kind: 'reviewed' as const,
+  status: action === 'reject' ? 'Rejected' : 'RequestedChanges',
+  action,
+  note: 'not a fit for the shop',
+});
+
+const item = (status: string, history: unknown[]) => ({
+  id: 42,
+  cosmeticId: 7,
+  unitAmount: 500,
+  status,
+  title: 'Golden Laurel',
+  description: 'A laurel',
+  availableQuantity: null,
+  addedById: 11,
+  meta: { history },
+  cosmetic: {
+    id: 7,
+    createdById: 11,
+    type: 'Badge',
+    data: { url: 'art' },
+    creator: { username: 'creator' },
+  },
+  _count: { purchases: 0 },
+});
+
+const REJECTED = item('Rejected', [reviewed('reject', '2026-08-02T00:00:00.000Z')]);
+const CHANGES_REQUESTED = item('RequestedChanges', [
+  reviewed('request-changes', '2026-08-02T00:00:00.000Z'),
+]);
+
+const FINAL = /Rejected items are final/;
+
+describe('a rejected item is terminal', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((m) => m.mockReset());
+    mocks.shopItemUpdate.mockImplementation(({ data }: { data: Record<string, unknown> }) => ({
+      id: 42,
+      ...data,
+    }));
+  });
+
+  it('cannot be edited', async () => {
+    mocks.shopItemFindUnique.mockResolvedValue(REJECTED);
+    await expect(updateCreatorShopItem({ id: 42, userId: 11, price: 900 })).rejects.toThrow(FINAL);
+    expect(mocks.shopItemUpdate).not.toHaveBeenCalled();
+  });
+
+  // Listing resets status to PendingReview and clears the verdict, so this is a
+  // re-entry into the queue with no edit at all.
+  it('cannot be listed back onto sale', async () => {
+    mocks.shopItemFindUnique.mockResolvedValue(REJECTED);
+    await expect(setCreatorShopItemListed({ id: 42, userId: 11, listed: true })).rejects.toThrow(
+      FINAL
+    );
+    expect(mocks.shopItemUpdate).not.toHaveBeenCalled();
+  });
+
+  // Archive → restore was the two-click version of the same laundering: restoring
+  // sets PendingReview and clears the verdict.
+  it('cannot be archived', async () => {
+    mocks.shopItemFindUnique.mockResolvedValue(REJECTED);
+    await expect(archiveCreatorShopItem({ id: 42, userId: 11 })).rejects.toThrow(FINAL);
+    expect(mocks.shopItemUpdate).not.toHaveBeenCalled();
+  });
+
+  // Archiving a rejected item is refused now, but rows archived before that was
+  // true still exist — Archived overwrote their status, so only the history says
+  // they were rejected.
+  it('cannot be restored when it was archived after being rejected', async () => {
+    mocks.shopItemFindUnique.mockResolvedValue(
+      item('Archived', [reviewed('reject', '2026-08-02T00:00:00.000Z')])
+    );
+    await expect(unarchiveCreatorShopItem({ id: 42, userId: 11 })).rejects.toThrow(FINAL);
+    expect(mocks.shopItemUpdate).not.toHaveBeenCalled();
+  });
+
+  // Older than the history log: the verdict that archived it is unknowable, and
+  // an unknown verdict must not become a resubmission.
+  it('cannot be restored by its creator when it predates the history log', async () => {
+    mocks.shopItemFindUnique.mockResolvedValue({
+      ...item('Archived', []),
+      rejectionReason: 'not a fit for the shop',
+    });
+    await expect(unarchiveCreatorShopItem({ id: 42, userId: 11 })).rejects.toThrow(FINAL);
+    expect(mocks.shopItemUpdate).not.toHaveBeenCalled();
+  });
+
+  // The carve-out is the REVIEW path and nothing else: a moderator who wants to
+  // change a rejected item reopens it first, which leaves a history entry.
+  it('is terminal on the creator-reachable paths even for a moderator', async () => {
+    mocks.shopItemFindUnique.mockResolvedValue(REJECTED);
+    await expect(
+      updateCreatorShopItem({ id: 42, userId: 500, isModerator: true, price: 900 })
+    ).rejects.toThrow(FINAL);
+    await expect(
+      archiveCreatorShopItem({ id: 42, userId: 500, isModerator: true })
+    ).rejects.toThrow(FINAL);
+    expect(mocks.shopItemUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// Controls: the same calls on an item that was NOT rejected still go through, so
+// a guard that over-reaches to every reviewed item fails here rather than
+// silently freezing the request-changes loop this queue runs on.
+describe('only a moderator can reopen a rejection', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((m) => m.mockReset());
+    mocks.shopItemUpdate.mockImplementation(({ data }: { data: Record<string, unknown> }) => ({
+      id: 42,
+      ...data,
+    }));
+    mocks.shopItemFindUnique.mockResolvedValue(REJECTED);
+  });
+
+  it.each([
+    ['request-changes', 'RequestedChanges'],
+    ['approve', 'Published'],
+  ] as const)('re-reviewing it as %s moves it to %s', async (action, status) => {
+    await reviewCreatorShopItem({
+      id: 42,
+      reviewerId: 99,
+      action,
+      rejectionReason: 'reopened on appeal',
+    });
+    expect(mocks.shopItemUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status }) })
+    );
+  });
+
+  // The same unknowable legacy row a creator is refused: a moderator can read the
+  // reason and decide, which is the only way one of these ever moves again.
+  it('a moderator can restore a pre-history archived item the creator cannot', async () => {
+    mocks.shopItemFindUnique.mockResolvedValue({
+      ...item('Archived', []),
+      rejectionReason: 'not a fit for the shop',
+    });
+    await unarchiveCreatorShopItem({ id: 42, userId: 500, isModerator: true });
+    expect(mocks.shopItemUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'PendingReview' }) })
+    );
+  });
+
+  it('records the reopening in the history, so the first rejection is not lost', async () => {
+    await reviewCreatorShopItem({
+      id: 42,
+      reviewerId: 99,
+      action: 'request-changes',
+      rejectionReason: 'reopened on appeal',
+    });
+    const history = mocks.shopItemUpdate.mock.calls[0][0].data.meta.history;
+    expect(history).toHaveLength(2);
+    expect(history[0]).toMatchObject({ action: 'reject' });
+    expect(history[1]).toMatchObject({
+      userId: 99,
+      kind: 'reviewed',
+      action: 'request-changes',
+      note: 'reopened on appeal',
+    });
+  });
+});
+
+describe('an item that was only sent back for changes still moves', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((m) => m.mockReset());
+    mocks.shopItemUpdate.mockImplementation(({ data }: { data: Record<string, unknown> }) => ({
+      id: 42,
+      ...data,
+    }));
+    mocks.shopItemFindUnique.mockResolvedValue(CHANGES_REQUESTED);
+  });
+
+  it('can be archived', async () => {
+    await archiveCreatorShopItem({ id: 42, userId: 11 });
+    expect(mocks.shopItemUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'Archived' }) })
+    );
+  });
+
+  it('can be reviewed again', async () => {
+    await reviewCreatorShopItem({
+      id: 42,
+      reviewerId: 99,
+      action: 'request-changes',
+      rejectionReason: 'one more pass please',
+    });
+    expect(mocks.shopItemUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'RequestedChanges' }) })
+    );
+  });
+
+  it('can be restored from the archive', async () => {
+    mocks.shopItemFindUnique.mockResolvedValue(
+      item('Archived', [reviewed('request-changes', '2026-08-02T00:00:00.000Z')])
+    );
+    await unarchiveCreatorShopItem({ id: 42, userId: 11 });
+    expect(mocks.shopItemUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'PendingReview' }) })
+    );
+  });
+});
+
+describe('wasLastReviewARejection', () => {
+  const entry = (kind: string, action?: string) =>
+    ({ at: '2026-08-02T00:00:00.000Z', userId: 99, kind, action } as never);
+
+  it('reads the LAST verdict, not any of them', () => {
+    expect(wasLastReviewARejection([entry('reviewed', 'reject')])).toBe(true);
+    // A rejection that was itself reverted is not what the item ended on.
+    expect(
+      wasLastReviewARejection([entry('reviewed', 'reject'), entry('reviewed', 'approve')])
+    ).toBe(false);
+  });
+
+  it('looks past the edits that follow a verdict', () => {
+    expect(wasLastReviewARejection([entry('reviewed', 'reject'), entry('edited')])).toBe(true);
+  });
+
+  it('is false when nothing was ever reviewed', () => {
+    expect(wasLastReviewARejection(undefined)).toBe(false);
+    expect(wasLastReviewARejection([])).toBe(false);
+    expect(wasLastReviewARejection([entry('submitted')])).toBe(false);
+  });
+});

--- a/src/server/services/creator-shop-pack.service.ts
+++ b/src/server/services/creator-shop-pack.service.ts
@@ -20,6 +20,7 @@ import {
 import { createBuzzTransaction, refundTransaction } from '~/server/services/buzz.service';
 import { assertQuotedFee, getCreatorShopFees } from '~/server/services/creator-shop-fees.service';
 import { getCosmeticArtworkUrl } from '~/server/services/cosmetic-phash.service';
+import { REJECTED_IS_FINAL } from '~/server/services/creator-shop.data';
 import { stickerUsesFromCosmeticData } from '~/shared/utils/sticker-token';
 import { throwBadRequestError, throwNotFoundError } from '~/server/utils/errorHandling';
 import { CosmeticShopItemStatus, CosmeticType } from '~/shared/utils/prisma/enums';
@@ -281,7 +282,7 @@ export const updateCreatorShopPack = async ({
   if (!isModerator && existing.addedById !== userId)
     throw throwBadRequestError('You can only manage your own shop items');
   if (existing.status === CosmeticShopItemStatus.Rejected)
-    throw throwBadRequestError('Rejected items cannot be edited');
+    throw throwBadRequestError(REJECTED_IS_FINAL);
   if (existing.status === CosmeticShopItemStatus.Archived)
     throw throwBadRequestError('Archived items cannot be edited');
 

--- a/src/server/services/creator-shop.data.ts
+++ b/src/server/services/creator-shop.data.ts
@@ -62,6 +62,41 @@ export const appendItemHistory = (
   history: [...(meta.history ?? []), entry].slice(-CREATOR_SHOP_HISTORY_LIMIT),
 });
 
+// Rejection is terminal on every path a creator can reach — edit, list, archive,
+// restore. Only a moderator re-reviewing it can bring one back, so the message
+// says where that happens rather than implying nothing can. One wording, so each
+// blocked path reads the same.
+export const REJECTED_IS_FINAL =
+  'Rejected items are final — a moderator has to reopen it from the review queue first';
+
+/**
+ * Index of the most recent review verdict in an item's history, or -1.
+ *
+ * Shared because two very different questions start with the same scan: the
+ * review queue asks what the last verdict SAID, and the terminal-rejection
+ * guards ask whether it was a rejection.
+ */
+export const lastReviewIndex = (history?: CosmeticShopItemHistoryEntry[]) => {
+  if (!history?.length) return -1;
+  for (let i = history.length - 1; i >= 0; i--) if (history[i].kind === 'reviewed') return i;
+  return -1;
+};
+
+/**
+ * Whether the last thing a moderator did to this item was reject it.
+ *
+ * A rejection is terminal, but archiving overwrites `status`, so an item that
+ * was archived after being rejected no longer says so — and restoring it clears
+ * the verdict and puts it back in the queue. Reading the history is the only way
+ * to tell those apart. An item whose rejection has aged out of the capped log
+ * reads as not-rejected; the status guards on the paths that can still see it
+ * are what keep new items out of that state.
+ */
+export const wasLastReviewARejection = (history?: CosmeticShopItemHistoryEntry[]) => {
+  const index = lastReviewIndex(history);
+  return index >= 0 && history![index].action === 'reject';
+};
+
 /**
  * Resolves the `Cosmetic.data` write for an edit. Replaced artwork rebuilds the
  * blob; an offsets- or slug-only edit patches the existing one. Returns

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -11,10 +11,12 @@ import {
 } from '~/server/services/cosmetic.service';
 import { removePlacementsByCosmetic } from '~/server/services/placement-moderation.service';
 import {
+  REJECTED_IS_FINAL,
   appendItemHistory,
   buildCosmeticData,
   creatorGrantRemaining,
   patchCosmeticData,
+  wasLastReviewARejection,
 } from '~/server/services/creator-shop.data';
 import type { StickerEconomics } from '~/shared/utils/sticker-token';
 import { stickerEconomicsFromCosmeticData } from '~/shared/utils/sticker-token';
@@ -438,6 +440,9 @@ const getOwnedItemOrThrow = async (id: number, userId: number, isModerator = fal
       title: true,
       meta: true,
       addedById: true,
+      // Archiving overwrites `status`, so on the restore path this column is the
+      // only thing left on an item that predates the history log.
+      rejectionReason: true,
       // Prior values, so an edit can record what it moved from.
       description: true,
       availableQuantity: true,
@@ -478,7 +483,7 @@ export const updateCreatorShopItem = async ({
     throw throwBadRequestError('Packs are edited through the pack editor');
   // Rejected is terminal; archived items must be restored before editing.
   if (existing.status === CosmeticShopItemStatus.Rejected)
-    throw throwBadRequestError('Rejected items cannot be edited');
+    throw throwBadRequestError(REJECTED_IS_FINAL);
   if (existing.status === CosmeticShopItemStatus.Archived)
     throw throwBadRequestError('Archived items cannot be edited');
 
@@ -825,6 +830,10 @@ export const archiveCreatorShopItem = async ({
   const existing = await getOwnedItemOrThrow(id, userId, isModerator);
   if (existing.status === CosmeticShopItemStatus.Archived)
     throw throwBadRequestError('Item is already archived');
+  // Archiving is how a rejection used to be laundered: Archived overwrites the
+  // status, and restoring re-enters review with the verdict cleared.
+  if (existing.status === CosmeticShopItemStatus.Rejected)
+    throw throwBadRequestError(REJECTED_IS_FINAL);
   const updated = await dbWrite.cosmeticShopItem.update({
     where: { id },
     data: { status: CosmeticShopItemStatus.Archived, archivedAt: new Date() },
@@ -876,6 +885,10 @@ export const setCreatorShopItemListed = async ({
   const existing = await getOwnedItemOrThrow(id, userId, isModerator);
   if (existing.status === CosmeticShopItemStatus.Archived)
     throw throwBadRequestError('Restore this item before changing its listing');
+  // Listing resets an item to PendingReview and clears the verdict, so without
+  // this a rejected item is one call away from being back in the queue unedited.
+  if (existing.status === CosmeticShopItemStatus.Rejected)
+    throw throwBadRequestError(REJECTED_IS_FINAL);
 
   const updated = await dbWrite.cosmeticShopItem.update({
     where: { id },
@@ -928,6 +941,18 @@ export const unarchiveCreatorShopItem = async ({
   };
   if (meta.takedown)
     throw throwBadRequestError('This item was taken down and cannot be restored to sale');
+  // Archiving a rejected item is blocked now, but items archived before that was
+  // true still exist, and restoring one would clear its verdict. Nothing appends
+  // to an archived item's history, so a verdict recorded there is still the last
+  // one — it cannot have aged out of the cap while the item sat archived.
+  //
+  // An item old enough to have no history at all leaves only `rejectionReason`,
+  // which a change request sets too. That is not enough to convict, so it is
+  // refused for the creator (who must never be able to resubmit a rejection) and
+  // left to a moderator, who can read the reason and decide.
+  const rejectionUnprovable = !meta.history?.length && !!existing.rejectionReason;
+  if (wasLastReviewARejection(meta.history) || (rejectionUnprovable && !isModerator))
+    throw throwBadRequestError(REJECTED_IS_FINAL);
   return dbWrite.cosmeticShopItem.update({
     where: { id },
     data: {
@@ -1725,6 +1750,10 @@ export const reviewCreatorShopItem = async ({
   if (!item) throw throwNotFoundError('Shop item not found');
   if (item.status === CosmeticShopItemStatus.Archived)
     throw throwBadRequestError('Archived items cannot be reviewed');
+  // Rejected is deliberately NOT blocked here: this procedure is
+  // moderatorProcedure, so a second verdict is the one way back from a mistaken
+  // rejection, and it stays out of the creator's hands. Every path a creator can
+  // reach — edit, list, archive, restore — refuses a rejected item.
   if (action === 'revert' && item.status !== CosmeticShopItemStatus.Published)
     throw throwBadRequestError('Only published items can be reverted to pending review');
 


### PR DESCRIPTION
Rejection is now refused on every creator path — edit, list, archive and restore — since archiving overwrote the status and restoring put the item back in the queue with the verdict cleared, letting a swapped-in image reach an already-paid slot. Moderators keep their review buttons as the only way back, and the queue and review panel now surface the unanswered verdict plus how many times the artwork was replaced since it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868kt96gj`). Reviewed locally before push.