### PR TITLE
fix(search): stop an autocomplete token filter replacing the browsing-level one

### DIFF
--- a/src/components/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/src/components/AutocompleteSearch/AutocompleteSearch.tsx
@@ -23,9 +23,9 @@ import React, {
   Fragment,
 } from 'react';
 import type { InstantSearchProps, SearchBoxProps } from 'react-instantsearch';
-import { Configure, InstantSearch, useInstantSearch, useSearchBox } from 'react-instantsearch';
+import { InstantSearch, useInstantSearch, useSearchBox } from 'react-instantsearch';
 import { ClearableAutoComplete } from '~/components/ClearableAutoComplete/ClearableAutoComplete';
-import { getModelUrl, slugit } from '~/utils/string-helpers';
+import { slugit } from '~/utils/string-helpers';
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 import { env } from '~/env/client';
 import { createResilientSearchClient } from '~/components/Search/resilientSearchClient';
@@ -50,7 +50,11 @@ import type { ReverseSearchIndexKey, SearchIndexKey } from '~/components/Search/
 import { reverseSearchIndexMap, searchIndexMap } from '~/components/Search/search.types';
 import { isDefined, paired } from '~/utils/type-guards';
 import { BrowsingLevelFilter } from '../Search/CustomSearchComponents';
-import { QS } from '~/utils/qs';
+import {
+  buildSearchPageUrl,
+  checkAIR,
+  parseQuery,
+} from '~/components/AutocompleteSearch/autocomplete-query';
 import { ToolSearchItem } from '~/components/AutocompleteSearch/renderItems/tools';
 import { ComicsSearchItem } from '~/components/AutocompleteSearch/renderItems/comics';
 import { Availability } from '~/shared/utils/prisma/enums';
@@ -163,12 +167,12 @@ export const AutocompleteSearch = forwardRef<{ focus: () => void }, Props>(({ ..
       indexName={searchIndexMap[targetIndex as keyof typeof searchIndexMap]}
       future={{ preserveSharedStateOnUnmount: false }}
     >
-      <BrowsingLevelFilter indexKey={targetIndex} filters={filters} />
       <AutocompleteSearchContent
         {...props}
         indexName={targetIndex}
         ref={ref}
         onTargetChange={handleTargetChange}
+        baseFilters={filters}
       />
     </InstantSearch>
   );
@@ -179,6 +183,7 @@ AutocompleteSearch.displayName = 'AutocompleteSearch';
 type AutocompleteSearchProps<T extends SearchIndexKey> = Props & {
   indexName: T;
   onTargetChange: (target: T) => void;
+  baseFilters: string[];
 };
 
 function AutocompleteSearchContentInner<TKey extends SearchIndexKey>(
@@ -189,6 +194,7 @@ function AutocompleteSearchContentInner<TKey extends SearchIndexKey>(
     searchBoxProps,
     indexName: indexNameProp,
     onTargetChange,
+    baseFilters,
     ...autocompleteProps
   }: AutocompleteSearchProps<TKey>,
   ref: React.ForwardedRef<{ focus: () => void }>
@@ -218,8 +224,7 @@ function AutocompleteSearchContentInner<TKey extends SearchIndexKey>(
 
   const [selectedItem, setSelectedItem] = useState<ComboboxData[number] | null>(null);
   const [search, setSearch] = useState(query);
-  const [filters, setFilters] = useState('');
-  const [searchPageQuery, setSearchPageQuery] = useState('');
+  const [queryFilters, setQueryFilters] = useState('');
   const [debouncedSearch] = useDebouncedValue(search, 300);
 
   const { trackSearch, trackAction } = useTrackEvent();
@@ -366,18 +371,12 @@ function AutocompleteSearchContentInner<TKey extends SearchIndexKey>(
     focus: focusInput,
   }));
 
+  // Not the refined `query`: `parseQuery` has already stripped the `#tag`/`@user` tokens out of it.
+  const searchPageUrl = () => buildSearchPageUrl(indexName, search);
+
   const handleSubmit = () => {
     if (search) {
-      const { query: cleanedSearch, searchPageQuery: currSearchPageQuery } = parseQuery(
-        indexName,
-        search
-      );
-      const queryString = QS.stringify({
-        query: cleanedSearch.trim(), // Search should be more accurate than query as it was the latest written.
-        ...QS.parse(currSearchPageQuery),
-      });
-
-      router.push(`/search/${indexName}?${queryString}`, undefined, { shallow: false });
+      router.push(searchPageUrl(), undefined, { shallow: false });
 
       blurInput();
     }
@@ -420,9 +419,7 @@ function AutocompleteSearchContentInner<TKey extends SearchIndexKey>(
       trackSearch({ query: search, index: searchIndexMap[indexName] }).catch(() => null);
     } else {
       // when view more is clicked
-      router.push(`/search/${indexName}?query=${encodeURIComponent(item.value)}`, undefined, {
-        shallow: false,
-      });
+      router.push(searchPageUrl(), undefined, { shallow: false });
     }
 
     setSelectedItem({ label: item.key, value });
@@ -447,15 +444,10 @@ function AutocompleteSearchContentInner<TKey extends SearchIndexKey>(
       return;
     }
 
-    const {
-      query: cleanedSearch,
-      filters,
-      searchPageQuery,
-    } = parseQuery(indexName, debouncedSearch);
+    const { query: cleanedSearch, filters } = parseQuery(indexName, debouncedSearch);
 
     setQuery(cleanedSearch);
-    setFilters(filters);
-    setSearchPageQuery(searchPageQuery);
+    setQueryFilters(filters);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSearch, query]);
 
@@ -493,7 +485,11 @@ function AutocompleteSearchContentInner<TKey extends SearchIndexKey>(
 
   return (
     <>
-      <Configure hitsPerPage={DEFAULT_DROPDOWN_ITEM_LIMIT} filters={filters} />
+      <BrowsingLevelFilter
+        indexKey={indexNameProp}
+        filters={[...baseFilters, queryFilters]}
+        hitsPerPage={DEFAULT_DROPDOWN_ITEM_LIMIT}
+      />
       <Group className={classes.wrapper} gap={0} wrap="nowrap">
         <Select
           key={pathname}
@@ -692,71 +688,3 @@ const IndexRenderItem: Record<SearchIndexKey, React.ComponentType<any>> = {
   comics: ComicsSearchItem,
 };
 
-const queryFilters: Record<
-  string,
-  { AIR?: RegExp; filters: Record<string, RegExp>; searchPageMap: Record<string, string> }
-> = {
-  models: {
-    AIR: /^civitai:(?<modelId>\d+)@(?<modelVersionId>\d+)/g,
-    filters: {
-      'tags.name': /(^|\s+)(?<not>!|-)?#(?<value>\w+)/g,
-      'user.username': /(^|\s+)(?<not>!|-)?@(?<value>\w+)/g,
-      'versions.hashes': /(^|\s+)(?<not>!|-)?hash:(?<value>[A-Za-z0-9_.-]+)/g,
-    },
-    searchPageMap: {
-      'user.username': 'users',
-      'tags.name': 'tags',
-    },
-  },
-};
-
-function checkAIR(index: string, query: string) {
-  const filterAttributes = queryFilters[index] ?? {};
-
-  if (!filterAttributes?.AIR) {
-    return null;
-  }
-
-  const { AIR } = filterAttributes;
-  const [match] = query.matchAll(AIR);
-
-  if (!match) return null;
-
-  if (index === 'models') {
-    const modelId = match?.groups?.modelId;
-    const modelVersionId = match?.groups?.modelVersionId;
-
-    if (!modelId || !modelVersionId) return null;
-
-    return getModelUrl({ modelId: Number(modelId), modelVersionId: Number(modelVersionId) });
-  }
-
-  return null;
-}
-
-function parseQuery(index: string, query: string) {
-  const filterAttributes = queryFilters[index];
-  const filters = [];
-  const searchPageQuery = [];
-
-  if (filterAttributes) {
-    for (const [attribute, regex] of Object.entries(filterAttributes.filters)) {
-      for (const match of query.matchAll(regex)) {
-        const cleanedMatch = match?.groups?.value?.trim();
-        const not = match?.groups?.not !== undefined;
-        if (!cleanedMatch) continue;
-        filters.push(`${not ? 'NOT ' : ''}${attribute} = ${quoteMeiliValue(cleanedMatch)}`);
-        searchPageQuery.push(
-          `${filterAttributes.searchPageMap[attribute] ?? attribute}=${encodeURIComponent(
-            cleanedMatch ?? ''
-          )}`
-        );
-      }
-
-      query = query.replace(regex, '');
-      if (query.length === 0 && filters.length !== 0) query = ' ';
-    }
-  }
-
-  return { query, filters: filters.join(' AND '), searchPageQuery: searchPageQuery.join('&') };
-}

--- a/src/components/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/src/components/AutocompleteSearch/AutocompleteSearch.tsx
@@ -449,7 +449,7 @@ function AutocompleteSearchContentInner<TKey extends SearchIndexKey>(
     setQuery(cleanedSearch);
     setQueryFilters(filters);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedSearch, query]);
+  }, [debouncedSearch, query, indexName]);
 
   // Clear selected item after search changes
   useEffect(() => {

--- a/src/components/AutocompleteSearch/__tests__/autocomplete-query.test.ts
+++ b/src/components/AutocompleteSearch/__tests__/autocomplete-query.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { buildSearchPageUrl, parseQuery } from '~/components/AutocompleteSearch/autocomplete-query';
+import { buildBrowsingLevelFilters, joinFilterClauses } from '~/components/Search/search-filters';
+
+const attribute = 'nsfwLevel' as const;
+const pg = 1;
+
+// What `AutocompleteSearch` builds for a signed-out PG user with the poi/minor addons on.
+const baseFilters = ['poi != true', 'minor != true', 'availability != Private'];
+
+function autocompleteFilters(search: string) {
+  const { filters } = parseQuery('models', search);
+
+  return joinFilterClauses(
+    buildBrowsingLevelFilters({
+      attribute,
+      browsingLevel: pg,
+      filters: [...baseFilters, filters],
+    })
+  );
+}
+
+describe('parseQuery', () => {
+  it('turns a #tag into a filter and strips it from the query', () => {
+    expect(parseQuery('models', '#anime')).toEqual({
+      query: ' ',
+      filters: "tags.name = 'anime'",
+      searchPageQuery: 'tags=anime',
+    });
+  });
+
+  it('turns an @user into a filter and strips it from the query', () => {
+    expect(parseQuery('models', '@civitai')).toEqual({
+      query: ' ',
+      filters: "user.username = 'civitai'",
+      searchPageQuery: 'users=civitai',
+    });
+  });
+
+  it('keeps the free text alongside the token', () => {
+    expect(parseQuery('models', 'anime #style')).toEqual({
+      query: 'anime',
+      filters: "tags.name = 'style'",
+      searchPageQuery: 'tags=style',
+    });
+  });
+
+  it('returns no filters for an index without token syntax', () => {
+    expect(parseQuery('images', '#anime')).toEqual({
+      query: '#anime',
+      filters: '',
+      searchPageQuery: '',
+    });
+  });
+});
+
+describe('the filters the autocomplete sends to Meilisearch', () => {
+  it('ANDs a #tag onto the browsing-level clause instead of replacing it', () => {
+    expect(autocompleteFilters('#anime')).toBe(
+      "(poi != true) AND (minor != true) AND (availability != Private) AND (tags.name = 'anime') AND (nsfwLevel=1)"
+    );
+  });
+
+  it('ANDs an @user onto the browsing-level clause instead of replacing it', () => {
+    expect(autocompleteFilters('@civitai')).toBe(
+      "(poi != true) AND (minor != true) AND (availability != Private) AND (user.username = 'civitai') AND (nsfwLevel=1)"
+    );
+  });
+
+  it('keeps every clause a plain query has once a token is added', () => {
+    const plain = autocompleteFilters('anime');
+    const tagged = autocompleteFilters('#anime');
+
+    for (const clause of plain.split(' AND ')) expect(tagged).toContain(clause);
+    expect(tagged).toContain(`(${attribute}=${pg})`);
+  });
+
+  it('emits the browsing-level clause last, so a token can never terminate the expression', () => {
+    expect(autocompleteFilters('#anime hash:abc123')).toMatch(/\(nsfwLevel=1\)$/);
+  });
+});
+
+describe('buildSearchPageUrl', () => {
+  it('carries a #tag as a tags param and drops the emptied query', () => {
+    expect(buildSearchPageUrl('models', '#anime')).toBe('/search/models?tags=anime');
+  });
+
+  it('carries an @user as a users param', () => {
+    expect(buildSearchPageUrl('models', '@civitai')).toBe('/search/models?users=civitai');
+  });
+
+  it('keeps free text and token together', () => {
+    expect(buildSearchPageUrl('models', 'anime #style')).toBe(
+      '/search/models?query=anime&tags=style'
+    );
+  });
+
+  it('passes a plain query straight through', () => {
+    expect(buildSearchPageUrl('models', 'anime')).toBe('/search/models?query=anime');
+  });
+
+  it('never emits the blank query the cleaned search would have produced', () => {
+    const url = buildSearchPageUrl('models', '#anime');
+
+    expect(url).not.toContain('query=');
+    expect(url).not.toContain('%20');
+  });
+});
+
+// Read as source because the unit project collects `.test.ts` only, and both bugs were wiring a
+// correct function into the wrong place: a second `filters` widget silently overwrites the
+// browsing-level one, and a hand-built /search URL silently drops the token params.
+describe('the AutocompleteSearch InstantSearch tree', () => {
+  const source = readFileSync(path.join(__dirname, '..', 'AutocompleteSearch.tsx'), 'utf-8');
+
+  it('has exactly one widget writing `filters`', () => {
+    const writers = [...source.matchAll(/<([A-Za-z]+)[^<>]*?\sfilters=\{/g)].map((m) => m[1]);
+
+    expect(writers).toEqual(['BrowsingLevelFilter']);
+  });
+
+  it('routes every /search push through buildSearchPageUrl', () => {
+    expect(source.match(/router\.push\(`\/search\/[^`]*`/g) ?? []).toEqual([]);
+    expect(source).toContain('buildSearchPageUrl');
+  });
+});

--- a/src/components/AutocompleteSearch/__tests__/autocomplete-query.test.ts
+++ b/src/components/AutocompleteSearch/__tests__/autocomplete-query.test.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { buildSearchPageUrl, parseQuery } from '~/components/AutocompleteSearch/autocomplete-query';
 import { buildBrowsingLevelFilters, joinFilterClauses } from '~/components/Search/search-filters';
+import { BROWSING_LEVEL_ATTRIBUTE } from '~/components/Search/search-index-filters';
+import type { SearchIndexKey } from '~/components/Search/search.types';
 
 const attribute = 'nsfwLevel' as const;
 const pg = 1;
@@ -10,14 +12,14 @@ const pg = 1;
 // What `AutocompleteSearch` builds for a signed-out PG user with the poi/minor addons on.
 const baseFilters = ['poi != true', 'minor != true', 'availability != Private'];
 
-function autocompleteFilters(search: string) {
-  const { filters } = parseQuery('models', search);
+function autocompleteFilters(index: SearchIndexKey, search: string, base: string[] = []) {
+  const { filters } = parseQuery(index, search);
 
   return joinFilterClauses(
     buildBrowsingLevelFilters({
-      attribute,
+      attribute: BROWSING_LEVEL_ATTRIBUTE[index],
       browsingLevel: pg,
-      filters: [...baseFilters, filters],
+      filters: [...base, filters],
     })
   );
 }
@@ -48,7 +50,7 @@ describe('parseQuery', () => {
   });
 
   it('returns no filters for an index without token syntax', () => {
-    expect(parseQuery('images', '#anime')).toEqual({
+    expect(parseQuery('tools', '#anime')).toEqual({
       query: '#anime',
       filters: '',
       searchPageQuery: '',
@@ -58,27 +60,122 @@ describe('parseQuery', () => {
 
 describe('the filters the autocomplete sends to Meilisearch', () => {
   it('ANDs a #tag onto the browsing-level clause instead of replacing it', () => {
-    expect(autocompleteFilters('#anime')).toBe(
+    expect(autocompleteFilters('models', '#anime', baseFilters)).toBe(
       "(poi != true) AND (minor != true) AND (availability != Private) AND (tags.name = 'anime') AND (nsfwLevel=1)"
     );
   });
 
   it('ANDs an @user onto the browsing-level clause instead of replacing it', () => {
-    expect(autocompleteFilters('@civitai')).toBe(
+    expect(autocompleteFilters('models', '@civitai', baseFilters)).toBe(
       "(poi != true) AND (minor != true) AND (availability != Private) AND (user.username = 'civitai') AND (nsfwLevel=1)"
     );
   });
 
   it('keeps every clause a plain query has once a token is added', () => {
-    const plain = autocompleteFilters('anime');
-    const tagged = autocompleteFilters('#anime');
+    const plain = autocompleteFilters('models', 'anime', baseFilters);
+    const tagged = autocompleteFilters('models', '#anime', baseFilters);
 
     for (const clause of plain.split(' AND ')) expect(tagged).toContain(clause);
     expect(tagged).toContain(`(${attribute}=${pg})`);
   });
 
   it('emits the browsing-level clause last, so a token can never terminate the expression', () => {
-    expect(autocompleteFilters('#anime hash:abc123')).toMatch(/\(nsfwLevel=1\)$/);
+    expect(autocompleteFilters('models', '#anime hash:abc123', baseFilters)).toMatch(
+      /\(nsfwLevel=1\)$/
+    );
+  });
+});
+
+describe.each([
+  ['images', 'tagNames'],
+  ['articles', 'tags.name'],
+] as const)('the %s index', (index, tagAttribute) => {
+  it(`filters a #tag on ${tagAttribute}`, () => {
+    expect(parseQuery(index, '#anime')).toEqual({
+      query: ' ',
+      filters: `${tagAttribute} = 'anime'`,
+      searchPageQuery: 'tags=anime',
+    });
+  });
+
+  it('filters an @user on user.username', () => {
+    expect(parseQuery(index, '@civitai')).toEqual({
+      query: ' ',
+      filters: "user.username = 'civitai'",
+      searchPageQuery: 'users=civitai',
+    });
+  });
+
+  it('ANDs a #tag onto the browsing-level clause', () => {
+    expect(autocompleteFilters(index, '#anime')).toBe(
+      `(${tagAttribute} = 'anime') AND (nsfwLevel=1)`
+    );
+  });
+
+  it('ANDs an @user onto the browsing-level clause', () => {
+    expect(autocompleteFilters(index, '@civitai')).toBe(
+      "(user.username = 'civitai') AND (nsfwLevel=1)"
+    );
+  });
+
+  it('carries a #tag to the search page as a tags param', () => {
+    expect(buildSearchPageUrl(index, '#anime')).toBe(`/search/${index}?tags=anime`);
+  });
+
+  it('carries an @user to the search page as a users param', () => {
+    expect(buildSearchPageUrl(index, '@civitai')).toBe(`/search/${index}?users=civitai`);
+  });
+
+  it('leaves hash: alone, which only the models index can filter on', () => {
+    expect(parseQuery(index, 'hash:abc123')).toEqual({
+      query: 'hash:abc123',
+      filters: '',
+      searchPageQuery: '',
+    });
+  });
+});
+
+describe('the collections index', () => {
+  it('filters an @user on user.username', () => {
+    expect(parseQuery('collections', '@civitai')).toEqual({
+      query: ' ',
+      filters: "user.username = 'civitai'",
+      searchPageQuery: 'users=civitai',
+    });
+  });
+
+  it('ANDs an @user onto the browsing-level clause', () => {
+    expect(autocompleteFilters('collections', '@civitai')).toBe(
+      "(user.username = 'civitai') AND (nsfwLevel=1)"
+    );
+  });
+
+  it('carries an @user to the search page as a users param', () => {
+    expect(buildSearchPageUrl('collections', '@civitai')).toBe('/search/collections?users=civitai');
+  });
+
+  it('leaves a #tag in the query, having no tag attribute to filter on', () => {
+    expect(parseQuery('collections', '#anime')).toEqual({
+      query: '#anime',
+      filters: '',
+      searchPageQuery: '',
+    });
+  });
+});
+
+describe.each(['tools', 'users'] as const)('the %s index, which supports no tokens', (index) => {
+  it('leaves every token in the query and builds no filter', () => {
+    expect(parseQuery(index, '#anime @civitai')).toEqual({
+      query: '#anime @civitai',
+      filters: '',
+      searchPageQuery: '',
+    });
+  });
+
+  it('sends the whole input to the search page as a plain query', () => {
+    expect(buildSearchPageUrl(index, '#anime @civitai')).toBe(
+      `/search/${index}?query=%23anime%20%40civitai`
+    );
   });
 });
 

--- a/src/components/AutocompleteSearch/autocomplete-query.ts
+++ b/src/components/AutocompleteSearch/autocomplete-query.ts
@@ -1,0 +1,83 @@
+import { quoteMeiliValue } from '~/components/Search/meili-filter';
+import { QS } from '~/utils/qs';
+import { getModelUrl } from '~/utils/string-helpers';
+
+const queryFilters: Record<
+  string,
+  { AIR?: RegExp; filters: Record<string, RegExp>; searchPageMap: Record<string, string> }
+> = {
+  models: {
+    AIR: /^civitai:(?<modelId>\d+)@(?<modelVersionId>\d+)/g,
+    filters: {
+      'tags.name': /(^|\s+)(?<not>!|-)?#(?<value>\w+)/g,
+      'user.username': /(^|\s+)(?<not>!|-)?@(?<value>\w+)/g,
+      'versions.hashes': /(^|\s+)(?<not>!|-)?hash:(?<value>[A-Za-z0-9_.-]+)/g,
+    },
+    searchPageMap: {
+      'user.username': 'users',
+      'tags.name': 'tags',
+    },
+  },
+};
+
+export function checkAIR(index: string, query: string) {
+  const filterAttributes = queryFilters[index] ?? {};
+
+  if (!filterAttributes?.AIR) {
+    return null;
+  }
+
+  const { AIR } = filterAttributes;
+  const [match] = query.matchAll(AIR);
+
+  if (!match) return null;
+
+  if (index === 'models') {
+    const modelId = match?.groups?.modelId;
+    const modelVersionId = match?.groups?.modelVersionId;
+
+    if (!modelId || !modelVersionId) return null;
+
+    return getModelUrl({ modelId: Number(modelId), modelVersionId: Number(modelVersionId) });
+  }
+
+  return null;
+}
+
+export function parseQuery(index: string, query: string) {
+  const filterAttributes = queryFilters[index];
+  const filters = [];
+  const searchPageQuery = [];
+
+  if (filterAttributes) {
+    for (const [attribute, regex] of Object.entries(filterAttributes.filters)) {
+      for (const match of query.matchAll(regex)) {
+        const cleanedMatch = match?.groups?.value?.trim();
+        const not = match?.groups?.not !== undefined;
+        if (!cleanedMatch) continue;
+        filters.push(`${not ? 'NOT ' : ''}${attribute} = ${quoteMeiliValue(cleanedMatch)}`);
+        searchPageQuery.push(
+          `${filterAttributes.searchPageMap[attribute] ?? attribute}=${encodeURIComponent(
+            cleanedMatch ?? ''
+          )}`
+        );
+      }
+
+      query = query.replace(regex, '');
+      if (query.length === 0 && filters.length !== 0) query = ' ';
+    }
+  }
+
+  return { query, filters: filters.join(' AND '), searchPageQuery: searchPageQuery.join('&') };
+}
+
+export function buildSearchPageUrl(index: string, search: string) {
+  const { query, searchPageQuery } = parseQuery(index, search);
+
+  const queryString = QS.stringify({
+    query: query.trim(),
+    ...QS.parse(searchPageQuery),
+  });
+
+  return `/search/${index}?${queryString}`;
+}

--- a/src/components/AutocompleteSearch/autocomplete-query.ts
+++ b/src/components/AutocompleteSearch/autocomplete-query.ts
@@ -1,27 +1,66 @@
 import { quoteMeiliValue } from '~/components/Search/meili-filter';
+import type { SearchIndexKey } from '~/components/Search/search.types';
 import { QS } from '~/utils/qs';
 import { getModelUrl } from '~/utils/string-helpers';
 
-const queryFilters: Record<
-  string,
-  { AIR?: RegExp; filters: Record<string, RegExp>; searchPageMap: Record<string, string> }
+const TAG_TOKEN = /(^|\s+)(?<not>!|-)?#(?<value>\w+)/g;
+const USER_TOKEN = /(^|\s+)(?<not>!|-)?@(?<value>\w+)/g;
+const HASH_TOKEN = /(^|\s+)(?<not>!|-)?hash:(?<value>[A-Za-z0-9_.-]+)/g;
+
+// Each key is an attribute its index declares filterable, and they diverge — images stores tags as
+// `tagNames`. One the index doesn't declare makes Meilisearch reject the search with a 400, which
+// the client swallows into an empty dropdown; search-index-contract.test.ts holds these against the
+// index definitions.
+export const queryFilters: Partial<
+  Record<
+    SearchIndexKey,
+    { AIR?: RegExp; filters: Record<string, RegExp>; searchPageMap: Record<string, string> }
+  >
 > = {
   models: {
     AIR: /^civitai:(?<modelId>\d+)@(?<modelVersionId>\d+)/g,
     filters: {
-      'tags.name': /(^|\s+)(?<not>!|-)?#(?<value>\w+)/g,
-      'user.username': /(^|\s+)(?<not>!|-)?@(?<value>\w+)/g,
-      'versions.hashes': /(^|\s+)(?<not>!|-)?hash:(?<value>[A-Za-z0-9_.-]+)/g,
+      'tags.name': TAG_TOKEN,
+      'user.username': USER_TOKEN,
+      'versions.hashes': HASH_TOKEN,
+    },
+    searchPageMap: {
+      'tags.name': 'tags',
+      'user.username': 'users',
+    },
+  },
+  images: {
+    filters: {
+      tagNames: TAG_TOKEN,
+      'user.username': USER_TOKEN,
+    },
+    searchPageMap: {
+      tagNames: 'tags',
+      'user.username': 'users',
+    },
+  },
+  articles: {
+    filters: {
+      'tags.name': TAG_TOKEN,
+      'user.username': USER_TOKEN,
+    },
+    searchPageMap: {
+      'tags.name': 'tags',
+      'user.username': 'users',
+    },
+  },
+  collections: {
+    filters: {
+      'user.username': USER_TOKEN,
     },
     searchPageMap: {
       'user.username': 'users',
-      'tags.name': 'tags',
     },
   },
 };
 
-export function checkAIR(index: string, query: string) {
-  const filterAttributes = queryFilters[index] ?? {};
+export function checkAIR(index: SearchIndexKey, query: string) {
+  const filterAttributes = queryFilters[index];
 
   if (!filterAttributes?.AIR) {
     return null;
@@ -44,7 +83,7 @@ export function checkAIR(index: string, query: string) {
   return null;
 }
 
-export function parseQuery(index: string, query: string) {
+export function parseQuery(index: SearchIndexKey, query: string) {
   const filterAttributes = queryFilters[index];
   const filters = [];
   const searchPageQuery = [];
@@ -71,7 +110,7 @@ export function parseQuery(index: string, query: string) {
   return { query, filters: filters.join(' AND '), searchPageQuery: searchPageQuery.join('&') };
 }
 
-export function buildSearchPageUrl(index: string, search: string) {
+export function buildSearchPageUrl(index: SearchIndexKey, search: string) {
   const { query, searchPageQuery } = parseQuery(index, search);
 
   const queryString = QS.stringify({

--- a/src/components/AutocompleteSearch/autocomplete-query.ts
+++ b/src/components/AutocompleteSearch/autocomplete-query.ts
@@ -118,5 +118,5 @@ export function buildSearchPageUrl(index: SearchIndexKey, search: string) {
     ...QS.parse(searchPageQuery),
   });
 
-  return `/search/${index}?${queryString}`;
+  return queryString ? `/search/${index}?${queryString}` : `/search/${index}`;
 }

--- a/src/components/Search/CustomSearchComponents.tsx
+++ b/src/components/Search/CustomSearchComponents.tsx
@@ -452,8 +452,11 @@ export const ApplyCustomFilter = ({
 
   const { refine } = useConfigure({ ...props, filters });
 
+  // `refine` REPLACES this widget's search parameters, so anything omitted here (hitsPerPage, …) is
+  // dropped from the request rather than left alone.
   useEffect(() => {
-    refine({ filters });
+    refine({ ...props, filters });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters]);
 
   return null;

--- a/src/components/Search/CustomSearchComponents.tsx
+++ b/src/components/Search/CustomSearchComponents.tsx
@@ -450,14 +450,7 @@ export const ApplyCustomFilter = ({
 }: { filters?: string[] | string } & Omit<ConfigureProps, 'filters'>) => {
   const filters = useMemo(() => joinFilterClauses(_filters), [_filters]);
 
-  const { refine } = useConfigure({ ...props, filters });
-
-  // `refine` REPLACES this widget's search parameters, so anything omitted here (hitsPerPage, …) is
-  // dropped from the request rather than left alone.
-  useEffect(() => {
-    refine({ ...props, filters });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters]);
+  useConfigure({ ...props, filters });
 
   return null;
 };

--- a/src/components/Search/__tests__/ApplyCustomFilter.browser.test.tsx
+++ b/src/components/Search/__tests__/ApplyCustomFilter.browser.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { InstantSearch } from 'react-instantsearch';
+import { ApplyCustomFilter } from '~/components/Search/CustomSearchComponents';
+
+type RecordedRequest = { params?: Record<string, unknown> };
+
+function createRecordingClient() {
+  const requests: RecordedRequest[] = [];
+
+  return {
+    requests,
+    searchClient: {
+      search: (queries: RecordedRequest[]) => {
+        requests.push(...queries);
+
+        return Promise.resolve({
+          results: queries.map(() => ({
+            hits: [],
+            nbHits: 0,
+            nbPages: 0,
+            page: 0,
+            processingTimeMS: 0,
+            hitsPerPage: 0,
+            exhaustiveNbHits: false,
+            query: '',
+            params: '',
+          })),
+        });
+      },
+    },
+  };
+}
+
+// Every request is asserted, not only the settled one: the widget registers with the full props and
+// is then re-refined by ApplyCustomFilter's own effect, and a refine that drops `hitsPerPage` still
+// ends up carrying it again by the time the searches stop.
+describe('ApplyCustomFilter', () => {
+  it('keeps its other Configure params on every request it drives', async () => {
+    const { requests, searchClient } = createRecordingClient();
+
+    render(
+      <InstantSearch searchClient={searchClient as never} indexName="models_v9">
+        <ApplyCustomFilter filters={['nsfwLevel=1']} hitsPerPage={6} />
+      </InstantSearch>
+    );
+
+    await vi.waitFor(() => {
+      expect(requests.length).toBeGreaterThanOrEqual(2);
+      expect(requests.map((r) => [r.params?.filters, r.params?.hitsPerPage])).toEqual(
+        requests.map(() => ['(nsfwLevel=1)', 6])
+      );
+    });
+  });
+});

--- a/src/components/Search/__tests__/ApplyCustomFilter.browser.test.tsx
+++ b/src/components/Search/__tests__/ApplyCustomFilter.browser.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
 import { render } from 'vitest-browser-react';
 import { InstantSearch } from 'react-instantsearch';
 import { ApplyCustomFilter } from '~/components/Search/CustomSearchComponents';
@@ -32,9 +33,8 @@ function createRecordingClient() {
   };
 }
 
-// Every request is asserted, not only the settled one: the widget registers with the full props and
-// is then re-refined by ApplyCustomFilter's own effect, and a refine that drops `hitsPerPage` still
-// ends up carrying it again by the time the searches stop.
+// Every request is asserted, not only the settled one: a request that carried the filter without
+// `hitsPerPage` would still settle on the right values and read as green.
 describe('ApplyCustomFilter', () => {
   it('keeps its other Configure params on every request it drives', async () => {
     const { requests, searchClient } = createRecordingClient();
@@ -46,10 +46,44 @@ describe('ApplyCustomFilter', () => {
     );
 
     await vi.waitFor(() => {
-      expect(requests.length).toBeGreaterThanOrEqual(2);
+      expect(requests.length).toBeGreaterThanOrEqual(1);
       expect(requests.map((r) => [r.params?.filters, r.params?.hitsPerPage])).toEqual(
         requests.map(() => ['(nsfwLevel=1)', 6])
       );
     });
+  });
+
+  // The widget re-registers with its full props when they change, so a manual `refine` on top of
+  // `useConfigure` only re-issues a search someone already asked for. Measured against production:
+  // it tripled a /search page load, 2 requests to 6.
+  it('drives one search per distinct filter, not two', async () => {
+    const { requests, searchClient } = createRecordingClient();
+    let setFilter: ((filter: string) => void) | undefined;
+
+    function Harness() {
+      const [filter, set] = useState('nsfwLevel=1');
+      setFilter = set;
+
+      return (
+        <InstantSearch searchClient={searchClient as never} indexName="models_v9">
+          <ApplyCustomFilter filters={[filter]} hitsPerPage={6} />
+        </InstantSearch>
+      );
+    }
+
+    render(<Harness />);
+
+    await vi.waitFor(() => expect(requests.length).toBeGreaterThanOrEqual(1));
+
+    setFilter?.('nsfwLevel=1 OR nsfwLevel=2');
+
+    await vi.waitFor(() =>
+      expect(requests.at(-1)?.params?.filters).toBe('(nsfwLevel=1 OR nsfwLevel=2)')
+    );
+
+    expect(requests.map((r) => r.params?.filters)).toEqual([
+      '(nsfwLevel=1)',
+      '(nsfwLevel=1 OR nsfwLevel=2)',
+    ]);
   });
 });

--- a/src/components/Search/__tests__/search-index-contract.test.ts
+++ b/src/components/Search/__tests__/search-index-contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { queryFilters } from '~/components/AutocompleteSearch/autocomplete-query';
 import { BROWSING_LEVEL_ATTRIBUTE } from '~/components/Search/search-index-filters';
 import { buildBrowsingLevelClause } from '~/components/Search/search-filters';
 import type { SearchIndexKey } from '~/components/Search/search.types';
@@ -35,6 +36,26 @@ describe('BROWSING_LEVEL_ATTRIBUTE', () => {
   it('the images override attribute is filterable', () => {
     expect(filterableAttributesByIndex[IMAGES_SEARCH_INDEX]).toContain('combinedNsfwLevel');
   });
+});
+
+describe('queryFilters', () => {
+  const tokenAttributes = Object.entries(queryFilters).flatMap(([key, config]) =>
+    Object.keys(config?.filters ?? {}).map(
+      (attribute) => [key, attribute] as [SearchIndexKey, string]
+    )
+  );
+
+  it.each(tokenAttributes)(
+    '"%s" builds its %s token filter on an attribute its index actually declares',
+    (key, attribute) => {
+      const indexName = searchIndexMap[key];
+
+      expect(
+        filterableAttributesByIndex[indexName],
+        `"${key}" autocomplete turns a search token into \`${attribute} = ...\`, but ${indexName} does not declare ${attribute} filterable — Meilisearch answers 400 invalid_search_filter and the dropdown goes empty`
+      ).toContain(attribute);
+    }
+  );
 });
 
 describe('filterableAttributesByIndex', () => {

--- a/src/components/Search/parsers/__tests__/parse-url.test.ts
+++ b/src/components/Search/parsers/__tests__/parse-url.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ArticlesSearchIndexSortBy,
+  articlesInstantSearchRoutingParser,
+} from '~/components/Search/parsers/article.parser';
+import type { InstantSearchRoutingParser } from '~/components/Search/parsers/base';
+import {
+  BountiesSearchIndexSortBy,
+  bountiesInstantSearchRoutingParser,
+} from '~/components/Search/parsers/bounties.parser';
+import {
+  CollectionsSearchIndexSortBy,
+  collectionsInstantSearchRoutingParser,
+} from '~/components/Search/parsers/collection.parser';
+import {
+  ComicsSearchIndexSortBy,
+  comicsInstantSearchRoutingParser,
+} from '~/components/Search/parsers/comic.parser';
+import {
+  ImagesSearchIndexSortBy,
+  imagesInstantSearchRoutingParser,
+} from '~/components/Search/parsers/image.parser';
+import {
+  ModelSearchIndexSortBy,
+  modelInstantSearchRoutingParser,
+} from '~/components/Search/parsers/model.parser';
+import {
+  ToolsSearchIndexSortBy,
+  toolsInstantSearchRoutingParser,
+} from '~/components/Search/parsers/tool.parser';
+import {
+  UsersSearchIndexSortBy,
+  usersInstantSearchRoutingParser,
+} from '~/components/Search/parsers/user.parser';
+import {
+  ARTICLES_SEARCH_INDEX,
+  BOUNTIES_SEARCH_INDEX,
+  COLLECTIONS_SEARCH_INDEX,
+  COMICS_SEARCH_INDEX,
+  IMAGES_SEARCH_INDEX,
+  MODELS_SEARCH_INDEX,
+  TOOLS_SEARCH_INDEX,
+  USERS_SEARCH_INDEX,
+} from '~/server/common/constants';
+import { QS } from '~/utils/qs';
+
+const parseSearch = (parser: InstantSearchRoutingParser, index: string, search: string) =>
+  parser.parseURL({ location: { search } as unknown as Location })[index] as Record<
+    string,
+    unknown
+  >;
+
+const parseParams = (
+  parser: InstantSearchRoutingParser,
+  index: string,
+  params: Record<string, unknown>
+) => parseSearch(parser, index, `?${QS.stringify(params)}`);
+
+const parserCases = [
+  {
+    name: 'articles',
+    index: ARTICLES_SEARCH_INDEX,
+    parser: articlesInstantSearchRoutingParser,
+    arrayParams: ['tags', 'users'],
+    sortBy: ArticlesSearchIndexSortBy[1],
+  },
+  {
+    name: 'bounties',
+    index: BOUNTIES_SEARCH_INDEX,
+    parser: bountiesInstantSearchRoutingParser,
+    arrayParams: ['baseModel', 'users', 'tags', 'type'],
+    sortBy: BountiesSearchIndexSortBy[1],
+  },
+  {
+    name: 'collections',
+    index: COLLECTIONS_SEARCH_INDEX,
+    parser: collectionsInstantSearchRoutingParser,
+    arrayParams: ['users', 'type'],
+    sortBy: CollectionsSearchIndexSortBy[1],
+  },
+  {
+    name: 'comics',
+    index: COMICS_SEARCH_INDEX,
+    parser: comicsInstantSearchRoutingParser,
+    arrayParams: ['genre'],
+    sortBy: ComicsSearchIndexSortBy[1],
+  },
+  {
+    name: 'images',
+    index: IMAGES_SEARCH_INDEX,
+    parser: imagesInstantSearchRoutingParser,
+    arrayParams: ['baseModel', 'aspectRatio', 'tags', 'tools', 'techniques', 'users'],
+    sortBy: ImagesSearchIndexSortBy[1],
+  },
+  {
+    name: 'models',
+    index: MODELS_SEARCH_INDEX,
+    parser: modelInstantSearchRoutingParser,
+    arrayParams: ['baseModel', 'modelType', 'checkpointType', 'tags', 'users', 'category'],
+    sortBy: ModelSearchIndexSortBy[1],
+  },
+  {
+    name: 'tools',
+    index: TOOLS_SEARCH_INDEX,
+    parser: toolsInstantSearchRoutingParser,
+    arrayParams: ['company', 'type'],
+    sortBy: ToolsSearchIndexSortBy[1],
+  },
+  {
+    name: 'users',
+    index: USERS_SEARCH_INDEX,
+    parser: usersInstantSearchRoutingParser,
+    arrayParams: [],
+    sortBy: UsersSearchIndexSortBy[1],
+  },
+];
+
+describe.each(parserCases)('$name parser', ({ index, parser, arrayParams, sortBy }) => {
+  it('keeps numeric and boolean-looking values in every array param, as strings', () => {
+    const params: Record<string, unknown> = { query: 'art', sortBy };
+    arrayParams.forEach((param, i) => {
+      params[param] = i % 2 === 0 ? 2026 : true;
+    });
+
+    const state = parseParams(parser, index, params);
+
+    expect(state.query).toBe('art');
+    expect(state.sortBy).toBe(sortBy);
+    arrayParams.forEach((param, i) => {
+      expect(state[param]).toEqual([i % 2 === 0 ? '2026' : 'true']);
+    });
+  });
+
+  it('drops only an unparseable sortBy', () => {
+    const params: Record<string, unknown> = { query: 'art', sortBy: 'bogus' };
+    arrayParams.forEach((param) => {
+      params[param] = 'anime';
+    });
+
+    const state = parseParams(parser, index, params);
+
+    expect(state.sortBy).toBeUndefined();
+    expect(state.query).toBe('art');
+    arrayParams.forEach((param) => {
+      expect(state[param]).toEqual(['anime']);
+    });
+  });
+});
+
+describe('articles parser, on the query strings that reported the bug', () => {
+  const articles = (search: string) =>
+    parseSearch(articlesInstantSearchRoutingParser, ARTICLES_SEARCH_INDEX, search);
+
+  it('keeps a numeric tag and its sibling query', () => {
+    expect(articles('?tags=2026&query=art')).toEqual({ tags: ['2026'], query: 'art' });
+  });
+
+  it('keeps a boolean-looking tag and its sibling query', () => {
+    expect(articles('?tags=true&query=art')).toEqual({ tags: ['true'], query: 'art' });
+  });
+
+  it('leaves an alphanumeric tag alone', () => {
+    expect(articles('?tags=1k&query=art')).toEqual({ tags: ['1k'], query: 'art' });
+  });
+
+  it('keeps repeated values for one param together', () => {
+    expect(articles('?tags=anime&tags=2026')).toEqual({ tags: ['anime', '2026'] });
+  });
+
+  it('drops an unparseable sortBy without taking the other params with it', () => {
+    expect(articles('?sortBy=bogus&query=art&tags=anime&users=alice')).toEqual({
+      query: 'art',
+      tags: ['anime'],
+      users: ['alice'],
+    });
+  });
+
+  it('returns an empty state when the only param present is unparseable', () => {
+    expect(articles('?sortBy=bogus')).toEqual({});
+  });
+});

--- a/src/components/Search/parsers/article.parser.ts
+++ b/src/components/Search/parsers/article.parser.ts
@@ -1,5 +1,9 @@
 import type { InstantSearchRoutingParser } from '~/components/Search/parsers/base';
-import { searchParamsSchema } from '~/components/Search/parsers/base';
+import {
+  parseSearchParams,
+  searchParamsSchema,
+  stringArrayParamSchema,
+} from '~/components/Search/parsers/base';
 import * as z from 'zod';
 import { QS } from '~/utils/qs';
 import { removeEmpty } from '~/utils/object-helpers';
@@ -21,12 +25,8 @@ const articleSearchParamsSchema = searchParamsSchema
   .extend({
     index: z.literal('articles'),
     sortBy: z.enum(ArticlesSearchIndexSortBy),
-    tags: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    users: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
+    tags: stringArrayParamSchema,
+    users: stringArrayParamSchema,
   })
   .partial();
 
@@ -34,9 +34,10 @@ export type ArticleSearchParams = z.output<typeof articleSearchParamsSchema>;
 
 export const articlesInstantSearchRoutingParser: InstantSearchRoutingParser = {
   parseURL: ({ location }) => {
-    const articleSearchIndexResult = articleSearchParamsSchema.safeParse(QS.parse(location.search));
-    const articleSearchIndexData: ArticleSearchParams | Record<string, string[]> =
-      articleSearchIndexResult.success ? articleSearchIndexResult.data : {};
+    const articleSearchIndexData = parseSearchParams(
+      articleSearchParamsSchema,
+      QS.parse(location.search)
+    );
 
     return { [ARTICLES_SEARCH_INDEX]: removeEmpty(articleSearchIndexData) };
   },

--- a/src/components/Search/parsers/base.ts
+++ b/src/components/Search/parsers/base.ts
@@ -45,6 +45,36 @@ export const searchParamsSchema = z.object({
   page: z.coerce.number().optional(),
 });
 
+// Coerced, not `z.string()`: QS.parse runs with parseNumbers/parseBooleans, so `?tags=2026`
+// arrives as a number and `?tags=true` as a boolean.
+const coercedString = z.coerce.string();
+
+export const stringArrayParamSchema = z
+  .union([z.array(coercedString), coercedString])
+  .transform((val) => (Array.isArray(val) ? val : [val]));
+
+/** Retries without the params that failed, so one bad value can't discard the search state. */
+export function parseSearchParams<TSchema extends z.ZodType<Record<string, unknown>>>(
+  schema: TSchema,
+  params: Record<string, unknown>
+): z.output<TSchema> | Record<string, never> {
+  const result = schema.safeParse(params);
+  if (result.success) return result.data;
+
+  const invalidKeys = new Set(
+    result.error.issues
+      .map((issue) => issue.path[0])
+      .filter((key): key is string => typeof key === 'string')
+  );
+  if (!invalidKeys.size) return {};
+
+  const retried = schema.safeParse(
+    Object.fromEntries(Object.entries(params).filter(([key]) => !invalidKeys.has(key)))
+  );
+
+  return retried.success ? retried.data : {};
+}
+
 export type InstantSearchRoutingParser = {
   parseURL: (params: { location: Location }) => UiState;
   routeToState: (routeState: UiState) => UiState;

--- a/src/components/Search/parsers/base.ts
+++ b/src/components/Search/parsers/base.ts
@@ -45,9 +45,10 @@ export const searchParamsSchema = z.object({
   page: z.coerce.number().optional(),
 });
 
-// Coerced, not `z.string()`: QS.parse runs with parseNumbers/parseBooleans, so `?tags=2026`
-// arrives as a number and `?tags=true` as a boolean.
-const coercedString = z.coerce.string();
+// QS.parse runs with parseNumbers/parseBooleans, so `?tags=2026` arrives as a number and
+// `?tags=true` as a boolean. Narrower than `z.coerce.string()`, which would also accept the `null`
+// a bare `?tags` produces and turn it into the string "null" — a filter that matches nothing.
+const coercedString = z.union([z.string(), z.number(), z.boolean()]).transform(String);
 
 export const stringArrayParamSchema = z
   .union([z.array(coercedString), coercedString])

--- a/src/components/Search/parsers/bounties.parser.ts
+++ b/src/components/Search/parsers/bounties.parser.ts
@@ -1,5 +1,9 @@
 import type { InstantSearchRoutingParser } from '~/components/Search/parsers/base';
-import { searchParamsSchema } from '~/components/Search/parsers/base';
+import {
+  parseSearchParams,
+  searchParamsSchema,
+  stringArrayParamSchema,
+} from '~/components/Search/parsers/base';
 import * as z from 'zod';
 import { QS } from '~/utils/qs';
 import { removeEmpty } from '~/utils/object-helpers';
@@ -20,18 +24,10 @@ const collectionSearchParamsSchema = searchParamsSchema
   .extend({
     index: z.literal('bounties'),
     sortBy: z.enum(BountiesSearchIndexSortBy),
-    baseModel: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    users: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    tags: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    type: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
+    baseModel: stringArrayParamSchema,
+    users: stringArrayParamSchema,
+    tags: stringArrayParamSchema,
+    type: stringArrayParamSchema,
   })
   .partial();
 
@@ -39,11 +35,10 @@ export type BountySearchParams = z.output<typeof collectionSearchParamsSchema>;
 
 export const bountiesInstantSearchRoutingParser: InstantSearchRoutingParser = {
   parseURL: ({ location }) => {
-    const collectionSearchIndexResult = collectionSearchParamsSchema.safeParse(
+    const collectionSearchIndexData = parseSearchParams(
+      collectionSearchParamsSchema,
       QS.parse(location.search)
     );
-    const collectionSearchIndexData: BountySearchParams | Record<string, string[]> =
-      collectionSearchIndexResult.success ? collectionSearchIndexResult.data : {};
 
     return { [BOUNTIES_SEARCH_INDEX]: removeEmpty(collectionSearchIndexData) };
   },

--- a/src/components/Search/parsers/collection.parser.ts
+++ b/src/components/Search/parsers/collection.parser.ts
@@ -1,5 +1,9 @@
 import type { InstantSearchRoutingParser } from '~/components/Search/parsers/base';
-import { searchParamsSchema } from '~/components/Search/parsers/base';
+import {
+  parseSearchParams,
+  searchParamsSchema,
+  stringArrayParamSchema,
+} from '~/components/Search/parsers/base';
 import * as z from 'zod';
 import { QS } from '~/utils/qs';
 import { removeEmpty } from '~/utils/object-helpers';
@@ -19,12 +23,8 @@ const collectionSearchParamsSchema = searchParamsSchema
   .extend({
     index: z.literal('collections'),
     sortBy: z.enum(CollectionsSearchIndexSortBy),
-    users: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    type: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
+    users: stringArrayParamSchema,
+    type: stringArrayParamSchema,
   })
   .partial();
 
@@ -32,11 +32,10 @@ export type CollectionSearchParams = z.output<typeof collectionSearchParamsSchem
 
 export const collectionsInstantSearchRoutingParser: InstantSearchRoutingParser = {
   parseURL: ({ location }) => {
-    const collectionSearchIndexResult = collectionSearchParamsSchema.safeParse(
+    const collectionSearchIndexData = parseSearchParams(
+      collectionSearchParamsSchema,
       QS.parse(location.search)
     );
-    const collectionSearchIndexData: CollectionSearchParams | Record<string, string[]> =
-      collectionSearchIndexResult.success ? collectionSearchIndexResult.data : {};
 
     return { [COLLECTIONS_SEARCH_INDEX]: removeEmpty(collectionSearchIndexData) };
   },

--- a/src/components/Search/parsers/comic.parser.ts
+++ b/src/components/Search/parsers/comic.parser.ts
@@ -1,7 +1,11 @@
 import type { UiState } from 'instantsearch.js';
 import * as z from 'zod';
 import type { InstantSearchRoutingParser } from '~/components/Search/parsers/base';
-import { searchParamsSchema } from '~/components/Search/parsers/base';
+import {
+  parseSearchParams,
+  searchParamsSchema,
+  stringArrayParamSchema,
+} from '~/components/Search/parsers/base';
 import { COMICS_SEARCH_INDEX } from '~/server/common/constants';
 import { removeEmpty } from '~/utils/object-helpers';
 import { QS } from '~/utils/qs';
@@ -21,17 +25,16 @@ const comicSearchParamsSchema = searchParamsSchema
   .extend({
     index: z.literal('comics'),
     sortBy: z.enum(ComicsSearchIndexSortBy),
-    genre: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
+    genre: stringArrayParamSchema,
   })
   .partial();
 
 export const comicsInstantSearchRoutingParser: InstantSearchRoutingParser = {
   parseURL: ({ location }) => {
-    const comicSearchIndexResult = comicSearchParamsSchema.safeParse(QS.parse(location.search));
-    const comicSearchIndexData: ComicSearchParams | Record<string, string[]> =
-      comicSearchIndexResult.success ? comicSearchIndexResult.data : {};
+    const comicSearchIndexData = parseSearchParams(
+      comicSearchParamsSchema,
+      QS.parse(location.search)
+    );
 
     return { [COMICS_SEARCH_INDEX]: removeEmpty(comicSearchIndexData) };
   },

--- a/src/components/Search/parsers/image.parser.ts
+++ b/src/components/Search/parsers/image.parser.ts
@@ -4,7 +4,7 @@ import { IMAGES_SEARCH_INDEX } from '~/server/common/constants';
 import { removeEmpty } from '~/utils/object-helpers';
 import { QS } from '~/utils/qs';
 import type { InstantSearchRoutingParser } from './base';
-import { searchParamsSchema } from './base';
+import { parseSearchParams, searchParamsSchema, stringArrayParamSchema } from './base';
 
 export const ImagesSearchIndexSortBy = [
   IMAGES_SEARCH_INDEX,
@@ -23,24 +23,12 @@ const imageSearchParamsSchema = searchParamsSchema
     index: z.literal('images'),
     createdAt: z.string(),
     sortBy: z.enum(ImagesSearchIndexSortBy),
-    baseModel: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    aspectRatio: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    tags: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    tools: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    techniques: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    users: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
+    baseModel: stringArrayParamSchema,
+    aspectRatio: stringArrayParamSchema,
+    tags: stringArrayParamSchema,
+    tools: stringArrayParamSchema,
+    techniques: stringArrayParamSchema,
+    users: stringArrayParamSchema,
   })
   .partial();
 
@@ -52,9 +40,10 @@ export type ImageSearchParams = z.output<typeof imageSearchParamsSchema>;
 
 export const imagesInstantSearchRoutingParser: InstantSearchRoutingParser = {
   parseURL: ({ location }) => {
-    const imageSearchIndexResult = imageSearchParamsSchema.safeParse(QS.parse(location.search));
-    const imageSearchIndexData: ImageSearchParams | Record<string, string[]> =
-      imageSearchIndexResult.success ? imageSearchIndexResult.data : {};
+    const imageSearchIndexData = parseSearchParams(
+      imageSearchParamsSchema,
+      QS.parse(location.search)
+    );
 
     return { [IMAGES_SEARCH_INDEX]: removeEmpty(imageSearchIndexData) };
   },

--- a/src/components/Search/parsers/model.parser.ts
+++ b/src/components/Search/parsers/model.parser.ts
@@ -1,10 +1,14 @@
 import type { InstantSearchRoutingParser } from '~/components/Search/parsers/base';
-import { searchParamsSchema } from '~/components/Search/parsers/base';
+import {
+  parseSearchParams,
+  searchParamsSchema,
+  stringArrayParamSchema,
+} from '~/components/Search/parsers/base';
 import * as z from 'zod';
 import { QS } from '~/utils/qs';
 import { removeEmpty } from '~/utils/object-helpers';
 import type { IndexUiState, UiState } from 'instantsearch.js';
-import { IMAGES_SEARCH_INDEX, MODELS_SEARCH_INDEX } from '~/server/common/constants';
+import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
 
 export const ModelSearchIndexSortBy = [
   MODELS_SEARCH_INDEX,
@@ -26,24 +30,12 @@ const modelSearchParamsSchema = searchParamsSchema
   .extend({
     sortBy: z.enum(ModelSearchIndexSortBy),
     lastVersionAt: z.string(),
-    baseModel: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    modelType: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    checkpointType: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    tags: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    users: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    category: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
+    baseModel: stringArrayParamSchema,
+    modelType: stringArrayParamSchema,
+    checkpointType: stringArrayParamSchema,
+    tags: stringArrayParamSchema,
+    users: stringArrayParamSchema,
+    category: stringArrayParamSchema,
   })
   .partial();
 
@@ -54,10 +46,10 @@ type ModelUiState = UiState & {
 
 export const modelInstantSearchRoutingParser: InstantSearchRoutingParser = {
   parseURL: ({ location }) => {
-    const modelSearchIndexResult = modelSearchParamsSchema.safeParse(QS.parse(location.search));
-
-    const modelSearchIndexData: ModelSearchParams | Record<string, string[]> =
-      modelSearchIndexResult.success ? modelSearchIndexResult.data : {};
+    const modelSearchIndexData = parseSearchParams(
+      modelSearchParamsSchema,
+      QS.parse(location.search)
+    );
 
     return { [MODELS_SEARCH_INDEX]: removeEmpty(modelSearchIndexData) };
   },

--- a/src/components/Search/parsers/tool.parser.ts
+++ b/src/components/Search/parsers/tool.parser.ts
@@ -1,7 +1,11 @@
 import type { UiState } from 'instantsearch.js';
 import * as z from 'zod';
 import type { InstantSearchRoutingParser } from '~/components/Search/parsers/base';
-import { searchParamsSchema } from '~/components/Search/parsers/base';
+import {
+  parseSearchParams,
+  searchParamsSchema,
+  stringArrayParamSchema,
+} from '~/components/Search/parsers/base';
 import { TOOLS_SEARCH_INDEX } from '~/server/common/constants';
 import { removeEmpty } from '~/utils/object-helpers';
 import { QS } from '~/utils/qs';
@@ -21,20 +25,17 @@ const toolSearchParamsSchema = searchParamsSchema
   .extend({
     index: z.literal('tools'),
     sortBy: z.enum(ToolsSearchIndexSortBy),
-    company: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
-    type: z
-      .union([z.array(z.string()), z.string()])
-      .transform((val) => (Array.isArray(val) ? val : [val])),
+    company: stringArrayParamSchema,
+    type: stringArrayParamSchema,
   })
   .partial();
 
 export const toolsInstantSearchRoutingParser: InstantSearchRoutingParser = {
   parseURL: ({ location }) => {
-    const collectionSearchIndexResult = toolSearchParamsSchema.safeParse(QS.parse(location.search));
-    const collectionSearchIndexData: ToolSearchParams | Record<string, string[]> =
-      collectionSearchIndexResult.success ? collectionSearchIndexResult.data : {};
+    const collectionSearchIndexData = parseSearchParams(
+      toolSearchParamsSchema,
+      QS.parse(location.search)
+    );
 
     return { [TOOLS_SEARCH_INDEX]: removeEmpty(collectionSearchIndexData) };
   },

--- a/src/components/Search/parsers/user.parser.ts
+++ b/src/components/Search/parsers/user.parser.ts
@@ -1,5 +1,5 @@
 import type { InstantSearchRoutingParser } from '~/components/Search/parsers/base';
-import { searchParamsSchema } from '~/components/Search/parsers/base';
+import { parseSearchParams, searchParamsSchema } from '~/components/Search/parsers/base';
 import * as z from 'zod';
 import { QS } from '~/utils/qs';
 import { removeEmpty } from '~/utils/object-helpers';
@@ -27,9 +27,10 @@ export type UserSearchParams = z.output<typeof userSearchParamsSchema>;
 
 export const usersInstantSearchRoutingParser: InstantSearchRoutingParser = {
   parseURL: ({ location }) => {
-    const userSearchIndexResult = userSearchParamsSchema.safeParse(QS.parse(location.search));
-    const userSearchIndexData: UserSearchParams | Record<string, string[]> =
-      userSearchIndexResult.success ? userSearchIndexResult.data : {};
+    const userSearchIndexData = parseSearchParams(
+      userSearchParamsSchema,
+      QS.parse(location.search)
+    );
 
     return { [USERS_SEARCH_INDEX]: removeEmpty(userSearchIndexData) };
   },


### PR DESCRIPTION
**Live NSFW fail-open.** Typing `#tag`, `@user` or `hash:` in the header search dropped the browsing-level filter entirely, so a PG user was served R/X/XXX and Blocked models.

Five commits: the leak fix (+ a second bug found beside it), a duplicate-request removal that fell out of it, token search extended to the other indexes that support it, and a URL-param parsing fix that the token work exposed.

---

## 1. The leak

`AutocompleteSearch` had **two** widgets writing the `filters` search parameter into one `<InstantSearch>` tree: `BrowsingLevelFilter` (browsing level + poi/minor/availability) and a raw `<Configure hitsPerPage filters={filters}>` inside `AutocompleteSearchContentInner` carrying the `parseQuery` token filters. The later-mounted widget wins, so a non-empty token filter **replaced** the safety filter instead of joining it.

Captured in a browser against production:

```
plain "anime" → (poi != true) AND (availability != Private) AND (nsfwLevel=1)   correct
"#anime"      → tags.name = 'anime'                                             browsing filter GONE
"@civitai"    → user.username = 'civitai'                                        browsing filter GONE
```

Measured over 50 hits on production `models_v9`:

| filter | hits with no PG bit |
|---|---|
| `tags.name = 'anime'` (what shipped) | **14 / 50** — levels `[4,8,16,32]`, including Blocked(32) |
| `(tags.name = 'anime') AND (nsfwLevel=1)` | 0 / 50 |

**Fix:** `BrowsingLevelFilter` moves into the inner component as the single writer, receiving the outer clauses via a new `baseFilters` prop alongside the token filters. The raw `Configure` is deleted.

Re-verified in a browser against production — every path now carries the browsing clause:

```
#anime     … AND (tags.name = 'anime') AND (nsfwLevel=1)
@civitai   … AND (user.username = 'civitai') AND (nsfwLevel=1)
hash:…     … AND (versions.hashes = '…') AND (nsfwLevel=1)
```

The other three `<InstantSearch>` trees were swept and do **not** have this collision: `SearchLayout` sets `hitsPerPage`/`attributesToHighlight` but not `filters`; `QuickSearchDropdown` has only `BrowsingLevelFilter`; `CollectionSelectModal` has one `Configure` and no browsing filter by construction (scoped to the model owner's own collections).

## 2. "View more results" dropped the token

Same `parseQuery` output, dropped on a different path — `handleSubmit` merged `searchPageQuery` into the URL, the view-more branch pushed `?query=${item.value}` and nothing else. Since `parseQuery` rewrites the query to a single space when the input was all tokens, view-more landed on a blank search.

| after typing `#anime` | before | after |
|---|---|---|
| press Enter | `/search/models?tags=anime&sortBy=models_v9` | unchanged |
| click View more results | `/search/models?sortBy=models_v9&query=%20` | `/search/models?tags=anime&sortBy=models_v9` |

Both paths now go through one exported `buildSearchPageUrl`.

## 3. `ApplyCustomFilter`'s redundant `refine`

`useConfigure` already re-registers the widget with its full props when they change, so the `useEffect` calling `refine` only re-issued a search that was already going out. Measured against production:

| | before | after |
|---|---|---|
| `/search/*` page load | **6** requests | **2** |
| autocomplete `@civitai` | 3 | 2 |

Correctness is unchanged — filters still apply and still update — and the effect did **not** prevent the unfiltered initial request, which is present either way (that one comes from inside the adapter; see the note below).

Worth knowing: `connectConfigure`'s `refine` **replaces** the widget's search parameters rather than merging, so the original `refine({ filters })` was deleting `hitsPerPage` from the request. `QuickSearchDropdown` already had that latent loss, masked by Mantine's client-side `limit`.

## 4. Token search for images, articles and collections

The `#tag` / `@user` tokens worked on models only. Attributes taken from the **production** indexes, not assumed:

| index | `#tag` | `@user` |
|---|---|---|
| models | `tags.name` | `user.username` |
| images | **`tagNames`** | `user.username` |
| articles | `tags.name` | `user.username` |
| collections | — | `user.username` |

`hash:` stays models-only. Bounties qualifies technically but bounty search isn't surfaced in the frontend, so it's left out.

⚠️ **images uses `tagNames`, not `tags.name`.** Copy-pasting the models block would 400 the whole search — the bug class #4128 fixed. The `searchPageMap` still translates it to the `tags` URL param, so the routing parsers need no changes.

The contract test from #4128 now covers token attributes too, so that mistake can't merge. Made deliberately, it fails in two places with the reason spelled out:

```
"images" autocomplete turns a search token into `tags.name = ...`, but images_v6 does not
declare tags.name filterable — Meilisearch answers 400 invalid_search_filter and the
dropdown goes empty: expected [ 'id', 'createdAtUnix', …(12) ] to include 'tags.name'
```

## 5. One bad URL param wiped the whole search state

Extending `#tag` to articles surfaced this. `QS.parse` runs with `parseNumbers`/`parseBooleans`, so
`?tags=2026` arrives as a **number** and `?tags=true` as a **boolean**. The parsers declared those
fields as `z.string()`, and each `parseURL` did `result.success ? result.data : {}` — so one bad
value discarded **every** param on the page.

`2026` is a real articles tag with 9 PG articles behind it. Measured in a browser on `main`:

| | main | this PR |
|---|---|---|
| `/search/articles?query=art&tags=2026` | **0 Meili requests, blank page** | **4 results, filter applied** |

Zero requests, not "filter ignored": the query was discarded too, so the empty-query short-circuit
fired and the page never searched.

Two independent faults, both fixed:

- **Coercion** — a shared `stringArrayParamSchema` built on `z.union([z.string(), z.number(), z.boolean()]).transform(String)`, replacing all 23 `z.union([z.array(z.string()), z.string()])` fields across 7 parsers. Deliberately narrower than `z.coerce.string()`, which also accepts the `null` a bare `?tags` produces and would turn it into the string `"null"` — a filter matching nothing.
- **`parseSearchParams`** — on failure, drops only the offending top-level keys and re-parses. Wired into all 8 `parseURL`s. This is what makes the narrowing above an improvement rather than a regression: a bare `?tags` now drops that one param and keeps the rest.

They are independent, proven by reverting each alone — **disjoint failure sets**: reverting the
coercion fails 10 tests (`expected undefined to deeply equal [ '2026' ]`), reverting the helper fails
9 (`parser drops only an unparseable sortBy`). Neither revert breaks the other's tests, so `?sortBy=bogus`
was never a coercion problem.

---

## Tests

`parseQuery`, `checkAIR` and `buildSearchPageUrl` move to `autocomplete-query.ts` so they are unit-testable (the vitest `unit` project collects `src/**/*.test.ts` only). 86 tests across the four affected files; typecheck clean.

Reverting each fix fails loudly:

| reverted | output |
|---|---|
| the two-widget shape | `expected [ 'BrowsingLevelFilter', 'Configure' ] to deeply equal [ 'BrowsingLevelFilter' ]` |
| the view-more URL | `expected '/search/models?query=%20' to be '/search/models?tags=anime'` |
| the `refine` removal | `expected [ '(nsfwLevel=1)', …(3) ] to deeply equal [ '(nsfwLevel=1)', …(1) ]` |
| images' tag attribute | the contract-test message above |

Stated plainly: the two *wiring* invariants (one widget writes `filters`; every `/search` push goes through the builder) are held by source-text assertions, following the convention-guard pattern already in this repo, because the unit project cannot collect `.tsx`. Everything else is real function-level or browser-level testing.

## Testing the token filters — one thing that looks like a bug and isn't

`#tag` on images resolves to `tagNames` and lands in the URL as `?tags=<value>`, which the images
parser maps back to the `tagNames` refinement. Verified end to end.

Two things can make a working filter look broken while testing:

1. **An empty intersection reads as "the filter did nothing".** On production, `q=goku` matches
   30,677 images and `tagNames = 'saiyan'` matches 10, but the intersection is **0** — and all 10 of
   those are excluded at PG/poi anyway. `goku #abs` returns 167 and is a better smoke test.
2. **The Tags chip disappears when the selection matches zero documents.** Measured on both pages,
   so it is index-independent and pre-existing:

   | page | tag + query | results | Tags widget |
   |---|---|---|---|
   | models | `saiyan` + `goku` | 4 | `[Tags saiyan]` |
   | models | `saiyan` + `zzqqxnomatch` | 0 | `[Tags]` |
   | images | `abs` + `goku` | 167 | `[Tags abs]` |
   | images | `saiyan` + `goku` | 0 | `[Tags]` |

   The Users widget keeps its chip at zero results. The one config difference is that Tags passes
   `operator="and"` on both pages while Users takes the default `"or"` — a plausible cause, but the
   mechanism is not verified here, only the behaviour. Untouched by this PR either way.

## Known, not fixed here

Each search still makes one extra `/multi-search` with no query and no filter. That is **inside the vendored adapter** — `initFacetDistribution` (`instant-meilisearch.esm.js:896`) issues `getParametersWithoutFilters(searchContext)` before every search cycle, which is why it carries no filter. It is not gated on `keepZeroFacets`, and it is **unchanged in the latest 1.0.0** (verified against the published tarball), so upgrading does not help. It is cached per `indexUid`, so it costs one request per index per page load, not per keystroke. Removing it needs a `pnpm patch` gating the call on `keepZeroFacets || placeholderSearch` — which is the condition the adapter's own comment says it is for — and belongs in its own PR.

Found while investigating CU 868kt6hdx.
