### PR TITLE
fix(tests): ModelFileHash writer ledger counted a commented-out INSERT as a writer

### DIFF
--- a/src/server/services/__tests__/model-file-hash-writers.test.ts
+++ b/src/server/services/__tests__/model-file-hash-writers.test.ts
@@ -16,7 +16,11 @@ import { describe, it, expect } from 'vitest';
  *   1. The ledger below is compared against a fresh enumeration of the source tree. It fails when
  *      the writer set GROWS (a new writer must declare whether it normalizes) or SHRINKS (a
  *      writer was removed and the ledger — and the doc comment on normalizeScanHashes — is now
- *      lying about the surface).
+ *      lying about the surface). The enumeration runs over COMMENT-STRIPPED source, because a
+ *      writer is something that executes: migration 20260819000000 documents the SHA256_12
+ *      backfill for other environments as a commented-out `INSERT INTO "ModelFileHash"`, and
+ *      matching that would force a maintainer to register prose as a writer — which then hides a
+ *      real INSERT later added to that same file behind an entry the ledger already holds.
  *   2. `describe('behaviour')` drives the two normalizing writers for real and asserts the exact
  *      rows they hand the database, against literal expected values. A structural ledger
  *      type-checks past a writer that calls the helper and then ignores its return value.
@@ -97,8 +101,9 @@ function enumerateWriters(): string[] {
   for (const file of files) {
     const rel = path.relative(REPO_ROOT, file);
     if (isTestFile(rel)) continue;
-    const source = fs.readFileSync(file, 'utf8');
-    if (!source.includes('odelFileHash')) continue; // cheap prefilter, case-insensitive on the M
+    const raw = fs.readFileSync(file, 'utf8');
+    if (!raw.includes('odelFileHash')) continue; // cheap prefilter, case-insensitive on the M
+    const source = stripCommentsForFile(rel, raw);
     for (const [, re] of WRITE_PATTERNS) {
       re.lastIndex = 0;
       let match: RegExpExecArray | null;
@@ -153,6 +158,51 @@ function stripComments(source: string): string {
     .join('\n');
 }
 
+/**
+ * SQL comments removed, statements kept. `--` to end of line and `/* … *\/` blocks, but only
+ * outside a quoted literal or identifier — Postgres spells the table `"ModelFileHash"`, and a
+ * string containing `--` must not swallow a real statement that follows it on the same line.
+ *
+ * A `'` inside a comment cannot open a literal, because the comment is consumed before the quote
+ * state is ever touched; `''` (an escaped quote inside a literal) closes and reopens, which nets
+ * out correctly.
+ */
+function stripSqlComments(source: string): string {
+  let out = '';
+  let inSingle = false;
+  let inDouble = false;
+  let i = 0;
+  while (i < source.length) {
+    if (!inSingle && !inDouble && source.startsWith('--', i)) {
+      const nl = source.indexOf('\n', i);
+      if (nl === -1) break;
+      i = nl; // keep the newline so line structure survives
+      continue;
+    }
+    if (!inSingle && !inDouble && source.startsWith('/*', i)) {
+      const end = source.indexOf('*/', i + 2);
+      out += ' '; // a block comment separates tokens; it must not join them
+      i = end === -1 ? source.length : end + 2;
+      continue;
+    }
+    const ch = source[i];
+    if (ch === "'" && !inDouble) inSingle = !inSingle;
+    else if (ch === '"' && !inSingle) inDouble = !inDouble;
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+/**
+ * The enumeration matches on code, so it must strip whatever the file's language calls a comment.
+ * `--` is a comment in SQL and a decrement in TS; `//` is a comment in TS and nothing in SQL.
+ * Using one stripper for both would either miss the prose or eat the code.
+ */
+function stripCommentsForFile(relPath: string, source: string): string {
+  return path.extname(relPath) === '.sql' ? stripSqlComments(source) : stripComments(source);
+}
+
 const LEDGER_ENTRIES = WRITER_LEDGER.flatMap(({ file, writes }) =>
   writes.map((w) => `${file} :: ${w}`)
 ).sort();
@@ -196,6 +246,83 @@ describe('ModelFileHash writer ledger', () => {
       });
       expect(matched, `${label} writer went undetected: ${snippet}`).toBe(true);
     }
+  });
+
+  it('enumerates statements, not a commented-out INSERT in a migration', () => {
+    // The case that made this necessary. Migration 20260819000000 adds the SHA256_12 enum value
+    // and nothing else; the `INSERT INTO "ModelFileHash"` in it is a `--` comment documenting the
+    // backfill for environments that still need it. Registering it would put a non-writer in the
+    // ledger AND make a real INSERT later added to that file invisible, since the entry key is
+    // `<path> :: INSERT INTO "ModelFileHash"` either way.
+    const rel =
+      'packages/civitai-db-schema/prisma/migrations/20260819000000_model_file_hash_sha256_12/migration.sql';
+    const abs = path.join(REPO_ROOT, rel);
+
+    // Three separate claims, because "the test is green" has three very different causes here.
+    // (1) the walk reaches the file at all — otherwise the strip is not what produced the green.
+    const files: string[] = [];
+    for (const root of SCAN_ROOTS) collectFiles(path.join(REPO_ROOT, root), files);
+    expect(files, 'the migration is outside the scanned roots').toContain(abs);
+
+    // (2) the raw file really does carry text the raw-sql matcher fires on…
+    const raw = fs.readFileSync(abs, 'utf8');
+    const rawSql = WRITE_PATTERNS.find(([kind]) => kind === 'raw-sql')![1];
+    rawSql.lastIndex = 0;
+    expect(rawSql.test(raw), 'fixture drift: the migration no longer contains the text').toBe(true);
+
+    // (3) …and stripping comments is what removes it.
+    rawSql.lastIndex = 0;
+    expect(rawSql.test(stripCommentsForFile(rel, raw))).toBe(false);
+    expect(enumerateWriters().filter((e) => e.startsWith(rel))).toEqual([]);
+  });
+
+  it('still sees a real SQL write after stripping (positive control for the strip)', () => {
+    // The dangerous direction: a stripper that eats statements reports a clean ledger while a raw
+    // SQL writer bypasses normalizeScanHashes. Every fixture below is a REAL write that must
+    // survive, paired with the commented form that must not.
+    const rawSql = WRITE_PATTERNS.find(([kind]) => kind === 'raw-sql')![1];
+    const survives = (sql: string) => {
+      rawSql.lastIndex = 0;
+      return rawSql.test(stripSqlComments(sql));
+    };
+
+    expect(survives('INSERT INTO "ModelFileHash" ("fileId", type) VALUES (1, \'SHA256\');')).toBe(
+      true
+    );
+    expect(survives('UPDATE "ModelFileHash" SET hash = \'x\' WHERE "fileId" = 1;')).toBe(true);
+    expect(survives('DELETE FROM "ModelFileHash" WHERE "fileId" = 1;')).toBe(true);
+    // A `--` inside a string literal is not a comment. Without quote tracking this line would be
+    // truncated at the dashes and the write after it would vanish.
+    expect(
+      survives(
+        'SELECT \'a--b\'; INSERT INTO "ModelFileHash" ("fileId", type) VALUES (1, \'SHA256\');'
+      )
+    ).toBe(true);
+    // A block comment SEPARATES tokens, so a write interrupted by one is still a write — the
+    // stripper leaves a space rather than splicing `INSERT` onto `INTO`.
+    expect(survives('INSERT /* note */ INTO "ModelFileHash" ("fileId") VALUES (1);')).toBe(true);
+    expect(survives('/* INSERT INTO "ModelFileHash" ("fileId") VALUES (1); */ SELECT 1;')).toBe(
+      false
+    );
+    expect(survives('--   INSERT INTO "ModelFileHash" ("fileId") VALUES (1);\nSELECT 1;')).toBe(
+      false
+    );
+  });
+
+  it('still sees a real Prisma write after stripping (positive control for the strip)', () => {
+    // Same control on the TS side: `stripCommentsForFile` routes .ts through the JS stripper, so a
+    // commented-out write stops being a phantom ledger entry — without hiding the live call.
+    const prisma = WRITE_PATTERNS.find(([kind]) => kind === 'prisma')![1];
+    const survives = (ts: string) => {
+      prisma.lastIndex = 0;
+      return prisma.test(stripCommentsForFile('x.ts', ts));
+    };
+
+    expect(survives('await dbWrite.modelFileHash.createMany({ data: rows });')).toBe(true);
+    expect(survives('// await dbWrite.modelFileHash.createMany({ data: rows });')).toBe(false);
+    expect(survives('/* await dbWrite.modelFileHash.deleteMany({ where }); */')).toBe(false);
+    // A trailing comment must not take the statement in front of it with it.
+    expect(survives('await dbWrite.modelFileHash.upsert(args); // legacy')).toBe(true);
   });
 
   it('strips comments before looking for the call (control for the check below)', () => {


### PR DESCRIPTION
## The failure

`ModelFileHash writer ledger > matches the writers actually present in the source tree` is red on `main`. Reproduced on a clean worktree at `origin/main` (`4214ecb10b`), before any change:

```
 ❯  unit  src/server/services/__tests__/model-file-hash-writers.test.ts (5 tests | 1 failed)
   × matches the writers actually present in the source tree

AssertionError: expected [ …(6) ] to deeply equal [ …(5) ]

- Expected
+ Received

@@ -1,6 +1,7 @@
  [
+   "packages/civitai-db-schema/prisma/migrations/20260819000000_model_file_hash_sha256_12/migration.sql :: INSERTINTO\"ModelFileHash\"",
    "src/pages/api/mod/reprocess-scan.ts :: modelFileHash.createMany",
    "src/pages/api/mod/reprocess-scan.ts :: modelFileHash.deleteMany",
    "src/server/services/model-file-scan.service.ts :: modelFileHash.createMany",
    "src/server/services/model-file-scan.service.ts :: modelFileHash.deleteMany",
    "src/server/services/orchestrator/orchestrator.service.ts :: modelFileHash.upsert",
```

It arrived with `a3e790ff2e` (*fix(images): resolve LoRAs whose metadata carries a 12-char sha256 prefix*). The guard was working correctly — it saw a sixth thing that matched a write pattern and had not been declared.

## Branch chosen: **(b) — not a writer**

The migration's only executable statement is the enum add:

```
$ grep -v '^\s*--' migration.sql | grep -v '^\s*$'
ALTER TYPE "ModelHashType" ADD VALUE IF NOT EXISTS 'SHA256_12';
```

It writes **zero rows**. The `INSERT INTO "ModelFileHash"` is on line 28, and every line of that block is prefixed `--`:

```
$ grep -n 'INSERT INTO "ModelFileHash"' migration.sql
28:--   INSERT INTO "ModelFileHash" ("fileId", type, hash, "createdAt")
```

It is the migration's own comment documenting the backfill recipe for environments that have not run it — the file says so directly: *"Backfill is NOT run here… this migration only adds the enum value; everything else is application code plus a one-time backfill."*

So the enumerator matched prose. The root cause is that `enumerateWriters()` ran its regexes over raw file bytes, while the sibling check in the very same file (`agrees with each writer file about whether it normalizes`) already strips comments first, for the reason its comment states: *"A guard on a word is walkable by writing the word."* The enumerator had the same defect in the other direction — prose readable as code.

### Why (a) would have been actively harmful

Registering it would not merely have recorded a falsehood. The ledger's entry key is `<path> :: INSERT INTO "ModelFileHash"`. Had that entry existed, a **real** `INSERT INTO "ModelFileHash"` later added to that same migration file would have produced the identical key, matched the entry the ledger already held, and shipped unreviewed. Branch (a) would have converted a correct red check into a permanent blind spot on exactly the file that triggered it.

## The change

`enumerateWriters()` now strips comments before matching, dispatching on file extension. One stripper cannot serve both languages: `--` is a comment in SQL and a decrement in TS; `//` is a comment in TS and nothing in SQL. The SQL stripper tracks quote state, because a `--` inside a string literal is not a comment and must not swallow a statement following it on the same line.

**The matchers, the ledger and its five entries are unchanged.** Nothing was loosened, deleted, or broadened — the guard now matches on statements rather than on statements-or-prose, which is a strictly better definition of "writer".

Three new cases pin the strip in the only direction that can hurt — that it cannot **hide** a real writer:

- The migration case asserts three things separately, because a green here otherwise cannot distinguish *"the strip removed a comment"* from *"the walk never opened the file"*: the walk reaches the file, its raw bytes **do** match the raw-sql pattern, and stripping is what removes them.
- A real uncommented `INSERT` / `UPDATE` / `DELETE` still matches after stripping — including one preceded by a `--` inside a string literal, and one interrupted by a block comment (a block comment separates tokens, so that is still a write).
- A real Prisma write still matches, including one carrying a trailing `//` comment.

## Mutation result — the guard still has teeth

Each mutant plants a writer the ledger does not declare; the ledger case must go red **and name the planted file**.

| Mutant | Expected | Ledger case | Diff names the planted writer |
|---|---|---|---|
| Real, **uncommented** `INSERT INTO "ModelFileHash"` in a new migration | RED | ✅ red | ✅ yes |
| Real Prisma `modelFileHash.createMany` in a new `.ts` | RED | ✅ red | ✅ yes |
| Real Kysely `insertInto('ModelFileHash')` in a new `.ts` | RED | ✅ red | ✅ yes |
| **Commented-out** `INSERT` in a new migration (anti-regression control) | GREEN | ✅ green | — |

The first mutant is the one this change could plausibly have blinded, and it reproduces the original failure shape exactly:

```
FAIL  ModelFileHash writer ledger > matches the writers actually present in the source tree
AssertionError: expected [ …(6) ] to deeply equal [ …(5) ]
+   "packages/civitai-db-schema/prisma/migrations/29990101000000_mutant_sql/migration.sql :: INSERTINTO\"ModelFileHash\"",
```

The last row is what proves the fix is load-bearing rather than cosmetic: a commented INSERT is now green where it was previously red.

## Tests

- `model-file-hash-writers.test.ts` — 8/8 pass (was 4/5).
- Whole `unit` project over `src/server/services`, which covers the entire `model-file-hash*` family plus `model-file-scan.service`, `reprocess-scan-hash-derivation` and `createModelFileScanRequest`: **468 files, 7808 passed, 8 skipped, 0 failed**, no timeout panics.
- `pnpm typecheck` — 0 type errors.
- eslint + prettier clean.

## ⚠️ Separate finding — the documented backfill diverges from `normalizeScanHashes()`

Not fixed here, and deliberately not bundled: this PR does not touch an already-applied migration, and the recipe is inert (a comment). Flagging it because a writer nobody registered is also a writer nobody reviewed.

`normalizeScanHashes()` suppresses `SHA256_12` derivation for an all-zero SHA256, with the reason in its own comment:

```ts
// The scan-request path writes an all-zero SHA256 as a "file unreachable" sentinel. Deriving
// from it would give every such file the same 12-char hash and make them match each other.
const sha256 = out.SHA256;
if (sha256 && !/^0+$/.test(sha256)) out.SHA256_12 = sha256.slice(0, SHA256_12_LENGTH);
```

The backfill recipe in migration 20260819000000 has **no such guard** — it derives from every `type = 'SHA256'` row:

```sql
SELECT src."fileId", 'SHA256_12', LEFT(src.hash::text, 12), NOW()
FROM "ModelFileHash" src
WHERE src.type = 'SHA256' AND …
```

Those sentinel rows are written by `createModelFileScanRequest`'s dev-only skip (`!isProd && !ORCHESTRATOR_ACCESS_TOKEN`) — i.e. they exist precisely in the non-prod environments the comment addresses with *"Any OTHER environment still needs it."* Running it there gives every unreachable file `SHA256_12 = '000000000000'`, which is the collision the helper's guard exists to prevent, on a Stage-2 join that has no type filter.

One clause fixes it, should you want it: `AND src.hash::text !~ '^0+$'`.

(The rest of the recipe checks out: `ON CONFLICT ("fileId", type)` matches the model's `@@id([fileId, type])`, and `LEFT(hash, 12)` matches the helper's `slice(0, 12)`.)
