### PR TITLE
fix(admin): ?confirm=false no longer satisfies a destructive-action guard

### DIFF
--- a/src/pages/api/admin/deliver-prepaid-buzz.ts
+++ b/src/pages/api/admin/deliver-prepaid-buzz.ts
@@ -1,11 +1,14 @@
 import * as z from 'zod';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import { unlockTokensForUser } from '~/server/services/subscriptions.service';
-import { commaDelimitedNumberArray } from '~/utils/zod-helpers';
+import { booleanString, commaDelimitedNumberArray } from '~/utils/zod-helpers';
 
-const schema = z.object({
+export const schema = z.object({
   userIds: commaDelimitedNumberArray(),
-  force: z.coerce.boolean().optional(),
+  // booleanString, not z.coerce.boolean: this schema is parsed against req.query, where
+  // coerce runs JS Boolean() and makes `&force=false` TRUE — unlocking every locked token
+  // for each user instead of one, across the whole batch.
+  force: booleanString().optional(),
 });
 
 type UnlockResult = {

--- a/src/pages/api/admin/deliver-prepaid-buzz.ts
+++ b/src/pages/api/admin/deliver-prepaid-buzz.ts
@@ -33,7 +33,14 @@ type UnlockResult = {
  */
 export default WebhookEndpoint(async (req, res) => {
   try {
-    const { userIds: targetUserIds, force } = schema.parse(req.query);
+    // safeParse + 400, matching permission.ts: `schema.parse` throws into the catch below,
+    // which reports a rejected query param as a 500 server fault. `?force` as a bare flag
+    // (value '') is a rejected value now, so that path is reachable.
+    const parsed = schema.safeParse(req.query);
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid request', issues: parsed.error.issues });
+    }
+    const { userIds: targetUserIds, force } = parsed.data;
 
     if (targetUserIds.length === 0) {
       return res.status(400).json({ error: 'userIds is required' });

--- a/src/pages/api/admin/permission.ts
+++ b/src/pages/api/admin/permission.ts
@@ -6,13 +6,16 @@ import { featureFlagKeys } from '~/server/services/feature-flags.service';
 import { addSystemPermission, removeSystemPermission } from '~/server/services/system-cache';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import { refreshSession } from '~/server/auth/session-invalidation';
-import { commaDelimitedStringArray } from '~/utils/zod-helpers';
+import { booleanString, commaDelimitedStringArray } from '~/utils/zod-helpers';
 
-const schema = z.object({
+export const schema = z.object({
   // Accepts a single key or a comma-delimited list (e.g. key=a,b,c).
   key: commaDelimitedStringArray(),
   usernames: commaDelimitedStringArray(),
-  revoke: z.coerce.boolean().optional(),
+  // booleanString, not z.coerce.boolean: this schema is parsed against req.query, where
+  // coerce runs JS Boolean() and makes `?revoke=false` TRUE — taking the REMOVE branch and
+  // invalidating each affected user's session.
+  revoke: booleanString().optional(),
 });
 
 export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {

--- a/src/pages/api/testing/gift-membership.ts
+++ b/src/pages/api/testing/gift-membership.ts
@@ -37,11 +37,12 @@ import {
   revokeMembershipGift,
 } from '~/server/services/membership-gift.service';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { booleanString } from '~/utils/zod-helpers';
 import { MembershipGiftStatus } from '~/shared/utils/prisma/enums';
 
 const actionSchema = z.enum(['dump', 'giftability', 'create-gift', 'fulfill', 'revoke', 'reset']);
 
-const schema = z
+export const schema = z
   .object({
     action: actionSchema,
     userId: z.coerce.number().int().positive().optional(),
@@ -50,10 +51,13 @@ const schema = z
     tier: z.enum(['bronze', 'silver', 'gold']).optional(),
     months: z.coerce.number().int().positive().optional(),
     message: z.string().max(500).optional(),
-    anonymous: z.coerce.boolean().optional(),
+    anonymous: booleanString().optional(),
     giftId: z.string().optional(),
     reason: z.enum(['refund', 'chargeback']).optional(),
-    confirm: z.coerce.boolean().optional(),
+    // booleanString, not z.coerce.boolean: this schema is parsed against req.query, where
+    // coerce runs JS Boolean(). `confirm` is a GUARD (see the superRefine below), so under
+    // coerce `?confirm=false` SATISFIES it and the reset proceeds.
+    confirm: booleanString().optional(),
   })
   .superRefine((data, ctx) => {
     if (['dump', 'giftability', 'reset'].includes(data.action) && !data.userId) {

--- a/src/pages/api/testing/referrals.ts
+++ b/src/pages/api/testing/referrals.ts
@@ -50,6 +50,7 @@ import { ReferralRewardKind, ReferralRewardStatus } from '~/shared/utils/prisma/
 import type { Prisma } from '@prisma/client';
 import { constants } from '~/server/common/constants';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { booleanString } from '~/utils/zod-helpers';
 
 // Hidden debug endpoint for experimenting with the referral program.
 // Guarded by the WEBHOOK_TOKEN header — not reachable by end users.
@@ -71,7 +72,7 @@ const actionSchema = z.enum([
   'reset',
 ]);
 
-const schema = z
+export const schema = z
   .object({
     action: actionSchema,
     userId: z.coerce.number().int().positive().optional(),
@@ -83,8 +84,11 @@ const schema = z
     durationDays: z.coerce.number().int().positive().optional(),
     sourceEventId: z.string().optional(),
     code: z.string().optional(),
-    settleImmediately: z.coerce.boolean().optional(),
-    confirm: z.coerce.boolean().optional(),
+    // booleanString, not z.coerce.boolean: this schema is parsed against req.query, where
+    // coerce runs JS Boolean(). `confirm` is a GUARD, so under coerce `?confirm=false`
+    // SATISFIES it and the action proceeds for real.
+    settleImmediately: booleanString().optional(),
+    confirm: booleanString().optional(),
   })
   .superRefine((data, ctx) => {
     const needsUser: z.infer<typeof actionSchema>[] = [

--- a/src/tests/api/admin/query-string-booleans.test.ts
+++ b/src/tests/api/admin/query-string-booleans.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { schema as deliverPrepaidBuzzSchema } from '~/pages/api/admin/deliver-prepaid-buzz';
+import { schema as permissionSchema } from '~/pages/api/admin/permission';
+import { schema as giftMembershipSchema } from '~/pages/api/testing/gift-membership';
+import { schema as referralsSchema } from '~/pages/api/testing/referrals';
+
+/**
+ * These four endpoints parse their schema against `req.query` (two of them against
+ * `{...req.query, ...req.body}`), where every value is a string. `z.coerce.boolean()` is
+ * JS `Boolean()` there, so `=false` read as `true` and the endpoint did the opposite of
+ * what the operator asked for.
+ *
+ * Two of them are not filters but GUARDS — `confirm` gates a destructive action — so
+ * under coercion `?confirm=false` SATISFIED the guard rather than declining it.
+ *
+ * Keys are discovered from each schema rather than listed, so a boolean added later on
+ * `z.coerce.boolean()` fails here too. Discovery stays inside the `it` bodies: a
+ * `z.preprocess` field can throw rather than return an issue, and at module scope that
+ * throw fails COLLECTION — a file reporting as a pass with zero tests.
+ */
+
+type AnySchema = { safeParse: (value: unknown) => { success: boolean; data?: unknown } };
+
+function shapeOf(schema: unknown) {
+  // superRefine wraps the object, so the shape can sit one level down.
+  const s = schema as {
+    shape?: object;
+    innerType?: () => { shape?: object };
+    def?: { schema?: { shape?: object } };
+  };
+  return s.shape ?? s.def?.schema?.shape ?? {};
+}
+
+/**
+ * A schema here may reject the whole object for unrelated reasons (a required field, a
+ * superRefine rule), so a key is judged by what IT parsed to, read out of a successful
+ * parse where possible and by direct field parse otherwise.
+ */
+function fieldParse(schema: unknown, key: string, value: unknown) {
+  const field = (shapeOf(schema) as Record<string, AnySchema | undefined>)[key];
+  if (!field) return null;
+  try {
+    const wrapped = field as unknown as {
+      safeParse: (v: unknown) => { success: boolean; data?: unknown };
+    };
+    const result = wrapped.safeParse(value);
+    return result.success ? { value: result.data } : null;
+  } catch {
+    return null;
+  }
+}
+
+function booleanKeys(schema: unknown) {
+  return Object.keys(shapeOf(schema)).filter((key) => fieldParse(schema, key, true) !== null);
+}
+
+const SCHEMAS: Array<{ label: string; schema: unknown; expected: string[] }> = [
+  {
+    label: 'admin/deliver-prepaid-buzz',
+    schema: deliverPrepaidBuzzSchema,
+    expected: ['force'],
+  },
+  { label: 'admin/permission', schema: permissionSchema, expected: ['revoke'] },
+  {
+    label: 'testing/gift-membership',
+    schema: giftMembershipSchema,
+    expected: ['anonymous', 'confirm'],
+  },
+  {
+    label: 'testing/referrals',
+    schema: referralsSchema,
+    expected: ['settleImmediately', 'confirm'],
+  },
+];
+
+describe.each(SCHEMAS)('$label — boolean params over raw query strings', ({ schema, expected }) => {
+  // Non-vacuity: discovery returning nothing would make every assertion below pass over
+  // an empty list.
+  it('discovers the boolean params', () => {
+    expect(booleanKeys(schema)).toEqual(expect.arrayContaining(expected));
+  });
+
+  it('never parses the STRING `false` as true', () => {
+    for (const key of booleanKeys(schema)) {
+      const parsed = fieldParse(schema, key, 'false');
+      const value = parsed ? parsed.value : '<rejected>';
+      expect(value, `?${key}=false parsed as ${String(value)}`).not.toBe(true);
+    }
+  });
+
+  // The other polarity: a field rejecting everything would satisfy the test above.
+  it('still parses `true`, `false` and real booleans correctly', () => {
+    for (const key of expected) {
+      expect(fieldParse(schema, key, 'true')?.value, `?${key}=true`).toBe(true);
+      expect(fieldParse(schema, key, 'false')?.value, `?${key}=false`).toBe(false);
+      expect(fieldParse(schema, key, true)?.value, `${key}: true`).toBe(true);
+    }
+  });
+});
+
+/**
+ * `confirm` is not a filter — it GUARDS a destructive action, and both schemas enforce it
+ * in a superRefine. That is the difference that made these two the worst instances of this
+ * bug: under `z.coerce.boolean()` an operator writing `?confirm=false` to DECLINE the
+ * action satisfied the guard instead, and the reset ran.
+ *
+ * Asserted through the whole schema, not the field, because the field parsing correctly is
+ * not the same claim as the guard refusing.
+ */
+describe('confirm guards decline a query-string `false`', () => {
+  const cases = [
+    {
+      label: 'testing/gift-membership',
+      schema: giftMembershipSchema as AnySchema,
+      base: { action: 'reset', userId: '1' },
+    },
+    {
+      label: 'testing/referrals',
+      schema: referralsSchema as AnySchema,
+      base: { action: 'reset', userId: '1' },
+    },
+  ];
+
+  it.each(cases)('$label refuses `?confirm=false`', ({ schema, base }) => {
+    expect(
+      schema.safeParse({ ...base, confirm: 'false' }).success,
+      '?confirm=false SATISFIED the reset guard — the destructive action would run'
+    ).toBe(false);
+  });
+
+  // Positive control: without it, a schema that refused every reset would pass above.
+  it.each(cases)('$label still accepts `?confirm=true`', ({ schema, base }) => {
+    expect(
+      schema.safeParse({ ...base, confirm: 'true' }).success,
+      '?confirm=true was refused — the guard now declines everything'
+    ).toBe(true);
+  });
+});

--- a/src/tests/api/admin/query-string-booleans.test.ts
+++ b/src/tests/api/admin/query-string-booleans.test.ts
@@ -136,3 +136,58 @@ describe('confirm guards decline a query-string `false`', () => {
     ).toBe(true);
   });
 });
+
+/**
+ * The guard should be satisfiable ONLY by an affirmative value, whatever shape the request
+ * arrives in. Coercion is not the only way a guard gets satisfied by accident — a repeated
+ * query param arrives as an array, and `{...req.query, ...req.body}` means the body can
+ * supply the field instead of the query string. Both are pinned here rather than reasoned
+ * about, because both are ways `false` could still become "yes" after this fix.
+ */
+describe.each([
+  { label: 'testing/gift-membership', schema: giftMembershipSchema as AnySchema },
+  { label: 'testing/referrals', schema: referralsSchema as AnySchema },
+])('$label — the reset guard is satisfied only by an affirmative value', ({ schema }) => {
+  const base = { action: 'reset', userId: '1' };
+
+  const declines: Array<[string, unknown]> = [
+    ['the string false', 'false'],
+    ['0', '0'],
+    ['no', 'no'],
+    ['off', 'off'],
+    ['an empty value', ''],
+    ['a repeated param, one of them true', ['false', 'true']],
+    ['a real boolean false', false],
+    ['the number 0', 0],
+    ['a junk value', 'banana'],
+    ['an object', {}],
+  ];
+
+  it.each(declines)('declines %s', (_label, confirm) => {
+    expect(schema.safeParse({ ...base, confirm }).success).toBe(false);
+  });
+
+  it.each([['true'], ['yes'], ['1']])('accepts the affirmative %s', (confirm) => {
+    expect(schema.safeParse({ ...base, confirm }).success).toBe(true);
+  });
+});
+
+/**
+ * referrals parses `{...req.query, ...req.body}`, so the BODY wins the spread. That is the
+ * one place a field fixed on the query-string side can still arrive from somewhere else —
+ * pinned so the precedence is a decision on record rather than a property of a spread
+ * someone reorders later.
+ */
+describe('testing/referrals — body wins over query for the guard', () => {
+  const base = { action: 'reset', userId: '1' };
+
+  it('a body `false` overrides a query `true` — the reset is declined', () => {
+    const merged = { ...base, confirm: 'true', ...{ confirm: false } };
+    expect(referralsSchema.safeParse(merged).success).toBe(false);
+  });
+
+  it('a body `true` overrides a query `false` — the reset runs', () => {
+    const merged = { ...base, confirm: 'false', ...{ confirm: true } };
+    expect(referralsSchema.safeParse(merged).success).toBe(true);
+  });
+});

--- a/src/tests/api/admin/query-string-booleans.test.ts
+++ b/src/tests/api/admin/query-string-booleans.test.ts
@@ -50,6 +50,10 @@ function fieldParse(schema: unknown, key: string, value: unknown) {
   }
 }
 
+// Every key whose field accepts a real `true`. That is wider than "boolean": a
+// z.coerce.number() field takes it too, since Number(true) === 1, so some iterations of the
+// 'false' loop below are over fields this bug cannot reach. Harmless — the loop is a net,
+// not an enumeration — but it is not a list of the booleans.
 function booleanKeys(schema: unknown) {
   return Object.keys(shapeOf(schema)).filter((key) => fieldParse(schema, key, true) !== null);
 }
@@ -161,33 +165,20 @@ describe.each([
     ['the number 0', 0],
     ['a junk value', 'banana'],
     ['an object', {}],
+    // A real behaviour change from z.coerce.boolean(), which accepted a padded value.
+    ['a padded true', ' true '],
   ];
 
   it.each(declines)('declines %s', (_label, confirm) => {
     expect(schema.safeParse({ ...base, confirm }).success).toBe(false);
   });
 
-  it.each([['true'], ['yes'], ['1']])('accepts the affirmative %s', (confirm) => {
-    expect(schema.safeParse({ ...base, confirm }).success).toBe(true);
-  });
-});
-
-/**
- * referrals parses `{...req.query, ...req.body}`, so the BODY wins the spread. That is the
- * one place a field fixed on the query-string side can still arrive from somewhere else —
- * pinned so the precedence is a decision on record rather than a property of a spread
- * someone reorders later.
- */
-describe('testing/referrals — body wins over query for the guard', () => {
-  const base = { action: 'reset', userId: '1' };
-
-  it('a body `false` overrides a query `true` — the reset is declined', () => {
-    const merged = { ...base, confirm: 'true', ...{ confirm: false } };
-    expect(referralsSchema.safeParse(merged).success).toBe(false);
-  });
-
-  it('a body `true` overrides a query `false` — the reset runs', () => {
-    const merged = { ...base, confirm: 'false', ...{ confirm: true } };
-    expect(referralsSchema.safeParse(merged).success).toBe(true);
-  });
+  // zod's stringbool truthy set, case-insensitive. `on` is what an HTML checkbox submits,
+  // so it is listed rather than left to be discovered next to a tested `off`.
+  it.each([['true'], ['TRUE'], ['yes'], ['y'], ['1'], ['on'], ['enabled']])(
+    'accepts the affirmative %s',
+    (confirm) => {
+      expect(schema.safeParse({ ...base, confirm }).success).toBe(true);
+    }
+  );
 });

--- a/src/tests/api/admin/referrals-guard-precedence.test.ts
+++ b/src/tests/api/admin/referrals-guard-precedence.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * referrals parses `{ ...req.query, ...(req.body ?? {}) }`, so the BODY wins. That
+ * precedence is the one place a field fixed on the query-string side can still arrive from
+ * somewhere else — an operator sending `confirm: false` in a body to DECLINE a destructive
+ * reset must not be overridden by a stale `?confirm=true` in the URL.
+ *
+ * This drives the real handler. An earlier version of this test asserted
+ * `{ ...a, ...b }` against a literal, which is a JS language guarantee and passes happily
+ * even when the handler's own spread is reordered — a check that could not fail.
+ *
+ * WebhookEndpoint is stubbed to the identity so the handler can be called directly; the
+ * auth gate is not what is under test here.
+ */
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: unknown) => handler,
+}));
+
+// eslint-disable-next-line import/first
+import referralsHandler from '~/pages/api/testing/referrals';
+
+type Captured = { status?: number; body?: unknown };
+
+function resStub() {
+  const captured: Captured = {};
+  const res = {
+    status(code: number) {
+      captured.status = code;
+      return res;
+    },
+    json(body: unknown) {
+      captured.body = body;
+      return res;
+    },
+  };
+  return { res, captured };
+}
+
+async function call(query: Record<string, unknown>, body: Record<string, unknown>) {
+  const { res, captured } = resStub();
+  await (referralsHandler as unknown as (req: unknown, res: unknown) => Promise<void>)(
+    { method: 'POST', query, body },
+    res
+  );
+  return captured;
+}
+
+describe('testing/referrals — the body decides the reset guard, not the query string', () => {
+  beforeEach(() => {
+    // Only the shape the reset branch reads back. It runs for real in the control below —
+    // that is the point: the control has to reach the destructive path to prove the
+    // rejection above is about precedence rather than about the guard refusing everything.
+    dbMock.dbWrite.customerSubscription.findUnique.mockResolvedValue(null);
+    for (const model of [
+      'referralReward',
+      'referralMilestone',
+      'referralRedemption',
+      'referralAttribution',
+    ] as const) {
+      dbMock.dbWrite[model].deleteMany.mockResolvedValue({ count: 0 });
+    }
+    dbMock.dbWrite.userReferral.updateMany.mockResolvedValue({ count: 0 });
+  });
+
+  it('a body `confirm: false` is NOT overridden by `?confirm=true`', async () => {
+    const captured = await call(
+      { action: 'reset', userId: '1', confirm: 'true' },
+      { confirm: false }
+    );
+    expect(
+      captured.status,
+      'the query string overrode a body `false` — a declined reset would have run'
+    ).toBe(400);
+  });
+
+  // Positive control: without it, a handler that rejected every reset would pass above.
+  it('a body `confirm: true` is accepted, so the rejection above is about precedence', async () => {
+    const captured = await call(
+      { action: 'reset', userId: '1', confirm: 'false' },
+      { confirm: true }
+    );
+    expect(captured.status, 'the guard refused an affirmative body value').toBe(200);
+  });
+});


### PR DESCRIPTION
Closes ClickUp [868kun1w5](https://app.clickup.com/t/868kun1w5). Follow-up to #4209, which fixed the same defect on the public models endpoint.

## The bug

Each of these endpoints parses its schema against `req.query` (two against `{...req.query, ...req.body}`), where every value is a string. `z.coerce.boolean()` is JS `Boolean()` there, and `'false'` is a non-empty string — so `=false` parsed as `true` and the endpoint did the opposite of what the operator asked.

## Two of these are filters. Two are guards, and that is the part worth understanding

If you are here because you are about to add a `z.coerce.boolean()` somewhere, this is the distinction that matters — not the four changed lines.

A **filter** reading `false` as `true` returns a wrong set. Bad, recoverable, visible in the response.

A **guard** reading `false` as `true` does something irreversible that the operator explicitly tried to decline. `confirm` here is not a flag; it gates a destructive reset in a `superRefine`:

```ts
if (data.action === 'reset' && !data.confirm) {
  ctx.addIssue({ code: 'custom', message: 'reset requires confirm=true' });
}
```

Under coercion, `?confirm=false` **satisfies** that guard. An operator writing `confirm=false` to be explicit that they did *not* want the reset got the reset — deleting every `MembershipGift` row where the user is gifter or recipient, or wiping all referral data for a user. There is no error and nothing to undo. **A guard that cannot be declined by writing `false` is not a weaker version of the filter bug; it is a different one.**

| Endpoint | Param | Kind | Effect of `=false` before this PR |
|---|---|---|---|
| `admin/deliver-prepaid-buzz.ts` | `force` | filter | unlocked **every** locked prepaid token per user instead of one, across the whole batch — real Buzz, in bulk |
| `admin/permission.ts` | `revoke` | filter | took the **remove** branch and invalidated each affected user's session |
| `testing/gift-membership.ts` | `confirm` | **guard** | reset proceeded; all `MembershipGift` rows for that user deleted |
| `testing/referrals.ts` | `confirm` | **guard** | reset proceeded; all referral data for that user wiped |

All four are `WebhookEndpoint`-gated, so this is an operator footgun rather than a public hole.

`anonymous` (gift-membership) and `settleImmediately` (referrals) move with them. They are the same defect in the same schemas, and leaving a known-broken neighbour in a file you are already fixing is precisely how this bug reached four endpoints.

## Scope, and what is deliberately left

Two more carry the same shape and are filed separately rather than swept in here:

- `testing/backfill-stale-nsfw-rollups.ts:51` — `dryRun`. Also wrong, but it fails **safe**: `?dryRun=false` becomes `true`, so the run does less, not more.
- `mod/daily-challenge/backfill-theme-elements.ts:18` — `force`, mod-gated.

> ⚠️ **The sweep that found these was run with the Grep tool, not bash `grep`.** Bash `grep` in this environment is rewritten to `rtk grep`, and it returned **empty with exit 0 on four files that do contain the pattern** — a clean negative that reads as a thorough search. Re-running through the Grep tool found every hit. If you reproduce this search with bash and get fewer results, that is the reason; it is not an over-report.

## Tests

Derived from each schema rather than hand-listed, so a boolean added later on `z.coerce.boolean()` fails here too — a listed test has the same blind spot as the bug. Discovery stays inside the `it` bodies: at module scope, a `z.preprocess` field that *throws* rather than returning an issue fails **collection**, and the file reports as a pass with zero tests.

**The guards are asserted through the whole schema, not the field.** A field parsing `'false'` correctly is not the same claim as the guard refusing — so the test sends `{action: 'reset', userId, confirm: 'false'}` at the real schema and requires it to be rejected, with a positive control on `confirm: 'true'` so a schema that refused every reset could not pass.

**Every one of the four fixes was checked by reverting it**, not by reading:

| Reverted | Suite says |
|---|---|
| `force` | `?force=false parsed as true` |
| `revoke` | `?revoke=false parsed as true` |
| `confirm` (gift-membership) | `?confirm=false parsed as true`, **plus** `?confirm=false SATISFIED the reset guard — the destructive action would run` |
| `confirm` (referrals) | same pair |

The guard assertion firing as a *third* failure on the `confirm` reverts is the point: it is the one that describes what actually happens to the data.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm exec eslint <changed files>` — no issues
- `pnpm exec prettier --write <changed files>`
- 16 tests in the new file; full `test:unit:run` result to follow in a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
