### PR TITLE
fix(rewards): make a reward-config save readable to the moderator who made it

### DIFF
--- a/src/components/Rewards/RewardConfigPanel.tsx
+++ b/src/components/Rewards/RewardConfigPanel.tsx
@@ -19,6 +19,7 @@ import { PopConfirm } from '~/components/PopConfirm/PopConfirm';
 import { useUserMultipliers } from '~/components/Buzz/useBuzz';
 import type { Draft } from '~/components/Rewards/reward-config-panel.utils';
 import {
+  applySavedRewardConfig,
   buildSetInput,
   initialDrafts,
   isStaleConflict,
@@ -58,16 +59,12 @@ export function RewardConfigPanel() {
   };
 
   const setMutation = trpc.rewardConfig.set.useMutation({
-    // 🔴 Seeds from the mutation's own response instead of refetching. The
-    // switches render what the grant path RESOLVED, and that resolution is
-    // memoised per pod for a minute — but the write invalidates only the pod that
-    // served it, and production runs ~100 of them. A refetch therefore answers
-    // from a stale pod almost every time, showing the moderator their own save as
-    // if it had not happened. `set` returns the config it wrote for this reason.
     onSuccess: (saved) => {
-      setDrafts(null);
-      setConflict(null);
-      queryUtils.rewardConfig.get.setData(undefined, saved);
+      applySavedRewardConfig(saved, {
+        setDrafts,
+        setConflict,
+        cache: queryUtils.rewardConfig.get,
+      });
       showSuccessNotification({ message: 'Reward config saved.' });
     },
     onError: (saveError) => {

--- a/src/components/Rewards/RewardConfigPanel.tsx
+++ b/src/components/Rewards/RewardConfigPanel.tsx
@@ -58,10 +58,16 @@ export function RewardConfigPanel() {
   };
 
   const setMutation = trpc.rewardConfig.set.useMutation({
-    onSuccess: async () => {
+    // 🔴 Seeds from the mutation's own response instead of refetching. The
+    // switches render what the grant path RESOLVED, and that resolution is
+    // memoised per pod for a minute — but the write invalidates only the pod that
+    // served it, and production runs ~100 of them. A refetch therefore answers
+    // from a stale pod almost every time, showing the moderator their own save as
+    // if it had not happened. `set` returns the config it wrote for this reason.
+    onSuccess: (saved) => {
       setDrafts(null);
       setConflict(null);
-      await queryUtils.rewardConfig.get.invalidate();
+      queryUtils.rewardConfig.get.setData(undefined, saved);
       showSuccessNotification({ message: 'Reward config saved.' });
     },
     onError: (saveError) => {

--- a/src/components/Rewards/__tests__/reward-config-panel.utils.test.ts
+++ b/src/components/Rewards/__tests__/reward-config-panel.utils.test.ts
@@ -61,6 +61,14 @@ const untouched = () => ({
   imagePostedToModel: row(),
 });
 
+// What an untouched form now writes: every reward records its switch, and only
+// its switch.
+const allOn = () => ({
+  dailyBoost: { enabled: true },
+  goodContent: { enabled: true },
+  imagePostedToModel: { enabled: true },
+});
+
 describe('initialDrafts', () => {
   // 🔴 The malformed row is the whole reason this feature exists, and it is the
   // one where `storedOverrides` returns `{}`. Seeding the switch from that
@@ -167,8 +175,8 @@ describe('buildRewardsPayload', () => {
 
     expect(buildRewardsPayload({ rewards: REWARDS, overrides, rows })).toEqual({
       dailyBoost: { enabled: false },
-      goodContent: { awardAmount: 1 },
-      imagePostedToModel: { awardAmount: 60 },
+      goodContent: { enabled: true, awardAmount: 1 },
+      imagePostedToModel: { enabled: true, awardAmount: 60 },
     });
   });
 
@@ -188,11 +196,17 @@ describe('buildRewardsPayload', () => {
 
     expect(buildRewardsPayload({ rewards: REWARDS, overrides, rows: untouched() })).toEqual({
       futureReward: { awardAmount: 5 },
+      ...allOn(),
     });
   });
 
-  it('writes nothing for a reward left at its defaults', () => {
-    expect(buildRewardsPayload({ rewards: REWARDS, overrides: {}, rows: untouched() })).toEqual({});
+  // The amounts still follow the differs-from-the-default rule — nothing is
+  // written for an untouched award or cap — but `enabled` is recorded either way,
+  // because its default is ON and an absent entry cannot say a decision was made.
+  it('writes only the explicit on for a reward left at its defaults', () => {
+    expect(buildRewardsPayload({ rewards: REWARDS, overrides: {}, rows: untouched() })).toEqual(
+      allOn()
+    );
   });
 
   it('removes an override when its input is cleared', () => {
@@ -200,14 +214,15 @@ describe('buildRewardsPayload', () => {
     const rows = { ...untouched(), goodContent: row({ awardAmount: '', cap: '50' }) };
 
     expect(buildRewardsPayload({ rewards: REWARDS, overrides, rows })).toEqual({
-      goodContent: { cap: 50 },
+      ...allOn(),
+      goodContent: { enabled: true, cap: 50 },
     });
   });
 
   it('never writes a cap the operator typed for a reward with multiple caps', () => {
     const rows = { ...untouched(), imagePostedToModel: row({ cap: '9999' }) };
 
-    expect(buildRewardsPayload({ rewards: REWARDS, overrides: {}, rows })).toEqual({});
+    expect(buildRewardsPayload({ rewards: REWARDS, overrides: {}, rows })).toEqual(allOn());
   });
 
   // No input is rendered for that reward, so an ordinary save about something
@@ -217,20 +232,35 @@ describe('buildRewardsPayload', () => {
     const overrides = { imagePostedToModel: { cap: 5000 } };
 
     expect(buildRewardsPayload({ rewards: REWARDS, overrides, rows: untouched() })).toEqual({
-      imagePostedToModel: { cap: 5000 },
+      ...allOn(),
+      imagePostedToModel: { enabled: true, cap: 5000 },
     });
   });
 
-  it('records only the off state, never an explicit on', () => {
+  // 🔴 The defect this replaced: only the `false` was ever written, so switching a
+  // reward ON deleted its override, and with nothing else differing from the
+  // compiled defaults the reward left the payload entirely. In production that
+  // emptied the row — two rewards turned on, `{"rewards":{}}` written — and the
+  // panel then had nothing to show for the save.
+  //
+  // `enabled: true` and an absent entry resolve identically at the grant path, so
+  // this changes what is RECORDED, not what pays. That is the point: the row is
+  // the only place a decision to enable can live.
+  it('records an explicit on for a reward switched back on', () => {
+    const overrides = { dailyBoost: { enabled: false } };
     const rows = { ...untouched(), dailyBoost: row({ enabled: true }) };
 
-    expect(buildRewardsPayload({ rewards: REWARDS, overrides: {}, rows })).toEqual({});
+    const payload = buildRewardsPayload({ rewards: REWARDS, overrides, rows });
+
+    expect(payload.dailyBoost).toEqual({ enabled: true });
+    expect(Object.keys(payload)).toContain('dailyBoost');
   });
 
   it('coerces the inputs to numbers, since they are strings in the form', () => {
     const rows = { ...untouched(), goodContent: row({ awardAmount: '2', cap: '100' }) };
 
     expect(buildRewardsPayload({ rewards: REWARDS, overrides: {}, rows }).goodContent).toEqual({
+      enabled: true,
       awardAmount: 2,
       cap: 100,
     });
@@ -240,6 +270,7 @@ describe('buildRewardsPayload', () => {
     const rows = { ...untouched(), goodContent: row({ awardAmount: '0' }) };
 
     expect(buildRewardsPayload({ rewards: REWARDS, overrides: {}, rows }).goodContent).toEqual({
+      enabled: true,
       awardAmount: 0,
     });
   });
@@ -288,7 +319,8 @@ describe('buildSetInput', () => {
     const rows = { ...untouched(), goodContent: row({ awardAmount: '2' }) };
 
     expect(buildSetInput({ rewards: REWARDS, overrides: {}, rows, hash: 'h' }).rewards).toEqual({
-      goodContent: { awardAmount: 2 },
+      ...allOn(),
+      goodContent: { enabled: true, awardAmount: 2 },
     });
   });
 });

--- a/src/components/Rewards/__tests__/reward-config-panel.utils.test.ts
+++ b/src/components/Rewards/__tests__/reward-config-panel.utils.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  applySavedRewardConfig,
   buildRewardsPayload,
   buildSetInput,
   initialDrafts,
@@ -253,7 +254,6 @@ describe('buildRewardsPayload', () => {
     const payload = buildRewardsPayload({ rewards: REWARDS, overrides, rows });
 
     expect(payload.dailyBoost).toEqual({ enabled: true });
-    expect(Object.keys(payload)).toContain('dailyBoost');
   });
 
   it('coerces the inputs to numbers, since they are strings in the form', () => {
@@ -353,5 +353,37 @@ describe('the panel covers every override field', () => {
     expect([...PANEL_OVERRIDE_FIELDS].sort()).toEqual(
       Object.keys(rewardOverrideSchema.shape).sort()
     );
+  });
+});
+
+// The step the incident was about. Reverting this to a refetch typechecks, and
+// nothing else in the repo observes it: the panel has no test file, so the failure
+// mode is a moderator watching their own save do nothing.
+describe('applySavedRewardConfig', () => {
+  const panel = () => ({
+    setDrafts: vi.fn(),
+    setConflict: vi.fn(),
+    cache: { setData: vi.fn(), invalidate: vi.fn() },
+  });
+
+  it('seeds the cache from the response and never refetches', () => {
+    const saved = { stored: { value: { rewards: {} }, malformed: false, hash: 'h1' }, rewards: [] };
+    const p = panel();
+
+    applySavedRewardConfig(saved, p);
+
+    expect(p.cache.setData).toHaveBeenCalledWith(undefined, saved);
+    // The addressable half: a refetch here answers from a pod that never saw the
+    // write, which is the whole defect.
+    expect(p.cache.invalidate).not.toHaveBeenCalled();
+  });
+
+  it('clears the draft and the conflict, so the form stops reporting both', () => {
+    const p = panel();
+
+    applySavedRewardConfig({ stored: { value: {}, malformed: false, hash: '' }, rewards: [] }, p);
+
+    expect(p.setDrafts).toHaveBeenCalledWith(null);
+    expect(p.setConflict).toHaveBeenCalledWith(null);
   });
 });

--- a/src/components/Rewards/reward-config-panel.utils.ts
+++ b/src/components/Rewards/reward-config-panel.utils.ts
@@ -130,10 +130,20 @@ export function buildRewardsPayload({
       );
 
     const entry: StoredOverride = {};
+    // 🔴 `enabled` is written either way, and is the one field that does not
+    // follow the differs-from-the-default rule below.
+    //
+    // Its compiled default is ON and there is no compiled OFF, so "no entry" and
+    // "an operator turned this on" are the same row. Writing only the `false`
+    // meant switching a reward on DELETED its override — and if nothing else on
+    // that reward differed from its defaults, dropped the reward from the payload
+    // entirely, leaving no record that anyone decided anything. Two rewards
+    // turned on that way emptied the row in production and read back as a save
+    // that never happened.
+    entry.enabled = row.enabled;
     // Only what DIFFERS from the compiled default is stored, so a later change to
     // that default flows through instead of being frozen behind an override
     // written months earlier. An empty input therefore removes the override.
-    if (!row.enabled) entry.enabled = false;
     if (row.awardAmount !== '') entry.awardAmount = Number(row.awardAmount);
 
     if (reward.capOverridable) {

--- a/src/components/Rewards/reward-config-panel.utils.ts
+++ b/src/components/Rewards/reward-config-panel.utils.ts
@@ -190,6 +190,33 @@ export function buildSetInput({
 }
 
 /**
+ * What a successful save does with its own response, extracted so the step the
+ * incident was actually about is not the one untested step in the panel.
+ *
+ * 🔴 Seeds the cache from the response instead of invalidating it. The switches
+ * render what the grant path RESOLVED, and that resolution is memoised per pod for
+ * a minute while a write invalidates only the pod that served it — so on ~100 pods
+ * a refetch here answers from a stale pod almost every time and shows the operator
+ * their own save as if it had not happened.
+ *
+ * `invalidate` is taken as a parameter it never calls, so a test can assert it was
+ * not called: a refetch reintroduced here is otherwise invisible to everything
+ * except a moderator watching their save do nothing.
+ */
+export function applySavedRewardConfig<T>(
+  saved: T,
+  panel: {
+    setDrafts: (drafts: null) => void;
+    setConflict: (conflict: null) => void;
+    cache: { setData: (input: undefined, value: T) => void; invalidate: () => unknown };
+  }
+) {
+  panel.setDrafts(null);
+  panel.setConflict(null);
+  panel.cache.setData(undefined, saved);
+}
+
+/**
  * The panel renders one input per field here. Driving it off the server's list
  * means a field added to `rewardOverrideSchema` and not to the panel fails a
  * test rather than being silently deleted from the row on the next save.

--- a/src/pages/api/testing/rewards-config.ts
+++ b/src/pages/api/testing/rewards-config.ts
@@ -14,18 +14,29 @@
  * — any override field that was refused for being out of bounds or the wrong
  * type.
  *
- * Read-only. It resolves through the same `resolveRewardConfig` the grant path
- * uses, including its cache, so a change written in the last minute may not
- * appear yet.
+ * Read-only. It applies the same resolution rules the grant path applies, but
+ * reads the row itself from the primary rather than through the grant path's
+ * per-pod memo: this is the endpoint an operator reaches for when the panel
+ * looks wrong, and a minute-old answer here is the same lie one layer down.
  */
 
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as rewardImports from '~/server/rewards';
-import { MAX_AWARD_AMOUNT, MAX_CAP, REWARD_CONFIG_KEY } from '~/server/rewards/reward-config';
+import {
+  configFromStoredValue,
+  getStoredRewardConfig,
+  MAX_AWARD_AMOUNT,
+  MAX_CAP,
+  REWARD_CONFIG_KEY,
+} from '~/server/rewards/reward-config';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 
 export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApiResponse) {
-  const rewards = await Promise.all(Object.values(rewardImports).map((x) => x.describeConfig()));
+  const stored = await getStoredRewardConfig();
+  const config = configFromStoredValue(stored.value);
+  const rewards = await Promise.all(
+    Object.values(rewardImports).map((x) => x.describeConfig(config))
+  );
 
   return res.status(200).json({
     key: REWARD_CONFIG_KEY,

--- a/src/pages/api/testing/rewards-config.ts
+++ b/src/pages/api/testing/rewards-config.ts
@@ -21,7 +21,7 @@
  */
 
 import type { NextApiRequest, NextApiResponse } from 'next';
-import * as rewardImports from '~/server/rewards';
+import { describeRewards } from '~/server/rewards/describe-rewards';
 import {
   configFromStoredValue,
   getStoredRewardConfig,
@@ -33,14 +33,10 @@ import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 
 export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApiResponse) {
   const stored = await getStoredRewardConfig();
-  const config = configFromStoredValue(stored.value);
-  const rewards = await Promise.all(
-    Object.values(rewardImports).map((x) => x.describeConfig(config))
-  );
 
   return res.status(200).json({
     key: REWARD_CONFIG_KEY,
     bounds: { awardAmount: [0, MAX_AWARD_AMOUNT], cap: [0, MAX_CAP] },
-    rewards: rewards.sort((a, b) => a.type.localeCompare(b.type)),
+    rewards: await describeRewards(configFromStoredValue(stored.value)),
   });
 });

--- a/src/server/rewards/__tests__/base.reward.config.test.ts
+++ b/src/server/rewards/__tests__/base.reward.config.test.ts
@@ -51,7 +51,7 @@ vi.mock('~/server/services/buzz.service', () => ({
 import { createBuzzEvent, ON_DEMAND_REWARD_SCRIPT } from '~/server/rewards/base.reward';
 import type { BuzzEventLog } from '~/server/rewards/base.reward';
 import { goodContentReward } from '~/server/rewards/passive/goodContent.reward';
-import { invalidateRewardConfigCache } from '~/server/rewards/reward-config';
+import { configFromStoredValue, invalidateRewardConfigCache } from '~/server/rewards/reward-config';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
 
@@ -61,6 +61,11 @@ redisMock.redis.hGet.mockImplementation((...args: any[]) => h.hGetImpl(...args))
 const findUnique = dbMock.dbRead.keyValue.findUnique;
 const configure = (rewards: Record<string, unknown>) =>
   findUnique.mockResolvedValue({ value: { rewards } });
+
+// `describeConfig` is handed the config rather than reading one, so the operator
+// views cannot pick up the grant path's per-pod memo. Resolves the same row
+// `configure` stores, through the same parser the grant path uses.
+const storedConfig = (rewards: Record<string, unknown>) => configFromStoredValue({ rewards });
 
 const AWARD_AMOUNT = 100;
 const CAP = 1000;
@@ -409,9 +414,9 @@ describe('a multi-entry cap table refuses the override', () => {
   // `capOverridable` is the only thing standing between an operator raising the
   // monthly cap and silently raising the per-entity one by the same number.
   it('leaves both caps at their compiled amounts', async () => {
-    configure({ testTwoCapReward: { cap: 5000 } });
-
-    const described = await twoCapReward().describeConfig();
+    const described = await twoCapReward().describeConfig(
+      storedConfig({ testTwoCapReward: { cap: 5000 } })
+    );
 
     expect(described.capOverridable).toBe(false);
     expect(described.effective.cap).toBeUndefined();
@@ -574,9 +579,11 @@ describe('the on-demand Lua keeps the properties the model assumes', () => {
 
 describe('describeConfig() answers "which rewards are on" from one place', () => {
   it('reports the default beside the effective value and names refused fields', async () => {
-    configure({ testProcessableReward: { enabled: false, awardAmount: 999999 } });
+    const config = storedConfig({
+      testProcessableReward: { enabled: false, awardAmount: 999999 },
+    });
 
-    expect(await processableReward().describeConfig()).toMatchObject({
+    expect(await processableReward().describeConfig(config)).toMatchObject({
       type: 'testProcessableReward',
       defaults: { awardAmount: AWARD_AMOUNT, cap: CAP },
       effective: { enabled: false, awardAmount: AWARD_AMOUNT, cap: CAP },

--- a/src/server/rewards/__tests__/reward-config.test.ts
+++ b/src/server/rewards/__tests__/reward-config.test.ts
@@ -23,6 +23,26 @@ import { buildRewardsPayload } from '~/components/Rewards/reward-config-panel.ut
 // here instead of passing on a coincidence.
 const DEFAULTS = { awardAmount: 10, cap: 30, capOverridable: true } as const;
 
+// 🔴 Models the jsonb round trip, which is where the hash bug lived. `KeyValue.value`
+// is jsonb: Postgres canonicalises key order (shortest key first, then bytewise) and
+// hands back a DIFFERENT insertion order than the one written, while
+// `rewardConfigHash` is `JSON.stringify` and is insertion-ordered. A fake that echoes
+// the object it was given makes the write and the read agree by construction — and a
+// test standing on that fake passes for code that hands the operator a hash for a row
+// that does not exist. Reversing the key order is enough: any reordering breaks a
+// stringify-based hash. Postgres's own rule is used rather than any reordering,
+// because it is IDEMPOTENT — reading a row twice must give the same order, and a fake
+// that merely flips the order gives back the original on the second pass.
+const asJsonb = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(asJsonb);
+  if (value === null || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.length - b.length || (a < b ? -1 : a > b ? 1 : 0))
+      .map(([key, entry]) => [key, asJsonb(entry)])
+  );
+};
+
 const findUnique = dbMock.dbRead.keyValue.findUnique;
 const findUniqueWrite = dbMock.dbWrite.keyValue.findUnique;
 // The hot read path (`resolveRewardConfig`) uses the replica; the version guard
@@ -40,6 +60,10 @@ beforeEach(() => {
   invalidateRewardConfigCache();
   findUnique.mockResolvedValue(null);
   findUniqueWrite.mockResolvedValue(null);
+  dbMock.dbWrite.keyValue.upsert.mockImplementation(async ({ update }: any) => ({
+    key: REWARD_CONFIG_KEY,
+    value: asJsonb(update.value),
+  }));
 });
 
 afterEach(() => {
@@ -766,14 +790,34 @@ describe('the hash a save hands back', () => {
       setRewardConfig({ rewards: { testReward: { enabled: true } } }, 1, { expectedHash: after })
     ).resolves.toBeDefined();
   });
+
+  // 🔴 The hash has to describe the row POSTGRES holds, not the object we sent it.
+  // `value` is jsonb and reorders keys; `rewardConfigHash` is `JSON.stringify` and
+  // does not. Hashing the in-memory object hands the panel a token for a row that
+  // never existed, and the moderator's NEXT save is refused as somebody else's edit
+  // — on a screen with one person in front of it, every time, forever.
+  it('describes the row as Postgres stored it, not the object it was sent', async () => {
+    storedConfig({ rewards: {} });
+    const row = { rewards: { testReward: { enabled: false, awardAmount: 4, cap: 8 } } };
+
+    const handedToTheClient = storedViewOf(await setRewardConfig(row, 1)).hash;
+
+    // What any later reader — including the guard itself — computes for that row.
+    findUniqueWrite.mockResolvedValue({ value: asJsonb(row) });
+    expect((await getStoredRewardConfig()).hash).toBe(handedToTheClient);
+  });
 });
 
 // The 60s per-pod memo is correct for the grant path — it runs on every reward
 // grant — and wrong for a moderator's screen, which is why the operator views
 // resolve a config they read themselves. Someone reading only the incident could
 // reasonably conclude "the cache was the bug" and delete it; the first assertion
-// here is what stops that, and the second is what would fail if the operator view
-// ever picked it up again.
+// here is what stops that.
+//
+// ⚠️ The second assertion is NOT the other half. It calls the resolver directly and
+// stays green for a router that goes back to the memo — what catches that is
+// `reward-config.router.test.ts`'s "resolves the rewards from the row it just read".
+// Kept only to show the two answers diverging at the same instant.
 describe('the grant path keeps its cache while the operator view reads through', () => {
   it('serves the memoised answer to a grant while a fresh read already sees the change', async () => {
     storedConfig({ rewards: { testReward: { enabled: false } } });

--- a/src/server/rewards/__tests__/reward-config.test.ts
+++ b/src/server/rewards/__tests__/reward-config.test.ts
@@ -3,15 +3,19 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
 import { loggingMock } from '~/__tests__/mocks/logging.mock';
 import { REWARD_CONFIG_CONFLICT } from '~/shared/constants/reward-config.constants';
 import {
+  configFromStoredValue,
   getStoredRewardConfig,
   invalidateRewardConfigCache,
   MAX_AWARD_AMOUNT,
   MAX_CAP,
+  resolveFromConfig,
   resolveRewardConfig,
   REWARD_CONFIG_KEY,
   rewardOverrideSchema,
   setRewardConfig,
+  storedViewOf,
 } from '~/server/rewards/reward-config';
+import { buildRewardsPayload } from '~/components/Rewards/reward-config-panel.utils';
 
 // The compiled definition's values. Every fallback below asserts against THIS
 // object rather than a repeated literal, so a fallback that lands on some other
@@ -676,5 +680,110 @@ describe('getStoredRewardConfig', () => {
     await getStoredRewardConfig();
 
     expect(findUniqueWrite).toHaveBeenCalledTimes(2);
+  });
+});
+
+// The panel builds the row and the grant path reads it, and nothing else sits
+// between them. Driving the REAL builder into the REAL writer and out through the
+// REAL resolver is the only place the two halves are checked against each other —
+// each half's own tests pass with the row shape they happen to agree on.
+describe('the round trip a moderator makes', () => {
+  const panelRow = {
+    type: 'testReward',
+    capOverridable: true,
+    defaults: { awardAmount: DEFAULTS.awardAmount, cap: DEFAULTS.cap },
+    effective: { enabled: false, awardAmount: DEFAULTS.awardAmount, cap: DEFAULTS.cap },
+  };
+
+  it('switches a stored-off reward on, and the row still names it', async () => {
+    storedConfig({ rewards: { testReward: { enabled: false } } });
+    expect((await resolve()).enabled).toBe(false);
+
+    const payload = buildRewardsPayload({
+      rewards: [panelRow],
+      overrides: { testReward: { enabled: false } },
+      rows: { testReward: { enabled: true, awardAmount: '', cap: '' } },
+    });
+
+    // 🔴 This assertion, not the one below it, is what catches the defect.
+    //
+    // An absent entry resolves to enabled exactly as `{enabled:true}` does, so a
+    // builder that DROPS the reward on the way in still ends this test with the
+    // reward paying. That is precisely why the production bug was invisible: the
+    // row emptied itself and everything kept working, with nothing left to show
+    // an operator that they had decided anything.
+    expect(payload.testReward).toEqual({ enabled: true });
+
+    const written = await setRewardConfig({ rewards: payload }, 1);
+    invalidateRewardConfigCache();
+    storedConfig(written);
+
+    expect(await resolve()).toMatchObject({
+      enabled: true,
+      awardAmount: DEFAULTS.awardAmount,
+      cap: DEFAULTS.cap,
+    });
+  });
+
+  it('turns it back off through the same path', async () => {
+    storedConfig({ rewards: { testReward: { enabled: true } } });
+
+    const payload = buildRewardsPayload({
+      rewards: [{ ...panelRow, effective: { ...panelRow.effective, enabled: true } }],
+      overrides: { testReward: { enabled: true } },
+      rows: { testReward: { enabled: false, awardAmount: '', cap: '' } },
+    });
+
+    const written = await setRewardConfig({ rewards: payload }, 1);
+    invalidateRewardConfigCache();
+    storedConfig(written);
+
+    expect((await resolve()).enabled).toBe(false);
+  });
+});
+
+// The panel sends the hash it was last given as `expectedHash`. A writer that
+// hands back the hash it LOADED describes a row that no longer exists, and the
+// caller's next save is refused as somebody else's edit — a conflict dialog on a
+// screen with one person in front of it.
+describe('the hash a save hands back', () => {
+  it('is accepted by the next save, while the pre-write hash is refused', async () => {
+    storedConfig({ rewards: {} });
+    const before = (await getStoredRewardConfig()).hash;
+
+    const written = await setRewardConfig({ rewards: { testReward: { enabled: false } } }, 1);
+    const after = storedViewOf(written).hash;
+    // The row that is now on disk, for both attempts below.
+    findUniqueWrite.mockResolvedValue({ value: written });
+
+    // The control: without it this passes for a writer that returns a hash the
+    // guard ignores entirely.
+    await expect(setRewardConfig({ rewards: {} }, 1, { expectedHash: before })).rejects.toThrow(
+      REWARD_CONFIG_CONFLICT.stale
+    );
+
+    await expect(
+      setRewardConfig({ rewards: { testReward: { enabled: true } } }, 1, { expectedHash: after })
+    ).resolves.toBeDefined();
+  });
+});
+
+// The 60s per-pod memo is correct for the grant path — it runs on every reward
+// grant — and wrong for a moderator's screen, which is why the operator views
+// resolve a config they read themselves. Someone reading only the incident could
+// reasonably conclude "the cache was the bug" and delete it; the first assertion
+// here is what stops that, and the second is what would fail if the operator view
+// ever picked it up again.
+describe('the grant path keeps its cache while the operator view reads through', () => {
+  it('serves the memoised answer to a grant while a fresh read already sees the change', async () => {
+    storedConfig({ rewards: { testReward: { enabled: false } } });
+    expect((await resolve()).enabled).toBe(false);
+
+    storedConfig({ rewards: { testReward: { enabled: true } } });
+
+    expect((await resolve()).enabled).toBe(false);
+
+    const fresh = configFromStoredValue((await getStoredRewardConfig()).value);
+    expect(resolveFromConfig(fresh, 'testReward', DEFAULTS).enabled).toBe(true);
   });
 });

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -108,8 +108,12 @@ export function createBuzzEvent<T>({
   const defaultCap =
     'cap' in buzzEvent ? buzzEvent.cap : capEntries.length === 1 ? capEntries[0].amount : undefined;
 
-  const resolveConfig = () =>
-    resolveRewardConfig(type, { awardAmount, cap: defaultCap, capOverridable });
+  // One literal for both readers. `resolveConfig` is what pays and `describeConfig`
+  // is what the operator is shown; a field added to one and not the other is the
+  // drift this whole design exists to prevent, and TypeScript only catches it for
+  // a required field.
+  const configDefaults = { awardAmount, cap: defaultCap, capOverridable };
+  const resolveConfig = () => resolveRewardConfig(type, configDefaults);
 
   const getUserRewardDetails = async (userId: number) => {
     const config = await resolveConfig();
@@ -526,11 +530,7 @@ export function createBuzzEvent<T>({
    * signature exists to make unrepresentable. Callers read the row themselves.
    */
   const describeConfig = async (config: RewardConfig) => {
-    const resolved = resolveFromConfig(config, type, {
-      awardAmount,
-      cap: defaultCap,
-      capOverridable,
-    });
+    const resolved = resolveFromConfig(config, type, configDefaults);
     return {
       type,
       visible,

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -13,8 +13,8 @@ import { redis, REDIS_KEYS } from '~/server/redis/client';
 import type { BuzzAccountType, BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 import { createBuzzTransactionMany, getMultipliersForUser } from '~/server/services/buzz.service';
-import type { ResolvedRewardConfig } from '~/server/rewards/reward-config';
-import { resolveRewardConfig } from '~/server/rewards/reward-config';
+import type { ResolvedRewardConfig, RewardConfig } from '~/server/rewards/reward-config';
+import { resolveFromConfig, resolveRewardConfig } from '~/server/rewards/reward-config';
 import { hashifyObject } from '~/utils/string-helpers';
 import { isClickHouseConnectionError, withRetries } from '../utils/errorHandling';
 
@@ -516,19 +516,33 @@ export function createBuzzEvent<T>({
 
   /**
    * The operator's answer to "which rewards are on, and at what amounts?".
-   * Resolves through the same `resolveConfig` the grant path uses, so what it
-   * reports and what gets paid cannot drift.
+   * Resolves through the same rules the grant path uses, so what it reports and
+   * what gets paid cannot drift.
+   *
+   * 🔴 Takes the stored config rather than reading it, and the argument is
+   * required on purpose. The grant path's `resolveConfig` memoises per pod for a
+   * minute; an operator view that quietly picked that up would report a
+   * minute-old answer on whichever pod served it, which is the state this
+   * signature exists to make unrepresentable. Callers read the row themselves.
    */
-  const describeConfig = async () => {
-    const config = await resolveConfig();
+  const describeConfig = async (config: RewardConfig) => {
+    const resolved = resolveFromConfig(config, type, {
+      awardAmount,
+      cap: defaultCap,
+      capOverridable,
+    });
     return {
       type,
       visible,
       onDemand: isOnDemand,
       capOverridable,
       defaults: { awardAmount, cap: defaultCap },
-      effective: { enabled: config.enabled, awardAmount: config.awardAmount, cap: config.cap },
-      rejected: config.rejected,
+      effective: {
+        enabled: resolved.enabled,
+        awardAmount: resolved.awardAmount,
+        cap: resolved.cap,
+      },
+      rejected: resolved.rejected,
     };
   };
 

--- a/src/server/rewards/describe-rewards.ts
+++ b/src/server/rewards/describe-rewards.ts
@@ -1,0 +1,24 @@
+import * as rewardImports from '~/server/rewards';
+import type { RewardConfig } from '~/server/rewards/reward-config';
+
+/**
+ * Every reward described against one config, for the two operator surfaces that
+ * answer "which rewards are on, and at what amounts?" — the moderator panel and
+ * the debug endpoint. Shared because the endpoint is the thing an operator
+ * reaches for when they doubt the panel, so a field added to one view and not the
+ * other diverges exactly during the debugging session that compares them.
+ *
+ * 🔴 Resolves against a config the CALLER read. `resolveRewardConfig` memoises per
+ * pod for `CONFIG_TTL_MS`, which is right for the grant path and wrong here: only
+ * the pod that served a write clears it, and production runs ~100 pods, so a
+ * moderator reading back their own save answers from a stale pod almost every
+ * time.
+ *
+ * Lives outside `reward-config.ts` because it imports the reward definitions,
+ * which import `reward-config.ts`.
+ */
+export async function describeRewards(config: RewardConfig) {
+  return (
+    await Promise.all(Object.values(rewardImports).map((x) => x.describeConfig(config)))
+  ).sort((a, b) => a.type.localeCompare(b.type));
+}

--- a/src/server/rewards/reward-config.ts
+++ b/src/server/rewards/reward-config.ts
@@ -372,7 +372,7 @@ export async function setRewardConfig(
   config: z.infer<typeof rewardConfigSchema>,
   userId: number,
   { expectedHash, force = false }: { expectedHash?: string; force?: boolean } = {}
-) {
+): Promise<unknown> {
   const value = storedRewardConfigSchema.parse(config);
 
   // The primary, for the reason given on `getStoredRewardConfig`: a guard that
@@ -395,7 +395,17 @@ export async function setRewardConfig(
   if (expectedHash !== undefined && expectedHash !== rewardConfigHash(previous))
     throw throwConflictError(REWARD_CONFIG_CONFLICT.stale);
 
-  await dbWrite.keyValue.upsert({
+  // 🔴 Returns the row as POSTGRES stored it, not the object we sent.
+  //
+  // `value` is jsonb, which canonicalises key order (by length, then bytes) while
+  // `rewardConfigHash` is `JSON.stringify`, which is insertion-ordered. A hash
+  // taken from the in-memory object therefore describes a row that does not exist
+  // — the caller sends it back as `expectedHash` on their next save, the guard
+  // compares it against a hash of the row read back through jsonb, and refuses a
+  // lone moderator's second consecutive save as somebody else's edit. Verified on
+  // prod: `'{"enabled":true,"awardAmount":5,"cap":9}'::jsonb::text` returns
+  // `{"cap": 9, "enabled": true, "awardAmount": 5}`.
+  const written = await dbWrite.keyValue.upsert({
     where: { key: REWARD_CONFIG_KEY },
     create: { key: REWARD_CONFIG_KEY, value },
     update: { value },
@@ -411,15 +421,19 @@ export async function setRewardConfig(
     message: 'Reward config updated',
     userId,
     previous: JSON.stringify(previous ?? null),
-    value: JSON.stringify(value),
+    value: JSON.stringify(written.value),
   }).catch(() => null);
 
   invalidateRewardConfigCache();
   // Seed the fallback from what was just written. Clearing it and leaving it null
   // means a failed read on this pod moments later falls back to compiled defaults
   // — re-enabling the very reward this call just turned off.
-  lastGoodConfig = buildConfig(value.rewards ?? {});
-  return value;
+  // Through the same parser every other reader uses. `buildConfig` starts after the
+  // envelope, so the two agree only because `value` just came out of the schema —
+  // and a change to either salvage rule would have this pod's failure fallback
+  // built by different code from the same bytes than the config it just showed.
+  lastGoodConfig = configFromStoredValue(written.value);
+  return written.value;
 }
 
 /**

--- a/src/server/rewards/reward-config.ts
+++ b/src/server/rewards/reward-config.ts
@@ -200,9 +200,12 @@ function buildConfig(rewards: Record<string, unknown>): RewardConfig {
 // NOT strict, and that is the fix rather than an oversight — see `loadConfig`.
 const envelopeSchema = z.object({ rewards: z.record(z.string(), z.unknown()).optional() });
 
-async function loadConfig(): Promise<RewardConfig> {
-  const row = await dbRead.keyValue.findUnique({ where: { key: REWARD_CONFIG_KEY } });
-  const stored = row?.value ?? {};
+/**
+ * The resolution the grant path performs on a stored row, without reading one.
+ * Shared so an operator-facing view resolves a row exactly as the grant path
+ * would rather than re-implementing the salvage rules beside it.
+ */
+export function configFromStoredValue(stored: unknown): RewardConfig {
   const envelope = envelopeSchema.safeParse(stored);
 
   if (!envelope.success) {
@@ -243,6 +246,11 @@ async function loadConfig(): Promise<RewardConfig> {
     );
 
   return buildConfig(envelope.data.rewards ?? {});
+}
+
+async function loadConfig(): Promise<RewardConfig> {
+  const row = await dbRead.keyValue.findUnique({ where: { key: REWARD_CONFIG_KEY } });
+  return configFromStoredValue(row?.value ?? {});
 }
 
 // Cache the parsed config, not the resolved decision: `resolveRewardConfig`
@@ -310,7 +318,18 @@ export async function getStoredRewardConfig(): Promise<StoredRewardConfig> {
   // the guard passes on save because both sides came from the same stale read.
   // No concurrency window is required — only that the LOAD fell inside one.
   const row = await dbWrite.keyValue.findUnique({ where: { key: REWARD_CONFIG_KEY } });
-  const value = row?.value ?? {};
+  return storedViewOf(row?.value ?? {});
+}
+
+/**
+ * The `StoredRewardConfig` for a row value already in hand.
+ *
+ * 🔴 `hash` is what the next save sends back as `expectedHash`. A writer that
+ * returns the hash it LOADED rather than the hash of what it just wrote hands
+ * the caller a token for a row that no longer exists, and the caller's next save
+ * is refused as someone else's edit.
+ */
+export function storedViewOf(value: unknown): StoredRewardConfig {
   return {
     value,
     malformed: !storedRewardConfigSchema.safeParse(value).success,
@@ -412,7 +431,21 @@ export async function resolveRewardConfig(
   type: string,
   defaults: RewardDefaults
 ): Promise<ResolvedRewardConfig> {
-  const entry = (await getRewardConfig())[type];
+  return resolveFromConfig(await getRewardConfig(), type, defaults);
+}
+
+/**
+ * The same resolution against a config the caller already holds. An
+ * operator-facing view reads the row itself — uncached, from the primary — and
+ * resolves it through this, so what it shows and what the grant path would pay
+ * cannot drift into two implementations.
+ */
+export function resolveFromConfig(
+  config: RewardConfig,
+  type: string,
+  defaults: RewardDefaults
+): ResolvedRewardConfig {
+  const entry = config[type];
   const override = entry?.override ?? {};
   const rejected = [...(entry?.rejected ?? [])];
 

--- a/src/server/routers/__tests__/reward-config.router.test.ts
+++ b/src/server/routers/__tests__/reward-config.router.test.ts
@@ -112,7 +112,11 @@ describe('rewardConfig.get', () => {
 
     const result = await caller.get();
 
-    expect(result.stored).toMatchObject({ value: { rewards: {} }, malformed: false });
+    // Every field, `hash` included: it is the token the panel hands back as
+    // `expectedHash`, so a `get` returning a hash that is not the row's makes the
+    // guard refuse every save as somebody else's edit, on a screen with one person
+    // in front of it. `toMatchObject` here passed for a `get` returning `hash: ''`.
+    expect(result.stored).toEqual({ value: { rewards: {} }, malformed: false, hash: 'h0' });
     expect(result.rewards).toHaveLength(1);
     expect(result.rewards[0]).toMatchObject({ type: 'testReward', rejected: [] });
   });

--- a/src/server/routers/__tests__/reward-config.router.test.ts
+++ b/src/server/routers/__tests__/reward-config.router.test.ts
@@ -10,18 +10,30 @@ import type * as RewardConfig from '~/server/rewards/reward-config';
  * procedures were declared.
  */
 
+const storedView = (value: unknown) => ({ value, malformed: false, hash: 'hash-of-loaded-row' });
+
 const { mockGetStored, mockSetConfig, mockDescribeConfig } = vi.hoisted(() => ({
-  mockGetStored: vi.fn(async () => ({ rewards: {} })),
+  mockGetStored: vi.fn(async () => ({ value: { rewards: {} }, malformed: false, hash: 'h0' })),
   mockSetConfig: vi.fn(async (config: unknown) => config),
-  mockDescribeConfig: vi.fn(async () => ({
-    type: 'testReward',
-    visible: true,
-    onDemand: true,
-    capOverridable: true,
-    defaults: { awardAmount: 10, cap: 30 },
-    effective: { enabled: true, awardAmount: 10, cap: 30 },
-    rejected: [] as string[],
-  })),
+  // Reads the switch out of the config it is HANDED, so an assertion about what
+  // the router reports is an assertion about which config it passed down. A stub
+  // returning a fixed row would pass for a router that resolved from anything at
+  // all, including the per-pod memo this design exists to keep out.
+  mockDescribeConfig: vi.fn(
+    async (config: Record<string, { override?: { enabled?: boolean } }>) => ({
+      type: 'testReward',
+      visible: true,
+      onDemand: true,
+      capOverridable: true,
+      defaults: { awardAmount: 10, cap: 30 },
+      effective: {
+        enabled: config?.testReward?.override?.enabled ?? true,
+        awardAmount: 10,
+        cap: 30,
+      },
+      rejected: [] as string[],
+    })
+  ),
 }));
 
 vi.mock('~/server/rewards/reward-config', async (importOriginal) => ({
@@ -35,6 +47,7 @@ vi.mock('~/server/rewards', () => ({
 }));
 
 import { rewardConfigRouter } from '~/server/routers/reward-config.router';
+import { storedViewOf } from '~/server/rewards/reward-config';
 
 function fakeCtx(user: unknown) {
   return {
@@ -55,6 +68,7 @@ const user = { id: 2, isModerator: false, tier: 'free', username: 'user', onboar
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockGetStored.mockResolvedValue({ value: { rewards: {} }, malformed: false, hash: 'h0' });
 });
 
 describe('rewardConfig router authz', () => {
@@ -98,9 +112,27 @@ describe('rewardConfig.get', () => {
 
     const result = await caller.get();
 
-    expect(result.stored).toEqual({ rewards: {} });
+    expect(result.stored).toMatchObject({ value: { rewards: {} }, malformed: false });
     expect(result.rewards).toHaveLength(1);
     expect(result.rewards[0]).toMatchObject({ type: 'testReward', rejected: [] });
+  });
+
+  // 🔴 `resolveRewardConfig` memoises per pod for a minute and only the pod that
+  // served a write clears it, so an operator screen resolving through it reports a
+  // stale answer on ~99 pods out of 100. Both halves of the response come from the
+  // one row this call read.
+  it('resolves the rewards from the row it just read', async () => {
+    mockGetStored.mockResolvedValue(
+      storedView({ rewards: { testReward: { enabled: false } } }) as never
+    );
+    const caller = rewardConfigRouter.createCaller(fakeCtx(mod) as never);
+
+    const result = await caller.get();
+
+    expect(result.rewards[0].effective.enabled).toBe(false);
+    expect(mockDescribeConfig).toHaveBeenCalledWith({
+      testReward: { override: { enabled: false }, rejected: [] },
+    });
   });
 });
 
@@ -140,5 +172,39 @@ describe('rewardConfig.set', () => {
       expectedHash: 'abc123',
       force: true,
     });
+  });
+
+  // 🔴 The response is built from the value just WRITTEN. Re-reading here instead
+  // reaches `dbRead` — the replica — and under lag hands back the pre-write row,
+  // which is the "my save did nothing" bug again with a fresh cause. The stored
+  // row is deliberately left saying the opposite of what is written.
+  it('answers from what it wrote, never from a read', async () => {
+    mockGetStored.mockResolvedValue(
+      storedView({ rewards: { testReward: { enabled: false } } }) as never
+    );
+    const caller = rewardConfigRouter.createCaller(fakeCtx(mod) as never);
+
+    const result = await caller.set({ rewards: { testReward: { enabled: true } } });
+
+    expect(result.rewards[0].effective.enabled).toBe(true);
+    expect(result.stored.value).toEqual({ rewards: { testReward: { enabled: true } } });
+    expect(mockGetStored).not.toHaveBeenCalled();
+  });
+
+  // The panel sends this straight back as `expectedHash` on the next save. The
+  // hash of the row that was LOADED describes a row that no longer exists, and
+  // the operator's next save is refused as someone else's edit.
+  it('hashes what it wrote, not what was loaded', async () => {
+    mockGetStored.mockResolvedValue(
+      storedView({ rewards: { testReward: { enabled: false } } }) as never
+    );
+    const caller = rewardConfigRouter.createCaller(fakeCtx(mod) as never);
+
+    const result = await caller.set({ rewards: { testReward: { enabled: true } } });
+
+    expect(result.stored.hash).toEqual(
+      storedViewOf({ rewards: { testReward: { enabled: true } } }).hash
+    );
+    expect(result.stored.hash).not.toEqual('hash-of-loaded-row');
   });
 });

--- a/src/server/routers/reward-config.router.ts
+++ b/src/server/routers/reward-config.router.ts
@@ -1,5 +1,4 @@
-import * as rewardImports from '~/server/rewards';
-import type { RewardConfig } from '~/server/rewards/reward-config';
+import { describeRewards } from '~/server/rewards/describe-rewards';
 import {
   configFromStoredValue,
   getStoredRewardConfig,
@@ -8,20 +7,6 @@ import {
   storedViewOf,
 } from '~/server/rewards/reward-config';
 import { moderatorProcedure, router } from '~/server/trpc';
-
-/**
- * 🔴 Resolves against a config the caller passes in, which is read UNCACHED.
- *
- * `resolveRewardConfig` memoises per pod for `CONFIG_TTL_MS`, which is right for
- * the grant path and wrong here: `invalidateRewardConfigCache` only clears the
- * pod that served the write, so on ~100 pods a moderator's read-back after a save
- * lands on a stale pod ~99% of the time and their save reads as a no-op.
- */
-async function describeRewards(config: RewardConfig) {
-  return (
-    await Promise.all(Object.values(rewardImports).map((x) => x.describeConfig(config)))
-  ).sort((a, b) => a.type.localeCompare(b.type));
-}
 
 export const rewardConfigRouter = router({
   // `stored` is the row as written — raw, and flagged when it would not survive

--- a/src/server/routers/reward-config.router.ts
+++ b/src/server/routers/reward-config.router.ts
@@ -1,28 +1,55 @@
 import * as rewardImports from '~/server/rewards';
+import type { RewardConfig } from '~/server/rewards/reward-config';
 import {
+  configFromStoredValue,
   getStoredRewardConfig,
   setRewardConfig,
   setRewardConfigSchema,
+  storedViewOf,
 } from '~/server/rewards/reward-config';
 import { moderatorProcedure, router } from '~/server/trpc';
+
+/**
+ * 🔴 Resolves against a config the caller passes in, which is read UNCACHED.
+ *
+ * `resolveRewardConfig` memoises per pod for `CONFIG_TTL_MS`, which is right for
+ * the grant path and wrong here: `invalidateRewardConfigCache` only clears the
+ * pod that served the write, so on ~100 pods a moderator's read-back after a save
+ * lands on a stale pod ~99% of the time and their save reads as a no-op.
+ */
+async function describeRewards(config: RewardConfig) {
+  return (
+    await Promise.all(Object.values(rewardImports).map((x) => x.describeConfig(config)))
+  ).sort((a, b) => a.type.localeCompare(b.type));
+}
 
 export const rewardConfigRouter = router({
   // `stored` is the row as written — raw, and flagged when it would not survive
   // `set`, so an editor can refuse to save over a row it cannot faithfully show.
-  // `rewards` is what the grant path actually resolved, including refused fields.
-  get: moderatorProcedure.query(async () => ({
-    stored: await getStoredRewardConfig(),
-    rewards: (await Promise.all(Object.values(rewardImports).map((x) => x.describeConfig()))).sort(
-      (a, b) => a.type.localeCompare(b.type)
-    ),
-  })),
+  // `rewards` is what the grant path would resolve from that same row, including
+  // refused fields — resolved from the row this call just read rather than from
+  // the memo, so one primary read answers both halves and they cannot disagree.
+  get: moderatorProcedure.query(async () => {
+    const stored = await getStoredRewardConfig();
+    return { stored, rewards: await describeRewards(configFromStoredValue(stored.value)) };
+  }),
   // The input schema is what keeps the middleware's `browsingLevel` out of a row
   // `set` replaces wholesale — zod strips unknown keys, and the router test
   // asserts the service is called with the row alone.
-  set: moderatorProcedure.input(setRewardConfigSchema).mutation(({ input, ctx }) =>
-    setRewardConfig({ rewards: input.rewards }, ctx.user.id, {
+  //
+  // 🔴 Returns the same shape as `get`, resolved from the value just WRITTEN, so
+  // the caller never has to read its own write back. Re-reading here instead
+  // would reach `dbRead` — the replica — and hand back the pre-write row under
+  // lag, which is this bug again with a fresh cause.
+  set: moderatorProcedure.input(setRewardConfigSchema).mutation(async ({ input, ctx }) => {
+    const value = await setRewardConfig({ rewards: input.rewards }, ctx.user.id, {
       expectedHash: input.expectedHash,
       force: input.force,
-    })
-  ),
+    });
+
+    return {
+      stored: storedViewOf(value),
+      rewards: await describeRewards(configFromStoredValue(value)),
+    };
+  }),
 });


### PR DESCRIPTION
## The bug

A moderator turns a reward on in the reward-config panel, saves, and the screen comes back saying nothing is set. Justin hit this on 2026-08-19; the Axiom audit log shows both saves **succeeded**:

```
17:55:00.555Z  userId 1
  previous {"rewards":{"remixAccept":{"enabled":false},"stickerPlacementAccepted":{"enabled":false}}}
  value    {"rewards":{}}
17:55:12.833Z  userId 1   previous {"rewards":{}}   value {"rewards":{}}
```

Two independent defects produced that.

**The row could not record an "on".** `buildRewardsPayload` wrote only `enabled: false`. Turning a reward on deleted its override, and with nothing else differing from the compiled defaults the reward left the payload entirely — so a save that turned two rewards on wrote `{"rewards":{}}`. "Nobody ever touched this" and "an operator deliberately enabled this" were the same row.

**The read-back came from a per-pod cache.** The switches render `effective.enabled`, resolved through `resolveRewardConfig`'s 60s in-process memo. `setRewardConfig` calls `invalidateRewardConfigCache()` on the pod that served the write; production runs ~100 pods. The refetch after a save therefore answered from a stale pod almost every time.

## The fix

- `buildRewardsPayload` writes `enabled` either way. `{enabled:true}` and an absent entry resolve identically (`override.enabled ?? true`), so **no reward changes state** — this changes what is recorded, not what pays. The row now names every reward instead of only the overridden ones.
- `rewardConfig.set` returns the same shape as `get`, built from the row it just wrote, and the panel seeds from that response instead of refetching.
- `rewardConfig.get` and `/api/testing/rewards-config` resolve the row they read from the **primary**, not the memo. `describeConfig` now takes the config rather than reading one, so an operator view cannot pick the memo up by accident.
- The grant path keeps its 60s memo. That cache is correct where it runs — using it to answer a moderator's screen was not.

### Why not cross-pod invalidation

"We shouldn't have a per-pod cache here" invites building an invalidation bus. **A cross-pod invalidation primitive does exist** — `bustFetchThroughCache` (`src/server/utils/cache-helpers.ts:398`) rewrites the redis entry with `cachedAt: 0` so every pod's next read refetches, paired with `fetchThroughCache`. What does not exist is any way to invalidate a `createTtlMemo` in-process memo across pods, which is the cache this panel was reading through.

Moving this config onto the redis-backed cache was considered and rejected: it would add a redis layer, a second staleness window and a bust call to a screen loaded a handful of times a day, to make a cache correct when the answer is not to cache. The source of truth is Postgres and the reader is one admin page. (An earlier revision of this description claimed no such primitive existed at all. That was too broad, and the reuse review caught it.)

### It is a read reduction too

`createTtlMemo` stores no in-flight promise, so it has no request coalescing. `get` called `describeConfig` once per reward, and on a pod whose memo was cold or expired all 14 entered the memo before any resolved — 14 concurrent `dbRead.keyValue.findUnique`. So `get` was **1-15 reads** and is now exactly **1**, and a save went from 2 requests / 2-16 reads to 1 request / 1 read. Worth knowing before anyone reinstates a cache here: the memo was not what kept the read count down.

### Two traps in the fix, both with tests that say so

**`set` must answer from what it wrote, never by re-reading.** `loadConfig` reads `dbRead`, the replica, so a re-read reintroduces this exact bug under lag.

**The hash must describe the row Postgres holds, not the object we sent it.** `KeyValue.value` is jsonb and canonicalises key order; `rewardConfigHash` is `JSON.stringify` and is insertion-ordered. Verified on prod: `'{"enabled":true,"awardAmount":5,"cap":9}'::jsonb::text` returns `{"cap": 9, "enabled": true, "awardAmount": 5}`. Hashing the in-memory value hands the panel a token for a row that never existed, and the moderator's *next* save is refused as "Someone else saved" — every time, forever, with nobody else on the screen. `setRewardConfig` therefore returns the row from the upsert's own RETURNING.

That one was introduced by this PR's first revision and found in review. It is also the reason the write fake now models jsonb by Postgres's key order rather than echoing what it was handed: **a fake that returns the object it was given makes the write and the read agree by construction**, which is precisely why the original tests were green.

## Verification

`pnpm run typecheck` — `0 type errors`. Lint over the eleven touched files: `0 errors, 19 warnings`, all pre-existing.

Full unit suite: `Test Files 3 failed | 1194 passed | 1 skipped (1198)`, `Tests 5 failed | 18899 passed | 23 skipped (18927)`, exit 1. **The same 3 files / 5 tests fail on unmodified `origin/main` in this worktree** (`standalone-boot-graph`, `rating-label`, `appListingStatChips` — source-scanning path guards that fail on Windows). `blocks.router.workflow.test.ts` collected 350 tests, so the submodule is present.

Every new test was checked by mutation, not by passing:

| Mutation | Result |
|---|---|
| `entry.enabled = row.enabled` → `if (!row.enabled) entry.enabled = false` | 9 panel tests + the round trip fail |
| `set` re-reads instead of answering from the write | 2 router tests fail |
| `get` resolves from an empty config instead of the row it read | 1 router test fails |
| `get` returns `hash: ''` instead of the row's hash | 1 router test fails (green before review) |
| the panel refetches instead of seeding from the response | 1 panel test fails |
| `set` returns the in-memory value instead of the stored row | 1 service test fails (the jsonb regression) |

The round-trip test asserts the **row still names the reward**, not just that the reward pays — an absent entry pays too, which is exactly why the production bug was invisible.

## Not touched

`rewards:config` was not written and no reward was enabled or disabled. The row is as Justin left it: `{"rewards": {}}`, one row, confirmed present on the replica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

