### PR TITLE
fix(tipalti): correct status values, card gating, and notify edge

### DIFF
--- a/src/components/Account/UserPaymentConfigurationCard.browser.test.tsx
+++ b/src/components/Account/UserPaymentConfigurationCard.browser.test.tsx
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * The Tipalti half of the account payments card. The status copy is driven by a plain text
+ * column that stores Tipalti's own spelling, so these cases pin the two failure modes the card
+ * has actually shipped: mounting for nobody who has an account, and telling a creator mid-
+ * onboarding that their account cannot be set up.
+ */
+
+const mocks = vi.hoisted(() => ({
+  config: {
+    userPaymentConfiguration: undefined as Record<string, unknown> | undefined,
+    isLoading: false,
+  },
+}));
+
+vi.mock('~/components/UserPaymentConfiguration/util', () => ({
+  useUserPaymentConfiguration: () => mocks.config,
+  useTipaltiConfigurationUrl: () => ({ tipaltiConfigurationUrl: undefined, isLoading: false }),
+}));
+
+import { UserPaymentConfigurationCard } from '~/components/Account/UserPaymentConfigurationCard';
+
+function withConfig(overrides: Record<string, unknown>) {
+  mocks.config.userPaymentConfiguration = {
+    userId: 1,
+    stripeAccountId: null,
+    tipaltiAccountId: 'payee-1',
+    tipaltiAccountStatus: 'Active',
+    tipaltiPaymentsEnabled: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mocks.config.userPaymentConfiguration = undefined;
+  mocks.config.isLoading = false;
+});
+
+describe('UserPaymentConfigurationCard — Tipalti', () => {
+  test('renders the status for a creator who HAS a Tipalti account', async () => {
+    withConfig({});
+    renderWithProviders(<UserPaymentConfigurationCard />);
+
+    await expect.element(page.getByText(/ready for withdrawals/i)).toBeInTheDocument();
+  });
+
+  test('an activated but not-yet-payable account gets the "activated, cannot withdraw" copy', async () => {
+    withConfig({ tipaltiPaymentsEnabled: false });
+    renderWithProviders(<UserPaymentConfigurationCard />);
+
+    await expect
+      .element(page.getByText(/activated but you are still not able to withdraw/i))
+      .toBeInTheDocument();
+  });
+
+  test('PendingOnboarding reads as "requires setup", never as "unable to setup"', async () => {
+    withConfig({ tipaltiAccountStatus: 'PendingOnboarding', tipaltiPaymentsEnabled: false });
+    renderWithProviders(<UserPaymentConfigurationCard />);
+
+    await expect.element(page.getByText(/Your account requires setup/i)).toBeInTheDocument();
+    expect(document.body.textContent).not.toMatch(/unable to setup your account/i);
+  });
+
+  test.each([['Blocked'], ['BlockedByProvider']])(
+    '%s hides the setup button and explains the account is unusable',
+    async (status) => {
+      withConfig({ tipaltiAccountStatus: status, tipaltiPaymentsEnabled: false });
+      renderWithProviders(<UserPaymentConfigurationCard />);
+
+      await expect.element(page.getByText(/unable to setup your account/i)).toBeInTheDocument();
+      expect(document.body.textContent).not.toMatch(/Set up my Tipalti Account/i);
+    }
+  );
+
+  test('a creator without a Tipalti account still sees the invitation copy', async () => {
+    withConfig({ tipaltiAccountId: null });
+    renderWithProviders(<UserPaymentConfigurationCard />);
+
+    await expect.element(page.getByText(/rolling invitations to Tipalti/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/Account/UserPaymentConfigurationCard.tsx
+++ b/src/components/Account/UserPaymentConfigurationCard.tsx
@@ -22,11 +22,8 @@ import { useState } from 'react';
 import { showErrorNotification } from '~/utils/notifications';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { dialogStore } from '~/components/Dialog/dialogStore';
-import { StripeConnectStatus, TipaltiStatus } from '~/server/common/enums';
-import {
-  useTipaltiConfigurationUrl,
-  useUserPaymentConfiguration,
-} from '~/components/UserPaymentConfiguration/util';
+import { parseTipaltiStatus, StripeConnectStatus, TipaltiStatus } from '~/server/common/enums';
+import { useUserPaymentConfiguration } from '~/components/UserPaymentConfiguration/util';
 import dynamic from 'next/dynamic';
 import { useMutateUserSettings } from '~/components/UserSettings/hooks';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -293,6 +290,12 @@ const TipaltiConfigurationCard = () => {
     );
   }
 
+  const status = parseTipaltiStatus(userPaymentConfiguration.tipaltiAccountStatus);
+  const isUnusable =
+    status === TipaltiStatus.Blocked ||
+    status === TipaltiStatus.BlockedByProvider ||
+    status === TipaltiStatus.Suspended;
+
   return (
     <>
       <Stack>
@@ -303,19 +306,12 @@ const TipaltiConfigurationCard = () => {
 
       <Divider my="xs" />
 
-      {userPaymentConfiguration?.tipaltiAccountStatus.toUpperCase() ===
-        TipaltiStatus.PendingOnboarding ||
-      userPaymentConfiguration?.tipaltiAccountStatus.toUpperCase() ===
-        TipaltiStatus.InternalValue ? (
-        <>
-          <Stack>
-            <Text>
-              Your account requires setup. Click the button below to start/continue your setup
-              process.
-            </Text>
-          </Stack>
-        </>
-      ) : userPaymentConfiguration?.tipaltiAccountStatus.toUpperCase() === TipaltiStatus.Active ? (
+      {isUnusable ? (
+        <Text>
+          We are unable to setup your account so that you can withdraw funds. You may contact
+          support if you think this is a mistake to get a better understanding of the issue.
+        </Text>
+      ) : status === TipaltiStatus.Active ? (
         <>
           {userPaymentConfiguration?.tipaltiPaymentsEnabled ? (
             <Text>
@@ -339,17 +335,19 @@ const TipaltiConfigurationCard = () => {
           )}
         </>
       ) : (
-        <Text>
-          We are unable to setup your account so that you can withdraw funds. You may contact
-          support if you think this is a mistake to get a better understanding of the issue.
-        </Text>
+        // PendingOnboarding, InternalValue, and any status we don't model. Pointing someone at setup is
+        // recoverable if we guessed wrong; telling them their account is unusable is not.
+        <Stack>
+          <Text>
+            Your account requires setup. Click the button below to start/continue your setup
+            process.
+          </Text>
+        </Stack>
       )}
 
       <Divider my="xs" />
 
-      {![TipaltiStatus.Blocked, TipaltiStatus.BlockedByTipalti].some(
-        (s) => s === userPaymentConfiguration?.tipaltiAccountStatus
-      ) && (
+      {!isUnusable && (
         <Button
           component="a"
           href="/tipalti/setup"
@@ -383,7 +381,7 @@ export function UserPaymentConfigurationCard() {
       {userPaymentConfiguration?.tipaltiAccountId && userPaymentConfiguration?.stripeAccountId && (
         <Divider my="xl" />
       )}
-      {!userPaymentConfiguration?.tipaltiAccountId && <TipaltiConfigurationCard />}
+      <TipaltiConfigurationCard />
     </Card>
   );
 }

--- a/src/server/common/enums.ts
+++ b/src/server/common/enums.ts
@@ -344,13 +344,27 @@ export enum StripeConnectStatus {
   Rejected = 'Rejected',
 }
 
+// Values must be Tipalti's own spelling: the payeeDetailsChanged webhook stores `status` verbatim into a
+// plain text column, so a member that differs by a single character can never equal a stored value.
+// `InternalValue` is ours, not Tipalti's — it is the column default from the original create-table.
 export enum TipaltiStatus {
   PendingOnboarding = 'PendingOnboarding',
-  Active = 'ACTIVE',
-  Suspended = 'SUSPENDED',
-  Blocked = 'BLOCKED',
-  BlockedByTipalti = 'BLOCKED_BY_TIPALTI',
+  Active = 'Active',
+  Suspended = 'Suspended',
+  Blocked = 'Blocked',
+  BlockedByProvider = 'BlockedByProvider',
   InternalValue = 'INTERNAL_VALUE',
+}
+
+const tipaltiStatusByValue = new Map(
+  Object.values(TipaltiStatus).map((value) => [value.toLowerCase(), value])
+);
+
+// Returns null rather than a fallback member so callers have to decide what an unmodeled status means —
+// bucketing one into "blocked" would tell a creator their account is unusable on a status we never saw.
+export function parseTipaltiStatus(status: string | null | undefined): TipaltiStatus | null {
+  if (!status) return null;
+  return tipaltiStatusByValue.get(status.toLowerCase()) ?? null;
 }
 
 export enum OrchPriorityTypes {
@@ -438,7 +452,6 @@ export enum NewOrderSignalActions {
 export enum ExternalModerationType {
   Clavata = 'Clavata',
 }
-
 
 export enum MarketplacePaymentMethod {
   CashApp = 'CashApp',

--- a/src/server/http/tipalti/tipalti.schema.ts
+++ b/src/server/http/tipalti/tipalti.schema.ts
@@ -1,5 +1,4 @@
 import * as z from 'zod';
-import { TipaltiStatus } from '~/server/common/enums';
 
 export namespace Tipalti {
   const paymentStatus = [
@@ -53,7 +52,9 @@ export namespace Tipalti {
   export const createPayeeResponseSchema = z.object({
     id: z.string(),
     refCode: z.string().optional(),
-    status: z.enum(TipaltiStatus),
+    // Deliberately not z.enum(TipaltiStatus): this schema gates createPayee, so a status we haven't
+    // modeled yet would throw here and fail onboarding. Read it with parseTipaltiStatus.
+    status: z.string(),
     statusChangeDateTimeUTC: z.string().nullish(),
     statusReason: z.string().nullish(),
     isAccountClosed: z.boolean().optional(),

--- a/src/server/services/__tests__/user-payment-configuration.service.test.ts
+++ b/src/server/services/__tests__/user-payment-configuration.service.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { parseTipaltiStatus, TipaltiStatus } from '~/server/common/enums';
+import type * as EmailTemplates from '~/server/email/templates';
+import type * as NotificationService from '~/server/services/notification.service';
+
+const { mockCreateNotification, mockTaxFormEmailSend } = vi.hoisted(() => ({
+  mockCreateNotification: vi.fn().mockResolvedValue(undefined),
+  mockTaxFormEmailSend: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/notification.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof NotificationService>()),
+  createNotification: mockCreateNotification,
+}));
+vi.mock('~/server/email/templates', async (importOriginal) => ({
+  ...(await importOriginal<typeof EmailTemplates>()),
+  tipaltiTaxFormRequiredEmail: { send: mockTaxFormEmailSend },
+}));
+
+import { updateByTipaltiAccount } from '~/server/services/user-payment-configuration.service';
+
+const userId = 1234;
+
+/** The row as it exists BEFORE the webhook's update lands. */
+function existingConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    userId,
+    tipaltiAccountId: 'payee-1',
+    tipaltiAccountStatus: 'Active',
+    tipaltiPaymentsEnabled: true,
+    ...overrides,
+  };
+}
+
+function notificationsOfType(type: string) {
+  return mockCreateNotification.mock.calls
+    .map(([row]) => row as { type: string; key: string })
+    .filter((row) => row.type === type);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMock.dbWrite.userPaymentConfiguration.update.mockImplementation(
+    async ({ data }: { data: Record<string, unknown> }) => ({ ...existingConfig(), ...data })
+  );
+  dbMock.dbRead.user.findUnique.mockResolvedValue(null);
+});
+
+describe('parseTipaltiStatus', () => {
+  it('maps every spelling observed in production', () => {
+    expect(parseTipaltiStatus('Active')).toBe(TipaltiStatus.Active);
+    expect(parseTipaltiStatus('PendingOnboarding')).toBe(TipaltiStatus.PendingOnboarding);
+    expect(parseTipaltiStatus('Blocked')).toBe(TipaltiStatus.Blocked);
+    expect(parseTipaltiStatus('BlockedByProvider')).toBe(TipaltiStatus.BlockedByProvider);
+    expect(parseTipaltiStatus('INTERNAL_VALUE')).toBe(TipaltiStatus.InternalValue);
+  });
+
+  it('matches case-insensitively so historic rows still resolve', () => {
+    expect(parseTipaltiStatus('ACTIVE')).toBe(TipaltiStatus.Active);
+    expect(parseTipaltiStatus('BLOCKED')).toBe(TipaltiStatus.Blocked);
+  });
+
+  it('returns null for a status we do not model, and for empty input', () => {
+    expect(parseTipaltiStatus('BlockedBySomeoneNew')).toBeNull();
+    expect(parseTipaltiStatus('')).toBeNull();
+    expect(parseTipaltiStatus(undefined)).toBeNull();
+  });
+});
+
+describe('updateByTipaltiAccount — creators-program-payments-enabled', () => {
+  it('does not notify when the account was already payable', async () => {
+    dbMock.dbWrite.userPaymentConfiguration.findUnique.mockResolvedValue(existingConfig());
+
+    await updateByTipaltiAccount({
+      userId,
+      tipaltiAccountStatus: 'Active',
+      tipaltiPaymentsEnabled: true,
+    });
+
+    expect(notificationsOfType('creators-program-payments-enabled')).toHaveLength(0);
+  });
+
+  it('stays silent across repeated payable webhooks', async () => {
+    dbMock.dbWrite.userPaymentConfiguration.findUnique.mockResolvedValue(existingConfig());
+
+    for (let i = 0; i < 3; i++) {
+      await updateByTipaltiAccount({
+        userId,
+        tipaltiAccountStatus: 'Active',
+        tipaltiPaymentsEnabled: true,
+      });
+    }
+
+    expect(notificationsOfType('creators-program-payments-enabled')).toHaveLength(0);
+  });
+
+  it('notifies once on the not-payable -> payable edge, under a key stable per user', async () => {
+    dbMock.dbWrite.userPaymentConfiguration.findUnique.mockResolvedValue(
+      existingConfig({ tipaltiAccountStatus: 'PendingOnboarding', tipaltiPaymentsEnabled: false })
+    );
+
+    await updateByTipaltiAccount({
+      userId,
+      tipaltiAccountStatus: 'Active',
+      tipaltiPaymentsEnabled: true,
+    });
+
+    const sent = notificationsOfType('creators-program-payments-enabled');
+    expect(sent).toHaveLength(1);
+    expect(sent[0].key).toBe(`creators-program-payments-enabled:${userId}`);
+  });
+});
+
+describe('updateByTipaltiAccount — creators-program-rejected-tipalti', () => {
+  it.each([['Blocked'], ['BlockedByProvider']])(
+    'notifies on the %s status Tipalti actually sends',
+    async (status) => {
+      dbMock.dbWrite.userPaymentConfiguration.findUnique.mockResolvedValue(existingConfig());
+
+      await updateByTipaltiAccount({
+        userId,
+        tipaltiAccountStatus: status,
+        tipaltiPaymentsEnabled: false,
+      });
+
+      const sent = notificationsOfType('creators-program-rejected-tipalti');
+      expect(sent).toHaveLength(1);
+      expect(sent[0].key).toBe(`creators-program-rejected-tipalti:${userId}`);
+    }
+  );
+
+  it('does not notify when the account is merely not payable', async () => {
+    dbMock.dbWrite.userPaymentConfiguration.findUnique.mockResolvedValue(existingConfig());
+
+    await updateByTipaltiAccount({
+      userId,
+      tipaltiAccountStatus: 'Active',
+      tipaltiPaymentsEnabled: false,
+    });
+
+    expect(notificationsOfType('creators-program-rejected-tipalti')).toHaveLength(0);
+  });
+
+  it("stores Tipalti's spelling verbatim rather than a normalized member", async () => {
+    dbMock.dbWrite.userPaymentConfiguration.findUnique.mockResolvedValue(existingConfig());
+
+    await updateByTipaltiAccount({
+      userId,
+      tipaltiAccountStatus: 'BlockedByProvider',
+      tipaltiPaymentsEnabled: false,
+    });
+
+    const lastUpdate = dbMock.dbWrite.userPaymentConfiguration.update.mock.calls.at(-1) as [
+      { data: Record<string, unknown> }
+    ];
+    expect(lastUpdate[0].data.tipaltiAccountStatus).toBe('BlockedByProvider');
+  });
+});

--- a/src/server/services/user-payment-configuration.service.ts
+++ b/src/server/services/user-payment-configuration.service.ts
@@ -1,6 +1,11 @@
 import type Stripe from 'stripe';
 import { v4 as uuid } from 'uuid';
-import { NotificationCategory, StripeConnectStatus, TipaltiStatus } from '~/server/common/enums';
+import {
+  NotificationCategory,
+  parseTipaltiStatus,
+  StripeConnectStatus,
+  TipaltiStatus,
+} from '~/server/common/enums';
 import { env } from '../../env/server';
 import { dbRead, dbWrite } from '../db/client';
 import { logToAxiom } from '../logging/client';
@@ -294,7 +299,8 @@ export async function updateByTipaltiAccount({
   userId,
 }: {
   tipaltiAccountId?: string;
-  tipaltiAccountStatus: TipaltiStatus;
+  // Tipalti's raw string, not a TipaltiStatus: the webhook forwards `eventData.status` unvalidated.
+  tipaltiAccountStatus: string;
   tipaltiPaymentsEnabled: boolean;
   tipaltiWithdrawalMethod?: CashWithdrawalMethod;
   unpayableReasons?: string[];
@@ -321,25 +327,31 @@ export async function updateByTipaltiAccount({
     },
   });
 
+  const parsedStatus = parseTipaltiStatus(tipaltiAccountStatus);
+
+  // Only on the false -> true edge of payable. Tipalti re-sends payeeDetailsChanged for every payee
+  // edit, so any predicate that is merely "currently payable" notifies all of them on every webhook.
   if (tipaltiPaymentsEnabled) {
-    if (userPaymentConfig.tipaltiAccountStatus !== TipaltiStatus.Active) {
+    if (!userPaymentConfig.tipaltiPaymentsEnabled) {
       await createNotification({
         userId: userPaymentConfig.userId,
         type: 'creators-program-payments-enabled',
         category: NotificationCategory.System,
-        key: `creators-program-payments-enabled:${uuid()}`,
+        key: `creators-program-payments-enabled:${userPaymentConfig.userId}`,
         details: {},
-      }).catch();
+      }).catch(() => {
+        log({ method: 'createNotification', userId: userPaymentConfig.userId });
+      });
     }
   } else if (
-    tipaltiAccountStatus === TipaltiStatus.BlockedByTipalti ||
-    tipaltiAccountStatus === TipaltiStatus.Blocked
+    parsedStatus === TipaltiStatus.BlockedByProvider ||
+    parsedStatus === TipaltiStatus.Blocked
   ) {
     await createNotification({
       userId: userPaymentConfig.userId,
       type: 'creators-program-rejected-tipalti',
       category: NotificationCategory.System,
-      key: `creators-program-rejected-tipalti:${uuid()}`,
+      key: `creators-program-rejected-tipalti:${userPaymentConfig.userId}`,
       details: {},
     }).catch(() => {
       log({ method: 'createNotification', userId: userPaymentConfig.userId });


### PR DESCRIPTION
TipaltiStatus members now carry Tipalti's own spelling — the payeeDetailsChanged webhook stores `status` verbatim, so the previous SCREAMING_CASE values could never match a stored row — and reads go through `parseTipaltiStatus`, which returns null for anything unmodeled so callers show the recoverable "requires setup" copy rather than telling a creator their account is unusable. The account card now mounts for creators who already have a Tipalti account instead of only for those who don't. The payments-enabled notification fires on the false→true edge of `tipaltiPaymentsEnabled` with a per-user key, so the webhook firing on every payee edit no longer re-notifies.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868ktur47`). Reviewed locally before push.