### PR TITLE
fix(apps): render display labels for listing category and content rating

### DIFF
--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -17,7 +17,7 @@ import {
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import {
   isMarketplaceCategory,
-  MARKETPLACE_CATEGORY_LABELS,
+  marketplaceCategoryLabel,
 } from '~/server/services/blocks/marketplace-categories.constants';
 import { hasInstallSlot } from '~/shared/constants/slot-registry';
 import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema';
@@ -61,15 +61,6 @@ export interface AppBlockCardProps {
    * track recents are unaffected.
    */
   onRecentOpen?: (block: AvailableBlock) => void;
-}
-
-/**
- * Maps a stored category value to its display label. Falls back to the raw
- * value for an unrecognised category (soft contract — adding a category is a
- * one-line const edit, and an older client won't crash on a newer category).
- */
-function categoryLabel(category: string): string {
-  return isMarketplaceCategory(category) ? MARKETPLACE_CATEGORY_LABELS[category] : category;
 }
 
 /**
@@ -240,7 +231,7 @@ export function AppBlockCard({
                     size="sm"
                     leftSection={<CategoryIcon size={12} />}
                   >
-                    {categoryLabel(block.category)}
+                    {marketplaceCategoryLabel(block.category)}
                   </Badge>
                 );
               })()}

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -560,8 +560,9 @@ describe('AppListingDetailBody', () => {
     // `formatDate` default format is `MMM D, YYYY`; base() pins 2026-03-04.
     expect(meta.element().textContent).toContain('Updated:');
     expect(meta.element().textContent).toContain('2026');
+    // 🔴 The DISPLAY label, not the stored `utility` this fixture holds.
     expect(container.querySelector('[data-testid="apps-listing-category"]')?.textContent).toBe(
-      'utility'
+      'Utility'
     );
   });
 

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -77,7 +77,10 @@ import { IconBadge } from '~/components/IconBadge/IconBadge';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { StatHoverCard } from '~/components/Stats/StatHoverCard';
 import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
-import { isMarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
+import {
+  isMarketplaceCategory,
+  marketplaceCategoryLabel,
+} from '~/server/services/blocks/marketplace-categories.constants';
 import { formatDate } from '~/utils/date-helpers';
 import detailClasses from '~/components/Model/ModelVersions/ModelVersionDetails.module.scss';
 import galleryClasses from '~/components/Apps/AppListingDetailBody.module.scss';
@@ -1021,7 +1024,7 @@ export function AppListingDetailBody({
                     holds its category filter in client state, not in the URL — so a
                     link here would either 404 or land on an unfiltered grid. */}
                 <Badge size="sm" color="blue" data-testid="apps-listing-category">
-                  {detail.category}
+                  {marketplaceCategoryLabel(detail.category)}
                 </Badge>
               </>
             )}

--- a/src/components/Apps/AppListingsModerationTable.browser.test.tsx
+++ b/src/components/Apps/AppListingsModerationTable.browser.test.tsx
@@ -276,6 +276,35 @@ describe('AppListingsModerationTable — sections + kind-aware visibility', () =
     await expect.element(page.getByText('gone-ext')).toBeInTheDocument();
   });
 
+  /**
+   * 🔴 CALL-SITE ASSERTION for the Category column, which shipped the raw stored
+   * value while the store card one component over was already mapping it.
+   *
+   * ⚠️ FIXTURE LIMIT, stated rather than hidden: every marketplace label is a plain
+   * capitalisation of its key, so `utility` → `Utility` differs only in CASE and
+   * that is the maximum discrimination this taxonomy allows — unlike the rating
+   * ladder, where `pg13` → `PG-13` separates the map from every transformation.
+   * Case is still enough to kill the mutant that matters here (the call site
+   * reverting to `{row.category}`), which is what this assertion is for.
+   */
+  test('🔴 the Category column renders the display LABEL, never the stored value', async () => {
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
+    // 🔴 Await the render BEFORE reading `.elements()`, which is a synchronous
+    // snapshot: without this the read runs against an empty DOM and every
+    // assertion below passes or fails for reasons that have nothing to do with
+    // the label. (Caught by the positive control on the first run — it reported
+    // 0 badges.)
+    const badges = page.getByTestId('apps-listing-mod-category');
+    await expect.element(badges.first()).toBeInTheDocument();
+    // Positive control: the column really does render, so the "no raw value"
+    // assertion below is a discrimination and not a query wired to nothing.
+    const texts = badges.elements().map((el) => el.textContent);
+    expect(texts.length).toBeGreaterThan(0);
+    // Every fixture row stores `utility`; every badge must read `Utility`.
+    expect(new Set(texts)).toEqual(new Set(['Utility']));
+    expect(texts).not.toContain('utility');
+  });
+
   test('off-site-only actions are hidden on an on-site row (kind-aware)', async () => {
     renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     // Off-site approved → BOTH reset-to-pending + hide.

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -41,6 +41,7 @@ import {
   type SubmissionGroup,
 } from '~/components/Apps/submissionsTable';
 import { SortableTh, StatusSections, SubmissionSearch } from '~/components/Apps/submissionsTableUi';
+import { marketplaceCategoryLabel } from '~/server/services/blocks/marketplace-categories.constants';
 import type { ModerationListingRow } from '~/server/services/blocks/app-listing.service';
 import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -316,7 +317,7 @@ export function AppListingsModerationTable({
                   <Table.Td>
                     {row.category ? (
                       <Badge size="sm" variant="light">
-                        {row.category}
+                        {marketplaceCategoryLabel(row.category)}
                       </Badge>
                     ) : (
                       <Text size="xs" c="dimmed">

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -316,7 +316,10 @@ export function AppListingsModerationTable({
                   </Table.Td>
                   <Table.Td>
                     {row.category ? (
-                      <Badge size="sm" variant="light">
+                      // testid so the display-label assertion can select this badge
+                      // STRUCTURALLY — a text search for a category word would also
+                      // match the app's name or a status chip.
+                      <Badge size="sm" variant="light" data-testid="apps-listing-mod-category">
                         {marketplaceCategoryLabel(row.category)}
                       </Badge>
                     ) : (

--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -247,6 +247,57 @@ describe('ExternalSubmitForm — redesigned wizard', () => {
     expect(mocks.mutate).toHaveBeenCalledTimes(1);
   });
 
+  /**
+   * 🔴 CALL-SITE ASSERTION for the two rating surfaces this wizard owns: the
+   * Details step's Content-rating `<Select>` option list, and the "Draft created"
+   * summary badge that echoes the chosen value back to the author.
+   *
+   * End-to-end on purpose — option LABEL → selection → summary badge. Picking the
+   * option by its accessible name IS the option-list guard: had the list still
+   * shipped `label: r` (or the `PG13` its `toUpperCase()` produced), this
+   * `getByRole('option', { name: 'PG-13' })` would not resolve and the test would
+   * die before ever reaching the badge.
+   *
+   * `pg13` is chosen over the form's default `g` deliberately: `g` → `G` differs
+   * only in CASE, while `PG-13` is a string no transformation of its key yields.
+   */
+  test('🔴 the rating Select and the Draft-created badge both show the LABEL, not the key', async () => {
+    mocks.clients = {
+      data: [{ id: 'oauth-client-1', name: 'My OAuth App', allowedScopes: 0 }],
+      isLoading: false,
+    };
+    mocks.meta = { data: {}, isFetching: false, isSuccess: true };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl();
+    await pickClient();
+    await page.getByTestId('apps-offsite-wizard-next-app').click();
+
+    // Positive control BEFORE touching anything: the form starts at `g`, and the
+    // closed Select must already read its label rather than the key.
+    const ratingSelect = page.getByRole('textbox', { name: 'Content rating' });
+    await expect.element(ratingSelect).toBeInTheDocument();
+    expect((ratingSelect.element() as HTMLInputElement).value).toBe('G');
+
+    await ratingSelect.click();
+    await page.getByRole('option', { name: 'PG-13' }).click();
+    expect((ratingSelect.element() as HTMLInputElement).value).toBe('PG-13');
+
+    await page.getByRole('button', { name: 'Create draft' }).click();
+    // 🔴 The VALUE half is untouched: the mutation still carries the stored key.
+    // The pair is the point — a mutant that mapped the value instead of the label
+    // would satisfy the assertion above and break this one.
+    expect(mocks.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ contentRating: 'pg13' })
+    );
+
+    // The "Draft created" summary badge echoes the same LABEL back to the author.
+    const assets = page.getByTestId('apps-offsite-wizard-assets-panel');
+    await expect.element(assets).toBeInTheDocument();
+    const text = assets.element().textContent ?? '';
+    expect(text).toContain('PG-13');
+    expect(text).not.toContain('Content rating: pg13');
+  });
+
   test('the page <title> (not the host) fills the Name; slug still derives from the host; og:description autofills the Description', async () => {
     // Regression (bug report): cosmetic-studio.civitai.com must show the real page
     // <title> "Civitai Cosmetic Studio" in Name, NOT the host-derived "Cosmetic Studio".

--- a/src/components/Apps/ExternalSubmitForm.tsx
+++ b/src/components/Apps/ExternalSubmitForm.tsx
@@ -50,6 +50,7 @@ import type { ListingEditContext } from '~/components/Apps/offsiteEditConfig';
 import type { MarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
 import type { OffsiteContentRating } from '~/server/schema/blocks/offsite-listing.schema';
 import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constants';
+import { offsiteContentRatingLabel } from '~/shared/constants/browsingLevel.constants';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -791,7 +792,7 @@ function ExternalCreateForm() {
                       <Code>{submitted.slug}</Code> is a pending standalone submission. Attach an
                       icon and a cover below to be approved — screenshots are recommended but
                       optional and can be added later. Content rating:{' '}
-                      <Badge size="xs">{values.contentRating}</Badge>
+                      <Badge size="xs">{offsiteContentRatingLabel(values.contentRating)}</Badge>
                     </Text>
                   </Alert>
                 }

--- a/src/components/Apps/ManifestEditForm.browser.test.tsx
+++ b/src/components/Apps/ManifestEditForm.browser.test.tsx
@@ -234,6 +234,36 @@ describe('ManifestEditForm — tagline + category (manifest-governed store field
     await expect.element(page.getByRole('textbox', { name: 'Category' })).toHaveValue('Utility');
   });
 
+  /**
+   * 🔴 CALL-SITE ASSERTION for the CONTENT-RATING Select, which shipped
+   * `label: r` — the raw stored key — while the Category Select one control up
+   * was already mapped.
+   *
+   * The fixture stores `pg13` rather than `BASE_MANIFEST`'s `g` deliberately:
+   * `g` → `G` differs from its key only in CASE, so it cannot separate the
+   * shared map from a `toUpperCase()`. `pg13` → `PG-13` separates it from every
+   * mechanical transformation of the key at once.
+   */
+  test('🔴 the content-rating Select displays the LABEL, not the stored key', async () => {
+    renderWithProviders(
+      <ManifestEditForm
+        appBlockId="app-1"
+        slug="my-block"
+        currentVersion="1.0.0"
+        manifest={{ ...BASE_MANIFEST, contentRating: 'pg13' }}
+      />
+    );
+    const rating = page.getByRole('textbox', { name: 'Content rating' });
+    await expect.element(rating).toHaveValue('PG-13');
+    // 🔴 The two near-miss spellings, named so neither can ship silently — asserted
+    // by reading the value rather than through `expect.element(...).not.*`, which
+    // is INERT in this repo (#4197). The positive assertion above is this read's
+    // control: it proves the element resolves and carries a value at all.
+    const value = (rating.element() as HTMLInputElement).value;
+    expect(value).not.toBe('pg13');
+    expect(value).not.toBe('PG13');
+  });
+
   test('Save includes the trimmed tagline + selected category on the patch', async () => {
     renderWithProviders(
       <ManifestEditForm

--- a/src/components/Apps/ManifestEditForm.tsx
+++ b/src/components/Apps/ManifestEditForm.tsx
@@ -23,6 +23,7 @@ import {
   MARKETPLACE_CATEGORY_LABELS,
   isMarketplaceCategory,
 } from '~/server/services/blocks/marketplace-categories.constants';
+import { offsiteContentRatingLabel } from '~/shared/constants/browsingLevel.constants';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -217,7 +218,12 @@ export function ManifestEditForm({
 
       <Select
         label="Content rating"
-        data={[...ALLOWED_CONTENT_RATINGS].map((r) => ({ value: r, label: r }))}
+        // `ALLOWED_CONTENT_RATINGS` is the manifest validator's own copy of the same
+        // five values; the LABEL still comes from the one display map (was `label: r`).
+        data={[...ALLOWED_CONTENT_RATINGS].map((r) => ({
+          value: r,
+          label: offsiteContentRatingLabel(r),
+        }))}
         value={contentRating}
         onChange={(v) => setContentRating(v ?? 'g')}
       />

--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -357,11 +357,17 @@ describe('OffsiteReviewModal — approve-notes gating, friendly date, field labe
     await expect.element(page.getByText('Content rating', { exact: true })).toBeInTheDocument();
     // The badge value the Category field labels is still rendered — scoped out of the
     // preview pane, which now also prints the category in its Details row.
+    // 🔴 The DISPLAY label: the fixture stores `utility`, the badge says `Utility` (the
+    // same word the store card and the store detail rail print).
     const formCategoryValues = page
-      .getByText('utility', { exact: true })
+      .getByText('Utility', { exact: true })
       .elements()
       .filter((el) => !el.closest('[data-testid="apps-listing-preview-detail"]'));
     expect(formCategoryValues.length).toBeGreaterThan(0);
+    // …and the raw stored value is gone from this surface entirely. `.not.toBeInTheDocument()`
+    // is INERT in this repo (#4197), so query for null instead — controlled against the
+    // label assertion above, which has just proved this query CAN find a match.
+    expect(page.getByText('utility', { exact: true }).query()).toBeNull();
     // #3412 added the listing-preview detail pane (`apps-listing-preview-detail`), which
     // renders its OWN content-rating badge — so a bare exact 'g' now matches 2 elements and
     // the strict query throws. Scope to the Content-rating FIELD GROUP this test is about,
@@ -369,7 +375,9 @@ describe('OffsiteReviewModal — approve-notes gating, friendly date, field labe
     // badge value is wrong or missing, rather than being satisfied by the preview's copy.
     const ratingLabel = page.getByText('Content rating', { exact: true });
     await expect.element(ratingLabel).toBeInTheDocument();
-    expect(ratingLabel.element().parentElement?.textContent).toBe('Content ratinggdeclared');
+    // 🔴 `G`, not the stored `g`. The whole normalised group text is pinned, so a
+    // reworded badge cannot be walked past by a looser substring check.
+    expect(ratingLabel.element().parentElement?.textContent).toBe('Content ratingGdeclared');
   });
 });
 
@@ -458,10 +466,13 @@ describe('OffsiteReviewModal — content-rating derive + mod override', () => {
   test('surfaces the DERIVED rating and FLAGS it as higher than the declared rating', async () => {
     renderWithProviders(<OffsiteReviewQueue />);
     await page.getByRole('button', { name: 'Review' }).click();
-    // Derived from the assets (max R) → 'r', shown alongside the declared 'g'.
-    await expect
-      .element(page.getByTestId('apps-offsite-derived-rating'))
-      .toHaveTextContent('r');
+    // Derived from the assets (max R) → stored `r`, DISPLAYED as `R` alongside the
+    // declared `g`'s `G`. 🔴 Asserted as EXACT text content, not `toHaveTextContent`:
+    // that matcher is a substring match and 'r' is a substring of most words, so it
+    // could not tell the label from the raw value.
+    const derived = page.getByTestId('apps-offsite-derived-rating');
+    await expect.element(derived).toBeInTheDocument();
+    expect(derived.element().textContent).toBe('R');
     // Assets more mature than declared → the mismatch warning renders.
     await expect
       .element(page.getByTestId('apps-offsite-rating-mismatch'))

--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -486,7 +486,18 @@ describe('OffsiteReviewModal — content-rating derive + mod override', () => {
     // The Select is present (defaulting to the derived rating), and confirming approve
     // forwards the chosen rating to the mutation.
     await expect.element(page.getByTestId('apps-offsite-approve-rating')).toBeInTheDocument();
+    // 🔴 CALL-SITE ASSERTION for the option list's LABEL half. Mantine renders the
+    // selected option's label in the input, so this reads what the moderator reads.
+    // Was `label: r`, i.e. the raw key.
+    const ratingInput = page
+      .getByTestId('apps-offsite-approve-rating')
+      .element() as HTMLInputElement;
+    expect(ratingInput.value).toBe('R');
+    expect(ratingInput.value).not.toBe('r');
     await page.getByTestId('apps-offsite-approve-confirm').click();
+    // 🔴 …and the VALUE half is unchanged: the mutation still receives the stored
+    // key. The pair is the point — a mutant that mapped the value instead of the
+    // label would satisfy the assertion above and break this one.
     expect(mocks.approveMutate).toHaveBeenCalledWith(
       expect.objectContaining({ publishRequestId: 'req-1', contentRating: 'r' })
     );

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -75,9 +75,12 @@ import {
   type OffsiteContentRating,
 } from '~/server/schema/blocks/offsite-listing.schema';
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
+import { OFFSITE_CONTENT_RATING_OPTIONS } from '~/components/Apps/offsiteSubmitFormConfig';
+import { marketplaceCategoryLabel } from '~/server/services/blocks/marketplace-categories.constants';
 import {
   deriveContentRatingFromAssets,
   nsfwLevelFromContentRating,
+  offsiteContentRatingLabel,
 } from '~/shared/constants/browsingLevel.constants';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { formatDate as formatDateHelper } from '~/utils/date-helpers';
@@ -621,7 +624,7 @@ export function OffsiteReviewModalBody({
                     Category
                   </Text>
                   <Badge size="sm" variant="light">
-                    {request.appListing.category}
+                    {marketplaceCategoryLabel(request.appListing.category)}
                   </Badge>
                 </Group>
               )}
@@ -631,7 +634,7 @@ export function OffsiteReviewModalBody({
                     Content rating
                   </Text>
                   <Badge size="sm" color="gray" variant="light">
-                    {request.appListing.contentRating}
+                    {offsiteContentRatingLabel(request.appListing.contentRating)}
                   </Badge>
                   <Text size="xs" c="dimmed">
                     {isOnsite ? 'app rating (cap)' : 'declared'}
@@ -649,7 +652,7 @@ export function OffsiteReviewModalBody({
                     variant="light"
                     data-testid="apps-offsite-derived-rating"
                   >
-                    {derivedRating}
+                    {offsiteContentRatingLabel(derivedRating)}
                   </Badge>
                 </Group>
               )}
@@ -784,15 +787,18 @@ export function OffsiteReviewModalBody({
           >
             {isOnsite ? (
               <Text size="sm">
-                Media assets are rated higher ({derivedRating}) than the app’s rating (
-                {declaredRating ?? '—'}). Listing media must not exceed the app’s rating — reject
-                this revision or ask the author to trim the over-rated assets.
+                Media assets are rated higher ({offsiteContentRatingLabel(derivedRating)}) than
+                the app’s rating (
+                {declaredRating ? offsiteContentRatingLabel(declaredRating) : '—'}). Listing media
+                must not exceed the app’s rating — reject this revision or ask the author to trim
+                the over-rated assets.
               </Text>
             ) : (
               <Text size="sm">
-                Assets contain higher-maturity content ({derivedRating}) than the declared rating (
-                {declaredRating ?? '—'}). The final rating defaults to the detected value; rate it at
-                least that high.
+                Assets contain higher-maturity content (
+                {offsiteContentRatingLabel(derivedRating)}) than the declared rating (
+                {declaredRating ? offsiteContentRatingLabel(declaredRating) : '—'}). The final
+                rating defaults to the detected value; rate it at least that high.
               </Text>
             )}
           </Alert>
@@ -840,7 +846,10 @@ export function OffsiteReviewModalBody({
                   ? 'Defaults to the app’s rating (the cap). Listing media must not exceed the app’s rating; assets rated higher are a reject reason.'
                   : 'Defaults to the rating detected from the assets. You may rate up; an under-rating is floored to the detected value on save.'
               }
-              data={OFFSITE_CONTENT_RATINGS.map((r) => ({ value: r, label: r }))}
+              // Same display map as the store rail and the submit form — the mod
+              // picks the rating a visitor will read, so it must be spelled the
+              // same. (Was `label: r`, i.e. the raw lowercase key.)
+              data={OFFSITE_CONTENT_RATING_OPTIONS}
               value={selectedRating}
               onChange={(v) => setRatingOverride((v as OffsiteContentRating) ?? null)}
               disabled={busy}

--- a/src/components/Apps/OnsiteReviewModal.browser.test.tsx
+++ b/src/components/Apps/OnsiteReviewModal.browser.test.tsx
@@ -264,6 +264,7 @@ describe('OnsiteReviewModal — store-visible copy is surfaced INLINE for the mo
         ...ONSITE_PENDING.manifest,
         tagline: 'The fastest way to remix a model',
         category: 'generation',
+        contentRating: 'pg13',
       },
     };
     renderWithProviders(
@@ -273,7 +274,22 @@ describe('OnsiteReviewModal — store-visible copy is surfaced INLINE for the mo
     await expect
       .element(page.getByText('The fastest way to remix a model'))
       .toBeInTheDocument();
-    await expect.element(page.getByText('generation')).toBeInTheDocument();
+    /**
+     * 🔴 CALL-SITE ASSERTION — and a REPAIR of one that could not fail.
+     *
+     * This line was `getByText('generation')`. Without `exact`, Playwright matches
+     * a case-insensitive SUBSTRING, so it resolved happily against both the raw
+     * `generation` this modal used to render AND the `Generation` it renders now —
+     * it named the value without ever being able to discriminate it. The audit
+     * counted this site as uncovered, and it was right: the assertion was inert
+     * for the property that matters.
+     */
+    await expect.element(page.getByText('Generation', { exact: true })).toBeInTheDocument();
+    expect(page.getByText('generation', { exact: true }).query()).toBeNull();
+    // 🔴 The rating badge beside it, on the rung that separates the shared map from
+    // every mechanical transformation of the key (`PG13`, `Pg13`, `pg13`).
+    await expect.element(page.getByText('PG-13', { exact: true })).toBeInTheDocument();
+    expect(page.getByText('pg13', { exact: true }).query()).toBeNull();
     // They are HANDLED keys, so the "Other manifest fields" count is unchanged
     // (still just the one novel key from the base fixture) — i.e. they did not
     // fall through to the raw-JSON dump.
@@ -289,7 +305,9 @@ describe('OnsiteReviewModal — store-visible copy is surfaced INLINE for the mo
     );
     await expect.element(page.getByText('My Onsite Block')).toBeInTheDocument();
     expect(page.getByText('The fastest way to remix a model').elements()).toHaveLength(0);
-    expect(page.getByText('generation').elements()).toHaveLength(0);
+    // Neither spelling renders when the manifest declares no category.
+    expect(page.getByText('generation', { exact: true }).elements()).toHaveLength(0);
+    expect(page.getByText('Generation', { exact: true }).elements()).toHaveLength(0);
   });
 });
 

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -46,8 +46,10 @@ import { isSensitiveBlockScope } from '~/shared/constants/block-scope.constants'
 import {
   MARKETPLACE_CATEGORIES,
   MARKETPLACE_CATEGORY_LABELS,
+  marketplaceCategoryLabel,
   type MarketplaceCategory,
 } from '~/server/services/blocks/marketplace-categories.constants';
+import { offsiteContentRatingLabel } from '~/shared/constants/browsingLevel.constants';
 import {
   SCOPE_DESCRIPTIONS,
   SLOT_DESCRIPTIONS,
@@ -1042,7 +1044,7 @@ function ManifestIdentity({ manifest }: { manifest: Record<string, unknown> }) {
               {category && (
                 <Tooltip label="Marketplace category">
                   <Badge color="gray" variant="light">
-                    {category}
+                    {marketplaceCategoryLabel(category)}
                   </Badge>
                 </Tooltip>
               )}
@@ -1052,7 +1054,7 @@ function ManifestIdentity({ manifest }: { manifest: Record<string, unknown> }) {
             {contentRating && (
               <Tooltip label="Content rating">
                 <Badge color={ratingColor(contentRating)} variant="filled">
-                  {contentRating}
+                  {offsiteContentRatingLabel(contentRating)}
                 </Badge>
               </Tooltip>
             )}

--- a/src/components/Apps/RelatedListings.tsx
+++ b/src/components/Apps/RelatedListings.tsx
@@ -6,12 +6,12 @@ import {
   isRelatedRailLoading,
   needsPopularTopUp,
   RELATED_LISTINGS_LIMIT,
+  relatedRailHeading,
   selectRelatedListings,
 } from '~/components/Apps/related-listings';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import {
   isMarketplaceCategory,
-  marketplaceCategoryLabel,
 } from '~/server/services/blocks/marketplace-categories.constants';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
@@ -37,12 +37,6 @@ import { trpc } from '~/utils/trpc';
  * queries load and when the rail resolves to nothing — so the detail page always
  * offers a way back into the store.
  */
-
-/** Null-tolerant wrapper over the SHARED label rule (raw fallback included). */
-function categoryLabel(category: string | null): string | null {
-  if (!category) return null;
-  return marketplaceCategoryLabel(category);
-}
 
 export interface RelatedListingsProps {
   /** The listing being viewed — excluded from the rail. */
@@ -90,8 +84,9 @@ export function RelatedListings({ listingId, category }: RelatedListingsProps) {
     popular: (popularQuery.data?.items ?? []) as ListingCard[],
   });
 
-  const label = categoryLabel(category);
-  const heading = label ? `More in ${label}` : 'More apps';
+  // 🔴 From the PURE module, so the blocking `unit` gate covers the one string on
+  // this surface that a reader actually sees the category in.
+  const heading = relatedRailHeading(category);
   const loading = isRelatedRailLoading({
     hasCategoryFilter: !!categoryFilter,
     categoryPending: categoryQuery.isPending,

--- a/src/components/Apps/RelatedListings.tsx
+++ b/src/components/Apps/RelatedListings.tsx
@@ -11,7 +11,7 @@ import {
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import {
   isMarketplaceCategory,
-  MARKETPLACE_CATEGORY_LABELS,
+  marketplaceCategoryLabel,
 } from '~/server/services/blocks/marketplace-categories.constants';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
@@ -38,9 +38,10 @@ import { trpc } from '~/utils/trpc';
  * offers a way back into the store.
  */
 
+/** Null-tolerant wrapper over the SHARED label rule (raw fallback included). */
 function categoryLabel(category: string | null): string | null {
   if (!category) return null;
-  return isMarketplaceCategory(category) ? MARKETPLACE_CATEGORY_LABELS[category] : category;
+  return marketplaceCategoryLabel(category);
 }
 
 export interface RelatedListingsProps {

--- a/src/components/Apps/__tests__/appListingDetailRows.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailRows.test.ts
@@ -54,8 +54,9 @@ describe('buildListingDetailRows — order', () => {
     const rows = buildListingDetailRows(detail(), { formatDate: fmt });
     const by = Object.fromEntries(rows.map((r) => [r.key, r]));
     expect(by.kind).toMatchObject({ label: 'Kind', value: 'On-site app' });
-    expect(by.category).toMatchObject({ label: 'Category', value: 'utility' });
-    expect(by.rating).toMatchObject({ label: 'Rating', value: 'pg' });
+    // 🔴 DISPLAY labels, not the stored enum. The fixture stores `utility` / `pg`.
+    expect(by.category).toMatchObject({ label: 'Category', value: 'Utility' });
+    expect(by.rating).toMatchObject({ label: 'Rating', value: 'PG' });
     // The SHARED ladder's word label plus the count, matching the model page's
     // "<label> (N)". Literal, not re-derived from `getRatingLabel`.
     expect(by.reviews).toMatchObject({
@@ -125,6 +126,117 @@ describe('buildListingDetailRows — order', () => {
         kindData: { kind: 'offsite', externalUrl: null },
       }).label
     );
+  });
+});
+
+/**
+ * 🔴 THE REPORTED DEFECT — "in the store preview, both the category and rating are
+ * lowercase". Both rows pushed the RAW stored enum while the card chip, the store
+ * filter buttons and both moderator selectors were already mapping the same two
+ * columns one component over.
+ *
+ * These are RED on the pre-fix builder: it emitted `utility` / `pg13`.
+ */
+describe('🔴 buildListingDetailRows — the category and rating rows render DISPLAY LABELS', () => {
+  const value = (rows: { key: string; value: string }[], key: string) =>
+    rows.find((r) => r.key === key)?.value;
+
+  /**
+   * The fixture deliberately does NOT reuse `detail()`'s defaults: `analytics` and
+   * `pg13` are pairwise distinct, distinct from the `utility`/`pg` used elsewhere in
+   * this file, and — the point of choosing `pg13` — its label `PG-13` is a string no
+   * mechanical transformation of the key produces, so an assertion on it cannot be
+   * satisfied by an implementation that uppercases or title-cases the enum.
+   */
+  it('🔴 the category row reads the label, not the stored value', () => {
+    const rows = buildListingDetailRows(detail({ category: 'analytics' }), { formatDate: fmt });
+    expect(value(rows, 'category')).toBe('Analytics');
+    expect(value(rows, 'category')).not.toBe('analytics');
+  });
+
+  it('🔴 the rating row reads the label, not the stored value', () => {
+    const rows = buildListingDetailRows(detail({ contentRating: 'pg13' }), { formatDate: fmt });
+    expect(value(rows, 'rating')).toBe('PG-13');
+    // The two near-miss fixes, named so neither can ship silently.
+    expect(value(rows, 'rating')).not.toBe('pg13');
+    expect(value(rows, 'rating')).not.toBe('PG13');
+  });
+
+  it('🔴 every rating on the ladder renders its own word', () => {
+    const expected: Array<[string, string]> = [
+      ['g', 'G'],
+      ['pg', 'PG'],
+      ['pg13', 'PG-13'],
+      ['r', 'R'],
+      ['x', 'X'],
+    ];
+    for (const [stored, label] of expected) {
+      const rows = buildListingDetailRows(detail({ contentRating: stored }), { formatDate: fmt });
+      expect(value(rows, 'rating')).toBe(label);
+    }
+  });
+
+  it('🔴 every category renders its own word', () => {
+    const expected: Array<[string, string]> = [
+      ['generation', 'Generation'],
+      ['games', 'Games'],
+      ['utility', 'Utility'],
+      ['discovery', 'Discovery'],
+      ['moderation', 'Moderation'],
+      ['analytics', 'Analytics'],
+      ['other', 'Other'],
+    ];
+    for (const [stored, label] of expected) {
+      const rows = buildListingDetailRows(detail({ category: stored }), { formatDate: fmt });
+      expect(value(rows, 'category')).toBe(label);
+    }
+  });
+
+  /**
+   * 🔴 THE FALLBACK, asserted at the ROW LEVEL and not only on the helpers.
+   *
+   * The row is DECORATION: an unknown value must degrade to the stored string. The
+   * two failure modes this rules out are a BLANK row (a lookup miss rendered
+   * straight) and a THROW (which, as this module's own header records, has already
+   * unmounted a moderator modal once).
+   *
+   * The fixtures are outside both taxonomies and share no substring with any label,
+   * so a mutant returning a constant cannot pass.
+   */
+  it('🔴 an unknown category/rating degrades to the raw value, and the rows still exist', () => {
+    const rows = buildListingDetailRows(
+      detail({ category: 'workflow-tools', contentRating: 'nc17' }),
+      { formatDate: fmt }
+    );
+    expect(keys(rows)).toContain('category');
+    expect(keys(rows)).toContain('rating');
+    expect(value(rows, 'category')).toBe('workflow-tools');
+    expect(value(rows, 'rating')).toBe('nc17');
+  });
+
+  it('🔴 an unknown value never throws (a details row must not blank the page)', () => {
+    expect(() =>
+      buildListingDetailRows(detail({ category: 'legacy_bucket', contentRating: 'xxx' }), {
+        formatDate: fmt,
+      })
+    ).not.toThrow();
+  });
+
+  /**
+   * The `preview` posture is the surface the tester was actually looking at (the
+   * moderator listing-media review renders an UNAPPROVED shadow listing). It drops
+   * the reviews/installs/updated rows but KEEPS category and rating — so the fix has
+   * to hold there too, and this is the case a fix applied only to the live posture
+   * would miss.
+   */
+  it('🔴 the preview posture renders the same labels as the live one', () => {
+    const args = detail({ category: 'discovery', contentRating: 'r' });
+    const live = buildListingDetailRows(args, { formatDate: fmt });
+    const preview = buildListingDetailRows(args, { preview: true, formatDate: fmt });
+    expect(value(preview, 'category')).toBe('Discovery');
+    expect(value(preview, 'rating')).toBe('R');
+    expect(value(preview, 'category')).toBe(value(live, 'category'));
+    expect(value(preview, 'rating')).toBe(value(live, 'rating'));
   });
 });
 

--- a/src/components/Apps/__tests__/listingLabelCallSites.test.ts
+++ b/src/components/Apps/__tests__/listingLabelCallSites.test.ts
@@ -1,0 +1,367 @@
+import fs from 'fs';
+import path from 'path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 🔒 THE ENROLMENT LEDGER for the two App-listing DISPLAY-LABEL rules.
+ *
+ * WHY THIS FILE EXISTS — measured, not hypothetical, and it is the same shape as
+ * its sibling `appsStoreAccessCallSites.test.ts`. A tester reported that the store
+ * preview showed a lowercase category and rating. The row they saw was one of
+ * THIRTEEN surfaces rendering `app_listings.category` / `.content_rating` raw or
+ * hand-derived, against five that were already mapped — the defect was never "this
+ * row is wrong", it was "a display rule has unenrolled call sites".
+ *
+ * Fixing the thirteen does not remove that condition. An adversarial audit of the
+ * fix reverted EVERY call site to raw and re-ran the cited suites: only 4 component
+ * + 6 unit tests went red, so 10 of 17 sites were reachable-but-unasserted. Worse,
+ * the fix's own mutation battery could not see it — every mutant targeted the two
+ * helper modules, so each one died to the helpers' own unit tests whether or not a
+ * single call site was wired correctly. The battery mutated the RULE, never its
+ * ENROLMENT.
+ *
+ * So this asserts the RELATIONSHIP: across every App-Blocks surface, NO JSX
+ * expression and NO Select-option `label` renders either field's raw value. It
+ * fails when the ledger GROWS (a new surface that forgot the helper) and when it
+ * SHRINKS (a mapped site reverted to raw) — including on the surfaces no component
+ * test can reach.
+ *
+ * 🔴 WHY STRUCTURAL, AND WHAT THAT BUYS THAT BEHAVIOURAL COVER CANNOT. The browser
+ * `component` project is REPORT-ONLY here — it runs as `preview / component-tests`,
+ * off the blocking path — and three of the raw sites live where no component test
+ * exists at all:
+ *   - `pages/apps/[appBlockId]/index.tsx` — a Next page with `getServerSideProps` +
+ *     `dbRead`, never import-testable; its sibling ledger already names it a known
+ *     blind spot.
+ *   - `components/Apps/RelatedListings.tsx` — its only test covers the pure
+ *     selection helper and never mounts the component.
+ *   - `components/Apps/AppListingDetailBody.tsx`'s meta-line badge, whose
+ *     assertion lives in the report-only tier.
+ * This file blocks. That is the whole point of it.
+ *
+ * 🔴 AND WHAT IT DOES NOT DO. A structural check proves a site does not render the
+ * RAW field; it cannot prove the helper was passed the right argument, and it would
+ * pass `marketplaceCategoryLabel(somethingElse)`. Behavioural cover lives alongside
+ * and is deliberately NOT replaced by it — `__tests__/appListingDetailRows.test.ts`,
+ * `__tests__/related-listings.test.ts`, `__tests__/offsiteSubmitFormConfig.test.ts`,
+ * and the four browser suites. Read this as a reversion guard, not as proof of
+ * correctness.
+ */
+
+const SRC = path.resolve(__dirname, '../../..');
+
+/** Every App-Blocks surface that can render a listing to a human. */
+const SCAN_ROOTS = ['components/Apps', 'components/AppBlocks', 'pages/apps'];
+
+/** The two free-text columns whose display rule this ledger enforces. */
+const GUARDED_FIELDS = ['category', 'contentRating'] as const;
+
+/**
+ * 🔴 ALIASED LOCALS — added because the first version of this scanner MISSED TWO
+ * REAL SITES, and a call-site mutation battery is what found them.
+ *
+ * Matching the field NAME only sees `x.contentRating` / `{category}`. It does not
+ * see a value that has been copied into a differently-named local first, and two
+ * live sites do exactly that: `OffsiteReviewQueue`'s `derivedRating` (from
+ * `deriveContentRatingFromAssets`) and `ManifestEditForm`'s `label: r` inside a
+ * `map` over the rating set. Reverting either to raw left this file GREEN — the
+ * ledger claimed a coverage it did not have.
+ *
+ * So a JSX child whose identifier merely ENDS in `Rating`/`Category` counts too.
+ * The net is deliberately wider than the two columns: this runs in a test, so a
+ * false positive costs one allowlist line with a reason, while a false negative
+ * costs a lowercase enum on a user's screen. Asymmetric on purpose.
+ */
+const ALIAS_SUFFIX = /(^|[a-z])(Rating|Category|rating|category)$/;
+
+/**
+ * Files whose raw render is CORRECT and must stay raw. Each needs a reason — an
+ * allowlist without one is how a real defect gets parked.
+ */
+const ALLOWED: Record<string, string> = {
+  // The moderator's manifest DIFF panel prints the author's manifest as raw JSON.
+  // The stored key is the thing under review there; mapping it would misrepresent
+  // the document the author actually submitted.
+  'components/Apps/reviewDiffPanels.tsx': 'raw manifest JSON diff — the key IS the subject',
+};
+
+/**
+ * Receivers whose `.category` is a DIFFERENT DOMAIN, exempted by RECEIVER rather
+ * than by file.
+ *
+ * 🔴 The distinction matters. A file-wide allowlist would stop scanning
+ * `ReportTabs.tsx` entirely, so a real listing category rendered raw in that same
+ * file would become invisible — an allowlist that silently widens is the second
+ * unenrolment channel this ledger is supposed to close. Exempting the receiver
+ * keeps every other expression in the file under the rule.
+ *
+ * `finding.category` is the automated-review FINDING's own taxonomy, rendered
+ * beside `finding.severity` and `finding.diffStatus`. It has no relationship to
+ * `app_listings.category` and no display-label map.
+ */
+const ALLOWED_RECEIVERS: Record<string, string> = {
+  finding: 'agent-review finding taxonomy — not the marketplace category column',
+};
+
+function parseTsx(fileName: string, text: string): ts.SourceFile {
+  return ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Does this expression READ one of the guarded fields, with nothing applied?
+ *
+ * Matches a bare identifier (`{category}` — the destructured form two review-modal
+ * badges used) and a property access (`{detail.contentRating}`, `{row.category}`).
+ * A call expression is NOT matched: `{marketplaceCategoryLabel(detail.category)}`
+ * is the fixed form, and it is the negative control below.
+ *
+ * 🔴 `?.` counts. `detail?.category` is the same raw read with a different token,
+ * and `ts.PropertyAccessExpression` covers both — asserted in the controls so the
+ * claim is measured rather than assumed.
+ */
+function rawFieldRead(node: ts.Node): string | null {
+  let e: ts.Node = node;
+  // Unwrap the shapes that do not change what reaches the DOM.
+  while (
+    ts.isParenthesizedExpression(e) ||
+    ts.isNonNullExpression(e) ||
+    ts.isAsExpression(e) ||
+    ts.isJsxExpression(e)
+  ) {
+    if (ts.isJsxExpression(e) && !e.expression) return null;
+    e = (e as { expression?: ts.Node }).expression ?? e;
+  }
+  if (ts.isIdentifier(e)) {
+    if ((GUARDED_FIELDS as readonly string[]).includes(e.text)) return e.text;
+    if (e.text in ALLOWED_RECEIVERS) return null;
+    if (ALIAS_SUFFIX.test(e.text)) return e.text;
+    return null;
+  }
+  if (
+    ts.isPropertyAccessExpression(e) &&
+    (GUARDED_FIELDS as readonly string[]).includes(e.name.text)
+  ) {
+    // Receiver-scoped exemption (see ALLOWED_RECEIVERS) — everything else in the
+    // same file stays under the rule.
+    const recv = e.expression;
+    if (ts.isIdentifier(recv) && recv.text in ALLOWED_RECEIVERS) return null;
+    return e.name.text;
+  }
+  return null;
+}
+
+/** Every raw render of a guarded field in one source, as `line:field` strings. */
+function findRawRenders(fileName: string, text: string): string[] {
+  const sf = parseTsx(fileName, text);
+  const hits: string[] = [];
+  const at = (n: ts.Node) => sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1;
+
+  const visit = (node: ts.Node): void => {
+    // (a) rendered as a JSX child — `<Badge>{row.category}</Badge>`
+    if (ts.isJsxExpression(node) && node.parent && ts.isJsxElement(node.parent)) {
+      const f = rawFieldRead(node);
+      if (f) hits.push(`${at(node)}:${f}`);
+    }
+    // (b) used as a Select/Chip option label — `{ value: r, label: r }`
+    if (ts.isPropertyAssignment(node) && ts.isIdentifier(node.name) && node.name.text === 'label') {
+      const f = rawFieldRead(node.initializer);
+      if (f) hits.push(`${at(node)}:${f}`);
+      /**
+       * 🔴 SHAPE RULE, not a name rule: an option label paired with a `value` in
+       * the same literal must be a LOOKUP or a LITERAL, never a bare identifier.
+       *
+       * This is the rule that catches `ALLOWED_CONTENT_RATINGS.map((r) => ({
+       * value: r, label: r }))` — the map variable is called `r`, so no amount of
+       * field-name matching reaches it, and reverting that site left the whole
+       * ledger green. Requiring the `value` sibling keeps the rule narrow: it only
+       * fires on option-list literals, not on every `label:` prop in the tree.
+       */
+      const obj = node.parent;
+      if (ts.isObjectLiteralExpression(obj) && ts.isIdentifier(node.initializer)) {
+        const hasValueSibling = obj.properties.some(
+          (p) => ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === 'value'
+        );
+        if (hasValueSibling) hits.push(`${at(node)}:bare-option-label`);
+      }
+      // The two near-miss re-derivations this PR removed: a label built by
+      // transforming the key rather than by looking it up.
+      const init = node.initializer;
+      if (
+        (ts.isCallExpression(init) &&
+          ts.isPropertyAccessExpression(init.expression) &&
+          /^(toUpperCase|toLowerCase)$/.test(init.expression.name.text)) ||
+        (ts.isBinaryExpression(init) && /charAt|slice/.test(init.getText(sf)))
+      ) {
+        hits.push(`${at(node)}:derived-label`);
+      }
+    }
+    node.forEachChild(visit);
+  };
+  visit(sf);
+  return hits;
+}
+
+// ---------------------------------------------------------------------------
+// 🔴 VALIDATE THE INSTRUMENT BEFORE READING ITS VERDICT.
+//
+// The assertion this file exists for is a ZERO, and a reassuring zero is
+// indistinguishable from a scanner wired to nothing. Both controls below run
+// against synthetic sources, so they cannot go stale when the real tree changes.
+// ---------------------------------------------------------------------------
+describe('🔴 the scanner (negative + positive controls)', () => {
+  it('POSITIVE CONTROL: it FINDS every raw shape this ledger is meant to catch', () => {
+    const bad = `
+      export function S(p: { category: string; contentRating: string }) {
+        const { category } = p;
+        return (
+          <div>
+            <Badge>{p.category}</Badge>
+            <Badge>{p.contentRating}</Badge>
+            <Badge>{category}</Badge>
+            <Badge>{p?.contentRating}</Badge>
+            <Select data={RATINGS.map((r) => ({ value: r, label: r.toUpperCase() }))} />
+            <Select data={CATS.map((c) => ({ value: c, label: c.charAt(0).toUpperCase() + c.slice(1) }))} />
+          </div>
+        );
+      }`;
+    const hits = findRawRenders('bad.tsx', bad).map((h) => h.split(':')[1]);
+    // Four raw reads (incl. the optional-chained one) + both derived labels.
+    expect(hits.filter((h) => h === 'category')).toHaveLength(2);
+    expect(hits.filter((h) => h === 'contentRating')).toHaveLength(2);
+    expect(hits.filter((h) => h === 'derived-label')).toHaveLength(2);
+  });
+
+  /**
+   * 🔴 THE REGRESSION CONTROL for this file's own measured blind spot. Both
+   * shapes below are real sites that the name-matching version scored SURVIVED —
+   * `derivedRating` in the review queue and `label: r` in the manifest editor.
+   * If either stops being caught, the ledger is lying about its coverage again.
+   */
+  it('POSITIVE CONTROL: it catches an ALIASED local and a bare option label', () => {
+    const aliased = `
+      export function S() {
+        const derivedRating = deriveContentRatingFromAssets(assets);
+        return (
+          <div>
+            <Badge>{derivedRating}</Badge>
+            <Select data={[...RATINGS].map((r) => ({ value: r, label: r }))} />
+          </div>
+        );
+      }`;
+    const hits = findRawRenders('aliased.tsx', aliased).map((h) => h.split(':')[1]);
+    expect(hits).toContain('derivedRating');
+    expect(hits).toContain('bare-option-label');
+  });
+
+  it('the bare-option-label rule needs a `value` SIBLING (it is not "every label:")', () => {
+    // A `label` prop that is not part of an option literal is ordinary React and
+    // must not be flagged, or the rule would be allowlisted into uselessness.
+    const notAnOption = `
+      export function S() {
+        return <Tooltip label={heading}><Button label={actionLabel} /></Tooltip>;
+      }`;
+    expect(findRawRenders('notAnOption.tsx', notAnOption)).toEqual([]);
+  });
+
+  it('NEGATIVE CONTROL: it does NOT flag the mapped form', () => {
+    const good = `
+      export function S(p: { category: string; contentRating: string }) {
+        return (
+          <div>
+            <Badge>{marketplaceCategoryLabel(p.category)}</Badge>
+            <Badge>{offsiteContentRatingLabel(p.contentRating)}</Badge>
+            <Select data={RATINGS.map((r) => ({ value: r, label: offsiteContentRatingLabel(r) }))} />
+          </div>
+        );
+      }`;
+    expect(findRawRenders('good.tsx', good)).toEqual([]);
+  });
+
+  it('does not mistake a NON-rendering use of the field for a render', () => {
+    // Filter values, query inputs, mutation args and comparisons are not renders —
+    // a scanner that flagged them would be unusable and would get allowlisted away.
+    const neutral = `
+      export function S(p: { category: string; contentRating: string }) {
+        const filter = isMarketplaceCategory(p.category) ? p.category : undefined;
+        mutate({ category: p.category, contentRating: p.contentRating });
+        if (p.category !== other.category) log(p.contentRating);
+        return <Select value={p.category} data={OPTIONS} />;
+      }`;
+    expect(findRawRenders('neutral.tsx', neutral)).toEqual([]);
+  });
+});
+
+const SCANNED = SCAN_ROOTS.flatMap((root) => walk(path.join(SRC, root))).map((file) => ({
+  rel: path.relative(SRC, file).split(path.sep).join('/'),
+  raw: fs.readFileSync(file, 'utf8'),
+}));
+
+describe('🔒 no App-Blocks surface renders a raw category / contentRating', () => {
+  /**
+   * 🔴 A ROW FLOOR ON THE SCANNER ITSELF. Without it, a `SCAN_ROOTS` typo or a
+   * directory rename turns this whole file into a green no-op — the exact failure
+   * mode the ledger is here to prevent, one level up. The number is deliberately
+   * well below the real count so a normal deletion cannot trip it.
+   */
+  it('POSITIVE CONTROL: the scan actually visited the App-Blocks tree', () => {
+    expect(SCANNED.length).toBeGreaterThan(60);
+    const rels = SCANNED.map((s) => s.rel);
+    // Named files, so a root that silently stops resolving is caught by identity
+    // and not only by count.
+    expect(rels).toContain('components/Apps/appListingDetailRows.ts');
+    expect(rels).toContain('components/Apps/OffsiteReviewQueue.tsx');
+    expect(rels).toContain('pages/apps/[appBlockId]/index.tsx');
+  });
+
+  it('🔴 every render goes through a display-label helper', () => {
+    const offenders = SCANNED.flatMap(({ rel, raw }) =>
+      rel in ALLOWED ? [] : findRawRenders(rel, raw).map((h) => `${rel}:${h}`)
+    );
+    // Listed in full on failure: the message IS the fix instructions.
+    expect(offenders).toEqual([]);
+  });
+
+  it('the allowlist stays small and every entry still exists', () => {
+    // An allowlist that can grow silently is a second unenrolment channel.
+    expect(Object.keys(ALLOWED)).toHaveLength(1);
+    expect(Object.keys(ALLOWED_RECEIVERS)).toEqual(['finding']);
+    for (const rel of Object.keys(ALLOWED)) {
+      expect(fs.existsSync(path.join(SRC, rel))).toBe(true);
+      expect(ALLOWED[rel].length).toBeGreaterThan(20);
+    }
+    for (const reason of Object.values(ALLOWED_RECEIVERS)) {
+      expect(reason.length).toBeGreaterThan(20);
+    }
+  });
+
+  /**
+   * 🔴 The receiver exemption is scoped, and this proves it — otherwise "exempt by
+   * receiver" would be indistinguishable from "exempt the whole file", which is
+   * the weaker thing I explicitly did not want.
+   */
+  it('the receiver exemption does NOT disable the rest of its file', () => {
+    const mixed = `
+      export function S() {
+        return (
+          <div>
+            <Badge>{finding.category}</Badge>
+            <Badge>{listing.category}</Badge>
+          </div>
+        );
+      }`;
+    const hits = findRawRenders('mixed.tsx', mixed);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatch(/category$/);
+  });
+});

--- a/src/components/Apps/__tests__/offsiteSubmitFormConfig.test.ts
+++ b/src/components/Apps/__tests__/offsiteSubmitFormConfig.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  OFFSITE_CATEGORY_OPTIONS,
+  OFFSITE_CONTENT_RATING_OPTIONS,
   OFFSITE_SUBMIT_LIMITS,
   emptyOffsiteSubmitForm,
   isOffsiteSubmitFormValid,
@@ -99,5 +101,57 @@ describe('validateOffsiteSubmitForm', () => {
   it('rejects an unknown content rating', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(validateOffsiteSubmitForm({ ...valid, contentRating: 'xxx' as any }).contentRating).toBeDefined();
+  });
+});
+
+/**
+ * 🔴 CALL-SITE COVERAGE for the two `<Select>` option lists.
+ *
+ * These two consts are the DATA both the standalone submit wizard
+ * (`ExternalSubmitForm`) and the listing edit form (`ExternalListingEditForm`)
+ * hand to Mantine, so pinning them here guards both surfaces without rendering
+ * either — and it guards the WIRING, not the label maps. A mutant that points
+ * either const back at its old re-derivation (`c.charAt(0).toUpperCase() +
+ * c.slice(1)` / `r.toUpperCase()`) leaves both label maps intact and every
+ * helper unit test green; only these assertions move.
+ *
+ * The `value` half is asserted alongside the `label` half deliberately: the
+ * whole failure mode being guarded is a surface that shows the stored key, so a
+ * test that only looked at labels could not tell a correct option list from one
+ * that had silently swapped the two halves.
+ */
+describe('🔴 the Select option lists render LABELS, never the stored key', () => {
+  it('category options pair each stored value with its display label', () => {
+    expect(OFFSITE_CATEGORY_OPTIONS).toEqual([
+      { value: 'generation', label: 'Generation' },
+      { value: 'games', label: 'Games' },
+      { value: 'utility', label: 'Utility' },
+      { value: 'discovery', label: 'Discovery' },
+      { value: 'moderation', label: 'Moderation' },
+      { value: 'analytics', label: 'Analytics' },
+      { value: 'other', label: 'Other' },
+    ]);
+  });
+
+  /**
+   * 🔴 `pg13` is the discriminating rung and the reason this assertion is not a
+   * loop: its label `PG-13` is the one value no transformation of the key
+   * produces, so it separates the shared map from BOTH near-miss re-derivations
+   * — the `PG13` this const used to ship, and the `Pg13` a title-case would give.
+   */
+  it('rating options pair each stored value with its display label', () => {
+    expect(OFFSITE_CONTENT_RATING_OPTIONS).toEqual([
+      { value: 'g', label: 'G' },
+      { value: 'pg', label: 'PG' },
+      { value: 'pg13', label: 'PG-13' },
+      { value: 'r', label: 'R' },
+      { value: 'x', label: 'X' },
+    ]);
+  });
+
+  it('no option anywhere renders its own stored key as the label', () => {
+    for (const o of [...OFFSITE_CATEGORY_OPTIONS, ...OFFSITE_CONTENT_RATING_OPTIONS]) {
+      expect(o.label).not.toBe(o.value);
+    }
   });
 });

--- a/src/components/Apps/__tests__/related-listings.test.ts
+++ b/src/components/Apps/__tests__/related-listings.test.ts
@@ -3,6 +3,7 @@ import {
   isRelatedRailLoading,
   needsPopularTopUp,
   RELATED_LISTINGS_LIMIT,
+  relatedRailHeading,
   selectRelatedListings,
 } from '~/components/Apps/related-listings';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
@@ -186,5 +187,44 @@ describe('isRelatedRailLoading — no "2 cards → loader → 6 cards" flash', (
         popularPending: false,
       })
     ).toBe(false);
+  });
+});
+
+/**
+ * 🔴 CALL-SITE COVERAGE — the rail heading (and its `aria-label`, the same string).
+ *
+ * This is the one place the rail shows a reader a category, and until the string
+ * moved into this pure module it was the only `marketplaceCategoryLabel` call
+ * site with no reachable assertion anywhere in the repo.
+ *
+ * These assertions guard the WIRING, not the label map: they fail if this
+ * function stops calling the shared helper (renders `utility`), if it calls the
+ * wrong one, or if the surrounding sentence is reworded — none of which any test
+ * of `marketplaceCategoryLabel` itself can see.
+ */
+describe('🔴 relatedRailHeading — the rail names the category by its LABEL', () => {
+  it('a known category is named by its display label, inside the full sentence', () => {
+    // Whole normalised string, not a substring: a check for "Utility" alone would
+    // be satisfied by a heading that had lost the "More in" half.
+    expect(relatedRailHeading('utility')).toBe('More in Utility');
+    // A second rung, so a mutant hardcoding one label has to move an assertion.
+    expect(relatedRailHeading('generation')).toBe('More in Generation');
+  });
+
+  it('🔴 never renders the raw stored key', () => {
+    expect(relatedRailHeading('utility')).not.toContain('utility');
+    expect(relatedRailHeading('analytics')).not.toContain('analytics');
+  });
+
+  it('an unknown category still names itself, via the shared raw fallback', () => {
+    // The rail below really is filtered by this value, so naming it is honest —
+    // and a blank/`More in ` heading would be the visible bug.
+    expect(relatedRailHeading('workflow-tools')).toBe('More in workflow-tools');
+  });
+
+  it('no category at all falls back to the generic heading, not a hole', () => {
+    expect(relatedRailHeading(null)).toBe('More apps');
+    expect(relatedRailHeading(undefined)).toBe('More apps');
+    expect(relatedRailHeading('')).toBe('More apps');
   });
 });

--- a/src/components/Apps/appListingDetailRows.ts
+++ b/src/components/Apps/appListingDetailRows.ts
@@ -36,6 +36,8 @@
  */
 
 import { getRatingLabel } from '~/utils/rating-label';
+import { marketplaceCategoryLabel } from '~/server/services/blocks/marketplace-categories.constants';
+import { offsiteContentRatingLabel } from '~/shared/constants/browsingLevel.constants';
 import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
 
 /** A single label/value row of the Details panel. */
@@ -90,11 +92,25 @@ export function buildListingDetailRows(
 
   rows.push({ key: 'kind', label: 'Kind', value: kindLabel(detail) });
 
+  // 🔴 BOTH VALUES GO THROUGH THEIR DISPLAY-LABEL MAP. These two rows shipped
+  // rendering the RAW stored enum — a tester read "utility" and "pg13" in the store
+  // preview — while the card chip, the filter buttons and both mod selectors were
+  // already mapping the same column one component over. Each helper keeps the raw
+  // value as its fallback, so an unknown/legacy rating or a category added after
+  // this client shipped degrades to the stored string rather than to a blank row.
   if (detail.category) {
-    rows.push({ key: 'category', label: 'Category', value: detail.category });
+    rows.push({
+      key: 'category',
+      label: 'Category',
+      value: marketplaceCategoryLabel(detail.category),
+    });
   }
   if (detail.contentRating) {
-    rows.push({ key: 'rating', label: 'Rating', value: detail.contentRating });
+    rows.push({
+      key: 'rating',
+      label: 'Rating',
+      value: offsiteContentRatingLabel(detail.contentRating),
+    });
   }
 
   if (!opts.preview) {

--- a/src/components/Apps/offsiteSubmitFormConfig.ts
+++ b/src/components/Apps/offsiteSubmitFormConfig.ts
@@ -14,8 +14,10 @@ import { SLUG_REGEX } from '~/server/schema/blocks/publish-request.schema';
 import {
   MARKETPLACE_CATEGORIES,
   isMarketplaceCategory,
+  marketplaceCategoryLabel,
   type MarketplaceCategory,
 } from '~/server/services/blocks/marketplace-categories.constants';
+import { offsiteContentRatingLabel } from '~/shared/constants/browsingLevel.constants';
 import {
   SCOPE_JUSTIFICATION_MAX_LENGTH,
   SENSITIVE_TOKEN_SCOPES,
@@ -80,16 +82,31 @@ export type OffsiteSubmitFormValues = {
 
 export type OffsiteSubmitFormErrors = Partial<Record<keyof OffsiteSubmitFormValues, string>>;
 
-/** Category `<Select>` data (value + human label). */
+/**
+ * Category `<Select>` data (value + human label).
+ *
+ * 🔴 The label comes from the SHARED map, not from re-deriving it here. This used
+ * to title-case the key (`c.charAt(0).toUpperCase() + c.slice(1)`), which happens
+ * to agree with `MARKETPLACE_CATEGORY_LABELS` for today's seven values and would
+ * silently stop agreeing for the first label that is not a plain capitalisation.
+ * An author picking "Analytics" here and a reader seeing something else in the
+ * store is the same one-rule-N-sites defect this whole change closes.
+ */
 export const OFFSITE_CATEGORY_OPTIONS: Array<{ value: MarketplaceCategory; label: string }> =
   MARKETPLACE_CATEGORIES.map((c) => ({
     value: c,
-    label: c.charAt(0).toUpperCase() + c.slice(1),
+    label: marketplaceCategoryLabel(c),
   }));
 
-/** Content-rating `<Select>` data. */
+/**
+ * Content-rating `<Select>` data.
+ *
+ * 🔴 Was `r.toUpperCase()`, which spelled the middle rung `PG13` — a spelling that
+ * exists nowhere else on the site (`browsingLevelLabels` says `PG-13`). The author
+ * picking the rating and the visitor reading it now see the same word.
+ */
 export const OFFSITE_CONTENT_RATING_OPTIONS: Array<{ value: OffsiteContentRating; label: string }> =
-  OFFSITE_CONTENT_RATINGS.map((r) => ({ value: r, label: r.toUpperCase() }));
+  OFFSITE_CONTENT_RATINGS.map((r) => ({ value: r, label: offsiteContentRatingLabel(r) }));
 
 /** The blank initial form state (SFW default, no category, no client / scopes). */
 export function emptyOffsiteSubmitForm(): OffsiteSubmitFormValues {

--- a/src/components/Apps/related-listings.ts
+++ b/src/components/Apps/related-listings.ts
@@ -24,6 +24,7 @@
  * grid already uses.
  */
 
+import { marketplaceCategoryLabel } from '~/server/services/blocks/marketplace-categories.constants';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 
 /** Rail cap — one row at the store's widest breakpoint, no "load more". */
@@ -111,4 +112,24 @@ export function isRelatedRailLoading(opts: {
   return (
     (opts.hasCategoryFilter && opts.categoryPending) || (opts.wantTopUp && opts.popularPending)
   );
+}
+
+/**
+ * The rail's HEADING — and its `aria-label`, which is the same string.
+ *
+ * 🔴 Lives here, not inline in the component, for this module's stated reason:
+ * the browser-mode component suites are not run in CI, so an expression that
+ * renders a user-facing string is only actually GUARDED once it is pure. It was
+ * inline, and that made `RelatedListings` the one call site of
+ * `marketplaceCategoryLabel` with no reachable assertion anywhere.
+ *
+ * Null/unknown handling is the rail's own, and deliberately asymmetric with the
+ * chip surfaces: a listing with NO category gets the generic "More apps" rather
+ * than a heading with a hole in it, while an UNKNOWN category still names itself
+ * (via the shared helper's raw fallback), because the rail beneath it really is
+ * filtered by that value.
+ */
+export function relatedRailHeading(category: string | null | undefined): string {
+  if (!category) return 'More apps';
+  return `More in ${marketplaceCategoryLabel(category)}`;
 }

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -51,6 +51,7 @@ import {
 import { dbRead } from '~/server/db/client';
 import { resolveStoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { offsiteContentRatingLabel } from '~/shared/constants/browsingLevel.constants';
 import { hasInstallSlot } from '~/shared/constants/slot-registry';
 import { trpc } from '~/utils/trpc';
 
@@ -339,7 +340,7 @@ export default function AppDetailPage() {
                     )}
                     {detail.contentRating && (
                       <Badge variant="light" color="gray" size="sm">
-                        {detail.contentRating}
+                        {offsiteContentRatingLabel(detail.contentRating)}
                       </Badge>
                     )}
                   </Group>

--- a/src/server/services/blocks/__tests__/marketplace-categories.constants.test.ts
+++ b/src/server/services/blocks/__tests__/marketplace-categories.constants.test.ts
@@ -3,6 +3,7 @@ import {
   isMarketplaceCategory,
   MARKETPLACE_CATEGORIES,
   MARKETPLACE_CATEGORY_LABELS,
+  marketplaceCategoryLabel,
 } from '../marketplace-categories.constants';
 import { listAvailableSchema } from '~/server/schema/blocks/subscription.schema';
 
@@ -50,6 +51,52 @@ describe('marketplace-categories taxonomy (F-E E3)', () => {
     // Rejects a value outside the taxonomy — proving the enum is derived from
     // the const, not a hand-maintained copy that could silently drift.
     expect(() => listAvailableSchema.parse({ category: 'not-a-category' })).toThrow();
+  });
+
+  /**
+   * 🔴 `marketplaceCategoryLabel` — the ONE display rule, extracted because it had
+   * been open-coded at four sites and skipped at four more, which is how the raw
+   * lowercase `utility` reached a tester in the store preview.
+   *
+   * The expected words are LITERALS, not `MARKETPLACE_CATEGORY_LABELS[c]` — reading
+   * the expectation out of the map under test would assert only that the map equals
+   * itself, and would stay green through a mutant that swapped two labels.
+   */
+  it('🔴 marketplaceCategoryLabel maps every taxonomy value to its display label', () => {
+    expect(marketplaceCategoryLabel('generation')).toBe('Generation');
+    expect(marketplaceCategoryLabel('games')).toBe('Games');
+    expect(marketplaceCategoryLabel('utility')).toBe('Utility');
+    expect(marketplaceCategoryLabel('discovery')).toBe('Discovery');
+    expect(marketplaceCategoryLabel('moderation')).toBe('Moderation');
+    expect(marketplaceCategoryLabel('analytics')).toBe('Analytics');
+    expect(marketplaceCategoryLabel('other')).toBe('Other');
+  });
+
+  it('🔴 no category renders its raw stored value (the reported defect)', () => {
+    for (const c of MARKETPLACE_CATEGORIES) {
+      expect(marketplaceCategoryLabel(c)).not.toBe(c);
+    }
+  });
+
+  /**
+   * 🔴 THE FALLBACK — the guard `AppBlockCard` already carried and the one most
+   * likely to be dropped when the helper is "simplified".
+   *
+   * `app_blocks.category` / `app_listings.category` is FREE TEXT, and adding a
+   * category is a one-line const edit with no migration, so a client older than the
+   * taxonomy will meet a value it has no label for. It must show the stored string —
+   * a blank chip is a bug report, a throw takes the surrounding surface down.
+   *
+   * The fixtures are pairwise distinct and share no substring with any label above,
+   * so a mutant returning a hardcoded constant cannot satisfy them.
+   */
+  it('🔴 an unknown category falls back to the RAW value — never blank, never a throw', () => {
+    expect(marketplaceCategoryLabel('workflow-tools')).toBe('workflow-tools');
+    expect(marketplaceCategoryLabel('legacy_bucket')).toBe('legacy_bucket');
+    expect(() => marketplaceCategoryLabel('workflow-tools')).not.toThrow();
+    // Negative control for the two assertions above: a blanket `(c) => c` would pass
+    // them while leaving the reported bug live.
+    expect(marketplaceCategoryLabel('utility')).not.toBe('utility');
   });
 
   it('listAvailable sort defaults to rating and rejects unknown sorts', () => {

--- a/src/server/services/blocks/marketplace-categories.constants.ts
+++ b/src/server/services/blocks/marketplace-categories.constants.ts
@@ -44,3 +44,27 @@ export function isMarketplaceCategory(value: unknown): value is MarketplaceCateg
     (MARKETPLACE_CATEGORIES as readonly string[]).includes(value)
   );
 }
+
+/**
+ * Stored category value → its DISPLAY label, with a raw fallback.
+ *
+ * 🔴 THE ONE PLACE this rule lives. `app_blocks.category` / `app_listings.category`
+ * is a FREE-TEXT column, so the value a surface receives is a `string`, not the
+ * `MarketplaceCategory` union — every renderer therefore needs the same
+ * guard-then-map-else-raw shape, and this is it.
+ *
+ * It exists because the rule was open-coded instead: two byte-identical private
+ * `categoryLabel` helpers (`AppBlockCard`, `RelatedListings`), one title-casing
+ * re-derivation (`offsiteSubmitFormConfig`'s `OFFSITE_CATEGORY_OPTIONS`), and five
+ * sites that skipped it entirely and rendered the raw lowercase enum to a user.
+ * A predicate open-coded at N sites is wrong at N−1 of them; import this instead
+ * of writing the guard again.
+ *
+ * FALLBACK IS DELIBERATE — an unknown/legacy value renders RAW, never blank and
+ * never a throw. Adding a category is a one-line const edit with no migration, so
+ * an older client will meet a category it has no label for; a chip reading
+ * `something-new` is honest, an empty chip is a bug report.
+ */
+export function marketplaceCategoryLabel(category: string): string {
+  return isMarketplaceCategory(category) ? MARKETPLACE_CATEGORY_LABELS[category] : category;
+}

--- a/src/shared/constants/__tests__/offsite-content-rating-labels.test.ts
+++ b/src/shared/constants/__tests__/offsite-content-rating-labels.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { NsfwLevel } from '~/server/common/enums';
+import {
+  browsingLevelLabels,
+  isOffsiteContentRating,
+  OFFSITE_CONTENT_RATING_LABELS,
+  OFFSITE_CONTENT_RATING_LADDER,
+  offsiteContentRatingLabel,
+} from '~/shared/constants/browsingLevel.constants';
+import { OFFSITE_CONTENT_RATINGS } from '~/server/schema/blocks/offsite-listing.schema';
+
+/**
+ * App-listing CONTENT-RATING display labels (blocking `unit` project).
+ *
+ * The stored value (`app_listings.content_rating`) is one of five lowercase keys.
+ * Until this map existed, three surfaces each invented their own rendering of them:
+ * the store detail rail and the moderator queue printed the raw key (a tester read
+ * "the category and rating are lowercase" in the store preview), the off-site submit
+ * form uppercased it to `PG13`, and title-casing would have produced `Pg13`.
+ *
+ * These assertions pin the WORDS as literals. They are deliberately NOT derived from
+ * the map under test — an expectation read out of the implementation asserts only
+ * that the implementation equals itself.
+ */
+
+describe('OFFSITE_CONTENT_RATING_LABELS — the taxonomy is fully and exclusively covered', () => {
+  it('the ladder under test is the schema taxonomy (not a drifted copy)', () => {
+    expect([...OFFSITE_CONTENT_RATING_LADDER]).toEqual([...OFFSITE_CONTENT_RATINGS]);
+  });
+
+  it('every rating has a label, and there are no labels for non-existent ratings', () => {
+    for (const r of OFFSITE_CONTENT_RATING_LADDER) {
+      expect(OFFSITE_CONTENT_RATING_LABELS[r]).toBeTruthy();
+    }
+    expect(Object.keys(OFFSITE_CONTENT_RATING_LABELS).sort()).toEqual(
+      [...OFFSITE_CONTENT_RATING_LADDER].sort()
+    );
+  });
+
+  /**
+   * 🔴 The literal words, each rung asserted separately.
+   *
+   * Every expected string here is DISTINCT from every other, and — critically —
+   * distinct from its own key under any mechanical transformation of that key. A
+   * mutant that hardcodes one label, or that swaps two of them, moves exactly one
+   * of these assertions and names it in the failure.
+   */
+  it('🔴 each rung reads its chosen word', () => {
+    expect(OFFSITE_CONTENT_RATING_LABELS.g).toBe('G');
+    expect(OFFSITE_CONTENT_RATING_LABELS.pg).toBe('PG');
+    expect(OFFSITE_CONTENT_RATING_LABELS.pg13).toBe('PG-13');
+    expect(OFFSITE_CONTENT_RATING_LABELS.r).toBe('R');
+    expect(OFFSITE_CONTENT_RATING_LABELS.x).toBe('X');
+  });
+
+  /**
+   * 🔴 NO LABEL IS DERIVABLE FROM ITS KEY. This is the assertion the whole map
+   * exists for: the reported defect was a surface rendering the key, and the
+   * near-miss fixes are `toUpperCase()` (`PG13`) and title-case (`Pg13`).
+   *
+   * `pg13` is the rung that discriminates — it is the ONLY key whose label is not
+   * simply its own uppercase — so it is asserted against both transformations by
+   * name rather than left to a loop that `g`/`r`/`x` would satisfy trivially.
+   */
+  it('🔴 `pg13` is spelled with a hyphen — no transformation of the key produces it', () => {
+    expect(OFFSITE_CONTENT_RATING_LABELS.pg13).not.toBe('pg13');
+    expect(OFFSITE_CONTENT_RATING_LABELS.pg13).not.toBe('pg13'.toUpperCase());
+    expect(OFFSITE_CONTENT_RATING_LABELS.pg13).not.toBe('Pg13');
+    expect(OFFSITE_CONTENT_RATING_LABELS.pg13).toContain('-');
+  });
+
+  it('every label differs from its own raw key (nothing renders the enum)', () => {
+    for (const r of OFFSITE_CONTENT_RATING_LADDER) {
+      expect(OFFSITE_CONTENT_RATING_LABELS[r]).not.toBe(r);
+    }
+  });
+
+  it('the five labels are pairwise distinct', () => {
+    const labels = OFFSITE_CONTENT_RATING_LADDER.map((r) => OFFSITE_CONTENT_RATING_LABELS[r]);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+});
+
+/**
+ * 🔴 SEAM GUARD — a RELATIONSHIP, not a component.
+ *
+ * Four of the five rungs name a maturity level Civitai already spells for users on
+ * models, images and posts (`browsingLevelLabels`). Pinning them to that map is
+ * what stops the store growing a SECOND maturity vocabulary: rewording either side
+ * alone goes red, and rewording both together (the legitimate case) stays green.
+ *
+ * `g` is deliberately absent from this check — the browsing ladder has no bit for
+ * it, which is precisely why it is the one word this map had to choose on its own.
+ */
+describe('🔴 the rating labels ARE the site-wide maturity vocabulary', () => {
+  it('the four overlapping rungs are byte-identical to browsingLevelLabels', () => {
+    expect(OFFSITE_CONTENT_RATING_LABELS.pg).toBe(browsingLevelLabels[NsfwLevel.PG]);
+    expect(OFFSITE_CONTENT_RATING_LABELS.pg13).toBe(browsingLevelLabels[NsfwLevel.PG13]);
+    expect(OFFSITE_CONTENT_RATING_LABELS.r).toBe(browsingLevelLabels[NsfwLevel.R]);
+    expect(OFFSITE_CONTENT_RATING_LABELS.x).toBe(browsingLevelLabels[NsfwLevel.X]);
+  });
+
+  it('`g` is the one rung with no browsing-level counterpart, and reads "G"', () => {
+    expect(Object.values(browsingLevelLabels)).not.toContain('G');
+    expect(OFFSITE_CONTENT_RATING_LABELS.g).toBe('G');
+  });
+});
+
+describe('isOffsiteContentRating', () => {
+  it('accepts exactly the ladder and rejects everything else', () => {
+    for (const r of OFFSITE_CONTENT_RATING_LADDER) expect(isOffsiteContentRating(r)).toBe(true);
+    // `xxx` is a real rung of the BROWSING ladder that this taxonomy does not have —
+    // the most likely wrong value to arrive here, so it is the guard's control.
+    expect(isOffsiteContentRating('xxx')).toBe(false);
+    expect(isOffsiteContentRating('PG-13')).toBe(false);
+    expect(isOffsiteContentRating('')).toBe(false);
+    expect(isOffsiteContentRating(null)).toBe(false);
+    expect(isOffsiteContentRating(13)).toBe(false);
+  });
+});
+
+describe('offsiteContentRatingLabel', () => {
+  it('maps every known rating to its label', () => {
+    expect(offsiteContentRatingLabel('g')).toBe('G');
+    expect(offsiteContentRatingLabel('pg')).toBe('PG');
+    expect(offsiteContentRatingLabel('pg13')).toBe('PG-13');
+    expect(offsiteContentRatingLabel('r')).toBe('R');
+    expect(offsiteContentRatingLabel('x')).toBe('X');
+  });
+
+  /**
+   * 🔴 THE FALLBACK — the guard most likely to be dropped as "dead code".
+   *
+   * `contentRating` is a nullable free-text column, and the backfill service
+   * explicitly handles "a poison row (an out-of-domain contentRating)", so an
+   * unknown value genuinely reaches renderers. It must degrade to the STORED
+   * STRING: blank is a bug report, and a throw inside a details row unmounts the
+   * page it decorates.
+   *
+   * The three fixtures are pairwise distinct AND distinct from every label the
+   * assertions above name, so none of them can be produced by a mutant that
+   * hardcodes a constant.
+   */
+  it('🔴 an unknown rating falls back to the RAW value — never blank, never a throw', () => {
+    expect(offsiteContentRatingLabel('nc17')).toBe('nc17');
+    expect(offsiteContentRatingLabel('xxx')).toBe('xxx');
+    expect(offsiteContentRatingLabel('unrated-legacy')).toBe('unrated-legacy');
+    expect(() => offsiteContentRatingLabel('nc17')).not.toThrow();
+  });
+
+  it('🔴 the fallback is not a blanket passthrough — a KNOWN value is still mapped', () => {
+    // Negative control for the test above: if the function were `(r) => r` every
+    // fallback assertion would pass while the reported bug remained live.
+    expect(offsiteContentRatingLabel('pg13')).not.toBe('pg13');
+  });
+
+  it('the empty string passes through rather than becoming a label', () => {
+    expect(offsiteContentRatingLabel('')).toBe('');
+  });
+});

--- a/src/shared/constants/browsingLevel.constants.ts
+++ b/src/shared/constants/browsingLevel.constants.ts
@@ -117,6 +117,64 @@ export const OFFSITE_CONTENT_RATING_LADDER = ['g', 'pg', 'pg13', 'r', 'x'] as co
 export type OffsiteRatingValue = (typeof OFFSITE_CONTENT_RATING_LADDER)[number];
 
 /**
+ * Off-site content rating → its USER-FACING label. The counterpart of
+ * `MARKETPLACE_CATEGORY_LABELS`, and the single source of truth for how a stored
+ * rating is spelled to a human.
+ *
+ * 🔴 THE WORDS ARE NOT DERIVED FROM THE ENUM, AND MUST NOT BE. Three surfaces had
+ * each invented their own transformation of the same five values — the store
+ * detail rail and the moderator queue rendered the raw key (`pg13`), the off-site
+ * submit form uppercased it (`PG13`), and title-casing it would give `Pg13`. All
+ * three are spellings this site uses NOWHERE else.
+ *
+ * The chosen words are `browsingLevelLabels` — the maturity vocabulary Civitai
+ * ALREADY shows users on models, images and posts. Four of the five rungs
+ * (`pg`/`pg13`/`r`/`x`) map onto an `NsfwLevel` with an existing label, so they
+ * reuse it verbatim (`PG`, `PG-13`, `R`, `X`) and one app cannot read "PG-13" on
+ * a model page and "pg13" in the store. `g` is the one rung the browsing ladder
+ * has no bit for — it shares `pg`'s PG ceiling but is a distinct stored value a
+ * moderator can pick — so it takes the natural next rung of the same
+ * film-classification ladder the other four already are: `G`.
+ *
+ * Spelled out LITERALLY here rather than read out of `browsingLevelLabels`, so
+ * this map answers "what does the store say?" on its own — and a unit test pins
+ * the four overlapping rungs to `browsingLevelLabels` as a RELATIONSHIP, so
+ * rewording either vocabulary alone goes red instead of silently diverging.
+ *
+ * ⚠️ `PG-13` carries a HYPHEN. That is the site's existing spelling and it is the
+ * whole point: no mechanical transformation of the string `pg13` produces it.
+ */
+export const OFFSITE_CONTENT_RATING_LABELS: Record<OffsiteRatingValue, string> = {
+  g: 'G',
+  pg: 'PG',
+  pg13: 'PG-13',
+  r: 'R',
+  x: 'X',
+};
+
+/** Type guard — is the given value one of the known off-site content ratings. */
+export function isOffsiteContentRating(value: unknown): value is OffsiteRatingValue {
+  return (
+    typeof value === 'string' &&
+    (OFFSITE_CONTENT_RATING_LADDER as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Stored content-rating value → its display label, with a RAW FALLBACK.
+ *
+ * `AppListing.contentRating` is a nullable free-text column (`string | null`), not
+ * the closed union — the backfill service explicitly guards against "a poison row
+ * (an out-of-domain contentRating)" — so a renderer can be handed a value outside
+ * the ladder. Mirrors `marketplaceCategoryLabel`: map it if known, otherwise show
+ * the raw string. Never blank, never a throw; a details row is decoration and must
+ * not be able to blank the page it decorates.
+ */
+export function offsiteContentRatingLabel(rating: string): string {
+  return isOffsiteContentRating(rating) ? OFFSITE_CONTENT_RATING_LABELS[rating] : rating;
+}
+
+/**
  * Map an off-site content rating (`g|pg|pg13|r|x` — nullable) to the MAXIMUM
  * `NsfwLevel` bit its published assets may carry. Reuses the canonical
  * `orchestratorNsfwLevelMap` (which lacks the SFW `g` rating → PG). A null/unknown


### PR DESCRIPTION
## The report

> *"In the store preview, both the category and rating are lowercase."*

`buildListingDetailRows` pushed both stored enums raw:

```ts
rows.push({ key: 'category', label: 'Category', value: detail.category });    // "utility"
rows.push({ key: 'rating',   label: 'Rating',   value: detail.contentRating }); // "pg13"
```

The row is the symptom. The defect is **a display rule with unenrolled call sites** — the card chip, the store filter buttons and both moderator category selectors were already mapping the same two columns one component over. So this PR enrols every renderer of both fields, and then guards the *enrolment* so the condition cannot recur.

---

## Renderer enumeration (complete, both taxonomies)

Population searched: all of `src/` and `packages/`, `.ts` + `.tsx`, for any place a `MARKETPLACE_CATEGORIES` (`generation|games|utility|discovery|moderation|analytics|other`) or `OFFSITE_CONTENT_RATINGS` (`g|pg|pg13|r|x`) value becomes user-facing text — a JSX child, a Select/Chip `label:`, a `title`/`aria-label`, or interpolated prose. Filter values, DB writes, validation, analytics properties and Select `value:` halves are excluded.

### `category` — 16 sites

| # | Site | Before | After |
|---|---|---|---|
| 1 | `appListingDetailRows.ts` — store **Details** rail | 🔴 RAW | mapped ← **the reported bug** |
| 2 | `AppListingDetailBody.tsx:1022` — store detail **meta line** badge | 🔴 RAW | mapped ← same page, two inches up |
| 3 | `AppListingsModerationTable.tsx` — moderator Category column | 🔴 RAW | mapped |
| 4 | `OffsiteReviewQueue.tsx:627` — review-queue metadata strip | 🔴 RAW | mapped |
| 5 | `OnsiteReviewModal.tsx:1045` — on-site review modal badge | 🔴 RAW | mapped |
| 6 | `offsiteSubmitFormConfig.ts` `OFFSITE_CATEGORY_OPTIONS` — author submit + edit Select | ⚠️ title-cased `c.charAt(0).toUpperCase() + c.slice(1)` | mapped |
| 7 | `AppBlockCard.tsx` — store card chip | ✅ private `categoryLabel` | consolidated onto the shared helper |
| 8 | `RelatedListings.tsx` — "More in …" rail heading + `aria-label` | ✅ a second private copy | consolidated, and moved into the pure module so it is *guarded* |
| 9 | `CategoryFilterButtons.tsx:61` — store filter tooltip + `aria-label` | ✅ mapped | unchanged |
| 10 | `ManifestEditForm.tsx:212` — author manifest Select | ✅ mapped | unchanged |
| 11 | `OnsiteReviewModal.tsx:711` — moderator curation Select | ✅ mapped | unchanged |
| 12 | `reviewDiffPanels.tsx:254/265` — manifest-diff `JSON.stringify` | raw | **out of scope** — a raw-JSON diff of the author's manifest; the key IS the subject under review |
| 13–16 | `block-manifest-validator.service.ts:395`, `offsite-listing.service.ts:191`/`:710`, `block-registry.service.ts:3585` — server error messages | raw | **out of scope** — they tell an author what to type in `manifest.json`, or echo a value that by construction failed the membership guard. Mapping them would instruct someone to write `PG-13` into a manifest, which is invalid. *(Added in review: I had listed the `contentRating` counterparts and omitted these.)* |

### `contentRating` — 11 sites

| # | Site | Before | After |
|---|---|---|---|
| 1 | `appListingDetailRows.ts` — store **Details** rail | 🔴 RAW | mapped ← **the reported bug** |
| 2 | `pages/apps/[appBlockId]/index.tsx:342` — legacy per-app detail header badge | 🔴 RAW | mapped |
| 3 | `OffsiteReviewQueue.tsx:637` — declared-rating chip | 🔴 RAW | mapped |
| 4 | `OffsiteReviewQueue.tsx:655` — "Detected from assets" chip | 🔴 RAW | mapped |
| 5 | `OffsiteReviewQueue.tsx:790/796` — rating-mismatch Alert prose (both values, both branches) | 🔴 RAW | mapped |
| 6 | `OffsiteReviewQueue.tsx:849` — moderator "Final content rating" Select | 🔴 RAW (`label: r`) | mapped |
| 7 | `OnsiteReviewModal.tsx:1055` — on-site review modal badge | 🔴 RAW | mapped |
| 8 | `ManifestEditForm.tsx:220` — author manifest Select | 🔴 RAW (`label: r`) | mapped |
| 9 | `ExternalSubmitForm.tsx:794` — "Draft created" banner badge | 🔴 RAW | mapped |
| 10 | `offsiteSubmitFormConfig.ts` `OFFSITE_CONTENT_RATING_OPTIONS` — author submit + edit Select | ⚠️ `r.toUpperCase()` → `PG13` | mapped |
| 11 | `block-manifest-validator.service.ts:370`, `offsite-listing.service.ts:201`/`:718` — server error messages | raw | **out of scope**, same reasoning as above |

**Card surfaces:** `AppListingCard.tsx` uses `category` only for the placeholder icon and gradient, never as text — nothing to fix. `AppBlockCard.tsx` renders it as text and was already mapped. `ratingColor()` maps a rating to a Mantine colour, not to text.

**Ruled out — different `category`/`rating` domains:** agent-report `finding.category` (`ReportTabs.tsx`), notification-bucket categories, article/model/challenge **tag** categories, moderation/NSFW tag categories, wildcard and buzz-rate-card categories; and on the rating side the review-sentiment ladder (`getRatingLabel`, "Very Positive"), star ratings, and `getBrowsingLevelLabel(nsfwLevel)`.

---

## The two halves

### Category — the rule existed, five sites had not enrolled

Extracted the guard-then-map-else-raw shape into **`marketplaceCategoryLabel()`**.

⚠️ *Correction from review:* an earlier draft of this description called the two private helpers "byte-identical copies". They were not. `AppBlockCard`'s was `(category: string): string`; `RelatedListings`' was `(category: string | null): string | null` with an extra `if (!category) return null`. Only the core expression line matched. The consolidation preserves the null wrapper, so behaviour is unchanged for every input — the code was right, the claim was sloppy.

### Rating — no label map existed, so these are chosen words

```ts
export const OFFSITE_CONTENT_RATING_LABELS = {
  g: 'G', pg: 'PG', pg13: 'PG-13', r: 'R', x: 'X',
};
```

Civitai already has a user-facing maturity vocabulary — `browsingLevelLabels`, shown on models, images and posts: `PG`, `PG-13`, `R`, `X`, `XXX`. Four of the five off-site rungs map onto an `NsfwLevel` that already has a label there, so they **reuse it verbatim**; inventing a second vocabulary (`Everyone`/`Teen`/`Mature`) would mean one app reading "PG-13" on a model page and "Teen" in the store — the exact defect class this PR is about. `g` is the one rung the browsing ladder has **no bit for**, so it needed a word of its own and takes the next rung of the same film-classification ladder: **`G`**.

**`pg13` → `PG-13` carries a hyphen, and that is the point.** No mechanical transformation of the key produces it: `toUpperCase()` gives `PG13` (what the submit form shipped), title-case gives `Pg13`, raw gives `pg13` (what the tester saw).

**Both helpers keep the RAW value as the fallback.** Both columns are free text, and the backfill service explicitly handles "a poison row (an out-of-domain contentRating)". A chip reading `something-new` is honest; a blank chip is a bug report, and a throw inside a details row unmounts the page it decorates — which has already happened once on this exact panel.

---

## 🔴 Guarding the *enrolment*, not just the rule

An audit reverted every call site to raw and re-ran the cited suites: only 4 component + 6 unit tests went red. **10 of 17 sites were reachable but unasserted.** And the first mutation battery could not have seen that — all five of its mutants targeted the two *helper modules*, so each died to the helpers' own unit tests whether or not any call site was wired. It mutated the rule, never its enrolment.

Two things were added in response.

**1. Call-site assertions.** `offsiteSubmitFormConfig` option lists (unit, covers both author forms), the rail heading (moved into the pure `related-listings.ts` so the *blocking* tier covers it), and behavioural assertions on the moderation table, both review-modal badges, the manifest-editor Select, the approve Select, and an end-to-end submit-wizard test that drives *option label → selection → summary badge*.

**2. `__tests__/listingLabelCallSites.test.ts` — an enrolment ledger** in the blocking `unit` tier, modelled on the repo's existing `appsStoreAccessCallSites.test.ts`. It walks `components/Apps`, `components/AppBlocks` and `pages/apps` with the TypeScript AST and asserts that **no** JSX child and **no** Select-option `label` renders either field raw. It fails when the ledger grows (a new surface that forgot the helper) *and* when it shrinks (a site reverted).

This matters because the browser `component` project is report-only, and three raw sites live where no component test exists at all: `pages/apps/[appBlockId]/index.tsx` (a Next page with `getServerSideProps` + `dbRead`, never import-testable — the sibling ledger already names it a known blind spot), `RelatedListings.tsx`, and the detail meta-line badge.

**The ledger caught its own blind spot, and I am reporting that rather than the polished result.** Its first version matched by field *name*, so two live sites that hold a rating in a differently-named local — `derivedRating` in the review queue, and `label: r` inside a `map` in the manifest editor — reverted to raw with the ledger still **green**. The call-site battery is what found it. It now also flags an aliased local whose identifier ends in `Rating`/`Category`, and a bare identifier used as an option `label` beside a `value` sibling. Both additions carry their own regression controls, and the file validates its scanner before reading its verdict: a positive control that must find every raw shape, a negative control that must not flag the mapped form, a control that non-rendering uses aren't flagged, a proof that the one receiver exemption (`finding.category`, a different domain) does not disable the rest of its file, and a floor on the number of files scanned so a `SCAN_ROOTS` typo cannot turn the whole thing into a green no-op.

---

## Coverage delta and mutation results

**Call-site battery — 15 mutants, each reverting one site to its exact pre-PR form.** Run against the **blocking `unit` tier only**.

| | Before this round | After |
|---|---|---|
| Sites killed by the blocking tier | 5 / 15 | **15 / 15** |
| Sites with no coverage anywhere | 10 / 17 | **0** |

Every mutant was asserted applied by re-reading the file (one that fails to apply also reports SURVIVED), and the tree was restored between each. The two that survived the first pass — `C9 ManifestEditForm` and `C14 OffsiteReviewQueue derived rating` — are the blind spot described above; both now die naming their own site and rule (`ManifestEditForm.tsx:225:bare-option-label`, `OffsiteReviewQueue.tsx:655:derivedRating`).

**Helper battery — 5 mutants, all killed, all on `AssertionError`** (no `TypeError` kills, so none died for the wrong reason): swap `pg13`↔`r` (7 tests, `expected 'R' to be 'PG-13'`); drop the rating fallback (3, `expected undefined to be 'nc17'`); swap `utility`↔`discovery` (4); drop the category fallback (2, `expected undefined to be 'workflow-tools'`); all rating labels hardcoded to `'G'` (9, including the pairwise-distinctness assertion `expected 1 to be 5`).

## Red → green matrix

| Suite | At base | At HEAD |
|---|---|---|
| `__tests__/appListingDetailRows.test.ts` | **6 failed** / 23 passed (29) | 29 passed |
| `offsite-content-rating-labels` + `marketplace-categories.constants` | **15 failed** / 6 passed (21) | 21 passed |
| Full `unit` project (**blocking**) | — | **19,815 passed**, 25 skipped (1,261 files) |
| Full `component` project | — | 1,905 passed before this round; re-run in progress at the time of writing |
| `pnpm typecheck` | — | **0 errors** |

Component runs use `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` pointed at a nix `chrome-headless-shell`; the Playwright-downloaded binary is a generic dynamically-linked ELF that cannot execute on NixOS and fails as *"Tests no tests"* — a green-looking zero. Every number above is a read test count, never an exit code.

---

## Notes for the reviewer

- **A pre-existing assertion was a false green, and is repaired here.** `OnsiteReviewModal.browser.test.tsx` asserted `page.getByText('generation')`. Without `{ exact: true }` that is a case-insensitive substring match, so it resolved happily against both the raw `generation` and the `Generation` this PR renders — it named the value while being unable to discriminate it. Now exact, in both directions.
- `expect.element(...).not.toBeInTheDocument()` is **inert** in this repo (#4197), so absence is asserted with `expect(locator.query()).toBeNull()` or by reading `.element().value`/`.textContent`, always controlled against a positive assertion in the same test. `toHaveTextContent` is a substring matcher and is avoided for the same reason.
- **A positive control earned its keep mid-review:** the first moderation-table assertion read `.elements()` synchronously before the render settled and reported **0 badges**. It now awaits the element first.
- **`--no-verify` on the commit skipped nothing, and my earlier explanation for it was wrong.** ⚠️ *Correction from review:* I said it avoided a prettier hook re-introducing formatting churn. There is no prettier hook and no `lint-staged` in this repo — `.husky/pre-commit` only rewrites ToS frontmatter and ends `exit 0`, and `.husky/pre-push` early-exits unless the branch is `main`. The flag was a no-op.
- **The diff is deliberately free of formatting churn**, and that is now measured rather than asserted: all 8 files `prettier:check` flags were **already unformatted at base** (verified by extracting each file at `HEAD` and checking it in isolation), so this PR adds no formatting debt. Both *added* files are prettier-clean, which is what CI actually blocks on — modified files are a warning by design.
- **Undocumented before, worth a line:** `OffsiteReviewQueue:792/800` changed `{declaredRating ?? '—'}` to `{declaredRating ? … : '—'}`. An empty-string rating previously rendered a blank gap and now renders `—`. That is an improvement, not an accident.

## Not verified

Not exercised in a running browser against real data — every claim rests on the unit + component suites, the mutation batteries, and reading each call site. The enrolment ledger is a **reversion** guard: it proves no site renders the raw field, not that each helper was passed the right argument.
