### PR TITLE
fix(typecheck): typecheck scripts/ — 15 non-test files now covered, scripts/__tests__ excluded like src/

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -241,55 +241,6 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
-  typecheck-scripts:
-    name: Typecheck scripts/ (quarantine ratchet)
-    runs-on: ubuntu-latest
-    # UNCONDITIONAL, unlike the `typecheck` job above. That one is narrowed to
-    # fork PRs and non-main bases because the in-cluster Tekton `pr-check`
-    # pipeline covers everything else — but Tekton runs `pnpm run typecheck`,
-    # i.e. the ROOT tsconfig, and this gate measures `tsconfig.scripts.json`.
-    # Nothing else runs it, so a narrowing `if:` here would mean it never ran at
-    # all on an internal PR.
-    #
-    # 🔴 READ THIS BEFORE ASSUMING THIS JOB IS WHAT COVERS scripts/. It is not.
-    # `tsconfig.json` now includes `scripts/**/*.ts(x)`, so the 33 clean files
-    # there are checked by the ROOT typecheck and BOTH tiers already block on
-    # them — including every file added under `scripts/` in future. This job
-    # exists for the FIVE quarantined files listed in that config's `exclude`,
-    # which no other tier can see. Deleting it does not uncover the 33; it
-    # uncovers the 5.
-    #
-    # Its own job rather than a step on `unit`: that job is `continue-on-error`
-    # (report-only by design), so a ratchet parked there could never block.
-    timeout-minutes: 25
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          # `tsconfig.scripts.json` inherits `src` from the root config, and src
-          # imports event-engine-common. Without the submodule those resolve to
-          # 12 TS2307/TS7006 errors. The gate reports them as "outside scripts/"
-          # and drops them rather than mis-scoring them, so the verdict would
-          # still be correct — but the log becomes noise around it, and the
-          # submodule is public and needs no secret.
-          submodules: true
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
-
-      # Drives `scripts/typecheck.mjs` internally — the wrapper that sets the V8
-      # heap cap and classifies the outcome, so a heap abort reads as CRASHED
-      # rather than as a clean zero. The gate additionally refuses (exit 3) on a
-      # measurement it cannot trust, which is neither a pass nor a failure.
-      - name: Scripts quarantine ratchet
-        run: node scripts/ci/typecheck-scripts-gate.mjs
-
   unit:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -241,6 +241,55 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
+  typecheck-scripts:
+    name: Typecheck scripts/ (quarantine ratchet)
+    runs-on: ubuntu-latest
+    # UNCONDITIONAL, unlike the `typecheck` job above. That one is narrowed to
+    # fork PRs and non-main bases because the in-cluster Tekton `pr-check`
+    # pipeline covers everything else — but Tekton runs `pnpm run typecheck`,
+    # i.e. the ROOT tsconfig, and this gate measures `tsconfig.scripts.json`.
+    # Nothing else runs it, so a narrowing `if:` here would mean it never ran at
+    # all on an internal PR.
+    #
+    # 🔴 READ THIS BEFORE ASSUMING THIS JOB IS WHAT COVERS scripts/. It is not.
+    # `tsconfig.json` now includes `scripts/**/*.ts(x)`, so the 33 clean files
+    # there are checked by the ROOT typecheck and BOTH tiers already block on
+    # them — including every file added under `scripts/` in future. This job
+    # exists for the FIVE quarantined files listed in that config's `exclude`,
+    # which no other tier can see. Deleting it does not uncover the 33; it
+    # uncovers the 5.
+    #
+    # Its own job rather than a step on `unit`: that job is `continue-on-error`
+    # (report-only by design), so a ratchet parked there could never block.
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `tsconfig.scripts.json` inherits `src` from the root config, and src
+          # imports event-engine-common. Without the submodule those resolve to
+          # 12 TS2307/TS7006 errors. The gate reports them as "outside scripts/"
+          # and drops them rather than mis-scoring them, so the verdict would
+          # still be correct — but the log becomes noise around it, and the
+          # submodule is public and needs no secret.
+          submodules: true
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # Drives `scripts/typecheck.mjs` internally — the wrapper that sets the V8
+      # heap cap and classifies the outcome, so a heap abort reads as CRASHED
+      # rather than as a clean zero. The gate additionally refuses (exit 3) on a
+      # measurement it cannot trust, which is neither a pass nor a failure.
+      - name: Scripts quarantine ratchet
+        run: node scripts/ci/typecheck-scripts-gate.mjs
+
   unit:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/scripts/__tests__/typecheck-scripts-gate.test.ts
+++ b/scripts/__tests__/typecheck-scripts-gate.test.ts
@@ -12,12 +12,15 @@ import {
   isScriptFileLine,
   relativizeToRepo,
   scriptFileFloor,
+  stripJsonComments,
 } from '../ci/typecheck-scripts-compare.mjs';
 
 /**
- * `scripts/ci/typecheck-scripts-gate.mjs` ratchets the type errors in the five
- * files `tsconfig.json` quarantines out of the `scripts/` typecheck. Its entire
- * value rests on one property: it must be UNABLE to report a confident zero.
+ * `scripts/ci/typecheck-scripts-gate.mjs` measures the type errors in the part of
+ * `scripts/` the root program excludes — `scripts/__tests__/**` and
+ * `scripts/local-dev/gen_seed.ts`. It is not wired into CI (see its header for
+ * why), so its exit code is a report rather than a merge block. Its entire value
+ * rests on one property: it must be UNABLE to report a confident zero.
  *
  * Two tiers here, deliberately:
  *
@@ -47,13 +50,10 @@ const plain = (file: string, code = 2322) =>
 
 // The quarantine the gate pins. Mirrored here so a drift between the gate's list
 // and the fixtures shows up as a failing test rather than as a silent no-op.
-const QUARANTINE = [
-  'scripts/__tests__/dev-server-test-queue.test.ts',
-  'scripts/__tests__/dev-server-env-modes.test.ts',
-  'scripts/__tests__/dev-server-port-reservation.test.ts',
-  'scripts/__tests__/typecheck-tests-gate.test.ts',
-  'scripts/local-dev/gen_seed.ts',
-];
+// What `tsconfig.json` excludes and `tsconfig.scripts.json` re-includes. Mirrored
+// here so a drift between the gate's list and these fixtures fails a test rather
+// than silently becoming a no-op.
+const QUARANTINE = ['scripts/__tests__/**', 'scripts/local-dev/gen_seed.ts'];
 const BASE_EXCLUDE = ['node_modules', 'src/**/__tests__/**', 'packages/civitai-ui'];
 
 let dir: string;
@@ -530,18 +530,58 @@ describe('the committed baseline', () => {
     for (const file of Object.keys(b.files)) expect(isGatedScriptFile(file)).toBe(true);
   });
 
-  it('covers exactly the files tsconfig.json quarantines — no more, no less', () => {
-    // A baseline entry for a file that is NOT quarantined would be unreachable
-    // (the root typecheck blocks on it first); a quarantined file with NO entry
-    // means the quarantine grew without the ratchet noticing.
+  it('records ONLY files the root program excludes — never one `pnpm typecheck` can see', () => {
+    // 🔴 The invariant that keeps this baseline from becoming a place to hide a
+    // real failure. Every entry must be a path `tsconfig.json` excludes. An entry
+    // for a root-COVERED file would mean somebody recorded an error that the root
+    // typecheck is red on — i.e. used this file to make a blocking failure look
+    // handled. That is the one way this instrument could do harm, so it is pinned
+    // structurally rather than trusted to review.
+    //
+    // The exclusion set is read from `tsconfig.json` rather than restated, so
+    // narrowing the exclusions automatically tightens this test.
     const root = path.resolve(__dirname, '../..');
-    const raw = readFileSync(path.join(root, 'tsconfig.json'), 'utf8');
-    const quarantined = [...raw.matchAll(/"(scripts\/[^"]+\.tsx?)"/g)]
-      .map((m) => m[1]!)
-      .filter((f) => !f.includes('*'));
+    const excludes: string[] = JSON.parse(
+      stripJsonComments(readFileSync(path.join(root, 'tsconfig.json'), 'utf8'))
+    ).exclude;
+    const scriptExcludes = excludes.filter((e) => e.startsWith('scripts/'));
+
+    // Positive control on the parse itself: a zero here would make the loop below
+    // vacuous, and a vacuous loop passes.
+    expect(scriptExcludes.length).toBeGreaterThan(0);
+
+    const covers = (file: string) =>
+      scriptExcludes.some((pattern) =>
+        pattern.endsWith('/**') ? file.startsWith(pattern.slice(0, -2)) : file === pattern
+      );
+
     const b = JSON.parse(
       readFileSync(path.resolve(__dirname, '../ci/typecheck-scripts-baseline.json'), 'utf8')
     );
-    expect(new Set(Object.keys(b.files))).toEqual(new Set(quarantined));
+    const entries = Object.keys(b.files);
+    expect(entries.length).toBeGreaterThan(0);
+    for (const file of entries) {
+      expect(
+        covers(file),
+        `${file} is in the baseline but is NOT excluded by tsconfig.json, so the root ` +
+          `typecheck can see it. Fix the file; do not record it here.`
+      ).toBe(true);
+    }
+  });
+
+  it('the covers() predicate can actually reject — negative control', () => {
+    // Without this, the loop above would pass just as happily against a predicate
+    // that returns true for everything.
+    const scriptExcludes = ['scripts/__tests__/**', 'scripts/local-dev/gen_seed.ts'];
+    const covers = (file: string) =>
+      scriptExcludes.some((pattern) =>
+        pattern.endsWith('/**') ? file.startsWith(pattern.slice(0, -2)) : file === pattern
+      );
+    expect(covers('scripts/__tests__/anything.test.ts')).toBe(true);
+    expect(covers('scripts/local-dev/gen_seed.ts')).toBe(true);
+    // Root-covered paths — a baseline entry for any of these must fail the test above.
+    expect(covers('scripts/oneoffs/parse_header.ts')).toBe(false);
+    expect(covers('scripts/local-dev/utils.ts')).toBe(false);
+    expect(covers('scripts/seed-comics.ts')).toBe(false);
   });
 });

--- a/scripts/__tests__/typecheck-scripts-gate.test.ts
+++ b/scripts/__tests__/typecheck-scripts-gate.test.ts
@@ -1,0 +1,547 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  ALLOW_EMPTY_ENV,
+  FALLBACK_MIN_SCRIPT_FILES,
+  countScriptFilesInProgram,
+  diffLists,
+  isGatedScriptFile,
+  isScriptFileLine,
+  relativizeToRepo,
+  scriptFileFloor,
+} from '../ci/typecheck-scripts-compare.mjs';
+
+/**
+ * `scripts/ci/typecheck-scripts-gate.mjs` ratchets the type errors in the five
+ * files `tsconfig.json` quarantines out of the `scripts/` typecheck. Its entire
+ * value rests on one property: it must be UNABLE to report a confident zero.
+ *
+ * Two tiers here, deliberately:
+ *
+ *  - the pure functions THIS gate adds (path anchoring, the positive control's
+ *    counter and floor, the config-drift diff), driven directly. The generic
+ *    half — parsing, run classification, plausibility, the ratchet comparison —
+ *    is imported from `typecheck-tests-compare.mjs` and is already covered by
+ *    `typecheck-tests-gate.test.ts`; re-testing it here would assert the same
+ *    code twice and drift.
+ *  - the gate END TO END, driven through the `TYPECHECK_SCRIPTS_WRAPPER` seam
+ *    with stub "typecheckers" that exit the way each real failure does. A real
+ *    repo-wide `tsc` run is minutes, so nobody would run one per case — and a
+ *    control nobody runs is not a control.
+ *
+ * Every end-to-end case asserts a NON-ZERO exit AND a message naming the real
+ * problem. A test that only asserted "it did not pass" would still be satisfied
+ * by a gate that fails for the wrong reason.
+ */
+
+const GATE = path.resolve(__dirname, '../ci/typecheck-scripts-gate.mjs');
+
+// Built by concatenation so this file's own source can never be mistaken for a
+// diagnostic by the parser it is testing.
+const TS = `error${' '}TS`;
+const plain = (file: string, code = 2322) =>
+  `${file}(1,1): ${TS}${code}: Type 'string' is not assignable to type 'number'.`;
+
+// The quarantine the gate pins. Mirrored here so a drift between the gate's list
+// and the fixtures shows up as a failing test rather than as a silent no-op.
+const QUARANTINE = [
+  'scripts/__tests__/dev-server-test-queue.test.ts',
+  'scripts/__tests__/dev-server-env-modes.test.ts',
+  'scripts/__tests__/dev-server-port-reservation.test.ts',
+  'scripts/__tests__/typecheck-tests-gate.test.ts',
+  'scripts/local-dev/gen_seed.ts',
+];
+const BASE_EXCLUDE = ['node_modules', 'src/**/__tests__/**', 'packages/civitai-ui'];
+
+let dir: string;
+beforeAll(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'typecheck-scripts-gate-'));
+});
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+let seq = 0;
+
+/**
+ * A stub that answers the `--listFilesOnly` arm and the verdict arm differently,
+ * which is what the real wrapper does. Without this the positive control and the
+ * verdict would see the same text.
+ */
+function twoArmWrapper(listOut: string, listCode: number, verdictOut: string, verdictCode: number) {
+  const file = path.join(dir, `stub-two-${seq++}.mjs`);
+  writeFileSync(
+    file,
+    `const listOnly = process.argv.includes('--listFilesOnly');\n` +
+      `process.stdout.write(listOnly ? ${JSON.stringify(listOut)} : ${JSON.stringify(
+        verdictOut
+      )});\n` +
+      `process.exit(listOnly ? ${listCode} : ${verdictCode});\n`
+  );
+  return file;
+}
+
+function writeConfigs(where: string, baseExclude: string[], scriptsExclude: string[]) {
+  mkdirSync(where, { recursive: true });
+  writeFileSync(
+    path.join(where, 'tsconfig.json'),
+    JSON.stringify({ include: ['scripts/**/*.ts', 'src'], exclude: baseExclude }, null, 2)
+  );
+  writeFileSync(
+    path.join(where, 'tsconfig.scripts.json'),
+    JSON.stringify({ extends: './tsconfig.json', exclude: scriptsExclude }, null, 2)
+  );
+}
+
+function writeBaselineFile(
+  where: string,
+  files: Record<string, number>,
+  scriptFilesInProgram = 34
+) {
+  const p = path.join(dir, `baseline-${seq++}.json`);
+  writeFileSync(
+    p,
+    JSON.stringify({
+      config: 'tsconfig.scripts.json',
+      scriptFilesInProgram,
+      totalErrors: Object.values(files).reduce((a, b) => a + b, 0),
+      files,
+    })
+  );
+  return p;
+}
+
+/** A `--listFilesOnly` payload naming `n` distinct files under `<root>/scripts/`. */
+function listing(root: string, n: number) {
+  return Array.from({ length: n }, (_, i) => `${root}/scripts/gen/file-${i}.ts`).join('\n');
+}
+
+function runGate(env: Record<string, string>) {
+  const res = spawnSync(process.execPath, [GATE], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return { ...res, output: `${res.stdout || ''}${res.stderr || ''}` };
+}
+
+// ------------------------------------------------------- path anchoring
+
+describe('relativizeToRepo', () => {
+  it('strips the repo root', () => {
+    expect(relativizeToRepo('/repo/scripts/a.ts', '/repo')).toBe('scripts/a.ts');
+  });
+
+  it('tolerates a trailing slash on the root', () => {
+    expect(relativizeToRepo('/repo/scripts/a.ts', '/repo/')).toBe('scripts/a.ts');
+  });
+
+  it('returns null for a path outside the repo', () => {
+    expect(relativizeToRepo('/elsewhere/scripts/a.ts', '/repo')).toBeNull();
+  });
+
+  it('does NOT treat a sibling directory sharing the root prefix as inside it', () => {
+    // `/repo-worktree` starts with `/repo`. Without the trailing separator this
+    // returns `worktree/scripts/a.ts`, which then matches nothing and is merely
+    // wrong; with a `scripts/` at the front it would be COUNTED as ours.
+    expect(relativizeToRepo('/repo-worktree/scripts/a.ts', '/repo')).toBeNull();
+  });
+
+  it('normalises backslashes so a win32-shaped path lands in the same space', () => {
+    expect(relativizeToRepo('C:\\repo\\scripts\\a.ts', 'C:\\repo')).toBe('scripts/a.ts');
+  });
+});
+
+describe('isScriptFileLine — the positive control must not be walkable by a substring', () => {
+  const ROOT = '/repo';
+
+  it('counts a file under the repo-root scripts/ directory', () => {
+    expect(isScriptFileLine(`${ROOT}/scripts/oneoffs/x.ts`, ROOT)).toBe(true);
+  });
+
+  it('does NOT count .claude/skills/**/scripts/, which this repo really does pull in', () => {
+    // Five of these are in the real program as transitive imports. A
+    // `p.includes('/scripts/')` control counts them, and could therefore stay
+    // green with the entire repo-root scripts/ tree gone. This is the assertion
+    // that makes the control a control.
+    expect(isScriptFileLine(`${ROOT}/.claude/skills/dev-server/scripts/daemon.mjs`, ROOT)).toBe(
+      false
+    );
+  });
+
+  it('does NOT count a vendored package that happens to have a scripts/ directory', () => {
+    expect(isScriptFileLine(`${ROOT}/node_modules/whatever/scripts/build.ts`, ROOT)).toBe(false);
+  });
+
+  it('does NOT count src/', () => {
+    expect(isScriptFileLine(`${ROOT}/src/server/a.ts`, ROOT)).toBe(false);
+  });
+
+  it('counts nothing at all when the root does not match — a wrong root reads as zero, not as noise', () => {
+    expect(countScriptFilesInProgram(listing('/repo', 40), '/somewhere-else')).toBe(0);
+  });
+
+  it('counts every scripts/ line under the right root', () => {
+    expect(countScriptFilesInProgram(listing('/repo', 40), '/repo')).toBe(40);
+  });
+});
+
+describe('isGatedScriptFile', () => {
+  it('claims files under scripts/', () => {
+    expect(isGatedScriptFile('scripts/local-dev/gen_seed.ts')).toBe(true);
+  });
+  it('does not claim src/ — those belong to `pnpm typecheck`', () => {
+    expect(isGatedScriptFile('src/server/a.ts')).toBe(false);
+  });
+  it('does not claim a path merely CONTAINING scripts/', () => {
+    expect(isGatedScriptFile('.claude/skills/dev-server/scripts/daemon.mjs')).toBe(false);
+  });
+});
+
+// ------------------------------------------------------------- the floor
+
+describe('scriptFileFloor', () => {
+  it('falls back to the fixed floor when the baseline records nothing', () => {
+    expect(scriptFileFloor(undefined)).toMatchObject({
+      ok: true,
+      floor: FALLBACK_MIN_SCRIPT_FILES,
+      derived: false,
+    });
+  });
+
+  it('derives 90% of the recorded count when that RAISES the fixed floor', () => {
+    expect(scriptFileFloor(100)).toMatchObject({ ok: true, floor: 90, derived: true });
+  });
+
+  it('never lets a derived floor LOWER the fixed one', () => {
+    // The defect this guards: `scriptFileFloor(1)` returning `{floor: 0}` — a
+    // floor no program can fail — while still reporting `derived: true`, i.e.
+    // while logging that it was derived and therefore trustworthy.
+    expect(scriptFileFloor(2)).toMatchObject({
+      ok: true,
+      floor: FALLBACK_MIN_SCRIPT_FILES,
+      derived: false,
+    });
+  });
+
+  it('REFUSES a zero or negative recorded count rather than falling back', () => {
+    // A corrupt count is not the same as an ABSENT one; quietly treating it as
+    // absent is how a broken baseline reads as a working control.
+    expect(scriptFileFloor(0).ok).toBe(false);
+    expect(scriptFileFloor(-5).ok).toBe(false);
+  });
+
+  it('REFUSES a non-integer recorded count', () => {
+    expect(scriptFileFloor('34' as unknown as number).ok).toBe(false);
+    expect(scriptFileFloor(3.5).ok).toBe(false);
+  });
+
+  it('REFUSES an absurd count, which would make the control permanently red', () => {
+    expect(scriptFileFloor(10_000_000).ok).toBe(false);
+  });
+});
+
+// ------------------------------------------------------- config drift
+
+describe('diffLists', () => {
+  it('accepts the base list minus exactly the expected set', () => {
+    const base = [...BASE_EXCLUDE, ...QUARANTINE];
+    expect(diffLists(base, BASE_EXCLUDE, QUARANTINE).ok).toBe(true);
+  });
+
+  it('ignores ORDER — a cosmetic reshuffle must not read as drift', () => {
+    const base = [...QUARANTINE, ...BASE_EXCLUDE];
+    expect(diffLists(base, [...BASE_EXCLUDE].reverse(), QUARANTINE).ok).toBe(true);
+  });
+
+  it('REJECTS when the variant still excludes a quarantined entry', () => {
+    // i.e. the measurement program is NOT measuring the file it claims to.
+    const base = [...BASE_EXCLUDE, ...QUARANTINE];
+    const variant = [...BASE_EXCLUDE, QUARANTINE[0]!];
+    const d = diffLists(base, variant, QUARANTINE);
+    expect(d.ok).toBe(false);
+    expect(d.missing).toEqual([QUARANTINE[0]]);
+  });
+
+  it('REJECTS when the variant drops something NOT in the quarantine', () => {
+    // This is the silent-widening case: the measurement program quietly stops
+    // excluding `src/**/__tests__/**` and the number starts meaning something
+    // else entirely.
+    const base = [...BASE_EXCLUDE, ...QUARANTINE];
+    const variant = base.filter((e) => e !== 'src/**/__tests__/**' && !QUARANTINE.includes(e));
+    const d = diffLists(base, variant, QUARANTINE);
+    expect(d.ok).toBe(false);
+    expect(d.unexpected).toContain('src/**/__tests__/**');
+  });
+
+  it('REJECTS when the variant ADDS an exclude of its own', () => {
+    const base = [...BASE_EXCLUDE, ...QUARANTINE];
+    const d = diffLists(base, [...BASE_EXCLUDE, 'scripts/**'], QUARANTINE);
+    expect(d.ok).toBe(false);
+    expect(d.added).toEqual(['scripts/**']);
+  });
+
+  it('REJECTS a STALE quarantine list — a file cleaned up in the configs but left in the gate', () => {
+    // The direction this gate is meant to move in. If someone removes an entry
+    // from both configs but forgets the gate's own list, the gate must refuse
+    // rather than measure a program it has the wrong model of.
+    const shrunk = QUARANTINE.slice(1);
+    const base = [...BASE_EXCLUDE, ...shrunk];
+    const d = diffLists(base, BASE_EXCLUDE, QUARANTINE);
+    expect(d.ok).toBe(false);
+    expect(d.missing).toEqual([QUARANTINE[0]]);
+  });
+});
+
+// --------------------------------------------------------------- end to end
+
+describe('the gate, end to end', () => {
+  /** Configs that satisfy the drift control, so other controls are reachable. */
+  function okConfigDir() {
+    const where = path.join(dir, `cfg-${seq++}`);
+    writeConfigs(where, [...BASE_EXCLUDE, ...QUARANTINE], BASE_EXCLUDE);
+    return where;
+  }
+
+  const ROOT = '/fixture-root';
+  const goodListing = listing(ROOT, 34);
+
+  it('PASSES when the measurement equals the baseline', () => {
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: okConfigDir(),
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: writeBaselineFile(dir, { 'scripts/a.ts': 2 }),
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(
+        goodListing,
+        0,
+        [plain('scripts/a.ts'), plain('scripts/a.ts')].join('\n'),
+        1
+      ),
+    });
+    expect(res.status).toBe(0);
+    expect(res.output).toContain('PASS');
+  });
+
+  it('BLOCKS a worsened baselined file, naming the delta', () => {
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: okConfigDir(),
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: writeBaselineFile(dir, { 'scripts/a.ts': 2 }),
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(
+        goodListing,
+        0,
+        [plain('scripts/a.ts'), plain('scripts/a.ts'), plain('scripts/a.ts')].join('\n'),
+        1
+      ),
+    });
+    expect(res.status).toBe(1);
+    expect(res.output).toContain('BLOCKED');
+    expect(res.output).toContain('scripts/a.ts  2 -> 3');
+  });
+
+  it('BLOCKS a file with errors that is not in the baseline', () => {
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: okConfigDir(),
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: writeBaselineFile(dir, { 'scripts/a.ts': 2 }),
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(
+        goodListing,
+        0,
+        [plain('scripts/a.ts'), plain('scripts/a.ts'), plain('scripts/new.ts')].join('\n'),
+        1
+      ),
+    });
+    expect(res.status).toBe(1);
+    expect(res.output).toContain('are NOT in the baseline');
+    expect(res.output).toContain('scripts/new.ts');
+  });
+
+  it('PASSES and SAYS SO when a baselined file is fixed', () => {
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: okConfigDir(),
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: writeBaselineFile(dir, { 'scripts/a.ts': 8, 'scripts/b.ts': 4 }),
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(
+        goodListing,
+        0,
+        Array.from({ length: 8 }, () => plain('scripts/a.ts')).join('\n'),
+        1
+      ),
+    });
+    expect(res.status).toBe(0);
+    expect(res.output).toContain('1 file(s) now clean');
+  });
+
+  it('does NOT claim errors outside scripts/, but reports them', () => {
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: okConfigDir(),
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: writeBaselineFile(dir, { 'scripts/a.ts': 1 }),
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(
+        goodListing,
+        0,
+        [plain('scripts/a.ts'), plain('src/server/x.ts')].join('\n'),
+        1
+      ),
+    });
+    // `src/server/x.ts` must not be scored as a newly-dirty file of this gate's.
+    expect(res.status).toBe(0);
+    expect(res.output).toContain('outside scripts/');
+    expect(res.output).toContain('src/server/x.ts');
+  });
+
+  // ---- the controls, each proven able to go red -------------------------
+
+  it('CANNOT MEASURE when the positive control finds too few scripts/ files', () => {
+    // The whole point: a program that has lost the tree reports every file as
+    // `fixed`, i.e. PASS, unless something refuses first.
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: okConfigDir(),
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: writeBaselineFile(dir, { 'scripts/a.ts': 2 }),
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(listing(ROOT, 3), 0, '', 0),
+    });
+    expect(res.status).toBe(3);
+    expect(res.output).toContain('POSITIVE CONTROL FAILED');
+    expect(res.output).toContain('below the floor of 30');
+  });
+
+  it('CANNOT MEASURE when the config-drift control fails', () => {
+    const where = path.join(dir, `cfg-drift-${seq++}`);
+    // The variant still excludes a quarantined file, so it is not measuring it.
+    writeConfigs(where, [...BASE_EXCLUDE, ...QUARANTINE], [...BASE_EXCLUDE, QUARANTINE[0]!]);
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: where,
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: writeBaselineFile(dir, { 'scripts/a.ts': 2 }),
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(goodListing, 0, plain('scripts/a.ts'), 1),
+    });
+    expect(res.status).toBe(3);
+    expect(res.output).toContain('no longer');
+    expect(res.output).toContain(QUARANTINE[0]!);
+  });
+
+  it('CANNOT MEASURE on a non-zero exit with zero diagnostics — the heap-abort shape', () => {
+    // exit 134 with no output is what a V8 heap abort looks like. Read as
+    // "clean", it is the single most dangerous false green available.
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: okConfigDir(),
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: writeBaselineFile(dir, { 'scripts/a.ts': 2 }),
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(goodListing, 0, '', 134),
+    });
+    expect(res.status).toBe(3);
+    expect(res.output).toContain('FAILURE TO RUN');
+  });
+
+  it('CANNOT MEASURE when the verdict run parses 0 against a non-zero baseline', () => {
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: okConfigDir(),
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: writeBaselineFile(dir, { 'scripts/a.ts': 198 }),
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(goodListing, 0, '', 0),
+    });
+    expect(res.status).toBe(3);
+    expect(res.output).toContain('parsed 0');
+  });
+
+  it('SHOUTS but still runs on a collapsed verdict measurement', () => {
+    // A collapse cannot hide a regression, so refusing would block a legitimate
+    // large cleanup for no safety gain. It must be loud, not fatal.
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: okConfigDir(),
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: writeBaselineFile(dir, { 'scripts/a.ts': 198 }),
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(goodListing, 0, plain('scripts/a.ts'), 1),
+    });
+    expect(res.status).toBe(0);
+    expect(res.output).toContain('IMPLAUSIBLE MEASUREMENT');
+  });
+
+  it('REFUSES the plausibility escape hatch on a verdict run', () => {
+    // Refused rather than ignored: silently ignoring a control-disabling
+    // variable is its own confident-wrong.
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: okConfigDir(),
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: writeBaselineFile(dir, { 'scripts/a.ts': 2 }),
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(goodListing, 0, '', 0),
+      [ALLOW_EMPTY_ENV]: 'the tree is genuinely clean now',
+    });
+    expect(res.status).toBe(3);
+    expect(res.output).toContain('REFUSING TO RUN');
+    // It must name ITS OWN variable, not the sibling gate's — the whole reason
+    // `classifyEmptyAllowance` takes an `envName`.
+    expect(res.output).toContain('TYPECHECK_SCRIPTS_ALLOW_EMPTY');
+    expect(res.output).not.toContain('TYPECHECK_TESTS_ALLOW_EMPTY');
+  });
+
+  it('ECHOES overridden seams, so a stub-driven run is not byte-identical to a real one', () => {
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: okConfigDir(),
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: writeBaselineFile(dir, { 'scripts/a.ts': 1 }),
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(goodListing, 0, plain('scripts/a.ts'), 1),
+    });
+    expect(res.output).toContain('[OVERRIDE]');
+    expect(res.output).toContain('seam(s) overridden by environment');
+  });
+
+  it('refuses a baseline whose totalErrors disagrees with its entries', () => {
+    const p = path.join(dir, `baseline-bad-${seq++}.json`);
+    writeFileSync(
+      p,
+      JSON.stringify({
+        config: 'tsconfig.scripts.json',
+        scriptFilesInProgram: 34,
+        totalErrors: 198,
+        files: { 'scripts/a.ts': 5 },
+      })
+    );
+    const res = runGate({
+      TYPECHECK_SCRIPTS_CONFIG_DIR: okConfigDir(),
+      TYPECHECK_SCRIPTS_PROGRAM_ROOT: ROOT,
+      TYPECHECK_SCRIPTS_BASELINE: p,
+      TYPECHECK_SCRIPTS_WRAPPER: twoArmWrapper(goodListing, 0, plain('scripts/a.ts'), 1),
+    });
+    expect(res.status).toBe(2);
+    expect(res.output).toContain('unusable baseline');
+  });
+});
+
+// ------------------------------------------- the committed baseline itself
+
+describe('the committed baseline', () => {
+  it('is internally consistent and measured against the right config', () => {
+    const p = path.resolve(__dirname, '../ci/typecheck-scripts-baseline.json');
+    const b = JSON.parse(readFileSync(p, 'utf8'));
+    expect(b.config).toBe('tsconfig.scripts.json');
+    const sum = Object.values(b.files as Record<string, number>).reduce((a, c) => a + c, 0);
+    expect(b.totalErrors).toBe(sum);
+    expect(Number.isInteger(b.scriptFilesInProgram)).toBe(true);
+    expect(b.scriptFilesInProgram).toBeGreaterThan(FALLBACK_MIN_SCRIPT_FILES);
+  });
+
+  it('names only files this gate is responsible for', () => {
+    const p = path.resolve(__dirname, '../ci/typecheck-scripts-baseline.json');
+    const b = JSON.parse(readFileSync(p, 'utf8'));
+    for (const file of Object.keys(b.files)) expect(isGatedScriptFile(file)).toBe(true);
+  });
+
+  it('covers exactly the files tsconfig.json quarantines — no more, no less', () => {
+    // A baseline entry for a file that is NOT quarantined would be unreachable
+    // (the root typecheck blocks on it first); a quarantined file with NO entry
+    // means the quarantine grew without the ratchet noticing.
+    const root = path.resolve(__dirname, '../..');
+    const raw = readFileSync(path.join(root, 'tsconfig.json'), 'utf8');
+    const quarantined = [...raw.matchAll(/"(scripts\/[^"]+\.tsx?)"/g)]
+      .map((m) => m[1]!)
+      .filter((f) => !f.includes('*'));
+    const b = JSON.parse(
+      readFileSync(path.resolve(__dirname, '../ci/typecheck-scripts-baseline.json'), 'utf8')
+    );
+    expect(new Set(Object.keys(b.files))).toEqual(new Set(quarantined));
+  });
+});

--- a/scripts/ci/typecheck-scripts-baseline.json
+++ b/scripts/ci/typecheck-scripts-baseline.json
@@ -1,9 +1,10 @@
 {
   "_comment": "Type errors in the files tsconfig.json quarantines out of the scripts/ typecheck. Entries may shrink or disappear freely; adding one, or raising a count, is a deliberate act visible in review. Regenerate with: node scripts/ci/typecheck-scripts-gate.mjs --write-baseline",
   "config": "tsconfig.scripts.json",
-  "scriptFilesInProgram": 36,
-  "totalErrors": 198,
+  "scriptFilesInProgram": 37,
+  "totalErrors": 202,
   "files": {
+    "scripts/__tests__/dev-server-daemon-port.test.ts": 4,
     "scripts/__tests__/dev-server-env-modes.test.ts": 14,
     "scripts/__tests__/dev-server-port-reservation.test.ts": 7,
     "scripts/__tests__/dev-server-test-queue.test.ts": 164,

--- a/scripts/ci/typecheck-scripts-baseline.json
+++ b/scripts/ci/typecheck-scripts-baseline.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Type errors in the files tsconfig.json quarantines out of the scripts/ typecheck. Entries may shrink or disappear freely; adding one, or raising a count, is a deliberate act visible in review. Regenerate with: node scripts/ci/typecheck-scripts-gate.mjs --write-baseline",
+  "config": "tsconfig.scripts.json",
+  "scriptFilesInProgram": 36,
+  "totalErrors": 198,
+  "files": {
+    "scripts/__tests__/dev-server-env-modes.test.ts": 14,
+    "scripts/__tests__/dev-server-port-reservation.test.ts": 7,
+    "scripts/__tests__/dev-server-test-queue.test.ts": 164,
+    "scripts/__tests__/typecheck-tests-gate.test.ts": 11,
+    "scripts/local-dev/gen_seed.ts": 2
+  }
+}

--- a/scripts/ci/typecheck-scripts-compare.mjs
+++ b/scripts/ci/typecheck-scripts-compare.mjs
@@ -1,0 +1,234 @@
+/**
+ * The pure, side-effect-free half of `typecheck-scripts-gate.mjs`.
+ *
+ * Everything region-agnostic — diagnostic parsing, run classification,
+ * plausibility, the ratchet comparison, rename detection, baseline validation,
+ * the tsconfig comment stripper — is IMPORTED from
+ * `typecheck-tests-compare.mjs` and re-exported here, not copied. Those
+ * functions are where a confident wrong answer gets produced, they were each
+ * fixed once already in response to a real defect, and a second copy would
+ * regenerate every one of those defects on its own schedule.
+ *
+ * What lives here is only what genuinely differs between the two gates:
+ *
+ *   - which files the gate is RESPONSIBLE for (`scripts/`, not `src/**\/__tests__/`);
+ *   - how the positive control counts them, which needs the repo root because
+ *     `/scripts/` is an ambiguous substring in this repo (see below);
+ *   - the positive control's floor constants, which are assertions about the
+ *     size of THIS population;
+ *   - `diffLists`, because this config's delta from the base is a SET of
+ *     excluded files rather than the single entry `diffExcludes` pins.
+ *
+ * Nothing in this file reads the filesystem, spawns a process, or exits, and
+ * nothing in it reads `path.sep` — see `toPosixPath` in the imported module for
+ * why that is load-bearing rather than incidental.
+ */
+import { NODE_MODULES_SEGMENT, toPosixPath } from './typecheck-tests-compare.mjs';
+
+export {
+  ALLOW_EMPTY_ENV as TESTS_ALLOW_EMPTY_ENV,
+  checkPlausibility,
+  classifyEmptyAllowance,
+  classifyRun,
+  compare,
+  detectRenames,
+  parseDiagnostics,
+  stripJsonComments,
+  toPosixPath,
+  validateBaseline,
+} from './typecheck-tests-compare.mjs';
+
+/** This gate's own plausibility escape hatch. Distinct from the tests gate's. */
+export const ALLOW_EMPTY_ENV = 'TYPECHECK_SCRIPTS_ALLOW_EMPTY';
+export const GATE_SCRIPT = 'scripts/ci/typecheck-scripts-gate.mjs';
+
+/**
+ * Files under the repo-root `scripts/` directory are this gate's business, and
+ * nothing else is. Diagnostic paths from `tsc` are already repo-relative, so the
+ * anchor is all that is needed.
+ *
+ * Errors in `src/` or `packages/` belong to `pnpm typecheck`, which blocks on
+ * them directly; claiming them here would demand a baseline entry for an error
+ * the root check already fails on.
+ */
+export const SCRIPTS_PATH_RE = /^scripts\//;
+
+/** Is this diagnostic path one this gate is responsible for? */
+export function isGatedScriptFile(file) {
+  return SCRIPTS_PATH_RE.test(toPosixPath(file));
+}
+
+/**
+ * Make an absolute path from `tsc --listFilesOnly` repo-relative, or return null
+ * if it does not live under `repoRoot`.
+ *
+ * `tsc` prints absolute paths here, and the repo root is stripped by TEXT rather
+ * than by `path.relative` so this stays a pure function over strings. The
+ * trailing separator matters: without it a sibling directory named
+ * `<repo>-worktree` would prefix-match the repo root and have its files counted
+ * as if they were ours.
+ */
+export function relativizeToRepo(line, repoRoot) {
+  const p = toPosixPath(line).trim();
+  if (!p) return null;
+  const root = toPosixPath(repoRoot).replace(/\/+$/, '');
+  if (!root) return null;
+  const prefix = `${root}/`;
+  if (!p.startsWith(prefix)) return null;
+  return p.slice(prefix.length);
+}
+
+/**
+ * Does this `--listFilesOnly` line name a file the positive control should count?
+ *
+ * 🔴 The substring test the sibling gate uses (`p.includes('/__tests__/')`) is
+ * NOT safe for this one, and that is the reason this function takes a repo root
+ * at all. `/scripts/` appears in paths that are NOT the population being
+ * measured — `.claude/skills/dev-server/scripts/daemon.mjs` and four of its
+ * siblings are pulled into the program transitively, and every vendored package
+ * with a `scripts/` directory would match too. A substring control would count
+ * those, so it could stay green while the entire repo-root `scripts/` tree
+ * dropped out of the program — a positive control that cannot fail is not one.
+ *
+ * Anchoring at the repo root is what makes the count mean "the files this gate
+ * measures". `node_modules` is excluded on the already-relativized path.
+ */
+export function isScriptFileLine(line, repoRoot) {
+  const rel = relativizeToRepo(line, repoRoot);
+  if (rel === null) return false;
+  if (`/${rel}`.includes(NODE_MODULES_SEGMENT)) return false;
+  return SCRIPTS_PATH_RE.test(rel);
+}
+
+/**
+ * The positive control's measurement: how many files under the repo-root
+ * `scripts/` directory the program actually contains, given raw
+ * `--listFilesOnly` output.
+ */
+export function countScriptFilesInProgram(output, repoRoot) {
+  return String(output ?? '')
+    .split('\n')
+    .filter((line) => isScriptFileLine(line, repoRoot)).length;
+}
+
+// `SHRINK_TOLERANCE` is the honest cost of the derived half of the floor: some
+// churn is normal, and a floor that blocks on ordinary deletion is a floor
+// people disable. `FALLBACK_MIN_SCRIPT_FILES` is the fixed half.
+//
+// The fixed value is an assertion about THIS population and is deliberately much
+// smaller than the sibling gate's 400: `tsconfig.scripts.json` contains 38 files
+// under `scripts/`, not 938. It is set below the real count by enough that
+// ordinary growth and deletion do not trip it, and far enough above zero that a
+// program which has lost the tree cannot pass.
+export const SHRINK_TOLERANCE = 0.9;
+export const FALLBACK_MIN_SCRIPT_FILES = 20;
+export const ABSURD_MAX_SCRIPT_FILES = 100_000;
+
+/**
+ * Positive-control floor for the number of `scripts/` files in the program.
+ *
+ * Identical in shape and in reasoning to `testFileFloor` in the sibling module,
+ * and it is a separate function ONLY because both constants differ. The two
+ * defects that module records are both defended against here:
+ *
+ *  - a bare fixed floor lets most of the population vanish while staying green,
+ *    and vanished files score as `fixed`, i.e. PASS. Hence the derived half.
+ *  - a purely derived floor is only as good as a number in a JSON file:
+ *    `scriptFileFloor(1)` would yield a floor of ZERO while still reporting
+ *    `derived: true`. Hence `Math.max` — the derived floor may RAISE the fixed
+ *    one, never lower it.
+ *
+ * A corrupt, negative or absurd recorded count is refused, not silently
+ * downgraded to the fallback: a broken baseline must not read as a working
+ * control.
+ */
+export function scriptFileFloor(baselineScriptFiles) {
+  if (baselineScriptFiles === undefined || baselineScriptFiles === null) {
+    return { ok: true, floor: FALLBACK_MIN_SCRIPT_FILES, derived: false, reason: null };
+  }
+  if (typeof baselineScriptFiles !== 'number' || !Number.isInteger(baselineScriptFiles)) {
+    return {
+      ok: false,
+      floor: null,
+      derived: false,
+      reason:
+        `the baseline records scriptFilesInProgram = ${JSON.stringify(
+          baselineScriptFiles
+        )}, which ` +
+        `is not an integer. This value is the positive control's floor; a baseline that cannot say ` +
+        `how many files it was measured over cannot validate anything. Regenerate it with ` +
+        `--write-baseline rather than editing it by hand.`,
+    };
+  }
+  if (baselineScriptFiles <= 0) {
+    return {
+      ok: false,
+      floor: null,
+      derived: false,
+      reason:
+        `the baseline records scriptFilesInProgram = ${baselineScriptFiles}. A baseline measured ` +
+        `over zero or fewer files is not a baseline, and deriving a floor from it yields a floor ` +
+        `no program can fail. Regenerate it with --write-baseline.`,
+    };
+  }
+  if (baselineScriptFiles > ABSURD_MAX_SCRIPT_FILES) {
+    return {
+      ok: false,
+      floor: null,
+      derived: false,
+      reason:
+        `the baseline records scriptFilesInProgram = ${baselineScriptFiles}, above the sanity ` +
+        `ceiling of ${ABSURD_MAX_SCRIPT_FILES}. Deriving a floor from it would make the positive ` +
+        `control permanently red, which is worse than having no control. Regenerate it with ` +
+        `--write-baseline.`,
+    };
+  }
+
+  const derivedFloor = Math.floor(baselineScriptFiles * SHRINK_TOLERANCE);
+  return {
+    ok: true,
+    floor: Math.max(FALLBACK_MIN_SCRIPT_FILES, derivedFloor),
+    // Strictly greater, not >=: at a tie the floor is the fixed one and would
+    // have been the fixed one anyway, and reporting it as "derived" credits the
+    // baseline with a number it did not determine.
+    derived: derivedFloor > FALLBACK_MIN_SCRIPT_FILES,
+    reason: null,
+  };
+}
+
+/**
+ * Assert that `tsconfig.scripts.json`'s exclude list is the base config's list
+ * minus exactly the quarantined entries, and nothing else.
+ *
+ * The sibling gate pins a single removed entry (`diffExcludes`); this one pins a
+ * SET, because the quarantine holds five files and will hold fewer over time.
+ * Both lists are written out verbatim in their configs, so without this control
+ * an addition to the base exclude list silently fails to reach the measurement
+ * program and NOTHING notices — the two programs quietly stop being "the same
+ * program with the quarantine added back", which is the only property that makes
+ * the measured number mean anything.
+ *
+ * `expectedRemoved` is compared as a SET: order is not meaningful in a tsconfig
+ * list, and pinning it would turn a cosmetic reordering into a CANNOT MEASURE.
+ */
+export function diffLists(baseList, variantList, expectedRemoved) {
+  const base = [...(baseList ?? [])];
+  const variant = [...(variantList ?? [])];
+  const variantSet = new Set(variant);
+  const baseSet = new Set(base);
+
+  const removed = base.filter((e) => !variantSet.has(e));
+  const added = variant.filter((e) => !baseSet.has(e));
+
+  const expected = new Set(expectedRemoved ?? []);
+  const missing = [...expected].filter((e) => !removed.includes(e));
+  const unexpected = removed.filter((e) => !expected.has(e));
+
+  return {
+    ok: added.length === 0 && missing.length === 0 && unexpected.length === 0,
+    removed,
+    added,
+    missing,
+    unexpected,
+  };
+}

--- a/scripts/ci/typecheck-scripts-gate.mjs
+++ b/scripts/ci/typecheck-scripts-gate.mjs
@@ -1,62 +1,79 @@
 #!/usr/bin/env node
 /**
- * Ratchet gate for the type errors in the QUARANTINED files under `scripts/`.
+ * MEASUREMENT INSTRUMENT for the part of `scripts/` the root typecheck does not
+ * cover. 🔴 IT IS NOT WIRED INTO CI, DELIBERATELY — see WHY IT DOES NOT BLOCK.
  *
  * WHY THIS EXISTS
  * ---------------
- * Until this gate landed, the root `tsconfig.json` put ZERO files under
- * `scripts/` into the program. Not "only `scripts/local-dev`" — zero. That
- * directory was named in `include` and ALSO in `exclude`, and exclude wins, so
- * the one entry that made the list look intentional was inert. Measured on
- * 23cecb57c0: `tsc -p tsconfig.json --listFilesOnly` contained 0 files under
- * `scripts/`, and a deliberate `const x: number = 'nope'` planted in
+ * The root `tsconfig.json` used to put ZERO files under `scripts/` into the
+ * program. Not "only `scripts/local-dev`" — zero. That directory was named in
+ * `include` and ALSO in `exclude`, and exclude wins, so the one entry that made
+ * the list look intentional was inert. Measured on 23cecb57c0:
+ * `tsc -p tsconfig.json --listFilesOnly` contained 0 files under `scripts/`, and
+ * a deliberate `const x: number = 'nope'` planted in
  * `scripts/oneoffs/parse_header.ts` produced `OK — 0 type errors`, exit 0. Both
  * CI tiers run that same config, so the gap could not close on its own.
  *
- * `tsconfig.json` now includes `scripts/**\/*.ts(x)`. 33 of the 38 files that
- * pulls in were already clean and are checked by the real `pnpm typecheck` from
- * now on, in both tiers, along with every file added under `scripts/` later.
- * The other five carried 198 pre-existing errors and are listed in that config's
- * `exclude` under a `scripts/ quarantine` heading.
+ * `tsconfig.json` now includes `scripts/**\/*.ts(x)` and excludes two things:
+ * the whole of `scripts/__tests__/**`, and `scripts/local-dev/gen_seed.ts`.
+ * Everything else under `scripts/` — the operational scripts, where a type error
+ * is a latent runtime bug rather than a test-harness artifact — is checked by
+ * the real `pnpm typecheck` in BOTH tiers from now on, as is any file added to
+ * those directories later. That is the blocking win, and it needs no gate.
  *
- * THIS GATE IS WHAT KEEPS THAT QUARANTINE FROM BEING A NEW BLIND SPOT. Excluding
- * five files and walking away would recreate, at smaller scale, exactly the
- * defect being fixed — which is how `src/**\/__tests__/**` got to 801 errors.
+ * This file measures what is left.
  *
- * `tsconfig.scripts.json` is the same program with the quarantine entries
- * removed. It is a strict superset: every other `include`/`exclude`/
- * `compilerOptions` value is inherited via `extends`, deliberately. A hand-rolled
- * narrowed program that picks its own `include` drops `src/types/global.d.ts`,
- * ambient names then resolve to TS2304, generics that depend on them collapse,
- * and the affected files report FEWER errors than they really have — a false
- * all-clear on exactly the files being measured.
+ * WHY IT DOES NOT BLOCK
+ * ---------------------
+ * An earlier revision quarantined four individual `scripts/__tests__` files and
+ * ran as a blocking CI job. That was wrong, and the evidence arrived within a
+ * day: PR #4181 added `scripts/__tests__/dev-server-daemon-port.test.ts`, a
+ * perfectly ordinary test, and it carried 4 TS2345s — which reddened the root
+ * typecheck AND blocked this gate as a file "not in the baseline".
  *
- * WHAT THIS GATE ASKS
- * -------------------
- * Not "is the quarantine clean" — it is not, and blocking on that would be
- * permanently red, which only teaches people to click through. It asks: **did
- * this change make it worse?**
+ * The cause is structural, not a backlog. That directory exists to test the
+ * untyped `.mjs` modules under `.claude/skills/` and `.claude/hooks/` by
+ * importing them, and none of those modules carries JSDoc, so under `allowJs`
+ * tsc infers their signatures from the implementation and every caller inherits
+ * the result. `daemonPortsGuarded(env = process.env)` infers as requiring a full
+ * `ProcessEnv`, so `{ DEV_DAEMON_PORT: '9555' }` is an error; the 164 errors in
+ * `dev-server-test-queue.test.ts` are the same mechanism, where
+ * `request({ worktree, args = [] } = {})` infers as `{ args?: never[] }` (40x
+ * TS2353) and a run object's `null` initializers infer as type `null` (123x
+ * TS18047/TS2531).
  *
- *   - a quarantined file whose error count went UP        -> BLOCK
- *   - a file with errors that is NOT in the baseline      -> BLOCK
- *   - a quarantined file whose error count went DOWN      -> pass, and say so
- *   - a quarantined file that is now clean, or is gone    -> pass, and say so
+ * Measured: 5 of the 15 files in that directory carry this class, and ALL 15
+ * were added within a single month. A blocking gate over it would therefore
+ * fire several times a month, always for a defect in a dependency the test
+ * author did not write, and the fastest way out would be to add a baseline
+ * entry. A gate whose common remedy is "record the failure" trains the reflex it
+ * exists to prevent. So the directory is excluded from the root program the same
+ * way `src/**\/__tests__/**` is, and this file reports on it instead of gating
+ * it. Typing the `.mjs` modules is the real fix; this is how you watch that
+ * number go down.
  *
- * Lowering a baseline entry is never required to merge; raising one is only
- * possible by editing a committed file inside the pull request, where a reviewer
- * sees it. When a file reaches zero, delete its line from `tsconfig.json`'s
- * quarantine block and from `tsconfig.scripts.json` is NOT needed — the latter
- * simply stops differing by that entry, which `diffLists` then requires you to
- * reflect in QUARANTINE below.
+ * `tsconfig.scripts.json` is the same program with those two exclusions removed.
+ * It is a strict superset: every other `include`/`exclude`/`compilerOptions`
+ * value is inherited via `extends`, deliberately. A hand-rolled narrowed program
+ * that picks its own `include` drops `src/types/global.d.ts`, ambient names then
+ * resolve to TS2304, generics that depend on them collapse, and the affected
+ * files report FEWER errors than they really have — a false all-clear on exactly
+ * the files being measured.
  *
- * A NOTE ON WHERE THE 198 COME FROM
- * ---------------------------------
- * 164 of them are in one file and share a single cause: it imports an untyped
- * `.mjs` module carrying no JSDoc, so under `allowJs` tsc infers
- * `request({ worktree, args = [] } = {})` as taking `{ args?: never[] }` (40x
- * TS2353) and infers the run object's `null` initializers as type `null` (123x
- * TS18047/TS2531). They are not 164 independent defects, and the fix is to type
- * that module rather than to edit 164 assertions.
+ * WHAT IT ASKS
+ * ------------
+ * Not "is this clean" — it is not, and blocking on that would be permanently
+ * red, which only teaches people to click through. It asks: **did this change
+ * make it worse?**
+ *
+ *   - a baselined file whose error count went UP          -> report, exit 1
+ *   - a file with errors that is NOT in the baseline      -> report, exit 1
+ *   - a baselined file whose error count went DOWN        -> pass, and say so
+ *   - a baselined file that is now clean, or is gone      -> pass, and say so
+ *
+ * Because nothing runs it automatically, exit 1 is a report to whoever ran it,
+ * not a merge block. Run it before and after a change to the `.mjs` modules, or
+ * on a schedule, and regenerate with `--write-baseline`.
  *
  * INSTRUMENT VALIDATION (read this before trusting a green run)
  * ------------------------------------------------------------
@@ -132,13 +149,7 @@ const BASE_TS_CONFIG = 'tsconfig.json';
  * if the two configs stop agreeing with it — including if this list goes STALE
  * after someone cleans a file up. Shrinking it is the intended direction.
  */
-const QUARANTINE = [
-  'scripts/__tests__/dev-server-test-queue.test.ts',
-  'scripts/__tests__/dev-server-env-modes.test.ts',
-  'scripts/__tests__/dev-server-port-reservation.test.ts',
-  'scripts/__tests__/typecheck-tests-gate.test.ts',
-  'scripts/local-dev/gen_seed.ts',
-];
+const QUARANTINE = ['scripts/__tests__/**', 'scripts/local-dev/gen_seed.ts'];
 
 function fail(msg, code) {
   console.error(msg);
@@ -488,9 +499,18 @@ if (result.renames.length) {
   console.error('    regression fits through. Re-run with --write-baseline in the same change.');
 }
 console.error('');
-console.error('  These are real type errors in files tsconfig.json quarantines out of the');
-console.error('  scripts/ typecheck. A file NOT in the baseline is the interesting case: it');
-console.error('  means the quarantine grew, or a quarantined file was renamed.');
+console.error('  These are real type errors under scripts/. Which ones MATTER depends on');
+console.error('  where the file sits, and the two cases have different remedies:');
+console.error('');
+console.error('    scripts/__tests__/… or scripts/local-dev/gen_seed.ts');
+console.error('      -> excluded from the root program, so `pnpm typecheck` is still green');
+console.error('         and nothing is blocked. This is a report. Fix it, or re-run with');
+console.error('         --write-baseline to record it.');
+console.error('');
+console.error('    ANY OTHER PATH under scripts/');
+console.error('      -> that file IS in the root program, which means `pnpm typecheck` is');
+console.error('         RED right now and BOTH CI tiers are blocking on it. Fix it; do not');
+console.error('         record it in this baseline.');
 console.error('');
 console.error('  Reproduce locally:');
 console.error(`    pnpm typecheck -p ${TS_CONFIG}`);

--- a/scripts/ci/typecheck-scripts-gate.mjs
+++ b/scripts/ci/typecheck-scripts-gate.mjs
@@ -1,0 +1,498 @@
+#!/usr/bin/env node
+/**
+ * Ratchet gate for the type errors in the QUARANTINED files under `scripts/`.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Until this gate landed, the root `tsconfig.json` put ZERO files under
+ * `scripts/` into the program. Not "only `scripts/local-dev`" — zero. That
+ * directory was named in `include` and ALSO in `exclude`, and exclude wins, so
+ * the one entry that made the list look intentional was inert. Measured on
+ * 23cecb57c0: `tsc -p tsconfig.json --listFilesOnly` contained 0 files under
+ * `scripts/`, and a deliberate `const x: number = 'nope'` planted in
+ * `scripts/oneoffs/parse_header.ts` produced `OK — 0 type errors`, exit 0. Both
+ * CI tiers run that same config, so the gap could not close on its own.
+ *
+ * `tsconfig.json` now includes `scripts/**\/*.ts(x)`. 33 of the 38 files that
+ * pulls in were already clean and are checked by the real `pnpm typecheck` from
+ * now on, in both tiers, along with every file added under `scripts/` later.
+ * The other five carried 198 pre-existing errors and are listed in that config's
+ * `exclude` under a `scripts/ quarantine` heading.
+ *
+ * THIS GATE IS WHAT KEEPS THAT QUARANTINE FROM BEING A NEW BLIND SPOT. Excluding
+ * five files and walking away would recreate, at smaller scale, exactly the
+ * defect being fixed — which is how `src/**\/__tests__/**` got to 801 errors.
+ *
+ * `tsconfig.scripts.json` is the same program with the quarantine entries
+ * removed. It is a strict superset: every other `include`/`exclude`/
+ * `compilerOptions` value is inherited via `extends`, deliberately. A hand-rolled
+ * narrowed program that picks its own `include` drops `src/types/global.d.ts`,
+ * ambient names then resolve to TS2304, generics that depend on them collapse,
+ * and the affected files report FEWER errors than they really have — a false
+ * all-clear on exactly the files being measured.
+ *
+ * WHAT THIS GATE ASKS
+ * -------------------
+ * Not "is the quarantine clean" — it is not, and blocking on that would be
+ * permanently red, which only teaches people to click through. It asks: **did
+ * this change make it worse?**
+ *
+ *   - a quarantined file whose error count went UP        -> BLOCK
+ *   - a file with errors that is NOT in the baseline      -> BLOCK
+ *   - a quarantined file whose error count went DOWN      -> pass, and say so
+ *   - a quarantined file that is now clean, or is gone    -> pass, and say so
+ *
+ * Lowering a baseline entry is never required to merge; raising one is only
+ * possible by editing a committed file inside the pull request, where a reviewer
+ * sees it. When a file reaches zero, delete its line from `tsconfig.json`'s
+ * quarantine block and from `tsconfig.scripts.json` is NOT needed — the latter
+ * simply stops differing by that entry, which `diffLists` then requires you to
+ * reflect in QUARANTINE below.
+ *
+ * A NOTE ON WHERE THE 198 COME FROM
+ * ---------------------------------
+ * 164 of them are in one file and share a single cause: it imports an untyped
+ * `.mjs` module carrying no JSDoc, so under `allowJs` tsc infers
+ * `request({ worktree, args = [] } = {})` as taking `{ args?: never[] }` (40x
+ * TS2353) and infers the run object's `null` initializers as type `null` (123x
+ * TS18047/TS2531). They are not 164 independent defects, and the fix is to type
+ * that module rather than to edit 164 assertions.
+ *
+ * INSTRUMENT VALIDATION (read this before trusting a green run)
+ * ------------------------------------------------------------
+ * The failure mode of a gate like this is a CONFIDENT ZERO — a run that measured
+ * nothing and reported "no new errors". Five controls stand between a run and a
+ * verdict, and they are the sibling gate's, reused rather than reimplemented
+ * (`typecheck-scripts-compare.mjs` re-exports them from
+ * `typecheck-tests-compare.mjs`). Each was written in response to a real defect
+ * in that gate; a second copy would regenerate each of them on its own schedule.
+ *
+ *  1. EXIT-STATUS TRUTH TABLE (`classifyRun`). A non-zero exit with zero parsed
+ *     diagnostics is a FAILURE TO RUN, never a clean tree — covering a rejected
+ *     `TYPECHECK_HEAP_MB` (exit 2), an unresolvable `typescript` (2), a spawn
+ *     error (2), a missing binary (127) and a V8 heap abort (134).
+ *  2. PARSE CONTROL (`parseDiagnostics` + `classifyRun`). `--pretty false` is
+ *     forced on the command line, BOTH diagnostic formats are recognised anyway,
+ *     and the parse must ACCOUNT FOR EVERY LINE carrying the `error TS` marker.
+ *  3. PLAUSIBILITY (`checkPlausibility`). A parsed total of 0 against a baseline
+ *     of N>0 is refused, and so is a collapse below 25% of the baseline.
+ *     "Everything got fixed" and "the instrument is broken" produce the same
+ *     number, and only one of them is common.
+ *  4. POSITIVE CONTROL ON THE MEASUREMENT ARM. `--listFilesOnly` proves the
+ *     program actually READS files under `scripts/`, through the SAME wrapper,
+ *     the same `-p` and the same flags as the verdict run. Its floor is
+ *     `max(20, 90% of the count STORED IN THE BASELINE)`. 🔴 It counts on a
+ *     REPO-ROOT-ANCHORED path, not the substring `/scripts/`: this repo pulls
+ *     `.claude/skills/dev-server/scripts/*.mjs` into the program transitively,
+ *     and every vendored package has a `scripts/` directory, so a substring
+ *     control could stay green with the entire measured tree gone.
+ *  5. CONFIG-DRIFT CONTROL (`diffLists`). `tsconfig.scripts.json` must be
+ *     `tsconfig.json`'s exclude list minus exactly the QUARANTINE set. Both
+ *     lists are written out verbatim, so without this an addition to the base
+ *     list silently fails to reach the measurement program and the "same program
+ *     plus the quarantine" property quietly stops being true.
+ *
+ * `--write-baseline` runs behind all five.
+ *
+ * The pure comparison/parsing/classification logic lives in
+ * `typecheck-scripts-compare.mjs` and is unit-tested in
+ * `scripts/__tests__/typecheck-scripts-gate.test.ts`.
+ *
+ * Exit codes: 0 pass · 1 regression (blocking) · 2 usage/baseline error ·
+ *             3 the environment could not run the check.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  ALLOW_EMPTY_ENV,
+  GATE_SCRIPT,
+  checkPlausibility,
+  classifyEmptyAllowance,
+  classifyRun,
+  compare,
+  countScriptFilesInProgram,
+  diffLists,
+  isGatedScriptFile,
+  parseDiagnostics,
+  scriptFileFloor,
+  stripJsonComments,
+  validateBaseline,
+} from './typecheck-scripts-compare.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const TS_CONFIG = 'tsconfig.scripts.json';
+const BASE_TS_CONFIG = 'tsconfig.json';
+
+/**
+ * The quarantine: files `tsconfig.json` excludes and `tsconfig.scripts.json` does
+ * not. This list is the gate's copy of that delta, and `diffLists` refuses to run
+ * if the two configs stop agreeing with it — including if this list goes STALE
+ * after someone cleans a file up. Shrinking it is the intended direction.
+ */
+const QUARANTINE = [
+  'scripts/__tests__/dev-server-test-queue.test.ts',
+  'scripts/__tests__/dev-server-env-modes.test.ts',
+  'scripts/__tests__/dev-server-port-reservation.test.ts',
+  'scripts/__tests__/typecheck-tests-gate.test.ts',
+  'scripts/local-dev/gen_seed.ts',
+];
+
+function fail(msg, code) {
+  console.error(msg);
+  process.exit(code);
+}
+
+function cannotMeasure(reason) {
+  fail(
+    `typecheck-scripts-gate: CANNOT MEASURE — ${reason}\n` +
+      '  This run produced no usable measurement, so it is not a pass and not a failure.\n' +
+      '  Do NOT read the absence of reported errors as a clean scripts/ tree.',
+    3
+  );
+}
+
+const WRITE_BASELINE = process.argv.includes('--write-baseline');
+
+// ------------------------------------------------------------------ seams
+// Three environment variables reach into this gate's production behaviour so the
+// suite can drive it with a stub typechecker and a fixture baseline at
+// sub-second cost instead of a multi-minute `tsc` — a control nobody can afford
+// to run is not a control. They are ECHOED below, because an unechoed seam makes
+// a stub-driven run byte-identical to a real one.
+const BASELINE_PATH =
+  process.env.TYPECHECK_SCRIPTS_BASELINE || path.join(HERE, 'typecheck-scripts-baseline.json');
+const WRAPPER =
+  process.env.TYPECHECK_SCRIPTS_WRAPPER || path.join(REPO_ROOT, 'scripts', 'typecheck.mjs');
+const CONFIG_DIR = process.env.TYPECHECK_SCRIPTS_CONFIG_DIR || REPO_ROOT;
+// Only the positive control's path-anchoring uses this. It is a seam because the
+// suite measures fixture output whose absolute paths are not this checkout's.
+const PROGRAM_ROOT = process.env.TYPECHECK_SCRIPTS_PROGRAM_ROOT || REPO_ROOT;
+
+const provenance = [
+  ['wrapper', WRAPPER, 'TYPECHECK_SCRIPTS_WRAPPER'],
+  ['baseline', BASELINE_PATH, 'TYPECHECK_SCRIPTS_BASELINE'],
+  ['tsconfig dir', CONFIG_DIR, 'TYPECHECK_SCRIPTS_CONFIG_DIR'],
+  ['program root', PROGRAM_ROOT, 'TYPECHECK_SCRIPTS_PROGRAM_ROOT'],
+];
+const overridden = provenance.filter(([, , env]) => process.env[env]);
+console.log(
+  `typecheck-scripts-gate: provenance — mode=${WRITE_BASELINE ? '--write-baseline' : 'verdict'}, ` +
+    provenance
+      .map(([label, value, env]) => `${label}=${value}${process.env[env] ? ' [OVERRIDE]' : ''}`)
+      .join(', ')
+);
+if (overridden.length) {
+  console.log(
+    `typecheck-scripts-gate: NOTE — ${overridden.length} seam(s) overridden by environment ` +
+      `(${overridden.map(([, , env]) => env).join(', ')}). This run did NOT necessarily measure ` +
+      `this repository; treat its numbers as belonging to whatever the override points at.`
+  );
+}
+
+// --------------------------------------------- the plausibility escape hatch
+const allowance = classifyEmptyAllowance({
+  raw: process.env[ALLOW_EMPTY_ENV],
+  writeBaseline: WRITE_BASELINE,
+  envName: ALLOW_EMPTY_ENV,
+  gateScript: GATE_SCRIPT,
+});
+if (allowance.refuse) {
+  fail(
+    `typecheck-scripts-gate: REFUSING TO RUN — ${allowance.refuse}\n` +
+      '  A disabled control is not a passing run. Nothing was measured.',
+    3
+  );
+}
+if (allowance.allowed) {
+  console.log('');
+  console.log('  ################################################################');
+  console.log('  #  PLAUSIBILITY CONTROL DISARMED — this run is NOT a clean bill #');
+  console.log('  ################################################################');
+  console.log(`  # reason given: ${allowance.reason}`);
+  console.log(`  # ${ALLOW_EMPTY_ENV} is set, so an implausible measurement (a zero, or a`);
+  console.log('  # collapse against the previous baseline) will be WRITTEN rather than');
+  console.log('  # refused. Whoever reviews the resulting baseline diff is the control.');
+  console.log('  ################################################################');
+  console.log('');
+}
+
+// ---------------------------------------------------------------- baseline
+if (!WRITE_BASELINE && !existsSync(BASELINE_PATH)) {
+  fail(`typecheck-scripts-gate: baseline not found at ${BASELINE_PATH}`, 2);
+}
+function readPrevious() {
+  try {
+    return JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+const previous = readPrevious();
+
+let baseline = { config: TS_CONFIG, files: {} };
+if (!WRITE_BASELINE) {
+  try {
+    baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+  } catch (err) {
+    fail(`typecheck-scripts-gate: baseline is not valid JSON: ${err.message}`, 2);
+  }
+  const problems = validateBaseline(baseline, TS_CONFIG);
+  if (problems.length) {
+    fail(`typecheck-scripts-gate: unusable baseline:\n    ${problems.join('\n    ')}`, 2);
+  }
+}
+
+// ------------------------------------------- control 5: config-drift control
+// Cheap, and it runs first: if the two programs have stopped being "the same
+// program plus the quarantine", every number below means something else.
+try {
+  const readExclude = (file) =>
+    JSON.parse(stripJsonComments(readFileSync(path.join(CONFIG_DIR, file), 'utf8'))).exclude;
+  const drift = diffLists(readExclude(BASE_TS_CONFIG), readExclude(TS_CONFIG), QUARANTINE);
+  if (!drift.ok) {
+    cannotMeasure(
+      `${TS_CONFIG} is no longer ${BASE_TS_CONFIG}'s exclude list minus exactly the ` +
+        `${QUARANTINE.length} quarantined entry/entries.\n` +
+        `    missing (this gate expects them removed, but ${TS_CONFIG} still excludes them): ` +
+        `[${drift.missing.join(', ')}]\n` +
+        `    unexpected (removed by ${TS_CONFIG} but not in this gate's QUARANTINE list): ` +
+        `[${drift.unexpected.join(', ')}]\n` +
+        `    added by ${TS_CONFIG}: [${drift.added.join(', ')}]\n` +
+        `    That delta is what makes this a measurement of the SAME program with the quarantined ` +
+        `files added back. If you cleaned a file up, remove it from BOTH ${BASE_TS_CONFIG}'s ` +
+        `quarantine block and the QUARANTINE list in ${GATE_SCRIPT}, then re-run with ` +
+        `--write-baseline.`
+    );
+  }
+} catch (err) {
+  cannotMeasure(`could not compare the two tsconfig exclude lists: ${err.message}`);
+}
+
+// -------------------------------------------------------- run the typecheck
+// `--pretty false` is control 2: `pretty` is a legal inherited compilerOption and
+// tsc turns it on by itself under a TTY, either of which reshapes every
+// diagnostic into a format the parser would have matched zero of. The command
+// line beats the config file.
+function runWrapper(extraArgs) {
+  const res = spawnSync(
+    process.execPath,
+    [WRAPPER, '-p', TS_CONFIG, '--pretty', 'false', ...extraArgs],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 256 * 1024 * 1024,
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+    }
+  );
+  if (res.error) cannotMeasure(`could not start the typecheck wrapper: ${res.error.message}`);
+  const output = `${res.stdout || ''}${res.stderr || ''}`;
+  const parsed = parseDiagnostics(output);
+  const verdict = classifyRun({
+    status: res.status,
+    signal: res.signal,
+    parsed,
+    crashMarker: output.includes('TYPECHECK CRASHED'),
+  });
+  return { res, output, parsed, verdict };
+}
+
+// ---------------------------------- control 4: positive control, same arm
+const listed = runWrapper(['--listFilesOnly']);
+if (!listed.verdict.ok) {
+  cannotMeasure(`the positive control could not run: ${listed.verdict.reason}`);
+}
+const scriptFilesInProgram = countScriptFilesInProgram(listed.output, PROGRAM_ROOT);
+
+const recordedScriptFiles = baseline.scriptFilesInProgram ?? previous?.scriptFilesInProgram;
+const floorResult = scriptFileFloor(recordedScriptFiles);
+if (!floorResult.ok) {
+  cannotMeasure(
+    `the positive control has no usable floor — ${floorResult.reason}\n` +
+      `    The floor is what makes the positive control a control; without it this run would ` +
+      `report a number nothing checked.`
+  );
+}
+const { floor, derived } = floorResult;
+if (scriptFilesInProgram < floor) {
+  cannotMeasure(
+    `POSITIVE CONTROL FAILED — the program built from ${TS_CONFIG} contains ` +
+      `${scriptFilesInProgram} file(s) under scripts/, below the floor of ${floor} ` +
+      (derived
+        ? `(90% of the ${recordedScriptFiles} recorded in the baseline).`
+        : recordedScriptFiles === undefined || recordedScriptFiles === null
+        ? `(fixed fallback; the baseline records no scriptFilesInProgram).`
+        : `(fixed fallback ${floor}; it OUTRANKS the ${Math.floor(
+            recordedScriptFiles * 0.9
+          )} that ` +
+          `90% of the baseline's ${recordedScriptFiles} would give — a derived floor may raise the ` +
+          `fixed one, never lower it).`) +
+      `\n    Whatever this run would have reported, it is not a measurement of the scripts/ tree. ` +
+      `Check ${TS_CONFIG}'s include/exclude lists and the -p path.`
+  );
+}
+console.log(
+  `typecheck-scripts-gate: positive control OK — ${scriptFilesInProgram} scripts/ file(s) in the ` +
+    `program (floor ${floor}${derived ? ', derived from the baseline' : ', fixed fallback'}).`
+);
+
+// ------------------------------------------------------------- the verdict run
+const measured = runWrapper([]);
+if (!measured.verdict.ok) cannotMeasure(measured.verdict.reason);
+
+const current = measured.parsed.counts;
+if (measured.parsed.formats.size) {
+  console.log(
+    `typecheck-scripts-gate: parsed ${measured.parsed.total} diagnostic(s) in ` +
+      `${[...measured.parsed.formats].join('+')} format.`
+  );
+}
+
+// Anything outside `scripts/` is not this gate's business — the root typecheck
+// already covers it and blocks on it, so reporting it here would double-count.
+// 🔴 It is also a REAL SIGNAL that something is wrong: `tsconfig.scripts.json`
+// differs from the root config only by the quarantine, so a `src/` error here
+// means `pnpm typecheck` is red too.
+const outside = [...current.keys()].filter((f) => !isGatedScriptFile(f));
+if (outside.length) {
+  console.log(
+    `typecheck-scripts-gate: note — ${outside.length} file(s) with errors outside scripts/; ` +
+      `those belong to \`pnpm typecheck\`, not this gate (and mean it is red too):`
+  );
+  for (const f of outside.slice(0, 10)) console.log(`    ${f} (${current.get(f)})`);
+  for (const f of outside) current.delete(f);
+}
+
+const currentTotal = [...current.values()].reduce((a, b) => a + b, 0);
+const baselineTotal = Object.values(baseline.files ?? {}).reduce((a, b) => a + b, 0);
+
+// Control 3. Applies to `--write-baseline` too — that is the path that would
+// silently zero the ratchet and exit 0.
+const previousTotal = Object.values(previous?.files ?? {}).reduce((a, b) => a + b, 0);
+const plausible = checkPlausibility({
+  currentTotal,
+  baselineTotal: WRITE_BASELINE ? previousTotal : baselineTotal,
+  allowEmpty: allowance.allowed,
+});
+if (!plausible.ok) {
+  // A collapsed VERDICT run is loud but harmless — it cannot hide a regression,
+  // since a regression is what the ratchet blocks on, and a collapsed
+  // measurement makes files look FIXED, never new. A collapsed
+  // --write-baseline rewrites the ratchet to the smaller number and destroys
+  // the evidence, so that one is refused.
+  if (plausible.kind === 'collapse' && !WRITE_BASELINE) {
+    console.log('');
+    console.log('  ################################################################');
+    console.log('  #  IMPLAUSIBLE MEASUREMENT — READ BEFORE BELIEVING THE VERDICT  #');
+    console.log('  ################################################################');
+    for (const line of plausible.reason.match(/.{1,72}(\s|$)/g) ?? []) {
+      console.log(`  # ${line.trim()}`);
+    }
+    console.log('  # This run can still BLOCK, and a block from it is real. What it');
+    console.log('  # cannot do is certify the tree: an instrument measuring a smaller');
+    console.log('  # program than the baseline reports the difference as progress.');
+    console.log('  ################################################################');
+    console.log('');
+  } else {
+    cannotMeasure(plausible.reason);
+  }
+}
+
+if (WRITE_BASELINE) {
+  const files = Object.fromEntries([...current.entries()].sort(([a], [b]) => (a < b ? -1 : 1)));
+  const total = Object.values(files).reduce((a, b) => a + b, 0);
+  writeFileSync(
+    BASELINE_PATH,
+    `${JSON.stringify(
+      {
+        _comment:
+          'Type errors in the files tsconfig.json quarantines out of the scripts/ typecheck. ' +
+          'Entries may shrink or disappear freely; adding one, or raising a count, is a ' +
+          'deliberate act visible in review. Regenerate with: node ' +
+          `${GATE_SCRIPT} --write-baseline`,
+        config: TS_CONFIG,
+        // The positive control's floor is derived from this. It is part of the
+        // measurement, not metadata: without it the control is a magic number
+        // that a shrinking tree walks straight under.
+        scriptFilesInProgram,
+        totalErrors: total,
+        files,
+      },
+      null,
+      2
+    )}\n`
+  );
+  console.log(
+    `typecheck-scripts-gate: wrote baseline — ${total} error(s) across ${
+      Object.keys(files).length
+    } ` +
+      `file(s), ${scriptFilesInProgram} scripts/ file(s) in program.` +
+      (allowance.allowed
+        ? `\ntypecheck-scripts-gate: ...WITH THE PLAUSIBILITY CONTROL DISARMED (${ALLOW_EMPTY_ENV}). ` +
+          `Reason given: ${allowance.reason}\n` +
+          `typecheck-scripts-gate: this baseline was NOT validated against the previous one. Review ` +
+          `the diff as if it were unreviewed, because it is.`
+        : '')
+  );
+  process.exit(0);
+}
+
+// ------------------------------------------------------------------- compare
+const result = compare(current, baseline.files);
+
+console.log('');
+console.log(
+  `typecheck-scripts-gate: ${result.currentTotal} error(s) across ${current.size} file(s) ` +
+    `(baseline: ${result.baselineTotal} across ${Object.keys(baseline.files).length}).`
+);
+
+if (result.improved.length || result.fixed.length) {
+  console.log(
+    `typecheck-scripts-gate: ${result.fixed.length} file(s) now clean, ${result.improved.length} improved — ` +
+      `lower the baseline when convenient (never required to merge). A file that reached ZERO can ` +
+      `leave the quarantine entirely: drop it from tsconfig.json's exclude and from QUARANTINE in ` +
+      `${GATE_SCRIPT}.`
+  );
+}
+
+if (!result.blocked) {
+  console.log('typecheck-scripts-gate: PASS — no new or worsened type errors under scripts/.');
+  process.exit(0);
+}
+
+console.error('');
+console.error('================================================================');
+console.error('  TYPECHECK-SCRIPTS GATE: BLOCKED');
+console.error('================================================================');
+if (result.newlyDirty.length) {
+  console.error(
+    `  ${result.newlyDirty.length} file(s) under scripts/ have type errors and are NOT in the baseline:`
+  );
+  for (const { file, count } of result.newlyDirty) console.error(`    ${file}  (${count})`);
+}
+if (result.worsened.length) {
+  console.error(`  ${result.worsened.length} baselined file(s) got WORSE:`);
+  for (const { file, was, now } of result.worsened) console.error(`    ${file}  ${was} -> ${now}`);
+}
+if (result.renames.length) {
+  console.error('');
+  console.error(`  ${result.renames.length} of these look like a RENAME, not a regression:`);
+  for (const { from, to, count } of result.renames)
+    console.error(`    ${from}  ->  ${to}  (${count}, unchanged)`);
+  console.error('    A moved file is a new path with no baseline entry, and this gate cannot see');
+  console.error(
+    '    file CONTENT, so it will not forgive one automatically — that is a hole a real'
+  );
+  console.error('    regression fits through. Re-run with --write-baseline in the same change.');
+}
+console.error('');
+console.error('  These are real type errors in files tsconfig.json quarantines out of the');
+console.error('  scripts/ typecheck. A file NOT in the baseline is the interesting case: it');
+console.error('  means the quarantine grew, or a quarantined file was renamed.');
+console.error('');
+console.error('  Reproduce locally:');
+console.error(`    pnpm typecheck -p ${TS_CONFIG}`);
+console.error('================================================================');
+process.exit(1);

--- a/scripts/ci/typecheck-tests-compare.mjs
+++ b/scripts/ci/typecheck-tests-compare.mjs
@@ -302,7 +302,9 @@ export function checkPlausibility({ currentTotal, baselineTotal, allowEmpty = fa
       kind: 'collapse',
       reason:
         `this run parsed ${currentTotal} error(s) against a baseline of ${baselineTotal} — a ${pct}% ` +
-        `drop, below the ${COLLAPSE_RATIO * 100}% plausibility floor. Either a great deal was genuinely ` +
+        `drop, below the ${
+          COLLAPSE_RATIO * 100
+        }% plausibility floor. Either a great deal was genuinely ` +
         `fixed, or the instrument measured a smaller program than the baseline was taken over ` +
         `(a changed -p, a widened exclude, a partially-parsed output). Those two produce the same ` +
         `number and only one of them is common.`,
@@ -342,7 +344,23 @@ export const ALLOW_EMPTY_ENV = 'TYPECHECK_TESTS_ALLOW_EMPTY';
 const BARE_TOKENS = new Set(['1', '0', 'true', 'false', 'yes', 'no', 'on', 'off', 'y', 'n']);
 export const MIN_REASON_CHARS = 12;
 
-export function classifyEmptyAllowance({ raw, writeBaseline }) {
+/**
+ * `envName` and `gateScript` are parameters purely so a SECOND gate built on this
+ * module reports its OWN variable and its OWN regeneration command. They default
+ * to this gate's, so every existing caller is unchanged.
+ *
+ * They are parameters rather than a copy of this function living next to the
+ * other gate: the policy encoded here (scope to --write-baseline, refuse rather
+ * than ignore, demand a written reason) is the thing that must not drift between
+ * two gates, and a duplicated predicate is wrong at one of its copies eventually.
+ * The only per-gate facts are the two strings a human is told to act on.
+ */
+export function classifyEmptyAllowance({
+  raw,
+  writeBaseline,
+  envName = ALLOW_EMPTY_ENV,
+  gateScript = 'scripts/ci/typecheck-tests-gate.mjs',
+}) {
   const value = typeof raw === 'string' ? raw.trim() : '';
   if (!value) return { allowed: false, refuse: null, reason: null };
 
@@ -351,24 +369,28 @@ export function classifyEmptyAllowance({ raw, writeBaseline }) {
       allowed: false,
       reason: null,
       refuse:
-        `${ALLOW_EMPTY_ENV} is set on a VERDICT run. It is honoured on --write-baseline only, and ` +
+        `${envName} is set on a VERDICT run. It is honoured on --write-baseline only, and ` +
         `is refused here rather than ignored — a run whose plausibility control has been switched ` +
-        `off must never be able to report PASS. If the test tree is genuinely clean, regenerate ` +
-        `the baseline (node scripts/ci/typecheck-tests-gate.mjs --write-baseline) in the same ` +
+        `off must never be able to report PASS. If the measured tree is genuinely clean, regenerate ` +
+        `the baseline (node ${gateScript} --write-baseline) in the same ` +
         `change; the regenerated baseline makes this control a no-op honestly. If you are seeing ` +
-        `this in CI, some job definition is exporting ${ALLOW_EMPTY_ENV} — remove it.`,
+        `this in CI, some job definition is exporting ${envName} — remove it.`,
     };
   }
 
-  if (BARE_TOKENS.has(value.toLowerCase()) || value.length < MIN_REASON_CHARS || !/\s/.test(value)) {
+  if (
+    BARE_TOKENS.has(value.toLowerCase()) ||
+    value.length < MIN_REASON_CHARS ||
+    !/\s/.test(value)
+  ) {
     return {
       allowed: false,
       reason: null,
       refuse:
-        `${ALLOW_EMPTY_ENV}=${JSON.stringify(value)} is not a reason. Disabling the plausibility ` +
+        `${envName}=${JSON.stringify(value)} is not a reason. Disabling the plausibility ` +
         `control requires a written justification of at least ${MIN_REASON_CHARS} characters and ` +
         `more than one word, which is echoed into this run's output — e.g. ` +
-        `${ALLOW_EMPTY_ENV}="test tree genuinely clean after PR #1234, regenerating". A control ` +
+        `${envName}="test tree genuinely clean after PR #1234, regenerating". A control ` +
         `that can be switched off by typing "1" is one nobody has to justify switching off.`,
     };
   }
@@ -429,7 +451,9 @@ export function testFileFloor(baselineTestFiles) {
       floor: null,
       derived: false,
       reason:
-        `the baseline records testFilesInProgram = ${JSON.stringify(baselineTestFiles)}, which is ` +
+        `the baseline records testFilesInProgram = ${JSON.stringify(
+          baselineTestFiles
+        )}, which is ` +
         `not an integer. This value is the positive control's floor; a baseline that cannot say ` +
         `how many files it was measured over cannot validate anything. Regenerate it with ` +
         `--write-baseline rather than editing it by hand.`,
@@ -479,7 +503,11 @@ export function validateBaseline(baseline, expectedConfig) {
   if (!baseline || typeof baseline !== 'object' || Array.isArray(baseline)) {
     return ['baseline is not a JSON object'];
   }
-  if (typeof baseline.files !== 'object' || baseline.files === null || Array.isArray(baseline.files)) {
+  if (
+    typeof baseline.files !== 'object' ||
+    baseline.files === null ||
+    Array.isArray(baseline.files)
+  ) {
     problems.push('baseline is missing a `files` object');
   } else {
     let sum = 0;
@@ -502,7 +530,9 @@ export function validateBaseline(baseline, expectedConfig) {
     if (summable && baseline.totalErrors !== undefined) {
       if (!Number.isInteger(baseline.totalErrors) || baseline.totalErrors < 0) {
         problems.push(
-          `baseline totalErrors is ${JSON.stringify(baseline.totalErrors)}, not a non-negative integer`
+          `baseline totalErrors is ${JSON.stringify(
+            baseline.totalErrors
+          )}, not a non-negative integer`
         );
       } else if (baseline.totalErrors !== sum) {
         problems.push(
@@ -621,22 +651,43 @@ export function stripJsonComments(text) {
     const c = text[i];
     const n = text[i + 1];
     if (inLine) {
-      if (c === '\n') { inLine = false; out += c; }
+      if (c === '\n') {
+        inLine = false;
+        out += c;
+      }
       continue;
     }
     if (inBlock) {
-      if (c === '*' && n === '/') { inBlock = false; i++; }
+      if (c === '*' && n === '/') {
+        inBlock = false;
+        i++;
+      }
       continue;
     }
     if (inString) {
       out += c;
-      if (c === '\\') { out += text[++i] ?? ''; continue; }
+      if (c === '\\') {
+        out += text[++i] ?? '';
+        continue;
+      }
       if (c === '"') inString = false;
       continue;
     }
-    if (c === '"') { inString = true; out += c; continue; }
-    if (c === '/' && n === '/') { inLine = true; i++; continue; }
-    if (c === '/' && n === '*') { inBlock = true; i++; continue; }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      continue;
+    }
+    if (c === '/' && n === '/') {
+      inLine = true;
+      i++;
+      continue;
+    }
+    if (c === '/' && n === '*') {
+      inBlock = true;
+      i++;
+      continue;
+    }
     out += c;
   }
   return out.replace(/,(\s*[}\]])/g, '$1');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -61,6 +61,12 @@
     // the one directory this list appeared to name. Measured on 23cecb57c0:
     // `tsc -p tsconfig.json --listFilesOnly` contained 0 files under scripts/.
     // Both globs are here, and the contradicting exclude entry is gone.
+    //
+    // What this actually buys, measured: the non-test scripts — `scripts/*.ts`,
+    // `oneoffs/`, `local-dev/`, `metric-migration/`, `test-perf/` — go from
+    // unchecked to checked, in BOTH CI tiers, along with any file added to them
+    // later. `scripts/__tests__/**` is excluded below; read that comment before
+    // assuming this line covers it.
     "scripts/**/*.ts",
     "scripts/**/*.tsx",
     "src",
@@ -77,31 +83,39 @@
     "src/**/__tests__/**",
     "packages/civitai-ui",
 
-    // ── scripts/ quarantine ───────────────────────────────────────────────
-    // Adding `scripts/**/*.ts` above put 36 files under `scripts/` into the
-    // program and surfaced 198 pre-existing errors, all of them in the five
-    // files below. The other 31 are clean and are checked from now on, by BOTH
-    // CI tiers, along with every file added under `scripts/` in future.
-    // (`node scripts/ci/typecheck-scripts-gate.mjs` reprints both counts.)
+    // 🔴 `scripts/__tests__/**` is NOT typechecked, exactly as `src/**/__tests__/**`
+    // above is not. This is a DIRECTORY exclusion on purpose, and the reason is
+    // structural rather than a backlog:
     //
-    // These five are excluded BY NAME rather than by a directory glob, so the
-    // blind spot is enumerable instead of open-ended, and it can only shrink in
-    // a diff a reviewer sees. They are NOT unchecked: `tsconfig.scripts.json`
-    // is this config without these five entries, and
-    // `scripts/ci/typecheck-scripts-gate.mjs` ratchets their per-file error
-    // counts so they cannot get worse. Delete an entry here once its file is
-    // clean — nothing else needs to change.
+    // That directory exists to test the untyped `.mjs` modules under
+    // `.claude/skills/` and `.claude/hooks/`, by importing them directly. None of
+    // those modules carries JSDoc, so under `allowJs` tsc infers their signatures
+    // from the implementation and the tests inherit the result. Two measured
+    // examples: `request({ worktree, args = [] } = {})` infers as taking
+    // `{ args?: never[] }` (40x TS2353 in one file) and its run object's `null`
+    // initializers infer as type `null` (123x TS18047/TS2531); and
+    // `daemonPortsGuarded(env = process.env)` infers as requiring a full
+    // `ProcessEnv`, so passing `{ DEV_DAEMON_PORT: '9555' }` is TS2345.
     //
-    // 164 of the 198 are in dev-server-test-queue.test.ts and share ONE cause:
-    // it imports an untyped `.mjs` module that carries no JSDoc, so under
-    // `allowJs` tsc infers `request({ worktree, args = [] } = {})` as taking
-    // `{ args?: never[] }` (40x TS2353) and infers the run object's `null`
-    // initializers as type `null` (123x TS18047/TS2531). Typing that module is
-    // the fix, and it is deliberately not attempted here.
-    "scripts/__tests__/dev-server-test-queue.test.ts",
-    "scripts/__tests__/dev-server-env-modes.test.ts",
-    "scripts/__tests__/dev-server-port-reservation.test.ts",
-    "scripts/__tests__/typecheck-tests-gate.test.ts",
+    // Those errors are not the test author's, and they are not rare: 5 of the 15
+    // files there carry them, and ALL 15 were added within one month. Including
+    // the directory here would therefore red the root typecheck several times a
+    // month for a defect in a dependency, and the only quick remedy would be to
+    // add another exclude line — which trains exactly the reflex this comment
+    // exists to prevent. Typing the `.mjs` modules is the real fix; until then
+    // the honest statement is that this directory is unchecked.
+    //
+    // It is not unmeasured: `tsconfig.scripts.json` re-includes it and
+    // `scripts/ci/typecheck-scripts-gate.mjs` reports the per-file counts.
+    "scripts/__tests__/**",
+
+    // The one NON-test file under `scripts/` with errors, excluded by name so the
+    // gap stays enumerable. Its 2 errors are a genuinely broken import, not an
+    // inference artifact: it imports `~/server/db/notifDb`, which was deleted in
+    // 927e31bfee. `notifDbWrite` now lives in `apps/notifications` behind a
+    // different API (a function returning a pool), so restoring this script is a
+    // cross-workspace migration rather than a one-line fix. Delete this entry
+    // when that lands.
     "scripts/local-dev/gen_seed.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,7 +55,14 @@
     // "**/*.tsx",
     // "**/*.cjs",
     // "**/*.mjs",
-    "scripts/local-dev/*.ts",
+    // `scripts/` used to be represented here by `scripts/local-dev/*.ts` ALONE,
+    // and that entry was ALSO listed in `exclude` below. Exclude wins, so the
+    // net effect was that NOTHING under `scripts/` was typechecked — not even
+    // the one directory this list appeared to name. Measured on 23cecb57c0:
+    // `tsc -p tsconfig.json --listFilesOnly` contained 0 files under scripts/.
+    // Both globs are here, and the contradicting exclude entry is gone.
+    "scripts/**/*.ts",
+    "scripts/**/*.tsx",
     "src",
     "packages/*/src",
     "tests",
@@ -67,8 +74,34 @@
     "./node_modules",
     "./node_modules/*",
     "src/pages/api/dev-local/*.ts",
-    "scripts/local-dev/*.ts",
     "src/**/__tests__/**",
-    "packages/civitai-ui"
+    "packages/civitai-ui",
+
+    // ── scripts/ quarantine ───────────────────────────────────────────────
+    // Adding `scripts/**/*.ts` above put 36 files under `scripts/` into the
+    // program and surfaced 198 pre-existing errors, all of them in the five
+    // files below. The other 31 are clean and are checked from now on, by BOTH
+    // CI tiers, along with every file added under `scripts/` in future.
+    // (`node scripts/ci/typecheck-scripts-gate.mjs` reprints both counts.)
+    //
+    // These five are excluded BY NAME rather than by a directory glob, so the
+    // blind spot is enumerable instead of open-ended, and it can only shrink in
+    // a diff a reviewer sees. They are NOT unchecked: `tsconfig.scripts.json`
+    // is this config without these five entries, and
+    // `scripts/ci/typecheck-scripts-gate.mjs` ratchets their per-file error
+    // counts so they cannot get worse. Delete an entry here once its file is
+    // clean — nothing else needs to change.
+    //
+    // 164 of the 198 are in dev-server-test-queue.test.ts and share ONE cause:
+    // it imports an untyped `.mjs` module that carries no JSDoc, so under
+    // `allowJs` tsc infers `request({ worktree, args = [] } = {})` as taking
+    // `{ args?: never[] }` (40x TS2353) and infers the run object's `null`
+    // initializers as type `null` (123x TS18047/TS2531). Typing that module is
+    // the fix, and it is deliberately not attempted here.
+    "scripts/__tests__/dev-server-test-queue.test.ts",
+    "scripts/__tests__/dev-server-env-modes.test.ts",
+    "scripts/__tests__/dev-server-port-reservation.test.ts",
+    "scripts/__tests__/typecheck-tests-gate.test.ts",
+    "scripts/local-dev/gen_seed.ts"
   ]
 }

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,24 @@
+{
+  // Audit/measurement config for `scripts/ci/typecheck-scripts-gate.mjs`:
+  // identical to tsconfig.json in every respect EXCEPT that it does not exclude
+  // the five quarantined files listed in that config's `scripts/ quarantine`
+  // block.
+  //
+  // The delta from the base config is exactly those five entries, deliberately,
+  // and `diffLists` in the gate re-asserts it on every run. A hand-rolled
+  // narrowed program (one that picks its own `include`, or drops `src`) silently
+  // loses `src/types/global.d.ts`, which makes ambient names resolve to TS2304
+  // and collapses downstream generics into a FALSE all-clear on exactly the
+  // files being measured. Extending the real config and subtracting the
+  // quarantine is what keeps the program honest — the same reasoning, and the
+  // same shape, as `tsconfig.tests.json`.
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "./node_modules",
+    "./node_modules/*",
+    "src/pages/api/dev-local/*.ts",
+    "src/**/__tests__/**",
+    "packages/civitai-ui"
+  ]
+}

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,17 +1,17 @@
 {
   // Audit/measurement config for `scripts/ci/typecheck-scripts-gate.mjs`:
   // identical to tsconfig.json in every respect EXCEPT that it does not exclude
-  // the five quarantined files listed in that config's `scripts/ quarantine`
-  // block.
+  // `scripts/__tests__/**` or `scripts/local-dev/gen_seed.ts` — i.e. it is the
+  // program the root config would be if `scripts/` were fully typechecked.
   //
-  // The delta from the base config is exactly those five entries, deliberately,
+  // The delta from the base config is exactly those two entries, deliberately,
   // and `diffLists` in the gate re-asserts it on every run. A hand-rolled
   // narrowed program (one that picks its own `include`, or drops `src`) silently
   // loses `src/types/global.d.ts`, which makes ambient names resolve to TS2304
   // and collapses downstream generics into a FALSE all-clear on exactly the
-  // files being measured. Extending the real config and subtracting the
-  // quarantine is what keeps the program honest — the same reasoning, and the
-  // same shape, as `tsconfig.tests.json`.
+  // files being measured. Extending the real config and subtracting the two
+  // entries is what keeps the program honest — the same reasoning, and the same
+  // shape, as `tsconfig.tests.json`.
   "extends": "./tsconfig.json",
   "exclude": [
     "node_modules",

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -13,12 +13,11 @@
   // `tsconfig.json`'s `exclude` by hand. `scripts/ci/typecheck-tests-gate.mjs`
   // refuses to run (CANNOT MEASURE, exit 3) when the two stop differing by
   // exactly `src/**/__tests__/**` — that is a control, not an inconvenience, and
-  // it is what caught the drift when the `scripts/ quarantine` block was added
-  // to the base config. There are now THREE configs to keep in step when the
-  // quarantine changes: this one, `tsconfig.scripts.json`, and `tsconfig.json`
-  // itself, plus the QUARANTINE list in
-  // `scripts/ci/typecheck-scripts-gate.mjs`. Both gates fail loudly rather than
-  // silently mismeasuring when one is forgotten.
+  // it is what caught the drift when the `scripts/` entries were added to the
+  // base config. There are THREE configs to keep in step: this one,
+  // `tsconfig.scripts.json`, and `tsconfig.json` itself, plus the QUARANTINE
+  // list in `scripts/ci/typecheck-scripts-gate.mjs`. Both gates fail loudly
+  // rather than silently mismeasuring when one is forgotten.
   "extends": "./tsconfig.json",
   "exclude": [
     "node_modules",
@@ -26,10 +25,7 @@
     "./node_modules/*",
     "src/pages/api/dev-local/*.ts",
     "packages/civitai-ui",
-    "scripts/__tests__/dev-server-test-queue.test.ts",
-    "scripts/__tests__/dev-server-env-modes.test.ts",
-    "scripts/__tests__/dev-server-port-reservation.test.ts",
-    "scripts/__tests__/typecheck-tests-gate.test.ts",
+    "scripts/__tests__/**",
     "scripts/local-dev/gen_seed.ts"
   ]
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -8,13 +8,28 @@
   // like `FileMetadata` resolve to TS2304 and collapses downstream generics
   // into a FALSE all-clear on the files that matter. Extending the real config
   // and subtracting one exclude entry is what keeps the program honest.
+  //
+  // 🔴 THIS LIST IS WRITTEN OUT VERBATIM, so it must be kept in step with
+  // `tsconfig.json`'s `exclude` by hand. `scripts/ci/typecheck-tests-gate.mjs`
+  // refuses to run (CANNOT MEASURE, exit 3) when the two stop differing by
+  // exactly `src/**/__tests__/**` — that is a control, not an inconvenience, and
+  // it is what caught the drift when the `scripts/ quarantine` block was added
+  // to the base config. There are now THREE configs to keep in step when the
+  // quarantine changes: this one, `tsconfig.scripts.json`, and `tsconfig.json`
+  // itself, plus the QUARANTINE list in
+  // `scripts/ci/typecheck-scripts-gate.mjs`. Both gates fail loudly rather than
+  // silently mismeasuring when one is forgotten.
   "extends": "./tsconfig.json",
   "exclude": [
     "node_modules",
     "./node_modules",
     "./node_modules/*",
     "src/pages/api/dev-local/*.ts",
-    "scripts/local-dev/*.ts",
-    "packages/civitai-ui"
+    "packages/civitai-ui",
+    "scripts/__tests__/dev-server-test-queue.test.ts",
+    "scripts/__tests__/dev-server-env-modes.test.ts",
+    "scripts/__tests__/dev-server-port-reservation.test.ts",
+    "scripts/__tests__/typecheck-tests-gate.test.ts",
+    "scripts/local-dev/gen_seed.ts"
   ]
 }


### PR DESCRIPTION
## What this does

`scripts/` was invisible to the typechecker. The root `tsconfig.json` named `scripts/local-dev/*.ts` in **both** `include` and `exclude` — exclude wins, so **zero** files under `scripts/` were in the program, not even the one directory the list appeared to name.

Demonstrated, not asserted. The same deliberate `const x: number = 'nope'` planted in `scripts/oneoffs/parse_header.ts`:

| config | result |
|---|---|
| `main`'s `tsconfig.json` | `typecheck: OK — 0 type errors`, **exit 0** |
| this PR's `tsconfig.json` | `parse_header.ts(112,7): error TS2322`, **exit 2** |

This PR adds `scripts/**/*.ts(x)` to `include`, and excludes two things: `scripts/__tests__/**` and `scripts/local-dev/gen_seed.ts`.

## The measurement

Adding all of `scripts/` surfaces **202 errors across 6 files** (of 37). Measured with a config that `extends` the real one and only *adds* to `include`, so the program stays a strict superset — a hand-rolled narrowed program drops `src/types/global.d.ts`, ambient names collapse to TS2304, and the affected files report *fewer* errors than they have. Same reasoning already written into `tsconfig.tests.json`.

```
scripts/__tests__/dev-server-test-queue.test.ts        164
scripts/__tests__/dev-server-env-modes.test.ts          14
scripts/__tests__/typecheck-tests-gate.test.ts          11
scripts/__tests__/dev-server-port-reservation.test.ts    7
scripts/__tests__/dev-server-daemon-port.test.ts         4
scripts/local-dev/gen_seed.ts                            2
                                                       ---
                                                       202
```

Five of the six are in `scripts/__tests__/`, and that is structural rather than a backlog.

## Why `scripts/__tests__/**` is excluded as a directory

An earlier revision of this PR quarantined four `__tests__` files individually and ran the ratchet as a blocking CI job. **#4181 broke it within a day** by adding an ordinary new test, `dev-server-daemon-port.test.ts`, carrying 4 × TS2345.

Cause, read at the source: that directory exists to test the untyped `.mjs` modules under `.claude/skills/` and `.claude/hooks/` by importing them. None carries JSDoc, so under `allowJs` tsc infers their signatures from the implementation and every caller inherits the result.

```js
export function daemonPortsGuarded(env = process.env) {   // no JSDoc
```
infers as requiring a full `ProcessEnv`, so `daemonPortsGuarded({ DEV_DAEMON_PORT: '9555' })` is an error. It is the **same mechanism** as the 164: `request({ worktree, args = [] } = {})` infers as `{ args?: never[] }` (40 × TS2353) and a run object's `null` initializers infer as type `null` (123 × TS18047/TS2531).

Frequency, measured from git history rather than guessed: **5 of the 15 files there carry this class, and all 15 were added within one month.** A blocking gate over that directory would fire several times a month, always for a defect in a dependency the test author did not write, and the fastest way out would be to add another exclude line — training exactly the reflex the quarantine existed to prevent.

So the directory is excluded the same way `src/**/__tests__/**` already is, and **the gate is no longer wired into CI**. Its job is removed; `.github/workflows/lint.yml` is byte-identical to `main`.

## What is covered, and what is not

**Covered** — 15 non-test files, now checked by the real `pnpm typecheck` in **both** tiers, along with any file added to these directories later. Counted with `--listFilesOnly`, not asserted:

| directory | files |
|---|---|
| `scripts/oneoffs/` | 6 |
| `scripts/local-dev/` | 3 |
| `scripts/test-perf/` | 2 |
| `scripts/*.ts` | 2 |
| `scripts/metric-migration/` | 2 |

> An earlier revision of this PR claimed 31. That was wrong: it counted `scripts/__tests__` files and transitively-imported `.mjs`. 15 is the honest number.

🔴 **Not covered** — `scripts/__tests__/**` is **unchecked**. That is the pre-existing state rather than a regression, but this PR does not fix it and should not be read as doing so. It is *measured*: `tsconfig.scripts.json` re-includes it and `node scripts/ci/typecheck-scripts-gate.mjs` prints per-file counts on demand. Typing the `.mjs` modules is the real fix and is the natural follow-up — the baseline is how you watch that number fall.

`scripts/local-dev/gen_seed.ts` is excluded by name. Its 2 errors are **a real bug the blind spot was hiding**, not an inference artifact: it imports `~/server/db/notifDb`, deleted in `927e31bfee`. `notifDbWrite` now lives in `apps/notifications` behind a different API (a function returning a pool), so restoring the script is a cross-workspace migration.

## The gate

Kept as an on-demand measurement instrument — the same status as its sibling `typecheck-tests-gate.mjs`, whose five controls it **imports rather than copies** (`classifyEmptyAllowance` gains a defaulted `envName`/`gateScript` so each names its own). Since nothing runs it automatically, its exit 1 is a report, not a merge block.

The one control genuinely new here: its positive control anchors at the repo root rather than matching the substring `/scripts/`, because this repo pulls `.claude/skills/**/scripts/*.mjs` in transitively and every vendored package has a `scripts/` directory — a substring control could stay green with the whole measured tree gone.

## Verification

- **Positive control**: planted error in `scripts/oneoffs/` → caught, exit 2. The remaining coverage is real, not a vacuous glob.
- **Negative control**: a new deliberately-broken test file dropped into `scripts/__tests__/` → **0** root errors. The tripwire is gone. The gate still reports that same file, so it is excluded, not invisible.
- **Ratchet both ways against real `tsc`**: `gen_seed.ts` 2→3 BLOCKS (exit 1, names the delta); untouched tree PASSES (exit 0).
- **New invariant test, watched fail**: a baseline entry for a root-*covered* file is rejected by name — so this baseline cannot be used to park a failure `pnpm typecheck` is actually red on. Ships with a negative control proving its predicate can reject.
- **Mutation battery**: 10 mutants, one per control, each killed by its specifically named test, with unmutated-green controls at both ends. The drift mutant was re-run against the new glob-shaped quarantine and is killed by 3 tests including the end-to-end one.
- Root `pnpm typecheck`: **0 errors**. Both gate suites: **190 passed**. Prettier + ESLint clean.

## Still unverified / known-unrelated

- **The sibling tests gate is already BLOCKED on `main`** (869 errors across 160 files vs its 784/140 baseline). Verified at the base ref with my changes reverted — identical counts, pre-existing, and it is not wired into CI. Its baseline wants a `--write-baseline` refresh; out of scope here.
- The gate script itself is a `.mjs` spawned as a subprocess, never imported by a `.ts`, so it is in no program and is not typechecked — same as its sibling. Its pure logic lives in `typecheck-scripts-compare.mjs`, which *is* checked and unit-tested.
- I did not run the full unit suite locally, only the two gate suites, the root typecheck, and the gate end to end.
- Three configs plus the gate's `QUARANTINE` list must stay in step when the exclusions change. Both gates refuse to run (`CANNOT MEASURE`, exit 3) rather than mismeasure when one is forgotten — that control is what caught the drift here.
