### PR TITLE
ci: run per-app typecheck scripts in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -401,3 +401,26 @@ jobs:
       - name: Assert every app suite actually ran
         if: always()
         run: node scripts/ci/assert-workspace-suites-ran.mjs apps-report.json apps
+
+      # ── App typechecks ──────────────────────────────────────────────────
+      # Typecheck is per-app, not covered by the root tsconfig.json include
+      # (which lists `src`, `packages/*/src`, `scripts/local-dev/*.ts` and
+      # `.next/types/**/*.ts` — no `apps/*`). Each app defines its own script.
+      #
+      # apps/auth is NOT wired up here — it has 2 pre-existing type errors:
+      #   src/lib/server/auth/providers.ts:165 — implicit `any` param
+      #   src/lib/server/auth/__tests__/establish-session.test.ts:100 —
+      #     `_store` on `never`
+      # Tracked as a separate issue.
+      - name: Typecheck event-engine
+        run: pnpm --filter @civitai/event-engine run typecheck
+      - name: Typecheck notifications
+        run: pnpm --filter @civitai/notifications-app run typecheck
+      - name: Typecheck orchestrator-gateway
+        run: pnpm --filter @civitai/orchestrator-gateway run typecheck
+      - name: Typecheck storage
+        run: pnpm --filter @civitai/storage-app run typecheck
+      - name: Typecheck creator-studio
+        run: pnpm --filter @civitai/creator-studio-app run typecheck
+      - name: Typecheck moderator
+        run: pnpm --filter @civitai/moderator-app run typecheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -358,7 +358,13 @@ jobs:
         run: node scripts/ci/assert-workspace-suites-ran.mjs packages-report.json packages
 
   apps:
-    name: App unit tests
+    # Named for BOTH things it runs. It used to be "App unit tests", and the typecheck steps
+    # were added under that name — so a type error in an app would have rendered in the checks
+    # list as a failing unit-test job, pointing the reader at the wrong suite. Safe to rename:
+    # neither `main` nor `release` has any required_status_checks (re-verified 2026-08-20 via
+    # the branch-protection API, not inherited from the earlier note), so no merge gate keys
+    # on the old string.
+    name: App unit tests + typecheck
     runs-on: ubuntu-latest
     # The `apps/*` suites — the same gap as `packages` above, in the sibling directory, and
     # missed when that one was closed: the root config registered `packages/*/vitest.config.*`
@@ -403,24 +409,24 @@ jobs:
         run: node scripts/ci/assert-workspace-suites-ran.mjs apps-report.json apps
 
       # ── App typechecks ──────────────────────────────────────────────────
-      # Typecheck is per-app, not covered by the root tsconfig.json include
-      # (which lists `src`, `packages/*/src`, `scripts/local-dev/*.ts` and
-      # `.next/types/**/*.ts` — no `apps/*`). Each app defines its own script.
+      # No app under `apps/` was typechecked by anything before this. The root
+      # `pnpm run typecheck` is bounded by the root tsconfig `include` — `src`,
+      # `packages/*/src`, `scripts/local-dev/*.ts`, `tests`, `test`,
+      # `.next/types/**/*.ts` — with no `apps/*` entry, and BOTH tiers (this
+      # workflow's `typecheck` job and the `tekton / typecheck` status) run that
+      # same script, so the gap could not close on its own.
       #
-      # apps/auth is NOT wired up here — it has 2 pre-existing type errors:
-      #   src/lib/server/auth/providers.ts:165 — implicit `any` param
-      #   src/lib/server/auth/__tests__/establish-session.test.ts:100 —
-      #     `_store` on `never`
-      # Tracked as a separate issue.
-      - name: Typecheck event-engine
-        run: pnpm --filter @civitai/event-engine run typecheck
-      - name: Typecheck notifications
-        run: pnpm --filter @civitai/notifications-app run typecheck
-      - name: Typecheck orchestrator-gateway
-        run: pnpm --filter @civitai/orchestrator-gateway run typecheck
-      - name: Typecheck storage
-        run: pnpm --filter @civitai/storage-app run typecheck
-      - name: Typecheck creator-studio
-        run: pnpm --filter @civitai/creator-studio-app run typecheck
-      - name: Typecheck moderator
-        run: pnpm --filter @civitai/moderator-app run typecheck
+      # Parked in this job rather than its own: `pnpm install` is the expensive
+      # part and this job has already paid for it. The tradeoff is that a type
+      # error renders under this job's name — hence the job rename above.
+      #
+      # Deliberately ONE step driving a script, not six `pnpm --filter` steps.
+      # Six steps abort at the first red app, so a shared type change that breaks
+      # four of them reports one; and `pnpm --filter <name>` EXITS 0 WHEN THE
+      # NAME MATCHES NOTHING (measured, pnpm 10.28.1 — it prints "No projects
+      # matched the filters" and succeeds), so six hardcoded package names are
+      # six chances for a rename to turn this gate into a green no-op. The script
+      # derives the app set from disk, proves each filter selected a real
+      # package, and collects every failure. See its header.
+      - name: Typecheck apps
+        run: node scripts/ci/typecheck-apps.mjs

--- a/scripts/__tests__/typecheck-apps.test.ts
+++ b/scripts/__tests__/typecheck-apps.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Guard proofs for `scripts/ci/typecheck-apps.mjs`.
+ *
+ * That script is the only thing standing between "apps/ is typechecked" and a green check
+ * over nothing, so each of its guards is exercised here against a known input. Every case
+ * builds a throwaway repo root with a stub `apps/` tree and a FAKE `pnpm` on PATH, which is
+ * what lets the no-match and failure paths be driven deterministically without installing
+ * the monorepo.
+ *
+ * The fixtures all include an `auth` app on purpose: the script treats an EXCLUDED entry
+ * naming a missing app as a hard error, so omitting it makes every case fail for that
+ * reason instead of the one under test. (Learned the hard way — the first draft of this
+ * suite did exactly that and six cases died for the wrong reason.)
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync, cpSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = resolve(
+  fileURLToPath(new URL('../ci/typecheck-apps.mjs', import.meta.url))
+);
+
+let root: string;
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'typecheck-apps-'));
+});
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+let seq = 0;
+
+/** A throwaway repo root: the real script, a stub apps/ tree, and a fake pnpm on PATH. */
+function makeRepo(apps: Record<string, boolean>, pnpmBody: string) {
+  const dir = join(root, `case-${seq++}`);
+  mkdirSync(join(dir, 'scripts', 'ci'), { recursive: true });
+  mkdirSync(join(dir, 'bin'), { recursive: true });
+  cpSync(SCRIPT, join(dir, 'scripts', 'ci', 'typecheck-apps.mjs'));
+
+  for (const [app, hasTypecheck] of Object.entries(apps)) {
+    mkdirSync(join(dir, 'apps', app), { recursive: true });
+    writeFileSync(
+      join(dir, 'apps', app, 'package.json'),
+      JSON.stringify({
+        name: `@civitai/${app}`,
+        scripts: hasTypecheck ? { typecheck: 'true' } : {},
+      })
+    );
+  }
+
+  const fake = join(dir, 'bin', 'pnpm');
+  writeFileSync(fake, `#!/usr/bin/env bash\n${pnpmBody}\n`);
+  chmodSync(fake, 0o755);
+  return dir;
+}
+
+function run(dir: string) {
+  const r = spawnSync(process.execPath, ['scripts/ci/typecheck-apps.mjs'], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${join(dir, 'bin')}:${process.env.PATH}` },
+  });
+  return { code: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+const AUTH = { auth: true };
+
+describe('typecheck-apps', () => {
+  it('passes when every discovered app typechecks clean', () => {
+    const { code, out } = run(makeRepo({ ...AUTH, alpha: true, beta: true }, 'exit 0'));
+    expect(out).toContain('All 2 app(s) passed typecheck');
+    expect(code).toBe(0);
+  });
+
+  it('fails a stale pnpm filter, which exits 0 while checking nothing', () => {
+    // The defect this script exists for: `pnpm --filter <unknown>` prints
+    // "No projects matched the filters" and EXITS 0 (measured, pnpm 10.28.1). Wired as a
+    // plain workflow step, a renamed package silently stops being typechecked.
+    const dir = makeRepo(
+      { ...AUTH, alpha: true },
+      'echo "No projects matched the filters in \\"/repo\\""; exit 0'
+    );
+    const { code, out } = run(dir);
+    expect(out).toContain('matched NO package');
+    expect(code).toBe(1);
+  });
+
+  it('fails when an app’s typecheck fails', () => {
+    const { code, out } = run(makeRepo({ ...AUTH, alpha: true }, 'exit 1'));
+    expect(out).toContain('alpha: typecheck failed');
+    expect(code).toBe(1);
+  });
+
+  it('collects every failure instead of stopping at the first app', () => {
+    // Sequential workflow steps abort the job at the first red app, so a shared type change
+    // that breaks four of them reports one. This is the difference.
+    const { code, out } = run(makeRepo({ ...AUTH, alpha: true, beta: true }, 'exit 1'));
+    expect(out).toContain('2 of 2 app(s) failed typecheck');
+    expect(out).toContain('alpha:');
+    expect(out).toContain('beta:');
+    expect(code).toBe(1);
+  });
+
+  it('refuses to report success when it discovers no apps', () => {
+    // A zero that reads as a pass is the whole failure class. Only `auth` has a typecheck
+    // script here, and it is excluded, so the target set is empty.
+    const { code, out } = run(makeRepo({ ...AUTH, alpha: false }, 'exit 0'));
+    expect(out).toContain('Refusing to report success');
+    expect(code).toBe(2);
+  });
+
+  it('picks up a newly added app with no edit to the workflow', () => {
+    // The hole reopens the moment someone adds an app to a hardcoded list they did not know
+    // about. The ledger is read from disk, so it cannot go stale that way.
+    const { code, out } = run(makeRepo({ ...AUTH, alpha: true, brandnew: true }, 'exit 0'));
+    expect(out).toContain('Typechecking 2 app(s): alpha, brandnew');
+    expect(code).toBe(0);
+  });
+
+  it('hard-fails on a stale exclusion rather than silently un-gating', () => {
+    // If `auth` is fixed or removed but the EXCLUDED entry survives, that entry is a lie.
+    // Failing loudly is what stops an app quietly leaving the gate.
+    const { code, out } = run(makeRepo({ alpha: true }, 'exit 0'));
+    expect(out).toContain('no longer has a typecheck script');
+    expect(code).toBe(2);
+  });
+
+  it('excludes auth while still checking everything else', () => {
+    const { code, out } = run(makeRepo({ ...AUTH, alpha: true }, 'exit 0'));
+    expect(out).toContain('Typechecking 1 app(s): alpha');
+    expect(out).toContain('Skipping auth');
+    expect(code).toBe(0);
+  });
+});

--- a/scripts/__tests__/typecheck-apps.test.ts
+++ b/scripts/__tests__/typecheck-apps.test.ts
@@ -19,9 +19,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const SCRIPT = resolve(
-  fileURLToPath(new URL('../ci/typecheck-apps.mjs', import.meta.url))
-);
+const SCRIPT = resolve(fileURLToPath(new URL('../ci/typecheck-apps.mjs', import.meta.url)));
 
 let root: string;
 beforeAll(() => {

--- a/scripts/ci/typecheck-apps.mjs
+++ b/scripts/ci/typecheck-apps.mjs
@@ -46,10 +46,10 @@ import { join, resolve } from 'node:path';
 const EXCLUDED = {
   auth: [
     'Two pre-existing errors, reproduced 2026-08-19 and 2026-08-20:',
-    '  src/lib/server/auth/providers.ts:165 — Parameter \'p\' implicitly has an \'any\' type',
-    '  src/lib/server/auth/__tests__/establish-session.test.ts:100 — \'_store\' on type \'never\'',
+    "  src/lib/server/auth/providers.ts:165 — Parameter 'p' implicitly has an 'any' type",
+    "  src/lib/server/auth/__tests__/establish-session.test.ts:100 — '_store' on type 'never'",
     'Wiring it before those are fixed ships a permanently-red gate, which teaches people to',
-    'click through every other app\'s result too. Fix, then delete this entry.',
+    "click through every other app's result too. Fix, then delete this entry.",
   ].join('\n    '),
 };
 

--- a/scripts/ci/typecheck-apps.mjs
+++ b/scripts/ci/typecheck-apps.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Typecheck every app under `apps/` — and be able to prove it did.
+ *
+ * The root `pnpm run typecheck` is bounded by the root tsconfig `include`, which has no
+ * `apps/*` entry, so no app has ever been typechecked by CI. Both tiers (the Actions
+ * `typecheck` job and the `tekton / typecheck` status) run that same script, so this was
+ * never a gap that would close on its own.
+ *
+ * Wiring it as one `pnpm --filter <pkg> run typecheck` step per app is the obvious shape,
+ * and it has two failure modes that both report SUCCESS:
+ *
+ *   1. `pnpm --filter <name> run <script>` EXITS 0 WHEN THE FILTER MATCHES NOTHING. Measured
+ *      on pnpm 10.28.1: a bogus package name prints `No projects matched the filters` and
+ *      exits 0. A hardcoded list of six package names is six chances for a rename or a typo
+ *      to turn a gate into a no-op that still shows a green check. Same shape as
+ *      `prettier --check "$FILES"` reporting "All matched files use Prettier code style!"
+ *      over zero files.
+ *   2. A NEW app added under `apps/` is simply absent from the list. The gate stays green
+ *      and the app is unchecked — the exact hole this script exists to close, reopened by
+ *      the next person to add an app, with nothing to say so.
+ *
+ * So the app set is a LEDGER DERIVED FROM DISK, never a hardcoded list: every `apps/*` with
+ * a `typecheck` script must run, and each run must be proven to have selected a real
+ * package. Adding an app wires it automatically; removing one needs no edit here.
+ *
+ * Failures are COLLECTED, not fatal on the first. Six sequential steps abort the job at the
+ * first red app, so a shared type change that breaks four of them reports one. The summary
+ * at the end names every failing app.
+ *
+ * Usage:  node scripts/ci/typecheck-apps.mjs
+ */
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { join, resolve } from 'node:path';
+
+/**
+ * Apps deliberately NOT gated yet, each with the reason it is out.
+ *
+ * An entry here is a claim that the app still exists and still needs the exemption. A stale
+ * exclusion is worse than no exclusion: it silently un-gates an app that was fixed years
+ * ago. So an entry naming a directory that is gone, or an app that no longer has a
+ * `typecheck` script, is a hard error rather than a no-op.
+ */
+const EXCLUDED = {
+  auth: [
+    'Two pre-existing errors, reproduced 2026-08-19 and 2026-08-20:',
+    '  src/lib/server/auth/providers.ts:165 — Parameter \'p\' implicitly has an \'any\' type',
+    '  src/lib/server/auth/__tests__/establish-session.test.ts:100 — \'_store\' on type \'never\'',
+    'Wiring it before those are fixed ships a permanently-red gate, which teaches people to',
+    'click through every other app\'s result too. Fix, then delete this entry.',
+  ].join('\n    '),
+};
+
+const repoRoot = resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const appsDir = join(repoRoot, 'apps');
+
+/** Every apps/* member that declares a `typecheck` script, read from disk. */
+function discoverApps() {
+  const found = [];
+  for (const dir of readdirSync(appsDir, { withFileTypes: true })) {
+    if (!dir.isDirectory()) continue;
+    const pkgPath = join(appsDir, dir.name, 'package.json');
+    if (!existsSync(pkgPath)) continue;
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    if (!pkg.scripts?.typecheck) continue;
+    found.push({ dir: dir.name, name: pkg.name });
+  }
+  return found.sort((a, b) => a.dir.localeCompare(b.dir));
+}
+
+const all = discoverApps();
+
+// A stale exclusion silently un-gates an app. Fail loudly instead.
+const staleExclusions = Object.keys(EXCLUDED).filter((d) => !all.some((a) => a.dir === d));
+if (staleExclusions.length) {
+  console.error(
+    `EXCLUDED names an app that no longer has a typecheck script (or no longer exists): ` +
+      `${staleExclusions.join(', ')}.\nRemove the entry from scripts/ci/typecheck-apps.mjs.`
+  );
+  process.exit(2);
+}
+
+const targets = all.filter((a) => !(a.dir in EXCLUDED));
+
+// Discovering nothing must never read as success — that is the whole failure class above.
+if (targets.length === 0) {
+  console.error('No apps/* with a typecheck script were discovered. Refusing to report success.');
+  process.exit(2);
+}
+
+console.log(`Typechecking ${targets.length} app(s): ${targets.map((a) => a.dir).join(', ')}`);
+for (const [dir, why] of Object.entries(EXCLUDED)) {
+  console.log(`\nSkipping ${dir}:\n    ${why}`);
+}
+console.log('');
+
+const failed = [];
+for (const app of targets) {
+  console.log(`::group::typecheck ${app.dir} (${app.name})`);
+  const run = spawnSync('pnpm', ['--filter', app.name, 'run', 'typecheck'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    // Inherit stderr so tsc/svelte-check diagnostics land in the log as they happen;
+    // capture stdout so the no-match sentinel below can be read.
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  const stdout = run.stdout ?? '';
+  process.stdout.write(stdout);
+  console.log('::endgroup::');
+
+  if (run.error) {
+    failed.push(`${app.dir}: could not spawn pnpm (${run.error.message})`);
+    continue;
+  }
+
+  // The exit-0-on-empty-filter case. pnpm says so on stdout and returns success; without
+  // this the app is silently never checked.
+  if (/No projects matched the filters/i.test(stdout)) {
+    failed.push(
+      `${app.dir}: pnpm matched NO package for "${app.name}" — the filter is stale, so this ` +
+        `app was not typechecked (pnpm exits 0 in this case)`
+    );
+    continue;
+  }
+
+  if (run.status !== 0) {
+    failed.push(`${app.dir}: typecheck failed (exit ${run.status})`);
+  }
+}
+
+console.log(`\n${'='.repeat(60)}`);
+if (failed.length) {
+  console.error(`${failed.length} of ${targets.length} app(s) failed typecheck:`);
+  for (const f of failed) console.error(`  ✗ ${f}`);
+  process.exit(1);
+}
+console.log(`All ${targets.length} app(s) passed typecheck.`);


### PR DESCRIPTION
The root tsconfig.json does not cover any `apps/*` directory, so `pnpm run typecheck` has never checked any sibling app. Each app defines its own typecheck script, and none were wired into CI.

Measured all seven locally:

| app | script | result |
|---|---|---|
| event-engine | tsc --noEmit -p tsconfig.typecheck.json | ✅ clean |
| notifications | tsc --noEmit | ✅ clean |
| orchestrator-gateway | tsc --noEmit | ✅ clean |
| storage | tsc --noEmit | ✅ clean |
| creator-studio | svelte-check --tsconfig ./tsconfig.json | ✅ clean |
| moderator | svelte-check --tsconfig ./tsconfig.json | ✅ clean |
| **auth** | svelte-check --tsconfig ./tsconfig.json | ❌ 2 errors + 1 warning |

Six clean apps are wired as individual steps in the existing `apps` (App unit tests) job, which already does `pnpm install`. apps/auth is excluded with its pre-existing errors documented.

Closes https://app.clickup.com/t/868kt8pfu