### PR TITLE
feat(articles): stickers on article covers, with a per-viewer show/hide toggle

### DIFF
--- a/src/components/Article/ArticleCoverStickers.tsx
+++ b/src/components/Article/ArticleCoverStickers.tsx
@@ -1,0 +1,35 @@
+import { CardStickerOverlay } from '~/components/Sticker/CardStickerOverlay';
+import { StickerPlacementBatchProvider } from '~/components/Sticker/StickerPlacementBatchProvider';
+import { StickerPlacementCardBadge } from '~/components/Sticker/StickerPlacementCardBadge';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+
+/**
+ * A cover is drawn at the article page's full width, so a default-sized sticker
+ * lands near 330 CSS px — 660 device px on a DPR-2 display. The card overlay's
+ * own 256 would upscale artwork a creator was paid for.
+ */
+const COVER_ARTWORK_WIDTH = 512;
+
+/**
+ * Placed stickers on an article cover, and the viewer's reveal toggle.
+ *
+ * Its own component rather than JSX in the page so the gate below is reachable
+ * by a test: `safe` is a boolean whose deletion no type checks, and dropping it
+ * would draw someone else's cosmetic over a cover the viewer's browsing level
+ * blurred.
+ *
+ * Renders nothing until the media is safe, which is also why the batch fetch
+ * lives inside the gate rather than around it — a blurred cover asks for no
+ * placements at all.
+ */
+export function ArticleCoverStickers({ imageId, safe }: { imageId: number; safe: boolean }) {
+  const features = useFeatureFlags();
+  if (!safe || !features.stickerPlacement) return null;
+
+  return (
+    <StickerPlacementBatchProvider imageIds={[imageId]}>
+      <CardStickerOverlay imageId={imageId} artworkWidth={COVER_ARTWORK_WIDTH} />
+      <StickerPlacementCardBadge imageId={imageId} className="absolute bottom-2 right-2 z-10" />
+    </StickerPlacementBatchProvider>
+  );
+}

--- a/src/components/Article/__tests__/ArticleCoverStickers.test.ts
+++ b/src/components/Article/__tests__/ArticleCoverStickers.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import * as React from 'react';
+import type { act as actType } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+
+const act = (React as unknown as { act: typeof actType }).act;
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * 🔴 THE GATE ON THE ARTICLE COVER, RENDERED — in the `unit` project, which is
+ * the one CI runs. The sticker components' own tests are `*.browser.test.tsx`
+ * in the `component` project, which no GitHub workflow invokes.
+ *
+ * `safe` is a boolean that no type checks: delete it from the condition and the
+ * code still compiles, still renders, and draws a placed sticker over a cover
+ * the viewer's browsing level blurred. That mutant is what these cases exist to
+ * print, so each one names the state rather than asserting a truthy blob.
+ *
+ * The three sticker components are stubbed to markers deliberately. Their own
+ * rendering is not the subject — the call site's composition is — and the two
+ * things this pins that nothing else does are the gate and the CDN request
+ * width, both of which are decisions taken here rather than in them.
+ *
+ * What this canNOT see, stated so a green run is not over-read: happy-dom
+ * computes no layout, so the overlay's measurement, its offset parent, and the
+ * pointer-events behaviour of a sticker over a cover link are all invisible
+ * here. Those were verified in a browser against a real cover and stay that way.
+ */
+
+const flags = { stickerPlacement: true };
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => flags,
+}));
+
+const overlayProps: Array<Record<string, unknown>> = [];
+const badgeProps: Array<Record<string, unknown>> = [];
+const providerProps: Array<Record<string, unknown>> = [];
+
+vi.mock('~/components/Sticker/CardStickerOverlay', () => ({
+  CardStickerOverlay: (props: Record<string, unknown>) => {
+    overlayProps.push(props);
+    return React.createElement('div', { 'data-testid': 'overlay' });
+  },
+}));
+
+vi.mock('~/components/Sticker/StickerPlacementCardBadge', () => ({
+  StickerPlacementCardBadge: (props: Record<string, unknown>) => {
+    badgeProps.push(props);
+    return React.createElement('button', { 'data-testid': 'badge' });
+  },
+}));
+
+vi.mock('~/components/Sticker/StickerPlacementBatchProvider', () => ({
+  StickerPlacementBatchProvider: (props: Record<string, unknown>) => {
+    providerProps.push(props);
+    return React.createElement(React.Fragment, null, props.children as React.ReactNode);
+  },
+}));
+
+import { ArticleCoverStickers } from '~/components/Article/ArticleCoverStickers';
+
+const IMAGE_ID = 139640277;
+
+function render({ safe }: { safe: boolean }) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(ArticleCoverStickers, { imageId: IMAGE_ID, safe }));
+  });
+  return container;
+}
+
+describe('ArticleCoverStickers', () => {
+  beforeEach(() => {
+    flags.stickerPlacement = true;
+    overlayProps.length = 0;
+    badgeProps.length = 0;
+    providerProps.length = 0;
+    document.body.innerHTML = '';
+  });
+
+  test('draws the stickers and the reveal toggle on a safe cover', () => {
+    const container = render({ safe: true });
+
+    expect(
+      container.querySelector('[data-testid="overlay"]'),
+      'the sticker overlay'
+    ).not.toBeNull();
+    expect(container.querySelector('[data-testid="badge"]'), 'the reveal toggle').not.toBeNull();
+  });
+
+  test("🔴 draws NOTHING on a cover the viewer's browsing level blurred", () => {
+    const container = render({ safe: false });
+
+    expect(
+      container.querySelector('[data-testid="overlay"]'),
+      "a sticker drawn over a blurred cover — someone else's art on content this viewer is not cleared for"
+    ).toBeNull();
+    expect(container.querySelector('[data-testid="badge"]'), 'the reveal toggle').toBeNull();
+  });
+
+  test('🔴 asks for NO placements at all on a blurred cover', () => {
+    render({ safe: false });
+
+    expect(
+      providerProps,
+      'the batch provider mounted behind the gate, so a blurred cover still queries placements'
+    ).toHaveLength(0);
+  });
+
+  test('draws nothing when the sticker placement flag is off', () => {
+    flags.stickerPlacement = false;
+    const container = render({ safe: true });
+
+    expect(container.querySelector('[data-testid="overlay"]'), 'the sticker overlay').toBeNull();
+    expect(container.querySelector('[data-testid="badge"]'), 'the reveal toggle').toBeNull();
+  });
+
+  test('requests cover-sized artwork, not the card default', () => {
+    render({ safe: true });
+
+    // 256 is the card constant and would upscale on a cover, which is visible
+    // only as soft artwork on a retina display — nothing else would report it.
+    expect(overlayProps[0]?.artworkWidth, 'the CDN request width for a cover sticker').toBe(512);
+  });
+
+  test('fetches placements for the cover image alone', () => {
+    render({ safe: true });
+
+    expect(providerProps[0]?.imageIds, 'the ids the batch provider fetches').toEqual([IMAGE_ID]);
+  });
+});

--- a/src/components/Sticker/CardStickerOverlay.tsx
+++ b/src/components/Sticker/CardStickerOverlay.tsx
@@ -73,7 +73,19 @@ export const offsetWithin = (el: HTMLElement, stop: Element | null) => {
  * A consequence worth knowing rather than fixing: `cover` crops, so a sticker
  * placed low on a tall image is outside the visible box and not shown in a feed.
  */
-export function CardStickerOverlay({ imageId }: { imageId: number }) {
+export function CardStickerOverlay({
+  imageId,
+  artworkWidth = CARD_ARTWORK_WIDTH,
+}: {
+  imageId: number;
+  /**
+   * What the CDN is asked for, when the host draws the media wider than a card.
+   * A sticker's drawn size is a fraction of the measured box, so a host with a
+   * bigger box needs a bigger request or it upscales artwork someone was paid
+   * for. `PostStickerOverlay` keeps 512 at 800px wide for the same reason.
+   */
+  artworkWidth?: number;
+}) {
   const currentUser = useCurrentUser();
   const revealed = useStickerRevealStore((state) => state.revealed);
   const batch = useStickerPlacementBatch(imageId);
@@ -138,7 +150,7 @@ export function CardStickerOverlay({ imageId }: { imageId: number }) {
             viewerId={currentUser?.id}
             interactive={false}
             sticker={batch?.sticker}
-            artworkWidth={CARD_ARTWORK_WIDTH}
+            artworkWidth={artworkWidth}
             treatment={batch.treatment}
             surface="card"
           />

--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -46,9 +46,7 @@ import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApp
 import { IconBadge } from '~/components/IconBadge/IconBadge';
 import { ImageContextMenu } from '~/components/Image/ContextMenu/ImageContextMenu';
 import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
-import { CardStickerOverlay } from '~/components/Sticker/CardStickerOverlay';
-import { StickerPlacementBatchProvider } from '~/components/Sticker/StickerPlacementBatchProvider';
-import { StickerPlacementCardBadge } from '~/components/Sticker/StickerPlacementCardBadge';
+import { ArticleCoverStickers } from '~/components/Article/ArticleCoverStickers';
 import { MediaHash } from '~/components/ImageHash/ImageHash';
 import { RoutedDialogLink } from '~/components/Dialog/RoutedDialogLink';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -472,17 +470,22 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
           <ContainerGrid2.Col span={{ base: 12, sm: 8 }}>
             <Stack gap="xs">
               {image && (
-                <StickerPlacementBatchProvider imageIds={[image.id]}>
-                  <AspectRatio
-                    ratio={constants.article.coverImageWidth / constants.article.coverImageHeight}
-                  >
+                <AspectRatio
+                  ratio={constants.article.coverImageWidth / constants.article.coverImageHeight}
+                >
+                  {/*
+                    AspectRatio sizes every direct child, and ImageGuard2 renders
+                    the blur explainer as a sibling of its content — so the guard
+                    goes inside this div rather than around it, or the explainer
+                    becomes a second sized child positioned against the page
+                    instead of the cover. It is also the box the sticker overlay
+                    measures the media against, which needs one shared offset
+                    parent.
+                  */}
+                  <div className="relative size-full">
                     <ImageGuard2 image={image} connectType="article" connectId={article.id}>
                       {(safe) => (
-                        // The overlay measures the cover against this box, so it
-                        // has to be the offset parent of both the media and
-                        // itself — and it sits outside the link, or every
-                        // sticker becomes part of the cover's click target.
-                        <div className="relative size-full">
+                        <>
                           <RoutedDialogLink
                             name="imageDetail"
                             state={{ imageId: image.id, withoutPost: true }}
@@ -514,20 +517,12 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
                               </div>
                             </Center>
                           </RoutedDialogLink>
-                          {safe && features.stickerPlacement && (
-                            <>
-                              <CardStickerOverlay imageId={image.id} />
-                              <StickerPlacementCardBadge
-                                imageId={image.id}
-                                className="absolute bottom-2 right-2 z-10"
-                              />
-                            </>
-                          )}
-                        </div>
+                          <ArticleCoverStickers imageId={image.id} safe={safe} />
+                        </>
                       )}
                     </ImageGuard2>
-                  </AspectRatio>
-                </StickerPlacementBatchProvider>
+                  </div>
+                </AspectRatio>
               )}
 
               {article.contentJson && (

--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -46,6 +46,9 @@ import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApp
 import { IconBadge } from '~/components/IconBadge/IconBadge';
 import { ImageContextMenu } from '~/components/Image/ContextMenu/ImageContextMenu';
 import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
+import { CardStickerOverlay } from '~/components/Sticker/CardStickerOverlay';
+import { StickerPlacementBatchProvider } from '~/components/Sticker/StickerPlacementBatchProvider';
+import { StickerPlacementCardBadge } from '~/components/Sticker/StickerPlacementCardBadge';
 import { MediaHash } from '~/components/ImageHash/ImageHash';
 import { RoutedDialogLink } from '~/components/Dialog/RoutedDialogLink';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -469,47 +472,62 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
           <ContainerGrid2.Col span={{ base: 12, sm: 8 }}>
             <Stack gap="xs">
               {image && (
-                <AspectRatio
-                  ratio={constants.article.coverImageWidth / constants.article.coverImageHeight}
-                >
-                  <RoutedDialogLink
-                    name="imageDetail"
-                    state={{ imageId: image.id, withoutPost: true }}
-                    className="block size-full cursor-pointer"
+                <StickerPlacementBatchProvider imageIds={[image.id]}>
+                  <AspectRatio
+                    ratio={constants.article.coverImageWidth / constants.article.coverImageHeight}
                   >
-                    <Center className="size-full">
-                      <div className="relative size-full">
-                        <ImageGuard2 image={image} connectType="article" connectId={article.id}>
-                          {(safe) => (
-                            <>
-                              <ImageGuard2.BlurToggle className="absolute left-2 top-2 z-10" />
-                              <ImageContextMenu
-                                image={image}
-                                noDelete={true}
-                                className="absolute right-2 top-2 z-10"
-                              />
-                              {!safe ? (
-                                <div className="relative h-full overflow-hidden rounded-lg object-cover">
-                                  <MediaHash {...image} />
-                                </div>
-                              ) : (
-                                <EdgeMedia
-                                  src={image.url}
-                                  className="h-full rounded-lg object-cover"
-                                  name={image.name}
-                                  alt={article.title}
-                                  type={image.type}
-                                  width={MAX_WIDTH}
-                                  anim={safe}
+                    <ImageGuard2 image={image} connectType="article" connectId={article.id}>
+                      {(safe) => (
+                        // The overlay measures the cover against this box, so it
+                        // has to be the offset parent of both the media and
+                        // itself — and it sits outside the link, or every
+                        // sticker becomes part of the cover's click target.
+                        <div className="relative size-full">
+                          <RoutedDialogLink
+                            name="imageDetail"
+                            state={{ imageId: image.id, withoutPost: true }}
+                            className="block size-full cursor-pointer"
+                          >
+                            <Center className="size-full">
+                              <div className="relative size-full">
+                                <ImageGuard2.BlurToggle className="absolute left-2 top-2 z-10" />
+                                <ImageContextMenu
+                                  image={image}
+                                  noDelete={true}
+                                  className="absolute right-2 top-2 z-10"
                                 />
-                              )}
+                                {!safe ? (
+                                  <div className="relative h-full overflow-hidden rounded-lg object-cover">
+                                    <MediaHash {...image} />
+                                  </div>
+                                ) : (
+                                  <EdgeMedia
+                                    src={image.url}
+                                    className="h-full rounded-lg object-cover"
+                                    name={image.name}
+                                    alt={article.title}
+                                    type={image.type}
+                                    width={MAX_WIDTH}
+                                    anim={safe}
+                                  />
+                                )}
+                              </div>
+                            </Center>
+                          </RoutedDialogLink>
+                          {safe && features.stickerPlacement && (
+                            <>
+                              <CardStickerOverlay imageId={image.id} />
+                              <StickerPlacementCardBadge
+                                imageId={image.id}
+                                className="absolute bottom-2 right-2 z-10"
+                              />
                             </>
                           )}
-                        </ImageGuard2>
-                      </div>
-                    </Center>
-                  </RoutedDialogLink>
-                </AspectRatio>
+                        </div>
+                      )}
+                    </ImageGuard2>
+                  </AspectRatio>
+                </StickerPlacementBatchProvider>
               )}
 
               {article.contentJson && (


### PR DESCRIPTION
Closes ClickUp [868ku8zdr](https://app.clickup.com/t/868ku8zdr).

Stickers now render on an article cover, and there is a per-viewer show/hide toggle on the cover.

## Why this is small

An article cover is already a real `Image` row (`Article.coverId`), and `StickerPlacementBar` in `ImageDetail2` is not gated on `postId` — the cover is wrapped in a `RoutedDialogLink` to `imageDetail`, so **placing a sticker on an article cover already worked** through the cover's own image-detail dialog. Justin's "the placement should be just like normal inside of the image detail" was already true.

What was missing was the article page drawing them. No new placement target, no schema, no migration, no new placement system — the existing surface, mounted at a new host.

## What changed

- `src/components/Article/ArticleCoverStickers.tsx` (new) — the gate, the batch provider, the overlay and the toggle
- `src/pages/articles/[id]/[[...slug]].tsx` — mounts it, and the cover JSX restructure below
- `src/components/Sticker/CardStickerOverlay.tsx` — an optional `artworkWidth` prop, defaulting to the existing card constant

### Three structural choices worth the reviewer's time

**`CardStickerOverlay`, not `ImageStickerOverlay`.** Cover media is `object-cover` inside a fixed `AspectRatio` — the feed-card case, not the letterboxed detail view. `CardStickerOverlay` measures the drawn box off the media element. `ImageStickerOverlay` assumes it *is* the coordinate system, and would also fetch its own placements and register a drag surface, which would have made the batch provider pointless and put a placing surface on a cropped hero.

**The positioned wrapper is `AspectRatio`'s direct child, with `ImageGuard2` inside it.** Both halves are load-bearing. Mantine's `AspectRatio` sizes *every* direct child (`> :where(*:not(style))`), and `ImageGuard2` renders the blur explainer as a sibling of its content — so a guard placed directly under `AspectRatio` leaves the "Show" button, the only control that reveals a blurred cover, resolving its `absolute` position against an ancestor far up the page. The wrapper is also the shared offset parent `CardStickerOverlay` walks to when measuring the media.

**Note what the wrapper is *not*.** It is not what makes a sticker click safe. `CardStickerOverlay` is `pointer-events-none` and passes `interactive={false}`, so stickers on a cover take no pointer events and a click falls through to the cover link. Verified on a running page: `elementFromPoint` at a sticker's centre returns the cover image. A structure defended by a wrong reason is worse than one with no comment, so this is stated rather than implied.

## The toggle is per viewer

Justin's call. It reuses `useStickerRevealStore` and inherits that store's existing answers:

- **Touches nothing in the placement lifecycle.** A hidden sticker is still placed, still paid for, still accepted.
- **Site-wide, `localStorage`, default off** — per-device rather than per-account, and flipping it on a cover flips stickers everywhere. Existing behaviour on every other surface; flagged, not changed here.
- **Renders nothing when the cover has no stickers**, same as a feed card. The feature is therefore invisible on an article whose cover has none — worth knowing before judging it by opening a random article.

## Known and accepted

- **A sticker placed low on a tall cover is cropped out.** Existing feed-card behaviour, newly visible here. Justin explicitly accepted it; not mitigated.
- **Stickers are not interactive on covers**, so the hover card in [868ku94bb](https://app.clickup.com/t/868ku94bb) reaches the image detail and not a cover. Justin chose this shape now, interactivity as a possible follow-up.
- **Ships dark.** Gated on `features.stickerPlacement`, which is mod-only.

## Testing

`src/components/Article/__tests__/ArticleCoverStickers.test.ts` — six cases in the **`unit` project, the one CI runs**. Every sticker component's own test is a `*.browser.test.tsx` in the `component` project, which no workflow invokes.

The gate is the subject: `safe` is a boolean no type checks, and deleting it from the condition still compiles, still renders, and draws a placed sticker over a cover the viewer's browsing level blurred. **All three decisions were mutation-checked** — dropping `safe`, dropping the flag, and dropping the cover artwork width each go red in about a second with a message naming the actual risk.

The test states what it cannot see: happy-dom computes no layout, so the overlay's measurement, its offset parent, and the pointer-events behaviour are invisible there. Those were verified in a browser against a real cover with a real placement, and stay that way.

Screenshots and the hit-test numbers are linked in a comment below, since GitHub takes image uploads only through its UI.

## Review

Five lanes ran (reuse, correctness, perf, tests, intent); all five reported. The perf lane re-measured after the fixes and withdrew two of its own findings, so its numbers describe the tree as it stands rather than the one it started on.

**Fixed from review, in the second commit:**

1. **The blur explainer regression above** — introduced by the first commit, found by review. The gate holds either way (no unsafe pixels reach the page), but the reveal control lands off the cover, and it only reproduces at a browsing level that actually blurs the cover.
2. **The batch provider mounted outside the guard**, so a blurred cover still issued both placement queries. Now behind the gate.
3. **`CARD_ARTWORK_WIDTH = 256` on a 1320px cover** — a cover draws a default-sized sticker near 330 CSS px, 660 device px on DPR-2, so it was upscaling artwork a creator was paid for. `PostStickerOverlay` keeps 512 at 800px wide for the same reason.

**Declined, with reasons:**

- **`ssg.placement.getStickerPlacementCounts.prefetch(...)`** in the existing prefetch block, offered as trading a client round trip for a measured 0.044 ms index-only scan. **A measured-cheap query is not a cheap change when the gates do not travel with it**: the client query is gated on the flag *and* on `safe`, an SSR prefetch has neither, so today it would add ~39,500 server queries/day to the TTFB path of an SEO cold-entry page to replace roughly zero client requests — and SSR cannot know `safe`, so it would prefetch for blurred covers and reintroduce what fix 2 just removed. Worth revisiting when the flag ramps; the decline is about today's gate state.
- **`surface="card"` treatment geometry**, tuned for a ~112px card sticker and now drawing one ~3x larger. Real, but changing it is a visual judgement and no defect was visible on a real cover.
- **`CardStickerOverlay` finds its media by document order**, and this host puts the blur toggle and context menu ahead of it in the subtree. Neither renders an `img`/`video` today, so it works; recording the fragility rather than restructuring around it.

**Carried to [868ku94bb](https://app.clickup.com/t/868ku94bb), not fixed here:** `StickerPlacementOverlay` statically imports `StickerPlacementHoverCard`, pulling ~75 KB of raw source this page can never render (`interactive={false}`). The flag gates the queries, not the bytes, so every article visitor downloads and parses it today while the feature is mod-only. `dynamic()` there wins on the feed and post detail too, which is why it belongs to that ticket.

**Pre-existing, for the product rather than this PR:** an article cover belonging to no post is reachable by neither `PlacementSpaceToggle` mount, so an author's only lever over stickers on their cover is the account-wide setting. And article *cards* in feeds show the same cover with no stickers, so "article covers" ships as the article page only.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — clean on all four changed files, checked directly on the paths (the repo-wide run exits 1 on ~1441 pre-existing files, so the aggregate says nothing)
- `pnpm run prettier:write` — changed files only
- `pnpm run test:unit:run` — 4 files / 6 tests fail, and **the same 4 files and 6 tests fail on pristine `origin/main` in this same worktree**: `model-file-scan.service` (the known red), `standalone-boot-graph`, `rating-label`, `appListingStatChips`. File count moved 1209 → 1210 and tests 19066 → 19072, which is exactly the six added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
