### PR TITLE
fix(auto-feature): separate the cap window from the freshness window

### DIFF
--- a/src/server/schema/home-block.schema.ts
+++ b/src/server/schema/home-block.schema.ts
@@ -40,6 +40,12 @@ export const autoFeatureSchema = z.object({
   // be candidates, and tuning a cap through this config must not silently change what the job
   // considers recent. Defaults to 7, the value `windowDays` shipped with, so splitting them
   // changes nothing until someone deliberately moves one.
+  //
+  // Worth knowing before tuning either: while they were one value, widening the candidate pool
+  // also lengthened the cap window, so a bigger pool automatically tightened per-creator
+  // repeats. That accidental brake is gone. Raising `windowDays` alone now widens the pool and
+  // leaves the cap counting over 7 days, which permits more repeats per creator than the same
+  // edit used to.
   capWindowDays: z.number().int().min(1).max(365).default(7),
   recencyOffsetHours: z.number().min(0).max(720).default(12),
   decayExponent: z.number().min(0).max(3).default(0.8),

--- a/src/server/schema/home-block.schema.ts
+++ b/src/server/schema/home-block.schema.ts
@@ -35,6 +35,12 @@ export const autoFeatureSchema = z.object({
   perRun: z.number().int().min(1).max(50).default(5),
   intervalHours: z.number().min(1).max(168).default(6),
   windowDays: z.number().int().min(1).max(90).default(7),
+  // How far back the per-creator and per-collection caps count previous auto-features.
+  // Separate from `windowDays` on purpose: that one decides which images are fresh enough to
+  // be candidates, and tuning a cap through this config must not silently change what the job
+  // considers recent. Defaults to 7, the value `windowDays` shipped with, so splitting them
+  // changes nothing until someone deliberately moves one.
+  capWindowDays: z.number().int().min(1).max(365).default(7),
   recencyOffsetHours: z.number().min(0).max(720).default(12),
   decayExponent: z.number().min(0).max(3).default(0.8),
   maxPerCreatorPerRun: z.number().int().min(1).max(50).default(1),

--- a/src/server/services/__tests__/auto-feature-images.service.test.ts
+++ b/src/server/services/__tests__/auto-feature-images.service.test.ts
@@ -11,6 +11,7 @@ const config = (overrides: Partial<AutoFeatureSchema> = {}): AutoFeatureSchema =
   perRun: 5,
   intervalHours: 6,
   windowDays: 7,
+  capWindowDays: 7,
   recencyOffsetHours: 12,
   decayExponent: 0.8,
   maxPerCreatorPerRun: 1,

--- a/src/server/services/__tests__/auto-feature-window-split.test.ts
+++ b/src/server/services/__tests__/auto-feature-window-split.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as Eligibility from '~/server/jobs/refresh-featured-collections-eligibility';
+import type { HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import '~/__tests__/mocks/redis.mock';
+
+vi.mock('~/server/jobs/refresh-featured-collections-eligibility', async (importOriginal) => ({
+  ...(await importOriginal<typeof Eligibility>()),
+  getFeaturedCollectionsState: vi.fn(async () => ({ eligibleIds: [111], checkedAt: new Date() })),
+}));
+
+const { runAutoFeatureImages } = await import('~/server/services/auto-feature-images.service');
+
+const CANDIDATE_WINDOW = 7;
+const CAP_WINDOW = 30;
+
+const block = { id: 388990, metadata: {} as HomeBlockMetaSchema };
+
+/**
+ * Rebuilds the text a `$queryRaw` tagged template would have produced. `Prisma.raw` arrives as a
+ * Sql fragment rather than a bound parameter, which is exactly why the interval days land in the
+ * query text and can be asserted on here.
+ */
+const sqlText = (call: unknown[] | undefined) => {
+  if (!call) return '';
+  const [strings, ...values] = call as [readonly string[], ...unknown[]];
+  return strings
+    .map((chunk, i) => {
+      const value = values[i];
+      const rendered =
+        value && typeof value === 'object' && 'strings' in (value as Record<string, unknown>)
+          ? (value as { strings: readonly string[] }).strings.join('')
+          : value === undefined
+          ? ''
+          : String(value);
+      return chunk + rendered;
+    })
+    .join('');
+};
+
+const queries = () => dbMock.dbRead.$queryRaw.mock.calls.map((call) => sqlText(call));
+const candidateQuery = () => queries().find((q) => q.includes('ImageReaction')) ?? '';
+const capCountQuery = () => queries().find((q) => q.includes('split_part')) ?? '';
+
+beforeEach(() => {
+  dbMock.dbRead.$queryRaw.mockClear();
+  dbMock.dbRead.$queryRaw.mockImplementation(async () => []);
+  dbMock.dbRead.homeBlock.findFirst.mockImplementation(async () => block);
+  dbMock.dbRead.user.findFirst.mockImplementation(async () => ({ id: 42 }));
+  block.metadata = {
+    featuredCollections: {
+      collectionIds: [111],
+      limit: 40,
+      rows: 2,
+      renderCount: 3,
+      nameSnapshots: {},
+      writeSnapshots: {},
+      autoFeature: {
+        collectionId: 107,
+        dryRun: true,
+        windowDays: CANDIDATE_WINDOW,
+        capWindowDays: CAP_WINDOW,
+      },
+    },
+  } as unknown as HomeBlockMetaSchema;
+});
+
+// The two windows were one config value. Tuning the repeat cap — the whole point of that value
+// living in editable metadata — also moved the candidate-freshness window, so the job quietly
+// picked from a different pool than the editor intended. These assert the split by giving the
+// two windows DIFFERENT values: recouple them and the interval printed here is the wrong number,
+// not a timeout or a silent pass.
+describe('auto-feature windows are independent', () => {
+  it('counts previous auto-features over capWindowDays', async () => {
+    await runAutoFeatureImages();
+
+    expect(capCountQuery()).toContain(`days => ${CAP_WINDOW}`);
+    expect(capCountQuery()).not.toContain(`days => ${CANDIDATE_WINDOW}`);
+  });
+
+  it('still picks candidates over windowDays', async () => {
+    await runAutoFeatureImages();
+
+    expect(candidateQuery()).toContain(`days => ${CANDIDATE_WINDOW}`);
+    expect(candidateQuery()).not.toContain(`days => ${CAP_WINDOW}`);
+  });
+
+  it('reports both windows so a run says which pool and which cap it used', async () => {
+    const result = await runAutoFeatureImages();
+
+    expect(result).toMatchObject({ windowDays: CANDIDATE_WINDOW, capWindowDays: CAP_WINDOW });
+  });
+});

--- a/src/server/services/__tests__/auto-feature-window-split.test.ts
+++ b/src/server/services/__tests__/auto-feature-window-split.test.ts
@@ -11,43 +11,17 @@ vi.mock('~/server/jobs/refresh-featured-collections-eligibility', async (importO
 
 const { runAutoFeatureImages } = await import('~/server/services/auto-feature-images.service');
 
+// Deliberately not prefixes of one another: the assertions match the interval by substring, so
+// 70 against 7 would fail spuriously. Wrong in the red direction, but worth not stepping on.
 const CANDIDATE_WINDOW = 7;
 const CAP_WINDOW = 30;
+/** What `capWindowDays` falls back to, and what live config — which has no such key — will use. */
+const SCHEMA_DEFAULT = 7;
 
 const block = { id: 388990, metadata: {} as HomeBlockMetaSchema };
 
-/**
- * Rebuilds the text a `$queryRaw` tagged template would have produced. `Prisma.raw` arrives as a
- * Sql fragment rather than a bound parameter, which is exactly why the interval days land in the
- * query text and can be asserted on here.
- */
-const sqlText = (call: unknown[] | undefined) => {
-  if (!call) return '';
-  const [strings, ...values] = call as [readonly string[], ...unknown[]];
-  return strings
-    .map((chunk, i) => {
-      const value = values[i];
-      const rendered =
-        value && typeof value === 'object' && 'strings' in (value as Record<string, unknown>)
-          ? (value as { strings: readonly string[] }).strings.join('')
-          : value === undefined
-          ? ''
-          : String(value);
-      return chunk + rendered;
-    })
-    .join('');
-};
-
-const queries = () => dbMock.dbRead.$queryRaw.mock.calls.map((call) => sqlText(call));
-const candidateQuery = () => queries().find((q) => q.includes('ImageReaction')) ?? '';
-const capCountQuery = () => queries().find((q) => q.includes('split_part')) ?? '';
-
-beforeEach(() => {
-  dbMock.dbRead.$queryRaw.mockClear();
-  dbMock.dbRead.$queryRaw.mockImplementation(async () => []);
-  dbMock.dbRead.homeBlock.findFirst.mockImplementation(async () => block);
-  dbMock.dbRead.user.findFirst.mockImplementation(async () => ({ id: 42 }));
-  block.metadata = {
+const metadata = (autoFeature: Record<string, unknown>) =>
+  ({
     featuredCollections: {
       collectionIds: [111],
       limit: 40,
@@ -55,14 +29,36 @@ beforeEach(() => {
       renderCount: 3,
       nameSnapshots: {},
       writeSnapshots: {},
-      autoFeature: {
-        collectionId: 107,
-        dryRun: true,
-        windowDays: CANDIDATE_WINDOW,
-        capWindowDays: CAP_WINDOW,
-      },
+      autoFeature: { collectionId: 107, dryRun: true, ...autoFeature },
     },
-  } as unknown as HomeBlockMetaSchema;
+  } as unknown as HomeBlockMetaSchema);
+
+/**
+ * The queries are built rather than issued inline, so this reads Prisma's own `.sql` off the
+ * argument instead of reconstructing text from a tagged template.
+ */
+const queries = () =>
+  dbMock.dbRead.$queryRaw.mock.calls.map((call) => (call[0] as { sql?: string })?.sql ?? '');
+const candidateQuery = () => queries().find((q) => q.includes('ImageReaction')) ?? '';
+const capCountQuery = () => queries().find((q) => q.includes('split_part')) ?? '';
+
+/**
+ * Pins that BOTH queries were issued. Without it the two `.not.toContain` assertions below could
+ * never fail on their own — `expect('').not.toContain(…)` passes — and they would be saved only
+ * by sitting next to a positive assertion in the same test.
+ */
+const expectBothQueriesIssued = () => {
+  expect(queries()).toHaveLength(2);
+  expect(candidateQuery()).not.toBe('');
+  expect(capCountQuery()).not.toBe('');
+};
+
+beforeEach(() => {
+  dbMock.dbRead.$queryRaw.mockClear();
+  dbMock.dbRead.$queryRaw.mockImplementation(async () => []);
+  dbMock.dbRead.homeBlock.findFirst.mockImplementation(async () => block);
+  dbMock.dbRead.user.findFirst.mockImplementation(async () => ({ id: 42 }));
+  block.metadata = metadata({ windowDays: CANDIDATE_WINDOW, capWindowDays: CAP_WINDOW });
 });
 
 // The two windows were one config value. Tuning the repeat cap — the whole point of that value
@@ -74,6 +70,7 @@ describe('auto-feature windows are independent', () => {
   it('counts previous auto-features over capWindowDays', async () => {
     await runAutoFeatureImages();
 
+    expectBothQueriesIssued();
     expect(capCountQuery()).toContain(`days => ${CAP_WINDOW}`);
     expect(capCountQuery()).not.toContain(`days => ${CANDIDATE_WINDOW}`);
   });
@@ -81,11 +78,28 @@ describe('auto-feature windows are independent', () => {
   it('still picks candidates over windowDays', async () => {
     await runAutoFeatureImages();
 
+    expectBothQueriesIssued();
     expect(candidateQuery()).toContain(`days => ${CANDIDATE_WINDOW}`);
     expect(candidateQuery()).not.toContain(`days => ${CAP_WINDOW}`);
   });
 
-  it('reports both windows so a run says which pool and which cap it used', async () => {
+  // The path every existing config actually takes. Stored metadata has no `capWindowDays` key, so
+  // the schema default is the only branch that runs on deploy — and it is the branch the "nothing
+  // changes on deploy" claim rests on. Without this, raising the default to 365 breaks nothing.
+  it('falls back to the schema default when config has no capWindowDays', async () => {
+    block.metadata = metadata({ windowDays: CANDIDATE_WINDOW });
+
+    await runAutoFeatureImages();
+
+    expectBothQueriesIssued();
+    expect(capCountQuery()).toContain(`days => ${SCHEMA_DEFAULT}`);
+    expect(candidateQuery()).toContain(`days => ${CANDIDATE_WINDOW}`);
+  });
+
+  // Echoes parsed config, so it cannot tell you the windows are wired correctly — it would have
+  // passed under the bug this PR fixes. It guards the run summary itself, which is what a run's
+  // log shows, and nothing more.
+  it('reports both windows in the run summary', async () => {
     const result = await runAutoFeatureImages();
 
     expect(result).toMatchObject({ windowDays: CANDIDATE_WINDOW, capWindowDays: CAP_WINDOW });

--- a/src/server/services/auto-feature-images.service.ts
+++ b/src/server/services/auto-feature-images.service.ts
@@ -159,7 +159,21 @@ async function getEligibleCollectionIds(poolFallback: number[]) {
   return state.eligibleIds.filter((id) => poolFallback.includes(id));
 }
 
-async function fetchCandidates({
+/**
+ * `make_interval(days => n)` with `n` inlined rather than bound. Prisma binds a JS number as int8
+ * and `make_interval` takes int4, so a bound parameter throws 42883 on every run. Callers pass a
+ * value the schema has already bounded to an integer, which is what makes inlining it safe.
+ */
+const intervalDays = (days: number) =>
+  Prisma.sql`make_interval(days => ${Prisma.raw(String(days))})`;
+
+/**
+ * Built rather than issued so a test can read `.sql` off it directly. The alternative is
+ * reconstructing the text from a mocked tagged template, which means guessing at Prisma's
+ * internals — a guess that already exists in three other test files, and whose failure mode is a
+ * suite that keeps passing over SQL it can no longer read.
+ */
+export function buildCandidatesQuery({
   collectionIds,
   targetCollectionId,
   windowDays,
@@ -168,9 +182,7 @@ async function fetchCandidates({
   targetCollectionId: number;
   windowDays: number;
 }) {
-  const rows = await dbRead.$queryRaw<
-    { imageId: number; userId: number; collectionId: number; curatedAt: Date; reactions: bigint }[]
-  >`
+  return Prisma.sql`
     WITH cand AS (
       SELECT DISTINCT ON (ci."imageId")
              ci."imageId", ci."collectionId",
@@ -179,9 +191,7 @@ async function fetchCandidates({
       WHERE ci."collectionId" = ANY(${collectionIds}::int[])
         AND ci.status = 'ACCEPTED'
         AND ci."imageId" IS NOT NULL
-        AND COALESCE(ci."reviewedAt", ci."createdAt") >= now() - make_interval(days => ${Prisma.raw(
-          String(windowDays)
-        )})
+        AND COALESCE(ci."reviewedAt", ci."createdAt") >= now() - ${intervalDays(windowDays)}
       ORDER BY ci."imageId", COALESCE(ci."reviewedAt", ci."createdAt") DESC
     )
     SELECT c."imageId", i."userId", c."collectionId", c."curatedAt",
@@ -206,6 +216,16 @@ async function fetchCandidates({
           AND existing."imageId" = c."imageId"
       )
   `;
+}
+
+async function fetchCandidates(args: {
+  collectionIds: number[];
+  targetCollectionId: number;
+  windowDays: number;
+}) {
+  const rows = await dbRead.$queryRaw<
+    { imageId: number; userId: number; collectionId: number; curatedAt: Date; reactions: bigint }[]
+  >(buildCandidatesQuery(args));
 
   return rows.map((r) => ({ ...r, reactions: Number(r.reactions) }));
 }
@@ -216,7 +236,7 @@ async function fetchCandidates({
  * they used to be the same value, so tuning a cap also changed which images the job considered
  * recent, and therefore what it picked.
  */
-async function fetchWindowCounts({
+export function buildWindowCountsQuery({
   targetCollectionId,
   capWindowDays,
   autoFeatureUserId,
@@ -225,7 +245,7 @@ async function fetchWindowCounts({
   capWindowDays: number;
   autoFeatureUserId: number;
 }) {
-  const rows = await dbRead.$queryRaw<{ userId: number; source: string | null }[]>`
+  return Prisma.sql`
     SELECT i."userId", split_part(ci.note, ':', 2) AS source
     FROM "CollectionItem" ci
     JOIN "Image" i ON i.id = ci."imageId"
@@ -233,8 +253,18 @@ async function fetchWindowCounts({
       AND ci."addedById" = ${autoFeatureUserId}
       AND ci.note LIKE ${`${AUTO_FEATURE_NOTE_PREFIX}:%`}
       AND ci.status <> 'REJECTED'::"CollectionItemStatus"
-      AND ci."createdAt" >= now() - make_interval(days => ${Prisma.raw(String(capWindowDays))})
+      AND ci."createdAt" >= now() - ${intervalDays(capWindowDays)}
   `;
+}
+
+async function fetchWindowCounts(args: {
+  targetCollectionId: number;
+  capWindowDays: number;
+  autoFeatureUserId: number;
+}) {
+  const rows = await dbRead.$queryRaw<{ userId: number; source: string | null }[]>(
+    buildWindowCountsQuery(args)
+  );
 
   const creatorCounts = new Map<number, number>();
   const collectionCounts = new Map<number, number>();

--- a/src/server/services/auto-feature-images.service.ts
+++ b/src/server/services/auto-feature-images.service.ts
@@ -210,13 +210,19 @@ async function fetchCandidates({
   return rows.map((r) => ({ ...r, reactions: Number(r.reactions) }));
 }
 
+/**
+ * Counts previous auto-features per creator and per source collection, over the window the caps
+ * are measured in. That window is `capWindowDays`, not the candidate-freshness `windowDays` —
+ * they used to be the same value, so tuning a cap also changed which images the job considered
+ * recent, and therefore what it picked.
+ */
 async function fetchWindowCounts({
   targetCollectionId,
-  windowDays,
+  capWindowDays,
   autoFeatureUserId,
 }: {
   targetCollectionId: number;
-  windowDays: number;
+  capWindowDays: number;
   autoFeatureUserId: number;
 }) {
   const rows = await dbRead.$queryRaw<{ userId: number; source: string | null }[]>`
@@ -227,7 +233,7 @@ async function fetchWindowCounts({
       AND ci."addedById" = ${autoFeatureUserId}
       AND ci.note LIKE ${`${AUTO_FEATURE_NOTE_PREFIX}:%`}
       AND ci.status <> 'REJECTED'::"CollectionItemStatus"
-      AND ci."createdAt" >= now() - make_interval(days => ${Prisma.raw(String(windowDays))})
+      AND ci."createdAt" >= now() - make_interval(days => ${Prisma.raw(String(capWindowDays))})
   `;
 
   const creatorCounts = new Map<number, number>();
@@ -267,7 +273,7 @@ export async function runAutoFeatureImages({
     }),
     fetchWindowCounts({
       targetCollectionId: config.collectionId,
-      windowDays: config.windowDays,
+      capWindowDays: config.capWindowDays,
       autoFeatureUserId,
     }),
   ]);
@@ -288,6 +294,8 @@ export async function runAutoFeatureImages({
   const dryRun = dryRunOverride ?? config.dryRun;
   const summary = {
     dryRun,
+    windowDays: config.windowDays,
+    capWindowDays: config.capWindowDays,
     candidates: candidates.length,
     eligibleCollections: eligible.length,
     picked: picks.length,


### PR DESCRIPTION
Closes the code half of ClickUp [868kum3b7](https://app.clickup.com/t/868kum3b7).

## What the ticket turned out to be

The ask was "cap how often the same creator can be promoted into featured placement". The audit found that cap **already exists** — `selectAutoFeaturePicks` enforces `maxPerCreatorInWindow` (2) and `maxPerCreatorPerRun` (1), and has since the job shipped. Justin's call: leave it at 2 per creator per 7 days, auto picker only, no gate on hand adds, no new tables.

That leaves one real defect, which is what this PR fixes.

## The defect

`windowDays` decided two unrelated things:

1. how far back the job looks for **candidate images** ("what counts as recent"), and
2. how far back it counts a creator's **previous auto-features** when applying the cap.

Same knob. So the next person to loosen or tighten the repeat cap through home-block metadata — no deploy, which is the entire point of that config living there — also silently changes what the job considers fresh, and therefore what it picks. Nothing errors; the picks just change for a reason nobody chose.

## The change

Adds `capWindowDays` (default **7**) for the cap counting window, leaving `windowDays` as candidate freshness only.

Live config on system block 388990 carries `windowDays: 7`, so **behaviour is identical on deploy** — the two are simply no longer the same value.

The run summary now reports both windows, so a run says which pool it drew from and which window its caps were measured over.

No migration. Config-only, no data change.

## Test

`auto-feature-window-split.test.ts` sets the two windows to **different** values (7 and 30) and asserts on the interval in each generated query. Verified it fails legibly on revert rather than passing quietly — recoupling them prints:

```
AssertionError: expected '...SELECT i."userId", split_part(c…' to contain 'days => 30'
- Expected: days => 30
+ Received: AND ci."createdAt" >= now() - make_interval(days => 7)
```

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm exec eslint <changed files>` — no issues
- `pnpm run test:unit:run` — 19,743 passed, 0 failed (1,253 files)
- `blocks.router.workflow.test.ts` collected **350** tests, so the worktree's submodule is wired and the run means something

## Context recorded, not open work

Justin has decided the hand-add path stays ungated. For a future reader: of the last 1,280 additions to Featured Images, the job placed 80 — the other ~1,200 were hand-added, 1,163 of them by JustMaier, and the top 7 creators account for 32% of everything featured in 90 days. The concentration raised at standup comes from human curation, deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)