### PR TITLE
feat(apps): App Store copy says "Standalone", not "Off-site" — labels only, no kind values

### DIFF
--- a/src/components/Apps/AppBlockCard.external.browser.test.tsx
+++ b/src/components/Apps/AppBlockCard.external.browser.test.tsx
@@ -12,7 +12,7 @@ import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema'
  *   - renders an "Open ↗" link to the external URL with target=_blank +
  *     rel="noopener noreferrer",
  *   - HIDES the Install / Manage button (an external app has no install),
- *   - shows an "Off-site" badge so the off-platform nature is visually clear,
+ *   - shows a "Standalone" badge so the off-platform nature is visually clear,
  *   - keeps the universal "View details" affordance.
  * A normal on-platform app (externalUrl=null) is unchanged.
  */
@@ -109,11 +109,11 @@ describe('AppBlockCard — external-link (off-site) app', () => {
     expect(page.getByRole('button', { name: /^install$/i }).query()).toBeNull();
   });
 
-  test('shows an "Off-site" badge', async () => {
+  test('shows a "Standalone" badge', async () => {
     renderWithProviders(
       <AppBlockCard block={makeExternalBlock()} alreadySubscribed={false} onOpen={onOpen} />
     );
-    await expect.element(page.getByText('Off-site', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText('Standalone', { exact: true })).toBeInTheDocument();
   });
 
   test('still renders the universal "View details" affordance', async () => {
@@ -143,13 +143,13 @@ describe('AppBlockCard — external-link (off-site) app', () => {
 });
 
 describe('AppBlockCard — on-platform app unchanged (no external affordance)', () => {
-  test('a model-slot app shows Install, NO "Open" link, NO "Off-site" badge', async () => {
+  test('a model-slot app shows Install, NO "Open" link, NO "Standalone" badge', async () => {
     renderWithProviders(
       <AppBlockCard block={makeModelBlock()} alreadySubscribed={false} onOpen={onOpen} />
     );
     await expect.element(page.getByRole('button', { name: /^install$/i })).toBeInTheDocument();
     // The external "Open" link is a link named exactly "Open" — must be absent.
     expect(page.getByRole('link', { name: /^open$/i }).query()).toBeNull();
-    expect(page.getByText('Off-site', { exact: true }).query()).toBeNull();
+    expect(page.getByText('Standalone', { exact: true }).query()).toBeNull();
   });
 });

--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -224,7 +224,7 @@ export function AppBlockCard({
                 size="sm"
                 leftSection={<IconExternalLink size={12} />}
               >
-                Off-site
+                Standalone
               </Badge>
             )}
             {/* Mod-assigned marketplace category (+ its icon). NULL until a mod

--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -157,7 +157,7 @@ export function AppBlockCard({
   // the card renders an "Open ↗" link to the off-site URL (new tab) and HIDES
   // the Install button + (already-card-hidden) scopes, since an external app has
   // no install / scopes / token. The off-site nature is flagged with a small
-  // "Off-site" badge. Everything else (View details) is unchanged.
+  // "Standalone" badge. Everything else (View details) is unchanged.
   const isExternal = Boolean(block.externalUrl);
   // Show Install ONLY for an app that installs into a model/in-context slot.
   // A page app (target slot `app.page`) is STATELESS — installModel `'none'` in

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -210,14 +210,21 @@ describe('AppListingCard', () => {
         })}
       />
     );
-    // The kind signal ("Standalone") is no longer a badge — it's conveyed by the
-    // CTA below (an external "Visit" anchor vs. an internal Open/View details
-    // link) plus the off-site disclosure Alert on the detail page.
-    await expect.element(page.getByText('Standalone', { exact: true })).not.toBeInTheDocument();
     const visit = page.getByRole('link', { name: 'Visit' });
     await expect.element(visit).toHaveAttribute('href', 'https://ext.app');
     await expect.element(visit).toHaveAttribute('target', '_blank');
     await expect.element(visit).toHaveAttribute('rel', 'noopener noreferrer');
+    // The kind signal ("Standalone") is no longer a badge — it's conveyed by the
+    // CTA above (an external "Visit" anchor vs. an internal Open/View details
+    // link) plus the off-site disclosure Alert on the detail page.
+    //
+    // 🔴 `expect(locator.query()).toBeNull()`, NOT `expect.element(...).not.toBeInTheDocument()`.
+    // The latter is REACHABLE BUT NON-ASSERTING: it passes for every string, including
+    // ones the card demonstrably renders. Controlled both ways — asserting absence of
+    // 'Visit' (rendered, per the three awaits above) goes RED in this form and PASSED in
+    // the old one. Ordering is load-bearing too: `.query()` is a point-in-time read, so
+    // it must follow an awaited positive assertion or it can pass on an unsettled render.
+    expect(page.getByText('Standalone', { exact: true }).query()).toBeNull();
   });
 
   test('off-site connect with NO external target → View details → unified detail', async () => {

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -210,10 +210,10 @@ describe('AppListingCard', () => {
         })}
       />
     );
-    // The kind signal ("Off-site") is no longer a badge — it's conveyed by the
+    // The kind signal ("Standalone") is no longer a badge — it's conveyed by the
     // CTA below (an external "Visit" anchor vs. an internal Open/View details
     // link) plus the off-site disclosure Alert on the detail page.
-    await expect.element(page.getByText('Off-site', { exact: true })).not.toBeInTheDocument();
+    await expect.element(page.getByText('Standalone', { exact: true })).not.toBeInTheDocument();
     const visit = page.getByRole('link', { name: 'Visit' });
     await expect.element(visit).toHaveAttribute('href', 'https://ext.app');
     await expect.element(visit).toHaveAttribute('target', '_blank');

--- a/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
@@ -243,7 +243,7 @@ describe('AppListingsMarketplaceBody', () => {
   test('clicking a kind toggle WRITES kind to the URL (shallow, no scroll)', async () => {
     renderWithProviders(<AppListingsMarketplaceBody />);
     await openFilters();
-    await userEvent.click(page.getByRole('button', { name: 'Off-site' }));
+    await userEvent.click(page.getByRole('button', { name: 'Standalone' }));
 
     expect(router.replace).toHaveBeenCalled();
     const [url, , options] = vi.mocked(router.replace).mock.calls.at(-1)!;

--- a/src/components/Apps/AppListingsMarketplaceBody.hydration.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.hydration.browser.test.tsx
@@ -196,7 +196,7 @@ describe('/apps store — the first client paint already reflects the URL', () =
     // so a name query is a strict-mode violation whenever both are on screen.)
     await userEvent.click(page.getByTestId('apps-store-filters-dropdown'));
     await expect
-      .element(page.getByRole('button', { name: 'Off-site' }))
+      .element(page.getByRole('button', { name: 'Standalone' }))
       .toHaveAttribute('aria-pressed', 'true');
   });
 

--- a/src/components/Apps/AppListingsMarketplaceBody.urlState.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.urlState.browser.test.tsx
@@ -195,7 +195,7 @@ describe('the harness itself round-trips (guard on the guard)', () => {
     // router would make the racing test pass for the wrong reason.
     renderWithProviders(<StatefulRouterHarness latencyMs={0} />);
     await openFilters();
-    await userEvent.click(page.getByRole('button', { name: 'Off-site' }));
+    await userEvent.click(page.getByRole('button', { name: 'Standalone' }));
     await vi.waitFor(() => expect(currentQuery()).toMatchObject({ kind: 'offsite' }));
     // …and the component re-renders FROM the URL.
     await vi.waitFor(() => expect(mocks.lastArgs).toMatchObject({ kind: 'offsite' }));
@@ -272,7 +272,7 @@ describe('(b) two fast filter clicks must not drop one', () => {
   test('a sort change racing a kind change keeps both', async () => {
     renderWithProviders(<StatefulRouterHarness latencyMs={ROUTER_LATENCY_MS} />);
     await openFilters();
-    await userEvent.click(page.getByRole('button', { name: 'Off-site' }));
+    await userEvent.click(page.getByRole('button', { name: 'Standalone' }));
     // Close the panel and change sort immediately.
     await userEvent.click(page.getByLabelText('Sort').first());
     await userEvent.click(page.getByRole('option', { name: 'Newest' }));

--- a/src/components/Apps/AppsStoreFiltersDropdown.browser.test.tsx
+++ b/src/components/Apps/AppsStoreFiltersDropdown.browser.test.tsx
@@ -99,7 +99,7 @@ describe('AppsStoreFiltersDropdown — the panel', () => {
     setup({ kind: 'offsite', category: 'games' });
     await userEvent.click(trigger());
     await expect
-      .element(page.getByRole('button', { name: 'Off-site' }))
+      .element(page.getByRole('button', { name: 'Standalone' }))
       .toHaveAttribute('aria-pressed', 'true');
     await expect
       .element(page.getByRole('button', { name: 'Games' }))

--- a/src/components/Apps/ExternalSubmitForm.tsx
+++ b/src/components/Apps/ExternalSubmitForm.tsx
@@ -405,10 +405,10 @@ function ExternalCreateForm() {
         title="List an external app"
       >
         <Text size="sm">
-          List an app hosted off-site by linking your registered OAuth app so users can grant it
-          access. Start with your app’s URL — we’ll pull in a name, description and images you can
-          tweak. A moderator reviews it before it appears. This does not change what your app can
-          do: your OAuth client’s allowed scopes stay the limit.
+          List a standalone app hosted elsewhere by linking your registered OAuth app so users can
+          grant it access. Start with your app’s URL — we’ll pull in a name, description and images
+          you can tweak. A moderator reviews it before it appears. This does not change what your
+          app can do: your OAuth client’s allowed scopes stay the limit.
         </Text>
       </Alert>
 
@@ -788,9 +788,9 @@ function ExternalCreateForm() {
                     title="Draft created"
                   >
                     <Text size="sm">
-                      <Code>{submitted.slug}</Code> is a pending off-site submission. Attach an icon
-                      and a cover below to be approved — screenshots are recommended but optional and
-                      can be added later. Content rating:{' '}
+                      <Code>{submitted.slug}</Code> is a pending standalone submission. Attach an
+                      icon and a cover below to be approved — screenshots are recommended but
+                      optional and can be added later. Content rating:{' '}
                       <Badge size="xs">{values.contentRating}</Badge>
                     </Text>
                   </Alert>

--- a/src/components/Apps/KindFilterButtons.tsx
+++ b/src/components/Apps/KindFilterButtons.tsx
@@ -12,13 +12,13 @@ import type { ListingKindFilter } from '~/server/schema/blocks/app-listing-read.
  * when the store's filters moved into the `/models`-style Filters dropdown: the
  * dropdown panel and the body are now different files, so the control has to be
  * importable. The rendered markup and the props are UNCHANGED by the move — the
- * existing marketplace-body tests that click `Off-site` still address the same
+ * existing marketplace-body tests that click `Standalone` still address the same
  * button, they just open the dropdown first.
  */
 const KIND_OPTIONS: { value: ListingKindFilter; label: string; icon: typeof IconApps }[] = [
   { value: 'all', label: 'All apps', icon: IconLayoutGrid },
   { value: 'onsite', label: 'On-site', icon: IconApps },
-  { value: 'offsite', label: 'Off-site', icon: IconExternalLink },
+  { value: 'offsite', label: 'Standalone', icon: IconExternalLink },
 ];
 
 export interface KindFilterButtonsProps {

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -195,7 +195,7 @@ export function OffsiteReviewQueue() {
         labelPosition="left"
       />
       <Text size="xs" c="dimmed">
-        Off-site apps — a lighter, content-only review (no code / bundle). Approving requires an
+        Standalone apps — a lighter, content-only review (no code / bundle). Approving requires an
         asset-complete draft (icon + cover + ≥1 screenshot).
       </Text>
 
@@ -1221,7 +1221,7 @@ export function OffsiteReportsQueue() {
           <Group gap={6}>
             <IconFlag size={14} />
             <Text size="sm" fw={600}>
-              Off-site listing reports
+              Standalone listing reports
             </Text>
             <Badge size="sm" variant="light" color={items.length > 0 ? 'red' : 'gray'}>
               {items.length}
@@ -1232,8 +1232,8 @@ export function OffsiteReportsQueue() {
       />
       <Group justify="space-between">
         <Text size="xs" c="dimmed">
-          User reports of approved off-site apps. Verify ownership out-of-band, then delist / relist
-          / purge and resolve or dismiss the report.
+          User reports of approved standalone apps. Verify ownership out-of-band, then delist /
+          relist / purge and resolve or dismiss the report.
         </Text>
         <SegmentedControl
           size="xs"

--- a/src/components/Apps/SubmitModeSelector.tsx
+++ b/src/components/Apps/SubmitModeSelector.tsx
@@ -32,7 +32,7 @@ export function SubmitModeSelector({ onSelect }: { onSelect: (mode: SubmitMode) 
       <ModeCard
         icon={<IconExternalLink size={22} />}
         title="List an external app (connect your OAuth app)"
-        description="List an app hosted off-site by linking your registered OAuth app so users can grant it access. Disclose the scopes your app requests and why, add an optional homepage link — a moderator reviews before it appears."
+        description="List a standalone app hosted elsewhere by linking your registered OAuth app so users can grant it access. Disclose the scopes your app requests and why, add an optional homepage link — a moderator reviews before it appears."
         onSelect={() => onSelect('external')}
         testId="apps-submit-mode-card-external"
       />

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -79,26 +79,28 @@ describe('getListingBadge', () => {
   /**
    * 🔴 NEW BEHAVIOUR (not regression coverage): off-site used to badge as
    * "Connect app" when a client was linked and "Off-site" when not. There is one
-   * badge now. This pins the collapsed pair — the "Connect app" case above is
-   * what a revert would put back, and it is what this assertion refuses.
+   * badge now, and PR #4187 renamed its word to "Standalone". This pins the
+   * collapsed pair — the "Connect app" case above is what a revert would put
+   * back, and it is what this assertion refuses.
    */
-  it('🔴 off-site → "Off-site", with or without a usable destination', () => {
+  it('🔴 off-site → "Standalone", with or without a usable destination', () => {
     for (const externalUrl of [null, 'https://x.com', 'http://insecure.example']) {
       expect(getListingBadge(offsiteCard(externalUrl)), String(externalUrl)).toEqual({
-        label: 'Off-site',
+        label: 'Standalone',
         kind: 'offsite',
       });
     }
   });
   /**
    * The word is load-bearing: it must be the SAME word the store's kind filter
-   * puts on the whole category (`KindFilterButtons`' "Off-site"). Under the fork
+   * puts on the whole category (`KindFilterButtons`' "Standalone"). Under the fork
    * the parent label was true of only one child while the submit flow minted
    * nothing but the other one. Pinned as a literal so a reword has to be
-   * deliberate — PR #4187 renames it, and this is the assertion it must update.
+   * deliberate — PR #4187 renamed it Off-site → Standalone, and this assertion
+   * moved with it.
    */
   it('🔴 the off-site badge label is exactly the store kind-filter word', () => {
-    expect(getListingBadge(offsiteCard('https://x.com')).label).toBe('Off-site');
+    expect(getListingBadge(offsiteCard('https://x.com')).label).toBe('Standalone');
   });
 });
 

--- a/src/components/Apps/__tests__/appListingDetailRows.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailRows.test.ts
@@ -73,8 +73,9 @@ describe('buildListingDetailRows — order', () => {
    * 🔴 NEW BEHAVIOUR (not regression coverage). The kind row used to read
    * "Connect app" or "Off-site link" depending on `connectClientId`; off-site is
    * one kind now, so it reads one word — and that word is the store kind
-   * filter's own "Off-site" (`KindFilterButtons`), which the "Connect app"
-   * branch was contradicting on the majority of listings.
+   * filter's own "Standalone" (`KindFilterButtons`; renamed from "Off-site" by
+   * PR #4187), which the "Connect app" branch was contradicting on the majority
+   * of listings.
    *
    * Both fixtures set a DIFFERENT `connectClientId` and a DIFFERENT
    * `externalUrl` — the two inputs the deleted fork could have keyed on — so a
@@ -88,7 +89,7 @@ describe('buildListingDetailRows — order', () => {
       }),
       { formatDate: fmt }
     );
-    expect(connected.find((r) => r.key === 'kind')?.value).toBe('Off-site');
+    expect(connected.find((r) => r.key === 'kind')?.value).toBe('Standalone');
 
     // 🔴 The grandfathered production listing: an approved off-site row with NO
     // OAuth client. It must render the same single label, not a blank / dash /
@@ -103,14 +104,15 @@ describe('buildListingDetailRows — order', () => {
       }),
       { formatDate: fmt }
     );
-    expect(grandfathered.find((r) => r.key === 'kind')?.value).toBe('Off-site');
+    expect(grandfathered.find((r) => r.key === 'kind')?.value).toBe('Standalone');
   });
 
   /**
    * The rail row and the card badge are two surfaces that MUST agree — the
    * `kindLabel` docstring claimed they mirrored each other while they said
    * "Off-site link" and "Off-site" respectively. Pinned as a relationship, so it
-   * fails if either side is reworded alone.
+   * fails if either side is reworded alone. (PR #4187 then reworded BOTH sides
+   * to "Standalone" together, which is exactly the case this is meant to allow.)
    */
   it('🔴 the off-site kind row is byte-identical to the card badge label', () => {
     const rows = buildListingDetailRows(

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -52,19 +52,21 @@ export type ListingBadgeKind = 'onsite' | 'offsite';
 export type ListingBadge = { label: string; kind: ListingBadgeKind };
 
 /**
- * The kind badge: on-site apps read "App"; every off-site app reads "Off-site".
+ * The kind badge: on-site apps read "App"; every off-site app reads "Standalone".
  *
  * 🔴 Off-site used to fork into two BADGES — "Connect app" (a linked OAuth
  * client) vs "Off-site" (no client) — derived from `connectClientId`. That fork
- * is removed: `offsite` is one kind. The word here is the SAME word the store's
- * kind filter already uses (`KindFilterButtons`' "Off-site"), which is what
- * makes the parent label true of the whole category again — under the fork it
- * was only true of one child, while the submit flow REQUIRES an OAuth client
- * and therefore minted nothing but the other one.
+ * is removed: `offsite` is one kind. (Those two names are the HISTORICAL labels;
+ * the surviving one has since been renamed "Standalone" as user-facing copy.)
+ * The word here is the SAME word the store's kind filter already uses
+ * (`KindFilterButtons`' "Standalone"), which is what makes the parent label true
+ * of the whole category again — under the fork it was only true of one child,
+ * while the submit flow REQUIRES an OAuth client and therefore minted nothing
+ * but the other one.
  */
 export function getListingBadge(card: Pick<ListingCard, 'kind' | 'kindData'>): ListingBadge {
   if (card.kindData.kind === 'onsite') return { label: 'App', kind: 'onsite' };
-  return { label: 'Off-site', kind: 'offsite' };
+  return { label: 'Standalone', kind: 'offsite' };
 }
 
 /**

--- a/src/components/Apps/appListingDetailRows.ts
+++ b/src/components/Apps/appListingDetailRows.ts
@@ -62,7 +62,7 @@ export type ListingDetailRow = {
  * filter uses.
  */
 function kindLabel(detail: Pick<ListingDetail, 'kindData'>): string {
-  return detail.kindData.kind === 'onsite' ? 'On-site app' : 'Off-site';
+  return detail.kindData.kind === 'onsite' ? 'On-site app' : 'Standalone';
 }
 
 /**

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -481,7 +481,7 @@ export default function AppDetailPage() {
                   <Stack gap="xs">
                     <Title order={4}>External site</Title>
                     <Text size="sm" c="dimmed">
-                      This app opens an external, off-site link in a new tab:{' '}
+                      This app opens an external, standalone link in a new tab:{' '}
                       <Anchor href={externalUrl!} target="_blank" rel="noopener noreferrer">
                         {externalUrl!.replace(/^https?:\/\//, '')}
                       </Anchor>

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -481,7 +481,7 @@ export default function AppDetailPage() {
                   <Stack gap="xs">
                     <Title order={4}>External site</Title>
                     <Text size="sm" c="dimmed">
-                      This app opens an external, standalone link in a new tab:{' '}
+                      This standalone app opens an external link in a new tab:{' '}
                       <Anchor href={externalUrl!} target="_blank" rel="noopener noreferrer">
                         {externalUrl!.replace(/^https?:\/\//, '')}
                       </Anchor>

--- a/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
@@ -228,7 +228,7 @@ describe('mod actions — error mapping via mapOffsiteError', () => {
   });
 
   it('a typed NOT_FOUND maps to NOT_FOUND', async () => {
-    mockRelist.mockRejectedValueOnce(offsiteModErr('NOT_FOUND', 'Off-site listing not found.'));
+    mockRelist.mockRejectedValueOnce(offsiteModErr('NOT_FOUND', 'Standalone listing not found.'));
     const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
     await expect(caller.relistListing({ appListingId: 'apl_x', reason: REASON })).rejects.toMatchObject({
       code: 'NOT_FOUND',

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -991,7 +991,9 @@ export const appListingsRouter = router({
     .input(approveExternalRequestSchema)
     .mutation(async ({ ctx, input }) => {
       if (!ctx.user?.isModerator) {
-        throw throwAuthorizationError('Approving off-site listings is restricted to civitai team');
+        throw throwAuthorizationError(
+          'Approving standalone listings is restricted to civitai team'
+        );
       }
       const { approveExternalRequest } = await import(
         '~/server/services/blocks/offsite-listing.service'
@@ -1021,7 +1023,9 @@ export const appListingsRouter = router({
     .input(rejectExternalRequestSchema)
     .mutation(async ({ ctx, input }) => {
       if (!ctx.user?.isModerator) {
-        throw throwAuthorizationError('Rejecting off-site listings is restricted to civitai team');
+        throw throwAuthorizationError(
+          'Rejecting standalone listings is restricted to civitai team'
+        );
       }
       const { rejectExternalRequest } = await import(
         '~/server/services/blocks/offsite-listing.service'
@@ -1115,7 +1119,7 @@ export const appListingsRouter = router({
    */
   delistListing: moderatorProcedure.input(delistListingSchema).mutation(async ({ ctx, input }) => {
     if (!ctx.user?.isModerator) {
-      throw throwAuthorizationError('Delisting off-site listings is restricted to civitai team');
+      throw throwAuthorizationError('Delisting standalone listings is restricted to civitai team');
     }
     const { delistListing } = await import('~/server/services/blocks/offsite-moderation.service');
     try {
@@ -1128,7 +1132,7 @@ export const appListingsRouter = router({
   /** MOD relist a removed off-site listing (removed → approved). Reversibility. */
   relistListing: moderatorProcedure.input(relistListingSchema).mutation(async ({ ctx, input }) => {
     if (!ctx.user?.isModerator) {
-      throw throwAuthorizationError('Relisting off-site listings is restricted to civitai team');
+      throw throwAuthorizationError('Relisting standalone listings is restricted to civitai team');
     }
     const { relistListing } = await import('~/server/services/blocks/offsite-moderation.service');
     try {
@@ -1150,7 +1154,9 @@ export const appListingsRouter = router({
    */
   claimListing: moderatorProcedure.input(claimListingSchema).mutation(async ({ ctx, input }) => {
     if (!ctx.user?.isModerator) {
-      throw throwAuthorizationError('Reassigning off-site listings is restricted to civitai team');
+      throw throwAuthorizationError(
+        'Reassigning standalone listings is restricted to civitai team'
+      );
     }
     const { claimListing } = await import('~/server/services/blocks/offsite-moderation.service');
     try {
@@ -1171,7 +1177,7 @@ export const appListingsRouter = router({
    */
   purgeListing: moderatorProcedure.input(purgeListingSchema).mutation(async ({ ctx, input }) => {
     if (!ctx.user?.isModerator) {
-      throw throwAuthorizationError('Purging off-site listings is restricted to civitai team');
+      throw throwAuthorizationError('Purging standalone listings is restricted to civitai team');
     }
     const { purgeListing } = await import('~/server/services/blocks/offsite-moderation.service');
     try {
@@ -1241,7 +1247,9 @@ export const appListingsRouter = router({
     .input(resetListingToPendingSchema)
     .mutation(async ({ ctx, input }) => {
       if (!ctx.user?.isModerator) {
-        throw throwAuthorizationError('Resetting off-site listings is restricted to civitai team');
+        throw throwAuthorizationError(
+          'Resetting standalone listings is restricted to civitai team'
+        );
       }
       const { resetListingToPending } = await import(
         '~/server/services/blocks/offsite-moderation.service'

--- a/src/server/schema/blocks/external-app.schema.ts
+++ b/src/server/schema/blocks/external-app.schema.ts
@@ -101,19 +101,19 @@ export function assertNoOnPlatformSurface(manifest: ExternalAppManifestInput): E
   if (page && typeof page === 'object') {
     return {
       ok: false,
-      error: 'an external-link app must not declare a page surface (it links off-site)',
+      error: 'an external-link app must not declare a page surface (it is a standalone app)',
     };
   }
   if (Array.isArray(manifest.targets) && manifest.targets.length > 0) {
     return {
       ok: false,
-      error: 'an external-link app must not declare target slots (it links off-site)',
+      error: 'an external-link app must not declare target slots (it is a standalone app)',
     };
   }
   if (manifest.iframe && typeof manifest.iframe === 'object') {
     return {
       ok: false,
-      error: 'an external-link app must not declare an iframe surface (it links off-site)',
+      error: 'an external-link app must not declare an iframe surface (it is a standalone app)',
     };
   }
   return { ok: true };

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -294,7 +294,7 @@ async function classifyOffsiteListing(
     select: { id: true, kind: true, status: true, slug: true },
   });
   if (!listing || listing.kind !== 'offsite') {
-    throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
+    throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
   }
   return { id: listing.id, status: listing.status, slug: listing.slug };
 }
@@ -681,7 +681,7 @@ export async function claimListing(opts: {
       select: { userId: true, status: true, slug: true, kind: true },
     });
     if (!current || current.kind !== 'offsite') {
-      throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
+      throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
     }
     // Status guard: claim is allowed only on an approved OR removed listing (a
     // mod-verified owner may reclaim a live OR a delisted listing). draft/pending/
@@ -842,7 +842,7 @@ export async function purgeListing(opts: {
       select: { status: true, slug: true, kind: true },
     });
     if (!current || current.kind !== 'offsite') {
-      throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
+      throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
     }
     // Event FIRST (so the slug/state snapshot is captured before the row is gone).
     await tx.appListingModerationEvent.create({
@@ -866,7 +866,7 @@ export async function purgeListing(opts: {
     });
     if (deleted.count === 0) {
       // Raced (concurrently purged between the snapshot and here) → roll the event back.
-      throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
+      throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
     }
   });
 
@@ -1076,7 +1076,7 @@ export async function resetListingToPending(opts: {
       select: { userId: true, status: true, kind: true, slug: true, name: true },
     });
     if (!current || current.kind !== 'offsite') {
-      throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
+      throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
     }
     ownerUserId = current.userId;
     slug = current.slug;


### PR DESCRIPTION
Renames the user-visible word for the off-site app kind on the App Store surfaces: **"Off-site" → "Standalone"**.

**The On-site → "Embedded" half is deliberately NOT in this PR — that is a decision, not an omission.** See §1. It becomes its own PR later, once the same tokenizer collision check has been run against a candidate term. §1 records everything needed so nobody re-derives it.

`20 files changed, 88 insertions(+), 67 deletions(-)` across two commits — the rename, then the audit fixes in §3. No reformat collateral (see *Formatting*).

Rebased onto `origin/main` @ **`56118b9d14`** (#4200, the off-site sub-kind collapse). ✅ **The two strings this PR previously held as known-false are now true** — verified against the landed taxonomy, no reword needed. See §2.

---

## 1. Collision check: does "Embedded" already mean something here? — and why On-site is deferred

**Yes — and not the way the failure mode was framed, which is why this stopped short of a decision and asked.**

I looked for *"does 'embedded' already mean **runs in an iframe** in user copy?"*. It does not. What it collides with is worse:

**(a) 🔴 "Embedding" is already a first-class, site-wide, user-facing Civitai noun — for a model type.**

```
src/utils/string-helpers.ts:49    TextualInversion: 'Embedding',
```

That is the display-name override table behind `getDisplayName` (consumed by 88 files). "Embedding" is what users read wherever a Textual Inversion appears — model-type filters, resource pickers, generation UI.

And it renders **inside an App Store surface**:

```
src/components/Apps/AppSettingsModal.tsx:72
  { value: ModelType.TextualInversion, label: 'Embedding' },
```

That is the per-app settings panel, in the model-type list beside `Checkpoint` / `LoRA` / `LoCon` / `DoRA`. Ship the rename and a store badge reading **"Embedded"** sits one panel from a chip reading **"Embedding"**, meaning something entirely unrelated.

**This is what settled the decision: two adjacent words, one letter apart, meaning unrelated things reads worse than the existing collision.**

Two findings cut the *other* way and are recorded so the next attempt weighs them properly:

**(b) "embedded" IS already the App Blocks code's word for iframe-hosting** — internal comments only, never user copy, so it argues *for* "Embedded" as the on-site term:

```
src/components/Apps/AppListingDetailBody.tsx:137  * not, and must not become, an embedded runtime.
src/components/AppBlocks/hostHandlerParity.ts:139 // the model slot is an embedded panel inside the model page
src/components/AppBlocks/sandbox.ts:25            // ... over the embedding page or the user
```

**(c) The CURRENT term is already ambiguous.** "on-site" is pervasive Civitai vocabulary for *generation*, not apps — ~25 user-facing strings, e.g. `Made On-site`, `On-site Generation`, `On-Site LoRA Trainer Guide`, `Generating on-site`, `Paid on-site generation`, `On-Site LoRA Trainer Guide`. So "On-site app" collides today. Renaming fixes one collision and creates another; that trade is what makes it a judgement call rather than a bug.

### The deferred On-site half — enumerated, ready to lift

7 copy sites. Every one is a rendered label; none is a `kind` value.

| File:line | Current copy |
|---|---|
| `src/components/Apps/KindFilterButtons.tsx:20` | `{ value: 'onsite', label: 'On-site', … }` |
| `src/components/Apps/appListingDetailRows.ts:59` | `'On-site app'` |
| `src/components/Apps/AppListingsModerationTable.tsx:415` | `{ label: 'On-site', value: 'onsite' }` |
| `src/components/Apps/AppTransferOffersView.tsx:203` | `'On-site app'` |
| `src/components/Apps/AppInvitesBody.tsx:130` | `'On-site app'` |
| `src/components/Apps/myAppsView.ts:182` | `'On-site'` |
| `src/components/Apps/appListingModerationTableView.ts:128` | `{ label: 'on-site', color: 'blue' }` |

Associated pins: ~6, same shape as the ones moved here.

**Whoever picks this up: run the tokenizer collision check in §2 against the candidate term FIRST.** That is what caught this one, and a grep would not have — `Embedding` and `Embedded` do not share a searchable stem with `onsite`.

**Also unresolved and larger than the rename:** the off-site kind is *also* labelled `External`, `External app`, `external` and `Connect app` in different views (`myAppsView.ts:182`, `AppListingsModerationTable.tsx:416`, `unifiedReviewRow.ts:248`, `appListingModerationTableView.ts:127`, `AppInvitesBody.tsx:130`, `AppTransferOffersView.tsx:203`). Out of scope here, but it is why "Standalone" will not read as fully consistent until the store's kind vocabulary gets one deliberate pass.

---

## 2. Enumeration method — and how copy was separated from identifiers

A grep count is not an enumeration and `sed` would have shredded the identifiers, so:

1. **Tokenized, not grepped.** A small JS/TS tokenizer walked every `.ts`/`.tsx` under `src/`, tracking line comments, block comments, single/double-quoted strings, template literals (with `${}` nesting) and bare code runs. It emitted every **string literal** and **JSX text run** matching `/o(ff|n)-?site/i` with `file:line`. Comments fall out by construction, not by heuristic. → **2,444 string/JSX hits**.
2. **Bucketed mechanically:** `bare_enum_literal` (`'onsite'`/`'offsite'` alone — **908**, the DB/API values, never touched), `identifier_in_string` (**266** — import paths, `data-testid`s, error-class names), `hyphenated` (**394**), `other` (**876**).
3. **Read the survivors by hand.** After dropping test files, **226** non-test string hits remained — small enough to read line by line, which I did.

The discriminator that did most of the work: **copy is hyphenated and spaced (`'Off-site'`, `"hosted off-site"`); identifiers are not (`offsiteListing`, `OffsiteSubmissionsList`, `'offsite'`, `apps-offsite-edit-url`).** Where ambiguous, I read the surrounding render.

Every replacement was applied by a script that **asserts an exact expected occurrence count per anchor and aborts on any mismatch** — 38 anchors, all fired at expected counts, no fuzzy matching.

**Scope is `src/` and that was verified, not assumed.** The only `off-site` occurrences outside `src/` are the Prisma schema + migrations (the `kind` CHECK constraint — explicitly must not move), `apps/moderator` comics-review, and `packages/civitai-shared/browsing-levels.ts`. None is an App Store surface: the set of files under `apps/` mentioning `app_listing` and the set mentioning `off-site` are **disjoint**.

**Explicitly NOT changed** (verified still `offsite` after the change): `app_listings.kind` / `app_listing_publish_requests.kind`, `/api/v1/apps?kind=`, `listingKindFilterSchema`, `ListingKind*`, `isOnsite`, `offsite-listing.service.ts`, `OffsiteSubmissionsList.tsx`, `offsiteEditConfig.ts`, every `apps-offsite-*` `data-testid`, `OffsiteRequestError` / `OffsiteModerationError`, all flag/scope literals, and all SQL (`al.kind = 'offsite'`).

**Out of scope by decision** (they say "off-site" but are not App Store): `src/components/RemixGallery/VerifiedRemixBadge.tsx:80` (remix provenance) and `src/pages/moderator/csam/external.tsx:263` (NCMEC reporting).

**Comments were left alone on purpose.** The internal concept is still *named* `offsite` end to end — types, files, DB, API — so a comment saying "off-site listing" remains true. Three exceptions, all comments that **quote the rendered string** (`appListingCardView.ts:57`, `KindFilterButtons.tsx:15`, `AppListingCard.browser.test.tsx:213`); leaving those would have made them false.

### The 18 copy strings

| File:line | Before → After |
|---|---|
| `AppBlockCard.tsx:227` | badge `Off-site` → `Standalone` |
| `appListingCardView.ts` | `getListingBadge` label → `'Standalone'` ⚠️ **dead code — see the import-graph note below** |
| `appListingDetailRows.ts` | detail Kind row → `'Standalone'` (post-#4200 this is one collapsed branch, byte-identical to the card badge) |
| `KindFilterButtons.tsx:21` | filter `label: 'Off-site'` → `'Standalone'` |
| `SubmitModeSelector.tsx:35` | "List an app hosted off-site…" → "List a standalone app hosted elsewhere…" |
| `ExternalSubmitForm.tsx:408` | same sentence, same treatment |
| `ExternalSubmitForm.tsx:791` | "a pending off-site submission" → "a pending standalone submission" |
| `OffsiteReviewQueue.tsx:198` | "Off-site apps — a lighter…" → "Standalone apps — …" |
| `OffsiteReviewQueue.tsx:1224` | "Off-site listing reports" → "Standalone listing reports" |
| `OffsiteReviewQueue.tsx:1235` | "approved off-site apps" → "approved standalone apps" |
| `pages/apps/[appBlockId]/index.tsx:484` | "This app opens an external, off-site link in a new tab" → "**This standalone app** opens an external link in a new tab" (same reason — the adjective belongs to the app, not the link) |
| `AppBlockCard.tsx:160` | comment still quoting the `"Off-site"` badge it renamed → `"Standalone"`. A comment is a claim. |
| `app-listings.router.ts` ×7 | "{Approving,Rejecting,Delisting,Relisting,Reassigning,Purging,Resetting} off-site listings is restricted…" → "…standalone listings…" |
| `offsite-moderation.service.ts` ×5 | `'Off-site listing not found.'` → `'Standalone listing not found.'` |
| `external-app.schema.ts` ×3 | "(it links off-site)" → "(it is a standalone app)" |

`SubmitModeSelector` / `ExternalSubmitForm` needed "hosted elsewhere" because "hosted standalone" is not grammatical; everything else is a straight term swap.

### ✅ RESOLVED — the two once-false strings are now true, verified against the landed taxonomy

**What was wrong:** `ExternalSubmitForm.tsx:408` and `SubmitModeSelector.tsx:35` said *"a standalone app hosted elsewhere"*, while every listing that flow created was `subKind: 'connect'` and rendered **"Connect app"**. The rename had turned a true sentence false.

It was deliberately **not** reworded, because **#4200** (`56118b9d14`) was in flight to collapse the `connect` / `external-link` fork into one kind. Rewording would have been thrown away and would have baked the fork's vocabulary into copy just as the fork disappeared.

**#4200 has now merged, and the sentence was re-verified rather than assumed true.** Traced end to end on the rebased tree:

| Claim in the sentence | Verified against |
|---|---|
| "…by linking your registered OAuth app" | `connectClientId` is **required** — `z.string().min(1).max(64)` in `offsite-listing.schema.ts:97`, and the form errors *"Choose one of your OAuth apps."* |
| "hosted elsewhere" | the flow writes `kind: 'offsite'` (`offsite-listing.service.ts:268,294`) |
| "a **standalone** app" | every `offsite` listing now badges one word — `getListingBadge` returns `{ label: 'Standalone', kind: 'offsite' }`, no fork |

And the contradicting child is genuinely gone, not merely bypassed: `'Connect app'` and `subKind` survive **only inside comments** — zero live labels, zero live branches, `resolveOffsiteSubKind` / `OffsiteSubKind` deleted from the tree.

So the copy is accurate *as a consequence* of the collapse, which is exactly what the hold was for. No wording change was needed.

**One of this PR's own earlier fixes was superseded by the collapse:** `'Standalone link'` → `'Standalone app'` (the "a link is not standalone" 🟡) is moot — #4200 had already dropped the word "link", so the detail Kind row is simply `'Standalone'`, byte-identical to the card badge. That equality is now pinned by #4200's own relationship test.

---

## 3. 🔴 `expect.element(x).not.toBeInTheDocument()` asserts NOTHING — and this is not a rename problem

**I got this wrong in the first version of this PR and an audit caught it. The corrected classification matters, so it is recorded here rather than quietly fixed.**

`src/components/Apps/AppListingCard.browser.test.tsx` asserted the kind label was **absent**:

```ts
await expect.element(page.getByText('Off-site', { exact: true })).not.toBeInTheDocument();
```

I originally described this as *"vacuous **after** a rename"* — as though renaming the string is what broke it, and re-pointing it at `'Standalone'` restored it. **That was wrong.** The form is **reachable but non-asserting**: it passes for *every* string, including ones the component demonstrably renders. It never asserted anything, before or after any rename. My first commit renamed it in place and shipped a still-inert assertion.

Scope of the defect, measured rather than assumed:

- **`.not` is not broadly broken.** `expect.element(...).not.toHaveAttribute(...)` goes red correctly. The defect is specific to **`toBeInTheDocument`**.
- **The sound idiom is `expect(locator.query()).toBeNull()`** — the sibling at `AppBlockCard.external.browser.test.tsx:153` uses it, and controlled, it does go red.
- **Ordering is load-bearing.** `.query()` is a point-in-time read, so it must follow an awaited positive assertion or it can pass merely because the render has not settled. The fix moves the check *after* the three `Visit` awaits.

Three controls, all watched:

| Control | Old form | New form |
|---|---|---|
| Assert absence of `'Visit'` — which the same test's next three lines prove **is** rendered | **passed** (RC=0) | **RED** — `expected <a …(8)>…</a> to be null` |
| Inject a literal `<span>Standalone</span>` into `AppListingCard.tsx` | **passed** (7 ms) | **RED** — `expected <span></span> to be null`, and it is *this* test that fails |
| Both reverted | — | **43/43 green** |

🔴 **69 live occurrences of the inert form remain across 17 files** (70 before this PR fixed one; 71 raw matches / 18 files if you count 2 mentions inside comments). **They are deliberately NOT fixed here** — tracked separately. Anyone reading a green `not.toBeInTheDocument` in this repo should assume it proves nothing until converted.

The general lesson still holds and is worth keeping: a positive assertion fails loudly when a rename passes it by; **an absence assertion goes quiet** — so when renaming copy, grep the blast radius for `not.toBeInTheDocument`, `.toBeNull()`, `queryBy*`, `expect(...).not.`. Just do not assume moving the string is the whole fix — check the idiom itself can go red.

---

## 4. Which test pins moved, and why

**20 pins across 7 files. No assertion was loosened — every one keeps its exact-match specificity; only the expected word changed.**

| Pin | Why it had to move |
|---|---|
| `appListingCardView.test.ts:82,84` — `label: 'Off-site'` | Pins `getListingBadge`'s literal output. |
| `appListingDetailRows.test.ts:91` — `.toBe('Off-site link')` | Pins the kind row's literal value. |
| `AppBlockCard.external.browser.test.tsx` ×4 | One presence assertion, one **absence** assertion (`.query()).toBeNull()` — the sound form), plus 2 names quoting the badge. |
| `AppListingCard.browser.test.tsx` | 🔴 Was the inert form — rewritten, not just re-pointed. See §3. |
| `AppListingsMarketplaceBody{,.urlState,.hydration}` ×4, `AppsStoreFiltersDropdown` ×1 | `getByRole('button', {name:'Off-site'})` accessible-name selectors on the filter button. |
| `app-listings.router.mod-actions-authz.test.ts:231` | ⚠️ **NOT a pin — a mock fixture.** It *supplies* the string and asserts only `code`, so it cannot ever fail on the message. Updated for fidelity to the real service, but **do not read it as coverage**: editing it makes the test *look* like it tracks the service string when it structurally cannot. |

Of the 16 changed test lines, **9 are real assertion lines**; the other 7 are test names, comments and that fixture.

The surrounding `kind: 'offsite'` fixtures in those same tests are **unchanged** — the value assertions still pin the API value, which is the point.

**Mutation-checked, not assumed.** I re-broke the copy and confirmed each pin dies for *its own* reason:

- `appListingCardView.ts` label → `'Off-site'` ⇒ `AssertionError: expected { label: 'Off-site', …(1) } to deeply equal { label: 'Standalone', …(1) }`, 1 file failed.
- `KindFilterButtons.tsx` label → `'Off-site'` ⇒ both component files failed with `Cannot find element with locator: getByRole('button', { name: 'Standalone' })` at the exact lines changed.

Both mutants reverted; restored files confirmed **sha256-identical** to the pre-mutation state and the diff returned to `20 files, 58+/50-`.

---

## 5. Positive control on the sweep

**The safety net is real.** I planted the exact mistake this PR must never make and confirmed the type checker catches it:

```
- export const listingKindFilterSchema = z.enum(['all', 'onsite', 'offsite']);
+ export const listingKindFilterSchema = z.enum(['all', 'onsite', 'standalone']);
```

`pnpm typecheck` → **exit 2, 4 errors**, including at the exact line this PR touches:

```
src/components/Apps/KindFilterButtons.tsx(21,5): error TS2322:
  Type '"offsite"' is not assignable to type '"all" | "onsite" | "standalone"'.
src/components/Apps/AppsStoreFiltersDropdown.browser.test.tsx(99,13):  ... (+2 more)
```

Had the `kind` **value** been renamed alongside the label, typecheck would have stopped it. Control reverted; `git status` confirmed back to exactly 20 modified files.

---

## 6. Verification

| Gate | Result |
|---|---|
All re-run **in full** on the rebased tree (`56118b9d14` + this PR):

| Gate | Result |
|---|---|
| `pnpm typecheck` | **0 errors in 53s** (exit 0; the wrapper classified it OK, not a heap-crash) |
| `pnpm test:unit:run` | **1252 files / 19,754 tests passed**, 0 failed, 25 skipped |
| `pnpm test:component` | **170 files / 1,859 tests passed**, 0 failed |

🔴 **The first typecheck after this rebase reported 20 errors, and the exit code alone would have hidden it in either direction.** I had chained the three runs and read only the tail, which showed `UNIT_RC=0 COMP_RC=0` — `TC_RC=2` had scrolled off. Reading the log *content* caught it. All 20 were `Property 'userHub' does not exist on PrismaClient` in `src/components/Hubs/`, `src/pages/hubs/` and `user-hub.service.ts` — a **stale generated Prisma client** in `node_modules`, because the rebase pulled in #4080's schema and the slim schema is generated from `schema.full.prisma`. `pnpm db:generate` → **0 errors**, and `git status` stayed empty (the stale artifact is untracked, and CI regenerates it via `postinstall`). This PR touches zero Hubs, Prisma or `collection.service` files.
| `eslint` on the 20 changed files | 0 errors. 2 warnings, both **pre-existing** — proven by linting the `HEAD` copy of `OffsiteReviewQueue.tsx`: same rule, same lines 1183/1549, far from any edit |

**Coverage positive control:** all 6 changed browser test files and all 3 changed unit test files were confirmed present-and-green in the run logs — the tiers actually exercised the renames rather than passing around them.

🔴 **`pnpm test:component` first reported success while running ZERO tests.** Playwright's browser would not launch (pinned `playwright-core@1.57.0` wants `chromium_headless_shell-1200`; the nix bundle ships `-1228`), the inner `ELIFECYCLE ... exit code 1` was masked by the wrapper's exit 0, and grepping the log for `Test Files` returned an empty result indistinguishable from a clean run. The numbers above are from a re-run against the nix-built browser. **Local environment, not this branch** — same `playwright-core` version and `PLAYWRIGHT_BROWSERS_PATH` in the primary clone.

### ⚠️ Which renamed strings actually reach a user

Established from the import graph, **not** from `AppListingCard.browser.test.tsx:216` (that line is the inert `not.toBeInTheDocument()` form — issue #4197 — and proves nothing either way):

**Live (user-visible):**
- `KindFilterButtons` "Standalone" → rendered via `AppsStoreFiltersDropdown`
- the detail **Kind row** "Standalone" → `buildListingDetailRows` → `AppListingDetailBody.tsx:598`
- `AppBlockCard`'s "Standalone" badge → rendered by `RecentlyOpenedApps` and `MarketplaceBody`
- the submit-flow copy, review-queue copy, and the server error messages

**Dead (no user-visible effect):**
- 🔴 **`getListingBadge`'s `'Standalone'` label.** Its only importers repo-wide are **two test files** (`appListingCardView.test.ts`, `appListingDetailRows.test.ts`). `AppListingCard.tsx` merely *mentions* it in a comment; it does not import it. So the badge half of both this rename **and** #4200's collapse is unobservable in the product. Pre-existing, flagged not fixed.

### Rebase re-verification

Now rebased onto `origin/main` @ **`56118b9d14`** (#4200, the sub-kind collapse). Earlier rebases picked up #4179 `3cf6c7e879` (the preview-smoke fix — `preview / smoke-tests` went from 4 failures to **66 passed, 0 flaky**).

This rebase was **not** clean — 4 conflicts, all in the files #4200 and this PR both touch (`appListingCardView.ts`, `appListingDetailRows.ts` and their two tests). Resolved by taking #4200's collapsed structure whole and re-applying only the copy rename on top. #4200's new guards were kept and updated, including its docstring that says *"PR #4187 renames it, and this is the assertion it must update."*

**Tokenizer delta — the count DID change this time**, unlike the previous two rebases:

| Base (pre-change) | Hits |
|---|---|
| `bc74ba06ea` (original) | 2,444 |
| `1891ce76aa` (previous) | 2,444 |
| **`56118b9d14` (now)** | **2,474** |

`1891ce76aa → 56118b9d14`: **25 new `(file, text)` pairs, 16 removed** — #4200's collapse. Of the 25 new pairs, only **4** are in non-test files, and only **one is user-facing copy**:

- `appListingDetailRows.ts :: 'Off-site'` — the collapsed Kind row. **Renamed** (it was one of the 4 conflicts).
- `appListingDetailView.ts :: 'offsite'` — a bare enum value. Untouched.
- 2 × `comment.notifications.ts` — SQL carrying `al.kind = 'onsite'`. Untouched.

The other 21 are in #4200's new test guards, which the conflict resolution already covered. So the enumeration needed exactly one extension, and it got it.

Since a clean *textual* merge is not a clean *semantic* one, the suites were re-run in full rather than trusted (below), and zero `'Off-site'` literals remain anywhere in `src/` outside historical comments.

### Resolved: the earlier red `Unit tests` rows were a `main` breakage, now fixed upstream

For one round this PR showed a red `Unit tests` / `preview / unit-tests`: `ModelFileHash writer ledger > matches the writers actually present in the source tree`. Root cause was a migration on `main` (`a3e790ff2e`) that added an `INSERT INTO "ModelFileHash"` without adding it to `LEDGER_ENTRIES` — the seam guard doing its job against someone else's change.

Attribution was established by control, not assertion: **all 20 of this PR's files were reverted to pristine `origin/main` content and the test failed identically**, then restored sha256-identical. `main` has since added the migration to `LEDGER_ENTRIES`, and this rebase picks that up — the local full unit run is now **19,754 passed / 0 failed**.

### Forbidden-token grep

Of the 58 added lines, exactly **2** match `'offsite'` / `"offsite"` / `kind:` / a filename — and in both the matching token is **unchanged**, present only because a label on the *same line* moved:

```
{ value: 'offsite', label: 'Standalone', icon: IconExternalLink },   // value: unchanged
: { label: 'Standalone', kind: 'external-link' };                    // kind: unchanged
```

Nothing else in the diff touches a DB value, an API value, a type, or a filename.

### Formatting

`pnpm prettier:write` reformatted ~700 unrelated lines in these files (the repo is knowingly not Prettier-clean — `scripts/prettier-changed.mjs` and `.github/workflows/lint.yml` both say so, and Prettier on *modified* files is report-only in CI). I discarded that and hand-formatted instead, then **verified** it: for every changed file I formatted a copy under the repo's `.prettierrc` and confirmed Prettier keeps every line this diff adds, verbatim, in all 20 files. Four authz messages went 99→101 cols and are wrapped exactly as Prettier would wrap them.

---

## Pre-existing gaps found while auditing this — recorded so nobody re-derives them

None of these are caused by this PR, and none are fixed here:

- **The 7 router authz messages and the 5 `'Standalone listing not found.'` strings have ZERO coverage.** They survive mutation — and they are *unasserted*, not unreachable: a code-level mutant on `code` killed 5 tests, so those lines definitely execute. Renaming them was safe but is unguarded.
- **`getListingBadge` has zero production consumers repo-wide.** Its unit test is real coverage of a function nothing calls.
- **69 live `not.toBeInTheDocument()` assertions across 17 files** assert nothing (§3).
- `MySubmissionsList.browser.test.tsx:1024` uses "standalone link" in a **test name**, in the unrelated sense of *a dangling hyperlink*. Pre-existing, not product copy — but it is now a mild homonym of the new kind name, worth knowing if the term spreads.

## Unverified / caveats

- **No hand click-through of the real `/apps` store.** Evidence is the component tier plus the mutation checks, not a browser session.
- `src/pages/apps/[appBlockId]/index.tsx` is described elsewhere as the "retired" detail page but still exists and still routes, so its copy was renamed. Worth confirming it is genuinely reachable.
- **`public/schemas/app-block/v1.json` still says "off-site listings"** in a developer-facing `description`. Left alone deliberately: it is byte-mirrored into the Go CLI and the app-sdk with cross-repo drift guards, so changing it here alone would break them. Needs its own coordinated PR.
- The store's kind vocabulary is inconsistent beyond this rename (see §1) — out of scope, but it bounds how consistent "Standalone" can read today.
