### PR TITLE
fix(moderator): move creator-shop review evidence below the verdict

### DIFF
--- a/packages/civitai-db-schema/src/enums.ts
+++ b/packages/civitai-db-schema/src/enums.ts
@@ -22,8 +22,7 @@ export const ReferralRedemptionType = {
   MembershipPerks: 'MembershipPerks',
 } as const;
 
-export type ReferralRedemptionType =
-  (typeof ReferralRedemptionType)[keyof typeof ReferralRedemptionType];
+export type ReferralRedemptionType = (typeof ReferralRedemptionType)[keyof typeof ReferralRedemptionType];
 
 export const BuzzWithdrawalRequestStatus = {
   Requested: 'Requested',
@@ -35,16 +34,14 @@ export const BuzzWithdrawalRequestStatus = {
   ExternallyResolved: 'ExternallyResolved',
 } as const;
 
-export type BuzzWithdrawalRequestStatus =
-  (typeof BuzzWithdrawalRequestStatus)[keyof typeof BuzzWithdrawalRequestStatus];
+export type BuzzWithdrawalRequestStatus = (typeof BuzzWithdrawalRequestStatus)[keyof typeof BuzzWithdrawalRequestStatus];
 
 export const UserPaymentConfigurationProvider = {
   Stripe: 'Stripe',
   Tipalti: 'Tipalti',
 } as const;
 
-export type UserPaymentConfigurationProvider =
-  (typeof UserPaymentConfigurationProvider)[keyof typeof UserPaymentConfigurationProvider];
+export type UserPaymentConfigurationProvider = (typeof UserPaymentConfigurationProvider)[keyof typeof UserPaymentConfigurationProvider];
 
 export const CashWithdrawalStatus = {
   Paid: 'Paid',
@@ -92,8 +89,7 @@ export const CryptoTransactionStatus = {
   Complete: 'Complete',
 } as const;
 
-export type CryptoTransactionStatus =
-  (typeof CryptoTransactionStatus)[keyof typeof CryptoTransactionStatus];
+export type CryptoTransactionStatus = (typeof CryptoTransactionStatus)[keyof typeof CryptoTransactionStatus];
 
 export const RewardsEligibility = {
   Eligible: 'Eligible',
@@ -271,8 +267,7 @@ export const ModelVersionSponsorshipSettingsType = {
   Bidding: 'Bidding',
 } as const;
 
-export type ModelVersionSponsorshipSettingsType =
-  (typeof ModelVersionSponsorshipSettingsType)[keyof typeof ModelVersionSponsorshipSettingsType];
+export type ModelVersionSponsorshipSettingsType = (typeof ModelVersionSponsorshipSettingsType)[keyof typeof ModelVersionSponsorshipSettingsType];
 
 export const ModelVersionMonetizationType = {
   PaidAccess: 'PaidAccess',
@@ -283,8 +278,7 @@ export const ModelVersionMonetizationType = {
   Sponsored: 'Sponsored',
 } as const;
 
-export type ModelVersionMonetizationType =
-  (typeof ModelVersionMonetizationType)[keyof typeof ModelVersionMonetizationType];
+export type ModelVersionMonetizationType = (typeof ModelVersionMonetizationType)[keyof typeof ModelVersionMonetizationType];
 
 export const LicensingFeeType = {
   PerImageBuzz: 'PerImageBuzz',
@@ -297,15 +291,13 @@ export const LicensingFeeSettlementCurrency = {
   Cash: 'Cash',
 } as const;
 
-export type LicensingFeeSettlementCurrency =
-  (typeof LicensingFeeSettlementCurrency)[keyof typeof LicensingFeeSettlementCurrency];
+export type LicensingFeeSettlementCurrency = (typeof LicensingFeeSettlementCurrency)[keyof typeof LicensingFeeSettlementCurrency];
 
 export const ModelVersionEngagementType = {
   Notify: 'Notify',
 } as const;
 
-export type ModelVersionEngagementType =
-  (typeof ModelVersionEngagementType)[keyof typeof ModelVersionEngagementType];
+export type ModelVersionEngagementType = (typeof ModelVersionEngagementType)[keyof typeof ModelVersionEngagementType];
 
 export const ModelHashType = {
   AutoV1: 'AutoV1',
@@ -392,8 +384,7 @@ export const ImageGenerationProcess = {
   inpainting: 'inpainting',
 } as const;
 
-export type ImageGenerationProcess =
-  (typeof ImageGenerationProcess)[keyof typeof ImageGenerationProcess];
+export type ImageGenerationProcess = (typeof ImageGenerationProcess)[keyof typeof ImageGenerationProcess];
 
 export const NsfwLevel = {
   None: 'None',
@@ -441,8 +432,7 @@ export const EntityModerationStatus = {
   Canceled: 'Canceled',
 } as const;
 
-export type EntityModerationStatus =
-  (typeof EntityModerationStatus)[keyof typeof EntityModerationStatus];
+export type EntityModerationStatus = (typeof EntityModerationStatus)[keyof typeof EntityModerationStatus];
 
 export const ImageEngagementType = {
   Favorite: 'Favorite',
@@ -570,8 +560,7 @@ export const CosmeticShopItemStatus = {
   Archived: 'Archived',
 } as const;
 
-export type CosmeticShopItemStatus =
-  (typeof CosmeticShopItemStatus)[keyof typeof CosmeticShopItemStatus];
+export type CosmeticShopItemStatus = (typeof CosmeticShopItemStatus)[keyof typeof CosmeticShopItemStatus];
 
 export const CosmeticEntity = {
   Model: 'Model',
@@ -611,16 +600,14 @@ export const ArticleIngestionStatus = {
   Rescan: 'Rescan',
 } as const;
 
-export type ArticleIngestionStatus =
-  (typeof ArticleIngestionStatus)[keyof typeof ArticleIngestionStatus];
+export type ArticleIngestionStatus = (typeof ArticleIngestionStatus)[keyof typeof ArticleIngestionStatus];
 
 export const ArticleEngagementType = {
   Favorite: 'Favorite',
   Hide: 'Hide',
 } as const;
 
-export type ArticleEngagementType =
-  (typeof ArticleEngagementType)[keyof typeof ArticleEngagementType];
+export type ArticleEngagementType = (typeof ArticleEngagementType)[keyof typeof ArticleEngagementType];
 
 export const GenerationSchedulers = {
   EulerA: 'EulerA',
@@ -651,8 +638,7 @@ export const CollectionWriteConfiguration = {
   Review: 'Review',
 } as const;
 
-export type CollectionWriteConfiguration =
-  (typeof CollectionWriteConfiguration)[keyof typeof CollectionWriteConfiguration];
+export type CollectionWriteConfiguration = (typeof CollectionWriteConfiguration)[keyof typeof CollectionWriteConfiguration];
 
 export const CollectionReadConfiguration = {
   Private: 'Private',
@@ -660,8 +646,7 @@ export const CollectionReadConfiguration = {
   Unlisted: 'Unlisted',
 } as const;
 
-export type CollectionReadConfiguration =
-  (typeof CollectionReadConfiguration)[keyof typeof CollectionReadConfiguration];
+export type CollectionReadConfiguration = (typeof CollectionReadConfiguration)[keyof typeof CollectionReadConfiguration];
 
 export const CollectionType = {
   Model: 'Model',
@@ -707,16 +692,14 @@ export const CollectionContributorPermission = {
   MANAGE: 'MANAGE',
 } as const;
 
-export type CollectionContributorPermission =
-  (typeof CollectionContributorPermission)[keyof typeof CollectionContributorPermission];
+export type CollectionContributorPermission = (typeof CollectionContributorPermission)[keyof typeof CollectionContributorPermission];
 
 export const CollectionCollaboratorRole = {
   Contributor: 'Contributor',
   Manager: 'Manager',
 } as const;
 
-export type CollectionCollaboratorRole =
-  (typeof CollectionCollaboratorRole)[keyof typeof CollectionCollaboratorRole];
+export type CollectionCollaboratorRole = (typeof CollectionCollaboratorRole)[keyof typeof CollectionCollaboratorRole];
 
 export const CollectionInviteStatus = {
   Pending: 'Pending',
@@ -724,8 +707,7 @@ export const CollectionInviteStatus = {
   Declined: 'Declined',
 } as const;
 
-export type CollectionInviteStatus =
-  (typeof CollectionInviteStatus)[keyof typeof CollectionInviteStatus];
+export type CollectionInviteStatus = (typeof CollectionInviteStatus)[keyof typeof CollectionInviteStatus];
 
 export const HomeBlockType = {
   Collection: 'Collection',
@@ -814,8 +796,7 @@ export const EntityCollaboratorStatus = {
   Rejected: 'Rejected',
 } as const;
 
-export type EntityCollaboratorStatus =
-  (typeof EntityCollaboratorStatus)[keyof typeof EntityCollaboratorStatus];
+export type EntityCollaboratorStatus = (typeof EntityCollaboratorStatus)[keyof typeof EntityCollaboratorStatus];
 
 export const ClubAdminPermission = {
   ManageMemberships: 'ManageMemberships',
@@ -862,8 +843,7 @@ export const PurchasableRewardUsage = {
   MultiUse: 'MultiUse',
 } as const;
 
-export type PurchasableRewardUsage =
-  (typeof PurchasableRewardUsage)[keyof typeof PurchasableRewardUsage];
+export type PurchasableRewardUsage = (typeof PurchasableRewardUsage)[keyof typeof PurchasableRewardUsage];
 
 export const EntityType = {
   Image: 'Image',
@@ -1015,8 +995,7 @@ export const ChallengeReviewCostType = {
   Flat: 'Flat',
 } as const;
 
-export type ChallengeReviewCostType =
-  (typeof ChallengeReviewCostType)[keyof typeof ChallengeReviewCostType];
+export type ChallengeReviewCostType = (typeof ChallengeReviewCostType)[keyof typeof ChallengeReviewCostType];
 
 export const ChallengeIngestionStatus = {
   Pending: 'Pending',
@@ -1025,22 +1004,19 @@ export const ChallengeIngestionStatus = {
   Error: 'Error',
 } as const;
 
-export type ChallengeIngestionStatus =
-  (typeof ChallengeIngestionStatus)[keyof typeof ChallengeIngestionStatus];
+export type ChallengeIngestionStatus = (typeof ChallengeIngestionStatus)[keyof typeof ChallengeIngestionStatus];
 
 export const ChallengeEngagementType = {
   Notify: 'Notify',
 } as const;
 
-export type ChallengeEngagementType =
-  (typeof ChallengeEngagementType)[keyof typeof ChallengeEngagementType];
+export type ChallengeEngagementType = (typeof ChallengeEngagementType)[keyof typeof ChallengeEngagementType];
 
 export const EntityMetric_EntityType_Type = {
   Image: 'Image',
 } as const;
 
-export type EntityMetric_EntityType_Type =
-  (typeof EntityMetric_EntityType_Type)[keyof typeof EntityMetric_EntityType_Type];
+export type EntityMetric_EntityType_Type = (typeof EntityMetric_EntityType_Type)[keyof typeof EntityMetric_EntityType_Type];
 
 export const EntityMetric_MetricType_Type = {
   ReactionLike: 'ReactionLike',
@@ -1052,8 +1028,7 @@ export const EntityMetric_MetricType_Type = {
   Buzz: 'Buzz',
 } as const;
 
-export type EntityMetric_MetricType_Type =
-  (typeof EntityMetric_MetricType_Type)[keyof typeof EntityMetric_MetricType_Type];
+export type EntityMetric_MetricType_Type = (typeof EntityMetric_MetricType_Type)[keyof typeof EntityMetric_MetricType_Type];
 
 export const ComicProjectStatus = {
   Active: 'Active',
@@ -1130,8 +1105,7 @@ export const UserRestrictionStatus = {
   Overturned: 'Overturned',
 } as const;
 
-export type UserRestrictionStatus =
-  (typeof UserRestrictionStatus)[keyof typeof UserRestrictionStatus];
+export type UserRestrictionStatus = (typeof UserRestrictionStatus)[keyof typeof UserRestrictionStatus];
 
 export const StrikeReason = {
   BlockedContent: 'BlockedContent',
@@ -1167,8 +1141,7 @@ export const WildcardSetAuditStatus = {
   Dirty: 'Dirty',
 } as const;
 
-export type WildcardSetAuditStatus =
-  (typeof WildcardSetAuditStatus)[keyof typeof WildcardSetAuditStatus];
+export type WildcardSetAuditStatus = (typeof WildcardSetAuditStatus)[keyof typeof WildcardSetAuditStatus];
 
 export const WildcardSetCategoryAuditStatus = {
   Pending: 'Pending',
@@ -1176,8 +1149,7 @@ export const WildcardSetCategoryAuditStatus = {
   Dirty: 'Dirty',
 } as const;
 
-export type WildcardSetCategoryAuditStatus =
-  (typeof WildcardSetCategoryAuditStatus)[keyof typeof WildcardSetCategoryAuditStatus];
+export type WildcardSetCategoryAuditStatus = (typeof WildcardSetCategoryAuditStatus)[keyof typeof WildcardSetCategoryAuditStatus];
 
 export const ReviewVerdict = {
   TruePositive: 'TruePositive',
@@ -1204,16 +1176,14 @@ export const Model3DEngagementType = {
   Notify: 'Notify',
 } as const;
 
-export type Model3DEngagementType =
-  (typeof Model3DEngagementType)[keyof typeof Model3DEngagementType];
+export type Model3DEngagementType = (typeof Model3DEngagementType)[keyof typeof Model3DEngagementType];
 
 export const ShopifyMerchOrderStatus = {
   Pending: 'Pending',
   Granted: 'Granted',
 } as const;
 
-export type ShopifyMerchOrderStatus =
-  (typeof ShopifyMerchOrderStatus)[keyof typeof ShopifyMerchOrderStatus];
+export type ShopifyMerchOrderStatus = (typeof ShopifyMerchOrderStatus)[keyof typeof ShopifyMerchOrderStatus];
 
 export const OutboxEntity = {
   Article: 'Article',

--- a/src/pages/moderator/creator-shop.tsx
+++ b/src/pages/moderator/creator-shop.tsx
@@ -856,48 +856,6 @@ function CreatorShopReviewPage() {
                       )}
                     </SimpleGrid>
 
-                    {/* A pack supplies no artwork to scan, so an empty checks
-                        card reads as an anomaly rather than "not applicable". */}
-                    {!isPack && (
-                      <ChecksCard
-                        icon={<IconScan size={15} color="var(--mantine-color-dimmed)" />}
-                        title="Automated checks"
-                      >
-                        {checks.length ? (
-                          checks.map((c, i) => (
-                            <CheckRow
-                              key={c.key}
-                              state={c.passed ? 'pass' : 'fail'}
-                              label={c.label}
-                              detail={c.detail}
-                              withBorder={i < checks.length - 1}
-                            />
-                          ))
-                        ) : (
-                          <Group gap={9} px="md" py={9} align="center">
-                            <IconAlertTriangle size={16} color="var(--mantine-color-yellow-5)" />
-                            <Text size="sm" c="dimmed">
-                              {isPack
-                                ? 'Packs have no artwork to scan — each member was checked when it was submitted.'
-                                : 'No automated checks were recorded for this submission.'}
-                            </Text>
-                          </Group>
-                        )}
-                      </ChecksCard>
-                    )}
-
-                    {/* Only when the flag is on: the query is disabled otherwise,
-                        so an empty-state card would claim a comparison nobody ran. */}
-                    {!isPack && features.cosmeticSimilarity && (
-                      <SimilarArtworkCard
-                        result={similarQuery.data}
-                        isLoading={similarQuery.isLoading}
-                        isError={similarQuery.isError}
-                      />
-                    )}
-
-                    <HistoryCard history={selectedMeta.history} creator={submitter} />
-
                     <Stack gap={8}>
                       <Text size="sm" fw={600}>
                         Details
@@ -1079,6 +1037,53 @@ function CreatorShopReviewPage() {
                     </Group>
                   </Stack>
                 )}
+
+                {/* Supporting evidence, below the decision controls: it is only
+                    occasionally relevant, and above them it pushed the verdict
+                    off-screen behind a long scroll. */}
+                <Stack gap="md" pt="md" style={{ borderTop: CREATOR_SHOP_BORDER }}>
+                  <HistoryCard history={selectedMeta.history} creator={submitter} />
+
+                  {/* Only when the flag is on: the query is disabled otherwise,
+                      so an empty-state card would claim a comparison nobody ran. */}
+                  {!isPack && features.cosmeticSimilarity && (
+                    <SimilarArtworkCard
+                      result={similarQuery.data}
+                      isLoading={similarQuery.isLoading}
+                      isError={similarQuery.isError}
+                    />
+                  )}
+
+                  {/* A pack supplies no artwork to scan, so an empty checks
+                      card reads as an anomaly rather than "not applicable". */}
+                  {!isPack && (
+                    <ChecksCard
+                      icon={<IconScan size={15} color="var(--mantine-color-dimmed)" />}
+                      title="Automated checks"
+                    >
+                      {checks.length ? (
+                        checks.map((c, i) => (
+                          <CheckRow
+                            key={c.key}
+                            state={c.passed ? 'pass' : 'fail'}
+                            label={c.label}
+                            detail={c.detail}
+                            withBorder={i < checks.length - 1}
+                          />
+                        ))
+                      ) : (
+                        <Group gap={9} px="md" py={9} align="center">
+                          <IconAlertTriangle size={16} color="var(--mantine-color-yellow-5)" />
+                          <Text size="sm" c="dimmed">
+                            {isPack
+                              ? 'Packs have no artwork to scan — each member was checked when it was submitted.'
+                              : 'No automated checks were recorded for this submission.'}
+                          </Text>
+                        </Group>
+                      )}
+                    </ChecksCard>
+                  )}
+                </Stack>
               </Stack>
             ) : (
               <Center h="100%" py={80}>


### PR DESCRIPTION
The history, similar-artwork, and automated-checks cards now render under the approve/reject controls instead of above them, so a moderator can act on a submission without scrolling past supporting detail that is only occasionally relevant. Also picks up unrelated line-width churn in the generated `civitai-db-schema` enums from a `db:generate` run.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868ku94t7`). Reviewed locally before push.