### PR TITLE
revert(notifications): removedBy is the MODE, so the old predicate was right

### DIFF
--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -140,20 +140,7 @@ describe('the remix type stops announcing declines', () => {
     expect(statusesSelectedBy(sql)).toBe('approved,removed');
     // The removal half is scoped to the owner's own action: a moderator takedown
     // is not something to announce to the person it was taken from.
-    //
-    // Keyed on the ACTOR rather than on `removedBy`. The two said the same
-    // thing until a moderator could act as one on their own gallery — that
-    // removal writes `removedBy = 'moderator'` and dropped out of this branch,
-    // so the submitter stopped being told about a removal by the creator.
-    expect(sql).toContain('p."takenDownById" = p."ownerId"');
-    // The role filter is GONE, deliberately, and this assertion is what says so.
-    // `removePlacementByModerator` and `removePlacementsByUser` are not
-    // surface-scoped, so a moderator removing from their OWN remix gallery
-    // through either writes `removedBy: 'moderator'` with `takenDownById =
-    // ownerId` — the one combination the old and new predicates disagree about.
-    // It now notifies, which is the intended reading of "the actor was the
-    // owner" rather than a side effect of the swap.
-    expect(sql).not.toContain('p."removedBy" = \'owner\'');
+    expect(sql).toContain('p."removedBy" = \'owner\'');
     // Same two mutations the sticker type is guarded against, and they survive
     // every assertion above on this one too.
     expect(sql).toMatch(/p\."placerId"\s+"userId"/);

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -318,15 +318,18 @@ export const placementNotifications = createNotificationProcessor({
             )
             OR (
               p.status = 'removed'
-              -- The ACTOR, not the role they acted in. Keying on removedBy
-              -- said the same thing until a moderator could act as one on
-              -- their own gallery: that removal is written as a moderator
-              -- action, so it dropped out of this branch and the submitter
-              -- stopped being told about a removal by the creator themselves.
+              -- removedBy is the MODE the remover acted in, not their role:
+              -- 'owner' for a creator and for a moderator in manage-as-creator
+              -- mode, 'moderator' for moderate mode or someone else's gallery.
+              -- So this reads "not acting as a moderator", which is the rule.
               --
-              -- A genuine third-party takedown stays silent, which is the same
-              -- set this branch always excluded.
-              AND p."takenDownById" = p."ownerId"
+              -- Read as a role it looks wrong once a moderator can act as one on
+              -- their own gallery, and keying on the actor instead
+              -- (takenDownById = ownerId) looks like the fix. It is not: that
+              -- announces a moderator-mode removal as a creator's, and does the
+              -- same to every moderation-tool removal on the actor's own
+              -- gallery. Tried in #4148 and reverted.
+              AND p."removedBy" = 'owner'
               AND p."takenDownAt" IS NOT NULL
               AND p."takenDownAt" > '${lastSent}'
             )


### PR DESCRIPTION
Follow-up to #4148, which merged a few minutes before this correction could
land on its branch. One-line revert plus a comment.

## What #4148 got wrong

It changed the remix removal-notice predicate:

```sql
- AND p."removedBy" = 'owner'
+ AND p."takenDownById" = p."ownerId"
```

on the reading that `removedBy` names the actor's **role**, and so stopped
identifying a creator's own removal once a moderator could act as one on their
own gallery.

**It names the MODE, not the role.**

| what happened | `removedBy` |
|---|---|
| Creator removes from own gallery | `owner` |
| Moderator on own gallery, **Manage as creator** | `owner` |
| Moderator on own gallery, **Moderate** | `moderator` |
| Moderator on another creator's gallery | `moderator` |

So `removedBy = 'owner'` already meant *"not acting as a moderator"*, which is
the rule we want: a removal made in moderator mode is not announced to the
person it was taken from; one made as the creator is.

## What the wrong version did

- Announced a **moderator-mode** removal as a creator's.
- Did the same to every moderation-tool removal on the actor's own gallery —
  `removePlacementByModerator` and `removePlacementsByUser` are not
  surface-scoped and write `takenDownById` = the actor, so a moderator using
  either on their own remix gallery produced `takenDownById = ownerId` and
  started notifying.

Neither is catastrophic — it over-notifies rather than under-notifies — but it
is the opposite of the intended rule in both cases.

## Why the wrong reading was tempting

A five-lane review raised the original predicate as a regression, I verified the
mechanism and agreed, and we were both wrong in the same way: we confirmed that
the *meaning of the value* had shifted without checking what the value was
*for*. The mode is also always deliberate — the toggle mounts at
**Manage as creator** on every modal open, so nobody arrives in Moderate mode
without choosing it that session, which is what makes the rule safe.

That reasoning is plausible enough that someone will retrace it, so it is now
written beside the predicate rather than living only in a commit message.

## The check that would have caught it

Not more testing. The change was mutation-checked in both directions, its test
went red on revert, and typecheck and the full unit suite were green. **Every one
of those confirms the code does what its author intended. None of them can ask
whether the intent was right.**

The trigger to look for is upstream of any of that: **this was a behaviour change
none of the three tickets asked for, made on the strength of a review finding
rather than a product rule.** That is the point at which to go and get the rule,
before implementing — not after, where the answer arrives as a revert instead of
a decision.

The one-sentence version of the specific miss: we confirmed that the *meaning of
the value had shifted* without checking what the value was *for*.

## Verification

`prettier` clean · the notification suite passes (12/12) with the assertion that
pins this predicate restored to its original form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

