### PR TITLE
feat(stickers): duplicate a draft, without a second way to charge for one

### DIFF
--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -9,6 +9,7 @@ import { renderWithProviders } from '../../../test/component-setup';
 import { resolveTreatment } from '~/components/Sticker/treatments/sticker-treatments';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import type { StickerDraft } from '~/store/sticker-placement-draft.store';
+import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
 
 /**
  * What the buttons on a draft actually SEND.
@@ -385,6 +386,26 @@ describe('the flip control draws the axis it mirrors across', () => {
  * is asserted is both halves of that — the handler is called with this draft's
  * id, AND nothing reached the placement mutation.
  */
+/**
+ * Which of the two control containers rendered.
+ *
+ * Asserting the button EXISTS cannot tell the branches apart — both render an
+ * identically named control — so a test meaning to cover the pill would pass on
+ * the cluster and the uncovered branch would stay uncovered. The shape differs
+ * and is stable: in the pill, remove lives in its own container; in the buy
+ * cluster, remove is a sibling of duplicate.
+ */
+const removeIsSiblingOfDuplicate = async () => {
+  const duplicate = (await page
+    .getByRole('button', { name: 'Duplicate this sticker' })
+    .element()) as HTMLElement;
+  const remove = (await page
+    .getByRole('button', { name: 'Remove this sticker' })
+    .element()) as HTMLElement;
+
+  return duplicate.parentElement?.contains(remove) ?? false;
+};
+
 describe('the duplicate control', () => {
   /**
    * ⚠️ THE NARROW FIXTURE PUTS THE CONTROL IN THE BUY CLUSTER, NOT THE PILL.
@@ -413,6 +434,7 @@ describe('the duplicate control', () => {
           onGesture={() => true}
           onDuplicate={(id) => {
             duplicated.push(id);
+            return 'copy-of-the-draft';
           }}
         />
       </div>
@@ -423,6 +445,9 @@ describe('the duplicate control', () => {
     ((await locator.element()) as HTMLElement).click();
 
     expect(duplicated).toEqual([draft.id]);
+    // Pins WHICH branch this covers: at 95px the controls are in the buy
+    // cluster, where remove sits beside duplicate.
+    expect(await removeIsSiblingOfDuplicate()).toBe(true);
     // 🔴 The half that matters for money: duplicating must not reach the
     // placement mutation.
     expect(placed).toHaveLength(0);
@@ -461,7 +486,7 @@ describe('the duplicate control', () => {
           ownerShare={undefined}
           ownerUsername="creator"
           onGesture={() => true}
-          onDuplicate={() => undefined}
+          onDuplicate={() => null}
         />
       </div>
     );
@@ -469,6 +494,12 @@ describe('the duplicate control', () => {
     await expect
       .element(page.getByRole('button', { name: 'Duplicate this sticker' }))
       .toBeInTheDocument();
+
+    // 🔴 The assertion that makes this a DIFFERENT test rather than a second
+    // copy of the one above. Both branches render a button of the same name, so
+    // presence alone is satisfied by the cluster; the pill keeps remove in its
+    // own container.
+    expect(await removeIsSiblingOfDuplicate()).toBe(false);
   });
 
   /**
@@ -479,5 +510,112 @@ describe('the duplicate control', () => {
     await renderDraft(null);
 
     expect(page.getByRole('button', { name: 'Duplicate this sticker' }).elements()).toHaveLength(0);
+  });
+});
+
+/**
+ * Alt-drag: leave a copy behind and drag the new one, the way a photo editor
+ * does it. Justin asked for it alongside the button.
+ *
+ * The property that matters is WHICH sticker the drag then moves. Dragging the
+ * original would leave the copy stranded under the pointer and move the thing
+ * the placer was trying to keep in place — a duplicate that appears to do the
+ * opposite of what it says.
+ */
+describe('alt-dragging a draft', () => {
+  const dragBody = (options: PointerEventInit = {}) => {
+    // The move handler is on the positioned wrapper — the element carrying the
+    // draft's own left/top — rather than on the artwork inside it.
+    const artwork = document.querySelector('img[alt=":star:"], img[alt="Star"]');
+    const body = artwork?.closest('[style*="touch-action"]') as HTMLElement | null;
+
+    body?.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        pointerId: 1,
+        clientX: 100,
+        clientY: 100,
+        ...options,
+      })
+    );
+
+    return body;
+  };
+
+  const renderForDrag = async (onDuplicate: (id: string) => string | null) => {
+    const gestures: { draftId: string }[] = [];
+
+    renderWithProviders(
+      <div data-drag-host style={{ position: 'relative', width: 380, height: 600 }}>
+        <DraftSticker
+          draft={draft}
+          art={art}
+          selected
+          dressed={resolveTreatment({ treatment: 'none', surface: 'detail', isPending: false })}
+          price={PRICE}
+          freeOffer={null}
+          ownerShare={undefined}
+          ownerUsername="creator"
+          onGesture={(gesture) => {
+            gestures.push(gesture);
+            return true;
+          }}
+          onDuplicate={onDuplicate}
+        />
+      </div>
+    );
+
+    await expect.element(page.getByRole('button').first()).toBeInTheDocument();
+
+    // 🔴 WITHOUT THIS THE HANDLER RETURNS AT ITS FIRST LINE. A press is
+    // translated into a fraction of the surface the placement session
+    // registered, and with no surface there is no fraction and no gesture — so
+    // every assertion below would pass or fail for the wrong reason. The app
+    // registers it from `ImageStickerOverlay`; here the host stands in for it.
+    const store = useStickerPlacementDraftStore.getState();
+    store.open(IMAGE_ID);
+    store.setSurface(document.querySelector('[data-drag-host]') as HTMLElement);
+
+    return gestures;
+  };
+
+  test('duplicates first, then drags the COPY', async () => {
+    const duplicated: string[] = [];
+    const gestures = await renderForDrag((id) => {
+      duplicated.push(id);
+      return 'the-copy';
+    });
+
+    expect(dragBody({ altKey: true })).not.toBeNull();
+
+    expect(duplicated).toEqual([draft.id]);
+    expect(gestures.at(-1)?.draftId).toBe('the-copy');
+  });
+
+  test('an ordinary drag duplicates nothing and moves the original', async () => {
+    const duplicated: string[] = [];
+    const gestures = await renderForDrag((id) => {
+      duplicated.push(id);
+      return 'the-copy';
+    });
+
+    dragBody();
+
+    expect(duplicated).toEqual([]);
+    expect(gestures.at(-1)?.draftId).toBe(draft.id);
+  });
+
+  /**
+   * The host may refuse — there is no handler on a surface that does not offer
+   * duplication. Alt then has to fall back to an ordinary drag rather than
+   * dropping the gesture on the floor.
+   */
+  test('falls back to moving the original when the copy is refused', async () => {
+    const gestures = await renderForDrag(() => null);
+
+    dragBody({ altKey: true });
+
+    expect(gestures.at(-1)?.draftId).toBe(draft.id);
   });
 });

--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -647,6 +647,10 @@ describe('the pack purchase key across one session', () => {
       <div style={{ position: 'relative', width: 380, height: 600 }}>
         <DraftSticker
           draft={gated}
+          // The gate is a prop now, decided across the drafts on the image
+          // rather than frozen onto one of them — so a test that wants a gated
+          // draft has to hand it over the same way the layer does.
+          purchase={gated.purchase}
           art={art}
           selected
           dressed={resolveTreatment({ treatment: 'none', surface: 'detail', isPending: false })}

--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -619,3 +619,59 @@ describe('alt-dragging a draft', () => {
     expect(gestures.at(-1)?.draftId).toBe(draft.id);
   });
 });
+
+/**
+ * 🔴 THE KEY IS RELEASED WHEN THE PURCHASE RESOLVES.
+ *
+ * The server's idempotency check reads a persisted purchase row and THROWS, so a
+ * key held past success refuses the next legitimate purchase of the same pack in
+ * that session — "this purchase has already been completed" — and the sticker
+ * stays unbuyable until a reload. Buy a refill pack, spend it, want another:
+ * that flow predates this feature and has to keep working.
+ *
+ * Asserted at the call site rather than on the store, because the store's own
+ * test cannot see whether anything calls it.
+ */
+describe('the pack purchase key across one session', () => {
+  const gated: StickerDraft = {
+    ...draft,
+    purchase: {
+      refill: true,
+      pack: { shopItemId: 7, unitAmount: 500, acceptsBlue: false, uses: 1 },
+      creatorUsername: 'maker',
+    },
+  };
+
+  test('is released once the purchase resolves, so the same pack can be bought again', async () => {
+    renderWithProviders(
+      <div style={{ position: 'relative', width: 380, height: 600 }}>
+        <DraftSticker
+          draft={gated}
+          art={art}
+          selected
+          dressed={resolveTreatment({ treatment: 'none', surface: 'detail', isPending: false })}
+          price={PRICE}
+          freeOffer={null}
+          ownerShare={undefined}
+          ownerUsername="creator"
+          onGesture={() => true}
+        />
+      </div>
+    );
+
+    const buy = page.getByRole('button', { name: 'Buy another pack' });
+    await expect.element(buy).toBeInTheDocument();
+
+    const store = useStickerPlacementDraftStore.getState();
+    const before = store.packPurchaseKey(gated.cosmeticId);
+
+    ((await buy.element()) as HTMLElement).click();
+
+    // The handler is async — it invalidates a query before releasing the key.
+    await vi.waitFor(() =>
+      expect(useStickerPlacementDraftStore.getState().packPurchaseKey(gated.cosmeticId)).not.toBe(
+        before
+      )
+    );
+  });
+});

--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -376,3 +376,75 @@ describe('the flip control draws the axis it mirrors across', () => {
     expect(boxes.some((box) => box.height === 0 && box.width > 0)).toBe(false);
   });
 });
+
+/**
+ * The duplicate control, and what it is allowed to do.
+ *
+ * Placement is charged, so the button's whole safety argument is that it does
+ * not place anything: it asks the host for another draft and nothing else. What
+ * is asserted is both halves of that — the handler is called with this draft's
+ * id, AND nothing reached the placement mutation.
+ */
+describe('the duplicate control', () => {
+  test('asks the host for another copy, and places nothing', async () => {
+    const duplicated: string[] = [];
+
+    renderWithProviders(
+      <div style={{ position: 'relative', width: 380, height: 600 }}>
+        <DraftSticker
+          // Wider than the shared fixture, deliberately: below a threshold the
+          // component hands its controls to the buy cluster instead of the pill
+          // above the sticker, and that cluster is the one this file documents
+          // as unreachable in this harness. A wide draft keeps the control in
+          // the pill, where an ordinary locator click reaches it with its full
+          // actionability check.
+          draft={draft}
+          art={art}
+          selected
+          dressed={resolveTreatment({ treatment: 'none', surface: 'detail', isPending: false })}
+          price={PRICE}
+          freeOffer={null}
+          ownerShare={undefined}
+          ownerUsername="creator"
+          onGesture={() => true}
+          onDuplicate={(id) => {
+            duplicated.push(id);
+          }}
+        />
+      </div>
+    );
+
+    // ⚠️ Pressed through the DOM, for the reachability reason this file
+    // documents above and measures again here: the control sits in a cluster
+    // that lands at a NEGATIVE x in this harness (-73px, measured), so a locator
+    // click spends its whole budget waiting for an element that will never be
+    // in view. What is under test is the wiring, not actionability — the control
+    // is a plain `ActionIcon` with no disabled state and nothing overlaying it.
+    //
+    // 🔴 THIS EXEMPTION ENDS the moment the control gains a disabled or loading
+    // state, or anything is painted over the cluster: a DOM press would then
+    // fire a handler a real placer could not fire.
+    // `.element()` does not retry, and the draft paints its controls a frame or
+    // two after mount. Poll for it first, then take the node.
+    const locator = page.getByRole('button', { name: 'Place another copy of this sticker' });
+    await expect.element(locator).toBeInTheDocument();
+    ((await locator.element()) as HTMLElement).click();
+
+    expect(duplicated).toEqual([draft.id]);
+    // 🔴 The half that matters for money. `placed` collects every call to the
+    // placement mutation; duplicating must not add to it.
+    expect(placed).toHaveLength(0);
+  });
+
+  /**
+   * Absent rather than disabled where the host supplies no handler: a control
+   * that cannot act is a question the placer answers by pressing it.
+   */
+  test('is not rendered at all without a handler', async () => {
+    await renderDraft(null);
+
+    expect(
+      page.getByRole('button', { name: 'Place another copy of this sticker' }).elements()
+    ).toHaveLength(0);
+  });
+});

--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -386,18 +386,22 @@ describe('the flip control draws the axis it mirrors across', () => {
  * id, AND nothing reached the placement mutation.
  */
 describe('the duplicate control', () => {
+  /**
+   * ⚠️ THE NARROW FIXTURE PUTS THE CONTROL IN THE BUY CLUSTER, NOT THE PILL.
+   *
+   * `panelsInside` needs the sticker to be at least 124px wide; the shared
+   * fixture is 0.25 of a 380px container, so 95px — the controls go to the buy
+   * cluster, which this file documents as landing at a negative x here. That is
+   * why this one is pressed through the DOM. The test below covers the pill
+   * branch with a wide draft and an ordinary locator click, so both render paths
+   * are exercised rather than one being described and neither checked.
+   */
   test('asks the host for another copy, and places nothing', async () => {
     const duplicated: string[] = [];
 
     renderWithProviders(
       <div style={{ position: 'relative', width: 380, height: 600 }}>
         <DraftSticker
-          // Wider than the shared fixture, deliberately: below a threshold the
-          // component hands its controls to the buy cluster instead of the pill
-          // above the sticker, and that cluster is the one this file documents
-          // as unreachable in this harness. A wide draft keeps the control in
-          // the pill, where an ordinary locator click reaches it with its full
-          // actionability check.
           draft={draft}
           art={art}
           selected
@@ -414,26 +418,57 @@ describe('the duplicate control', () => {
       </div>
     );
 
-    // ⚠️ Pressed through the DOM, for the reachability reason this file
-    // documents above and measures again here: the control sits in a cluster
-    // that lands at a NEGATIVE x in this harness (-73px, measured), so a locator
-    // click spends its whole budget waiting for an element that will never be
-    // in view. What is under test is the wiring, not actionability — the control
-    // is a plain `ActionIcon` with no disabled state and nothing overlaying it.
-    //
-    // 🔴 THIS EXEMPTION ENDS the moment the control gains a disabled or loading
-    // state, or anything is painted over the cluster: a DOM press would then
-    // fire a handler a real placer could not fire.
-    // `.element()` does not retry, and the draft paints its controls a frame or
-    // two after mount. Poll for it first, then take the node.
-    const locator = page.getByRole('button', { name: 'Place another copy of this sticker' });
+    const locator = page.getByRole('button', { name: 'Duplicate this sticker' });
     await expect.element(locator).toBeInTheDocument();
     ((await locator.element()) as HTMLElement).click();
 
     expect(duplicated).toEqual([draft.id]);
-    // 🔴 The half that matters for money. `placed` collects every call to the
-    // placement mutation; duplicating must not add to it.
+    // 🔴 The half that matters for money: duplicating must not reach the
+    // placement mutation.
     expect(placed).toHaveLength(0);
+
+    // 🔴 THE POSITIVE CONTROL, IN THE SAME RENDER. Without it the zero above is
+    // an absence measured by an instrument nothing proved was live — a broken
+    // mock would certify "charges nothing" forever.
+    await pressPaid();
+    expect(placed).toHaveLength(1);
+  });
+
+  /**
+   * The OTHER render path. Below 124px of sticker width the controls go to the
+   * buy cluster; above it they go to the pill. Both have to actually render the
+   * duplicate control, and only one of them was being exercised — deleting
+   * `{duplicateControl}` from the pill left every test green.
+   *
+   * ⚠️ What this does NOT assert is reachability. Measured in this harness, the
+   * control sits at x = -95 in the pill branch and x = -73 in the cluster
+   * branch: the whole draft renders at negative coordinates here, so no locator
+   * click succeeds on either path and a passing "it is clickable" test would be
+   * a fiction. Presence is what this harness can honestly check.
+   */
+  test('renders in the pill branch as well as the buy cluster', async () => {
+    renderWithProviders(
+      <div style={{ position: 'relative', width: 380, height: 600 }}>
+        <DraftSticker
+          // 0.5 of 380 is 190px, past the 124px threshold, so the controls sit
+          // in the pill above the sticker rather than in the buy cluster.
+          draft={{ ...draft, scale: 0.5, y: 0.5 }}
+          art={art}
+          selected
+          dressed={resolveTreatment({ treatment: 'none', surface: 'detail', isPending: false })}
+          price={PRICE}
+          freeOffer={null}
+          ownerShare={undefined}
+          ownerUsername="creator"
+          onGesture={() => true}
+          onDuplicate={() => undefined}
+        />
+      </div>
+    );
+
+    await expect
+      .element(page.getByRole('button', { name: 'Duplicate this sticker' }))
+      .toBeInTheDocument();
   });
 
   /**
@@ -443,8 +478,6 @@ describe('the duplicate control', () => {
   test('is not rendered at all without a handler', async () => {
     await renderDraft(null);
 
-    expect(
-      page.getByRole('button', { name: 'Place another copy of this sticker' }).elements()
-    ).toHaveLength(0);
+    expect(page.getByRole('button', { name: 'Duplicate this sticker' }).elements()).toHaveLength(0);
   });
 });

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -40,7 +40,10 @@ import {
 import { payoutCopy, stickerPurchaseCopy } from '~/components/Sticker/payout-copy';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { useCreateStickerPlacement } from '~/components/Sticker/placement.util';
-import { useBuyStickerUses } from '~/components/Sticker/sticker.util';
+import {
+  purchaseDefinitelyDidNotCharge,
+  useBuyStickerUses,
+} from '~/components/Sticker/sticker.util';
 import type { ResolvedSticker } from '~/components/Sticker/sticker.util';
 import type { StickerTreatment } from '~/components/Sticker/treatments/sticker-treatments';
 import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
@@ -155,6 +158,7 @@ export function DraftSticker({
   purchase?: DraftPurchase;
 }) {
   const markPurchased = useStickerPlacementDraftStore((state) => state.markPurchased);
+  const markPaidForUse = useStickerPlacementDraftStore((state) => state.markPaidForUse);
   const { purchaseShopItem, purchasingShopItem } = useMutateCosmeticShop();
   const queryUtils = trpc.useUtils();
   // 🔴 ONE KEY PER STICKER PER SESSION, HELD IN THE STORE — not one per draft.
@@ -206,10 +210,12 @@ export function DraftSticker({
         message: 'Place it whenever you like — it stays where you put it.',
       });
     } catch (error) {
-      // The attempt is over, so the next press is a new intent rather than a
-      // retry of this one. Holding the key would have a server that records
-      // failed keys refuse every later attempt this session.
-      clearPackPurchaseKey(draft.cosmeticId);
+      // 🔴 ONLY WHERE THE SERVER SAID NO. A refusal is the end of the attempt, so
+      // the next press is a new intent and needs a new key. A timeout or a 5xx
+      // is NOT: the charge may well have gone through, and minting a fresh key
+      // for the retry is how one purchase becomes two. Holding it wrongly costs
+      // a refusal on the next press; releasing it wrongly costs someone's Buzz.
+      if (purchaseDefinitelyDidNotCharge(error)) clearPackPurchaseKey(draft.cosmeticId);
       showErrorNotification({
         title: 'Could not buy that sticker',
         error: error instanceof Error ? error : new Error('Purchase failed'),
@@ -233,10 +239,13 @@ export function DraftSticker({
         expectedPricePerUse: perUse,
         payWith: 'default',
       });
-      // This draft only. One use funds one placement, so lifting the gate from
-      // every draft of the sticker would show a Place button on stickers that
-      // cannot be placed — the server refuses them at `assertHasUse`, after the
-      // button has already claimed they were paid for.
+      // 🔴 THE USE BELONGS TO THE DRAFT THAT PAID FOR IT. Coverage is otherwise
+      // assigned in creation order, so buying from the second of two copies
+      // raised the balance and covered the FIRST — this button would not change,
+      // which reads as a purchase that failed and invites paying twice.
+      markPaidForUse(draft.id);
+      // Kept for the case where a gate IS stored on this draft (a sticker being
+      // bought outright). One use funds one placement, so this draft only.
       markPurchased(draft.cosmeticId, draft.id);
     } catch (error) {
       showErrorNotification({

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mantine/core';
 import {
   IconAlertTriangleFilled,
+  IconCopy,
   IconDropletHalf2,
   IconFlipVertical,
   IconMessage,
@@ -132,6 +133,7 @@ export function DraftSticker({
   ownerShare,
   ownerUsername,
   onGesture,
+  onDuplicate,
 }: {
   draft: StickerDraft;
   art: ResolvedSticker;
@@ -148,6 +150,13 @@ export function DraftSticker({
   ownerShare: number | undefined;
   ownerUsername: string | null | undefined;
   onGesture: StartGesture;
+  /**
+   * Makes a second draft of this sticker. Supplied by the host rather than
+   * called on the store from here, because whether the copy needs to be bought
+   * depends on the viewer's remaining uses — which the layer can see and this
+   * component cannot.
+   */
+  onDuplicate?: (id: string) => void;
 }) {
   const markPurchased = useStickerPlacementDraftStore((state) => state.markPurchased);
   const { purchaseShopItem, purchasingShopItem } = useMutateCosmeticShop();
@@ -525,6 +534,34 @@ export function DraftSticker({
     },
   });
 
+  /**
+   * A second copy of this sticker, already arranged.
+   *
+   * Placing several of one sticker meant a trip back through the tray for each,
+   * which is what this removes. It creates a DRAFT and nothing else — the copy
+   * is bought and placed by the same button and the same mutation as the first,
+   * so there is no second route into the charge path and nothing here can place
+   * a sticker without being charged for it.
+   *
+   * Absent rather than disabled where the host does not supply a handler: a
+   * control that cannot act is a question the placer has to answer by pressing
+   * it.
+   */
+  const duplicateControl = onDuplicate && (
+    <Tooltip label="Duplicate" withinPortal>
+      <ActionIcon
+        size="sm"
+        radius="xl"
+        variant="subtle"
+        color="gray"
+        aria-label="Place another copy of this sticker"
+        onClick={() => onDuplicate(draft.id)}
+      >
+        <IconCopy size={14} />
+      </ActionIcon>
+    </Tooltip>
+  );
+
   const flipControl = (
     <Tooltip label={draft.flip ? 'Unflip' : 'Flip'} withinPortal>
       <ActionIcon
@@ -691,6 +728,7 @@ export function DraftSticker({
             className="absolute -top-9 left-0 flex cursor-auto items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5"
             onPointerDown={pressPanel}
           >
+            {duplicateControl}
             {flipControl}
             {opacityControl}
           </div>
@@ -752,6 +790,7 @@ export function DraftSticker({
             className="flex items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5"
             onPointerDown={pressPanel}
           >
+            {duplicateControl}
             {flipControl}
             {opacityControl}
             {removeControl}

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -141,7 +141,7 @@ export function DraftSticker({
    * depends on the viewer's remaining uses — which the layer can see and this
    * component cannot.
    */
-  onDuplicate?: (id: string) => void;
+  onDuplicate?: (id: string) => string | null;
 }) {
   const markPurchased = useStickerPlacementDraftStore((state) => state.markPurchased);
   const { purchaseShopItem, purchasingShopItem } = useMutateCosmeticShop();
@@ -154,6 +154,7 @@ export function DraftSticker({
   // apart. The per-use path below is unaffected: each use genuinely is another
   // purchase.
   const packPurchaseKey = useStickerPlacementDraftStore((state) => state.packPurchaseKey);
+  const clearPackPurchaseKey = useStickerPlacementDraftStore((state) => state.clearPackPurchaseKey);
   const buyUses = useBuyStickerUses();
 
   const buySticker = async () => {
@@ -182,6 +183,10 @@ export function DraftSticker({
         message: 'Place it whenever you like — it stays where you put it.',
       });
     } catch (error) {
+      // The attempt is over, so the next press is a new intent rather than a
+      // retry of this one. Holding the key would have a server that records
+      // failed keys refuse every later attempt this session.
+      clearPackPurchaseKey(draft.cosmeticId);
       showErrorNotification({
         title: 'Could not buy that sticker',
         error: error instanceof Error ? error : new Error('Purchase failed'),
@@ -441,7 +446,7 @@ export function DraftSticker({
       const target = event.currentTarget;
       const take = (gesture: Gesture) => {
         if (!onGesture(gesture)) return;
-        select(draft.id);
+        select(gesture.draftId);
         try {
           target.setPointerCapture(gesture.pointerId);
         } catch {
@@ -450,10 +455,27 @@ export function DraftSticker({
       };
 
       if (mode === 'move') {
+        /**
+         * Alt-drag leaves a copy behind and drags the new one, the way every
+         * photo editor does it.
+         *
+         * The gesture continues against the COPY rather than the original, which
+         * is why `onDuplicate` hands back an id: dragging the original instead
+         * would leave the duplicate stranded under the pointer and move the
+         * thing the placer was trying to keep in place.
+         *
+         * The copy lands at the original's position for this path — the button's
+         * nudge exists so a click produces something visible, but an alt-drag is
+         * about to be positioned by the pointer, and offsetting it first makes
+         * the sticker jump out from under the cursor at the start of the drag.
+         */
+        const altCopyId = event.altKey ? onDuplicate?.(draft.id) : null;
+        if (altCopyId) move(altCopyId, { x: draft.x, y: draft.y });
+
         // Keep the sticker where it was relative to the grab, instead of
         // snapping its centre to the cursor.
         take({
-          draftId: draft.id,
+          draftId: altCopyId ?? draft.id,
           pointerId: event.pointerId,
           mode: 'move',
           offsetX: draft.x - point.x,

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -40,10 +40,7 @@ import {
 import { payoutCopy, stickerPurchaseCopy } from '~/components/Sticker/payout-copy';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { useCreateStickerPlacement } from '~/components/Sticker/placement.util';
-import {
-  purchaseDefinitelyDidNotCharge,
-  useBuyStickerUses,
-} from '~/components/Sticker/sticker.util';
+import { purchaseCanBeRetriedFresh, useBuyStickerUses } from '~/components/Sticker/sticker.util';
 import type { ResolvedSticker } from '~/components/Sticker/sticker.util';
 import type { StickerTreatment } from '~/components/Sticker/treatments/sticker-treatments';
 import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
@@ -210,12 +207,12 @@ export function DraftSticker({
         message: 'Place it whenever you like — it stays where you put it.',
       });
     } catch (error) {
-      // 🔴 ONLY WHERE THE SERVER SAID NO. A refusal is the end of the attempt, so
-      // the next press is a new intent and needs a new key. A timeout or a 5xx
+      // 🔴 ONLY WHERE THE SERVER DECLINED. A 4xx is the end of the attempt, so
+      // the next press is a new intent and needs a new key. A 5xx or a timeout
       // is NOT: the charge may well have gone through, and minting a fresh key
       // for the retry is how one purchase becomes two. Holding it wrongly costs
       // a refusal on the next press; releasing it wrongly costs someone's Buzz.
-      if (purchaseDefinitelyDidNotCharge(error)) clearPackPurchaseKey(draft.cosmeticId);
+      if (purchaseCanBeRetriedFresh(error)) clearPackPurchaseKey(draft.cosmeticId);
       showErrorNotification({
         title: 'Could not buy that sticker',
         error: error instanceof Error ? error : new Error('Purchase failed'),
@@ -244,9 +241,6 @@ export function DraftSticker({
       // raised the balance and covered the FIRST — this button would not change,
       // which reads as a purchase that failed and invites paying twice.
       markPaidForUse(draft.id);
-      // Kept for the case where a gate IS stored on this draft (a sticker being
-      // bought outright). One use funds one placement, so this draft only.
-      markPurchased(draft.cosmeticId, draft.id);
     } catch (error) {
       showErrorNotification({
         title: 'Could not buy a use',

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -71,21 +71,6 @@ const NOTE_WIDTH = 220;
 const BUY_BUTTON_GAP = 8;
 
 /**
- * A purchase's idempotency key, which the server refuses a repeat of.
- *
- * Feature-detected for the same reason the draft ids are: `crypto.randomUUID`
- * is undefined outside a secure context, and throwing here would take down the
- * purchase button on any http origin that is not localhost. The fallback is
- * still unique per page — and a key that repeats across sessions would only ever
- * refuse a charge, never duplicate one.
- */
-let purchaseKeySequence = 0;
-const nextPurchaseKey = () =>
-  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-    ? crypto.randomUUID()
-    : `00000000-0000-4000-8000-${String(++purchaseKeySequence).padStart(12, '0')}`;
-
-/**
  * The nearest ancestor that clips — the carousel's viewport on the image detail
  * page, whose bottom edge is the bottom of the media box.
  *
@@ -161,10 +146,14 @@ export function DraftSticker({
   const markPurchased = useStickerPlacementDraftStore((state) => state.markPurchased);
   const { purchaseShopItem, purchasingShopItem } = useMutateCosmeticShop();
   const queryUtils = trpc.useUtils();
-  // One buying intent, minted with the draft and reused by every press on it.
-  // The server refuses a repeat of the same key, so a double-click or a retry
-  // after a timeout cannot be charged twice.
-  const purchaseKey = useRef(nextPurchaseKey());
+  // 🔴 ONE KEY PER STICKER PER SESSION, HELD IN THE STORE — not one per draft.
+  // A pack grants the sticker itself and `markPurchased` then frees every draft
+  // of it, so two copies showing two buy buttons are ONE buying intent. Minted
+  // per draft, pressing both within a second was two keys and two charges for
+  // something you only get once; duplicating put those two buttons a click
+  // apart. The per-use path below is unaffected: each use genuinely is another
+  // purchase.
+  const packPurchaseKey = useStickerPlacementDraftStore((state) => state.packPurchaseKey);
   const buyUses = useBuyStickerUses();
 
   const buySticker = async () => {
@@ -176,10 +165,9 @@ export function DraftSticker({
         shopItemId: pack.shopItemId,
         viaShopUserId: pack.viaShopUserId,
         payWith: pack.acceptsBlue ? 'blue-first' : undefined,
-        // One key per draft, minted once: a double-click, a retry, or a second
-        // tab replaying this purchase is one intent and must be charged once.
-        // Stickers can be bought repeatedly now, so nothing else refuses it.
-        idempotencyKey: purchaseKey.current,
+        // One key per sticker per session: a double-click, a retry, a second tab
+        // — or the second copy's own buy button — are one intent, charged once.
+        idempotencyKey: packPurchaseKey(draft.cosmeticId),
         // The number this button is showing. A listing re-priced while the panel
         // sat open must refuse rather than charge something else.
         expectedUnitAmount: pack.unitAmount,
@@ -554,7 +542,7 @@ export function DraftSticker({
         radius="xl"
         variant="subtle"
         color="gray"
-        aria-label="Place another copy of this sticker"
+        aria-label="Duplicate this sticker"
         onClick={() => onDuplicate(draft.id)}
       >
         <IconCopy size={14} />

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -51,7 +51,7 @@ import {
 import { numberWithCommas } from '~/utils/number-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
-import type { StickerDraft } from '~/store/sticker-placement-draft.store';
+import type { DraftPurchase, StickerDraft } from '~/store/sticker-placement-draft.store';
 import {
   pointerToSurfaceFraction,
   useStickerPlacementDraftStore,
@@ -119,6 +119,7 @@ export function DraftSticker({
   ownerUsername,
   onGesture,
   onDuplicate,
+  purchase,
 }: {
   draft: StickerDraft;
   art: ResolvedSticker;
@@ -142,6 +143,16 @@ export function DraftSticker({
    * component cannot.
    */
   onDuplicate?: (id: string) => string | null;
+  /**
+   * What this draft still has to buy, decided ACROSS the drafts on the image
+   * rather than frozen onto this one when it was created.
+   *
+   * The draft's own `purchase` is the sticker-not-owned-yet case, which is a
+   * fact about this draft. Whether an owned sticker's use is available is a fact
+   * about the whole set — delete a draft and its use goes to the next one — so
+   * the host recomputes it and passes it down.
+   */
+  purchase?: DraftPurchase;
 }) {
   const markPurchased = useStickerPlacementDraftStore((state) => state.markPurchased);
   const { purchaseShopItem, purchasingShopItem } = useMutateCosmeticShop();
@@ -158,7 +169,7 @@ export function DraftSticker({
   const buyUses = useBuyStickerUses();
 
   const buySticker = async () => {
-    const pack = draft.purchase?.pack;
+    const pack = purchase?.pack;
     if (!pack) return;
 
     try {
@@ -210,7 +221,7 @@ export function DraftSticker({
   // the shop's business, not this button's — the sticker is already arranged and
   // the next press after this one is Place.
   const buyOneUse = async () => {
-    const perUse = draft.purchase?.perUse;
+    const perUse = purchase?.perUse;
     if (perUse == null) return;
 
     try {
@@ -260,8 +271,8 @@ export function DraftSticker({
   // share of them is a claim about money that does not move. PR 3's accept
   // reward is the creator's side of a free placement and is not derived from
   // this split, so it does not belong in this sentence either.
-  const payout = draft.purchase
-    ? stickerPurchaseCopy(draft.purchase.creatorUsername)
+  const payout = purchase
+    ? stickerPurchaseCopy(purchase.creatorUsername)
     : placingFree
     ? null
     : payoutCopy(ownerShare, ownerUsername);
@@ -270,14 +281,14 @@ export function DraftSticker({
   // use: it is the cheaper of the two and exactly what placing this draft
   // spends, so the larger commitment is the one you have to ask for.
   const [buyMode, setBuyMode] = useState<'use' | 'pack'>('use');
-  const canBuyUse = draft.purchase?.perUse != null;
-  const canBuyPack = !!draft.purchase?.pack;
+  const canBuyUse = purchase?.perUse != null;
+  const canBuyPack = !!purchase?.pack;
   const offersBoth = canBuyUse && canBuyPack;
   // A first purchase has no per-use option at all — you cannot top up a sticker
   // you do not own — so the toggle's value only decides anything when both are
   // open.
   const effectiveMode = offersBoth ? buyMode : canBuyPack ? 'pack' : 'use';
-  const packUses = draft.purchase?.pack?.uses;
+  const packUses = purchase?.pack?.uses;
 
   // Local to the draft rather than in the store: it is written once, read once
   // at purchase, and putting it in the store would make every keystroke a
@@ -890,7 +901,7 @@ export function DraftSticker({
             deliberately does not. This is the last moment the placer can change
             their mind, and it is what makes auto-accept and review read as two
             different offers rather than a setting nobody can see. */}
-        {!draft.purchase && freeOffer && (
+        {!purchase && freeOffer && (
           <SegmentedControl
             size="xs"
             radius="xl"
@@ -903,23 +914,23 @@ export function DraftSticker({
           />
         )}
 
-        {draft.purchase && effectiveMode === 'pack' && draft.purchase.pack ? (
+        {purchase && effectiveMode === 'pack' && purchase.pack ? (
           <BuzzTransactionButton
             size="sm"
             style={{ minWidth: BUY_BUTTON_MIN_WIDTH }}
-            buzzAmount={draft.purchase.pack.unitAmount}
-            accountTypes={draft.purchase.pack.acceptsBlue ? ['blue', ...spendTypes] : spendTypes}
-            label={draft.purchase.refill ? 'Buy another pack' : 'Purchase sticker'}
+            buzzAmount={purchase.pack.unitAmount}
+            accountTypes={purchase.pack.acceptsBlue ? ['blue', ...spendTypes] : spendTypes}
+            label={purchase.refill ? 'Buy another pack' : 'Purchase sticker'}
             loading={purchasingShopItem}
             onPerformTransaction={buySticker}
           />
-        ) : draft.purchase ? (
+        ) : purchase ? (
           // Owned, and out of uses. One use, because one is what placing this
           // draft spends.
           <BuzzTransactionButton
             size="sm"
             style={{ minWidth: BUY_BUTTON_MIN_WIDTH }}
-            buzzAmount={draft.purchase.perUse ?? 0}
+            buzzAmount={purchase.perUse ?? 0}
             accountTypes={spendTypes}
             label="Buy a use"
             loading={buyUses.isPending}
@@ -927,7 +938,7 @@ export function DraftSticker({
             // charge, and the listing price is not a stand-in for one. Says so
             // rather than offering a button that cannot work.
             error={
-              draft.purchase.perUse == null
+              purchase.perUse == null
                 ? 'This sticker sells no extra uses, and it is not on sale right now'
                 : undefined
             }
@@ -981,7 +992,7 @@ export function DraftSticker({
         {/* The second payment, said before the first one is made. Someone who
             buys a sticker to put it here and then meets another price has been
             surprised with their own money. */}
-        {draft.purchase && (
+        {purchase && (
           <div className="flex items-center gap-1 rounded-full bg-black/80 px-2 py-0.5">
             <IconAlertTriangleFilled size={12} className="shrink-0 text-yellow-4" />
             <Text size="xs" c="gray.3" className="leading-tight">

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -178,6 +178,18 @@ export function DraftSticker({
       // tray keeps calling this sticker spent and offering to sell it again.
       await queryUtils.cosmetic.getStickerBalances.invalidate();
       markPurchased(draft.cosmeticId);
+      // 🔴 SUCCESS ENDS THE INTENT; THE SESSION DOES NOT. The server's
+      // idempotency check is not a soft dedupe — it looks up a persisted
+      // purchase row and throws — so holding this key would refuse the NEXT
+      // legitimate purchase of the same pack in this session with "this purchase
+      // has already been completed", and the sticker would stay unbuyable until
+      // a reload. Buy a refill pack, spend it, want another: that flow worked
+      // before the key became session-scoped and has to keep working.
+      //
+      // The race this key exists for is unaffected: two copies pressed inside
+      // the same second both read the key BEFORE either resolves, so the second
+      // is still refused as one intent charged once.
+      clearPackPurchaseKey(draft.cosmeticId);
       showSuccessNotification({
         title: 'Sticker purchased',
         message: 'Place it whenever you like — it stays where you put it.',

--- a/src/components/Sticker/DraftStickerLayer.tsx
+++ b/src/components/Sticker/DraftStickerLayer.tsx
@@ -87,6 +87,7 @@ export function DraftStickerLayer() {
   });
   const refillFor = useStickerRefill();
 
+  const paidDraftIds = useStickerPlacementDraftStore((state) => state.paidDraftIds);
   const duplicateDraft = useStickerPlacementDraftStore((state) => state.duplicateDraft);
 
   /**
@@ -99,8 +100,8 @@ export function DraftStickerLayer() {
    * a use that had just been handed back. Entitlement belongs to the set.
    */
   const entitlements = useMemo(
-    () => allocateDraftEntitlements({ drafts, balances, freeAvailable: !!freeOffer }),
-    [drafts, balances, freeOffer]
+    () => allocateDraftEntitlements({ drafts, balances, freeAvailable: !!freeOffer, paidDraftIds }),
+    [drafts, balances, freeOffer, paidDraftIds]
   );
 
   const onDuplicate = useCallback(

--- a/src/components/Sticker/DraftStickerLayer.tsx
+++ b/src/components/Sticker/DraftStickerLayer.tsx
@@ -8,6 +8,9 @@ import {
   useImagePlacementSpace,
 } from '~/components/Sticker/placement.util';
 import { useOwnedSticker, useStickerCosmetics } from '~/components/Sticker/sticker.util';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { STICKER_OFFER_LIMIT } from '~/server/schema/cosmetic.schema';
+import { trpc } from '~/utils/trpc';
 import { resolveTreatment } from '~/components/Sticker/treatments/sticker-treatments';
 import { useStickerTreatment } from '~/components/Sticker/treatments/useStickerTreatment';
 import { STICKER_PLACEMENT_MIN_SCALE, stickerMaxScale } from '~/shared/utils/sticker-placement';
@@ -63,6 +66,76 @@ export function DraftStickerLayer() {
   // per sticker would be N observers refetching through an arrangement.
   const { standing } = useFreePlacementStanding(targetImageId ?? undefined);
   const freeOffer = freeOfferFor(space, standing);
+
+  /**
+   * What the placer has left of each sticker, and what a spent one costs to top
+   * up — the same two queries the tray runs, so this shares their cache rather
+   * than making its own requests.
+   *
+   * 🔴 THIS IS WHAT MAKES A DUPLICATE HONEST. A copy spends a use of its own, so
+   * duplicating the last one has to arrive carrying the same purchase gate a
+   * fresh pickup of a spent sticker would. Cloning the original's gate instead
+   * would be wrong in both directions: a copy of an already-bought draft would
+   * show a Place button the server refuses at `assertHasUse`, and a copy made
+   * after the purchase landed would ask to buy the sticker twice.
+   */
+  const currentUser = useCurrentUser();
+  const { data: balances } = trpc.cosmetic.getStickerBalances.useQuery(undefined, {
+    enabled: !!currentUser && targetImageId != null,
+  });
+  const draftedIds = useMemo(() => [...new Set(drafts.map((draft) => draft.cosmeticId))], [drafts]);
+  const { data: offers } = trpc.cosmetic.getStickerOffers.useQuery(
+    { ids: draftedIds.slice(0, STICKER_OFFER_LIMIT) },
+    { enabled: !!currentUser && !!draftedIds.length, staleTime: 60_000 }
+  );
+
+  const duplicateDraft = useStickerPlacementDraftStore((state) => state.duplicateDraft);
+
+  const onDuplicate = useCallback(
+    (id: string) => {
+      const source = useStickerPlacementDraftStore
+        .getState()
+        .drafts.find((draft) => draft.id === id);
+      if (!source) return;
+
+      const balance = balances?.find((entry) => entry.cosmeticId === source.cosmeticId)?.remaining;
+      // `null` is unlimited. Every draft of this sticker already on the image is
+      // subtracted, including the one being copied: each of them will spend a use
+      // when it is bought, so the copy is only free of a gate while there is a
+      // use left AFTER all of them.
+      const drafted = useStickerPlacementDraftStore
+        .getState()
+        .drafts.filter((draft) => draft.cosmeticId === source.cosmeticId).length;
+      const spent = balance != null && balance - drafted <= 0;
+
+      if (!spent) return duplicateDraft(id);
+
+      // Out of uses, so the copy needs the same top-up offer a fresh pickup of a
+      // spent sticker gets. An offer that is not on sale leaves the copy gated
+      // with no way to buy — which is the truth, and the draft says so, rather
+      // than a Place button that fails at the mutation.
+      const offer = offers?.find((entry) => entry.cosmeticId === source.cosmeticId);
+      const listing = offer?.listing;
+
+      duplicateDraft(id, {
+        refill: true,
+        perUse: offer?.pricePerUse ?? undefined,
+        ...(listing
+          ? {
+              pack: {
+                shopItemId: listing.shopItemId,
+                unitAmount: listing.unitAmount,
+                acceptsBlue: listing.acceptsBlue,
+                uses: listing.uses,
+                viaShopUserId: listing.viaShopUserId ?? undefined,
+              },
+            }
+          : {}),
+        creatorUsername: offer ? offer.creatorUsername : undefined,
+      });
+    },
+    [balances, offers, duplicateDraft]
+  );
 
   const gesture = useRef<Gesture | null>(null);
   // Held in a ref because the pointer listener is bound once; re-binding it when
@@ -243,6 +316,7 @@ export function DraftStickerLayer() {
             ownerShare={space?.ownerShare}
             ownerUsername={space?.ownerUsername}
             onGesture={onGesture}
+            onDuplicate={onDuplicate}
           />
         );
       })}

--- a/src/components/Sticker/DraftStickerLayer.tsx
+++ b/src/components/Sticker/DraftStickerLayer.tsx
@@ -92,9 +92,9 @@ export function DraftStickerLayer() {
     (id: string) => {
       const current = useStickerPlacementDraftStore.getState().drafts;
       const source = current.find((draft) => draft.id === id);
-      if (!source) return;
+      if (!source) return null;
 
-      duplicateDraft(
+      return duplicateDraft(
         id,
         duplicateGateFor({
           source,

--- a/src/components/Sticker/DraftStickerLayer.tsx
+++ b/src/components/Sticker/DraftStickerLayer.tsx
@@ -9,7 +9,7 @@ import {
 } from '~/components/Sticker/placement.util';
 import {
   allocateDraftEntitlements,
-  duplicateGateFor,
+  unownedGateFor,
   useOwnedSticker,
   useStickerCosmetics,
   useStickerRefill,
@@ -109,20 +109,12 @@ export function DraftStickerLayer() {
       const source = current.find((draft) => draft.id === id);
       if (!source) return null;
 
-      return duplicateDraft(
-        id,
-        duplicateGateFor({
-          source,
-          drafts: current,
-          balances,
-          refillFor,
-          // The owned payload's price, so a copy made before the offers query
-          // lands is not frozen on "this sticker sells no extra uses".
-          ownedPricePerUse: sticker.find((option) => option.id === source.cosmeticId)?.pricePerUse,
-        })
-      );
+      // Only the sticker-not-owned-yet gate travels with a copy. Whether an
+      // owned sticker still has a use is decided across the whole set on every
+      // render — storing that answer here is exactly what froze it before.
+      return duplicateDraft(id, unownedGateFor(source));
     },
-    [balances, refillFor, duplicateDraft, sticker]
+    [duplicateDraft]
   );
 
   const gesture = useRef<Gesture | null>(null);

--- a/src/components/Sticker/DraftStickerLayer.tsx
+++ b/src/components/Sticker/DraftStickerLayer.tsx
@@ -8,6 +8,7 @@ import {
   useImagePlacementSpace,
 } from '~/components/Sticker/placement.util';
 import {
+  allocateDraftEntitlements,
   duplicateGateFor,
   useOwnedSticker,
   useStickerCosmetics,
@@ -87,6 +88,20 @@ export function DraftStickerLayer() {
   const refillFor = useStickerRefill();
 
   const duplicateDraft = useStickerPlacementDraftStore((state) => state.duplicateDraft);
+
+  /**
+   * Who is covered and who is buying, recomputed from the whole set every time
+   * it changes.
+   *
+   * 🔴 THIS REPLACES A SNAPSHOT, AND THAT IS THE POINT. The gate used to be
+   * decided when a draft was created and written onto it — so with one use left,
+   * deleting the covered draft left the other one still asking to be bought for
+   * a use that had just been handed back. Entitlement belongs to the set.
+   */
+  const entitlements = useMemo(
+    () => allocateDraftEntitlements({ drafts, balances, freeAvailable: !!freeOffer }),
+    [drafts, balances, freeOffer]
+  );
 
   const onDuplicate = useCallback(
     (id: string) => {
@@ -285,11 +300,24 @@ export function DraftStickerLayer() {
             selected={draft.id === selectedDraftId}
             dressed={dressed}
             price={space?.price ?? 0}
-            freeOffer={freeOffer}
             ownerShare={space?.ownerShare}
             ownerUsername={space?.ownerUsername}
             onGesture={onGesture}
             onDuplicate={onDuplicate}
+            // The sticker-not-owned-yet gate belongs to the draft; the
+            // is-there-a-use-left gate belongs to the set and is decided above.
+            purchase={
+              draft.purchase ??
+              (entitlements.get(draft.id)?.covered
+                ? undefined
+                : refillFor(
+                    draft.cosmeticId,
+                    sticker.find((option) => option.id === draft.cosmeticId)?.pricePerUse
+                  ))
+            }
+            // Exactly one draft can take the free placement — it is once per
+            // image — so the offer goes to that one rather than to all of them.
+            freeOffer={entitlements.get(draft.id)?.free ? freeOffer : null}
           />
         );
       })}

--- a/src/components/Sticker/DraftStickerLayer.tsx
+++ b/src/components/Sticker/DraftStickerLayer.tsx
@@ -7,9 +7,13 @@ import {
   useFreePlacementStanding,
   useImagePlacementSpace,
 } from '~/components/Sticker/placement.util';
-import { useOwnedSticker, useStickerCosmetics } from '~/components/Sticker/sticker.util';
+import {
+  duplicateGateFor,
+  useOwnedSticker,
+  useStickerCosmetics,
+  useStickerRefill,
+} from '~/components/Sticker/sticker.util';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { STICKER_OFFER_LIMIT } from '~/server/schema/cosmetic.schema';
 import { trpc } from '~/utils/trpc';
 import { resolveTreatment } from '~/components/Sticker/treatments/sticker-treatments';
 import { useStickerTreatment } from '~/components/Sticker/treatments/useStickerTreatment';
@@ -68,73 +72,42 @@ export function DraftStickerLayer() {
   const freeOffer = freeOfferFor(space, standing);
 
   /**
-   * What the placer has left of each sticker, and what a spent one costs to top
-   * up — the same two queries the tray runs, so this shares their cache rather
-   * than making its own requests.
+   * What the placer has left of each sticker, and what a top-up costs.
    *
-   * 🔴 THIS IS WHAT MAKES A DUPLICATE HONEST. A copy spends a use of its own, so
-   * duplicating the last one has to arrive carrying the same purchase gate a
-   * fresh pickup of a spent sticker would. Cloning the original's gate instead
-   * would be wrong in both directions: a copy of an already-bought draft would
-   * show a Place button the server refuses at `assertHasUse`, and a copy made
-   * after the purchase landed would ask to buy the sticker twice.
+   * `getStickerBalances` takes no input, so it genuinely shares the tray's cache
+   * entry. The offers query does NOT share it by accident — it is keyed on the
+   * OWNED ids inside `useStickerRefill`, which is the only way both callers ask
+   * the same question. Keying it on the drafted ids, as this did first, is a
+   * second request that refetches every time a draft is laid down.
    */
   const currentUser = useCurrentUser();
   const { data: balances } = trpc.cosmetic.getStickerBalances.useQuery(undefined, {
     enabled: !!currentUser && targetImageId != null,
   });
-  const draftedIds = useMemo(() => [...new Set(drafts.map((draft) => draft.cosmeticId))], [drafts]);
-  const { data: offers } = trpc.cosmetic.getStickerOffers.useQuery(
-    { ids: draftedIds.slice(0, STICKER_OFFER_LIMIT) },
-    { enabled: !!currentUser && !!draftedIds.length, staleTime: 60_000 }
-  );
+  const refillFor = useStickerRefill();
 
   const duplicateDraft = useStickerPlacementDraftStore((state) => state.duplicateDraft);
 
   const onDuplicate = useCallback(
     (id: string) => {
-      const source = useStickerPlacementDraftStore
-        .getState()
-        .drafts.find((draft) => draft.id === id);
+      const current = useStickerPlacementDraftStore.getState().drafts;
+      const source = current.find((draft) => draft.id === id);
       if (!source) return;
 
-      const balance = balances?.find((entry) => entry.cosmeticId === source.cosmeticId)?.remaining;
-      // `null` is unlimited. Every draft of this sticker already on the image is
-      // subtracted, including the one being copied: each of them will spend a use
-      // when it is bought, so the copy is only free of a gate while there is a
-      // use left AFTER all of them.
-      const drafted = useStickerPlacementDraftStore
-        .getState()
-        .drafts.filter((draft) => draft.cosmeticId === source.cosmeticId).length;
-      const spent = balance != null && balance - drafted <= 0;
-
-      if (!spent) return duplicateDraft(id);
-
-      // Out of uses, so the copy needs the same top-up offer a fresh pickup of a
-      // spent sticker gets. An offer that is not on sale leaves the copy gated
-      // with no way to buy — which is the truth, and the draft says so, rather
-      // than a Place button that fails at the mutation.
-      const offer = offers?.find((entry) => entry.cosmeticId === source.cosmeticId);
-      const listing = offer?.listing;
-
-      duplicateDraft(id, {
-        refill: true,
-        perUse: offer?.pricePerUse ?? undefined,
-        ...(listing
-          ? {
-              pack: {
-                shopItemId: listing.shopItemId,
-                unitAmount: listing.unitAmount,
-                acceptsBlue: listing.acceptsBlue,
-                uses: listing.uses,
-                viaShopUserId: listing.viaShopUserId ?? undefined,
-              },
-            }
-          : {}),
-        creatorUsername: offer ? offer.creatorUsername : undefined,
-      });
+      duplicateDraft(
+        id,
+        duplicateGateFor({
+          source,
+          drafts: current,
+          balances,
+          refillFor,
+          // The owned payload's price, so a copy made before the offers query
+          // lands is not frozen on "this sticker sells no extra uses".
+          ownedPricePerUse: sticker.find((option) => option.id === source.cosmeticId)?.pricePerUse,
+        })
+      );
     },
-    [balances, offers, duplicateDraft]
+    [balances, refillFor, duplicateDraft, sticker]
   );
 
   const gesture = useRef<Gesture | null>(null);

--- a/src/components/Sticker/StickerPlacementTray.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementTray.browser.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import type * as PlacementUtil from '~/components/Sticker/placement.util';
+import type * as StickerUtil from '~/components/Sticker/sticker.util';
 import type * as Trpc from '~/utils/trpc';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
@@ -72,11 +73,20 @@ vi.mock('~/store/sticker-placement-draft.store', () => ({
 
 // Owning nothing is the tray's simplest state and says nothing about the free
 // offer, which is the only thing this file asserts.
-vi.mock('~/components/Sticker/sticker.util', () => ({
+// Spread rather than hand-listed, which is not tidiness: a hand-written factory
+// replaces the module, so the day `sticker.util` gains an export this file omits,
+// the import fails and the WHOLE FILE collects zero tests — silently green. It
+// happened twice while the duplicate action was being built, once for
+// `useStickerRefill` and once for `remainingStickerUses`. Only the two hooks
+// that would reach the network are overridden.
+vi.mock('~/components/Sticker/sticker.util', async (importOriginal) => ({
+  ...(await importOriginal<typeof StickerUtil>()),
+  // Owning nothing is the tray's simplest state and says nothing about the free
+  // offer, which is the only thing this file asserts.
   useOwnedSticker: () => ({ sticker: [], isLoading: false }),
-  // The tray asks this for a top-up offer when a spent sticker is dragged out.
-  // Owning nothing, nothing here is ever spent — but the hook still has to
-  // exist, or the module fails to load and this file collects zero tests.
+  // Owning nothing, nothing here is ever spent — but the hook runs a query, so
+  // it is stubbed rather than left to reach a client this scaffold does not
+  // provide.
   useStickerRefill: () => () => ({ refill: true }),
 }));
 vi.mock('~/components/Sticker/StickerShopPanel', () => ({ StickerShopPanel: () => null }));

--- a/src/components/Sticker/StickerPlacementTray.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementTray.browser.test.tsx
@@ -5,6 +5,7 @@ import type * as StickerUtil from '~/components/Sticker/sticker.util';
 import type * as Trpc from '~/utils/trpc';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import { IsClientProvider } from '~/providers/IsClientProvider';
 import { StickerPlacementTray } from '~/components/Sticker/StickerPlacementTray';
 
 /**
@@ -111,27 +112,45 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
 }));
 
 const renderTray = async () => {
-  renderWithProviders(<StickerPlacementTray imageId={IMAGE_ID} />);
+  // 🔴 SCOPED HERE, NOT ADDED TO THE SHARED HARNESS. The tray renders a live
+  // countdown, and `useIsClient` THROWS rather than defaulting — but putting the
+  // provider in `renderWithProviders` breaks five other files on purpose:
+  // several `/apps` tests assert what the FIRST client paint looks like, and
+  // that is exactly the flag this provider flips.
+  renderWithProviders(
+    <IsClientProvider>
+      <StickerPlacementTray imageId={IMAGE_ID} />
+    </IsClientProvider>
+  );
   await expect.element(page.getByText(/Drag a sticker onto the image/)).toBeInTheDocument();
 };
 
 describe('StickerPlacementTray — the reason free is unavailable', () => {
-  test('says the allowance is spent, and what it is shared with, before anything is placed', async () => {
+  /**
+   * Justin, using it: the sentence had a summary after it — what the allowance is
+   * shared with, and when it comes back — and he asked for both to go. What
+   * replaces the "comes back" half is a live countdown, because a phrase like
+   * "comes back at midnight UTC" is still sitting there at 23:59 saying nothing
+   * useful.
+   */
+  test('says the allowance is spent, and counts down to the next one', async () => {
     Object.assign(queryState, {
       freeSlots: 1,
       freeSlotsRemaining: 1,
       remaining: 0,
       usedHere: false,
+      resetsAt: new Date(Date.now() + 3 * 60 * 60 * 1000),
     });
     await renderTray();
 
     await expect.element(page.getByText(/used today's free placement/)).toBeInTheDocument();
-    // The second ticket: this reader may well have spent it on a remix gallery,
-    // and without this clause the sticker surface cannot account for where it
-    // went.
-    await expect
-      .element(page.getByText(/shared between stickers and remix galleries/))
-      .toBeInTheDocument();
+    await expect.element(page.getByText(/Next free placement/)).toBeInTheDocument();
+
+    // The summary that used to follow it, both halves.
+    expect(page.getByText(/shared between stickers and remix galleries/).elements()).toHaveLength(
+      0
+    );
+    expect(page.getByText(/comes back at/).elements()).toHaveLength(0);
   });
 
   test('says a free sticker was already used on this image', async () => {

--- a/src/components/Sticker/StickerPlacementTray.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementTray.browser.test.tsx
@@ -74,6 +74,10 @@ vi.mock('~/store/sticker-placement-draft.store', () => ({
 // offer, which is the only thing this file asserts.
 vi.mock('~/components/Sticker/sticker.util', () => ({
   useOwnedSticker: () => ({ sticker: [], isLoading: false }),
+  // The tray asks this for a top-up offer when a spent sticker is dragged out.
+  // Owning nothing, nothing here is ever spent — but the hook still has to
+  // exist, or the module fails to load and this file collects zero tests.
+  useStickerRefill: () => () => ({ refill: true }),
 }));
 vi.mock('~/components/Sticker/StickerShopPanel', () => ({ StickerShopPanel: () => null }));
 vi.mock('~/components/Sticker/StickerShopTile', () => ({ StickerShopTile: () => null }));

--- a/src/components/Sticker/StickerPlacementTray.tsx
+++ b/src/components/Sticker/StickerPlacementTray.tsx
@@ -3,6 +3,7 @@ import { IconAlertTriangle, IconInfoCircle, IconPlus, IconSticker } from '@table
 import clsx from 'clsx';
 import { useEffect, useRef, useState } from 'react';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
+import { Countdown } from '~/components/Countdown/Countdown';
 import { freeOfferFor, preCommitFreeReason, trayNotes } from '~/components/Sticker/free-offer';
 import { StickerShopPanel } from '~/components/Sticker/StickerShopPanel';
 import { StickerShopTile } from '~/components/Sticker/StickerShopTile';
@@ -105,12 +106,15 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
    * appearing on ordinary paid images are two `&&`s nothing can observe.
    */
   const freeUnavailableReason = preCommitFreeReason(freeAvailable, standing, space);
+  // `Countdown` needs a Date; the query hands back whatever JSON carried.
+  const resetsAt = standing?.resetsAt ? new Date(standing.resetsAt) : null;
 
   const notes = trayNotes({
     freeAvailable,
     price,
     review: space?.mode === 'review',
     reason: freeUnavailableReason,
+    declineFee: space?.declineFee,
   });
   // Says the panel can be got out of the way, and that more than one is allowed,
   // only once there is something that would survive it. Before that both are
@@ -156,6 +160,18 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
                     )}
                     <Text size="xs" c={note.tone === 'warn' ? 'yellow.6' : 'dimmed'}>
                       {note.text}
+                      {/* The spent-allowance line is the one note whose answer
+                          keeps changing while the panel is open, so it says WHEN
+                          rather than a phrase that ages: a live countdown to the
+                          reset instead of "it comes back tomorrow" still sitting
+                          there at 11:59. Only on that note, and only when the
+                          server told us when. */}
+                      {note.id === 'reason' && standing && standing.remaining <= 0 && resetsAt && (
+                        <>
+                          {' Next free placement: '}
+                          <Countdown endTime={resetsAt} format="short" />
+                        </>
+                      )}
                     </Text>
                   </div>
                 ))}

--- a/src/components/Sticker/StickerPlacementTray.tsx
+++ b/src/components/Sticker/StickerPlacementTray.tsx
@@ -12,11 +12,7 @@ import {
   useImagePlacementSpace,
 } from '~/components/Sticker/placement.util';
 import { stickerMaxScale } from '~/shared/utils/sticker-placement';
-import {
-  remainingStickerUses,
-  useOwnedSticker,
-  useStickerRefill,
-} from '~/components/Sticker/sticker.util';
+import { remainingStickerUses, useOwnedSticker } from '~/components/Sticker/sticker.util';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
 import { trpc } from '~/utils/trpc';
@@ -81,15 +77,6 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
   // below, because the pickup gesture is a hook and cannot be conditional.
   const maxScale = stickerMaxScale(space?.settings as Record<string, unknown> | undefined);
   const { grab, dragging } = useStickerDragOut(maxScale);
-
-  /**
-   * What a spent sticker's draft may be refilled with, shared with the draft
-   * layer so both ask the same question of the same cache key. It was two copies
-   * of this rule keyed on two different id lists — the layer's refetched
-   * mid-arrangement, which is exactly what the comment that used to live here
-   * warned against.
-   */
-  const refillFor = useStickerRefill();
 
   if (!showing) return null;
 
@@ -221,15 +208,13 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
                   <button
                     key={option.id}
                     type="button"
-                    // An exhausted sticker drags out like any other. What is
-                    // different is the draft it makes: it carries the price of
-                    // one more use, and asks for that before it can be placed.
-                    // Arranging it first is the point — the same argument as
-                    // buying one from the shop, and the same gesture.
-                    onPointerDown={grab(
-                      option.id,
-                      exhausted ? refillFor(option.id, option.pricePerUse) : undefined
-                    )}
+                    // 🔴 NO GATE IS STORED HERE, DELIBERATELY. An exhausted
+                    // sticker drags out like any other and the draft layer
+                    // decides what it owes, because that answer changes as other
+                    // drafts come and go: freezing "you must buy this" onto the
+                    // draft is what left a sticker asking to be bought for a use
+                    // another draft had just handed back.
+                    onPointerDown={grab(option.id)}
                     className={clsx(
                       'flex shrink-0 cursor-grab flex-col items-center gap-1 rounded border p-2',
                       drafts.some((draft) => draft.cosmeticId === option.id) ||

--- a/src/components/Sticker/StickerPlacementTray.tsx
+++ b/src/components/Sticker/StickerPlacementTray.tsx
@@ -1,7 +1,7 @@
 import { Button, CloseButton, Group, ScrollArea, Text, ThemeIcon } from '@mantine/core';
 import { IconAlertTriangle, IconInfoCircle, IconPlus, IconSticker } from '@tabler/icons-react';
 import clsx from 'clsx';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
 import { freeOfferFor, preCommitFreeReason, trayNotes } from '~/components/Sticker/free-offer';
 import { StickerShopPanel } from '~/components/Sticker/StickerShopPanel';
@@ -12,10 +12,9 @@ import {
   useImagePlacementSpace,
 } from '~/components/Sticker/placement.util';
 import { stickerMaxScale } from '~/shared/utils/sticker-placement';
-import { useOwnedSticker } from '~/components/Sticker/sticker.util';
+import { useOwnedSticker, useStickerRefill } from '~/components/Sticker/sticker.util';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
-import { STICKER_OFFER_LIMIT } from '~/server/schema/cosmetic.schema';
 import { trpc } from '~/utils/trpc';
 
 /**
@@ -79,52 +78,14 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
   const maxScale = stickerMaxScale(space?.settings as Record<string, unknown> | undefined);
   const { grab, dragging } = useStickerDragOut(maxScale);
 
-  // Asked for every owned sticker rather than only the spent ones, because the
-  // list of spent ones changes as drafts are laid down — keying the query on it
-  // would refetch mid-arrangement, and the answer is the same either way.
-  // Capped at what the schema accepts. Past it the whole query fails zod, and
-  // the failure is invisible — `offers` stays undefined and the pack option
-  // silently never appears for anyone with a large collection. Newest-obtained
-  // first, which is the order the row is already in.
-  const ownedIds = useMemo(
-    () => sticker.slice(0, STICKER_OFFER_LIMIT).map((option) => option.id),
-    [sticker]
-  );
-  const { data: offers } = trpc.cosmetic.getStickerOffers.useQuery(
-    { ids: ownedIds },
-    { enabled: !!currentUser && !!ownedIds.length, staleTime: 60_000 }
-  );
   /**
-   * What a spent sticker's draft may be refilled with. The listing is offered
-   * only while it is genuinely on sale — a delisted or sold-out one would show a
-   * price the purchase then refuses.
-   *
-   * `pricePerUse` falls back to the owned payload's copy so the single-use price
-   * is there on the first frame, before the offers query lands.
+   * What a spent sticker's draft may be refilled with, shared with the draft
+   * layer so both ask the same question of the same cache key. It was two copies
+   * of this rule keyed on two different id lists — the layer's refetched
+   * mid-arrangement, which is exactly what the comment that used to live here
+   * warned against.
    */
-  const refillOffer = (cosmeticId: number, ownedPricePerUse?: number) => {
-    const offer = offers?.find((entry) => entry.cosmeticId === cosmeticId);
-    const listing = offer?.listing;
-
-    return {
-      refill: true,
-      perUse: offer?.pricePerUse ?? ownedPricePerUse,
-      ...(listing
-        ? {
-            pack: {
-              shopItemId: listing.shopItemId,
-              unitAmount: listing.unitAmount,
-              acceptsBlue: listing.acceptsBlue,
-              uses: listing.uses,
-              viaShopUserId: listing.viaShopUserId ?? undefined,
-            },
-          }
-        : {}),
-      // `undefined` until the offers land, which shows no attribution rather
-      // than crediting the wrong party while it is unknown.
-      creatorUsername: offer ? offer.creatorUsername : undefined,
-    };
-  };
+  const refillFor = useStickerRefill();
 
   if (!showing) return null;
 
@@ -265,7 +226,7 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
                     // buying one from the shop, and the same gesture.
                     onPointerDown={grab(
                       option.id,
-                      exhausted ? refillOffer(option.id, option.pricePerUse) : undefined
+                      exhausted ? refillFor(option.id, option.pricePerUse) : undefined
                     )}
                     className={clsx(
                       'flex shrink-0 cursor-grab flex-col items-center gap-1 rounded border p-2',

--- a/src/components/Sticker/StickerPlacementTray.tsx
+++ b/src/components/Sticker/StickerPlacementTray.tsx
@@ -12,7 +12,11 @@ import {
   useImagePlacementSpace,
 } from '~/components/Sticker/placement.util';
 import { stickerMaxScale } from '~/shared/utils/sticker-placement';
-import { useOwnedSticker, useStickerRefill } from '~/components/Sticker/sticker.util';
+import {
+  remainingStickerUses,
+  useOwnedSticker,
+  useStickerRefill,
+} from '~/components/Sticker/sticker.util';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
 import { trpc } from '~/utils/trpc';
@@ -95,12 +99,10 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
   // Drafts already on the image are subtracted, because each one will spend a
   // use when it is bought. Without this you could lay out three with one use
   // left and only find out at the third purchase, having arranged all of them.
-  const balanceFor = (cosmeticId: number) => {
-    const remaining = balances?.find((balance) => balance.cosmeticId === cosmeticId)?.remaining;
-    if (remaining == null) return remaining;
-    const drafted = drafts.filter((draft) => draft.cosmeticId === cosmeticId).length;
-    return Math.max(remaining - drafted, 0);
-  };
+  // Shared with the duplicate action, which asks the same question about the
+  // same three states. It was this rule written out twice, which is the drift
+  // the refill offer had already been split into two copies by.
+  const balanceFor = (cosmeticId: number) => remainingStickerUses({ balances, drafts, cosmeticId });
 
   const price = space?.price ?? 0;
   // The same predicate the draft's own control uses, so the sentence here and

--- a/src/components/Sticker/__tests__/draft-entitlements.test.ts
+++ b/src/components/Sticker/__tests__/draft-entitlements.test.ts
@@ -167,3 +167,83 @@ describe('allocating the free placement', () => {
     expect(freeIds(result)).toEqual(['owned']);
   });
 });
+
+/**
+ * 🔴 THE USE BELONGS TO THE DRAFT THAT PAID FOR IT.
+ *
+ * Coverage is otherwise assigned in creation order, so buying a use from the
+ * SECOND of two gated copies raised the balance and covered the FIRST: the
+ * button that was pressed did not change, which reads as a purchase that failed
+ * and invites paying again. Uses are fungible per sticker so no Buzz is lost —
+ * the wrong sticker simply becomes the placeable one.
+ */
+describe('a draft that paid for a use gets it', () => {
+  it('covers the draft that bought, not the one created first', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [draft('first'), draft('second')],
+      balances: owned(1),
+      freeAvailable: false,
+      paidDraftIds: ['second'],
+    });
+
+    expect(coveredIds(result)).toEqual(['second']);
+  });
+
+  it('resolves two purchases in the order they were made', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [draft('a'), draft('b'), draft('c')],
+      balances: owned(2),
+      freeAvailable: false,
+      paidDraftIds: ['c', 'b'],
+    });
+
+    expect(coveredIds(result).sort()).toEqual(['b', 'c']);
+  });
+
+  it('falls back to creation order for drafts nobody paid for', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [draft('a'), draft('b')],
+      balances: owned(1),
+      freeAvailable: false,
+      paidDraftIds: [],
+    });
+
+    expect(coveredIds(result)).toEqual(['a']);
+  });
+});
+
+/**
+ * 🔴 THE FREE PLACEMENT HAS TO GO TO A DRAFT THAT CAN TAKE IT.
+ *
+ * Chosen before coverage, it landed on a spent owned sticker — which then
+ * renders a buy button, and a draft with a gate hides the free option. Every
+ * other draft was told there was no free offer, so the placer had a free
+ * placement available and nowhere to spend it.
+ */
+describe('the free placement skips drafts that cannot use it', () => {
+  const freeIds = (result: Map<string, { free: boolean }>) =>
+    [...result].filter(([, value]) => value.free).map(([id]) => id);
+
+  it('passes over an uncovered draft to one that is covered', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [draft('spent', 42), draft('has-uses', 99)],
+      balances: [
+        { cosmeticId: 42, remaining: 0 },
+        { cosmeticId: 99, remaining: 3 },
+      ],
+      freeAvailable: true,
+    });
+
+    expect(freeIds(result)).toEqual(['has-uses']);
+  });
+
+  it('offers it to nobody when every draft needs buying first', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [draft('spent')],
+      balances: owned(0),
+      freeAvailable: true,
+    });
+
+    expect(freeIds(result)).toEqual([]);
+  });
+});

--- a/src/components/Sticker/__tests__/draft-entitlements.test.ts
+++ b/src/components/Sticker/__tests__/draft-entitlements.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { allocateDraftEntitlements } from '~/components/Sticker/sticker.util';
+
+/**
+ * 🔴 THE BUG JUSTIN FOUND BY USING IT.
+ *
+ * With one use left, laying out two stickers made the first placeable and the
+ * second ask to be bought — correct. Then deleting the FIRST left the second
+ * still asking, because the reason had been frozen onto it when it was created.
+ * The use had been handed back and nothing gave it to anybody.
+ *
+ * Entitlement is a property of the set of drafts, not of any one draft, so it is
+ * recomputed from the set every time the set changes.
+ */
+const draft = (id: string, cosmeticId = 42) => ({ id, cosmeticId });
+const owned = (remaining: number | null, cosmeticId = 42) => [{ cosmeticId, remaining }];
+
+const coveredIds = (result: Map<string, { covered: boolean }>) =>
+  [...result].filter(([, value]) => value.covered).map(([id]) => id);
+
+describe('allocating uses across the drafts on an image', () => {
+  it('covers as many drafts as there are uses, in the order they were laid down', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [draft('a'), draft('b'), draft('c')],
+      balances: owned(2),
+      freeAvailable: false,
+    });
+
+    expect(coveredIds(result)).toEqual(['a', 'b']);
+  });
+
+  /**
+   * The actual report: delete the covered one and the use it was holding has to
+   * move to the next draft rather than evaporating.
+   */
+  it('hands the use to the next draft when the covered one is deleted', () => {
+    const before = allocateDraftEntitlements({
+      drafts: [draft('a'), draft('b')],
+      balances: owned(1),
+      freeAvailable: false,
+    });
+    expect(coveredIds(before)).toEqual(['a']);
+
+    const after = allocateDraftEntitlements({
+      drafts: [draft('b')],
+      balances: owned(1),
+      freeAvailable: false,
+    });
+
+    expect(coveredIds(after)).toEqual(['b']);
+  });
+
+  it('counts each sticker separately', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [draft('a', 42), draft('b', 42), draft('c', 99)],
+      balances: [
+        { cosmeticId: 42, remaining: 1 },
+        { cosmeticId: 99, remaining: 1 },
+      ],
+      freeAvailable: false,
+    });
+
+    expect(coveredIds(result)).toEqual(['a', 'c']);
+  });
+
+  it('covers everything when the holding is unlimited', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [draft('a'), draft('b'), draft('c')],
+      balances: owned(null),
+      freeAvailable: false,
+    });
+
+    expect(coveredIds(result)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('covers nothing when the uses are spent', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [draft('a'), draft('b')],
+      balances: owned(0),
+      freeAvailable: false,
+    });
+
+    expect(coveredIds(result)).toEqual([]);
+  });
+
+  /**
+   * Unknown is not zero. Before the balances arrive — or for a sticker being
+   * bought outright, which has no holding — this rule has nothing to say, and
+   * the draft's own stored gate answers instead. Guessing "not covered" would
+   * put a buy button on every draft for a frame.
+   */
+  it('says nothing while the balances are unknown', () => {
+    const loading = allocateDraftEntitlements({
+      drafts: [draft('a'), draft('b')],
+      balances: undefined,
+      freeAvailable: false,
+    });
+    expect(coveredIds(loading)).toEqual(['a', 'b']);
+
+    const unowned = allocateDraftEntitlements({
+      drafts: [draft('a')],
+      balances: [],
+      freeAvailable: false,
+    });
+    expect(coveredIds(unowned)).toEqual(['a']);
+  });
+});
+
+/**
+ * The same rule, applied to the free placement — which Justin named in the same
+ * breath, and for the same reason. A free placement is once per image, so
+ * exactly one draft can be the free one, and it has to move when that draft goes.
+ */
+describe('allocating the free placement', () => {
+  const freeIds = (result: Map<string, { free: boolean }>) =>
+    [...result].filter(([, value]) => value.free).map(([id]) => id);
+
+  it('offers it to exactly one draft, not all of them', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [draft('a'), draft('b'), draft('c')],
+      balances: owned(null),
+      freeAvailable: true,
+    });
+
+    expect(freeIds(result)).toEqual(['a']);
+  });
+
+  it('moves it to the next draft when the free one is deleted', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [draft('b'), draft('c')],
+      balances: owned(null),
+      freeAvailable: true,
+    });
+
+    expect(freeIds(result)).toEqual(['b']);
+  });
+
+  it('offers it to nobody when there is no free placement on offer', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [draft('a')],
+      balances: owned(null),
+      freeAvailable: false,
+    });
+
+    expect(freeIds(result)).toEqual([]);
+  });
+
+  /**
+   * A sticker still being bought outright cannot take it: it has to be paid for
+   * before it can be placed at all, and that is not what free means here. The
+   * offer goes to the first draft that could actually keep it.
+   */
+  it('skips a draft that has to be bought before it can be placed', () => {
+    const result = allocateDraftEntitlements({
+      drafts: [
+        {
+          id: 'shop',
+          cosmeticId: 42,
+          purchase: { pack: { shopItemId: 1, unitAmount: 5, acceptsBlue: false } },
+        },
+        draft('owned'),
+      ],
+      balances: owned(null),
+      freeAvailable: true,
+    });
+
+    expect(freeIds(result)).toEqual(['owned']);
+  });
+});

--- a/src/components/Sticker/__tests__/duplicate-draft.test.ts
+++ b/src/components/Sticker/__tests__/duplicate-draft.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
+
+/**
+ * Duplicating a sticker makes a DRAFT and nothing else.
+ *
+ * That is the whole safety argument for this feature. Placement is charged, and
+ * the allowance behind it is not simple — one free placement per person per day,
+ * shared with remix galleries, plus a once-ever free slot per image. A second
+ * route into the charge path would have to reproduce every one of those guards
+ * and would be wrong the day one of them moved.
+ *
+ * So there is no second route: a duplicate is an unplaced draft, bought and
+ * committed by the same button and the same mutation as the first one. What is
+ * asserted here is that copying places nothing and charges nothing — and that
+ * the copy carries the purchase gate the CALLER decided on, rather than
+ * inheriting the original's, which is a fact about inventory at the moment the
+ * copy was made rather than a property of the draft.
+ */
+const purchase = {
+  pack: { shopItemId: 7, unitAmount: 500, acceptsBlue: false },
+  creatorUsername: 'maker',
+};
+
+const store = () => useStickerPlacementDraftStore.getState();
+const drafts = () => store().drafts;
+
+describe('duplicating a draft', () => {
+  beforeEach(() => {
+    store().close();
+    store().open(1);
+    store().begin(42, { x: 0.4, y: 0.5 }, 0.4);
+    store().move(drafts()[0].id, { rotation: 12, scale: 0.3, flip: true, opacity: 0.6 });
+  });
+
+  it('copies the arrangement, which is the point of copying rather than picking up', () => {
+    const original = drafts()[0];
+    store().duplicateDraft(original.id);
+
+    const copy = drafts()[1];
+    expect(copy).toMatchObject({
+      cosmeticId: original.cosmeticId,
+      imageId: original.imageId,
+      rotation: 12,
+      scale: 0.3,
+      flip: true,
+      opacity: 0.6,
+    });
+  });
+
+  it('is its own draft, not a second reference to the first', () => {
+    const original = drafts()[0];
+    store().duplicateDraft(original.id);
+
+    expect(drafts()).toHaveLength(2);
+    expect(drafts()[1].id).not.toBe(original.id);
+
+    // Moving the copy must not move the original, which a shared id would.
+    store().move(drafts()[1].id, { rotation: -30 });
+    expect(drafts()[0].rotation).toBe(12);
+  });
+
+  it('lands beside the original rather than exactly on top of it', () => {
+    const original = drafts()[0];
+    store().duplicateDraft(original.id);
+
+    const copy = drafts()[1];
+    expect(copy.x).toBeGreaterThan(original.x);
+    expect(copy.y).toBeGreaterThan(original.y);
+  });
+
+  /**
+   * A duplicate of a sticker already at the far edge would otherwise be offset
+   * off the image, where it cannot be seen or dragged back — and where the
+   * server refuses the placement for a position outside the bounds.
+   */
+  it('stays on the image when the original is at the edge', () => {
+    store().move(drafts()[0].id, { x: 1, y: 1 });
+    store().duplicateDraft(drafts()[0].id);
+
+    expect(drafts()[1]).toMatchObject({ x: 1, y: 1 });
+  });
+
+  it('selects the copy, because that is the one being positioned now', () => {
+    store().duplicateDraft(drafts()[0].id);
+
+    expect(store().selectedDraftId).toBe(drafts()[1].id);
+  });
+
+  it('does nothing at all for an id that is not there', () => {
+    store().duplicateDraft('not-a-draft');
+
+    expect(drafts()).toHaveLength(1);
+  });
+
+  describe('the purchase gate is the caller’s decision, not the original’s', () => {
+    it('gates the copy when the caller says it must be bought', () => {
+      store().duplicateDraft(drafts()[0].id, purchase);
+
+      expect(drafts()[1].purchase).toEqual(purchase);
+    });
+
+    /**
+     * 🔴 The one that would sell the same use twice. The original was dragged out
+     * of the shop and is still unbought; by the time the copy is made the caller
+     * has seen a use available and passes nothing. Cloning the original's gate
+     * here would put a second buy button on a sticker that needs buying once.
+     */
+    it('does not inherit the original’s gate when the caller passes none', () => {
+      store().close();
+      store().open(1);
+      store().begin(42, { x: 0.4, y: 0.5 }, 0.4, purchase);
+      expect(drafts()[0].purchase).toEqual(purchase);
+
+      store().duplicateDraft(drafts()[0].id);
+
+      expect(drafts()[1].purchase).toBeUndefined();
+    });
+
+    /**
+     * The opposite direction, and the one that matters for money: the original
+     * was placed with a use the placer had, the copy needs another and there is
+     * none left. The caller sees that and hands over the top-up offer.
+     */
+    it('gates a copy of an ungated draft when the uses have run out', () => {
+      expect(drafts()[0].purchase).toBeUndefined();
+
+      store().duplicateDraft(drafts()[0].id, { ...purchase, refill: true });
+
+      expect(drafts()[1].purchase).toMatchObject({ refill: true });
+    });
+  });
+
+  it('places nothing and charges nothing — it only adds a draft', () => {
+    const before = drafts().length;
+    store().duplicateDraft(drafts()[0].id);
+
+    // The only observable effect is one more unplaced draft. Nothing here can
+    // reach the mutation: the store holds no network client at all.
+    expect(drafts()).toHaveLength(before + 1);
+    expect(drafts().every((draft) => draft.imageId === 1)).toBe(true);
+  });
+});

--- a/src/components/Sticker/__tests__/duplicate-draft.test.ts
+++ b/src/components/Sticker/__tests__/duplicate-draft.test.ts
@@ -70,15 +70,27 @@ describe('duplicating a draft', () => {
   });
 
   /**
-   * A duplicate of a sticker already at the far edge would otherwise be offset
-   * off the image, where it cannot be seen or dragged back — and where the
-   * server refuses the placement for a position outside the bounds.
+   * 🔴 THE CASE THE OFFSET EXISTS FOR, AND THE ONE AN EARLIER VERSION OF THIS
+   * TEST ASSERTED BACKWARDS.
+   *
+   * Clamping the nudge produced a copy at exactly the original's position — the
+   * invisible overlap the offset is there to prevent — and this test asserted
+   * that overlap as correct, so the defect was pinned rather than caught. The
+   * copy has to be somewhere else, and still on the image: a position outside
+   * the bounds is one the server refuses.
    */
-  it('stays on the image when the original is at the edge', () => {
+  it('lands somewhere else, and still on the image, at the far edge', () => {
     store().move(drafts()[0].id, { x: 1, y: 1 });
     store().duplicateDraft(drafts()[0].id);
 
-    expect(drafts()[1]).toMatchObject({ x: 1, y: 1 });
+    const [original, copy] = drafts();
+
+    expect(copy.x).not.toBe(original.x);
+    expect(copy.y).not.toBe(original.y);
+    expect(copy.x).toBeGreaterThanOrEqual(0);
+    expect(copy.x).toBeLessThanOrEqual(1);
+    expect(copy.y).toBeGreaterThanOrEqual(0);
+    expect(copy.y).toBeLessThanOrEqual(1);
   });
 
   it('selects the copy, because that is the one being positioned now', () => {
@@ -88,9 +100,13 @@ describe('duplicating a draft', () => {
   });
 
   it('does nothing at all for an id that is not there', () => {
+    const before = store().selectedDraftId;
     store().duplicateDraft('not-a-draft');
 
     expect(drafts()).toHaveLength(1);
+    // Also asserted: a miss does not move the selection. Without this an
+    // implementation that cleared it on the way out would pass.
+    expect(store().selectedDraftId).toBe(before);
   });
 
   describe('the purchase gate is the caller’s decision, not the original’s', () => {
@@ -129,15 +145,5 @@ describe('duplicating a draft', () => {
 
       expect(drafts()[1].purchase).toMatchObject({ refill: true });
     });
-  });
-
-  it('places nothing and charges nothing — it only adds a draft', () => {
-    const before = drafts().length;
-    store().duplicateDraft(drafts()[0].id);
-
-    // The only observable effect is one more unplaced draft. Nothing here can
-    // reach the mutation: the store holds no network client at all.
-    expect(drafts()).toHaveLength(before + 1);
-    expect(drafts().every((draft) => draft.imageId === 1)).toBe(true);
   });
 });

--- a/src/components/Sticker/__tests__/duplicate-gate.test.ts
+++ b/src/components/Sticker/__tests__/duplicate-gate.test.ts
@@ -131,3 +131,41 @@ describe('remaining uses', () => {
     expect(remainingStickerUses({ balances: owned(1), drafts, cosmeticId: 42 })).toBe(0);
   });
 });
+
+/**
+ * 🔴 THE DEPENDENCY THE UNOWNED BRANCH RESTS ON, PINNED.
+ *
+ * `duplicateGateFor` gives a copy of an unbought shop sticker the SAME gate as
+ * its original, which is only right because one purchase grants the sticker and
+ * `markPurchased(cosmeticId)` then frees every draft of it. Scope that per-draft
+ * later and the branch silently becomes "sell the same sticker twice" — with no
+ * test failing, because the gate decision itself would still be correct.
+ */
+describe('one purchase frees every copy of the sticker', () => {
+  it('lifts the gate from the original and its duplicate together', async () => {
+    const { useStickerPlacementDraftStore } = await import('~/store/sticker-placement-draft.store');
+    const store = () => useStickerPlacementDraftStore.getState();
+
+    store().close();
+    store().open(1);
+    store().begin(42, { x: 0.4, y: 0.4 }, 0.4, pack);
+
+    const originalId = store().drafts[0].id;
+    // The gate the unowned branch hands a copy: the source's own.
+    store().duplicateDraft(
+      originalId,
+      duplicateGateFor({
+        source: store().drafts[0],
+        drafts: store().drafts,
+        balances: [],
+        refillFor,
+      })
+    );
+
+    expect(store().drafts.map((draft) => draft.purchase)).toEqual([pack, pack]);
+
+    store().markPurchased(42);
+
+    expect(store().drafts.map((draft) => draft.purchase)).toEqual([undefined, undefined]);
+  });
+});

--- a/src/components/Sticker/__tests__/duplicate-gate.test.ts
+++ b/src/components/Sticker/__tests__/duplicate-gate.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+import { duplicateGateFor, remainingStickerUses } from '~/components/Sticker/sticker.util';
+
+/**
+ * Whether a duplicated sticker has to be bought — the money decision, and the
+ * part that was wrong.
+ *
+ * It lived as a closure inside `DraftStickerLayer`, where nothing could test it,
+ * and three independent reviews found the same defect in it: a sticker dragged
+ * from the shop has NO balance row, which the old code read as "not spent" and
+ * therefore "no gate" — producing a Place button on a sticker nobody had bought,
+ * which the server refuses at `assertHasUse` after taking an escrow hold.
+ *
+ * Every branch below is one of those cases, asserted directly rather than
+ * through a component that cannot reach them.
+ */
+const pack = {
+  pack: { shopItemId: 7, unitAmount: 500, acceptsBlue: false },
+  creatorUsername: 'maker',
+};
+
+const refill = { refill: true, perUse: 25, creatorUsername: 'maker' };
+const refillFor = () => refill;
+
+const owned = (remaining: number | null) => [{ cosmeticId: 42, remaining }];
+const source = (purchase?: typeof pack) => ({ cosmeticId: 42, purchase });
+
+describe('the gate on a duplicated draft', () => {
+  it('keeps the source gate for a sticker the viewer does not own', () => {
+    // The shop-dragged case: balances loaded, no row for this cosmetic. One
+    // purchase grants the sticker and frees every draft of it, so the copy must
+    // carry the same gate rather than none.
+    expect(duplicateGateFor({ source: source(pack), drafts: [], balances: [], refillFor })).toEqual(
+      pack
+    );
+  });
+
+  it('keeps the source gate while the balances are still loading', () => {
+    // Indistinguishable from "not owned" at this layer, and the honest answer is
+    // the same one. Guessing "has uses" is what shipped a Place button that
+    // could not be placed.
+    expect(
+      duplicateGateFor({ source: source(pack), drafts: [], balances: undefined, refillFor })
+    ).toEqual(pack);
+  });
+
+  it('gates nothing when the sticker is unlimited', () => {
+    expect(
+      duplicateGateFor({ source: source(), drafts: [], balances: owned(null), refillFor })
+    ).toBeUndefined();
+  });
+
+  it('gates nothing while a use remains after every draft', () => {
+    const drafts = [{ cosmeticId: 42 }];
+
+    expect(
+      duplicateGateFor({ source: source(), drafts, balances: owned(2), refillFor })
+    ).toBeUndefined();
+  });
+
+  /**
+   * The arithmetic that decides who pays. Every draft of the sticker already on
+   * the image spends a use when it is bought — including the one being copied —
+   * so a single use with one draft against it is already committed.
+   */
+  it('offers a top-up when the drafts already on the image spend the last use', () => {
+    const drafts = [{ cosmeticId: 42 }];
+
+    expect(duplicateGateFor({ source: source(), drafts, balances: owned(1), refillFor })).toEqual(
+      refill
+    );
+  });
+
+  it('offers a top-up when the sticker is outright spent', () => {
+    expect(
+      duplicateGateFor({ source: source(), drafts: [], balances: owned(0), refillFor })
+    ).toEqual(refill);
+  });
+
+  it('passes the owned price through, so a copy is never stuck on “sells no uses”', () => {
+    const spy = vi.fn(() => refill);
+
+    duplicateGateFor({
+      source: source(),
+      drafts: [],
+      balances: owned(0),
+      refillFor: spy,
+      ownedPricePerUse: 25,
+    });
+
+    expect(spy).toHaveBeenCalledWith(42, 25);
+  });
+
+  it('ignores drafts of other stickers', () => {
+    const drafts = [{ cosmeticId: 99 }, { cosmeticId: 99 }];
+
+    expect(
+      duplicateGateFor({ source: source(), drafts, balances: owned(1), refillFor })
+    ).toBeUndefined();
+  });
+});
+
+/**
+ * The three states, kept apart. Collapsing "not loaded" into either of the other
+ * two is the bug above in its general form.
+ */
+describe('remaining uses', () => {
+  it('is undefined before the balances arrive', () => {
+    expect(
+      remainingStickerUses({ balances: undefined, drafts: [], cosmeticId: 42 })
+    ).toBeUndefined();
+  });
+
+  it('is undefined for a sticker with no holding, which is not the same as zero', () => {
+    expect(remainingStickerUses({ balances: [], drafts: [], cosmeticId: 42 })).toBeUndefined();
+  });
+
+  it('is null for an unlimited holding', () => {
+    expect(remainingStickerUses({ balances: owned(null), drafts: [], cosmeticId: 42 })).toBeNull();
+  });
+
+  it('subtracts every draft of that sticker', () => {
+    const drafts = [{ cosmeticId: 42 }, { cosmeticId: 42 }, { cosmeticId: 99 }];
+
+    expect(remainingStickerUses({ balances: owned(5), drafts, cosmeticId: 42 })).toBe(3);
+  });
+
+  it('floors at zero rather than going negative', () => {
+    const drafts = [{ cosmeticId: 42 }, { cosmeticId: 42 }, { cosmeticId: 42 }];
+
+    expect(remainingStickerUses({ balances: owned(1), drafts, cosmeticId: 42 })).toBe(0);
+  });
+});

--- a/src/components/Sticker/__tests__/duplicate-gate.test.ts
+++ b/src/components/Sticker/__tests__/duplicate-gate.test.ts
@@ -1,145 +1,60 @@
-import { describe, expect, it, vi } from 'vitest';
-import { duplicateGateFor, remainingStickerUses } from '~/components/Sticker/sticker.util';
+import { describe, expect, it } from 'vitest';
+import { unownedGateFor } from '~/components/Sticker/sticker.util';
 
 /**
- * Whether a duplicated sticker has to be bought — the money decision, and the
- * part that was wrong.
+ * What a copy inherits, and — more importantly — what it does not.
  *
- * It lived as a closure inside `DraftStickerLayer`, where nothing could test it,
- * and three independent reviews found the same defect in it: a sticker dragged
- * from the shop has NO balance row, which the old code read as "not spent" and
- * therefore "no gate" — producing a Place button on a sticker nobody had bought,
- * which the server refuses at `assertHasUse` after taking an escrow hold.
+ * 🔴 THE REFILL GATE USED TO BE DECIDED HERE AND WRITTEN ONTO THE COPY. That is
+ * a fact about the moment the copy was made rather than about the copy, and it
+ * went stale the instant another draft was deleted: the use came back and the
+ * copy carried on asking to be bought for it. Justin found that twice — the
+ * first fix moved the decision for RENDERING but left this path still storing
+ * one, so duplicates stayed frozen while dragged-out stickers no longer were.
  *
- * Every branch below is one of those cases, asserted directly rather than
- * through a component that cannot reach them.
+ * Whether an owned sticker has a use left now belongs to
+ * `allocateDraftEntitlements`, recomputed across every draft on every render.
+ * Nothing stores it. What is left here is the one gate that genuinely belongs to
+ * a draft: this sticker is not owned yet and has to be bought.
  */
 const pack = {
   pack: { shopItemId: 7, unitAmount: 500, acceptsBlue: false },
   creatorUsername: 'maker',
 };
 
-const refill = { refill: true, perUse: 25, creatorUsername: 'maker' };
-const refillFor = () => refill;
-
-const owned = (remaining: number | null) => [{ cosmeticId: 42, remaining }];
-const source = (purchase?: typeof pack) => ({ cosmeticId: 42, purchase });
-
-describe('the gate on a duplicated draft', () => {
-  it('keeps the source gate for a sticker the viewer does not own', () => {
-    // The shop-dragged case: balances loaded, no row for this cosmetic. One
-    // purchase grants the sticker and frees every draft of it, so the copy must
-    // carry the same gate rather than none.
-    expect(duplicateGateFor({ source: source(pack), drafts: [], balances: [], refillFor })).toEqual(
-      pack
-    );
+describe('the gate a copy inherits', () => {
+  it('carries the not-owned-yet purchase, because one buy grants every copy', () => {
+    expect(unownedGateFor({ purchase: pack })).toEqual(pack);
   });
 
-  it('keeps the source gate while the balances are still loading', () => {
-    // Indistinguishable from "not owned" at this layer, and the honest answer is
-    // the same one. Guessing "has uses" is what shipped a Place button that
-    // could not be placed.
-    expect(
-      duplicateGateFor({ source: source(pack), drafts: [], balances: undefined, refillFor })
-    ).toEqual(pack);
-  });
-
-  it('gates nothing when the sticker is unlimited', () => {
-    expect(
-      duplicateGateFor({ source: source(), drafts: [], balances: owned(null), refillFor })
-    ).toBeUndefined();
-  });
-
-  it('gates nothing while a use remains after every draft', () => {
-    const drafts = [{ cosmeticId: 42 }];
-
-    expect(
-      duplicateGateFor({ source: source(), drafts, balances: owned(2), refillFor })
-    ).toBeUndefined();
+  it('carries nothing for an owned sticker', () => {
+    expect(unownedGateFor({})).toBeUndefined();
   });
 
   /**
-   * The arithmetic that decides who pays. Every draft of the sticker already on
-   * the image spends a use when it is bought — including the one being copied —
-   * so a single use with one draft against it is already committed.
+   * The regression in one assertion. A refill gate must never travel with a
+   * copy: the moment another draft is deleted, the use it was waiting for is
+   * available and the allocation says so — but only if nothing has written the
+   * old answer onto the draft.
    */
-  it('offers a top-up when the drafts already on the image spend the last use', () => {
-    const drafts = [{ cosmeticId: 42 }];
+  it('refuses to carry a refill gate, which is what went stale', () => {
+    const refill = { refill: true, perUse: 25, pack: { ...pack.pack, uses: 1 } };
 
-    expect(duplicateGateFor({ source: source(), drafts, balances: owned(1), refillFor })).toEqual(
-      refill
-    );
+    expect(unownedGateFor({ purchase: refill })).toBeUndefined();
   });
 
-  it('offers a top-up when the sticker is outright spent', () => {
-    expect(
-      duplicateGateFor({ source: source(), drafts: [], balances: owned(0), refillFor })
-    ).toEqual(refill);
-  });
-
-  it('passes the owned price through, so a copy is never stuck on “sells no uses”', () => {
-    const spy = vi.fn(() => refill);
-
-    duplicateGateFor({
-      source: source(),
-      drafts: [],
-      balances: owned(0),
-      refillFor: spy,
-      ownedPricePerUse: 25,
-    });
-
-    expect(spy).toHaveBeenCalledWith(42, 25);
-  });
-
-  it('ignores drafts of other stickers', () => {
-    const drafts = [{ cosmeticId: 99 }, { cosmeticId: 99 }];
-
-    expect(
-      duplicateGateFor({ source: source(), drafts, balances: owned(1), refillFor })
-    ).toBeUndefined();
+  it('carries nothing for a gate with no pack at all', () => {
+    expect(unownedGateFor({ purchase: { refill: true, perUse: 25 } })).toBeUndefined();
   });
 });
 
 /**
- * The three states, kept apart. Collapsing "not loaded" into either of the other
- * two is the bug above in its general form.
- */
-describe('remaining uses', () => {
-  it('is undefined before the balances arrive', () => {
-    expect(
-      remainingStickerUses({ balances: undefined, drafts: [], cosmeticId: 42 })
-    ).toBeUndefined();
-  });
-
-  it('is undefined for a sticker with no holding, which is not the same as zero', () => {
-    expect(remainingStickerUses({ balances: [], drafts: [], cosmeticId: 42 })).toBeUndefined();
-  });
-
-  it('is null for an unlimited holding', () => {
-    expect(remainingStickerUses({ balances: owned(null), drafts: [], cosmeticId: 42 })).toBeNull();
-  });
-
-  it('subtracts every draft of that sticker', () => {
-    const drafts = [{ cosmeticId: 42 }, { cosmeticId: 42 }, { cosmeticId: 99 }];
-
-    expect(remainingStickerUses({ balances: owned(5), drafts, cosmeticId: 42 })).toBe(3);
-  });
-
-  it('floors at zero rather than going negative', () => {
-    const drafts = [{ cosmeticId: 42 }, { cosmeticId: 42 }, { cosmeticId: 42 }];
-
-    expect(remainingStickerUses({ balances: owned(1), drafts, cosmeticId: 42 })).toBe(0);
-  });
-});
-
-/**
- * 🔴 THE DEPENDENCY THE UNOWNED BRANCH RESTS ON, PINNED.
+ * 🔴 THE DEPENDENCY THE INHERITED GATE RESTS ON, PINNED.
  *
- * `duplicateGateFor` gives a copy of an unbought shop sticker the SAME gate as
- * its original, which is only right because one purchase grants the sticker and
- * `markPurchased(cosmeticId)` then frees every draft of it. Scope that per-draft
- * later and the branch silently becomes "sell the same sticker twice" — with no
- * test failing, because the gate decision itself would still be correct.
+ * Giving a copy of an unbought sticker the SAME gate is only right because one
+ * purchase grants the sticker and `markPurchased(cosmeticId)` then frees every
+ * draft of it. Scope that per-draft later and this silently becomes "sell the
+ * same sticker twice", with no test failing, because the gate itself would still
+ * be correct.
  */
 describe('one purchase frees every copy of the sticker', () => {
   it('lifts the gate from the original and its duplicate together', async () => {
@@ -151,16 +66,7 @@ describe('one purchase frees every copy of the sticker', () => {
     store().begin(42, { x: 0.4, y: 0.4 }, 0.4, pack);
 
     const originalId = store().drafts[0].id;
-    // The gate the unowned branch hands a copy: the source's own.
-    store().duplicateDraft(
-      originalId,
-      duplicateGateFor({
-        source: store().drafts[0],
-        drafts: store().drafts,
-        balances: [],
-        refillFor,
-      })
-    );
+    store().duplicateDraft(originalId, unownedGateFor(store().drafts[0]));
 
     expect(store().drafts.map((draft) => draft.purchase)).toEqual([pack, pack]);
 

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -69,8 +69,17 @@ describe('what a refused free claim says', () => {
     );
   });
 
-  it('names the reset when the day is spent', () => {
-    expect(freeRefusalMessage({ remaining: 0, usedHere: false }, HAS_SLOT)).toMatch(/midnight UTC/);
+  /**
+   * The sentence no longer names WHEN. The reset is a live countdown beside it
+   * now — a phrase like "comes back at midnight UTC" is still sitting there at
+   * 23:59 saying nothing useful, and Justin asked for the time remaining
+   * instead. What this still has to say is WHICH refusal it is.
+   */
+  it('says the day is spent, without dating it', () => {
+    const message = freeRefusalMessage({ remaining: 0, usedHere: false }, HAS_SLOT);
+
+    expect(message).toMatch(/used today's free placement/);
+    expect(message).not.toMatch(/UTC|comes back/);
   });
 
   it('names the race when the last slot went to somebody else', () => {
@@ -222,7 +231,7 @@ describe('the refusal ladder is ordered, not merely complete', () => {
       BOTH_SPENT,
       /already used a free sticker on this image/,
     ],
-    ['a spent day outranks a full space', FULL, SPENT, /midnight UTC/],
+    ['a spent day outranks a full space', FULL, SPENT, /used today's free placement/],
   ])('%s', (_name, space, standing, expected) => {
     expect(freeRefusalMessage(standing, space)).toMatch(expected);
   });
@@ -417,38 +426,6 @@ describe('the tray says its piece in short lines', () => {
   it('keeps each line separate and short', () => {
     for (const note of trayNotes({ freeAvailable: true, price: 700, review: true }))
       expect(note.text.length).toBeLessThan(60);
-  });
-});
-
-/**
- * When the allowance comes back, taken from the value the server computed rather
- * than from a boundary written down twice.
- */
-describe('the reset the refusal names', () => {
-  const spent = { remaining: 0, usedHere: false };
-  const open = { freeSlots: 4, freeSlotsRemaining: 2 };
-
-  it('uses the reset the server shipped', () => {
-    expect(
-      freeRefusalMessage({ ...spent, resetsAt: new Date('2026-08-18T00:00:00Z') }, open)
-    ).toMatch(/comes back at 00:00 UTC/);
-  });
-
-  /**
-   * The point of deriving it: the day boundary is the server's rule, so a
-   * different one has to change this sentence rather than leave it wrong.
-   */
-  it('follows a reset that is not midnight', () => {
-    expect(
-      freeRefusalMessage({ ...spent, resetsAt: new Date('2026-08-18T06:30:00Z') }, open)
-    ).toMatch(/comes back at 06:30 UTC/);
-  });
-
-  it('still says when it lifts if the reset never arrived', () => {
-    expect(freeRefusalMessage(spent, open)).toMatch(/comes back at midnight UTC/);
-    expect(freeRefusalMessage({ ...spent, resetsAt: 'not a date' }, open)).toMatch(
-      /comes back at midnight UTC/
-    );
   });
 });
 
@@ -667,5 +644,41 @@ describe('the shared-allowance note tracks the rules it describes', () => {
    */
   it('fails if a surface is added to the shared budget without updating the copy', () => {
     expect(Object.keys(PLACEMENT_SURFACES).sort()).toEqual(['remixGallery', 'sticker']);
+  });
+});
+
+/**
+ * The decline caveat names the amount.
+ *
+ * Justin, using it: "we should tell them the exact amount... they keep X amount
+ * of buzz, whatever that value is." A placer cannot work it out themselves —
+ * the rate is operator-tunable and floors at 1⚡ — and it is the number that
+ * actually leaves their wallet.
+ */
+describe('what the decline caveat says', () => {
+  const paid = { freeAvailable: false, price: 500, review: true };
+
+  it('names the amount the creator keeps', () => {
+    const note = trayNotes({ ...paid, declineFee: 25 }).find((entry) => entry.id === 'decline');
+
+    expect(note?.text).toBe('If they decline, they keep 25 Buzz');
+  });
+
+  /**
+   * Not known yet is not zero. Before the space loads there is no fee to name,
+   * and "they keep 0 Buzz" would be a false statement rather than a vague one.
+   */
+  it('stays vague while the fee is unknown', () => {
+    const note = trayNotes(paid).find((entry) => entry.id === 'decline');
+
+    expect(note?.text).toBe('If they decline, part of what you paid stays with them');
+  });
+
+  it('says nothing about money on a free placement', () => {
+    const note = trayNotes({ ...paid, freeAvailable: true, declineFee: 25 }).find(
+      (entry) => entry.id === 'decline'
+    );
+
+    expect(note?.text).not.toMatch(/Buzz/);
   });
 });

--- a/src/components/Sticker/__tests__/pack-purchase-key.test.ts
+++ b/src/components/Sticker/__tests__/pack-purchase-key.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
+
+/**
+ * The idempotency key a pack purchase is charged under.
+ *
+ * 🔴 THIS IS THE ONE WHOSE FAILURE MODE IS CHARGING SOMEONE TWICE, and it had no
+ * test at all until a review said so. A pack grants the STICKER — `markPurchased`
+ * then frees every draft of it — so two copies of one sticker showing two buy
+ * buttons are one buying intent wearing two faces. Minted per draft, pressing
+ * both inside a second was two keys and two charges for something you get once.
+ * Duplicating put those two buttons a click apart.
+ */
+const store = () => useStickerPlacementDraftStore.getState();
+
+describe('the pack purchase key', () => {
+  beforeEach(() => {
+    store().close();
+    store().open(1);
+  });
+
+  it('is the same key for the same sticker, which is the whole point', () => {
+    expect(store().packPurchaseKey(42)).toBe(store().packPurchaseKey(42));
+  });
+
+  it('is a different key for a different sticker', () => {
+    expect(store().packPurchaseKey(42)).not.toBe(store().packPurchaseKey(43));
+  });
+
+  /**
+   * Two sessions are two intents: someone who buys a pack, spends it, and comes
+   * back later to buy the same pack again must not be refused as a duplicate.
+   */
+  it('is forgotten when the session ends', () => {
+    const first = store().packPurchaseKey(42);
+    store().close();
+    store().open(1);
+
+    expect(store().packPurchaseKey(42)).not.toBe(first);
+  });
+
+  /**
+   * But NOT forgotten by re-opening the same image mid-session — the tray can be
+   * put away and brought back with drafts alive, and that is one intent still.
+   */
+  it('survives re-opening the image it was minted on', () => {
+    const first = store().packPurchaseKey(42);
+    store().open(1);
+
+    expect(store().packPurchaseKey(42)).toBe(first);
+  });
+
+  /**
+   * A failed purchase ends the attempt. Reusing its key would have a server that
+   * records failed keys refuse every later attempt this session, locking the
+   * placer out of a sticker they are trying to buy.
+   */
+  it('mints a new key after a failure clears the old one', () => {
+    const first = store().packPurchaseKey(42);
+    store().clearPackPurchaseKey(42);
+
+    expect(store().packPurchaseKey(42)).not.toBe(first);
+  });
+
+  it('clearing one sticker leaves the others alone', () => {
+    const other = store().packPurchaseKey(43);
+    store().packPurchaseKey(42);
+    store().clearPackPurchaseKey(42);
+
+    expect(store().packPurchaseKey(43)).toBe(other);
+  });
+});

--- a/src/components/Sticker/__tests__/pack-purchase-key.test.ts
+++ b/src/components/Sticker/__tests__/pack-purchase-key.test.ts
@@ -74,35 +74,47 @@ describe('the pack purchase key', () => {
 /**
  * 🔴 WHICH FAILURES RELEASE THE KEY.
  *
- * Releasing it after a refusal is right — the attempt is over and the next press
- * is a new intent. Releasing it after a TIMEOUT is how one purchase becomes two:
- * the charge may well have gone through, and a fresh key makes the retry a
- * second, separate purchase. So the default is to hold.
+ * Releasing after a refusal is right — the attempt is over and the next press is
+ * a new intent. Releasing after a TIMEOUT is how one purchase becomes two: the
+ * charge may well have gone through, and a fresh key makes the retry a second,
+ * separate purchase.
+ *
+ * ⚠️ THE FIRST VERSION OF THIS TEST PASSED AGAINST INVENTED SERVER MESSAGES. It
+ * matched a hand-written list of refusal wordings, and the fixtures were written
+ * to match the list rather than to match the server — so it certified a
+ * classifier that missed seven of the ten real refusals, including the
+ * re-priced-listing case it was supposed to be for. The rule is structural now,
+ * and these fixtures are tRPC error shapes rather than sentences.
  */
-describe('classifying a failed purchase', () => {
-  it('releases on refusals the server states', async () => {
-    const { purchaseDefinitelyDidNotCharge } = await import('~/components/Sticker/sticker.util');
+const trpcError = (httpStatus: number) => ({ data: { httpStatus } });
 
-    for (const message of [
-      'Insufficient funds',
-      'This purchase has already been completed',
-      'That price has changed',
-      'You already own this cosmetic',
-    ])
-      expect(purchaseDefinitelyDidNotCharge(new Error(message))).toBe(true);
+describe('classifying a failed purchase', () => {
+  it('releases on anything the server declined', async () => {
+    const { purchaseCanBeRetriedFresh } = await import('~/components/Sticker/sticker.util');
+
+    // 400 covers every refusal in the purchase path now that they are TRPCErrors;
+    // the others are here because the rule is the class, not the number.
+    for (const status of [400, 401, 403, 404, 409, 422])
+      expect(purchaseCanBeRetriedFresh(trpcError(status))).toBe(true);
   });
 
-  it('holds the key on anything it cannot read as a refusal', async () => {
-    const { purchaseDefinitelyDidNotCharge } = await import('~/components/Sticker/sticker.util');
+  /**
+   * Everything that might have charged. A network failure has no `data` at all,
+   * which is exactly the case the old string matching could not see.
+   */
+  it('holds the key on anything that might have gone through', async () => {
+    const { purchaseCanBeRetriedFresh } = await import('~/components/Sticker/sticker.util');
 
     for (const error of [
-      new Error('fetch failed'),
+      trpcError(500),
+      trpcError(502),
+      trpcError(504),
+      new Error('Failed to fetch'),
       new Error('The operation timed out'),
-      new Error('Internal server error'),
-      new Error(''),
+      {},
+      null,
       undefined,
-      { message: 'insufficient' },
     ])
-      expect(purchaseDefinitelyDidNotCharge(error)).toBe(false);
+      expect(purchaseCanBeRetriedFresh(error)).toBe(false);
   });
 });

--- a/src/components/Sticker/__tests__/pack-purchase-key.test.ts
+++ b/src/components/Sticker/__tests__/pack-purchase-key.test.ts
@@ -70,3 +70,39 @@ describe('the pack purchase key', () => {
     expect(store().packPurchaseKey(43)).toBe(other);
   });
 });
+
+/**
+ * 🔴 WHICH FAILURES RELEASE THE KEY.
+ *
+ * Releasing it after a refusal is right — the attempt is over and the next press
+ * is a new intent. Releasing it after a TIMEOUT is how one purchase becomes two:
+ * the charge may well have gone through, and a fresh key makes the retry a
+ * second, separate purchase. So the default is to hold.
+ */
+describe('classifying a failed purchase', () => {
+  it('releases on refusals the server states', async () => {
+    const { purchaseDefinitelyDidNotCharge } = await import('~/components/Sticker/sticker.util');
+
+    for (const message of [
+      'Insufficient funds',
+      'This purchase has already been completed',
+      'That price has changed',
+      'You already own this cosmetic',
+    ])
+      expect(purchaseDefinitelyDidNotCharge(new Error(message))).toBe(true);
+  });
+
+  it('holds the key on anything it cannot read as a refusal', async () => {
+    const { purchaseDefinitelyDidNotCharge } = await import('~/components/Sticker/sticker.util');
+
+    for (const error of [
+      new Error('fetch failed'),
+      new Error('The operation timed out'),
+      new Error('Internal server error'),
+      new Error(''),
+      undefined,
+      { message: 'insufficient' },
+    ])
+      expect(purchaseDefinitelyDidNotCharge(error)).toBe(false);
+  });
+});

--- a/src/components/Sticker/__tests__/refill-gate.test.ts
+++ b/src/components/Sticker/__tests__/refill-gate.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { refillFromOffer } from '~/components/Sticker/sticker.util';
+
+/**
+ * The top-up gate itself — the part the duplicate action's F3 fix actually
+ * changed, and which was asserted only through a spy until a review pointed out
+ * that the arithmetic was covered and the thing it called was not.
+ */
+const listing = {
+  shopItemId: 7,
+  unitAmount: 500,
+  acceptsBlue: true,
+  uses: 20,
+  viaShopUserId: 88,
+};
+
+describe('the top-up gate built from an offer', () => {
+  it('carries the listing as a pack the draft can buy', () => {
+    const gate = refillFromOffer({ pricePerUse: 25, creatorUsername: 'maker', listing });
+
+    expect(gate).toEqual({
+      refill: true,
+      perUse: 25,
+      pack: { shopItemId: 7, unitAmount: 500, acceptsBlue: true, uses: 20, viaShopUserId: 88 },
+      creatorUsername: 'maker',
+    });
+  });
+
+  /**
+   * 🔴 THE FIX. `purchase` is snapshotted onto the draft and never recomputed, so
+   * a gate built before the offers query resolves is the one that draft keeps.
+   * Without the owned price standing in, it renders as "this sticker sells no
+   * extra uses" — false, and permanent.
+   */
+  it('falls back to the owned price while the offers are still loading', () => {
+    expect(refillFromOffer(undefined, 25)).toMatchObject({ refill: true, perUse: 25 });
+  });
+
+  it('prefers the offer price over the owned one once it lands', () => {
+    const gate = refillFromOffer({ pricePerUse: 30, creatorUsername: null, listing: null }, 25);
+
+    expect(gate.perUse).toBe(30);
+  });
+
+  /**
+   * A real state rather than a bug: a sticker sold before per-use pricing and
+   * since delisted cannot be topped up at all. The draft says so instead of
+   * showing a button that fails.
+   */
+  it('is a dead end when there is no price and nothing on sale', () => {
+    expect(refillFromOffer({ pricePerUse: null, creatorUsername: 'maker', listing: null })).toEqual(
+      {
+        refill: true,
+        perUse: undefined,
+        creatorUsername: 'maker',
+      }
+    );
+  });
+
+  it('credits nobody until the offer is known', () => {
+    expect(refillFromOffer(undefined).creatorUsername).toBeUndefined();
+  });
+
+  it('normalises a null storefront rather than passing it through', () => {
+    const gate = refillFromOffer({
+      pricePerUse: 25,
+      creatorUsername: 'maker',
+      listing: { ...listing, viaShopUserId: null },
+    });
+
+    expect(gate.pack?.viaShopUserId).toBeUndefined();
+  });
+});

--- a/src/components/Sticker/free-offer.ts
+++ b/src/components/Sticker/free-offer.ts
@@ -1,4 +1,5 @@
 import { FREE_SLOT_TAKEN_NOTE, SHARED_ALLOWANCE_NOTE } from '~/shared/utils/placement';
+import { numberWithCommas } from '~/utils/number-helpers';
 
 /**
  * Whether the free offer is on the table, and what it says.
@@ -119,10 +120,7 @@ export const FREE_REVIEW_CAVEAT = 'Spends your free placement, even if they decl
  * both name the shared budget — two wordings of the one fact this change exists
  * to stop drifting. One function, so a reword lands everywhere or nowhere.
  */
-export const spentAllowanceNote = (resetsAt?: Date | string) =>
-  `You have used today's free placement — ${SHARED_ALLOWANCE_NOTE}. It comes back ${allowanceResetLabel(
-    resetsAt
-  )}.`;
+export const spentAllowanceNote = () => "You have used today's free placement.";
 
 export function freeRefusalMessage(standing?: FreeStanding, space?: FreeCapacity) {
   // Permanent for this image, and true of everybody — so it outranks the two
@@ -133,7 +131,7 @@ export function freeRefusalMessage(standing?: FreeStanding, space?: FreeCapacity
   if (standing?.usedHere) return 'You have already used a free sticker on this image.';
   // Transient, and it says when it lifts — derived from the reset the server
   // computed rather than restating the boundary here.
-  if (standing && standing.remaining <= 0) return spentAllowanceNote(standing.resetsAt);
+  if (standing && standing.remaining <= 0) return spentAllowanceNote();
   // The most transient of all — a declined placement releases its slot at once.
   //
   // ⚠️ Two readers, two truths, so the wording is chosen by the caller. Someone
@@ -223,22 +221,6 @@ type FreeStanding = {
 type FreeCapacity = { freeSlots: number; freeSlotsRemaining: number };
 
 /**
- * When the daily allowance comes back, in words.
- *
- * Falls back to the boundary the server currently uses rather than saying nothing,
- * because a refusal that cannot say when it lifts is worse than one that names a
- * default — but the value is preferred, so changing the day boundary changes this
- * sentence instead of making it wrong.
- */
-function allowanceResetLabel(resetsAt?: Date | string) {
-  if (!resetsAt) return 'at midnight UTC';
-  const at = new Date(resetsAt);
-  if (Number.isNaN(at.getTime())) return 'at midnight UTC';
-
-  return `at ${at.toISOString().slice(11, 16)} UTC`;
-}
-
-/**
  * The free label on the reaction bar, or `null` for no label at all.
  *
  * 🔴 **This is the fix for the whole ticket.** The bar used to print the
@@ -318,9 +300,17 @@ export function trayNotes({
   price,
   review,
   reason,
+  declineFee,
 }: {
   freeAvailable: boolean;
   price: number;
+  /**
+   * What the creator keeps if they decline, in Buzz. Absent while the space is
+   * still loading, which is why the vaguer sentence survives as a fallback
+   * rather than being deleted — a number that is not known yet must not render
+   * as "they keep 0 Buzz".
+   */
+  declineFee?: number;
   /** The space reviews placements, so nothing goes live until the owner says so. */
   review: boolean;
   /** From `preCommitFreeReason` — `null` whenever free is genuinely on offer. */
@@ -364,6 +354,14 @@ export function trayNotes({
       tone: 'warn',
       text: freeAvailable
         ? FREE_REVIEW_CAVEAT
+        : declineFee
+        ? // The exact number, because "part of what you paid" is the one thing a
+          // placer cannot check for themselves and the amount is what actually
+          // leaves their wallet. It comes from the server already computed: the
+          // rate is operator-tunable and floors at 1⚡, so a percentage worked
+          // out here would be wrong on precisely the cheap placements the floor
+          // exists for.
+          `If they decline, they keep ${numberWithCommas(declineFee)} Buzz`
         : 'If they decline, part of what you paid stays with them',
     });
 

--- a/src/components/Sticker/sticker.util.ts
+++ b/src/components/Sticker/sticker.util.ts
@@ -339,3 +339,75 @@ export function duplicateGateFor({
 
   return refillFor(source.cosmeticId, ownedPricePerUse);
 }
+
+/**
+ * Which drafts on the image are covered by what the placer already has, and
+ * which still have to be bought.
+ *
+ * 🔴 AN ALLOCATION, NOT A SNAPSHOT — and that distinction is the bug Justin
+ * found by using it. The gate used to be decided when a draft was CREATED and
+ * written onto it: with one use left, the first draft was free to place and the
+ * second arrived asking to be bought. Delete the first, and the second kept
+ * asking, because the fact that stopped it was frozen into it. The use it was
+ * waiting for had been handed back and nothing reassigned it.
+ *
+ * So entitlement belongs to the SET of drafts, recomputed whenever it changes:
+ * `remaining` uses cover the first `remaining` drafts of that sticker in the
+ * order they were laid down, and every later one needs a top-up. Remove a
+ * covered draft and the next one moves up into the use it left behind.
+ *
+ * The same rule decides the free placement, and for the same reason: a free
+ * placement is once per image, so exactly ONE draft can be the free one. Showing
+ * "free" on all of them is an offer three of them cannot keep — and the free one
+ * has to move too when the draft holding it is deleted.
+ *
+ * Creation order rather than selection or position: it is the only order that
+ * does not change under the placer's hands, so a sticker does not lose its use
+ * because another one was dragged.
+ */
+export type DraftEntitlement = {
+  /** This draft is covered by a use the placer already owns. */
+  covered: boolean;
+  /** This is the one draft that may take the free placement, if one is on offer. */
+  free: boolean;
+};
+
+export function allocateDraftEntitlements({
+  drafts,
+  balances,
+  freeAvailable,
+}: {
+  /** In creation order — the store appends, so `drafts` already is. */
+  drafts: { id: string; cosmeticId: number; purchase?: DraftPurchase }[];
+  balances: { cosmeticId: number; remaining: number | null }[] | undefined;
+  freeAvailable: boolean;
+}): Map<string, DraftEntitlement> {
+  const seen = new Map<number, number>();
+  const result = new Map<string, DraftEntitlement>();
+
+  // The free placement goes to the first draft that could actually take it. A
+  // draft of a sticker the placer does not own yet cannot: it has to be bought
+  // before it can be placed at all, and buying it is not what "free" means here.
+  const freeDraft = freeAvailable
+    ? drafts.find((draft) => !draft.purchase?.pack || draft.purchase.refill)?.id
+    : undefined;
+
+  for (const draft of drafts) {
+    const before = seen.get(draft.cosmeticId) ?? 0;
+    seen.set(draft.cosmeticId, before + 1);
+
+    const remaining = balances?.find((entry) => entry.cosmeticId === draft.cosmeticId)?.remaining;
+
+    // Unknown is not zero. No balances yet, or no holding for a sticker being
+    // bought outright, both mean this rule has nothing to say — the draft's own
+    // stored gate answers instead.
+    const covered =
+      balances === undefined || remaining === undefined
+        ? true
+        : remaining === null || before < remaining;
+
+    result.set(draft.id, { covered, free: draft.id === freeDraft });
+  }
+
+  return result;
+}

--- a/src/components/Sticker/sticker.util.ts
+++ b/src/components/Sticker/sticker.util.ts
@@ -433,35 +433,25 @@ export function allocateDraftEntitlements({
 }
 
 /**
- * Whether a failed purchase definitely did NOT take the money.
+ * Whether a failed purchase can be retried as a NEW intent.
  *
- * 🔴 THE DEFAULT MUST BE "IT MIGHT HAVE". An idempotency key is released so the
- * next press is a new intent — right after a refusal, wrong after a timeout,
- * because a request that timed out may well have been processed. Releasing the
- * key there mints a fresh one and charges the same purchase twice, which is the
- * exact thing the key exists to prevent.
+ * 🔴 STRUCTURAL, NOT TEXTUAL — and the first attempt at this was textual, which
+ * is why it was wrong. It matched refusal wording, and the server says "This
+ * cosmetic is not available", "out of stock", "The price changed to N Buzz" and
+ * four others the list never had. A miss locks the placer out of that sticker
+ * until they reload, which is the bug releasing the key was meant to fix.
  *
- * So this recognises refusals the server states, and treats everything else —
- * network errors, 5xx, an unreadable message — as unknown, holding the key. The
- * cost of holding it wrongly is a refusal on the next press; the cost of
- * releasing it wrongly is someone's Buzz.
+ * A 4xx is the server declining: nothing was charged, so the next press is a new
+ * intent and needs a new key. Anything else — a 5xx, a timeout, no response at
+ * all — might have gone through, and reissuing the key there is how one purchase
+ * becomes two. Unknown holds the key, always.
+ *
+ * `data.httpStatus` comes from tRPC's error shape, which this repo's
+ * `errorFormatter` passes through untouched. A network failure has no `data` and
+ * therefore holds, which is the point.
  */
-const DEFINITIVE_REFUSALS = [
-  'insufficient',
-  'not enough',
-  'price has changed',
-  'no longer available',
-  'sold out',
-  'not on sale',
-  'already own',
-  'already been completed',
-  'invalid',
-];
+export function purchaseCanBeRetriedFresh(error: unknown): boolean {
+  const status = (error as { data?: { httpStatus?: number } } | null)?.data?.httpStatus;
 
-export function purchaseDefinitelyDidNotCharge(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
-  if (!message) return false;
-
-  const normalised = message.toLowerCase();
-  return DEFINITIVE_REFUSALS.some((refusal) => normalised.includes(refusal));
+  return typeof status === 'number' && status >= 400 && status < 500;
 }

--- a/src/components/Sticker/sticker.util.ts
+++ b/src/components/Sticker/sticker.util.ts
@@ -7,6 +7,9 @@ import {
 } from '~/shared/utils/sticker-token';
 import { numberWithCommas } from '~/utils/number-helpers';
 import { trpc } from '~/utils/trpc';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { STICKER_OFFER_LIMIT } from '~/server/schema/cosmetic.schema';
+import type { DraftPurchase } from '~/store/sticker-placement-draft.store';
 
 /**
  * What buying a sticker gets you, as shop copy: the balance included and what a
@@ -163,4 +166,144 @@ export function useStickerCosmetics(ids: number[]) {
   }, [queries.map((q) => q.dataUpdatedAt).join(',')]);
 
   return { sticker, isLoading: queries.some((q) => q.isLoading) };
+}
+
+/**
+ * What a sticker's top-up costs, for whoever needs to offer one.
+ *
+ * 🔴 SHARED BECAUSE THE KEY HAS TO BE. Two surfaces ask this — the tray, when a
+ * spent sticker is dragged out, and the draft layer, when a spent sticker is
+ * duplicated — and the second one keyed its query on the DRAFTED ids while the
+ * tray keys on the OWNED ids. Different arrays are different cache entries, so
+ * what looked like a shared read was a second request that refetched every time
+ * a draft was laid down. The tray's own comment warns against exactly that
+ * derivation; the fix is for both callers to ask the same question.
+ *
+ * The owned payload's `pricePerUse` is the fallback rather than an afterthought:
+ * `purchase` is snapshotted onto a draft when it is created and never
+ * recomputed, so a copy made before this query resolves would be stuck
+ * permanently on "this sticker sells no extra uses" — a false statement, frozen.
+ */
+export function useStickerRefill() {
+  const currentUser = useCurrentUser();
+  const { sticker } = useOwnedSticker();
+
+  // The same ids the tray asks for, in the same order: every owned sticker,
+  // newest first, capped where the schema caps. Past the cap the whole query
+  // fails zod validation and `offers` stays undefined — silently, for anyone
+  // with a large collection.
+  const ownedIds = useMemo(
+    () => sticker.slice(0, STICKER_OFFER_LIMIT).map((option) => option.id),
+    [sticker]
+  );
+
+  const { data: offers } = trpc.cosmetic.getStickerOffers.useQuery(
+    { ids: ownedIds },
+    { enabled: !!currentUser && !!ownedIds.length, staleTime: 60_000 }
+  );
+
+  return useMemo(() => {
+    const byCosmetic = new Map(offers?.map((offer) => [offer.cosmeticId, offer]));
+
+    return (cosmeticId: number, ownedPricePerUse?: number): DraftPurchase => {
+      const offer = byCosmetic.get(cosmeticId);
+      const listing = offer?.listing;
+
+      return {
+        refill: true,
+        perUse: offer?.pricePerUse ?? ownedPricePerUse,
+        ...(listing
+          ? {
+              pack: {
+                shopItemId: listing.shopItemId,
+                unitAmount: listing.unitAmount,
+                acceptsBlue: listing.acceptsBlue,
+                uses: listing.uses,
+                viaShopUserId: listing.viaShopUserId ?? undefined,
+              },
+            }
+          : {}),
+        // `undefined` until the offers land, which shows no attribution rather
+        // than crediting the wrong party while it is unknown.
+        creatorUsername: offer ? offer.creatorUsername : undefined,
+      };
+    };
+  }, [offers]);
+}
+
+/**
+ * Uses left of one sticker once every draft of it on the image is paid for.
+ *
+ * Three states, and collapsing any two of them is a bug someone has already
+ * shipped: `null` is unlimited, `undefined` is NOT LOADED YET, and a number is a
+ * count. Reading "not loaded" as "has uses" hands out an ungated draft that the
+ * server refuses at `assertHasUse`; reading it as "spent" offers to sell a
+ * top-up to someone who has plenty.
+ *
+ * Every draft counts, including the one being copied — each will spend a use
+ * when it is bought.
+ */
+export function remainingStickerUses({
+  balances,
+  drafts,
+  cosmeticId,
+}: {
+  balances: { cosmeticId: number; remaining: number | null }[] | undefined;
+  drafts: { cosmeticId: number }[];
+  cosmeticId: number;
+}): number | null | undefined {
+  if (!balances) return undefined;
+
+  const holding = balances.find((entry) => entry.cosmeticId === cosmeticId);
+  // No row at all is not "no uses" — it is a sticker the viewer does not own,
+  // which is a different question answered by the draft's own purchase gate.
+  if (!holding) return undefined;
+  if (holding.remaining == null) return null;
+
+  const drafted = drafts.filter((draft) => draft.cosmeticId === cosmeticId).length;
+  return Math.max(holding.remaining - drafted, 0);
+}
+
+/**
+ * Whether a duplicated draft has to be bought before it can be placed.
+ *
+ * 🔴 THE MONEY DECISION, LIFTED OUT OF THE COMPONENT SO IT CAN BE TESTED. Every
+ * branch below is a case that was live and unasserted while this was an inline
+ * closure in the layer, and two of them were wrong.
+ *
+ * The gate is not copied from the source draft, because it says "this sticker is
+ * not bought yet" — a fact about the viewer's inventory at the moment the copy
+ * is made, not a property of the draft. But it is not discarded either:
+ *
+ * - **Not owned at all** (no balance row) — a sticker dragged from the shop and
+ *   still unbought. The copy needs the SAME gate, because one purchase grants
+ *   the sticker and `markPurchased` then clears every draft of it. Dropping the
+ *   gate here was the bug: it produced a Place button the server refuses at
+ *   `assertHasUse`, from the one direction the original code did not consider.
+ * - **Not loaded yet** — indistinguishable from the above at this layer, and the
+ *   honest answer is the same: carry the source's gate rather than invent one.
+ *   Guessing "has uses" hands out a draft that cannot be placed; guessing
+ *   "spent" offers to sell a top-up to someone with plenty.
+ * - **Unlimited, or uses left after every draft** — no gate.
+ * - **Spent** — the top-up offer a fresh pickup of a spent sticker would get.
+ */
+export function duplicateGateFor({
+  source,
+  drafts,
+  balances,
+  refillFor,
+  ownedPricePerUse,
+}: {
+  source: { cosmeticId: number; purchase?: DraftPurchase };
+  drafts: { cosmeticId: number }[];
+  balances: { cosmeticId: number; remaining: number | null }[] | undefined;
+  refillFor: (cosmeticId: number, ownedPricePerUse?: number) => DraftPurchase;
+  ownedPricePerUse?: number;
+}): DraftPurchase | undefined {
+  const remaining = remainingStickerUses({ balances, drafts, cosmeticId: source.cosmeticId });
+
+  if (remaining === undefined) return source.purchase;
+  if (remaining === null || remaining > 0) return undefined;
+
+  return refillFor(source.cosmeticId, ownedPricePerUse);
 }

--- a/src/components/Sticker/sticker.util.ts
+++ b/src/components/Sticker/sticker.util.ts
@@ -297,47 +297,27 @@ export function remainingStickerUses({
 }
 
 /**
- * Whether a duplicated draft has to be bought before it can be placed.
+ * The gate a copy inherits: the sticker-not-owned-yet one, and nothing else.
  *
- * 🔴 THE MONEY DECISION, LIFTED OUT OF THE COMPONENT SO IT CAN BE TESTED. Every
- * branch below is a case that was live and unasserted while this was an inline
- * closure in the layer, and two of them were wrong.
+ * 🔴 WHAT IS **NOT** HERE IS THE POINT. This used to decide the refill gate too —
+ * "you are out of uses, so this copy must be topped up" — and write it onto the
+ * copy. That is a fact about the moment the copy was made, not about the copy,
+ * and it went stale the instant another draft was deleted: the use came back and
+ * the copy carried on asking to be bought for it. Justin found it by using it,
+ * twice, because the first fix left this path still writing one.
  *
- * The gate is not copied from the source draft, because it says "this sticker is
- * not bought yet" — a fact about the viewer's inventory at the moment the copy
- * is made, not a property of the draft. But it is not discarded either:
+ * Whether an owned sticker has a use left is now decided across every draft on
+ * the image, on every render, by `allocateDraftEntitlements`. Nothing stores it.
  *
- * - **Not owned at all** (no balance row) — a sticker dragged from the shop and
- *   still unbought. The copy needs the SAME gate, because one purchase grants
- *   the sticker and `markPurchased` then clears every draft of it. Dropping the
- *   gate here was the bug: it produced a Place button the server refuses at
- *   `assertHasUse`, from the one direction the original code did not consider.
- * - **Not loaded yet** — indistinguishable from the above at this layer, and the
- *   honest answer is the same: carry the source's gate rather than invent one.
- *   Guessing "has uses" hands out a draft that cannot be placed; guessing
- *   "spent" offers to sell a top-up to someone with plenty.
- * - **Unlimited, or uses left after every draft** — no gate.
- * - **Spent** — the top-up offer a fresh pickup of a spent sticker would get.
+ * A sticker that is not owned at all is different: it must be bought before it
+ * can be placed, one purchase grants it, and `markPurchased` then frees every
+ * draft of it. That is a property of the draft and it travels with the copy.
  */
-export function duplicateGateFor({
-  source,
-  drafts,
-  balances,
-  refillFor,
-  ownedPricePerUse,
-}: {
-  source: { cosmeticId: number; purchase?: DraftPurchase };
-  drafts: { cosmeticId: number }[];
-  balances: { cosmeticId: number; remaining: number | null }[] | undefined;
-  refillFor: (cosmeticId: number, ownedPricePerUse?: number) => DraftPurchase;
-  ownedPricePerUse?: number;
-}): DraftPurchase | undefined {
-  const remaining = remainingStickerUses({ balances, drafts, cosmeticId: source.cosmeticId });
+export function unownedGateFor(source: { purchase?: DraftPurchase }): DraftPurchase | undefined {
+  const purchase = source.purchase;
+  if (!purchase?.pack || purchase.refill) return undefined;
 
-  if (remaining === undefined) return source.purchase;
-  if (remaining === null || remaining > 0) return undefined;
-
-  return refillFor(source.cosmeticId, ownedPricePerUse);
+  return purchase;
 }
 
 /**

--- a/src/components/Sticker/sticker.util.ts
+++ b/src/components/Sticker/sticker.util.ts
@@ -205,30 +205,62 @@ export function useStickerRefill() {
   return useMemo(() => {
     const byCosmetic = new Map(offers?.map((offer) => [offer.cosmeticId, offer]));
 
-    return (cosmeticId: number, ownedPricePerUse?: number): DraftPurchase => {
-      const offer = byCosmetic.get(cosmeticId);
-      const listing = offer?.listing;
-
-      return {
-        refill: true,
-        perUse: offer?.pricePerUse ?? ownedPricePerUse,
-        ...(listing
-          ? {
-              pack: {
-                shopItemId: listing.shopItemId,
-                unitAmount: listing.unitAmount,
-                acceptsBlue: listing.acceptsBlue,
-                uses: listing.uses,
-                viaShopUserId: listing.viaShopUserId ?? undefined,
-              },
-            }
-          : {}),
-        // `undefined` until the offers land, which shows no attribution rather
-        // than crediting the wrong party while it is unknown.
-        creatorUsername: offer ? offer.creatorUsername : undefined,
-      };
-    };
+    return (cosmeticId: number, ownedPricePerUse?: number) =>
+      refillFromOffer(byCosmetic.get(cosmeticId), ownedPricePerUse);
   }, [offers]);
+}
+
+/** One offer turned into the gate a draft carries. Pure, so it can be asserted. */
+export type StickerOfferLike = {
+  pricePerUse: number | null;
+  creatorUsername: string | null;
+  listing: {
+    shopItemId: number;
+    unitAmount: number;
+    acceptsBlue: boolean;
+    uses?: number | null;
+    viaShopUserId?: number | null;
+  } | null;
+};
+
+/**
+ * The top-up gate for one sticker.
+ *
+ * 🔴 THE FALLBACK IS THE POINT. `purchase` is snapshotted onto a draft when the
+ * draft is created and never recomputed, so a gate built before the offers query
+ * resolves is what that draft keeps. Without the owned payload's price standing
+ * in, that gate has no price and no pack — which renders as "this sticker sells
+ * no extra uses, and it is not on sale right now", a false sentence the placer
+ * cannot get out of except by deleting the sticker and starting again.
+ *
+ * A gate with neither price nor pack is still a real state, not a bug: a sticker
+ * sold before per-use pricing existed and since delisted genuinely cannot be
+ * topped up. The draft says so instead of offering a button that fails.
+ */
+export function refillFromOffer(
+  offer: StickerOfferLike | undefined,
+  ownedPricePerUse?: number
+): DraftPurchase {
+  const listing = offer?.listing;
+
+  return {
+    refill: true,
+    perUse: offer?.pricePerUse ?? ownedPricePerUse,
+    ...(listing
+      ? {
+          pack: {
+            shopItemId: listing.shopItemId,
+            unitAmount: listing.unitAmount,
+            acceptsBlue: listing.acceptsBlue,
+            uses: listing.uses,
+            viaShopUserId: listing.viaShopUserId ?? undefined,
+          },
+        }
+      : {}),
+    // `undefined` until the offers land, which shows no attribution rather than
+    // crediting the wrong party while it is unknown.
+    creatorUsername: offer ? offer.creatorUsername : undefined,
+  };
 }
 
 /**

--- a/src/components/Sticker/sticker.util.ts
+++ b/src/components/Sticker/sticker.util.ts
@@ -356,23 +356,41 @@ export function allocateDraftEntitlements({
   drafts,
   balances,
   freeAvailable,
+  paidDraftIds = [],
 }: {
   /** In creation order — the store appends, so `drafts` already is. */
   drafts: { id: string; cosmeticId: number; purchase?: DraftPurchase }[];
   balances: { cosmeticId: number; remaining: number | null }[] | undefined;
   freeAvailable: boolean;
+  /** Drafts whose own buy button paid for a use, oldest purchase first. */
+  paidDraftIds?: string[];
 }): Map<string, DraftEntitlement> {
   const seen = new Map<number, number>();
   const result = new Map<string, DraftEntitlement>();
 
-  // The free placement goes to the first draft that could actually take it. A
-  // draft of a sticker the placer does not own yet cannot: it has to be bought
-  // before it can be placed at all, and buying it is not what "free" means here.
-  const freeDraft = freeAvailable
-    ? drafts.find((draft) => !draft.purchase?.pack || draft.purchase.refill)?.id
-    : undefined;
+  /**
+   * Drafts that paid for a use come first.
+   *
+   * 🔴 WITHOUT THIS, BUYING A USE HANDS IT TO A DIFFERENT STICKER. Coverage is
+   * assigned in creation order, so pressing "Buy a use" on the SECOND of two
+   * gated copies raised the balance and covered the FIRST — the button you paid
+   * on did not change, which reads as a failed purchase and invites paying
+   * again. Uses are fungible per sticker so no Buzz is lost, but the wrong
+   * sticker becomes placeable and the right one keeps asking.
+   *
+   * Purchase order among themselves, so two purchases resolve in the order they
+   * were made rather than by where the drafts happen to sit.
+   */
+  const ordered = [...drafts].sort((a, b) => {
+    const paidA = paidDraftIds.indexOf(a.id);
+    const paidB = paidDraftIds.indexOf(b.id);
+    if (paidA === paidB) return 0;
+    if (paidA < 0) return 1;
+    if (paidB < 0) return -1;
+    return paidA - paidB;
+  });
 
-  for (const draft of drafts) {
+  for (const draft of ordered) {
     const before = seen.get(draft.cosmeticId) ?? 0;
     seen.set(draft.cosmeticId, before + 1);
 
@@ -386,8 +404,64 @@ export function allocateDraftEntitlements({
         ? true
         : remaining === null || before < remaining;
 
-    result.set(draft.id, { covered, free: draft.id === freeDraft });
+    result.set(draft.id, { covered, free: false });
+  }
+
+  /**
+   * The free placement goes to the first draft that can actually take it — which
+   * is decided AFTER coverage, not before.
+   *
+   * 🔴 CHOSEN BEFORE COVERAGE, IT LANDED ON A DRAFT THAT COULD NOT USE IT. A
+   * spent owned sticker created first won the free slot and then rendered a buy
+   * button, because a draft that has to be bought hides the free option — and
+   * every other draft was told there was no free offer. The placer had a free
+   * placement available and nowhere to spend it.
+   *
+   * A sticker not owned at all is skipped for the same reason from the other
+   * direction: it must be bought before it can be placed, which is not what free
+   * means here.
+   */
+  if (freeAvailable) {
+    const freeDraft = drafts.find(
+      (draft) => result.get(draft.id)?.covered && (!draft.purchase?.pack || !!draft.purchase.refill)
+    );
+
+    if (freeDraft) result.set(freeDraft.id, { ...result.get(freeDraft.id)!, free: true });
   }
 
   return result;
+}
+
+/**
+ * Whether a failed purchase definitely did NOT take the money.
+ *
+ * 🔴 THE DEFAULT MUST BE "IT MIGHT HAVE". An idempotency key is released so the
+ * next press is a new intent — right after a refusal, wrong after a timeout,
+ * because a request that timed out may well have been processed. Releasing the
+ * key there mints a fresh one and charges the same purchase twice, which is the
+ * exact thing the key exists to prevent.
+ *
+ * So this recognises refusals the server states, and treats everything else —
+ * network errors, 5xx, an unreadable message — as unknown, holding the key. The
+ * cost of holding it wrongly is a refusal on the next press; the cost of
+ * releasing it wrongly is someone's Buzz.
+ */
+const DEFINITIVE_REFUSALS = [
+  'insufficient',
+  'not enough',
+  'price has changed',
+  'no longer available',
+  'sold out',
+  'not on sale',
+  'already own',
+  'already been completed',
+  'invalid',
+];
+
+export function purchaseDefinitelyDidNotCharge(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  if (!message) return false;
+
+  const normalised = message.toLowerCase();
+  return DEFINITIVE_REFUSALS.some((refusal) => normalised.includes(refusal));
 }

--- a/src/components/Sticker/sticker.util.ts
+++ b/src/components/Sticker/sticker.util.ts
@@ -453,5 +453,7 @@ export function allocateDraftEntitlements({
 export function purchaseCanBeRetriedFresh(error: unknown): boolean {
   const status = (error as { data?: { httpStatus?: number } } | null)?.data?.httpStatus;
 
-  return typeof status === 'number' && status >= 400 && status < 500;
+  // 408 is the one 4xx that does not mean "nothing happened": a request timed
+  // out at an edge or proxy may still have been forwarded and processed.
+  return typeof status === 'number' && status >= 400 && status < 500 && status !== 408;
 }

--- a/src/server/services/cosmetic-pack.service.ts
+++ b/src/server/services/cosmetic-pack.service.ts
@@ -456,8 +456,13 @@ export const purchaseCosmeticPack = async ({
     description: `Cosmetic pack purchase - ${shopItem.title}`,
     externalTransactionIdPrefix: transactionId,
   });
-  if (!transaction.transactionCount)
-    throw throwBadRequestError('There was an error creating the transaction');
+  // 🔴 NOT a 400, and that changed meaning recently. The Buzz service answered
+  // and created nothing, which is AMBIGUOUS — the charge may have happened. The
+  // sticker purchase flow now reads a 4xx as "nothing was charged, retry as a
+  // new intent", so raising a refusal here would release an idempotency key on a
+  // failure that may already have taken the money. The shop path's identical
+  // case is a 500 for the same reason.
+  if (!transaction.transactionCount) throw new Error('There was an error creating the transaction');
   const bluePaid = transaction.transactionIds
     .filter((t) => t.accountType === 'blue')
     .reduce((sum, t) => sum + t.amount, 0);

--- a/src/server/services/cosmetic-shop.service.ts
+++ b/src/server/services/cosmetic-shop.service.ts
@@ -1,8 +1,8 @@
 import { Prisma } from '@prisma/client';
-import { TRPCError } from '@trpc/server';
 import { randomUUID } from 'node:crypto';
 import { ImageSort } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { throwBadRequestError } from '~/server/utils/errorHandling';
 import { refreshOwnedStickerCache } from '~/server/redis/caches';
 import { dbReadFallbackCounter } from '~/server/prom/client';
 import { logToAxiom } from '~/server/logging/client';
@@ -59,24 +59,22 @@ import {
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 
 /**
- * A refusal the buyer can act on, as a 400 rather than a 500.
+ * 🔴 REFUSALS IN THIS FUNCTION ARE 400s, AND THAT IS LOAD-BEARING FOR MONEY.
  *
- * 🔴 THESE USED TO BE BARE `Error`s, AND THE CLIENT COULD NOT TELL THEM APART
- * FROM A CRASH. tRPC wraps an unrecognised throw as INTERNAL_SERVER_ERROR, so
- * "you already own this" and "the database fell over" arrived identically — and
- * the sticker purchase flow, which has to decide whether to reuse an idempotency
- * key, was left matching on message TEXT to guess. That guess is wrong the day
- * anybody rewords a sentence, and it was already wrong for seven of these.
+ * They used to be bare `Error`s, which tRPC wraps as INTERNAL_SERVER_ERROR — so
+ * "you already own this" and "the database fell over" arrived at the client
+ * identically. The sticker purchase flow has to decide whether a failed attempt
+ * may have charged, and with no code to read it was matching on message TEXT,
+ * which was wrong for seven of the ten sentences this file actually throws.
  *
- * With a code the rule is structural: a 4xx means the charge did not happen and
- * the next press is a new intent; anything else — including no response at all —
- * means it might have, so the key is held rather than reissued.
+ * The rule is now structural: a 4xx means nothing was charged and the next press
+ * is a new intent; anything else — including no response at all — means it might
+ * have, so the idempotency key is held rather than reissued.
  *
- * The messages are unchanged. This also stops ordinary refusals being logged and
- * alerted as server errors.
+ * ⚠️ So a refusal here must NOT be raised for an ambiguous failure. The two
+ * below (`transactionCount`, and the post-charge grant failure) stay 500s
+ * deliberately: the money may already have moved.
  */
-const refusal = (message: string) => new TRPCError({ code: 'BAD_REQUEST', message });
-
 export const getShopItemById = async ({ id }: GetByIdInput) => {
   const shopItemFindArgs = {
     where: {
@@ -779,19 +777,19 @@ export const purchaseCosmeticShopItem = async ({
   const noun = shopItem && shopItem.cosmeticId == null ? 'pack' : 'cosmetic';
 
   if (!shopItem) {
-    throw refusal('Cosmetic not found');
+    throw throwBadRequestError('Cosmetic not found');
   }
 
   // Creator-submitted items share this table; only Published items are sellable.
   // Guards against buying Draft/PendingReview/Rejected/Archived items by id.
   if (shopItem.status !== CosmeticShopItemStatus.Published) {
-    throw refusal(`This ${noun} is not available`);
+    throw throwBadRequestError(`This ${noun} is not available`);
   }
 
   // Delisted: still Published so it stays bundlable, but off individual sale.
   // Resale listings don't outlive this — withdrawing the item ends them.
   if (!shopItem.listed) {
-    throw refusal(`This ${noun} is not available`);
+    throw throwBadRequestError(`This ${noun} is not available`);
   }
 
   // A pack carries no cosmetic of its own; the guards below are answered per
@@ -802,12 +800,12 @@ export const purchaseCosmeticShopItem = async ({
     // could otherwise pay for a sticker they can't place, since the picker is
     // gated too. Refuse at the mutation, where the cosmetic is already loaded.
     if (shopItem.cosmetic.type === CosmeticType.Sticker && !stickersEnabled) {
-      throw refusal(`This ${noun} is not available`);
+      throw throwBadRequestError(`This ${noun} is not available`);
     }
 
     // Creators can't buy their own cosmetic — they're granted it on approval.
     if (shopItem.cosmetic.createdById === userId) {
-      throw refusal('You already own this cosmetic');
+      throw throwBadRequestError('You already own this cosmetic');
     }
 
     // A block between the buyer and the item's creator or lister (either
@@ -820,7 +818,7 @@ export const purchaseCosmeticShopItem = async ({
         (id): id is number => id != null
       );
       if (sellerIds.some((id) => blockedPairIds.includes(id))) {
-        throw refusal(`This ${noun} is not available`);
+        throw throwBadRequestError(`This ${noun} is not available`);
       }
     }
   }
@@ -841,15 +839,15 @@ export const purchaseCosmeticShopItem = async ({
         },
       });
     }
-    throw refusal(`This ${noun} is out of stock`);
+    throw throwBadRequestError(`This ${noun} is out of stock`);
   }
 
   if (shopItem.availableFrom && shopItem.availableFrom > new Date()) {
-    throw refusal(`This ${noun} is not available yet`);
+    throw throwBadRequestError(`This ${noun} is not available yet`);
   }
 
   if (shopItem.availableTo && shopItem.availableTo < new Date()) {
-    throw refusal(`This ${noun} is no longer available`);
+    throw throwBadRequestError(`This ${noun} is no longer available`);
   }
 
   // Packs diverge here: the money path, the grant and the payout are all
@@ -858,7 +856,7 @@ export const purchaseCosmeticShopItem = async ({
   if (shopItem.cosmeticId == null || !shopItem.cosmetic) {
     // Filtering a pack out of a list is not refusing it — with an id in hand a
     // buyer could otherwise purchase one while the flag is off.
-    if (!packsEnabled) throw refusal('This pack is not available');
+    if (!packsEnabled) throw throwBadRequestError('This pack is not available');
     const members = await getPackMembers(shopItemId);
     return purchaseCosmeticPack({
       userId,
@@ -899,7 +897,7 @@ export const purchaseCosmeticShopItem = async ({
     });
 
     if (userCosmetic) {
-      throw refusal('You already own this cosmetic');
+      throw throwBadRequestError('You already own this cosmetic');
     }
   }
 
@@ -912,7 +910,7 @@ export const purchaseCosmeticShopItem = async ({
       where: { userId, cosmeticId: singleCosmeticId, remaining: null },
       select: { claimKey: true },
     });
-    if (unlimited) throw refusal('You already have unlimited uses of this sticker');
+    if (unlimited) throw throwBadRequestError('You already have unlimited uses of this sticker');
   }
 
   // The buyer confirmed a number on a button. A listing re-priced between that
@@ -921,7 +919,7 @@ export const purchaseCosmeticShopItem = async ({
   // stale price is most likely: a shop panel and a draft can sit open for as
   // long as the image does.
   if (expectedUnitAmount !== undefined && expectedUnitAmount !== shopItem.unitAmount) {
-    throw refusal(
+    throw throwBadRequestError(
       `The price changed to ${shopItem.unitAmount} Buzz. Check the new price and try again.`
     );
   }
@@ -930,7 +928,7 @@ export const purchaseCosmeticShopItem = async ({
 
   // Blue payment is a per-item creator opt-in (meta.acceptsBlueBuzz).
   if (payWith !== 'default' && !meta.acceptsBlueBuzz) {
-    throw refusal('This item does not accept Blue Buzz');
+    throw throwBadRequestError('This item does not accept Blue Buzz');
   }
   // 'blue-first' drains blue before completing with the domain color.
   const fromAccountTypes: BuzzSpendType[] =
@@ -979,7 +977,7 @@ export const purchaseCosmeticShopItem = async ({
       where: { buzzTransactionId: transactionId },
       select: { buzzTransactionId: true },
     });
-    if (alreadyProcessed) throw refusal('This purchase has already been completed');
+    if (alreadyProcessed) throw throwBadRequestError('This purchase has already been completed');
   }
   const transaction = await createMultiAccountBuzzTransaction({
     fromAccountId: userId,

--- a/src/server/services/cosmetic-shop.service.ts
+++ b/src/server/services/cosmetic-shop.service.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@prisma/client';
+import { TRPCError } from '@trpc/server';
 import { randomUUID } from 'node:crypto';
 import { ImageSort } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
@@ -56,6 +57,25 @@ import {
   MetricTimeframe,
 } from '~/shared/utils/prisma/enums';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
+
+/**
+ * A refusal the buyer can act on, as a 400 rather than a 500.
+ *
+ * 🔴 THESE USED TO BE BARE `Error`s, AND THE CLIENT COULD NOT TELL THEM APART
+ * FROM A CRASH. tRPC wraps an unrecognised throw as INTERNAL_SERVER_ERROR, so
+ * "you already own this" and "the database fell over" arrived identically — and
+ * the sticker purchase flow, which has to decide whether to reuse an idempotency
+ * key, was left matching on message TEXT to guess. That guess is wrong the day
+ * anybody rewords a sentence, and it was already wrong for seven of these.
+ *
+ * With a code the rule is structural: a 4xx means the charge did not happen and
+ * the next press is a new intent; anything else — including no response at all —
+ * means it might have, so the key is held rather than reissued.
+ *
+ * The messages are unchanged. This also stops ordinary refusals being logged and
+ * alerted as server errors.
+ */
+const refusal = (message: string) => new TRPCError({ code: 'BAD_REQUEST', message });
 
 export const getShopItemById = async ({ id }: GetByIdInput) => {
   const shopItemFindArgs = {
@@ -759,19 +779,19 @@ export const purchaseCosmeticShopItem = async ({
   const noun = shopItem && shopItem.cosmeticId == null ? 'pack' : 'cosmetic';
 
   if (!shopItem) {
-    throw new Error('Cosmetic not found');
+    throw refusal('Cosmetic not found');
   }
 
   // Creator-submitted items share this table; only Published items are sellable.
   // Guards against buying Draft/PendingReview/Rejected/Archived items by id.
   if (shopItem.status !== CosmeticShopItemStatus.Published) {
-    throw new Error(`This ${noun} is not available`);
+    throw refusal(`This ${noun} is not available`);
   }
 
   // Delisted: still Published so it stays bundlable, but off individual sale.
   // Resale listings don't outlive this — withdrawing the item ends them.
   if (!shopItem.listed) {
-    throw new Error(`This ${noun} is not available`);
+    throw refusal(`This ${noun} is not available`);
   }
 
   // A pack carries no cosmetic of its own; the guards below are answered per
@@ -782,12 +802,12 @@ export const purchaseCosmeticShopItem = async ({
     // could otherwise pay for a sticker they can't place, since the picker is
     // gated too. Refuse at the mutation, where the cosmetic is already loaded.
     if (shopItem.cosmetic.type === CosmeticType.Sticker && !stickersEnabled) {
-      throw new Error(`This ${noun} is not available`);
+      throw refusal(`This ${noun} is not available`);
     }
 
     // Creators can't buy their own cosmetic — they're granted it on approval.
     if (shopItem.cosmetic.createdById === userId) {
-      throw new Error('You already own this cosmetic');
+      throw refusal('You already own this cosmetic');
     }
 
     // A block between the buyer and the item's creator or lister (either
@@ -800,7 +820,7 @@ export const purchaseCosmeticShopItem = async ({
         (id): id is number => id != null
       );
       if (sellerIds.some((id) => blockedPairIds.includes(id))) {
-        throw new Error(`This ${noun} is not available`);
+        throw refusal(`This ${noun} is not available`);
       }
     }
   }
@@ -821,15 +841,15 @@ export const purchaseCosmeticShopItem = async ({
         },
       });
     }
-    throw new Error(`This ${noun} is out of stock`);
+    throw refusal(`This ${noun} is out of stock`);
   }
 
   if (shopItem.availableFrom && shopItem.availableFrom > new Date()) {
-    throw new Error(`This ${noun} is not available yet`);
+    throw refusal(`This ${noun} is not available yet`);
   }
 
   if (shopItem.availableTo && shopItem.availableTo < new Date()) {
-    throw new Error(`This ${noun} is no longer available`);
+    throw refusal(`This ${noun} is no longer available`);
   }
 
   // Packs diverge here: the money path, the grant and the payout are all
@@ -838,7 +858,7 @@ export const purchaseCosmeticShopItem = async ({
   if (shopItem.cosmeticId == null || !shopItem.cosmetic) {
     // Filtering a pack out of a list is not refusing it — with an id in hand a
     // buyer could otherwise purchase one while the flag is off.
-    if (!packsEnabled) throw new Error('This pack is not available');
+    if (!packsEnabled) throw refusal('This pack is not available');
     const members = await getPackMembers(shopItemId);
     return purchaseCosmeticPack({
       userId,
@@ -879,7 +899,7 @@ export const purchaseCosmeticShopItem = async ({
     });
 
     if (userCosmetic) {
-      throw new Error('You already own this cosmetic');
+      throw refusal('You already own this cosmetic');
     }
   }
 
@@ -892,7 +912,7 @@ export const purchaseCosmeticShopItem = async ({
       where: { userId, cosmeticId: singleCosmeticId, remaining: null },
       select: { claimKey: true },
     });
-    if (unlimited) throw new Error('You already have unlimited uses of this sticker');
+    if (unlimited) throw refusal('You already have unlimited uses of this sticker');
   }
 
   // The buyer confirmed a number on a button. A listing re-priced between that
@@ -901,7 +921,7 @@ export const purchaseCosmeticShopItem = async ({
   // stale price is most likely: a shop panel and a draft can sit open for as
   // long as the image does.
   if (expectedUnitAmount !== undefined && expectedUnitAmount !== shopItem.unitAmount) {
-    throw new Error(
+    throw refusal(
       `The price changed to ${shopItem.unitAmount} Buzz. Check the new price and try again.`
     );
   }
@@ -910,7 +930,7 @@ export const purchaseCosmeticShopItem = async ({
 
   // Blue payment is a per-item creator opt-in (meta.acceptsBlueBuzz).
   if (payWith !== 'default' && !meta.acceptsBlueBuzz) {
-    throw new Error('This item does not accept Blue Buzz');
+    throw refusal('This item does not accept Blue Buzz');
   }
   // 'blue-first' drains blue before completing with the domain color.
   const fromAccountTypes: BuzzSpendType[] =
@@ -959,7 +979,7 @@ export const purchaseCosmeticShopItem = async ({
       where: { buzzTransactionId: transactionId },
       select: { buzzTransactionId: true },
     });
-    if (alreadyProcessed) throw new Error('This purchase has already been completed');
+    if (alreadyProcessed) throw refusal('This purchase has already been completed');
   }
   const transaction = await createMultiAccountBuzzTransaction({
     fromAccountId: userId,

--- a/src/server/services/placement-space.service.ts
+++ b/src/server/services/placement-space.service.ts
@@ -11,6 +11,7 @@ import type {
 } from '~/shared/utils/placement';
 import {
   effectiveFreeSlots,
+  declineFeeAmount,
   effectivePlacementPrice,
   FREE_SLOT_HOLDING_STATUSES,
   PLACEMENT_SURFACES,
@@ -70,6 +71,12 @@ export type ResolvedPlacementSpace = {
    * stop being true.
    */
   ownerShare: number;
+  /**
+   * What the creator keeps if they decline, in Buzz, at this space's price.
+   * Already an amount rather than a rate: the fee floors at 1⚡ so a client
+   * multiplying a percentage would be wrong on cheap placements.
+   */
+  declineFee: number;
   /**
    * The count the cascade resolved, before the cap — the same relationship
    * `setPrice` has to `price`, so a caller can say "you have set 9, we are
@@ -184,7 +191,8 @@ export async function resolvePlacementSpaceFor({
   });
 
   const { max: cap, freeSlotCap } = await placementPriceRange(ownerId, surface);
-  const shares = (await getPlacementConfig()).approvalShares(surface);
+  const config = await getPlacementConfig();
+  const shares = config.approvalShares(surface);
 
   // `resolvePlacementSpace` is the one place the surface default is applied, so
   // this reads it rather than defaulting again — the same shape as `setPrice`
@@ -211,6 +219,20 @@ export async function resolvePlacementSpaceFor({
     price: effectivePlacementPrice(resolved.price, cap),
     cap,
     ownerShare: 1 - shares.seller - shares.platform,
+    /**
+     * What the creator keeps if they decline, in Buzz, at this space's price.
+     *
+     * Computed here rather than shipped as a rate: the rate is operator-tunable
+     * and the floor is not linear — `declineFeeAmount` clamps to a minimum of 1
+     * so the fee cannot round away to nothing on a cheap placement — so a client
+     * multiplying a percentage would be quietly wrong on exactly the cheap
+     * placements the floor exists for. The placer is told an amount because an
+     * amount is what leaves their wallet.
+     */
+    declineFee: declineFeeAmount(
+      effectivePlacementPrice(resolved.price, cap) ?? 0,
+      config.declineFeeRate(surface)
+    ),
     setFreeSlots,
     freeSlots,
     freeSlotCap,

--- a/src/store/sticker-placement-draft.store.ts
+++ b/src/store/sticker-placement-draft.store.ts
@@ -128,6 +128,17 @@ interface StickerPlacementDraftStore {
   interactionPointerId: number | null;
   /** Idempotency keys for pack purchases, one per sticker per session. */
   packKeys: Record<number, string>;
+  /**
+   * Drafts whose own buy button paid for a use, oldest purchase first.
+   *
+   * 🔴 WITHOUT THIS THE USE GOES TO THE WRONG STICKER. Coverage is otherwise
+   * assigned in creation order, so buying a use from the second of two copies
+   * raised the balance and covered the FIRST — the button that was pressed did
+   * not change, which reads as a purchase that failed.
+   */
+  paidDraftIds: string[];
+  /** Records that this draft's own purchase bought a use. */
+  markPaidForUse: (draftId: string) => void;
 
   open: (imageId: number) => void;
   /** End the session outright — every draft, the panel and the target. */
@@ -267,11 +278,15 @@ const ENDED = {
   // Minted per session: a key reused across sessions would have the server
   // refuse a purchase someone genuinely wants to make again.
   packKeys: {} as Record<number, string>,
+  // Cleared with the session for the same reason the keys are: it describes
+  // purchases made against THESE drafts.
+  paidDraftIds: [] as string[],
 };
 
 export const useStickerPlacementDraftStore = create<StickerPlacementDraftStore>((set, get) => ({
   drafts: [],
   packKeys: {},
+  paidDraftIds: [],
   selectedDraftId: null,
   targetImageId: null,
   trayOpen: false,
@@ -392,6 +407,13 @@ export const useStickerPlacementDraftStore = create<StickerPlacementDraftStore>(
     set((state) => ({ packKeys: { ...state.packKeys, [cosmeticId]: key } }));
     return key;
   },
+
+  markPaidForUse: (draftId) =>
+    set((state) =>
+      state.paidDraftIds.includes(draftId)
+        ? state
+        : { paidDraftIds: [...state.paidDraftIds, draftId] }
+    ),
 
   clearPackPurchaseKey: (cosmeticId) =>
     set((state) => {

--- a/src/store/sticker-placement-draft.store.ts
+++ b/src/store/sticker-placement-draft.store.ts
@@ -126,6 +126,8 @@ interface StickerPlacementDraftStore {
    * sticker.
    */
   interactionPointerId: number | null;
+  /** Idempotency keys for pack purchases, one per sticker per session. */
+  packKeys: Record<number, string>;
 
   open: (imageId: number) => void;
   /** End the session outright — every draft, the panel and the target. */
@@ -157,6 +159,19 @@ interface StickerPlacementDraftStore {
    */
   markPurchased: (cosmeticId: number, draftId?: string) => void;
   setInteraction: (interaction: StickerInteraction | null, pointerId?: number) => void;
+  /**
+   * The idempotency key for buying one particular sticker in this session.
+   *
+   * 🔴 PER COSMETIC, NOT PER DRAFT, AND THAT IS THE WHOLE POINT. A pack grants
+   * the STICKER — `markPurchased` then frees every draft of it — so two copies
+   * of one sticker showing two buy buttons are one buying intent wearing two
+   * faces. Minted per draft, pressing both inside the same second is two keys
+   * and two charges for the thing you only get once. Duplicating made that a
+   * click apart rather than two shop drags apart, which is why it is fixed here.
+   *
+   * Cleared with the session, so a later session can legitimately buy again.
+   */
+  packPurchaseKey: (cosmeticId: number) => string;
   /**
    * A second copy of a draft, ready to be placed on its own.
    *
@@ -192,6 +207,13 @@ const clamp = (value: number, min: number, max: number) => Math.min(Math.max(val
  */
 const DUPLICATE_OFFSET = 0.04;
 
+/**
+ * One axis of a duplicate's position: away from the original, and never off the
+ * image. Moves back toward the middle when a forward nudge would not fit.
+ */
+const nudge = (value: number) =>
+  clamp(value + DUPLICATE_OFFSET <= 1 ? value + DUPLICATE_OFFSET : value - DUPLICATE_OFFSET, 0, 1);
+
 let draftSequence = 0;
 
 /**
@@ -212,6 +234,19 @@ const nextDraftId = () =>
     ? crypto.randomUUID()
     : `draft-${++draftSequence}`;
 
+/**
+ * A purchase's idempotency key, which the server refuses a repeat of.
+ *
+ * Feature-detected for the same reason the draft ids are: `crypto.randomUUID` is
+ * undefined outside a secure context, and throwing here would take down the buy
+ * button on any http origin that is not localhost.
+ */
+let purchaseKeySequence = 0;
+const nextPurchaseKey = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `00000000-0000-4000-8000-${String(++purchaseKeySequence).padStart(12, '0')}`;
+
 const ENDED = {
   targetImageId: null,
   trayOpen: false,
@@ -219,10 +254,14 @@ const ENDED = {
   selectedDraftId: null,
   interaction: null,
   interactionPointerId: null,
+  // Minted per session: a key reused across sessions would have the server
+  // refuse a purchase someone genuinely wants to make again.
+  packKeys: {} as Record<number, string>,
 };
 
-export const useStickerPlacementDraftStore = create<StickerPlacementDraftStore>((set) => ({
+export const useStickerPlacementDraftStore = create<StickerPlacementDraftStore>((set, get) => ({
   drafts: [],
+  packKeys: {},
   selectedDraftId: null,
   targetImageId: null,
   trayOpen: false,
@@ -335,6 +374,15 @@ export const useStickerPlacementDraftStore = create<StickerPlacementDraftStore>(
       return { drafts: [...state.drafts, draft], selectedDraftId: draft.id };
     }),
 
+  packPurchaseKey: (cosmeticId) => {
+    const existing = get().packKeys[cosmeticId];
+    if (existing) return existing;
+
+    const key = nextPurchaseKey();
+    set((state) => ({ packKeys: { ...state.packKeys, [cosmeticId]: key } }));
+    return key;
+  },
+
   duplicateDraft: (id, purchase) =>
     set((state) => {
       const source = state.drafts.find((draft) => draft.id === id);
@@ -342,21 +390,23 @@ export const useStickerPlacementDraftStore = create<StickerPlacementDraftStore>(
 
       const copy: StickerDraft = {
         ...source,
-        ...(purchase ? { purchase } : {}),
+        // One mechanism, not two: the caller's answer wins outright, including
+        // when the answer is "nothing to buy". `markPurchased` already writes an
+        // undefined `purchase` elsewhere in this store, so an own key holding
+        // undefined is the shape the rest of the code already reads.
+        purchase,
         id: nextDraftId(),
         // Offset so the copy is visibly its own sticker rather than an exact
-        // overlap the placer has to discover by dragging the top one off. Down
-        // and right by the same nudge in both axes, clamped so a duplicate of a
-        // sticker already at the edge lands ON the image rather than outside it.
-        x: clamp(source.x + DUPLICATE_OFFSET, 0, 1),
-        y: clamp(source.y + DUPLICATE_OFFSET, 0, 1),
+        // overlap the placer has to discover by dragging the top one off.
+        //
+        // 🔴 AWAY FROM THE EDGE, NOT CLAMPED TO IT. Clamping ate the whole nudge
+        // at exactly the case the nudge exists for: duplicate a sticker in the
+        // corner and the copy landed at the same point, so the button looked
+        // like it had done nothing. Nudging inward keeps the copy visible and
+        // on the image, which is also what the server requires of the position.
+        x: nudge(source.x),
+        y: nudge(source.y),
       };
-
-      // `purchase` is not carried over implicitly: an undefined argument means
-      // the caller looked and found nothing to buy, which is different from not
-      // having looked. Spreading `source` first and then overwriting keeps the
-      // gate only when one was handed in.
-      if (!purchase) delete copy.purchase;
 
       // Appended and selected, the same as a fresh pickup: the copy is the one
       // being positioned now, and the handles belong to it.

--- a/src/store/sticker-placement-draft.store.ts
+++ b/src/store/sticker-placement-draft.store.ts
@@ -173,6 +173,16 @@ interface StickerPlacementDraftStore {
    */
   packPurchaseKey: (cosmeticId: number) => string;
   /**
+   * Forget the key for one sticker, so the next attempt is a NEW intent.
+   *
+   * Called when a purchase fails outright. An idempotency key exists to make a
+   * retry of the SAME attempt safe; reusing it after a definitive failure is a
+   * different thing — if the server has recorded that key, the placer is locked
+   * out of buying this sticker for the rest of the session with no way back
+   * except reloading the page.
+   */
+  clearPackPurchaseKey: (cosmeticId: number) => void;
+  /**
    * A second copy of a draft, ready to be placed on its own.
    *
    * Deliberately NOT a second route into the charge path: it makes another
@@ -186,7 +196,7 @@ interface StickerPlacementDraftStore {
    * inventory at the moment the copy is made — not a property of the draft — and
    * the caller is what can see the balance.
    */
-  duplicateDraft: (id: string, purchase?: DraftPurchase) => void;
+  duplicateDraft: (id: string, purchase?: DraftPurchase) => string | null;
   /**
    * Moves one draft by id rather than "the current one". A gesture outlives the
    * selection — a press selects and then drags — so resolving the target at
@@ -383,11 +393,22 @@ export const useStickerPlacementDraftStore = create<StickerPlacementDraftStore>(
     return key;
   },
 
-  duplicateDraft: (id, purchase) =>
+  clearPackPurchaseKey: (cosmeticId) =>
     set((state) => {
-      const source = state.drafts.find((draft) => draft.id === id);
-      if (!source) return state;
+      const { [cosmeticId]: _gone, ...rest } = state.packKeys;
+      return { packKeys: rest };
+    }),
 
+  duplicateDraft: (id, purchase) => {
+    const source = get().drafts.find((draft) => draft.id === id);
+    if (!source) return null;
+
+    // The id is minted here rather than inside the updater so it can be handed
+    // back: an alt-drag has to continue against the COPY, and the caller cannot
+    // ask "which one is new" from outside without racing its own update.
+    const copyId = nextDraftId();
+
+    set((state) => {
       const copy: StickerDraft = {
         ...source,
         // One mechanism, not two: the caller's answer wins outright, including
@@ -395,7 +416,7 @@ export const useStickerPlacementDraftStore = create<StickerPlacementDraftStore>(
         // undefined `purchase` elsewhere in this store, so an own key holding
         // undefined is the shape the rest of the code already reads.
         purchase,
-        id: nextDraftId(),
+        id: copyId,
         // Offset so the copy is visibly its own sticker rather than an exact
         // overlap the placer has to discover by dragging the top one off.
         //
@@ -411,7 +432,10 @@ export const useStickerPlacementDraftStore = create<StickerPlacementDraftStore>(
       // Appended and selected, the same as a fresh pickup: the copy is the one
       // being positioned now, and the handles belong to it.
       return { drafts: [...state.drafts, copy], selectedDraftId: copy.id };
-    }),
+    });
+
+    return copyId;
+  },
 
   move: (id, next) =>
     set((state) => {

--- a/src/store/sticker-placement-draft.store.ts
+++ b/src/store/sticker-placement-draft.store.ts
@@ -158,6 +158,21 @@ interface StickerPlacementDraftStore {
   markPurchased: (cosmeticId: number, draftId?: string) => void;
   setInteraction: (interaction: StickerInteraction | null, pointerId?: number) => void;
   /**
+   * A second copy of a draft, ready to be placed on its own.
+   *
+   * Deliberately NOT a second route into the charge path: it makes another
+   * unplaced draft and nothing else, so the copy is bought and committed by the
+   * same button, the same mutation and the same guards as the first one. There
+   * is no way for a copy to be placed without being charged, because copying
+   * places nothing.
+   *
+   * `purchase` is passed in rather than cloned. The gate on the original says
+   * "this sticker has not been bought yet", which is a fact about the viewer's
+   * inventory at the moment the copy is made — not a property of the draft — and
+   * the caller is what can see the balance.
+   */
+  duplicateDraft: (id: string, purchase?: DraftPurchase) => void;
+  /**
    * Moves one draft by id rather than "the current one". A gesture outlives the
    * selection — a press selects and then drags — so resolving the target at
    * every pointer move would let a selection change mid-drag redirect it.
@@ -166,6 +181,16 @@ interface StickerPlacementDraftStore {
 }
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+/**
+ * How far a duplicate lands from the sticker it was copied from, as a fraction
+ * of the image.
+ *
+ * Big enough to see at the smallest sticker size, small enough that the copy
+ * reads as belonging to the original rather than as a new pickup dropped
+ * somewhere else.
+ */
+const DUPLICATE_OFFSET = 0.04;
 
 let draftSequence = 0;
 
@@ -308,6 +333,34 @@ export const useStickerPlacementDraftStore = create<StickerPlacementDraftStore>(
       // Appended and selected: the one just dragged out is the one being placed,
       // and the drag that created it is already in flight against it.
       return { drafts: [...state.drafts, draft], selectedDraftId: draft.id };
+    }),
+
+  duplicateDraft: (id, purchase) =>
+    set((state) => {
+      const source = state.drafts.find((draft) => draft.id === id);
+      if (!source) return state;
+
+      const copy: StickerDraft = {
+        ...source,
+        ...(purchase ? { purchase } : {}),
+        id: nextDraftId(),
+        // Offset so the copy is visibly its own sticker rather than an exact
+        // overlap the placer has to discover by dragging the top one off. Down
+        // and right by the same nudge in both axes, clamped so a duplicate of a
+        // sticker already at the edge lands ON the image rather than outside it.
+        x: clamp(source.x + DUPLICATE_OFFSET, 0, 1),
+        y: clamp(source.y + DUPLICATE_OFFSET, 0, 1),
+      };
+
+      // `purchase` is not carried over implicitly: an undefined argument means
+      // the caller looked and found nothing to buy, which is different from not
+      // having looked. Spreading `source` first and then overwriting keeps the
+      // gate only when one was handed in.
+      if (!purchase) delete copy.purchase;
+
+      // Appended and selected, the same as a fresh pickup: the copy is the one
+      // being positioned now, and the handles belong to it.
+      return { drafts: [...state.drafts, copy], selectedDraftId: copy.id };
     }),
 
   move: (id, next) =>


### PR DESCRIPTION
Placing several copies of one sticker meant a trip back through the tray for each. Justin, mid-placement: *"There needs to be like a duplicate button."*

## The safety argument, first, because this is the charge path

**Duplicating places nothing.** Placement is charged, and the allowance behind it is not simple — one free placement per person per UTC day (shared with remix galleries), plus a once-ever free slot per image, all counted inside the insert's transaction under two advisory locks taken placer-then-target. A second route into that path would have to reproduce every guard, and would be wrong the day one of them moved.

So duplicate is a **client-side clone of the draft**. It adds another unplaced sticker; the copy is bought and committed by the same button, the same mutation and the same guards as the first. The two failure shapes named on the ticket are closed *by construction* rather than by review:

| Failure shape | Why it cannot happen |
|---|---|
| A copy placed without being charged | Copying reaches no server at all — there is one entry point into `createStickerPlacement` and this is not a second one |
| A copy silently consuming a free slot | Same reason; the free/paid decision is still made by the code that already makes it |

## The purchase gate is the caller's decision, not the original's

The gate on a draft says *"this sticker has not been bought yet"* — a fact about the viewer's inventory **at the moment the copy is made**, not a property of the draft. Cloning it would be wrong in both directions:

- copy of an already-bought draft → a Place button the server refuses at `assertHasUse`
- copy made after the purchase landed → asks to buy the same sticker twice

So `duplicateDraft(id, purchase?)` takes the gate as an argument, and the layer decides: it reads the live balance, subtracts every draft of that sticker already on the image (each will spend a use when bought), and hands the copy a top-up offer **only** when the uses have actually run out. It uses the same two queries the tray uses, so it shares their cache rather than issuing its own requests.

## Free placements need no special case

The free allowance is **once ever per image**, so a copy of a free placement is simply paid — and the tray already renders *"You have already used a free sticker on this image"* before anything is pressed. Confirmed with the seat that owns that copy (`868ku9d39`). Justin has the product call on a card; the implementation is the same either way, since hiding the button would be a one-line change on top of this.

## Tests

Ten store tests and two component tests, each confirmed red on the specific revert rather than on removal of the whole feature:

| Revert | What fails |
|---|---|
| copy inherits the original's gate | `does not inherit the original's gate when the caller passes none` |
| offset not clamped | `stays on the image when the original is at the edge` |
| copy reuses the source id | `is its own draft, not a second reference to the first` |
| button not wired | `asks the host for another copy, and places nothing` |

That last one also asserts the half that matters for money: the placement mutation collected **zero** calls.

⚠️ One documented exemption: the duplicate control is pressed through the DOM rather than via a locator. Measured, the control's cluster lands at **x = −73px** in this harness — off-canvas, so a locator click spends its budget waiting for something that will never be in view. This file already documents the same limitation for the buy cluster. The exemption ends the moment the control gains a disabled or loading state.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm exec eslint` on the changed files — clean
- component + unit suites for the touched area — green

Note for reviewers: an earlier local typecheck reported an unrelated `paid-access.service.ts` error. That was a **stale local Prisma client** (PR #4112 added a model; `db:generate` had not run in this worktree, and the running dev server held the query-engine DLL). Repaired and re-verified clean against both the base and this branch.

ClickUp: [868kum38p](https://app.clickup.com/t/868kum38p)
