### PR TITLE
fix(auth): fix the two type errors gating apps/auth, and bring it into the CI typecheck gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -420,13 +420,13 @@ jobs:
       # part and this job has already paid for it. The tradeoff is that a type
       # error renders under this job's name — hence the job rename above.
       #
-      # Deliberately ONE step driving a script, not six `pnpm --filter` steps.
-      # Six steps abort at the first red app, so a shared type change that breaks
-      # four of them reports one; and `pnpm --filter <name>` EXITS 0 WHEN THE
-      # NAME MATCHES NOTHING (measured, pnpm 10.28.1 — it prints "No projects
-      # matched the filters" and succeeds), so six hardcoded package names are
-      # six chances for a rename to turn this gate into a green no-op. The script
-      # derives the app set from disk, proves each filter selected a real
-      # package, and collects every failure. See its header.
+      # Deliberately ONE step driving a script, not one `pnpm --filter` step per
+      # app. Per-app steps abort at the first red app, so a shared type change
+      # that breaks several of them reports one; and `pnpm --filter <name>` EXITS
+      # 0 WHEN THE NAME MATCHES NOTHING (measured, pnpm 10.28.1 — it prints "No
+      # projects matched the filters" and succeeds), so a hardcoded list of
+      # package names is one chance per app for a rename to turn this gate into a
+      # green no-op. The script derives the app set from disk, proves each filter
+      # selected a real package, and collects every failure. See its header.
       - name: Typecheck apps
         run: node scripts/ci/typecheck-apps.mjs

--- a/apps/auth/src/lib/server/auth/__tests__/establish-session.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/establish-session.test.ts
@@ -31,6 +31,7 @@ vi.mock('../device', () => ({
 
 import { establishSession } from '../session';
 import type { SessionUser } from '@civitai/auth';
+import type { Cookies } from '@sveltejs/kit';
 
 const user = (id: number): SessionUser =>
   ({
@@ -43,18 +44,30 @@ const user = (id: number): SessionUser =>
     createdAt: new Date(),
     isModerator: false,
     muted: false,
-  }) as unknown as SessionUser;
+  } as unknown as SessionUser);
 
 // A minimal Cookies stub: in-memory get + a set that records the queued cookie.
-function makeCookies(initial: Record<string, string> = {}) {
+//
+// It implements the WHOLE `Cookies` interface (get/getAll/set/delete/serialize — five members) rather than
+// casting a partial object, so it is assignable to `establishSession`'s parameter with no cast at all. The
+// previous `as never` satisfied that parameter the blunt way, but `never` has no properties, so reading
+// `_store` back in an assertion was itself a type error.
+type CookiesStub = Cookies & { _store: Map<string, string> };
+
+function makeCookies(initial: Record<string, string> = {}): CookiesStub {
   const store = new Map(Object.entries(initial));
-  const set = vi.fn((name: string, value: string) => store.set(name, value));
   return {
     _store: store,
-    set,
+    set: vi.fn((name: string, value: string) => {
+      store.set(name, value);
+    }),
     get: (name: string) => store.get(name),
-    delete: vi.fn(),
-  } as never;
+    getAll: () => [...store].map(([name, value]) => ({ name, value })),
+    delete: vi.fn((name: string) => {
+      store.delete(name);
+    }),
+    serialize: (name: string, value: string) => `${name}=${value}`,
+  };
 }
 
 beforeEach(() => vi.clearAllMocks());

--- a/apps/auth/src/lib/server/auth/providers.ts
+++ b/apps/auth/src/lib/server/auth/providers.ts
@@ -140,6 +140,13 @@ const PROVIDERS: Record<ProviderId, ProviderDef> = {
   // It is enabled ONLY when AUTH_ENABLE_STUB_PROVIDER is truthy AND its STUB_CLIENT_ID/SECRET are set
   // (see listEnabledProviders' stubEnabled gate) — so with the flag unset (prod) it never appears in the
   // provider list and /login/stub 404s (the start route rejects an unconfigured provider).
+  //
+  // TYPES: this entry's key is a COMPUTED property whose type is the whole `ProviderId` union rather than a
+  // single literal, so TypeScript cannot match it to a member of `Record<ProviderId, ProviderDef>` and drops
+  // contextual typing for the value — which left `mapProfile`'s parameter implicitly `any` (and the rest of
+  // the entry unchecked against `ProviderDef`). The four literal-keyed entries above are unaffected because
+  // their keys resolve to a single member. `satisfies ProviderDef` restores both: the object is checked
+  // against the interface, and `mapProfile`'s `p` infers `Record<string, unknown>` from it.
   ['stub' as ProviderId]: {
     id: 'stub' as ProviderId,
     name: 'Stub',
@@ -172,7 +179,7 @@ const PROVIDERS: Record<ProviderId, ProviderDef> = {
         username: p.preferred_username as string | undefined,
       };
     },
-  },
+  } satisfies ProviderDef,
 };
 
 export function getProvider(id: string): ProviderDef | undefined {
@@ -215,7 +222,8 @@ function validatedStubUrl(raw: string | undefined): string {
   // CONSTRAINT: the stub MUST be a plain ClusterIP Service (2-label host). A headless/StatefulSet pod
   // FQDN (<pod>.<svc>.<ns>.svc.cluster.local, 3 labels) does NOT match and would fail-close the provider.
   const clusterServiceFqdn = /^[a-z0-9-]+\.[a-z0-9-]+\.svc\.cluster\.local$/;
-  if ((u.protocol === 'http:' || u.protocol === 'https:') && clusterServiceFqdn.test(u.hostname)) return raw;
+  if ((u.protocol === 'http:' || u.protocol === 'https:') && clusterServiceFqdn.test(u.hostname))
+    return raw;
   return '';
 }
 

--- a/scripts/__tests__/typecheck-apps.test.ts
+++ b/scripts/__tests__/typecheck-apps.test.ts
@@ -7,10 +7,12 @@
  * what lets the no-match and failure paths be driven deterministically without installing
  * the monorepo.
  *
- * The fixtures all include an `auth` app on purpose: the script treats an EXCLUDED entry
- * naming a missing app as a hard error, so omitting it makes every case fail for that
- * reason instead of the one under test. (Learned the hard way — the first draft of this
- * suite did exactly that and six cases died for the wrong reason.)
+ * EXCLUSIONS ARE INJECTED, NOT INHERITED. The shipped `EXCLUDED` map is empty (every app is
+ * gated), and an earlier version of this suite encoded "auth is excluded" into every fixture
+ * — so emptying the map broke six of eight cases for reasons unrelated to what they test.
+ * The exclusion guards are the ones the NEXT excluded app will depend on, so they are driven
+ * here through `runTypecheckApps({ excluded })` with a SYNTHETIC app instead: they stay
+ * covered no matter what the real map happens to contain today.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync, cpSync } from 'node:fs';
@@ -19,7 +21,21 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { EXCLUDED } from '../ci/typecheck-apps.mjs';
+
 const SCRIPT = resolve(fileURLToPath(new URL('../ci/typecheck-apps.mjs', import.meta.url)));
+
+/**
+ * Test-only entrypoint: imports the REAL module and calls it with an injected exclusion map,
+ * so the injected-exclusion cases still run the genuine script end-to-end (real spawn of the
+ * fake pnpm, real discovery off disk) rather than a reimplementation of it.
+ *
+ * This is a fixture file, never shipped — the production script takes no exclusion override,
+ * because an env-var/argv one would be a live way to un-gate an app in CI.
+ */
+const DRIVER = `import { runTypecheckApps } from './typecheck-apps.mjs';
+process.exit(runTypecheckApps({ excluded: JSON.parse(process.argv[2]) }));
+`;
 
 let root: string;
 beforeAll(() => {
@@ -37,6 +53,7 @@ function makeRepo(apps: Record<string, boolean>, pnpmBody: string) {
   mkdirSync(join(dir, 'scripts', 'ci'), { recursive: true });
   mkdirSync(join(dir, 'bin'), { recursive: true });
   cpSync(SCRIPT, join(dir, 'scripts', 'ci', 'typecheck-apps.mjs'));
+  writeFileSync(join(dir, 'scripts', 'ci', 'run-with-exclusions.mjs'), DRIVER);
 
   for (const [app, hasTypecheck] of Object.entries(apps)) {
     mkdirSync(join(dir, 'apps', app), { recursive: true });
@@ -55,8 +72,8 @@ function makeRepo(apps: Record<string, boolean>, pnpmBody: string) {
   return dir;
 }
 
-function run(dir: string) {
-  const r = spawnSync(process.execPath, ['scripts/ci/typecheck-apps.mjs'], {
+function spawnIn(dir: string, args: string[]) {
+  const r = spawnSync(process.execPath, args, {
     cwd: dir,
     encoding: 'utf8',
     env: { ...process.env, PATH: `${join(dir, 'bin')}:${process.env.PATH}` },
@@ -64,11 +81,27 @@ function run(dir: string) {
   return { code: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
 }
 
-const AUTH = { auth: true };
+/**
+ * Run the script with an EXPLICIT exclusion map — `{}` by default.
+ *
+ * Every mechanism case below goes through here, so none of them can be perturbed by what
+ * the shipped map happens to contain. That coupling is not hypothetical: while writing this
+ * suite, re-adding a single shipped exclusion broke six unrelated cases, because their
+ * fixtures had no directory for the excluded app and so tripped the stale-exclusion guard
+ * before reaching the assertion under test.
+ */
+function run(dir: string, excluded: Record<string, string> = {}) {
+  return spawnIn(dir, ['scripts/ci/run-with-exclusions.mjs', JSON.stringify(excluded)]);
+}
+
+/** Run the REAL CI entrypoint: `node scripts/ci/typecheck-apps.mjs`, shipped map and all. */
+function runShipped(dir: string) {
+  return spawnIn(dir, ['scripts/ci/typecheck-apps.mjs']);
+}
 
 describe('typecheck-apps', () => {
   it('passes when every discovered app typechecks clean', () => {
-    const { code, out } = run(makeRepo({ ...AUTH, alpha: true, beta: true }, 'exit 0'));
+    const { code, out } = run(makeRepo({ alpha: true, beta: true }, 'exit 0'));
     expect(out).toContain('All 2 app(s) passed typecheck');
     expect(code).toBe(0);
   });
@@ -78,7 +111,7 @@ describe('typecheck-apps', () => {
     // "No projects matched the filters" and EXITS 0 (measured, pnpm 10.28.1). Wired as a
     // plain workflow step, a renamed package silently stops being typechecked.
     const dir = makeRepo(
-      { ...AUTH, alpha: true },
+      { alpha: true },
       'echo "No projects matched the filters in \\"/repo\\""; exit 0'
     );
     const { code, out } = run(dir);
@@ -87,7 +120,7 @@ describe('typecheck-apps', () => {
   });
 
   it('fails when an app’s typecheck fails', () => {
-    const { code, out } = run(makeRepo({ ...AUTH, alpha: true }, 'exit 1'));
+    const { code, out } = run(makeRepo({ alpha: true }, 'exit 1'));
     expect(out).toContain('alpha: typecheck failed');
     expect(code).toBe(1);
   });
@@ -95,7 +128,7 @@ describe('typecheck-apps', () => {
   it('collects every failure instead of stopping at the first app', () => {
     // Sequential workflow steps abort the job at the first red app, so a shared type change
     // that breaks four of them reports one. This is the difference.
-    const { code, out } = run(makeRepo({ ...AUTH, alpha: true, beta: true }, 'exit 1'));
+    const { code, out } = run(makeRepo({ alpha: true, beta: true }, 'exit 1'));
     expect(out).toContain('2 of 2 app(s) failed typecheck');
     expect(out).toContain('alpha:');
     expect(out).toContain('beta:');
@@ -103,9 +136,9 @@ describe('typecheck-apps', () => {
   });
 
   it('refuses to report success when it discovers no apps', () => {
-    // A zero that reads as a pass is the whole failure class. Only `auth` has a typecheck
-    // script here, and it is excluded, so the target set is empty.
-    const { code, out } = run(makeRepo({ ...AUTH, alpha: false }, 'exit 0'));
+    // A zero that reads as a pass is the whole failure class. Nothing here has a typecheck
+    // script, so discovery comes back empty.
+    const { code, out } = run(makeRepo({ alpha: false }, 'exit 0'));
     expect(out).toContain('Refusing to report success');
     expect(code).toBe(2);
   });
@@ -113,23 +146,59 @@ describe('typecheck-apps', () => {
   it('picks up a newly added app with no edit to the workflow', () => {
     // The hole reopens the moment someone adds an app to a hardcoded list they did not know
     // about. The ledger is read from disk, so it cannot go stale that way.
-    const { code, out } = run(makeRepo({ ...AUTH, alpha: true, brandnew: true }, 'exit 0'));
+    const { code, out } = run(makeRepo({ alpha: true, brandnew: true }, 'exit 0'));
     expect(out).toContain('Typechecking 2 app(s): alpha, brandnew');
     expect(code).toBe(0);
   });
 
+  // --- the exclusion mechanism, driven with a synthetic app ---
+
   it('hard-fails on a stale exclusion rather than silently un-gating', () => {
-    // If `auth` is fixed or removed but the EXCLUDED entry survives, that entry is a lie.
-    // Failing loudly is what stops an app quietly leaving the gate.
-    const { code, out } = run(makeRepo({ alpha: true }, 'exit 0'));
+    // If an excluded app is fixed or removed but its EXCLUDED entry survives, that entry is
+    // a lie. Failing loudly is what stops an app quietly leaving the gate. `ghost` exists in
+    // the exclusion map but not on disk.
+    const { code, out } = run(makeRepo({ alpha: true }, 'exit 0'), { ghost: 'no longer real' });
     expect(out).toContain('no longer has a typecheck script');
+    expect(out).toContain('ghost');
     expect(code).toBe(2);
   });
 
-  it('excludes auth while still checking everything else', () => {
-    const { code, out } = run(makeRepo({ ...AUTH, alpha: true }, 'exit 0'));
+  it('skips an excluded app while still checking everything else', () => {
+    const dir = makeRepo({ alpha: true, legacy: true }, 'exit 0');
+    const { code, out } = run(dir, { legacy: 'known broken, tracked in ISSUE-1' });
     expect(out).toContain('Typechecking 1 app(s): alpha');
-    expect(out).toContain('Skipping auth');
+    expect(out).toContain('Skipping legacy');
+    expect(out).toContain('known broken, tracked in ISSUE-1');
+    expect(code).toBe(0);
+  });
+
+  it('refuses to report success when every discovered app is excluded', () => {
+    // The other route to an empty target set: discovery finds apps, but the exclusion map
+    // eats all of them. That must not read as a pass either.
+    const { code, out } = run(makeRepo({ legacy: true }, 'exit 0'), { legacy: 'known broken' });
+    expect(out).toContain('Refusing to report success');
+    expect(code).toBe(2);
+  });
+
+  // --- the shipped ledger ---
+
+  it('ships no exclusion for auth, so auth is inside the gate', () => {
+    // auth was the last excluded app; its two type errors are fixed. This pins that it did
+    // not quietly get re-excluded. Excluding a DIFFERENT app in future must NOT fail here,
+    // so the fixture grows a directory for every shipped exclusion (otherwise the
+    // stale-exclusion guard would fire and this case would die for the wrong reason).
+    expect(Object.keys(EXCLUDED)).not.toContain('auth');
+
+    // …and behaviourally, through the REAL entrypoint: an `auth` app on disk is a target,
+    // not a skip. This is also the only case that proves `node scripts/ci/typecheck-apps.mjs`
+    // still self-executes — the direct-run guard added alongside the exported function.
+    const fixture: Record<string, boolean> = { alpha: true, auth: true };
+    for (const excludedDir of Object.keys(EXCLUDED)) fixture[excludedDir] = true;
+
+    const { code, out } = runShipped(makeRepo(fixture, 'exit 0'));
+    const ledger = /Typechecking \d+ app\(s\): (.*)/.exec(out)?.[1] ?? '';
+    expect(ledger.split(', ')).toContain('auth');
+    expect(out).not.toContain('Skipping auth');
     expect(code).toBe(0);
   });
 });

--- a/scripts/ci/typecheck-apps.mjs
+++ b/scripts/ci/typecheck-apps.mjs
@@ -12,8 +12,8 @@
  *
  *   1. `pnpm --filter <name> run <script>` EXITS 0 WHEN THE FILTER MATCHES NOTHING. Measured
  *      on pnpm 10.28.1: a bogus package name prints `No projects matched the filters` and
- *      exits 0. A hardcoded list of six package names is six chances for a rename or a typo
- *      to turn a gate into a no-op that still shows a green check. Same shape as
+ *      exits 0. A hardcoded list of package names is one chance PER APP for a rename or a
+ *      typo to turn a gate into a no-op that still shows a green check. Same shape as
  *      `prettier --check "$FILES"` reporting "All matched files use Prettier code style!"
  *      over zero files.
  *   2. A NEW app added under `apps/` is simply absent from the list. The gate stays green
@@ -24,9 +24,9 @@
  * a `typecheck` script must run, and each run must be proven to have selected a real
  * package. Adding an app wires it automatically; removing one needs no edit here.
  *
- * Failures are COLLECTED, not fatal on the first. Six sequential steps abort the job at the
- * first red app, so a shared type change that breaks four of them reports one. The summary
- * at the end names every failing app.
+ * Failures are COLLECTED, not fatal on the first. Sequential per-app steps abort the job at
+ * the first red app, so a shared type change that breaks several of them reports one. The
+ * summary at the end names every failing app.
  *
  * Usage:  node scripts/ci/typecheck-apps.mjs
  */
@@ -42,22 +42,23 @@ import { join, resolve } from 'node:path';
  * exclusion is worse than no exclusion: it silently un-gates an app that was fixed years
  * ago. So an entry naming a directory that is gone, or an app that no longer has a
  * `typecheck` script, is a hard error rather than a no-op.
+ *
+ * CURRENTLY EMPTY — every app under `apps/` is gated. `auth` was the last holdout (two
+ * pre-existing errors in providers.ts + establish-session.test.ts); both are fixed, so its
+ * entry is gone and all 7 apps run.
+ *
+ * An empty map must NOT mean the exclusion machinery is untested. The guards here are what
+ * the NEXT excluded app will depend on, so `runTypecheckApps` takes the map as a parameter
+ * and `scripts/__tests__/typecheck-apps.test.ts` drives them with a synthetic app. That is
+ * deliberately a function parameter and not an env var: an env-var override would be a live
+ * way to un-gate an app in CI, which is the whole failure class this script exists to close.
  */
-const EXCLUDED = {
-  auth: [
-    'Two pre-existing errors, reproduced 2026-08-19 and 2026-08-20:',
-    "  src/lib/server/auth/providers.ts:165 — Parameter 'p' implicitly has an 'any' type",
-    "  src/lib/server/auth/__tests__/establish-session.test.ts:100 — '_store' on type 'never'",
-    'Wiring it before those are fixed ships a permanently-red gate, which teaches people to',
-    "click through every other app's result too. Fix, then delete this entry.",
-  ].join('\n    '),
-};
+export const EXCLUDED = {};
 
-const repoRoot = resolve(fileURLToPath(new URL('../..', import.meta.url)));
-const appsDir = join(repoRoot, 'apps');
+const defaultRepoRoot = resolve(fileURLToPath(new URL('../..', import.meta.url)));
 
 /** Every apps/* member that declares a `typecheck` script, read from disk. */
-function discoverApps() {
+function discoverApps(appsDir) {
   const found = [];
   for (const dir of readdirSync(appsDir, { withFileTypes: true })) {
     if (!dir.isDirectory()) continue;
@@ -70,70 +71,87 @@ function discoverApps() {
   return found.sort((a, b) => a.dir.localeCompare(b.dir));
 }
 
-const all = discoverApps();
+/**
+ * Typecheck every discovered app that is not excluded. Returns the process exit code
+ * (0 pass · 1 an app failed · 2 the ledger itself is untrustworthy) instead of calling
+ * `process.exit`, so the guards can be driven in-process by a test.
+ *
+ * @param {object} [options]
+ * @param {string} [options.repoRoot]  Repo root to discover `apps/` under.
+ * @param {Record<string,string>} [options.excluded]  dir -> reason. Defaults to EXCLUDED.
+ */
+export function runTypecheckApps({ repoRoot = defaultRepoRoot, excluded = EXCLUDED } = {}) {
+  const all = discoverApps(join(repoRoot, 'apps'));
 
-// A stale exclusion silently un-gates an app. Fail loudly instead.
-const staleExclusions = Object.keys(EXCLUDED).filter((d) => !all.some((a) => a.dir === d));
-if (staleExclusions.length) {
-  console.error(
-    `EXCLUDED names an app that no longer has a typecheck script (or no longer exists): ` +
-      `${staleExclusions.join(', ')}.\nRemove the entry from scripts/ci/typecheck-apps.mjs.`
-  );
-  process.exit(2);
-}
-
-const targets = all.filter((a) => !(a.dir in EXCLUDED));
-
-// Discovering nothing must never read as success — that is the whole failure class above.
-if (targets.length === 0) {
-  console.error('No apps/* with a typecheck script were discovered. Refusing to report success.');
-  process.exit(2);
-}
-
-console.log(`Typechecking ${targets.length} app(s): ${targets.map((a) => a.dir).join(', ')}`);
-for (const [dir, why] of Object.entries(EXCLUDED)) {
-  console.log(`\nSkipping ${dir}:\n    ${why}`);
-}
-console.log('');
-
-const failed = [];
-for (const app of targets) {
-  console.log(`::group::typecheck ${app.dir} (${app.name})`);
-  const run = spawnSync('pnpm', ['--filter', app.name, 'run', 'typecheck'], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-    // Inherit stderr so tsc/svelte-check diagnostics land in the log as they happen;
-    // capture stdout so the no-match sentinel below can be read.
-    stdio: ['ignore', 'pipe', 'inherit'],
-  });
-  const stdout = run.stdout ?? '';
-  process.stdout.write(stdout);
-  console.log('::endgroup::');
-
-  if (run.error) {
-    failed.push(`${app.dir}: could not spawn pnpm (${run.error.message})`);
-    continue;
-  }
-
-  // The exit-0-on-empty-filter case. pnpm says so on stdout and returns success; without
-  // this the app is silently never checked.
-  if (/No projects matched the filters/i.test(stdout)) {
-    failed.push(
-      `${app.dir}: pnpm matched NO package for "${app.name}" — the filter is stale, so this ` +
-        `app was not typechecked (pnpm exits 0 in this case)`
+  // A stale exclusion silently un-gates an app. Fail loudly instead.
+  const staleExclusions = Object.keys(excluded).filter((d) => !all.some((a) => a.dir === d));
+  if (staleExclusions.length) {
+    console.error(
+      `EXCLUDED names an app that no longer has a typecheck script (or no longer exists): ` +
+        `${staleExclusions.join(', ')}.\nRemove the entry from scripts/ci/typecheck-apps.mjs.`
     );
-    continue;
+    return 2;
   }
 
-  if (run.status !== 0) {
-    failed.push(`${app.dir}: typecheck failed (exit ${run.status})`);
+  const targets = all.filter((a) => !(a.dir in excluded));
+
+  // Discovering nothing must never read as success — that is the whole failure class above.
+  if (targets.length === 0) {
+    console.error('No apps/* with a typecheck script were discovered. Refusing to report success.');
+    return 2;
   }
+
+  console.log(`Typechecking ${targets.length} app(s): ${targets.map((a) => a.dir).join(', ')}`);
+  for (const [dir, why] of Object.entries(excluded)) {
+    console.log(`\nSkipping ${dir}:\n    ${why}`);
+  }
+  console.log('');
+
+  const failed = [];
+  for (const app of targets) {
+    console.log(`::group::typecheck ${app.dir} (${app.name})`);
+    const run = spawnSync('pnpm', ['--filter', app.name, 'run', 'typecheck'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      // Inherit stderr so tsc/svelte-check diagnostics land in the log as they happen;
+      // capture stdout so the no-match sentinel below can be read.
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+    const stdout = run.stdout ?? '';
+    process.stdout.write(stdout);
+    console.log('::endgroup::');
+
+    if (run.error) {
+      failed.push(`${app.dir}: could not spawn pnpm (${run.error.message})`);
+      continue;
+    }
+
+    // The exit-0-on-empty-filter case. pnpm says so on stdout and returns success; without
+    // this the app is silently never checked.
+    if (/No projects matched the filters/i.test(stdout)) {
+      failed.push(
+        `${app.dir}: pnpm matched NO package for "${app.name}" — the filter is stale, so this ` +
+          `app was not typechecked (pnpm exits 0 in this case)`
+      );
+      continue;
+    }
+
+    if (run.status !== 0) {
+      failed.push(`${app.dir}: typecheck failed (exit ${run.status})`);
+    }
+  }
+
+  console.log(`\n${'='.repeat(60)}`);
+  if (failed.length) {
+    console.error(`${failed.length} of ${targets.length} app(s) failed typecheck:`);
+    for (const f of failed) console.error(`  ✗ ${f}`);
+    return 1;
+  }
+  console.log(`All ${targets.length} app(s) passed typecheck.`);
+  return 0;
 }
 
-console.log(`\n${'='.repeat(60)}`);
-if (failed.length) {
-  console.error(`${failed.length} of ${targets.length} app(s) failed typecheck:`);
-  for (const f of failed) console.error(`  ✗ ${f}`);
-  process.exit(1);
+// Run only when invoked as a script, so importing this module (the tests do) has no side effect.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(runTypecheckApps());
 }
-console.log(`All ${targets.length} app(s) passed typecheck.`);


### PR DESCRIPTION
`apps/auth` was the last app excluded from the per-app typecheck gate added in #4156. Both of its pre-existing errors are fixed at the root — no `any`, no `@ts-ignore`, no compiler-option loosening — and the exclusion is removed, so the gate now covers all **7** apps.

## The two errors

**`providers.ts:165` — `Parameter 'p' implicitly has an 'any' type`**

The stub provider's key is a *computed* property, `['stub' as ProviderId]`, whose type is the whole `ProviderId` union rather than a single literal. TypeScript therefore cannot match it to a member of `Record<ProviderId, ProviderDef>` and drops contextual typing for the value — which is why only this entry's `mapProfile` parameter was untyped while the four literal-keyed entries above were fine. Fixed with `satisfies ProviderDef`.

That turned out to be worth more than the one parameter. Measured both arms:

| `satisfies ProviderDef` | mutation: stub's `scope:` → `scopes:` | result |
|---|---|---|
| present | applied | `'scopes' does not exist in type 'ProviderDef'. Did you mean to write 'scope'?` — **caught** |
| removed | applied | **silently accepted**; only the implicit-`any` resurfaces |

So the entire stub entry was unchecked against `ProviderDef`, not just that parameter.

**`establish-session.test.ts:100` — `Property '_store' does not exist on type 'never'`**

The `Cookies` stub was cast `as never` to satisfy `establishSession`'s parameter. `never` has no properties, so reading `_store` back in an assertion was itself a type error. `Cookies` has exactly five members (`get`/`getAll`/`set`/`delete`/`serialize`), so the stub now implements all of them and is assignable with **no cast at all**.

## The real work: the guard suite

Emptying `EXCLUDED` breaks `scripts/__tests__/typecheck-apps.test.ts`. Measured: **6 of 8 cases fail**, because every fixture contained an `auth` app purely to satisfy the stale-exclusion guard, so an empty map made them fail for reasons unrelated to what they test.

Those guards are not deleted — they are what the *next* excluded app will depend on. Instead the exclusion map became a parameter of an exported `runTypecheckApps({ excluded })`, and the tests drive it with a synthetic app (`ghost`, `legacy`) through a test-only driver that imports the real module, so the injected cases still run the genuine script end-to-end.

Deliberately a **function parameter, not an env var**: an env-var override would be a live way to un-gate an app in CI, which is the exact failure class this script exists to close.

The suite is now 10 cases and decoupled from the shipped map. Verified by mutating the shipped map two ways:

- exclude an unrelated app (a plausible future change) → **0 failures**
- re-exclude `auth` → **exactly 1 failure**, the dedicated ledger test, on its own assertion

## Verification

Base ref for every "before" number: **`23cecb57c0`**.

**Red → green matrix**

| Check | at base `23cecb57c0` | at HEAD |
|---|---|---|
| `apps/auth` svelte-check | `COMPLETED 8037 FILES 2 ERRORS` | `COMPLETED 8037 FILES 0 ERRORS` |
| guard suite, `EXCLUDED` as shipped | 8 passed | 10 passed |
| guard suite, `EXCLUDED` emptied, tests unchanged | **6 failed / 2 passed** | n/a (tests reworked) |
| `apps/auth` unit tests | 372 passed | 372 passed |

**Positive control for the `0 ERRORS`.** A zero is indistinguishable from a check wired to nothing, so deliberate type errors were planted in *both* touched files and the run reported exactly them, at exactly the planted lines:

```
ERROR "src/lib/server/auth/providers.ts" 356:7 "Type 'string' is not assignable to type 'number'."
ERROR "src/lib/server/auth/__tests__/establish-session.test.ts" 118:7 "Type 'Map<string, string>' is not assignable to type 'string'."
COMPLETED 8037 FILES 2 ERRORS
```

Controls removed; the clean run reports the same **8037** files, so the check did not shrink. (File count matters: a run reporting `1 FILES` has checked nothing.)

**Mutation-tested the guards** — six mutants, each killed by the right test for its own reason:

| mutant | tests killed |
|---|---|
| stale-exclusion guard returns nothing | 1 (its own, on the exit code) |
| exclusion filter ignored | 2 (skip case, all-excluded case) |
| empty-targets guard returns 0 | 2 (both "refuses to report success" cases) |
| direct-run guard removed | 1 (the real-entrypoint case) |
| shipped map re-excludes `auth` | 1 (the dedicated ledger case) |
| shipped map excludes an unrelated app | **0 — correct**, proves the decoupling |

**Ledger.** `node scripts/ci/typecheck-apps.mjs` now prints:

```
Typechecking 7 app(s): auth, creator-studio, event-engine, moderator, notifications, orchestrator-gateway, storage
```

with **no `Skipping` line**.

## What I could NOT verify

`auth` typechecks clean, but I could not get a fully green 7/7 local run: `creator-studio`, `notifications` and `orchestrator-gateway` fail on my machine with `Module '"@prisma/client"' has no exported member 'Prisma'`. That is a local environment artifact — Prisma has no prebuilt engine for `linux-nixos`, so `postinstall`'s `db:generate` fails and the client is never generated. Evidence it is not this PR:

- every error is in `packages/civitai-db-schema` / `packages/civitai-db` or a downstream consumer of those types
- this PR touches 5 files, none under those three apps or under `packages/`
- those three apps were already un-excluded at base, and #4156's `App unit tests + typecheck` job passed in CI

CI runs on Linux with a working Prisma generate, so it is the authority on the 7/7 result. **Please confirm the `App unit tests + typecheck` job is green before merging** — that is the one claim I am relying on CI for rather than having measured myself.

Also note: my local runs used Node **v26.7.0** while `.nvmrc` pins **24.19.0** (pnpm warned `Unsupported engine` on every invocation). CI uses the pinned version.

## Incidental

- Neutralised the "six apps" counts in the script header and the workflow comment, which this change would otherwise make wrong (6 gated → 7).
- Ran prettier on the touched files, which also reformatted **two pre-existing** unformatted lines I did not otherwise modify (`providers.ts` `validatedStubUrl`, and the `user` helper in the test). The changed-files prettier step is report-only, but it would have started flagging them the moment this PR touched these files.
- ESLint reports two pre-existing `no-empty-function` errors in the test's `vi.hoisted` block. Left alone: CI's lint gate scopes to `^(src|packages|apps/event-engine)/`, so `apps/auth` is not linted, and they are unrelated to this change.
