### PR TITLE
feat(post): Save as Draft, and stop the post editor dropping autosaves on exit

### DIFF
--- a/src/components/Post/EditV2/PostEditForm.tsx
+++ b/src/components/Post/EditV2/PostEditForm.tsx
@@ -17,6 +17,7 @@ const formSchema = z.object({ title: z.string().nullish(), detail: z.string().nu
 
 export function PostEditForm() {
   const post = usePostEditStore((state) => state.post);
+  const setPendingSave = usePostEditStore((state) => state.setPendingSave);
   const { postTitle, collectionId } = usePostEditParams();
   const form = useForm({
     schema: formSchema,
@@ -37,15 +38,24 @@ export function PostEditForm() {
     const subscription = form.watch(({ title, detail }, { name }) => {
       if (!post) return;
       const state = name ? form.getFieldState(name) : ({} as ReturnType<typeof form.getFieldState>);
-      if (state.isDirty || state.isTouched)
-        debounce(() =>
+      if (state.isDirty || state.isTouched) {
+        // Single-shot: a flush can't cancel the debounce timer, so whichever fires
+        // first has to make the other a no-op or the same edit is saved twice.
+        let saved = false;
+        const save = () => {
+          if (saved) return;
+          saved = true;
+          setPendingSave(null);
           mutate({
             id: post.id,
             title:
               title && title.length > titleCharLimit ? title.substring(0, titleCharLimit) : title,
             detail,
-          })
-        );
+          });
+        };
+        setPendingSave(save);
+        debounce(save);
+      }
     });
     return () => {
       subscription.unsubscribe();

--- a/src/components/Post/EditV2/PostEditForm.tsx
+++ b/src/components/Post/EditV2/PostEditForm.tsx
@@ -17,7 +17,8 @@ const formSchema = z.object({ title: z.string().nullish(), detail: z.string().nu
 
 export function PostEditForm() {
   const post = usePostEditStore((state) => state.post);
-  const setPendingSave = usePostEditStore((state) => state.setPendingSave);
+  const updatePost = usePostEditStore((state) => state.updatePost);
+  const registerPendingSave = usePostEditStore((state) => state.registerPendingSave);
   const { postTitle, collectionId } = usePostEditParams();
   const form = useForm({
     schema: formSchema,
@@ -26,6 +27,17 @@ export function PostEditForm() {
   const debounce = useDebouncer(1000);
 
   const { mutate } = trpc.post.update.useMutation({
+    // Applied when the request is SENT, not when it lands. The provider snapshots the store into
+    // the `post.getEdit` cache on `routeChangeStart` and nothing refetches it (staleTime is
+    // Infinity), so a save flushed on the way out would otherwise still be in flight when that
+    // snapshot is taken — the next visit then seeds the form from the pre-edit values and its
+    // first autosave writes them back over the server.
+    onMutate({ title, detail }) {
+      updatePost((data) => {
+        if (title !== undefined) data.title = title ?? null;
+        if (detail !== undefined) data.detail = detail ?? null;
+      });
+    },
     onError(error) {
       showErrorNotification({
         title: 'Failed to update post',
@@ -38,29 +50,25 @@ export function PostEditForm() {
     const subscription = form.watch(({ title, detail }, { name }) => {
       if (!post) return;
       const state = name ? form.getFieldState(name) : ({} as ReturnType<typeof form.getFieldState>);
-      if (state.isDirty || state.isTouched) {
-        // Single-shot: a flush can't cancel the debounce timer, so whichever fires
-        // first has to make the other a no-op or the same edit is saved twice.
-        let saved = false;
-        const save = () => {
-          if (saved) return;
-          saved = true;
-          setPendingSave(null);
+      if (state.isDirty || state.isTouched)
+        debounce(() =>
           mutate({
             id: post.id,
             title:
               title && title.length > titleCharLimit ? title.substring(0, titleCharLimit) : title,
             detail,
-          });
-        };
-        setPendingSave(save);
-        debounce(save);
-      }
+          })
+        );
     });
     return () => {
       subscription.unsubscribe();
     };
   }, []); // eslint-disable-line
+
+  useEffect(
+    () => registerPendingSave('post-detail', debounce.flush),
+    [registerPendingSave, debounce]
+  );
 
   const controls = [
     'heading',

--- a/src/components/Post/EditV2/PostEditForm.tsx
+++ b/src/components/Post/EditV2/PostEditForm.tsx
@@ -5,7 +5,11 @@ import { trpc } from '~/utils/trpc';
 import { showErrorNotification } from '~/utils/notifications';
 import { useDebouncer } from '~/utils/debouncer';
 import { EditPostTags } from '~/components/Post/EditV2/EditPostTags';
-import { usePostEditParams, usePostEditStore } from '~/components/Post/EditV2/PostEditProvider';
+import {
+  usePendingSave,
+  usePostEditParams,
+  usePostEditStore,
+} from '~/components/Post/EditV2/PostEditProvider';
 
 import { Group } from '@mantine/core';
 import { CollectionSelectDropdown } from '~/components/Post/EditV2/Collections/CollectionSelectDropdown';
@@ -18,7 +22,6 @@ const formSchema = z.object({ title: z.string().nullish(), detail: z.string().nu
 export function PostEditForm() {
   const post = usePostEditStore((state) => state.post);
   const updatePost = usePostEditStore((state) => state.updatePost);
-  const registerPendingSave = usePostEditStore((state) => state.registerPendingSave);
   const { postTitle, collectionId } = usePostEditParams();
   const form = useForm({
     schema: formSchema,
@@ -33,12 +36,24 @@ export function PostEditForm() {
     // snapshot is taken — the next visit then seeds the form from the pre-edit values and its
     // first autosave writes them back over the server.
     onMutate({ title, detail }) {
+      let previous: { title: string | null; detail: string | null } | undefined;
       updatePost((data) => {
+        previous = { title: data.title ?? null, detail: data.detail ?? null };
         if (title !== undefined) data.title = title ?? null;
         if (detail !== undefined) data.detail = detail ?? null;
       });
+      return previous;
     },
-    onError(error) {
+    onError(error, { title, detail }, previous) {
+      // Roll back, or the store keeps a value the server rejected and hands it to the
+      // `post.getEdit` cache on the way out — claiming a save that never landed. Each field
+      // is restored only if it still holds what THIS request set, so a later edit that
+      // succeeded while this one was failing isn't clobbered.
+      updatePost((data) => {
+        if (!previous) return;
+        if (title !== undefined && data.title === (title ?? null)) data.title = previous.title;
+        if (detail !== undefined && data.detail === (detail ?? null)) data.detail = previous.detail;
+      });
       showErrorNotification({
         title: 'Failed to update post',
         error: new Error(error.message),
@@ -65,10 +80,7 @@ export function PostEditForm() {
     };
   }, []); // eslint-disable-line
 
-  useEffect(
-    () => registerPendingSave('post-detail', debounce.flush),
-    [registerPendingSave, debounce]
-  );
+  usePendingSave('post-detail', debounce);
 
   const controls = [
     'heading',

--- a/src/components/Post/EditV2/PostEditProvider.tsx
+++ b/src/components/Post/EditV2/PostEditProvider.tsx
@@ -10,6 +10,7 @@ import { FileUploadProvider } from '~/components/FileUpload/FileUploadProvider';
 import type { MediaUploadOnCompleteProps } from '~/hooks/useMediaUpload';
 import type { PostEditQuerySchema } from '~/server/schema/post.schema';
 import type { PostDetailEditable, PostEditImageDetail } from '~/server/services/post.service';
+import type { Debouncer } from '~/utils/debouncer';
 import { trpc } from '~/utils/trpc';
 import { isDefined } from '~/utils/type-guards';
 
@@ -155,6 +156,20 @@ export function usePostEditStore<T>(selector: (state: State) => T) {
   const store = useContext(StoreContext);
   if (!store) throw new Error('missing PostEditProvider');
   return useStore(store, selector, shallow);
+}
+// #endregion
+
+/**
+ * Lets an intentional exit flush this debouncer before it navigates. An effect is the right
+ * shape here and not an incidental one: the registry lives outside React, so registering is a
+ * subscription, and the unregister has to run on unmount or a stale row's flush outlives it.
+ */
+export function usePendingSave(key: string, debouncer: Debouncer) {
+  const registerPendingSave = usePostEditStore((state) => state.registerPendingSave);
+  useEffect(
+    () => registerPendingSave(key, debouncer.flush),
+    [registerPendingSave, key, debouncer]
+  );
 }
 // #endregion
 

--- a/src/components/Post/EditV2/PostEditProvider.tsx
+++ b/src/components/Post/EditV2/PostEditProvider.tsx
@@ -57,6 +57,7 @@ type State = {
   post?: PostDetailEditable;
   images: ControlledImage[];
   isReordering: boolean;
+  pendingSave: (() => void) | null;
   collectionId?: number | null;
   collectionTagId: number | null;
   collectionItemExists?: boolean;
@@ -65,6 +66,8 @@ type State = {
   setImages: (cb: (images: ControlledImage[]) => ControlledImage[]) => void;
   updateImage: (id: number, cb: (image: PostEditImageDetail) => void) => void;
   toggleReordering: () => void;
+  setPendingSave: (fn: (() => void) | null) => void;
+  flushPendingSave: () => void;
   updateCollection: (
     collectionId: number | null,
     tagId?: number | null,
@@ -78,7 +81,7 @@ type Store = ReturnType<typeof createContextStore>;
 const createContextStore = (post?: PostDetailEditable) =>
   createStore<State>()(
     devtools(
-      immer((set) => ({
+      immer((set, get) => ({
         post,
         images:
           post?.images.map((data, index) => ({
@@ -86,6 +89,7 @@ const createContextStore = (post?: PostDetailEditable) =>
             data: { ...data, index },
           })) ?? [],
         isReordering: false,
+        pendingSave: null,
         collectionId: post?.collectionId,
         collectionTagId: post?.collectionTagId ?? null,
         collectionItemExists: post?.collectionItemExists,
@@ -111,6 +115,16 @@ const createContextStore = (post?: PostDetailEditable) =>
           set((state) => {
             state.isReordering = !state.isReordering;
           }),
+        setPendingSave: (fn) => set({ pendingSave: fn }),
+        // The form autosaves on a debounce whose timer is cleared on unmount, so an
+        // edit made within that window is dropped by any navigation. Anything that
+        // navigates deliberately must flush first or it silently discards that edit.
+        flushPendingSave: () => {
+          const { pendingSave } = get();
+          if (!pendingSave) return;
+          set({ pendingSave: null });
+          pendingSave();
+        },
         updateCollection: (collectionId, tagId, collectionItemExists) =>
           set({
             collectionId,

--- a/src/components/Post/EditV2/PostEditProvider.tsx
+++ b/src/components/Post/EditV2/PostEditProvider.tsx
@@ -220,6 +220,11 @@ export function PostEditProvider({ post, params = {}, children, ...extendedParam
 
   useEffect(() => {
     const handleBrowsingAway = async () => {
+      // Runs after `useCatchNavigation`'s guard (registered first, by a descendant), so by here
+      // the navigation is going ahead. Flush before the snapshot below: an edit still inside the
+      // autosave debounce would otherwise be dropped on unmount, and the snapshot would record
+      // the value it replaced.
+      store.getState().flushPendingSaves();
       if (postId) {
         // console.log('browse away');
         await queryUtils.post.get.invalidate({ id: postId });

--- a/src/components/Post/EditV2/PostEditProvider.tsx
+++ b/src/components/Post/EditV2/PostEditProvider.tsx
@@ -57,7 +57,6 @@ type State = {
   post?: PostDetailEditable;
   images: ControlledImage[];
   isReordering: boolean;
-  pendingSave: (() => void) | null;
   collectionId?: number | null;
   collectionTagId: number | null;
   collectionItemExists?: boolean;
@@ -66,8 +65,9 @@ type State = {
   setImages: (cb: (images: ControlledImage[]) => ControlledImage[]) => void;
   updateImage: (id: number, cb: (image: PostEditImageDetail) => void) => void;
   toggleReordering: () => void;
-  setPendingSave: (fn: (() => void) | null) => void;
-  flushPendingSave: () => void;
+  /** Returns its own unregister, so callers can use it as an effect cleanup. */
+  registerPendingSave: (key: string, flush: () => void) => () => void;
+  flushPendingSaves: () => void;
   updateCollection: (
     collectionId: number | null,
     tagId?: number | null,
@@ -78,10 +78,16 @@ type State = {
 
 // #region [create store]
 type Store = ReturnType<typeof createContextStore>;
-const createContextStore = (post?: PostDetailEditable) =>
-  createStore<State>()(
+const createContextStore = (post?: PostDetailEditable) => {
+  // Deliberately outside the store's reactive state: these are per-mount callbacks, not data.
+  // Keeping them here means registering costs no `set()` (so no notification to every
+  // subscriber, and nothing extra for the devtools middleware to serialize) and lets the many
+  // tool/technique rows register at once — a single slot would silently drop all but the last.
+  const pendingSaves = new Map<string, () => void>();
+
+  return createStore<State>()(
     devtools(
-      immer((set, get) => ({
+      immer((set) => ({
         post,
         images:
           post?.images.map((data, index) => ({
@@ -89,7 +95,6 @@ const createContextStore = (post?: PostDetailEditable) =>
             data: { ...data, index },
           })) ?? [],
         isReordering: false,
-        pendingSave: null,
         collectionId: post?.collectionId,
         collectionTagId: post?.collectionTagId ?? null,
         collectionItemExists: post?.collectionItemExists,
@@ -115,15 +120,14 @@ const createContextStore = (post?: PostDetailEditable) =>
           set((state) => {
             state.isReordering = !state.isReordering;
           }),
-        setPendingSave: (fn) => set({ pendingSave: fn }),
-        // The form autosaves on a debounce whose timer is cleared on unmount, so an
-        // edit made within that window is dropped by any navigation. Anything that
-        // navigates deliberately must flush first or it silently discards that edit.
-        flushPendingSave: () => {
-          const { pendingSave } = get();
-          if (!pendingSave) return;
-          set({ pendingSave: null });
-          pendingSave();
+        registerPendingSave: (key, flush) => {
+          pendingSaves.set(key, flush);
+          return () => {
+            if (pendingSaves.get(key) === flush) pendingSaves.delete(key);
+          };
+        },
+        flushPendingSaves: () => {
+          for (const flush of pendingSaves.values()) flush();
         },
         updateCollection: (collectionId, tagId, collectionItemExists) =>
           set({
@@ -133,9 +137,16 @@ const createContextStore = (post?: PostDetailEditable) =>
             collectionItemExists: collectionItemExists ?? true,
           }),
       })),
-      { name: 'PostDetailEditable' }
+      {
+        name: 'PostDetailEditable',
+        // `import.meta.env` doesn't exist in a Next bundle, so zustand's own default resolves
+        // to enabled everywhere — which serializes the whole store, images included, on every
+        // `set()` for anyone with the Redux devtools extension installed.
+        enabled: process.env.NODE_ENV !== 'production',
+      }
     )
   );
+};
 // #endregion
 
 // #region [state context]

--- a/src/components/Post/EditV2/PostEditSidebar.tsx
+++ b/src/components/Post/EditV2/PostEditSidebar.tsx
@@ -37,6 +37,7 @@ import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { removeEmpty } from '~/utils/object-helpers';
+import { safeInternalPath } from '~/utils/url-helpers';
 import { isValidAIGeneration, hasImageLicenseViolation } from '~/utils/image-utils';
 import type { ImageMetaProps } from '~/server/schema/image.schema';
 import type { ImageResourceHelper } from '~/shared/utils/prisma/models';
@@ -78,7 +79,7 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
     collectionId,
     collectionTagId,
     images,
-    flushPendingSave,
+    flushPendingSaves,
   ] = usePostEditStore((state) => [
     state.updatePost,
     state.isReordering,
@@ -87,7 +88,7 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
     state.collectionId,
     state.collectionTagId,
     state.images,
-    state.flushPendingSave,
+    state.flushPendingSaves,
   ]);
   const todayRef = useRef(new Date());
 
@@ -170,7 +171,7 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
           });
           if (publishedAt && afterPublish) await afterPublish({ postId: id, publishedAt });
           else {
-            if (returnUrl) router.push(returnUrl);
+            if (returnUrl) router.push(safeInternalPath(returnUrl, `/posts/${post.id}`));
             else router.push({ pathname: `/posts/${post.id}`, query: removeEmpty({ returnUrl }) });
           }
           await queryUtils.image.getImagesAsPostsInfinite.invalidate();
@@ -236,17 +237,38 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
     });
   };
 
-  const savingDraftRef = useRef(false);
+  // Holds the url this handler pushed, so the guard below waives that navigation and no other.
+  const savingDraftRef = useRef<string | null>(null);
 
-  const handleSaveAsDraft = () => {
-    flushPendingSave();
-    savingDraftRef.current = true;
-    // `section=draft` because the posts tab defaults to Published, where the post
-    // just saved is by definition absent.
-    router.push(
-      returnUrl ??
-        (currentUser ? `/user/${currentUser.username}/posts?section=draft` : `/posts/${post.id}`)
-    );
+  const handleSaveAsDraft = async () => {
+    // A second click would push again and let the first push's `finally` re-arm the guard
+    // mid-navigation, prompting on a navigation the user explicitly asked for.
+    if (savingDraftRef.current) return;
+
+    flushPendingSaves();
+
+    // Only the owner has a drafts section to land on — `/posts/[postId]/edit` also admits
+    // moderators, and the profile posts page shows Published for anyone but the owner.
+    const isOwner = currentUser?.id === post.user.id;
+    // `section=draft` because the posts tab defaults to Published, where the post just saved
+    // is by definition absent.
+    const fallback =
+      isOwner && currentUser.username
+        ? `/user/${currentUser.username}/posts?section=draft`
+        : `/posts/${post.id}`;
+    const destination = safeInternalPath(returnUrl, fallback);
+
+    savingDraftRef.current = destination;
+    try {
+      await router.push(destination);
+    } catch {
+      // swallowed: a rejected push is a navigation that didn't happen, and the only
+      // thing to do about it is the reset below
+    } finally {
+      // A push that fails or is cancelled leaves this component mounted, and a bypass that
+      // outlives its own navigation disables the unsaved-changes guard for good.
+      savingDraftRef.current = null;
+    }
   };
 
   useCatchNavigation({
@@ -431,8 +453,8 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
         </Button.Group>
       )}
 
-      {!post.publishedAt && !isUnpublishedByParent && (
-        <Button variant="default" onClick={handleSaveAsDraft}>
+      {!post.publishedAt && !isUnpublishedByParent && !deleted && (
+        <Button variant="default" onClick={handleSaveAsDraft} disabled={!features.canWrite}>
           Save as Draft
         </Button>
       )}

--- a/src/components/Post/EditV2/PostEditSidebar.tsx
+++ b/src/components/Post/EditV2/PostEditSidebar.tsx
@@ -238,7 +238,10 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
   };
 
   // Holds the url this handler pushed, so the guard below waives that navigation and no other.
+  // The ref is what the guard reads (synchronously, mid-navigation); the state is only the
+  // button's spinner, since the awaited push is a real round trip to the destination.
   const savingDraftRef = useRef<string | null>(null);
+  const [savingDraft, setSavingDraft] = useState(false);
 
   const handleSaveAsDraft = async () => {
     // A second click would push again and let the first push's `finally` re-arm the guard
@@ -259,6 +262,7 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
     const destination = safeInternalPath(returnUrl, fallback);
 
     savingDraftRef.current = destination;
+    setSavingDraft(true);
     try {
       await router.push(destination);
     } catch {
@@ -268,6 +272,7 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
       // A push that fails or is cancelled leaves this component mounted, and a bypass that
       // outlives its own navigation disables the unsaved-changes guard for good.
       savingDraftRef.current = null;
+      setSavingDraft(false);
     }
   };
 
@@ -276,7 +281,10 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
     // unpublished, the user can't republish from this page anyway —
     // showing the "you haven't published this post" warning is misleading.
     unsavedChanges: !post.publishedAt && !deleted && !isUnpublishedByParent,
-    message: `You haven't published this post, all images will stay hidden. Do you wish to continue?`,
+    // Every edit is autosaved and the provider flushes anything still pending on the way out,
+    // so nothing is lost here — what the user needs warning about is that a draft is invisible
+    // until they publish it, which is the mistake this prompt was added to prevent.
+    message: `Your changes are saved, but this post is still a draft — it stays hidden until you publish it. Leave anyway?`,
     bypassRef: savingDraftRef,
   });
   // #endregion
@@ -454,7 +462,12 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
       )}
 
       {!post.publishedAt && !isUnpublishedByParent && !deleted && (
-        <Button variant="default" onClick={handleSaveAsDraft} disabled={!features.canWrite}>
+        <Button
+          variant="default"
+          onClick={handleSaveAsDraft}
+          loading={savingDraft}
+          disabled={!features.canWrite}
+        >
           Save as Draft
         </Button>
       )}

--- a/src/components/Post/EditV2/PostEditSidebar.tsx
+++ b/src/components/Post/EditV2/PostEditSidebar.tsx
@@ -28,7 +28,7 @@ import { SchedulePostModal } from '~/components/Post/EditV2/SchedulePostModal';
 import { usePostContestCollectionDetails } from '~/components/Post/post.utils';
 import { ShareButton } from '~/components/ShareButton/ShareButton';
 import { useCatchNavigation } from '~/hooks/useCatchNavigation';
-// import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useTourContext } from '~/components/Tours/ToursProvider';
 import type { PostDetailEditable } from '~/server/services/post.service';
 import { CollectionType } from '~/shared/utils/prisma/enums';
@@ -65,21 +65,30 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
   const queryUtils = trpc.useUtils();
   const router = useRouter();
   const params = usePostEditParams();
-  // const currentUser = useCurrentUser();
+  const currentUser = useCurrentUser();
   const { runTour } = useTourContext();
   const features = useFeatureFlags();
 
   const [deleted, setDeleted] = useState(false);
-  const [updatePost, isReordering, hasImages, showReorder, collectionId, collectionTagId, images] =
-    usePostEditStore((state) => [
-      state.updatePost,
-      state.isReordering,
-      state.images.filter((x) => x.type === 'added').length > 0,
-      state.images.length > 1,
-      state.collectionId,
-      state.collectionTagId,
-      state.images,
-    ]);
+  const [
+    updatePost,
+    isReordering,
+    hasImages,
+    showReorder,
+    collectionId,
+    collectionTagId,
+    images,
+    flushPendingSave,
+  ] = usePostEditStore((state) => [
+    state.updatePost,
+    state.isReordering,
+    state.images.filter((x) => x.type === 'added').length > 0,
+    state.images.length > 1,
+    state.collectionId,
+    state.collectionTagId,
+    state.images,
+    state.flushPendingSave,
+  ]);
   const todayRef = useRef(new Date());
 
   const addedImages = useMemo(
@@ -163,7 +172,6 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
           else {
             if (returnUrl) router.push(returnUrl);
             else router.push({ pathname: `/posts/${post.id}`, query: removeEmpty({ returnUrl }) });
-            // else router.push(`/user/${currentUser?.username}/posts`);
           }
           await queryUtils.image.getImagesAsPostsInfinite.invalidate();
         },
@@ -228,12 +236,26 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
     });
   };
 
+  const savingDraftRef = useRef(false);
+
+  const handleSaveAsDraft = () => {
+    flushPendingSave();
+    savingDraftRef.current = true;
+    // `section=draft` because the posts tab defaults to Published, where the post
+    // just saved is by definition absent.
+    router.push(
+      returnUrl ??
+        (currentUser ? `/user/${currentUser.username}/posts?section=draft` : `/posts/${post.id}`)
+    );
+  };
+
   useCatchNavigation({
     // When the post is unpublished because the parent model/version is
     // unpublished, the user can't republish from this page anyway —
     // showing the "you haven't published this post" warning is misleading.
     unsavedChanges: !post.publishedAt && !deleted && !isUnpublishedByParent,
     message: `You haven't published this post, all images will stay hidden. Do you wish to continue?`,
+    bypassRef: savingDraftRef,
   });
   // #endregion
 
@@ -407,6 +429,12 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
             </Tooltip>
           )}
         </Button.Group>
+      )}
+
+      {!post.publishedAt && !isUnpublishedByParent && (
+        <Button variant="default" onClick={handleSaveAsDraft}>
+          Save as Draft
+        </Button>
       )}
 
       {showReorder && <ReorderImagesButton />}

--- a/src/components/Post/EditV2/Techniques/PostImageTechnique.tsx
+++ b/src/components/Post/EditV2/Techniques/PostImageTechnique.tsx
@@ -1,10 +1,10 @@
 import { ActionIcon, Collapse, Text, Textarea } from '@mantine/core';
 import { IconMessagePlus, IconTrash } from '@tabler/icons-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
-import { usePostEditStore } from '~/components/Post/EditV2/PostEditProvider';
+import { usePendingSave, usePostEditStore } from '~/components/Post/EditV2/PostEditProvider';
 import type { PostEditImageDetail } from '~/server/services/post.service';
 import { useDebouncer } from '~/utils/debouncer';
 import { showErrorNotification } from '~/utils/notifications';
@@ -21,7 +21,6 @@ export function PostImageTechnique({
   const [opened, setOpened] = useState(!!technique.notes?.length);
   const [notes, setNotes] = useState(technique.notes ?? '');
   const updateImage = usePostEditStore((state) => state.updateImage);
-  const registerPendingSave = usePostEditStore((state) => state.registerPendingSave);
   const removeTechniqueMutation = trpc.image.removeTechniques.useMutation({
     onSuccess: (response, { data }) => {
       for (const { imageId, techniqueId } of data) {
@@ -57,14 +56,30 @@ export function PostImageTechnique({
     // onMutate, not onSuccess: the provider snapshots the store into the `post.getEdit`
     // cache on `routeChangeStart`, so a note flushed on the way out has not landed yet.
     onMutate: ({ data }) => {
+      const previous: Record<number, string | null> = {};
       for (const { imageId, techniqueId, notes } of data) {
         updateImage(imageId, (image) => {
           const technique = image.techniques.find((x) => x.id === techniqueId);
-          if (technique) technique.notes = notes?.length ? notes : null;
+          if (!technique) return;
+          previous[techniqueId] = technique.notes ?? null;
+          technique.notes = notes?.length ? notes : null;
         });
       }
+      return previous;
     },
-    onError: (error: any) => showErrorNotification({ error: new Error(error.message) }),
+    // Roll back, or the note reads as saved — `dirty` below compares against this value, so an
+    // optimistic write that the server rejected also clears the unsaved marker. Restored only
+    // where the store still holds what THIS request set.
+    onError: (error: any, { data }, previous) => {
+      for (const { imageId, techniqueId, notes } of data) {
+        updateImage(imageId, (image) => {
+          const technique = image.techniques.find((x) => x.id === techniqueId);
+          if (!technique || !previous || !(techniqueId in previous)) return;
+          if (technique.notes === (notes?.length ? notes : null)) technique.notes = previous[techniqueId];
+        });
+      }
+      showErrorNotification({ error: new Error(error.message) });
+    },
   });
   const handleUpdateTechnique = (notes: string) => {
     debouncer(() => {
@@ -74,10 +89,7 @@ export function PostImageTechnique({
     });
   };
 
-  useEffect(
-    () => registerPendingSave(`technique:${image.id}:${technique.id}`, debouncer.flush),
-    [registerPendingSave, debouncer, image.id, technique.id]
-  );
+  usePendingSave(`technique:${image.id}:${technique.id}`, debouncer);
 
   const dirty = notes.length && notes !== technique.notes;
   const saving = updateTechniqueMutation.isPending;

--- a/src/components/Post/EditV2/Techniques/PostImageTechnique.tsx
+++ b/src/components/Post/EditV2/Techniques/PostImageTechnique.tsx
@@ -1,6 +1,6 @@
 import { ActionIcon, Collapse, Text, Textarea } from '@mantine/core';
 import { IconMessagePlus, IconTrash } from '@tabler/icons-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -21,6 +21,7 @@ export function PostImageTechnique({
   const [opened, setOpened] = useState(!!technique.notes?.length);
   const [notes, setNotes] = useState(technique.notes ?? '');
   const updateImage = usePostEditStore((state) => state.updateImage);
+  const registerPendingSave = usePostEditStore((state) => state.registerPendingSave);
   const removeTechniqueMutation = trpc.image.removeTechniques.useMutation({
     onSuccess: (response, { data }) => {
       for (const { imageId, techniqueId } of data) {
@@ -53,7 +54,9 @@ export function PostImageTechnique({
   };
 
   const updateTechniqueMutation = trpc.image.updateTechniques.useMutation({
-    onSuccess: (_, { data }) => {
+    // onMutate, not onSuccess: the provider snapshots the store into the `post.getEdit`
+    // cache on `routeChangeStart`, so a note flushed on the way out has not landed yet.
+    onMutate: ({ data }) => {
       for (const { imageId, techniqueId, notes } of data) {
         updateImage(imageId, (image) => {
           const technique = image.techniques.find((x) => x.id === techniqueId);
@@ -70,6 +73,11 @@ export function PostImageTechnique({
       });
     });
   };
+
+  useEffect(
+    () => registerPendingSave(`technique:${image.id}:${technique.id}`, debouncer.flush),
+    [registerPendingSave, debouncer, image.id, technique.id]
+  );
 
   const dirty = notes.length && notes !== technique.notes;
   const saving = updateTechniqueMutation.isPending;

--- a/src/components/Post/EditV2/Tools/PostImageTool.tsx
+++ b/src/components/Post/EditV2/Tools/PostImageTool.tsx
@@ -1,6 +1,6 @@
 import { ActionIcon, Collapse, Text, Textarea } from '@mantine/core';
 import { IconMessagePlus, IconTrash } from '@tabler/icons-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -22,6 +22,7 @@ export function PostImageTool({
   const [opened, setOpened] = useState(!!tool.notes?.length);
   const [notes, setNotes] = useState(tool.notes ?? '');
   const updateImage = usePostEditStore((state) => state.updateImage);
+  const registerPendingSave = usePostEditStore((state) => state.registerPendingSave);
   const removeToolMutation = trpc.image.removeTools.useMutation({
     onSuccess: (response, { data }) => {
       for (const { imageId, toolId } of data) {
@@ -53,7 +54,9 @@ export function PostImageTool({
   };
 
   const updateToolMutation = trpc.image.updateTools.useMutation({
-    onSuccess: (_, { data }) => {
+    // onMutate, not onSuccess: the provider snapshots the store into the `post.getEdit`
+    // cache on `routeChangeStart`, so a note flushed on the way out has not landed yet.
+    onMutate: ({ data }) => {
       for (const { imageId, toolId, notes } of data) {
         updateImage(imageId, (image) => {
           const tool = image.tools.find((x) => x.id === toolId);
@@ -68,6 +71,11 @@ export function PostImageTool({
       updateToolMutation.mutate({ data: [{ imageId: image.id, toolId: tool.id, notes }] });
     });
   };
+
+  useEffect(
+    () => registerPendingSave(`tool:${image.id}:${tool.id}`, debouncer.flush),
+    [registerPendingSave, debouncer, image.id, tool.id]
+  );
 
   const dirty = notes.length && notes !== tool.notes;
   const saving = updateToolMutation.isPending;

--- a/src/components/Post/EditV2/Tools/PostImageTool.tsx
+++ b/src/components/Post/EditV2/Tools/PostImageTool.tsx
@@ -1,10 +1,10 @@
 import { ActionIcon, Collapse, Text, Textarea } from '@mantine/core';
 import { IconMessagePlus, IconTrash } from '@tabler/icons-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
-import { usePostEditStore } from '~/components/Post/EditV2/PostEditProvider';
+import { usePendingSave, usePostEditStore } from '~/components/Post/EditV2/PostEditProvider';
 import type { PostEditImageDetail } from '~/server/services/post.service';
 import { useDebouncer } from '~/utils/debouncer';
 import { showErrorNotification } from '~/utils/notifications';
@@ -22,7 +22,6 @@ export function PostImageTool({
   const [opened, setOpened] = useState(!!tool.notes?.length);
   const [notes, setNotes] = useState(tool.notes ?? '');
   const updateImage = usePostEditStore((state) => state.updateImage);
-  const registerPendingSave = usePostEditStore((state) => state.registerPendingSave);
   const removeToolMutation = trpc.image.removeTools.useMutation({
     onSuccess: (response, { data }) => {
       for (const { imageId, toolId } of data) {
@@ -57,14 +56,30 @@ export function PostImageTool({
     // onMutate, not onSuccess: the provider snapshots the store into the `post.getEdit`
     // cache on `routeChangeStart`, so a note flushed on the way out has not landed yet.
     onMutate: ({ data }) => {
+      const previous: Record<number, string | null> = {};
       for (const { imageId, toolId, notes } of data) {
         updateImage(imageId, (image) => {
           const tool = image.tools.find((x) => x.id === toolId);
-          if (tool) tool.notes = notes?.length ? notes : null;
+          if (!tool) return;
+          previous[toolId] = tool.notes ?? null;
+          tool.notes = notes?.length ? notes : null;
         });
       }
+      return previous;
     },
-    onError: (error: any) => showErrorNotification({ error: new Error(error.message) }),
+    // Roll back, or the note reads as saved — `dirty` below compares against this value, so an
+    // optimistic write that the server rejected also clears the unsaved marker. Restored only
+    // where the store still holds what THIS request set.
+    onError: (error: any, { data }, previous) => {
+      for (const { imageId, toolId, notes } of data) {
+        updateImage(imageId, (image) => {
+          const tool = image.tools.find((x) => x.id === toolId);
+          if (!tool || !previous || !(toolId in previous)) return;
+          if (tool.notes === (notes?.length ? notes : null)) tool.notes = previous[toolId];
+        });
+      }
+      showErrorNotification({ error: new Error(error.message) });
+    },
   });
   const handleUpdateTool = (notes: string) => {
     debouncer(() => {
@@ -72,10 +87,7 @@ export function PostImageTool({
     });
   };
 
-  useEffect(
-    () => registerPendingSave(`tool:${image.id}:${tool.id}`, debouncer.flush),
-    [registerPendingSave, debouncer, image.id, tool.id]
-  );
+  usePendingSave(`tool:${image.id}:${tool.id}`, debouncer);
 
   const dirty = notes.length && notes !== tool.notes;
   const saving = updateToolMutation.isPending;

--- a/src/hooks/__tests__/useCatchNavigation.browser.test.tsx
+++ b/src/hooks/__tests__/useCatchNavigation.browser.test.tsx
@@ -1,0 +1,84 @@
+import Router from 'next/router';
+import { useRef } from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { useCatchNavigation } from '../useCatchNavigation';
+
+/**
+ * Locks the shape of `bypassRef`. A bare `true` waives EVERY navigation for as long as it is
+ * set, which is wrong for a caller that trips it around one awaited `router.push`: the pages
+ * router cancels an in-flight `change()` with a flag rather than by settling its promise, and
+ * emits the new `routeChangeStart` before the old push rejects — so a navigation the user
+ * starts during that window also skips the prompt. A url string waives only that destination.
+ */
+
+// The scaffold mocks `next/router` as a shared singleton, so the default export is the same
+// object `useCatchNavigation` reaches for and its spies observe the guard. Imported as the
+// default rather than via `useRouter()` so this isn't a hook call outside a component.
+const onSpy = Router.events.on as unknown as ReturnType<typeof vi.fn>;
+
+const DESTINATION = '/user/alice/posts?section=draft';
+const MESSAGE = 'unsaved changes, continue?';
+
+// The `routeChangeStart` handler `useCatchNavigation` last registered. It throws to cancel a
+// client navigation — the documented pages-router idiom.
+const lastRouteChangeStartHandler = () =>
+  onSpy.mock.calls.filter((c: unknown[]) => c[0] === 'routeChangeStart').at(-1)![1] as (
+    url: string
+  ) => void;
+
+function Harness({ bypass }: { bypass: boolean | string | null }) {
+  const bypassRef = useRef<boolean | string | null>(bypass);
+  bypassRef.current = bypass;
+  useCatchNavigation({ unsavedChanges: true, message: MESSAGE, bypassRef });
+  return <div data-testid="guard-harness" />;
+}
+
+let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  onSpy.mockClear();
+  (Router.events.emit as unknown as ReturnType<typeof vi.fn>).mockClear();
+  // Answering `false` keeps the "user declined" branch, which is the one that throws.
+  confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+});
+
+afterEach(() => {
+  confirmSpy.mockRestore();
+});
+
+describe('useCatchNavigation bypassRef', () => {
+  test('with no bypass, an unsaved-changes navigation prompts and is cancelled', async () => {
+    await renderWithProviders(<Harness bypass={null} />);
+    await expect.element(page.getByTestId('guard-harness')).toBeInTheDocument();
+
+    expect(() => lastRouteChangeStartHandler()(DESTINATION)).toThrow();
+    expect(confirmSpy).toHaveBeenCalledWith(MESSAGE);
+  });
+
+  test('a url bypass waives THAT destination and no other', async () => {
+    await renderWithProviders(<Harness bypass={DESTINATION} />);
+    await expect.element(page.getByTestId('guard-harness')).toBeInTheDocument();
+    const handler = lastRouteChangeStartHandler();
+
+    // The navigation the caller tripped the ref for: through, silently.
+    expect(() => handler(DESTINATION)).not.toThrow();
+    expect(confirmSpy).not.toHaveBeenCalled();
+
+    // Negative control — without this, `bypass={true}` would also pass this test.
+    expect(() => handler('/models')).toThrow();
+    expect(confirmSpy).toHaveBeenCalledWith(MESSAGE);
+  });
+
+  test('a boolean bypass still waives everything (useReviewNavigationGuard relies on it)', async () => {
+    await renderWithProviders(<Harness bypass={true} />);
+    await expect.element(page.getByTestId('guard-harness')).toBeInTheDocument();
+    const handler = lastRouteChangeStartHandler();
+
+    expect(() => handler(DESTINATION)).not.toThrow();
+    expect(() => handler('/models')).not.toThrow();
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useCatchNavigation.tsx
+++ b/src/hooks/useCatchNavigation.tsx
@@ -6,15 +6,19 @@ type Props = {
   message?: string;
   eval?: () => boolean;
   /**
-   * Live, synchronous escape hatch. When this ref reads `true` at navigation
-   * time, the guard lets the navigation through WITHOUT prompting — even while
-   * `unsavedChanges` is still true. A caller trips it (synchronously) right
-   * before its OWN programmatic `router.push` so the guard never blocks the
-   * redirect it intends, without depending on the `unsavedChanges` effect having
-   * re-run first (the effect-cleanup-vs-microtask race). Optional and
-   * backward-compatible: callers that omit it keep the exact prior behaviour.
+   * Live, synchronous escape hatch. A caller trips it (synchronously) right before its OWN
+   * programmatic `router.push` so the guard never blocks the redirect it intends, without
+   * depending on the `unsavedChanges` effect having re-run first (the
+   * effect-cleanup-vs-microtask race). Optional and backward-compatible: callers that omit it
+   * keep the exact prior behaviour.
+   *
+   * `true` bypasses every navigation while it is set. Prefer a **url string**, which bypasses
+   * only that one destination: the pages router cancels an in-flight `change()` by setting a
+   * flag rather than settling its promise, and emits the new `routeChangeStart` before the old
+   * push rejects — so with a bare `true` any navigation the user starts during an awaited push
+   * also skips the prompt.
    */
-  bypassRef?: { current: boolean };
+  bypassRef?: { current: boolean | string | null };
 };
 
 export function useCatchNavigation({
@@ -36,7 +40,9 @@ export function useCatchNavigation({
       // Live escape hatch — a caller-owned programmatic redirect (which trips
       // this synchronously just before router.push) is never treated as an
       // unsaved-changes navigation, so the guard doesn't block its own redirect.
-      if (bypassRef?.current) return;
+      const bypass = bypassRef?.current;
+      if (bypass === true) return;
+      if (typeof bypass === 'string' && bypass === url) return;
 
       const currentUrl = window.location.pathname;
       const nextUrl = url.split('?')[0];

--- a/src/utils/__tests__/debouncer.test.ts
+++ b/src/utils/__tests__/debouncer.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+import type { act as actType } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+
+import type { Debouncer } from '~/utils/debouncer';
+import { useDebouncer } from '~/utils/debouncer';
+
+// React 18.3 exposes `act` on the `react` export, but our @types/react (18.0.14) predates that
+// typing. Use the runtime `React.act` and borrow the correctly-typed signature.
+const act = (React as unknown as { act: typeof actType }).act;
+
+const TIMEOUT = 1000;
+
+function renderDebouncer() {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  let debouncer: Debouncer | undefined;
+  function Probe() {
+    debouncer = useDebouncer(TIMEOUT);
+    return null;
+  }
+  act(() => {
+    root.render(React.createElement(Probe));
+  });
+  return {
+    debouncer: debouncer as Debouncer,
+    unmount: () =>
+      act(() => {
+        root.unmount();
+      }),
+  };
+}
+
+beforeEach(() => {
+  // Only the timer functions the debouncer uses — faking React 18's MessageChannel scheduler
+  // would stop `act` from flushing renders.
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useDebouncer', () => {
+  it('defers the call until the window elapses', () => {
+    const { debouncer, unmount } = renderDebouncer();
+    const fn = vi.fn();
+
+    debouncer(fn);
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(TIMEOUT);
+    expect(fn).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('keeps only the latest call in a window', () => {
+    const { debouncer, unmount } = renderDebouncer();
+    const first = vi.fn();
+    const second = vi.fn();
+
+    debouncer(first);
+    vi.advanceTimersByTime(TIMEOUT - 1);
+    debouncer(second);
+    vi.advanceTimersByTime(TIMEOUT);
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('flush runs the pending call immediately AND exactly once', () => {
+    const { debouncer, unmount } = renderDebouncer();
+    const fn = vi.fn();
+
+    debouncer(fn);
+    debouncer.flush();
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // The timer is still armed at this point. Without flush clearing it, the same edit is
+    // written a second time when the window elapses.
+    vi.advanceTimersByTime(TIMEOUT * 5);
+    expect(fn).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('flush after the window elapsed does not repeat the call', () => {
+    const { debouncer, unmount } = renderDebouncer();
+    const fn = vi.fn();
+
+    debouncer(fn);
+    vi.advanceTimersByTime(TIMEOUT);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    debouncer.flush();
+    expect(fn).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('flush with nothing pending is a no-op', () => {
+    const { debouncer, unmount } = renderDebouncer();
+    expect(() => debouncer.flush()).not.toThrow();
+    unmount();
+  });
+
+  it('cancel drops the pending call', () => {
+    const { debouncer, unmount } = renderDebouncer();
+    const fn = vi.fn();
+
+    debouncer(fn);
+    debouncer.cancel();
+    vi.advanceTimersByTime(TIMEOUT * 5);
+
+    expect(fn).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  // This is the behaviour that makes `flush` necessary rather than merely convenient: anything
+  // navigating away deliberately has to flush, or the last edit is discarded with no error.
+  it('drops a pending call on unmount', () => {
+    const { debouncer, unmount } = renderDebouncer();
+    const fn = vi.fn();
+
+    debouncer(fn);
+    unmount();
+    vi.advanceTimersByTime(TIMEOUT * 5);
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/__tests__/url-helpers.test.ts
+++ b/src/utils/__tests__/url-helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { safeInternalPath } from '~/utils/url-helpers';
+
+const FALLBACK = '/posts/1';
+
+describe('safeInternalPath', () => {
+  it('keeps a same-origin path, query and hash included', () => {
+    expect(safeInternalPath('/user/alice/posts?section=draft', FALLBACK)).toBe(
+      '/user/alice/posts?section=draft'
+    );
+    expect(safeInternalPath('/user/account#accounts', FALLBACK)).toBe('/user/account#accounts');
+  });
+
+  it('collapses an absolute url to the fallback', () => {
+    expect(safeInternalPath('https://evil.example/steal', FALLBACK)).toBe(FALLBACK);
+    expect(safeInternalPath('//evil.example/steal', FALLBACK)).toBe(FALLBACK);
+    expect(safeInternalPath('/\\evil.example/steal', FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('collapses anything that is not a path-shaped string', () => {
+    expect(safeInternalPath('evil.example', FALLBACK)).toBe(FALLBACK);
+    expect(safeInternalPath('', FALLBACK)).toBe(FALLBACK);
+    expect(safeInternalPath(undefined, FALLBACK)).toBe(FALLBACK);
+    expect(safeInternalPath(null, FALLBACK)).toBe(FALLBACK);
+    expect(safeInternalPath(42, FALLBACK)).toBe(FALLBACK);
+    expect(safeInternalPath(['/ok'], FALLBACK)).toBe(FALLBACK);
+  });
+});

--- a/src/utils/debouncer.ts
+++ b/src/utils/debouncer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { isDev } from '~/env/other';
 
 export const createDebouncer = (timeout: number) => {
@@ -10,8 +10,20 @@ export const createDebouncer = (timeout: number) => {
   return debouncer;
 };
 
-export const useDebouncer = (timeout: number) => {
+export type Debouncer = ((func: () => void) => void) & {
+  /** Run the pending call now. No-op when nothing is pending. */
+  flush: () => void;
+  /** Drop the pending call without running it. */
+  cancel: () => void;
+};
+
+/**
+ * The timer is cleared on unmount, so a call still inside the debounce window is dropped by any
+ * navigation. Anything that navigates deliberately must `flush()` first or it discards that edit.
+ */
+export const useDebouncer = (timeout: number): Debouncer => {
   const timeoutRef = useRef<NodeJS.Timeout | undefined>();
+  const pendingRef = useRef<(() => void) | undefined>();
 
   useEffect(() => {
     return () => {
@@ -21,15 +33,33 @@ export const useDebouncer = (timeout: number) => {
     };
   }, [timeout]);
 
-  const debouncer = useCallback(
-    (func: () => void) => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      timeoutRef.current = setTimeout(func, timeout);
-    },
-    [timeout]
-  );
+  const cancel = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = undefined;
+    pendingRef.current = undefined;
+  }, []);
 
-  return debouncer;
+  const flush = useCallback(() => {
+    const pending = pendingRef.current;
+    cancel();
+    pending?.();
+  }, [cancel]);
+
+  return useMemo(() => {
+    const debouncer = ((func: () => void) => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      pendingRef.current = func;
+      timeoutRef.current = setTimeout(() => {
+        // cleared before running so a flush racing the timer cannot run it twice
+        timeoutRef.current = undefined;
+        pendingRef.current = undefined;
+        func();
+      }, timeout);
+    }) as Debouncer;
+    debouncer.flush = flush;
+    debouncer.cancel = cancel;
+    return debouncer;
+  }, [timeout, flush, cancel]);
 };
 
 export const createKeyDebouncer = (timeout: number) => {

--- a/src/utils/url-helpers.ts
+++ b/src/utils/url-helpers.ts
@@ -1,0 +1,10 @@
+/**
+ * Collapses anything that isn't a same-origin path to `fallback`, so a caller-supplied
+ * `returnUrl` can't be turned into an off-site redirect.
+ *
+ * Same rule as `safePath` in `@civitai/auth`, restated here rather than imported: that module
+ * pulls node `crypto` at import time, and this one runs in the browser.
+ */
+export function safeInternalPath(raw: unknown, fallback: string): string {
+  return typeof raw === 'string' && raw.startsWith('/') && !/^\/[/\\]/.test(raw) ? raw : fallback;
+}


### PR DESCRIPTION
Closes [868ku8n2g](https://app.clickup.com/t/8459928/868ku8n2g).

Started as a button. Review turned up a data-loss bug in the same code path, so it is now
also a fix for how the post editor persists edits on exit. Both are described below.

## The button

A post is already a draft the moment it is created, and the edit form autosaves, so a "save"
button has nothing to persist — Justin: *"this button wouldn't do anything… it would just
close the post."* The actual complaint (Ellie) is the **exit**: the only way to leave a post
as a draft was to back out of the page, which fires the `useCatchNavigation` confirm. That
reads like the work is about to be lost, and it takes extra steps.

- **`Save as Draft`** in the post edit sidebar, under Publish. Shown while `!post.publishedAt`;
  hidden when the post is only hidden because its parent model/version was unpublished, hidden
  mid-delete, gated on `canWrite`, and carrying a loading state (the push is a real round trip).
- Waives the confirm for that one navigation, then lands on
  `/user/<username>/posts?section=draft`. The `section` param matters: that page defaults to
  **Published**, where the post just saved is by definition absent. Non-owners (moderators can
  open anyone's editor) go to the post instead of a drafts list that is not theirs. `returnUrl`
  is honoured when the flow supplied one, as Publish already does.
- The leave prompt was reworded. It said *"You haven't published this post, all images will
  stay hidden"* — phrased as an unsaved-changes warning when nothing is unsaved. It now says
  the changes are saved and the draft stays hidden until published, which is the mistake the
  prompt exists to prevent.

**Autosave behaviour is unchanged.** The `form.watch` → `debounce` → `mutate` block is
byte-identical to `main`. Nothing is staged for the button; typing still saves ~1s after you
stop, with or without it.

## The editor dropped edits on the way out

`useDebouncer` clears its timer on unmount, so an edit made inside the 1s autosave window was
discarded by **any** navigation. Pre-existing, but a button labelled *Save as Draft* cannot
inherit it — click it right after typing a title and the title was gone.

`useDebouncer` now exposes `flush()` and `cancel()`, and the post editor flushes pending saves
before it leaves. This covers all three of the editor's debounced autosaves — the title/detail
form plus the per-row tool notes and technique notes, which have their own debouncers and many
mounted at once. They register into a keyed map held outside reactive state, so registering
costs no store write. The debouncer owning its own flush also removed a hand-rolled
single-shot guard.

The flush runs on **every** exit, not only the button's — the provider's existing
`routeChangeStart` handler does it, after the guard has decided the navigation is going ahead.

### And an edit could be reverted on the server

The provider snapshots the store into the `post.getEdit` cache when the user leaves, nothing
refetches it (`staleTime: Infinity`), and the autosave never told the store what it had saved.
Re-entering the post seeded the form from pre-edit values and the next keystroke wrote them
back. Reproduced end to end:

```
typed "ORIGINAL-TITLE-KEEP-ME"  -> autosave lands, server correct
Save as Draft, return to post   -> form seeded with ""
type one character "X"          -> server title becomes "X"
```

The store is now updated when the request is **sent** rather than when it lands, because a save
flushed on the way out is still in flight when that snapshot is taken. That write is optimistic,
so it is rolled back in `onError` — a field is restored only if it still holds what that request
set, so a later edit that succeeded meanwhile is not clobbered. Rollback matters most for the
tool/technique notes, where `dirty` compares against that same value and drives the unsaved
marker.

## Other review findings folded in

- `bypassRef` on `useCatchNavigation` now accepts a **url** as well as a boolean. The pages
  router cancels an in-flight `change()` with a flag rather than by settling its promise and
  emits the new `routeChangeStart` before the old push rejects, so a bare boolean waived any
  navigation started during the awaited push. Boolean still waives everything, which
  `useReviewNavigationGuard` relies on. Plus a re-entrancy guard on the handler.
- `returnUrl` is collapsed to a same-origin path before it is pushed, on both the publish and
  draft paths.
- zustand `devtools` gated off in production, where `import.meta.env` does not exist so its own
  default left it enabled — serializing the whole store, images included, on every `set()` for
  anyone with the extension installed.

## Verification

Local dev as user 4 against the dev database, plus tests.

| Check | Result |
|---|---|
| No confirm on the draft exit; an unrelated navigation still prompts | both hold |
| Lands on the Draft section with the post visible | yes |
| Title typed 120 ms before the click persists | yes |
| Tool note typed 120 ms before the click persists | yes |
| Edit inside the debounce survives an **ordinary** navigation too | yes |
| Re-entering the post shows the saved title | yes (was empty) |
| Next keystroke does not revert the server | `…KEEP-MEZ`, was `Z` |
| Failed save rolls the store back; unsaved marker returns | yes (forced 500) |
| Autosave still fires on its own with no exit | `post.update` at 1099 ms |
| Hidden on a parent-unpublished post | not rendered |

`pnpm run typecheck` 0 errors · unit **19,700 passed / 0 failed** · component **1,859 passed /
3 failed**, and those 3 fail identically at this branch's base commit (`AppListingCard` and
`AppsPageLayout` pixel-geometry assertions — pre-existing, unrelated to this diff).

Tests added: the debouncer contract (flush runs the pending call exactly once, cancel, drop on
unmount), the `returnUrl` collapse, and the url-scoped bypass with a negative control. Both
non-trivial ones were mutation-checked — reverting the fix prints
`expected "vi.fn()" to be called 1 times, but got 2 times` and
`expected [Function] to throw an error`, in under 100 ms each.

**Verified manually, not by tests:** the sidebar wiring itself, the rollback, and the
provider-wide flush. A render test for the sidebar needs `trpc.useUtils`, `post.update`,
`post.delete` and two `placement.*` queries faked for child components, which tests the mocks
rather than the wiring.

## Follow-ups

- Draft reaping/expiry and the cosmetics-image untangling, both deferred in the sync.
- `useCatchNavigation` exists twice (`src/hooks/` for components, `src/store/` used only by
  `s3-upload.store.ts`).
- The draft feed re-scans the full per-user set on every page — p99 is 73 drafts so only a
  four-figure tail pays, and it is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
