### PR TITLE
feat(model-file-hash): implement the SHA256_12 backfill endpoint

### DIFF
--- a/docs/image-resource-hash-matching.md
+++ b/docs/image-resource-hash-matching.md
@@ -20,13 +20,13 @@ four-stage pipeline.
 **Stage 1 — collect candidates** (lines 12–86). Five `UNION ALL` branches pull `(name, hash)` pairs
 out of `Image.meta`, because different tools write metadata differently:
 
-| Branch | Source | Shape |
-|---|---|---|
-| 1 | `meta.resources[]` | array with name / hash / weight |
-| 2 | `meta.hashes{}` | object — **the Forge / A1111 path, and the subject of this document** |
-| 3 | `meta."Model hash"` | single checkpoint string |
-| 4 | `meta.civitaiResources[]` | carries `modelVersionId` **directly — no hash** |
-| 5 | `Post.modelVersionId` | inherited, `detected: false` |
+| Branch | Source                    | Shape                                                                 |
+| ------ | ------------------------- | --------------------------------------------------------------------- |
+| 1      | `meta.resources[]`        | array with name / hash / weight                                       |
+| 2      | `meta.hashes{}`           | object — **the Forge / A1111 path, and the subject of this document** |
+| 3      | `meta."Model hash"`       | single checkpoint string                                              |
+| 4      | `meta.civitaiResources[]` | carries `modelVersionId` **directly — no hash**                       |
+| 5      | `Post.modelVersionId`     | inherited, `detected: false`                                          |
 
 Branch 4 is why on-site generations always work: we wrote that metadata ourselves and put the
 version id in it, so no matching is required.
@@ -56,7 +56,7 @@ once. A tool writes 10 characters and hits `AutoV2`; 12 characters and hits `Aut
 That is genuinely useful, and it is also the defect: **the system matches _values_, not
 _algorithms_.** It behaves as a lookup table of every hash string we have ever stored, and detection
 succeeds if and only if the generating tool wrote a string we hold verbatim. Exact equality cannot
-see that one string is a *prefix* of another.
+see that one string is a _prefix_ of another.
 
 ---
 
@@ -85,14 +85,14 @@ hash: hash?.replace('0x', '').slice(0, 12),   // correct as written — leave it
 ```
 
 SwarmUI's `sui_models[].hash` is a **tensorhash**, not a file SHA256 — per its own spec, linked at
-`swarmui.metadata.ts:21`: *"a hash of the data of the model processing only its tensor sections and
-not its header (ie to allow metadata to change without affecting the hash)"*. That is the same
+`swarmui.metadata.ts:21`: _"a hash of the data of the model processing only its tensor sections and
+not its header (ie to allow metadata to change without affecting the hash)"_. That is the same
 quantity as `AutoV3`, which we store truncated to 12. (Prod did that in a `truncate_autov3_hash()`
 trigger, `SUBSTRING(NEW.hash FROM 1 FOR 12)`; `normalizeScanHashes()` took it over in application
 code and migration `20260819010000` drops the trigger.)
 
 So `.slice(0, 12)` lands **exactly on `AutoV3`** — the one 12-character value that does match.
-Truncating to 10 would produce a 10-character *tensor*-hash prefix, and `AutoV2` is a *file*-hash
+Truncating to 10 would produce a 10-character _tensor_-hash prefix, and `AutoV2` is a _file_-hash
 prefix, so it would match nothing.
 
 This also explains the AutoV3 collision behaviour noted under Collision analysis: 1,505 AutoV3 values
@@ -175,7 +175,7 @@ v1.10.1 (stock A1111)       n=2409   exact=2341   sha12=5
 ```
 
 Stock A1111 is clean; Forge and Forge Neo carry essentially all of it. **It is not purely per-build,
-though**: 1,332 images in that single day contain *both* an exact-matching and a `sha12` LoRA hash,
+though**: 1,332 images in that single day contain _both_ an exact-matching and a `sha12` LoRA hash,
 so the same build emits both forms depending on the file. Treat "which build" as an open question,
 not a settled one.
 
@@ -183,11 +183,11 @@ not a settled one.
 
 Two independent samples over different windows:
 
-| Outcome | Sample A (1 day, n=800) | Sample B (1 day, n=2887) |
-|---|---|---|
-| Matches `AutoV3` — works today | 680 (85%) | 2549 (88.3%) |
-| Recoverable via `left(,10)` + SHA256 confirm | 57 (7.1%) | 168 (5.8%) |
-| Matches neither — genuinely local / unpublished | 63 (7.9%) | 170 (5.9%) |
+| Outcome                                         | Sample A (1 day, n=800) | Sample B (1 day, n=2887) |
+| ----------------------------------------------- | ----------------------- | ------------------------ |
+| Matches `AutoV3` — works today                  | 680 (85%)               | 2549 (88.3%)             |
+| Recoverable via `left(,10)` + SHA256 confirm    | 57 (7.1%)               | 168 (5.8%)               |
+| Matches neither — genuinely local / unpublished | 63 (7.9%)               | 170 (5.9%)               |
 
 So the fix recovers roughly **6–7% of all LoRA references, and about half of currently-failing
 ones**. In sample B, **all 168** prefix hits also passed the 12-character SHA256 confirmation —
@@ -204,11 +204,11 @@ rather than assumed.
 ≈ n²/2N = **0.92**. Observed: **1**. The estimate is accurate, so it projects:
 
 | Distinct files | Expected 10-char collisions | Expected 12-char collisions |
-|---|---|---|
-| 1.43M (today) | 0.9 (1 observed) | 0.004 (0 observed) |
-| 3M | 4 | 0.02 |
-| 10M | 46 | 0.18 |
-| 20M | 182 | 0.71 |
+| -------------- | --------------------------- | --------------------------- |
+| 1.43M (today)  | 0.9 (1 observed)            | 0.004 (0 observed)          |
+| 3M             | 4                           | 0.02                        |
+| 10M            | 46                          | 0.18                        |
+| 20M            | 182                         | 0.71                        |
 
 Collisions grow quadratically, so 10-character matching degrades faster than the catalog grows.
 
@@ -216,10 +216,10 @@ Collisions grow quadratically, so 10-character matching degrades faster than the
 `row_number` dedup already resolves those, and only **1** is a true prefix collision.
 
 **`AutoV3` is different, and worse than a naive reading suggests.** 44,321 `AutoV3` values map to
-more than one file, and **1,505 of those map to byte-*different* files** — roughly 400,000× what
+more than one file, and **1,505 of those map to byte-_different_ files** — roughly 400,000× what
 48-bit birthday collisions would predict. That is not probabilistic: `AutoV3` is a tensor-only hash
 that is deliberately blind to header/metadata differences, so two files with identical tensors and
-different metadata share one. This argues *for* the SHA256-confirm path below, which has 0
+different metadata share one. This argues _for_ the SHA256-confirm path below, which has 0
 collisions against `AutoV3`'s 1,505.
 
 This 10-character exposure is **pre-existing, not introduced by this work**: `AutoV2` is already the
@@ -241,14 +241,14 @@ This is not a special case bolted onto the resolver — it is the same mechanism
 (`SHA256[0:10]`) and `AutoV3` (tensor hash at 12) already use. The schema is a table of truncations
 mirroring what generation tools emit; this fills the one entry that was missing.
 
-| Change | Where |
-|---|---|
-| `SHA256_12` enum value | `schema.full.prisma`, migration `20260819000000_model_file_hash_sha256_12` |
-| Derive it | `normalizeScanHashes()` in `src/server/services/model-file-scan.service.ts`. Produces every truncated form (AutoV3, SHA256_12) in one place, in application code. Both hash-writing paths call it — `applyScanOutcome` and `/api/mod/reprocess-scan`, which needs it independently because it replays `rawScanResult` where AutoV3 is still full-length. |
-| Guard it | `src/server/services/__tests__/model-file-hash-writers.test.ts` — a ledger of every `ModelFileHash` writer, enumerated from source, failing when the set grows or shrinks; plus behavioural cases in `reprocess-scan-hash-derivation.test.ts` and `model-file-hash-writer-exemption.test.ts` |
-| Backfill existing files | 🔴 **not implemented** — see below |
-| Detection SQL | **unchanged** |
-| Public API | **unchanged** — the new type is returned alongside the others, exactly as `AutoV2` (also a `SHA256` truncation) already is |
+| Change                  | Where                                                                                                                                                                                                                                                                                                                                                    |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SHA256_12` enum value  | `schema.full.prisma`, migration `20260819000000_model_file_hash_sha256_12`                                                                                                                                                                                                                                                                               |
+| Derive it               | `normalizeScanHashes()` in `src/server/services/model-file-scan.service.ts`. Produces every truncated form (AutoV3, SHA256_12) in one place, in application code. Both hash-writing paths call it — `applyScanOutcome` and `/api/mod/reprocess-scan`, which needs it independently because it replays `rawScanResult` where AutoV3 is still full-length. |
+| Guard it                | `src/server/services/__tests__/model-file-hash-writers.test.ts` — a ledger of every `ModelFileHash` writer, enumerated from source, failing when the set grows or shrinks; plus behavioural cases in `reprocess-scan-hash-derivation.test.ts` and `model-file-hash-writer-exemption.test.ts`                                                             |
+| Backfill existing files | `GET /api/admin/temp/backfill-sha256-12` — see below                                                                                                                                                                                                                                                                                                     |
+| Detection SQL           | **unchanged**                                                                                                                                                                                                                                                                                                                                            |
+| Public API              | **unchanged** — the new type is returned alongside the others, exactly as `AutoV2` (also a `SHA256` truncation) already is                                                                                                                                                                                                                               |
 
 ### Why not a prefix match in SQL
 
@@ -262,22 +262,51 @@ uploader is warned about. Adding rows introduces no new code path, so none of th
 Storage is net negative anyway: +400 MB of rows against −577 MB from dropping `modelfilehash_hash`,
 an index on `lower(hash)` over a `citext` column with **849 lifetime scans**.
 
-### Backfill — 🔴 NOT IMPLEMENTED
+### Backfill
 
-This section previously documented a `GET /api/admin/temp/backfill-sha256-12` endpoint, and the
-`20260819000000` migration told the operator to run it. **That file has never existed on any
-branch** (`git log --diff-filter=A -- src/pages/api/admin/temp/backfill-sha256-12.ts` returns
-nothing), so following either instruction gets a 404.
+`GET /api/admin/temp/backfill-sha256-12`, guarded by `WEBHOOK_TOKEN` like every other endpoint in
+that directory. (Two earlier revisions of this section were wrong in opposite directions: the first
+documented the endpoint before it existed, the second recorded that it never had. It exists now.)
 
-The design it described is still the right one — derive entirely from stored `SHA256` rows, no file
-access, no orchestrator, no re-scan; batch internally, log a resumable cursor, idempotent via
-`ON CONFLICT ("fileId", type) DO NOTHING` — it just has not been written.
+It derives entirely from stored `SHA256` rows — no file access, no orchestrator, no re-scan. Each
+hash goes through `normalizeScanHashes()` rather than being truncated inline, so the backfill
+inherits the scan path's rules and **cannot drift from them**. That is load-bearing, not stylistic:
+the helper suppresses derivation from the all-zero "file unreachable" sentinel, and an inline
+`slice(0, 12)` would give every unreachable file the same 12-char hash and make them all match each
+other. It is the fourth entry in the writer ledger
+(`src/server/services/__tests__/model-file-hash-writers.test.ts`).
 
-Until it is, the split is: files scanned **after** the release that ships `normalizeScanHashes()`
-get their `SHA256_12` row from the scan path; files scanned **before** it keep failing 12-char LoRA
-detection exactly as they do today, indefinitely. That is not a half-broken state, but it is also
-not self-healing — the existing corpus needs either this backfill or a replay through
-`/api/mod/reprocess-scan`.
+Idempotent via `createMany({ skipDuplicates: true })` → `ON CONFLICT ("fileId", type) DO NOTHING`
+against `ModelFileHash_pkey`, the table's only unique constraint. Re-running a completed range
+writes nothing and costs only the read.
+
+| Param        | Default         | Meaning                                             |
+| ------------ | --------------- | --------------------------------------------------- |
+| `dryRun`     | `true`          | Count what a live run would insert, without writing |
+| `batchSize`  | 1000 (max 5000) | `SHA256` rows per page                              |
+| `maxBatches` | 100 (max 10000) | Hard cap on batches per invocation                  |
+| `start`      | 0               | Minimum `fileId` — the resume point                 |
+| `end`        | —               | Maximum `fileId`                                    |
+
+A full pass is ~1.49M `SHA256` rows, so at the defaults **one call does not finish the corpus**: it
+stops at 100 batches (~100k files) and returns `complete: false` with `lastCursor`. Resume with
+`start=<lastCursor>` until `complete: true`. Start with the default `dryRun=true` — its `candidates`
+is the real write volume, computed against existing siblings rather than assumed from the row count.
+
+🔴 **Production was already backfilled out-of-band on 2026-08-19/20**, before this endpoint existed.
+Measured on the nvme0 replica 2026-08-20: 1,489,384 `SHA256` rows against 1,489,372 `SHA256_12`
+rows, all 12 chars, **zero** disagreeing with `left(sha256, 12)`, and every one of them created
+between `22:15Z` and `02:29Z` — i.e. by a manual pass, not by the scan path. The anti-join finds
+**15** `SHA256` rows still lacking a sibling. So the corpus-wide run this endpoint was designed for
+is already done; what remains is a near-free idempotent sweep. Treat the "~1.5M rows failing
+indefinitely" framing above as historical — re-run the anti-join before planning any run:
+
+```sql
+SELECT count(*) FROM "ModelFileHash" s
+WHERE s.type = 'SHA256' AND s.hash !~ '^0+$'
+  AND NOT EXISTS (SELECT 1 FROM "ModelFileHash" t
+                  WHERE t."fileId" = s."fileId" AND t.type = 'SHA256_12');
+```
 
 ### One accepted behaviour change
 
@@ -306,7 +335,7 @@ loss. The case for the confirm step rests on the **10M-file projection (46 colli
 present-day benefit, and it should be argued on those terms.
 
 **Store `SHA256[0:12]` as its own hash type row.** Because the Stage 2 join has no type filter, this
-would work with *zero* SQL change — the most elegant option on paper. Rejected on size:
+would work with _zero_ SQL change — the most elegant option on paper. Rejected on size:
 `ModelFileHash` is **8,751,379 rows / 2,305 MB** (744 MB heap + 1,561 MB indexes), and this adds one
 row per `SHA256` row — **+1,486,996 rows, +17%, roughly 400 MB** — to store a prefix of a column
 that already exists on a sibling row of the same table, plus a backfill over 1.5M files and a
@@ -331,7 +360,7 @@ There is therefore no separate write path. `createImageResources()`
 (`src/server/services/image.service.ts:8671`) is the live writer, and it consumes
 `get_image_resources()` output — so fixing that one function fixes both directions.
 
-🔴 **Latent hazard worth fixing separately:** `pnpm db:program` applies *every* `.sql` in the
+🔴 **Latent hazard worth fixing separately:** `pnpm db:program` applies _every_ `.sql` in the
 programmability directory, so the next run **re-creates the dropped function**. It would be inert
 (no callers), but it is a deliberately-removed object silently reappearing, pointed at the wrong
 table. The file should be deleted rather than left to be resurrected.
@@ -381,7 +410,7 @@ still cap the warning at one for any image with two genuinely-unmatchable resour
 `ORDER BY`, and `createImageResources` applies `uniqBy(modelversionid)`, which keeps whichever row
 came first. Normally `row_number_version` guarantees one row per version — but the final
 `OR iri.hash IS NULL` lets branch-4 (`civitaiResources`) rows bypass that filter, so an image
-carrying *both* `civitaiResources` and `hashes` can emit two rows for one version. Measured on two
+carrying _both_ `civitaiResources` and `hashes` can emit two rows for one version. Measured on two
 ComfyUI images in the corpus (140015836, 140015048): version 3181498 appears twice, once as
 `('kreamania_variant6', hash 6a847a168a)` and once as `('checkpoint', hash NULL)`.
 
@@ -467,15 +496,15 @@ It needs its own fixtures. The `local/hashfix` harness exercises the SQL only.
 The images below are real uploads whose embedded metadata exercises each case. Fetch them from the
 CDN at `original=true` (a transformed variant drops the metadata) to rebuild a fixture set.
 
-| Image id | Case | Expected after a fix |
-|---|---|---|
-| 139444993 | `SHA256[0:12]`, `neo-2.28` | `ffdb3743c1c8` resolves to version 3214341 |
-| 138775138 | 3 LoRAs, 1 matching | `7e5a17e35800` keeps resolving to 365933; other two resolve; **two** unmatched reported, not one |
-| 139934636 | local-only LoRA | still resolves to **nothing** — matching it means the comparison is too loose |
-| 135566724, 119372854 | `0x` prefix | unchanged until the algorithm is identified |
-| 139830592 | `neo-2.28`, matches today | unchanged — the A/B partner for 139444993 |
-| 140087915 | 5 LoRAs, mixed outcomes | multi-resource regression case |
-| 140039335 | mojibake in a LoRA name | unrelated UTF-8 decoding case, noted in passing |
+| Image id             | Case                       | Expected after a fix                                                                             |
+| -------------------- | -------------------------- | ------------------------------------------------------------------------------------------------ |
+| 139444993            | `SHA256[0:12]`, `neo-2.28` | `ffdb3743c1c8` resolves to version 3214341                                                       |
+| 138775138            | 3 LoRAs, 1 matching        | `7e5a17e35800` keeps resolving to 365933; other two resolve; **two** unmatched reported, not one |
+| 139934636            | local-only LoRA            | still resolves to **nothing** — matching it means the comparison is too loose                    |
+| 135566724, 119372854 | `0x` prefix                | unchanged until the algorithm is identified                                                      |
+| 139830592            | `neo-2.28`, matches today  | unchanged — the A/B partner for 139444993                                                        |
+| 140087915            | 5 LoRAs, mixed outcomes    | multi-resource regression case                                                                   |
+| 140039335            | mojibake in a LoRA name    | unrelated UTF-8 decoding case, noted in passing                                                  |
 
 A fix is correct when the majority path (85–88% of references, matching `AutoV3` today) is provably
 unchanged. That negative control matters as much as the positive ones: the failure mode of a

--- a/packages/civitai-db-schema/prisma/migrations/20260819000000_model_file_hash_sha256_12/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260819000000_model_file_hash_sha256_12/migration.sql
@@ -16,12 +16,15 @@ ALTER TYPE "ModelHashType" ADD VALUE IF NOT EXISTS 'SHA256_12';
 -- Backfill is NOT run here. ADD VALUE cannot be referenced in the same transaction that adds
 -- it, and this is ~1.5M rows.
 --
--- 🔴 THE BACKFILL IS NOT IMPLEMENTED. This comment (and docs/image-resource-hash-matching.md)
--- used to describe a `GET /api/admin/temp/backfill-sha256-12` endpoint. That file has never
--- existed on any branch — `git log --diff-filter=A -- src/pages/api/admin/temp/backfill-sha256-12.ts`
--- returns nothing. Anyone following the old instruction gets a 404, not a backfill.
+-- The backfill is `GET /api/admin/temp/backfill-sha256-12` — token-gated, dry-run by default,
+-- batched, resumable via `start=<lastCursor>`, idempotent via ON CONFLICT ("fileId", type) DO
+-- NOTHING. It derives from the stored SHA256 row THROUGH normalizeScanHashes() rather than
+-- truncating inline, so it inherits the all-zero "file unreachable" sentinel guard; deriving from
+-- that sentinel would give every unreachable file the same 12-char hash. See
+-- docs/image-resource-hash-matching.md for the parameters and the resume loop.
 --
--- Consequence, and it is not a broken state: files scanned AFTER the release that ships
--- normalizeScanHashes() get their SHA256_12 row from the scan path. Files scanned BEFORE it keep
--- failing 12-char LoRA detection exactly as they do today, indefinitely, until someone either
--- writes the backfill or replays them through /api/mod/reprocess-scan.
+-- 🔴 Production was already backfilled OUT-OF-BAND on 2026-08-19/20, before that endpoint existed.
+-- Measured on the nvme0 replica 2026-08-20: 1,489,372 SHA256_12 rows against 1,489,384 SHA256
+-- rows, all 12 chars, none disagreeing with left(sha256,12), every one created between 22:15Z and
+-- 02:29Z. The anti-join leaves 15 files short. Re-run that anti-join (in the doc) before planning
+-- a run — do not assume a corpus-wide job is still outstanding.

--- a/src/pages/api/admin/temp/backfill-sha256-12.ts
+++ b/src/pages/api/admin/temp/backfill-sha256-12.ts
@@ -1,0 +1,238 @@
+/**
+ * Backfill `SHA256_12` rows for files scanned before `normalizeScanHashes()` shipped.
+ * =============================================================================
+ *
+ * Hidden admin route. Guarded by WEBHOOK_TOKEN via `?token=` query param, the same as every
+ * other endpoint in this directory.
+ *
+ * ## Why
+ *
+ * A1111/Forge write `sha256[0:12]` into image metadata for LoRAs. `AutoV2` is `sha256[0:10]`
+ * and `AutoV3` is a different (tensor-only) algorithm, so no stored width matched that value
+ * and resource detection silently failed. Migration `20260819000000_model_file_hash_sha256_12`
+ * added the enum value; `normalizeScanHashes()` derives the row on the SCAN path.
+ *
+ * The scan path only covers files scanned AFTER that release. The pre-existing corpus never
+ * gets a row and is not self-healing. This endpoint closes that gap.
+ *
+ * ## How
+ *
+ * Derived entirely from stored `SHA256` rows — no file access, no orchestrator, no re-scan.
+ * Each hash is passed through `normalizeScanHashes()` rather than truncated here, so this
+ * writer inherits the same rules as the scan path (including the all-zero sentinel guard
+ * below) and cannot drift from it. See the writer ledger in
+ * src/server/services/__tests__/model-file-hash-writers.test.ts.
+ *
+ * 🔴 The all-zero `SHA256` is the "file unreachable" sentinel. Deriving from it would give
+ * every such file the SAME 12-char hash, so they would all match each other. It is
+ * `normalizeScanHashes()` that suppresses it — this endpoint gets that for free by calling the
+ * helper, and would reintroduce the bug the moment it truncated inline instead.
+ *
+ * Idempotent: `createMany({ skipDuplicates: true })` compiles to
+ * `ON CONFLICT ("fileId", type) DO NOTHING` against the `ModelFileHash_pkey` on
+ * `("fileId", type)` — the table's only unique constraint. A second run over the same range
+ * writes nothing and reports `written: 0`.
+ *
+ * ## Cost of a full run, and how to resume
+ *
+ * The scan is a `fileId`-ordered walk of `type='SHA256'` rows. As of 2026-08-20 production
+ * holds 1,489,384 such rows, so a full pass reads ~1.49M rows and writes at most one row per
+ * file (~400 MB at full corpus width). At the default `batchSize=1000` that is ~1,490 batches;
+ * `maxBatches` caps a single invocation at 100 batches (~100k files) so one call cannot run
+ * unbounded against production.
+ *
+ * A run therefore does NOT finish the corpus by default. The response reports:
+ *
+ *   complete   - true when the range was exhausted, false when `maxBatches` stopped it early
+ *   lastCursor - the next `fileId` to start from
+ *
+ * Resume by passing `start=<lastCursor>` and calling again until `complete: true`. Because the
+ * write is idempotent, re-running an already-processed range is safe and costs only the read.
+ *
+ * ⚠️ Start with `dryRun=true` (the default) to see the scale before writing. Dry run performs
+ * an extra lookup per batch to count rows that genuinely lack a `SHA256_12` sibling, so its
+ * `candidates` is the real number of writes a live run would make — not the row count scanned.
+ *
+ * Usage:
+ *   GET /api/admin/temp/backfill-sha256-12?token=$WEBHOOK_TOKEN
+ *   GET /api/admin/temp/backfill-sha256-12?token=$WEBHOOK_TOKEN&dryRun=false&start=123456
+ *
+ * Params (query):
+ *   dryRun     - default true. Report candidates without writing.
+ *   batchSize  - default 1000, max 5000. SHA256 rows per page.
+ *   maxBatches - default 100, max 10000. Hard bound on batches per invocation.
+ *   start      - default 0. Minimum ModelFile id to consider (resume point).
+ *   end        - optional. Maximum ModelFile id to consider.
+ */
+
+import * as z from 'zod';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { normalizeScanHashes } from '~/server/services/model-file-scan.service';
+import { ModelHashType } from '~/shared/utils/prisma/enums';
+import { WebhookEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { createLogger } from '~/utils/logging';
+import { booleanString } from '~/utils/zod-helpers';
+
+const log = createLogger('backfill-sha256-12', 'cyan');
+
+const querySchema = z.object({
+  dryRun: booleanString().default(true),
+  batchSize: z.coerce.number().min(1).max(5000).default(1000),
+  maxBatches: z.coerce.number().min(1).max(10000).default(100),
+  start: z.coerce.number().min(0).optional().default(0),
+  end: z.coerce.number().optional(),
+});
+
+type Stats = {
+  /** SHA256 rows read. */
+  scanned: number;
+  /** Rows normalizeScanHashes produced a SHA256_12 for. */
+  derivable: number;
+  /**
+   * Rows it did NOT — the all-zero "file unreachable" sentinel. Reported separately because a
+   * non-zero value here is the guard doing its job, not an error.
+   */
+  skippedSentinel: number;
+  /** Dry run only: derivable rows with no existing SHA256_12 sibling. */
+  candidates: number;
+  /** Live run only: rows the database actually inserted, after ON CONFLICT DO NOTHING. */
+  written: number;
+  batches: number;
+};
+
+export default WebhookEndpoint(async (req, res) => {
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ ok: false, error: z.treeifyError(parsed.error) });
+  }
+  const params = parsed.data;
+  const startTime = Date.now();
+  const stats: Stats = {
+    scanned: 0,
+    derivable: 0,
+    skippedSentinel: 0,
+    candidates: 0,
+    written: 0,
+    batches: 0,
+  };
+
+  let cursor = params.start;
+  let complete = false;
+
+  try {
+    log(
+      `Starting${params.dryRun ? ' (DRY RUN)' : ''} | batchSize=${params.batchSize} ` +
+        `maxBatches=${params.maxBatches} start=${params.start} end=${params.end ?? 'MAX'}`
+    );
+
+    while (stats.batches < params.maxBatches) {
+      const rows = await dbRead.modelFileHash.findMany({
+        where: {
+          type: ModelHashType.SHA256,
+          fileId: { gte: cursor, ...(params.end !== undefined && { lte: params.end }) },
+        },
+        select: { fileId: true, hash: true },
+        orderBy: { fileId: 'asc' },
+        take: params.batchSize,
+      });
+
+      if (rows.length === 0) {
+        complete = true;
+        break;
+      }
+
+      stats.batches++;
+      stats.scanned += rows.length;
+      const firstId = rows[0].fileId;
+      const lastId = rows[rows.length - 1].fileId;
+
+      // The derivation. Deliberately NOT `hash.slice(0, 12)` — the helper owns the rules,
+      // including suppressing the all-zero sentinel, and it is the same call the scan path
+      // makes. Re-implementing it here is the exact drift the writer ledger exists to catch.
+      const toWrite: { fileId: number; type: ModelHashType; hash: string }[] = [];
+      for (const row of rows) {
+        const derived = normalizeScanHashes({ [ModelHashType.SHA256]: row.hash }).SHA256_12;
+        if (!derived) {
+          stats.skippedSentinel++;
+          continue;
+        }
+        stats.derivable++;
+        toWrite.push({ fileId: row.fileId, type: ModelHashType.SHA256_12, hash: derived });
+      }
+
+      if (toWrite.length > 0) {
+        if (params.dryRun) {
+          // Count what a live run would insert, rather than assuming every derivable row is a
+          // write. Most of the corpus may already be covered, and reporting `derivable` as the
+          // write volume would overstate the job to whoever is deciding whether to run it.
+          const existing = await dbRead.modelFileHash.findMany({
+            where: {
+              type: ModelHashType.SHA256_12,
+              fileId: { in: toWrite.map((r) => r.fileId) },
+            },
+            select: { fileId: true },
+          });
+          const covered = new Set(existing.map((r) => r.fileId));
+          stats.candidates += toWrite.filter((r) => !covered.has(r.fileId)).length;
+        } else {
+          // skipDuplicates -> ON CONFLICT ("fileId", type) DO NOTHING. `count` is what the
+          // database really inserted, so a re-run over covered ground reports 0 rather than
+          // restating the candidate count.
+          const result = await dbWrite.modelFileHash.createMany({
+            data: toWrite,
+            skipDuplicates: true,
+          });
+          stats.written += result.count;
+        }
+      }
+
+      const elapsedSec = (Date.now() - startTime) / 1000;
+      log(
+        `[batch ${stats.batches} | fileId ${firstId}-${lastId}] ${rows.length} scanned | ` +
+          `totals: ${stats.scanned} seen, ${stats.derivable} derivable, ` +
+          `${stats.skippedSentinel} sentinel, ` +
+          `${params.dryRun ? `${stats.candidates} candidates` : `${stats.written} written`} | ` +
+          `elapsed: ${elapsedSec.toFixed(1)}s | resume with start=${lastId + 1}`
+      );
+
+      cursor = lastId + 1;
+      if (params.end !== undefined && cursor > params.end) {
+        complete = true;
+        break;
+      }
+      // A short page means the range is exhausted; asking for another would return nothing.
+      if (rows.length < params.batchSize) {
+        complete = true;
+        break;
+      }
+    }
+
+    const duration = ((Date.now() - startTime) / 1000).toFixed(2);
+    log(
+      `${
+        complete ? 'Completed' : `Stopped at the ${params.maxBatches}-batch bound`
+      } in ${duration}s` + `${complete ? '' : ` — resume with start=${cursor}`}`
+    );
+
+    res.status(200).json({
+      ok: true,
+      dryRun: params.dryRun,
+      duration: `${duration}s`,
+      complete,
+      lastCursor: cursor,
+      result: stats,
+    });
+  } catch (error) {
+    const duration = ((Date.now() - startTime) / 1000).toFixed(2);
+    // The resume point is the operationally important half of a failure here, and it goes to the
+    // log rather than the response body: `handleEndpointError` is the shared 500 chokepoint
+    // (civitai#3845) and deliberately does not echo error text, because a driver error's own
+    // message carries the table/column — or, for a 23505, the offending row value.
+    log(
+      `Failed after ${duration}s — resume with start=${cursor} | ` +
+        `stats=${JSON.stringify(stats)}`,
+      error
+    );
+    return handleEndpointError(res, error);
+  }
+});

--- a/src/server/services/__tests__/backfill-sha256-12.test.ts
+++ b/src/server/services/__tests__/backfill-sha256-12.test.ts
@@ -1,0 +1,426 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * `/api/admin/temp/backfill-sha256-12` — the one-time backfill that gives files scanned before
+ * `normalizeScanHashes()` shipped their missing `SHA256_12` row.
+ *
+ * It is the fourth `ModelFileHash` writer (ledger: model-file-hash-writers.test.ts). The ledger
+ * is structural — it proves the endpoint CALLS the helper. It cannot prove the endpoint uses
+ * what the helper returns, that it stops where it was told to stop, or that a second run is
+ * free. Those are the four hazards below, and each is asserted behaviourally:
+ *
+ *   1. derivation      writes sha256[0:12] — a value present nowhere in the input
+ *   2. sentinel        the all-zero "file unreachable" SHA256 gets NO derived row
+ *   3. idempotency     a second run over covered ground inserts nothing
+ *   4. bounds/cursor   maxBatches stops the walk and reports a resumable cursor
+ *
+ * The write fake below enforces the real `ModelFileHash_pkey` on `("fileId", type)`: inserting a
+ * pair that already exists throws unless `skipDuplicates` is set. So hazard 3 is a property of
+ * the endpoint's call, not of a `mockResolvedValue({ count: 0 })` that would pass for an
+ * endpoint with no conflict handling at all.
+ */
+
+// The endpoint imports the real model-file-scan.service for normalizeScanHashes. That module's
+// import graph reaches clickhouse/redis/search-index/flipt at load time; stub the edges so the
+// helper under test is the only real code in the path. (Same surface as
+// reprocess-scan-hash-derivation.test.ts, which drives the same service for the same reason.)
+vi.mock('@civitai/client', () => ({
+  getWorkflow: vi.fn(),
+  submitWorkflow: vi.fn(),
+  createCivitaiClient: vi.fn(),
+  WorkflowStatus: { Pending: 'Pending', Running: 'Running', Completed: 'Completed' },
+  TimeSpan: { fromDays: vi.fn(), fromHours: vi.fn() },
+}));
+vi.mock('~/server/services/orchestrator/client', () => ({ internalOrchestratorClient: {} }));
+vi.mock('~/server/redis/caches', () => ({ dataForModelsCache: { refresh: vi.fn() } }));
+vi.mock('~/server/search-index', () => ({ modelsSearchIndex: { queueUpdate: vi.fn() } }));
+vi.mock('~/server/services/model-file.service', () => ({
+  deleteFilesForModelVersionCache: vi.fn(),
+  findOfficialFileByHash: vi.fn(),
+}));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/orchestrator/orchestrator.service', () => ({
+  createModelFileScanRequest: vi.fn(),
+  ModelFileScanSubmissionError: class extends Error {},
+}));
+vi.mock('~/server/utils/concurrency-helpers', () => ({ limitConcurrency: vi.fn() }));
+vi.mock('~/server/services/model.service', () => ({ unpublishModelById: vi.fn() }));
+vi.mock('~/server/services/model-version.service', () => ({ addLinkedComponent: vi.fn() }));
+vi.mock('~/server/services/minor-hash.service', () => ({
+  checkMinorHashOnScan: vi.fn(),
+  MINOR_HASH_FILE_TYPE: 'Model',
+}));
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: vi.fn().mockResolvedValue(true),
+  FLIPT_FEATURE_FLAGS: { MINOR_HASH_AUTO_FLAG: 'minor-hash-auto-flag' },
+}));
+
+// WebhookEndpoint wraps the handler in a WEBHOOK_TOKEN check. Unwrap it — this file is about the
+// rows written, and token auth is covered by the endpoint-helpers tests. `handleEndpointError` is
+// the shared 500 chokepoint (civitai#3845); spy on it so the failure path can be asserted without
+// reimplementing its genericization here.
+const helperMocks = vi.hoisted(() => ({ handleEndpointError: vi.fn() }));
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: (req: NextApiRequest, res: NextApiResponse) => unknown) => handler,
+  handleEndpointError: helperMocks.handleEndpointError,
+}));
+
+import handler from '~/pages/api/admin/temp/backfill-sha256-12';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// Pairwise distinct, and distinct from every constant the assertions name (12, 10, the all-zero
+// sentinel, and every fileId), so a mutant that truncates to the wrong width, hardcodes a literal
+// prefix, or copies one file's hash onto another's row cannot land on an expected value by
+// accident. Two DIFFERENT hashes is the control that kills a hardcoded-literal mutant: it can
+// only ever match one of them.
+const HASH_A = '1a2b3c4d5e6f7081'.repeat(4); // 64 chars; [0:12] = '1a2b3c4d5e6f'
+const HASH_B = '9f8e7d6c5b4a3928'.repeat(4); // 64 chars; [0:12] = '9f8e7d6c5b4a'
+const HASH_C = 'c0ffee1234567890'.repeat(4); // 64 chars; [0:12] = 'c0ffee123456'
+const SENTINEL = '0'.repeat(64);
+
+const PREFIX_A = '1a2b3c4d5e6f';
+const PREFIX_B = '9f8e7d6c5b4a';
+const PREFIX_C = 'c0ffee123456';
+
+// fileIds are non-contiguous and share no digits with any prefix, so a cursor assertion cannot be
+// satisfied by an off-by-one that happens to land on the next fixture.
+const FILE_A = 101;
+const FILE_B = 205;
+const FILE_C = 317;
+
+type Row = { fileId: number; hash: string };
+
+/** Rows the fake `createMany` has accepted, keyed like the real PK: `<fileId>:<type>`. */
+let storedKeys: Set<string>;
+/** Every row handed to `createMany`, flattened, in call order. */
+let insertAttempts: { fileId: number; type: string; hash: string }[];
+
+/**
+ * Installs an in-memory corpus behind `dbRead.modelFileHash.findMany`, branching on the `type`
+ * the endpoint asks for — SHA256 pages the walk, SHA256_12 answers the dry-run coverage lookup.
+ * A single blanket mock would let a dry run read its own candidate list as "already covered".
+ */
+function installCorpus(sha256Rows: Row[], alreadyCovered: number[] = []) {
+  for (const fileId of alreadyCovered) storedKeys.add(`${fileId}:SHA256_12`);
+
+  dbMock.dbRead.modelFileHash.findMany.mockImplementation(async (args: any) => {
+    if (args.where.type === 'SHA256_12') {
+      const ids: number[] = args.where.fileId.in;
+      return ids.filter((id) => storedKeys.has(`${id}:SHA256_12`)).map((fileId) => ({ fileId }));
+    }
+    const gte = args.where.fileId.gte ?? 0;
+    const lte = args.where.fileId.lte ?? Number.POSITIVE_INFINITY;
+    return sha256Rows
+      .filter((r) => r.fileId >= gte && r.fileId <= lte)
+      .sort((a, b) => a.fileId - b.fileId)
+      .slice(0, args.take)
+      .map((r) => ({ fileId: r.fileId, hash: r.hash }));
+  });
+}
+
+const runHandler = async (query: Record<string, string> = {}) => {
+  const req = { method: 'GET', query } as unknown as NextApiRequest;
+  const json = vi.fn().mockReturnThis();
+  const status = vi.fn().mockReturnThis();
+  const res = { status, json } as unknown as NextApiResponse;
+  await handler(req, res);
+  const body = json.mock.calls.at(-1)?.[0] as any;
+  expect(body, 'the endpoint never responded').toBeDefined();
+  // A 500 carries `ok: false` and an `error`; surface it instead of failing on a missing field.
+  expect(body.error, `endpoint errored: ${body.error}`).toBeUndefined();
+  return body;
+};
+
+/** `<fileId>=<hash>` for every row handed to createMany, sorted. */
+const rowsWritten = () =>
+  insertAttempts.map(({ fileId, type, hash }) => `${fileId}:${type}=${hash}`).sort();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storedKeys = new Set();
+  insertAttempts = [];
+
+  // Enforces the real `ModelFileHash_pkey` on ("fileId", type). Without `skipDuplicates` a
+  // repeat insert throws, exactly as Postgres would — which is what makes the idempotency test
+  // an assertion about the endpoint rather than about this fake.
+  dbMock.dbWrite.modelFileHash.createMany.mockImplementation(async (args: any) => {
+    const { data, skipDuplicates } = args;
+    let count = 0;
+    for (const row of data) {
+      insertAttempts.push(row);
+      const key = `${row.fileId}:${row.type}`;
+      if (storedKeys.has(key)) {
+        if (!skipDuplicates) {
+          throw new Error(
+            `duplicate key value violates unique constraint "ModelFileHash_pkey" (${key})`
+          );
+        }
+        continue;
+      }
+      storedKeys.add(key);
+      count++;
+    }
+    return { count };
+  });
+});
+
+describe('/api/admin/temp/backfill-sha256-12', () => {
+  describe('derivation', () => {
+    it('writes sha256[0:12] for every stored SHA256 row', async () => {
+      installCorpus([
+        { fileId: FILE_A, hash: HASH_A },
+        { fileId: FILE_B, hash: HASH_B },
+      ]);
+
+      const body = await runHandler({ dryRun: 'false' });
+
+      // Literal expectations, not `normalizeScanHashes(input)` — restating the implementation
+      // would pass for any consistent-but-wrong truncation.
+      expect(rowsWritten()).toEqual(
+        [`${FILE_A}:SHA256_12=${PREFIX_A}`, `${FILE_B}:SHA256_12=${PREFIX_B}`].sort()
+      );
+      expect(body.result.written).toBe(2);
+      expect(body.result.derivable).toBe(2);
+      expect(body.result.scanned).toBe(2);
+    });
+
+    it('derives a value present nowhere in the input, at the A1111 width', async () => {
+      installCorpus([{ fileId: FILE_A, hash: HASH_A }]);
+      await runHandler({ dryRun: 'false' });
+
+      const [row] = insertAttempts;
+      expect(row.hash).toBe(PREFIX_A);
+      expect(row.hash).toHaveLength(12);
+      // The whole point of the type: it is not the AutoV2 width (10) and not the stored SHA256.
+      expect(row.hash).not.toBe(HASH_A.slice(0, 10));
+      expect(row.hash).not.toBe(HASH_A);
+    });
+
+    it('never writes a row of any type other than SHA256_12', async () => {
+      // A mutant that copied the source row through would re-write SHA256 and corrupt nothing
+      // visibly — but it would double the table. Assert the type, not just the hash.
+      installCorpus([{ fileId: FILE_A, hash: HASH_A }]);
+      await runHandler({ dryRun: 'false' });
+
+      expect(insertAttempts.map((r) => r.type)).toEqual(['SHA256_12']);
+    });
+  });
+
+  describe('the all-zero sentinel', () => {
+    it('skips it — deriving would make every unreachable file match every other', async () => {
+      installCorpus([
+        { fileId: FILE_A, hash: SENTINEL },
+        { fileId: FILE_B, hash: HASH_B },
+      ]);
+
+      const body = await runHandler({ dryRun: 'false' });
+
+      // Assert the STATE of the written set, not the absence of a substring: a `not.toContain`
+      // on the zero-prefix passes for a run that wrote nothing at all, which is a different bug.
+      expect(rowsWritten()).toEqual([`${FILE_B}:SHA256_12=${PREFIX_B}`]);
+      expect(body.result.skippedSentinel).toBe(1);
+      expect(body.result.derivable).toBe(1);
+      expect(body.result.scanned).toBe(2);
+    });
+
+    it('reports it as skipped rather than written, even when it is the only row', async () => {
+      installCorpus([{ fileId: FILE_A, hash: SENTINEL }]);
+
+      const body = await runHandler({ dryRun: 'false' });
+
+      expect(insertAttempts).toHaveLength(0);
+      expect(body.result.written).toBe(0);
+      expect(body.result.skippedSentinel).toBe(1);
+      // ...and the walk still completed, rather than treating "nothing derivable" as an error.
+      expect(body.complete).toBe(true);
+    });
+  });
+
+  describe('idempotency', () => {
+    it('writes nothing on a second run over the same range', async () => {
+      installCorpus([
+        { fileId: FILE_A, hash: HASH_A },
+        { fileId: FILE_B, hash: HASH_B },
+      ]);
+
+      const first = await runHandler({ dryRun: 'false' });
+      expect(first.result.written).toBe(2);
+
+      insertAttempts = [];
+      const second = await runHandler({ dryRun: 'false' });
+
+      // The rows are still OFFERED — the endpoint does not pre-filter — but the database inserts
+      // none of them. `written` must reflect what the database did, not what was offered.
+      expect(second.result.written).toBe(0);
+      expect(second.result.derivable).toBe(2);
+      expect(storedKeys.size).toBe(2);
+    });
+
+    it('passes skipDuplicates, so a covered range cannot raise a duplicate-key error', async () => {
+      // The mechanism, pinned directly. The fake throws without it, so dropping `skipDuplicates`
+      // turns the test above red too — but this names the specific cause so the failure is
+      // legible rather than an opaque rethrow.
+      installCorpus([{ fileId: FILE_A, hash: HASH_A }], [FILE_A]);
+
+      const body = await runHandler({ dryRun: 'false' });
+
+      const call = dbMock.dbWrite.modelFileHash.createMany.mock.calls.at(-1)?.[0] as any;
+      expect(call.skipDuplicates).toBe(true);
+      expect(body.result.written).toBe(0);
+    });
+
+    it('dry run counts only rows that are genuinely missing a sibling', async () => {
+      installCorpus(
+        [
+          { fileId: FILE_A, hash: HASH_A },
+          { fileId: FILE_B, hash: HASH_B },
+          { fileId: FILE_C, hash: HASH_C },
+        ],
+        [FILE_B] // already backfilled
+      );
+
+      const body = await runHandler({ dryRun: 'true' });
+
+      // Reporting `derivable` (3) as the write volume would overstate the job by 50% here — the
+      // exact error that makes an operator plan for a corpus-wide run that is already done.
+      expect(body.result.candidates).toBe(2);
+      expect(body.result.derivable).toBe(3);
+      expect(body.result.written).toBe(0);
+      expect(insertAttempts).toHaveLength(0);
+      expect(body.dryRun).toBe(true);
+    });
+  });
+
+  describe('bounds and cursor resumption', () => {
+    it('stops at maxBatches and reports a cursor that resumes the walk', async () => {
+      // 6 files, batchSize 2, maxBatches 2 => the run must stop after 4, not finish all 6.
+      const corpus = [
+        { fileId: 10, hash: HASH_A },
+        { fileId: 20, hash: HASH_B },
+        { fileId: 30, hash: HASH_C },
+        { fileId: 40, hash: HASH_A },
+        { fileId: 50, hash: HASH_B },
+        { fileId: 60, hash: HASH_C },
+      ];
+      installCorpus(corpus);
+
+      const first = await runHandler({ dryRun: 'false', batchSize: '2', maxBatches: '2' });
+
+      expect(first.result.batches).toBe(2);
+      expect(first.result.scanned).toBe(4);
+      expect(first.complete).toBe(false);
+      expect(first.lastCursor).toBe(41); // last id seen (40) + 1
+      expect(rowsWritten()).toEqual(
+        [
+          `10:SHA256_12=${PREFIX_A}`,
+          `20:SHA256_12=${PREFIX_B}`,
+          `30:SHA256_12=${PREFIX_C}`,
+          `40:SHA256_12=${PREFIX_A}`,
+        ].sort()
+      );
+
+      // Resume exactly where it stopped: the remaining two files, and nothing re-read.
+      insertAttempts = [];
+      const second = await runHandler({
+        dryRun: 'false',
+        batchSize: '2',
+        maxBatches: '2',
+        start: String(first.lastCursor),
+      });
+
+      expect(second.result.scanned).toBe(2);
+      expect(second.complete).toBe(true);
+      expect(rowsWritten()).toEqual(
+        [`50:SHA256_12=${PREFIX_B}`, `60:SHA256_12=${PREFIX_C}`].sort()
+      );
+      // Every file covered exactly once across the two runs.
+      expect(storedKeys.size).toBe(6);
+    });
+
+    it('honours batchSize as the page bound', async () => {
+      const corpus = Array.from({ length: 9 }, (_, i) => ({
+        fileId: (i + 1) * 10,
+        hash: [HASH_A, HASH_B, HASH_C][i % 3],
+      }));
+      installCorpus(corpus);
+
+      await runHandler({ dryRun: 'false', batchSize: '3', maxBatches: '1' });
+
+      // One batch of exactly 3 — not the whole corpus, and not a hardcoded default page size.
+      const pageCalls = dbMock.dbRead.modelFileHash.findMany.mock.calls.filter(
+        (c: any) => c[0].where.type === 'SHA256'
+      );
+      expect(pageCalls).toHaveLength(1);
+      expect(pageCalls[0][0].take).toBe(3);
+      expect(insertAttempts).toHaveLength(3);
+    });
+
+    it('starts at `start`, leaving earlier files untouched', async () => {
+      installCorpus([
+        { fileId: FILE_A, hash: HASH_A },
+        { fileId: FILE_B, hash: HASH_B },
+        { fileId: FILE_C, hash: HASH_C },
+      ]);
+
+      await runHandler({ dryRun: 'false', start: String(FILE_B) });
+
+      // FILE_A is before the cursor and must not be written — a `start` that is read but not
+      // applied to the query would silently re-walk the whole corpus on every resume.
+      expect(rowsWritten()).toEqual(
+        [`${FILE_B}:SHA256_12=${PREFIX_B}`, `${FILE_C}:SHA256_12=${PREFIX_C}`].sort()
+      );
+    });
+
+    it('respects `end` as the upper bound of the range', async () => {
+      installCorpus([
+        { fileId: FILE_A, hash: HASH_A },
+        { fileId: FILE_B, hash: HASH_B },
+        { fileId: FILE_C, hash: HASH_C },
+      ]);
+
+      const body = await runHandler({ dryRun: 'false', end: String(FILE_B) });
+
+      expect(rowsWritten()).toEqual(
+        [`${FILE_A}:SHA256_12=${PREFIX_A}`, `${FILE_B}:SHA256_12=${PREFIX_B}`].sort()
+      );
+      expect(body.complete).toBe(true);
+    });
+
+    it('routes a mid-run failure through the shared 500 chokepoint, not a hand-rolled body', async () => {
+      // A hand-rolled `{ error: (e as Error).message }` here would leak driver text — for a Prisma
+      // error the table + column, for a pg 23505 the offending ROW VALUE (civitai#3845). The
+      // repo-wide ledger in rest-error-envelope-ledger.test.ts blocks that class; this pins the
+      // behaviour at the one site, so the endpoint cannot regress back to it silently.
+      installCorpus([{ fileId: FILE_A, hash: HASH_A }]);
+      const boom = new Error('relation "ModelFileHash" column "hash" does not exist');
+      dbMock.dbWrite.modelFileHash.createMany.mockRejectedValueOnce(boom);
+
+      const req = { method: 'GET', query: { dryRun: 'false' } } as unknown as NextApiRequest;
+      const json = vi.fn().mockReturnThis();
+      const status = vi.fn().mockReturnThis();
+      await handler(req, { status, json } as unknown as NextApiResponse);
+
+      expect(helperMocks.handleEndpointError).toHaveBeenCalledWith(expect.anything(), boom);
+      // And nothing carrying the driver text was written to the response directly.
+      const bodies = JSON.stringify(json.mock.calls);
+      expect(bodies).not.toContain('does not exist');
+    });
+
+    it('rejects an out-of-range batchSize rather than running unbounded', async () => {
+      installCorpus([{ fileId: FILE_A, hash: HASH_A }]);
+
+      const req = { method: 'GET', query: { batchSize: '999999' } } as unknown as NextApiRequest;
+      const json = vi.fn().mockReturnThis();
+      const status = vi.fn().mockReturnThis();
+      await handler(req, { status, json } as unknown as NextApiResponse);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(insertAttempts).toHaveLength(0);
+    });
+  });
+});

--- a/src/server/services/__tests__/model-file-hash-writers.test.ts
+++ b/src/server/services/__tests__/model-file-hash-writers.test.ts
@@ -130,6 +130,12 @@ const WRITER_LEDGER = [
     why: 'replays rawScanResult, where AutoV3 is still full-length and SHA256_12 is absent',
   },
   {
+    file: 'src/pages/api/admin/temp/backfill-sha256-12.ts',
+    writes: ['modelFileHash.createMany'],
+    normalizes: true,
+    why: 'one-time backfill of SHA256_12 for files scanned before normalizeScanHashes() shipped; derives from the stored SHA256 row through the helper, so it inherits the all-zero sentinel guard instead of re-implementing the truncation',
+  },
+  {
     file: 'src/server/services/orchestrator/orchestrator.service.ts',
     writes: ['modelFileHash.upsert'],
     normalizes: false,

--- a/src/server/services/model-file-scan.service.ts
+++ b/src/server/services/model-file-scan.service.ts
@@ -444,14 +444,20 @@ const orchestratorHashFieldMap: Record<string, ModelHashType> = {
  *              See docs/image-resource-hash-matching.md.
  *
  * Every writer of ModelFileHash that can carry a hash the orchestrator produced must run it
- * through this. There are THREE writers, and the ledger test enumerates them from source —
+ * through this. There are FOUR writers, and the ledger test enumerates them from source —
  * src/server/services/__tests__/model-file-hash-writers.test.ts fails when the set grows OR
  * shrinks, so a new writer forces a decision here rather than inheriting one:
  *
  *   applyScanOutcome (this file)                     normalizes
  *   /api/mod/reprocess-scan                          normalizes
+ *   /api/admin/temp/backfill-sha256-12               normalizes
  *   createModelFileScanRequest's dev-only skip       EXEMPT — see below
  *     (orchestrator/orchestrator.service.ts)
+ *
+ * The backfill writer derives SHA256_12 for files scanned before this helper shipped. It reads
+ * the stored SHA256 row and calls this function rather than truncating inline, so the all-zero
+ * sentinel guard below applies there too — which is the whole reason it is not a one-line SQL
+ * UPDATE.
  *
  * The exemption is not "it's dev-only": it is that the sentinel that writer stores (SHA256 =
  * 64 zeroes, "file unreachable") is a fixed point of this function, so calling it there would


### PR DESCRIPTION
Implements `GET /api/admin/temp/backfill-sha256-12`, the endpoint that migration `20260819000000` and `docs/image-resource-hash-matching.md` have twice been wrong about — first documenting it before it existed, then (in #4149) recording that it never had.

## Premise check

Every premise I was handed was re-verified before building on it. Three held; **one did not.**

| Premise | Verdict |
|---|---|
| The endpoint does not exist on any ref | ✅ **Held.** `git log --all --diff-filter=A -- src/pages/api/admin/temp/backfill-sha256-12.ts` returns nothing. |
| Both docs still say "🔴 not implemented" | ✅ **Held.** `docs/image-resource-hash-matching.md:249,265` and the migration's trailing comment. |
| `normalizeScanHashes()` excludes the all-zero sentinel | ✅ **Held.** `if (sha256 && !/^0+$/.test(sha256))` — and it is the reason this endpoint calls the helper instead of truncating inline. |
| The writer ledger fails when the set grows | ✅ **Held.** It tripped on the new writer exactly as designed; updated deliberately (below). |
| **~1.5M rows keep failing 12-char LoRA detection indefinitely; not self-healing** | ❌ **FALSE as of now.** |

### The corrected premise

**Production was already backfilled out-of-band, hours before this PR.** Measured on the nvme0 replica (`cnpg-cluster-nvme0-4`, read-only, SELECT-only):

| Metric | 2026-08-20 first read | re-read ~40 min later |
|---|---|---|
| `SHA256` rows | 1,489,384 | 1,487,830 |
| `SHA256_12` rows | 1,489,372 | 1,487,815 |
| `SHA256` rows lacking a `SHA256_12` sibling (sentinels excluded) | 15 | **15** |

Corroborating evidence that this was a deliberate pass, not scan-path drift:

- **Zero** `SHA256_12` rows disagree with `left(sha256, 12)`; all 1.49M are exactly 12 chars.
- Every one was created between `2026-08-19 22:15:34Z` and `2026-08-20 02:29:17Z` — a ~4-hour window, not the months the corpus spans.
- The migration contains no backfill DML, so it did not come from there.

The absolute counts drift (files get deleted; the table is live) — the **gap of 15 is the stable number**, and it is what a run today would actually write. So the corpus-wide job this endpoint was designed for is already done, and what remains is a near-free idempotent sweep. That is now recorded in both the doc and the migration comment, with the anti-join query, so nobody plans a 1.5M-row run that is already complete.

I did **not** run the endpoint against anything.

A fourth premise also turned out to be environmental rather than true: **repo-wide `tsc` is not red.** `pnpm typecheck` reports **0 errors in 78s**. The redness came from a stale generated Prisma client — `packages/civitai-db-schema/prisma/schema.prisma` and `node_modules/.prisma/client` are *generated, untracked* artifacts, and a copy taken from another clone predates the `SHA256_12` enum. `pnpm db:generate` + `npx prisma generate` fixes it. (`packages/civitai-db-schema` itself *is* tracked, contrary to the brief.)

## The endpoint

Follows `backfill-b2-file-locations.ts` — `WebhookEndpoint` token gate (33 of 35 endpoints in that directory use it), zod query schema, `booleanString()` dry-run default, per-batch cursor logging, `{ ok, dryRun, duration, complete, lastCursor, result }` response.

Derived entirely from stored `SHA256` rows: **no file access, no orchestrator, no re-scan.**

🔴 **It calls `normalizeScanHashes()` rather than truncating inline.** This is the design decision the whole PR turns on. The helper suppresses derivation from the all-zero "file unreachable" sentinel; an inline `slice(0, 12)` would give every unreachable file the *same* 12-char hash and make them all match each other. Calling the helper means the backfill cannot drift from the scan path's rules. Mutant M1 below is exactly this substitution, and it produces `SHA256_12=000000000000` — the hazard, reproduced on demand.

### Cost and resume

| Param | Default | Meaning |
|---|---|---|
| `dryRun` | `true` | Count what a live run would insert, without writing |
| `batchSize` | 1000 (max 5000) | `SHA256` rows per page |
| `maxBatches` | 100 (max 10000) | Hard cap on batches per invocation |
| `start` | 0 | Minimum `fileId` — the resume point |
| `end` | — | Maximum `fileId` |

A full pass is ~1.49M rows ≈ 1,490 batches at the default page size, so **one call deliberately does not finish the corpus**: it stops at 100 batches (~100k files), returns `complete: false` and `lastCursor`, and the operator resumes with `start=<lastCursor>` until `complete: true`. Re-running a completed range is safe and costs only the read.

Dry run does an extra PK lookup per batch so its `candidates` is the **real** write volume rather than the scanned row count — the difference between "1.5M rows to write" and the true "15", which is precisely the mistake this PR is documenting.

Idempotent via `createMany({ skipDuplicates: true })` → `ON CONFLICT ("fileId", type) DO NOTHING` against `ModelFileHash_pkey`, verified in prod as the table's only unique constraint.

## The ledger update, and why it is safe

Adding a writer trips `model-file-hash-writers.test.ts` **by design** — it asserts the exact writer set and fails when it grows. The new entry declares `normalizes: true`, and that flag is not taken on faith: the ledger greps the file (comments stripped) for a real `normalizeScanHashes(` **call**, so the entry cannot be a lie about a writer that doesn't call it. The `THREE writers` doc comment on `normalizeScanHashes` is updated to `FOUR` — a comment is a claim, and the ledger's own docstring says a stale one means the ledger is lying about the surface.

`normalizeScanHashes` itself is **unchanged**; the only edit to that file is its doc comment.

A second ledger, `rest-error-envelope-ledger.test.ts`, also caught this endpoint — my first draft returned `{ error: (error as Error).message }` on a 500. Fixed by routing through `handleEndpointError` (the shared chokepoint from civitai#3845) rather than adding a baseline exception; the resume cursor goes to the log instead. Both ledgers were found by grepping for affected suites, not by guessing names.

## Verification

**Suites enumerated by grep**, not by name — `grep -rl "normalizeScanHashes\|ModelFileHash\|modelFileHash\|model-file-scan\|reprocess-scan\|createModelFileScanRequest\|backfill-sha256-12"` over `src/ apps/ packages/ scripts/`, which is how the two ledgers surfaced.

Scored from `--reporter=json` test **counts**, never an exit code (prettier demonstrated why: it reported 2 failing files and still exited 0). Zero-test suites were counted separately, since an import failure reports "no tests" rather than a failure:

```
TOTAL 161  PASSED 161  FAILED 0  zero-test suites: 0
```

11 suites: the 10 grep-identified ones plus the `no-direct-shared-module-mock` ratchet (passes; the shared `dbMock` is used, no hand-rolled `~/server/db/client` mock). Repo-wide `pnpm typecheck`: **0 errors**. Prettier: clean.

### Red-at-base matrix — 11/11 mutants killed

Each mutant edits the **narrowest** expression that can be wrong, restores from a pristine copy, and is scored on test counts. Fixtures are pairwise distinct 64-char hashes whose 12-char prefixes differ from each other, from the fileIds, and from every constant the assertions name — so a mutant that hardcodes a literal prefix can only ever satisfy one of them.

| # | Mutation | Verdict | Killed by |
|---|---|---|---|
| M1 | `normalizeScanHashes(…).SHA256_12` → `row.hash.slice(0, 12)` (inline truncate, drops the sentinel guard) | **KILLED** 2/14 | both sentinel tests — mutant emits `101:SHA256_12=000000000000` |
| M2 | truncate to AutoV2's width 10 | **KILLED** 6/14 | both derivation tests + sentinel + 3 cursor tests |
| M3 | `skipDuplicates` removed | **KILLED** 2/14 | both idempotency tests (fake raises the real PK violation) |
| M4 | `written += result.count` → `+= toWrite.length` | **KILLED** 2/14 | "second run writes nothing" |
| M5 | `while (batches < maxBatches)` → `while (true)` | **KILLED** 2/14 | maxBatches + batchSize bounds |
| M6 | `gte: cursor` → `gte: 0` | **KILLED** 2/14 | cursor resumption + `start` |
| M7 | `take: params.batchSize` → `take: 1000` | **KILLED** 2/14 | batchSize page bound |
| M8 | dry run skips the coverage filter | **KILLED** 1/14 | "counts only rows genuinely missing a sibling" |
| M9 | writes `SHA256` instead of `SHA256_12` | **KILLED** 7/14 | derivation + type + sentinel + cursor |
| M10 | hand-rolled error envelope | **KILLED** 2/25 | the repo-wide envelope ledger **and** the local chokepoint test |
| M11 | `end` bound ignored | **KILLED** 1/14 | `end` upper bound |

M1's failure message is the point of the exercise:

```
expected [ '101:SHA256_12=000000000000', …(1) ] to deeply equal [ '205:SHA256_12=9f8e7d6c5b4a' ]
```

Each guard was watched go red for **its own** reason, on a reachable input, before being counted.

## Not done

- The endpoint has **not been executed** against any environment.
- The 15 remaining rows are left alone — running the sweep is an operator decision, and the doc now carries the anti-join to re-measure first.
- I could not determine *who* ran the out-of-band backfill or by what means; the evidence establishes that it happened and that its output is correct, not its provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
