### PR TITLE
feat(stickers): attribution card on stickers in comments

### DIFF
--- a/src/components/RenderHtml/RenderHtml.tsx
+++ b/src/components/RenderHtml/RenderHtml.tsx
@@ -15,6 +15,7 @@ import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import { STICKER_JUMBO_LIMIT, stickerMaxWidth, STICKER_SIZE } from '~/shared/utils/sticker-token';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { MentionHoverCard } from '~/components/UserAvatar/MentionHoverCard';
+import { StickerAttributionHoverCard } from '~/components/Sticker/StickerAttributionHoverCard';
 
 // Match host exactly or as a subdomain (e.g. "www.youtube.com"), never as a
 // substring elsewhere in the URL — `url.includes('youtube.com')` would let
@@ -286,6 +287,10 @@ export function RenderHtml({
       {/* Not gated on `withMentions` — that prop only decides whether a mention
           becomes a link. The span carries the user either way. */}
       <MentionHoverCard containerRef={contentRef} />
+      {/* Behind the same opt-in as drawing the sticker at all, so a surface that
+          stores unsanitized HTML cannot acquire a shop link by acquiring a
+          sticker. */}
+      {allowStickers && <StickerAttributionHoverCard containerRef={contentRef} />}
     </TypographyStylesWrapper>
   );
 }

--- a/src/components/RenderHtml/RenderHtml.tsx
+++ b/src/components/RenderHtml/RenderHtml.tsx
@@ -290,7 +290,9 @@ export function RenderHtml({
       {/* Behind the same opt-in as drawing the sticker at all, so a surface that
           stores unsanitized HTML cannot acquire a shop link by acquiring a
           sticker. */}
-      {allowStickers && <StickerAttributionHoverCard containerRef={contentRef} />}
+      {allowStickers && stickerIds.length > 0 && (
+        <StickerAttributionHoverCard containerRef={contentRef} />
+      )}
     </TypographyStylesWrapper>
   );
 }

--- a/src/components/RenderHtml/__tests__/sticker-render-optin.test.ts
+++ b/src/components/RenderHtml/__tests__/sticker-render-optin.test.ts
@@ -72,4 +72,37 @@ describe('sticker rendering is opt-in', () => {
 
     expect(registers).toEqual([...MAY_REGISTER_STICKER_NODE].sort());
   });
+
+  /**
+   * The attribution card is the same containment question one step on: it turns
+   * a drawn sticker into a route to its creator's shop.
+   *
+   * Justin's call was comments now, DMs a separate decision — a card in a DM
+   * makes any sticker a stranger sends you a shop link, with no message text to
+   * report. `Sticker.tsx` is shared with chat, so mounting the card there would
+   * have shipped that decision by accident. It lives in `RenderHtml` behind the
+   * same opt-in as drawing the sticker at all.
+   */
+  it('the attribution card is mounted only by RenderHtml, and only behind the opt-in', () => {
+    const mounts = walk(SRC, [], ['.ts', '.tsx'])
+      .filter((file) => /<StickerAttributionHoverCard/.test(fs.readFileSync(file, 'utf8')))
+      .map(relative)
+      .filter((file) => !file.includes('/__tests__/'))
+      .sort();
+
+    expect(mounts).toEqual(['components/RenderHtml/RenderHtml.tsx']);
+
+    const source = fs.readFileSync(path.join(SRC, 'components/RenderHtml/RenderHtml.tsx'), 'utf8');
+    expect(source).toMatch(/allowStickers && <StickerAttributionHoverCard/);
+  });
+
+  it('🔴 the shared inline sticker component carries NO card — that is what keeps it out of DMs', () => {
+    // `Sticker.tsx` is what chat renders. A card reached from here is a card in
+    // a private message.
+    const shared = fs.readFileSync(path.join(SRC, 'components/Sticker/Sticker.tsx'), 'utf8');
+    expect(shared).not.toMatch(/HoverCard|Popover|StickerAttribution/);
+
+    const chat = fs.readFileSync(path.join(SRC, 'components/Chat/ExistingChat.tsx'), 'utf8');
+    expect(chat).not.toMatch(/StickerAttribution/);
+  });
 });

--- a/src/components/RenderHtml/__tests__/sticker-render-optin.test.ts
+++ b/src/components/RenderHtml/__tests__/sticker-render-optin.test.ts
@@ -93,16 +93,48 @@ describe('sticker rendering is opt-in', () => {
     expect(mounts).toEqual(['components/RenderHtml/RenderHtml.tsx']);
 
     const source = fs.readFileSync(path.join(SRC, 'components/RenderHtml/RenderHtml.tsx'), 'utf8');
-    expect(source).toMatch(/allowStickers && <StickerAttributionHoverCard/);
+    // Every mount gated, not merely one — a second ungated mount beside the
+    // gated one would satisfy an existence check. The optional paren allows
+    // prettier to wrap the line when a prop pushes it past printWidth, which
+    // would otherwise turn a formatting change into a failed gate.
+    const mountCount = (source.match(/<StickerAttributionHoverCard/g) ?? []).length;
+    // `[^<]*` allows further conditions and prettier's wrapping between the gate
+    // and the mount, while still refusing any mount that no `allowStickers` in
+    // the same expression reaches — an intervening tag ends the match.
+    const gatedCount = (source.match(/allowStickers &&[^<]*<StickerAttributionHoverCard/g) ?? [])
+      .length;
+    expect(mountCount, 'mounts of the attribution card in RenderHtml').toBe(1);
+    expect(gatedCount, 'those mounts sitting behind the allowStickers gate').toBe(mountCount);
   });
 
   it('🔴 the shared inline sticker component carries NO card — that is what keeps it out of DMs', () => {
     // `Sticker.tsx` is what chat renders. A card reached from here is a card in
     // a private message.
+    //
+    // Read by fixed path rather than by glob: a rename or move throws instead of
+    // quietly matching nothing.
     const shared = fs.readFileSync(path.join(SRC, 'components/Sticker/Sticker.tsx'), 'utf8');
+
+    // Two assertions, because they fail for different reasons and the first is
+    // not enough. Forbidding component names forbids three spellings of one
+    // implementation — a Tooltip whose label holds an Anchor to the shop is a
+    // shop link in a DM and matches none of them. The data is the property: any
+    // route to a shop needs a username or an href, and the only server source of
+    // either is `getStickerAttribution`. `Sticker.tsx`'s own data is
+    // `{url, slug, animated}`.
+    expect(shared).not.toMatch(/getStickerAttribution|shopHref|creatorName/);
     expect(shared).not.toMatch(/HoverCard|Popover|StickerAttribution/);
 
-    const chat = fs.readFileSync(path.join(SRC, 'components/Chat/ExistingChat.tsx'), 'utf8');
-    expect(chat).not.toMatch(/StickerAttribution/);
+    // Every chat surface, not one file: `ChatWindow` picks between `ExistingChat`
+    // and `ExistingChatV1` behind a flag, and both render stickers. The filename
+    // is prefixed into the subject so a failure names the file rather than
+    // dumping it.
+    const chatFiles = walk(path.join(SRC, 'components/Chat'), [], ['.ts', '.tsx']);
+    expect(chatFiles.length, 'chat files scanned').toBeGreaterThan(3);
+    for (const file of chatFiles) {
+      expect(`${relative(file)}: ${fs.readFileSync(file, 'utf8')}`).not.toMatch(
+        /StickerAttribution|getStickerAttribution|shopHref/
+      );
+    }
   });
 });

--- a/src/components/Sticker/StickerAttributionHoverCard.tsx
+++ b/src/components/Sticker/StickerAttributionHoverCard.tsx
@@ -1,7 +1,7 @@
 import { Anchor, Group, Popover, Skeleton, Text } from '@mantine/core';
 import { IconSticker } from '@tabler/icons-react';
 import type { RefObject } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import {
   CREATOR_HOVER_DROPDOWN_CLASS,
@@ -161,8 +161,23 @@ function StickerAttributionCard({
   // them: without this, blocking someone still leaves their storefront one hover
   // away on any comment using their art. The name stays; the route and the
   // creator card do not.
-  const hiddenUsers = useHiddenPreferencesData().hiddenUsers;
-  const blocked = !!raw?.creatorId && hiddenUsers.some((user) => user.id === raw.creatorId);
+  //
+  // Three separate lists, and only one of them is a block: `hiddenUsers` is
+  // "people I hid", while a block is a *pair* — `blockedUsers` one way and
+  // `blockedByUsers` the other. `getBlockedPairIds`, which the shop filters on,
+  // is both directions, so checking hidden alone would leave a creator who
+  // blocked this viewer still one hover from their shop.
+  const preferences = useHiddenPreferencesData();
+  const suppressed = useMemo(
+    () =>
+      new Set([
+        ...preferences.hiddenUsers.map((user) => user.id),
+        ...preferences.blockedUsers.map((user) => user.id),
+        ...preferences.blockedByUsers.map((user) => user.id),
+      ]),
+    [preferences.hiddenUsers, preferences.blockedUsers, preferences.blockedByUsers]
+  );
+  const blocked = !!raw?.creatorId && suppressed.has(raw.creatorId);
   const sticker = raw && blocked ? { ...raw, shopHref: null, creatorId: null } : raw;
 
   return (

--- a/src/components/Sticker/StickerAttributionHoverCard.tsx
+++ b/src/components/Sticker/StickerAttributionHoverCard.tsx
@@ -1,0 +1,201 @@
+import { Anchor, Group, Popover, Skeleton, Text } from '@mantine/core';
+import { IconSticker } from '@tabler/icons-react';
+import type { RefObject } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { NextLink as Link } from '~/components/NextLink/NextLink';
+import {
+  CREATOR_HOVER_DROPDOWN_CLASS,
+  CreatorHoverDropdown,
+  HOVER_CARD_WIDTH,
+  HOVER_CARD_Z_INDEX,
+  HOVER_CLOSE_DELAY_MS,
+  HOVER_DELAY_MS,
+  HoverCreatorCard,
+  useHoverCapable,
+  useNestedHoverCard,
+} from '~/components/UserAvatar/UserHoverCard';
+import { trpc } from '~/utils/trpc';
+
+type Hovered = { cosmeticId: number; rect: DOMRect };
+
+/**
+ * Who made the sticker in a comment, and where to buy it.
+ *
+ * Same shape as `MentionHoverCard` and for the same reason: a rendered sticker
+ * is an `<img>` built imperatively inside `dangerouslySetInnerHTML`, so there is
+ * no React node to wrap. Hover is delegated from the container and the card is
+ * anchored to a zero-size box parked over the sticker.
+ *
+ * 🔴 MOUNTED BY `RenderHtml` UNDER `allowStickers`, WHICH IS WHY IT IS NOT IN
+ * `Sticker.tsx`. That component is shared with chat, and chat renders stickers
+ * inline in DMs. Justin's call was comments first and DMs as a separate
+ * decision — a hover card in a DM turns any sticker anyone sends you into a
+ * route to a stranger's shop, which is a product judgement rather than a
+ * rendering one. Putting the card on the shared component would have shipped
+ * that decision by accident.
+ *
+ * The identity is not taken on trust from the markup: `RenderHtml` only draws a
+ * sticker whose `data-id` resolved against server-supplied cosmetics, and the
+ * name and shop link here come from the server keyed on that same id. Nothing
+ * builds a href from a username — see `getStickerAttribution`.
+ */
+export function StickerAttributionHoverCard({
+  containerRef,
+}: {
+  containerRef: RefObject<HTMLElement | null>;
+}) {
+  const nested = useNestedHoverCard();
+  const hoverCapable = useHoverCapable();
+  const enabled = hoverCapable && !nested;
+
+  const [hovered, setHovered] = useState<Hovered | null>(null);
+  const openTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !enabled) return;
+
+    const cancelOpen = () => clearTimeout(openTimer.current);
+    const cancelClose = () => clearTimeout(closeTimer.current);
+
+    const onOver = (e: MouseEvent) => {
+      const el = (e.target as HTMLElement | null)?.closest<HTMLElement>(
+        'span[data-type="sticker"]'
+      );
+      if (!el) return;
+      cancelClose();
+      cancelOpen();
+
+      const raw = el.getAttribute('data-id') ?? '';
+      if (!/^\d+$/.test(raw)) return;
+      const cosmeticId = Number(raw);
+
+      openTimer.current = setTimeout(() => {
+        // The container swaps its whole innerHTML when the html prop changes, so
+        // an element captured a delay ago may be detached — and a detached
+        // element measures as all zeros, pinning the card to the viewport corner.
+        if (!el.isConnected) return;
+        setHovered({ cosmeticId, rect: el.getBoundingClientRect() });
+      }, HOVER_DELAY_MS);
+    };
+
+    const onOut = (e: MouseEvent) => {
+      const el = (e.target as HTMLElement | null)?.closest('span[data-type="sticker"]');
+      if (!el) return;
+      cancelOpen();
+      cancelClose();
+      closeTimer.current = setTimeout(() => setHovered(null), HOVER_CLOSE_DELAY_MS);
+    };
+
+    container.addEventListener('mouseover', onOver);
+    container.addEventListener('mouseout', onOut);
+
+    return () => {
+      container.removeEventListener('mouseover', onOver);
+      container.removeEventListener('mouseout', onOut);
+      cancelOpen();
+      cancelClose();
+    };
+  }, [containerRef, enabled]);
+
+  // Only while a card is open: the anchor is a fixed box over the sticker, so it
+  // goes stale the moment the page moves under it.
+  useEffect(() => {
+    if (!hovered) return;
+    const onScroll = (e: Event) => {
+      if (e.target instanceof Element && e.target.closest(`.${CREATOR_HOVER_DROPDOWN_CLASS}`))
+        return;
+      setHovered(null);
+    };
+    window.addEventListener('scroll', onScroll, true);
+    return () => window.removeEventListener('scroll', onScroll, true);
+  }, [hovered]);
+
+  if (!hovered) return null;
+
+  return (
+    <StickerAttributionCard
+      hovered={hovered}
+      onClose={() => setHovered(null)}
+      onDropdownEnter={() => clearTimeout(closeTimer.current)}
+    />
+  );
+}
+
+/**
+ * Split out so the query is mounted with the card rather than with every comment
+ * on the page — one sticker's attribution, asked for when someone hovers it.
+ */
+function StickerAttributionCard({
+  hovered,
+  onClose,
+  onDropdownEnter,
+}: {
+  hovered: Hovered;
+  onClose: () => void;
+  onDropdownEnter: () => void;
+}) {
+  const { rect, cosmeticId } = hovered;
+  const { data, isLoading } = trpc.cosmetic.getStickerAttribution.useQuery(
+    { ids: [cosmeticId] },
+    { staleTime: 5 * 60_000 }
+  );
+  const sticker = data?.[0];
+
+  return (
+    <Popover
+      opened
+      onChange={(opened) => !opened && onClose()}
+      width={HOVER_CARD_WIDTH}
+      shadow="sm"
+      withArrow
+      withinPortal
+      withRoles={false}
+      zIndex={HOVER_CARD_Z_INDEX}
+      position="bottom-start"
+      offset={4}
+    >
+      <Popover.Target>
+        <div
+          className="pointer-events-none fixed"
+          style={{ left: rect.left, top: rect.top, width: rect.width, height: rect.height }}
+        />
+      </Popover.Target>
+      <CreatorHoverDropdown
+        component={Popover.Dropdown}
+        onMouseEnter={onDropdownEnter}
+        onMouseLeave={onClose}
+      >
+        <Group gap={6} px="sm" py={6} wrap="nowrap" className="min-w-0">
+          <IconSticker size={14} className="shrink-0 text-yellow-6" />
+          {isLoading ? (
+            <Skeleton height={12} width={140} />
+          ) : (
+            <Text size="xs" c="dimmed" className="min-w-0 truncate">
+              {sticker?.shopHref ? (
+                <Anchor
+                  component={Link}
+                  href={sticker.shopHref}
+                  underline="always"
+                  fw={600}
+                  inherit
+                >
+                  {sticker.name}
+                </Anchor>
+              ) : (
+                // A sticker whose creator's account is gone still has a name
+                // worth showing; it just has nowhere to link to.
+                <Text span fw={600} inherit>
+                  {sticker?.name}
+                </Text>
+              )}
+              {sticker?.creatorName && <> by {sticker.creatorName}</>}
+            </Text>
+          )}
+        </Group>
+        {sticker?.creatorName && <HoverCreatorCard userId={null} username={sticker.creatorName} />}
+      </CreatorHoverDropdown>
+    </Popover>
+  );
+}

--- a/src/components/Sticker/StickerAttributionHoverCard.tsx
+++ b/src/components/Sticker/StickerAttributionHoverCard.tsx
@@ -14,6 +14,7 @@ import {
   useHoverCapable,
   useNestedHoverCard,
 } from '~/components/UserAvatar/UserHoverCard';
+import { useHiddenPreferencesData } from '~/hooks/hidden-preferences';
 import { trpc } from '~/utils/trpc';
 
 type Hovered = { cosmeticId: number; rect: DOMRect };
@@ -67,6 +68,12 @@ export function StickerAttributionHoverCard({
       cancelClose();
       cancelOpen();
 
+      // The span must carry the image RenderHtml injects. An id that did not
+      // resolve leaves the span in place with the author's own text inside it —
+      // attaching a card to that would put site chrome on words someone chose,
+      // and "has a card" must never be broader than "drew a sticker".
+      if (!el.querySelector('img')) return;
+
       const raw = el.getAttribute('data-id') ?? '';
       if (!/^\d+$/.test(raw)) return;
       const cosmeticId = Number(raw);
@@ -108,6 +115,11 @@ export function StickerAttributionHoverCard({
         return;
       setHovered(null);
     };
+    // No Escape handler, deliberately — the same reason as `MentionHoverCard`:
+    // a modal binds Escape as a capturing window listener, so a card opened
+    // inside one (a comment thread modal, which is one of the four surfaces
+    // this renders on) would take the modal down with it. Mouseleave, scroll
+    // and outside-click already dismiss it.
     window.addEventListener('scroll', onScroll, true);
     return () => window.removeEventListener('scroll', onScroll, true);
   }, [hovered]);
@@ -141,7 +153,17 @@ function StickerAttributionCard({
     { ids: [cosmeticId] },
     { staleTime: 5 * 60_000 }
   );
-  const sticker = data?.[0];
+  const raw = data?.[0];
+
+  // A block hides that creator's shop entries already — `getBlockedPairIds` is
+  // applied to creator-made cosmetics in the shop for exactly this. The sticker's
+  // creator is not the comment's author, so comment-level filtering never sees
+  // them: without this, blocking someone still leaves their storefront one hover
+  // away on any comment using their art. The name stays; the route and the
+  // creator card do not.
+  const hiddenUsers = useHiddenPreferencesData().hiddenUsers;
+  const blocked = !!raw?.creatorId && hiddenUsers.some((user) => user.id === raw.creatorId);
+  const sticker = raw && blocked ? { ...raw, shopHref: null, creatorId: null } : raw;
 
   return (
     <Popover
@@ -194,7 +216,9 @@ function StickerAttributionCard({
             </Text>
           )}
         </Group>
-        {sticker?.creatorName && <HoverCreatorCard userId={null} username={sticker.creatorName} />}
+        {sticker?.creatorName && !blocked && (
+          <HoverCreatorCard userId={sticker.creatorId} username={sticker.creatorName} />
+        )}
       </CreatorHoverDropdown>
     </Popover>
   );

--- a/src/server/routers/cosmetic.router.ts
+++ b/src/server/routers/cosmetic.router.ts
@@ -8,6 +8,7 @@ import {
 import {
   getCosmeticDetail,
   getStickerCosmetics,
+  getStickerAttribution,
   getPaginatedCosmetics,
   equipCosmeticToEntity,
   unequipCosmetic,
@@ -39,6 +40,15 @@ export const cosmeticRouter = router({
     .input(getStickerCosmeticsSchema)
     .query(({ input }) => {
       return getStickerCosmetics(input);
+    }),
+  // Who made a sticker and where to buy it, for the attribution card on an
+  // inline sticker. Public: the answer is the same for every viewer, and the
+  // sticker is already visible to anyone reading the comment.
+  getStickerAttribution: publicProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
+    .input(getStickerCosmeticsSchema)
+    .query(({ input }) => {
+      return getStickerAttribution(input);
     }),
   // Remaining uses per owned sticker, so the picker can show a balance instead
   // of the user discovering it as a failed comment submit.

--- a/src/server/services/__tests__/sticker-attribution.service.test.ts
+++ b/src/server/services/__tests__/sticker-attribution.service.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * `getStickerAttribution` decides three things a comment reader sees, and each
+ * of them is a decision rather than a passthrough:
+ *
+ * - whether there is a link at all, which is the difference between "buy this"
+ *   and a 404 — a disabled shop returns NOT_FOUND to visitors, and a comment can
+ *   name any sticker, including one whose creator never opened a shop;
+ * - whether a deleted creator's name still shows (it does; the link does not);
+ * - that only Sticker cosmetics are answerable at all. That last one is the
+ *   reason for a negative control: the procedure is public and takes an array of
+ *   ids, so without the type filter it is a name-and-creator lookup over every
+ *   cosmetic in the table.
+ */
+
+const findMany = dbMock.dbRead.cosmetic.findMany;
+
+const { getStickerAttribution } = await import('~/server/services/cosmetic.service');
+
+const shopOpen = { creatorShop: { enabled: true } };
+
+beforeEach(() => {
+  findMany.mockReset();
+});
+
+describe('getStickerAttribution', () => {
+  test('links to the shop when the creator has one open', async () => {
+    findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Garlic Allergy',
+        creator: { username: 'neclordx', deletedAt: null, settings: shopOpen },
+      },
+    ]);
+
+    const [sticker] = await getStickerAttribution({ ids: [1] });
+
+    expect(sticker.creatorName).toBe('neclordx');
+    expect(sticker.shopHref).toBe('/user/neclordx/shop');
+  });
+
+  test('🔴 names the creator but does NOT link when their shop is disabled', async () => {
+    findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Garlic Allergy',
+        creator: {
+          username: 'neclordx',
+          deletedAt: null,
+          settings: { creatorShop: { enabled: false } },
+        },
+      },
+    ]);
+
+    const [sticker] = await getStickerAttribution({ ids: [1] });
+
+    expect(sticker.creatorName, 'the maker is still named').toBe('neclordx');
+    expect(
+      sticker.shopHref,
+      'a link to a disabled shop is a 404 — the card would offer to sell something nobody can buy'
+    ).toBeNull();
+  });
+
+  test('🔴 does NOT link when the creator never opened a shop', async () => {
+    findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Staff Sticker',
+        creator: { username: 'civitai', deletedAt: null, settings: {} },
+      },
+    ]);
+
+    const [sticker] = await getStickerAttribution({ ids: [1] });
+
+    expect(sticker.shopHref, 'no shop settings at all is not an open shop').toBeNull();
+  });
+
+  test('keeps the name but drops the link for a deleted creator', async () => {
+    findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Garlic Allergy',
+        creator: { username: 'gone', deletedAt: new Date(), settings: shopOpen },
+      },
+    ]);
+
+    const [sticker] = await getStickerAttribution({ ids: [1] });
+
+    expect(sticker.name, 'the sticker is still drawn, so its name is still worth showing').toBe(
+      'Garlic Allergy'
+    );
+    expect(sticker.creatorName).toBeNull();
+    expect(sticker.shopHref).toBeNull();
+  });
+
+  test('handles a sticker with no creator row at all', async () => {
+    findMany.mockResolvedValue([{ id: 1, name: 'Orphan', creator: null }]);
+
+    const [sticker] = await getStickerAttribution({ ids: [1] });
+
+    expect(sticker.creatorName).toBeNull();
+    expect(sticker.shopHref).toBeNull();
+  });
+
+  test('🔴 withholds a BANNED creator, not just a deleted one', async () => {
+    findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Garlic Allergy',
+        createdById: 7,
+        creator: {
+          username: 'banned',
+          deletedAt: null,
+          bannedAt: new Date(),
+          settings: shopOpen,
+        },
+      },
+    ]);
+
+    const [sticker] = await getStickerAttribution({ ids: [1] });
+
+    expect(sticker.creatorName, 'a banned creator is not attributed').toBeNull();
+    expect(sticker.shopHref).toBeNull();
+    expect(sticker.creatorId, 'and nothing keys a creator card on them either').toBeNull();
+  });
+
+  test('returns the creator id so the card keys on it rather than a username', async () => {
+    findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Garlic Allergy',
+        createdById: 7,
+        creator: { username: 'neclordx', deletedAt: null, bannedAt: null, settings: shopOpen },
+      },
+    ]);
+
+    const [sticker] = await getStickerAttribution({ ids: [1] });
+
+    // The viewer's block check needs an id, and every other creator card on the
+    // page keys its lookup on id — two keys for one creator misses both caches.
+    expect(sticker.creatorId).toBe(7);
+  });
+
+  test('🔴 asks only for Sticker cosmetics (negative control on a public, id-taking procedure)', async () => {
+    findMany.mockResolvedValue([]);
+
+    await getStickerAttribution({ ids: [1, 2] });
+
+    const where = findMany.mock.calls[0]?.[0]?.where;
+    expect(where?.id).toEqual({ in: [1, 2] });
+    expect(
+      where?.type,
+      'without the type filter this is a name-and-creator lookup over every cosmetic'
+    ).toBe('Sticker');
+  });
+});

--- a/src/server/services/cosmetic.service.ts
+++ b/src/server/services/cosmetic.service.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
 import type { CosmeticEntity } from '~/shared/utils/prisma/enums';
 import { CosmeticType } from '~/shared/utils/prisma/enums';
+import type { UserSettingsSchema } from '~/server/schema/user.schema';
 import dayjs from '~/shared/utils/dayjs';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
@@ -69,19 +70,48 @@ export async function getStickerCosmetics({ ids }: GetStickerCosmeticsInput) {
  */
 export async function getStickerAttribution({ ids }: GetStickerCosmeticsInput) {
   const cosmetics = await dbRead.cosmetic.findMany({
-    where: { id: { in: ids }, type: CosmeticType.Sticker },
-    select: { id: true, name: true, creator: { select: { username: true, deletedAt: true } } },
+    where: {
+      id: { in: ids },
+      type: CosmeticType.Sticker,
+      // Not yet released, or no longer available, is not a thing to attribute.
+      // The procedure is public and takes an id array, so without this a staged
+      // sticker is readable before its launch.
+      OR: [{ availableStart: null }, { availableStart: { lte: new Date() } }],
+      AND: [{ OR: [{ availableEnd: null }, { availableEnd: { gte: new Date() } }] }],
+    },
+    select: {
+      id: true,
+      name: true,
+      createdById: true,
+      creator: {
+        select: { username: true, deletedAt: true, bannedAt: true, settings: true },
+      },
+    },
   });
 
   return cosmetics.map((cosmetic) => {
-    // A deleted creator keeps the sticker drawable and its name worth showing;
-    // it just has nowhere to send anyone.
-    const username = cosmetic.creator?.deletedAt ? null : cosmetic.creator?.username ?? null;
+    const creator = cosmetic.creator;
+    // Only link to a shop someone can actually buy from. A disabled shop is a
+    // 404 to visitors, and a comment can name any sticker — including a
+    // staff-authored cosmetic whose creator never opened one — so unlike the
+    // placement card, a link here is not implied by someone having bought it.
+    // Same predicate the shop listings filter on.
+    const settings = (creator?.settings ?? {}) as UserSettingsSchema;
+    const shopEnabled = settings.creatorShop?.enabled === true;
+    // A deleted or banned creator keeps the sticker drawable and its name worth
+    // showing; it just has nowhere to send anyone. `deletedAt` alone would be a
+    // narrower rule than the rest of the codebase applies to attributing someone.
+    const withheld = !!creator?.deletedAt || !!creator?.bannedAt;
+    const username = withheld ? null : creator?.username ?? null;
     return {
       id: cosmetic.id,
       name: cosmetic.name,
+      // The viewer's side needs an id to check a block against, and every other
+      // creator card on the page keys its lookup on id rather than username —
+      // two keys for one creator otherwise misses both caches.
+      creatorId: withheld ? null : cosmetic.createdById,
       creatorName: username,
-      shopHref: username ? `/user/${username}/shop` : null,
+      shopHref: username && shopEnabled ? `/user/${username}/shop` : null,
     };
   });
 }

--- a/src/server/services/cosmetic.service.ts
+++ b/src/server/services/cosmetic.service.ts
@@ -54,6 +54,38 @@ export async function getStickerCosmetics({ ids }: GetStickerCosmeticsInput) {
     .filter((sticker) => !!sticker.slug && !!sticker.url);
 }
 
+/**
+ * Who made a sticker, and where to buy it.
+ *
+ * Separate from `getStickerCosmetics` because the shared `cosmeticCache` does not
+ * hold a creator — it selects id/name/type/data/source, and widening a cache
+ * every avatar and badge lookup goes through, to serve a hover, is the wrong
+ * trade. This is asked for one sticker at a time, when someone hovers it.
+ *
+ * Emits the href rather than the username, matching the placement card: a
+ * template literal accepts null silently, which is how `/user/null/shop` once
+ * shipped past a typecheck. No consumer can build the wrong link if none of them
+ * builds one.
+ */
+export async function getStickerAttribution({ ids }: GetStickerCosmeticsInput) {
+  const cosmetics = await dbRead.cosmetic.findMany({
+    where: { id: { in: ids }, type: CosmeticType.Sticker },
+    select: { id: true, name: true, creator: { select: { username: true, deletedAt: true } } },
+  });
+
+  return cosmetics.map((cosmetic) => {
+    // A deleted creator keeps the sticker drawable and its name worth showing;
+    // it just has nowhere to send anyone.
+    const username = cosmetic.creator?.deletedAt ? null : cosmetic.creator?.username ?? null;
+    return {
+      id: cosmetic.id,
+      name: cosmetic.name,
+      creatorName: username,
+      shopHref: username ? `/user/${username}/shop` : null,
+    };
+  });
+}
+
 export async function getOwnedStickerCosmetics(userId: number) {
   const owned = await userOwnedStickerCache.fetch([userId]);
   const ids = owned[userId]?.cosmeticIds ?? [];


### PR DESCRIPTION
Closes the comments half of ClickUp [868ku94bb](https://app.clickup.com/t/868ku94bb).

A sticker in a comment now says who made it and links to their shop, on hover.

## What Justin asked, and what it turned out to mean

His answer on placement surfaces was already true: a placed sticker's card shows the **placer**, and that ships today. Nothing changed there.

The second half — *"if it's in a comment or a DM, then it needs to be the creator of the sticker"* — sat against something he said earlier: *"be thoughtful about not having it trigger on the place spaces just inside of comments and DMs."*

Those reconcile once you know the state: **inline stickers have no card of any kind today.** They render through `Sticker.tsx` from the TipTap node and chat, a path with no hover card in it. So this was never "swap who the card is about" — it was "add a card to a surface that has none", on the surface he'd said to be careful about.

Put to him as a product call, he chose **comments now, DMs a separate decision**. This is that.

## Why it is mounted where it is

**In `RenderHtml`, behind `allowStickers`.** That opt-in already governs whether a sticker is drawn at all: ~30 rich-text surfaces render through `RenderHtml`, several storing user HTML without sanitizing it, so containment lives at the renderer and a new surface fails closed. It is granted at exactly four comment call sites. Reusing it means the card reaches precisely the surfaces Justin named, and **no surface can acquire a shop link by acquiring a sticker**.

🔴 **Deliberately not in `Sticker.tsx`.** That component is shared with chat, which renders stickers inline in DMs. A card there makes any sticker a stranger sends you a route to their shop — with no message text to report, and a third party the recipient never chose to interact with. Mounting on the shared component would have shipped the DM decision by accident. The guard asserts the shared component carries no card, so that cannot happen quietly later.

**Shaped after `MentionHoverCard`**, which solves the same problem one component over: a rendered sticker is an `<img>` built imperatively inside `dangerouslySetInnerHTML`, so there is no React node to wrap. Hover is delegated from the container and the card anchors to a zero-size box over the sticker — including its detached-element check, since the container swaps its whole `innerHTML` when the html prop changes and a detached element measures as all zeros.

## Server

`getStickerAttribution` is its own lookup rather than a widening of `cosmeticCache`. That cache selects `id/name/type/data/source` and every avatar and badge lookup goes through it; growing it to serve a hover is the wrong trade. This is asked for one sticker, when someone hovers it, with a 5-minute `staleTime`.

It emits the **href**, not the username — matching the placement card, whose comment records that a template literal accepts `null` silently, which is how `/user/null/shop` once shipped past a typecheck. A soft-deleted creator yields a name with no link rather than a broken one.

Public procedure: the answer is identical for every viewer, and the sticker is already visible to anyone reading the comment.

## Identity is not taken from the markup

Comment HTML is user-authored, so `data-*` attributes are attacker-controlled — the reason `MentionHoverCard` validates its mention against the link beside it. Here the equivalent check already exists upstream: `RenderHtml` only draws a sticker whose `data-id` resolved against server-supplied cosmetics, and the name and shop link come from the server keyed on that same id. There is no username in the DOM for anyone to spoof.

⚠️ Review narrowed this. A comment author **cannot** reference an arbitrary sticker id — `spendStickerUses` throws when they hold no row for it, and the edit path reads `previousContent` from the stored comment rather than the client. What they *can* do is reference an id for a cosmetic of another type, which never draws; the card now refuses to attach to a span that did not draw, so that case carries nothing.

## Testing

Two guards, both mutation-checked.

**Containment** extends `sticker-render-optin.test.ts`, because that file already owns "stickers are opt-in" and this is the same question one step on. Review found my first version was a spelled guard — it forbade three component names, so a `Tooltip` whose label held a shop `Anchor` would have put a shop link in every DM while staying green. It now forbids the **data** as well: no route to a shop exists without a username or an href, and the only server source of either is `getStickerAttribution`. It counts mounts rather than checking one exists, and walks every chat file rather than one, since `ChatWindow` picks between two chat renderers behind a flag and both draw stickers.

| mutation | result |
|---|---|
| shop-link data on `Sticker.tsx`, using none of the forbidden component names | **red** |
| a hover card on `Sticker.tsx` | **red** |
| a second, ungated mount beside the gated one | **red** — `expected 2 to be 1` |

**`getStickerAttribution`** has its own service test — eight cases covering the decisions, not the passthrough: shop open, shop disabled, no shop settings, deleted creator, banned creator, no creator row, the creator id, and a **negative control that the `type: Sticker` filter is in the query** (without it, a public id-taking procedure becomes a name-and-creator lookup over every cosmetic). Dropping the shop check reddens two cases; dropping the banned check reddens one — re-verified after the mock swap below, since that is where a test goes hollow.

It uses the repo's canonical `dbMock` rather than a direct `~/server/db/client` mock. I wrote the direct one first and `no-direct-shared-module-mock` caught it; the repo ships a codemod for the conversion.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — clean on all five changed files. Two `no-unused-vars` warnings in `cosmetic.service.ts` are pre-existing; confirmed by stashing the change and re-running.
- `pnpm run prettier:write` — changed files only
- `pnpm run test:unit:run` — **5 failed / 1222 passed / 1 skipped (1228)**. Three are the standing set (`appListingStatChips`, `standalone-boot-graph`, `rating-label`). Two arrived with a newer `main` after I rebased: `model-file-hash-writers` — confirmed pre-existing by stashing my changes and re-running it, identical failure — and `no-direct-shared-module-mock`, which was mine and is fixed above.

**Verified in a browser, against a comment seeded through the real write path.** Dev had no comment carrying an inline sticker, so I posted one as a signed-in user by typing `:botkek:` into the actual comment editor — the token converted to a sticker node, submitted, and rendered as `span[data-type="sticker"]` with `data-id="1410"` and a drawn `<img>`. Hovering it opens the card reading **"CivBot Ultra KEK by DD13"** with DD13's creator card, and the name links to `/user/DD13/shop`.

Seeding through the editor rather than a database insert was deliberate: it exercises the sanitizer and the ownership path a real comment goes through, so the rendered markup is what users actually produce. Dev only — nothing was seeded on production and no Buzz was spent.

## Not in this PR

- **DMs.** Justin's separate decision, deliberately not built.
- **Touch devices.** Hover has no mobile equivalent; I asked and it was not the part he answered, so tap-to-open is unbuilt and the card is desktop-only, as `useHoverCapable` already enforces for mentions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
