### PR TITLE
fix(placement): plain-language Buzz ledger rows that link to the image

### DIFF
--- a/src/components/Notifications/NotificationList.tsx
+++ b/src/components/Notifications/NotificationList.tsx
@@ -6,6 +6,8 @@ import type { MouseEvent } from 'react';
 import React, { useMemo } from 'react';
 
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
+import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
+import { useNotificationThumbnails } from '~/components/Notifications/notification-thumbnails';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { getNotificationMessage } from '~/server/notifications/utils.notifications';
 import type { NotificationGetAll } from '~/types/router';
@@ -54,6 +56,7 @@ export function NotificationList({
   searchText,
 }: Props) {
   const router = useRouter();
+  const thumbnails = useNotificationThumbnails(items);
 
   const fullItems = useMemo(() => {
     return items
@@ -90,6 +93,7 @@ export function NotificationList({
         const notificationDetails = notification.details;
         const details = notification.fullDetails;
 
+        const thumbnail = thumbnails.get(Number(notificationDetails?.imageId));
         const systemNotification = notification.type === 'system-announcement';
         const milestoneNotification = notification.type.includes('milestone');
 
@@ -169,6 +173,16 @@ export function NotificationList({
                   </Group>
                 </Stack>
               </Group>
+              {thumbnail && (
+                <EdgeMedia
+                  src={thumbnail.url}
+                  type={thumbnail.type}
+                  width={90}
+                  alt=""
+                  anim={false}
+                  className="size-12 shrink-0 rounded-md object-cover"
+                />
+              )}
             </Group>
           </Paper>
         );

--- a/src/components/Notifications/NotificationList.tsx
+++ b/src/components/Notifications/NotificationList.tsx
@@ -6,9 +6,7 @@ import type { MouseEvent } from 'react';
 import React, { useMemo } from 'react';
 
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
-import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
-import { MediaHash } from '~/components/ImageHash/ImageHash';
-import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
+import { NotificationThumbnail } from '~/components/Notifications/NotificationThumbnail';
 import {
   notificationImageId,
   useNotificationThumbnails,
@@ -182,39 +180,7 @@ export function NotificationList({
                   </Group>
                 </Stack>
               </Group>
-              {thumbnail && (
-                <div className="relative size-12 shrink-0 overflow-hidden rounded-md">
-                  {/*
-                   * Hidden preferences decide whether the viewer may see the image
-                   * at all; this decides whether they asked to see it uncovered.
-                   * The two are not the same set — with blur on, the mask covers
-                   * every mature level, including the ones inside the viewer's own
-                   * browsing level — so filtering alone would render plainly, in a
-                   * dropdown over whatever page they are on, what the rest of the
-                   * app blurs.
-                   *
-                   * `explain={false}`: the Show overlay is a button and a badge,
-                   * which do not fit 48px. The blurhash is the whole affordance
-                   * here, and the row already opens the image.
-                   */}
-                  <ImageGuard2 image={thumbnail} explain={false}>
-                    {(safe) =>
-                      safe ? (
-                        <EdgeMedia
-                          src={thumbnail.url}
-                          type={thumbnail.type}
-                          width={90}
-                          alt=""
-                          anim={false}
-                          className="size-full object-cover"
-                        />
-                      ) : (
-                        <MediaHash {...thumbnail} />
-                      )
-                    }
-                  </ImageGuard2>
-                </div>
-              )}
+              {thumbnail && <NotificationThumbnail image={thumbnail} />}
             </Group>
           </Paper>
         );

--- a/src/components/Notifications/NotificationList.tsx
+++ b/src/components/Notifications/NotificationList.tsx
@@ -7,7 +7,12 @@ import React, { useMemo } from 'react';
 
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
-import { useNotificationThumbnails } from '~/components/Notifications/notification-thumbnails';
+import { MediaHash } from '~/components/ImageHash/ImageHash';
+import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
+import {
+  notificationImageId,
+  useNotificationThumbnails,
+} from '~/components/Notifications/notification-thumbnails';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { getNotificationMessage } from '~/server/notifications/utils.notifications';
 import type { NotificationGetAll } from '~/types/router';
@@ -93,7 +98,11 @@ export function NotificationList({
         const notificationDetails = notification.details;
         const details = notification.fullDetails;
 
-        const thumbnail = thumbnails.get(Number(notificationDetails?.imageId));
+        // Through the same normaliser the ids were collected with. Reading the
+        // id a second way here is how the map ends up keyed on one thing and
+        // looked up with another, silently, with no test red.
+        const imageId = notificationImageId(notificationDetails);
+        const thumbnail = imageId ? thumbnails.get(imageId) : undefined;
         const systemNotification = notification.type === 'system-announcement';
         const milestoneNotification = notification.type.includes('milestone');
 
@@ -174,14 +183,37 @@ export function NotificationList({
                 </Stack>
               </Group>
               {thumbnail && (
-                <EdgeMedia
-                  src={thumbnail.url}
-                  type={thumbnail.type}
-                  width={90}
-                  alt=""
-                  anim={false}
-                  className="size-12 shrink-0 rounded-md object-cover"
-                />
+                <div className="relative size-12 shrink-0 overflow-hidden rounded-md">
+                  {/*
+                   * Hidden preferences decide whether the viewer may see the image
+                   * at all; this decides whether they asked to see it uncovered.
+                   * The two are not the same set — with blur on, the mask covers
+                   * every mature level, including the ones inside the viewer's own
+                   * browsing level — so filtering alone would render plainly, in a
+                   * dropdown over whatever page they are on, what the rest of the
+                   * app blurs.
+                   *
+                   * `explain={false}`: the Show overlay is a button and a badge,
+                   * which do not fit 48px. The blurhash is the whole affordance
+                   * here, and the row already opens the image.
+                   */}
+                  <ImageGuard2 image={thumbnail} explain={false}>
+                    {(safe) =>
+                      safe ? (
+                        <EdgeMedia
+                          src={thumbnail.url}
+                          type={thumbnail.type}
+                          width={90}
+                          alt=""
+                          anim={false}
+                          className="size-full object-cover"
+                        />
+                      ) : (
+                        <MediaHash {...thumbnail} />
+                      )
+                    }
+                  </ImageGuard2>
+                </div>
               )}
             </Group>
           </Paper>

--- a/src/components/Notifications/NotificationThumbnail.tsx
+++ b/src/components/Notifications/NotificationThumbnail.tsx
@@ -1,0 +1,42 @@
+import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
+import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
+import { MediaHash } from '~/components/ImageHash/ImageHash';
+import type { NotificationThumbnailImage } from '~/components/Notifications/notification-thumbnails';
+
+/**
+ * Hidden preferences decide whether the viewer may see this image at all, and
+ * have already run by the time it gets here. This decides the other question:
+ * whether they asked to see it uncovered.
+ *
+ * The two are not the same set. With blur on, the mask covers every mature
+ * level, including the ones inside the viewer's own browsing level — so an
+ * image that legitimately passed the filter would otherwise render plainly, in
+ * a dropdown over whatever page they are on, where the rest of the app blurs it.
+ *
+ * `explain={false}`: the Show overlay is a button and a badge, which do not fit
+ * 48px, and its badge would name the rating of an image the viewer chose to
+ * keep covered. Clicking through is the reveal path — the row already opens the
+ * image, and the image page carries its own blur toggle.
+ */
+export function NotificationThumbnail({ image }: { image: NotificationThumbnailImage }) {
+  return (
+    <div className="relative size-12 shrink-0 overflow-hidden rounded-md">
+      <ImageGuard2 image={image} explain={false}>
+        {(safe) =>
+          safe ? (
+            <EdgeMedia
+              src={image.url}
+              type={image.type}
+              width={90}
+              alt=""
+              anim={false}
+              className="size-full object-cover"
+            />
+          ) : (
+            <MediaHash {...image} />
+          )
+        }
+      </ImageGuard2>
+    </div>
+  );
+}

--- a/src/components/Notifications/__tests__/NotificationThumbnail.test.ts
+++ b/src/components/Notifications/__tests__/NotificationThumbnail.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The hook suite next door tests the VISIBILITY filter — whether the viewer may
+ * see the image at all. This tests the other half, which no hook test can
+ * reach: whether an image they may see is rendered uncovered. Delete the guard
+ * from this component and the hook suite stays green, which is why this file
+ * exists.
+ */
+const state = vi.hoisted(() => ({ blurLevels: 0 }));
+
+vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', () => ({
+  useBrowsingLevelContext: () => ({ blurLevels: state.blurLevels }),
+}));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  // Never the owner, never a moderator: both bypass the cover for an unrated
+  // image, so a viewer who is either makes the covered cases vacuous.
+  useCurrentUser: () => ({ id: 999, isModerator: false }),
+}));
+// Stands in for the media element itself. What is under test is WHETHER it is
+// rendered, not what it renders.
+vi.mock('~/components/EdgeMedia/EdgeMedia', () => ({
+  EdgeMedia: () => createElement('img', { 'data-testid': 'thumbnail' }),
+}));
+
+import { NotificationThumbnail } from '~/components/Notifications/NotificationThumbnail';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const MATURE_LEVEL = 4;
+
+const render = (image: Record<string, unknown>) => {
+  const container = document.createElement('div');
+  act(() => {
+    createRoot(container).render(createElement(NotificationThumbnail, { image: image as never }));
+  });
+
+  return container;
+};
+
+const givenImage = (overrides: Record<string, unknown> = {}) => ({
+  id: 99,
+  url: 'abc-123',
+  type: 'image',
+  nsfwLevel: MATURE_LEVEL,
+  userId: 555,
+  width: 100,
+  height: 100,
+  hash: null,
+  poi: false,
+  minor: false,
+  ...overrides,
+});
+
+beforeEach(() => {
+  state.blurLevels = 0;
+});
+
+describe('the image on a notification row', () => {
+  // The control. Without it the covered case below passes against a component
+  // that renders nothing at all.
+  it('shows the image when the viewer has not asked for it to be covered', () => {
+    const container = render(givenImage());
+
+    expect(container.querySelector('[data-testid="thumbnail"]')).not.toBeNull();
+  });
+
+  it('covers an image at a level the viewer blurs', () => {
+    state.blurLevels = MATURE_LEVEL;
+
+    const container = render(givenImage());
+
+    // Not "renders a blurhash" — the hash is nullable and MediaHash renders
+    // nothing without one. What must hold is that the media never appears.
+    expect(container.querySelector('[data-testid="thumbnail"]')).toBeNull();
+  });
+
+  it('shows an image whose level the viewer does not blur, while blurring others', () => {
+    state.blurLevels = MATURE_LEVEL;
+
+    const container = render(givenImage({ nsfwLevel: 1 }));
+
+    expect(container.querySelector('[data-testid="thumbnail"]')).not.toBeNull();
+  });
+});

--- a/src/components/Notifications/__tests__/notification-thumbnails.test.ts
+++ b/src/components/Notifications/__tests__/notification-thumbnails.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { notificationImageIds } from '~/components/Notifications/notification-thumbnails';
+
+describe('collecting the images a panel of notifications names', () => {
+  it('asks for each image once, however many notifications name it', () => {
+    const ids = notificationImageIds([
+      { details: { imageId: 99 } },
+      { details: { imageId: 99 } },
+      { details: { imageId: 140197043 } },
+    ]);
+
+    // One entity per image is what keeps this a single batched query rather
+    // than one per row in the panel.
+    expect(ids).toEqual([99, 140197043]);
+  });
+
+  it('reads an id that came back from JSON as a string', () => {
+    expect(notificationImageIds([{ details: { imageId: '99' } }])).toEqual([99]);
+  });
+
+  it.each([
+    ['no details at all', undefined],
+    ['details without an image', { placementId: 1 }],
+    ['a null id', { imageId: null }],
+    ['a non-numeric id', { imageId: 'unknown' }],
+    ['a fractional id', { imageId: 1.5 }],
+    ['a zero id', { imageId: 0 }],
+    ['a negative id', { imageId: -1 }],
+  ])('asks for nothing given %s', (_label, details) => {
+    // Every one of these would otherwise reach the query as an entity, and an
+    // entity list built from junk is a query that returns nothing slowly.
+    expect(notificationImageIds([{ details: details ?? undefined }])).toEqual([]);
+  });
+
+  it('keeps the images it can read when a neighbouring row has none', () => {
+    const ids = notificationImageIds([
+      { details: { imageId: 'unknown' } },
+      { details: { imageId: 7 } },
+      {},
+    ]);
+
+    expect(ids).toEqual([7]);
+  });
+});

--- a/src/components/Notifications/__tests__/useNotificationThumbnails.test.ts
+++ b/src/components/Notifications/__tests__/useNotificationThumbnails.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as TrpcModule from '~/utils/trpc';
+
+/**
+ * The hook's own filter is the ONLY thing standing between a raw Image row and
+ * the panel: the `Image` arm of `getEntitiesCoverImage` is an identity select,
+ * gated by nothing but `ingestion = 'Scanned' AND needsReview IS NULL`. So this
+ * suite leaves `useApplyHiddenPreferences` real and mocks only what it reads
+ * from React context — mocking the filter would leave the gate untested and the
+ * suite green, which is the failure this file exists to prevent.
+ */
+const state = vi.hoisted(() => ({
+  hiddenTags: new Map<number, boolean>(),
+  browsingLevel: 1,
+  images: [] as Record<string, unknown>[],
+  useQuery: vi.fn(),
+}));
+
+vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', () => ({
+  useBrowsingLevelDebounced: () => state.browsingLevel,
+}));
+vi.mock('~/components/HiddenPreferences/HiddenPreferencesProvider', () => ({
+  useHiddenPreferencesContext: () => ({
+    hiddenUsers: new Map(),
+    hiddenTags: state.hiddenTags,
+    hiddenModels: new Map(),
+    hiddenModel3Ds: new Map(),
+    hiddenImages: new Map(),
+    hiddenLoading: false,
+    moderatedTags: [],
+    systemHiddenTags: new Map(),
+  }),
+}));
+// Never the owner and never a moderator. Both of those bypass the level gate
+// for an unrated image, so a viewer who is either turns every drop assertion
+// below into one that passes on a gutted filter.
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 999, isModerator: false }),
+}));
+vi.mock('~/providers/BrowsingSettingsAddonsProvider', () => ({
+  useBrowsingSettingsAddons: () => ({ settings: { disablePoi: false, disableMinor: false } }),
+}));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ canViewNsfw: true }),
+}));
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  // Delegates rather than capturing, so a per-test `useQuery` is the one that
+  // actually gets called. Wiring the captured reference in directly leaves the
+  // mock pointing at whatever existed when the module was first imported.
+  trpc: {
+    image: {
+      getEntitiesCoverImage: {
+        useQuery: (...args: unknown[]) => state.useQuery(...args),
+      },
+    },
+  },
+}));
+
+import { useNotificationThumbnails } from '~/components/Notifications/notification-thumbnails';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+function renderHook<T>(useHook: () => T) {
+  const result = { current: undefined as T };
+  const root = createRoot(document.createElement('div'));
+  function Probe() {
+    result.current = useHook();
+    return null;
+  }
+  act(() => {
+    root.render(createElement(Probe));
+  });
+  return result;
+}
+
+const IMAGE_ID = 99;
+const OTHER_USER = 555;
+
+const givenImage = (overrides: Record<string, unknown> = {}) => {
+  state.images = [
+    {
+      id: IMAGE_ID,
+      entityId: IMAGE_ID,
+      entityType: 'Image',
+      url: 'abc-123',
+      type: 'image',
+      nsfwLevel: 1,
+      userId: OTHER_USER,
+      poi: false,
+      minor: false,
+      tags: [],
+      ...overrides,
+    },
+  ];
+};
+
+const thumbnailsFor = (imageId: number = IMAGE_ID) =>
+  renderHook(() => useNotificationThumbnails([{ details: { imageId } }])).current;
+
+beforeEach(() => {
+  state.hiddenTags = new Map();
+  state.browsingLevel = 1;
+  state.images = [];
+  state.useQuery = vi.fn(() => ({ data: state.images }));
+});
+
+describe('resolving the image a notification is about', () => {
+  // The control the three drop cases below are worthless without: they would
+  // all pass against a hook that returned an empty map unconditionally.
+  it('returns an image the viewer is allowed to see', () => {
+    givenImage();
+
+    expect(thumbnailsFor().get(IMAGE_ID)).toMatchObject({ id: IMAGE_ID, url: 'abc-123' });
+  });
+
+  it('drops an image above the viewer browsing level', () => {
+    givenImage({ nsfwLevel: 2 });
+
+    expect(thumbnailsFor().size).toBe(0);
+  });
+
+  // Pins the tags -> tagIds mapping the hook does by hand. Drop that one line
+  // and every hidden-tag check silently reads an empty list instead.
+  it('drops an image carrying a tag the viewer hid', () => {
+    givenImage({ tags: [{ id: 5 }] });
+    state.hiddenTags = new Map([[5, true]]);
+
+    expect(thumbnailsFor().size).toBe(0);
+  });
+
+  it('asks for the ids as Image entities, in one query', () => {
+    givenImage();
+
+    thumbnailsFor();
+
+    expect(state.useQuery).toHaveBeenCalledTimes(1);
+    expect(state.useQuery.mock.calls[0][0]).toEqual({
+      entities: [{ entityType: 'Image', entityId: IMAGE_ID }],
+    });
+  });
+
+  it('asks for nothing when no notification names an image', () => {
+    givenImage();
+
+    renderHook(() => useNotificationThumbnails([{ details: { placementId: 1 } }]));
+
+    expect(state.useQuery.mock.calls[0][1]).toMatchObject({ enabled: false });
+  });
+});

--- a/src/components/Notifications/notification-thumbnails.ts
+++ b/src/components/Notifications/notification-thumbnails.ts
@@ -4,6 +4,10 @@ import { trpc } from '~/utils/trpc';
 
 type WithDetails = { details?: Record<string, unknown> | null };
 
+export type NotificationThumbnailImage = NonNullable<
+  ReturnType<typeof useNotificationThumbnails> extends Map<number, infer T> ? T : never
+>;
+
 /**
  * Notifications that name an image, deduped, in the order they appear.
  *

--- a/src/components/Notifications/notification-thumbnails.ts
+++ b/src/components/Notifications/notification-thumbnails.ts
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { trpc } from '~/utils/trpc';
+
+type WithDetails = { details?: Record<string, unknown> | null };
+
+/**
+ * Notifications that name an image, deduped, in the order they appear.
+ *
+ * `imageId` is the key every processor that points at an image already writes,
+ * so a notification type added later is covered without being listed here.
+ */
+export function notificationImageIds(items: WithDetails[]) {
+  const ids = new Set<number>();
+  for (const { details } of items) {
+    const id = Number(details?.imageId);
+    if (Number.isInteger(id) && id > 0) ids.add(id);
+  }
+
+  return [...ids];
+}
+
+/**
+ * Resolved when the panel opens, never stored on the notification.
+ *
+ * `details` is frozen at write time: a url and level stamped into it keep
+ * rendering an image that has since been deleted, moderated or re-levelled, at
+ * the level it had the day the row was written. That is a browsing-level gate
+ * that silently stops being correct, where reading now is current by
+ * construction and costs one batched query for the whole panel.
+ *
+ * An image the viewer may not see is dropped by `useApplyHiddenPreferences`
+ * rather than blurred, so the row falls back to its icon and nothing about the
+ * image is disclosed by the shape of the fallback.
+ */
+export function useNotificationThumbnails(items: WithDetails[]) {
+  const imageIds = useMemo(() => notificationImageIds(items), [items]);
+
+  const { data } = trpc.image.getEntitiesCoverImage.useQuery(
+    { entities: imageIds.map((entityId) => ({ entityType: 'Image' as const, entityId })) },
+    { enabled: imageIds.length > 0, trpc: { context: { skipBatch: true } } }
+  );
+
+  const withTagIds = useMemo(
+    () => data?.map((image) => ({ ...image, tagIds: image.tags?.map((tag) => tag.id) })) ?? [],
+    [data]
+  );
+  const { items: visible } = useApplyHiddenPreferences({ type: 'images', data: withTagIds });
+
+  return useMemo(() => new Map(visible.map((image) => [image.id, image])), [visible]);
+}

--- a/src/components/Notifications/notification-thumbnails.ts
+++ b/src/components/Notifications/notification-thumbnails.ts
@@ -10,11 +10,17 @@ type WithDetails = { details?: Record<string, unknown> | null };
  * `imageId` is the key every processor that points at an image already writes,
  * so a notification type added later is covered without being listed here.
  */
+export function notificationImageId(details: WithDetails['details']) {
+  const id = Number(details?.imageId);
+
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
 export function notificationImageIds(items: WithDetails[]) {
   const ids = new Set<number>();
   for (const { details } of items) {
-    const id = Number(details?.imageId);
-    if (Number.isInteger(id) && id > 0) ids.add(id);
+    const id = notificationImageId(details);
+    if (id) ids.add(id);
   }
 
   return [...ids];
@@ -31,7 +37,16 @@ export function notificationImageIds(items: WithDetails[]) {
  *
  * An image the viewer may not see is dropped by `useApplyHiddenPreferences`
  * rather than blurred, so the row falls back to its icon and nothing about the
- * image is disclosed by the shape of the fallback.
+ * image is disclosed by the shape of the fallback. Whether a visible image is
+ * shown uncovered is a separate question, answered by `ImageGuard2` at the
+ * render site.
+ *
+ * ⚠️ The ids are trusted because every processor writing `details.imageId`
+ * addresses the image's owner or a participant on a published image. A
+ * processor that names an image its recipient is not otherwise entitled to see
+ * — something in a draft post, a moderation queue, anything private — would be
+ * rendering it here with no gate beyond the viewer's own preferences, and
+ * nothing in this file would need to change for that to happen.
  */
 export function useNotificationThumbnails(items: WithDetails[]) {
   const imageIds = useMemo(() => notificationImageIds(items), [items]);

--- a/src/server/notifications/__tests__/placement.detail-fetcher.test.ts
+++ b/src/server/notifications/__tests__/placement.detail-fetcher.test.ts
@@ -81,4 +81,33 @@ describe('the avatar on a placement notification', () => {
     expect(placementDetailFetcher.types.sort()).toEqual(Object.keys(placementNotifications).sort());
     expect(placementDetailFetcher.types.length).toBeGreaterThan(1);
   });
+
+  /**
+   * The coalesce above picks the placer whenever both ids are present, which is
+   * only the right person because no processor writes both. That is a property
+   * of the QUERIES, not of this fetcher, and the coverage test cannot see it: a
+   * new type auto-enrols and a changed details shape renders the reader their
+   * own avatar with every other assertion green.
+   *
+   * Fails closed — a type whose query emits neither id fails here rather than
+   * passing for want of a match.
+   */
+  it('has exactly one party to name in every processor', async () => {
+    const emitted = await Promise.all(
+      Object.entries(placementNotifications).map(async ([type, processor]) => {
+        const query = await processor.prepareQuery?.({
+          lastSent: '2026-01-01',
+          category: 'Creator',
+        } as never);
+
+        return {
+          type,
+          ids: (["'placerId'", "'ownerId'"] as const).filter((id) => String(query).includes(id)),
+        };
+      })
+    );
+
+    expect(emitted.length).toBe(Object.keys(placementNotifications).length);
+    for (const { type, ids } of emitted) expect([type, ids]).toEqual([type, [expect.any(String)]]);
+  });
 });

--- a/src/server/notifications/__tests__/placement.detail-fetcher.test.ts
+++ b/src/server/notifications/__tests__/placement.detail-fetcher.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { placementDetailFetcher } from '~/server/notifications/detail-fetchers/placement.detail-fetcher';
+import { placementNotifications } from '~/server/notifications/placement.notifications';
+
+const fakeDb = (users: { id: number; username: string }[]) => {
+  const findMany = vi.fn(async ({ where }: { where: { id: { in: number[] } } }) =>
+    users.filter((u) => where.id.in.includes(u.id))
+  );
+
+  return { db: { user: { findMany } } as never, findMany };
+};
+
+const notification = (type: string, details: Record<string, unknown>) => ({
+  id: 1,
+  type,
+  details,
+});
+
+describe('the avatar on a placement notification', () => {
+  // The row falls back to a generic bell without this, which is what every
+  // placement notification did before the fetcher existed.
+  it('names the placer on a notification addressed to the owner', async () => {
+    const { db } = fakeDb([{ id: 20, username: 'demiandei' }]);
+    const rows = [notification('sticker-placement-pending', { placerId: 20, imageId: 99 })];
+
+    await placementDetailFetcher.fetcher(rows, { db });
+
+    expect(rows[0].details.actor).toMatchObject({ id: 20, username: 'demiandei' });
+  });
+
+  it('names the owner on a notification addressed to the placer', async () => {
+    const { db } = fakeDb([{ id: 10, username: 'boerboer' }]);
+    const rows = [notification('sticker-placement-resolved', { ownerId: 10, imageId: 99 })];
+
+    await placementDetailFetcher.fetcher(rows, { db });
+
+    expect(rows[0].details.actor).toMatchObject({ id: 10, username: 'boerboer' });
+  });
+
+  // One query for the panel, not one per row — the whole reason this runs as a
+  // fetcher over the page rather than per notification.
+  it('asks for each user once across the page', async () => {
+    const { db, findMany } = fakeDb([
+      { id: 20, username: 'demiandei' },
+      { id: 10, username: 'boerboer' },
+    ]);
+    const rows = [
+      notification('sticker-placement-pending', { placerId: 20 }),
+      notification('sticker-placement-pending', { placerId: 20 }),
+      notification('sticker-placement-resolved', { ownerId: 10 }),
+    ];
+
+    await placementDetailFetcher.fetcher(rows, { db });
+
+    expect(findMany).toHaveBeenCalledTimes(1);
+    expect(findMany.mock.calls[0][0].where.id.in).toEqual([20, 10]);
+  });
+
+  it('queries nothing when no row names anyone', async () => {
+    const { db, findMany } = fakeDb([{ id: 20, username: 'demiandei' }]);
+    const rows = [notification('sticker-placement-pending', { imageId: 99 })];
+
+    await placementDetailFetcher.fetcher(rows, { db });
+
+    expect(findMany).not.toHaveBeenCalled();
+    expect(rows[0].details.actor).toBeUndefined();
+  });
+
+  it('leaves the row alone when the user no longer exists', async () => {
+    const { db } = fakeDb([]);
+    const rows = [notification('sticker-placement-pending', { placerId: 20 })];
+
+    await placementDetailFetcher.fetcher(rows, { db });
+
+    expect(rows[0].details.actor).toBeUndefined();
+  });
+
+  // Registered against the processor's own keys, so a placement type added later
+  // is covered without being listed here a second time.
+  it('covers every placement notification type', () => {
+    expect(placementDetailFetcher.types.sort()).toEqual(Object.keys(placementNotifications).sort());
+    expect(placementDetailFetcher.types.length).toBeGreaterThan(1);
+  });
+});

--- a/src/server/notifications/detail-fetchers/index.ts
+++ b/src/server/notifications/detail-fetchers/index.ts
@@ -5,6 +5,7 @@ import { buzzDetailFetcher } from '~/server/notifications/detail-fetchers/buzz.d
 import { commentDetailFetcher } from '~/server/notifications/detail-fetchers/comment.detail-fetcher';
 import { followDetailFetcher } from '~/server/notifications/detail-fetchers/follow.detail-fetcher';
 import { modelDetailFetcher } from '~/server/notifications/detail-fetchers/model.detail-fetcher';
+import { placementDetailFetcher } from '~/server/notifications/detail-fetchers/placement.detail-fetcher';
 import { reviewDetailFetcher } from '~/server/notifications/detail-fetchers/review.detail-fetcher';
 
 const detailFetchers = [
@@ -14,6 +15,7 @@ const detailFetchers = [
   buzzDetailFetcher,
   followDetailFetcher,
   reviewDetailFetcher,
+  placementDetailFetcher,
 ];
 
 export async function populateNotificationDetails(notifications: BareNotification[]) {

--- a/src/server/notifications/detail-fetchers/placement.detail-fetcher.ts
+++ b/src/server/notifications/detail-fetchers/placement.detail-fetcher.ts
@@ -1,0 +1,34 @@
+import { createDetailFetcher } from '~/server/notifications/detail-fetchers/base.detail-fetcher';
+import { placementNotifications } from '~/server/notifications/placement.notifications';
+import { simpleUserSelect } from '~/server/selectors/user.selector';
+import { isDefined } from '~/utils/type-guards';
+
+/**
+ * The other party to the placement, whoever the reader is not.
+ *
+ * A pending type is addressed to the owner and names the placer; a resolved one
+ * is addressed to the placer and names the owner. Both are written by the
+ * processor, so this picks whichever is there rather than branching on the type.
+ */
+const counterpartyId = (details: Record<string, unknown>) =>
+  (details.placerId ?? details.ownerId) as number | undefined;
+
+export const placementDetailFetcher = createDetailFetcher({
+  types: [...Object.keys(placementNotifications)],
+  fetcher: async (notifications, { db }) => {
+    const userIds = [
+      ...new Set(notifications.map((n) => counterpartyId(n.details)).filter(isDefined)),
+    ];
+    if (!userIds.length) return;
+
+    const users = await db.user.findMany({
+      where: { id: { in: userIds } },
+      select: simpleUserSelect,
+    });
+
+    for (const n of notifications) {
+      const user = users.find((u) => u.id === counterpartyId(n.details));
+      if (user) n.details.actor = user;
+    }
+  },
+});

--- a/src/server/services/__tests__/placement-escrow.service.test.ts
+++ b/src/server/services/__tests__/placement-escrow.service.test.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PLACEMENT_HOLD_KINDS } from '~/shared/utils/placement';
 // Mocked below; imported for the assertion that a swallowed reward failure is
 // still reported.
 import { logToAxiom } from '~/server/logging/client';
@@ -111,8 +112,21 @@ Object.assign(dbWriteMock, {
   $queryRaw: queryRaw,
   ...{
     placement: {
+      // Projects `select` rather than handing back the whole row. A double that
+      // ignores it answers with columns the query never asked for, so narrowing
+      // a select in the code under test changes nothing here and the revert is
+      // invisible.
       findUnique: vi.fn(
-        async ({ where }: { where: { id: number } }) => db.placements.get(where.id) ?? null
+        async ({ where, select }: { where: { id: number }; select?: Record<string, boolean> }) => {
+          const row = db.placements.get(where.id);
+          if (!row) return null;
+          if (!select) return row;
+          return Object.fromEntries(
+            Object.keys(select)
+              .filter((column) => select[column])
+              .map((column) => [column, row[column]])
+          );
+        }
       ),
       findMany: vi.fn(async ({ take }: { take?: number }) =>
         [...db.placements.values()]
@@ -281,6 +295,7 @@ const storedShares = (shares: { seller: number; platform: number }) =>
   (configState.shares = shares);
 
 const {
+  PAYOUT_KINDS,
   holdPlacementEscrow,
   settlePlacement,
   expirePlacements,
@@ -2108,14 +2123,17 @@ describe('what a placement says in the Buzz ledger', () => {
       amount: 1000,
     });
 
-  const descriptionsWritten = () =>
+  // Not `String(...)`: coercing turns a missing description into the literal
+  // 'undefined', which carries no leg name and no digit and so satisfies every
+  // assertion below.
+  const descriptionsWritten = (): unknown[] =>
     [
       ...createMultiAccountBuzzTransaction.mock.calls,
       ...createBuzzTransaction.mock.calls,
       ...refundMultiAccountTransaction.mock.calls,
-    ].map((call) => String(call[0].description));
+    ].map((call) => call[0].description);
 
-  it('names the two holds in words the placer can read', async () => {
+  it('names the two holds in words the placer can read, and links both to the image', async () => {
     givenPlacement();
     await hold();
 
@@ -2123,6 +2141,12 @@ describe('what a placement says in the Buzz ledger', () => {
       'Sticker placement fee, held while the creator decides',
       'Sticker placement, held while the creator decides',
     ]);
+    // Asserted positively on the hold legs, not only negatively in the
+    // non-image case below: these are the rows whose link depends on the
+    // widened `select`, and the fake honours `select`, so dropping a column
+    // from it lands here.
+    for (const call of createMultiAccountBuzzTransaction.mock.calls)
+      expect(call[0].details).toEqual({ entityType: 'Image', entityId: 99 });
   });
 
   it('tells the owner what landed on their image, and links the row to it', async () => {
@@ -2193,37 +2217,64 @@ describe('what a placement says in the Buzz ledger', () => {
       expect(call[0].details).toBeUndefined();
   });
 
-  it.each([
-    ['approve', OWNER],
-    ['decline', OWNER],
-    ['expire', undefined],
-  ] as const)('leaks no leg name or placement id through a %s', async (action, actorId) => {
-    givenPlacement();
+  // Each case pins the exact number of rows its action writes. `toBeGreaterThan`
+  // was satisfied by the two holds alone — before the settle ran — so a settle
+  // that paid nothing swept two known-clean strings and passed.
+  const settlements = [
+    {
+      name: 'an approval',
+      arrange: () => givenPlacement(),
+      // Two holds and toOwner. toPlatform keeps the money in escrow and writes
+      // no Buzz row.
+      writes: 3,
+      settle: () => settlePlacement({ placementId: 1, action: 'approve' as const, actorId: OWNER }),
+    },
+    {
+      // The only path that reaches toSeller, and therefore the only one that
+      // sweeps its copy.
+      name: 'an approval paying a seller',
+      arrange: () => {
+        givenPlacement({ sellerId: SELLER });
+        storedShares({ seller: 0.2, platform: 0.1 });
+      },
+      writes: 4,
+      settle: () => settlePlacement({ placementId: 1, action: 'approve' as const, actorId: OWNER }),
+    },
+    {
+      name: 'a decline',
+      arrange: () => givenPlacement(),
+      // Two holds, the owner's fee, and the placer's principal refund.
+      writes: 4,
+      settle: () => settlePlacement({ placementId: 1, action: 'decline' as const, actorId: OWNER }),
+    },
+    {
+      name: 'an expiry',
+      arrange: () => givenPlacement(),
+      // Two holds and both refunds.
+      writes: 4,
+      settle: () => settlePlacement({ placementId: 1, action: 'expire' as const }),
+    },
+  ];
+
+  it.each(settlements)('leaks no leg name or placement id through $name', async (settlement) => {
+    settlement.arrange();
     await hold();
 
-    await settlePlacement({ placementId: 1, action, actorId });
+    await settlement.settle();
 
     const written = descriptionsWritten();
-    // Not a vacuous sweep: the settle paths above write these, and an empty list
-    // would pass every assertion below.
-    expect(written.length).toBeGreaterThan(1);
+    expect(written).toHaveLength(settlement.writes);
 
     for (const description of written) {
-      for (const kind of [
-        'holdFee',
-        'holdPrincipal',
-        'toOwner',
-        'toSeller',
-        'toPlatform',
-        'feeToOwner',
-        'principalToPlacer',
-        'feeToPlacer',
-        'forfeit',
-      ])
+      expect(description).toBeTypeOf('string');
+
+      // The lists the code pays from, so a leg added later is swept without
+      // anyone remembering to add it here.
+      for (const kind of [...PLACEMENT_HOLD_KINDS, ...PAYOUT_KINDS])
         expect(description).not.toContain(kind);
 
       expect(description).not.toMatch(/placement \d/i);
-      expect(description.length).toBeLessThanOrEqual(100);
+      expect(String(description).length).toBeLessThanOrEqual(100);
     }
   });
 });

--- a/src/server/services/__tests__/placement-escrow.service.test.ts
+++ b/src/server/services/__tests__/placement-escrow.service.test.ts
@@ -2089,3 +2089,141 @@ describe('the accept reward', () => {
     );
   });
 });
+
+/**
+ * The strings here are the whole of what a user sees for a placement in their
+ * Buzz history, so the leg name and the placement id — both internal, both
+ * meaningless to the reader — must not survive into one.
+ *
+ * The sweep at the end is what guards a leg added later: a per-string assertion
+ * only covers the legs someone remembered to list.
+ */
+describe('what a placement says in the Buzz ledger', () => {
+  const hold = (surface: 'sticker' | 'remixGallery' = 'sticker') =>
+    holdPlacementEscrow({
+      spendType: 'yellow',
+      placementId: 1,
+      placerId: PLACER,
+      surface,
+      amount: 1000,
+    });
+
+  const descriptionsWritten = () =>
+    [
+      ...createMultiAccountBuzzTransaction.mock.calls,
+      ...createBuzzTransaction.mock.calls,
+      ...refundMultiAccountTransaction.mock.calls,
+    ].map((call) => String(call[0].description));
+
+  it('names the two holds in words the placer can read', async () => {
+    givenPlacement();
+    await hold();
+
+    expect(descriptionsWritten()).toEqual([
+      'Sticker placement fee, held while the creator decides',
+      'Sticker placement, held while the creator decides',
+    ]);
+  });
+
+  it('tells the owner what landed on their image, and links the row to it', async () => {
+    givenPlacement();
+    await hold();
+
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+
+    expect(createBuzzTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toAccountId: OWNER,
+        description: 'Someone placed a sticker on your image',
+        // `/user/transactions` builds its "View Image" link from these two.
+        details: { entityType: 'Image', entityId: 99 },
+      }),
+      expect.anything()
+    );
+  });
+
+  it('describes a refund without claiming a reason it cannot know', async () => {
+    givenPlacement();
+    await hold();
+
+    await settlePlacement({ placementId: 1, action: 'decline', actorId: OWNER });
+
+    expect(refundMultiAccountTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalTransactionIdPrefix: 'placement-1-holdPrincipal',
+        description: 'Refund: your sticker placement',
+        details: { entityType: 'Image', entityId: 99 },
+      }),
+      expect.anything()
+    );
+    expect(createBuzzTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toAccountId: OWNER,
+        description: 'Fee for a sticker you declined',
+      }),
+      expect.anything()
+    );
+  });
+
+  it('calls a remix a remix rather than a sticker', async () => {
+    givenPlacement({ surface: 'remixGallery' });
+    await hold('remixGallery');
+
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+
+    expect(createBuzzTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'Someone added a remix to your gallery' }),
+      expect.anything()
+    );
+    expect(descriptionsWritten().join(' ')).not.toContain('ticker');
+  });
+
+  // The link is built from the target, so a target that is not an image must
+  // produce no link at all rather than one pointing at /images/<some other id>.
+  it('omits the link when the placement is not on an image', async () => {
+    givenPlacement({ targetType: 'video' });
+    await hold();
+
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+
+    for (const call of [
+      ...createMultiAccountBuzzTransaction.mock.calls,
+      ...createBuzzTransaction.mock.calls,
+    ])
+      expect(call[0].details).toBeUndefined();
+  });
+
+  it.each([
+    ['approve', OWNER],
+    ['decline', OWNER],
+    ['expire', undefined],
+  ] as const)('leaks no leg name or placement id through a %s', async (action, actorId) => {
+    givenPlacement();
+    await hold();
+
+    await settlePlacement({ placementId: 1, action, actorId });
+
+    const written = descriptionsWritten();
+    // Not a vacuous sweep: the settle paths above write these, and an empty list
+    // would pass every assertion below.
+    expect(written.length).toBeGreaterThan(1);
+
+    for (const description of written) {
+      for (const kind of [
+        'holdFee',
+        'holdPrincipal',
+        'toOwner',
+        'toSeller',
+        'toPlatform',
+        'feeToOwner',
+        'principalToPlacer',
+        'feeToPlacer',
+        'forfeit',
+      ])
+        expect(description).not.toContain(kind);
+
+      expect(description).not.toMatch(/placement \d/i);
+      expect(description.length).toBeLessThanOrEqual(100);
+    }
+  });
+});

--- a/src/server/services/placement-escrow.service.ts
+++ b/src/server/services/placement-escrow.service.ts
@@ -195,6 +195,63 @@ const PAYOUT_KINDS = [
   'forfeit',
 ] as const;
 
+/**
+ * What a placement leg reads as in someone's Buzz history.
+ *
+ * Keyed by surface as well as leg because the two surfaces are different events
+ * to the person reading the row: a sticker is put on your image, a remix is
+ * added to your gallery. The internal leg name is unchanged and still identifies
+ * the leg everywhere it is used to find money — the `PlacementTransaction` row,
+ * the external transaction id, every recovery query.
+ */
+const LEDGER_TEXT: Record<PlacementSurface, Record<PlacementTransactionKind, string>> = {
+  sticker: {
+    holdFee: 'Sticker placement fee, held while the creator decides',
+    holdPrincipal: 'Sticker placement, held while the creator decides',
+    toOwner: 'Someone placed a sticker on your image',
+    feeToOwner: 'Fee for a sticker you declined',
+    toSeller: 'Someone used your sticker',
+    // Deliberately says nothing about why. One refund path serves a decline, an
+    // expiry, an owner removal and a cosmetic takedown, and a leg cannot tell
+    // them apart — so naming one of them here would be wrong on the other three.
+    principalToPlacer: 'Refund: your sticker placement',
+    feeToPlacer: 'Refund: sticker placement fee',
+    toPlatform: 'Platform share of a sticker placement',
+    forfeit: 'Forfeited sticker placement',
+  },
+  remixGallery: {
+    holdFee: 'Remix submission fee, held while the creator decides',
+    holdPrincipal: 'Remix submission, held while the creator decides',
+    toOwner: 'Someone added a remix to your gallery',
+    feeToOwner: 'Fee for a remix you declined',
+    toSeller: 'Share of a remix submission',
+    principalToPlacer: 'Refund: your remix submission',
+    feeToPlacer: 'Refund: remix submission fee',
+    toPlatform: 'Platform share of a remix submission',
+    forfeit: 'Forfeited remix submission',
+  },
+};
+
+/**
+ * `/user/transactions` renders a "View Image" link from `entityType`/`entityId`,
+ * so the row reaches the image the placement is on and the copy never has to
+ * name a raw id. Both columns are on the row every caller already holds, so this
+ * costs no lookup.
+ */
+const placementLedgerEntry = (
+  kind: PlacementTransactionKind,
+  target: { surface: string; targetType: string | null; targetId: number | null }
+) => ({
+  // A surface missing from the table cannot reach here — PLACEMENT_SURFACES
+  // denies one everywhere — but this is a money path, and a dull row beats a
+  // TypeError that strands the leg.
+  description: LEDGER_TEXT[target.surface as PlacementSurface]?.[kind] ?? 'Placement',
+  details:
+    target.targetType === 'image' && target.targetId
+      ? { entityType: 'Image', entityId: target.targetId }
+      : undefined,
+});
+
 type SettleAction =
   | 'approve'
   | 'decline'
@@ -434,7 +491,7 @@ export async function holdPlacementEscrow({
   // is how the free path silently acquires a second, half-built creation route.
   const row = await dbWrite.placement.findUnique({
     where: { id: placementId },
-    select: { free: true },
+    select: { free: true, targetType: true, targetId: true },
   });
   if (!row) throw new Error(`placement escrow: placement ${placementId} not found`);
   if (row.free)
@@ -519,7 +576,11 @@ export async function holdPlacementEscrow({
           // took yellow for a green placement.
           fromAccountTypes: [spendType],
           toAccountType: spendType,
-          description: `Placement escrow (${kind}) for placement ${placementId}`,
+          ...placementLedgerEntry(kind, {
+            surface,
+            targetType: row.targetType,
+            targetId: row.targetId,
+          }),
           externalTransactionIdPrefix,
         },
         BUZZ_CALL_OPTIONS
@@ -827,7 +888,7 @@ async function payOutPlacement(placement: PlacementRow) {
           toAccountId,
           toAccountType: spendType,
           type: TransactionType.Fee,
-          description: `Placement ${placement.id} (${kind})`,
+          ...placementLedgerEntry(kind, placement),
           externalTransactionId,
         },
         BUZZ_CALL_OPTIONS
@@ -847,7 +908,7 @@ async function payOutPlacement(placement: PlacementRow) {
             placement.id,
             holdKind as PlacementTransactionKind
           ),
-          description: `Placement ${placement.id} refund (${holdKind})`,
+          ...placementLedgerEntry(kind, placement),
         },
         BUZZ_CALL_OPTIONS
       );

--- a/src/server/services/placement-escrow.service.ts
+++ b/src/server/services/placement-escrow.service.ts
@@ -25,6 +25,7 @@ import type {
 import {
   PLACEMENT_SURFACES,
   declineFeeAmount,
+  isPlacementSurface,
   placementOutcomeFromStatus,
   placementTransactionId,
   splitPlacementPayment,
@@ -185,7 +186,7 @@ const HOLD_KINDS = ['holdFee', 'holdPrincipal'] as const;
 
 /** Where the unfunded-settlement gauge stops counting. See the gauge's own note. */
 const UNFUNDED_GAUGE_CEILING = 1_000;
-const PAYOUT_KINDS = [
+export const PAYOUT_KINDS = [
   'toOwner',
   'toSeller',
   'toPlatform',
@@ -216,6 +217,9 @@ const LEDGER_TEXT: Record<PlacementSurface, Record<PlacementTransactionKind, str
     // them apart — so naming one of them here would be wrong on the other three.
     principalToPlacer: 'Refund: your sticker placement',
     feeToPlacer: 'Refund: sticker placement fee',
+    // Neither of these two reaches Buzz — the platform legs keep the money in
+    // escrow and record a receipt instead — so this text is what a row WOULD say
+    // if that ever changes, and nothing renders it today.
     toPlatform: 'Platform share of a sticker placement',
     forfeit: 'Forfeited sticker placement',
   },
@@ -242,10 +246,9 @@ const placementLedgerEntry = (
   kind: PlacementTransactionKind,
   target: { surface: string; targetType: string | null; targetId: number | null }
 ) => ({
-  // A surface missing from the table cannot reach here — PLACEMENT_SURFACES
-  // denies one everywhere — but this is a money path, and a dull row beats a
-  // TypeError that strands the leg.
-  description: LEDGER_TEXT[target.surface as PlacementSurface]?.[kind] ?? 'Placement',
+  // Guarded rather than cast: `surface` is a TEXT column, and this is a money
+  // path where a dull row beats a TypeError that strands the leg.
+  description: isPlacementSurface(target.surface) ? LEDGER_TEXT[target.surface][kind] : 'Placement',
   details:
     target.targetType === 'image' && target.targetId
       ? { entityType: 'Image', entityId: target.targetId }


### PR DESCRIPTION
Closes ClickUp [868kuagz3](https://app.clickup.com/t/868kuagz3). Reported by demiandei and boerboer, raised by Ellie at standup: *"Users don't understand any of that. That's more dev speak."*

## The problem

Every placement escrow leg wrote its internal leg name and the raw placement id into the Buzz transaction description, so a creator paid for a sticker on their image saw this in their Buzz history:

```
Aug 20, 2026   FEE  YELLOW   +50
Placement 76 (toOwner)
```

`toOwner` is an escrow leg, `76` is a row id, and the row never said which image it was about — the one detail that would make it mean anything. Users could be shown any of `toOwner`, `toSeller`, `toPlatform`, `feeToOwner`, `principalToPlacer`, `feeToPlacer`, `forfeit`, `holdFee` or `holdPrincipal`.

## What changed

Each leg now writes copy addressed to whoever is reading the row, keyed by surface as well as leg, and carries the placement's target as `entityType`/`entityId`.

| leg | now reads (sticker surface) |
|---|---|
| `holdPrincipal` | Sticker placement, held while the creator decides |
| `holdFee` | Sticker placement fee, held while the creator decides |
| `toOwner` | Someone placed a sticker on your image |
| `feeToOwner` | Fee for a sticker you declined |
| `toSeller` | Someone used your sticker |
| `principalToPlacer` | Refund: your sticker placement |
| `feeToPlacer` | Refund: sticker placement fee |

`remixGallery` gets its own column of the same table, because the two surfaces are different events to the reader: a sticker is put on your image, a remix is added to your gallery.

**The refund copy deliberately names no reason.** One refund path serves a decline, an expiry, an owner removal and a cosmetic takedown, and the leg cannot tell them apart — so naming one would be wrong on the other three.

**No id in the copy, and no new query for the link.** `/user/transactions` already renders a "View Image" link from `details.entityType` + `details.entityId`; placements simply never populated them. `targetType` and `targetId` are on rows every write path already holds — the hold path reads them by widening the `select` of a `findUnique` it already makes — so this adds no lookup on any path, list views included.

The internal leg names are unchanged everywhere they identify money: the `PlacementTransaction` row, the external transaction id, and every recovery query (`sweepUnpaidLegs`, `listExhaustedLegs`, `heldAmountsFor`).

## Audit — where these strings actually surface

Three renderers, one source, and they do not share code:

1. **`/user/transactions`** — the ticket's screenshot. Renders `description` verbatim and owns the "View Image" link this PR feeds.
2. **Buzz dashboard "Recent Transactions"** — shows `description` only for `Reward` and `Purchase`. Placement legs are `Fee`, so it shows the bare word "Fee" and no description at all. **Unchanged here** — surfacing it means letting every other `Fee` description through too.
3. **App Blocks `blocks.getMyBuzzTransactions`** — third-party app UIs get the same `description` plus an allowlisted `details`, so they inherit the fix.

4. **The transactions CSV export** (`/api/download/user-transactions`, `buzz.service.ts:690-712`) - writes `row.description` verbatim into a column *and* builds an `entityUrl` from `parseBuzzTransactionDetails`. It was emitting the raw leg names too, and it picks up both the new copy and the `/images/<id>` URL with no code change. **I missed this one on the first pass; the intent review caught it.**

No email or digest renders these. **Notification copy was already fine** ("X wants to place a sticker on your image", linking to `/images/<id>`) — the raw leg names only ever existed in the Buzz ledger.

## One thing not verified

`details` reaches the Buzz service on all three paths — `BuzzMultiTransactionInput` and `BuzzRefundMultiTransactionInput` both carry it, and the payout path uses the same `createBuzzTransaction` route tips already use. Whether the external service **persists** it for multi-account and refund rows I have not exercised, because doing so means spending real Buzz against production. If it drops them, the hold and refund rows still get the new copy and lose only the link.

## Existing rows are not backfilled

This is write-time only. The rows that prompted the ticket keep their old text, since the ledger lives in ClickHouse. Worth saying when the ticket is closed, so "fixed" and the original screenshot do not contradict each other.

## Tests

Eight new cases in `placement-escrow.service.test.ts`. The per-leg assertions cover the legs that exist today; the sweep at the end is what guards a leg added later, since a hand-listed assertion only covers what someone remembered to write down.

Revert-checked rather than assumed green — putting the old wording back fails with `expected 'Placement (toOwner)' not to contain 'toOwner'`.

**Second commit fixes two tests that could not fail**, both found by review:

- The sweep's non-vacuity guard (`length > 1`) was already satisfied by the two hold rows *before* the settlement ran, so a settlement that paid nothing swept two known-clean strings and passed. Each case now pins the exact row count for its action. Verified by emptying the payout loop: `expected [ ...(2) ] to have a length of 3 but got 2`, on all four cases.
- The `placement.findUnique` double ignored `select`, so reverting the widened projection kept all 93 tests green while production would have lost the link on the hold rows. The double now projects `select`. Verified: reverting the select gives `expected undefined to deeply equal { entityType: 'Image', entityId: 99 }`.

The sweep also derives its leg names from `PLACEMENT_HOLD_KINDS` + `PAYOUT_KINDS` rather than a hand-written copy of the same nine, and covers `toSeller`. `toPlatform` and `forfeit` are deliberately not swept: they write no Buzz row at all - the platform legs keep the money in escrow and record a receipt - so their copy renders nowhere today, which the table now says.

Reviewed by the five `civitai-review` lanes; all five reported. Perf confirmed the no-extra-query claim against prod - `EXPLAIN` on both selects gave the same plan, the same buffers and an unchanged cost.

## Notification thumbnails

Folded in on Justin's call. A notification that points at an image said so only in words; the row now carries the image.

- The panel collects `details.imageId` off its notifications and resolves them in **one** batched `image.getEntitiesCoverImage` call. That key is what every processor pointing at an image already writes, so a type added later is covered without being listed anywhere.
- **Resolved on open, never stamped into the notification.** `details` is frozen at write time, so a url and `nsfwLevel` stored there keep rendering an image that has since been deleted, moderated or re-levelled, at the level it had the day the row was written. That is a browsing-level gate that silently stops being correct.
- **Two gates, because they are two different questions.** `useApplyHiddenPreferences` decides whether the viewer may see the image at all - one that fails is dropped, not blurred, so the row falls back to its icon and the shape of the fallback discloses nothing. `ImageGuard2` then decides whether they asked to see it uncovered. Those sets are not the same: with blur on, the mask covers every mature level **including the ones inside the viewer's own browsing level**. The first version of this shipped only the first gate, which would have rendered a mature image plainly in a dropdown over whatever page the viewer was on.

### Tests

The gate is the only gate on this path - the `Image` arm of `getEntitiesCoverImage` is an identity select - so it is tested rather than assumed:

- `useNotificationThumbnails.test.ts` leaves `useApplyHiddenPreferences` **real** and mocks only what it reads from context. Positive control, browsing-level drop, hidden-tag drop (the only thing pinning the hand-rolled `tags` -> `tagIds` map), query shape. Verified by gutting the filter two ways.
- `NotificationThumbnail.test.ts` asserts the cover where the decision is made. The hook suite could not: deleting `ImageGuard2` left it green.
- Both are `.test.ts`. The `unit` project globs `src/**/*.test.ts`, so the `.tsx` the second one started as collected **zero tests** and printed a run that reads as a pass.

### Known, not addressed here

- `getEntitiesCoverImage` returns `i.meta` unconditionally, where every other read path in that file withholds it when `hideMeta` is set. Pre-existing and in the endpoint; this PR adds a caller.
- The fetch -> `tagIds` -> hidden-preferences block is now a third copy of the one in `ShowcaseSection`, and the `tagIds` shim is hand-rolled in seven places with no shared helper. The extraction is right and belongs in its own change, not in a copy fix.
- `populateNotificationDetails` already does server-side batched enrichment for notifications, so there are now two mechanisms. The gating half has to stay on the client either way, and moving it would give up the "any type carrying an imageId is covered" property - a decision, not a mechanical fix.

typecheck 0 errors · eslint clean on both files · unit suite 19767 passed / 0 failed (`blocks.router.workflow.test.ts` collected 350, so the worktree submodule is real)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

