### PR TITLE
fix(search): quote user-controlled string values in Meilisearch filters

### DIFF
--- a/src/components/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/src/components/AutocompleteSearch/AutocompleteSearch.tsx
@@ -29,6 +29,7 @@ import { getModelUrl, slugit } from '~/utils/string-helpers';
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 import { env } from '~/env/client';
 import { createResilientSearchClient } from '~/components/Search/resilientSearchClient';
+import { quoteMeiliValue } from '~/components/Search/meili-filter';
 import {
   autocompleteAvailability,
   useAutocompleteAvailabilityStore,
@@ -156,7 +157,11 @@ export const AutocompleteSearch = forwardRef<{ focus: () => void }, Props>(({ ..
       ? `poi != true${currentUser?.id ? ` OR user.id = ${currentUser?.id}` : ''}`
       : null,
     isImages && supportsPoi && browsingSettingsAddons.settings.disablePoi
-      ? `poi != true${currentUser?.username ? ` OR user.username = ${currentUser?.username}` : ''}`
+      ? `poi != true${
+          currentUser?.username
+            ? ` OR user.username = ${quoteMeiliValue(currentUser.username)}`
+            : ''
+        }`
       : null,
     supportsMinor && browsingSettingsAddons.settings.disableMinor ? 'minor != true' : null,
     isModels && !currentUser?.isModerator
@@ -761,7 +766,7 @@ function parseQuery(index: string, query: string) {
         const cleanedMatch = match?.groups?.value?.trim();
         const not = match?.groups?.not !== undefined;
         if (!cleanedMatch) continue;
-        filters.push(`${not ? 'NOT ' : ''}${attribute} = ${cleanedMatch}`);
+        filters.push(`${not ? 'NOT ' : ''}${attribute} = ${quoteMeiliValue(cleanedMatch)}`);
         searchPageQuery.push(
           `${filterAttributes.searchPageMap[attribute] ?? attribute}=${encodeURIComponent(
             cleanedMatch ?? ''

--- a/src/components/CollectionSelectModal/CollectionSelectModal.tsx
+++ b/src/components/CollectionSelectModal/CollectionSelectModal.tsx
@@ -19,6 +19,7 @@ import cardClasses from '~/components/Cards/Cards.module.css';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { CustomSearchBox } from '~/components/Search/CustomSearchComponents';
+import { quoteMeiliValue } from '~/components/Search/meili-filter';
 import { createResilientSearchClient } from '~/components/Search/resilientSearchClient';
 import { searchIndexMap } from '~/components/Search/search.types';
 import type { SearchIndexDataMap } from '~/components/Search/search.utils2';
@@ -50,7 +51,7 @@ export default function ModelShowcaseCollectionModal({
   const dialog = useDialogContext();
   const isMobile = useIsMobile();
 
-  const filters: string[] = ['type = Model', `user.username = ${username}`];
+  const filters: string[] = ['type = Model', `user.username = ${quoteMeiliValue(username)}`];
 
   function handleSelect(collectionId: number) {
     onSelect(collectionId);

--- a/src/components/Profile/ShowcaseItemsInput.tsx
+++ b/src/components/Profile/ShowcaseItemsInput.tsx
@@ -5,6 +5,7 @@ import React, { useMemo, useState } from 'react';
 import { useDidUpdate } from '@mantine/hooks';
 import type { ShowcaseItemSchema } from '~/server/schema/user-profile.schema';
 import { QuickSearchDropdown } from '~/components/Search/QuickSearchDropdown';
+import { quoteMeiliValue } from '~/components/Search/meili-filter';
 import { trpc } from '~/utils/trpc';
 import { GenericImageCard } from '~/components/Cards/GenericImageCard';
 import { IconTrash } from '@tabler/icons-react';
@@ -115,7 +116,7 @@ export const ShowcaseItemsInput = ({
           <QuickSearchDropdown
             supportedIndexes={['models', 'images']}
             onItemSelected={onItemSelected}
-            filters={`user.username='${username}'`}
+            filters={`user.username = ${quoteMeiliValue(username)}`}
             dropdownItemLimit={25}
           />
         )}

--- a/src/components/Resource/Wizard/TemplateSelect.tsx
+++ b/src/components/Resource/Wizard/TemplateSelect.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { Checkbox, Stack, Text } from '@mantine/core';
 import { QuickSearchDropdown } from '~/components/Search/QuickSearchDropdown';
+import { quoteMeiliValue } from '~/components/Search/meili-filter';
 import type { TemplateOmittableField } from '~/server/schema/model.schema';
 
 // "Settings only" is one preset over the omit list; a future granular picker can write
@@ -45,7 +46,7 @@ export function TemplateSelect({ username, onSelect }: Props) {
           );
           onSelect();
         }}
-        filters={`user.username='${username}'`}
+        filters={`user.username = ${quoteMeiliValue(username)}`}
         dropdownItemLimit={10}
         placeholder="Search your models..."
       />

--- a/src/components/Search/__tests__/meili-filter.test.ts
+++ b/src/components/Search/__tests__/meili-filter.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { quoteMeiliValue } from '~/components/Search/meili-filter';
+
+describe('quoteMeiliValue', () => {
+  it('quotes an ordinary username without altering it', () => {
+    expect(quoteMeiliValue('manuelurenah')).toBe("'manuelurenah'");
+  });
+
+  it('quotes whitespace', () => {
+    expect(quoteMeiliValue('Rogue Light')).toBe("'Rogue Light'");
+  });
+
+  it('escapes a single quote', () => {
+    expect(quoteMeiliValue("O'Brien")).toBe("'O\\'Brien'");
+  });
+
+  it('escapes a backslash', () => {
+    expect(quoteMeiliValue('a\\b')).toBe("'a\\\\b'");
+  });
+
+  it('escapes the backslash before the quote it precedes', () => {
+    expect(quoteMeiliValue("a\\'b")).toBe("'a\\\\\\'b'");
+  });
+
+  it('quotes a reserved word so it is read as a value', () => {
+    expect(quoteMeiliValue('NOT')).toBe("'NOT'");
+    expect(quoteMeiliValue('EXISTS')).toBe("'EXISTS'");
+  });
+
+  it('quotes expression punctuation', () => {
+    expect(quoteMeiliValue('ab)cd')).toBe("'ab)cd'");
+    expect(quoteMeiliValue('ab"cd')).toBe("'ab\"cd'");
+    expect(quoteMeiliValue('a,b:c;d')).toBe("'a,b:c;d'");
+  });
+
+  it('quotes non-ASCII values', () => {
+    expect(quoteMeiliValue('🙂emoji')).toBe("'🙂emoji'");
+    expect(quoteMeiliValue('é中')).toBe("'é中'");
+  });
+
+  it('builds the filter expression the images search page sends', () => {
+    expect(`poi != true OR user.username = ${quoteMeiliValue("Rogue O'Light")}`).toBe(
+      "poi != true OR user.username = 'Rogue O\\'Light'"
+    );
+  });
+});

--- a/src/components/Search/meili-filter.ts
+++ b/src/components/Search/meili-filter.ts
@@ -1,0 +1,5 @@
+// An unquoted value only parses if it is [A-Za-z0-9_.-] or non-ASCII letters, and the search client
+// swallows the resulting 400 as an empty result set. Strings only: quoting a number changes it.
+export function quoteMeiliValue(value: string) {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}

--- a/src/pages/search/images.tsx
+++ b/src/pages/search/images.tsx
@@ -8,6 +8,7 @@ import {
   SearchableMultiSelectRefinementList,
   SortBy,
 } from '~/components/Search/CustomSearchComponents';
+import { quoteMeiliValue } from '~/components/Search/meili-filter';
 import { SearchHeader } from '~/components/Search/SearchHeader';
 import { SearchLayout } from '~/components/Search/SearchLayout';
 import { IconCloudOff } from '@tabler/icons-react';
@@ -60,7 +61,11 @@ function RenderFilters() {
 
   const filters = [
     browsingSettingsAddons.settings.disablePoi
-      ? `poi != true${currentUser?.username ? ` OR user.username = ${currentUser.username}` : ''}`
+      ? `poi != true${
+          currentUser?.username
+            ? ` OR user.username = ${quoteMeiliValue(currentUser.username)}`
+            : ''
+        }`
       : null,
     browsingSettingsAddons.settings.disableMinor ? 'minor != true' : null,
     // Filter out images from NSFW models with restricted base models


### PR DESCRIPTION
**145 live, non-banned accounts currently get an empty image search, always.** Measured against the production database and the production Meilisearch, not estimated.

## What was wrong

Meilisearch filter strings interpolate a username straight into the expression, unquoted:

```ts
`poi != true${currentUser?.username ? ` OR user.username = ${currentUser.username}` : ''}`
```

On Meilisearch 1.15 an unquoted value only parses if it is alphanumerics, `_`, `-`, `.` or non-ASCII letters. A space, an emoji, or any of ``,:;()[]{}"'`=!<>&|+*/\@#$%^~?`` makes the whole filter a `400 invalid_search_filter`, which `createResilientSearchClient` then swallows into an empty result set — so the user sees "no results", not an error.

I pulled every candidate username from production (637 rows) and probed each one against the live `images_v6` index with the exact expression this code builds:

| | |
|---|---|
| candidates | 637 |
| **break the filter (400)** | **145** |
| of which not banned | **145** |
| — punctuation / symbol | 140 |
| — whitespace | 5 |
| — reserved keyword | 0 |

Zero from reserved keywords because Meilisearch matches those **case-sensitively** (`NOT` fails, `not` does not) and every such username on prod is stored lower- or mixed-case.

This is on the live path for essentially every non-moderator: production sys-redis `system:browsing-setting-addons` holds `{"type":"some","nsfwLevels":[1,2,4,8,16],"disablePoi":true}`, which intersects every browsing level, and `resolveBrowsingSettingsAddons` only short-circuits for moderators.

## What this does

Adds `quoteMeiliValue` — wrap in single quotes, escape `\` then `'`. Order matters and is pinned by test: swapping it double-escapes the backslash a quote introduces.

Applied to six sites. Two were the known ones; four more turned up while looking for the same pattern:

| Site | Was | Effect |
|---|---|---|
| `pages/search/images.tsx` | unquoted | the 145 accounts |
| `AutocompleteSearch.tsx` (images branch) | unquoted | same |
| `CollectionSelectModal.tsx` | unquoted | model-showcase picker empty for the same accounts |
| `ShowcaseItemsInput.tsx` | quoted, **not escaped** | breaks on an apostrophe |
| `Resource/Wizard/TemplateSelect.tsx` | quoted, **not escaped** | same |
| `AutocompleteSearch.tsx` `parseQuery` | unquoted | typing `@NOT` or `#AND` 400s the request |

Numeric values are deliberately left unquoted — `user.id = 123` must not become `user.id = '123'`.

## Verification

`pnpm run typecheck` → 0 errors. 9 tests pass.

Mutating the helper fails fast with a concrete string diff every way it can break — no quoting: 9/9 fail; escaping dropped: 4/9; escape order swapped: 3/9.

**Checked against the production index that quoting does not change what matches**, which is the risk in touching `parseQuery`:

```
versions.hashes  unquoted -> 1 hit     quoted -> 1 hit
user.username    unquoted -> 53 hits   quoted -> 53 hits
tags.name        unquoted -> 400       quoted -> 12,013 hits
```

The tag row is worth noting: a real production tag is `base model`, with a space — so quoting is an outright fix there, not just a no-op.

## What these tests prove, and what they don't

They pin the exact string the helper emits. They do **not** prove Meilisearch accepts it — that came from the live-engine probes above, and nothing in this suite would notice if the grammar changed underneath us.

Found while investigating CU 868kt6hdx.
