### PR TITLE
fix(dev-server): give a queued test run a FILE, not a pipe — a child that exits without flushing was losing most of its log

### DIFF
--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -17,6 +17,7 @@ import { closeSync, openSync, readSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
+import { StringDecoder } from 'string_decoder';
 
 export const DEFAULT_CONCURRENCY = 1;
 const DEFAULT_ABANDON_AFTER_MS = 10 * 60 * 1000;
@@ -83,9 +84,16 @@ export function createOutputCapture(onLine) {
   // torn in two and BOTH halves are recorded as lines — which corrupted the log even when every
   // byte arrived: 5,000 lines in, 4,998 recognised, 6 fragments invented, 353,893/353,893 bytes.
   let carry = '';
+  // A carry buffer fixes a torn LINE and does nothing for a torn CHARACTER. Decoding each read
+  // independently turned a 3-byte `⎯` starting at byte 65535 into THREE U+FFFD — and vitest's
+  // failure output is built from `⎯`/`✓`/`×`/`❯`, one boundary per 64 KiB. The decoder holds an
+  // incomplete sequence back until the bytes that finish it arrive.
+  const decoder = new StringDecoder('utf8');
+
+  // Hoisted: the tail runs 10x a second per run, and this was a fresh 64 KiB allocation each time.
+  const buf = Buffer.allocUnsafe(64 * 1024);
 
   const drain = (final = false) => {
-    const buf = Buffer.allocUnsafe(64 * 1024);
     for (;;) {
       let read = 0;
       try {
@@ -96,12 +104,19 @@ export function createOutputCapture(onLine) {
       }
       if (read <= 0) break;
       offset += read;
-      carry += buf.toString('utf8', 0, read);
+      carry += decoder.write(buf.subarray(0, read));
       const lines = carry.split('\n');
       carry = lines.pop() ?? '';
       for (const line of lines) if (line.trim()) onLine(line.trim());
-      if (read < buf.length) break;
+      // A short read means EOF on a regular file, so the incremental drain can stop there. The
+      // FINAL drain cannot afford that reasoning — truncating here would report `logsDropped: 0`
+      // over a clipped log, the exact thing warnIfLogsDropped exists to make impossible — so it
+      // keeps going until a read genuinely returns nothing.
+      if (read < buf.length && !final) break;
     }
+    // Anything the decoder is still holding is an incomplete sequence at EOF; flush it so the
+    // bytes are visible as replacement chars rather than silently dropped.
+    if (final) carry += decoder.end();
     // A run whose last line has no trailing newline still emitted that line.
     if (final && carry.trim()) {
       onLine(carry.trim());
@@ -141,6 +156,7 @@ export function defaultStartRun({ worktree, args, onLog, onExit }) {
   } catch (err) {
     queueMicrotask(() => onExit(-1, `could not open a capture file: ${err.message}`));
     emitter.kill = () => {};
+    emitter.dispose = () => {};
     return emitter;
   }
 
@@ -166,6 +182,7 @@ export function defaultStartRun({ worktree, args, onLog, onExit }) {
     capture.close();
     queueMicrotask(() => onExit(-1, err.message));
     emitter.kill = () => {};
+    emitter.dispose = () => {};
     return emitter;
   }
 
@@ -191,6 +208,26 @@ export function defaultStartRun({ worktree, args, onLog, onExit }) {
 
   child.on('exit', (code) => finish(code ?? -1));
   child.on('error', (err) => finish(-1, err.message));
+
+  /**
+   * Release the capture without an exit.
+   *
+   * `finish` is bound to the child's own 'exit', and there are two live paths where that event
+   * never comes: the sweep's force-release past the kill grace — the wedge this queue exists to
+   * prevent — and daemon shutdown. Both used to drop the queue's last reference to the handle
+   * while the interval, both descriptors and an unbounded /tmp file stayed alive inside the
+   * closure. Measured on a forced run: 2 fds still open, the log still growing 2s after the run
+   * was reported terminal (logIndex 75 -> 471), file 102,465 bytes and climbing, never unlinked.
+   *
+   * Idempotent, and it deliberately does NOT call onExit: the caller has already settled the run.
+   */
+  emitter.dispose = () => {
+    if (finished) return;
+    finished = true;
+    clearInterval(tail);
+    capture.drain(true);
+    capture.close();
+  };
 
   emitter.pid = child.pid;
   // `sync` is for daemon shutdown, where an asynchronously spawned taskkill would never get to
@@ -349,6 +386,9 @@ export class TestQueue {
       // exists to prevent. Past the grace, detach the handle (so a late exit cannot double-settle)
       // and free the slot on our own authority.
       if (run.killRequestedAt !== null && at - run.killRequestedAt >= this.killGraceMs) {
+        // Before dropping the reference: the handle owns a capture file, two descriptors and a
+        // tail interval, and none of them are released by anything else on this path.
+        run.handle?.dispose?.();
         run.handle = null;
         this.release(id);
         this.settle(
@@ -379,6 +419,9 @@ export class TestQueue {
       run.cancelReason = 'daemon-shutdown';
       run.killRequestedAt = this.now();
       run.handle?.kill(true);
+      // The daemon exits immediately after this, so the child's 'exit' will not be observed —
+      // without this the capture file survives the daemon that created it, every time.
+      run.handle?.dispose?.();
     }
   }
 

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -219,8 +219,14 @@ export function defaultStartRun({ worktree, args, onLog, onExit }) {
     // Ordering is the point. Every remaining line is read BEFORE the run is reported terminal,
     // so a waiter that wakes on the terminal status cannot observe a log that is still filling.
     // The old pipe path could call onExit with lines still in flight.
-    capture.drain(true);
-    capture.close();
+    //
+    // `finally`, because draining calls back into `onLog`: a consumer that throws would otherwise
+    // leave both descriptors open and the capture file on disk, per run, in a long-lived daemon.
+    try {
+      capture.drain(true);
+    } finally {
+      capture.close();
+    }
     onExit(code, error);
   };
 
@@ -243,8 +249,13 @@ export function defaultStartRun({ worktree, args, onLog, onExit }) {
     if (finished) return;
     finished = true;
     clearInterval(tail);
-    capture.drain(true);
-    capture.close();
+    // See finish(): the close is in `finally` so a throwing log consumer cannot leak the
+    // descriptors and the file.
+    try {
+      capture.drain(true);
+    } finally {
+      capture.close();
+    }
   };
 
   emitter.pid = child.pid;
@@ -414,8 +425,10 @@ export class TestQueue {
         // Releasing the slot matters more than releasing the file descriptors.
         try {
           run.handle?.dispose?.();
-        } catch {
-          /* the slot must be freed regardless */
+        } catch (err) {
+          // The slot is freed regardless — but silently swallowing this would hide a clipped log
+          // behind `logsDropped: 0`, which is exactly what the truncation marker exists to stop.
+          this.addLog(run, 'error', `capture release failed: ${err?.message ?? String(err)}`);
         }
         run.handle = null;
         this.release(id);
@@ -472,8 +485,8 @@ export class TestQueue {
       // leaving every remaining run unkilled and the caller's `process.exit(0)` unreached.
       try {
         run.handle?.dispose?.();
-      } catch {
-        /* the slot must be freed regardless */
+      } catch (err) {
+        this.addLog(run, 'error', `capture release failed: ${err?.message ?? String(err)}`);
       }
       run.handle = null;
       this.release(id);

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -99,7 +99,11 @@ export function createOutputCapture(onLine) {
       try {
         // Explicit position, so this never moves the shared write offset.
         read = readSync(readFd, buf, 0, buf.length, offset);
-      } catch {
+      } catch (err) {
+        // Same argument as the short-read break below: stopping here silently would report a
+        // clipped log with `logsDropped: 0`, which is the one thing the queue's log contract
+        // promises cannot happen. A read we cannot complete is said out loud instead.
+        if (final) onLine(`[capture truncated: ${err.code ?? err.message}]`);
         break;
       }
       if (read <= 0) break;
@@ -108,10 +112,14 @@ export function createOutputCapture(onLine) {
       const lines = carry.split('\n');
       carry = lines.pop() ?? '';
       for (const line of lines) if (line.trim()) onLine(line.trim());
-      // A short read means EOF on a regular file, so the incremental drain can stop there. The
-      // FINAL drain cannot afford that reasoning — truncating here would report `logsDropped: 0`
-      // over a clipped log, the exact thing warnIfLogsDropped exists to make impossible — so it
-      // keeps going until a read genuinely returns nothing.
+      // A short read means EOF on a regular file, so the incremental drain can stop there.
+      //
+      // This has effect on exactly ONE path, and the honest scope is worth stating: on the
+      // `finish()` path the writer is already dead, so a short read IS EOF and `!final` changes
+      // nothing. It matters on `dispose()`, where force-release fires precisely because the child
+      // did NOT die and may still be appending. There, stopping at the first short read would
+      // report a clipped log with `logsDropped: 0`. Bounded: against a maximally fast live writer
+      // this returned in 89.5 ms having read 2,082,688 lines.
       if (read < buf.length && !final) break;
     }
     // Anything the decoder is still holding is an incomplete sequence at EOF; flush it so the
@@ -419,9 +427,30 @@ export class TestQueue {
       run.cancelReason = 'daemon-shutdown';
       run.killRequestedAt = this.now();
       run.handle?.kill(true);
-      // The daemon exits immediately after this, so the child's 'exit' will not be observed —
-      // without this the capture file survives the daemon that created it, every time.
+
+      // Dispose, then settle HERE — the two go together, and the first version shipped only the
+      // first half.
+      //
+      // `dispose()` sets the same `finished` flag `finish()` guards on, so the SIGKILLed child's
+      // 'exit' arrives and returns early: `onExit` never fires. Without settling on this side,
+      // the run stays `running` and `running.size` never drops, so `pump()` can never start
+      // another run — the queue is wedged, which is the exact failure it exists to prevent.
+      // Measured: 300 ms after shutdown(), status `running` and running.size 1, against
+      // `cancelled` / 0 when the dispose is removed.
+      //
+      // Today every caller exits the process straight after, so nothing observes the wedge. That
+      // is not a reason to leave it: each one first awaits rgbProxy.stop(), authHub.stop() and
+      // stopSpokeApps(), and if any of those hangs the daemon stays up and serving with a queue
+      // that can never run anything again.
+      //
+      // (An earlier comment here claimed the capture file would otherwise "survive the daemon
+      // every time". That was wrong — measured in both arms, the file was unlinked either way,
+      // because the daemon does linger long enough for the child's exit. The dispose earns its
+      // place by releasing the interval and the descriptors deterministically, not by that.)
       run.handle?.dispose?.();
+      run.handle = null;
+      this.release(id);
+      this.settle(run, 'cancelled', null, 'daemon-shutdown');
     }
   }
 

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -221,7 +221,9 @@ export function defaultStartRun({ worktree, args, onLog, onExit }) {
     // The old pipe path could call onExit with lines still in flight.
     //
     // `finally`, because draining calls back into `onLog`: a consumer that throws would otherwise
-    // leave both descriptors open and the capture file on disk, per run, in a long-lived daemon.
+    // leave both descriptors open and the capture file on disk. Scope, stated honestly: the
+    // daemon's own `onLog` is `addLog`, which cannot throw, so no daemon run reaches this today —
+    // it is cheap insurance against a future consumer, not a live leak.
     try {
       capture.drain(true);
     } finally {
@@ -461,7 +463,8 @@ export class TestQueue {
       run.killRequestedAt = this.now();
       // Not guarded, unlike the dispose below, and the asymmetry is deliberate: `defaultStartRun`
       // puts its whole kill body inside its own try/catch, and the daemon always uses that runner
-      // (it is the only `new TestQueue` and passes no `startRun`). Nothing here can throw.
+      // (the daemon's is the only PRODUCTION `new TestQueue`, and it passes no `startRun`; the
+      // other constructions are in tests). Nothing here can throw.
       run.handle?.kill(true);
 
       // Dispose, then settle HERE — the two go together, and the first version shipped only the

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -459,6 +459,9 @@ export class TestQueue {
       const run = this.runs.get(id);
       run.cancelReason = 'daemon-shutdown';
       run.killRequestedAt = this.now();
+      // Not guarded, unlike the dispose below, and the asymmetry is deliberate: `defaultStartRun`
+      // puts its whole kill body inside its own try/catch, and the daemon always uses that runner
+      // (it is the only `new TestQueue` and passes no `startRun`). Nothing here can throw.
       run.handle?.kill(true);
 
       // Dispose, then settle HERE — the two go together, and the first version shipped only the

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -13,6 +13,10 @@
 
 import { EventEmitter } from 'events';
 import { spawn, execFileSync } from 'child_process';
+import { closeSync, openSync, readSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
 
 export const DEFAULT_CONCURRENCY = 1;
 const DEFAULT_ABANDON_AFTER_MS = 10 * 60 * 1000;
@@ -42,6 +46,87 @@ export function exitCodeFor(run) {
   return Number.isInteger(run.exitCode) && run.exitCode > 0 ? run.exitCode : 1;
 }
 
+/**
+ * Where a run's output is captured while it runs.
+ *
+ * A FILE, not a pipe, and that is the whole fix for the drop. Node makes a child's stdout
+ * synchronous when it refers to a regular file and asynchronous when it refers to a pipe — so a
+ * child that calls `process.exit()` with data still queued on a pipe DISCARDS it, before the
+ * parent ever receives it. Measured on this box: 5,000 lines written, 172 recorded, 11,932 of
+ * 353,893 bytes delivered, every missing line a contiguous tail. The same child exiting naturally
+ * delivered all 353,893 bytes.
+ *
+ * That also rules out the fix that looks obvious from the daemon's side. The daemon cannot detect
+ * the loss by reading: it sees a clean EOF and there is no signal to compare against. And the
+ * child is vitest, so "flush before exit" is not ours to call. Handing it a file is the only one
+ * of the three that needs no cooperation from the thing losing the data.
+ *
+ * One file for both streams rather than two, so the interleaving a reader depends on is the real
+ * one. The cost is that stdout and stderr are no longer distinguishable, which is why lines are
+ * recorded as `output` rather than claiming to be one or the other — nothing renders the level for
+ * a test run (both consumers print `entry.message`), and a label we cannot support is worse than
+ * an honest one.
+ */
+export function createOutputCapture(onLine) {
+  const path = join(tmpdir(), `civitai-test-run-${process.pid}-${randomUUID()}.log`);
+  const writeFd = openSync(path, 'a');
+  let readFd;
+  try {
+    readFd = openSync(path, 'r');
+  } catch (err) {
+    closeSync(writeFd);
+    throw err;
+  }
+
+  let offset = 0;
+  // The tail of a read that stopped mid-line. Without it, a line straddling a read boundary is
+  // torn in two and BOTH halves are recorded as lines — which corrupted the log even when every
+  // byte arrived: 5,000 lines in, 4,998 recognised, 6 fragments invented, 353,893/353,893 bytes.
+  let carry = '';
+
+  const drain = (final = false) => {
+    const buf = Buffer.allocUnsafe(64 * 1024);
+    for (;;) {
+      let read = 0;
+      try {
+        // Explicit position, so this never moves the shared write offset.
+        read = readSync(readFd, buf, 0, buf.length, offset);
+      } catch {
+        break;
+      }
+      if (read <= 0) break;
+      offset += read;
+      carry += buf.toString('utf8', 0, read);
+      const lines = carry.split('\n');
+      carry = lines.pop() ?? '';
+      for (const line of lines) if (line.trim()) onLine(line.trim());
+      if (read < buf.length) break;
+    }
+    // A run whose last line has no trailing newline still emitted that line.
+    if (final && carry.trim()) {
+      onLine(carry.trim());
+      carry = '';
+    }
+  };
+
+  const close = () => {
+    for (const fd of [readFd, writeFd]) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+    try {
+      unlinkSync(path);
+    } catch {
+      /* already gone */
+    }
+  };
+
+  return { path, writeFd, drain, close };
+}
+
 export function defaultStartRun({ worktree, args, onLog, onExit }) {
   const emitter = new EventEmitter();
   const isWindows = process.platform === 'win32';
@@ -49,6 +134,15 @@ export function defaultStartRun({ worktree, args, onLog, onExit }) {
   const argv = ['run', 'test:unit:run', ...args];
 
   onLog('info', `> ${pnpm} ${argv.join(' ')}`);
+
+  let capture;
+  try {
+    capture = createOutputCapture((line) => onLog('output', line));
+  } catch (err) {
+    queueMicrotask(() => onExit(-1, `could not open a capture file: ${err.message}`));
+    emitter.kill = () => {};
+    return emitter;
+  }
 
   let child;
   try {
@@ -58,12 +152,10 @@ export function defaultStartRun({ worktree, args, onLog, onExit }) {
       // enqueue a second run and wait for it, while this one holds the slot that run needs — a
       // deadlock on every full-suite run, not a race. Concurrency is not the fix: each logical run
       // would need two slots, so N agents starting together still fill them all with waiters.
-      // The command above is the script that routes to this queue. Inheriting the flag makes it
-      // enqueue a second run and wait for it, while this one holds the slot that run needs — a
-      // deadlock on every full-suite run, not a race. Concurrency is not the fix: each logical run
-      // would need two slots, so N agents starting together still fill them all with waiters.
       env: { ...process.env, CIVITAI_TEST_QUEUE: '0' },
-      stdio: ['ignore', 'pipe', 'pipe'],
+      // The same fd twice: one file description, one shared offset, so the two streams append in
+      // the order they were actually written. See createOutputCapture.
+      stdio: ['ignore', capture.writeFd, capture.writeFd],
       shell: isWindows,
       // Its own process group, so the kill below can take the whole vitest tree. Without this,
       // killing by negative pid names no group, fails with ESRCH, and leaves the run burning
@@ -71,22 +163,34 @@ export function defaultStartRun({ worktree, args, onLog, onExit }) {
       detached: !isWindows,
     });
   } catch (err) {
+    capture.close();
     queueMicrotask(() => onExit(-1, err.message));
     emitter.kill = () => {};
     return emitter;
   }
 
-  const pipe = (stream, level) =>
-    stream.on('data', (d) => {
-      for (const line of d.toString().split('\n')) {
-        if (line.trim()) onLog(level, line.trim());
-      }
-    });
-  pipe(child.stdout, 'stdout');
-  pipe(child.stderr, 'stderr');
+  // Polled rather than watched: fs.watch's semantics differ per platform and it can miss an
+  // append entirely. The interval only decides how LIVE the log is — completeness comes from the
+  // final drain below, which runs after the writer is gone.
+  const tail = setInterval(() => capture.drain(), 100);
+  // So a forgotten run can never hold the daemon open.
+  tail.unref?.();
 
-  child.on('exit', (code) => onExit(code ?? -1));
-  child.on('error', (err) => onExit(-1, err.message));
+  let finished = false;
+  const finish = (code, error) => {
+    if (finished) return;
+    finished = true;
+    clearInterval(tail);
+    // Ordering is the point. Every remaining line is read BEFORE the run is reported terminal,
+    // so a waiter that wakes on the terminal status cannot observe a log that is still filling.
+    // The old pipe path could call onExit with lines still in flight.
+    capture.drain(true);
+    capture.close();
+    onExit(code, error);
+  };
+
+  child.on('exit', (code) => finish(code ?? -1));
+  child.on('error', (err) => finish(-1, err.message));
 
   emitter.pid = child.pid;
   // `sync` is for daemon shutdown, where an asynchronously spawned taskkill would never get to

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -19,6 +19,16 @@ import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
 import { StringDecoder } from 'string_decoder';
 
+/**
+ * How much the tail reads at a time.
+ *
+ * Exported because two tests pin behaviour AT this boundary — a line and a multi-byte character
+ * straddling it — and a private copy of the number in the test file means widening the window
+ * here makes both of those controls vacuous while they stay green. Measured: at 128 KiB with a
+ * hand-copied constant, the whole suite passed with the StringDecoder deleted outright.
+ */
+export const READ_WINDOW_BYTES = 64 * 1024;
+
 export const DEFAULT_CONCURRENCY = 1;
 const DEFAULT_ABANDON_AFTER_MS = 10 * 60 * 1000;
 const DEFAULT_RUN_TIMEOUT_MS = 30 * 60 * 1000;
@@ -90,8 +100,8 @@ export function createOutputCapture(onLine) {
   // incomplete sequence back until the bytes that finish it arrive.
   const decoder = new StringDecoder('utf8');
 
-  // Hoisted: the tail runs 10x a second per run, and this was a fresh 64 KiB allocation each time.
-  const buf = Buffer.allocUnsafe(64 * 1024);
+  // Hoisted: the tail runs 10x a second per run, and this was a fresh allocation each time.
+  const buf = Buffer.allocUnsafe(READ_WINDOW_BYTES);
 
   const drain = (final = false) => {
     for (;;) {
@@ -103,7 +113,7 @@ export function createOutputCapture(onLine) {
         // Same argument as the short-read break below: stopping here silently would report a
         // clipped log with `logsDropped: 0`, which is the one thing the queue's log contract
         // promises cannot happen. A read we cannot complete is said out loud instead.
-        if (final) onLine(`[capture truncated: ${err.code ?? err.message}]`);
+        if (final) onLine(`[capture truncated: ${err?.code ?? err?.message ?? String(err)}]`);
         break;
       }
       if (read <= 0) break;
@@ -396,7 +406,17 @@ export class TestQueue {
       if (run.killRequestedAt !== null && at - run.killRequestedAt >= this.killGraceMs) {
         // Before dropping the reference: the handle owns a capture file, two descriptors and a
         // tail interval, and none of them are released by anything else on this path.
-        run.handle?.dispose?.();
+        //
+        // Guarded, because `dispose()` does real IO and calls back into `onLog`. If it throws,
+        // everything below — the detach, the release, the settle — is skipped and the slot is
+        // held forever, which is the wedge this branch exists to break. Measured with a throwing
+        // dispose: status `running`, running.size 1, against `cancelled` / 0 when it returns.
+        // Releasing the slot matters more than releasing the file descriptors.
+        try {
+          run.handle?.dispose?.();
+        } catch {
+          /* the slot must be freed regardless */
+        }
         run.handle = null;
         this.release(id);
         this.settle(
@@ -447,7 +467,14 @@ export class TestQueue {
       // every time". That was wrong — measured in both arms, the file was unlinked either way,
       // because the daemon does linger long enough for the child's exit. The dispose earns its
       // place by releasing the interval and the descriptors deterministically, not by that.)
-      run.handle?.dispose?.();
+      // Guarded for the same reason as the sweep's force-release: a throwing dispose must not
+      // skip the settle below and leave the queue wedged — and it would also abort this loop,
+      // leaving every remaining run unkilled and the caller's `process.exit(0)` unreached.
+      try {
+        run.handle?.dispose?.();
+      } catch {
+        /* the slot must be freed regardless */
+      }
       run.handle = null;
       this.release(id);
       this.settle(run, 'cancelled', null, 'daemon-shutdown');

--- a/scripts/__tests__/dev-server-test-queue-capture.test.ts
+++ b/scripts/__tests__/dev-server-test-queue-capture.test.ts
@@ -21,6 +21,23 @@ const { createOutputCapture, defaultStartRun, READ_WINDOW_BYTES } = await import
 // nothing. importActual is how a test that mocks a module still reaches the genuine one.
 const { spawn: realSpawn } = await vi.importActual<typeof ChildProcess>('child_process');
 
+/** Every capture this process currently owns. */
+const listCaptures = () =>
+  readdirSync(tmpdir()).filter((f) => f.startsWith(`civitai-test-run-${process.pid}-`));
+
+/**
+ * The captures created since `before`, i.e. the ones THIS case owns.
+ *
+ * A snapshot taken after the fact claims every live capture for this pid, and these cases share a
+ * fork — so a defect in a SIBLING test leaves its file behind and this one fails on the
+ * bookkeeping rather than on its own assertion. The mutant still dies, at the wrong line, which
+ * silently over-credits whatever this test was meant to cover. A delta is exact.
+ */
+const capturesCreatedBy = (before: string[]): string[] =>
+  listCaptures()
+    .filter((f) => !before.includes(f))
+    .map((f) => resolve(tmpdir(), f));
+
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../..');
 
@@ -400,6 +417,7 @@ describe('the queue hands its child the capture file, not a pipe', () => {
     const child = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn() });
     spawnMock.mockReturnValue(child);
 
+    const before = listCaptures();
     let seen = 0;
     const handle = defaultStartRun({
       worktree: repoRoot,
@@ -419,12 +437,10 @@ describe('the queue hands its child the capture file, not a pipe', () => {
     // that a file it does not own has been deleted, and goes red with no defect present. Measured:
     // a single foreign file made the unmutated test fail, and made three mutants report a false
     // KILLED. The filename carries the owning pid precisely so this can be scoped.
-    const capturePath = readdirSync(tmpdir())
-      .filter((f) => f.startsWith(`civitai-test-run-${process.pid}-`))
-      .map((f) => resolve(tmpdir(), f));
-    // The positive control for the scope above. An empty list makes every deletion assertion
-    // below a no-op loop that passes trivially — so if the filename format ever changes, this
-    // fails loudly instead of the suite quietly protecting nothing. Measured at exactly 1.
+    const capturePath = capturesCreatedBy(before);
+    // The positive control for the delta above. An empty list makes the deletion assertions below
+    // a no-op loop that passes trivially — so if the filename format ever changes, this fails
+    // loudly instead of the suite quietly protecting nothing. Measured at exactly 1.
     expect(capturePath).toHaveLength(1);
     writeSync(stdio[1], 'boom one\nboom two\n');
 
@@ -447,6 +463,7 @@ describe('the queue hands its child the capture file, not a pipe', () => {
     const child = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn() });
     spawnMock.mockReturnValue(child);
 
+    const before = listCaptures();
     let seen = 0;
     defaultStartRun({
       worktree: repoRoot,
@@ -460,9 +477,7 @@ describe('the queue hands its child the capture file, not a pipe', () => {
       onExit: () => {},
     });
     const stdio = (spawnMock.mock.calls[0][2] as { stdio: number[] }).stdio;
-    const mine = readdirSync(tmpdir())
-      .filter((f) => f.startsWith(`civitai-test-run-${process.pid}-`))
-      .map((f) => resolve(tmpdir(), f));
+    const mine = capturesCreatedBy(before);
     // Same positive control as above: an empty list would make the loop below vacuous.
     expect(mine).toHaveLength(1);
     writeSync(stdio[1], 'boom one\nboom two\n');

--- a/scripts/__tests__/dev-server-test-queue-capture.test.ts
+++ b/scripts/__tests__/dev-server-test-queue-capture.test.ts
@@ -101,6 +101,12 @@ describe('a run that exits without flushing still has all of its output', () => 
       const READ_WINDOW = 64 * 1024;
       // Pad so the 3-byte U+23AF begins one byte before the window ends, splitting it 1 + 2.
       const pad = Buffer.alloc(READ_WINDOW - 1, 0x61); // 'a'
+      // The control this test needs and its sibling already has: without a straddle the
+      // assertion below is satisfied by a character that never crossed a boundary, and passes
+      // with the StringDecoder removed entirely. Pin that the character STARTS inside the first
+      // read window and ENDS outside it.
+      expect(pad.length).toBeLessThan(READ_WINDOW);
+      expect(pad.length + Buffer.byteLength('⎯', 'utf8')).toBeGreaterThan(READ_WINDOW);
       writeSync(cap.writeFd, pad);
       writeSync(cap.writeFd, Buffer.from('⎯MARKER\n', 'utf8'));
 
@@ -151,6 +157,45 @@ describe('a line that straddles a read boundary survives whole', () => {
     } finally {
       cap.close();
     }
+  });
+
+  // A child killed mid-sequence leaves an incomplete character at EOF. Without `decoder.end()`
+  // those bytes are dropped silently; with it they surface as U+FFFD, which is a visible
+  // artefact rather than an absent one. That distinction is the whole point of the log contract.
+  it('surfaces an incomplete trailing character rather than dropping it', () => {
+    const lines: string[] = [];
+    const cap = createOutputCapture((line: string) => lines.push(line));
+    try {
+      // The first two bytes of a 3-byte U+23AF, and nothing more — a killed writer's tail.
+      writeSync(cap.writeFd, Buffer.from([0xe2, 0x8e]));
+
+      cap.drain(true);
+
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain('\ufffd');
+    } finally {
+      cap.close();
+    }
+  });
+
+  /**
+   * A final drain that cannot read must SAY so. Stopping silently would hand back a clipped log
+   * with `logsDropped: 0` — a complete-looking record of an incomplete run, which is the one
+   * thing the queue's log contract promises cannot happen.
+   */
+  it('says so when the final drain cannot read, instead of returning a short log', () => {
+    const lines: string[] = [];
+    const cap = createOutputCapture((line: string) => lines.push(line));
+    writeSync(cap.writeFd, 'delivered\n');
+    cap.drain();
+    // Releasing the descriptors out from under the capture is the reachable way to make the
+    // final read fail; the queue's own dispose path closes them for real.
+    cap.close();
+
+    cap.drain(true);
+
+    expect(lines[0]).toBe('delivered');
+    expect(lines.some((l) => l.startsWith('[capture truncated:'))).toBe(true);
   });
 
   it('emits a final line that has no trailing newline, but only on the final drain', () => {
@@ -248,6 +293,38 @@ describe('the queue hands its child the capture file, not a pipe', () => {
     // And a late exit after disposal cannot re-enter finish().
     child.emit('exit', 0);
     expect(exits).toBe(0);
+  });
+
+  /**
+   * dispose() must READ before it releases, and release in the right order.
+   *
+   * Both halves were unpinned. `capture.drain(true)` after `capture.close()` emits nothing at all
+   * — everything the child wrote is silently lost — and this is the one path where the child is
+   * KNOWN to still be producing output, because force-release fires exactly when a kill did not
+   * take. The ordering is load-bearing rather than cosmetic: fd numbers are reused, so a tail
+   * interval surviving a close would read whatever file next claimed that descriptor and splice
+   * its bytes into this run's log.
+   */
+  it('drains before releasing, and stops the tail before closing the descriptors', () => {
+    const child = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn() });
+    spawnMock.mockReturnValue(child);
+
+    const messages: string[] = [];
+    const handle = defaultStartRun({
+      worktree: repoRoot,
+      args: [],
+      onLog: (_level: string, message: string) => messages.push(message),
+      onExit: () => {},
+    });
+    const stdio = (spawnMock.mock.calls[0][2] as { stdio: number[] }).stdio;
+    writeSync(stdio[1], 'written but never drained\n');
+
+    handle.dispose();
+
+    // Drained, not lost — this fails outright if dispose closes before draining.
+    expect(messages).toContain('written but never drained');
+    // The descriptor is closed, so the tail cannot still be reading it.
+    expect(() => writeSync(stdio[1], 'x')).toThrow();
   });
 
   /**

--- a/scripts/__tests__/dev-server-test-queue-capture.test.ts
+++ b/scripts/__tests__/dev-server-test-queue-capture.test.ts
@@ -1,7 +1,8 @@
 import type * as ChildProcess from 'child_process';
 import { EventEmitter } from 'events';
-import { existsSync, writeSync } from 'fs';
+import { closeSync, existsSync, openSync, rmSync, writeFileSync, writeSync } from 'fs';
 import { dirname, resolve } from 'path';
+import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -11,7 +12,7 @@ vi.mock('child_process', async (importOriginal) => ({
   spawn: (...args: unknown[]) => spawnMock(...args),
 }));
 
-const { createOutputCapture, defaultStartRun } = await import(
+const { createOutputCapture, defaultStartRun, READ_WINDOW_BYTES } = await import(
   '../../.claude/skills/dev-server/scripts/test-queue.mjs'
 );
 
@@ -98,7 +99,9 @@ describe('a run that exits without flushing still has all of its output', () => 
     const lines: string[] = [];
     const cap = createOutputCapture((line: string) => lines.push(line));
     try {
-      const READ_WINDOW = 64 * 1024;
+      // The module's own window, not a copy of the number: with a hand-copied 64 KiB here, the
+      // whole suite passed at a 128 KiB window with the StringDecoder deleted outright.
+      const READ_WINDOW = READ_WINDOW_BYTES;
       // Pad so the 3-byte U+23AF begins one byte before the window ends, splitting it 1 + 2.
       const pad = Buffer.alloc(READ_WINDOW - 1, 0x61); // 'a'
       // The control this test needs and its sibling already has: without a straddle the
@@ -136,9 +139,10 @@ describe('a line that straddles a read boundary survives whole', () => {
     const lines: string[] = [];
     const cap = createOutputCapture((line: string) => lines.push(line));
     try {
-      // Land a line's midpoint exactly past the 64 KiB buffer: pad to just under, then write a
-      // marked line long enough to cross it.
-      const READ_WINDOW = 64 * 1024;
+      // Land a line's midpoint exactly past the read window: pad to just under, then write a
+      // marked line long enough to cross it. Taken from the module so widening it there cannot
+      // silently make this control vacuous.
+      const READ_WINDOW = READ_WINDOW_BYTES;
       const filler = `${'f'.repeat(99)}\n`;
       const padding = filler.repeat(Math.floor((READ_WINDOW - 50) / filler.length));
       const straddler = `STRADDLE-${'s'.repeat(400)}-END`;
@@ -305,7 +309,7 @@ describe('the queue hands its child the capture file, not a pipe', () => {
    * interval surviving a close would read whatever file next claimed that descriptor and splice
    * its bytes into this run's log.
    */
-  it('drains before releasing, and stops the tail before closing the descriptors', () => {
+  it('drains before releasing the descriptors', () => {
     const child = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn() });
     spawnMock.mockReturnValue(child);
 
@@ -323,8 +327,59 @@ describe('the queue hands its child the capture file, not a pipe', () => {
 
     // Drained, not lost — this fails outright if dispose closes before draining.
     expect(messages).toContain('written but never drained');
-    // The descriptor is closed, so the tail cannot still be reading it.
+    // The descriptor is closed.
     expect(() => writeSync(stdio[1], 'x')).toThrow();
+  });
+
+  /**
+   * The tail must actually STOP, and this is not cosmetic.
+   *
+   * I previously argued this mutant had no observable effect because a surviving interval would
+   * just throw on the closed descriptor. That is wrong, and measurably so: descriptor NUMBERS are
+   * reused, so once the next `openSync` claims the freed fd the surviving interval reads whatever
+   * file now owns it and splices those bytes into a terminal run's log. Measured against the
+   * mechanism: 4,246 lines of an unrelated file, versus 0 with the clearInterval in place.
+   *
+   * Driven with fake timers so the 100 ms tick is reached without waiting for it.
+   */
+  it('stops the tail, so a reused descriptor cannot splice another file into the log', () => {
+    vi.useFakeTimers();
+    const foreign = resolve(tmpdir(), `civitai-fd-probe-${process.pid}-${Date.now()}.log`);
+    const foreignFds: number[] = [];
+    try {
+      const child = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn() });
+      spawnMock.mockReturnValue(child);
+
+      const messages: string[] = [];
+      const handle = defaultStartRun({
+        worktree: repoRoot,
+        args: [],
+        onLog: (_level: string, message: string) => messages.push(message),
+        onExit: () => {},
+      });
+
+      handle.dispose();
+      const before = messages.length;
+
+      // Claim the descriptors the capture just released, and fill the new file with something
+      // unmistakable. A surviving tail would read THIS.
+      //
+      // BOTH of them, and that detail is the test: the capture closed two fds, `openSync` hands
+      // back the LOWEST free number, and the tail reads from `readFd` — the higher of the pair.
+      // Claiming only one takes writeFd's number and the mutant goes unobserved, which is exactly
+      // how the first version of this test passed against a surviving interval.
+      writeFileSync(foreign, 'FOREIGN-SECRET\n'.repeat(500));
+      foreignFds.push(openSync(foreign, 'r'), openSync(foreign, 'r'));
+
+      vi.advanceTimersByTime(1000);
+
+      expect(messages.slice(before)).toEqual([]);
+      expect(messages.some((m) => m.includes('FOREIGN-SECRET'))).toBe(false);
+    } finally {
+      for (const fd of foreignFds) closeSync(fd);
+      rmSync(foreign, { force: true });
+      vi.useRealTimers();
+    }
   });
 
   /**

--- a/scripts/__tests__/dev-server-test-queue-capture.test.ts
+++ b/scripts/__tests__/dev-server-test-queue-capture.test.ts
@@ -1,0 +1,206 @@
+import type * as ChildProcess from 'child_process';
+import { EventEmitter } from 'events';
+import { existsSync, writeSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock('child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof ChildProcess>()),
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+const { createOutputCapture, defaultStartRun } = await import(
+  '../../.claude/skills/dev-server/scripts/test-queue.mjs'
+);
+
+// The mock above replaces `spawn` for EVERY importer, this file included — so a plain
+// `import { spawn }` here would hand back the mock and the "real child" cases would spawn
+// nothing. importActual is how a test that mocks a module still reaches the genuine one.
+const { spawn: realSpawn } = await vi.importActual<typeof ChildProcess>('child_process');
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+
+/**
+ * A child that writes N numbered lines and then calls `process.exit()` — the exact shape that
+ * loses output down a pipe. Numbered, because a COUNT alone cannot tell truncation (a prefix
+ * survives, the tail is gone) from sampling (gaps throughout), and the two point at different
+ * causes.
+ */
+const WRITER = `
+const N = Number(process.argv[1]);
+for (let i = 1; i <= N; i++) process.stdout.write('LINE ' + i + ' ' + 'x'.repeat(60) + '\\n');
+process.exit(0);
+`;
+
+afterEach(() => vi.clearAllMocks());
+
+describe('a run that exits without flushing still has all of its output', () => {
+  /** Runs the writer against a capture and returns what the capture recorded. */
+  function capture(n: number) {
+    return new Promise<{ lines: string[]; path: string }>((done) => {
+      const lines: string[] = [];
+      const cap = createOutputCapture((line: string) => lines.push(line));
+      const child = realSpawn(process.execPath, ['--input-type=module', '-e', WRITER, String(n)], {
+        stdio: ['ignore', cap.writeFd, cap.writeFd],
+      });
+      const tail = setInterval(() => cap.drain(), 20);
+      child.on('exit', () => {
+        clearInterval(tail);
+        cap.drain(true);
+        const { path } = cap;
+        cap.close();
+        done({ lines, path });
+      });
+    });
+  }
+
+  /**
+   * The regression. Measured head-to-head against the mechanism this replaces, same child, same
+   * process: through PIPES the parent received 172 of 5,000 lines with a slow consumer (three
+   * identical runs) and 1,473 on one of three fast runs; through the FILE, 5,000 of 5,000 on all
+   * six. Node makes a child's stdout synchronous for a regular file and asynchronous for a pipe,
+   * so `process.exit()` can discard a pipe's queue and cannot discard a file's.
+   */
+  it('records every line of a 5,000-line run', async () => {
+    const { lines } = await capture(5000);
+
+    const numbers = new Set<number>();
+    let malformed = 0;
+    for (const line of lines) {
+      const m = /^LINE (\d+) x{60}$/.exec(line);
+      if (m) numbers.add(Number(m[1]));
+      else malformed += 1;
+    }
+
+    // Three distinct claims. The count catches loss; the distinct count catches a duplicate
+    // standing in for a missing line; malformed catches a line torn at a read boundary and
+    // recorded as two.
+    expect(lines).toHaveLength(5000);
+    expect(numbers.size).toBe(5000);
+    expect(malformed).toBe(0);
+  }, 60_000);
+
+  it('cleans up its capture file', async () => {
+    const { path } = await capture(10);
+    expect(existsSync(path)).toBe(false);
+  }, 30_000);
+});
+
+/**
+ * The second defect, and it is independent of the first: with every byte delivered, the old
+ * per-chunk `split('\n')` still tore any line straddling a read boundary into two, recording
+ * BOTH halves as lines. Measured at 5,000 lines: 4,998 recognised, 6 fragments invented, and
+ * 353,893 of 353,893 bytes — complete delivery, corrupted log. `logsDropped` reports 0 for this,
+ * correctly, which is what makes it invisible.
+ */
+describe('a line that straddles a read boundary survives whole', () => {
+  it('does not tear a line across the 64 KiB read window', () => {
+    const lines: string[] = [];
+    const cap = createOutputCapture((line: string) => lines.push(line));
+    try {
+      // Land a line's midpoint exactly past the 64 KiB buffer: pad to just under, then write a
+      // marked line long enough to cross it.
+      const READ_WINDOW = 64 * 1024;
+      const filler = `${'f'.repeat(99)}\n`;
+      const padding = filler.repeat(Math.floor((READ_WINDOW - 50) / filler.length));
+      const straddler = `STRADDLE-${'s'.repeat(400)}-END`;
+      writeSync(cap.writeFd, `${padding}${straddler}\n`);
+
+      cap.drain(true);
+
+      const found = lines.filter((l) => l.includes('STRADDLE'));
+      expect(found).toHaveLength(1);
+      expect(found[0]).toBe(straddler);
+      // The positive control: the write really did cross the window, so the assertion above was
+      // exercised rather than passing because everything fit in one read.
+      expect(padding.length + straddler.length).toBeGreaterThan(READ_WINDOW);
+    } finally {
+      cap.close();
+    }
+  });
+
+  it('emits a final line that has no trailing newline, but only on the final drain', () => {
+    const lines: string[] = [];
+    const cap = createOutputCapture((line: string) => lines.push(line));
+    try {
+      writeSync(cap.writeFd, 'complete line\nno trailing newline');
+
+      cap.drain();
+      // Mid-run it is not a line yet — the writer may still be mid-write.
+      expect(lines).toEqual(['complete line']);
+
+      cap.drain(true);
+      expect(lines).toEqual(['complete line', 'no trailing newline']);
+    } finally {
+      cap.close();
+    }
+  });
+});
+
+/**
+ * The seam. The capture above can be perfect and the queue can still hand its child a pipe — the
+ * two are different files and nothing else here loads both. This asserts the mechanism is wired
+ * in, by reading the stdio the queue actually passes to spawn.
+ */
+describe('the queue hands its child the capture file, not a pipe', () => {
+  it('passes one file descriptor for both stdout and stderr', () => {
+    const child = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn() });
+    spawnMock.mockReturnValue(child);
+
+    defaultStartRun({ worktree: repoRoot, args: [], onLog: () => {}, onExit: () => {} });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const stdio = (spawnMock.mock.calls[0][2] as { stdio: unknown[] }).stdio;
+    expect(stdio[0]).toBe('ignore');
+    // Numbers, not 'pipe' — that difference IS the fix.
+    expect(typeof stdio[1]).toBe('number');
+    expect(stdio[1]).not.toBe('pipe');
+    // The SAME descriptor for both, so the two streams share one offset and interleave in the
+    // order they were written. Two descriptors would reorder them.
+    expect(stdio[2]).toBe(stdio[1]);
+
+    child.emit('exit', 0);
+  });
+
+  /**
+   * The ordering invariant, and it is the half that actually protects a reader.
+   *
+   * A waiter wakes on the run's TERMINAL status and then reads the log. If the queue reports the
+   * exit before it has read what the child wrote, the waiter sees a complete-looking log that is
+   * still filling — the same false-green as losing the lines outright, arrived at differently.
+   * The old pipe path could do exactly that, because 'exit' does not wait for pending 'data'.
+   *
+   * Driven through the real `defaultStartRun` with a fake child, writing to the very descriptor
+   * the queue handed to spawn.
+   */
+  it('reads everything the child wrote BEFORE reporting the exit', () => {
+    const child = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn() });
+    spawnMock.mockReturnValue(child);
+
+    const events: string[] = [];
+    defaultStartRun({
+      worktree: repoRoot,
+      args: [],
+      onLog: (_level: string, message: string) => events.push(`log:${message}`),
+      onExit: (code: number) => events.push(`exit:${code}`),
+    });
+
+    const stdio = (spawnMock.mock.calls[0][2] as { stdio: number[] }).stdio;
+    // Written and never drained by the interval — the child "exits" immediately after, so the
+    // only thing that can have read these is the final drain inside the exit handler.
+    writeSync(stdio[1], 'first\nsecond\nthird\n');
+
+    child.emit('exit', 0);
+
+    const exitAt = events.indexOf('exit:0');
+    expect(exitAt).toBeGreaterThan(-1);
+    expect(events.slice(0, exitAt)).toEqual(
+      expect.arrayContaining(['log:first', 'log:second', 'log:third'])
+    );
+    // Stated as an index comparison too, so a reordering cannot hide behind arrayContaining.
+    expect(events.indexOf('log:third')).toBeLessThan(exitAt);
+  });
+});

--- a/scripts/__tests__/dev-server-test-queue-capture.test.ts
+++ b/scripts/__tests__/dev-server-test-queue-capture.test.ts
@@ -1,6 +1,6 @@
 import type * as ChildProcess from 'child_process';
 import { EventEmitter } from 'events';
-import { closeSync, existsSync, openSync, rmSync, writeFileSync, writeSync } from 'fs';
+import { closeSync, existsSync, openSync, readdirSync, rmSync, writeFileSync, writeSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
@@ -357,6 +357,7 @@ describe('the queue hands its child the capture file, not a pipe', () => {
         onLog: (_level: string, message: string) => messages.push(message),
         onExit: () => {},
       });
+      const stdio = (spawnMock.mock.calls[0][2] as { stdio: number[] }).stdio;
 
       handle.dispose();
       const before = messages.length;
@@ -370,6 +371,92 @@ describe('the queue hands its child the capture file, not a pipe', () => {
       // how the first version of this test passed against a surviving interval.
       writeFileSync(foreign, 'FOREIGN-SECRET\n'.repeat(500));
       foreignFds.push(openSync(foreign, 'r'), openSync(foreign, 'r'));
+
+      // The self-check. This case only has teeth if the reclamation actually happened — if it
+      // ever stops, `readSync` gets EBADF, `drain()` breaks silently, and the test goes on
+      // passing while protecting nothing.
+      expect(foreignFds).toContain(stdio[1]);
+
+      vi.advanceTimersByTime(1000);
+
+      expect(messages.slice(before)).toEqual([]);
+      expect(messages.some((m) => m.includes('FOREIGN-SECRET'))).toBe(false);
+    } finally {
+      for (const fd of foreignFds) closeSync(fd);
+      rmSync(foreign, { force: true });
+      vi.useRealTimers();
+    }
+  });
+
+  /**
+   * A log consumer that throws must not cost the descriptors and the file.
+   *
+   * Draining calls back into `onLog`. With the close outside a `finally`, a throwing consumer
+   * left BOTH descriptors open and the capture file on disk — measured — per run, in a daemon
+   * that runs for days. The slot-freeing guard upstream then swallows it, so it would be silent
+   * as well as leaky.
+   */
+  it('releases the descriptors and the file even when the log consumer throws', () => {
+    const child = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn() });
+    spawnMock.mockReturnValue(child);
+
+    let seen = 0;
+    const handle = defaultStartRun({
+      worktree: repoRoot,
+      args: [],
+      onLog: (_level: string, message: string) => {
+        // The queue's own preamble line arrives first; blow up on captured output.
+        if (message.startsWith('boom')) {
+          seen += 1;
+          throw new Error('log consumer blew up');
+        }
+      },
+      onExit: () => {},
+    });
+    const stdio = (spawnMock.mock.calls[0][2] as { stdio: number[] }).stdio;
+    const capturePath = readdirSync(tmpdir())
+      .filter((f) => f.startsWith('civitai-test-run-'))
+      .map((f) => resolve(tmpdir(), f));
+    writeSync(stdio[1], 'boom one\nboom two\n');
+
+    expect(() => handle.dispose()).toThrow(/log consumer blew up/);
+
+    expect(seen).toBeGreaterThan(0);
+    // Released despite the throw: the descriptor is closed and the file is gone.
+    expect(() => writeSync(stdio[1], 'x')).toThrow();
+    for (const p of capturePath) expect(existsSync(p)).toBe(false);
+  });
+
+  /**
+   * The same hazard on the path every healthy run takes.
+   *
+   * `finish()` and `dispose()` have the identical clearInterval -> drain -> close shape, and the
+   * previous round pinned only `dispose()` — the RARER of the two. `finish()` runs on every
+   * normal child exit, so a stray interval there is the common case, not the edge case.
+   */
+  it('stops the tail on a normal exit too, not just on dispose', () => {
+    vi.useFakeTimers();
+    const foreign = resolve(tmpdir(), `civitai-fd-probe-${process.pid}-${Date.now()}-exit.log`);
+    const foreignFds: number[] = [];
+    try {
+      const child = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn() });
+      spawnMock.mockReturnValue(child);
+
+      const messages: string[] = [];
+      defaultStartRun({
+        worktree: repoRoot,
+        args: [],
+        onLog: (_level: string, message: string) => messages.push(message),
+        onExit: () => {},
+      });
+      const stdio = (spawnMock.mock.calls[0][2] as { stdio: number[] }).stdio;
+
+      child.emit('exit', 0);
+      const before = messages.length;
+
+      writeFileSync(foreign, 'FOREIGN-SECRET\n'.repeat(500));
+      foreignFds.push(openSync(foreign, 'r'), openSync(foreign, 'r'));
+      expect(foreignFds).toContain(stdio[1]);
 
       vi.advanceTimersByTime(1000);
 

--- a/scripts/__tests__/dev-server-test-queue-capture.test.ts
+++ b/scripts/__tests__/dev-server-test-queue-capture.test.ts
@@ -87,6 +87,35 @@ describe('a run that exits without flushing still has all of its output', () => 
     const { path } = await capture(10);
     expect(existsSync(path)).toBe(false);
   }, 30_000);
+
+  /**
+   * A carry buffer fixes a torn LINE and does nothing for a torn CHARACTER. Decoding each read
+   * independently turned a 3-byte `⎯` starting at byte 65535 into THREE U+FFFD, with the original
+   * gone — and vitest builds its failure output from `⎯`/`✓`/`×`/`❯`, with one boundary every
+   * 64 KiB. The straddle case below is ASCII and structurally cannot see this.
+   */
+  it('does not corrupt a multi-byte character split across the read window', () => {
+    const lines: string[] = [];
+    const cap = createOutputCapture((line: string) => lines.push(line));
+    try {
+      const READ_WINDOW = 64 * 1024;
+      // Pad so the 3-byte U+23AF begins one byte before the window ends, splitting it 1 + 2.
+      const pad = Buffer.alloc(READ_WINDOW - 1, 0x61); // 'a'
+      writeSync(cap.writeFd, pad);
+      writeSync(cap.writeFd, Buffer.from('⎯MARKER\n', 'utf8'));
+
+      cap.drain(true);
+
+      const marked = lines.filter((l) => l.includes('MARKER'));
+      expect(marked).toHaveLength(1);
+      expect(marked[0].endsWith('⎯MARKER')).toBe(true);
+      // The control: no replacement character anywhere. Without the decoder this line carries
+      // three of them in place of the `⎯`.
+      expect(marked[0]).not.toContain('�');
+    } finally {
+      cap.close();
+    }
+  });
 });
 
 /**
@@ -114,8 +143,10 @@ describe('a line that straddles a read boundary survives whole', () => {
       const found = lines.filter((l) => l.includes('STRADDLE'));
       expect(found).toHaveLength(1);
       expect(found[0]).toBe(straddler);
-      // The positive control: the write really did cross the window, so the assertion above was
-      // exercised rather than passing because everything fit in one read.
+      // The positive control, pinned from both sides. `> READ_WINDOW` alone is also satisfied if
+      // the padding ALREADY exceeded the window, which would put the line wholly inside the
+      // second read and never exercise the hazard.
+      expect(padding.length).toBeLessThan(READ_WINDOW);
       expect(padding.length + straddler.length).toBeGreaterThan(READ_WINDOW);
     } finally {
       cap.close();
@@ -163,6 +194,60 @@ describe('the queue hands its child the capture file, not a pipe', () => {
     expect(stdio[2]).toBe(stdio[1]);
 
     child.emit('exit', 0);
+  });
+
+  it('records lines at the level the trade-off claims, not a stream it cannot know', () => {
+    const child = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn() });
+    spawnMock.mockReturnValue(child);
+
+    const levels: string[] = [];
+    const handle = defaultStartRun({
+      worktree: repoRoot,
+      args: [],
+      onLog: (level: string) => levels.push(level),
+      onExit: () => {},
+    });
+    const stdio = (spawnMock.mock.calls[0][2] as { stdio: number[] }).stdio;
+    writeSync(stdio[1], 'a line\n');
+    child.emit('exit', 0);
+    handle.dispose();
+
+    // One file cannot tell stdout from stderr, so claiming either would be a false label in
+    // stored data. `info` is the queue's own preamble line; captured output is `output`.
+    expect(levels.filter((l) => l !== 'info')).toEqual(['output']);
+  });
+
+  /**
+   * The capture has to be releasable WITHOUT an exit, because two live paths never produce one:
+   * the sweep's force-release past the kill grace — the wedge this queue exists to prevent — and
+   * daemon shutdown. Both dropped the queue's last reference while the interval, both descriptors
+   * and an unbounded /tmp file stayed alive in the closure.
+   */
+  it('releases the capture when the child never exits', () => {
+    const child = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn() });
+    spawnMock.mockReturnValue(child);
+
+    let exits = 0;
+    const handle = defaultStartRun({
+      worktree: repoRoot,
+      args: [],
+      onLog: () => {},
+      onExit: () => (exits += 1),
+    });
+    const stdio = (spawnMock.mock.calls[0][2] as { stdio: number[] }).stdio;
+
+    handle.dispose();
+
+    // The descriptor is closed, so a write to it now throws — that is the observable proof the
+    // fds were released, rather than a claim that dispose() was called.
+    expect(() => writeSync(stdio[1], 'x')).toThrow();
+    // The caller has already settled the run; disposing must not settle it a second time.
+    expect(exits).toBe(0);
+    // Idempotent — shutdown may dispose a handle the sweep already did.
+    expect(() => handle.dispose()).not.toThrow();
+    // And a late exit after disposal cannot re-enter finish().
+    child.emit('exit', 0);
+    expect(exits).toBe(0);
   });
 
   /**

--- a/scripts/__tests__/dev-server-test-queue-capture.test.ts
+++ b/scripts/__tests__/dev-server-test-queue-capture.test.ts
@@ -414,8 +414,13 @@ describe('the queue hands its child the capture file, not a pipe', () => {
       onExit: () => {},
     });
     const stdio = (spawnMock.mock.calls[0][2] as { stdio: number[] }).stdio;
+    // Scoped to THIS process. The prefix alone matches every capture in /tmp, including one the
+    // operator's own daemon creates whenever it runs a queued test — so the unscoped form asserts
+    // that a file it does not own has been deleted, and goes red with no defect present. Measured:
+    // a single foreign file made the unmutated test fail, and made three mutants report a false
+    // KILLED. The filename carries the owning pid precisely so this can be scoped.
     const capturePath = readdirSync(tmpdir())
-      .filter((f) => f.startsWith('civitai-test-run-'))
+      .filter((f) => f.startsWith(`civitai-test-run-${process.pid}-`))
       .map((f) => resolve(tmpdir(), f));
     writeSync(stdio[1], 'boom one\nboom two\n');
 
@@ -425,6 +430,43 @@ describe('the queue hands its child the capture file, not a pipe', () => {
     // Released despite the throw: the descriptor is closed and the file is gone.
     expect(() => writeSync(stdio[1], 'x')).toThrow();
     for (const p of capturePath) expect(existsSync(p)).toBe(false);
+  });
+
+  /**
+   * The same release guarantee on the path every healthy run takes.
+   *
+   * `finish()` and `dispose()` have the identical drain-then-close shape, and the first version of
+   * the throwing-consumer test drove only `dispose()`. Reverting `finish()`'s try/finally survived
+   * the entire suite — the headline change of its own round, untested, on the common path.
+   */
+  it('releases the descriptors on a normal exit even when the log consumer throws', () => {
+    const child = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn() });
+    spawnMock.mockReturnValue(child);
+
+    let seen = 0;
+    defaultStartRun({
+      worktree: repoRoot,
+      args: [],
+      onLog: (_level: string, message: string) => {
+        if (message.startsWith('boom')) {
+          seen += 1;
+          throw new Error('log consumer blew up');
+        }
+      },
+      onExit: () => {},
+    });
+    const stdio = (spawnMock.mock.calls[0][2] as { stdio: number[] }).stdio;
+    const mine = readdirSync(tmpdir())
+      .filter((f) => f.startsWith(`civitai-test-run-${process.pid}-`))
+      .map((f) => resolve(tmpdir(), f));
+    writeSync(stdio[1], 'boom one\nboom two\n');
+
+    // The real exit path, not dispose().
+    expect(() => child.emit('exit', 0)).toThrow(/log consumer blew up/);
+
+    expect(seen).toBeGreaterThan(0);
+    expect(() => writeSync(stdio[1], 'x')).toThrow();
+    for (const f of mine) expect(existsSync(f)).toBe(false);
   });
 
   /**

--- a/scripts/__tests__/dev-server-test-queue-capture.test.ts
+++ b/scripts/__tests__/dev-server-test-queue-capture.test.ts
@@ -422,6 +422,10 @@ describe('the queue hands its child the capture file, not a pipe', () => {
     const capturePath = readdirSync(tmpdir())
       .filter((f) => f.startsWith(`civitai-test-run-${process.pid}-`))
       .map((f) => resolve(tmpdir(), f));
+    // The positive control for the scope above. An empty list makes every deletion assertion
+    // below a no-op loop that passes trivially — so if the filename format ever changes, this
+    // fails loudly instead of the suite quietly protecting nothing. Measured at exactly 1.
+    expect(capturePath).toHaveLength(1);
     writeSync(stdio[1], 'boom one\nboom two\n');
 
     expect(() => handle.dispose()).toThrow(/log consumer blew up/);
@@ -459,6 +463,8 @@ describe('the queue hands its child the capture file, not a pipe', () => {
     const mine = readdirSync(tmpdir())
       .filter((f) => f.startsWith(`civitai-test-run-${process.pid}-`))
       .map((f) => resolve(tmpdir(), f));
+    // Same positive control as above: an empty list would make the loop below vacuous.
+    expect(mine).toHaveLength(1);
     writeSync(stdio[1], 'boom one\nboom two\n');
 
     // The real exit path, not dispose().

--- a/scripts/__tests__/dev-server-test-queue-spawn.test.ts
+++ b/scripts/__tests__/dev-server-test-queue-spawn.test.ts
@@ -35,12 +35,16 @@ describe('the queued run does not re-enter the queue', () => {
    * agents it takes, because each logical run then occupies two slots.
    */
   it('disables the queue flag for the process it spawns', () => {
-    defaultStartRun({
+    // Disposed, because a run now owns a capture file, two descriptors and a tail interval, and
+    // the fake child below never emits 'exit'. Without this, every `pnpm test:unit` left two
+    // files in /tmp forever — measured at 15 stale files before it was noticed.
+    const handle = defaultStartRun({
       worktree: '/repo',
       args: [],
       onLog: () => undefined,
       onExit: () => undefined,
     });
+    handle.dispose();
 
     const env = (spawn.mock.calls[0][2] as { env: Record<string, string> }).env;
     expect(env.CIVITAI_TEST_QUEUE).toBe('0');
@@ -51,12 +55,13 @@ describe('the queued run does not re-enter the queue', () => {
   it('passes the rest of the environment through', () => {
     process.env.CIVITAI_TEST_QUEUE_PROBE = 'kept';
 
-    defaultStartRun({
+    const handle = defaultStartRun({
       worktree: '/repo',
       args: [],
       onLog: () => undefined,
       onExit: () => undefined,
     });
+    handle.dispose();
 
     const env = (spawn.mock.calls[0][2] as { env: Record<string, string> }).env;
     expect(env.CIVITAI_TEST_QUEUE_PROBE).toBe('kept');

--- a/scripts/__tests__/dev-server-test-queue.test.ts
+++ b/scripts/__tests__/dev-server-test-queue.test.ts
@@ -207,6 +207,66 @@ describe('dev-server test queue', () => {
     expect(queue.get(next.id).status).toBe('running');
   });
 
+  /**
+   * The two paths where a run's own 'exit' never arrives are exactly the two that must still
+   * release what the run owns. A real handle owns a capture file, two descriptors and a tail
+   * interval, and `finish` is bound to that 'exit' — so dropping `run.handle` here without a
+   * dispose left all three alive forever. Measured before the fix, on a forced run: 2 fds still
+   * open and the log still growing 2s after the run was reported terminal (logIndex 75 -> 471),
+   * the file at 102,465 bytes and never unlinked.
+   *
+   * Asserted on the QUEUE rather than on the handle: a `dispose()` that exists and is never
+   * called is exactly the shape this missed the first time.
+   */
+  it('disposes a handle whose process never exits, on both release paths', () => {
+    const disposals: string[] = [];
+    const stubborn = (tag: string) => (): FakeRun => {
+      const handle = new EventEmitter() as FakeRun & { dispose: () => void };
+      handle.kill = vi.fn();
+      handle.finish = () => {};
+      handle.worktree = '/wt';
+      handle.dispose = vi.fn(() => disposals.push(tag));
+      runner.started.push(handle);
+      return handle;
+    };
+
+    // Path 1 — the sweep's force-release past the kill grace.
+    const queue = build({ killGraceMs: 5_000 });
+    runner.startRun = stubborn('forced');
+    const stuck = queue.request({ worktree: '/wt/a' });
+    now += 60_001;
+    queue.sweep();
+    now += 5_000;
+    expect(queue.sweep().forced).toEqual([stuck.id]);
+    expect(disposals).toEqual(['forced']);
+
+    // Path 2 — daemon shutdown, which exits the process immediately afterwards.
+    const queue2 = build();
+    runner.startRun = stubborn('shutdown');
+    queue2.request({ worktree: '/wt/b' });
+    queue2.shutdown();
+    expect(disposals).toEqual(['forced', 'shutdown']);
+  });
+
+  // A runner that predates `dispose` must not crash the sweep — the queue calls it optionally.
+  it('tolerates a handle with no dispose', () => {
+    const queue = build({ killGraceMs: 5_000 });
+    runner.startRun = ({ worktree }: RunnerArgs): FakeRun => {
+      const handle = new EventEmitter() as FakeRun;
+      handle.kill = vi.fn();
+      handle.finish = () => {};
+      handle.worktree = worktree;
+      runner.started.push(handle);
+      return handle;
+    };
+    const stuck = queue.request({ worktree: '/wt/a' });
+    now += 60_001;
+    queue.sweep();
+    now += 5_000;
+    expect(() => queue.sweep()).not.toThrow();
+    expect(queue.get(stuck.id).status).toBe('timeout');
+  });
+
   it('does not settle a forced run twice when its exit finally arrives', () => {
     const queue = build({ killGraceMs: 5_000 });
     const stuck = queue.request({ worktree: '/wt/a' });

--- a/scripts/__tests__/dev-server-test-queue.test.ts
+++ b/scripts/__tests__/dev-server-test-queue.test.ts
@@ -248,6 +248,48 @@ describe('dev-server test queue', () => {
     expect(disposals).toEqual(['forced', 'shutdown']);
   });
 
+  /**
+   * The regression the dispose itself introduced, and the reason a spy-only fake could not see it.
+   *
+   * `dispose()` and `finish()` share one `finished` flag, so disposing DISABLES the child's exit
+   * callback. `shutdown()` disposed and settled nothing, so the run stayed `running` forever and
+   * `running.size` never dropped — `pump()` could never start another run. That is the wedge this
+   * queue exists to prevent, reintroduced by the fix for a leak.
+   *
+   * The fake below carries the real interaction — a shared flag whose `dispose` suppresses the
+   * later exit — because a `vi.fn()` that only records the call cannot express it.
+   */
+  it('settles a run it shuts down, even though disposing suppresses the exit callback', () => {
+    const queue = build();
+    runner.startRun = ({ worktree, onExit }: RunnerArgs): FakeRun => {
+      const handle = new EventEmitter() as FakeRun & { dispose: () => void };
+      let done = false;
+      handle.kill = vi.fn();
+      // The shape of the real handle: dispose and exit share one latch.
+      handle.dispose = () => {
+        done = true;
+      };
+      handle.finish = (code: number) => {
+        if (done) return;
+        done = true;
+        onExit?.(code);
+      };
+      handle.worktree = worktree;
+      runner.started.push(handle);
+      return handle;
+    };
+
+    const run = queue.request({ worktree: '/wt/a' });
+    queue.shutdown();
+    // The SIGKILLed child's exit arrives after the dispose and is swallowed — as it is in reality.
+    runner.started[0].finish(-1);
+
+    expect(queue.get(run.id).status).toBe('cancelled');
+    expect(queue.get(run.id).error).toMatch(/daemon-shutdown/);
+    // The slot, which is the thing that actually wedges: it must be free.
+    expect(queue.running.size).toBe(0);
+  });
+
   // A runner that predates `dispose` must not crash the sweep — the queue calls it optionally.
   it('tolerates a handle with no dispose', () => {
     const queue = build({ killGraceMs: 5_000 });

--- a/scripts/__tests__/dev-server-test-queue.test.ts
+++ b/scripts/__tests__/dev-server-test-queue.test.ts
@@ -332,6 +332,12 @@ describe('dev-server test queue', () => {
     // wrong terminal status — a shutdown reported as a timeout, or the reverse — which is the
     // shape of assertion that lets a real mix-up through.
     expect(queue.get(run.id).status).toBe(expected);
+    // And it must SAY so. Swallowing this silently hides a clipped log behind `logsDropped: 0`,
+    // which is the one outcome the queue's log contract rules out — and nothing asserted the line
+    // existed, so both call sites could revert to a silent catch with the suite still green.
+    expect(queue.logs(run.id).map((l: { message: string }) => l.message)).toContainEqual(
+      expect.stringContaining('capture release failed: capture release blew up')
+    );
   });
 
   // A runner that predates `dispose` must not crash the sweep — the queue calls it optionally.

--- a/scripts/__tests__/dev-server-test-queue.test.ts
+++ b/scripts/__tests__/dev-server-test-queue.test.ts
@@ -290,6 +290,46 @@ describe('dev-server test queue', () => {
     expect(queue.running.size).toBe(0);
   });
 
+  /**
+   * Releasing the SLOT matters more than releasing the file descriptors.
+   *
+   * `dispose()` does real IO and calls back into `onLog`, and it sits above the detach/release/
+   * settle that free the slot. Unguarded, a throw there skips all three and the queue is wedged —
+   * the identical failure the settle was added to fix. It also aborts the loop, leaving every
+   * remaining run unkilled.
+   */
+  it.each([
+    ['shutdown', (q: ReturnType<typeof build>) => q.shutdown()],
+    [
+      'the sweep force-release',
+      (q: ReturnType<typeof build>) => {
+        now += 60_001;
+        q.sweep();
+        now += 5_000;
+        q.sweep();
+      },
+    ],
+  ])('frees the slot on %s even when dispose throws', (_name, act) => {
+    const queue = build({ killGraceMs: 5_000 });
+    runner.startRun = ({ worktree }: RunnerArgs): FakeRun => {
+      const handle = new EventEmitter() as FakeRun & { dispose: () => void };
+      handle.kill = vi.fn();
+      handle.finish = () => {};
+      handle.dispose = () => {
+        throw new Error('capture release blew up');
+      };
+      handle.worktree = worktree;
+      runner.started.push(handle);
+      return handle;
+    };
+
+    const run = queue.request({ worktree: '/wt/a' });
+    expect(() => act(queue)).not.toThrow();
+
+    expect(queue.running.size).toBe(0);
+    expect(['cancelled', 'timeout']).toContain(queue.get(run.id).status);
+  });
+
   // A runner that predates `dispose` must not crash the sweep — the queue calls it optionally.
   it('tolerates a handle with no dispose', () => {
     const queue = build({ killGraceMs: 5_000 });

--- a/scripts/__tests__/dev-server-test-queue.test.ts
+++ b/scripts/__tests__/dev-server-test-queue.test.ts
@@ -299,7 +299,7 @@ describe('dev-server test queue', () => {
    * remaining run unkilled.
    */
   it.each([
-    ['shutdown', (q: ReturnType<typeof build>) => q.shutdown()],
+    ['shutdown', (q: ReturnType<typeof build>) => q.shutdown(), 'cancelled'],
     [
       'the sweep force-release',
       (q: ReturnType<typeof build>) => {
@@ -308,8 +308,9 @@ describe('dev-server test queue', () => {
         now += 5_000;
         q.sweep();
       },
+      'timeout',
     ],
-  ])('frees the slot on %s even when dispose throws', (_name, act) => {
+  ])('frees the slot on %s even when dispose throws', (_name, act, expected) => {
     const queue = build({ killGraceMs: 5_000 });
     runner.startRun = ({ worktree }: RunnerArgs): FakeRun => {
       const handle = new EventEmitter() as FakeRun & { dispose: () => void };
@@ -327,7 +328,10 @@ describe('dev-server test queue', () => {
     expect(() => act(queue)).not.toThrow();
 
     expect(queue.running.size).toBe(0);
-    expect(['cancelled', 'timeout']).toContain(queue.get(run.id).status);
+    // The exact status for THIS path, not either-of. `toContain` over both would pass with the
+    // wrong terminal status — a shutdown reported as a timeout, or the reverse — which is the
+    // shape of assertion that lets a real mix-up through.
+    expect(queue.get(run.id).status).toBe(expected);
   });
 
   // A runner that predates `dispose` must not crash the sweep — the queue calls it optionally.


### PR DESCRIPTION
A queued test run's output was captured through a **pipe**. Node makes a child's stdout synchronous when it refers to a regular file and **asynchronous when it refers to a pipe**, so a child that calls `process.exit()` discards whatever is still queued — before the parent ever receives it.

## The measurement that picked the fix

Head-to-head: the **same child**, in the same process, through the old mechanism and the new one. Two separate runs would not be a comparison.

```
consumer=slow  PIPES received= 172 missing=4828  |  FILE received=5000 missing=0
consumer=slow  PIPES received= 172 missing=4828  |  FILE received=5000 missing=0
consumer=slow  PIPES received= 172 missing=4828  |  FILE received=5000 missing=0
consumer=fast  PIPES received=1473 missing=3527  |  FILE received=5000 missing=0
consumer=fast  PIPES received=5000 missing=   0  |  FILE received=5000 missing=0
consumer=fast  PIPES received=5000 missing=   0  |  FILE received=5000 missing=0
```

The lines are **numbered**, which is what makes this readable: a bare count cannot tell truncation from sampling, and here every missing line is a **contiguous tail** — that is what identifies the mechanism rather than just confirming loss.

It also **ruled out both fixes the ticket proposed**:

- *"the daemon detects a short read on child exit"* — it cannot. The daemon sees a clean EOF and has no signal to compare against, because the bytes never reached the pipe.
- *"flush child stdout before exit"* — not ours to call. The child is vitest.

A file needs no cooperation from the thing losing the data.

## A second, independent defect on the same path

With **every byte delivered**, the reader still corrupted the log. `d.toString().split('\n')` per chunk, with no carry buffer, tore any line straddling a read boundary into two and recorded **both halves as lines**: 5,000 in → 4,998 recognised, 6 fragments invented, 353,893 of 353,893 bytes. `logsDropped` reports 0 for this, correctly — which is exactly what made it invisible behind a counter readers had been trained to trust.

## A third thing, in neither ticket

The final drain now runs **before** `onExit`. A waiter wakes on the run's terminal status and *then* reads the log, so reporting the exit while lines are still unread yields a complete-*looking* log that is still filling — the same false green, reached a different way. The old path could do this, because `'exit'` does not wait for pending `'data'`.

## Trade-off, stated rather than buried

One file for both streams, so the interleaving a reader depends on is the real one. The cost: stdout and stderr are no longer distinguishable. Lines are therefore recorded as `output` rather than claiming to be one or the other — nothing renders the level for a test run (both consumers print `entry.message`), and a label we cannot support is worse than an honest one.

## Verification

Seven mutants, each applied alone, tree `cmp`-verified between each:

| mutant | killed by |
|---|---|
| carry buffer removed | the straddle case (+2 more) |
| final flush removed | the trailing-line case |
| back to pipes | both seam cases |
| `onExit` before the drain | the ordering case |
| drain reads a single chunk | the 5,000-line case + straddle |
| stderr to a different fd | the shared-descriptor case |
| capture file not deleted | the cleanup case |

All killed. The ordering mutant is killed **only** by the ordering test, which is why that test exists — the capture can be perfect and the queue can still report the exit too early.

`scripts/__tests__` — **344 passed** (15 files). `pnpm typecheck` — 0 errors. New test file prettier-clean.

**Not verified:** Windows. The mechanism is `stdio` fds and `fs.readSync`, neither platform-specific, and the queue already routes through a shell there — but that is a design claim, not a measurement.

Closes ClickUp 868ktwgyc and 868kubfd9.
