### PR TITLE
fix(search): never emit an empty browsing-level filter

### DIFF
--- a/src/components/Search/CustomSearchComponents.tsx
+++ b/src/components/Search/CustomSearchComponents.tsx
@@ -46,10 +46,9 @@ import { DatePickerInput } from '@mantine/dates';
 import dayjs from '~/shared/utils/dayjs';
 import { TimeoutLoader } from './TimeoutLoader';
 import { useBrowsingLevelDebounced } from '../BrowsingLevel/BrowsingLevelProvider';
-import { Flags } from '~/shared/utils/flags';
 import { getBlockedNsfwWords } from '~/utils/metadata/audit-base';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { isDefined } from '~/utils/type-guards';
+import { buildBrowsingLevelFilters, joinFilterClauses } from './search-filters';
 import styles from './CustomSearchComponents.module.scss';
 
 // const useStyles = createStyles((theme) => ({
@@ -268,15 +267,10 @@ export const BrowsingLevelFilter = ({
 }: { attributeName: string; filters?: string[] | string } & Omit<ConfigureProps, 'filters'>) => {
   const browsingLevel = useBrowsingLevelDebounced();
 
-  const filters = useMemo(() => {
-    const browsingLevelArray = Flags.instanceToArray(browsingLevel);
-    const browsingLevelFilter = attributeName
-      ? browsingLevelArray.map((value) => `${attributeName}=${value}`).join(' OR ')
-      : null;
-    const filterList = Array.isArray(_filters) ? _filters : [_filters];
-
-    return [...filterList, browsingLevelFilter].filter(isDefined);
-  }, [browsingLevel, attributeName, _filters]);
+  const filters = useMemo(
+    () => buildBrowsingLevelFilters({ attributeName, browsingLevel, filters: _filters }),
+    [browsingLevel, attributeName, _filters]
+  );
 
   return <ApplyCustomFilter filters={filters} {...props} />;
 };
@@ -445,10 +439,7 @@ export const ApplyCustomFilter = ({
   filters: _filters,
   ...props
 }: { filters?: string[] | string } & Omit<ConfigureProps, 'filters'>) => {
-  const filters = useMemo(() => {
-    const filterList = Array.isArray(_filters) ? _filters : _filters ? [_filters] : [];
-    return filterList.map((f) => `(${f})`).join(' AND ');
-  }, [_filters]);
+  const filters = useMemo(() => joinFilterClauses(_filters), [_filters]);
 
   const { refine } = useConfigure({ ...props, filters });
 

--- a/src/components/Search/__tests__/search-filters.test.ts
+++ b/src/components/Search/__tests__/search-filters.test.ts
@@ -95,7 +95,11 @@ describe('the expression BrowsingLevelFilter hands to ApplyCustomFilter', () => 
 
   it('is unchanged for a normal browsing level', () => {
     const filters = joinFilterClauses(
-      buildBrowsingLevelFilters({ attributeName, browsingLevel: pg | pg13, filters: ['type=Model'] })
+      buildBrowsingLevelFilters({
+        attributeName,
+        browsingLevel: pg | pg13,
+        filters: ['type=Model'],
+      })
     );
 
     expect(filters).toBe('(type=Model) AND (nsfwLevel=1 OR nsfwLevel=2)');

--- a/src/components/Search/__tests__/search-filters.test.ts
+++ b/src/components/Search/__tests__/search-filters.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBrowsingLevelClause,
+  buildBrowsingLevelFilters,
+  joinFilterClauses,
+} from '~/components/Search/search-filters';
+
+const attributeName = 'nsfwLevel';
+const pg = 1;
+const pg13 = 2;
+const r = 4;
+
+describe('buildBrowsingLevelClause', () => {
+  it('emits the same OR chain it has always emitted for a multi-bit level', () => {
+    expect(buildBrowsingLevelClause(attributeName, pg | pg13 | r)).toBe(
+      'nsfwLevel=1 OR nsfwLevel=2 OR nsfwLevel=4'
+    );
+  });
+
+  it('emits a single equality for a single-bit level', () => {
+    expect(buildBrowsingLevelClause(attributeName, pg)).toBe('nsfwLevel=1');
+  });
+
+  it('emits no clause for an empty browsing level', () => {
+    expect(buildBrowsingLevelClause(attributeName, 0)).toBeNull();
+  });
+
+  it('emits no clause without an attribute name', () => {
+    expect(buildBrowsingLevelClause('', pg)).toBeNull();
+  });
+});
+
+describe('buildBrowsingLevelFilters', () => {
+  it('appends the browsing clause after the caller filters', () => {
+    expect(
+      buildBrowsingLevelFilters({ attributeName, browsingLevel: pg, filters: ['type=Model'] })
+    ).toEqual(['type=Model', 'nsfwLevel=1']);
+  });
+
+  it('accepts a single filter string', () => {
+    expect(
+      buildBrowsingLevelFilters({ attributeName, browsingLevel: pg, filters: 'type=Model' })
+    ).toEqual(['type=Model', 'nsfwLevel=1']);
+  });
+
+  it('drops the browsing clause entirely for an empty browsing level', () => {
+    expect(buildBrowsingLevelFilters({ attributeName, browsingLevel: 0 })).toEqual([]);
+    expect(
+      buildBrowsingLevelFilters({ attributeName, browsingLevel: 0, filters: ['type=Model'] })
+    ).toEqual(['type=Model']);
+  });
+});
+
+describe('joinFilterClauses', () => {
+  it('wraps each clause and joins with AND', () => {
+    expect(joinFilterClauses(['type=Model', 'nsfwLevel=1'])).toBe('(type=Model) AND (nsfwLevel=1)');
+  });
+
+  it('wraps a single filter string', () => {
+    expect(joinFilterClauses('type=Model')).toBe('(type=Model)');
+  });
+
+  it('returns an empty expression when there is nothing to filter on', () => {
+    expect(joinFilterClauses(undefined)).toBe('');
+    expect(joinFilterClauses([])).toBe('');
+  });
+
+  it('drops empty and whitespace-only clauses instead of wrapping them', () => {
+    const filters = joinFilterClauses(['', '   ', 'type=Model']);
+
+    expect(filters).toBe('(type=Model)');
+    expect(filters).not.toContain('()');
+  });
+});
+
+// Either guard alone hides the `()`, so the assembled expression is asserted separately from both.
+describe('the expression BrowsingLevelFilter hands to ApplyCustomFilter', () => {
+  it('is empty, not "()", when the browsing level is empty', () => {
+    const filters = joinFilterClauses(
+      buildBrowsingLevelFilters({ attributeName, browsingLevel: 0 })
+    );
+
+    expect(filters).toBe('');
+    expect(filters).not.toContain('()');
+  });
+
+  it('keeps only the caller filters when the browsing level is empty', () => {
+    const filters = joinFilterClauses(
+      buildBrowsingLevelFilters({ attributeName, browsingLevel: 0, filters: ['type=Model'] })
+    );
+
+    expect(filters).toBe('(type=Model)');
+    expect(filters).not.toContain('()');
+  });
+
+  it('is unchanged for a normal browsing level', () => {
+    const filters = joinFilterClauses(
+      buildBrowsingLevelFilters({ attributeName, browsingLevel: pg | pg13, filters: ['type=Model'] })
+    );
+
+    expect(filters).toBe('(type=Model) AND (nsfwLevel=1 OR nsfwLevel=2)');
+  });
+});

--- a/src/components/Search/search-filters.ts
+++ b/src/components/Search/search-filters.ts
@@ -1,0 +1,37 @@
+import { Flags } from '~/shared/utils/flags';
+import { isDefined } from '~/utils/type-guards';
+
+// Meilisearch rejects a bare `()` with invalid_search_filter, so a clause with nothing to say has
+// to disappear rather than become an empty string that still gets parenthesized downstream.
+
+export function buildBrowsingLevelClause(attributeName: string, browsingLevel: number) {
+  if (!attributeName) return null;
+
+  const levels = Flags.instanceToArray(browsingLevel);
+  if (!levels.length) return null;
+
+  return levels.map((value) => `${attributeName}=${value}`).join(' OR ');
+}
+
+export function buildBrowsingLevelFilters({
+  attributeName,
+  browsingLevel,
+  filters,
+}: {
+  attributeName: string;
+  browsingLevel: number;
+  filters?: string[] | string;
+}) {
+  const filterList = Array.isArray(filters) ? filters : [filters];
+
+  return [...filterList, buildBrowsingLevelClause(attributeName, browsingLevel)].filter(isDefined);
+}
+
+export function joinFilterClauses(filters?: string[] | string) {
+  const filterList = Array.isArray(filters) ? filters : filters ? [filters] : [];
+
+  return filterList
+    .filter((filter) => typeof filter === 'string' && filter.trim().length > 0)
+    .map((filter) => `(${filter})`)
+    .join(' AND ');
+}


### PR DESCRIPTION
A latent fail-closed hazard whose only guard lives in a different file from the code that would break.

## What was wrong

`BrowsingLevelFilter` built its clause as

```ts
Flags.instanceToArray(browsingLevel).map((v) => `${attributeName}=${v}`).join(' OR ')
```

`Flags.instanceToArray(0)` returns `[]` — `hasFlag(0, x)` is `(0|x) === 0`, false for every bit — so `.join(' OR ')` yields the **empty string**. `isDefined` only rejects `null` and `undefined`, so that empty string survived, and `ApplyCustomFilter` then wrapped it as `(${f})`, putting a literal `()` into the filter.

Against production Meilisearch 1.15:

```
()                    -> 400 invalid_search_filter :: Was expecting an operation `=`, `!=`, … at `)`
() AND (nsfwLevel=1)  -> 400, same
```

`createResilientSearchClient` swallows that into an empty result set, so it surfaces as "no results" or a false "search is temporarily unavailable" banner.

It is not reachable today: `useBrowsingLevelDebounced` ends with `return debounced ? debounced : NsfwLevel.PG`, which floors a 0 to PG. That guard is in `BrowsingLevelProvider.tsx` — a different file from the code it protects, which is exactly why this is worth closing where it breaks.

## What this does

Extracts the assembly into `src/components/Search/search-filters.ts` so it is unit-testable without rendering (the vitest `unit` project takes `src/**/*.test.ts` only; `.tsx` is not collected), and adds two guards:

- `buildBrowsingLevelClause` returns `null` rather than `''` when the level array is empty.
- `joinFilterClauses` drops empty and whitespace-only entries before wrapping, so no caller can inject a bare `()` either.

Net **−9 lines** in the component. Output for every non-empty case is byte-identical — the tests assert literal strings rather than re-deriving the implementation.

## Verification

`pnpm run typecheck` → 0 errors. 14 tests pass.

I reverted each guard and ran the suite rather than reasoning about the failure mode.

| Reverted | Result |
|---|---|
| empty-clause guard | 2 failed — `expected '' to be null`, `expected [ '' ] to deeply equal []` |
| empty-entry filter | 1 failed — `expected '() AND (   ) AND (type=Model)' to be '(type=Model)'` |
| both (i.e. today's code) | 5 failed — `expected '()' to be ''`, `expected '(type=Model) AND ()' to be '(type=Model)'` |

**The two guards mask each other**, which is the part worth knowing: with only the empty-clause guard reverted, the end-to-end assertions still pass, because `joinFilterClauses` drops the `''` before it can become `()`. That is why per-function assertions sit alongside the assembled-expression ones — the assembled ones alone would go green on a single-guard revert.

All failures are assertion failures in under a second. Nothing here loops, waits, or can hang instead of failing.

## Conflicts with

Overlaps `fix/search-browsing-level-attribute-map` in `BrowsingLevelFilter`'s `useMemo`, and both PRs add a pure filter-builder module (`search-filters.ts` here, `search-index-filters.ts` there). Both are based directly on `main` — deliberately not stacked.

**Reconciliation if that PR merges first**, so the rebase is mechanical: keep its `search-index-filters.ts` and fold this PR's empty-level guard into its `buildBrowsingLevelFilter` (`if (!levels.length) return null`); `joinFilterClauses` is unaffected and moves across as-is. Its version drops the `if (!attributeName) return null` line entirely, since the free-text `attributeName` prop no longer exists there.

Found while investigating CU 868kt6hdx.
