### PR TITLE
docs(tests): the dropped report coverage is LOST, not relocated — a do-not-restore comment had a false reason

### DIFF
--- a/tests/preview-moderation.spec.ts
+++ b/tests/preview-moderation.spec.ts
@@ -28,7 +28,9 @@ import { trpcMutation, uniqueToken } from './preview-trpc';
  *   3. The report-CREATION leg of the old end-to-end action test. `report.create`
  *      is still a main-app guardedProcedure; `report.getAll` / `report.setStatus`
  *      are not (they were deleted in #3573), so the ACTIONING half of that
- *      coverage now belongs to the moderator app's own suite, not here.
+ *      coverage cannot be asserted from here. 🔴 It is LOST, NOT RELOCATED —
+ *      `apps/moderator` has ZERO test files (measured; positive control: 81 under
+ *      `packages/`). Tracked as #4182.
  *
  * Only runs under playwright.preview.config.ts (needs PREVIEW_URL + minted states).
  *
@@ -195,7 +197,18 @@ test.describe('moderation surface (mod)', () => {
     // 🔴 The ACTIONING legs (report.getAll → report.setStatus → re-read as
     // 'Actioned') used to live here. #3573 deleted both procedures from this app's
     // report.router.ts — that queue is the moderator app's now, and asserting it
-    // from a preview of THIS app is not possible. Do not "restore" them here; the
-    // coverage belongs to apps/moderator's own suite.
+    // from a preview of THIS app is not possible. Do not "restore" them here: the
+    // procedures do not exist, so it cannot be made to work.
+    //
+    // 🔴 AND DO NOT READ THAT AS "the coverage moved". An earlier version of this
+    // comment said it "belongs to apps/moderator's own suite" — there is no such
+    // suite. `apps/moderator` has ZERO test files (measured; positive control: 81
+    // under `packages/`). This coverage is LOST, and the loss originates in #3573,
+    // not in the change that stopped asserting it. Tracked as #4182.
+    //
+    // The distinction matters here specifically: this is a do-not-restore
+    // instruction, so a maintainer who checks its stated reason, finds no suite and
+    // concludes the comment is stale could try to restore procedures that no longer
+    // exist. The reason above — they were deleted — is the one that holds.
   });
 });


### PR DESCRIPTION
Comment-only. Corrects a claim that #4179 put into the merged code, where it is more dangerous than it was in the PR body.

## The claim

`tests/preview-moderation.spec.ts` asserts in two places that the dropped report-actioning coverage *"belongs to `apps/moderator`'s own suite"*. **There is no such suite.**

```
apps/moderator   *.test.ts / *.spec.ts files : 0
positive control — packages/                 : 81
```

The coverage is **lost, not relocated**, and the loss originates in #3573's deletion of `report.getAll` / `report.setStatus` — not in the change that stopped asserting them. Tracked as #4182.

## Why this one is worth a PR rather than a note on the issue

The second instance is attached to a **do-not-restore instruction**:

> *"Do not 'restore' them here; the coverage belongs to `apps/moderator`'s own suite."*

That is the shape where a false rationale actively misleads. A maintainer who does the right thing — checks the stated reason before obeying the instruction — finds no suite, reasonably concludes the comment is stale, and may try to restore legs that call procedures which **no longer exist in this app**.

The load-bearing half of that comment is correct and is kept verbatim: the procedures were deleted, so asserting them from a preview of this app is not possible. Only the clause about where the coverage went was wrong, and it is now replaced with what is true plus the measurement behind it.

## What changed

- Header block: "belongs to the moderator app's own suite" → "cannot be asserted from here; it is LOST, NOT RELOCATED", with the measured zero and the positive control.
- Inline comment: the do-not-restore reason is now *"the procedures do not exist, so it cannot be made to work"* — which holds independently — plus an explicit note that the old rationale was refuted, and why the distinction matters at that exact site.

## Verification

- **Comment-only**, verified by stripping comments from base and head and diffing the result — not by a line-prefix grep, which cannot tell a JSX/block comment from code.
- `prettier --check` clean. The file is **modified**, not added, so it routes to the report-only prettier step rather than the blocking added-files one; checked anyway.
- No behaviour, no assertions, no test names touched. `preview / smoke-tests` was green at 66 passed / 0 flaky when #4179 merged and nothing here can move it.

Refs: #4182, #4179, #4171, #3573
