### PR TITLE
fix(flipt): an entity-scoped evaluation must carry a context, and gate the class

### DIFF
--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -1,0 +1,322 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { OnboardingSteps } from '~/server/common/enums';
+import { buildFliptContext } from '~/server/services/feature-flags.service';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * 🔴 SOURCE GATE + BEHAVIOURAL PAIR — an entity-scoped Flipt evaluation must
+ * carry an evaluation CONTEXT.
+ *
+ * THE DEFECT CLASS. A Flipt segment constraint reads one of two inputs, and
+ * which one is decided by the constraint's TYPE, not by the flag:
+ *
+ * - `ENTITY_ID_COMPARISON_TYPE` matches the `entityId` ARGUMENT.
+ * - `STRING_COMPARISON_TYPE` matches a named property of the CONTEXT argument.
+ *
+ * Measured against flipt-state's `civitai-app/default/features.yaml`: of the 15
+ * segments defined there, 12 are built from `STRING_COMPARISON_TYPE` constraints
+ * — every identity, tier and cohort segment we have (`moderators`, `testers`,
+ * `early-adopters`, `members`, `app-dev-testers`, `license-fee-tester`,
+ * `CreatorProgram`, …). Only three (`is-zach`, `is-koen`, `is-debuggador`) read
+ * the entityId. 65 of the 125 flags carry at least one segment rollout.
+ *
+ * So an evaluation that names a subject in `entityId` and passes NO context can
+ * match `all-users` and the three entityId segments, and nothing else. For every
+ * other segment it returns the flag's base `enabled` value — which is
+ * indistinguishable from an honest "this subject is not in the segment". There
+ * is no error, no log line, and no way to tell the two apart from the outside.
+ *
+ * That is the failure this repo has already paid for twice: once in the feedback
+ * gate (fixed in #4042 by threading `buildFliptContext`) and once in
+ * `resolveTestingAccess`, whose `testers` rollout was structurally unreachable
+ * for every non-moderator (fixed in the commit that adds this file).
+ *
+ * WHY THE RULE IS "entityId ⇒ context" AND NOT "user-keyed ⇒ context". A scan
+ * cannot reliably tell a user-derived entityId from any other: one of the sites
+ * below passes a bare local called `entityId` that happens to hold a user id.
+ * Keying the rule on the presence of the entityId argument needs no such guess —
+ * and it is the honest rule anyway, since an entityId is a claim that the
+ * evaluation is scoped to a subject, and a scoped evaluation with no context can
+ * only see a quarter of the segment vocabulary. A genuinely global evaluation
+ * passes one argument and is not covered here.
+ *
+ * WHAT THIS IS NOT. It is structural. It cannot tell a CORRECT context from a
+ * wrong one — `isFlipt(flag, id, {})` satisfies it. The behavioural claim lives
+ * in the second half of this file (the segment predicates below) and, for the
+ * one call site fixed alongside this gate, in
+ * `generation.service.testing-access-flag-context.test.ts`. This gate exists so
+ * that the population those tests speak for cannot silently grow a member.
+ */
+
+const SRC = path.resolve(__dirname, '../../..');
+
+/** The four evaluation entry points `~/server/flipt/client` exports. */
+const EVAL_FNS = ['isFlipt', 'isFliptSync', 'getFliptBoolean', 'getFliptVariant'] as const;
+
+const SKIP_DIRS = new Set(['node_modules', '__tests__', '__screenshots__']);
+const isTestFile = (name: string) => /\.(test|spec)\.[cm]?[jt]sx?$/.test(name);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(entry) && !isTestFile(entry)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Blank comments out rather than deleting them, so a reported line number still
+ * matches the file on disk. (This file, and `client.ts`, both write example
+ * calls in prose; an unstripped scan would count them as call sites.)
+ */
+const stripComments = (s: string) =>
+  s
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/^[ \t]*\/\/.*$/gm, (m) => ' '.repeat(m.length));
+
+/**
+ * Split the argument list starting at `open` (the index of `(`). Depth-counting
+ * rather than a regex, because two of the real call sites pass a nested call and
+ * one passes an object literal containing a comma.
+ */
+function splitArgs(src: string, open: number): string[] | null {
+  let depth = 0;
+  const parts: string[] = [];
+  let cur = '';
+  for (let i = open; i < src.length; i++) {
+    const c = src[i];
+    if (c === '(' || c === '[' || c === '{') depth++;
+    else if (c === ')' || c === ']' || c === '}') {
+      depth--;
+      if (depth === 0) {
+        parts.push(cur);
+        return parts.map((p) => p.trim()).filter((p, idx) => !(idx === 0 && p === ''));
+      }
+    }
+    if (depth === 1 && c === ',') {
+      parts.push(cur);
+      cur = '';
+      continue;
+    }
+    if (depth >= 1) cur += c;
+  }
+  return null;
+}
+
+type EvalCall = { site: string; fn: string; argc: number };
+
+function scanEvalCalls(): { calls: EvalCall[]; scanned: number } {
+  const calls: EvalCall[] = [];
+  let scanned = 0;
+  for (const file of walk(SRC)) {
+    scanned++;
+    const rel = path.relative(SRC, file).split(path.sep).join('/');
+    const src = stripComments(readFileSync(file, 'utf8'));
+    // `[\w$]+\.` so the module-object form (`_fliptModule.isFliptSync(...)`) in
+    // feature-flags.service is seen; the leading `[^\w.$]` keeps a longer
+    // identifier ending in one of these names out.
+    const re = new RegExp(`(?:^|[^\\w.$])(?:[\\w$]+\\.)?(${EVAL_FNS.join('|')})\\s*\\(`, 'g');
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src))) {
+      const open = src.indexOf('(', m.index + m[0].length - 1);
+      const args = splitArgs(src, open);
+      if (!args) continue;
+      const line = src.slice(0, m.index).split('\n').length;
+      calls.push({ site: `${rel}:${line}`, fn: m[1], argc: args.length });
+    }
+  }
+  return { calls, scanned };
+}
+
+/**
+ * 🔴 HAND-TYPED. Sites that pass an `entityId` and no context, accepted for the
+ * stated reason. Every reason was checked against the flag's definition in
+ * flipt-state, not assumed.
+ *
+ * "No segments today" is a statement about the flag as it stands, NOT a licence:
+ * add one segment rollout to any of these flags and the site below goes silently
+ * wrong. The reason each is here rather than fixed is that the fix is not free —
+ * the four feed sites are on hot list paths where `buildFliptContext` was
+ * deliberately hoisted out of per-flag work, and the dispute helper has a bare
+ * `userId` and no `SessionUser` to build a truthful context from.
+ */
+const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
+  // flag `article-rating-dispute`: enabled=true, 0 rules, 0 rollouts → answers
+  // true for every entity regardless of context. A background auto-resolve path
+  // with only `pending.userId` in hand; building a real context would cost a
+  // user fetch. Revisit the moment this flag gains a rollout.
+  'server/services/article-rating-review.helpers.ts:482':
+    'article-rating-dispute has no segment rollouts; background path with no SessionUser',
+  // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
+  'server/services/image.service.ts:3864':
+    'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
+  // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
+  'server/services/image.service.ts:3994':
+    'feed-image-existence has no segment rollouts; hot feed path',
+  'server/services/image.service.ts:4704':
+    'feed-image-existence has no segment rollouts; hot feed path',
+  'server/services/image.service.ts:5814':
+    'feed-image-existence has no segment rollouts; hot feed path',
+};
+
+describe('flipt evaluation context — source gate', () => {
+  const { calls, scanned } = scanEvalCalls();
+
+  // POSITIVE CONTROLS. Every assertion below compares against this scan, and a
+  // scan wired to nothing returns an empty list — which would make "no new
+  // context-less evaluation" vacuously true. Floors are well under the real
+  // numbers (≈3,800 files, ≈69 calls) so ordinary growth never trips them.
+  it('actually walked the server tree', () => {
+    expect(scanned).toBeGreaterThan(2500);
+  });
+
+  it('actually found Flipt evaluations, of all three argument shapes', () => {
+    expect(calls.length).toBeGreaterThan(40);
+    // Named shapes, not just a total: a scanner that collapsed every call to one
+    // arity would still clear a total-count floor.
+    expect(calls.some((c) => c.argc === 1)).toBe(true);
+    expect(calls.some((c) => c.argc === 2)).toBe(true);
+    expect(calls.some((c) => c.argc >= 3)).toBe(true);
+  });
+
+  it('sees a known contexted site as contexted, and a known bare site as bare', () => {
+    // The pair matters. A detector hardwired to "3 args" would pass the first of
+    // these and fail the second, and vice versa.
+    const bySite = new Map(calls.map((c) => [c.site, c]));
+    expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
+    expect(bySite.get('server/services/image.service.ts:3994')?.argc).toBe(2);
+  });
+
+  it('adds no Flipt evaluation that names an entity but passes no context', () => {
+    const unledgered = calls
+      .filter((c) => c.argc === 2)
+      .map((c) => c.site)
+      .filter((site) => !(site in ENTITY_WITHOUT_CONTEXT_LEDGER))
+      .sort();
+    expect(
+      unledgered,
+      'A Flipt evaluation passes an entityId with no evaluation context. Every identity, ' +
+        'tier and cohort segment in flipt-state is a STRING_COMPARISON_TYPE constraint, ' +
+        'which reads the CONTEXT and never the entityId — so this evaluation cannot match ' +
+        'any of them, and returns the flag default instead. That is indistinguishable from ' +
+        '"the subject is not in the segment". Pass `buildFliptContext(user)`, or the ' +
+        'properties you actually know; if the flag genuinely has no segment rollout, add ' +
+        'the site to ENTITY_WITHOUT_CONTEXT_LEDGER with the reason you checked.'
+    ).toEqual([]);
+  });
+
+  it('keeps the ledger honest — a fixed or moved site must be removed from it', () => {
+    // The direction that gets left out. Without it the ledger silently becomes a
+    // list of line numbers that stopped meaning anything, and the next reviewer
+    // reads five accepted exceptions that are no longer there.
+    const bare = new Set(calls.filter((c) => c.argc === 2).map((c) => c.site));
+    const stale = Object.keys(ENTITY_WITHOUT_CONTEXT_LEDGER)
+      .filter((site) => !bare.has(site))
+      .sort();
+    expect(
+      stale,
+      'A ledgered site no longer passes an entityId without a context — it was fixed, ' +
+        'deleted, or the line moved. Drop or update its row.'
+    ).toEqual([]);
+  });
+});
+
+/**
+ * THE BEHAVIOURAL HALF.
+ *
+ * The gate above is a claim about argument counts. On its own it would be
+ * satisfied by `isFlipt(flag, id, {})`, and it asserts nothing at all about WHY
+ * a context is required. These cases drive the real `buildFliptContext` against
+ * hand-typed transcriptions of the live segments and show the mechanism: the
+ * same subject matches with a context and does not match without one.
+ *
+ * The predicates are transcribed from flipt-state's `features.yaml`, so they can
+ * disagree with the code. Deriving them from `buildFliptContext`'s output would
+ * make them agree with anything.
+ */
+describe('flipt evaluation context — the mechanism the gate exists for', () => {
+  const EARLY_ADOPTER_ID = 8123;
+  const PLAIN_ID = 4471;
+
+  const sessionUser = (over: Partial<SessionUser> = {}): SessionUser =>
+    ({
+      id: PLAIN_ID,
+      isModerator: false,
+      muted: false,
+      onboarding: OnboardingSteps.Buzz,
+      isEarlyAdopter: false,
+      ...over,
+    } as SessionUser);
+
+  /** `early-adopters`: ALL_MATCH over `isEarlyAdopter eq "true"`. */
+  const earlyAdopters = (ctx: Record<string, string>) => ctx.isEarlyAdopter === 'true';
+  /** `moderators`: ALL_MATCH over `isModerator eq "true"`. */
+  const moderators = (ctx: Record<string, string>) => ctx.isModerator === 'true';
+  /** `app-dev-testers`: ANY_MATCH over `userId isoneof [...]`. */
+  const idListed = (ids: string[]) => (ctx: Record<string, string>) => ids.includes(ctx.userId);
+  /** `members`: ANY_MATCH over `isMember eq "true"` OR `isModerator eq "true"`. */
+  const members = (ctx: Record<string, string>) =>
+    ctx.isMember === 'true' || ctx.isModerator === 'true';
+
+  it('an EMPTY context matches none of the live property segments', () => {
+    // This is the whole defect in one line: the entityId is not on offer to any
+    // of these, so a context-less evaluation is a uniform miss.
+    const empty: Record<string, string> = {};
+    expect(earlyAdopters(empty)).toBe(false);
+    expect(moderators(empty)).toBe(false);
+    expect(members(empty)).toBe(false);
+    expect(idListed([String(EARLY_ADOPTER_ID), String(PLAIN_ID)])(empty)).toBe(false);
+  });
+
+  it('buildFliptContext emits the properties those segments read', () => {
+    const ctx = buildFliptContext(sessionUser({ id: EARLY_ADOPTER_ID, isEarlyAdopter: true }));
+    // Hand-typed against the segment constraints, not read back off the helper.
+    expect(ctx.isEarlyAdopter).toBe('true');
+    expect(ctx.userId).toBe(String(EARLY_ADOPTER_ID));
+    expect(ctx.isModerator).toBe('false');
+    expect(ctx.isMember).toBe('false');
+    expect(ctx.isInCreatorProgram).toBe('false');
+    expect(ctx.isLoggedIn).toBe('true');
+    expect(ctx.tier).toBe('free');
+  });
+
+  it('the same subject matches early-adopters WITH a context and misses WITHOUT one', () => {
+    const user = sessionUser({ id: EARLY_ADOPTER_ID, isEarlyAdopter: true });
+    // The only thing that changes between the two arms is whether the context is
+    // handed over — same user, same segment, opposite answers.
+    expect(earlyAdopters(buildFliptContext(user))).toBe(true);
+    expect(earlyAdopters({})).toBe(false);
+  });
+
+  it('a context is not a rubber stamp — a non-member still misses', () => {
+    // The negative control on the case above. Without it, "with a context it
+    // matches" would also be satisfied by a predicate wired to true.
+    expect(earlyAdopters(buildFliptContext(sessionUser({ isEarlyAdopter: false })))).toBe(false);
+    expect(moderators(buildFliptContext(sessionUser({ isModerator: false })))).toBe(false);
+    expect(members(buildFliptContext(sessionUser({ tier: 'free' })))).toBe(false);
+  });
+
+  it('a userId-list segment reads the CONTEXT property, so the entityId cannot serve it', () => {
+    const user = sessionUser({ id: PLAIN_ID });
+    const segment = idListed([String(PLAIN_ID)]);
+    expect(segment(buildFliptContext(user))).toBe(true);
+    // The defect shape: the id was passed, just not where the constraint looks.
+    expect(segment({ isModerator: 'false' })).toBe(false);
+  });
+
+  it('an anonymous context is a real answer, not an empty one', () => {
+    const ctx = buildFliptContext(undefined);
+    expect(ctx.isLoggedIn).toBe('false');
+    expect(ctx.userId).toBeUndefined();
+    expect(earlyAdopters(ctx)).toBe(false);
+  });
+
+  it('a tiered user is a member and a moderator is one too', () => {
+    expect(members(buildFliptContext(sessionUser({ tier: 'bronze' })))).toBe(true);
+    expect(members(buildFliptContext(sessionUser({ isModerator: true })))).toBe(true);
+  });
+});

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -159,6 +159,20 @@ const flipt = createFliptClient({
   },
 });
 
+// 🔴 THE ENTITY-ID TRAP. All four evaluators below take `(flag, entityId?,
+// context?)`, and the two arguments are NOT interchangeable. A Flipt segment
+// constraint reads one of two inputs depending on its TYPE:
+// `ENTITY_ID_COMPARISON_TYPE` matches the `entityId` argument, while
+// `STRING_COMPARISON_TYPE` matches a named property of the `context`. Of the 15
+// segments in flipt-state today, 12 are the latter — including every identity,
+// tier and cohort segment we have (`moderators`, `testers`, `early-adopters`,
+// `members`, `app-dev-testers`, `CreatorProgram`, …).
+//
+// So `isFlipt(FLAG, String(user.id))` cannot match any of those, for anybody.
+// It returns the flag's base `enabled` value instead, which is indistinguishable
+// from an honest "this user is not in the segment" — no error, no log line. Pass
+// `buildFliptContext(user)`, or at minimum the properties you actually know.
+// Enforced by `src/server/flipt/__tests__/flipt-eval-context.test.ts`.
 export const isFlipt = flipt.isEnabled;
 export const getFliptVariant = flipt.getVariant;
 export const getFliptBoolean = flipt.getBoolean;

--- a/src/server/services/generation/__tests__/generation.service.testing-access-flag-context.test.ts
+++ b/src/server/services/generation/__tests__/generation.service.testing-access-flag-context.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+// Type-only, so it is erased and does NOT evaluate the module before the
+// hoisted `vi.mock` below registers its factory. Keep it `import type`.
+import type * as FliptClient from '~/server/flipt/client';
 
 /**
  * THE SEAM: `resolveTestingAccess` decides who is in the `testers` tier of the
@@ -59,7 +62,7 @@ vi.mock('~/server/utils/otel-helpers', () => ({
 
 const { mockIsFlipt } = vi.hoisted(() => ({ mockIsFlipt: vi.fn() }));
 vi.mock('~/server/flipt/client', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/server/flipt/client')>();
+  const actual = await importOriginal<typeof FliptClient>();
   return { ...actual, isFlipt: (...args: unknown[]) => mockIsFlipt(...args) };
 });
 

--- a/src/server/services/generation/__tests__/generation.service.testing-access-flag-context.test.ts
+++ b/src/server/services/generation/__tests__/generation.service.testing-access-flag-context.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * THE SEAM: `resolveTestingAccess` decides who is in the `testers` tier of the
+ * generation gate rules, and it decides it by handing Flipt an evaluation.
+ *
+ * The failure this file exists for is invisible from either side alone. The
+ * function is obviously correct read on its own — it passes the user's id — and
+ * the flag is obviously correct read on its own — it rolls out to `testers`.
+ * They disagree about WHERE the id has to be, and the disagreement produces a
+ * plain `false`, which is exactly what a genuine non-tester produces.
+ *
+ * 🔴 A Flipt segment constraint reads ONE of two inputs, and which one is a
+ * property of the constraint's TYPE, not of the flag:
+ *
+ * - `ENTITY_ID_COMPARISON_TYPE` matches the `entityId` ARGUMENT.
+ * - `STRING_COMPARISON_TYPE` matches a named property of the evaluation CONTEXT.
+ *
+ * The live `testers` segment is `ANY_MATCH_TYPE` over two
+ * `STRING_COMPARISON_TYPE` constraints (`isModerator eq "true"`, `userId isoneof
+ * [...]`). Both read the context. So an evaluation that carries the user's id
+ * ONLY as the entityId cannot match it — for anybody, ever.
+ *
+ * The stubs below encode that segment's real shape rather than the shape the
+ * code happens to send, which is what makes them able to disagree with the code.
+ */
+
+// Collapse the sibling-service graph — `resolveTestingAccess` touches nothing but
+// Flipt, while importing generation.service pulls in DB / search-index / image
+// infra. Mirrors generation.service.generation-disabled-flag.test.ts, MINUS its
+// `~/server/redis/client` factory: that module has a canonical mock registered in
+// `src/__tests__/setup.ts`, and re-declaring it per-file is what
+// `no-direct-shared-module-mock` exists to stop.
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  getDbWithoutLag: vi.fn(),
+  getDbWithoutLagBatch: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/ecosystems/wan.handler', () => ({
+  wanBaseModelGroupIdMap: {},
+}));
+vi.mock('~/server/search-index', () => ({ modelsSearchIndex: {} }));
+vi.mock('~/server/services/common.service', () => ({ hasEntityAccess: vi.fn() }));
+vi.mock('~/server/services/model-file.service', () => ({ getFilesForModelVersionCache: vi.fn() }));
+vi.mock('~/server/redis/resource-data.redis', () => ({ resourceDataCache: {} }));
+vi.mock('~/server/services/model.service', () => ({ getFeaturedModels: vi.fn() }));
+vi.mock('~/server/services/model-version.service', () => ({
+  getLinkedVaeIds: vi.fn(),
+  bustMvCache: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', () => ({ imagesForModelVersionsCache: {} }));
+vi.mock('~/server/services/generation/version-generation-state.service', () => ({
+  getVisibleSystemWildcardSetIdsByVersionId: vi.fn(),
+}));
+vi.mock('~/server/utils/otel-helpers', () => ({
+  withSpan: (_name: string, fn: () => unknown) => fn(),
+}));
+
+const { mockIsFlipt } = vi.hoisted(() => ({ mockIsFlipt: vi.fn() }));
+vi.mock('~/server/flipt/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/flipt/client')>();
+  return { ...actual, isFlipt: (...args: unknown[]) => mockIsFlipt(...args) };
+});
+
+const { resolveTestingAccess } = await import('~/server/services/generation/generation.service');
+
+/**
+ * A userId on the live `testers` list, and one that is not.
+ *
+ * 🔴 Deliberately NOT the ids the flag actually carries. If the fixture used a
+ * real entry, a mutant that hardcoded that literal would survive. These two are
+ * pairwise distinct from each other and from every constant the code names.
+ */
+const TESTER_ID = 5150;
+const OUTSIDER_ID = 90210;
+
+/**
+ * The live `testers` segment, transcribed from flipt-state:
+ * ANY_MATCH over `isModerator eq "true"` OR `userId isoneof [...]`, both
+ * STRING_COMPARISON_TYPE — i.e. both read the CONTEXT.
+ *
+ * Note what it does NOT look at: the `entityId` argument. That omission is the
+ * whole point, and it is why this stub can fail code that "passes the user id".
+ */
+const testersSegment = async (_flag: string, _entityId: string, context?: Record<string, string>) =>
+  context?.isModerator === 'true' || context?.userId === String(TESTER_ID);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsFlipt.mockImplementation(testersSegment);
+});
+
+const evalCalls = () =>
+  mockIsFlipt.mock.calls as [string, string, Record<string, string> | undefined][];
+
+describe('resolveTestingAccess evaluates generation-testing against the testers segment', () => {
+  it('lets a listed tester through', async () => {
+    await expect(resolveTestingAccess({ id: TESTER_ID, isModerator: false })).resolves.toBe(true);
+  });
+
+  it('keeps a non-tester out', async () => {
+    await expect(resolveTestingAccess({ id: OUTSIDER_ID, isModerator: false })).resolves.toBe(
+      false
+    );
+  });
+
+  it('puts the user id in the CONTEXT, not only in the entityId argument', async () => {
+    await resolveTestingAccess({ id: TESTER_ID, isModerator: false });
+
+    expect(evalCalls()).toHaveLength(1);
+    const [flag, entityId, context] = evalCalls()[0];
+    // The hand-typed contract with flipt-state's features.yaml.
+    expect(flag).toBe('generation-testing');
+    expect(entityId).toBe(String(TESTER_ID));
+    // 🔴 The load-bearing assertion. `entityId` above being right is precisely
+    // what made the defect look fine; only the context property is read by a
+    // STRING_COMPARISON_TYPE constraint.
+    expect(context?.userId).toBe(String(TESTER_ID));
+  });
+
+  it('still reports isModerator=false for a non-moderator, so the mods arm is not spoofed', async () => {
+    // The function answers `true` for a moderator BEFORE reaching Flipt. If it
+    // also claimed `isModerator: 'true'` here, every non-moderator would match
+    // the segment's first constraint and the tester list would be moot.
+    await resolveTestingAccess({ id: OUTSIDER_ID, isModerator: false });
+    expect(evalCalls()[0][2]?.isModerator).toBe('false');
+  });
+
+  it('does not fabricate a tier, membership or cohort it was never given', async () => {
+    // This caller is handed `{ id, isModerator }`, not a SessionUser. Emitting a
+    // defaulted `tier: 'free'` / `isEarlyAdopter: 'false'` would let a rollout
+    // scoped to either match on a value nobody here knows.
+    await resolveTestingAccess({ id: OUTSIDER_ID, isModerator: false });
+    const context = evalCalls()[0][2] ?? {};
+    expect(Object.keys(context).sort()).toEqual(['isModerator', 'userId']);
+  });
+
+  it('answers true for a moderator without evaluating the flag at all', async () => {
+    await expect(resolveTestingAccess({ id: OUTSIDER_ID, isModerator: true })).resolves.toBe(true);
+    expect(mockIsFlipt).not.toHaveBeenCalled();
+  });
+
+  it('answers false for an anonymous caller without evaluating the flag at all', async () => {
+    await expect(resolveTestingAccess({})).resolves.toBe(false);
+    expect(mockIsFlipt).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * NEGATIVE CONTROL for the stub itself.
+ *
+ * Every assertion above is a claim about what `testersSegment` answers. A stub
+ * that answered `true` unconditionally would make "a listed tester gets through"
+ * pass while proving nothing, and a stub that answered `false` unconditionally
+ * would make "a non-tester is kept out" pass the same way. So drive the stub
+ * directly, with the two shapes that matter.
+ */
+describe('the testers-segment stub reads the context and ignores the entityId', () => {
+  it('matches on a context userId', async () => {
+    await expect(testersSegment('generation-testing', 'ignored', { userId: '5150' })).resolves.toBe(
+      true
+    );
+  });
+
+  it('does NOT match the same id passed only as the entityId — the defect shape', async () => {
+    await expect(
+      testersSegment('generation-testing', String(TESTER_ID), { isModerator: 'false' })
+    ).resolves.toBe(false);
+  });
+});

--- a/src/server/services/generation/generation.service.ts
+++ b/src/server/services/generation/generation.service.ts
@@ -696,6 +696,29 @@ export async function getUnstableResources() {
 /**
  * Whether the user passes the `generation-testing` Flipt flag — the `testers`
  * tier of the gate rules. Mods always do; anonymous callers never do.
+ *
+ * 🔴 `userId` MUST be in the CONTEXT, not only in the entityId argument.
+ *
+ * A Flipt segment constraint is one of two kinds and they read different inputs:
+ * `ENTITY_ID_COMPARISON_TYPE` matches the entityId argument, and
+ * `STRING_COMPARISON_TYPE` matches a property of the evaluation CONTEXT. The
+ * `testers` segment this flag rolls out to is `ANY_MATCH_TYPE` over two
+ * `STRING_COMPARISON_TYPE` constraints — `isModerator = "true"` and `userId
+ * isoneof [...]` — so it reads the context and never the entityId.
+ *
+ * This used to pass `{ isModerator: 'false' }` alone, with the user's id only as
+ * the entityId. Both constraints then failed for every non-moderator: the
+ * hardcoded `isModerator` by construction, and `userId` because the property was
+ * absent. The flag's base `enabled` is `false`, so the function returned `false`
+ * for every non-moderator regardless of the tester list — silently, and
+ * indistinguishably from "this user is not a tester".
+ *
+ * Deliberately NOT `buildFliptContext(user)`: this call site is handed
+ * `{ id, isModerator }`, not a `SessionUser`, so that helper would emit DEFAULTED
+ * values for `tier`, `isMember`, `isInCreatorProgram` and `isEarlyAdopter`. A
+ * fabricated context is worse than a narrow one — it would let a `tier`- or
+ * cohort-scoped rollout match on values this caller never knew. Emit only what
+ * is actually known here.
  */
 export async function resolveTestingAccess(user: {
   id?: number;
@@ -704,6 +727,7 @@ export async function resolveTestingAccess(user: {
   if (user.isModerator) return true;
   if (!user.id) return false;
   return isFlipt(FLIPT_FEATURE_FLAGS.GENERATION_TESTING, String(user.id), {
+    userId: String(user.id),
     isModerator: 'false',
   });
 }


### PR DESCRIPTION
## What this is, and what it deliberately is not

This is ClickUp `868krm9ct` phase 2. **The registry↔flag link the card asks for is already on `main`** — #4101 (`9c99d53db3`, merged 2026-08-19) added `audience?: { feature: FeatureFlagKey }` to `FeatureNotice`, made `useFeatureNotice` branch on it via `useOptionalFeatureFlags`, and wired `RemixGalleryExplainer` to `remixGallery`. I re-derived that before writing anything rather than re-implementing it. Its shape is exactly the accepted option on the card — a reviewed in-code lookup, not `flipt-state` metadata (no review gate: 7.9% of that repo's commits carry a PR number) and not a naming convention (conflates *who can see this* with *who should be told*).

What #4101 explicitly did **not** do is the item the card flags in red: *"other direct call sites reportedly still have it. Sweep them."* Its own body says "This PR adds no direct keyed evaluation" — true, and not a sweep. **This PR is that sweep, its one live finding, and a gate for the class.**

## The mechanism, measured

A Flipt segment constraint reads one of two inputs, decided by the constraint's **type**, not by the flag:

| constraint type | reads |
|---|---|
| `ENTITY_ID_COMPARISON_TYPE` | the `entityId` **argument** |
| `STRING_COMPARISON_TYPE` | a named property of the **context** |

Read from `flipt-state@a61bf0b` `civitai-app/default/features.yaml`: **12 of 15 segments are the latter** — every identity, tier and cohort segment we have (`moderators`, `testers`, `early-adopters`, `members`, `app-dev-testers`, `license-fee-tester`, `CreatorProgram`). Only `is-zach`, `is-koen`, `is-debuggador` read the entityId. **65 of 125 flags** carry a segment rollout.

So a context-less evaluation cannot match any identity segment, for anybody. It returns the flag's base `enabled` value — indistinguishable from an honest "not in the segment". No error, no log line.

### Verified live against the production Flipt (`flipt-v2`, ns `flipt`), with both control arms

| evaluation | result |
|---|---|
| `generation-testing`, tester id, `userId` **in context** | `enabled: true`, `MATCH`, `segmentKeys: ["testers"]` |
| `generation-testing`, **same tester id, entityId only** + `{isModerator:'false'}` — what `main` sends | `enabled: false`, `DEFAULT`, `segmentKeys: []` |
| `generation-testing`, non-tester id, `userId` in context — negative control | `enabled: false`, `DEFAULT`, `segmentKeys: []` |
| `early-adopter` with `{isEarlyAdopter:'true'}` | `enabled: true`, `MATCH`, `segmentKeys: ["early-adopters"]` |
| `early-adopter` with `{}` | `enabled: false`, `DEFAULT`, `segmentKeys: []` |
| `b2-image-upload` (`is-zach`, an entityId-type segment), entityId only, **empty context** | `enabled: true`, `MATCH`, `segmentKeys: ["is-zach"]` |

Rows 2 and 3 are byte-identical in `enabled`. That is the whole defect: the broken case and the correct negative are the same observable. Row 6 is why the rule below is "an entityId **requires** a context", not "don't use entityId" — entityId-type constraints genuinely work without one.

## The sweep

Enumerated by a balanced-paren scan of every call to the four evaluators `~/server/flipt/client` exports (`isFlipt`, `isFliptSync`, `getFliptBoolean`, `getFliptVariant`) across `src/`, cross-checked against `packages/` and `apps/` with a separate grep that found **zero** consumer call sites outside `src/` (only the implementation inside `@civitai/flipt` itself). Population: **69 calls / 3,849 files** — 41 pass one argument (genuinely global), 23 pass a context, **5 name an entity and pass none.**

### 1 live defect — fixed here

**`resolveTestingAccess`** (`generation.service.ts`) gates the `testers` tier of the generation gate rules. `generation-testing` has base `enabled: false` and rolls out to `moderators` OR `testers`; `testers` is `ANY_MATCH` over `isModerator eq "true"` and `userId isoneof [...]`, both context-reading. The call passed the user id **only as the entityId**, plus a hardcoded `{ isModerator: 'false' }` — so both constraints failed for every non-moderator and the function returned `false` for the entire tester list, silently.

🔴 **This is a behaviour change and it is deliberate: the listed tester ids now resolve `true`, which is what `flipt-state` already declares.** It is in its own commit so it can be dropped if you'd rather land the gate alone. Nothing else in this PR changes runtime behaviour.

Deliberately **not** `buildFliptContext(user)` there: that call site is handed `{ id, isModerator }`, not a `SessionUser`, so the helper would emit defaulted `tier`, `isMember`, `isInCreatorProgram` and `isEarlyAdopter`. A fabricated context is worse than a narrow one — it lets a tier- or cohort-scoped rollout match on values the caller never knew. It emits only `userId` and `isModerator`, asserted as an exact key set.

### 4 latent — ledgered with the flag definition each was checked against

| site | flag | why it is latent |
|---|---|---|
| `article-rating-review.helpers.ts:482` | `article-rating-dispute` | `enabled: true`, 0 rules, 0 rollouts. Background path with only `pending.userId`; a truthful context would cost a user fetch. |
| `image.service.ts:3864` | `feed-fetch-filter-in-post` | `enabled: true`, 0 rollouts. Hot feed path. |
| `image.service.ts:3994` / `:4704` / `:5814` | `feed-image-existence` | `enabled: true`, 0 rollouts. Hot feed paths where `buildFliptContext` was deliberately hoisted out of per-flag work. |

"No segments today" is a statement about the flag as it stands, **not a licence** — add one rollout to any of these and the site goes silently wrong. The ledger row is what makes that visible at review time.

Sites already correct and left alone: `feedback.service` (#4042), `orchestrator/experimental`, all ten `app-blocks-flag` user arms, `gift-card-vendors`, `image-search.service`, `image.controller` ×2, `feature-flags.service` (`hasFeature`), `redis/client`, `wan.handler`.

## The gate

`src/server/flipt/__tests__/flipt-eval-context.test.ts`, in the `unit` project (the only one CI executes).

**Rule: any Flipt evaluation that passes an `entityId` must also pass a context.** Keyed on "entityId present" rather than "user-derived" on purpose — one of the real sites passes a bare local named `entityId` that happens to hold a user id, so a classification heuristic would have missed it, and the stricter rule is the honest one anyway: an entityId is a claim the evaluation is scoped to a subject, and a scoped evaluation with no context can see a quarter of the segment vocabulary.

It fails when the set **grows** and when a ledgered row goes **stale**, with positive controls on the walk (file count, all three arities present, one known-contexted and one known-bare site named by hand).

**It is structural, and structural is weak** — it is satisfied by `isFlipt(flag, id, {})` and it says nothing about *why* a context is needed. So it is paired with a behavioural half that drives the real `buildFliptContext` against hand-typed transcriptions of the live segments, and shows the same subject matching **with** a context and missing **without** one, plus the negative control (a non-member still misses). `generation.service.testing-access-flag-context.test.ts` does the same at the fixed call site, driving the real function through a stub that encodes the `testers` segment's real shape rather than the shape the code happens to send — which is what lets it disagree with the code.

Fixtures name ids (`5150`, `90210`, `8123`, `4471`) that are **not** on the real tester list, so a mutant hardcoding a production literal cannot survive.

## Red-at-base matrix

Every guard was watched fail. All mutants restored; the tree is clean.

| # | mutation | result |
|---|---|---|
| 1 | fix reverted, test kept (i.e. `origin/main`'s `resolveTestingAccess`) | **3 of 9 red** — `lets a listed tester through`; `puts the user id in the CONTEXT, not only in the entityId argument`; `does not fabricate a tier…` (key set `[isModerator]` vs `[isModerator, userId]`) |
| 2 | `userId: String(user.id + 1)` — wrong value, not absence | **2 red** — proves the assertion reads the value, not just its presence |
| 3 | a context dropped from a real call site (`orchestrator/experimental.ts`) | **1 red**, with *this* gate's own message, no other test disturbed — the failure is attributed, not smeared |
| 4 | a ledgered site given a context | **1 red**, the staleness test alone |
| 5 | scanner made to return no files | **4 red on the positive controls** — while `adds no Flipt evaluation that names an entity but passes no context` stays **vacuously green**. That is precisely why those controls exist, and it is the reason a bare green from this gate would otherwise be unreadable |
| 6 | `buildFliptContext` stops emitting `userId` | **2 red** in the behavioural half |

Mutation 1 was re-run **after** the `no-direct-shared-module-mock` rewrite (the file originally re-declared a `~/server/redis/client` factory; it now uses the canonical mock from `setup.ts`), because a mock rewrite can hollow a test out. Same 3 failures, same names.

## Verification

- **Full `unit` project on the MERGED tree** (`origin/main@124e256a44` merged in): **4,994 suites / 19,481 tests / 0 failures / 0 zero-test suites / 25 skipped.** Scored from `--reporter=json` counts, not an exit code. Both new suites confirmed to have *executed* — `flipt-eval-context.test.ts (12)`, `generation.service.testing-access-flag-context.test.ts (9)` — as were the five phase-1/phase-2 notice suites (`notice-registry` 31, `useFeatureNotice.audience` 14, `notice-callsite-composition` 9, `notice-callsite-coverage` 9).
- **`pnpm typecheck`: 0 errors** (53s). Note for anyone reproducing: a fresh worktree needs `git submodule update --init` or `event-engine-common` produces 12 phantom TS2307s that are not a baseline.
- **`eslint --max-warnings=0`** clean on all four changed files; **prettier** clean.
- Affected suites enumerated **by grep** (`resolveTestingAccess|buildFliptContext|server/flipt/client|generation/generation.service` → 108 files), then subsumed by the full run.
- Live Flipt probes above are against production `flipt-v2`, each with its control arm.

## What I could not verify

- The `component` (browser) project was not run; nothing in this PR touches it.
- The four ledgered feed sites are latent **on today's flag definitions**. I did not measure what adding `buildFliptContext` would cost on those hot paths, so "the fix is not free" is a stated reason, not a measurement.
- Untouched, and outside this PR: `dismissAlertHandler`'s raw `jsonb_set` vs `setUserSettingHandler`'s read-modify-write on `User.settings` — now a live collision surface, since the early-adopter cohort has grown to **338** (re-derived on the replica today; the card recorded 238 on Aug 19) and those users are the ones dismissing notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
