### PR TITLE
fix(search): derive the browsing-level attribute from the index, not a hand-kept list

### DIFF
--- a/src/components/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/src/components/AutocompleteSearch/AutocompleteSearch.tsx
@@ -49,7 +49,7 @@ import { useHitsTransformed } from '~/components/Search/search.utils2';
 import type { ReverseSearchIndexKey, SearchIndexKey } from '~/components/Search/search.types';
 import { reverseSearchIndexMap, searchIndexMap } from '~/components/Search/search.types';
 import { isDefined, paired } from '~/utils/type-guards';
-import { ApplyCustomFilter, BrowsingLevelFilter } from '../Search/CustomSearchComponents';
+import { BrowsingLevelFilter } from '../Search/CustomSearchComponents';
 import { QS } from '~/utils/qs';
 import { ToolSearchItem } from '~/components/AutocompleteSearch/renderItems/tools';
 import { ComicsSearchItem } from '~/components/AutocompleteSearch/renderItems/comics';
@@ -134,20 +134,6 @@ export const AutocompleteSearch = forwardRef<{ focus: () => void }, Props>(({ ..
   };
   const currentUser = useCurrentUser();
 
-  const indexSupportsNsfwLevel = useMemo(
-    () =>
-      [
-        searchIndexMap.articles,
-        searchIndexMap.bounties,
-        searchIndexMap.models,
-        searchIndexMap.images,
-        searchIndexMap.collections,
-        searchIndexMap.tools,
-        searchIndexMap.comics,
-      ].some((i) => i === searchIndexMap[targetIndex]),
-    [targetIndex]
-  );
-
   const isModels = targetIndex === 'models';
   const isImages = targetIndex === 'images';
   const supportsPoi = ['models', 'images'].includes(targetIndex);
@@ -177,14 +163,7 @@ export const AutocompleteSearch = forwardRef<{ focus: () => void }, Props>(({ ..
       indexName={searchIndexMap[targetIndex as keyof typeof searchIndexMap]}
       future={{ preserveSharedStateOnUnmount: false }}
     >
-      {indexSupportsNsfwLevel ? (
-        <BrowsingLevelFilter
-          attributeName={indexSupportsNsfwLevel ? 'nsfwLevel' : ''}
-          filters={filters}
-        />
-      ) : filters.length > 0 ? (
-        <ApplyCustomFilter filters={filters} />
-      ) : null}
+      <BrowsingLevelFilter indexKey={targetIndex} filters={filters} />
       <AutocompleteSearchContent
         {...props}
         indexName={targetIndex}

--- a/src/components/Search/CustomSearchComponents.tsx
+++ b/src/components/Search/CustomSearchComponents.tsx
@@ -46,6 +46,9 @@ import { DatePickerInput } from '@mantine/dates';
 import dayjs from '~/shared/utils/dayjs';
 import { TimeoutLoader } from './TimeoutLoader';
 import { useBrowsingLevelDebounced } from '../BrowsingLevel/BrowsingLevelProvider';
+import type { BrowsingLevelAttribute } from '~/components/Search/search-index-filters';
+import { BROWSING_LEVEL_ATTRIBUTE } from '~/components/Search/search-index-filters';
+import type { SearchIndexKey } from '~/components/Search/search.types';
 import { getBlockedNsfwWords } from '~/utils/metadata/audit-base';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { buildBrowsingLevelFilters, joinFilterClauses } from './search-filters';
@@ -261,15 +264,21 @@ export const ClearRefinements = ({ ...props }: ButtonProps) => {
 };
 
 export const BrowsingLevelFilter = ({
-  attributeName,
+  indexKey,
+  attributeOverride,
   filters: _filters,
   ...props
-}: { attributeName: string; filters?: string[] | string } & Omit<ConfigureProps, 'filters'>) => {
+}: {
+  indexKey: SearchIndexKey;
+  attributeOverride?: BrowsingLevelAttribute;
+  filters?: string[] | string;
+} & Omit<ConfigureProps, 'filters'>) => {
   const browsingLevel = useBrowsingLevelDebounced();
+  const attribute = attributeOverride ?? BROWSING_LEVEL_ATTRIBUTE[indexKey];
 
   const filters = useMemo(
-    () => buildBrowsingLevelFilters({ attributeName, browsingLevel, filters: _filters }),
-    [browsingLevel, attributeName, _filters]
+    () => buildBrowsingLevelFilters({ attribute, browsingLevel, filters: _filters }),
+    [browsingLevel, attribute, _filters]
   );
 
   return <ApplyCustomFilter filters={filters} {...props} />;

--- a/src/components/Search/QuickSearchDropdown.tsx
+++ b/src/components/Search/QuickSearchDropdown.tsx
@@ -27,7 +27,7 @@ import type { ShowcaseItemSchema } from '~/server/schema/user-profile.schema';
 import { paired } from '~/utils/type-guards';
 import { searchClient } from '~/components/Search/search.client';
 import { createResilientSearchClient } from '~/components/Search/resilientSearchClient';
-import { ApplyCustomFilter, BrowsingLevelFilter } from './CustomSearchComponents';
+import { BrowsingLevelFilter } from './CustomSearchComponents';
 import { ToolSearchItem } from '~/components/AutocompleteSearch/renderItems/tools';
 import { ComicsSearchItem } from '~/components/AutocompleteSearch/renderItems/comics';
 import classes from './QuickSearchDropdown.module.scss';
@@ -147,17 +147,6 @@ export const QuickSearchDropdown = ({
   };
 
   const indexName = searchIndexMap[targetIndex];
-  const indexSupportsNsfwLevel = useMemo(
-    () =>
-      [
-        searchIndexMap.articles,
-        searchIndexMap.bounties,
-        searchIndexMap.models,
-        searchIndexMap.images,
-        searchIndexMap.collections,
-      ].some((i) => i === indexName),
-    [indexName]
-  );
 
   return (
     <InstantSearch
@@ -165,15 +154,11 @@ export const QuickSearchDropdown = ({
       indexName={indexName}
       future={{ preserveSharedStateOnUnmount: true }}
     >
-      {indexSupportsNsfwLevel ? (
-        <BrowsingLevelFilter
-          attributeName="nsfwLevel"
-          filters={filters}
-          hitsPerPage={dropdownItemLimit}
-        />
-      ) : (
-        <ApplyCustomFilter hitsPerPage={dropdownItemLimit} filters={filters} />
-      )}
+      <BrowsingLevelFilter
+        indexKey={targetIndex}
+        filters={filters}
+        hitsPerPage={dropdownItemLimit}
+      />
 
       <QuickSearchDropdownContent
         {...props}

--- a/src/components/Search/__tests__/search-filters.test.ts
+++ b/src/components/Search/__tests__/search-filters.test.ts
@@ -5,24 +5,24 @@ import {
   joinFilterClauses,
 } from '~/components/Search/search-filters';
 
-const attributeName = 'nsfwLevel';
+const attribute = 'nsfwLevel' as const;
 const pg = 1;
 const pg13 = 2;
 const r = 4;
 
 describe('buildBrowsingLevelClause', () => {
   it('emits the same OR chain it has always emitted for a multi-bit level', () => {
-    expect(buildBrowsingLevelClause(attributeName, pg | pg13 | r)).toBe(
+    expect(buildBrowsingLevelClause(attribute, pg | pg13 | r)).toBe(
       'nsfwLevel=1 OR nsfwLevel=2 OR nsfwLevel=4'
     );
   });
 
   it('emits a single equality for a single-bit level', () => {
-    expect(buildBrowsingLevelClause(attributeName, pg)).toBe('nsfwLevel=1');
+    expect(buildBrowsingLevelClause(attribute, pg)).toBe('nsfwLevel=1');
   });
 
   it('emits no clause for an empty browsing level', () => {
-    expect(buildBrowsingLevelClause(attributeName, 0)).toBeNull();
+    expect(buildBrowsingLevelClause(attribute, 0)).toBeNull();
   });
 
   it('emits no clause without an attribute name', () => {
@@ -33,20 +33,20 @@ describe('buildBrowsingLevelClause', () => {
 describe('buildBrowsingLevelFilters', () => {
   it('appends the browsing clause after the caller filters', () => {
     expect(
-      buildBrowsingLevelFilters({ attributeName, browsingLevel: pg, filters: ['type=Model'] })
+      buildBrowsingLevelFilters({ attribute, browsingLevel: pg, filters: ['type=Model'] })
     ).toEqual(['type=Model', 'nsfwLevel=1']);
   });
 
   it('accepts a single filter string', () => {
     expect(
-      buildBrowsingLevelFilters({ attributeName, browsingLevel: pg, filters: 'type=Model' })
+      buildBrowsingLevelFilters({ attribute, browsingLevel: pg, filters: 'type=Model' })
     ).toEqual(['type=Model', 'nsfwLevel=1']);
   });
 
   it('drops the browsing clause entirely for an empty browsing level', () => {
-    expect(buildBrowsingLevelFilters({ attributeName, browsingLevel: 0 })).toEqual([]);
+    expect(buildBrowsingLevelFilters({ attribute, browsingLevel: 0 })).toEqual([]);
     expect(
-      buildBrowsingLevelFilters({ attributeName, browsingLevel: 0, filters: ['type=Model'] })
+      buildBrowsingLevelFilters({ attribute, browsingLevel: 0, filters: ['type=Model'] })
     ).toEqual(['type=Model']);
   });
 });
@@ -77,7 +77,7 @@ describe('joinFilterClauses', () => {
 describe('the expression BrowsingLevelFilter hands to ApplyCustomFilter', () => {
   it('is empty, not "()", when the browsing level is empty', () => {
     const filters = joinFilterClauses(
-      buildBrowsingLevelFilters({ attributeName, browsingLevel: 0 })
+      buildBrowsingLevelFilters({ attribute, browsingLevel: 0 })
     );
 
     expect(filters).toBe('');
@@ -86,7 +86,7 @@ describe('the expression BrowsingLevelFilter hands to ApplyCustomFilter', () => 
 
   it('keeps only the caller filters when the browsing level is empty', () => {
     const filters = joinFilterClauses(
-      buildBrowsingLevelFilters({ attributeName, browsingLevel: 0, filters: ['type=Model'] })
+      buildBrowsingLevelFilters({ attribute, browsingLevel: 0, filters: ['type=Model'] })
     );
 
     expect(filters).toBe('(type=Model)');
@@ -96,7 +96,7 @@ describe('the expression BrowsingLevelFilter hands to ApplyCustomFilter', () => 
   it('is unchanged for a normal browsing level', () => {
     const filters = joinFilterClauses(
       buildBrowsingLevelFilters({
-        attributeName,
+        attribute,
         browsingLevel: pg | pg13,
         filters: ['type=Model'],
       })

--- a/src/components/Search/__tests__/search-index-contract.test.ts
+++ b/src/components/Search/__tests__/search-index-contract.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { BROWSING_LEVEL_ATTRIBUTE } from '~/components/Search/search-index-filters';
+import { buildBrowsingLevelClause } from '~/components/Search/search-filters';
+import type { SearchIndexKey } from '~/components/Search/search.types';
+import { searchIndexMap } from '~/components/Search/search.types';
+import { IMAGES_SEARCH_INDEX } from '~/server/common/constants';
+import { filterableAttributesByIndex } from '~/server/search-index/filterable-attributes';
+
+const searchIndexKeys = Object.keys(searchIndexMap) as SearchIndexKey[];
+
+describe('BROWSING_LEVEL_ATTRIBUTE', () => {
+  it.each(Object.entries(BROWSING_LEVEL_ATTRIBUTE) as [SearchIndexKey, string][])(
+    '"%s" filters on an attribute its index actually declares',
+    (key, attribute) => {
+      const indexName = searchIndexMap[key];
+      const filterable = filterableAttributesByIndex[indexName];
+
+      expect(
+        filterable,
+        `"${key}" search filters on ${attribute}, but ${indexName} does not declare it filterable — Meilisearch answers 400 invalid_search_filter and the whole search fails`
+      ).toContain(attribute);
+    }
+  );
+
+  it('covers every index that can filter on a browsing level', () => {
+    const unmapped = searchIndexKeys.filter(
+      (key) =>
+        filterableAttributesByIndex[searchIndexMap[key]].includes('nsfwLevel') &&
+        !BROWSING_LEVEL_ATTRIBUTE[key]
+    );
+
+    expect(unmapped).toEqual([]);
+  });
+
+  it('the images override attribute is filterable', () => {
+    expect(filterableAttributesByIndex[IMAGES_SEARCH_INDEX]).toContain('combinedNsfwLevel');
+  });
+});
+
+describe('an index with no browsing-level attribute', () => {
+  it('contributes no clause, so nothing unfilterable reaches Meilisearch', () => {
+    expect(buildBrowsingLevelClause(BROWSING_LEVEL_ATTRIBUTE.tools, 5)).toBeNull();
+    expect(buildBrowsingLevelClause(BROWSING_LEVEL_ATTRIBUTE.users, 5)).toBeNull();
+  });
+
+  it('still builds a clause for a mapped index', () => {
+    expect(buildBrowsingLevelClause(BROWSING_LEVEL_ATTRIBUTE.models, 1 | 2)).toBe(
+      'nsfwLevel=1 OR nsfwLevel=2'
+    );
+  });
+});

--- a/src/components/Search/__tests__/search-index-contract.test.ts
+++ b/src/components/Search/__tests__/search-index-contract.test.ts
@@ -37,6 +37,20 @@ describe('BROWSING_LEVEL_ATTRIBUTE', () => {
   });
 });
 
+describe('filterableAttributesByIndex', () => {
+  // Meilisearch dedupes on write, so a repeated entry leaves onIndexSetup's
+  // declared-vs-stored check unsatisfiable — it re-sends the settings on every run and
+  // the stored value can never match what it is compared against.
+  it.each(Object.entries(filterableAttributesByIndex))(
+    '%s declares each attribute once',
+    (indexName, attributes) => {
+      const duplicates = attributes.filter((a, i) => attributes.indexOf(a) !== i);
+
+      expect(duplicates, `${indexName} repeats ${duplicates.join(', ')}`).toEqual([]);
+    }
+  );
+});
+
 describe('an index with no browsing-level attribute', () => {
   it('contributes no clause, so nothing unfilterable reaches Meilisearch', () => {
     expect(buildBrowsingLevelClause(BROWSING_LEVEL_ATTRIBUTE.tools, 5)).toBeNull();

--- a/src/components/Search/search-filters.ts
+++ b/src/components/Search/search-filters.ts
@@ -1,30 +1,34 @@
+import type { BrowsingLevelAttribute } from '~/components/Search/search-index-filters';
 import { Flags } from '~/shared/utils/flags';
 import { isDefined } from '~/utils/type-guards';
 
 // Meilisearch rejects a bare `()` with invalid_search_filter, so a clause with nothing to say has
 // to disappear rather than become an empty string that still gets parenthesized downstream.
 
-export function buildBrowsingLevelClause(attributeName: string, browsingLevel: number) {
-  if (!attributeName) return null;
+export function buildBrowsingLevelClause(
+  attribute: BrowsingLevelAttribute | undefined,
+  browsingLevel: number
+) {
+  if (!attribute) return null;
 
   const levels = Flags.instanceToArray(browsingLevel);
   if (!levels.length) return null;
 
-  return levels.map((value) => `${attributeName}=${value}`).join(' OR ');
+  return levels.map((value) => `${attribute}=${value}`).join(' OR ');
 }
 
 export function buildBrowsingLevelFilters({
-  attributeName,
+  attribute,
   browsingLevel,
   filters,
 }: {
-  attributeName: string;
+  attribute: BrowsingLevelAttribute | undefined;
   browsingLevel: number;
   filters?: string[] | string;
 }) {
   const filterList = Array.isArray(filters) ? filters : [filters];
 
-  return [...filterList, buildBrowsingLevelClause(attributeName, browsingLevel)].filter(isDefined);
+  return [...filterList, buildBrowsingLevelClause(attribute, browsingLevel)].filter(isDefined);
 }
 
 export function joinFilterClauses(filters?: string[] | string) {

--- a/src/components/Search/search-index-filters.ts
+++ b/src/components/Search/search-index-filters.ts
@@ -1,0 +1,15 @@
+import type { SearchIndexKey } from '~/components/Search/search.types';
+
+export type BrowsingLevelAttribute = 'nsfwLevel' | 'combinedNsfwLevel';
+
+// An attribute the index doesn't declare filterable makes Meilisearch reject the whole query with
+// a 400, so `tools` and `users` are omitted deliberately — their indexes have no browsing level.
+// __tests__/search-index-contract.test.ts holds this against the index definitions.
+export const BROWSING_LEVEL_ATTRIBUTE: Partial<Record<SearchIndexKey, BrowsingLevelAttribute>> = {
+  models: 'nsfwLevel',
+  images: 'nsfwLevel',
+  articles: 'nsfwLevel',
+  collections: 'nsfwLevel',
+  bounties: 'nsfwLevel',
+  comics: 'nsfwLevel',
+};

--- a/src/pages/search/articles.tsx
+++ b/src/pages/search/articles.tsx
@@ -41,7 +41,7 @@ export default function ArticlesSearch() {
 const RenderFilters = () => {
   return (
     <>
-      <BrowsingLevelFilter attributeName="nsfwLevel" />
+      <BrowsingLevelFilter indexKey="articles" />
       <SortBy
         title="Sort articles by"
         items={[

--- a/src/pages/search/bounties.tsx
+++ b/src/pages/search/bounties.tsx
@@ -33,7 +33,7 @@ export default function BountySearch() {
 const RenderFilters = () => {
   return (
     <>
-      <BrowsingLevelFilter attributeName="nsfwLevel" />
+      <BrowsingLevelFilter indexKey="bounties" />
       <SortBy
         title="Sort bounties by"
         items={[

--- a/src/pages/search/collections.tsx
+++ b/src/pages/search/collections.tsx
@@ -34,7 +34,7 @@ export default function CollectionSearch() {
 const RenderFilters = () => {
   return (
     <>
-      <BrowsingLevelFilter attributeName="nsfwLevel" />
+      <BrowsingLevelFilter indexKey="collections" />
       <SortBy
         title="Sort collections by"
         items={[

--- a/src/pages/search/comics.tsx
+++ b/src/pages/search/comics.tsx
@@ -48,7 +48,7 @@ export default function ComicSearch() {
 const RenderFilters = () => {
   return (
     <>
-      <BrowsingLevelFilter attributeName="nsfwLevel" />
+      <BrowsingLevelFilter indexKey="comics" />
       <SortBy
         title="Sort comics by"
         items={[

--- a/src/pages/search/images.tsx
+++ b/src/pages/search/images.tsx
@@ -77,8 +77,9 @@ function RenderFilters() {
   return (
     <>
       <BrowsingLevelFilter
+        indexKey="images"
         filters={filters}
-        attributeName={!features.canViewNsfw ? 'combinedNsfwLevel' : 'nsfwLevel'}
+        attributeOverride={features.canViewNsfw ? undefined : 'combinedNsfwLevel'}
       />
       <SortBy
         title="Sort images by"

--- a/src/pages/search/models.tsx
+++ b/src/pages/search/models.tsx
@@ -65,7 +65,7 @@ const RenderFilters = () => {
 
   return (
     <>
-      <BrowsingLevelFilter filters={filters} attributeName="nsfwLevel" />
+      <BrowsingLevelFilter indexKey="models" filters={filters} />
       <SortBy
         title="Sort models by"
         items={[

--- a/src/server/search-index/articles.search-index.ts
+++ b/src/server/search-index/articles.search-index.ts
@@ -5,6 +5,7 @@ import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.sea
 import { ArticleIngestionStatus, ArticleStatus, Availability } from '~/shared/utils/prisma/enums';
 import { articleDetailSelect } from '~/server/selectors/article.selector';
 import { ARTICLES_SEARCH_INDEX } from '~/server/common/constants';
+import { articlesFilterableAttributes } from '~/server/search-index/filterable-attributes';
 import { removeTags } from '~/utils/string-helpers';
 import { isDefined } from '~/utils/type-guards';
 import type { ImageMetaProps } from '~/server/schema/image.schema';
@@ -53,17 +54,13 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
 
   console.log('onIndexSetup :: sortableFieldsAttributesTask created', sortableFieldsAttributesTask);
 
-  // `id` is required filterable for the keyset pagination scan in
-  // src/server/meilisearch/cleanup.ts. `id` is already declared in the
-  // updateSortableAttributes call above.
-  const filterableAttributes = ['id', 'tags.name', 'user.username', 'nsfwLevel'];
-
   if (
     // Meilisearch stores sorted.
-    JSON.stringify(filterableAttributes.sort()) !== JSON.stringify(settings.filterableAttributes)
+    JSON.stringify(articlesFilterableAttributes.sort()) !==
+    JSON.stringify(settings.filterableAttributes)
   ) {
     const updateFilterableAttributesTask = await index.updateFilterableAttributes(
-      filterableAttributes
+      articlesFilterableAttributes
     );
 
     console.log(

--- a/src/server/search-index/bounties.search-index.ts
+++ b/src/server/search-index/bounties.search-index.ts
@@ -10,6 +10,7 @@ import type {
   MediaType,
 } from '~/shared/utils/prisma/enums';
 import { BOUNTIES_SEARCH_INDEX } from '~/server/common/constants';
+import { bountiesFilterableAttributes } from '~/server/search-index/filterable-attributes';
 import { isDefined } from '~/utils/type-guards';
 import { dbRead } from '~/server/db/client';
 import type { ImageMetadata } from '~/server/schema/media.schema';
@@ -67,23 +68,13 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
     console.log('onIndexSetup :: updateRankingRulesTask created', updateRankingRulesTask);
   }
 
-  const filterableAttributes = [
-    // `id` required by the keyset cleanup scan (src/server/meilisearch/cleanup.ts).
-    'id',
-    'user.username',
-    'type',
-    'details.baseModel',
-    'tags.name',
-    'complete',
-    'nsfwLevel',
-  ];
-
   if (
     // Meilisearch stores sorted.
-    JSON.stringify(filterableAttributes.sort()) !== JSON.stringify(settings.filterableAttributes)
+    JSON.stringify(bountiesFilterableAttributes.sort()) !==
+    JSON.stringify(settings.filterableAttributes)
   ) {
     const updateFilterableAttributesTask = await index.updateFilterableAttributes(
-      filterableAttributes
+      bountiesFilterableAttributes
     );
 
     console.log(

--- a/src/server/search-index/collections.search-index.ts
+++ b/src/server/search-index/collections.search-index.ts
@@ -11,6 +11,7 @@ import type {
 } from '~/shared/utils/prisma/enums';
 import { CollectionReadConfiguration } from '~/shared/utils/prisma/enums';
 import { COLLECTIONS_SEARCH_INDEX } from '~/server/common/constants';
+import { collectionsFilterableAttributes } from '~/server/search-index/filterable-attributes';
 import { isDefined } from '~/utils/type-guards';
 import { uniqBy } from 'lodash-es';
 import { tagIdsForImagesCache } from '~/server/redis/caches';
@@ -71,14 +72,13 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
     console.log('onIndexSetup :: updateRankingRulesTask created', updateRankingRulesTask);
   }
 
-  const filterableAttributes = ['user.username', 'type', 'nsfwLevel', 'id'];
-
   if (
     // Meilisearch stores sorted.
-    JSON.stringify(filterableAttributes.sort()) !== JSON.stringify(settings.filterableAttributes)
+    JSON.stringify(collectionsFilterableAttributes.sort()) !==
+    JSON.stringify(settings.filterableAttributes)
   ) {
     const updateFilterableAttributesTask = await index.updateFilterableAttributes(
-      filterableAttributes
+      collectionsFilterableAttributes
     );
 
     console.log(

--- a/src/server/search-index/comics.search-index.ts
+++ b/src/server/search-index/comics.search-index.ts
@@ -3,6 +3,7 @@ import { updateDocs } from '~/server/meilisearch/client';
 import { getOrCreateIndex } from '~/server/meilisearch/util';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
 import { COMICS_SEARCH_INDEX } from '~/server/common/constants';
+import { comicsFilterableAttributes } from '~/server/search-index/filterable-attributes';
 import { isDefined } from '~/utils/type-guards';
 import { parseBitwiseBrowsingLevel } from '~/shared/constants/browsingLevel.constants';
 import { profileImageSelect } from '../selectors/image.selector';
@@ -12,7 +13,8 @@ const MEILISEARCH_DOCUMENT_BATCH_SIZE = 1000;
 const INDEX_ID = COMICS_SEARCH_INDEX;
 
 const searchableAttributes = ['name', 'description', 'user.username'];
-// `id` is in both lists for the keyset cleanup scan (src/server/meilisearch/cleanup.ts).
+// `id` is here and in the filterable list for the keyset cleanup scan
+// (src/server/meilisearch/cleanup.ts).
 const sortableAttributes = [
   'createdAt',
   'id',
@@ -20,7 +22,6 @@ const sortableAttributes = [
   'stats.chapterCount',
   'stats.followerCount',
 ];
-const filterableAttributes = ['id', 'user.username', 'genre', 'nsfwLevel'];
 const rankingRules = ['sort', 'words', 'typo', 'proximity', 'attribute', 'exactness'];
 
 const onIndexSetup = async ({ indexName }: { indexName: string }) => {
@@ -54,10 +55,11 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
   }
 
   if (
-    JSON.stringify(filterableAttributes.sort()) !== JSON.stringify(settings.filterableAttributes)
+    JSON.stringify(comicsFilterableAttributes.sort()) !==
+    JSON.stringify(settings.filterableAttributes)
   ) {
     const updateFilterableAttributesTask = await index.updateFilterableAttributes(
-      filterableAttributes
+      comicsFilterableAttributes
     );
 
     console.log(

--- a/src/server/search-index/filterable-attributes.ts
+++ b/src/server/search-index/filterable-attributes.ts
@@ -66,7 +66,6 @@ export const modelsFilterableAttributes = [
   'versions.baseModel',
   'versions.hashes',
   'versions.id',
-  'availability',
   'cannotPromote',
   'poi',
   'minor',

--- a/src/server/search-index/filterable-attributes.ts
+++ b/src/server/search-index/filterable-attributes.ts
@@ -1,0 +1,88 @@
+import {
+  ARTICLES_SEARCH_INDEX,
+  BOUNTIES_SEARCH_INDEX,
+  COLLECTIONS_SEARCH_INDEX,
+  COMICS_SEARCH_INDEX,
+  IMAGES_SEARCH_INDEX,
+  MODELS_SEARCH_INDEX,
+  TOOLS_SEARCH_INDEX,
+  USERS_SEARCH_INDEX,
+} from '~/server/common/constants';
+
+// Kept a leaf so a test can read these without loading `~/server/meilisearch/client`, which builds
+// pLimit/prom collectors at module load.
+
+// `id` is filterable on every index because the keyset cleanup scan in
+// src/server/meilisearch/cleanup.ts pages on it.
+export const articlesFilterableAttributes = ['id', 'tags.name', 'user.username', 'nsfwLevel'];
+
+export const bountiesFilterableAttributes = [
+  'id',
+  'user.username',
+  'type',
+  'details.baseModel',
+  'tags.name',
+  'complete',
+  'nsfwLevel',
+];
+
+export const collectionsFilterableAttributes = ['user.username', 'type', 'nsfwLevel', 'id'];
+
+export const comicsFilterableAttributes = ['id', 'user.username', 'genre', 'nsfwLevel'];
+
+export const imagesFilterableAttributes = [
+  'id',
+  'createdAtUnix',
+  'tagNames',
+  'user.username',
+  'baseModel',
+  'aspectRatio',
+  'nsfwLevel',
+  'combinedNsfwLevel',
+  'type',
+  'toolNames',
+  'techniqueNames',
+  'flags.promptNsfw',
+  'poi',
+  'minor',
+];
+
+export const modelsFilterableAttributes = [
+  'availability',
+  'canGenerate',
+  'category.name',
+  'checkpointType',
+  'fileFormats',
+  'hashes',
+  'id',
+  'lastVersionAtUnix',
+  'nsfwLevel',
+  'status',
+  'tags.name',
+  'type',
+  'user.id',
+  'user.username',
+  'version.baseModel',
+  'versions.baseModel',
+  'versions.hashes',
+  'versions.id',
+  'availability',
+  'cannotPromote',
+  'poi',
+  'minor',
+];
+
+export const toolsFilterableAttributes = ['id', 'type', 'company'];
+
+export const usersFilterableAttributes = ['id', 'username'];
+
+export const filterableAttributesByIndex = {
+  [ARTICLES_SEARCH_INDEX]: articlesFilterableAttributes,
+  [BOUNTIES_SEARCH_INDEX]: bountiesFilterableAttributes,
+  [COLLECTIONS_SEARCH_INDEX]: collectionsFilterableAttributes,
+  [COMICS_SEARCH_INDEX]: comicsFilterableAttributes,
+  [IMAGES_SEARCH_INDEX]: imagesFilterableAttributes,
+  [MODELS_SEARCH_INDEX]: modelsFilterableAttributes,
+  [TOOLS_SEARCH_INDEX]: toolsFilterableAttributes,
+  [USERS_SEARCH_INDEX]: usersFilterableAttributes,
+} as const;

--- a/src/server/search-index/images.search-index.ts
+++ b/src/server/search-index/images.search-index.ts
@@ -1,6 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { chunk } from 'lodash-es';
-import type { FilterableAttributes, SearchableAttributes, SortableAttributes } from 'meilisearch';
+import type { SearchableAttributes, SortableAttributes } from 'meilisearch';
 import { clickhouse } from '~/server/clickhouse/client';
 import { imageReviewedSql } from '~/server/common/image-visibility';
 import { IMAGES_SEARCH_INDEX } from '~/server/common/constants';
@@ -17,6 +17,7 @@ import {
   userBasicCache,
 } from '~/server/redis/caches';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
+import { imagesFilterableAttributes } from '~/server/search-index/filterable-attributes';
 import { modelsSearchIndex } from '~/server/search-index/models.search-index';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
 import { getCosmeticsForUsers, getProfilePicturesForUsers } from '~/server/services/user.service';
@@ -54,23 +55,6 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
     'stats.tippedAmountCountAllTime',
   ];
 
-  const filterableAttributes: FilterableAttributes = [
-    'id',
-    'createdAtUnix',
-    'tagNames',
-    'user.username',
-    'baseModel',
-    'aspectRatio',
-    'nsfwLevel',
-    'combinedNsfwLevel',
-    'type',
-    'toolNames',
-    'techniqueNames',
-    'flags.promptNsfw',
-    'poi',
-    'minor',
-  ];
-
   if (JSON.stringify(searchableAttributes) !== JSON.stringify(settings.searchableAttributes)) {
     const updateSearchableAttributesTask = await index.updateSearchableAttributes(
       searchableAttributes
@@ -92,10 +76,11 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
   }
 
   if (
-    JSON.stringify(filterableAttributes.sort()) !== JSON.stringify(settings.filterableAttributes)
+    JSON.stringify(imagesFilterableAttributes.sort()) !==
+    JSON.stringify(settings.filterableAttributes)
   ) {
     const updateFilterableAttributesTask = await index.updateFilterableAttributes(
-      filterableAttributes
+      imagesFilterableAttributes
     );
 
     console.log(

--- a/src/server/search-index/models.search-index.ts
+++ b/src/server/search-index/models.search-index.ts
@@ -15,6 +15,7 @@ import type { ModelFileMetadata } from '~/server/schema/model-file.schema';
 import type { RecommendedSettingsSchema } from '~/server/schema/model-version.schema';
 import type { ModelMeta } from '~/server/schema/model.schema';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
+import { modelsFilterableAttributes } from '~/server/search-index/filterable-attributes';
 import { getValidCreatorMembershipMap } from '~/server/services/creator-program.service';
 import {
   anyMetricHidden,
@@ -148,37 +149,13 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
     console.log('onIndexSetup :: updateRankingRulesTask created', updateRankingRulesTask);
   }
 
-  const filterableAttributes = [
-    'availability',
-    'canGenerate',
-    'category.name',
-    'checkpointType',
-    'fileFormats',
-    'hashes',
-    'id',
-    'lastVersionAtUnix',
-    'nsfwLevel',
-    'status',
-    'tags.name',
-    'type',
-    'user.id',
-    'user.username',
-    'version.baseModel',
-    'versions.baseModel',
-    'versions.hashes',
-    'versions.id',
-    'availability',
-    'cannotPromote',
-    'poi',
-    'minor',
-  ];
-
   if (
     // Meilisearch stores sorted.
-    JSON.stringify(filterableAttributes.sort()) !== JSON.stringify(settings.filterableAttributes)
+    JSON.stringify(modelsFilterableAttributes.sort()) !==
+    JSON.stringify(settings.filterableAttributes)
   ) {
     const updateFilterableAttributesTask = await index.updateFilterableAttributes(
-      filterableAttributes
+      modelsFilterableAttributes
     );
 
     console.log(

--- a/src/server/search-index/tools.search-index.ts
+++ b/src/server/search-index/tools.search-index.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
 import type { ToolType } from '~/shared/utils/prisma/enums';
 import { TOOLS_SEARCH_INDEX } from '~/server/common/constants';
+import { toolsFilterableAttributes } from '~/server/search-index/filterable-attributes';
 import { updateDocs } from '~/server/meilisearch/client';
 
 import { getOrCreateIndex } from '~/server/meilisearch/util';
@@ -14,7 +15,6 @@ const INDEX_ID = TOOLS_SEARCH_INDEX;
 
 const searchableAttributes = ['name', 'domain', 'company', 'description'];
 const sortableAttributes = ['createdAt', 'id', 'name'];
-const filterableAttributes = ['id', 'type', 'company'];
 const rankingRules = [
   'supported:desc',
   'sort',
@@ -56,10 +56,11 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
   }
 
   if (
-    JSON.stringify(filterableAttributes.sort()) !== JSON.stringify(settings.filterableAttributes)
+    JSON.stringify(toolsFilterableAttributes.sort()) !==
+    JSON.stringify(settings.filterableAttributes)
   ) {
     const updateFilterableAttributesTask = await index.updateFilterableAttributes(
-      filterableAttributes
+      toolsFilterableAttributes
     );
 
     console.log(

--- a/src/server/search-index/users.search-index.ts
+++ b/src/server/search-index/users.search-index.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { USERS_SEARCH_INDEX } from '~/server/common/constants';
+import { usersFilterableAttributes } from '~/server/search-index/filterable-attributes';
 import { updateDocs } from '~/server/meilisearch/client';
 
 import { getOrCreateIndex } from '~/server/meilisearch/util';
@@ -57,14 +58,13 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
     console.log('onIndexSetup :: updateRankingRulesTask created', updateRankingRulesTask);
   }
 
-  const filterableAttributes = ['id', 'username'];
-
   if (
     // Meilisearch stores sorted.
-    JSON.stringify(filterableAttributes.sort()) !== JSON.stringify(settings.filterableAttributes)
+    JSON.stringify(usersFilterableAttributes.sort()) !==
+    JSON.stringify(settings.filterableAttributes)
   ) {
     const updateFilterableAttributesTask = await index.updateFilterableAttributes(
-      filterableAttributes
+      usersFilterableAttributes
     );
 
     console.log(


### PR DESCRIPTION
Header search → **Tools** has returned an error for every user since PR #1448 (2024-10-29), the PR that shipped tool search.

## What was wrong

"Which search indexes support an `nsfwLevel` filter" was written down by hand in two components, which had drifted from each other and from the indexes themselves.

`AutocompleteSearch` listed `tools` in its `indexSupportsNsfwLevel` array, so picking Tools emitted `filter: ["(nsfwLevel=1)"]` against `tools_v2` — whose filterable attributes are `id`, `type`, `company`. `nsfwLevel` has never been on that index (`git log -S nsfwLevel -- src/server/search-index/tools.search-index.ts` returns nothing). Meilisearch answered:

```
400 invalid_search_filter
Index `tools_v2`: Attribute `nsfwLevel` is not filterable.
Available filterable attribute patterns are: `company`, `id`, `type`.
```

`createResilientSearchClient` swallowed that into an empty result set, so the dropdown rendered "There was an error while performing your request… Please try again later". `toolSearch: ['public']`, so every user hit it.

`QuickSearchDropdown` kept a second, *different* copy of the same list (no tools). Nothing reconciled them.

Separately, `BrowsingLevelFilter` took a free-text `attributeName: string`, and a falsy value made the browsing-level clause `null`, which `.filter(isDefined)` then dropped — the search ran with **no browsing-level filter at all**. `AutocompleteSearch` already wrote `attributeName={indexSupportsNsfwLevel ? 'nsfwLevel' : ''}` inside a branch guarded by the same condition, so flattening that redundant ternary would have silently un-filtered the header search.

## What this does

- `src/server/search-index/filterable-attributes.ts` (new) — the eight `filterableAttributes` arrays as data, plus a map keyed by index name. A pure leaf: the only import is `~/server/common/constants`. It has to be a leaf because the `*.search-index.ts` modules import `~/server/meilisearch/client`, which builds pLimit/prom collectors at load, and a unit test must not pull that in. Array contents are unchanged.
- `src/components/Search/search-index-filters.ts` (new) — `BROWSING_LEVEL_ATTRIBUTE`, six entries; `tools` and `users` deliberately absent.
- `BrowsingLevelFilter` now takes `indexKey: SearchIndexKey` and an optional, typed `attributeOverride`. Passing `''` is no longer expressible. Both hand-maintained arrays are gone, and so is the call-site branching around them.
- A contract test holds the map against the index definitions, in **both** directions. The reverse direction is the one that matters most: silently dropping `models` from the map would run the models search unfiltered, and without that assertion no test would notice.

## Verification

`pnpm run typecheck` → 0 errors. Contract test: 12 passed. `pnpm run test:lint-rules` → 243 passed.

Re-adding `tools: 'nsfwLevel'` fails the suite with the reason spelled out, rather than a bare diff:

```
"tools" search filters on nsfwLevel, but tools_v2 does not declare it filterable —
Meilisearch answers 400 invalid_search_filter and the whole search fails:
expected [ 'id', 'type', 'company' ] to include 'nsfwLevel'
```

**Checked in a browser against the production Meilisearch**, header search, every category:

| Category | Filter sent | Result |
|---|---|---|
| Models | `(poi != true) AND (availability != Private) AND (nsfwLevel=1)` | results |
| Images | `(poi != true) AND (nsfwLevel=1)` | results |
| Articles / Collections / Bounties | `(nsfwLevel=1)` | results |
| **Tools** | none | **results — was an error banner** |
| Users | none | results |

Every NSFW-capable index still carries its browsing-level filter; only the two indexes that genuinely lack the attribute send none.

## What this does not fix

- **Comics.** `comics_v1` has *zero* filterable attributes configured on the live instance, so `/search/comics` still fails — on the `genre` facet, before the browsing-level filter is even reached. The index is out of service and is deliberately left wired exactly as it is.
- This test compares **code to code**. It catches the Tools drift. It cannot catch an index whose declared settings were never applied to the live instance — that needs an ops check.
- `attributeOverride` is typed but not index-scoped: nothing stops `indexKey="tools" attributeOverride="nsfwLevel"`. Closing that needs a generic component over the index key; not worth the machinery for one call site today.

## Conflicts with

Overlaps `fix/search-empty-browsing-filter` in `BrowsingLevelFilter`'s `useMemo`, and both PRs add a pure filter-builder module. Both are based directly on `main` — deliberately not stacked. Whichever merges second gets a hand rebase; see that PR for the reconciliation note.

Found while investigating CU 868kt6hdx.
