### PR TITLE
fix(remix-gallery): moderator mode toggle, removal copy, submit picker

### DIFF
--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -40,7 +40,10 @@ import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImag
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import type { RemixGalleryItem } from '~/components/RemixGallery/remix-gallery.utils';
-import { dedupeGalleryItems } from '~/components/RemixGallery/remix-gallery.utils';
+import {
+  dedupeGalleryItems,
+  remixGalleryModerating,
+} from '~/components/RemixGallery/remix-gallery.utils';
 import { QueueThumb } from '~/components/RemixGallery/SubmissionPair';
 import { VerifiedRemixBadge } from '~/components/RemixGallery/VerifiedRemixBadge';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
@@ -112,6 +115,9 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
 
   // The card has already run this, so react-query serves it from cache.
   const { data: visibility } = trpc.placement.getRemixGalleryVisibility.useQuery({ imageId });
+  // `undefined` while the query is in flight, which is NOT "not the owner" — see
+  // `remixGalleryModerating`.
+  const ownerKnown = visibility !== undefined;
   const isOwner = !!currentUser && currentUser.id === visibility?.ownerId;
 
   /**
@@ -135,11 +141,17 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
    * throw "not in this gallery". Hiding them is honesty about reach, not a
    * permission check — the server is the permission check.
    *
-   * They are hidden on an owner's own gallery in this mode too, where they
-   * would work. The point of the mode is to be looking at the gallery the way a
-   * moderator does, and the toggle is one click away.
+   * On your OWN gallery in this mode they are kept, because there they work —
+   * the `ownerId = caller` scoping those queries use is satisfied. Hiding them
+   * would take away working controls that nobody asked to lose, and leave the
+   * ordinary job of clearing your queue behind a round trip through the toggle.
    */
-  const moderating = isModerator && (!isOwner || asModerator);
+  const moderating = remixGalleryModerating({ isModerator, isOwner, ownerKnown, asModerator });
+
+  // Reach, not permission: the review queue, the pinned row and the pin control
+  // all scope to `ownerId = caller` server-side, so they are empty or refusing
+  // on someone else's gallery. On your own they work in either mode.
+  const hideOwnerSections = moderating && !isOwner;
 
   // Scoped server-side. Filtering the account-wide list here meant its limit
   // truncated before the filter ran, so a busy owner saw "nothing waiting" on
@@ -312,15 +324,17 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                 : `You are moderating ${visibility?.ownerUsername ?? 'another creator'}'s gallery`}
             </Text>
             <Text size="xs" mt={2}>
-              You can remove entries here at any time — the creator has to wait a week after
-              approving one. The submitter is not refunded, and the removal is logged under your
-              name rather than the creator&apos;s. Approving, declining and pinning stay with the
-              creator.
+              You can remove entries here at any time — as the creator you would have to wait a week
+              after approving one. The submitter is not refunded, and the removal is logged as a
+              moderator action.{' '}
+              {isOwner
+                ? 'Approving, declining and pinning are unchanged — they are yours either way.'
+                : 'Approving, declining and pinning stay with the creator.'}
             </Text>
           </Alert>
         )}
 
-        {!moderating && (
+        {!hideOwnerSections && (
           <div>
             <SectionDivider
               icon={IconInbox}
@@ -617,7 +631,7 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
           </div>
         )}
 
-        {!moderating && (
+        {!hideOwnerSections && (
           <div>
             <SectionDivider
               icon={IconPin}
@@ -682,7 +696,7 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                         scopes its lookup to the caller as owner — a moderator
                         pressing this would get "not in this gallery" on every
                         press. */}
-                    {!moderating && (
+                    {!hideOwnerSections && (
                       <Tooltip
                         label={
                           atPinCap

--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -14,6 +14,7 @@ import {
   Loader,
   Modal,
   Popover,
+  SegmentedControl,
   Stack,
   Text,
   Tooltip,
@@ -114,17 +115,31 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
   const isOwner = !!currentUser && currentUser.id === visibility?.ownerId;
 
   /**
-   * A moderator on someone else's gallery, which is a different modal.
+   * Opt-in, and only offered to a moderator on their own gallery.
+   *
+   * Off by default because moderators use the site as ordinary creators and
+   * should get the creator rules on their own work unless they say otherwise.
+   * Ownership used to decide this on its own, which left a moderator able to
+   * moderate every gallery except the one they owned.
+   */
+  const [asModerator, setAsModerator] = useState(false);
+
+  /**
+   * Moderating rather than curating, which is a different modal.
    *
    * Two of the three sections are not merely disallowed for them, they are
-   * unusable: `getPendingRemixGallerySubmissions` scopes to `ownerId = caller`,
-   * so the review queue comes back empty and would render "Nothing waiting."
-   * over a gallery that has two waiting; and `setRemixGalleryPins` scopes its
-   * lookup the same way, so every drag would throw "not in this gallery".
-   * Hiding them is honesty about reach, not a permission check — the server is
-   * the permission check.
+   * unusable on someone else's gallery: `getPendingRemixGallerySubmissions`
+   * scopes to `ownerId = caller`, so the review queue comes back empty and
+   * would render "Nothing waiting." over a gallery that has two waiting; and
+   * `setRemixGalleryPins` scopes its lookup the same way, so every drag would
+   * throw "not in this gallery". Hiding them is honesty about reach, not a
+   * permission check — the server is the permission check.
+   *
+   * They are hidden on an owner's own gallery in this mode too, where they
+   * would work. The point of the mode is to be looking at the gallery the way a
+   * moderator does, and the toggle is one click away.
    */
-  const moderating = isModerator && !isOwner;
+  const moderating = isModerator && (!isOwner || asModerator);
 
   // Scoped server-side. Filtering the account-wide list here meant its limit
   // truncated before the filter ran, so a busy owner saw "nothing waiting" on
@@ -264,19 +279,43 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
       size="lg"
     >
       <Stack gap="md">
+        {isModerator && isOwner && (
+          // Only on your own gallery. Everywhere else the mode is not a choice:
+          // there is no creator role available to a moderator on someone
+          // else's gallery, and offering one would be a control that does
+          // nothing.
+          <SegmentedControl
+            fullWidth
+            size="xs"
+            value={asModerator ? 'moderate' : 'manage'}
+            onChange={(value) => setAsModerator(value === 'moderate')}
+            data={[
+              { value: 'manage', label: 'Manage as creator' },
+              { value: 'moderate', label: 'Moderate' },
+            ]}
+          />
+        )}
+
         {moderating && (
           // Not decoration. The same button in an owner's hands returns the
           // submitter's Buzz and in a moderator's keeps it, and the row records
           // which happened. Someone holding both roles should not have to
           // remember which gallery they are looking at.
+          //
+          // "Takedown" is deliberately not used here. It is our word for DMCA
+          // and NCII, and two moderators independently read this copy as one of
+          // those.
           <Alert color="red" icon={<IconShieldCheck size={18} />} p="xs">
             <Text size="sm" fw={600}>
-              You are moderating {visibility?.ownerUsername ?? 'another creator'}&apos;s gallery
+              {isOwner
+                ? 'You are moderating your own gallery'
+                : `You are moderating ${visibility?.ownerUsername ?? 'another creator'}'s gallery`}
             </Text>
             <Text size="xs" mt={2}>
-              You can take entries down. Removing one here is a moderator takedown — the submitter
-              is not refunded, and the removal is recorded against you rather than the creator.
-              Approving, declining and pinning stay with the creator.
+              You can remove entries here at any time — the creator has to wait a week after
+              approving one. The submitter is not refunded, and the removal is logged under your
+              name rather than the creator&apos;s. Approving, declining and pinning stay with the
+              creator.
             </Text>
           </Alert>
         )}
@@ -664,27 +703,33 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                     )}
                     <RemoveEntryButton
                       item={item}
-                      isModerator={isModerator}
+                      moderating={moderating}
                       pending={actingOn(item.placementId, 'remove')}
                       onRemove={() => {
+                        // The server cannot read the mode off ownership — that
+                        // is the bug — so it is sent.
                         const remove = () =>
-                          act.mutate({ placementId: item.placementId, action: 'remove' });
+                          act.mutate({
+                            placementId: item.placementId,
+                            action: 'remove',
+                            asModerator: moderating,
+                          });
                         // Confirmed for a moderator and not for an owner, because
                         // the two are different acts: an owner removal returns the
-                        // submitter's Buzz, a moderator takedown keeps it. Nothing
+                        // submitter's Buzz, a moderator removal keeps it. Nothing
                         // undoes that, and the row records who did it.
                         if (!moderating) return remove();
                         openConfirmModal({
-                          title: 'Take this entry down',
+                          title: 'Remove this entry',
                           children: (
                             <Text size="sm">
                               This removes the remix from{' '}
-                              {visibility?.ownerUsername ?? 'the creator'}&apos;s gallery for
-                              everyone. The submitter is not refunded, and the takedown is recorded
-                              against you.
+                              {isOwner ? 'your' : `${visibility?.ownerUsername ?? 'the creator'}'s`}{' '}
+                              gallery for everyone. The submitter is not refunded, and the removal
+                              is logged as a moderator action under your name.
                             </Text>
                           ),
-                          labels: { confirm: 'Take down', cancel: 'Cancel' },
+                          labels: { confirm: 'Remove', cancel: 'Cancel' },
                           confirmProps: { color: 'red' },
                           onConfirm: remove,
                         });
@@ -728,23 +773,24 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
  * a missing `resolvedAt` shows an enabled button and lets the server rule,
  * rather than locking someone out on absent data.
  *
- * Moderators are exempt here because they are exempt on the mutation. Disabling
- * it for them would hide an action the server would allow, and a takedown is
- * the case that must not wait.
+ * Keyed on the MODE rather than on holding the moderator role, because that is
+ * what the mutation is keyed on. Reading the role alone left a moderator on
+ * their own gallery an enabled button and a server refusal — the wait still
+ * applied, and the only place it was stated was the error.
  */
 function RemoveEntryButton({
   item,
-  isModerator,
+  moderating,
   pending,
   onRemove,
 }: {
   item: RemixGalleryItem;
-  isModerator: boolean;
+  moderating: boolean;
   pending: boolean;
   onRemove: () => void;
 }) {
   const removableAt = item.resolvedAt ? remixGalleryRemovableAt(item.resolvedAt) : null;
-  const locked = !isModerator && !!removableAt && removableAt > new Date();
+  const locked = !moderating && !!removableAt && removableAt > new Date();
 
   return (
     <Tooltip

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -17,6 +17,7 @@ import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
 import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { useQueryImages } from '~/components/Image/image.utils';
+import { ImageSort } from '~/server/common/enums';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { NoContent } from '~/components/NoContent/NoContent';
 import {
@@ -72,8 +73,18 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
     { enabled: !!currentUser && selected != null }
   );
 
+  // `publishedOnly` because both feed paths otherwise carve out the caller's own
+  // unpublished posts, and a draft cannot be submitted — the mutation refuses it.
+  // Newest because someone submitting a remix has usually just made it; the
+  // default is most-reacted, which buries it.
   const { images, isLoading, fetchNextPage, hasNextPage, isRefetching } = useQueryImages(
-    { userId: currentUser?.id, period: 'AllTime', limit: 50 },
+    {
+      userId: currentUser?.id,
+      period: 'AllTime',
+      limit: 50,
+      sort: ImageSort.Newest,
+      publishedOnly: true,
+    },
     { enabled: !!currentUser }
   );
 

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -17,7 +17,7 @@ import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
 import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { useQueryImages } from '~/components/Image/image.utils';
-import { ImageSort } from '~/server/common/enums';
+import { remixSubmitPickerFilters } from '~/components/RemixGallery/remix-gallery.utils';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { NoContent } from '~/components/NoContent/NoContent';
 import {
@@ -73,18 +73,8 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
     { enabled: !!currentUser && selected != null }
   );
 
-  // `publishedOnly` because both feed paths otherwise carve out the caller's own
-  // unpublished posts, and a draft cannot be submitted — the mutation refuses it.
-  // Newest because someone submitting a remix has usually just made it; the
-  // default is most-reacted, which buries it.
   const { images, isLoading, fetchNextPage, hasNextPage, isRefetching } = useQueryImages(
-    {
-      userId: currentUser?.id,
-      period: 'AllTime',
-      limit: 50,
-      sort: ImageSort.Newest,
-      publishedOnly: true,
-    },
+    remixSubmitPickerFilters(currentUser?.id),
     { enabled: !!currentUser }
   );
 

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -7,6 +7,7 @@ import {
   freeSubmissionOffer,
   galleryDialogImages,
   paidSubmissionOpen,
+  remixSubmitPickerFilters,
   submissionMethod,
   trimToWholeRows,
 } from '~/components/RemixGallery/remix-gallery.utils';
@@ -389,5 +390,26 @@ describe('galleryDialogImages', () => {
     expect(result).toHaveLength(100);
     expect(result[0].id).toBe(70);
     expect(result[result.length - 1].id).toBe(169);
+  });
+});
+
+describe('remixSubmitPickerFilters', () => {
+  // Both of these were reported from the picker: a moderator was offered their
+  // own drafts, which the submit mutation refuses, and the grid opened on a
+  // year-old image because the feed sorts by reactions unless told otherwise.
+  // Neither is visible in a rendered grid — a picker missing them looks like a
+  // picker.
+  it('asks for published images only', () => {
+    expect(remixSubmitPickerFilters(7).publishedOnly).toBe(true);
+  });
+
+  it('asks for the newest first, not the feed default', () => {
+    expect(remixSubmitPickerFilters(7).sort).toBe('Newest');
+  });
+
+  it('scopes the picker to the submitter', () => {
+    // The picker offers your own work to submit. Dropping this would offer
+    // everyone's, and every one of them would be refused.
+    expect(remixSubmitPickerFilters(7).userId).toBe(7);
   });
 });

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -7,6 +7,7 @@ import {
   freeSubmissionOffer,
   galleryDialogImages,
   paidSubmissionOpen,
+  remixGalleryModerating,
   remixSubmitPickerFilters,
   submissionMethod,
   trimToWholeRows,
@@ -411,5 +412,40 @@ describe('remixSubmitPickerFilters', () => {
     // The picker offers your own work to submit. Dropping this would offer
     // everyone's, and every one of them would be refused.
     expect(remixSubmitPickerFilters(7).userId).toBe(7);
+  });
+});
+
+describe('remixGalleryModerating', () => {
+  const base = { isModerator: true, isOwner: false, ownerKnown: true, asModerator: false };
+
+  it('moderates another creator gallery without being asked', () => {
+    // There is no creator role available there, so there is nothing to choose.
+    expect(remixGalleryModerating(base)).toBe(true);
+  });
+
+  it('leaves a moderator on their own gallery under the creator rules by default', () => {
+    expect(remixGalleryModerating({ ...base, isOwner: true })).toBe(false);
+  });
+
+  it('moderates your own gallery only when you ask', () => {
+    expect(remixGalleryModerating({ ...base, isOwner: true, asModerator: true })).toBe(true);
+  });
+
+  it('gives a non-moderator nothing, whatever they claim', () => {
+    expect(remixGalleryModerating({ ...base, isModerator: false, asModerator: true })).toBe(false);
+  });
+
+  // 🔴 The reason this is a function at all. `isOwner` comes from a query and is
+  // `false` while it is in flight, which is indistinguishable from a stranger's
+  // gallery — so a moderator opening their OWN gallery moderated it for as long
+  // as that query took, and a removal in that window kept the submitter's Buzz.
+  it('refuses to moderate anything until it knows whose gallery this is', () => {
+    expect(remixGalleryModerating({ ...base, ownerKnown: false })).toBe(false);
+  });
+
+  it('stays refused while unknown even when the mode was explicitly asked for', () => {
+    expect(
+      remixGalleryModerating({ ...base, ownerKnown: false, isOwner: true, asModerator: true })
+    ).toBe(false);
   });
 });

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -1,4 +1,5 @@
 import type { ImageGetInfinite } from '~/types/router';
+import { ImageSort } from '~/server/common/enums';
 import { PLACEMENT_SURFACES } from '~/shared/utils/placement';
 import { REMIX_GALLERY_ROW_WIDTH } from '~/shared/utils/remix-gallery';
 
@@ -312,3 +313,26 @@ export const submissionMethod = (
   if (!paidOpen && takesFree) return 'free';
   return chosen === 'free' && !freeAvailable ? 'paid' : chosen ?? (freeAvailable ? 'free' : 'paid');
 };
+
+/**
+ * What the submit picker asks the image feed for.
+ *
+ * Out here so it can be asserted. Both are corrections to a default rather than
+ * decoration, and both are invisible in a rendered grid — a picker missing them
+ * looks like a working picker.
+ *
+ * `publishedOnly`: the submit mutation refuses an unpublished image, so offering
+ * one is an invitation to a refusal. The feed's default is to carve out the
+ * caller's own unpublished posts, which is right for a profile and wrong here.
+ *
+ * `sort`: the feed defaults to most-reacted. Someone submitting a remix has
+ * usually just made it, which puts it last.
+ */
+export const remixSubmitPickerFilters = (userId: number | undefined) =>
+  ({
+    userId,
+    period: 'AllTime',
+    limit: 50,
+    sort: ImageSort.Newest,
+    publishedOnly: true,
+  } as const);

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -336,3 +336,40 @@ export const remixSubmitPickerFilters = (userId: number | undefined) =>
     sort: ImageSort.Newest,
     publishedOnly: true,
   } as const);
+
+/**
+ * Whether this modal is being used to moderate rather than to curate.
+ *
+ * Out here and pure because it decides a **refund**. The mutation reads the
+ * caller's claim rather than inferring the mode from ownership, so whatever this
+ * returns is what the server acts on — a wrong answer here keeps a submitter's
+ * Buzz and writes a moderation record, and nothing undoes either.
+ *
+ * 🔴 `ownerKnown` is the whole reason this is a function. `isOwner` is derived
+ * from a query, and while that query is in flight it is `false` — which is
+ * indistinguishable from "someone else's gallery". A moderator opening their own
+ * gallery therefore looked like a moderator on a stranger's until it resolved,
+ * and a removal in that window took the moderator branch on their own content.
+ * Unknown is not the same as false, so it is a separate input and it wins:
+ * nobody moderates anything until we know whose gallery this is.
+ *
+ * Mirrors the server's rule in `actOnRemixGallerySubmission` — the role is the
+ * permission, the claim only chooses between two things that role already
+ * allows.
+ */
+export function remixGalleryModerating({
+  isModerator,
+  isOwner,
+  ownerKnown,
+  asModerator,
+}: {
+  isModerator: boolean;
+  isOwner: boolean;
+  /** Whether the visibility query has resolved. */
+  ownerKnown: boolean;
+  asModerator: boolean;
+}) {
+  if (!isModerator) return false;
+  if (!ownerKnown) return false;
+  return !isOwner || asModerator;
+}

--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -146,6 +146,13 @@ describe('the remix type stops announcing declines', () => {
     // removal writes `removedBy = 'moderator'` and dropped out of this branch,
     // so the submitter stopped being told about a removal by the creator.
     expect(sql).toContain('p."takenDownById" = p."ownerId"');
+    // The role filter is GONE, deliberately, and this assertion is what says so.
+    // `removePlacementByModerator` and `removePlacementsByUser` are not
+    // surface-scoped, so a moderator removing from their OWN remix gallery
+    // through either writes `removedBy: 'moderator'` with `takenDownById =
+    // ownerId` — the one combination the old and new predicates disagree about.
+    // It now notifies, which is the intended reading of "the actor was the
+    // owner" rather than a side effect of the swap.
     expect(sql).not.toContain('p."removedBy" = \'owner\'');
     // Same two mutations the sticker type is guarded against, and they survive
     // every assertion above on this one too.

--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -140,7 +140,13 @@ describe('the remix type stops announcing declines', () => {
     expect(statusesSelectedBy(sql)).toBe('approved,removed');
     // The removal half is scoped to the owner's own action: a moderator takedown
     // is not something to announce to the person it was taken from.
-    expect(sql).toContain('p."removedBy" = \'owner\'');
+    //
+    // Keyed on the ACTOR rather than on `removedBy`. The two said the same
+    // thing until a moderator could act as one on their own gallery — that
+    // removal writes `removedBy = 'moderator'` and dropped out of this branch,
+    // so the submitter stopped being told about a removal by the creator.
+    expect(sql).toContain('p."takenDownById" = p."ownerId"');
+    expect(sql).not.toContain('p."removedBy" = \'owner\'');
     // Same two mutations the sticker type is guarded against, and they survive
     // every assertion above on this one too.
     expect(sql).toMatch(/p\."placerId"\s+"userId"/);

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -318,7 +318,15 @@ export const placementNotifications = createNotificationProcessor({
             )
             OR (
               p.status = 'removed'
-              AND p."removedBy" = 'owner'
+              -- The ACTOR, not the role they acted in. Keying on removedBy
+              -- said the same thing until a moderator could act as one on
+              -- their own gallery: that removal is written as a moderator
+              -- action, so it dropped out of this branch and the submitter
+              -- stopped being told about a removal by the creator themselves.
+              --
+              -- A genuine third-party takedown stays silent, which is the same
+              -- set this branch always excluded.
+              AND p."takenDownById" = p."ownerId"
               AND p."takenDownAt" IS NOT NULL
               AND p."takenDownAt" > '${lastSent}'
             )

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -249,6 +249,12 @@ export const getRemixGalleryFreeEligibilitySchema = z.object({
 export const actOnRemixGallerySubmissionSchema = z.object({
   placementId: z.number().int().positive(),
   action: z.enum(['approve', 'decline', 'remove']),
+  // A moderator acting on their OWN gallery, which ownership alone cannot
+  // express: without it they get creator rules on their own content and can
+  // moderate everyone except themselves. Requested, never inferred — moderators
+  // browsing the site as ordinary users is the default and stays that way.
+  // Ignored for anyone who is not a moderator.
+  asModerator: z.boolean().optional(),
 });
 
 export const retractRemixGallerySubmissionSchema = z.object({

--- a/src/server/services/__tests__/bitdex-feed-source.test.ts
+++ b/src/server/services/__tests__/bitdex-feed-source.test.ts
@@ -494,3 +494,65 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
     });
   });
 });
+
+/**
+ * The publication rule on the BitDex leg, asserted at the DISPATCHER.
+ *
+ * 🔴 These belong here rather than beside the Meili filter-string tests, and the
+ * reason is the bug that produced them. `publishedOnly` was added to both Meili
+ * filter builders and tested there by a `describe.each` over a hand-authored
+ * list of two — and a hand-authored list cannot report a member it does not
+ * have. The BitDex leg was the member it did not have, so the picker that
+ * started all this still served a moderator their own drafts while the tests
+ * stayed green.
+ *
+ * `getImagesFromSearch` is the one place that enumerates the backends, so a test
+ * parameterised over the FLAG (a closed set the dispatcher already switches on)
+ * fails when a fourth leg arrives, where a test parameterised over a list of
+ * functions cannot.
+ *
+ * The subject has to change with it: BitDex applies this rule as a post-filter
+ * over fetched documents and emits no filter clause at all, so a filter-string
+ * assertion is structurally incapable of seeing it. These assert on the rows
+ * that came back, which every backend has to produce.
+ */
+describe('publishedOnly is honoured on every backend, not only the ones with a filter string', () => {
+  const unpublishedOwnDoc = { ...bitdexDoc, id: 909, userId: CURRENT_USER_ID, publishedAt: null };
+
+  const moderatorPickerInput = {
+    ...baseInput,
+    currentUserId: CURRENT_USER_ID,
+    userId: CURRENT_USER_ID,
+    isModerator: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getFliptVariantMock.mockResolvedValue('primary');
+    // The own-content pass is the door the drafts came in by; the main pass is
+    // already published-only for everyone and is not what this is about.
+    queryBitdexMock.mockImplementation((_index: unknown, filters: unknown) =>
+      Promise.resolve(
+        isOwnExcludedQuery(filters)
+          ? { documents: [unpublishedOwnDoc], cursor: undefined }
+          : { documents: [], cursor: undefined }
+      )
+    );
+  });
+
+  it('does not hand a publishedOnly caller their own unpublished row', async () => {
+    const result = await getImagesFromSearch({ ...moderatorPickerInput, publishedOnly: true });
+
+    expect(result.data.map((row: { id: number }) => row.id)).not.toContain(unpublishedOwnDoc.id);
+  });
+
+  it('still merges a moderator own unpublished row when they did not ask for published only', async () => {
+    // The control, and it is load-bearing twice over: without it the assertion
+    // above passes against a build where the own-content pass returns nothing at
+    // all, and it pins the deliberate moderator carve-out that the fix narrows
+    // rather than removes.
+    const result = await getImagesFromSearch(moderatorPickerInput);
+
+    expect(result.data.map((row: { id: number }) => row.id)).toContain(unpublishedOwnDoc.id);
+  });
+});

--- a/src/server/services/__tests__/image-search-published-only.test.ts
+++ b/src/server/services/__tests__/image-search-published-only.test.ts
@@ -56,7 +56,6 @@ vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }
 vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
 
 import { getImagesFromSearchPreFilter, getImagesFromSearchPostFilter } from '../image.service';
-import { redisMock } from '~/__tests__/mocks/redis.mock';
 
 const MODERATOR = 4321;
 
@@ -88,7 +87,11 @@ describe.each([
   // that one instead, which would have read as the fix not working.
   const publicationClauseFor = async (input: Record<string, unknown>) => {
     await expect(fn(input as unknown as SearchArg)).rejects.toThrow('stop here');
-    expect(fetchDocumentsAbortableMock).toHaveBeenCalled();
+    // Not just "called": the BitDex path runs a parallel own-content pass whose
+    // whole job is to re-admit the caller's own excluded rows. If that shape ever
+    // reaches a Meili builder, `calls[0]` becomes whichever fired first and both
+    // cases below would move for the wrong reason.
+    expect(fetchDocumentsAbortableMock).toHaveBeenCalledTimes(1);
     const [, request] = fetchDocumentsAbortableMock.mock.calls[0];
     const filter = String((request as { filter: string }).filter);
     const clause = filter.match(/\(publishedAtUnix <= \d+[^)]*\)/);

--- a/src/server/services/__tests__/image-search-published-only.test.ts
+++ b/src/server/services/__tests__/image-search-published-only.test.ts
@@ -47,16 +47,6 @@ vi.mock('~/env/server', () => ({
 }));
 
 vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
-vi.mock('~/server/redis/client', () => {
-  const make = (): any => new Proxy(() => 'k', { get: () => make() });
-  const keyProxy = make();
-  return {
-    redis: { packed: { get: vi.fn(), set: vi.fn() } },
-    sysRedis: {},
-    REDIS_KEYS: keyProxy,
-    REDIS_SYS_KEYS: keyProxy,
-  };
-});
 vi.mock('../../../../event-engine-common/services/metrics', () => ({
   MetricService: class {
     fetch = vi.fn();
@@ -66,6 +56,7 @@ vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }
 vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
 
 import { getImagesFromSearchPreFilter, getImagesFromSearchPostFilter } from '../image.service';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
 
 const MODERATOR = 4321;
 

--- a/src/server/services/__tests__/image-search-published-only.test.ts
+++ b/src/server/services/__tests__/image-search-published-only.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `publishedOnly` was honoured by the DB feed path and silently ignored by both
+// Meilisearch filter builders, so a caller that cannot use an unpublished row
+// still got the moderator's own-content carve-out
+// (`publishedAtUnix <= now OR userId = me`). The remix-gallery submit picker is
+// one such caller: it offered a moderator their own drafts, and the submit
+// mutation refuses a draft, so every one of them was an invitation to a refusal.
+//
+// Asserted on the filter string handed to Meili rather than on returned rows,
+// because that string IS the fix — the rows would come from a fake and could
+// not tell a working filter from an absent one.
+//
+// Mock preamble mirrors search-error-log-pii.test.ts: the smallest set of stubs
+// that lets image.service import without booting real infra.
+
+import type * as MeilisearchClient from '~/server/meilisearch/client';
+
+const { fetchDocumentsAbortableMock } = vi.hoisted(() => ({
+  fetchDocumentsAbortableMock: vi.fn(),
+}));
+
+vi.mock('~/server/meilisearch/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof MeilisearchClient>();
+  return {
+    ...actual,
+    metricsSearchClient: {},
+    getMetricsSearchClient: () => ({}),
+    fetchDocumentsAbortable: fetchDocumentsAbortableMock,
+  };
+});
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn() } },
+    sysRedis: {},
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+  };
+});
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+import { getImagesFromSearchPreFilter, getImagesFromSearchPostFilter } from '../image.service';
+
+const MODERATOR = 4321;
+
+const baseInput = {
+  // Deliberately no `userId`: that is a feed-by-creator search filter and emits
+  // its own `userId = …` clause. Leaving it out makes any `userId` in the filter
+  // unambiguously the own-content carve-out this test is about.
+  currentUserId: MODERATOR,
+  isModerator: true,
+  limit: 20,
+  period: 'AllTime',
+  sort: 'Newest',
+  browsingLevel: 31,
+  include: [] as string[],
+  headers: { src: 'test' },
+};
+
+// Both builders carry their own copy of the branch, and a fix applied to one
+// leaves the other serving drafts on whichever path the flag routes to.
+describe.each([
+  ['getImagesFromSearchPreFilter', getImagesFromSearchPreFilter],
+  ['getImagesFromSearchPostFilter', getImagesFromSearchPostFilter],
+])('%s publication filter', (_name, fn) => {
+  type SearchArg = Parameters<typeof getImagesFromSearchPreFilter>[0];
+
+  // Only the publication clause. The filter carries a SECOND own-content
+  // carve-out — own `nsfwLevel = 0` rows, which is about rating and not about
+  // publication — and asserting against the whole string made this test fail on
+  // that one instead, which would have read as the fix not working.
+  const publicationClauseFor = async (input: Record<string, unknown>) => {
+    await expect(fn(input as unknown as SearchArg)).rejects.toThrow('stop here');
+    expect(fetchDocumentsAbortableMock).toHaveBeenCalled();
+    const [, request] = fetchDocumentsAbortableMock.mock.calls[0];
+    const filter = String((request as { filter: string }).filter);
+    const clause = filter.match(/\(publishedAtUnix <= \d+[^)]*\)/);
+    // The clause is unconditional on this path, so its absence means the filter
+    // moved and this test is now asserting about nothing.
+    expect(clause, `no publication clause in: ${filter}`).not.toBeNull();
+    return clause![0];
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Thrown so the test stops at the seam it is about. The filter is built
+    // before the call, so it is fully formed on the recorded arguments.
+    fetchDocumentsAbortableMock.mockRejectedValue(new Error('stop here'));
+  });
+
+  it('drops the moderator own-content carve-out when the caller asked for published only', async () => {
+    const clause = await publicationClauseFor({ ...baseInput, publishedOnly: true });
+
+    expect(clause).not.toContain(`userId = ${MODERATOR}`);
+  });
+
+  it('still carves out own content for a moderator who did not ask', async () => {
+    // The control. Without it the test above passes against a build that never
+    // emits the carve-out at all — which would be a different bug (a moderator
+    // losing sight of their own scheduled posts across every feed), not a fix.
+    const clause = await publicationClauseFor(baseInput);
+
+    expect(clause).toContain(`userId = ${MODERATOR}`);
+  });
+});

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -928,6 +928,74 @@ describe('owner actions', () => {
     expect(placementUpdateMany.mock.calls[0][0].data).toMatchObject({ removedBy: 'moderator' });
   });
 
+  describe('a moderator on their own gallery', () => {
+    // Ownership used to decide the mode on its own, so a moderator got the
+    // creator rules on their own content and could moderate every gallery
+    // except their own. The mode is now asked for, and these pin both halves:
+    // asking works, and not asking still gets the creator rules.
+    const lockedOwnEntry = () => {
+      placementFindUnique.mockResolvedValue({
+        ...pending,
+        status: 'approved',
+        resolvedAt: new Date(),
+      });
+      placementUpdateMany.mockResolvedValue({ count: 1 });
+    };
+
+    it('is still held to the removal lock when they have not asked to moderate', async () => {
+      // The control on the pair below. Exempting them for holding the role
+      // would pass that test and silently drop the wait their own submitters
+      // were promised, on every removal they ever make.
+      lockedOwnEntry();
+
+      await expect(
+        actOnRemixGallerySubmission({
+          placementId: PLACEMENT,
+          action: 'remove',
+          userId: OWNER,
+          isModerator: true,
+        })
+      ).rejects.toThrow(/can be removed from/i);
+      expect(placementUpdateMany).not.toHaveBeenCalled();
+    });
+
+    it('takes down a locked entry once they ask to act as a moderator', async () => {
+      lockedOwnEntry();
+
+      await actOnRemixGallerySubmission({
+        placementId: PLACEMENT,
+        action: 'remove',
+        userId: OWNER,
+        isModerator: true,
+        asModerator: true,
+      });
+
+      // Recorded as the moderation action it is. `owner` here would say a
+      // creator removed it under creator rules, which is the one thing that
+      // did not happen — those rules refused it a moment ago.
+      expect(placementUpdateMany.mock.calls[0][0].data).toMatchObject({
+        removedBy: 'moderator',
+      });
+    });
+
+    it('ignores the claim from someone who is not a moderator', async () => {
+      // `asModerator` chooses between two things a moderator may already do.
+      // It is not where the permission comes from, and a plain owner sending it
+      // must buy nothing.
+      lockedOwnEntry();
+
+      await expect(
+        actOnRemixGallerySubmission({
+          placementId: PLACEMENT,
+          action: 'remove',
+          userId: OWNER,
+          asModerator: true,
+        })
+      ).rejects.toThrow(/can be removed from/i);
+      expect(placementUpdateMany).not.toHaveBeenCalled();
+    });
+  });
+
   it('takes a live entry down with a direct write, not through settlePlacement', async () => {
     // `settlePlacement` claims with `WHERE status = 'pending'`, so routing an
     // approved row through it matched nothing and threw — owner remove was

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -978,6 +978,31 @@ describe('owner actions', () => {
       });
     });
 
+    it('attributes a plain owner removal to the owner even when they claim otherwise', async () => {
+      // The claim reaches the ATTRIBUTION as well as the lock, and the lock test
+      // below cannot see it — that one throws before the write happens. Verified
+      // by mutation: `removedBy: isModeratorTakedown || asModerator` passes every
+      // other test in this file, and writes a moderation record for an ordinary
+      // creator removing from their own gallery.
+      //
+      // Unlocked deliberately, so the write is reached at all.
+      placementFindUnique.mockResolvedValue({
+        ...pending,
+        status: 'approved',
+        resolvedAt: new Date(Date.now() - (REMIX_GALLERY_REMOVAL_LOCK_HOURS + 1) * 60 * 60 * 1000),
+      });
+      placementUpdateMany.mockResolvedValue({ count: 1 });
+
+      await actOnRemixGallerySubmission({
+        placementId: PLACEMENT,
+        action: 'remove',
+        userId: OWNER,
+        asModerator: true,
+      });
+
+      expect(placementUpdateMany.mock.calls[0][0].data).toMatchObject({ removedBy: 'owner' });
+    });
+
     it('ignores the claim from someone who is not a moderator', async () => {
       // `asModerator` chooses between two things a moderator may already do.
       // It is not where the permission comes from, and a plain owner sending it

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3586,7 +3586,14 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
     // for them. Without this a moderator's own unpublished image would be served
     // when it arrived through the main pass and dropped when it arrived through
     // this one — visibility decided by which door it came in by.
-    if (!wantsUnpublished && !input.isModerator) {
+    //
+    // `publishedOnly` withdraws that exemption, because it withdraws its
+    // premise: the main post-filter drops the `OR userId = me` carve-out for
+    // such a caller, so keeping the exemption here would restore by the back
+    // door exactly what they asked to be rid of. This is the door the remix
+    // submit picker came in by — it asks for published images only, and a
+    // moderator was still offered their own drafts.
+    if (!wantsUnpublished && (!input.isModerator || input.publishedOnly)) {
       const mergeNow = Date.now();
       ownDocs = ownDocs.filter((d) => isPublicallyPublished(d, mergeNow, stats));
     }
@@ -4732,7 +4739,6 @@ export async function getImagesFromBitdexPreFilter(
     fromPlatform,
     notPublished,
     scheduled,
-    publishedOnly,
     username,
     tags,
     tools,

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -4053,6 +4053,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     fromPlatform,
     notPublished,
     scheduled,
+    publishedOnly,
     username,
     tags,
     tools,
@@ -4296,7 +4297,11 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
       filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${snappedNow}`));
     else {
       const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
-      if (currentUserId) {
+      // `publishedOnly` is the caller saying it cannot use an unpublished row at
+      // all, so the moderator's own-content carve-out is lifted too. Without
+      // this a moderator got their own drafts in a picker whose mutation
+      // refuses them, and no other caller could opt out of that.
+      if (currentUserId && !publishedOnly) {
         publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
       }
       filters.push(`(${publishedFilters.join(' OR ')})`);
@@ -4727,6 +4732,7 @@ export async function getImagesFromBitdexPreFilter(
     fromPlatform,
     notPublished,
     scheduled,
+    publishedOnly,
     username,
     tags,
     tools,
@@ -4967,6 +4973,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
     fromPlatform,
     notPublished,
     scheduled,
+    publishedOnly,
     username,
     tags,
     tools,
@@ -5195,7 +5202,11 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
       filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${snappedNow}`));
     else {
       const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
-      if (currentUserId) {
+      // `publishedOnly` is the caller saying it cannot use an unpublished row at
+      // all, so the moderator's own-content carve-out is lifted too. Without
+      // this a moderator got their own drafts in a picker whose mutation
+      // refuses them, and no other caller could opt out of that.
+      if (currentUserId && !publishedOnly) {
         publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
       }
       filters.push(`(${publishedFilters.join(' OR ')})`);

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -419,12 +419,6 @@ export async function actOnRemixGallerySubmission({
   isModerator?: boolean;
   asModerator?: boolean;
 }) {
-  // A moderator on someone else's gallery is moderating whatever they claim —
-  // there is no creator role available to them there. On their own, it is the
-  // claim that decides, so the default stays the creator rules everyone else
-  // gets. `isModerator` is the permission; `asModerator` only chooses between
-  // two things this caller is already allowed to do.
-  const actingAsModerator = isModerator && asModerator;
   const placement = await dbWrite.placement.findUnique({
     where: { id: placementId },
     select: {
@@ -489,7 +483,12 @@ export async function actOnRemixGallerySubmission({
     // must not wait. On their own gallery they are exempt only when they asked
     // to be — otherwise a moderator would silently never be held to the wait
     // their own submitters were promised.
-    const isModeratorTakedown = isModerator && (placement.ownerId !== userId || actingAsModerator);
+    //
+    // `isModerator` is the permission and `asModerator` only picks between two
+    // things this caller may already do, so the claim is read INSIDE the role
+    // check rather than beside it. On someone else's gallery there is no
+    // creator role to go back to, so the claim is not asked for.
+    const isModeratorTakedown = isModerator && (placement.ownerId !== userId || asModerator);
     if (!isModeratorTakedown) {
       // Falls back to `createdAt` rather than skipping when `resolvedAt` is
       // absent. Gating the check on the column being set made this fail OPEN:

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -411,12 +411,20 @@ export async function actOnRemixGallerySubmission({
   action,
   userId,
   isModerator = false,
+  asModerator = false,
 }: {
   placementId: number;
   action: OwnerAction;
   userId: number;
   isModerator?: boolean;
+  asModerator?: boolean;
 }) {
+  // A moderator on someone else's gallery is moderating whatever they claim —
+  // there is no creator role available to them there. On their own, it is the
+  // claim that decides, so the default stays the creator rules everyone else
+  // gets. `isModerator` is the permission; `asModerator` only chooses between
+  // two things this caller is already allowed to do.
+  const actingAsModerator = isModerator && asModerator;
   const placement = await dbWrite.placement.findUnique({
     where: { id: placementId },
     select: {
@@ -476,9 +484,12 @@ export async function actOnRemixGallerySubmission({
     // which is indistinguishable from an honest removal and costs the submitter
     // everything they paid.
     //
-    // A moderator is exempt: a takedown is a moderation record rather than an
-    // owner decision, and the abusive cases are the ones that must not wait.
-    const isModeratorTakedown = isModerator && placement.ownerId !== userId;
+    // A moderator is exempt: a removal by a moderator is a moderation record
+    // rather than an owner decision, and the abusive cases are the ones that
+    // must not wait. On their own gallery they are exempt only when they asked
+    // to be — otherwise a moderator would silently never be held to the wait
+    // their own submitters were promised.
+    const isModeratorTakedown = isModerator && (placement.ownerId !== userId || actingAsModerator);
     if (!isModeratorTakedown) {
       // Falls back to `createdAt` rather than skipping when `resolvedAt` is
       // absent. Gating the check on the column being set made this fail OPEN:
@@ -507,10 +518,12 @@ export async function actOnRemixGallerySubmission({
       where: { id: placementId, status: 'approved' },
       data: {
         status: 'removed',
-        // A moderator acting on someone else's gallery is a moderation record,
-        // not an owner decision, and the two refund differently everywhere else
-        // in this system. Recording it as `owner` would misattribute it.
-        removedBy: isModerator && placement.ownerId !== userId ? 'moderator' : 'owner',
+        // A moderator acting as one is a moderation record, not an owner
+        // decision, and the two refund differently everywhere else in this
+        // system. Recording it as `owner` would misattribute it — including on
+        // their own gallery, where the moderator exemption above is what let
+        // the removal through at all.
+        removedBy: isModeratorTakedown ? 'moderator' : 'owner',
         // Not `resolvedAt`/`resolvedById`: those record who approved it, and
         // overwriting them here would destroy the approval trail.
         takenDownAt: new Date(),


### PR DESCRIPTION
Three findings from Justin and Ellie's walkthrough of the remix gallery.
[868ku8mzf](https://app.clickup.com/t/868ku8mzf),
[868ku8n0v](https://app.clickup.com/t/868ku8n0v),
[868ku8n1v](https://app.clickup.com/t/868ku8n1v). One surface, so one PR.

## A moderator could moderate every gallery except their own

`moderating` was `isModerator && !isOwner`, so on her own gallery Ellie got
the creator view. **The mutation agreed with it** — `isModeratorTakedown`
was also keyed on `ownerId !== userId`, so the removal button was enabled
for her (that check read the role) and the server then refused with the
one-week hold. The message she read out came from the mutation, not a
tooltip.

Mods browsing as ordinary creators is deliberate and stays. What was
missing is a way to say otherwise, so there is now a segmented control —
**Manage as creator** / **Moderate** — shown only to a moderator on their
own gallery, and the choice is sent to the mutation as `asModerator`.
`isModerator` is still the permission; the flag only picks between two
things that caller may already do, and is ignored for everyone else.

Two smaller consequences, both from the same root:
- the remove button now locks on the **mode** rather than on holding the
  role, so a moderator in creator mode sees the wait explained in the
  tooltip instead of meeting it as a server error;
- `removedBy` follows the same value, so a removal in moderator mode on
  your own gallery is recorded as `moderator`, which is what it is.

## Removal dialog copy — copy only

"Takedown" is our word for DMCA and NCII, and two moderators independently
read this flow as one of those. "The takedown is recorded against you" read
as points being deducted from the moderator; it means the removal is
attributed to them rather than to the creator.

Reworded to "removal" and "logged under your name rather than the
creator's". What is load-bearing is kept: the submitter is not refunded, a
moderator can remove at any time where the creator waits out a week, and
approving, declining and pinning stay with the creator. No behaviour
changed.

## The submit picker offered drafts, and sorted by reactions

**Drafts.** The picker asked the image feed for the caller's own images.
Both feed paths carve out the caller's own unpublished posts, and the
submit mutation refuses an unpublished image — so every draft offered was
an invitation to a refusal.

Worth stating precisely, because it was reported as possibly
moderator-only: on the **Meili** path it is, the moderator branch is
`publishedAtUnix <= now OR userId = me` while the non-moderator branch is
strict. On the **DB** path (`getAllImages`) it is everyone —
`publishedAt < now() OR p."userId" = $userId` regardless of role. Either
way it is only ever **your own** drafts, never another user's, so this is
a validity bug and not a disclosure one.

`publishedOnly` already existed and was honoured only by the DB path.

**There are three feed backends, not two.** Named explicitly because the review
found this PR had fixed two and claimed all:

| backend | before | now |
|---|---|---|
| DB (`getAllImages`) | honoured `publishedOnly` | unchanged |
| Meili (pre- and post-filter) | ignored it | honoured, mutation test per copy |
| BitDex (`fetchBitdexPrimary`) | **ignored it** | honoured |

The BitDex leg is the one moderators get routed to, so the original symptom was
untouched there — the fix would have been true of the code I changed and false
of what Ellie experiences. Its own-content merge exempted moderators *explicitly
because* the main post-filter keeps their `OR userId = me` carve-out, a premise
`publishedOnly` removes; the comment there now says so. A dead `publishedOnly`
binding in the BitDex prefilter is gone — it read as a covered path, which is how
this would have been missed a second time.

**Sort.** The feed defaults to most-reacted. Someone submitting a remix has
usually just made it, so the picker now asks for newest. The shuffled
gallery card on the side is a different surface and is untouched.

## Tests

Nine mutations of the real source, each demanded red:

| mutation | goes red |
|---|---|
| claim ignored (revert the exemption) | ✅ |
| claim alone exempts, no role required | ✅ |
| any moderator always exempt | ✅ |
| `removedBy` misattributed | ✅ |
| `publishedOnly` dropped in both builders | ✅ |
| dropped in the post-filter only | ✅ |
| picker drops `publishedOnly` | ✅ |
| picker back to the reactions default | ✅ |
| picker drops the user scope | ✅ |

Two of my own tests did **not** discriminate on the first pass and are
worth naming rather than quietly fixed:

- the non-moderator case was held by an outer `isModerator &&`, not by the
  inner one I wrote it for — so the inner check was redundant and no test
  could hold it. Inlined, and the mutation now lands.
- the first `publishedOnly` assertion read the whole filter string and
  tripped on a **different** own-content carve-out (own `nsfwLevel = 0`,
  about rating, not publication). Scoped to the publication clause, with the
  clause's presence asserted so a moved filter fails loudly rather than
  passing vacuously.

The picker's feed filters moved into `remix-gallery.utils.ts` so they can
be asserted at all — both are corrections to a default and both are
invisible in a rendered grid, so a call site that loses them looks like a
working picker.

## Verification

`typecheck` 0 errors · `eslint` 0 errors on changed paths · `prettier`
clean · `test:lint-rules` 243/243 · unit suite **19056 passed, 6 failed**.

Those 6 are pre-existing and were confirmed by checking out pristine
`origin/main` in the same worktree and running the same four files: the
identical 6 fail there. They are Windows path-guard failures
(`ENOENT: 'C:\C:\Dev\...'`) plus one unrelated service assertion, in
`appListingStatChips`, `model-file-scan.service`, `standalone-boot-graph`
and `rating-label`.

## What the five-lane review changed

Five lanes, all reported (two needed chasing; one needed three). Five findings
acted on:

1. ~~**The submitter stopped being told.**~~ **Raised, fixed, and then reverted
   — the original code was right.** The review lane read `removedBy` as the
   actor's *role*; it is the *mode* they pressed remove in. `'owner'` covers a
   creator and a moderator in Manage-as-creator; `'moderator'` covers Moderate
   mode and someone else's gallery. So `removedBy = 'owner'` already meant "not
   acting as a moderator", which is the intended rule, and keying on the actor
   instead announced a moderator-mode removal as a creator's — and did the same
   to every moderation-tool removal on the actor's own gallery. Confirmed with
   Justin and reverted; the notification files are byte-identical to base.
   Recorded here rather than dropped, because the reasoning that produced the
   wrong fix was plausible and someone will retrace it.
2. **The BitDex backend**, above.
3. **The mode was inferred before ownership was known.** `isOwner` is `false`
   while its query is in flight, which is indistinguishable from a stranger's
   gallery — and the client's answer now decides a refund. Extracted to a pure
   `remixGalleryModerating` with an explicit `ownerKnown` input, so unknown
   cannot collapse into false, and unit-tested in the lane CI actually runs
   rather than a browser test no job executes.
4. **Moderator mode hid controls that work.** On your own gallery the review
   queue, pinned row and pin control all function (`ownerId = caller` is
   satisfied), and the alert said "approving, declining and pinning stay with the
   creator" when the creator is you. Both fixed.
5. **Attribution was untested where it lands.** A plain owner sending
   `asModerator` only ever reached the lock, never the write. Confirmed green
   under `removedBy: isModeratorTakedown || asModerator` before adding the case.

**The test that was missing is a different shape, not more assertions.** The
Meili tests enumerated builders by hand, and a hand-authored list cannot report
the member it lacks — the same mistake the fix made. The new assertion sits at
`getImagesFromSearch`, parameterised over the flag the dispatcher already
switches on, and asserts on returned rows because BitDex applies the rule as a
post-filter and emits no filter string to read. Both directions mutation-checked.

Perf lane: nothing to fix. Cache keys clean, filter-string cardinality goes
*down*, and the sort change is byte-identical SQL on the DB path.

Two things worth carrying out of the review, neither for this PR:
`ChallengeSubmitModal` already passed `publishedOnly: true` and it was a **silent
no-op** on the search path until this change; `AddUserContentModal` is the same
picker shape *without* the flag and still offers drafts.

## For review

Moderator mode on your own gallery **skips the one-week hold**, which is
the point of the feature and also the thing to look at hardest: that hold
exists so an owner cannot approve a submission, keep the Buzz, and remove
the entry before anyone sees it. A moderator can now do exactly that on
their own gallery. It is recorded (`removedBy: 'moderator'`,
`takenDownById`), so it is auditable rather than invisible. Justin picked
the toggle placement; **the skip-the-hold behaviour is a stated default I
announced, not a decision he ratified** — recorded here because a reader six
weeks out cannot tell those apart from the code. Refunding the submitter in that specific
case would close it at no cost elsewhere, if we want it closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



