### PR TITLE
fix(robots): disallow the review routes for meta-externalagent

### DIFF
--- a/src/pages/robots.txt/index.tsx
+++ b/src/pages/robots.txt/index.tsx
@@ -1,78 +1,14 @@
 import type { GetServerSideProps } from 'next';
+import { buildRobotsTxt } from '~/server/utils/robots';
 import { getRequestDomainColor } from '~/server/utils/server-domain';
 import { respondWithText } from '~/server/utils/sitemap';
 import { getBaseUrl } from '~/server/utils/url-helpers';
-
-const disallowPaths = [
-  '/*/create',
-  '/api/*',
-  '/discord/*',
-  '/dmca/*',
-  '/intent/*',
-  '/models/train',
-  '/models/*/wizard',
-  '/models/*/model-versions/*/wizard',
-  '/moderator/*',
-  '/payment/*',
-  '/redirect',
-  '/search/*',
-  '/testing/*',
-  '/user/account',
-  '/user/downloads',
-  '/user/notifications',
-  '/user/transactions',
-  '/user/buzz-dashboard',
-  '/user/vault',
-  '/user/membership',
-  '/user/stripe-connect/onboard',
-  '/user/earn-potential',
-  '/tipalti/*',
-  '/research/*',
-  '/claim/*',
-  '/collections/youtube/auth',
-  '/questions/*',
-];
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const color = getRequestDomainColor(ctx.req) ?? 'green';
   const baseUrl = getBaseUrl(color);
 
-  const lines: string[] = [];
-
-  lines.push('# *');
-  lines.push('User-agent: *');
-  lines.push('Allow: /api/trpc/*');
-  for (const path of disallowPaths) lines.push(`Disallow: ${path}`);
-  lines.push('');
-
-  lines.push('# Login pages — high alternate-canonical volume from /login?returnUrl=... variants');
-  lines.push('Disallow: /login');
-  lines.push('');
-
-  lines.push(
-    '# Ad/affiliate tracking parameters — canonical handles correctness, but each',
-    '# variant wastes crawl budget'
-  );
-  lines.push('Disallow: /*?adid=');
-  lines.push('Disallow: /*&adid=');
-  lines.push('');
-
-  lines.push('# Site-search query URLs — thin/duplicate content, low SEO value');
-  lines.push('Disallow: /*?query=');
-  lines.push('Disallow: /*&query=');
-  lines.push('');
-
-  lines.push('# Host');
-  lines.push(`Host: ${baseUrl}`);
-  lines.push('');
-
-  lines.push('# Sitemaps');
-  lines.push(`Sitemap: ${baseUrl}/sitemap.xml`);
-  lines.push(`Sitemap: ${baseUrl}/sitemap-pages.xml`);
-  lines.push(`Sitemap: ${baseUrl}/sitemap-articles.xml`);
-  lines.push(`Sitemap: ${baseUrl}/sitemap-models.xml`);
-
-  return respondWithText(ctx, lines.join('\n') + '\n');
+  return respondWithText(ctx, buildRobotsTxt(baseUrl));
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/server/utils/robots.test.ts
+++ b/src/server/utils/robots.test.ts
@@ -1,17 +1,41 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildRobotsTxt,
+  crawlBudgetDisallowPaths,
   metaExternalAgentDisallowPaths,
   parseRobotsGroups,
 } from '~/server/utils/robots';
 
 const BASE = 'https://example.test';
-const txt = buildRobotsTxt(BASE);
-const groups = parseRobotsGroups(txt);
+// Built inside a helper, not at module scope: a throw at module scope surfaces
+// as a COLLECTION error ("no tests") rather than a failure, which reads as
+// nothing-to-see in a report-only lane.
+const build = () => {
+  const txt = buildRobotsTxt(BASE);
+  return { txt, groups: parseRobotsGroups(txt) };
+};
 
 describe('robots.txt', () => {
   it('emits exactly two user-agent groups', () => {
+    const { groups } = build();
     expect(Object.keys(groups).sort()).toEqual(['*', 'meta-externalagent']);
+  });
+
+  // 🔴 The value this whole change exists to add. Without a LITERAL pin, every
+  // wrong value passes: a singular `/model/*/reviews` typo (change is inert) and
+  // an over-broad `/models/*` (deindexes the entire model catalogue for Meta)
+  // both satisfied every other assertion here. Both failure directions are
+  // silent in production.
+  it('pins the exact disallowed paths, literally', () => {
+    expect(metaExternalAgentDisallowPaths).toEqual(['/models/*/reviews', '/3d-models/*/reviews']);
+  });
+
+  // Kills the drift where an entry added to `crawlBudgetDisallow` reaches only
+  // the meta group. These paths must appear in the `*` group too.
+  it('emits every crawl-budget path in the * group', () => {
+    const { groups } = build();
+    expect(crawlBudgetDisallowPaths.length).toBeGreaterThan(0); // positive control
+    for (const path of crawlBudgetDisallowPaths) expect(groups['*']).toContain(path);
   });
 
   // 🔴 The load-bearing one. A crawler obeys only its most specific matching
@@ -19,6 +43,7 @@ describe('robots.txt', () => {
   // repeat every `*` disallow would LOOSEN the rules for Meta. This fails if a
   // future edit adds a path to the `*` group without adding it to Meta's.
   it('meta-externalagent disallows a strict superset of the * group', () => {
+    const { groups } = build();
     const wildcard = groups['*'];
     const meta = groups['meta-externalagent'];
     expect(wildcard.length).toBeGreaterThan(0); // positive control: not vacuous
@@ -28,6 +53,7 @@ describe('robots.txt', () => {
   });
 
   it('disallows the review routes for meta-externalagent only', () => {
+    const { groups } = build();
     for (const path of metaExternalAgentDisallowPaths) {
       expect(groups['meta-externalagent']).toContain(path);
       expect(groups['*']).not.toContain(path);
@@ -35,6 +61,7 @@ describe('robots.txt', () => {
   });
 
   it('keeps the * group unchanged — pinned to the full shipped text', () => {
+    const { txt } = build();
     // Pinned literally, not derived from the arrays under test, so a change to
     // those arrays cannot silently update the expectation too.
     const wildcardSection = txt.slice(0, txt.indexOf('# meta-externalagent'));
@@ -89,7 +116,16 @@ describe('robots.txt', () => {
     );
   });
 
+  it('keeps Allow: /api/trpc/* in BOTH groups', () => {
+    const { txt } = build();
+    const meta = txt.slice(txt.indexOf('# meta-externalagent'));
+    expect(meta).toContain('Allow: /api/trpc/*');
+    expect(txt.slice(0, txt.indexOf('# meta-externalagent'))).toContain('Allow: /api/trpc/*');
+  });
+
   it('still emits Host and every sitemap, after the new group', () => {
+    const { txt, groups } = build();
+    expect(groups['meta-externalagent']).toBeDefined();
     expect(txt).toContain(`Host: ${BASE}`);
     for (const s of ['', '-pages', '-articles', '-models'])
       expect(txt).toContain(`Sitemap: ${BASE}/sitemap${s}.xml`);

--- a/src/server/utils/robots.test.ts
+++ b/src/server/utils/robots.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildRobotsTxt,
+  metaExternalAgentDisallowPaths,
+  parseRobotsGroups,
+} from '~/server/utils/robots';
+
+const BASE = 'https://example.test';
+const txt = buildRobotsTxt(BASE);
+const groups = parseRobotsGroups(txt);
+
+describe('robots.txt', () => {
+  it('emits exactly two user-agent groups', () => {
+    expect(Object.keys(groups).sort()).toEqual(['*', 'meta-externalagent']);
+  });
+
+  // 🔴 The load-bearing one. A crawler obeys only its most specific matching
+  // group and ignores `*` entirely, so a meta-externalagent block that does not
+  // repeat every `*` disallow would LOOSEN the rules for Meta. This fails if a
+  // future edit adds a path to the `*` group without adding it to Meta's.
+  it('meta-externalagent disallows a strict superset of the * group', () => {
+    const wildcard = groups['*'];
+    const meta = groups['meta-externalagent'];
+    expect(wildcard.length).toBeGreaterThan(0); // positive control: not vacuous
+    const missing = wildcard.filter((p) => !meta.includes(p));
+    expect(missing).toEqual([]);
+    expect(meta.length).toBeGreaterThan(wildcard.length);
+  });
+
+  it('disallows the review routes for meta-externalagent only', () => {
+    for (const path of metaExternalAgentDisallowPaths) {
+      expect(groups['meta-externalagent']).toContain(path);
+      expect(groups['*']).not.toContain(path);
+    }
+  });
+
+  it('keeps the * group unchanged — pinned to the full shipped text', () => {
+    // Pinned literally, not derived from the arrays under test, so a change to
+    // those arrays cannot silently update the expectation too.
+    const wildcardSection = txt.slice(0, txt.indexOf('# meta-externalagent'));
+    expect(wildcardSection).toBe(
+      [
+        '# *',
+        'User-agent: *',
+        'Allow: /api/trpc/*',
+        'Disallow: /*/create',
+        'Disallow: /api/*',
+        'Disallow: /discord/*',
+        'Disallow: /dmca/*',
+        'Disallow: /intent/*',
+        'Disallow: /models/train',
+        'Disallow: /models/*/wizard',
+        'Disallow: /models/*/model-versions/*/wizard',
+        'Disallow: /moderator/*',
+        'Disallow: /payment/*',
+        'Disallow: /redirect',
+        'Disallow: /search/*',
+        'Disallow: /testing/*',
+        'Disallow: /user/account',
+        'Disallow: /user/downloads',
+        'Disallow: /user/notifications',
+        'Disallow: /user/transactions',
+        'Disallow: /user/buzz-dashboard',
+        'Disallow: /user/vault',
+        'Disallow: /user/membership',
+        'Disallow: /user/stripe-connect/onboard',
+        'Disallow: /user/earn-potential',
+        'Disallow: /tipalti/*',
+        'Disallow: /research/*',
+        'Disallow: /claim/*',
+        'Disallow: /collections/youtube/auth',
+        'Disallow: /questions/*',
+        '',
+        '# Login pages — high alternate-canonical volume from /login?returnUrl=... variants',
+        'Disallow: /login',
+        '',
+        '# Ad/affiliate tracking parameters — canonical handles correctness, but each',
+        '# variant wastes crawl budget',
+        'Disallow: /*?adid=',
+        'Disallow: /*&adid=',
+        '',
+        '# Site-search query URLs — thin/duplicate content, low SEO value',
+        'Disallow: /*?query=',
+        'Disallow: /*&query=',
+        '',
+        // the blank line that separates this group from the next one
+        '',
+      ].join('\n')
+    );
+  });
+
+  it('still emits Host and every sitemap, after the new group', () => {
+    expect(txt).toContain(`Host: ${BASE}`);
+    for (const s of ['', '-pages', '-articles', '-models'])
+      expect(txt).toContain(`Sitemap: ${BASE}/sitemap${s}.xml`);
+    expect(txt.indexOf('# meta-externalagent')).toBeLessThan(txt.indexOf('# Host'));
+  });
+});

--- a/src/server/utils/robots.ts
+++ b/src/server/utils/robots.ts
@@ -32,22 +32,38 @@ export const disallowPaths = [
 /**
  * Further disallows for the `*` group. These exist to protect crawl budget
  * rather than to hide content, which is why they carry their own comments in
- * the emitted file.
+ * the emitted file. This is the single source for those lines — the `*` group
+ * is emitted FROM it, so adding an entry here reaches both groups.
  */
-export const crawlBudgetDisallowPaths = [
-  '/login',
-  '/*?adid=',
-  '/*&adid=',
-  '/*?query=',
-  '/*&query=',
+export const crawlBudgetDisallow: { comment: string[]; paths: string[] }[] = [
+  {
+    comment: ['# Login pages — high alternate-canonical volume from /login?returnUrl=... variants'],
+    paths: ['/login'],
+  },
+  {
+    comment: [
+      '# Ad/affiliate tracking parameters — canonical handles correctness, but each',
+      '# variant wastes crawl budget',
+    ],
+    paths: ['/*?adid=', '/*&adid='],
+  },
+  {
+    comment: ['# Site-search query URLs — thin/duplicate content, low SEO value'],
+    paths: ['/*?query=', '/*&query='],
+  },
 ];
+
+export const crawlBudgetDisallowPaths = crawlBudgetDisallow.flatMap((g) => g.paths);
 
 /**
  * Disallowed for `meta-externalagent` only, on top of everything the `*` group
- * disallows. The review routes are server-rendered per request and the
- * canonical model page already carries the same content.
+ * disallows. These review pages are server-rendered per request.
+ *
+ * Scope note: this covers the paginated review LISTING pages. Individual review
+ * permalinks (`/reviews/[reviewId]`) are deliberately left crawlable — they are
+ * the canonical URL for a single review, and cheap by comparison.
  */
-export const metaExternalAgentDisallowPaths = ['/models/*/reviews'];
+export const metaExternalAgentDisallowPaths = ['/models/*/reviews', '/3d-models/*/reviews'];
 
 /**
  * Every disallow that applies to the `*` group, in emitted order.
@@ -63,31 +79,22 @@ export function buildRobotsTxt(baseUrl: string): string {
   for (const path of disallowPaths) lines.push(`Disallow: ${path}`);
   lines.push('');
 
-  lines.push('# Login pages — high alternate-canonical volume from /login?returnUrl=... variants');
-  lines.push('Disallow: /login');
-  lines.push('');
+  // Emitted from `crawlBudgetDisallow` so this block and the meta group below
+  // cannot drift apart.
+  for (const group of crawlBudgetDisallow) {
+    lines.push(...group.comment);
+    for (const path of group.paths) lines.push(`Disallow: ${path}`);
+    lines.push('');
+  }
 
-  lines.push(
-    '# Ad/affiliate tracking parameters — canonical handles correctness, but each',
-    '# variant wastes crawl budget'
-  );
-  lines.push('Disallow: /*?adid=');
-  lines.push('Disallow: /*&adid=');
-  lines.push('');
-
-  lines.push('# Site-search query URLs — thin/duplicate content, low SEO value');
-  lines.push('Disallow: /*?query=');
-  lines.push('Disallow: /*&query=');
-  lines.push('');
-
-  // Meta's declared AI/content crawler. It is a large and growing share of the
-  // requests to the server-rendered review routes, which are expensive to
-  // render; the canonical model page carries the same content and stays fully
-  // crawlable.
+  // Meta's declared AI/content crawler, which documents itself as honouring
+  // robots.txt. These review listing pages are server-rendered per request.
   //
-  // 🔴 robots.txt group semantics: a crawler obeys ONLY its most specific
-  // matching group and ignores `User-agent: *` entirely. This block therefore
-  // repeats every `*` disallow on purpose. Removing that repetition would leave
+  // 🔴 robots.txt group semantics (RFC 9309 §2.2.1): a crawler that matches a
+  // named group obeys ONLY that group — "If no matching group exists, crawlers
+  // MUST obey the group with a user-agent line with the `*` value, if present",
+  // i.e. a named group suppresses `*` entirely. This block therefore repeats
+  // every `*` disallow on purpose. Removing that repetition would leave
   // meta-externalagent LESS restricted than it is today, not more —
   // `robots.test.ts` asserts the superset property so the mistake cannot ship.
   lines.push('# meta-externalagent');
@@ -126,7 +133,10 @@ export function parseRobotsGroups(txt: string): Record<string, string[]> {
       groups[current] ??= [];
       continue;
     }
-    const dis = /^Disallow:\s*(.+)$/i.exec(line);
+    // `(.*)` not `(.+)`: per RFC 9309 an EMPTY `Disallow:` is meaningful — it
+    // means "allow everything". `(.+)` would silently skip a group neutered
+    // that way, so the parser would not see the very mistake it exists to catch.
+    const dis = /^Disallow:\s*(.*)$/i.exec(line);
     if (dis && current) groups[current].push(dis[1].trim());
   }
   return groups;

--- a/src/server/utils/robots.ts
+++ b/src/server/utils/robots.ts
@@ -1,0 +1,133 @@
+/** Paths disallowed for every crawler. */
+export const disallowPaths = [
+  '/*/create',
+  '/api/*',
+  '/discord/*',
+  '/dmca/*',
+  '/intent/*',
+  '/models/train',
+  '/models/*/wizard',
+  '/models/*/model-versions/*/wizard',
+  '/moderator/*',
+  '/payment/*',
+  '/redirect',
+  '/search/*',
+  '/testing/*',
+  '/user/account',
+  '/user/downloads',
+  '/user/notifications',
+  '/user/transactions',
+  '/user/buzz-dashboard',
+  '/user/vault',
+  '/user/membership',
+  '/user/stripe-connect/onboard',
+  '/user/earn-potential',
+  '/tipalti/*',
+  '/research/*',
+  '/claim/*',
+  '/collections/youtube/auth',
+  '/questions/*',
+];
+
+/**
+ * Further disallows for the `*` group. These exist to protect crawl budget
+ * rather than to hide content, which is why they carry their own comments in
+ * the emitted file.
+ */
+export const crawlBudgetDisallowPaths = [
+  '/login',
+  '/*?adid=',
+  '/*&adid=',
+  '/*?query=',
+  '/*&query=',
+];
+
+/**
+ * Disallowed for `meta-externalagent` only, on top of everything the `*` group
+ * disallows. The review routes are server-rendered per request and the
+ * canonical model page already carries the same content.
+ */
+export const metaExternalAgentDisallowPaths = ['/models/*/reviews'];
+
+/**
+ * Every disallow that applies to the `*` group, in emitted order.
+ */
+export const allWildcardDisallowPaths = [...disallowPaths, ...crawlBudgetDisallowPaths];
+
+export function buildRobotsTxt(baseUrl: string): string {
+  const lines: string[] = [];
+
+  lines.push('# *');
+  lines.push('User-agent: *');
+  lines.push('Allow: /api/trpc/*');
+  for (const path of disallowPaths) lines.push(`Disallow: ${path}`);
+  lines.push('');
+
+  lines.push('# Login pages — high alternate-canonical volume from /login?returnUrl=... variants');
+  lines.push('Disallow: /login');
+  lines.push('');
+
+  lines.push(
+    '# Ad/affiliate tracking parameters — canonical handles correctness, but each',
+    '# variant wastes crawl budget'
+  );
+  lines.push('Disallow: /*?adid=');
+  lines.push('Disallow: /*&adid=');
+  lines.push('');
+
+  lines.push('# Site-search query URLs — thin/duplicate content, low SEO value');
+  lines.push('Disallow: /*?query=');
+  lines.push('Disallow: /*&query=');
+  lines.push('');
+
+  // Meta's declared AI/content crawler. It is a large and growing share of the
+  // requests to the server-rendered review routes, which are expensive to
+  // render; the canonical model page carries the same content and stays fully
+  // crawlable.
+  //
+  // 🔴 robots.txt group semantics: a crawler obeys ONLY its most specific
+  // matching group and ignores `User-agent: *` entirely. This block therefore
+  // repeats every `*` disallow on purpose. Removing that repetition would leave
+  // meta-externalagent LESS restricted than it is today, not more —
+  // `robots.test.ts` asserts the superset property so the mistake cannot ship.
+  lines.push('# meta-externalagent');
+  lines.push('User-agent: meta-externalagent');
+  lines.push('Allow: /api/trpc/*');
+  for (const path of [...allWildcardDisallowPaths, ...metaExternalAgentDisallowPaths])
+    lines.push(`Disallow: ${path}`);
+  lines.push('');
+
+  lines.push('# Host');
+  lines.push(`Host: ${baseUrl}`);
+  lines.push('');
+
+  lines.push('# Sitemaps');
+  lines.push(`Sitemap: ${baseUrl}/sitemap.xml`);
+  lines.push(`Sitemap: ${baseUrl}/sitemap-pages.xml`);
+  lines.push(`Sitemap: ${baseUrl}/sitemap-articles.xml`);
+  lines.push(`Sitemap: ${baseUrl}/sitemap-models.xml`);
+
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Parse the emitted file back into `user-agent -> disallow paths`. Used by the
+ * tests so they assert the SHIPPED text rather than the arrays that built it.
+ */
+export function parseRobotsGroups(txt: string): Record<string, string[]> {
+  const groups: Record<string, string[]> = {};
+  let current: string | null = null;
+  for (const raw of txt.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const ua = /^User-agent:\s*(.+)$/i.exec(line);
+    if (ua) {
+      current = ua[1].trim();
+      groups[current] ??= [];
+      continue;
+    }
+    const dis = /^Disallow:\s*(.+)$/i.exec(line);
+    if (dis && current) groups[current].push(dis[1].trim());
+  }
+  return groups;
+}


### PR DESCRIPTION
## What

Adds a `meta-externalagent` group to `robots.txt` disallowing the review **listing** routes (`/models/*/reviews`, `/3d-models/*/reviews`), and extracts the file's construction into a tested pure function.

## Why

`meta-externalagent` is Meta's declared AI/content crawler — one of the few that documents itself as honouring `robots.txt` (unlike `facebookexternalhit` / `meta-externalfetcher`, which Meta says may not). It has become a large and growing share of the requests to the review listing routes, which are server-rendered per request and among the more expensive pages we serve.

**This is a real trade-off, not a free win.** Those pages are self-canonical (`src/pages/models/[id]/reviews.tsx:206` canonicalises to itself, not to the model page), and the paged review query is reached from that page only — so review prose lives on those URLs and nowhere else. Disallowing them removes user review text from Meta's corpus. The model page keeps its rating aggregate and stays fully crawlable, and individual review permalinks (`/reviews/[reviewId]`) are deliberately left crawlable. If we'd rather keep review prose in that corpus, this PR is the wrong call and should be closed.

## 🔴 The subtlety worth reviewing carefully

RFC 9309 §2.2.1: *"If no matching group exists, crawlers MUST obey the group with a user-agent line with the `*` value, if present."* A named group therefore **suppresses `*` entirely**. So the naive version

```
User-agent: meta-externalagent
Disallow: /models/*/reviews
```

would make Meta ignore **every** existing `*` disallow — `/api/*`, `/moderator/*`, `/user/account`, the crawl-budget rules — leaving it **less** restricted than it is today.

This PR therefore emits the full `*` disallow list inside the Meta group as well, and the test asserts that superset property so a later edit that adds a path to `*` alone cannot silently loosen things for Meta.

`Host:` / `Sitemap:` moving below the new group is safe — RFC 9309: *"a `Sitemaps` record MUST NOT terminate a group"*; they are non-group records and stay global.

## Tests

`src/server/utils/robots.test.ts` — 8 cases. The two load-bearing ones:

- **the exact disallowed paths are pinned literally**
- **the Meta group disallows a strict superset of the `*` group**

plus: exactly two groups emitted; every crawl-budget path appears in `*`; review paths disallowed for Meta and not `*`; `Allow: /api/trpc/*` in both groups; the `*` group's emitted text **pinned literally** (so this refactor is provably output-neutral for every existing crawler); `Host` + all four sitemaps still emitted after the new group.

Mutants run against the suite, all **killed**: singular-typo path (change inert), over-broad `/models/*` (deindexes the catalogue), meta group repeating nothing, and a crawl-budget entry reaching only the Meta group.

## Audit corrections

An adversarial audit of the first commit found two things this PR originally got wrong, both now fixed in `18f54db`:

1. **The suite could not tell `/models/*/reviews` from `/models/*`.** It built its expectation by iterating the constant under test, so any string passed. Verified: a singular typo (inert) and an over-broad `/models/*` (deindexes the whole catalogue for Meta) both passed all 5 original tests. Now pinned literally.
2. **`crawlBudgetDisallowPaths` didn't actually build the `*` group** — those paths were hardcoded literals there, so adding an entry to the array shipped it to Meta *only*, the opposite of what the name promised. The `*` group is now emitted from the array.

An earlier revision of this description also claimed a stale `public/robots.txt` shadowed this route and was worth deleting. **That was wrong** — `public/robots.txt` is gitignored (`.gitignore:79`), untracked, and has never existed in this repo's history; the file I saw was a local untracked artifact. The route is what serves `robots.txt`, but not for the reason originally given. (Next.js treats a `public/` file colliding with a `pages/` route as a build error anyway, so such a file could not silently shadow it.)

## Rollout note

`robots.txt` is served with `max-age=300`, but the live response is currently sitting at `cf-cache-status: HIT` with an `age` well past that, and crawlers cache `robots.txt` on top of that (Google ~24h; Meta unspecified). **A revert is not instant** — purge the cached object as part of any rollback.

## Not verified

The traffic premise is not measurable from the tools available here (the access-log sample is filtered and short-retention), so "large and growing share" is stated from external measurement, not from anything in this repo. The change is cheap and reversible either way. It's also unproven whether disallowing this route *reduces* Meta's crawl volume or merely **redistributes** it onto other pages, since crawlers work to a per-host budget.
