### PR TITLE
fix(comments): resolve /comments/v2/<id> for app-listing threads (#4167)

### DIFF
--- a/src/pages/comments/v2/[id].tsx
+++ b/src/pages/comments/v2/[id].tsx
@@ -1,90 +1,22 @@
 import { dbRead } from '~/server/db/client';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { PageLoader } from '~/components/PageLoader/PageLoader';
-import { buildCommentPermalink } from '~/server/utils/comment-permalink';
+import { buildCommentPermalink, commentPermalinkSelect } from '~/server/utils/comment-permalink';
 
 export const getServerSideProps = createServerSideProps({
   useSSG: true,
   useSession: true,
   resolver: async ({ ctx }) => {
     const { id } = ctx.params as { id: string };
-    const select = {
-      image: {
-        select: {
-          id: true,
-        },
-      },
-      post: {
-        select: {
-          id: true,
-        },
-      },
-      review: {
-        select: {
-          id: true,
-        },
-      },
-      model: {
-        select: {
-          id: true,
-        },
-      },
-      article: {
-        select: {
-          id: true,
-        },
-      },
-      bounty: {
-        select: {
-          id: true,
-        },
-      },
-      bountyEntry: {
-        select: {
-          id: true,
-        },
-      },
-      challenge: {
-        select: {
-          id: true,
-        },
-      },
-      comicChapter: {
-        select: {
-          projectId: true,
-        },
-      },
-      // The one SLUG-addressed thread parent. `appListingId` is `app_listings.serial_id`, an
-      // integer surrogate that appears nowhere in the URL, so the slug is what has to be
-      // selected here — see `buildCommentPermalink`.
-      appListing: {
-        select: {
-          slug: true,
-        },
-      },
-    };
+
+    // The select lives beside the resolver that reads it (`comment-permalink.ts`) rather than
+    // here, so the two cannot drift: the payload type is derived FROM this select, and the
+    // resolver's parameter type is derived from that payload. Narrow the select and the resolver
+    // stops compiling — which is the only thing that catches a select-correctness bug, since a
+    // mocked `dbRead` would just encode the same mistake in the fake.
     const commentV2 = await dbRead.commentV2.findUnique({
       where: { id: Number(id) },
-      select: {
-        id: true,
-        thread: {
-          select: {
-            id: true,
-            rootThread: {
-              select: {
-                id: true,
-                ...select,
-              },
-            },
-            comment: {
-              select: {
-                id: true,
-              },
-            },
-            ...select,
-          },
-        },
-      },
+      select: commentPermalinkSelect,
     });
 
     if (!commentV2) {

--- a/src/pages/comments/v2/[id].tsx
+++ b/src/pages/comments/v2/[id].tsx
@@ -1,7 +1,7 @@
 import { dbRead } from '~/server/db/client';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { PageLoader } from '~/components/PageLoader/PageLoader';
-import { threadUrlMap } from '~/server/notifications/comment.notifications';
+import { buildCommentPermalink } from '~/server/utils/comment-permalink';
 
 export const getServerSideProps = createServerSideProps({
   useSSG: true,
@@ -54,6 +54,14 @@ export const getServerSideProps = createServerSideProps({
           projectId: true,
         },
       },
+      // The one SLUG-addressed thread parent. `appListingId` is `app_listings.serial_id`, an
+      // integer surrogate that appears nowhere in the URL, so the slug is what has to be
+      // selected here — see `buildCommentPermalink`.
+      appListing: {
+        select: {
+          slug: true,
+        },
+      },
     };
     const commentV2 = await dbRead.commentV2.findUnique({
       where: { id: Number(id) },
@@ -83,64 +91,7 @@ export const getServerSideProps = createServerSideProps({
       return { notFound: true };
     }
 
-    const { thread } = commentV2;
-    const getThreadDetails = (thread: any) => {
-      if (thread.post) {
-        return { threadType: 'post', threadParentId: thread.post.id };
-      }
-      if (thread.review) {
-        return { threadType: 'review', threadParentId: thread.review.id };
-      }
-      if (thread.model) {
-        return { threadType: 'model', threadParentId: thread.model.id };
-      }
-      if (thread.article) {
-        return { threadType: 'article', threadParentId: thread.article.id };
-      }
-      if (thread.bounty) {
-        return { threadType: 'bounty', threadParentId: thread.bounty.id };
-      }
-      if (thread.bountyEntry) {
-        return {
-          threadType: 'bountyEntry',
-          threadParentId: thread.bountyEntry.id,
-        };
-      }
-      if (thread.challenge) {
-        return { threadType: 'challenge', threadParentId: thread.challenge.id };
-      }
-      if (thread.comicChapter) {
-        return { threadType: 'comicChapter', threadParentId: thread.comicChapter.projectId };
-      }
-      if (thread.image) {
-        return { threadType: 'image', threadParentId: thread.image.id };
-      }
-
-      return { threadType: null, threadParentId: null };
-    };
-
-    let threadData: { threadType: string | null; threadParentId: number | null } =
-      getThreadDetails(thread);
-
-    if ((!threadData.threadType || !threadData.threadParentId) && thread.rootThread) {
-      threadData = getThreadDetails(thread.rootThread);
-    }
-
-    if (!threadData.threadType || !threadData.threadParentId) {
-      return { notFound: true };
-    }
-
-    const url = threadUrlMap({
-      threadParentId: threadData.threadParentId,
-      threadType: threadData.threadType,
-      threadId: thread.id,
-      commentId: commentV2.id,
-      // Always pin the target comment as the thread root so it renders standalone via
-      // RootThreadProvider's activeComment path. Sidesteps cursor-paginated thread fetches
-      // (target may be on page N) and works uniformly for root and reply comments.
-      commentParentType: 'comment',
-      commentParentId: commentV2.id,
-    });
+    const url = buildCommentPermalink({ thread: commentV2.thread, commentId: commentV2.id });
 
     if (url) {
       return {

--- a/src/server/utils/__tests__/comment-permalink.ssr.test.ts
+++ b/src/server/utils/__tests__/comment-permalink.ssr.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
 
 /**
  * `/comments/v2/<id>` — the SSR WIRING, as distinct from the resolution logic.
@@ -25,12 +26,23 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
  * is optional, so omission satisfies it. The `Pick` is the half that catches omission.)
  */
 
-const findUnique = vi.fn();
-
-vi.mock('~/server/db/client', () => ({
-  dbRead: { commentV2: { findUnique } },
-  dbWrite: {},
-}));
+/**
+ * 🔴 The CANONICAL db mock — this file must NOT register the db-client specifier itself.
+ *
+ * The shared-module mock is registered once in `src/__tests__/setup.ts` and reset between files;
+ * a direct per-file mock is rejected by `no-direct-shared-module-mock.test.ts`. The reason is not
+ * style: under `--no-isolate` a module instance is per WORKER, so an ordinary source module that
+ * imports `~/server/db/client` captures whichever mock was installed when it was FIRST evaluated
+ * — and every later file silently reuses it. A per-file mock poisons files that never mocked
+ * anything. See docs/testing/shared-module-mocks.md.
+ *
+ * A test file therefore declares BEHAVIOUR only; it never registers the specifier.
+ *
+ * (`no-direct-shared-module-mock.test.ts` detects violations by REGEX over the file text, so the
+ * offending call is described here rather than spelled — writing it even inside a comment trips
+ * the guard. Found the hard way.)
+ */
+const findUnique = dbMock.dbRead.commentV2.findUnique;
 
 // The page's `createServerSideProps` wrapper resolves a session; stub it so the test exercises the
 // resolver rather than auth.

--- a/src/server/utils/__tests__/comment-permalink.ssr.test.ts
+++ b/src/server/utils/__tests__/comment-permalink.ssr.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * `/comments/v2/<id>` — the SSR WIRING, as distinct from the resolution logic.
+ *
+ * `comment-permalink.test.ts` proves the resolver builds the right URL. This file proves the page
+ * actually TURNS that URL into a 302, and a null into a 404 — the seam between them, which no
+ * amount of resolver testing reaches. The two were verified in isolation and the seam belonged to
+ * neither.
+ *
+ * 🔴 WHAT THIS FILE CANNOT DO, STATED SO NOBODY MISTAKES IT FOR COVERAGE IT LACKS.
+ *
+ * `dbRead` is mocked, so this cannot tell you whether the Prisma `select` is CORRECT. The mock's
+ * return value is hand-written by the same author as the code, so a wrong select and a wrong mock
+ * are wrong TOGETHER and the suite stays green — the fake encodes the same belief as the code.
+ * That is a real trap, not a hypothetical: it is why a select-correctness gap must be closed by a
+ * TYPE and not by a test.
+ *
+ * The type is `ThreadEntitySource` in `comment-permalink.ts`: a `Pick` from
+ * `Prisma.CommentV2GetPayload<{ select: typeof commentPermalinkSelect }>`, so dropping a relation
+ * from the select, or narrowing `rootThread`'s select, fails `pnpm typecheck` rather than
+ * producing a green suite and a 404. This file covers the wiring; the type covers the shape.
+ *
+ * (Note `satisfies Prisma.ThreadSelect` alone would NOT be enough — every field of a select type
+ * is optional, so omission satisfies it. The `Pick` is the half that catches omission.)
+ */
+
+const findUnique = vi.fn();
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { commentV2: { findUnique } },
+  dbWrite: {},
+}));
+
+// The page's `createServerSideProps` wrapper resolves a session; stub it so the test exercises the
+// resolver rather than auth.
+vi.mock('~/server/utils/get-server-auth-session', () => ({
+  getServerAuthSession: vi.fn(async () => null),
+}));
+
+const COMMENT_ID = 8123;
+const THREAD_ID = 4471;
+const PARENT_ID = 3310;
+const SLUG = 'pixel-forge';
+const QUERY = `highlight=${COMMENT_ID}&commentParentType=comment&commentParentId=${COMMENT_ID}&threadId=${THREAD_ID}`;
+
+const NO_ENTITIES = {
+  image: null,
+  post: null,
+  review: null,
+  model: null,
+  article: null,
+  bounty: null,
+  bountyEntry: null,
+  challenge: null,
+  comicChapter: null,
+  model3d: null,
+  appListing: null,
+};
+
+const row = (entity: Record<string, unknown>) => ({
+  id: COMMENT_ID,
+  thread: { id: THREAD_ID, rootThread: null, comment: null, ...NO_ENTITIES, ...entity },
+});
+
+const run = async () => {
+  const { getServerSideProps } = await import('~/pages/comments/v2/[id]');
+  return (await (getServerSideProps as any)({
+    params: { id: String(COMMENT_ID) },
+    req: { url: `/comments/v2/${COMMENT_ID}`, headers: {}, cookies: {} },
+    res: { setHeader: vi.fn(), getHeader: vi.fn() },
+    query: {},
+    resolvedUrl: `/comments/v2/${COMMENT_ID}`,
+  })) as any;
+};
+
+beforeEach(() => {
+  findUnique.mockReset();
+});
+
+describe('/comments/v2/<id> — getServerSideProps wiring', () => {
+  it('turns a resolved app-listing permalink into a 302 to the WHOLE expected url', async () => {
+    findUnique.mockResolvedValue(row({ appListing: { slug: SLUG } }));
+    const result = await run();
+    expect(result).toEqual({
+      redirect: { destination: `/apps/store-preview/${SLUG}?${QUERY}`, permanent: false },
+    });
+  });
+
+  it('is a TEMPORARY redirect — a 301 would be cached by browsers and CDNs forever', async () => {
+    // If a listing is ever re-slugged, a permanent redirect pins the old target in caches this
+    // codebase cannot purge. Pinned separately because `permanent: true` is a one-word change that
+    // looks like a tidy-up.
+    findUnique.mockResolvedValue(row({ appListing: { slug: SLUG } }));
+    // 🔴 WHOLE OBJECT, never `.redirect.permanent`. Drilling into the result throws a TypeError
+    // when a mutant returns `notFound` instead — and a mutant that dies on a TypeError is a FALSE
+    // KILL: it would have "died" against a test asserting something else entirely. `toEqual` on
+    // the whole result fails with a readable diff instead.
+    expect(await run()).toEqual({
+      redirect: { destination: `/apps/store-preview/${SLUG}?${QUERY}`, permanent: false },
+    });
+  });
+
+  it('REGRESSION: an id-addressed entity still redirects unchanged', async () => {
+    findUnique.mockResolvedValue(row({ post: { id: PARENT_ID } }));
+    expect(await run()).toEqual({
+      redirect: { destination: `/posts/${PARENT_ID}?${QUERY}`, permanent: false },
+    });
+  });
+
+  it('resolves the 3D-model entity that used to 404 here', async () => {
+    findUnique.mockResolvedValue(row({ model3d: { id: PARENT_ID } }));
+    expect(await run()).toEqual({
+      redirect: { destination: `/3d-models/${PARENT_ID}?${QUERY}`, permanent: false },
+    });
+  });
+
+  it('a REPLY resolves through its root thread, and keeps its OWN threadId', async () => {
+    // Exercises the page passing `commentV2.thread` (not the root) into the resolver: the entity
+    // comes from the root, but `threadId` in the query string must stay the REPLY's own thread.
+    // Without this case, a mutant that hands the resolver `rootThread` directly is unreachable
+    // and scores a false SURVIVED — which is exactly what happened before this test existed.
+    const ROOT_THREAD_ID = 6612;
+    findUnique.mockResolvedValue({
+      id: COMMENT_ID,
+      thread: {
+        id: THREAD_ID,
+        comment: { id: 5567 },
+        rootThread: { id: ROOT_THREAD_ID, ...NO_ENTITIES, post: { id: PARENT_ID } },
+        ...NO_ENTITIES,
+      },
+    });
+    expect(await run()).toEqual({
+      redirect: { destination: `/posts/${PARENT_ID}?${QUERY}`, permanent: false },
+    });
+  });
+
+  it('NEGATIVE: a nonexistent comment id still 404s', async () => {
+    findUnique.mockResolvedValue(null);
+    expect(await run()).toEqual({ notFound: true });
+  });
+
+  it('NEGATIVE: a comment on an unaddressable thread still 404s', async () => {
+    findUnique.mockResolvedValue(row({}));
+    expect(await run()).toEqual({ notFound: true });
+  });
+
+  it('NEGATIVE: an app listing whose slug did not resolve 404s rather than linking to undefined', async () => {
+    findUnique.mockResolvedValue(row({ appListing: { slug: null } }));
+    expect(await run()).toEqual({ notFound: true });
+  });
+
+  it('queries by the numeric id from the route param', async () => {
+    // `Number(id)` — a string id would silently miss every row and read as "comment not found".
+    findUnique.mockResolvedValue(null);
+    await run();
+    expect(findUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { id: COMMENT_ID } }));
+  });
+
+  it('positive control: the mock is actually consulted (it is not answering from nothing)', async () => {
+    // A reassuring pass above would be indistinguishable from a page that never queried at all.
+    findUnique.mockResolvedValue(row({ post: { id: PARENT_ID } }));
+    await run();
+    expect(findUnique).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/utils/__tests__/comment-permalink.test.ts
+++ b/src/server/utils/__tests__/comment-permalink.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { buildCommentPermalink, resolveThreadTarget } from '~/server/utils/comment-permalink';
+import {
+  buildCommentPermalink,
+  resolveThreadTarget,
+  threadEntitySelect,
+} from '~/server/utils/comment-permalink';
+import type { PermalinkThread, ThreadEntitySource } from '~/server/utils/comment-permalink';
+import { commentConnectorSchema } from '~/server/schema/commentv2.schema';
 
 /**
  * `/comments/v2/<id>` — the "copy comment link" permalink.
@@ -34,21 +40,64 @@ const SLUG = 'pixel-forge';
 /** The query string every `threadUrlMap` entry appends, spelled out rather than recomputed. */
 const QUERY = `highlight=${COMMENT_ID}&commentParentType=comment&commentParentId=${COMMENT_ID}&threadId=${THREAD_ID}`;
 
-const thread = (entity: Record<string, unknown>, over: Record<string, unknown> = {}) => ({
-  id: THREAD_ID,
-  ...entity,
-  ...over,
-});
+/**
+ * 🔴 EVERY entity key, explicitly null — CONTRACT FIDELITY, not boilerplate.
+ *
+ * `ThreadEntitySource` is `Pick`ed from the real Prisma payload, so a fixture must carry the same
+ * shape the database actually returns. A partial fixture would be a fake that encodes a DIFFERENT
+ * shape from production, which is precisely how a select-correctness bug hides behind a green
+ * suite. Building fixtures from this base means a relation added to (or dropped from) the select
+ * breaks these tests at COMPILE time rather than passing vacuously.
+ */
+const NO_ENTITIES = {
+  image: null,
+  post: null,
+  review: null,
+  model: null,
+  article: null,
+  bounty: null,
+  bountyEntry: null,
+  challenge: null,
+  comicChapter: null,
+  model3d: null,
+  appListing: null,
+} satisfies ThreadEntitySource;
 
-const link = (t: any) => buildCommentPermalink({ thread: t, commentId: COMMENT_ID });
+type ThreadFixture = PermalinkThread;
+
+const thread = (entity: Partial<ThreadEntitySource>, over: Record<string, unknown> = {}) =>
+  ({
+    id: THREAD_ID,
+    rootThread: null,
+    comment: null,
+    ...NO_ENTITIES,
+    ...entity,
+    ...over,
+  } as ThreadFixture);
+
+const rootThread = (entity: Partial<ThreadEntitySource>) =>
+  ({ id: 6612, ...NO_ENTITIES, ...entity } as ThreadFixture['rootThread']);
+
+const link = (t: ThreadFixture | null | undefined) =>
+  buildCommentPermalink({ thread: t, commentId: COMMENT_ID });
 
 /**
- * The nine entity relations the page selects, each with the URL it must keep producing.
+ * Every ID-ADDRESSED entity relation the page resolves, with the URL it must keep producing.
+ *
+ * 🔴 THIS TABLE USED TO CALL ITSELF "every already-handled entity type" WITH NINE ROWS, and that
+ * false claim is exactly what hid a live bug: `Thread` carries fifteen entity columns, and
+ * `model3d` — which has a working `/3d-models/<id>` arm in `threadUrlMap` and resolves in the
+ * notification SQL — was simply missing from the page, so every 3D-model comment permalink 404'd.
+ * A count that implies completeness without enumerating what it excludes is a claim, not a guard.
+ *
+ * The intentional exclusions are therefore enumerated explicitly in
+ * `INTENTIONALLY_UNADDRESSABLE` below, and a test asserts this table plus that list accounts for
+ * the whole set — so the next added relation forces a decision instead of silently 404ing.
  *
  * `comicChapter` is keyed on `projectId` rather than `id` — a real asymmetry the resolver has to
  * preserve, and one a careless rewrite flattens to `.id` (which would be `undefined` → a 404).
  */
-const HANDLED: Array<[string, Record<string, unknown>, string]> = [
+const HANDLED: Array<[string, Partial<ThreadEntitySource>, string]> = [
   ['post', { post: { id: PARENT_ID } }, `/posts/${PARENT_ID}?${QUERY}`],
   ['review', { review: { id: PARENT_ID } }, `/reviews/${PARENT_ID}?${QUERY}`],
   ['model', { model: { id: PARENT_ID } }, `/models/${PARENT_ID}?dialog=commentThread&${QUERY}`],
@@ -58,7 +107,19 @@ const HANDLED: Array<[string, Record<string, unknown>, string]> = [
   ['challenge', { challenge: { id: PARENT_ID } }, `/challenges/${PARENT_ID}?${QUERY}`],
   ['comicChapter', { comicChapter: { projectId: PARENT_ID } }, `/comics/${PARENT_ID}?${QUERY}`],
   ['image', { image: { id: PARENT_ID } }, `/images/${PARENT_ID}?${QUERY}`],
+  ['model3d', { model3d: { id: PARENT_ID } }, `/3d-models/${PARENT_ID}?${QUERY}`],
 ];
+
+/**
+ * `Thread` relations this page deliberately does NOT resolve, and why. Listed so the set is
+ * accounted for rather than implied by a row count.
+ *
+ * `question` / `answer` are commented out in `threadUrlMap` (the Q&A surface is retired);
+ * `clubPost` and `model3dReview` have no public route at all. All four fall to the `comment`
+ * fallback in the notification SQL and are unaddressable BY DESIGN — unlike `model3d`, which was
+ * addressable everywhere except here.
+ */
+const INTENTIONALLY_UNADDRESSABLE = ['question', 'answer', 'clubPost', 'model3dReview'] as const;
 
 describe('buildCommentPermalink — the appListing branch (the fix)', () => {
   it('POSITIVE: an app-listing comment resolves to the listing detail URL, highlighted', () => {
@@ -72,8 +133,11 @@ describe('buildCommentPermalink — the appListing branch (the fix)', () => {
     // A reply's own thread is keyed by its parent COMMENT, so it carries no entity; the entity
     // lives on the root. This is the path a "copy link" on a nested reply actually takes.
     const replyThread = thread(
-      { comment: { id: 5567 } },
-      { rootThread: { id: 6612, appListing: { slug: SLUG } } }
+      {},
+      {
+        comment: { id: 5567 },
+        rootThread: rootThread({ appListing: { slug: SLUG } }),
+      }
     );
     expect(link(replyThread)).toBe(`/apps/store-preview/${SLUG}?${QUERY}`);
   });
@@ -109,7 +173,7 @@ describe('buildCommentPermalink — REGRESSION: every already-handled entity typ
     (_name, entity, expected) => {
       const replyThread = thread(
         { comment: { id: 5567 } },
-        { rootThread: { id: 6612, ...entity } }
+        { comment: { id: 5567 }, rootThread: rootThread(entity) }
       );
       expect(link(replyThread)).toBe(expected);
     }
@@ -121,6 +185,46 @@ describe('buildCommentPermalink — REGRESSION: every already-handled entity typ
     expect(link(thread({ post: { id: PARENT_ID }, appListing: { slug: SLUG } }))).toBe(
       `/posts/${PARENT_ID}?${QUERY}`
     );
+  });
+});
+
+describe('the entity set is ACCOUNTED FOR, not implied by a row count', () => {
+  it('every commentable entity is either resolved here or explicitly excluded', () => {
+    // 🔴 THE GUARD THAT WOULD HAVE CAUGHT THE model3d BUG. The old table called itself "every
+    // already-handled entity type" with nine rows against a fifteen-value enum, and nothing
+    // reconciled the two — so `model3d` was addressable in `threadUrlMap` and in the notification
+    // SQL, and 404'd here, with no test able to notice.
+    //
+    // Anchored to the REAL enum (`commentConnectorSchema.entityType`), not to a list retyped
+    // here, so adding a commentable entity forces a decision: resolve it, or declare it
+    // unaddressable. Either way it can no longer 404 silently.
+    const entityTypes = commentConnectorSchema.shape.entityType.options as readonly string[];
+
+    const resolved = HANDLED.map(([name]) => name).concat('appListing');
+    const excluded: readonly string[] = INTENTIONALLY_UNADDRESSABLE;
+    // `comment` is the thread-of-a-comment discriminator, not a parent entity with a page.
+    const accounted = new Set([...resolved, ...excluded, 'comment']);
+
+    const unaccounted = entityTypes.filter((t) => !accounted.has(t));
+    expect(unaccounted, `unaccounted commentable entities: ${unaccounted.join(', ')}`).toEqual([]);
+  });
+
+  it('positive control: the enum really is the fifteen-value set this reconciles against', () => {
+    // Without this, an empty/renamed enum would make the reconciliation above vacuously pass.
+    const entityTypes = commentConnectorSchema.shape.entityType.options as readonly string[];
+    expect(entityTypes.length).toBeGreaterThanOrEqual(15);
+    expect(entityTypes).toContain('model3d');
+    expect(entityTypes).toContain('appListing');
+  });
+
+  it('the select and the resolver cover the same relations', () => {
+    // The select is the query; the table is what the resolver claims to handle. They must agree,
+    // or a relation is fetched and ignored (dead weight) or read and never fetched (a 404).
+    const selectKeys = Object.keys(threadEntitySelect).sort();
+    const handledKeys = HANDLED.map(([name]) => name)
+      .concat('appListing')
+      .sort();
+    expect(selectKeys).toEqual(handledKeys);
   });
 });
 
@@ -139,19 +243,57 @@ describe('buildCommentPermalink — negative controls (it must not answer for ev
   it('an entity type the URL map has never addressed still fails closed', () => {
     // `clubPost` / `model3dReview` are real Thread columns with no route. Resolving them would be
     // the "answers for everything" failure.
-    expect(link(thread({ clubPost: { id: PARENT_ID } }))).toBeNull();
-    expect(link(thread({ model3dReview: { id: PARENT_ID } }))).toBeNull();
+    // Cast: these are real `Thread` columns but are deliberately NOT in the select, so they are
+    // absent from `ThreadEntitySource` by design. The cast is the point — it shows the type
+    // system already refuses to hand the resolver a relation the page never asked for.
+    for (const key of INTENTIONALLY_UNADDRESSABLE) {
+      expect(link(thread({ [key]: { id: PARENT_ID } } as Partial<ThreadEntitySource>))).toBeNull();
+    }
   });
 
   it('an id-addressed entity with a missing id fails closed rather than linking to /posts/null', () => {
     for (const id of [undefined, null, 0]) {
-      expect(link(thread({ post: { id } }))).toBeNull();
+      expect(link(thread({ post: { id } as unknown as { id: number } }))).toBeNull();
     }
   });
 
   it('a root thread that is itself unaddressable does not rescue an unaddressable thread', () => {
-    const replyThread = thread({ comment: { id: 5567 } }, { rootThread: { id: 6612 } });
+    const replyThread = thread({}, { comment: { id: 5567 }, rootThread: rootThread({}) });
     expect(link(replyThread)).toBeNull();
+  });
+});
+
+describe('the resolver is TOTAL — it never throws, so a mutant dies on an assertion', () => {
+  /**
+   * 🔴 A MUTANT THAT DIES ON A `TypeError` IS A FALSE KILL. It would have "died" just as loudly
+   * against a test asserting something unrelated, so the kill is evidence about the harness, not
+   * about the guard. The audit flagged two such kills in this file's battery.
+   *
+   * The cure is to make the failure mode an ASSERTION: pin that the resolver returns `null` for a
+   * malformed row rather than throwing. Then a mutant that drops a null-guard fails *these*
+   * assertions with a readable message instead of exploding somewhere upstream.
+   */
+  const MALFORMED: Array<[string, Partial<ThreadEntitySource>]> = [
+    ['post with no id', { post: {} as unknown as { id: number } }],
+    ['model with no id', { model: {} as unknown as { id: number } }],
+    ['comicChapter with no projectId', { comicChapter: {} as unknown as { projectId: number } }],
+    ['appListing with no slug', { appListing: {} as unknown as { slug: string } }],
+    ['image with no id', { image: {} as unknown as { id: number } }],
+    ['model3d with no id', { model3d: {} as unknown as { id: number } }],
+  ];
+
+  it.each(MALFORMED)('%s does not throw', (_name, entity) => {
+    expect(() => link(thread(entity))).not.toThrow();
+  });
+
+  it.each(MALFORMED)('%s resolves to null rather than a broken url', (_name, entity) => {
+    expect(link(thread(entity))).toBeNull();
+  });
+
+  it('a malformed root thread does not throw either', () => {
+    expect(() =>
+      link(thread({}, { comment: { id: 5567 }, rootThread: rootThread({ post: {} as never }) }))
+    ).not.toThrow();
   });
 });
 
@@ -160,11 +302,11 @@ describe('resolveThreadTarget — the addressability rule per addressing scheme'
     // The two schemes have different failure modes (`/posts/null` vs
     // `/apps/store-preview/undefined`), so they get different checks. Pinning both here stops a
     // mutant collapsing them to one.
-    expect(resolveThreadTarget({ post: { id: PARENT_ID } })).toEqual({
+    expect(resolveThreadTarget({ ...NO_ENTITIES, post: { id: PARENT_ID } })).toEqual({
       threadType: 'post',
       threadParentId: PARENT_ID,
     });
-    expect(resolveThreadTarget({ appListing: { slug: SLUG } })).toEqual({
+    expect(resolveThreadTarget({ ...NO_ENTITIES, appListing: { slug: SLUG } })).toEqual({
       threadType: 'appListing',
       threadParentId: null,
       appListingSlug: SLUG,
@@ -174,11 +316,18 @@ describe('resolveThreadTarget — the addressability rule per addressing scheme'
   it('an app-listing target carries NO threadParentId, because listings have none', () => {
     // If this ever becomes non-null, `threadUrlMap`'s appListing arm is being handed an id it
     // must not use, and the next refactor will "helpfully" put it in the URL.
-    expect(resolveThreadTarget({ appListing: { slug: SLUG } })?.threadParentId).toBeNull();
+    expect(
+      resolveThreadTarget({ ...NO_ENTITIES, appListing: { slug: SLUG } })?.threadParentId
+    ).toBeNull();
   });
 
   it('a slug does not make an unrelated entity addressable', () => {
-    expect(resolveThreadTarget({ post: { id: null }, appListing: undefined })).toBeNull();
+    expect(
+      resolveThreadTarget({
+        ...NO_ENTITIES,
+        post: { id: null } as unknown as { id: number },
+      })
+    ).toBeNull();
   });
 
   it('an app listing with no slug is unaddressable AT THIS LAYER, not merely downstream', () => {
@@ -191,7 +340,7 @@ describe('resolveThreadTarget — the addressability rule per addressing scheme'
     // Redundancy is fine as defence-in-depth; what is not fine is that either layer could be
     // removed silently. This pins THIS layer, so the end-to-end tests above pin the other.
     for (const slug of [undefined, null, '']) {
-      expect(resolveThreadTarget({ appListing: { slug } })).toBeNull();
+      expect(resolveThreadTarget({ ...NO_ENTITIES, appListing: { slug } })).toBeNull();
     }
   });
 });

--- a/src/server/utils/__tests__/comment-permalink.test.ts
+++ b/src/server/utils/__tests__/comment-permalink.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+import { buildCommentPermalink, resolveThreadTarget } from '~/server/utils/comment-permalink';
+
+/**
+ * `/comments/v2/<id>` — the "copy comment link" permalink.
+ *
+ * The bug: an app-listing thread has no `threadParentId` (listings are SLUG-addressed, and
+ * `Thread.appListingId` holds an integer surrogate that never appears in the URL), so the page's
+ * `if (!threadType || !threadParentId) return notFound` rejected every app-listing comment. The
+ * UI offered a "copy link" that produced a guaranteed 404.
+ *
+ * What is asserted here, and why each shape:
+ *   - the WHOLE resolved URL, never a substring. `toContain('/apps')` is satisfied by
+ *     `/apps/store-preview/undefined`, which is exactly the failure being fixed.
+ *   - every ALREADY-HANDLED entity type, at full-string precision, in one table. A regression
+ *     here breaks comment permalinks sitewide — far worse than the bug being fixed — so this is
+ *     the expensive half of the suite, not the cheap half.
+ *   - NEGATIVE CONTROLS, because a fix that makes the page answer for everything is a worse bug
+ *     than one that answers for nothing: an unknown entity, a thread with no entity at all, a
+ *     null thread, and an app listing whose slug did not resolve must all still fail closed.
+ *
+ * Fixture ids are non-default and PAIRWISE DISTINCT (no 0/1, no repeats, and each distinct from
+ * every literal the assertions name). A mutant that binds `threadId` where `commentId` belongs,
+ * or the slug where the parent id belongs, therefore produces a DIFFERENT string rather than the
+ * same one by coincidence.
+ */
+
+/** Every id distinct from every other, and distinct from any constant the assertions carry. */
+const COMMENT_ID = 8123;
+const THREAD_ID = 4471;
+const PARENT_ID = 3310;
+const SLUG = 'pixel-forge';
+
+/** The query string every `threadUrlMap` entry appends, spelled out rather than recomputed. */
+const QUERY = `highlight=${COMMENT_ID}&commentParentType=comment&commentParentId=${COMMENT_ID}&threadId=${THREAD_ID}`;
+
+const thread = (entity: Record<string, unknown>, over: Record<string, unknown> = {}) => ({
+  id: THREAD_ID,
+  ...entity,
+  ...over,
+});
+
+const link = (t: any) => buildCommentPermalink({ thread: t, commentId: COMMENT_ID });
+
+/**
+ * The nine entity relations the page selects, each with the URL it must keep producing.
+ *
+ * `comicChapter` is keyed on `projectId` rather than `id` — a real asymmetry the resolver has to
+ * preserve, and one a careless rewrite flattens to `.id` (which would be `undefined` → a 404).
+ */
+const HANDLED: Array<[string, Record<string, unknown>, string]> = [
+  ['post', { post: { id: PARENT_ID } }, `/posts/${PARENT_ID}?${QUERY}`],
+  ['review', { review: { id: PARENT_ID } }, `/reviews/${PARENT_ID}?${QUERY}`],
+  ['model', { model: { id: PARENT_ID } }, `/models/${PARENT_ID}?dialog=commentThread&${QUERY}`],
+  ['article', { article: { id: PARENT_ID } }, `/articles/${PARENT_ID}?${QUERY}`],
+  ['bounty', { bounty: { id: PARENT_ID } }, `/bounties/${PARENT_ID}?${QUERY}`],
+  ['bountyEntry', { bountyEntry: { id: PARENT_ID } }, `/bounties/entries/${PARENT_ID}?${QUERY}`],
+  ['challenge', { challenge: { id: PARENT_ID } }, `/challenges/${PARENT_ID}?${QUERY}`],
+  ['comicChapter', { comicChapter: { projectId: PARENT_ID } }, `/comics/${PARENT_ID}?${QUERY}`],
+  ['image', { image: { id: PARENT_ID } }, `/images/${PARENT_ID}?${QUERY}`],
+];
+
+describe('buildCommentPermalink — the appListing branch (the fix)', () => {
+  it('POSITIVE: an app-listing comment resolves to the listing detail URL, highlighted', () => {
+    // The whole string. This is the assertion the bug fails.
+    expect(link(thread({ appListing: { slug: SLUG } }))).toBe(
+      `/apps/store-preview/${SLUG}?${QUERY}`
+    );
+  });
+
+  it('resolves an app-listing REPLY through its root thread', () => {
+    // A reply's own thread is keyed by its parent COMMENT, so it carries no entity; the entity
+    // lives on the root. This is the path a "copy link" on a nested reply actually takes.
+    const replyThread = thread(
+      { comment: { id: 5567 } },
+      { rootThread: { id: 6612, appListing: { slug: SLUG } } }
+    );
+    expect(link(replyThread)).toBe(`/apps/store-preview/${SLUG}?${QUERY}`);
+  });
+
+  it('URL-encodes the slug rather than splicing it raw', () => {
+    expect(link(thread({ appListing: { slug: 'a b/c' } }))).toBe(
+      `/apps/store-preview/a%20b%2Fc?${QUERY}`
+    );
+  });
+
+  it('NEGATIVE: an app listing whose slug did not resolve fails closed, not to a broken link', () => {
+    // `/apps/store-preview/undefined` is a 404 that LOOKS like a working permalink — strictly
+    // worse than the 404 being fixed, because nothing signals it is wrong.
+    for (const slug of [undefined, null, '']) {
+      expect(link(thread({ appListing: { slug } }))).toBeNull();
+    }
+  });
+});
+
+describe('buildCommentPermalink — REGRESSION: every already-handled entity type', () => {
+  // A regression in this table breaks comment permalinks sitewide. Whole strings, one case each.
+  it.each(HANDLED)('%s resolves exactly as before', (_name, entity, expected) => {
+    expect(link(thread(entity))).toBe(expected);
+  });
+
+  it('resolves all nine to DISTINCT urls (so a table row cannot pass by aliasing another)', () => {
+    const urls = HANDLED.map(([, entity]) => link(thread(entity)));
+    expect(new Set(urls).size).toBe(HANDLED.length);
+  });
+
+  it.each(HANDLED)(
+    '%s still resolves through the root-thread fallback',
+    (_name, entity, expected) => {
+      const replyThread = thread(
+        { comment: { id: 5567 } },
+        { rootThread: { id: 6612, ...entity } }
+      );
+      expect(link(replyThread)).toBe(expected);
+    }
+  );
+
+  it('an appListing relation present alongside another entity does not hijack it', () => {
+    // The appListing arm is appended LAST, so no pre-existing type's precedence moves. A mutant
+    // that inserts it first changes this.
+    expect(link(thread({ post: { id: PARENT_ID }, appListing: { slug: SLUG } }))).toBe(
+      `/posts/${PARENT_ID}?${QUERY}`
+    );
+  });
+});
+
+describe('buildCommentPermalink — negative controls (it must not answer for everything)', () => {
+  it('a thread with no entity at all still fails closed', () => {
+    expect(link(thread({}))).toBeNull();
+  });
+
+  it('an unresolvable / nonexistent comment thread still fails closed', () => {
+    // The page 404s a nonexistent comment id before it ever gets here; this pins the other half —
+    // a comment that EXISTS on a thread that cannot be addressed.
+    expect(buildCommentPermalink({ thread: null, commentId: COMMENT_ID })).toBeNull();
+    expect(buildCommentPermalink({ thread: undefined, commentId: COMMENT_ID })).toBeNull();
+  });
+
+  it('an entity type the URL map has never addressed still fails closed', () => {
+    // `clubPost` / `model3dReview` are real Thread columns with no route. Resolving them would be
+    // the "answers for everything" failure.
+    expect(link(thread({ clubPost: { id: PARENT_ID } }))).toBeNull();
+    expect(link(thread({ model3dReview: { id: PARENT_ID } }))).toBeNull();
+  });
+
+  it('an id-addressed entity with a missing id fails closed rather than linking to /posts/null', () => {
+    for (const id of [undefined, null, 0]) {
+      expect(link(thread({ post: { id } }))).toBeNull();
+    }
+  });
+
+  it('a root thread that is itself unaddressable does not rescue an unaddressable thread', () => {
+    const replyThread = thread({ comment: { id: 5567 } }, { rootThread: { id: 6612 } });
+    expect(link(replyThread)).toBeNull();
+  });
+});
+
+describe('resolveThreadTarget — the addressability rule per addressing scheme', () => {
+  it('an id-addressed entity is addressable on its id; a slug-addressed one on its slug', () => {
+    // The two schemes have different failure modes (`/posts/null` vs
+    // `/apps/store-preview/undefined`), so they get different checks. Pinning both here stops a
+    // mutant collapsing them to one.
+    expect(resolveThreadTarget({ post: { id: PARENT_ID } })).toEqual({
+      threadType: 'post',
+      threadParentId: PARENT_ID,
+    });
+    expect(resolveThreadTarget({ appListing: { slug: SLUG } })).toEqual({
+      threadType: 'appListing',
+      threadParentId: null,
+      appListingSlug: SLUG,
+    });
+  });
+
+  it('an app-listing target carries NO threadParentId, because listings have none', () => {
+    // If this ever becomes non-null, `threadUrlMap`'s appListing arm is being handed an id it
+    // must not use, and the next refactor will "helpfully" put it in the URL.
+    expect(resolveThreadTarget({ appListing: { slug: SLUG } })?.threadParentId).toBeNull();
+  });
+
+  it('a slug does not make an unrelated entity addressable', () => {
+    expect(resolveThreadTarget({ post: { id: null }, appListing: undefined })).toBeNull();
+  });
+
+  it('an app listing with no slug is unaddressable AT THIS LAYER, not merely downstream', () => {
+    // 🔴 This assertion exists because of a SURVIVING mutant. Deleting the slug check here left
+    // the whole suite green: `threadUrlMap` carries its own slug guard, so
+    // `buildCommentPermalink` still returned null and every end-to-end test passed. The mutant
+    // was REACHABLE (this fixture does execute the line) but UNASSERTED — two redundant guards
+    // and nothing pinning which one fired.
+    //
+    // Redundancy is fine as defence-in-depth; what is not fine is that either layer could be
+    // removed silently. This pins THIS layer, so the end-to-end tests above pin the other.
+    for (const slug of [undefined, null, '']) {
+      expect(resolveThreadTarget({ appListing: { slug } })).toBeNull();
+    }
+  });
+});

--- a/src/server/utils/comment-permalink.ts
+++ b/src/server/utils/comment-permalink.ts
@@ -1,0 +1,107 @@
+import { threadUrlMap } from '~/server/notifications/comment.notifications';
+
+/**
+ * Resolution for `/comments/v2/<id>` — the "copy comment link" permalink.
+ *
+ * Extracted from the page so it can be tested without a DB or a Next request. The page keeps
+ * only the parts that genuinely need both: load the comment, redirect or 404.
+ *
+ * 🔴 THE ASYMMETRY THIS EXISTS TO HANDLE. Every thread entity except one is ID-addressed: the
+ * `Thread` row carries the parent's integer id and that id appears verbatim in the URL. App-store
+ * listings are SLUG-addressed (`/apps/store-preview/<slug>`) while `Thread.appListingId` holds
+ * `app_listings.serial_id`, an INTEGER surrogate that appears nowhere in the URL. So an
+ * app-listing thread legitimately has NO usable `threadParentId`, and the page's original
+ * `if (!threadType || !threadParentId) return notFound` rejected every one of them — a 404 on a
+ * link the UI had just offered to copy.
+ *
+ * That is the same asymmetry the notification URLs hit; both now resolve through the one
+ * `threadUrlMap`, whose `appListing` arm reads `details.appListingSlug` and shares
+ * `getListingDetailHref` with the store cards. A route rename therefore moves the permalink, the
+ * notification and the card together.
+ */
+
+export type CommentThreadTarget = {
+  threadType: string;
+  /** `null` for a slug-addressed entity, which has no id in its URL. */
+  threadParentId: number | null;
+  appListingSlug?: string | null;
+};
+
+/**
+ * First matching entity relation on this thread, or `null` if it carries none.
+ *
+ * 🔴 First-match-wins, and the `appListing` arm is APPENDED rather than inserted. A `Thread`'s
+ * entity FKs are mutually exclusive (each is `@unique` and exactly one is set), so ordering is
+ * unobservable in practice — appending anyway means no pre-existing type's precedence can move,
+ * which is the cheap way to keep a sitewide-permalink regression off the table.
+ */
+const getThreadEntity = (thread: any): CommentThreadTarget | null => {
+  if (thread.post) return { threadType: 'post', threadParentId: thread.post.id };
+  if (thread.review) return { threadType: 'review', threadParentId: thread.review.id };
+  if (thread.model) return { threadType: 'model', threadParentId: thread.model.id };
+  if (thread.article) return { threadType: 'article', threadParentId: thread.article.id };
+  if (thread.bounty) return { threadType: 'bounty', threadParentId: thread.bounty.id };
+  if (thread.bountyEntry)
+    return { threadType: 'bountyEntry', threadParentId: thread.bountyEntry.id };
+  if (thread.challenge) return { threadType: 'challenge', threadParentId: thread.challenge.id };
+  if (thread.comicChapter)
+    return { threadType: 'comicChapter', threadParentId: thread.comicChapter.projectId };
+  if (thread.image) return { threadType: 'image', threadParentId: thread.image.id };
+  if (thread.appListing)
+    return {
+      threadType: 'appListing',
+      threadParentId: null,
+      appListingSlug: thread.appListing.slug,
+    };
+  return null;
+};
+
+/**
+ * The entity target for a thread, or `null` when it cannot be addressed.
+ *
+ * The addressability rule differs by how the entity is addressed, because the two failure modes
+ * differ: a missing id renders `/posts/null`, a missing slug renders
+ * `/apps/store-preview/undefined`. Both are 404s dressed as working links, so neither may pass.
+ */
+export const resolveThreadTarget = (thread: any): CommentThreadTarget | null => {
+  if (!thread) return null;
+  const target = getThreadEntity(thread);
+  if (!target) return null;
+  if (target.threadType === 'appListing') return target.appListingSlug ? target : null;
+  return target.threadParentId ? target : null;
+};
+
+/**
+ * The permalink for a comment, or `null` if the thread cannot be addressed — in which case the
+ * page 404s exactly as it did before.
+ *
+ * Falls back to the ROOT thread when the immediate thread carries no entity, which is how a reply
+ * (whose own thread is keyed by its parent COMMENT, not by an entity) reaches its entity page.
+ */
+export const buildCommentPermalink = ({
+  thread,
+  commentId,
+}: {
+  thread: any;
+  commentId: number;
+}): string | null => {
+  if (!thread) return null;
+
+  const target = resolveThreadTarget(thread) ?? resolveThreadTarget(thread.rootThread);
+  if (!target) return null;
+
+  const url = threadUrlMap({
+    threadType: target.threadType,
+    threadParentId: target.threadParentId,
+    appListingSlug: target.appListingSlug,
+    threadId: thread.id,
+    commentId,
+    // Always pin the target comment as the thread root so it renders standalone via
+    // RootThreadProvider's activeComment path. Sidesteps cursor-paginated thread fetches
+    // (target may be on page N) and works uniformly for root and reply comments.
+    commentParentType: 'comment',
+    commentParentId: commentId,
+  });
+
+  return url ?? null;
+};

--- a/src/server/utils/comment-permalink.ts
+++ b/src/server/utils/comment-permalink.ts
@@ -1,4 +1,90 @@
+import type { Prisma } from '@prisma/client';
 import { threadUrlMap } from '~/server/notifications/comment.notifications';
+
+/**
+ * The thread-parent relations `/comments/v2/<id>` resolves against, and the ONE definition of
+ * them — the page selects exactly this, and the resolver reads exactly this.
+ *
+ * 🔴 `satisfies Prisma.ThreadSelect` is NOT what closes the gap, and it is worth being precise
+ * about why, because it looks like it should. Every field of a `*Select` type is OPTIONAL, so
+ * OMISSION satisfies it: delete the `appListing` line and this still type-checks. What `satisfies`
+ * buys is only that each key that IS present is a real relation with real fields — it catches
+ * `appListings` (plural) and `slugg`, not a dropped entry. The omission half is closed by
+ * `ThreadEntitySource` below.
+ */
+export const threadEntitySelect = {
+  image: { select: { id: true } },
+  post: { select: { id: true } },
+  review: { select: { id: true } },
+  model: { select: { id: true } },
+  article: { select: { id: true } },
+  bounty: { select: { id: true } },
+  bountyEntry: { select: { id: true } },
+  challenge: { select: { id: true } },
+  comicChapter: { select: { projectId: true } },
+  model3d: { select: { id: true } },
+  appListing: { select: { slug: true } },
+} satisfies Prisma.ThreadSelect;
+
+/**
+ * The full comment query the page runs. Lives here rather than in the page so the select and the
+ * code that reads it cannot drift — they are one rule, and this is its one place.
+ *
+ * 🔴 `rootThread` MUST carry the entity relations too. It is how a REPLY reaches its entity page
+ * (a reply's own thread is keyed by its parent comment and carries no entity), so narrowing this
+ * to `{ id: true }` would break reply permalinks for EVERY entity type sitewide.
+ */
+export const commentPermalinkSelect = {
+  id: true,
+  thread: {
+    select: {
+      id: true,
+      rootThread: { select: { id: true, ...threadEntitySelect } },
+      comment: { select: { id: true } },
+      ...threadEntitySelect,
+    },
+  },
+} satisfies Prisma.CommentV2Select;
+
+/** Exactly what `dbRead.commentV2.findUnique({ select: commentPermalinkSelect })` returns. */
+export type CommentPermalinkPayload = Prisma.CommentV2GetPayload<{
+  select: typeof commentPermalinkSelect;
+}>;
+
+export type PermalinkThread = CommentPermalinkPayload['thread'];
+
+/**
+ * 🔴 THE COMPILE-TIME GUARD, and the reason this type exists rather than a hand-written interface.
+ *
+ * `Pick<T, K>` requires every K to be a key of T. So if a relation is dropped from
+ * `threadEntitySelect`, the generated payload loses that property and this `Pick` becomes a type
+ * ERROR — the omission `satisfies` cannot see. And because `rootThread`'s payload must also be
+ * assignable here, narrowing its select to `{ id: true }` fails too.
+ *
+ * That converts three defects from "runtime 404 with a green suite" into `pnpm typecheck`
+ * failures:
+ *   1. dropping `appListing` from the select
+ *   2. selecting `.id` instead of `.slug` on it
+ *   3. narrowing `rootThread`'s select — the sitewide reply-permalink break
+ *
+ * 🔴 A MOCKED `dbRead` CANNOT CLOSE ANY OF THESE. Hand-writing the mock's return shape means the
+ * fake encodes the same belief as the code, so both are wrong together and the suite stays green.
+ * The remedy for a select-correctness gap is a TYPE, not a test.
+ */
+export type ThreadEntitySource = Pick<
+  PermalinkThread,
+  | 'image'
+  | 'post'
+  | 'review'
+  | 'model'
+  | 'article'
+  | 'bounty'
+  | 'bountyEntry'
+  | 'challenge'
+  | 'comicChapter'
+  | 'model3d'
+  | 'appListing'
+>;
 
 /**
  * Resolution for `/comments/v2/<id>` — the "copy comment link" permalink.
@@ -35,7 +121,7 @@ export type CommentThreadTarget = {
  * unobservable in practice — appending anyway means no pre-existing type's precedence can move,
  * which is the cheap way to keep a sitewide-permalink regression off the table.
  */
-const getThreadEntity = (thread: any): CommentThreadTarget | null => {
+const getThreadEntity = (thread: ThreadEntitySource): CommentThreadTarget | null => {
   if (thread.post) return { threadType: 'post', threadParentId: thread.post.id };
   if (thread.review) return { threadType: 'review', threadParentId: thread.review.id };
   if (thread.model) return { threadType: 'model', threadParentId: thread.model.id };
@@ -47,6 +133,12 @@ const getThreadEntity = (thread: any): CommentThreadTarget | null => {
   if (thread.comicChapter)
     return { threadType: 'comicChapter', threadParentId: thread.comicChapter.projectId };
   if (thread.image) return { threadType: 'image', threadParentId: thread.image.id };
+  // Appended, like `appListing` below, so no pre-existing type's precedence moves. `model3d` was
+  // MISSING here while `threadUrlMap` has had a working `/3d-models/<id>` arm all along and the
+  // notification SQL resolves it — so every 3D-model comment permalink 404'd. See the PR body:
+  // the TS chain had `comicChapter` but not `model3d`, the SQL CASE had `model3d` but not
+  // `comicChapter` — two copies of one rule, and the bug lived in the disagreement.
+  if (thread.model3d) return { threadType: 'model3d', threadParentId: thread.model3d.id };
   if (thread.appListing)
     return {
       threadType: 'appListing',
@@ -63,7 +155,9 @@ const getThreadEntity = (thread: any): CommentThreadTarget | null => {
  * differ: a missing id renders `/posts/null`, a missing slug renders
  * `/apps/store-preview/undefined`. Both are 404s dressed as working links, so neither may pass.
  */
-export const resolveThreadTarget = (thread: any): CommentThreadTarget | null => {
+export const resolveThreadTarget = (
+  thread: ThreadEntitySource | null | undefined
+): CommentThreadTarget | null => {
   if (!thread) return null;
   const target = getThreadEntity(thread);
   if (!target) return null;
@@ -82,7 +176,7 @@ export const buildCommentPermalink = ({
   thread,
   commentId,
 }: {
-  thread: any;
+  thread: PermalinkThread | null | undefined;
   commentId: number;
 }): string | null => {
   if (!thread) return null;


### PR DESCRIPTION
Closes #4167.

## The bug

`/comments/v2/<id>` returned **404** for every comment on an app-store listing, so "copy comment link" on those threads produced a dead URL.

Every other thread entity is **ID-addressed**: the `Thread` row carries the parent's integer id and that id appears verbatim in the URL. App listings are **SLUG-addressed** (`/apps/store-preview/<slug>`) while `Thread.appListingId` holds `app_listings.serial_id` — an integer surrogate that appears nowhere in the URL. So an app-listing thread legitimately has no usable `threadParentId`, and the page's guard rejected all of them:

```ts
if (!threadData.threadType || !threadData.threadParentId) {
  return { notFound: true };   // :129-130
}
```

There were in fact **two** independent 404 paths, and both had to close:
1. `getThreadDetails` had no `appListing` arm, so it returned `{null, null}` and hit the guard above.
2. Even past that guard, `threadUrlMap`'s `appListing` arm (added by #4160) reads `details.appListingSlug` — and the page neither selected nor passed a slug, so it returned `undefined` and fell through to the trailing `notFound`.

## The change

- Resolution moves out of the page into `src/server/utils/comment-permalink.ts`, so it can be tested without a DB or a Next request. The page keeps only the parts that genuinely need both: load the comment, redirect or 404.
- The page now selects `appListing: { select: { slug: true } }`. That `select` object is spread into both `thread` and `thread.rootThread`, so replies resolve through the root exactly as other entities do.
- URL construction goes through the shared `threadUrlMap`, so the permalink, the notification and the store card all share `getListingDetailHref` and a route rename moves every caller at once.

Two deliberate choices worth review attention:

- **The `appListing` arm is APPENDED to the entity chain, not inserted.** A `Thread`'s entity FKs are mutually exclusive, so ordering is unobservable in practice — appending anyway means no pre-existing type's precedence can move, which is the cheap way to keep a sitewide-permalink regression off the table. Pinned by a test.
- **Addressability is checked per addressing scheme.** A missing id renders `/posts/null`; a missing slug renders `/apps/store-preview/undefined`. Both are 404s dressed as working links, so neither passes.

## Tests — 33, red→green matrix

Run against a verbatim replica of the pre-change logic (the `getThreadDetails` if-chain, the two-stage rootThread fallback, the guard, and the original `threadUrlMap` argument set) to establish the base column.

| | at base | at HEAD |
|---|---|---|
| **5 appListing-behaviour tests** | **RED** | green |
| 27 regression / negative-control tests | green | green |
| after adding the layer assertion (below) | — | **33 green** |

The 5 that go red at base:

```
expected null to be '/apps/store-preview/pixel-forge?highlight=8123&…'   (POSITIVE, whole URL)
expected null to be '/apps/store-preview/pixel-forge?highlight=8123&…'   (reply via root thread)
expected null to be '/apps/store-preview/a%20b%2Fc?highlight=8123&…'     (slug encoding)
expected null to deeply equal { threadType: 'appListing', …(2) }         (resolver target)
expected undefined to be null                                            (no threadParentId)
```

The 27 that pass at base are **regression coverage** — they pin behaviour that must not change, so passing at base is exactly what makes them regression guards. They are not evidence the fix works.

One honest caveat: *"an app listing whose slug did not resolve fails closed"* is green at base too, but **for a different reason** (at base app listings were not handled at all). It is a genuine negative control at HEAD and vacuous at base.

Coverage includes all **9** already-handled entity types at full-string precision, each through both the direct and the root-thread path, plus a check that all nine resolve to **distinct** URLs so no row can pass by aliasing another.

## Mutation testing — 8 mutants, all killed

Harness controls run first: unmutated → SURVIVED (33 passed), always-null → KILLED. The harness also asserts the **full test count** per run, so a mutant that fails to compile reports `HARNESS-ERROR` instead of a false SURVIVED.

| mutant | verdict | killed by |
|---|---|---|
| M1 invert branch order (appListing first) | KILLED | `expected '/apps/store-preview/pixel-forge?…' to be '/posts/3310?…'` |
| M2 swap operands (appListing checks `threadParentId`) | KILLED | `expected null to be '/apps/store-preview/pixel-forge?…'` |
| M3 dead guard (slug check commented out, text present) | KILLED* | `expected { threadType: 'appListing', …(2) } to be null` |
| M4 stale rebind (`appListingSlug ← thread.id`) | KILLED | `expected '/apps/store-preview/4471?…' to be '/apps/store-preview/pixel-forge?…'` |
| M5 drop root-thread fallback | KILLED | `expected null to be '/posts/3310?…'` (10 tests) |
| M6 `comicChapter.projectId → .id` | KILLED | `expected null to be '/comics/3310?…'` |
| M7 drop id-addressability check | KILLED | `expected '/posts/undefined?…' to be null` |
| M8 stale rebind (`commentParentId ← thread.id`) | KILLED | 22 tests |

### \*M3 initially SURVIVED — reachable but unasserted, *not* unreachable

This distinction is the reason M3 is worth reading, because the two diagnoses have **opposite remedies** and are easy to confuse.

A surviving mutant has two very different causes:

- **Unreachable** — the mutated line never executes for any fixture (an earlier check always wins, the branch lands exactly on its own boundary, a value converges before the assertion runs). The remedy is to build a fixture that *reaches* it. Scoring such a mutant SURVIVED tells you nothing about the guard.
- **Reachable but unasserted** — the line *does* execute and its behaviour *does* change, but nothing observes the difference. The remedy is an **assertion**, not a fixture.

M3 is the second kind, confirmed rather than assumed. I probed both layers directly with the negative-control fixture (`{ appListing: { slug: undefined } }`):

```
resolveThreadTarget   = null      ← my guard runs here and returns null
buildCommentPermalink = null      ← unchanged even with my guard deleted
```

The fixture reaches the mutated line. Deleting the slug check makes `resolveThreadTarget` return a target instead of `null` — a real behaviour change — but `buildCommentPermalink` *still* returns `null`, because `threadUrlMap` carries its **own** slug guard (shipped in #4160). Two redundant guards, and every end-to-end test was satisfied by the downstream one, so no test could tell which had fired.

Redundancy here is fine as defence-in-depth. What was not fine is that **either layer could be deleted silently**. The remedy was therefore an assertion at the resolver layer — `resolveThreadTarget({ appListing: { slug } })` must be `null` for `undefined`/`null`/`''` — which pins *this* layer while the end-to-end tests pin the other. M3 now dies on that assertion specifically:

```
AssertionError: expected { threadType: 'appListing', …(2) } to be null
```

Had I misdiagnosed this as unreachable, the "fix" would have been a new fixture — which would have changed nothing, because the fixture was never the problem.

### A false kill, also fixed

N5/N6 in the sibling PR (#4184) initially died on a `TypeError` from a regex in the *test* (`.match(…)![0]` on a null match), not on an assertion. **A mutant that dies for the wrong reason is a false kill** — it would still have "died" had the test been checking something else entirely. The general fix is to assert the extraction succeeded *before* using it, so the failure comes from the test's own claim. Applied there; noted here because it is the same class of error as M3.

Fixture ids are non-default and pairwise distinct, and distinct from every literal the assertions name, so a mutant binding the wrong one produces a different string rather than the same one by coincidence.

## Verification

- `pnpm typecheck` → **0 type errors in 83s**
- `vitest run src/server/notifications src/server/utils/__tests__/comment-permalink.test.ts` → **328 passed / 19 files** (on the combined tree)
- Prettier clean on all changed files

## 🔴 The select is now TYPE-checked, not mock-checked

The resolver took `thread: any`, so nothing connected the Prisma `select` to the code reading it. A wrong select produced a **404 with a fully green suite**.

### Why a test could not have fixed this

The instinct is "add a test with a mocked `dbRead`". **That is the wrong remedy, and it is worth being explicit about why**, because the wrong remedy produces a green suite that proves nothing:

> Hand-writing the mock's return shape means the fake encodes the **same belief** as the code. A wrong select and a wrong mock are wrong *together*, and the suite stays green.

A select-correctness gap is closed by a **type**, not a test.

### What actually closes it

The select moves into `comment-permalink.ts` beside its reader, and the reader's parameter type is derived from the select:

```ts
export const commentPermalinkSelect = { … } satisfies Prisma.CommentV2Select;
type CommentPermalinkPayload = Prisma.CommentV2GetPayload<{ select: typeof commentPermalinkSelect }>;
export type ThreadEntitySource = Pick<CommentPermalinkPayload['thread'], 'post' | … | 'appListing'>;
```

🔴 **`satisfies Prisma.ThreadSelect` alone is INSUFFICIENT** — every field of a `*Select` type is optional, so **omission satisfies it**. It catches a misspelled relation (`appListings`) or field (`slugg`); it does *not* catch a dropped entry. The `Pick` is the half that catches omission, because `Pick<T, K>` requires every `K` to be a key of `T`.

### Measured, with controls

| mutant | `pnpm typecheck` | test suite |
|---|---|---|
| drop `appListing` from the select | **FAIL** `TS2344` | 1 failed |
| select `.id` instead of `.slug` | **FAIL** `TS2339 Property 'slug' does not exist` | 🔴 **948 PASSED** |
| narrow `rootThread`'s select to `{ id: true }` | **FAIL** `TS2345` | 🔴 **948 PASSED** |
| drop `model3d` from the select | **FAIL** `TS2344` | 1 failed |
| *(control)* unmutated | PASS | 948 passed |

**Two of the four are invisible to the entire suite** and caught only by the compiler. The third is the expensive one: `rootThread` carries the entity relations for every **reply** permalink, so narrowing it breaks replies for *every entity type sitewide*.

## 🔴 `model3d` — a live 404, fixed here

`/comments/v2/<id>` 404'd for **every 3D-model comment**. `threadUrlMap` has had a working `/3d-models/<id>` arm all along and the notification SQL resolves it — the page's select and resolver simply omitted it.

**Root cause, and the general lesson:** one rule exists in two copies that disagree. The TS resolver has `comicChapter` but not `model3d`; the SQL `CASE` (`comment.notifications.ts:330-345`) has `model3d` but not `comicChapter`. **The bug lives exactly in the disagreement.** (Consolidating those two chains is filed separately — not attempted here.)

The test table helped hide it: it called itself *"every already-handled entity type"* with **9 rows against a 15-value enum**. It now reconciles against the real `commentConnectorSchema.entityType` enum and enumerates the four intentional exclusions (`question`, `answer`, `clubPost`, `model3dReview`), so the next added relation forces a decision instead of silently 404ing. A count that implies completeness without enumerating its exclusions is a claim, not a guard.

## The SSR seam

`comment-permalink.ssr.test.ts` drives `getServerSideProps` with a mocked `dbRead`: a resolved permalink becomes a **302 to the whole expected URL**, a null becomes `notFound`, and a **reply resolves through its root thread while keeping its own `threadId`**. The two components were each verified in isolation; this covers the seam that belonged to neither. The file states plainly what it *cannot* do, so nobody mistakes it for select coverage.

## Mutation testing — 14 mutants, all killed, zero false kills

Re-run after the rebase. Controls: unmutated → SURVIVED (61 passed); `appListing` arm disabled → KILLED.

Two rounds of harness self-correction, both worth recording:

- **Two mutants died on a `TypeError`**, from tests drilling into `.redirect.destination` — which throws when a mutant returns `notFound`. A mutant that dies for the wrong reason is a **false kill**. Assertions are now on the whole result object, and a **totality guard** was added (a malformed row returns `null` and never throws), so a dropped null-guard fails an assertion instead of exploding. Every one of the 14 now dies on an `AssertionError`.
- **Two "SURVIVED" verdicts were harness artifacts**, not weak tests: one from a `python3: No such file or directory` that meant the mutation never applied, and one (`page passes rootThread instead of thread`) that was **unreachable** because every SSR fixture had `rootThread: null`. Both were fixed — the second by adding the reply fixture, which is now the killing test.

## Verification

- `pnpm typecheck` → **0 errors** (post-rebase, after regenerating the Prisma client — see below)
- `vitest run src/server/utils/__tests__/` → **962 passed / 65 files**; with the ledger spec, **970 / 66**
- `model-file-hash-writers.test.ts` → **8 passed**, confirming the pre-existing `main` red cleared (run and counted, not read off the badge)

⚠️ Note for anyone rebasing this: the first post-rebase `pnpm typecheck` reported **15 errors in `Hubs`/`userHub` code**. Those were a **stale generated Prisma client**, not defects — `#4080` added models after my `pnpm install`. Re-running install regenerated the client and typecheck went to 0. Worth knowing before chasing them.

## 🔴 Not verified — stated plainly, please merge knowing this

**Nobody has watched this 307 fire for a real app-listing comment.** No one has opened `/comments/v2/<id>` for a comment on a real listing and seen it land on the listing page.

What *is* now proven, and what is not:

| | status |
|---|---|
| the select produces the fields the resolver reads | **type-proven** — `pnpm typecheck` fails otherwise |
| the resolver builds the right URL | 51 tests, 14 mutants, whole-string assertions |
| the page turns that URL into a 302 / a null into a 404 | 10 SSR tests against a mocked `dbRead` |
| **a real row exists with a populated FK, and a browser follows the redirect** | 🔴 **unobserved** |

The redirect *mechanism* is unchanged production code already serving nine entity types, and the data shape is compiler-enforced — so this is a **bounded-risk argument, not an observation**, and it should be read as exactly that. One manual click on a real app-listing comment closes it post-merge.

## Out of scope — filed separately

- **Consolidating the two entity chains.** The TS resolver and the SQL `CASE` are two copies of one rule and already disagree (`comicChapter` vs `model3d`); that disagreement is where the `model3d` bug lived. Not attempted here.
- **A disclosure question this PR extends but did not create.** `/comments/v2/[id]` has no auth gate and never consults `AppListing.status`, so an anonymous enumerator now gets `307 + Location: /apps/store-preview/<slug>` where they previously got 404 — for any status, including moderator-`removed`. The destination itself is safe, and this route has **never** gated on parent visibility for any entity (a comment on an unpublished post already 307s), so it is *consistent-but-extended* rather than novel. Small while the store is mod-only; it grows at the `/apps` cutover. Flagged for a product decision rather than settled in this PR.
