### PR TITLE
fix(blocks): a hide can no longer destroy a block, and the follow/hide toggles report what they did

### DIFF
--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -881,6 +881,10 @@ export const getUserHiddenListHandler = async ({ ctx }: { ctx: ProtectedContext 
   }
 };
 
+// Registered on no router: every hide in the product goes through
+// `toggleHidden({ kind: 'user' })`. Kept and fixed rather than deleted, but the
+// second writer on that table is a hazard in itself — 868kurrfj weighs removing
+// this and `toggleHideUser` in user.service together.
 export const toggleHideUserHandler = async ({
   input,
   ctx,

--- a/src/server/services/__tests__/toggle-hide-user.service.test.ts
+++ b/src/server/services/__tests__/toggle-hide-user.service.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
+import { UserEngagementType } from '~/shared/utils/prisma/enums';
 import { HiddenUsers, toggleHidden } from '~/server/services/user-preferences.service';
+import { userFollowsCache } from '~/server/redis/caches';
 import { toggleFollowUser, toggleHideUser } from '~/server/services/user.service';
+import { clearUserEngagement, setUserEngagement } from '~/server/services/user-engagement';
 
 const { Prisma } = await import('@prisma/client');
 
@@ -22,6 +25,23 @@ const engagement = dbMock.dbWrite.userEngagement;
 // about which `type` survives a write aimed at a different one.
 const scoped = { userId, targetUserId };
 
+// Every pass fails: nothing claimable to update, and the insert always conflicts.
+// The fake must TERMINATE on its own — an unbounded-loop mutant driven by a
+// persistent `mockResolvedValue` is a pure MICROTASK spin, measured at 4.24M
+// iterations in 4s with a queued 300ms setTimeout that never ran. vitest's
+// testTimeout is setTimeout-based, so that mutant does not fail, it kills the
+// worker with `Worker exited unexpectedly` and no test named. Throwing after ten
+// passes turns it into a named failure in under a second.
+const everyPassFails = () => {
+  const state = { passes: 0 };
+  engagement.updateMany.mockImplementation(async () => {
+    if (++state.passes > 10) throw new Error(`setUserEngagement did not stop: ${state.passes}`);
+    return { count: 0 };
+  });
+  engagement.create.mockRejectedValue(p2002());
+  return state;
+};
+
 const hide = (hidden?: boolean) =>
   toggleHidden({ kind: 'user', data: [{ id: targetUserId }], hidden, userId });
 
@@ -32,10 +52,19 @@ beforeEach(() => {
   // drain a queued once-implementation, so a test that threw early would leak its
   // fixture into the next one.
   engagement.findUnique.mockResolvedValue(null);
-  engagement.create.mockResolvedValue({});
+  // `toggleFollowUser`'s create selects `user.username` for the follow
+  // notification, so a bare `{}` throws on the success path rather than failing an
+  // assertion — a fixture gap that reads as a code bug.
+  engagement.create.mockResolvedValue({ user: { username: 'target' } });
   engagement.deleteMany.mockResolvedValue({ count: 0 });
   // A row matched by default, so a test that means "nothing matched" has to say so.
   engagement.updateMany.mockResolvedValue({ count: 1 });
+});
+
+// The LAST spy created in a file has no following `beforeEach` to restore it, so
+// the `beforeEach` above is order-dependent on its own. This makes it not.
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 // 868kunqg5. `UserEngagement` is one row per (user, target) carrying one type, so a
@@ -113,8 +142,7 @@ describe('toggleHidden kind=user — a Block outranks a Hide', () => {
 
   it('survives the create losing to the Block row', async () => {
     engagement.findUnique.mockResolvedValue({ type: 'Block' });
-    engagement.updateMany.mockResolvedValue({ count: 0 });
-    engagement.create.mockRejectedValue(p2002());
+    everyPassFails();
 
     // Nothing matched the update and the insert conflicts with the block — the
     // intended end state either way, so the toggle must not 500 on a safety
@@ -260,8 +288,7 @@ describe('toggleHideUser (user.service) — reports what it did', () => {
   });
 
   it('survives the create losing to a Block that arrived in between', async () => {
-    engagement.updateMany.mockResolvedValue({ count: 0 });
-    engagement.create.mockRejectedValue(p2002());
+    everyPassFails();
 
     await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(true);
   });
@@ -319,13 +346,25 @@ describe('toggleFollowUser — scoped writes', () => {
   // exists". Once every writer is scoped it means only "something holds the PK",
   // and `toggleFollowUserHandler` pays a Buzz reward and fires a notification on
   // the strength of the return value.
-  it('reports NO follow when a Block won the insert race', async () => {
+  // Only a Follow is a follow. `winner?.type !== 'Block'` reads as equivalent and
+  // is not: it pays the reward for a Hide the user's own toggle established in the
+  // race, and for a pair that was cleared between the conflict and the re-read.
+  it.each([
+    ['Block', false],
+    ['Hide', false],
+    [null, false],
+    ['Follow', true],
+  ] as const)('reports the pair honestly when %s won the insert race', async (type, expected) => {
     engagement.create.mockRejectedValue(p2002());
     engagement.findUnique
       .mockResolvedValueOnce(null) // the read that chose the create path
-      .mockResolvedValueOnce({ type: 'Block' }); // what actually holds the pair
+      .mockResolvedValueOnce(type === null ? null : { type }); // what actually holds it
 
-    await expect(toggleFollowUser({ userId, targetUserId })).resolves.toBe(false);
+    await expect(toggleFollowUser({ userId, targetUserId })).resolves.toBe(expected);
+
+    // Pins the re-read itself, so a mutant that skips it fails in the test that
+    // owns it rather than leaking its queued fixture into the next one.
+    expect(engagement.findUnique).toHaveBeenCalledTimes(2);
   });
 
   it('still reports a follow when the toggle merely raced ITSELF', async () => {
@@ -377,15 +416,105 @@ describe('setUserEngagement — the second pass, and its ceiling', () => {
   });
 
   it('gives up after the second pass rather than spinning', async () => {
-    engagement.updateMany.mockResolvedValue({ count: 0 });
-    engagement.create.mockRejectedValue(p2002());
+    // The fake TERMINATES on its own. Against a standing Block an unbounded loop
+    // here is a pure microtask loop — measured at 4.24M iterations in 4s with a
+    // queued 300ms setTimeout that never ran — and vitest's testTimeout is
+    // setTimeout-based, so the run would hang until CI killed it with no
+    // assertion to read. A fake that throws turns that into a named failure in
+    // under a second; `toBe(2)` still pins the ceiling from below.
+    const state = everyPassFails();
 
     await hide(true);
 
-    // A `while` here would loop forever against a standing Block — and a pure
-    // microtask loop starves the macrotask queue, so vitest's setTimeout-based
-    // testTimeout never fires and the run hangs with nothing to read.
-    expect(engagement.updateMany).toHaveBeenCalledTimes(2);
+    expect(state.passes).toBe(2);
     expect(engagement.create).toHaveBeenCalledTimes(2);
+  });
+});
+
+// The precedence order lives in exactly one place, so this is where it is pinned.
+// It used to be an optional `outrankedBy` argument, which defaults to NO guard —
+// omitting it at one call site silently reproduces 868kun67j.
+describe('setUserEngagement — the guard is derived from the type, not passed in', () => {
+  it.each([
+    [
+      UserEngagementType.Follow,
+      { type: { notIn: [UserEngagementType.Hide, UserEngagementType.Block] } },
+    ],
+    [UserEngagementType.Hide, { type: { notIn: [UserEngagementType.Block] } }],
+    // Nothing outranks a Block, so its update carries no type filter at all.
+    [UserEngagementType.Block, {}],
+  ])('claims a pair for %s only against what it outranks', async (type, guard) => {
+    await setUserEngagement({ userId, targetUserId, type });
+
+    expect(engagement.updateMany).toHaveBeenCalledWith({
+      where: { ...scoped, ...guard },
+      data: { type },
+    });
+  });
+});
+
+// Both helpers advertise a boolean, and nothing in the repo reads it today — which
+// is correct for a hide, since the only way `setUserEngagement` returns false is a
+// standing Block and a blocked target is hidden. Pinned anyway: this module is the
+// one place every future writer is meant to go through, so its contract should
+// break loudly rather than drift.
+describe('user-engagement helpers — the returned contract', () => {
+  it('reports the claim when the scoped update matched', async () => {
+    await expect(
+      setUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide })
+    ).resolves.toBe(true);
+  });
+
+  it('reports the claim when the row had to be created', async () => {
+    engagement.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      setUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide })
+    ).resolves.toBe(true);
+  });
+
+  it('reports NO claim when something outranking holds the pair', async () => {
+    everyPassFails();
+
+    await expect(
+      setUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide })
+    ).resolves.toBe(false);
+  });
+
+  it('reports whether a row was actually removed', async () => {
+    engagement.deleteMany.mockResolvedValue({ count: 1 });
+    await expect(
+      clearUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide })
+    ).resolves.toBe(true);
+
+    engagement.deleteMany.mockResolvedValue({ count: 0 });
+    await expect(
+      clearUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide })
+    ).resolves.toBe(false);
+  });
+});
+
+// Same class as the HiddenUsers pair above, opposite cache: delete any of these
+// refreshes and the user's own follow set stays stale until the hash TTL.
+describe('cache invalidation on the follow set', () => {
+  it.each([
+    ['Follow', 'unfollowing'],
+    ['Hide', 'following someone hidden'],
+    [null, 'following from nothing'],
+  ] as const)('refreshes userFollowsCache when %s (%s)', async (type) => {
+    engagement.findUnique.mockResolvedValue(type === null ? null : { type });
+    const follows = vi.spyOn(userFollowsCache, 'refresh').mockResolvedValue(undefined);
+
+    await toggleFollowUser({ userId, targetUserId });
+
+    expect(follows).toHaveBeenCalledWith(userId);
+  });
+
+  it('refreshes it on a hide too', async () => {
+    const follows = vi.spyOn(userFollowsCache, 'refresh').mockResolvedValue(undefined);
+
+    await toggleHideUser({ userId, targetUserId });
+
+    expect(follows).toHaveBeenCalledWith(userId);
   });
 });

--- a/src/server/services/__tests__/toggle-hide-user.service.test.ts
+++ b/src/server/services/__tests__/toggle-hide-user.service.test.ts
@@ -517,4 +517,15 @@ describe('cache invalidation on the follow set', () => {
 
     expect(follows).toHaveBeenCalledWith(userId);
   });
+
+  // The live path — `toggleHidden({ kind: 'user' })` is the one 868kun67j is
+  // about, and its own follow-set refresh was the last call site in the diff's
+  // blast radius that nothing asserted.
+  it.each([true, false])('refreshes it on the toggleHidden path (hidden=%s)', async (hidden) => {
+    const follows = vi.spyOn(userFollowsCache, 'refresh').mockResolvedValue(undefined);
+
+    await hide(hidden);
+
+    expect(follows).toHaveBeenCalledWith(userId);
+  });
 });

--- a/src/server/services/__tests__/toggle-hide-user.service.test.ts
+++ b/src/server/services/__tests__/toggle-hide-user.service.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { toggleHidden } from '~/server/services/user-preferences.service';
+import { toggleFollowUser, toggleHideUser } from '~/server/services/user.service';
+
+const { Prisma } = await import('@prisma/client');
+
+// The real class, because `isPrismaUniqueViolation` is an `instanceof` check — a
+// duck-typed `{ code: 'P2002' }` is rethrown, and a test using one would report the
+// catch as broken when it works.
+const p2002 = () =>
+  new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+    code: 'P2002',
+    clientVersion: 'test',
+  });
+
+const userId = 42;
+const targetUserId = 99;
+const engagement = dbMock.dbWrite.userEngagement;
+
+// The one row this table allows for the pair. Every assertion below is really
+// about which `type` survives a write aimed at a different one.
+const scoped = { userId, targetUserId };
+
+const hide = (hidden?: boolean) =>
+  toggleHidden({ kind: 'user', data: [{ id: targetUserId }], hidden, userId });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+  // `mockResolvedValue`, not `...Once` — `clearAllMocks` is `mockClear` and does not
+  // drain a queued once-implementation, so a test that threw early would leak its
+  // fixture into the next one.
+  engagement.findUnique.mockResolvedValue(null);
+  engagement.create.mockResolvedValue({});
+  engagement.deleteMany.mockResolvedValue({ count: 0 });
+  // A row matched by default, so a test that means "nothing matched" has to say so.
+  engagement.updateMany.mockResolvedValue({ count: 1 });
+});
+
+// 868kunqg5. `UserEngagement` is one row per (user, target) carrying one type, so a
+// write addressed by the PK alone lands on whatever type occupies it — including a
+// Block applied a millisecond earlier, which is then gone with a success reported.
+// These assert the shape rather than any one interleaving: a test cannot schedule the
+// race, but it can prove no writer is capable of it.
+describe('UserEngagement writers are all scoped by type', () => {
+  const unqualified = () => [...engagement.delete.mock.calls, ...engagement.update.mock.calls];
+
+  it('toggleHidden kind=user never issues a PK-addressed delete or update', async () => {
+    for (const [type, hidden] of [
+      ['Block', true],
+      ['Block', false],
+      ['Follow', true],
+      ['Follow', false],
+      ['Hide', undefined],
+    ] as const) {
+      vi.clearAllMocks();
+      engagement.findUnique.mockResolvedValue({ type });
+
+      await hide(hidden);
+
+      expect(unqualified()).toEqual([]);
+    }
+  });
+
+  it('toggleHideUser and toggleFollowUser never issue one either', async () => {
+    for (const type of ['Block', 'Follow', 'Hide'] as const) {
+      vi.clearAllMocks();
+      engagement.findUnique.mockResolvedValue({ type });
+
+      await toggleHideUser({ userId, targetUserId });
+      await toggleFollowUser({ userId, targetUserId });
+
+      expect(unqualified()).toEqual([]);
+    }
+  });
+});
+
+// 868kun67j. The unconditional `else` here updated the row to `Hide` whatever it
+// held, so hiding someone you had blocked overwrote the block — no race needed, from
+// the ordinary product UI, with nothing shown to the user.
+describe('toggleHidden kind=user — a Block outranks a Hide', () => {
+  it('hiding a BLOCKED user leaves the block standing', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Block' });
+    engagement.updateMany.mockResolvedValue({ count: 0 });
+
+    await hide(true);
+
+    // The `type` filter is the protection, so assert the filter itself: an
+    // unscoped updateMany passes a bare "was it called" check and still eats the
+    // block.
+    expect(engagement.updateMany).toHaveBeenCalledWith({
+      where: { ...scoped, type: { not: 'Block' } },
+      data: { type: 'Hide' },
+    });
+    expect(engagement.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('survives the create losing to the Block row', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Block' });
+    engagement.updateMany.mockResolvedValue({ count: 0 });
+    engagement.create.mockRejectedValue(p2002());
+
+    // Nothing matched the update and the insert conflicts with the block — the
+    // intended end state either way, so the toggle must not 500 on a safety
+    // control.
+    await expect(hide(true)).resolves.toEqual({ added: [], removed: [] });
+  });
+
+  it('still surfaces a create failure that is not the conflict', async () => {
+    engagement.updateMany.mockResolvedValue({ count: 0 });
+    engagement.create.mockRejectedValue(new Error('connection terminated'));
+
+    // Control for the test above: a bare `catch (() => {})` would pass that one
+    // and swallow every real write failure with it.
+    await expect(hide(true)).rejects.toThrow('connection terminated');
+  });
+
+  it('un-hiding a BLOCKED user does not lift the block', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Block' });
+
+    await hide(false);
+
+    expect(engagement.deleteMany).toHaveBeenCalledWith({ where: { ...scoped, type: 'Hide' } });
+    expect(engagement.create).not.toHaveBeenCalled();
+  });
+
+  it('un-hiding a FOLLOWED user does not drop the follow', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Follow' });
+
+    await hide(false);
+
+    expect(engagement.deleteMany).toHaveBeenCalledWith({ where: { ...scoped, type: 'Hide' } });
+  });
+});
+
+// The second half of 868kun67j: asked to UN-hide a pair with no row at all, the old
+// branch fell through to the `else` and created a `Hide` — the same dropped-intent
+// shape as the block bug, with `setTo` available and unread.
+describe('toggleHidden kind=user — honours the caller intent', () => {
+  it('hidden=false with no engagement never creates one', async () => {
+    await hide(false);
+
+    expect(engagement.create).not.toHaveBeenCalled();
+    expect(engagement.updateMany).not.toHaveBeenCalled();
+    // Assert the un-hide still took its own path, so deleting the branch outright
+    // cannot pass on the negative alone.
+    expect(engagement.deleteMany).toHaveBeenCalledWith({ where: { ...scoped, type: 'Hide' } });
+  });
+
+  it('hidden=true with no engagement creates the Hide', async () => {
+    engagement.updateMany.mockResolvedValue({ count: 0 });
+
+    await hide(true);
+
+    expect(engagement.create).toHaveBeenCalledWith({
+      data: { userId, targetUserId, type: 'Hide' },
+    });
+  });
+
+  it('hidden=true on an ALREADY hidden user is a no-op that keeps the row', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Hide' });
+
+    await hide(true);
+
+    expect(engagement.deleteMany).not.toHaveBeenCalled();
+    expect(engagement.updateMany).toHaveBeenCalledWith({
+      where: { ...scoped, type: { not: 'Block' } },
+      data: { type: 'Hide' },
+    });
+  });
+
+  it('hidden omitted still flips a Hide off, so intent-less callers are unchanged', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Hide' });
+
+    await hide(undefined);
+
+    expect(engagement.deleteMany).toHaveBeenCalledWith({ where: { ...scoped, type: 'Hide' } });
+    expect(engagement.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('hidden omitted with no engagement hides — the fallback must work both ways', async () => {
+    engagement.updateMany.mockResolvedValue({ count: 0 });
+
+    await hide(undefined);
+
+    // Without this the suite cannot tell `setTo ?? !alreadyHidden` from
+    // `setTo === true`: every other omitted-intent case starts from a Hide row,
+    // where both forms agree — and that mutant makes the `findUnique` read dead.
+    expect(engagement.create).toHaveBeenCalledWith({
+      data: { userId, targetUserId, type: 'Hide' },
+    });
+  });
+});
+
+// 868kumcfc. The OTHER `toggleHideUser` — same name, different file, opposite
+// failure: over a Block it matched no branch, wrote nothing, and returned falsy, so
+// the caller logged the hide as a removal.
+describe('toggleHideUser (user.service) — reports what it did', () => {
+  it('reports a blocked user as hidden without touching the row', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Block' });
+
+    await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(true);
+
+    expect(engagement.updateMany).not.toHaveBeenCalled();
+    expect(engagement.deleteMany).not.toHaveBeenCalled();
+    expect(engagement.create).not.toHaveBeenCalled();
+  });
+
+  it('hiding a followed user reports HIDDEN, not removed', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Follow' });
+
+    // The old branch converted the row and returned false, so the tracking event
+    // recorded a `Delete` for a write that established a Hide.
+    await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(true);
+
+    expect(engagement.updateMany).toHaveBeenCalledWith({
+      where: { ...scoped, type: { not: 'Block' } },
+      data: { type: 'Hide' },
+    });
+  });
+
+  it('un-hiding removes a Hide and only a Hide', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Hide' });
+
+    await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(false);
+
+    expect(engagement.deleteMany).toHaveBeenCalledWith({ where: { ...scoped, type: 'Hide' } });
+  });
+});
+
+describe('toggleFollowUser — scoped writes', () => {
+  it('unfollowing deletes the Follow row, not whatever occupies the pair', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Follow' });
+
+    await expect(toggleFollowUser({ userId, targetUserId })).resolves.toBe(false);
+
+    expect(engagement.deleteMany).toHaveBeenCalledWith({ where: { ...scoped, type: 'Follow' } });
+  });
+
+  it('following over a Hide converts that Hide and nothing else', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Hide' });
+
+    await expect(toggleFollowUser({ userId, targetUserId })).resolves.toBe(true);
+
+    expect(engagement.updateMany).toHaveBeenCalledWith({
+      where: { ...scoped, type: 'Hide' },
+      data: { type: 'Follow' },
+    });
+  });
+
+  it('reports NO follow when the Hide it read is gone', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Hide' });
+    engagement.updateMany.mockResolvedValue({ count: 0 });
+
+    // Zero rows means a Block took the pair in between. Returning true here is what
+    // pays a follow reward and fires a notification for a follow that does not exist.
+    await expect(toggleFollowUser({ userId, targetUserId })).resolves.toBe(false);
+  });
+
+  it('leaves a blocked pair alone entirely', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Block' });
+
+    await expect(toggleFollowUser({ userId, targetUserId })).resolves.toBe(false);
+
+    expect(engagement.updateMany).not.toHaveBeenCalled();
+    expect(engagement.deleteMany).not.toHaveBeenCalled();
+    expect(engagement.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/toggle-hide-user.service.test.ts
+++ b/src/server/services/__tests__/toggle-hide-user.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
-import { toggleHidden } from '~/server/services/user-preferences.service';
+import { HiddenUsers, toggleHidden } from '~/server/services/user-preferences.service';
 import { toggleFollowUser, toggleHideUser } from '~/server/services/user.service';
 
 const { Prisma } = await import('@prisma/client');
@@ -46,34 +46,49 @@ beforeEach(() => {
 describe('UserEngagement writers are all scoped by type', () => {
   const unqualified = () => [...engagement.delete.mock.calls, ...engagement.update.mock.calls];
 
-  it('toggleHidden kind=user never issues a PK-addressed delete or update', async () => {
-    for (const [type, hidden] of [
-      ['Block', true],
-      ['Block', false],
-      ['Follow', true],
-      ['Follow', false],
-      ['Hide', undefined],
-    ] as const) {
-      vi.clearAllMocks();
+  // `it.each` rather than a loop inside one `it`: a loop aborts on the first bad
+  // row and leaves the rest of the matrix unmeasured, and its failure names no
+  // fixture — you get an argument dump and have to work out which case produced it.
+  it.each([
+    ['Block', true],
+    ['Block', false],
+    ['Follow', true],
+    ['Follow', false],
+    ['Hide', true],
+    ['Hide', false],
+    ['Hide', undefined],
+  ] as const)(
+    'toggleHidden kind=user issues no PK-addressed write over a %s row (hidden=%s)',
+    async (type, hidden) => {
       engagement.findUnique.mockResolvedValue({ type });
 
       await hide(hidden);
 
       expect(unqualified()).toEqual([]);
     }
-  });
+  );
 
-  it('toggleHideUser and toggleFollowUser never issue one either', async () => {
-    for (const type of ['Block', 'Follow', 'Hide'] as const) {
-      vi.clearAllMocks();
+  it.each(['Block', 'Follow', 'Hide'] as const)(
+    'toggleHideUser issues no PK-addressed write over a %s row',
+    async (type) => {
       engagement.findUnique.mockResolvedValue({ type });
 
       await toggleHideUser({ userId, targetUserId });
+
+      expect(unqualified()).toEqual([]);
+    }
+  );
+
+  it.each(['Block', 'Follow', 'Hide'] as const)(
+    'toggleFollowUser issues no PK-addressed write over a %s row',
+    async (type) => {
+      engagement.findUnique.mockResolvedValue({ type });
+
       await toggleFollowUser({ userId, targetUserId });
 
       expect(unqualified()).toEqual([]);
     }
-  });
+  );
 });
 
 // 868kun67j. The unconditional `else` here updated the row to `Hide` whatever it
@@ -90,7 +105,7 @@ describe('toggleHidden kind=user — a Block outranks a Hide', () => {
     // unscoped updateMany passes a bare "was it called" check and still eats the
     // block.
     expect(engagement.updateMany).toHaveBeenCalledWith({
-      where: { ...scoped, type: { not: 'Block' } },
+      where: { ...scoped, type: { notIn: ['Block'] } },
       data: { type: 'Hide' },
     });
     expect(engagement.deleteMany).not.toHaveBeenCalled();
@@ -165,9 +180,12 @@ describe('toggleHidden kind=user — honours the caller intent', () => {
 
     expect(engagement.deleteMany).not.toHaveBeenCalled();
     expect(engagement.updateMany).toHaveBeenCalledWith({
-      where: { ...scoped, type: { not: 'Block' } },
+      where: { ...scoped, type: { notIn: ['Block'] } },
       data: { type: 'Hide' },
     });
+    // Paired with the positive above, so this is not a free-pass negative: making
+    // the create unconditional would insert over a row the update just matched.
+    expect(engagement.create).not.toHaveBeenCalled();
   });
 
   it('hidden omitted still flips a Hide off, so intent-less callers are unchanged', async () => {
@@ -215,7 +233,7 @@ describe('toggleHideUser (user.service) — reports what it did', () => {
     await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(true);
 
     expect(engagement.updateMany).toHaveBeenCalledWith({
-      where: { ...scoped, type: { not: 'Block' } },
+      where: { ...scoped, type: { notIn: ['Block'] } },
       data: { type: 'Hide' },
     });
   });
@@ -226,6 +244,35 @@ describe('toggleHideUser (user.service) — reports what it did', () => {
     await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(false);
 
     expect(engagement.deleteMany).toHaveBeenCalledWith({ where: { ...scoped, type: 'Hide' } });
+  });
+
+  // The dominant real path — hiding someone you have no engagement with — and the
+  // one every other test in this describe routes past, because they all supply a
+  // row and leave `updateMany` matching it.
+  it('hiding a user with no engagement creates the row', async () => {
+    engagement.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(true);
+
+    expect(engagement.create).toHaveBeenCalledWith({
+      data: { type: 'Hide', targetUserId, userId },
+    });
+  });
+
+  it('survives the create losing to a Block that arrived in between', async () => {
+    engagement.updateMany.mockResolvedValue({ count: 0 });
+    engagement.create.mockRejectedValue(p2002());
+
+    await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(true);
+  });
+
+  it('still surfaces a create failure that is not the conflict', async () => {
+    engagement.updateMany.mockResolvedValue({ count: 0 });
+    engagement.create.mockRejectedValue(new Error('connection terminated'));
+
+    // Control for the test above: `catch(() => {})` passes that one and swallows
+    // every real write failure with it, reporting a hide that never happened.
+    await expect(toggleHideUser({ userId, targetUserId })).rejects.toThrow('connection terminated');
   });
 });
 
@@ -266,5 +313,79 @@ describe('toggleFollowUser — scoped writes', () => {
     expect(engagement.updateMany).not.toHaveBeenCalled();
     expect(engagement.deleteMany).not.toHaveBeenCalled();
     expect(engagement.create).not.toHaveBeenCalled();
+  });
+
+  // The create path's P2002 used to mean "the toggle raced itself, the follow
+  // exists". Once every writer is scoped it means only "something holds the PK",
+  // and `toggleFollowUserHandler` pays a Buzz reward and fires a notification on
+  // the strength of the return value.
+  it('reports NO follow when a Block won the insert race', async () => {
+    engagement.create.mockRejectedValue(p2002());
+    engagement.findUnique
+      .mockResolvedValueOnce(null) // the read that chose the create path
+      .mockResolvedValueOnce({ type: 'Block' }); // what actually holds the pair
+
+    await expect(toggleFollowUser({ userId, targetUserId })).resolves.toBe(false);
+  });
+
+  it('still reports a follow when the toggle merely raced ITSELF', async () => {
+    engagement.create.mockRejectedValue(p2002());
+    engagement.findUnique.mockResolvedValueOnce(null).mockResolvedValueOnce({ type: 'Follow' });
+
+    // Control for the test above: returning a blanket `false` on P2002 would make
+    // a duplicate follow report failure, and the button flip back.
+    await expect(toggleFollowUser({ userId, targetUserId })).resolves.toBe(true);
+  });
+});
+
+// `HiddenUsers` is keyed on `type = 'Hide'` and its TTL is set NX on first
+// population, so a write that changes the Hide set without refreshing it stays
+// invisible until the whole per-user hash ages out.
+describe('cache invalidation on the Hide set', () => {
+  it('refreshes HiddenUsers when a follow converts a Hide away', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Hide' });
+    const hidden = vi.spyOn(HiddenUsers, 'refreshCache').mockResolvedValue(undefined);
+
+    await toggleFollowUser({ userId, targetUserId });
+
+    // Without this the user follows someone who stays filtered out of their feed.
+    expect(hidden).toHaveBeenCalledWith({ userId });
+  });
+
+  it('refreshes HiddenUsers when toggleHideUser writes the Hide', async () => {
+    const hidden = vi.spyOn(HiddenUsers, 'refreshCache').mockResolvedValue(undefined);
+
+    await toggleHideUser({ userId, targetUserId });
+
+    expect(hidden).toHaveBeenCalledWith({ userId });
+  });
+});
+
+// The write sequence is two passes, never more. Pass two exists for one schedule:
+// the pair was empty at the update, a CLAIMABLE row was inserted before ours, so
+// the update matched nothing and the create hit the PK. Stopping after one pass
+// drops the write while reporting it applied.
+describe('setUserEngagement — the second pass, and its ceiling', () => {
+  it('retries the scoped update when a claimable row won the insert race', async () => {
+    engagement.updateMany.mockResolvedValueOnce({ count: 0 }).mockResolvedValueOnce({ count: 1 });
+    engagement.create.mockRejectedValueOnce(p2002());
+
+    await hide(true);
+
+    expect(engagement.updateMany).toHaveBeenCalledTimes(2);
+    expect(engagement.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after the second pass rather than spinning', async () => {
+    engagement.updateMany.mockResolvedValue({ count: 0 });
+    engagement.create.mockRejectedValue(p2002());
+
+    await hide(true);
+
+    // A `while` here would loop forever against a standing Block — and a pure
+    // microtask loop starves the macrotask queue, so vitest's setTimeout-based
+    // testTimeout never fires and the run hangs with nothing to read.
+    expect(engagement.updateMany).toHaveBeenCalledTimes(2);
+    expect(engagement.create).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/server/services/user-engagement.ts
+++ b/src/server/services/user-engagement.ts
@@ -1,0 +1,74 @@
+import { dbWrite } from '~/server/db/client';
+import { isPrismaUniqueViolation } from '~/server/utils/errorHandling';
+import type { UserEngagementType } from '~/shared/utils/prisma/enums';
+
+/**
+ * `UserEngagement` holds ONE row per (userId, targetUserId) pair carrying ONE
+ * `type`, so Follow / Hide / Block are mutually exclusive by construction and the
+ * pair has a precedence order: Block outranks Hide outranks Follow.
+ *
+ * Every writer of that table goes through these two functions. Addressing the row
+ * by its primary key alone — `update`/`delete` on `userId_targetUserId` — is what
+ * let an ordinary hide overwrite a block, so neither of these can express that.
+ */
+
+/** Put `type` on the pair unless a type in `outrankedBy` holds it. */
+export async function setUserEngagement({
+  userId,
+  targetUserId,
+  type,
+  outrankedBy = [],
+}: {
+  userId: number;
+  targetUserId: number;
+  type: UserEngagementType;
+  outrankedBy?: UserEngagementType[];
+}): Promise<boolean> {
+  const pair = { userId, targetUserId };
+  const claimable = outrankedBy.length ? { type: { notIn: outrankedBy } } : {};
+
+  // Two passes, never more, so a losing writer cannot spin. Pass one handles the
+  // ordinary cases: a claimable row is converted, an empty pair is inserted.
+  //
+  // Pass two exists for one schedule — the pair was empty at the update and a
+  // CLAIMABLE row was inserted before ours, so the update matched nothing and the
+  // create hit the PK. Returning after one pass would drop the write silently
+  // while reporting it applied. Re-running the same scoped update converts that
+  // row; if what won is outranking instead, it matches nothing again and we
+  // report the pair as not ours, which is the intended end state.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const { count } = await dbWrite.userEngagement.updateMany({
+      where: { ...pair, ...claimable },
+      data: { type },
+    });
+    if (count) return true;
+
+    const created = await dbWrite.userEngagement
+      .create({ data: { ...pair, type } })
+      .then(() => true)
+      .catch((error) => {
+        if (!isPrismaUniqueViolation(error)) throw error;
+        return false;
+      });
+    if (created) return true;
+  }
+
+  return false;
+}
+
+/** Remove `type` from the pair, and only `type`. */
+export async function clearUserEngagement({
+  userId,
+  targetUserId,
+  type,
+}: {
+  userId: number;
+  targetUserId: number;
+  type: UserEngagementType;
+}): Promise<boolean> {
+  const { count } = await dbWrite.userEngagement.deleteMany({
+    where: { userId, targetUserId, type },
+  });
+
+  return count > 0;
+}

--- a/src/server/services/user-engagement.ts
+++ b/src/server/services/user-engagement.ts
@@ -13,8 +13,9 @@ import { UserEngagementType } from '~/shared/utils/prisma/enums';
  * Three writers stay outside them, deliberately: `toggleBlockUser` keeps the
  * `upsert` that #4210 settled on for the block itself, `toggleFollowUser` converts
  * a Hide into a Follow — a deliberate downgrade rather than a claim, which has no
- * expression here — and `deleteUser` clears a pair wholesale, which is correct for
- * it. Every other writer routes through these two, and a new one should.
+ * expression here — and `deleteUser` clears a pair wholesale, which is the right
+ * shape for it even though its predicate is currently wrong (868kurkcf). Every
+ * other writer routes through these two, and a new one should.
  *
  * Do NOT call either inside an interactive `$transaction`. Prisma does not
  * savepoint per statement, so the swallowed P2002 below would poison the rest of

--- a/src/server/services/user-engagement.ts
+++ b/src/server/services/user-engagement.ts
@@ -1,31 +1,59 @@
 import { dbWrite } from '~/server/db/client';
 import { isPrismaUniqueViolation } from '~/server/utils/errorHandling';
-import type { UserEngagementType } from '~/shared/utils/prisma/enums';
+import { UserEngagementType } from '~/shared/utils/prisma/enums';
 
 /**
  * `UserEngagement` holds ONE row per (userId, targetUserId) pair carrying ONE
- * `type`, so Follow / Hide / Block are mutually exclusive by construction and the
- * pair has a precedence order: Block outranks Hide outranks Follow.
+ * `type`, so Follow / Hide / Block are mutually exclusive by construction.
  *
- * Every writer of that table goes through these two functions. Addressing the row
- * by its primary key alone — `update`/`delete` on `userId_targetUserId` — is what
- * let an ordinary hide overwrite a block, so neither of these can express that.
+ * Addressing that row by its primary key alone — `update`/`delete` on
+ * `userId_targetUserId` — is what let an ordinary hide overwrite a block, and
+ * neither function here can express it.
+ *
+ * Three writers stay outside them, deliberately: `toggleBlockUser` keeps the
+ * `upsert` that #4210 settled on for the block itself, `toggleFollowUser` converts
+ * a Hide into a Follow — a deliberate downgrade rather than a claim, which has no
+ * expression here — and `deleteUser` clears a pair wholesale, which is correct for
+ * it. Every other writer routes through these two, and a new one should.
+ *
+ * Do NOT call either inside an interactive `$transaction`. Prisma does not
+ * savepoint per statement, so the swallowed P2002 below would poison the rest of
+ * the transaction — and an INSERT conflicting with a row that transaction still
+ * holds waits on the lock instead of failing fast, which is unbounded rather than
+ * the sub-millisecond wait it is today.
  */
 
-/** Put `type` on the pair unless a type in `outrankedBy` holds it. */
+/** Weakest first. The only place the precedence order is written down. */
+const PRECEDENCE = [
+  UserEngagementType.Follow,
+  UserEngagementType.Hide,
+  UserEngagementType.Block,
+] as const;
+
+/**
+ * Put `type` on the pair unless a type that outranks it holds it — a Hide never
+ * overwrites a Block, and nothing overwrites one but a Block.
+ *
+ * Derived from `type` rather than passed in: an optional "which types outrank
+ * this one" argument defaults to no protection, so omitting it at one call site
+ * silently reproduces the write this file exists to prevent.
+ *
+ * Returns whether the pair now carries `type`.
+ */
 export async function setUserEngagement({
   userId,
   targetUserId,
   type,
-  outrankedBy = [],
 }: {
   userId: number;
   targetUserId: number;
   type: UserEngagementType;
-  outrankedBy?: UserEngagementType[];
 }): Promise<boolean> {
   const pair = { userId, targetUserId };
-  const claimable = outrankedBy.length ? { type: { notIn: outrankedBy } } : {};
+  const outranking = PRECEDENCE.slice(PRECEDENCE.indexOf(type) + 1);
+  // Nothing outranks a Block, so its update is unconditional — correct by
+  // construction here rather than by an argument someone remembered to omit.
+  const claimable = outranking.length ? { type: { notIn: outranking } } : {};
 
   // Two passes, never more, so a losing writer cannot spin. Pass one handles the
   // ordinary cases: a claimable row is converted, an empty pair is inserted.
@@ -34,8 +62,8 @@ export async function setUserEngagement({
   // CLAIMABLE row was inserted before ours, so the update matched nothing and the
   // create hit the PK. Returning after one pass would drop the write silently
   // while reporting it applied. Re-running the same scoped update converts that
-  // row; if what won is outranking instead, it matches nothing again and we
-  // report the pair as not ours, which is the intended end state.
+  // row; if what won outranks us instead, it matches nothing again and we report
+  // the pair as not ours, which is the intended end state.
   for (let attempt = 0; attempt < 2; attempt++) {
     const { count } = await dbWrite.userEngagement.updateMany({
       where: { ...pair, ...claimable },

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -716,34 +716,41 @@ async function toggleHideUser({
     where: { userId_targetUserId: { userId, targetUserId } },
     select: { type: true },
   });
-  if (!engagement)
-    await dbWrite.userEngagement
-      .create({
-        data: { userId, targetUserId, type: 'Hide' },
-      })
-      // Toggle racing itself → P2002 on the (userId, targetUserId) PK. The row
-      // already exists — idempotent, so fall through to the cache refreshes
-      // (which read DB truth) instead of bubbling a 500.
-      .catch((error) => {
-        if (!isPrismaUniqueViolation(error)) throw error;
-      });
-  else if (engagement.type === 'Hide' && setTo !== true)
-    await dbWrite.userEngagement.delete({
-      where: { userId_targetUserId: { userId, targetUserId } },
-    });
-  else
-    await dbWrite.userEngagement.update({
-      where: { userId_targetUserId: { userId, targetUserId } },
-      data: { type: 'Hide' },
-    });
+  // `setTo` carries the caller's INTENT; fall back to flipping only when none was
+  // supplied. The row this reads may be gone or a different type by the time the
+  // write lands, so every statement below is scoped by `type` rather than by the
+  // PK alone — an unqualified `update`/`delete` here would overwrite whatever
+  // Follow or Block a sibling writer had just established.
+  const hiding = setTo ?? engagement?.type !== UserEngagementType.Hide;
 
-  // const addedOrUpdated = !engagement || engagement.type !== 'Hide';
-  // const user = await dbRead.user.findUnique({
-  //   where: { id: targetUserId },
-  //   select: { id: true, username: true },
-  // });
-
-  // const toReturn = user ? ({ ...user, kind: 'user' } as HiddenPreferencesKind) : undefined;
+  if (hiding) {
+    // A Block already hides the target and is strictly stronger, so it is the one
+    // type a hide must never overwrite. Excluding it in the WHERE makes that
+    // structural instead of a branch on a stale read: if the row is (or becomes)
+    // a Block, nothing matches, the create loses to the PK, and the block stands.
+    const { count } = await dbWrite.userEngagement.updateMany({
+      where: { userId, targetUserId, type: { not: UserEngagementType.Block } },
+      data: { type: UserEngagementType.Hide },
+    });
+    if (!count)
+      await dbWrite.userEngagement
+        .create({
+          data: { userId, targetUserId, type: UserEngagementType.Hide },
+        })
+        // No row to update: either there is none (create it) or it is a Block
+        // (P2002, and the block is what we wanted to keep). Both are the intended
+        // end state, so fall through to the cache refreshes, which read DB truth.
+        .catch((error) => {
+          if (!isPrismaUniqueViolation(error)) throw error;
+        });
+  } else {
+    // Un-hiding removes a Hide and only a Hide. Unqualified, this deleted the
+    // Follow or Block that happened to occupy the pair; unfiltered on intent, it
+    // also created a Hide row when asked to un-hide a pair that had none.
+    await dbWrite.userEngagement.deleteMany({
+      where: { userId, targetUserId, type: UserEngagementType.Hide },
+    });
+  }
 
   await userFollowsCache.refresh(userId);
   await HiddenUsers.refreshCache({ userId });

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -11,6 +11,7 @@ import { isPrismaUniqueViolation } from '~/server/utils/errorHandling';
 import { boundExcludedUserIds } from '~/server/utils/excluded-user-ids';
 import { withSpan } from '~/server/utils/otel-helpers';
 import { logToAxiom } from '~/server/logging/client';
+import { clearUserEngagement, setUserEngagement } from '~/server/services/user-engagement';
 import { TagEngagementType, UserEngagementType } from '~/shared/utils/prisma/enums';
 
 const HIDDEN_CACHE_EXPIRY_BASE = 60 * 60 * 4; // 4 hours
@@ -723,34 +724,18 @@ async function toggleHideUser({
   // Follow or Block a sibling writer had just established.
   const hiding = setTo ?? engagement?.type !== UserEngagementType.Hide;
 
-  if (hiding) {
-    // A Block already hides the target and is strictly stronger, so it is the one
-    // type a hide must never overwrite. Excluding it in the WHERE makes that
-    // structural instead of a branch on a stale read: if the row is (or becomes)
-    // a Block, nothing matches, the create loses to the PK, and the block stands.
-    const { count } = await dbWrite.userEngagement.updateMany({
-      where: { userId, targetUserId, type: { not: UserEngagementType.Block } },
-      data: { type: UserEngagementType.Hide },
+  // A Block already hides the target and is strictly stronger, so it is the one
+  // type a hide must never overwrite. Un-hiding removes a Hide and only a Hide:
+  // unqualified, it deleted whatever Follow or Block held the pair, and unfiltered
+  // on intent it created a Hide row when asked to un-hide a pair that had none.
+  if (hiding)
+    await setUserEngagement({
+      userId,
+      targetUserId,
+      type: UserEngagementType.Hide,
+      outrankedBy: [UserEngagementType.Block],
     });
-    if (!count)
-      await dbWrite.userEngagement
-        .create({
-          data: { userId, targetUserId, type: UserEngagementType.Hide },
-        })
-        // No row to update: either there is none (create it) or it is a Block
-        // (P2002, and the block is what we wanted to keep). Both are the intended
-        // end state, so fall through to the cache refreshes, which read DB truth.
-        .catch((error) => {
-          if (!isPrismaUniqueViolation(error)) throw error;
-        });
-  } else {
-    // Un-hiding removes a Hide and only a Hide. Unqualified, this deleted the
-    // Follow or Block that happened to occupy the pair; unfiltered on intent, it
-    // also created a Hide row when asked to un-hide a pair that had none.
-    await dbWrite.userEngagement.deleteMany({
-      where: { userId, targetUserId, type: UserEngagementType.Hide },
-    });
-  }
+  else await clearUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide });
 
   await userFollowsCache.refresh(userId);
   await HiddenUsers.refreshCache({ userId });

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -728,13 +728,7 @@ async function toggleHideUser({
   // type a hide must never overwrite. Un-hiding removes a Hide and only a Hide:
   // unqualified, it deleted whatever Follow or Block held the pair, and unfiltered
   // on intent it created a Hide row when asked to un-hide a pair that had none.
-  if (hiding)
-    await setUserEngagement({
-      userId,
-      targetUserId,
-      type: UserEngagementType.Hide,
-      outrankedBy: [UserEngagementType.Block],
-    });
+  if (hiding) await setUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide });
   else await clearUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide });
 
   await userFollowsCache.refresh(userId);
@@ -855,10 +849,7 @@ async function toggleBlockUser({
       .catch((error) => {
         if (!isPrismaUniqueViolation(error)) throw error;
       });
-  else
-    await dbWrite.userEngagement.deleteMany({
-      where: { userId, targetUserId, type: UserEngagementType.Block },
-    });
+  else await clearUserEngagement({ userId, targetUserId, type: UserEngagementType.Block });
 
   await userFollowsCache.refresh(userId);
   await BlockedUsers.refreshCache({ userId });

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -907,20 +907,27 @@ export const toggleFollowUser = async ({
     select: { type: true },
   });
 
+  // Every write below is scoped by `type`. The row read a moment ago may already
+  // be a different type — a block applied from another tab, say — and an
+  // unqualified `delete`/`update` on the PK would take that block with it while
+  // reporting success.
   if (engagement) {
     if (engagement.type === 'Follow') {
-      await dbWrite.userEngagement.delete({
-        where: { userId_targetUserId: { userId, targetUserId } },
+      await dbWrite.userEngagement.deleteMany({
+        where: { userId, targetUserId, type: UserEngagementType.Follow },
       });
       await userFollowsCache.refresh(userId);
       return false;
     } else if (engagement.type === 'Hide') {
-      await dbWrite.userEngagement.update({
-        where: { userId_targetUserId: { userId, targetUserId } },
-        data: { type: 'Follow' },
+      const { count } = await dbWrite.userEngagement.updateMany({
+        where: { userId, targetUserId, type: UserEngagementType.Hide },
+        data: { type: UserEngagementType.Follow },
       });
       await userFollowsCache.refresh(userId);
-      return true;
+      // Zero rows means the Hide is gone — replaced by a Block, most likely — so
+      // no follow was established and saying otherwise would be a lie the caller
+      // acts on (reward, notification, tracking event).
+      return count > 0;
     }
 
     return false;
@@ -971,30 +978,39 @@ export const toggleHideUser = async ({
     select: { type: true },
   });
 
-  if (engagement) {
-    if (engagement.type === 'Hide')
-      await dbWrite.userEngagement.delete({
-        where: { userId_targetUserId: { userId, targetUserId } },
-      });
-    else if (engagement.type === 'Follow')
-      await dbWrite.userEngagement.update({
-        where: { userId_targetUserId: { userId, targetUserId } },
-        data: { type: 'Hide' },
-      });
+  // A Block already hides the target and is strictly stronger, so a hide over one
+  // leaves it alone and reports the target as hidden — which it is. Previously
+  // this matched neither branch, wrote nothing, and returned falsy, so the caller
+  // logged the hide as a removal.
+  if (engagement?.type === UserEngagementType.Block) return true;
 
-    return false;
+  const hiding = engagement?.type !== UserEngagementType.Hide;
+
+  // Scoped by `type`, never by the PK alone: the row read above may already be a
+  // Block, and an unqualified `delete`/`update` would destroy it while reporting
+  // success.
+  if (hiding) {
+    const { count } = await dbWrite.userEngagement.updateMany({
+      where: { userId, targetUserId, type: { not: UserEngagementType.Block } },
+      data: { type: UserEngagementType.Hide },
+    });
+    if (!count)
+      await dbWrite.userEngagement
+        .create({ data: { type: UserEngagementType.Hide, targetUserId, userId } })
+        // Nothing to update: either no row (create it) or a Block arrived in
+        // between (P2002, and keeping it is the intended end state). Both leave
+        // the target hidden, so fall through to the cache refresh.
+        .catch((error) => {
+          if (!isPrismaUniqueViolation(error)) throw error;
+        });
+  } else {
+    await dbWrite.userEngagement.deleteMany({
+      where: { userId, targetUserId, type: UserEngagementType.Hide },
+    });
   }
 
-  await dbWrite.userEngagement
-    .create({ data: { type: 'Hide', targetUserId, userId } })
-    .catch((error) => {
-      // Toggle racing itself: the loser hits the (userId, targetUserId) unique
-      // constraint (P2002). The engagement now exists — idempotent, so still
-      // refresh the cache + return true instead of bubbling a 500.
-      if (!isPrismaUniqueViolation(error)) throw error;
-    });
   await userFollowsCache.refresh(userId);
-  return true;
+  return hiding;
 };
 
 export const getUserList = async ({ username, type, limit, page }: GetUserListSchema) => {

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1003,13 +1003,7 @@ export const toggleHideUser = async ({
   // Scoped by `type`, never by the PK alone: the row read above may already be a
   // Block, and an unqualified `delete`/`update` would destroy it while reporting
   // success.
-  if (hiding)
-    await setUserEngagement({
-      userId,
-      targetUserId,
-      type: UserEngagementType.Hide,
-      outrankedBy: [UserEngagementType.Block],
-    });
+  if (hiding) await setUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide });
   else await clearUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide });
 
   await userFollowsCache.refresh(userId);

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -89,7 +89,9 @@ import {
   BlockedByUsers,
   BlockedUsers,
   HiddenModels,
+  HiddenUsers,
 } from '~/server/services/user-preferences.service';
+import { clearUserEngagement, setUserEngagement } from '~/server/services/user-engagement';
 import { createCachedObject, fetchThroughCache } from '~/server/utils/cache-helpers';
 import { bustRatingTotalsCache } from '~/server/services/resourceReview.cache';
 import { getResourceReviewsByUserId } from '~/server/services/resourceReview.service';
@@ -913,9 +915,7 @@ export const toggleFollowUser = async ({
   // reporting success.
   if (engagement) {
     if (engagement.type === 'Follow') {
-      await dbWrite.userEngagement.deleteMany({
-        where: { userId, targetUserId, type: UserEngagementType.Follow },
-      });
+      await clearUserEngagement({ userId, targetUserId, type: UserEngagementType.Follow });
       await userFollowsCache.refresh(userId);
       return false;
     } else if (engagement.type === 'Hide') {
@@ -924,6 +924,10 @@ export const toggleFollowUser = async ({
         data: { type: UserEngagementType.Follow },
       });
       await userFollowsCache.refresh(userId);
+      // This branch REMOVES a Hide, and `HiddenUsers` is keyed on `type = 'Hide'`.
+      // Without this the target stays hidden from the feed of the user who just
+      // followed them, until the hash TTL expires.
+      await HiddenUsers.refreshCache({ userId });
       // Zero rows means the Hide is gone — replaced by a Block, most likely — so
       // no follow was established and saying otherwise would be a lie the caller
       // acts on (reward, notification, tracking event).
@@ -939,17 +943,27 @@ export const toggleFollowUser = async ({
       select: { user: { select: { username: true } } },
     })
     .catch((error) => {
-      // Toggle racing itself: the loser hits the (userId, targetUserId) unique
-      // constraint (P2002). The follow already exists — idempotent, so return
-      // null and fall through to the cache refresh. The racing winner already
-      // created the follow-notification (deduped by `key`), so we skip it here
-      // rather than bubble a 500.
+      // Something took the (userId, targetUserId) PK between the read and the
+      // insert. Which type it is decides the answer, so read it back below rather
+      // than bubble a 500.
       if (!isPrismaUniqueViolation(error)) throw error;
       return null;
     });
   await userFollowsCache.refresh(userId);
 
-  if (ret) {
+  if (!ret) {
+    const winner = await dbWrite.userEngagement.findUnique({
+      where: { userId_targetUserId: { userId, targetUserId } },
+      select: { type: true },
+    });
+    // Usually the toggle racing itself, and the winner already sent the
+    // follow-notification (deduped by `key`) — but the row can equally be a Block,
+    // which outranks a Follow. Returning true there tells the user they follow
+    // someone they do not, and pays a follow reward for it.
+    return winner?.type === UserEngagementType.Follow;
+  }
+
+  {
     const details: NotifDetailsFollowedBy = {
       username: ret.user.username,
       userId,
@@ -989,27 +1003,17 @@ export const toggleHideUser = async ({
   // Scoped by `type`, never by the PK alone: the row read above may already be a
   // Block, and an unqualified `delete`/`update` would destroy it while reporting
   // success.
-  if (hiding) {
-    const { count } = await dbWrite.userEngagement.updateMany({
-      where: { userId, targetUserId, type: { not: UserEngagementType.Block } },
-      data: { type: UserEngagementType.Hide },
+  if (hiding)
+    await setUserEngagement({
+      userId,
+      targetUserId,
+      type: UserEngagementType.Hide,
+      outrankedBy: [UserEngagementType.Block],
     });
-    if (!count)
-      await dbWrite.userEngagement
-        .create({ data: { type: UserEngagementType.Hide, targetUserId, userId } })
-        // Nothing to update: either no row (create it) or a Block arrived in
-        // between (P2002, and keeping it is the intended end state). Both leave
-        // the target hidden, so fall through to the cache refresh.
-        .catch((error) => {
-          if (!isPrismaUniqueViolation(error)) throw error;
-        });
-  } else {
-    await dbWrite.userEngagement.deleteMany({
-      where: { userId, targetUserId, type: UserEngagementType.Hide },
-    });
-  }
+  else await clearUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide });
 
   await userFollowsCache.refresh(userId);
+  await HiddenUsers.refreshCache({ userId });
   return hiding;
 };
 


### PR DESCRIPTION
Fixes three ClickUp tickets that had to be fixed together — [868kun67j](https://app.clickup.com/t/868kun67j) (urgent), [868kunqg5](https://app.clickup.com/t/868kunqg5), [868kumcfc](https://app.clickup.com/t/868kumcfc).

## Where each ticket's fix is

| Ticket | Where to look |
|---|---|
| **868kun67j** | `user-preferences.service.ts` — `hiding = setTo ?? …` and the scoped write below it. Two lines. |
| **868kumcfc** | `user.service.ts` — the `Block` early return in `toggleHideUser`. One line. |
| **868kunqg5** | 🔍 **No hunk closes this one, by design.** Its fix is that a PK-addressed write is no longer *expressible*: `setUserEngagement` / `clearUserEngagement` cannot emit one, and two guard tests assert `engagement.delete` and `engagement.update` are never called across every starting type. The fix is an absence, so looking for the diff that closes it will not find one. |

**Size, so the diffstat is not the objection:** 701 insertions, of which **531 are the test file** — 76%. The production change is 170 lines across four files, roughly half of the new file being docblock.

## The shared root cause

`UserEngagement` holds **one row per (user, target) pair carrying one `type`**, so Follow / Hide / Block are mutually exclusive by construction, with a precedence order: **Block outranks Hide outranks Follow** (Justin's call). Four writers touched that row by the primary key alone and set the type they meant. That makes an ordinary action capable of destroying a block.

**Two functions are named `toggleHideUser`, in different files, with opposite failure modes.** That is the trap this PR exists to avoid: a fix to one reads as a fix to both.

## What each ticket was

**868kun67j (urgent)** — `toggleHideUser` in `user-preferences.service.ts`, the one `toggleHidden({ kind: 'user' })` actually reaches, ended in an unconditional `else` that updated the row to `Hide`. **Hiding someone you had blocked overwrote the block.** No race needed, from the ordinary product UI, success reported, and the blocked user silently dropped off the block list. The same branch also created a `Hide` row when asked to *un*-hide a pair that had no engagement at all.

**868kunqg5** — a sibling write could destroy a *just-applied* block: `toggleFollowUser` reads `Hide`, the block path upserts, returns success and runs the placement cascade, then the follow toggle's unqualified `update { type: 'Follow' }` lands and takes the block with it. Not fixable from inside `toggleBlockUser` — the destroying write belongs to a sibling.

**868kumcfc** — the *other* `toggleHideUser` (`user.service.ts`) matched neither branch over a Block, wrote nothing, and returned falsy, so the caller logged the hide as a `Delete`. Two more defects surfaced in the same function while fixing it: it returned falsy after converting a Follow to a Hide, and it refreshed no cache on either existing-row branch.

## The fix

Every write of that table now goes through `src/server/services/user-engagement.ts`:

- `setUserEngagement({ userId, targetUserId, type })` — put `type` on the pair unless a type that outranks it holds it. The guard is **derived** from `type` against a single `PRECEDENCE` constant, not passed in: an optional "which types outrank this one" argument defaults to no protection, so omitting it at one call site reproduces 868kun67j. An unknown type also fails closed — `indexOf` returns `-1`, every type outranks it, and the helper writes nothing rather than writing unscoped.
- `clearUserEngagement({ userId, targetUserId, type })` — remove `type`, and only `type`.

**Neither can express a PK-addressed write**, which is what made an ordinary hide capable of destroying a block. It replaces three slightly different hand-written copies of the same sequence — that divergence is the defect family, so it lives in one place now.

`setUserEngagement` is a scoped `updateMany` then a `create` that tolerates P2002, run **twice, never more**. Pass one covers the ordinary cases. Pass two covers one schedule: the pair was empty at the update, a *claimable* row was inserted before ours, so the update matched nothing and the create hit the PK — one pass would drop that write and report it applied. Against a standing Block both passes match nothing and the block stands.

Precedence, confirmed with Justin: hiding a blocked user keeps the block and reports the target as hidden (it is). Un-hiding a blocked user does not lift the block — that needs an explicit unblock.

## Review round (five lanes)

Three real findings, all in the same family, all fixed in `9761a2c`:

1. **`toggleFollowUser` reported a follow that a concurrent Block had prevented.** Its create path swallowed P2002 and returned `true`. Once every writer is scoped, P2002 no longer means "the follow already exists" — it means *something* holds the pair. `toggleFollowUserHandler` pays `firstDailyFollowReward` and emits a `Follow` tracking event on that return value, so it now reads the row back. The comment asserting the old meaning is gone — it had become false, which is worse than no comment.
2. **Converting a Hide into a Follow never refreshed `HiddenUsers`.** Its TTL is set `NX` at first population, so following someone you had hidden left them filtered out of your own feed until the whole per-user hash aged out. Same omission in `toggleHideUser`.
3. **The P2002 catch was too broad for the guarantee its comment claimed** — the conflicting row could be a Follow, not only a Block, and the hide was then silently lost. That is what pass two closes.

Perf lane found **no regression**: measured against prod, every new `where` still pins both PK columns, so the planner takes `UserEngagement_pkey` (4 buffers, 0.02–0.05 ms) with `type` as a post-index filter. Lock scope is unchanged, and hiding an already-blocked target now takes *no* row lock where the old unqualified `update` took one.

## What a revert prints

Seventeen mutations, run against `81ba005a` over a run that **collected 55 tests** in that file, each one at a time with the restore verified after it. The collected count is part of the claim: a suite that collects nothing does not report red, it reports nothing, and still exits like a pass — so "N failed" means little without the total it failed out of.

| Mutation | Result |
|---|---|
| guard dropped entirely (`claimable = {}`) | 5 failed |
| guard off by one, includes the type itself | 6 failed |
| `clearUserEngagement` ignores `type` | 6 failed |
| one pass only, no retry | 2 failed |
| ignore `setTo` (hide can only ever hide) | 4 failed |
| drop the Block early return in `user.service` | 1 failed |
| skip the create when nothing matched | 2 failed |
| swallow every create error, not just P2002 | 1 failed |
| create unconditionally | 1 failed |
| blanket `true` on the follow P2002 | 1 failed |
| drop the `HiddenUsers` refresh | 1 failed |
| drop the `toggleHidden` follow-set refresh | 2 failed |
| unbounded loop instead of two passes | 4 failed, named, in ~1s |
| unscope `toggleFollowUser`'s delete | 1 failed |
| `toggleFollowUser` reports success on zero rows | 1 failed |
| unscope the un-hide delete | 4 failed |
| drop the Block filter on the hide update | 2 failed |

Each prints a named wrong value — a call assertion missing its `type` filter, a call count, or a `true`/`false` return — never a timeout or a hang. The P2002 catch has its own control (a non-P2002 create failure must still surface), so a bare `catch {}` cannot pass. The two-pass ceiling is asserted directly, because a `while` there would be a pure microtask loop: vitest's `testTimeout` is `setTimeout`-based and would never fire.

The scoping tests assert the *shape* rather than an interleaving: a unit test cannot schedule the race, but it can prove no writer is capable of one — `engagement.delete` and `engagement.update` are never called, across every starting type, as named `it.each` cases.

## Not in this PR — filed instead

- **[868kurj0y](https://app.clickup.com/t/868kurj0y)** — the UI still offers Hide on a blocked user, which Justin said it should not. Pressing it is now harmless, but offering a control that cannot do anything is the "indefensible presentation" 868kumcfc named. Server-side only tonight.
- **[868kurkc7](https://app.clickup.com/t/868kurkc7)** — **five sibling toggles have this same bug, unfixed.** `ModelEngagement` is the worst and needs no race: a user with `Notify` on a model who hits Hide has the subscription converted, and un-hiding does not bring it back. Reported rather than folded in, per the scope I was given.
- **[868kurkcf](https://app.clickup.com/t/868kurkcf)** — `deleteUser`'s `OR: [{ userId, targetUserId }]` is one ANDed predicate, so it deletes only a self-pair row and every engagement of a deleted user survives.
- **[868kurkd0](https://app.clickup.com/t/868kurkd0)** — `userFollowsCache.refresh` refetches the user's entire follow set from the **primary** on every toggle: 19,224 buffers and ~100 ms for the 130k-follow tail user, measured. Three orders of magnitude above anything here.
- **[868kurrfj](https://app.clickup.com/t/868kurrfj)** — `toggleHideUserHandler` is registered on no router, so `toggleHideUser` in `user.service.ts` is unreachable from the product. I fixed it rather than deleting it; the reuse and intent lanes both argued for deletion, and their argument is good — fixing it makes the trap *more* attractive, since the handler now presents as correct and ready to register, and 868kumcfc is satisfied in code nobody can exercise. Which resolution is right belongs to whoever owns that ticket, not to the end of a review round, so the handler carries a comment pointing at the ticket.
- **`toggleFollowUser` still converts a Hide into a Follow**, deliberately. The levels rule governs what a *sibling or stale* write may destroy; here the same user is explicitly issuing an upward intent about the same pair. Block is a safety control and a Hide is a preference, which is exactly why an accidental downgrade of a Block is a bug and a deliberate one of a Hide is a feature.
- **A single-statement alternative exists** and would be better: `INSERT … ON CONFLICT DO UPDATE SET type = … WHERE type <> 'Block'`. Prisma's `upsert()` cannot express a conditional update branch, so it needs `$executeRaw` — which loses the enum typing and is awkward to assert on through the db mock. Worth taking if anyone touches this again.

## In this PR but not asked for

The inverse of the list above, stated once so a reviewer does not have to derive it five times. Every item traces to a lane finding on code the three tickets named:

- **The second pass** in `setUserEngagement` — fixes a schedule none of the tickets describes (empty pair, a *claimable* row inserted between the update and the create). Found by the round's own review of the code the tickets asked for.
- **Two `HiddenUsers.refreshCache` calls** — a Hide removed without invalidating the cache keyed on it. See the cost note below.
- **Three return-value corrections** — the create read-back, `count > 0`, and `winner?.type === 'Follow'`. The first exists *because* this PR's scoping changed what a P2002 means there, which is why it cannot be split out: it would ship one PR whose comment is true and another that makes it false.
- **`toggleBlockUser`'s unblock rerouted** through `clearUserEngagement` — byte-for-byte identical, and leaving it inline was the evidence that nothing held the invariant up.
- **A `$transaction` warning** on the helper — Prisma does not savepoint per statement, so a swallowed P2002 inside an interactive transaction would poison it.

**One accepted cost, stated as a decision rather than a surprise:** hiding an already-blocked user on the live path runs 4 statements and raises 2 unique violations per call, because `toggleHidden` has no early return. The only way to skip it is to branch on the row read a moment earlier — which is exactly the stale-read branching this PR removes. Vacuum debt only, at ~0.6 writes/s across 42M pairs.

**And one that turned out not to be a cost at all**, recorded because two lanes disagreed and the disagreement is worth keeping: the perf lane measured `HiddenUsers.refreshCache` as an unbounded recompute — 3.8 s and 726k buffers for the max user — and read the two new calls as putting that on the write path. The correctness lane checked the implementation and it is `redis.hDel` of one hash field: an *invalidation*, no database at all. The 3.8 s query is the repopulate, which happens on the next read. I verified it myself before writing this.

The trap is the name. `createUserCache`'s `refreshCache` invalidates; `createCachedObject`'s `refresh` — `userFollowsCache`, four call sites in this diff — genuinely refetches from `dbWrite`, which is the separate finding in [868kurkd0](https://app.clickup.com/t/868kurkd0) and is unchanged in count by this PR. Same method name on two caches, opposite semantics, and one of them is on the write path.

The correctness lane's warning is the part worth carrying forward: the *wrong* fix for the deferred cost would be recomputing at the write, because that callback reads a replica — repopulating immediately after a `dbWrite` can stamp the pre-write set into Redis until the hash TTL. Invalidation has no such hazard.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm exec eslint` on the changed files — 0 errors; the 5 `no-unused-vars` warnings in `user.service.ts` are pre-existing on `origin/main` and on unrelated lines
- `pnpm run test:unit:run` — **20284 passed**, 27 skipped, 0 failed
- `blocks.router.workflow.test.ts` collected **350 tests** (nonzero — the submodule is initialised, so the run is valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
