### PR TITLE
feat(apps): show a positive "connects to your account" indicator

### DIFF
--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -299,6 +299,63 @@ describe('AppListingDetailBody', () => {
     expect(row?.textContent).toContain('PG');
   });
 
+  /**
+   * 🔴 #4207 — THE TWO PERMISSION SIGNALS, AS A RELATIONSHIP, AT THE RENDER LAYER.
+   *
+   * The view-model test pins the predicates; this pins that the JSX actually
+   * wires them to two mutually-exclusive Alerts. The failure that matters is the
+   * page CONTRADICTING itself — telling a viewer an OAuth app has "no account
+   * access" — so both states are asserted in ONE test rather than separately.
+   *
+   * 🔴 The absence assertions are plain `toContain` on `textContent`, NOT
+   * `expect.element(...).not.toBeInTheDocument()`, which is inert in this repo
+   * (#4197) and passes for any string whatsoever.
+   *
+   * Each state asserts one sentence PRESENT and the other ABSENT in the same
+   * container, so the present-check is the positive control for the absent-check:
+   * a container wired to nothing fails the `toContain` before the `not` can pass
+   * vacuously. Both awaits settle the render first.
+   *
+   * Fixtures are the two REAL production shapes (measured): `vitrine` is the one
+   * approved off-site listing with no OAuth client; `comfy` carries one.
+   */
+  test('🔴 #4207 disclosure XOR connect indicator — never both, never neither', async () => {
+    const DISCLOSURE = 'This app runs entirely off-platform';
+    const INDICATOR = 'can connect to your Civitai account';
+
+    const grandfathered = await renderScoped(
+      <AppListingDetailBody
+        detail={base({
+          kind: 'offsite',
+          kindData: {
+            kind: 'offsite',
+            externalUrl: 'https://vitrine.civitai.com/',
+            connectClientId: null,
+          },
+        })}
+      />
+    );
+    await expect.element(grandfathered.within.getByText('My App')).toBeInTheDocument();
+    expect(grandfathered.container.textContent).toContain(DISCLOSURE);
+    expect(grandfathered.container.textContent).not.toContain(INDICATOR);
+
+    const withOauth = await renderScoped(
+      <AppListingDetailBody
+        detail={base({
+          kind: 'offsite',
+          kindData: {
+            kind: 'offsite',
+            externalUrl: 'https://comfy.civitai.com/',
+            connectClientId: 'oauth_comfy',
+          },
+        })}
+      />
+    );
+    await expect.element(withOauth.within.getByText('My App')).toBeInTheDocument();
+    expect(withOauth.container.textContent).toContain(INDICATOR);
+    expect(withOauth.container.textContent).not.toContain(DISCLOSURE);
+  });
+
   // ── The `⋮` overflow menu ──────────────────────────────────────────────────
   //
   // 🔴 RED AT BASE. The base renders the secondary actions as a stacked full-width

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -26,6 +26,7 @@ import {
   IconFlag,
   IconInfoCircle,
   IconPencil,
+  IconPlugConnected,
   IconThumbUp,
 } from '@tabler/icons-react';
 import type { Icon } from '@tabler/icons-react';
@@ -45,6 +46,7 @@ import {
   type DetailActionMode,
   getDetailPrimaryAction,
   getOwnerEditHref,
+  shouldShowConnectCapability,
   shouldShowOffsiteDisclosure,
 } from '~/components/Apps/appListingDetailView';
 import { toRecentAppFromListing } from '~/components/Apps/recentAppsRail';
@@ -1114,6 +1116,27 @@ export function AppListingDetailBody({
               <Alert variant="light" color="blue" icon={<IconInfoCircle size={16} />}>
                 This app runs entirely off-platform — no Civitai install, account access, or
                 permissions.
+              </Alert>
+            )}
+
+            {/* The POSITIVE half of the same permission signal (#4207).
+                🔴 These two Alerts are MUTUALLY EXCLUSIVE by construction, not by
+                convention: `shouldShowConnectCapability` is the exact complement
+                of `shouldShowOffsiteDisclosure` over one shared domain, so
+                exactly one renders for an off-site listing with a destination and
+                neither renders otherwise. Do not add a third condition here, and
+                do not inline either predicate — the disclosure makes a SECURITY
+                claim and the reason it lives in a pure function is that inline in
+                this JSX nothing could test it. The relationship (never both,
+                never neither) is pinned as a single test in
+                `__tests__/appListingDetailView.test.ts`.
+                🔴 This is a CAPABILITY, not a kind: it selects a sentence, never
+                a badge or a CTA. #4200 removed the off-site sub-kind and this
+                must not reintroduce it by the back door. */}
+            {shouldShowConnectCapability(detail.kindData) && (
+              <Alert variant="light" color="blue" icon={<IconPlugConnected size={16} />}>
+                This app runs off-platform, but can connect to your Civitai account — you&apos;ll be
+                asked to sign in and approve access.
               </Alert>
             )}
           </Stack>

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -745,6 +745,32 @@ describe('shouldShowOffsiteDisclosure — the "no account access" claim', () => 
     // how the two signals would drift into contradicting each other.
     expect(body).toMatch(/shouldShowConnectCapability\(detail\.kindData\)/);
   });
+
+  /**
+   * 🔴 THE SECURITY DOCSTRING MUST STILL DOCUMENT THIS FUNCTION.
+   *
+   * A JSDoc block attaches to whatever declaration FOLLOWS it, so inserting a
+   * helper between this docstring and its function silently re-points ~46 lines
+   * of security rationale at the helper and leaves `shouldShowOffsiteDisclosure`
+   * with no docs at all — hover shows nothing. That happened once during #4207
+   * and is invisible in a diff, which is why it is pinned rather than just fixed.
+   *
+   * This is the docstring `AppListingDetailBody`'s JSX comment tells readers to
+   * consult before changing what the sentence says.
+   */
+  it('🔴 the security docstring is still attached to the disclosure predicate', () => {
+    const view = fs.readFileSync(path.resolve(__dirname, '../appListingDetailView.ts'), 'utf8');
+    // POSITIVE CONTROL: the docstring exists and we really read this module.
+    const marker = 'EXTRACTED FROM THE JSX ON PURPOSE';
+    expect(view).toContain(marker);
+
+    // Whatever declaration follows that docstring's terminator must be the
+    // disclosure itself — not a helper that drifted in between.
+    const close = view.indexOf('\n */\n', view.indexOf(marker));
+    expect(close, 'docstring terminator not found').toBeGreaterThan(-1);
+    const following = view.slice(close + '\n */\n'.length).split('\n')[0];
+    expect(following).toMatch(/^export function shouldShowOffsiteDisclosure\b/);
+  });
 });
 
 /**
@@ -872,18 +898,29 @@ describe('🔴 the disclosure and the connect indicator, as a relationship', () 
    * 🔴 A NON-HTTPS URL IS INSIDE THE DOMAIN, AND THAT IS PRE-EXISTING.
    *
    * `shouldShowOffsiteDisclosure` has always tested `!!externalUrl` — plain
-   * truthiness, not an https guard — so a listing with `http://…` shows the
-   * off-platform disclosure today. The connect indicator MIRRORS that rather
+   * truthiness, not an https guard. The connect indicator MIRRORS that rather
    * than narrowing it: tightening the domain to https would silently change when
    * an existing SECURITY claim is displayed, which is a behaviour change #4207
    * did not ask for and which belongs in its own change if it is wanted.
    *
-   * ⚠️ Worth knowing, NOT fixed here: this diverges from the primary CTA, which
-   * routes through `safeExternalHref` and treats a non-https URL as NO
-   * destination. So such a listing shows a permission sentence about running
-   * off-platform while offering no way to go there. That inconsistency predates
-   * both #4207 and #4200; it is recorded here so the next reader does not
-   * mistake it for something this change introduced.
+   * 🔴 SCOPE — WHICH PRODUCER CAN ACTUALLY REACH THESE CELLS. Not the public
+   * store detail. `app-listing.service` applies `safeExternalUrl()` (https-only)
+   * to BOTH projections (`:255` card, `:315` detail), so a non-https column
+   * arrives at this predicate as `null`, never as `http://…`; and the submit path
+   * validates https whenever a URL is present. The ONLY producer that can deliver
+   * these values is the moderator review preview — `reviewListingPreview.ts:98`
+   * passes `row.appListing?.externalUrl ?? null` through UNGUARDED — and then
+   * only for a legacy row that already holds one.
+   *
+   * An earlier version of this note stated the divergence unconditionally, which
+   * over-warned: it read as though a public listing could show an off-platform
+   * sentence with no way to go there. It cannot. The moderator-preview path can,
+   * which is a much narrower and less alarming claim.
+   *
+   * ⚠️ Still worth knowing, NOT fixed here: on that preview path the predicates
+   * and the CTA disagree — the CTA's `safeExternalHref` treats a non-https URL as
+   * NO destination while these predicates count it as one. Predates both #4207
+   * and #4200.
    *
    * What this test pins is the part that IS this change's business: whatever the
    * domain turns out to be, the two signals agree about it and still XOR.

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -6,6 +6,7 @@ import {
   getDetailPrimaryAction,
   getOwnerEditHref,
   isEditableListingStatus,
+  shouldShowConnectCapability,
   shouldShowOffsiteDisclosure,
 } from '~/components/Apps/appListingDetailView';
 import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
@@ -739,6 +740,200 @@ describe('shouldShowOffsiteDisclosure — the "no account access" claim', () => 
     // POSITIVE CONTROL first: the read really returned this component's source.
     expect(body).toMatch(/This app runs entirely off-platform/);
     expect(body).toMatch(/shouldShowOffsiteDisclosure\(detail\.kindData\)/);
+    // …and the same for the positive counterpart (#4207): the renderer must call
+    // it, not re-derive `connectClientId` inline. A second inline copy is exactly
+    // how the two signals would drift into contradicting each other.
+    expect(body).toMatch(/shouldShowConnectCapability\(detail\.kindData\)/);
+  });
+});
+
+/**
+ * 🔴 #4207 — THE TWO PERMISSION SIGNALS ARE ONE STATEMENT WITH TWO SIDES.
+ *
+ * The off-platform disclosure ("no Civitai install, account access, or
+ * permissions") and the connect indicator ("can connect to your Civitai
+ * account") are the negative and positive halves of the SAME permission claim.
+ * The failure mode that matters is not either one being wrong on its own — it is
+ * the two DISAGREEING: showing both (the page contradicts itself about account
+ * access) or showing neither (the state that made #4207 worth filing, where the
+ * capability was communicated only by an absence).
+ *
+ * 🔴 So this is asserted as a RELATIONSHIP, in one test, over both states.
+ * Testing each predicate in isolation — which the suite above already does — is
+ * exactly how a contradiction between them would be missed: both files stay
+ * green while the page says two things at once.
+ *
+ * 🔴 XOR ALONE IS NOT ENOUGH, and that is why the table below pins WHICH signal
+ * shows for WHICH state. Swapping the two predicates preserves XOR perfectly:
+ * every listing would still show exactly one signal, and a test that only
+ * checked "exactly one" would stay green while every OAuth app was labelled
+ * "no account access" — the worst possible inversion of a security claim.
+ */
+describe('🔴 the disclosure and the connect indicator, as a relationship', () => {
+  /**
+   * Distinct, non-default values on every axis, and pairwise distinct from each
+   * other — so a mutant that hardcodes any single literal still moves a row.
+   */
+  const DESTINATIONS = ['https://ext.app', 'https://other.example/path'] as const;
+  /** Truthy client ids (capability PRESENT) — two distinct, neither a default. */
+  const OAUTH_IDS = ['oauth_abc', 'oauth_zzz'] as const;
+  /** Falsy client ids (capability ABSENT) — the grandfathered shapes. */
+  const NO_OAUTH = [null, '', undefined] as const;
+
+  it('🔴 for a listing WITH a destination, EXACTLY ONE renders — and it is the right one', () => {
+    let disclosureRows = 0;
+    let indicatorRows = 0;
+
+    for (const externalUrl of DESTINATIONS) {
+      for (const connectClientId of OAUTH_IDS) {
+        const key = `url=${externalUrl} client=${String(connectClientId)}`;
+        const kindData = { kind: 'offsite', externalUrl, connectClientId } as const;
+        const disclosure = shouldShowOffsiteDisclosure(kindData);
+        const indicator = shouldShowConnectCapability(kindData);
+
+        // The relationship: never both, never neither.
+        expect(disclosure !== indicator, `XOR ${key}`).toBe(true);
+        // …and the DIRECTION, which XOR cannot see. An OAuth app must never be
+        // told it has "no account access".
+        expect(disclosure, `disclosure ${key}`).toBe(false);
+        expect(indicator, `indicator ${key}`).toBe(true);
+        indicatorRows++;
+      }
+
+      for (const connectClientId of NO_OAUTH) {
+        const key = `url=${externalUrl} client=${String(connectClientId)}`;
+        const kindData = { kind: 'offsite', externalUrl, connectClientId } as unknown as Parameters<
+          typeof shouldShowOffsiteDisclosure
+        >[0];
+        const disclosure = shouldShowOffsiteDisclosure(kindData);
+        const indicator = shouldShowConnectCapability(kindData);
+
+        expect(disclosure !== indicator, `XOR ${key}`).toBe(true);
+        expect(disclosure, `disclosure ${key}`).toBe(true);
+        expect(indicator, `indicator ${key}`).toBe(false);
+        disclosureRows++;
+      }
+    }
+
+    // 🔴 ANTI-VACUITY. Without these the test passes if the loops ran zero times,
+    // and — more importantly — it proves BOTH arms were actually exercised, so
+    // the XOR assertions above are not all coming from one side of the fork.
+    expect(indicatorRows).toBe(4); // 2 destinations x 2 truthy client ids
+    expect(disclosureRows).toBe(6); // 2 destinations x 3 falsy client ids
+  });
+
+  it('🔴 outside the domain, NEITHER renders (no destination, and on-site)', () => {
+    // The one state where "both hidden" is correct: there is no claim to make
+    // about where an app runs when it has nowhere to run. Pinned so a future
+    // change that makes the indicator unconditional on `connectClientId` — the
+    // obvious naive implementation — fails here rather than printing a
+    // permission claim over a listing with no destination.
+    let checked = 0;
+    // 🔴 `'http://insecure.app'` is deliberately NOT in this list — see the
+    // dedicated test below. The domain is TRUTHINESS on `externalUrl`, not an
+    // https check, so a non-https URL is INSIDE it.
+    for (const externalUrl of [null, '']) {
+      for (const connectClientId of ['oauth_abc', null]) {
+        const key = `url=${String(externalUrl)} client=${String(connectClientId)}`;
+        const kindData = { kind: 'offsite', externalUrl, connectClientId } as unknown as Parameters<
+          typeof shouldShowOffsiteDisclosure
+        >[0];
+        expect(shouldShowOffsiteDisclosure(kindData), `disclosure ${key}`).toBe(false);
+        expect(shouldShowConnectCapability(kindData), `indicator ${key}`).toBe(false);
+        checked++;
+      }
+    }
+    expect(checked).toBe(4);
+
+    // An on-site listing, including the cast-producer shape that smuggles in an
+    // externalUrl — the same fixture the disclosure suite uses, applied to both.
+    const onsite = {
+      kind: 'onsite',
+      appBlockId: 'blk-1',
+      hasPage: true,
+      liveUrl: 'https://blk-1.civit.ai',
+    } as unknown as Parameters<typeof shouldShowOffsiteDisclosure>[0];
+    expect(shouldShowOffsiteDisclosure(onsite)).toBe(false);
+    expect(shouldShowConnectCapability(onsite)).toBe(false);
+
+    const smuggled = {
+      ...onsite,
+      externalUrl: 'https://smuggled.example/app',
+      connectClientId: 'oauth_abc',
+    } as unknown as Parameters<typeof shouldShowOffsiteDisclosure>[0];
+    // POSITIVE CONTROL: the same object as OFF-SITE does light the indicator, so
+    // the two `false`s below are about the kind term and not an inert function.
+    expect(shouldShowConnectCapability({ ...smuggled, kind: 'offsite' })).toBe(true);
+    expect(shouldShowOffsiteDisclosure(smuggled)).toBe(false);
+    expect(shouldShowConnectCapability(smuggled)).toBe(false);
+  });
+
+  /**
+   * 🔴 A NON-HTTPS URL IS INSIDE THE DOMAIN, AND THAT IS PRE-EXISTING.
+   *
+   * `shouldShowOffsiteDisclosure` has always tested `!!externalUrl` — plain
+   * truthiness, not an https guard — so a listing with `http://…` shows the
+   * off-platform disclosure today. The connect indicator MIRRORS that rather
+   * than narrowing it: tightening the domain to https would silently change when
+   * an existing SECURITY claim is displayed, which is a behaviour change #4207
+   * did not ask for and which belongs in its own change if it is wanted.
+   *
+   * ⚠️ Worth knowing, NOT fixed here: this diverges from the primary CTA, which
+   * routes through `safeExternalHref` and treats a non-https URL as NO
+   * destination. So such a listing shows a permission sentence about running
+   * off-platform while offering no way to go there. That inconsistency predates
+   * both #4207 and #4200; it is recorded here so the next reader does not
+   * mistake it for something this change introduced.
+   *
+   * What this test pins is the part that IS this change's business: whatever the
+   * domain turns out to be, the two signals agree about it and still XOR.
+   */
+  it('🔴 a non-https destination stays INSIDE the domain, and the two still XOR', () => {
+    let rows = 0;
+    for (const externalUrl of ['http://insecure.app', 'javascript:alert(1)']) {
+      for (const connectClientId of ['oauth_abc', null]) {
+        const key = `url=${externalUrl} client=${String(connectClientId)}`;
+        const kindData = { kind: 'offsite', externalUrl, connectClientId } as unknown as Parameters<
+          typeof shouldShowOffsiteDisclosure
+        >[0];
+        const disclosure = shouldShowOffsiteDisclosure(kindData);
+        const indicator = shouldShowConnectCapability(kindData);
+        expect(disclosure !== indicator, `XOR ${key}`).toBe(true);
+        // Direction, as everywhere else: the capability decides which one.
+        expect(indicator, `indicator ${key}`).toBe(!!connectClientId);
+        expect(disclosure, `disclosure ${key}`).toBe(!connectClientId);
+        rows++;
+      }
+    }
+    expect(rows).toBe(4);
+  });
+
+  it('🔴 the GRANDFATHERED production listing and an OAuth one, side by side', () => {
+    // The two real shapes, asserted against each other in one place. Production
+    // (measured): `vitrine` is the single approved off-site listing with no OAuth
+    // client; `comfy`, `cosmetic-studio` and `radio` all carry one. Both arms of
+    // this test therefore describe listings that actually exist.
+    const grandfathered = {
+      kind: 'offsite',
+      externalUrl: 'https://vitrine.civitai.com/',
+      connectClientId: null,
+    } as const;
+    const oauth = {
+      kind: 'offsite',
+      externalUrl: 'https://comfy.civitai.com/',
+      connectClientId: 'oauth_comfy',
+    } as const;
+
+    expect(shouldShowOffsiteDisclosure(grandfathered)).toBe(true);
+    expect(shouldShowConnectCapability(grandfathered)).toBe(false);
+
+    expect(shouldShowOffsiteDisclosure(oauth)).toBe(false);
+    expect(shouldShowConnectCapability(oauth)).toBe(true);
+
+    // Stated as the relationship rather than four constants: the two listings
+    // must disagree on BOTH signals, in opposite directions.
+    expect(shouldShowOffsiteDisclosure(grandfathered)).not.toBe(shouldShowOffsiteDisclosure(oauth));
+    expect(shouldShowConnectCapability(grandfathered)).not.toBe(shouldShowConnectCapability(oauth));
   });
 });
 

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -673,15 +673,15 @@ describe('shouldShowOffsiteDisclosure — the "no account access" claim', () => 
   });
 
   it('an empty-string connectClientId does NOT suppress it (truthiness, not nullish)', () => {
-    // Matches `app-listing.service`'s `|| null` projection — so BOTH remaining
-    // readers agree that an empty string is not a connected OAuth app.
+    // Matches `app-listing.service`'s `|| null` projection and
+    // `shouldShowConnectCapability` — so all THREE readers agree that an empty
+    // string is not a connected OAuth app.
     //
-    // 🔴 This used to say "and `getDetailPrimaryAction`'s test, so all three read
-    // the capability the same way". #4208 deleted that reader: the primary action
-    // no longer branches on `connectClientId` at all, so this predicate is the
-    // only place in this module that does. Count the readers, don't restate the
-    // number — the sibling branch that adds `shouldShowConnectCapability` takes
-    // it back up.
+    // 🔴 Count the readers, don't restate the number — it has been wrong in both
+    // directions. It said three when the third was `getDetailPrimaryAction`'s
+    // no-destination fallback; #4208 deleted that read (the CTA no longer touches
+    // the capability, and a region gate now asserts it cannot), and #4207 added
+    // `shouldShowConnectCapability`. Three again, different membership.
     expect(
       shouldShowOffsiteDisclosure({
         kind: 'offsite',
@@ -689,6 +689,15 @@ describe('shouldShowOffsiteDisclosure — the "no account access" claim', () => 
         connectClientId: '',
       })
     ).toBe(true);
+    // The third reader, on the same fixture — pins the AGREEMENT rather than
+    // asserting the disclosure alone and describing the others in prose.
+    expect(
+      shouldShowConnectCapability({
+        kind: 'offsite',
+        externalUrl: 'https://ext.app',
+        connectClientId: '',
+      })
+    ).toBe(false);
   });
 
   /**

--- a/src/components/Apps/appListingDetailView.ts
+++ b/src/components/Apps/appListingDetailView.ts
@@ -292,13 +292,19 @@ function hasOffsitePermissionSignal(
  * domain" are unrepresentable rather than merely untested. See that function.
  *
  * Truthiness on `connectClientId`, matching `app-listing.service`'s `|| null`,
- * so both read the capability the same way.
+ * and `shouldShowConnectCapability` below — so all THREE read the capability the
+ * same way.
  *
- * 🔴 This used to say "and the no-destination fallback above, so all THREE read
- * the capability the same way". #4208 deleted that fallback's `connectClientId`
- * test outright — the primary action no longer reads the capability at all — so
- * there are two readers here, not three. This predicate is now the ONLY place in
- * this module that branches on it.
+ * 🔴 THAT COUNT IS LOAD-BEARING AND IT MOVES — recount it against the tree, never
+ * restate it. It has now been wrong in BOTH directions. It originally read three:
+ * this predicate, the service projection, and `getDetailPrimaryAction`'s
+ * no-destination fallback. #4208 deleted that fallback's `connectClientId` test
+ * outright — the primary action no longer reads the capability at all, and a
+ * region gate in the tests asserts the CTA renderer cannot — taking it to two.
+ * #4207 then added `shouldShowConnectCapability`, bringing it back to three with
+ * DIFFERENT membership. Counted on this tree the three are: this predicate
+ * (`!connectClientId`), `shouldShowConnectCapability` (`!!connectClientId`), and
+ * `app-listing.service`'s `row.connectClientId || null` projection.
  *
  * 🔴 TWO PRODUCERS FEED THIS, and only one is the store read path.
  * `OffsiteReviewQueue`'s `ListingPreviewSection` renders `AppListingDetailBody`

--- a/src/components/Apps/appListingDetailView.ts
+++ b/src/components/Apps/appListingDetailView.ts
@@ -244,6 +244,27 @@ export function getDetailPrimaryAction(
 }
 
 /**
+ * The DOMAIN both permission signals live in: an off-site listing that has
+ * somewhere to run.
+ *
+ * 🔴 This exists so the disclosure and the connect indicator are complements BY
+ * CONSTRUCTION rather than by coincidence. Two independently-written predicates
+ * reading the same field is exactly the shape that drifts — one gets a fix, the
+ * other does not, and the page then either makes both claims at once or neither.
+ * Factoring the shared half out means the only difference between them is the
+ * sense of one negation.
+ *
+ * A listing OUTSIDE this domain (on-site, or off-site with no destination) shows
+ * NEITHER signal, which is correct: an on-site app runs on platform, and there
+ * is no "where it runs" claim to make about a listing with nowhere to run.
+ */
+function hasOffsitePermissionSignal(
+  kindData: ListingDetail['kindData']
+): kindData is Extract<ListingDetail['kindData'], { kind: 'offsite' }> {
+  return kindData.kind === 'offsite' && !!kindData.externalUrl;
+}
+
+/**
  * Does the detail page show the "runs entirely off-platform — no Civitai
  * install, account access, or permissions" disclosure?
  *
@@ -295,27 +316,6 @@ export function getDetailPrimaryAction(
  * empty string is not a connected OAuth app — but it is a real difference, so
  * do not read "identical rendering" as universal across both producers.
  */
-/**
- * The DOMAIN both permission signals live in: an off-site listing that has
- * somewhere to run.
- *
- * 🔴 This exists so the disclosure and the connect indicator are complements BY
- * CONSTRUCTION rather than by coincidence. Two independently-written predicates
- * reading the same field is exactly the shape that drifts — one gets a fix, the
- * other does not, and the page then either makes both claims at once or neither.
- * Factoring the shared half out means the only difference between them is the
- * sense of one negation.
- *
- * A listing OUTSIDE this domain (on-site, or off-site with no destination) shows
- * NEITHER signal, which is correct: an on-site app runs on platform, and there
- * is no "where it runs" claim to make about a listing with nowhere to run.
- */
-function hasOffsitePermissionSignal(
-  kindData: ListingDetail['kindData']
-): kindData is Extract<ListingDetail['kindData'], { kind: 'offsite' }> {
-  return kindData.kind === 'offsite' && !!kindData.externalUrl;
-}
-
 export function shouldShowOffsiteDisclosure(kindData: ListingDetail['kindData']): boolean {
   return hasOffsitePermissionSignal(kindData) && !kindData.connectClientId;
 }

--- a/src/components/Apps/appListingDetailView.ts
+++ b/src/components/Apps/appListingDetailView.ts
@@ -256,12 +256,19 @@ export function getDetailPrimaryAction(
  * listing — was a change no test could catch. Here it is a pure function with
  * its own truth-table tests.
  *
- * Three conjuncts, each load-bearing:
+ * Three conjuncts, each load-bearing — now expressed as a shared DOMAIN
+ * (`hasOffsitePermissionSignal`: offsite + a destination) plus the capability
+ * term:
  *   - `offsite` — an on-site app runs ON platform, so the sentence is simply
  *     wrong about it;
- *   - no `connectClientId` — the capability check; see above;
  *   - a non-null `externalUrl` — there is no "runs off-platform" claim to make
- *     about a listing with nowhere to run.
+ *     about a listing with nowhere to run;
+ *   - no `connectClientId` — the capability check; see above.
+ *
+ * 🔴 The domain is factored out so this predicate and its positive counterpart
+ * `shouldShowConnectCapability` CANNOT DRIFT APART. They differ by exactly one
+ * negation, over one shared domain, so "both shown" and "both hidden inside the
+ * domain" are unrepresentable rather than merely untested. See that function.
  *
  * Truthiness on `connectClientId`, matching `app-listing.service`'s `|| null`,
  * so both read the capability the same way.
@@ -288,6 +295,65 @@ export function getDetailPrimaryAction(
  * empty string is not a connected OAuth app — but it is a real difference, so
  * do not read "identical rendering" as universal across both producers.
  */
+/**
+ * The DOMAIN both permission signals live in: an off-site listing that has
+ * somewhere to run.
+ *
+ * 🔴 This exists so the disclosure and the connect indicator are complements BY
+ * CONSTRUCTION rather than by coincidence. Two independently-written predicates
+ * reading the same field is exactly the shape that drifts — one gets a fix, the
+ * other does not, and the page then either makes both claims at once or neither.
+ * Factoring the shared half out means the only difference between them is the
+ * sense of one negation.
+ *
+ * A listing OUTSIDE this domain (on-site, or off-site with no destination) shows
+ * NEITHER signal, which is correct: an on-site app runs on platform, and there
+ * is no "where it runs" claim to make about a listing with nowhere to run.
+ */
+function hasOffsitePermissionSignal(
+  kindData: ListingDetail['kindData']
+): kindData is Extract<ListingDetail['kindData'], { kind: 'offsite' }> {
+  return kindData.kind === 'offsite' && !!kindData.externalUrl;
+}
+
 export function shouldShowOffsiteDisclosure(kindData: ListingDetail['kindData']): boolean {
-  return kindData.kind === 'offsite' && !kindData.connectClientId && !!kindData.externalUrl;
+  return hasOffsitePermissionSignal(kindData) && !kindData.connectClientId;
+}
+
+/**
+ * Does the detail page show the POSITIVE "this app can connect to your Civitai
+ * account" indicator?
+ *
+ * 🔴 A CAPABILITY, NOT A KIND. #4200 deleted the off-site sub-kind because a
+ * parent category and one of its children were sharing a word; this does not
+ * bring that back. There is one off-site kind, one badge, one CTA path. What
+ * this adds is a PROPERTY of a listing — it has an OAuth client, so it can ask
+ * for access to your account — surfaced on the page body next to the
+ * disclosure. Nothing here forks the taxonomy, the kind label, or the action.
+ * If a future change makes this select a different badge or a different CTA,
+ * that is the sub-kind returning under a new name; don't.
+ *
+ * WHY IT EXISTS (#4207). "This app can connect to your Civitai account" is a
+ * permission-relevant fact, and until now it was communicated ONLY by the
+ * ABSENCE of the off-platform disclosure. A user had to notice that a sentence
+ * they had never seen was missing. That is the weakest possible form of a
+ * permission signal, and it is invisible to anyone who has not seen the other
+ * variant for comparison.
+ *
+ * 🔴 THE EXACT COMPLEMENT of `shouldShowOffsiteDisclosure` over the shared
+ * domain — same truthiness test on `connectClientId`, opposite sense. So for any
+ * listing in the domain EXACTLY ONE of the two renders, and outside it neither
+ * does. That relationship is the thing worth pinning, and it is pinned as a
+ * relationship (one test, both states) rather than as two isolated assertions —
+ * testing them separately is precisely how a contradiction between them would be
+ * missed.
+ *
+ * Truthiness, not `!= null`, matching the disclosure, `app-listing.service`'s
+ * `|| null`, and the no-destination fallback — so every reader of this field
+ * agrees. At `connectClientId === ''` this is false and the disclosure is true:
+ * an empty string is not a connected OAuth app, and that is the safe direction
+ * (we under-claim the capability rather than over-claim it).
+ */
+export function shouldShowConnectCapability(kindData: ListingDetail['kindData']): boolean {
+  return hasOffsitePermissionSignal(kindData) && !!kindData.connectClientId;
 }


### PR DESCRIPTION
Closes #4207.

## What

There was no positive signal that a listing can connect to your Civitai account. The only signal was **inverted** — an OAuth-connected app was indicated by the *absence* of the off-platform disclosure. A user had to notice that a sentence they had never seen was missing.

This adds the positive half. Option **1** from the issue.

| listing | before | after |
|---|---|---|
| no OAuth (grandfathered) | disclosure shown | disclosure shown *(unchanged)* |
| **has OAuth** | **nothing** | **indicator shown** |

## Copy

> "This app runs off-platform, but can connect to your Civitai account — you'll be asked to sign in and approve access."

Two deliberate choices:

- It **mirrors the disclosure's structure** ("runs off-platform") so the two read as one statement with two sides, rather than as unrelated notices.
- It **stops at what is verifiable**: that connecting requires sign-in and consent. It makes no claim about *which* scopes are requested — those are per-listing and surfaced by `ConnectScopesPanel`. The disclosure is a security claim that was once wrong about OAuth listings; over-claiming on the positive side is the same defect mirrored, so the copy stays descriptive rather than promising a guarantee.

Icon is `IconPlugConnected` (the established connect glyph in this codebase) so the two Alerts are distinguishable at a glance; both stay `variant="light" color="blue"` — this is a capability, not a warning.

## 🔴 A capability, not a kind

#4200 deleted the off-site sub-kind because a parent category and one of its children were sharing a word. **This does not bring it back.** There is still one off-site kind, one badge, one CTA path. What is added is a *property* of a listing that selects a **sentence in the page body** — never a badge, a kind label, or an action. If a future change makes this select a different badge or CTA, that is the sub-kind returning under a new name.

## The relationship is structural, not conventional

Both signals are now expressed over one shared domain and differ by **exactly one negation**:

```ts
function hasOffsitePermissionSignal(kd) {        // offsite + a destination
  return kd.kind === 'offsite' && !!kd.externalUrl;
}
shouldShowOffsiteDisclosure = (kd) => hasOffsitePermissionSignal(kd) && !kd.connectClientId;
shouldShowConnectCapability = (kd) => hasOffsitePermissionSignal(kd) && !!kd.connectClientId;
```

So "both shown", and "both hidden inside the domain", are **unrepresentable** rather than merely untested. Two independently-written predicates reading the same field is exactly the shape that drifts — one gets a fix, the other does not, and the page then makes both claims at once.

Pinned as a **relationship in one test over both states**, because the failure that matters is the two *disagreeing*, and testing them in isolation is how that would be missed.

### 🔴 XOR alone is not enough

Swapping the two predicates **preserves XOR perfectly** while labelling every OAuth app "no account access" — the worst possible inversion of a security claim. So the test also pins *which* signal shows for *which* state.

That is demonstrated rather than argued: under the swap mutant the XOR assertion **passes**, and the direction assertion is what fails.

## Tests

Red→green, node `unit` project. All are **new-behaviour guards** (they pin behaviour this PR introduces), labelled as such in the source rather than counted as regression coverage. 4 fail at base because the predicate does not exist; 1 on the renderer structural gate.

| test | at base | at HEAD |
|---|---|---|
| for a listing with a destination, EXACTLY ONE renders — and it is the right one | **RED** | GREEN |
| outside the domain, NEITHER renders | **RED** | GREEN |
| a non-https destination stays INSIDE the domain, and the two still XOR | **RED** | GREEN |
| the grandfathered production listing and an OAuth one, side by side | **RED** | GREEN |
| the renderer calls the predicate and does not re-derive it | **RED** | GREEN |

Plus a render-layer relationship test in the browser suite asserting both states in one test.

### Mutation results

Each mutant verified to have actually landed (grepped post-edit), each dying on **its own** assertion:

| mutant | verdict | killing assertion |
|---|---|---|
| M-A invert the indicator's condition | KILLED | `XOR url=https://ext.app client=oauth_abc: expected false to be true` |
| M-B drop the indicator render | KILLED | structural gate: `expected source to match /shouldShowConnectCapability\(detail\.…/` |
| M-C swap it with the disclosure's | KILLED | `disclosure url=https://ext.app client=oauth_abc: expected true to be false` — **XOR passed** |

Fixtures carry pairwise-distinct, non-default values (two destinations × two truthy client ids × three falsy shapes), with explicit anti-vacuity counts so the loops cannot pass by running zero times or by exercising only one arm.

## One pre-existing nuance, found and deliberately NOT changed

The tests surfaced that the domain is **truthiness** on `externalUrl`, not an https check — so a listing with an `http://` URL is *inside* it and shows a permission sentence. The indicator **mirrors** that rather than narrowing it: tightening the domain to https would silently change when an existing **security claim** is displayed, which is a behaviour change #4207 did not ask for.

**Scope, corrected after audit:** these cells are **not reachable from the public store**. `app-listing.service` applies `safeExternalUrl()` (https-only) to both projections (`:255` card, `:315` detail), so a non-https column arrives as `null`; the submit path validates https whenever a URL is present. The only producer that can deliver them is the moderator review preview (`reviewListingPreview.ts:98`, raw passthrough), and only for a legacy row already holding one. An earlier revision stated the divergence unconditionally, which over-warned — it read as though a public listing could show an off-platform sentence with nowhere to go. It cannot.

⚠️ On that moderator-preview path the predicates and the CTA do disagree (the CTA's `safeExternalHref` treats a non-https URL as *no* destination). Predates both #4207 and #4200. Say the word if you want it closed separately.

## Verification

- `pnpm typecheck` — **0 type errors**.
- `vitest --project 'unit*' src/components/Apps src/server/services/blocks` — **197 files / 4498 tests green**.
- eslint — **4 files linted, 0 errors** (counted via `-f json`; a clean run and a zero-file run are otherwise indistinguishable).
- prettier — clean.

Not verified: the browser-mode relationship test is written but that project is report-only in this repo and is not part of any merge gate, so it has not been executed here. The unit-tier relationship test covers the same invariant at the predicate layer and does run.

**Rebased onto `main` after #4215 merged** (squash `ac9819ed9c`). The two PRs touched the same files, so this needed a rebase, not a stack — conflicts were in `appListingDetailView.ts` and its test, both on the capability-reader count, which is exactly the claim #4215 also changed.

🔴 **The reader count was recounted against the rebased tree, not carried over.** This PR previously said *four*; #4215 removed `getDetailPrimaryAction`'s read of `connectClientId` entirely, so the count is now **three** — with different membership than the original three. Enumerated on the rebased tree:

| # | reader | test |
|---|---|---|
| 1 | `shouldShowOffsiteDisclosure` (`appListingDetailView.ts:326`) | `!connectClientId` |
| 2 | `shouldShowConnectCapability` (`:364`) | `!!connectClientId` |
| 3 | `app-listing.service.ts:325` | `row.connectClientId \|\| null` |

`getDetailPrimaryAction` is absent from that list — #4215's region gate now asserts the CTA renderer *cannot* read it.

Both the source docstring and the test now say three, name the three, and record that the number has been wrong in **both** directions — so the standing instruction is *recount against the tree, never restate*.

Post-rebase verification: `src/components/Apps` + `src/server/services/blocks` — **197 files / 4502 tests green**; `typecheck` 0 errors; prettier clean; eslint 3 files, 0 errors. The swap mutant was re-run against #4215's merged code and is still killed on the **direction** assertion (`disclosure url=https://ext.app client=oauth_abc: expected true to be false`) while the XOR assertion passes — the security-claim protection survived the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

