### PR TITLE
fix(feeds): scope the own-excluded pass by creator SET, not just a single userId (#4123)

### DIFF
--- a/src/server/metrics/bitdex-feed-serve.metrics.ts
+++ b/src/server/metrics/bitdex-feed-serve.metrics.ts
@@ -62,10 +62,23 @@
 //   2. a `bdx:` cursor — i.e. a BITDEX-paginated request, which is NOT the same
 //      as any paginated request: a request that fell back to Meilisearch carries
 //      a Meilisearch cursor on its next page and does NOT match
-//   3. signed-in caller viewing ANOTHER user's profile
+//   3. `creatorScopeExcludesCaller` — the request is scoped to a set of creators
+//      that does not contain the caller. Named BY SYMBOL deliberately: it is
+//      computed from three scopes (`userId`, `followed`, `newCreators`) and any
+//      gloss of it drifts. This disjunct REPLACED "signed-in caller viewing
+//      another user's profile" in #4123; that wording described only the
+//      single-`userId` case and was silent on the set-shaped ones.
 // When none holds, the own-content query goes out regardless of what the feed
 // query did, so the request made a call and IS counted even though its feed
 // query never left the process.
+//
+// 🔴 #4123 CHANGED WHICH DOORS THIS COUNTS, so the enumeration above it is no
+// longer uniform. `followed`-with-zero-follows and `newCreators`-with-none are
+// now excluded (their creator scope is the empty set, which does not contain the
+// caller, so no second query goes out); `hidden`-with-no-hidden-images is still
+// counted, because `hidden` is not a creator scope. That is a REDUCTION in the
+// `fallback_empty` population and it SHIFTS THE SERVED-RATIO BASELINE, exactly as
+// #4122 did — do not compare that ratio across #4123.
 //
 // Counting it is correct under "requests that ENGAGED the backend". It is simply
 // not the same set as "requests whose FEED query went out", and a dashboard must

--- a/src/server/services/__tests__/bitdex-feed-source.test.ts
+++ b/src/server/services/__tests__/bitdex-feed-source.test.ts
@@ -413,8 +413,10 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
    * `userId` case and was silent on the set-shaped ones (`followed`,
    * `newCreators`). This was the THIRD copy of that enumeration in the repo and
    * the last to be corrected — the other two are in image.service.ts and
-   * src/server/metrics/bitdex-feed-serve.metrics.ts, and both point readers HERE
-   * as the pin. Reference the predicate by SYMBOL when updating it again.
+   * src/server/metrics/bitdex-feed-serve.metrics.ts. Of those, only
+   * image.service.ts points readers at THIS file as the pin; the metrics module
+   * points at the `skipOwnExcluded` symbol instead. Reference the predicate by
+   * SYMBOL when updating it again.
    *
    * This case drives an ANONYMOUS caller, which is the disjunct that makes the
    * exclusion apply — so on its own it flatters the claim. The sibling case below

--- a/src/server/services/__tests__/bitdex-feed-source.test.ts
+++ b/src/server/services/__tests__/bitdex-feed-source.test.ts
@@ -434,36 +434,43 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
    * 🔴 THE CASE THAT REFUTES THE ABSOLUTE VERSION OF THE CLAIM ABOVE, PINNED SO
    * IT CANNOT BE RE-ASSERTED.
    *
-   * A signed-in caller on the first page opening the Following feed with zero
-   * follows: the FEED query returns early inside the builder and never reaches
-   * the client — but no disjunct of `skipOwnExcluded` holds here (signed in, no
-   * `bdx:` cursor, not viewing another user's profile), so the own-content pass
-   * IS issued, completes, and counts. One call went out, so the request is
-   * recorded as `fallback_empty`.
+   * A signed-in caller whose `hidden` feed has no hidden images: the FEED query
+   * returns early inside the builder and never reaches the client — but no
+   * disjunct of `skipOwnExcluded` holds here, so the own-content pass IS issued,
+   * completes, and counts. One call went out, so the request is recorded as
+   * `fallback_empty`.
    *
    * That is defensible under the stated denominator — "requests that ENGAGED the
-   * backend" — and it is deliberately NOT changed here. What was wrong was the
-   * claim that all five doors are excluded: `currentUserId` is a PRECONDITION of
-   * two of them (`hidden`-with-no-hidden-images, followed-with-zero-follows), so
-   * for those two the exclusion can never apply at all.
+   * backend" — and it is deliberately NOT changed. What was wrong was the claim
+   * that all five doors are excluded: `currentUserId` is a PRECONDITION of two of
+   * them, so for those two the exclusion can never apply at all.
    *
-   * Measured before being written: `calls=1 ownCalls=1
-   * moved=["fallback_empty|primary"]`.
+   * 🔴 THIS CASE USED TO BE DRIVEN BY followed-with-zero-follows, AND #4123 MOVED
+   * IT HERE. That fix makes the own-content pass conditional on the request's
+   * CREATOR SCOPE containing the caller, so a Following feed with zero follows now
+   * issues zero calls and records nothing — it joined the other doors instead of
+   * being the one that leaked a call. `hidden` is not a creator scope, so this
+   * door is untouched by that change and still drives the state this case needs.
    *
-   * 🔴 This is also the ONLY killing case for `if (ownExcluded)
-   * bitdexCallsObserved++` — the third observation site, which had no mutation
-   * killing it. Delete that line and this case goes red, because the request then
-   * looks like it made no calls at all.
+   * 🔴 Retargeted rather than deleted BECAUSE it is the ONLY killing case for
+   * `if (ownExcluded) bitdexCallsObserved++` — the third observation site, which
+   * has no other mutation killing it. Rewriting the followed case to expect zero
+   * calls and stopping there would have left that line untested while every suite
+   * stayed green. Delete that line and this case goes red, because the request
+   * then looks like it made no calls at all.
    */
-  it('🔴 PRIMARY, signed-in, followed-with-zero-follows: the own-content pass still counts', async () => {
+  it('🔴 PRIMARY, signed-in, hidden-with-no-hidden-images: the own-content pass still counts', async () => {
     getFliptVariantMock.mockResolvedValue('primary');
     queryBitdexMock.mockResolvedValue({ documents: [], cursor: undefined });
+    // The door: signed in, so the `!currentUserId` line does not fire, and the
+    // hidden-image lookup comes back empty so the builder returns null after it.
+    dbMock.dbRead.imageEngagement.findMany.mockResolvedValue([]);
     const before = await readOutcomes();
 
     const result = await getImagesFromSearch({
       ...baseInput,
       currentUserId: CURRENT_USER_ID,
-      followed: true,
+      hidden: true,
     });
 
     const after = await readOutcomes();
@@ -476,6 +483,34 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
 
     expect(result.source).toBe('meili');
     expect(seriesThatMoved(before, after)).toEqual([key('fallback_empty', 'primary')]);
+  });
+
+  /**
+   * The counterpart, and the reason the case above had to move: after #4123 a
+   * Following feed with zero follows makes NO BitDex call at all, so it records
+   * nothing. The caller's creator scope is the empty set, which does not contain
+   * them, so the own-content pass is not issued.
+   *
+   * This is a REDUCTION in what `fallback_empty` counts, and it is deliberate —
+   * the request never engaged the backend, so counting it overstated the fallback
+   * population. ⚠️ It also shifts the served-ratio baseline, exactly as #4122 did.
+   * Do not compare that ratio across this change.
+   */
+  it('🔴 PRIMARY, signed-in, followed-with-zero-follows: no call goes out, so nothing is recorded', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+    queryBitdexMock.mockResolvedValue({ documents: [], cursor: undefined });
+    const before = await readOutcomes();
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: CURRENT_USER_ID,
+      followed: true,
+    });
+
+    const after = await readOutcomes();
+    expect(queryBitdexMock).not.toHaveBeenCalled();
+    expect(result.source).toBe('meili');
+    expect(seriesThatMoved(before, after)).toEqual([]);
   });
 
   it('SHADOW, BitDex answers with documents → served{mode="shadow"} +1 (Meili still serves the user)', async () => {

--- a/src/server/services/__tests__/bitdex-feed-source.test.ts
+++ b/src/server/services/__tests__/bitdex-feed-source.test.ts
@@ -403,9 +403,18 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
    * this comment glossed it and both were refuted by measurement. The exclusion
    * holds exactly when `skipOwnExcluded` (image.service.ts, declared beside the
    * own-content pass) is true, i.e. one of: anonymous caller; a `bdx:` cursor;
-   * signed-in caller viewing another user's profile. A NON-`bdx:` cursor does
-   * NOT qualify — and that is the common case, since a request that fell back to
-   * Meilisearch carries a Meilisearch cursor on its next page.
+   * or `creatorScopeExcludesCaller` — the request is scoped to a set of creators
+   * that does not contain the caller. A NON-`bdx:` cursor does NOT qualify — and
+   * that is the common case, since a request that fell back to Meilisearch carries
+   * a Meilisearch cursor on its next page.
+   *
+   * 🔴 THE THIRD DISJUNCT USED TO READ "signed-in caller viewing another user's
+   * profile", AND #4123 REPLACED IT. That wording described only the single-
+   * `userId` case and was silent on the set-shaped ones (`followed`,
+   * `newCreators`). This was the THIRD copy of that enumeration in the repo and
+   * the last to be corrected — the other two are in image.service.ts and
+   * src/server/metrics/bitdex-feed-serve.metrics.ts, and both point readers HERE
+   * as the pin. Reference the predicate by SYMBOL when updating it again.
    *
    * This case drives an ANONYMOUS caller, which is the disjunct that makes the
    * exclusion apply — so on its own it flatters the claim. The sibling case below

--- a/src/server/services/__tests__/bitdex-followed-own-excluded-scope.test.ts
+++ b/src/server/services/__tests__/bitdex-followed-own-excluded-scope.test.ts
@@ -377,6 +377,96 @@ describe('#4123 — a set-shaped creator scope is resolved before the own-exclud
     expect(ownExcludedCalls()).toHaveLength(0);
   });
 
+  // 🔴 THE COUPLING IS THE CORRECTNESS ARGUMENT, SO PIN THE ARGUMENTS TOO.
+  //
+  // The guard is only right if it reads the SAME creator scope the pre-filter
+  // filters by. Asserting that the helpers were CALLED does not establish that —
+  // the arguments select which set comes back. Three mutants survived the first
+  // battery precisely here: dropping `domain`, swapping `entity` to `'models'`,
+  // and resolving follows for `input.userId` instead of `input.currentUserId`.
+  // Each produces a well-formed set from the WRONG source and re-admits #4123.
+  //
+  // ⚠️ `domain` must be NON-UNDEFINED in this fixture. `toHaveBeenCalledWith` uses
+  // deep equality, under which `{ entity, domain: undefined }` and `{ entity }`
+  // compare EQUAL — so a fixture leaving `domain` unset could never catch the
+  // dropped-`domain` mutant. `'red'` is chosen because it maps to a different
+  // board (`images-new-red`) than the default, which is exactly the desync.
+  it('reads the new-creator board with the request’s OWN entity and domain', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    await getImagesFromSearch(authedInput({ newCreators: true, domain: 'red' }));
+
+    // 🔴 EVERY call, not `toHaveBeenCalledWith`. That matcher passes if ANY call
+    // matched, and the pre-filter makes its own correct call to this same helper
+    // — so it is satisfied by the pre-filter no matter what the guard passed.
+    // Measured: with `toHaveBeenCalledWith`, mutants that drop `domain` or swap
+    // `entity` to 'models' BOTH survived a fully green suite.
+    expect(getNewCreatorUserIdsMock.mock.calls.length).toBeGreaterThan(0);
+    for (const [args] of getNewCreatorUserIdsMock.mock.calls) {
+      expect(args).toEqual({ entity: 'images', domain: 'red' });
+    }
+  });
+
+  // Resolves follows for the CALLER, never for the creator being viewed. Both
+  // fields are set and they disagree, so a mutant reading the wrong one returns a
+  // different set rather than the same one by luck.
+  it('resolves the followed set for the CALLER, not for the userId being viewed', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    await getImagesFromSearch(
+      authedInput({ followed: true, userId: FOLLOWED_CREATOR_ID })
+    );
+
+    expect(getUserFollowsMock).toHaveBeenCalledWith(CURRENT_USER_ID);
+    expect(getUserFollowsMock).not.toHaveBeenCalledWith(FOLLOWED_CREATOR_ID);
+  });
+
+  // 🔴 `some` vs `every`, pinned by a request carrying TWO simultaneous non-null
+  // scopes that DISAGREE — the only shape that can tell them apart. Every other
+  // case here supplies one scope plus nulls, where `every` fails on the nulls
+  // rather than on the intersection semantics, so it would die for the wrong
+  // reason. Here the caller IS the userId in view (scope contains them) but does
+  // NOT self-follow (scope excludes them). The pre-filter ANDs both filters, so
+  // exclusion by either one excludes the caller from the feed: `some` is correct
+  // and must skip the pass; `every` would run it.
+  it('two disagreeing scopes: exclusion by EITHER one skips the own-excluded pass', async () => {
+    callerFollows([FOLLOWED_CREATOR_ID]); // caller not in their own followed set
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(
+      authedInput({ followed: true, userId: CURRENT_USER_ID })
+    );
+
+    expect(ownExcludedCalls()).toHaveLength(0);
+    expect(ids(result.data)).not.toContain(callerOwnPrivateDoc.id);
+  });
+
+  // The cheap disjuncts must SHORT-CIRCUIT the scope resolution, not merely
+  // out-vote it: without the hoist these shapes pay a lookup whose result is then
+  // discarded, and every behavioural test still passes — so this asserts the CALL,
+  // not the outcome.
+  //
+  // ⚠️ The expected count is ONE, not zero, and that is not a fudge: the request
+  // falls through to the Meili leg, which resolves the same scope for its own
+  // filtering. The BitDex guard's call would be a SECOND one. Verified by
+  // mutation: removing the hoist takes this count 1 -> 2.
+  //
+  // 🔴 A SIBLING ASSERTION FOR THE `bdx:`-CURSOR SHAPE WAS WRITTEN AND THEN
+  // DELETED, because the mutation showed it could not fail: with the hoist removed
+  // it still read 1. The likeliest cause is that its hand-written `bdx:` cursor
+  // fixture did not decode, so `bitdexCursor` was falsy and the request never had
+  // the property the test was named for. Rather than ship an assertion that passes
+  // in both arms, the `bitdexCursor` half of the short-circuit is left argued from
+  // the code (it is the same `skipOwnExcludedCheaply` expression this case pins
+  // via `!input.currentUserId`) and is NOT claimed as tested.
+  it('an anonymous newCreators feed adds no creator-scope lookup of its own', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    await getImagesFromSearch({ ...baseInput, newCreators: true });
+
+    expect(getNewCreatorUserIdsMock).toHaveBeenCalledTimes(1);
+  });
+
   // A third creator's private document is not reachable in production (the own
   // pass pins `userId = currentUserId`), but the fake returns it to prove the
   // decision is about SCOPE MEMBERSHIP and not about "is this document mine".

--- a/src/server/services/__tests__/bitdex-followed-own-excluded-scope.test.ts
+++ b/src/server/services/__tests__/bitdex-followed-own-excluded-scope.test.ts
@@ -407,6 +407,21 @@ describe('#4123 — a set-shaped creator scope is resolved before the own-exclud
     }
   });
 
+  // 🔴 AND THE UNSET SHAPE, WHICH IS THE PRODUCTION DEFAULT. Both cases above
+  // pass `domain` explicitly, so `domain: input.domain ?? 'red'` — a guard-side
+  // default that would desync from the pre-filter's board — survived them both.
+  // Only red domains set `domain` at all, so `undefined` is the common case.
+  it('passes an unset domain THROUGH rather than defaulting it', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    await getImagesFromSearch(authedInput({ newCreators: true }));
+
+    expect(getNewCreatorUserIdsMock.mock.calls.length).toBeGreaterThan(0);
+    for (const [args] of getNewCreatorUserIdsMock.mock.calls) {
+      expect(args.domain).toBeUndefined();
+    }
+  });
+
   // 🔴 A SECOND DOMAIN, BECAUSE ONE CANNOT DETECT A HARDCODE. With `'red'` as the
   // only fixture value, `domain: input.domain` and a literal `domain: 'red'`
   // produce identical calls — measured: that mutant SURVIVED the full 72-test
@@ -460,23 +475,38 @@ describe('#4123 — a set-shaped creator scope is resolved before the own-exclud
 
   // The cheap disjuncts must SHORT-CIRCUIT the scope resolution, not merely
   // out-vote it: without the hoist these shapes pay a lookup whose result is then
-  // discarded, and every behavioural test still passes — so this asserts the CALL,
-  // not the outcome.
+  // discarded, and every behavioural test still passes — so these two assert the
+  // CALL, not the outcome.
   //
-  // ⚠️ The expected count is ONE, not zero, and that is not a fudge: the request
-  // falls through to the Meili leg, which resolves the same scope for its own
-  // filtering. The BitDex guard's call would be a SECOND one. Verified by
-  // mutation: removing the hoist takes this count 1 -> 2.
+  // 🔴 THE TWO CASES EXPECT DIFFERENT COUNTS, AND THE REASON IS NOT WHAT THREE
+  // EARLIER REVISIONS OF THIS COMMENT SAID. It is not that one request reaches a
+  // second leg and the other does not — both reach the pre-filter. It is WHICH
+  // HELPER each scope's other reader uses:
+  //   * `followed`     — the pre-filter reads follows with a raw
+  //                      `dbRead.userEngagement.findMany`, NOT `getUserFollows`.
+  //                      So the guard is the only caller of the mocked helper, and
+  //                      with the hoist the count is ZERO.
+  //   * `newCreators`  — the pre-filter calls the SAME `getNewCreatorUserIds`
+  //                      helper the guard does, so one call remains regardless and
+  //                      the guard's would be a SECOND.
+  // Measured both ways by mutation: removing the hoist takes the followed count
+  // 0 -> 1 and the newCreators count 1 -> 2.
+  //
+  // ⚠️ Two earlier attempts at this explanation were refuted by measurement — one
+  // blamed "the Meili leg" (which returns early here, `!metricsSearchClient`), one
+  // blamed the request "not reaching the leg that resolves follows" (it does).
+  // The asymmetry is a fact about the two helpers, not about the two requests.
   //
   // 🔴 THE `bdx:` HALF WAS ALMOST LEFT UNTESTED ON A WRONG DIAGNOSIS. A first
-  // version of the sibling case below passed with the hoist removed, so it was
-  // deleted as vacuous — correctly — but the accompanying note concluded the shape
-  // could not be pinned. It can: the fixture just has to be a cursor that actually
-  // DECODES. `bitdexCursor` comes from `JSON.parse` of everything after `bdx:`, so
-  // a hand-written `bdx:eyJhIjoxfQ==` (base64, not JSON) parsed to nothing, left
-  // `bitdexCursor` falsy, and the request never had the property the test was
-  // named for. The shape below is the one used in bitdex-empty-fallback.test.ts.
-  // Measured with a decoding cursor: 0 lookups with the hoist, 1 without.
+  // version of the case below passed with the hoist removed, so it was deleted as
+  // vacuous — correctly — but the accompanying note concluded the shape could not
+  // be pinned. It can: the fixture just has to be a cursor that actually DECODES.
+  // `bitdexCursor` is `JSON.parse` of everything after `bdx:`, so a base64-looking
+  // literal parses to nothing and leaves `bitdexCursor` falsy, and the request
+  // never has the property the test is named for. (That deleted test was never
+  // committed, so its exact fixture cannot be recovered from the repo — the
+  // MECHANISM is established, the specific literal is a reconstruction.) The shape
+  // below is the one used in bitdex-empty-fallback.test.ts.
   it('a bdx:-paginated followed feed adds no creator-scope lookup of its own', async () => {
     serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
 
@@ -484,11 +514,21 @@ describe('#4123 — a set-shaped creator scope is resolved before the own-exclud
       authedInput({ followed: true, cursor: 'bdx:{"sortAt":1700000000,"id":101}' })
     );
 
-    // ZERO here, unlike the anonymous case below which expects one: a
-    // BitDex-paginated request does not reach the leg that resolves follows for
-    // its own filtering, so the guard's lookup would be the ONLY one. Measured:
-    // 0 with the hoist, 1 without.
     expect(getUserFollowsMock).not.toHaveBeenCalled();
+  });
+
+  // 🔴 `bitdexCursor`, NOT `input.cursor` — the distinction three comments in this
+  // change call load-bearing, and which nothing pinned until now. A request that
+  // fell back to Meilisearch carries a MEILI cursor on its next page, which the
+  // `bdx:` decode rejects; such a request is NOT BitDex-paginated and must still
+  // resolve its scope. Swapping the guard to `!!input.cursor` survives every other
+  // test in this file.
+  it('a NON-bdx cursor is not a bdx: cursor — the scope is still resolved', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    await getImagesFromSearch(authedInput({ followed: true, cursor: '12345' }));
+
+    expect(getUserFollowsMock).toHaveBeenCalledTimes(1);
   });
 
   it('an anonymous newCreators feed adds no creator-scope lookup of its own', async () => {

--- a/src/server/services/__tests__/bitdex-followed-own-excluded-scope.test.ts
+++ b/src/server/services/__tests__/bitdex-followed-own-excluded-scope.test.ts
@@ -407,15 +407,32 @@ describe('#4123 — a set-shaped creator scope is resolved before the own-exclud
     }
   });
 
+  // 🔴 A SECOND DOMAIN, BECAUSE ONE CANNOT DETECT A HARDCODE. With `'red'` as the
+  // only fixture value, `domain: input.domain` and a literal `domain: 'red'`
+  // produce identical calls — measured: that mutant SURVIVED the full 72-test
+  // suite. A fixture that can only ever produce the constant's own value cannot
+  // see a mutant that hardcodes the literal. `'blue'` is a value the constant
+  // cannot equal, and it matters in production: of the four `DomainColor` members
+  // only `red` maps to the red board, so a hardcode would send every green/blue
+  // caller's guard to the wrong board while the feed filtered on the right one.
+  it('reads the board for a DIFFERENT domain too — the argument is read, not hardcoded', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    await getImagesFromSearch(authedInput({ newCreators: true, domain: 'blue' }));
+
+    expect(getNewCreatorUserIdsMock.mock.calls.length).toBeGreaterThan(0);
+    for (const [args] of getNewCreatorUserIdsMock.mock.calls) {
+      expect(args).toEqual({ entity: 'images', domain: 'blue' });
+    }
+  });
+
   // Resolves follows for the CALLER, never for the creator being viewed. Both
   // fields are set and they disagree, so a mutant reading the wrong one returns a
   // different set rather than the same one by luck.
   it('resolves the followed set for the CALLER, not for the userId being viewed', async () => {
     serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
 
-    await getImagesFromSearch(
-      authedInput({ followed: true, userId: FOLLOWED_CREATOR_ID })
-    );
+    await getImagesFromSearch(authedInput({ followed: true, userId: FOLLOWED_CREATOR_ID }));
 
     expect(getUserFollowsMock).toHaveBeenCalledWith(CURRENT_USER_ID);
     expect(getUserFollowsMock).not.toHaveBeenCalledWith(FOLLOWED_CREATOR_ID);
@@ -451,14 +468,29 @@ describe('#4123 — a set-shaped creator scope is resolved before the own-exclud
   // filtering. The BitDex guard's call would be a SECOND one. Verified by
   // mutation: removing the hoist takes this count 1 -> 2.
   //
-  // 🔴 A SIBLING ASSERTION FOR THE `bdx:`-CURSOR SHAPE WAS WRITTEN AND THEN
-  // DELETED, because the mutation showed it could not fail: with the hoist removed
-  // it still read 1. The likeliest cause is that its hand-written `bdx:` cursor
-  // fixture did not decode, so `bitdexCursor` was falsy and the request never had
-  // the property the test was named for. Rather than ship an assertion that passes
-  // in both arms, the `bitdexCursor` half of the short-circuit is left argued from
-  // the code (it is the same `skipOwnExcludedCheaply` expression this case pins
-  // via `!input.currentUserId`) and is NOT claimed as tested.
+  // 🔴 THE `bdx:` HALF WAS ALMOST LEFT UNTESTED ON A WRONG DIAGNOSIS. A first
+  // version of the sibling case below passed with the hoist removed, so it was
+  // deleted as vacuous — correctly — but the accompanying note concluded the shape
+  // could not be pinned. It can: the fixture just has to be a cursor that actually
+  // DECODES. `bitdexCursor` comes from `JSON.parse` of everything after `bdx:`, so
+  // a hand-written `bdx:eyJhIjoxfQ==` (base64, not JSON) parsed to nothing, left
+  // `bitdexCursor` falsy, and the request never had the property the test was
+  // named for. The shape below is the one used in bitdex-empty-fallback.test.ts.
+  // Measured with a decoding cursor: 0 lookups with the hoist, 1 without.
+  it('a bdx:-paginated followed feed adds no creator-scope lookup of its own', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    await getImagesFromSearch(
+      authedInput({ followed: true, cursor: 'bdx:{"sortAt":1700000000,"id":101}' })
+    );
+
+    // ZERO here, unlike the anonymous case below which expects one: a
+    // BitDex-paginated request does not reach the leg that resolves follows for
+    // its own filtering, so the guard's lookup would be the ONLY one. Measured:
+    // 0 with the hoist, 1 without.
+    expect(getUserFollowsMock).not.toHaveBeenCalled();
+  });
+
   it('an anonymous newCreators feed adds no creator-scope lookup of its own', async () => {
     serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
 

--- a/src/server/services/__tests__/bitdex-followed-own-excluded-scope.test.ts
+++ b/src/server/services/__tests__/bitdex-followed-own-excluded-scope.test.ts
@@ -1,0 +1,393 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #4123 — own-excluded images appearing in the FOLLOWING feed.
+//
+// Same class as #3929 (`username`), and deliberately NOT fixed by #4122: that
+// change resolves a single `username` into a single `userId` before
+// `fetchBitdexPrimary` decides whether to run the "own excluded" second pass.
+// A Following feed has no `userId` at all — its creator scope is a SET, resolved
+// later and locally inside `getImagesFromBitdexPreFilter`. So the `userId`-shaped
+// guard reads `undefined`, does not fire, the second pass runs, and the caller's
+// own private/blocked/nsfw0 content is merged into a feed that is supposed to
+// show the people they follow.
+//
+// Both halves of #4122 are structurally unable to reach this shape: its guard
+// takes one id, and the merge's content-scope filter scopes to one creator.
+//
+// Not a cross-user exposure — every document involved belongs to the caller. The
+// defect is feed integrity. Reach is WIDER than #3929's, because Following is a
+// primary browsing surface rather than a `username`-addressed request.
+//
+// Same minimal-seam mocking as bitdex-username-own-excluded-scope.test.ts.
+
+import type * as BitdexClient from '~/server/bitdex/client';
+import type * as FliptClient from '~/server/flipt/client';
+import type * as MeiliClient from '~/server/meilisearch/client';
+import type * as Caches from '~/server/redis/caches';
+import type * as NewCreators from '~/server/services/new-creators.service';
+
+const { queryBitdexMock, getFliptVariantMock, getUserFollowsMock, getNewCreatorUserIdsMock } =
+  vi.hoisted(() => ({
+    queryBitdexMock: vi.fn(),
+    getFliptVariantMock: vi.fn(),
+    getUserFollowsMock: vi.fn(),
+    getNewCreatorUserIdsMock: vi.fn(),
+  }));
+
+vi.mock('../../../../event-engine-common/feeds', () => ({
+  ImagesFeed: class {
+    populatedQuery = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/meilisearch/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof MeiliClient>()),
+  metricsSearchClient: null,
+}));
+
+vi.mock('~/server/bitdex/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof BitdexClient>()),
+  queryBitdex: queryBitdexMock,
+}));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof FliptClient>()),
+  getFliptVariant: getFliptVariantMock,
+  getFliptBoolean: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('~/server/redis/caches', async (importOriginal) => ({
+  ...(await importOriginal<typeof Caches>()),
+  getUserFollows: getUserFollowsMock,
+}));
+
+vi.mock('~/server/services/new-creators.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof NewCreators>()),
+  getNewCreatorUserIds: getNewCreatorUserIdsMock,
+}));
+
+import { getImagesFromSearch } from '../image.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+redisMock.redis.get.mockResolvedValue('[]');
+redisMock.redis.set.mockResolvedValue(undefined);
+
+// Pairwise distinct, and none equal to a threshold, a default, or an array
+// length used anywhere below — a fixture whose ids collide would let a mutant
+// that reads the wrong field produce the right answer by accident.
+const CURRENT_USER_ID = 42;
+const FOLLOWED_CREATOR_ID = 7;
+const NEW_CREATOR_ID = 23;
+const THIRD_PARTY_ID = 13;
+
+/**
+ * Both BitDex passes go through the same `queryBitdex`, so the fake tells them
+ * apart from their arguments — structurally, via the `Or` that only the
+ * own-excluded pass builds, not by call order or position.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw BitDex filter clauses
+type Clause = any;
+function isOwnExcludedQuery(filters: unknown): boolean {
+  if (!Array.isArray(filters)) return false;
+  return filters.some(
+    (clause: Clause) =>
+      Array.isArray(clause?.Or) &&
+      clause.Or.some(
+        (member: Clause) =>
+          Array.isArray(member?.Eq) &&
+          member.Eq[0] === 'availability' &&
+          member.Eq[1]?.String === 'Private'
+      )
+  );
+}
+
+const ownExcludedCalls = () => queryBitdexMock.mock.calls.filter((c) => isOwnExcludedQuery(c[1]));
+const mainCalls = () => queryBitdexMock.mock.calls.filter((c) => !isOwnExcludedQuery(c[1]));
+
+/** A followed creator's ordinary published image — what the feed SHOULD contain. */
+const followedCreatorPublicDoc = {
+  id: 101,
+  url: 'abc',
+  hash: null,
+  nsfwLevel: 1,
+  userId: FOLLOWED_CREATOR_ID,
+  type: 'image',
+  availability: 'Public',
+  postId: 55,
+  postedToId: null,
+  hasMeta: true,
+  onSite: true,
+  poi: false,
+  minor: false,
+  width: 100,
+  height: 100,
+  reactionCount: 3,
+  commentCount: 2,
+  collectedCount: 1,
+  sortAt: 1_700_000_000,
+  publishedAt: 1_700_000_000,
+};
+
+/**
+ * The CALLER's own private image — exactly what the second pass exists to re-add
+ * on the caller's own views, and exactly what must not appear in a feed scoped
+ * to other people.
+ */
+const callerOwnPrivateDoc = {
+  ...followedCreatorPublicDoc,
+  id: 777,
+  userId: CURRENT_USER_ID,
+  availability: 'Private',
+  postId: 61,
+  reactionCount: 9,
+  commentCount: 8,
+  collectedCount: 7,
+};
+
+/** A new-and-upcoming creator's published image. */
+const newCreatorPublicDoc = {
+  ...followedCreatorPublicDoc,
+  id: 303,
+  userId: NEW_CREATOR_ID,
+  postId: 88,
+};
+
+const EMPTY_PAGE = { documents: [], cursor: undefined };
+
+/**
+ * `cursor: undefined` terminates fetchBitdexPrimary's pass loop on the first
+ * iteration. A fake that always returned a cursor would spin to MAX_PASSES.
+ */
+function page(documents: Record<string, unknown>[]) {
+  return { documents, cursor: undefined };
+}
+
+/** Route each call to the pass it belongs to. */
+function serve({
+  main = EMPTY_PAGE,
+  ownExcluded = EMPTY_PAGE,
+}: {
+  main?: { documents: Record<string, unknown>[]; cursor: undefined };
+  ownExcluded?: { documents: Record<string, unknown>[]; cursor: undefined };
+}) {
+  queryBitdexMock.mockImplementation(async (_index: string, filters: unknown) =>
+    isOwnExcludedQuery(filters) ? ownExcluded : main
+  );
+}
+
+/**
+ * 🔴 Sets BOTH sources of the followed set, because there are two and they are
+ * not the same code path: `fetchBitdexPrimary` reads the cached
+ * `getUserFollows`, while `getImagesFromBitdexPreFilter` issues its own raw
+ * `dbRead.userEngagement.findMany` on every pass. A fixture that set only one
+ * would leave whichever half it missed answering `undefined`/`[]`, and a test
+ * could then pass for a reason unrelated to the guard under test.
+ */
+function callerFollows(targetUserIds: number[]) {
+  getUserFollowsMock.mockResolvedValue(targetUserIds);
+  dbMock.dbRead.userEngagement.findMany.mockResolvedValue(
+    targetUserIds.map((targetUserId) => ({ targetUserId }))
+  );
+}
+
+function newCreatorsAre(userIds: number[]) {
+  getNewCreatorUserIdsMock.mockResolvedValue(userIds);
+}
+
+const baseInput = {
+  limit: 10,
+  browsingLevel: 1,
+  periodMode: 'published',
+  include: [],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ImageSearchInput isn't exported
+} as any;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ImageSearchInput isn't exported
+const authedInput = (overrides: Record<string, unknown> = {}): any => ({
+  ...baseInput,
+  currentUserId: CURRENT_USER_ID,
+  ...overrides,
+});
+
+const ids = (data: { id: number }[]) => data.map((d) => d.id);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getFliptVariantMock.mockResolvedValue('primary');
+  callerFollows([FOLLOWED_CREATOR_ID]);
+  newCreatorsAre([NEW_CREATOR_ID]);
+  dbMock.dbRead.user.findUnique.mockResolvedValue(null);
+  dbMock.dbWrite.user.findUnique.mockResolvedValue(null);
+  serve({});
+});
+
+describe('#4123 — a set-shaped creator scope is resolved before the own-excluded decision', () => {
+  // THE REGRESSION. Signed in, first page, Following feed, caller does not
+  // follow themselves. Before the fix `skipOwnExcluded` inspected only
+  // `input.userId` — absent here — so the second pass ran and the caller's own
+  // private image was served as the whole of their Following feed.
+  it("authenticated + followed feed + empty main pass → no own-excluded pass, and the caller's own private image is not served", async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(authedInput({ followed: true }));
+
+    // Proving the pass never RAN is what makes this a claim about the guard
+    // rather than about some filter downstream of it.
+    expect(ownExcludedCalls()).toHaveLength(0);
+    expect(ids(result.data)).toEqual([]);
+    expect(result.source).toBe('meili');
+  });
+
+  // The same defect with a NON-empty main pass: before the fix the caller's own
+  // private image was interleaved into a real Following feed rather than being
+  // the whole of it, which is the shape a reader would actually meet.
+  it('authenticated + followed feed + non-empty main pass → serves only followed creators, no injected own content', async () => {
+    serve({
+      main: page([followedCreatorPublicDoc]),
+      ownExcluded: page([callerOwnPrivateDoc]),
+    });
+
+    const result = await getImagesFromSearch(authedInput({ followed: true }));
+
+    expect(ownExcludedCalls()).toHaveLength(0);
+    expect(ids(result.data)).toEqual([followedCreatorPublicDoc.id]);
+    expect(ids(result.data)).not.toContain(callerOwnPrivateDoc.id);
+    expect(result.source).toBe('bitdex');
+  });
+
+  // `newCreators` was called out in #4123 as "looks identical by inspection,
+  // NOT probed". This is the probe: it is the same set-shaped scope, resolved in
+  // the same place, and it must behave the same way.
+  it('authenticated + newCreators feed + the caller is not a new creator → no own-excluded pass', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(authedInput({ newCreators: true }));
+
+    expect(ownExcludedCalls()).toHaveLength(0);
+    expect(ids(result.data)).toEqual([]);
+  });
+
+  it('authenticated + newCreators feed + non-empty main pass → serves only new creators', async () => {
+    serve({ main: page([newCreatorPublicDoc]), ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(authedInput({ newCreators: true }));
+
+    expect(ownExcludedCalls()).toHaveLength(0);
+    expect(ids(result.data)).toEqual([newCreatorPublicDoc.id]);
+  });
+
+  // 🔴 THE OTHER DIRECTION. An assertion that only checks ABSENCE is walked by a
+  // mutant that deletes the pass outright; these two require it to still RUN
+  // where it legitimately belongs, so a blanket "never run the second pass on a
+  // scoped feed" fix fails here.
+  //
+  // Self-follow is the reachable case: `toggleFollowUser` creates
+  // `{ userId, targetUserId }` with no `userId !== targetUserId` guard, so a
+  // caller CAN be inside their own followed set. That is why the fix tests set
+  // MEMBERSHIP rather than assuming a Following feed never contains the caller.
+  it('positive control: the caller follows THEMSELVES → the own-excluded pass runs and its content is served', async () => {
+    callerFollows([FOLLOWED_CREATOR_ID, CURRENT_USER_ID]);
+    serve({
+      main: page([followedCreatorPublicDoc]),
+      ownExcluded: page([callerOwnPrivateDoc]),
+    });
+
+    const result = await getImagesFromSearch(authedInput({ followed: true }));
+
+    expect(ownExcludedCalls()).toHaveLength(1);
+    expect(ids(result.data)).toContain(callerOwnPrivateDoc.id);
+  });
+
+  it('positive control: the caller IS a new creator → the own-excluded pass runs', async () => {
+    newCreatorsAre([NEW_CREATOR_ID, CURRENT_USER_ID]);
+    serve({ main: page([newCreatorPublicDoc]), ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(authedInput({ newCreators: true }));
+
+    expect(ownExcludedCalls()).toHaveLength(1);
+    expect(ids(result.data)).toContain(callerOwnPrivateDoc.id);
+  });
+
+  // The guard must be SCOPED, not blanket. With no creator scope at all the
+  // second pass is the whole point of the feature and must still run — this is
+  // what fails if someone "fixes" #4123 by disabling the pass more broadly.
+  it('positive control: an unscoped feed still runs the own-excluded pass', async () => {
+    serve({ main: page([followedCreatorPublicDoc]), ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(authedInput());
+
+    expect(ownExcludedCalls()).toHaveLength(1);
+    expect(ids(result.data)).toContain(callerOwnPrivateDoc.id);
+  });
+
+  // The main pass must be unaffected — a fix that suppressed the whole BitDex
+  // leg on a Following feed would satisfy every absence assertion above.
+  it('the main pass still runs for a followed feed', async () => {
+    serve({ main: page([followedCreatorPublicDoc]) });
+
+    await getImagesFromSearch(authedInput({ followed: true }));
+
+    expect(mainCalls().length).toBeGreaterThan(0);
+  });
+
+  // Following-with-zero-follows is one of the pre-filter's five early `return
+  // null` doors. It must not become a route by which the own pass serves the
+  // caller their own content — and, per #3930's counter, it is also the shape
+  // that records `fallback_empty` while a call did go out.
+  it('followed feed with ZERO follows → BitDex declines and serves nothing of the caller’s own', async () => {
+    callerFollows([]);
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    const result = await getImagesFromSearch(authedInput({ followed: true }));
+
+    expect(ids(result.data)).not.toContain(callerOwnPrivateDoc.id);
+    expect(result.source).toBe('meili');
+  });
+
+  // An anonymous caller has no own content to re-add; the pass must never run.
+  // Cheap, and it pins the disjunct #4122 did not touch.
+  it('anonymous + followed feed → no own-excluded pass', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
+
+    await getImagesFromSearch({ ...baseInput, followed: true });
+
+    expect(ownExcludedCalls()).toHaveLength(0);
+  });
+
+  // A third creator's private document is not reachable in production (the own
+  // pass pins `userId = currentUserId`), but the fake returns it to prove the
+  // decision is about SCOPE MEMBERSHIP and not about "is this document mine".
+  it('a followed feed does not serve a private document belonging to someone else', async () => {
+    serve({
+      main: page([followedCreatorPublicDoc]),
+      ownExcluded: page([{ ...callerOwnPrivateDoc, id: 909, userId: THIRD_PARTY_ID }]),
+    });
+
+    const result = await getImagesFromSearch(authedInput({ followed: true }));
+
+    expect(ids(result.data)).not.toContain(909);
+  });
+});

--- a/src/server/services/__tests__/bitdex-followed-own-excluded-scope.test.ts
+++ b/src/server/services/__tests__/bitdex-followed-own-excluded-scope.test.ts
@@ -407,10 +407,19 @@ describe('#4123 — a set-shaped creator scope is resolved before the own-exclud
     }
   });
 
-  // 🔴 AND THE UNSET SHAPE, WHICH IS THE PRODUCTION DEFAULT. Both cases above
-  // pass `domain` explicitly, so `domain: input.domain ?? 'red'` — a guard-side
-  // default that would desync from the pre-filter's board — survived them both.
-  // Only red domains set `domain` at all, so `undefined` is the common case.
+  // 🔴 AND THE UNSET SHAPE. The other two argument cases both pass `domain`
+  // explicitly, so `domain: input.domain ?? 'red'` — a guard-side default that
+  // would desync the guard's board from the pre-filter's — survived both of them.
+  //
+  // ⚠️ `undefined` is NOT the common production shape, and an earlier version of
+  // this comment claimed it was. `getRequestBoardDomainColor` stamps a colour on
+  // the image-feed path (`image.controller.ts:329,348`), returning 'green' for
+  // civitai.com and 'red' for civitai.red; it yields `undefined` only for an
+  // unknown or missing host, and for internal callers that omit `domain`. The
+  // point of this case is narrower and does not depend on how common it is: the
+  // guard must pass `domain` THROUGH unchanged, whatever it is, so that it reads
+  // the same board the pre-filter filters on. A default applied on one side only
+  // is a desync by construction.
   it('passes an unset domain THROUGH rather than defaulting it', async () => {
     serve({ main: EMPTY_PAGE, ownExcluded: page([callerOwnPrivateDoc]) });
 
@@ -475,8 +484,9 @@ describe('#4123 — a set-shaped creator scope is resolved before the own-exclud
 
   // The cheap disjuncts must SHORT-CIRCUIT the scope resolution, not merely
   // out-vote it: without the hoist these shapes pay a lookup whose result is then
-  // discarded, and every behavioural test still passes — so these two assert the
-  // CALL, not the outcome.
+  // discarded, and every behavioural test still passes — so the cases below assert
+  // the CALL, not the outcome. (Three of them now; the non-bdx cursor case sits
+  // between the two this header's bullets describe and carries its own note.)
   //
   // 🔴 THE TWO CASES EXPECT DIFFERENT COUNTS, AND THE REASON IS NOT WHAT THREE
   // EARLIER REVISIONS OF THIS COMMENT SAID. It is not that one request reaches a

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3236,22 +3236,35 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   //   1. `!input.currentUserId`                                  — anonymous caller
   //   2. `bitdexCursor`                — a `bdx:` cursor, i.e. a BitDex-paginated
   //                                      request (NOT any paginated request)
-  //   3. `input.userId && input.userId !== input.currentUserId`
-  //                                    — signed-in, viewing another user's profile
+  //   3. `creatorScopeExcludesCaller`  — the request is scoped to a set of
+  //                                      creators that does not contain the
+  //                                      caller (#4123). Reference it BY SYMBOL:
+  //                                      it is computed from three scopes and a
+  //                                      gloss of it drifts, which is what
+  //                                      happened to the `input.userId` version
+  //                                      this replaced.
   // If none holds, the own-content pass is issued regardless of what the feed
   // query did, a call goes out, and the request IS counted.
   //
   // Measured, driving the real path (each row is a request that walks a door):
   //   signed-in, other user's profile        → 0 calls, nothing recorded
   //   signed-in, `bdx:` cursor               → 0 calls, nothing recorded
-  //   signed-in, NON-`bdx:` cursor           → 1 call,  `fallback_empty` recorded
-  //   signed-in, first page                  → 1 call,  `fallback_empty` recorded
-  // The third row is why "any paginated request" was wrong, and it is the NORMAL
+  //   signed-in, followed-with-zero-follows  → 0 calls, nothing recorded  (#4123)
+  //   signed-in, newCreators-with-none       → 0 calls, nothing recorded  (#4123)
+  //   signed-in, `hidden`-with-none, page 1  → 1 call,  `fallback_empty` recorded
+  //   signed-in, unscoped, NON-`bdx:` cursor → 1 call,  `fallback_empty` recorded
+  // 🔴 ROWS 3 AND 4 USED TO READ `1 call, fallback_empty recorded`, AND #4123
+  // CHANGED THEM. A set-shaped creator scope is now resolved before the decision,
+  // so those two doors stopped issuing the own pass and joined the other doors
+  // instead of being the ones that leaked a call. That is a REDUCTION in what
+  // `fallback_empty` counts — it shifts the served-ratio baseline, exactly as
+  // #4122 did. Do not compare that ratio across #4123.
+  // The last row is why "any paginated request" was wrong, and it is the NORMAL
   // shape: a request that walks a door falls back to Meili, so its next page
   // carries a MEILI cursor, which the `bdx:` decode above does not accept.
   //
-  // Counting those requests is correct under the stated denominator — a call did
-  // go out — and is deliberately left as is. Both shapes are pinned in
+  // Counting the remaining two is correct under the stated denominator — a call
+  // did go out — and is deliberately left as is. Every shape above is pinned in
   // bitdex-feed-source.test.ts.
   //
   // The two observations that mean "a call was made": the client reported a
@@ -3354,32 +3367,67 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   // `src/server/services/__tests__/bitdex-followed-own-excluded-scope.test.ts`; a
   // blanket "never run the second pass on a scoped feed" fails them.
   //
-  // COST: both helpers are cached (`getUserFollows` via `userFollowsCache`,
-  // `getNewCreatorUserIds` via `fetchThroughCache`) and are the same helpers the
-  // Meili leg already calls for these two scopes, so a scoped request adds a cache
-  // read rather than a query. In practice the await is free where it matters: an
-  // unscoped feed and an own-profile feed resolve to literals with nothing to
-  // await, and the two scopes that DO await are the ones this guard then skips.
+  // COST: both helpers are cached — `getNewCreatorUserIds` via `fetchThroughCache`
+  // (genuinely shared: the pre-filter calls the very same helper), and
+  // `getUserFollows` via `userFollowsCache`. ⚠️ `getUserFollows` is NOT already on
+  // this path: the search legs read follows with a raw
+  // `dbRead.userEngagement.findMany` (`getImagesFromSearchPreFilter`,
+  // `getImagesFromBitdexPreFilter`, `getImagesFromSearchPostFilter`), and the only
+  // other `getUserFollows` call in this file is in `getAllImages`, the legacy SQL
+  // feed. So this introduces a NEW `userFollowsCache` dependency into the
+  // image-search hot path rather than reusing one. Steady-state cost is still
+  // small — `cacheNotFound` defaults to true, so a zero-follow caller is
+  // negatively cached instead of falling through to the DB every request — but
+  // the basis is "a new, cheap cache read", not "a read we already do".
   //
-  // ⚠️ `getUserFollows` is the CACHED set, while `getImagesFromBitdexPreFilter`
-  // reads `userEngagement` directly, so the two can disagree while the cache is
-  // stale. `toggleFollowUser` refreshes that cache on both follow and unfollow, so
-  // the window is write-propagation, not the entry's TTL. Both directions are
-  // benign and self-healing: a stale "caller is in the set" re-admits the old
-  // behaviour for that window; a stale "caller is not in the set" withholds the
-  // caller's own excluded content from their own feed. Deliberately NOT unified
-  // here — repointing the pre-filter at the cache would change what the FEED
-  // CONTAINS, which is a different change from what this decision READS.
-  const creatorScopes = await Promise.all([
-    input.userId ? [input.userId] : null,
-    input.currentUserId && input.followed ? getUserFollows(input.currentUserId) : null,
-    input.newCreators ? getNewCreatorUserIds({ entity: 'images', domain: input.domain }) : null,
-  ]);
+  // The cheap disjuncts are evaluated FIRST and short-circuit the awaits entirely,
+  // so an anonymous request and any `bdx:`-paginated page (i.e. every page ≥2 of a
+  // BitDex-served Following feed) pay nothing here.
+  //
+  // ⚠️ THE STALENESS WINDOW IS REPLICA LAG, NOT CACHE TTL — and the cache is the
+  // FRESHER of the two. `userFollowsCache.refresh()` re-reads through `lookupFn(…,
+  // true)`, i.e. dbWrite, and `toggleFollowUser` calls it on both follow and
+  // unfollow; the pre-filter reads the REPLICA. So the reachable disagreement is a
+  // caller who has just self-followed: for the replica-lag window this guard says
+  // "in scope" and runs the own pass while the replica-derived filter still
+  // excludes them. It needs a self-follow to reach at all, is self-healing, and
+  // the other direction merely withholds the caller's own excluded content from
+  // their own feed. Deliberately NOT unified here — repointing the pre-filter at
+  // the cache would change what the FEED CONTAINS, which is a different change
+  // from what this decision READS.
+  // The two cheap disjuncts are evaluated FIRST and short-circuit the scope
+  // resolution entirely. Without this the `Promise.all` below runs on every
+  // request including ones already destined to skip — notably every page >= 2 of a
+  // BitDex-served Following feed (`bitdexCursor` set) and an anonymous
+  // `newCreators` request, both of which would pay a cache read whose result is
+  // then discarded. Cheap-first is also the order the old single-expression guard
+  // had by virtue of `||` short-circuiting, so this preserves it rather than
+  // introducing it.
+  const skipOwnExcludedCheaply = !input.currentUserId || !!bitdexCursor;
+
+  // 🔴 The three scopes here must stay 1:1 with the creator-scoping filters
+  // `getImagesFromBitdexPreFilter` applies — `followed`, `newCreators` and
+  // `userId`. That coupling IS the correctness argument: the guard has to read
+  // the same creator scope the feed is filtered by, or it decides from a
+  // different set than the one that shaped the results. The ARGUMENTS matter as
+  // much as the calls — `entity` and `domain` select which board
+  // `getNewCreatorUserIds` reads, and passing a different `domain` here would
+  // silently consult the SFW board while the feed filters on the red one. Pinned
+  // by argument assertions in bitdex-followed-own-excluded-scope.test.ts.
+  const creatorScopes = skipOwnExcludedCheaply
+    ? []
+    : await Promise.all([
+        input.userId ? [input.userId] : null,
+        input.followed ? getUserFollows(input.currentUserId!) : null,
+        input.newCreators ? getNewCreatorUserIds({ entity: 'images', domain: input.domain }) : null,
+      ]);
+  // `some`, not `every`: the pre-filter ANDs these scopes, so exclusion by ANY
+  // one of them excludes the caller from the feed.
   const creatorScopeExcludesCaller = creatorScopes.some(
     (scope) => scope !== null && !scope.includes(input.currentUserId!)
   );
 
-  const skipOwnExcluded = !input.currentUserId || bitdexCursor || creatorScopeExcludesCaller;
+  const skipOwnExcluded = skipOwnExcludedCheaply || creatorScopeExcludesCaller;
 
   let ownExcludedPromise: ReturnType<typeof queryBitdex> | null = null;
   if (!skipOwnExcluded) {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3264,8 +3264,15 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   // carries a MEILI cursor, which the `bdx:` decode above does not accept.
   //
   // Counting the remaining two is correct under the stated denominator — a call
-  // did go out — and is deliberately left as is. Every shape above is pinned in
-  // bitdex-feed-source.test.ts.
+  // did go out — and is deliberately left as is.
+  //
+  // ⚠️ PIN SCOPE, STATED NARROWLY ON PURPOSE: of the six rows above, exactly TWO
+  // are driven in bitdex-feed-source.test.ts — followed-with-zero-follows and
+  // `hidden`-with-none, the two the counter's behaviour turns on. The other four
+  // are read from the code, not pinned by a test there. An earlier revision of
+  // this comment said "every shape above is pinned", which was a true narrow claim
+  // widened into a false one — the exact failure this comment block exists to
+  // prevent.
   //
   // The two observations that mean "a call was made": the client reported a
   // FAILURE, or it handed back a NON-NULL result (it returns null on every
@@ -3395,14 +3402,20 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   // their own feed. Deliberately NOT unified here — repointing the pre-filter at
   // the cache would change what the FEED CONTAINS, which is a different change
   // from what this decision READS.
-  // The two cheap disjuncts are evaluated FIRST and short-circuit the scope
-  // resolution entirely. Without this the `Promise.all` below runs on every
-  // request including ones already destined to skip — notably every page >= 2 of a
-  // BitDex-served Following feed (`bitdexCursor` set) and an anonymous
-  // `newCreators` request, both of which would pay a cache read whose result is
-  // then discarded. Cheap-first is also the order the old single-expression guard
-  // had by virtue of `||` short-circuiting, so this preserves it rather than
-  // introducing it.
+  //
+  // 🔴 THIS HOIST INTRODUCES THE SHORT-CIRCUIT — IT DOES NOT PRESERVE ONE. An
+  // earlier revision of this comment claimed the pre-#4123 guard already had it
+  // "by virtue of `||`". It did not: before the hoist the scope resolution was an
+  // unconditional `await Promise.all([...])` on the line ABOVE the guard, and `||`
+  // short-circuited only the read of a boolean that had already been computed. So
+  // deleting this line is NOT a no-op — it reinstates a cache read on every
+  // request already destined to skip, notably an anonymous `newCreators` request
+  // and every page >= 2 of a BitDex-served Following feed.
+  //
+  // ⚠️ It is also load-bearing for the `getUserFollows(input.currentUserId!)`
+  // call below, which dropped its own `input.currentUserId &&` guard because this
+  // line makes it unreachable when `currentUserId` is absent. Reorder or remove
+  // the hoist and that non-null assertion becomes `getUserFollows(undefined)`.
   const skipOwnExcludedCheaply = !input.currentUserId || !!bitdexCursor;
 
   // 🔴 The three scopes here must stay 1:1 with the creator-scoping filters

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3327,9 +3327,59 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   //
   // Content-scoping filters from the main query are applied so the second pass
   // only returns content relevant to the current view (e.g. same model, same post).
-  // Skip entirely if viewing another user's profile (userId !== currentUserId).
-  const skipOwnExcluded =
-    !input.currentUserId || bitdexCursor || (input.userId && input.userId !== input.currentUserId);
+  //
+  // 🔴 #4123 — THE CREATOR SCOPE CAN BE A SET, AND IT WAS RESOLVED TOO LATE.
+  //
+  // This decision used to read `input.userId` alone — "skip entirely if viewing
+  // another user's profile". That covers a feed addressed to ONE creator, and
+  // since #4122 one addressed by handle. But a Following or new-creators feed has
+  // no `userId` at all: its creator scope is a SET, resolved later and locally
+  // inside `getImagesFromBitdexPreFilter`. The `userId`-shaped test therefore read
+  // `undefined`, did not fire, the second pass ran anyway, and the caller's own
+  // private/blocked/nsfw0 content was merged into a feed that exists to show OTHER
+  // people's work. Not a cross-user exposure — every document returned belongs to
+  // the caller — but the feed misrepresents whose work it is showing, and Following
+  // is a primary browsing surface.
+  //
+  // Generalised to the invariant both shapes share: THE OWN PASS BELONGS ONLY IN A
+  // FEED WHOSE CREATOR SCOPE CONTAINS THE CALLER. A single `userId` is a
+  // one-element set, so the old disjunct is SUBSUMED here rather than left sitting
+  // beside this one — one rule in one place, so a third scope shape cannot be added
+  // to one test and missed by the other.
+  //
+  // ⚠️ MEMBERSHIP, not "is this feed scoped to somebody else". `toggleFollowUser`
+  // creates `{ userId, targetUserId }` with no `userId !== targetUserId` guard, so
+  // a caller CAN sit inside their own followed set, and can be on the
+  // new-and-upcoming board. Both are pinned as positive controls in
+  // `src/server/services/__tests__/bitdex-followed-own-excluded-scope.test.ts`; a
+  // blanket "never run the second pass on a scoped feed" fails them.
+  //
+  // COST: both helpers are cached (`getUserFollows` via `userFollowsCache`,
+  // `getNewCreatorUserIds` via `fetchThroughCache`) and are the same helpers the
+  // Meili leg already calls for these two scopes, so a scoped request adds a cache
+  // read rather than a query. In practice the await is free where it matters: an
+  // unscoped feed and an own-profile feed resolve to literals with nothing to
+  // await, and the two scopes that DO await are the ones this guard then skips.
+  //
+  // ⚠️ `getUserFollows` is the CACHED set, while `getImagesFromBitdexPreFilter`
+  // reads `userEngagement` directly, so the two can disagree while the cache is
+  // stale. `toggleFollowUser` refreshes that cache on both follow and unfollow, so
+  // the window is write-propagation, not the entry's TTL. Both directions are
+  // benign and self-healing: a stale "caller is in the set" re-admits the old
+  // behaviour for that window; a stale "caller is not in the set" withholds the
+  // caller's own excluded content from their own feed. Deliberately NOT unified
+  // here — repointing the pre-filter at the cache would change what the FEED
+  // CONTAINS, which is a different change from what this decision READS.
+  const creatorScopes = await Promise.all([
+    input.userId ? [input.userId] : null,
+    input.currentUserId && input.followed ? getUserFollows(input.currentUserId) : null,
+    input.newCreators ? getNewCreatorUserIds({ entity: 'images', domain: input.domain }) : null,
+  ]);
+  const creatorScopeExcludesCaller = creatorScopes.some(
+    (scope) => scope !== null && !scope.includes(input.currentUserId!)
+  );
+
+  const skipOwnExcluded = !input.currentUserId || bitdexCursor || creatorScopeExcludesCaller;
 
   let ownExcludedPromise: ReturnType<typeof queryBitdex> | null = null;
   if (!skipOwnExcluded) {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3253,8 +3253,10 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   //   signed-in, newCreators-with-none       → 0 calls, nothing recorded  (#4123)
   //   signed-in, `hidden`-with-none, page 1  → 1 call,  `fallback_empty` recorded
   //   signed-in, unscoped, NON-`bdx:` cursor → 1 call,  `fallback_empty` recorded
-  // 🔴 ROWS 3 AND 4 USED TO READ `1 call, fallback_empty recorded`, AND #4123
-  // CHANGED THEM. A set-shaped creator scope is now resolved before the decision,
+  // 🔴 THE TWO SHAPES NAMED ON ROWS 3 AND 4 ABOVE — followed-with-zero-follows and
+  // newCreators-with-none — USED TO READ `1 call, fallback_empty recorded`, AND
+  // #4123 CHANGED THEM. (Row numbers index THIS table, which #4123 also reordered;
+  // read the shapes, not the positions.) A set-shaped creator scope is now resolved before the decision,
   // so those two doors stopped issuing the own pass and joined the other doors
   // instead of being the ones that leaked a call. That is a REDUCTION in what
   // `fallback_empty` counts — it shifts the served-ratio baseline, exactly as
@@ -3404,13 +3406,15 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   // from what this decision READS.
   //
   // 🔴 THIS HOIST INTRODUCES THE SHORT-CIRCUIT — IT DOES NOT PRESERVE ONE. An
-  // earlier revision of this comment claimed the pre-#4123 guard already had it
-  // "by virtue of `||`". It did not: before the hoist the scope resolution was an
-  // unconditional `await Promise.all([...])` on the line ABOVE the guard, and `||`
-  // short-circuited only the read of a boolean that had already been computed. So
-  // deleting this line is NOT a no-op — it reinstates a cache read on every
-  // request already destined to skip, notably an anonymous `newCreators` request
-  // and every page >= 2 of a BitDex-served Following feed.
+  // earlier revision claimed the guard "already had it by virtue of `||`". Two
+  // different baselines, and neither had it: pre-#4123 there were no awaits here
+  // at all, so there was nothing to short-circuit; and in #4123's own first
+  // revision the scope resolution was an unconditional `await Promise.all([...])`
+  // on the line ABOVE the guard, where `||` short-circuited only the read of an
+  // already-computed boolean. So removing the `skipOwnExcludedCheaply ? [] :`
+  // ternary below is NOT a no-op — it reinstates a lookup on every request already
+  // destined to skip, notably an anonymous `newCreators` request and every page
+  // >= 2 of a BitDex-served Following feed.
   //
   // ⚠️ It is also load-bearing for the `getUserFollows(input.currentUserId!)`
   // call below, which dropped its own `input.currentUserId &&` guard because this

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3253,10 +3253,9 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
   //   signed-in, newCreators-with-none       → 0 calls, nothing recorded  (#4123)
   //   signed-in, `hidden`-with-none, page 1  → 1 call,  `fallback_empty` recorded
   //   signed-in, unscoped, NON-`bdx:` cursor → 1 call,  `fallback_empty` recorded
-  // 🔴 THE TWO SHAPES NAMED ON ROWS 3 AND 4 ABOVE — followed-with-zero-follows and
-  // newCreators-with-none — USED TO READ `1 call, fallback_empty recorded`, AND
-  // #4123 CHANGED THEM. (Row numbers index THIS table, which #4123 also reordered;
-  // read the shapes, not the positions.) A set-shaped creator scope is now resolved before the decision,
+  // 🔴 THE TWO SHAPES followed-with-zero-follows AND newCreators-with-none USED TO
+  // READ `1 call, fallback_empty recorded`, AND #4123 CHANGED THEM. (Named by
+  // shape, not by row number: #4123 reordered this table.) A set-shaped creator scope is now resolved before the decision,
   // so those two doors stopped issuing the own pass and joined the other doors
   // instead of being the ones that leaked a call. That is a REDUCTION in what
   // `fallback_empty` counts — it shifts the served-ratio baseline, exactly as


### PR DESCRIPTION
Closes #4123.

A Following feed served the caller their own private/blocked/nsfw0 content.

## The defect

`fetchBitdexPrimary` decided whether to issue the "own excluded" second pass from `input.userId` alone. That covers a feed addressed to **one** creator — and, since #4122, one addressed by handle — but a Following or new-creators feed has **no `userId` at all**: its creator scope is a **set**, resolved later and locally inside `getImagesFromBitdexPreFilter`. So the `userId`-shaped test read `undefined`, did not fire, the second pass ran anyway, and the caller's own excluded content was merged into a feed that exists to show *other people's* work.

**Not a cross-user exposure** — every document returned belongs to the caller. It is feed integrity, with **wider reach than #3929**: Following is a primary browsing surface, whereas #3929 needed a `username`-addressed request.

## The fix

Generalised to the invariant both shapes share: **the own pass belongs only in a feed whose creator scope contains the caller.** A single `userId` is a one-element set, so the old disjunct is *subsumed* rather than left sitting beside a new one — one rule in one place, so a third scope shape cannot be added to one test and missed by the other.

```ts
const creatorScopes = await Promise.all([
  input.userId ? [input.userId] : null,
  input.currentUserId && input.followed ? getUserFollows(input.currentUserId) : null,
  input.newCreators ? getNewCreatorUserIds({ entity: 'images', domain: input.domain }) : null,
]);
const creatorScopeExcludesCaller = creatorScopes.some(
  (scope) => scope !== null && !scope.includes(input.currentUserId!)
);
const skipOwnExcluded = !input.currentUserId || bitdexCursor || creatorScopeExcludesCaller;
```

⚠️ **Membership, not "is this feed scoped to somebody else".** `toggleFollowUser` creates `{ userId, targetUserId }` with no `userId !== targetUserId` guard, so a caller **can** sit inside their own followed set, and can be on the new-and-upcoming board. Both are pinned as positive controls — a blanket "never run the second pass on a scoped feed" fails them.

**Cost:** both helpers are cached (`getUserFollows` via `userFollowsCache`, `getNewCreatorUserIds` via `fetchThroughCache`) and are the same helpers the Meili leg already calls for these scopes. The await is free where it matters: unscoped and own-profile feeds resolve to literals with nothing to await, and the two scopes that *do* await are the ones this guard then skips.

#4123 flagged `newCreators` as *"looks identical by inspection, **not probed**"*. It is now probed — same set-shaped scope, same place, same behaviour, covered in both directions.

## 🔴 A real collision with #4114, caught by its test rather than by reading

#4114's case *"followed-with-zero-follows: the own-content pass still counts"* went red, because that request now makes **zero** BitDex calls instead of one. That is the more correct behaviour — the door joined the other four instead of being the one that leaked a call, and #4114's own denominator is "requests that ENGAGED the backend".

But that case was documented as the **only killing case** for the third observation site, `if (ownExcluded) bitdexCallsObserved++`. Rewriting it to expect zero calls and stopping there would have left that line untested while every suite stayed green.

So it is **retargeted** onto the `hidden`-with-no-hidden-images door — not a creator scope, therefore untouched by this change — and the mutation battery confirms the retargeted case *still kills that line*. The old shape is kept as its own test asserting the new zero-call behaviour.

## ⚠️ Consequence for the #3930 metric

This **reduces** what `fallback_empty` counts, because followed/newCreators door-walks stop issuing the own pass and therefore stop being counted. It shifts the served-ratio baseline exactly as #4122 did — **do not compare that ratio across this change.** Measured immediately before this PR: **~81% served / ~19% `fallback_empty`**. Flagged on talos-infra#1155, which specifies the dashboard and alerts over that counter.

## Verification

| check | result |
|---|---|
| new suite red at base | **6 of 11 fail on `origin/main`**, all 11 pass here |
| the other 5 | positive controls asserting existing-correct behaviour — pass in **both** arms, so they are not manufacturing red |
| all `bitdex-*` suites | 6 files / 68 tests green |
| `pnpm typecheck` | 0 errors |
| `tsc -p tsconfig.tests.json` | 852 errors, all pre-existing, **zero in the three files touched** |

**Mutation battery — 6 mutants, each required to die on its OWN named test** (not merely "something failed"):

| mutant | dies on |
|---|---|
| `revert-to-userid-only-guard` | followed feed + empty main pass |
| `invert-membership` | followed feed + empty main pass |
| `drop-followed-scope` | followed feed + empty main pass |
| `drop-newcreators-scope` | newCreators feed + caller is not a new creator |
| `some-to-every` | followed feed + empty main pass |
| `drop-owncall-observation` | hidden-with-no-hidden-images: the own-content pass still counts |

Two instrument failures were caught and corrected while doing this, both of which had produced a confident wrong reading first: the mutation harness grepped an **ANSI-prefixed** vitest summary and scored a passing suite as failed (its own precondition caught it); and `tsc -p tsconfig.tests.json` **OOM'd and printed `0 errors`** — a false zero that reads exactly like a clean result, re-run at an 8 GB heap to get the real 852.

## Not verified

- No live or staging reproduction — the tests drive the unit seam, as #4123's own probe did.
- The cache-vs-DB caveat is documented inline: `getUserFollows` is the cached set while the pre-filter reads `userEngagement` directly, so they can disagree while the cache is stale. `toggleFollowUser` refreshes on both follow and unfollow, so the window is write-propagation rather than the entry's TTL. Both directions are benign and self-healing. Deliberately **not** unified here — repointing the pre-filter at the cache would change what the feed *contains*, which is a different change from what this decision *reads*.
