### PR TITLE
fix(images): scope a username-addressed feed before the own-excluded decision

### DIFF
--- a/src/server/services/__tests__/bitdex-username-own-excluded-scope.test.ts
+++ b/src/server/services/__tests__/bitdex-username-own-excluded-scope.test.ts
@@ -1,0 +1,423 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #3929 — own-excluded images appearing on ANOTHER creator's feed when the
+// caller addresses that creator by `username` instead of `userId`.
+//
+// `fetchBitdexPrimary` decides whether to run the "own excluded" second pass
+// from `input.userId`. When the request names the creator by handle, that field
+// is empty at the point the decision is made — the handle used to be resolved
+// later and locally, inside `getImagesFromBitdexPreFilter` — so the "viewing
+// someone else's profile" guard read `undefined`, did not fire, and the
+// caller's own private/blocked/nsfw0 content was merged into a feed it does not
+// belong to.
+//
+// Not a cross-user exposure: every document involved belongs to the caller. The
+// defect is feed integrity — the feed misrepresents what that creator posted.
+//
+// Same minimal-seam mocking as bitdex-empty-fallback.test.ts: stub the
+// event-engine-common submodule + infra clients + env so importing
+// image.service doesn't boot real infra, and null out the Meili client so the
+// Meili leg still RUNS (and still stamps source 'meili') without a live index.
+
+import type * as BitdexClient from '~/server/bitdex/client';
+import type * as FliptClient from '~/server/flipt/client';
+import type * as MeiliClient from '~/server/meilisearch/client';
+
+const { queryBitdexMock, getFliptVariantMock } = vi.hoisted(() => ({
+  queryBitdexMock: vi.fn(),
+  getFliptVariantMock: vi.fn(),
+}));
+
+vi.mock('../../../../event-engine-common/feeds', () => ({
+  ImagesFeed: class {
+    populatedQuery = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/meilisearch/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof MeiliClient>()),
+  metricsSearchClient: null,
+}));
+
+vi.mock('~/server/bitdex/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof BitdexClient>()),
+  queryBitdex: queryBitdexMock,
+}));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof FliptClient>()),
+  getFliptVariant: getFliptVariantMock,
+  getFliptBoolean: vi.fn().mockResolvedValue(false),
+}));
+
+import { getImagesFromSearch } from '../image.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+redisMock.redis.get.mockResolvedValue('[]');
+redisMock.redis.set.mockResolvedValue(undefined);
+
+// Pairwise distinct, none of them a default. A fixture whose ids collide would
+// let a mutant that reads the wrong field produce the right answer by accident.
+const CURRENT_USER_ID = 42;
+const OTHER_CREATOR_ID = 7;
+const THIRD_PARTY_ID = 13;
+
+const OTHER_CREATOR_USERNAME = 'some-other-creator';
+const CALLER_USERNAME = 'the-caller-themselves';
+const MISSING_USERNAME = 'no-such-handle';
+
+/**
+ * Both BitDex passes go through the same `queryBitdex`, so the fake has to tell
+ * them apart from its arguments or it would answer the same thing to both and
+ * every assertion below would be meaningless.
+ *
+ * The main pass filters availability with `Not(Eq(availability, Private))`; the
+ * own-excluded pass asks for the opposite inside an `Or`. Keying on that `Or`
+ * distinguishes them structurally rather than by position or call order.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw BitDex filter clauses
+type Clause = any;
+function isOwnExcludedQuery(filters: unknown): boolean {
+  if (!Array.isArray(filters)) return false;
+  return filters.some(
+    (clause: Clause) =>
+      Array.isArray(clause?.Or) &&
+      clause.Or.some(
+        (member: Clause) =>
+          Array.isArray(member?.Eq) &&
+          member.Eq[0] === 'availability' &&
+          member.Eq[1]?.String === 'Private'
+      )
+  );
+}
+
+const ownExcludedCalls = () => queryBitdexMock.mock.calls.filter((c) => isOwnExcludedQuery(c[1]));
+const mainCalls = () => queryBitdexMock.mock.calls.filter((c) => !isOwnExcludedQuery(c[1]));
+
+/** The other creator's ordinary published image — what the feed SHOULD contain. */
+const otherCreatorPublicDoc = {
+  id: 101,
+  url: 'abc',
+  hash: null,
+  nsfwLevel: 1,
+  userId: OTHER_CREATOR_ID,
+  type: 'image',
+  availability: 'Public',
+  postId: 55,
+  postedToId: null,
+  hasMeta: true,
+  onSite: true,
+  poi: false,
+  minor: false,
+  width: 100,
+  height: 100,
+  reactionCount: 3,
+  commentCount: 2,
+  collectedCount: 1,
+  sortAt: 1_700_000_000,
+  publishedAt: 1_700_000_000,
+};
+
+/**
+ * The CALLER's own private image — exactly what the second pass exists to
+ * re-add on the caller's own views, and exactly what must not appear on
+ * someone else's.
+ */
+const callerOwnPrivateDoc = {
+  ...otherCreatorPublicDoc,
+  id: 777,
+  userId: CURRENT_USER_ID,
+  availability: 'Private',
+  postId: 61,
+  reactionCount: 9,
+  commentCount: 8,
+  collectedCount: 7,
+};
+
+/**
+ * A private document belonging to NEITHER the caller nor the creator in view.
+ * In production the own-excluded query pins `userId = currentUserId`, so BitDex
+ * cannot return this; the fake returns it anyway to prove the merge's creator
+ * scope is a live, reachable filter rather than a clause that never executes.
+ */
+const thirdPartyPrivateDoc = {
+  ...otherCreatorPublicDoc,
+  id: 909,
+  userId: THIRD_PARTY_ID,
+  availability: 'Private',
+  postId: 73,
+  reactionCount: 5,
+  commentCount: 4,
+  collectedCount: 6,
+};
+
+const EMPTY_PAGE = { documents: [], cursor: undefined };
+
+/**
+ * `cursor: undefined` terminates fetchBitdexPrimary's pass loop on the first
+ * iteration. A fake that always returned a cursor would spin to MAX_PASSES.
+ */
+function page(documents: Record<string, unknown>[]) {
+  return { documents, cursor: undefined };
+}
+
+/** Route each call to the pass it belongs to. */
+function serve({
+  main = EMPTY_PAGE,
+  ownExcluded = EMPTY_PAGE,
+}: {
+  main?: { documents: Record<string, unknown>[]; cursor: undefined };
+  ownExcluded?: { documents: Record<string, unknown>[]; cursor: undefined };
+}) {
+  queryBitdexMock.mockImplementation(async (_index: string, filters: unknown) =>
+    isOwnExcludedQuery(filters) ? ownExcluded : main
+  );
+}
+
+/**
+ * Drive the resolution from DATA, not from a pre-set `userId`: the handle→id
+ * lookup is the seam under test, so the test says which handles exist and lets
+ * the code decide when to consult that.
+ */
+function usernamesResolveTo(table: Record<string, number>) {
+  dbMock.dbRead.user.findUnique.mockImplementation(
+    async ({ where }: { where: { username?: string } }) => {
+      const id = where?.username != null ? table[where.username] : undefined;
+      return id === undefined ? null : { id };
+    }
+  );
+  dbMock.dbWrite.user.findUnique.mockResolvedValue(null);
+}
+
+const baseInput = {
+  limit: 10,
+  browsingLevel: 1,
+  periodMode: 'published',
+  include: [],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ImageSearchInput isn't exported
+} as any;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ImageSearchInput isn't exported
+const authedInput = (overrides: Record<string, unknown> = {}): any => ({
+  ...baseInput,
+  currentUserId: CURRENT_USER_ID,
+  ...overrides,
+});
+
+const ids = (data: { id: number }[]) => data.map((d) => d.id);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getFliptVariantMock.mockResolvedValue('primary');
+  usernamesResolveTo({
+    [OTHER_CREATOR_USERNAME]: OTHER_CREATOR_ID,
+    [CALLER_USERNAME]: CURRENT_USER_ID,
+  });
+  serve({});
+});
+
+describe('#3929 — a username-addressed creator feed is scoped before the own-excluded decision', () => {
+  // THE REGRESSION. Signed in, first page, another creator addressed by HANDLE.
+  // Before the fix `skipOwnExcluded` read an unresolved `input.userId`, the
+  // second pass ran, and the caller's own private image was served as the whole
+  // of that creator's feed.
+  it("authenticated + another creator by username + empty main pass → no own-excluded pass, and the caller's own private image is not served", async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(authedInput({ username: OTHER_CREATOR_USERNAME }));
+
+    // Proving the pass never ran is what makes this a claim about the guard
+    // rather than about a filter downstream of it.
+    expect(ownExcludedCalls()).toHaveLength(0);
+    expect(ids(result.data)).toEqual([]);
+    expect(result.source).toBe('meili');
+  });
+
+  // The same defect with the main pass NON-empty: before the fix the caller's
+  // private image was interleaved into a real creator feed rather than being
+  // the whole of it, which is the shape a reader would actually meet.
+  it('authenticated + another creator by username + non-empty main pass → serves only that creator, no injected own content', async () => {
+    serve({ main: page([otherCreatorPublicDoc]), ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(authedInput({ username: OTHER_CREATOR_USERNAME }));
+
+    expect(result.source).toBe('bitdex');
+    expect(ids(result.data)).toEqual([101]);
+    expect(ownExcludedCalls()).toHaveLength(0);
+  });
+
+  // An unresolvable handle names no view at all, so there is nothing for the
+  // own-excluded pass to be scoped to. Before the fix it was issued anyway and
+  // — because the main pass declined while the second pass had already
+  // answered — BitDex SERVED the caller their own private image under a
+  // creator who does not exist, never reaching the Meili leg at all.
+  //
+  // The NotFound the Meili leg raises for a bad handle is not observable here:
+  // `metricsSearchClient` is nulled so that leg returns an empty page instead
+  // of searching. What is asserted is what this function decides — decline,
+  // hand off, and issue no second pass.
+  it('authenticated + a username that resolves to nothing → no own-excluded pass, nothing served by BitDex', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(authedInput({ username: MISSING_USERNAME }));
+
+    expect(ownExcludedCalls()).toHaveLength(0);
+    expect(result.source).toBe('meili');
+    expect(ids(result.data)).toEqual([]);
+  });
+
+  // The other direction: the fix must not over-block. A caller viewing their
+  // OWN profile by handle still gets their excluded content back.
+  it('authenticated + own profile by username → own-excluded pass runs and its content is served', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(authedInput({ username: CALLER_USERNAME }));
+
+    expect(ownExcludedCalls()).toHaveLength(1);
+    expect(result.source).toBe('bitdex');
+    expect(ids(result.data)).toEqual([777]);
+  });
+});
+
+describe('#3929 — userId/username precedence and normalisation', () => {
+  // INVARIANT GUARDS — these already held. `userId` wins over a disagreeing
+  // `username` at every resolution site in image.service, and the new one has
+  // to spell the precedence the same way or the two forms of the same request
+  // would address different creators.
+  it('userId and a disagreeing username → userId wins (another creator: no own-excluded pass)', async () => {
+    serve({ main: page([otherCreatorPublicDoc]), ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(
+      // CALLER_USERNAME resolves to the caller; userId names someone else.
+      authedInput({ userId: OTHER_CREATOR_ID, username: CALLER_USERNAME })
+    );
+
+    expect(ownExcludedCalls()).toHaveLength(0);
+    expect(ids(result.data)).toEqual([101]);
+  });
+
+  it('userId and a disagreeing username → userId wins (own feed: own-excluded pass runs)', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(
+      // OTHER_CREATOR_USERNAME resolves to someone else; userId names the caller.
+      authedInput({ userId: CURRENT_USER_ID, username: OTHER_CREATOR_USERNAME })
+    );
+
+    expect(ownExcludedCalls()).toHaveLength(1);
+    expect(ids(result.data)).toEqual([777]);
+  });
+
+  // INVARIANT GUARD. The handle is looked up verbatim — no lowercasing, no
+  // trimming — so whatever the column's collation already decides about case
+  // keeps deciding it, and the BitDex and Meili legs cannot disagree about
+  // which account a handle names.
+  it('the handle reaches the lookup byte-for-byte, uncased and untrimmed', async () => {
+    const MIXED = '  SoMe-Other-Creator  ';
+    usernamesResolveTo({ [MIXED]: OTHER_CREATOR_ID });
+    serve({ main: page([otherCreatorPublicDoc]), ownExcluded: page([callerOwnPrivateDoc]) });
+
+    await getImagesFromSearch(authedInput({ username: MIXED }));
+
+    expect(dbMock.dbRead.user.findUnique).toHaveBeenCalledWith({
+      where: { username: MIXED },
+      select: { id: true },
+    });
+  });
+});
+
+describe('#3929 — the merge constrains own-excluded docs to the creator in view', () => {
+  // STRUCTURAL GUARD, not regression coverage: with the resolution fix in
+  // place the upstream guard already refuses to issue the pass for another
+  // creator, so no live caller can reach this filter. It exists so the
+  // constraint holds where the documents are ADDED to the page, not only where
+  // the decision to fetch them was made — the exact separation #3929 broke.
+  //
+  // Reached here by having the fake return a document the production query
+  // could not: proving the clause EXECUTES, rather than that it compiles.
+  it('drops a merged document whose creator is not the creator being viewed', async () => {
+    serve({
+      main: page([otherCreatorPublicDoc]),
+      ownExcluded: page([callerOwnPrivateDoc, thirdPartyPrivateDoc]),
+    });
+
+    // Own feed by id: the pass IS issued, so the merge actually runs.
+    const result = await getImagesFromSearch(authedInput({ userId: CURRENT_USER_ID }));
+
+    expect(ownExcludedCalls()).toHaveLength(1);
+    // 777 is the caller's own and the view is the caller's own feed → kept.
+    // 909 belongs to a third party → dropped by the creator scope.
+    expect(ids(result.data)).toEqual(expect.arrayContaining([777]));
+    expect(ids(result.data)).not.toContain(909);
+  });
+
+  // Positive control for the guard above: with NO creator scope on the request
+  // the same third-party document is not dropped, so the assertion above is
+  // testing the filter and not a fake that never returned the document.
+  it('positive control: with no creator scope on the request the same document survives the merge', async () => {
+    serve({
+      main: page([otherCreatorPublicDoc]),
+      ownExcluded: page([callerOwnPrivateDoc, thirdPartyPrivateDoc]),
+    });
+
+    const result = await getImagesFromSearch(authedInput());
+
+    expect(ownExcludedCalls()).toHaveLength(1);
+    expect(ids(result.data)).toEqual(expect.arrayContaining([777, 909]));
+  });
+});
+
+// A fake that ignores its arguments, or a username table nothing consults,
+// would make every assertion above vacuous.
+describe('#3929 — fake fidelity', () => {
+  it('the username table is consulted, and a different handle yields a different creator', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    // Resolves to the caller → pass issued.
+    const own = await getImagesFromSearch(authedInput({ username: CALLER_USERNAME }));
+    expect(ids(own.data)).toEqual([777]);
+
+    vi.clearAllMocks();
+    usernamesResolveTo({
+      [OTHER_CREATOR_USERNAME]: OTHER_CREATOR_ID,
+      [CALLER_USERNAME]: CURRENT_USER_ID,
+    });
+    getFliptVariantMock.mockResolvedValue('primary');
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    // Same fake, same documents, only the handle differs → pass withheld.
+    const other = await getImagesFromSearch(authedInput({ username: OTHER_CREATOR_USERNAME }));
+    expect(ids(other.data)).toEqual([]);
+  });
+
+  it('the main pass still runs for a username-addressed feed', async () => {
+    serve({ main: page([otherCreatorPublicDoc]) });
+
+    await getImagesFromSearch(authedInput({ username: OTHER_CREATOR_USERNAME }));
+
+    expect(mainCalls().length).toBeGreaterThan(0);
+  });
+});

--- a/src/server/services/__tests__/bitdex-username-own-excluded-scope.test.ts
+++ b/src/server/services/__tests__/bitdex-username-own-excluded-scope.test.ts
@@ -74,6 +74,7 @@ vi.mock('~/server/flipt/client', async (importOriginal) => ({
 }));
 
 import { getImagesFromSearch } from '../image.service';
+import { usernameSchema } from '~/shared/zod/username.schema';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
 redisMock.redis.get.mockResolvedValue('[]');
@@ -367,10 +368,44 @@ describe('#3929 — userId/username precedence and normalisation', () => {
     serve({ main: page([otherCreatorPublicDoc]), ownExcluded: page([callerOwnPrivateDoc]) });
     const callerInput = authedInput({ username: OTHER_CREATOR_USERNAME });
 
-    await getImagesFromSearch(callerInput);
+    const result = await getImagesFromSearch(callerInput);
 
+    // On its own, `userId === undefined` is VACUOUS: "the resolution never ran"
+    // and "the resolution ran and copied" both leave it undefined, so a mutant
+    // deleting the resolution outright would pass.
+    //
+    // 🔴 The obvious repair — `expect(findUnique).toHaveBeenCalled()` — does
+    // NOT fix it, measured: `getImagesFromBitdexPreFilter` performs its own
+    // `username → userId` lookup, which no such mutant touches, so the
+    // assertion is satisfied by the wrong call site and stays green.
+    //
+    // What actually discriminates is asserting the resolution had its EFFECT
+    // as well as leaving no trace: correctly scoped (no second pass, only the
+    // creator's own document) AND the caller's object untouched. That fails
+    // when the resolution is absent, and fails when it mutates in place.
+    expect(ownExcludedCalls()).toHaveLength(0);
+    expect(ids(result.data)).toEqual([101]);
     expect(callerInput.userId).toBeUndefined();
     expect(callerInput.username).toBe(OTHER_CREATOR_USERNAME);
+  });
+
+  // PREMISE GUARD — pins something OUTSIDE this file, and deliberately so.
+  //
+  // The comment above argues that adding `.trim()` to the resolution would be
+  // a provable no-op. That argument rests entirely on `usernameSchema`'s
+  // shape, which nothing here owns, so the argument can rot silently while
+  // every test stays green.
+  //
+  // 🔴 Be exact about what this does and does not buy. It does NOT kill a
+  // `.trim()` added to image.service.ts — no realistic fixture can, because
+  // padding never reaches the service. It fails when the REASON that mutant is
+  // equivalent stops holding: if usernameSchema ever accepts padding, or
+  // reorders `.trim()` ahead of the regex.
+  it('premise: usernameSchema rejects a padded handle rather than trimming it', () => {
+    expect(usernameSchema.safeParse('  SoMeOtHeRcReAtOr  ').success).toBe(false);
+    // Positive control — the same handle unpadded parses, so the assertion
+    // above is about the padding and not about the handle being invalid.
+    expect(usernameSchema.safeParse('SoMeOtHeRcReAtOr').success).toBe(true);
   });
 });
 

--- a/src/server/services/__tests__/bitdex-username-own-excluded-scope.test.ts
+++ b/src/server/services/__tests__/bitdex-username-own-excluded-scope.test.ts
@@ -85,9 +85,9 @@ const CURRENT_USER_ID = 42;
 const OTHER_CREATOR_ID = 7;
 const THIRD_PARTY_ID = 13;
 
-const OTHER_CREATOR_USERNAME = 'some-other-creator';
-const CALLER_USERNAME = 'the-caller-themselves';
-const MISSING_USERNAME = 'no-such-handle';
+const OTHER_CREATOR_USERNAME = 'SomeOtherCreator';
+const CALLER_USERNAME = 'TheCallerThemselves';
+const MISSING_USERNAME = 'NoSuchHandle_42';
 
 /**
  * Both BitDex passes go through the same `queryBitdex`, so the fake has to tell
@@ -331,12 +331,20 @@ describe('#3929 — userId/username precedence and normalisation', () => {
     expect(ids(result.data)).toEqual([777]);
   });
 
-  // INVARIANT GUARD. The handle is looked up verbatim — no lowercasing, no
-  // trimming — so whatever the column's collation already decides about case
-  // keeps deciding it, and the BitDex and Meili legs cannot disagree about
-  // which account a handle names.
-  it('the handle reaches the lookup byte-for-byte, uncased and untrimmed', async () => {
-    const MIXED = '  SoMe-Other-Creator  ';
+  // INVARIANT GUARD. The handle is looked up verbatim — no lowercasing — so
+  // whatever the column's collation already decides about case keeps deciding
+  // it, and the BitDex and Meili legs cannot disagree about which account a
+  // handle names.
+  //
+  // Case is the only normalisation worth pinning here. Trimming is NOT
+  // reachable from the request surface: `usernameSchema` is
+  // `.regex(/^[A-Za-z0-9_]*$/).trim()`, and the regex runs FIRST, so a
+  // whitespace-padded handle is rejected outright rather than trimmed. Every
+  // fixture in this file is deliberately schema-valid for the same reason — a
+  // hyphenated handle could never reach this code from a real request, and a
+  // guard proven only on input the schema rejects proves less than it looks.
+  it('the handle reaches the lookup byte-for-byte, uncased', async () => {
+    const MIXED = 'SoMeOtHeRcReAtOr';
     usernamesResolveTo({ [MIXED]: OTHER_CREATOR_ID });
     serve({ main: page([otherCreatorPublicDoc]), ownExcluded: page([callerOwnPrivateDoc]) });
 
@@ -346,6 +354,23 @@ describe('#3929 — userId/username precedence and normalisation', () => {
       where: { username: MIXED },
       select: { id: true },
     });
+  });
+
+  // The resolution writes a NEW input object rather than mutating the caller's.
+  // `getImagesFromSearch` hands its own `input` to the Meili leg after this
+  // function declines, and to the shadow comparator. An in-place `input.userId
+  // = …` would rob the Meili leg of its own `dbRead ?? dbWrite` resolution and
+  // its NotFound, and would flip the shadow comparator's `hasFilters` from
+  // false to true for every username-addressed request — neither of which any
+  // other assertion in this file would notice.
+  it('does not write the resolved userId back into the caller’s input object', async () => {
+    serve({ main: page([otherCreatorPublicDoc]), ownExcluded: page([callerOwnPrivateDoc]) });
+    const callerInput = authedInput({ username: OTHER_CREATOR_USERNAME });
+
+    await getImagesFromSearch(callerInput);
+
+    expect(callerInput.userId).toBeUndefined();
+    expect(callerInput.username).toBe(OTHER_CREATOR_USERNAME);
   });
 });
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3128,6 +3128,48 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   // properly means changing what the query asks for, which is not this PR.
   if (input.isModerator && (input.scheduled || input.notPublished)) return null;
 
+  // Resolve `username` → `userId` BEFORE anything reads the creator scope.
+  //
+  // `skipOwnExcluded` below decides whether to issue the own-excluded second
+  // pass from `input.userId`. When the caller addresses a creator by handle
+  // instead of id, that field is empty here — the resolution used to happen
+  // later and locally, inside `getImagesFromBitdexPreFilter` — so the "viewing
+  // someone else's profile" arm of that guard tested `undefined`, never fired,
+  // and the caller's own private/blocked/nsfw0 content was merged into a feed
+  // it does not belong to (#3929). Every document involved belongs to the
+  // caller, so nothing of anyone else's is exposed; what breaks is feed
+  // integrity — the feed misrepresents what that creator posted.
+  //
+  // Precedence is spelled exactly as every other resolution site in this file
+  // spells it (`username && !userId`): an explicit `userId` wins and a
+  // disagreeing `username` is ignored. Spelling it differently here would make
+  // the two forms of the same request address different creators depending on
+  // which backend answered.
+  //
+  // The handle is passed to the lookup verbatim — no lowercasing, no trimming.
+  // Case semantics stay whatever the column's collation already decides, and
+  // the BitDex and Meili legs keep agreeing about which account a handle names.
+  //
+  // This costs no extra round trip. `getImagesFromBitdexPreFilter` guards its
+  // own resolution on `!userId`, so handing it the resolved input makes that a
+  // no-op — and it runs once PER PASS, so one lookup here replaces up to
+  // MAX_PASSES + MAX_EMPTIED_PAGES of them. Same client (`dbRead`) and same
+  // query as the one it replaces, so replica-lag behaviour is unchanged.
+  if (input.username && !input.userId) {
+    const targetUser = await dbRead.user.findUnique({
+      where: { username: input.username },
+      select: { id: true },
+    });
+    // A handle that resolves to nothing names no view, so there is nothing for
+    // a second pass to be scoped to. Returning null hands the request to the
+    // Meili leg, which raises NotFound — which is what a bad handle should do
+    // and, before this, did not: the main pass declined, but the own-excluded
+    // pass had already been issued, so `data` was non-empty and BitDex served
+    // the caller their own private images under a creator who does not exist.
+    if (!targetUser) return null;
+    input = { ...input, userId: targetUser.id };
+  }
+
   const limit = input.limit ?? 100;
   // Opt-in to one's own not-yet-published content. Read once so the main
   // post-filter and the own-excluded merge below cannot disagree about it.
@@ -3338,6 +3380,22 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
       .filter((d) => !mainIds.has(d.id));
 
     // Content-scope filtering — narrow unscoped results to the current view
+    //
+    // Creator scope first, because it is the one the rest of this list was
+    // missing. The second pass asks BitDex for `userId = currentUserId` and
+    // nothing else, so on a view pinned to a single creator these documents
+    // belong on the page only when that creator IS the caller. The
+    // `skipOwnExcluded` guard above already refuses to issue the pass
+    // otherwise — this makes the constraint hold where the documents are ADDED
+    // to the page rather than only where the decision to fetch them was made.
+    //
+    // That separation is exactly what #3929 broke: the decision was computed
+    // from a field that had not been resolved yet, and nothing downstream
+    // re-checked it. With the resolution above in place no live caller reaches
+    // this clause, so it is a structural guard rather than a second fix — but
+    // it is the guard that makes any future entry point arriving here with an
+    // unresolved creator fail closed instead of open.
+    if (input.userId) ownDocs = ownDocs.filter((d) => d.userId === input.userId);
     if (input.modelVersionId) {
       ownDocs = ownDocs.filter(
         (d) =>

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3146,15 +3146,27 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   // the two forms of the same request address different creators depending on
   // which backend answered.
   //
-  // The handle is passed to the lookup verbatim — no lowercasing, no trimming.
-  // Case semantics stay whatever the column's collation already decides, and
-  // the BitDex and Meili legs keep agreeing about which account a handle names.
+  // The handle is passed to the lookup verbatim — no lowercasing. Case
+  // semantics stay whatever the column's collation already decides, and the
+  // BitDex and Meili legs keep agreeing about which account a handle names.
+  // (Trimming is not a concern reachable from the request surface:
+  // `usernameSchema` runs `.trim()` before this is ever called, and its
+  // `^[A-Za-z0-9_]*$` regex rejects whitespace outright.)
   //
-  // This costs no extra round trip. `getImagesFromBitdexPreFilter` guards its
-  // own resolution on `!userId`, so handing it the resolved input makes that a
-  // no-op — and it runs once PER PASS, so one lookup here replaces up to
-  // MAX_PASSES + MAX_EMPTIED_PAGES of them. Same client (`dbRead`) and same
-  // query as the one it replaces, so replica-lag behaviour is unchanged.
+  // Normally this costs no extra round trip: `getImagesFromBitdexPreFilter`
+  // guards its own resolution on `!userId`, so handing it the resolved input
+  // makes that a no-op — and it runs once PER PASS, so one lookup here replaces
+  // up to MAX_PASSES + MAX_EMPTIED_PAGES of them. The one exception is
+  // `hidden: true`, whose branch sits BEFORE that resolution and can return
+  // null without reaching it; such a request now pays one lookup it previously
+  // skipped.
+  //
+  // Same client (`dbRead`) and same query as the resolution it replaces, so
+  // this path's replica-lag behaviour is unchanged. It does NOT have the
+  // `dbRead ?? dbWrite` fallback the Meili-side sites have — deliberately, to
+  // keep a primary read off the feed hot path. On a replica miss the effect is
+  // strictly better than before: BitDex declines and the Meili leg, which does
+  // have the fallback, resolves and answers.
   if (input.username && !input.userId) {
     const targetUser = await dbRead.user.findUnique({
       where: { username: input.username },
@@ -3167,6 +3179,12 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
     // pass had already been issued, so `data` was non-empty and BitDex served
     // the caller their own private images under a creator who does not exist.
     if (!targetUser) return null;
+    // A NEW object, never an in-place mutation. `getImagesFromSearch` hands the
+    // caller's own `input` to the Meili leg after this function returns null,
+    // and to the shadow comparator; writing `userId` into it would rob the
+    // Meili leg of its own `dbRead ?? dbWrite` resolution and its NotFound, and
+    // would flip the shadow comparator's `hasFilters` from false to true for
+    // every username-addressed request. Pinned by a test.
     input = { ...input, userId: targetUser.id };
   }
 
@@ -3392,9 +3410,19 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
     // That separation is exactly what #3929 broke: the decision was computed
     // from a field that had not been resolved yet, and nothing downstream
     // re-checked it. With the resolution above in place no live caller reaches
-    // this clause, so it is a structural guard rather than a second fix — but
-    // it is the guard that makes any future entry point arriving here with an
-    // unresolved creator fail closed instead of open.
+    // this clause, so it is a structural guard rather than a second fix.
+    //
+    // 🔴 Be precise about what it does and does not catch, because the obvious
+    // reading is backwards. It catches a RESOLVED creator that reaches the
+    // merge past a wrong upstream decision — e.g. `skipOwnExcluded` recomputed
+    // from a stale pre-resolution binding. It does NOT catch an UNRESOLVED
+    // creator: `input.userId` is falsy in that case, so this clause is skipped
+    // entirely and the merge fails OPEN. That is measured, not assumed —
+    // deleting the resolution above while leaving this clause in place still
+    // serves the caller's own private image on another creator's feed. The two
+    // guards are therefore SEQUENTIAL, not independent: this one only has
+    // anything to test once the resolution has run. Do not cite it as coverage
+    // for a caller that arrives here with no creator resolved.
     if (input.userId) ownDocs = ownDocs.filter((d) => d.userId === input.userId);
     if (input.modelVersionId) {
       ownDocs = ownDocs.filter(

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3149,9 +3149,13 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   // The handle is passed to the lookup verbatim — no lowercasing. Case
   // semantics stay whatever the column's collation already decides, and the
   // BitDex and Meili legs keep agreeing about which account a handle names.
-  // (Trimming is not a concern reachable from the request surface:
-  // `usernameSchema` runs `.trim()` before this is ever called, and its
-  // `^[A-Za-z0-9_]*$` regex rejects whitespace outright.)
+  // (Trimming is not a concern reachable from the request surface.
+  // `usernameSchema` is `.regex(/^[A-Za-z0-9_]*$/).trim()` and the REGEX RUNS
+  // FIRST — that ordering is what makes padding unreachable, since a padded
+  // handle is rejected outright rather than trimmed into a valid one. The
+  // ordering is pinned by a premise guard in
+  // `src/server/services/__tests__/bitdex-username-own-excluded-scope.test.ts`,
+  // because this argument rests on a file this one does not own.)
   //
   // Normally this costs no extra round trip: `getImagesFromBitdexPreFilter`
   // guards its own resolution on `!userId`, so handing it the resolved input


### PR DESCRIPTION
Closes #3929.

## The defect

`fetchBitdexPrimary` decides whether to run the "own excluded" second pass from `input.userId`:

```ts
const skipOwnExcluded =
  !input.currentUserId || bitdexCursor || (input.userId && input.userId !== input.currentUserId);
```

When a caller addresses a creator by **handle** rather than id, `input.userId` is still empty at that point — `username` was resolved later and locally, inside `getImagesFromBitdexPreFilter`. So the "viewing someone else's profile" arm tested `undefined`, never fired, and the merge's content-scope list (`modelVersionId`, `postId`, `postIds`, `types`, `baseModels`, `remixOfId`, `withMeta`, `fromPlatform`) had no user filter to re-scope the result.

**Priced as feed integrity, not exposure.** Every document involved belongs to the caller, so nobody sees anyone else's private content. What breaks is that the feed misrepresents what that creator posted.

### Blast radius is narrower than #3929 states

The issue says "an authenticated caller browses another creator's images by `username`". In practice **the site's own profile gallery was never affected**: `src/components/Image/Infinite/UserMediaInfinite.tsx:161-162` sends **both** `userId: user.id` and `username`, so `input.userId` is populated and `skipOwnExcluded` already fires. `/user/<name>/images` and `/user/<name>/videos` are not reachable instances of this.

The reachable population is the public REST surface `/api/v1/images?username=` (`src/pages/api/v1/images/index.ts:56`) plus a hand-constructed `/images?username=X` URL. A search over `src/` found no in-app link that generates that shape — that is a search, not a proof of absence.

## What changed

**1. Resolve `username` → `userId` at the top of `fetchBitdexPrimary`, before anything reads the creator scope.**

Chosen as the primary fix because the merge is *downstream of the decision*: leaving the guard reading an unresolved field keeps it wrong for every consumer of that decision, and the wasted second-pass query is still issued.

- Precedence spelled exactly as the file's other three resolution sites spell it — `username && !userId`, so an explicit `userId` wins and a disagreeing `username` is ignored.
- The handle reaches the lookup verbatim: no lowercasing. Trimming is unreachable by construction — `usernameSchema` is `.regex(/^[A-Za-z0-9_]*$/).trim()` with the **regex first**, so a padded handle is rejected rather than trimmed.
- **Normally no extra round trip**: `getImagesFromBitdexPreFilter` guards its own resolution on `!userId`, and it runs once *per pass*, so one lookup replaces up to `MAX_PASSES + MAX_EMPTIED_PAGES` of them. **One exception**: the `hidden` branch sits before that resolution and can `return null` without reaching it, so `hidden: true` + `username` now pays one lookup it previously skipped.
- Uses `dbRead` only — no `dbWrite` fallback, unlike the Meili-side sites — deliberately, to keep a primary read off the feed hot path. On a replica miss the outcome is strictly better than before: BitDex declines and the Meili leg, which *does* have the fallback, resolves and answers.
- Writes a **new** input object rather than mutating the caller's. In-place would rob the Meili leg of its own `dbRead ?? dbWrite` resolution and its `NotFound`, and flip the shadow comparator's `hasFilters` from false to true for every username-addressed request. Pinned by a test.

**2. Add a creator scope to the merge's content-scope list.**

`if (input.userId) ownDocs = ownDocs.filter((d) => d.userId === input.userId);`

**These two guards are SEQUENTIAL, not independent — be precise about what the second one buys.** It catches a *resolved* creator that reaches the merge past a wrong upstream decision (e.g. `skipOwnExcluded` recomputed from a stale pre-resolution binding — mutant M3, where this clause alone keeps 777 off the page). It does **not** catch an *unresolved* creator: `input.userId` is falsy then, so the clause is skipped and the merge fails **open**. Measured, not assumed — mutant M1 deletes the resolution while leaving this clause in place and still serves the caller's private image (`expected [ 101, 777 ] to deeply equal [ 101 ]`). Do not cite this as defence-in-depth for the defect as originally reported.

## Edge cases

| Case | Behaviour |
|---|---|
| Handle resolves to nothing | Decline before any BitDex query; Meili leg raises NotFound |
| Handle → the caller | Second pass runs (own profile), pinned so the fix can't over-block |
| `userId` + disagreeing `username` | `userId` wins — spelled identically to the file's other sites; pinned both directions |
| Casing | **None introduced.** Pinned by asserting the exact `findUnique` argument |

## Tests

`src/server/services/__tests__/bitdex-username-own-excluded-scope.test.ts` — 13 tests, driven from a handle→id table the code consults rather than a pre-set `userId`, so they prove the guard is *reached*. Every fixture is **schema-valid** (`^[A-Za-z0-9_]*$`); a hyphenated handle could never reach this code from a real request.

**Matrix: 6 red at `origin/main`, 13 green at HEAD.** The other 7 are labelled **invariant guards**, not counted as regression coverage.

Red at base:
- `expected [ [ 'civitai', …(6) ] ] to have a length of +0 but got 1` — second pass issued for another creator's feed
- `expected [ 101, 777 ] to deeply equal [ 101 ]` — own private image interleaved into a real creator feed
- `expected [ [ 'civitai', …(6) ] ] to have a length of +0 but got 1` — issued for an unresolvable handle too
- `expected [ 101, 777, 909 ] to not include 909` — merge had no creator scope
- `expected [ 777 ] to deeply equal []` — same fake, only the handle differs, and the result did not
- `expected [ 101, 777 ] to deeply equal [ 101 ]` — the input-copy guard, which also proves the resolution had its effect

Full suites green: `src/server/services/__tests__/` 266 files / 3786 tests; `pnpm test:lint-rules` 243 tests.

### Mutation results (measured)

| # | Mutation | Killed | First failure |
|---|---|---|---|
| M1 | Delete the resolution entirely (the defect as reported) | ✅ 4 | `expected [ 101, 777 ] to deeply equal [ 101 ]` |
| M2 | Swap precedence — `username` wins over explicit `userId` | ✅ 2 | `expected [] to have a length of 1 but got +0` |
| M3 | Resolve, but compute the guard from the **pre-resolution** value | ✅ 2 | `expected […] to have a length of +0 but got 1` |
| M4 | Drop the merge creator scope | ✅ 1 | `expected [ 101, 777, 909 ] to not include 909` |
| M5 | Invert the merge creator scope | ✅ 4 | `expected 'meili' to be 'bitdex'` |
| M6 | Unresolvable handle no longer declines | ✅ 1 | `expected […] to have a length of +0 but got 1` |
| M7 | Merge scope compares `currentUserId` instead of `userId` | ⚠️ **survived** | — |
| M8 | `.toLowerCase()` on the handle | ✅ 5 | `expected "dbRead.user.findUnique" to be called with arguments: […]` |
| M9 | Invert the skip guard outright | ✅ 7 | `expected [] to deeply equal [ 777 ]` |
| M10 | M3 **+** M7 together | ✅ 3 | `expected [ 101, 777 ] to deeply equal [ 101 ]` |
| M11 | M3 **+** M4 together | ✅ 4 | `expected [ 101, 777 ] to deeply equal [ 101 ]` |
| M12 | Mutate the caller's `input` in place | ✅ 1 | `expected 7 to be undefined` |
| M13 | `.trim()` on the handle in the service | ⚠️ **survived** | — |
| M14 | Reorder `usernameSchema` to trim **before** the regex | ✅ 1 | `expected true to be false` |
| MX | Control: a deliberately THROWING mutant | n/a | reported 13/13 green — flagged **INVALID** by the harness |

**Two equivalent mutants, both stated rather than papered over.**

**M7** is equivalent under a correct upstream guard: `skipOwnExcluded` refuses the pass whenever `userId !== currentUserId`, so no reachable input separates the two spellings. **M10 kills it** — proving they diverge exactly when the guard they back up fails, which is why the clause reads `input.userId`.

**M13** (a service-side `.trim()`) is equivalent by an **external** invariant: all three `username` entry points (`image.schema.ts:363`, `pages/api/v1/images/index.ts:56`, `pages/api/v1/blocks/images.ts:99`) go through `usernameSchema`, and the only non-schema caller (`pages/api/mod/unblock-images.ts`) passes no username. No realistic fixture can kill it, because padding never reaches the service. So the PREMISE is pinned instead — **M14** reorders the schema and dies. The test says explicitly that it does not cover the service-side mutant.

🔴 **A mutant that THROWS is not a valid mutant.** `getImagesFromSearch` wraps the BitDex path in `try/catch` and falls through to Meili, so a mutant that dereferences null produces *exactly the expected outcome* and reports a clean false survival. The harness now checks well-formedness alongside anchor count, validated against control **MX**, which reported 13/13 green and was correctly flagged INVALID. Anchor hazards in this region, for anyone extending the battery: `if (username && !userId) {` matches **3** sites and `if (!targetUser) return null;` matches **2** — the unique anchor for the new site is `if (input.username && !input.userId) {`.

## Coordination with #4114

#4114 (`zach/3930-bitdex-serve-outcome-metric`) edits the same functions. Test-merged twice, independently, with the same result: **one conflict in `image.service.ts`, an insert/insert at the same anchor with an empty base side**. Resolve by keeping both hunks, #4122's block first; ordering is semantically neutral for the metric. Merged tree green and typecheck 0 in both runs — 277 files / 3910 tests in mine, 278 / 3922 in the auditor's independent re-merge (different `main` tip, hence the count).

**For whoever merges second:**

1. #4114 documents its moderator decline as *"Deliberately BEFORE any outcome is recorded… a policy choice"*. This PR's `return null` for an unresolvable handle is the same category and carries **no such note** in the merged tree — add one, or the convention gains an undocumented sibling.
2. **Measured** on the merged tree: an unresolvable handle under **#4114 alone** yields `source=bitdex`, `ids=[777]`, 1 BitDex call, and `bitdex_primary_result_total{outcome="served",mode="primary"} +1` — the counter scores a defective serve as a **success**. Merged, it is 0 calls and no series moves. So #3929 was inflating #4114's `served` numerator.
3. **Directional, not measured**: this PR also moves some previously-`served` requests to `fallback_empty`. If #4114's served ratio is ever used as a rollout gate, **its baseline shifts when this lands.**

## Gates

- `pnpm typecheck`: **0 errors**.
- `tsc -p tsconfig.tests.json`: **825 at `origin/main`, 825 at HEAD in the same tree — delta 0**, none in the changed files. (Re-derived from scratch; raw text differs only in TypeScript's property ordering for the same structural type, so the comparison is on the file+code multiset.)
- `npx eslint` on the two changed files: 3 errors, all **pre-existing** in `image.service.ts` and outside the diff hunks; the new test file is clean. CI's changed-files ESLint job passes.
- `prettier --check`: clean.
- The `preview / component-tests` CI job is **ungated** — `pr-preview-pipeline.yaml` says *"To make it gating later, change the component-tests step to `exit "$RC"`"*, and the status itself reports "(report-only)".

## Known sibling defect, deliberately not fixed here

A `followed: true` feed has the identical hole. Probed on the fixed tree: `source=bitdex ids=[101,777] ownPasses=1` — the caller's own private image is still injected into their Following feed. `skipOwnExcluded` only inspects `input.userId`, and the merge creator scope cannot help because that view's scope is a *set* of ids resolved inside the pre-filter. `newCreators` looks the same by inspection (not probed). Filed as **#4123**; whoever takes it must test-merge against #4114 and this PR.

