### PR TITLE
fix(tests): the ModelFileHash writer ledger counted a COMMENTED-OUT statement, and it has trunk red

### DIFF
--- a/src/server/services/__tests__/model-file-hash-writers.test.ts
+++ b/src/server/services/__tests__/model-file-hash-writers.test.ts
@@ -66,6 +66,25 @@ const WRITE_PATTERNS: Array<[kind: string, re: RegExp]> = [
   ],
 ];
 
+/**
+ * A commented-out statement is not a writer.
+ *
+ * `--` and block comments make "the token is present" and "the clause is LIVE" different facts,
+ * and this ledger only cares about the second. Migration
+ * `20260819000000_model_file_hash_sha256_12` documents its backfill as commented SQL — its only
+ * live statement is an `ALTER TYPE` — and matching that text put a sixth "writer" in the
+ * enumeration that writes nothing. It made trunk red for every PR until someone either declared a
+ * non-writer in the ledger or deleted the documentation, and both would have been wrong.
+ *
+ * Scoped to `.sql` deliberately. The same argument applies to a commented-out `.ts` writer, but
+ * stripping there could only ever SHRINK the enumeration, which is the direction this ledger is
+ * also meant to catch — so that half needs its own evidence, not a drive-by.
+ */
+export function stripSqlComments(source: string, ext: string): string {
+  if (ext !== '.sql') return source;
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ');
+}
+
 const isTestFile = (relPath: string) =>
   relPath.includes('__tests__') || /\.(test|spec)\.[cm]?[jt]sx?$/.test(relPath);
 
@@ -97,7 +116,7 @@ function enumerateWriters(): string[] {
   for (const file of files) {
     const rel = path.relative(REPO_ROOT, file);
     if (isTestFile(rel)) continue;
-    const source = fs.readFileSync(file, 'utf8');
+    const source = stripSqlComments(fs.readFileSync(file, 'utf8'), path.extname(file));
     if (!source.includes('odelFileHash')) continue; // cheap prefilter, case-insensitive on the M
     for (const [, re] of WRITE_PATTERNS) {
       re.lastIndex = 0;


### PR DESCRIPTION
**`Unit tests` is red on `main`, and every open PR inherits it.** 1 failed / 19,457 passed. Measured rather than inferred: the same test fails at `9c373dfb4e` with no other commit applied, in the same tree.

## The sixth "writer" writes nothing

`ModelFileHash writer ledger > matches the writers actually present in the source tree` enumerates writes to `ModelFileHash` and compares against a declared ledger. It found six; five are declared.

The sixth is migration `20260819000000_model_file_hash_sha256_12`, which documents the backfill other environments still need as **commented SQL**. Its only live statement is the enum add:

```
$ grep -vE '^\s*--|^\s*$' migration.sql
ALTER TYPE "ModelHashType" ADD VALUE IF NOT EXISTS 'SHA256_12';
```

Every `INSERT INTO "ModelFileHash"` in the file is behind `--`. The enumeration matched documentation.

`--` and `/* */` make *"the token is present"* and *"the clause is LIVE"* different facts, and this ledger only cares about the second.

## What I deliberately did not do

**Add the migration to `WRITER_LEDGER`.** The `normalizes` field is a decision a maintainer makes about a real writer, and recording a non-writer there is a false declaration that would outlive the inconvenience that motivated it. Deleting the documentation to satisfy a scanner would be worse — that comment is the only record of a backfill that has been applied to production but never committed.

## Scope

`.sql` only, on purpose. The same argument applies to a commented-out `.ts` writer, but stripping comments there could only ever **shrink** the enumeration — the direction this ledger also exists to catch — so that half needs its own evidence rather than riding along with an unblock.

## The guard still fires

Loosening a matcher is precisely when a guard quietly stops testing anything, so this is measured in both directions, by planting a probe migration under a scanned root:

| planted in a scanned `.sql` | result |
|---|---|
| live `INSERT INTO "ModelFileHash" (...) VALUES (...)` | **1 failed** / 4 passed — still fires |
| the same statement behind `--` and `/* */` | 5 passed — false positive gone |

The first row is the one that matters. A guard that cannot go red is testing nothing.

Probe removed afterwards; tree clean.
