### PR TITLE
refactor(apps): collapse the off-site display sub-kind into one kind

### DIFF
--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -206,7 +206,7 @@ describe('AppListingCard', () => {
         card={base({
           kind: 'offsite',
           name: 'External App',
-          kindData: { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://ext.app' },
+          kindData: { kind: 'offsite', externalUrl: 'https://ext.app' },
         })}
       />
     );
@@ -233,7 +233,7 @@ describe('AppListingCard', () => {
         card={base({
           kind: 'offsite',
           name: 'Connect App',
-          kindData: { kind: 'offsite', subKind: 'connect', externalUrl: null },
+          kindData: { kind: 'offsite', externalUrl: null },
         })}
       />
     );
@@ -251,7 +251,7 @@ describe('AppListingCard', () => {
         card={base({
           kind: 'offsite',
           name: 'Connect App',
-          kindData: { kind: 'offsite', subKind: 'connect', externalUrl: 'https://connect.app' },
+          kindData: { kind: 'offsite', externalUrl: 'https://connect.app' },
         })}
       />
     );
@@ -400,7 +400,7 @@ describe('AppListingCard', () => {
         card={base({
           kind: 'offsite',
           name: 'External App',
-          kindData: { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://ext.app' },
+          kindData: { kind: 'offsite', externalUrl: 'https://ext.app' },
         })}
       />
     );
@@ -432,7 +432,7 @@ describe('AppListingCard', () => {
       <AppListingCard
         card={base({
           kind: 'offsite',
-          kindData: { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://ext.app' },
+          kindData: { kind: 'offsite', externalUrl: 'https://ext.app' },
         })}
       />
     );
@@ -593,7 +593,7 @@ describe('AppListingCard', () => {
       <AppListingCard
         card={base({
           kind: 'offsite',
-          kindData: { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://ext.app' },
+          kindData: { kind: 'offsite', externalUrl: 'https://ext.app' },
         })}
       />
     );
@@ -673,7 +673,6 @@ describe('AppListingCard', () => {
             kind: 'offsite',
             kindData: {
               kind: 'offsite',
-              subKind: 'external-link',
               externalUrl: 'https://ext.example/app',
             },
           })}
@@ -770,20 +769,19 @@ describe('AppListingCard', () => {
         recommend: { recommendedCount: 91, notRecommendedCount: 9, recommendPct: 0.91 },
         reviewCount: 100,
       };
-      // The widest CTA ("View details") — the tight cell in the table above. A
-      // connect-kind listing has no external target, so `getListingCta` falls
+      // The widest CTA ("View details") — the tight cell in the table above. An
+      // off-site listing with no external target makes `getListingCta` fall
       // through to the unified detail. Fully typed (`externalUrl` included)
-      // rather than cast. Two bugs the cast was HIDING, both surfaced the moment
-      // it became a `satisfies`: `externalUrl` was missing, and the subKind was
-      // `'oauth-connect'` — not a member of `OffsiteSubKind` at all
-      // (`'connect' | 'external-link'`). Neither `tsc` error reached vitest,
-      // which type-strips.
+      // rather than cast: the cast was HIDING a missing `externalUrl` and a
+      // `subKind: 'oauth-connect'` that was not a member of the sub-kind union
+      // at all, and neither `tsc` error reached vitest, which type-strips.
+      // (The sub-kind itself is now gone — `externalUrl` is the only off-site
+      // card input, so that particular typo has no shape left to take.)
       const OFFSITE_CONNECT = {
         ...REVIEWED,
         kind: 'offsite' as const,
         kindData: {
           kind: 'offsite',
-          subKind: 'connect',
           externalUrl: null,
         } satisfies ListingCard['kindData'],
       };
@@ -806,7 +804,6 @@ describe('AppListingCard', () => {
         reviewCount: 0,
         kindData: {
           kind: 'offsite',
-          subKind: 'connect',
           externalUrl: null,
         } satisfies ListingCard['kindData'],
       };

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -41,10 +41,22 @@ import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema
  * App Store Listings (W13) — P2b unified store CARD, over BOTH kinds.
  *
  * Renders one `ListingCard` (from `appListings.listAvailable`): cover + app icon
- * + name + tagline + creator chip + a kind badge (App / Connect app / Off-site)
- * + the Steam-style recommend rollup + a kind-aware CTA (Open / View details /
- * Visit ↗ / Connect). Mirrors the visual language of the live `AppBlockCard`
- * (Mantine Card + category-glyph cover placeholder) so listings feel native.
+ * + name + tagline + creator chip + the Steam-style recommend rollup + a
+ * kind-aware CTA (Open / View details / Visit ↗). Mirrors the visual language of
+ * the live `AppBlockCard` (Mantine Card + category-glyph cover placeholder) so
+ * listings feel native.
+ *
+ * 🔴 THERE IS NO KIND BADGE ON THIS CARD. This line used to claim "a kind badge
+ * (App / Connect app / Off-site)" — doubly wrong: two of those labels no longer
+ * exist (the off-site display sub-kind was collapsed), and the card does not
+ * render a badge at all. The evidence is the IMPORT GRAPH, checkable by grep:
+ * `getListingBadge` lives in `appListingCardView` and is imported by two test
+ * files and nothing else — this component does not import it. (There is an
+ * "Off-site is absent" check in `AppListingCard.browser.test.tsx`, but it uses
+ * the `expect.element(...).not.toBeInTheDocument()` form that is INERT in this
+ * repo — issue #4197 — so it is not evidence of anything. Don't cite it.)
+ * The kind signal here is the CTA (an external "Visit" anchor vs. an internal
+ * Open / View details link), plus the off-site disclosure on the detail page.
  *
  * LIVE (P2d cut over): this is the DEFAULT `/apps` store card
  * (`AppListingsMarketplaceBody` → `AppListingCard`) over BOTH kinds. The page is

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -339,7 +339,6 @@ describe('AppListingDetailBody', () => {
           kind: 'offsite',
           kindData: {
             kind: 'offsite',
-            subKind: 'external-link',
             externalUrl: 'https://ext.app',
             connectClientId: null,
           },
@@ -951,13 +950,12 @@ describe('AppListingDetailBody', () => {
     return modifier.replace('tabler-icon-', '');
   }
 
-  /** The off-site (external-link) variant of `base()`. */
+  /** The off-site variant of `base()` — no OAuth client (the grandfathered shape). */
   const offsite = () =>
     base({
       kind: 'offsite',
       kindData: {
         kind: 'offsite',
-        subKind: 'external-link',
         externalUrl: 'https://ext.app',
         connectClientId: null,
       },
@@ -1054,7 +1052,6 @@ describe('AppListingDetailBody', () => {
           kind: 'offsite',
           kindData: {
             kind: 'offsite',
-            subKind: 'connect',
             externalUrl: 'https://connect.app',
             connectClientId: 'oauth-client-1',
           },
@@ -1078,7 +1075,6 @@ describe('AppListingDetailBody', () => {
           kind: 'offsite',
           kindData: {
             kind: 'offsite',
-            subKind: 'connect',
             externalUrl: null,
             connectClientId: 'oauth-client-1',
           },

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -44,6 +44,7 @@ import {
   type DetailActionMode,
   getDetailPrimaryAction,
   getOwnerEditHref,
+  shouldShowOffsiteDisclosure,
 } from '~/components/Apps/appListingDetailView';
 import { toRecentAppFromListing } from '~/components/Apps/recentAppsRail';
 import { recordRecentlyOpenedApp } from '~/components/Apps/recentlyOpenedAppsStore';
@@ -951,21 +952,20 @@ export function AppListingDetailBody({
             )}
 
             {/* Off-site external destination disclosure (mirrors the live detail).
-                🔴 Gated on `connectClientId == null` — a CAPABILITY check, not a
-                kind. The sentence claims "no account access, or permissions",
-                which is FALSE of a listing with an OAuth app connected, so this
-                cannot become unconditional now that off-site is one kind. The
-                test previously read `subKind === 'external-link'`, which was
-                derived from exactly this field by a truthiness test — same
+                🔴 The condition lives in `shouldShowOffsiteDisclosure`, NOT here —
+                it makes a security claim ("no account access, or permissions")
+                that is FALSE of a listing with an OAuth app connected, and inline
+                it was covered by nothing. Read that function's docstring before
+                changing what the sentence says or when it appears. It replaces a
+                `subKind === 'external-link'` test, which was derived from
+                `connectClientId` by a truthiness test and nothing else — same
                 predicate, no derived taxonomy, identical rendering. */}
-            {detail.kindData.kind === 'offsite' &&
-              !detail.kindData.connectClientId &&
-              detail.kindData.externalUrl && (
-                <Alert variant="light" color="blue" icon={<IconInfoCircle size={16} />}>
-                  This app runs entirely off-platform — no Civitai install, account access, or
-                  permissions.
-                </Alert>
-              )}
+            {shouldShowOffsiteDisclosure(detail.kindData) && (
+              <Alert variant="light" color="blue" icon={<IconInfoCircle size={16} />}>
+                This app runs entirely off-platform — no Civitai install, account access, or
+                permissions.
+              </Alert>
+            )}
           </Stack>
         </ContainerGrid2.Col>
       </ContainerGrid2>

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -957,9 +957,15 @@ export function AppListingDetailBody({
                 that is FALSE of a listing with an OAuth app connected, and inline
                 it was covered by nothing. Read that function's docstring before
                 changing what the sentence says or when it appears. It replaces a
-                `subKind === 'external-link'` test, which was derived from
-                `connectClientId` by a truthiness test and nothing else — same
-                predicate, no derived taxonomy, identical rendering. */}
+                `subKind === 'external-link'` test: identical rendering for every
+                input produced by `app-listing.service` (truthiness on both
+                sides), and for the mod-review preview builder identical except
+                at `connectClientId === ''`, where the disclosure now SHOWS —
+                see `shouldShowOffsiteDisclosure`'s docstring for why that is the
+                safer answer. 🔴 This component is also rendered with a detail
+                built by `buildListingDetailPreview` (`OffsiteReviewQueue`'s
+                fallback), which is why that builder's `connectClientId`
+                passthrough carries its own test. */}
             {shouldShowOffsiteDisclosure(detail.kindData) && (
               <Alert variant="light" color="blue" icon={<IconInfoCircle size={16} />}>
                 This app runs entirely off-platform — no Civitai install, account access, or

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -950,9 +950,16 @@ export function AppListingDetailBody({
               </Stack>
             )}
 
-            {/* Off-site external destination disclosure (mirrors the live detail). */}
+            {/* Off-site external destination disclosure (mirrors the live detail).
+                🔴 Gated on `connectClientId == null` — a CAPABILITY check, not a
+                kind. The sentence claims "no account access, or permissions",
+                which is FALSE of a listing with an OAuth app connected, so this
+                cannot become unconditional now that off-site is one kind. The
+                test previously read `subKind === 'external-link'`, which was
+                derived from exactly this field by a truthiness test — same
+                predicate, no derived taxonomy, identical rendering. */}
             {detail.kindData.kind === 'offsite' &&
-              detail.kindData.subKind === 'external-link' &&
+              !detail.kindData.connectClientId &&
               detail.kindData.externalUrl && (
                 <Alert variant="light" color="blue" icon={<IconInfoCircle size={16} />}>
                   This app runs entirely off-platform — no Civitai install, account access, or

--- a/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
@@ -30,7 +30,7 @@ function makeCard(id: string, name: string, kind: 'onsite' | 'offsite' = 'onsite
     kindData:
       kind === 'onsite'
         ? { kind: 'onsite', appBlockId: `blk-${id}`, hasPage: false, liveUrl: `https://slug-${id}.civit.ai` }
-        : { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://x.app' },
+        : { kind: 'offsite', externalUrl: 'https://x.app' },
   };
 }
 

--- a/src/components/Apps/AppListingsMarketplaceBody.hydration.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.hydration.browser.test.tsx
@@ -63,7 +63,7 @@ function makeCard(id: string, name: string, kind: 'onsite' | 'offsite' = 'onsite
             hasPage: false,
             liveUrl: `https://slug-${id}.civit.ai`,
           }
-        : { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://x.app' },
+        : { kind: 'offsite', externalUrl: 'https://x.app' },
   };
 }
 

--- a/src/components/Apps/AppListingsMarketplaceBody.urlState.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.urlState.browser.test.tsx
@@ -57,7 +57,7 @@ function makeCard(id: string, name: string, kind: 'onsite' | 'offsite' = 'onsite
             hasPage: false,
             liveUrl: `https://slug-${id}.civit.ai`,
           }
-        : { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://x.app' },
+        : { kind: 'offsite', externalUrl: 'https://x.app' },
   };
 }
 

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -48,10 +48,13 @@ function onsiteCard(over: Partial<ListingCard> & { hasPage: boolean; appBlockId?
   };
 }
 
-function offsiteCard(
-  subKind: 'connect' | 'external-link',
-  externalUrl: string | null
-): ListingCard {
+/**
+ * 🔴 The `subKind` parameter is GONE. Off-site listings used to fork for display
+ * into `connect` / `external-link`, derived from `connectClientId`; the card DTO
+ * no longer carries either the sub-kind or the client id, so a card cannot
+ * express the distinction at all. `externalUrl` is the only off-site input left.
+ */
+function offsiteCard(externalUrl: string | null): ListingCard {
   return {
     id: 'l2',
     slug: 'ext-app',
@@ -65,7 +68,7 @@ function offsiteCard(
     creator: null,
     recommend: roll(0, 0, null),
     reviewCount: 0,
-    kindData: { kind: 'offsite', subKind, externalUrl },
+    kindData: { kind: 'offsite', externalUrl },
   };
 }
 
@@ -73,17 +76,29 @@ describe('getListingBadge', () => {
   it('on-site → "App"', () => {
     expect(getListingBadge(onsiteCard({ hasPage: true }))).toEqual({ label: 'App', kind: 'onsite' });
   });
-  it('off-site connect → "Connect app"', () => {
-    expect(getListingBadge(offsiteCard('connect', null))).toEqual({
-      label: 'Connect app',
-      kind: 'connect',
-    });
+  /**
+   * 🔴 NEW BEHAVIOUR (not regression coverage): off-site used to badge as
+   * "Connect app" when a client was linked and "Off-site" when not. There is one
+   * badge now. This pins the collapsed pair — the "Connect app" case above is
+   * what a revert would put back, and it is what this assertion refuses.
+   */
+  it('🔴 off-site → "Off-site", with or without a usable destination', () => {
+    for (const externalUrl of [null, 'https://x.com', 'http://insecure.example']) {
+      expect(getListingBadge(offsiteCard(externalUrl)), String(externalUrl)).toEqual({
+        label: 'Off-site',
+        kind: 'offsite',
+      });
+    }
   });
-  it('off-site external-link → "Off-site"', () => {
-    expect(getListingBadge(offsiteCard('external-link', 'https://x.com'))).toEqual({
-      label: 'Off-site',
-      kind: 'external-link',
-    });
+  /**
+   * The word is load-bearing: it must be the SAME word the store's kind filter
+   * puts on the whole category (`KindFilterButtons`' "Off-site"). Under the fork
+   * the parent label was true of only one child while the submit flow minted
+   * nothing but the other one. Pinned as a literal so a reword has to be
+   * deliberate — PR #4187 renames it, and this is the assertion it must update.
+   */
+  it('🔴 the off-site badge label is exactly the store kind-filter word', () => {
+    expect(getListingBadge(offsiteCard('https://x.com')).label).toBe('Off-site');
   });
 });
 
@@ -165,59 +180,34 @@ describe('getListingCta — on-site (P2c: View details → unified detail)', () 
 });
 
 describe('getListingCta — off-site (P2c: View details → unified detail)', () => {
-  it('external-link https → Visit ↗ (direct external primary)', () => {
-    expect(getListingCta(offsiteCard('external-link', 'https://foo.app'), { canOpenPage: true })).toEqual({
+  it('https externalUrl → Visit ↗ (direct external primary)', () => {
+    expect(getListingCta(offsiteCard('https://foo.app'), { canOpenPage: true })).toEqual({
       label: 'Visit',
       action: 'visit',
       href: 'https://foo.app',
       external: true,
     });
   });
-  it('external-link non-https → View details → unified detail (guard drops the href)', () => {
-    expect(getListingCta(offsiteCard('external-link', 'http://foo.app'), { canOpenPage: true })).toEqual({
+  it('non-https → View details → unified detail (guard drops the href)', () => {
+    expect(getListingCta(offsiteCard('http://foo.app'), { canOpenPage: true })).toEqual({
       label: 'View details',
       action: 'detail',
       href: '/apps/store-preview/ext-app',
       external: false,
     });
   });
-  it('external-link null url → View details → unified detail', () => {
-    expect(getListingCta(offsiteCard('external-link', null), { canOpenPage: true })).toEqual({
+  it('null url → View details → unified detail', () => {
+    expect(getListingCta(offsiteCard(null), { canOpenPage: true })).toEqual({
       label: 'View details',
       action: 'detail',
       href: '/apps/store-preview/ext-app',
       external: false,
     });
   });
-  /**
-   * 🔴 INTENT CHANGED alongside the detail view-model. Connect used to route to
-   * "View details" unconditionally, on the premise that the Connect affordance
-   * lived on the detail page — but that affordance was a dead stub, so the card
-   * sent the viewer to a page with no way to open the app. The detail now
-   * renders a real `Visit ↗` whenever an off-site listing carries an https
-   * `externalUrl`; the card matches, so the two cannot disagree about whether an
-   * app is reachable.
-   */
-  it('🔴 connect + https externalUrl → Visit ↗ (matches the detail, was View details)', () => {
-    expect(
-      getListingCta(offsiteCard('connect', 'https://connect.app'), { canOpenPage: true })
-    ).toEqual({
-      label: 'Visit',
-      action: 'visit',
-      href: 'https://connect.app',
-      external: true,
-    });
-  });
-  it('🔴 connect and external-link with the SAME url produce the SAME CTA', () => {
-    const url = 'https://same-target.app';
-    expect(getListingCta(offsiteCard('connect', url), { canOpenPage: true })).toEqual(
-      getListingCta(offsiteCard('external-link', url), { canOpenPage: true })
-    );
-  });
-  it('connect with no usable target → View details → unified detail (fails safe)', () => {
+  it('no usable target → View details → unified detail (fails safe)', () => {
     for (const externalUrl of [null, '', 'http://insecure.app', 'javascript:alert(1)']) {
       expect(
-        getListingCta(offsiteCard('connect', externalUrl), { canOpenPage: true }),
+        getListingCta(offsiteCard(externalUrl), { canOpenPage: true }),
         String(externalUrl)
       ).toEqual({
         label: 'View details',

--- a/src/components/Apps/__tests__/appListingDetailRows.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailRows.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { getListingBadge } from '~/components/Apps/appListingCardView';
 import { buildListingDetailRows } from '~/components/Apps/appListingDetailRows';
 import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
 
@@ -68,27 +69,60 @@ describe('buildListingDetailRows — order', () => {
     expect(by.updated).toMatchObject({ label: 'Updated', value: `formatted:${FIXED_DATE}` });
   });
 
-  it('the kind row names the sub-kind for both off-site shapes', () => {
-    const connect = buildListingDetailRows(
+  /**
+   * 🔴 NEW BEHAVIOUR (not regression coverage). The kind row used to read
+   * "Connect app" or "Off-site link" depending on `connectClientId`; off-site is
+   * one kind now, so it reads one word — and that word is the store kind
+   * filter's own "Off-site" (`KindFilterButtons`), which the "Connect app"
+   * branch was contradicting on the majority of listings.
+   *
+   * Both fixtures set a DIFFERENT `connectClientId` and a DIFFERENT
+   * `externalUrl` — the two inputs the deleted fork could have keyed on — so a
+   * mutant that re-derives a label from either one moves at least one of these
+   * assertions.
+   */
+  it('🔴 the kind row reads one word for BOTH off-site shapes', () => {
+    const connected = buildListingDetailRows(
       detail({
-        kindData: { kind: 'offsite', subKind: 'connect', externalUrl: null, connectClientId: 'c1' },
+        kindData: { kind: 'offsite', externalUrl: null, connectClientId: 'c1' },
       }),
       { formatDate: fmt }
     );
-    expect(connect.find((r) => r.key === 'kind')?.value).toBe('Connect app');
+    expect(connected.find((r) => r.key === 'kind')?.value).toBe('Off-site');
 
-    const link = buildListingDetailRows(
+    // 🔴 The grandfathered production listing: an approved off-site row with NO
+    // OAuth client. It must render the same single label, not a blank / dash /
+    // "unknown" left behind by the deleted branch.
+    const grandfathered = buildListingDetailRows(
       detail({
         kindData: {
           kind: 'offsite',
-          subKind: 'external-link',
-          externalUrl: 'https://x.example',
+          externalUrl: 'https://grandfathered.example',
           connectClientId: null,
         },
       }),
       { formatDate: fmt }
     );
-    expect(link.find((r) => r.key === 'kind')?.value).toBe('Off-site link');
+    expect(grandfathered.find((r) => r.key === 'kind')?.value).toBe('Off-site');
+  });
+
+  /**
+   * The rail row and the card badge are two surfaces that MUST agree — the
+   * `kindLabel` docstring claimed they mirrored each other while they said
+   * "Off-site link" and "Off-site" respectively. Pinned as a relationship, so it
+   * fails if either side is reworded alone.
+   */
+  it('🔴 the off-site kind row is byte-identical to the card badge label', () => {
+    const rows = buildListingDetailRows(
+      detail({ kindData: { kind: 'offsite', externalUrl: null, connectClientId: null } }),
+      { formatDate: fmt }
+    );
+    expect(rows.find((r) => r.key === 'kind')?.value).toBe(
+      getListingBadge({
+        kind: 'offsite',
+        kindData: { kind: 'offsite', externalUrl: null },
+      }).label
+    );
   });
 });
 

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -423,11 +423,16 @@ describe('getDetailPrimaryAction — off-site', () => {
 
   /**
    * An empty-string client id is FALSY, which is what the deleted
-   * `resolveOffsiteSubKind` tested — so it took the no-client arm. The
-   * projection now guarantees this never reaches the wire (`|| null` in
-   * `detailKindData`), but this view-model is called directly by
-   * `app-listing-actionable.service` and by `MySubmissionsList`, so pin the
-   * truthiness here too rather than relying on a caller.
+   * `resolveOffsiteSubKind` tested — so it took the no-client arm.
+   * `app-listing.service.detailKindData`'s `|| null` guarantees this never
+   * reaches the wire by THAT path, but `app-listing-actionable.service` calls
+   * this view-model directly with a listing row, so pin the truthiness here
+   * rather than relying on a caller. (`MySubmissionsList` also calls it
+   * directly, but hardcodes `kind: 'onsite'` and never reaches this branch —
+   * it is NOT an off-site caller; an earlier version of this note implied it
+   * was.) The mod-review preview builder reaches it too, via
+   * `buildListingDetailPreview` → `AppListingDetailBody`, and it uses
+   * `?? null` — see `shouldShowOffsiteDisclosure`'s docstring.
    */
   it('an empty-string connectClientId takes the no-client arm (truthiness, not nullish)', () => {
     const action = getDetailPrimaryAction(

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -6,6 +6,7 @@ import {
   getDetailPrimaryAction,
   getOwnerEditHref,
   isEditableListingStatus,
+  shouldShowOffsiteDisclosure,
 } from '~/components/Apps/appListingDetailView';
 import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
 
@@ -466,6 +467,100 @@ describe('getDetailPrimaryAction — off-site', () => {
     // matrix also crossed a sub-kind that no longer exists; the DROP is the
     // point — the removed dimension was never independent of `connectClientId`.)
     expect(navigable).toBe(2);
+  });
+});
+
+/**
+ * 🔴 THE OFF-SITE ACCOUNT-ACCESS DISCLOSURE.
+ *
+ * "This app runs entirely off-platform — no Civitai install, account access, or
+ * permissions." That is a SECURITY CLAIM, and it is FALSE of a listing with an
+ * OAuth app connected. Until this PR the condition lived inline in
+ * `AppListingDetailBody`'s JSX, where the blocking `unit` project could not see
+ * it and the report-only browser suite asserted it NOWHERE — so removing the
+ * condition, and printing "no account access" over every off-site listing
+ * including the OAuth-connected ones, was a change no test could catch.
+ *
+ * It was gated on `subKind === 'external-link'`. Since the sub-kind was
+ * `connectClientId ? … : …` and nothing else, collapsing the taxonomy would have
+ * silently deleted this gate if it were treated as "just another sub-kind
+ * branch" — hence the extraction, and hence a full 2×3 truth table rather than
+ * one happy case.
+ */
+describe('shouldShowOffsiteDisclosure — the "no account access" claim', () => {
+  /** The three off-site destination shapes × the two OAuth capability states. */
+  const URLS = ['https://ext.app', 'https://other.example/path', null] as const;
+
+  it('🔴 GRANDFATHERED (no OAuth client) + a destination → SHOWN', () => {
+    // Production's one approved `connect_client_id IS NULL` off-site listing.
+    // Two distinct URLs so a mutant hardcoding either literal still moves one.
+    for (const externalUrl of ['https://ext.app', 'https://other.example/path']) {
+      expect(
+        shouldShowOffsiteDisclosure({ kind: 'offsite', externalUrl, connectClientId: null }),
+        externalUrl
+      ).toBe(true);
+    }
+  });
+
+  it('🔴 an OAuth-connected listing → NOT shown (the sentence would be a lie)', () => {
+    for (const externalUrl of URLS) {
+      expect(
+        shouldShowOffsiteDisclosure({
+          kind: 'offsite',
+          externalUrl,
+          connectClientId: 'oauth_abc',
+        }),
+        String(externalUrl)
+      ).toBe(false);
+    }
+  });
+
+  it('an off-site listing with no destination → NOT shown (nothing runs off-platform)', () => {
+    expect(
+      shouldShowOffsiteDisclosure({ kind: 'offsite', externalUrl: null, connectClientId: null })
+    ).toBe(false);
+  });
+
+  it('🔴 an ON-SITE listing → NOT shown (it runs ON platform)', () => {
+    expect(
+      shouldShowOffsiteDisclosure({
+        kind: 'onsite',
+        appBlockId: 'blk-1',
+        hasPage: true,
+        liveUrl: 'https://blk-1.civit.ai',
+      })
+    ).toBe(false);
+  });
+
+  it('an empty-string connectClientId does NOT suppress it (truthiness, not nullish)', () => {
+    // Matches the projection's `|| null` and `getDetailPrimaryAction`'s test, so
+    // all three read the capability the same way.
+    expect(
+      shouldShowOffsiteDisclosure({
+        kind: 'offsite',
+        externalUrl: 'https://ext.app',
+        connectClientId: '',
+      })
+    ).toBe(true);
+  });
+
+  /**
+   * The RENDERER must not re-implement the predicate. A structural check on the
+   * source, because the JSX itself is invisible to this project — the same
+   * technique the iframe gate below uses, with its positive control.
+   */
+  it('🔴 AppListingDetailBody calls this predicate and does not re-derive it', () => {
+    // 🔴 `__dirname`, never `process.cwd()`. The runner's cwd is whatever
+    // directory `vitest` was invoked from, so a cwd-relative read passes in CI
+    // (where it is the repo root) and ENOENTs locally — a test whose verdict is
+    // about the caller's shell. Same idiom as the iframe gate below.
+    const body = fs.readFileSync(
+      path.resolve(__dirname, '../AppListingDetailBody.tsx'),
+      'utf8'
+    );
+    // POSITIVE CONTROL first: the read really returned this component's source.
+    expect(body).toMatch(/This app runs entirely off-platform/);
+    expect(body).toMatch(/shouldShowOffsiteDisclosure\(detail\.kindData\)/);
   });
 });
 

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -545,6 +545,41 @@ describe('shouldShowOffsiteDisclosure — the "no account access" claim', () => 
   });
 
   /**
+   * 🔴 THE `kind === 'offsite'` CONJUNCT IS A RUNTIME GUARD, NOT TYPE NOISE —
+   * and this fixture exists because the ordinary on-site case CANNOT SEE IT.
+   *
+   * Measured: deleting that conjunct leaves the whole suite GREEN. The on-site
+   * case above still returns `false`, but for the WRONG reason — an on-site
+   * `kindData` has no `externalUrl` at all, so the third conjunct carries the
+   * verdict and the deleted one is never the deciding term. The mutant RAN; the
+   * assertion just could not observe it. (Reachable-but-unasserted and
+   * never-executed are different findings; this was the former.)
+   *
+   * The shape that discriminates is a CAST producer handing over an object with
+   * BOTH `kind: 'onsite'` and an `externalUrl` — impossible per the DTO union,
+   * routine at runtime. `appListingDetailRows` already carries a 🔴 note about
+   * exactly this: the moderator combined-review surface builds
+   * `ListingDetail`-shaped objects through a cast, and a required field being
+   * absent there once blanked the whole review modal. An on-site listing must
+   * never claim it "runs entirely off-platform" no matter what a producer
+   * attaches to it.
+   */
+  it('🔴 an ON-SITE kindData carrying an externalUrl (cast producer) → still NOT shown', () => {
+    const cast = {
+      kind: 'onsite',
+      appBlockId: 'blk-1',
+      hasPage: true,
+      liveUrl: 'https://blk-1.civit.ai',
+      externalUrl: 'https://smuggled.example/app',
+      connectClientId: null,
+    } as unknown as ListingDetail['kindData'];
+    // POSITIVE CONTROL: the same object with `kind: 'offsite'` IS shown, so the
+    // `false` below is about the kind term and not about an inert function.
+    expect(shouldShowOffsiteDisclosure({ ...cast, kind: 'offsite' })).toBe(true);
+    expect(shouldShowOffsiteDisclosure(cast)).toBe(false);
+  });
+
+  /**
    * The RENDERER must not re-implement the predicate. A structural check on the
    * source, because the JSX itself is invisible to this project — the same
    * technique the iframe gate below uses, with its positive control.

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -14,7 +14,7 @@ import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.sche
  * project — the fast, deterministic suite; CI runs it `continue-on-error`, and
  * the browser component suites are not run by CI at all, so this is where the
  * correctness coverage belongs even though nothing here BLOCKS a merge).
- * Pin the kind × hasPage × subKind primary-action matrix incl.
+ * Pin the kind × hasPage × destination primary-action matrix incl.
  * the appBlocksPages gate, https guard, connect stub, and slug encoding, so a
  * regression in the detail action routing FAILS here.
  */
@@ -44,8 +44,14 @@ function onsiteDetail(
   };
 }
 
+/**
+ * 🔴 The `subKind` positional argument is GONE. It used to be passed
+ * INDEPENDENTLY of `connectClientId`, so a fixture could declare
+ * `('external-link', { connectClientId: 'c1' })` — a shape the real projection
+ * can never produce, since the sub-kind was derived from that very field. One
+ * input now, so a fixture cannot describe an impossible listing.
+ */
 function offsiteDetail(
-  subKind: 'connect' | 'external-link',
   over: { externalUrl?: string | null; connectClientId?: string | null; slug?: string } = {}
 ): ListingDetail {
   const { externalUrl = null, connectClientId = null, slug = 'ext-app' } = over;
@@ -65,7 +71,7 @@ function offsiteDetail(
     recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
     reviewCount: 0,
     screenshots: [],
-    kindData: { kind: 'offsite', subKind, externalUrl, connectClientId },
+    kindData: { kind: 'offsite', externalUrl, connectClientId },
   };
 }
 
@@ -277,16 +283,24 @@ describe('getDetailPrimaryAction — on-site', () => {
 });
 
 describe('getDetailPrimaryAction — off-site', () => {
-  it('external-link https → Visit ↗ (external)', () => {
+  /**
+   * 🔴 THE GRANDFATHERED LISTING drives this whole block. Production carries
+   * exactly one approved off-site row with `connect_client_id IS NULL`
+   * (measured 2026-08-19); `ExternalSubmitForm` requires a client on create, so
+   * nothing new can be minted into that shape. Every `connectClientId: null`
+   * fixture below IS that listing.
+   */
+  it('🔴 GRANDFATHERED (no OAuth client) + https → Visit ↗ (external)', () => {
     expect(
-      getDetailPrimaryAction(offsiteDetail('external-link', { externalUrl: 'https://foo.app' }), {
-        canOpenPage: true,
-      })
+      getDetailPrimaryAction(
+        offsiteDetail({ externalUrl: 'https://foo.app', connectClientId: null }),
+        { canOpenPage: true }
+      )
     ).toEqual({ label: 'Visit', mode: 'visit', href: 'https://foo.app', external: true });
   });
-  it('external-link non-https → info Unavailable (guard drops it, no target)', () => {
+  it('🔴 GRANDFATHERED + non-https → info Unavailable (guard drops it, no target)', () => {
     const action = getDetailPrimaryAction(
-      offsiteDetail('external-link', { externalUrl: 'http://foo.app' }),
+      offsiteDetail({ externalUrl: 'http://foo.app', connectClientId: null }),
       { canOpenPage: true }
     );
     expect(action).toEqual({
@@ -296,10 +310,13 @@ describe('getDetailPrimaryAction — off-site', () => {
       note: 'This app has no valid external link.',
     });
   });
-  it('external-link null url → info Unavailable', () => {
-    expect(getDetailPrimaryAction(offsiteDetail('external-link', { externalUrl: null }), { canOpenPage: true }).mode).toBe(
-      'info'
+  it('🔴 GRANDFATHERED + null url → info Unavailable (never a dead Connect stub)', () => {
+    const action = getDetailPrimaryAction(
+      offsiteDetail({ externalUrl: null, connectClientId: null }),
+      { canOpenPage: true }
     );
+    expect(action.mode).toBe('info');
+    expect(action.label).toBe('Unavailable');
   });
   /**
    * COVERAGE ADDED, NOTHING REVERSED — and the distinction matters, because an
@@ -312,15 +329,15 @@ describe('getDetailPrimaryAction — off-site', () => {
    * That behaviour is UNCHANGED — every one of its assertions still holds, and
    * they are re-pinned below over four absence shapes instead of one.
    *
-   * What this case adds is the shape nothing covered: connect WITH a valid
-   * https address. `resolveOffsiteSubKind` flips the sub-kind on
+   * What this case adds is the shape nothing covered: an OAuth-connected
+   * listing WITH a valid https address. The removed sub-kind flipped on
    * `connectClientId != null` alone, so linking an OAuth client was the sole
    * cause of the dead CTA on three approved, live listings. The destination
-   * decides now — the sub-kind does not.
+   * decides now.
    */
-  it('🔴 connect + https externalUrl → Visit ↗ (a client_id no longer kills the CTA)', () => {
+  it('🔴 OAuth client + https externalUrl → Visit ↗ (a client_id no longer kills the CTA)', () => {
     const action = getDetailPrimaryAction(
-      offsiteDetail('connect', {
+      offsiteDetail({
         connectClientId: 'client-123',
         externalUrl: 'https://connect.app',
       }),
@@ -336,36 +353,47 @@ describe('getDetailPrimaryAction — off-site', () => {
     });
   });
 
-  it('🔴 connect and external-link with the SAME url produce the SAME action', () => {
+  it('🔴 an OAuth-connected and a grandfathered listing with the SAME url produce the SAME action', () => {
     // Structural restatement of the rule, independent of the literals above: if
-    // a future change re-branches on sub-kind before the href guard, these two
-    // diverge and this fails — even if it picks copy that satisfies the pins.
+    // a future change re-branches on the OAuth capability before the href guard,
+    // these two diverge and this fails — even if it picks copy that satisfies
+    // the pins. This is the assertion a revert of the collapse must survive.
     const url = 'https://same-target.app';
     expect(
-      getDetailPrimaryAction(
-        offsiteDetail('connect', { connectClientId: 'c1', externalUrl: url }),
-        {
-          canOpenPage: true,
-        }
-      )
+      getDetailPrimaryAction(offsiteDetail({ connectClientId: 'c1', externalUrl: url }), {
+        canOpenPage: true,
+      })
     ).toEqual(
-      getDetailPrimaryAction(offsiteDetail('external-link', { externalUrl: url }), {
+      getDetailPrimaryAction(offsiteDetail({ connectClientId: null, externalUrl: url }), {
         canOpenPage: true,
       })
     );
   });
 
-  it('🔴 connect with NO usable destination → the stub still fails safe', () => {
+  /**
+   * 🔴 SURFACED, NOT DECIDED — the one place off-site listings still diverge.
+   *
+   * With no usable destination there is nothing to navigate to, and the two
+   * fallbacks say different things: an app with no OAuth client is simply
+   * "Unavailable", while an OAuth-connected one keeps the "Connect" stub for a
+   * route that does not exist yet. That is a CAPABILITY difference (does this
+   * app connect to your Civitai account?), not a kind difference, and the
+   * predicate is now read straight off `connectClientId` — byte-identical to
+   * what the deleted sub-kind computed from the same field.
+   *
+   * Whether the stub should survive at all is a product question this change
+   * does not answer; it is pinned here so a future answer has to be deliberate.
+   */
+  it('🔴 OAuth-connected with NO usable destination → the stub still fails safe', () => {
     // The stub must stay REACHABLE and must stay hrefless. Enumerated over every
-    // way a destination can be absent, with the client_id present in each — so
-    // this cannot pass by accident of the sub-kind being mis-resolved.
+    // way a destination can be absent, with the client_id present in each.
     // (`undefined` is deliberately absent: the DTO types `externalUrl` as
     // `string | null`, and the fixture's destructuring default would silently
     // rewrite it to `null` anyway — a row whose label lied about its input.)
     for (const externalUrl of [null, '', 'http://insecure.app', 'javascript:alert(1)']) {
       const key = `externalUrl=${String(externalUrl)}`;
       const action = getDetailPrimaryAction(
-        offsiteDetail('connect', { connectClientId: 'client-123', externalUrl }),
+        offsiteDetail({ connectClientId: 'client-123', externalUrl }),
         { canOpenPage: true }
       );
       expect(action.mode, key).toBe('connect');
@@ -376,6 +404,40 @@ describe('getDetailPrimaryAction — off-site', () => {
     }
   });
 
+  it('🔴 GRANDFATHERED with NO usable destination → Unavailable, NOT the Connect stub', () => {
+    // The negative arm of the case above, over the same four absence shapes.
+    // Without it the capability test could be inverted (or deleted, defaulting
+    // everything to the stub) and the suite would stay green.
+    for (const externalUrl of [null, '', 'http://insecure.app', 'javascript:alert(1)']) {
+      const key = `externalUrl=${String(externalUrl)}`;
+      const action = getDetailPrimaryAction(offsiteDetail({ connectClientId: null, externalUrl }), {
+        canOpenPage: true,
+      });
+      expect(action.mode, key).toBe('info');
+      expect(action.label, key).toBe('Unavailable');
+      expect(action.note, key).toBe('This app has no valid external link.');
+      expect(action.href, key).toBeUndefined();
+    }
+  });
+
+  /**
+   * An empty-string client id is FALSY, which is what the deleted
+   * `resolveOffsiteSubKind` tested — so it took the no-client arm. The
+   * projection now guarantees this never reaches the wire (`|| null` in
+   * `detailKindData`), but this view-model is called directly by
+   * `app-listing-actionable.service` and by `MySubmissionsList`, so pin the
+   * truthiness here too rather than relying on a caller.
+   */
+  it('an empty-string connectClientId takes the no-client arm (truthiness, not nullish)', () => {
+    const action = getDetailPrimaryAction(
+      offsiteDetail({ connectClientId: '', externalUrl: null }),
+      {
+        canOpenPage: true,
+      }
+    );
+    expect(action.label).toBe('Unavailable');
+  });
+
   it('🔴 no off-site listing with an https target is ever left un-navigable', () => {
     // The off-site analogue of the on-site "no state strands the viewer" matrix.
     // Anti-vacuity is explicit: count the rows that MUST be navigable and assert
@@ -383,30 +445,27 @@ describe('getDetailPrimaryAction — off-site', () => {
     // this green by having nothing to check.
     const stranded: string[] = [];
     let navigable = 0;
-    for (const subKind of ['connect', 'external-link'] as const) {
-      for (const externalUrl of ['https://ok.app', 'http://insecure.app', null]) {
-        for (const connectClientId of ['client-123', null]) {
-          const key = `subKind=${subKind} url=${String(externalUrl)} client=${
-            connectClientId ?? 'null'
-          }`;
-          const action = getDetailPrimaryAction(
-            offsiteDetail(subKind, { externalUrl, connectClientId }),
-            { canOpenPage: true }
-          );
-          // `visit` is the only external mode and may only carry an https target.
-          expect(action.external, key).toBe(action.mode === 'visit');
-          if (action.mode === 'visit') {
-            expect(action.href, key).toMatch(/^https:\/\//);
-            navigable++;
-          } else if (externalUrl?.startsWith('https://')) {
-            stranded.push(key);
-          }
+    for (const externalUrl of ['https://ok.app', 'http://insecure.app', null]) {
+      for (const connectClientId of ['client-123', null]) {
+        const key = `url=${String(externalUrl)} client=${connectClientId ?? 'null'}`;
+        const action = getDetailPrimaryAction(offsiteDetail({ externalUrl, connectClientId }), {
+          canOpenPage: true,
+        });
+        // `visit` is the only external mode and may only carry an https target.
+        expect(action.external, key).toBe(action.mode === 'visit');
+        if (action.mode === 'visit') {
+          expect(action.href, key).toMatch(/^https:\/\//);
+          navigable++;
+        } else if (externalUrl?.startsWith('https://')) {
+          stranded.push(key);
         }
       }
     }
     expect(stranded).toEqual([]);
-    // 2 sub-kinds × 2 client values, all with the https url → 4 navigable rows.
-    expect(navigable).toBe(4);
+    // 2 client values with the https url → 2 navigable rows. (Was 4 while the
+    // matrix also crossed a sub-kind that no longer exists; the DROP is the
+    // point — the removed dimension was never independent of `connectClientId`.)
+    expect(navigable).toBe(2);
   });
 });
 
@@ -603,10 +662,12 @@ describe('owner Edit deep-link + gating (on the detail view-model)', () => {
     expect(getOwnerEditHref(onsiteDetail({ hasPage: false, appBlockId: null }).kindData, 'l1')).toBeNull();
   });
   it('off-site detail kindData → the submit editor keyed on the listing id', () => {
-    expect(getOwnerEditHref(offsiteDetail('external-link', { externalUrl: 'https://x' }).kindData, 'l2')).toBe(
+    expect(getOwnerEditHref(offsiteDetail({ externalUrl: 'https://x' }).kindData, 'l2')).toBe(
       '/apps/submit?edit=l2'
     );
-    expect(getOwnerEditHref(offsiteDetail('connect').kindData, 'l2')).toBe('/apps/submit?edit=l2');
+    expect(getOwnerEditHref(offsiteDetail({ connectClientId: 'c1' }).kindData, 'l2')).toBe(
+      '/apps/submit?edit=l2'
+    );
   });
 
   it('owner + editable → show; non-owner → hide; mod-removed → hide', () => {

--- a/src/components/Apps/__tests__/recentAppsRail.test.ts
+++ b/src/components/Apps/__tests__/recentAppsRail.test.ts
@@ -271,7 +271,7 @@ describe('toRecentAppFromListing', () => {
       card({
         kind: 'offsite',
         iconUrl: null,
-        kindData: { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://ext.app' },
+        kindData: { kind: 'offsite', externalUrl: 'https://ext.app' },
       })
     );
     expect(entry).toEqual({
@@ -288,7 +288,7 @@ describe('toRecentAppFromListing', () => {
     const entry = toRecentAppFromListing(
       card({
         kind: 'offsite',
-        kindData: { kind: 'offsite', subKind: 'external-link', externalUrl: 'http://ext.app' },
+        kindData: { kind: 'offsite', externalUrl: 'http://ext.app' },
       })
     );
     expect(entry.externalUrl).toBeUndefined();
@@ -919,7 +919,7 @@ describe('reconcileRecentApps', () => {
       slug: 'ext-app',
       kind: 'offsite',
       name: 'Ext App',
-      kindData: { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://ext.example/a' },
+      kindData: { kind: 'offsite', externalUrl: 'https://ext.example/a' },
     });
     const [out] = reconcileRecentApps([{ id: 'lst_ext', blockId: 'stale-block' }], [card]);
     expect(out.blockId).toBeUndefined();

--- a/src/components/Apps/__tests__/reviewListingPreview.test.ts
+++ b/src/components/Apps/__tests__/reviewListingPreview.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { buildListingDetailRows } from '~/components/Apps/appListingDetailRows';
+import { shouldShowOffsiteDisclosure } from '~/components/Apps/appListingDetailView';
 import {
   buildListingCardPreview,
   buildListingDetailPreview,
@@ -153,6 +154,11 @@ describe('buildListingDetailPreview', () => {
   });
 
   it('an external row carries the connectClientId (null) + externalUrl on kindData', () => {
+    // 🔴 VACUOUS ON ITS OWN — kept for the null shape, but read the next test.
+    // The fixture supplies NO `connectClientId` and the assertion expects
+    // `null`, so the fixture constant EQUALS the assertion constant: this case
+    // passes identically against a passthrough and against a hardcoded
+    // `connectClientId: null`. The discriminating value is a TRUTHY one.
     const detail = buildListingDetailPreview(
       row({
         id: 'r2',
@@ -169,6 +175,75 @@ describe('buildListingDetailPreview', () => {
       externalUrl: 'https://ext.app',
       connectClientId: null,
     });
+  });
+
+  /**
+   * 🔴 THE PREVIEW IS A SECOND PRODUCER OF THE OAUTH CAPABILITY, AND SINCE THE
+   * SUB-KIND COLLAPSE IT IS THE SOLE CARRIER ON THIS PATH.
+   *
+   * `ListingPreviewSection` (`OffsiteReviewQueue.tsx`) falls back to
+   * `buildListingDetailPreview(request)` whenever the mod-only projection query
+   * is loading, errors, or the row has no `appListingId`, and feeds the result
+   * straight into `<AppListingDetailBody detail={detail} preview />` — which
+   * renders the off-platform disclosure through `shouldShowOffsiteDisclosure`.
+   *
+   * So if this builder drops `connectClientId`, a moderator previewing an
+   * OAuth-CONNECTED listing is told "no Civitai install, account access, or
+   * permissions" — the exact false claim `shouldShowOffsiteDisclosure` exists to
+   * prevent, arriving by the builder instead of the JSX.
+   *
+   * 🔴 This exposure is CREATED by the sub-kind collapse. Before it, the
+   * preview's own `subKind` (`connectClientId != null`) carried the capability
+   * and the disclosure keyed on that, so nulling `connectClientId` alone changed
+   * nothing on screen. Now nothing else carries it.
+   *
+   * The value is TRUTHY and distinct from every other literal in the fixture, so
+   * a hardcoded `null` — or any constant — fails here.
+   */
+  it('🔴 an OAuth-connected row PASSES THE CLIENT ID THROUGH (not a hardcoded null)', () => {
+    const detail = buildListingDetailPreview(
+      row({
+        id: 'r2b',
+        appListing: {
+          name: 'Connected',
+          externalUrl: 'https://connected.example/app',
+          category: null,
+          contentRating: null,
+          connectClientId: 'cc_1',
+        },
+      })
+    );
+    expect(detail.kindData).toEqual({
+      kind: 'offsite',
+      externalUrl: 'https://connected.example/app',
+      connectClientId: 'cc_1',
+    });
+    // …and the consequence that actually matters, asserted through the SAME
+    // predicate the renderer calls rather than restated as a boolean here.
+    expect(shouldShowOffsiteDisclosure(detail.kindData)).toBe(false);
+  });
+
+  /**
+   * The other half of the seam, so the pair pins a RELATIONSHIP rather than one
+   * value: the grandfathered row (no OAuth client) must still get the
+   * disclosure. Without this, inverting the predicate would leave the case above
+   * green.
+   */
+  it('🔴 a grandfathered row (no OAuth client) DOES get the disclosure', () => {
+    const detail = buildListingDetailPreview(
+      row({
+        id: 'r2c',
+        appListing: {
+          name: 'Legacy',
+          externalUrl: 'https://grandfathered.example/app',
+          category: null,
+          contentRating: null,
+          connectClientId: null,
+        },
+      })
+    );
+    expect(detail.kindData.kind === 'offsite' && detail.kindData.connectClientId).toBeNull();
+    expect(shouldShowOffsiteDisclosure(detail.kindData)).toBe(true);
   });
 
   it('passes resolved screenshots + cover through when provided', () => {

--- a/src/components/Apps/__tests__/reviewListingPreview.test.ts
+++ b/src/components/Apps/__tests__/reviewListingPreview.test.ts
@@ -58,7 +58,7 @@ describe('buildListingCardPreview', () => {
     });
   });
 
-  it('an external (offsite) row → offsite kindData with the external url + sub-kind', () => {
+  it('an external (offsite) row → offsite kindData with the external url, no sub-kind', () => {
     const card = buildListingCardPreview(
       row({
         id: 'r2',
@@ -73,26 +73,48 @@ describe('buildListingCardPreview', () => {
     expect(card.kind).toBe('offsite');
     expect(card.kindData).toEqual({
       kind: 'offsite',
-      subKind: 'external-link',
       externalUrl: 'https://ext.app',
     });
   });
 
-  it('a connect (offsite) row → connect sub-kind', () => {
-    const card = buildListingCardPreview(
+  /**
+   * 🔴 The moderator preview is a SECOND producer of `ListingCardKindData` — it
+   * builds the DTO by hand from a review row rather than through
+   * `projectListingCard`, and it carried its OWN copy of the sub-kind
+   * derivation. Both copies are gone, so the preview must now agree with the
+   * store for a row that differs only by `connectClientId`.
+   *
+   * The two rows carry deliberately distinct names and ids so an equality that
+   * passes cannot be two default objects.
+   */
+  it('🔴 a linked OAuth client no longer changes the preview card kindData', () => {
+    const connected = buildListingCardPreview(
       row({
         id: 'r3',
         appListing: {
           name: 'Conn',
-          externalUrl: null,
+          externalUrl: 'https://ext.app',
           category: null,
           contentRating: null,
           connectClientId: 'cc_1',
         },
       })
     );
-    expect(card.kind).toBe('offsite');
-    expect(card.kindData.kind === 'offsite' && card.kindData.subKind).toBe('connect');
+    const grandfathered = buildListingCardPreview(
+      row({
+        id: 'r3b',
+        appListing: {
+          name: 'Legacy',
+          externalUrl: 'https://ext.app',
+          category: null,
+          contentRating: null,
+          connectClientId: null,
+        },
+      })
+    );
+    expect(connected.kind).toBe('offsite');
+    expect(connected.kindData).toEqual(grandfathered.kindData);
+    expect(connected.kindData).toEqual({ kind: 'offsite', externalUrl: 'https://ext.app' });
   });
 
   it('falls back to the slug when the listing (or its name) is absent', () => {
@@ -144,7 +166,6 @@ describe('buildListingDetailPreview', () => {
     );
     expect(detail.kindData).toEqual({
       kind: 'offsite',
-      subKind: 'external-link',
       externalUrl: 'https://ext.app',
       connectClientId: null,
     });

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -21,22 +21,21 @@
  *     there when the viewer can actually open it) — the direct primary action.
  *   - on-site otherwise (no page, or page but no `appBlocksPages`) → **View
  *     details** → `/apps/store-preview/<slug>` (the unified P2c detail).
- *   - off-site, EITHER sub-kind, with an https `externalUrl` → **Visit ↗** →
- *     external anchor (direct primary action). 🔴 The sub-kind does NOT decide
- *     this; the presence of a destination does — see below.
- *   - off-site with no usable target (missing / non-https url, either sub-kind)
- *     → **View details** → the unified detail (the DTO already null-guards
- *     non-https — we re-guard; the detail page shows the informational state).
+ *   - off-site with an https `externalUrl` → **Visit ↗** → external anchor
+ *     (direct primary action). 🔴 The presence of a destination decides this.
+ *   - off-site with no usable target (missing / non-https url) → **View
+ *     details** → the unified detail (the DTO already null-guards non-https —
+ *     we re-guard; the detail page shows the informational state).
  *
- * 🔴 Connect used to route to "View details" UNCONDITIONALLY, on the premise
- * that "the Connect affordance lives on the detail page". That affordance was a
- * dead stub, so the card handed the viewer a detail page with nothing on it —
- * the card half of the same defect. The detail now renders a real `Visit ↗` for
- * any off-site listing carrying an https `externalUrl` (see
- * `appListingDetailView`), so the card matches it: a connect listing with a
- * destination gets the direct Visit, and only a listing with NO destination
- * falls back to the detail. Card and detail must not disagree about whether an
- * app is reachable.
+ * 🔴 A listing with a linked OAuth client used to route to "View details"
+ * UNCONDITIONALLY, on the premise that "the Connect affordance lives on the
+ * detail page". That affordance was a dead stub, so the card handed the viewer a
+ * detail page with nothing on it — the card half of the same defect. The detail
+ * now renders a real `Visit ↗` for any off-site listing carrying an https
+ * `externalUrl` (see `appListingDetailView`), so the card matches it: an
+ * OAuth-connected listing with a destination gets the direct Visit, and only a
+ * listing with NO destination falls back to the detail. Card and detail must not
+ * disagree about whether an app is reachable.
  * Every CTA now has a working `href` (never actionless). The card ALSO links its
  * title to the detail (via `getListingDetailHref`) so the detail is reachable
  * even when the primary CTA is a direct Open / Visit.
@@ -49,18 +48,23 @@ import type {
 import type { AppListingStatus } from '~/server/services/blocks/app-listing-status.constants';
 
 /** Kind badge shown on the card face. */
-export type ListingBadgeKind = 'onsite' | 'connect' | 'external-link';
+export type ListingBadgeKind = 'onsite' | 'offsite';
 export type ListingBadge = { label: string; kind: ListingBadgeKind };
 
 /**
- * The kind badge: on-site apps read "App"; off-site splits into the two
- * sub-kinds — an OAuth "Connect app" vs a plain "Off-site" external link.
+ * The kind badge: on-site apps read "App"; every off-site app reads "Off-site".
+ *
+ * 🔴 Off-site used to fork into two BADGES — "Connect app" (a linked OAuth
+ * client) vs "Off-site" (no client) — derived from `connectClientId`. That fork
+ * is removed: `offsite` is one kind. The word here is the SAME word the store's
+ * kind filter already uses (`KindFilterButtons`' "Off-site"), which is what
+ * makes the parent label true of the whole category again — under the fork it
+ * was only true of one child, while the submit flow REQUIRES an OAuth client
+ * and therefore minted nothing but the other one.
  */
 export function getListingBadge(card: Pick<ListingCard, 'kind' | 'kindData'>): ListingBadge {
   if (card.kindData.kind === 'onsite') return { label: 'App', kind: 'onsite' };
-  return card.kindData.subKind === 'connect'
-    ? { label: 'Connect app', kind: 'connect' }
-    : { label: 'Off-site', kind: 'external-link' };
+  return { label: 'Off-site', kind: 'offsite' };
 }
 
 /**
@@ -137,17 +141,17 @@ export function getListingCta(
     return { label: 'View details', action: 'detail', href: detailHref, external: false };
   }
 
-  // Off-site — BOTH sub-kinds. The destination decides, not the sub-kind: a
-  // connect app is reached at its own address exactly like a plain external
-  // link (it starts its own OAuth flow from there). Mirrors
-  // `getDetailPrimaryAction`; do NOT reintroduce a sub-kind test above this
-  // line, or the card and the detail disagree again.
+  // Off-site — ONE kind. The destination decides: an OAuth-connected app is
+  // reached at its own address exactly like a plain external link (it starts its
+  // own OAuth flow from there). Mirrors `getDetailPrimaryAction`; do NOT
+  // reintroduce a `connectClientId` test above this line, or the card and the
+  // detail disagree again. (The card DTO does not even carry that field.)
   const href = safeExternalHref(card.kindData.externalUrl);
   if (href) {
     return { label: 'Visit', action: 'visit', href, external: true };
   }
-  // No usable external target (missing / non-https, either sub-kind) → the
-  // unified detail, which shows the informational / connect-stub state.
+  // No usable external target (missing / non-https) → the unified detail, which
+  // shows the informational / connect-stub state.
   return { label: 'View details', action: 'detail', href: detailHref, external: false };
 }
 

--- a/src/components/Apps/appListingDetailRows.ts
+++ b/src/components/Apps/appListingDetailRows.ts
@@ -54,10 +54,15 @@ export type ListingDetailRow = {
   color?: string;
 };
 
-/** Human label for the store kind + sub-kind. Mirrors `getListingBadge`'s wording. */
+/**
+ * Human label for the store kind. Mirrors `getListingBadge`'s wording — and now
+ * actually does: off-site used to fork here into "Connect app" / "Off-site link"
+ * while the badge said "Connect app" / "Off-site", so the two surfaces disagreed
+ * about the SAME listing. One kind, one word, the same word the store's kind
+ * filter uses.
+ */
 function kindLabel(detail: Pick<ListingDetail, 'kindData'>): string {
-  if (detail.kindData.kind === 'onsite') return 'On-site app';
-  return detail.kindData.subKind === 'connect' ? 'Connect app' : 'Off-site link';
+  return detail.kindData.kind === 'onsite' ? 'On-site app' : 'Off-site';
 }
 
 /**

--- a/src/components/Apps/appListingDetailView.ts
+++ b/src/components/Apps/appListingDetailView.ts
@@ -23,7 +23,7 @@
  * which that URL resolves to something new: from the store detail it redirects
  * straight back to the page the viewer is already on.
  *
- * PRIMARY-ACTION policy (kind × hasPage × subKind), all with NO dead 404 nav:
+ * PRIMARY-ACTION policy (kind × hasPage × destination), all with NO dead 404 nav:
  *   - on-site + hasPage + canOpenPage → **Open** (`/apps/run/<slug>`, the LIVE
  *     W10 in-host page route; flag-gated on `appBlocksPages`). The raw-origin
  *     "Open live" action is HIDDEN here: the app opens properly in-page, so a
@@ -58,21 +58,23 @@
  *     explicitly in the "no on-site state strands the viewer" matrix test — but
  *     the branch is vacuous today: every approved on-site listing declares a
  *     page, so nothing takes it.
- *   - off-site, EITHER sub-kind, with an https `externalUrl` → **Visit ↗** →
- *     external anchor. 🔴 The sub-kind does NOT decide this; the presence of a
- *     destination does. See the connect note below.
- *   - off-site external-link with no usable target (missing / non-https) →
+ *   - off-site with an https `externalUrl` → **Visit ↗** → external anchor.
+ *     🔴 The presence of a destination decides this, and nothing else.
+ *   - off-site with NO usable target and no OAuth client connected →
  *     **informational** (guarded out; no target).
- *   - off-site connect (OAuth) with no usable target → **Connect** STUB with a
- *     note — the only remaining state with nowhere to send the viewer.
+ *   - off-site with NO usable target but an OAuth client connected → **Connect**
+ *     STUB with a note — the only remaining state with nowhere to send the
+ *     viewer. That last test is a CAPABILITY check on `connectClientId`, not a
+ *     kind: off-site is one kind (the `connect` / `external-link` display
+ *     sub-kind was removed).
  *
  * 🔴 THE CONNECT STUB USED TO BE UNCONDITIONAL, AND THAT WAS THE BUG. Every
  * off-site listing with a linked OAuth client rendered a dead
  * "Connecting this app will be available soon." affordance — no href, disabled
- * button — because `resolveOffsiteSubKind` routes on `connectClientId != null`
- * alone (`app-listing.service.ts`), so linking a client was the ONLY thing that
- * moved a listing off the working `Visit ↗` path. Three approved, live listings
- * were in that state; a fourth, with no client, worked.
+ * button — because the sub-kind routed on `connectClientId != null` alone, so
+ * linking a client was the ONLY thing that moved a listing off the working
+ * `Visit ↗` path. Three approved, live listings were in that state; a fourth,
+ * with no client, worked.
  *
  * The stub's stated premise — "a complete OAuth authorize URL is NOT derivable
  * from the public DTO" — is true and irrelevant. These are CONFIDENTIAL clients
@@ -191,17 +193,26 @@ export function getDetailPrimaryAction(
     };
   }
 
-  // Off-site — BOTH sub-kinds. An off-site app lives at its own address, and
-  // that address is the only thing this page can route to; a connect app then
-  // runs its own confidential-client OAuth flow from there. So the destination,
-  // not the sub-kind, decides the action: one https-guarded path
-  // (`safeExternalHref`), shared with the external-link case that has always
-  // worked. Do NOT reintroduce a sub-kind test above this line — that is
-  // precisely what made a linked OAuth client the sole cause of a dead CTA.
+  // Off-site — ONE kind. An off-site app lives at its own address, and that
+  // address is the only thing this page can route to; an OAuth-connected app
+  // then runs its own confidential-client OAuth flow from there. So the
+  // destination decides the action: one https-guarded path
+  // (`safeExternalHref`). Do NOT reintroduce a `connectClientId` test above this
+  // line — that is precisely what made a linked OAuth client the sole cause of a
+  // dead CTA.
   const href = safeExternalHref(kd.externalUrl);
   if (href) return { label: 'Visit', mode: 'visit', href, external: true };
 
-  if (kd.subKind === 'external-link') {
+  // NO usable destination. The two fallbacks below differ by a CAPABILITY, not
+  // by a kind: an app with no OAuth client connected has simply nowhere to send
+  // you ("Unavailable"), whereas an app that DOES connect to your Civitai
+  // account has a second, not-yet-built route ("Connect", stubbed). This test
+  // used to read `kd.subKind === 'external-link'`; `subKind` was derived from
+  // `connectClientId` by a truthiness test and nothing else, so reading the
+  // field directly is the SAME predicate with no derived taxonomy in between —
+  // behaviour is byte-identical for every input. Whether the stub should exist
+  // at all is a product question this change deliberately does not answer.
+  if (!kd.connectClientId) {
     return {
       label: 'Unavailable',
       mode: 'info',
@@ -210,8 +221,8 @@ export function getDetailPrimaryAction(
     };
   }
 
-  // Off-site connect with NO usable destination — the honest stub, now reached
-  // only in that genuinely-nowhere-to-go state. Fails safe: no dead nav.
+  // OAuth-connected, with NO usable destination — the honest stub, reached only
+  // in that genuinely-nowhere-to-go state. Fails safe: no dead nav.
   return {
     label: 'Connect',
     mode: 'connect',

--- a/src/components/Apps/appListingDetailView.ts
+++ b/src/components/Apps/appListingDetailView.ts
@@ -230,3 +230,30 @@ export function getDetailPrimaryAction(
     note: 'Connecting this app will be available soon.',
   };
 }
+
+/**
+ * Does the detail page show the "runs entirely off-platform — no Civitai
+ * install, account access, or permissions" disclosure?
+ *
+ * 🔴 EXTRACTED FROM THE JSX ON PURPOSE. This predicate makes a SECURITY CLAIM to
+ * the viewer, and it is FALSE of a listing with an OAuth app connected — that
+ * app can be granted account access, which is the whole point of connecting it.
+ * Inline in `AppListingDetailBody` it was unreachable by the blocking node
+ * `unit` project, and the report-only browser suite asserted it nowhere at all,
+ * so deleting the condition — printing "no account access" over every off-site
+ * listing — was a change no test could catch. Here it is a pure function with
+ * its own truth-table tests.
+ *
+ * Three conjuncts, each load-bearing:
+ *   - `offsite` — an on-site app runs ON platform, so the sentence is simply
+ *     wrong about it;
+ *   - no `connectClientId` — the capability check; see above;
+ *   - a non-null `externalUrl` — there is no "runs off-platform" claim to make
+ *     about a listing with nowhere to run.
+ *
+ * Truthiness on `connectClientId`, matching the projection's `|| null` and the
+ * no-destination fallback above, so all three read the capability the same way.
+ */
+export function shouldShowOffsiteDisclosure(kindData: ListingDetail['kindData']): boolean {
+  return kindData.kind === 'offsite' && !kindData.connectClientId && !!kindData.externalUrl;
+}

--- a/src/components/Apps/appListingDetailView.ts
+++ b/src/components/Apps/appListingDetailView.ts
@@ -207,11 +207,25 @@ export function getDetailPrimaryAction(
   // by a kind: an app with no OAuth client connected has simply nowhere to send
   // you ("Unavailable"), whereas an app that DOES connect to your Civitai
   // account has a second, not-yet-built route ("Connect", stubbed). This test
-  // used to read `kd.subKind === 'external-link'`; `subKind` was derived from
-  // `connectClientId` by a truthiness test and nothing else, so reading the
-  // field directly is the SAME predicate with no derived taxonomy in between —
-  // behaviour is byte-identical for every input. Whether the stub should exist
-  // at all is a product question this change deliberately does not answer.
+  // used to read `kd.subKind === 'external-link'`.
+  //
+  // 🔴 EQUIVALENCE, STATED AT THE SCOPE IT ACTUALLY HOLDS — there are TWO
+  // producers of this DTO and they did not agree:
+  //   - `app-listing.service.detailKindData` derived the sub-kind by TRUTHINESS
+  //     (`connectClientId ? … : …`), so reading the field directly is the same
+  //     predicate and the behaviour is byte-identical for every input there.
+  //   - `reviewListingPreview.detailKindData` (the mod-review preview) used
+  //     `!= null` for the sub-kind while passing the field through with
+  //     `?? null`. At `connectClientId === ''` those disagree: the OLD preview
+  //     hid the disclosure and showed this Connect stub; the NEW one shows the
+  //     disclosure and "Unavailable". That is a real, if practically
+  //     unreachable, behaviour change (`connect_client_id` is an FK to
+  //     `OauthClient.id` and `offsite-listing.schema.ts` requires
+  //     `z.string().min(1)` on create), and the new answer is the safer of the
+  //     two — an empty string is not a connected OAuth app.
+  //
+  // Whether the stub should exist at all is a product question this change
+  // deliberately does not answer.
   if (!kd.connectClientId) {
     return {
       label: 'Unavailable',
@@ -251,8 +265,25 @@ export function getDetailPrimaryAction(
  *   - a non-null `externalUrl` — there is no "runs off-platform" claim to make
  *     about a listing with nowhere to run.
  *
- * Truthiness on `connectClientId`, matching the projection's `|| null` and the
- * no-destination fallback above, so all three read the capability the same way.
+ * Truthiness on `connectClientId`, matching `app-listing.service`'s `|| null`
+ * and the no-destination fallback above, so all three read the capability the
+ * same way.
+ *
+ * 🔴 TWO PRODUCERS FEED THIS, and only one is the store read path.
+ * `OffsiteReviewQueue`'s `ListingPreviewSection` renders `AppListingDetailBody`
+ * with a detail from `buildListingDetailPreview` whenever the mod-only
+ * projection query is loading, errors, or the row has no `appListingId` — so
+ * that builder's `connectClientId` is load-bearing for THIS claim, and it has
+ * its own passthrough test for exactly that reason. If you add a third
+ * producer, give it one too.
+ *
+ * That preview builder passes the field through with `?? null` while its old
+ * sub-kind used `!= null`, so at `connectClientId === ''` this predicate now
+ * SHOWS the disclosure where the old code hid it. Practically unreachable
+ * (`connect_client_id` is an FK to `OauthClient.id`; `offsite-listing.schema.ts`
+ * requires `z.string().min(1)` on create) and the safer of the two answers — an
+ * empty string is not a connected OAuth app — but it is a real difference, so
+ * do not read "identical rendering" as universal across both producers.
  */
 export function shouldShowOffsiteDisclosure(kindData: ListingDetail['kindData']): boolean {
   return kindData.kind === 'offsite' && !kindData.connectClientId && !!kindData.externalUrl;

--- a/src/components/Apps/reviewListingPreview.ts
+++ b/src/components/Apps/reviewListingPreview.ts
@@ -85,7 +85,6 @@ function cardKindData(row: OffsitePendingRow): ListingCardKindData {
   }
   return {
     kind: 'offsite',
-    subKind: row.appListing?.connectClientId != null ? 'connect' : 'external-link',
     externalUrl: row.appListing?.externalUrl ?? null,
   };
 }
@@ -96,7 +95,6 @@ function detailKindData(row: OffsitePendingRow): ListingDetailKindData {
   }
   return {
     kind: 'offsite',
-    subKind: row.appListing?.connectClientId != null ? 'connect' : 'external-link',
     externalUrl: row.appListing?.externalUrl ?? null,
     connectClientId: row.appListing?.connectClientId ?? null,
   };

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -125,9 +125,6 @@ export type GetAppListingDetailInput = z.infer<typeof getAppListingDetailSchema>
 
 export type ListingKind = 'onsite' | 'offsite';
 
-/** Off-site apps come in two shapes (locked decision §6.4). */
-export type OffsiteSubKind = 'connect' | 'external-link';
-
 /**
  * Public creator chip — id/username/image ONLY (the standard public-user
  * projection subset). No email/PII. `null` only if the owner row vanished.
@@ -169,8 +166,12 @@ export type ListingCardKindData =
     }
   | {
       kind: 'offsite';
-      subKind: OffsiteSubKind;
-      /** External-link target (Visit CTA). Null for a connect-only listing. */
+      /**
+       * External destination (Visit CTA), https-guarded; null when the listing
+       * has none. 🔴 This is the ONLY off-site field on a card — the card DTO
+       * deliberately carries no `connectClientId`, so nothing downstream of it
+       * can re-derive a sub-kind.
+       */
       externalUrl: string | null;
     };
 
@@ -209,9 +210,20 @@ export type ListingDetailKindData =
     }
   | {
       kind: 'offsite';
-      subKind: OffsiteSubKind;
       externalUrl: string | null;
-      /** Public OAuth client_id for a connect-kind listing (NOT a secret); null otherwise. */
+      /**
+       * Public OAuth client_id (NOT a secret) when this listing has an OAuth app
+       * connected; null otherwise.
+       *
+       * 🔴 This is a CAPABILITY flag, not a kind discriminator. Off-site listings
+       * used to fork into a `connect` / `external-link` sub-kind derived from
+       * exactly this field, and the store rendered two different KIND labels off
+       * it. That fork is gone — every off-site listing is one thing. What survives
+       * is the capability question "does this app connect to your Civitai
+       * account?", which two surfaces legitimately still ask (the account-access
+       * disclosure in `AppListingDetailBody` and the no-destination fallback in
+       * `getDetailPrimaryAction`). Read it for THAT; never to re-derive a kind.
+       */
       connectClientId: string | null;
     };
 

--- a/src/server/services/blocks/__tests__/app-listing-actionable.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-actionable.service.test.ts
@@ -44,7 +44,7 @@ describe('checkOffsiteListingActionable — the verdict', () => {
   });
 
   for (const { name, url } of NO_DESTINATION) {
-    it(`BLOCKS an off-site external-link listing whose externalUrl is ${name}`, () => {
+    it(`BLOCKS an off-site listing with NO OAuth client whose externalUrl is ${name}`, () => {
       const result = checkOffsiteListingActionable(offsite({ externalUrl: url }));
       expect(result.ok).toBe(false);
       expect(result.action?.href).toBeUndefined();
@@ -52,8 +52,8 @@ describe('checkOffsiteListingActionable — the verdict', () => {
   }
 
   for (const { name, url } of NO_DESTINATION) {
-    it(`BLOCKS an off-site CONNECT listing whose externalUrl is ${name}`, () => {
-      // client_id present → `resolveOffsiteSubKind` routes this to the connect arm.
+    it(`BLOCKS an OAuth-connected off-site listing whose externalUrl is ${name}`, () => {
+      // client_id present → the no-destination fallback takes the Connect-stub arm.
       const result = checkOffsiteListingActionable(
         offsite({ externalUrl: url, connectClientId: 'client-123' })
       );
@@ -232,12 +232,14 @@ describe('buildActionabilityError', () => {
  * shares the code under test cannot discriminate.
  */
 function expectedKindData(listing: ListingActionabilitySource) {
-  const subKind = listing.connectClientId ? ('connect' as const) : ('external-link' as const);
   return {
     kind: 'offsite' as const,
-    subKind,
     externalUrl:
       listing.externalUrl && /^https:\/\//i.test(listing.externalUrl) ? listing.externalUrl : null,
-    connectClientId: subKind === 'connect' ? listing.connectClientId ?? null : null,
+    // 🔴 TRUTHINESS, not nullish — an empty-string client id projects as null.
+    // This oracle mirrors the projection deliberately by hand; the removed
+    // `subKind` used the same truthiness test, which is why dropping it changes
+    // nothing here.
+    connectClientId: listing.connectClientId || null,
   };
 }

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -54,7 +54,6 @@ import {
   projectListingCard,
   projectListingDetail,
   recommendRollup,
-  resolveOffsiteSubKind,
 } from '../app-listing.service';
 import { listAppListingsSchema } from '~/server/schema/blocks/app-listing-read.schema';
 
@@ -145,13 +144,13 @@ describe('recommendRollup', () => {
   });
 });
 
-describe('resolveOffsiteSubKind', () => {
-  it('connect when a connect client is set, external-link otherwise', () => {
-    expect(resolveOffsiteSubKind('oauth_123')).toBe('connect');
-    expect(resolveOffsiteSubKind(null)).toBe('external-link');
-    expect(resolveOffsiteSubKind(undefined)).toBe('external-link');
-  });
-});
+/**
+ * 🔴 `resolveOffsiteSubKind` is DELETED. It returned `connectClientId ? 'connect'
+ * : 'external-link'`, and that derived value was the whole off-site display
+ * taxonomy. Its coverage moves to the two projections below, which now assert
+ * the ABSENCE of a `subKind` key rather than its value (the "key set is exactly
+ * …" cases), plus the truthiness case its deletion could have silently changed.
+ */
 
 describe('cursor encode/decode', () => {
   it('round-trips a 2-field cursor (non-top-rated sorts)', () => {
@@ -312,7 +311,7 @@ describe('projectListingCard — public allowlist (no internal leaks)', () => {
     expect(card.reviewCount).toBe(0);
   });
 
-  it('offsite connect card: subKind=connect + externalUrl passthrough', () => {
+  it('offsite card with an OAuth client and no URL: NO subKind, externalUrl passthrough', () => {
     const row = hydratedRow({
       kind: 'offsite',
       appBlockId: null,
@@ -322,41 +321,84 @@ describe('projectListingCard — public allowlist (no internal leaks)', () => {
     });
     const card = projectListingCard(row as never);
     expect(card.kind).toBe('offsite');
-    expect(card.kindData).toEqual({ kind: 'offsite', subKind: 'connect', externalUrl: null });
+    expect(card.kindData).toEqual({ kind: 'offsite', externalUrl: null });
   });
 
-  it('offsite external-link card (LEGACY URL-only, connectClientId null): subKind=external-link + externalUrl, grandfathered', () => {
+  /**
+   * 🔴 THE GRANDFATHERED LISTING — the load-bearing case for this change.
+   *
+   * Measured in production 2026-08-19: of five off-site listings, exactly ONE
+   * approved row has `connect_client_id IS NULL`. Every listing minted since
+   * then goes through `ExternalSubmitForm`, whose create flow REQUIRES a
+   * `connectClientId` — so this row is the only live inhabitant of what used to
+   * be the `external-link` sub-kind, and it is the shape most at risk of
+   * rendering blank / "unknown" / falling through a deleted branch.
+   *
+   * It must project to the SAME `kindData` shape as an OAuth-connected row: one
+   * kind, no sub-kind key, its URL intact.
+   */
+  it('🔴 GRANDFATHERED offsite card (connectClientId null): same shape, no subKind, URL intact', () => {
     const row = hydratedRow({
       kind: 'offsite',
       appBlockId: null,
       appBlock: null,
       connectClientId: null,
-      externalUrl: 'https://ext.example/app',
+      externalUrl: 'https://grandfathered.example/app',
     });
     const card = projectListingCard(row as never);
     expect(card.kindData).toEqual({
       kind: 'offsite',
-      subKind: 'external-link',
-      externalUrl: 'https://ext.example/app',
+      externalUrl: 'https://grandfathered.example/app',
     });
   });
 
-  it('MERGED offsite card (connect client + a homepage URL): subKind=connect AND the Visit URL both surface', () => {
-    // The merged model — a new external listing links an OAuth client AND may carry an
-    // optional homepage link. Both must be present on the card DTO.
-    const row = hydratedRow({
-      kind: 'offsite',
+  /**
+   * 🔴 The collapse, stated as an EQUALITY rather than as two labels. Two rows
+   * differing ONLY in `connectClientId` — the exact field the deleted sub-kind
+   * was derived from — must produce byte-identical card kindData. A revert
+   * reintroducing `subKind` fails HERE, on this assertion, because the two
+   * objects would then differ by `'connect'` vs `'external-link'`.
+   *
+   * The URL is deliberately shared and non-default so the equality cannot be
+   * satisfied by two empty objects.
+   */
+  it('🔴 the grandfathered row and an OAuth-connected row produce IDENTICAL card kindData', () => {
+    const shared = {
+      kind: 'offsite' as const,
       appBlockId: null,
       appBlock: null,
-      connectClientId: 'oauth_abc',
-      externalUrl: 'https://ext.example/app',
-    });
-    const card = projectListingCard(row as never);
-    expect(card.kindData).toEqual({
+      externalUrl: 'https://same-target.example/app',
+    };
+    const connected = projectListingCard(
+      hydratedRow({ ...shared, connectClientId: 'oauth_abc' }) as never
+    );
+    const grandfathered = projectListingCard(
+      hydratedRow({ ...shared, connectClientId: null }) as never
+    );
+    expect(connected.kindData).toEqual(grandfathered.kindData);
+    // …and it is the collapsed shape, not merely "equal to each other".
+    expect(connected.kindData).toEqual({
       kind: 'offsite',
-      subKind: 'connect',
-      externalUrl: 'https://ext.example/app',
+      externalUrl: 'https://same-target.example/app',
     });
+  });
+
+  it('🔴 the offsite card kindData has NO subKind key at all (not merely a falsy one)', () => {
+    for (const connectClientId of ['oauth_abc', null]) {
+      const card = projectListingCard(
+        hydratedRow({
+          kind: 'offsite',
+          appBlockId: null,
+          appBlock: null,
+          connectClientId,
+          externalUrl: 'https://keys.example/app',
+        }) as never
+      );
+      expect(Object.keys(card.kindData).sort(), String(connectClientId)).toEqual([
+        'externalUrl',
+        'kind',
+      ]);
+    }
   });
 
   it('a vanished owner yields a null creator chip (no crash)', () => {
@@ -437,7 +479,7 @@ describe('projectListingDetail — public allowlist + gallery', () => {
     });
   });
 
-  it('offsite connect detail exposes the PUBLIC connectClientId (never a secret)', () => {
+  it('offsite detail exposes the PUBLIC connectClientId (never a secret), and NO subKind', () => {
     const row = hydratedRow({
       kind: 'offsite',
       appBlockId: null,
@@ -448,24 +490,73 @@ describe('projectListingDetail — public allowlist + gallery', () => {
     const detail = projectListingDetail(row as never);
     expect(detail.kindData).toEqual({
       kind: 'offsite',
-      subKind: 'connect',
       externalUrl: null,
       connectClientId: 'oauth_abc',
     });
   });
 
-  it('offsite external-link detail has a null connectClientId', () => {
+  /**
+   * 🔴 The grandfathered listing at the DETAIL projection. `connectClientId`
+   * stays on the wire as a CAPABILITY (two surfaces still read it — the
+   * account-access disclosure and the no-destination CTA fallback); what is gone
+   * is the derived `subKind`.
+   */
+  it('🔴 GRANDFATHERED offsite detail (connectClientId null): null client, URL intact, no subKind', () => {
     const row = hydratedRow({
       kind: 'offsite',
       appBlockId: null,
       appBlock: null,
       connectClientId: null,
-      externalUrl: 'https://ext.example/app',
+      externalUrl: 'https://grandfathered.example/app',
     });
     const detail = projectListingDetail(row as never);
-    expect(detail.kindData).toMatchObject({
+    expect(detail.kindData).toEqual({
       kind: 'offsite',
-      subKind: 'external-link',
+      externalUrl: 'https://grandfathered.example/app',
+      connectClientId: null,
+    });
+  });
+
+  it('🔴 the offsite detail kindData key set is exactly kind/externalUrl/connectClientId', () => {
+    for (const connectClientId of ['oauth_abc', null]) {
+      const detail = projectListingDetail(
+        hydratedRow({
+          kind: 'offsite',
+          appBlockId: null,
+          appBlock: null,
+          connectClientId,
+          externalUrl: 'https://keys.example/app',
+        }) as never
+      );
+      expect(Object.keys(detail.kindData).sort(), String(connectClientId)).toEqual([
+        'connectClientId',
+        'externalUrl',
+        'kind',
+      ]);
+    }
+  });
+
+  /**
+   * 🔴 `|| null`, NOT `?? null`. The deleted `resolveOffsiteSubKind` used a
+   * TRUTHINESS test, and the old projection wrote
+   * `subKind === 'connect' ? connectClientId ?? null : null` — so an
+   * empty-string client id reached the wire as `null`. Preserving that is what
+   * makes this collapse behaviour-neutral rather than merely type-clean; `??`
+   * would newly emit `''`, and every consumer of this field is a
+   * "does this app connect to your account?" truthiness check.
+   */
+  it('🔴 an empty-string connectClientId still projects as null (truthiness, not nullish)', () => {
+    const row = hydratedRow({
+      kind: 'offsite',
+      appBlockId: null,
+      appBlock: null,
+      connectClientId: '',
+      externalUrl: 'https://empty-client.example/app',
+    });
+    const detail = projectListingDetail(row as never);
+    expect(detail.kindData).toEqual({
+      kind: 'offsite',
+      externalUrl: 'https://empty-client.example/app',
       connectClientId: null,
     });
   });

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -21,7 +21,6 @@ import type {
   ListingKind,
   ListingRecommendRollup,
   ListingSort,
-  OffsiteSubKind,
 } from '~/server/schema/blocks/app-listing-read.schema';
 import { listingCoverUrl, listingIconUrl } from '~/server/services/blocks/listing-media-url';
 import { queryCache } from '~/server/utils/cache-helpers';
@@ -150,11 +149,6 @@ export function recommendRollup(
   };
 }
 
-/** Off-site sub-kind: OAuth-connect when a connect client is set, else external-link. */
-export function resolveOffsiteSubKind(connectClientId: string | null | undefined): OffsiteSubKind {
-  return connectClientId ? 'connect' : 'external-link';
-}
-
 /**
  * Re-assert (defense-in-depth) that an off-site `externalUrl` is an https URL
  * before it reaches the wire — so a bad row can never surface a `javascript:` /
@@ -258,7 +252,6 @@ function cardKindData(row: HydratedListing): ListingCardKindData {
   if (row.kind === 'offsite') {
     return {
       kind: 'offsite',
-      subKind: resolveOffsiteSubKind(row.connectClientId),
       externalUrl: safeExternalUrl(row.externalUrl),
     };
   }
@@ -307,8 +300,8 @@ export type DetailKindDataSource = {
   kind: string;
   slug: string;
   // `| undefined` so a Prisma *create input* (whose nullable columns are optional)
-  // satisfies this as-is. Both consumers below (`safeExternalUrl`,
-  // `resolveOffsiteSubKind`) already accept `undefined` identically to `null`.
+  // satisfies this as-is. Both consumers below (`safeExternalUrl` and the
+  // `|| null` on `connectClientId`) treat `undefined` identically to `null`.
   externalUrl?: string | null;
   connectClientId?: string | null;
   appBlockId?: string | null;
@@ -317,14 +310,19 @@ export type DetailKindDataSource = {
 
 export function detailKindData(row: DetailKindDataSource): ListingDetailKindData {
   if (row.kind === 'offsite') {
-    const subKind = resolveOffsiteSubKind(row.connectClientId);
     return {
       kind: 'offsite',
-      subKind,
       externalUrl: safeExternalUrl(row.externalUrl),
       // The OAuth client_id is public (it's sent in the connect URL); the secret
-      // is never selected here. Null for an external-link listing.
-      connectClientId: subKind === 'connect' ? row.connectClientId ?? null : null,
+      // is never selected here. Null when no OAuth app is connected.
+      //
+      // 🔴 `|| null`, NOT `?? null`, and that is deliberate: this used to read
+      // `subKind === 'connect' ? row.connectClientId ?? null : null`, and the
+      // removed sub-kind was `connectClientId ? 'connect' : 'external-link'` —
+      // a TRUTHINESS test. So an EMPTY-STRING client id projected as `null`
+      // before, and `?? null` would newly project it as `''`. `|| null` keeps
+      // the wire value byte-identical for every input.
+      connectClientId: row.connectClientId || null,
     };
   }
   return {

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -502,10 +502,13 @@ export function listingMatureFilter(redCapable: boolean): Prisma.Sql {
  * public external App-store GA. Mirrors `listingMatureFilter`'s pure-`Prisma.Sql`
  * shape (uses the `al` alias, safe to AND into the keyset WHERE):
  *   - `full`            → `TRUE` (no kind restriction — byte-identical to today).
- *   - `public-external` → `al.kind = 'offsite'` — the offsite subset ONLY, for BOTH
- *     sub-kinds (`connect` AND `external-link`). Onsite App Blocks are excluded.
+ *   - `public-external` → `al.kind = 'offsite'` — the offsite subset ONLY, whether
+ *     or not the listing links an OAuth client. Onsite App Blocks are excluded.
  *     🔴 The kind gate is `kind='offsite'`, NOT `connect_client_id IS NULL` — an
  *     offsite listing is public whether or not it links an OAuth connect client.
+ *     (This used to say "for BOTH sub-kinds (`connect` AND `external-link`)";
+ *     that display taxonomy is gone — offsite is one kind — but the gate itself
+ *     is unchanged, because it never keyed on the sub-kind in the first place.)
  *   - `none`            → `FALSE` — fail-closed. (The router short-circuits `none`
  *     before reaching SQL, so this is defense-in-depth, never the live path.)
  *
@@ -686,8 +689,8 @@ export async function getListingDetail(
   if (!row || row.status !== 'approved') return null;
   // STORE-SCOPE kind gate (the public/onsite security boundary): under
   // `public-external` an ONSITE listing is indistinguishable from a missing one —
-  // return null so no crafted id/slug can reach an onsite listing's detail. Both
-  // offsite sub-kinds (connect + external-link) remain visible (gate on `kind`,
+  // return null so no crafted id/slug can reach an onsite listing's detail. EVERY
+  // offsite listing remains visible, OAuth-connected or not (gate on `kind`,
   // never `connectClientId`). `full` imposes no kind restriction (unchanged).
   if (scope === 'public-external' && row.kind !== 'offsite') return null;
   // DEPLOY-GATE (generic, all app-blocks): an ONSITE listing whose backing

--- a/src/shared/constants/app-transfer.constants.ts
+++ b/src/shared/constants/app-transfer.constants.ts
@@ -38,11 +38,11 @@
  *      confirmation in `OAuthAppsCard` itself describes as revoking every token and
  *      disconnecting every user. Copy that names it as the prerequisite for a listing
  *      transfer makes an irreversible act on a LIVE integration read as routine paperwork.
- *   2. ITS EFFECT ON THE LISTING IS SILENT AND UNWANTED. `SetNull` demotes the listing out
- *      of the `connect` sub-kind (`resolveOffsiteSubKind` routes on
- *      `connectClientId != null`), stranding the `connectRequestedScopes` /
- *      `connectScopeJustifications` a moderator approved — and on a connect listing with
- *      no `externalUrl` it leaves an approved listing whose primary CTA has no `href`,
+ *   2. ITS EFFECT ON THE LISTING IS SILENT AND UNWANTED. `SetNull` nulls the listing's
+ *      `connectClientId`, stranding the `connectRequestedScopes` /
+ *      `connectScopeJustifications` a moderator approved — and on an OAuth-connected
+ *      listing with no `externalUrl` it leaves an approved listing whose primary CTA has
+ *      no `href`,
  *      i.e. exactly the state `assertOffsiteListingActionable` exists to refuse at
  *      go-live. The "remedy" would walk the owner into a shape the go-live gate rejects.
  *   3. IT IS NOT RELIABLY AVAILABLE TO WHOEVER READS THE STRING.

--- a/src/shared/constants/app-transfer.constants.ts
+++ b/src/shared/constants/app-transfer.constants.ts
@@ -42,9 +42,8 @@
  *      `connectClientId`, stranding the `connectRequestedScopes` /
  *      `connectScopeJustifications` a moderator approved — and on an OAuth-connected
  *      listing with no `externalUrl` it leaves an approved listing whose primary CTA has
- *      no `href`,
- *      i.e. exactly the state `assertOffsiteListingActionable` exists to refuse at
- *      go-live. The "remedy" would walk the owner into a shape the go-live gate rejects.
+ *      no `href`, i.e. exactly the state `assertOffsiteListingActionable` exists to refuse
+ *      at go-live. The "remedy" would walk the owner into a shape the go-live gate rejects.
  *   3. IT IS NOT RELIABLY AVAILABLE TO WHOEVER READS THE STRING.
  *      `loadConnectClientForListing` BYPASSES its owner check for a moderator, so a
  *      mod may link a client the listing owner does not own, while `oauthClient.delete`


### PR DESCRIPTION
## What

Off-site app-store listings forked **for display** into two sub-kinds. This removes that fork: `offsite` is one kind with one label.

The sub-kind was **derived**, never stored:

```ts
resolveOffsiteSubKind(connectClientId) => connectClientId ? 'connect' : 'external-link'
```

and the store rendered two different **kind** labels off it — `Connect app` / `Off-site` on the card badge, `Connect app` / `Off-site link` in the detail rail. Because `ExternalSubmitForm`'s create flow **requires** a `connectClientId` (`offsiteSubmitFormConfig.ts:440-441`, *"Choose one of your OAuth apps."*), every listing minted since then is `connect` — so the parent category filter labelled the whole category `Off-site`, a word that was true only of the child nothing could create any more, while the reachable child contradicted it.

Collapsing onto the parent word removes the contradiction instead of papering over it.

**Out of scope, deliberately:** OAuth stays **required** on new submissions. The submit flow is untouched.

## No migration, no DB change — confirmed

There is **no `sub_kind` column**. Verified in this branch, not from memory:

* `grep -n "sub_kind\|subKind"` over `packages/civitai-db-schema/prisma/schema.prisma` and `schema.full.prisma` → **0 hits**
* `grep -rl "sub_kind"` over every file under `packages/civitai-db-schema/prisma/migrations/` → **0 files**
* `app_listings.kind` is `'onsite' | 'offsite'` and nothing else (DB CHECK + service validation)

The taxonomy existed only in the projection layer. Nothing to migrate, nothing to backfill, no `_prisma_migrations` involvement.

## What changed

1. **Deleted** `resolveOffsiteSubKind` and the `OffsiteSubKind` type; dropped `subKind` from `ListingCardKindData` and `ListingDetailKindData`.
2. **Collapsed the labels** onto the existing parent word **`Off-site`** — byte-identical to what `KindFilterButtons` already puts on the category. **No new user-facing wording is introduced.** #4187 renames that word; keeping the two apart is what makes both reviewable, and the rename lands cleanly because this PR removes the child that contradicted it.
   * Side effect worth noting: `kindLabel`'s docstring *claimed* it mirrored `getListingBadge`'s wording and did not (`Off-site link` vs `Off-site`). Now it does, and there is a test pinning the equality.
3. **Kept `connectClientId` as data.** Still written, still required on submit, still on the detail DTO. It no longer forks the display taxonomy.

### Two surfaces still read `connectClientId` — as a capability, not a kind

Both were `subKind === '…'` tests. Since the sub-kind was a *truthiness test on this exact field and nothing else*, reading the field directly is the **same predicate with no derived taxonomy in between** — behaviour is byte-identical for every input, which is what the mutation results below show.

| Surface | Predicate | Why it must survive |
|---|---|---|
| `AppListingDetailBody` — the off-platform disclosure | `shouldShowOffsiteDisclosure(kindData)` | The sentence says *"no Civitai install, account access, or permissions"*. That is **false** of a listing with an OAuth app connected. It cannot become unconditional. |
| `getDetailPrimaryAction` — the no-destination fallback | `!kd.connectClientId` → `Unavailable`, else the `Connect` stub | An app with no client has nowhere to send you; an OAuth-connected one has a second, not-yet-built route. |

**Empty-string guard:** the projection keeps `|| null` (**not** `?? null`) on `connectClientId`, because the deleted `subKind === 'connect' ? connectClientId ?? null : null` was truthiness-based and mapped `''` to `null`. `??` would newly put `''` on the wire, and every consumer is a truthiness check. Pinned by a test; mutating `||` → `??` is killed.

## 🔴 Answering "does anything still need an OAuth-connected indicator?" — yes, surfaced, not decided

Two findings, both left alone:

1. **The disclosure Alert is that indicator today, inverted.** It says "no account access" and is suppressed for OAuth-connected listings — so a connected app is signalled by the *absence* of a sentence. That is a weak indicator, and with the `Connect app` kind label gone there is now **nothing positive** on the card or the detail header saying "this app can connect to your Civitai account". If the product wants a capability chip, this is where it goes. **I did not invent one.**
2. **The `Connect` stub survives** for the OAuth-connected + no-destination state, promising *"Connecting this app will be available soon."* for a flow that does not exist. Collapsing the taxonomy makes it easy to read as "one more sub-kind branch to delete" — it is not, so I preserved it exactly and pinned both arms. Whether it should exist at all is a product call.

### 🔴 Scope honesty on the badge half — it changes nothing anyone can see

`getListingBadge` has **no production consumer**: it is imported by two test files and nothing else, and `AppListingCard.tsx` does not import it. So of the two labels this PR collapses, **only the detail rail's "Kind" row is rendered to a user.** The badge half is a dead-code cleanup.

That also means the new test pinning the kind row byte-identical to the card badge reconciles a value **no surface displays**. It is still worth having — it stops the two from drifting again if the badge is ever wired up, which is exactly how they diverged in the first place — but it should not be read as reconciling two rendered surfaces. Only one renders.

(The browser suite does contain an "Off-site is absent from the card" check, but it uses the `expect.element(...).not.toBeInTheDocument()` form that is **inert in this repo — #4197** — so it is not evidence. The import graph is; that is what the corrected `AppListingCard.tsx` header now cites.)

## Testing

Blocking gate is the node `unit` project (`src/**/__tests__` is excluded from `tsconfig`, so those files are **not** typechecked — every edit there was made by hand, not by following `tsc`).

### Red → green matrix

**New tests vs. base source** (source files reverted to `origin/main`, new tests kept):

```
Test Files  5 failed | 2 passed (7)
     Tests  18 failed | 233 passed (251)
```

**Same tests at HEAD (post-rebase):** `1252 files / 19754 tests passed, 0 failed` for the whole `unit` project; `170 files / 1859 tests passed, 0 failed` for the whole `component` project.

Honest labelling of those 18:

* **Genuine behaviour reds** (base emits a different value with base-shaped inputs too): the 8 in `app-listing.service.test.ts` and 3 in `reviewListingPreview.test.ts` (`subKind` present in the projected DTO), plus the 2 in `appListingDetailRows.test.ts` (`'Off-site link'` ≠ `'Off-site'`, and the badge/rail equality).
* **New-behaviour guards, not regression coverage**: the 4 `GRANDFATHERED …` cases in `appListingDetailView.test.ts` and the empty-string one. They go red at base partly because the collapsed fixture *cannot express* a `subKind`, so base takes the stub arm. They pin the new predicate; they do not prove a base defect.
* The whole change is an intentional behaviour change, so nothing here is claimed as "regression coverage" for a shipped bug.

### 🔴 The grandfathered listing — the load-bearing case

Production (measured 2026-08-19): 5 off-site listings — 4 approved (3 with `connect_client_id`, **1 without**) and 1 draft (with). Exactly one live listing lacks OAuth, and `ExternalSubmitForm` cannot mint another. It is built explicitly as a fixture, not hypothetically:

* `🔴 GRANDFATHERED offsite card (connectClientId null): same shape, no subKind, URL intact`
* `🔴 GRANDFATHERED offsite detail (connectClientId null): null client, URL intact, no subKind`
* `🔴 the grandfathered row and an OAuth-connected row produce IDENTICAL card kindData` — stated as an equality between two rows differing **only** in `connectClientId`, plus the collapsed shape itself so it cannot pass on two empty objects
* `🔴 GRANDFATHERED (no OAuth client) + https → Visit ↗`, `+ non-https → Unavailable`, `+ null url → Unavailable (never a dead Connect stub)`, and the full 4-shape `Unavailable, NOT the Connect stub` sweep
* `🔴 GRANDFATHERED (no OAuth client) + a destination → SHOWN` for the disclosure
* `🔴 the kind row reads one word for BOTH off-site shapes` — grandfathered included

It renders the single label. Not blank, not "unknown", no dead branch.

### Mutation results — each killed by its own assertion

| # | Mutant | Verdict | Killing assertion |
|---|---|---|---|
| M0 | **Revert the whole collapse** (base source, new tests) | KILLED | 18 tests, incl. `expected 'Off-site link' to be 'Off-site'` and `expected { label: 'Connect', …} to deeply equal { label: 'Unavailable', …}` |
| M1 | badge label → `'Connect app'` | KILLED (3) | `🔴 the off-site badge label is exactly the store kind-filter word` — `expected 'Connect app' to be 'Off-site'` |
| M2 | kind row → `'Off-site link'` | KILLED (2) | `🔴 the kind row reads one word for BOTH off-site shapes` — `expected 'Off-site link' to be 'Off-site'` |
| M3 | projection `\|\| null` → `?? null` | KILLED (1) | `🔴 an empty-string connectClientId still projects as null` |
| M4 | invert `!kd.connectClientId` in the CTA fallback | KILLED (7) | `🔴 GRANDFATHERED with NO usable destination → Unavailable, NOT the Connect stub` — `expected 'connect' to be 'info'` |
| M5 | delete that test (always `Unavailable`) | KILLED (2) | `🔴 OAuth-connected with NO usable destination → the stub still fails safe` — `expected 'info' to be 'connect'` |
| M6 | disclosure: drop the capability conjunct | KILLED (1) | `🔴 an OAuth-connected listing → NOT shown` — `expected true to be false` |
| M7 | disclosure: `!x` → `x == null` | KILLED (1) | `an empty-string connectClientId does NOT suppress it` |
| M8 | disclosure: drop the `kind === 'offsite'` conjunct | **SURVIVED, then fixed** | see below |
| M9 | disclosure: drop the `externalUrl` conjunct | KILLED (1) | `an off-site listing with no destination → NOT shown` |
| M23 | preview builder: hardcode `connectClientId: null` | **SURVIVED, then fixed** — see the audit round below | `🔴 an OAuth-connected row PASSES THE CLIENT ID THROUGH` |
| M24 | preview builder: wrong field (`externalUrl` → `connectClientId`) | KILLED (3) | same, plus `🔴 a grandfathered row … DOES get the disclosure` |

All 11 re-run on the rebased tree; all killed, each on its own named assertion.

**M8 is the interesting one, and it forced a real change (commits 2–3).**

The condition lived **inline in `AppListingDetailBody`'s JSX**, where the blocking `unit` project cannot reach it — and the report-only browser suite asserted it **nowhere at all** (`grep` for the sentence finds only the component). So the whole predicate was uncovered, and a mutant that shows *"no Civitai install, account access, or permissions"* over **every** off-site listing, OAuth-connected ones included, passed a fully green suite. That is a security claim, and the branch is live: the grandfathered listing sits exactly on it.

So it was extracted as `shouldShowOffsiteDisclosure(kindData)` with a truth-table test plus a structural check (with positive control) that the renderer calls it rather than re-deriving it.

Then M8 **still survived** — and per the rule, reachability was established before concluding anything: the mutant *ran* (the on-site case reaches it), it simply could not be **observed**, because an on-site `kindData` has no `externalUrl`, so the third conjunct carried the verdict and the deleted term was never the deciding one. **Reachable-but-unasserted, not never-executed** — different findings, opposite remedies. The discriminating fixture is a **cast producer** handing over both `kind: 'onsite'` and an `externalUrl`: impossible per the DTO union, routine at runtime (the moderator combined-review surface builds `ListingDetail`-shaped objects through a cast — `appListingDetailRows` carries a 🔴 note about a required field being absent there once blanking the whole review modal). With that fixture + a positive control that flips only `kind`, M8 dies on `🔴 an ON-SITE kindData carrying an externalUrl (cast producer) → still NOT shown`.

Fixtures throughout use pairwise-distinct, non-default values (two different grandfathered URLs, distinct ids/names on the equality pairs) so a mutant hardcoding a literal cannot survive.

### Instruments validated

* **`pnpm typecheck`** — reported **16 errors** mid-way (browser fixtures still passing `subKind`), so the instrument was watched going red before its final `0 type errors` was believed. Never bare `tsc --noEmit`.
* **`eslint`** on the 21 changed files: `0 errors, 4 warnings`, all pre-existing on untouched lines. (First attempt fed it a mis-built file list and it errored on a nonexistent path rather than silently passing — the list was rebuilt against the merge-base.)
* **`vitest`** counts read from the body, never an exit code — every number here is quoted as observed, and each mutation run reports its own failed/passed split.
* **Browser (`component`) project — full project green: `170 files / 1859 tests passed, 0 failed`**, under nix with `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` at the 1228 bundle (the repo-pinned 1200 shell will not launch on NixOS). The five suites this PR touches: `133 passed, 0 failed`.

  🔴 **Retracted: an earlier revision of this section claimed the component project was broken locally and called its failures "pre-existing and environmental". That was wrong, and it was my own instrument error.** I had invoked it as `npx --prefix <worktree> vitest --root <worktree>` from a *different* cwd. `--prefix`/`--root` do not change the process cwd, so postcss/tailwind resolved `tailwind.config` against my invocation directory, found none, and fell back to Tailwind defaults — hence `'screens.xs' does not exist in your theme config` and `content option … is missing or empty`, and hence 7 geometry/CSS failures that were artifacts of my command line. Re-run with the cwd actually inside the worktree (`pnpm --dir <worktree> test:component`), the same tree is **1859/1859 green**.

  The tell I walked past: my "base control" reproduced the same failures — which I read as *"pre-existing, therefore environmental"*, when it equally meant *"my invocation is wrong in both arms"*. **A control that fires identically in both arms attributes nothing.** The tier was available the whole time.

### Deleted-symbol sweep

`git grep -E "resolveOffsiteSubKind|OffsiteSubKind|subKind" -- src packages`, before → after: **13 non-test references across 7 files** before; after, **zero live references anywhere**. The 20 remaining hits are all prose — comments explaining what the code *used to* read, and test titles asserting the key's absence — deliberately kept so the next reader does not reintroduce the fork.

## Audit round (F1 / F2 / F4)

**🔴 F1 — a survived mutant on the sibling producer, and this PR is what created the exposure.**

`reviewListingPreview.detailKindData` also emits `connectClientId`, and hardcoding it to `null` (M23) **survived** — reproduced here before fixing anything. Verified reachable by reading the call site, not by assumption: `ListingPreviewSection` (`OffsiteReviewQueue.tsx`) uses `previewQuery.data?.detail ?? buildListingDetailPreview(request)` and renders it via `<AppListingDetailBody detail={detail} preview />`, so the fallback path (query loading / errored / no `appListingId`) reaches the disclosure. Material: a moderator previewing an **OAuth-connected** listing would be told *"no Civitai install, account access, or permissions"*.

Why nothing caught it: the one off-site test fed a row with **no** `connectClientId` and asserted `connectClientId: null` — **fixture constant equals assertion constant**, so it passes against a passthrough and against a hardcoded null alike. I had added exactly the right connected/grandfathered pair for the sibling `buildListingCardPreview` in the same file and the same commit, and not for this one.

And it is **this PR's doing**: pre-change the preview's own `subKind` carried the capability, so nulling `connectClientId` alone changed nothing on screen. Post-collapse it is the sole carrier.

Fixed with a truthy-valued passthrough test plus its grandfathered counterpart, both asserting through `shouldShowOffsiteDisclosure` — the predicate the renderer actually calls — so the pair pins the **seam**, not one field. The vacuous case is kept for the null shape and labelled vacuous in place. M23 now dies on its own assertion; M6 now dies in **both** the view-model truth table and the preview seam.

**F2 — an equivalence claim stated wider than it holds.** Two comments said the new predicate is "byte-identical for every input". True for `app-listing.service` (truthiness both sides); **false** for the preview builder, whose old sub-kind used `!= null` while it passes the field through with `?? null` — at `connectClientId === ''` the old preview hid the disclosure and showed the Connect stub, the new one shows the disclosure and "Unavailable". Independently verified as practically unreachable (FK to `OauthClient.id` in `schema.prisma`; `z.string().min(1)` in `offsite-listing.schema.ts`), and the new answer is the safer one — but the comment is what a maintainer leans on, so both sites now name the producer they mean.

**F4 — stale prose in files already touched here.** Two `app-listing.service.ts` store-scope comments naming the dead sub-kinds (the gate itself never keyed on them and is unchanged), and `AppListingCard.tsx`'s header claiming a badge the card does not render. Untouched files carrying the same rot were left alone.

Also corrected: a test comment that named `MySubmissionsList` as a direct off-site caller of `getDetailPrimaryAction` — it hardcodes `kind: 'onsite'` and never reaches that branch.

**Rebased onto current `origin/main`** (14 commits had landed) so the gate ran on the merged tree, not the stale branch. Only one unrelated file overlapped (`__tests__/appListingStatChips.test.ts`).

### CI — post-rebase, at head `2992bce4`

**19 rows terminal: 18 SUCCESS + 1 SKIPPED, none failed** — including `preview / smoke-tests` → **"Preview smoke tests passed (66 passed, 0 flaky)"**.

🔴 Gated on the **PipelineRun**, not the rollup, because the rollup lies during a run. Measured on this very PR: at one point the rollup showed **12 rows, every one green**, while `pr-preview-4200-r5jzx` was still `Running`; later it showed **19 rows, every one green** — and the PipelineRun was *still* `Running`, with a `lighthouse` TaskRun outstanding after `smoke-test` had already posted its success. An all-green rollup is not a finished pipeline at any row count.

Both runs for this SHA now report `Succeeded / Completed` in-cluster:

* `pr-check-4200-th5vt` → `True / Completed`
* `pr-preview-4200-r5jzx` → `True / Completed` (20:55:49Z)

---

<details>
<summary>Pre-audit run at the old head <code>d59ba514</code> (superseded — kept for the record, and it is where the smoke-tests mistake above was made)</summary>

All 18 checks terminal, **17 SUCCESS + 1 SKIPPED**, none failed:

`App unit tests + typecheck` · `Unit tests` · `Package unit tests` · `ESLint + Prettier (changed files)` · `Schema drift gate` · `event-engine-common pin` · `Windows dev-env (bash)` · `Windows dev-env (pwsh)` · `tekton / typecheck` · `tekton / fixture-bootstrap` · `preview / deploy` ("Preview deployed and reachable") · `preview / render-check` ("HTTP 302, renders correctly") · `preview / unit-tests` · `preview / apps-tests` · `preview / auth-tests` · `preview / packages-tests` · `preview / component-tests` — and `Typecheck (fork PRs / non-main base)` skipped by design.

Two honest caveats on that list:

* 🔴 **Retracted.** That earlier "no `preview / smoke-tests` check exists on this PR" claim was wrong, and it was the classic shape: I read an all-green 18-row rollup **while the `pr-preview-…` PipelineRun was still `Running`**, and inferred a missing check from a *not-yet-posted* one. `smoke-tests` posted afterwards as the 19th row and passed. **An absent row means "not yet", not "not a thing"** — the fix is to gate on the PipelineRun's own completion plus an expected minimum row count, which is what the post-rebase verification below does.
* Every `preview / *-tests` check reports **"(report-only)"** in its own description, so their green is a weak signal by construction. `preview / smoke-tests` is not report-only.

</details>

## Not verified

* Nothing was run against a real database or a live listing — the store read path is exercised only through its unit fixtures.
* The rendered `/apps` grid and `/apps/store-preview/<slug>` were **not** opened in a real browser session. The `component` project renders these components in headless chromium and is fully green (1859/1859), but that is not the same as clicking the live, flag-gated pages.
* The `OffsiteReviewQueue` moderator preview path that F1 is about is covered at the **builder + predicate** level (its two producers and the predicate they feed), not by a rendered assertion through `ListingPreviewSection` itself.
* The prod row counts (5 off-site, 1 grandfathered) are carried over from the measurement in the task brief, not re-queried in this session.
