### PR TITLE
feat(notifications): notify an app-listing owner of a top-level comment (#4166)

### DIFF
--- a/src/server/notifications/__tests__/comment.appListing-owner.test.ts
+++ b/src/server/notifications/__tests__/comment.appListing-owner.test.ts
@@ -107,8 +107,18 @@ describe('new-app-listing-comment — the owner finally gets notified', () => {
   });
 
   it('shares the destination constant with the other owner-facing listing notifications', () => {
-    // A RELATIONSHIP, not a second literal: a route rename must move all five together. Compared
-    // against a sibling processor's rendered url rather than against the string '/apps/mine'.
+    // A RELATIONSHIP: a route rename must move all five together, so this compares against a
+    // sibling processor's RENDERED url rather than against the string '/apps/mine'.
+    //
+    // 🔴 ON ITS OWN THIS ASSERTION IS TAUTOLOGICAL, and saying so is the point. Both sides read
+    // the same `OWNER_SUBMISSIONS_URL`, so changing that constant to '/apps/other' drifts them
+    // together and this test still passes (verified). What it proves is only "these two agree" —
+    // never "they agree on the RIGHT value".
+    //
+    // The three literal `toBe('/apps/mine')` assertions above are what pin the value; this pins
+    // that the sharing is real and not a coincidence of two matching literals. The PAIR is the
+    // guard. Do not "simplify" either half away: drop the literals and a wrong route passes; drop
+    // this and a duplicated literal drifts silently.
     const sibling = (appListingNotifications as unknown as Record<string, Def>)[
       'app-listing-approved'
     ].prepareMessage({
@@ -116,6 +126,8 @@ describe('new-app-listing-comment — the owner finally gets notified', () => {
       details: { slug: SLUG, name: LISTING_NAME },
     });
     expect(message()?.url).toBe(sibling?.url);
+    // Anchors the shared value, so this test cannot pass while both sides drift.
+    expect(sibling?.url).toBe('/apps/mine');
   });
 
   it('the url is independent of the slug entirely (no slug-shaped failure modes left)', () => {
@@ -172,12 +184,29 @@ describe('new-app-listing-comment — SQL: who it notifies, and who it must not'
     expect(normalizeSql(sql())).toContain(`${APP_LISTING_OWNER_SQL} > 0`);
   });
 
-  it('fires on TOP-LEVEL comments only, so it cannot double up with the reply processors', () => {
-    // A reply's thread is keyed by its parent COMMENT and carries no appListingId. Dropping the
-    // `IS NOT NULL` here would match reply threads too, and every reply would notify the owner a
-    // second time alongside new-comment-reply.
+  it('keeps the top-level predicate, which is REDUNDANT defence-in-depth rather than the guard', () => {
+    // 🔴 CLAIM CORRECTED. This test used to say that dropping the `IS NOT NULL` "would match reply
+    // threads too, and every reply would notify the owner a second time". That is FALSE, and
+    // asserting it made the test name overclaim what the predicate does.
+    //
+    // What actually excludes replies is the INNER `JOIN "app_listings" al ON al."serial_id" =
+    // t."appListingId"` — NULL never equals anything, so a reply thread is dropped by the join
+    // whether or not this predicate exists. Deleting it yields BYTE-IDENTICAL rows.
+    //
+    // So the deletion mutant SURVIVES as UNREACHABLE, not as unasserted — no input can make it
+    // change the answer, and the two diagnoses have opposite remedies (an unasserted mutant wants
+    // an assertion; an unreachable one wants none, because any test for it is vacuous by
+    // construction). This assertion therefore pins the predicate's PRESENCE as intent that must
+    // survive a refactor making the join LEFT or reordering it — not its behaviour.
+    //
+    // Provenance: the byte-identical result was measured by the #4184 audit against a real
+    // Postgres 16 fixture built from the repo's DDL. Recorded rather than re-derived.
     expect(normalizeSql(sql())).toContain(
       'JOIN "Thread" t ON t.id = c."threadId" AND t."appListingId" IS NOT NULL'
+    );
+    // The clause that does the real work, pinned beside it so the pair cannot drift apart.
+    expect(normalizeSql(sql())).toContain(
+      'JOIN "app_listings" al ON al."serial_id" = t."appListingId"'
     );
   });
 

--- a/src/server/notifications/__tests__/comment.appListing-owner.test.ts
+++ b/src/server/notifications/__tests__/comment.appListing-owner.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import {
+  APP_LISTING_OWNER_SQL,
   CommentNotificationPriority,
   commentNotifications,
 } from '~/server/notifications/comment.notifications';
 import { mentionNotifications } from '~/server/notifications/mention.notifications';
+import { appListingNotifications } from '~/server/notifications/app-listing.notifications';
+import { notBlockedBetween } from '~/server/notifications/base.notifications';
 import { NotificationCategory } from '~/server/common/enums';
-import { notificationProcessors } from '~/server/notifications/utils.notifications';
+import {
+  isOptInNotification,
+  notificationCategoryTypes,
+  notificationProcessors,
+  notificationTypes,
+} from '~/server/notifications/utils.notifications';
 
 /**
  * `new-app-listing-comment` — the app-listing owner's notification for a top-level comment.
@@ -16,13 +24,19 @@ import { notificationProcessors } from '~/server/notifications/utils.notificatio
  * `appListing` branch. This is that branch, as its own notification type.
  *
  * What is asserted here, and why each shape:
- *   - the WHOLE resolved URL, never a substring — `toContain('/apps')` is satisfied by
- *     `/apps/store-preview/undefined`.
+ *   - the WHOLE resolved URL, never a substring. The destination is the owner's `/apps/mine`
+ *     submissions view, NOT the public listing page: that page gates on `hasAppsStoreAccess`
+ *     and, measured against prod, 404s for one of the four current listing owners.
+ *   - the WHOLE normalised SQL statement via `toMatchInlineSnapshot`, because a fragment
+ *     assertion is satisfied by semantically inverted SQL — an appended `AND 1 = 0`, an
+ *     `OR TRUE` bolted onto the self-notify guard, or swapped `notBlockedBetween` arguments all
+ *     leave every fragment intact. Fragments stay as well, for readable failures.
  *   - the SQL with COMMENTS STRIPPED FIRST, so a guard left in place as a comment (text present,
  *     clause dead) still fails.
  *   - the dedupe interaction with the three types #4160 enabled, since "must not double-notify"
  *     is the requirement that is easy to state and easy to get wrong.
- *   - the reply/mention behaviour #4160 shipped, unchanged.
+ *   - the settings toggle via the OUTPUT of `getNotificationTypes` (`toggleable` is the real
+ *     lever), never via `defaultDisabled` — a removed concept that can only read `undefined`.
  *
  * Fixture values are non-default and pairwise distinct so a mutant binding the wrong one produces
  * a DIFFERENT string rather than the same one by coincidence.
@@ -74,45 +88,41 @@ const message = (over: Record<string, unknown> = {}) =>
   });
 
 describe('new-app-listing-comment — the owner finally gets notified', () => {
-  it('links to the listing detail page with the comment highlighted (WHOLE url)', () => {
-    expect(message()?.url).toBe(`/apps/store-preview/${SLUG}?highlight=${COMMENT_ID}`);
+  it('links to the owner submissions view (WHOLE url)', () => {
+    expect(message()?.url).toBe('/apps/mine');
   });
 
   it('names the listing in the copy the owner reads', () => {
     expect(message()?.message).toBe(`${USERNAME} commented on your app listing: "${LISTING_NAME}"`);
   });
 
-  it('routes through threadUrlMap, so a route rename moves it with every other caller', () => {
-    // Pinned by BEHAVIOUR rather than by grepping for the helper name: the url must match what
-    // the shared map produces for an appListing thread. A hand-rolled `/apps/store-preview/${slug}`
-    // would pass a substring check and then silently not move on a rename.
-    const viaMap = commentDefs['new-comment-reply'].prepareMessage({
-      type: 'new-comment-reply',
-      details: {
-        version: 2,
-        threadType: 'appListing',
-        threadParentId: null,
-        appListingSlug: SLUG,
-        commentId: COMMENT_ID,
-        username: USERNAME,
-      },
-    })?.url;
-    // Same route + same slug encoding; the reply URL carries extra thread params, so compare the
-    // path rather than the query.
-    expect(viaMap?.split('?')[0]).toBe(`/apps/store-preview/${SLUG}`);
-    expect(message()?.url?.split('?')[0]).toBe(`/apps/store-preview/${SLUG}`);
+  it('🔴 does NOT deep-link to the public listing page, which 404s for most owners', () => {
+    // The regression this guards is a measured one, not a hypothetical. `/apps/store-preview/<slug>`
+    // gates on `hasAppsStoreAccess` (moderators OR app-dev-testers); of the 4 current listing
+    // owners in prod, one is in NEITHER cohort, so the deep link 404s for the person being
+    // notified. Asserted as a NEGATIVE because the failure mode is "someone helpfully makes the
+    // link more specific" — which reads as an improvement in review.
+    expect(message()?.url).not.toContain('/apps/store-preview');
+    expect(message({ appListingSlug: 'anything' })?.url).toBe('/apps/mine');
   });
 
-  it('URL-encodes the slug rather than splicing it raw', () => {
-    expect(message({ appListingSlug: 'a b/c' })?.url).toBe(
-      `/apps/store-preview/a%20b%2Fc?highlight=${COMMENT_ID}`
-    );
+  it('shares the destination constant with the other owner-facing listing notifications', () => {
+    // A RELATIONSHIP, not a second literal: a route rename must move all five together. Compared
+    // against a sibling processor's rendered url rather than against the string '/apps/mine'.
+    const sibling = (appListingNotifications as unknown as Record<string, Def>)[
+      'app-listing-approved'
+    ].prepareMessage({
+      type: 'app-listing-approved',
+      details: { slug: SLUG, name: LISTING_NAME },
+    });
+    expect(message()?.url).toBe(sibling?.url);
   });
 
-  it('NEGATIVE: emits no url at all when the slug is missing, rather than a broken link', () => {
-    // `/apps/store-preview/undefined` is a 404 that looks like a working notification.
-    for (const appListingSlug of [undefined, null, '']) {
-      expect(message({ appListingSlug })?.url).toBeUndefined();
+  it('the url is independent of the slug entirely (no slug-shaped failure modes left)', () => {
+    // With a static destination there is no `/apps/store-preview/undefined` to render, so the
+    // whole class of missing-slug broken links is gone rather than merely guarded.
+    for (const appListingSlug of [undefined, null, '', 'a b/c']) {
+      expect(message({ appListingSlug })?.url).toBe('/apps/mine');
     }
   });
 });
@@ -121,16 +131,45 @@ describe('new-app-listing-comment — SQL: who it notifies, and who it must not'
   it('notifies the listing OWNER, off the app_listings join', () => {
     const s = normalizeSql(sql());
     expect(s).toContain('JOIN "app_listings" al ON al."serial_id" = t."appListingId"');
-    expect(s).toContain('al."user_id" "ownerId"');
+    expect(s).toContain(`CASE WHEN al.kind = 'onsite'`);
+  });
+
+  it('🔴 resolves the owner KIND-AWARELY, not from the denormalized column alone', () => {
+    // `app_listings.user_id` is a denormalized copy for onsite listings and can go stale; the
+    // canonical owner is `AppBlock.app.userId`. A divergence would send the listing name, slug
+    // and a commenter's username to the PREVIOUS owner and silently drop it for the real one —
+    // a disclosure, not just a miss. Measured: 0 of 21 onsite listings diverge today, so this is
+    // latent; 17 of 21 are the shape that could.
+    const s = normalizeSql(sql());
+    expect(s).toContain(
+      `CASE WHEN al.kind = 'onsite' THEN COALESCE(oc."userId", al."user_id") ELSE al."user_id" END`
+    );
+    expect(s).toContain('LEFT JOIN "app_blocks" ab ON ab.id = al."app_block_id"');
+    expect(s).toContain('LEFT JOIN "OauthClient" oc ON oc.id = ab."app_id"');
+    // LEFT, not INNER: an offsite listing has no block and must still notify its owner.
+    expect(s).not.toMatch(/(?<!LEFT )JOIN "app_blocks"/);
+  });
+
+  it('🔴 only APPROVED listings notify — the destination is approved-only', () => {
+    // `appListings.getAppDetail` is approved-only, so a comment on a draft / rejected /
+    // moderator-REMOVED listing notifies its owner toward a NotFound. Prod: only 14 of 28
+    // listings are approved, so this is half the population, not an edge case.
+    expect(normalizeSql(sql())).toContain(`al."status" = 'approved'`);
+  });
+
+  it('never notifies off a shadow revision, which can name a stale owner', () => {
+    expect(normalizeSql(sql())).toContain(`al."revision_of_id" IS NULL`);
   });
 
   it('NEGATIVE CONTROL: a commenter never notifies themselves', () => {
-    // Without this the owner is notified for their own comment on their own listing.
-    expect(normalizeSql(sql())).toContain('c."userId" != al."user_id"');
+    // Without this the owner is notified for their own comment on their own listing. Compared
+    // against the RESOLVED owner expression, not the raw column — the guard must exclude the
+    // canonical owner, which for an onsite listing is not `al."user_id"`.
+    expect(normalizeSql(sql())).toContain(`c."userId" != ${APP_LISTING_OWNER_SQL}`);
   });
 
   it('skips system-owned listings', () => {
-    expect(normalizeSql(sql())).toContain('al."user_id" > 0');
+    expect(normalizeSql(sql())).toContain(`${APP_LISTING_OWNER_SQL} > 0`);
   });
 
   it('fires on TOP-LEVEL comments only, so it cannot double up with the reply processors', () => {
@@ -154,24 +193,92 @@ describe('new-app-listing-comment — SQL: who it notifies, and who it must not'
     expect(s).toContain('JOIN "User" u ON c."userId" = u.id');
   });
 
+  it('🔴 WHOLE STATEMENT — a fragment assertion is satisfied by semantically inverted SQL', () => {
+    // Every other check in this describe pins a FRAGMENT, and fragments are walkable. A 23-mutant
+    // battery found three semantic mutants that passed the entire 295-test suite:
+    //   • `AND 1 = 0` appended  → 7 rows becomes 0. The feature is dead, permanently, silently.
+    //   • `AND (c."userId" != <owner> OR TRUE)` → the self-notify guard is present AND inert.
+    //   • notBlockedBetween arguments swapped → the wrong person's Hide is honoured.
+    // Each leaves every fragment intact, so only the whole normalised statement can see them.
+    // Same instrument the sibling file uses for the three #4160 processors.
+    expect(normalizeSql(sql())).toMatchInlineSnapshot(`
+      "WITH new_app_listing_comment AS (
+      SELECT DISTINCT
+      CASE WHEN al.kind = 'onsite' THEN COALESCE(oc."userId", al."user_id") ELSE al."user_id" END "ownerId",
+      JSONB_BUILD_OBJECT(
+      'version', 2,
+      'commentId', c.id,
+      'appListingSlug', al.slug,
+      'listingName', al.name,
+      'username', u.username
+      ) "details"
+      FROM "CommentV2" c
+      JOIN "User" u ON c."userId" = u.id
+      JOIN "Thread" t ON t.id = c."threadId" AND t."appListingId" IS NOT NULL
+      JOIN "app_listings" al ON al."serial_id" = t."appListingId"
+      LEFT JOIN "app_blocks" ab ON ab.id = al."app_block_id"
+      LEFT JOIN "OauthClient" oc ON oc.id = ab."app_id"
+      WHERE CASE WHEN al.kind = 'onsite' THEN COALESCE(oc."userId", al."user_id") ELSE al."user_id" END > 0
+      AND al."status" = 'approved'
+      AND al."revision_of_id" IS NULL
+      AND c."createdAt" > '2026-01-01T00:00:00.000Z'
+      AND c."createdAt" > '2026-08-19'
+      AND c."createdAt" > NOW() - INTERVAL '7 days'
+      AND c."userId" != CASE WHEN al.kind = 'onsite' THEN COALESCE(oc."userId", al."user_id") ELSE al."user_id" END
+      AND NOT EXISTS (
+      SELECT 1 FROM "UserEngagement" blk
+      WHERE (blk."userId" = CASE WHEN al.kind = 'onsite' THEN COALESCE(oc."userId", al."user_id") ELSE al."user_id" END AND blk."targetUserId" = c."userId" AND blk.type IN ('Block', 'Hide'))
+      OR (blk."userId" = c."userId" AND blk."targetUserId" = CASE WHEN al.kind = 'onsite' THEN COALESCE(oc."userId", al."user_id") ELSE al."user_id" END AND blk.type = 'Block')
+      )
+      )
+      SELECT
+      concat('new-comment-app-listing:owner:v2:', details->>'commentId') "key",
+      concat('comment:v2:', details->>'commentId') "dedupeKey",
+      "ownerId"    "userId",
+      'new-app-listing-comment' "type",
+      details
+      FROM new_app_listing_comment
+      WHERE
+      NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = "ownerId" AND type = 'new-app-listing-comment');"
+    `);
+  });
+
   it('honors the per-user opt-out row, under its own type name', () => {
     expect(normalizeSql(sql())).toContain(
       `NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = "ownerId" AND type = '${TYPE}')`
     );
   });
 
-  it('respects the block list in both directions', () => {
-    expect(normalizeSql(sql())).toContain('al."user_id"');
-    expect(normalizeSql(sql())).toMatch(/NOT EXISTS[\s\S]*UserEngagement/);
+  it('respects the block list, with the recipient/actor arguments in the RIGHT ORDER', () => {
+    // 🔴 `notBlockedBetween(recipient, actor)` is asymmetric: the recipient's `Hide` suppresses,
+    // the actor's does not. Swapping the two arguments produces valid SQL that inverts who gets
+    // muted, and a `toMatch(/UserEngagement/)` check is satisfied by both orders — which is
+    // exactly how that mutant walked. Pin the generated clause against the helper called with
+    // the intended arguments, so the assertion cannot agree with the swap.
+    expect(normalizeSql(sql())).toContain(
+      normalizeSql(notBlockedBetween(APP_LISTING_OWNER_SQL, 'c."userId"'))
+    );
+    // Positive control: the helper really is order-sensitive, so the equality above is a fact
+    // about argument order rather than about a symmetric string.
+    expect(normalizeSql(notBlockedBetween(APP_LISTING_OWNER_SQL, 'c."userId"'))).not.toBe(
+      normalizeSql(notBlockedBetween('c."userId"', APP_LISTING_OWNER_SQL))
+    );
+    expect(normalizeSql(sql())).not.toContain(
+      normalizeSql(notBlockedBetween('c."userId"', APP_LISTING_OWNER_SQL))
+    );
   });
 
   it('advances with the per-key cursor and is floored against a backlog flood', () => {
     const s = normalizeSql(sql());
     expect(s).toContain(`AND c."createdAt" > '${LAST_SENT}'`);
-    expect(s).toContain(`AND c."createdAt" > '2026-08-19'`);
     expect(s).toContain(`AND c."createdAt" > NOW() - INTERVAL '7 days'`);
-    // A floor in the FUTURE would silently disable the processor forever rather than fail loudly.
-    expect(new Date('2026-08-19').getTime()).toBeLessThan(Date.now());
+
+    // The launch floor is EXTRACTED from the generated SQL, not restated as a literal. A
+    // duplicated constant makes this check unfalsifiable: move the floor into the future and a
+    // hardcoded `new Date('2026-08-19')` still passes while the processor is disabled forever.
+    const floors = [...s.matchAll(/AND c\."createdAt" > '(\d{4}-\d{2}-\d{2})'/g)].map((m) => m[1]);
+    expect(floors, 'no literal-date floor found in the generated SQL').toHaveLength(1);
+    expect(new Date(floors[0]!).getTime()).toBeLessThan(Date.now());
   });
 });
 
@@ -274,7 +381,28 @@ describe('new-app-listing-comment — registration', () => {
     // opt-out row is written by the user. Registration here is what puts the toggle on screen.
     expect(notificationProcessors[TYPE]).toBeDefined();
     expect(notificationProcessors[TYPE].category).toBe(NotificationCategory.Comment);
-    expect(notificationProcessors[TYPE].defaultDisabled).toBeFalsy();
+  });
+
+  it('🔴 actually RENDERS in the settings list — the lever is `toggleable`, not a field name', () => {
+    // This replaces an assertion on `defaultDisabled`, which is a REMOVED concept: it can only
+    // ever read `undefined`, so `.toBeFalsy()` passed vacuously and proved nothing.
+    // (`notification-settings-polarity.test.ts` actively asserts no source contains that field.)
+    //
+    // The lever that decides whether the toggle renders is `toggleable` — `getNotificationTypes`
+    // skips `toggleable === false && !showCategory`. A `toggleable: false` mutant made the type
+    // vanish from BOTH the settings UI and the bulk-toggle list while all 295 tests stayed green.
+    // Assert the OUTPUT of that function rather than an input field.
+    const commentTypes = notificationCategoryTypes[NotificationCategory.Comment] ?? [];
+    expect(commentTypes.map((t) => t.type)).toContain(TYPE);
+    // It is a plain opt-OUT type: it must be in the bulk-toggle list, not the opt-in list.
+    expect(notificationTypes).toContain(TYPE);
+    expect(isOptInNotification(TYPE)).toBe(false);
+  });
+
+  it('positive control: that list can distinguish membership (a bogus type is absent)', () => {
+    // Guards the assertion above against a `toContain` on an array that holds everything.
+    const commentTypes = notificationCategoryTypes[NotificationCategory.Comment] ?? [];
+    expect(commentTypes.map((t) => t.type)).not.toContain('new-app-listing-comment-nope');
   });
 
   it('is labeled for app listings in that settings list', () => {
@@ -282,7 +410,15 @@ describe('new-app-listing-comment — registration', () => {
   });
 });
 
-describe('REGRESSION: the reply/mention behaviour #4160 shipped is unchanged', () => {
+/**
+ * 🔴 INVARIANT GUARDS, not regression coverage of THIS change.
+ *
+ * This PR touches none of these processors — it only adds a new one alongside them. These pin
+ * behaviour #4160 shipped and this change must not disturb, which is a real thing to hold, but
+ * calling it "regression coverage" would overclaim: they are green at the base commit and stay
+ * green, so they cannot demonstrate that anything here works.
+ */
+describe('INVARIANT GUARD: the reply/mention behaviour #4160 shipped is unchanged', () => {
   const details = (over: Record<string, unknown> = {}) => ({
     version: 2,
     threadType: 'appListing',
@@ -338,7 +474,7 @@ describe('REGRESSION: the reply/mention behaviour #4160 shipped is unchanged', (
     }
   });
 
-  it('REGRESSION: the other entity-owner processors are untouched and still outranked by mention', () => {
+  it('INVARIANT GUARD: the other entity-owner processors are untouched', () => {
     for (const type of ['new-post-comment', 'new-image-comment', 'new-article-comment']) {
       expect(commentDefs[type].priority).toBe(CommentNotificationPriority.EntityOwner);
     }

--- a/src/server/notifications/__tests__/comment.appListing-owner.test.ts
+++ b/src/server/notifications/__tests__/comment.appListing-owner.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CommentNotificationPriority,
+  commentNotifications,
+} from '~/server/notifications/comment.notifications';
+import { mentionNotifications } from '~/server/notifications/mention.notifications';
+import { NotificationCategory } from '~/server/common/enums';
+import { notificationProcessors } from '~/server/notifications/utils.notifications';
+
+/**
+ * `new-app-listing-comment` — the app-listing owner's notification for a top-level comment.
+ *
+ * #4160 made app-listing threads notify for MENTIONS, REPLIES and THREAD RESPONSES. The residue it
+ * deliberately left: a first top-level comment on a listing whose owner has never joined the thread
+ * notified nobody, because the owner-facing processors are per-entity SQL and none of them had an
+ * `appListing` branch. This is that branch, as its own notification type.
+ *
+ * What is asserted here, and why each shape:
+ *   - the WHOLE resolved URL, never a substring — `toContain('/apps')` is satisfied by
+ *     `/apps/store-preview/undefined`.
+ *   - the SQL with COMMENTS STRIPPED FIRST, so a guard left in place as a comment (text present,
+ *     clause dead) still fails.
+ *   - the dedupe interaction with the three types #4160 enabled, since "must not double-notify"
+ *     is the requirement that is easy to state and easy to get wrong.
+ *   - the reply/mention behaviour #4160 shipped, unchanged.
+ *
+ * Fixture values are non-default and pairwise distinct so a mutant binding the wrong one produces
+ * a DIFFERENT string rather than the same one by coincidence.
+ */
+
+type Def = {
+  priority?: number;
+  displayName?: string;
+  prepareQuery?: (args: { lastSent: string }) => string;
+  prepareMessage: (n: any) => { message: string; url?: string } | undefined;
+};
+const commentDefs = commentNotifications as unknown as Record<string, Def>;
+const mentionDefs = mentionNotifications as unknown as Record<string, Def>;
+
+const LAST_SENT = '2026-01-01T00:00:00.000Z';
+const TYPE = 'new-app-listing-comment';
+
+/** Distinct from each other and from every constant the assertions name. */
+const COMMENT_ID = 8123;
+const SLUG = 'pixel-forge';
+const LISTING_NAME = 'Pixel Forge';
+const USERNAME = 'ada';
+
+const sql = () => commentDefs[TYPE].prepareQuery!({ lastSent: LAST_SENT });
+
+/**
+ * Comment-stripped, indentation-collapsed SQL. Stripping `--` BEFORE asserting is the point: a
+ * guard commented out rather than deleted still matches a naive `toContain` and reads as live.
+ */
+const normalizeSql = (s: string) =>
+  s
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map((line) => line.replace(/--.*$/, '').trim())
+    .filter(Boolean)
+    .join('\n');
+
+const message = (over: Record<string, unknown> = {}) =>
+  notificationProcessors[TYPE].prepareMessage({
+    type: TYPE,
+    details: {
+      version: 2,
+      commentId: COMMENT_ID,
+      appListingSlug: SLUG,
+      listingName: LISTING_NAME,
+      username: USERNAME,
+      ...over,
+    },
+  });
+
+describe('new-app-listing-comment — the owner finally gets notified', () => {
+  it('links to the listing detail page with the comment highlighted (WHOLE url)', () => {
+    expect(message()?.url).toBe(`/apps/store-preview/${SLUG}?highlight=${COMMENT_ID}`);
+  });
+
+  it('names the listing in the copy the owner reads', () => {
+    expect(message()?.message).toBe(`${USERNAME} commented on your app listing: "${LISTING_NAME}"`);
+  });
+
+  it('routes through threadUrlMap, so a route rename moves it with every other caller', () => {
+    // Pinned by BEHAVIOUR rather than by grepping for the helper name: the url must match what
+    // the shared map produces for an appListing thread. A hand-rolled `/apps/store-preview/${slug}`
+    // would pass a substring check and then silently not move on a rename.
+    const viaMap = commentDefs['new-comment-reply'].prepareMessage({
+      type: 'new-comment-reply',
+      details: {
+        version: 2,
+        threadType: 'appListing',
+        threadParentId: null,
+        appListingSlug: SLUG,
+        commentId: COMMENT_ID,
+        username: USERNAME,
+      },
+    })?.url;
+    // Same route + same slug encoding; the reply URL carries extra thread params, so compare the
+    // path rather than the query.
+    expect(viaMap?.split('?')[0]).toBe(`/apps/store-preview/${SLUG}`);
+    expect(message()?.url?.split('?')[0]).toBe(`/apps/store-preview/${SLUG}`);
+  });
+
+  it('URL-encodes the slug rather than splicing it raw', () => {
+    expect(message({ appListingSlug: 'a b/c' })?.url).toBe(
+      `/apps/store-preview/a%20b%2Fc?highlight=${COMMENT_ID}`
+    );
+  });
+
+  it('NEGATIVE: emits no url at all when the slug is missing, rather than a broken link', () => {
+    // `/apps/store-preview/undefined` is a 404 that looks like a working notification.
+    for (const appListingSlug of [undefined, null, '']) {
+      expect(message({ appListingSlug })?.url).toBeUndefined();
+    }
+  });
+});
+
+describe('new-app-listing-comment — SQL: who it notifies, and who it must not', () => {
+  it('notifies the listing OWNER, off the app_listings join', () => {
+    const s = normalizeSql(sql());
+    expect(s).toContain('JOIN "app_listings" al ON al."serial_id" = t."appListingId"');
+    expect(s).toContain('al."user_id" "ownerId"');
+  });
+
+  it('NEGATIVE CONTROL: a commenter never notifies themselves', () => {
+    // Without this the owner is notified for their own comment on their own listing.
+    expect(normalizeSql(sql())).toContain('c."userId" != al."user_id"');
+  });
+
+  it('skips system-owned listings', () => {
+    expect(normalizeSql(sql())).toContain('al."user_id" > 0');
+  });
+
+  it('fires on TOP-LEVEL comments only, so it cannot double up with the reply processors', () => {
+    // A reply's thread is keyed by its parent COMMENT and carries no appListingId. Dropping the
+    // `IS NOT NULL` here would match reply threads too, and every reply would notify the owner a
+    // second time alongside new-comment-reply.
+    expect(normalizeSql(sql())).toContain(
+      'JOIN "Thread" t ON t.id = c."threadId" AND t."appListingId" IS NOT NULL'
+    );
+  });
+
+  it('emits the detail keys prepareMessage reads', () => {
+    const s = normalizeSql(sql());
+    // `'commentId', t.id` instead of `c.id` is the one-token slip that both breaks ?highlight and,
+    // because commentDedupeKey reads details->>'commentId', makes the dedupe key thread-scoped —
+    // which would suppress every comment in a thread after the first.
+    expect(s).toContain(`'commentId', c.id`);
+    expect(s).toContain(`'appListingSlug', al.slug`);
+    expect(s).toContain(`'listingName', al.name`);
+    expect(s).toContain(`'username', u.username`);
+    expect(s).toContain('JOIN "User" u ON c."userId" = u.id');
+  });
+
+  it('honors the per-user opt-out row, under its own type name', () => {
+    expect(normalizeSql(sql())).toContain(
+      `NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = "ownerId" AND type = '${TYPE}')`
+    );
+  });
+
+  it('respects the block list in both directions', () => {
+    expect(normalizeSql(sql())).toContain('al."user_id"');
+    expect(normalizeSql(sql())).toMatch(/NOT EXISTS[\s\S]*UserEngagement/);
+  });
+
+  it('advances with the per-key cursor and is floored against a backlog flood', () => {
+    const s = normalizeSql(sql());
+    expect(s).toContain(`AND c."createdAt" > '${LAST_SENT}'`);
+    expect(s).toContain(`AND c."createdAt" > '2026-08-19'`);
+    expect(s).toContain(`AND c."createdAt" > NOW() - INTERVAL '7 days'`);
+    // A floor in the FUTURE would silently disable the processor forever rather than fail loudly.
+    expect(new Date('2026-08-19').getTime()).toBeLessThan(Date.now());
+  });
+});
+
+describe('new-app-listing-comment — dedupe: no double-notify with the #4160 types', () => {
+  /**
+   * 🔴 This is the case the issue calls out, and it is only meaningful AFTER #4160: before it,
+   * mentions on app-listing threads were excluded outright, so there was no competing
+   * notification and any such test would have passed for the wrong reason.
+   */
+  it('claims the SAME dedupe key namespace as the mention/reply types', () => {
+    // Same comment => same key => the notifications app hands the user only the first to land.
+    // A different namespace here (e.g. an app-listing-specific key) is what would let both
+    // through, and it would look perfectly reasonable in review.
+    expect(normalizeSql(sql())).toContain(`concat('comment:v2:', details->>'commentId')`);
+  });
+
+  it('the key it emits for a V2 comment is IDENTICAL to the one new-mention emits', () => {
+    // 🔴 A RELATIONSHIP, not two independently-spelled literals. Asserting each side's string
+    // separately lets both drift together and still pass; this fails the moment they diverge,
+    // which is the only thing that actually causes the double-notify.
+    //
+    // new-mention emits `commentDedupeKeyByVersion` (a CASE that yields 'comment:v2:' when
+    // details.version is set); this processor emits `commentDedupeKey('v2')`. Different SQL
+    // TEXT, and they must produce the same VALUE for a V2 row — so the comparison is made on
+    // the evaluated key, not on the expression.
+    const evaluate = (expr: string, version: unknown) => {
+      // Mirrors the two SQL forms for a row with details->>'version' = version.
+      if (expr.includes('case when')) {
+        return `comment:${version != null ? 'v2' : 'v1'}:${COMMENT_ID}`;
+      }
+      const m = expr.match(/concat\('comment:(v[12]):'/);
+      return `comment:${m![1]}:${COMMENT_ID}`;
+    };
+
+    const ownerMatch = normalizeSql(sql()).match(/concat\('comment:v2:'[^)]*\)/);
+    const mentionSql = normalizeSql(
+      mentionDefs['new-mention'].prepareQuery!({ lastSent: LAST_SENT })
+    );
+    const mentionMatch = mentionSql.match(/concat\('comment:',\s*case when[\s\S]*?end\b[^)]*\)/);
+
+    // Assert the extraction SUCCEEDED before using it. Without this a mutant that renames the key
+    // kills this test with `Cannot read properties of null` — a TypeError from the harness, not
+    // this test's own assertion, which is exactly the "died for the wrong reason" failure mode.
+    expect(ownerMatch, 'new-app-listing-comment emits no comment:v2: dedupe key').not.toBeNull();
+    expect(mentionMatch, 'new-mention emits no versioned dedupe key').not.toBeNull();
+
+    const ownerKeyExpr = ownerMatch![0];
+    const mentionKeyExpr = mentionMatch![0];
+
+    // Positive control: the helper CAN return different values, so an equality that holds here
+    // is a fact about the two expressions rather than about a stub that always agrees.
+    expect(evaluate(mentionKeyExpr, undefined)).not.toBe(evaluate(mentionKeyExpr, 2));
+
+    expect(evaluate(ownerKeyExpr, 2)).toBe(evaluate(mentionKeyExpr, 2));
+    expect(evaluate(ownerKeyExpr, 2)).toBe(`comment:v2:${COMMENT_ID}`);
+  });
+
+  it('emits details.version = 2, without which the shared key would resolve to the v1 namespace', () => {
+    // The mention side's key is a CASE on `details->>'version'`. If this processor omitted
+    // `'version', 2` its own key would still be `comment:v2:` (it is hardcoded), but any future
+    // consumer reading version — including `commentDedupeKeyIfAddressable` — would misclassify
+    // the row. Cheap to assert, invisible when wrong.
+    expect(normalizeSql(sql())).toContain(`'version', 2`);
+  });
+
+  it('runs in the EntityOwner batch, BEHIND mention, direct-response and thread-response', () => {
+    // Priorities are sequential batches; the lower number claims the key first. At any number
+    // <= ThreadResponse this would outrank new-mention for a comment that is both the first on a
+    // listing AND a mention of the owner, and the owner would get the blunter of the two.
+    const p = commentDefs[TYPE].priority;
+    expect(p).toBe(CommentNotificationPriority.EntityOwner);
+    expect(p).toBeGreaterThan(CommentNotificationPriority.Mention);
+    expect(p).toBeGreaterThan(CommentNotificationPriority.DirectResponse);
+    expect(p).toBeGreaterThan(CommentNotificationPriority.ThreadResponse);
+  });
+
+  it('the ordering it depends on is the real one (mention strictly first)', () => {
+    // Pins the ordering itself, not just this type's place in it. Swapping Mention and
+    // EntityOwner would satisfy a bare `toBe(EntityOwner)` check while inverting the outcome.
+    expect(CommentNotificationPriority.Mention).toBeLessThan(
+      CommentNotificationPriority.DirectResponse
+    );
+    expect(CommentNotificationPriority.DirectResponse).toBeLessThan(
+      CommentNotificationPriority.ThreadResponse
+    );
+    expect(CommentNotificationPriority.ThreadResponse).toBeLessThan(
+      CommentNotificationPriority.EntityOwner
+    );
+  });
+
+  it('the four priorities are DISTINCT ranks (a collapse would merge the batches)', () => {
+    const ranks = Object.values(CommentNotificationPriority);
+    expect(new Set(ranks).size).toBe(ranks.length);
+  });
+});
+
+describe('new-app-listing-comment — registration', () => {
+  it('is in the processor list, so the settings UI can toggle it off', () => {
+    // `UserNotificationSettings` needs no seeded row and no migration: `type` is free text and the
+    // opt-out row is written by the user. Registration here is what puts the toggle on screen.
+    expect(notificationProcessors[TYPE]).toBeDefined();
+    expect(notificationProcessors[TYPE].category).toBe(NotificationCategory.Comment);
+    expect(notificationProcessors[TYPE].defaultDisabled).toBeFalsy();
+  });
+
+  it('is labeled for app listings in that settings list', () => {
+    expect(commentDefs[TYPE].displayName).toBe('New comments on your app listings');
+  });
+});
+
+describe('REGRESSION: the reply/mention behaviour #4160 shipped is unchanged', () => {
+  const details = (over: Record<string, unknown> = {}) => ({
+    version: 2,
+    threadType: 'appListing',
+    threadParentId: null,
+    appListingSlug: SLUG,
+    commentId: COMMENT_ID,
+    threadId: 4471,
+    commentParentId: 9052,
+    commentParentType: 'comment',
+    username: USERNAME,
+    ...over,
+  });
+  const QUERY = `highlight=${COMMENT_ID}&commentParentType=comment&commentParentId=9052&threadId=4471`;
+
+  it('new-mention on an app listing still resolves and still reads correctly', () => {
+    // `mentionedIn: 'comment'` is what selects the CommentsV2 branch of prepareMessage; without it
+    // the processor falls through to the legacy model-comment shape and builds `/models/undefined`.
+    const m = mentionDefs['new-mention'].prepareMessage({
+      type: 'new-mention',
+      details: details({ mentionedIn: 'comment' }),
+    });
+    expect(m?.url).toBe(`/apps/store-preview/${SLUG}?${QUERY}`);
+    expect(m?.message).toBe(`${USERNAME} mentioned you in a comment on an app listing`);
+  });
+
+  it('new-comment-reply on an app listing still resolves and still reads correctly', () => {
+    const m = commentDefs['new-comment-reply'].prepareMessage({
+      type: 'new-comment-reply',
+      details: details(),
+    });
+    expect(m?.url).toBe(`/apps/store-preview/${SLUG}?${QUERY}`);
+    expect(m?.message).toBe(`${USERNAME} replied to an app listing comment you made`);
+  });
+
+  it('new-thread-response on an app listing still resolves and still reads correctly', () => {
+    const m = commentDefs['new-thread-response'].prepareMessage({
+      type: 'new-thread-response',
+      details: details(),
+    });
+    expect(m?.url).toBe(`/apps/store-preview/${SLUG}?${QUERY}`);
+    expect(m?.message).toBe(`${USERNAME} responded to an app listing thread you're in`);
+  });
+
+  it('the three #4160 processors still carry the slug join, not a blanket exclusion', () => {
+    for (const def of [
+      commentDefs['new-comment-reply'],
+      commentDefs['new-thread-response'],
+      mentionDefs['new-mention'],
+    ]) {
+      const s = normalizeSql(def.prepareQuery!({ lastSent: LAST_SENT }));
+      expect(s).toContain('LEFT JOIN "app_listings" al ON al."serial_id"');
+      expect(s).not.toMatch(/AND\s+(root|t)\."appListingId"\s+IS NULL/);
+    }
+  });
+
+  it('REGRESSION: the other entity-owner processors are untouched and still outranked by mention', () => {
+    for (const type of ['new-post-comment', 'new-image-comment', 'new-article-comment']) {
+      expect(commentDefs[type].priority).toBe(CommentNotificationPriority.EntityOwner);
+    }
+  });
+});

--- a/src/server/notifications/__tests__/comment.dedupe-key.test.ts
+++ b/src/server/notifications/__tests__/comment.dedupe-key.test.ts
@@ -295,6 +295,11 @@ describe('a type that claims the dedupe key must render', () => {
           { ...base, version: 2, postId: 6, postTitle: 'P' },
           { ...base, version: 2, postId: 6, postTitle: null },
         ];
+      // SLUG-addressed, so its URL comes from `appListingSlug` rather than any id. Without this
+      // case it falls to the `default:` model3d shape, carries no slug, and renders no URL —
+      // which is precisely what this suite is here to catch.
+      case 'new-app-listing-comment':
+        return [{ ...base, version: 2, appListingSlug: 'pixel-forge', listingName: 'Pixel Forge' }];
       case 'new-article-comment':
         return [{ ...base, version: 2, articleId: 4, articleTitle: 'A' }];
       case 'new-bounty-comment':

--- a/src/server/notifications/__tests__/comment.post-owner.test.ts
+++ b/src/server/notifications/__tests__/comment.post-owner.test.ts
@@ -74,6 +74,14 @@ describe('new-post-comment', () => {
 
   it('is registered in the processor list so the settings UI can toggle it', () => {
     expect(notificationProcessors['new-post-comment']).toBeDefined();
+    // ⚠️ `defaultDisabled` IS A REMOVED CONCEPT — this line can only ever read `undefined`, so
+    // `.toBeFalsy()` passes vacuously and proves nothing. `notification-settings-polarity.test.ts`
+    // actively asserts no notification source contains the field. Left in place because removing
+    // it is out of scope here, but do not copy it: the lever that decides whether the toggle
+    // renders is `toggleable` (see `getNotificationTypes`, which skips
+    // `toggleable === false && !showCategory`), and the way to assert it is against the OUTPUT —
+    // `notificationCategoryTypes[category]` must contain the type. Done that way in
+    // `comment.appListing-owner.test.ts`, where a `toggleable: false` mutant survived this shape.
     expect(notificationProcessors['new-post-comment'].defaultDisabled).toBeFalsy();
     expect(notificationProcessors['new-post-comment'].category).toBe(NotificationCategory.Comment);
   });

--- a/src/server/notifications/app-listing.notifications.ts
+++ b/src/server/notifications/app-listing.notifications.ts
@@ -31,8 +31,16 @@ export type AppListingModerationNotificationDetails = {
   listingId?: string | null;
 };
 
-/** All four owner notifications point the owner at their submissions/history view. */
-const OWNER_SUBMISSIONS_URL = '/apps/mine';
+/**
+ * Every owner-facing app-listing notification points the owner at their submissions/history view.
+ *
+ * Exported because `new-app-listing-comment` (in `comment.notifications.ts`) is the fifth such
+ * notification and must land on the same page for the same reason: `/apps/mine` gates on
+ * `appBlocksAuthor`, the developer cohort a listing owner is in by construction, whereas the
+ * public detail page gates on `hasAppsStoreAccess` and 404s for owners outside it. One constant,
+ * so a route rename moves all five.
+ */
+export const OWNER_SUBMISSIONS_URL = '/apps/mine';
 
 function appLabel(details: AppListingModerationNotificationDetails): string {
   return details.name ? `"${details.name}"` : 'Your app';

--- a/src/server/notifications/comment.notifications.ts
+++ b/src/server/notifications/comment.notifications.ts
@@ -754,9 +754,14 @@ export const commentNotifications = createNotificationProcessor({
       // first app-listing notification pushed to an owner UNCONDITIONALLY, so it cannot borrow
       // that assumption.
       //
-      // `/apps/mine` gates on `appBlocksAuthor` — the developer cohort a listing owner is in by
-      // construction — and is where every other owner-facing app-listing notification already
-      // points. Shared constant rather than a second literal, so a route rename moves both.
+      // `/apps/mine` gates on `isAppDeveloper` = `isModerator || opts.appBlocksAuthor`
+      // (`app-blocks-access.ts:52`). 🔴 That is a FLIPT COHORT FLAG, not a structural property of
+      // owning a listing: an owner outside the cohort gets `notFound` here too. This is therefore
+      // the BETTER destination, not a guaranteed one — it is where all four existing owner-facing
+      // app-listing notifications already point, so this type is not inventing a reachability
+      // assumption of its own, and the cohort it needs is the developer one rather than the
+      // narrower store-access one. Shared constant rather than a second literal, so a route
+      // rename moves all five.
       url: OWNER_SUBMISSIONS_URL,
     }),
     prepareQuery: ({ lastSent }) => `
@@ -772,10 +777,22 @@ export const commentNotifications = createNotificationProcessor({
           ) "details"
         FROM "CommentV2" c
         JOIN "User" u ON c."userId" = u.id
-        -- TOP-LEVEL comments only. A reply's own thread is keyed by its parent COMMENT, so it
-        -- carries no "appListingId" and never matches here — replies are already covered by
-        -- new-comment-reply / new-thread-response, which is precisely the overlap that would
-        -- otherwise double-notify.
+        -- TOP-LEVEL comments only. A reply's own thread is keyed by its parent COMMENT and carries
+        -- no "appListingId", so it never matches — replies stay with new-comment-reply /
+        -- new-thread-response.
+        --
+        -- 🔴 THIS PREDICATE IS BEHAVIOURALLY REDUNDANT, AND THAT IS DELIBERATE. The
+        -- app_listings join below is an INNER join on al."serial_id" = t."appListingId", and NULL
+        -- never equals anything, so a NULL "appListingId" is already excluded by the join itself:
+        -- removing this line produces BYTE-IDENTICAL result rows — executed against a real
+        -- Postgres 16 fixture by the #4184 audit, not reasoned about here.
+        --
+        -- So a mutant that deletes it SURVIVES because it is UNREACHABLE — no input can make the
+        -- guard change the answer — NOT because a test forgot to assert it. The distinction has
+        -- opposite remedies: an unasserted mutant wants a new assertion, an unreachable one wants
+        -- nothing (adding a test for it would be vacuous by construction). Kept as
+        -- defence-in-depth so the intent survives a future refactor that makes the join LEFT or
+        -- reorders it — at which point the redundancy ends and this becomes load-bearing.
         JOIN "Thread" t ON t.id = c."threadId" AND t."appListingId" IS NOT NULL
         JOIN "app_listings" al ON al."serial_id" = t."appListingId"
         -- Ownership chain for the onsite kind — see APP_LISTING_OWNER_SQL. LEFT, because an

--- a/src/server/notifications/comment.notifications.ts
+++ b/src/server/notifications/comment.notifications.ts
@@ -5,6 +5,7 @@ import {
   createNotificationProcessor,
   notBlockedBetween,
 } from '~/server/notifications/base.notifications';
+import { OWNER_SUBMISSIONS_URL } from '~/server/notifications/app-listing.notifications';
 import { QS } from '~/utils/qs';
 
 /**
@@ -37,6 +38,31 @@ export const appListingSlugJoin = (expr: string) =>
  * `ON DELETE SET NULL`, so a resolvable `appListingId` always has a slug).
  */
 export const appListingSlugResolved = (expr: string) => `(${expr} IS NULL OR al.slug IS NOT NULL)`;
+
+/**
+ * The canonical owner of an app listing, in SQL — the raw-SQL mirror of
+ * `resolveCanonicalListingOwner` in `~/server/services/blocks/app-access.service`.
+ *
+ * 🔴 OWNERSHIP IS NOT ONE COLUMN. It depends on the listing's KIND:
+ *   - `onsite`  → the owner is `OauthClient.userId`, reached as `AppBlock.app.userId`.
+ *                 `app_listings.user_id` is a DENORMALIZED COPY there and can go stale —
+ *                 `acceptTransfer` calls it "the denormalized follow-up, where a 0-count is a
+ *                 legitimate desync". It stays the FALLBACK, because a listing whose block
+ *                 carries a dangling `app_id` still needs an owner.
+ *   - anything else (incl. `offsite`) → the column IS the owner, unconditionally. An unknown
+ *                 kind falls through to the column deliberately, matching the service's
+ *                 fail-closed behaviour.
+ *
+ * Reading the column alone is latent-wrong rather than wrong today (measured: 0 of 21 onsite
+ * listings diverge), but 17 of 21 onsite listings are the shape that could — and a divergence
+ * would send the listing name, slug and a commenter's username to the PREVIOUS owner while the
+ * real one silently got nothing. That is a disclosure, not just a miss, so it is resolved here
+ * rather than commented around.
+ *
+ * Requires `al`, plus `LEFT JOIN "app_blocks" ab ON ab.id = al."app_block_id"` and
+ * `LEFT JOIN "OauthClient" oc ON oc.id = ab."app_id"` to be in scope.
+ */
+export const APP_LISTING_OWNER_SQL = `CASE WHEN al.kind = 'onsite' THEN COALESCE(oc."userId", al."user_id") ELSE al."user_id" END`;
 
 /**
  * Human-readable noun for a thread type in notification copy.
@@ -717,21 +743,26 @@ export const commentNotifications = createNotificationProcessor({
     priority: CommentNotificationPriority.EntityOwner,
     prepareMessage: ({ details }) => ({
       message: `${details.username} commented on your app listing: "${details.listingName}"`,
-      // Built by `threadUrlMap`, NOT by hand. It is the one place that knows an app listing is
-      // SLUG-addressed, and it shares `getListingDetailHref` with the store cards and the
-      // permalink page — so a route rename moves every caller at once. Hand-rolling
-      // `/apps/store-preview/${slug}` here is what would leave one of them behind.
-      url: threadUrlMap({
-        threadType: 'appListing',
-        threadParentId: null,
-        appListingSlug: details.appListingSlug,
-        commentId: details.commentId,
-      }),
+      // 🔴 THE OWNER'S SUBMISSIONS VIEW, **NOT** the public listing detail page — and this is a
+      // deliberate reversal of the issue's suggestion, for a measured reason.
+      //
+      // `/apps/store-preview/<slug>` gates on `hasAppsStoreAccess`, which rolls out to
+      // `moderators` OR `app-dev-testers` only. Measured against prod: of the 4 current listing
+      // owners, one is in NEITHER cohort — so a deep link 404s for the very person being
+      // notified. #4160's three types escaped this because their recipient had already commented
+      // in the thread and had therefore already proven they could open the page; this is the
+      // first app-listing notification pushed to an owner UNCONDITIONALLY, so it cannot borrow
+      // that assumption.
+      //
+      // `/apps/mine` gates on `appBlocksAuthor` — the developer cohort a listing owner is in by
+      // construction — and is where every other owner-facing app-listing notification already
+      // points. Shared constant rather than a second literal, so a route rename moves both.
+      url: OWNER_SUBMISSIONS_URL,
     }),
     prepareQuery: ({ lastSent }) => `
       WITH new_app_listing_comment AS (
         SELECT DISTINCT
-          al."user_id" "ownerId",
+          ${APP_LISTING_OWNER_SQL} "ownerId",
           JSONB_BUILD_OBJECT(
             'version', 2,
             'commentId', c.id,
@@ -747,7 +778,24 @@ export const commentNotifications = createNotificationProcessor({
         -- otherwise double-notify.
         JOIN "Thread" t ON t.id = c."threadId" AND t."appListingId" IS NOT NULL
         JOIN "app_listings" al ON al."serial_id" = t."appListingId"
-        WHERE al."user_id" > 0
+        -- Ownership chain for the onsite kind — see APP_LISTING_OWNER_SQL. LEFT, because an
+        -- offsite listing has no block and an onsite one may carry a dangling app_id; both must
+        -- still fall back to the column rather than drop the row.
+        LEFT JOIN "app_blocks" ab ON ab.id = al."app_block_id"
+        LEFT JOIN "OauthClient" oc ON oc.id = ab."app_id"
+        WHERE ${APP_LISTING_OWNER_SQL} > 0
+          -- Only APPROVED listings. The destination reads through
+          -- \`appListings.getAppDetail\`, which is approved-only, so a comment on a draft /
+          -- rejected / moderator-removed listing would notify its owner toward a NotFound.
+          -- Measured on prod: only 14 of 28 listings are approved. Mirrors the sibling raw-SQL
+          -- consumer (appListing.metrics.sql.ts).
+          AND al."status" = 'approved'
+          -- Never a shadow revision. \`beginListingRevision\` clones an approved parent as a
+          -- hidden draft; the clone freezes \`user_id\` at clone time and no ownership write
+          -- revisits it, so a shadow can name a STALE owner. Not reachable today (shadows are
+          -- draft, so the status filter already excludes them) — belt and braces, and it
+          -- matches every Prisma-side ownership read.
+          AND al."revision_of_id" IS NULL
           AND c."createdAt" > '${lastSent}'
           -- Two floors, for the reason new-post-comment carries them: this type has no cursor row
           -- until its first successful run, so it inherits the job's GLOBAL last-run — new Date(0)
@@ -757,8 +805,10 @@ export const commentNotifications = createNotificationProcessor({
           -- ~7 days however far the cursor drifted.
           AND c."createdAt" > NOW() - INTERVAL '7 days'
           -- A commenter never notifies themselves for their own listing.
-          AND c."userId" != al."user_id"
-          AND ${notBlockedBetween('al."user_id"', 'c."userId"')}
+          AND c."userId" != ${APP_LISTING_OWNER_SQL}
+          -- Argument ORDER is load-bearing: (recipient, actor). Swapped, the owner's Hide stops
+          -- suppressing and the commenter's starts — a silent inversion of who gets muted.
+          AND ${notBlockedBetween(APP_LISTING_OWNER_SQL, 'c."userId"')}
       )
       SELECT
         concat('new-comment-app-listing:owner:v2:', details->>'commentId') "key",

--- a/src/server/notifications/comment.notifications.ts
+++ b/src/server/notifications/comment.notifications.ts
@@ -711,6 +711,66 @@ export const commentNotifications = createNotificationProcessor({
         NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = "ownerId" AND type = 'new-post-comment');
     `,
   },
+  'new-app-listing-comment': {
+    displayName: 'New comments on your app listings',
+    category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.EntityOwner,
+    prepareMessage: ({ details }) => ({
+      message: `${details.username} commented on your app listing: "${details.listingName}"`,
+      // Built by `threadUrlMap`, NOT by hand. It is the one place that knows an app listing is
+      // SLUG-addressed, and it shares `getListingDetailHref` with the store cards and the
+      // permalink page — so a route rename moves every caller at once. Hand-rolling
+      // `/apps/store-preview/${slug}` here is what would leave one of them behind.
+      url: threadUrlMap({
+        threadType: 'appListing',
+        threadParentId: null,
+        appListingSlug: details.appListingSlug,
+        commentId: details.commentId,
+      }),
+    }),
+    prepareQuery: ({ lastSent }) => `
+      WITH new_app_listing_comment AS (
+        SELECT DISTINCT
+          al."user_id" "ownerId",
+          JSONB_BUILD_OBJECT(
+            'version', 2,
+            'commentId', c.id,
+            'appListingSlug', al.slug,
+            'listingName', al.name,
+            'username', u.username
+          ) "details"
+        FROM "CommentV2" c
+        JOIN "User" u ON c."userId" = u.id
+        -- TOP-LEVEL comments only. A reply's own thread is keyed by its parent COMMENT, so it
+        -- carries no "appListingId" and never matches here — replies are already covered by
+        -- new-comment-reply / new-thread-response, which is precisely the overlap that would
+        -- otherwise double-notify.
+        JOIN "Thread" t ON t.id = c."threadId" AND t."appListingId" IS NOT NULL
+        JOIN "app_listings" al ON al."serial_id" = t."appListingId"
+        WHERE al."user_id" > 0
+          AND c."createdAt" > '${lastSent}'
+          -- Two floors, for the reason new-post-comment carries them: this type has no cursor row
+          -- until its first successful run, so it inherits the job's GLOBAL last-run — new Date(0)
+          -- on a fresh DB, and stale by the outage duration after any send-notifications outage.
+          AND c."createdAt" > '2026-08-19'
+          -- The rolling window is the one that never goes stale: it bounds any first batch to
+          -- ~7 days however far the cursor drifted.
+          AND c."createdAt" > NOW() - INTERVAL '7 days'
+          -- A commenter never notifies themselves for their own listing.
+          AND c."userId" != al."user_id"
+          AND ${notBlockedBetween('al."user_id"', 'c."userId"')}
+      )
+      SELECT
+        concat('new-comment-app-listing:owner:v2:', details->>'commentId') "key",
+        ${commentDedupeKey('v2')} "dedupeKey",
+        "ownerId"    "userId",
+        'new-app-listing-comment' "type",
+        details
+      FROM new_app_listing_comment
+      WHERE
+        NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = "ownerId" AND type = 'new-app-listing-comment');
+    `,
+  },
   'new-article-comment': {
     displayName: 'New comments on your articles',
     category: NotificationCategory.Comment,


### PR DESCRIPTION
Closes #4166.

## The gap

#4160 made app-listing comment threads notify for **mentions**, **replies** and **thread responses**. The residue it deliberately left:

> A first top-level comment on a listing whose owner has never joined the thread produces no notification for that owner.

The owner-facing processors are per-entity SQL and none had an `appListing` branch — a **missing branch**, not an exclusion guard, so nothing needed removing.

## The change

`new-app-listing-comment`, a new notification type modelled on `new-post-comment`:

- Joins `app_listings` for the owner and the listing name.
- **Top-level comments only** (`t."appListingId" IS NOT NULL`). A reply's own thread is keyed by its parent *comment* and carries no `appListingId`, so replies stay with the reply processors and cannot double up.
- Skips self-comments and system-owned listings, both against the **resolved** owner.
- **Approved listings only**, and never a shadow revision — see below.
- **Resolves the owner kind-awarely**, not from the denormalized column — see below.
- Carries the same two lookback floors `new-post-comment` carries, for the same reason: the type has no cursor row until its first successful run, so it inherits the job's global last-run.
- Links to `/apps/mine`, **not** the public listing page — see below.

### 🔴 Three fixes from audit, all measured against production

**1. Approved-only.** Comments on `draft`, `rejected` and moderator-`removed` listings all emitted. `appListings.getAppDetail` is approved-only (`app-listings.router.ts:1416`), so those notifications pointed at a `NotFound`. **Only 14 of 28 prod listings are `approved`** — half the population, not an edge case. Now `al."status" = 'approved'`, mirroring the sibling raw-SQL consumer (`appListing.metrics.sql.ts:36,87`). `al."revision_of_id" IS NULL` added alongside: a shadow revision freezes `user_id` at clone time and can name a stale owner. Not reachable today (shadows are draft) — free to add.

**2. The destination, reversing the issue's suggestion.** #4166 asks for the `getListingDetailHref` deep link. **That link 404s for the people being notified.** `/apps/store-preview/<slug>` gates on `hasAppsStoreAccess`, which rolls out to `moderators` OR `app-dev-testers` only — and of the **4 current listing owners in prod, one is in neither cohort**.

#4160's three types escaped this because their recipient had already commented in the thread, and had therefore already proven they could open the page. **This is the first app-listing notification pushed to an owner unconditionally**, so it cannot borrow that assumption.

`/apps/mine` gates on `appBlocksAuthor` — the developer cohort a listing owner is in by construction — and is where all four existing owner-facing app-listing notifications already point (`app-listing.notifications.ts:35`). That constant is now **exported and shared** rather than duplicated, so a route rename moves all five. The trade-off is losing the comment highlight: a link the owner can open beats a more precise one they cannot.

**3. Kind-aware ownership.** The owner was read from `al."user_id"` alone. `app-access.service.ts:222-272` carries a 🔴 header — *"Ownership is not one column"*: for `kind='onsite'` the canonical owner is `AppBlock.app.userId`, with the column only a fallback that `acceptTransfer` itself calls *"the denormalized follow-up, where a 0-count is a legitimate desync"*. Measured: **0 of 21 onsite listings diverge today**, so this is latent — but 17 of 21 onsite listings are the shape that could, and a divergence would send the listing name, slug and a commenter's username to the **previous** owner while silently dropping it for the real one. That is a disclosure, not just a miss, so it is resolved rather than commented around:

```sql
CASE WHEN al.kind = 'onsite' THEN COALESCE(oc."userId", al."user_id") ELSE al."user_id" END
```

with `LEFT JOIN`s (never `INNER` — an offsite listing has no block and must still notify).

### Dedupe

It emits the shared `comment:v2:<id>` key and runs in the **EntityOwner** batch, behind Mention / DirectResponse / ThreadResponse. So a comment that is both the first on a listing **and** a mention of the owner yields exactly one notification — the mention, the more specific of the two.

> [!NOTE]
> **One deliberate deviation from the issue text, flagged for your call.** The issue asks for "its own entry in the dedupe-priority ordering". I used the existing `CommentNotificationPriority.EntityOwner` rather than adding a fifth distinct rank, because that is what every other owner processor uses (`new-post-comment`, `new-image-comment`, `new-article-comment`) and it already satisfies the functional requirement — losing the key race to all three types #4160 enabled. A distinct rank would add a fifth sequential batch in `send-notifications` for one processor and buy nothing, since there is no other `appListing` claimant in the EntityOwner batch to tie with. Happy to change it if you want the literal reading.

### Schema

**No schema change and no migration.** `UserNotificationSettings` is `{id, userId, type, disabledAt}` with `@@unique([userId, type])`; `type` is free text and rows are written as **user opt-outs**, not seeded definitions. The settings list is derived from the processor registry by `getNotificationTypes()` (`utils.notifications.ts:101-113`), so registering the processor is what puts the toggle on screen. Nothing needs manual application in any environment.

## Tests — 32, red→green matrix

Base column measured by removing the new processor block from `comment.notifications.ts` and running the same suite.

| | at base | at HEAD |
|---|---|---|
| **tests of the new type** | **RED** | green |
| invariant guards (#4160 behaviour, priority ordering) | green | green |
| **total after the audit fix round** | — | **32 green** |

**Labelled honestly.** The two `INVARIANT GUARD:` describe blocks pin behaviour this PR does **not** change — #4160's mention/reply/thread-response rendering, and the pre-existing `CommentNotificationPriority` ordering. They are green at base and stay green, so they cannot demonstrate that anything here works. They were previously labelled `REGRESSION:`, which overclaimed; relabelled this round.

The dedupe test the issue asks for — *"owner does not receive a duplicate when the same comment also mentions them"* — is genuinely red→green. It could not have been on the pre-#4160 tree, where mentions on app-listing threads were excluded outright and there was no competing notification to dedupe against; it would have passed for the wrong reason.

It is asserted as a **relationship**, not two independently-spelled literals: the key this processor emits for a V2 row must be *identical* to the one `new-mention` emits, compared on the evaluated key rather than the SQL text (the two use different expressions — `commentDedupeKey('v2')` vs `commentDedupeKeyByVersion`). A positive control confirms the evaluator can return differing values.

### 🔴 The SQL is now pinned by a WHOLE-STATEMENT snapshot

Audit found that fragment assertions let **three semantic mutants walk a fully green 295-test suite**, each proven reachable by executing the mutant SQL:

| mutant | effect | why fragments missed it |
|---|---|---|
| append `AND 1 = 0` | **7 rows → 0. The feature is dead, permanently and silently.** | every fragment still present |
| `AND (c."userId" != <owner> OR TRUE)` | owner notified for their own comment | the guard text is still there, just inert |
| `notBlockedBetween` args swapped | the *commenter's* Hide suppresses instead of the owner's | valid SQL, same tokens |

Fixed by pinning the **whole normalised statement** with `toMatchInlineSnapshot`, the instrument the sibling file already uses for #4160's three processors (`comment.appListing-notifications.test.ts:417,488,615`) under a comment reading *"A fragment assertion is satisfied by semantically inverted SQL … a full snapshot is not."* The `notBlockedBetween` argument **order** is additionally pinned by generating the expected clause from the helper, with a positive control proving the helper is order-sensitive.

### The settings-toggle assertion was vacuous

`expect(…defaultDisabled).toBeFalsy()` asserted a **removed concept** — it can only ever read `undefined` (`notification-settings-polarity.test.ts:204` actively asserts no source contains the field), so it passed vacuously. The real lever is **`toggleable`**, and a `toggleable: false` mutant survived the entire suite while the type vanished from both the settings UI and the bulk-toggle list.

Now asserted against the **output** of `getNotificationTypes` — `notificationCategoryTypes['Comment']` must contain the type, it must be in `notificationTypes`, and it must not be opt-in — with a positive control that a bogus type is absent. A note was added at `comment.post-owner.test.ts:77`, where the pattern was copied from, so it does not spread further.

## Mutation testing — 14 mutants, all killed (re-run after the fix round)

A fix round resets the gate, so the whole battery was re-run. Controls: unmutated → SURVIVED (32 passed), broken-displayName → KILLED. A full-count assertion turns a non-compiling mutant into a loud `HARNESS-ERROR` rather than a false SURVIVED.

| mutant | killed by |
|---|---|
| **S1 append `AND 1 = 0`** (feature dead) | whole-statement snapshot |
| **S2 self-notify guard inert via `OR TRUE`** | whole-statement snapshot |
| **S3 `notBlockedBetween` args swapped** | snapshot **+** the argument-order test |
| **S4 `toggleable: false`** (vanishes from settings) | the new `notificationCategoryTypes` test |
| S5 drop approved-only filter | approved-only test + snapshot |
| S6 `= 'approved'` → `<> 'removed'` | approved-only test + snapshot |
| S7 drop shadow-revision guard | shadow-revision test + snapshot |
| S8 owner collapses to the denormalized column | kind-aware test + snapshot |
| S9 `COALESCE` operands swapped (column wins) | kind-aware test + snapshot |
| S10 deep link restored | 3 URL tests, incl. the explicit no-deep-link guard |
| S11 launch floor → 2099 (disabled forever) | floor test (now extracted from SQL) + snapshot |
| S12 drop top-level-only restriction | top-level test + snapshot |
| S13 priority → Mention | priority test |
| S14 `app_blocks` LEFT → INNER (offsite dropped) | kind-aware test + snapshot |

S1–S4 are the four the audit found walking; all now die. The date-floor guard was also fixed — it compared a **duplicated literal** rather than the value in the SQL, so it could not fail if the floor moved; it now extracts the floor from the generated statement, which is what lets S11 die.

## A seam catch worth flagging

The existing `comment.dedupe-key.test.ts` auto-enumerates every processor that claims the dedupe key and asserts each renders a URL. The new type fell to that suite's `default:` details shape (a `model3d` payload), carried no slug, and rendered no URL — caught only when the suites were run **together**, not in isolation. Fixed by adding the type's real details shape to that switch, which is the intended extension point. One line, included here.

## Verification

- `pnpm typecheck` → **0 type errors in 83s**
- `vitest run src/server/notifications` → **295 passed / 18 files** on this branch; **328 passed / 19 files** on the combined tree with #4167
- Prettier clean on all changed files

## 🔴 Rollback is NOT a `git revert`

`getNotificationMessage` resolves at **render** time (`NotificationList.tsx:64-69`), not at write time. So reverting this PR after even one notification has been delivered leaves those rows in the database with **no processor to render them**: they display as nothing while still counting toward the unread badge. The repo already carries this scar (`collection.notifications.ts:50-56`).

**Correct rollback: delete `prepareQuery`, keep `prepareMessage`.** That stops new notifications immediately while every delivered row still renders. Only remove `prepareMessage` once the delivered rows have aged out.

## 🔴 No feature flag

Unlike the rest of the W13 App Blocks family, this processor carries **no flag** — it begins emitting on merge. That is much less pointed now that the link goes to `/apps/mine` (which gates on `appBlocksAuthor`, a cohort every listing owner is in) rather than the public detail page, but it is still true: the first app-listing comment after merge notifies its owner, with no staged rollout. Worth a deliberate yes rather than a default.

## 🔴 Not verified — stated plainly, please merge knowing this

**The SQL has never been executed against a database.** Not in a test, not by hand. Every assertion in the 26 tests is on the **generated query text** and the **rendered message** — `toContain` against a string. No row has ever come back from this query.

What *is* confirmed: the identifiers, against `schema.full.prisma` — `@@map("app_listings")`, `serialId @map("serial_id")`, `userId @map("user_id")`, `slug`/`name` unmapped, plus an existing `app_listings_user_idx` on the owner column. And the same `LEFT JOIN "app_listings" al ON al."serial_id" = …` already ships in #4160, so the join shape has run in production.

What is **not** confirmed is that the query **returns the rows intended**. A predicate that is syntactically valid and semantically wrong — a join that silently matches nothing, a `WHERE` that excludes every real row — produces **zero notifications and a fully green suite**. String assertions cannot distinguish "correct query" from "query that returns nothing".

The cheapest closing check: run the generated SQL read-only against a listing that has a top-level comment from a non-owner, and confirm it returns exactly one row for the owner.

Interpretation note: "first top-level comment" in the issue describes the *symptom scenario*. This notifies on every top-level comment, as every other entity-owner processor does; dedupe handles the overlap.
