### PR TITLE
fix(stickers): hover card opened on a pass, and the flip glyph named the wrong axis

### DIFF
--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -7,6 +7,7 @@ import type * as Trpc from '~/utils/trpc';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 import { resolveTreatment } from '~/components/Sticker/treatments/sticker-treatments';
+import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import type { StickerDraft } from '~/store/sticker-placement-draft.store';
 
 /**
@@ -332,5 +333,37 @@ describe('the free option carries the mode', () => {
     await renderDraft(null, { ownerShare: 1 });
 
     await expect.element(page.getByText(/proceeds go to/)).toBeInTheDocument();
+  });
+});
+
+/**
+ * The glyph on the flip control has to name the axis the transform mirrors
+ * across, and Tabler's names run the other way: `IconFlipHorizontal` draws a
+ * HORIZONTAL mirror line, which reads as a top-to-bottom flip. Picking the icon
+ * by its name is how this control ended up showing the wrong one twice.
+ *
+ * So this asserts the geometry rather than the icon's name or its path data: the
+ * mirror line is the one sub-path of the glyph that is a straight line, and a
+ * vertical line has zero width. That survives a Tabler version bump redrawing
+ * the arrows, and still fails if someone swaps the pair back.
+ */
+describe('the flip control draws the axis it mirrors across', () => {
+  test('mirror line is vertical, matching the artwork transform', async () => {
+    // The claim the glyph has to agree with. `scaleX(-1)` mirrors left-to-right,
+    // i.e. across a VERTICAL axis — read it here rather than restating it, so
+    // changing the transform to `scaleY` fails this test instead of silently
+    // making the icon wrong again.
+    expect(stickerArtworkStyle({ flip: true, opacity: 1 }).transform).toBe('scaleX(-1)');
+
+    await renderDraft(null);
+
+    const button = (await page
+      .getByRole('button', { name: 'Flip this sticker' })
+      .element()) as HTMLElement;
+    const boxes = Array.from(button.querySelectorAll('path')).map((path) => path.getBBox());
+
+    expect(boxes.length).toBeGreaterThan(0);
+    expect(boxes.some((box) => box.width === 0 && box.height > 0)).toBe(true);
+    expect(boxes.some((box) => box.height === 0 && box.width > 0)).toBe(false);
   });
 });

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -12,7 +12,7 @@ import {
 import {
   IconAlertTriangleFilled,
   IconDropletHalf2,
-  IconFlipHorizontal,
+  IconFlipVertical,
   IconMessage,
   IconTrash,
 } from '@tabler/icons-react';
@@ -535,7 +535,11 @@ export function DraftSticker({
         aria-label={draft.flip ? 'Unflip this sticker' : 'Flip this sticker'}
         onClick={() => move(draft.id, { flip: !draft.flip })}
       >
-        <IconFlipHorizontal size={14} />
+        {/* Tabler names these for the MIRROR AXIS, not the motion: this control
+            mirrors left-to-right (`scaleX(-1)`, see `placement-appearance`), and
+            the glyph that draws a vertical mirror line is `IconFlipVertical`.
+            The same crossed pairing is in the drawing editor's flip controls. */}
+        <IconFlipVertical size={14} />
       </ActionIcon>
     </Tooltip>
   );

--- a/src/components/Sticker/StickerPlacementHoverCard.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.browser.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import type * as Trpc from '~/utils/trpc';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { HOVER_DELAY_MS } from '~/components/UserAvatar/UserHoverCard';
+
+/**
+ * The card must not open on a pointer that is only passing over the sticker.
+ *
+ * A feed is swiped through, and a placed sticker is a small target inside it, so
+ * the pointer crosses several stickers on the way to something else. What is
+ * asserted is the WAIT — how long the card takes to appear — rather than that it
+ * is absent at some instant, because an absence assertion passes for free the
+ * day the locator stops matching.
+ */
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 7 }) }));
+
+// Held in its loading state deliberately: `data` mounts the creator card, which
+// wants profile cosmetics, live metrics and edge media. The dropdown's own
+// header renders either way, which is all this file needs to see.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof Trpc>();
+  return {
+    ...actual,
+    trpc: {
+      ...actual.trpc,
+      placement: {
+        ...actual.trpc.placement,
+        getStickerPlacementDetail: {
+          useQuery: () => ({ data: undefined, isLoading: true, error: null }),
+        },
+      },
+    },
+  };
+});
+
+const { StickerPlacementHoverCard } = await import(
+  '~/components/Sticker/StickerPlacementHoverCard'
+);
+
+const renderCard = async () => {
+  renderWithProviders(
+    <StickerPlacementHoverCard placementId={11} imageId={74}>
+      <button type="button">sticker</button>
+    </StickerPlacementHoverCard>
+  );
+
+  await expect.element(page.getByRole('button', { name: 'sticker' })).toBeInTheDocument();
+};
+
+describe('the placed-sticker hover card waits before it opens', () => {
+  /**
+   * The measurement only ever runs long — a slow box delays the open, it cannot
+   * make it early — so this fails on a shortened delay and never on load. The
+   * floor is under `HOVER_DELAY_MS` for that reason: it is asserting that a real
+   * delay is in force, not stopwatching the exact constant.
+   */
+  test('takes the shared hover delay to appear', async () => {
+    await renderCard();
+
+    const start = performance.now();
+    await page.getByRole('button', { name: 'sticker' }).hover();
+    await expect.element(page.getByText('Placed')).toBeInTheDocument();
+    const elapsed = performance.now() - start;
+
+    expect(HOVER_DELAY_MS).toBeGreaterThanOrEqual(500);
+    expect(elapsed).toBeGreaterThanOrEqual(HOVER_DELAY_MS * 0.8);
+  });
+});

--- a/src/components/Sticker/StickerPlacementHoverCard.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.browser.test.tsx
@@ -3,7 +3,7 @@ import { page } from 'vitest/browser';
 import type * as Trpc from '~/utils/trpc';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
-import { HOVER_DELAY_MS } from '~/components/UserAvatar/UserHoverCard';
+import { HOVER_DELAY_MS } from '~/components/UserAvatar/hover-card.constants';
 
 /**
  * The card must not open on a pointer that is only passing over the sticker.
@@ -16,33 +16,67 @@ import { HOVER_DELAY_MS } from '~/components/UserAvatar/UserHoverCard';
  */
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 7 }) }));
 
-// Held in its loading state deliberately: `data` mounts the creator card, which
-// wants profile cosmetics, live metrics and edge media. The dropdown's own
-// header renders either way, which is all this file needs to see.
-vi.mock('~/utils/trpc', async (importOriginal) => {
-  const actual = await importOriginal<typeof Trpc>();
-  return {
-    ...actual,
-    trpc: {
-      ...actual.trpc,
-      placement: {
-        ...actual.trpc.placement,
-        getStickerPlacementDetail: {
-          useQuery: () => ({ data: undefined, isLoading: true, error: null }),
-        },
+/**
+ * The module spread is load-bearing; the one that used to sit inside it was not.
+ *
+ * `...(await importOriginal())` carries `~/utils/trpc`'s OTHER exports —
+ * `setTrpcBatchingEnabled` among them, which another module in this graph
+ * imports. Dropping it is how a wholesale trpc mock takes a whole file down to
+ * zero collected tests with nothing turning red, which is what
+ * `local-rules/no-wholesale-module-mock` exists to stop.
+ *
+ * What was decoration is the inner `...actual.trpc`: `trpc` is a `createFlatProxy`
+ * over a `noop` function with no `ownKeys` trap, so spreading it enumerates
+ * nothing and yields `{}`. Removed rather than left in place looking protective.
+ *
+ * So what is below `trpc:` is a hand-listed stub of exactly the path under test,
+ * held in its loading state deliberately — `data` mounts the creator card, which
+ * wants profile cosmetics, live metrics and edge media, and the dropdown's own
+ * header renders either way.
+ *
+ * ⚠️ Supplying `data` from here needs more than this: the card then renders
+ * `ReportPlacement`, whose `HideNote` calls `trpc.useUtils()` and
+ * `trpc.placement.setStickerCommentHidden.useMutation`. Add them explicitly.
+ */
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof Trpc>()),
+  trpc: {
+    placement: {
+      getStickerPlacementDetail: {
+        useQuery: () => ({ data: undefined, isLoading: true, error: null }),
       },
     },
-  };
-});
+  },
+}));
 
 const { StickerPlacementHoverCard } = await import(
   '~/components/Sticker/StickerPlacementHoverCard'
 );
 
+/**
+ * Stamped by the target's own `mouseenter`, which is the event Mantine starts
+ * the delay from.
+ *
+ * Timing from before `hover()` would credit Playwright's actionability checks,
+ * scroll-into-view and CDP round-trips to the delay — several WS hops, which on
+ * a loaded box can cover the floor by themselves and let a regression through.
+ * Timing from after `hover()` returns has the opposite fault: the delay is
+ * already running by then, so the measurement comes back short and the test
+ * flakes red. The event is the only honest zero.
+ */
+let enteredAt = 0;
+
 const renderCard = async () => {
   renderWithProviders(
     <StickerPlacementHoverCard placementId={11} imageId={74}>
-      <button type="button">sticker</button>
+      <button
+        type="button"
+        onMouseEnter={() => {
+          enteredAt = performance.now();
+        }}
+      >
+        sticker
+      </button>
     </StickerPlacementHoverCard>
   );
 
@@ -52,19 +86,25 @@ const renderCard = async () => {
 describe('the placed-sticker hover card waits before it opens', () => {
   /**
    * The measurement only ever runs long — a slow box delays the open, it cannot
-   * make it early — so this fails on a shortened delay and never on load. The
-   * floor is under `HOVER_DELAY_MS` for that reason: it is asserting that a real
-   * delay is in force, not stopwatching the exact constant.
+   * make it early — so this fails on a shortened delay and never on load.
    */
   test('takes the shared hover delay to appear', async () => {
     await renderCard();
 
-    const start = performance.now();
     await page.getByRole('button', { name: 'sticker' }).hover();
-    await expect.element(page.getByText('Placed')).toBeInTheDocument();
-    const elapsed = performance.now() - start;
 
+    // 🔴 The explicit timeout is load-bearing. `expect.element` polls on a
+    // 1000ms default that nothing in this repo raises — `component-setup` lifts
+    // `vi.waitFor`, not this — and half of that budget is spent by design before
+    // the dropdown can exist at all. On the saturated CI box the same file
+    // describes, the remainder is not enough.
+    await expect.element(page.getByText('Placed'), { timeout: 5000 }).toBeInTheDocument();
+    const elapsed = performance.now() - enteredAt;
+
+    expect(enteredAt).toBeGreaterThan(0);
     expect(HOVER_DELAY_MS).toBeGreaterThanOrEqual(500);
-    expect(elapsed).toBeGreaterThanOrEqual(HOVER_DELAY_MS * 0.8);
+    // Tight enough to catch a regression to the 300ms this replaced, which a
+    // floor drawn below that would let through.
+    expect(elapsed).toBeGreaterThanOrEqual(HOVER_DELAY_MS * 0.9);
   });
 });

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -5,7 +5,7 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { openReportModal } from '~/components/Dialog/triggers/report';
 import { ReportEntity } from '~/shared/utils/report-helpers';
-import { HOVER_DELAY_MS } from '~/components/UserAvatar/UserHoverCard';
+import { HOVER_DELAY_MS } from '~/components/UserAvatar/hover-card.constants';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -116,10 +116,11 @@ export function StickerPlacementHoverCard({
       shadow="sm"
       withArrow
       withinPortal
-      // The same delays every other hover card in the app uses. A placed sticker
-      // is a small target inside a feed people swipe through, so the pointer
-      // crosses several without stopping on any of them; 300ms was short enough
-      // that a pass over the artwork opened the card.
+      // The delay the creator card and the sticker attribution card already use,
+      // which is what a card that opens on a whole-object hover is tuned for. A
+      // placed sticker is a small target inside a feed people swipe through, so
+      // the pointer crosses several without stopping on any of them; 300ms was
+      // short enough that a pass over the artwork opened the card.
       openDelay={HOVER_DELAY_MS}
       position="bottom"
       // Closer than the default, so the card reads as belonging to the sticker

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -5,6 +5,7 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { openReportModal } from '~/components/Dialog/triggers/report';
 import { ReportEntity } from '~/shared/utils/report-helpers';
+import { HOVER_DELAY_MS } from '~/components/UserAvatar/UserHoverCard';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -115,7 +116,11 @@ export function StickerPlacementHoverCard({
       shadow="sm"
       withArrow
       withinPortal
-      openDelay={300}
+      // The same delays every other hover card in the app uses. A placed sticker
+      // is a small target inside a feed people swipe through, so the pointer
+      // crosses several without stopping on any of them; 300ms was short enough
+      // that a pass over the artwork opened the card.
+      openDelay={HOVER_DELAY_MS}
       position="bottom"
       // Closer than the default, so the card reads as belonging to the sticker
       // rather than floating near it.

--- a/src/components/Sticker/StickerShopPanel.tsx
+++ b/src/components/Sticker/StickerShopPanel.tsx
@@ -22,6 +22,7 @@ import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
 import { RenderHtml } from '~/components/RenderHtml/RenderHtml';
 import { browseShopItems } from '~/components/Shop/shop-browse';
 import { STICKER_HOVER_CARD_WIDTH } from '~/components/Sticker/StickerPlacementHoverCard';
+import { HOVER_DELAY_MS } from '~/components/UserAvatar/hover-card.constants';
 import { StickerPriceBadge } from '~/components/Sticker/StickerPriceBadge';
 import { useStickerDragOut } from '~/components/Sticker/use-sticker-drag-out';
 import { stickerPurchaseTerms } from '~/components/Sticker/sticker.util';
@@ -244,7 +245,12 @@ export function StickerShopPanel({
                 // scroll area inside it clip the card to the shelf — which on
                 // the top row cut off everything but the title.
                 withinPortal
-                openDelay={200}
+                // The shelf is scanned across, not aimed at: the tiles are 48px
+                // squares in a horizontal scroller, so a pointer on its way to
+                // the one you want crosses several. 200ms opened a card on each
+                // of them. The app's shared delay, same as every other hover
+                // card here.
+                openDelay={HOVER_DELAY_MS}
                 position="top"
                 offset={4}
                 shadow="sm"

--- a/src/components/Sticker/__tests__/hover-delay-is-shared.test.ts
+++ b/src/components/Sticker/__tests__/hover-delay-is-shared.test.ts
@@ -1,65 +1,136 @@
 import { describe, expect, test } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join, relative, resolve, sep } from 'node:path';
 import { stripComments } from '../../../../test/strip-comments';
 
 /**
- * Every sticker hover card opens on the SAME delay, and that delay is a constant.
+ * Every sticker hover card opens on the SAME delay, and takes it from the shared
+ * constant rather than writing a number.
  *
  * Three of these were tuned separately — the placed sticker at 300ms, the shop
- * shelf at 200ms, the chat attribution card on `HOVER_DELAY_MS` — and the two
- * literals were both reported as opening too fast. The shop one was reported
- * after the placed one had already been "fixed", because a number written at a
- * call site is invisible to anyone changing the other call site.
+ * shelf at 200ms, the chat attribution card on `HOVER_DELAY_MS` — and both
+ * literals were reported as opening too fast. The shop one was reported AFTER
+ * the placed one had been "fixed", because a number at one call site is
+ * invisible to whoever is changing the other.
  *
  * 🔴 WHAT THIS CATCHES THAT THE BROWSER TESTS DO NOT. `StickerPlacementHoverCard`
- * has a test that measures its open delay, and it stays green while a NEW card
- * ships next to it on a hand-written 150. This is the only check that sees a
- * surface nobody wrote a test for, which is exactly how the shop shelf got its
- * own number.
+ * has a test that measures its own open delay, and it stays green while a new
+ * card ships beside it on a hand-written 150. This is the check that sees a
+ * surface nobody wrote a test for.
  *
- * It reads source text rather than rendering, so it costs nothing and covers
- * files that have no test harness at all. Comments are stripped first: this file
- * discusses `openDelay={200}` at length, and so do the components.
+ * 🔴 TWO SPELLINGS, NOT ONE. A card here either passes `openDelay` to Mantine or
+ * hand-rolls a `setTimeout` — the attribution card does the latter, because a
+ * chat sticker is built inside `dangerouslySetInnerHTML` and has no React node
+ * to wrap. An earlier version of this file scanned only the prop, named the
+ * attribution card in its own docstring, and would have stayed green with that
+ * timer edited to 150. Both spellings are checked now.
+ *
+ * 🔴 AND IT CHECKS THE IMPORT, NOT THE TOKEN. Matching the name `HOVER_DELAY_MS`
+ * alone passes for a file that declares its own `const HOVER_DELAY_MS = 200`,
+ * which is exactly what copying the pattern without noticing the constants
+ * module produces.
+ *
+ * ⚠️ WHAT IT DOES NOT COVER, stated because a silent gap is worse than a narrow
+ * scope: a hover card for stickers living OUTSIDE `src/components/Sticker`
+ * (`Sticker.tsx` renders through `RenderHtml`, whose card is the attribution one
+ * covered here, but a future card mounted from elsewhere would be invisible);
+ * and a delay arriving through a spread props object or a Mantine theme
+ * `defaultProps`, neither of which is a static call site this can read.
  */
 const STICKER_DIR = resolve(__dirname, '..');
+/**
+ * Both paths to the one constant. `UserHoverCard` re-exports it, and the
+ * attribution card reads it from there because it takes four other names from
+ * that module in the same import — identity holds through a re-export, so
+ * forcing a second import line would be noise, not safety.
+ */
+const SHARED_SOURCES = [
+  '~/components/UserAvatar/hover-card.constants',
+  '~/components/UserAvatar/UserHoverCard',
+];
+const SHARED = 'HOVER_DELAY_MS';
 
-const componentFiles = () =>
-  readdirSync(STICKER_DIR)
-    .filter((name) => name.endsWith('.tsx') && !name.includes('.test.'))
-    .map((name) => ({
-      name,
-      source: stripComments(readFileSync(join(STICKER_DIR, name), 'utf-8')),
-    }));
+/** Every component file under the sticker directory, subdirectories included. */
+const componentFiles = (dir = STICKER_DIR): { name: string; source: string }[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    // `__tests__` holds this file, which discusses every pattern it forbids.
+    if (entry.isDirectory()) return entry.name === '__tests__' ? [] : componentFiles(full);
+    if (!entry.name.endsWith('.tsx') && !entry.name.endsWith('.ts')) return [];
+    if (entry.name.includes('.test.')) return [];
+    return [
+      {
+        name: relative(STICKER_DIR, full).split(sep).join('/'),
+        source: stripComments(readFileSync(full, 'utf-8')),
+      },
+    ];
+  });
 
-/** `openDelay={…}` and whatever is inside the braces, per file. */
-const OPEN_DELAY = /openDelay=\{([^}]*)\}/g;
+/**
+ * `openDelay={…}`, but only on a hover card.
+ *
+ * Scoped by the element it sits on rather than by the prop name alone: `Tooltip`
+ * takes an `openDelay` too, and a tooltip is aimed at, not swept across. Left
+ * unscoped, the first `<Tooltip openDelay={300}>` anyone adds in this directory
+ * turns this red and pressures a tooltip onto a hover-card constant.
+ */
+const HOVER_CARD_OPEN_DELAY = /<HoverCard\b[^>]*?\bopenDelay=\{([^}]*)\}/gs;
+
+/** A hand-rolled open timer: `setTimeout(…, <delay>)` closing an open handler. */
+const HAND_ROLLED_DELAY = /openTimer\.current = setTimeout\([\s\S]*?,\s*([A-Za-z0-9_]+)\s*\)/
+  .source;
+
+/**
+ * Every open delay a file states, in both spellings. Fresh regexes per call —
+ * a `g` regex carries `lastIndex` between uses, and a shared one silently skips
+ * matches on the second file it is pointed at.
+ */
+const delaysIn = (source: string) =>
+  [
+    ...Array.from(source.matchAll(new RegExp(HOVER_CARD_OPEN_DELAY, 'gs')), (m) => m[1]),
+    ...Array.from(source.matchAll(new RegExp(HAND_ROLLED_DELAY, 'g')), (m) => m[1]),
+  ].map((value) => value.trim());
+
+const offenders = () => {
+  const found: string[] = [];
+
+  for (const { name, source } of componentFiles()) {
+    const delays = delaysIn(source);
+    if (!delays.length) continue;
+
+    for (const value of delays)
+      if (value !== SHARED) found.push(`${name}: opens on ${value}, not ${SHARED}`);
+
+    // Identity, not spelling. A local `const HOVER_DELAY_MS = 200` reads
+    // identically at the call site and opens on 200.
+    if (delays.includes(SHARED) && !SHARED_SOURCES.some((path) => source.includes(path)))
+      found.push(`${name}: uses ${SHARED} without importing it from ${SHARED_SOURCES[0]}`);
+  }
+
+  return found;
+};
 
 describe('sticker hover cards share one open delay', () => {
-  test('no call site writes its own number', () => {
-    const literals: string[] = [];
-
-    for (const { name, source } of componentFiles())
-      for (const [, value] of source.matchAll(OPEN_DELAY))
-        if (value.trim() !== 'HOVER_DELAY_MS')
-          literals.push(`${name}: openDelay={${value.trim()}}`);
-
-    expect(literals).toEqual([]);
+  test('no card writes its own number, or its own copy of the constant', () => {
+    expect(offenders()).toEqual([]);
   });
 
   /**
-   * The positive control, and it is not decoration: the assertion above passes
-   * for free against zero matches, so a rename of the prop — or a move of these
-   * components to another directory — would leave it green forever while every
-   * card drifted apart again.
+   * The positive control, and it is load-bearing twice over: the assertion above
+   * passes for free against zero matches, so a prop rename or a directory move
+   * would leave it green forever — and naming the three files means a card that
+   * stops being scanned is a failure rather than a silent gap.
    */
-  test('the scan actually found the call sites it is guarding', () => {
-    const found = componentFiles().flatMap(({ name, source }) =>
-      Array.from(source.matchAll(OPEN_DELAY), () => name)
-    );
+  test('the scan still finds all three cards it is guarding', () => {
+    const scanned = componentFiles()
+      .filter(({ source }) => delaysIn(source).length > 0)
+      .map(({ name }) => name)
+      .sort();
 
-    expect(found.length).toBeGreaterThanOrEqual(2);
-    expect(found).toContain('StickerPlacementHoverCard.tsx');
-    expect(found).toContain('StickerShopPanel.tsx');
+    expect(scanned).toEqual([
+      'StickerAttributionHoverCard.tsx',
+      'StickerPlacementHoverCard.tsx',
+      'StickerShopPanel.tsx',
+    ]);
   });
 });

--- a/src/components/Sticker/__tests__/hover-delay-is-shared.test.ts
+++ b/src/components/Sticker/__tests__/hover-delay-is-shared.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { stripComments } from '../../../../test/strip-comments';
+
+/**
+ * Every sticker hover card opens on the SAME delay, and that delay is a constant.
+ *
+ * Three of these were tuned separately — the placed sticker at 300ms, the shop
+ * shelf at 200ms, the chat attribution card on `HOVER_DELAY_MS` — and the two
+ * literals were both reported as opening too fast. The shop one was reported
+ * after the placed one had already been "fixed", because a number written at a
+ * call site is invisible to anyone changing the other call site.
+ *
+ * 🔴 WHAT THIS CATCHES THAT THE BROWSER TESTS DO NOT. `StickerPlacementHoverCard`
+ * has a test that measures its open delay, and it stays green while a NEW card
+ * ships next to it on a hand-written 150. This is the only check that sees a
+ * surface nobody wrote a test for, which is exactly how the shop shelf got its
+ * own number.
+ *
+ * It reads source text rather than rendering, so it costs nothing and covers
+ * files that have no test harness at all. Comments are stripped first: this file
+ * discusses `openDelay={200}` at length, and so do the components.
+ */
+const STICKER_DIR = resolve(__dirname, '..');
+
+const componentFiles = () =>
+  readdirSync(STICKER_DIR)
+    .filter((name) => name.endsWith('.tsx') && !name.includes('.test.'))
+    .map((name) => ({
+      name,
+      source: stripComments(readFileSync(join(STICKER_DIR, name), 'utf-8')),
+    }));
+
+/** `openDelay={…}` and whatever is inside the braces, per file. */
+const OPEN_DELAY = /openDelay=\{([^}]*)\}/g;
+
+describe('sticker hover cards share one open delay', () => {
+  test('no call site writes its own number', () => {
+    const literals: string[] = [];
+
+    for (const { name, source } of componentFiles())
+      for (const [, value] of source.matchAll(OPEN_DELAY))
+        if (value.trim() !== 'HOVER_DELAY_MS')
+          literals.push(`${name}: openDelay={${value.trim()}}`);
+
+    expect(literals).toEqual([]);
+  });
+
+  /**
+   * The positive control, and it is not decoration: the assertion above passes
+   * for free against zero matches, so a rename of the prop — or a move of these
+   * components to another directory — would leave it green forever while every
+   * card drifted apart again.
+   */
+  test('the scan actually found the call sites it is guarding', () => {
+    const found = componentFiles().flatMap(({ name, source }) =>
+      Array.from(source.matchAll(OPEN_DELAY), () => name)
+    );
+
+    expect(found.length).toBeGreaterThanOrEqual(2);
+    expect(found).toContain('StickerPlacementHoverCard.tsx');
+    expect(found).toContain('StickerShopPanel.tsx');
+  });
+});

--- a/src/components/UserAvatar/UserHoverCard.tsx
+++ b/src/components/UserAvatar/UserHoverCard.tsx
@@ -5,6 +5,7 @@ import type { ReactElement, ReactNode } from 'react';
 import { createContext, useContext, useSyncExternalStore } from 'react';
 import type { UserWithCosmetics } from '~/server/selectors/user.selector';
 import { trpc } from '~/utils/trpc';
+import { HOVER_CLOSE_DELAY_MS, HOVER_DELAY_MS } from './hover-card.constants';
 
 // Loaded with the hover, not with the page. The creator card drags in profile
 // cosmetics, live metrics and edge media, and a feed renders dozens of avatars
@@ -19,8 +20,10 @@ const SmartCreatorCard = dynamic(() =>
  */
 export const HOVER_CARD_WIDTH = 400;
 
-export const HOVER_DELAY_MS = 500;
-export const HOVER_CLOSE_DELAY_MS = 150;
+// Defined in their own module so a consumer that wants only the timing does not
+// take this component with it; re-exported here because every existing importer
+// reads them from this path.
+export { HOVER_CLOSE_DELAY_MS, HOVER_DELAY_MS } from './hover-card.constants';
 
 /**
  * Above Mantine's default popover layer. A hover card is frequently rendered

--- a/src/components/UserAvatar/hover-card.constants.ts
+++ b/src/components/UserAvatar/hover-card.constants.ts
@@ -1,0 +1,18 @@
+/**
+ * The delays every hover card in the app shares, kept apart from the component.
+ *
+ * A card that only wants the timing should not have to import `UserHoverCard` to
+ * get it — that pulls a component module into the importer's graph for an
+ * integer, on routes that may never render a creator card. `UserHoverCard`
+ * re-exports both names, so existing importers are unaffected.
+ */
+
+/**
+ * Long enough that a pointer crossing a target on its way somewhere else does
+ * not open anything. Hover cards sit on avatars in a feed and on stickers inside
+ * one, both of which get swiped past rather than aimed at.
+ */
+export const HOVER_DELAY_MS = 500;
+
+/** Enough to cross the gap from the target to the dropdown without it closing. */
+export const HOVER_CLOSE_DELAY_MS = 150;


### PR DESCRIPTION
Two corrections in the sticker placement editor, both from the 2026-08-20 breakout. Separate from the duplicate-placement work (`868kum38p`), which touches the charge path and gets its own PR cut fresh after this one merges.

## The placed-sticker hover card opened on a pointer that was passing over — `868kum34n`

> "I need to make it so that that hover card doesn't pop so quick because that can be annoying as you're like swiping through these."

The delay already existed and was already in the shared component, not at a call site: `StickerPlacementHoverCard` passed `openDelay={300}`. 300ms is short enough that swiping a feed opens the card on stickers nobody stopped at.

Raised to the app's shared `HOVER_DELAY_MS` (500) — the same constant `UserHoverCard` and the sticker attribution card already use, so all three hover cards now open on one delay instead of three. The card itself is untouched; its content is `868ku94bb`.

**Touch path, as asked.** No change in reachability. Mantine's `HoverCard.Target` binds `onMouseEnter`/`onMouseLeave` and nothing else, so on a phone the card opens off the tap's synthesised mouseover exactly as before — 200ms later, not unreachable. (Unlike `UserHoverCard`, this card does not gate on `useHoverCapable`, so touch was already able to open it. That is pre-existing and out of scope here.)

## The flip control drew the wrong glyph — `868kum387`

> "The flip icon still didn't get rotated... it's still showing like the vertical flip instead of the horizontal flip."

Audited which half was wrong before swapping anything, and it is the icon. `stickerArtworkStyle` emits `transform: scaleX(-1)` — a mirror across a **vertical** axis, left-to-right — which is the horizontal flip the tooltip means. There is one control, not an H/V pair.

The trap is that **Tabler names its flip icons for the mirror axis, not the motion**:

| Icon | Draws | Reads as |
|---|---|---|
| `IconFlipHorizontal` | a horizontal line, `M3 12 l18 0` | flipping top-to-bottom |
| `IconFlipVertical` | a vertical line, `M12 3 l0 18` | flipping left-to-right ✅ |

So the control that mirrors left-to-right needs `IconFlipVertical`. Picking by name is how this got reported twice.

This is not a novel reading: `DrawingCanvas.tsx` already pairs them crossed, with a comment saying why. The new comment here points at it, so the next person to "fix" this finds the reason before the swap.

No other component uses either icon.

## Tests

Both are browser tests, and **both were confirmed to fail on revert** rather than assumed to:

- flip glyph → `AssertionError: expected false to be true`
- hover delay → `AssertionError: expected 221.40 to be greater than or equal to 400`

**The flip test asserts geometry, not the icon's name or its path data.** The mirror line is the one sub-path of the glyph that is a straight line, so it has zero width when vertical. A Tabler version bump that redraws the arrows leaves it green; swapping the pair back turns it red. It also reads the transform from `stickerArtworkStyle` rather than restating `scaleX(-1)`, so changing the transform to `scaleY` fails the test instead of silently making the icon wrong again.

**The hover test measures how long the card takes to appear.** That measurement only ever runs long — a loaded machine delays the open, it cannot make it early — so it cannot flake on CI.

⚠️ **What it does not catch:** harness overhead is ~220ms, so the floor is set at 400ms and a delay *lowered* to 300 would still pass. It catches the delay being **removed**, not re-tuned. Pinning the exact constant would mean a timing window, which is the flaky shape this deliberately avoids.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm exec eslint <the four files>` — clean (repo-wide lint has ~1,425 pre-existing files with findings; none are these)
- `pnpm exec prettier` — clean
- `vitest --project component` on both files — 14 passed, 0 failed
- `blocks.router.workflow.test.ts` — **350 tests collected**, so the submodule is wired and the suite result means something

**Full unit suite: 1249 files passed, 0 test failures attributable to this diff — but neither run exited clean, and both reasons are unrelated to it.** Reporting them rather than rounding to green:

1. Run 1: `19718 passed`, plus one unhandled `Worker exited unexpectedly` from the vitest pool. No test failed.
2. Run 2: `19723 passed, 1 failed` — `home-block-fetch-sizing.test.ts` timed out at 60s.

That file passes in isolation on this branch, passes in isolation on `origin/main`, and passed in run 1. Its failure mode when it does fail is a TDZ error (`Cannot access 'FEED_FETCH_CEILING' before initialization`) inside `home-block.service.ts`, which is module-init ordering under a cold transform, not anything a sticker component can reach — `home-block.service.ts` contains no reference to stickers, and this diff is four files under `src/components/Sticker`.

ClickUp: [868kum34n](https://app.clickup.com/t/868kum34n), [868kum387](https://app.clickup.com/t/868kum387)
