### PR TITLE
feat(apps): open an app-store screenshot full size — prev/next, arrow keys, Esc

### DIFF
--- a/src/components/Apps/AppListingDetailBody.gallery.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.gallery.browser.test.tsx
@@ -131,7 +131,7 @@ beforeEach(async () => {
 
 /**
  * A screenshot URL that RESOLVES — an inline 320x180 SVG. It has to be a real,
- * loadable image: `ScreenshotTile` removes itself from the DOM on an `error` event, so
+ * loadable image: a tile is removed from the DOM on an `error` event, so
  * a tile built from an unreachable URL is not a tile whose width can be measured. The
  * 16:9 box keeps the rendered rows a sane height; only widths are asserted.
  */
@@ -139,7 +139,7 @@ const OK_SHOT = `data:image/svg+xml;base64,${btoa(
   '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"/>'
 )}`;
 
-/** A URL that cannot resolve, so the browser fires `error` and the tile hides itself. */
+/** A URL that cannot resolve, so the browser fires `error` and the tile is dropped. */
 const BROKEN_SHOT = (n: number) => `https://cdn.invalid.example/missing-${n}.png`;
 
 function base(over: Partial<ListingDetail>): ListingDetail {
@@ -354,7 +354,7 @@ describe('screenshot gallery — rendered tile width', () => {
    * 🔴 THE COUNT-MISMATCH CASE — the reason the fix is a CSS structural selector and
    * not a `cols` value computed from `screenshots.length`.
    *
-   * Three screenshots go in; two of them 404, so `ScreenshotTile` removes them and the
+   * Three screenshots go in; two of them 404, so the gallery drops them and the
    * browser ends up with ONE tile. Any number derived before render would still say
    * "3" here and would leave that survivor at half width. `:last-child:nth-child(odd)`
    * is matched against the LIVE DOM, so the remaining tile is re-matched for free.
@@ -425,7 +425,7 @@ describe('screenshot gallery — rendered tile width', () => {
 
     // POSITIVE CONTROL, and not a racy one — see the sibling test above. Indexes 1 and
     // 3 with nothing between them is a string pair only a three-element map can
-    // produce, so the middle tile demonstrably rendered and then removed itself.
+    // produce, so the middle tile demonstrably rendered and was then dropped.
     expect(Array.from(grid.querySelectorAll('img')).map((img) => img.getAttribute('alt'))).toEqual([
       'My App screenshot 1',
       'My App screenshot 3',

--- a/src/components/Apps/AppListingDetailBody.module.scss
+++ b/src/components/Apps/AppListingDetailBody.module.scss
@@ -13,7 +13,7 @@
  * NOT `screenshots.length` and is not known at render time — a `cols` value
  * computed from the array would be wrong for exactly the listings whose art is
  * broken. `:last-child` / `:nth-child` are matched against the LIVE DOM, so when a
- * tile removes itself the remaining ones are re-matched for free: 3 shots of which
+ * tile is dropped the remaining ones are re-matched for free: 3 shots of which
  * the middle one 404s leaves two tiles that correctly stay half-width, and 3 of
  * which two 404 leaves one tile that correctly goes full-width. Pinned as measured
  * geometry in `AppListingDetailBody.gallery.browser.test.tsx`.

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -396,12 +396,20 @@ function CreatorChip({ creator }: { creator: ListingDetail['creator'] }) {
  *
  * 🔴 IT IS A REAL `<button>` (`UnstyledButton`), NOT an `<img onClick>`. The tile has
  * to be tab-reachable and Enter/Space-activatable, and the accessible name has to
- * come from somewhere: it is COMPUTED FROM THE CONTENT (the image `alt` plus the
- * caption text) rather than pinned with an `aria-label`, so the name always contains
- * the caption the viewer can see — a bare `aria-label="View screenshot"` would strip
- * it and break WCAG 2.5.3 label-in-name. The button sits INSIDE the `Card` rather
- * than replacing it so the grid's children stay one element per tile, which is what
- * the gallery's fill rule (`:last-child:nth-child(odd)`) matches on.
+ * come from somewhere: it is COMPUTED FROM THE CONTENT rather than pinned with an
+ * `aria-label`, so the name always contains the caption the viewer can see — a bare
+ * `aria-label="View screenshot"` would strip it and break WCAG 2.5.3 label-in-name.
+ * The button sits INSIDE the `Card` rather than replacing it so the grid's children
+ * stay one element per tile, which is what the gallery's fill rule
+ * (`:last-child:nth-child(odd)`) matches on.
+ *
+ * 🔴 …AND THE IMAGE IS `alt=""` WHEN THERE IS A CAPTION, because the caption is
+ * rendered as TEXT inside the same button. Both contribute to the computed name, so
+ * naming the image with the caption too made the control announce "Shot three Shot
+ * three" — measured, and the reason `getByRole('button', { name: 'Shot three' })`
+ * matched nothing at all. An `alt=""` image beside its own visible caption is the
+ * standard pairing. The descriptive fallback stays for a captionless shot, where
+ * nothing else names the tile.
  */
 function ScreenshotTile({
   shot,
@@ -434,7 +442,7 @@ function ScreenshotTile({
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={shot.url}
-          alt={shot.caption ? shot.caption : `${name} screenshot ${index + 1}`}
+          alt={shot.caption ? '' : `${name} screenshot ${index + 1}`}
           loading="lazy"
           onError={onBroken}
           style={{ width: '100%', height: 'auto', display: 'block' }}
@@ -479,9 +487,11 @@ function ScreenshotTile({
  * LAST child and at an ODD position spans `1 / -1` — so the gallery uses the width
  * it actually has. See the stylesheet's header for why it is written as a
  * structural CSS selector rather than a count-aware `cols` value: `ScreenshotTile`
- * hides ITSELF on a load error, so the rendered tile count is discovered after
- * render and any number computed from `shots.length` here would be wrong for
- * exactly the listings with broken art.
+ * is DROPPED on a load error — it reports upward and the gallery filters it out —
+ * so the rendered tile count is discovered after render and any number computed
+ * from `shots.length` here would be wrong for exactly the listings with broken art.
+ * (It used to hide ITSELF, from its own `useState`; the DOM result is identical,
+ * but the decision moved to the gallery so the viewer skips the same shots.)
  *
  * 🔴 Do not "simplify" this to `cols={shots.length === 1 ? 1 : 2}`. That reads as
  * the same fix and is not: it fires on the ARRAY, so a 2-shot listing whose first
@@ -511,6 +521,29 @@ function ScreenshotGallery({
     (index: number) => setBroken((prev) => withBrokenIndex(prev, index)),
     []
   );
+
+  // 🔴 BOTH PIECES OF STATE ARE POSITIONS IN `shots`, SO A DIFFERENT `shots` MAKES
+  // THEM LIES. If the array changes under a mounted gallery — a `getAppDetail`
+  // invalidate, or the review preview swapping its local
+  // `buildListingDetailPreview(request)` for `previewQuery.data.detail`
+  // (`OffsiteReviewQueue`) — then "index 2 is broken" is a fact about screenshots that
+  // are no longer there, and it hides the WRONG tile in the new set. The viewer's
+  // rescue effect covers the open VIEWER; nothing covered the GRID.
+  //
+  // Keyed on the URL LIST rather than the array's identity, deliberately: `screenshots`
+  // is a fresh array on every refetch even when the content is identical, and resetting
+  // then would make already-failed tiles flash back in and re-request on every poll.
+  // The URLs are what the indices mean, so they are what has to change.
+  //
+  // Written as a render-phase adjustment (React's documented "adjusting state when a
+  // prop changes") rather than an effect, so the stale set is never rendered even once.
+  const urls = shots.map((s) => s.url).join('\n');
+  const [seenUrls, setSeenUrls] = useState(urls);
+  if (seenUrls !== urls) {
+    setSeenUrls(urls);
+    setBroken(NO_BROKEN_SCREENSHOTS);
+    setOpenIndex(null);
+  }
 
   if (shots.length === 0) return null;
 

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -15,6 +15,7 @@ import {
   Stack,
   Text,
   Title,
+  UnstyledButton,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
@@ -30,7 +31,7 @@ import {
 import type { Icon } from '@tabler/icons-react';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import {
   appInitial,
@@ -47,6 +48,12 @@ import {
 } from '~/components/Apps/appListingDetailView';
 import { toRecentAppFromListing } from '~/components/Apps/recentAppsRail';
 import { recordRecentlyOpenedApp } from '~/components/Apps/recentlyOpenedAppsStore';
+import { AppListingScreenshotViewer } from '~/components/Apps/AppListingScreenshotViewer';
+import {
+  NO_BROKEN_SCREENSHOTS,
+  withBrokenIndex,
+  type BrokenScreenshotIndexes,
+} from '~/components/Apps/appListingScreenshotNav';
 import { RelatedListings } from '~/components/Apps/RelatedListings';
 import { TruncatedText } from '~/components/Apps/AppListingTruncate';
 import { ListingCollaboratorByline } from '~/components/Apps/ListingCollaboratorByline';
@@ -375,43 +382,95 @@ function CreatorChip({ creator }: { creator: ListingDetail['creator'] }) {
 }
 
 /**
- * One screenshot tile — hides itself on load error (a dangling Image ref) rather
- * than rendering a broken `<img>`. Plain `<img>` (mirrors AppDetailsModal / the
- * live detail): the URL is a CDN edge URL, not a configured Next/Image domain.
+ * One screenshot tile — a BUTTON that opens the full-size viewer, and the reporter
+ * of a dangling Image ref. Plain `<img>` (mirrors AppDetailsModal / the live
+ * detail): the URL is a CDN edge URL, not a configured Next/Image domain.
+ *
+ * 🔴 THE `broken` STATE MOVED UP TO THE GALLERY, DELIBERATELY. It used to be this
+ * component's own `useState`, and hiding itself was all it ever did with it — which
+ * was enough while nothing else needed to know. It is not enough now: the viewer
+ * navigates over the same list, so a shot the GRID has already given up on must be
+ * one the VIEWER skips too, and one component's private state cannot say that. The
+ * rendered result is unchanged — the tile still disappears on a load error — but the
+ * decision is made once, by the owner of the list, instead of twice.
+ *
+ * 🔴 IT IS A REAL `<button>` (`UnstyledButton`), NOT an `<img onClick>`. The tile has
+ * to be tab-reachable and Enter/Space-activatable, and the accessible name has to
+ * come from somewhere: it is COMPUTED FROM THE CONTENT (the image `alt` plus the
+ * caption text) rather than pinned with an `aria-label`, so the name always contains
+ * the caption the viewer can see — a bare `aria-label="View screenshot"` would strip
+ * it and break WCAG 2.5.3 label-in-name. The button sits INSIDE the `Card` rather
+ * than replacing it so the grid's children stay one element per tile, which is what
+ * the gallery's fill rule (`:last-child:nth-child(odd)`) matches on.
  */
 function ScreenshotTile({
   shot,
   name,
   index,
+  onOpen,
+  onBroken,
 }: {
   shot: ListingGalleryScreenshot;
   name: string;
+  /** Index into the gallery's URL-filtered list — the viewer's index space. */
   index: number;
+  onOpen: () => void;
+  onBroken: () => void;
 }) {
-  const [broken, setBroken] = useState(false);
-  if (broken) return null;
   return (
     <Card withBorder padding={0} radius="md" style={{ overflow: 'hidden' }}>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={shot.url}
-        alt={shot.caption ? shot.caption : `${name} screenshot ${index + 1}`}
-        loading="lazy"
-        onError={() => setBroken(true)}
-        style={{ width: '100%', height: 'auto', display: 'block' }}
-      />
-      {shot.caption && (
-        <Text size="xs" c="dimmed" p="xs" lineClamp={2}>
-          {shot.caption}
-        </Text>
-      )}
+      <UnstyledButton
+        onClick={onOpen}
+        data-testid="apps-listing-screenshot-tile"
+        // The index this tile represents, as a DOM fact. A test that clicks "the
+        // third tile" and asserts the viewer opened on shot 3 is otherwise asserting
+        // against its own fixture order rather than against the wiring.
+        data-screenshot-index={index}
+        // Paired with a ring, never a bare `outline: none` — keyboard focus has to
+        // stay visible on a tile whose whole job is to be activated by keyboard.
+        className="focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-5"
+        style={{ display: 'block', width: '100%', textAlign: 'left' }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={shot.url}
+          alt={shot.caption ? shot.caption : `${name} screenshot ${index + 1}`}
+          loading="lazy"
+          onError={onBroken}
+          style={{ width: '100%', height: 'auto', display: 'block' }}
+        />
+        {shot.caption && (
+          <Text size="xs" c="dimmed" p="xs" lineClamp={2}>
+            {shot.caption}
+          </Text>
+        )}
+      </UnstyledButton>
     </Card>
   );
 }
 
 /**
  * Screenshot gallery — reuses AppDetailsModal's SimpleGrid pattern. Empty/broken
- * URLs are skipped; the whole section is hidden when nothing remains.
+ * URLs are skipped; the whole section is hidden when nothing remains. Each tile
+ * opens the full-size `AppListingScreenshotViewer` (prev/next, arrow keys, Esc,
+ * caption, `3 / 7` indicator).
+ *
+ * 🔴 THIS COMPONENT OWNS THE INDEX SPACE THAT BOTH SURFACES READ, and that is the
+ * whole reason the viewer is mounted HERE rather than fired at the app-wide
+ * `dialogStore`. `shots` (the URL-filtered list) and `broken` (the indices whose
+ * image 404'd) are single copies shared by the grid and the viewer, so the tile at
+ * `shots` index *i* opens the viewer at *i* with nothing in between to be off by
+ * one about. A viewer holding its own snapshot of either would diverge silently —
+ * see the rejected-alternatives ledger in `AppListingScreenshotViewer`'s header,
+ * and the seam gate in `__tests__/appListingScreenshotViewerWiring.test.ts`.
+ *
+ * 🔴 THE VIEWER IS **NOT** OMITTED IN `preview`, deliberately, and that is a
+ * decision against the grain of the posture ledger on this file's props. The
+ * ledger's rule is "omit every LIVE / interactive / AGGREGATE surface"; a lightbox
+ * is none of those — it queries nothing, writes nothing and acts on nothing. A
+ * moderator reviewing a shadow listing's MEDIA is precisely the reader who most
+ * needs to see a screenshot at full size, so keeping it serves the posture rather
+ * than bending it. The gallery itself was already on the KEPT side of that ledger.
  *
  * 🔴 THE GRID IS STILL TWO TRACKS; WHAT CHANGED IS WHAT AN UNPAIRED TILE DOES.
  * A fixed `cols={{ base: 1, sm: 2 }}` gave a single-screenshot listing HALF the
@@ -438,7 +497,31 @@ function ScreenshotGallery({
   name: string;
 }) {
   const shots = screenshots.filter((s) => !!s.url);
+
+  // 🔴 THE ONE INDEX SPACE, AND THE ONE PLACE THAT KNOWS WHICH SHOTS ARE REAL.
+  // Both pieces of state are indices into `shots` — the URL-filtered list above —
+  // never into the raw `screenshots` prop, and the tile at `shots` index *i* opens
+  // the viewer at *i* with no mapping in between. That is the whole defence against
+  // the off-by-one this feature invites: there is no second numbering to disagree
+  // with the first. `broken` lives here rather than in the tile because the viewer
+  // has to skip the same shots the grid has dropped (see `ScreenshotTile`).
+  const [broken, setBroken] = useState<BrokenScreenshotIndexes>(NO_BROKEN_SCREENSHOTS);
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const markBroken = useCallback(
+    (index: number) => setBroken((prev) => withBrokenIndex(prev, index)),
+    []
+  );
+
   if (shots.length === 0) return null;
+
+  // Rendered from the SAME array the viewer reads, minus what has failed to load, so
+  // a tile's `index` prop is its viewer index even after earlier tiles have dropped
+  // out. Mapping over the filtered-but-not-renumbered pairs is what keeps that true:
+  // renumbering here would silently shift every `alt` and every open target.
+  const visible = shots
+    .map((shot, index) => ({ shot, index }))
+    .filter(({ index }) => !broken.has(index));
+
   return (
     <Stack gap="xs">
       <Title order={4}>Screenshots</Title>
@@ -448,10 +531,26 @@ function ScreenshotGallery({
         className={galleryClasses.gallery}
         data-testid="apps-listing-screenshot-grid"
       >
-        {shots.map((shot, i) => (
-          <ScreenshotTile key={`${shot.url}-${i}`} shot={shot} name={name} index={i} />
+        {visible.map(({ shot, index }) => (
+          <ScreenshotTile
+            key={`${shot.url}-${index}`}
+            shot={shot}
+            name={name}
+            index={index}
+            onOpen={() => setOpenIndex(index)}
+            onBroken={() => markBroken(index)}
+          />
         ))}
       </SimpleGrid>
+      <AppListingScreenshotViewer
+        shots={shots}
+        name={name}
+        broken={broken}
+        index={openIndex}
+        onIndexChange={setOpenIndex}
+        onBroken={markBroken}
+        onClose={() => setOpenIndex(null)}
+      />
     </Stack>
   );
 }

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -417,6 +417,7 @@ function ScreenshotTile({
   index,
   onOpen,
   onBroken,
+  autoFocus,
 }: {
   shot: ListingGalleryScreenshot;
   name: string;
@@ -424,6 +425,8 @@ function ScreenshotTile({
   index: number;
   onOpen: () => void;
   onBroken: () => void;
+  /** Marks this tile as where a re-armed ancestor focus trap should land. */
+  autoFocus: boolean;
 }) {
   return (
     <Card withBorder padding={0} radius="md" style={{ overflow: 'hidden' }}>
@@ -434,6 +437,18 @@ function ScreenshotTile({
         // third tile" and asserts the viewer opened on shot 3 is otherwise asserting
         // against its own fixture order rather than against the wiring.
         data-screenshot-index={index}
+        // 🔴 MANTINE'S OWN RE-FOCUS TARGET, and the only thing that survives a
+        // nested close. When the screenshot viewer closes inside the moderator
+        // review modal, the review modal's `trapFocus` flips back on, and
+        // `useFocusTrap`'s effect then calls `focusNode` UNCONDITIONALLY on a
+        // `setTimeout` — it does not check whether focus is already somewhere
+        // sensible. `focusNode` prefers `[data-autofocus]` over the first tabbable,
+        // so marking the tile the viewer was opened from is what makes that
+        // re-focus land on the tile instead of the review modal's close button.
+        // Any synchronous restore loses this race by construction: the trap's
+        // timeout is scheduled from an ANCESTOR effect, which React runs after
+        // ours.
+        data-autofocus={autoFocus ? '' : undefined}
         // Paired with a ring, never a bare `outline: none` — keyboard focus has to
         // stay visible on a tile whose whole job is to be activated by keyboard.
         className="focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-5"
@@ -517,6 +532,16 @@ function ScreenshotGallery({
   // has to skip the same shots the grid has dropped (see `ScreenshotTile`).
   const [broken, setBroken] = useState<BrokenScreenshotIndexes>(NO_BROKEN_SCREENSHOTS);
   const [openIndex, setOpenIndex] = useState<number | null>(null);
+  // The tile the viewer was LAST opened from. Distinct from `openIndex` because it
+  // has to outlive the close — the ancestor focus trap re-focuses on a timeout, by
+  // which point `openIndex` is already null. See `ScreenshotTile`'s `data-autofocus`.
+  //
+  // 🔴 KEYING THIS ON `openIndex` INSTEAD DOES NOT MERELY MISS THE RESTORE — IT WEDGES
+  // THE PAGE. Measured: with `data-autofocus` on the tile that is currently OPEN, a
+  // nested viewer pegs the browser (a mutation run producing no output at all in five
+  // minutes, reproduced standalone). The marker must name a tile that is BEHIND a
+  // closed viewer, never one behind an open one.
+  const [lastOpenedIndex, setLastOpenedIndex] = useState<number | null>(null);
   const markBroken = useCallback(
     (index: number) => setBroken((prev) => withBrokenIndex(prev, index)),
     []
@@ -543,6 +568,7 @@ function ScreenshotGallery({
     setSeenUrls(urls);
     setBroken(NO_BROKEN_SCREENSHOTS);
     setOpenIndex(null);
+    setLastOpenedIndex(null);
   }
 
   if (shots.length === 0) return null;
@@ -570,7 +596,11 @@ function ScreenshotGallery({
             shot={shot}
             name={name}
             index={index}
-            onOpen={() => setOpenIndex(index)}
+            autoFocus={lastOpenedIndex === index}
+            onOpen={() => {
+              setOpenIndex(index);
+              setLastOpenedIndex(index);
+            }}
             onBroken={() => markBroken(index)}
           />
         ))}

--- a/src/components/Apps/AppListingDetailBody.viewer.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.viewer.browser.test.tsx
@@ -486,6 +486,44 @@ describe('screenshot viewer — accessibility', () => {
     expect(document.getElementById(labelledBy!)?.textContent).toBe('My App screenshots');
   });
 
+  /**
+   * 🔴 THE VIEWER IMAGE'S `alt`, WHICH HAD NO ASSERTIONS AT ALL. An independent sweep
+   * mutated it in both directions — back to the duplicated caption, and to an
+   * unconditional `alt=""` — and BOTH survived a fully green suite, while the tile's
+   * equivalent change was well covered. The change was defensible; the silence was not.
+   *
+   * The rule is the same as the tile's and is asserted in both directions here: empty
+   * when the caption is rendered as text beside it (so a screen reader is not told the
+   * same string twice), and a describing fallback when there is no caption and nothing
+   * else names the image.
+   */
+  test('the viewer image is alt="" when a caption is shown beside it', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(3) }));
+    await userEvent.click(tiles(container)[1]);
+    await expectShowing(1);
+
+    // The caption IS on screen — so the image must not repeat it.
+    expect(viewerCaptionText()).toBe('Shot two');
+    expect(viewerImage()?.getAttribute('alt')).toBe('');
+  });
+
+  test('the viewer image keeps a describing alt when the shot has NO caption', async () => {
+    const { container } = await renderBody(
+      base({
+        screenshots: [
+          { url: okShot(0), caption: null },
+          { url: okShot(1), caption: null },
+        ],
+      })
+    );
+    await userEvent.click(tiles(container)[1]);
+    await expectShowing(1);
+
+    // Nothing else names it, so the alt has to.
+    expect(document.querySelector('[data-testid="apps-listing-screenshot-caption"]')).toBeNull();
+    expect(viewerImage()?.getAttribute('alt')).toBe('My App screenshot 2');
+  });
+
   test('focus moves INTO the dialog when it opens', async () => {
     const { container } = await renderBody(base({ screenshots: okShots(5) }));
     await userEvent.click(tiles(container)[1]);
@@ -502,6 +540,18 @@ describe('screenshot viewer — accessibility', () => {
    * 🔴 FOCUS RETURNS TO THE TILE THAT OPENED IT — to that tile, not to "some tile".
    * The listing has five, and the one opened is the fourth, so a restore that
    * defaulted to the first or to the gallery container fails here.
+   *
+   * 🔴 THE `{ArrowRight}` IS LOAD-BEARING; DO NOT "SIMPLIFY" IT AWAY. It is what makes
+   * this test able to kill the guard that is the entire reason `useOpenerFocusReturn`
+   * exists — `if (opened && !prevOpenedRef.current)`. Without the second half of that
+   * condition the hook re-captures `document.activeElement` on EVERY render while open,
+   * which is exactly the Mantine defect it replaces, re-created by hand. Every focus
+   * test in this PR previously opened and immediately closed, so the viewer never
+   * re-rendered while open and the guard never saw a second render: mutating it to a
+   * bare `if (opened)` left the whole suite GREEN. One arrow key re-renders the viewer
+   * mid-flight, the capture is overwritten with something inside the dialog, and the
+   * restore lands on `<body>`. Measured both ways — green at HEAD, and
+   * `expected <body> to be <button>` at the mutant.
    */
   test('focus returns to the ORIGINATING tile on close', async () => {
     const { container } = await renderBody(base({ screenshots: okShots(5) }));
@@ -512,6 +562,11 @@ describe('screenshot viewer — accessibility', () => {
     // Control: focus really did leave the tile, so the assertion after the close is
     // about a restore and not about focus that never moved.
     await vi.waitFor(() => expect(document.activeElement).not.toBe(opener));
+
+    // …and the viewer is USED before it is closed, so the opener has to survive a
+    // re-render rather than merely a mount/unmount pair. See the header.
+    await userEvent.keyboard('{ArrowRight}');
+    await expectShowing(4);
 
     await userEvent.keyboard('{Escape}');
     await vi.waitFor(() => expect(viewer()).toBeNull());
@@ -792,6 +847,35 @@ describe('screenshot viewer — nested inside the moderator review modal', () =>
     await vi.waitFor(() => expect(viewer()).toBeNull());
     expect(outerBody()).not.toBeNull();
   });
+
+  /**
+   * 🔴 THE VIEWER'S OWN FOCUS RETURN, ASSERTED **NESTED** — because being in a stack
+   * is exactly the condition that breaks Mantine's built-in one.
+   *
+   * Inside a `Modal.Stack`, `trapFocus` is `ctx.currentId === stackId`, so it FLIPS
+   * while a modal stays open (the stack registers members in an effect, so it flips on
+   * the very first open). `useModal` feeds it into
+   * `useFocusReturn({ opened, shouldReturnFocus: trapFocus && returnFocus })`, whose
+   * deps are `[opened, shouldReturnFocus]` — so each flip re-runs the effect with
+   * `opened === true` and re-takes the `lastActiveElement.current = document.activeElement`
+   * branch, overwriting the element the modal was opened from with whatever has focus
+   * by then. Measured on the review modal: focus lands on `<body>`.
+   *
+   * The un-nested version of this test (`focus returns to the ORIGINATING tile on
+   * close`) cannot see that, because with no stack ancestor `stackId` is inert and
+   * nothing flips. Same assertion, second measured point.
+   */
+  test('Esc returns focus to the originating TILE even when nested', async () => {
+    const opener = await openNestedViewer(base({ screenshots: okShots(5) }));
+    // Control: focus really did leave the tile, so the assertion below is about a
+    // restore and not about focus that never moved.
+    await vi.waitFor(() => expect(document.activeElement).not.toBe(opener));
+
+    await userEvent.keyboard('{Escape}');
+    await vi.waitFor(() => expect(viewer()).toBeNull());
+
+    await vi.waitFor(() => expect(document.activeElement).toBe(opener));
+  });
 });
 
 describe('screenshot viewer — broken screenshots', () => {
@@ -999,21 +1083,41 @@ describe('screenshot viewer — broken screenshots', () => {
    * The same reset closes an OPEN viewer, for the same reason: `openIndex` is a
    * position too, and holding it across a swap points the viewer at a screenshot the
    * user never asked to see.
+   *
+   * 🔴 THE REPLACEMENT LIST IS THE **SAME LENGTH**, AND THAT IS A CORRECTION FOUND BY
+   * AN INDEPENDENT SWEEP. This test used to swap 3 screenshots for a 1-screenshot list,
+   * and it PASSED BY CONVERGENCE: with `setOpenIndex(null)` deleted, the stale
+   * `openIndex = 2` pointed past the end of the new list, so `shots[2]` was undefined,
+   * so the VIEWER'S RESCUE EFFECT called `onClose()` — the viewer shut anyway, for a
+   * reason that had nothing to do with the reset. The mutant survived a green suite.
+   *
+   * A same-length swap removes that escape route: index 2 is still a valid, viable
+   * screenshot in the new list, so nothing rescues, and a viewer that fails to close
+   * sits there showing `okShot(32)` — the new list's third screenshot, which the user
+   * never opened. That is the failure this test has to be able to see.
+   *
+   * 🔴 This was the THIRD convergence-class instrument failure in this change, in the
+   * very area hardened against convergence one round earlier. When adding an assertion
+   * here, ask specifically: is there a SECOND mechanism that produces this same
+   * observable?
    */
-  test('a NEW screenshot list closes an open viewer', async () => {
+  test('a NEW screenshot list of the SAME LENGTH closes an open viewer', async () => {
     const { container, rerender } = await renderWithProviders(
       <AppListingDetailBody detail={base({ screenshots: okShots(3) })} />
     );
     await userEvent.click(tiles(container)[2]);
     await expectShowing(2);
 
-    await rerender(
-      <AppListingDetailBody
-        detail={base({ screenshots: [{ url: okShot(20), caption: 'Only one' }] })}
-      />
-    );
+    const replacement = [
+      { url: okShot(30), caption: 'Fresh one' },
+      { url: okShot(31), caption: 'Fresh two' },
+      { url: okShot(32), caption: 'Fresh three' },
+    ];
+    await rerender(<AppListingDetailBody detail={base({ screenshots: replacement })} />);
 
     await vi.waitFor(() => expect(viewer()).toBeNull());
+    // …and specifically NOT by having quietly swapped to the new list's third shot.
+    expect(viewerImage()).toBeNull();
   });
 
   /**

--- a/src/components/Apps/AppListingDetailBody.viewer.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.viewer.browser.test.tsx
@@ -1,3 +1,5 @@
+import { Modal } from '@mantine/core';
+import { useState } from 'react';
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
@@ -92,6 +94,7 @@ vi.mock('~/components/Apps/AppListingComments', () => ({
 
 // Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
 const { AppListingDetailBody } = await import('./AppListingDetailBody');
+const { AppListingScreenshotViewer } = await import('./AppListingScreenshotViewer');
 
 beforeEach(async () => {
   await page.viewport(...WIDE);
@@ -174,8 +177,23 @@ const tiles = (container: HTMLElement) =>
     container.querySelectorAll<HTMLElement>('[data-testid="apps-listing-screenshot-tile"]')
   );
 
-/** The viewer's modal, or null when it is closed. It renders in a PORTAL, not in `container`. */
-const viewer = () => document.querySelector<HTMLElement>('[role="dialog"][aria-modal="true"]');
+/**
+ * The viewer's modal, or null when it is closed. It renders in a PORTAL, not in
+ * `container`.
+ *
+ * 🔴 ANCHORED ON THE VIEWER'S OWN MARKER, NOT ON `[role="dialog"][aria-modal="true"]`,
+ * AND THAT IS A CORRECTION. The selector-only form identifies "a Mantine modal" but
+ * not WHICH ONE, and in the `preview` posture there are two of them — so in the nested
+ * tests below it silently resolved to the moderator REVIEW modal. Every "the viewer is
+ * closed" assertion then read the wrong element: one waited 10s for the review modal to
+ * disappear, another declared the viewer open before it existed. Both looked like
+ * product defects. The suite never had two dialogs before, so nothing could have caught
+ * it — the config-blind case, exactly.
+ */
+const viewer = () =>
+  (document
+    .querySelector('[data-testid="apps-listing-screenshot-viewer"]')
+    ?.closest('[role="dialog"]') as HTMLElement | null) ?? null;
 
 /** The `<img>` the viewer is displaying, read from the document (portal again). */
 const viewerImage = () =>
@@ -407,11 +425,37 @@ describe('screenshot viewer — accessibility', () => {
     expect(all).toHaveLength(3);
     for (const tile of all) expect(tile.tagName).toBe('BUTTON');
 
-    // The accessible name is COMPUTED FROM CONTENT (image alt + caption), never an
-    // aria-label that would strip the visible caption (WCAG 2.5.3).
+    // The accessible name is COMPUTED FROM CONTENT, never an aria-label that would
+    // strip the visible caption (WCAG 2.5.3).
     const third = all[2];
     expect(third.textContent).toContain('Shot three');
-    expect(third.querySelector('img')?.getAttribute('alt')).toBe('Shot three');
+
+    // 🔴 …AND IT IS ANNOUNCED ONCE. The image carries `alt=""` when there is a caption,
+    // because the caption is already inside this button as text and BOTH contribute to
+    // the computed name. Asserted through the accessibility tree rather than by reading
+    // the attribute: with the caption duplicated into `alt` the name was
+    // "Shot three Shot three", so a query for the exact caption matched NOTHING while
+    // every attribute-level assertion still passed.
+    await expect
+      .element(page.getByRole('button', { name: 'Shot three', exact: true }))
+      .toBeVisible();
+  });
+
+  /**
+   * The captionless tile still gets a describing name, from the `alt` fallback — the
+   * control that says the `alt=""` above is conditional and not a blanket removal.
+   */
+  test('a tile with NO caption is named by its image alt instead', async () => {
+    const { container } = await renderBody(
+      base({ screenshots: [{ url: okShot(0), caption: null }] })
+    );
+    expect(tiles(container)).toHaveLength(1);
+    expect(tiles(container)[0].querySelector('img')?.getAttribute('alt')).toBe(
+      'My App screenshot 1'
+    );
+    await expect
+      .element(page.getByRole('button', { name: 'My App screenshot 1', exact: true }))
+      .toBeVisible();
   });
 
   test('a tile opens the viewer from the keyboard alone', async () => {
@@ -475,6 +519,281 @@ describe('screenshot viewer — accessibility', () => {
   });
 });
 
+/**
+ * 🔴 THE RESCUE EFFECT — the branch this feature argues hardest for, and the one that
+ * had NO coverage in either tier until this block existed.
+ *
+ * It is what stops the viewer sitting on an empty frame when the shot it is displaying
+ * stops being displayable: tiles are `loading="lazy"`, so a dangling URL below the fold
+ * is only discovered when the VIEWER fetches it, and the listing's screenshot array can
+ * also change under an open viewer. Two fixtures elsewhere in this file had to be
+ * reshaped *because* the rescue silently produced the right answer by another route —
+ * and yet mutating the whole effect body to an unconditional `return` left all of the
+ * other tests green. The node project cannot see it at all (it is an effect, not
+ * arithmetic). So it was the single least-tested branch in the change, while being the
+ * one the headers cite most.
+ *
+ * 🔴 DRIVEN AS AN ORDINARY CONTROLLED COMPONENT — no gallery, no tiles, no image
+ * loading. The rescue's inputs are just `index` / `shots` / `broken`, and the gallery
+ * can only reach a few of their combinations by racing a real 404. Rendering the viewer
+ * directly makes every branch reachable deterministically, and `onIndexChange` /
+ * `onClose` are spies rather than state, so the effect's DECISION is observed instead
+ * of its downstream consequence.
+ */
+describe('screenshot viewer — the rescue effect', () => {
+  const NAME = 'My App';
+
+  function renderViewer(over: {
+    shots: { url: string; caption: string | null }[];
+    index: number | null;
+    broken?: ReadonlySet<number>;
+  }) {
+    const onIndexChange = vi.fn();
+    const onClose = vi.fn();
+    const onBroken = vi.fn();
+    const rendered = renderWithProviders(
+      <AppListingScreenshotViewer
+        shots={over.shots}
+        name={NAME}
+        broken={over.broken ?? new Set<number>()}
+        index={over.index}
+        onIndexChange={onIndexChange}
+        onClose={onClose}
+        onBroken={onBroken}
+      />
+    );
+    return { rendered, onIndexChange, onClose, onBroken };
+  }
+
+  /**
+   * 🔴 FORWARD IS PREFERRED WHEN BOTH DIRECTIONS ARE AVAILABLE. Shot 2 of 5 is broken,
+   * so 1 and 3 are both reachable and the two arms of the `??` give DIFFERENT answers —
+   * which is the only fixture shape in which swapping them is visible. A fixture where
+   * only one direction is viable would be satisfied by either order.
+   */
+  test('rescues FORWARD when both directions are viable', async () => {
+    const { onIndexChange, onClose } = renderViewer({
+      shots: okShots(5),
+      index: 2,
+      broken: new Set([2]),
+    });
+
+    await vi.waitFor(() => expect(onIndexChange).toHaveBeenCalledWith(3));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The backward arm, reached only when there is nothing ahead: the last shot of three
+   * has 404'd, so forward is exhausted and the rescue falls back to 1. A mutant that
+   * drops the `?? adjacentViableIndex(index, -1, …)` arm closes the viewer here
+   * instead — losing a listing that still has two perfectly good screenshots.
+   */
+  test('falls BACK when there is nothing viable ahead', async () => {
+    const { onIndexChange, onClose } = renderViewer({
+      shots: okShots(3),
+      index: 2,
+      broken: new Set([2]),
+    });
+
+    await vi.waitFor(() => expect(onIndexChange).toHaveBeenCalledWith(1));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  /** An index past the end of a shrunken array resolves backward, into the array. */
+  test('rescues an index left over from a longer screenshot list', async () => {
+    const { onIndexChange, onClose } = renderViewer({ shots: okShots(3), index: 3 });
+
+    await vi.waitFor(() => expect(onIndexChange).toHaveBeenCalledWith(2));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  /**
+   * 🔴 NOTHING VIABLE IN EITHER DIRECTION → CLOSE, and it must be `onClose`, not an
+   * index. This is the arm that keeps the viewer from becoming a permanently empty
+   * dialog, and it is separately asserted that no index was proposed — a rescue that
+   * both closed AND navigated would leave the gallery holding a stale open index.
+   */
+  test('CLOSES when no screenshot is viable in either direction', async () => {
+    const { onIndexChange, onClose } = renderViewer({
+      shots: okShots(3),
+      index: 1,
+      broken: new Set([0, 1, 2]),
+    });
+
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(onIndexChange).not.toHaveBeenCalled();
+  });
+
+  /** An index far past a two-shot array has nothing to step to — it closes. */
+  test('CLOSES when the index is far outside a shrunken list', async () => {
+    const { onIndexChange, onClose } = renderViewer({ shots: okShots(2), index: 5 });
+
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(onIndexChange).not.toHaveBeenCalled();
+  });
+
+  /**
+   * 🔴 THE NEGATIVE CONTROL, and without it every assertion above is satisfied by an
+   * effect that fires on EVERYTHING. A viewer sitting on a perfectly good shot must be
+   * left alone: no rescue, no close, and the shot still on screen. This is the mutant
+   * "delete the `|| viable` half of the guard" — which no other test here can see.
+   */
+  test('does NOT fire for a viable shot (negative control)', async () => {
+    const { onIndexChange, onClose } = renderViewer({ shots: okShots(5), index: 2 });
+
+    await expectShowing(2);
+    // Give the effect every chance to misfire before asserting it did not.
+    await new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+    expect(onIndexChange).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  /** Closed viewer: the effect must not act on a `null` index either. */
+  test('does NOT fire while the viewer is closed (negative control)', async () => {
+    const { onIndexChange, onClose } = renderViewer({ shots: okShots(5), index: null });
+
+    await new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+    expect(viewer()).toBeNull();
+    expect(onIndexChange).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * 🔴 NESTED IN THE MODERATOR REVIEW MODAL — the `preview` posture's real shape.
+ *
+ * `OffsiteReviewQueue`'s `OffsiteReviewModal` renders `<AppListingDetailBody … preview />`
+ * inside a Mantine `<Modal>`, so opening a screenshot puts one Modal inside another.
+ * Mantine's Esc handling is a **per-Modal `window` keydown listener in CAPTURE phase**
+ * (`@mantine/core/…/ModalBase/use-modal.mjs`), so without coordination EVERY open
+ * Modal's handler fires for the same key — one Escape closed the viewer AND the review
+ * modal, discarding the moderator's in-progress `rejectionReason` / `approvalNotes`
+ * (local state in `OffsiteReviewModalBody`, `keepMounted: false`) and their place in
+ * the queue.
+ *
+ * 🔴 THESE TESTS ASSERT THE RELATIONSHIP, NOT A PROP VALUE, AND THAT IS THE POINT.
+ * The seam gate already pinned that `closeOnEscape` is not switched OFF — which is the
+ * MIRROR IMAGE of this defect, and is exactly why this area read as covered while it
+ * was not. A guard that certifies the opposite half of a hazard is worse than no guard.
+ * So: one Escape, two open dialogs, and the assertion is about which of them is still
+ * there afterwards.
+ *
+ * 🔴 WHY ORDERING TRICKS WERE NOT THE FIX, read off the installed source rather than
+ * guessed: `useWindowEvent` lists `[type, listener]` as its deps and Mantine passes a
+ * NEW inline arrow every render, so each Modal's listener is torn down and re-added on
+ * every one of its renders. Registration order — the only thing that decides which
+ * `window`-capture listener runs first — is therefore whatever rendered most recently,
+ * and a `stopImmediatePropagation` from the inner modal cannot be relied on to preempt
+ * the outer. Mantine's own answer is `Modal.Stack`, which gates `closeOnEscape` (and
+ * `trapFocus`) on `ctx.currentId === stackId` (`Modal.mjs:53-57`) instead of racing.
+ */
+describe('screenshot viewer — nested inside the moderator review modal', () => {
+  /**
+   * The production shape: a `Modal.Stack` wrapping the review `Modal`, with the
+   * listing body — and therefore the screenshot viewer — rendered as its child. The
+   * viewer joins the same stack through React context, which reaches it even though
+   * both modals render into portals (context follows the React tree, not the DOM).
+   */
+  function NestedReviewHarness({ detail }: { detail: ListingDetail }) {
+    const [outerOpen, setOuterOpen] = useState(true);
+    return (
+      <Modal.Stack>
+        <Modal
+          opened={outerOpen}
+          onClose={() => setOuterOpen(false)}
+          stackId="offsite-review"
+          title="Review request"
+        >
+          <div data-testid="outer-review-modal-body">
+            <AppListingDetailBody detail={detail} preview />
+          </div>
+        </Modal>
+      </Modal.Stack>
+    );
+  }
+
+  const outerBody = () => document.querySelector('[data-testid="outer-review-modal-body"]');
+
+  async function openNestedViewer(detail: ListingDetail) {
+    await renderWithProviders(<NestedReviewHarness detail={detail} />);
+    await vi.waitFor(() => expect(outerBody()).not.toBeNull());
+    const tile = document.querySelectorAll<HTMLElement>(
+      '[data-testid="apps-listing-screenshot-tile"]'
+    );
+    expect(tile).toHaveLength(5);
+    await userEvent.click(tile[2]);
+    await expectShowing(2);
+    return tile[2];
+  }
+
+  /**
+   * 🔴 THE DEFECT. One Escape must close the INNER dialog only.
+   *
+   * Both halves are asserted because either alone is satisfiable by a broken viewer:
+   * "the outer survives" is also true of a viewer whose Escape does nothing at all,
+   * and "the viewer closed" is also true of the bug this fixes.
+   */
+  test('one Escape closes the VIEWER and leaves the review modal open', async () => {
+    await openNestedViewer(base({ screenshots: okShots(5) }));
+    expect(outerBody(), 'the review modal was not open to begin with').not.toBeNull();
+
+    await userEvent.keyboard('{Escape}');
+
+    await vi.waitFor(() => expect(viewer()).toBeNull());
+    expect(
+      outerBody(),
+      'one Escape closed BOTH dialogs — the moderator just lost their rejection reason'
+    ).not.toBeNull();
+  });
+
+  /**
+   * 🔴 THE CONTROL, and it is what stops the test above passing for the wrong reason.
+   * With no viewer open, Escape must still close the review modal — otherwise a fix
+   * that simply disabled Escape everywhere would satisfy the assertion above while
+   * making the moderator's own dialog unclosable.
+   */
+  test('with no viewer open, Escape still closes the review modal (control)', async () => {
+    await renderWithProviders(<NestedReviewHarness detail={base({ screenshots: okShots(5) })} />);
+    await vi.waitFor(() => expect(outerBody()).not.toBeNull());
+    expect(viewer()).toBeNull();
+
+    await userEvent.keyboard('{Escape}');
+
+    await vi.waitFor(() => expect(outerBody()).toBeNull());
+  });
+
+  /**
+   * A SECOND Escape, once the viewer is gone, closes the review modal — so the fix
+   * hands the key back rather than swallowing it for the rest of the session. This is
+   * the pair to the control above: together they say Escape is *scoped*, not disabled.
+   */
+  test('a second Escape, after the viewer has closed, closes the review modal', async () => {
+    await openNestedViewer(base({ screenshots: okShots(5) }));
+
+    await userEvent.keyboard('{Escape}');
+    await vi.waitFor(() => expect(viewer()).toBeNull());
+    expect(outerBody()).not.toBeNull();
+
+    await userEvent.keyboard('{Escape}');
+    await vi.waitFor(() => expect(outerBody()).toBeNull());
+  });
+
+  /**
+   * The close BUTTON was already correct (the auditor's probe returned `true` for it),
+   * but it is asserted here anyway: the fix changes how the viewer participates in
+   * Escape, and "the other way out still works" is the kind of thing a scoping change
+   * breaks silently.
+   */
+  test('the viewer close button closes only the viewer', async () => {
+    await openNestedViewer(base({ screenshots: okShots(5) }));
+
+    await page.getByRole('button', { name: 'Close screenshot viewer' }).click();
+
+    await vi.waitFor(() => expect(viewer()).toBeNull());
+    expect(outerBody()).not.toBeNull();
+  });
+});
+
 describe('screenshot viewer — broken screenshots', () => {
   /**
    * 🔴 THE INDEX-SPACE TEST, AND THE ONE THIS FEATURE IS MOST LIKELY TO GET WRONG.
@@ -496,9 +815,10 @@ describe('screenshot viewer — broken screenshots', () => {
    *
    * The `data-screenshot-index` assertion is the direct form of the same claim: the
    * tile states which shot it represents, and under the renumbering mutant it states
-   * `2` where the correct value is `3`. The `alt` list is the positive control that
-   * the first tile really rendered and then removed itself — `Shot one` is present in
-   * the fixture and absent from the DOM.
+   * `2` where the correct value is `3`. The CAPTION list is the positive control that
+   * the first tile really rendered and was then dropped — `Shot one` is present in the
+   * fixture and absent from the DOM. (It reads the tiles' text rather than their image
+   * `alt`, because a captioned tile's `alt` is deliberately empty; see the a11y test.)
    */
   test('a broken screenshot does not shift the index the surviving tiles open', async () => {
     const shots = okShots(5);
@@ -506,7 +826,7 @@ describe('screenshot viewer — broken screenshots', () => {
     const { container } = await renderBody(base({ screenshots: shots }));
 
     await vi.waitFor(() => expect(tiles(container)).toHaveLength(4));
-    expect(tiles(container).map((t) => t.querySelector('img')?.getAttribute('alt'))).toEqual([
+    expect(tiles(container).map((t) => t.textContent?.trim())).toEqual([
       'Shot two',
       'Shot three',
       'Shot four',
@@ -638,6 +958,107 @@ describe('screenshot viewer — broken screenshots', () => {
    * exactly the pre-existing behaviour (the tiles hide themselves; the `Screenshots`
    * heading stays) — and, the new part, there is still no dialog to open.
    */
+  /**
+   * 🔴 A NEW SCREENSHOT LIST INVALIDATES THE BROKEN SET, because the broken set is a
+   * list of POSITIONS and positions only mean something relative to one array.
+   *
+   * The listing's screenshots can change under a mounted gallery — a `getAppDetail`
+   * invalidate on the live page, or the moderator review preview swapping its locally
+   * built preview for the fetched one. Without a reset, "index 0 is broken" survives
+   * into the new set and hides whichever screenshot now happens to sit at index 0: a
+   * perfectly good image, gone, with no error anywhere.
+   *
+   * Latent rather than live today only because the preview's fallback list is empty, so
+   * the swap only ever goes empty→populated. That is a property of one consumer, not of
+   * this component, and it is exactly the kind of thing that changes without anyone
+   * remembering this depended on it.
+   */
+  test('a NEW screenshot list clears the broken set rather than hiding the wrong tile', async () => {
+    const first = okShots(3);
+    first[0] = { url: brokenShot(70), caption: 'Shot one' };
+    const { container, rerender } = await renderWithProviders(
+      <AppListingDetailBody detail={base({ screenshots: first })} />
+    );
+    // Index 0 has 404'd, so two tiles remain — the state the reset has to discard.
+    await vi.waitFor(() => expect(tiles(container)).toHaveLength(2));
+
+    // A genuinely different list: three loadable shots, none of them shared with the
+    // first set, so nothing about the old indices can still be true.
+    const second = [
+      { url: okShot(10), caption: 'Fresh one' },
+      { url: okShot(11), caption: 'Fresh two' },
+      { url: okShot(12), caption: 'Fresh three' },
+    ];
+    await rerender(<AppListingDetailBody detail={base({ screenshots: second })} />);
+
+    await vi.waitFor(() => expect(tiles(container)).toHaveLength(3));
+    expect(tiles(container).map((t) => t.dataset.screenshotIndex)).toEqual(['0', '1', '2']);
+  });
+
+  /**
+   * The same reset closes an OPEN viewer, for the same reason: `openIndex` is a
+   * position too, and holding it across a swap points the viewer at a screenshot the
+   * user never asked to see.
+   */
+  test('a NEW screenshot list closes an open viewer', async () => {
+    const { container, rerender } = await renderWithProviders(
+      <AppListingDetailBody detail={base({ screenshots: okShots(3) })} />
+    );
+    await userEvent.click(tiles(container)[2]);
+    await expectShowing(2);
+
+    await rerender(
+      <AppListingDetailBody
+        detail={base({ screenshots: [{ url: okShot(20), caption: 'Only one' }] })}
+      />
+    );
+
+    await vi.waitFor(() => expect(viewer()).toBeNull());
+  });
+
+  /**
+   * 🔴 THE NEGATIVE CONTROL — a re-render carrying an EQUAL list must NOT reset.
+   * `screenshots` is a fresh array on every refetch, so an identity-keyed reset would
+   * fire on every poll: an open lightbox would slam shut and already-failed tiles would
+   * flash back in and re-request, forever. The reset is keyed on the URLs, and this is
+   * what says so.
+   *
+   * 🔴 THE OPEN VIEWER IS THE OBSERVABLE, AND THAT IS A CORRECTION FOUND BY MUTATION.
+   * This test used to assert only the tile COUNT after an equal re-render, and it
+   * measured nothing: an identity-keyed reset DOES clear the broken set there, but the
+   * restored tile re-requests its dangling URL and errors again within a frame, so the
+   * count converges back to 2 before any assertion can run. The mutant SURVIVED a green
+   * test. `openIndex` is reset by the same code path and does NOT converge — a closed
+   * viewer stays closed — so it is the assertion with teeth. Do not drop it back to a
+   * count check.
+   */
+  test('an equal-but-new screenshots array does NOT reset the broken set (control)', async () => {
+    const build = () => {
+      const s = okShots(3);
+      s[0] = { url: brokenShot(71), caption: 'Shot one' };
+      return s;
+    };
+    const { container, rerender } = await renderWithProviders(
+      <AppListingDetailBody detail={base({ screenshots: build() })} />
+    );
+    await vi.waitFor(() => expect(tiles(container)).toHaveLength(2));
+
+    // Open the viewer, so the reset has something non-converging to destroy.
+    await userEvent.click(tiles(container)[1]);
+    await expectShowing(2);
+
+    // A brand-new array object with identical contents — what a refetch produces.
+    await rerender(<AppListingDetailBody detail={base({ screenshots: build() })} />);
+    await new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+
+    // The viewer is untouched…
+    expect(viewer(), 'an equal refetch closed the open lightbox').not.toBeNull();
+    expect(viewerImage()?.getAttribute('src')).toBe(okShot(2));
+    // …and so is the broken set.
+    expect(tiles(container)).toHaveLength(2);
+    expect(tiles(container).map((t) => t.dataset.screenshotIndex)).toEqual(['1', '2']);
+  });
+
   test('every screenshot broken — no tiles remain and nothing can be opened', async () => {
     const { container } = await renderBody(
       base({

--- a/src/components/Apps/AppListingDetailBody.viewer.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.viewer.browser.test.tsx
@@ -1,0 +1,655 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
+import type * as FeatureFlagsMod from '~/providers/FeatureFlagsProvider';
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * App-listing detail — the SCREENSHOT VIEWER (click a tile → full-size modal with
+ * prev/next, Esc, caption and a `3 / 7` position indicator).
+ *
+ * 🔴 READ THIS BEFORE TREATING ANY RESULT HERE AS A GATE: IT IS NOT ONE. This file
+ * is in the Vitest browser-mode `component` project, which CI runs only as the
+ * preview pipeline's `preview / component-tests` — report-only, non-blocking, and
+ * not reported at all when the preview build fails. The gating half of this change
+ * is `__tests__/appListingScreenshotNav.test.ts`, in the blocking node project,
+ * which pins the INDEX ARITHMETIC (open on N, step by one, stop at the ends, skip
+ * broken, count only what is reachable). That file cannot see a single DOM node;
+ * this one cannot block a merge. Both claims are needed; neither substitutes for the
+ * other, and this file exists for the half the pure functions structurally cannot
+ * make: that the component actually CALLS them, that the tile hands them the index it
+ * represents, that the arrow labelled "Next" is wired to `+1`, and that the a11y
+ * contract (focus in, focus back, Esc, `aria-modal`) really holds in a browser.
+ *
+ * 🔴 RED/GREEN HONESTY. Every test below is NEW-FEATURE coverage, not regression
+ * coverage. At `origin/main` `AppListingScreenshotViewer` does not exist and the
+ * tiles are not buttons, so this file does not fail an assertion there — it fails to
+ * find a tile at all. That is a much weaker statement than "red at base", and it is
+ * labelled as such rather than counted as a regression guard. The one thing that IS
+ * regression-shaped is the untouched sibling suite: `AppListingDetailBody.gallery.
+ * browser.test.tsx` (7 tests) and `AppListingDetailBody.browser.test.tsx` (64) both
+ * pass unchanged, which is what says the tile-becomes-a-button change did not move
+ * the grid geometry or the page structure.
+ *
+ * 🔴 NO CSS IS LOADED (`vitest.config.mts` registers only the process shim and
+ * `test/component-setup`), so nothing here measures a visual property. Every
+ * assertion is structural: an element's role, its accessible name, a `data-testid`,
+ * `document.activeElement`, an attribute. The sibling gallery suite is the one file
+ * that loads a stylesheet, and it does so because its claims are geometry.
+ *
+ * 🔴 FIXTURES ARE PAIRWISE DISTINCT BY CONSTRUCTION. Every screenshot carries a
+ * caption naming its own index (`Shot one` … `Shot seven`) and a URL that differs in
+ * one encoded byte, so "the viewer opened on the wrong shot" is a different string
+ * rather than an identical-looking one. A fixture whose captions repeat, or whose
+ * URLs are all the same data URI, cannot see an off-by-one at all — it is the single
+ * likeliest way this file would go vacuously green.
+ */
+
+const WIDE: [number, number] = [1440, 900];
+
+// Anonymous viewer, so the `⋮` menu and its modals never mount — nothing here is
+// about them, and each is a portal that would sit beside the viewer's own portal.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// 🔴 `importOriginal` SPREAD, not a wholesale replacement (local-rules/
+// no-wholesale-module-mock): a hand-written factory silently breaks every importer
+// the day the real module grows an export it omits — and in this project that
+// surfaces as `Tests no tests`, i.e. as nothing to see rather than as a failure.
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsMod>()),
+  useFeatureFlags: () => ({ appBlocks: true, appListings: true, appBlocksPages: false }),
+}));
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    appListings: {
+      listAvailable: { useQuery: () => ({ data: { items: [] }, isLoading: false }) },
+      getMyReview: { useQuery: () => ({ data: null, isLoading: false }) },
+      upsertReview: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      reportListing: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
+    user: {
+      getCreator: { useQuery: () => ({ data: null }) },
+      getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) },
+    },
+    useUtils: () => ({
+      appListings: {
+        getMyReview: { invalidate: async () => undefined },
+        listReviews: { invalidate: async () => undefined },
+        getAppDetail: { invalidate: async () => undefined },
+      },
+    }),
+  },
+}));
+vi.mock('~/components/Apps/AppListingReviews', () => ({
+  AppListingReviews: () => <div data-testid="mock-reviews" />,
+}));
+vi.mock('~/components/Apps/AppListingComments', () => ({
+  AppListingComments: () => <div data-testid="mock-comments" />,
+}));
+
+// Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
+const { AppListingDetailBody } = await import('./AppListingDetailBody');
+
+beforeEach(async () => {
+  await page.viewport(...WIDE);
+});
+
+/**
+ * A screenshot URL that RESOLVES, and that is DIFFERENT for every index.
+ *
+ * The SVG carries the index in an attribute, so each shot's `src` is a distinct
+ * string while every one of them still decodes to a real image. Both halves matter:
+ * a shared data URI would make "showing the wrong shot" indistinguishable from
+ * "showing the right one", and an http(s) URL would not load at all (see
+ * `LOADABLE_IMAGE_DATA_URI`'s header in `test/component-setup`).
+ */
+const okShot = (n: number) =>
+  `data:image/svg+xml;base64,${btoa(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" data-n="${n}"/>`
+  )}`;
+
+/** A URL that cannot resolve, so the browser fires `error` and the shot goes broken. */
+const brokenShot = (n: number) => `https://cdn.invalid.example/missing-${n}.png`;
+
+const CAPTIONS = ['Shot one', 'Shot two', 'Shot three', 'Shot four', 'Shot five'];
+
+/** `n` loadable screenshots, each with its own caption and its own URL. */
+const okShots = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    url: okShot(i),
+    caption: CAPTIONS[i] ?? `Shot ${i + 1}`,
+  }));
+
+function base(over: Partial<ListingDetail>): ListingDetail {
+  return {
+    id: 'l1',
+    serialId: 1,
+    slug: 'my-app',
+    kind: 'onsite',
+    collaborators: [],
+    name: 'My App',
+    tagline: 'A handy app',
+    description: null,
+    category: 'utility',
+    contentRating: null,
+    iconUrl: null,
+    coverUrl: null,
+    // `null` deliberately — a creator mounts `SmartCreatorCard`, a live tRPC surface
+    // with its own child graph, none of which this file is about.
+    creator: null,
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    installCount: 4213,
+    updatedAt: '2026-03-04T05:06:07.000Z',
+    screenshots: [],
+    kindData: {
+      kind: 'onsite',
+      appBlockId: 'blk-1',
+      hasPage: true,
+      liveUrl: 'https://my-app.civit.ai',
+    },
+    ...over,
+  };
+}
+
+async function renderBody(detail: ListingDetail) {
+  const { container } = await renderWithProviders(<AppListingDetailBody detail={detail} />);
+  const within = page.elementLocator(container);
+  await expect.element(within.getByText('My App')).toBeInTheDocument();
+  return { container, within };
+}
+
+/**
+ * The tiles CURRENTLY rendered, in document order.
+ *
+ * 🔴 Read live from the DOM on every call rather than captured once: a tile removes
+ * itself when its image 404s, so a list captured before that settles is a list of
+ * elements some of which are no longer in the document.
+ */
+const tiles = (container: HTMLElement) =>
+  Array.from(
+    container.querySelectorAll<HTMLElement>('[data-testid="apps-listing-screenshot-tile"]')
+  );
+
+/** The viewer's modal, or null when it is closed. It renders in a PORTAL, not in `container`. */
+const viewer = () => document.querySelector<HTMLElement>('[role="dialog"][aria-modal="true"]');
+
+/** The `<img>` the viewer is displaying, read from the document (portal again). */
+const viewerImage = () =>
+  document.querySelector<HTMLImageElement>('[data-testid="apps-listing-screenshot-viewer-image"]');
+
+const viewerPositionText = () =>
+  document
+    .querySelector('[data-testid="apps-listing-screenshot-position"]')
+    ?.textContent?.replace(/\s+/g, ' ')
+    .trim() ?? null;
+
+const viewerCaptionText = () =>
+  document.querySelector('[data-testid="apps-listing-screenshot-caption"]')?.textContent ?? null;
+
+/** Wait until the viewer is showing the shot at `index` — asserted by its `src`. */
+async function expectShowing(index: number) {
+  await vi.waitFor(() => {
+    const img = viewerImage();
+    expect(img, `no viewer image while expecting shot ${index}`).not.toBeNull();
+    expect(img!.getAttribute('src')).toBe(okShot(index));
+  });
+}
+
+const prevButton = () => page.getByRole('button', { name: 'Previous screenshot' });
+const nextButton = () => page.getByRole('button', { name: 'Next screenshot' });
+
+describe('screenshot viewer — opening', () => {
+  /**
+   * 🔴 THE HEADLINE: THE TILE OPENS ITS OWN SHOT, NOT THE FIRST ONE.
+   *
+   * Tile 2 (the third) is chosen rather than tile 1, because index 1 is where an
+   * off-by-one and a correct answer can coincide: `0 + 1` and `1` are both plausible
+   * and only one of the two arrows distinguishes them. From index 2 the four
+   * candidate mutants — always-0, index±1, and the mirrored `count - index - 1`
+   * (which is 2 for a 5-shot list, so the fixture is FIVE long and the tile is the
+   * THIRD, giving `5 - 2 - 1 = 2`… deliberately equal, and therefore excluded by the
+   * SECOND assertion below, which opens tile 3 where the mirror gives 1).
+   */
+  test('clicking tile N opens the viewer on shot N', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+    expect(tiles(container)).toHaveLength(5);
+
+    await userEvent.click(tiles(container)[2]);
+    await expectShowing(2);
+    expect(viewerCaptionText()).toBe('Shot three');
+    expect(viewerPositionText()).toBe('3 / 5');
+  });
+
+  /**
+   * A SECOND opening point, on a different tile of the same listing, so no single
+   * arithmetic coincidence can satisfy both. (Together with the case above this is
+   * the two-measured-points rule: `2 → 2` and `3 → 3` share no wrong formula.)
+   */
+  test('a different tile opens a different shot — two measured points', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+
+    await userEvent.click(tiles(container)[3]);
+    await expectShowing(3);
+    expect(viewerCaptionText()).toBe('Shot four');
+    expect(viewerPositionText()).toBe('4 / 5');
+  });
+
+  test('the first tile opens the first shot', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+
+    await userEvent.click(tiles(container)[0]);
+    await expectShowing(0);
+    expect(viewerPositionText()).toBe('1 / 5');
+  });
+
+  /** Nothing is open before a click — so every assertion above is about the click. */
+  test('the viewer is closed until a tile is activated', async () => {
+    await renderBody(base({ screenshots: okShots(5) }));
+    expect(viewer()).toBeNull();
+    expect(viewerImage()).toBeNull();
+  });
+});
+
+describe('screenshot viewer — navigation', () => {
+  test('next advances by exactly one, and prev goes back by exactly one', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+    await userEvent.click(tiles(container)[1]);
+    await expectShowing(1);
+
+    await nextButton().click();
+    await expectShowing(2);
+    expect(viewerPositionText()).toBe('3 / 5');
+    expect(viewerCaptionText()).toBe('Shot three');
+
+    await nextButton().click();
+    await expectShowing(3);
+    expect(viewerPositionText()).toBe('4 / 5');
+
+    await prevButton().click();
+    await expectShowing(2);
+    expect(viewerPositionText()).toBe('3 / 5');
+  });
+
+  /**
+   * 🔴 THE BOUNDARY RULE IS **STOP, NOT WRAP** — decided in
+   * `appListingScreenshotNav.ts` and rendered as a DISABLED control, so the viewer
+   * never offers a move it will not make. Both ends are measured; one end alone
+   * cannot tell "stops at the last" from "stops everywhere".
+   */
+  test('at the LAST shot, next is disabled and prev still works', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+    await userEvent.click(tiles(container)[4]);
+    await expectShowing(4);
+    expect(viewerPositionText()).toBe('5 / 5');
+
+    await expect.element(nextButton()).toBeDisabled();
+    await expect.element(prevButton()).toBeEnabled();
+
+    // …and pressing the key the disabled control mirrors does not wrap either.
+    await userEvent.keyboard('{ArrowRight}');
+    await expectShowing(4);
+  });
+
+  test('at the FIRST shot, prev is disabled and next still works', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+    await userEvent.click(tiles(container)[0]);
+    await expectShowing(0);
+
+    await expect.element(prevButton()).toBeDisabled();
+    await expect.element(nextButton()).toBeEnabled();
+
+    await userEvent.keyboard('{ArrowLeft}');
+    await expectShowing(0);
+  });
+
+  /**
+   * 🔴 ARROW KEYS, AND THE DIRECTIONS ARE ASSERTED SEPARATELY. A single "arrows
+   * navigate" test is satisfied by a swapped pair; landing on 3 after Right and back
+   * on 2 after Left is not.
+   */
+  test('ArrowRight and ArrowLeft move the viewer in their own directions', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+    await userEvent.click(tiles(container)[2]);
+    await expectShowing(2);
+
+    await userEvent.keyboard('{ArrowRight}');
+    await expectShowing(3);
+    expect(viewerPositionText()).toBe('4 / 5');
+
+    await userEvent.keyboard('{ArrowLeft}');
+    await expectShowing(2);
+
+    await userEvent.keyboard('{ArrowLeft}');
+    await expectShowing(1);
+    expect(viewerPositionText()).toBe('2 / 5');
+  });
+
+  /**
+   * A one-screenshot listing offers NO navigation. It is still a viewer — it opens,
+   * shows the shot, its caption and `1 / 1` — but both controls are dead, which is
+   * the honest rendering of "there is nothing either way".
+   */
+  test('a listing with exactly ONE screenshot offers no navigation', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(1) }));
+    expect(tiles(container)).toHaveLength(1);
+
+    await userEvent.click(tiles(container)[0]);
+    await expectShowing(0);
+    expect(viewerPositionText()).toBe('1 / 1');
+    expect(viewerCaptionText()).toBe('Shot one');
+
+    await expect.element(prevButton()).toBeDisabled();
+    await expect.element(nextButton()).toBeDisabled();
+
+    // Neither key moves it, and neither closes it.
+    await userEvent.keyboard('{ArrowRight}');
+    await userEvent.keyboard('{ArrowLeft}');
+    await expectShowing(0);
+  });
+
+  /**
+   * 🔴 ZERO SCREENSHOTS — there is no gallery at all, so there is nothing to open and
+   * no viewer mounted. This is the invariant the existing gallery suite also pins
+   * (the section is hidden), restated here as "and therefore no dialog exists": a
+   * viewer that mounted for an empty listing would be an empty modal one stray key
+   * away.
+   */
+  test('a listing with ZERO screenshots renders no gallery and no viewer', async () => {
+    const { container, within } = await renderBody(base({ screenshots: [] }));
+    expect(container.querySelectorAll('[data-testid="apps-listing-screenshot-grid"]')).toHaveLength(
+      0
+    );
+    expect(tiles(container)).toHaveLength(0);
+    expect(within.getByText('Screenshots').elements()).toHaveLength(0);
+    expect(viewer()).toBeNull();
+
+    // The arrow keys are bound only while the viewer is open, so they must be inert
+    // here — a global binding would fight the page behind it.
+    await userEvent.keyboard('{ArrowRight}');
+    expect(viewer()).toBeNull();
+  });
+});
+
+describe('screenshot viewer — closing', () => {
+  test('Escape closes the viewer', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+    await userEvent.click(tiles(container)[2]);
+    await expectShowing(2);
+
+    await userEvent.keyboard('{Escape}');
+    await vi.waitFor(() => expect(viewer()).toBeNull());
+  });
+
+  test('the close button closes the viewer', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+    await userEvent.click(tiles(container)[1]);
+    await expectShowing(1);
+
+    await page.getByRole('button', { name: 'Close screenshot viewer' }).click();
+    await vi.waitFor(() => expect(viewer()).toBeNull());
+  });
+});
+
+describe('screenshot viewer — accessibility', () => {
+  /**
+   * 🔴 THE TILE IS A REAL BUTTON, ASSERTED STRUCTURALLY. `role="button"` on the
+   * ELEMENT (not a `getByRole` query that a `role` attribute on a `<div>` would also
+   * satisfy) plus the tag name, because "keyboard-activatable" is a property of the
+   * element the browser gives you for free, and of nothing else.
+   */
+  test('each tile is a keyboard-activatable <button> with the caption in its name', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(3) }));
+    const all = tiles(container);
+    expect(all).toHaveLength(3);
+    for (const tile of all) expect(tile.tagName).toBe('BUTTON');
+
+    // The accessible name is COMPUTED FROM CONTENT (image alt + caption), never an
+    // aria-label that would strip the visible caption (WCAG 2.5.3).
+    const third = all[2];
+    expect(third.textContent).toContain('Shot three');
+    expect(third.querySelector('img')?.getAttribute('alt')).toBe('Shot three');
+  });
+
+  test('a tile opens the viewer from the keyboard alone', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+    const tile = tiles(container)[3];
+
+    tile.focus();
+    expect(document.activeElement).toBe(tile);
+    await userEvent.keyboard('{Enter}');
+
+    await expectShowing(3);
+  });
+
+  /** The dialog is labelled and marked modal — the two things a screen reader needs. */
+  test('the dialog is modal and carries an accessible name', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+    await userEvent.click(tiles(container)[0]);
+    await expectShowing(0);
+
+    const dialog = viewer();
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute('aria-modal')).toBe('true');
+
+    // `aria-labelledby` must resolve to real text, not merely be present — a label
+    // pointing at a missing id is worse than no label.
+    const labelledBy = dialog!.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)?.textContent).toBe('My App screenshots');
+  });
+
+  test('focus moves INTO the dialog when it opens', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+    await userEvent.click(tiles(container)[1]);
+    await expectShowing(1);
+
+    const dialog = viewer()!;
+    await vi.waitFor(() => {
+      expect(document.activeElement).not.toBe(document.body);
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+  });
+
+  /**
+   * 🔴 FOCUS RETURNS TO THE TILE THAT OPENED IT — to that tile, not to "some tile".
+   * The listing has five, and the one opened is the fourth, so a restore that
+   * defaulted to the first or to the gallery container fails here.
+   */
+  test('focus returns to the ORIGINATING tile on close', async () => {
+    const { container } = await renderBody(base({ screenshots: okShots(5) }));
+    const opener = tiles(container)[3];
+
+    await userEvent.click(opener);
+    await expectShowing(3);
+    // Control: focus really did leave the tile, so the assertion after the close is
+    // about a restore and not about focus that never moved.
+    await vi.waitFor(() => expect(document.activeElement).not.toBe(opener));
+
+    await userEvent.keyboard('{Escape}');
+    await vi.waitFor(() => expect(viewer()).toBeNull());
+    await vi.waitFor(() => expect(document.activeElement).toBe(opener));
+  });
+});
+
+describe('screenshot viewer — broken screenshots', () => {
+  /**
+   * 🔴 THE INDEX-SPACE TEST, AND THE ONE THIS FEATURE IS MOST LIKELY TO GET WRONG.
+   *
+   * Five screenshots go in; the FIRST one 404s, so the grid ends up with four tiles.
+   * The tile a viewer now sees third is shot index 3, NOT index 2 — and the viewer
+   * must open on 3. A viewer keyed on the tile's POSITION in the rendered grid would
+   * open on shot 2 here, and would be indistinguishable from correct on any listing
+   * with no broken art, which is every listing anyone checks by hand.
+   *
+   * 🔴 THE BROKEN SHOT IS THE **FIRST** ONE, AND THAT IS A CORRECTION, NOT A STYLE
+   * CHOICE. This test originally broke shot index 1, and MEASURED AS VACUOUS: the
+   * renumbering mutant (grid position used as the viewer index) SURVIVED it. With
+   * shot 1 broken, a renumbered click on the second visible tile resolves to index 1
+   * — which is the broken shot — so the viewer's own rescue effect skipped forward to
+   * index 2 and produced the correct answer for the wrong reason. Breaking shot 0
+   * shifts every later index by one onto a VIABLE shot, so the rescue cannot launder
+   * the mistake and the mutant dies. Do not "simplify" the fixture back.
+   *
+   * The `data-screenshot-index` assertion is the direct form of the same claim: the
+   * tile states which shot it represents, and under the renumbering mutant it states
+   * `2` where the correct value is `3`. The `alt` list is the positive control that
+   * the first tile really rendered and then removed itself — `Shot one` is present in
+   * the fixture and absent from the DOM.
+   */
+  test('a broken screenshot does not shift the index the surviving tiles open', async () => {
+    const shots = okShots(5);
+    shots[0] = { url: brokenShot(0), caption: 'Shot one' };
+    const { container } = await renderBody(base({ screenshots: shots }));
+
+    await vi.waitFor(() => expect(tiles(container)).toHaveLength(4));
+    expect(tiles(container).map((t) => t.querySelector('img')?.getAttribute('alt'))).toEqual([
+      'Shot two',
+      'Shot three',
+      'Shot four',
+      'Shot five',
+    ]);
+
+    // The tile now THIRD in the grid represents shot index 3 — as a DOM fact…
+    expect(tiles(container).map((t) => t.dataset.screenshotIndex)).toEqual(['1', '2', '3', '4']);
+    // …and as behaviour.
+    await userEvent.click(tiles(container)[2]);
+    await expectShowing(3);
+    expect(viewerCaptionText()).toBe('Shot four');
+  });
+
+  /**
+   * 🔴 AND THE COUNTER COUNTS WHAT NAVIGATION CAN REACH. With one of five broken the
+   * indicator reads `3 / 4`, not `4 / 5`: a total that included the broken shot would
+   * promise a screenshot prev/next can never land on. The broken shot is the first
+   * one for the same reason as the test above — see its header.
+   */
+  test('the position indicator excludes broken screenshots from BOTH numbers', async () => {
+    const shots = okShots(5);
+    shots[0] = { url: brokenShot(0), caption: 'Shot one' };
+    const { container } = await renderBody(base({ screenshots: shots }));
+    await vi.waitFor(() => expect(tiles(container)).toHaveLength(4));
+
+    await userEvent.click(tiles(container)[2]); // shot index 3, viable position 3
+    await expectShowing(3);
+    expect(viewerPositionText()).toBe('3 / 4');
+  });
+
+  /**
+   * 🔴 NAVIGATION SKIPS THE BROKEN SHOT RATHER THAN LANDING ON IT. Shot 1 is broken,
+   * so stepping back from shot 2 must reach shot 0 — a TWO-place move that a "step
+   * by one" implementation cannot produce, and that a "skip exactly one broken" and a
+   * "skip until viable" implementation agree on… which is why the second half of this
+   * test uses a RUN of two broken shots, where they disagree.
+   */
+  test('prev/next skip over broken screenshots, including a run of them', async () => {
+    const shots = okShots(5);
+    shots[1] = { url: brokenShot(1), caption: 'Shot two' };
+    const { container } = await renderBody(base({ screenshots: shots }));
+    await vi.waitFor(() => expect(tiles(container)).toHaveLength(4));
+
+    await userEvent.click(tiles(container)[1]); // shot 2
+    await expectShowing(2);
+    await prevButton().click();
+    await expectShowing(0); // skipped 1
+    expect(viewerPositionText()).toBe('1 / 4');
+    // Forward again lands back on 2, not on the broken 1.
+    await nextButton().click();
+    await expectShowing(2);
+
+    await userEvent.keyboard('{Escape}');
+    await vi.waitFor(() => expect(viewer()).toBeNull());
+  });
+
+  test('a RUN of broken screenshots is skipped in one move', async () => {
+    const shots = okShots(5);
+    shots[1] = { url: brokenShot(1), caption: 'Shot two' };
+    shots[2] = { url: brokenShot(2), caption: 'Shot three' };
+    const { container } = await renderBody(base({ screenshots: shots }));
+    await vi.waitFor(() => expect(tiles(container)).toHaveLength(3));
+
+    await userEvent.click(tiles(container)[0]); // shot 0
+    await expectShowing(0);
+    expect(viewerPositionText()).toBe('1 / 3');
+
+    await nextButton().click();
+    await expectShowing(3); // skipped BOTH 1 and 2
+    expect(viewerPositionText()).toBe('2 / 3');
+  });
+
+  /**
+   * 🔴 A TRAILING RUN OF BROKEN SHOTS MEANS THE LAST VIABLE SHOT REALLY IS THE END —
+   * and this is the ONE browser case that can see a navigation which does not skip.
+   *
+   * MEASURED, not assumed. A mutant replacing the skip loop with a bare `index ± 1`
+   * SURVIVED every other broken-shot test in this file, because the viewer's own
+   * rescue effect moves off the broken index it lands on and arrives at the same
+   * answer by a different route. The rescue cannot launder THIS case: with 3 and 4
+   * broken, correct code reports "nothing after shot 2" and DISABLES the control,
+   * while the unskipping mutant offers shot 3 and leaves it enabled. A disabled
+   * button is a state no rescue can reach after the fact.
+   *
+   * (The same mutant is also killed outright in the blocking node project — see
+   * `appListingScreenshotNav.test.ts`. This is the browser half of that claim.)
+   *
+   * 🔴 THE FIXTURE IS TWO SHOTS, AND THAT IS A MEASURED CONSTRAINT RATHER THAN
+   * MINIMALISM. Two earlier drafts — five shots with the last two broken, then three
+   * with the last one broken — each PASSED IN ISOLATION AND FAILED IN THE FULL-FILE
+   * RUN, on the tile count: the broken tile never fired `error`, because tiles are
+   * `loading="lazy"` and a tile below the first grid row is only FETCHED when Chrome's
+   * distance-from-viewport heuristic says so — which is not a constant, and which
+   * earlier tests in the file can move (a Mantine `Modal` locks body scroll while it
+   * is open). Substituting a fresh URL ruled out negative caching; the row did. That
+   * lazy behaviour is real page behaviour, and it is exactly why the viewer carries a
+   * rescue effect — but it makes any below-the-fold dangling URL a non-deterministic
+   * fixture. **Every broken-shot fixture in this file keeps its dangling URL in the
+   * first grid row**, which for a two-track grid means index 0 or 1.
+   *
+   * The lost "the other direction is still live" control lives at suite level instead:
+   * `at the FIRST shot, prev is disabled and next still works` shows the same viewer
+   * rendering an ENABLED next from index 0 when nothing is broken, so the disabled
+   * assertion below is about the trailing broken shot and not about a dead control.
+   */
+  test('a TRAILING run of broken screenshots ends the navigation', async () => {
+    const shots = okShots(2);
+    shots[1] = { url: brokenShot(92), caption: 'Shot two' };
+    const { container } = await renderBody(base({ screenshots: shots }));
+    await vi.waitFor(() => expect(tiles(container)).toHaveLength(1));
+
+    await userEvent.click(tiles(container)[0]); // shot 0 — the ONLY viable one
+    await expectShowing(0);
+    expect(viewerPositionText()).toBe('1 / 1');
+
+    // 🔴 The listing HAS a second screenshot; it just cannot be shown. So the control
+    // that would carry the viewer to it must be dead — an enabled "Next" here is an
+    // offer to navigate onto a blank frame.
+    await expect.element(nextButton()).toBeDisabled();
+
+    // …and the key mirrors the control rather than reaching the broken shot.
+    await userEvent.keyboard('{ArrowRight}');
+    await expectShowing(0);
+  });
+
+  /**
+   * 🔴 A LISTING WHOSE SCREENSHOTS ALL 404 LOSES ITS GRID BUT KEEPS ITS SECTION —
+   * exactly the pre-existing behaviour (the tiles hide themselves; the `Screenshots`
+   * heading stays) — and, the new part, there is still no dialog to open.
+   */
+  test('every screenshot broken — no tiles remain and nothing can be opened', async () => {
+    const { container } = await renderBody(
+      base({
+        screenshots: [
+          { url: brokenShot(1), caption: 'Shot one' },
+          { url: brokenShot(2), caption: 'Shot two' },
+        ],
+      })
+    );
+    await vi.waitFor(() => expect(tiles(container)).toHaveLength(0));
+    expect(viewer()).toBeNull();
+    await userEvent.keyboard('{ArrowRight}');
+    expect(viewer()).toBeNull();
+  });
+});

--- a/src/components/Apps/AppListingScreenshotViewer.tsx
+++ b/src/components/Apps/AppListingScreenshotViewer.tsx
@@ -2,6 +2,7 @@ import { ActionIcon, Modal, Text, Tooltip } from '@mantine/core';
 import { useHotkeys } from '@mantine/hooks';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import { useEffect } from 'react';
+import { useOpenerFocusReturn } from '~/components/Apps/useOpenerFocusReturn';
 import {
   adjacentViableIndex,
   viewerPosition,
@@ -26,22 +27,35 @@ import type { ListingGalleryScreenshot } from '~/server/schema/blocks/app-listin
  *     supplies, for free and correctly, every a11y requirement this feature has:
  *     `role="dialog"` + `aria-modal="true"` + `aria-labelledby` wired to the `title`
  *     (`ModalBaseContent.mjs:41-43`), `trapFocus` (focus moves INTO the dialog on
- *     open), `closeOnEscape`, and `returnFocus` — all defaulting to `true`
- *     (`Modal.mjs:26-37`). None of it is hand-rolled here.
- *   - **The full-screen media chrome** — `fullScreen` + `withOverlay={false}` + the
- *     `styles={{ inner, content, body }}` block — is taken from
- *     `TrainingSampleViewer` / `GeneratedOutputLightbox` / `Model3DLightbox`, the
- *     three existing lightboxes, which set those three keys identically. It is the
- *     repo's de-facto full-screen-media convention; it has simply never been
- *     extracted. 🔴 THIS VIEWER DIVERGES IN ONE KEY, DELIBERATELY: all three also set
- *     `header: { position: 'absolute', right: 0, zIndex: 10 }` and this one does not,
- *     because none of them renders a `title` — their header holds a close button and
- *     nothing else, so lifting it out of the flow buys the media its full height. This
- *     viewer's header carries the dialog's visible label, which has to stay readable
- *     and in flow; absolute-positioning it would float the listing's name over the
- *     screenshot. (An earlier version of this bullet said the block was "copied
- *     verbatim" and that all three "share it identically" — the rendering was right,
- *     the claim was not.)
+ *     open) and `closeOnEscape` — both defaulting to `true` (`Modal.mjs:26-37`).
+ *     🔴 `returnFocus` IS THE EXCEPTION, and this bullet used to claim otherwise:
+ *     it is switched OFF here and replaced by `useOpenerFocusReturn`, because inside
+ *     the `Modal.Stack` this viewer joins, Mantine's version captures the wrong
+ *     element (see that hook's header). Everything else on this list really is
+ *     Mantine's.
+ *   - **The full-screen media chrome** — `fullScreen` + `withOverlay={false}` + a
+ *     `styles` block — follows the three existing lightboxes: `TrainingSampleViewer`
+ *     (`:206-211`), `GeneratedOutputLightbox` (`:100-105`) and `Model3DLightbox`
+ *     (`:37-42`). 🔴 MEASURED KEY BY KEY, because two earlier versions of this bullet
+ *     described it wrongly:
+ *       · `inner` — identical in all three, and here: `{ position: 'absolute' }`.
+ *       · `content` — identical in all three, and here:
+ *         `{ display:'flex', flexDirection:'column', overflow:'hidden' }`.
+ *       · `header` — identical in all three (`{ position:'absolute', right:0,
+ *         zIndex:10 }`) and DELIBERATELY ABSENT here. None of them renders a `title`,
+ *         so their header holds only a close button and lifting it out of the flow
+ *         buys the media its full height. This viewer's header carries the dialog's
+ *         visible label, which must stay readable and in flow; absolute-positioning it
+ *         would float the listing's name over the screenshot.
+ *       · `body` — the three do NOT agree. `TrainingSampleViewer` uses
+ *         `{ flex:1, minHeight:0, display:'flex', flexDirection:'column', padding:16 }`;
+ *         the other two use `{ flex:1, minHeight:0, overflow:'hidden', padding:16 }`.
+ *         This viewer matches `TrainingSampleViewer` — ONE of the three, not all —
+ *         because like it, this one stacks an indicator, the media and a caption
+ *         vertically rather than filling the body with a single element.
+ *     (History, since it is the point: round 1 of review caught an overclaim about
+ *     `header`; the narrowed rewrite was still wrong, on `body`. This version was
+ *     measured against all three files rather than reasoned about.)
  *   - **`useHotkeys` from `@mantine/hooks`** for the arrow keys — the convention at
  *     every arrow-nav site in the repo (`TrainingSampleViewer.tsx:154`,
  *     `GeneratedOutputLightbox.tsx:32`, `ImageDetailProvider`). There is no shared
@@ -114,6 +128,14 @@ export function AppListingScreenshotViewer({
   onClose,
 }: AppListingScreenshotViewerProps) {
   const opened = index !== null;
+
+  // 🔴 Focus return is OURS, not Mantine's — see `useOpenerFocusReturn`. Inside the
+  // `Modal.Stack` this viewer joins, Mantine's `returnFocus` captures the wrong
+  // element (the stack flips `trapFocus` while the modal is open, which re-arms its
+  // capture). Measured: nested, Esc landed focus on the review modal's chrome
+  // instead of the tile. `returnFocus={false}` below turns Mantine's off so there is
+  // exactly one owner — measured as a convention, not as a second load-bearing half.
+  useOpenerFocusReturn(opened);
   const viable = index !== null && !broken.has(index) && !!shots[index];
   const shot = viable && index !== null ? shots[index] : undefined;
 
@@ -176,6 +198,7 @@ export function AppListingScreenshotViewer({
       opened={opened}
       onClose={onClose}
       fullScreen
+      returnFocus={false}
       withOverlay={false}
       // 🔴 STACK MEMBERSHIP — this is what stops ONE Escape closing this viewer AND
       // whatever dialog it is nested inside. `preview` renders this body inside the
@@ -207,17 +230,12 @@ export function AppListingScreenshotViewer({
       // the body, which is where a screen reader will read it in document order.
       title={`${name} screenshots`}
       closeButtonProps={{ 'aria-label': 'Close screenshot viewer' }}
-      // 🔴 The full-screen media chrome, adapted from the three existing lightboxes
-      // (`TrainingSampleViewer`, `GeneratedOutputLightbox`, `Model3DLightbox`), which
-      // all three set `inner` / `content` / `body` exactly as below. They ALSO set
-      // `header: { position: 'absolute', right: 0, zIndex: 10 }`, and this one
-      // deliberately does not: that rule lifts a header containing nothing but a close
-      // button out of the flow so the media can use the full height. This viewer
-      // renders a `title`, so its header carries text that has to stay readable and in
-      // flow — an absolute header would overlap the image with the listing's name.
-      // (An earlier version of this comment claimed the block was "copied verbatim"
-      // and that all three "share it identically". The rendering is right; the claim
-      // was not.)
+      // 🔴 The full-screen media chrome. `inner` and `content` are identical across
+      // all three existing lightboxes; `body` matches `TrainingSampleViewer` only (the
+      // other two use `overflow:'hidden'` in place of the flex column); and `header` is
+      // omitted on purpose because this viewer, unlike all three, renders a `title`.
+      // Key-by-key measurement and the reasoning are in this file's header — read it
+      // before "aligning" this block with a sibling lightbox.
       styles={{
         inner: { position: 'absolute' },
         content: { display: 'flex', flexDirection: 'column', overflow: 'hidden' },

--- a/src/components/Apps/AppListingScreenshotViewer.tsx
+++ b/src/components/Apps/AppListingScreenshotViewer.tsx
@@ -1,0 +1,278 @@
+import { ActionIcon, Center, Group, Modal, Text, Tooltip } from '@mantine/core';
+import { useHotkeys } from '@mantine/hooks';
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import { useEffect } from 'react';
+import {
+  adjacentViableIndex,
+  viewerPosition,
+  type BrokenScreenshotIndexes,
+} from '~/components/Apps/appListingScreenshotNav';
+import type { ListingGalleryScreenshot } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * App Store listing — the full-size SCREENSHOT VIEWER.
+ *
+ * Opened by clicking (or Entering / Spacing) a tile in `ScreenshotGallery`
+ * (`AppListingDetailBody.tsx`). Shows that shot full-screen with prev/next controls,
+ * ArrowLeft/ArrowRight, Esc-to-close, the shot's caption and a `3 / 7` position
+ * indicator.
+ *
+ * 🔴 WHAT THIS REUSES, AND WHAT IT DELIBERATELY DOES NOT — the survey is part of the
+ * change, so it is written down here rather than only in the PR:
+ *
+ *   - **Mantine `Modal`, CONTROLLED (`opened` / `onClose`)** — the repo's modal base
+ *     everywhere, and specifically the shape `AppDetailsModal` (this same directory,
+ *     the component whose SimpleGrid the gallery was copied from) already uses. It
+ *     supplies, for free and correctly, every a11y requirement this feature has:
+ *     `role="dialog"` + `aria-modal="true"` + `aria-labelledby` wired to the `title`
+ *     (`ModalBaseContent.mjs:41-43`), `trapFocus` (focus moves INTO the dialog on
+ *     open), `closeOnEscape`, and `returnFocus` — all defaulting to `true`
+ *     (`Modal.mjs:26-37`). None of it is hand-rolled here.
+ *   - **The full-screen media chrome** — `fullScreen` + `withOverlay={false}` + the
+ *     `styles={{ inner, content, header, body }}` block — is copied verbatim from
+ *     `TrainingSampleViewer` / `GeneratedOutputLightbox` / `Model3DLightbox`, which
+ *     are the three existing lightboxes and share it identically. It is the repo's
+ *     de-facto full-screen-media convention; it has simply never been extracted.
+ *   - **`useHotkeys` from `@mantine/hooks`** for the arrow keys — the convention at
+ *     every arrow-nav site in the repo (`TrainingSampleViewer.tsx:154`,
+ *     `GeneratedOutputLightbox.tsx:32`, `ImageDetailProvider`). There is no shared
+ *     arrow-nav hook to reuse; this is the pattern instead of one.
+ *   - **The skip-missing navigation, the "N of M" counter that counts only what is
+ *     actually reachable, and the disabled-at-the-ends arrow buttons** are
+ *     `TrainingSampleViewer`'s design, ported (its `findSampleInEpoch` /
+ *     `navigableCount` / `navigablePosition` / `NavButton`). That component is the
+ *     closest existing thing to this one: it is the only viewer in the repo that
+ *     navigates over PLAIN URL STRINGS rather than a civitai `Image` entity.
+ *
+ *   REJECTED, each for a stated reason rather than by omission:
+ *   - `dialogStore` + `DialogProvider` (the app's dialog stack, and already imported
+ *     by `AppListingComments` on this very page). Two disqualifiers, both structural.
+ *     (a) Props are a SNAPSHOT taken at `trigger()` time and the dialog renders
+ *     outside this component's tree, so the viewer could not share the gallery's live
+ *     broken-tile set — and keeping those two in step is the whole index-consistency
+ *     requirement. (b) `DialogProviderInner` closes by REMOVING the dialog from the
+ *     store, so the modal UNMOUNTS rather than toggling `opened` to `false`; Mantine's
+ *     `useFocusReturn` restores focus from a `useDidUpdate` on `[opened]` and clears
+ *     its own timeout in the unmount cleanup (`use-focus-return.mjs:12-28`), so
+ *     `returnFocus` provably cannot fire on that path and focus return would have to
+ *     be hand-rolled as a deferred `.focus()`. A controlled `Modal` keeps the
+ *     component mounted, so the built-in does the work.
+ *   - `Embla` (`EmblaCarousel.tsx`), the carousel `GeneratedOutputLightbox` uses.
+ *     Embla derives its snap points from MEASURED slide geometry, which here comes
+ *     from Tailwind utility classes (`flex-[0_0_100%]`) — and the browser-mode
+ *     `component` project loads no stylesheet at all, so `scrollNext()` would resolve
+ *     to a single snap point and every prev/next test would pass while measuring
+ *     nothing. A carousel is also the wrong instrument: a listing has a handful of
+ *     static screenshots, no swipe requirement and a hard need for an exact index.
+ *   - `ImageDetailByProps`, `Bounty/ImageCarousel`, `ImageViewer` — all three are
+ *     keyed on a civitai `Image` ENTITY (a numeric `id`, `nsfwLevel`, `meta`) and
+ *     pull a live tRPC query, `ImageGuard2` and browsing-level providers. A listing
+ *     screenshot is a bare `{ url, caption }` from an allowlist DTO; there is no id
+ *     to hand them.
+ *   - `next/image` — the URLs are CDN edge URLs, not configured Next image domains.
+ *     Plain `<img>`, exactly as the tile and `AppDetailsModal` already do. (There is
+ *     zero `next/image` usage anywhere in `src/components/Apps/`.)
+ *
+ * 🔴 INDEX SPACE + BROKEN-SHOT RULES live in `appListingScreenshotNav.ts` and are
+ * pinned in the BLOCKING node project. Read that module's header before changing
+ * anything here; the summary is: one index space (the URL-filtered list, shared with
+ * the grid), navigation SKIPS broken shots and STOPS at the ends, and the counter
+ * counts only what navigation can reach.
+ */
+
+/** A dangling screenshot the viewer landed on has nothing to show — see `useEffect`. */
+export interface AppListingScreenshotViewerProps {
+  /** The URL-filtered screenshot list. Index space for `index` and `broken`. */
+  shots: ListingGalleryScreenshot[];
+  /** The listing name, for the dialog label and the image `alt` fallback. */
+  name: string;
+  /** Indices whose image has failed to load — owned by the gallery, shared with it. */
+  broken: BrokenScreenshotIndexes;
+  /** The shot on display, or `null` when the viewer is closed. */
+  index: number | null;
+  onIndexChange: (index: number) => void;
+  onBroken: (index: number) => void;
+  onClose: () => void;
+}
+
+export function AppListingScreenshotViewer({
+  shots,
+  name,
+  broken,
+  index,
+  onIndexChange,
+  onBroken,
+  onClose,
+}: AppListingScreenshotViewerProps) {
+  const opened = index !== null;
+  const viable = index !== null && !broken.has(index) && !!shots[index];
+  const shot = viable && index !== null ? shots[index] : undefined;
+
+  const prevIndex =
+    index === null ? undefined : adjacentViableIndex(index, -1, shots.length, broken);
+  const nextIndex =
+    index === null ? undefined : adjacentViableIndex(index, 1, shots.length, broken);
+  const { position, total } = viewerPosition(index ?? -1, shots.length, broken);
+
+  /**
+   * 🔴 THE RESCUE. The viewer must never be an empty frame, and it can land on one
+   * two ways: the shot it is showing 404s WHILE OPEN (tiles are `loading="lazy"`, so
+   * a dangling URL below the fold is only discovered when the viewer fetches it), or
+   * the listing's screenshot array changes under it. Either way it moves to the
+   * nearest reachable shot — FORWARD first, because that is the direction the viewer
+   * was reading — and closes when there is none left, rather than sitting on an
+   * error placeholder with a position indicator that cannot be true.
+   *
+   * Written as an effect, not inside the error handler, so BOTH causes are covered by
+   * one rule: `onBroken` only knows about the first.
+   */
+  useEffect(() => {
+    if (index === null || viable) return;
+    const rescue =
+      adjacentViableIndex(index, 1, shots.length, broken) ??
+      adjacentViableIndex(index, -1, shots.length, broken);
+    if (rescue === undefined) onClose();
+    else onIndexChange(rescue);
+  }, [index, viable, shots, broken, onClose, onIndexChange]);
+
+  /**
+   * Arrow keys, bound only while OPEN — an empty binding list when closed, so the
+   * viewer never eats an arrow key belonging to the page behind it (this listing page
+   * carries a comment box and a review form). Mantine's `useHotkeys` already declines
+   * to fire inside `input` / `textarea` / `select`; this is the second, coarser guard.
+   *
+   * `preventDefault` only when the move is actually available, so at a boundary the
+   * arrow key still does whatever it would normally do (scroll) rather than being
+   * swallowed by a control that declined to act.
+   */
+  useHotkeys(
+    opened
+      ? [
+          [
+            'ArrowLeft',
+            () => prevIndex !== undefined && onIndexChange(prevIndex),
+            { preventDefault: prevIndex !== undefined },
+          ],
+          [
+            'ArrowRight',
+            () => nextIndex !== undefined && onIndexChange(nextIndex),
+            { preventDefault: nextIndex !== undefined },
+          ],
+        ]
+      : []
+  );
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      fullScreen
+      withOverlay={false}
+      // Labels the dialog (Mantine renders it as the `aria-labelledby` target). Kept
+      // to the LISTING rather than the caption so the dialog's accessible name is
+      // stable across navigation — a name that changes under the user is a worse
+      // label than a general one. The per-shot detail is the caption + indicator in
+      // the body, which is where a screen reader will read it in document order.
+      title={`${name} screenshots`}
+      closeButtonProps={{ 'aria-label': 'Close screenshot viewer' }}
+      // The full-screen media chrome shared by every lightbox in the repo.
+      styles={{
+        inner: { position: 'absolute' },
+        content: { display: 'flex', flexDirection: 'column', overflow: 'hidden' },
+        body: { flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', padding: 16 },
+      }}
+    >
+      <Group justify="space-between" wrap="nowrap" mb="xs">
+        <Text size="sm" c="dimmed" data-testid="apps-listing-screenshot-position">
+          {position} / {total}
+        </Text>
+      </Group>
+
+      <div className="relative flex min-h-0 flex-1 items-center justify-center">
+        {shot && index !== null && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            // Keyed by index so navigating swaps the ELEMENT rather than mutating one
+            // `src`. Without it a browser keeps painting the previous shot until the
+            // new one decodes, and — worse — a stale `error` from the outgoing URL
+            // would be attributed to the incoming index.
+            key={index}
+            src={shot.url}
+            alt={shot.caption ? shot.caption : `${name} screenshot ${index + 1}`}
+            data-testid="apps-listing-screenshot-viewer-image"
+            onError={() => onBroken(index)}
+            style={{ maxHeight: '100%', maxWidth: '100%', objectFit: 'contain' }}
+          />
+        )}
+        {!shot && (
+          // One frame at most: the rescue effect above runs immediately after.
+          <Center className="absolute inset-0">
+            <Text c="dimmed">Loading screenshot…</Text>
+          </Center>
+        )}
+
+        <NavButton
+          label="Previous screenshot"
+          disabled={prevIndex === undefined}
+          onClick={() => prevIndex !== undefined && onIndexChange(prevIndex)}
+          className="left-2 top-1/2 -translate-y-1/2"
+        >
+          <IconChevronLeft size={24} />
+        </NavButton>
+        <NavButton
+          label="Next screenshot"
+          disabled={nextIndex === undefined}
+          onClick={() => nextIndex !== undefined && onIndexChange(nextIndex)}
+          className="right-2 top-1/2 -translate-y-1/2"
+        >
+          <IconChevronRight size={24} />
+        </NavButton>
+      </div>
+
+      {/* The caption is rendered for every shot that HAS one, and the element is
+          absent otherwise — never an empty box holding a line of vertical space. */}
+      {shot?.caption && (
+        <Text size="sm" mt="xs" data-testid="apps-listing-screenshot-caption">
+          {shot.caption}
+        </Text>
+      )}
+    </Modal>
+  );
+}
+
+/**
+ * A round overlay arrow, ported from `TrainingSampleViewer`'s `NavButton`.
+ *
+ * `disabled` is the rendered form of `adjacentViableIndex` returning `undefined`, so
+ * "there is nothing that way" is visible rather than a click that silently no-ops.
+ */
+function NavButton({
+  label,
+  disabled,
+  onClick,
+  className,
+  children,
+}: {
+  label: string;
+  disabled: boolean;
+  onClick: () => void;
+  className: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip label={label} withArrow>
+      <ActionIcon
+        size="xl"
+        radius="xl"
+        variant="filled"
+        color="dark"
+        aria-label={label}
+        disabled={disabled}
+        onClick={onClick}
+        className={`absolute z-10 opacity-80 ${className}`}
+      >
+        {children}
+      </ActionIcon>
+    </Tooltip>
+  );
+}

--- a/src/components/Apps/AppListingScreenshotViewer.tsx
+++ b/src/components/Apps/AppListingScreenshotViewer.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Center, Group, Modal, Text, Tooltip } from '@mantine/core';
+import { ActionIcon, Modal, Text, Tooltip } from '@mantine/core';
 import { useHotkeys } from '@mantine/hooks';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import { useEffect } from 'react';
@@ -29,10 +29,19 @@ import type { ListingGalleryScreenshot } from '~/server/schema/blocks/app-listin
  *     open), `closeOnEscape`, and `returnFocus` — all defaulting to `true`
  *     (`Modal.mjs:26-37`). None of it is hand-rolled here.
  *   - **The full-screen media chrome** — `fullScreen` + `withOverlay={false}` + the
- *     `styles={{ inner, content, header, body }}` block — is copied verbatim from
- *     `TrainingSampleViewer` / `GeneratedOutputLightbox` / `Model3DLightbox`, which
- *     are the three existing lightboxes and share it identically. It is the repo's
- *     de-facto full-screen-media convention; it has simply never been extracted.
+ *     `styles={{ inner, content, body }}` block — is taken from
+ *     `TrainingSampleViewer` / `GeneratedOutputLightbox` / `Model3DLightbox`, the
+ *     three existing lightboxes, which set those three keys identically. It is the
+ *     repo's de-facto full-screen-media convention; it has simply never been
+ *     extracted. 🔴 THIS VIEWER DIVERGES IN ONE KEY, DELIBERATELY: all three also set
+ *     `header: { position: 'absolute', right: 0, zIndex: 10 }` and this one does not,
+ *     because none of them renders a `title` — their header holds a close button and
+ *     nothing else, so lifting it out of the flow buys the media its full height. This
+ *     viewer's header carries the dialog's visible label, which has to stay readable
+ *     and in flow; absolute-positioning it would float the listing's name over the
+ *     screenshot. (An earlier version of this bullet said the block was "copied
+ *     verbatim" and that all three "share it identically" — the rendering was right,
+ *     the claim was not.)
  *   - **`useHotkeys` from `@mantine/hooks`** for the arrow keys — the convention at
  *     every arrow-nav site in the repo (`TrainingSampleViewer.tsx:154`,
  *     `GeneratedOutputLightbox.tsx:32`, `ImageDetailProvider`). There is no shared
@@ -168,6 +177,29 @@ export function AppListingScreenshotViewer({
       onClose={onClose}
       fullScreen
       withOverlay={false}
+      // 🔴 STACK MEMBERSHIP — this is what stops ONE Escape closing this viewer AND
+      // whatever dialog it is nested inside. `preview` renders this body inside the
+      // moderator review `Modal` (`OffsiteReviewQueue`'s `OffsiteReviewModal`), and
+      // Mantine's Esc handling is a per-Modal `window` keydown listener in CAPTURE
+      // phase (`ModalBase/use-modal.mjs`), so by default every open Modal's handler
+      // fires for the same key: the moderator lost the rejection reason they were
+      // typing, and their place in the queue, by dismissing a lightbox.
+      //
+      // `Modal.Stack` is Mantine's answer and it gates rather than races —
+      // `closeOnEscape` and `trapFocus` become `ctx.currentId === stackId`
+      // (`Modal.mjs:53-57`), so only the top-most member responds. The ordering trick
+      // it replaces cannot work here: `useWindowEvent` deps are `[type, listener]` and
+      // Mantine passes a NEW inline arrow every render, so each Modal re-registers its
+      // listener on every render and "who runs first" is whatever rendered last.
+      //
+      // 🔴 It degrades cleanly where there is no stack. `stackProps` is applied only
+      // `if (ctx && stackId)`, and on the public `/apps/store-preview/<slug>` page
+      // there is no `Modal.Stack` ancestor — so `ctx` is undefined, this prop is inert,
+      // and the viewer behaves exactly as it did. The COUNTERPART lives in
+      // `OffsiteReviewQueue`, which must wrap its modal in a `Modal.Stack`; that pairing
+      // is a seam, so it is pinned as one in
+      // `__tests__/appListingScreenshotViewerWiring.test.ts`.
+      stackId="app-listing-screenshot-viewer"
       // Labels the dialog (Mantine renders it as the `aria-labelledby` target). Kept
       // to the LISTING rather than the caption so the dialog's accessible name is
       // stable across navigation — a name that changes under the user is a worse
@@ -175,67 +207,94 @@ export function AppListingScreenshotViewer({
       // the body, which is where a screen reader will read it in document order.
       title={`${name} screenshots`}
       closeButtonProps={{ 'aria-label': 'Close screenshot viewer' }}
-      // The full-screen media chrome shared by every lightbox in the repo.
+      // 🔴 The full-screen media chrome, adapted from the three existing lightboxes
+      // (`TrainingSampleViewer`, `GeneratedOutputLightbox`, `Model3DLightbox`), which
+      // all three set `inner` / `content` / `body` exactly as below. They ALSO set
+      // `header: { position: 'absolute', right: 0, zIndex: 10 }`, and this one
+      // deliberately does not: that rule lifts a header containing nothing but a close
+      // button out of the flow so the media can use the full height. This viewer
+      // renders a `title`, so its header carries text that has to stay readable and in
+      // flow — an absolute header would overlap the image with the listing's name.
+      // (An earlier version of this comment claimed the block was "copied verbatim"
+      // and that all three "share it identically". The rendering is right; the claim
+      // was not.)
       styles={{
         inner: { position: 'absolute' },
         content: { display: 'flex', flexDirection: 'column', overflow: 'hidden' },
         body: { flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', padding: 16 },
       }}
     >
-      <Group justify="space-between" wrap="nowrap" mb="xs">
-        <Text size="sm" c="dimmed" data-testid="apps-listing-screenshot-position">
-          {position} / {total}
-        </Text>
-      </Group>
-
-      <div className="relative flex min-h-0 flex-1 items-center justify-center">
-        {shot && index !== null && (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            // Keyed by index so navigating swaps the ELEMENT rather than mutating one
-            // `src`. Without it a browser keeps painting the previous shot until the
-            // new one decodes, and — worse — a stale `error` from the outgoing URL
-            // would be attributed to the incoming index.
-            key={index}
-            src={shot.url}
-            alt={shot.caption ? shot.caption : `${name} screenshot ${index + 1}`}
-            data-testid="apps-listing-screenshot-viewer-image"
-            onError={() => onBroken(index)}
-            style={{ maxHeight: '100%', maxWidth: '100%', objectFit: 'contain' }}
-          />
-        )}
-        {!shot && (
-          // One frame at most: the rescue effect above runs immediately after.
-          <Center className="absolute inset-0">
-            <Text c="dimmed">Loading screenshot…</Text>
-          </Center>
+      {/* 🔴 A marker for "THIS dialog", and it exists because its absence produced a
+          false reading. `[role="dialog"][aria-modal="true"]` identifies a Mantine modal
+          but NOT WHICH ONE — and in the `preview` posture there are two, so a
+          document-scoped query for the viewer silently resolved to the review modal
+          instead. Tests anchor on this and walk up to the dialog. */}
+      <div data-testid="apps-listing-screenshot-viewer" className="flex min-h-0 flex-1 flex-col">
+        {/* Rendered only for a shot that is actually on screen. A `0 / N` beside a
+            placeholder is a statement about nothing — see the media block below. */}
+        {shot && (
+          <Text size="sm" c="dimmed" mb="xs" data-testid="apps-listing-screenshot-position">
+            {position} / {total}
+          </Text>
         )}
 
-        <NavButton
-          label="Previous screenshot"
-          disabled={prevIndex === undefined}
-          onClick={() => prevIndex !== undefined && onIndexChange(prevIndex)}
-          className="left-2 top-1/2 -translate-y-1/2"
-        >
-          <IconChevronLeft size={24} />
-        </NavButton>
-        <NavButton
-          label="Next screenshot"
-          disabled={nextIndex === undefined}
-          onClick={() => nextIndex !== undefined && onIndexChange(nextIndex)}
-          className="right-2 top-1/2 -translate-y-1/2"
-        >
-          <IconChevronRight size={24} />
-        </NavButton>
+        <div className="relative flex min-h-0 flex-1 items-center justify-center">
+          {shot && index !== null && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              // Keyed by index so navigating swaps the ELEMENT rather than mutating one
+              // `src`. Without it a browser keeps painting the previous shot until the
+              // new one decodes, and — worse — a stale `error` from the outgoing URL
+              // would be attributed to the incoming index.
+              key={index}
+              src={shot.url}
+              // 🔴 EMPTY when there is a caption, because the caption is rendered as
+              // TEXT directly below. Naming the image with the same string makes a
+              // screen reader announce it twice; an `alt=""` image beside its own
+              // visible caption is the standard pairing. The descriptive fallback is
+              // kept for a shot that has no caption, where nothing else names it.
+              alt={shot.caption ? '' : `${name} screenshot ${index + 1}`}
+              data-testid="apps-listing-screenshot-viewer-image"
+              onError={() => onBroken(index)}
+              style={{ maxHeight: '100%', maxWidth: '100%', objectFit: 'contain' }}
+            />
+          )}
+          {/* 🔴 NOTHING is rendered when there is no viable shot — deliberately, and
+              this replaces a "Loading screenshot…" placeholder that was simply false:
+              the state it described is not loading, it is "the shot 404'd or vanished",
+              and the rescue effect above moves off it (or closes) in the same commit.
+              A one-frame lie is still a lie, and it sat next to a `0 / N` indicator
+              that was counting a shot nobody could see. */}
+
+          {/* 🔴 The arrows live INSIDE this `relative` box, not beside it — they are
+              `absolute`, so they position against the nearest positioned ancestor, and
+              moving them out silently reparents them to the page. */}
+          <NavButton
+            label="Previous screenshot"
+            disabled={prevIndex === undefined}
+            onClick={() => prevIndex !== undefined && onIndexChange(prevIndex)}
+            className="left-2 top-1/2 -translate-y-1/2"
+          >
+            <IconChevronLeft size={24} />
+          </NavButton>
+          <NavButton
+            label="Next screenshot"
+            disabled={nextIndex === undefined}
+            onClick={() => nextIndex !== undefined && onIndexChange(nextIndex)}
+            className="right-2 top-1/2 -translate-y-1/2"
+          >
+            <IconChevronRight size={24} />
+          </NavButton>
+        </div>
+
+        {/* The caption is rendered for every shot that HAS one, and the element is
+            absent otherwise — never an empty box holding a line of vertical space. */}
+        {shot?.caption && (
+          <Text size="sm" mt="xs" data-testid="apps-listing-screenshot-caption">
+            {shot.caption}
+          </Text>
+        )}
       </div>
-
-      {/* The caption is rendered for every shot that HAS one, and the element is
-          absent otherwise — never an empty box holding a line of vertical space. */}
-      {shot?.caption && (
-        <Text size="sm" mt="xs" data-testid="apps-listing-screenshot-caption">
-          {shot.caption}
-        </Text>
-      )}
     </Modal>
   );
 }

--- a/src/components/Apps/CombinedReviewModal.tsx
+++ b/src/components/Apps/CombinedReviewModal.tsx
@@ -3,6 +3,7 @@ import { IconCode, IconPhoto } from '@tabler/icons-react';
 import { useRef } from 'react';
 import { OnsiteReviewModalBody, type AnyRequest } from '~/components/Apps/OnsiteReviewModal';
 import { OffsiteReviewModalBody, type OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';
+import { useOpenerFocusReturn } from '~/components/Apps/useOpenerFocusReturn';
 import type { CombinedReviewPayload } from '~/components/Apps/unifiedReviewRow';
 
 /**
@@ -58,53 +59,66 @@ export function CombinedReviewModal({
   const onsiteRequest: AnyRequest | undefined = selection?.onsiteRequest;
   const listingRow: OffsitePendingRow | undefined = selection?.listingRow;
 
+  // 🔴 SECOND HOST OF THE NESTED SCREENSHOT VIEWER, AND IT NEEDS THE SAME PAIR AS
+  // `OffsiteReviewModal`. This shell renders `OffsiteReviewModalBody`, which carries
+  // the listing preview — so `AppListingDetailBody`'s screenshot gallery can open a
+  // full-screen `Modal` inside THIS one. Without the stack, one Escape closes both
+  // and takes the moderator's in-flight code AND media review with it; without the
+  // focus-return pair, closing this modal drops a keyboard moderator on `<body>`.
+  // Both are properties of nesting, not of this component, so both live here.
+  useOpenerFocusReturn(!!selection);
+
   return (
-    <Modal
-      opened={!!selection}
-      onClose={() => {
-        if (busyCode.current || busyMedia.current) return;
-        onClose();
-      }}
-      title={
-        selection ? (
-          <Group gap={6}>
-            <Text fw={600}>{selection.onsiteRequest.slug}</Text>
-            <Badge color="indigo" size="sm" variant="light" data-testid="combined-review-kind-badge">
-              App + media
-            </Badge>
-          </Group>
-        ) : null
-      }
-      size="xl"
-      centered
-    >
-      {selection && onsiteRequest && listingRow && (
-        <Stack gap="xl">
-          <Stack gap="sm" data-testid="combined-review-code-section">
-            <SectionHeader icon={<IconCode size={14} />} title="App code review" />
-            <OnsiteReviewModalBody
-              key={`code-${onsiteRequest.id}`}
-              selection={{ request: onsiteRequest, mode: 'pending' }}
-              onClose={onClose}
-              onActioned={selection.onActioned}
-              busyRef={busyCode}
-            />
-          </Stack>
+    <Modal.Stack>
+      <Modal
+        stackId="combined-review"
+        returnFocus={false}
+        opened={!!selection}
+        onClose={() => {
+          if (busyCode.current || busyMedia.current) return;
+          onClose();
+        }}
+        title={
+          selection ? (
+            <Group gap={6}>
+              <Text fw={600}>{selection.onsiteRequest.slug}</Text>
+              <Badge color="indigo" size="sm" variant="light" data-testid="combined-review-kind-badge">
+                App + media
+              </Badge>
+            </Group>
+          ) : null
+        }
+        size="xl"
+        centered
+      >
+        {selection && onsiteRequest && listingRow && (
+          <Stack gap="xl">
+            <Stack gap="sm" data-testid="combined-review-code-section">
+              <SectionHeader icon={<IconCode size={14} />} title="App code review" />
+              <OnsiteReviewModalBody
+                key={`code-${onsiteRequest.id}`}
+                selection={{ request: onsiteRequest, mode: 'pending' }}
+                onClose={onClose}
+                onActioned={selection.onActioned}
+                busyRef={busyCode}
+              />
+            </Stack>
 
-          <Divider />
+            <Divider />
 
-          <Stack gap="sm" data-testid="combined-review-media-section">
-            <SectionHeader icon={<IconPhoto size={14} />} title="Listing media" />
-            <OffsiteReviewModalBody
-              key={`media-${listingRow.id}`}
-              request={listingRow}
-              onClose={onClose}
-              onActioned={selection.onActioned}
-              busyRef={busyMedia}
-            />
+            <Stack gap="sm" data-testid="combined-review-media-section">
+              <SectionHeader icon={<IconPhoto size={14} />} title="Listing media" />
+              <OffsiteReviewModalBody
+                key={`media-${listingRow.id}`}
+                request={listingRow}
+                onClose={onClose}
+                onActioned={selection.onActioned}
+                busyRef={busyMedia}
+              />
+            </Stack>
           </Stack>
-        </Stack>
-      )}
-    </Modal>
+        )}
+      </Modal>
+    </Modal.Stack>
   );
 }

--- a/src/components/Apps/OffsiteReviewModal.focus.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewModal.focus.browser.test.tsx
@@ -1,0 +1,195 @@
+import { Button } from '@mantine/core';
+import { useState } from 'react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as FeatureFlagsMod from '~/providers/FeatureFlagsProvider';
+import type * as TrpcModule from '~/utils/trpc';
+
+/**
+ * The moderator review modal's FOCUS RETURN, under the `Modal.Stack` it joined so that
+ * a nested screenshot viewer could scope its own Escape.
+ *
+ * 🔴 THIS FILE EXISTS BECAUSE THE STACK BROKE SOMETHING THAT USED TO WORK, AND IT BROKE
+ * IT UNCONDITIONALLY — not only when the nested viewer was used. Inside a stack
+ * `trapFocus` is `ctx.currentId === stackId`, and the stack registers its members from
+ * an effect, so even a lone modal renders once with the trap OFF and again with it ON.
+ * `useModal` passes that into `useFocusReturn({ opened, shouldReturnFocus: trapFocus &&
+ * returnFocus })`, whose deps are `[opened, shouldReturnFocus]` — so the flip re-runs
+ * that effect while `opened` is still true and overwrites the captured opener with
+ * whatever holds focus by then. Measured, three arms differing only in the wrapper:
+ *
+ *     without Modal.Stack                     focus -> the trigger   ✅
+ *     with Modal.Stack                        focus -> <body>        ❌
+ *     with Modal.Stack + returnFocus={false}  focus -> <body>        ❌
+ *
+ * The third arm is the one that matters for the fix: switching Mantine's version off
+ * restores nothing by itself, which is why `useOpenerFocusReturn` exists.
+ *
+ * 🔴 THE CONVERSE IS NOT ESTABLISHED, and an earlier draft of this header claimed it
+ * was ("a PAIR, not an alternative"). A mutation sweep deleted `returnFocus={false}`
+ * while keeping the hook and BOTH tests below stayed green; only the source gate
+ * noticed. The two are still used together, as a single-owner convention, but this
+ * file measures the HOOK — it is not evidence that the prop is load-bearing.
+ *
+ * 🔴 ASSERTED AS A RELATIONSHIP: focus must land on THE ELEMENT THAT OPENED the modal,
+ * not merely "not on `<body>`". A moderator working the queue by keyboard has to get
+ * their row back; landing on some other control, or on the page container, is a
+ * different bug wearing the same green.
+ */
+
+// 🔴 BOTH the fixture and the spy live in `vi.hoisted`, because the `vi.mock`
+// factory below closes over them and `vi.mock` is hoisted to the top of the file. A
+// plain top-level `const` referenced from the factory is a temporal-dead-zone read:
+// vitest reports "There was an error when mocking a module … no top level variables
+// inside", the suite produces NO summary line at all, and under load the run wedges
+// rather than failing — which reads as an infrastructure problem rather than a defect
+// in this file. (A neighbouring suite gets away with the plain form; that is luck of
+// evaluation order, not a pattern to copy.)
+const hoisted = vi.hoisted(() => ({
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  row: {
+    id: 'req-1',
+    appListingId: 'listing-1',
+    slug: 'ci-ext-app',
+    status: 'pending',
+    submittedAt: new Date('2026-01-01T00:00:00Z'),
+    changelog: 'a note for the reviewer',
+    appListing: {
+      name: 'CI External App',
+      externalUrl: 'https://example.com/app',
+      category: 'utility',
+      contentRating: 'g',
+    },
+    submittedBy: { id: 42, username: 'author-dev', image: null },
+  },
+}));
+
+const OFFSITE_ROW = hoisted.row;
+
+// 🔴 `importOriginal` SPREAD, not a wholesale replacement (local-rules/
+// no-wholesale-module-mock) — mirrors `OffsiteReviewQueue.browser.test.tsx`, whose
+// header records what a hand-written factory costs the day the graph grows an export.
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsMod>()),
+  useFeatureFlags: () => ({ appBlocks: true }),
+}));
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
+  return {
+    ...actual,
+    trpc: {
+      useUtils: () => ({
+        appListings: {
+          listPendingRequests: { invalidate: hoisted.invalidate },
+          listApprovedRequests: { invalidate: hoisted.invalidate },
+          listRejectedRequests: { invalidate: hoisted.invalidate },
+        },
+      }),
+      appListings: {
+        listPendingRequests: {
+          useQuery: () => ({
+            data: { items: [hoisted.row], nextCursor: null },
+            isLoading: false,
+            error: null,
+          }),
+        },
+        getAssets: { useQuery: () => ({ data: null, isLoading: false, error: null }) },
+        approveExternalRequest: {
+          useMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+        },
+        rejectExternalRequest: {
+          useMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+        },
+        getListingPreviewForReview: {
+          useQuery: () => ({ data: undefined, isLoading: false, error: null }),
+        },
+      },
+    },
+  };
+});
+
+const { OffsiteReviewModal } = await import('./OffsiteReviewQueue');
+
+beforeEach(async () => {
+  await page.viewport(1440, 900);
+});
+
+/** A trigger button plus the modal — the shape the queue's `Review` button renders. */
+function Harness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button data-testid="opener" onClick={() => setOpen(true)}>
+        Review
+      </Button>
+      <OffsiteReviewModal
+        request={open ? (OFFSITE_ROW as never) : null}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  );
+}
+
+const opener = () => document.querySelector('[data-testid="opener"]') as HTMLElement;
+const dialog = () => document.querySelector('[role="dialog"][aria-modal="true"]');
+
+async function openModal() {
+  await renderWithProviders(<Harness />);
+  const trigger = opener();
+  trigger.focus();
+  expect(document.activeElement).toBe(trigger);
+  await userEvent.click(trigger);
+  await vi.waitFor(() => expect(dialog()).not.toBeNull());
+  // Control: focus really left the trigger, so what follows is a restore rather than
+  // focus that never moved.
+  await vi.waitFor(() => expect(document.activeElement).not.toBe(trigger));
+  return trigger;
+}
+
+describe('OffsiteReviewModal — focus return under Modal.Stack', () => {
+  /**
+   * 🔴 THE REGRESSION. The nested viewer is never opened here — this is the plain
+   * open-then-close path every moderator takes, and it is the arm that measured
+   * `<body>` before the fix.
+   */
+  test('closing with Escape returns focus to the element that opened it', async () => {
+    const trigger = await openModal();
+
+    await userEvent.keyboard('{Escape}');
+    await vi.waitFor(() => expect(dialog()).toBeNull());
+
+    await vi.waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  /**
+   * The same claim through the close BUTTON rather than Escape — the fix hangs off the
+   * `opened` transition, not off which affordance caused it, and that should be
+   * measured rather than assumed.
+   */
+  test('closing with the close button returns focus to the opener too', async () => {
+    const trigger = await openModal();
+
+    // 🔴 Located STRUCTURALLY, by Mantine's own close-button class, not by an
+    // accessible name: this modal does not set `closeButtonProps`, so its close button
+    // has no `aria-label` and `getByRole('button', { name: … })` matches nothing —
+    // which times out after 15s and reads exactly like the focus assertion failing.
+    // (That the button is unlabelled is a real a11y gap, but it is pre-existing and
+    // not this PR's to change.)
+    const close = document.querySelector(
+      '[role="dialog"] button[class*="mantine-Modal-close"]'
+    ) as HTMLElement | null;
+    expect(close, 'the review modal has no close button').not.toBeNull();
+    close!.click();
+    await vi.waitFor(() => expect(dialog()).toBeNull());
+
+    await vi.waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+});

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -280,6 +280,28 @@ export function OffsiteReviewQueue() {
  * resetting its approve/reject UI state — mirrors `OnsiteReviewModal`). The body is
  * exported so the combined code+media review surface can re-host it WITHOUT this
  * `<Modal>` shell.
+ *
+ * 🔴 THE `Modal.Stack` WRAPPER IS LOAD-BEARING, NOT DECORATION, AND IT IS HALF OF A
+ * SEAM. The listing PREVIEW inside this modal renders `AppListingDetailBody`, whose
+ * screenshot gallery opens a full-screen `AppListingScreenshotViewer` — a second
+ * `<Modal>`, nested inside this one. Mantine's Esc handling is a per-Modal `window`
+ * keydown listener in CAPTURE phase (`ModalBase/use-modal.mjs`), so with no
+ * coordination BOTH handlers fire for one key: dismissing the lightbox also closed
+ * THIS modal, discarding the `rejectionReason` / `approvalNotes` the moderator was
+ * typing (local state in `OffsiteReviewModalBody`, and `keepMounted` is false so it is
+ * gone) along with their place in the queue. Measured, not theorised.
+ *
+ * `Modal.Stack` + `stackId` makes Mantine gate instead of race: `closeOnEscape` and
+ * `trapFocus` become `ctx.currentId === stackId` (`Modal.mjs:53-57`), so only the
+ * top-most member of the stack responds to Escape, and the key is handed back to this
+ * modal the moment the viewer closes.
+ *
+ * 🔴 BOTH HALVES ARE REQUIRED AND NEITHER ERRORS WITHOUT THE OTHER — the viewer's
+ * `stackId` is inert with no `Modal.Stack` ancestor, and this wrapper does nothing on
+ * its own. That is what makes it a seam rather than two settings, and it is pinned as
+ * one in `__tests__/appListingScreenshotViewerWiring.test.ts`. Do not remove the
+ * wrapper because "there is only one modal here" — the second one is three components
+ * down, inside the preview.
  */
 export function OffsiteReviewModal({
   request,
@@ -295,41 +317,44 @@ export function OffsiteReviewModal({
   const busyRef = useRef(false);
   const isOnsite = request?.kind === 'onsite';
   return (
-    <Modal
-      opened={!!request}
-      onClose={() => {
-        if (busyRef.current) return;
-        onClose();
-      }}
-      title={
-        request ? (
-          <Group gap={6}>
-            <Text fw={600}>{request.slug}</Text>
-            <Badge
-              color={isOnsite ? 'teal' : 'grape'}
-              size="sm"
-              variant="light"
-              data-testid="apps-offsite-kind-badge"
-            >
-              {isOnsite ? 'listing media' : 'external'}
-            </Badge>
-          </Group>
-        ) : null
-      }
-      size="lg"
-      centered
-    >
-      {request && (
-        <OffsiteReviewModalBody
-          key={request.id}
-          request={request}
-          onClose={onClose}
-          onActioned={onActioned}
-          readOnly={readOnly}
-          busyRef={busyRef}
-        />
-      )}
-    </Modal>
+    <Modal.Stack>
+      <Modal
+        stackId="offsite-review"
+        opened={!!request}
+        onClose={() => {
+          if (busyRef.current) return;
+          onClose();
+        }}
+        title={
+          request ? (
+            <Group gap={6}>
+              <Text fw={600}>{request.slug}</Text>
+              <Badge
+                color={isOnsite ? 'teal' : 'grape'}
+                size="sm"
+                variant="light"
+                data-testid="apps-offsite-kind-badge"
+              >
+                {isOnsite ? 'listing media' : 'external'}
+              </Badge>
+            </Group>
+          ) : null
+        }
+        size="lg"
+        centered
+      >
+        {request && (
+          <OffsiteReviewModalBody
+            key={request.id}
+            request={request}
+            onClose={onClose}
+            onActioned={onActioned}
+            readOnly={readOnly}
+            busyRef={busyRef}
+          />
+        )}
+      </Modal>
+    </Modal.Stack>
   );
 }
 

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -34,6 +34,7 @@ import {
 import { useRef, useState } from 'react';
 import { AppListingCard } from '~/components/Apps/AppListingCard';
 import { AppListingDetailBody } from '~/components/Apps/AppListingDetailBody';
+import { useOpenerFocusReturn } from '~/components/Apps/useOpenerFocusReturn';
 import {
   buildListingCardPreview,
   buildListingDetailPreview,
@@ -316,10 +317,16 @@ export function OffsiteReviewModal({
 }) {
   const busyRef = useRef(false);
   const isOnsite = request?.kind === 'onsite';
+  // Inside the stack Mantine's own focus return captures the wrong element and drops
+  // the moderator on `<body>` — measured. This restores the opener; the
+  // `returnFocus={false}` below leaves Mantine's inert so there is one owner.
+  // (Deleting that prop alone did NOT break the focus tests — see the hook's header.)
+  useOpenerFocusReturn(!!request);
   return (
     <Modal.Stack>
       <Modal
         stackId="offsite-review"
+        returnFocus={false}
         opened={!!request}
         onClose={() => {
           if (busyRef.current) return;

--- a/src/components/Apps/__tests__/appListingGalleryFill.test.ts
+++ b/src/components/Apps/__tests__/appListingGalleryFill.test.ts
@@ -74,7 +74,7 @@ describe('🔴 the screenshot gallery fill rule is declared AND wired', () => {
     'Without `.gallery > :last-child:nth-child(odd) { grid-column: 1 / -1 }` a listing ' +
     'with ONE screenshot renders it at half the main column with dead space beside it, ' +
     'and so does the trailing tile of any odd count. The rule is written as a ' +
-    'structural selector on purpose: ScreenshotTile hides itself on a load error, so ' +
+    'structural selector on purpose: a tile is dropped on a load error, so ' +
     'the rendered tile count is not screenshots.length and cannot be computed before ' +
     'render. See the stylesheet header.';
 
@@ -209,7 +209,7 @@ describe('🔴 the screenshot gallery fill rule is declared AND wired', () => {
     expect(
       body,
       'ScreenshotGallery is computing its column count from the screenshots array. ' +
-        'ScreenshotTile hides ITSELF on a load error, so that number is not the number ' +
+        'a tile is DROPPED on a load error, so that number is not the number ' +
         'of tiles the browser ends up with — the fill rule is a CSS structural selector ' +
         'precisely so it does not have to know. See the stylesheet header.'
     ).not.toMatch(/cols=\{[^}]*shots\b/);

--- a/src/components/Apps/__tests__/appListingScreenshotNav.test.ts
+++ b/src/components/Apps/__tests__/appListingScreenshotNav.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import {
+  adjacentViableIndex,
+  NO_BROKEN_SCREENSHOTS,
+  viewerPosition,
+  withBrokenIndex,
+} from '~/components/Apps/appListingScreenshotNav';
+
+/**
+ * The app-listing screenshot viewer's INDEX ARITHMETIC.
+ *
+ * 🔴 WHY THIS FILE IS IN THE BLOCKING `unit` PROJECT AND ITS SIBLING IS NOT. The
+ * viewer's whole failure mode is arithmetic — open on the wrong shot, advance by the
+ * wrong amount, prev and next swapped — and every one of those renders a completely
+ * healthy modal showing the wrong picture. The browser suite
+ * (`AppListingDetailBody.viewer.browser.test.tsx`) can see it, but it runs only as
+ * the preview pipeline's report-only `preview / component-tests`, so a guard that
+ * lives ONLY there cannot block the regression coming back. The arithmetic is pure,
+ * so it is pinned here, where CI's `Unit tests` job runs it.
+ *
+ * 🔴 WHAT THIS FILE CANNOT SEE, stated so nobody reads it as more than it is: it
+ * proves the FUNCTIONS are right, never that the component CALLS them, never that a
+ * tile hands them the index it actually represents, and never that a rendered arrow
+ * is wired to the direction its label claims. Those are DOM facts and only the
+ * browser tier has them.
+ *
+ * 🔴 EVERY FIXTURE BELOW IS SIZED SO THAT THE OFF-BY-ONE MUTANTS CANNOT SURVIVE. A
+ * 2-element list is the classic vacuous fixture here: `index + 1` and `index - 1` and
+ * `count - index - 1` all collide on it, and `position` and `total` are frequently
+ * equal, so a swapped prev/next or a mis-derived total passes. Lists are 5-7 long,
+ * the interrogated index is never the midpoint and never `count / 2`, and `position`
+ * is never equal to `total` or to `index` in the cases that matter.
+ */
+
+const noneBroken = NO_BROKEN_SCREENSHOTS;
+const brokenAt = (...indexes: number[]) => new Set(indexes);
+
+describe('adjacentViableIndex', () => {
+  /**
+   * The plain step, in BOTH directions, from an index that is neither an end nor the
+   * midpoint of a 7-element list. `3 - 1 = 2` and `3 + 1 = 4` are distinct from each
+   * other, from `3`, and from `7 - 3 - 1 = 3`, so a mutant that swaps the directions,
+   * that returns the current index, or that mirrors around the centre all fail here.
+   */
+  it('steps exactly one place, in the direction it is given', () => {
+    expect(adjacentViableIndex(3, 1, 7, noneBroken)).toBe(4);
+    expect(adjacentViableIndex(3, -1, 7, noneBroken)).toBe(2);
+    // …and from an index whose neighbours are NOT symmetric about it, so "off by one
+    // in the same direction" is visible rather than absorbed.
+    expect(adjacentViableIndex(1, 1, 7, noneBroken)).toBe(2);
+    expect(adjacentViableIndex(5, -1, 7, noneBroken)).toBe(4);
+  });
+
+  /**
+   * 🔴 THE BOUNDARY RULE IS **STOP**, NOT WRAP — the decision recorded in the
+   * module header. `undefined` is what disables the arrow button, so a mutant that
+   * wraps would not merely navigate differently, it would render a control that
+   * claims there is something further on when there is not.
+   */
+  it('returns undefined at each end rather than wrapping', () => {
+    expect(adjacentViableIndex(0, -1, 7, noneBroken)).toBeUndefined();
+    expect(adjacentViableIndex(6, 1, 7, noneBroken)).toBeUndefined();
+    // The neighbouring index in each case IS reachable, so the two assertions above
+    // are about the boundary and not about a function that returns undefined a lot.
+    expect(adjacentViableIndex(0, 1, 7, noneBroken)).toBe(1);
+    expect(adjacentViableIndex(6, -1, 7, noneBroken)).toBe(5);
+  });
+
+  /**
+   * A single element is the degenerate case the viewer renders with NO navigation at
+   * all. Both directions must be dead, or the viewer offers a control that goes
+   * nowhere.
+   */
+  it('offers no move at all in a one-screenshot listing', () => {
+    expect(adjacentViableIndex(0, 1, 1, noneBroken)).toBeUndefined();
+    expect(adjacentViableIndex(0, -1, 1, noneBroken)).toBeUndefined();
+  });
+
+  /**
+   * 🔴 BROKEN SHOTS ARE SKIPPED, NOT STEPPED ONTO. A run of consecutive broken shots
+   * is deliberately longer than one, because "skip one" and "skip until viable" are
+   * different functions that agree on a single gap — the exact shape that makes a
+   * `if (broken.has(i)) i += direction` mutant survive.
+   */
+  it('skips a RUN of broken screenshots in either direction', () => {
+    const broken = brokenAt(2, 3, 4);
+    expect(adjacentViableIndex(1, 1, 7, broken)).toBe(5);
+    expect(adjacentViableIndex(5, -1, 7, broken)).toBe(1);
+    // The same call with nothing broken lands on the adjacent index instead — the
+    // control that says the skip above was caused by `broken` and not by the fixture.
+    expect(adjacentViableIndex(1, 1, 7, noneBroken)).toBe(2);
+    expect(adjacentViableIndex(5, -1, 7, noneBroken)).toBe(4);
+  });
+
+  it('reports no move when every shot beyond the current one is broken', () => {
+    expect(adjacentViableIndex(1, 1, 5, brokenAt(2, 3, 4))).toBeUndefined();
+    expect(adjacentViableIndex(3, -1, 5, brokenAt(0, 1, 2))).toBeUndefined();
+  });
+
+  /**
+   * The CURRENT index being broken must not stop the search: the viewer rescues off a
+   * shot that 404s while open by calling this from that very index.
+   */
+  it('searches from a broken current index without getting stuck on it', () => {
+    const broken = brokenAt(2);
+    expect(adjacentViableIndex(2, 1, 7, broken)).toBe(3);
+    expect(adjacentViableIndex(2, -1, 7, broken)).toBe(1);
+  });
+
+  /**
+   * 🔴 THE OUT-OF-RANGE CONTRACT, MEASURED RATHER THAN ASSUMED. The search begins at
+   * `index + direction` and stops the moment that probe is outside `[0, count)` — it
+   * does NOT clamp back toward the list. So an index left over from a longer list
+   * resolves only when the first step happens to land in range (`-1` stepping
+   * forward does; `9` stepping back from a 4-shot list does not).
+   *
+   * That is the deliberate behaviour, not a gap: the only caller that can pass an
+   * out-of-range index is the viewer's rescue effect, reached when the listing's
+   * screenshot array shrinks under an open viewer — and there `undefined` from both
+   * directions closes the viewer, which is the right answer, because the shot it was
+   * displaying no longer exists. An earlier draft of this test asserted clamping and
+   * was wrong about the code; the assertion is written from the loop, and the reason
+   * it is acceptable is written from the caller.
+   */
+  it('does not clamp an out-of-range index back into the list', () => {
+    expect(adjacentViableIndex(-1, 1, 4, noneBroken)).toBe(0);
+    expect(adjacentViableIndex(9, -1, 4, noneBroken)).toBeUndefined();
+    expect(adjacentViableIndex(9, 1, 4, noneBroken)).toBeUndefined();
+    expect(adjacentViableIndex(-1, -1, 4, noneBroken)).toBeUndefined();
+  });
+});
+
+describe('viewerPosition', () => {
+  /**
+   * 🔴 THE INDICATOR IS 1-BASED AND THE FIXTURE PROVES IT. `index = 2` in a 5-shot
+   * listing gives `3 / 5`: three values that are pairwise distinct AND distinct from
+   * the index, so a mutant that renders the raw index, that drops the `+ 1`, or that
+   * reports `count` where it means `total` fails here rather than coinciding.
+   */
+  it('is 1-based over the whole list when nothing is broken', () => {
+    expect(viewerPosition(2, 5, noneBroken)).toEqual({ position: 3, total: 5 });
+    expect(viewerPosition(0, 5, noneBroken)).toEqual({ position: 1, total: 5 });
+    expect(viewerPosition(4, 5, noneBroken)).toEqual({ position: 5, total: 5 });
+  });
+
+  /**
+   * 🔴 BOTH NUMBERS COUNT ONLY VIABLE SHOTS. With 2 of 7 broken BEFORE the current
+   * index, the position drops by exactly 2 and the total by exactly 2 — and neither
+   * new value equals the other, equals the index, or equals the raw count, so a
+   * mutant that subtracts from only one of them is visible.
+   */
+  it('counts only the shots navigation can reach — position AND total', () => {
+    // shots 0..6, broken at 1 and 3. Viable: 0,2,4,5,6 → five of them.
+    const broken = brokenAt(1, 3);
+    expect(viewerPosition(4, 7, broken)).toEqual({ position: 3, total: 5 });
+    expect(viewerPosition(0, 7, broken)).toEqual({ position: 1, total: 5 });
+    expect(viewerPosition(6, 7, broken)).toEqual({ position: 5, total: 5 });
+    // …and a shot AFTER the current index reduces the total without touching the
+    // position, which is the half a single combined counter would get wrong.
+    expect(viewerPosition(2, 7, brokenAt(5))).toEqual({ position: 3, total: 6 });
+  });
+
+  /**
+   * `position: 0` marks an index the viewer must not display. It never renders that
+   * value — it rescues off such an index — so this pins the marker, not a label.
+   */
+  it('reports position 0 for a broken or out-of-range index', () => {
+    expect(viewerPosition(3, 7, brokenAt(3))).toEqual({ position: 0, total: 6 });
+    expect(viewerPosition(-1, 7, noneBroken)).toEqual({ position: 0, total: 7 });
+    expect(viewerPosition(7, 7, noneBroken)).toEqual({ position: 0, total: 7 });
+  });
+
+  it('reports 1 / 1 for a single screenshot and 0 total when all are broken', () => {
+    expect(viewerPosition(0, 1, noneBroken)).toEqual({ position: 1, total: 1 });
+    expect(viewerPosition(0, 3, brokenAt(0, 1, 2))).toEqual({ position: 0, total: 0 });
+  });
+});
+
+describe('withBrokenIndex', () => {
+  it('adds an index without mutating the set it was given', () => {
+    const before = brokenAt(1);
+    const after = withBrokenIndex(before, 4);
+    expect([...after].sort()).toEqual([1, 4]);
+    // The original is untouched — this state lives in React and a mutation in place
+    // would not re-render, so the copy is behaviour rather than hygiene.
+    expect([...before]).toEqual([1]);
+    expect(after).not.toBe(before);
+  });
+
+  /**
+   * 🔴 THE IDENTITY RETURN IS LOAD-BEARING. This runs inside a `setState` updater
+   * from an `<img>` `onError`, and a browser can fire `error` more than once for the
+   * same element. Returning a fresh Set every time would schedule a state change
+   * every time — a render loop. Same-set-on-repeat is what stops it.
+   */
+  it('returns the SAME set object when the index is already there', () => {
+    const before = brokenAt(2, 5);
+    expect(withBrokenIndex(before, 5)).toBe(before);
+    // Control: a genuinely new index does produce a new object, so the assertion
+    // above is about the repeat and not about a function that never copies.
+    expect(withBrokenIndex(before, 6)).not.toBe(before);
+  });
+
+  it('never mutates the shared empty constant', () => {
+    const next = withBrokenIndex(NO_BROKEN_SCREENSHOTS, 0);
+    expect([...next]).toEqual([0]);
+    expect(NO_BROKEN_SCREENSHOTS.size).toBe(0);
+  });
+});

--- a/src/components/Apps/__tests__/appListingScreenshotViewerWiring.test.ts
+++ b/src/components/Apps/__tests__/appListingScreenshotViewerWiring.test.ts
@@ -25,7 +25,9 @@ import { describe, expect, it } from 'vitest';
  *   - CAUGHT: the viewer being dropped from the gallery; it being handed a different
  *     list or a different broken set than the grid uses; the tile losing its
  *     `onOpen` / `onBroken` / `index` wiring; the tile reverting to a non-button
- *     click target; any of the Modal's three a11y defaults being switched OFF.
+ *     click target; `trapFocus` / `closeOnEscape` being switched OFF; either half of
+ *     the `Modal.Stack` seam going missing from either host; and either half of the
+ *     `returnFocus={false}` + `useOpenerFocusReturn` pair.
  *   - NOT CAUGHT: an off-by-one inside either component, a control wired to the wrong
  *     direction, or anything about what is actually rendered. Those are behaviour and
  *     belong to the other two files.
@@ -134,8 +136,13 @@ describe('🔴 the screenshot viewer is WIRED to the gallery that owns the list'
     const body = norm(fnBody(bodySrc(), 'ScreenshotGallery'));
     expect(body, WHY_TILE).toContain('<ScreenshotTile');
     expect(body, WHY_TILE).toContain('index={index}');
-    expect(body, WHY_TILE).toContain('onOpen={() => setOpenIndex(index)}');
+    // The tile opens ITS OWN index — the whole index-space claim in one line.
+    expect(body, WHY_TILE).toContain('setOpenIndex(index)');
     expect(body, WHY_TILE).toContain('onBroken={() => markBroken(index)}');
+    // …and records itself as the tile an ancestor focus trap should return to. Without
+    // this the nested close lands on the review modal's chrome; see `data-autofocus`.
+    expect(body, WHY_TILE).toContain('setLastOpenedIndex(index)');
+    expect(body, WHY_TILE).toContain('autoFocus={lastOpenedIndex === index}');
   });
 
   const WHY_BUTTON =
@@ -175,21 +182,72 @@ describe('🔴 the screenshot viewer is WIRED to the gallery that owns the list'
    * `AppListingDetailBody.viewer.browser.test.tsx` ("nested inside the moderator review
    * modal"), and its structural half is the `Modal.Stack` seam in the test below.
    */
-  it('🔴 the viewer does not switch OFF focus trap, focus return or Esc', () => {
+  it('🔴 the viewer does not switch OFF focus trap or Esc', () => {
     const src = norm(viewerSrc());
-    for (const prop of ['trapFocus', 'returnFocus', 'closeOnEscape', 'withCloseButton']) {
+    for (const prop of ['trapFocus', 'closeOnEscape', 'withCloseButton']) {
       // Positive control first: the matcher can see such a thing at all.
       expect(norm(`<Modal ${prop}={false} />`)).toContain(`${prop}={false}`);
       expect(
         src,
         `AppListingScreenshotViewer sets ${prop}={false}. That is the modal's a11y ` +
-          `contract — focus moves into the dialog, returns to the tile that opened it, ` +
-          `and Escape closes it. All are Mantine defaults, so turning one off is ` +
-          `a one-word edit no reviewer would flag.`
+          `contract — focus moves into the dialog and Escape closes it. Both are ` +
+          `Mantine defaults, so turning one off is a one-word edit no reviewer would flag.`
       ).not.toContain(`${prop}={false}`);
     }
     // …and the dialog really is labelled, which is what `aria-labelledby` resolves to.
     expect(src).toContain('title={`${name} screenshots`}');
+  });
+
+  /**
+   * 🔴 `returnFocus={false}` IS REQUIRED HERE, NOT FORBIDDEN — and an earlier version
+   * of this gate had it exactly backwards, which would have blocked its own fix.
+   *
+   * Inside a `Modal.Stack` Mantine's focus return is BROKEN for every member: the stack
+   * gates `trapFocus` on `ctx.currentId === stackId`, that value flips while the modal
+   * is open, and `useFocusReturn`'s deps `[opened, shouldReturnFocus]` make each flip
+   * re-capture `document.activeElement` — by then something inside the dialog.
+   * Measured: focus lands on `<body>`. So each stacked modal turns Mantine's version
+   * OFF and uses `useOpenerFocusReturn`, which captures the opener during RENDER,
+   * before the trap can move focus.
+   *
+   * 🔴 THE TWO HALVES ARE NOT EQUALLY LOAD-BEARING, AND THIS GATE USED TO SAY THEY
+   * WERE. `returnFocus={false}` without the hook is a real regression — no focus
+   * return at all, measured. The reverse is NOT: an independent sweep deleted
+   * `returnFocus={false}` while keeping the hook and every focus test stayed GREEN;
+   * only this gate noticed. The earlier claim that Mantine's 10ms post-close timeout
+   * would clobber the correct restore was reasoning, and it was wrong.
+   *
+   * The gate still requires both, as a SINGLE-OWNER convention: one mechanism owns
+   * focus return, and Mantine's corrupted capture is left inert rather than racing us
+   * in some flow nobody has measured. That is a convention worth pinning; it is not
+   * evidence of a behavioural pair, and this comment must not be read as claiming so.
+   */
+  it('🔴 every stacked modal pairs returnFocus={false} with useOpenerFocusReturn', () => {
+    const REVIEW = path.resolve(__dirname, '../OffsiteReviewQueue.tsx');
+    const COMBINED = path.resolve(__dirname, '../CombinedReviewModal.tsx');
+    const VIEWER_PATH = path.resolve(__dirname, '../AppListingScreenshotViewer.tsx');
+
+    // Positive controls — each matcher can see its target, and the comment stripper
+    // stops the prose in these files (which names both halves) from satisfying it.
+    expect(norm('<Modal returnFocus={false} />')).toContain('returnFocus={false}');
+    expect(norm('useOpenerFocusReturn(opened);')).toContain('useOpenerFocusReturn(');
+    expect(norm(stripComments('/* returnFocus={false} useOpenerFocusReturn( */'))).not.toContain(
+      'returnFocus={false}'
+    );
+
+    for (const file of [VIEWER_PATH, REVIEW, COMBINED]) {
+      const name = path.basename(file);
+      const src = norm(stripComments(fs.readFileSync(file, 'utf8')));
+      const why =
+        `${name} joins a Modal.Stack, where Mantine's own returnFocus captures the ` +
+        `wrong element and drops the user on <body>. It must set returnFocus={false} ` +
+        `AND call useOpenerFocusReturn(...). Dropping the HOOK is a measured ` +
+        `regression (no focus return at all). Dropping the PROP is a convention ` +
+        `violation rather than a measured break — it left the focus tests green — ` +
+        `but it leaves two mechanisms owning focus return, one of them corrupted.`;
+      expect(src, why).toContain('returnFocus={false}');
+      expect(src, why).toContain('useOpenerFocusReturn(');
+    }
   });
 
   /**
@@ -209,34 +267,61 @@ describe('🔴 the screenshot viewer is WIRED to the gallery that owns the list'
    * warns, and the regression is only visible by opening a screenshot from the review
    * queue and pressing one key. That is what makes it a seam rather than two settings.
    */
-  it('🔴 the viewer joins a Modal.Stack that the review modal actually provides', () => {
-    const REVIEW = path.resolve(__dirname, '../OffsiteReviewQueue.tsx');
+  it('🔴 the viewer joins a Modal.Stack that BOTH of its hosts actually provide', () => {
     const viewer = norm(viewerSrc());
-    const review = norm(stripComments(fs.readFileSync(REVIEW, 'utf8')));
 
-    // Positive controls: both matchers can see their target, and the comment stripper
+    // Positive controls: the matchers can see their target, and the comment stripper
     // is what stops each file's own PROSE (which names both halves verbatim) from
     // satisfying the gate.
-    expect(norm('<Modal stackId="x" />')).toContain('stackId=');
-    expect(norm('<Modal.Stack>')).toContain('<Modal.Stack>');
-    expect(norm(stripComments('/* <Modal.Stack> stackId="offsite-review" */'))).not.toContain(
-      '<Modal.Stack>'
+    const stacked = (id: string) =>
+      new RegExp(`<Modal\\.Stack>\\s*<Modal\\b[\\s\\S]{0,200}?stackId="${id}"`);
+    expect(norm('<Modal.Stack> <Modal returnFocus={false} stackId="x"')).toMatch(stacked('x'));
+    // …and it is a PROXIMITY check, not a pair of independent substrings: a stackId
+    // that belongs to some other modal far away in the file does not satisfy it.
+    expect(norm(`<Modal.Stack><Modal/></Modal.Stack> ${'z'.repeat(400)} stackId="x"`)).not.toMatch(
+      stacked('x')
+    );
+    expect(norm(stripComments('/* <Modal.Stack> <Modal stackId="offsite-review" */'))).not.toMatch(
+      /<Modal\.Stack>/
     );
 
     expect(
       viewer,
-      'AppListingScreenshotViewer no longer joins a modal stack. Nested inside the ' +
+      'AppListingScreenshotViewer no longer joins a modal stack. Nested inside a ' +
         'moderator review modal, one Escape will now close BOTH dialogs and discard ' +
         'whatever the moderator had typed. See the header on its `stackId` prop.'
     ).toContain('stackId="app-listing-screenshot-viewer"');
 
-    expect(
-      review,
-      'OffsiteReviewQueue no longer wraps its review Modal in a <Modal.Stack>. The ' +
-        "screenshot viewer's `stackId` is INERT without it (Modal.mjs applies stack " +
-        'props only `if (ctx && stackId)`), so Escape silently goes back to closing ' +
-        'both dialogs at once. Both halves are required; neither errors alone.'
-    ).toContain('<Modal.Stack>');
-    expect(review, 'The review Modal lost its own stackId.').toContain('stackId="offsite-review"');
+    /**
+     * 🔴 BOTH HOSTS, because there are two and only one of them was obvious. The
+     * listing preview — and therefore this viewer — is rendered by
+     * `OffsiteReviewModalBody`, which BOTH `OffsiteReviewModal` and
+     * `CombinedReviewModal` mount inside their own `<Modal>`. Fixing only the first
+     * leaves the identical Escape defect live on the combined code+media review.
+     *
+     * 🔴 ASSERTED AS PROXIMITY, not as two independent substrings. A file can contain
+     * `<Modal.Stack>` and a `stackId` while the wrapper sits around a DIFFERENT modal —
+     * which the substring form would happily pass. The regex pins that the id belongs
+     * to the modal directly inside the wrapper, with a 200-char window so a legitimate
+     * prop reorder does not break the gate. Residual gap, stated rather than implied: a
+     * second `<Modal>` inserted between the wrapper and this one, within that window,
+     * would still satisfy it. Closing that needs a real JSX parse, which is more
+     * machinery than this class of regression warrants.
+     */
+    for (const [file, stackId] of [
+      ['../OffsiteReviewQueue.tsx', 'offsite-review'],
+      ['../CombinedReviewModal.tsx', 'combined-review'],
+    ] as const) {
+      const src = norm(stripComments(fs.readFileSync(path.resolve(__dirname, file), 'utf8')));
+      expect(
+        src,
+        `${path.basename(file)} no longer wraps its review Modal in a <Modal.Stack> ` +
+          `carrying stackId="${stackId}". The screenshot viewer's own stackId is INERT ` +
+          `without it (Modal.mjs applies stack props only \`if (ctx && stackId)\`), so ` +
+          `Escape silently goes back to closing both dialogs at once — losing the ` +
+          `moderator's in-progress review notes. Both halves are required; neither ` +
+          `errors alone.`
+      ).toMatch(stacked(stackId));
+    }
   });
 });

--- a/src/components/Apps/__tests__/appListingScreenshotViewerWiring.test.ts
+++ b/src/components/Apps/__tests__/appListingScreenshotViewerWiring.test.ts
@@ -158,12 +158,22 @@ describe('🔴 the screenshot viewer is WIRED to the gallery that owns the list'
   });
 
   /**
-   * 🔴 THE MODAL'S A11Y CONTRACT IS THREE MANTINE DEFAULTS, AND DEFAULTS ARE EXACTLY
+   * 🔴 THE MODAL'S A11Y CONTRACT IS A SET OF MANTINE DEFAULTS, AND DEFAULTS ARE EXACTLY
    * WHAT GETS SWITCHED OFF IN PASSING. `trapFocus`, `returnFocus` and `closeOnEscape`
    * all default to `true` (`@mantine/core` `Modal.mjs`), which is why the viewer sets
    * none of them — and why nothing in a diff would draw attention to a `={false}`
-   * appearing. Each of the three is measured for real in the browser suite; this is
-   * the blocking half.
+   * appearing.
+   *
+   * 🔴 READ THE `closeOnEscape` LINE FOR EXACTLY WHAT IT SAYS, WHICH IS LESS THAN IT
+   * LOOKS. It pins that Escape is not switched OFF. That is the MIRROR IMAGE of the
+   * defect this feature actually had — one Escape closing the viewer AND the moderator
+   * review modal it is nested in — and while this assertion was the only thing here
+   * mentioning Escape, the area READ as covered while the real hazard was untested. A
+   * guard that certifies the opposite half of a hazard is worse than no guard, because
+   * it answers the question nobody needed answered. The nesting behaviour is a
+   * RELATIONSHIP between two dialogs, so it is asserted as one, in
+   * `AppListingDetailBody.viewer.browser.test.tsx` ("nested inside the moderator review
+   * modal"), and its structural half is the `Modal.Stack` seam in the test below.
    */
   it('🔴 the viewer does not switch OFF focus trap, focus return or Esc', () => {
     const src = norm(viewerSrc());
@@ -174,11 +184,59 @@ describe('🔴 the screenshot viewer is WIRED to the gallery that owns the list'
         src,
         `AppListingScreenshotViewer sets ${prop}={false}. That is the modal's a11y ` +
           `contract — focus moves into the dialog, returns to the tile that opened it, ` +
-          `and Escape closes it. All three are Mantine defaults, so turning one off is ` +
+          `and Escape closes it. All are Mantine defaults, so turning one off is ` +
           `a one-word edit no reviewer would flag.`
       ).not.toContain(`${prop}={false}`);
     }
     // …and the dialog really is labelled, which is what `aria-labelledby` resolves to.
     expect(src).toContain('title={`${name} screenshots`}');
+  });
+
+  /**
+   * 🔴 THE SECOND SEAM: `Modal.Stack` IS TWO HALVES IN TWO FILES, AND NEITHER ERRORS
+   * ALONE.
+   *
+   * In the `preview` posture the listing body renders inside `OffsiteReviewQueue`'s
+   * review `<Modal>`, so the screenshot viewer is a Modal nested in a Modal. Mantine's
+   * Esc handling is a per-Modal `window` keydown listener in CAPTURE phase, so without
+   * coordination one key closes BOTH — taking the moderator's in-progress rejection
+   * reason and their place in the queue with it.
+   *
+   * The fix pairs a `stackId` on the viewer with a `Modal.Stack` wrapper on the review
+   * modal, and the failure mode of losing either half is SILENCE: `stackId` with no
+   * `Modal.Stack` ancestor is inert (`stackProps` is applied only `if (ctx && stackId)`),
+   * and a `Modal.Stack` around a single modal changes nothing. Nothing throws, nothing
+   * warns, and the regression is only visible by opening a screenshot from the review
+   * queue and pressing one key. That is what makes it a seam rather than two settings.
+   */
+  it('🔴 the viewer joins a Modal.Stack that the review modal actually provides', () => {
+    const REVIEW = path.resolve(__dirname, '../OffsiteReviewQueue.tsx');
+    const viewer = norm(viewerSrc());
+    const review = norm(stripComments(fs.readFileSync(REVIEW, 'utf8')));
+
+    // Positive controls: both matchers can see their target, and the comment stripper
+    // is what stops each file's own PROSE (which names both halves verbatim) from
+    // satisfying the gate.
+    expect(norm('<Modal stackId="x" />')).toContain('stackId=');
+    expect(norm('<Modal.Stack>')).toContain('<Modal.Stack>');
+    expect(norm(stripComments('/* <Modal.Stack> stackId="offsite-review" */'))).not.toContain(
+      '<Modal.Stack>'
+    );
+
+    expect(
+      viewer,
+      'AppListingScreenshotViewer no longer joins a modal stack. Nested inside the ' +
+        'moderator review modal, one Escape will now close BOTH dialogs and discard ' +
+        'whatever the moderator had typed. See the header on its `stackId` prop.'
+    ).toContain('stackId="app-listing-screenshot-viewer"');
+
+    expect(
+      review,
+      'OffsiteReviewQueue no longer wraps its review Modal in a <Modal.Stack>. The ' +
+        "screenshot viewer's `stackId` is INERT without it (Modal.mjs applies stack " +
+        'props only `if (ctx && stackId)`), so Escape silently goes back to closing ' +
+        'both dialogs at once. Both halves are required; neither errors alone.'
+    ).toContain('<Modal.Stack>');
+    expect(review, 'The review Modal lost its own stackId.').toContain('stackId="offsite-review"');
   });
 });

--- a/src/components/Apps/__tests__/appListingScreenshotViewerWiring.test.ts
+++ b/src/components/Apps/__tests__/appListingScreenshotViewerWiring.test.ts
@@ -1,0 +1,184 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 🔴 SEAM GATE — the screenshot GRID and the screenshot VIEWER must stay one feature.
+ *
+ * WHY A SEAM AND NOT TWO CHECKS. The viewer's arithmetic is pinned in the blocking
+ * node project (`appListingScreenshotNav.test.ts`) and its rendered behaviour is
+ * pinned in the browser project (`AppListingDetailBody.viewer.browser.test.tsx`).
+ * Both can be fully green while the FEATURE is broken, because neither of them owns
+ * the join: the grid decides which shots exist and which index a tile represents, and
+ * the viewer navigates over that same list. If those two stop reading the SAME
+ * bindings — a viewer handed the raw `screenshots` prop instead of the filtered
+ * `shots`, or handed its own broken set instead of the gallery's — every existing
+ * test still passes and the page opens the wrong picture the moment a URL dangles.
+ * The relationship is the checkable claim, so it is checked here.
+ *
+ * 🔴 AND WHY IN THE **node** PROJECT. The browser suite that measures this for real
+ * runs only as the preview pipeline's `preview / component-tests` — report-only,
+ * non-blocking, and not reported at all when the preview build fails. A guard that
+ * lives only there cannot stop the regression coming back. This file is source TEXT,
+ * with the honesty that implies:
+ *
+ *   - CAUGHT: the viewer being dropped from the gallery; it being handed a different
+ *     list or a different broken set than the grid uses; the tile losing its
+ *     `onOpen` / `onBroken` / `index` wiring; the tile reverting to a non-button
+ *     click target; any of the Modal's three a11y defaults being switched OFF.
+ *   - NOT CAUGHT: an off-by-one inside either component, a control wired to the wrong
+ *     direction, or anything about what is actually rendered. Those are behaviour and
+ *     belong to the other two files.
+ *
+ * Same shape and same rationale as `appListingGalleryFill.test.ts` next door.
+ */
+describe('🔴 the screenshot viewer is WIRED to the gallery that owns the list', () => {
+  const BODY = path.resolve(__dirname, '../AppListingDetailBody.tsx');
+  const VIEWER = path.resolve(__dirname, '../AppListingScreenshotViewer.tsx');
+
+  /**
+   * Strip block and line comments. Load-bearing rather than tidy: BOTH files document
+   * this wiring in prose that names the props verbatim, so an unstripped match would
+   * be reading the DOCSTRING and would stay green with the real code deleted — the
+   * exact way a source gate becomes decorative.
+   */
+  const stripComments = (s: string) =>
+    s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+
+  /** Collapse whitespace so every matcher is indentation- and newline-agnostic. */
+  const norm = (s: string) => s.replace(/\s+/g, ' ');
+
+  /**
+   * A named function's body, sliced from its declaration to the start of the next
+   * TOP-LEVEL declaration.
+   *
+   * 🔴 THE OBVIOUS SLICER IS WRONG — "cut at the next column-0 `}`" truncates these
+   * functions after their first line, because a multi-line destructured signature
+   * closes with a column-0 `}: {` of its own. That is not hypothetical: it happened
+   * in this directory (see `appListingGalleryFill.test.ts`'s note), and the control
+   * below carries that exact signature shape so it cannot come back.
+   */
+  const fnBody = (src: string, name: string) => {
+    const start = src.indexOf(`function ${name}(`);
+    if (start < 0) return '';
+    const after = src.slice(start + 1);
+    const next = after.search(/\n(?:function |const |export |\/\*\*)/);
+    return next < 0 ? src.slice(start) : src.slice(start, start + 1 + next);
+  };
+
+  const bodySrc = () => stripComments(fs.readFileSync(BODY, 'utf8'));
+  const viewerSrc = () => stripComments(fs.readFileSync(VIEWER, 'utf8'));
+
+  it('every matcher can SEE its target and MISS a mutated one (positive control)', () => {
+    // 🔴 Each assertion in this file is a `toContain` or a `not.toContain`. A
+    // `toContain` that can never match, and a `not.toContain` over a needle nothing
+    // could ever spell, are both greens that mean nothing — so both directions are
+    // driven through a fixture whose answer is known.
+
+    // The slicer really isolates ONE function, returns '' when it is gone (so a
+    // rename fails loudly rather than silently matching a neighbour), and survives a
+    // multi-line destructured signature.
+    const fake =
+      'function Other() {\n  return <AppListingScreenshotViewer shots={x} />;\n}\n' +
+      'function ScreenshotGallery({\n  screenshots,\n  name,\n}: {\n' +
+      '  screenshots: S[];\n  name: string;\n}) {\n  return <SimpleGrid cols={2} />;\n}\n' +
+      'function After() {\n  return null;\n}\n';
+    expect(fnBody(fake, 'ScreenshotGallery')).toContain('cols={2}');
+    expect(fnBody(fake, 'ScreenshotGallery')).not.toContain('AppListingScreenshotViewer');
+    expect(fnBody(fake, 'ScreenshotGallery')).not.toContain('function After');
+    expect(fnBody('function Nope() {}\n', 'ScreenshotGallery')).toBe('');
+
+    // The comment stripper removes ENOUGH — both real files name these props in
+    // prose — and NOT TOO MUCH, or every `not.toContain` below passes vacuously
+    // against an empty string (`stripComments = () => ''` satisfies them all).
+    const docOnly = '/* it passes broken={broken} to the viewer */\n';
+    expect(norm(docOnly)).toContain('broken={broken}');
+    expect(norm(stripComments(docOnly))).not.toContain('broken={broken}');
+    expect(stripComments('const a = 1;')).toContain('const a = 1;');
+  });
+
+  const WHY_SEAM =
+    'ScreenshotGallery no longer mounts AppListingScreenshotViewer, or no longer ' +
+    'hands it the SAME `shots` list and `broken` set the grid itself renders from. ' +
+    'Those two bindings ARE the shared index space — a viewer reading a different ' +
+    'list opens a different screenshot than the tile the viewer clicked, and every ' +
+    'other test in this feature stays green while it does. See the header of ' +
+    'appListingScreenshotNav.ts.';
+
+  it('🔴 ScreenshotGallery mounts the viewer and shares its list and broken set', () => {
+    const body = norm(fnBody(bodySrc(), 'ScreenshotGallery'));
+    expect(body, WHY_SEAM).not.toBe('');
+
+    // The seam exists…
+    expect(body, WHY_SEAM).toContain('<AppListingScreenshotViewer');
+    // …and is fed the very bindings the grid is built from. `shots` is what the grid
+    // maps over; `broken` is what it filters by. Passing anything else here is how
+    // the two surfaces silently disagree.
+    expect(body, WHY_SEAM).toContain('shots={shots}');
+    expect(body, WHY_SEAM).toContain('broken={broken}');
+    expect(body, WHY_SEAM).toContain('index={openIndex}');
+
+    // 🔴 …and the grid is genuinely built from those same two, so the assertions
+    // above are about a SHARED binding rather than about two same-named locals.
+    expect(body, WHY_SEAM).toContain('shots .map((shot, index) => ({ shot, index }))');
+    expect(body, WHY_SEAM).toContain('!broken.has(index)');
+  });
+
+  const WHY_TILE =
+    'A screenshot tile is no longer wired to open the viewer, or no longer reports ' +
+    'its load error upward. `onBroken` is not optional politeness: the gallery owns ' +
+    'the broken set precisely so the viewer skips the same shots the grid dropped, ' +
+    'and a tile that keeps that fact to itself puts the two back out of step.';
+
+  it('🔴 each tile carries its index, its open handler and its broken reporter', () => {
+    const body = norm(fnBody(bodySrc(), 'ScreenshotGallery'));
+    expect(body, WHY_TILE).toContain('<ScreenshotTile');
+    expect(body, WHY_TILE).toContain('index={index}');
+    expect(body, WHY_TILE).toContain('onOpen={() => setOpenIndex(index)}');
+    expect(body, WHY_TILE).toContain('onBroken={() => markBroken(index)}');
+  });
+
+  const WHY_BUTTON =
+    'The screenshot tile is no longer a real <button>. An <img onClick> is not ' +
+    'tab-reachable, is not Enter/Space-activatable and exposes no accessible name, ' +
+    'so the whole gallery becomes mouse-only. Use UnstyledButton (see ScreenshotTile).';
+
+  it('🔴 the tile is a real button, and the image is not the click target', () => {
+    const tile = norm(fnBody(bodySrc(), 'ScreenshotTile'));
+    expect(tile, WHY_BUTTON).not.toBe('');
+    expect(tile, WHY_BUTTON).toContain('<UnstyledButton');
+    expect(tile, WHY_BUTTON).toContain('onClick={onOpen}');
+    // The handler belongs to the button, not to the image — a click handler on the
+    // `<img>` would render as a mouse-only affordance that LOOKS wired up.
+    expect(tile.split('<img')[1] ?? '', WHY_BUTTON).not.toContain('onClick');
+    // Positive control for that slice: the part BEFORE the `<img>` really does
+    // contain the handler, so `not.toContain` above is about the split and not about
+    // a needle that appears nowhere in the function.
+    expect(tile.split('<img')[0]).toContain('onClick={onOpen}');
+  });
+
+  /**
+   * 🔴 THE MODAL'S A11Y CONTRACT IS THREE MANTINE DEFAULTS, AND DEFAULTS ARE EXACTLY
+   * WHAT GETS SWITCHED OFF IN PASSING. `trapFocus`, `returnFocus` and `closeOnEscape`
+   * all default to `true` (`@mantine/core` `Modal.mjs`), which is why the viewer sets
+   * none of them — and why nothing in a diff would draw attention to a `={false}`
+   * appearing. Each of the three is measured for real in the browser suite; this is
+   * the blocking half.
+   */
+  it('🔴 the viewer does not switch OFF focus trap, focus return or Esc', () => {
+    const src = norm(viewerSrc());
+    for (const prop of ['trapFocus', 'returnFocus', 'closeOnEscape', 'withCloseButton']) {
+      // Positive control first: the matcher can see such a thing at all.
+      expect(norm(`<Modal ${prop}={false} />`)).toContain(`${prop}={false}`);
+      expect(
+        src,
+        `AppListingScreenshotViewer sets ${prop}={false}. That is the modal's a11y ` +
+          `contract — focus moves into the dialog, returns to the tile that opened it, ` +
+          `and Escape closes it. All three are Mantine defaults, so turning one off is ` +
+          `a one-word edit no reviewer would flag.`
+      ).not.toContain(`${prop}={false}`);
+    }
+    // …and the dialog really is labelled, which is what `aria-labelledby` resolves to.
+    expect(src).toContain('title={`${name} screenshots`}');
+  });
+});

--- a/src/components/Apps/appListingScreenshotNav.ts
+++ b/src/components/Apps/appListingScreenshotNav.ts
@@ -1,0 +1,123 @@
+/**
+ * App Store listing — the screenshot VIEWER's index arithmetic, as pure functions.
+ *
+ * 🔴 WHY THIS IS A SEPARATE MODULE AND NOT INLINE IN THE COMPONENT. The viewer's
+ * only interesting logic is index math, and index math is exactly the class of bug
+ * that ships silently: an off-by-one on open, an off-by-one on next, or prev/next
+ * swapped all render a perfectly healthy modal showing the WRONG screenshot. The
+ * browser-mode `component` project can see that — but it runs only as the preview
+ * pipeline's `preview / component-tests`, which is report-only and not reported at
+ * all when the preview build fails. So the arithmetic lives here, where the
+ * BLOCKING node `unit` project can pin it (`__tests__/appListingScreenshotNav.test.ts`).
+ * The wiring — that the tile hands these functions the index it actually represents
+ * — is a DOM fact and is pinned in `AppListingDetailBody.viewer.browser.test.tsx`.
+ * Two separate claims; neither substitutes for the other.
+ *
+ * 🔴 THE INDEX SPACE, stated once so nothing has to re-derive it. Every index below
+ * — and every index the grid and the viewer exchange — is an index into the
+ * URL-FILTERED list, `screenshots.filter((s) => !!s.url)`. It is NOT an index into
+ * the raw `ListingDetail.screenshots` array. The gallery does that filter once,
+ * before it renders anything, and both surfaces read from the same filtered array,
+ * so the tile at position *i* opens the viewer at *i* with no mapping step. A
+ * mapping step is where an off-by-one would live, so there isn't one.
+ *
+ * BROKEN SCREENSHOTS are tracked as a set of indices INTO THAT SAME LIST. A listing's
+ * screenshot URLs can dangle (the tile has hidden itself on a load error since the
+ * gallery shipped), and the set is owned by the gallery so the grid and the viewer
+ * can never disagree about which shots exist. `broken` is passed in rather than
+ * derived here because only the DOM knows: an `<img>` reports a dangling URL by
+ * firing `error`, which no amount of inspecting the array can predict.
+ */
+
+/** Indices, into the URL-filtered screenshot list, whose image failed to load. */
+export type BrokenScreenshotIndexes = ReadonlySet<number>;
+
+/**
+ * The empty broken set, as a module constant.
+ *
+ * A shared identity so a gallery that never sees a load error keeps the same set
+ * object for its whole life, and so `withBrokenIndex(NO_BROKEN_SCREENSHOTS, …)`
+ * cannot be mistaken for a mutation of it — it never is: `withBrokenIndex` copies.
+ */
+export const NO_BROKEN_SCREENSHOTS: BrokenScreenshotIndexes = new Set<number>();
+
+/**
+ * The nearest index in `direction` that is NOT broken, or `undefined` when there is
+ * none — i.e. navigation SKIPS broken screenshots and STOPS at the ends.
+ *
+ * 🔴 STOP, NOT WRAP, and it is a decision rather than an accident. The two viewers
+ * this one is modelled on disagree: `TrainingSampleViewer` stops (its arrow buttons
+ * go `disabled` at the ends) and `GeneratedOutputLightbox` wraps (`Embla loop`). A
+ * listing gallery is a short, ordered set a viewer reads front to back — wrapping
+ * from the last shot back to the first with no visible seam reads as "it broke" far
+ * more often than as a feature. Stopping also gives the controls something honest to
+ * say: `undefined` here is exactly what disables the button.
+ *
+ * `direction` is `+1` / `-1` rather than a boolean so a swapped prev/next is a
+ * mutation the caller's own tests can see, not a silent inversion of a `next: true`.
+ *
+ * OUT-OF-RANGE `index`: the search begins at `index + direction` and stops as soon as
+ * that probe is outside `[0, count)` — it does NOT clamp back toward the list. The
+ * only caller that can pass one is the viewer's rescue effect (the listing's
+ * screenshot array shrank under an open viewer), and there `undefined` from BOTH
+ * directions closes the viewer, which is correct: the shot it was displaying is gone.
+ */
+export function adjacentViableIndex(
+  index: number,
+  direction: 1 | -1,
+  count: number,
+  broken: BrokenScreenshotIndexes
+): number | undefined {
+  for (let i = index + direction; i >= 0 && i < count; i += direction) {
+    if (!broken.has(i)) return i;
+  }
+  return undefined;
+}
+
+/**
+ * The 1-based position of `index` among the VIABLE screenshots, and how many there
+ * are — i.e. the `3 / 7` the viewer shows.
+ *
+ * 🔴 BOTH NUMBERS COUNT ONLY VIABLE SHOTS, and they have to, together. A total that
+ * included broken shots would promise the viewer screenshots that prev/next can
+ * never reach (`adjacentViableIndex` skips them), so the indicator would count to a
+ * number the controls stop short of. Counting neither is the only self-consistent
+ * pair.
+ *
+ * `position` is 0 when `index` is itself broken or out of range. The viewer never
+ * displays such an index — it rescues off it (see `AppListingScreenshotViewer`) —
+ * so 0 is an unreachable-state marker, not a rendered value.
+ */
+export function viewerPosition(
+  index: number,
+  count: number,
+  broken: BrokenScreenshotIndexes
+): { position: number; total: number } {
+  let position = 0;
+  let total = 0;
+  for (let i = 0; i < count; i += 1) {
+    if (broken.has(i)) continue;
+    total += 1;
+    if (i === index) position = total;
+  }
+  return { position, total };
+}
+
+/**
+ * Add `index` to a broken set, returning the SAME set when it is already there.
+ *
+ * The identity check is load-bearing, not a micro-optimisation: this is called from
+ * an `<img>` `onError` inside a `setState` updater, and a fresh `Set` on every call
+ * makes the state change on every error event. A browser can fire `error` more than
+ * once for one element (a re-render with the same failed `src` does), so returning a
+ * new object unconditionally is a render loop waiting for a slow CDN.
+ */
+export function withBrokenIndex(
+  broken: BrokenScreenshotIndexes,
+  index: number
+): BrokenScreenshotIndexes {
+  if (broken.has(index)) return broken;
+  const next = new Set(broken);
+  next.add(index);
+  return next;
+}

--- a/src/components/Apps/useOpenerFocusReturn.ts
+++ b/src/components/Apps/useOpenerFocusReturn.ts
@@ -1,0 +1,107 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Return focus to the element that OPENED a dialog, for dialogs that are members of a
+ * Mantine `Modal.Stack`.
+ *
+ * 🔴 WHY THIS EXISTS: INSIDE A STACK, MANTINE'S OWN `returnFocus` IS BROKEN, AND IT IS
+ * BROKEN FOR EVERY MEMBER — MEASURED, NOT INFERRED.
+ *
+ * `Modal.Stack` gates each member's `trapFocus` on `ctx.currentId === stackId`
+ * (`Modal.mjs:53-57`). That value therefore FLIPS while a modal stays open: the stack
+ * registers its members from a `useEffect`, so even a lone modal renders once with
+ * `currentId === undefined` (trap off) and then again with itself current (trap on),
+ * and opening a second member flips the first back off. `useModal` feeds it straight
+ * into `useFocusReturn({ opened, shouldReturnFocus: trapFocus && returnFocus })`, whose
+ * `useDidUpdate` deps are `[opened, shouldReturnFocus]` — so every flip re-runs that
+ * effect while `opened` is still `true`, re-taking the
+ * `lastActiveElement.current = document.activeElement` branch and overwriting the
+ * opener with whatever holds focus by then (something inside the dialog).
+ *
+ * Measured with three arms differing only in the wrapper — close the dialog, then read
+ * `document.activeElement`:
+ *
+ *   without `Modal.Stack`                  → the trigger button   ✅
+ *   with `Modal.Stack`                     → `<body>`             ❌
+ *   with `Modal.Stack` + returnFocus false → `<body>`             ❌ (Mantine simply idle)
+ *
+ * The third arm is why this hook exists at all: switching Mantine's version off
+ * restores nothing by itself.
+ *
+ * 🔴 THE OTHER DIRECTION IS WEAKER THAN IT LOOKS, AND SAYING SO IS THE POINT. An
+ * earlier version of this note claimed that leaving Mantine's `returnFocus` ON would
+ * clobber ours, via its 10ms post-close timeout — "neither half works alone". That
+ * was reasoning, and a mutation sweep refuted it: with this hook in place, DELETING
+ * `returnFocus={false}` left the focus tests GREEN. Only the source gate noticed.
+ * So callers still pair the two, but for a weaker and honest reason — one owner of
+ * focus return instead of two, with Mantine's corrupted capture left inert rather
+ * than racing us in some flow nobody has measured. The gate in
+ * `__tests__/appListingScreenshotViewerWiring.test.ts` enforces the convention; it is
+ * NOT evidence that both halves are behaviourally load-bearing.
+ *
+ * THE CAPTURE HAPPENS DURING RENDER — as belt-and-braces, NOT because an effect could
+ * not work.
+ *
+ * 🔴 AN EARLIER VERSION OF THIS PARAGRAPH WAS WRONG, AND WRONG IN THE EXACT WAY THE
+ * COMMIT THAT CREATED THIS FILE CLAIMED TO BE PURGING. It asserted, as a 🔴 fact, that
+ * "an effect is TOO LATE: React runs child effects before parent effects, so the trap
+ * has already moved focus." That is reasoning dressed as measurement, and the mechanism
+ * is not what it says: `use-focus-trap.mjs` wraps `focusNode` in `setTimeout` in BOTH
+ * its ref callback and its effect, so the focus move is a MACROTASK and necessarily
+ * runs after every effect in that commit. Moving the whole capture into a plain
+ * `useEffect` was then measured green across the full suite, including a
+ * navigate-then-close probe. Effect ordering was never the reason.
+ *
+ * WHAT IS ACTUALLY TRUE, and why the render-phase read stays:
+ *   - At the render that first sees `opened === true`, this commit's DOM mutations have
+ *     not happened yet, so `document.activeElement` is unambiguously the element the
+ *     user activated. That holds without depending on anything else.
+ *   - An effect-phase read gets the same answer TODAY only because Mantine defers its
+ *     focus move to a macrotask. That is a property of Mantine's current implementation,
+ *     not a guarantee — a future version moving focus synchronously in a layout effect
+ *     would break it silently, with no test able to name the cause.
+ *   - So: keep the earlier read, which cannot be wrong, rather than the later one, which
+ *     is right for a reason outside this repo's control. That is a real justification;
+ *     "an effect is too late" was not.
+ *
+ * Reading `document.activeElement` is a side-effect-free DOM read, and the ref write is
+ * the documented "adjusting a ref for a prop transition" shape; a double render cannot
+ * corrupt it because the guard means the second pass captures the same element or
+ * nothing.
+ *
+ * 🔴 THE `!prevOpenedRef.current` HALF OF THAT GUARD IS THE WHOLE POINT OF THE HOOK.
+ * Without it the capture re-runs on EVERY render while open — which is precisely the
+ * Mantine defect this hook replaces, re-created by hand. It is reachable in ordinary
+ * use: the viewer re-renders on every arrow-key navigation. Pinned by the
+ * `{ArrowRight}` in `AppListingDetailBody.viewer.browser.test.tsx`'s "focus returns to
+ * the ORIGINATING tile on close" — open, NAVIGATE, then close. Do not remove that
+ * keystroke to "simplify" the test; without it the guard has no killing case.
+ */
+export function useOpenerFocusReturn(opened: boolean): void {
+  const openerRef = useRef<HTMLElement | null>(null);
+  const prevOpenedRef = useRef(false);
+
+  if (opened && !prevOpenedRef.current) {
+    // `typeof document` because this runs during RENDER and both hosting routes
+    // (`/apps/review`, `/apps/store-preview/[slug]`) are server-rendered. No call site
+    // passes `opened === true` on a first render today, so the guard is unreachable —
+    // but a dialog seeded open from props or a query param would make it a server-side
+    // `ReferenceError`, and that is a one-word thing to make impossible.
+    openerRef.current =
+      typeof document === 'undefined'
+        ? null
+        : (document.activeElement as HTMLElement | null) ?? null;
+  }
+  prevOpenedRef.current = opened;
+
+  useEffect(() => {
+    if (opened) return;
+    const opener = openerRef.current;
+    openerRef.current = null;
+    // `isConnected` because the opener can legitimately be gone — a queue row that the
+    // action just removed, a list that refetched. Focusing a detached node silently
+    // moves focus to `<body>`, which is the exact failure this hook exists to prevent,
+    // so not restoring at all is the better answer there.
+    if (opener?.isConnected) opener.focus({ preventScroll: true });
+  }, [opened]);
+}


### PR DESCRIPTION
## The problem

On `/apps/store-preview/<slug>` a listing's screenshots were a **dead grid**. `ScreenshotTile` rendered a plain `<img>` inside a `Card` with no click handler, no viewer, and no way to see a screenshot at anything larger than half a column.

Clicking a tile now opens that shot full-screen with prev/next controls, ArrowLeft/ArrowRight, Esc-to-close, the shot's caption and a `3 / 7` position indicator — and it opens on **the tile that was clicked**, not always on the first.

---

## What I surveyed, and what I reused

The first step was the survey, not the code. Everything below was read before anything was written.

### Reused

| Reused | For | Why |
|---|---|---|
| **Mantine `Modal`, controlled (`opened` / `onClose`)** | the whole dialog shell | The repo's modal base everywhere, and specifically the shape **`AppDetailsModal`** — the component in this same directory whose `SimpleGrid` the gallery was originally copied from — already uses. It supplies, correctly and for free, *every* a11y requirement in the brief: `role="dialog"` + `aria-modal="true"` + `aria-labelledby` wired to `title` (`ModalBaseContent.mjs:41-43`), `trapFocus`, `closeOnEscape`, `returnFocus` — all defaulting to `true` (`Modal.mjs:26-37`). **None of the a11y is hand-rolled.** |
| **`TrainingSampleViewer`** (`src/components/Training/TrainingSampleViewer/`) | the viewer's design | The closest existing thing in the repo: the only full-screen viewer that navigates over **plain URL strings** rather than a civitai `Image` entity. Ported: its full-screen `styles={{inner, content, body}}` chrome, its skip-missing navigation (`findSampleInEpoch`), its "N of M" counter that counts only reachable items (`navigablePosition` / `navigableCount`), and its `NavButton` disabled-at-the-ends arrows. |
| **The full-screen media chrome** | layout | `fullScreen` + `withOverlay={false}` + that `styles` block is byte-identical across `TrainingSampleViewer`, `GeneratedOutputLightbox` and `Model3DLightbox`. It is the repo's de-facto convention; it has simply never been extracted. |
| **`useHotkeys` (`@mantine/hooks`)** | arrow keys | The convention at every arrow-nav site in the repo (`TrainingSampleViewer.tsx:154`, `GeneratedOutputLightbox.tsx:32`, `ImageDetailProvider`). There is no shared arrow-nav hook to reuse — this *is* the pattern. |
| **Plain `<img>`** | the media | Same as the tile and `AppDetailsModal`: the URLs are CDN edge URLs, not configured Next image domains. (There is zero `next/image` usage anywhere in `src/components/Apps/`.) |

### Rejected — each for a stated structural reason

- **`dialogStore` + `DialogProvider`** — the app's dialog stack, already imported by `AppListingComments` on this very page, and the candidate I expected to adopt. Two disqualifiers, both structural rather than stylistic:
  1. **Props are a snapshot taken at `trigger()` time** and the dialog renders outside the gallery's tree, so the viewer could not share the gallery's live broken-tile set. Keeping those two in step *is* the index-consistency requirement in the brief.
  2. **`DialogProviderInner` closes by removing the dialog from the store**, so the modal *unmounts* rather than toggling `opened` to `false`. Mantine's `useFocusReturn` restores focus from a `useDidUpdate` on `[opened]` and clears its own timeout in the unmount cleanup (`use-focus-return.mjs:12-28`) — so on that path `returnFocus` **cannot fire**, and focus return would have to be hand-rolled as a deferred `.focus()` racing the focus trap. A controlled `Modal` keeps the component mounted and the built-in does the work. (This is read off the installed source, not assumed.)
- **`Embla` (`EmblaCarousel.tsx`)**, the carousel `GeneratedOutputLightbox` uses — Embla derives its snap points from **measured slide geometry**, which there comes from Tailwind classes (`flex-[0_0_100%]`). The browser-mode `component` project loads **no stylesheet at all**, so `scrollNext()` would resolve to one snap point and every prev/next test would pass while measuring nothing. A carousel is also the wrong instrument for a handful of static screenshots that need an exact index.
- **`ImageDetailByProps`, `Bounty/ImageCarousel`, `ImageViewer`** — all three are keyed on a civitai `Image` **entity** (numeric `id`, `nsfwLevel`, `meta`) and pull a live tRPC query plus `ImageGuard2` and browsing-level providers. A listing screenshot is a bare `{ url, caption }` from an allowlist DTO; there is no id to hand them.
- **`CarouselIndicators`** — generic and reusable, but its dots are `aria-hidden` + `tabIndex={-1}` decorations. The brief wants a *readable* position indicator, so a `3 / 7` text node is the right thing.
- **A generic lightbox** — there isn't one. Every full-screen media viewer in the repo is bound to a domain type.

---

## Rules I chose, and where they live

The only interesting logic here is index arithmetic, so it is a separate pure module (`appListingScreenshotNav.ts`) that the **blocking** node project can gate.

- **One index space.** Every index — the tile's, the viewer's, the broken set's — is an index into the URL-filtered list `screenshots.filter(s => !!s.url)`. `ScreenshotGallery` owns that list *and* the broken set; the grid and the viewer both read them. The tile at index *i* opens the viewer at *i* with **no mapping step**, because a mapping step is where an off-by-one would live.
- **Broken shots → skipped.** A tile that fails to load still hides itself (unchanged behaviour), but it now *reports* upward, so the viewer skips the same shots the grid dropped. Broken shots are excluded from prev/next **and** from both numbers of the position indicator — a total that counted them would promise a screenshot the controls can never reach.
  - The tile's per-tile `broken` `useState` moved up to the gallery for exactly this reason. Rendered output is unchanged.
- **Boundaries → STOP, not wrap.** At the first viable shot "Previous" is `disabled`; at the last, "Next" is. (`TrainingSampleViewer` stops, `GeneratedOutputLightbox` wraps — I picked stopping: a short ordered gallery that silently loops reads as broken, and `undefined` is what disables the control honestly.)
- **A shot that dangles *while the viewer is open*** (tiles are `loading="lazy"`, so a below-the-fold dangling URL is only discovered when the viewer fetches it) is **rescued** to the nearest reachable neighbour — forward first — and closes the viewer if none remains. The viewer is never an empty frame, and the indicator is never about a shot that isn't displayed.
- **A11y**: the tile is a real `<button>` (`UnstyledButton`) with a **content-derived** accessible name (image `alt` + caption) rather than an `aria-label` that would strip the visible caption (WCAG 2.5.3 label-in-name); focus moves into the dialog on open and returns to the originating tile on close; `aria-modal` + `aria-labelledby`; Esc closes.
- **Not omitted in `preview`.** The moderator listing-media review renders this body read-only with an explicit omission ledger ("omit every LIVE / interactive / AGGREGATE surface"). A lightbox is none of those — it queries nothing, writes nothing, acts on nothing — and a moderator reviewing a listing's *media* is the reader who most needs it full size. Called out in the code so it reads as a decision.

---

## Tests — 42 new, split by which tier can gate

| File | Project | Tests | Gates? |
|---|---|---|---|
| `__tests__/appListingScreenshotNav.test.ts` | `unit` | 14 | **Yes** — CI's `Unit tests` job |
| `__tests__/appListingScreenshotViewerWiring.test.ts` | `unit` | 5 | **Yes** — the grid↔viewer seam, as source text |
| `AppListingDetailBody.viewer.browser.test.tsx` | `component` | 23 | **No** — report-only `preview / component-tests` |

The browser project is report-only, so putting the arithmetic *only* there would mean no gate at all. Hence the pure module + a seam gate in the node tier, and honest headers on all three saying what each cannot see.

### Red / green matrix at `origin/main`

Measured in a **clean worktree at `origin/main`** with the test files copied in — not by reasoning.

| Suite | At `origin/main` | At HEAD | Label |
|---|---|---|---|
| `viewer.browser.test.tsx` | **20 failed / 3 passed** | 23 passed | New-feature coverage — see below |
| `appListingScreenshotViewerWiring.test.ts` | **4 failed / 1 passed** | 5 passed | New-feature coverage; the 1 pass is the matcher positive-control test |
| `appListingScreenshotNav.test.ts` | `Tests no tests` — **fails to import** | 14 passed | New-feature coverage, and *not even a behavioural red* |
| `AppListingDetailBody.gallery.browser.test.tsx` (untouched) | 7 passed | **7 passed** | **Regression-shaped** — unchanged |
| `AppListingDetailBody.browser.test.tsx` (untouched) | 64 passed | **64 passed** | **Regression-shaped** — unchanged |

🔴 **Labelled honestly: none of the new tests is regression coverage.** At `origin/main` the browser tests fail because there is no tile to click — an *affordance-missing* red, not a behavioural one — and the node arithmetic suite fails to **import** a module that does not exist, which is not a red at all. The genuinely regression-shaped claim in this PR is the untouched sibling suites (71 tests) still passing, which is what says turning the tile into a button did not move the grid geometry or the page structure.

The 3 browser tests that pass at `origin/main` are **invariant guards, not coverage**: "the viewer is closed until a tile is activated", "zero screenshots renders no gallery and no viewer", "every screenshot broken — nothing can be opened". They were green before and are green after; they exist to stop the *other* assertions passing for the wrong reason.

### Mutation check — 21 mutants, 21 killed, 0 survived

Each mutant names **one designated test** and only that test is run, so a kill is attributed to a specific assertion rather than to "something failed". Every one reported `1 failed | 0 passed` — i.e. the designated test, and only it, went red.

Harness controls, because a mutation sweep lies in several directions:
- **Positive control on every `-t` pattern first**: all 21 patterns matched exactly 1 test and were green unmutated. A name filter that matches nothing reports `0 failed` and reads as a pass.
- **Anchor occurrence count asserted** before each replacement, and the file hash asserted to have *changed* after the write and to be restored byte-for-byte after — a mutant that did not apply otherwise scores as a false survival.
- **The `Tests N failed | M passed` line is counted, never the exit code.**
- Mutants were written from the *spec* (the rules above), not by walking the assertions — a list derived from the tests measures self-consistency, not coverage.

| Mutant | Designated test | Verdict |
|---|---|---|
| open always shot 0 | `clicking tile N opens the viewer on shot N` | KILLED |
| open off-by-one (`index + 1`) | same, **+** `each tile carries its index, its open handler…` (node seam gate) | KILLED |
| **tile index renumbered to grid position** | `a broken screenshot does not shift the index the surviving tiles open` | KILLED |
| next off-by-one (`nextIndex + 1`) | `next advances by exactly one, and prev goes back by exactly one` | KILLED |
| **prev/next swapped** | same | KILLED |
| ArrowLeft/ArrowRight swapped | `ArrowRight and ArrowLeft move the viewer in their own directions` | KILLED |
| navigation wraps instead of stopping | `returns undefined at each end rather than wrapping` (node) **+** `at the LAST shot…` | KILLED |
| navigation does not skip broken | `skips a RUN of broken screenshots` (node) **+** `a TRAILING run… ends the navigation` | KILLED |
| indicator total counts broken shots | `counts only the shots navigation can reach` (node) **+** `excludes broken screenshots from BOTH numbers` | KILLED |
| position 0-based | `is 1-based over the whole list` (node) **+** `clicking tile N…` | KILLED |
| tile rendered as a `div` | `each tile is a keyboard-activatable <button>…` | KILLED |
| tile element renamed in source | `the tile is a real button…` (node seam gate) | KILLED |
| `returnFocus={false}` | `focus returns to the ORIGINATING tile on close` **+** node seam gate | KILLED |
| `closeOnEscape={false}` | `Escape closes the viewer` **+** node seam gate | KILLED |
| indicator renders the raw index | `clicking tile N opens the viewer on shot N` | KILLED |
| caption always shot 0's | same | KILLED |
| gallery renders when empty | `a listing with ZERO screenshots renders no gallery and no viewer` | KILLED |
| viewer handed an empty list | node seam gate **+** `clicking tile N…` | KILLED |
| viewer handed its own broken set | node seam gate **+** `excludes broken screenshots from BOTH numbers` | KILLED |
| tile loses its broken reporter | node seam gate **+** `excludes broken screenshots from BOTH numbers` | KILLED |
| **pre-existing gallery fill class removed** | `1 screenshot — the lone tile fills the whole column` (untouched suite) | KILLED |

🔴 **The sweep found a real blind spot, and the first round was wrong.** The renumbering mutant (grid position used as the viewer index) **SURVIVED** the original index-space test, which broke shot index **1**: a renumbered click on the second visible tile resolves to index 1 — *the broken shot* — so the viewer's own rescue effect skipped forward and produced the correct answer for the wrong reason. Breaking shot **0** instead shifts every later index onto a *viable* shot, which the rescue cannot launder. The test now also asserts each tile's `data-screenshot-index` directly. Fixture header records this so it cannot be "simplified" back.

Two further honest notes from the same sweep:
- The "navigation does not skip broken" mutant initially came back **PARTIAL** — killed in the node tier, survived in the browser tier, again because the rescue effect reached the same answer by another route. The browser half only discriminates where correct code says *"nothing that way"* and the mutant offers a broken shot: hence the new `a TRAILING run of broken screenshots ends the navigation` test, which asserts a **disabled** control — a state no rescue can reach after the fact.
- The "tile is not a button" mutant was **invalid, not survived** — renaming the opening tag alone left `</UnstyledButton>` behind, so the browser run reported `no tests` rather than a failure. The harness flagged it rather than scoring it; it was split into a compiling mutant for the browser tier and a text mutant for the source gate.

---

## Verification

| Check | Result |
|---|---|
| `pnpm typecheck` | **0 errors** — and the instrument was validated: a planted `let position: string = 0;` produced `error TS2322` and `3 type error(s)`, then reverted (hash-verified). |
| `eslint` (6 changed files) | 0 errors, 0 warnings, **6 files reported linted** — instrument validated against a probe file that produced 2 errors + 2 warnings (`no-wholesale-module-mock`, `no-unused-vars`, `no-img-element`, `no-unloadable-image-fixture`). |
| `prettier --check` (6 files) | clean — and it *did* flag one of them before I ran `--write`, so the check is live. |
| node `unit`, `src/components/Apps/__tests__/` | **54 files / 997 tests passed** |
| browser `component`, `src/components/Apps/` | **69 files / 908 tests passed** |
| new browser suite, 3 consecutive runs | 23/23 each time |

All re-run **after** rebasing onto current `origin/main`.

## What I could NOT verify

- **Nothing here is a visual claim.** The `component` project loads no stylesheet (no Mantine CSS, no Tailwind), so every assertion in the browser suite is structural — role, accessible name, attribute, `document.activeElement`. How the full-screen viewer actually *looks* — the overlay-arrow placement, the `object-fit: contain` sizing, the focus ring on the tile — is reasoning, not measurement. I did not run the app.
- **No real screenshot URLs were exercised.** Fixtures are inline SVG data URIs and an unresolvable host. Behaviour against actual CDN edge URLs (decode timing, very large images, portrait aspect ratios) is untested.
- **`loading="lazy"` makes below-the-fold error discovery non-deterministic** — measured, twice, while building the trailing-broken-run test: whether a second- or third-row tile is ever fetched depends on Chrome's distance-from-viewport heuristic, which earlier tests in the same file can move (a Mantine `Modal` locks body scroll). The viewer's rescue effect exists for exactly this, but it means "how many tiles have hidden themselves at time T" is not a deterministic property of a listing. Every broken-shot fixture keeps its dangling URL in the first grid row for this reason.
- **`preview / component-tests` is report-only**, so the 23 browser tests cannot block a future regression. That is why the arithmetic and the seam were extracted into the node tier — but the keyboard, focus and rendered-behaviour claims genuinely have no blocking gate.
- **Mobile/touch** — no swipe gesture, and the viewer was only exercised at 1440×900. `TrainingSampleViewer` has no swipe either; if touch-swipe is wanted, that is the argument for revisiting `Embla`.

## Open questions

1. **Stop vs wrap at the boundaries** — I chose stop (arrows go `disabled`), matching `TrainingSampleViewer`. `GeneratedOutputLightbox` wraps. Easy to flip if the product preference is the other way; it is one function and it is gated.
2. **Should the viewer show up in the moderator `preview` posture?** I kept it, reasoning above. It is a one-line gate if the answer is no.
3. **Swipe on touch** — deliberately out of scope; see above.
