### PR TITLE
test(preview): repoint the moderator smoke specs off the pre-#3573 routing (fixes #4171)

### DIFF
--- a/tests/preview-auth-guard.spec.ts
+++ b/tests/preview-auth-guard.spec.ts
@@ -6,15 +6,20 @@ import { storageStatePath } from './preview-fixtures';
  * existing smoke / moderation specs don't cover:
  *
  *   1. The _app moderator guard (server/auth/route-guard.ts, moved off the edge middleware) REDIRECTS a
- *      gate-passing NON-moderator away from /moderator. preview-smoke proves a mod can enter and
- *      preview-moderation proves the queues render — neither proves a non-mod is bounced, which is the whole
- *      point of the new guard.
+ *      gate-passing NON-moderator away from /moderator. preview-moderation proves the surviving moderator
+ *      surfaces render for a mod — neither proves a non-mod is bounced, which is the whole point of the new
+ *      guard.
  *   2. /login is now a pure server-side redirect to the centralized hub (buildHubLoginRedirect), threading the
  *      returnUrl. We assert the redirect target WITHOUT following it (the hop lands on the external hub).
  *
  * Only runs under playwright.preview.config.ts (needs PREVIEW_URL + the minted storage states).
  */
 
+// #3573 migrated this path to the standalone moderator app (shared/constants/migrated-moderator-routes.ts:
+// `reports` -> `reports`), so for a MODERATOR it now ends in a 3xx to that app. It is still the right probe
+// for the guard: the guard runs in _app.getInitialProps, ahead of the catchall's getServerSideProps, so a
+// non-mod is bounced before the migration redirect can matter (which is why the two bounce tests below are
+// unaffected by the migration), and for a mod the Location tells us WHICH hop happened.
 const MODERATOR_PATH = '/moderator/reports';
 
 // tester (Flipt allowlist) + gold (allowlist + tier) both CLEAR the preview gate but lack isModerator, so the
@@ -28,11 +33,17 @@ for (const role of NON_MOD_ROLES) {
     test(`${role} cannot reach ${MODERATOR_PATH}`, async ({ page }) => {
       await page.goto(MODERATOR_PATH, { waitUntil: 'domcontentloaded' });
       // The guard sends an authed non-mod to '/' (login can't grant the missing permission, so it would loop).
-      expect(page.url(), `${role} should be bounced off the moderator surface`).not.toContain('/moderator');
+      expect(page.url(), `${role} should be bounced off the moderator surface`).not.toContain(
+        '/moderator'
+      );
       // A bounce to /login would mean the session didn't resolve (a different failure) — assert it did.
-      expect(page.url(), `${role} session should resolve, not bounce to login`).not.toContain('/login');
+      expect(page.url(), `${role} session should resolve, not bounce to login`).not.toContain(
+        '/login'
+      );
       // And it isn't the preview-access gate firing instead (these roles are allowlisted).
-      expect(page.url(), `${role} should not hit preview-restricted`).not.toContain('/preview-restricted');
+      expect(page.url(), `${role} should not hit preview-restricted`).not.toContain(
+        '/preview-restricted'
+      );
     });
   });
 }
@@ -40,10 +51,27 @@ for (const role of NON_MOD_ROLES) {
 test.describe('_app moderator guard admits a moderator (control)', () => {
   test.use({ storageState: storageStatePath('mod') });
 
-  test('mod stays on /moderator/reports', async ({ page }) => {
-    const resp = await page.goto(MODERATOR_PATH, { waitUntil: 'domcontentloaded' });
-    expect(resp?.status(), 'HTTP status for /moderator/reports').toBeLessThan(400);
-    await expect(page).toHaveURL(/\/moderator\/reports/);
+  test('mod is not bounced — the only hop is the moderator-app migration redirect', async ({
+    page,
+  }) => {
+    // Inspect the 3xx Location WITHOUT following it — same idiom (and same reason) as the /login test below:
+    // the hop leaves this origin for the standalone moderator app, which a preview cannot exercise
+    // (MODERATOR_APP_URL defaults to production — server-schema.ts). `page.request` shares the browser
+    // context's cookies (minted by preview-auth.setup.ts) and its baseURL, so this is the mod's session.
+    const res = await page.request.get(MODERATOR_PATH, { maxRedirects: 0 });
+    expect(res.status(), `HTTP status for ${MODERATOR_PATH}`).toBeGreaterThanOrEqual(300);
+    expect(res.status(), `HTTP status for ${MODERATOR_PATH}`).toBeLessThan(400);
+
+    const location = res.headers()['location'] ?? '';
+    expect(location, `${MODERATOR_PATH} should set a redirect Location`).not.toBe('');
+    // The GUARD has exactly two bounces (route-guard.ts): '/' for an authed non-moderator, and
+    // '/login?returnUrl=…' when the session didn't resolve. Neither may fire for a mod — that IS this
+    // control. (The login bounce percent-encodes its returnUrl, so it can't spell a literal '/reports'.)
+    expect(location, 'a mod must not be bounced home by the _app guard').not.toBe('/');
+    expect(location, 'a mod session should resolve, not bounce to login').not.toContain('/login');
+    // …so the hop is the migration one. Deploy-agnostic: MODERATOR_APP_URL is env-per-deploy, so pin the
+    // PATH the mapping produces, not the host.
+    expect(location, 'mod should be forwarded to the moderator app /reports').toMatch(/\/reports$/);
   });
 });
 

--- a/tests/preview-auth.setup.ts
+++ b/tests/preview-auth.setup.ts
@@ -143,8 +143,13 @@ setup('mint preview sessions', async ({ request }) => {
   if (mod) {
     // /moderator/* render only for a moderator (gold would be bounced), so warm the
     // moderation-spec pages with the mod cookie.
+    // These MUST be paths this app still serves. /moderator/reports + /moderator/images
+    // migrated to the standalone moderator app in #3573 and now 302 off-origin to
+    // MODERATOR_APP_URL — which defaults to PRODUCTION — so warming them warmed prod
+    // and compiled nothing here (civitai#4171). Keep this list in step with
+    // MODERATOR_SURFACES in preview-moderation.spec.ts.
     const headers = { cookie: `${COOKIE_NAME}=${mod}` };
-    for (const path of ['/moderator/reports', '/moderator/images']) {
+    for (const path of ['/moderator/rewards', '/moderator/suspicious-audit-matches']) {
       await request.get(path, { timeout: 60_000, headers }).catch(() => {});
     }
   }
@@ -154,10 +159,11 @@ setup('mint preview sessions', async ({ request }) => {
   // can be cold/overloaded; fire ONE GET to warm the connection. We deliberately do
   // NOT poll-until-ready: the earlier 12x6s gate wasted up to ~72s when search was
   // overloaded for the whole window, and it was never the load-bearing fix anyway —
-  // each search-dependent spec (whatIf, /moderator/images, image-feed) wraps its
-  // query in retryFlaky (preview-retry.ts), which rides out a transient 408/5xx with
-  // backoff. So a single fire-and-forget warm-up is all that's useful here.
-  // (/moderator/images is already warmed by the mod loop above.)
+  // each search-dependent spec (whatIf, image-feed) wraps its query in retryFlaky
+  // (preview-retry.ts), which rides out a transient 408/5xx with backoff. So a single
+  // fire-and-forget warm-up is all that's useful here.
+  // (/moderator/images used to be warmed by the mod loop above; it migrated out of
+  // this app in #3573 and is no longer a search consumer here — civitai#4171.)
   if (gold) {
     await request
       .get('/api/v1/images?sort=Most%20Reactions&limit=1', {

--- a/tests/preview-moderation.spec.ts
+++ b/tests/preview-moderation.spec.ts
@@ -1,20 +1,34 @@
 import { expect, test } from '@playwright/test';
 import { storageStatePath } from './preview-fixtures';
-import { trpcMutation, trpcQuery, uniqueToken } from './preview-trpc';
-import { retryFlaky } from './preview-retry';
+import { trpcMutation, uniqueToken } from './preview-trpc';
 
 /**
  * Moderation-surface tests for a deployed PR preview environment.
  *
  * Runs as the `mod` fixture — the ONLY role that both clears the preview gate and
- * carries user.isModerator, which the /moderator/* tRPC procedures
- * (moderatorProcedure) require. The mod fixture is also onboarding=15, so it
- * passes guardedProcedure and can self-seed a post + report.
+ * carries user.isModerator, which the moderator-gated pages
+ * (createServerSideProps({ requireModerator: true })) and the /moderator/* tRPC
+ * procedures require. The mod fixture is also onboarding=15, so it passes
+ * guardedProcedure and can self-seed a post + report.
  *
- * Two render tests (the reports + images queues render behind the gate) and one
- * end-to-end ACTION test (a mod self-seeds an isolated post -> reports it ->
- * actions the report), kept as separate test()s so a render-selector miss can't
- * mask the action coverage and vice-versa.
+ * 🔴 SCOPE MOVED (civitai#3573, tracked as civitai#4171). The reports + images
+ * QUEUES and their moderator tRPC procedures (report.getAll / report.setStatus)
+ * were migrated OUT of this app into the standalone moderator app
+ * (`apps/moderator`), and the main app now 302s those paths there
+ * (src/pages/moderator/[...slug].tsx + shared/constants/migrated-moderator-routes.ts).
+ * A preview cannot exercise the moderator app at all — MODERATOR_APP_URL defaults
+ * to PRODUCTION (server-schema.ts), so the hop leaves the preview origin. So this
+ * spec now covers the three things that DO still live here:
+ *
+ *   1. Two render tests on moderator surfaces that stayed in this app, proving the
+ *      requireModerator SSR gate admits a mod and the page renders. Kept as
+ *      separate test()s so a selector miss on one can't mask the other.
+ *   2. A migration test pinning that the two migrated paths still redirect to the
+ *      moderator app — asserted WITHOUT following the hop.
+ *   3. The report-CREATION leg of the old end-to-end action test. `report.create`
+ *      is still a main-app guardedProcedure; `report.getAll` / `report.setStatus`
+ *      are not (they were deleted in #3573), so the ACTIONING half of that
+ *      coverage now belongs to the moderator app's own suite, not here.
  *
  * Only runs under playwright.preview.config.ts (needs PREVIEW_URL + minted states).
  *
@@ -25,27 +39,64 @@ import { retryFlaky } from './preview-retry';
  *                       returns the created Post incl. `id`
  *                       (server/controllers/post.controller.ts createPostHandler `return post`).
  *  - report.create      guardedProcedure, input createReportInputSchema
- *                       (server/schema/report.schema.ts:104) — a discriminatedUnion
- *                       on `reason`. The `Spam` variant (reportSpamSchema, :92) is the
+ *                       (server/schema/report.schema.ts) — a discriminatedUnion
+ *                       on `reason`. The `Spam` variant (reportSpamSchema) is the
  *                       minimal shape: { type: ReportEntity, id: number,
  *                       reason: 'Spam', details: {} }. `type` is z.enum(ReportEntity)
  *                       and the Post entity string is 'post'
  *                       (shared/utils/report-helpers.ts:8 `Post = 'post'`).
- *                       Returns the created Report row incl. `id` + `status`
- *                       (server/services/report.service.ts createReport `return createdReport`).
- *  - report.getAll      moderatorProcedure, input getReportsSchema
- *                       (server/schema/report.schema.ts:128) = getAllQuerySchema
- *                       (page/limit) + { type: ReportEntity, filters?, sort? }.
- *                       Row shape selects post.post.id
- *                       (server/controllers/report.controller.ts:180) so a Post
- *                       report row is matched via row.post?.post?.id.
- *  - report.setStatus   moderatorProcedure, input setReportStatusSchema
- *                       (server/schema/report.schema.ts:116) = { id: number,
- *                       status: ReportStatus }. ReportStatus ∈
- *                       Pending|Processing|Actioned|Unactioned (prisma/schema.prisma:1114).
+ *                       Returns a Report row incl. `id` — either the freshly
+ *                       created one or, if one already existed for the entity, the
+ *                       existing one (server/services/report.service.ts createReport:
+ *                       `if (validReport) return validReport` / `return createdReport`).
+ *                       Self-reporting is only blocked for ReportEntity.User, so a
+ *                       mod may report their own post.
  */
 
 const ROLE = 'mod' as const;
+
+/**
+ * Moderator surfaces that are STILL SERVED BY THIS APP, with an anchor verified to
+ * render unconditionally (outside every loading / empty / feature branch).
+ *
+ * Screened on origin/main against the four ways a moderator page makes a bad probe:
+ * present under src/pages/moderator/, absent from MIGRATED_ROUTES, gated by
+ * `createServerSideProps({ requireModerator: true })`, and carrying NO `features.*`
+ * flag check (a flag-gated page renders <NotFound /> when the flag is off in
+ * preview, which would look exactly like a broken gate).
+ *
+ * `title` is what the page's <Meta title> emits — Meta renders `<title>{title}</title>`
+ * verbatim (components/Meta/Meta.tsx). Matched as a case-insensitive SUBSTRING, the
+ * same tolerance the pre-#3573 version of this spec used, so a layout that appends a
+ * site suffix doesn't turn a rendering page into a red gate.
+ * `heading` is an unconditional Mantine `<Title order={1}>` (an <h1>).
+ */
+const MODERATOR_SURFACES = [
+  {
+    // src/pages/moderator/rewards/index.tsx — Buzz purchasable-rewards admin.
+    path: '/moderator/rewards',
+    title: /Rewards/i,
+    heading: 'Purchasable Rewards',
+  },
+  {
+    // src/pages/moderator/suspicious-audit-matches.tsx — prompt-audit flag queue.
+    path: '/moderator/suspicious-audit-matches',
+    title: /Suspicious Audit Matches/i,
+    heading: 'Suspicious Audit Matches',
+  },
+] as const;
+
+/**
+ * Paths #3573 moved to the moderator app, and the PATH the mapping produces there.
+ * Literal expectations on purpose — derived from MIGRATED_ROUTES' declared values,
+ * not imported from it, so a wrong edit to that map fails this test instead of
+ * silently redefining what "correct" means. The HOST is deploy-dependent
+ * (MODERATOR_APP_URL), so only the path is pinned.
+ */
+const MIGRATED_PATHS = [
+  { path: '/moderator/reports', target: '/reports' },
+  { path: '/moderator/images', target: '/images' },
+] as const;
 
 // Mirror preview-smoke.spec.ts: assert we cleared the preview gate.
 function assertGatePassed(page: import('@playwright/test').Page, path: string) {
@@ -58,56 +109,56 @@ function assertGatePassed(page: import('@playwright/test').Page, path: string) {
 test.describe('moderation surface (mod)', () => {
   test.use({ storageState: storageStatePath(ROLE) });
 
-  test('/moderator/reports renders the report queue', async ({ page }) => {
-    const resp = await page.goto('/moderator/reports', { waitUntil: 'domcontentloaded' });
-    expect(resp?.status(), 'HTTP status for /moderator/reports').toBeLessThan(400);
-    assertGatePassed(page, '/moderator/reports');
+  for (const surface of MODERATOR_SURFACES) {
+    test(`${surface.path} renders behind the moderator gate`, async ({ page }) => {
+      const resp = await page.goto(surface.path, { waitUntil: 'domcontentloaded' });
+      expect(resp?.status(), `HTTP status for ${surface.path}`).toBeLessThan(400);
+      assertGatePassed(page, surface.path);
+      // Not bounced home by the requireModerator gate, and not swallowed by the
+      // migration catchall (which would leave this origin entirely).
+      await expect(page).toHaveURL(new RegExp(`${surface.path}/?$`));
 
-    // Page-loaded anchor: reports.tsx renders <Meta title="Reports" /> (line 219),
-    // so the document <title> is the most stable "the mod page rendered (not an
-    // error/redirect)" signal, independent of how many rows the prod-clone DB has.
-    await expect(page).toHaveTitle(/Reports/i, { timeout: 30_000 });
+      // Anchor 1: the document title. <Meta title> is rendered unconditionally at
+      // the top of the page component, so it is the "the mod page rendered, not an
+      // error/redirect" signal that is independent of how many rows the prod-clone
+      // DB has.
+      await expect(page).toHaveTitle(surface.title, { timeout: 30_000 });
 
-    // Structural presence of the queue UI. reports.tsx renders a MantineReactTable
-    // (import line 30, JSX line 231), which emits a <table> with role="table".
-    // Be tolerant of 0..N rows on the prod clone — assert the grid scaffold exists,
-    // not any specific row.
-    // NOTE: if MantineReactTable's role/markup changes, widen this — the intent is
-    // "a table/grid structure is on the page". A visible table OR a non-empty main
-    // region both satisfy "the queue rendered".
-    const table = page.getByRole('table').first();
-    await expect(table).toBeVisible({ timeout: 30_000 });
-  });
-
-  test('/moderator/images renders the image review queue', async ({ page }) => {
-    // /moderator/images is image-search-backed (getModeratorReviewQueue ->
-    // getAllImagesIndex -> the in-cluster feeds-proxy), which intermittently 5xx's
-    // under concurrent preview-build load. Retry the navigation with backoff to ride
-    // out a transient search spike — honest: the page must still render < 400, and a
-    // sustained outage still fails after the attempts are exhausted.
-    await retryFlaky('/moderator/images navigation', async () => {
-      const resp = await page.goto('/moderator/images', { waitUntil: 'domcontentloaded' });
-      expect(resp?.status(), 'HTTP status for /moderator/images').toBeLessThan(400);
+      // Anchor 2: the page's own <h1>. Also unconditional — it sits outside the
+      // isLoading / empty-state branches, so it holds on a full OR empty queue and
+      // even if the page's tRPC query errors. That is the point: a structural
+      // anchor inside a data branch would make this test a data test.
+      await expect(
+        page.getByRole('heading', { name: surface.heading, exact: true }).first()
+      ).toBeVisible({ timeout: 30_000 });
     });
-    assertGatePassed(page, '/moderator/images');
+  }
 
-    // images.tsx is an infinite list off trpc.image.getModeratorReviewQueue. It
-    // renders either image <Card>s (Mantine Card import line 5, usage line 366) OR,
-    // when the queue is empty, <NoContent message="There are no images that need
-    // review" /> (line 343). Tolerate BOTH branches: assert at least one of the
-    // known structural anchors is present so the test passes on a full or empty
-    // prod-clone queue.
-    // NOTE: broad OR over the empty-state copy and the card/list region. If a
-    // preview shows different empty copy, widen the regex — the structural intent
-    // is "the review queue surface rendered, not an error/redirect".
-    const queueRendered = page
-      .getByText(/no images that need review|need review|review queue/i)
-      .first()
-      .or(page.locator('.mantine-Card-root, [class*="Card-root"]').first());
-    await expect(queueRendered).toBeVisible({ timeout: 30_000 });
+  test('migrated /moderator paths redirect to the moderator app', async ({ page }) => {
+    for (const { path, target } of MIGRATED_PATHS) {
+      // Inspect the 3xx Location WITHOUT following it: the hop leaves this origin for
+      // the moderator app, which on a preview is PRODUCTION (MODERATOR_APP_URL's
+      // default) — following it would probe prod from CI and prove nothing about the
+      // preview. `page.request` carries the mod's cookies + the preview baseURL.
+      const res = await page.request.get(path, { maxRedirects: 0 });
+      expect(res.status(), `HTTP status for ${path}`).toBeGreaterThanOrEqual(300);
+      expect(res.status(), `HTTP status for ${path}`).toBeLessThan(400);
+
+      const location = res.headers()['location'] ?? '';
+      expect(location, `${path} should set a redirect Location`).not.toBe('');
+      // A mod must not be bounced by the _app guard instead — its two bounces are
+      // '/' and '/login?returnUrl=…'; distinguish them from the migration hop.
+      expect(location, `${path}: a mod must not be bounced home`).not.toBe('/');
+      expect(location, `${path}: a mod session should resolve, not bounce to login`).not.toContain(
+        '/login'
+      );
+      expect(location, `${path} should map to ${target} on the moderator app`).toMatch(
+        new RegExp(`${target}$`)
+      );
+    }
   });
 
-  test('mod can self-seed a post, report it, and action the report', async ({ page }) => {
+  test('mod can self-seed a post and report it', async ({ page }) => {
     const token = uniqueToken('mod');
 
     // Warm the context (cookies + an allowlisted Origin host) before hitting tRPC.
@@ -124,50 +175,27 @@ test.describe('moderation surface (mod)', () => {
 
     // 2) Report that post. Minimal valid variant of the createReportInputSchema
     //    discriminatedUnion is reason:'Spam' (reportSpamSchema → just baseDetailSchema).
-    //    type:'post' is ReportEntity.Post. createReport returns the row incl. id+status.
-    // NOTE: 'Spam' / type:'post' verified in report.schema.ts:92 + report-helpers.ts:8.
+    //    type:'post' is ReportEntity.Post. createReport returns the row incl. id.
+    // NOTE: 'Spam' / type:'post' verified in report.schema.ts + report-helpers.ts:8.
     // If the CSRF/origin gate (createContext.ts) rejects this direct tRPC POST with
     // 403 live, the UI-driven fallback would be: open the post page → use the report
-    // menu → then drive setStatus from /moderator/reports' row status Badge → Menu.
+    // menu.
     const report = await trpcMutation<{ id: number; status: string }>(
       page.request,
       'report.create',
       { type: 'post', id: post.id, reason: 'Spam', details: {} }
     );
+    // trpcMutation throws on any tRPC error envelope or non-2xx, so reaching here
+    // already means the mutation succeeded; the id assertion pins that the handler
+    // returned the row (createReportHandler `return result`) rather than undefined.
+    expect(report?.id, 'report.create should return a numeric report id').toEqual(
+      expect.any(Number)
+    );
 
-    // 3) Resolve the report id. Prefer it straight from report.create's return; fall
-    //    back to report.getAll (moderatorProcedure) matching on the seeded post id.
-    let reportId: number | undefined = report?.id;
-    if (typeof reportId !== 'number') {
-      // getReportsSchema = page/limit (getAllQuerySchema) + type (ReportEntity).
-      // Newest-first isn't guaranteed by default, so request a generous page and
-      // match on the post relation's id (handler selects post.post.id).
-      const all = await trpcQuery<{
-        items: Array<{ id: number; post?: { post?: { id?: number } | null } | null }>;
-      }>(page.request, 'report.getAll', { page: 1, limit: 100, type: 'post' });
-      const mine = all?.items?.find((r) => r.post?.post?.id === post.id);
-      reportId = mine?.id;
-    }
-    expect(reportId, 'should resolve the seeded report id').toEqual(expect.any(Number));
-
-    // 4) Action the report. setReportStatusSchema = { id, status } with status ∈
-    //    ReportStatus; 'Actioned' is a valid enum member.
-    // NOTE: setStatus's handler returns void (controller setReportStatusHandler), so
-    // we assert the mutation resolves without throwing — trpcMutation throws on any
-    // tRPC error envelope or non-2xx, so a clean resolve == success.
-    await expect(
-      trpcMutation(page.request, 'report.setStatus', { id: reportId, status: 'Actioned' })
-    ).resolves.toBeDefined();
-
-    // Best-effort confirmation: re-query and assert our row now reads 'Actioned'.
-    // Kept non-fatal-shaped (still an assertion, but only runs if getAll is reachable
-    // for a mod, which it is) — the setStatus resolve above is the primary signal.
-    const after = await trpcQuery<{
-      items: Array<{ id: number; status?: string; post?: { post?: { id?: number } | null } | null }>;
-    }>(page.request, 'report.getAll', { page: 1, limit: 100, type: 'post' });
-    const updated = after?.items?.find((r) => r.id === reportId);
-    if (updated) {
-      expect(updated.status, 'seeded report should now be Actioned').toBe('Actioned');
-    }
+    // 🔴 The ACTIONING legs (report.getAll → report.setStatus → re-read as
+    // 'Actioned') used to live here. #3573 deleted both procedures from this app's
+    // report.router.ts — that queue is the moderator app's now, and asserting it
+    // from a preview of THIS app is not possible. Do not "restore" them here; the
+    // coverage belongs to apps/moderator's own suite.
   });
 });


### PR DESCRIPTION
Fixes #4171.

## Why

`preview / smoke-tests` is red on every PR based after **#3573** (`moderator-app-pages`). It is a stale-test break, not a product break — but it is a **shared gate** currently red on unrelated PRs, and a permanently-red shared gate trains everyone to click through it. The root cause, the base-commit ancestry that separates pass from fail, and two refuted theories are all in #4171; this PR implements the fix.

## The failures — four, not two

#4171's table lists two assertions. The smoke bot's per-test breakdown on #4156 lists **four**, and the fourth has a distinct mechanism worth calling out:

| failing test | mechanism |
|---|---|
| `mod stays on /moderator/reports` (`preview-auth-guard`) | mod is now 302'd off-origin to the moderator app |
| `/moderator/reports renders the report queue` (`preview-moderation`) | page deleted; `reports` ∈ `MIGRATED_ROUTES` |
| `/moderator/images renders the image review queue` (`preview-moderation`) | same — `images` ∈ `MIGRATED_ROUTES` |
| `mod can self-seed a post, report it, and action the report` | **not a routing problem** — `report.getAll` and `report.setStatus` were deleted from `src/server/routers/report.router.ts` in #3573 (`95157404b0`, `e782b7ceeb`, `b3f01055af`). Only `report.create` survives here. |

A fix that only touched the two routing assertions would have left the gate red.

## What changed

**`tests/preview-auth-guard.spec.ts`** — as #4171 proposed, no route judgment. `MODERATOR_PATH` stays `/moderator/reports`; the mod control now asserts the **3xx without following it** (`maxRedirects: 0`), the idiom this file already uses for the `/login` hub test and for the same reason (the hop leaves this origin). The guard's only two bounces are `'/'` and `'/login?returnUrl=…'` (`server/auth/route-guard.ts`), so asserting the `Location` is neither of those — and *is* the moderator-app `/reports` hop — keeps the guard coverage the test exists for **and** pins the migration. The two non-mod bounce tests are untouched: the guard writes its 302 from `_app.getInitialProps`, ahead of the catchall's `getServerSideProps`, which is why they never broke.

**`tests/preview-moderation.spec.ts`** — repointed at two moderator surfaces that still live in this app, plus an explicit migration pin, plus the surviving half of the action test.

**`tests/preview-auth.setup.ts`** — the mod warm-up loop was warming `/moderator/reports` and `/moderator/images`. Those now 302 to `MODERATOR_APP_URL`, which **defaults to production** (`server-schema.ts:373`), so the warm-up was hitting prod from CI and compiling nothing on the preview. Repointed at the two new paths.

## Routes chosen, and why

Screened every file under `src/pages/moderator/` on `origin/main` against four criteria: present on `origin/main`; absent from `MIGRATED_ROUTES`; `requireModerator: true`; **no** `features.*` gate; and an anchor verified to render **outside** every loading / empty-state / error branch.

| route | file | anchors |
|---|---|---|
| `/moderator/rewards` | `src/pages/moderator/rewards/index.tsx` | `<Meta title="Rewards" deIndex />` (L47) + `<Title order={1}>Purchasable Rewards</Title>` (L50) |
| `/moderator/suspicious-audit-matches` | `src/pages/moderator/suspicious-audit-matches.tsx` | `<Meta title="Suspicious Audit Matches" deIndex />` (L239) + `<Title order={1}>Suspicious Audit Matches</Title>` (L245) |

Both anchors sit above the `isLoading ? … : empty ? … : rows` ternary, so they hold on a full **or** empty prod-clone DB, and even if the page's tRPC query errors — which is the property the old `role="table"` anchor did *not* have. `<Title order={1}>` renders `component: 'h1'` (`@mantine/core` `Title.cjs:73`), so `getByRole('heading')` is a structural assertion, not a text search. Neither page does data work in SSR (`createServerSideProps` with no `useSSG` and no resolver / a session-only resolver), so they are cheap on a cold single-replica preview pod.

Both are also **absent from `apps/moderator/src/routes/`**, i.e. they are not mid-migration. (I deliberately avoided `/moderator/models`, which is clean on the other criteria but *does* have a counterpart route in the spoke.)

### Candidates rejected

- `strikes.tsx` — `if (!features.strikes) return <NotFound />`; the test would silently depend on a flag being on in preview. *(rejected in #4171; re-confirmed)*
- `tags.tsx` — feature gate **and** no `<Meta title>`. *(rejected in #4171; re-confirmed — `grep` for `<Meta title` returns nothing)*
- `scanner-policies/index.tsx` — clean on gate + title, but #4171 could not confirm its `<Table>` renders unconditionally. I did not need to resolve that: I anchored on an unconditional `<h1>` instead of a table, which makes the whole question moot, and the two pages above have simpler render trees.

## Coverage that moved rather than being deleted

- The reports/images **queues** are now covered by a single test asserting both migrated paths still 302 to their mapped moderator-app path (`reports` → `/reports`, `images` → `/images`), inspected **without following** — following would probe production from CI. Expected targets are written as literals, not imported from `MIGRATED_ROUTES`, so a wrong edit to that map fails the test instead of redefining what "correct" means.
- The action test keeps `post.create` → `report.create` (both still main-app `guardedProcedure`) and drops the `report.getAll` / `report.setStatus` legs, with a comment saying **why** and that they belong to `apps/moderator`'s own suite now. That coverage genuinely left this repo; I did not want it to look like an oversight to the next person.

## What I verified — and what I could not

**Verified statically, on `origin/main`:**
- Both chosen files exist (`git cat-file -e origin/main:<path>`).
- Neither is matched by `MIGRATED_ROUTES` — ran the real `migratedRouteKey` longest-prefix logic over the parsed map: `rewards` → no key, `suspicious-audit-matches` → no key. Positive control in the same run: `reports` → key `reports` → `reports`, `images` → key `images` → `images` (17/17 keys parsed).
- Both have `requireModerator: true`; neither contains `features.` or `useFeatureFlags`.
- Both `<Meta title>` and both `<Title order={1}>` are outside every conditional branch (read the files, not grepped).
- `Meta` emits `<title>{title}</title>` verbatim (`components/Meta/Meta.tsx`); titles are still matched as case-insensitive regexes, the same tolerance the pre-#3573 spec used.
- `pnpm typecheck` — **0 type errors** (`tests/` is in `tsconfig.json`'s `include`).
- `pnpm exec prettier --check` — clean on all three files. (`preview-auth-guard.spec.ts` was already unformatted on `main`; it is formatted now, which is the small unrelated hunk in that file.)

**Could not be verified locally.** These are **preview** specs — they only run against a deployed preview under `playwright.preview.config.ts`, so nothing here can be executed on a workstation. Two assertions in particular were new behaviour reasoned to rather than watched:
- that `page.request` carries the `test.use({ storageState })` cookies and `baseURL` (documented for `browserContext.request`, but not something I ran here), and
- that `report.create` returns a row with a numeric `id` — the code says it always does (`createReport` returns either the pre-existing `validReport` or the created row, and self-reporting is only blocked for `ReportEntity.User`), but the previous spec had a `report.getAll` fallback, so I cannot tell from history which branch actually fired.

**Now verified on a real preview run** (`preview` label → `pr-preview-4179-s64z2`, commit `da475ed`):

> `preview / smoke-tests` — ✅ **66 passed · 0 flaky · 0 failed**

against the broken baseline of **61 passed · 4 failed** on #4156. That exercises both open questions above: `page.request` did carry the mod's session (the auth-guard control and the migration test both went green, and a missing cookie would have produced the `/login` bounce those tests explicitly assert against), and `report.create` did return a numeric `id`. Every other check on this PR is green too, including `tekton / typecheck`.

Test count moved 65 → 66: the two deleted render tests were replaced by two render tests **plus** one migration test, and the action test stayed (with its actioning legs removed).

## Blast radius

Test-only — three files under `tests/`, no `src/` change. `tests/` is outside the lint workflow's `LINTABLE` filter (`^(src|packages|apps/event-engine)/`), and the modified-file ESLint/Prettier steps are `continue-on-error` anyway.
