### PR TITLE
fix(blocks): toggleHidden blockedUser ignored the caller's intent

### DIFF
--- a/src/server/services/__tests__/toggle-block-user.service.test.ts
+++ b/src/server/services/__tests__/toggle-block-user.service.test.ts
@@ -33,6 +33,9 @@ const block = (hidden?: boolean) =>
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The cache test spies on module-scope objects. Without a restore those spies
+  // outlive it and silently cover every test declared after it.
+  vi.restoreAllMocks();
   // `mockResolvedValue`, not `...Once`: `clearAllMocks` is `mockClear`, which does
   // not drain a queued once-implementation, so a test that threw before reaching
   // `findUnique` would leak its fixture into the next one — invisibly, because the
@@ -88,6 +91,11 @@ describe('toggleHidden kind=blockedUser — honours the caller intent', () => {
     await block(false);
 
     expect(engagement.upsert).not.toHaveBeenCalled();
+    // Assert the unblock still took its own path, so deleting the else-branch
+    // outright cannot pass this test on the negative alone.
+    expect(engagement.deleteMany).toHaveBeenCalledWith({
+      where: { userId, targetUserId, type: 'Block' },
+    });
   });
 
   it('hidden=true over an existing Follow promotes the row to Block', async () => {
@@ -122,6 +130,18 @@ describe('toggleHidden kind=blockedUser — honours the caller intent', () => {
     expect(engagement.deleteMany).toHaveBeenCalled();
     expect(engagement.upsert).not.toHaveBeenCalled();
   });
+
+  it('hidden omitted with no engagement blocks — the fallback must work both ways', async () => {
+    await block(undefined);
+
+    // Without this the suite cannot tell `setTo ?? !alreadyBlocked` from
+    // `setTo === true`: every other omitted-intent case starts from a Block row,
+    // where both forms happen to agree. That mutant also makes the `findUnique`
+    // read dead code.
+    expect(engagement.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ create: { userId, targetUserId, type: 'Block' } })
+    );
+  });
 });
 
 // Without these the writes are correct and invisible: every read path serves the
@@ -139,6 +159,20 @@ describe('toggleHidden kind=blockedUser — cache invalidation', () => {
     expect(blocked).toHaveBeenCalledWith({ userId });
     expect(blockedBy).toHaveBeenCalledWith({ userId: targetUserId });
     expect(follows).toHaveBeenCalledWith(userId);
+  });
+
+  it('refreshes them on an unblock too, not only on a block', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Block' });
+    const blocked = vi.spyOn(BlockedUsers, 'refreshCache').mockResolvedValue(undefined);
+    const blockedBy = vi.spyOn(BlockedByUsers, 'refreshCache').mockResolvedValue(undefined);
+
+    await block(false);
+
+    // Gating the refreshes on `blocking` would leave a lifted block invisible to
+    // every read path until the hash TTL — the stale list is what caused this bug
+    // in the first place.
+    expect(blocked).toHaveBeenCalledWith({ userId });
+    expect(blockedBy).toHaveBeenCalledWith({ userId: targetUserId });
   });
 });
 
@@ -158,14 +192,47 @@ describe('toggleHidden kind=blockedUser — placement cascade', () => {
     });
   });
 
-  it('runs again on a repeat block, so a large backlog can still be drained', async () => {
+  it('cascades even when the user is ALREADY blocked', async () => {
     engagement.findUnique.mockResolvedValue({ type: 'Block' });
 
     await block(true);
 
-    // `declinePlacementsOnBlock` caps at 200 pending rows per run and swallows
-    // its own failures, so blocking again is the only user-reachable retry.
-    // Gating this on the transition would silently remove it.
+    // `declinePlacementsOnBlock` caps at 200 pending rows per direction and
+    // swallows its own failures, so blocking again is the only user-reachable
+    // retry. Gating this on `!alreadyBlocked` would silently remove it.
+    //
+    // The count alone does not prove that — a first-time block also produces 2,
+    // one per direction — so assert both legs and let the `findUnique` fixture
+    // above carry the "already blocked" part.
+    expect(declinePlacementsOnBlock).toHaveBeenCalledWith({
+      ownerId: userId,
+      placerId: targetUserId,
+      waiveFee: true,
+    });
+    expect(declinePlacementsOnBlock).toHaveBeenCalledWith({
+      ownerId: targetUserId,
+      placerId: userId,
+      waiveFee: false,
+    });
+    expect(declinePlacementsOnBlock).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs AFTER the block is committed, which is the precondition it asserts', async () => {
+    await block(true);
+
+    expect(declinePlacementsOnBlock.mock.invocationCallOrder[0]).toBeGreaterThan(
+      engagement.upsert.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('never fails the block when a cascade leg throws', async () => {
+    declinePlacementsOnBlock.mockRejectedValueOnce(new Error('buzz outage'));
+
+    await expect(block(true)).resolves.toEqual({ added: [], removed: [] });
+
+    // The block is the protection; the refunds are recoverable by the expiry job.
+    // The second direction must still be attempted after the first throws.
+    expect(engagement.upsert).toHaveBeenCalled();
     expect(declinePlacementsOnBlock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/server/services/__tests__/toggle-block-user.service.test.ts
+++ b/src/server/services/__tests__/toggle-block-user.service.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import type * as PlacementModeration from '~/server/services/placement-moderation.service';
+
+const { declinePlacementsOnBlock } = vi.hoisted(() => ({
+  declinePlacementsOnBlock: vi.fn(async () => undefined),
+}));
+
+vi.mock('~/server/services/placement-moderation.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof PlacementModeration>()),
+  declinePlacementsOnBlock,
+}));
+
+import { toggleHidden } from '~/server/services/user-preferences.service';
+
+const userId = 42;
+const targetUserId = 99;
+const engagement = dbMock.dbWrite.userEngagement;
+
+const block = (hidden?: boolean) =>
+  toggleHidden({ kind: 'blockedUser', data: [{ id: targetUserId }], hidden, userId });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  engagement.create.mockResolvedValue({});
+  engagement.update.mockResolvedValue({});
+  engagement.delete.mockResolvedValue({});
+});
+
+// The bug this pins: `toggleHidden` dropped `hidden` on the way to
+// `toggleBlockUser`, so the service could only flip whatever it found. A client
+// holding a stale block list therefore sent "block" and got an UNBLOCK, and the
+// UI reported success either way. These assert through `toggleHidden` — the
+// exported entry the router calls — because a test calling `toggleBlockUser`
+// directly cannot see an argument the caller failed to pass.
+describe('toggleHidden kind=blockedUser — honours the caller intent', () => {
+  it('hidden=true on an ALREADY blocked user leaves the block in place', async () => {
+    engagement.findUnique.mockResolvedValueOnce({ type: 'Block' });
+
+    await block(true);
+
+    expect(engagement.delete).not.toHaveBeenCalled();
+    expect(engagement.create).not.toHaveBeenCalled();
+    expect(engagement.update).not.toHaveBeenCalled();
+  });
+
+  it('hidden=false on a blocked user removes the block', async () => {
+    engagement.findUnique.mockResolvedValueOnce({ type: 'Block' });
+
+    await block(false);
+
+    expect(engagement.delete).toHaveBeenCalledWith({
+      where: { userId_targetUserId: { userId, targetUserId } },
+    });
+  });
+
+  it('hidden=true with no engagement writes a Block row', async () => {
+    engagement.findUnique.mockResolvedValueOnce(null);
+
+    await block(true);
+
+    expect(engagement.create).toHaveBeenCalledWith({
+      data: { userId, targetUserId, type: 'Block' },
+    });
+  });
+
+  it('hidden=false with no engagement writes nothing — an unblock must not create a block', async () => {
+    engagement.findUnique.mockResolvedValueOnce(null);
+
+    await block(false);
+
+    expect(engagement.create).not.toHaveBeenCalled();
+    expect(engagement.update).not.toHaveBeenCalled();
+    expect(engagement.delete).not.toHaveBeenCalled();
+  });
+
+  it('hidden=true over an existing Follow promotes the row to Block', async () => {
+    engagement.findUnique.mockResolvedValueOnce({ type: 'Follow' });
+
+    await block(true);
+
+    expect(engagement.update).toHaveBeenCalledWith({
+      where: { userId_targetUserId: { userId, targetUserId } },
+      data: { type: 'Block' },
+    });
+  });
+
+  it('hidden omitted still flips, so callers that send no intent are unchanged', async () => {
+    engagement.findUnique.mockResolvedValueOnce({ type: 'Block' });
+
+    await block(undefined);
+
+    expect(engagement.delete).toHaveBeenCalled();
+  });
+});
+
+describe('toggleHidden kind=blockedUser — placement cascade', () => {
+  it('runs when the block is newly established', async () => {
+    engagement.findUnique.mockResolvedValueOnce(null);
+
+    await block(true);
+
+    expect(declinePlacementsOnBlock).toHaveBeenCalledWith({
+      ownerId: userId,
+      placerId: targetUserId,
+      waiveFee: true,
+    });
+    expect(declinePlacementsOnBlock).toHaveBeenCalledWith({
+      ownerId: targetUserId,
+      placerId: userId,
+      waiveFee: false,
+    });
+  });
+
+  it('does not run on an unblock', async () => {
+    engagement.findUnique.mockResolvedValueOnce({ type: 'Block' });
+
+    await block(false);
+
+    expect(declinePlacementsOnBlock).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/toggle-block-user.service.test.ts
+++ b/src/server/services/__tests__/toggle-block-user.service.test.ts
@@ -1,103 +1,149 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
-import type * as PlacementModeration from '~/server/services/placement-moderation.service';
+import { toggleHiddenSchema } from '~/server/schema/user-preferences.schema';
+import { userFollowsCache } from '~/server/redis/caches';
 
 const { declinePlacementsOnBlock } = vi.hoisted(() => ({
   declinePlacementsOnBlock: vi.fn(async () => undefined),
 }));
 
-vi.mock('~/server/services/placement-moderation.service', async (importOriginal) => ({
-  ...(await importOriginal<typeof PlacementModeration>()),
+// Bare factory rather than a spread of the original: `user-preferences.service`
+// reaches this module ONLY through the dynamic import inside
+// `cascadeBlockToPlacements`, and only for this one export. Spreading the real
+// module would pull the escrow -> Buzz -> prom chain into the test graph, which
+// survives today only because setup.ts happens to mock every link — the trap
+// documented at the top of src/__tests__/setup.ts.
+vi.mock('~/server/services/placement-moderation.service', () => ({
   declinePlacementsOnBlock,
 }));
 
-import { toggleHidden } from '~/server/services/user-preferences.service';
+import {
+  toggleHidden,
+  BlockedUsers,
+  BlockedByUsers,
+} from '~/server/services/user-preferences.service';
 
 const userId = 42;
 const targetUserId = 99;
 const engagement = dbMock.dbWrite.userEngagement;
+const where = { userId_targetUserId: { userId, targetUserId } };
 
 const block = (hidden?: boolean) =>
   toggleHidden({ kind: 'blockedUser', data: [{ id: targetUserId }], hidden, userId });
 
 beforeEach(() => {
   vi.clearAllMocks();
-  engagement.create.mockResolvedValue({});
-  engagement.update.mockResolvedValue({});
-  engagement.delete.mockResolvedValue({});
+  // `mockResolvedValue`, not `...Once`: `clearAllMocks` is `mockClear`, which does
+  // not drain a queued once-implementation, so a test that threw before reaching
+  // `findUnique` would leak its fixture into the next one — invisibly, because the
+  // drained fallback (`null`) is itself a valid fixture here.
+  engagement.findUnique.mockResolvedValue(null);
+  engagement.upsert.mockResolvedValue({});
+  engagement.deleteMany.mockResolvedValue({ count: 0 });
 });
 
 // The bug this pins: `toggleHidden` dropped `hidden` on the way to
-// `toggleBlockUser`, so the service could only flip whatever it found. A client
-// holding a stale block list therefore sent "block" and got an UNBLOCK, and the
-// UI reported success either way. These assert through `toggleHidden` — the
-// exported entry the router calls — because a test calling `toggleBlockUser`
-// directly cannot see an argument the caller failed to pass.
+// `toggleBlockUser`, so the service could only flip whatever row it found. A
+// client holding a stale block list therefore sent "block" and got an UNBLOCK,
+// and the UI reported success either way.
+//
+// These assert through `toggleHidden` — the exported entry the router calls —
+// NOT `toggleBlockUser`. That is load-bearing: a test calling the inner
+// function supplies `setTo` itself and passes against the broken code. Please
+// keep them at this level.
 describe('toggleHidden kind=blockedUser — honours the caller intent', () => {
-  it('hidden=true on an ALREADY blocked user leaves the block in place', async () => {
-    engagement.findUnique.mockResolvedValueOnce({ type: 'Block' });
+  it('hidden=true on an ALREADY blocked user leaves the block standing', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Block' });
 
     await block(true);
 
-    expect(engagement.delete).not.toHaveBeenCalled();
-    expect(engagement.create).not.toHaveBeenCalled();
-    expect(engagement.update).not.toHaveBeenCalled();
+    expect(engagement.deleteMany).not.toHaveBeenCalled();
+    expect(engagement.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ where, update: { type: 'Block' } })
+    );
   });
 
   it('hidden=false on a blocked user removes the block', async () => {
-    engagement.findUnique.mockResolvedValueOnce({ type: 'Block' });
+    engagement.findUnique.mockResolvedValue({ type: 'Block' });
 
     await block(false);
 
-    expect(engagement.delete).toHaveBeenCalledWith({
-      where: { userId_targetUserId: { userId, targetUserId } },
+    expect(engagement.upsert).not.toHaveBeenCalled();
+    expect(engagement.deleteMany).toHaveBeenCalledWith({
+      where: { userId, targetUserId, type: 'Block' },
     });
   });
 
-  it('hidden=true with no engagement writes a Block row', async () => {
-    engagement.findUnique.mockResolvedValueOnce(null);
-
+  it('hidden=true with no engagement establishes the block', async () => {
     await block(true);
 
-    expect(engagement.create).toHaveBeenCalledWith({
-      data: { userId, targetUserId, type: 'Block' },
+    expect(engagement.upsert).toHaveBeenCalledWith({
+      where,
+      create: { userId, targetUserId, type: 'Block' },
+      update: { type: 'Block' },
     });
   });
 
-  it('hidden=false with no engagement writes nothing — an unblock must not create a block', async () => {
-    engagement.findUnique.mockResolvedValueOnce(null);
-
+  it('hidden=false with no engagement never creates one — an unblock must not block', async () => {
     await block(false);
 
-    expect(engagement.create).not.toHaveBeenCalled();
-    expect(engagement.update).not.toHaveBeenCalled();
-    expect(engagement.delete).not.toHaveBeenCalled();
+    expect(engagement.upsert).not.toHaveBeenCalled();
   });
 
   it('hidden=true over an existing Follow promotes the row to Block', async () => {
-    engagement.findUnique.mockResolvedValueOnce({ type: 'Follow' });
+    engagement.findUnique.mockResolvedValue({ type: 'Follow' });
 
     await block(true);
 
-    expect(engagement.update).toHaveBeenCalledWith({
-      where: { userId_targetUserId: { userId, targetUserId } },
-      data: { type: 'Block' },
+    expect(engagement.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ update: { type: 'Block' } })
+    );
+  });
+
+  it('hidden=false over an existing Follow leaves that Follow alone', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Follow' });
+
+    await block(false);
+
+    expect(engagement.upsert).not.toHaveBeenCalled();
+    // The `type` filter is what protects the row, so assert the filter itself —
+    // an unscoped deleteMany would pass a "was it called" check and still take
+    // the Follow with it.
+    expect(engagement.deleteMany).toHaveBeenCalledWith({
+      where: { userId, targetUserId, type: 'Block' },
     });
   });
 
   it('hidden omitted still flips, so callers that send no intent are unchanged', async () => {
-    engagement.findUnique.mockResolvedValueOnce({ type: 'Block' });
+    engagement.findUnique.mockResolvedValue({ type: 'Block' });
 
     await block(undefined);
 
-    expect(engagement.delete).toHaveBeenCalled();
+    expect(engagement.deleteMany).toHaveBeenCalled();
+    expect(engagement.upsert).not.toHaveBeenCalled();
+  });
+});
+
+// Without these the writes are correct and invisible: every read path serves the
+// stale cached list until the hash TTL expires.
+describe('toggleHidden kind=blockedUser — cache invalidation', () => {
+  it('refreshes both projections of the row plus the follows cache', async () => {
+    const blocked = vi.spyOn(BlockedUsers, 'refreshCache').mockResolvedValue(undefined);
+    const blockedBy = vi.spyOn(BlockedByUsers, 'refreshCache').mockResolvedValue(undefined);
+    const follows = vi.spyOn(userFollowsCache, 'refresh').mockResolvedValue(undefined);
+
+    await block(true);
+
+    // One row, two projections: the blocker's list is keyed on `userId`, the
+    // target's "blocked by" list on `targetUserId`.
+    expect(blocked).toHaveBeenCalledWith({ userId });
+    expect(blockedBy).toHaveBeenCalledWith({ userId: targetUserId });
+    expect(follows).toHaveBeenCalledWith(userId);
   });
 });
 
 describe('toggleHidden kind=blockedUser — placement cascade', () => {
-  it('runs when the block is newly established', async () => {
-    engagement.findUnique.mockResolvedValueOnce(null);
-
+  it('runs in both directions when the block is established', async () => {
     await block(true);
 
     expect(declinePlacementsOnBlock).toHaveBeenCalledWith({
@@ -112,11 +158,53 @@ describe('toggleHidden kind=blockedUser — placement cascade', () => {
     });
   });
 
+  it('runs again on a repeat block, so a large backlog can still be drained', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Block' });
+
+    await block(true);
+
+    // `declinePlacementsOnBlock` caps at 200 pending rows per run and swallows
+    // its own failures, so blocking again is the only user-reachable retry.
+    // Gating this on the transition would silently remove it.
+    expect(declinePlacementsOnBlock).toHaveBeenCalledTimes(2);
+  });
+
   it('does not run on an unblock', async () => {
-    engagement.findUnique.mockResolvedValueOnce({ type: 'Block' });
+    engagement.findUnique.mockResolvedValue({ type: 'Block' });
 
     await block(false);
 
     expect(declinePlacementsOnBlock).not.toHaveBeenCalled();
+  });
+});
+
+describe('toggleHidden kind=blockedUser — guards', () => {
+  it('refuses to block yourself', async () => {
+    await expect(
+      toggleHidden({ kind: 'blockedUser', data: [{ id: userId }], hidden: true, userId })
+    ).rejects.toThrow('Cannot block yourself');
+    expect(engagement.upsert).not.toHaveBeenCalled();
+  });
+
+  it('refuses to block the civitai account', async () => {
+    await expect(
+      toggleHidden({ kind: 'blockedUser', data: [{ id: -1 }], hidden: true, userId })
+    ).rejects.toThrow('Cannot block civitai account');
+    expect(engagement.upsert).not.toHaveBeenCalled();
+  });
+});
+
+// The last link in the chain. Drop or rename `hidden` on this schema member and
+// the intent never reaches the service, the original bug is back, and every test
+// above still passes because they build their input by hand.
+describe('toggleHiddenSchema', () => {
+  it('carries hidden through the blockedUser member', () => {
+    const parsed = toggleHiddenSchema.parse({
+      kind: 'blockedUser',
+      data: [{ id: targetUserId }],
+      hidden: false,
+    });
+
+    expect(parsed).toMatchObject({ kind: 'blockedUser', hidden: false });
   });
 });

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -526,7 +526,7 @@ export async function toggleHidden({
     case 'tag':
       return await toggleHiddenTags({ tagIds: data.map((x) => x.id), hidden, userId });
     case 'blockedUser':
-      return await toggleBlockUser({ targetUserId: data[0].id, userId });
+      return await toggleBlockUser({ targetUserId: data[0].id, userId, setTo: hidden });
     default:
       throw new Error('unsupported hidden toggle kind');
   }
@@ -824,8 +824,14 @@ async function toggleBlockUser({
     where: { userId_targetUserId: { userId, targetUserId } },
     select: { type: true },
   });
-  const unblocking = engagement?.type === 'Block' && setTo !== true;
-  if (!engagement)
+  const alreadyBlocked = engagement?.type === 'Block';
+  // `setTo` carries the caller's INTENT. Without it this fell back to a blind
+  // flip, so a client whose block list was stale sent "block" and got an
+  // unblock — with a success toast either way. Only fall back to flipping
+  // when no intent was supplied at all.
+  const blocking = setTo ?? !alreadyBlocked;
+
+  if (blocking && !engagement)
     await dbWrite.userEngagement
       .create({
         data: { userId, targetUserId, type: 'Block' },
@@ -836,21 +842,21 @@ async function toggleBlockUser({
       .catch((error) => {
         if (!isPrismaUniqueViolation(error)) throw error;
       });
-  else if (engagement.type === 'Block' && setTo !== true)
-    await dbWrite.userEngagement.delete({
-      where: { userId_targetUserId: { userId, targetUserId } },
-    });
-  else
+  else if (blocking && !alreadyBlocked)
     await dbWrite.userEngagement.update({
       where: { userId_targetUserId: { userId, targetUserId } },
       data: { type: 'Block' },
+    });
+  else if (!blocking && alreadyBlocked)
+    await dbWrite.userEngagement.delete({
+      where: { userId_targetUserId: { userId, targetUserId } },
     });
 
   await userFollowsCache.refresh(userId);
   await BlockedUsers.refreshCache({ userId });
   await BlockedByUsers.refreshCache({ userId: targetUserId });
 
-  if (!unblocking) await cascadeBlockToPlacements({ userId, targetUserId });
+  if (blocking && !alreadyBlocked) await cascadeBlockToPlacements({ userId, targetUserId });
 
   return {
     added: [],

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -824,39 +824,42 @@ async function toggleBlockUser({
     where: { userId_targetUserId: { userId, targetUserId } },
     select: { type: true },
   });
-  const alreadyBlocked = engagement?.type === 'Block';
   // `setTo` carries the caller's INTENT. Without it this fell back to a blind
   // flip, so a client whose block list was stale sent "block" and got an
-  // unblock — with a success toast either way. Only fall back to flipping
-  // when no intent was supplied at all.
+  // unblock — with a success toast either way. Only fall back to flipping when
+  // no intent was supplied at all.
+  const alreadyBlocked = engagement?.type === 'Block';
   const blocking = setTo ?? !alreadyBlocked;
 
-  if (blocking && !engagement)
-    await dbWrite.userEngagement
-      .create({
-        data: { userId, targetUserId, type: 'Block' },
-      })
-      // Toggle racing itself → P2002 on the (userId, targetUserId) PK. The row
-      // already exists — idempotent, so fall through to the cache refreshes
-      // (which read DB truth) instead of bubbling a 500.
-      .catch((error) => {
-        if (!isPrismaUniqueViolation(error)) throw error;
-      });
-  else if (blocking && !alreadyBlocked)
-    await dbWrite.userEngagement.update({
+  // Both statements are idempotent and unconditional, which is what makes them
+  // safe against a concurrent write to the same PK. Branching on the row we
+  // read a moment ago is not: a block that read `Block` and then lost the row
+  // to a concurrent unblock would fall through every branch, write nothing,
+  // and still report success — silently leaving a safety control off. `upsert`
+  // re-establishes it instead (and needs no P2002 catch, since the conflict is
+  // resolved in the statement). `deleteMany` cannot raise P2025 on an
+  // already-removed row, and its `type` filter makes "never delete a Follow or
+  // a Hide" structural rather than a branch condition.
+  if (blocking)
+    await dbWrite.userEngagement.upsert({
       where: { userId_targetUserId: { userId, targetUserId } },
-      data: { type: 'Block' },
+      create: { userId, targetUserId, type: 'Block' },
+      update: { type: 'Block' },
     });
-  else if (!blocking && alreadyBlocked)
-    await dbWrite.userEngagement.delete({
-      where: { userId_targetUserId: { userId, targetUserId } },
+  else
+    await dbWrite.userEngagement.deleteMany({
+      where: { userId, targetUserId, type: UserEngagementType.Block },
     });
 
   await userFollowsCache.refresh(userId);
   await BlockedUsers.refreshCache({ userId });
   await BlockedByUsers.refreshCache({ userId: targetUserId });
 
-  if (blocking && !alreadyBlocked) await cascadeBlockToPlacements({ userId, targetUserId });
+  // Every block cascades, not only a newly established one. `declinePlacementsOnBlock`
+  // touches only `pending` rows and caps at 200 per run, so a user with a larger
+  // backlog — or one whose first cascade hit a Buzz outage — drains the rest by
+  // blocking again. Gating on the transition would have removed that retry.
+  if (blocking) await cascadeBlockToPlacements({ userId, targetUserId });
 
   return {
     added: [],

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -830,6 +830,10 @@ async function toggleBlockUser({
   // no intent was supplied at all.
   const alreadyBlocked = engagement?.type === 'Block';
   const blocking = setTo ?? !alreadyBlocked;
+  // If you ever make the read above conditional, keep the `setTo === undefined`
+  // branch explicit. Dropping the read collapses this to `setTo ?? true`, which
+  // reads harmlessly and means an omitted intent can only ever BLOCK and never
+  // unblock. Nothing in the type system catches that.
 
   // Both statements are idempotent and unconditional, which is what makes them
   // safe against a concurrent write to the same PK. Branching on the row we
@@ -841,11 +845,24 @@ async function toggleBlockUser({
   // already-removed row, and its `type` filter makes "never delete a Follow or
   // a Hide" structural rather than a branch condition.
   if (blocking)
-    await dbWrite.userEngagement.upsert({
-      where: { userId_targetUserId: { userId, targetUserId } },
-      create: { userId, targetUserId, type: 'Block' },
-      update: { type: 'Block' },
-    });
+    await dbWrite.userEngagement
+      .upsert({
+        where: { userId_targetUserId: { userId, targetUserId } },
+        create: { userId, targetUserId, type: 'Block' },
+        update: { type: 'Block' },
+      })
+      // Belt-and-braces, and deliberately not load-bearing. This call meets every
+      // documented condition for Prisma to compile it to a native
+      // `INSERT … ON CONFLICT DO UPDATE` (single model, scalar-only create/update,
+      // one unique in `where`, `where` values equal to `create` values), under
+      // which P2002 cannot be raised and this catch is dead. That was inferred
+      // from the schema, NOT observed in a query log — so if the query ever falls
+      // back to read-then-write, the loser of a concurrent block would 500 on a
+      // safety control instead of succeeding idempotently. One line to not depend
+      // on an unverified premise.
+      .catch((error) => {
+        if (!isPrismaUniqueViolation(error)) throw error;
+      });
   else
     await dbWrite.userEngagement.deleteMany({
       where: { userId, targetUserId, type: UserEngagementType.Block },


### PR DESCRIPTION
Fixes [868kueneg](https://app.clickup.com/t/868kueneg).

## The bug

`toggleHidden` dropped the caller's `hidden` flag on the way to `toggleBlockUser`:

```ts
case 'user':
  return await toggleHideUser({ userId, targetUserId: data[0].id, setTo: hidden });
case 'blockedUser':
  return await toggleBlockUser({ targetUserId: data[0].id, userId });   // no setTo
```

The sibling passes `setTo`. This branch never has — introduced 2024-06-20 in `4fa40241b8`. With no intent to act on, the service could only **flip whatever row it found**, which inverts the action whenever the client's block list disagrees with the database (a block made in another tab, on another device, or in a session whose cached preferences predate it):

- button renders "Block" over an existing Block row → sends `hidden: true` → the row is **deleted**. The user sees "User blocked" and has just **unblocked** the person.
- `hidden: false` with no row → a Block row is **created**. An unblock creates a block.
- `hidden: false` over a row you `Follow` → the final `else` promoted it to **Block**. An unblock that blocks someone you follow.

All three show a success toast, so nobody has a reason to check. This is a safety control.

## It is live, and it was never a no-op

The ticket filed this as "200, empty diff, no row written". That reading was wrong in both halves:

- `BlockUserButton` reaches this branch and is mounted on ~10 surfaces — model cards, comments, image context menu, resource-select modal, model3d actions menu, profile layout, user context menu, user list pages.
- Prod `UserEngagement` holds **533,345** `type='Block'` rows and writes **~3–4k/day** (4,152 on 2026-08-20, read from the replica).

The original observation is explained by the flip: two calls through the branch net to zero rows — create, then delete. **The empty diff is a red herring**, not a bug — `toggleBlockUser` has always returned `{ added: [], removed: [] }`, as do the image and user toggles beside it, and the client relies on the optimistic update in `useToggleHiddenPreferences` instead.

## The fix

`setTo: hidden` at the call site, and the write reduced to two unconditional, idempotent statements:

```ts
const alreadyBlocked = engagement?.type === 'Block';
const blocking = setTo ?? !alreadyBlocked;

if (blocking)
  await dbWrite.userEngagement.upsert({ where, create: {...type: 'Block'}, update: { type: 'Block' } });
else
  await dbWrite.userEngagement.deleteMany({ where: { userId, targetUserId, type: 'Block' } });
```

Falling back to flipping only when no intent was supplied keeps every existing caller's behaviour unchanged.

### A review lane caught a regression in the first repair. The test suite did not.

My first version of this fix branched on the row it had just read — "write only on a real transition", which was **my framing, and it was wrong**. Under concurrency it was worse than `main`:

```
t0  request B (block)   reads engagement → Block.  alreadyBlocked = true, blocking = true.
t1  request U (unblock) reads → Block, deletes the row.
t2  request B falls through every branch and writes nothing.
```

End state: **not blocked**, `B` returned success, the client's optimistic cache says blocked, and the placement cascade never ran. Order doesn't save it — `B` writes nothing whenever it loses the row. `main` hit an unconditional `else → update`, which either re-established the block or threw P2025 loudly. So `main` was wrong-or-loud and my repair was **silently wrong on a safety control** — the exact failure this PR exists to remove, reintroduced by the fix for it.

The 8 tests I had written at that point were all green. The `civitai-review` correctness lane found it by construction, not by running anything.

Two unconditional idempotent statements remove the whole class: `upsert` resolves the conflict inside the statement, and `deleteMany` cannot raise P2025 on an already-removed row. (The P2002 catch was deleted on that reasoning and then **put back** — see below; the reasoning holds only if Prisma compiles the upsert natively, which I inferred rather than measured.) Its `type: 'Block'` filter also makes "never delete a Follow or a Hide" **structural** rather than a branch condition that a later edit can get wrong.

### The cascade runs on every block, not only a new one

Deliberate, and reversed from my first version after two lanes disagreed about it. `declinePlacementsOnBlock` caps at **200 pending rows per direction** and swallows its own failures into an Axiom log, so blocking again is the only user-reachable retry for a larger backlog or a cascade that hit a Buzz outage. Gating it on the transition would have removed that silently.

The reason that settles it is a money difference: the remainder past the 200 cap falls to `expirePlacementsJob`, which returns both holds **in full**, whereas the block cascade declines **with a fee** (waived only on the owner-side leg). Same pair, different money rules — in what is by definition a harassment case. A test pins the retry.

## Why the tests assert through `toggleHidden`

All of them go through `toggleHidden`, the exported entry the router calls — **not** `toggleBlockUser`. That is deliberate and load-bearing: the bug was an argument the caller failed to pass, and a test that calls the inner function supplies `setTo` itself and passes against the broken code. Please keep them at this level.

**Tests went 8 → 18, and reverting the one-line call-site fix now turns 4 red instead of 2.** The second number is the point — it is a statement about the failure mode, not about coverage:

```
× hidden=true on an ALREADY blocked user leaves the block standing
  AssertionError: expected "dbWrite.userEngagement.deleteMany" to not be called at all, but actually been called 1 times
× hidden=false with no engagement never creates one — an unblock must not block
  AssertionError: expected "dbWrite.userEngagement.upsert" to not be called at all, but actually been called 1 times
× hidden=false over an existing Follow leaves that Follow alone
  AssertionError: expected "dbWrite.userEngagement.upsert" to not be called at all, but actually been called 1 times
× runs again on a repeat block, so a large backlog can still be drained
  AssertionError: expected "vi.fn()" to be called 2 times, but got 0 times
```

**One hole was found by mutation, not by review.** With the cascade guard weakened from `blocking && !alreadyBlocked` to plain `blocking`, all 8 of the original tests stayed **green** — a repeat press would have re-declined placements and re-refunded escrow with nothing going red. The suite now covers it. Recorded here rather than only fixed, because "these tests pass" is a claim about now and "I removed half the guard and nothing went red" is a claim about the failure mode.

The suite also now pins the three cache invalidations, the two guards, and — via one `toggleHiddenSchema.parse()` assertion — that `hidden` survives on the schema at all. Drop or rename it there and the original bug returns with every other test still green.

### A second review round found four mutations the 14 still survived

Every one was confirmed by breaking the code on purpose, not by reasoning about it:

| mutation | 14 tests | 18 tests |
|---|---|---|
| `setTo ?? !alreadyBlocked` → `setTo === true` | green | **red** |
| cache refreshes gated on `if (blocking)` | green | **red** |
| cascade moved above the write | green | **red** |
| cascade `try/catch` deleted | green | **red** |

The first is the one worth knowing about: the intent flag this PR exists to deliver could be replaced by a constant — making the `findUnique` read and `alreadyBlocked` dead code — and nothing went red, because every omitted-intent test started from a `Block` row, where both forms happen to agree.

The added tests cover the omitted-intent fallback in the blocking direction, cache invalidation on **unblock** (a lifted block invisible until the hash TTL is the same staleness that caused this bug), the cascade-after-commit ordering the docblock calls a precondition, and the cascade swallowing one failed leg while still attempting the second.

Two suite defects fixed alongside them. The `vi.spyOn` calls were never restored and there is no `restoreMocks` in `vitest.config.mts`, so every test declared after the cache block ran with the refresh functions silently stubbed. And `toHaveBeenCalledTimes(2)` in the repeat-block cascade test is the two *directions* of one cascade, not a retry count — a first-time block produces 2 as well — so it was renamed to what it actually pins.

### On the P2002 catch

It is back on the `upsert`, and deliberately not load-bearing. The call meets every documented condition for Prisma (6.13.0) to compile it to a native `INSERT … ON CONFLICT DO UPDATE` — single model, scalar-only `create`/`update`, one unique in `where` (the compound `@@id`), `where` values equal to `create` values — under which P2002 cannot be raised and the catch is dead code. **That was inferred from the schema, not observed in a query log.** If the query ever falls back to read-then-write, the loser of a concurrent block would 500 on a safety control. One line beats depending on an inference.

Note also that `UserEngagement` has no `updatedAt` and no triggers, and the `update` path leaves `createdAt` alone — so a repeat block now preserves the original block timestamp, where the old `create` would have reset it.

## Prod data worth a look — no repair run

Under the old code the `hidden: false` + no-row path created a Block **and** ran `cascadeBlockToPlacements`, declining pending placements and refunding escrow in both directions. So an unblock click could produce a block plus placement declines. The spurious-delete direction skipped the cascade, so no placement was declined off one.

No repair has been run and none is proposed here — flagging it so it can be decided separately.

## Deliberately not done

- **`userFollowsCache.refresh` is still unconditional.** It is the only one of the three refreshes that queries the primary (`dbWrite.userEngagement.findMany({ type: 'Follow' })` via `cached-array.ts`), and it can only matter on the promotion branch, so gating it would take a primary read off essentially every block toggle. Narrowing a cache invalidation in the same change that repairs a safety control is not a trade worth making unasked — worth its own PR.
- **`UserEngagement (targetUserId, type)` has no index.** `BlockedByUsers` queries `WHERE ue."targetUserId" = $1 AND type = 'Block'`; the PK is `(userId, targetUserId)` and the secondary index is `(type, userId)`, so nothing can serve that predicate and it filters over all 533k Block rows. Read off the schema, not EXPLAINed. Separate PR.
- **`hidden` stays optional on the schema.** Making it required on the `blockedUser` member would close the blind-flip fallback entirely, but it is a wire-contract change and the `?? !alreadyBlocked` fallback preserves old behaviour for any caller that omits it.
- **`HiddenUsers` is not refreshed on a Follow/Hide → Block promotion**, so such a user stays listed as hidden until the hash TTL. Pre-existing, unchanged.
- **Sibling writers can still destroy a Block.** `UserEngagement` is one row per pair with a three-valued `type`, and four other writers hit that PK with an unqualified `delete`/`update` (`user.service.ts:908`/`:914`/`:972`/`:976`, `user-preferences.service.ts:731`/`:735`). Interleave one with a block and the follow toggle's `update { type: 'Follow' }` overwrites a committed Block — success returned, cascade run, block silently off. The structural fix is what this diff did for its own delete: scope those calls by `type`. It cannot be fixed from inside `toggleBlockUser`, and it is a distinct defect from the two tickets below.
- **A `Follow` destroyed by a block/unblock cycle does not come back.** `UserEngagement` is one row carrying one type; confirmed identical on `main`. Data-model limitation, not a diff defect.
- **`toggleHidden` still drops `hidden` for `image`, `model` and `model3d`**, whose services take no `setTo` at all. Same defect class, different writes — naming it so it doesn't read as deliberate.
- **This is the fourth hand-copy of a decision table** that already exists generically as `toggleModelEngagement` (`user.service.ts:843`). Extraction to a shared `toggleUserEngagement` was considered and deferred to keep this PR to the safety fix; recording it so the next person doesn't re-derive it a fifth time.

## Related, filed separately — both are safety findings

There are **two** live functions named `toggleHideUser`, in different files, with opposite failure modes:

- `user.service.ts:958` (via `toggleHideUserHandler`) — over a `Block` row it returns `false` and **writes nothing**. → **868kumcfc**
- `user-preferences.service.ts:706` (what `toggleHidden({kind:'user'})` actually reaches) — its final `else` updates the row to `'Hide'` **unconditionally**, so hiding someone you have blocked **overwrites the Block with a Hide**. A hide silently destroys a block, on the same PK this PR guards. → **868kun67j**

They have to be fixed together: two same-named functions on two call paths is exactly the shape where fixing one reads as having fixed both.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` on both changed files — clean
- `pnpm run test:unit:run` — full suite, with `blocks.router.workflow.test.ts` confirmed collecting 350 tests (a worktree missing its submodule collects **0** there and still exits clean)
- Revert-check and mutation-check, both above
- Reviewed by all five `civitai-review` lanes; every lane accounted for by name and none went silent
