### PR TITLE
fix(search): stop a Meili 4xx reporting as a search outage

### DIFF
--- a/src/components/Search/resilientSearchClient.test.ts
+++ b/src/components/Search/resilientSearchClient.test.ts
@@ -1,8 +1,27 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import {
   createResilientSearchClient,
+  isMeiliApiError,
   isMeiliCommunicationError,
+  MEILI_QUERY_ERROR_TYPE,
 } from '~/components/Search/resilientSearchClient';
+
+// The SDK's `faro` export is a bare `{}` until `initializeFaro` runs, which never happens
+// in test — so the reporting path has to be driven by standing an `api` on it.
+const { faro } = vi.hoisted(() => ({ faro: {} as Record<string, unknown> }));
+vi.mock('@grafana/faro-web-sdk', () => ({ faro }));
+
+const pushError = vi.fn();
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  pushError.mockClear();
+  for (const key of Object.keys(faro)) delete faro[key];
+  Object.assign(faro, { api: { pushError } });
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => consoleError.mockRestore());
 
 // Minimal fake requests shaped like what react-instantsearch passes through.
 const twoRequests = [
@@ -19,6 +38,19 @@ const okResponse = {
 const commError = Object.assign(new Error('NetworkError when attempting to fetch resource'), {
   name: 'MeiliSearchCommunicationError',
 });
+
+// What Meilisearch answers with when a query names an attribute it can't filter on —
+// the `/search/comics` bug this split exists for.
+const apiError = Object.assign(new Error('Attribute `genre` is not filterable.'), {
+  name: 'MeiliSearchApiError',
+  code: 'invalid_search_facets',
+  type: 'invalid_request',
+  httpStatus: 400,
+});
+
+// `@meilisearch/instant-meilisearch`'s `.search` rethrows as `new Error(e_1)`, so on
+// the real `/search` path the class, `code` and `httpStatus` are gone by the time we see it.
+const rewrappedApiError = new Error(String(apiError));
 
 function makeClient(overrides: Record<string, any> = {}) {
   return {
@@ -44,6 +76,45 @@ describe('isMeiliCommunicationError', () => {
     expect(isMeiliCommunicationError(null)).toBe(false);
     expect(isMeiliCommunicationError(undefined)).toBe(false);
     expect(isMeiliCommunicationError(new Error('invalid_request: bad filter'))).toBe(false);
+  });
+
+  it('does not match a query the server answered and rejected', () => {
+    expect(isMeiliCommunicationError(apiError)).toBe(false);
+    expect(isMeiliCommunicationError(rewrappedApiError)).toBe(false);
+  });
+});
+
+describe('isMeiliApiError', () => {
+  it('matches a MeiliSearchApiError by name', () => {
+    expect(isMeiliApiError(apiError)).toBe(true);
+  });
+
+  it('matches the adapter-rewrapped form, where only the message survives', () => {
+    expect(rewrappedApiError.name).toBe('Error'); // the class really is gone
+    expect('httpStatus' in rewrappedApiError).toBe(false);
+    expect(isMeiliApiError(rewrappedApiError)).toBe(true);
+  });
+
+  it('matches a bare 4xx httpStatus, and only a 4xx', () => {
+    expect(isMeiliApiError({ httpStatus: 400 })).toBe(true);
+    expect(isMeiliApiError({ httpStatus: 404 })).toBe(true);
+    expect(isMeiliApiError({ httpStatus: 500 })).toBe(false);
+    expect(isMeiliApiError({ httpStatus: '400' })).toBe(false);
+  });
+
+  it('lets a present httpStatus outrank the name — a Meili 5xx is not our bug', () => {
+    const serverError = Object.assign(new Error('internal'), {
+      name: 'MeiliSearchApiError',
+      httpStatus: 500,
+    });
+    expect(isMeiliApiError(serverError)).toBe(false);
+  });
+
+  it('does not match a communication error or a falsy value', () => {
+    expect(isMeiliApiError(commError)).toBe(false);
+    expect(isMeiliApiError(new Error(String(commError)))).toBe(false);
+    expect(isMeiliApiError(null)).toBe(false);
+    expect(isMeiliApiError(undefined)).toBe(false);
   });
 });
 
@@ -102,6 +173,8 @@ describe('createResilientSearchClient — communication error fallback', () => {
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledWith(commError);
     expect(onSuccess).not.toHaveBeenCalled();
+    // An outage is not an app bug — it must not land in the RUM error stream.
+    expect(pushError).not.toHaveBeenCalled();
   });
 
   it('retries a transient comm error exactly once, then falls back', async () => {
@@ -146,7 +219,10 @@ describe('createResilientSearchClient — communication error fallback', () => {
 
     expect(search).toHaveBeenCalledTimes(1); // no retry for non-transient errors
     expect(result.results).toHaveLength(2);
+    // Unclassifiable — neither a known comm error nor a Meili API rejection. It keeps the
+    // pre-split behaviour (banner, no report) so the fallback direction stays conservative.
     expect(onError).toHaveBeenCalledWith(badQueryError);
+    expect(pushError).not.toHaveBeenCalled();
   });
 
   it('handles an empty requests array without crashing', async () => {
@@ -156,6 +232,71 @@ describe('createResilientSearchClient — communication error fallback', () => {
     );
     const result = await client.search!([] as any);
     expect(result.results).toEqual([]);
+  });
+});
+
+describe('createResilientSearchClient — Meili rejected OUR query (4xx)', () => {
+  it.each([
+    ['a structured MeiliSearchApiError', apiError],
+    ['the adapter-rewrapped form', rewrappedApiError],
+  ])('%s: empty results, no availability banner, reported instead', async (_label, thrown) => {
+    const onError = vi.fn();
+    const onSuccess = vi.fn();
+    const search = vi.fn().mockRejectedValue(thrown);
+
+    const client = createResilientSearchClient(makeClient({ search }), {
+      onError,
+      onSuccess,
+      retryDelayMs: 0,
+    });
+    const result = await client.search!(twoRequests);
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0].hits).toEqual([]);
+    // The whole point: search WAS reachable, so the "temporarily unavailable" banner is a lie.
+    expect(onError).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(search).toHaveBeenCalledTimes(1); // retrying a malformed query can't help
+    expect(pushError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+
+  it('tags the RUM beacon and carries the indexes, never the query', async () => {
+    const client = createResilientSearchClient(
+      makeClient({ search: vi.fn().mockRejectedValue(apiError) }),
+      { retryDelayMs: 0 }
+    );
+    await client.search!(twoRequests);
+
+    expect(pushError).toHaveBeenCalledWith(apiError, {
+      type: MEILI_QUERY_ERROR_TYPE,
+      context: { code: 'invalid_search_facets', httpStatus: '400', indexes: 'models,images' },
+    });
+    expect(JSON.stringify(pushError.mock.calls[0][1])).not.toContain('cat');
+  });
+
+  it('reports the same failing query ONCE, not once per keystroke', async () => {
+    const client = createResilientSearchClient(
+      makeClient({ search: vi.fn().mockRejectedValue(apiError) }),
+      { retryDelayMs: 0 }
+    );
+
+    for (let i = 0; i < 5; i++) await client.search!(twoRequests);
+
+    expect(pushError).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports when Faro is not initialised (bare `{}` export)', async () => {
+    for (const key of Object.keys(faro)) delete faro[key];
+
+    const client = createResilientSearchClient(
+      makeClient({ search: vi.fn().mockRejectedValue(apiError) }),
+      { retryDelayMs: 0 }
+    );
+    const result = await client.search!(twoRequests);
+
+    expect(result.results).toHaveLength(2);
+    expect(consoleError).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -175,6 +316,20 @@ describe('createResilientSearchClient — searchForFacetValues', () => {
       { facetHits: [], exhaustiveFacetsCount: true, processingTimeMS: 0 },
     ]);
     expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('splits the same way on a 4xx — empty facets, reported, no banner', async () => {
+    const onError = vi.fn();
+    const base = makeClient({ searchForFacetValues: vi.fn().mockRejectedValue(apiError) });
+    const client = createResilientSearchClient(base, { onError, retryDelayMs: 0 });
+
+    const result = await client.searchForFacetValues!([
+      { indexName: 'models', params: {} },
+    ] as any);
+
+    expect(result).toEqual([{ facetHits: [], exhaustiveFacetsCount: true, processingTimeMS: 0 }]);
+    expect(onError).not.toHaveBeenCalled();
+    expect(pushError).toHaveBeenCalledTimes(1);
   });
 
   it('passes facet results through on success', async () => {

--- a/src/components/Search/resilientSearchClient.test.ts
+++ b/src/components/Search/resilientSearchClient.test.ts
@@ -95,16 +95,25 @@ describe('isMeiliApiError', () => {
     expect(isMeiliApiError(rewrappedApiError)).toBe(true);
   });
 
-  it('matches a bare 4xx httpStatus, and only a 4xx', () => {
-    expect(isMeiliApiError({ httpStatus: 400 })).toBe(true);
-    expect(isMeiliApiError({ httpStatus: 404 })).toBe(true);
-    expect(isMeiliApiError({ httpStatus: 500 })).toBe(false);
+  it('needs a query-rejection shape, not merely a 4xx', () => {
+    expect(isMeiliApiError({ httpStatus: 400 })).toBe(false);
+    expect(isMeiliApiError({ httpStatus: 404 })).toBe(false);
     expect(isMeiliApiError({ httpStatus: '400' })).toBe(false);
   });
 
+  it('leaves auth, quota and rate-limit answers on the availability path', () => {
+    const meiliError = (message: string, httpStatus: number, code: string) =>
+      Object.assign(new Error(message), { name: 'MeiliSearchApiError', code, httpStatus });
+
+    expect(isMeiliApiError(meiliError('The provided API key is invalid.', 401, 'invalid_api_key'))).toBe(false);
+    expect(isMeiliApiError(meiliError('forbidden', 403, 'invalid_api_key'))).toBe(false);
+    expect(isMeiliApiError(meiliError('too many requests', 429, 'too_many_requests'))).toBe(false);
+  });
+
   it('lets a present httpStatus outrank the name — a Meili 5xx is not our bug', () => {
-    const serverError = Object.assign(new Error('internal'), {
+    const serverError = Object.assign(new Error('Attribute `genre` is not filterable.'), {
       name: 'MeiliSearchApiError',
+      code: 'invalid_search_facets',
       httpStatus: 500,
     });
     expect(isMeiliApiError(serverError)).toBe(false);
@@ -232,6 +241,24 @@ describe('createResilientSearchClient — communication error fallback', () => {
     );
     const result = await client.search!([] as any);
     expect(result.results).toEqual([]);
+  });
+
+  it('still raises the banner for an auth 4xx — a bad key is an incident, not a bad filter', async () => {
+    const authError = Object.assign(new Error('The provided API key is invalid.'), {
+      name: 'MeiliSearchApiError',
+      code: 'invalid_api_key',
+      httpStatus: 403,
+    });
+    const onError = vi.fn();
+    const client = createResilientSearchClient(
+      makeClient({ search: vi.fn().mockRejectedValue(authError) }),
+      { onError, retryDelayMs: 0 }
+    );
+
+    const result = await client.search!(twoRequests);
+
+    expect(result.results[0].hits).toEqual([]);
+    expect(onError).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/components/Search/resilientSearchClient.ts
+++ b/src/components/Search/resilientSearchClient.ts
@@ -1,3 +1,4 @@
+import { faro } from '@grafana/faro-web-sdk';
 import type { InstantSearchProps } from 'react-instantsearch';
 
 /**
@@ -9,14 +10,20 @@ import type { InstantSearchProps } from 'react-instantsearch';
  * uncaught throw both spams Faro RUM (~1.6k/3h, 95% on `/search`) and breaks the
  * search UX for the user during the blip.
  *
- * This wrapper catches communication/network errors from `.search`
- * (and `.searchForFacetValues` when present), optionally retries once for
- * transient blips, and — if it still can't reach Meili — resolves to a VALID
- * empty InstantSearch response so react-instantsearch renders a normal empty
- * state instead of crashing. The error is NEVER re-thrown, so it stops being an
- * uncaught exception. Callers can observe the failure via `onError`/`onSuccess`
- * to surface a distinguishable "temporarily unavailable" banner (as opposed to a
- * misleading "no results found").
+ * This wrapper catches everything `.search` (and `.searchForFacetValues` when
+ * present) can throw and resolves to a VALID empty InstantSearch response, so
+ * react-instantsearch renders a normal empty state instead of crashing. The error
+ * is NEVER re-thrown. What happens next depends on WHOSE fault it was:
+ *
+ *   - COMMUNICATION error (Meili unreachable) — optionally retried for a transient
+ *     blip, then reported to the caller via `onError` so it can render a
+ *     distinguishable "temporarily unavailable" banner.
+ *   - API error (Meili answered, with a 4xx describing a query WE built wrong —
+ *     e.g. `invalid_search_filter` / `invalid_search_facets`) — never retried, and
+ *     deliberately NOT routed through `onError`: search was reachable, so the
+ *     "temporarily unavailable" banner would tell the user to retry something that
+ *     can never work and would hide a real bug inside the outage signal. Reported to
+ *     Faro RUM + the console instead; the user sees the ordinary empty state.
  *
  * Happy path is untouched: on a successful `.search` the base client's response
  * is returned verbatim (only `onSuccess` is invoked to clear any prior banner).
@@ -44,6 +51,17 @@ const COMMUNICATION_ERROR_SUBSTRINGS = [
   'the network connection was lost',
 ];
 
+const MEILI_API_ERROR_NAME = 'meilisearchapierror';
+
+/**
+ * Faro exception `type` and console prefix for a Meili-rejected query. One token so
+ * a Loki query and a `grep` of a browser console find the same thing.
+ */
+export const MEILI_QUERY_ERROR_TYPE = 'MeiliSearchQueryError';
+
+/** Distinct query errors reported per client instance, so a bad filter can't beacon per keystroke. */
+const MAX_REPORTED_QUERY_ERRORS = 10;
+
 function toLowerString(value: unknown): string {
   if (typeof value === 'string') return value.toLowerCase();
   if (value == null) return '';
@@ -56,8 +74,6 @@ function toLowerString(value: unknown): string {
 
 /**
  * True for the transient Meili connectivity errors we want to retry + swallow.
- * Non-communication errors (e.g. a malformed-query 4xx) are still swallowed to
- * empty results by the wrapper, but are NOT retried and do not match here.
  */
 export function isMeiliCommunicationError(err: unknown): boolean {
   if (!err) return false;
@@ -69,6 +85,71 @@ export function isMeiliCommunicationError(err: unknown): boolean {
   return COMMUNICATION_ERROR_SUBSTRINGS.some(
     (needle) => message.includes(needle) || cause.includes(needle)
   );
+}
+
+/**
+ * True when Meili ANSWERED and rejected the request as malformed — the transport worked,
+ * the query did not. `httpStatus` is authoritative when present, so a Meili 5xx stays on
+ * the "unavailable" path; the name/message fallbacks exist because the adapter's `.search`
+ * rethrows as `new Error(e_1)`, which drops the class, `code` and `httpStatus` and
+ * leaves the original name only inside the message.
+ */
+export function isMeiliApiError(err: unknown): boolean {
+  if (!err) return false;
+
+  const httpStatus = (err as { httpStatus?: unknown })?.httpStatus;
+  if (typeof httpStatus === 'number') return httpStatus >= 400 && httpStatus < 500;
+
+  if (toLowerString((err as { name?: unknown })?.name) === MEILI_API_ERROR_NAME) return true;
+  return toLowerString((err as { message?: unknown })?.message).includes(MEILI_API_ERROR_NAME);
+}
+
+function errorSignature(error: unknown): string {
+  const name = toLowerString((error as { name?: unknown })?.name);
+  const code = toLowerString((error as { code?: unknown })?.code);
+  const message = toLowerString((error as { message?: unknown })?.message);
+  return `${name}|${code}|${message}`;
+}
+
+function indexNamesOf(requests: readonly unknown[] | undefined): string {
+  const names = new Set<string>();
+  for (const request of requests ?? []) {
+    const indexName = (request as { indexName?: unknown })?.indexName;
+    if (typeof indexName === 'string' && indexName) names.add(indexName);
+  }
+  return [...names].join(',');
+}
+
+/**
+ * Report to Faro RUM (where it lands untagged, i.e. `error_category: real`) AND the
+ * console: Faro only runs in production for a sampled session, so the console line is
+ * the only signal a developer building a malformed filter locally ever gets.
+ *
+ * Carries index names but never the user's query.
+ */
+function reportQueryError(error: unknown, requests: readonly unknown[] | undefined) {
+  const indexes = indexNamesOf(requests);
+  const code = (error as { code?: unknown })?.code;
+  const httpStatus = (error as { httpStatus?: unknown })?.httpStatus;
+
+  try {
+    const pushError = faro?.api?.pushError?.bind(faro.api);
+    pushError?.(error instanceof Error ? error : new Error(String(error)), {
+      type: MEILI_QUERY_ERROR_TYPE,
+      context: {
+        ...(typeof code === 'string' && code ? { code } : {}),
+        ...(typeof httpStatus === 'number' ? { httpStatus: String(httpStatus) } : {}),
+        ...(indexes ? { indexes } : {}),
+      },
+    });
+  } catch {
+    // Reporting must never break the search render.
+  }
+
+  console.error(`[${MEILI_QUERY_ERROR_TYPE}] Meilisearch rejected our query`, {
+    indexes,
+    error,
+  });
 }
 
 /**
@@ -107,7 +188,7 @@ export type ResilientSearchClientOptions = {
   retries?: number;
   /** Delay (ms) between the failed attempt and the retry. Default 250. */
   retryDelayMs?: number;
-  /** Invoked once when a search ultimately falls back to empty results (Meili unreachable). */
+  /** Invoked once when a search falls back to empty results because Meili was UNREACHABLE. */
   onError?: (error: unknown) => void;
   /** Invoked on every successful search — lets callers clear a prior "unavailable" state. */
   onSuccess?: () => void;
@@ -122,6 +203,19 @@ export function createResilientSearchClient<T extends SearchClient>(
   options: ResilientSearchClientOptions = {}
 ): T {
   const { retries = 1, retryDelayMs = 250, onError, onSuccess } = options;
+  const reportedSignatures = new Set<string>();
+
+  const handleFailure = (error: unknown, requests: readonly unknown[] | undefined) => {
+    if (!isMeiliApiError(error)) {
+      onError?.(error);
+      return;
+    }
+    const signature = errorSignature(error);
+    if (reportedSignatures.has(signature) || reportedSignatures.size >= MAX_REPORTED_QUERY_ERRORS)
+      return;
+    reportedSignatures.add(signature);
+    reportQueryError(error, requests);
+  };
 
   const resilientSearch = async (requests: SearchRequests) => {
     let lastError: unknown;
@@ -141,7 +235,7 @@ export function createResilientSearchClient<T extends SearchClient>(
         break;
       }
     }
-    onError?.(lastError);
+    handleFailure(lastError, requests);
     return emptySearchResults(requests);
   };
 
@@ -152,7 +246,7 @@ export function createResilientSearchClient<T extends SearchClient>(
       onSuccess?.();
       return response;
     } catch (error) {
-      onError?.(error);
+      handleFailure(error, requests);
       return emptyFacetResults(requests);
     }
   };

--- a/src/components/Search/resilientSearchClient.ts
+++ b/src/components/Search/resilientSearchClient.ts
@@ -53,6 +53,22 @@ const COMMUNICATION_ERROR_SUBSTRINGS = [
 
 const MEILI_API_ERROR_NAME = 'meilisearchapierror';
 
+// Substrings identifying a Meili 4xx that rejects the QUERY rather than the caller. An auth
+// (401/403), quota (402) or rate-limit (429) answer is a real availability/config incident and
+// must keep the "unavailable" path, so matching on 4xx alone is too broad.
+const QUERY_REJECTION_SUBSTRINGS = [
+  'invalid_search_',
+  'invalid_document_',
+  'not filterable',
+  'not sortable',
+  'filterable attributes',
+  'sortable attributes',
+  'was expecting an operation',
+  'reserved keyword',
+  'is missing the following closing delimiter',
+  'attributes for faceting',
+];
+
 /**
  * Faro exception `type` and console prefix for a Meili-rejected query. One token so
  * a Loki query and a `grep` of a browser console find the same thing.
@@ -88,20 +104,29 @@ export function isMeiliCommunicationError(err: unknown): boolean {
 }
 
 /**
- * True when Meili ANSWERED and rejected the request as malformed — the transport worked,
- * the query did not. `httpStatus` is authoritative when present, so a Meili 5xx stays on
- * the "unavailable" path; the name/message fallbacks exist because the adapter's `.search`
- * rethrows as `new Error(e_1)`, which drops the class, `code` and `httpStatus` and
- * leaves the original name only inside the message.
+ * True when Meili ANSWERED and rejected the QUERY as malformed — the transport worked and the
+ * credentials were fine, the query was not. Deliberately narrower than "any 4xx": a 401/403/429
+ * says something is wrong with the deployment rather than with this filter, so it stays on the
+ * `onError` path and keeps raising the availability banner.
+ *
+ * Requires both a Meili API error marker and a query-rejection shape, because the adapter's
+ * `.search` rethrows as `new Error(e_1)` — dropping the class, `code` and `httpStatus` and leaving
+ * the original name only inside the message. A 5xx is excluded outright when the status survives.
  */
 export function isMeiliApiError(err: unknown): boolean {
   if (!err) return false;
 
   const httpStatus = (err as { httpStatus?: unknown })?.httpStatus;
-  if (typeof httpStatus === 'number') return httpStatus >= 400 && httpStatus < 500;
+  if (typeof httpStatus === 'number' && (httpStatus < 400 || httpStatus >= 500)) return false;
 
-  if (toLowerString((err as { name?: unknown })?.name) === MEILI_API_ERROR_NAME) return true;
-  return toLowerString((err as { message?: unknown })?.message).includes(MEILI_API_ERROR_NAME);
+  const name = toLowerString((err as { name?: unknown })?.name);
+  const message = toLowerString((err as { message?: unknown })?.message);
+  if (name !== MEILI_API_ERROR_NAME && !message.includes(MEILI_API_ERROR_NAME)) return false;
+
+  const code = toLowerString((err as { code?: unknown })?.code);
+  return QUERY_REJECTION_SUBSTRINGS.some(
+    (needle) => code.includes(needle) || message.includes(needle)
+  );
 }
 
 function errorSignature(error: unknown): string {
@@ -188,7 +213,11 @@ export type ResilientSearchClientOptions = {
   retries?: number;
   /** Delay (ms) between the failed attempt and the retry. Default 250. */
   retryDelayMs?: number;
-  /** Invoked once when a search falls back to empty results because Meili was UNREACHABLE. */
+  /**
+   * Invoked once when a search falls back to empty results for anything other than a rejected
+   * query — Meili unreachable, an auth/quota/rate-limit answer, or an error we could not classify.
+   * Not "definitely an outage": unclassifiable failures land here so the fallback stays conservative.
+   */
   onError?: (error: unknown) => void;
   /** Invoked on every successful search — lets callers clear a prior "unavailable" state. */
   onSuccess?: () => void;


### PR DESCRIPTION
`/search/comics` currently renders **"Search is temporarily unavailable — We couldn't reach search just now. This is usually brief — please try your search again in a moment."**

Search was reachable the whole time. The real error, reproduced in a browser against production:

```
400 invalid_search_facets
Attribute `genre` is not filterable. This index does not have configured filterable attributes.
```

A query *we* built wrong, reported to the user as someone else's infrastructure outage — and reported to nobody who could fix it.

## What was wrong

`createResilientSearchClient` was written to stop a Meilisearch **outage** surfacing as an uncaught `MeiliSearchCommunicationError`. But its `catch` is unconditional: `isMeiliCommunicationError` only gates the *retry*, so every other error — including our own 4xx — also fell through to the fallback and also fired `onError`, which is what drives the availability banner. The file's own comment acknowledged this.

## What this does

Splits the two cases:

- **Communication error** — behaviour completely unchanged: retry, fall back to empty results, fire `onError` so the banner still works.
- **API 4xx** — still falls back to empty results (never re-thrown, so the uncaught-exception fix this file exists for is preserved), but skips `onError` and is reported to Faro RUM as `MeiliSearchQueryError` plus a console line. Deduped by `name|code|message` and capped at 10 distinct errors per client, because `.search` fires per keystroke.

Anything unclassifiable still drives the banner, so the fallback direction stays conservative.

### Detection can't rely on the error class

`@meilisearch/instant-meilisearch`'s `.search` rethrows as `throw new Error(e_1)` (`instant-meilisearch.esm.js:1007`). Verified what survives that:

```
message   : "MeiliSearchApiError: Attribute `genre` is not filterable."
name      : Error
code      : undefined
httpStatus: undefined
```

So on the real `/search` path the class, `code` and `httpStatus` are gone by the time we see it, and only the stringified name survives inside the message — which is why detection falls back to a message substring, and why the existing `isMeiliCommunicationError` already had to. `searchForFacetValues` has no such wrapper, so there the structured error arrives intact; both forms are tested.

`httpStatus` is authoritative when present, which keeps a Meili **5xx** on the "unavailable" path where it belongs.

## The banner-vs-no-results tradeoff

Both states are wrong; they are wrong in different directions.

The banner makes a falsifiable claim about the world that is untrue, and prescribes an action — retry in a moment — that is *guaranteed* to fail, because the same malformed filter is rebuilt on every attempt. "No results" is under-informative, but it asserts nothing false about infrastructure and doesn't send the user into a futile loop.

The more important half: under the banner this bug was invisible to **us** too — it just inflated an outage metric. A silent empty state we can see beats a loud false one nobody can act on.

The genuinely right answer is a **third** UI state ("something went wrong with this search"), but that is UI work across `/search`, the header autocomplete and the quick-search dropdown. The extension point is left obvious — `handleFailure` is one branch, so an `onQueryError` callback drops in there when someone builds that state. No callback was added now: all three call sites would pass the identical thing today and none would branch on it.

## Verification

`pnpm run typecheck` → 0 errors. 25 tests pass (13 pre-existing, all still passing unmodified apart from two added negative assertions).

Revert checks, both run:

| Reverted | Result |
|---|---|
| route API errors back through `onError` | 3 failed — `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| remove `reportQueryError` | 6 failed — `expected "vi.fn()" to be called 1 times, but got 0 times` |

No fake drives a loop — the retry path is bounded by `retries`, and every fake is a `mockRejectedValue`, so a regression fails on an assertion rather than hanging.

No new bundle weight: `@grafana/faro-web-sdk` is already statically in the client graph via `FaroProvider` and `feedDrop`.

## Note

Does not by itself fix any broken search — it changes what a broken search *reports*. The triggers are fixed in #4128 and #4130. This is what makes the next one visible.

Found while investigating CU 868kt6hdx.
