### PR TITLE
fix(stickers): a cropped card measured the hole, not the picture

### DIFF
--- a/src/components/CardTemplates/AspectRatioImageCard.module.scss
+++ b/src/components/CardTemplates/AspectRatioImageCard.module.scss
@@ -7,7 +7,26 @@
     .image {
       transform: scale(1.05) rotate(0.02deg);
     }
+
+    // Placed stickers ride the same zoom as the picture they were placed on.
+    // The overlay is a SIBLING of this link rather than a child — it must paint
+    // above the media and must not join the link's click target — so it cannot
+    // inherit the transform and has to be given the same one. Left out, the
+    // artwork grows under stickers that stay put, and every one of them drifts
+    // off the spot it was placed on for as long as the pointer is on the card.
+    //
+    // Same box, so the same transform is exact: the overlay is `inset-0` of the
+    // element the media fills, and both scale about their own centre.
+    ~ :global([data-sticker-overlay]) {
+      transform: scale(1.05) rotate(0.02deg);
+    }
   }
+}
+
+// Matches `.image`'s transition, so the two move together rather than the
+// stickers snapping to the zoomed position while the picture eases into it.
+:global([data-sticker-overlay]) {
+  transition: transform 400ms ease;
 }
 
 .image {

--- a/src/components/CardTemplates/AspectRatioImageCard.module.scss
+++ b/src/components/CardTemplates/AspectRatioImageCard.module.scss
@@ -15,8 +15,14 @@
     // artwork grows under stickers that stay put, and every one of them drifts
     // off the spot it was placed on for as long as the pointer is on the card.
     //
-    // Same box, so the same transform is exact: the overlay is `inset-0` of the
-    // element the media fills, and both scale about their own centre.
+    // 🔴 WHAT MAKES THIS EXACT IS COINCIDENT CENTRES, NOT EQUAL BOXES. Two boxes
+    // of different sizes scaled about one centre map every point identically;
+    // two boxes of the SAME size about different centres do not. So the property
+    // to preserve is that the media and this overlay share a centre — which they
+    // do because the overlay is `inset-0` of the element the media fills edge to
+    // edge. `.image` pins its own height below for exactly that reason: let the
+    // media box shrink and the centres separate, and this rule starts CAUSING
+    // the drift it exists to remove.
     ~ :global([data-sticker-overlay]) {
       transform: scale(1.05) rotate(0.02deg);
     }
@@ -31,7 +37,15 @@
 
 .image {
   flex: 1;
-  height: 100%;
+  // `!important` because `EdgeMedia` puts its own `.responsive` class — which
+  // sets `height: auto` — on this same element, at the same specificity and in
+  // the same cascade layer. The winner is then chunk order and nothing else.
+  // `Cards.module.css` carries the same `!important` for the same collision.
+  //
+  // It is load-bearing for stickers, not only for looks: a media box shorter
+  // than the card moves its centre up, and the hover rule above scales the
+  // overlay about a centre the picture no longer shares.
+  height: 100% !important;
   min-width: 100%;
   object-fit: cover;
   object-position: top;

--- a/src/components/Post/Detail/PostStickerOverlay.tsx
+++ b/src/components/Post/Detail/PostStickerOverlay.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { offsetWithin } from '~/components/Sticker/CardStickerOverlay';
+import { mediaContentRectOf } from '~/components/Sticker/media-content-rect';
 import { StickerPlacementOverlay } from '~/components/Sticker/StickerPlacementOverlay';
 import { useStickerPlacementBatch } from '~/components/Sticker/StickerPlacementBatchProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -68,11 +69,18 @@ export function PostStickerOverlay({ imageId }: { imageId: number }) {
       const self = offsetWithin(node, stop);
       if (!at || !self) return;
 
+      // A post image is not cropped today — nothing here sets `object-fit`, so
+      // this resolves to the element box and the behaviour is unchanged. It goes
+      // through the same helper as the card overlay anyway, because the two
+      // measure the same thing and the card's copy was silently wrong under a
+      // crop for as long as both existed.
+      const drawn = mediaContentRectOf(element);
+
       const next = {
-        width: element.offsetWidth,
-        height: element.offsetHeight,
-        left: at.x - self.x,
-        top: at.y - self.y,
+        width: drawn.width,
+        height: drawn.height,
+        left: at.x - self.x + drawn.left,
+        top: at.y - self.y + drawn.top,
       };
       setBox((current) => (same(current, next) ? current : next));
     };
@@ -81,7 +89,17 @@ export function PostStickerOverlay({ imageId }: { imageId: number }) {
     const observer = new ResizeObserver(measure);
     observer.observe(node);
     observer.observe(media);
-    return () => observer.disconnect();
+
+    // The natural size arrives with the file, and no ResizeObserver fires for
+    // it. Harmless here while nothing crops; correct if anything ever does.
+    media.addEventListener('load', measure);
+    media.addEventListener('loadedmetadata', measure);
+
+    return () => {
+      observer.disconnect();
+      media.removeEventListener('load', measure);
+      media.removeEventListener('loadedmetadata', measure);
+    };
   }, [hasPlacements]);
 
   // A post is a scroll, so an overlay that armed on mount would play its whole

--- a/src/components/Sticker/CardStickerOverlay.browser.test.tsx
+++ b/src/components/Sticker/CardStickerOverlay.browser.test.tsx
@@ -1,0 +1,152 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * 🔴 THE WIRING, WHICH IS WHERE THE REPORTED BUG ACTUALLY LIVED.
+ *
+ * `mediaContentRect` is covered as arithmetic, and it would catch a regression
+ * inside itself. It cannot catch the overlay going back to measuring
+ * `offsetWidth`/`offsetHeight` — and that one line IS the defect ECAJ reported.
+ * Before this file, reverting it left the entire suite green on the exact
+ * surface the bug came from.
+ *
+ * So this renders the real `CardStickerOverlay` over a real `object-fit: cover`
+ * image and asserts where the overlay box lands: the artwork's rectangle, which
+ * on a cropped card is taller than the card and starts above its top edge.
+ */
+
+const IMAGE_ID = 74;
+
+/** A 1x2 PNG — portrait, the shape that gets cropped in a wide card. */
+const PORTRAIT_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAIAAAAW4yFwAAAADklEQVR4nGNgaPjPAMQACgIC/2I9KX4AAAAASUVORK5CYII=';
+
+const placement = {
+  id: 1,
+  imageId: IMAGE_ID,
+  isPending: false,
+  data: { cosmeticId: 9, x: 0.5, y: 0.5, scale: 0.25, rotation: 0, flip: false, opacity: 1 },
+};
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 7 }) }));
+
+// The store's default is `revealed: false`, which renders no placements at all —
+// so without this the overlay never measures and every assertion below would be
+// asserting an empty card.
+vi.mock('~/store/sticker-reveal.store', () => ({
+  useStickerRevealStore: (select: (state: { revealed: boolean }) => unknown) =>
+    select({ revealed: true }),
+}));
+
+vi.mock('~/components/Sticker/StickerPlacementBatchProvider', () => ({
+  useStickerPlacementBatch: () => ({
+    count: 1,
+    placements: [placement],
+    pending: [],
+    sticker: new Map(),
+    treatment: 'none',
+  }),
+}));
+
+// Reduced to a marker: what is asserted is the BOX the overlay is given, which
+// is the thing the fix changes. The real overlay wants artwork, reveal timing
+// and a treatment, none of which decide where the box lands.
+vi.mock('~/components/Sticker/StickerPlacementOverlay', () => ({
+  StickerPlacementOverlay: () => <div data-testid="placements" />,
+}));
+
+const { CardStickerOverlay } = await import('~/components/Sticker/CardStickerOverlay');
+
+/**
+ * A card wider than it is tall, holding a portrait image under `cover`.
+ *
+ * 400x200 with a 1:2 picture: covering 400 wide scales the artwork to 800 tall,
+ * so 600px of it is cropped. `object-position: top` keeps the top edge, which is
+ * what both real card stylesheets do.
+ */
+const CARD = { width: 400, height: 200 };
+
+const renderCard = async () => {
+  renderWithProviders(
+    <div style={{ position: 'relative', ...CARD }}>
+      {/* Absolutely positioned, as the real cards have it — the media sits inside
+          a positioned link and the overlay is its sibling. It also keeps the
+          media out of normal flow, which matters here: this harness mounts
+          components without the app's stylesheet, so the overlay's own
+          `absolute inset-0` does nothing and an in-flow image would push the
+          overlay's root below it, measuring an offset no real card has. */}
+      {/* eslint-disable-next-line @next/next/no-img-element -- a fixture, not app
+          markup: the point is a plain element with a known natural size and a
+          real object-fit, which next/image would wrap and re-style. */}
+      <img
+        src={PORTRAIT_PNG}
+        alt=""
+        style={{
+          position: 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%',
+          objectFit: 'cover',
+          objectPosition: 'top',
+        }}
+      />
+      <CardStickerOverlay imageId={IMAGE_ID} />
+    </div>
+  );
+
+  // `.element()` does not retry, and the overlay paints its positioned box only
+  // after the effect has measured a laid-out image — a later frame than the
+  // first render. Poll for it, then take the node.
+  const locator = page.getByTestId('placements');
+  await expect.element(locator, { timeout: 5000 }).toBeInTheDocument();
+  const marker = await locator.element();
+  // The box is the overlay's positioned wrapper — the element the fix moves.
+  return marker.parentElement as HTMLElement;
+};
+
+/**
+ * The box's own inline style, which is where the measurement lands.
+ *
+ * Not `offsetTop`/`offsetWidth`: the overlay positions itself with Tailwind's
+ * `absolute inset-0`, and this harness mounts components without the app's
+ * stylesheet — so those classes do nothing here and the layout numbers describe
+ * normal flow rather than anything the component decided. The inline style is
+ * the component's own output and is unaffected by that.
+ */
+const measured = (box: HTMLElement) => ({
+  width: parseFloat(box.style.width),
+  height: parseFloat(box.style.height),
+  left: parseFloat(box.style.left),
+  top: parseFloat(box.style.top),
+});
+
+describe('the overlay is sized to the artwork, not to the card', () => {
+  test('a cropped card gets the artwork rect, which overflows it', async () => {
+    const box = measured(await renderCard());
+
+    // 1:2 artwork covering 400 wide is 800 tall. The card is 200.
+    expect(box.width).toBe(400);
+    expect(box.height).toBe(800);
+
+    // `object-position: top` pins the top edge, so the overflow hangs below.
+    expect(box.top).toBe(0);
+    expect(box.left).toBe(0);
+  });
+
+  /**
+   * The assertion that speaks in the reporter's terms rather than the DOM's:
+   * a sticker at y = 0.5 belongs halfway down the PICTURE. The old code made
+   * that halfway down the CARD, which is a different place on any cropped image
+   * — 400px down here against 100.
+   */
+  test('half way down the artwork is not half way down the card', async () => {
+    const box = measured(await renderCard());
+
+    const middleOfArtwork = box.top + box.height * 0.5;
+
+    expect(middleOfArtwork).toBe(400);
+    expect(middleOfArtwork).not.toBe(CARD.height * 0.5);
+  });
+});

--- a/src/components/Sticker/CardStickerOverlay.tsx
+++ b/src/components/Sticker/CardStickerOverlay.tsx
@@ -233,7 +233,15 @@ export function CardStickerOverlay({
   if (!batch || !hasPlacements) return null;
 
   return (
-    <div ref={ref} className="pointer-events-none absolute inset-0 overflow-hidden">
+    <div
+      ref={ref}
+      // The hook the card templates use to make this ride whatever transform
+      // they apply to the media on hover. An attribute rather than a class
+      // because the two templates own different stylesheets and neither should
+      // have to import a class from this component to scale it.
+      data-sticker-overlay=""
+      className="pointer-events-none absolute inset-0 overflow-hidden"
+    >
       {box && (
         <div className="pointer-events-none absolute" style={box}>
           <StickerPlacementOverlay

--- a/src/components/Sticker/CardStickerOverlay.tsx
+++ b/src/components/Sticker/CardStickerOverlay.tsx
@@ -23,6 +23,13 @@ type Box = { width: number; height: number; left: number; top: number };
  */
 const CARD_ARTWORK_WIDTH = 256;
 
+/**
+ * The ceiling on the scaled request. 512 is what the image detail view asks for,
+ * and a feed card has no business fetching sticker artwork larger than the page
+ * that shows the sticker at full size.
+ */
+const MAX_ARTWORK_WIDTH = 512;
+
 const same = (a: Box | null, b: Box) =>
   !!a && a.width === b.width && a.height === b.height && a.left === b.left && a.top === b.top;
 
@@ -104,15 +111,15 @@ export function CardStickerOverlay({
     const node = ref.current;
     if (!node || !hasPlacements) return;
 
-    // The media is a sibling subtree, not a child of the overlay: the overlay
-    // must sit above it, and nesting inside the link would make it part of the
-    // card's click target.
-    const media = node.parentElement?.querySelector('img, video');
-    if (!media) return;
+    const parent = node.parentElement;
+    if (!parent) return;
+
+    let bound: HTMLElement | null = null;
+    let observer: ResizeObserver | null = null;
 
     const measure = () => {
-      const element = media as HTMLElement;
-      if (element.offsetWidth <= 0 || element.offsetHeight <= 0) return;
+      const element = bound;
+      if (!element || element.offsetWidth <= 0 || element.offsetHeight <= 0) return;
 
       const stop = node.offsetParent;
       const at = offsetWithin(element, stop);
@@ -137,25 +144,89 @@ export function CardStickerOverlay({
       setBox((current) => (same(current, next) ? current : next));
     };
 
-    measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(node);
-    observer.observe(media);
+    /**
+     * 🔴 THE MEDIA ELEMENT IS REPLACED, NOT MERELY RESIZED.
+     *
+     * `EdgeMedia` renders an `<img>` instead of a `<video>` when the viewer
+     * turns off animated media, and `EdgeVideo` keys on its src, so a changed
+     * URL remounts it. This effect keys on `hasPlacements` and does not re-run
+     * for either — so an observer bound once stays bound to a DETACHED node,
+     * `measure` then early-returns on its zero-size guard forever, and the
+     * overlay keeps its last box with a clean render and no error at all.
+     */
+    const bind = () => {
+      const media = parent.querySelector<HTMLElement>('img, video');
+      if (media === bound) return;
 
-    // The natural size arrives with the file, not with the element, and a
-    // `ResizeObserver` does not fire for it: the box is already its final size
-    // while the picture inside it is still unknown. Without this the overlay
-    // keeps the uncropped geometry it measured before the image loaded — which
-    // is the bug, one frame late.
-    media.addEventListener('load', measure);
-    media.addEventListener('loadedmetadata', measure);
+      unbind();
+      bound = media;
+      if (!media) return;
+
+      observer = new ResizeObserver(measure);
+      observer.observe(node);
+      observer.observe(media);
+
+      // The natural size arrives with the FILE, not with the element, and no
+      // `ResizeObserver` fires for it: the box is already final while the
+      // picture inside it is still unknown. Without these the overlay keeps the
+      // uncropped geometry it measured before the image loaded, which is the
+      // same bug one frame later.
+      //
+      // `resize` is the video one and is not decoration: card video is
+      // `preload="none"`, so `videoWidth` stays 0 until something plays it —
+      // `loadedmetadata` may be minutes away or never come. Until it does,
+      // `mediaContentRect` returns the element box, which is exactly the
+      // behaviour that shipped before this change rather than a new failure.
+      media.addEventListener('load', measure);
+      media.addEventListener('loadedmetadata', measure);
+      media.addEventListener('resize', measure);
+
+      measure();
+    };
+
+    const unbind = () => {
+      observer?.disconnect();
+      observer = null;
+      if (!bound) return;
+      bound.removeEventListener('load', measure);
+      bound.removeEventListener('loadedmetadata', measure);
+      bound.removeEventListener('resize', measure);
+      bound = null;
+    };
+
+    bind();
+
+    const swaps = new MutationObserver(bind);
+    swaps.observe(parent, { childList: true, subtree: true });
 
     return () => {
-      observer.disconnect();
-      media.removeEventListener('load', measure);
-      media.removeEventListener('loadedmetadata', measure);
+      swaps.disconnect();
+      unbind();
     };
   }, [hasPlacements]);
+
+  /**
+   * What the CDN is asked for, scaled to the box the sticker is actually drawn
+   * against.
+   *
+   * A sticker's size is a fraction of its container, and this overlay's
+   * container is now the ARTWORK rect rather than the card. Under a horizontal
+   * crop that rect is much wider than the card — a 16:9 image in the 7:9 card is
+   * about 2.3x — so `artworkWidth` alone would under-request by the same factor
+   * and upscale artwork a creator was paid for. That is the exact failure the
+   * constant above was chosen to avoid, reintroduced by moving the container.
+   *
+   * Rounded up to whole hundreds so a card that resizes by a pixel does not mint
+   * a new CDN URL per frame, and capped: a very wide crop should not fetch a
+   * sticker larger than the detail view ever asks for.
+   */
+  const requestWidth = (() => {
+    if (!box || box.width <= 0) return artworkWidth;
+    const measured = ref.current?.offsetWidth ?? 0;
+    if (measured <= 0) return artworkWidth;
+    const scaled = artworkWidth * (box.width / measured);
+    return Math.min(Math.ceil(scaled / 100) * 100, MAX_ARTWORK_WIDTH);
+  })();
 
   // Narrows `batch` as well: `placements` is empty without one, so reaching
   // here means the provider is present.
@@ -170,7 +241,7 @@ export function CardStickerOverlay({
             viewerId={currentUser?.id}
             interactive={false}
             sticker={batch?.sticker}
-            artworkWidth={artworkWidth}
+            artworkWidth={requestWidth}
             treatment={batch.treatment}
             surface="card"
           />

--- a/src/components/Sticker/CardStickerOverlay.tsx
+++ b/src/components/Sticker/CardStickerOverlay.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { mediaContentRectOf } from '~/components/Sticker/media-content-rect';
 import { StickerPlacementOverlay } from '~/components/Sticker/StickerPlacementOverlay';
 import { useStickerPlacementBatch } from '~/components/Sticker/StickerPlacementBatchProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -118,11 +119,17 @@ export function CardStickerOverlay({
       const self = offsetWithin(node, stop);
       if (!at || !self) return;
 
+      // The rectangle the ARTWORK occupies, which under `object-fit: cover` is
+      // larger than the element and offset inside it. Positions are fractions of
+      // the artwork, so the overlay has to be that rectangle; the wrapper's
+      // `overflow-hidden` then crops it exactly as the card crops the picture.
+      const drawn = mediaContentRectOf(element);
+
       const next = {
-        width: element.offsetWidth,
-        height: element.offsetHeight,
-        left: at.x - self.x,
-        top: at.y - self.y,
+        width: drawn.width,
+        height: drawn.height,
+        left: at.x - self.x + drawn.left,
+        top: at.y - self.y + drawn.top,
       };
       // A ResizeObserver fires on every layout pass, so setting state
       // unconditionally would re-render the overlay continuously on a page that
@@ -134,7 +141,20 @@ export function CardStickerOverlay({
     const observer = new ResizeObserver(measure);
     observer.observe(node);
     observer.observe(media);
-    return () => observer.disconnect();
+
+    // The natural size arrives with the file, not with the element, and a
+    // `ResizeObserver` does not fire for it: the box is already its final size
+    // while the picture inside it is still unknown. Without this the overlay
+    // keeps the uncropped geometry it measured before the image loaded — which
+    // is the bug, one frame late.
+    media.addEventListener('load', measure);
+    media.addEventListener('loadedmetadata', measure);
+
+    return () => {
+      observer.disconnect();
+      media.removeEventListener('load', measure);
+      media.removeEventListener('loadedmetadata', measure);
+    };
   }, [hasPlacements]);
 
   // Narrows `batch` as well: `placements` is empty without one, so reaching

--- a/src/components/Sticker/__tests__/hover-zoom-pairs-with-overlay.test.ts
+++ b/src/components/Sticker/__tests__/hover-zoom-pairs-with-overlay.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * The card's hover zoom and the sticker overlay move together, or stickers drift.
+ *
+ * A placed sticker sits on an overlay that is a SIBLING of the card's link — it
+ * has to paint above the media and must not join the click target — so it does
+ * not inherit the transform the media gets on hover. The two are kept in step by
+ * one rule listing both. Retune the media's zoom alone and every sticker slides
+ * off its spot for as long as the pointer is on the card.
+ *
+ * 🔴 WHY THIS IS A SOURCE SCAN AND NOT A RENDER. `:hover` is not a state a
+ * component test drives, and the component harness mounts without the app's
+ * stylesheet — so `CardStickerOverlay.browser.test.tsx` positions its fixture
+ * media by hand and could never notice a stylesheet change. An adversarial
+ * review of the hover fix found exactly that: nothing in the suite could fail if
+ * the pairing broke.
+ *
+ * 🔴 AND WHY IT ALSO CHECKS THE HEIGHT. What makes one transform correct for two
+ * elements is a SHARED CENTRE, not equal boxes. `EdgeMedia` puts `.responsive`
+ * (`height: auto`) on the same element as `.image` (`height: 100%`), same
+ * specificity, same layer — so without `!important` the winner is chunk order.
+ * Lose that tie and the media box is shorter than the card, the centres
+ * separate, and the hover rule starts causing the drift it exists to remove.
+ */
+const STYLESHEET = resolve(
+  __dirname,
+  '..',
+  '..',
+  'CardTemplates',
+  'AspectRatioImageCard.module.scss'
+);
+
+const source = () => readFileSync(STYLESHEET, 'utf-8');
+
+/** The `&:hover { … }` block inside `.linkOrClick`, braces balanced. */
+const hoverBlock = (css: string) => {
+  const start = css.indexOf('&:hover');
+  if (start < 0) return null;
+
+  let depth = 0;
+  for (let i = css.indexOf('{', start); i < css.length; i += 1) {
+    if (css[i] === '{') depth += 1;
+    else if (css[i] === '}') {
+      depth -= 1;
+      if (!depth) return css.slice(start, i + 1);
+    }
+  }
+  return null;
+};
+
+/** Every `transform: …;` value in a block, in order. */
+const transformsIn = (css: string) =>
+  Array.from(css.matchAll(/transform:\s*([^;]+);/g), (match) => match[1].trim());
+
+describe('the hover zoom carries the sticker overlay with it', () => {
+  test('the hover block scales the media and the overlay by the same transform', () => {
+    const block = hoverBlock(source());
+
+    // The positive control: if the block cannot be found at all — renamed,
+    // restructured, moved to another file — that is a failure, not a pass. Every
+    // assertion below is vacuously true against `null`.
+    expect(block).not.toBeNull();
+    expect(block).toContain('.image');
+    expect(block).toContain('[data-sticker-overlay]');
+
+    const transforms = transformsIn(block ?? '');
+
+    // Two rules, one value. A retune that touches only the media leaves two
+    // different values here and fails on this line.
+    expect(transforms).toHaveLength(2);
+    expect(new Set(transforms).size).toBe(1);
+  });
+
+  test('the media height is pinned, so the two keep a common centre', () => {
+    expect(source()).toMatch(/height:\s*100%\s*!important/);
+  });
+
+  test('the overlay transitions with the media rather than snapping', () => {
+    const css = source();
+
+    const mediaTransition = /transition:\s*transform\s+400ms\s+ease/.test(css);
+    const overlayTransition =
+      /:global\(\[data-sticker-overlay\]\)\s*\{[^}]*transition:\s*transform\s+400ms\s+ease/.test(
+        css
+      );
+
+    expect(mediaTransition).toBe(true);
+    expect(overlayTransition).toBe(true);
+  });
+});

--- a/src/components/Sticker/__tests__/media-content-rect.test.ts
+++ b/src/components/Sticker/__tests__/media-content-rect.test.ts
@@ -127,6 +127,50 @@ describe('what it refuses to guess', () => {
     expect(drawn.top).toBe(-300);
   });
 
+  /**
+   * Refusing beats guessing. Every one of these used to fall through to
+   * centring, which answers a question the parser could not read — and centring
+   * is plausible, so nobody would have found it.
+   */
+  test('an object-position it cannot read gives back the element box', () => {
+    for (const position of [
+      'right 20px bottom 10px', // four tokens: reading the first two is wrong on both axes
+      'calc(50% + 10px) 0%', // legal computed value, matches neither regex
+      '', // nothing at all
+    ])
+      expect(mediaContentRect({ box: CARD, natural: PORTRAIT, fit: 'cover', position })).toEqual({
+        ...CARD,
+        left: 0,
+        top: 0,
+      });
+  });
+
+  /**
+   * `object-position: top center` is the literal value in `Cards.module.css`.
+   * Read positionally, `top` lands on the x axis and pins the artwork to the
+   * LEFT edge — a real card, silently offset, if a browser ever hands the
+   * keywords back unresolved.
+   */
+  test('keyword pairs written vertical-first are not read as horizontal', () => {
+    const wide = { width: 2000, height: 1000 };
+
+    expect(
+      mediaContentRect({ box: CARD, natural: wide, fit: 'cover', position: 'top center' })
+    ).toEqual(mediaContentRect({ box: CARD, natural: wide, fit: 'cover', position: 'center top' }));
+  });
+
+  test('a single keyword centres the other axis', () => {
+    const wide = { width: 2000, height: 1000 };
+
+    // 1200 wide in a 450 box, centred: 375 of overflow either side.
+    expect(mediaContentRect({ box: CARD, natural: wide, fit: 'cover', position: 'top' })).toEqual({
+      width: 1200,
+      height: 600,
+      left: -375,
+      top: 0,
+    });
+  });
+
   test('a pixel offset is an offset, not a proportion', () => {
     const drawn = mediaContentRect({
       box: CARD,

--- a/src/components/Sticker/__tests__/media-content-rect.test.ts
+++ b/src/components/Sticker/__tests__/media-content-rect.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'vitest';
+import { mediaContentRect } from '../media-content-rect';
+
+/**
+ * The arithmetic behind the featured-feed misplacement.
+ *
+ * A placement is a fraction of the ARTWORK. Under `object-fit: cover` the
+ * element is a hole the artwork is cropped into, so the two rectangles differ —
+ * and the overlay was using the hole. The numbers below are the reported case:
+ * a portrait image in a landscape-ish card, where the crop takes most of the
+ * height and a sticker placed near the middle lands near the bottom.
+ */
+const PORTRAIT = { width: 1000, height: 2000 };
+const CARD = { width: 450, height: 600 };
+
+describe('object-fit: cover', () => {
+  /**
+   * 🔴 The bug, stated as an assertion about a sticker rather than a rectangle.
+   *
+   * The card is the same box either way, so a test that only compared rects
+   * could be read as "the numbers changed". What matters is that a placement at
+   * y = 0.5 does not sit halfway down the CARD, because half the artwork is not
+   * where half the card is.
+   */
+  test('a placement in the middle of the artwork is not the middle of the card', () => {
+    const drawn = mediaContentRect({
+      box: CARD,
+      natural: PORTRAIT,
+      fit: 'cover',
+      position: '50% 0%',
+    });
+
+    // Scaled to cover 450 wide: 1000 -> 450 is 0.45, so 2000 -> 900.
+    expect(drawn).toEqual({ width: 450, height: 900, left: 0, top: 0 });
+
+    // Where the middle of the artwork actually falls inside the card.
+    const middleOfArtwork = drawn.top + drawn.height * 0.5;
+    expect(middleOfArtwork).toBe(450);
+
+    // The card is 600 tall, so the old behaviour put it at 300 — 150px too high,
+    // a quarter of the card. That gap is the whole bug.
+    expect(middleOfArtwork).not.toBe(CARD.height * 0.5);
+  });
+
+  test('centres the overflow when object-position says so', () => {
+    const drawn = mediaContentRect({
+      box: CARD,
+      natural: PORTRAIT,
+      fit: 'cover',
+      position: '50% 50%',
+    });
+
+    // 900 tall in a 600 box: 300 of overflow, half of it above.
+    expect(drawn).toEqual({ width: 450, height: 900, left: 0, top: -150 });
+  });
+
+  test('crops the sides when the artwork is the wider one', () => {
+    const drawn = mediaContentRect({
+      box: CARD,
+      natural: { width: 2000, height: 1000 },
+      fit: 'cover',
+      position: '50% 50%',
+    });
+
+    // Covers 600 tall: scale 0.6, so 2000 -> 1200 wide, 375 of overflow either
+    // side of a 450 box.
+    expect(drawn).toEqual({ width: 1200, height: 600, left: -375, top: 0 });
+  });
+});
+
+describe('the fits that are not cover', () => {
+  test('contain letterboxes rather than cropping', () => {
+    const drawn = mediaContentRect({
+      box: CARD,
+      natural: PORTRAIT,
+      fit: 'contain',
+      position: '50% 50%',
+    });
+
+    // 600 tall is the binding side: scale 0.3, so 1000 -> 300 wide, centred.
+    expect(drawn).toEqual({ width: 300, height: 600, left: 75, top: 0 });
+  });
+
+  test('fill draws to the box, which is what every uncropped surface does', () => {
+    expect(
+      mediaContentRect({ box: CARD, natural: PORTRAIT, fit: 'fill', position: '50% 50%' })
+    ).toEqual({ ...CARD, left: 0, top: 0 });
+  });
+
+  test('scale-down never enlarges a small image', () => {
+    const drawn = mediaContentRect({
+      box: CARD,
+      natural: { width: 100, height: 100 },
+      fit: 'scale-down',
+      position: '50% 50%',
+    });
+
+    expect(drawn).toEqual({ width: 100, height: 100, left: 175, top: 250 });
+  });
+});
+
+describe('what it refuses to guess', () => {
+  /**
+   * An unloaded image reports 0x0. Scaling by that produces `Infinity` and then
+   * `NaN` offsets, which reach the DOM as a style of `NaNpx` — the overlay
+   * disappears rather than being merely misplaced, so this is the one input that
+   * must not be computed from.
+   */
+  test('an unloaded image gets the element box, not NaN', () => {
+    for (const natural of [null, { width: 0, height: 0 }, { width: 1000, height: 0 }])
+      expect(mediaContentRect({ box: CARD, natural, fit: 'cover', position: '50% 50%' })).toEqual({
+        ...CARD,
+        left: 0,
+        top: 0,
+      });
+  });
+
+  test('keywords still resolve if a browser hands them back unresolved', () => {
+    const drawn = mediaContentRect({
+      box: CARD,
+      natural: PORTRAIT,
+      fit: 'cover',
+      position: 'center bottom',
+    });
+
+    // Bottom-aligned: the whole 300 of overflow is above.
+    expect(drawn.top).toBe(-300);
+  });
+
+  test('a pixel offset is an offset, not a proportion', () => {
+    const drawn = mediaContentRect({
+      box: CARD,
+      natural: PORTRAIT,
+      fit: 'cover',
+      position: '0px -20px',
+    });
+
+    expect(drawn).toEqual({ width: 450, height: 900, left: 0, top: -20 });
+  });
+});

--- a/src/components/Sticker/media-content-rect.browser.test.tsx
+++ b/src/components/Sticker/media-content-rect.browser.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'vitest';
+import { mediaContentRectOf } from '~/components/Sticker/media-content-rect';
+
+/**
+ * The half the unit tests cannot reach: reading a real element.
+ *
+ * `mediaContentRect` is arithmetic and covered as arithmetic. What is asserted
+ * here is that the three values fed to it come off the DOM correctly — the
+ * natural size of a decoded image, and `object-fit`/`object-position` as the
+ * browser resolves them, which is where keywords become percentages and where a
+ * stylesheet's `object-position: top` stops being a string anyone can predict.
+ */
+
+/** A 2x1 PNG. Its natural size is the point; the pixels are not. */
+const TWO_BY_ONE =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAIAAAB7QOjdAAAADUlEQVR4nGP4z8AARAAI/gH/xp559wAAAABJRU5ErkJggg==';
+
+const drawImage = async (style: Partial<CSSStyleDeclaration>) => {
+  const host = document.createElement('div');
+  host.style.width = '400px';
+  host.style.height = '400px';
+  document.body.append(host);
+
+  const img = document.createElement('img');
+  Object.assign(img.style, { width: '100%', height: '100%', ...style });
+
+  const loaded = new Promise((resolve, reject) => {
+    img.addEventListener('load', resolve, { once: true });
+    img.addEventListener('error', reject, { once: true });
+  });
+
+  img.src = TWO_BY_ONE;
+  host.append(img);
+  await loaded;
+
+  return { img, cleanup: () => host.remove() };
+};
+
+describe('reading a real element', () => {
+  test('cover: the artwork overflows the element, and the rect says where', async () => {
+    const { img, cleanup } = await drawImage({ objectFit: 'cover', objectPosition: 'top' });
+
+    // The element is the square the card gives it...
+    expect(img.offsetWidth).toBe(400);
+    expect(img.offsetHeight).toBe(400);
+
+    // ...and the artwork inside it is 2:1, scaled to cover 400 tall, so it is
+    // 800 wide and hanging 200px off each side. `object-position: top` resolves
+    // to `50% 0%`, which centres the horizontal overflow.
+    const drawn = mediaContentRectOf(img);
+    expect(drawn).toEqual({ width: 800, height: 400, left: -200, top: 0 });
+
+    cleanup();
+  });
+
+  test('an element with no object-fit is its own box', async () => {
+    const { img, cleanup } = await drawImage({});
+
+    expect(mediaContentRectOf(img)).toEqual({ width: 400, height: 400, left: 0, top: 0 });
+
+    cleanup();
+  });
+
+  /**
+   * The state the overlay measures in before the file arrives. It must come back
+   * as the element box rather than as `NaN` — a `NaN` reaches the DOM as
+   * `NaNpx` and the overlay vanishes instead of being merely misplaced.
+   */
+  test('an image that has not loaded yields the element box, not NaN', () => {
+    const host = document.createElement('div');
+    host.style.cssText = 'width:400px;height:400px';
+    const img = document.createElement('img');
+    img.style.cssText = 'width:100%;height:100%;object-fit:cover';
+    host.append(img);
+    document.body.append(host);
+
+    expect(img.naturalWidth).toBe(0);
+    const drawn = mediaContentRectOf(img);
+
+    expect(Number.isNaN(drawn.width + drawn.height + drawn.left + drawn.top)).toBe(false);
+    expect(drawn).toEqual({ width: 400, height: 400, left: 0, top: 0 });
+
+    host.remove();
+  });
+});

--- a/src/components/Sticker/media-content-rect.ts
+++ b/src/components/Sticker/media-content-rect.ts
@@ -41,24 +41,31 @@ const scaleFor = (fit: string, box: Size, natural: Size) => {
   }
 };
 
+const HORIZONTAL = new Set(['left', 'right']);
+const VERTICAL = new Set(['top', 'bottom']);
+
 /**
- * One axis of `object-position`, as a fraction of the free space.
+ * One axis of `object-position`, as a fraction of the free space — or `null`
+ * where the value is not one this understands.
  *
- * `getComputedStyle` resolves keywords to percentages (`top` becomes `50% 0%`),
- * so percentages are the common case. A length is an offset from the leading
- * edge rather than a proportion, which is the same distinction
- * `background-position` makes.
+ * `null` matters more than the arithmetic does. Every unparsed value used to
+ * fall back to centring, which is a confident answer to a question this could
+ * not read: `calc(50% + 10px)` is a legal computed value, and centring it puts
+ * every sticker somewhere plausible and wrong. The caller returns the element
+ * box instead, which is the pre-fix behaviour — wrong in the same direction it
+ * has always been wrong, rather than newly and differently wrong.
  */
 const offsetFor = (value: string | undefined, free: number) => {
-  if (!value) return free / 2;
+  if (!value) return null;
 
   const percent = /^(-?[\d.]+)%$/.exec(value);
   if (percent) return (free * Number(percent[1])) / 100;
 
+  // Computed style resolves em/rem/vh to px, so this covers every length that
+  // survives to this point.
   const pixels = /^(-?[\d.]+)px$/.exec(value);
   if (pixels) return Number(pixels[1]);
 
-  // Keywords, in case a browser hands them back unresolved.
   switch (value) {
     case 'left':
     case 'top':
@@ -69,8 +76,33 @@ const offsetFor = (value: string | undefined, free: number) => {
     case 'center':
       return free / 2;
     default:
-      return free / 2;
+      return null;
   }
+};
+
+/**
+ * The two axes of `object-position`, in x-then-y order.
+ *
+ * Keywords may be written either way round — `object-position: top center` is
+ * the literal value in `Cards.module.css` — so a positional read of the tokens
+ * maps `top` onto x and lands the artwork at the left edge. Browsers normally
+ * resolve both to percentages before this sees them; this is for the case where
+ * one does not.
+ *
+ * Anything with more than two tokens (`right 20px bottom 10px`) is refused
+ * rather than truncated: reading the first two of four gives a number that is
+ * confidently wrong on both axes.
+ */
+const axesOf = (position: string) => {
+  const tokens = position.trim().split(/\s+/).filter(Boolean);
+  if (!tokens.length || tokens.length > 2) return null;
+
+  const [first, second] = tokens;
+  if (tokens.length === 1) return VERTICAL.has(first) ? ['center', first] : [first, 'center'];
+
+  // Written the other way round, which CSS allows for keyword pairs.
+  if (VERTICAL.has(first) || HORIZONTAL.has(second)) return [second, first];
+  return [first, second];
 };
 
 /**
@@ -107,21 +139,39 @@ export function mediaContentRect({
 
   const width = natural.width * scale;
   const height = natural.height * scale;
-  const [x, y] = position.split(/\s+/);
+
+  const axes = axesOf(position);
+  if (!axes) return asIs;
+
+  const left = offsetFor(axes[0], box.width - width);
+  const top = offsetFor(axes[1], box.height - height);
+  if (left == null || top == null) return asIs;
 
   return {
     width,
     height,
-    // `+ 0` normalises negative zero, which `0% ` of a zero overflow produces.
+    // `+ 0` normalises negative zero, which `0%` of a zero overflow produces.
     // It styles identically but is a different value to `Object.is`, so without
-    // this a test asserting the uncropped axis compares -0 against 0 and fails
-    // on an equality nobody can see.
-    left: offsetFor(x, box.width - width) + 0,
-    top: offsetFor(y, box.height - height) + 0,
+    // it a test asserting the uncropped axis compares -0 against 0 and fails on
+    // an equality nobody can see.
+    left: left + 0,
+    top: top + 0,
   };
 }
 
-/** `mediaContentRect` for a live element, reading the values off the DOM. */
+/**
+ * `mediaContentRect` for a live element, reading the values off the DOM.
+ *
+ * The box is the CONTENT box, not `offsetWidth`/`offsetHeight`. `object-fit`
+ * fits the content box, so padding or a border on the media would otherwise
+ * make the artwork rect too large and shift every sticker by the border width —
+ * silently, and only on cropped cards. Nothing sets either today; the card
+ * wrapper beside it already carries a border, and one stylesheet change moves
+ * it onto the media.
+ *
+ * The returned rect is in the ELEMENT's coordinates (border box), so the
+ * content box's own inset is added back.
+ */
 export function mediaContentRectOf(element: HTMLElement): Rect {
   const style = getComputedStyle(element);
 
@@ -132,10 +182,24 @@ export function mediaContentRectOf(element: HTMLElement): Rect {
       ? { width: element.videoWidth, height: element.videoHeight }
       : null;
 
-  return mediaContentRect({
-    box: { width: element.offsetWidth, height: element.offsetHeight },
+  const px = (value: string) => parseFloat(value) || 0;
+  const insetLeft = px(style.borderLeftWidth) + px(style.paddingLeft);
+  const insetTop = px(style.borderTopWidth) + px(style.paddingTop);
+  const contentWidth =
+    element.clientWidth > 0
+      ? element.clientWidth - px(style.paddingLeft) - px(style.paddingRight)
+      : element.offsetWidth;
+  const contentHeight =
+    element.clientHeight > 0
+      ? element.clientHeight - px(style.paddingTop) - px(style.paddingBottom)
+      : element.offsetHeight;
+
+  const rect = mediaContentRect({
+    box: { width: contentWidth, height: contentHeight },
     natural,
     fit: style.objectFit,
     position: style.objectPosition,
   });
+
+  return { ...rect, left: rect.left + insetLeft, top: rect.top + insetTop };
 }

--- a/src/components/Sticker/media-content-rect.ts
+++ b/src/components/Sticker/media-content-rect.ts
@@ -1,0 +1,141 @@
+/**
+ * Where a cropped image actually is inside the element that draws it.
+ *
+ * A placement is a fraction of the ARTWORK's bounds. An `<img>` under
+ * `object-fit: cover` is a box the artwork is scaled and cropped INTO, so the
+ * element's own `offsetWidth`/`offsetHeight` describe the hole, not the picture.
+ * Mapping fractions onto the hole puts every sticker in the wrong place, by an
+ * amount that grows with how much the card crops — which is why it was reported
+ * from the featured feed, where a portrait image loses most of its height, and
+ * never from the post page, where nothing is cropped at all.
+ *
+ * The maths is `object-fit`'s own: scale the artwork by the larger ratio for
+ * `cover` and the smaller for `contain`, then place it with `object-position`.
+ * The result deliberately OVERFLOWS the element for `cover` — that is the part
+ * being cropped, and the overlay's container clips it, so a sticker placed on
+ * the cropped-away part of the image is correctly not visible on the card.
+ */
+export type Rect = { width: number; height: number; left: number; top: number };
+
+type Size = { width: number; height: number };
+
+/** The scale `object-fit` applies, per its spec. */
+const scaleFor = (fit: string, box: Size, natural: Size) => {
+  const wide = box.width / natural.width;
+  const tall = box.height / natural.height;
+
+  switch (fit) {
+    case 'cover':
+      return Math.max(wide, tall);
+    case 'contain':
+      return Math.min(wide, tall);
+    case 'none':
+      return 1;
+    // Whichever of `none` and `contain` is smaller — never enlarges.
+    case 'scale-down':
+      return Math.min(1, Math.min(wide, tall));
+    // `fill` stretches to the box on both axes, so there is no single scale and
+    // no crop: the drawn rect IS the element box. Handled by the caller.
+    default:
+      return null;
+  }
+};
+
+/**
+ * One axis of `object-position`, as a fraction of the free space.
+ *
+ * `getComputedStyle` resolves keywords to percentages (`top` becomes `50% 0%`),
+ * so percentages are the common case. A length is an offset from the leading
+ * edge rather than a proportion, which is the same distinction
+ * `background-position` makes.
+ */
+const offsetFor = (value: string | undefined, free: number) => {
+  if (!value) return free / 2;
+
+  const percent = /^(-?[\d.]+)%$/.exec(value);
+  if (percent) return (free * Number(percent[1])) / 100;
+
+  const pixels = /^(-?[\d.]+)px$/.exec(value);
+  if (pixels) return Number(pixels[1]);
+
+  // Keywords, in case a browser hands them back unresolved.
+  switch (value) {
+    case 'left':
+    case 'top':
+      return 0;
+    case 'right':
+    case 'bottom':
+      return free;
+    case 'center':
+      return free / 2;
+    default:
+      return free / 2;
+  }
+};
+
+/**
+ * The artwork's rectangle inside `box`, in the box's own coordinates.
+ *
+ * `left`/`top` are negative wherever the artwork is cropped — that is the point.
+ * Returns the box unchanged when there is nothing to compute from: an unloaded
+ * image has no natural size, and `fill` (the CSS default) draws to the box by
+ * definition.
+ */
+export function mediaContentRect({
+  box,
+  natural,
+  fit,
+  position,
+}: {
+  box: Size;
+  /** `naturalWidth`/`naturalHeight`, or a video's `videoWidth`/`videoHeight`. */
+  natural: Size | null;
+  /** Computed `object-fit`. */
+  fit: string;
+  /** Computed `object-position`, e.g. `"50% 0%"`. */
+  position: string;
+}): Rect {
+  const asIs = { width: box.width, height: box.height, left: 0, top: 0 };
+
+  // A natural size of 0 is an image that has not loaded. Guessing here would
+  // paint every sticker in the wrong place for one frame and then correct it,
+  // which reads as a glitch; the caller re-measures on load instead.
+  if (!natural || natural.width <= 0 || natural.height <= 0) return asIs;
+
+  const scale = scaleFor(fit, box, natural);
+  if (scale == null) return asIs;
+
+  const width = natural.width * scale;
+  const height = natural.height * scale;
+  const [x, y] = position.split(/\s+/);
+
+  return {
+    width,
+    height,
+    // `+ 0` normalises negative zero, which `0% ` of a zero overflow produces.
+    // It styles identically but is a different value to `Object.is`, so without
+    // this a test asserting the uncropped axis compares -0 against 0 and fails
+    // on an equality nobody can see.
+    left: offsetFor(x, box.width - width) + 0,
+    top: offsetFor(y, box.height - height) + 0,
+  };
+}
+
+/** `mediaContentRect` for a live element, reading the values off the DOM. */
+export function mediaContentRectOf(element: HTMLElement): Rect {
+  const style = getComputedStyle(element);
+
+  const natural =
+    element instanceof HTMLImageElement
+      ? { width: element.naturalWidth, height: element.naturalHeight }
+      : element instanceof HTMLVideoElement
+      ? { width: element.videoWidth, height: element.videoHeight }
+      : null;
+
+  return mediaContentRect({
+    box: { width: element.offsetWidth, height: element.offsetHeight },
+    natural,
+    fit: style.objectFit,
+    position: style.objectPosition,
+  });
+}


### PR DESCRIPTION
Reported by ECAJ in DM: a placed sticker sits somewhere else on the featured feed than it does on the full image. **His diagnosis was right** — the card crops and the overlay did not.

## The cause

A placement is a fraction of the **artwork's** bounds. Card media is `object-fit: cover`, so the `<img>` element is a box the artwork is scaled and cropped *into* — and `CardStickerOverlay` was measuring `offsetWidth`/`offsetHeight`, which describes the hole, not the picture.

Measured on the reported shape — a 1000×2000 image in a 450×600 card:

| | Artwork rect | What the overlay used |
|---|---|---|
| Height | 900px (scaled to cover 450 wide) | 600px (the card) |
| A sticker at `y = 0.5` | 450px down | 300px down |

150px out, a quarter of the card. The error grows with the crop, which is why a portrait image is where it got noticed and why nobody saw it on the post page.

## The sweep

The same overlay draws on more than one surface, so this was audited before it was fixed. **Three surfaces are affected, sharing one cause and now one fix:**

| Surface | Where the crop comes from | |
|---|---|---|
| `ImageCard` → featured feed, collection blocks, image feed | `AspectRatioImageCard.module.scss` — `object-fit: cover; object-position: top` | ❌ affected |
| `ImagesCard` → image infinite feeds | `Cards.module.css` — `cover`, `object-position: top center` | ❌ affected |
| `ArticleCoverStickers` → article cover | `object-cover` on the cover media | ❌ affected |
| `PostStickerOverlay` → post pages | nothing sets `object-fit` | ✅ not cropped today |
| `ImageStickerOverlay` → image detail | takes an already-fitted box as props | ✅ unaffected |

`PostStickerOverlay` carried its own copy of the same measurement, so it goes through the shared helper too. With no `object-fit` it resolves to the element box, so its behaviour is unchanged — but it stops being a second place that would need the same fix later.

## What changed

`mediaContentRect` — `object-fit`'s own arithmetic: scale by the larger ratio for `cover`, the smaller for `contain`, then place with `object-position`. Both overlays position to that rect instead of the element box.

**The crop is untouched, deliberately** — the ticket is explicit that the card's cropping is intended. The overlay now agrees with whatever the card does. The computed rect deliberately **overflows** the element under `cover`: that overflow is the cropped part, and the wrapper's `overflow-hidden` clips it exactly as the card clips the picture, so a sticker placed on the cropped-away part is correctly not visible on the card.

## A second bug the first one was hiding

Natural size arrives with the **file**, and no `ResizeObserver` fires for it — the box is already final while the picture inside it is still unknown. Measuring only on resize would have kept the uncropped geometry from before the image loaded, which is the same bug one frame later. Both overlays now re-measure on `load` / `loadedmetadata`.

An unloaded image (0×0) returns the element box rather than computing from it: scaling by zero gives `Infinity` and then `NaN` offsets, which reach the DOM as `NaNpx` and make the overlay **vanish** rather than merely sit wrong. Asserted directly rather than left to inference.

## Tests

12 across two files, and the fix was reverted two ways to confirm they fail:

- `cover` computed as `contain` → 4 unit tests red
- the helper ignoring natural size (i.e. the old behaviour) → the browser test red

The unit tests assert the geometry, and the headline one asserts it **as a claim about a sticker** rather than about a rectangle: a placement in the middle of the artwork must not land in the middle of the card. The browser test covers what arithmetic cannot — real natural size off a decoded image, and `object-fit`/`object-position` as Chromium resolves them (`top` → `50% 0%`).

`ImageCard.browser.test.tsx` and `PostStickerOverlay.browser.test.tsx` still pass unchanged.

## Not chased, on the reporter's own note

The green tip buttons in ECAJ's screenshots are a userscript of his, not our UI. He volunteered that so nobody went looking.

ClickUp: [868kuqxjb](https://app.clickup.com/t/868kuqxjb)
