### PR TITLE
fix(images): getEntitiesCoverImage no longer returns meta a creator hid

### DIFF
--- a/src/server/services/__tests__/entity-cover-image-hidemeta.test.ts
+++ b/src/server/services/__tests__/entity-cover-image-hidemeta.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type * as PromClient from '~/server/prom/client';
+
+/**
+ * `getEntityCoverImage` backs a `publicProcedure` callable with arbitrary ids,
+ * so the `hideMeta` decision has to be made in SQL: the return map spreads the
+ * raw row, and nothing downstream re-filters it.
+ *
+ * The gate is therefore only observable as query text. A fixture-driven test
+ * would prove nothing — feed it a row carrying `meta` and the row leaks, which
+ * is a statement about the fixture rather than about the query.
+ */
+
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof PromClient>();
+  return { ...actual, registerCounter: () => ({ inc: vi.fn() }) };
+});
+
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/services/cosmetic.service', () => ({
+  getCosmeticsForEntity: vi.fn().mockResolvedValue({}),
+}));
+
+import { getEntityCoverImage } from '../image.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const ENTITY = { entityId: 1, entityType: 'Image' as const };
+
+const RAW_ROW = {
+  id: 1,
+  name: 'x',
+  url: 'x',
+  nsfwLevel: 1,
+  width: 1,
+  height: 1,
+  hash: 'x',
+  hideMeta: true,
+  hasMeta: false,
+  hasPositivePrompt: false,
+  createdAt: new Date(0),
+  mimeType: 'image/jpeg',
+  type: 'image',
+  metadata: null,
+  scannedAt: new Date(0),
+  needsReview: null,
+  userId: 1,
+  index: 0,
+  postId: null,
+  entityId: ENTITY.entityId,
+  entityType: ENTITY.entityType,
+};
+
+/** Runs the service and returns the query text it built. */
+async function captureQuery() {
+  const queryRaw = dbMock.dbRead.$queryRaw as unknown as ReturnType<typeof vi.fn>;
+  let strings: TemplateStringsArray | undefined;
+  queryRaw.mockImplementation((s: TemplateStringsArray) => {
+    strings = s;
+    return Promise.resolve([RAW_ROW]);
+  });
+
+  const result = await getEntityCoverImage({ entities: [ENTITY] });
+
+  // Positive control: an early return or a throw would leave every assertion
+  // below a statement about nothing.
+  expect(strings, 'getEntityCoverImage never issued its query').toBeDefined();
+  expect(result).toHaveLength(1);
+
+  return { sql: (strings as TemplateStringsArray).join('?'), row: result[0] };
+}
+
+describe('getEntityCoverImage withholds meta the creator chose to hide', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not select the meta column at all', async () => {
+    const { sql } = await captureQuery();
+
+    // A bare `i.meta,` on its own line is the leak: the row spreads straight to
+    // the client. The `hasMeta` CASE below mentions `i.meta` too, hence the
+    // line anchor rather than a substring.
+    expect(sql, 'getEntityCoverImage selects i.meta, which ships to the client').not.toMatch(
+      /^\s*i\.meta,\s*$/m
+    );
+  });
+
+  it('derives hasMeta from hideMeta, matching the other read paths', async () => {
+    const { sql } = await captureQuery();
+
+    // Drop the `i."hideMeta"` term from the CASE and this goes red naming it —
+    // a `hasMeta` that ignores the flag is the same leak one level down.
+    expect(sql).toMatch(/OR i\."hideMeta" THEN FALSE[\s\S]{0,80}?AS "hasMeta"/);
+    expect(sql).toMatch(/AND NOT i\."hideMeta"[\s\S]{0,160}?AS "hasPositivePrompt"/);
+  });
+
+  it('returns the derived booleans and no meta', async () => {
+    const { row } = await captureQuery();
+
+    expect(row).toMatchObject({ hideMeta: true, hasMeta: false, hasPositivePrompt: false });
+    expect(Object.keys(row)).not.toContain('meta');
+  });
+});

--- a/src/server/services/__tests__/entity-cover-image-hidemeta.test.ts
+++ b/src/server/services/__tests__/entity-cover-image-hidemeta.test.ts
@@ -119,10 +119,13 @@ describe('getEntityCoverImage withholds meta the creator chose to hide', () => {
     expect(sql).toMatch(/AND NOT i\."hideMeta"[\s\S]{0,160}?AS "hasPositivePrompt"/);
   });
 
-  it('returns the derived booleans and no meta', async () => {
+  // Pairs with the query assertions above: the gate is in SQL, but it is worth
+  // nothing if the return map stops spreading the derived columns through.
+  // Deliberately no `meta` absence check here — the fixture decides that, so it
+  // passes just as happily against the leaking query.
+  it('spreads the derived booleans through the return map', async () => {
     const { row } = await captureQuery();
 
     expect(row).toMatchObject({ hideMeta: true, hasMeta: false, hasPositivePrompt: false });
-    expect(Object.keys(row)).not.toContain('meta');
   });
 });

--- a/src/server/services/__tests__/entity-cover-image-hidemeta.test.ts
+++ b/src/server/services/__tests__/entity-cover-image-hidemeta.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import type * as PromClient from '~/server/prom/client';
-
 /**
  * `getEntityCoverImage` backs a `publicProcedure` callable with arbitrary ids,
  * so the `hideMeta` decision has to be made in SQL: the return map spreads the
@@ -11,11 +9,6 @@ import type * as PromClient from '~/server/prom/client';
  * would prove nothing — feed it a row carrying `meta` and the row leaks, which
  * is a statement about the fixture rather than about the query.
  */
-
-vi.mock('~/server/prom/client', async (importOriginal) => {
-  const actual = await importOriginal<typeof PromClient>();
-  return { ...actual, registerCounter: () => ({ inc: vi.fn() }) };
-});
 
 vi.mock('../../../../event-engine-common/services/metrics', () => ({
   MetricService: class {
@@ -102,12 +95,18 @@ describe('getEntityCoverImage withholds meta the creator chose to hide', () => {
   it('does not select the meta column at all', async () => {
     const { sql } = await captureQuery();
 
-    // A bare `i.meta,` on its own line is the leak: the row spreads straight to
-    // the client. The `hasMeta` CASE below mentions `i.meta` too, hence the
-    // line anchor rather than a substring.
-    expect(sql, 'getEntityCoverImage selects i.meta, which ships to the client').not.toMatch(
-      /^\s*i\.meta,\s*$/m
-    );
+    // The two CASE blocks read `i.meta` legitimately, so they come out first
+    // and whatever remains must not mention the column in any spelling. Pinning
+    // one spelling instead — `i.meta,` — would pass on `i."meta",`, on
+    // `i.meta AS meta,` and on a trailing `i.meta` with no comma, each of which
+    // re-opens the leak this file exists to catch. `metadata` and `hideMeta`
+    // survive the word boundary and the case respectively.
+    const withoutDerivations = sql.replace(/\(\s*CASE[\s\S]*?END\s*\)/g, '');
+
+    expect(
+      withoutDerivations,
+      'getEntityCoverImage selects the meta column, which ships to the client'
+    ).not.toMatch(/\bmeta\b/);
   });
 
   it('derives hasMeta from hideMeta, matching the other read paths', async () => {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -7154,8 +7154,9 @@ type GetEntityImageRaw = {
   width: number;
   height: number;
   hash: string;
-  meta: ImageMetaProps;
   hideMeta: boolean;
+  hasMeta: boolean;
+  hasPositivePrompt: boolean;
   createdAt: Date;
   mimeType: string;
   scannedAt: Date;
@@ -7198,8 +7199,21 @@ export const getEntityCoverImage = async ({
       i.width,
       i.height,
       i.hash,
-      i.meta,
       i."hideMeta",
+      (
+        CASE
+          WHEN i.meta IS NULL OR jsonb_typeof(i.meta) = 'null' OR i."hideMeta" THEN FALSE
+          ELSE TRUE
+        END
+      ) AS "hasMeta",
+      (
+        CASE
+          WHEN i.meta IS NOT NULL AND jsonb_typeof(i.meta) != 'null' AND NOT i."hideMeta"
+            AND i.meta->>'prompt' IS NOT NULL
+          THEN TRUE
+          ELSE FALSE
+        END
+      ) AS "hasPositivePrompt",
       i."createdAt",
       i."mimeType",
       i.type,


### PR DESCRIPTION
Closes ClickUp [868kur8qq](https://app.clickup.com/t/868kur8qq).

`getEntityCoverImage` selected `i.meta` and the return map spreads the raw row straight through, so an image whose creator set `hideMeta` had its generation metadata served anyway. The endpoint is a `publicProcedure` callable with arbitrary ids, so this is not scoped to a caller's own images.

The four other read paths in `image.service.ts` (`:2183`, `:6214`, `:6493`, `:6996`) already make this decision the same way: they drop the column and return `hasMeta` / `hasPositivePrompt` booleans derived in SQL. There is no shared helper — each inlines the same CASE pair — so this copies that shape exactly rather than inventing a second rule.

**Callers checked before removing the field.** None read `meta`. Three go through the tRPC procedure — `notification-thumbnails.ts`, `Profile/Sections/ShowcaseSection.tsx` and `Profile/ShowcaseItemsInput.tsx` — and all pass the row into cards or thumbnails that never touch it. A fourth calls the service directly: `user.controller.ts:1202` (`getUserCosmeticsHandler`) puts the whole row on `entityImage`, and its only consumer, `CardDecorationModal.tsx:141-149`, reads `url` / `thumbnailUrl` / `type` / `entityId` / `entityType`. That one was a fourth leak surface, closed by the same change.

(The fourth caller came out of review, not my first sweep — I grepped the procedure name `getEntitiesCoverImage` and missed the service name `getEntityCoverImage`.)

### Tests

`src/server/services/__tests__/entity-cover-image-hidemeta.test.ts` asserts on the query text, because that is where the gate lives — the return map spreads whatever the row contains, so a fixture-driven assertion would be a statement about the fixture.

The guard strips the two `CASE` blocks that read `i.meta` legitimately, then rejects any mention of the column in what remains. An earlier revision pinned the single spelling `i.meta,`, which would have passed on `i."meta",` — the quoted form this same file uses at `:2196` — and on `i.meta AS meta,` and on a trailing `i.meta`. Verified red on all four, plus on stripping the `i."hideMeta"` term from the CASEs.

A `not.toContain('meta')` assertion on the returned row was written and removed: it passes just as happily against the leaking query, because the fixture decides it.

### Not in this PR

`getImagesByEntity` (`image.service.ts:6981`) has the identical shape — it selects `i.meta` raw alongside its own `hasMeta`. Unlike the cover-image path it has live consumers: `bountyEntry.controller.ts:88` maps `meta: i.meta as ImageMetaProps` deliberately and `bounty.controller.ts:273` spreads it through. Closing it would remove metadata a bounty entry page is currently displaying, which is a product decision rather than a fix. Filed as [868kut1mt](https://app.clickup.com/t/868kut1mt).

Review also flagged that this is now the fifth verbatim copy of the `hasMeta` / `hasPositivePrompt` CASE pair, and that `imageOnSiteSql()` in `src/server/utils/image-onsite.ts` is the precedent for extracting it. Left alone deliberately: a five-call-site refactor of the hottest file in the repo does not belong in a privacy fix, and matching the existing shape exactly is what the ticket asked for. Filed as [868kut2hp](https://app.clickup.com/t/868kut2hp).

The blur / browsing-level half of the ticket was closed by 52b59d81c7 (thumbnail through `ImageGuard2`); only the `hideMeta` half was open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
