### PR TITLE
revert(models): bring the category bar back on the models feeds

### DIFF
--- a/docs/cls-remediation-plan.md
+++ b/docs/cls-remediation-plan.md
@@ -112,7 +112,8 @@ but more plumbing) for being surgical and zero-risk.
 > `/user/[username]/models`, via `CategoryTags`, which never used `TagScroller` and so
 > never carried the reservation this section describes. It carries its own `min-h-[26px]`
 > now, in both the empty and populated states. So the shift cannot occur on any surface:
-> removed everywhere else, reserved on the two that render it.
+> removed from every other feed, and reserved on all three surfaces that still render
+> `CategoryTags` — those two pages and the generation resource-select modal.
 
 **Verified (local dev build, same `layout-shift` harness):**
 

--- a/docs/cls-remediation-plan.md
+++ b/docs/cls-remediation-plan.md
@@ -103,11 +103,16 @@ model3d) share `TagScroller` and it has no other usages, so this one change cove
 Chosen over SSR-seeding `useCategoryTags` (cleaner first paint, no reserved space,
 but more plumbing) for being surgical and zero-risk.
 
-> **Superseded (2026-08-19).** The category tag filter bar was removed from every
-> feed-like surface, and `TagScroller` and its five `*Categories` consumers were
-> deleted with it (ClickUp 868ku6983). The shift this section describes can no
-> longer occur, because the element that caused it no longer renders. The file
-> links above point at deleted paths and are kept for the record.
+> **Superseded (2026-08-19), then partly reinstated (2026-08-20).** The category tag
+> filter bar was removed from every feed-like surface, and `TagScroller` and its five
+> `*Categories` consumers were deleted with it (ClickUp 868ku6983). The file links
+> above point at deleted paths and are kept for the record.
+>
+> The bar came back for **models only** (ClickUp 868kumr1c) — `/models` and
+> `/user/[username]/models`, via `CategoryTags`, which never used `TagScroller` and so
+> never carried the reservation this section describes. It carries its own `min-h-[26px]`
+> now, in both the empty and populated states. So the shift cannot occur on any surface:
+> removed everywhere else, reserved on the two that render it.
 
 **Verified (local dev build, same `layout-shift` harness):**
 

--- a/src/components/CategoryTags/CategoryTags.tsx
+++ b/src/components/CategoryTags/CategoryTags.tsx
@@ -21,15 +21,23 @@ export function CategoryTags({
 
   const { data: categories } = useCategoryTags({ entityType: TagTarget.Model });
 
-  if (!categories.length) return null;
+  // Reserve the row height while the client-side `useCategoryTags` query and the hidden
+  // preferences resolve. Returning null lets the 26px chip row pop in and shove the feed
+  // down — the shift `docs/cls-remediation-plan.md` measured at 0.65 on /images. That fix
+  // landed in TagScroller, which these surfaces never used.
+  if (!categories.length) return <div className="min-h-[26px]" />;
 
   const handleSetTag = (tag: string | undefined) => set({ tag });
 
-  const _tag = selected ?? tagQuery;
+  // Controlled and uncontrolled are either/or, not a fallback chain: the generation
+  // resource-select modal opens over /models, so `selected ?? tagQuery` would let the
+  // page's `?tag=` light up a chip the modal has not actually filtered on.
+  const controlled = !!setSelected;
+  const _tag = controlled ? selected : tagQuery;
   const _setTag = setSelected ?? handleSetTag;
 
   return (
-    <TwScrollX className="flex gap-1">
+    <TwScrollX className="flex min-h-[26px] gap-1">
       {includeAll && (
         <Button
           className="overflow-visible uppercase"

--- a/src/components/CategoryTags/CategoryTags.tsx
+++ b/src/components/CategoryTags/CategoryTags.tsx
@@ -7,6 +7,8 @@ import { TagTarget } from '~/shared/utils/prisma/enums';
 
 // `selected` without `setSelected` would be silently discarded — the bar reads the URL
 // and writes it, ignoring the prop. Pairing them in the type makes that uncompilable.
+// The controlled branch admits an explicit `selected={undefined}` only because
+// `exactOptionalPropertyTypes` is off; turning it on breaks the resource-select modal here.
 type CategoryTagsProps = {
   filter?: (tag: string) => boolean;
   includeAll?: boolean;

--- a/src/components/CategoryTags/CategoryTags.tsx
+++ b/src/components/CategoryTags/CategoryTags.tsx
@@ -5,26 +5,33 @@ import { useCategoryTags } from '~/components/Tags/tag.utils';
 import { TwScrollX } from '~/components/TwScrollX/TwScrollX';
 import { TagTarget } from '~/shared/utils/prisma/enums';
 
+// `selected` without `setSelected` would be silently discarded — the bar reads the URL
+// and writes it, ignoring the prop. Pairing them in the type makes that uncompilable.
+type CategoryTagsProps = {
+  filter?: (tag: string) => boolean;
+  includeAll?: boolean;
+} & (
+  | { selected?: undefined; setSelected?: undefined }
+  | { selected?: string; setSelected: (tag?: string) => void }
+);
+
 export function CategoryTags({
   selected,
   setSelected,
   filter,
   includeAll = true,
-}: {
-  selected?: string;
-  setSelected?: (tag?: string) => void;
-  filter?: (tag: string) => boolean;
-  includeAll?: boolean;
-}) {
+}: CategoryTagsProps) {
   const colorScheme = useComputedColorScheme('dark');
   const { set, tag: tagQuery } = useModelQueryParams();
 
   const { data: categories } = useCategoryTags({ entityType: TagTarget.Model });
 
   // Reserve the row height while the client-side `useCategoryTags` query and the hidden
-  // preferences resolve. Returning null lets the 26px chip row pop in and shove the feed
-  // down — the shift `docs/cls-remediation-plan.md` measured at 0.65 on /images. That fix
-  // landed in TagScroller, which these surfaces never used.
+  // preferences resolve. Returning null lets the chip row pop in and shove the feed down —
+  // the shift `docs/cls-remediation-plan.md` measured at 0.65 on /images. That fix landed
+  // in TagScroller, which these surfaces never used. 26px is Mantine's
+  // `--button-height-compact-sm`; both states must carry it or the row shifts one way or
+  // the other.
   if (!categories.length) return <div className="min-h-[26px]" />;
 
   const handleSetTag = (tag: string | undefined) => set({ tag });

--- a/src/components/CategoryTags/CategoryTags.tsx
+++ b/src/components/CategoryTags/CategoryTags.tsx
@@ -1,5 +1,6 @@
 import { Button, useComputedColorScheme } from '@mantine/core';
 
+import { useModelQueryParams } from '~/components/Model/model.utils';
 import { useCategoryTags } from '~/components/Tags/tag.utils';
 import { TwScrollX } from '~/components/TwScrollX/TwScrollX';
 import { TagTarget } from '~/shared/utils/prisma/enums';
@@ -8,30 +9,49 @@ export function CategoryTags({
   selected,
   setSelected,
   filter,
+  includeAll = true,
 }: {
   selected?: string;
-  setSelected: (tag?: string) => void;
+  setSelected?: (tag?: string) => void;
   filter?: (tag: string) => boolean;
+  includeAll?: boolean;
 }) {
   const colorScheme = useComputedColorScheme('dark');
+  const { set, tag: tagQuery } = useModelQueryParams();
 
   const { data: categories } = useCategoryTags({ entityType: TagTarget.Model });
 
   if (!categories.length) return null;
 
+  const handleSetTag = (tag: string | undefined) => set({ tag });
+
+  const _tag = selected ?? tagQuery;
+  const _setTag = setSelected ?? handleSetTag;
+
   return (
     <TwScrollX className="flex gap-1">
+      {includeAll && (
+        <Button
+          className="overflow-visible uppercase"
+          variant={!_tag ? 'filled' : colorScheme === 'dark' ? 'filled' : 'light'}
+          color={!_tag ? 'blue' : 'gray'}
+          onClick={() => _setTag(undefined)}
+          size="compact-sm"
+        >
+          All
+        </Button>
+      )}
       {categories
         .filter((x) => (filter ? filter(x.name) : true))
         .map((tag) => {
-          const active = selected === tag.name;
+          const active = _tag === tag.name;
           return (
             <Button
               key={tag.id}
               className="overflow-visible uppercase"
               variant={active ? 'filled' : colorScheme === 'dark' ? 'filled' : 'light'}
               color={active ? 'blue' : 'gray'}
-              onClick={() => setSelected(!active ? tag.name : undefined)}
+              onClick={() => _setTag(!active ? tag.name : undefined)}
               size="compact-sm"
             >
               {tag.name}

--- a/src/components/CategoryTags/__tests__/CategoryTags.test.ts
+++ b/src/components/CategoryTags/__tests__/CategoryTags.test.ts
@@ -171,6 +171,11 @@ describe('CategoryTags', () => {
 
     expect(backgroundOf(container, 'style')).toBe('var(--mantine-color-blue-filled)');
     expect(backgroundOf(container, 'character')).toBe('var(--mantine-color-gray-filled)');
+
+    // The All chip carries the same two ternaries and is inactive here; without this the
+    // dark arm can be deleted from it alone and every other assertion stays green.
+    expect(variantOf(container, 'All')).toBe('filled');
+    expect(backgroundOf(container, 'All')).toBe('var(--mantine-color-gray-filled)');
   });
 
   it('fills the All chip when no category is active', () => {
@@ -178,6 +183,9 @@ describe('CategoryTags', () => {
 
     expect(variantOf(container, 'All')).toBe('filled');
     expect(variantOf(container, 'style')).toBe('light');
+
+    // All is the active chip on a bare /models, so its blue is the page's default state.
+    expect(backgroundOf(container, 'All')).toBe('var(--mantine-color-blue-filled)');
   });
 
   it('prefers selected over ?tag= when controlled, and leaves the URL alone', () => {
@@ -252,19 +260,16 @@ describe('models surfaces mount the category bar', () => {
 
     // Commented-out JSX still contains the string, and commenting it out is the likelier
     // way the bar disappears than deletion. `124e256a44` on main was this same bug in this
-    // same shape of test: a commented-out INSERT counted as a writer. Verified against
-    // deletion, a `{/* */}` wrap and a moved file; a deliberate `{false && ...}` guard
-    // still counts, which is the known limit of scanning source rather than rendering.
-    const mounted = source
+    // same shape of test: a commented-out INSERT counted as a writer. Block comments are
+    // stripped first because wrapping a multi-line selection is what an editor's
+    // comment command produces. A deliberate `{false && ...}` guard still counts — that is
+    // the known limit of scanning source rather than rendering, and it is a change a
+    // reviewer sees in a diff, unlike a mount vanishing in a conflict resolution.
+    const code = source.replace(/\{\/\*[\s\S]*?\*\/\}/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+    const mounted = code
       .split('\n')
       .map((line) => line.trim())
-      .filter(
-        (line) =>
-          line.includes('<CategoryTags') &&
-          !line.startsWith('//') &&
-          !line.startsWith('{/*') &&
-          !line.startsWith('*')
-      );
+      .filter((line) => line.includes('<CategoryTags') && !line.startsWith('//'));
 
     expect(source).toContain("from '~/components/CategoryTags/CategoryTags'");
     expect(mounted).toHaveLength(expected);

--- a/src/components/CategoryTags/__tests__/CategoryTags.test.ts
+++ b/src/components/CategoryTags/__tests__/CategoryTags.test.ts
@@ -26,16 +26,19 @@ import { MantineProvider } from '@mantine/core';
 
 import { CategoryTags } from '~/components/CategoryTags/CategoryTags';
 
-globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-function render(props?: Parameters<typeof CategoryTags>[0]) {
+function render(
+  props?: Parameters<typeof CategoryTags>[0],
+  colorScheme: 'light' | 'dark' = 'light'
+) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   act(() => {
     createRoot(container).render(
       createElement(
         MantineProvider,
-        { forceColorScheme: 'light' },
+        { forceColorScheme: colorScheme },
         createElement(CategoryTags, props)
       )
     );
@@ -47,12 +50,29 @@ function buttonLabels(container: HTMLElement) {
   return Array.from(container.querySelectorAll('button')).map((b) => b.textContent?.trim());
 }
 
-function variantOf(container: HTMLElement, label: string) {
+function reservedRows(container: HTMLElement) {
+  return Array.from(container.querySelectorAll('div')).filter((el) =>
+    el.className.includes('min-h-[26px]')
+  );
+}
+
+function buttonNamed(container: HTMLElement, label: string) {
   const button = Array.from(container.querySelectorAll('button')).find(
     (b) => b.textContent?.trim() === label
   );
   if (!button) throw new Error(`no button labelled ${label}; found ${buttonLabels(container)}`);
-  return button.dataset.variant;
+  return button;
+}
+
+function variantOf(container: HTMLElement, label: string) {
+  return buttonNamed(container, label).dataset.variant;
+}
+
+// Mantine resolves variant+color into this custom property on the button's inline style.
+// In dark mode every chip is `filled`, so colour is the only thing separating active from
+// inactive there — asserting variant alone would leave that undetectable.
+function backgroundOf(container: HTMLElement, label: string) {
+  return buttonNamed(container, label).style.getPropertyValue('--button-bg');
 }
 
 function clickButton(container: HTMLElement, label: string) {
@@ -83,6 +103,10 @@ describe('CategoryTags', () => {
   it('renders the All chip plus every category by default', () => {
     const container = render();
     expect(buttonLabels(container)).toEqual(['All', 'character', 'style']);
+
+    // The populated row needs the reservation too: with `filter` or `includeAll: false` it
+    // can hold zero chips, and would then collapse below the height the empty state holds.
+    expect(reservedRows(container)).toHaveLength(1);
   });
 
   it('omits the All chip when includeAll is false', () => {
@@ -131,6 +155,22 @@ describe('CategoryTags', () => {
     expect(variantOf(container, 'style')).toBe('filled');
     expect(variantOf(container, 'character')).toBe('light');
     expect(variantOf(container, 'All')).toBe('light');
+
+    expect(backgroundOf(container, 'style')).toBe('var(--mantine-color-blue-filled)');
+    expect(backgroundOf(container, 'character')).toBe('var(--mantine-color-gray-light)');
+  });
+
+  // The inactive chips take a different variant per scheme. Testing only in light leaves
+  // the dark arm of that expression unexecuted.
+  it('keeps inactive chips filled in dark mode, separating them by colour', () => {
+    mocks.query = { tag: 'style' };
+    const container = render(undefined, 'dark');
+
+    expect(variantOf(container, 'character')).toBe('filled');
+    expect(variantOf(container, 'style')).toBe('filled');
+
+    expect(backgroundOf(container, 'style')).toBe('var(--mantine-color-blue-filled)');
+    expect(backgroundOf(container, 'character')).toBe('var(--mantine-color-gray-filled)');
   });
 
   it('fills the All chip when no category is active', () => {
@@ -178,10 +218,7 @@ describe('CategoryTags', () => {
     const container = render();
 
     expect(container.querySelector('button')).toBeNull();
-    const reserved = Array.from(container.querySelectorAll('div')).filter((el) =>
-      el.className.includes('min-h-[26px]')
-    );
-    expect(reserved).toHaveLength(1);
+    expect(reservedRows(container)).toHaveLength(1);
   });
 
   it('applies the filter prop, dropping excluded categories', () => {
@@ -202,14 +239,34 @@ describe('CategoryTags', () => {
  * the bar is on the pages at all.
  */
 describe('models surfaces mount the category bar', () => {
-  it.each([['src/pages/models/index.tsx'], ['src/pages/user/[username]/models.tsx']])(
-    '%s renders <CategoryTags />',
-    (relative) => {
-      // readFileSync throws on a moved or renamed page rather than silently passing.
-      const source = fs.readFileSync(path.join(process.cwd(), ...relative.split('/')), 'utf-8');
+  // The profile page mounts it twice, in the published and private branches. Counting
+  // rather than asserting presence is what catches one branch losing it.
+  it.each([
+    ['src/pages/models/index.tsx', 1],
+    ['src/pages/user/[username]/models.tsx', 2],
+  ])('%s renders <CategoryTags /> %i time(s)', (relative, expected) => {
+    // Resolved from __dirname, not cwd, so the guard does not depend on how vitest was
+    // invoked; readFileSync throws on a moved or renamed page rather than silently passing.
+    const repoRoot = path.resolve(__dirname, '../../../..');
+    const source = fs.readFileSync(path.join(repoRoot, ...relative.split('/')), 'utf-8');
 
-      expect(source).toContain("from '~/components/CategoryTags/CategoryTags'");
-      expect(source).toContain('<CategoryTags');
-    }
-  );
+    // Commented-out JSX still contains the string, and commenting it out is the likelier
+    // way the bar disappears than deletion. `124e256a44` on main was this same bug in this
+    // same shape of test: a commented-out INSERT counted as a writer. Verified against
+    // deletion, a `{/* */}` wrap and a moved file; a deliberate `{false && ...}` guard
+    // still counts, which is the known limit of scanning source rather than rendering.
+    const mounted = source
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(
+        (line) =>
+          line.includes('<CategoryTags') &&
+          !line.startsWith('//') &&
+          !line.startsWith('{/*') &&
+          !line.startsWith('*')
+      );
+
+    expect(source).toContain("from '~/components/CategoryTags/CategoryTags'");
+    expect(mounted).toHaveLength(expected);
+  });
 });

--- a/src/components/CategoryTags/__tests__/CategoryTags.test.ts
+++ b/src/components/CategoryTags/__tests__/CategoryTags.test.ts
@@ -1,4 +1,6 @@
 // @vitest-environment happy-dom
+import fs from 'fs';
+import path from 'path';
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -8,6 +10,7 @@ import type * as TagUtils from '~/components/Tags/tag.utils';
 const mocks = vi.hoisted(() => ({
   replace: vi.fn(),
   query: {} as Record<string, unknown>,
+  categories: [] as { id: number; name: string }[],
 }));
 
 vi.mock('next/router', () => ({
@@ -16,25 +19,25 @@ vi.mock('next/router', () => ({
 
 vi.mock('~/components/Tags/tag.utils', async (importOriginal) => ({
   ...(await importOriginal<typeof TagUtils>()),
-  useCategoryTags: () => ({
-    data: [
-      { id: 1, name: 'character' },
-      { id: 2, name: 'style' },
-    ],
-    isLoading: false,
-  }),
+  useCategoryTags: () => ({ data: mocks.categories, isLoading: false }),
 }));
 
 import { MantineProvider } from '@mantine/core';
 
 import { CategoryTags } from '~/components/CategoryTags/CategoryTags';
 
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
 function render(props?: Parameters<typeof CategoryTags>[0]) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   act(() => {
     createRoot(container).render(
-      createElement(MantineProvider, null, createElement(CategoryTags, props))
+      createElement(
+        MantineProvider,
+        { forceColorScheme: 'light' },
+        createElement(CategoryTags, props)
+      )
     );
   });
   return container;
@@ -42,6 +45,14 @@ function render(props?: Parameters<typeof CategoryTags>[0]) {
 
 function buttonLabels(container: HTMLElement) {
   return Array.from(container.querySelectorAll('button')).map((b) => b.textContent?.trim());
+}
+
+function variantOf(container: HTMLElement, label: string) {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    (b) => b.textContent?.trim() === label
+  );
+  if (!button) throw new Error(`no button labelled ${label}; found ${buttonLabels(container)}`);
+  return button.dataset.variant;
 }
 
 function clickButton(container: HTMLElement, label: string) {
@@ -63,6 +74,10 @@ describe('CategoryTags', () => {
   beforeEach(() => {
     mocks.replace.mockClear();
     mocks.query = {};
+    mocks.categories = [
+      { id: 1, name: 'character' },
+      { id: 2, name: 'style' },
+    ];
   });
 
   it('renders the All chip plus every category by default', () => {
@@ -107,13 +122,94 @@ describe('CategoryTags', () => {
     expect(target.query).not.toHaveProperty('tag');
   });
 
-  it('defers to setSelected when controlled, leaving the URL alone', () => {
+  // Asserted before any click: the router is mocked, so `mocks.query` never moves in
+  // response to `replace` and a post-click read would report the pre-click state.
+  it('marks the active chip, and only it, as filled', () => {
+    mocks.query = { tag: 'style' };
+    const container = render();
+
+    expect(variantOf(container, 'style')).toBe('filled');
+    expect(variantOf(container, 'character')).toBe('light');
+    expect(variantOf(container, 'All')).toBe('light');
+  });
+
+  it('fills the All chip when no category is active', () => {
+    const container = render();
+
+    expect(variantOf(container, 'All')).toBe('filled');
+    expect(variantOf(container, 'style')).toBe('light');
+  });
+
+  it('prefers selected over ?tag= when controlled, and leaves the URL alone', () => {
     const setSelected = vi.fn();
-    const container = render({ selected: undefined, setSelected });
+    mocks.query = { tag: 'character' };
+    const container = render({ selected: 'style', setSelected });
 
+    // Active per `selected`, so this toggles off.
     clickButton(container, 'style');
+    expect(setSelected).toHaveBeenCalledTimes(1);
+    expect(setSelected).toHaveBeenCalledWith(undefined);
 
-    expect(setSelected).toHaveBeenCalledWith('style');
+    // Negative control: `?tag=character` must not select anything in a controlled bar.
+    clickButton(container, 'character');
+    expect(setSelected).toHaveBeenLastCalledWith('character');
+
     expect(mocks.replace).not.toHaveBeenCalled();
   });
+
+  // The generation resource-select modal opens over /models with `selected` undefined
+  // until the user picks. A `selected ?? tagQuery` fallback would light up the page's
+  // category behind the modal and swallow the first click as a toggle-off.
+  it('ignores ?tag= entirely when controlled with no selection', () => {
+    const setSelected = vi.fn();
+    mocks.query = { tag: 'character' };
+    const container = render({ selected: undefined, setSelected, includeAll: false });
+
+    expect(variantOf(container, 'character')).toBe('light');
+
+    clickButton(container, 'character');
+    expect(setSelected).toHaveBeenCalledWith('character');
+  });
+
+  // The chip row resolves client-side. Rendering nothing until it does lets it pop in
+  // above the feed and shove it down — 0.65 CLS on /images when this last shipped.
+  it('reserves the row height before the categories resolve', () => {
+    mocks.categories = [];
+    const container = render();
+
+    expect(container.querySelector('button')).toBeNull();
+    const reserved = Array.from(container.querySelectorAll('div')).filter((el) =>
+      el.className.includes('min-h-[26px]')
+    );
+    expect(reserved).toHaveLength(1);
+  });
+
+  it('applies the filter prop, dropping excluded categories', () => {
+    const container = render({
+      includeAll: false,
+      setSelected: vi.fn(),
+      filter: (tag) => tag !== 'style',
+    });
+
+    expect(buttonLabels(container)).toEqual(['character']);
+  });
+});
+
+/**
+ * The component tests all render CategoryTags directly, so deleting the JSX from the
+ * pages leaves every one of them green — which is how #4141 shipped ActiveTagFilter
+ * with a passing suite and no mount point anywhere. This is the only assertion that
+ * the bar is on the pages at all.
+ */
+describe('models surfaces mount the category bar', () => {
+  it.each([['src/pages/models/index.tsx'], ['src/pages/user/[username]/models.tsx']])(
+    '%s renders <CategoryTags />',
+    (relative) => {
+      // readFileSync throws on a moved or renamed page rather than silently passing.
+      const source = fs.readFileSync(path.join(process.cwd(), ...relative.split('/')), 'utf-8');
+
+      expect(source).toContain("from '~/components/CategoryTags/CategoryTags'");
+      expect(source).toContain('<CategoryTags');
+    }
+  );
 });

--- a/src/components/CategoryTags/__tests__/CategoryTags.test.ts
+++ b/src/components/CategoryTags/__tests__/CategoryTags.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as TagUtils from '~/components/Tags/tag.utils';
+
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+  query: {} as Record<string, unknown>,
+}));
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ query: mocks.query, pathname: '/models', replace: mocks.replace }),
+}));
+
+vi.mock('~/components/Tags/tag.utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof TagUtils>()),
+  useCategoryTags: () => ({
+    data: [
+      { id: 1, name: 'character' },
+      { id: 2, name: 'style' },
+    ],
+    isLoading: false,
+  }),
+}));
+
+import { MantineProvider } from '@mantine/core';
+
+import { CategoryTags } from '~/components/CategoryTags/CategoryTags';
+
+function render(props?: Parameters<typeof CategoryTags>[0]) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    createRoot(container).render(
+      createElement(MantineProvider, null, createElement(CategoryTags, props))
+    );
+  });
+  return container;
+}
+
+function buttonLabels(container: HTMLElement) {
+  return Array.from(container.querySelectorAll('button')).map((b) => b.textContent?.trim());
+}
+
+function clickButton(container: HTMLElement, label: string) {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    (b) => b.textContent?.trim() === label
+  );
+  if (!button) throw new Error(`no button labelled ${label}; found ${buttonLabels(container)}`);
+  act(() => {
+    button.click();
+  });
+}
+
+/**
+ * The bar is the only category navigation on /models — without it categories are
+ * reachable only from inside a search. If the uncontrolled path stops reading and
+ * writing `?tag=`, browsing by category is gone with nothing else offering it.
+ */
+describe('CategoryTags', () => {
+  beforeEach(() => {
+    mocks.replace.mockClear();
+    mocks.query = {};
+  });
+
+  it('renders the All chip plus every category by default', () => {
+    const container = render();
+    expect(buttonLabels(container)).toEqual(['All', 'character', 'style']);
+  });
+
+  it('omits the All chip when includeAll is false', () => {
+    const container = render({ includeAll: false, setSelected: vi.fn() });
+    expect(buttonLabels(container)).toEqual(['character', 'style']);
+  });
+
+  it('writes the category to ?tag= when uncontrolled', () => {
+    mocks.query = { sort: 'Newest' };
+    const container = render();
+
+    clickButton(container, 'character');
+
+    expect(mocks.replace).toHaveBeenCalledTimes(1);
+    const [target] = mocks.replace.mock.calls[0];
+    expect(target.query).toEqual({ sort: 'Newest', tag: 'character' });
+  });
+
+  it('clears ?tag= from All, keeping the rest of the query', () => {
+    mocks.query = { tag: 'character', sort: 'Newest' };
+    const container = render();
+
+    clickButton(container, 'All');
+
+    const [target] = mocks.replace.mock.calls[0];
+    expect(target.query).toEqual({ sort: 'Newest' });
+    expect(target.query).not.toHaveProperty('tag');
+  });
+
+  it('reads the active category from ?tag= rather than from props', () => {
+    mocks.query = { tag: 'style' };
+    const container = render();
+
+    clickButton(container, 'style');
+
+    const [target] = mocks.replace.mock.calls[0];
+    expect(target.query).not.toHaveProperty('tag');
+  });
+
+  it('defers to setSelected when controlled, leaving the URL alone', () => {
+    const setSelected = vi.fn();
+    const container = render({ selected: undefined, setSelected });
+
+    clickButton(container, 'style');
+
+    expect(setSelected).toHaveBeenCalledWith('style');
+    expect(mocks.replace).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/CategoryTagFilters.tsx
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/CategoryTagFilters.tsx
@@ -9,6 +9,7 @@ export function CategoryTagFilters() {
       selected={categoryTag}
       setSelected={(value) => setCategoryTag(value)}
       filter={(tag) => !['celebrity'].includes(tag)}
+      includeAll={false}
     />
   );
 }

--- a/src/components/Tags/ActiveTagFilter.tsx
+++ b/src/components/Tags/ActiveTagFilter.tsx
@@ -2,7 +2,6 @@ import { Button } from '@mantine/core';
 import { IconX } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 
-import { useModelQueryParams } from '~/components/Model/model.utils';
 import { parseNumericStringArray } from '~/utils/query-string-helpers';
 
 function ClearButton({ label, onClear }: { label: string; onClear: () => void }) {
@@ -47,13 +46,4 @@ export function ActiveTagFilter() {
       onClear={handleClear}
     />
   );
-}
-
-/** `/models` carries the tag by name in `?tag=` rather than by id. */
-export function ActiveModelTagFilter() {
-  const { tag, set } = useModelQueryParams();
-
-  if (!tag) return null;
-
-  return <ClearButton label={`Clear tag: ${tag}`} onClear={() => set({ tag: undefined })} />;
 }

--- a/src/pages/models/index.tsx
+++ b/src/pages/models/index.tsx
@@ -2,6 +2,7 @@ import { Title } from '@mantine/core';
 import { useEffect } from 'react';
 import { FeedLayout } from '~/components/AppLayout/FeedLayout';
 import { Page } from '~/components/AppLayout/Page';
+import { CategoryTags } from '~/components/CategoryTags/CategoryTags';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { Meta } from '~/components/Meta/Meta';
 import { ModelsInfinite } from '~/components/Model/Infinite/ModelsInfinite';
@@ -68,6 +69,7 @@ function ModelsPage() {
       <MasonryContainer className="flex flex-col gap-2">
         {username && typeof username === 'string' && <Title>Models by {username}</Title>}
         <div className="flex flex-col gap-2">
+          <CategoryTags />
           <ModelsInfinite filters={queryFilters} showEof showAds />
         </div>
       </MasonryContainer>

--- a/src/pages/user/[username]/models.tsx
+++ b/src/pages/user/[username]/models.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { Page } from '~/components/AppLayout/Page';
+import { CategoryTags } from '~/components/CategoryTags/CategoryTags';
 import { SortFilter } from '~/components/Filters';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { MasonryProvider } from '~/components/MasonryColumns/MasonryProvider';
@@ -111,6 +112,7 @@ function UserModelsPage() {
             </Group>
             {viewingPublished ? (
               <>
+                <CategoryTags />
                 <ModelsInfinite
                   filters={{
                     ...queryFilters,
@@ -135,6 +137,7 @@ function UserModelsPage() {
               </>
             ) : viewingPrivate ? (
               <>
+                <CategoryTags />
                 <ModelsInfinite
                   filters={{
                     ...queryFilters,


### PR DESCRIPTION
## What

Restores the category tag bar on `/models` and the profile models tab. Models only — images, video, posts, articles and 3d-models stay as #4141 left them, and `TagScroller` stays deleted.

## Why

#4141 (`020ba963`) removed the bar from every feed surface because the curated list was stale and moderators said it was not useful. Daz pushed back: that reasoning holds for images and video, not for models, where categories are core navigation. Justin confirmed it as a straight revert of the models half — the stale-list judgement was about the *image* categories.

It also covers the second half of the complaint: categories currently only surface as a filter once you are inside a search (the `tags.name` refinement on `/search/models`). Restoring the bar puts them back on the browse path, which is where they were missing.

## The diff

- `CategoryTags` regains its uncontrolled path — `setSelected` optional again, falling back to `useModelQueryParams` so a click reads and writes `?tag=` — plus the `All` chip (`includeAll`, default true) that clears the filter. The resource-select modal is unchanged in behaviour: it passes both props and now opts out of `All` with `includeAll={false}`, exactly as it did before.
- `/models` and `/user/[username]/models` render `<CategoryTags />` again, in their original positions.

Deliberately **not** restored: the Early Access badge the bar used to carry. #4141 moved it into the models filter dropdown because it is a filter rather than a tag category, and that move was not part of what Daz objected to — bringing it back here would give it two homes.

## Tests

`src/components/CategoryTags/__tests__/CategoryTags.test.ts` — 6 tests over the uncontrolled path, the `All` chip, and the controlled path the modal depends on. Mutation-checked: reverting `_tag = selected ?? tagQuery` to `_tag = selected` fails with `expected { tag: 'style' } to not have property "tag"` in under a second, not a timeout.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — no new issues on the touched files (the one `containerQuery` unused-var warning on the profile page is pre-existing on `origin/main`)
- `pnpm run test:unit:run` — 1263 files, 19900 passed, 0 failed; `blocks.router.workflow.test.ts` collected 350

## Noticed, not fixed — separate from this PR

`src/components/Tags/ActiveTagFilter.tsx` was added by #4141 as "the ONLY way to unset `?tags=` now that the category scroller is gone", and it is **mounted nowhere** — `ActiveTagFilter` and `ActiveModelTagFilter` have no consumers anywhere in `src/`. Its unit test renders the component directly, so it passes. That leaves the image/video/post/article feeds with a `?tags=` deep link and no UI to widen it, which is the failure that component exists to prevent. Out of scope here (this PR is models-only, and the models path is covered by the `All` chip), but it needs its own fix.

ClickUp: https://app.clickup.com/t/868kumr1c

🤖 Generated with [Claude Code](https://claude.com/claude-code)
