### PR TITLE
docs: route agent-generated follow-ups to their own ClickUp list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -595,6 +595,25 @@ A useful tell: if you are documenting **why** a guard exists and **what it stops
 - If a change depends on an unmerged PR, **wait for that PR to merge, then branch off the updated base** — or fold both changes into a single PR.
 - (Bit us 2026-06-13: PR #2520's App Blocks W11 F5 was stacked on #2518 (F6) → #2520 squash-merged into the #2518 branch instead of `feat/app-blocks-main-v1`; corrected via #2525.)
 
+### Filing follow-up work: two lists, and the line between them
+
+Work you generate about your own work — the deferred half of a review, a duplicate you noticed, a missing
+index, a test you did not write — goes in the **`Agent Follow-ups`** list, not the team list. Resolve the
+id with `find-list "Agent Follow-ups"`.
+
+**`Synced Team`** stays what a human would recognise as the team's work: anything a person asked for out
+loud, and anything security-shaped or user-facing-broken, filed at its real priority. Those never go in
+the follow-ups list — the line exists so the new list does not become where real bugs go to be quiet.
+
+Two rules for anything you file:
+
+- **File as the human whose session you are running in**, not as the meta agent. Their name on it is what
+  makes it findable by the person who has to decide it.
+- **Name the PR or commit it fell out of.** A follow-up without that is a sentence nobody can act on six
+  weeks later.
+
+The follow-ups list is a queue to be worked down, not an archive.
+
 ## Common Patterns
 
 ### Infinite Scroll


### PR DESCRIPTION
Standup 2026-08-20 agreed that agent-generated follow-up work should stop landing in the team list, where it buries the human deliverables.

Adds a short CLAUDE.md section covering:
- which list takes which kind of task
- that security-shaped and user-facing-broken bugs stay on the team list at their real priority, so the new list does not become where real bugs go quiet
- that agents file as the human whose session they are running in, and name the PR or commit the follow-up fell out of

The list itself already exists. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)