### PR TITLE
fix(app-store): stop the listing preview stating what the posture cannot know

### DIFF
--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -772,7 +772,7 @@ describe('AppListingDetailBody', () => {
     expect(prev.within.getByText('Back to store').elements()).toHaveLength(0);
   });
 
-  test('🔴 preview omits the REVIEWS row from the details rail, keeping the others', async () => {
+  test('🔴 preview omits the REVIEWS / INSTALLS / UPDATED rows, keeping the others', async () => {
     const prev = await renderScoped(
       <AppListingDetailBody detail={base({ contentRating: 'PG' })} preview />
     );
@@ -783,7 +783,12 @@ describe('AppListingDetailBody', () => {
       r.getAttribute('data-listing-detail-row')
     );
     // Control: the live arm has 6 rows including `reviews` (asserted above).
-    expect(rows).toEqual(['kind', 'category', 'rating', 'installs', 'updated']);
+    // The three dropped here are the ones a shadow listing cannot state honestly: two
+    // usage aggregates and a date that is the SUBMISSION time, not `updated_at`.
+    expect(rows).toEqual(['kind', 'category', 'rating']);
+    // 🔴 The rule itself is pinned in the blocking node project
+    // (`__tests__/appListingDetailRows.test.ts` + `__tests__/reviewListingPreview.test.ts`);
+    // this arm only pins that the DOM the component renders agrees with it.
   });
 
   test('🔴 preview keeps the read-only creator CHIP so the submitter is still named', async () => {

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -623,12 +623,15 @@ export interface AppListingDetailBodyProps {
    *     stands in so the submitter is still identified),
    *   - the header META LINE (`Updated:` + category), whose date is the publish
    *     request's submission time rather than a listing's `updated_at`,
-   *   - the Details rail's REVIEWS row (same reason as the chips),
+   *   - the Details rail's REVIEWS, INSTALLS and UPDATED rows — the first two for the
+   *     same reason as the chips (aggregates a shadow listing structurally cannot
+   *     have), the third for the same reason as the meta line above. All three
+   *     omissions are decided inside the pure row builder, not here.
    *   - the related-listings rail and the back-to-store link.
    *
-   * The Details ACCORDION itself is KEPT: kind / category / rating / installs /
-   * updated are exactly the scalars a moderator is reviewing, and the reviews row is
-   * dropped inside the pure row builder.
+   * The Details ACCORDION itself is KEPT: kind / category / rating are exactly the
+   * scalars a moderator is reviewing, and they are the ones the posture can state
+   * honestly.
    *
    * Used by the moderator listing-media review to render an unapproved SHADOW listing
    * as a store preview. Every omission above has its own test, each paired with a

--- a/src/components/Apps/__tests__/appListingDetailRows.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailRows.test.ts
@@ -7,8 +7,8 @@ import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.sche
  * The listing detail's "Details" accordion ROW MODEL (blocking `unit` project).
  *
  * The browser `component` project is not run by CI and loads no CSS, so nothing there
- * can be the gate for which rows exist, in what order, or whether the `preview`
- * posture drops the reviews row. That decision is pure, so it is pinned here.
+ * can be the gate for which rows exist, in what order, or which rows the `preview`
+ * posture drops. That decision is pure, so it is pinned here.
  *
  * `formatDate` is INJECTED throughout — a fixed marker rather than the real dayjs
  * formatter — so these assertions are about ORDER and OMISSION and cannot go red on a
@@ -230,16 +230,93 @@ describe('buildListingDetailRows — the reviews row', () => {
 });
 
 describe('🔴 buildListingDetailRows — the `preview` posture', () => {
-  it('POSITIVE CONTROL: the reviews row IS present in the live posture', () => {
-    // Same fixture, `preview` unset. Without this the omission below is a zero from a
-    // builder that might never emit the row at all.
-    expect(keys(buildListingDetailRows(detail(), { formatDate: fmt }))).toContain('reviews');
+  it('POSITIVE CONTROL: reviews, installs and updated ARE present in the live posture', () => {
+    // Same fixture, `preview` unset. Without this the omissions below are zeros from a
+    // builder that might never emit those rows at all.
+    const live = keys(buildListingDetailRows(detail(), { formatDate: fmt }));
+    expect(live).toContain('reviews');
+    expect(live).toContain('installs');
+    expect(live).toContain('updated');
   });
 
-  it('preview OMITS the reviews row (a shadow listing has none) and keeps the rest', () => {
+  it('preview OMITS reviews / installs / updated and keeps exactly the honest rows', () => {
     const rows = keys(buildListingDetailRows(detail(), { preview: true, formatDate: fmt }));
     expect(rows).not.toContain('reviews');
-    expect(rows).toEqual(['kind', 'category', 'rating', 'installs', 'updated']);
+    expect(rows).not.toContain('installs');
+    expect(rows).not.toContain('updated');
+    expect(rows).toEqual(['kind', 'category', 'rating']);
+  });
+
+  /**
+   * 🔴 INSTALLS — asserted on the ROW, not on a word.
+   *
+   * `buildListingStatChips` already returns NO chips in preview, with a docstring
+   * saying the reason is that a zero would read as a measured fact about an app nobody
+   * could yet have installed. The rail then rendered `Installs: 0` anyway. The rule is
+   * one rule; this pins that the rail obeys it too.
+   *
+   * The assertion is the ABSENCE OF THE ROW OBJECT plus the absence of any row whose
+   * rendered value is the zero string — not "the DOM does not contain '0'", which any
+   * other number on the page can spell.
+   */
+  it('🔴 preview renders NO installs row — not even the zero one', () => {
+    const zeroed = detail({ installCount: 0 });
+    // Control: with `preview` unset the zero really does render, so the omission below
+    // is about the posture and not about a builder that drops zeros generally.
+    const live = buildListingDetailRows(zeroed, { formatDate: fmt });
+    expect(live.find((r) => r.key === 'installs')).toMatchObject({
+      label: 'Installs',
+      value: '0',
+    });
+
+    const rows = buildListingDetailRows(zeroed, { preview: true, formatDate: fmt });
+    expect(rows.find((r) => r.key === 'installs')).toBeUndefined();
+    // …and no OTHER row smuggles the count in under a different key.
+    expect(rows.map((r) => r.value)).not.toContain('0');
+    expect(rows.map((r) => r.label)).not.toContain('Installs');
+  });
+
+  /**
+   * 🔴 UPDATED — the mislabelled-submission-date row.
+   *
+   * In preview the `updatedAt` a `ListingDetail` carries is not necessarily
+   * `app_listings.updated_at`: `buildListingDetailPreview` has no such field and
+   * substitutes the publish request's SUBMISSION time. The row rendered it as
+   * "Updated: <submission date>". `AppListingDetailBody` already omits its header meta
+   * line in preview for exactly this reason; the rail now agrees.
+   *
+   * Asserted on the row's rendered VALUE — the formatted date string is pinned absent,
+   * so a row that came back under a different key or label would still fail.
+   */
+  it('🔴 preview renders NO updated row, so no date reaches the screen under that label', () => {
+    // Control: the live posture DOES render the formatted date.
+    const live = buildListingDetailRows(detail(), { formatDate: fmt });
+    expect(live.find((r) => r.key === 'updated')).toMatchObject({
+      label: 'Updated',
+      value: `formatted:${FIXED_DATE}`,
+    });
+
+    const rows = buildListingDetailRows(detail(), { preview: true, formatDate: fmt });
+    expect(rows.find((r) => r.key === 'updated')).toBeUndefined();
+    expect(rows.map((r) => r.value)).not.toContain(`formatted:${FIXED_DATE}`);
+    expect(rows.map((r) => r.label)).not.toContain('Updated');
+  });
+
+  it('🔴 preview never calls the date formatter at all', () => {
+    // Stronger than "no row": if the formatter is never invoked, no formatted date can
+    // exist to be rendered by any future row. A spy, not a string search.
+    const calls: string[] = [];
+    const spy = (iso: string) => {
+      calls.push(iso);
+      return `formatted:${iso}`;
+    };
+    // Positive control first — the spy DOES fire in the live posture.
+    buildListingDetailRows(detail(), { formatDate: spy });
+    expect(calls).toEqual([FIXED_DATE]);
+
+    calls.length = 0;
+    buildListingDetailRows(detail(), { preview: true, formatDate: spy });
+    expect(calls).toEqual([]);
   });
 
   it('preview: false is byte-identical to omitting the flag', () => {

--- a/src/components/Apps/__tests__/reviewListingPreview.test.ts
+++ b/src/components/Apps/__tests__/reviewListingPreview.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { buildListingDetailRows } from '~/components/Apps/appListingDetailRows';
 import {
   buildListingCardPreview,
   buildListingDetailPreview,
@@ -49,7 +50,12 @@ describe('buildListingCardPreview', () => {
     // No reviews on an unapproved listing.
     expect(card.recommend.recommendPct).toBeNull();
     expect(card.reviewCount).toBe(0);
-    expect(card.kindData).toEqual({ kind: 'onsite', appBlockId: null, hasPage: false, liveUrl: '' });
+    expect(card.kindData).toEqual({
+      kind: 'onsite',
+      appBlockId: null,
+      hasPage: false,
+      liveUrl: '',
+    });
   });
 
   it('an external (offsite) row → offsite kindData with the external url + sub-kind', () => {
@@ -90,7 +96,9 @@ describe('buildListingCardPreview', () => {
   });
 
   it('falls back to the slug when the listing (or its name) is absent', () => {
-    expect(buildListingCardPreview(row({ id: 'r4', appListing: null, slug: 'sx' })).name).toBe('sx');
+    expect(buildListingCardPreview(row({ id: 'r4', appListing: null, slug: 'sx' })).name).toBe(
+      'sx'
+    );
   });
 
   it('passes resolved image URLs straight through when provided', () => {
@@ -114,7 +122,12 @@ describe('buildListingDetailPreview', () => {
     // serialId only feeds the comments thread, which preview omits.
     expect(detail.serialId).toBe(0);
     expect(detail.screenshots).toEqual([]);
-    expect(detail.kindData).toEqual({ kind: 'onsite', appBlockId: null, hasPage: false, liveUrl: '' });
+    expect(detail.kindData).toEqual({
+      kind: 'onsite',
+      appBlockId: null,
+      hasPage: false,
+      liveUrl: '',
+    });
   });
 
   it('an external row carries the connectClientId (null) + externalUrl on kindData', () => {
@@ -144,5 +157,70 @@ describe('buildListingDetailPreview', () => {
     });
     expect(detail.coverUrl).toBe('https://cdn/cover.png');
     expect(detail.screenshots).toEqual([{ url: 'https://cdn/s1.png', caption: 'one' }]);
+  });
+});
+
+/**
+ * 🔴 THE SEAM — this builder's fabricated scalars vs the rail that renders them.
+ *
+ * Both halves were individually tested and individually right, and the defect lived
+ * BETWEEN them: this module substitutes the publish request's SUBMISSION time for the
+ * required `updatedAt`, and `buildListingDetailRows` rendered that value under the
+ * label "Updated". Neither module's own suite could see it — one never loads the rail,
+ * the other never loads this builder. So the composition is asserted here, with the
+ * SUBMISSION TIMESTAMP as the thing that must not appear.
+ *
+ * The `installCount: 0` half is the same shape: a structural zero this builder emits,
+ * which the rail printed as `Installs: 0` while the header chips (which decided the
+ * same question correctly) showed nothing.
+ */
+describe('🔴 SEAM: nothing the preview builder FABRICATES reaches the details rail', () => {
+  const SUBMITTED = '2026-01-01T00:00:00Z';
+  /** A marker formatter — the rendered date is identifiable no matter the locale. */
+  const fmt = (iso: string) => `formatted:${iso}`;
+
+  const previewDetail = () => buildListingDetailPreview(row({ id: 'seam', kind: 'onsite' }));
+
+  it('POSITIVE CONTROL: the builder really does fabricate both scalars', () => {
+    // Without this, the assertions below could pass because the builder stopped
+    // emitting the fields at all — a different change, and not the one under test.
+    const detail = previewDetail();
+    expect(detail.updatedAt).toBe(new Date(SUBMITTED).toISOString());
+    expect(detail.installCount).toBe(0);
+  });
+
+  it('POSITIVE CONTROL: rendered in the LIVE posture, both fabricated values DO show', () => {
+    // The rail is not blind to these values in general — which is what makes their
+    // absence in `preview` a fact about the posture rather than about the rail.
+    const rows = buildListingDetailRows(previewDetail(), { formatDate: fmt });
+    expect(rows.find((r) => r.key === 'updated')?.value).toBe(
+      `formatted:${new Date(SUBMITTED).toISOString()}`
+    );
+    expect(rows.find((r) => r.key === 'installs')?.value).toBe('0');
+  });
+
+  it('🔴 in `preview` the submission time is NOT rendered, under any label', () => {
+    const rows = buildListingDetailRows(previewDetail(), { preview: true, formatDate: fmt });
+    const submittedIso = new Date(SUBMITTED).toISOString();
+    // The formatted value, the raw ISO string, and the row key — three shapes the same
+    // date could arrive in.
+    expect(rows.map((r) => r.value)).not.toContain(`formatted:${submittedIso}`);
+    expect(rows.map((r) => r.value)).not.toContain(submittedIso);
+    expect(rows.find((r) => r.key === 'updated')).toBeUndefined();
+    expect(rows.map((r) => r.label)).not.toContain('Updated');
+  });
+
+  it('🔴 in `preview` the structural zero install count is NOT rendered', () => {
+    const rows = buildListingDetailRows(previewDetail(), { preview: true, formatDate: fmt });
+    expect(rows.find((r) => r.key === 'installs')).toBeUndefined();
+    expect(rows.map((r) => r.value)).not.toContain('0');
+    expect(rows.map((r) => r.label)).not.toContain('Installs');
+  });
+
+  it('🔴 the preview rail states ONLY what the posture can state honestly', () => {
+    // The whole row set, pinned — so a future row carrying another fabricated scalar
+    // has to be added here deliberately.
+    const rows = buildListingDetailRows(previewDetail(), { preview: true, formatDate: fmt });
+    expect(rows.map((r) => r.key)).toEqual(['kind', 'category', 'rating']);
   });
 });

--- a/src/components/Apps/appListingDetailRows.ts
+++ b/src/components/Apps/appListingDetailRows.ts
@@ -11,9 +11,24 @@
  *   1. A row whose underlying field is null/absent is OMITTED. A "Rating: —" row is
  *      noise; an absent row is the honest signal.
  *   2. In `preview` posture (the moderator listing-media review, rendering an
- *      UNAPPROVED shadow listing) the REVIEWS row is omitted. A shadow listing has no
- *      review rows at all, so its rollup is structurally 0/0 and rendering "No reviews
- *      yet" there would read as a fact about the app rather than about the posture.
+ *      UNAPPROVED shadow listing) the REVIEWS, INSTALLS and UPDATED rows are omitted.
+ *      One rule, three fields — every one of them is a number or a date the posture
+ *      cannot supply honestly:
+ *        - REVIEWS: a shadow listing has no review rows at all, so its rollup is
+ *          structurally 0/0. "No reviews yet" there reads as a fact about the APP
+ *          rather than about the POSTURE.
+ *        - INSTALLS: identical reasoning, and it was the inconsistency this rule was
+ *          widened to close. `buildListingStatChips` already returns NO chips in
+ *          preview precisely so a zero cannot be read as a measurement — and then
+ *          `Installs: 0` rendered here anyway, in the rail, one column over. An
+ *          un-approved listing has never been installable by anyone.
+ *        - UPDATED: the date a preview carries is NOT `app_listings.updated_at`.
+ *          `buildListingDetailPreview` has no such field to read and substitutes the
+ *          publish request's SUBMISSION time, so the row labelled "Updated" showed a
+ *          moderator the moment the app was submitted. `AppListingDetailBody` already
+ *          omits its header META LINE in preview for exactly this reason; the rail row
+ *          rendered the same value under the same label two inches lower. The review
+ *          surface prints the submission time itself, twice, correctly labelled.
  *
  * The REVIEWS row's word label comes from the SHARED ladder (`~/utils/rating-label`),
  * the same one the model version page renders — not a second copy with its own
@@ -48,7 +63,8 @@ function kindLabel(detail: Pick<ListingDetail, 'kindData'>): string {
 /**
  * Build the ordered Details rows for a listing.
  *
- * @param opts.preview read-only moderator posture — omits the reviews row (rule 2).
+ * @param opts.preview read-only moderator posture — omits the reviews, installs and
+ *   updated rows (rule 2).
  * @param opts.formatDate injected so this module stays pure and the test can pin the
  *   ORDER and OMISSION rules without depending on dayjs' locale or the host timezone.
  */
@@ -110,7 +126,11 @@ export function buildListingDetailRows(
   // A details row is DECORATION. It must never be able to blank the page it decorates,
   // and a required TYPE is not a runtime guarantee about a value that crossed a cast.
   // An absent field therefore takes the same path as a null `category`: omit the row.
-  if (typeof detail.installCount === 'number') {
+  //
+  // 🔴 …AND OMITTED WHOLESALE IN `preview` (rule 2). A shadow listing has never been
+  // installable, so the zero is a fact about the POSTURE, not about the app — the same
+  // reasoning that makes `buildListingStatChips` return no chips at all in preview.
+  if (!opts.preview && typeof detail.installCount === 'number') {
     rows.push({
       key: 'installs',
       label: 'Installs',
@@ -118,7 +138,11 @@ export function buildListingDetailRows(
     });
   }
 
-  if (detail.updatedAt) {
+  // 🔴 OMITTED IN `preview` (rule 2): a preview's `updatedAt` is not the listing row's
+  // `updated_at` — the fallback builder substitutes the publish request's submission
+  // time — so this row labelled a submission date "Updated". The body already omits its
+  // header meta line in preview for the same reason.
+  if (!opts.preview && detail.updatedAt) {
     rows.push({ key: 'updated', label: 'Updated', value: opts.formatDate(detail.updatedAt) });
   }
 

--- a/src/components/Apps/reviewListingPreview.ts
+++ b/src/components/Apps/reviewListingPreview.ts
@@ -130,13 +130,22 @@ export function buildListingDetailPreview(
     // accepted-and-displayed set to read yet. An empty array is the honest answer, not
     // a placeholder.
     collaborators: [],
+    // 🔴 A REQUIRED-FIELD STAND-IN, NOT AN UPDATE TIME — and nothing may render it.
+    //
     // The row is a PUBLISH REQUEST, not a live listing, so there is no
-    // `app_listings.updated_at` to read. The submission time is the honest nearest
-    // fact, and it is unobserved in practice: this shape is only ever handed to
-    // `AppListingDetailBody` in `preview` mode, which omits the whole header meta
-    // line (see that component's preview posture). Normalised to the same ISO string
-    // the real projection emits, so both producers of a `ListingDetail` agree on the
-    // field's TYPE as well as its presence.
+    // `app_listings.updated_at` to read (which is what `ListingDetail.updatedAt` is
+    // declared to mean). The field is non-optional on the DTO, so the submission time
+    // goes in as the nearest available scalar, normalised to the same ISO string the
+    // real projection emits so both producers agree on the field's TYPE.
+    //
+    // An earlier note here claimed the value was "unobserved in practice" because the
+    // `preview` posture omits the header meta line. That was FALSE: the Details rail's
+    // `updated` row rendered it, under the label "Updated", so a moderator was shown
+    // the SUBMISSION date presented as the app's last update. Both surfaces now omit it
+    // in preview — the meta line in `AppListingDetailBody`, the rail row in
+    // `buildListingDetailRows` (rule 2 there) — and the seam between THIS builder and
+    // that one is pinned in `__tests__/reviewListingPreview.test.ts`, so the claim is a
+    // guarded one rather than a comment anybody has to take on trust.
     updatedAt: new Date(row.submittedAt).toISOString(),
     // An unapproved listing has never been installable. Same reasoning as the
     // `EMPTY_RECOMMEND` rollup above: zero is the fact, not a placeholder.

--- a/src/pages/3d-models/[id]/[[...slug]].tsx
+++ b/src/pages/3d-models/[id]/[[...slug]].tsx
@@ -124,10 +124,27 @@ export const getServerSideProps = createServerSideProps({
 });
 
 /**
- * Derive a coarse sentiment label from the recommend percentage. Inlined
- * here — no shared helper exists for this on the AI-model side (they show
- * raw thumbs counts instead of a sentiment band). Bands mirror the common
- * Steam-style scale, scaled down to fit the typical Civitai review volume.
+ * Derive a coarse sentiment label from the recommend percentage. Bands mirror the
+ * common Steam-style scale, scaled down to fit the typical Civitai review volume.
+ *
+ * 🔴 DELIBERATELY NOT the shared ladder in `~/utils/rating-label` (used by the model
+ * version page and the app-store listing detail), and this is a decision that was
+ * measured rather than a helper nobody noticed. Two structural differences:
+ *
+ *   1. That ladder takes a 0–1 proportion; this takes an integer PERCENT, which is
+ *      what the caller already computes for the badge beside this label.
+ *   2. That ladder's WORD widens with the review COUNT — "Overwhelmingly …" is
+ *      withheld until 500 reviews. This one's word depends on the percentage alone,
+ *      with a single `< 5` insufficient-data floor ("Too few reviews", a label the
+ *      shared ladder has no band for).
+ *
+ * Across the whole `pct × count` grid the two agree except at the extremes, and they
+ * agree COMPLETELY once the count clears ~500 — so difference (2) is the entire
+ * divergence, and it only bites below the volume a 3D model reaches. Adopting the
+ * shared ladder here would re-word live verdicts (6/6 recommends: "Overwhelmingly
+ * positive" → "Positive"). The decision, the grid measurement and the reason it cannot
+ * be folded into one band set are recorded in `src/utils/__tests__/rating-label.test.ts`
+ * beside the allowlist entry that keeps this function visible to that guard.
  */
 function sentimentLabel(recommendPct: number, ratingCount: number): string {
   if (ratingCount < 5) return 'Too few reviews';

--- a/src/utils/__tests__/rating-label.test.ts
+++ b/src/utils/__tests__/rating-label.test.ts
@@ -237,18 +237,48 @@ describe('🔴 the rating ladder has exactly the callers it is supposed to have'
   const LADDER_LABEL_THRESHOLD = 3;
 
   /**
-   * 🔴 KNOWN, DELIBERATELY-TOLERATED SECOND LADDER — a FOLLOW-UP, not an exemption.
+   * 🔴 A DECIDED DIVERGENCE — the follow-up was worked, and the answer was "separate".
    *
-   * `pages/3d-models/[id]/[[...slug]].tsx` defines `sentimentLabel`, a drifted third
-   * ladder on a 0–100 scale with different bands and a sixth label ("Too few reviews").
-   * It PREDATES this module's extraction and consolidating it is out of scope for the
-   * change that added this guard — folding a 0–100 ladder with different bands into the
-   * 0–1 one is a behaviour change to a live page, not a refactor.
+   * `pages/3d-models/[id]/[[...slug]].tsx` defines `sentimentLabel`: a second ladder on
+   * a 0–100 integer scale, with a sixth label ("Too few reviews") and NO count-widening
+   * of the word itself. The entry used to read "not yet consolidated". It was
+   * consolidated-or-not on the evidence below, and the answer is NOT.
    *
-   * It is listed HERE, explicitly, rather than dodged by weakening the scan: the scan
-   * DOES flag it (asserted below, so this entry can never rot into dead weight), and
-   * when the consolidation lands, removing the file's own ladder makes that assertion
-   * fail and this entry has to come out with it.
+   * 🔴 THE MEASUREMENT. Both ladders were evaluated over the whole input grid
+   * (`pct` 0…100 × `count` 1…1000, 101,000 cells), comparing the word case-insensitively:
+   *
+   *     agree 86.2% · disagree 13.8% (13.5% ignoring the `< 5` floor)
+   *
+   * and every disagreement is in one of two places, at every count below 500:
+   *
+   *     n ∈ [5, 9]   : 0–19%  Overwhelmingly negative → Mixed
+   *                    80–94% Very positive          → Positive
+   *                    95–100% Overwhelmingly positive → Positive
+   *     n ∈ [10, 49] : 0–19%  Overwhelmingly negative → Negative      (+ the same top two)
+   *     n ∈ [50, 499]: 0–19%  Overwhelmingly negative → Very Negative
+   *                    95–100% Overwhelmingly positive → Very Positive
+   *     n >= 600     : NO disagreement anywhere on the row.
+   *
+   * That shape is the whole argument. The disagreement is not drift and not sloppiness:
+   * it is precisely THIS module's count-widening, which reserves "Overwhelmingly …" for
+   * >= 500 reviews. The 3D page's own comment says its bands are "scaled down to fit the
+   * typical Civitai review volume", and the two ladders become IDENTICAL once the count
+   * clears ~500 — i.e. they differ only where a 3D model actually lives. Migrating that
+   * caller would silently re-word live verdicts: a 6/6-recommend model drops from
+   * "Overwhelmingly positive" to "Positive", a 0/60 one softens from "Overwhelmingly
+   * negative" to "Very Negative".
+   *
+   * 🔴 AND IT CANNOT BE EXPRESSED BY WIDENING THIS LADDER. The scale (0–100 vs 0–1) and
+   * the sixth label are both easy — an argument each. The irreducible difference is
+   * STRUCTURAL: here the WORD depends on the review count, there it does not. One band
+   * set cannot be both, so "extend the shared ladder" degrades into a ladder FACTORY
+   * with two configs — two ladders in one file, which is the drift this module exists to
+   * prevent, with an indirection added on top.
+   *
+   * The entry stays listed HERE, explicitly, rather than dodged by weakening the scan:
+   * the scan DOES flag it (asserted below, so this entry can never rot into dead
+   * weight), and if that page's ladder is ever removed or rewritten to import this one,
+   * the assertion fails and this entry has to come out with it.
    */
   const KNOWN_UNSHARED_LADDERS = ['pages/3d-models/[id]/[[...slug]].tsx'];
 
@@ -352,6 +382,29 @@ describe('🔴 the rating ladder has exactly the callers it is supposed to have'
     expect(
       quotedLadderLabels(`const k = { positive: 'positive', negative: 'negative' };`).length
     ).toBeLessThan(LADDER_LABEL_THRESHOLD);
+  });
+
+  /**
+   * INVARIANT GUARD — not regression coverage, and labelled as such.
+   *
+   * It cannot have been red before this change, because it pins a property that was
+   * already true. What it buys is that the *reason* recorded above stops being prose:
+   * the divergence is justified by the sixth label and the 0–100 scale, so if the 3D
+   * page's ladder ever loses them, the justification no longer describes the code and
+   * this fails rather than quietly becoming stale.
+   */
+  it('INVARIANT: the shared ladder structurally cannot express the 3d page label set', () => {
+    // The sixth label is not in this ladder's alphabet, and cannot be — this ladder has
+    // no insufficient-data band at all (its contract puts the zero-review short-circuit
+    // on the CALLER; see `getRatingLabel`'s param docs).
+    expect(LADDER_LABELS).not.toContain('Too few reviews');
+    expect(fs.readFileSync(path.resolve(SRC, LADDER_MODULE), 'utf8')).not.toMatch(
+      /(["'`])Too few reviews\1/
+    );
+
+    // …and the divergent caller still carries it, as a whole quoted literal.
+    const text = fs.readFileSync(path.resolve(SRC, KNOWN_UNSHARED_LADDERS[0]), 'utf8');
+    expect(text).toMatch(/(["'`])Too few reviews\1/);
   });
 
   it('🔴 the tolerated 3d-models ladder is still THERE and still FLAGGED (allowlist is live)', () => {

--- a/src/utils/rating-label.ts
+++ b/src/utils/rating-label.ts
@@ -24,10 +24,14 @@ import type { MantineColor } from '@mantine/core';
  *     does), and a drifted copy planted in `components/Apps/` passed all 49 tests. The
  *     second scan looks for this ladder's OUTPUT ALPHABET in the source text instead.
  *
- * 🔴 KNOWN, NOT YET CONSOLIDATED: `pages/3d-models/[id]/[[...slug]].tsx` defines
- * `sentimentLabel`, a third ladder on a 0–100 scale with different bands and a sixth
- * label. It predates this extraction, the scan DOES flag it, and it is allowlisted by
- * name in that test file with the follow-up recorded there — not silently tolerated.
+ * 🔴 DECIDED, NOT PENDING: `pages/3d-models/[id]/[[...slug]].tsx` keeps its own
+ * `sentimentLabel` ladder — a DELIBERATE divergence, not a consolidation still owed.
+ * The follow-up that was recorded here was worked and closed with "leave it separate";
+ * the reasoning, and the measurement it rests on, live beside the allowlist entry in
+ * `__tests__/rating-label.test.ts`. The short version: the two ladders disagree only at
+ * the EXTREMES, and they disagree there because this one withholds its strongest words
+ * until 500 reviews — a threshold a 3D model does not reach. Folding them together
+ * would change verdicts on a live page at exactly the review counts that page sees.
  */
 export type RatingLabel = {
   /** Display copy, e.g. `Very Positive`. Rendered `tt="capitalize"` by both callers. */


### PR DESCRIPTION
Three follow-ups recorded on the #4058 thread. All three live in the moderator `preview` posture of the store-listing detail, and two of them are the same defect wearing different clothes: the posture states something it cannot know.

---

## 1. `Installs: 0` rendered in preview

`buildListingStatChips` already returns **no chips at all** in preview, with a docstring saying why: an un-approved listing's rollup is `0/0` because nobody *could* have installed it, and a zero there "would read as a fact about the app rather than about the posture".

The Details rail printed `Installs: 0` anyway, one column over from the chips that were suppressed for exactly that reason. One rule, now applied in both places.

## 2. The submission date was labelled "Updated"

`buildListingDetailPreview` builds a `ListingDetail` from a **publish request**, which has no `app_listings.updated_at` to read — so it substitutes `submittedAt` for the required field. The rail then rendered that value as `Updated: <submission date>`.

`AppListingDetailBody` **already omits its header meta line in preview for precisely this reason** — the omission ledger says the date "is the publish request's submission time rather than a listing's `updated_at`". The rail row showed the same value under the same label two inches lower. It is now omitted too.

The comment in `reviewListingPreview.ts` claiming the field was "unobserved in practice" was **false** — a browser test asserted the `updated` row rendered. It is replaced with what is actually true, plus the guard that makes the claim checkable rather than something a reader has to take on trust.

Nothing is lost: the review surface already prints the submission time twice, correctly labelled, in the queue row and the open-request header.

### Both were SEAM defects

Each module's own suite was right, and neither loads the other — `reviewListingPreview.test.ts` never built a row, `appListingDetailRows.test.ts` never built a preview view-model. So the composition is now asserted directly: build the preview view-model from a review row, run it through the **real** rail builder, and pin that neither fabricated scalar comes out.

---

## 3. The third rating ladder — **left separate, deliberately**

`sentimentLabel` in `pages/3d-models/[id]/[[...slug]].tsx` stays where it is. This is a decision, not a consolidation still owed, and the allowlist entry is rewritten from a pending TODO into the decision plus its measurement.

**The measurement.** Both ladders evaluated over the whole input grid (`pct` 0…100 × `count` 1…1000 — 101,000 cells), words compared case-insensitively:

```
agree 86.2%  ·  disagree 13.8%   (13.5% ignoring the `< 5` floor)
```

Every disagreement is in one of two places:

| reviews | disagreement |
|---|---|
| 5–9 | 0–19% `Overwhelmingly negative`→`Mixed` · 80–94% `Very positive`→`Positive` · 95–100% `Overwhelmingly positive`→`Positive` |
| 10–49 | 0–19% `Overwhelmingly negative`→`Negative` (+ the same top two) |
| 50–499 | 0–19% `Overwhelmingly negative`→`Very Negative` · 95–100% `Overwhelmingly positive`→`Very Positive` |
| ≥ 600 | **none, anywhere on the row** |

That shape is the whole argument. The disagreement is not drift — it *is* the shared ladder's count-widening, which withholds "Overwhelmingly …" until 500 reviews. The 3D page's own comment says its bands are "scaled down to fit the typical Civitai review volume", and the two become identical once the count clears ~500 — i.e. they differ only where a 3D model actually lives. Migrating would silently re-word live verdicts: a 6/6-recommend model drops `Overwhelmingly positive` → `Positive`; a 0/60 one softens `Overwhelmingly negative` → `Very Negative`.

**And it cannot be expressed by extending the shared ladder.** The 0–100 scale and the sixth label are one argument each — easy. The irreducible difference is structural: in the shared ladder the **word depends on the review count**; in this one it does not. One band set cannot be both, so "extend it" degrades into a ladder *factory* with two configs — two ladders in one file, which is the drift the module exists to prevent, with indirection added on top.

The scan still flags the file and the liveness assertion is unchanged, so the entry cannot rot: if that page's ladder is ever removed or rewritten to import the shared one, the assertion fails and the entry has to come out with it.

---

## Test coverage — red→green matrix

Guards land in the **blocking node `unit` project**, not the report-only browser tier. Every omission assertion is paired with a positive control from the live posture, and asserts the **row object and its rendered value** rather than the absence of a word another row could spell.

Base = `origin/main` (`315bdf26a`), reached by reverting only the behaviour-carrying source (`src/components/Apps/appListingDetailRows.ts`) to that ref and re-running — the test files are unchanged between arms.

```
npx vitest run --project unit \
  src/components/Apps/__tests__/appListingDetailRows.test.ts \
  src/components/Apps/__tests__/reviewListingPreview.test.ts \
  src/utils/__tests__/rating-label.test.ts
```

| guard | project | base | HEAD |
|---|---|---|---|
| `appListingDetailRows`: preview OMITS reviews / installs / updated and keeps exactly the honest rows | `unit` | ❌ | ✅ |
| `appListingDetailRows`: preview renders NO installs row — not even the zero one | `unit` | ❌ | ✅ |
| `appListingDetailRows`: preview renders NO updated row, so no date reaches the screen under that label | `unit` | ❌ | ✅ |
| `appListingDetailRows`: preview never calls the date formatter at all | `unit` | ❌ | ✅ |
| `reviewListingPreview` **SEAM**: in preview the submission time is NOT rendered, under any label | `unit` | ❌ | ✅ |
| `reviewListingPreview` **SEAM**: in preview the structural zero install count is NOT rendered | `unit` | ❌ | ✅ |
| `reviewListingPreview` **SEAM**: the preview rail states ONLY what the posture can state honestly | `unit` | ❌ | ✅ |
| `AppListingDetailBody`: preview omits the REVIEWS / INSTALLS / UPDATED rows (DOM) | `component` | ❌ | ✅ |
| `rating-label`: the shared ladder structurally cannot express the 3d page label set | `unit` | ✅ | ✅ |

- **base run:** `Tests 7 failed | 84 passed (91)` — the 7 failures are exactly the new guards; every positive control passed in both arms. Each died with its own message, e.g. `expected [ Array(5) ] to not include 'formatted:2026-01-01T00:00:00.000Z'` — the submission timestamp on screen, which is the defect reproduced.
- **HEAD run:** `Test Files 3 passed (3) · Tests 91 passed (91)`.
- The last row is an **INVARIANT guard, labelled as such in the file and not counted as regression coverage** — it pins that the shared ladder has no insufficient-data band while the divergent caller still carries `'Too few reviews'`, so the recorded justification cannot go stale without failing.

### Wider runs at HEAD

| run | result |
|---|---|
| `npx vitest run --project unit src/components/Apps src/utils` | `94 files passed · 1729 passed, 1 skipped` |
| `--project component src/components/Apps/AppListingDetailBody.browser.test.tsx` | `64 passed` (base: `1 failed \| 63 passed`) |
| `--project component` — OffsiteReviewQueue / ConnectScopesPanel / CombinedReviewModal / ReviewDetailView | `4 files · 41 passed` |
| `npm run typecheck` | `OK — 0 type errors in 87s` |
| `eslint` (8 changed files, JSON reporter) | `0 errors, 2 warnings` — both pre-existing `react-hooks/exhaustive-deps` in the 3D page, untouched by the comment-only edit there |
| `prettier --check` (9 files) | clean |

## Blast radius

`preview` has exactly one production consumer: `OffsiteReviewQueue.tsx`'s `ListingPreviewSection` (grepped for every `AppListingDetailBody` call site — the only other one, `/apps/store-preview/[slug]`, passes no `preview` prop).

The **live** posture is untouched, and the evidence for that is the base/HEAD arms rather than a single test: the live-arm assertions — `a fully-populated listing yields every row, in the fixed order`, `labels and values are the display strings, not the raw fields`, the null-field omission cases and both `POSITIVE CONTROL` rows — passed **identically in both arms**, and the only tests whose verdict moved were the 7 preview guards. `preview: false is byte-identical to omitting the flag` also passed in both arms.

The preview accordion always keeps at least the `kind` row, so it can never render empty.
