### PR TITLE
fix(dev-server): the daemon never read DEV_DAEMON_PORT, so setting it broke the CLI instead of moving the daemon

### DIFF
--- a/.claude/hooks/check-writable.mjs
+++ b/.claude/hooks/check-writable.mjs
@@ -9,6 +9,7 @@
  */
 
 import { stdin } from 'process';
+import { readFileSync } from 'fs';
 
 // `prettier --write <targets>`: the incident was a repo-WIDE rewrite, not formatting a directory
 // this change owns. Read the targets instead of matching `--write`, so a scoped path just runs.
@@ -84,7 +85,39 @@ function isUnscoped(target) {
 // URL carrying a dev port in a query parameter — and `$(curl ...)` defeats it anyway. A guard with
 // those false positives and no override is one people route around, and the routes around it are
 // shorter than the compliant path. Asking keeps the nudge and costs a keystroke when it is wrong.
-const DEV_PORTS = /(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?):(?:30\d\d|51[67]\d|9444)\b/i;
+//
+// The daemon's port comes from the dev-server skill rather than being baked in here: it is
+// overridable via DEV_DAEMON_PORT, and a hardcoded copy meant that setting it silently switched
+// this nudge off for the daemon — the one long-lived server the rule most exists for.
+//
+// Resolved lazily and defensively, and both matter. A hook that throws breaks EVERY Bash call, so
+// a missing skill directory or a malformed DEV_DAEMON_PORT must degrade, not propagate; and doing
+// it on first use rather than at import keeps this file free of top-level await.
+let devPortsRe = null;
+function devPorts() {
+  if (devPortsRe) return devPortsRe;
+  let daemon = '';
+  try {
+    // Synchronous require-equivalent is unavailable in ESM, so the port is read from the module
+    // source. A regex over one `export const` line is deliberately duller than an import: it
+    // cannot execute skill code inside a hook that runs before every command.
+    const source = readFileSync(
+      new URL('../skills/dev-server/scripts/daemon-port.mjs', import.meta.url),
+      'utf8'
+    );
+    const declared = /export const DEFAULT_DAEMON_PORT = (\d+)/.exec(source);
+    const override = process.env.DEV_DAEMON_PORT?.trim();
+    const port = /^\d+$/.test(override ?? '') ? override : declared?.[1];
+    if (port) daemon = `|${port}`;
+  } catch {
+    /* skill absent — the 30xx/516x-517x ranges still guard the dev servers themselves */
+  }
+  devPortsRe = new RegExp(
+    String.raw`(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?):(?:30\d\d|51[67]\d${daemon})\b`,
+    'i'
+  );
+  return devPortsRe;
+}
 
 // Any of curl's, wget's or PowerShell's own timeout flags, including `-m5` and bundled shorts.
 // `-T` is wget's timeout but curl's --upload-file, and `-m` is curl's --max-time but wget's
@@ -106,7 +139,7 @@ export function unboundedDevRequest(command) {
     .split(/[;&|\n]+/)
     .map((seg) => seg.trim())
     .filter((seg) => seg && !seg.startsWith('#'))
-    .filter((seg) => DEV_PORTS.test(seg.replace(/[?&][^\s"']*/g, '')))
+    .filter((seg) => devPorts().test(seg.replace(/[?&][^\s"']*/g, '')))
     .filter((seg) => REQUEST_TOOL.test(seg))
     .filter((seg) => !isBounded(seg));
 }

--- a/.claude/hooks/check-writable.mjs
+++ b/.claude/hooks/check-writable.mjs
@@ -94,24 +94,37 @@ function isUnscoped(target) {
 // a missing skill directory or a malformed DEV_DAEMON_PORT must degrade, not propagate; and doing
 // it on first use rather than at import keeps this file free of top-level await.
 let devPortsRe = null;
-function devPorts() {
-  if (devPortsRe) return devPortsRe;
-  let daemon = '';
+export function daemonPortsGuarded(env = process.env) {
+  const ports = new Set();
   try {
     // Synchronous require-equivalent is unavailable in ESM, so the port is read from the module
-    // source. A regex over one `export const` line is deliberately duller than an import: it
-    // cannot execute skill code inside a hook that runs before every command.
+    // source. A regex over one declaration is deliberately duller than an import: it cannot
+    // execute skill code inside a hook that runs before every command. Loose about spacing and
+    // digit separators, because it is pinned only by that file's formatting — a reformat there
+    // must not silently drop the daemon out of this guard.
     const source = readFileSync(
       new URL('../skills/dev-server/scripts/daemon-port.mjs', import.meta.url),
       'utf8'
     );
-    const declared = /export const DEFAULT_DAEMON_PORT = (\d+)/.exec(source);
-    const override = process.env.DEV_DAEMON_PORT?.trim();
-    const port = /^\d+$/.test(override ?? '') ? override : declared?.[1];
-    if (port) daemon = `|${port}`;
+    const declared = /DEFAULT_DAEMON_PORT\s*=\s*([\d_]+)/.exec(source);
+    if (declared) ports.add(declared[1].replace(/_/g, ''));
   } catch {
     /* skill absent — the 30xx/516x-517x ranges still guard the dev servers themselves */
   }
+
+  // The override ADDS a port, it does not move one. `DEV_DAEMON_PORT` stands a second daemon
+  // BESIDE the shared one (SKILL.md), so both are live and both need guarding. Replacing the
+  // default here silently un-guarded the shared daemon for anyone who set the variable.
+  const override = env.DEV_DAEMON_PORT?.trim();
+  if (/^\d+$/.test(override ?? '') && Number(override) >= 1 && Number(override) <= 65535) {
+    ports.add(String(Number(override)));
+  }
+  return [...ports];
+}
+
+function devPorts() {
+  if (devPortsRe) return devPortsRe;
+  const daemon = daemonPortsGuarded().map((p) => `|${p}`).join('');
   devPortsRe = new RegExp(
     String.raw`(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?):(?:30\d\d|51[67]\d${daemon})\b`,
     'i'

--- a/.claude/hooks/check-writable.mjs
+++ b/.claude/hooks/check-writable.mjs
@@ -86,27 +86,29 @@ function isUnscoped(target) {
 // those false positives and no override is one people route around, and the routes around it are
 // shorter than the compliant path. Asking keeps the nudge and costs a keystroke when it is wrong.
 //
-// The daemon's port comes from the dev-server skill rather than being baked in here: it is
-// overridable via DEV_DAEMON_PORT, and a hardcoded copy meant that setting it silently switched
-// this nudge off for the daemon — the one long-lived server the rule most exists for.
+// The daemon's port comes from the dev-server skill rather than being baked in here. A hardcoded
+// copy meant a second daemon was never guarded at all; replacing the default with the override
+// then meant the FIRST one stopped being guarded. Both are live, so the set is additive.
 //
-// Resolved lazily and defensively, and both matter. A hook that throws breaks EVERY Bash call, so
-// a missing skill directory or a malformed DEV_DAEMON_PORT must degrade, not propagate; and doing
-// it on first use rather than at import keeps this file free of top-level await.
+// Defensive on purpose: a hook that throws breaks EVERY Bash call, so a missing skill directory
+// or a malformed DEV_DAEMON_PORT must degrade, not propagate.
 let devPortsRe = null;
 export function daemonPortsGuarded(env = process.env) {
   const ports = new Set();
   try {
     // Synchronous require-equivalent is unavailable in ESM, so the port is read from the module
-    // source. A regex over one declaration is deliberately duller than an import: it cannot
-    // execute skill code inside a hook that runs before every command. Loose about spacing and
-    // digit separators, because it is pinned only by that file's formatting — a reformat there
-    // must not silently drop the daemon out of this guard.
+    // source. A regex over the declaration is deliberately duller than an import: it cannot
+    // execute skill code inside a hook that runs before every command.
+    //
+    // Anchored on `export const`, loose only about spacing and digit separators. An earlier
+    // version dropped the anchor to survive a reformat — which it never needed to, since a
+    // reformat does not rewrite `export const NAME =` — and that let the FIRST match anywhere in
+    // the file win, including one inside a comment.
     const source = readFileSync(
       new URL('../skills/dev-server/scripts/daemon-port.mjs', import.meta.url),
       'utf8'
     );
-    const declared = /DEFAULT_DAEMON_PORT\s*=\s*([\d_]+)/.exec(source);
+    const declared = /export\s+const\s+DEFAULT_DAEMON_PORT\s*=\s*([\d_]+)/.exec(source);
     if (declared) ports.add(declared[1].replace(/_/g, ''));
   } catch {
     /* skill absent — the 30xx/516x-517x ranges still guard the dev servers themselves */
@@ -122,6 +124,9 @@ export function daemonPortsGuarded(env = process.env) {
   return [...ports];
 }
 
+// The laziness lives here, not in daemonPortsGuarded: building the pattern on first use rather
+// than at import keeps this file free of top-level await. Per-process cache, and the process is
+// per-command, so it cannot go stale within a run.
 function devPorts() {
   if (devPortsRe) return devPortsRe;
   const daemon = daemonPortsGuarded().map((p) => `|${p}`).join('');

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -33,7 +33,7 @@ node .claude/skills/dev-server/cli.mjs stop <session-id>
 
 ## Which node the daemon runs on — and why it is sticky
 
-The daemon is spawned with `process.execPath` (`cli.mjs:70`, `console.mjs:88`), i.e. **whatever node ran
+The daemon is spawned with `process.execPath` (`cli.mjs:70`, `console.mjs:89`), i.e. **whatever node ran
 the CLI verb that first started it**. It then passes its own environment down to every `next dev` it
 supervises. So the node you happened to have on `PATH` the first time you typed any command above is the
 node the whole tree runs on, until someone shuts the daemon down — and nothing records which one that was.

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -33,7 +33,7 @@ node .claude/skills/dev-server/cli.mjs stop <session-id>
 
 ## Which node the daemon runs on — and why it is sticky
 
-The daemon is spawned with `process.execPath` (`cli.mjs:69`, `console.mjs:88`), i.e. **whatever node ran
+The daemon is spawned with `process.execPath` (`cli.mjs:70`, `console.mjs:88`), i.e. **whatever node ran
 the CLI verb that first started it**. It then passes its own environment down to every `next dev` it
 supervises. So the node you happened to have on `PATH` the first time you typed any command above is the
 node the whole tree runs on, until someone shuts the daemon down — and nothing records which one that was.

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -33,7 +33,7 @@ node .claude/skills/dev-server/cli.mjs stop <session-id>
 
 ## Which node the daemon runs on — and why it is sticky
 
-The daemon is spawned with `process.execPath` (`cli.mjs:66`, `console.mjs:87`), i.e. **whatever node ran
+The daemon is spawned with `process.execPath` (`cli.mjs:69`, `console.mjs:88`), i.e. **whatever node ran
 the CLI verb that first started it**. It then passes its own environment down to every `next dev` it
 supervises. So the node you happened to have on `PATH` the first time you typed any command above is the
 node the whole tree runs on, until someone shuts the daemon down — and nothing records which one that was.
@@ -68,6 +68,22 @@ readlink -f /proc/$(cat .claude/skills/dev-server/daemon.pid)/exe
 
 Changing node means restarting the daemon — `cli.mjs shutdown`, then start it again from the right shell.
 A running daemon will not pick up a new `PATH`.
+
+### A second daemon: `DEV_DAEMON_PORT`
+
+The daemon lives on `127.0.0.1:9444`. Set `DEV_DAEMON_PORT` to stand another one beside it:
+
+```bash
+DEV_DAEMON_PORT=9555 node .claude/skills/dev-server/cli.mjs status
+```
+
+The CLI, the console, `scripts/test-unit-run.mjs` and the daemon itself all resolve the port through
+`scripts/daemon-port.mjs`, and a daemon a client spawns inherits that client's environment — so no two
+of them can disagree about where it is. Until 2026-08-19 the daemon did not read the variable at all,
+and setting it pointed the client at a port nothing was serving.
+
+The variable is only a default for the daemon; an explicit `node scripts/daemon.mjs --port <port>` still
+wins. Each daemon owns the shared `daemon.pid`, so the last one started is the one that file names.
 
 ## Never curl a dev port — `probe` instead
 

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -9,6 +9,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
 import { exitCodeFor, isTerminal as isTerminalStatus } from './scripts/test-queue.mjs';
+import { resolveDaemonPort } from './scripts/daemon-port.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -28,8 +29,9 @@ const projectRoot = findProjectRoot(__dirname);
 const pidFile = resolve(__dirname, 'daemon.pid');
 const serverScript = resolve(__dirname, 'scripts/daemon.mjs');
 
-// Overridable so a second daemon can be exercised without touching the shared one on 9444.
-const DAEMON_PORT = parseInt(process.env.DEV_DAEMON_PORT || '9444', 10);
+// Overridable via DEV_DAEMON_PORT, so a second daemon can be exercised without touching the
+// shared one. The daemon resolves it through the same module — see scripts/daemon-port.mjs.
+const DAEMON_PORT = resolveDaemonPort();
 const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
 
 async function daemonRequest(path, options = {}) {
@@ -62,7 +64,9 @@ async function startDaemon() {
     shell: true,
   };
 
-  // Use quoted command string for shell: true on Windows
+  // Use quoted command string for shell: true on Windows. No --port: the daemon resolves
+  // DEV_DAEMON_PORT through the same function this file does, off the environment it inherits
+  // here, so the two cannot disagree about where it lives.
   const command = `"${process.execPath}" "${serverScript}"`;
   const child = spawn(command, [], spawnOptions);
   child.unref();

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -9,7 +9,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
 import { exitCodeFor, isTerminal as isTerminalStatus } from './scripts/test-queue.mjs';
-import { resolveDaemonPort } from './scripts/daemon-port.mjs';
+import { resolveDaemonUrl } from './scripts/daemon-port.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -30,9 +30,9 @@ const pidFile = resolve(__dirname, 'daemon.pid');
 const serverScript = resolve(__dirname, 'scripts/daemon.mjs');
 
 // Overridable via DEV_DAEMON_PORT, so a second daemon can be exercised without touching the
-// shared one. The daemon resolves it through the same module — see scripts/daemon-port.mjs.
-const DAEMON_PORT = resolveDaemonPort();
-const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
+// shared one. The whole decision — port included — is made in scripts/daemon-port.mjs, which is
+// also what the daemon reads, so this file does no arithmetic on a port and cannot drift from it.
+const DAEMON_URL = resolveDaemonUrl();
 
 async function daemonRequest(path, options = {}) {
   const url = `${DAEMON_URL}${path}`;

--- a/.claude/skills/dev-server/console.mjs
+++ b/.claude/skills/dev-server/console.mjs
@@ -12,6 +12,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import readline from 'readline';
+import { resolveDaemonPort } from './scripts/daemon-port.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -28,7 +29,7 @@ const projectRoot = findProjectRoot(__dirname);
 const pidFile = resolve(__dirname, 'daemon.pid');
 const serverScript = resolve(__dirname, 'scripts/daemon.mjs');
 
-const DAEMON_PORT = 9444;
+const DAEMON_PORT = resolveDaemonPort();
 const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
 
 // ── ANSI ──────────────────────────────────────────────────────────────────────

--- a/.claude/skills/dev-server/console.mjs
+++ b/.claude/skills/dev-server/console.mjs
@@ -12,7 +12,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import readline from 'readline';
-import { resolveDaemonPort } from './scripts/daemon-port.mjs';
+import { resolveDaemonUrl } from './scripts/daemon-port.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -29,8 +29,9 @@ const projectRoot = findProjectRoot(__dirname);
 const pidFile = resolve(__dirname, 'daemon.pid');
 const serverScript = resolve(__dirname, 'scripts/daemon.mjs');
 
-const DAEMON_PORT = resolveDaemonPort();
-const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
+// The whole decision — port included — is made in scripts/daemon-port.mjs, the same module the
+// daemon reads, so this file does no arithmetic on a port and cannot drift from it.
+const DAEMON_URL = resolveDaemonUrl();
 
 // ── ANSI ──────────────────────────────────────────────────────────────────────
 const C = {

--- a/.claude/skills/dev-server/scripts/daemon-port.mjs
+++ b/.claude/skills/dev-server/scripts/daemon-port.mjs
@@ -1,20 +1,45 @@
 /**
- * One rule, one place: what port the dev daemon lives on.
+ * One rule, one place: where the dev daemon lives.
  *
- * This used to be open-coded at four sites and disagreed at two of them — cli.mjs and
- * scripts/test-unit-run.mjs read DEV_DAEMON_PORT, console.mjs hardcoded 9444, and the daemon
- * itself only ever saw `--port`. Setting DEV_DAEMON_PORT therefore pointed the client at a port
- * nothing was serving instead of relocating the daemon.
+ * This used to be open-coded at five sites and disagreed at three of them — cli.mjs and
+ * scripts/test-unit-run.mjs read DEV_DAEMON_PORT, console.mjs hardcoded 9444, the daemon itself
+ * only ever saw `--port`, and .claude/hooks/check-writable.mjs baked 9444 into a regex. Setting
+ * DEV_DAEMON_PORT therefore pointed the client at a port nothing was serving.
  *
- * Every one of those four now resolves the port here. A daemon a client spawns inherits that
+ * Every one of those now resolves through this module. A daemon a client spawns inherits that
  * client's environment, so both ends read the same variable through the same function and cannot
- * disagree. An explicit `node daemon.mjs --port <port>` still beats the environment.
+ * disagree. An explicit `node daemon.mjs --port <port>` still beats the environment — and goes
+ * through `parsePort` here too, so argv gets the same validation the environment gets.
  *
- * 9444 is spelled once, in this file. `dev-server-daemon-port.test.ts` fails if a second copy
- * appears.
+ * `9444` is spelled once, in this file. `dev-server-daemon-port.test.ts` scans the whole skill
+ * for a second copy and fails if one appears anywhere, including in a file that does not exist
+ * yet.
  */
 
 export const DEFAULT_DAEMON_PORT = 9444;
+
+/**
+ * Parse one port value from anywhere — an env var, an argv flag.
+ *
+ * parseInt, which every one of these call sites used to use, reads '9555abc' as 9555 and 'abc'
+ * as NaN. NaN reaches a URL as `http://127.0.0.1:NaN`, or a listen() as ERR_SOCKET_BAD_PORT, a
+ * long way from the thing that was actually wrong.
+ *
+ * @param {string | undefined} raw
+ * @param {string} source — named in the error, so the message says which input to go fix
+ * @returns {number}
+ */
+export function parsePort(raw, source) {
+  const value = typeof raw === 'string' ? raw.trim() : raw;
+  if (!/^\d+$/.test(String(value ?? ''))) {
+    throw new Error(`${source} is not a port number: ${JSON.stringify(raw)}`);
+  }
+  const port = Number(value);
+  if (port < 1 || port > 65535) {
+    throw new Error(`${source} is out of the port range 1-65535: ${JSON.stringify(raw)}`);
+  }
+  return port;
+}
 
 /**
  * @param {Record<string, string | undefined>} [env]
@@ -23,16 +48,17 @@ export const DEFAULT_DAEMON_PORT = 9444;
  */
 export function resolveDaemonPort(env = process.env) {
   const raw = env.DEV_DAEMON_PORT;
-  if (raw === undefined || raw === '') return DEFAULT_DAEMON_PORT;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_DAEMON_PORT;
+  return parsePort(raw, 'DEV_DAEMON_PORT');
+}
 
-  // parseInt('9555abc') is 9555 and parseInt('abc') is NaN — neither is a port, and NaN would
-  // otherwise reach a URL as `http://127.0.0.1:NaN` and fail somewhere far from the cause.
-  if (!/^\d+$/.test(raw.trim())) {
-    throw new Error(`DEV_DAEMON_PORT is not a number: ${JSON.stringify(raw)}`);
-  }
-  const port = Number(raw.trim());
-  if (port < 1 || port > 65535) {
-    throw new Error(`DEV_DAEMON_PORT is out of range 1-65535: ${JSON.stringify(raw)}`);
-  }
-  return port;
+/**
+ * The daemon's base URL. Exported so a caller never does arithmetic on the port itself — the
+ * whole decision, port included, is made here.
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {string}
+ */
+export function resolveDaemonUrl(env = process.env) {
+  return `http://127.0.0.1:${resolveDaemonPort(env)}`;
 }

--- a/.claude/skills/dev-server/scripts/daemon-port.mjs
+++ b/.claude/skills/dev-server/scripts/daemon-port.mjs
@@ -11,9 +11,11 @@
  * disagree. An explicit `node daemon.mjs --port <port>` still beats the environment — and goes
  * through `parsePort` here too, so argv gets the same validation the environment gets.
  *
- * `9444` is spelled once, in this file. `dev-server-daemon-port.test.ts` scans the whole skill
- * for a second copy and fails if one appears anywhere, including in a file that does not exist
- * yet.
+ * `9444` is spelled once in the code that DECIDES it. `dev-server-daemon-port.test.ts` walks
+ * three roots — this skill, `scripts/`, `.claude/hooks` — over .mjs/.cjs/.js/.ts, and fails if a
+ * second copy appears in any of them, including in a file that does not exist yet. Deliberately
+ * NOT covered: prose (SKILL.md names the default, as documentation should) and test files, which
+ * must pin the expected value as a literal rather than derive it from this module.
  */
 
 export const DEFAULT_DAEMON_PORT = 9444;

--- a/.claude/skills/dev-server/scripts/daemon-port.mjs
+++ b/.claude/skills/dev-server/scripts/daemon-port.mjs
@@ -1,0 +1,38 @@
+/**
+ * One rule, one place: what port the dev daemon lives on.
+ *
+ * This used to be open-coded at four sites and disagreed at two of them — cli.mjs and
+ * scripts/test-unit-run.mjs read DEV_DAEMON_PORT, console.mjs hardcoded 9444, and the daemon
+ * itself only ever saw `--port`. Setting DEV_DAEMON_PORT therefore pointed the client at a port
+ * nothing was serving instead of relocating the daemon.
+ *
+ * Every one of those four now resolves the port here. A daemon a client spawns inherits that
+ * client's environment, so both ends read the same variable through the same function and cannot
+ * disagree. An explicit `node daemon.mjs --port <port>` still beats the environment.
+ *
+ * 9444 is spelled once, in this file. `dev-server-daemon-port.test.ts` fails if a second copy
+ * appears.
+ */
+
+export const DEFAULT_DAEMON_PORT = 9444;
+
+/**
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {number} a valid TCP port
+ * @throws {Error} if DEV_DAEMON_PORT is set to something that is not a port
+ */
+export function resolveDaemonPort(env = process.env) {
+  const raw = env.DEV_DAEMON_PORT;
+  if (raw === undefined || raw === '') return DEFAULT_DAEMON_PORT;
+
+  // parseInt('9555abc') is 9555 and parseInt('abc') is NaN — neither is a port, and NaN would
+  // otherwise reach a URL as `http://127.0.0.1:NaN` and fail somewhere far from the cause.
+  if (!/^\d+$/.test(raw.trim())) {
+    throw new Error(`DEV_DAEMON_PORT is not a number: ${JSON.stringify(raw)}`);
+  }
+  const port = Number(raw.trim());
+  if (port < 1 || port > 65535) {
+    throw new Error(`DEV_DAEMON_PORT is out of range 1-65535: ${JSON.stringify(raw)}`);
+  }
+  return port;
+}

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -8,6 +8,10 @@
  * Usage:
  *   node daemon.mjs [--port <port>] [--base-dev-port <port>]
  *
+ * --port beats DEV_DAEMON_PORT, which beats the default in scripts/daemon-port.mjs. A daemon a
+ * client spawns inherits that client's environment and resolves the port through the same
+ * module, so the two cannot end up on different ports.
+ *
  * Security: Binds to 127.0.0.1 only (localhost)
  */
 
@@ -19,6 +23,7 @@ import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
 import { access } from 'fs/promises';
 import { isPortFree } from './port-probe.mjs';
+import { resolveDaemonPort } from './daemon-port.mjs';
 import { TestQueue } from './test-queue.mjs';
 import {
   loadModeDefinitions,
@@ -35,7 +40,8 @@ const projectRoot = resolve(skillDir, '../../..');
 const pidFile = resolve(skillDir, 'daemon.pid');
 
 // Configuration
-const DEFAULT_DAEMON_PORT = 9444;
+// Read at module load so a hand-started daemon honours DEV_DAEMON_PORT; `--port` still wins.
+const DEFAULT_DAEMON_PORT = resolveDaemonPort();
 const DEFAULT_BASE_DEV_PORT = 3000;
 const MAX_LOG_LINES = 2000;
 

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
 import { access } from 'fs/promises';
 import { isPortFree } from './port-probe.mjs';
-import { resolveDaemonPort } from './daemon-port.mjs';
+import { parsePort, resolveDaemonPort } from './daemon-port.mjs';
 import { TestQueue } from './test-queue.mjs';
 import {
   loadModeDefinitions,
@@ -40,8 +40,6 @@ const projectRoot = resolve(skillDir, '../../..');
 const pidFile = resolve(skillDir, 'daemon.pid');
 
 // Configuration
-// Read at module load so a hand-started daemon honours DEV_DAEMON_PORT; `--port` still wins.
-const DEFAULT_DAEMON_PORT = resolveDaemonPort();
 const DEFAULT_BASE_DEV_PORT = 3000;
 const MAX_LOG_LINES = 2000;
 
@@ -183,18 +181,26 @@ const readyPatterns = [
   /listening on/i,
 ];
 
-// Parse command line arguments
-function parseArgs() {
-  const args = process.argv.slice(2);
+// Parse command line arguments.
+//
+// The port is resolved HERE, not at module load: importing this file must not start a daemon
+// (see the `invokedDirectly` guard at the bottom), and resolving at load would additionally make
+// a bad DEV_DAEMON_PORT throw on mere import — which would take down the suites that import
+// DevSession and the port reservation without ever intending to run a daemon.
+function parseArgs(argv = process.argv.slice(2)) {
+  const args = argv;
   const config = {
-    port: DEFAULT_DAEMON_PORT,
+    port: resolveDaemonPort(),
     baseDevPort: DEFAULT_BASE_DEV_PORT,
   };
 
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
       case '--port':
-        config.port = parseInt(args[++i], 10);
+        // Through the same validator the environment gets: `--port abc` used to become NaN and
+        // surface as ERR_SOCKET_BAD_PORT, which via `cli.mjs` is invisible (the daemon is
+        // detached with stdio ignored) and reads only as "Failed to start daemon".
+        config.port = parsePort(args[++i], '--port');
         break;
       case '--base-dev-port':
         config.baseDevPort = parseInt(args[++i], 10);
@@ -2655,6 +2661,7 @@ export {
   findSessionByWorktree,
   getUsedPorts,
   listSessions,
+  parseArgs,
   sessionIsBusy,
   sessions,
 };

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -203,7 +203,7 @@ function parseArgs(argv = process.argv.slice(2)) {
         config.port = parsePort(args[++i], '--port');
         break;
       case '--base-dev-port':
-        config.baseDevPort = parseInt(args[++i], 10);
+        config.baseDevPort = parsePort(args[++i], '--base-dev-port');
         break;
     }
   }

--- a/scripts/__tests__/dev-server-daemon-port.test.ts
+++ b/scripts/__tests__/dev-server-daemon-port.test.ts
@@ -119,7 +119,9 @@ describe('parsePort / resolveDaemonPort', () => {
 describe('the write-guard hook guards the ports the skill actually uses', () => {
   it('guards the declared default', async () => {
     const { unboundedDevRequest } = await import('../../.claude/hooks/check-writable.mjs');
-    expect(unboundedDevRequest(`curl http://localhost:${DEFAULT_DAEMON_PORT}/sessions`)).toHaveLength(1);
+    expect(
+      unboundedDevRequest(`curl http://localhost:${DEFAULT_DAEMON_PORT}/sessions`)
+    ).toHaveLength(1);
     // The negative control: a port the skill does not use must stay silent, or "it guards
     // everything" would read the same as "it guards the right thing".
     expect(unboundedDevRequest('curl http://localhost:7777/sessions')).toHaveLength(0);
@@ -138,9 +140,7 @@ describe('the write-guard hook guards the ports the skill actually uses', () => 
     expect(daemonPortsGuarded({ DEV_DAEMON_PORT: 'nope' }).map(Number)).toEqual([
       DEFAULT_DAEMON_PORT,
     ]);
-    expect(daemonPortsGuarded({ DEV_DAEMON_PORT: '0' }).map(Number)).toEqual([
-      DEFAULT_DAEMON_PORT,
-    ]);
+    expect(daemonPortsGuarded({ DEV_DAEMON_PORT: '0' }).map(Number)).toEqual([DEFAULT_DAEMON_PORT]);
   });
 });
 

--- a/scripts/__tests__/dev-server-daemon-port.test.ts
+++ b/scripts/__tests__/dev-server-daemon-port.test.ts
@@ -100,6 +100,48 @@ describe('parsePort / resolveDaemonPort', () => {
     expect(() => resolveDaemonPort({ DEV_DAEMON_PORT: 'nope' })).toThrow(/DEV_DAEMON_PORT/);
     expect(() => parsePort('nope', '--port')).toThrow(/--port/);
   });
+
+  // ON the boundary, not near it. Fixtures of 0 and 70000 leave `65535` free to drift to 65536
+  // without any test noticing — measured: that mutant survived the whole suite.
+  it('accepts the highest legal port and rejects the first illegal one', () => {
+    expect(parsePort('65535', 'X')).toBe(65535);
+    expect(parsePort('1', 'X')).toBe(1);
+    expect(() => parsePort('65536', 'X')).toThrow(/out of the port range/);
+  });
+});
+
+/**
+ * The PreToolUse hook is a fifth consumer of the port, and until this round it had a sixth copy
+ * of the literal. It cannot import the module (it must resolve synchronously, before every Bash
+ * command), so it reads the declaration out of the module source — a dependency on that file's
+ * formatting, which nothing was testing. Loosening the regex is not a guarantee; this is.
+ */
+describe('the write-guard hook guards the ports the skill actually uses', () => {
+  it('guards the declared default', async () => {
+    const { unboundedDevRequest } = await import('../../.claude/hooks/check-writable.mjs');
+    expect(unboundedDevRequest(`curl http://localhost:${DEFAULT_DAEMON_PORT}/sessions`)).toHaveLength(1);
+    // The negative control: a port the skill does not use must stay silent, or "it guards
+    // everything" would read the same as "it guards the right thing".
+    expect(unboundedDevRequest('curl http://localhost:7777/sessions')).toHaveLength(0);
+  });
+
+  // The override ADDS a daemon beside the shared one; it does not move it. Replacing the default
+  // silently un-guarded 9444 for everyone who set the variable — the hook's own selftest went red
+  // under DEV_DAEMON_PORT=9555 and nothing in this suite noticed.
+  it('guards BOTH the default and an override, because both daemons are live', async () => {
+    const { daemonPortsGuarded } = await import('../../.claude/hooks/check-writable.mjs');
+    expect(daemonPortsGuarded({}).map(Number)).toEqual([DEFAULT_DAEMON_PORT]);
+    expect(daemonPortsGuarded({ DEV_DAEMON_PORT: '9555' }).map(Number).sort()).toEqual(
+      [DEFAULT_DAEMON_PORT, 9555].sort()
+    );
+    // A value that is not a port adds nothing rather than corrupting the pattern.
+    expect(daemonPortsGuarded({ DEV_DAEMON_PORT: 'nope' }).map(Number)).toEqual([
+      DEFAULT_DAEMON_PORT,
+    ]);
+    expect(daemonPortsGuarded({ DEV_DAEMON_PORT: '0' }).map(Number)).toEqual([
+      DEFAULT_DAEMON_PORT,
+    ]);
+  });
 });
 
 /**
@@ -208,6 +250,16 @@ describe('argv goes through the same validator as the environment', () => {
     expect(parseArgs(['--port', '9555']).port).toBe(9555);
   });
 
+  // "argv gets the same validation the environment gets" is a claim about ALL of argv. There are
+  // two port flags, and leaving the second on parseInt made that sentence false.
+  it('validates --base-dev-port too, not just --port', async () => {
+    const { parseArgs } = await import('../../.claude/skills/dev-server/scripts/daemon.mjs');
+    expect(() => parseArgs(['--base-dev-port', 'abc'])).toThrow(
+      /--base-dev-port is not a port number/
+    );
+    expect(parseArgs(['--base-dev-port', '3100']).baseDevPort).toBe(3100);
+  });
+
   // The daemon's own header says importing it must not start a daemon; resolving the port at
   // module load would have made a bad DEV_DAEMON_PORT throw on mere import, taking down the
   // suites that import DevSession and the port reservation without intending to run anything.
@@ -308,6 +360,53 @@ describe('nothing outside daemon-port.mjs decides the daemon port', () => {
       );
     }
   });
+});
+
+/**
+ * console.mjs, behaviourally — the residual of the "ledger is spelled, not structural" finding.
+ *
+ * Every structural assertion available is walkable by a mutant that resolves the URL correctly
+ * and then drifts it: `resolveDaemonUrl().replace(/\d+$/, n => Number(n) + 1)` passes the import
+ * check and the call check both. Only asking the socket which port it was actually asked for
+ * settles it, so this stands a stub daemon up and reads the request that arrives.
+ */
+describe('the console talks to the port it resolved', () => {
+  it('sends its first request to the port DEV_DAEMON_PORT names', async () => {
+    const consoleScript = resolve(skillDir, 'console.mjs');
+    const hits: string[] = [];
+
+    const server = createServer((req, res) => {
+      hits.push(req.url ?? '');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ sessions: [], runs: [] }));
+    });
+    await new Promise<void>((done) => server.listen(0, '127.0.0.1', done));
+    const { port } = server.address() as AddressInfo;
+
+    // `--tail`, because the dashboard refuses to start without a TTY ("Dashboard requires a TTY
+    // terminal") and exits 1 before it ever contacts the daemon. --tail is its own documented
+    // non-interactive mode and goes through the same resolved DAEMON_URL.
+    const child = spawn(process.execPath, [consoleScript, '--tail'], {
+      cwd: repoRoot,
+      env: { ...process.env, DEV_DAEMON_PORT: String(port) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.stdout.resume();
+    child.stderr.resume();
+
+    try {
+      for (let i = 0; i < 100 && hits.length === 0; i++) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+    } finally {
+      child.kill('SIGKILL');
+      await new Promise<void>((done) => server.close(() => done()));
+    }
+
+    // A stub on a port nothing else knows about. A request arriving here at all is proof the
+    // console resolved THIS port — an off-by-one would have gone somewhere else and hit nothing.
+    expect(hits.length).toBeGreaterThan(0);
+  }, 60_000);
 });
 
 /**
@@ -424,6 +523,59 @@ describe('an unusable DEV_DAEMON_PORT still runs the tests', () => {
     expect(stderr).toMatch(/Test queue address unusable/);
     expect(stderr).toMatch(/running directly/i);
     expect(stderr).not.toMatch(/UnhandledPromiseRejection|ERR_UNHANDLED_REJECTION/);
+  }, 40_000);
+
+  /**
+   * The other half of that guarantee, and the direction it must NOT go.
+   *
+   * Once the daemon has accepted the run it owns a slot for it. Degrading to a direct run at that
+   * point starts a second, unqueued full suite beside the queued one — defeating the serialisation
+   * the script exists to provide. The fix round's first attempt wrapped the whole lifecycle in one
+   * catch and did exactly that: a socket dropped mid-poll printed "running directly" and started
+   * vitest.
+   */
+  it('does NOT start a second suite once the queue has accepted the run', async () => {
+    const script = resolve(repoRoot, 'scripts/test-unit-run.mjs');
+
+    // A daemon that accepts the run and then dies, which is the shape that used to double-run.
+    let sockets: import('net').Socket[] = [];
+    const server = createServer((req, res) => {
+      if (req.url === '/test-runs') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ id: 'stub', status: 'queued', position: 1, queueLength: 1 }));
+        return;
+      }
+      // The poll: drop the connection rather than answer.
+      req.socket.destroy();
+    });
+    server.on('connection', (s) => sockets.push(s));
+    await new Promise<void>((done) => server.listen(0, '127.0.0.1', done));
+    const { port } = server.address() as AddressInfo;
+
+    const out = await new Promise<{ code: number | null; text: string }>((done) => {
+      const child = spawn(process.execPath, [script], {
+        cwd: repoRoot,
+        env: { ...process.env, CI: '', CIVITAI_TEST_QUEUE: '1', DEV_DAEMON_PORT: String(port) },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let text = '';
+      child.stdout.on('data', (d: Buffer) => (text += d.toString()));
+      child.stderr.on('data', (d: Buffer) => (text += d.toString()));
+      const bail = setTimeout(() => child.kill('SIGKILL'), 25_000);
+      child.on('exit', (code) => {
+        clearTimeout(bail);
+        done({ code, text });
+      });
+    });
+
+    sockets.forEach((s) => s.destroy());
+    await new Promise<void>((done) => server.close(() => done()));
+
+    expect(out.text).toMatch(/Queued at position/);
+    // The tell that the bug is back would be a vitest banner in this output.
+    expect(out.text).not.toMatch(/running directly/i);
+    expect(out.text).not.toMatch(/RUN\s+v\d/);
+    expect(out.code).toBe(2);
   }, 40_000);
 
   it('does not hold a stale port module reference', () => {

--- a/scripts/__tests__/dev-server-daemon-port.test.ts
+++ b/scripts/__tests__/dev-server-daemon-port.test.ts
@@ -1,20 +1,23 @@
 import { spawn } from 'child_process';
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'fs';
 import { createServer } from 'http';
 import type { AddressInfo } from 'net';
-import { dirname, resolve } from 'path';
+import { dirname, relative, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_DAEMON_PORT,
+  parsePort,
   resolveDaemonPort,
+  resolveDaemonUrl,
 } from '../../.claude/skills/dev-server/scripts/daemon-port.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const skillDir = resolve(repoRoot, '.claude/skills/dev-server');
 const daemonScript = resolve(skillDir, 'scripts/daemon.mjs');
 const cliScript = resolve(skillDir, 'cli.mjs');
+const portModule = resolve(skillDir, 'scripts/daemon-port.mjs');
 const pidFile = resolve(skillDir, 'daemon.pid');
 
 /** A port nothing holds right now. Bound and released so the number is real, not a guess. */
@@ -26,9 +29,34 @@ async function freePort(): Promise<number> {
   return port;
 }
 
+/** True once nothing answers on the port. */
+async function isDown(port: number): Promise<boolean> {
+  const res = await fetch(`http://127.0.0.1:${port}/`).catch(() => null);
+  return res === null;
+}
+
+/**
+ * Stop a daemon over its own API and WAIT for it to be gone.
+ *
+ * The wait is the point, and it is load-bearing rather than tidy. `POST /shutdown` replies 200
+ * and only then schedules `unlinkSync(pidFile); process.exit(0)` on a 100 ms timer
+ * (daemon.mjs, the /shutdown branch). Returning at the 200 therefore returns ~100 ms BEFORE the
+ * unlink, so a caller that restores the developer's pid file at that moment has it deleted out
+ * from under them a tick later — which is exactly what this file used to do, on every run of the
+ * unit suite.
+ */
+async function shutdown(port: number) {
+  await fetch(`http://127.0.0.1:${port}/shutdown`, { method: 'POST' }).catch(() => null);
+  for (let i = 0; i < 100; i++) {
+    if (await isDown(port)) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
 /**
  * The daemon writes its pid into the skill directory, and a developer running this suite has a
- * daemon of their own whose pid file that is. Every case here restores it.
+ * daemon of their own whose pid file that is. Every case here restores it — after the daemon it
+ * started is confirmed gone, never before.
  */
 async function withPidFilePreserved<T>(body: () => Promise<T>): Promise<T> {
   const saved = existsSync(pidFile) ? readFileSync(pidFile) : null;
@@ -40,31 +68,37 @@ async function withPidFilePreserved<T>(body: () => Promise<T>): Promise<T> {
   }
 }
 
-/** Ask a daemon to stop over its own API — the one teardown that also works on Windows. */
-async function shutdown(port: number) {
-  await fetch(`http://127.0.0.1:${port}/shutdown`, { method: 'POST' }).catch(() => null);
-}
-
-describe('resolveDaemonPort', () => {
-  it('is 9444 when the variable is unset or empty', () => {
+describe('parsePort / resolveDaemonPort', () => {
+  it('is the default when the variable is unset or empty', () => {
     expect(resolveDaemonPort({})).toBe(9444);
     expect(resolveDaemonPort({ DEV_DAEMON_PORT: '' })).toBe(9444);
+    expect(resolveDaemonPort({ DEV_DAEMON_PORT: '   ' })).toBe(9444);
     expect(DEFAULT_DAEMON_PORT).toBe(9444);
   });
 
   it('honours a numeric value', () => {
     expect(resolveDaemonPort({ DEV_DAEMON_PORT: '9555' })).toBe(9555);
     expect(resolveDaemonPort({ DEV_DAEMON_PORT: ' 9555 ' })).toBe(9555);
+    expect(resolveDaemonUrl({ DEV_DAEMON_PORT: '9555' })).toBe('http://127.0.0.1:9555');
+    expect(resolveDaemonUrl({})).toBe('http://127.0.0.1:9444');
   });
 
   // parseInt — what every one of these call sites used to do — reads '9555abc' as 9555 and 'abc'
-  // as NaN. NaN reaches a URL as `http://127.0.0.1:NaN` and fails somewhere far from the cause.
+  // as NaN. NaN reaches a URL as `http://127.0.0.1:NaN` and a listen() as ERR_SOCKET_BAD_PORT,
+  // both a long way from the input that was actually wrong.
   it('refuses a value that is not a port instead of guessing one', () => {
-    expect(() => resolveDaemonPort({ DEV_DAEMON_PORT: 'abc' })).toThrow(/not a number/);
-    expect(() => resolveDaemonPort({ DEV_DAEMON_PORT: '9555abc' })).toThrow(/not a number/);
-    expect(() => resolveDaemonPort({ DEV_DAEMON_PORT: '-1' })).toThrow(/not a number/);
-    expect(() => resolveDaemonPort({ DEV_DAEMON_PORT: '0' })).toThrow(/out of range/);
-    expect(() => resolveDaemonPort({ DEV_DAEMON_PORT: '70000' })).toThrow(/out of range/);
+    for (const bad of ['abc', '9555abc', '-1', '95.5', '']) {
+      expect(() => parsePort(bad, 'X')).toThrow(/X is not a port number/);
+    }
+    expect(() => parsePort(undefined, 'X')).toThrow(/X is not a port number/);
+    // Out of range is a DIFFERENT complaint from unparseable — '0' is a number, just not a port.
+    expect(() => parsePort('0', 'X')).toThrow(/X is out of the port range/);
+    expect(() => parsePort('70000', 'X')).toThrow(/X is out of the port range/);
+  });
+
+  it('names the input in the error, so the message says what to go fix', () => {
+    expect(() => resolveDaemonPort({ DEV_DAEMON_PORT: 'nope' })).toThrow(/DEV_DAEMON_PORT/);
+    expect(() => parsePort('nope', '--port')).toThrow(/--port/);
   });
 });
 
@@ -160,40 +194,118 @@ describe('the dev daemon listens where DEV_DAEMON_PORT says', () => {
 });
 
 /**
- * The ledger. What made this bug possible was four files each deciding the port for themselves,
- * and it is not a bug any of them contains — it is a bug in the set. console.mjs in particular
- * has no end-to-end case here (it is a TUI), so a structural claim about the set is the only
- * thing standing between it and a second hardcoded 9444.
- *
- * This fails when the set grows (a new copy appears) and when it shrinks (daemon-port.mjs stops
- * owning the number).
+ * `--port` is the HIGHER-precedence input, and it used to be the unvalidated one: `parseInt`
+ * turned `--port abc` into NaN. Via cli.mjs the daemon is detached with stdio ignored, so
+ * ERR_SOCKET_BAD_PORT is invisible and the user sees only "Failed to start daemon" after a 5 s
+ * poll. Validating the environment while argv bypasses the check is not one rule in one place.
  */
-describe('nothing outside daemon-port.mjs decides the daemon port', () => {
-  const owner = resolve(skillDir, 'scripts/daemon-port.mjs');
-  const readers = [
-    resolve(skillDir, 'cli.mjs'),
-    resolve(skillDir, 'console.mjs'),
-    resolve(skillDir, 'scripts/daemon.mjs'),
-    resolve(repoRoot, 'scripts/test-unit-run.mjs'),
-  ];
-
-  it('spells 9444 exactly once, in the module that owns it', () => {
-    // The positive control for the scan itself: the owner MUST contain the literal, or a typo in
-    // these paths would read as "no copies anywhere" and pass.
-    expect(readFileSync(owner, 'utf8')).toContain('9444');
-
-    for (const file of readers) {
-      expect(`${file}: ${readFileSync(file, 'utf8').includes('9444')}`).toBe(`${file}: false`);
-    }
+describe('argv goes through the same validator as the environment', () => {
+  it('rejects a --port that is not a port, naming the flag', async () => {
+    const { parseArgs } = await import('../../.claude/skills/dev-server/scripts/daemon.mjs');
+    expect(() => parseArgs(['--port', 'abc'])).toThrow(/--port is not a port number/);
+    expect(() => parseArgs(['--port'])).toThrow(/--port is not a port number/);
+    expect(() => parseArgs(['--port', '70000'])).toThrow(/--port is out of the port range/);
+    expect(parseArgs(['--port', '9555']).port).toBe(9555);
   });
 
-  it('has every reader take the port from that module', () => {
-    for (const file of readers) {
+  // The daemon's own header says importing it must not start a daemon; resolving the port at
+  // module load would have made a bad DEV_DAEMON_PORT throw on mere import, taking down the
+  // suites that import DevSession and the port reservation without intending to run anything.
+  it('can be imported with an unusable DEV_DAEMON_PORT without throwing', async () => {
+    const code = await new Promise<number | null>((done) => {
+      const child = spawn(
+        process.execPath,
+        ['--input-type=module', '-e', `await import(${JSON.stringify(daemonScript)});`],
+        { cwd: repoRoot, env: { ...process.env, DEV_DAEMON_PORT: 'nope' }, stdio: 'ignore' }
+      );
+      child.on('exit', done);
+    });
+    expect(code).toBe(0);
+  }, 30_000);
+});
+
+/**
+ * The ledger. What made this bug possible was several files each deciding the port for
+ * themselves, and it is not a bug any of them contains — it is a bug in the SET. console.mjs in
+ * particular is a TUI with no end-to-end case here, so a claim about the set is most of what
+ * stands between it and a second hardcoded copy.
+ *
+ * The first version of this scanned a FIXED list of four readers, which could not see the set
+ * GROW — and a fifth copy already existed, in `.claude/hooks/check-writable.mjs`, while the test
+ * was green. It now walks the tree, so a file that does not exist yet is still covered.
+ */
+describe('nothing outside daemon-port.mjs decides the daemon port', () => {
+  const roots = [skillDir, resolve(repoRoot, 'scripts'), resolve(repoRoot, '.claude/hooks')];
+
+  /** Every .mjs/.js/.ts under the roots, minus node_modules and test files. */
+  function sourceFiles(): string[] {
+    const out: string[] = [];
+    const walk = (dir: string) => {
+      let entries;
+      try {
+        entries = readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        const full = resolve(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+          walk(full);
+          continue;
+        }
+        if (!/\.(mjs|cjs|js|ts)$/.test(entry.name)) continue;
+        // Test files legitimately pin the expected default as a literal — a test that derived
+        // its expectation from the implementation would assert nothing.
+        if (/\.(test|spec|selftest)\./.test(entry.name)) continue;
+        out.push(full);
+      }
+    };
+    roots.forEach(walk);
+    return out;
+  }
+
+  it('finds the files it claims to scan', () => {
+    // The positive control. Without it a typo in `roots` yields an empty set, every assertion
+    // below passes vacuously, and "no second copy anywhere" would be a fact about the walk.
+    const files = sourceFiles().map((f) => relative(repoRoot, f));
+    expect(files.length).toBeGreaterThan(10);
+    expect(files).toContain('.claude/skills/dev-server/cli.mjs');
+    expect(files).toContain('.claude/skills/dev-server/console.mjs');
+    expect(files).toContain('.claude/skills/dev-server/scripts/daemon.mjs');
+    expect(files).toContain('.claude/hooks/check-writable.mjs');
+    expect(files).toContain('scripts/test-unit-run.mjs');
+  });
+
+  it('spells the port in exactly one source file', () => {
+    // \b so 19444 and 94440 are not counted as a copy of 9444.
+    const literal = new RegExp(String.raw`\b${DEFAULT_DAEMON_PORT}\b`);
+    const owner = relative(repoRoot, portModule);
+
+    const holders = sourceFiles()
+      .filter((f) => literal.test(readFileSync(f, 'utf8')))
+      .map((f) => relative(repoRoot, f))
+      .sort();
+
+    expect(holders).toEqual([owner]);
+  });
+
+  it('has every daemon client take its address from that module', () => {
+    const clients = [cliScript, resolve(skillDir, 'console.mjs')];
+    for (const file of clients) {
       const source = readFileSync(file, 'utf8');
-      // Static `from '…/daemon-port.mjs'` in three of them; test-unit-run.mjs names the path and
-      // imports it dynamically, because it must still run when `.claude/` is absent.
-      expect(`${file}: ${source.includes('daemon-port.mjs')}`).toBe(`${file}: true`);
-      expect(`${file}: ${source.includes('resolveDaemonPort(')}`).toBe(`${file}: true`);
+      const name = relative(repoRoot, file);
+      // An IMPORT, not a mention: `includes('daemon-port.mjs')` alone is satisfied by a comment,
+      // and this file's prose names the module in several of them.
+      expect(`${name}: ${/^import .*from '.*daemon-port\.mjs';$/m.test(source)}`).toBe(
+        `${name}: true`
+      );
+      // The client takes the whole URL. Resolving a PORT and then doing arithmetic on it is the
+      // shape that let a wrong-but-non-literal value through: `resolveDaemonPort() + 1` used to
+      // satisfy every assertion here.
+      expect(`${name}: ${/const DAEMON_URL = resolveDaemonUrl\(\);/.test(source)}`).toBe(
+        `${name}: true`
+      );
     }
   });
 });
@@ -233,4 +345,94 @@ describe('the CLI reaches the daemon it starts', () => {
     expect(result.stderr).not.toMatch(/Failed to start daemon/);
     expect(result.code).toBe(0);
   }, 60_000);
+
+  // The bug this file shipped in its first version: the restore raced the daemon's own unlink,
+  // so running the unit suite deleted the developer's daemon.pid and it never came back.
+  it('leaves the pid file exactly as it found it', async () => {
+    const port = await freePort();
+    const sentinel = String(Date.now());
+    const had = existsSync(pidFile);
+    const saved = had ? readFileSync(pidFile) : null;
+
+    try {
+      writeFileSync(pidFile, sentinel);
+      await withPidFilePreserved(async () => {
+        await new Promise<void>((done) => {
+          const child = spawn(process.execPath, [cliScript, 'status'], {
+            cwd: repoRoot,
+            env: { ...process.env, DEV_DAEMON_PORT: String(port) },
+            stdio: 'ignore',
+          });
+          child.on('exit', () => done());
+        });
+        await shutdown(port);
+      });
+
+      // Long enough to cover the daemon's 100 ms post-response unlink timer several times over.
+      await new Promise((r) => setTimeout(r, 600));
+      expect(existsSync(pidFile)).toBe(true);
+      expect(readFileSync(pidFile, 'utf8')).toBe(sentinel);
+    } finally {
+      if (saved) writeFileSync(pidFile, saved);
+      else rmSync(pidFile, { force: true });
+    }
+  }, 60_000);
+});
+
+/**
+ * `scripts/test-unit-run.mjs` promises, in its own comment, never to leave a caller unable to
+ * run tests because the queue is unavailable. Resolving the address can now THROW, and an
+ * unusable address is the queue being unavailable — so it has to degrade the same way. It did
+ * not: the throw escaped an un-awaited runQueued as an unhandled rejection and no tests ran.
+ */
+describe('an unusable DEV_DAEMON_PORT still runs the tests', () => {
+  it('falls back to a direct run instead of dying', async () => {
+    const script = resolve(repoRoot, 'scripts/test-unit-run.mjs');
+
+    const stderr = await new Promise<string>((done) => {
+      const child = spawn(process.execPath, [script], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CI: '',
+          CIVITAI_TEST_QUEUE: '1',
+          DEV_DAEMON_PORT: 'nope',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let buf = '';
+      const finish = () => {
+        child.kill('SIGKILL');
+        done(buf);
+      };
+      // The fallback is a REAL vitest run of the whole suite, so the moment the decision is
+      // observable the child is killed. Waiting for it to finish would run the suite recursively.
+      child.stderr.on('data', (d: Buffer) => {
+        buf += d.toString();
+        if (/running directly/i.test(buf)) finish();
+      });
+      child.stdout.resume();
+      child.on('exit', () => done(buf));
+      setTimeout(finish, 25_000);
+    });
+
+    // The SPECIFIC message, not just "running directly". There are two guards on this path — the
+    // targeted catch around address resolution, and a general `.catch()` on the un-awaited
+    // runQueued — and the general one also degrades to a direct run. Asserting the generic phrase
+    // was satisfied by whichever fired, so deleting the targeted guard left the suite green
+    // (measured: it survived the mutation battery). Naming the message pins which one ran.
+    expect(stderr).toMatch(/Test queue address unusable/);
+    expect(stderr).toMatch(/running directly/i);
+    expect(stderr).not.toMatch(/UnhandledPromiseRejection|ERR_UNHANDLED_REJECTION/);
+  }, 40_000);
+
+  it('does not hold a stale port module reference', () => {
+    // The module the script reaches for must actually be there; the script gates on existsSync
+    // and would silently take the direct path forever if this moved.
+    expect(existsSync(portModule)).toBe(true);
+    expect(statSync(portModule).size).toBeGreaterThan(0);
+    expect(readFileSync(resolve(repoRoot, 'scripts/test-unit-run.mjs'), 'utf8')).toContain(
+      'daemon-port.mjs'
+    );
+  });
 });

--- a/scripts/__tests__/dev-server-daemon-port.test.ts
+++ b/scripts/__tests__/dev-server-daemon-port.test.ts
@@ -383,25 +383,32 @@ describe('the console talks to the port it resolved', () => {
     await new Promise<void>((done) => server.listen(0, '127.0.0.1', done));
     const { port } = server.address() as AddressInfo;
 
-    // `--tail`, because the dashboard refuses to start without a TTY ("Dashboard requires a TTY
-    // terminal") and exits 1 before it ever contacts the daemon. --tail is its own documented
-    // non-interactive mode and goes through the same resolved DAEMON_URL.
-    const child = spawn(process.execPath, [consoleScript, '--tail'], {
-      cwd: repoRoot,
-      env: { ...process.env, DEV_DAEMON_PORT: String(port) },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    child.stdout.resume();
-    child.stderr.resume();
+    // Wrapped, and specifically for the FAILING path. On a green run the stub answers `/` so the
+    // console never starts a daemon and never writes the pid file. Under the mutant this case
+    // exists to catch, the console cannot reach the stub, falls through to its own startDaemon,
+    // and overwrites the developer's daemon.pid with a dead pid — i.e. the test that proves the
+    // bug would also damage the thing the rest of this file is careful about.
+    await withPidFilePreserved(async () => {
+      // `--tail`, because the dashboard refuses to start without a TTY ("Dashboard requires a TTY
+      // terminal") and exits 1 before it ever contacts the daemon. --tail is its own documented
+      // non-interactive mode and goes through the same resolved DAEMON_URL.
+      const child = spawn(process.execPath, [consoleScript, '--tail'], {
+        cwd: repoRoot,
+        env: { ...process.env, DEV_DAEMON_PORT: String(port) },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      child.stdout.resume();
+      child.stderr.resume();
 
-    try {
-      for (let i = 0; i < 100 && hits.length === 0; i++) {
-        await new Promise((r) => setTimeout(r, 50));
+      try {
+        for (let i = 0; i < 100 && hits.length === 0; i++) {
+          await new Promise((r) => setTimeout(r, 50));
+        }
+      } finally {
+        child.kill('SIGKILL');
+        await new Promise<void>((done) => server.close(() => done()));
       }
-    } finally {
-      child.kill('SIGKILL');
-      await new Promise<void>((done) => server.close(() => done()));
-    }
+    });
 
     // A stub on a port nothing else knows about. A request arriving here at all is proof the
     // console resolved THIS port — an off-by-one would have gone somewhere else and hit nothing.

--- a/scripts/__tests__/dev-server-daemon-port.test.ts
+++ b/scripts/__tests__/dev-server-daemon-port.test.ts
@@ -1,0 +1,236 @@
+import { spawn } from 'child_process';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { createServer } from 'http';
+import type { AddressInfo } from 'net';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_DAEMON_PORT,
+  resolveDaemonPort,
+} from '../../.claude/skills/dev-server/scripts/daemon-port.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const skillDir = resolve(repoRoot, '.claude/skills/dev-server');
+const daemonScript = resolve(skillDir, 'scripts/daemon.mjs');
+const cliScript = resolve(skillDir, 'cli.mjs');
+const pidFile = resolve(skillDir, 'daemon.pid');
+
+/** A port nothing holds right now. Bound and released so the number is real, not a guess. */
+async function freePort(): Promise<number> {
+  const probe = createServer();
+  await new Promise<void>((done) => probe.listen(0, '127.0.0.1', done));
+  const { port } = probe.address() as AddressInfo;
+  await new Promise<void>((done) => probe.close(() => done()));
+  return port;
+}
+
+/**
+ * The daemon writes its pid into the skill directory, and a developer running this suite has a
+ * daemon of their own whose pid file that is. Every case here restores it.
+ */
+async function withPidFilePreserved<T>(body: () => Promise<T>): Promise<T> {
+  const saved = existsSync(pidFile) ? readFileSync(pidFile) : null;
+  try {
+    return await body();
+  } finally {
+    if (saved) writeFileSync(pidFile, saved);
+    else rmSync(pidFile, { force: true });
+  }
+}
+
+/** Ask a daemon to stop over its own API — the one teardown that also works on Windows. */
+async function shutdown(port: number) {
+  await fetch(`http://127.0.0.1:${port}/shutdown`, { method: 'POST' }).catch(() => null);
+}
+
+describe('resolveDaemonPort', () => {
+  it('is 9444 when the variable is unset or empty', () => {
+    expect(resolveDaemonPort({})).toBe(9444);
+    expect(resolveDaemonPort({ DEV_DAEMON_PORT: '' })).toBe(9444);
+    expect(DEFAULT_DAEMON_PORT).toBe(9444);
+  });
+
+  it('honours a numeric value', () => {
+    expect(resolveDaemonPort({ DEV_DAEMON_PORT: '9555' })).toBe(9555);
+    expect(resolveDaemonPort({ DEV_DAEMON_PORT: ' 9555 ' })).toBe(9555);
+  });
+
+  // parseInt — what every one of these call sites used to do — reads '9555abc' as 9555 and 'abc'
+  // as NaN. NaN reaches a URL as `http://127.0.0.1:NaN` and fails somewhere far from the cause.
+  it('refuses a value that is not a port instead of guessing one', () => {
+    expect(() => resolveDaemonPort({ DEV_DAEMON_PORT: 'abc' })).toThrow(/not a number/);
+    expect(() => resolveDaemonPort({ DEV_DAEMON_PORT: '9555abc' })).toThrow(/not a number/);
+    expect(() => resolveDaemonPort({ DEV_DAEMON_PORT: '-1' })).toThrow(/not a number/);
+    expect(() => resolveDaemonPort({ DEV_DAEMON_PORT: '0' })).toThrow(/out of range/);
+    expect(() => resolveDaemonPort({ DEV_DAEMON_PORT: '70000' })).toThrow(/out of range/);
+  });
+});
+
+/**
+ * The regression, and it needs a real daemon: the defect was that the value was read where the
+ * client decides what to CONNECT to and ignored where the daemon decides what to LISTEN on, so a
+ * test that imported functions would have seen a consistent-looking pair of constants and nothing
+ * else. Only binding a socket tells the two apart.
+ *
+ * Measured on pre-change code with DEV_DAEMON_PORT=19461: the daemon logged `Daemon port: 9444`,
+ * emitted no ready line, and nothing ever listened on 19461.
+ */
+describe('the dev daemon listens where DEV_DAEMON_PORT says', () => {
+  type Ready = { type: string; port: number; pid: number };
+
+  /** Run the real daemon to its ready line, probe it, then stop it. */
+  async function daemonReady(env: Record<string, string>, args: string[] = []) {
+    return withPidFilePreserved(async () => {
+      const child = spawn(process.execPath, [daemonScript, ...args], {
+        cwd: repoRoot,
+        env: { ...process.env, ...env },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      try {
+        const ready = await new Promise<Ready | null>((done) => {
+          let out = '';
+          const timer = setTimeout(() => done(null), 30_000);
+          const settle = (value: Ready | null) => {
+            clearTimeout(timer);
+            done(value);
+          };
+          child.stdout.on('data', (chunk: Buffer) => {
+            out += chunk.toString();
+            for (const line of out.split('\n')) {
+              if (!line.trim().startsWith('{')) continue;
+              try {
+                const parsed = JSON.parse(line) as Ready;
+                if (parsed.type === 'daemon_ready') settle(parsed);
+              } catch {
+                /* a partial line — wait for the rest */
+              }
+            }
+          });
+          child.stderr.resume();
+          child.on('exit', () => settle(null));
+        });
+
+        // A port that answers proves a listener, not THIS listener. Matching the pid the daemon
+        // reports against the child we spawned is what separates the two — an orphan left on a
+        // port by an earlier run answers just as cheerfully.
+        let reachable = false;
+        if (ready) {
+          const response = await fetch(`http://127.0.0.1:${ready.port}/`).catch(() => null);
+          reachable = response?.ok === true;
+        }
+        return { ready, reachable, spawnedPid: child.pid };
+      } finally {
+        child.kill('SIGTERM');
+        await new Promise<void>((done) => {
+          if (child.exitCode !== null || child.signalCode !== null) return done();
+          const hard = setTimeout(() => child.kill('SIGKILL'), 5_000);
+          child.on('exit', () => {
+            clearTimeout(hard);
+            done();
+          });
+        });
+      }
+    });
+  }
+
+  it('binds the port the environment names, with no arguments passed', async () => {
+    const port = await freePort();
+    const { ready, reachable, spawnedPid } = await daemonReady({ DEV_DAEMON_PORT: String(port) });
+
+    expect(ready?.port).toBe(port);
+    expect(reachable).toBe(true);
+    expect(ready?.pid).toBe(spawnedPid);
+  }, 60_000);
+
+  it('lets an explicit --port beat the environment', async () => {
+    const [envPort, argPort] = [await freePort(), await freePort()];
+    expect(envPort).not.toBe(argPort);
+
+    const { ready, reachable } = await daemonReady({ DEV_DAEMON_PORT: String(envPort) }, [
+      '--port',
+      String(argPort),
+    ]);
+
+    expect(ready?.port).toBe(argPort);
+    expect(reachable).toBe(true);
+  }, 60_000);
+});
+
+/**
+ * The ledger. What made this bug possible was four files each deciding the port for themselves,
+ * and it is not a bug any of them contains — it is a bug in the set. console.mjs in particular
+ * has no end-to-end case here (it is a TUI), so a structural claim about the set is the only
+ * thing standing between it and a second hardcoded 9444.
+ *
+ * This fails when the set grows (a new copy appears) and when it shrinks (daemon-port.mjs stops
+ * owning the number).
+ */
+describe('nothing outside daemon-port.mjs decides the daemon port', () => {
+  const owner = resolve(skillDir, 'scripts/daemon-port.mjs');
+  const readers = [
+    resolve(skillDir, 'cli.mjs'),
+    resolve(skillDir, 'console.mjs'),
+    resolve(skillDir, 'scripts/daemon.mjs'),
+    resolve(repoRoot, 'scripts/test-unit-run.mjs'),
+  ];
+
+  it('spells 9444 exactly once, in the module that owns it', () => {
+    // The positive control for the scan itself: the owner MUST contain the literal, or a typo in
+    // these paths would read as "no copies anywhere" and pass.
+    expect(readFileSync(owner, 'utf8')).toContain('9444');
+
+    for (const file of readers) {
+      expect(`${file}: ${readFileSync(file, 'utf8').includes('9444')}`).toBe(`${file}: false`);
+    }
+  });
+
+  it('has every reader take the port from that module', () => {
+    for (const file of readers) {
+      const source = readFileSync(file, 'utf8');
+      // Static `from '…/daemon-port.mjs'` in three of them; test-unit-run.mjs names the path and
+      // imports it dynamically, because it must still run when `.claude/` is absent.
+      expect(`${file}: ${source.includes('daemon-port.mjs')}`).toBe(`${file}: true`);
+      expect(`${file}: ${source.includes('resolveDaemonPort(')}`).toBe(`${file}: true`);
+    }
+  });
+});
+
+/**
+ * The seam neither half owns. cli.mjs resolved the port correctly and the daemon did not resolve
+ * it at all, so two files that each looked right disagreed about where the daemon was. Driving
+ * the real CLI is the only thing that builds the combined state.
+ */
+describe('the CLI reaches the daemon it starts', () => {
+  it('starts a daemon on the port it is going to talk to', async () => {
+    const port = await freePort();
+
+    const result = await withPidFilePreserved(async () => {
+      try {
+        return await new Promise<{ code: number | null; stdout: string; stderr: string }>(
+          (done) => {
+            const child = spawn(process.execPath, [cliScript, 'status'], {
+              cwd: repoRoot,
+              env: { ...process.env, DEV_DAEMON_PORT: String(port) },
+              stdio: ['ignore', 'pipe', 'pipe'],
+            });
+            let stdout = '';
+            let stderr = '';
+            child.stdout.on('data', (d: Buffer) => (stdout += d.toString()));
+            child.stderr.on('data', (d: Buffer) => (stderr += d.toString()));
+            child.on('exit', (code) => done({ code, stdout, stderr }));
+          }
+        );
+      } finally {
+        await shutdown(port);
+      }
+    });
+
+    // Pre-change this printed `Failed to start daemon` and exited 1: the daemon it had just
+    // spawned was listening on 9444 while the CLI polled the port it had been told to use.
+    expect(result.stderr).not.toMatch(/Failed to start daemon/);
+    expect(result.code).toBe(0);
+  }, 60_000);
+});

--- a/scripts/test-unit-run.mjs
+++ b/scripts/test-unit-run.mjs
@@ -22,9 +22,12 @@ const CLI = resolve(repoRoot, '.claude/skills/dev-server/cli.mjs');
 // rather than at the top of the file because it lives under `.claude/`, which the direct path
 // must keep working without: a static import would fail the whole script when the skill is absent.
 const QUEUE = resolve(repoRoot, '.claude/skills/dev-server/scripts/test-queue.mjs');
-// Same override the CLI honours. Without it this file can only ever talk to the shared daemon,
-// which is why the verdict below had no test: there was no way to stand a fake one up beside it.
-const DAEMON = `http://127.0.0.1:${parseInt(process.env.DEV_DAEMON_PORT || '9444', 10)}`;
+// Same override the CLI and the daemon honour, and from the same module, so no two of the three
+// can disagree about where the daemon is. Without it this file could only ever talk to the shared
+// daemon, which is why the verdict below had no test: there was no way to stand a fake one up
+// beside it. Imported on the queue path only, for the reason given above QUEUE.
+const PORT_MODULE = resolve(repoRoot, '.claude/skills/dev-server/scripts/daemon-port.mjs');
+let DAEMON = null;
 const POLL_MS = 2000;
 
 const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
@@ -97,6 +100,8 @@ async function runQueued(args) {
   // Resolved once, up front: this is the module that decides pass from fail, and a waiter that
   // discovers it cannot load that rule at the moment it must apply it has no verdict to give.
   const { exitCodeFor } = await import(pathToFileURL(QUEUE).href);
+  const { resolveDaemonPort } = await import(pathToFileURL(PORT_MODULE).href);
+  DAEMON = `http://127.0.0.1:${resolveDaemonPort()}`;
 
   let run;
   try {
@@ -163,6 +168,7 @@ if (
 ) {
   const args = process.argv.slice(2);
   const decision = queueDecision(args, process.env);
-  if (decision.queue && existsSync(CLI) && existsSync(QUEUE)) runQueued(args);
+  if (decision.queue && existsSync(CLI) && existsSync(QUEUE) && existsSync(PORT_MODULE))
+    runQueued(args);
   else runDirect(args);
 }

--- a/scripts/test-unit-run.mjs
+++ b/scripts/test-unit-run.mjs
@@ -105,10 +105,10 @@ async function runQueued(args) {
   const { exitCodeFor } = await import(pathToFileURL(QUEUE).href);
 
   // Resolving the daemon's address can THROW — a malformed DEV_DAEMON_PORT is rejected rather
-  // than silently becoming NaN. That must not cost the caller their test run: the guarantee at
-  // :123 is that the queue being unusable degrades to a direct run, and an unusable ADDRESS is
-  // the queue being unusable. Before this catch existed the throw escaped an un-awaited
-  // `runQueued` as an unhandled rejection and no tests ran at all.
+  // than silently becoming NaN. That must not cost the caller their test run: the
+  // "Test queue unreachable" guarantee below is that an unusable queue degrades to a direct run,
+  // and an unusable ADDRESS is the queue being unusable. Before this catch existed the throw
+  // escaped an un-awaited `runQueued` as an unhandled rejection and no tests ran at all.
   try {
     const { resolveDaemonUrl } = await import(pathToFileURL(PORT_MODULE).href);
     DAEMON = resolveDaemonUrl();
@@ -134,8 +134,14 @@ async function runQueued(args) {
   // From here the daemon has ACCEPTED the run, and that changes what a failure may do. Falling
   // back to a direct run now would start a second, unqueued full suite beside one the queue is
   // already holding a slot for — which is precisely the serialisation this script exists to
-  // provide. `:159` already decided this for the status-code form of the same condition; the
-  // network form gets the same answer.
+  // provide. The "Lost contact with the test queue" branch below already decided this for the
+  // status-code form of the same condition; the network form gets the same answer.
+  //
+  // Not airtight, and the gap is worth naming rather than implying it away: the daemon enqueues
+  // INSIDE the response write, so the slot is taken before the client can observe it. Lose the
+  // response between those two points and this flag is still false while the run is queued —
+  // the one window where a duplicate can still happen. Closing it needs an idempotency key on
+  // the enqueue, not a flag here.
   accepted = true;
 
   if (run.status === 'queued') {
@@ -191,12 +197,11 @@ if (
   const decision = queueDecision(args, process.env);
   if (decision.queue && existsSync(CLI) && existsSync(QUEUE) && existsSync(PORT_MODULE)) {
     // Un-awaited at top level, so anything runQueued throws would otherwise be an unhandled
-    // rejection that kills the process with no tests run. The same guarantee as :123.
-    // Un-awaited at top level, so anything runQueued throws would otherwise be an unhandled
     // rejection that kills the process with no tests run.
     //
     // What it does about it depends on whether the queue took the run. Before acceptance,
-    // degrading to a direct run keeps the guarantee at :128. AFTER acceptance it would start a
+    // degrading to a direct run keeps the "Test queue unreachable" guarantee. AFTER acceptance
+    // it would start a
     // second, unqueued suite beside the one the queue is holding a slot for, so it exits 2 — the
     // same verdict :159 already gives when the poll comes back with a bad status.
     //

--- a/scripts/test-unit-run.mjs
+++ b/scripts/test-unit-run.mjs
@@ -28,6 +28,9 @@ const QUEUE = resolve(repoRoot, '.claude/skills/dev-server/scripts/test-queue.mj
 // beside it. Imported on the queue path only, for the reason given above QUEUE.
 const PORT_MODULE = resolve(repoRoot, '.claude/skills/dev-server/scripts/daemon-port.mjs');
 let DAEMON = null;
+// Whether the queue has taken ownership of this run. Once it has, a later failure must NOT be
+// answered by starting a second, unqueued suite — see the note where this is set.
+let accepted = false;
 const POLL_MS = 2000;
 
 const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
@@ -128,6 +131,13 @@ async function runQueued(args) {
     }
   }
 
+  // From here the daemon has ACCEPTED the run, and that changes what a failure may do. Falling
+  // back to a direct run now would start a second, unqueued full suite beside one the queue is
+  // already holding a slot for — which is precisely the serialisation this script exists to
+  // provide. `:159` already decided this for the status-code form of the same condition; the
+  // network form gets the same answer.
+  accepted = true;
+
   if (run.status === 'queued') {
     console.error(
       run.paused
@@ -182,8 +192,24 @@ if (
   if (decision.queue && existsSync(CLI) && existsSync(QUEUE) && existsSync(PORT_MODULE)) {
     // Un-awaited at top level, so anything runQueued throws would otherwise be an unhandled
     // rejection that kills the process with no tests run. The same guarantee as :123.
+    // Un-awaited at top level, so anything runQueued throws would otherwise be an unhandled
+    // rejection that kills the process with no tests run.
+    //
+    // What it does about it depends on whether the queue took the run. Before acceptance,
+    // degrading to a direct run keeps the guarantee at :128. AFTER acceptance it would start a
+    // second, unqueued suite beside the one the queue is holding a slot for, so it exits 2 — the
+    // same verdict :159 already gives when the poll comes back with a bad status.
+    //
+    // `err?.message` rather than `err.message`: a non-Error throw would otherwise print
+    // `(undefined)`, and a null throw would raise inside the handler and land back at the
+    // unhandled rejection this exists to prevent.
     runQueued(args).catch((err) => {
-      console.error(`Test queue failed (${err.message}); running directly.`);
+      const detail = err?.message ?? String(err);
+      if (accepted) {
+        console.error(`Lost contact with the test queue (${detail}). The run may still be queued.`);
+        process.exit(2);
+      }
+      console.error(`Test queue failed (${detail}); running directly.`);
       runDirect(args);
     });
   } else runDirect(args);

--- a/scripts/test-unit-run.mjs
+++ b/scripts/test-unit-run.mjs
@@ -100,8 +100,19 @@ async function runQueued(args) {
   // Resolved once, up front: this is the module that decides pass from fail, and a waiter that
   // discovers it cannot load that rule at the moment it must apply it has no verdict to give.
   const { exitCodeFor } = await import(pathToFileURL(QUEUE).href);
-  const { resolveDaemonPort } = await import(pathToFileURL(PORT_MODULE).href);
-  DAEMON = `http://127.0.0.1:${resolveDaemonPort()}`;
+
+  // Resolving the daemon's address can THROW — a malformed DEV_DAEMON_PORT is rejected rather
+  // than silently becoming NaN. That must not cost the caller their test run: the guarantee at
+  // :123 is that the queue being unusable degrades to a direct run, and an unusable ADDRESS is
+  // the queue being unusable. Before this catch existed the throw escaped an un-awaited
+  // `runQueued` as an unhandled rejection and no tests ran at all.
+  try {
+    const { resolveDaemonUrl } = await import(pathToFileURL(PORT_MODULE).href);
+    DAEMON = resolveDaemonUrl();
+  } catch (err) {
+    console.error(`Test queue address unusable (${err.message}); running directly.`);
+    return runDirect(args);
+  }
 
   let run;
   try {
@@ -168,7 +179,12 @@ if (
 ) {
   const args = process.argv.slice(2);
   const decision = queueDecision(args, process.env);
-  if (decision.queue && existsSync(CLI) && existsSync(QUEUE) && existsSync(PORT_MODULE))
-    runQueued(args);
-  else runDirect(args);
+  if (decision.queue && existsSync(CLI) && existsSync(QUEUE) && existsSync(PORT_MODULE)) {
+    // Un-awaited at top level, so anything runQueued throws would otherwise be an unhandled
+    // rejection that kills the process with no tests run. The same guarantee as :123.
+    runQueued(args).catch((err) => {
+      console.error(`Test queue failed (${err.message}); running directly.`);
+      runDirect(args);
+    });
+  } else runDirect(args);
 }


### PR DESCRIPTION
`DEV_DAEMON_PORT` was read where the client decides what to **connect** to and ignored where the daemon decides what to **listen** on. Setting it pointed the CLI at a port nothing was serving:

```
DEV_DAEMON_PORT=9555 node .claude/skills/dev-server/cli.mjs status
  -> CLI polls :9555, spawns a daemon that binds :9444, gives up: "Failed to start daemon"
```

The daemon has always accepted `--port` — the spawn simply passed no arguments, and the daemon read no environment. So this is not "the daemon is unconfigurable"; it is a missing pass-through.

## Why the diff is bigger than one line

Five files each decided the port for themselves, and three of them were wrong:

| file | before |
|---|---|
| `cli.mjs` | reads `DEV_DAEMON_PORT` |
| `scripts/test-unit-run.mjs` | reads `DEV_DAEMON_PORT` |
| `console.mjs` | **hardcoded `9444`** |
| `scripts/daemon.mjs` | **argv only, no environment** |
| `.claude/hooks/check-writable.mjs` | **`9444` baked into a regex** |

That is not a bug any one of them contains — it is a bug in the set, and patching one site leaves the others regenerating it. The number now lives in `scripts/daemon-port.mjs` and everything resolves it there. A daemon a client spawns inherits that client's environment, so both ends read the same variable through the same function and cannot disagree; an explicit `node daemon.mjs --port <port>` still wins for a daemon started by hand, and goes through the same validator.

The hook mattered more than it looks: with `9444` baked in, setting `DEV_DAEMON_PORT` silently switched the "never curl a dev port unbounded" nudge off *for the daemon* — the one long-lived server the rule most exists for. Verified with a negative control: at `DEV_DAEMON_PORT=9555`, `curl :9555` nudges and `curl :7777` stays silent.

`parsePort` refuses a value that is not a port instead of handing back `parseInt`'s `NaN`, which used to reach a URL as `http://127.0.0.1:NaN` and a `listen()` as `ERR_SOCKET_BAD_PORT` — the latter invisible via `cli.mjs`, which detaches the daemon with stdio ignored and reports only "Failed to start daemon".

## Verification

Reproduced the reported path rather than reasoning about the code.

**Red at base** (`2b226eb054`, pristine worktree, `DEV_DAEMON_PORT=19461`):

```
  Daemon port: 9444
Uncaught exception: Error: listen EADDRINUSE ... 127.0.0.1:9444
```
No ready line, and nothing ever listened on 19461.

**Green at HEAD:** `{"type":"daemon_ready","port":19461,"pid":2584501,...}`, socket confirmed via `ss -lptn`. The test asserts the pid the daemon reports equals the child that was spawned — a port that answers proves a listener, not *this* listener, and an orphan from an earlier run answers just as cheerfully.

**Mutation battery**, run twice — once on the original guards, once on the audit-round guards. Each mutant applied alone, tree restored and `cmp`-verified between each, every one killed by its own named assertion:

| mutant | killed by |
|---|---|
| daemon ignores the environment | both behavioural cases |
| daemon ignores `--port` | the `--port` precedence case |
| `--port` back to `parseInt` | the argv-validation case |
| port resolved at module load | the import-safety case |
| resolver stops validating | the rejects-a-non-port case |
| a **new** file hardcodes 9444 | the ledger (the growth case) |
| the hook re-hardcodes 9444 | the ledger |
| `console.mjs` does `resolvePort() + 1` | the client-address case |
| `shutdown()` stops waiting | the pid-file case |
| the targeted fallback is removed | the degrade-to-direct case |
| the default drifts to 9445 | the default case |

🔴 **Two of these batteries reported a wrong result first, and both corrections are the interesting part.** The first battery reported every mutant SURVIVED — its own output parser matched nothing, so it was measuring itself, not the code. The second had a genuine survivor: the `test-unit-run` fallback assertion matched the generic phrase "running directly", which *both* guards on that path print, so deleting the targeted guard left the suite green. It now names the specific message.

`console.mjs` is a TUI with no end-to-end case here, which is what the ledger is for. It walks the tree rather than a fixed list, so it fails when the set of files deciding the port **grows** — including a file that does not exist yet — or **shrinks**, and it carries a positive control asserting it found the files it claims to scan, so a typo in its roots cannot read as "no copies anywhere".

`scripts/__tests__` — **324 passed**, including the 15 existing `test-unit-run` cases that drive the real script against a stub daemon over `DEV_DAEMON_PORT`, i.e. the queue path this touches. The hook's own selftest is green, and the `daemon port` case in it is a real positive control: `9444` matches none of the other port ranges, so it passes only if the module-source read worked.

## Typecheck

`pnpm typecheck` — **0 errors in 61s**.

Correcting an earlier version of this description, which claimed 12 pre-existing errors on `main`: that was wrong, and it was my environment. `git worktree add` does not initialise submodules, so `event-engine-common` was an empty directory in my worktree and 9 `TS2307 Cannot find module '…/event-engine-common/…'` errors followed, with 3 `implicitly any` errors downstream of them. `git submodule update --init event-engine-common` — which CI does and a fresh worktree does not — takes it to 0. `main` was never red.

## Not verified

Windows was not exercised locally. Nothing here is platform-specific — no `--port` argument quoting was added, and the teardown in the new tests uses the daemon's own `POST /shutdown` rather than a signal — but that is a design claim, not a measurement. Both `Windows dev-env` legs are green on this PR.

Closes ClickUp 868kuaa4e.
