### PR TITLE
test(placement): repair the stale freeSlots trpc mock #4147 outran, and pin the seam it left open

### DIFF
--- a/src/components/Account/PlacementSpaceSection.freeSlots.browser.test.tsx
+++ b/src/components/Account/PlacementSpaceSection.freeSlots.browser.test.tsx
@@ -19,9 +19,10 @@ import { renderWithProviders } from '../../../test/component-setup';
  * nobody.
  */
 
-const { mutate, spaces } = vi.hoisted(() => ({
+const { mutate, spaces, sent } = vi.hoisted(() => ({
   mutate: vi.fn(),
   spaces: { value: [] as Record<string, unknown>[] },
+  sent: { value: [] as { status: string }[] },
 }));
 
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 7 }) }));
@@ -41,6 +42,16 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
         useQuery: () => ({ data: spaces.value, isPending: false, isError: false }),
       },
       getPending: { useQuery: () => ({ data: { items: [], nextCursor: null } }) },
+      // The queue in the OTHER direction — what this creator has placed on other
+      // people's images. This mock lists procedures by hand, so a component that
+      // starts calling one that isn't here reads `undefined.useQuery` and throws
+      // during render: every test in the file then fails as a 15s
+      // `getByText('Accept all')` timeout, which names the control rather than
+      // the missing procedure. Keep this list level with what the component
+      // calls. `getMyStickerPlacements` returns a bare array of rows, not a
+      // paged `{ items }` envelope — see `getMyStickerPlacements` in
+      // `sticker-placement.service.ts`.
+      getMyStickerPlacements: { useQuery: () => ({ data: sent.value }) },
       setSpace: { useMutation: () => ({ mutate, isPending: false }) },
     },
   },
@@ -60,6 +71,7 @@ const lastPayload = () => mutate.mock.calls[mutate.mock.calls.length - 1][0];
 beforeEach(() => {
   vi.clearAllMocks();
   spaces.value = [];
+  sent.value = [];
 });
 
 describe('PlacementSpaceSection — what a save sends for freeSlots', () => {
@@ -111,5 +123,48 @@ describe('PlacementSpaceSection — what a save sends for freeSlots', () => {
     // stores the old count. Fully determined: the space is unset, so the thumb
     // rests on the surface default of 1 and one ArrowRight makes it 2.
     expect(lastPayload().freeSlots).toBe(2);
+  });
+});
+
+/**
+ * The other half of the same mock, and the reason it is asserted here rather
+ * than left as scenery: `pendingCount` is covered in isolation by
+ * `queue-counts.test.ts`, and the button is covered nowhere. Neither test can
+ * see the join — that the count the filter computes is the number this badge
+ * shows — so the filter could be right and the badge still show `rows.length`.
+ */
+describe('PlacementSpaceSection — the count on the placed-stickers button', () => {
+  const placedButton = () => page.getByRole('link', { name: /stickers you.{0,3}ve placed/i });
+  const squashed = (el: Element) => el.textContent?.replace(/\s+/g, '');
+
+  test('badges what is still waiting on someone, not everything sent', async () => {
+    // Deliberately 2-of-3 rather than all-pending: `rows.length` is 3 here, so a
+    // badge that dropped the status filter shows a DIFFERENT number instead of
+    // coincidentally the right one. The list is also not empty, which the zero
+    // case below cannot distinguish on its own.
+    sent.value = [{ status: 'pending' }, { status: 'approved' }, { status: 'pending' }];
+    renderWithProviders(<PlacementSpaceSection />);
+
+    const link = placedButton();
+    await expect.element(link).toBeInTheDocument();
+    // The WHOLE string, not `toHaveTextContent('2')`: a substring check passes
+    // on "12" and on a stray digit anywhere else in the button. Whitespace is
+    // stripped rather than collapsed because the badge is a sibling element and
+    // whether Mantine puts a space before it is layout, not behaviour — the
+    // digit is what this test is about.
+    expect(squashed(link.element())).toBe("Stickersyou'veplaced2");
+  });
+
+  test('carries no badge when nothing is outstanding', async () => {
+    // Not the empty list — approved-only. The badge is hidden because the COUNT
+    // is zero, and only a non-empty list proves the filter is what zeroed it.
+    sent.value = [{ status: 'approved' }];
+    renderWithProviders(<PlacementSpaceSection />);
+
+    const link = placedButton();
+    await expect.element(link).toBeInTheDocument();
+    // A `0` badge is a to-do list with nothing on it; the button has to read as
+    // plain text. Exact string again, so a rendered "0" cannot hide in here.
+    expect(squashed(link.element())).toBe("Stickersyou'veplaced");
   });
 });


### PR DESCRIPTION
`PlacementSpaceSection.freeSlots.browser.test.tsx` has been failing 3/3 on `main` since
#4147. This restores it, and pins the behaviour #4147 added while it is here.

`preview / component-tests` is report-only, so nothing is blocked today — but five open
PRs are green on that check only because their bases predate #4147, and every one of them
starts failing the moment it rebases. That is how a gate becomes one people click through.

## What actually broke

Not an assertion. The test hand-builds a `trpc` mock that lists procedures one by one:

```
placement: { getPriceRange, getMySpaces, getPending, setSpace }
```

#4147 added a fourth call to the component — `PlacementSpaceSection.tsx:65`:

```ts
const { data: sent } = trpc.placement.getMyStickerPlacements.useQuery({}, { enabled });
```

The mock has no `getMyStickerPlacements`, so that line reads `undefined.useQuery` and
throws during render. The component never mounts, and all three tests then die on the
control they were reaching for rather than on the missing procedure:

```
TypeError: Cannot read properties of undefined (reading 'useQuery')
 ❯ PlacementSpaceSection src/components/Account/PlacementSpaceSection.tsx:65:63

TimeoutError: locator.click: Timeout 14898ms exceeded.
Call log:
  - waiting for locator('[data-vitest="true"]').contentFrame().getByText('Accept all')
```

`Test Files 1 failed (1)` / `Tests 3 failed (3)` / `Errors 3 errors`.

Typecheck cannot see it: the factory's return is untyped, so nothing compares the mock's
`trpc` object against the real one.

## Caused, not merely exposed

Containment across six open PRs was a 6/6 split (#4165 contains #4147 and fails; #4160,
#4154, #4156, #4152, #4149 do not and pass), but containment is not a diagnosis. The
discriminating control: at current `origin/main`, revert **only**
`src/components/Account/PlacementSpaceSection.tsx` to `13e7e39c52^` and change nothing
else.

| tree | result |
|---|---|
| `origin/main` (a0f4a86fba) | `rc=1` — 3 failed (3) |
| `origin/main`, component only at `13e7e39c52^` | `rc=0` — **3 passed (3)** |

So #4147 **caused** it. Nothing latent was uncovered by it: the invariant the file
asserts — that an unrelated save omits `freeSlots` — was true before #4147, is true after
it, and #4147 does not touch `commit()` or any free-slot code path.

The pre-existing *fragility* is the mocking style, not a defect: a hand-listed `trpc`
object is a fixture that silently falls behind the component. Worth noting that
`local-rules/no-wholesale-module-mock` already exists in this repo and its message
describes this exact failure mode — but it guards the **module** export surface, and the
mock here spreads `importOriginal` correctly. The same hazard one level down, inside the
`trpc` value, is not covered by anything. Flagging, not fixing, in this PR.

## Case (a) or case (b)?

**Neither, and that is the finding.**

- **(b) is ruled out.** No production behaviour is wrong. `getMyStickerPlacements` exists
  on the router (`placement.router.ts:360`), returns a bare array of rows, and
  `pendingCount(sent ?? [])` reads `status` off them correctly. **No production file is
  touched by this PR.**
- **(a) is ruled out.** No invariant changed. The three original assertions are
  byte-identical in this diff — not loosened, not skipped, not deleted, not reworded.

What was stale is the test's **fixture**, and the repair is additive: one missing
procedure added to the mock. If the fix had required weakening any of the three
assertions, that would have been the signal the diagnosis was wrong.

## What is added, and why it is not scenery

A mock entry nothing asserts is dead weight that the next person deletes. So the two new
tests pin the seam #4147 left open: `pendingCount` is covered in isolation by
`queue-counts.test.ts`, the button is covered nowhere, and **neither can see the join** —
the filter could be correct while the badge still renders `rows.length`.

Both fixtures are deliberately `2 pending + 1 approved` and `1 approved` rather than
all-pending or empty: `rows.length` is 3 and 1 there, so a badge that dropped the status
filter shows a *different* number instead of coincidentally the right one, and the
zero case is proved by the filter rather than by an empty list. Assertions pin the whole
normalised string, not `toHaveTextContent('2')`, which passes on `"12"`.

## Red → green

Command: `vitest run --project component <path>`, browser-mode Chromium.

| tree | result |
|---|---|
| `origin/main` | `rc=1` — **3 failed** (3) |
| `origin/main`, component at `13e7e39c52^` (causation control) | `rc=0` — 3 passed (3) |
| this branch, the one file | `rc=0` — **5 passed** (5) |
| this branch, whole `component` project over `src/components/Account` + `src/components/Placement` | `rc=0` — **19 passed** (19), 3 files |

The neighbours (`DeleteCard`, `SettingsCard.earlyAdopter`) were green before and are green
after. `pnpm typecheck`, `eslint` and `prettier --check` are clean on the changed file.

## Mutation results — the tests still have teeth

Each mutant was applied alone to production code and reverted before the next. Every one
died on **its own** assertion, and the survivals are the informative half.

| # | mutant | killed by | message |
|---|---|---|---|
| 1 | `freeSlots: nextFreeSlots` → `nextFreeSlots ?? freeSlots ?? undefined` | *stored count untouched* | `expected 3 to be undefined` |
| 1b | `… ?? freeSlots ?? 1` | *NULL count untouched* **and** *stored count untouched* | `expected 1 to be undefined`, `expected 3 to be undefined` |
| 2 | slider commits `freeSlots ?? 1` instead of `value` | *moving the control sends the number* | `expected 1 to be 2` |
| 3 | `pendingCount(sent ?? [])` → `(sent ?? []).length` | both badge tests | `expected 'Stickersyou'veplaced3' to be '…2'`, `expected '…1' to be '…'` |
| 4 | `placedCount > 0` → `placedCount >= 0` | *carries no badge* | `expected 'Stickersyou'veplaced0' to be '…'` |

Mutant 1 **survives** the NULL test, correctly — with a NULL stored count
`nextFreeSlots ?? freeSlots ?? undefined` is still `undefined`. That is precisely why the
file carries both the NULL and the stored-number case, and it is what tells us the two
tests are not redundant. Mutants 3 and 4 separate the *filter* from the *render gate*:
3 kills both badge tests, 4 kills only the zero case, so neither test is riding on the
other's failure.

Positive control on the repair itself: delete the one added mock line from this branch and
the file goes back to `5 failed`, all with
`TypeError: Cannot read properties of undefined (reading 'useQuery')` at
`PlacementSpaceSection.tsx:65`. The line is load-bearing, not decoration.

## Unverified

- The five other open PRs were not rebased onto this branch to confirm they go green;
  the claim that they fail on rebase rests on the containment split above.
- Run locally on NixOS via the documented `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` escape
  hatch (host bundle is chromium-1228, the repo pin wants 1200). CI runs a
  version-matched image, so CI is the authority on the browser-provider path.
