### PR TITLE
fix(apps): let the store-listing screenshot gallery use the width it has

### DIFF
--- a/src/components/Apps/AppListingDetailBody.gallery.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.gallery.browser.test.tsx
@@ -1,0 +1,501 @@
+/**
+ * App-listing detail — the SCREENSHOT GALLERY's RENDERED WIDTH.
+ *
+ * The reported defect: a listing with ONE screenshot rendered it at roughly half the
+ * main column with dead space beside it (observed live at 1440px: ~415px of image in
+ * an ~880px column), and the trailing tile of any ODD count did the same. The gallery
+ * was a fixed two-track `SimpleGrid`, so an unpaired tile occupied one track and left
+ * the other empty. The fix is one CSS rule — `.gallery > :last-child:nth-child(odd) {
+ * grid-column: 1 / -1 }` — and this file is the only place that can prove it, because
+ * it is the only place a real layout engine runs.
+ *
+ * 🔴 READ THIS BEFORE TRUSTING IT AS A GATE: IT IS NOT ONE. This file is in the
+ * Vitest browser-mode `component` project, which CI runs only as the preview
+ * pipeline's `preview / component-tests` — report-only, non-blocking, and not
+ * reported at all when the preview build fails. The enforceable half of the change is
+ * the seam gate in the blocking node project (`__tests__/appListingGalleryFill.test.ts`),
+ * which pins that the rule and the `className` both exist and agree. That gate cannot
+ * see a single pixel; this file cannot block a merge. Both claims are needed and
+ * neither substitutes for the other.
+ *
+ * 🔴 WHY THIS FILE LOADS `@mantine/core/styles.css` AND ITS SIBLING MUST NOT.
+ * `AppListingDetailBody.browser.test.tsx` deliberately loads no stylesheet and says so
+ * in its header — every assertion there is structural (DOM order, props, ARIA). But
+ * every number here comes FROM a stylesheet: `SimpleGrid`'s
+ * `grid-template-columns: repeat(var(--sg-cols), minmax(0, 1fr))` is a Mantine rule,
+ * and without it the grid container is a plain block, every tile is full width by
+ * default, and the "a lone tile fills the row" assertions below would pass while
+ * measuring nothing at all. That is not a hypothetical — it is the single most likely
+ * way this file goes vacuously green, which is why the TWO-screenshot case is asserted
+ * first and treated as the instrument control (see it). Vitest browser mode runs each
+ * test file in its own iframe, so this import does not leak into the sibling suites.
+ *
+ * 🔴 WHAT IS ASSERTED IS GEOMETRY, NOT A CLASS NAME. A test that pinned
+ * `className`, `cols`, or the presence of a CSS rule passes with the rendered width
+ * still wrong — that check already exists in the node project and is honest about
+ * being source text. Here every assertion is a measured `getBoundingClientRect()`
+ * width, stated RELATIVE to the gallery's own container width, so it is a claim about
+ * what the viewer sees rather than about what the source says.
+ *
+ * MEASURED, at 1440x900, `spacing="md"` = a 16px column gap. The main column's content
+ * box — the gallery's container — resolves to 949.33px here, so one track is 466.66px.
+ * (That container is WIDER than the ~880px seen on the live page, because this file
+ * mounts the body directly rather than inside the page's 1320px `Container`. Nothing
+ * below is asserted against an absolute px value for exactly that reason: every claim
+ * is stated relative to the measured `gridWidth`, so it holds at any container width.)
+ *
+ * The "before" column is the ISOLATED mutation — `className={galleryClasses.gallery}`
+ * removed and NOTHING else, so the stylesheet, the testid and the import all stay put
+ * and the only variable is whether the fill rule applies:
+ *
+ *                              before                after           at base
+ *   1 screenshot               466.66               949.33            RED
+ *   3 screenshots       466.66 x2 + 466.66   466.66 x2 + 949.33       RED
+ *   3, last two 404       466.66 (survivor)        949.33             RED
+ *   2 screenshots           466.66 x2            466.66 x2           green  <- control
+ *   3, middle 404s          466.66 x2            466.66 x2           green  <- invariant
+ *   0 screenshots           no section           no section          green  <- invariant
+ *   390x844, 3 shots      full width x3        full width x3         green  <- invariant
+ *
+ * The four green rows are what make the three red ones mean something: they say the
+ * rule fires ONLY on a tile with no partner. A rule that widened everything would take
+ * the control and the middle-404 case down with it.
+ */
+import '@mantine/core/styles.css';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
+import type * as FeatureFlagsMod from '~/providers/FeatureFlagsProvider';
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+
+const WIDE: [number, number] = [1440, 900];
+const NARROW: [number, number] = [390, 844];
+
+/** Mantine `spacing="md"` — the gallery's column gap, in px. */
+const GAP = 16;
+
+// Anonymous viewer, so the `⋮` menu and its modals never mount. Nothing in this file
+// is about them and each one is a portal that would sit outside the measured tree.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// 🔴 `importOriginal` SPREAD, not a wholesale replacement (local-rules/
+// no-wholesale-module-mock): a hand-written factory silently breaks every importer
+// the day the real module grows an export it omits — and in this project that
+// surfaces as `Tests no tests`, i.e. as nothing to see rather than as a failure.
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsMod>()),
+  useFeatureFlags: () => ({ appBlocks: true, appListings: true, appBlocksPages: false }),
+}));
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    appListings: {
+      // The discovery rail sits BELOW the two-column grid, so what it returns cannot
+      // move a tile. Empty anyway, to keep the suite network-free.
+      listAvailable: { useQuery: () => ({ data: { items: [] }, isLoading: false }) },
+      getMyReview: { useQuery: () => ({ data: null, isLoading: false }) },
+      upsertReview: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      reportListing: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
+    user: {
+      getCreator: { useQuery: () => ({ data: null }) },
+      getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) },
+    },
+    useUtils: () => ({
+      appListings: {
+        getMyReview: { invalidate: async () => undefined },
+        listReviews: { invalidate: async () => undefined },
+        getAppDetail: { invalidate: async () => undefined },
+      },
+    }),
+  },
+}));
+vi.mock('~/components/Apps/AppListingReviews', () => ({
+  AppListingReviews: () => <div data-testid="mock-reviews" />,
+}));
+vi.mock('~/components/Apps/AppListingComments', () => ({
+  AppListingComments: () => <div data-testid="mock-comments" />,
+}));
+
+// Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
+const { AppListingDetailBody } = await import('./AppListingDetailBody');
+
+beforeEach(async () => {
+  // 🔴 Restore the WIDE viewport before every test. The viewport is browser-global
+  // state, so without this the one narrow test below would silently re-run every
+  // later test at 390px and the two-track assertions would measure a one-track grid.
+  await page.viewport(...WIDE);
+});
+
+/**
+ * A screenshot URL that RESOLVES — an inline 320x180 SVG. It has to be a real,
+ * loadable image: `ScreenshotTile` removes itself from the DOM on an `error` event, so
+ * a tile built from an unreachable URL is not a tile whose width can be measured. The
+ * 16:9 box keeps the rendered rows a sane height; only widths are asserted.
+ */
+const OK_SHOT = `data:image/svg+xml;base64,${btoa(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"/>'
+)}`;
+
+/** A URL that cannot resolve, so the browser fires `error` and the tile hides itself. */
+const BROKEN_SHOT = (n: number) => `https://cdn.invalid.example/missing-${n}.png`;
+
+function base(over: Partial<ListingDetail>): ListingDetail {
+  return {
+    id: 'l1',
+    serialId: 1,
+    slug: 'my-app',
+    kind: 'onsite',
+    collaborators: [],
+    name: 'My App',
+    tagline: 'A handy app',
+    description: null,
+    category: 'utility',
+    contentRating: null,
+    iconUrl: null,
+    coverUrl: null,
+    // 🔴 `null` DELIBERATELY. A creator mounts `SmartCreatorCard`, a live tRPC surface
+    // with its own child graph — none of which this file is about, and all of which
+    // would need mocking to keep the render clean. It sits in the RAIL, whose width is
+    // set by the grid's column span and not by its contents, so the gallery's
+    // container width is identical either way.
+    creator: null,
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    installCount: 4213,
+    updatedAt: '2026-03-04T05:06:07.000Z',
+    screenshots: [],
+    kindData: {
+      kind: 'onsite',
+      appBlockId: 'blk-1',
+      hasPage: true,
+      liveUrl: 'https://my-app.civit.ai',
+    },
+    ...over,
+  };
+}
+
+const round = (n: number) => Math.round(n * 100) / 100;
+
+type Geometry = {
+  /** Guard-the-guard — false means Mantine's stylesheet did not load. */
+  gridIsGrid: boolean;
+  trackCount: number;
+  columnGap: number;
+  gridWidth: number;
+  /**
+   * The main column's CONTENT width — its border box minus its own inline padding.
+   *
+   * 🔴 Not `getBoundingClientRect().width`. `ContainerGrid2`'s columns carry the
+   * grid gutter as inline PADDING (16px a side here), so the border box is 32px wider
+   * than anything that can ever be laid out inside it. Comparing the gallery against
+   * that number reports a 32px shortfall on a gallery that is in fact flush with its
+   * column — a permanent false red that would get this assertion deleted.
+   */
+  mainColContentWidth: number;
+  tiles: { width: number; left: number; top: number }[];
+};
+
+function measure(container: HTMLElement): Geometry {
+  const grid = container.querySelector(
+    '[data-testid="apps-listing-screenshot-grid"]'
+  ) as HTMLElement;
+  const main = container.querySelector('[data-testid="apps-listing-main-col"]') as HTMLElement;
+  const cs = getComputedStyle(grid);
+  const mainCs = getComputedStyle(main);
+  return {
+    gridIsGrid: cs.display === 'grid',
+    // A resolved `grid-template-columns` is a space-separated list of used track
+    // sizes, so its length IS the track count. `none` (no grid) splits to 1, which is
+    // why `gridIsGrid` is asserted alongside it rather than instead of it.
+    trackCount: cs.gridTemplateColumns.split(/\s+/).filter(Boolean).length,
+    columnGap: round(parseFloat(cs.columnGap)),
+    gridWidth: round(grid.getBoundingClientRect().width),
+    mainColContentWidth: round(
+      main.getBoundingClientRect().width -
+        parseFloat(mainCs.paddingLeft) -
+        parseFloat(mainCs.paddingRight)
+    ),
+    tiles: Array.from(grid.children).map((el) => {
+      const r = (el as HTMLElement).getBoundingClientRect();
+      return { width: round(r.width), left: round(r.left), top: round(r.top) };
+    }),
+  };
+}
+
+async function renderGallery(detail: ListingDetail) {
+  const { container } = await renderWithProviders(<AppListingDetailBody detail={detail} />);
+  const within = page.elementLocator(container);
+  await expect.element(within.getByText('My App')).toBeInTheDocument();
+  // Two frames so layout + the injected stylesheet have both settled.
+  await new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+  return { container, within };
+}
+
+/**
+ * Assert the grid really is a two-track CSS grid at this viewport. Every width claim
+ * below is meaningless without it: with no stylesheet the container is a block, tiles
+ * are full width by default, and "the lone tile fills the row" passes for the wrong
+ * reason.
+ */
+function expectTwoTrackGrid(g: Geometry) {
+  expect(g.gridIsGrid).toBe(true);
+  expect(g.trackCount).toBe(2);
+  expect(g.columnGap).toBe(GAP);
+  // A floor, so a collapsed or zero-width column cannot produce a vacuous pass on
+  // any of the equalities below.
+  expect(g.gridWidth).toBeGreaterThan(400);
+  // The gallery fills the main column it sits in — the column whose unused half is
+  // the whole complaint.
+  expect(g.gridWidth).toBeCloseTo(g.mainColContentWidth, 1);
+}
+
+/** The width one track of a two-track grid resolves to — i.e. the DEFECT's width. */
+const halfTrack = (g: Geometry) => round((g.gridWidth - GAP) / 2);
+
+/**
+ * Compare two measured px values with a 0.05px tolerance.
+ *
+ * 🔴 Sub-pixel, and bounded on purpose. Chromium lays a 949.33px grid out as two
+ * 466.66px tracks while `(949.33 - 16) / 2` rounds to 466.67 — a 0.01px disagreement
+ * that made three tests red for a reason that had nothing to do with the layout. The
+ * tolerance absorbs that and NOTHING else: every difference this file exists to detect
+ * is a factor of two (466 vs 949), four orders of magnitude away from it. Do not widen
+ * it — a tolerance large enough to hide a real regression is how a geometry suite
+ * becomes decorative.
+ */
+const expectWidth = (actual: number, expected: number) => expect(actual).toBeCloseTo(expected, 1);
+
+describe('screenshot gallery — rendered tile width', () => {
+  /**
+   * 🔴 THE INSTRUMENT CONTROL, AND IT IS DELIBERATELY FIRST.
+   *
+   * This case is UNCHANGED by the fix — green before and after — so it is an invariant
+   * guard, not regression coverage, and must not be counted as any. Its job is to make
+   * every other assertion in this file mean something: it proves the measurement can
+   * tell HALF from FULL. If Mantine's stylesheet failed to load, or `SimpleGrid` stopped
+   * being a grid, or the fill rule leaked onto tiles that DO have a partner, the tiles
+   * here would measure full width and this test would go red — which is exactly what
+   * stops the one- and three-screenshot cases below from passing for the wrong reason.
+   */
+  test('2 screenshots — CONTROL: a paired row stays two half-width tiles', async () => {
+    const { container } = await renderGallery(
+      base({
+        screenshots: [
+          { url: OK_SHOT, caption: null },
+          { url: OK_SHOT, caption: null },
+        ],
+      })
+    );
+    const g = measure(container);
+    expectTwoTrackGrid(g);
+
+    expect(g.tiles).toHaveLength(2);
+    expectWidth(g.tiles[0].width, halfTrack(g));
+    expectWidth(g.tiles[1].width, halfTrack(g));
+    // …and they are genuinely SIDE BY SIDE, not two full-width tiles that happen to
+    // measure the same. Same row, second one a gap to the right of the first.
+    expect(g.tiles[1].top).toBe(g.tiles[0].top);
+    expectWidth(g.tiles[1].left, round(g.tiles[0].left + g.tiles[0].width + GAP));
+    // The number that names the defect: half a track is nowhere near the column.
+    expect(g.tiles[0].width).toBeLessThan(g.gridWidth * 0.55);
+  });
+
+  /**
+   * 🔴 THE REPORTED DEFECT. RED AT BASE: the single tile measured one track —
+   * 421.33px inside an 858.66px column — leaving 437.33px of dead space beside it.
+   */
+  test('1 screenshot — the lone tile fills the whole column', async () => {
+    const { container } = await renderGallery(
+      base({ screenshots: [{ url: OK_SHOT, caption: null }] })
+    );
+    const g = measure(container);
+    expectTwoTrackGrid(g);
+
+    expect(g.tiles).toHaveLength(1);
+    expectWidth(g.tiles[0].width, g.gridWidth);
+    // Stated a second way, against the DEFECT's own number rather than against the
+    // container: the tile is not one track wide. `halfTrack` is derived from the same
+    // measured `gridWidth`, so this cannot drift with the viewport or the container.
+    expect(g.tiles[0].width).toBeGreaterThan(halfTrack(g) * 1.9);
+  });
+
+  /**
+   * 🔴 THE SAME BUG IN ITS SECOND SHAPE. RED AT BASE: the third tile measured one
+   * track and left the rest of its row empty.
+   */
+  test('3 screenshots — the first two pair up, the odd trailing tile fills its row', async () => {
+    const { container } = await renderGallery(
+      base({
+        screenshots: [
+          { url: OK_SHOT, caption: null },
+          { url: OK_SHOT, caption: null },
+          { url: OK_SHOT, caption: null },
+        ],
+      })
+    );
+    const g = measure(container);
+    expectTwoTrackGrid(g);
+
+    expect(g.tiles).toHaveLength(3);
+    // Row 1 is untouched — the fix must not widen a tile that HAS a partner.
+    expectWidth(g.tiles[0].width, halfTrack(g));
+    expectWidth(g.tiles[1].width, halfTrack(g));
+    expect(g.tiles[1].top).toBe(g.tiles[0].top);
+    // Row 2 is the whole column, flush with the grid's left edge.
+    expectWidth(g.tiles[2].width, g.gridWidth);
+    expectWidth(g.tiles[2].left, g.tiles[0].left);
+    expect(g.tiles[2].top).toBeGreaterThan(g.tiles[0].top);
+  });
+
+  /**
+   * 🔴 THE COUNT-MISMATCH CASE — the reason the fix is a CSS structural selector and
+   * not a `cols` value computed from `screenshots.length`.
+   *
+   * Three screenshots go in; two of them 404, so `ScreenshotTile` removes them and the
+   * browser ends up with ONE tile. Any number derived before render would still say
+   * "3" here and would leave that survivor at half width. `:last-child:nth-child(odd)`
+   * is matched against the LIVE DOM, so the remaining tile is re-matched for free.
+   *
+   * RED AT BASE: the survivor measured one track.
+   */
+  test('3 screenshots, two of them 404 — the surviving tile fills the column', async () => {
+    // 🔴 THE SURVIVOR IS THE MIDDLE ENTRY, DELIBERATELY. Its `alt` is generated from
+    // the tile's INDEX IN THE FULL ARRAY, so "screenshot 2" is a string only a
+    // three-element map can produce — which is what makes this a real positive
+    // control for "three tiles were rendered and two removed themselves", rather than
+    // for "the fixture only ever had one".
+    //
+    // 🔴 An immediate `expect(tiles).toHaveLength(3)` is what this replaces, and it
+    // was RACY, not merely redundant: the data-URI tiles resolve instantly while the
+    // unreachable host fails DNS in about as long, so the count had already dropped
+    // to 2 by the time the render settled. It failed 1-in-1 here; a slightly faster
+    // box would have made it flaky instead, which is worse. The `alt` is a fact about
+    // the render that no timing can change.
+    const { container } = await renderGallery(
+      base({
+        screenshots: [
+          { url: BROKEN_SHOT(1), caption: null },
+          { url: OK_SHOT, caption: null },
+          { url: BROKEN_SHOT(2), caption: null },
+        ],
+      })
+    );
+
+    const grid = container.querySelector(
+      '[data-testid="apps-listing-screenshot-grid"]'
+    ) as HTMLElement;
+    await vi.waitUntil(() => grid.children.length === 1, { timeout: 10000, interval: 25 });
+    await new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+
+    expect(Array.from(grid.querySelectorAll('img')).map((img) => img.getAttribute('alt'))).toEqual([
+      'My App screenshot 2',
+    ]);
+
+    const g = measure(container);
+    expectTwoTrackGrid(g);
+    expect(g.tiles).toHaveLength(1);
+    expectWidth(g.tiles[0].width, g.gridWidth);
+  });
+
+  /**
+   * The other direction of the same mismatch, and an INVARIANT GUARD rather than
+   * regression coverage — it was green before the fix too. Three go in, ONE 404s, two
+   * survive: a fill rule that keyed on anything other than the live DOM would either
+   * widen a tile that now has a partner, or leave the pair alone for the wrong reason.
+   * This is what says the rule does not over-fire.
+   */
+  test('3 screenshots, the MIDDLE one 404s — the two survivors pair up (invariant guard)', async () => {
+    const { container } = await renderGallery(
+      base({
+        screenshots: [
+          { url: OK_SHOT, caption: null },
+          { url: BROKEN_SHOT(3), caption: null },
+          { url: OK_SHOT, caption: null },
+        ],
+      })
+    );
+    const grid = container.querySelector(
+      '[data-testid="apps-listing-screenshot-grid"]'
+    ) as HTMLElement;
+    await vi.waitUntil(() => grid.children.length === 2, { timeout: 10000, interval: 25 });
+    await new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+
+    // POSITIVE CONTROL, and not a racy one — see the sibling test above. Indexes 1 and
+    // 3 with nothing between them is a string pair only a three-element map can
+    // produce, so the middle tile demonstrably rendered and then removed itself.
+    expect(Array.from(grid.querySelectorAll('img')).map((img) => img.getAttribute('alt'))).toEqual([
+      'My App screenshot 1',
+      'My App screenshot 3',
+    ]);
+
+    const g = measure(container);
+    expectTwoTrackGrid(g);
+    expect(g.tiles).toHaveLength(2);
+    expectWidth(g.tiles[0].width, halfTrack(g));
+    expectWidth(g.tiles[1].width, halfTrack(g));
+    expect(g.tiles[1].top).toBe(g.tiles[0].top);
+  });
+
+  /**
+   * 🔴 0 screenshots — INVARIANT GUARD, unchanged by this PR. The section is hidden
+   * entirely, and it must stay hidden: the brief for this change was explicitly not to
+   * invent content for a sparse listing, so a gallery that started rendering an empty
+   * full-width box would be a regression introduced BY the fix.
+   */
+  test('0 screenshots — no gallery section at all (invariant guard)', async () => {
+    const { container, within } = await renderGallery(base({ screenshots: [] }));
+    expect(container.querySelectorAll('[data-testid="apps-listing-screenshot-grid"]')).toHaveLength(
+      0
+    );
+    expect(within.getByText('Screenshots').elements()).toHaveLength(0);
+    // …and the rest of the page is still there, so this is a hidden section rather
+    // than a failed render.
+    const main = container.querySelector('[data-testid="apps-listing-main-col"]') as HTMLElement;
+    expect(main.getBoundingClientRect().width).toBeGreaterThan(400);
+  });
+
+  /**
+   * 🔴 THE SECOND MEASURED POINT — a phone, where the gallery is ONE track.
+   *
+   * This is why the rule is `grid-column: 1 / -1` and not `span 2`. Below Mantine's
+   * `sm` breakpoint `cols` is 1, and asking for a 2-track span on a 1-track grid makes
+   * the browser create an implicit second column — which would render every tile at
+   * HALF the phone's width, turning a desktop fix into a mobile defect. `1 / -1` spans
+   * "first line to last line", so on one track it is a no-op. One viewport could not
+   * have seen this; two can.
+   *
+   * 🔴 MUTATION-TESTED, not assumed. Rewriting the stylesheet's `grid-column: 1 / -1`
+   * as `grid-column: span 2` — the narrowest expression that can be wrong, with the
+   * selector and everything else untouched — leaves ALL SIX other tests in this file
+   * green and takes ONLY this one red, at `trackCount` (`expected 2 to be 1`: the
+   * implicit column really is created). So the hazard is real, this test is the only
+   * thing that sees it, and it dies for its own reason rather than to a neighbour's
+   * assertion.
+   */
+  test('390x844 — one track, and the fill rule is a no-op there', async () => {
+    await page.viewport(...NARROW);
+    const { container } = await renderGallery(
+      base({
+        screenshots: [
+          { url: OK_SHOT, caption: null },
+          { url: OK_SHOT, caption: null },
+          { url: OK_SHOT, caption: null },
+        ],
+      })
+    );
+    const g = measure(container);
+    expect(g.gridIsGrid).toBe(true);
+    expect(g.trackCount).toBe(1);
+    expect(g.tiles).toHaveLength(3);
+    // Every tile — the two that pair up on desktop AND the odd trailing one — is the
+    // full width of the single track. If `1 / -1` had been written `span 2`, the
+    // trailing tile would measure about half of this.
+    for (const tile of g.tiles) expectWidth(tile.width, g.gridWidth);
+    // …and they really are stacked, not squeezed side by side.
+    expect(g.tiles[1].top).toBeGreaterThan(g.tiles[0].top);
+    expect(g.tiles[2].top).toBeGreaterThan(g.tiles[1].top);
+  });
+});

--- a/src/components/Apps/AppListingDetailBody.module.scss
+++ b/src/components/Apps/AppListingDetailBody.module.scss
@@ -1,0 +1,35 @@
+/**
+ * App-listing detail — the SCREENSHOT GALLERY's use of the tracks it has.
+ *
+ * The gallery is a fixed two-track grid (`SimpleGrid cols={{ base: 1, sm: 2 }}`).
+ * A tile that has no partner in its row therefore occupied ONE track and left the
+ * other empty: a listing with a single screenshot rendered its only image at half
+ * the main column with dead space beside it, and so did the trailing tile of any
+ * ODD count. This rule is the whole fix — a tile that is both the LAST child and
+ * at an ODD position has nothing to sit beside, so it spans every track instead.
+ *
+ * 🔴 STRUCTURAL, NOT COUNT-AWARE, AND THAT IS THE POINT. `ScreenshotTile` returns
+ * `null` when its image 404s, so the number of tiles the browser ends up with is
+ * NOT `screenshots.length` and is not known at render time — a `cols` value
+ * computed from the array would be wrong for exactly the listings whose art is
+ * broken. `:last-child` / `:nth-child` are matched against the LIVE DOM, so when a
+ * tile removes itself the remaining ones are re-matched for free: 3 shots of which
+ * the middle one 404s leaves two tiles that correctly stay half-width, and 3 of
+ * which two 404 leaves one tile that correctly goes full-width. Pinned as measured
+ * geometry in `AppListingDetailBody.gallery.browser.test.tsx`.
+ *
+ * `1 / -1` (first line to last line), never a hard-coded `span 2`: the track count
+ * is `1` below Mantine's `sm` breakpoint and `2` above it, and `1 / -1` is the only
+ * form that is correct at both. On the one-track layout it is a no-op, which is
+ * what it should be — every tile is already full width there.
+ *
+ * The class is applied in `AppListingDetailBody.tsx`'s `ScreenshotGallery`; the
+ * pairing (rule here, class there) is pinned in the BLOCKING node project by
+ * `__tests__/appListingGalleryFill.test.ts`, because a rule nothing references and
+ * a `className` pointing at a rule that no longer exists are both silent.
+ */
+.gallery {
+  > :last-child:nth-child(odd) {
+    grid-column: 1 / -1;
+  }
+}

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -70,6 +70,7 @@ import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
 import { isMarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
 import { formatDate } from '~/utils/date-helpers';
 import detailClasses from '~/components/Model/ModelVersions/ModelVersionDetails.module.scss';
+import galleryClasses from '~/components/Apps/AppListingDetailBody.module.scss';
 import type {
   ListingDetail,
   ListingGalleryScreenshot,
@@ -408,8 +409,27 @@ function ScreenshotTile({
   );
 }
 
-/** Screenshot gallery — reuses AppDetailsModal's SimpleGrid pattern. Empty/broken
- *  URLs are skipped; the whole section is hidden when nothing remains. */
+/**
+ * Screenshot gallery — reuses AppDetailsModal's SimpleGrid pattern. Empty/broken
+ * URLs are skipped; the whole section is hidden when nothing remains.
+ *
+ * 🔴 THE GRID IS STILL TWO TRACKS; WHAT CHANGED IS WHAT AN UNPAIRED TILE DOES.
+ * A fixed `cols={{ base: 1, sm: 2 }}` gave a single-screenshot listing HALF the
+ * main column and dead space beside it, and did the same to the trailing tile of
+ * any odd count. `galleryClasses.gallery` adds one rule — a tile that is both the
+ * LAST child and at an ODD position spans `1 / -1` — so the gallery uses the width
+ * it actually has. See the stylesheet's header for why it is written as a
+ * structural CSS selector rather than a count-aware `cols` value: `ScreenshotTile`
+ * hides ITSELF on a load error, so the rendered tile count is discovered after
+ * render and any number computed from `shots.length` here would be wrong for
+ * exactly the listings with broken art.
+ *
+ * 🔴 Do not "simplify" this to `cols={shots.length === 1 ? 1 : 2}`. That reads as
+ * the same fix and is not: it fires on the ARRAY, so a 2-shot listing whose first
+ * image 404s still renders its surviving tile at half width, and it does nothing
+ * at all for the odd-trailing case. Measured, both cases, in
+ * `AppListingDetailBody.gallery.browser.test.tsx`.
+ */
 function ScreenshotGallery({
   screenshots,
   name,
@@ -422,7 +442,12 @@ function ScreenshotGallery({
   return (
     <Stack gap="xs">
       <Title order={4}>Screenshots</Title>
-      <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+      <SimpleGrid
+        cols={{ base: 1, sm: 2 }}
+        spacing="md"
+        className={galleryClasses.gallery}
+        data-testid="apps-listing-screenshot-grid"
+      >
         {shots.map((shot, i) => (
           <ScreenshotTile key={`${shot.url}-${i}`} shot={shot} name={name} index={i} />
         ))}

--- a/src/components/Apps/__tests__/appListingGalleryFill.test.ts
+++ b/src/components/Apps/__tests__/appListingGalleryFill.test.ts
@@ -1,0 +1,220 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 🔴 SEAM GATE — the screenshot gallery's "an unpaired tile fills the row" rule and
+ * the `className` that activates it must both exist, and must agree.
+ *
+ * WHY THIS IS A SEAM AND NOT TWO CHECKS. The fix is one CSS rule
+ * (`AppListingDetailBody.module.scss` → `.gallery > :last-child:nth-child(odd) {
+ * grid-column: 1 / -1 }`) plus one `className={galleryClasses.gallery}` on the
+ * gallery's `SimpleGrid`. Either half alone is INERT AND SILENT: a stylesheet whose
+ * class nothing references changes no pixels, and a `className` naming a class the
+ * stylesheet no longer declares resolves to `undefined`, renders no attribute, and
+ * throws nothing. Neither shows up as an error anywhere — the page just quietly goes
+ * back to rendering a single screenshot at half the column, which is the defect this
+ * change exists to fix. So the checkable claim is the RELATIONSHIP, and it is checked
+ * in BOTH directions.
+ *
+ * 🔴 WHY IT IS IN THE NODE `unit` PROJECT AND WHAT IT IS NOT. The real proof lives in
+ * `AppListingDetailBody.gallery.browser.test.tsx`, which renders the page in Chromium
+ * with Mantine's stylesheet loaded and MEASURES the tiles. But that file is in the
+ * browser-mode `component` project, which CI runs only as the preview pipeline's
+ * `preview / component-tests` — report-only, non-blocking, and not reported at all
+ * when the preview build fails. So the geometry claim cannot gate anything, and this
+ * file is what does. It is a SOURCE-TEXT gate, with the honesty that implies:
+ *
+ *   - CAUGHT: deleting the rule from the stylesheet; deleting the stylesheet import;
+ *     dropping `className` from the grid; renaming the class on one side only;
+ *     changing `1 / -1` to a hard-coded `span 2` (which is wrong on the one-track
+ *     mobile layout); moving the gallery to a plain `SimpleGrid` with no class.
+ *   - NOT CAUGHT: a rule that is present but overridden by later CSS, a `SimpleGrid`
+ *     replaced by something that is not `display: grid`, or any change to what the
+ *     rule renders as. Those are pixel facts and only the browser tier can see them.
+ *
+ * The repo already uses source-level unit gates for exactly this shape of invariant —
+ * see the `no raw <iframe>` gate in `appListingDetailView.test.ts` and the
+ * `AppBlockChrome is actually WIRED` block in `recentAppsRail.test.ts`.
+ */
+describe('🔴 the screenshot gallery fill rule is declared AND wired', () => {
+  const STYLES = path.resolve(__dirname, '../AppListingDetailBody.module.scss');
+  const SOURCE = path.resolve(__dirname, '../AppListingDetailBody.tsx');
+
+  /**
+   * Strip SCSS/JS comments. Load-bearing rather than tidy: BOTH files document this
+   * rule in prose that names the selector and the `1 / -1` value verbatim, so an
+   * unstripped match would be reading the DOCSTRING and would stay green with the
+   * real declaration deleted — the exact way a gate becomes decorative.
+   */
+  const stripComments = (s: string) =>
+    s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+
+  /** Collapse whitespace so the matchers below are indentation- and newline-agnostic. */
+  const norm = (s: string) => s.replace(/\s+/g, ' ');
+
+  /**
+   * The fill rule: a `>`-combined `:last-child:nth-child(odd)` whose block sets
+   * `grid-column` to `1 / -1`.
+   *
+   * 🔴 `1 / -1` IS REQUIRED, `span 2` IS NOT ACCEPTED, and that is a decision rather
+   * than pedantry. The gallery is ONE track below Mantine's `sm` breakpoint and two
+   * above it; `span 2` on the one-track layout asks for a track that does not exist,
+   * so the browser implicitly creates a second column and the tile ends up half the
+   * width of the phone. `1 / -1` is the only form correct at both track counts.
+   */
+  const FILL_RULE =
+    />\s*:last-child:nth-child\(\s*odd\s*\)\s*\{[^}]*grid-column:\s*1\s*\/\s*-1\s*;/;
+
+  /** The class must be declared as a top-level `.gallery { … }` block in the module. */
+  const CLASS_DECL = /\.gallery\s*\{/;
+
+  const WHY_STYLES =
+    'The screenshot gallery fill rule is gone from AppListingDetailBody.module.scss. ' +
+    'Without `.gallery > :last-child:nth-child(odd) { grid-column: 1 / -1 }` a listing ' +
+    'with ONE screenshot renders it at half the main column with dead space beside it, ' +
+    'and so does the trailing tile of any odd count. The rule is written as a ' +
+    'structural selector on purpose: ScreenshotTile hides itself on a load error, so ' +
+    'the rendered tile count is not screenshots.length and cannot be computed before ' +
+    'render. See the stylesheet header.';
+
+  const WHY_WIRING =
+    'AppListingDetailBody.tsx no longer applies the gallery fill class to the ' +
+    'screenshot SimpleGrid. The stylesheet rule is inert without it — nothing errors, ' +
+    'the gallery just goes back to leaving half the column empty for a single ' +
+    'screenshot. Re-add className={galleryClasses.gallery} to the grid in ' +
+    'ScreenshotGallery.';
+
+  /**
+   * The `ScreenshotGallery` function body — sliced from its declaration to the start
+   * of the next TOP-LEVEL declaration. Every other `SimpleGrid` in the file (there are
+   * none today, which is precisely why this must not rely on that staying true) is
+   * excluded, so the wiring assertion is about THIS grid and not about any grid.
+   *
+   * 🔴 THE OBVIOUS SLICER IS WRONG HERE, MEASURED RATHER THAN REASONED. "Cut at the
+   * next column-0 `}`" is the natural implementation and it truncates this function
+   * after its FIRST LINE, because a multi-line destructured signature closes with a
+   * column-0 `}` of its own (`}: {`). It returned `'function ScreenshotGallery({
+   * screenshots, name, }'` — a non-empty string, so the `!== ''` guard passed — and
+   * the wiring assertion then failed for a reason that had nothing to do with the
+   * wiring. That failure was LOUD; the mirror image would not have been. The fixture
+   * in the control below carries that exact signature shape so this cannot come back.
+   */
+  const screenshotGalleryBody = (src: string) => {
+    const start = src.indexOf('function ScreenshotGallery(');
+    if (start < 0) return '';
+    const after = src.slice(start + 1);
+    const next = after.search(/\n(?:function |const |export |\/\*\*)/);
+    return next < 0 ? src.slice(start) : src.slice(start, start + 1 + next);
+  };
+
+  it('every matcher can SEE its target and can MISS a mutated one (positive control)', () => {
+    // 🔴 Each matcher is driven through a fixture whose answer is known, in BOTH
+    // directions. A `toMatch` that can never match, or a `not.toMatch` over a regex
+    // wired to nothing, is a green that means nothing — and every assertion in this
+    // file is one of those two shapes.
+
+    // FILL_RULE sees the real shape…
+    expect(norm('.gallery { > :last-child:nth-child(odd) { grid-column: 1 / -1; } }')).toMatch(
+      FILL_RULE
+    );
+    // …tolerates the whitespace the author might use…
+    expect(norm('.g {\n  > :last-child:nth-child( odd ) {\n grid-column:1/-1;\n }\n}')).toMatch(
+      FILL_RULE
+    );
+    // …and MISSES the three mutations that would silently reinstate the defect:
+    // the rule deleted outright,
+    expect(norm('.gallery { gap: 16px; }')).not.toMatch(FILL_RULE);
+    // the selector narrowed so a lone tile (which is also `:first-child`) is the only
+    // one it catches — leaving the odd-trailing case broken,
+    expect(norm('.gallery { > :only-child { grid-column: 1 / -1; } }')).not.toMatch(FILL_RULE);
+    // and the value swapped for the track-count-dependent `span 2`.
+    expect(norm('.gallery { > :last-child:nth-child(odd) { grid-column: span 2; } }')).not.toMatch(
+      FILL_RULE
+    );
+
+    // The comment stripper must remove ENOUGH — both files' prose names the selector
+    // and the value verbatim, so this is what stops the docstring satisfying the gate…
+    const docOnly = '/* .gallery > :last-child:nth-child(odd) { grid-column: 1 / -1; } */\n';
+    expect(norm(docOnly)).toMatch(FILL_RULE);
+    expect(norm(stripComments(docOnly))).not.toMatch(FILL_RULE);
+    // …and must NOT remove too much, or every `not.toMatch` below passes vacuously
+    // against an empty string. (`stripComments = () => ''` satisfies every assertion
+    // above this line.)
+    expect(stripComments('.gallery { color: red; }')).toContain('.gallery { color: red; }');
+
+    // The body slicer really isolates a function, and returns '' rather than the whole
+    // file when the function is gone (so a rename fails LOUDLY at the assertion below
+    // instead of silently matching some other component's grid).
+    //
+    // 🔴 THE FIXTURE CARRIES THE REAL SIGNATURE SHAPE — a MULTI-LINE DESTRUCTURED
+    // parameter list whose closing `}: {` sits at column 0 — and that is the whole
+    // reason it is written this way. A slicer that cuts at "the next column-0 `}`"
+    // reads plausibly, passes a fixture with a one-line signature, and truncates the
+    // real function after its first line. Measured on this very file.
+    const fake =
+      'function Other() {\n  return <SimpleGrid className={x.gallery} />;\n}\n' +
+      'function ScreenshotGallery({\n  screenshots,\n  name,\n}: {\n' +
+      '  screenshots: S[];\n  name: string;\n}) {\n  return <SimpleGrid cols={2} />;\n}\n' +
+      'function After() {\n  return null;\n}\n';
+    expect(screenshotGalleryBody(fake)).toContain('cols={2}');
+    expect(screenshotGalleryBody(fake)).not.toContain('className={x.gallery}');
+    expect(screenshotGalleryBody(fake)).not.toContain('function After');
+    expect(screenshotGalleryBody('function Nope() {}\n')).toBe('');
+  });
+
+  it('🔴 the stylesheet declares .gallery and the unpaired-tile fill rule', () => {
+    const css = norm(stripComments(fs.readFileSync(STYLES, 'utf8')));
+    expect(css, WHY_STYLES).toMatch(CLASS_DECL);
+    expect(css, WHY_STYLES).toMatch(FILL_RULE);
+  });
+
+  it('🔴 ScreenshotGallery imports that stylesheet and applies .gallery to its grid', () => {
+    const raw = fs.readFileSync(SOURCE, 'utf8');
+    const src = stripComments(raw);
+
+    // (a) the module is imported at all, under a binding we can then look for…
+    const importMatch = src.match(
+      /import\s+(\w+)\s+from\s+'~\/components\/Apps\/AppListingDetailBody\.module\.scss'/
+    );
+    expect(importMatch, WHY_WIRING).not.toBeNull();
+    const binding = importMatch![1];
+
+    // (b) …and THAT binding's `.gallery` is applied inside ScreenshotGallery, on the
+    // same element that declares the grid. Scoped to the function body so this cannot
+    // be satisfied by an unrelated element elsewhere in the file.
+    const body = norm(screenshotGalleryBody(src));
+    expect(body, WHY_WIRING).not.toBe('');
+    expect(body, WHY_WIRING).toContain('<SimpleGrid');
+    expect(body, WHY_WIRING).toContain(`className={${binding}.gallery}`);
+  });
+
+  /**
+   * 🔴 INVARIANT GUARD, NOT REGRESSION COVERAGE — it was green before this change and
+   * could not have caught the defect. It is here because the fix's whole premise is
+   * that the tile count is a DOM fact rather than an array fact, and the single most
+   * tempting "simplification" of this change is to compute `cols` from `shots.length`.
+   * That reads as the same fix and is not: it fires on the array, so a 2-shot listing
+   * whose first image 404s still renders its survivor at half width, and it does
+   * nothing at all for the odd-trailing case (3 shots → the 3rd still gets one track).
+   */
+  it('🔴 the gallery derives no column count from the screenshot array (invariant guard)', () => {
+    // Positive control FIRST: the matcher must be able to see such a thing, or the
+    // absence assertion is a zero from a regex wired to nothing.
+    const planted = 'cols={{ base: 1, sm: shots.length === 1 ? 1 : 2 }}';
+    expect(planted).toMatch(/cols=\{[^}]*shots\b/);
+    expect(planted).toMatch(/shots\.length/);
+
+    const body = norm(screenshotGalleryBody(stripComments(fs.readFileSync(SOURCE, 'utf8'))));
+    expect(
+      body,
+      'ScreenshotGallery is computing its column count from the screenshots array. ' +
+        'ScreenshotTile hides ITSELF on a load error, so that number is not the number ' +
+        'of tiles the browser ends up with — the fill rule is a CSS structural selector ' +
+        'precisely so it does not have to know. See the stylesheet header.'
+    ).not.toMatch(/cols=\{[^}]*shots\b/);
+    // …including via a hoisted local, which the `cols={…}` shape above would miss.
+    // `shots.length` legitimately appears ONCE, in the section-hiding early return.
+    expect([...body.matchAll(/shots\.length/g)]).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## The complaint

Reviewer feedback on the redesigned store-listing detail page: *"I would love to see if I can use my screen space here a little more."* #4058 ported the model-page design language and widened the page container; the screen-space half was still outstanding, and it is visible at 1440px on two live listings:

- `cosmetic-studio` — one screenshot renders at roughly **415px inside an ~880px main column**, with dead space to its right.
- any listing with an **odd** screenshot count — the trailing tile does the same thing on its own row.

## Mechanism

`ScreenshotGallery` is a fixed two-track grid (`SimpleGrid cols={{ base: 1, sm: 2 }}`). A tile with no partner in its row occupies one track and the other track stays empty. That is the whole defect, in both of its shapes.

## The fix, and why this mechanism

One CSS rule, in a new co-located CSS module:

```scss
.gallery {
  > :last-child:nth-child(odd) {
    grid-column: 1 / -1;
  }
}
```

A tile that is both the **last** child and at an **odd** position has nothing to sit beside, so it spans every track. 1 → full width. 3 → two paired, then one full-width. 2 and 4 → unchanged.

**Why a structural CSS selector rather than a count-aware `cols`.** `ScreenshotTile` returns `null` when its image 404s, so the number of tiles the browser ends up with is **not** `screenshots.length` and is not known at render time. Anything computed before render — `cols={shots.length === 1 ? 1 : 2}` and friends — is wrong for exactly the listings whose art is broken: a 2-shot listing whose first image dangles would still render its survivor at half width, and it does nothing at all for the odd-trailing case. `:last-child` / `:nth-child` are matched against the **live DOM**, so when a tile removes itself the remaining ones are re-matched for free. Both directions of that are measured below. The node suite carries an invariant guard against the tempting "simplification" coming back.

**Why `1 / -1` rather than `span 2`.** The gallery is one track below Mantine's `sm` breakpoint and two above it. `span 2` on a one-track grid makes the browser create an implicit second column, which would render every tile at half the phone's width — a desktop fix that becomes a mobile defect. `1 / -1` is the only form correct at both track counts, and the 390px test is what pins it.

**Considered and rejected:** `repeat(auto-fit, minmax(…, 1fr))`. It fixes the 1-screenshot case (empty tracks collapse) but **not** the 3-screenshot one — track 2 is occupied in row 1, so it is never empty and the trailing tile still gets one track.

## What is deliberately NOT touched

The two columns use `order={{ sm: 2 }}` on the rail and `order={{ sm: 1 }}` on the main column, so desktop reads main-left / rail-right while **mobile deliberately stacks the rail first** — the way in should not sit below a gallery on a phone. That is documented in the source and pinned in `AppListingDetailBody.browser.test.tsx`. Neither the props, the source order, the comment, nor the guard appears anywhere in this diff, and that suite is green (67 tests).

No content is invented for sparse listings. A listing with no screenshots and a two-line description still renders a short page — that is the honest result, and the 0-screenshot case is asserted to keep the section hidden so the fix cannot introduce an empty full-width box.

## Verification

A layout fix with only prop assertions is unverified, so the load-bearing claim here is measured geometry, and the two tiers carry different halves of it.

**node `unit` — `__tests__/appListingGalleryFill.test.ts` (4 tests).** This is the blocking tier, so it holds the gate. It is a **seam** guard rather than two separate checks: either half of the change alone is inert *and silent* — a stylesheet whose class nothing references changes no pixels, and a `className` naming a class that no longer exists resolves to `undefined`, renders no attribute and throws nothing. So it asserts the relationship in both directions, plus the "no count derived from the array" invariant. Every matcher is driven through a fixture whose answer is known, in both directions, including the three mutations that would silently reinstate the defect. It is honest about being source text: it cannot see a pixel.

**browser `component` — `AppListingDetailBody.gallery.browser.test.tsx` (7 tests).** Report-only and non-blocking, which is exactly why it holds the claim the other tier structurally cannot make. It loads `@mantine/core/styles.css` (the sibling suite deliberately loads no stylesheet) and asserts measured `getBoundingClientRect()` widths, stated **relative to the gallery's own measured container width** — never a class name, a `cols` prop, or an absolute px constant.

The **2-screenshot case is the instrument control** and is asserted first: if Mantine's stylesheet failed to load, or `SimpleGrid` stopped being a grid, or the rule leaked onto tiles that *do* have a partner, those tiles would measure full width and it would go red. That is what stops the other cases passing for the wrong reason.

### Red → green, per case

The "before" column is an **isolated** mutation — `className={galleryClasses.gallery}` removed and nothing else, so the stylesheet, the testid and the import all stay put and the only variable is whether the rule applies. Grid container 949.33px in the harness, one track 466.66px.

| Case | before | after | at base |
|---|---|---|---|
| 1 screenshot | 466.66 | **949.33** | **RED** |
| 3 screenshots | 466.66 ×2 + 466.66 | 466.66 ×2 + **949.33** | **RED** |
| 3, last two 404 | 466.66 (survivor) | **949.33** | **RED** |
| 2 screenshots | 466.66 ×2 | 466.66 ×2 | green — control |
| 3, middle one 404s | 466.66 ×2 | 466.66 ×2 | green — invariant |
| 0 screenshots | no section | no section | green — invariant |
| 390×844, 3 shots | full width ×3 | full width ×3 | green — invariant |

The four green rows are what make the three red ones mean something: they say the rule fires **only** on a tile with no partner. A rule that widened everything would take the control and the middle-404 case down with it.

```
# before (className removed, nothing else)
npx vitest run --project component src/components/Apps/AppListingDetailBody.gallery.browser.test.tsx
  Tests  3 failed | 4 passed (7)
  AssertionError: expected 466.66 to be close to 949.33, received difference is 482.67

npx vitest run --project unit src/components/Apps/__tests__/appListingGalleryFill.test.ts
  Tests  1 failed | 3 passed (4)

# after
component  Tests  7 passed (7)
unit       Tests  4 passed (4)
```

### Second mutation

Rewriting the stylesheet's `grid-column: 1 / -1` as `grid-column: span 2` — the narrowest expression that can be wrong, selector untouched — leaves all six other browser tests green and takes **only** the 390×844 test red, at `trackCount` (`expected 2 to be 1`: the implicit column really is created), and takes the node stylesheet assertion red for its own reason. So that hazard is real, one viewport could not have seen it, and each guard dies for its own reason rather than to a neighbour's assertion.

### Neighbours

`AppListingDetailBody.browser.test.tsx` (67) + `AppsPageLayout.geometry.browser.test.tsx` — 74 browser tests passed together. `appListingDetailView` / `appListingDetailRows` / `appsPageWidths` + the new gate — 62 node tests passed. `pnpm typecheck`: 0 errors. ESLint and Prettier clean on all four files.

## Not in this PR

For a genuinely sparse listing — no screenshots, a two-line description — the main column is much shorter than the rail beside it. Nothing here fills it, deliberately: there is no content to invent. If that is worth addressing, the cheap non-invented option is to let the two columns' proportions respond when the main column has no gallery, rather than to add anything to the page. Happy to take that as a follow-up; it is a separate decision from this one.
