### PR TITLE
fix(training): bundle epoch models and sample media into one archive

### DIFF
--- a/src/components/Resource/Forms/TrainingSelectFile.tsx
+++ b/src/components/Resource/Forms/TrainingSelectFile.tsx
@@ -467,13 +467,22 @@ export default function TrainingSelectFile({
   // The orchestrator bundles every blob the run produced (epoch models + sample media)
   // into one zip and hands back a short-lived signed URL, so nothing streams through us.
   const archiveMutation = trpc.training.getEpochArchive.useMutation({
-    onSuccess: ({ url, omittedCount }) => {
-      if (omittedCount > 0) {
+    onSuccess: ({ url, unresolvedCount, cappedCount }) => {
+      const reasons: string[] = [];
+      if (unresolvedCount > 0)
+        reasons.push(
+          `${unresolvedCount} file${unresolvedCount > 1 ? 's are' : ' is'} no longer available.`
+        );
+      if (cappedCount > 0)
+        reasons.push(
+          `${cappedCount} file${
+            cappedCount > 1 ? 's were' : ' was'
+          } left out because the archive hit its file limit.`
+        );
+      if (reasons.length > 0) {
         showWarningNotification({
           title: 'Some files could not be included',
-          message: `${omittedCount} file${
-            omittedCount > 1 ? 's are' : ' is'
-          } no longer available and was left out of the archive.`,
+          message: reasons.join(' '),
           autoClose: false,
         });
       }

--- a/src/components/Resource/Forms/TrainingSelectFile.tsx
+++ b/src/components/Resource/Forms/TrainingSelectFile.tsx
@@ -58,7 +58,7 @@ import type { TrainingBaseModelType } from '~/utils/training';
 import type { ModelVersionById } from '~/types/router';
 import { formatDate } from '~/utils/date-helpers';
 import { getModelFileFormat } from '~/utils/file-helpers';
-import { showErrorNotification } from '~/utils/notifications';
+import { showErrorNotification, showWarningNotification } from '~/utils/notifications';
 import { bytesToKB, formatKBytes } from '~/utils/number-helpers';
 import { trpc } from '~/utils/trpc';
 import classes from './TrainingSelectFile.module.css';
@@ -304,7 +304,7 @@ const EpochRow = ({
                             className="size-full object-cover"
                           />
                         )}
-                        <span className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+                        <span className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
                           <IconZoomIn size={28} color="white" />
                         </span>
                       </button>
@@ -417,7 +417,6 @@ export default function TrainingSelectFile({
   const [selectedFile, setSelectedFile] = useState<string | undefined>(
     existingModelFile?.metadata?.selectedEpochUrl
   );
-  const [downloading, setDownloading] = useState(false);
 
   const upsertFileMutation = trpc.modelFile.upsert.useMutation({
     async onSuccess() {
@@ -465,6 +464,29 @@ export default function TrainingSelectFile({
   });
 
   const moveAssetMutation = trpc.training.moveAsset.useMutation();
+  // The orchestrator bundles every blob the run produced (epoch models + sample media)
+  // into one zip and hands back a short-lived signed URL, so nothing streams through us.
+  const archiveMutation = trpc.training.getEpochArchive.useMutation({
+    onSuccess: ({ url, omittedCount }) => {
+      if (omittedCount > 0) {
+        showWarningNotification({
+          title: 'Some files could not be included',
+          message: `${omittedCount} file${
+            omittedCount > 1 ? 's are' : ' is'
+          } no longer available and was left out of the archive.`,
+          autoClose: false,
+        });
+      }
+      window.location.assign(url);
+    },
+    onError: (error) => {
+      showErrorNotification({
+        title: 'Failed to prepare download',
+        error: new Error(error.message),
+        autoClose: false,
+      });
+    },
+  });
 
   // -- "Train Further" (steps-based pricing, AI Toolkit only) --------------------------
   // Starts a new training run that continues from a selected epoch: creates a new Pending
@@ -767,29 +789,9 @@ export default function TrainingSelectFile({
       !hasFailedWithEpochs) ||
     noEpochs;
 
-  const downloadAll = async () => {
-    if (noEpochs || downloading) return;
-
-    setDownloading(true);
-
-    // Trigger browser-native downloads sequentially with a small delay
-    // so the browser can handle multiple concurrent downloads to disk
-    for (let i = 0; i < epochs.length; i++) {
-      const epochData = epochs[i];
-      const link = document.createElement('a');
-      link.href = `/api/download/training/${modelVersion.id}?epochNumber=${epochData.epochNumber}`;
-      link.download = `${model.name}_epoch_${epochData.epochNumber}.safetensors`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-
-      // Small delay between downloads to avoid browser throttling
-      if (i < epochs.length - 1) {
-        await new Promise((resolve) => setTimeout(resolve, 500));
-      }
-    }
-
-    setDownloading(false);
+  const downloadAll = () => {
+    if (noEpochs || archiveMutation.isPending) return;
+    archiveMutation.mutate({ modelVersionId: modelVersion.id });
   };
 
   const canGenerateWithEpochBool = canGenerateWithEpoch(completeDate);
@@ -917,14 +919,21 @@ export default function TrainingSelectFile({
           )}
           <Stack gap="xs">
             <Flex justify="flex-end" align="center" gap="md">
-              <Button
-                color="cyan"
-                leftSection={<IconFileDownload size={18} />}
-                onClick={downloadAll}
-                loading={downloading}
+              <Tooltip
+                label="Bundles every epoch model file and sample image from this run into a single zip"
+                withArrow
+                multiline
+                maw={260}
               >
-                Download All ({epochs.length})
-              </Button>
+                <Button
+                  color="cyan"
+                  leftSection={<IconFileDownload size={18} />}
+                  onClick={downloadAll}
+                  loading={archiveMutation.isPending}
+                >
+                  Download All ({epochs.length})
+                </Button>
+              </Tooltip>
             </Flex>
           </Stack>
           <Center>

--- a/src/server/routers/training.router.ts
+++ b/src/server/routers/training.router.ts
@@ -11,9 +11,11 @@ import {
   createTrainingRequestSchema,
   getAutoLabelUploadUrlSchema,
   getAutoLabelWorkflowSchema,
+  getTrainingEpochArchiveSchema,
   moveAssetInput,
   submitAutoLabelWorkflowSchema,
 } from '~/server/schema/training.schema';
+import { getTrainingEpochArchive } from '~/server/services/orchestrator/training/epoch-archive';
 import {
   autoCaptionHandler,
   autoTagHandler,
@@ -68,6 +70,20 @@ export const trainingRouter = router({
     .input(moveAssetInput)
     .use(isFlagProtected('imageTraining'))
     .mutation(({ input, ctx }) => moveAsset({ ...input, userId: ctx.user.id })),
+  // One zip of everything a finished run produced (epoch models + sample media).
+  // A mutation rather than a query: each call mints a short-lived signed URL from
+  // the orchestrator, which must not be served from the tRPC query cache.
+  getEpochArchive: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .input(getTrainingEpochArchiveSchema)
+    .use(rateLimit({ limit: 30, period: 60 }))
+    .mutation(({ input, ctx }) =>
+      getTrainingEpochArchive({
+        ...input,
+        userId: ctx.user.id,
+        isModerator: ctx.user.isModerator,
+      })
+    ),
   getModelBasic: publicProcedure
     .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(getByIdSchema)

--- a/src/server/schema/training.schema.ts
+++ b/src/server/schema/training.schema.ts
@@ -106,6 +106,11 @@ export const getAutoLabelWorkflowSchema = z.object({
   workflowId: z.string().min(1),
 });
 
+export type GetTrainingEpochArchiveInput = z.infer<typeof getTrainingEpochArchiveSchema>;
+export const getTrainingEpochArchiveSchema = z.object({
+  modelVersionId: z.number().positive(),
+});
+
 export const trainingServiceStatusSchema = z.object({
   available: z.boolean().default(true),
   message: z.string().nullish(),

--- a/src/server/services/__tests__/training-epoch-archive.test.ts
+++ b/src/server/services/__tests__/training-epoch-archive.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import type * as BlobArchiveModule from '~/server/services/orchestrator/blobArchive';
+
+/**
+ * "Download All" on the training epoch view now asks the orchestrator to bundle every
+ * blob a run produced into one zip, instead of streaming each epoch model through us.
+ * What matters is the manifest we hand the orchestrator: which blobs, in what order,
+ * and what happens to the ones we cannot resolve.
+ */
+
+const findUnique = dbMock.dbRead.modelVersion.findUnique;
+vi.mock('~/server/services/orchestrator/client', () => ({ internalOrchestratorClient: {} }));
+
+const createBlobArchive = vi.fn();
+vi.mock('~/server/services/orchestrator/blobArchive', async (importOriginal) => ({
+  ...(await importOriginal<typeof BlobArchiveModule>()),
+  createBlobArchive: (...args: unknown[]) => createBlobArchive(...args),
+}));
+
+const { buildEpochArchiveEntries, getTrainingEpochArchive } = await import(
+  '~/server/services/orchestrator/training/epoch-archive'
+);
+
+const blobUrl = (id: string) =>
+  `https://orchestration.civitai.com/v2/consumer/blobs/${id}?sig=abc&exp=2030-01-01T00:00:00Z`;
+
+const v2Results = {
+  version: 2 as const,
+  submittedAt: '2026-08-01T00:00:00Z',
+  workflowId: 'wf-1',
+  transactionData: [],
+  history: [],
+  sampleImagesPrompts: ['a', 'b'],
+  epochs: [
+    {
+      epochNumber: 2,
+      modelUrl: blobUrl('MODEL2.safetensors'),
+      modelSize: 10,
+      sampleImages: [blobUrl('E2S1.jpeg'), blobUrl('E2S2.mp4')],
+    },
+    {
+      epochNumber: 1,
+      modelUrl: blobUrl('MODEL1.safetensors'),
+      modelSize: 10,
+      sampleImages: [blobUrl('E1S1.jpeg')],
+    },
+  ],
+};
+
+describe('buildEpochArchiveEntries', () => {
+  it('includes every epoch model AND every sample, models first, ascending by epoch', () => {
+    const { entries, omittedCount } = buildEpochArchiveEntries({
+      trainingResults: v2Results,
+      modelName: 'My Cool Model!',
+    });
+
+    expect(omittedCount).toBe(0);
+    expect(entries).toEqual([
+      { blobId: 'MODEL1.safetensors', fileName: 'My_Cool_Model__epoch_1.safetensors' },
+      { blobId: 'MODEL2.safetensors', fileName: 'My_Cool_Model__epoch_2.safetensors' },
+      { blobId: 'E1S1.jpeg', fileName: 'My_Cool_Model__epoch_1_sample_1.jpeg' },
+      { blobId: 'E2S1.jpeg', fileName: 'My_Cool_Model__epoch_2_sample_1.jpeg' },
+      { blobId: 'E2S2.mp4', fileName: 'My_Cool_Model__epoch_2_sample_2.mp4' },
+    ]);
+  });
+
+  it('normalizes the legacy v1 epoch shape', () => {
+    const { entries } = buildEpochArchiveEntries({
+      trainingResults: {
+        start_time: null,
+        end_time: null,
+        attempts: null,
+        jobId: null,
+        transactionId: null,
+        history: null,
+        epochs: [
+          {
+            epoch_number: 1,
+            model_url: blobUrl('LEGACY.safetensors'),
+            sample_images: [{ image_url: blobUrl('LEGACYS1.jpeg'), prompt: 'a' }],
+          },
+        ],
+      },
+      modelName: 'legacy',
+    });
+
+    expect(entries).toEqual([
+      { blobId: 'LEGACY.safetensors', fileName: 'legacy_epoch_1.safetensors' },
+      { blobId: 'LEGACYS1.jpeg', fileName: 'legacy_epoch_1_sample_1.jpeg' },
+    ]);
+  });
+
+  it('counts URLs that are not orchestrator blobs as omitted rather than dropping them silently', () => {
+    const { entries, omittedCount } = buildEpochArchiveEntries({
+      trainingResults: {
+        ...v2Results,
+        epochs: [
+          {
+            epochNumber: 1,
+            modelUrl: 'https://s3.example.com/jobs/abc/assets/old.safetensors',
+            modelSize: 0,
+            sampleImages: [blobUrl('OK.jpeg'), ''],
+          },
+        ],
+      },
+      modelName: 'legacy',
+    });
+
+    expect(entries).toEqual([{ blobId: 'OK.jpeg', fileName: 'legacy_epoch_1_sample_1.jpeg' }]);
+    expect(omittedCount).toBe(2);
+  });
+
+  it('keeps the model files and reports the overflow when a run exceeds the entry cap', () => {
+    const { entries, omittedCount } = buildEpochArchiveEntries({
+      trainingResults: v2Results,
+      modelName: 'capped',
+      maxEntries: 3,
+    });
+
+    expect(entries.map((e) => e.blobId)).toEqual([
+      'MODEL1.safetensors',
+      'MODEL2.safetensors',
+      'E1S1.jpeg',
+    ]);
+    expect(omittedCount).toBe(2);
+  });
+});
+
+describe('getTrainingEpochArchive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createBlobArchive.mockResolvedValue({
+      url: 'https://orchestration.civitai.com/v2/consumer/blobs/archive/token',
+      entryCount: 5,
+      format: 'zip',
+      expiresAt: '2030-01-01T00:00:00Z',
+    });
+  });
+
+  const modelVersion = {
+    id: 1,
+    model: { userId: 10, name: 'My Cool Model!' },
+    files: [{ metadata: { trainingResults: v2Results } }],
+  };
+
+  it('archives every blob for the owner', async () => {
+    findUnique.mockResolvedValue(modelVersion);
+
+    const result = await getTrainingEpochArchive({ modelVersionId: 1, userId: 10 });
+
+    expect(createBlobArchive).toHaveBeenCalledWith({
+      entries: expect.arrayContaining([
+        { blobId: 'MODEL1.safetensors', fileName: 'My_Cool_Model__epoch_1.safetensors' },
+        { blobId: 'E2S2.mp4', fileName: 'My_Cool_Model__epoch_2_sample_2.mp4' },
+      ]),
+      archiveName: 'My_Cool_Model__training.zip',
+    });
+    expect(createBlobArchive.mock.calls[0][0].entries).toHaveLength(5);
+    expect(result.url).toContain('/archive/token');
+    expect(result.omittedCount).toBe(0);
+  });
+
+  it('refuses a user who does not own the model', async () => {
+    findUnique.mockResolvedValue(modelVersion);
+
+    await expect(getTrainingEpochArchive({ modelVersionId: 1, userId: 99 })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(createBlobArchive).not.toHaveBeenCalled();
+  });
+
+  it('allows a moderator', async () => {
+    findUnique.mockResolvedValue(modelVersion);
+
+    await expect(
+      getTrainingEpochArchive({ modelVersionId: 1, userId: 99, isModerator: true })
+    ).resolves.toMatchObject({ entryCount: 5 });
+  });
+
+  it('fails loudly rather than requesting an empty archive when no blob survives', async () => {
+    findUnique.mockResolvedValue({
+      ...modelVersion,
+      files: [
+        {
+          metadata: {
+            trainingResults: {
+              ...v2Results,
+              epochs: [
+                {
+                  epochNumber: 1,
+                  modelUrl: 'https://s3.example.com/jobs/abc/assets/old.safetensors',
+                  modelSize: 0,
+                  sampleImages: [],
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    await expect(getTrainingEpochArchive({ modelVersionId: 1, userId: 10 })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+    expect(createBlobArchive).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/training-epoch-archive.test.ts
+++ b/src/server/services/__tests__/training-epoch-archive.test.ts
@@ -50,12 +50,13 @@ const v2Results = {
 
 describe('buildEpochArchiveEntries', () => {
   it('includes every epoch model AND every sample, models first, ascending by epoch', () => {
-    const { entries, omittedCount } = buildEpochArchiveEntries({
+    const { entries, unresolvedCount, cappedCount } = buildEpochArchiveEntries({
       trainingResults: v2Results,
       modelName: 'My Cool Model!',
     });
 
-    expect(omittedCount).toBe(0);
+    expect(unresolvedCount).toBe(0);
+    expect(cappedCount).toBe(0);
     expect(entries).toEqual([
       { blobId: 'MODEL1.safetensors', fileName: 'My_Cool_Model__epoch_1.safetensors' },
       { blobId: 'MODEL2.safetensors', fileName: 'My_Cool_Model__epoch_2.safetensors' },
@@ -91,8 +92,8 @@ describe('buildEpochArchiveEntries', () => {
     ]);
   });
 
-  it('counts URLs that are not orchestrator blobs as omitted rather than dropping them silently', () => {
-    const { entries, omittedCount } = buildEpochArchiveEntries({
+  it('counts URLs that are not orchestrator blobs as unresolved rather than dropping them silently', () => {
+    const { entries, unresolvedCount, cappedCount } = buildEpochArchiveEntries({
       trainingResults: {
         ...v2Results,
         epochs: [
@@ -108,11 +109,12 @@ describe('buildEpochArchiveEntries', () => {
     });
 
     expect(entries).toEqual([{ blobId: 'OK.jpeg', fileName: 'legacy_epoch_1_sample_1.jpeg' }]);
-    expect(omittedCount).toBe(2);
+    expect(unresolvedCount).toBe(2);
+    expect(cappedCount).toBe(0);
   });
 
   it('keeps the model files and reports the overflow when a run exceeds the entry cap', () => {
-    const { entries, omittedCount } = buildEpochArchiveEntries({
+    const { entries, unresolvedCount, cappedCount } = buildEpochArchiveEntries({
       trainingResults: v2Results,
       modelName: 'capped',
       maxEntries: 3,
@@ -123,7 +125,8 @@ describe('buildEpochArchiveEntries', () => {
       'MODEL2.safetensors',
       'E1S1.jpeg',
     ]);
-    expect(omittedCount).toBe(2);
+    expect(cappedCount).toBe(2);
+    expect(unresolvedCount).toBe(0);
   });
 });
 
@@ -158,7 +161,8 @@ describe('getTrainingEpochArchive', () => {
     });
     expect(createBlobArchive.mock.calls[0][0].entries).toHaveLength(5);
     expect(result.url).toContain('/archive/token');
-    expect(result.omittedCount).toBe(0);
+    expect(result.unresolvedCount).toBe(0);
+    expect(result.cappedCount).toBe(0);
   });
 
   it('refuses a user who does not own the model', async () => {

--- a/src/server/services/orchestrator/__tests__/blobArchive.error-mapping.test.ts
+++ b/src/server/services/orchestrator/__tests__/blobArchive.error-mapping.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * Error mapping for the blob-archive step. The archive call reaches the orchestrator
+ * over the network, so an upstream 5xx or a status-less transport failure is a
+ * dependency outage — a retry-able 503, not a 500 against our own SLO — and whatever
+ * detail the orchestrator gave has to survive into the message we surface.
+ */
+
+const { mockInvoke } = vi.hoisted(() => ({ mockInvoke: vi.fn() }));
+
+vi.mock('@civitai/client', () => ({ invokeBlobArchiveStepTemplate: mockInvoke }));
+vi.mock('~/server/services/orchestrator/client', () => ({ internalOrchestratorClient: {} }));
+
+import { createBlobArchive } from '~/server/services/orchestrator/blobArchive';
+
+const entries = [{ blobId: 'A.safetensors', fileName: 'a.safetensors' }];
+
+// The generated client RESOLVES `{ data: undefined, error }` on an error response;
+// it only REJECTS when the request never got a response at all.
+const errorResolve = (error: Record<string, unknown>) => ({ data: undefined, error });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('createBlobArchive error mapping', () => {
+  it('maps an upstream 5xx to a retry-able 503, keeping the client error as cause', async () => {
+    const upstream = { status: 502, detail: 'bad gateway' };
+    mockInvoke.mockResolvedValue(errorResolve(upstream));
+
+    const thrown = await createBlobArchive({ entries }).catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(TRPCError);
+    expect(thrown.code).toBe('SERVICE_UNAVAILABLE');
+    // tRPC re-wraps a non-Error cause, so match on the carried fields rather than identity.
+    expect(thrown.cause).toMatchObject(upstream);
+  });
+
+  it('maps a status-less network failure to a retry-able 503', async () => {
+    mockInvoke.mockRejectedValue(new TypeError('fetch failed'));
+
+    const thrown = await createBlobArchive({ entries }).catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(TRPCError);
+    expect(thrown.code).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('lets an unrecognized rejection bubble as-is rather than calling it an outage', async () => {
+    const bug = new TypeError("Cannot read properties of undefined (reading 'map')");
+    mockInvoke.mockRejectedValue(bug);
+
+    await expect(createBlobArchive({ entries })).rejects.toBe(bug);
+  });
+
+  it('keeps the orchestrator detail in the message on an unclassified failure', async () => {
+    mockInvoke.mockResolvedValue(errorResolve({ detail: 'blob A.safetensors is unreadable' }));
+
+    const thrown = await createBlobArchive({ entries }).catch((e) => e);
+
+    expect(thrown.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(thrown.message).toBe('blob A.safetensors is unreadable');
+  });
+
+  it('prefers the structured validation messages over `detail` on a 400', async () => {
+    mockInvoke.mockResolvedValue(
+      errorResolve({ status: 400, detail: 'ignored', errors: { messages: ['too many entries'] } })
+    );
+
+    const thrown = await createBlobArchive({ entries }).catch((e) => e);
+
+    expect(thrown.code).toBe('BAD_REQUEST');
+    expect(thrown.message).toBe('too many entries');
+  });
+
+  it('maps a non-400 4xx to BAD_REQUEST instead of a 500', async () => {
+    mockInvoke.mockResolvedValue(errorResolve({ status: 404, detail: 'blob not found' }));
+
+    const thrown = await createBlobArchive({ entries }).catch((e) => e);
+
+    expect(thrown.code).toBe('BAD_REQUEST');
+    expect(thrown.message).toBe('blob not found');
+  });
+});

--- a/src/server/services/orchestrator/blobArchive.ts
+++ b/src/server/services/orchestrator/blobArchive.ts
@@ -1,10 +1,19 @@
 import type { BlobArchiveEntry, BlobArchiveOutput } from '@civitai/client';
 import { invokeBlobArchiveStepTemplate } from '@civitai/client';
 import { internalOrchestratorClient } from '~/server/services/orchestrator/client';
-import { throwBadRequestError, throwInternalServerError } from '~/server/utils/errorHandling';
+import {
+  isUpstreamNetworkError,
+  isUpstreamServerOrNetworkError,
+  throwBadRequestError,
+  throwInternalServerError,
+  throwServiceUnavailableError,
+} from '~/server/utils/errorHandling';
 
 /** The orchestrator rejects a blobArchive step with more entries than this. */
 export const MAX_BLOB_ARCHIVE_ENTRIES = 1000;
+
+const ARCHIVE_UNAVAILABLE_MESSAGE =
+  'Archive services are temporarily unavailable. Please try again.';
 
 /**
  * Asks the orchestrator to bundle a set of blobs into one archive and returns the
@@ -25,13 +34,31 @@ export async function createBlobArchive({
   const { data, error } = await invokeBlobArchiveStepTemplate({
     client: internalOrchestratorClient,
     body: { entries, archiveName, format: 'zip' },
+  }).catch((thrown) => {
+    // A rejected call never carries an HTTP status. A recognized network failure is a
+    // transient upstream outage → retry-able 503; anything else is a real bug on our
+    // side and is left to surface as a 500.
+    if (isUpstreamNetworkError(thrown))
+      throw throwServiceUnavailableError(ARCHIVE_UNAVAILABLE_MESSAGE, thrown);
+    throw thrown;
   });
 
   if (!data) {
     const messages = (error as { errors?: { messages?: string[] } })?.errors?.messages?.join('\n');
     const detail = messages ?? (error as { detail?: string })?.detail;
     if (error?.status === 400) throw throwBadRequestError(detail ?? 'Unable to build archive');
-    throw throwInternalServerError(detail ?? 'Unable to build archive');
+    // An upstream 5xx is a dependency outage, not our fault — surface it as a
+    // retry-able 503 rather than a 500 the client cannot act on.
+    if (isUpstreamServerOrNetworkError({ clientError: error, thrown: error }))
+      throw throwServiceUnavailableError(ARCHIVE_UNAVAILABLE_MESSAGE, error);
+    // Any other 4xx is a client/validation fault; keep it 4xx instead of flattening to 500.
+    if (typeof error?.status === 'number' && error.status > 400 && error.status < 500)
+      throw throwBadRequestError(detail ?? 'Unable to build archive');
+    // `throwInternalServerError` reads `.message` off what it's given, so hand it an
+    // Error carrying the orchestrator's detail — a bare string loses it.
+    throw throwInternalServerError(
+      new Error(detail ?? 'Unable to build archive', { cause: error })
+    );
   }
 
   return data;

--- a/src/server/services/orchestrator/blobArchive.ts
+++ b/src/server/services/orchestrator/blobArchive.ts
@@ -1,0 +1,38 @@
+import type { BlobArchiveEntry, BlobArchiveOutput } from '@civitai/client';
+import { invokeBlobArchiveStepTemplate } from '@civitai/client';
+import { internalOrchestratorClient } from '~/server/services/orchestrator/client';
+import { throwBadRequestError, throwInternalServerError } from '~/server/utils/errorHandling';
+
+/** The orchestrator rejects a blobArchive step with more entries than this. */
+export const MAX_BLOB_ARCHIVE_ENTRIES = 1000;
+
+/**
+ * Asks the orchestrator to bundle a set of blobs into one archive and returns the
+ * signed URL that streams it. The step runs in-process on the orchestrator, so the
+ * archive is never buffered or proxied through us.
+ */
+export async function createBlobArchive({
+  entries,
+  archiveName,
+}: {
+  entries: BlobArchiveEntry[];
+  archiveName?: string;
+}): Promise<BlobArchiveOutput> {
+  if (!entries.length) throw throwBadRequestError('No blobs to archive');
+  if (entries.length > MAX_BLOB_ARCHIVE_ENTRIES)
+    throw throwBadRequestError(`Cannot archive more than ${MAX_BLOB_ARCHIVE_ENTRIES} blobs`);
+
+  const { data, error } = await invokeBlobArchiveStepTemplate({
+    client: internalOrchestratorClient,
+    body: { entries, archiveName, format: 'zip' },
+  });
+
+  if (!data) {
+    const messages = (error as { errors?: { messages?: string[] } })?.errors?.messages?.join('\n');
+    const detail = messages ?? (error as { detail?: string })?.detail;
+    if (error?.status === 400) throw throwBadRequestError(detail ?? 'Unable to build archive');
+    throw throwInternalServerError(detail ?? 'Unable to build archive');
+  }
+
+  return data;
+}

--- a/src/server/services/orchestrator/training/epoch-archive.ts
+++ b/src/server/services/orchestrator/training/epoch-archive.ts
@@ -39,8 +39,10 @@ function extensionOf(blobId: string) {
 
 export type TrainingEpochArchiveEntries = {
   entries: BlobArchiveEntry[];
-  /** Blobs we could not include — either not orchestrator blobs, or over the entry cap. */
-  omittedCount: number;
+  /** Files whose URL is not an orchestrator blob, so there is nothing left to fetch. */
+  unresolvedCount: number;
+  /** Files that still exist but did not fit under the archive's entry cap. */
+  cappedCount: number;
 };
 
 /**
@@ -81,23 +83,24 @@ export function buildEpochArchiveEntries({
 
   const entries: BlobArchiveEntry[] = [];
   const seen = new Set<string>();
-  let omittedCount = 0;
+  let unresolvedCount = 0;
+  let cappedCount = 0;
 
   for (const candidate of candidates) {
     const blobId = candidate.url ? getConsumerBlobId(candidate.url) : undefined;
     if (!blobId || seen.has(blobId)) {
-      if (!blobId) omittedCount++;
+      if (!blobId) unresolvedCount++;
       continue;
     }
     if (entries.length >= maxEntries) {
-      omittedCount++;
+      cappedCount++;
       continue;
     }
     seen.add(blobId);
     entries.push({ blobId, fileName: candidate.fileName(blobId) });
   }
 
-  return { entries, omittedCount };
+  return { entries, unresolvedCount, cappedCount };
 }
 
 /**
@@ -131,7 +134,10 @@ export async function getTrainingEpochArchive({
   if (!trainingResults?.epochs?.length) throw throwNotFoundError('No training epochs found');
 
   const modelName = modelVersion.model.name;
-  const { entries, omittedCount } = buildEpochArchiveEntries({ trainingResults, modelName });
+  const { entries, unresolvedCount, cappedCount } = buildEpochArchiveEntries({
+    trainingResults,
+    modelName,
+  });
   if (!entries.length) throw throwNotFoundError('No downloadable training files found');
 
   const archive = await createBlobArchive({
@@ -143,6 +149,7 @@ export async function getTrainingEpochArchive({
     url: archive.url,
     entryCount: archive.entryCount,
     expiresAt: archive.expiresAt,
-    omittedCount,
+    unresolvedCount,
+    cappedCount,
   };
 }

--- a/src/server/services/orchestrator/training/epoch-archive.ts
+++ b/src/server/services/orchestrator/training/epoch-archive.ts
@@ -1,0 +1,148 @@
+import type { BlobArchiveEntry } from '@civitai/client';
+import { dbRead } from '~/server/db/client';
+import type { ModelFileMetadata, TrainingResults } from '~/server/schema/model-file.schema';
+import { pickBestTrainingFile } from '~/server/schema/model-file.schema';
+import {
+  createBlobArchive,
+  MAX_BLOB_ARCHIVE_ENTRIES,
+} from '~/server/services/orchestrator/blobArchive';
+import { throwAuthorizationError, throwNotFoundError } from '~/server/utils/errorHandling';
+import { getConsumerBlobId } from '~/shared/orchestrator/blob-url';
+
+type NormalizedEpoch = { epochNumber: number; modelUrl: string; sampleImages: string[] };
+
+function normalizeEpochs(trainingResults: TrainingResults): NormalizedEpoch[] {
+  return (trainingResults.epochs ?? []).map((epoch) =>
+    'epoch_number' in epoch
+      ? {
+          epochNumber: epoch.epoch_number,
+          modelUrl: epoch.model_url,
+          sampleImages: epoch.sample_images?.map((s) => s.image_url) ?? [],
+        }
+      : {
+          epochNumber: epoch.epochNumber,
+          modelUrl: epoch.modelUrl,
+          sampleImages: epoch.sampleImages ?? [],
+        }
+  );
+}
+
+function sanitize(value: string) {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+/** Blob ids carry the original extension (`ABC123.jpeg`), which is all we know about the media type. */
+function extensionOf(blobId: string) {
+  const dot = blobId.lastIndexOf('.');
+  return dot > 0 ? blobId.slice(dot) : '';
+}
+
+export type TrainingEpochArchiveEntries = {
+  entries: BlobArchiveEntry[];
+  /** Blobs we could not include — either not orchestrator blobs, or over the entry cap. */
+  omittedCount: number;
+};
+
+/**
+ * Epoch models first, then sample media, both ascending by epoch. Ordering is what
+ * decides the contents when a run has more blobs than one archive can hold, and the
+ * model files are the part a user cannot regenerate.
+ */
+export function buildEpochArchiveEntries({
+  trainingResults,
+  modelName,
+  maxEntries = MAX_BLOB_ARCHIVE_ENTRIES,
+}: {
+  trainingResults: TrainingResults;
+  modelName: string;
+  maxEntries?: number;
+}): TrainingEpochArchiveEntries {
+  const epochs = [...normalizeEpochs(trainingResults)].sort(
+    (a, b) => a.epochNumber - b.epochNumber
+  );
+  const prefix = sanitize(modelName);
+
+  const candidates: Array<{ url: string; fileName: (blobId: string) => string }> = [];
+  for (const epoch of epochs) {
+    candidates.push({
+      url: epoch.modelUrl,
+      fileName: () => `${prefix}_epoch_${epoch.epochNumber}.safetensors`,
+    });
+  }
+  for (const epoch of epochs) {
+    epoch.sampleImages.forEach((url, index) => {
+      candidates.push({
+        url,
+        fileName: (blobId) =>
+          `${prefix}_epoch_${epoch.epochNumber}_sample_${index + 1}${extensionOf(blobId)}`,
+      });
+    });
+  }
+
+  const entries: BlobArchiveEntry[] = [];
+  const seen = new Set<string>();
+  let omittedCount = 0;
+
+  for (const candidate of candidates) {
+    const blobId = candidate.url ? getConsumerBlobId(candidate.url) : undefined;
+    if (!blobId || seen.has(blobId)) {
+      if (!blobId) omittedCount++;
+      continue;
+    }
+    if (entries.length >= maxEntries) {
+      omittedCount++;
+      continue;
+    }
+    seen.add(blobId);
+    entries.push({ blobId, fileName: candidate.fileName(blobId) });
+  }
+
+  return { entries, omittedCount };
+}
+
+/**
+ * Builds a single zip of everything a completed training run produced — every epoch's
+ * model file and every sample image — and returns the orchestrator's signed URL for it.
+ */
+export async function getTrainingEpochArchive({
+  modelVersionId,
+  userId,
+  isModerator,
+}: {
+  modelVersionId: number;
+  userId: number;
+  isModerator?: boolean;
+}) {
+  const modelVersion = await dbRead.modelVersion.findUnique({
+    where: { id: modelVersionId },
+    select: {
+      id: true,
+      model: { select: { userId: true, name: true } },
+      files: { select: { metadata: true }, where: { type: 'Training Data' } },
+    },
+  });
+
+  if (!modelVersion) throw throwNotFoundError('Model version not found');
+  if (modelVersion.model.userId !== userId && !isModerator)
+    throw throwAuthorizationError('You do not have permission to download this training run');
+
+  const trainingFile = pickBestTrainingFile(modelVersion.files);
+  const trainingResults = (trainingFile?.metadata as ModelFileMetadata | null)?.trainingResults;
+  if (!trainingResults?.epochs?.length) throw throwNotFoundError('No training epochs found');
+
+  const modelName = modelVersion.model.name;
+  const { entries, omittedCount } = buildEpochArchiveEntries({ trainingResults, modelName });
+  if (!entries.length) throw throwNotFoundError('No downloadable training files found');
+
+  const archive = await createBlobArchive({
+    entries,
+    archiveName: `${sanitize(modelName)}_training.zip`,
+  });
+
+  return {
+    url: archive.url,
+    entryCount: archive.entryCount,
+    expiresAt: archive.expiresAt,
+    omittedCount,
+  };
+}


### PR DESCRIPTION
"Download All" fired one browser download per epoch model, so sample images from the run were never included. It now calls a new `training.getEpochArchive` procedure, which asks the orchestrator to zip every blob the run produced and returns a short-lived signed URL, warning the user when blobs could not be resolved.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868ktyc2f`). Reviewed locally before push.