### PR TITLE
fix(models): ?earlyAccess=false no longer switches the filter on

### DIFF
--- a/src/pages/api/v1/models/index.ts
+++ b/src/pages/api/v1/models/index.ts
@@ -37,7 +37,7 @@ export const config = {
 
 const authedOnlyOptions: Array<keyof GetAllModelsInput> = ['favorites', 'hidden'];
 
-const modelsEndpointSchema = getAllModelsSchema.extend({
+export const modelsEndpointSchema = getAllModelsSchema.extend({
   limit: z.preprocess((val) => Number(val), z.number().min(0).max(100)).default(100),
   nsfw: booleanString().optional(),
   primaryFileOnly: booleanString().optional(),

--- a/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
+++ b/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { getAllModelsSchema } from '~/server/schema/model.schema';
+
+/**
+ * /api/v1/models parses this schema straight off `req.query`, where every value is a
+ * string. `z.coerce.boolean()` is JS `Boolean()` there, so `?earlyAccess=false` parsed
+ * as `true` and switched the filter on — the caller got the opposite of what it asked
+ * for, with no error.
+ *
+ * The keys are discovered from the schema rather than listed, because a hand-listed set
+ * has the same blind spot as the bug: it cannot see the next field someone declares on
+ * `z.coerce.boolean()`.
+ */
+
+// A `z.preprocess` field can THROW rather than return an issue (commaDelimitedNumberArray
+// calls .map on whatever it is handed), and at module scope that would fail collection —
+// zero tests, reported as a pass. Treat a throw as "does not accept this value".
+function parseOne(key: string, value: unknown) {
+  try {
+    const result = getAllModelsSchema.safeParse({ [key]: value });
+    return result.success ? { ok: true as const, value: (result.data as Record<string, unknown>)[key] } : null;
+  } catch {
+    return null;
+  }
+}
+
+function booleanKeys() {
+  return Object.keys(getAllModelsSchema.shape).filter((key) => parseOne(key, true) !== null);
+}
+
+describe('getAllModelsSchema — boolean params over raw query strings', () => {
+  // Non-vacuity: if discovery silently returned nothing, or stopped reaching the fields
+  // this is about, every assertion below would pass over an empty list.
+  it('discovers the boolean params, including the ones this bug was found on', () => {
+    expect(booleanKeys()).toEqual(expect.arrayContaining(['earlyAccess', 'paidAccess']));
+    expect(booleanKeys().length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('never parses the STRING `false` as true, for any boolean param', () => {
+    for (const key of booleanKeys()) {
+      const parsed = parseOne(key, 'false');
+      // Rejecting the string is fine — that fails closed with a 400. Accepting it as
+      // `true` is the bug.
+      const value = parsed ? parsed.value : '<rejected>';
+      expect(value, `?${key}=false parsed as ${String(value)}`).not.toBe(true);
+    }
+  });
+
+  it('still parses `true` and real booleans as true', () => {
+    expect(getAllModelsSchema.parse({ earlyAccess: 'true' }).earlyAccess).toBe(true);
+    expect(getAllModelsSchema.parse({ earlyAccess: true }).earlyAccess).toBe(true);
+    expect(getAllModelsSchema.parse({ earlyAccess: 'false' }).earlyAccess).toBe(false);
+  });
+});

--- a/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
+++ b/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
@@ -18,7 +18,9 @@ import { getAllModelsSchema } from '~/server/schema/model.schema';
 function parseOne(key: string, value: unknown) {
   try {
     const result = getAllModelsSchema.safeParse({ [key]: value });
-    return result.success ? { ok: true as const, value: (result.data as Record<string, unknown>)[key] } : null;
+    return result.success
+      ? { ok: true as const, value: (result.data as Record<string, unknown>)[key] }
+      : null;
   } catch {
     return null;
   }

--- a/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
+++ b/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
@@ -18,9 +18,7 @@ import { getAllModelsSchema } from '~/server/schema/model.schema';
 function parseOne(key: string, value: unknown) {
   try {
     const result = getAllModelsSchema.safeParse({ [key]: value });
-    return result.success
-      ? { ok: true as const, value: (result.data as Record<string, unknown>)[key] }
-      : null;
+    return result.success ? { value: (result.data as Record<string, unknown>)[key] } : null;
   } catch {
     return null;
   }

--- a/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
+++ b/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import type * as z from 'zod';
 import { getAllModelsSchema } from '~/server/schema/model.schema';
+import { modelsEndpointSchema } from '~/pages/api/v1/models';
 
 /**
  * /api/v1/models parses this schema straight off `req.query`, where every value is a
@@ -10,45 +12,80 @@ import { getAllModelsSchema } from '~/server/schema/model.schema';
  * The keys are discovered from the schema rather than listed, because a hand-listed set
  * has the same blind spot as the bug: it cannot see the next field someone declares on
  * `z.coerce.boolean()`.
+ *
+ * BOTH schemas are checked. The endpoint parses `modelsEndpointSchema`, which extends
+ * the shared one and overrides several fields — so an override reintroducing
+ * `z.coerce.boolean()` at the endpoint is the same live bug, and it is invisible to a
+ * test that only knows about the shared schema.
  */
 
 // A `z.preprocess` field can THROW rather than return an issue (commaDelimitedNumberArray
 // calls .map on whatever it is handed), and at module scope that would fail collection —
 // zero tests, reported as a pass. Treat a throw as "does not accept this value".
-function parseOne(key: string, value: unknown) {
+function parseOne(schema: z.ZodObject, key: string, value: unknown) {
   try {
-    const result = getAllModelsSchema.safeParse({ [key]: value });
+    const result = schema.safeParse({ [key]: value });
     return result.success ? { value: (result.data as Record<string, unknown>)[key] } : null;
   } catch {
     return null;
   }
 }
 
-function booleanKeys() {
-  return Object.keys(getAllModelsSchema.shape).filter((key) => parseOne(key, true) !== null);
+function booleanKeys(schema: z.ZodObject) {
+  return Object.keys(schema.shape).filter((key) => parseOne(schema, key, true) !== null);
 }
 
-describe('getAllModelsSchema — boolean params over raw query strings', () => {
-  // Non-vacuity: if discovery silently returned nothing, or stopped reaching the fields
-  // this is about, every assertion below would pass over an empty list.
-  it('discovers the boolean params, including the ones this bug was found on', () => {
-    expect(booleanKeys()).toEqual(expect.arrayContaining(['earlyAccess', 'paidAccess']));
-    expect(booleanKeys().length).toBeGreaterThanOrEqual(8);
-  });
+/**
+ * Every field that is meant to read a boolean OUT OF A QUERY STRING. Named, and only for
+ * the non-vacuity guard below — the assertions themselves stay derived from the schema.
+ */
+const QUERY_STRING_BOOLEANS = [
+  'favorites',
+  'hidden',
+  'needsReview',
+  'earlyAccess',
+  'paidAccess',
+  'supportsGeneration',
+  'fromPlatform',
+  'followed',
+  'newCreators',
+  'archived',
+];
 
-  it('never parses the STRING `false` as true, for any boolean param', () => {
-    for (const key of booleanKeys()) {
-      const parsed = parseOne(key, 'false');
-      // Rejecting the string is fine — that fails closed with a 400. Accepting it as
-      // `true` is the bug.
-      const value = parsed ? parsed.value : '<rejected>';
-      expect(value, `?${key}=false parsed as ${String(value)}`).not.toBe(true);
-    }
-  });
+function describeSchema(label: string, schema: z.ZodObject, expected: string[]) {
+  describe(`${label} — boolean params over raw query strings`, () => {
+    // Non-vacuity. Discovery also picks up keys that merely tolerate a boolean —
+    // `Number(true) === 1` gets `limit`, `page` and `rating` in — so a bare count is
+    // satisfied by fields this bug cannot touch. Name the ones that must be there.
+    it('discovers every query-string boolean', () => {
+      expect(booleanKeys(schema)).toEqual(expect.arrayContaining(expected));
+    });
 
-  it('still parses `true` and real booleans as true', () => {
-    expect(getAllModelsSchema.parse({ earlyAccess: 'true' }).earlyAccess).toBe(true);
-    expect(getAllModelsSchema.parse({ earlyAccess: true }).earlyAccess).toBe(true);
-    expect(getAllModelsSchema.parse({ earlyAccess: 'false' }).earlyAccess).toBe(false);
+    it('never parses the STRING `false` as true, for any boolean param', () => {
+      for (const key of booleanKeys(schema)) {
+        const parsed = parseOne(schema, key, 'false');
+        // Rejecting the string is fine — that fails closed with a 400. Accepting it as
+        // `true` is the bug.
+        const value = parsed ? parsed.value : '<rejected>';
+        expect(value, `?${key}=false parsed as ${String(value)}`).not.toBe(true);
+      }
+    });
+
+    // The other polarity: a field that rejected everything would satisfy the test above.
+    it('still parses `true`, `false` and real booleans correctly', () => {
+      for (const key of expected) {
+        expect(parseOne(schema, key, 'true')?.value, `?${key}=true`).toBe(true);
+        expect(parseOne(schema, key, 'false')?.value, `?${key}=false`).toBe(false);
+        expect(parseOne(schema, key, true)?.value, `${key}: true`).toBe(true);
+      }
+    });
   });
-});
+}
+
+describeSchema('getAllModelsSchema', getAllModelsSchema, QUERY_STRING_BOOLEANS);
+describeSchema('modelsEndpointSchema (/api/v1/models)', modelsEndpointSchema, [
+  ...QUERY_STRING_BOOLEANS,
+  // The endpoint's own additions.
+  'nsfw',
+  'primaryFileOnly',
+]);

--- a/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
+++ b/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
@@ -20,8 +20,12 @@ import { modelsEndpointSchema } from '~/pages/api/v1/models';
  */
 
 // A `z.preprocess` field can THROW rather than return an issue (commaDelimitedNumberArray
-// calls .map on whatever it is handed), and at module scope that would fail collection —
-// zero tests, reported as a pass. Treat a throw as "does not accept this value".
+// calls .map on whatever it is handed), so a bare safeParse over every key is not safe.
+// Treat a throw as "does not accept this value".
+//
+// Keep every call to this inside an `it` body. An earlier version derived the key list at
+// module scope, where that same throw failed COLLECTION: the file reported as a pass with
+// zero tests. Inside a test, a throw is a red test.
 function parseOne(schema: z.ZodObject, key: string, value: unknown) {
   try {
     const result = schema.safeParse({ [key]: value });
@@ -36,8 +40,14 @@ function booleanKeys(schema: z.ZodObject) {
 }
 
 /**
- * Every field that is meant to read a boolean OUT OF A QUERY STRING. Named, and only for
- * the non-vacuity guard below — the assertions themselves stay derived from the schema.
+ * Every field that is meant to read a boolean OUT OF A QUERY STRING.
+ *
+ * The `'false'` check below stays derived from the schema and needs nothing from this list
+ * — that is the point of the file. But this list drives two assertions that CANNOT be
+ * derived: the non-vacuity guard, and the both-polarity check. So an eleventh
+ * `booleanString()` field added to the schema is covered for the bug this PR fixed, and is
+ * NOT covered for the opposite failure (a field that rejects everything) until it is named
+ * here. Add it in both places.
  */
 const QUERY_STRING_BOOLEANS = [
   'favorites',
@@ -77,6 +87,17 @@ function describeSchema(label: string, schema: z.ZodObject, expected: string[]) 
         expect(parseOne(schema, key, 'true')?.value, `?${key}=true`).toBe(true);
         expect(parseOne(schema, key, 'false')?.value, `?${key}=false`).toBe(false);
         expect(parseOne(schema, key, true)?.value, `${key}: true`).toBe(true);
+      }
+    });
+
+    // An empty value is REJECTED, which 400s the whole request. That is a decision, not an
+    // accident: `?earlyAccess=` reads as asking FOR early access, so if it meant anything it
+    // would have to mean `true` — requiring an explicit value avoids picking a side. It is
+    // also a behaviour change from `z.coerce.boolean()`, which read empty as `false`, so it
+    // is pinned here rather than left to a PR comment.
+    it('rejects an empty value rather than guessing what it meant', () => {
+      for (const key of expected) {
+        expect(parseOne(schema, key, ''), `?${key}= should be rejected`).toBeNull();
       }
     });
   });

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -100,8 +100,12 @@ export const getAllModelsSchema = z.object({
     .preprocess((val) => Number(val), z.number())
     .transform((val) => Math.floor(val))
     .optional(),
-  // Every boolean below is booleanString(), never z.coerce.boolean(): /api/v1/models parses
-  // this schema against raw req.query, where coerce runs JS Boolean() and makes `=false` true.
+  // The query-string booleans — `favorites` through `archived` below — are booleanString(),
+  // never z.coerce.boolean(): /api/v1/models parses this schema against raw req.query, where
+  // coerce runs JS Boolean() and makes `=false` true. This does NOT describe the whole object:
+  // `pending`, `disablePoi`, `disableMinor`, `isFeatured`, `poiOnly`, `minorOnly` and the
+  // spread-in `allow*` fields are plain z.boolean() on purpose — they reject a string outright,
+  // so the endpoint 400s rather than returning the wrong set.
   favorites: booleanString().optional().default(false),
   hidden: booleanString().optional().default(false),
   needsReview: booleanString().optional(),

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -100,24 +100,22 @@ export const getAllModelsSchema = z.object({
     .preprocess((val) => Number(val), z.number())
     .transform((val) => Math.floor(val))
     .optional(),
-  favorites: z.coerce.boolean().optional().default(false),
-  hidden: z.coerce.boolean().optional().default(false),
-  needsReview: z.coerce.boolean().optional(),
-  earlyAccess: z.coerce.boolean().optional(),
-  // booleanString, not z.coerce.boolean: the REST endpoint parses raw query strings,
-  // where coerce makes `?paidAccess=false` truthy.
+  // Every boolean below is booleanString(), never z.coerce.boolean(): /api/v1/models parses
+  // this schema against raw req.query, where coerce runs JS Boolean() and makes `=false` true.
+  favorites: booleanString().optional().default(false),
+  hidden: booleanString().optional().default(false),
+  needsReview: booleanString().optional(),
+  earlyAccess: booleanString().optional(),
   paidAccess: booleanString().optional(),
   ids: commaDelimitedNumberArray().optional(),
   modelVersionIds: commaDelimitedNumberArray().optional(),
-  supportsGeneration: z.coerce.boolean().optional(),
-  fromPlatform: z.coerce.boolean().optional(),
-  followed: z.coerce.boolean().optional(),
+  supportsGeneration: booleanString().optional(),
+  fromPlatform: booleanString().optional(),
+  followed: booleanString().optional(),
   // Restrict to creators currently on the "new & upcoming" board. Server resolves
   // the board from this flag plus the request domain; the client sends no user list.
-  // booleanString, not z.coerce.boolean: the REST endpoint parses raw query strings,
-  // where coerce makes `?newCreators=false` truthy.
   newCreators: booleanString().optional(),
-  archived: z.coerce.boolean().optional(),
+  archived: booleanString().optional(),
   collectionId: z.number().optional(),
   collectionItemStatus: z.array(z.enum(CollectionItemStatus)).optional(),
   fileFormats: z.enum(constants.modelFileFormats).array().optional(),

--- a/src/server/services/__tests__/get-models-raw.paid-access-filter.test.ts
+++ b/src/server/services/__tests__/get-models-raw.paid-access-filter.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, vi } from 'vitest';
 // is a ~4800-line module whose cold transform would otherwise be charged to the first
 // test's timeout budget rather than to collection.
 import { getModelsRaw, getPermanentPaidAccessModelIds } from '~/server/services/model.service';
-import { getAllModelsSchema } from '~/server/schema/model.schema';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
 
@@ -105,16 +104,7 @@ describe('getPermanentPaidAccessModelIds', () => {
   });
 });
 
-describe('getAllModelsSchema — paidAccess over raw query strings', () => {
-  // The REST endpoint parses req.query, where z.coerce.boolean() turns the STRING
-  // 'false' into true and silently switches the filter on.
-  it('parses `?paidAccess=false` as false, not true', () => {
-    const parsed = getAllModelsSchema.parse({ paidAccess: 'false' });
-    expect(parsed.paidAccess).toBe(false);
-  });
-
-  it('still parses `?paidAccess=true` and a real boolean as true', () => {
-    expect(getAllModelsSchema.parse({ paidAccess: 'true' }).paidAccess).toBe(true);
-    expect(getAllModelsSchema.parse({ paidAccess: true }).paidAccess).toBe(true);
-  });
-});
+// The `?paidAccess=false` parse assertions that used to live here moved to
+// src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts, which derives
+// its field list from the schema instead of naming paidAccess. Same invariant, and it
+// also covers the next field someone declares on z.coerce.boolean().

--- a/src/server/services/__tests__/get-models.early-access-query-string.test.ts
+++ b/src/server/services/__tests__/get-models.early-access-query-string.test.ts
@@ -68,12 +68,19 @@ describe('?earlyAccess=false reaches the raw SQL consumer as OFF', () => {
 
 describe('?earlyAccess=false reaches the Prisma consumer as OFF', () => {
   async function whereFor(earlyAccess: string) {
+    // `resetSharedMocks()` runs per FILE, not per test, so without this the assertions
+    // below can read the previous test's call and pass on stale state.
+    dbMock.dbRead.model.findMany.mockClear();
     dbMock.dbRead.$queryRaw.mockResolvedValue([{ modelId: 123 }]);
     dbMock.dbRead.model.findMany.mockResolvedValue([]);
     await getModels({
       input: { ...fromQueryString(earlyAccess), take: 10 } as never,
       select: { id: true },
     });
+    // Pin the call itself. Without this, an early return inside getModels leaves `where`
+    // undefined, the stringified `[]` contains no '123', and the negative test passes for
+    // entirely the wrong reason.
+    expect(dbMock.dbRead.model.findMany).toHaveBeenCalledTimes(1);
     const call = dbMock.dbRead.model.findMany.mock.calls.at(-1);
     return (call?.[0] as { where?: { AND?: unknown[] } } | undefined)?.where;
   }

--- a/src/server/services/__tests__/get-models.early-access-query-string.test.ts
+++ b/src/server/services/__tests__/get-models.early-access-query-string.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+// STATIC import, same reasoning as get-models-raw.paid-access-filter.test.ts: model.service
+// is a ~4800-line module whose cold transform would otherwise be charged to the first
+// test's timeout budget rather than to collection.
+import { getModels, getModelsRaw } from '~/server/services/model.service';
+import { getAllModelsSchema } from '~/server/schema/model.schema';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+redisMock.redis.packed.get.mockImplementation(async () => null);
+redisMock.redis.packed.set.mockImplementation(async () => undefined);
+
+const { capturedQueries } = vi.hoisted(() => ({ capturedQueries: [] as { sql: string }[] }));
+
+vi.mock('~/server/db/pgDb', () => ({
+  pgDbRead: {
+    cancellableQuery: vi.fn(async (query: { sql: string }) => {
+      capturedQueries.push(query);
+      return { result: async () => [], cancel: async () => undefined };
+    }),
+  },
+  pgDbWrite: {},
+  pgDbReadLong: {},
+}));
+
+// Same seams as the paid-access filter test: break the event-engine-common import chain
+// and no-op the blocked-tag enforcement that runs before either query is built.
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(),
+  getImagesForModelVersionCache: vi.fn(),
+  queueImageSearchIndexUpdate: vi.fn(),
+}));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn().mockResolvedValue(false) }));
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTagsForModels: vi.fn().mockResolvedValue({ emptyResult: false }),
+}));
+
+/** What the REST endpoint hands the services: `req.query`, so a STRING. */
+function fromQueryString(earlyAccess: string) {
+  const { cursor, ...input } = getAllModelsSchema.parse({ earlyAccess, browsingLevel: 1 });
+  return input;
+}
+
+/**
+ * The parse is only half the bug. Both consumers read the parsed value with a bare
+ * truthy check, so this pins that each one actually stops emitting its filter — asserted
+ * against the query, not reasoned from the parsed value.
+ */
+describe('?earlyAccess=false reaches the raw SQL consumer as OFF', () => {
+  beforeEach(() => {
+    capturedQueries.length = 0;
+  });
+
+  it('emits no early-access predicate for the string `false`', async () => {
+    await getModelsRaw({ input: { ...fromQueryString('false'), take: 10 } as never });
+    expect(capturedQueries).toHaveLength(1);
+    expect(capturedQueries[0].sql).not.toContain('"endsAt" > NOW()');
+  });
+
+  // Positive control: without it the assertion above passes just as happily against a
+  // build that never emits the predicate at all.
+  it('still emits it for the string `true`', async () => {
+    await getModelsRaw({ input: { ...fromQueryString('true'), take: 10 } as never });
+    expect(capturedQueries).toHaveLength(1);
+    expect(capturedQueries[0].sql).toContain('"endsAt" > NOW()');
+  });
+});
+
+describe('?earlyAccess=false reaches the Prisma consumer as OFF', () => {
+  async function whereFor(earlyAccess: string) {
+    dbMock.dbRead.$queryRaw.mockResolvedValue([{ modelId: 123 }]);
+    dbMock.dbRead.model.findMany.mockResolvedValue([]);
+    await getModels({
+      input: { ...fromQueryString(earlyAccess), take: 10 } as never,
+      select: { id: true },
+    });
+    const call = dbMock.dbRead.model.findMany.mock.calls.at(-1);
+    return (call?.[0] as { where?: { AND?: unknown[] } } | undefined)?.where;
+  }
+
+  it('adds no early-access id restriction for the string `false`', async () => {
+    const where = await whereFor('false');
+    expect(JSON.stringify(where?.AND ?? [])).not.toContain('123');
+  });
+
+  it('still adds it for the string `true`', async () => {
+    const where = await whereFor('true');
+    expect(JSON.stringify(where?.AND ?? [])).toContain('123');
+  });
+});


### PR DESCRIPTION
Closes ClickUp [868ku8g1k](https://app.clickup.com/t/868ku8g1k).

## The bug

`/api/v1/models` parses `getAllModelsSchema` against raw `req.query`, where every value is a string. `z.coerce.boolean()` is JS `Boolean()` there, and `'false'` is a non-empty string — so `?earlyAccess=false` parsed as `true` and switched the early-access filter **on**. The caller asking to exclude early access got exactly the opposite set, with no error and no warning. tRPC callers send real booleans, which is why it survived.

The fix already existed two lines below: `booleanString()`, used for `paidAccess` and `newCreators` with the reasoning recorded beside it.

## Scope — the whole column, with reachability stated per param

Every boolean in `getAllModelsSchema` is reachable from the public REST endpoint: the handler does `modelsEndpointSchema.safeParse(req.query)` over the whole query object, with no key filtering (the only gate is a 401 when `favorites`/`hidden` are sent unauthenticated).

**Fixed here — the parse was wrong on all six.** But the *effect* differs, and the distinction matters for anyone sizing the incident: two of them are gated downstream, so only four returned a wrong set to an ordinary public caller.

| Param | Reachable | Effect of `=false` before this PR |
|---|---|---|
| `earlyAccess` | public | **wrong set returned** — the reported bug |
| `supportsGeneration` | public | **wrong set returned** |
| `fromPlatform` | public | **wrong set returned** |
| `archived` | public | **wrong set returned** |
| `needsReview` | public | parsed `true`, then **gated on `sessionUser?.isModerator`** in both consumers (`model.service.ts:550`, `:1298`) — no effect for a non-moderator |
| `followed` | public | parsed `true`, then **gated on a signed-in user** (`:612`, `:1320`) — no effect for an anonymous caller |

So: **four ungated public-facing bugs, not six.** `booleanString()` is right for all six regardless — a moderator or a signed-in user sending `=false` got the wrong set too.

**Moved for consistency, not a live bug** — `favorites`, `hidden`. Both were already shielded at REST by a `booleanString()` override in the endpoint's own `modelsEndpointSchema`.

> ⚠️ **Those two overrides in `src/pages/api/v1/models/index.ts` are now redundant but harmless, and this PR deliberately leaves them in place.** They restate what the shared schema now says, so they change nothing. Removing them is filed separately; do not delete one as drive-by cleanup here.

**Reachable but already correct** — `paidAccess`, `newCreators` (fixed in #4141 and earlier).

**Different bucket, deliberately not changed** — `pending`, `disablePoi`, `disableMinor`, `isFeatured`, `poiOnly`, `minorOnly`, `allowNoCredit`, `allowDerivatives`, `allowDifferentLicense` are plain `z.boolean()`. A query string is *rejected* there, so the endpoint 400s: unusable over REST, but it fails closed rather than returning the wrong set.

**Out of scope, reported for separate tickets** — `image.schema.ts` (`fromPlatform`, `notPublished`, `scheduled`) and `post.schema.ts` (`scheduled`, `video`) still use `z.coerce.boolean()`; they look tRPC-only, since `/api/v1/images` parses its own schema which already uses `booleanString()` throughout. Two admin endpoints have the same defect on a money path and are filed as [868kun1w5](https://app.clickup.com/t/868kun1w5).

## Tests

**The test discovers its own field list, over BOTH schemas.** A test that enumerates the fields it checks has the same blind spot as the bug — it cannot see the next field someone declares on `z.coerce.boolean()`. This one reads `.shape`, keeps every key that accepts a real boolean, and asserts none of them parses the string `'false'` as `true`.

It runs over `getAllModelsSchema` **and** over `modelsEndpointSchema`, the extended schema the endpoint actually parses. An override reintroducing `z.coerce.boolean()` at the endpoint is the same live bug, and it is invisible to a test that only knows the shared schema. Proven by mutation: coercing the endpoint's own `nsfw` override turns it red with `?nsfw=false parsed as true`.

### 🔴 If you copy this test, copy all three guards with it

A schema-driven test buys its coverage by giving up a hand-written list — which means **it can silently end up covering nothing.** Three guards make that visible:

1. **Discovery runs inside the test, never at module scope.** A `z.preprocess` field can *throw* rather than return an issue — `commaDelimitedNumberArray` calls `.map` on whatever it is handed, so `safeParse({ ids: true })` throws outright. At module scope that throw failed *collection*: the file reported as a **pass with zero tests**. Same shape as a missing submodule hiding a whole suite.
2. **Non-vacuity names the fields, and does not count them.** Discovery keeps anything that tolerates a boolean, so `Number(true) === 1` pulls in `limit`, `page` and `rating` — a numeric floor is satisfied by fields this bug cannot touch, even if every field it *can* touch dropped out. The guard asserts the query-string booleans by name.
3. **Both polarities are asserted.** A field that rejected everything would satisfy "never parses `'false'` as true" perfectly. `'true'`, `'false'` and a real boolean are each pinned.

**Both consumers are asserted, not reasoned about.** The parsed value is read by two separate truthy checks — the raw-SQL `EXISTS` in `getModelsRaw` and the Prisma `id IN` in the `getModelsPagedSimple` path — so the test drives a query string through the schema into each one and asserts the query itself, with a positive control on each and a `toHaveBeenCalledTimes(1)` pin so an early return cannot pass as a clean negative.

**Revert legibility, checked by mutation.** Run against the unfixed schema, the suite fails with `AssertionError: ?favorites=false parsed as true: expected true not to be true` — an assertion naming the wrong value, not a timeout.

**One test was deleted, and its coverage moved.** `get-models-raw.paid-access-filter.test.ts` had a hand-listed `paidAccess` parse describe that the derived loop now covers. Two copies of one invariant, and the hand-listed copy was the exact blind spot this file argues against. A pointer comment says where it went.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm exec eslint <changed files>` — no issues (repo-wide `lint` is noisy on ~1,400 pre-existing files)
- `pnpm exec prettier --write <changed files>`
- `pnpm run test:unit:run` — full suite green; `blocks.router.workflow.test.ts` collects **350 tests**, so the submodule is initialised and the run is meaningful rather than a silent zero-collection pass

See the comment below for the full before/after table of input handling, and the decision on the empty value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
