### PR TITLE
fix(training): retry image loads before calling a dataset file corrupt

### DIFF
--- a/src/components/Training/Form/TrainingImages.tsx
+++ b/src/components/Training/Form/TrainingImages.tsx
@@ -152,6 +152,11 @@ const MAX_FILES_ALLOWED = 1000;
 
 const limit = pLimit(10);
 
+// A load failure here is a browser-side event, not a property of the file - the same
+// bytes load fine on their own. Retry before skipping the file. See e6c9f52251, which
+// made decode() failures non-fatal for the same reason.
+const IMAGE_LOAD_RETRIES = 2;
+
 // TODO [bw] is this enough? do we want jfif?
 const imageExts: { [key: string]: string } = {
   png: MIME_TYPES.png,
@@ -340,7 +345,7 @@ export const TrainingFormImages = ({ model }: { model: NonNullable<TrainingModel
   const showImgResizeDown = useRef<number>(0);
   const showImgResizeUp = useRef<number>(0);
   const showImgTooSmall = useRef<string[]>([]);
-  const showImgCorrupt = useRef<string[]>([]);
+  const showImgLoadFailed = useRef<string[]>([]);
 
   const theme = useMantineTheme();
   const queryUtils = trpc.useUtils();
@@ -385,7 +390,9 @@ export const TrainingFormImages = ({ model }: { model: NonNullable<TrainingModel
     type: string,
     fileName?: string
   ): Promise<string> => {
-    const blob = new Blob([data], { type: type });
+    // `data` is already a Blob, and `new Blob([data])` duplicates its bytes. Slicing
+    // re-labels the same bytes instead, which halves peak memory over a 1000-image zip.
+    const blob = data.type === type ? data : data.slice(0, data.size, type);
     const imgUrl = URL.createObjectURL(blob);
 
     // Skip validation for non-image types (e.g., videos)
@@ -393,7 +400,7 @@ export const TrainingFormImages = ({ model }: { model: NonNullable<TrainingModel
 
     let img: HTMLImageElement;
     try {
-      img = await createImageElement(imgUrl);
+      img = await createImageElement(imgUrl, { loadRetries: IMAGE_LOAD_RETRIES });
     } catch (loadError) {
       const name = fileName ?? 'image';
       console.error(`[ImageValidation] createImageElement failed for "${name}"`, {
@@ -402,8 +409,8 @@ export const TrainingFormImages = ({ model }: { model: NonNullable<TrainingModel
         type,
       });
       URL.revokeObjectURL(imgUrl);
-      showImgCorrupt.current.push(name);
-      throw new Error(`Image "${name}" failed to load and may be corrupt.`);
+      showImgLoadFailed.current.push(name);
+      throw new Error(`Image "${name}" could not be loaded by this browser.`);
     }
 
     let { width, height } = img;
@@ -526,18 +533,24 @@ export const TrainingFormImages = ({ model }: { model: NonNullable<TrainingModel
       });
       showImgTooSmall.current = [];
     }
-    if (showImgCorrupt.current.length) {
-      const count = showImgCorrupt.current.length;
+    if (showImgLoadFailed.current.length) {
+      const count = showImgLoadFailed.current.length;
       const fileNames =
         count <= 3
-          ? showImgCorrupt.current.join(', ')
-          : `${showImgCorrupt.current.slice(0, 3).join(', ')} and ${count - 3} more`;
+          ? showImgLoadFailed.current.join(', ')
+          : `${showImgLoadFailed.current.slice(0, 3).join(', ')} and ${count - 3} more`;
       showErrorNotification({
-        title: `${count} file${count === 1 ? '' : 's'} rejected - corrupt`,
-        error: new Error(`These images appear to be corrupt and were skipped: ${fileNames}`),
+        title: `${count} file${count === 1 ? '' : 's'} skipped - could not be read`,
+        error: new Error(
+          `Your browser could not load ${count === 1 ? 'this file' : 'these files'}, so ${
+            count === 1 ? 'it was' : 'they were'
+          } skipped: ${fileNames}. ` +
+            `This usually means the browser ran out of memory rather than that the files are damaged - ` +
+            `try adding them again, in smaller batches.`
+        ),
         autoClose: false,
       });
-      showImgCorrupt.current = [];
+      showImgLoadFailed.current = [];
     }
   };
 

--- a/src/utils/__tests__/image-utils.create-image-element.test.ts
+++ b/src/utils/__tests__/image-utils.create-image-element.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createImageElement } from '~/utils/image-utils';
+
+type Outcome = 'load' | 'error';
+
+// Outcomes are consumed one per attempt; a shorter script than the attempts made means the
+// element never settles, so every test also asserts the attempt count to keep that visible.
+let outcomes: Outcome[] = [];
+let attempts = 0;
+
+class FakeImage {
+  crossOrigin: string | null = null;
+  complete = false;
+  naturalWidth = 0;
+  width = 0;
+  height = 0;
+
+  private listeners: Record<string, ((event: unknown) => void)[]> = {};
+  private _src = '';
+
+  addEventListener(type: string, listener: (event: unknown) => void) {
+    (this.listeners[type] ??= []).push(listener);
+  }
+
+  decode() {
+    return Promise.resolve();
+  }
+
+  set src(value: string) {
+    this._src = value;
+    const outcome = outcomes[attempts];
+    attempts += 1;
+    if (!outcome) return;
+    queueMicrotask(() => {
+      if (outcome === 'load') {
+        this.complete = true;
+        this.naturalWidth = 512;
+        this.width = 512;
+        this.height = 512;
+        for (const listener of this.listeners.load ?? []) listener(new Event('load'));
+      } else {
+        for (const listener of this.listeners.error ?? []) listener(new Event('error'));
+      }
+    });
+  }
+
+  get src() {
+    return this._src;
+  }
+}
+
+describe('createImageElement', () => {
+  beforeEach(() => {
+    outcomes = [];
+    attempts = 0;
+    vi.stubGlobal('Image', FakeImage);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects with an Error, not the bare error Event', async () => {
+    outcomes = ['error'];
+
+    // Rejecting with the DOM Event is what made the caller's diagnostic log read
+    // "[object Event]" and name nothing about the failure.
+    await expect(createImageElement('blob:test')).rejects.toBeInstanceOf(Error);
+    expect(attempts).toBe(1);
+  });
+
+  it('makes a single attempt by default', async () => {
+    outcomes = ['error', 'load'];
+
+    await expect(createImageElement('blob:test')).rejects.toBeInstanceOf(Error);
+    expect(attempts).toBe(1);
+  });
+
+  it('retries a failed load and resolves when a later attempt succeeds', async () => {
+    outcomes = ['error', 'error', 'load'];
+
+    const img = await createImageElement('blob:test', {
+      loadRetries: 2,
+      loadRetryDelayMs: 0,
+    });
+
+    expect(img.width).toBe(512);
+    expect(attempts).toBe(3);
+  });
+
+  it('gives up after the configured number of retries', async () => {
+    outcomes = ['error', 'error', 'error'];
+
+    await expect(
+      createImageElement('blob:test', { loadRetries: 2, loadRetryDelayMs: 0 })
+    ).rejects.toBeInstanceOf(Error);
+    expect(attempts).toBe(3);
+  });
+});

--- a/src/utils/image-utils.ts
+++ b/src/utils/image-utils.ts
@@ -50,8 +50,7 @@ export async function imageToBlurhash(url: string) {
   return { hash: '', width: 0, height: 0 };
 }
 
-export async function createImageElement(src: string | Blob | File) {
-  const objectUrl = typeof src === 'string' ? src : URL.createObjectURL(src);
+function loadImageElement(objectUrl: string) {
   return new Promise<HTMLImageElement>((resolve, reject) => {
     const img = new Image();
     img.crossOrigin = 'Anonymous';
@@ -77,12 +76,52 @@ export async function createImageElement(src: string | Blob | File) {
       }
       resolve(img);
     });
-    img.addEventListener('error', (error) => {
-      console.error('[createImageElement] Image failed to load:', error);
-      reject(error);
+    img.addEventListener('error', (event) => {
+      // The `error` event on <img> carries no reason, so rejecting with it gives callers
+      // an Event that stringifies to "[object Event]". Reject with a real Error instead,
+      // and record the little the element does expose, so a caller's log names something.
+      reject(
+        new Error(
+          `Image failed to load (complete=${img.complete}, naturalWidth=${img.naturalWidth})`,
+          { cause: event }
+        )
+      );
     });
     img.src = objectUrl;
   });
+}
+
+export type CreateImageElementOptions = {
+  /**
+   * Extra load attempts, spaced by `loadRetryDelayMs`. A blob that decoded a moment ago can
+   * still fail to load when many images are in flight, so anything processing a batch should
+   * retry before treating a failure as a property of the file.
+   */
+  loadRetries?: number;
+  loadRetryDelayMs?: number;
+};
+
+export async function createImageElement(
+  src: string | Blob | File,
+  { loadRetries = 0, loadRetryDelayMs = 250 }: CreateImageElementOptions = {}
+) {
+  const objectUrl = typeof src === 'string' ? src : URL.createObjectURL(src);
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= loadRetries; attempt++) {
+    if (attempt > 0) await new Promise((r) => setTimeout(r, loadRetryDelayMs));
+    try {
+      return await loadImageElement(objectUrl);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  console.error(
+    `[createImageElement] Image failed to load after ${loadRetries + 1} attempt(s):`,
+    lastError
+  );
+  throw lastError;
 }
 
 export async function getImageDimensions(src: string | Blob | File) {


### PR DESCRIPTION
Dataset validation rejected images as "corrupt" whenever the browser's `<img>` load failed, which happens under memory pressure when many images are decoded at once rather than because the bytes are bad. `createImageElement` now retries the load (2 extra attempts, 250ms apart) and rejects with a real `Error` instead of the reasonless DOM event, the training uploader reuses the source blob instead of copying its bytes, and the notification now says the browser couldn't read the files and suggests smaller batches.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868ktyfaj`). Reviewed locally before push.