### PR TITLE
fix(placement): say who the free placement is actually free for

### DIFF
--- a/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
@@ -383,7 +383,12 @@ describe('a gallery that takes free submissions and refuses paid ones', () => {
     // worse than the paid button this replaced.
     await expect.element(page.getByText(/once per gallery/i)).toBeInTheDocument();
     // Not a claim about spending, on a path that cannot be pressed.
-    await expect.element(page.getByText(/spends a free placement/i)).not.toBeInTheDocument();
+    //
+    // ⚠️ Matched against the note's CURRENT wording. This assertion is a
+    // negative, so a reworded note turns it green forever rather than red once —
+    // it went vacuous exactly that way when the note gained the shared-allowance
+    // clause. If you change the copy, change this with it.
+    await expect.element(page.getByText(/spends your free placement/i)).not.toBeInTheDocument();
   });
 
   /**

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -15,6 +15,7 @@ import clsx from 'clsx';
 import { useState } from 'react';
 import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
 import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
+import { SHARED_ALLOWANCE_NOTE } from '~/components/Sticker/free-offer';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { useQueryImages } from '~/components/Image/image.utils';
 import { remixSubmitPickerFilters } from '~/components/RemixGallery/remix-gallery.utils';
@@ -524,11 +525,16 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
               {/* No number and no reset time written here. The allowance is a
                   server-side rule and both of its facts already come back from
                   `getFreePlacementAllowance`; a sentence that spells either one
-                  out is a claim this file cannot keep true. */}
+                  out is a claim this file cannot keep true.
+
+                  What the allowance is SHARED with is not such a claim — it is a
+                  product rule, it is the one readers were getting wrong, and it
+                  comes from the same constant the sticker surface uses so the
+                  two cannot describe different budgets. */}
               {method === 'free' && freeAvailable && (
                 <Text size="xs" c="dimmed">
-                  This spends a free placement from today&apos;s allowance, and it is spent even if
-                  the creator declines.
+                  This spends your free placement for today &mdash; {SHARED_ALLOWANCE_NOTE} &mdash;
+                  and it is spent even if the creator declines.
                 </Text>
               )}
             </Stack>

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -501,11 +501,13 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                 data={[
                   {
                     value: 'free',
-                    // Always "needs review" on this surface: a gallery places
-                    // arbitrary media on someone else's page, so `auto` is
-                    // refused for it in three places. Written out rather than
-                    // branched on the mode, which cannot be anything else here.
-                    label: 'Free · needs review',
+                    // 🔴 Just "Free". It read `Free · needs review` beside a
+                    // plain `N Buzz`, which says the paid one does not — and on
+                    // this surface EVERY submission goes to the creator, free or
+                    // paid, because a gallery places arbitrary media on someone
+                    // else's page and `auto` is refused for it in three places.
+                    // The review is said once, below, where it applies to both.
+                    label: 'Free',
                     disabled: !freeAvailable,
                   },
                   {

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -15,7 +15,7 @@ import clsx from 'clsx';
 import { useState } from 'react';
 import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
 import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
-import { SHARED_ALLOWANCE_NOTE } from '~/components/Sticker/free-offer';
+import { SHARED_ALLOWANCE_NOTE } from '~/shared/utils/placement';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { useQueryImages } from '~/components/Image/image.utils';
 import { remixSubmitPickerFilters } from '~/components/RemixGallery/remix-gallery.utils';

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { SHARED_ALLOWANCE_NOTE } from '~/shared/utils/placement';
 import type { RemixGalleryItem } from '~/components/RemixGallery/remix-gallery.utils';
 import {
   dedupeGalleryItems,
@@ -447,5 +448,29 @@ describe('remixGalleryModerating', () => {
     expect(
       remixGalleryModerating({ ...base, ownerKnown: false, isOwner: true, asModerator: true })
     ).toBe(false);
+  });
+});
+
+/**
+ * 🔴 The cross-surface guard, on the surface that would drift silently.
+ *
+ * The whole point of one shared constant is that a placer who spends their day
+ * on a remix gallery meets the same description of the budget on the sticker
+ * side. The sticker half is pinned in `free-offer.test.ts`; without this, the
+ * remix half could drop the clause and every test in the repo would stay green.
+ */
+describe('the remix surface names the shared budget too', () => {
+  it('says what the allowance is shared with when it is spent', () => {
+    const spent = freeSubmissionOffer({
+      verified: true,
+      freeSlots: 1,
+      freeSlotsRemaining: 1,
+      allowanceRemaining: 0,
+      usedHere: false,
+      resetsAt: new Date('2026-08-21T00:00:00.000Z'),
+      paidOpen: true,
+    });
+
+    expect(spent.reason).toContain(SHARED_ALLOWANCE_NOTE);
   });
 });

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -1,3 +1,4 @@
+import { SHARED_ALLOWANCE_NOTE } from '~/components/Sticker/free-offer';
 import type { ImageGetInfinite } from '~/types/router';
 import { ImageSort } from '~/server/common/enums';
 import { PLACEMENT_SURFACES } from '~/shared/utils/placement';
@@ -177,10 +178,15 @@ export function freeSubmissionOffer({
   // a person sees, so a shared module would have to hold the ordering too.
   // Change this wording and change its twin. Its twin still spells out "midnight
   // UTC" rather than reading `resetsAt`; that is the same fix as this one.
+  //
+  // The one clause both twins now take from one place is what the allowance is
+  // SHARED with — `SHARED_ALLOWANCE_NOTE`. That is the fact people were getting
+  // wrong, so it is the one that cannot be allowed to drift between two
+  // surfaces; the orderings stay separate for the reason above.
   if (allowanceRemaining <= 0)
     return {
       available: false,
-      reason: `You've used today's free placement. It comes back at ${allowanceResetLabel(
+      reason: `You've used today's free placement — ${SHARED_ALLOWANCE_NOTE}. It comes back at ${allowanceResetLabel(
         resetsAt
       )}.`,
     };

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -1,7 +1,6 @@
-import { SHARED_ALLOWANCE_NOTE } from '~/components/Sticker/free-offer';
 import type { ImageGetInfinite } from '~/types/router';
 import { ImageSort } from '~/server/common/enums';
-import { PLACEMENT_SURFACES } from '~/shared/utils/placement';
+import { PLACEMENT_SURFACES, SHARED_ALLOWANCE_NOTE } from '~/shared/utils/placement';
 import { REMIX_GALLERY_ROW_WIDTH } from '~/shared/utils/remix-gallery';
 
 /**

--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -290,31 +290,40 @@ describe('what a draft sends when it is placed', () => {
 });
 
 /**
- * The mode belongs to the free option, not to the button upstream, so it has to
- * be readable here — and the two modes have to read differently or the placer
- * cannot tell an instant placement from one that spends their day on a review
- * they may lose.
+ * The free option is a price; the review is a property of the SPACE.
+ *
+ * 🔴 The option used to read `Free · instant` / `Free · needs review` beside a
+ * plain `100 Buzz`, which says the paid one does not get reviewed — and on a
+ * review space both do. Justin, on seeing it: "it makes it seem like the other
+ * one's not going to need review". So the segment says `Free`, and what a
+ * decline costs is said once, under the button that spends the placement, where
+ * it applies to whichever option is selected.
  */
-describe('the free option carries the mode', () => {
-  test('says instant on an auto-accept space, with no review caveat', async () => {
+describe('the free option is a price, not a process', () => {
+  test('says nothing about review on an auto-accept space, and warns of nothing', async () => {
     await renderDraft({ instant: true });
 
-    await expect.element(page.getByText('Free · instant')).toBeInTheDocument();
-    expect(page.getByText(/spent even if they decline/).elements()).toHaveLength(0);
+    // `exact`, because "Place free" on the button below also contains the word.
+    await expect.element(page.getByText('Free', { exact: true })).toBeInTheDocument();
+    // Nothing to warn about: an auto space places it live, so there is no
+    // decline that could take the day with it.
+    expect(page.getByText(/Spends your free placement/).elements()).toHaveLength(0);
   });
 
-  test('says needs review, and warns the day is spent regardless', async () => {
+  test('says the same on a review space, and warns under the button instead', async () => {
     await renderDraft({ instant: false });
 
-    await expect.element(page.getByText('Free · needs review')).toBeInTheDocument();
-    await expect.element(page.getByText(/spent even if they decline/)).toBeInTheDocument();
+    await expect.element(page.getByText('Free', { exact: true })).toBeInTheDocument();
+    // The label does not carry the mode; this line does, and it says the thing
+    // that actually costs the reader something.
+    await expect.element(page.getByText(/Spends your free placement/)).toBeInTheDocument();
   });
 
   test('offers no choice at all where there is no free offer', async () => {
     await renderDraft(null);
 
-    expect(page.getByText(/^Free ·/).elements()).toHaveLength(0);
     expect(page.getByRole('button', { name: 'Place free' }).elements()).toHaveLength(0);
+    expect(page.getByText(/Spends your free placement/).elements()).toHaveLength(0);
   });
 
   /**

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -832,20 +832,10 @@ export function DraftSticker({
             value={payMode}
             onChange={(value) => setPayChoice(value as 'free' | 'paid')}
             data={[
-              { label: freeOptionLabel(freeOffer.instant), value: 'free' },
+              { label: freeOptionLabel(), value: 'free' },
               { label: `${numberWithCommas(price)} Buzz`, value: 'paid' },
             ]}
           />
-        )}
-
-        {/* Only where it is true. On an auto-accept space the placement is live
-            the moment it is made, so there is no decline to warn about. */}
-        {placingFree && freeOffer && !freeOffer.instant && (
-          <div className="max-w-[240px] whitespace-normal rounded-lg bg-black/80 px-2 py-1 text-center">
-            <Text size="xs" c="gray.3" className="leading-tight">
-              {FREE_REVIEW_CAVEAT}
-            </Text>
-          </div>
         )}
 
         {draft.purchase && effectiveMode === 'pack' && draft.purchase.pack ? (
@@ -905,6 +895,22 @@ export function DraftSticker({
             loading={place.isPending}
             onPerformTransaction={() => place.mutate(placementInput())}
           />
+        )}
+
+        {/* Under the button, not above it: it is a consequence of pressing, and
+            above the control it read as a description of the option. Same chip
+            shape and same triangle as the second-payment warning below, because
+            they are the same kind of thing — a cost you meet by pressing.
+
+            Only where it is true. On an auto-accept space the placement is live
+            the moment it is made, so there is no decline to warn about. */}
+        {placingFree && freeOffer && !freeOffer.instant && (
+          <div className="flex items-center gap-1 rounded-full bg-black/80 px-2 py-0.5">
+            <IconAlertTriangleFilled size={12} className="shrink-0 text-yellow-4" />
+            <Text size="xs" c="gray.3" className="leading-tight">
+              {FREE_REVIEW_CAVEAT}
+            </Text>
+          </div>
         )}
 
         {/* The second payment, said before the first one is made. Someone who

--- a/src/components/Sticker/StickerCountChip.browser.test.tsx
+++ b/src/components/Sticker/StickerCountChip.browser.test.tsx
@@ -28,15 +28,26 @@ const chip = async () => {
 const backgroundOf = (element: Element) => getComputedStyle(element).backgroundColor;
 
 describe('StickerCountChip', () => {
-  test('says the word at zero, and never the number', async () => {
+  test('shows the icon alone at zero — no word, and never the number', async () => {
     renderWithProviders(
-      <StickerCountChip count={0} revealed={false} tooltip="Place a sticker" onClick={vi.fn()} />
+      <StickerCountChip
+        count={0}
+        revealed={false}
+        ariaLabel="No stickers yet"
+        tooltip="Place a sticker"
+        onClick={vi.fn()}
+      />
     );
 
     const text = (await chip()).textContent;
-    expect(text).toContain('stickers');
-    // A count of zero rendered as a numeral is the regression this guards.
+    // The word "stickers" was the widest thing in a row that has to fit beside
+    // the reaction buttons on a phone, and the icon already says it.
+    expect(text).not.toContain('sticker');
+    // A count of zero rendered as a numeral is the older regression this guards.
     expect(text).not.toContain('0');
+    // 🔴 But the accessible name still spells it out. Dropping a word to save
+    // space is a layout decision and must not reach a screen reader.
+    expect(page.getByRole('button', { name: 'No stickers yet' }).elements()).toHaveLength(1);
   });
 
   test('says the number when there are stickers', async () => {
@@ -47,25 +58,23 @@ describe('StickerCountChip', () => {
     expect((await chip()).textContent).toContain('3');
   });
 
-  test('spells the count out only where the row has room, and gets the singular right', async () => {
+  test('renders the bare number, whatever the count', async () => {
     renderWithProviders(
       <>
-        <StickerCountChip count={1} revealed={false} showLabel tooltip="Show" onClick={vi.fn()} />
-        <StickerCountChip count={4} revealed={false} showLabel tooltip="Show" onClick={vi.fn()} />
-        <StickerCountChip count={7} revealed={false} tooltip="Show" onClick={vi.fn()} />
+        <StickerCountChip count={1} revealed={false} tooltip="Show" onClick={vi.fn()} />
+        <StickerCountChip count={4} revealed={false} tooltip="Show" onClick={vi.fn()} />
       </>
     );
 
-    // Anchor the wait on the unlabelled chip: its text is "7" whether or not
-    // `showLabel` works, and no other chip here renders that. Awaiting a
-    // labelled one would spend the full 15 s matcher budget on precisely the
-    // regression this test exists to catch, and anchoring on a name two chips
-    // could share turns the same failure into a strict-mode retry.
-    await expect.element(page.getByRole('button', { name: /^7$/ })).toBeInTheDocument();
-
-    expect(page.getByRole('button', { name: /^1 sticker$/ }).elements()).toHaveLength(1);
-    expect(page.getByRole('button', { name: /^1 stickers$/ }).elements()).toHaveLength(0);
+    // No singular/plural to get right any more, because there is no noun: the
+    // chip is the icon and the number, and nothing else.
+    // The FACE of the chip is the number alone; the accessible name still
+    // carries the noun, and gets the singular right.
+    await expect.element(page.getByRole('button', { name: /^1 sticker$/ })).toBeInTheDocument();
     expect(page.getByRole('button', { name: /^4 stickers$/ }).elements()).toHaveLength(1);
+    expect(page.getByRole('button', { name: /^1 stickers$/ }).elements()).toHaveLength(0);
+    // Nothing rendered says it, though — that is the space this saves.
+    expect(page.getByText(/sticker/i).elements()).toHaveLength(0);
   });
 
   /**
@@ -88,9 +97,9 @@ describe('StickerCountChip', () => {
     // Anchored on the counted chip, whose name survives any regression in the
     // empty state — anchoring on "stickers" would make a lost empty state a 15 s
     // poll here instead of the millisecond failure it already is above.
-    await expect.element(page.getByRole('button', { name: /^3$/ })).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: /^3 stickers$/ })).toBeInTheDocument();
     const empty = backgroundOf(page.getByRole('button', { name: /^stickers$/ }).element());
-    const counted = backgroundOf(page.getByRole('button', { name: /^3$/ }).element());
+    const counted = backgroundOf(page.getByRole('button', { name: /^3 stickers$/ }).element());
 
     expect(empty).not.toBe(counted);
     expect(empty).not.toBe('rgba(0, 0, 0, 0)');
@@ -148,13 +157,19 @@ describe('StickerCountChip', () => {
       </>
     );
 
-    await expect.element(page.getByRole('button', { name: /^3$/ })).toBeInTheDocument();
-    expect(page.getByRole('button', { name: /^3$/ }).element().getAttribute('data-variant')).toBe(
-      'light'
-    );
-    expect(page.getByRole('button', { name: /^5$/ }).element().getAttribute('data-variant')).toBe(
-      'subtle'
-    );
+    await expect.element(page.getByRole('button', { name: /^3 stickers$/ })).toBeInTheDocument();
+    expect(
+      page
+        .getByRole('button', { name: /^3 stickers$/ })
+        .element()
+        .getAttribute('data-variant')
+    ).toBe('light');
+    expect(
+      page
+        .getByRole('button', { name: /^5 stickers$/ })
+        .element()
+        .getAttribute('data-variant')
+    ).toBe('subtle');
   });
 
   test('paints the empty state as its own thing, not as the revealed state', async () => {
@@ -165,7 +180,7 @@ describe('StickerCountChip', () => {
       </>
     );
 
-    await expect.element(page.getByRole('button', { name: /^5$/ })).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: /^5 stickers$/ })).toBeInTheDocument();
     const empty = page.getByRole('button', { name: /^stickers$/ }).element() as HTMLElement;
 
     expect(empty.getAttribute('data-variant')).toBe('light');

--- a/src/components/Sticker/StickerCountChip.tsx
+++ b/src/components/Sticker/StickerCountChip.tsx
@@ -26,11 +26,16 @@ export function useStickerInviteStyle() {
  * The sticker entry chip, shared by the image detail view and feed cards so the
  * empty state is written once rather than once per surface.
  *
- * A count of zero reads as an invitation rather than a fact: the word instead of
- * the number, under the place button's tint instead of the reaction row's. Only
- * the detail view ever passes zero — a card with no stickers renders nothing at
- * all, because a card offers no way to place one and would be advertising an
- * action it does not have.
+ * **The icon and the number, and nothing else.** The word "stickers" was the
+ * widest thing in a row that has to fit beside the reaction buttons on a phone,
+ * and the icon already says it. A count of zero is the icon alone, wearing the
+ * place button's tint instead of the reaction row's — an invitation rather than
+ * a fact. Only the detail view ever passes zero: a card with no stickers renders
+ * nothing at all, because a card offers no way to place one and would be
+ * advertising an action it does not have.
+ *
+ * The accessible name still spells it out. Losing a word to save space is a
+ * layout decision, and it must not reach a screen reader.
  *
  * Deliberately just the button: each surface wraps it in whatever its own row
  * needs — `Button.Group` beside the plus on the detail view, nothing on a card —
@@ -39,7 +44,6 @@ export function useStickerInviteStyle() {
 export function StickerCountChip({
   count,
   revealed,
-  showLabel,
   tooltip,
   ariaLabel,
   onClick,
@@ -48,8 +52,6 @@ export function StickerCountChip({
 }: {
   count: number;
   revealed: boolean;
-  /** Spell out "3 stickers" rather than "3", where the row has room for it. */
-  showLabel?: boolean;
   /** Omit for no tooltip at all — see the bar, which now says nothing on hover. */
   tooltip?: string;
   ariaLabel?: string;
@@ -78,19 +80,35 @@ export function StickerCountChip({
       variant={empty || revealed ? 'light' : 'subtle'}
       color={empty ? 'yellow' : 'gray'}
       onClick={onClick}
-      aria-label={ariaLabel}
-      leftSection={<IconSticker size={16} />}
+      // 🔴 The name has to survive the word being dropped from the face of the
+      // chip. Without this the accessible name falls back to the text content,
+      // which is now a bare numeral — "3" — or, at zero, nothing at all.
+      aria-label={
+        ariaLabel ?? (empty ? 'stickers' : `${count} ${count === 1 ? 'sticker' : 'stickers'}`)
+      }
       {...restButtonProps}
       style={{ ...providedStyle, ...(empty ? inviteStyle : null) }}
-      className={clsx(providedClassName, className)}
+      // Hover has to be a filter, not a colour: the row hands these buttons an
+      // inline background, and an inline style beats every CSS `:hover` rule
+      // Mantine ships — which is why the whole row stopped responding once the
+      // tint arrived.
+      className={clsx(
+        providedClassName,
+        className,
+        'transition-[filter] duration-150 hover:brightness-110'
+      )}
     >
-      <Text size="xs" fw={600}>
-        {empty
-          ? 'stickers'
-          : showLabel
-          ? `${count} ${count === 1 ? 'sticker' : 'stickers'}`
-          : count}
-      </Text>
+      {/* The icon sits in the body rather than in `leftSection`, which reserves
+          a gap beside itself — at zero there is nothing to the right of it and
+          the chip would carry a hole where the word used to be. */}
+      <IconSticker size={16} className={clsx(!empty && 'mr-1')} />
+      {/* No text at zero: the icon IS the invitation, and the tint says the
+          rest. A number only appears once there is one. */}
+      {!empty && (
+        <Text size="xs" fw={600}>
+          {count}
+        </Text>
+      )}
     </Button>
   );
 

--- a/src/components/Sticker/StickerCountChip.tsx
+++ b/src/components/Sticker/StickerCountChip.tsx
@@ -50,7 +50,8 @@ export function StickerCountChip({
   revealed: boolean;
   /** Spell out "3 stickers" rather than "3", where the row has room for it. */
   showLabel?: boolean;
-  tooltip: string;
+  /** Omit for no tooltip at all — see the bar, which now says nothing on hover. */
+  tooltip?: string;
   ariaLabel?: string;
   onClick: (event: React.MouseEvent) => void;
   // Whatever the surface's `ReactionSettingsProvider` hands its reaction
@@ -70,28 +71,37 @@ export function StickerCountChip({
     ...restButtonProps
   } = buttonProps ?? {};
 
-  return (
+  const chip = (
+    <Button
+      size="compact-sm"
+      radius="xl"
+      variant={empty || revealed ? 'light' : 'subtle'}
+      color={empty ? 'yellow' : 'gray'}
+      onClick={onClick}
+      aria-label={ariaLabel}
+      leftSection={<IconSticker size={16} />}
+      {...restButtonProps}
+      style={{ ...providedStyle, ...(empty ? inviteStyle : null) }}
+      className={clsx(providedClassName, className)}
+    >
+      <Text size="xs" fw={600}>
+        {empty
+          ? 'stickers'
+          : showLabel
+          ? `${count} ${count === 1 ? 'sticker' : 'stickers'}`
+          : count}
+      </Text>
+    </Button>
+  );
+
+  // No tooltip, no wrapper. The bar deliberately says nothing on hover now — the
+  // free hint is a popover everyone can see, and a hover-only price line was
+  // telling a phone nothing at all.
+  return tooltip ? (
     <Tooltip label={tooltip} withArrow>
-      <Button
-        size="compact-sm"
-        radius="xl"
-        variant={empty || revealed ? 'light' : 'subtle'}
-        color={empty ? 'yellow' : 'gray'}
-        onClick={onClick}
-        aria-label={ariaLabel}
-        leftSection={<IconSticker size={16} />}
-        {...restButtonProps}
-        style={{ ...providedStyle, ...(empty ? inviteStyle : null) }}
-        className={clsx(providedClassName, className)}
-      >
-        <Text size="xs" fw={600}>
-          {empty
-            ? 'stickers'
-            : showLabel
-            ? `${count} ${count === 1 ? 'sticker' : 'stickers'}`
-            : count}
-        </Text>
-      </Button>
+      {chip}
     </Tooltip>
+  ) : (
+    chip
   );
 }

--- a/src/components/Sticker/StickerPlacementBar.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementBar.browser.test.tsx
@@ -243,7 +243,6 @@ describe('StickerPlacementBar — free slots', () => {
     signedIn: true,
   };
 
-  const placeButton = () => page.getByRole('button', { name: /^Place a sticker/ });
   // By exact name, because the comparison below renders twice in one test and
   // both buttons stay mounted — a pattern locator resolves to two elements there
   // and fails on strict mode rather than on the property being tested.
@@ -377,98 +376,83 @@ describe('StickerPlacementBar — free slots', () => {
    * "explains which scarcity ran out" fail independently — a tooltip that quotes
    * the price and explains nothing is exactly what shipped.
    */
-  test('explains a spent allowance, and names what it is shared with', async () => {
+  /**
+   * 🔴 The hint replaced a tooltip, and the difference is who can see it.
+   *
+   * The bar used to explain itself on hover — which meant a phone was told
+   * nothing, in the states where knowing matters most. What is left is a
+   * popover: on screen without a pointer, dismissable by anyone, and shown ONLY
+   * where there is a free placement to take. The reasons free is unavailable
+   * moved to the tray, at the point the choice is made.
+   */
+  test('announces a free sticker without needing a pointer', async () => {
+    localStorage.removeItem('sticker-free-hint-dismissed');
     Object.assign(queryState, settled, {
       freeSlots: 4,
       freeSlotsRemaining: 2,
-      allowanceRemaining: 0,
-    });
-    await renderBar();
-
-    await placeButton().hover();
-    // The sharing is the fact readers were getting wrong: spend it on a remix
-    // gallery and the sticker surface had no explanation for where it went.
-    await expect
-      .element(page.getByText(/shared between stickers and remix galleries/))
-      .toBeInTheDocument();
-    await expect.element(page.getByText(/100 Buzz/)).toBeInTheDocument();
-  });
-
-  test('distinguishes a held slot from a creator who takes none', async () => {
-    Object.assign(queryState, settled, {
-      freeSlots: 4,
-      freeSlotsRemaining: 0,
       allowanceRemaining: 1,
     });
     await renderBar();
 
-    await placeButton().hover();
-    // Worth saying precisely because it lifts by itself: a decline returns the
-    // slot, so this reader has a reason to come back to THIS image.
-    await expect.element(page.getByText(/comes back if the creator declines/)).toBeInTheDocument();
+    // No hover anywhere in this test. That is the point of it.
+    await expect.element(page.getByText('You have a free sticker today')).toBeInTheDocument();
   });
 
-  test('quotes the price and promises nothing while the allowance is unknown', async () => {
+  test.each([
+    ['the allowance is spent', { freeSlots: 4, freeSlotsRemaining: 2, allowanceRemaining: 0 }],
+    ['the slot here is held', { freeSlots: 4, freeSlotsRemaining: 0, allowanceRemaining: 1 }],
+    ['the creator takes none', { freeSlots: 0, freeSlotsRemaining: 0, allowanceRemaining: 1 }],
+    [
+      'a free one was already used here',
+      { freeSlots: 4, freeSlotsRemaining: 2, allowanceRemaining: 1, usedHere: true },
+    ],
+  ])('says nothing at all when %s', async (_name, state) => {
+    localStorage.removeItem('sticker-free-hint-dismissed');
+    Object.assign(queryState, settled, state);
+    await renderBar();
+
+    // A popover that appears to tell you what you cannot have is an
+    // interruption on somebody else's image.
+    expect(page.getByText(/You have/).elements()).toHaveLength(0);
+    // The button is still there and still opens the tray, which is where the
+    // reason lives now.
+    expect(page.getByRole('button', { name: /^Place a sticker/ }).elements()).toHaveLength(1);
+  });
+
+  test('stays dismissed for the day it is about', async () => {
+    localStorage.removeItem('sticker-free-hint-dismissed');
     Object.assign(queryState, settled, {
       freeSlots: 4,
       freeSlotsRemaining: 2,
-      allowanceRemaining: undefined,
+      allowanceRemaining: 1,
     });
     await renderBar();
 
-    await placeButton().hover();
-    await expect.element(page.getByText('Place a sticker · 100 Buzz')).toBeInTheDocument();
-    expect(page.getByText(/\bfree\b/i).elements()).toHaveLength(0);
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+    await expect.element(page.getByText('You have a free sticker today')).not.toBeInTheDocument();
+
+    // And it does not come back on the next render, which is what "dismiss"
+    // means to the person who pressed it.
+    await renderBar();
+    expect(page.getByText('You have a free sticker today').elements()).toHaveLength(0);
   });
 
   /**
-   * The cost control, asserted rather than assumed.
-   *
-   * The whole design rests on the allowance being ONE query for a page — it is a
-   * property of the person, not of the image. The bar passes an `enabled` flag
-   * so a surface where the answer cannot matter never asks; this pins that the
-   * flag is actually passed, and passed true where it should be, so the negative
-   * is not a test that cannot fail.
+   * Keyed on the UTC day rather than forever, because what it announces is
+   * itself daily. A permanent dismissal would mean the free tier introduces
+   * itself exactly once per person, ever — and tomorrow's allowance is news
+   * again.
    */
-  /**
-   * 🔴 The rule the bar could not see until it took the per-image query.
-   *
-   * Free is once EVER per image, and the sticker decline path makes the gap
-   * permanent rather than a day long: free-place, the creator declines, the
-   * image's slot returns and the allowance resets — so a chip reading the
-   * allowance alone advertises "1 free" on that image every day afterwards, to
-   * the one person who can never take it.
-   */
-  test('says nothing about free on an image the viewer has already used one on', async () => {
+  test("comes back once yesterday's dismissal is stale", async () => {
+    localStorage.setItem('sticker-free-hint-dismissed', '2020-01-01');
     Object.assign(queryState, settled, {
       freeSlots: 4,
       freeSlotsRemaining: 2,
       allowanceRemaining: 1,
-      usedHere: true,
     });
     await renderBar();
 
-    // `\d+ free` is the label's shape, not the whole word: unanchored `/free/i`
-    // also matches wrapper elements whose subtree text contains it, and `/free$/`
-    // would let a regression to "1 free left" through.
-    expect(page.getByText(/\d+ free/).elements()).toHaveLength(0);
-  });
-
-  test('explains that one, rather than only withholding the label', async () => {
-    Object.assign(queryState, settled, {
-      freeSlots: 4,
-      freeSlotsRemaining: 2,
-      allowanceRemaining: 1,
-      usedHere: true,
-    });
-    await renderBar();
-
-    await placeButton().hover();
-    // The tray's own sentence, because the bar now defers to the same ladder —
-    // one wording per fact, which is what the tooltip used to break.
-    await expect
-      .element(page.getByText(/already used a free sticker on this image/))
-      .toBeInTheDocument();
+    await expect.element(page.getByText('You have a free sticker today')).toBeInTheDocument();
   });
 
   test('asks for the standing exactly once where the viewer can place', async () => {

--- a/src/components/Sticker/StickerPlacementBar.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementBar.browser.test.tsx
@@ -47,12 +47,14 @@ const queryState = {
    * then adding "free" a beat later on every card in a feed.
    */
   allowanceRemaining: undefined as number | undefined,
+  /** The third rule, which only a per-image query can answer. */
+  usedHere: false,
   /** Whether a viewer is signed in at all — the other half of the query guard. */
   signedIn: true,
 };
 
 /** What the bar passed as `enabled`, verbatim — see the cost test. */
-const allowanceEnabled: (boolean | undefined)[] = [];
+const standingEnabled: (boolean | undefined)[] = [];
 
 // Spread the real module: a hand-listed mock couples this test to the whole
 // transitive import graph of the bar, and nothing warns when that graph grows.
@@ -71,18 +73,19 @@ vi.mock('~/components/Sticker/placement.util', async (importOriginal) => ({
     };
   },
   // 🔴 No default value for `enabled`, deliberately. With `(enabled = true)` a
-  // mutation dropping BOTH guards at the callsite still pushes `true`, and the
-  // control below stays green while a protected query fires for signed-out
-  // viewers — a 401 per page. Undefined must arrive as undefined.
-  useFreePlacementAllowance: (enabled?: boolean) => {
-    allowanceEnabled.push(enabled);
+  // mutation dropping the guard at the callsite still pushes `true`, and the
+  // control below stays green while a protected query fires for viewers who
+  // cannot place — a 401 per page. Undefined must arrive as undefined.
+  useFreePlacementStanding: (_imageId?: number, enabled?: boolean) => {
+    standingEnabled.push(enabled);
     return {
-      allowance:
+      standing:
         queryState.allowanceRemaining == null
           ? undefined
           : {
               used: 1 - queryState.allowanceRemaining,
               remaining: queryState.allowanceRemaining,
+              usedHere: queryState.usedHere,
               resetsAt: new Date('2026-08-21T00:00:00.000Z'),
             },
       isLoading: queryState.allowanceRemaining == null,
@@ -236,6 +239,7 @@ describe('StickerPlacementBar — free slots', () => {
     // set one fails loudly instead of borrowing the previous test's value — the
     // "passes for the wrong reason" class this suite was rewritten to remove.
     allowanceRemaining: undefined as number | undefined,
+    usedHere: false,
     signedIn: true,
   };
 
@@ -287,7 +291,10 @@ describe('StickerPlacementBar — free slots', () => {
 
     // The exact state from the meeting: the creator has slots going spare and
     // the reader still may not have one.
-    expect(page.getByText(/free/i).elements()).toHaveLength(0);
+    // `\d+ free` is the label's shape, not the whole word: unanchored `/free/i`
+    // also matches wrapper elements whose subtree text contains it, and `/free$/`
+    // would let a regression to "1 free left" through.
+    expect(page.getByText(/\d+ free/).elements()).toHaveLength(0);
     // `exact`, because the default is a substring match — without it the bare
     // name also matches a button labelled "… · 1 free" and the assertion
     // survives the mutation it exists to catch.
@@ -304,7 +311,10 @@ describe('StickerPlacementBar — free slots', () => {
     });
     await renderBar();
 
-    expect(page.getByText(/free/i).elements()).toHaveLength(0);
+    // `\d+ free` is the label's shape, not the whole word: unanchored `/free/i`
+    // also matches wrapper elements whose subtree text contains it, and `/free$/`
+    // would let a regression to "1 free left" through.
+    expect(page.getByText(/\d+ free/).elements()).toHaveLength(0);
     expect(
       page.getByRole('button', { name: 'Place a sticker', exact: true }).elements()
     ).toHaveLength(1);
@@ -321,7 +331,10 @@ describe('StickerPlacementBar — free slots', () => {
     // Not "1 free", and not a promise it would have to take back: an absent
     // label becomes one, whereas a price becoming "free" is the flash this
     // ordering exists to prevent.
-    expect(page.getByText(/free/i).elements()).toHaveLength(0);
+    // `\d+ free` is the label's shape, not the whole word: unanchored `/free/i`
+    // also matches wrapper elements whose subtree text contains it, and `/free$/`
+    // would let a regression to "1 free left" through.
+    expect(page.getByText(/\d+ free/).elements()).toHaveLength(0);
   });
 
   /**
@@ -417,8 +430,49 @@ describe('StickerPlacementBar — free slots', () => {
    * flag is actually passed, and passed true where it should be, so the negative
    * is not a test that cannot fail.
    */
-  test('asks for the allowance exactly once where the viewer can place', async () => {
-    allowanceEnabled.length = 0;
+  /**
+   * 🔴 The rule the bar could not see until it took the per-image query.
+   *
+   * Free is once EVER per image, and the sticker decline path makes the gap
+   * permanent rather than a day long: free-place, the creator declines, the
+   * image's slot returns and the allowance resets — so a chip reading the
+   * allowance alone advertises "1 free" on that image every day afterwards, to
+   * the one person who can never take it.
+   */
+  test('says nothing about free on an image the viewer has already used one on', async () => {
+    Object.assign(queryState, settled, {
+      freeSlots: 4,
+      freeSlotsRemaining: 2,
+      allowanceRemaining: 1,
+      usedHere: true,
+    });
+    await renderBar();
+
+    // `\d+ free` is the label's shape, not the whole word: unanchored `/free/i`
+    // also matches wrapper elements whose subtree text contains it, and `/free$/`
+    // would let a regression to "1 free left" through.
+    expect(page.getByText(/\d+ free/).elements()).toHaveLength(0);
+  });
+
+  test('explains that one, rather than only withholding the label', async () => {
+    Object.assign(queryState, settled, {
+      freeSlots: 4,
+      freeSlotsRemaining: 2,
+      allowanceRemaining: 1,
+      usedHere: true,
+    });
+    await renderBar();
+
+    await placeButton().hover();
+    // The tray's own sentence, because the bar now defers to the same ladder —
+    // one wording per fact, which is what the tooltip used to break.
+    await expect
+      .element(page.getByText(/already used a free sticker on this image/))
+      .toBeInTheDocument();
+  });
+
+  test('asks for the standing exactly once where the viewer can place', async () => {
+    standingEnabled.length = 0;
     Object.assign(queryState, settled, {
       counts: { [IMAGE_ID]: 3 },
       freeSlots: 4,
@@ -430,13 +484,13 @@ describe('StickerPlacementBar — free slots', () => {
     // `toEqual`, not `toContain`: the exact argument, once. `toContain` passes
     // on an array that also holds a stray `false` or `undefined`, which is the
     // shape a broken guard produces.
-    expect(allowanceEnabled).toEqual([true]);
+    expect(standingEnabled).toEqual([true]);
   });
 
   /**
    * 🔴 The half that makes the control above falsifiable.
    *
-   * `getFreeAllowance` is a protectedProcedure, so asking it for a signed-out
+   * `getFreeStanding` is a protectedProcedure, so asking it for a signed-out
    * viewer is a 401 — once per page it renders on. Every other test in this file
    * is signed in, so without this one the guard is never observed being false
    * and dropping it ships green.
@@ -445,8 +499,8 @@ describe('StickerPlacementBar — free slots', () => {
    * `canPlace` false; the property under test is "a bar that cannot place does
    * not ask", not anything specific to sessions.
    */
-  test('does not ask a signed-out viewer for an allowance they cannot have', async () => {
-    allowanceEnabled.length = 0;
+  test('does not ask for the standing of a viewer who cannot place', async () => {
+    standingEnabled.length = 0;
     Object.assign(queryState, settled, {
       counts: { [IMAGE_ID]: 3 },
       freeSlots: 4,
@@ -456,8 +510,11 @@ describe('StickerPlacementBar — free slots', () => {
     });
     await renderBar();
 
-    expect(allowanceEnabled).toEqual([false]);
+    expect(standingEnabled).toEqual([false]);
     // And nothing offers them a free placement they could not claim.
-    expect(page.getByText(/free/i).elements()).toHaveLength(0);
+    // `\d+ free` is the label's shape, not the whole word: unanchored `/free/i`
+    // also matches wrapper elements whose subtree text contains it, and `/free$/`
+    // would let a regression to "1 free left" through.
+    expect(page.getByText(/\d+ free/).elements()).toHaveLength(0);
   });
 });

--- a/src/components/Sticker/StickerPlacementBar.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementBar.browser.test.tsx
@@ -395,7 +395,7 @@ describe('StickerPlacementBar — free slots', () => {
     await renderBar();
 
     // No hover anywhere in this test. That is the point of it.
-    await expect.element(page.getByText('You have a free sticker today')).toBeInTheDocument();
+    await expect.element(page.getByText('Daily free sticker')).toBeInTheDocument();
   });
 
   test.each([
@@ -413,7 +413,7 @@ describe('StickerPlacementBar — free slots', () => {
 
     // A popover that appears to tell you what you cannot have is an
     // interruption on somebody else's image.
-    expect(page.getByText(/You have/).elements()).toHaveLength(0);
+    expect(page.getByText(/free sticker/i).elements()).toHaveLength(0);
     // The button is still there and still opens the tray, which is where the
     // reason lives now.
     expect(page.getByRole('button', { name: /^Place a sticker/ }).elements()).toHaveLength(1);
@@ -429,12 +429,12 @@ describe('StickerPlacementBar — free slots', () => {
     await renderBar();
 
     await page.getByRole('button', { name: 'Dismiss' }).click();
-    await expect.element(page.getByText('You have a free sticker today')).not.toBeInTheDocument();
+    await expect.element(page.getByText('Daily free sticker')).not.toBeInTheDocument();
 
     // And it does not come back on the next render, which is what "dismiss"
     // means to the person who pressed it.
     await renderBar();
-    expect(page.getByText('You have a free sticker today').elements()).toHaveLength(0);
+    expect(page.getByText('Daily free sticker').elements()).toHaveLength(0);
   });
 
   /**
@@ -452,7 +452,7 @@ describe('StickerPlacementBar — free slots', () => {
     });
     await renderBar();
 
-    await expect.element(page.getByText('You have a free sticker today')).toBeInTheDocument();
+    await expect.element(page.getByText('Daily free sticker')).toBeInTheDocument();
   });
 
   test('asks for the standing exactly once where the viewer can place', async () => {

--- a/src/components/Sticker/StickerPlacementBar.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementBar.browser.test.tsx
@@ -47,10 +47,12 @@ const queryState = {
    * then adding "free" a beat later on every card in a feed.
    */
   allowanceRemaining: undefined as number | undefined,
+  /** Whether a viewer is signed in at all — the other half of the query guard. */
+  signedIn: true,
 };
 
-/** Whether the bar asked for the allowance at all — see the cost test. */
-const allowanceEnabled: boolean[] = [];
+/** What the bar passed as `enabled`, verbatim — see the cost test. */
+const allowanceEnabled: (boolean | undefined)[] = [];
 
 // Spread the real module: a hand-listed mock couples this test to the whole
 // transitive import graph of the bar, and nothing warns when that graph grows.
@@ -68,7 +70,11 @@ vi.mock('~/components/Sticker/placement.util', async (importOriginal) => ({
       isLoading: queryState.placementsLoading,
     };
   },
-  useFreePlacementAllowance: (enabled = true) => {
+  // 🔴 No default value for `enabled`, deliberately. With `(enabled = true)` a
+  // mutation dropping BOTH guards at the callsite still pushes `true`, and the
+  // control below stays green while a protected query fires for signed-out
+  // viewers — a 401 per page. Undefined must arrive as undefined.
+  useFreePlacementAllowance: (enabled?: boolean) => {
     allowanceEnabled.push(enabled);
     return {
       allowance:
@@ -114,7 +120,9 @@ vi.mock('~/components/Sticker/StickerHistoryPanel', () => ({
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ stickerPlacement: true }),
 }));
-vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 7 }) }));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => (queryState.signedIn ? { id: 7 } : null),
+}));
 
 const renderBar = async () => {
   renderWithProviders(<StickerPlacementBar imageId={IMAGE_ID} />);
@@ -224,6 +232,11 @@ describe('StickerPlacementBar — free slots', () => {
     countsError: false,
     placementsLoading: false,
     pending: [],
+    // Both halves of the free question are reset here, so a test that forgets to
+    // set one fails loudly instead of borrowing the previous test's value — the
+    // "passes for the wrong reason" class this suite was rewritten to remove.
+    allowanceRemaining: undefined as number | undefined,
+    signedIn: true,
   };
 
   const placeButton = () => page.getByRole('button', { name: /^Place a sticker/ });
@@ -274,7 +287,7 @@ describe('StickerPlacementBar — free slots', () => {
 
     // The exact state from the meeting: the creator has slots going spare and
     // the reader still may not have one.
-    expect(page.getByText(/free$/).elements()).toHaveLength(0);
+    expect(page.getByText(/free/i).elements()).toHaveLength(0);
     // `exact`, because the default is a substring match — without it the bare
     // name also matches a button labelled "… · 1 free" and the assertion
     // survives the mutation it exists to catch.
@@ -291,7 +304,7 @@ describe('StickerPlacementBar — free slots', () => {
     });
     await renderBar();
 
-    expect(page.getByText(/free$/).elements()).toHaveLength(0);
+    expect(page.getByText(/free/i).elements()).toHaveLength(0);
     expect(
       page.getByRole('button', { name: 'Place a sticker', exact: true }).elements()
     ).toHaveLength(1);
@@ -308,7 +321,7 @@ describe('StickerPlacementBar — free slots', () => {
     // Not "1 free", and not a promise it would have to take back: an absent
     // label becomes one, whereas a price becoming "free" is the flash this
     // ordering exists to prevent.
-    expect(page.getByText(/free$/).elements()).toHaveLength(0);
+    expect(page.getByText(/free/i).elements()).toHaveLength(0);
   });
 
   /**
@@ -392,7 +405,7 @@ describe('StickerPlacementBar — free slots', () => {
 
     await placeButton().hover();
     await expect.element(page.getByText('Place a sticker · 100 Buzz')).toBeInTheDocument();
-    expect(page.getByText(/free,/).elements()).toHaveLength(0);
+    expect(page.getByText(/\bfree\b/i).elements()).toHaveLength(0);
   });
 
   /**
@@ -404,7 +417,7 @@ describe('StickerPlacementBar — free slots', () => {
    * flag is actually passed, and passed true where it should be, so the negative
    * is not a test that cannot fail.
    */
-  test('asks for the allowance where the viewer can place', async () => {
+  test('asks for the allowance exactly once where the viewer can place', async () => {
     allowanceEnabled.length = 0;
     Object.assign(queryState, settled, {
       counts: { [IMAGE_ID]: 3 },
@@ -414,6 +427,37 @@ describe('StickerPlacementBar — free slots', () => {
     });
     await renderBar();
 
-    expect(allowanceEnabled).toContain(true);
+    // `toEqual`, not `toContain`: the exact argument, once. `toContain` passes
+    // on an array that also holds a stray `false` or `undefined`, which is the
+    // shape a broken guard produces.
+    expect(allowanceEnabled).toEqual([true]);
+  });
+
+  /**
+   * 🔴 The half that makes the control above falsifiable.
+   *
+   * `getFreeAllowance` is a protectedProcedure, so asking it for a signed-out
+   * viewer is a 401 — once per page it renders on. Every other test in this file
+   * is signed in, so without this one the guard is never observed being false
+   * and dropping it ships green.
+   *
+   * Signed-out is the state driven here because it is the cheapest way to make
+   * `canPlace` false; the property under test is "a bar that cannot place does
+   * not ask", not anything specific to sessions.
+   */
+  test('does not ask a signed-out viewer for an allowance they cannot have', async () => {
+    allowanceEnabled.length = 0;
+    Object.assign(queryState, settled, {
+      counts: { [IMAGE_ID]: 3 },
+      freeSlots: 4,
+      freeSlotsRemaining: 2,
+      allowanceRemaining: 1,
+      signedIn: false,
+    });
+    await renderBar();
+
+    expect(allowanceEnabled).toEqual([false]);
+    // And nothing offers them a free placement they could not claim.
+    expect(page.getByText(/free/i).elements()).toHaveLength(0);
   });
 });

--- a/src/components/Sticker/StickerPlacementBar.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementBar.browser.test.tsx
@@ -39,7 +39,18 @@ const queryState = {
    */
   freeSlots: 0,
   freeSlotsRemaining: 0,
+  /**
+   * The VIEWER's half, and the reason this file changed.
+   *
+   * `undefined` is the in-flight state and is not zero: the bar must render no
+   * free label at all until the answer lands, rather than showing the price and
+   * then adding "free" a beat later on every card in a feed.
+   */
+  allowanceRemaining: undefined as number | undefined,
 };
+
+/** Whether the bar asked for the allowance at all — see the cost test. */
+const allowanceEnabled: boolean[] = [];
 
 // Spread the real module: a hand-listed mock couples this test to the whole
 // transitive import graph of the bar, and nothing warns when that graph grows.
@@ -55,6 +66,20 @@ vi.mock('~/components/Sticker/placement.util', async (importOriginal) => ({
     return {
       byImage: new Map(queryState.pending.length ? [[IMAGE_ID, queryState.pending]] : []),
       isLoading: queryState.placementsLoading,
+    };
+  },
+  useFreePlacementAllowance: (enabled = true) => {
+    allowanceEnabled.push(enabled);
+    return {
+      allowance:
+        queryState.allowanceRemaining == null
+          ? undefined
+          : {
+              used: 1 - queryState.allowanceRemaining,
+              remaining: queryState.allowanceRemaining,
+              resetsAt: new Date('2026-08-21T00:00:00.000Z'),
+            },
+      isLoading: queryState.allowanceRemaining == null,
     };
   },
   useImagePlacementSpace: () => ({
@@ -205,103 +230,190 @@ describe('StickerPlacementBar — free slots', () => {
   // By exact name, because the comparison below renders twice in one test and
   // both buttons stay mounted — a pattern locator resolves to two elements there
   // and fails on strict mode rather than on the property being tested.
-  const backgroundOf = async (name: string) =>
-    getComputedStyle(await page.getByRole('button', { name }).element()).backgroundColor;
-
-  test('carries the remaining count out of the creator capacity', async () => {
-    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 2 });
-    await renderBar();
-
-    await expect.element(page.getByText('2 of 4 free')).toBeInTheDocument();
-    // On the accessible name too. A number only a sighted user can read is not
-    // the button carrying it.
-    expect(
-      page.getByRole('button', { name: 'Place a sticker · 2 of 4 free' }).elements()
-    ).toHaveLength(1);
-  });
+  const backgroundOf = async (name: string, exact = false) =>
+    getComputedStyle(await page.getByRole('button', { name, exact }).element()).backgroundColor;
 
   /**
-   * The ambiguity that needed two numbers to resolve. A creator whose slots are
-   * all held still has something to say, because a slot comes back the moment
-   * one is declined — so this state reads `0 of 4`, not silence.
+   * 🔴 The defect this suite was rewritten for.
+   *
+   * The label used to be `${freeSlotsRemaining} of ${freeSlots} free`, which is
+   * the CREATOR's capacity and says nothing about the reader. Somebody who had
+   * spent their one placement for the day saw "1 of 1 free" on every image in
+   * the feed, pressed it, and was charged. Justin hit it live in a meeting; a
+   * user hit it ninety minutes after launch and reported it as "there is no
+   * actual free one at the moment".
+   *
+   * So "free" is allowed on screen only where BOTH scarcities hold, and the
+   * number is the smaller of the two, because that is how many the reader can
+   * actually take.
    */
-  test('says nothing about free stickers when the creator takes none', async () => {
-    Object.assign(queryState, settled, { freeSlots: 0, freeSlotsRemaining: 0 });
+  test('offers free only when the creator has a slot and the viewer has their day', async () => {
+    Object.assign(queryState, settled, {
+      freeSlots: 4,
+      freeSlotsRemaining: 2,
+      allowanceRemaining: 1,
+    });
     await renderBar();
 
+    // One, not two: the creator's capacity is 2 and the viewer may take 1.
+    await expect.element(page.getByText('1 free')).toBeInTheDocument();
+    // On the accessible name too. A number only a sighted user can read is not
+    // the button carrying it.
+    expect(page.getByRole('button', { name: 'Place a sticker · 1 free' }).elements()).toHaveLength(
+      1
+    );
+  });
+
+  test('says nothing about free when the viewer has spent their placement for the day', async () => {
+    Object.assign(queryState, settled, {
+      freeSlots: 4,
+      freeSlotsRemaining: 2,
+      allowanceRemaining: 0,
+    });
+    await renderBar();
+
+    // The exact state from the meeting: the creator has slots going spare and
+    // the reader still may not have one.
     expect(page.getByText(/free$/).elements()).toHaveLength(0);
-    // `exact`, because the default is a substring match — so the bare name also
-    // matched "Place a sticker · 0 of 0 free" and the assertion survived the
-    // mutation `showsFree = canPlace`, which is the one it exists to catch.
+    // `exact`, because the default is a substring match — without it the bare
+    // name also matches a button labelled "… · 1 free" and the assertion
+    // survives the mutation it exists to catch.
     expect(
       page.getByRole('button', { name: 'Place a sticker', exact: true }).elements()
     ).toHaveLength(1);
   });
 
-  test('still reports the capacity when every slot is currently held', async () => {
-    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 0 });
+  test('says nothing about free stickers when the creator takes none', async () => {
+    Object.assign(queryState, settled, {
+      freeSlots: 0,
+      freeSlotsRemaining: 0,
+      allowanceRemaining: 1,
+    });
     await renderBar();
 
-    await expect.element(page.getByText('0 of 4 free')).toBeInTheDocument();
+    expect(page.getByText(/free$/).elements()).toHaveLength(0);
+    expect(
+      page.getByRole('button', { name: 'Place a sticker', exact: true }).elements()
+    ).toHaveLength(1);
+  });
+
+  test('withholds the label while the allowance is still in flight', async () => {
+    Object.assign(queryState, settled, {
+      freeSlots: 4,
+      freeSlotsRemaining: 2,
+      allowanceRemaining: undefined,
+    });
+    await renderBar();
+
+    // Not "1 free", and not a promise it would have to take back: an absent
+    // label becomes one, whereas a price becoming "free" is the flash this
+    // ordering exists to prevent.
+    expect(page.getByText(/free$/).elements()).toHaveLength(0);
   });
 
   /**
    * The shiny treatment, asserted as a difference rather than as a colour: what
-   * has to be true is that a slot being available looks unlike one that is not.
-   * Pinning the exact rgba would fail on a theme change that kept the behaviour.
+   * has to be true is that an offer the reader can take looks unlike one they
+   * cannot. Pinning the exact rgba would fail on a theme change that kept the
+   * behaviour.
    */
-  test('draws the button differently when a slot is available', async () => {
+  test('draws the button differently when the viewer can actually take a free one', async () => {
     // A stickered image, deliberately. On an empty one the button already wears
     // this tint as half of the "place the first one" invitation, so both renders
-    // would come back identical and the test would pass for the wrong reason —
-    // or fail, as it did, on a cause that has nothing to do with free slots.
+    // would come back identical and the test would pass for the wrong reason.
     const stickered = { ...settled, counts: { [IMAGE_ID]: 3 } };
 
-    Object.assign(queryState, stickered, { freeSlots: 4, freeSlotsRemaining: 1 });
+    Object.assign(queryState, stickered, {
+      freeSlots: 4,
+      freeSlotsRemaining: 1,
+      allowanceRemaining: 1,
+    });
     await renderBar();
-    const available = await backgroundOf('Place a sticker · 1 of 4 free');
+    const available = await backgroundOf('Place a sticker · 1 free');
 
-    Object.assign(queryState, stickered, { freeSlots: 4, freeSlotsRemaining: 0 });
+    Object.assign(queryState, stickered, {
+      freeSlots: 4,
+      freeSlotsRemaining: 1,
+      allowanceRemaining: 0,
+    });
     await renderBar();
-    const taken = await backgroundOf('Place a sticker · 0 of 4 free');
+    // `exact`, because the first render is still mounted and its button is
+    // named "Place a sticker · 1 free" — a substring match resolves to both and
+    // fails on strict mode rather than on the property under test.
+    const spent = await backgroundOf('Place a sticker', true);
 
-    expect(available).not.toBe(taken);
+    expect(available).not.toBe(spent);
   });
 
   /**
-   * 🔴 The bar must never promise free, and the count is why it is tempting to.
-   *
-   * `freeSlotsRemaining` is the CREATOR's capacity. It says nothing about this
-   * viewer — somebody who spent today's allowance, or already free-placed on this
-   * image, has no free option at all — and only the standing query answers that,
-   * which this bar deliberately does not make because it renders per feed card.
-   * So a "free" label here is read by the people it is false for, who then open
-   * the tray and pay a number they were never shown.
-   *
-   * Asserted across both capacity states, because the defect only appeared in one
-   * of them: a test pinned to the empty case passes while the promise is made.
+   * The tooltip is where the price has always lived, and now where the reason
+   * lives too. Both halves are asserted per state, because "says the price" and
+   * "explains which scarcity ran out" fail independently — a tooltip that quotes
+   * the price and explains nothing is exactly what shipped.
    */
-  test.each([
-    ['slots remaining', 2],
-    ['slots all taken', 0],
-  ])('quotes the price and never promises free — %s', async (_name, remaining) => {
-    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: remaining });
+  test('explains a spent allowance, and names what it is shared with', async () => {
+    Object.assign(queryState, settled, {
+      freeSlots: 4,
+      freeSlotsRemaining: 2,
+      allowanceRemaining: 0,
+    });
+    await renderBar();
+
+    await placeButton().hover();
+    // The sharing is the fact readers were getting wrong: spend it on a remix
+    // gallery and the sticker surface had no explanation for where it went.
+    await expect
+      .element(page.getByText(/shared between stickers and remix galleries/))
+      .toBeInTheDocument();
+    await expect.element(page.getByText(/100 Buzz/)).toBeInTheDocument();
+  });
+
+  test('distinguishes a held slot from a creator who takes none', async () => {
+    Object.assign(queryState, settled, {
+      freeSlots: 4,
+      freeSlotsRemaining: 0,
+      allowanceRemaining: 1,
+    });
+    await renderBar();
+
+    await placeButton().hover();
+    // Worth saying precisely because it lifts by itself: a decline returns the
+    // slot, so this reader has a reason to come back to THIS image.
+    await expect.element(page.getByText(/comes back if the creator declines/)).toBeInTheDocument();
+  });
+
+  test('quotes the price and promises nothing while the allowance is unknown', async () => {
+    Object.assign(queryState, settled, {
+      freeSlots: 4,
+      freeSlotsRemaining: 2,
+      allowanceRemaining: undefined,
+    });
     await renderBar();
 
     await placeButton().hover();
     await expect.element(page.getByText('Place a sticker · 100 Buzz')).toBeInTheDocument();
-    expect(page.getByText(/·\s*free/).elements()).toHaveLength(0);
+    expect(page.getByText(/free,/).elements()).toHaveLength(0);
   });
 
   /**
-   * The count itself stays, and this is the line between the two: a number about
-   * the creator's capacity is a fact the bar has, and a claim about what THIS
-   * viewer will be charged is not.
+   * The cost control, asserted rather than assumed.
+   *
+   * The whole design rests on the allowance being ONE query for a page — it is a
+   * property of the person, not of the image. The bar passes an `enabled` flag
+   * so a surface where the answer cannot matter never asks; this pins that the
+   * flag is actually passed, and passed true where it should be, so the negative
+   * is not a test that cannot fail.
    */
-  test('still states the creator capacity it does know', async () => {
-    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 2 });
+  test('asks for the allowance where the viewer can place', async () => {
+    allowanceEnabled.length = 0;
+    Object.assign(queryState, settled, {
+      counts: { [IMAGE_ID]: 3 },
+      freeSlots: 4,
+      freeSlotsRemaining: 2,
+      allowanceRemaining: 1,
+    });
     await renderBar();
 
-    await expect.element(page.getByText('2 of 4 free')).toBeInTheDocument();
+    expect(allowanceEnabled).toContain(true);
   });
 });

--- a/src/components/Sticker/StickerPlacementBar.tsx
+++ b/src/components/Sticker/StickerPlacementBar.tsx
@@ -7,7 +7,7 @@ import { StickerHistoryButton } from '~/components/Sticker/StickerHistoryPanel';
 import { StickerPlacementTray } from '~/components/Sticker/StickerPlacementTray';
 import { barFreeLabel, barTooltip } from '~/components/Sticker/free-offer';
 import {
-  useFreePlacementAllowance,
+  useFreePlacementStanding,
   useImagePlacementSpace,
   useStickerPlacementCounts,
   useStickerPlacements,
@@ -76,19 +76,24 @@ export function StickerPlacementBar({
   const total = count + pending;
 
   /**
-   * The viewer's own half of the answer.
+   * The viewer's own half of the answer — all of it, for this image.
    *
-   * One query for the whole page rather than one per card: the allowance belongs
-   * to the person, so every bar on a page shares one cache key and one request.
-   * That is what makes it affordable to check, and checking is the point — the
-   * label below used to be the creator's capacity alone, which promised free
-   * placements to people who had already spent theirs.
+   * **The per-image standing rather than the page-wide allowance**, which is a
+   * deliberate choice about where this bar lives *today*: one callsite, the
+   * image detail view. Feed cards mount `StickerPlacementCardBadge`, which
+   * cannot place. So the target-scoped query costs the same single request the
+   * untargeted one did, and it answers the third rule as well — "already
+   * free-placed on THIS image" — which the untargeted one structurally cannot.
    *
-   * ⚠️ Today this bar has ONE callsite, the image detail view; feed cards mount
-   * `StickerPlacementCardBadge`, which cannot place. So the present cost is one
-   * request per detail view. The per-card reasoning is for the future this
-   * component was written toward, and it is what keeps that future cheap — but
-   * do not read "per feed card" here as a description of what ships now.
+   * 🔴 **When this bar reaches feed cards, this has to change back.** A
+   * per-image query renders once per card; the allowance is a property of the
+   * person, so the page-wide form (`getFreePlacementAllowance`, still on the
+   * service, exposed then as its own procedure) is the affordable one there —
+   * at the cost of the chip over-offering on images the viewer has already used.
+   * Chosen with Justin, 2026-08-20: complete promise now, cheap promise later.
+   *
+   * Shares its key with the tray's own standing query, so opening the tray on
+   * this image costs nothing extra.
    *
    * Gated on `canPlace`, which already requires a signed-in viewer — the
    * procedure is protected, so asking without one is a 401 per page it renders
@@ -96,12 +101,12 @@ export function StickerPlacementBar({
    * alongside it can never be the reason this is false, so a test claiming to
    * pin it would be asserting something it cannot fail on.
    */
-  const { allowance } = useFreePlacementAllowance(canPlace);
+  const { standing } = useFreePlacementStanding(imageId, canPlace);
 
-  // `null` until BOTH facts are known, and absent rather than paid while the
-  // allowance is loading — a label that appears a beat late is quieter than a
-  // price that turns into "free" on every card in the feed.
-  const freeLabel = canPlace ? barFreeLabel(space ?? undefined, allowance?.remaining) : null;
+  // `null` until every fact is known, and absent rather than paid while the
+  // standing is loading — a label that appears a beat late is quieter than a
+  // price that turns into "free".
+  const freeLabel = canPlace ? barFreeLabel(space ?? undefined, standing) : null;
 
   // The invitation needs a zero that is KNOWN to be zero. `total` is fed by two
   // separate queries and a failure of either reads as empty, so an image with
@@ -147,8 +152,7 @@ export function StickerPlacementBar({
             tooltip={barTooltip({
               price: space?.price ?? 0,
               space: space ?? undefined,
-              allowanceRemaining: allowance?.remaining,
-              resetsAt: allowance?.resetsAt,
+              standing,
             })}
             // Distinct from the plus beside it, which is also "Place a sticker".
             // They share a Button.Group and an action, so identical names read
@@ -186,17 +190,14 @@ export function StickerPlacementBar({
              * slots are all currently held", which is worth saying because a
              * decline gives one back. `barTooltip` branches on both.
              *
-             * The one rule left un-checked here is "already free-placed on THIS
-             * image", which needs a per-image query — affordable on the detail
-             * view where this bar lives today, not on the feed it is written
-             * toward. The tray checks it before anything is committed, so the
-             * residual is an over-offer the tray corrects, never a wrong charge.
+             * All three rules are in hand here now, so this ladder and the
+             * tray's are the same one: `barTooltip` defers to
+             * `preCommitFreeReason` and owns only the price.
              */
             label={barTooltip({
               price: space?.price ?? 0,
               space: space ?? undefined,
-              allowanceRemaining: allowance?.remaining,
-              resetsAt: allowance?.resetsAt,
+              standing,
             })}
             withArrow
             multiline

--- a/src/components/Sticker/StickerPlacementBar.tsx
+++ b/src/components/Sticker/StickerPlacementBar.tsx
@@ -13,6 +13,7 @@ import {
   useStickerPlacements,
 } from '~/components/Sticker/placement.util';
 import { useCallback, useState } from 'react';
+import hintClasses from '~/components/Sticker/free-hint.module.scss';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
@@ -215,6 +216,11 @@ export function StickerPlacementBar({
             arrowSize={10}
             shadow="md"
             radius="md"
+            // Under the placement tray, which is `z-30` and fixed to the bottom
+            // of the viewport. Mantine's default (300) put this hint on top of
+            // the panel it exists to send people to — pointing at a button that
+            // was no longer the thing to press.
+            zIndex={20}
             // Dismissed by its own control only. A click-outside dismissal on a
             // hint anchored to a button people are about to press would count
             // pressing the button as "I have read this".
@@ -281,13 +287,29 @@ export function StickerPlacementBar({
               // The button's own yellow, because it is about that button and
               // nothing else. A neutral card floating over the image reads as a
               // site notice; this reads as the button talking.
-              className="border-none bg-yellow-4 px-3 py-2 dark:bg-yellow-6"
+              //
+              // The wiggle runs once, on appearance. Beside a picture somebody
+              // came to look at, a permanent animation is a nag; two beats is
+              // enough to move an eye that was already on the image.
+              className={clsx(
+                'border-none bg-yellow-4 px-3 py-2 dark:bg-yellow-6',
+                hintClasses.wiggle
+              )}
             >
               <div className="flex items-center gap-2">
                 <Text size="xs" fw={600} c="dark.8">
                   {hint}
                 </Text>
-                <CloseButton size="xs" c="dark.8" aria-label="Dismiss" onClick={dismissHint} />
+                <CloseButton
+                  size="xs"
+                  aria-label="Dismiss"
+                  onClick={dismissHint}
+                  // Mantine's close button hovers to a dark fill, which on this
+                  // yellow card is a black square around a black glyph — the
+                  // control disappears at the moment you reach for it. A tint of
+                  // the card's own ink instead, which darkens without hiding.
+                  className="text-dark-8 hover:bg-black/10"
+                />
               </div>
             </Popover.Dropdown>
           </Popover>

--- a/src/components/Sticker/StickerPlacementBar.tsx
+++ b/src/components/Sticker/StickerPlacementBar.tsx
@@ -1,21 +1,42 @@
-import { Button, Text, Tooltip } from '@mantine/core';
+import { Button, CloseButton, Popover, Text } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useReactionSettingsContext } from '~/components/Reaction/ReactionSettingsProvider';
 import { StickerCountChip, useStickerInviteStyle } from '~/components/Sticker/StickerCountChip';
 import { StickerHistoryButton } from '~/components/Sticker/StickerHistoryPanel';
 import { StickerPlacementTray } from '~/components/Sticker/StickerPlacementTray';
-import { barFreeLabel, barTooltip } from '~/components/Sticker/free-offer';
+import { barFreeLabel, freeHintText } from '~/components/Sticker/free-offer';
 import {
   useFreePlacementStanding,
   useImagePlacementSpace,
   useStickerPlacementCounts,
   useStickerPlacements,
 } from '~/components/Sticker/placement.util';
+import { useCallback, useState } from 'react';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
 import { useStickerRevealStore } from '~/store/sticker-reveal.store';
+
+/** Where a dismissed free hint is remembered. Per browser, not per session. */
+const HINT_DISMISSED_KEY = 'sticker-free-hint-dismissed';
+
+/**
+ * The UTC day, as the server means it.
+ *
+ * Matches `freePlacementDayStart` — the allowance resets at midnight UTC, so a
+ * hint dismissed "today" has to mean the same today the allowance does, or it
+ * comes back mid-afternoon for anyone west of Greenwich.
+ */
+const utcDay = () => new Date().toISOString().slice(0, 10);
+
+const readDismissedDay = () => {
+  try {
+    return localStorage.getItem(HINT_DISMISSED_KEY);
+  } catch {
+    return null;
+  }
+};
 
 /**
  * The reaction-bar entry: whether stickers exist here, how many, and the way in
@@ -108,6 +129,26 @@ export function StickerPlacementBar({
   // price that turns into "free".
   const freeLabel = canPlace ? barFreeLabel(space ?? undefined, standing) : null;
 
+  const hint = canPlace ? freeHintText(space ?? undefined, standing) : null;
+  const [dismissedDay, setDismissedDay] = useState(readDismissedDay);
+  const dismissHint = useCallback(() => {
+    const day = utcDay();
+    setDismissedDay(day);
+    try {
+      localStorage.setItem(HINT_DISMISSED_KEY, day);
+    } catch {
+      // Private mode, or storage full. The hint simply comes back next load —
+      // the dismissal is a courtesy, not state anything depends on.
+    }
+  }, []);
+
+  // Shown only where there is genuinely a free placement to take, and only until
+  // it is waved away for the day. Keyed on the UTC day rather than forever
+  // because the thing it announces is itself daily: tomorrow's allowance is news
+  // again, and a permanent dismissal would mean the feature announces itself
+  // exactly once per person, ever.
+  const showHint = !!hint && dismissedDay !== utcDay();
+
   // The invitation needs a zero that is KNOWN to be zero. `total` is fed by two
   // separate queries and a failure of either reads as empty, so an image with
   // stickers would otherwise show the invitation — and a press there opens a
@@ -145,15 +186,6 @@ export function StickerPlacementBar({
           <StickerCountChip
             count={0}
             revealed={revealed}
-            // The same sentence the plus beside it gets. They open the same
-            // tray with the same action, so a hand-written price line here
-            // would let the two disagree the moment the plus started saying
-            // "free, or N Buzz" — which is exactly what this change made it do.
-            tooltip={barTooltip({
-              price: space?.price ?? 0,
-              space: space ?? undefined,
-              standing,
-            })}
             // Distinct from the plus beside it, which is also "Place a sticker".
             // They share a Button.Group and an action, so identical names read
             // to a screen reader as the same control announced twice.
@@ -171,76 +203,80 @@ export function StickerPlacementBar({
         )}
 
         {canPlace && (
-          <Tooltip
-            /**
-             * 🔴 The price, always — plus the reason free is unavailable, when
-             * it is.
-             *
-             * `freeSlotsRemaining` alone is the CREATOR's capacity and says
-             * nothing about this viewer, which is how the old label promised
-             * free to somebody who had spent their day and then charged them a
-             * number they were never shown. Both facts are now in hand, so the
-             * tooltip can say which of the two ran out instead of leaving the
-             * reader to find out by pressing.
-             *
-             * ⚠️ `freeSlotsRemaining === 0` covers two different facts and only
-             * `freeSlots` tells them apart: the resolver short-circuits the
-             * reservation count when there is no capacity, so zero is both "this
-             * creator takes no free placements" — nothing to say — and "their
-             * slots are all currently held", which is worth saying because a
-             * decline gives one back. `barTooltip` branches on both.
-             *
-             * All three rules are in hand here now, so this ladder and the
-             * tray's are the same one: `barTooltip` defers to
-             * `preCommitFreeReason` and owns only the price.
-             */
-            label={barTooltip({
-              price: space?.price ?? 0,
-              space: space ?? undefined,
-              standing,
-            })}
+          /* 🔴 No tooltip. The bar used to explain itself on hover — the price,
+             and which scarcity had run out — which meant a phone was told
+             nothing at all, in the states where knowing matters most. What is
+             left here is the label; the reasons are said in the tray, at the
+             point the choice is made, and the one piece of good news gets the
+             popover below, which everyone can see and anyone can dismiss. */
+          <Popover
+            opened={showHint}
+            position="top"
             withArrow
-            multiline
-            w={260}
+            arrowSize={10}
+            shadow="md"
+            radius="md"
+            // Dismissed by its own control only. A click-outside dismissal on a
+            // hint anchored to a button people are about to press would count
+            // pressing the button as "I have read this".
+            trapFocus={false}
+            closeOnClickOutside={false}
+            closeOnEscape
+            onClose={dismissHint}
           >
-            <Button
-              size="compact-sm"
-              radius="xl"
-              variant="light"
-              color="yellow"
-              onClick={() => openTray(imageId)}
-              aria-label={freeLabel ? `Place a sticker · ${freeLabel}` : 'Place a sticker'}
-              // A plus rather than a second sticker glyph: beside a count of
-              // stickers it reads as "add one" without a word, which is what
-              // keeps the fused control narrow enough to belong in this row.
-              {...buttonStyling?.('BuzzTip')}
-              // Last, and merged over whatever the row's styling set: at zero
-              // the plus is half the invitation, so it has to carry the same
-              // tint the chip does or the pair reads as two unrelated controls.
-              //
-              // A free slot borrows the same tint for the same reason it exists:
-              // it is the row's own "there is something for you here" language,
-              // and inventing a second one for the free tier would make the two
-              // states compete rather than agree.
-              style={{
-                ...buttonStyling?.('BuzzTip')?.style,
-                ...(inviting || freeLabel ? inviteStyle : null),
-              }}
+            <Popover.Target>
+              <Button
+                size="compact-sm"
+                radius="xl"
+                variant="light"
+                color="yellow"
+                onClick={() => openTray(imageId)}
+                aria-label={freeLabel ? `Place a sticker · ${freeLabel}` : 'Place a sticker'}
+                // A plus rather than a second sticker glyph: beside a count of
+                // stickers it reads as "add one" without a word, which is what
+                // keeps the fused control narrow enough to belong in this row.
+                {...buttonStyling?.('BuzzTip')}
+                // Last, and merged over whatever the row's styling set: at zero
+                // the plus is half the invitation, so it has to carry the same
+                // tint the chip does or the pair reads as two unrelated controls.
+                //
+                // A free slot borrows the same tint for the same reason it exists:
+                // it is the row's own "there is something for you here" language,
+                // and inventing a second one for the free tier would make the two
+                // states compete rather than agree.
+                style={{
+                  ...buttonStyling?.('BuzzTip')?.style,
+                  ...(inviting || freeLabel ? inviteStyle : null),
+                }}
+              >
+                <IconPlus size={16} stroke={2.5} />
+                {/* Only where the viewer can actually take it. The old label
+                counted the creator's slots and said nothing about the reader,
+                so a spent allowance still read as "1 of 1 free" on every image.
+                The states worth knowing but not offering — a full space, a
+                spent day, one already used here — say nothing at all here and
+                are explained in the tray, where the choice is made. */}
+                {freeLabel && (
+                  <Text size="xs" fw={600} className="ml-1">
+                    {freeLabel}
+                  </Text>
+                )}
+              </Button>
+            </Popover.Target>
+            <Popover.Dropdown
+              // The button's own yellow, because it is about that button and
+              // nothing else. A neutral card floating over the image reads as a
+              // site notice; this reads as the button talking.
+              className="border-none bg-yellow-4 px-3 py-2 dark:bg-yellow-6"
             >
-              <IconPlus size={16} stroke={2.5} />
-              {/* Only where the viewer can actually take it. The old label
-                  counted the creator's slots and said nothing about the reader,
-                  so a spent allowance still read as "1 of 1 free" on every image
-                  in the feed. A state worth knowing but not offering — a full
-                  space, a spent day — is now said in the tooltip instead, where
-                  it can give the reason and the price together. */}
-              {freeLabel && (
-                <Text size="xs" fw={600} className="ml-1">
-                  {freeLabel}
+              <div className="flex items-center gap-2">
+                <Text size="xs" fw={600} c="dark.8">
+                  {hint}
                 </Text>
-              )}
-            </Button>
-          </Tooltip>
+                <CloseButton size="xs" c="dark.8" aria-label="Dismiss" onClick={dismissHint} />
+              </div>
+            </Popover.Dropdown>
+          </Popover>
         )}
       </Button.Group>
 

--- a/src/components/Sticker/StickerPlacementBar.tsx
+++ b/src/components/Sticker/StickerPlacementBar.tsx
@@ -169,7 +169,6 @@ export function StickerPlacementBar({
           <StickerCountChip
             count={total}
             revealed={revealed}
-            showLabel
             tooltip={revealed ? 'Hide stickers on all images' : 'Show stickers on all images'}
             onClick={toggle}
             // Revealed reads as `hasReacted`, so the toggle's on state borrows
@@ -248,6 +247,21 @@ export function StickerPlacementBar({
                   ...buttonStyling?.('BuzzTip')?.style,
                   ...(inviting || freeLabel ? inviteStyle : null),
                 }}
+                // 🔴 Two fixes, one cause: an INLINE background.
+                //
+                // `Button.Group` squares the corners between its children and
+                // leaves the outer ones alone — but this is the group's last
+                // child AND `Popover.Target` clones it, so the rounding it
+                // should inherit from being last is stated here instead. That
+                // is the outside edge of the fused control; square there reads
+                // as a rendering fault.
+                //
+                // And an inline background beats every CSS `:hover` Mantine
+                // ships, which is why this row went inert the moment these
+                // buttons started carrying the invite tint. A filter has no
+                // background of its own to be overridden, so it works over
+                // whatever styling the row hands us.
+                className="rounded-r-full transition-[filter] duration-150 hover:brightness-110"
               >
                 <IconPlus size={16} stroke={2.5} />
                 {/* Only where the viewer can actually take it. The old label

--- a/src/components/Sticker/StickerPlacementBar.tsx
+++ b/src/components/Sticker/StickerPlacementBar.tsx
@@ -5,7 +5,9 @@ import { useReactionSettingsContext } from '~/components/Reaction/ReactionSettin
 import { StickerCountChip, useStickerInviteStyle } from '~/components/Sticker/StickerCountChip';
 import { StickerHistoryButton } from '~/components/Sticker/StickerHistoryPanel';
 import { StickerPlacementTray } from '~/components/Sticker/StickerPlacementTray';
+import { barFreeLabel, barTooltip } from '~/components/Sticker/free-offer';
 import {
+  useFreePlacementAllowance,
   useImagePlacementSpace,
   useStickerPlacementCounts,
   useStickerPlacements,
@@ -74,22 +76,23 @@ export function StickerPlacementBar({
   const total = count + pending;
 
   /**
-   * How much of this creator's free capacity is still open.
+   * The viewer's own half of the answer.
    *
-   * ⚠️ `freeSlotsRemaining === 0` covers two different facts and only
-   * `freeSlots` tells them apart: the resolver short-circuits the reservation
-   * count when there is no capacity, so zero is both "this creator takes no free
-   * placements" and "their slots are all currently held". The first has nothing
-   * to say and the second does, because a slot comes back on a decline.
+   * One query for the whole page rather than one per card: the allowance belongs
+   * to the person, so every bar in a feed shares its cache key. That is what
+   * makes it affordable to check, and checking is the point — the label below
+   * used to be the creator's capacity alone, which promised free placements to
+   * people who had already spent theirs.
    *
-   * Both numbers ride on the space query this bar already makes, so the count
-   * costs nothing extra. It is a display number and stale by construction — the
-   * claim re-counts under a lock — which is why the button offers rather than
-   * promises.
+   * Not asked of a signed-out viewer, who has no allowance and would get a 401
+   * per page from a protected procedure.
    */
-  const freeSlots = space?.freeSlots ?? 0;
-  const freeRemaining = space?.freeSlotsRemaining ?? 0;
-  const showsFree = canPlace && freeSlots > 0;
+  const { allowance } = useFreePlacementAllowance(!!currentUser && canPlace);
+
+  // `null` until BOTH facts are known, and absent rather than paid while the
+  // allowance is loading — a label that appears a beat late is quieter than a
+  // price that turns into "free" on every card in the feed.
+  const freeLabel = canPlace ? barFreeLabel(space ?? undefined, allowance?.remaining) : null;
 
   // The invitation needs a zero that is KNOWN to be zero. `total` is fed by two
   // separate queries and a failure of either reads as empty, so an image with
@@ -148,21 +151,36 @@ export function StickerPlacementBar({
         {canPlace && (
           <Tooltip
             /**
-             * 🔴 The price, always — never "free".
+             * 🔴 The price, always — plus the reason free is unavailable, when
+             * it is.
              *
-             * `freeRemaining` is the CREATOR's capacity and says nothing about
-             * this viewer: somebody who has spent today's allowance, or already
-             * free-placed on this image, would be promised free and then pay a
-             * number they were never shown. Only the standing query answers that,
-             * and this bar deliberately does not make it — it renders per feed
-             * card, so it would be one request per card.
+             * `freeSlotsRemaining` alone is the CREATOR's capacity and says
+             * nothing about this viewer, which is how the old label promised
+             * free to somebody who had spent their day and then charged them a
+             * number they were never shown. Both facts are now in hand, so the
+             * tooltip can say which of the two ran out instead of leaving the
+             * reader to find out by pressing.
              *
-             * So the bar states the fact it has (the count beside this, which is
-             * about the creator) and makes no claim about the offer. The offer is
-             * made in the tray, where the standing is known.
+             * ⚠️ `freeSlotsRemaining === 0` covers two different facts and only
+             * `freeSlots` tells them apart: the resolver short-circuits the
+             * reservation count when there is no capacity, so zero is both "this
+             * creator takes no free placements" — nothing to say — and "their
+             * slots are all currently held", which is worth saying because a
+             * decline gives one back. `barTooltip` branches on both.
+             *
+             * The one rule left un-checked here is "already free-placed on THIS
+             * image", which needs a per-image query and would cost one request
+             * per feed card. The tray checks it before anything is committed.
              */
-            label={`Place a sticker · ${space?.price} Buzz`}
+            label={barTooltip({
+              price: space?.price ?? 0,
+              space: space ?? undefined,
+              allowanceRemaining: allowance?.remaining,
+              resetsAt: allowance?.resetsAt,
+            })}
             withArrow
+            multiline
+            w={260}
           >
             <Button
               size="compact-sm"
@@ -170,11 +188,7 @@ export function StickerPlacementBar({
               variant="light"
               color="yellow"
               onClick={() => openTray(imageId)}
-              aria-label={
-                showsFree
-                  ? `Place a sticker · ${freeRemaining} of ${freeSlots} free`
-                  : 'Place a sticker'
-              }
+              aria-label={freeLabel ? `Place a sticker · ${freeLabel}` : 'Place a sticker'}
               // A plus rather than a second sticker glyph: beside a count of
               // stickers it reads as "add one" without a word, which is what
               // keeps the fused control narrow enough to belong in this row.
@@ -189,17 +203,19 @@ export function StickerPlacementBar({
               // states compete rather than agree.
               style={{
                 ...buttonStyling?.('BuzzTip')?.style,
-                ...(inviting || freeRemaining > 0 ? inviteStyle : null),
+                ...(inviting || freeLabel ? inviteStyle : null),
               }}
             >
               <IconPlus size={16} stroke={2.5} />
-              {/* One number. Rendered even at zero remaining, because a full
-                  space is a thing worth knowing — a slot comes back on a
-                  decline — while a creator who takes no free placements has
-                  nothing to say and gets no label at all. */}
-              {showsFree && (
+              {/* Only where the viewer can actually take it. The old label
+                  counted the creator's slots and said nothing about the reader,
+                  so a spent allowance still read as "1 of 1 free" on every image
+                  in the feed. A state worth knowing but not offering — a full
+                  space, a spent day — is now said in the tooltip instead, where
+                  it can give the reason and the price together. */}
+              {freeLabel && (
                 <Text size="xs" fw={600} className="ml-1">
-                  {freeRemaining} of {freeSlots} free
+                  {freeLabel}
                 </Text>
               )}
             </Button>

--- a/src/components/Sticker/StickerPlacementBar.tsx
+++ b/src/components/Sticker/StickerPlacementBar.tsx
@@ -79,15 +79,24 @@ export function StickerPlacementBar({
    * The viewer's own half of the answer.
    *
    * One query for the whole page rather than one per card: the allowance belongs
-   * to the person, so every bar in a feed shares its cache key. That is what
-   * makes it affordable to check, and checking is the point — the label below
-   * used to be the creator's capacity alone, which promised free placements to
-   * people who had already spent theirs.
+   * to the person, so every bar on a page shares one cache key and one request.
+   * That is what makes it affordable to check, and checking is the point — the
+   * label below used to be the creator's capacity alone, which promised free
+   * placements to people who had already spent theirs.
    *
-   * Not asked of a signed-out viewer, who has no allowance and would get a 401
-   * per page from a protected procedure.
+   * ⚠️ Today this bar has ONE callsite, the image detail view; feed cards mount
+   * `StickerPlacementCardBadge`, which cannot place. So the present cost is one
+   * request per detail view. The per-card reasoning is for the future this
+   * component was written toward, and it is what keeps that future cheap — but
+   * do not read "per feed card" here as a description of what ships now.
+   *
+   * Gated on `canPlace`, which already requires a signed-in viewer — the
+   * procedure is protected, so asking without one is a 401 per page it renders
+   * on. One condition rather than two so the guard is testable: `!!currentUser`
+   * alongside it can never be the reason this is false, so a test claiming to
+   * pin it would be asserting something it cannot fail on.
    */
-  const { allowance } = useFreePlacementAllowance(!!currentUser && canPlace);
+  const { allowance } = useFreePlacementAllowance(canPlace);
 
   // `null` until BOTH facts are known, and absent rather than paid while the
   // allowance is loading — a label that appears a beat late is quieter than a
@@ -131,7 +140,16 @@ export function StickerPlacementBar({
           <StickerCountChip
             count={0}
             revealed={revealed}
-            tooltip={`Place a sticker · ${space?.price} Buzz`}
+            // The same sentence the plus beside it gets. They open the same
+            // tray with the same action, so a hand-written price line here
+            // would let the two disagree the moment the plus started saying
+            // "free, or N Buzz" — which is exactly what this change made it do.
+            tooltip={barTooltip({
+              price: space?.price ?? 0,
+              space: space ?? undefined,
+              allowanceRemaining: allowance?.remaining,
+              resetsAt: allowance?.resetsAt,
+            })}
             // Distinct from the plus beside it, which is also "Place a sticker".
             // They share a Button.Group and an action, so identical names read
             // to a screen reader as the same control announced twice.
@@ -169,8 +187,10 @@ export function StickerPlacementBar({
              * decline gives one back. `barTooltip` branches on both.
              *
              * The one rule left un-checked here is "already free-placed on THIS
-             * image", which needs a per-image query and would cost one request
-             * per feed card. The tray checks it before anything is committed.
+             * image", which needs a per-image query — affordable on the detail
+             * view where this bar lives today, not on the feed it is written
+             * toward. The tray checks it before anything is committed, so the
+             * residual is an over-offer the tray corrects, never a wrong charge.
              */
             label={barTooltip({
               price: space?.price ?? 0,

--- a/src/components/Sticker/StickerPlacementTray.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementTray.browser.test.tsx
@@ -1,0 +1,191 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import type * as PlacementUtil from '~/components/Sticker/placement.util';
+import type * as Trpc from '~/utils/trpc';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { StickerPlacementTray } from '~/components/Sticker/StickerPlacementTray';
+
+/**
+ * The tray's pre-commit reason: why free is unavailable, said while both options
+ * are still on screen.
+ *
+ * 🔴 This file exists because the reason was rendered by nothing under test. The
+ * branches of `preCommitFreeReason` are covered exhaustively as a pure function
+ * in `__tests__/free-offer.test.ts`, and the reaction-bar suite mocks this whole
+ * component away — so deleting the block that renders the sentence left every
+ * suite in the repo green while half of what the change is for silently stopped
+ * reaching a screen.
+ *
+ * Scoped to that one line. The tray's drag-out gesture, shop panel and purchase
+ * path are somebody else's tests.
+ */
+const IMAGE_ID = 1;
+
+const queryState = {
+  /** The creator's side: capacity, and how much of it is currently held. */
+  freeSlots: 1,
+  freeSlotsRemaining: 1,
+  /** The viewer's side. `usedHere` is the rule only this surface can see. */
+  remaining: 1,
+  usedHere: false,
+};
+
+// Spread the real module rather than hand-listing it, so this test does not
+// couple itself to the tray's whole transitive import graph.
+vi.mock('~/components/Sticker/placement.util', async (importOriginal) => ({
+  ...(await importOriginal<typeof PlacementUtil>()),
+  useImagePlacementSpace: () => ({
+    space: {
+      mode: 'open',
+      price: 100,
+      ownerId: 999,
+      freeSlots: queryState.freeSlots,
+      freeSlotsRemaining: queryState.freeSlotsRemaining,
+    },
+    isLoading: false,
+  }),
+  useFreePlacementStanding: () => ({
+    standing: {
+      used: 1 - queryState.remaining,
+      remaining: queryState.remaining,
+      usedHere: queryState.usedHere,
+      resetsAt: new Date('2026-08-21T00:00:00.000Z'),
+    },
+    isLoading: false,
+  }),
+}));
+
+// The tray only renders for the image whose session is open, so the store is
+// driven rather than mocked away — `showing` is what gates everything below it.
+vi.mock('~/store/sticker-placement-draft.store', () => ({
+  useStickerPlacementDraftStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      targetImageId: IMAGE_ID,
+      trayOpen: true,
+      drafts: [],
+      closeTray: () => undefined,
+      setTray: () => undefined,
+      begin: () => undefined,
+    }),
+}));
+
+// Owning nothing is the tray's simplest state and says nothing about the free
+// offer, which is the only thing this file asserts.
+vi.mock('~/components/Sticker/sticker.util', () => ({
+  useOwnedSticker: () => ({ sticker: [], isLoading: false }),
+}));
+vi.mock('~/components/Sticker/StickerShopPanel', () => ({ StickerShopPanel: () => null }));
+vi.mock('~/components/Sticker/StickerShopTile', () => ({ StickerShopTile: () => null }));
+vi.mock('~/components/Sticker/use-sticker-drag-out', () => ({
+  useStickerDragOut: () => ({ grab: () => undefined, dragging: false }),
+}));
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 7 }) }));
+
+// The tray calls two cosmetic queries directly. The scaffold is network-free and
+// provides no tRPC client, so an unmocked `trpc.*` render throws and this file
+// would assert against an empty body — which is why the harness note says tRPC
+// hooks are mocked per test.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof Trpc>()),
+  trpc: {
+    cosmetic: {
+      getStickerBalances: { useQuery: () => ({ data: [] }) },
+      getStickerOffers: { useQuery: () => ({ data: [] }) },
+    },
+  },
+}));
+
+const renderTray = async () => {
+  renderWithProviders(<StickerPlacementTray imageId={IMAGE_ID} />);
+  await expect.element(page.getByText(/Drag a sticker onto the image/)).toBeInTheDocument();
+};
+
+describe('StickerPlacementTray — the reason free is unavailable', () => {
+  test('says the allowance is spent, and what it is shared with, before anything is placed', async () => {
+    Object.assign(queryState, {
+      freeSlots: 1,
+      freeSlotsRemaining: 1,
+      remaining: 0,
+      usedHere: false,
+    });
+    await renderTray();
+
+    await expect.element(page.getByText(/used today's free placement/)).toBeInTheDocument();
+    // The second ticket: this reader may well have spent it on a remix gallery,
+    // and without this clause the sticker surface cannot account for where it
+    // went.
+    await expect
+      .element(page.getByText(/shared between stickers and remix galleries/))
+      .toBeInTheDocument();
+  });
+
+  test('says a free sticker was already used on this image', async () => {
+    // The rule the reaction bar cannot see — a per-image fact — which is why the
+    // tray is the surface that has to say it.
+    Object.assign(queryState, {
+      freeSlots: 1,
+      freeSlotsRemaining: 1,
+      remaining: 1,
+      usedHere: true,
+    });
+    await renderTray();
+
+    await expect
+      .element(page.getByText(/already used a free sticker on this image/))
+      .toBeInTheDocument();
+  });
+
+  test('does not tell someone who has pressed nothing that they lost a race', async () => {
+    Object.assign(queryState, {
+      freeSlots: 1,
+      freeSlotsRemaining: 0,
+      remaining: 1,
+      usedHere: false,
+    });
+    await renderTray();
+
+    await expect.element(page.getByText(/free slot on this image is taken/)).toBeInTheDocument();
+    // "Someone took the last free slot FIRST" is the post-refusal wording and is
+    // false about a reader who has not pressed anything.
+    expect(page.getByText(/first/i).elements()).toHaveLength(0);
+  });
+
+  /**
+   * 🔴 Silence, which is the state most of the site is in.
+   *
+   * Free is genuinely on offer here, so a sentence explaining why it is not
+   * would be both wrong and alarming. Asserted with a positive control in the
+   * same render — the price line — so this cannot pass because the tray failed
+   * to render at all.
+   */
+  test('says nothing about a refusal when free is on offer', async () => {
+    Object.assign(queryState, {
+      freeSlots: 1,
+      freeSlotsRemaining: 1,
+      remaining: 1,
+      usedHere: false,
+    });
+    await renderTray();
+
+    await expect.element(page.getByText(/Free, or 100 Buzz/)).toBeInTheDocument();
+    expect(page.getByText(/used today's free placement/).elements()).toHaveLength(0);
+    expect(page.getByText(/already used a free sticker/).elements()).toHaveLength(0);
+    expect(page.getByText(/free slot on this image is taken/).elements()).toHaveLength(0);
+  });
+
+  test('says nothing on an image whose creator never offered free', async () => {
+    Object.assign(queryState, {
+      freeSlots: 0,
+      freeSlotsRemaining: 0,
+      remaining: 0,
+      usedHere: false,
+    });
+    await renderTray();
+
+    // The price line still renders — the tray is fine, it simply has no refusal
+    // to explain, because nobody was offered anything.
+    await expect.element(page.getByText(/100 Buzz \+ one use/)).toBeInTheDocument();
+    expect(page.getByText(/used today's free placement/).elements()).toHaveLength(0);
+  });
+});

--- a/src/components/Sticker/StickerPlacementTray.tsx
+++ b/src/components/Sticker/StickerPlacementTray.tsx
@@ -1,14 +1,9 @@
 import { Button, CloseButton, Group, ScrollArea, Text, ThemeIcon } from '@mantine/core';
-import { IconPlus, IconSticker } from '@tabler/icons-react';
+import { IconAlertTriangle, IconInfoCircle, IconPlus, IconSticker } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
-import {
-  freeOfferFor,
-  preCommitFreeReason,
-  trayPriceLine,
-  trayReviewLine,
-} from '~/components/Sticker/free-offer';
+import { freeOfferFor, preCommitFreeReason, trayNotes } from '~/components/Sticker/free-offer';
 import { StickerShopPanel } from '~/components/Sticker/StickerShopPanel';
 import { StickerShopTile } from '~/components/Sticker/StickerShopTile';
 import { useStickerDragOut } from '~/components/Sticker/use-sticker-drag-out';
@@ -160,6 +155,13 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
    * appearing on ordinary paid images are two `&&`s nothing can observe.
    */
   const freeUnavailableReason = preCommitFreeReason(freeAvailable, standing, space);
+
+  const notes = trayNotes({
+    freeAvailable,
+    price,
+    review: space?.mode === 'review',
+    reason: freeUnavailableReason,
+  });
   // Says the panel can be got out of the way, and that more than one is allowed,
   // only once there is something that would survive it. Before that both are
   // instructions about nothing.
@@ -182,26 +184,32 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
               <Text size="sm" fw={600}>
                 {instruction}
               </Text>
-              <Text size="xs" c="dimmed">
-                {/* Both sentences come from `free-offer.ts`, where their
-                    branches are covered — inline here, dropping either ternary
-                    is a mutation nothing in the suite can observe, and what it
-                    produces is the exact contradiction these lines exist to
-                    prevent. The free half of the decline warning is
-                    FREE_REVIEW_CAVEAT itself rather than a paraphrase. */}
-                {trayPriceLine(freeAvailable, price)}
-                {space?.mode === 'review' &&
-                  ' · this creator reviews placements, so only you will see it until they approve.'}
-                {space?.mode === 'review' && trayReviewLine(freeAvailable)}
-                {/* Before the press, not after it. Its own line rather than
-                    appended, because it is about the reader while everything
-                    above it is about the placement. */}
-                {freeUnavailableReason && (
-                  <Text component="span" size="xs" display="block" className="mt-1">
-                    {freeUnavailableReason}
-                  </Text>
-                )}
-              </Text>
+              {/* One short line each, with an icon, rather than one sentence
+                  spanning the panel. Which lines exist and what they say is
+                  decided in `free-offer.ts`, where every branch is covered;
+                  this only draws them. */}
+              <div className="mt-0.5 flex flex-col gap-0.5">
+                {notes.map((note) => (
+                  <div key={note.id} className="flex items-start gap-1.5">
+                    {note.tone === 'warn' ? (
+                      <IconAlertTriangle
+                        size={13}
+                        className="mt-0.5 shrink-0 text-yellow-6"
+                        aria-hidden
+                      />
+                    ) : (
+                      <IconInfoCircle
+                        size={13}
+                        className="mt-0.5 shrink-0 opacity-60"
+                        aria-hidden
+                      />
+                    )}
+                    <Text size="xs" c={note.tone === 'warn' ? 'yellow.6' : 'dimmed'}>
+                      {note.text}
+                    </Text>
+                  </div>
+                ))}
+              </div>
             </div>
             <CloseButton
               onClick={closeTray}

--- a/src/components/Sticker/StickerPlacementTray.tsx
+++ b/src/components/Sticker/StickerPlacementTray.tsx
@@ -3,7 +3,12 @@ import { IconPlus, IconSticker } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
-import { freeOfferFor, trayPriceLine, trayReviewLine } from '~/components/Sticker/free-offer';
+import {
+  freeOfferFor,
+  preCommitFreeReason,
+  trayPriceLine,
+  trayReviewLine,
+} from '~/components/Sticker/free-offer';
 import { StickerShopPanel } from '~/components/Sticker/StickerShopPanel';
 import { StickerShopTile } from '~/components/Sticker/StickerShopTile';
 import { useStickerDragOut } from '~/components/Sticker/use-sticker-drag-out';
@@ -145,6 +150,16 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
   // The same predicate the draft's own control uses, so the sentence here and
   // the button down there cannot disagree about what is on offer.
   const freeAvailable = !!freeOfferFor(space, standing);
+
+  /**
+   * Why free is off the table, said while the choice is still being made rather
+   * than after the server has refused it.
+   *
+   * Every branch of that decision is in `free-offer.ts`, where a test can put
+   * all four states to it — inline here, the guards that keep the sentence from
+   * appearing on ordinary paid images are two `&&`s nothing can observe.
+   */
+  const freeUnavailableReason = preCommitFreeReason(freeAvailable, standing, space);
   // Says the panel can be got out of the way, and that more than one is allowed,
   // only once there is something that would survive it. Before that both are
   // instructions about nothing.
@@ -178,6 +193,14 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
                 {space?.mode === 'review' &&
                   ' · this creator reviews placements, so only you will see it until they approve.'}
                 {space?.mode === 'review' && trayReviewLine(freeAvailable)}
+                {/* Before the press, not after it. Its own line rather than
+                    appended, because it is about the reader while everything
+                    above it is about the placement. */}
+                {freeUnavailableReason && (
+                  <Text component="span" size="xs" display="block" className="mt-1">
+                    {freeUnavailableReason}
+                  </Text>
+                )}
               </Text>
             </div>
             <CloseButton

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -390,48 +390,51 @@ describe('the reset the refusal names', () => {
 /**
  * The reaction bar, which is where this whole thing went wrong.
  *
- * The bar renders per feed card and used to print the creator's capacity —
- * `N of M free` — in a place every reader takes as an offer to themselves. Two
- * people reported the same thing within a day of launch: the label said free,
- * the placement cost Buzz.
+ * The bar printed the creator's capacity — `N of M free` — in a place every
+ * reader takes as an offer to themselves. Two people reported the same thing
+ * within a day of launch: the label said free, the placement cost Buzz.
  *
  * These sit here rather than in the component for the reason the rest of this
  * file does: the branches are the product decision, and a component test that
- * renders one of them proves nothing about the other three.
+ * renders one of them proves nothing about the other four.
  */
 describe('the bar offers free only where the reader can take it', () => {
   const SLOTS_OPEN = { freeSlots: 4, freeSlotsRemaining: 2 };
   const SLOTS_HELD = { freeSlots: 4, freeSlotsRemaining: 0 };
   const NO_FREE = { freeSlots: 0, freeSlotsRemaining: 0 };
+  const READY = { remaining: 1, usedHere: false };
 
-  it('labels the smaller of the two scarcities', () => {
+  it('labels the smaller of the two counts', () => {
     // The creator has two going spare; the reader may take one. Quoting the
     // creator's number here is the original defect.
-    expect(barFreeLabel(SLOTS_OPEN, 1)).toBe('1 free');
+    expect(barFreeLabel(SLOTS_OPEN, READY)).toBe('1 free');
     // And the other way round: a reader with allowance to spare is still bounded
     // by the image.
-    expect(barFreeLabel({ freeSlots: 4, freeSlotsRemaining: 1 }, 3)).toBe('1 free');
+    expect(
+      barFreeLabel({ freeSlots: 4, freeSlotsRemaining: 1 }, { remaining: 3, usedHere: false })
+    ).toBe('1 free');
   });
 
   it.each([
-    ['the viewer has spent their day', SLOTS_OPEN, 0],
-    ['the creator takes no free placements', NO_FREE, 1],
-    ['every slot on the image is held', SLOTS_HELD, 1],
-  ])('says nothing when %s', (_name, space, remaining) => {
-    expect(barFreeLabel(space, remaining)).toBeNull();
+    ['the viewer has spent their day', SLOTS_OPEN, { remaining: 0, usedHere: false }],
+    ['they already used a free one here', SLOTS_OPEN, { remaining: 1, usedHere: true }],
+    ['the creator takes no free placements', NO_FREE, READY],
+    ['every slot on the image is held', SLOTS_HELD, READY],
+  ])('says nothing when %s', (_name, space, standing) => {
+    expect(barFreeLabel(space, standing)).toBeNull();
   });
 
   /**
-   * 🔴 `undefined` is not zero.
+   * 🔴 `undefined` is not "no allowance".
    *
-   * In flight, the honest render is no label at all. Treating it as zero shows
-   * the paid state and then adds "free" a beat later on every card in the feed;
-   * treating it as one promises something that may not exist. Absent becomes
-   * present quietly, which is the only transition that costs the reader nothing.
+   * In flight, the honest render is no label at all. Treating it as spent shows
+   * the paid state and then adds "free" a beat later; treating it as available
+   * promises something that may not exist. Absent becomes present quietly, which
+   * is the only transition that costs the reader nothing.
    */
-  it('claims nothing while the allowance is still loading', () => {
+  it('claims nothing while the standing is still loading', () => {
     expect(barFreeLabel(SLOTS_OPEN, undefined)).toBeNull();
-    expect(barFreeLabel(undefined, 1)).toBeNull();
+    expect(barFreeLabel(undefined, READY)).toBeNull();
   });
 });
 
@@ -440,6 +443,9 @@ describe('the bar tooltip names the price, and the reason when there is one', ()
   const SLOTS_HELD = { freeSlots: 4, freeSlotsRemaining: 0 };
   const NO_FREE = { freeSlots: 0, freeSlotsRemaining: 0 };
   const RESETS = new Date('2026-08-21T00:00:00.000Z');
+  const READY = { remaining: 1, usedHere: false, resetsAt: RESETS };
+  const SPENT = { remaining: 0, usedHere: false, resetsAt: RESETS };
+  const USED_HERE = { remaining: 1, usedHere: true, resetsAt: RESETS };
 
   /**
    * The price in every branch. That rule predates this change — it is what kept
@@ -447,23 +453,17 @@ describe('the bar tooltip names the price, and the reason when there is one', ()
    * addition to it, never a replacement.
    */
   it.each([
-    ['free on offer', SLOTS_OPEN, 1],
-    ['a spent allowance', SLOTS_OPEN, 0],
-    ['slots all held', SLOTS_HELD, 1],
-    ['a creator who takes none', NO_FREE, 1],
-  ])('quotes the price with %s', (_name, space, remaining) => {
-    expect(
-      barTooltip({ price: 100, space, allowanceRemaining: remaining, resetsAt: RESETS })
-    ).toMatch(/100 Buzz/);
+    ['free on offer', SLOTS_OPEN, READY],
+    ['a spent allowance', SLOTS_OPEN, SPENT],
+    ['a free one already used here', SLOTS_OPEN, USED_HERE],
+    ['slots all held', SLOTS_HELD, READY],
+    ['a creator who takes none', NO_FREE, READY],
+  ])('quotes the price with %s', (_name, space, standing) => {
+    expect(barTooltip({ price: 100, space, standing })).toMatch(/100 Buzz/);
   });
 
   it('explains a spent allowance and names what it is shared with', () => {
-    const tip = barTooltip({
-      price: 100,
-      space: SLOTS_OPEN,
-      allowanceRemaining: 0,
-      resetsAt: RESETS,
-    });
+    const tip = barTooltip({ price: 100, space: SLOTS_OPEN, standing: SPENT });
 
     expect(tip).toMatch(/used today's free placement/);
     // The second ticket, in the sentence that needs it most: this reader's
@@ -475,21 +475,43 @@ describe('the bar tooltip names the price, and the reason when there is one', ()
   });
 
   /**
+   * 🔴 One ladder, asserted as one.
+   *
+   * An earlier version of this tooltip wrote its own wording for two of these
+   * states, so the bar and the tray could describe the same fact differently.
+   * Now it defers, and this pins that: the sentence after the price IS the
+   * tray's, character for character.
+   */
+  it.each([
+    ['already used here', SLOTS_OPEN, USED_HERE],
+    ['slots all held', SLOTS_HELD, READY],
+    ['allowance spent', SLOTS_OPEN, SPENT],
+  ])('says exactly what the tray says — %s', (_name, space, standing) => {
+    const reason = preCommitFreeReason(false, standing, space);
+
+    expect(reason).not.toBeNull();
+    expect(barTooltip({ price: 100, space, standing })).toBe(
+      `Place a sticker · 100 Buzz. ${reason}`
+    );
+  });
+
+  /**
    * The two zeroes that look alike. `freeSlotsRemaining === 0` is both "takes no
    * free placements" and "all currently held", and only `freeSlots` separates
    * them — the first has nothing to say, the second says something worth acting
    * on, because a decline returns the slot.
    */
   it('tells a held slot apart from a creator who takes none', () => {
-    const held = barTooltip({ price: 100, space: SLOTS_HELD, allowanceRemaining: 1 });
-    const none = barTooltip({ price: 100, space: NO_FREE, allowanceRemaining: 1 });
-
-    expect(held).toMatch(/comes back if the creator declines/);
-    expect(none).toBe('Place a sticker · 100 Buzz');
+    expect(barTooltip({ price: 100, space: SLOTS_HELD, standing: READY })).toMatch(
+      /comes back if the creator declines/
+    );
+    expect(barTooltip({ price: 100, space: NO_FREE, standing: READY })).toBe(
+      'Place a sticker · 100 Buzz'
+    );
   });
 
   it('offers both prices when free is genuinely available', () => {
-    const tip = barTooltip({ price: 100, space: SLOTS_OPEN, allowanceRemaining: 1 });
+    const tip = barTooltip({ price: 100, space: SLOTS_OPEN, standing: READY });
 
     expect(tip).toMatch(/free, or 100 Buzz/);
     expect(tip).toMatch(new RegExp(SHARED_ALLOWANCE_NOTE));
@@ -498,22 +520,21 @@ describe('the bar tooltip names the price, and the reason when there is one', ()
   /**
    * Loading is not "spent". A tooltip asserting a reset time from a defaulted
    * zero tells a reader with a free placement in hand that they have none — for
-   * as long as the query takes, on every card.
+   * as long as the query takes.
    */
-  it('promises and refuses nothing while the allowance is unknown', () => {
-    const tip = barTooltip({ price: 100, space: SLOTS_OPEN, allowanceRemaining: undefined });
-
-    expect(tip).toBe('Place a sticker · 100 Buzz');
+  it('promises and refuses nothing while the standing is unknown', () => {
+    expect(barTooltip({ price: 100, space: SLOTS_OPEN, standing: undefined })).toBe(
+      'Place a sticker · 100 Buzz'
+    );
   });
 
   /**
    * The space query is in flight too, and the bar passes `space ?? undefined`
-   * while it is. Its own case rather than folded into the one above: dropping
-   * the `!space ||` guard is a TypeError on `space.freeSlots`, not a copy bug,
-   * and nothing else in this file would catch it.
+   * while it is. Its own case: dropping the `!space ||` guard is a TypeError on
+   * `space.freeSlots`, not a copy bug, and nothing else here would catch it.
    */
   it('survives having no space at all', () => {
-    expect(barTooltip({ price: 100, space: undefined, allowanceRemaining: 1 })).toBe(
+    expect(barTooltip({ price: 100, space: undefined, standing: READY })).toBe(
       'Place a sticker · 100 Buzz'
     );
   });
@@ -580,7 +601,7 @@ describe('the tray says why free is unavailable before anything is committed', (
     expect(reason).not.toMatch(/first/i);
     // And the bar says the same sentence for the same state, which is the point
     // of it being a constant rather than two hand-written lines.
-    expect(barTooltip({ price: 100, space: held, allowanceRemaining: 1 })).toContain(
+    expect(barTooltip({ price: 100, space: held, standing: READY })).toContain(
       FREE_SLOT_TAKEN_NOTE
     );
   });

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -15,8 +15,7 @@ import {
   freeRefusalOutcome,
   isPlacingFree,
   preCommitFreeReason,
-  trayPriceLine,
-  trayReviewLine,
+  trayNotes,
 } from '~/components/Sticker/free-offer';
 
 describe('the free option is a price, not a process', () => {
@@ -318,46 +317,106 @@ describe('what a refused free claim does next', () => {
 });
 
 /**
- * The tray's two sentences, here rather than in the component because inline
- * neither ternary was observable: dropping either one turns nothing red and
- * produces the exact contradiction the lines exist to prevent.
+ * The tray's lines.
+ *
+ * They were one sentence, concatenated with ` · ` separators, spanning the full
+ * width of the panel — and at that width nobody read to the end. They are now
+ * one short line each, and the coupling went with the prose: no fragment has to
+ * know whether another will be appended after it, which is what made a full stop
+ * in one of them render a separator mid-sentence.
  */
-describe('the tray states both offers when both are open', () => {
-  it('names free and the price together, with the use as the constant', () => {
-    const both = trayPriceLine(true, 700);
+describe('the tray says its piece in short lines', () => {
+  const texts = (notes: ReturnType<typeof trayNotes>) => notes.map((note) => note.text).join(' | ');
 
-    expect(both).toMatch(/Free/);
-    expect(both).toMatch(/700 Buzz/);
+  it('names free and the price together when both are open', () => {
+    const notes = trayNotes({ freeAvailable: true, price: 700, review: false });
+
+    expect(texts(notes)).toMatch(/Free, or 700 Buzz/);
     // Free of the creator's price and of nothing else. Without this the tray and
     // the Place button disagree about what a sticker costs.
-    expect(both).toMatch(/one use either way/);
+    expect(texts(notes)).toMatch(/one use either way/);
   });
 
   it('names only the price when free is not on offer', () => {
-    const paid = trayPriceLine(false, 700);
+    const notes = trayNotes({ freeAvailable: false, price: 700, review: false });
 
-    expect(paid).toBe('700 Buzz + one use');
-    expect(paid).not.toMatch(/[Ff]ree/);
+    expect(texts(notes)).toBe('700 Buzz + one use');
+    expect(texts(notes)).not.toMatch(/[Ff]ree/);
+  });
+
+  it('names the shared budget only where there is a free one to spend', () => {
+    // Case-insensitive: the line capitalises the clause, because on a row of
+    // its own it starts the sentence rather than continuing one.
+    expect(texts(trayNotes({ freeAvailable: true, price: 700, review: false }))).toMatch(
+      new RegExp(SHARED_ALLOWANCE_NOTE, 'i')
+    );
+    // Explaining a limit to somebody who has nothing to spend against it is
+    // noise about a thing they did not ask for.
+    expect(texts(trayNotes({ freeAvailable: false, price: 700, review: false }))).not.toMatch(
+      new RegExp(SHARED_ALLOWANCE_NOTE, 'i')
+    );
   });
 
   /**
    * 🔴 The free half is `FREE_REVIEW_CAVEAT` itself, not a paraphrase. Three
    * places in the product state what a decline costs a free placer — this, the
-   * caveat under the draft's own free option, and `declineConsequence` on the
-   * owner's side — and two of the three now come from one constant.
+   * line under the draft's own Place button, and `declineConsequence` on the
+   * owner's side — and two of the three come from one constant.
    */
   it('reuses the owned caveat rather than restating it', () => {
-    expect(trayReviewLine(true)).toContain(FREE_REVIEW_CAVEAT);
+    expect(texts(trayNotes({ freeAvailable: true, price: 700, review: true }))).toContain(
+      FREE_REVIEW_CAVEAT
+    );
   });
 
-  it('keeps the paid fee disclosure in both branches', () => {
-    // Where both offers are open, somebody choosing to pay still needs it.
-    for (const freeAvailable of [true, false])
-      expect(trayReviewLine(freeAvailable)).toMatch(/part of what you paid/);
+  it('keeps the paid fee disclosure where the space reviews', () => {
+    expect(texts(trayNotes({ freeAvailable: false, price: 700, review: true }))).toMatch(
+      /part of what you paid/
+    );
   });
 
-  it('says nothing about an allowance when free is not on offer', () => {
-    expect(trayReviewLine(false)).not.toMatch(/allowance/);
+  it('says nothing about review on a space that does not review', () => {
+    const notes = trayNotes({ freeAvailable: true, price: 700, review: false });
+
+    expect(texts(notes)).not.toMatch(/approves/);
+    expect(texts(notes)).not.toMatch(/decline/);
+  });
+
+  /**
+   * The reason is last and warns, because it is the only line about the READER
+   * rather than about the placement — and it is the one they are looking for
+   * when free is not on offer.
+   */
+  it('puts the refusal last, and marks it', () => {
+    const notes = trayNotes({
+      freeAvailable: false,
+      price: 700,
+      review: true,
+      reason: 'You have already used a free sticker on this image.',
+    });
+
+    expect(notes[notes.length - 1]).toEqual({
+      id: 'reason',
+      tone: 'warn',
+      text: 'You have already used a free sticker on this image.',
+    });
+  });
+
+  it('adds no line at all when there is no reason to give', () => {
+    expect(
+      trayNotes({ freeAvailable: true, price: 700, review: true, reason: null }).some(
+        (note) => note.id === 'reason'
+      )
+    ).toBe(false);
+  });
+
+  /**
+   * Every line is its own row, so none of them can end up inside another. This
+   * is what the ` · ` concatenation could not promise.
+   */
+  it('keeps each line separate and short', () => {
+    for (const note of trayNotes({ freeAvailable: true, price: 700, review: true }))
+      expect(note.text.length).toBeLessThan(60);
   });
 });
 
@@ -608,15 +667,5 @@ describe('the shared-allowance note tracks the rules it describes', () => {
    */
   it('fails if a surface is added to the shared budget without updating the copy', () => {
     expect(Object.keys(PLACEMENT_SURFACES).sort()).toEqual(['remixGallery', 'sticker']);
-  });
-
-  /**
-   * The tray appends ` · this creator reviews placements…` straight onto the
-   * price line, so a terminated sentence there renders a separator mid-sentence.
-   * Asserted on the composed line rather than on the constant, because that is
-   * where the defect is visible and the constant alone cannot show it.
-   */
-  it('leaves the tray price line open for the clause that follows it', () => {
-    expect(trayPriceLine(true, 700).endsWith('.')).toBe(false);
   });
 });

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -454,7 +454,7 @@ describe('the free hint is shown only where there is something to take', () => {
   const USED_HERE = { remaining: 1, usedHere: true, resetsAt: RESETS };
 
   it('announces a free sticker when the reader actually has one', () => {
-    expect(freeHintText(SLOTS_OPEN, READY)).toBe('You have a free sticker today');
+    expect(freeHintText(SLOTS_OPEN, READY)).toBe('Daily free sticker');
   });
 
   it('counts, when the reader can take more than one', () => {

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import {
+  barFreeLabel,
+  barTooltip,
   FREE_REVIEW_CAVEAT,
   freeOfferFor,
   freeOptionLabel,
   freeRefusalMessage,
   freeRefusalOutcome,
   isPlacingFree,
+  preCommitFreeReason,
+  SHARED_ALLOWANCE_NOTE,
   trayPriceLine,
   trayReviewLine,
 } from '~/components/Sticker/free-offer';
@@ -375,5 +379,169 @@ describe('the reset the refusal names', () => {
     expect(freeRefusalMessage({ ...spent, resetsAt: 'not a date' }, open)).toMatch(
       /comes back at midnight UTC/
     );
+  });
+});
+
+/**
+ * The reaction bar, which is where this whole thing went wrong.
+ *
+ * The bar renders per feed card and used to print the creator's capacity —
+ * `N of M free` — in a place every reader takes as an offer to themselves. Two
+ * people reported the same thing within a day of launch: the label said free,
+ * the placement cost Buzz.
+ *
+ * These sit here rather than in the component for the reason the rest of this
+ * file does: the branches are the product decision, and a component test that
+ * renders one of them proves nothing about the other three.
+ */
+describe('the bar offers free only where the reader can take it', () => {
+  const SLOTS_OPEN = { freeSlots: 4, freeSlotsRemaining: 2 };
+  const SLOTS_HELD = { freeSlots: 4, freeSlotsRemaining: 0 };
+  const NO_FREE = { freeSlots: 0, freeSlotsRemaining: 0 };
+
+  it('labels the smaller of the two scarcities', () => {
+    // The creator has two going spare; the reader may take one. Quoting the
+    // creator's number here is the original defect.
+    expect(barFreeLabel(SLOTS_OPEN, 1)).toBe('1 free');
+    // And the other way round: a reader with allowance to spare is still bounded
+    // by the image.
+    expect(barFreeLabel({ freeSlots: 4, freeSlotsRemaining: 1 }, 3)).toBe('1 free');
+  });
+
+  it.each([
+    ['the viewer has spent their day', SLOTS_OPEN, 0],
+    ['the creator takes no free placements', NO_FREE, 1],
+    ['every slot on the image is held', SLOTS_HELD, 1],
+  ])('says nothing when %s', (_name, space, remaining) => {
+    expect(barFreeLabel(space, remaining)).toBeNull();
+  });
+
+  /**
+   * 🔴 `undefined` is not zero.
+   *
+   * In flight, the honest render is no label at all. Treating it as zero shows
+   * the paid state and then adds "free" a beat later on every card in the feed;
+   * treating it as one promises something that may not exist. Absent becomes
+   * present quietly, which is the only transition that costs the reader nothing.
+   */
+  it('claims nothing while the allowance is still loading', () => {
+    expect(barFreeLabel(SLOTS_OPEN, undefined)).toBeNull();
+    expect(barFreeLabel(undefined, 1)).toBeNull();
+  });
+});
+
+describe('the bar tooltip names the price, and the reason when there is one', () => {
+  const SLOTS_OPEN = { freeSlots: 4, freeSlotsRemaining: 2 };
+  const SLOTS_HELD = { freeSlots: 4, freeSlotsRemaining: 0 };
+  const NO_FREE = { freeSlots: 0, freeSlotsRemaining: 0 };
+  const RESETS = new Date('2026-08-21T00:00:00.000Z');
+
+  /**
+   * The price in every branch. That rule predates this change — it is what kept
+   * the old label from being an outright lie about cost — and the reason is an
+   * addition to it, never a replacement.
+   */
+  it.each([
+    ['free on offer', SLOTS_OPEN, 1],
+    ['a spent allowance', SLOTS_OPEN, 0],
+    ['slots all held', SLOTS_HELD, 1],
+    ['a creator who takes none', NO_FREE, 1],
+  ])('quotes the price with %s', (_name, space, remaining) => {
+    expect(
+      barTooltip({ price: 100, space, allowanceRemaining: remaining, resetsAt: RESETS })
+    ).toMatch(/100 Buzz/);
+  });
+
+  it('explains a spent allowance and names what it is shared with', () => {
+    const tip = barTooltip({
+      price: 100,
+      space: SLOTS_OPEN,
+      allowanceRemaining: 0,
+      resetsAt: RESETS,
+    });
+
+    expect(tip).toMatch(/used today's free placement/);
+    // The second ticket, in the sentence that needs it most: this reader's
+    // allowance may well have gone on a remix gallery, and without this the
+    // sticker surface has no explanation for where it went.
+    expect(tip).toMatch(new RegExp(SHARED_ALLOWANCE_NOTE));
+    // Read off the server's own reset rather than restating the boundary.
+    expect(tip).toMatch(/00:00 UTC/);
+  });
+
+  /**
+   * The two zeroes that look alike. `freeSlotsRemaining === 0` is both "takes no
+   * free placements" and "all currently held", and only `freeSlots` separates
+   * them — the first has nothing to say, the second says something worth acting
+   * on, because a decline returns the slot.
+   */
+  it('tells a held slot apart from a creator who takes none', () => {
+    const held = barTooltip({ price: 100, space: SLOTS_HELD, allowanceRemaining: 1 });
+    const none = barTooltip({ price: 100, space: NO_FREE, allowanceRemaining: 1 });
+
+    expect(held).toMatch(/comes back if the creator declines/);
+    expect(none).toBe('Place a sticker · 100 Buzz');
+  });
+
+  it('offers both prices when free is genuinely available', () => {
+    const tip = barTooltip({ price: 100, space: SLOTS_OPEN, allowanceRemaining: 1 });
+
+    expect(tip).toMatch(/free, or 100 Buzz/);
+    expect(tip).toMatch(new RegExp(SHARED_ALLOWANCE_NOTE));
+  });
+
+  /**
+   * Loading is not "spent". A tooltip asserting a reset time from a defaulted
+   * zero tells a reader with a free placement in hand that they have none — for
+   * as long as the query takes, on every card.
+   */
+  it('promises and refuses nothing while the allowance is unknown', () => {
+    const tip = barTooltip({ price: 100, space: SLOTS_OPEN, allowanceRemaining: undefined });
+
+    expect(tip).toBe('Place a sticker · 100 Buzz');
+  });
+});
+
+/**
+ * The tray's pre-commit reason.
+ *
+ * The strings were always there; what was missing was a caller that ran BEFORE
+ * the placement. This gate is the caller, and its two silences are as much the
+ * product decision as the sentences are.
+ */
+describe('the tray says why free is unavailable before anything is committed', () => {
+  const HAS_SLOT = { freeSlots: 4, freeSlotsRemaining: 2 };
+  const NO_FREE = { freeSlots: 0, freeSlotsRemaining: 0 };
+  const SPENT = { remaining: 0, usedHere: false };
+  const READY = { remaining: 1, usedHere: false };
+  const USED_HERE = { remaining: 1, usedHere: true };
+
+  it('explains a spent allowance while both offers are still on screen', () => {
+    expect(preCommitFreeReason(false, SPENT, HAS_SLOT)).toMatch(/used today's free placement/);
+  });
+
+  it('explains a free placement already used on this image', () => {
+    // Once ever, not once per day — so this one does not lift at midnight, and
+    // saying it does would send someone back tomorrow to the same refusal.
+    expect(preCommitFreeReason(false, USED_HERE, HAS_SLOT)).toMatch(/already used a free sticker/);
+  });
+
+  /**
+   * 🔴 Silence is the correct output here, and it is the half a test is most
+   * likely to skip.
+   */
+  it('says nothing when free is on offer', () => {
+    expect(preCommitFreeReason(true, READY, HAS_SLOT)).toBeNull();
+  });
+
+  it('says nothing on an image whose creator never offered free', () => {
+    // True of most of the site. Narrating it on every ordinary paid image turns
+    // a limit nobody was promised into a notice everybody reads.
+    expect(preCommitFreeReason(false, SPENT, NO_FREE)).toBeNull();
+  });
+
+  it('says nothing until both facts have arrived', () => {
+    expect(preCommitFreeReason(false, undefined, HAS_SLOT)).toBeNull();
+    expect(preCommitFreeReason(false, SPENT, undefined)).toBeNull();
   });
 });

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -462,7 +462,7 @@ describe('the free hint is shown only where there is something to take', () => {
     // promise more than the image can accept.
     expect(
       freeHintText({ freeSlots: 4, freeSlotsRemaining: 3 }, { remaining: 2, usedHere: false })
-    ).toBe('You have 2 free stickers today');
+    ).toBe('2 daily free stickers');
   });
 
   /**

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { FREE_PLACEMENTS_PER_DAY, PLACEMENT_SURFACES } from '~/shared/utils/placement';
+import {
+  FREE_PLACEMENTS_PER_DAY,
+  FREE_SLOT_TAKEN_NOTE,
+  PLACEMENT_SURFACES,
+  SHARED_ALLOWANCE_NOTE,
+} from '~/shared/utils/placement';
 import {
   barFreeLabel,
   barTooltip,
@@ -10,7 +15,6 @@ import {
   freeRefusalOutcome,
   isPlacingFree,
   preCommitFreeReason,
-  SHARED_ALLOWANCE_NOTE,
   trayPriceLine,
   trayReviewLine,
 } from '~/components/Sticker/free-offer';
@@ -501,6 +505,18 @@ describe('the bar tooltip names the price, and the reason when there is one', ()
 
     expect(tip).toBe('Place a sticker · 100 Buzz');
   });
+
+  /**
+   * The space query is in flight too, and the bar passes `space ?? undefined`
+   * while it is. Its own case rather than folded into the one above: dropping
+   * the `!space ||` guard is a TypeError on `space.freeSlots`, not a copy bug,
+   * and nothing else in this file would catch it.
+   */
+  it('survives having no space at all', () => {
+    expect(barTooltip({ price: 100, space: undefined, allowanceRemaining: 1 })).toBe(
+      'Place a sticker · 100 Buzz'
+    );
+  });
 });
 
 /**
@@ -545,6 +561,43 @@ describe('the tray says why free is unavailable before anything is committed', (
     expect(preCommitFreeReason(false, undefined, HAS_SLOT)).toBeNull();
     expect(preCommitFreeReason(false, SPENT, undefined)).toBeNull();
   });
+
+  /**
+   * 🔴 The rung that had to be worded twice.
+   *
+   * `freeRefusalMessage`'s version is "Someone took the last free slot on this
+   * image FIRST" — written for a placer who pressed and lost a race. Before the
+   * press the reader has pressed nothing, so "first" is false, and the bar's own
+   * tooltip says something different for the identical state. Both now take
+   * `FREE_SLOT_TAKEN_NOTE`, and this pins that the pre-commit path does not fall
+   * through to the post-race wording.
+   */
+  it('does not tell someone who has pressed nothing that they lost a race', () => {
+    const held = { freeSlots: 4, freeSlotsRemaining: 0 };
+    const reason = preCommitFreeReason(false, READY, held);
+
+    expect(reason).toBe(FREE_SLOT_TAKEN_NOTE);
+    expect(reason).not.toMatch(/first/i);
+    // And the bar says the same sentence for the same state, which is the point
+    // of it being a constant rather than two hand-written lines.
+    expect(barTooltip({ price: 100, space: held, allowanceRemaining: 1 })).toContain(
+      FREE_SLOT_TAKEN_NOTE
+    );
+  });
+
+  /**
+   * The ordering the substitution must not disturb: a permanent refusal still
+   * outranks the transient one. Both conditions are true here, and the answer
+   * has to be the one that does not lift by itself.
+   */
+  it('still prefers the permanent refusal when both are true', () => {
+    expect(preCommitFreeReason(false, USED_HERE, { freeSlots: 4, freeSlotsRemaining: 0 })).toMatch(
+      /already used a free sticker/
+    );
+    expect(preCommitFreeReason(false, SPENT, { freeSlots: 4, freeSlotsRemaining: 0 })).toMatch(
+      /used today's free placement/
+    );
+  });
 });
 
 /**
@@ -552,6 +605,22 @@ describe('the tray says why free is unavailable before anything is committed', (
  * does not own.
  */
 describe('the shared-allowance note tracks the rules it describes', () => {
+  /**
+   * 🔴 The derivation is PARTIAL, and this is the tripwire for the half it does
+   * not reach.
+   *
+   * The note says "one a day" from the constant, but the sentences around it are
+   * singular and hand-written — "You have used today's free placement", "Your
+   * free one is…", and `barFreeLabel`'s `Math.min`, which caps a label at the
+   * allowance. Move the constant to 2 and the note updates while those keep
+   * asserting one. So the note's own derivation is not enough on its own: this
+   * asserts the value the rest of the copy is written for, and goes red if it
+   * moves, pointing at the sentences that need rewriting.
+   */
+  it('fails if the daily count moves away from what the copy assumes', () => {
+    expect(FREE_PLACEMENTS_PER_DAY).toBe(1);
+  });
+
   it('reads its count from the rule rather than spelling one out', () => {
     // Goes red if `FREE_PLACEMENTS_PER_DAY` moves and the copy does not, which
     // is the whole reason the number is derived. "one" is the English for 1; any

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { FREE_PLACEMENTS_PER_DAY, PLACEMENT_SURFACES } from '~/shared/utils/placement';
 import {
   barFreeLabel,
   barTooltip,
@@ -543,5 +544,42 @@ describe('the tray says why free is unavailable before anything is committed', (
   it('says nothing until both facts have arrived', () => {
     expect(preCommitFreeReason(false, undefined, HAS_SLOT)).toBeNull();
     expect(preCommitFreeReason(false, SPENT, undefined)).toBeNull();
+  });
+});
+
+/**
+ * The shared-allowance clause: one string that has to stay true to two rules it
+ * does not own.
+ */
+describe('the shared-allowance note tracks the rules it describes', () => {
+  it('reads its count from the rule rather than spelling one out', () => {
+    // Goes red if `FREE_PLACEMENTS_PER_DAY` moves and the copy does not, which
+    // is the whole reason the number is derived. "one" is the English for 1; any
+    // other value renders as the digit.
+    const expected = FREE_PLACEMENTS_PER_DAY === 1 ? 'one' : String(FREE_PLACEMENTS_PER_DAY);
+    expect(SHARED_ALLOWANCE_NOTE.startsWith(`${expected} a day`)).toBe(true);
+  });
+
+  /**
+   * 🔴 A rule someone can fail.
+   *
+   * The surface list is written out in English and cannot be derived, so nothing
+   * would notice a third surface joining the shared budget — both surfaces would
+   * quietly keep describing a two-way split. This is the tripwire: add a surface
+   * to `PLACEMENT_SURFACES` and this goes red, pointing at the copy that needs
+   * the third name.
+   */
+  it('fails if a surface is added to the shared budget without updating the copy', () => {
+    expect(Object.keys(PLACEMENT_SURFACES).sort()).toEqual(['remixGallery', 'sticker']);
+  });
+
+  /**
+   * The tray appends ` · this creator reviews placements…` straight onto the
+   * price line, so a terminated sentence there renders a separator mid-sentence.
+   * Asserted on the composed line rather than on the constant, because that is
+   * where the defect is visible and the constant alone cannot show it.
+   */
+  it('leaves the tray price line open for the clause that follows it', () => {
+    expect(trayPriceLine(true, 700).endsWith('.')).toBe(false);
   });
 });

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -7,9 +7,9 @@ import {
 } from '~/shared/utils/placement';
 import {
   barFreeLabel,
-  barTooltip,
   FREE_REVIEW_CAVEAT,
   freeOfferFor,
+  freeHintText,
   freeOptionLabel,
   freeRefusalMessage,
   freeRefusalOutcome,
@@ -19,27 +19,33 @@ import {
   trayReviewLine,
 } from '~/components/Sticker/free-offer';
 
-describe('the free option carries the mode', () => {
-  it('says instant on an auto-accept space and needs review otherwise', () => {
-    expect(freeOptionLabel(true)).toBe('Free · instant');
-    expect(freeOptionLabel(false)).toBe('Free · needs review');
-  });
-
+describe('the free option is a price, not a process', () => {
   /**
-   * The distinction is the whole reason the mode is on this option rather than on
-   * the sticker button: a placer choosing between two offers needs to know which
-   * one goes live now. A label that read the same either way would leave the mode
-   * a hidden setting again.
+   * 🔴 It used to read `Free · instant` / `Free · needs review` beside a plain
+   * `100 Buzz`. Justin, on seeing it: "it makes it seem like the other one's not
+   * going to need review". Both options go to the creator on a review space and
+   * both are live at once on an auto one — the mode was never a property of the
+   * FREE option, it is a property of the space, and putting it on one of two
+   * segments made it read as the difference between them.
    */
-  it('reads differently in the two modes', () => {
-    expect(freeOptionLabel(true)).not.toBe(freeOptionLabel(false));
+  it('says nothing about review, on either kind of space', () => {
+    expect(freeOptionLabel()).toBe('Free');
   });
+});
 
-  it('states the asymmetry a decline creates', () => {
-    // The image's slot comes back and the placer's day does not, which is the
-    // one fact somebody might choose to pay to avoid.
-    expect(FREE_REVIEW_CAVEAT).toMatch(/spent even if they decline/);
-    expect(FREE_REVIEW_CAVEAT).toMatch(/allowance does not/);
+/**
+ * What a decline costs the placer, which is the one line under the button.
+ */
+describe('the caveat says what pressing spends', () => {
+  it('names the spend and the decline in one clause', () => {
+    // Shrunk from two sentences about the asymmetry between the creator's slot
+    // and the placer's day. The fact that has to land is that pressing spends
+    // it, and that a decline does not give it back.
+    expect(FREE_REVIEW_CAVEAT).toMatch(/Spends your free placement/);
+    expect(FREE_REVIEW_CAVEAT).toMatch(/even if they decline/);
+    // Short enough to sit in a chip under the button rather than as a paragraph
+    // above it — the shape Justin asked for.
+    expect(FREE_REVIEW_CAVEAT.length).toBeLessThan(70);
   });
 });
 
@@ -438,7 +444,7 @@ describe('the bar offers free only where the reader can take it', () => {
   });
 });
 
-describe('the bar tooltip names the price, and the reason when there is one', () => {
+describe('the free hint is shown only where there is something to take', () => {
   const SLOTS_OPEN = { freeSlots: 4, freeSlotsRemaining: 2 };
   const SLOTS_HELD = { freeSlots: 4, freeSlotsRemaining: 0 };
   const NO_FREE = { freeSlots: 0, freeSlotsRemaining: 0 };
@@ -447,96 +453,38 @@ describe('the bar tooltip names the price, and the reason when there is one', ()
   const SPENT = { remaining: 0, usedHere: false, resetsAt: RESETS };
   const USED_HERE = { remaining: 1, usedHere: true, resetsAt: RESETS };
 
-  /**
-   * The price in every branch. That rule predates this change — it is what kept
-   * the old label from being an outright lie about cost — and the reason is an
-   * addition to it, never a replacement.
-   */
-  it.each([
-    ['free on offer', SLOTS_OPEN, READY],
-    ['a spent allowance', SLOTS_OPEN, SPENT],
-    ['a free one already used here', SLOTS_OPEN, USED_HERE],
-    ['slots all held', SLOTS_HELD, READY],
-    ['a creator who takes none', NO_FREE, READY],
-  ])('quotes the price with %s', (_name, space, standing) => {
-    expect(barTooltip({ price: 100, space, standing })).toMatch(/100 Buzz/);
+  it('announces a free sticker when the reader actually has one', () => {
+    expect(freeHintText(SLOTS_OPEN, READY)).toBe('You have a free sticker today');
   });
 
-  it('explains a spent allowance and names what it is shared with', () => {
-    const tip = barTooltip({ price: 100, space: SLOTS_OPEN, standing: SPENT });
-
-    expect(tip).toMatch(/used today's free placement/);
-    // The second ticket, in the sentence that needs it most: this reader's
-    // allowance may well have gone on a remix gallery, and without this the
-    // sticker surface has no explanation for where it went.
-    expect(tip).toMatch(new RegExp(SHARED_ALLOWANCE_NOTE));
-    // Read off the server's own reset rather than restating the boundary.
-    expect(tip).toMatch(/00:00 UTC/);
+  it('counts, when the reader can take more than one', () => {
+    // Bounded by the smaller of the two, like the label — the hint must not
+    // promise more than the image can accept.
+    expect(
+      freeHintText({ freeSlots: 4, freeSlotsRemaining: 3 }, { remaining: 2, usedHere: false })
+    ).toBe('You have 2 free stickers today');
   });
 
   /**
-   * 🔴 One ladder, asserted as one.
+   * 🔴 The silences, which are the whole reason this replaced a tooltip rather
+   * than being added beside one.
    *
-   * An earlier version of this tooltip wrote its own wording for two of these
-   * states, so the bar and the tray could describe the same fact differently.
-   * Now it defers, and this pins that: the sentence after the price IS the
-   * tray's, character for character.
+   * A popover that appears to tell you what you CANNOT have is an interruption
+   * on somebody else's image. Every unavailable state says nothing at the bar
+   * and is explained in the tray, at the point the choice is made.
    */
   it.each([
-    ['already used here', SLOTS_OPEN, USED_HERE],
-    ['slots all held', SLOTS_HELD, READY],
-    ['allowance spent', SLOTS_OPEN, SPENT],
-  ])('says exactly what the tray says — %s', (_name, space, standing) => {
-    const reason = preCommitFreeReason(false, standing, space);
-
-    expect(reason).not.toBeNull();
-    expect(barTooltip({ price: 100, space, standing })).toBe(
-      `Place a sticker · 100 Buzz. ${reason}`
-    );
+    ['the allowance is spent', SLOTS_OPEN, SPENT],
+    ['a free one was already used here', SLOTS_OPEN, USED_HERE],
+    ['the slot on this image is held', SLOTS_HELD, READY],
+    ['the creator takes no free placements', NO_FREE, READY],
+  ])('stays silent when %s', (_name, space, standing) => {
+    expect(freeHintText(space, standing)).toBeNull();
   });
 
-  /**
-   * The two zeroes that look alike. `freeSlotsRemaining === 0` is both "takes no
-   * free placements" and "all currently held", and only `freeSlots` separates
-   * them — the first has nothing to say, the second says something worth acting
-   * on, because a decline returns the slot.
-   */
-  it('tells a held slot apart from a creator who takes none', () => {
-    expect(barTooltip({ price: 100, space: SLOTS_HELD, standing: READY })).toMatch(
-      /comes back if the creator declines/
-    );
-    expect(barTooltip({ price: 100, space: NO_FREE, standing: READY })).toBe(
-      'Place a sticker · 100 Buzz'
-    );
-  });
-
-  it('offers both prices when free is genuinely available', () => {
-    const tip = barTooltip({ price: 100, space: SLOTS_OPEN, standing: READY });
-
-    expect(tip).toMatch(/free, or 100 Buzz/);
-    expect(tip).toMatch(new RegExp(SHARED_ALLOWANCE_NOTE));
-  });
-
-  /**
-   * Loading is not "spent". A tooltip asserting a reset time from a defaulted
-   * zero tells a reader with a free placement in hand that they have none — for
-   * as long as the query takes.
-   */
-  it('promises and refuses nothing while the standing is unknown', () => {
-    expect(barTooltip({ price: 100, space: SLOTS_OPEN, standing: undefined })).toBe(
-      'Place a sticker · 100 Buzz'
-    );
-  });
-
-  /**
-   * The space query is in flight too, and the bar passes `space ?? undefined`
-   * while it is. Its own case: dropping the `!space ||` guard is a TypeError on
-   * `space.freeSlots`, not a copy bug, and nothing else here would catch it.
-   */
-  it('survives having no space at all', () => {
-    expect(barTooltip({ price: 100, space: undefined, standing: READY })).toBe(
-      'Place a sticker · 100 Buzz'
-    );
+  it('claims nothing while either query is still loading', () => {
+    expect(freeHintText(SLOTS_OPEN, undefined)).toBeNull();
+    expect(freeHintText(undefined, READY)).toBeNull();
   });
 });
 
@@ -589,9 +537,9 @@ describe('the tray says why free is unavailable before anything is committed', (
    * `freeRefusalMessage`'s version is "Someone took the last free slot on this
    * image FIRST" — written for a placer who pressed and lost a race. Before the
    * press the reader has pressed nothing, so "first" is false, and the bar's own
-   * tooltip says something different for the identical state. Both now take
-   * `FREE_SLOT_TAKEN_NOTE`, and this pins that the pre-commit path does not fall
-   * through to the post-race wording.
+   * bar said something different for the identical state, back when the bar
+   * spoke at all. `FREE_SLOT_TAKEN_NOTE` is what survived, and this pins that
+   * the pre-commit path does not fall through to the post-race wording.
    */
   it('does not tell someone who has pressed nothing that they lost a race', () => {
     const held = { freeSlots: 4, freeSlotsRemaining: 0 };
@@ -599,11 +547,10 @@ describe('the tray says why free is unavailable before anything is committed', (
 
     expect(reason).toBe(FREE_SLOT_TAKEN_NOTE);
     expect(reason).not.toMatch(/first/i);
-    // And the bar says the same sentence for the same state, which is the point
-    // of it being a constant rather than two hand-written lines.
-    expect(barTooltip({ price: 100, space: held, standing: READY })).toContain(
-      FREE_SLOT_TAKEN_NOTE
-    );
+    // The bar says nothing at all in this state now — no tooltip, and the hint
+    // is only for a free placement the reader can actually take — so the tray is
+    // the only place this sentence appears.
+    expect(freeHintText(held, READY)).toBeNull();
   });
 
   /**

--- a/src/components/Sticker/free-hint.module.scss
+++ b/src/components/Sticker/free-hint.module.scss
@@ -1,0 +1,42 @@
+/**
+ * The daily-free hint's wiggle.
+ *
+ * It fires once on appearance rather than looping: the hint is an offer, not an
+ * alarm, and something that never stops moving beside a creator's image is a
+ * nag. Two beats is enough to catch an eye that was already on the picture.
+ *
+ * Transform-only, so it composites on its own layer and never reflows the row it
+ * points at.
+ */
+.wiggle {
+  animation: hint-wiggle 700ms ease-in-out 1;
+  transform-origin: center bottom;
+}
+
+@keyframes hint-wiggle {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  15% {
+    transform: rotate(-3.5deg);
+  }
+  35% {
+    transform: rotate(3deg);
+  }
+  55% {
+    transform: rotate(-2deg);
+  }
+  75% {
+    transform: rotate(1deg);
+  }
+}
+
+/* Movement is the whole point of this class, so there is nothing to soften — it
+   simply does not run for somebody who asked for less of it. The hint still
+   appears, in the same place, saying the same thing. */
+@media (prefers-reduced-motion: reduce) {
+  .wiggle {
+    animation: none;
+  }
+}

--- a/src/components/Sticker/free-offer.ts
+++ b/src/components/Sticker/free-offer.ts
@@ -239,82 +239,72 @@ function allowanceResetLabel(resetsAt?: Date | string) {
  * 🔴 **This is the fix for the whole ticket.** The bar used to print the
  * creator's `N of M free` capacity, which is a fact about the IMAGE, in a place
  * every reader takes as an offer to THEM — so a viewer who had spent their day
- * saw "1 of 1 free" on every image in the feed, pressed it, and was charged.
- * Justin hit it live in a meeting; a user hit it ninety minutes after launch.
+ * saw "1 of 1 free" on every image, pressed it, and was charged. Justin hit it
+ * live in a meeting; a user hit it ninety minutes after launch.
  *
- * Both scarcities have to hold before the word "free" is allowed on screen: the
- * creator must have an open slot AND the viewer must still have their placement
- * for today. The number is the smaller of the two, because that is how many the
- * reader can actually use.
+ * All three rules have to hold before the word "free" is allowed on screen: the
+ * creator must have an open slot, the viewer must still have their placement for
+ * today, and they must not already have free-placed on this image. The number is
+ * the smaller of the two counts, because that is how many the reader can take.
  *
- * ⚠️ **`allowanceRemaining` is `undefined` while the query is in flight, and
- * that is not zero.** Rendering the paid state on `undefined` would flash the
- * price and then add a free label a beat later on every card in the feed; the
- * label is simply absent until the answer lands, which is the same thing an
- * image with no free capacity shows.
- *
- * The one rule the bar cannot see is "already used a free placement on THIS
- * image" — that needs a per-image query, which is exactly the per-card cost this
- * design avoids. The tray makes that check before anything is committed.
+ * ⚠️ **`standing` is `undefined` while the query is in flight, and that is not
+ * "no allowance".** Rendering the paid state on `undefined` would flash the
+ * price and then add a free label a beat later; the label is simply absent until
+ * the answer lands, which is what an image with no free capacity also shows.
  */
-export function barFreeLabel(
-  space: FreeCapacity | undefined,
-  allowanceRemaining: number | undefined
-) {
-  if (!space || allowanceRemaining == null) return null;
+export function barFreeLabel(space?: FreeCapacity, standing?: FreeStanding) {
+  if (!space || !standing) return null;
   if (space.freeSlots <= 0 || space.freeSlotsRemaining <= 0) return null;
-  if (allowanceRemaining <= 0) return null;
+  if (standing.remaining <= 0 || standing.usedHere) return null;
 
-  return `${Math.min(space.freeSlotsRemaining, allowanceRemaining)} free`;
+  return `${Math.min(space.freeSlotsRemaining, standing.remaining)} free`;
 }
 
 /**
  * The bar's tooltip: the price always, and the reason free is off the table when
  * it is.
  *
- * The price stays in every branch. That was already the rule — the tooltip is
- * what stopped the old label being an outright lie about cost — and it survives
- * because the reason is the addition, not the replacement.
+ * The price stays in every branch. That rule predates this change — it is what
+ * kept the old label from being an outright lie about cost — and the reason is
+ * an addition to it, never a replacement.
  *
- * Ordered like `freeRefusalMessage` and for the same reason: a refusal that is
- * permanent for this image outranks one that lifts by itself, so nobody is
- * promised a midnight reset that will not change what this creator offers.
+ * 🔴 **One ladder, not two.** An earlier version restated two of
+ * `freeRefusalMessage`'s rungs in its own words, so the bar and the tray could
+ * describe the same state differently — on the one fact this change exists to
+ * stop drifting. The bar now reads the same per-image standing the tray does, so
+ * it can defer to `preCommitFreeReason` outright and own only the price.
  *
- * It is a separate ladder because it answers a different question — this one
- * from a bar that cannot see `usedHere`, that one from a surface that can — but
- * every SENTENCE the two share now comes from one place (`spentAllowanceNote`,
- * `FREE_SLOT_TAKEN_NOTE`). What differs is which rungs exist and in what order,
- * not how any of them is worded.
-
- * ⚠️ An ERRORED allowance query is `undefined` too, and renders exactly like a
- * loading one: the bare price, no free label anywhere on the page. Deliberate
- * and fail-closed — nobody is promised something they cannot have — but it does
- * mean a 401 makes the free tier invisible rather than noisy.
+ * ⚠️ An ERRORED standing query is `undefined` too, and renders exactly like a
+ * loading one: the bare price, no free label. Deliberate and fail-closed —
+ * nobody is promised something they cannot have — but it does mean a 401 makes
+ * the free tier invisible rather than noisy.
  */
 export function barTooltip({
   price,
   space,
-  allowanceRemaining,
-  resetsAt,
+  standing,
 }: {
   price: number;
   space?: FreeCapacity;
-  allowanceRemaining?: number;
-  resetsAt?: Date | string;
+  standing?: FreeStanding;
 }) {
   const base = `Place a sticker · ${price} Buzz`;
 
-  // Nothing free is on offer here for anyone, so there is nothing to explain.
+  // Nothing free is on offer here for anyone, so there is nothing to explain —
+  // and nothing to wait for either, which is why this outranks the loading gate.
   if (!space || space.freeSlots <= 0) return base;
 
   // Still loading. Say the price and claim nothing about the offer.
-  if (allowanceRemaining == null) return base;
+  if (!standing) return base;
 
-  if (allowanceRemaining <= 0) return `${base}. ${spentAllowanceNote(resetsAt)}`;
+  if (barFreeLabel(space, standing))
+    return `Place a sticker · free, or ${price} Buzz. Your free one is ${SHARED_ALLOWANCE_NOTE}.`;
 
-  if (space.freeSlotsRemaining <= 0) return `${base}. ${FREE_SLOT_TAKEN_NOTE}`;
+  // `false` for `freeAvailable`, because the line above already established
+  // there is no offer. Everything after that is the tray's ladder, verbatim.
+  const reason = preCommitFreeReason(false, standing, space);
 
-  return `Place a sticker · free, or ${price} Buzz. Your free one is ${SHARED_ALLOWANCE_NOTE}.`;
+  return reason ? `${base}. ${reason}` : base;
 }
 
 /**

--- a/src/components/Sticker/free-offer.ts
+++ b/src/components/Sticker/free-offer.ts
@@ -111,13 +111,52 @@ export function freeRefusalMessage(standing?: FreeStanding, space?: FreeCapacity
   // Transient, and it says when it lifts — derived from the reset the server
   // computed rather than restating the boundary here.
   if (standing && standing.remaining <= 0)
-    return `You have used today's free placement. It comes back ${allowanceResetLabel(
+    return `You have used today's free placement — ${SHARED_ALLOWANCE_NOTE}. It comes back ${allowanceResetLabel(
       standing.resetsAt
     )}.`;
   // The most transient of all — a declined placement releases its slot at once.
   if (space && space.freeSlotsRemaining <= 0)
     return 'Someone took the last free slot on this image first.';
   return null;
+}
+
+/**
+ * The reason free is unavailable, said while the choice is still being made — or
+ * `null` when there is nothing worth saying.
+ *
+ * 🔴 **The reason existed and was only ever shown AFTER the server refused.**
+ * `freeRefusalMessage` had exactly one consumer, the post-refusal handler, so
+ * somebody who had spent their day or already free-placed here saw a plain paid
+ * button, pressed it, and paid. The remix modal has rendered its reason inline
+ * since it shipped; this is that pattern for the surface that lacked it.
+ *
+ * Two guards, and each one is a state where the sentence would be worse than
+ * silence:
+ *
+ * - **`freeAvailable`** — free is on the table, so there is no refusal to
+ *   explain. Without this the ladder's last rung would narrate a slot count at
+ *   somebody about to take one.
+ * - **`freeSlots <= 0`** — this creator takes no free placements at all, which
+ *   is the first rung and true of every ordinary paid image. Nobody is waiting
+ *   on an offer that was never made, so it would be noise on most of the site.
+ *
+ * Both inputs must have arrived. Asserted from defaulted zeroes this tells a
+ * fresh reader their allowance is spent for as long as the query takes.
+ *
+ * Separate from `freeRefusalMessage` rather than folded into it, because that
+ * one answers a refusal that already happened and may not be about the free tier
+ * at all — its `null` return is load-bearing there in a way it is not here.
+ */
+export function preCommitFreeReason(
+  freeAvailable: boolean,
+  standing?: FreeStanding,
+  space?: FreeCapacity
+) {
+  if (freeAvailable) return null;
+  if (!space || !standing) return null;
+  if (space.freeSlots <= 0) return null;
+
+  return freeRefusalMessage(standing, space);
 }
 
 /**
@@ -167,6 +206,101 @@ function allowanceResetLabel(resetsAt?: Date | string) {
 }
 
 /**
+ * What the daily allowance is shared with, in one clause.
+ *
+ * 🔴 **One constant, because the sharing is the fact people get wrong.** Every
+ * string that mentions the daily free is on one of two surfaces, and each used
+ * to say "today's allowance" as though it were its own — so somebody who spent
+ * it submitting a remix met a sticker surface that had no explanation for why
+ * free was gone, and read a limit as a bug. Said once here, both surfaces cannot
+ * drift into describing two different budgets.
+ *
+ * Written as a clause rather than a sentence so it can be appended to whatever
+ * came before it without a second full stop.
+ */
+export const SHARED_ALLOWANCE_NOTE = 'one a day, shared between stickers and remix galleries';
+
+/**
+ * The free label on the reaction bar, or `null` for no label at all.
+ *
+ * 🔴 **This is the fix for the whole ticket.** The bar used to print the
+ * creator's `N of M free` capacity, which is a fact about the IMAGE, in a place
+ * every reader takes as an offer to THEM — so a viewer who had spent their day
+ * saw "1 of 1 free" on every image in the feed, pressed it, and was charged.
+ * Justin hit it live in a meeting; a user hit it ninety minutes after launch.
+ *
+ * Both scarcities have to hold before the word "free" is allowed on screen: the
+ * creator must have an open slot AND the viewer must still have their placement
+ * for today. The number is the smaller of the two, because that is how many the
+ * reader can actually use.
+ *
+ * ⚠️ **`allowanceRemaining` is `undefined` while the query is in flight, and
+ * that is not zero.** Rendering the paid state on `undefined` would flash the
+ * price and then add a free label a beat later on every card in the feed; the
+ * label is simply absent until the answer lands, which is the same thing an
+ * image with no free capacity shows.
+ *
+ * The one rule the bar cannot see is "already used a free placement on THIS
+ * image" — that needs a per-image query, which is exactly the per-card cost this
+ * design avoids. The tray makes that check before anything is committed.
+ */
+export function barFreeLabel(
+  space: FreeCapacity | undefined,
+  allowanceRemaining: number | undefined
+) {
+  if (!space || allowanceRemaining == null) return null;
+  if (space.freeSlots <= 0 || space.freeSlotsRemaining <= 0) return null;
+  if (allowanceRemaining <= 0) return null;
+
+  return `${Math.min(space.freeSlotsRemaining, allowanceRemaining)} free`;
+}
+
+/**
+ * The bar's tooltip: the price always, and the reason free is off the table when
+ * it is.
+ *
+ * The price stays in every branch. That was already the rule — the tooltip is
+ * what stopped the old label being an outright lie about cost — and it survives
+ * because the reason is the addition, not the replacement.
+ *
+ * Ordered like `freeRefusalMessage` and for the same reason: a refusal that is
+ * permanent for this image outranks one that lifts by itself, so nobody is
+ * promised a midnight reset that will not change what this creator offers. The
+ * two ladders stay separate because they answer different questions — this one
+ * before the press, from a bar that cannot see `usedHere`; that one after a
+ * refusal, from a surface that can.
+ */
+export function barTooltip({
+  price,
+  space,
+  allowanceRemaining,
+  resetsAt,
+}: {
+  price: number;
+  space?: FreeCapacity;
+  allowanceRemaining?: number;
+  resetsAt?: Date | string;
+}) {
+  const base = `Place a sticker · ${price} Buzz`;
+
+  // Nothing free is on offer here for anyone, so there is nothing to explain.
+  if (!space || space.freeSlots <= 0) return base;
+
+  // Still loading. Say the price and claim nothing about the offer.
+  if (allowanceRemaining == null) return base;
+
+  if (allowanceRemaining <= 0)
+    return `${base}. You have used today's free placement — ${SHARED_ALLOWANCE_NOTE}. Yours is back ${allowanceResetLabel(
+      resetsAt
+    )}.`;
+
+  if (space.freeSlotsRemaining <= 0)
+    return `${base}. The free slot on this image is taken — it comes back if the creator declines.`;
+
+  return `Place a sticker · free, or ${price} Buzz. Your free one is ${SHARED_ALLOWANCE_NOTE}.`;
+}
+
+/**
  * The tray's price line, which has to name both offers when both are open.
  *
  * The use is the constant: a free placement is free of the creator's price and of
@@ -174,7 +308,9 @@ function allowanceResetLabel(resetsAt?: Date | string) {
  * disagreeing about what a sticker costs.
  */
 export const trayPriceLine = (freeAvailable: boolean, price: number) =>
-  freeAvailable ? `Free, or ${price} Buzz · one use either way` : `${price} Buzz + one use`;
+  freeAvailable
+    ? `Free, or ${price} Buzz · one use either way. Your free one is ${SHARED_ALLOWANCE_NOTE}.`
+    : `${price} Buzz + one use`;
 
 /**
  * What the tray says a decline costs on a review-mode space.

--- a/src/components/Sticker/free-offer.ts
+++ b/src/components/Sticker/free-offer.ts
@@ -292,30 +292,82 @@ export function freeHintText(space?: FreeCapacity, standing?: FreeStanding) {
 }
 
 /**
- * The tray's price line, which has to name both offers when both are open.
+ * What the tray says, as separate short lines rather than one sentence.
  *
- * The use is the constant: a free placement is free of the creator's price and of
- * nothing else. Saying so here is what stops the tray and the Place button
- * disagreeing about what a sticker costs.
+ * 🔴 **The prose version was unreadable.** It ran the full width of the panel —
+ * price, then review, then what a decline costs, then why free was unavailable,
+ * concatenated with ` · ` separators — and at that width nobody reads to the
+ * end. Justin, looking at it: "the text is just way too long there… completely
+ * unreadable."
+ *
+ * Lines also fix a defect the concatenation kept producing: each fragment had to
+ * know whether another would be appended after it, so a full stop added to one
+ * of them rendered a separator mid-sentence. A list has no such coupling.
+ *
+ * Ordered by what changes a decision: what it costs, what happens to it, what
+ * pressing spends, and last the reason free is off the table — which is the only
+ * one that is about the reader rather than the placement.
+ *
+ * `tone` picks the icon at the render site rather than naming one here, so this
+ * module stays free of anything that has to be mounted to be tested.
  */
-export const trayPriceLine = (freeAvailable: boolean, price: number) =>
-  freeAvailable
-    ? `Free, or ${price} Buzz · one use either way, and your free one is ${SHARED_ALLOWANCE_NOTE}`
-    : `${price} Buzz + one use`;
+export type TrayNote = { id: string; tone: 'info' | 'warn'; text: string };
 
-/**
- * What the tray says a decline costs on a review-mode space.
- *
- * 🔴 The free half is `FREE_REVIEW_CAVEAT` itself rather than a paraphrase of it.
- * There are three statements of this rule in the product — this one, the caveat
- * under the draft's own free option, and `declineConsequence`'s free branch on the
- * owner's side — and two of the three now come from one constant, so a change to
- * what a decline costs cannot leave a stale copy behind in the tray.
- *
- * The paid half is kept in both branches: where both offers are open, somebody
- * choosing to pay still needs the fee disclosure.
- */
-export const trayReviewLine = (freeAvailable: boolean) =>
-  freeAvailable
-    ? ` ${FREE_REVIEW_CAVEAT} A paid placement leaves part of what you paid with them.`
-    : ' If they decline, part of what you paid stays with them.';
+export function trayNotes({
+  freeAvailable,
+  price,
+  review,
+  reason,
+}: {
+  freeAvailable: boolean;
+  price: number;
+  /** The space reviews placements, so nothing goes live until the owner says so. */
+  review: boolean;
+  /** From `preCommitFreeReason` — `null` whenever free is genuinely on offer. */
+  reason?: string | null;
+}): TrayNote[] {
+  const notes: TrayNote[] = [
+    {
+      id: 'price',
+      tone: 'info',
+      text: freeAvailable
+        ? `Free, or ${price} Buzz · one use either way`
+        : `${price} Buzz + one use`,
+    },
+  ];
+
+  // Only where free is on the table. Naming the shared budget to somebody who
+  // has no free placement to spend explains a limit they did not ask about.
+  if (freeAvailable)
+    notes.push({
+      id: 'shared',
+      tone: 'info',
+      // The clause itself, capitalised — not "Your free one is …" in front of
+      // it. On a line of its own the preamble is four words the reader has to
+      // get past to reach the fact, and the line has to stay short enough to
+      // read at a glance beside an icon.
+      text: `${SHARED_ALLOWANCE_NOTE.charAt(0).toUpperCase()}${SHARED_ALLOWANCE_NOTE.slice(1)}`,
+    });
+
+  if (review)
+    notes.push({
+      id: 'review',
+      tone: 'info',
+      text: 'Only you see it until the creator approves',
+    });
+
+  // What pressing costs, which differs by what is being pressed: a free
+  // placement spends the day regardless, a paid one leaves part of the money.
+  if (review)
+    notes.push({
+      id: 'decline',
+      tone: 'warn',
+      text: freeAvailable
+        ? FREE_REVIEW_CAVEAT
+        : 'If they decline, part of what you paid stays with them',
+    });
+
+  if (reason) notes.push({ id: 'reason', tone: 'warn', text: reason });
+
+  return notes;
+}

--- a/src/components/Sticker/free-offer.ts
+++ b/src/components/Sticker/free-offer.ts
@@ -286,7 +286,9 @@ export function freeHintText(space?: FreeCapacity, standing?: FreeStanding) {
 
   const count = Math.min(space?.freeSlotsRemaining ?? 0, standing?.remaining ?? 0);
 
-  return count === 1 ? 'You have a free sticker today' : `You have ${count} free stickers today`;
+  // A label, not a sentence. It sits on a chip beside a button, where "You have
+  // a free sticker today" is three words of throat-clearing before the noun.
+  return count === 1 ? 'Daily free sticker' : `${count} daily free stickers`;
 }
 
 /**

--- a/src/components/Sticker/free-offer.ts
+++ b/src/components/Sticker/free-offer.ts
@@ -1,4 +1,4 @@
-import { FREE_PLACEMENTS_PER_DAY } from '~/shared/utils/placement';
+import { FREE_SLOT_TAKEN_NOTE, SHARED_ALLOWANCE_NOTE } from '~/shared/utils/placement';
 
 /**
  * Whether the free offer is on the table, and what it says.
@@ -7,7 +7,9 @@ import { FREE_PLACEMENTS_PER_DAY } from '~/shared/utils/placement';
  * has none: these are the branches most worth testing and the least worth
  * dragging Mantine, tRPC and the edge image loader into a unit run to reach.
  * `~/shared/utils/placement` pulls in none of that. It is the rules themselves,
- * which is what the copy here has to stay true to.
+ * and the clauses that describe them live beside them there, so the remix
+ * gallery does not have to import a sticker module for a fact neither surface
+ * owns.
  *
  * The predicate lives here rather than at each of the three places that need it
  * — the button's tray, the draft layer, and the draft itself — because three
@@ -105,6 +107,18 @@ export const FREE_REVIEW_CAVEAT =
  * conditions of an adjacent pair, so a swap fails rather than passing on
  * fixtures that only ever trip one rung.
  */
+/**
+ * The spent-allowance sentence, which three surfaces say.
+ *
+ * The bar said "Yours is back", the refusal ladder said "It comes back", and
+ * both name the shared budget — two wordings of the one fact this change exists
+ * to stop drifting. One function, so a reword lands everywhere or nowhere.
+ */
+export const spentAllowanceNote = (resetsAt?: Date | string) =>
+  `You have used today's free placement — ${SHARED_ALLOWANCE_NOTE}. It comes back ${allowanceResetLabel(
+    resetsAt
+  )}.`;
+
 export function freeRefusalMessage(standing?: FreeStanding, space?: FreeCapacity) {
   // Permanent for this image, and true of everybody — so it outranks the two
   // below it, which are about this placer and about right now.
@@ -114,11 +128,13 @@ export function freeRefusalMessage(standing?: FreeStanding, space?: FreeCapacity
   if (standing?.usedHere) return 'You have already used a free sticker on this image.';
   // Transient, and it says when it lifts — derived from the reset the server
   // computed rather than restating the boundary here.
-  if (standing && standing.remaining <= 0)
-    return `You have used today's free placement — ${SHARED_ALLOWANCE_NOTE}. It comes back ${allowanceResetLabel(
-      standing.resetsAt
-    )}.`;
+  if (standing && standing.remaining <= 0) return spentAllowanceNote(standing.resetsAt);
   // The most transient of all — a declined placement releases its slot at once.
+  //
+  // ⚠️ Two readers, two truths, so the wording is chosen by the caller. Someone
+  // who pressed and lost the race is told they lost it; someone still deciding
+  // has pressed nothing, and "first" would be false. `preCommitFreeReason`
+  // substitutes `FREE_SLOT_TAKEN_NOTE` for exactly this rung.
   if (space && space.freeSlotsRemaining <= 0)
     return 'Someone took the last free slot on this image first.';
   return null;
@@ -159,6 +175,14 @@ export function preCommitFreeReason(
   if (freeAvailable) return null;
   if (!space || !standing) return null;
   if (space.freeSlots <= 0) return null;
+
+  // 🔴 The one rung whose wording depends on who is reading it. The ladder's
+  // version — "someone took the last free slot FIRST" — was written for a
+  // placer who pressed and lost a race. Said before the press it is false about
+  // the reader and contradicts what the bar's own tooltip says for the same
+  // state, so both take the shared clause instead.
+  if (!standing.usedHere && standing.remaining > 0 && space.freeSlotsRemaining <= 0)
+    return FREE_SLOT_TAKEN_NOTE;
 
   return freeRefusalMessage(standing, space);
 }
@@ -210,31 +234,6 @@ function allowanceResetLabel(resetsAt?: Date | string) {
 }
 
 /**
- * What the daily allowance is shared with, in one clause.
- *
- * 🔴 **One constant, because the sharing is the fact people get wrong.** Every
- * string that mentions the daily free is on one of two surfaces, and each used
- * to say "today's allowance" as though it were its own — so somebody who spent
- * it submitting a remix met a sticker surface that had no explanation for why
- * free was gone, and read a limit as a bug. Said once here, both surfaces cannot
- * drift into describing two different budgets.
- *
- * Written as a clause rather than a sentence, with **no terminating full stop**,
- * so it can be appended to whatever came before it and still have a clause
- * appended to it in turn — which the tray does, with a ` · ` separator.
- *
- * The count is read from `FREE_PLACEMENTS_PER_DAY` rather than written out, for
- * the same reason `allowanceResetLabel` reads `resetsAt` instead of restating
- * midnight: a number spelled into copy is a second copy of a rule, and the two
- * are free to disagree the day the rule moves. The SURFACE list stays literal —
- * there is no derivation of it that reads as English — so a guard test fails if
- * a third surface is ever added to `PLACEMENT_SURFACES`.
- */
-export const SHARED_ALLOWANCE_NOTE = `${
-  FREE_PLACEMENTS_PER_DAY === 1 ? 'one' : FREE_PLACEMENTS_PER_DAY
-} a day, shared between stickers and remix galleries`;
-
-/**
  * The free label on the reaction bar, or `null` for no label at all.
  *
  * 🔴 **This is the fix for the whole ticket.** The bar used to print the
@@ -279,10 +278,18 @@ export function barFreeLabel(
  *
  * Ordered like `freeRefusalMessage` and for the same reason: a refusal that is
  * permanent for this image outranks one that lifts by itself, so nobody is
- * promised a midnight reset that will not change what this creator offers. The
- * two ladders stay separate because they answer different questions — this one
- * before the press, from a bar that cannot see `usedHere`; that one after a
- * refusal, from a surface that can.
+ * promised a midnight reset that will not change what this creator offers.
+ *
+ * It is a separate ladder because it answers a different question — this one
+ * from a bar that cannot see `usedHere`, that one from a surface that can — but
+ * every SENTENCE the two share now comes from one place (`spentAllowanceNote`,
+ * `FREE_SLOT_TAKEN_NOTE`). What differs is which rungs exist and in what order,
+ * not how any of them is worded.
+
+ * ⚠️ An ERRORED allowance query is `undefined` too, and renders exactly like a
+ * loading one: the bare price, no free label anywhere on the page. Deliberate
+ * and fail-closed — nobody is promised something they cannot have — but it does
+ * mean a 401 makes the free tier invisible rather than noisy.
  */
 export function barTooltip({
   price,
@@ -303,13 +310,9 @@ export function barTooltip({
   // Still loading. Say the price and claim nothing about the offer.
   if (allowanceRemaining == null) return base;
 
-  if (allowanceRemaining <= 0)
-    return `${base}. You have used today's free placement — ${SHARED_ALLOWANCE_NOTE}. Yours is back ${allowanceResetLabel(
-      resetsAt
-    )}.`;
+  if (allowanceRemaining <= 0) return `${base}. ${spentAllowanceNote(resetsAt)}`;
 
-  if (space.freeSlotsRemaining <= 0)
-    return `${base}. The free slot on this image is taken — it comes back if the creator declines.`;
+  if (space.freeSlotsRemaining <= 0) return `${base}. ${FREE_SLOT_TAKEN_NOTE}`;
 
   return `Place a sticker · free, or ${price} Buzz. Your free one is ${SHARED_ALLOWANCE_NOTE}.`;
 }

--- a/src/components/Sticker/free-offer.ts
+++ b/src/components/Sticker/free-offer.ts
@@ -1,9 +1,13 @@
+import { FREE_PLACEMENTS_PER_DAY } from '~/shared/utils/placement';
+
 /**
  * Whether the free offer is on the table, and what it says.
  *
- * Its own module with no imports, for the same reason `payout-copy.ts` is one:
- * these are the branches most worth testing and the least worth dragging
- * Mantine, tRPC and the edge image loader into a unit run to reach.
+ * One import, and it is a constants module — for the same reason `payout-copy.ts`
+ * has none: these are the branches most worth testing and the least worth
+ * dragging Mantine, tRPC and the edge image loader into a unit run to reach.
+ * `~/shared/utils/placement` pulls in none of that. It is the rules themselves,
+ * which is what the copy here has to stay true to.
  *
  * The predicate lives here rather than at each of the three places that need it
  * — the button's tray, the draft layer, and the draft itself — because three
@@ -215,10 +219,20 @@ function allowanceResetLabel(resetsAt?: Date | string) {
  * free was gone, and read a limit as a bug. Said once here, both surfaces cannot
  * drift into describing two different budgets.
  *
- * Written as a clause rather than a sentence so it can be appended to whatever
- * came before it without a second full stop.
+ * Written as a clause rather than a sentence, with **no terminating full stop**,
+ * so it can be appended to whatever came before it and still have a clause
+ * appended to it in turn — which the tray does, with a ` · ` separator.
+ *
+ * The count is read from `FREE_PLACEMENTS_PER_DAY` rather than written out, for
+ * the same reason `allowanceResetLabel` reads `resetsAt` instead of restating
+ * midnight: a number spelled into copy is a second copy of a rule, and the two
+ * are free to disagree the day the rule moves. The SURFACE list stays literal —
+ * there is no derivation of it that reads as English — so a guard test fails if
+ * a third surface is ever added to `PLACEMENT_SURFACES`.
  */
-export const SHARED_ALLOWANCE_NOTE = 'one a day, shared between stickers and remix galleries';
+export const SHARED_ALLOWANCE_NOTE = `${
+  FREE_PLACEMENTS_PER_DAY === 1 ? 'one' : FREE_PLACEMENTS_PER_DAY
+} a day, shared between stickers and remix galleries`;
 
 /**
  * The free label on the reaction bar, or `null` for no label at all.
@@ -309,7 +323,7 @@ export function barTooltip({
  */
 export const trayPriceLine = (freeAvailable: boolean, price: number) =>
   freeAvailable
-    ? `Free, or ${price} Buzz · one use either way. Your free one is ${SHARED_ALLOWANCE_NOTE}.`
+    ? `Free, or ${price} Buzz · one use either way, and your free one is ${SHARED_ALLOWANCE_NOTE}`
     : `${price} Buzz + one use`;
 
 /**

--- a/src/components/Sticker/free-offer.ts
+++ b/src/components/Sticker/free-offer.ts
@@ -57,26 +57,31 @@ export const isPlacingFree = (chosen: 'free' | 'paid' | null, offer: { instant: 
   (chosen ?? (offer ? 'free' : 'paid')) === 'free' && !!offer;
 
 /**
- * The free option's own label, which carries the mode.
+ * The free option's own label.
  *
- * The mode goes here rather than on the sticker button because this is the last
- * moment the placer can change their mind, and it makes auto-accept and review
- * read as two different offers rather than one setting they cannot see. The
- * button upstream stays a single number.
+ * 🔴 **Deliberately does NOT carry the mode any more.** It read `Free · needs
+ * review` beside a plain `100 Buzz`, which says the paid one does not — and on
+ * this surface both go to the creator for review, always. Justin's words on
+ * seeing it: "it makes it seem like the other one's not going to need review".
+ *
+ * The mode is still said, once, under the button that spends the placement,
+ * where it applies to whichever option is selected rather than to one of them.
  */
-export const freeOptionLabel = (instant: boolean) =>
-  instant ? 'Free · instant' : 'Free · needs review';
+export const freeOptionLabel = () => 'Free';
 
 /**
- * The one line under a review-mode free option.
+ * The one line under the button that spends the placement.
  *
- * Said before the press, not after, because it is the whole asymmetry of the
- * free tier: the image's slot comes back when a creator declines and the
- * placer's day does not. Somebody who would rather spend Buzz on a creator who
- * reviews needs that fact while both options are still on screen.
+ * Shrunk to the only fact that has to land: pressing this spends your free
+ * placement, and a decline does not give it back. It used to be two sentences
+ * explaining the asymmetry between the creator's slot and the placer's day —
+ * true, but nobody standing over a Place button is reading a paragraph about
+ * accounting.
+ *
+ * Under the button rather than above it, with an alert triangle, so it reads as
+ * a consequence of pressing rather than as a description of the option.
  */
-export const FREE_REVIEW_CAVEAT =
-  "Your free placement for today is spent even if they decline. The creator's slot comes back; your allowance does not.";
+export const FREE_REVIEW_CAVEAT = 'Spends your free placement, even if they decline it';
 
 /**
  * What went wrong when a free claim was refused, from state re-read after the
@@ -261,50 +266,27 @@ export function barFreeLabel(space?: FreeCapacity, standing?: FreeStanding) {
 }
 
 /**
- * The bar's tooltip: the price always, and the reason free is off the table when
- * it is.
+ * The line on the free hint, or `null` when there is no hint to show.
  *
- * The price stays in every branch. That rule predates this change — it is what
- * kept the old label from being an outright lie about cost — and the reason is
- * an addition to it, never a replacement.
+ * 🔴 **Replaces the bar's tooltip, and the difference is who gets to see it.** A
+ * tooltip is hover-only, so on a phone the whole free tier was invisible until
+ * you opened the tray — the state that matters most, "you have one and it is
+ * free", was told only to people with a mouse. A popover is on screen for
+ * everyone and dismissable by anyone.
  *
- * 🔴 **One ladder, not two.** An earlier version restated two of
- * `freeRefusalMessage`'s rungs in its own words, so the bar and the tray could
- * describe the same state differently — on the one fact this change exists to
- * stop drifting. The bar now reads the same per-image standing the tray does, so
- * it can defer to `preCommitFreeReason` outright and own only the price.
- *
- * ⚠️ An ERRORED standing query is `undefined` too, and renders exactly like a
- * loading one: the bare price, no free label. Deliberate and fail-closed —
- * nobody is promised something they cannot have — but it does mean a 401 makes
- * the free tier invisible rather than noisy.
+ * Said only where free is genuinely on offer. The states where it is not —
+ * spent, held, already used here, no capacity — get nothing at the bar at all
+ * and are explained in the tray, at the point the choice is actually made. A
+ * notice that pops up to tell you what you CANNOT have is an interruption
+ * charging rent on somebody else's image.
  */
-export function barTooltip({
-  price,
-  space,
-  standing,
-}: {
-  price: number;
-  space?: FreeCapacity;
-  standing?: FreeStanding;
-}) {
-  const base = `Place a sticker · ${price} Buzz`;
+export function freeHintText(space?: FreeCapacity, standing?: FreeStanding) {
+  const label = barFreeLabel(space, standing);
+  if (!label) return null;
 
-  // Nothing free is on offer here for anyone, so there is nothing to explain —
-  // and nothing to wait for either, which is why this outranks the loading gate.
-  if (!space || space.freeSlots <= 0) return base;
+  const count = Math.min(space?.freeSlotsRemaining ?? 0, standing?.remaining ?? 0);
 
-  // Still loading. Say the price and claim nothing about the offer.
-  if (!standing) return base;
-
-  if (barFreeLabel(space, standing))
-    return `Place a sticker · free, or ${price} Buzz. Your free one is ${SHARED_ALLOWANCE_NOTE}.`;
-
-  // `false` for `freeAvailable`, because the line above already established
-  // there is no offer. Everything after that is the tray's ladder, verbatim.
-  const reason = preCommitFreeReason(false, standing, space);
-
-  return reason ? `${base}. ${reason}` : base;
+  return count === 1 ? 'You have a free sticker today' : `You have ${count} free stickers today`;
 }
 
 /**

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -199,39 +199,13 @@ export function useForgetStickerPlacement() {
  * **A listing.** Whatever it says, the claim re-decides all of it under a lock,
  * so this only ever chooses which offer to show — never whether one is allowed.
  */
-export function useFreePlacementStanding(imageId?: number) {
+export function useFreePlacementStanding(imageId?: number, enabled = true) {
   const { data, isLoading } = trpc.placement.getFreeStanding.useQuery(
     { surface: 'sticker', targetType: 'image', targetId: imageId as number },
-    { enabled: !!imageId, staleTime: 60_000 }
+    { enabled: enabled && !!imageId, staleTime: 60_000 }
   );
 
   return { standing: data, isLoading };
-}
-
-/**
- * The viewer's daily free allowance, with no image in the question.
- *
- * **One query for a whole page.** `useFreePlacementStanding` takes an image, so
- * a reaction bar using it would fire once per card; the allowance is a property
- * of the person, so this has a single cache key and every bar on the page reads
- * the same in-flight request — measured at 40 observers to 1 fetch, including
- * when `enabled` flips true at staggered times as each card's space resolves.
- * That is what makes it affordable for the bar to stop advertising a free
- * placement the viewer does not have.
- *
- * `enabled` is the caller's, because a signed-out viewer has no allowance to
- * read and the procedure is protected — asking would be a 401 per page.
- *
- * **A listing**, like everything else on the free path: stale on return, and
- * `createFreePlacement` re-decides under a lock. It picks what to SHOW.
- */
-export function useFreePlacementAllowance(enabled = true) {
-  const { data, isLoading } = trpc.placement.getFreeAllowance.useQuery(undefined, {
-    enabled,
-    staleTime: 60_000,
-  });
-
-  return { allowance: data, isLoading };
 }
 
 export function useImagePlacementSpace(imageId?: number) {
@@ -333,14 +307,6 @@ export function useCreateStickerPlacement(
       // what a control elsewhere reads to decide whether to offer free at all.
       // Unkeyed for that reason; the space is per image and needs no sweep.
       void utils.placement.getFreeStanding.invalidate();
-      // 🔴 And the page-wide copy of the same fact, which is a SECOND cache of
-      // it. `getFreeAllowance` has one key for the whole feed and no target, so
-      // nothing above sweeps it — and a mounted reaction bar has no refetch
-      // trigger, so `staleTime` never expires it either. Left out, the refusal
-      // that just proved the allowance is spent leaves every other card in the
-      // feed labelled "1 free", which is the promise-then-charge this whole
-      // change exists to remove.
-      void utils.placement.getFreeAllowance.invalidate();
 
       // 🔴 Only a refusal the re-read can account for falls back to paid. The
       // free path refuses plenty of things that have nothing to do with the free

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -211,11 +211,13 @@ export function useFreePlacementStanding(imageId?: number) {
 /**
  * The viewer's daily free allowance, with no image in the question.
  *
- * **One query for a whole feed.** `useFreePlacementStanding` takes an image, so
+ * **One query for a whole page.** `useFreePlacementStanding` takes an image, so
  * a reaction bar using it would fire once per card; the allowance is a property
  * of the person, so this has a single cache key and every bar on the page reads
- * the same in-flight request. That is what makes it affordable for the bar to
- * stop advertising a free placement the viewer does not have.
+ * the same in-flight request — measured at 40 observers to 1 fetch, including
+ * when `enabled` flips true at staggered times as each card's space resolves.
+ * That is what makes it affordable for the bar to stop advertising a free
+ * placement the viewer does not have.
  *
  * `enabled` is the caller's, because a signed-out viewer has no allowance to
  * read and the procedure is protected — asking would be a 401 per page.

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -208,6 +208,30 @@ export function useFreePlacementStanding(imageId?: number) {
   return { standing: data, isLoading };
 }
 
+/**
+ * The viewer's daily free allowance, with no image in the question.
+ *
+ * **One query for a whole feed.** `useFreePlacementStanding` takes an image, so
+ * a reaction bar using it would fire once per card; the allowance is a property
+ * of the person, so this has a single cache key and every bar on the page reads
+ * the same in-flight request. That is what makes it affordable for the bar to
+ * stop advertising a free placement the viewer does not have.
+ *
+ * `enabled` is the caller's, because a signed-out viewer has no allowance to
+ * read and the procedure is protected — asking would be a 401 per page.
+ *
+ * **A listing**, like everything else on the free path: stale on return, and
+ * `createFreePlacement` re-decides under a lock. It picks what to SHOW.
+ */
+export function useFreePlacementAllowance(enabled = true) {
+  const { data, isLoading } = trpc.placement.getFreeAllowance.useQuery(undefined, {
+    enabled,
+    staleTime: 60_000,
+  });
+
+  return { allowance: data, isLoading };
+}
+
 export function useImagePlacementSpace(imageId?: number) {
   const { data, isLoading } = trpc.placement.getSpace.useQuery(
     { surface: 'sticker', targetType: 'image', targetId: imageId as number },

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -331,6 +331,14 @@ export function useCreateStickerPlacement(
       // what a control elsewhere reads to decide whether to offer free at all.
       // Unkeyed for that reason; the space is per image and needs no sweep.
       void utils.placement.getFreeStanding.invalidate();
+      // 🔴 And the page-wide copy of the same fact, which is a SECOND cache of
+      // it. `getFreeAllowance` has one key for the whole feed and no target, so
+      // nothing above sweeps it — and a mounted reaction bar has no refetch
+      // trigger, so `staleTime` never expires it either. Left out, the refusal
+      // that just proved the allowance is spent leaves every other card in the
+      // feed labelled "1 free", which is the promise-then-charge this whole
+      // change exists to remove.
+      void utils.placement.getFreeAllowance.invalidate();
 
       // 🔴 Only a refusal the re-read can account for falls back to paid. The
       // free path refuses plenty of things that have nothing to do with the free

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -203,30 +203,6 @@ export const placementRouter = router({
       return { ...allowance, usedHere };
     }),
 
-  /**
-   * The viewer's daily allowance alone, with no target.
-   *
-   * The same listing as `getFreeStanding` minus the per-target half, and it
-   * exists because of where it is read: the reaction bar renders once per feed
-   * card, and `getFreeStanding` takes a target, so a bar asking that question
-   * would make one request per card. **The daily allowance is a property of the
-   * person, not of the image** — one query answers it for every card on the
-   * page, under a single cache key.
-   *
-   * So a surface that only needs "does this viewer have a free placement left
-   * today" asks this, and a surface deciding a specific placement asks
-   * `getFreeStanding`, which also answers "already used one here".
-   *
-   * **A listing, like its sibling.** Replica read, stale on return, and the
-   * refusal lives in `createFreePlacement` under a lock. Never gate a mutation
-   * on it.
-   *
-   * `placerId` is the session's. Off an input it would read anyone's allowance.
-   */
-  getFreeAllowance: protectedProcedure.query(({ ctx }) =>
-    getFreePlacementAllowance({ placerId: ctx.user.id })
-  ),
-
   getStickerPlacements: publicProcedure
     .input(getStickerPlacementsSchema)
     .query(({ input, ctx }) =>

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -203,6 +203,30 @@ export const placementRouter = router({
       return { ...allowance, usedHere };
     }),
 
+  /**
+   * The viewer's daily allowance alone, with no target.
+   *
+   * The same listing as `getFreeStanding` minus the per-target half, and it
+   * exists because of where it is read: the reaction bar renders once per feed
+   * card, and `getFreeStanding` takes a target, so a bar asking that question
+   * would make one request per card. **The daily allowance is a property of the
+   * person, not of the image** — one query answers it for every card on the
+   * page, under a single cache key.
+   *
+   * So a surface that only needs "does this viewer have a free placement left
+   * today" asks this, and a surface deciding a specific placement asks
+   * `getFreeStanding`, which also answers "already used one here".
+   *
+   * **A listing, like its sibling.** Replica read, stale on return, and the
+   * refusal lives in `createFreePlacement` under a lock. Never gate a mutation
+   * on it.
+   *
+   * `placerId` is the session's. Off an input it would read anyone's allowance.
+   */
+  getFreeAllowance: protectedProcedure.query(({ ctx }) =>
+    getFreePlacementAllowance({ placerId: ctx.user.id })
+  ),
+
   getStickerPlacements: publicProcedure
     .input(getStickerPlacementsSchema)
     .query(({ input, ctx }) =>

--- a/src/shared/utils/placement.ts
+++ b/src/shared/utils/placement.ts
@@ -569,6 +569,48 @@ export const effectiveFreeSlots = (setSlots: number, cap: number) =>
  */
 export const FREE_PLACEMENTS_PER_DAY = 1;
 
+/**
+ * What the daily allowance is shared with, in one clause.
+ *
+ * 🔴 **One constant, because the sharing is the fact people get wrong.** Every
+ * string that mentions the daily free is on one of two surfaces, and each used
+ * to say "today's allowance" as though it were its own — so somebody who spent
+ * it submitting a remix met a sticker surface with no explanation for where it
+ * went, and read a limit as a bug. Said once, both surfaces cannot drift into
+ * describing two different budgets.
+ *
+ * **Here rather than in either surface's module**, beside the rule it describes.
+ * It began life in `~/components/Sticker/free-offer`, which made the remix
+ * gallery import a sticker component module for a fact neither feature owns.
+ *
+ * Written as a clause, with **no terminating full stop**, so it can be appended
+ * to whatever came before it and still have a clause appended to it in turn —
+ * which the sticker tray does, with a ` · ` separator.
+ *
+ * The count is read from `FREE_PLACEMENTS_PER_DAY` rather than written out, for
+ * the same reason the reset time is read from the server rather than restated:
+ * a number spelled into copy is a second copy of a rule, and the two are free to
+ * disagree the day the rule moves. The SURFACE list stays literal — no
+ * derivation of it reads as English — so a guard test fails if a third surface
+ * is ever added to `PLACEMENT_SURFACES`.
+ */
+export const SHARED_ALLOWANCE_NOTE = `${
+  FREE_PLACEMENTS_PER_DAY === 1 ? 'one' : FREE_PLACEMENTS_PER_DAY
+} a day, shared between stickers and remix galleries`;
+
+/**
+ * What a held free slot means, in one clause — shared by every surface that says
+ * it.
+ *
+ * The bar says it before a press and the tray says it beside the paid option;
+ * they described the same state in two voices, and the tray's came from a
+ * post-race sentence ("someone took the last free slot **first**") that is
+ * simply false about a reader who has pressed nothing. One constant, so the two
+ * cannot disagree about a fact that lifts on its own.
+ */
+export const FREE_SLOT_TAKEN_NOTE =
+  'The free slot on this image is taken — it comes back if the creator declines.';
+
 /** Milliseconds in a UTC day. Unix time has no leap seconds, so this is exact. */
 const DAY_MS = 24 * 3_600_000;
 


### PR DESCRIPTION
## What was wrong

Three separate scarcities decide whether a placement is free, and the reaction bar could see one of them:

1. **You** get one free placement per UTC day — shared across stickers *and* remix galleries.
2. **The image** has its own free slots, set by the creator (defaults to 1).
3. Free is **once ever per image**, per placer, per surface.

The bar printed `N of M free`, which is rule 2 — a fact about the *image* — in a place every reader takes as an offer to *themselves*. It deliberately made no per-viewer query, because it renders once per feed card.

So someone who had spent their day saw "1 of 1 free" on every image in the feed, pressed it, and was charged. Justin hit it live in a meeting on 2026-08-20. A user reported it 90 minutes after launch: *"there is no actual free one at the moment… Every image I visited since this is live wanted 100 Buzz from me, except for one."*

Nothing anywhere said the daily allowance is shared with remix galleries, so spending it on one surface made the other look broken.

## The key insight

**The daily allowance is a property of the person, not of the image.** One query answers it for every card on a page, under a single cache key — which is what makes checking it affordable in a feed. `getFreeStanding` takes a target and could not be used here for exactly the per-card cost this avoids.

## What changed

**New: `placement.getFreeAllowance`** — no input, returns the viewer's `{ used, remaining, resetsAt }`. A listing, like its sibling: replica read, stale on return, and `createFreePlacement` still re-decides everything under a lock. Never gates a mutation.

**`barFreeLabel`** — "free" appears only when *both* scarcities hold, and shows the smaller of the two numbers, because that is how many the reader can actually take. `undefined` is the in-flight state and is **not** zero: the label is absent until the answer lands, rather than showing a price that turns into "free" a beat later on every card.

**`barTooltip`** — keeps the price in every branch (that rule predates this change) and adds *which* scarcity ran out. It tells a held slot — "comes back if the creator declines", worth saying because it lifts by itself — apart from a creator who takes no free placements, which `freeSlotsRemaining === 0` alone cannot express.

**`preCommitFreeReason`** — the refusal sentence now renders while the choice is still being made. Those strings existed in `free-offer.ts` with exactly one consumer: the *post-refusal* error handler. The remix modal has rendered its reason inline since it shipped; this is that pattern on the surface that lacked it. Two deliberate silences: nothing when free is on offer, and nothing on an image whose creator never offered free (true of most of the site).

**`SHARED_ALLOWANCE_NOTE`** — one constant, both surfaces, naming what the day is shared with. The orderings of the two refusal ladders stay separate (they answer different questions); only the shared fact is centralised, because that is the one that must not drift.

## What the bar still cannot see

Rule 3 — "already free-placed on **this** image" — needs a per-image query, which is the per-card cost this design exists to avoid. The tray checks it before anything is committed, and says so in words.

## Tests

`StickerPlacementBar.browser.test.tsx` asserted the old contract, so it is rewritten rather than extended. The suite now covers: both scarcities held, spent allowance, creator takes none, slots all held, and the loading state — plus a control asserting the allowance query is actually made, so the cost claim is not a check that cannot fail.

`free-offer.test.ts` covers every branch of the three new functions, including the silences, which are the half a test is most likely to skip.

Verified: `typecheck` 0 errors · `eslint` clean on changed files · `test:unit:run` 19,742 passed / 0 failed (`blocks.router.workflow.test.ts` collected nonzero) · component project green.

## Not in this PR

- No change to the allowance, the price, or the rules — only to what the screen says about them.
- The duplicate-placement action, hover-card delay and flip glyph belong to a parallel seat; file ownership was agreed in advance and there is no overlap. `placement.util.ts` gains one hook and nothing else.
- One finding handed to that seat rather than built here: **a duplicate of a free placement cannot itself be free** — the once-ever-per-image rule refuses it, and `preCommitFreeReason` already prints the sentence that explains why.

ClickUp: [868ku9d39](https://app.clickup.com/t/868ku9d39), [868ku9d43](https://app.clickup.com/t/868ku9d43)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
