### PR TITLE
fix(scan): only tombstone a file when a 404 proves it is gone

### DIFF
--- a/src/server/services/orchestrator/__tests__/createModelFileScanRequest.test.ts
+++ b/src/server/services/orchestrator/__tests__/createModelFileScanRequest.test.ts
@@ -554,6 +554,36 @@ describe('createModelFileScanRequest', () => {
       );
     });
 
+    // The verdict is deliberately taken from the RETRY, and so are the audit
+    // fields. Every other fixture here rejects with the same object twice, which
+    // cannot tell the two apart — so re-sourcing the log from `firstError` passes
+    // a fully green suite while making the log describe the wrong attempt. Give
+    // the two attempts pairwise-distinct values so that mutant is observable.
+    it('sources the audit fields from the RETRY, not the first attempt', async () => {
+      const firstFailure = new DeliveryWorkerError(410, 'Gone');
+      firstFailure.resolverError = new StorageResolverError(503, 'Service Unavailable');
+      const retryFailure = new DeliveryWorkerError(404, 'Not Found');
+      retryFailure.resolverError = new TypeError('fetch failed');
+
+      mockResolveDownloadUrl
+        .mockRejectedValueOnce(firstFailure)
+        .mockRejectedValueOnce(retryFailure);
+
+      const promise = createModelFileScanRequest(baseInput).catch((e) => e);
+      await vi.advanceTimersByTimeAsync(60_000);
+      await promise;
+
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // 404 from the retry, NOT 410 from the first attempt.
+          deliveryWorkerStatus: 404,
+          // The retry's resolver failure had no status; the first attempt's did.
+          resolverStatus: undefined,
+          resolverError: 'TypeError: fetch failed',
+        })
+      );
+    });
+
     it('skips pre-flight entirely when preflight=false (inline upload path)', async () => {
       mockResolveDownloadUrl.mockRejectedValue(new Error('would fail if called'));
       mockSubmitWorkflow.mockResolvedValue({

--- a/src/server/services/orchestrator/__tests__/createModelFileScanRequest.test.ts
+++ b/src/server/services/orchestrator/__tests__/createModelFileScanRequest.test.ts
@@ -559,10 +559,15 @@ describe('createModelFileScanRequest', () => {
     // cannot tell the two apart — so re-sourcing the log from `firstError` passes
     // a fully green suite while making the log describe the wrong attempt. Give
     // the two attempts pairwise-distinct values so that mutant is observable.
+    // 🔴 The retry carries 410, NOT 404, on purpose. 404 is the only value
+    // `deliveryWorkerStatus` takes anywhere else in this suite, so asserting 404
+    // here could not distinguish "reads the retry" from "hardcoded to 404" — a
+    // fixture that can only ever produce the constant it names cannot detect a
+    // mutant that returns that constant. 410 is a value no other fixture emits.
     it('sources the audit fields from the RETRY, not the first attempt', async () => {
-      const firstFailure = new DeliveryWorkerError(410, 'Gone');
+      const firstFailure = new DeliveryWorkerError(404, 'Not Found');
       firstFailure.resolverError = new StorageResolverError(503, 'Service Unavailable');
-      const retryFailure = new DeliveryWorkerError(404, 'Not Found');
+      const retryFailure = new DeliveryWorkerError(410, 'Gone');
       retryFailure.resolverError = new TypeError('fetch failed');
 
       mockResolveDownloadUrl
@@ -575,11 +580,16 @@ describe('createModelFileScanRequest', () => {
 
       expect(mockLogToAxiom).toHaveBeenCalledWith(
         expect.objectContaining({
-          // 404 from the retry, NOT 410 from the first attempt.
-          deliveryWorkerStatus: 404,
+          // 410 from the retry, NOT 404 from the first attempt.
+          deliveryWorkerStatus: 410,
           // The retry's resolver failure had no status; the first attempt's did.
           resolverStatus: undefined,
           resolverError: 'TypeError: fetch failed',
+          // These two are what an on-call reader uses to reconstruct which
+          // attempt said what, and nothing else in the suite asserts them —
+          // swapping or dropping them survives a green run without this.
+          firstError: 'Delivery worker error: Not Found',
+          retryError: 'Delivery worker error: Gone',
         })
       );
     });

--- a/src/server/services/orchestrator/__tests__/createModelFileScanRequest.test.ts
+++ b/src/server/services/orchestrator/__tests__/createModelFileScanRequest.test.ts
@@ -65,8 +65,9 @@ vi.mock('~/env/server', () => ({
     WEBHOOK_TOKEN: 'wh-token',
     // Required because the delivery-worker mock above spreads the REAL module,
     // which transitively imports s3-utils — and s3-utils does `new URL(...)` on
-    // these at module load. Without them the whole suite fails to IMPORT, which
-    // vitest reports as "0 test" rather than as a failure.
+    // these at module load. Without them the whole suite fails to import
+    // (vitest reports `1 failed` and `Tests no tests` — loud, but the TEST count
+    // is zero, so read the count and not just the pass/fail line).
     S3_UPLOAD_ENDPOINT: 'https://abcd1234.r2.cloudflarestorage.com',
     S3_UPLOAD_B2_ENDPOINT: 'https://s3.us-west-004.backblazeb2.com',
     DELIVERY_WORKER_ENDPOINT: 'https://delivery.example.com/',
@@ -448,6 +449,9 @@ describe('createModelFileScanRequest', () => {
       expect(err).toBeInstanceOf(ModelFileScanSubmissionError);
       expect(err.code).toBe('transient');
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      // NB: this function never writes the tombstone itself — the CALLER does,
+      // keyed off `code`. So `code === 'transient'` above is the load-bearing
+      // assertion; this one only pins that no write leaked into this path.
       expect(mockDbWrite.modelFile.update).not.toHaveBeenCalled();
       expect(mockLogToAxiom).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/server/services/orchestrator/__tests__/createModelFileScanRequest.test.ts
+++ b/src/server/services/orchestrator/__tests__/createModelFileScanRequest.test.ts
@@ -38,9 +38,18 @@ vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
 
 vi.mock('~/shared/utils/air', () => ({ stringifyAIR: mockStringifyAIR }));
 
-vi.mock('~/utils/delivery-worker', () => ({
-  resolveDownloadUrl: mockResolveDownloadUrl,
-}));
+// Spread the REAL module and override only `resolveDownloadUrl`. A wholesale
+// one-key mock would (a) go stale the moment the module gains an export — it
+// already did, when `isDefiniteNotFound` was added — and (b) make the not-found
+// vs transient classification a property of the fake instead of the code under
+// test. The error classes and the classifier here are the real ones.
+vi.mock('~/utils/delivery-worker', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/utils/delivery-worker')>();
+  return {
+    ...actual,
+    resolveDownloadUrl: mockResolveDownloadUrl,
+  };
+});
 
 // Use a getter so tests can flip isProd between cases.
 vi.mock('~/env/other', () => ({
@@ -54,6 +63,17 @@ vi.mock('~/env/server', () => ({
     ORCHESTRATOR_ACCESS_TOKEN: 'token',
     NEXTAUTH_URL: 'https://civitai.test',
     WEBHOOK_TOKEN: 'wh-token',
+    // Required because the delivery-worker mock above spreads the REAL module,
+    // which transitively imports s3-utils — and s3-utils does `new URL(...)` on
+    // these at module load. Without them the whole suite fails to IMPORT, which
+    // vitest reports as "0 test" rather than as a failure.
+    S3_UPLOAD_ENDPOINT: 'https://abcd1234.r2.cloudflarestorage.com',
+    S3_UPLOAD_B2_ENDPOINT: 'https://s3.us-west-004.backblazeb2.com',
+    DELIVERY_WORKER_ENDPOINT: 'https://delivery.example.com/',
+    DELIVERY_WORKER_TOKEN: 'tok',
+    STORAGE_RESOLVER_ENDPOINT: '',
+    STORAGE_RESOLVER_AUTH: '',
+    LOGGING: [],
   },
 }));
 
@@ -67,6 +87,7 @@ import {
   createModelFileScanRequest,
   ModelFileScanSubmissionError,
 } from '~/server/services/orchestrator/orchestrator.service';
+import { DeliveryWorkerError, StorageResolverError } from '~/utils/delivery-worker';
 
 const baseInput = {
   fileId: 1,
@@ -377,10 +398,10 @@ describe('createModelFileScanRequest', () => {
       expect(mockSubmitWorkflow).toHaveBeenCalled();
     });
 
-    it('throws code=not-found when both pre-flight attempts fail', async () => {
+    it('throws code=not-found when the retry fails with a 404 (absence PROVEN)', async () => {
       mockResolveDownloadUrl
-        .mockRejectedValueOnce(new Error('first miss'))
-        .mockRejectedValueOnce(new Error('still missing'));
+        .mockRejectedValueOnce(new DeliveryWorkerError(404, 'Not Found'))
+        .mockRejectedValueOnce(new DeliveryWorkerError(404, 'Not Found'));
 
       const promise = createModelFileScanRequest(baseInput).catch((e) => e);
       await vi.advanceTimersByTimeAsync(60_000);
@@ -399,6 +420,66 @@ describe('createModelFileScanRequest', () => {
           fileId: 1,
         })
       );
+    });
+
+    // 🔴 REGRESSION GUARD. Before this was fixed, EVERY second pre-flight failure
+    // produced code=not-found, and the caller writes a PERMANENT
+    // ModelFile.exists=false tombstone on that code — which also permanently
+    // excludes the file from the scan retry job. A resolver outage therefore left
+    // Published, Public files downloadable and unscannable forever. Measured
+    // 2026-08-20: 41 of 41 readable tombstoned files were still fully
+    // downloadable, i.e. the tombstones recorded outages, not missing objects.
+    // These cases MUST be transient. This test fails on the pre-fix code.
+    it.each([
+      ['resolver 503', () => new StorageResolverError(503, 'Service Unavailable')],
+      ['resolver 500', () => new StorageResolverError(500, 'Internal Server Error')],
+      ['resolver 401 (auth)', () => new StorageResolverError(401, 'Unauthorized')],
+      ['delivery worker 429 (rate limit)', () => new DeliveryWorkerError(429, 'Too Many Requests')],
+      ['delivery worker 503', () => new DeliveryWorkerError(503, 'Service Unavailable')],
+      ['a status-less transport error', () => new Error('ECONNRESET')],
+      ['a non-Error rejection', () => 'boom' as unknown as Error],
+    ])('throws code=transient (never not-found) for %s — no tombstone', async (_label, makeErr) => {
+      mockResolveDownloadUrl.mockRejectedValueOnce(makeErr()).mockRejectedValueOnce(makeErr());
+
+      const promise = createModelFileScanRequest(baseInput).catch((e) => e);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const err = await promise;
+
+      expect(err).toBeInstanceOf(ModelFileScanSubmissionError);
+      expect(err.code).toBe('transient');
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(mockDbWrite.modelFile.update).not.toHaveBeenCalled();
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'model-file-scan',
+          submissionErrorCode: 'transient',
+          fileId: 1,
+        })
+      );
+    });
+
+    it('classifies on the RETRY, so a transient first failure followed by a 404 is not-found', async () => {
+      mockResolveDownloadUrl
+        .mockRejectedValueOnce(new StorageResolverError(503, 'Service Unavailable'))
+        .mockRejectedValueOnce(new DeliveryWorkerError(404, 'Not Found'));
+
+      const promise = createModelFileScanRequest(baseInput).catch((e) => e);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const err = await promise;
+
+      expect(err.code).toBe('not-found');
+    });
+
+    it('and the mirror: a 404 first, then a 5xx, is transient — absence was not re-proven', async () => {
+      mockResolveDownloadUrl
+        .mockRejectedValueOnce(new DeliveryWorkerError(404, 'Not Found'))
+        .mockRejectedValueOnce(new StorageResolverError(503, 'Service Unavailable'));
+
+      const promise = createModelFileScanRequest(baseInput).catch((e) => e);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const err = await promise;
+
+      expect(err.code).toBe('transient');
     });
 
     it('skips pre-flight entirely when preflight=false (inline upload path)', async () => {

--- a/src/server/services/orchestrator/__tests__/createModelFileScanRequest.test.ts
+++ b/src/server/services/orchestrator/__tests__/createModelFileScanRequest.test.ts
@@ -259,9 +259,7 @@ describe('createModelFileScanRequest', () => {
       await createModelFileScanRequest(baseInput);
 
       const submitCall = mockSubmitWorkflow.mock.calls[0][0];
-      expect(submitCall.body.callbacks[0].url).toContain(
-        '/api/webhooks/model-file-scan-result'
-      );
+      expect(submitCall.body.callbacks[0].url).toContain('/api/webhooks/model-file-scan-result');
       expect(submitCall.body.callbacks[0].url).toContain('token=wh-token');
       expect(submitCall.body.callbacks[0].type).toEqual([
         'workflow:succeeded',
@@ -326,7 +324,9 @@ describe('createModelFileScanRequest', () => {
       expect(err).toBeInstanceOf(ModelFileScanSubmissionError);
       expect(err.code).toBe('transient');
       expect(err.status).toBe(400);
-      expect(err.message).toMatch(/Failed to submit model file scan workflow for file 1.*status 400/);
+      expect(err.message).toMatch(
+        /Failed to submit model file scan workflow for file 1.*status 400/
+      );
     });
 
     it('logs to Axiom with file context + submissionErrorCode=transient before throwing', async () => {
@@ -484,6 +484,74 @@ describe('createModelFileScanRequest', () => {
       const err = await promise;
 
       expect(err.code).toBe('transient');
+    });
+
+    // These fields exist ONLY to make a tombstone auditable after the fact, so
+    // nothing else in the codebase reads them — which means without an assertion
+    // here, swapping resolverStatus and deliveryWorkerStatus, or dropping either,
+    // passes a fully green suite while making every future audit read the wrong
+    // authority's answer. Assert the exact values, not merely that they exist.
+    it('logs WHICH authority reported what, so the verdict is auditable', async () => {
+      const dwError = new DeliveryWorkerError(404, 'Not Found');
+      dwError.resolverError = new StorageResolverError(503, 'Service Unavailable');
+      mockResolveDownloadUrl.mockRejectedValueOnce(dwError).mockRejectedValueOnce(dwError);
+
+      const promise = createModelFileScanRequest(baseInput).catch((e) => e);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const err = await promise;
+
+      // The resolver was down, so the delivery worker's 404 is not proof.
+      expect(err.code).toBe('transient');
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          submissionErrorCode: 'transient',
+          deliveryWorkerStatus: 404,
+          resolverStatus: 503,
+          resolverError: 'StorageResolverError: Storage resolver error: Service Unavailable',
+        })
+      );
+    });
+
+    it('logs the resolver failure even when it has no status (transport reject)', async () => {
+      // The outage shape this change exists for: a resolver pod that refuses the
+      // connection rejects at the transport layer, so there IS no status. Without
+      // resolverError the log would carry the delivery worker's text twice and no
+      // resolver signal at all.
+      const dwError = new DeliveryWorkerError(404, 'Not Found');
+      dwError.resolverError = new TypeError('fetch failed');
+      mockResolveDownloadUrl.mockRejectedValueOnce(dwError).mockRejectedValueOnce(dwError);
+
+      const promise = createModelFileScanRequest(baseInput).catch((e) => e);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const err = await promise;
+
+      expect(err.code).toBe('transient');
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deliveryWorkerStatus: 404,
+          resolverStatus: undefined,
+          resolverError: 'TypeError: fetch failed',
+        })
+      );
+    });
+
+    it('omits the resolver fields when the resolver was never consulted', async () => {
+      mockResolveDownloadUrl
+        .mockRejectedValueOnce(new DeliveryWorkerError(404, 'Not Found'))
+        .mockRejectedValueOnce(new DeliveryWorkerError(404, 'Not Found'));
+
+      const promise = createModelFileScanRequest(baseInput).catch((e) => e);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const err = await promise;
+
+      expect(err.code).toBe('not-found');
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deliveryWorkerStatus: 404,
+          resolverStatus: undefined,
+          resolverError: undefined,
+        })
+      );
     });
 
     it('skips pre-flight entirely when preflight=false (inline upload path)', async () => {

--- a/src/server/services/orchestrator/orchestrator.service.ts
+++ b/src/server/services/orchestrator/orchestrator.service.ts
@@ -21,7 +21,7 @@ import { hashContent } from '~/server/services/entity-moderation.service';
 import type { MediaType, ModelType } from '~/shared/utils/prisma/enums';
 import { EntityModerationStatus, ModelHashType, ScanResultCode } from '~/shared/utils/prisma/enums';
 import { stringifyAIR } from '~/shared/utils/air';
-import { resolveDownloadUrl } from '~/utils/delivery-worker';
+import { isDefiniteNotFound, resolveDownloadUrl } from '~/utils/delivery-worker';
 
 // Per-attempt backstop for the image-ingestion orchestrator SUBMIT (enqueue only —
 // this returns a workflow id immediately, it does NOT wait for the scan to finish).
@@ -587,11 +587,15 @@ export async function createXGuardModerationRequest(args: XGuardModerationArgs) 
 /**
  * Thrown by createModelFileScanRequest when submission can't proceed. The
  * `code` lets callers branch their recovery:
- *   - 'not-found': pre-flight download-URL resolution failed twice (storage
- *     resolver + delivery worker both can't locate the file). Caller should
- *     mark ModelFile.exists=false to exit the scan retry loop.
- *   - 'transient': submitWorkflow itself failed (5xx, network, auth, etc.).
- *     Caller should leave `exists` alone and rely on retry.
+ *   - 'not-found': pre-flight download-URL resolution failed twice AND the retry
+ *     failed with a 404 — i.e. the resolver positively reported the object is not
+ *     there. Caller may mark ModelFile.exists=false to exit the scan retry loop.
+ *     🔴 That tombstone is PERMANENT and also permanently exempts the file from
+ *     scanning, so this code must mean "absence was proven", never "we could not
+ *     ask". It is emitted only via `isDefiniteNotFound`.
+ *   - 'transient': submitWorkflow itself failed (5xx, network, auth, etc.), OR
+ *     pre-flight failed in any way that does not prove absence. Caller should
+ *     leave `exists` alone and rely on retry.
  *
  * Why pre-flight (not orchestrator response): submitWorkflow only enqueues —
  * orchestrator validates the AIR-fetchable file later, asynchronously, in
@@ -668,10 +672,17 @@ export async function createModelFileScanRequest({
   //   1) try storage-resolver / delivery-worker (resolveDownloadUrl)
   //   2) on failure, wait 60s and retry once (covers registration sync lag
   //      for recently-uploaded files)
-  //   3) on second failure, throw 'not-found' so the caller can tombstone
+  //   3) on second failure, classify: only a 404 proves the file is gone
+  //      ('not-found', caller tombstones). Everything else — 5xx, auth, rate
+  //      limit, timeout, transport reject — is 'transient' and gets retried.
   //
-  // This is the file-gone signal we used in the legacy scanner; orchestrator
-  // submitWorkflow doesn't surface one synchronously.
+  // 🔴 Step 3 used to treat EVERY second failure as 'not-found'. That is how a
+  // resolver outage became a permanent `ModelFile.exists=false` tombstone, which
+  // `scanFilesFallbackJob` then excludes from its retry query forever — leaving a
+  // Published, Public file downloadable and permanently unscanned. Measured
+  // 2026-08-20: 41 of 41 readable tombstoned files were still fully downloadable
+  // (across 51 uploaders), and the tombstones arrived in bursts (top 5 hours held
+  // 52% of them) rather than spread out as independent file losses would be.
   if (preflight) {
     try {
       await resolveDownloadUrl(fileId, url);
@@ -680,19 +691,25 @@ export async function createModelFileScanRequest({
       try {
         await resolveDownloadUrl(fileId, url);
       } catch (retryError) {
+        // Classify on the RETRY's failure: it is the most recent evidence, and
+        // the first failure may have been the transient one that the retry
+        // exists to absorb.
+        const code = isDefiniteNotFound(retryError) ? 'not-found' : 'transient';
         logToAxiom({
           type: 'error',
           name: 'model-file-scan',
           message: `Pre-flight download URL resolution failed for file ${fileId}`,
           fileId,
           modelVersionId,
-          submissionErrorCode: 'not-found',
+          submissionErrorCode: code,
           firstError: firstError instanceof Error ? firstError.message : String(firstError),
           retryError: retryError instanceof Error ? retryError.message : String(retryError),
         });
         throw new ModelFileScanSubmissionError(
-          `Pre-flight resolution failed for file ${fileId}; treating as not-found`,
-          'not-found'
+          code === 'not-found'
+            ? `Pre-flight resolution returned 404 for file ${fileId}; the file is not there`
+            : `Pre-flight resolution failed for file ${fileId} without proving absence; treating as transient`,
+          code
         );
       }
     }

--- a/src/server/services/orchestrator/orchestrator.service.ts
+++ b/src/server/services/orchestrator/orchestrator.service.ts
@@ -21,7 +21,12 @@ import { hashContent } from '~/server/services/entity-moderation.service';
 import type { MediaType, ModelType } from '~/shared/utils/prisma/enums';
 import { EntityModerationStatus, ModelHashType, ScanResultCode } from '~/shared/utils/prisma/enums';
 import { stringifyAIR } from '~/shared/utils/air';
-import { isDefiniteNotFound, resolveDownloadUrl } from '~/utils/delivery-worker';
+import {
+  DeliveryWorkerError,
+  StorageResolverError,
+  isDefiniteNotFound,
+  resolveDownloadUrl,
+} from '~/utils/delivery-worker';
 
 // Per-attempt backstop for the image-ingestion orchestrator SUBMIT (enqueue only —
 // this returns a workflow id immediately, it does NOT wait for the scan to finish).
@@ -588,8 +593,8 @@ export async function createXGuardModerationRequest(args: XGuardModerationArgs) 
  * Thrown by createModelFileScanRequest when submission can't proceed. The
  * `code` lets callers branch their recovery:
  *   - 'not-found': pre-flight download-URL resolution failed twice AND the retry
- *     failed with a 404 — i.e. the resolver positively reported the object is not
- *     there. Caller may mark ModelFile.exists=false to exit the scan retry loop.
+ *     failed with an absence status (404/410) reported by the authority that can
+ *     actually see the file — i.e. absence was positively established. Caller may mark ModelFile.exists=false to exit the scan retry loop.
  *     🔴 That tombstone is PERMANENT and also permanently exempts the file from
  *     scanning, so this code must mean "absence was proven", never "we could not
  *     ask". It is emitted only via `isDefiniteNotFound`.
@@ -672,7 +677,8 @@ export async function createModelFileScanRequest({
   //   1) try storage-resolver / delivery-worker (resolveDownloadUrl)
   //   2) on failure, wait 60s and retry once (covers registration sync lag
   //      for recently-uploaded files)
-  //   3) on second failure, classify: only a 404 proves the file is gone
+  //   3) on second failure, classify via isDefiniteNotFound: absence must be
+  //      POSITIVELY reported (404/410) by the authority that can see the file
   //      ('not-found', caller tombstones). Everything else — 5xx, auth, rate
   //      limit, timeout, transport reject — is 'transient' and gets retried.
   //
@@ -695,6 +701,15 @@ export async function createModelFileScanRequest({
         // the first failure may have been the transient one that the retry
         // exists to absorb.
         const code = isDefiniteNotFound(retryError) ? 'not-found' : 'transient';
+        // The verdict turns on WHICH component reported what, and the two message
+        // fields below both carry the delivery worker's text — so without this the
+        // decision input is invisible in production and no one can confirm after
+        // the fact whether a given tombstone was justified.
+        const resolverStatus =
+          retryError instanceof DeliveryWorkerError &&
+          retryError.resolverError instanceof StorageResolverError
+            ? retryError.resolverError.statusCode
+            : undefined;
         logToAxiom({
           type: 'error',
           name: 'model-file-scan',
@@ -702,12 +717,14 @@ export async function createModelFileScanRequest({
           fileId,
           modelVersionId,
           submissionErrorCode: code,
+          deliveryWorkerStatus: retryError instanceof DeliveryWorkerError ? retryError.statusCode : undefined,
+          resolverStatus,
           firstError: firstError instanceof Error ? firstError.message : String(firstError),
           retryError: retryError instanceof Error ? retryError.message : String(retryError),
         });
         throw new ModelFileScanSubmissionError(
           code === 'not-found'
-            ? `Pre-flight resolution returned 404 for file ${fileId}; the file is not there`
+            ? `Pre-flight resolution reported the file absent for file ${fileId}`
             : `Pre-flight resolution failed for file ${fileId} without proving absence; treating as transient`,
           code
         );

--- a/src/server/services/orchestrator/orchestrator.service.ts
+++ b/src/server/services/orchestrator/orchestrator.service.ts
@@ -701,15 +701,24 @@ export async function createModelFileScanRequest({
         // the first failure may have been the transient one that the retry
         // exists to absorb.
         const code = isDefiniteNotFound(retryError) ? 'not-found' : 'transient';
-        // The verdict turns on WHICH component reported what, and the two message
-        // fields below both carry the delivery worker's text — so without this the
+        // The verdict turns on WHICH component reported what, and both message
+        // fields below carry the DELIVERY WORKER's text — so without these the
         // decision input is invisible in production and no one can confirm after
         // the fact whether a given tombstone was justified.
+        const resolverFailure =
+          retryError instanceof DeliveryWorkerError ? retryError.resolverError : undefined;
+        // Status only exists when the resolver answered with one. A pod outage
+        // rejects at the transport layer instead, which is the very case this
+        // change is about — so log the error itself too, or that case arrives
+        // with no resolver signal at all.
         const resolverStatus =
-          retryError instanceof DeliveryWorkerError &&
-          retryError.resolverError instanceof StorageResolverError
-            ? retryError.resolverError.statusCode
-            : undefined;
+          resolverFailure instanceof StorageResolverError ? resolverFailure.statusCode : undefined;
+        const resolverError =
+          resolverFailure === undefined
+            ? undefined
+            : resolverFailure instanceof Error
+            ? `${resolverFailure.name}: ${resolverFailure.message}`
+            : String(resolverFailure);
         logToAxiom({
           type: 'error',
           name: 'model-file-scan',
@@ -717,8 +726,10 @@ export async function createModelFileScanRequest({
           fileId,
           modelVersionId,
           submissionErrorCode: code,
-          deliveryWorkerStatus: retryError instanceof DeliveryWorkerError ? retryError.statusCode : undefined,
+          deliveryWorkerStatus:
+            retryError instanceof DeliveryWorkerError ? retryError.statusCode : undefined,
           resolverStatus,
+          resolverError,
           firstError: firstError instanceof Error ? firstError.message : String(firstError),
           retryError: retryError instanceof Error ? retryError.message : String(retryError),
         });

--- a/src/utils/__tests__/delivery-worker.resolver-enabled.test.ts
+++ b/src/utils/__tests__/delivery-worker.resolver-enabled.test.ts
@@ -55,19 +55,24 @@ describe('getDownloadUrlByFileId — throws a typed error carrying the resolver 
   // other test constructs StorageResolverError by hand, so reverting the class
   // to a bare `throw new Error(...)`, or hardcoding its status to 404, both
   // survive the suite. Those are the two mutants this file exists to kill.
-  it.each([404, 410, 500, 503, 401, 429])('propagates HTTP %i as StorageResolverError.statusCode', async (status) => {
-    fetchMock.mockResolvedValue(resolverFail(status));
+  it.each([404, 410, 500, 503, 401, 429])(
+    'propagates HTTP %i as StorageResolverError.statusCode',
+    async (status) => {
+      fetchMock.mockResolvedValue(resolverFail(status));
 
-    const err = await getDownloadUrlByFileId(1).catch((e) => e);
+      const err = await getDownloadUrlByFileId(1).catch((e) => e);
 
-    expect(err).toBeInstanceOf(StorageResolverError);
-    expect((err as StorageResolverError).statusCode).toBe(status);
-    expect((err as Error).message).toContain(`resolver said ${status}`);
-  });
+      expect(err).toBeInstanceOf(StorageResolverError);
+      expect((err as StorageResolverError).statusCode).toBe(status);
+      expect((err as Error).message).toContain(`resolver said ${status}`);
+    }
+  );
 
   it('returns the resolved url when the resolver answers OK', async () => {
     fetchMock.mockResolvedValue(OK_BODY);
-    await expect(getDownloadUrlByFileId(1)).resolves.toMatchObject({ url: 'https://cdn.example/ok' });
+    await expect(getDownloadUrlByFileId(1)).resolves.toMatchObject({
+      url: 'https://cdn.example/ok',
+    });
   });
 });
 
@@ -105,20 +110,27 @@ describe('resolveDownloadUrl — the resolver verdict survives the delivery-work
   // would leave a transport reject unattached, fall through to `return true`, and
   // tombstone a healthy file — the exact bug this PR exists to fix.
   it.each([
-    ['connection refused / DNS', () => new TypeError('fetch failed')],
-    ['socket timeout', () => Object.assign(new Error('The operation timed out.'), { name: 'TimeoutError' })],
-  ])('a resolver TRANSPORT reject (%s) + delivery worker 404 is NOT definite-not-found', async (_l, makeErr) => {
-    fetchMock.mockRejectedValueOnce(makeErr()).mockResolvedValue(deliveryFail(404));
+    // undici surfaces connection-refused/DNS/header-timeout alike as
+    // `TypeError: fetch failed` (no AbortSignal is passed, so no DOMException
+    // TimeoutError arises on this path). The second row is a non-TypeError Error
+    // to pin that the guard keys off "not a StorageResolverError", not off TypeError.
+    ['connection refused / DNS / header timeout', () => new TypeError('fetch failed')],
+    ['a non-TypeError transport failure', () => new Error('socket hang up')],
+  ])(
+    'a resolver TRANSPORT reject (%s) + delivery worker 404 is NOT definite-not-found',
+    async (_l, makeErr) => {
+      fetchMock.mockRejectedValueOnce(makeErr()).mockResolvedValue(deliveryFail(404));
 
-    const err = await resolveDownloadUrl(1, 's3://b/k.safetensors').catch((e) => e);
+      const err = await resolveDownloadUrl(1, 's3://b/k.safetensors').catch((e) => e);
 
-    expect(err).toBeInstanceOf(DeliveryWorkerError);
-    expect((err as DeliveryWorkerError).statusCode).toBe(404);
-    // Attached but NOT a StorageResolverError — this is the shape the guard must keep.
-    expect((err as DeliveryWorkerError).resolverError).toBeDefined();
-    expect((err as DeliveryWorkerError).resolverError).not.toBeInstanceOf(StorageResolverError);
-    expect(isDefiniteNotFound(err)).toBe(false);
-  });
+      expect(err).toBeInstanceOf(DeliveryWorkerError);
+      expect((err as DeliveryWorkerError).statusCode).toBe(404);
+      // Attached but NOT a StorageResolverError — this is the shape the guard must keep.
+      expect((err as DeliveryWorkerError).resolverError).toBeDefined();
+      expect((err as DeliveryWorkerError).resolverError).not.toBeInstanceOf(StorageResolverError);
+      expect(isDefiniteNotFound(err)).toBe(false);
+    }
+  );
 
   it('a resolver CONFIG error (bare Error, no status) + delivery worker 404 is NOT definite-not-found', async () => {
     // `getDownloadUrlByFileId` throws a plain Error when the endpoint is unset;
@@ -138,7 +150,9 @@ describe('resolveDownloadUrl — the resolver verdict survives the delivery-work
     expect(err).toBeInstanceOf(DeliveryWorkerError);
     expect((err as DeliveryWorkerError).statusCode).toBe(404);
     expect((err as DeliveryWorkerError).resolverError).toBeInstanceOf(StorageResolverError);
-    expect(((err as DeliveryWorkerError).resolverError as StorageResolverError).statusCode).toBe(503);
+    expect(((err as DeliveryWorkerError).resolverError as StorageResolverError).statusCode).toBe(
+      503
+    );
   });
 
   // 🔴 THE REGRESSION THIS FILE EXISTS FOR. The delivery worker is the legacy

--- a/src/utils/__tests__/delivery-worker.resolver-enabled.test.ts
+++ b/src/utils/__tests__/delivery-worker.resolver-enabled.test.ts
@@ -140,6 +140,13 @@ describe('resolveDownloadUrl — the resolver verdict survives the delivery-work
       .mockResolvedValue(deliveryFail(404));
 
     const err = await resolveDownloadUrl(1, 's3://b/k.safetensors').catch((e) => e);
+    // Pin the arrangement, not just the verdict. With the resolver disabled this
+    // rejection would be consumed by the delivery worker's own fetch and a bare
+    // Error returns false anyway — so without these two assertions the test stays
+    // green in a config where it is exercising nothing it claims to.
+    expect(fetchMock.mock.calls[0][0]).toContain('resolver.example.com');
+    expect((err as DeliveryWorkerError).resolverError).toBeInstanceOf(Error);
+    expect((err as DeliveryWorkerError).resolverError).not.toBeInstanceOf(StorageResolverError);
     expect(isDefiniteNotFound(err)).toBe(false);
   });
 

--- a/src/utils/__tests__/delivery-worker.resolver-enabled.test.ts
+++ b/src/utils/__tests__/delivery-worker.resolver-enabled.test.ts
@@ -92,6 +92,43 @@ describe('resolveDownloadUrl — the resolver verdict survives the delivery-work
     await expect(resolveDownloadUrl(1, 's3://b/k.safetensors')).resolves.toMatchObject({
       url: 'https://cdn.example/ok',
     });
+    // Pin the ORDER, not just the outcome: without this the test would still pass
+    // if the env mock silently degraded to a disabled resolver, because fetch[0]
+    // would then be the delivery worker and the second key candidate would hit OK.
+    expect(fetchMock.mock.calls[0][0]).toContain('resolver.example.com');
+  });
+
+  // 🔴 A resolver pod outage does NOT usually arrive as a clean HTTP status — the
+  // connection is refused, DNS fails, or the socket times out, and `fetch` REJECTS.
+  // That throws a TypeError, not a StorageResolverError. The attach guard is
+  // therefore `!== undefined` rather than an `instanceof` narrowing; tightening it
+  // would leave a transport reject unattached, fall through to `return true`, and
+  // tombstone a healthy file — the exact bug this PR exists to fix.
+  it.each([
+    ['connection refused / DNS', () => new TypeError('fetch failed')],
+    ['socket timeout', () => Object.assign(new Error('The operation timed out.'), { name: 'TimeoutError' })],
+  ])('a resolver TRANSPORT reject (%s) + delivery worker 404 is NOT definite-not-found', async (_l, makeErr) => {
+    fetchMock.mockRejectedValueOnce(makeErr()).mockResolvedValue(deliveryFail(404));
+
+    const err = await resolveDownloadUrl(1, 's3://b/k.safetensors').catch((e) => e);
+
+    expect(err).toBeInstanceOf(DeliveryWorkerError);
+    expect((err as DeliveryWorkerError).statusCode).toBe(404);
+    // Attached but NOT a StorageResolverError — this is the shape the guard must keep.
+    expect((err as DeliveryWorkerError).resolverError).toBeDefined();
+    expect((err as DeliveryWorkerError).resolverError).not.toBeInstanceOf(StorageResolverError);
+    expect(isDefiniteNotFound(err)).toBe(false);
+  });
+
+  it('a resolver CONFIG error (bare Error, no status) + delivery worker 404 is NOT definite-not-found', async () => {
+    // `getDownloadUrlByFileId` throws a plain Error when the endpoint is unset;
+    // it is reachable via other callers and must not read as proof of absence.
+    fetchMock
+      .mockRejectedValueOnce(new Error('STORAGE_RESOLVER_ENDPOINT is not configured'))
+      .mockResolvedValue(deliveryFail(404));
+
+    const err = await resolveDownloadUrl(1, 's3://b/k.safetensors').catch((e) => e);
+    expect(isDefiniteNotFound(err)).toBe(false);
   });
 
   it('attaches the resolver error to the delivery-worker error it throws', async () => {

--- a/src/utils/__tests__/delivery-worker.resolver-enabled.test.ts
+++ b/src/utils/__tests__/delivery-worker.resolver-enabled.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The storage resolver is ENABLED here — the production config, and the one the
+// sibling delivery-worker.test.ts deliberately does NOT exercise (it pins
+// STORAGE_RESOLVER_ENDPOINT: '' to reach the legacy path). Module-load constants
+// mean this cannot be toggled per-test, hence a separate file.
+vi.mock('~/env/server', () => ({
+  env: new Proxy(
+    {
+      DELIVERY_WORKER_ENDPOINT: 'https://delivery.example.com/',
+      DELIVERY_WORKER_TOKEN: 'tok',
+      STORAGE_RESOLVER_ENDPOINT: 'https://resolver.example.com',
+      STORAGE_RESOLVER_AUTH: '',
+      S3_UPLOAD_ENDPOINT: 'https://abcd1234.r2.cloudflarestorage.com',
+      S3_UPLOAD_B2_ENDPOINT: 'https://s3.us-west-004.backblazeb2.com',
+      LOGGING: [],
+    } as Record<string, unknown>,
+    {
+      get(target, prop: string) {
+        if (prop in target) return target[prop];
+        return undefined;
+      },
+    }
+  ),
+}));
+
+import {
+  DeliveryWorkerError,
+  StorageResolverError,
+  getDownloadUrlByFileId,
+  isDefiniteNotFound,
+  resolveDownloadUrl,
+} from '../delivery-worker';
+
+const OK_BODY = {
+  ok: true,
+  json: async () => ({ url: 'https://cdn.example/ok', urlExpiryDate: new Date().toISOString() }),
+} as unknown as Response;
+
+const resolverFail = (status: number) =>
+  ({ ok: false, status, text: async () => `resolver said ${status}` } as unknown as Response);
+
+const deliveryFail = (status: number) =>
+  ({ ok: false, status, statusText: `dw ${status}` } as unknown as Response);
+
+describe('getDownloadUrlByFileId — throws a typed error carrying the resolver status', () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  // Without this, nothing drives the real function to a non-OK response: every
+  // other test constructs StorageResolverError by hand, so reverting the class
+  // to a bare `throw new Error(...)`, or hardcoding its status to 404, both
+  // survive the suite. Those are the two mutants this file exists to kill.
+  it.each([404, 410, 500, 503, 401, 429])('propagates HTTP %i as StorageResolverError.statusCode', async (status) => {
+    fetchMock.mockResolvedValue(resolverFail(status));
+
+    const err = await getDownloadUrlByFileId(1).catch((e) => e);
+
+    expect(err).toBeInstanceOf(StorageResolverError);
+    expect((err as StorageResolverError).statusCode).toBe(status);
+    expect((err as Error).message).toContain(`resolver said ${status}`);
+  });
+
+  it('returns the resolved url when the resolver answers OK', async () => {
+    fetchMock.mockResolvedValue(OK_BODY);
+    await expect(getDownloadUrlByFileId(1)).resolves.toMatchObject({ url: 'https://cdn.example/ok' });
+  });
+});
+
+describe('resolveDownloadUrl — the resolver verdict survives the delivery-worker fallback', () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  // fetch order with the resolver enabled: [0] resolver, then [1..] delivery
+  // worker (it retries a second key candidate, so mockResolvedValue covers both).
+  const arrange = (resolverStatus: number, deliveryStatus: number) => {
+    fetchMock
+      .mockResolvedValueOnce(resolverFail(resolverStatus))
+      .mockResolvedValue(deliveryFail(deliveryStatus));
+  };
+
+  it('still falls back to the delivery worker on a resolver 404 (unsynced File records depend on it)', async () => {
+    fetchMock.mockResolvedValueOnce(resolverFail(404)).mockResolvedValue(OK_BODY);
+    await expect(resolveDownloadUrl(1, 's3://b/k.safetensors')).resolves.toMatchObject({
+      url: 'https://cdn.example/ok',
+    });
+  });
+
+  it('attaches the resolver error to the delivery-worker error it throws', async () => {
+    arrange(503, 404);
+    const err = await resolveDownloadUrl(1, 's3://b/k.safetensors').catch((e) => e);
+
+    expect(err).toBeInstanceOf(DeliveryWorkerError);
+    expect((err as DeliveryWorkerError).statusCode).toBe(404);
+    expect((err as DeliveryWorkerError).resolverError).toBeInstanceOf(StorageResolverError);
+    expect(((err as DeliveryWorkerError).resolverError as StorageResolverError).statusCode).toBe(503);
+  });
+
+  // 🔴 THE REGRESSION THIS FILE EXISTS FOR. The delivery worker is the legacy
+  // path keyed off ModelFile.url and cannot see a file registered only in
+  // file_locations. So during a resolver outage it returns 404 for a perfectly
+  // healthy file — and treating that as proof of absence is what burst-tombstoned
+  // healthy files in the first place. Classifying on the delivery worker's status
+  // alone reproduces the original bug one layer down.
+  it.each([
+    ['resolver 503 outage + delivery worker 404', 503, 404],
+    ['resolver 500 outage + delivery worker 404', 500, 404],
+    ['resolver 401 auth failure + delivery worker 404', 401, 404],
+    ['resolver 429 rate limit + delivery worker 410', 429, 410],
+  ])('is NOT definite-not-found: %s', async (_label, resolverStatus, deliveryStatus) => {
+    arrange(resolverStatus, deliveryStatus);
+    const err = await resolveDownloadUrl(1, 's3://b/k.safetensors').catch((e) => e);
+    expect(isDefiniteNotFound(err)).toBe(false);
+  });
+
+  it.each([
+    ['both 404 — every authority agrees', 404, 404],
+    ['resolver 404 + delivery worker 410', 404, 410],
+    ['resolver 410 + delivery worker 404', 410, 404],
+  ])('IS definite-not-found: %s', async (_label, resolverStatus, deliveryStatus) => {
+    arrange(resolverStatus, deliveryStatus);
+    const err = await resolveDownloadUrl(1, 's3://b/k.safetensors').catch((e) => e);
+    expect(isDefiniteNotFound(err)).toBe(true);
+  });
+
+  it('is NOT definite-not-found when the resolver proved absence but the delivery worker could not answer', async () => {
+    // The resolver's 404 is real, but we never learned whether the legacy path
+    // would have served it, so absence is not established end-to-end.
+    arrange(404, 500);
+    const err = await resolveDownloadUrl(1, 's3://b/k.safetensors').catch((e) => e);
+    expect((err as DeliveryWorkerError).statusCode).toBe(500);
+    expect(isDefiniteNotFound(err)).toBe(false);
+  });
+});

--- a/src/utils/__tests__/delivery-worker.test.ts
+++ b/src/utils/__tests__/delivery-worker.test.ts
@@ -28,7 +28,9 @@ vi.mock('~/env/server', () => ({
 
 import {
   DeliveryWorkerError,
+  StorageResolverError,
   getDownloadUrl,
+  isDefiniteNotFound,
   resolveDownloadUrl,
   safeDecodeURIComponent,
 } from '../delivery-worker';
@@ -168,5 +170,51 @@ describe('resolveDownloadUrl — falls back to delivery worker when resolver dis
       'weird%name%.safetensors'
     );
     expect(result.url).toBe('https://cdn.example.com/ok');
+  });
+});
+
+describe('isDefiniteNotFound — only a 404 proves the object is absent', () => {
+  // Callers act on `true` by writing a PERMANENT tombstone that also permanently
+  // exempts the file from virus/pickle scanning, so a wrongly-true answer is far
+  // more expensive than a wrongly-false one (which costs a single retry).
+  it.each([
+    ['DeliveryWorkerError 404', new DeliveryWorkerError(404, 'Not Found')],
+    ['StorageResolverError 404', new StorageResolverError(404, 'not found')],
+  ])('is true for %s', (_label, err) => {
+    expect(isDefiniteNotFound(err)).toBe(true);
+  });
+
+  it.each([
+    ['DeliveryWorkerError 500', new DeliveryWorkerError(500, 'Internal Server Error')],
+    ['DeliveryWorkerError 502', new DeliveryWorkerError(502, 'Bad Gateway')],
+    ['DeliveryWorkerError 503', new DeliveryWorkerError(503, 'Service Unavailable')],
+    ['DeliveryWorkerError 429', new DeliveryWorkerError(429, 'Too Many Requests')],
+    ['DeliveryWorkerError 401', new DeliveryWorkerError(401, 'Unauthorized')],
+    ['DeliveryWorkerError 403', new DeliveryWorkerError(403, 'Forbidden')],
+    // 400 is deliberately NOT treated as proof of absence: a malformed key is
+    // real, but 400 is also what a transiently-misbehaving upstream returns.
+    ['DeliveryWorkerError 400', new DeliveryWorkerError(400, 'Bad Request')],
+    ['StorageResolverError 503', new StorageResolverError(503, 'Service Unavailable')],
+    ['StorageResolverError 500', new StorageResolverError(500, 'boom')],
+    ['a bare Error (no status at all)', new Error('ECONNRESET')],
+    ['a config Error', new Error('STORAGE_RESOLVER_ENDPOINT is not configured')],
+    ['a TypeError from fetch', new TypeError('fetch failed')],
+  ])('is false for %s', (_label, err) => {
+    expect(isDefiniteNotFound(err)).toBe(false);
+  });
+
+  it.each([
+    ['a string', 'not found'],
+    ['null', null],
+    ['undefined', undefined],
+    // Shape-alike: carries statusCode 404 but is not one of our error types.
+    ['a plain object with statusCode 404', { statusCode: 404 }],
+  ])('is false for a non-Error rejection: %s', (_label, value) => {
+    expect(isDefiniteNotFound(value)).toBe(false);
+  });
+
+  it('keeps the historical message prefixes so existing log-matchers still fire', () => {
+    expect(new StorageResolverError(503, 'boom').message).toBe('Storage resolver error: boom');
+    expect(new DeliveryWorkerError(503, 'boom').message).toBe('Delivery worker error: boom');
   });
 });

--- a/src/utils/__tests__/delivery-worker.test.ts
+++ b/src/utils/__tests__/delivery-worker.test.ts
@@ -161,7 +161,10 @@ describe('resolveDownloadUrl — falls back to delivery worker when resolver dis
   it('does not throw URI malformed for a malformed filename on the resolver-disabled path', async () => {
     fetchMock.mockResolvedValue({
       ok: true,
-      json: async () => ({ url: 'https://cdn.example.com/ok', urlExpiryDate: new Date().toISOString() }),
+      json: async () => ({
+        url: 'https://cdn.example.com/ok',
+        urlExpiryDate: new Date().toISOString(),
+      }),
     } as unknown as Response);
 
     const result = await resolveDownloadUrl(

--- a/src/utils/__tests__/delivery-worker.test.ts
+++ b/src/utils/__tests__/delivery-worker.test.ts
@@ -173,13 +173,15 @@ describe('resolveDownloadUrl — falls back to delivery worker when resolver dis
   });
 });
 
-describe('isDefiniteNotFound — only a 404 proves the object is absent', () => {
+describe('isDefiniteNotFound — absence must be positively reported (404/410)', () => {
   // Callers act on `true` by writing a PERMANENT tombstone that also permanently
   // exempts the file from virus/pickle scanning, so a wrongly-true answer is far
   // more expensive than a wrongly-false one (which costs a single retry).
   it.each([
     ['DeliveryWorkerError 404', new DeliveryWorkerError(404, 'Not Found')],
+    ['DeliveryWorkerError 410', new DeliveryWorkerError(410, 'Gone')],
     ['StorageResolverError 404', new StorageResolverError(404, 'not found')],
+    ['StorageResolverError 410', new StorageResolverError(410, 'gone')],
   ])('is true for %s', (_label, err) => {
     expect(isDefiniteNotFound(err)).toBe(true);
   });

--- a/src/utils/delivery-worker.ts
+++ b/src/utils/delivery-worker.ts
@@ -36,6 +36,31 @@ export class DeliveryWorkerError extends Error {
 }
 
 /**
+ * Thrown by `getDownloadUrlByFileId` when the storage resolver responds non-OK.
+ * Carries the resolver's HTTP `statusCode` for the same reason
+ * `DeliveryWorkerError` does: a caller must be able to tell "this file is not
+ * there" (404) from "the resolver could not answer" (5xx, auth, rate limit).
+ *
+ * This previously threw a bare `Error`, which discarded the status — so every
+ * failure mode looked identical downstream. `createModelFileScanRequest` then
+ * treated all of them as `not-found` and wrote a PERMANENT `ModelFile.exists=false`
+ * tombstone, which also permanently excludes the file from ever being scanned
+ * (see `scanFilesFallbackJob`'s `exists` filter). Measured 2026-08-20: 41 of 41
+ * readable tombstoned files were still fully downloadable, so the tombstones were
+ * recording resolver outages, not missing objects.
+ */
+export class StorageResolverError extends Error {
+  readonly statusCode: number;
+  constructor(statusCode: number, errorText: string) {
+    // Keep the historical "Storage resolver error: …" message so existing
+    // callers/log-matchers that key off it are unaffected.
+    super(`Storage resolver error: ${errorText}`);
+    this.name = 'StorageResolverError';
+    this.statusCode = statusCode;
+  }
+}
+
+/**
  * `decodeURIComponent` throws `URIError: URI malformed` on a value with a
  * broken/truncated percent-sequence (e.g. a lone `%`, `%E0%A4%A`). Some stored
  * `file.url` / filename values are already-encoded or contain raw `%` literals,
@@ -92,7 +117,7 @@ export async function getDownloadUrlByFileId(
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => response.statusText);
-    throw new Error(`Storage resolver error: ${errorText}`);
+    throw new StorageResolverError(response.status, errorText);
   }
 
   const result = await response.json();
@@ -100,6 +125,29 @@ export async function getDownloadUrlByFileId(
     url: result.url,
     urlExpiryDate: new Date(result.urlExpiryDate),
   };
+}
+
+/**
+ * Did this resolution failure prove the file is not there, as opposed to proving
+ * only that we could not ask?
+ *
+ * Deliberately narrow: ONLY a 404 counts. A caller acting on `true` here writes a
+ * permanent tombstone that also permanently exempts the file from virus/pickle
+ * scanning, so the asymmetry matters — a wrongly-`true` answer silently leaves a
+ * public file unscanned forever, while a wrongly-`false` answer costs one retry
+ * on the next tick.
+ *
+ * 400 (malformed key) is NOT included even though such keys are genuinely
+ * unresolvable: 400 is also what a transiently-misbehaving upstream returns, and
+ * the malformed-key population is separately identifiable from the stored `url`
+ * itself. Anything without a status (transport reject, config error, timeout) is
+ * likewise not proof of absence.
+ */
+export function isDefiniteNotFound(err: unknown): boolean {
+  if (err instanceof DeliveryWorkerError || err instanceof StorageResolverError) {
+    return err.statusCode === 404;
+  }
+  return false;
 }
 
 /**

--- a/src/utils/delivery-worker.ts
+++ b/src/utils/delivery-worker.ts
@@ -26,6 +26,18 @@ export type DownloadInfo = {
  */
 export class DeliveryWorkerError extends Error {
   readonly statusCode: number;
+  /**
+   * Set by `resolveDownloadUrl` when the storage resolver was consulted FIRST and
+   * also failed, so this delivery-worker error is the second of two answers.
+   *
+   * 🔴 Load-bearing for `isDefiniteNotFound`. The delivery worker is the legacy
+   * path keyed off `ModelFile.url`; a file whose bytes are registered only in
+   * `file_locations` is resolvable ONLY through the storage resolver. So when the
+   * resolver could not answer, a delivery-worker 404 does not mean the object is
+   * absent — it can equally mean "the only component that could have found it was
+   * down". Keeping the resolver's error here is what lets the two be told apart.
+   */
+  resolverError?: unknown;
   constructor(statusCode: number, statusText: string) {
     // Keep the historical "Delivery worker error: …" message so existing
     // callers/log-matchers that key off it are unaffected.
@@ -128,6 +140,14 @@ export async function getDownloadUrlByFileId(
 }
 
 /**
+ * Statuses that positively assert the object is not there. 410 is included for
+ * consistency with the download endpoint, which has always treated `404 || 410`
+ * as "the key doesn't resolve to a stored file" (`src/pages/api/download/[...key].ts`),
+ * and the delivery worker does return 410 in practice.
+ */
+const ABSENCE_STATUSES = new Set([404, 410]);
+
+/**
  * Did this resolution failure prove the file is not there, as opposed to proving
  * only that we could not ask?
  *
@@ -144,9 +164,24 @@ export async function getDownloadUrlByFileId(
  * likewise not proof of absence.
  */
 export function isDefiniteNotFound(err: unknown): boolean {
-  if (err instanceof DeliveryWorkerError || err instanceof StorageResolverError) {
-    return err.statusCode === 404;
+  if (err instanceof StorageResolverError) return ABSENCE_STATUSES.has(err.statusCode);
+
+  if (err instanceof DeliveryWorkerError) {
+    if (!ABSENCE_STATUSES.has(err.statusCode)) return false;
+    // The resolver was consulted first and also failed. Its answer decides: only
+    // the resolver can locate a file registered in `file_locations`, so unless IT
+    // reported absence, this 404 is "the legacy path can't see it", not "gone".
+    if (err.resolverError !== undefined) {
+      return (
+        err.resolverError instanceof StorageResolverError &&
+        ABSENCE_STATUSES.has(err.resolverError.statusCode)
+      );
+    }
+    // Resolver disabled, or it succeeded and the failure came later: the delivery
+    // worker was the only authority and it said not-there.
+    return true;
   }
+
   return false;
 }
 
@@ -167,13 +202,26 @@ export async function resolveDownloadUrl(
   fileName?: string
 ): Promise<DownloadInfo> {
   if (isStorageResolverEnabled()) {
+    let resolverError: unknown;
     try {
       return await getDownloadUrlByFileId(fileId, fileName);
-    } catch {
+    } catch (err) {
       // Fall back to delivery worker when the storage resolver doesn't have
       // this file (e.g. File table records like BountyEntry attachments that
-      // aren't synced to file_locations).
-      return getDownloadUrl(fileUrl, fileName);
+      // aren't synced to file_locations). The fallback must still happen on a
+      // resolver 404 — that is its whole purpose — so we cannot short-circuit
+      // here. But we must not DISCARD the resolver's answer either: keep it and
+      // attach it below, so a caller can tell "both said absent" from "the
+      // resolver was down and the legacy path simply can't see this file".
+      resolverError = err;
+    }
+    try {
+      return await getDownloadUrl(fileUrl, fileName);
+    } catch (deliveryWorkerError) {
+      if (deliveryWorkerError instanceof DeliveryWorkerError) {
+        deliveryWorkerError.resolverError = resolverError;
+      }
+      throw deliveryWorkerError;
     }
   }
   return getDownloadUrl(fileUrl, fileName);

--- a/src/utils/delivery-worker.ts
+++ b/src/utils/delivery-worker.ts
@@ -192,9 +192,10 @@ export function isDefiniteNotFound(err: unknown): boolean {
         ABSENCE_STATUSES.has(err.resolverError.statusCode)
       );
     }
-    // Reached only when the resolver is disabled: if it had succeeded,
-    // `resolveDownloadUrl` would have returned rather than reaching the fallback.
-    // The delivery worker was the only authority and it said not-there.
+    // Reached when the resolver was not CONSULTED at all — the disabled path, or
+    // a direct `getDownloadUrl` caller. (It cannot mean "the resolver succeeded":
+    // `resolveDownloadUrl` returns on success rather than reaching the fallback.)
+    // The delivery worker was then the only authority, and it said not-there.
     return true;
   }
 

--- a/src/utils/delivery-worker.ts
+++ b/src/utils/delivery-worker.ts
@@ -140,10 +140,14 @@ export async function getDownloadUrlByFileId(
 }
 
 /**
- * Statuses that positively assert the object is not there. 410 is included for
- * consistency with the download endpoint, which has always treated `404 || 410`
- * as "the key doesn't resolve to a stored file" (`src/pages/api/download/[...key].ts`),
- * and the delivery worker does return 410 in practice.
+ * Statuses that positively assert the object is not there — 404 and 410 only.
+ *
+ * 410 is included to match the download endpoint, which has always treated
+ * `404 || 410` as "the key doesn't resolve to a stored file"
+ * (`src/pages/api/download/[...key].ts`) — a handling decision that predates this
+ * code. Whether the delivery worker actually EMITS a 410 is not established in
+ * this repo (it is a Cloudflare Worker whose source lives elsewhere), so treat
+ * 410 as defensive parity, not as an observed case.
  */
 const ABSENCE_STATUSES = new Set([404, 410]);
 
@@ -151,11 +155,12 @@ const ABSENCE_STATUSES = new Set([404, 410]);
  * Did this resolution failure prove the file is not there, as opposed to proving
  * only that we could not ask?
  *
- * Deliberately narrow: ONLY a 404 counts. A caller acting on `true` here writes a
- * permanent tombstone that also permanently exempts the file from virus/pickle
- * scanning, so the asymmetry matters — a wrongly-`true` answer silently leaves a
- * public file unscanned forever, while a wrongly-`false` answer costs one retry
- * on the next tick.
+ * Deliberately narrow: only the statuses in `ABSENCE_STATUSES` count, and when the
+ * storage resolver was consulted it must be the one that said so. A caller acting
+ * on `true` writes a permanent tombstone that also permanently exempts the file
+ * from virus/pickle scanning, so the asymmetry matters — a wrongly-`true` answer
+ * silently leaves a public file unscanned forever, while a wrongly-`false` answer
+ * costs one retry on the next tick.
  *
  * 400 (malformed key) is NOT included even though such keys are genuinely
  * unresolvable: 400 is also what a transiently-misbehaving upstream returns, and
@@ -164,21 +169,32 @@ const ABSENCE_STATUSES = new Set([404, 410]);
  * likewise not proof of absence.
  */
 export function isDefiniteNotFound(err: unknown): boolean {
+  // Note: unreachable from the scan pre-flight today — `resolveDownloadUrl` always
+  // falls through to the delivery worker, so a StorageResolverError never escapes
+  // it. Kept so the predicate is correct for any direct caller of
+  // `getDownloadUrlByFileId`.
   if (err instanceof StorageResolverError) return ABSENCE_STATUSES.has(err.statusCode);
 
   if (err instanceof DeliveryWorkerError) {
     if (!ABSENCE_STATUSES.has(err.statusCode)) return false;
     // The resolver was consulted first and also failed. Its answer decides: only
     // the resolver can locate a file registered in `file_locations`, so unless IT
-    // reported absence, this 404 is "the legacy path can't see it", not "gone".
+    // reported absence, this is "the legacy path can't see it", not "gone".
+    //
+    // 🔴 `!== undefined`, NOT an `instanceof` narrowing. A resolver that fails at
+    // the TRANSPORT layer (connection refused, DNS, TCP timeout — what a pod
+    // outage actually looks like) throws a TypeError, not a StorageResolverError.
+    // Narrowing the guard would leave that unattached and fall through to
+    // `return true`, tombstoning the file: precisely the bug this exists to stop.
     if (err.resolverError !== undefined) {
       return (
         err.resolverError instanceof StorageResolverError &&
         ABSENCE_STATUSES.has(err.resolverError.statusCode)
       );
     }
-    // Resolver disabled, or it succeeded and the failure came later: the delivery
-    // worker was the only authority and it said not-there.
+    // Reached only when the resolver is disabled: if it had succeeded,
+    // `resolveDownloadUrl` would have returned rather than reaching the fallback.
+    // The delivery worker was the only authority and it said not-there.
     return true;
   }
 


### PR DESCRIPTION
## The bug

A **transient** failure to resolve a download URL is recorded as a **permanent** "this file is gone" flag — and that flag also permanently exempts the file from virus and pickle scanning, while the file stays `Published`, `Public`, and downloadable.

`createModelFileScanRequest` pre-flights a scan submission by calling `resolveDownloadUrl` twice, 60s apart. The second `catch` was untyped, so **every** failure mode — resolver 5xx, timeout, rate limit, auth failure, DNS, a transport reject — produced `code: 'not-found'`. `scanFilesFallbackJob` converts that code into `ModelFile.exists = false`, and its own query then filters those rows out:

```ts
{ OR: [{ exists: null }, { exists: true }] },
```

So one bad minute at the resolver takes a healthy file out of the scan queue permanently. Nothing ever revisits it.

## Evidence it was misfiring

Measured against the real download path (endpoint redirect → range-GET the signed URL it returns):

- **41 of 41** readable files carrying the `exists = false` tombstone were still **fully downloadable** (`307` → `206`), across **51 distinct uploaders**. Zero were actually missing.
- The tombstones arrive in **bursts**, which independent file losses would not: the top 5 hours hold **52%** of them, with 85 distinct model versions tombstoned inside a single hour. For comparison, successful scans over the same period put only **1.4%** of their volume in their top 5 hours — and the scanner demonstrably sustains ~1,100 files/hour, so this isn't a busy-period artifact.

## The fix

1. `getDownloadUrlByFileId` threw a bare `Error`, discarding `response.status`. It now throws a `StorageResolverError` carrying the status — mirroring `DeliveryWorkerError`, which has carried it all along. That class's own docstring already described this exact hazard ("masking a real storage outage as *not found*"); the mechanism existed and simply wasn't used here.
2. New `isDefiniteNotFound(err)` — deliberately narrow: **only a 404** counts as proof of absence. The asymmetry is the point. Acting wrongly on `true` leaves a public file unscanned forever; acting wrongly on `false` costs one retry on the next 5-minute tick. `400` (malformed key) is excluded too — genuinely-unresolvable keys are separately identifiable from the stored `url`, and 400 is also what a transiently-misbehaving upstream returns.
3. `createModelFileScanRequest` classifies on the **retry's** failure — the most recent evidence, and the first failure may well be the transient one the retry exists to absorb. Anything that isn't a proven 404 is now `'transient'`, which already had correct handling (reset `scanRequestedAt`, retry next tick).

No change to the caller's branching: `not-found` still tombstones, `transient` still retries. Only the classification moved.

## Tests

`60 passed` across the three affected suites.

The regression guard was **watched to fail** on the pre-fix behaviour. Reverting only the classification expression (leaving all other changes in place, so the mutation is isolated to the line under test) turns **8 tests red** with `expected 'not-found' to be 'transient'` — the exact defect — while both legitimate `not-found` cases stay green, so the tests are not merely asserting "always transient". Every pre-existing test stays green under that mutation.

Covered: resolver 500/503/401, delivery-worker 429/503, a status-less transport error, a non-`Error` rejection, a plain object that merely *looks* like a 404, and both orderings of a 404 paired with a 5xx.

One pre-existing test — `'throws code=not-found when both pre-flight attempts fail'` — asserted the old behaviour using a bare `Error`. It encoded the bug, so it is now split into the 404 case and the transient case.

The `~/utils/delivery-worker` mock in `createModelFileScanRequest.test.ts` was a wholesale one-key replacement; it now spreads the real module and overrides only `resolveDownloadUrl`. Otherwise the classification under test would have been a property of the fake, and the mock would have gone stale the moment the module gained an export — which is precisely what adding `isDefiniteNotFound` did.

## Follow-up, not in this PR

Existing tombstones were written by the broken predicate and are untrustworthy. Clearing `exists = false` on the affected rows returns those files to the scan queue — but only **after** this lands, or the next transient blip re-tombstones them. That's a production data change and belongs in its own change.

Separately: whether a `Published` + `Public` file whose scan has never completed should be downloadable at all is a product question this PR does not touch.
