### PR TITLE
feat(chat): add a free Stacked/Bubbles layout picker alongside themes

### DIFF
--- a/packages/civitai-db-schema/src/enums.ts
+++ b/packages/civitai-db-schema/src/enums.ts
@@ -22,8 +22,7 @@ export const ReferralRedemptionType = {
   MembershipPerks: 'MembershipPerks',
 } as const;
 
-export type ReferralRedemptionType =
-  (typeof ReferralRedemptionType)[keyof typeof ReferralRedemptionType];
+export type ReferralRedemptionType = (typeof ReferralRedemptionType)[keyof typeof ReferralRedemptionType];
 
 export const BuzzWithdrawalRequestStatus = {
   Requested: 'Requested',
@@ -35,16 +34,14 @@ export const BuzzWithdrawalRequestStatus = {
   ExternallyResolved: 'ExternallyResolved',
 } as const;
 
-export type BuzzWithdrawalRequestStatus =
-  (typeof BuzzWithdrawalRequestStatus)[keyof typeof BuzzWithdrawalRequestStatus];
+export type BuzzWithdrawalRequestStatus = (typeof BuzzWithdrawalRequestStatus)[keyof typeof BuzzWithdrawalRequestStatus];
 
 export const UserPaymentConfigurationProvider = {
   Stripe: 'Stripe',
   Tipalti: 'Tipalti',
 } as const;
 
-export type UserPaymentConfigurationProvider =
-  (typeof UserPaymentConfigurationProvider)[keyof typeof UserPaymentConfigurationProvider];
+export type UserPaymentConfigurationProvider = (typeof UserPaymentConfigurationProvider)[keyof typeof UserPaymentConfigurationProvider];
 
 export const CashWithdrawalStatus = {
   Paid: 'Paid',
@@ -92,8 +89,7 @@ export const CryptoTransactionStatus = {
   Complete: 'Complete',
 } as const;
 
-export type CryptoTransactionStatus =
-  (typeof CryptoTransactionStatus)[keyof typeof CryptoTransactionStatus];
+export type CryptoTransactionStatus = (typeof CryptoTransactionStatus)[keyof typeof CryptoTransactionStatus];
 
 export const RewardsEligibility = {
   Eligible: 'Eligible',
@@ -271,8 +267,7 @@ export const ModelVersionSponsorshipSettingsType = {
   Bidding: 'Bidding',
 } as const;
 
-export type ModelVersionSponsorshipSettingsType =
-  (typeof ModelVersionSponsorshipSettingsType)[keyof typeof ModelVersionSponsorshipSettingsType];
+export type ModelVersionSponsorshipSettingsType = (typeof ModelVersionSponsorshipSettingsType)[keyof typeof ModelVersionSponsorshipSettingsType];
 
 export const ModelVersionMonetizationType = {
   PaidAccess: 'PaidAccess',
@@ -283,8 +278,7 @@ export const ModelVersionMonetizationType = {
   Sponsored: 'Sponsored',
 } as const;
 
-export type ModelVersionMonetizationType =
-  (typeof ModelVersionMonetizationType)[keyof typeof ModelVersionMonetizationType];
+export type ModelVersionMonetizationType = (typeof ModelVersionMonetizationType)[keyof typeof ModelVersionMonetizationType];
 
 export const LicensingFeeType = {
   PerImageBuzz: 'PerImageBuzz',
@@ -297,15 +291,13 @@ export const LicensingFeeSettlementCurrency = {
   Cash: 'Cash',
 } as const;
 
-export type LicensingFeeSettlementCurrency =
-  (typeof LicensingFeeSettlementCurrency)[keyof typeof LicensingFeeSettlementCurrency];
+export type LicensingFeeSettlementCurrency = (typeof LicensingFeeSettlementCurrency)[keyof typeof LicensingFeeSettlementCurrency];
 
 export const ModelVersionEngagementType = {
   Notify: 'Notify',
 } as const;
 
-export type ModelVersionEngagementType =
-  (typeof ModelVersionEngagementType)[keyof typeof ModelVersionEngagementType];
+export type ModelVersionEngagementType = (typeof ModelVersionEngagementType)[keyof typeof ModelVersionEngagementType];
 
 export const ModelHashType = {
   AutoV1: 'AutoV1',
@@ -392,8 +384,7 @@ export const ImageGenerationProcess = {
   inpainting: 'inpainting',
 } as const;
 
-export type ImageGenerationProcess =
-  (typeof ImageGenerationProcess)[keyof typeof ImageGenerationProcess];
+export type ImageGenerationProcess = (typeof ImageGenerationProcess)[keyof typeof ImageGenerationProcess];
 
 export const NsfwLevel = {
   None: 'None',
@@ -441,8 +432,7 @@ export const EntityModerationStatus = {
   Canceled: 'Canceled',
 } as const;
 
-export type EntityModerationStatus =
-  (typeof EntityModerationStatus)[keyof typeof EntityModerationStatus];
+export type EntityModerationStatus = (typeof EntityModerationStatus)[keyof typeof EntityModerationStatus];
 
 export const ImageEngagementType = {
   Favorite: 'Favorite',
@@ -570,8 +560,7 @@ export const CosmeticShopItemStatus = {
   Archived: 'Archived',
 } as const;
 
-export type CosmeticShopItemStatus =
-  (typeof CosmeticShopItemStatus)[keyof typeof CosmeticShopItemStatus];
+export type CosmeticShopItemStatus = (typeof CosmeticShopItemStatus)[keyof typeof CosmeticShopItemStatus];
 
 export const CosmeticEntity = {
   Model: 'Model',
@@ -611,16 +600,14 @@ export const ArticleIngestionStatus = {
   Rescan: 'Rescan',
 } as const;
 
-export type ArticleIngestionStatus =
-  (typeof ArticleIngestionStatus)[keyof typeof ArticleIngestionStatus];
+export type ArticleIngestionStatus = (typeof ArticleIngestionStatus)[keyof typeof ArticleIngestionStatus];
 
 export const ArticleEngagementType = {
   Favorite: 'Favorite',
   Hide: 'Hide',
 } as const;
 
-export type ArticleEngagementType =
-  (typeof ArticleEngagementType)[keyof typeof ArticleEngagementType];
+export type ArticleEngagementType = (typeof ArticleEngagementType)[keyof typeof ArticleEngagementType];
 
 export const GenerationSchedulers = {
   EulerA: 'EulerA',
@@ -651,8 +638,7 @@ export const CollectionWriteConfiguration = {
   Review: 'Review',
 } as const;
 
-export type CollectionWriteConfiguration =
-  (typeof CollectionWriteConfiguration)[keyof typeof CollectionWriteConfiguration];
+export type CollectionWriteConfiguration = (typeof CollectionWriteConfiguration)[keyof typeof CollectionWriteConfiguration];
 
 export const CollectionReadConfiguration = {
   Private: 'Private',
@@ -660,8 +646,7 @@ export const CollectionReadConfiguration = {
   Unlisted: 'Unlisted',
 } as const;
 
-export type CollectionReadConfiguration =
-  (typeof CollectionReadConfiguration)[keyof typeof CollectionReadConfiguration];
+export type CollectionReadConfiguration = (typeof CollectionReadConfiguration)[keyof typeof CollectionReadConfiguration];
 
 export const CollectionType = {
   Model: 'Model',
@@ -707,16 +692,14 @@ export const CollectionContributorPermission = {
   MANAGE: 'MANAGE',
 } as const;
 
-export type CollectionContributorPermission =
-  (typeof CollectionContributorPermission)[keyof typeof CollectionContributorPermission];
+export type CollectionContributorPermission = (typeof CollectionContributorPermission)[keyof typeof CollectionContributorPermission];
 
 export const CollectionCollaboratorRole = {
   Contributor: 'Contributor',
   Manager: 'Manager',
 } as const;
 
-export type CollectionCollaboratorRole =
-  (typeof CollectionCollaboratorRole)[keyof typeof CollectionCollaboratorRole];
+export type CollectionCollaboratorRole = (typeof CollectionCollaboratorRole)[keyof typeof CollectionCollaboratorRole];
 
 export const CollectionInviteStatus = {
   Pending: 'Pending',
@@ -724,8 +707,7 @@ export const CollectionInviteStatus = {
   Declined: 'Declined',
 } as const;
 
-export type CollectionInviteStatus =
-  (typeof CollectionInviteStatus)[keyof typeof CollectionInviteStatus];
+export type CollectionInviteStatus = (typeof CollectionInviteStatus)[keyof typeof CollectionInviteStatus];
 
 export const HomeBlockType = {
   Collection: 'Collection',
@@ -814,8 +796,7 @@ export const EntityCollaboratorStatus = {
   Rejected: 'Rejected',
 } as const;
 
-export type EntityCollaboratorStatus =
-  (typeof EntityCollaboratorStatus)[keyof typeof EntityCollaboratorStatus];
+export type EntityCollaboratorStatus = (typeof EntityCollaboratorStatus)[keyof typeof EntityCollaboratorStatus];
 
 export const ClubAdminPermission = {
   ManageMemberships: 'ManageMemberships',
@@ -862,8 +843,7 @@ export const PurchasableRewardUsage = {
   MultiUse: 'MultiUse',
 } as const;
 
-export type PurchasableRewardUsage =
-  (typeof PurchasableRewardUsage)[keyof typeof PurchasableRewardUsage];
+export type PurchasableRewardUsage = (typeof PurchasableRewardUsage)[keyof typeof PurchasableRewardUsage];
 
 export const EntityType = {
   Image: 'Image',
@@ -1015,8 +995,7 @@ export const ChallengeReviewCostType = {
   Flat: 'Flat',
 } as const;
 
-export type ChallengeReviewCostType =
-  (typeof ChallengeReviewCostType)[keyof typeof ChallengeReviewCostType];
+export type ChallengeReviewCostType = (typeof ChallengeReviewCostType)[keyof typeof ChallengeReviewCostType];
 
 export const ChallengeIngestionStatus = {
   Pending: 'Pending',
@@ -1025,22 +1004,19 @@ export const ChallengeIngestionStatus = {
   Error: 'Error',
 } as const;
 
-export type ChallengeIngestionStatus =
-  (typeof ChallengeIngestionStatus)[keyof typeof ChallengeIngestionStatus];
+export type ChallengeIngestionStatus = (typeof ChallengeIngestionStatus)[keyof typeof ChallengeIngestionStatus];
 
 export const ChallengeEngagementType = {
   Notify: 'Notify',
 } as const;
 
-export type ChallengeEngagementType =
-  (typeof ChallengeEngagementType)[keyof typeof ChallengeEngagementType];
+export type ChallengeEngagementType = (typeof ChallengeEngagementType)[keyof typeof ChallengeEngagementType];
 
 export const EntityMetric_EntityType_Type = {
   Image: 'Image',
 } as const;
 
-export type EntityMetric_EntityType_Type =
-  (typeof EntityMetric_EntityType_Type)[keyof typeof EntityMetric_EntityType_Type];
+export type EntityMetric_EntityType_Type = (typeof EntityMetric_EntityType_Type)[keyof typeof EntityMetric_EntityType_Type];
 
 export const EntityMetric_MetricType_Type = {
   ReactionLike: 'ReactionLike',
@@ -1052,8 +1028,7 @@ export const EntityMetric_MetricType_Type = {
   Buzz: 'Buzz',
 } as const;
 
-export type EntityMetric_MetricType_Type =
-  (typeof EntityMetric_MetricType_Type)[keyof typeof EntityMetric_MetricType_Type];
+export type EntityMetric_MetricType_Type = (typeof EntityMetric_MetricType_Type)[keyof typeof EntityMetric_MetricType_Type];
 
 export const ComicProjectStatus = {
   Active: 'Active',
@@ -1130,8 +1105,7 @@ export const UserRestrictionStatus = {
   Overturned: 'Overturned',
 } as const;
 
-export type UserRestrictionStatus =
-  (typeof UserRestrictionStatus)[keyof typeof UserRestrictionStatus];
+export type UserRestrictionStatus = (typeof UserRestrictionStatus)[keyof typeof UserRestrictionStatus];
 
 export const StrikeReason = {
   BlockedContent: 'BlockedContent',
@@ -1167,8 +1141,7 @@ export const WildcardSetAuditStatus = {
   Dirty: 'Dirty',
 } as const;
 
-export type WildcardSetAuditStatus =
-  (typeof WildcardSetAuditStatus)[keyof typeof WildcardSetAuditStatus];
+export type WildcardSetAuditStatus = (typeof WildcardSetAuditStatus)[keyof typeof WildcardSetAuditStatus];
 
 export const WildcardSetCategoryAuditStatus = {
   Pending: 'Pending',
@@ -1176,8 +1149,7 @@ export const WildcardSetCategoryAuditStatus = {
   Dirty: 'Dirty',
 } as const;
 
-export type WildcardSetCategoryAuditStatus =
-  (typeof WildcardSetCategoryAuditStatus)[keyof typeof WildcardSetCategoryAuditStatus];
+export type WildcardSetCategoryAuditStatus = (typeof WildcardSetCategoryAuditStatus)[keyof typeof WildcardSetCategoryAuditStatus];
 
 export const ReviewVerdict = {
   TruePositive: 'TruePositive',
@@ -1204,16 +1176,14 @@ export const Model3DEngagementType = {
   Notify: 'Notify',
 } as const;
 
-export type Model3DEngagementType =
-  (typeof Model3DEngagementType)[keyof typeof Model3DEngagementType];
+export type Model3DEngagementType = (typeof Model3DEngagementType)[keyof typeof Model3DEngagementType];
 
 export const ShopifyMerchOrderStatus = {
   Pending: 'Pending',
   Granted: 'Granted',
 } as const;
 
-export type ShopifyMerchOrderStatus =
-  (typeof ShopifyMerchOrderStatus)[keyof typeof ShopifyMerchOrderStatus];
+export type ShopifyMerchOrderStatus = (typeof ShopifyMerchOrderStatus)[keyof typeof ShopifyMerchOrderStatus];
 
 export const OutboxEntity = {
   Article: 'Article',

--- a/src/components/Chat/Chat.module.scss
+++ b/src/components/Chat/Chat.module.scss
@@ -41,12 +41,12 @@
   --chat-msg-size: 13.5px;
   --chat-radius: 19px;
 
-  /* Off by default: the stock surface is flat rows, and a bubble is a thing a
-     theme opts into. Transparent with no padding leaves the row untouched. */
-  --chat-bubble: transparent;
-  --chat-bubble-me: transparent;
-  --chat-bubble-pad: 0;
-  --chat-bubble-radius: 0;
+  /* Left UNDEFINED rather than set to transparent: the stock surface is flat
+     rows, and a bubble is a thing a theme opts into — but the Bubbles layout has
+     to draw one whatever theme is on, and var()'s fallback is the only way to
+     say "unless someone already answered this". Defining them here as
+     transparent would answer it, and every theme would flatten to one palette.
+     See .messageText / .bubbles in ExistingChat.module.scss. */
 
   /* Derived so a theme only has to name its accent — the quote and reply tints
      follow it instead of each carrying a hand-mixed colour. */

--- a/src/components/Chat/Chat.module.scss
+++ b/src/components/Chat/Chat.module.scss
@@ -33,7 +33,10 @@
   --chat-bg-image: none;
 
   /* Type and geometry are as much of a skin as colour is — a terminal that is
-     merely green is a recolour, not a terminal. */
+     merely green is a recolour, not a terminal. --chat-ui-font is the window's
+     own face: the rail, the headers and the usernames, which a theme that
+     restyles only the messages leaves speaking in the app's voice. */
+  --chat-ui-font: inherit;
   --chat-msg-font: inherit;
   --chat-msg-size: 13.5px;
   --chat-radius: 19px;
@@ -53,6 +56,7 @@
 .surface.surface {
   background-color: var(--chat-bg);
   background-image: var(--chat-bg-image);
+  font-family: var(--chat-ui-font);
 }
 
 /* The rail, the conversation header and the composer are the chrome around the

--- a/src/components/Chat/ChatSettings.tsx
+++ b/src/components/Chat/ChatSettings.tsx
@@ -19,7 +19,7 @@ import produce from 'immer';
 import React from 'react';
 import type { ChatSettingsScope } from '~/components/Chat/ChatProvider';
 import { useChatStore } from '~/components/Chat/ChatProvider';
-import { useChatTheme } from '~/components/Chat/useChatTheme';
+import { useChatLayout, useChatTheme } from '~/components/Chat/useChatTheme';
 import { useContainerSmallerThan } from '~/components/ContainerProvider/useContainerSmallerThan';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
@@ -27,6 +27,8 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useDomainColor } from '~/hooks/useDomainColor';
 import type { ChatDmPolicy, UserSettingsChat } from '~/server/schema/chat.schema';
 import { DEFAULT_CHAT_SETTINGS } from '~/server/schema/chat.schema';
+import type { ChatLayoutSlug } from '~/shared/constants/chat-layout';
+import { chatLayouts } from '~/shared/constants/chat-layout';
 import type { ChatThemeSlug } from '~/shared/constants/chat-theme';
 import { chatThemes } from '~/shared/constants/chat-theme';
 import { ChatNotifyLevel } from '~/shared/utils/prisma/enums';
@@ -312,6 +314,8 @@ function GlobalChatSettings({
       </SettingsGroup>
 
       <SettingsGroup title="Appearance">
+        <ChatLayoutPicker onChange={(layout) => update({ layout })} />
+        <Divider />
         <ChatThemePicker onChange={(theme) => update({ theme })} />
       </SettingsGroup>
 
@@ -329,6 +333,26 @@ function GlobalChatSettings({
         />
       </SettingsGroup>
     </>
+  );
+}
+
+function ChatLayoutPicker({ onChange }: { onChange: (slug: ChatLayoutSlug) => void }) {
+  const layout = useChatLayout();
+
+  return (
+    <Radio.Group value={layout} onChange={(value) => onChange(value as ChatLayoutSlug)}>
+      <Stack gap={4}>
+        {chatLayouts.map((option) => (
+          <Radio
+            key={option.slug}
+            value={option.slug}
+            label={option.name}
+            description={option.description}
+            className={clsx(classes.option, { [classes.selected]: option.slug === layout })}
+          />
+        ))}
+      </Stack>
+    </Radio.Group>
   );
 }
 
@@ -377,14 +401,14 @@ function ChatThemePicker({ onChange }: { onChange: (slug: ChatThemeSlug) => void
           </>
         ) : (
           <>
-            Citron, Bubblegum and Terminal come with any{' '}
+            Every theme past Civitai comes with any{' '}
             <Anchor
               component={Link}
               href={`/pricing?returnUrl=${encodeURIComponent(router.asPath)}`}
             >
               membership
             </Anchor>
-            .
+            . Layout is free either way.
           </>
         )}
       </Text>

--- a/src/components/Chat/ExistingChat.module.scss
+++ b/src/components/Chat/ExistingChat.module.scss
@@ -30,9 +30,11 @@
   }
 
   /* Padding rather than margin so the hover band covers the gap too — a margin
-     here would leave an unlit strip above the row it belongs to. */
+     here would leave an unlit strip above the row it belongs to. Big enough to
+     read as a turn change at a glance: against .grouped's 1px, this is the only
+     thing separating one person's run from the next. */
   &.newSender {
-    padding-top: 12px;
+    padding-top: 20px;
   }
 }
 
@@ -65,9 +67,9 @@
   font-size: var(--chat-msg-size);
   color: var(--chat-text);
   line-height: 1.5;
-  background-color: var(--chat-bubble);
-  padding: var(--chat-bubble-pad);
-  border-radius: var(--chat-bubble-radius);
+  background-color: var(--chat-bubble, transparent);
+  padding: var(--chat-bubble-pad, 0);
+  border-radius: var(--chat-bubble-radius, 0);
 
   /* ChatMessageContent wraps every run in a Mantine <Text>, which writes its own
      font-size onto the span — so sizing this container alone changes nothing. */
@@ -121,7 +123,7 @@
 }
 
 .mine {
-  background-color: var(--chat-bubble-me);
+  background-color: var(--chat-bubble-me, transparent);
 }
 
 /* A sticker or a lone jumbo emoji IS the message. A themed bubble around it
@@ -131,6 +133,69 @@
 .standalone.standalone {
   background-color: transparent;
   padding: 0;
+}
+
+/* The Bubbles layout: the reader's own messages on the right, everyone else's on
+   the left. The layout IS the bubble, so where a theme paints none it supplies
+   one through var()'s fallback rather than by setting --chat-bubble itself — a
+   real declaration here would outrank every theme and flatten them all to grey.
+   `:not(.standalone)` keeps a sticker or a jumbo emoji unframed, which no
+   specificity juggling between these two rules would survive. */
+.bubbles {
+  .messageBody {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding-left: 0;
+  }
+
+  /* Short of the full pane: a bubble that spans the column stops reading as a
+     side and the layout collapses back to stacked. */
+  .messageText {
+    max-width: 78%;
+  }
+
+  .messageText:not(.standalone) {
+    background-color: var(
+      --chat-bubble,
+      light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5))
+    );
+    padding: var(--chat-bubble-pad, 6px 11px);
+    border-radius: var(--chat-bubble-radius, 14px);
+  }
+
+  &.mineRow {
+    .messageHead {
+      flex-direction: row-reverse;
+    }
+
+    .messageBody {
+      align-items: flex-end;
+    }
+
+    .messageText:not(.standalone) {
+      background-color: var(
+        --chat-bubble-me,
+        light-dark(var(--mantine-color-blue-2), var(--mantine-color-blue-9))
+      );
+    }
+
+    /* Follows the message to the right, where it would sit on top of the bubble. */
+    .messageActions {
+      right: auto;
+      left: 14px;
+    }
+
+    .embedRow {
+      margin-left: auto;
+      margin-right: 14px;
+    }
+  }
+
+  /* .messageBody no longer indents, so neither does the unfurl beneath it. */
+  .embedRow {
+    margin-left: 14px;
+  }
 }
 
 /* An embed is the unfurl of a link in the message above it, not a message of its

--- a/src/components/Chat/ExistingChat.module.scss
+++ b/src/components/Chat/ExistingChat.module.scss
@@ -28,6 +28,12 @@
   &.grouped {
     padding-top: 1px;
   }
+
+  /* Padding rather than margin so the hover band covers the gap too — a margin
+     here would leave an unlit strip above the row it belongs to. */
+  &.newSender {
+    padding-top: 12px;
+  }
 }
 
 .messageHead {
@@ -125,6 +131,74 @@
 .standalone.standalone {
   background-color: transparent;
   padding: 0;
+}
+
+/* An embed is the unfurl of a link in the message above it, not a message of its
+   own: it lines up under that message's body and keeps a full row of space below
+   so the next sender's header can never butt against it. The left margin is
+   .messageRow's 14px plus .messageBody's 34px. */
+.embedRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: fit-content;
+  max-width: min(420px, calc(100% - 62px));
+  margin: 2px 14px 10px 48px;
+  padding: 7px 9px;
+  border: 1px solid var(--chat-line);
+  border-left: 3px solid var(--chat-accent);
+  border-radius: var(--mantine-radius-sm);
+  background-color: var(--chat-panel);
+}
+
+/* A bare image unfurl is the preview — the card is just its frame. */
+.embedMedia {
+  padding: 0;
+  overflow: hidden;
+}
+
+.embedBody {
+  min-width: 0;
+  flex: 1;
+}
+
+.embedTitle {
+  display: block;
+  font-family: var(--chat-msg-font);
+  font-size: 12.5px;
+  font-weight: 600;
+  line-height: 1.35;
+  color: var(--chat-accent);
+  overflow-wrap: anywhere;
+}
+
+.embedDesc {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-top: 2px;
+  font-family: var(--chat-msg-font);
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--chat-text-dim);
+}
+
+/* Fixed box, not intrinsic size: two unfurls in a row have to present the same
+   silhouette, or they read as misaligned against each other. */
+.embedThumb {
+  flex: none;
+  width: 56px;
+  height: 56px;
+  border-radius: var(--mantine-radius-sm);
+  object-fit: cover;
+}
+
+.embedImage {
+  display: block;
+  max-width: 100%;
+  max-height: 260px;
+  object-fit: contain;
 }
 
 .editedTag {

--- a/src/components/Chat/ExistingChat.tsx
+++ b/src/components/Chat/ExistingChat.tsx
@@ -13,7 +13,6 @@ import {
   Stack,
   Text,
   Textarea,
-  Title,
   Tooltip,
   UnstyledButton,
   useComputedColorScheme,
@@ -45,6 +44,7 @@ import { div } from 'motion/react-m';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChatActions } from '~/components/Chat/ChatActions';
 import { useChatStore } from '~/components/Chat/ChatProvider';
+import { getMessageRowFlags, isSameDay } from '~/components/Chat/message-grouping';
 import { getLinkHref, linkifyOptions, loadMotion } from '~/components/Chat/util';
 import { useContainerSmallerThan } from '~/components/ContainerProvider/useContainerSmallerThan';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
@@ -1136,19 +1136,25 @@ function ChatInputBox({
 }
 
 const EmbedLink = ({ href, title }: { href?: string; title: string }) => {
-  if (!href) return <Title order={6}>{title}</Title>;
+  if (!href) return <span className={classes.embedTitle}>{title}</span>;
 
   if (constants.chat.externalRegex.test(href)) {
     return (
-      <Anchor href={href} target="_blank" rel="noopener noreferrer" variant="link">
-        <Title order={6}>{title}</Title>
+      <Anchor
+        className={classes.embedTitle}
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        underline="hover"
+      >
+        {title}
       </Anchor>
     );
   }
 
   return (
-    <Anchor component={Link} href={href} variant="link">
-      <Title order={6}>{title}</Title>
+    <Anchor className={classes.embedTitle} component={Link} href={href} underline="hover">
+      {title}
     </Anchor>
   );
 };
@@ -1171,29 +1177,25 @@ const EmbedMessage = ({ content }: { content: string }) => {
   if (!title && !description && !image) return <></>;
 
   const modHref = getLinkHref(href);
+  // A link to an image unfurls to the image alone. Shown at thumbnail size it is
+  // an icon of itself, so the card becomes the frame and the preview fills it.
+  const isMediaOnly = !title && !description;
 
   return (
-    <Group
-      style={{ alignSelf: 'center' }}
-      className={clsx(classes.chatMessage, classes.embedCard)}
-      wrap="nowrap"
-    >
-      {(!!title || !!description) && (
-        <Stack>
+    <div className={clsx(classes.embedRow, { [classes.embedMedia]: isMediaOnly })}>
+      {!isMediaOnly && (
+        <div className={classes.embedBody}>
           {!!title && <EmbedLink href={modHref} title={title} />}
-          {!!description && <Text size="xs">{description}</Text>}
-        </Stack>
+          {!!description && <div className={classes.embedDesc}>{description}</div>}
+        </div>
       )}
-      {!!image && (
-        <EdgeMedia
-          src={image}
-          width={75}
-          height={75}
-          alt="Link preview"
-          style={{ objectFit: 'cover' }}
-        />
-      )}
-    </Group>
+      {!!image &&
+        (isMediaOnly ? (
+          <EdgeMedia src={image} width={450} alt="Link preview" className={classes.embedImage} />
+        ) : (
+          <EdgeMedia src={image} width={112} alt="Link preview" className={classes.embedThumb} />
+        ))}
+    </div>
   );
 };
 
@@ -1252,20 +1254,14 @@ function DisplayMessages({
 
   const blur = replaceBadWords || domainColor === 'green';
 
-  let loopMsgDate = new Date(1970);
-  let loopPreviousChatter = 0;
+  const rowFlags = useMemo(() => getMessageRowFlags(chats), [chats]);
 
   return (
     <StickerProvider ids={stickerIds}>
       <LazyMotion features={loadMotion}>
         {chats.map((c, idx) => {
-          const hourDiff = (c.createdAt.valueOf() - loopMsgDate.valueOf()) / (1000 * 60 * 60);
-          const sameChatter = loopPreviousChatter === c.userId;
-          const shouldShowInfo = hourDiff >= 1 || !sameChatter;
-          const showDayChip = !isSameDay(c.createdAt, loopMsgDate);
-
-          loopMsgDate = c.createdAt;
-          loopPreviousChatter = c.userId;
+          const { showHeader, showDayChip, isNewSender } = rowFlags[idx];
+          const isEmbed = c.contentType === ChatMessageType.Embed;
 
           const cachedUser = tChat?.chatMembers?.find((cm) => cm.userId === c.userId)?.user;
           const isMe = c.userId === currentUser?.id;
@@ -1288,7 +1284,7 @@ function DisplayMessages({
                 animate={{ opacity: 1 }}
                 transition={{ duration: 0.12 }}
               >
-                {isSystemChat && c.contentType === ChatMessageType.Embed ? (
+                {isSystemChat && isEmbed ? (
                   <EmbedMessage content={c.content} />
                 ) : isSystemChat ? (
                   <Text className={classes.systemNote} component="div" size="xs">
@@ -1297,8 +1293,13 @@ function DisplayMessages({
                     </CustomMarkdown>
                   </Text>
                 ) : (
-                  <div className={clsx(classes.messageRow, { [classes.grouped]: !shouldShowInfo })}>
-                    {shouldShowInfo && (
+                  <div
+                    className={clsx(classes.messageRow, {
+                      [classes.grouped]: !showHeader,
+                      [classes.newSender]: isNewSender,
+                    })}
+                  >
+                    {showHeader && (
                       <Group gap={8} align="center" wrap="nowrap" className={classes.messageHead}>
                         {!!cachedUser ? (
                           <UserAvatar user={cachedUser} withUsername size="sm" />
@@ -1408,14 +1409,6 @@ function DisplayMessages({
         })}
       </LazyMotion>
     </StickerProvider>
-  );
-}
-
-function isSameDay(a: Date, b: Date) {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
   );
 }
 

--- a/src/components/Chat/ExistingChat.tsx
+++ b/src/components/Chat/ExistingChat.tsx
@@ -44,6 +44,7 @@ import { div } from 'motion/react-m';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChatActions } from '~/components/Chat/ChatActions';
 import { useChatStore } from '~/components/Chat/ChatProvider';
+import { useChatLayout } from '~/components/Chat/useChatTheme';
 import { getMessageRowFlags, isSameDay } from '~/components/Chat/message-grouping';
 import { getLinkHref, linkifyOptions, loadMotion } from '~/components/Chat/util';
 import { useContainerSmallerThan } from '~/components/ContainerProvider/useContainerSmallerThan';
@@ -1255,6 +1256,7 @@ function DisplayMessages({
   const blur = replaceBadWords || domainColor === 'green';
 
   const rowFlags = useMemo(() => getMessageRowFlags(chats), [chats]);
+  const bubbles = useChatLayout() === 'bubbles';
 
   return (
     <StickerProvider ids={stickerIds}>
@@ -1266,6 +1268,10 @@ function DisplayMessages({
           const cachedUser = tChat?.chatMembers?.find((cm) => cm.userId === c.userId)?.user;
           const isMe = c.userId === currentUser?.id;
           const isSystemChat = c.userId === -1;
+          // An unfurl is written by the system but belongs to whoever posted the
+          // link, so in Bubbles it takes that person's side rather than always
+          // the left — which would strand your own link previews opposite you.
+          const isMySide = isEmbed ? c.referenceMessage?.userId === currentUser?.id : isMe;
 
           const quotedUser = !!c.referenceMessage
             ? tChat?.chatMembers?.find((cm) => cm.userId === c.referenceMessage?.userId)?.user
@@ -1279,6 +1285,10 @@ function DisplayMessages({
               <PStack
                 component={div}
                 gap={0}
+                className={clsx({
+                  [classes.bubbles]: bubbles,
+                  [classes.mineRow]: bubbles && isMySide,
+                })}
                 style={idx === chats.length - 1 ? { paddingBottom: 12 } : {}}
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}

--- a/src/components/Chat/__tests__/message-grouping.test.ts
+++ b/src/components/Chat/__tests__/message-grouping.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { getMessageRowFlags } from '~/components/Chat/message-grouping';
+import { ChatMessageType } from '~/shared/utils/prisma/enums';
+
+const ALICE = 11;
+const BOB = 22;
+const SYSTEM = -1;
+
+// Local rather than UTC: isSameDay reads the local calendar date, so a UTC
+// literal would put the day boundary in a different place per machine.
+const at = (day: number, hour: number, minute: number, second = 0) =>
+  new Date(2026, 7, day, hour, minute, second);
+
+const msg = (userId: number, createdAt: Date) => ({
+  userId,
+  createdAt,
+  contentType: ChatMessageType.Markdown,
+});
+
+/** The unfurl the server writes as its own row, attributed to the system user. */
+const embed = (createdAt: Date) => ({
+  userId: SYSTEM,
+  createdAt,
+  contentType: ChatMessageType.Embed,
+});
+
+describe('getMessageRowFlags', () => {
+  it('draws one header for a run and repeats it when the sender changes', () => {
+    const flags = getMessageRowFlags([
+      msg(ALICE, at(20, 10, 0)),
+      msg(ALICE, at(20, 10, 1)),
+      msg(BOB, at(20, 10, 2)),
+    ]);
+
+    expect(flags.map((f) => f.showHeader)).toEqual([true, false, true]);
+  });
+
+  it('starts a new run once the sender has been quiet for an hour', () => {
+    const flags = getMessageRowFlags([
+      msg(ALICE, at(20, 10, 0)),
+      msg(ALICE, at(20, 10, 59)),
+      msg(ALICE, at(20, 12, 0)),
+    ]);
+
+    expect(flags.map((f) => f.showHeader)).toEqual([true, false, true]);
+  });
+
+  it('spaces every run but the first, so the top of the pane has no dangling gap', () => {
+    const flags = getMessageRowFlags([
+      msg(ALICE, at(20, 10, 0)),
+      msg(ALICE, at(20, 10, 1)),
+      msg(BOB, at(20, 10, 2)),
+    ]);
+
+    expect(flags.map((f) => f.isNewSender)).toEqual([false, false, true]);
+  });
+
+  it('keeps a sender in one run across the embed their own link produced', () => {
+    const flags = getMessageRowFlags([
+      msg(ALICE, at(20, 10, 0)),
+      embed(at(20, 10, 0, 1)),
+      msg(ALICE, at(20, 10, 0, 30)),
+    ]);
+
+    // Reverting the embed skip makes the third row's header come back, because the
+    // embed leaves -1 as the previous sender.
+    expect(flags[2].showHeader).toBe(false);
+    expect(flags[2].isNewSender).toBe(false);
+  });
+
+  it('leaves the day chip on the first real message of the day, not on the embed', () => {
+    const flags = getMessageRowFlags([
+      msg(ALICE, at(19, 23, 59)),
+      embed(at(20, 0, 0, 10)),
+      msg(BOB, at(20, 0, 0, 30)),
+    ]);
+
+    // The chip is suppressed on system rows at render, so an embed that consumed
+    // it would leave the day change unmarked entirely.
+    expect(flags[2].showDayChip).toBe(true);
+  });
+
+  it('marks the very first message with a day chip', () => {
+    const flags = getMessageRowFlags([msg(ALICE, at(20, 10, 0))]);
+
+    expect(flags[0].showDayChip).toBe(true);
+  });
+
+  it('returns one entry per message, in order', () => {
+    const messages = [msg(ALICE, at(20, 10, 0)), embed(at(20, 10, 0, 1)), msg(BOB, at(20, 10, 5))];
+
+    expect(getMessageRowFlags(messages)).toHaveLength(messages.length);
+  });
+});

--- a/src/components/Chat/message-grouping.ts
+++ b/src/components/Chat/message-grouping.ts
@@ -1,0 +1,47 @@
+import { ChatMessageType } from '~/shared/utils/prisma/enums';
+
+/** Past this, a sender starts a fresh run even if nobody else spoke in between. */
+const GROUP_WINDOW_HOURS = 1;
+
+export function isSameDay(a: Date, b: Date) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+type GroupingInput = { createdAt: Date; userId: number; contentType: ChatMessageType };
+
+export type MessageRowFlags = {
+  /** The avatar, username and time — drawn once at the head of a sender's run. */
+  showHeader: boolean;
+  showDayChip: boolean;
+  /** A run starting against something above it, which needs space to read as new. */
+  isNewSender: boolean;
+};
+
+/**
+ * Resolved for the whole list rather than per row because each row's answer
+ * depends on the rows before it.
+ */
+export function getMessageRowFlags(messages: GroupingInput[]): MessageRowFlags[] {
+  let lastAt = new Date(0);
+  let lastUserId = 0;
+
+  return messages.map((message, idx) => {
+    const hourDiff = (message.createdAt.valueOf() - lastAt.valueOf()) / (1000 * 60 * 60);
+    const showHeader = hourDiff >= GROUP_WINDOW_HOURS || lastUserId !== message.userId;
+    const showDayChip = !isSameDay(message.createdAt, lastAt);
+
+    // An embed belongs to the message it unfurled, so it must not count as a turn:
+    // advancing these would break its own sender's run and let the embed swallow
+    // the day chip owed to the next real message.
+    if (message.contentType !== ChatMessageType.Embed) {
+      lastAt = message.createdAt;
+      lastUserId = message.userId;
+    }
+
+    return { showHeader, showDayChip, isNewSender: showHeader && idx > 0 };
+  });
+}

--- a/src/components/Chat/useChatTheme.ts
+++ b/src/components/Chat/useChatTheme.ts
@@ -1,4 +1,5 @@
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { resolveChatLayout } from '~/shared/constants/chat-layout';
 import { resolveChatTheme } from '~/shared/constants/chat-theme';
 import { trpc } from '~/utils/trpc';
 
@@ -20,4 +21,18 @@ export function useChatTheme() {
   const theme = resolveChatTheme(settings?.theme, isMember);
 
   return { theme, isMember, selectedSlug: settings?.theme };
+}
+
+/**
+ * How the message column is arranged. Ungated, unlike the theme — reading your
+ * own messages down one side is an accessibility preference as much as a look,
+ * and putting it behind a membership would sell that back.
+ */
+export function useChatLayout() {
+  const currentUser = useCurrentUser();
+  const { data: settings } = trpc.chat.getUserSettings.useQuery(undefined, {
+    enabled: !!currentUser,
+  });
+
+  return resolveChatLayout(settings?.layout);
 }

--- a/src/server/schema/chat.schema.ts
+++ b/src/server/schema/chat.schema.ts
@@ -2,6 +2,7 @@ import { ChatMemberStatus, ChatMessageType, ChatNotifyLevel } from '~/shared/uti
 import * as z from 'zod';
 import { infiniteQuerySchema } from '~/server/schema/base.schema';
 import { MAX_CHAT_MESSAGE_LENGTH } from '~/shared/utils/chat';
+import { chatLayoutSlugs } from '~/shared/constants/chat-layout';
 import { chatThemeSlugs } from '~/shared/constants/chat-theme';
 
 export type CreateChatInput = z.infer<typeof createChatInput>;
@@ -103,6 +104,7 @@ export const userSettingsChat = z.object({
   dmPolicy: chatDmPolicy.optional(),
   holdNewAccounts: z.boolean().optional(),
   theme: z.enum(chatThemeSlugs).optional(),
+  layout: z.enum(chatLayoutSlugs).optional(),
 });
 
 /**

--- a/src/shared/constants/__tests__/chat-appearance.test.ts
+++ b/src/shared/constants/__tests__/chat-appearance.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CHAT_LAYOUT_DEFAULT,
+  chatLayouts,
+  chatLayoutSlugs,
+  resolveChatLayout,
+} from '~/shared/constants/chat-layout';
+import {
+  CHAT_THEME_DEFAULT,
+  chatThemes,
+  chatThemeSlugs,
+  resolveChatTheme,
+} from '~/shared/constants/chat-theme';
+
+describe('chat themes', () => {
+  it('has exactly one theme per slug, and no theme without one', () => {
+    // The zod enum on userSettingsChat is built from chatThemeSlugs, so a theme
+    // missing from it is unsavable and a slug missing a theme resolves to default
+    // — both silently, and only for the person who picked it.
+    expect(chatThemes.map((t) => t.slug).sort()).toEqual([...chatThemeSlugs].sort());
+  });
+
+  it('gives every membership theme the bubble tokens the Bubbles layout reads', () => {
+    // .bubbles falls back to a neutral grey per token, so a theme that sets its
+    // window colours but forgets --chat-bubble reads as unthemed in that layout
+    // rather than failing outright.
+    for (const theme of chatThemes.filter((t) => t.slug !== CHAT_THEME_DEFAULT)) {
+      expect(theme.vars, theme.slug).toBeTruthy();
+      expect(Object.keys(theme.vars ?? {}), theme.slug).toEqual(
+        expect.arrayContaining(['--chat-bubble', '--chat-bubble-me'])
+      );
+    }
+  });
+
+  it('leaves the default theme without vars so the app tokens show through', () => {
+    expect(chatThemes.find((t) => t.slug === CHAT_THEME_DEFAULT)?.vars).toBeNull();
+  });
+
+  it('offers the default free and everything else behind a membership', () => {
+    expect(chatThemes.filter((t) => t.free).map((t) => t.slug)).toEqual([CHAT_THEME_DEFAULT]);
+  });
+
+  it('paints a non-member the default rather than the theme they used to have', () => {
+    expect(resolveChatTheme('violet', false).slug).toBe(CHAT_THEME_DEFAULT);
+    expect(resolveChatTheme('violet', true).slug).toBe('violet');
+  });
+
+  it('falls back to the default for a slug that no longer exists', () => {
+    expect(resolveChatTheme('retired-theme', true).slug).toBe(CHAT_THEME_DEFAULT);
+    expect(resolveChatTheme(undefined, true).slug).toBe(CHAT_THEME_DEFAULT);
+  });
+});
+
+describe('chat layouts', () => {
+  it('has exactly one layout per slug, and no layout without one', () => {
+    expect(chatLayouts.map((l) => l.slug).sort()).toEqual([...chatLayoutSlugs].sort());
+  });
+
+  it('resolves a stored layout, and anything unrecognised to stacked', () => {
+    expect(resolveChatLayout('bubbles')).toBe('bubbles');
+    expect(resolveChatLayout('stacked')).toBe('stacked');
+    expect(resolveChatLayout(undefined)).toBe(CHAT_LAYOUT_DEFAULT);
+    expect(resolveChatLayout('sidebar')).toBe(CHAT_LAYOUT_DEFAULT);
+  });
+
+  it('keeps stacked as the default, so nobody is re-laid-out without asking', () => {
+    expect(CHAT_LAYOUT_DEFAULT).toBe('stacked');
+  });
+});

--- a/src/shared/constants/chat-layout.ts
+++ b/src/shared/constants/chat-layout.ts
@@ -1,0 +1,30 @@
+/**
+ * How the message column is arranged. Independent of the theme, which is a
+ * palette: either layout renders in any theme, and unlike a theme this is free
+ * for everyone — it is a legibility preference, not a cosmetic.
+ */
+export const CHAT_LAYOUT_DEFAULT = 'stacked';
+
+export const chatLayoutSlugs = ['stacked', 'bubbles'] as const;
+export type ChatLayoutSlug = (typeof chatLayoutSlugs)[number];
+
+export const chatLayouts: { slug: ChatLayoutSlug; name: string; description: string }[] = [
+  {
+    slug: 'stacked',
+    name: 'Stacked',
+    description: 'One column, newest at the bottom, sender shown once per run — like Discord.',
+  },
+  {
+    slug: 'bubbles',
+    name: 'Bubbles',
+    description: 'Your messages on the right, everyone else on the left — like WhatsApp.',
+  },
+];
+
+export function isChatLayoutSlug(value: unknown): value is ChatLayoutSlug {
+  return chatLayoutSlugs.includes(value as ChatLayoutSlug);
+}
+
+export function resolveChatLayout(slug: string | undefined): ChatLayoutSlug {
+  return isChatLayoutSlug(slug) ? slug : CHAT_LAYOUT_DEFAULT;
+}

--- a/src/shared/constants/chat-theme.ts
+++ b/src/shared/constants/chat-theme.ts
@@ -23,6 +23,16 @@ export type ChatTheme = {
   vars: Record<string, string> | null;
 };
 
+/**
+ * Named rather than `--mantine-font-family-monospace`, whose stack leads with
+ * `ui-monospace`/`SFMono-Regular` — the system UI mono, which reads as the app's
+ * own face on a Mac and defeats the point of the skin. Locally installed faces
+ * only, so the theme costs no webfont: the open-licensed ones are preferred and
+ * the platform monos are the floor.
+ */
+const TERMINAL_FONT =
+  "'Cascadia Mono', 'Cascadia Code', 'JetBrains Mono', 'Fira Code', 'DejaVu Sans Mono', Consolas, 'Liberation Mono', 'Courier New', monospace";
+
 export const chatThemes: ChatTheme[] = [
   {
     slug: 'default',
@@ -101,7 +111,8 @@ export const chatThemes: ChatTheme[] = [
       '--chat-text-dim': '#8fbf98',
       '--chat-meta': '#6f8a75',
       '--chat-hover': 'rgb(105 219 124 / 8%)',
-      '--chat-msg-font': 'var(--mantine-font-family-monospace)',
+      '--chat-ui-font': TERMINAL_FONT,
+      '--chat-msg-font': TERMINAL_FONT,
       '--chat-msg-size': '12.5px',
       '--chat-radius': '4px',
       '--chat-bubble': '#111c12',

--- a/src/shared/constants/chat-theme.ts
+++ b/src/shared/constants/chat-theme.ts
@@ -5,7 +5,15 @@
  */
 export const CHAT_THEME_DEFAULT = 'default';
 
-export const chatThemeSlugs = ['default', 'citron', 'bubblegum', 'terminal'] as const;
+export const chatThemeSlugs = [
+  'default',
+  'citron',
+  'bubblegum',
+  'terminal',
+  'orange',
+  'blue',
+  'violet',
+] as const;
 export type ChatThemeSlug = (typeof chatThemeSlugs)[number];
 
 export type ChatTheme = {
@@ -119,6 +127,81 @@ export const chatThemes: ChatTheme[] = [
       '--chat-bubble-me': 'rgb(105 219 124 / 20%)',
       '--chat-bubble-pad': '4px 9px',
       '--chat-bubble-radius': '3px',
+    },
+  },
+  {
+    slug: 'orange',
+    name: 'Orange',
+    free: false,
+    swatch: ['#160f08', '#ff922b'],
+    vars: {
+      '--chat-bg': '#160f08',
+      '--chat-bg-image':
+        'radial-gradient(120% 85% at 50% 0%, rgb(255 146 43 / 9%), transparent 70%)',
+      '--chat-panel': '#1e150c',
+      '--chat-panel-strong': '#2a1d0f',
+      '--chat-selected': '#332211',
+      '--chat-line': '#4d3216',
+      '--chat-accent': '#ff922b',
+      '--chat-send': '#e8590c',
+      '--chat-text': '#f7ead9',
+      '--chat-text-dim': '#d2b393',
+      '--chat-meta': '#9a8069',
+      '--chat-hover': 'rgb(255 146 43 / 8%)',
+      '--chat-bubble': '#261a0e',
+      '--chat-bubble-me': 'rgb(255 146 43 / 22%)',
+      '--chat-bubble-pad': '5px 10px',
+      '--chat-bubble-radius': '12px',
+    },
+  },
+  {
+    slug: 'blue',
+    name: 'Blue',
+    free: false,
+    swatch: ['#061225', '#74c0fc'],
+    vars: {
+      '--chat-bg': '#061225',
+      '--chat-bg-image':
+        'radial-gradient(130% 90% at 0% 0%, rgb(116 192 252 / 10%), transparent 65%)',
+      '--chat-panel': '#0b1930',
+      '--chat-panel-strong': '#11233f',
+      '--chat-selected': '#152c4d',
+      '--chat-line': '#1e3d68',
+      '--chat-accent': '#74c0fc',
+      '--chat-send': '#1c7ed6',
+      '--chat-text': '#e2eefb',
+      '--chat-text-dim': '#a9c4e0',
+      '--chat-meta': '#7391b0',
+      '--chat-hover': 'rgb(116 192 252 / 9%)',
+      '--chat-bubble': '#0f2340',
+      '--chat-bubble-me': 'rgb(116 192 252 / 22%)',
+      '--chat-bubble-pad': '5px 10px',
+      '--chat-bubble-radius': '14px',
+    },
+  },
+  {
+    slug: 'violet',
+    name: 'Violet',
+    free: false,
+    swatch: ['#100c1c', '#b197fc'],
+    vars: {
+      '--chat-bg': '#100c1c',
+      '--chat-bg-image':
+        'radial-gradient(125% 85% at 50% 100%, rgb(177 151 252 / 10%), transparent 70%)',
+      '--chat-panel': '#171126',
+      '--chat-panel-strong': '#201733',
+      '--chat-selected': '#281c3e',
+      '--chat-line': '#3a2a5c',
+      '--chat-accent': '#b197fc',
+      '--chat-send': '#6741d9',
+      '--chat-text': '#ece5fb',
+      '--chat-text-dim': '#bfaee0',
+      '--chat-meta': '#8b7bab',
+      '--chat-hover': 'rgb(177 151 252 / 9%)',
+      '--chat-bubble': '#1c1430',
+      '--chat-bubble-me': 'rgb(177 151 252 / 22%)',
+      '--chat-bubble-pad': '5px 10px',
+      '--chat-bubble-radius': '14px',
     },
   },
 ];


### PR DESCRIPTION
Split message arrangement out of the theme into a separate, free `layout` setting (stacked or bubbles) with its own picker in chat settings, grouped message runs, and a `--chat-ui-font` token so themes can restyle the chat chrome as well as the messages. Bubble tokens are now left undefined in the base surface so the Bubbles layout's `var()` fallbacks work and each theme's own bubble colours show through.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868kuajdp`). Reviewed locally before push.