### PR TITLE
fix(apps): restore the Unpublish/Republish pair #4154 dropped from /apps/mine, + an author-action ledger

### DIFF
--- a/src/components/Apps/MyAppsBody.authorActions.browser.test.tsx
+++ b/src/components/Apps/MyAppsBody.authorActions.browser.test.tsx
@@ -67,11 +67,23 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true, appBlocksAuthor: true }),
 }));
 
-/** One mutation stub that RECORDS which procedure it belongs to — see `the wiring` below. */
+/**
+ * One mutation stub that RECORDS which procedure it belongs to — see `the wiring` below.
+ *
+ * 🔴 IT INVOKES THE CALLER'S `onSuccess`, and that is load-bearing rather than realism for its
+ * own sake. `OwnerUnpublishModal` closes itself and calls `onDone` from inside `onSuccess`, so
+ * a stub that only recorded the call would leave every post-success behaviour (the Inactive
+ * section opening, the row list invalidating, the modal closing) permanently unexercised — and
+ * a test asserting them would pass or fail on nothing at all.
+ */
+type MutationOpts = { onSuccess?: (data: unknown) => unknown; onError?: (e: unknown) => unknown };
 function mutationStub(name: string, isPending = false) {
   return {
-    useMutation: () => ({
-      mutate: (input: unknown) => mocks.calls.push([name, input]),
+    useMutation: (opts?: MutationOpts) => ({
+      mutate: (input: unknown) => {
+        mocks.calls.push([name, input]);
+        void opts?.onSuccess?.(undefined);
+      },
       isPending,
     }),
   };
@@ -125,9 +137,11 @@ const { MyAppsBody, rowActionsTestId } = await import('./MyAppsBody');
 /**
  * Fixtures are pairwise distinct on every dimension an assertion names — id, slug, name,
  * status, kind and last moderation action — and none of them can produce an expected value by
- * coincidence. In particular no two rows share a `lastModerationAction`, and `'delist'` is a
- * real moderator action rather than a placeholder, so a mutant that compares against the wrong
- * literal cannot survive on a fixture that could only ever have yielded it.
+ * coincidence. In particular no two rows share a `lastModerationAction`. The mod-removed
+ * fixture uses `'other'` because that is what the SERVER now sends — the projection normalises
+ * every non-owner verb to one value so a seated editor never receives the moderator's actual
+ * action. That a RAW verb (`delist`/`purge`/`claim`/…) still routes to the same state is pinned
+ * in the blocking `unit` tier, not here.
  */
 function row(over: Partial<MyAppRow> & { appListingId: string }): MyAppRow {
   const kind = over.kind ?? 'onsite';
@@ -158,7 +172,7 @@ const OWNER_HIDDEN = row({
 const MOD_REMOVED = row({
   appListingId: 'apl_modgone_r3',
   status: 'removed',
-  lastModerationAction: 'delist',
+  lastModerationAction: 'other',
 });
 const INACTIVE_DRAFT = row({ appListingId: 'apl_draft_k4', status: 'draft' });
 const SEAT_LIVE = row({ appListingId: 'apl_seat_m5', status: 'approved', role: 'editor' });
@@ -382,6 +396,36 @@ describe('the wiring — each control fires the right procedure with the right i
    * wording is present AND that the other kind's wording is not, so neither passes by a
    * variant that renders both strings.
    */
+  test('🔴 a successful unpublish OPENS the Inactive section the row is about to move into', async () => {
+    /**
+     * The row leaves the viewport at the exact moment the author acts: `partitionMyAppRows`
+     * files every `removed` listing under Inactive, which is collapsed by default, so without
+     * this the app AND its Republish button vanish while a success toast says it worked.
+     *
+     * Driven through the real confirm flow rather than by poking the prop, because the whole
+     * claim is "on SUCCESS" — `OwnerUnpublishModal` calls `onDone` from its mutation's
+     * `onSuccess`, and this test is what pins that wiring rather than the effect in isolation.
+     */
+    // A second, already-removed row so the Inactive section exists and has something in it.
+    mocks.rows = [LIVE_ONSITE, MOD_REMOVED];
+    renderWithProviders(<MyAppsBody />);
+
+    // Closed to begin with — the control reports its own state, so this is the negative arm.
+    const panelToggle = page.getByTestId('apps-mine-inactive-toggle');
+    await expect.element(panelToggle).toBeInTheDocument();
+    expect(panelToggle.element().getAttribute('aria-expanded')).toBe('false');
+
+    await userEvent.click(page.getByTestId(`apps-mine-unpublish-${LIVE_ONSITE.appListingId}`));
+    await userEvent.click(page.getByTestId('apps-mine-unpublish-confirm'));
+
+    // …and open afterwards. `aria-expanded` is read from the same boolean the panel renders
+    // from, so it cannot report a state the DOM does not have.
+    await expect.element(panelToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(mocks.calls).toEqual([
+      ['unpublishOwnListing', { appListingId: 'apl_live_on', reason: undefined }],
+    ]);
+  });
+
   test('an ON-SITE unpublish warns that the app goes OFFLINE', async () => {
     mocks.rows = [LIVE_ONSITE];
     renderWithProviders(<MyAppsBody />);

--- a/src/components/Apps/MyAppsBody.authorActions.browser.test.tsx
+++ b/src/components/Apps/MyAppsBody.authorActions.browser.test.tsx
@@ -1,0 +1,400 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as MantineHooks from '@mantine/hooks';
+import type { MyAppRow } from '~/components/Apps/myAppsView';
+import type * as TrpcModule from '~/utils/trpc';
+import { capabilitiesForKind } from '~/shared/constants/app-capabilities.constants';
+import {
+  EDITOR_ACTIONS,
+  OWNER_ACTIONS_BY_STATE,
+  sortAuthorActions,
+} from '~/components/Apps/myAppsAuthorActions';
+
+/**
+ * THE AUTHOR-ACTION LEDGER for `/apps/mine`, and the restored Unpublish / Republish pair.
+ *
+ * 🔴 WHY THIS FILE EXISTS, AND WHY IT IS NOT JUST "TESTS FOR THE FIX". PR #4154 consolidated
+ * `/apps/my-submissions` into `/apps/mine`. `MySubmissionsList` — the only surface carrying
+ * the owner Unpublish/Republish controls — was orphaned by that merge, and the new page body
+ * contained zero occurrences of `unpublish`. The gap was DISCLOSED in the implementing PR and
+ * recorded as a noted omission rather than as a functional regression, and then THREE audit
+ * rounds passed over it. Each round asked "is the new page correct?"; none asked "is it
+ * COMPLETE?" — and no per-assertion suite can answer the second question, because a control
+ * that is simply absent has nothing to assert against. A tester found it instead.
+ *
+ * So the instrument here is a LEDGER, not another assertion:
+ *
+ *   `renderedActions()` enumerates EVERY interactive control inside a row's action container
+ *   and compares the resulting SET against `OWNER_ACTIONS_BY_STATE` / `EDITOR_ACTIONS`. It
+ *   fails when the set SHRINKS (a control was dropped — the #4154 shape) and when it GROWS
+ *   (a control was added without being declared). It additionally REFUSES a control that
+ *   carries no `data-author-action`, so "grew" cannot be evaded by omitting the attribute.
+ *
+ * 🔴 THE LEDGER ALONE IS NOT ENOUGH, and the second half is deliberate. A structural set
+ * comparison type-checks straight past a button wired to the wrong procedure, or to none —
+ * both of which render an identical DOM. `describe('the wiring')` therefore drives each
+ * control for real and asserts the exact procedure and the exact input.
+ *
+ * 🔴 RED-AT-BASE, STATED PRECISELY AND MEASURED. Against a tree whose `RowActions` renders
+ * only the History toggle — which is exactly what `origin/main`'s `MyAppsBody` offers an
+ * author — this file is **8 failed / 3 passed**, and the two distinct assertion messages are
+ * `expected [ 'history' ] to deeply equal [ 'unpublish', 'history' ]` and
+ * `… to deeply equal [ 'republish', 'history' ]`. That is a BEHAVIOURAL red on the ledger's
+ * own assertions. It is stated that way rather than as "checked out `origin/main`" because a
+ * literal checkout of the base component fails on a missing export instead, which would be a
+ * much weaker claim. The three that still pass are the mod-removed, draft and collaborator
+ * cases — correctly, since `['history']` is their right answer either way.
+ *
+ * The `sortAuthorActions` / vocabulary guards in `__tests__/myAppsAuthorActions.test.ts` are
+ * NEW-BEHAVIOUR guards and are labelled as such there — nothing on `main` could have violated
+ * them.
+ *
+ * 🔴 WHAT IS MOCK-SHADOWED. The data layer entirely. The `component` project loads no CSS, so
+ * nothing here is a claim about layout — only about which controls exist and what they call.
+ */
+
+const mocks = vi.hoisted(() => ({
+  rows: [] as unknown[],
+  /** `[procedureName, input]` for every mutation fired, in order. */
+  calls: [] as Array<[string, unknown]>,
+  republishPending: false,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksAuthor: true }),
+}));
+
+/** One mutation stub that RECORDS which procedure it belongs to — see `the wiring` below. */
+function mutationStub(name: string, isPending = false) {
+  return {
+    useMutation: () => ({
+      mutate: (input: unknown) => mocks.calls.push([name, input]),
+      isPending,
+    }),
+  };
+}
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    useUtils: () => ({
+      appListings: {
+        listingHistory: { invalidate: vi.fn() },
+        listMine: { invalidate: vi.fn() },
+        listMyOrphanedSubmissions: { invalidate: vi.fn() },
+      },
+    }),
+    appListings: {
+      listMine: { useQuery: () => ({ data: mocks.rows, isLoading: false, error: null }) },
+      listingHistory: { useQuery: () => ({ data: [], isLoading: false, error: null }) },
+      listMyOrphanedSubmissions: {
+        useQuery: () => ({ data: [], isLoading: false, error: null }),
+      },
+      withdrawExternalRequest: mutationStub('withdrawExternalRequest'),
+      // 🔴 The two procedures under test are stubbed with DISTINCT recorded names, so an
+      // assertion cannot pass by hitting the wrong one. `unpublishOwnListing` is consumed
+      // inside `OwnerUnpublishModal`, which is why the confirm click has to be driven for
+      // real rather than the mutation called directly.
+      unpublishOwnListing: mutationStub('unpublishOwnListing'),
+      get republishOwnListing() {
+        return mutationStub('republishOwnListing', mocks.republishPending);
+      },
+      listMyListingModerationEvents: {
+        useQuery: () => ({ data: { items: [] }, isLoading: false, error: null }),
+      },
+    },
+    blocks: { withdrawPublishRequest: mutationStub('withdrawPublishRequest') },
+  },
+}));
+
+vi.mock('@mantine/hooks', async (importOriginal) => ({
+  ...(await importOriginal<typeof MantineHooks>()),
+  useMediaQuery: () => false,
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showErrorNotification: vi.fn(),
+  showSuccessNotification: vi.fn(),
+}));
+
+const { MyAppsBody, rowActionsTestId } = await import('./MyAppsBody');
+
+/**
+ * Fixtures are pairwise distinct on every dimension an assertion names — id, slug, name,
+ * status, kind and last moderation action — and none of them can produce an expected value by
+ * coincidence. In particular no two rows share a `lastModerationAction`, and `'delist'` is a
+ * real moderator action rather than a placeholder, so a mutant that compares against the wrong
+ * literal cannot survive on a fixture that could only ever have yielded it.
+ */
+function row(over: Partial<MyAppRow> & { appListingId: string }): MyAppRow {
+  const kind = over.kind ?? 'onsite';
+  return {
+    slug: `slug-${over.appListingId}`,
+    name: `Name ${over.appListingId}`,
+    status: 'approved',
+    kind,
+    appBlockId: kind === 'onsite' ? `ab-${over.appListingId}` : null,
+    role: 'owner',
+    capabilities: capabilitiesForKind(kind),
+    iconUrl: null,
+    coverUrl: null,
+    lastModerationAction: null,
+    updatedAt: '2026-08-01T00:00:00Z',
+    ...over,
+    ...(over.capabilities ? {} : { capabilities: capabilitiesForKind(over.kind ?? kind) }),
+  };
+}
+
+const LIVE_ONSITE = row({ appListingId: 'apl_live_on', kind: 'onsite', status: 'approved' });
+const LIVE_OFFSITE = row({ appListingId: 'apl_live_off', kind: 'offsite', status: 'approved' });
+const OWNER_HIDDEN = row({
+  appListingId: 'apl_hidden_q2',
+  status: 'removed',
+  lastModerationAction: 'owner-unpublish',
+});
+const MOD_REMOVED = row({
+  appListingId: 'apl_modgone_r3',
+  status: 'removed',
+  lastModerationAction: 'delist',
+});
+const INACTIVE_DRAFT = row({ appListingId: 'apl_draft_k4', status: 'draft' });
+const SEAT_LIVE = row({ appListingId: 'apl_seat_m5', status: 'approved', role: 'editor' });
+
+/**
+ * Every interactive control in a row's action container, as declared action ids.
+ *
+ * 🔴 IT ENUMERATES `button`/`a[href]` AND *THEN* READS THE ATTRIBUTE, in that order. Selecting
+ * on `[data-author-action]` directly would make the growth arm inert: a control added without
+ * the attribute would simply not be selected, the sets would still match, and the ledger would
+ * report clean over a page that had grown a new affordance nobody registered. Throwing on an
+ * undeclared control is what closes that.
+ */
+function renderedActions(appListingId: string): string[] {
+  const container = page.getByTestId(rowActionsTestId(appListingId)).element();
+  const controls = [...container.querySelectorAll('button, a[href]')];
+  const undeclared = controls.filter((c) => !c.getAttribute('data-author-action'));
+  if (undeclared.length > 0) {
+    throw new Error(
+      `${undeclared.length} control(s) in ${rowActionsTestId(appListingId)} carry no ` +
+        `data-author-action and are therefore invisible to the ledger: ` +
+        undeclared.map((c) => `<${c.tagName.toLowerCase()}>${c.textContent ?? ''}`).join(', ')
+    );
+  }
+  return sortAuthorActions(controls.map((c) => c.getAttribute('data-author-action') as string));
+}
+
+/**
+ * A `removed` listing lives in the default-collapsed **Inactive** group, so its Republish
+ * control is one disclosure click away rather than on the front of the table. Opening it here
+ * rather than hiding the fact in a helper: the reachability cost is real and is called out in
+ * the PR body as a follow-up, not silently absorbed.
+ */
+async function openInactive() {
+  const toggle = page.getByTestId('apps-mine-inactive-toggle');
+  await expect.element(toggle).toBeInTheDocument();
+  await userEvent.click(toggle);
+}
+
+beforeEach(() => {
+  mocks.rows = [];
+  mocks.calls = [];
+  mocks.republishPending = false;
+});
+
+describe('the ledger — the SET of author controls a row offers, per state', () => {
+  test('a LIVE (approved) listing offers exactly Unpublish + History', async () => {
+    mocks.rows = [LIVE_ONSITE];
+    renderWithProviders(<MyAppsBody />);
+    await expect
+      .element(page.getByTestId(`apps-mine-row-${LIVE_ONSITE.appListingId}`))
+      .toBeInTheDocument();
+
+    // 🔴 SET EQUALITY, not `toContain`. `toContain('unpublish')` would pass with Republish
+    // wrongly rendered beside it, and would pass with three more controls added silently.
+    expect(renderedActions(LIVE_ONSITE.appListingId)).toEqual(
+      sortAuthorActions(OWNER_ACTIONS_BY_STATE.live)
+    );
+    // The literal, restated independently of the table — a mutant that empties
+    // `OWNER_ACTIONS_BY_STATE.live` would otherwise make the assertion above trivially true.
+    expect(renderedActions(LIVE_ONSITE.appListingId)).toEqual(['unpublish', 'history']);
+  });
+
+  test('an OWNER-UNPUBLISHED listing offers exactly Republish + History, and says "unpublished"', async () => {
+    mocks.rows = [OWNER_HIDDEN];
+    renderWithProviders(<MyAppsBody />);
+    await openInactive();
+    await expect
+      .element(page.getByTestId(`apps-mine-inactive-row-${OWNER_HIDDEN.appListingId}`))
+      .toBeInTheDocument();
+
+    expect(renderedActions(OWNER_HIDDEN.appListingId)).toEqual(
+      sortAuthorActions(OWNER_ACTIONS_BY_STATE['owner-hidden'])
+    );
+    expect(renderedActions(OWNER_HIDDEN.appListingId)).toEqual(['republish', 'history']);
+
+    // 🔴 THE BADGE IS PART OF THE AFFORDANCE. `status` reads `removed` for this row and for a
+    // moderator takedown alike; the badge is what tells the author which one happened, and
+    // therefore why one of them has a button and the other does not.
+    await expect
+      .element(page.getByTestId(`apps-mine-status-${OWNER_HIDDEN.appListingId}`))
+      .toHaveTextContent('unpublished');
+
+    // 🔴 `.query()` — NOT `expect.element(...).not.toBeInTheDocument()`, which is INERT in
+    // this repo (issue #4197: it never fails, for any string). Placed AFTER the awaits above
+    // so the render has settled; `.query()` is a point-in-time read.
+    expect(page.getByTestId(`apps-mine-unpublish-${OWNER_HIDDEN.appListingId}`).query()).toBeNull();
+    expect(
+      page.getByTestId(`apps-mine-mod-removed-${OWNER_HIDDEN.appListingId}`).query()
+    ).toBeNull();
+  });
+
+  test('a MODERATOR-REMOVED listing offers NEITHER control, and says why', async () => {
+    mocks.rows = [MOD_REMOVED];
+    renderWithProviders(<MyAppsBody />);
+    await openInactive();
+    await expect
+      .element(page.getByTestId(`apps-mine-inactive-row-${MOD_REMOVED.appListingId}`))
+      .toBeInTheDocument();
+
+    expect(renderedActions(MOD_REMOVED.appListingId)).toEqual(
+      sortAuthorActions(OWNER_ACTIONS_BY_STATE['mod-removed'])
+    );
+    expect(renderedActions(MOD_REMOVED.appListingId)).toEqual(['history']);
+
+    // 🔴 THE LOAD-BEARING ABSENCE. `republishOwnListing` refuses a listing whose last event is
+    // a moderator action — "This listing was removed by a moderator and cannot be restored by
+    // its owner." A Republish button here could only ever fail.
+    expect(page.getByTestId(`apps-mine-republish-${MOD_REMOVED.appListingId}`).query()).toBeNull();
+    expect(page.getByTestId(`apps-mine-unpublish-${MOD_REMOVED.appListingId}`).query()).toBeNull();
+
+    // 🔴 THE POSITIVE CONTROL FOR THOSE TWO NULLS. Two `.query()` calls returning null are
+    // indistinguishable from a probe wired to nothing — a wrong test-id prefix, a row that
+    // never rendered — so something that IS on screen has to be found by the same mechanism.
+    expect(
+      page.getByTestId(`apps-mine-mod-removed-${MOD_REMOVED.appListingId}`).query()
+    ).not.toBeNull();
+    await expect
+      .element(page.getByTestId(`apps-mine-status-${MOD_REMOVED.appListingId}`))
+      .toHaveTextContent('removed by a moderator');
+  });
+
+  test('a never-approved (draft) listing offers History only', async () => {
+    mocks.rows = [INACTIVE_DRAFT];
+    renderWithProviders(<MyAppsBody />);
+    await expect
+      .element(page.getByTestId(`apps-mine-row-${INACTIVE_DRAFT.appListingId}`))
+      .toBeInTheDocument();
+
+    expect(renderedActions(INACTIVE_DRAFT.appListingId)).toEqual(
+      sortAuthorActions(OWNER_ACTIONS_BY_STATE.inactive)
+    );
+    expect(
+      page.getByTestId(`apps-mine-unpublish-${INACTIVE_DRAFT.appListingId}`).query()
+    ).toBeNull();
+  });
+
+  test('a seated COLLABORATOR gets History only on a LIVE app — a seat is not ownership', async () => {
+    mocks.rows = [SEAT_LIVE];
+    renderWithProviders(<MyAppsBody />);
+    await expect
+      .element(page.getByTestId(`apps-mine-row-${SEAT_LIVE.appListingId}`))
+      .toBeInTheDocument();
+
+    // Same status as LIVE_ONSITE, different role — so this case isolates the ROLE branch.
+    expect(renderedActions(SEAT_LIVE.appListingId)).toEqual(sortAuthorActions(EDITOR_ACTIONS));
+    expect(page.getByTestId(`apps-mine-unpublish-${SEAT_LIVE.appListingId}`).query()).toBeNull();
+  });
+
+  test('every state at once — each row keeps its OWN set', async () => {
+    // 🔴 The states are rendered TOGETHER because a per-row derivation that had collapsed into
+    // a page-level one would still pass all five single-row cases above. Here it cannot: no
+    // single set satisfies four rows at the same time.
+    mocks.rows = [LIVE_ONSITE, INACTIVE_DRAFT, OWNER_HIDDEN, MOD_REMOVED];
+    renderWithProviders(<MyAppsBody />);
+    await openInactive();
+    await expect
+      .element(page.getByTestId(`apps-mine-inactive-row-${MOD_REMOVED.appListingId}`))
+      .toBeInTheDocument();
+
+    expect(renderedActions(LIVE_ONSITE.appListingId)).toEqual(['unpublish', 'history']);
+    expect(renderedActions(INACTIVE_DRAFT.appListingId)).toEqual(['history']);
+    expect(renderedActions(OWNER_HIDDEN.appListingId)).toEqual(['republish', 'history']);
+    expect(renderedActions(MOD_REMOVED.appListingId)).toEqual(['history']);
+  });
+});
+
+describe('the wiring — each control fires the right procedure with the right input', () => {
+  test('Unpublish is CONFIRM-GATED, then calls unpublishOwnListing with the listing id', async () => {
+    mocks.rows = [LIVE_ONSITE];
+    renderWithProviders(<MyAppsBody />);
+    const button = page.getByTestId(`apps-mine-unpublish-${LIVE_ONSITE.appListingId}`);
+    await expect.element(button).toBeInTheDocument();
+
+    // 🔴 NOTHING FIRES ON THE FIRST CLICK. An unpublish takes a live app off the store (and,
+    // on-site, offline); a control that did it on one click would be a different defect from
+    // the one being fixed, not a smaller one.
+    await userEvent.click(button);
+    expect(mocks.calls).toEqual([]);
+
+    const confirm = page.getByTestId('apps-mine-unpublish-confirm');
+    await expect.element(confirm).toBeInTheDocument();
+    await userEvent.click(confirm);
+
+    // The WHOLE call list, so a stray call to any other procedure fails here.
+    expect(mocks.calls).toEqual([
+      ['unpublishOwnListing', { appListingId: 'apl_live_on', reason: undefined }],
+    ]);
+  });
+
+  test('Republish calls republishOwnListing with the listing id, and needs no confirmation', async () => {
+    mocks.rows = [OWNER_HIDDEN];
+    renderWithProviders(<MyAppsBody />);
+    await openInactive();
+    const button = page.getByTestId(`apps-mine-republish-${OWNER_HIDDEN.appListingId}`);
+    await expect.element(button).toBeInTheDocument();
+    await userEvent.click(button);
+
+    // 🔴 A DIFFERENT ID FROM THE UNPUBLISH CASE, so a mutant that hardcodes either literal
+    // fails in one of the two tests. Republish is not confirm-gated on purpose: it restores
+    // the previous state, so the recovery from a misclick is the button next to it.
+    expect(mocks.calls).toEqual([['republishOwnListing', { appListingId: 'apl_hidden_q2' }]]);
+  });
+
+  test('a republish in flight DISABLES the button rather than allowing a second fire', async () => {
+    mocks.rows = [OWNER_HIDDEN];
+    mocks.republishPending = true;
+    renderWithProviders(<MyAppsBody />);
+    await openInactive();
+    const button = page.getByTestId(`apps-mine-republish-${OWNER_HIDDEN.appListingId}`);
+    await expect.element(button).toBeInTheDocument();
+    expect(button.element().hasAttribute('disabled')).toBe(true);
+  });
+
+  /**
+   * 🔴 THE DUAL-KIND TRAP, split into two tests rather than one with an unmount.
+   * `/apps/my-submissions` was TWO lists, each passing a FIXED copy variant; `/apps/mine`
+   * merges both kinds into one table. A fixed variant here would tell half of all authors
+   * something untrue about what the button is about to do — an on-site unpublish takes the
+   * app OFFLINE, an off-site one only delists it from the store. Each test asserts its own
+   * wording is present AND that the other kind's wording is not, so neither passes by a
+   * variant that renders both strings.
+   */
+  test('an ON-SITE unpublish warns that the app goes OFFLINE', async () => {
+    mocks.rows = [LIVE_ONSITE];
+    renderWithProviders(<MyAppsBody />);
+    await userEvent.click(page.getByTestId(`apps-mine-unpublish-${LIVE_ONSITE.appListingId}`));
+    await expect.element(page.getByText(/takes your app OFFLINE/i)).toBeInTheDocument();
+    expect(page.getByText(/hides your live app from the store/i).query()).toBeNull();
+  });
+
+  test('an OFF-SITE unpublish warns only about the STORE listing', async () => {
+    mocks.rows = [LIVE_OFFSITE];
+    renderWithProviders(<MyAppsBody />);
+    await userEvent.click(page.getByTestId(`apps-mine-unpublish-${LIVE_OFFSITE.appListingId}`));
+    await expect.element(page.getByText(/hides your live app from the store/i)).toBeInTheDocument();
+    expect(page.getByText(/takes your app OFFLINE/i).query()).toBeNull();
+  });
+});

--- a/src/components/Apps/MyAppsBody.browser.test.tsx
+++ b/src/components/Apps/MyAppsBody.browser.test.tsx
@@ -75,6 +75,16 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
         }),
       },
       withdrawExternalRequest: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      // The restored owner takedown pair. Present here so the CONTAINER block below mounts
+      // at all — the mutation hooks run unconditionally on render, so an absent entry is a
+      // `Cannot read properties of undefined` at mount, not a missing assertion. What these
+      // two procedures are actually CALLED WITH is asserted in
+      // `MyAppsBody.authorActions.browser.test.tsx`, which owns the ledger.
+      republishOwnListing: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      unpublishOwnListing: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      listMyListingModerationEvents: {
+        useQuery: () => ({ data: { items: [] }, isLoading: false, error: null }),
+      },
     },
     blocks: {
       withdrawPublishRequest: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },

--- a/src/components/Apps/MyAppsBody.tsx
+++ b/src/components/Apps/MyAppsBody.tsx
@@ -24,7 +24,7 @@ import {
   IconEyeOff,
 } from '@tabler/icons-react';
 import Link from 'next/link';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ListingProblemsIndicator } from '~/components/Apps/ListingProblemsIndicator';
 import {
@@ -326,17 +326,31 @@ export function rowActionsTestId(appListingId: string): string {
 }
 
 /**
- * EVERY author-facing control on a row, in ONE container — the takedown controls plus the
- * History disclosure.
+ * The row's ACTIONS CELL — the owner takedown controls plus the History disclosure.
+ *
+ * 🔴 SCOPE, STATED EXACTLY, BECAUSE THE OVERCLAIM IS THE DANGEROUS PART. This is **not**
+ * every interactive control on the row, and the ledger does not see the ones outside it:
+ * `ListingName`'s edit link and the Withdraw buttons inside the expanded `HistoryPanel` both
+ * live elsewhere in the row and are invisible to it. An earlier draft of this comment said
+ * "every author-facing control on a row", which is false — and false in the worst direction,
+ * because it is exactly the sentence a future consolidation would cite as proof of coverage
+ * it does not have. That is how the bug this PR fixes happened in the first place.
  *
  * 🔴 THE CONTAINER IS PART OF THE GUARD, not layout tidiness. `myAppsAuthorActions.ts`
- * declares the exact set of controls each row state offers, and the ledger test enumerates
- * `button`/`a` inside THIS element to compare against it. That comparison fails when the set
- * shrinks — which is the regression this whole file is answering: PR #4154 dropped Unpublish
- * and Republish from this page and three audits passed, because an absent control has
- * nothing to assert on. It also fails when the set grows, and refuses any control here that
- * omits `data-author-action`, so the enumeration cannot be walked by forgetting the
- * attribute.
+ * declares the exact set of controls each row state offers *in this cell*, and the ledger
+ * test enumerates `button`/`a[href]` inside THIS element to compare against it. That
+ * comparison fails when the set shrinks — which is the regression this whole file is
+ * answering: PR #4154 dropped Unpublish and Republish from this page and three audits
+ * passed, because an absent control has nothing to assert on. It also fails when the set
+ * grows, and refuses any control here that omits `data-author-action`, so the enumeration
+ * cannot be walked by forgetting the attribute.
+ *
+ * Kept scoped to the cell rather than widened to the whole row deliberately: the Withdraw
+ * buttons only exist once a row is expanded AND its history has loaded, so a row-wide ledger
+ * would have to model per-expansion, per-fetch action sets — turning a deterministic
+ * structural guard into one whose expected value depends on a query resolving. Widening it
+ * is a real improvement and worth doing; it is not a one-line change, and a ledger that goes
+ * intermittently red is worth less than none.
  *
  * 🔴 WHICH CONTROLS APPEAR IS DECIDED BY `myAppsAuthorActions`, NOT BY LOCAL BRANCHING. A
  * second copy of the predicate would let the DOM and the ledger drift while both stayed
@@ -416,8 +430,22 @@ function RowActions({
 function ModRemovedNotice({ row }: { row: MyAppRow }) {
   if (!showModRemovedNotice(row)) return null;
   return (
+    /*
+     * 🔴 IT STATES THE CONSEQUENCE, NOT A CAUSE, AND THE DIFFERENCE IS TRUTH. An earlier
+     * wording read "Removed by a moderator — contact them to restore it", which asserts WHO
+     * removed the app. That is not what this state means: the server's guard refuses an owner
+     * republish whenever the newest moderation event is anything other than `owner-unpublish`,
+     * and `resolveReport`/`dismissReport` write event rows too. So an owner who unpublishes
+     * their own app and then has a pre-existing report closed by a moderator lands here — the
+     * refusal is real and the mirror is faithful, but nobody removed their app. The sentence
+     * now says only the part that is true in every case that reaches it.
+     *
+     * (The `removed by a moderator` BADGE has the same problem and is deliberately untouched:
+     * it comes from the shared `ownerStateChip`, which the off-site and on-site submissions
+     * lists also render. Rewording it is a cross-surface copy change, not this PR's.)
+     */
     <Text size="xs" c="red" data-testid={`apps-mine-mod-removed-${row.appListingId}`}>
-      Removed by a moderator — contact them to restore it.
+      Only a moderator can restore this listing.
     </Text>
   );
 }
@@ -742,6 +770,21 @@ export type MyAppsBodyViewProps = {
   onRepublish?: (row: MyAppRow) => void;
   /** Is a republish in flight? Disables the button rather than allowing a double-fire. */
   republishing?: boolean;
+  /**
+   * Bumped by the container after a SUCCESSFUL unpublish, to open the Inactive collapse.
+   *
+   * 🔴 THE ROW LEAVES THE VIEWPORT AT THE MOMENT THE AUTHOR ACTS, and without this nothing
+   * says where it went. `partitionMyAppRows` files every `removed` listing under Inactive,
+   * which is collapsed by default, so a successful unpublish moves the app — and its
+   * Republish button — out of sight in the same instant the success toast appears. Opening
+   * the section is the cheap half of the fix; the underlying disagreement about what
+   * `removed` MEANS is recorded as open in the PR body and is deliberately not resolved here.
+   *
+   * A counter rather than a boolean because the trigger is an EVENT, not a state: two
+   * unpublishes in a row must each re-open a section the author may have closed in between,
+   * and a boolean that is already `true` fires no effect the second time.
+   */
+  revealInactive?: number;
   /** Submissions whose listing was deleted — see `listMyOrphanedSubmissions`. */
   orphanedSubmissions?: OrphanedSubmissionRow[];
   /** Message from a FAILED orphan read. Never conflate with an empty one. */
@@ -767,6 +810,7 @@ export function MyAppsBodyView({
   onUnpublish,
   onRepublish,
   republishing = false,
+  revealInactive = 0,
   orphanedSubmissions = [],
   orphanedError = null,
   orphanedLoading = false,
@@ -774,6 +818,12 @@ export function MyAppsBodyView({
 }: MyAppsBodyViewProps) {
   const [inactiveOpen, setInactiveOpen] = useState(false);
   const [inactivePage, setInactivePage] = useState(1);
+
+  // 🔴 GUARDED ON `> 0` so the initial render does not open the section — the prop defaults
+  // to 0 and only a real unpublish bumps it. See `revealInactive` on the props type.
+  useEffect(() => {
+    if (revealInactive > 0) setInactiveOpen(true);
+  }, [revealInactive]);
 
   const { active, inactive } = useMemo(
     () => partitionMyAppRows(sortByRecentlyUpdated(rows)),
@@ -1197,6 +1247,17 @@ export function MyAppsBody() {
     void utils.appListings.listMine.invalidate();
   }, [utils]);
 
+  /**
+   * Bumped only on a SUCCESSFUL unpublish — see `revealInactive` on the props type. It is
+   * wired to the modal's `onDone`, which `OwnerUnpublishModal` calls in its mutation's
+   * `onSuccess`, so a cancelled or refused unpublish does not move the page around.
+   */
+  const [revealInactive, setRevealInactive] = useState(0);
+  const onUnpublished = useCallback(() => {
+    refetchRows();
+    setRevealInactive((n) => n + 1);
+  }, [refetchRows]);
+
   const republish = trpc.appListings.republishOwnListing.useMutation({
     onSuccess: () => {
       showSuccessNotification({ message: 'App republished — it is live again.' });
@@ -1257,6 +1318,7 @@ export function MyAppsBody() {
         onUnpublish={onUnpublish}
         onRepublish={onRepublish}
         republishing={republish.isPending}
+        revealInactive={revealInactive}
       />
       {/*
         🔴 CONFIRM-GATED, REUSING THE EXISTING MODAL RATHER THAN A FRESH `confirm()`.
@@ -1267,7 +1329,7 @@ export function MyAppsBody() {
       <OwnerUnpublishModal
         target={unpublishTarget}
         onClose={() => setUnpublishTarget(null)}
-        onDone={refetchRows}
+        onDone={onUnpublished}
         testIdPrefix="apps-mine"
         variant={unpublishTarget?.variant ?? 'store'}
       />

--- a/src/components/Apps/MyAppsBody.tsx
+++ b/src/components/Apps/MyAppsBody.tsx
@@ -20,11 +20,18 @@ import {
   IconApps,
   IconChevronDown,
   IconChevronRight,
+  IconEye,
+  IconEyeOff,
 } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useCallback, useMemo, useState } from 'react';
 
 import { ListingProblemsIndicator } from '~/components/Apps/ListingProblemsIndicator';
+import {
+  showModRemovedNotice,
+  showRepublish,
+  showUnpublish,
+} from '~/components/Apps/myAppsAuthorActions';
 import type { MyAppRow } from '~/components/Apps/myAppsView';
 import {
   historyStatusColor,
@@ -36,6 +43,11 @@ import {
   partitionMyAppRows,
   sortByRecentlyUpdated,
 } from '~/components/Apps/myAppsView';
+import { ownerListingState, ownerStateChip } from '~/components/Apps/offsiteOwnerControls';
+import {
+  OwnerUnpublishModal,
+  type OwnerUnpublishVariant,
+} from '~/components/Apps/ownerListingModals';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAuthorableListingStatus } from '~/shared/constants/app-capabilities.constants';
 import { formatDate } from '~/utils/date-helpers';
@@ -228,13 +240,31 @@ function StatusBadges({ row }: { row: MyAppRow }) {
       >
         {row.role === 'owner' ? 'Owner' : 'Collaborator'}
       </Badge>
-      <Badge
-        variant="outline"
-        color={listingStatusColor(row.status)}
-        data-testid={`apps-mine-status-${row.appListingId}`}
-      >
-        {row.status}
-      </Badge>
+      {/*
+        🔴 A REMOVED LISTING'S BADGE SAYS *WHO* REMOVED IT. `status` reads `removed` for an
+        owner self-unpublish and for a moderator takedown alike, which is precisely the
+        distinction the author needs — one of those they can undo themselves and the other
+        they cannot. `ownerStateChip` returns null for every other state, so the normal
+        status badge is unchanged there. Same override the off-site and on-site submissions
+        lists apply, from the same function.
+      */}
+      {(() => {
+        const chip = ownerStateChip(
+          ownerListingState({
+            listingStatus: row.status,
+            lastModerationAction: row.lastModerationAction,
+          })
+        );
+        return (
+          <Badge
+            variant="outline"
+            color={chip ? chip.color : listingStatusColor(row.status)}
+            data-testid={`apps-mine-status-${row.appListingId}`}
+          >
+            {chip ? chip.label : row.status}
+          </Badge>
+        );
+      })()}
       {/*
         🔴 THE COMPLETENESS ADVISORY'S ONLY REMAINING HOME. It hung off the two
         `/apps/my-submissions` tables, which lost their importer when that page merged
@@ -274,6 +304,7 @@ function HistoryToggle({
       aria-expanded={expanded}
       aria-controls={historyPanelId(row.appListingId)}
       data-testid={`apps-mine-expand-${row.appListingId}`}
+      data-author-action="history"
     >
       <Group gap={4} wrap="nowrap">
         {expanded ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
@@ -287,6 +318,108 @@ function HistoryToggle({
 
 export function historyPanelId(appListingId: string): string {
   return `apps-mine-history-${appListingId}`;
+}
+
+/** The container the action ledger enumerates. See {@link RowActions}. */
+export function rowActionsTestId(appListingId: string): string {
+  return `apps-mine-actions-${appListingId}`;
+}
+
+/**
+ * EVERY author-facing control on a row, in ONE container — the takedown controls plus the
+ * History disclosure.
+ *
+ * 🔴 THE CONTAINER IS PART OF THE GUARD, not layout tidiness. `myAppsAuthorActions.ts`
+ * declares the exact set of controls each row state offers, and the ledger test enumerates
+ * `button`/`a` inside THIS element to compare against it. That comparison fails when the set
+ * shrinks — which is the regression this whole file is answering: PR #4154 dropped Unpublish
+ * and Republish from this page and three audits passed, because an absent control has
+ * nothing to assert on. It also fails when the set grows, and refuses any control here that
+ * omits `data-author-action`, so the enumeration cannot be walked by forgetting the
+ * attribute.
+ *
+ * 🔴 WHICH CONTROLS APPEAR IS DECIDED BY `myAppsAuthorActions`, NOT BY LOCAL BRANCHING. A
+ * second copy of the predicate would let the DOM and the ledger drift while both stayed
+ * green — the ledger would then be pinning itself.
+ */
+function RowActions({
+  row,
+  expanded,
+  onToggle,
+  onUnpublish,
+  onRepublish,
+  republishing,
+}: {
+  row: MyAppRow;
+  expanded: boolean;
+  onToggle: () => void;
+  onUnpublish?: (row: MyAppRow) => void;
+  onRepublish?: (row: MyAppRow) => void;
+  republishing: boolean;
+}) {
+  /**
+   * 🔴 THE HANDLER IS PART OF THE CONDITION. Rendering Unpublish with no `onUnpublish`
+   * would give the author a button that does nothing — indistinguishable, from the outside,
+   * from the bug being fixed here. The View is used directly in tests and in principle by
+   * any caller, so "the container always passes one" is an assumption, not a guarantee.
+   */
+  const canUnpublish = showUnpublish(row) && !!onUnpublish;
+  const canRepublish = showRepublish(row) && !!onRepublish;
+  return (
+    <Group
+      gap={6}
+      wrap="nowrap"
+      justify="flex-end"
+      data-testid={rowActionsTestId(row.appListingId)}
+    >
+      {canUnpublish && (
+        <Button
+          size="compact-xs"
+          variant="default"
+          color="orange"
+          leftSection={<IconEyeOff size={12} />}
+          onClick={() => onUnpublish?.(row)}
+          data-testid={`apps-mine-unpublish-${row.appListingId}`}
+          data-author-action="unpublish"
+        >
+          Unpublish
+        </Button>
+      )}
+      {canRepublish && (
+        <Button
+          size="compact-xs"
+          variant="default"
+          color="green"
+          leftSection={<IconEye size={12} />}
+          disabled={republishing}
+          loading={republishing}
+          onClick={() => onRepublish?.(row)}
+          data-testid={`apps-mine-republish-${row.appListingId}`}
+          data-author-action="republish"
+        >
+          Republish
+        </Button>
+      )}
+      <HistoryToggle row={row} expanded={expanded} onToggle={onToggle} />
+    </Group>
+  );
+}
+
+/**
+ * "Removed by a moderator" — a STATEMENT, not an action, which is why it is not in the
+ * ledger's action set and why it renders for a collaborator too.
+ *
+ * 🔴 IT EXISTS SO THE MISSING BUTTON IS LEGIBLE. An owner-unpublished row and a
+ * moderator-removed row differ only by the presence of Republish; without this line the
+ * second one is an empty cell, and an empty cell is what a dropped control looks like.
+ */
+function ModRemovedNotice({ row }: { row: MyAppRow }) {
+  if (!showModRemovedNotice(row)) return null;
+  return (
+    <Text size="xs" c="red" data-testid={`apps-mine-mod-removed-${row.appListingId}`}>
+      Removed by a moderator — contact them to restore it.
+    </Text>
+  );
 }
 
 function HistoryPanel({
@@ -405,6 +538,9 @@ type RowRenderProps = {
   onWithdraw?: (entry: MyAppHistoryEntry) => void;
   withdrawing: boolean;
   withdrawEnabled: boolean;
+  onUnpublish?: (row: MyAppRow) => void;
+  onRepublish?: (row: MyAppRow) => void;
+  republishing: boolean;
 };
 
 function rowTestId(group: 'active' | 'inactive', appListingId: string): string {
@@ -434,7 +570,10 @@ function AppTableRow(props: RowRenderProps) {
           <ListingCover row={row} />
         </Table.Td>
         <Table.Td>
-          <StatusBadges row={row} />
+          <Stack gap={4} align="flex-start">
+            <StatusBadges row={row} />
+            <ModRemovedNotice row={row} />
+          </Stack>
         </Table.Td>
         <Table.Td>
           <Text size="xs" c="dimmed">
@@ -442,7 +581,14 @@ function AppTableRow(props: RowRenderProps) {
           </Text>
         </Table.Td>
         <Table.Td>
-          <HistoryToggle row={row} expanded={expanded} onToggle={props.onToggle} />
+          <RowActions
+            row={row}
+            expanded={expanded}
+            onToggle={props.onToggle}
+            onUnpublish={props.onUnpublish}
+            onRepublish={props.onRepublish}
+            republishing={props.republishing}
+          />
         </Table.Td>
       </Table.Tr>
       <Table.Tr>
@@ -488,11 +634,19 @@ function AppCardRow(props: RowRenderProps) {
           <ListingCover row={row} />
         </Group>
         <StatusBadges row={row} />
+        <ModRemovedNotice row={row} />
         <Group justify="space-between" wrap="wrap" gap="xs">
           <Text size="xs" c="dimmed">
             Updated {formatWhen(row.updatedAt)}
           </Text>
-          <HistoryToggle row={row} expanded={expanded} onToggle={props.onToggle} />
+          <RowActions
+            row={row}
+            expanded={expanded}
+            onToggle={props.onToggle}
+            onUnpublish={props.onUnpublish}
+            onRepublish={props.onRepublish}
+            republishing={props.republishing}
+          />
         </Group>
         <HistoryPanel
           row={row}
@@ -574,6 +728,20 @@ export type MyAppsBodyViewProps = {
    * — `appListings.withdrawExternalRequest` has no such gate.
    */
   withdrawEnabled?: boolean;
+  /**
+   * OWNER TAKEDOWN CONTROLS — the pair PR #4154 dropped when it consolidated
+   * `/apps/my-submissions` into this page.
+   *
+   * 🔴 THEY ARE A PAIR, and shipping only the first is worse than shipping neither. An
+   * unpublish with no way back is a one-way door for the author: `republishOwnListing` is
+   * the only owner-reachable route from `removed` to `approved`, and without it the app can
+   * be restored only by a moderator `relistListing`. The row-state routing that decides
+   * which of the two a row offers lives in `myAppsAuthorActions.ts`.
+   */
+  onUnpublish?: (row: MyAppRow) => void;
+  onRepublish?: (row: MyAppRow) => void;
+  /** Is a republish in flight? Disables the button rather than allowing a double-fire. */
+  republishing?: boolean;
   /** Submissions whose listing was deleted — see `listMyOrphanedSubmissions`. */
   orphanedSubmissions?: OrphanedSubmissionRow[];
   /** Message from a FAILED orphan read. Never conflate with an empty one. */
@@ -596,6 +764,9 @@ export function MyAppsBodyView({
   onWithdraw,
   withdrawing = false,
   withdrawEnabled = true,
+  onUnpublish,
+  onRepublish,
+  republishing = false,
   orphanedSubmissions = [],
   orphanedError = null,
   orphanedLoading = false,
@@ -625,6 +796,9 @@ export function MyAppsBodyView({
         onWithdraw,
         withdrawing,
         withdrawEnabled,
+        onUnpublish,
+        onRepublish,
+        republishing,
       };
     },
     [
@@ -636,6 +810,9 @@ export function MyAppsBodyView({
       onWithdraw,
       withdrawing,
       withdrawEnabled,
+      onUnpublish,
+      onRepublish,
+      republishing,
     ]
   );
 
@@ -913,6 +1090,22 @@ function OrphanedSubmissionsSection({
 /** The container: `listMine` for the rows, and ONE lazy history query keyed to the open row. */
 export function MyAppsBody() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  /**
+   * The row the unpublish confirmation is open for, plus its COPY VARIANT.
+   *
+   * 🔴 THE VARIANT IS PER-ROW BECAUSE THIS TABLE IS DUAL-KIND, and that is the one thing a
+   * straight lift from either source page would get wrong. `/apps/my-submissions` was two
+   * separate lists: the on-site one always passed `offline` (unpublishing an on-site app is a
+   * FULL takedown — it stops serving at its app page) and the off-site one always passed
+   * `store` (a delist; the author's own site keeps running). `/apps/mine` merges both kinds
+   * into one table, so a fixed variant would tell half the authors something untrue about
+   * what the button is about to do.
+   */
+  const [unpublishTarget, setUnpublishTarget] = useState<{
+    id: string;
+    slug: string;
+    variant: OwnerUnpublishVariant;
+  } | null>(null);
   // 🔴 `48em` is Mantine's `sm` breakpoint. `useMediaQuery` returns `undefined` before it
   // has measured, so the `=== true` keeps the first paint on the table rather than
   // flashing the card layout on desktop.
@@ -995,6 +1188,45 @@ export function MyAppsBody() {
     [withdrawVersion, withdrawListing]
   );
 
+  /**
+   * 🔴 BOTH WRITES INVALIDATE `listMine`, because both change `AppListing.status` — the very
+   * column the row's state routing reads. Without it the button stays on screen after a
+   * successful unpublish and the author's next click hits a listing that is already removed.
+   */
+  const refetchRows = useCallback(() => {
+    void utils.appListings.listMine.invalidate();
+  }, [utils]);
+
+  const republish = trpc.appListings.republishOwnListing.useMutation({
+    onSuccess: () => {
+      showSuccessNotification({ message: 'App republished — it is live again.' });
+      refetchRows();
+    },
+    /**
+     * 🔴 THE SERVER STAYS AUTHORITATIVE. `showRepublish` is a CLIENT MIRROR of the
+     * last-event guard, so a listing a moderator took down between the render and the click
+     * still 403s ("This listing was removed by a moderator and cannot be restored by its
+     * owner."). Surfacing that message rather than swallowing it is what makes the mirror
+     * safe to have.
+     */
+    onError: (e) =>
+      showErrorNotification({ title: 'Republish failed', error: new Error(e.message) }),
+  });
+
+  const onUnpublish = useCallback((row: MyAppRow) => {
+    setUnpublishTarget({
+      id: row.appListingId,
+      slug: row.slug,
+      // On-site apps go OFFLINE; an off-site listing is only delisted from the store.
+      variant: row.kind === 'onsite' ? 'offline' : 'store',
+    });
+  }, []);
+
+  const onRepublish = useCallback(
+    (row: MyAppRow) => republish.mutate({ appListingId: row.appListingId }),
+    [republish]
+  );
+
   // An orphan is by construction a BLOCK publish request, so it only ever has one proc.
   const onWithdrawOrphan = useCallback(
     (rowToWithdraw: OrphanedSubmissionRow) => {
@@ -1004,23 +1236,41 @@ export function MyAppsBody() {
   );
 
   return (
-    <MyAppsBodyView
-      rows={(rowsQuery.data ?? []) as MyAppRow[]}
-      isLoading={rowsQuery.isLoading}
-      errorMessage={rowsQuery.error?.message ?? null}
-      compact={isCompact}
-      expandedId={expandedId}
-      onToggleExpand={setExpandedId}
-      history={(historyQuery.data ?? []) as MyAppHistoryEntry[]}
-      historyLoading={!!expandedId && historyQuery.isLoading}
-      historyError={historyQuery.error?.message ?? null}
-      onWithdraw={onWithdraw}
-      withdrawing={withdrawVersion.isPending || withdrawListing.isPending}
-      withdrawEnabled={!!features?.appBlocks}
-      orphanedSubmissions={(orphansQuery.data ?? []) as OrphanedSubmissionRow[]}
-      orphanedError={orphansQuery.error?.message ?? null}
-      orphanedLoading={orphansQuery.isLoading}
-      onWithdrawOrphan={onWithdrawOrphan}
-    />
+    <>
+      <MyAppsBodyView
+        rows={(rowsQuery.data ?? []) as MyAppRow[]}
+        isLoading={rowsQuery.isLoading}
+        errorMessage={rowsQuery.error?.message ?? null}
+        compact={isCompact}
+        expandedId={expandedId}
+        onToggleExpand={setExpandedId}
+        history={(historyQuery.data ?? []) as MyAppHistoryEntry[]}
+        historyLoading={!!expandedId && historyQuery.isLoading}
+        historyError={historyQuery.error?.message ?? null}
+        onWithdraw={onWithdraw}
+        withdrawing={withdrawVersion.isPending || withdrawListing.isPending}
+        withdrawEnabled={!!features?.appBlocks}
+        orphanedSubmissions={(orphansQuery.data ?? []) as OrphanedSubmissionRow[]}
+        orphanedError={orphansQuery.error?.message ?? null}
+        orphanedLoading={orphansQuery.isLoading}
+        onWithdrawOrphan={onWithdrawOrphan}
+        onUnpublish={onUnpublish}
+        onRepublish={onRepublish}
+        republishing={republish.isPending}
+      />
+      {/*
+        🔴 CONFIRM-GATED, REUSING THE EXISTING MODAL RATHER THAN A FRESH `confirm()`.
+        `OwnerUnpublishModal` already owns the `unpublishOwnListing` mutation, the optional
+        reason field and the two copy variants; a second implementation would be the place
+        the two surfaces come to disagree about what unpublishing does.
+      */}
+      <OwnerUnpublishModal
+        target={unpublishTarget}
+        onClose={() => setUnpublishTarget(null)}
+        onDone={refetchRows}
+        testIdPrefix="apps-mine"
+        variant={unpublishTarget?.variant ?? 'store'}
+      />
+    </>
   );
 }

--- a/src/components/Apps/__tests__/myAppsAuthorActions.test.ts
+++ b/src/components/Apps/__tests__/myAppsAuthorActions.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AUTHOR_ROW_ACTIONS,
+  authorRowActions,
+  EDITOR_ACTIONS,
+  OWNER_ACTIONS_BY_STATE,
+  rowOwnerState,
+  showModRemovedNotice,
+  showRepublish,
+  showUnpublish,
+  sortAuthorActions,
+  type AuthorActionRow,
+} from '~/components/Apps/myAppsAuthorActions';
+import { OWNER_UNPUBLISH_ACTION } from '~/components/Apps/offsiteOwnerControls';
+
+/**
+ * The PURE half of the `/apps/mine` author-action ledger. The DOM half — the one that
+ * actually catches a dropped button — lives in `MyAppsBody.authorActions.browser.test.tsx`
+ * and compares the rendered controls against the same table.
+ *
+ * 🔴 WHAT THIS FILE CAN AND CANNOT PROVE, stated up front. It runs in the **`unit`**
+ * project, which is the tier that BLOCKS; the browser-mode `component` project is
+ * report-only. So the routing rules are pinned here where a red is enforceable, and the
+ * rendering is pinned there where it is observable. Neither is sufficient alone: this file
+ * would pass with the buttons deleted from the page, and the browser file's ledger is only
+ * as good as the table this file pins.
+ *
+ * 🔴 FIXTURES ARE PAIRWISE DISTINCT AND NON-DEFAULT. `status`, `lastModerationAction` and
+ * `role` never share a value across the cases that separate them, and no fixture's fields
+ * can produce an expected value by coincidence — a mutant that hardcodes `'live'`, `'owner'`
+ * or an empty action list has to be visible in at least one case.
+ */
+
+function row(over: Partial<AuthorActionRow> = {}): AuthorActionRow {
+  return { status: 'approved', lastModerationAction: null, role: 'owner', ...over };
+}
+
+/** The four states, each reached by the field combination that is the ONLY route to it. */
+const LIVE = row({ status: 'approved', lastModerationAction: null });
+const OWNER_HIDDEN = row({ status: 'removed', lastModerationAction: OWNER_UNPUBLISH_ACTION });
+const MOD_REMOVED = row({ status: 'removed', lastModerationAction: 'delist' });
+const INACTIVE = row({ status: 'draft', lastModerationAction: null });
+
+describe('the ledger table itself', () => {
+  it('declares an entry for every owner state, drawn from the declared action vocabulary', () => {
+    // 🔴 SET EQUALITY ON THE KEYS, not `toBeDefined` per key. A state added to
+    // `OwnerListingState` without an entry here would leave the component with
+    // `OWNER_ACTIONS_BY_STATE[state] === undefined` and render nothing at all — which is
+    // exactly the silent-drop shape this ledger exists to make loud.
+    expect(Object.keys(OWNER_ACTIONS_BY_STATE).sort()).toEqual(
+      ['inactive', 'live', 'mod-removed', 'owner-hidden'].sort()
+    );
+    for (const [state, actions] of Object.entries(OWNER_ACTIONS_BY_STATE)) {
+      for (const a of actions) {
+        expect(AUTHOR_ROW_ACTIONS, `${state} declares unknown action ${a}`).toContain(a);
+      }
+      // No duplicates — a repeated entry would make a set comparison against the DOM
+      // (which cannot repeat an action) fail for a reason that is not a missing control.
+      expect(new Set(actions).size).toBe(actions.length);
+    }
+  });
+
+  it('pins the exact per-state sets, as literals', () => {
+    // 🔴 LITERAL EXPECTED VALUES, never derived from the implementation. These four lines
+    // are the whole contract: the state that offers Unpublish, the state that offers
+    // Republish, and the two that offer neither.
+    expect(OWNER_ACTIONS_BY_STATE.live).toEqual(['unpublish', 'history']);
+    expect(OWNER_ACTIONS_BY_STATE['owner-hidden']).toEqual(['republish', 'history']);
+    expect(OWNER_ACTIONS_BY_STATE['mod-removed']).toEqual(['history']);
+    expect(OWNER_ACTIONS_BY_STATE.inactive).toEqual(['history']);
+    expect(EDITOR_ACTIONS).toEqual(['history']);
+  });
+
+  it('never offers Unpublish and Republish on the same row', () => {
+    // They are mutually exclusive by construction (one moves `approved → removed`, the
+    // other the reverse), and a row offering both would be offering one guaranteed 403.
+    for (const actions of Object.values(OWNER_ACTIONS_BY_STATE)) {
+      expect(actions.includes('unpublish') && actions.includes('republish')).toBe(false);
+    }
+  });
+
+  it('offers exactly ONE state a way back — the owner-unpublished one', () => {
+    // 🔴 THE POINT OF THE PAIR. If no state carried `republish`, an owner unpublish would be
+    // a one-way door (only a moderator `relistListing` reopens it); if more than one did, the
+    // client would be offering a restore the server's last-event guard refuses.
+    const withRepublish = Object.entries(OWNER_ACTIONS_BY_STATE)
+      .filter(([, actions]) => actions.includes('republish'))
+      .map(([state]) => state);
+    expect(withRepublish).toEqual(['owner-hidden']);
+  });
+});
+
+describe('rowOwnerState — the routing the ledger is keyed on', () => {
+  it('maps each field combination to its own state', () => {
+    expect(rowOwnerState(LIVE)).toBe('live');
+    expect(rowOwnerState(OWNER_HIDDEN)).toBe('owner-hidden');
+    expect(rowOwnerState(MOD_REMOVED)).toBe('mod-removed');
+    expect(rowOwnerState(INACTIVE)).toBe('inactive');
+  });
+
+  it('treats a removed listing with NO recorded event as a moderator removal', () => {
+    // 🔴 THE SAFE DIRECTION, and it is a real production shape: a listing removed before the
+    // moderation-event table existed has no last event. Guessing "owner" there would offer a
+    // Republish the server refuses; guessing "moderator" withholds a button the owner may
+    // genuinely be entitled to, which is recoverable by asking a moderator.
+    expect(rowOwnerState(row({ status: 'removed', lastModerationAction: null }))).toBe(
+      'mod-removed'
+    );
+    expect(rowOwnerState(row({ status: 'removed', lastModerationAction: undefined }))).toBe(
+      'mod-removed'
+    );
+  });
+
+  it('does not read the moderation action on a non-removed listing', () => {
+    // A stale `owner-unpublish` on a listing that is approved again must not re-open
+    // Republish next to a live app.
+    expect(
+      rowOwnerState(row({ status: 'approved', lastModerationAction: 'owner-unpublish' }))
+    ).toBe('live');
+  });
+});
+
+describe('authorRowActions', () => {
+  it('returns the ledger entry for the row state', () => {
+    expect(authorRowActions(LIVE)).toEqual(['unpublish', 'history']);
+    expect(authorRowActions(OWNER_HIDDEN)).toEqual(['republish', 'history']);
+    expect(authorRowActions(MOD_REMOVED)).toEqual(['history']);
+    expect(authorRowActions(INACTIVE)).toEqual(['history']);
+  });
+
+  it('gives a seated EDITOR history only, in every state', () => {
+    // 🔴 Both takedown procs are owner-scoped server-side. This loop is the reachability
+    // proof for the role branch: it is exercised at all four states, not just the live one,
+    // so a mutant that gates on the state instead of the role fails on at least one.
+    for (const base of [LIVE, OWNER_HIDDEN, MOD_REMOVED, INACTIVE]) {
+      expect(authorRowActions({ ...base, role: 'editor' })).toEqual(['history']);
+    }
+  });
+
+  it('agrees with the per-control predicates the component calls', () => {
+    // 🔴 THE COMPONENT USES `showUnpublish`/`showRepublish`, and the ledger test compares the
+    // DOM against `OWNER_ACTIONS_BY_STATE`. If those two ever disagreed, the ledger would be
+    // pinning itself rather than the page. This is the seam that forbids it.
+    for (const base of [LIVE, OWNER_HIDDEN, MOD_REMOVED, INACTIVE]) {
+      for (const role of ['owner', 'editor'] as const) {
+        const r = { ...base, role };
+        const declared = authorRowActions(r);
+        expect(showUnpublish(r)).toBe(declared.includes('unpublish'));
+        expect(showRepublish(r)).toBe(declared.includes('republish'));
+      }
+    }
+  });
+});
+
+describe('showModRemovedNotice', () => {
+  it('fires only on a moderator takedown, for owners AND collaborators alike', () => {
+    expect(showModRemovedNotice(MOD_REMOVED)).toBe(true);
+    expect(showModRemovedNotice({ ...MOD_REMOVED, role: 'editor' })).toBe(true);
+    expect(showModRemovedNotice(LIVE)).toBe(false);
+    expect(showModRemovedNotice(OWNER_HIDDEN)).toBe(false);
+    expect(showModRemovedNotice(INACTIVE)).toBe(false);
+  });
+
+  it('is a STATEMENT, not an action — absent from the action vocabulary', () => {
+    expect(AUTHOR_ROW_ACTIONS).not.toContain('mod-removed');
+  });
+});
+
+describe('sortAuthorActions', () => {
+  it('imposes the canonical order regardless of input order', () => {
+    expect(sortAuthorActions(['history', 'unpublish'])).toEqual(['unpublish', 'history']);
+    expect(sortAuthorActions(['history', 'republish'])).toEqual(['republish', 'history']);
+  });
+
+  it('keeps an UNKNOWN action last and visible rather than dropping it', () => {
+    // 🔴 A comparison helper that silently discarded an unrecognised entry would turn the
+    // ledger's GROWTH arm off: a new, unregistered control would sort away and the sets would
+    // match. `zz-new` is deliberately not a prefix or suffix of any real action.
+    expect(sortAuthorActions(['zz-new', 'history', 'unpublish'])).toEqual([
+      'unpublish',
+      'history',
+      'zz-new',
+    ]);
+  });
+});

--- a/src/components/Apps/__tests__/myAppsAuthorActions.test.ts
+++ b/src/components/Apps/__tests__/myAppsAuthorActions.test.ts
@@ -39,7 +39,11 @@ function row(over: Partial<AuthorActionRow> = {}): AuthorActionRow {
 /** The four states, each reached by the field combination that is the ONLY route to it. */
 const LIVE = row({ status: 'approved', lastModerationAction: null });
 const OWNER_HIDDEN = row({ status: 'removed', lastModerationAction: OWNER_UNPUBLISH_ACTION });
-const MOD_REMOVED = row({ status: 'removed', lastModerationAction: 'delist' });
+// `other` is what the SERVER now sends for every non-owner action — the projection
+// normalises `delist`/`purge`/`claim`/… to one value so a seated editor never receives the
+// moderator's verb (`app-access.my-app-listings-moderation.test.ts`). The routing must key on
+// "not owner-unpublish", so a raw verb is also exercised below to prove it still does.
+const MOD_REMOVED = row({ status: 'removed', lastModerationAction: 'other' });
 const INACTIVE = row({ status: 'draft', lastModerationAction: null });
 
 describe('the ledger table itself', () => {
@@ -110,6 +114,18 @@ describe('rowOwnerState — the routing the ledger is keyed on', () => {
     expect(rowOwnerState(row({ status: 'removed', lastModerationAction: undefined }))).toBe(
       'mod-removed'
     );
+  });
+
+  it('routes on "not owner-unpublish", so a RAW verb lands in the same state as `other`', () => {
+    // 🔴 The client must not depend on the server's normalisation having happened. A cached
+    // payload from before that projection shipped, or any future caller that hands over a raw
+    // action, still has to reach `mod-removed` — the predicate is an equality test against ONE
+    // value, and everything else is the safe side of it. Four pairwise-distinct real verbs.
+    for (const verb of ['delist', 'purge', 'claim', 'report-dismiss']) {
+      expect(rowOwnerState(row({ status: 'removed', lastModerationAction: verb }))).toBe(
+        'mod-removed'
+      );
+    }
   });
 
   it('does not read the moderation action on a non-removed listing', () => {

--- a/src/components/Apps/myAppsAuthorActions.ts
+++ b/src/components/Apps/myAppsAuthorActions.ts
@@ -116,10 +116,16 @@ export function rowOwnerState(row: AuthorActionRow): OwnerListingState {
 /**
  * The exact set of author controls this row must render.
  *
- * 🔴 THE COMPONENT CALLS THIS RATHER THAN RE-BRANCHING. If the component decided for itself
- * which buttons to draw, the ledger above would be a comment: the test would compare the
- * DOM against a table nothing forces the DOM to follow. Routing both through one function
- * is what makes a red test mean "the page changed", not "the table is stale".
+ * 🔴 THE COMPONENT DOES **NOT** CALL THIS — it calls {@link showUnpublish} /
+ * {@link showRepublish} per control, because it renders them as separate JSX branches rather
+ * than mapping over a list. So this function and the DOM are two independent derivations, and
+ * the property the ledger depends on — that they agree — is NOT structural here. It is
+ * enforced by a dedicated seam test — "agrees with the per-control predicates the component
+ * calls", in `src/components/Apps/__tests__/myAppsAuthorActions.test.ts` — which drives all
+ * four states × both roles and asserts each predicate matches this list's membership. Without that test the ledger would be comparing the DOM against a table nothing
+ * forces the DOM to follow — i.e. pinning itself. Named explicitly because an earlier version
+ * of this comment claimed the stronger, structural version, and a reader who believed it
+ * would have deleted the seam test as redundant.
  */
 export function authorRowActions(row: AuthorActionRow): AuthorRowAction[] {
   if (row.role !== 'owner') return [...EDITOR_ACTIONS];

--- a/src/components/Apps/myAppsAuthorActions.ts
+++ b/src/components/Apps/myAppsAuthorActions.ts
@@ -1,0 +1,149 @@
+import type { OwnerListingState } from '~/components/Apps/offsiteOwnerControls';
+import {
+  canOwnerRepublish,
+  canOwnerUnpublish,
+  ownerListingState,
+} from '~/components/Apps/offsiteOwnerControls';
+import type { AppRole } from '~/shared/constants/app-capabilities.constants';
+
+/**
+ * THE LEDGER OF AUTHOR ACTIONS ON AN `/apps/mine` ROW.
+ *
+ * 🔴 WHY A LEDGER AND NOT JUST A FIX. PR #4154 consolidated `/apps/my-submissions` into
+ * `/apps/mine` and orphaned `MySubmissionsList`, which was the only surface carrying the
+ * owner **Unpublish** / **Republish** controls. The new page body contained zero
+ * occurrences of `unpublish`. The gap was DISCLOSED in that PR and then reviewed three
+ * times without being caught, because every round asked "is the new page correct?" and
+ * none asked "is it COMPLETE?" — a question no per-assertion test can answer, since a
+ * control that is simply absent has nothing to assert against.
+ *
+ * So the class of defect is: *a consolidation silently drops an author affordance and
+ * passes every audit*. The instrument against that class is a ledger — an enumerated set
+ * that fails when it SHRINKS as well as when it GROWS:
+ *
+ *   1. This module declares, per row state, the EXACT set of controls the row offers.
+ *   2. `MyAppsBody.authorActions.browser.test.tsx` renders each state, enumerates every
+ *      interactive control the row's action container actually contains, and asserts SET
+ *      EQUALITY against this table. Deleting a control makes the rendered set smaller than
+ *      the ledger; adding one makes it larger. Either way the test is red, and the author
+ *      of the change has to come here and say what they meant.
+ *   3. That enumeration also REFUSES any control in the container that does not declare a
+ *      `data-author-action`, so "grew" cannot be evaded by forgetting the attribute.
+ *
+ * The behavioural half — that each control fires the right procedure with the right input —
+ * is asserted separately in the same file. A structural ledger type-checks past a button
+ * wired to the wrong mutation.
+ *
+ * 🔴 THE STATE MACHINE ITSELF IS NOT RE-DERIVED HERE. `ownerListingState` in
+ * `offsiteOwnerControls.ts` is the single client mirror of the server guard in
+ * `offsite-moderation.service.ts#republishOwnListing` (the last moderation event must be
+ * `owner-unpublish`), and the off-site list already depends on it. Re-implementing the
+ * live/owner-hidden/mod-removed split here would be the second copy of a predicate, which
+ * is how the two surfaces would come to disagree.
+ */
+
+/**
+ * Every author-facing control an `/apps/mine` row can render, in the canonical order used
+ * for comparison. Adding a control to a row means adding it here first.
+ *
+ * - `unpublish` — owner takedown of a live (approved) listing.
+ * - `republish` — the owner's way BACK from their own unpublish. Not optional: without it
+ *   an owner unpublish is a one-way door only a moderator `relistListing` can reopen.
+ * - `history` — the per-row disclosure toggle. Present on every row regardless of state or
+ *   role, which is exactly why it belongs in the ledger: it is the constant against which a
+ *   state-dependent control's absence is legible rather than looking like an empty cell.
+ */
+export const AUTHOR_ROW_ACTIONS = ['unpublish', 'republish', 'history'] as const;
+export type AuthorRowAction = (typeof AUTHOR_ROW_ACTIONS)[number];
+
+/** Canonical-order sort, so a set comparison never fails on ordering alone. */
+export function sortAuthorActions(actions: readonly string[]): string[] {
+  const rank = (a: string) => {
+    const i = (AUTHOR_ROW_ACTIONS as readonly string[]).indexOf(a);
+    return i === -1 ? AUTHOR_ROW_ACTIONS.length : i;
+  };
+  return [...actions].sort((a, b) => rank(a) - rank(b) || (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/**
+ * The ledger for an **owner**, keyed by {@link OwnerListingState}.
+ *
+ * 🔴 `mod-removed` HAS NEITHER TAKEDOWN CONTROL, AND THAT IS THE LOAD-BEARING CELL. The
+ * server refuses an owner republish whose last event is a moderator action, with
+ * "This listing was removed by a moderator and cannot be restored by its owner." Rendering
+ * Republish there would be a button that can only fail; rendering Unpublish there would be
+ * a button for a state the listing is already in.
+ *
+ * 🔴 `inactive` COVERS `draft`/`pending`/`rejected`. A listing that was never approved has
+ * nothing to take down, so the absence here is a fact about the lifecycle, not an omission.
+ */
+export const OWNER_ACTIONS_BY_STATE: Readonly<
+  Record<OwnerListingState, readonly AuthorRowAction[]>
+> = {
+  live: ['unpublish', 'history'],
+  'owner-hidden': ['republish', 'history'],
+  'mod-removed': ['history'],
+  inactive: ['history'],
+};
+
+/**
+ * The ledger for a seated COLLABORATOR, in every state.
+ *
+ * 🔴 A SEAT IS NOT OWNERSHIP. Both `unpublishOwnListing` and `republishOwnListing` are
+ * owner-scoped server-side and throw for anyone else, so an editor offered either control
+ * gets a guaranteed red toast. One entry rather than a per-state table because the answer
+ * does not depend on the state — and saying so once is what makes it checkable.
+ */
+export const EDITOR_ACTIONS: readonly AuthorRowAction[] = ['history'];
+
+/** The subset of a row this derivation reads. Structural, so any row shape satisfies it. */
+export type AuthorActionRow = {
+  /** The LISTING's own status — `draft|pending|approved|rejected|removed`. */
+  status: string;
+  /** The listing's most-recent moderation-event action; only meaningful when `removed`. */
+  lastModerationAction?: string | null;
+  role: AppRole;
+};
+
+/** The owner-control state for a row — the state the ledger is keyed on. */
+export function rowOwnerState(row: AuthorActionRow): OwnerListingState {
+  return ownerListingState({
+    listingStatus: row.status,
+    lastModerationAction: row.lastModerationAction,
+  });
+}
+
+/**
+ * The exact set of author controls this row must render.
+ *
+ * 🔴 THE COMPONENT CALLS THIS RATHER THAN RE-BRANCHING. If the component decided for itself
+ * which buttons to draw, the ledger above would be a comment: the test would compare the
+ * DOM against a table nothing forces the DOM to follow. Routing both through one function
+ * is what makes a red test mean "the page changed", not "the table is stale".
+ */
+export function authorRowActions(row: AuthorActionRow): AuthorRowAction[] {
+  if (row.role !== 'owner') return [...EDITOR_ACTIONS];
+  const state = rowOwnerState(row);
+  return [...OWNER_ACTIONS_BY_STATE[state]];
+}
+
+/** Does this row offer Unpublish? Owner + live only — mirrors {@link canOwnerUnpublish}. */
+export function showUnpublish(row: AuthorActionRow): boolean {
+  return row.role === 'owner' && canOwnerUnpublish(rowOwnerState(row));
+}
+
+/** Does this row offer Republish? Owner + owner-hidden only — see {@link canOwnerRepublish}. */
+export function showRepublish(row: AuthorActionRow): boolean {
+  return row.role === 'owner' && canOwnerRepublish(rowOwnerState(row));
+}
+
+/**
+ * Is this row a MODERATOR takedown, i.e. should it say so instead of offering a way back?
+ *
+ * Deliberately NOT gated on `role`: a seated collaborator looking at a taken-down app needs
+ * the same explanation the owner gets. It is a statement, not an action, which is why it is
+ * absent from {@link AUTHOR_ROW_ACTIONS}.
+ */
+export function showModRemovedNotice(row: AuthorActionRow): boolean {
+  return rowOwnerState(row) === 'mod-removed';
+}

--- a/src/components/Apps/myAppsView.ts
+++ b/src/components/Apps/myAppsView.ts
@@ -69,6 +69,17 @@ export type MyAppRow = {
   coverUrl: string | null;
   updatedAt: string | Date;
   /**
+   * The listing's most-recent moderation-event action — `owner-unpublish` when the OWNER
+   * took it down, a moderator action (`delist`/`purge`/…) otherwise.
+   *
+   * 🔴 ONLY MEANINGFUL WHEN `status === 'removed'`, and it is the only thing that separates
+   * "I unpublished this and may put it back" from "a moderator removed this and only a
+   * moderator can restore it". `status` alone reads `removed` for both. Optional on the type
+   * so a fixture need not spell it; absent is read as a moderator removal, which is the safe
+   * direction (it withholds a button the server would refuse rather than inventing one).
+   */
+  lastModerationAction?: string | null;
+  /**
    * The listing-completeness advisory (missing icon / cover / screenshots / description /
    * tagline / category), computed server-side by `computeListingProblems`.
    *

--- a/src/server/services/blocks/__tests__/app-access.accessible-listings.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.accessible-listings.test.ts
@@ -31,6 +31,14 @@ const { mockDb, mockWriteDb } = vi.hoisted(() => {
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
     },
+    // `hydrateMyAppListings` reads the latest moderation event for any `removed` row, to
+    // separate an owner self-unpublish from a moderator takedown. No fixture here is
+    // `removed`, so the guarded call does not fire — the model is declared anyway because
+    // the failure mode if it ever did would be `Cannot read properties of undefined`, which
+    // reads as a broken mock rather than as the one-line fixture change that caused it.
+    appListingModerationEvent: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
   });
   return { mockDb: make(), mockWriteDb: make() };
 });

--- a/src/server/services/blocks/__tests__/app-access.my-app-listings-moderation.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.my-app-listings-moderation.test.ts
@@ -120,6 +120,49 @@ function eventsFake(byListingId: Record<string, string>) {
   };
 }
 
+/** One row of a listing's moderation history, for {@link historyFake}. */
+type Event = { action: string; createdAt: Date; id: string };
+
+/**
+ * A moderation-event fake that holds a real multi-event HISTORY per listing and **honours
+ * `orderBy` + `distinct`** the way Postgres would.
+ *
+ * 🔴 IT EXISTS BECAUSE `eventsFake` CANNOT SEE THE SORT. That one synthesises a single event
+ * per id, so `orderBy: [{createdAt}]` is unobservable through it and a `desc` → `asc` mutant
+ * SURVIVES a fully green run — reachable, not unreachable: the args object really is passed
+ * and really is read by the `distinct`/`in` assertions, it just carries a key no assertion
+ * and no fixture can feel. Ordering only becomes a behavioural fact once a listing has more
+ * than one event, so that is what this builds.
+ */
+function historyFake(byListingId: Record<string, Event[]>) {
+  return async (...a: unknown[]): Promise<unknown[]> => {
+    const args = (a[0] ?? {}) as {
+      where?: { appListingId?: { in: string[] } };
+      orderBy?: Array<Record<string, 'asc' | 'desc'>>;
+      distinct?: string[];
+    };
+    const ids = args.where?.appListingId?.in ?? Object.keys(byListingId);
+    let rows: Array<Event & { appListingId: string }> = ids.flatMap((id) =>
+      (byListingId[id] ?? []).map((e) => ({ ...e, appListingId: id }))
+    );
+    // Apply the query's OWN sort, key by key, rather than a hardcoded newest-first.
+    for (const clause of [...(args.orderBy ?? [])].reverse()) {
+      const [key, dir] = Object.entries(clause)[0] as ['createdAt' | 'id', 'asc' | 'desc'];
+      rows = [...rows].sort((x, y) => {
+        const a1 = key === 'createdAt' ? x.createdAt.getTime() : x.id;
+        const b1 = key === 'createdAt' ? y.createdAt.getTime() : y.id;
+        const cmp = a1 < b1 ? -1 : a1 > b1 ? 1 : 0;
+        return dir === 'desc' ? -cmp : cmp;
+      });
+    }
+    if (args.distinct?.includes('appListingId')) {
+      const seen = new Set<string>();
+      rows = rows.filter((r) => !seen.has(r.appListingId) && seen.add(r.appListingId));
+    }
+    return rows.map((r) => ({ appListingId: r.appListingId, action: r.action }));
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockDb.appListing.findMany.mockImplementation(async () => []);
@@ -145,11 +188,76 @@ describe('listMyAppListings — lastModerationAction', () => {
     const byId = Object.fromEntries(rows.map((r) => [r.appListingId, r.lastModerationAction]));
     // Literal expected values, and pairwise distinct — a mutant that returns one constant for
     // every row fails on at least two of these three.
+    // 🔴 The moderator's verb is NORMALISED to `other` before it leaves the server — this
+    // read is reachable by a seated editor, who has no other route to a listing's moderation
+    // history, and the UI needs only "may the owner Republish". `delist` going in and `other`
+    // coming out IS the disclosure boundary; asserting the raw verb here would pin the hole.
     expect(byId).toEqual({
       apl_mine: 'owner-unpublish',
-      apl_theirs: 'delist',
+      apl_theirs: 'other',
       apl_live: null,
     });
+  });
+
+  it('collapses EVERY non-owner action to the same `other`, whatever the verb', async () => {
+    // 🔴 Pairwise-distinct real moderator verbs, each narrating a different enforcement
+    // history — `claim` in particular says a moderator seized the app from an impersonating
+    // owner. A projection that leaked any one of them fails here; one that leaked only the
+    // verb it was written against would still be caught, because these are four different
+    // strings and the expected value is one constant.
+    const verbs = ['delist', 'purge', 'claim', 'report-dismiss'];
+    const table = verbs.map((_, i) => stored({ id: `apl_v${i}` }));
+    mockDb.appListing.findMany.mockImplementation(findManyFake(table));
+    mockDb.appListingModerationEvent.findMany.mockImplementation(
+      eventsFake(Object.fromEntries(verbs.map((v, i) => [`apl_v${i}`, v])))
+    );
+
+    const rows = await listMyAppListings({ userId: OWNER });
+    expect(rows.map((r) => r.lastModerationAction)).toEqual(verbs.map(() => 'other'));
+    // Positive control for that constant: the owner's own action is NOT collapsed, so this
+    // assertion cannot be satisfied by a projection that hardcodes `other` for everything.
+    mockDb.appListingModerationEvent.findMany.mockImplementation(
+      eventsFake({ apl_v0: 'owner-unpublish' })
+    );
+    const again = await listMyAppListings({ userId: OWNER });
+    expect(again.find((r) => r.appListingId === 'apl_v0')?.lastModerationAction).toBe(
+      'owner-unpublish'
+    );
+  });
+
+  it('🔴 takes the NEWEST event, not an arbitrary one — a relisted-then-self-unpublished app', async () => {
+    /**
+     * The history that makes `orderBy` load-bearing, and the direction that matters: an app
+     * a moderator once delisted, then relisted, and whose owner has since unpublished it
+     * themselves. The newest event is `owner-unpublish`, so the owner MAY restore it — and
+     * the server's own guard agrees. Reading the oldest instead reports the `delist`, the row
+     * hides Republish behind "a moderator removed this", and an entitled author is stranded
+     * on a listing the server would have let them bring back.
+     *
+     * `historyFake` honours the query's own `orderBy`, so this dies on a `desc` → `asc`
+     * mutation rather than surviving it — which is exactly what the single-event fake could
+     * not see.
+     */
+    mockDb.appListing.findMany.mockImplementation(findManyFake([stored({ id: 'apl_arc' })]));
+    mockDb.appListingModerationEvent.findMany.mockImplementation(
+      historyFake({
+        apl_arc: [
+          { action: 'delist', createdAt: new Date('2026-03-01T00:00:00Z'), id: 'ev_a' },
+          { action: 'relist', createdAt: new Date('2026-04-01T00:00:00Z'), id: 'ev_b' },
+          { action: 'owner-unpublish', createdAt: new Date('2026-05-01T00:00:00Z'), id: 'ev_c' },
+        ],
+      })
+    );
+
+    const rows = await listMyAppListings({ userId: OWNER });
+    expect(rows[0].lastModerationAction).toBe('owner-unpublish');
+
+    // Structural half, next to the `distinct` assertion below: the exact sort the newest-first
+    // keyset needs. `createdAt` first, `id` as the tiebreak for two events in the same instant.
+    const args = mockDb.appListingModerationEvent.findMany.mock.calls[0]?.[0] as {
+      orderBy: Array<Record<string, string>>;
+    };
+    expect(args.orderBy).toEqual([{ createdAt: 'desc' }, { id: 'desc' }]);
   });
 
   it('reads events ONLY for the removed subset', async () => {

--- a/src/server/services/blocks/__tests__/app-access.my-app-listings-moderation.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.my-app-listings-moderation.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * `listMyAppListings` — the `lastModerationAction` widening that makes the `/apps/mine`
+ * **Republish** control possible at all.
+ *
+ * 🔴 WHY THE FIELD IS NOT OPTIONAL POLISH. `app_listings.status = 'removed'` is written by
+ * BOTH an owner self-unpublish and a moderator takedown, so the row alone cannot tell the two
+ * apart — and they have opposite affordances. `republishOwnListing` refuses unless the most
+ * recent moderation event is `owner-unpublish` ("This listing was removed by a moderator and
+ * cannot be restored by its owner."), so without this field the page must either hide
+ * Republish from an author who is entitled to it — leaving an owner unpublish a one-way door
+ * only a moderator can reopen — or render a button that is guaranteed to 403. There is no
+ * third option, which is what makes this a SERVER change rather than a client one.
+ *
+ * 🔴 RED AT BASE, BEHAVIOURALLY. On `origin/main` `listMyAppListings` does not select or
+ * return this column, so every assertion below reads `undefined` where it expects a real
+ * action — a failure about the payload, not about a missing module.
+ *
+ * The db is mocked through the canonical shared `dbMock` (a per-file mock of the db-client
+ * specifier is refused by `no-direct-shared-module-mock.test.ts`).
+ */
+
+const mockDb = dbMock.dbRead;
+
+const { listMyAppListings } = await import('~/server/services/blocks/app-access.service');
+
+/** Distinct so no assertion's expected value can be produced by the wrong row or user. */
+const OWNER = 41;
+
+type Stored = {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+  kind: string;
+  appBlockId: string | null;
+  updatedAt: Date;
+  icon: null;
+  cover: null;
+  iconId: number | null;
+  coverId: number | null;
+  description: string | null;
+  tagline: string | null;
+  category: string | null;
+  _count: { screenshots: number };
+  columnUserId: number;
+};
+
+function stored(over: Partial<Stored> & { id: string }): Stored {
+  return {
+    slug: `slug-${over.id}`,
+    name: `Name ${over.id}`,
+    status: 'removed',
+    kind: 'offsite',
+    appBlockId: null,
+    updatedAt: new Date('2026-02-03T00:00:00Z'),
+    icon: null,
+    cover: null,
+    iconId: 5,
+    coverId: 8,
+    description: `Description of ${over.id}`,
+    tagline: `Tagline of ${over.id}`,
+    category: 'utility',
+    _count: { screenshots: 2 },
+    columnUserId: OWNER,
+    ...over,
+  };
+}
+
+/** `appListing.findMany` honouring `select` — see the sibling media test for why. */
+function findManyFake(table: Stored[]) {
+  return async (...a: unknown[]): Promise<unknown[]> => {
+    const args = (a[0] ?? {}) as {
+      where?: { OR?: Array<Record<string, unknown>>; id?: { in: string[] } };
+      take?: number;
+      select?: Record<string, unknown>;
+    };
+    const where = args.where ?? {};
+    let rows = table;
+    if (where.id?.in) rows = rows.filter((r) => where.id!.in.includes(r.id));
+    if (where.OR) {
+      const userId = ((): number | undefined => {
+        for (const branch of where.OR) {
+          if (typeof branch.userId === 'number') return branch.userId;
+        }
+        return undefined;
+      })();
+      rows = rows.filter((r) => r.columnUserId === userId);
+    }
+    const select = args.select;
+    return rows.slice(0, args.take ?? rows.length).map((r) => {
+      if (!select) return { ...r };
+      const out: Record<string, unknown> = {};
+      for (const key of Object.keys(select)) {
+        if (select[key]) out[key] = (r as unknown as Record<string, unknown>)[key];
+      }
+      return out;
+    });
+  };
+}
+
+/**
+ * The moderation-event read, honouring `where.appListingId.in`.
+ *
+ * 🔴 IT FILTERS, rather than returning everything. A fake that ignored the `where` would make
+ * the `in`-clause unobservable: a mutant querying every listing's events (or the wrong id
+ * set) would produce the same answer, and the assertion that a MOD-removed row and an
+ * OWNER-removed row get DIFFERENT actions would pass either way.
+ */
+function eventsFake(byListingId: Record<string, string>) {
+  return async (...a: unknown[]): Promise<unknown[]> => {
+    const args = (a[0] ?? {}) as { where?: { appListingId?: { in: string[] } } };
+    const ids = args.where?.appListingId?.in ?? Object.keys(byListingId);
+    return ids
+      .filter((id) => byListingId[id] != null)
+      .map((id) => ({ appListingId: id, action: byListingId[id] }));
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.appListing.findMany.mockImplementation(async () => []);
+  mockDb.appCollaborator.findMany.mockImplementation(async () => []);
+  mockDb.appListingModerationEvent.findMany.mockImplementation(async () => []);
+});
+
+describe('listMyAppListings — lastModerationAction', () => {
+  it('🔴 tells an OWNER unpublish apart from a MODERATOR takedown, on rows that look identical', async () => {
+    // Both rows are `removed` and owned by the same user. The ONLY thing that differs is the
+    // last moderation event — which is exactly the situation the field exists for.
+    const table = [
+      stored({ id: 'apl_mine' }),
+      stored({ id: 'apl_theirs' }),
+      stored({ id: 'apl_live', status: 'approved' }),
+    ];
+    mockDb.appListing.findMany.mockImplementation(findManyFake(table));
+    mockDb.appListingModerationEvent.findMany.mockImplementation(
+      eventsFake({ apl_mine: 'owner-unpublish', apl_theirs: 'delist' })
+    );
+
+    const rows = await listMyAppListings({ userId: OWNER });
+    const byId = Object.fromEntries(rows.map((r) => [r.appListingId, r.lastModerationAction]));
+    // Literal expected values, and pairwise distinct — a mutant that returns one constant for
+    // every row fails on at least two of these three.
+    expect(byId).toEqual({
+      apl_mine: 'owner-unpublish',
+      apl_theirs: 'delist',
+      apl_live: null,
+    });
+  });
+
+  it('reads events ONLY for the removed subset', async () => {
+    const table = [stored({ id: 'apl_gone' }), stored({ id: 'apl_up', status: 'approved' })];
+    mockDb.appListing.findMany.mockImplementation(findManyFake(table));
+    mockDb.appListingModerationEvent.findMany.mockImplementation(
+      eventsFake({ apl_gone: 'owner-unpublish', apl_up: 'approve' })
+    );
+
+    const rows = await listMyAppListings({ userId: OWNER });
+    const args = mockDb.appListingModerationEvent.findMany.mock.calls[0]?.[0] as {
+      where: { appListingId: { in: string[] } };
+      distinct: string[];
+    };
+    // 🔴 The `in` set is the removed rows and nothing else. Widening it would fan a
+    // per-author list read out over every listing's whole moderation history.
+    expect(args.where.appListingId.in).toEqual(['apl_gone']);
+    // Latest-per-listing, or the map would key on an arbitrary older event.
+    expect(args.distinct).toEqual(['appListingId']);
+    // …and the approved row stays null even though the fake HAS an event for it. This is the
+    // stale-event guard: an `approve` action leaking onto a live row would be read by
+    // `ownerListingState` as… nothing, but an `owner-unpublish` one would re-open Republish
+    // next to a published app.
+    expect(rows.find((r) => r.appListingId === 'apl_up')?.lastModerationAction).toBeNull();
+  });
+
+  /**
+   * ⚠️ LABELLED HONESTLY: this one is an INVARIANT GUARD, not regression coverage. It passes
+   * on `origin/main` too — vacuously, because the query it forbids does not exist there. The
+   * three tests around it are the ones that go red at base.
+   */
+  it('does NOT issue the events query when nothing is removed', async () => {
+    mockDb.appListing.findMany.mockImplementation(
+      findManyFake([stored({ id: 'apl_ok', status: 'approved' })])
+    );
+    const rows = await listMyAppListings({ userId: OWNER });
+    expect(rows).toHaveLength(1);
+    // 🔴 POSITIVE CONTROL FOR THIS ZERO: the previous test asserts the SAME mock records a
+    // call when a removed row IS present. A "0 calls" assertion alone is indistinguishable
+    // from a mock nothing ever reaches.
+    expect(mockDb.appListingModerationEvent.findMany).not.toHaveBeenCalled();
+  });
+
+  it('a removed listing with NO recorded event comes back null, not undefined', async () => {
+    // `undefined` and `null` are the same to `ownerListingState`, but the field is declared
+    // non-optional on `MyAppListing` — a row that omitted it would be a lie the type tells.
+    mockDb.appListing.findMany.mockImplementation(findManyFake([stored({ id: 'apl_orphan' })]));
+    mockDb.appListingModerationEvent.findMany.mockImplementation(eventsFake({}));
+    const rows = await listMyAppListings({ userId: OWNER });
+    expect(rows[0].lastModerationAction).toBeNull();
+    expect('lastModerationAction' in rows[0]).toBe(true);
+  });
+});

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -866,8 +866,12 @@ export type MyAppListing = {
    * Populated ONLY for a `removed` listing (the sole state that reads it); `null`
    * everywhere else — including on a removed listing with no recorded event, which
    * {@link ownerListingState} treats as a mod removal, the SAFE direction.
+   *
+   * 🔴 NORMALISED, NOT RAW — see {@link normalizeLastModerationAction} and the note at its
+   * call site. This read is reachable by a seated EDITOR, so it carries the one bit the UI
+   * branches on and never the moderator's actual verb.
    */
-  lastModerationAction: string | null;
+  lastModerationAction: NormalizedModerationAction | null;
 };
 
 /**
@@ -913,6 +917,24 @@ export type AppListingAuthoringContext = Omit<
    */
   connectClientId: string | null;
 };
+
+/**
+ * The one moderation-event action `/apps/mine` is allowed to name, and the bucket for
+ * everything else.
+ *
+ * 🔴 THE VALUE SPACE IS THE POINT. `owner-unpublish` is the only action the client may act
+ * on (it is what `republishOwnListing`'s last-event guard permits), so every other verb
+ * collapses to `other` before it leaves the server. Widening this back to the raw string
+ * re-opens the editor-disclosure hole described at the call site — do not "simplify" it away.
+ */
+export const OWNER_UNPUBLISH_EVENT = 'owner-unpublish';
+export type NormalizedModerationAction = typeof OWNER_UNPUBLISH_EVENT | 'other';
+
+/** `null` in ⇒ `null` out (no event); the owner's own unpublish keeps its name; all else → `other`. */
+function normalizeLastModerationAction(action: string | null): NormalizedModerationAction | null {
+  if (action == null) return null;
+  return action === OWNER_UNPUBLISH_EVENT ? OWNER_UNPUBLISH_EVENT : 'other';
+}
 
 /** Hydrate {@link resolveAccessibleListingIds} into rows, newest listing first. */
 async function hydrateMyAppListings(
@@ -1043,8 +1065,20 @@ async function hydrateMyAppListings(
         }).problems,
         // 🔴 Only a `removed` row can carry one — see the field's doc. A non-removed row
         // returning an action would let a stale event re-open Republish on a live listing.
-        lastModerationAction:
-          r.status === 'removed' ? lastActionByListingId.get(r.id) ?? null : null,
+        //
+        // 🔴 NORMALISED TO THE DISTINCTION, NOT THE VERB, AND THAT IS A DISCLOSURE BOUNDARY.
+        // `listMine` is reachable by an accepted EDITOR, and the only other route to a
+        // listing's moderation actions (`listMyListingModerationEvents`) is owner-scoped —
+        // so shipping the raw action would hand a seated collaborator facts they have no
+        // route to today, and specific ones: `claim` says a moderator seized the app from
+        // an impersonating owner, `purge`/`report-resolve`/`report-dismiss` each narrate a
+        // different enforcement history. The consumer needs exactly one bit — may the owner
+        // press Republish — so that is all this carries. Same bar {@link MyAppListing}
+        // already sets for `iconUrl` ("discloses nothing to a seated editor that the store
+        // does not"); the raw verb neither met it nor argued for an exception.
+        lastModerationAction: normalizeLastModerationAction(
+          r.status === 'removed' ? lastActionByListingId.get(r.id) ?? null : null
+        ),
       };
     }
   );

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -851,6 +851,23 @@ export type MyAppListing = {
    * Empty array = nothing to flag. Never `undefined`.
    */
   problems: ListingProblem[];
+  /**
+   * The listing's MOST-RECENT moderation-event action, or `null`.
+   *
+   * 🔴 CARRIED BECAUSE `removed` ALONE CANNOT TELL THE AUTHOR APART FROM A MODERATOR, and
+   * that distinction is what decides whether the row may offer **Republish**.
+   * `app_listings.status = 'removed'` is written by BOTH an owner self-unpublish and a mod
+   * takedown; only the last event separates them (`owner-unpublish` ⇒ the owner may restore
+   * it, anything else ⇒ `republishOwnListing` 403s and a moderator `relistListing` is the
+   * only way back). Without this field `/apps/mine` cannot render either affordance
+   * correctly — it would either hide Republish from an author who is entitled to it, or
+   * offer a guaranteed-403 button on a moderator takedown.
+   *
+   * Populated ONLY for a `removed` listing (the sole state that reads it); `null`
+   * everywhere else — including on a removed listing with no recorded event, which
+   * {@link ownerListingState} treats as a mod removal, the SAFE direction.
+   */
+  lastModerationAction: string | null;
 };
 
 /**
@@ -880,7 +897,7 @@ export type MyAppListing = {
  */
 export type AppListingAuthoringContext = Omit<
   MyAppListing,
-  'iconUrl' | 'coverUrl' | 'updatedAt' | 'problems'
+  'iconUrl' | 'coverUrl' | 'updatedAt' | 'problems' | 'lastModerationAction'
 > & {
   /**
    * The listing's linked OAuth `client_id`, or `null`. PUBLIC, not a secret — the same
@@ -946,6 +963,34 @@ async function hydrateMyAppListings(
     orderBy: { serialId: 'desc' },
     take: limit,
   });
+  /**
+   * For every REMOVED listing, its MOST-RECENT moderation-event action.
+   *
+   * 🔴 ONE batched query, and ONLY over the removed subset — the same shape
+   * `blocks.router::listMyPublishRequests` and the off-site `listMySubmissions` already use,
+   * so the three author surfaces derive owner-hidden-vs-mod-removed from one query pattern
+   * rather than three. `distinct` + `orderBy desc` is the latest-per-listing keyset.
+   *
+   * The `.length` guard is not micro-optimisation: the overwhelmingly common case is an
+   * author with no removed listings, and skipping the round-trip keeps this read at the ONE
+   * hydrate query `app-access.accessible-listings.test.ts` pins by call count.
+   */
+  const removedListingIds = rows
+    .filter((r: { status: string }) => r.status === 'removed')
+    .map((r: { id: string }) => r.id);
+  const lastEvents = removedListingIds.length
+    ? await dbRead.appListingModerationEvent.findMany({
+        where: { appListingId: { in: removedListingIds } },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        distinct: ['appListingId'],
+        select: { appListingId: true, action: true },
+      })
+    : [];
+  const lastActionByListingId = new Map<string, string>(
+    (lastEvents as Array<{ appListingId: string | null; action: string }>)
+      .filter((e): e is { appListingId: string; action: string } => e.appListingId != null)
+      .map((e) => [e.appListingId, e.action])
+  );
   const ownedSet = new Set(ids.ownedIds);
   return rows.map(
     (r: {
@@ -996,6 +1041,10 @@ async function hydrateMyAppListings(
           tagline: r.tagline ?? null,
           category: r.category ?? null,
         }).problems,
+        // 🔴 Only a `removed` row can carry one — see the field's doc. A non-removed row
+        // returning an action would let a stale event re-open Republish on a live listing.
+        lastModerationAction:
+          r.status === 'removed' ? lastActionByListingId.get(r.id) ?? null : null,
       };
     }
   );


### PR DESCRIPTION
## This is a regression from #4154, not a new feature

A tester reported: *"no unpublish button on the my app"* — they wanted to unpublish an already-approved app and there was no way to do it.

**It is ours.** PR #4154 consolidated `/apps/my-submissions` into `/apps/mine`. The owner unpublish/republish controls lived in `MySubmissionsList.tsx`, which that merge orphaned. `MyAppsBody.tsx` — the new page body — contained **zero** occurrences of `unpublish`.

The uncomfortable part, recorded here because the audit trail is worth more than the tidier story:

- The implementing agent **disclosed it at the time** — *"no inline analytics, install counters, deploy-failure panel, or unpublish/republish controls"* — and it was filed as a noted gap rather than treated as a functional regression.
- **Three audit rounds missed it.** Every round asked *"is the new page correct?"*. None asked *"is it complete?"* — and no per-assertion suite can answer the second question, because a control that is simply absent has nothing to assert against. A tester found it instead.

**What this PR does about that, beyond restoring the buttons:** the class of defect is *a consolidation silently drops an author affordance and passes every audit*, and no amount of extra per-assertion review closes it. So this adds a **ledger** — an enumerated set of the controls each row state offers, compared against what the page actually renders, failing when the set **shrinks** as well as when it grows. A future consolidation that drops Unpublish again produces a red test instead of a tester report. Details and the mutation proof below.

Scope here is the **Unpublish + Republish pair only**. Inline analytics, install counters and the deploy-failure panel stay deferred and are explicitly not in this PR.

---

## The fix

**Republish is not optional.** `republishOwnListing` is the only owner-reachable route from `removed` back to `approved`; without it, an unpublish is a one-way door that only a moderator `relistListing` can reopen. Both halves ship together.

Per-state behaviour, adapted from `MySubmissionsList` rather than lifted from it (the new page is row-based and, unlike either source list, **dual-kind**):

| Row state | Controls | Badge |
|---|---|---|
| approved (live) | **Unpublish** | `approved` |
| owner-unpublished | **Republish** | `unpublished` |
| moderator-removed | neither | `removed by a moderator` + "contact them to restore it" |
| draft / pending / rejected | neither | the plain status |
| seated collaborator, any state | neither | — |

A seat is not ownership: both procedures are owner-scoped server-side, so an editor offered either control gets a guaranteed red toast.

**Dual-kind confirmation copy.** `/apps/my-submissions` was two lists, each passing a *fixed* copy variant to `OwnerUnpublishModal` — `offline` for on-site (a full takedown; the app stops serving at its app page) and `store` for off-site (a delist; the author's own site keeps running). `/apps/mine` merges both kinds into one table, so the variant is derived **per row**. A fixed variant would have told half of all authors something untrue about what the button was about to do — the one thing a straight lift from either source page would have got wrong.

### Server change

`listMyAppListings` now carries `lastModerationAction` for `removed` rows. This is not polish: `app_listings.status = 'removed'` is written by **both** an owner self-unpublish and a moderator takedown, and only the last moderation event separates them. Without the field the page must either hide Republish from an author entitled to it, or render a button guaranteed to 403. One batched `distinct` + `orderBy desc` query over the removed subset only — the same shape `blocks.router::listMyPublishRequests` and the off-site `listMySubmissions` already use. The query is skipped entirely when nothing is removed, so the common case stays at one hydrate query.

`app-listings.router.ts` is **not** touched: `listMine` already just delegates to the service.

---

## The ledger test — the part that prevents recurrence

A one-off restore fixes this instance. The **class** is *a consolidation silently drops an author affordance and passes every audit*.

`myAppsAuthorActions.ts` declares, per row state, the exact set of controls the row offers. `MyAppsBody.authorActions.browser.test.tsx` renders each state, **enumerates every interactive control inside the row's action container**, and asserts **set equality** against that table. Three properties make it a real ledger rather than another assertion:

1. It fails when the set **shrinks** — the #4154 shape.
2. It fails when the set **grows** — a new control must be declared.
3. It **refuses** any control in the container that carries no `data-author-action`, so the growth arm cannot be walked by forgetting the attribute. (The enumeration selects `button, a[href]` and *then* reads the attribute — selecting on `[data-author-action]` directly would have made that arm inert.)

The component calls `showUnpublish`/`showRepublish` from the same module the ledger is keyed on, and a unit test asserts those two agree with the table across all 4 states × 2 roles — otherwise the ledger would be pinning itself rather than the page.

Same writer-ledger pattern as `model-file-hash-writers.test.ts`.

### Teeth — proved, not asserted

Six mutants, each applied, **confirmed landed by diff**, run, and killed on its **own** assertion (all `AssertionError`, none a `TypeError`):

| Mutant | Killed by | Message |
|---|---|---|
| delete the Unpublish button | live-state ledger (+4 more) | `expected [ 'history' ] to deeply equal [ 'unpublish', 'history' ]` |
| delete the Republish button | owner-hidden ledger (+3) | `expected [ 'history' ] to deeply equal [ 'republish', 'history' ]` |
| **swap** the owner-hidden / mod-removed arms in `ownerListingState` | owner-hidden **and** mod-removed ledgers (+3); **4 unit tests too** | both directions, incl. `expected [ 'republish', 'history' ] to deeply equal [ 'history' ]` |
| add an undeclared `<button>` to the row | all 6 ledger cases | `1 control(s) … carry no data-author-action and are therefore invisible to the ledger` |
| Republish fires with `row.slug` instead of the id | the wiring test, alone | call-list mismatch |
| drop the owner role gate from `showUnpublish` | the collaborator case, alone | `expected [ 'unpublish', 'history' ] to deeply equal [ 'history' ]` |

Baseline re-run after restoring: **11/11 green** (positive control).

---

## Test matrix

| Suite | Base | HEAD | Kind |
|---|---|---|---|
| `MyAppsBody.authorActions.browser.test.tsx` (11) | **8 failed / 3 passed** | 11 passed | **regression** — behavioural red |
| `app-access.my-app-listings-moderation.test.ts` (4) | **3 failed / 1 passed** | 4 passed | **regression** — 3 red at base; the 4th is labelled in-file as an **invariant guard** (passes vacuously on `main`) |
| `__tests__/myAppsAuthorActions.test.ts` (14) | n/a | 14 passed | **new-behaviour guard**, labelled as such |

"Red at base" for the browser file is stated as *"against a tree whose `RowActions` renders only the History toggle — which is exactly what `origin/main` offers an author"*, because a literal `origin/main` checkout of the component fails on a missing export instead, which would be a much weaker claim. The two assertion messages measured in that run are quoted verbatim in the file's header.

Regression suites, all green:
- `unit` over `src/server/services/blocks/__tests__/` + `src/components/Apps/__tests__/`: **188 files / 4058 tests**
- `component` over `src/components/Apps/`: **71 files / 983 tests**
- `pnpm typecheck`: **0 errors** (read from the reported count, not the exit code)
- `prettier --check` and `eslint` clean on every changed file

### The earlier `component-tests` red was a load flake — proven by re-run, not argued

The first run of this branch failed one spec. Re-triggered by rebasing onto current `main`; the **same spec passed**, which is the discriminator that separates "load" from "still open":

| | failing run (`9afed638`) | passing re-run (`cf4bce5e02`) |
|---|---|---|
| result | 1 failed / 1915 passed | **1917 passed** |
| `MySubmissionsList … History button` | **15289 ms** (timeout) | **773 ms** ✅ |
| tests > 5 s | 80 | 38 |
| slowest test | 68.8 s | 40.9 s |
| `Duration` / `tests` / `import` / `setup` | 215 / 941 / 715 / 268 s | 107 / 548 / 346 / 103 s |

Every phase roughly halved and the >5 s population halved — **whole-run inflation, not one-assertion inflation**, which is the shape that distinguishes a starved box from a real failed assertion. The spec itself is normally a 773 ms test; it did not become slow, the box did. Mechanism: `expect.element(…).toBeInTheDocument()` polls on vitest's **1000 ms default** — `vitest.config.mts` raises `testTimeout`/`hookTimeout` to 60 s but never `expect.poll`, so under starvation the matcher gives up while the run is still healthy. Corroborating: `pr-preview-4173` failed the same tier the same day at 14977/14949/14982 ms on an unrelated file, and #4219 ran on the same box in the same minute at the same ~9× and passed 1906/1906.

Instrument checks, because a reassuring zero is not evidence: the component runner was validated with a positive control first (an unmodified `MyAppsBody.browser.test.tsx` run reporting **56 tests executed**, not 0) before any verdict here was believed; `prettier --check` was confirmed able to go red (it flagged 3 of the 9 files on the first pass). Negative assertions use `expect(locator.query()).toBeNull()` — **not** `expect.element(...).not.toBeInTheDocument()`, which is inert in this repo (#4197) — placed after the awaits that settle the render, and each cluster of nulls is paired with a positive control asserting something that *is* on screen is found by the same mechanism.

---

## Audit round — what changed in `0234822`

| # | Finding | Fix |
|---|---|---|
| 🟡 1 | `orderBy: createdAt desc` load-bearing and unasserted; `desc`→`asc` **SURVIVED**, reachable but unfeelable through a single-event fake | Added `historyFake` (honours `orderBy` + `distinct`) and the case that matters — `delist` → `relist` → `owner-unpublish`. The mutant now dies **behaviourally**: `expected 'other' to be 'owner-unpublish'` — the strand-an-entitled-author direction, not merely the structural assertion. Structural `orderBy` check added too. |
| 🟡 2 | `RowActions` doc claimed "EVERY author-facing control on a row" — false; the edit link and History-panel Withdraw sit outside it | **Chose narrowing, not widening.** The comment now says "actions cell", names both excluded controls, and says why: Withdraw only exists once a row is expanded *and* its history has resolved, so a row-wide ledger would need per-expansion, per-fetch expected sets — turning a deterministic guard into one whose expected value waits on a query. Widening is the stronger end state and is recorded as worth doing; it is not a one-liner, and an intermittently-red ledger is worth less than none. |
| 🟡 3 | Projection widened what a seated **editor** receives (`claim`, `purge`, `report-*`) | Server now normalises to `'owner-unpublish' \| 'other' \| null`. New test collapses four pairwise-distinct real verbs to one constant, with a positive control proving `owner-unpublish` is *not* collapsed. Deleting the normalisation kills 2 tests. |
| 🟡 4 | "Removed by a moderator — contact them to restore it" can be false (a closed report writes an event row) | Now **"Only a moderator can restore this listing."** — states the consequence, which is true in every case that reaches it, instead of narrating a cause. The shared `ownerStateChip` badge has the same flaw and is deliberately untouched: it renders on two other surfaces, so rewording it is a cross-surface change, not this PR's. |
| 🟡 5 | Row vanishes into collapsed *Inactive* the instant the author unpublishes | The section now **auto-opens on success**. Chose this over "name the section in the toast" because that toast lives in the shared `OwnerUnpublishModal`, where the other two surfaces have no Inactive section — naming it there would be wrong for them. Driven through the real confirm flow in test, and the mock now invokes `onSuccess` so the assertion is not vacuous. |
| 🟢 | `myAppsAuthorActions` claimed the component calls `authorRowActions` — it calls the per-control predicates | Comment now names the real mechanism (the seam test), and says why it matters: a reader who believed the stronger claim would have deleted that test as redundant. |

**Mutation-checked, each landing confirmed by diff and each dying on its own assertion:**

- `orderBy` `desc`→`asc` → `expected 'other' to be 'owner-unpublish'` (1 failed / 5 passed)
- normalisation removed → `expected [ 'delist', 'purge', 'claim', …(1) ] to deeply equal [ 'other', 'other', 'other', 'other' ]` (2 failed / 4 passed)
- auto-open disabled → the reveal test fails (1 failed / 11 passed)

**Recorded, not fixed** (per audit): the page-level `republishing` state disables every Republish button while one is in flight; there is no `owner-hidden` + `editor` DOM fixture (the blocking tier already pins that predicate across all four states × both roles); the ledger runs at one viewport. The pre-existing unhandled rejection in `ItemResellersPopover.browser.test.tsx` is filed as **#4223** — and note it is *also* load-correlated: present in the loaded run, absent in the quiet one.

---

## Known limitations / follow-ups, stated rather than absorbed

- 🔴 **OPEN: two components disagree about what `status = 'removed'` MEANS, and this PR does not resolve it.** This is a modelling disagreement, not a UI nit, and it should be settled deliberately rather than papered over:

  - `myAppsView.ts::partitionMyAppRows` treats `removed` as **terminal** — one of "the two `app_listings.status` values an app cannot come back from on its own" — and routes every such row into the default-collapsed *Inactive* group. It reads `status` and nothing else, by an explicit 🔴 documented invariant with its own test.
  - `offsiteOwnerControls.ts::isModRemovedListing` takes the **opposite** position for the same column: it deliberately EXCLUDES an owner-unpublished listing from the removed bucket, on the stated grounds that it "stays Republish-able and keeps its normal (Live) placement", and routes only *moderator* takedowns aside.

  Both are load-bearing and both are documented as intentional. They cannot both be right, because an owner-unpublished listing is simultaneously `removed` (so: terminal, Inactive) and self-restorable (so: not terminal, normal placement). The observable consequence today is that **Republish sits one disclosure click inside a group labelled "Inactive"** — reachable, but filed under a heading that asserts the app cannot come back, which is exactly what Republish disproves.

  I did not change `partitionMyAppRows`: overriding a 🔴 invariant with its own test, in a PR about restoring two buttons, is the kind of drive-by that produces the next silent regression. Whoever resolves this should pick ONE meaning for `removed` and make both modules read it from one predicate — the one-rule-one-place fix — rather than adding a third local branch. The ledger test opens the collapse **explicitly** rather than hiding it in a helper, so the cost stays visible in the code. Mitigated meanwhile only in that the badge now reads `unpublished` rather than `removed`, so the row is at least identifiable inside that group.
- Analytics, install counters and the deploy-failure panel remain dropped from this page. Unchanged by this PR; still open from #4154.
- `MyAppsBody.browser.test.tsx`'s tRPC mock gained the two new procedures — the mutation hooks run unconditionally at mount, so an absent entry is a mount-time `TypeError`, not a missing assertion. What they are *called with* is asserted in the new ledger file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
