### PR TITLE
fix(apps): remove the dead "Connect" CTA from the listing detail

### DIFF
--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -1068,7 +1068,11 @@ describe('AppListingDetailBody', () => {
     expect(container.textContent).not.toContain('Connecting this app will be available soon');
   });
 
-  test('the connect branch keeps its own glyph', async () => {
+  // 🔴 #4208 — was "the connect branch keeps its own glyph", asserting a disabled
+  // "Connect" button with a `plug-connected` glyph. That CTA had no flow behind
+  // it and is deleted; an OAuth listing with no destination now takes the SAME
+  // informational arm as a grandfathered one. NEW-BEHAVIOUR GUARD.
+  test('🔴 an OAuth listing with NO destination renders Unavailable, not a Connect CTA', async () => {
     const { container } = await renderScoped(
       <AppListingDetailBody
         detail={base({
@@ -1081,7 +1085,14 @@ describe('AppListingDetailBody', () => {
         })}
       />
     );
-    expect(await waitForCtaGlyph(container as HTMLElement, 'Connect')).toBe('plug-connected');
+    // Positive assertion first — this also settles the render before the
+    // point-in-time absence reads below.
+    expect(await waitForCtaGlyph(container as HTMLElement, 'Unavailable')).toBe('info-circle');
+    expect(container.textContent).toContain('This app has no valid external link.');
+    // 🔴 Plain string absence, NOT `expect.element(...).not.toBeInTheDocument()`,
+    // which is inert in this repo (#4197) and passes for any string.
+    expect(container.textContent).not.toContain('Connecting this app will be available soon');
+    expect(container.querySelector('button[disabled]')).toBeNull();
   });
 
   test('the info (model-slot) branch keeps its own glyph', async () => {

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -683,30 +683,12 @@ function PrimaryAction({ detail, canOpenPage }: { detail: ListingDetail; canOpen
     );
   }
 
-  if (action.mode === 'connect') {
-    // Honest stub for a connect listing with NO destination at all: inert button
-    // + a note, so the affordance is never a dead 404 link.
-    //
-    // 🔴 This is NOT the ordinary connect case any more. A connect listing that
-    // carries an https `externalUrl` — which is every one in production — takes
-    // the `visit` branch above and renders a real `Visit ↗`. The mode used to be
-    // returned unconditionally for the sub-kind, which made this inert button
-    // the ONLY thing a viewer ever saw for an app with a linked OAuth client.
-    // See `getDetailPrimaryAction`.
-    const GlyphIcon = glyphFor('connect');
-    return (
-      <Stack gap={4}>
-        <Button variant="default" leftSection={<GlyphIcon size={16} />} disabled fullWidth>
-          {action.label}
-        </Button>
-        {action.note && (
-          <Text size="xs" c="dimmed">
-            {action.note}
-          </Text>
-        )}
-      </Stack>
-    );
-  }
+  // 🔴 THERE IS NO `connect` BRANCH — #4208 removed the disabled "Connect" button
+  // and its note promising the flow was coming soon. It promised an
+  // action with no flow behind it; an off-site listing with no usable destination
+  // now falls through to the informational arm below and reads "Unavailable".
+  // `DetailActionMode` no longer has the member, so re-adding a branch here does
+  // not type-check. Do not widen the type to make one fit.
 
   // Informational (`info`) — a note plus, if the action ever carries one, an
   // internal "learn more" link. `getDetailPrimaryAction` produces NO href for

--- a/src/components/Apps/__tests__/appListingActionGlyph.test.ts
+++ b/src/components/Apps/__tests__/appListingActionGlyph.test.ts
@@ -22,10 +22,13 @@ import type { DetailActionMode } from '~/components/Apps/appListingDetailView';
 // with a missing key, so adding a 5th mode fails to typecheck HERE. A plain
 // `readonly DetailActionMode[]` would NOT — it accepts any subset, which would
 // let the distinctness tests below silently under-cover a newly added mode.
+// 🔴 `connect` is deliberately ABSENT (#4208 removed the mode). `satisfies` is
+// exact both ways here: re-adding the key without re-adding the union member is
+// an excess-property error, so this literal is also the tripwire for the dead
+// Connect CTA coming back.
 const DETAIL_MODES = Object.keys({
   open: true,
   visit: true,
-  connect: true,
   info: true,
 } satisfies Record<DetailActionMode, true>) as DetailActionMode[];
 
@@ -44,7 +47,6 @@ describe('detailActionGlyph', () => {
   test('maps each detail mode to its named glyph', () => {
     expect(detailActionGlyph('open')).toBe('launch');
     expect(detailActionGlyph('visit')).toBe('external');
-    expect(detailActionGlyph('connect')).toBe('connect');
     expect(detailActionGlyph('info')).toBe('info');
   });
 
@@ -81,8 +83,18 @@ describe('cardActionGlyph', () => {
   test('agrees with the detail page on every shared action name', () => {
     // The two view-models use the same words for the same meaning; a card and
     // the detail it links to must not disagree about what the CTA is.
-    for (const shared of ['open', 'visit', 'connect'] as const) {
-      expect(cardActionGlyph(shared)).toBe(detailActionGlyph(shared));
+    //
+    // 🔴 `connect` LEFT this list because it is no longer shared — #4208 removed
+    // the detail mode, so `detailActionGlyph('connect')` does not type-check.
+    // The set is derived, not hand-written, so it cannot silently under-cover:
+    // it is every card action that is ALSO a detail mode.
+    const shared = CARD_ACTIONS.filter((a): a is DetailActionMode =>
+      (DETAIL_MODES as string[]).includes(a)
+    );
+    // Anti-vacuity: a filter that matched nothing would pass this loop trivially.
+    expect(shared).toEqual(['open', 'visit']);
+    for (const action of shared) {
+      expect(cardActionGlyph(action), action).toBe(detailActionGlyph(action));
     }
   });
 });

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -388,7 +388,8 @@ describe('getDetailPrimaryAction — off-site', () => {
    *
    * Measured against production before removal: ZERO listings sat in the state
    * (all five off-site rows, every status, carry an https destination), so no
-   * live listing changed. The state remains REACHABLE — `offsiteSubmitSchema`
+   * live listing changed. The state remains REACHABLE —
+   * `submitExternalListingSchema` (`src/server/schema/blocks/offsite-listing.schema.ts`)
    * requires `connectClientId` but leaves `externalUrl` optional — which is why
    * the fallthrough still has to be honest rather than absent.
    *
@@ -519,17 +520,56 @@ describe('getDetailPrimaryAction — off-site', () => {
 describe('🔴 the removed Connect CTA cannot silently return', () => {
   const body = fs.readFileSync(path.resolve(__dirname, '../AppListingDetailBody.tsx'), 'utf8');
 
-  it('the renderer no longer carries the stub copy or a connect branch', () => {
+  /**
+   * 🔴 ASSERT THE STATE, NOT THE WORDING.
+   *
+   * An earlier version of this gate checked three strings. Two of them —
+   * `action.mode === 'connect'` and `glyphFor('connect')` — were VACUOUS BY
+   * CONSTRUCTION: with `'connect'` removed from `DetailActionMode`, writing
+   * either is a `TS2367`/`TS2345`, so no compiling tree can contain them and
+   * neither assertion could ever fire. The third was a SPELLED guard, walkable
+   * by rewording the sentence.
+   *
+   * Measured: a stub restored under a DIFFERENT mode with REWORDED copy —
+   *
+   *   if (action.mode === 'info' && detail.kindData.kind === 'offsite' &&
+   *       detail.kindData.connectClientId) { …disabled "Connect" button… }
+   *
+   * — typechecked with 0 errors and SURVIVED the whole blocking suite.
+   *
+   * So gate the STATE the mutant cannot avoid needing: the CTA renderer routes
+   * on the view-model's `action` ONLY. It must not read listing kind data at
+   * all, because re-deriving the OAuth capability there is exactly how the dead
+   * button comes back — under any mode name, behind any wording.
+   */
+  it('🔴 the CTA renderer never re-derives the capability (state, not wording)', () => {
+    const start = body.indexOf('function PrimaryAction(');
+    expect(start, 'PrimaryAction not found — did the component get renamed?').toBeGreaterThan(-1);
+    const end = body.indexOf('\n}\n', start);
+    expect(end, 'PrimaryAction end not found').toBeGreaterThan(start);
+    const cta = body.slice(start, end);
+
+    // POSITIVE CONTROLS — prove we sliced the real function BODY, not an empty
+    // string or just its signature. Without these the absences below would pass
+    // against a mis-slice, which is the failure mode of every region gate.
+    expect(cta).toMatch(/getDetailPrimaryAction\(detail/);
+    expect(cta).toMatch(/action\.mode === 'visit'/);
+    expect(cta.length).toBeGreaterThan(500);
+
+    // 🔴 THE GATE. The CTA branches on `action` and nothing else.
+    expect(cta, 'the CTA must not read the OAuth capability').not.toMatch(/connectClientId/);
+    expect(cta, 'the CTA must not branch on listing kind data').not.toMatch(/kindData/);
+  });
+
+  it('the renderer no longer carries the stub copy', () => {
     // POSITIVE CONTROL first: prove the read returned this component's source,
-    // so the absences below are about the file and not about an empty string.
+    // so the absence below is about the file and not about an empty string.
     expect(body).toMatch(/shouldShowOffsiteDisclosure\(detail\.kindData\)/);
 
-    // The exact promise the CTA made.
+    // The exact promise the CTA made. Kept as a cheap catch for a VERBATIM
+    // restore — but it is a spelled guard, so the state gate above is the one
+    // doing the real work.
     expect(body).not.toMatch(/Connecting this app will be available soon/);
-    // The branch itself, in either quote style.
-    expect(body).not.toMatch(/action\.mode\s*===\s*['"]connect['"]/);
-    // A re-hand-rolled glyph lookup for the removed mode.
-    expect(body).not.toMatch(/glyphFor\(\s*['"]connect['"]\s*\)/);
   });
 
   it('the view-model no longer emits the mode or its copy', () => {

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -16,8 +16,12 @@ import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.sche
  * the browser component suites are not run by CI at all, so this is where the
  * correctness coverage belongs even though nothing here BLOCKS a merge).
  * Pin the kind × hasPage × destination primary-action matrix incl.
- * the appBlocksPages gate, https guard, connect stub, and slug encoding, so a
- * regression in the detail action routing FAILS here.
+ * the appBlocksPages gate, https guard, and slug encoding, so a regression in
+ * the detail action routing FAILS here.
+ *
+ * 🔴 There is no "connect stub" arm any more — #4208 deleted that CTA. What is
+ * pinned instead is its ABSENCE, and the fact that the OAuth capability no
+ * longer changes the action at all.
  */
 
 function onsiteDetail(
@@ -78,7 +82,9 @@ function offsiteDetail(
 
 describe('getDetailPrimaryAction — on-site', () => {
   it('hasPage + canOpenPage → Open → /apps/run/<slug>', () => {
-    expect(getDetailPrimaryAction(onsiteDetail({ hasPage: true, slug: 'gen' }), { canOpenPage: true })).toEqual({
+    expect(
+      getDetailPrimaryAction(onsiteDetail({ hasPage: true, slug: 'gen' }), { canOpenPage: true })
+    ).toEqual({
       label: 'Open',
       mode: 'open',
       href: '/apps/run/gen',
@@ -278,7 +284,8 @@ describe('getDetailPrimaryAction — on-site', () => {
   });
   it('encodes an odd slug on the Open run link', () => {
     expect(
-      getDetailPrimaryAction(onsiteDetail({ hasPage: true, slug: 'a b/c' }), { canOpenPage: true }).href
+      getDetailPrimaryAction(onsiteDetail({ hasPage: true, slug: 'a b/c' }), { canOpenPage: true })
+        .href
     ).toBe('/apps/run/a%20b%2Fc');
   });
 });
@@ -372,24 +379,27 @@ describe('getDetailPrimaryAction — off-site', () => {
   });
 
   /**
-   * 🔴 SURFACED, NOT DECIDED — the one place off-site listings still diverge.
+   * 🔴 #4208 — THE DEAD "Connect" CTA IS GONE, AND MUST NOT COME BACK.
    *
-   * With no usable destination there is nothing to navigate to, and the two
-   * fallbacks say different things: an app with no OAuth client is simply
-   * "Unavailable", while an OAuth-connected one keeps the "Connect" stub for a
-   * route that does not exist yet. That is a CAPABILITY difference (does this
-   * app connect to your Civitai account?), not a kind difference, and the
-   * predicate is now read straight off `connectClientId` — byte-identical to
-   * what the deleted sub-kind computed from the same field.
+   * With no usable destination there is nothing to navigate to. This used to
+   * fork on the OAuth capability: no client → "Unavailable", a client → a
+   * disabled "Connect" button reading "Connecting this app will be available
+   * soon." Nothing was behind it, so it cost a click and returned nowhere.
    *
-   * Whether the stub should survive at all is a product question this change
-   * does not answer; it is pinned here so a future answer has to be deliberate.
+   * Measured against production before removal: ZERO listings sat in the state
+   * (all five off-site rows, every status, carry an https destination), so no
+   * live listing changed. The state remains REACHABLE — `offsiteSubmitSchema`
+   * requires `connectClientId` but leaves `externalUrl` optional — which is why
+   * the fallthrough still has to be honest rather than absent.
+   *
+   * 🔴 NEW-BEHAVIOUR GUARD, not regression coverage: it pins an outcome this
+   * commit introduces. Its value is forward-looking — reintroducing the fork
+   * fails here.
    */
-  it('🔴 OAuth-connected with NO usable destination → the stub still fails safe', () => {
-    // The stub must stay REACHABLE and must stay hrefless. Enumerated over every
-    // way a destination can be absent, with the client_id present in each.
-    // (`undefined` is deliberately absent: the DTO types `externalUrl` as
-    // `string | null`, and the fixture's destructuring default would silently
+  it('🔴 OAuth-connected with NO usable destination → Unavailable (no Connect stub)', () => {
+    // Enumerated over every way a destination can be absent, client_id present
+    // in each. (`undefined` is deliberately absent: the DTO types `externalUrl`
+    // as `string | null`, and the fixture's destructuring default would silently
     // rewrite it to `null` anyway — a row whose label lied about its input.)
     for (const externalUrl of [null, '', 'http://insecure.app', 'javascript:alert(1)']) {
       const key = `externalUrl=${String(externalUrl)}`;
@@ -397,28 +407,46 @@ describe('getDetailPrimaryAction — off-site', () => {
         offsiteDetail({ connectClientId: 'client-123', externalUrl }),
         { canOpenPage: true }
       );
-      expect(action.mode, key).toBe('connect');
-      expect(action.label, key).toBe('Connect');
+      expect(action.mode, key).toBe('info');
+      expect(action.label, key).toBe('Unavailable');
       expect(action.href, key).toBeUndefined();
       expect(action.external, key).toBe(false);
-      expect(action.note, key).toBeTruthy();
+      // 🔴 Pin the WHOLE note, not "is truthy" — the defect was a specific
+      // sentence promising a flow, and a truthiness check is satisfied by it.
+      expect(action.note, key).toBe('This app has no valid external link.');
+      expect(action.label, key).not.toBe('Connect');
     }
   });
 
-  it('🔴 GRANDFATHERED with NO usable destination → Unavailable, NOT the Connect stub', () => {
-    // The negative arm of the case above, over the same four absence shapes.
-    // Without it the capability test could be inverted (or deleted, defaulting
-    // everything to the stub) and the suite would stay green.
+  /**
+   * 🔴 THE CAPABILITY NO LONGER CHANGES THE ACTION — assert the EQUALITY, not
+   * two separate constants.
+   *
+   * The grandfathered (no-OAuth) arm was already "Unavailable" before #4208, so
+   * asserting it alone is unchanged behaviour and could not detect the fork
+   * being restored. What is new is that the two arms are now IDENTICAL, so that
+   * is what this pins: same object, both capability states, every absence shape.
+   * A restored `connectClientId` branch makes these differ and fails here.
+   */
+  it('🔴 with no destination, the action is IDENTICAL with and without OAuth', () => {
+    let compared = 0;
     for (const externalUrl of [null, '', 'http://insecure.app', 'javascript:alert(1)']) {
       const key = `externalUrl=${String(externalUrl)}`;
-      const action = getDetailPrimaryAction(offsiteDetail({ connectClientId: null, externalUrl }), {
-        canOpenPage: true,
-      });
-      expect(action.mode, key).toBe('info');
-      expect(action.label, key).toBe('Unavailable');
-      expect(action.note, key).toBe('This app has no valid external link.');
-      expect(action.href, key).toBeUndefined();
+      const withOauth = getDetailPrimaryAction(
+        offsiteDetail({ connectClientId: 'client-123', externalUrl }),
+        { canOpenPage: true }
+      );
+      const grandfathered = getDetailPrimaryAction(
+        offsiteDetail({ connectClientId: null, externalUrl }),
+        { canOpenPage: true }
+      );
+      expect(withOauth, key).toEqual(grandfathered);
+      // Anti-vacuity: both being some empty/undefined value would also compare
+      // equal. Pin the shared value too.
+      expect(grandfathered.label, key).toBe('Unavailable');
+      compared++;
     }
+    expect(compared).toBe(4);
   });
 
   /**
@@ -472,6 +500,48 @@ describe('getDetailPrimaryAction — off-site', () => {
     // matrix also crossed a sub-kind that no longer exists; the DROP is the
     // point — the removed dimension was never independent of `connectClientId`.)
     expect(navigable).toBe(2);
+  });
+});
+
+/**
+ * 🔴 #4208 SOURCE-LEVEL GATE — the dead Connect affordance must not return to the
+ * renderer.
+ *
+ * The type guard (`DetailActionMode` has no `'connect'`) already makes the
+ * VIEW-MODEL unable to emit it. This closes the other half: a hand-rolled button
+ * in the JSX, which no type would catch, and which the browser suite — run only
+ * by the PR preview pipeline, report-only and not a required check — would not
+ * block either. Same technique and same positive-control discipline as the
+ * disclosure gate below.
+ *
+ * 🔴 NEW-BEHAVIOUR GUARD, not regression coverage.
+ */
+describe('🔴 the removed Connect CTA cannot silently return', () => {
+  const body = fs.readFileSync(path.resolve(__dirname, '../AppListingDetailBody.tsx'), 'utf8');
+
+  it('the renderer no longer carries the stub copy or a connect branch', () => {
+    // POSITIVE CONTROL first: prove the read returned this component's source,
+    // so the absences below are about the file and not about an empty string.
+    expect(body).toMatch(/shouldShowOffsiteDisclosure\(detail\.kindData\)/);
+
+    // The exact promise the CTA made.
+    expect(body).not.toMatch(/Connecting this app will be available soon/);
+    // The branch itself, in either quote style.
+    expect(body).not.toMatch(/action\.mode\s*===\s*['"]connect['"]/);
+    // A re-hand-rolled glyph lookup for the removed mode.
+    expect(body).not.toMatch(/glyphFor\(\s*['"]connect['"]\s*\)/);
+  });
+
+  it('the view-model no longer emits the mode or its copy', () => {
+    const view = fs.readFileSync(path.resolve(__dirname, '../appListingDetailView.ts'), 'utf8');
+    // POSITIVE CONTROL: the read really returned the view-model.
+    expect(view).toMatch(/export function getDetailPrimaryAction/);
+
+    // 🔴 Match a `mode:` ASSIGNMENT, not the bare word — the docstrings discuss
+    // the removal at length and name `'connect'` repeatedly, so a bare-word
+    // check would fail on the prose explaining why the code is gone.
+    expect(view).not.toMatch(/mode:\s*['"]connect['"]/);
+    expect(view).not.toMatch(/Connecting this app will be available soon/);
   });
 });
 
@@ -594,10 +664,7 @@ describe('shouldShowOffsiteDisclosure — the "no account access" claim', () => 
     // directory `vitest` was invoked from, so a cwd-relative read passes in CI
     // (where it is the repo root) and ENOENTs locally — a test whose verdict is
     // about the caller's shell. Same idiom as the iframe gate below.
-    const body = fs.readFileSync(
-      path.resolve(__dirname, '../AppListingDetailBody.tsx'),
-      'utf8'
-    );
+    const body = fs.readFileSync(path.resolve(__dirname, '../AppListingDetailBody.tsx'), 'utf8');
     // POSITIVE CONTROL first: the read really returned this component's source.
     expect(body).toMatch(/This app runs entirely off-platform/);
     expect(body).toMatch(/shouldShowOffsiteDisclosure\(detail\.kindData\)/);
@@ -794,7 +861,9 @@ describe('owner Edit deep-link + gating (on the detail view-model)', () => {
     ).toBe('/apps/blk-7/edit');
   });
   it('on-site with no appBlockId → null (no editable target → hide)', () => {
-    expect(getOwnerEditHref(onsiteDetail({ hasPage: false, appBlockId: null }).kindData, 'l1')).toBeNull();
+    expect(
+      getOwnerEditHref(onsiteDetail({ hasPage: false, appBlockId: null }).kindData, 'l1')
+    ).toBeNull();
   });
   it('off-site detail kindData → the submit editor keyed on the listing id', () => {
     expect(getOwnerEditHref(offsiteDetail({ externalUrl: 'https://x' }).kindData, 'l2')).toBe(

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -451,26 +451,50 @@ describe('getDetailPrimaryAction — off-site', () => {
   });
 
   /**
-   * An empty-string client id is FALSY, which is what the deleted
-   * `resolveOffsiteSubKind` tested — so it took the no-client arm.
-   * `app-listing.service.detailKindData`'s `|| null` guarantees this never
-   * reaches the wire by THAT path, but `app-listing-actionable.service` calls
-   * this view-model directly with a listing row, so pin the truthiness here
-   * rather than relying on a caller. (`MySubmissionsList` also calls it
-   * directly, but hardcodes `kind: 'onsite'` and never reaches this branch —
-   * it is NOT an off-site caller; an earlier version of this note implied it
-   * was.) The mod-review preview builder reaches it too, via
-   * `buildListingDetailPreview` → `AppListingDetailBody`, and it uses
-   * `?? null` — see `shouldShowOffsiteDisclosure`'s docstring.
+   * 🔴 INVARIANT GUARD, NOT A CAPABILITY TEST — and its title used to claim
+   * otherwise, which is why it is relabelled rather than left alone.
+   *
+   * Before #4208 this pinned TRUTHINESS: an empty-string client id is falsy,
+   * which is what the deleted `resolveOffsiteSubKind` tested, so it took the
+   * "no client" arm instead of the Connect stub. **That arm no longer exists.**
+   * `getDetailPrimaryAction` does not read `connectClientId` at all now, so
+   * `''`, `'client-123'` and `null` are indistinguishable here BY CONSTRUCTION
+   * and this fixture exercises the no-destination path and nothing else. Left
+   * as-is it would have read as capability coverage while being unable to fail
+   * for any capability reason.
+   *
+   * Kept and widened to assert what is actually true now: the action does not
+   * vary with the capability, empty string included.
+   *
+   * The truthiness contract still matters and still has a real test — it moved
+   * to `shouldShowOffsiteDisclosure`, which does still read the field. The
+   * callers that reach this view-model directly with a raw row
+   * (`app-listing-actionable.service`; and the mod-review preview builder via
+   * `buildListingDetailPreview` → `AppListingDetailBody`, which uses `?? null`)
+   * are documented in that predicate's docstring. (`MySubmissionsList` also
+   * calls it directly but hardcodes `kind: 'onsite'` and never reaches this
+   * branch — it is NOT an off-site caller.)
    */
-  it('an empty-string connectClientId takes the no-client arm (truthiness, not nullish)', () => {
-    const action = getDetailPrimaryAction(
+  it('🔴 the action ignores connectClientId entirely, empty string included', () => {
+    const baseline = getDetailPrimaryAction(
       offsiteDetail({ connectClientId: '', externalUrl: null }),
-      {
-        canOpenPage: true,
-      }
+      { canOpenPage: true }
     );
-    expect(action.label).toBe('Unavailable');
+    expect(baseline.label).toBe('Unavailable');
+
+    // The invariant, stated as one: every capability shape yields the SAME
+    // action. Anti-vacuity — the loop must actually compare all three.
+    let compared = 0;
+    for (const connectClientId of [null, '', 'client-123']) {
+      expect(
+        getDetailPrimaryAction(offsiteDetail({ connectClientId, externalUrl: null }), {
+          canOpenPage: true,
+        }),
+        `client=${String(connectClientId)}`
+      ).toEqual(baseline);
+      compared++;
+    }
+    expect(compared).toBe(3);
   });
 
   it('🔴 no off-site listing with an https target is ever left un-navigable', () => {
@@ -648,8 +672,15 @@ describe('shouldShowOffsiteDisclosure — the "no account access" claim', () => 
   });
 
   it('an empty-string connectClientId does NOT suppress it (truthiness, not nullish)', () => {
-    // Matches the projection's `|| null` and `getDetailPrimaryAction`'s test, so
-    // all three read the capability the same way.
+    // Matches `app-listing.service`'s `|| null` projection — so BOTH remaining
+    // readers agree that an empty string is not a connected OAuth app.
+    //
+    // 🔴 This used to say "and `getDetailPrimaryAction`'s test, so all three read
+    // the capability the same way". #4208 deleted that reader: the primary action
+    // no longer branches on `connectClientId` at all, so this predicate is the
+    // only place in this module that does. Count the readers, don't restate the
+    // number — the sibling branch that adds `shouldShowConnectCapability` takes
+    // it back up.
     expect(
       shouldShowOffsiteDisclosure({
         kind: 'offsite',

--- a/src/components/Apps/appListingActionGlyph.ts
+++ b/src/components/Apps/appListingActionGlyph.ts
@@ -80,6 +80,12 @@ export const ACTION_GLYPH_ICONS: Record<PrimaryActionGlyph, Icon> = {
  * front, would then paint a launch icon on the informational fallback. Not
  * reachable from today's `getDetailPrimaryAction` (every `open`/`visit` return
  * sets an href), which is precisely why it would be easy to introduce later.
+ *
+ * 🔴 There is no `'connect'` arm: `DetailActionMode` no longer has that member
+ * (#4208 deleted the dead Connect CTA). `PrimaryActionGlyph` KEEPS its `'connect'`
+ * glyph because `cardActionGlyph` still maps `ListingCtaAction`'s own `'connect'`
+ * for totality — the two vocabularies are no longer identical, and that is
+ * deliberate rather than an oversight.
  */
 export function detailActionGlyph(mode: DetailActionMode): PrimaryActionGlyph {
   switch (mode) {
@@ -87,8 +93,6 @@ export function detailActionGlyph(mode: DetailActionMode): PrimaryActionGlyph {
       return 'launch';
     case 'visit':
       return 'external';
-    case 'connect':
-      return 'connect';
     case 'info':
       return 'info';
   }
@@ -106,8 +110,12 @@ export function detailActionGlyph(mode: DetailActionMode): PrimaryActionGlyph {
  * `'connect'` at all: an off-site connect listing now takes the `'visit'` arm
  * when it carries an https `externalUrl` and `'detail'` when it does not, so the
  * `'connect'` arm remains unreachable from live data and is mapped for totality
- * over the type. (The DETAIL view-model does still emit `connect`, for a connect
- * listing with no destination — `detailActionGlyph`'s arm is live.)
+ * over the type.
+ *
+ * 🔴 The DETAIL view-model no longer emits `connect` either — #4208 removed that
+ * mode outright. So NOTHING produces a connect glyph today. This arm survives
+ * only because `ListingCtaAction` still declares the member; if that type is ever
+ * cleaned up too, delete the glyph rather than finding it a new caller.
  */
 export function cardActionGlyph(action: ListingCtaAction): PrimaryActionGlyph {
   switch (action) {

--- a/src/components/Apps/appListingDetailView.ts
+++ b/src/components/Apps/appListingDetailView.ts
@@ -60,31 +60,44 @@
  *     page, so nothing takes it.
  *   - off-site with an https `externalUrl` → **Visit ↗** → external anchor.
  *     🔴 The presence of a destination decides this, and nothing else.
- *   - off-site with NO usable target and no OAuth client connected →
- *     **informational** (guarded out; no target).
- *   - off-site with NO usable target but an OAuth client connected → **Connect**
- *     STUB with a note — the only remaining state with nowhere to send the
- *     viewer. That last test is a CAPABILITY check on `connectClientId`, not a
- *     kind: off-site is one kind (the `connect` / `external-link` display
- *     sub-kind was removed).
+ *   - off-site with NO usable target → **informational** ("Unavailable"),
+ *     regardless of whether an OAuth client is connected. There is nowhere to
+ *     send the viewer, and the page says so.
  *
- * 🔴 THE CONNECT STUB USED TO BE UNCONDITIONAL, AND THAT WAS THE BUG. Every
- * off-site listing with a linked OAuth client rendered a dead
- * "Connecting this app will be available soon." affordance — no href, disabled
- * button — because the sub-kind routed on `connectClientId != null` alone, so
- * linking a client was the ONLY thing that moved a listing off the working
- * `Visit ↗` path. Three approved, live listings were in that state; a fourth,
- * with no client, worked.
+ * 🔴 THE "CONNECT" STUB IS DELETED (#4208) — DO NOT REINTRODUCE IT.
  *
- * The stub's stated premise — "a complete OAuth authorize URL is NOT derivable
- * from the public DTO" — is true and irrelevant. These are CONFIDENTIAL clients
- * that own their own `redirect_uri` / `state` / PKCE and start the flow from
- * their own site; the store never needed to build an authorize URL, only to get
- * the viewer to the app. That destination is already on the public DTO as
- * `externalUrl`, https-guarded, and the external-link branch has always
- * rendered it correctly. So connect now reuses that same proven path rather
- * than growing a second one, and the stub survives only for a connect listing
- * with genuinely no destination — where it still fails safe.
+ * History, because the shape recurs. The stub was once UNCONDITIONAL for the
+ * `connect` sub-kind: every off-site listing with a linked OAuth client rendered
+ * a dead affordance — no href, disabled button, and a note promising the flow
+ * was coming soon — because the sub-kind routed on `connectClientId != null`
+ * alone, so linking a client was the ONLY thing that moved a listing off the
+ * working `Visit ↗` path. Three approved, live listings were in that state.
+ * #4200 fixed that by routing on the destination, which left the stub reachable
+ * only for a connect listing with genuinely no destination.
+ *
+ * #4208 removes what was left. The stub promised an action and delivered
+ * nothing: there is no connect flow behind it, and a CTA that costs a click and
+ * returns nowhere reads as broken rather than incomplete. Measured against
+ * production before removing it — ZERO listings sat in that state (all five
+ * off-site rows, every status, carry an https destination), so nothing regressed
+ * for a live listing.
+ *
+ * 🔴 The state is still REACHABLE — `offsiteSubmitSchema` requires
+ * `connectClientId` but leaves `externalUrl` OPTIONAL, so a submission with no
+ * URL lands here. Closing that is an API-contract change, deliberately NOT made
+ * a rider on this one. So this branch must keep failing safe; it now does so by
+ * saying "Unavailable" instead of lying.
+ *
+ * 🔴 `'connect'` IS GONE FROM `DetailActionMode`. That is the guard: reintroducing
+ * the stub is a COMPILE ERROR, not a silent behaviour change a reviewer has to
+ * notice. Do not re-add the member to make a new branch type-check.
+ *
+ * (For the record, the stub's stated premise — "a complete OAuth authorize URL is
+ * NOT derivable from the public DTO" — was true and irrelevant. These are
+ * CONFIDENTIAL clients that own their own `redirect_uri` / `state` / PKCE and
+ * start the flow from their own site; the store never needed to build an
+ * authorize URL, only to get the viewer to the app, which `externalUrl` already
+ * does.)
  */
 
 import { safeExternalHref } from '~/components/Apps/appListingCardView';
@@ -105,24 +118,29 @@ export {
  * Primary-action mode:
  *   - `open`    → internal nav to the in-host page runner.
  *   - `visit`   → external new-tab anchor (Visit / Open live).
- *   - `connect` → the OAuth connect affordance (stubbed until cutover; `note` set).
  *   - `info`    → informational affordance. NO href is produced for this mode
  *                 today (the only "learn more" target was the retired
  *                 `/apps/[appBlockId]`); the field stays optional on the type
  *                 and both renderers keep their text-only fallback.
+ *
+ * 🔴 There is deliberately NO `'connect'` member (#4208). It described a CTA with
+ * no flow behind it. Its absence from this union is what makes the dead button
+ * un-reintroducible without a compile error — see the module docstring. If you
+ * are here to add it back because a new branch won't type-check, build the
+ * connect flow first.
  */
-export type DetailActionMode = 'open' | 'visit' | 'connect' | 'info';
+export type DetailActionMode = 'open' | 'visit' | 'info';
 
 export type DetailPrimaryAction = {
   /** Button / affordance copy. */
   label: string;
   mode: DetailActionMode;
   /** Nav target (internal for `open`, external for `visit`), or undefined. Never
-   *  set for `info`/`connect` — see the mode docs above. */
+   *  set for `info` — see the mode docs above. */
   href?: string;
   /** True → open in a new tab as an external anchor (rel=noopener noreferrer). */
   external: boolean;
-  /** Informational copy for the `info` / `connect`-stub modes. */
+  /** Informational copy for the `info` mode. */
   note?: string;
 };
 
@@ -203,45 +221,24 @@ export function getDetailPrimaryAction(
   const href = safeExternalHref(kd.externalUrl);
   if (href) return { label: 'Visit', mode: 'visit', href, external: true };
 
-  // NO usable destination. The two fallbacks below differ by a CAPABILITY, not
-  // by a kind: an app with no OAuth client connected has simply nowhere to send
-  // you ("Unavailable"), whereas an app that DOES connect to your Civitai
-  // account has a second, not-yet-built route ("Connect", stubbed). This test
-  // used to read `kd.subKind === 'external-link'`.
+  // NO usable destination → ONE informational fallback, whether or not an OAuth
+  // client is connected.
   //
-  // 🔴 EQUIVALENCE, STATED AT THE SCOPE IT ACTUALLY HOLDS — there are TWO
-  // producers of this DTO and they did not agree:
-  //   - `app-listing.service.detailKindData` derived the sub-kind by TRUTHINESS
-  //     (`connectClientId ? … : …`), so reading the field directly is the same
-  //     predicate and the behaviour is byte-identical for every input there.
-  //   - `reviewListingPreview.detailKindData` (the mod-review preview) used
-  //     `!= null` for the sub-kind while passing the field through with
-  //     `?? null`. At `connectClientId === ''` those disagree: the OLD preview
-  //     hid the disclosure and showed this Connect stub; the NEW one shows the
-  //     disclosure and "Unavailable". That is a real, if practically
-  //     unreachable, behaviour change (`connect_client_id` is an FK to
-  //     `OauthClient.id` and `offsite-listing.schema.ts` requires
-  //     `z.string().min(1)` on create), and the new answer is the safer of the
-  //     two — an empty string is not a connected OAuth app.
+  // 🔴 This used to fork on `kd.connectClientId`, giving the OAuth arm a
+  // "Connect" stub for a flow that does not exist. #4208 deleted that arm: the
+  // capability is real, but it is not a NAVIGATION target, and the store has
+  // nowhere to send this viewer either way. Do NOT reintroduce a
+  // `connectClientId` test here — the capability is communicated by the
+  // permission signal on the page body (`shouldShowOffsiteDisclosure` and its
+  // positive counterpart), not by a button that does nothing.
   //
-  // Whether the stub should exist at all is a product question this change
-  // deliberately does not answer.
-  if (!kd.connectClientId) {
-    return {
-      label: 'Unavailable',
-      mode: 'info',
-      external: false,
-      note: 'This app has no valid external link.',
-    };
-  }
-
-  // OAuth-connected, with NO usable destination — the honest stub, reached only
-  // in that genuinely-nowhere-to-go state. Fails safe: no dead nav.
+  // The note is accurate for both arms: a listing in this state has no valid
+  // external link, which is exactly why there is no action to offer.
   return {
-    label: 'Connect',
-    mode: 'connect',
+    label: 'Unavailable',
+    mode: 'info',
     external: false,
-    note: 'Connecting this app will be available soon.',
+    note: 'This app has no valid external link.',
   };
 }
 

--- a/src/components/Apps/appListingDetailView.ts
+++ b/src/components/Apps/appListingDetailView.ts
@@ -82,7 +82,8 @@
  * off-site rows, every status, carry an https destination), so nothing regressed
  * for a live listing.
  *
- * 🔴 The state is still REACHABLE — `offsiteSubmitSchema` requires
+ * 🔴 The state is still REACHABLE — `submitExternalListingSchema`
+ * (`src/server/schema/blocks/offsite-listing.schema.ts`) requires
  * `connectClientId` but leaves `externalUrl` OPTIONAL, so a submission with no
  * URL lands here. Closing that is an API-contract change, deliberately NOT made
  * a rider on this one. So this branch must keep failing safe; it now does so by
@@ -262,9 +263,14 @@ export function getDetailPrimaryAction(
  *   - a non-null `externalUrl` — there is no "runs off-platform" claim to make
  *     about a listing with nowhere to run.
  *
- * Truthiness on `connectClientId`, matching `app-listing.service`'s `|| null`
- * and the no-destination fallback above, so all three read the capability the
- * same way.
+ * Truthiness on `connectClientId`, matching `app-listing.service`'s `|| null`,
+ * so both read the capability the same way.
+ *
+ * 🔴 This used to say "and the no-destination fallback above, so all THREE read
+ * the capability the same way". #4208 deleted that fallback's `connectClientId`
+ * test outright — the primary action no longer reads the capability at all — so
+ * there are two readers here, not three. This predicate is now the ONLY place in
+ * this module that branches on it.
  *
  * 🔴 TWO PRODUCERS FEED THIS, and only one is the store read path.
  * `OffsiteReviewQueue`'s `ListingPreviewSection` renders `AppListingDetailBody`

--- a/src/server/services/blocks/__tests__/app-listing-actionable.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-actionable.service.test.ts
@@ -53,7 +53,9 @@ describe('checkOffsiteListingActionable — the verdict', () => {
 
   for (const { name, url } of NO_DESTINATION) {
     it(`BLOCKS an OAuth-connected off-site listing whose externalUrl is ${name}`, () => {
-      // client_id present → the no-destination fallback takes the Connect-stub arm.
+      // client_id present → the no-destination fallback. Since #4208 that is the
+      // same informational arm a grandfathered listing takes; either way it
+      // yields no href, which is the only thing this gate reads.
       const result = checkOffsiteListingActionable(
         offsite({ externalUrl: url, connectClientId: 'client-123' })
       );
@@ -198,12 +200,18 @@ describe('assertOffsiteListingActionable — fails CLOSED with mod-actionable co
     // Names the listing…
     expect(trpc.message).toContain('demo-app');
     // …quotes what the moderator would have seen on the button…
-    expect(trpc.message).toContain('Connecting this app will be available soon.');
+    //
+    // 🔴 #4208: this used to quote the dead Connect stub's copy. That CTA is
+    // deleted, so an OAuth listing with no destination now renders the SAME
+    // informational affordance as any other — the gate still fails closed, and
+    // the message now quotes the honest sentence instead of the promise.
+    expect(trpc.message).toContain('This app has no valid external link.');
+    expect(trpc.message).not.toContain('Connecting this app will be available soon.');
     // …and states the remedy.
     expect(trpc.message).toContain('https external URL');
   });
 
-  it('quotes the OTHER non-actionable shape too (no valid link), not just the connect stub', () => {
+  it('quotes the same copy for the OTHER non-actionable shape (non-https link)', () => {
     let message = '';
     try {
       assertOffsiteListingActionable(offsite({ externalUrl: 'http://insecure.app' }));


### PR DESCRIPTION
Closes #4208.

## What

The off-site listing detail rendered a **disabled "Connect" button** — with a note promising the flow was coming soon — whenever a listing had an OAuth client and no usable destination. Nothing is behind it. Selecting it leads nowhere.

That state now falls through to the same informational affordance a grandfathered listing already took: **"Unavailable"**, with the accurate note *"This app has no valid external link."*

Option **1** from the issue (remove the stub). Not option 3 — see below.

## Reachability, measured

The issue's suggested first step was to count live listings in the state. Enumerated (not sampled) every off-site row in production, all statuses:

| slug | status | OAuth | destination |
|---|---|---|---|
| comfy | approved | yes | `https://comfy.civitai.com/` |
| cosmetic-studio | approved | yes | `https://cosmetic-studio.civitai.com/` |
| radio | approved | yes | `https://radio.civitai.com/` |
| vitrine | approved | no | `https://vitrine.civitai.com/` |
| rev-01M08GJ… (shadow) | draft | yes | `https://radio.civitai.com/` |

**Zero listings** in the OAuth + no-destination state. No live listing changes behaviour.

Two notes on how that was measured, because a naive version gets it wrong:

- The predicate is not `external_url IS NULL`. The DTO nulls the destination via `safeExternalUrl()`, which requires `^https://` — so a row with an `http:` URL presents as no-destination in the UI while being non-NULL in the column. Re-run with the DTO's own predicate; still zero.
- **Zero is not the same as unreachable.** `submitExternalListingSchema` (`src/server/schema/blocks/offsite-listing.schema.ts:92`) requires `connectClientId` (`:97`) but leaves `externalUrl` **optional** (`:118`), so a submission with no URL lands in this state today. It reads as zero only because all five existing rows happen to carry a URL.

## Why not option 3

Option 3 (make the state unreachable, delete the branch) would close the class, but it is **not** just a deletion — it needs `externalUrl` to become required at submit, which starts rejecting submissions the API accepts today. That is an API-contract change worth making deliberately and separately, not as a rider on removing a dead button. So the state stays reachable and stops lying; the branch remains, and fails safe.

## The removal cannot silently revert

- **`'connect'` is gone from `DetailActionMode`.** Re-adding the return is a *compile error*, not a behaviour change a reviewer has to spot. Proven, not assumed — see M1 below.
- **A state gate on the CTA region.** The renderer routes on the view-model's `action` only, and must not read listing kind data at all — re-deriving the OAuth capability there is how the button comes back under any mode name, behind any wording. Positive controls prove the slice captured the real function body.

> **Corrected after audit.** An earlier revision of this PR claimed the source gates covered the render layer. They did not. Two of the three assertions were **vacuous by construction** — with `'connect'` removed from `DetailActionMode`, writing `action.mode === 'connect'` or `glyphFor('connect')` is a `TS2367`/`TS2345`, so no compiling tree could contain them and neither could ever fire. The third was a **spelled** guard, walkable by rewording. A stub restored under a different mode with reworded copy typechecked clean and **survived the entire blocking suite**. The state gate above replaces them; the verbatim-copy check is kept as a cheap catch and labelled as the spelled guard it is.

`assertOffsiteListingActionable` is **behaviourally unchanged**: it delegates to `getDetailPrimaryAction` and reads only whether an href was produced, so it still fails closed for this state. Only the copy it quotes back moved.

## Tests

Red→green, node `unit` project:

| test | at base | at HEAD |
|---|---|---|
| OAuth + no destination → Unavailable (no Connect stub) | **RED** | GREEN |
| with no destination, action IDENTICAL with/without OAuth | **RED** | GREEN |
| renderer carries no stub copy / connect branch | **RED** | GREEN |
| view-model emits neither the mode nor the copy | **RED** | GREEN |

All four are **new-behaviour guards** — they pin an outcome this PR introduces. Labelled as such in the source rather than counted as regression coverage.

Measured by restoring the three source files to base while keeping the new tests: exactly those 4 fail, the other 39 stay green.

### Mutation results

Each mutant verified to have actually landed (grepped post-edit), and each dies on **its own** assertion:

| mutant | verdict | killing assertion |
|---|---|---|
| M1 restore the stub verbatim | KILLED (tsc) | `TS2322: Type '"connect"' is not assignable to type 'DetailActionMode'` |
| M2 restore the fork with `mode: 'info'` (compiles) | KILLED | `expected 'Connect' to be 'Unavailable'`, and the deep-equal mismatch in the identity test |
| M3 re-add branch + copy to the renderer | KILLED | renderer gate: `not to match /Connecting this app will be available…/` |
| **M-X** restore under a *different mode* with *reworded copy* | **KILLED** (was SURVIVED before the audit fix) | `the CTA must not read the OAuth capability: expected 'function PrimaryAction({ detail, canO…' not to match /connectClientId/` |

M2 exists because M1 alone would only prove the *type* guard; M2 is the variant that compiles and therefore tests the runtime assertions.

## Verification

- `pnpm typecheck` — **0 type errors** (read the reported count, not the exit code).
- `vitest --project 'unit*' src/components/Apps src/server/services/blocks` — **197 files / 4496 tests green**.
- eslint on the 7 changed files — **7 files linted, 0 errors** (counted via `-f json`; a silent zero-file run and a clean run look identical otherwise).
- prettier — clean.

Not verified: the browser-mode component test is updated but that project is report-only and not run here; it is not part of any merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
