### PR TITLE
ci: give a commit on `main` a CI verdict again, and pin that it keeps one

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,11 +55,18 @@ name: Lint
 # which is why the gap read as one thing and stayed unexplained for two months:
 #
 #   1. `.github/workflows/pr-check.yml` was deleted by #2547 ("runs in Tekton,
-#      removes GH Actions pr-check"). It was the ONLY workflow this repo has
-#      ever had with `push: branches: [main]`. Everything built afterwards —
-#      this file (#3362, 2026-07-24), submodule-pin-guard, schema-drift (#3643),
-#      windows-dev-env (#4162) — is `pull_request`-only, so the main-push
-#      trigger was never rebuilt. Nobody decided that; it was lost in a move.
+#      removes GH Actions pr-check"). It carried the only live push-to-`main`
+#      trigger. Enumerated rather than assumed — every revision of every one of
+#      the 12 files that has ever existed under `.github/workflows/` was parsed,
+#      and exactly TWO have ever fired on a branch push to `main`:
+#      `docker-deploy.yml` (removed 2023-11) and `pr-check.yml`. Two near
+#      misses are worth naming so they are not re-counted: `auth-app.yml` has a
+#      `push:` block but filters on `tags:` only, which never fires on a branch
+#      push, and the last `docker-deploy.yml` had `main` commented out under
+#      `branches:`. Everything built after the deletion — this file (#3362,
+#      2026-07-24), submodule-pin-guard, schema-drift (#3643), windows-dev-env
+#      (#4162) — is `pull_request`-only, so the trigger was never rebuilt.
+#      Nobody decided that; it was lost in a move.
 #   2. CodeQL, whose runs carried the "Push on main" title in the run list,
 #      stopped the same afternoon (code-scanning default setup now reads
 #      `not-configured`). Unrelated cause, same date, no test coverage either

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,22 +47,93 @@ name: Lint
 #
 # The modified-file steps flip to blocking once the backlog is cleared, planned to
 # ride along with the Prettier 2->3 upgrade (which forces a reformat anyway).
+#
+# ── ALSO RUNS ON PUSH TO `main`, and that is not decoration ──────────────────
+#
+# Between 2026-06-14 and 2026-08-21 NO CI of any kind produced a verdict for a
+# commit on `main`. Two unrelated mechanisms happened to stop on the same day,
+# which is why the gap read as one thing and stayed unexplained for two months:
+#
+#   1. `.github/workflows/pr-check.yml` was deleted by #2547 ("runs in Tekton,
+#      removes GH Actions pr-check"). It was the ONLY workflow this repo has
+#      ever had with `push: branches: [main]`. Everything built afterwards —
+#      this file (#3362, 2026-07-24), submodule-pin-guard, schema-drift (#3643),
+#      windows-dev-env (#4162) — is `pull_request`-only, so the main-push
+#      trigger was never rebuilt. Nobody decided that; it was lost in a move.
+#   2. CodeQL, whose runs carried the "Push on main" title in the run list,
+#      stopped the same afternoon (code-scanning default setup now reads
+#      `not-configured`). Unrelated cause, same date, no test coverage either
+#      way — it is named here only so the next reader does not "confirm" the
+#      workflow deletion by pointing at a CodeQL run and vice versa.
+#
+# And Tekton does NOT close it. The in-cluster `pr-check` pipeline is driven by
+# a resource that watches OPEN PULL REQUESTS targeting `main`; the only
+# main-branch trigger is a container image build for the staging deployment,
+# which runs no test suite and posts no commit status. So "Tekton covers main"
+# is false, and was the assumption that let the gap persist.
+#
+# What that cost, concretely: a3e790ff2e was pushed straight to `main` with no
+# PR, broke `model-file-scan.service.test.ts`, and sat undetected for ~7 hours.
+# It surfaced only when unrelated PRs inherited the failure through their merge
+# commits — every open PR going red at once, which reads as a CI outage rather
+# than as one bad commit.
+#
+# The push path deliberately does NOT run every job here. `eslint` is diff-vs-
+# base by construction and is skipped; so are the three sibling workflows
+# (schema-drift, submodule-pin-guard, windows-dev-env), which are all
+# base-relative gates with nothing to compare against on a push. The consequence
+# is worth stating rather than leaving implied: the added-file ESLint/Prettier
+# gate and the stray-migrations guard remain reachable only through a PR, so a
+# direct push to `main` still bypasses them. Closing that is a separate change,
+# and requires deciding what "the base" means for a push.
+#
+# A red run on `main` blocks nothing — the merge has already happened, and
+# `main` carries no required_status_checks in any case. Its whole value is that
+# it renders RED, on the commit that caused it, within minutes instead of
+# whenever the next PR happens to inherit it.
 
 on:
   pull_request:
     branches: [main, release]
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+# On a PR this is unchanged: `github.ref` is `refs/pull/N/merge`, so a new push
+# to the branch cancels the in-flight run.
+#
+# On a push to `main` it MUST NOT be `github.ref` — that is the same string for
+# every commit on the branch, so a busy `main` would cancel its own runs and the
+# only commit with a verdict would be whichever one happened to be last. Worse,
+# the losers would render as `cancelled`, a status this repo already has an open
+# complaint about being indistinguishable from a real failure. Grouping by
+# `github.sha` gives each commit its own group, so nothing cancels anything and
+# every commit on `main` gets its own answer.
 concurrency:
-  group: lint-${{ github.ref }}
+  group: lint-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 
 jobs:
   eslint:
     name: ESLint + Prettier (changed files)
     runs-on: ubuntu-latest
+    # PULL REQUESTS ONLY, and not as a matter of taste. Every step in this job
+    # is defined against `FETCH_HEAD...HEAD` where FETCH_HEAD is
+    # `origin/$BASE_REF`, and `github.base_ref` is EMPTY on a push event — so on
+    # `main` the first step would run `git fetch -q origin ""` and the job would
+    # fail for a reason that has nothing to do with the code. "Changed files" is
+    # a PR concept here; a push has no base to diff against.
+    #
+    # `scripts/__tests__/main-branch-ci-coverage.test.ts` pins this as a
+    # RELATIONSHIP rather than as this one job's setting: any job in this file
+    # that reads `github.base_ref` or `github.event.pull_request` must be gated
+    # to pull_request events. That is the guard that catches the NEXT
+    # base-relative job someone adds, which would otherwise be red on every
+    # commit to `main` from the day it lands.
+    if: github.event_name == 'pull_request'
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -174,7 +245,7 @@ jobs:
           echo "all modified files formatted"
 
   typecheck:
-    name: Typecheck (fork PRs / non-main base)
+    name: Typecheck (main pushes / fork PRs / non-main base)
     runs-on: ubuntu-latest
     # 🔴 NARROWED, not retired (talos-infra #855, stage 1). The in-cluster Tekton
     # `pr-check` pipeline runs `tsc --noEmit` on every PR and posts the result as
@@ -199,16 +270,35 @@ jobs:
     #     recent #2582, closed 2026-06-16; last merged #2248, 2026-05-09. Rare is
     #     what makes this cheap, not a reason to drop it.
     #
-    # Deleting either disjunct silently removes the only typecheck on that path.
+    #   push to main — the THIRD disjunct, added 2026-08-21. Read this before
+    #     trimming it as redundant with the first: the Tekton `pr-check`
+    #     pipeline is driven by a resource that watches OPEN PULL REQUESTS
+    #     targeting `main`, so a COMMIT on `main` is outside its trigger
+    #     entirely. The only Tekton trigger on the main branch builds a
+    #     container image for the staging deployment; it runs no `tsc` and posts
+    #     no status. So on this path there is no second typecheck to be a
+    #     duplicate of — this job is the only one, exactly as in the fork case.
+    #
+    # Deleting any disjunct silently removes the only typecheck on that path.
     # The honest way to retire this job entirely is to widen Tekton's coverage
     # first and prove it on a real PR of each shape.
     #
+    # ⚠️ `github.event.pull_request` is null on a push event, so BOTH PR
+    # disjuncts evaluate to `null != <string>` — which is TRUE. The push arm is
+    # therefore already implied and the explicit `github.event_name == 'push'`
+    # below is redundant *today*. It is written anyway because the redundancy is
+    # an accident of null-comparison semantics rather than a decision, and the
+    # next person to tighten these disjuncts (e.g. by pinning
+    # `github.event_name == 'pull_request' && ...`) would silently drop main
+    # coverage with no test naming it. The guard test asserts the push arm.
+    #
     # The name changed with the gate so the checks list explains its own absence.
     # Safe: neither `main` nor `release` has any required_status_checks (verified
-    # 2026-08-07 via the branch-protection API), so no merge gate keys on the old
-    # name.
+    # 2026-08-07 via the branch-protection API, re-verified 2026-08-21), so no
+    # merge gate keys on the old name.
     if: >-
-      github.event.pull_request.head.repo.full_name != github.repository
+      github.event_name == 'push'
+      || github.event.pull_request.head.repo.full_name != github.repository
       || github.event.pull_request.base.ref != 'main'
     # event-engine-common is public and fetched over HTTPS, so this needs no
     # secret — which is why the ssh-agent step is gone rather than merely unused.
@@ -274,13 +364,36 @@ jobs:
     # merge, 5 of 5 are green across 4 branches. Encouraging, and far too short a
     # window to act on — 36 minutes is not "a couple of weeks".
     #
-    # Two things to know before re-measuring. The run-level `conclusion` is USELESS
-    # here: `continue-on-error` makes it `success` while the step underneath is
-    # `failure`, so read `steps[].conclusion` from the jobs endpoint, not the run.
-    # And this workflow is `pull_request`-only, so the suite never runs against `main`
-    # itself — a trunk-red test shows up as every PR going red at once, which is the
-    # signature to look for and exactly what the 8 above turned out to be.
-    continue-on-error: true
+    # Two things to know before re-measuring. On a PULL REQUEST the run-level
+    # `conclusion` is USELESS here: `continue-on-error` makes it `success` while the
+    # step underneath is `failure`, so read `steps[].conclusion` from the jobs
+    # endpoint, not the run. That is not true of a push run — see below.
+    #
+    # The second used to read "this workflow is `pull_request`-only, so the suite
+    # never runs against `main` itself — a trunk-red test shows up as every PR going
+    # red at once". That was accurate when written and is now the thing this change
+    # fixes; the signature it describes is still worth recognising in runs from
+    # before 2026-08-21.
+    #
+    # ── REPORT-ONLY ON PULL REQUESTS, REAL VERDICT ON `main` ────────────────────
+    #
+    # The soak above is a claim about PRs and it is left exactly as it is: flipping
+    # the PR side to blocking is a separate, deliberately-unmade decision with its own
+    # open ticket, and nothing here should be read as making it.
+    #
+    # `main` is a different question, because the reason for report-only does not
+    # exist there. Report-only buys "do not red an unrelated PR over a load-timeout";
+    # on a push the merge has already happened, so there is no unrelated work to red
+    # and nothing to block. What `continue-on-error: true` WOULD buy on `main` is the
+    # exact failure this repo just spent two months inside: a run whose conclusion is
+    # `success` while the suite underneath is broken. A green that has to be
+    # disbelieved is worse than no run at all — checking "is main green?" would go on
+    # returning success, and the staleness would merely have been replaced by a lie.
+    #
+    # So: the flake risk is accepted on `main` and the verdict is rendered honestly.
+    # If the suite proves too noisy there, the fix is to de-flake the tests or to
+    # narrow what runs on push — NOT to hide the result behind continue-on-error.
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -480,6 +480,36 @@ jobs:
       - name: Next SVG loader patch applied
         run: node scripts/ci/assert-next-svg-patch-applied.mjs
 
+      # Parked here for the same two reasons as the step above: it needs a completed
+      # `pnpm install` and a job that FAILS the build, and this is the cheapest one that is
+      # both. `postinstall` has already run `db:generate`, so the re-run inside the script is
+      # idempotent and costs ~1s.
+      #
+      # What it guards: `packages/civitai-db-schema/src/*` is GENERATED but TRACKED, so a
+      # commit whose author's editor reformatted it lands a file that disagrees with its own
+      # generator, and every developer then gets a spurious dirty tree after `pnpm install`.
+      # `db:check-generated` has existed for exactly this and was wired to NOTHING — measured
+      # 2026-08-21, it appeared in no workflow. `enums.ts` flipped between the wrapped and
+      # unwrapped forms FOUR times in four days (470f0fd993 0, 4214ecb10b 30, 15c1408d3d 31,
+      # a5ed2dc83e 0, d0327f55ef 31), and TWICE AFTER `15c1408d3d` made the generator emit
+      # Prettier-formatted bytes specifically to end it. That fix is correct; it was a
+      # convention with nothing enforcing it, which is why it did not hold.
+      #
+      # 🔴 The `test -f` is not decoration. `git diff --exit-code -- <path>` exits 0 when the
+      # path exists on NEITHER side, so if these files are ever moved, renamed or untracked
+      # this gate goes silently and permanently GREEN instead of failing. Verified: an
+      # `--exit-code` diff against a nonexistent sibling path exits 0 here today.
+      #
+      # 🔴 Note for anyone re-testing this: a working-tree edit CANNOT exercise it. The script
+      # regenerates before it diffs, so it overwrites your mutation and passes. The regression
+      # being caught is a COMMITTED file that disagrees with the generator, so the mutant has
+      # to be committed too. Measured both ways: uncommitted edit -> exit 0 (proves nothing),
+      # same edit committed -> exit 1 with 62 changed alias lines (= 2 x 31 aliases).
+      - name: Generated DB schema files match their generator
+        run: |
+          test -f packages/civitai-db-schema/src/enums.ts
+          pnpm run db:check-generated
+
       - name: Package unit tests
         run: pnpm run test:packages:run --reporter=default --reporter=json --outputFile=packages-report.json
 

--- a/scripts/__tests__/main-branch-ci-coverage.test.ts
+++ b/scripts/__tests__/main-branch-ci-coverage.test.ts
@@ -91,9 +91,7 @@ function reachableOnPush(job: Job): boolean {
 
 /** Every `run:` script in a job, concatenated. */
 function runScripts(job: Job): string {
-  return (job.steps ?? [])
-    .map((s) => (typeof s.run === 'string' ? s.run : ''))
-    .join('\n');
+  return (job.steps ?? []).map((s) => (typeof s.run === 'string' ? s.run : '')).join('\n');
 }
 
 /** A job's steps, serialised — everything EXCEPT the job-level `if`. See the seam test. */

--- a/scripts/__tests__/main-branch-ci-coverage.test.ts
+++ b/scripts/__tests__/main-branch-ci-coverage.test.ts
@@ -9,10 +9,12 @@ import { describe, expect, it } from 'vitest';
 //
 // THE REGRESSION THIS EXISTS FOR, stated so it is not re-derived from scratch.
 // Between 2026-06-14 and 2026-08-21 nothing produced a verdict for a commit on
-// `main`. The cause was not a decision: `.github/workflows/pr-check.yml` was the
-// only workflow this repo ever had with `push: branches: [main]`, and when #2547
-// deleted it ("runs in Tekton, removes GH Actions pr-check") the main-push
-// trigger went with it. Every workflow written afterwards is `pull_request`-only,
+// `main`. The cause was not a decision: `.github/workflows/pr-check.yml` carried
+// the only live push-to-`main` trigger, and when #2547 deleted it ("runs in
+// Tekton, removes GH Actions pr-check") that trigger went with it. Only one
+// other workflow in the repo's history ever fired on a branch push to `main`,
+// `docker-deploy.yml`, removed in 2023-11. Every workflow written afterwards is
+// `pull_request`-only,
 // so nothing rebuilt it and nothing said it was gone. A commit pushed straight to
 // `main` broke the unit suite and sat undetected for ~7 hours.
 //

--- a/scripts/__tests__/main-branch-ci-coverage.test.ts
+++ b/scripts/__tests__/main-branch-ci-coverage.test.ts
@@ -1,0 +1,227 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parse } from 'yaml';
+import { describe, expect, it } from 'vitest';
+
+// Guards that a COMMIT ON `main` gets a CI verdict.
+//
+// THE REGRESSION THIS EXISTS FOR, stated so it is not re-derived from scratch.
+// Between 2026-06-14 and 2026-08-21 nothing produced a verdict for a commit on
+// `main`. The cause was not a decision: `.github/workflows/pr-check.yml` was the
+// only workflow this repo ever had with `push: branches: [main]`, and when #2547
+// deleted it ("runs in Tekton, removes GH Actions pr-check") the main-push
+// trigger went with it. Every workflow written afterwards is `pull_request`-only,
+// so nothing rebuilt it and nothing said it was gone. A commit pushed straight to
+// `main` broke the unit suite and sat undetected for ~7 hours.
+//
+// The old runs kept reading `success`, because those June runs really did
+// succeed. "Is main green?" answered yes for two months. That is why this is a
+// test and not a convention: the failure mode is a stale TRUE, which no amount of
+// looking at the checks list surfaces.
+//
+// WHAT IS ASSERTED IS THE OUTCOME, NOT THE SPELLING. None of these name
+// `lint.yml`, and none of them care which job runs what — they ask whether a
+// push to `main` reaches a typecheck and the unit suite at all. Moving those
+// tiers into a different workflow, renaming the jobs, or splitting the file
+// keeps this green; losing main coverage does not, however it is lost.
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WORKFLOW_DIR = path.resolve(HERE, '../../.github/workflows');
+
+type Job = {
+  if?: string;
+  'continue-on-error'?: boolean | string;
+  steps?: Array<Record<string, unknown>>;
+  [k: string]: unknown;
+};
+type Workflow = {
+  name?: string;
+  on?: Record<string, unknown>;
+  concurrency?: { group?: string; 'cancel-in-progress'?: boolean | string };
+  jobs?: Record<string, Job>;
+};
+
+function loadWorkflows(): Array<{ file: string; doc: Workflow }> {
+  return readdirSync(WORKFLOW_DIR)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .sort()
+    .map((file) => ({
+      file,
+      doc: parse(readFileSync(path.join(WORKFLOW_DIR, file), 'utf8')) as Workflow,
+    }));
+}
+
+/**
+ * Does this workflow fire on a push to `main`?
+ *
+ * `on:` has three legal shapes (string, array, map) and the branch filter is
+ * optional — `push:` with no `branches` fires on every branch, `main` included.
+ * Getting that wrong in the permissive direction is how a guard reports covered
+ * over nothing, so absence of a filter counts as covering `main` only because it
+ * genuinely does.
+ */
+function triggersOnPushToMain(doc: Workflow): boolean {
+  const on = doc.on as unknown;
+  if (typeof on === 'string') return on === 'push';
+  if (Array.isArray(on)) return on.includes('push');
+  if (!on || typeof on !== 'object') return false;
+  if (!('push' in on)) return false;
+  const push = (on as Record<string, unknown>).push as { branches?: string[] } | null;
+  if (push === null || push === undefined) return true;
+  if (!push.branches) return true;
+  return push.branches.includes('main');
+}
+
+/**
+ * Is this job reachable on a push event?
+ *
+ * Conservative in the direction that matters: an `if` this does not understand
+ * counts as reachable, so an unrecognised gate makes the coverage assertions
+ * STRICTER (the job's steps get scanned for PR-only inputs), never weaker.
+ */
+function reachableOnPush(job: Job): boolean {
+  const cond = (job.if ?? '').replace(/\s+/g, ' ');
+  return !(
+    cond.includes("github.event_name == 'pull_request'") ||
+    cond.includes("github.event_name != 'push'")
+  );
+}
+
+/** Every `run:` script in a job, concatenated. */
+function runScripts(job: Job): string {
+  return (job.steps ?? [])
+    .map((s) => (typeof s.run === 'string' ? s.run : ''))
+    .join('\n');
+}
+
+/** A job's steps, serialised — everything EXCEPT the job-level `if`. See the seam test. */
+function stepsBlob(job: Job): string {
+  const { if: _ignored, ...rest } = job;
+  return JSON.stringify(rest);
+}
+
+const workflows = loadWorkflows();
+
+describe('CI coverage for commits on main', () => {
+  it('has at least one workflow that fires on a push to main', () => {
+    const covering = workflows.filter((w) => triggersOnPushToMain(w.doc)).map((w) => w.file);
+    // Named in the failure so the message is actionable rather than a bare false.
+    expect(
+      covering,
+      `No workflow in .github/workflows fires on a push to main. Scanned: ${workflows
+        .map((w) => w.file)
+        .join(', ')}. This is the exact state the repo sat in from 2026-06-14 to 2026-08-21.`
+    ).not.toHaveLength(0);
+  });
+
+  // The two tiers a main-only break has actually landed in. `pnpm run typecheck`
+  // rather than a bare "typecheck" on purpose: `typecheck-apps.mjs` is a
+  // different, narrower thing and would satisfy a looser match while the
+  // whole-repo typecheck was gone.
+  it.each([
+    ['the whole-repo typecheck', 'pnpm run typecheck'],
+    ['the unit suite', 'test:unit:run'],
+  ])('runs %s on a push to main', (_label, needle) => {
+    const reached = workflows
+      .filter((w) => triggersOnPushToMain(w.doc))
+      .flatMap((w) =>
+        Object.entries(w.doc.jobs ?? {})
+          .filter(([, job]) => reachableOnPush(job))
+          .map(([id, job]) => ({ where: `${w.file}:${id}`, script: runScripts(job) }))
+      );
+    const hit = reached.filter((j) => j.script.includes(needle)).map((j) => j.where);
+    expect(
+      hit,
+      `Nothing reachable on a push to main runs \`${needle}\`. Push-reachable jobs: ${
+        reached.map((j) => j.where).join(', ') || '(none)'
+      }`
+    ).not.toHaveLength(0);
+  });
+
+  // A green that has to be disbelieved is worse than no run. `continue-on-error`
+  // makes the RUN report `success` while the step underneath is `failure`, which
+  // is the same stale-TRUE shape as the outage this file guards — so on the push
+  // path no job may be unconditionally report-only.
+  //
+  // A conditional value is allowed (that is how the unit tier stays report-only
+  // on PRs, a separate and deliberately-unmade decision) but it must be an
+  // expression, i.e. it must be able to differ between a PR and a push. Literal
+  // `true` cannot.
+  it('has no unconditionally report-only job on the push path', () => {
+    const offenders = workflows
+      .filter((w) => triggersOnPushToMain(w.doc))
+      .flatMap((w) =>
+        Object.entries(w.doc.jobs ?? {})
+          .filter(([, job]) => reachableOnPush(job))
+          .filter(([, job]) => {
+            const coe = job['continue-on-error'];
+            if (coe === undefined || coe === false) return false;
+            if (coe === true) return true;
+            // A string that is not an expression is YAML-truthy in spirit and
+            // opaque in fact — treat it as an offender rather than guess.
+            return !(typeof coe === 'string' && coe.includes('${{'));
+          })
+          .map(([id]) => `${w.file}:${id}`)
+      );
+    expect(
+      offenders,
+      `These jobs run on a push to main with \`continue-on-error: true\`, so the run reports success while the step underneath fails: ${offenders.join(
+        ', '
+      )}`
+    ).toEqual([]);
+  });
+
+  // THE SEAM GUARD, and the one most likely to earn its keep. `github.base_ref`
+  // is the EMPTY STRING on a push event and `github.event.pull_request` is null.
+  // A job that consumes either as step input is a PR-shaped job; leave it
+  // reachable on a push and it fails on every commit to `main` for a reason
+  // unrelated to the code — which is how a permanently-red gate gets switched
+  // off, taking the real coverage with it.
+  //
+  // The job-level `if` is deliberately exempt: a null-safe comparison there is
+  // how a job decides not to run, which is the correct use. This scans the
+  // steps.
+  it('runs no job on the push path whose STEPS consume PR-only context', () => {
+    const offenders = workflows
+      .filter((w) => triggersOnPushToMain(w.doc))
+      .flatMap((w) =>
+        Object.entries(w.doc.jobs ?? {})
+          .filter(([, job]) => reachableOnPush(job))
+          .flatMap(([id, job]) => {
+            const blob = stepsBlob(job);
+            return ['github.base_ref', 'github.event.pull_request']
+              .filter((ctx) => blob.includes(ctx))
+              .map((ctx) => `${w.file}:${id} uses ${ctx}`);
+          })
+      );
+    expect(
+      offenders,
+      `Gate these jobs to \`if: github.event_name == 'pull_request'\`, or give the step a push-valid base. ${offenders.join(
+        '; '
+      )}`
+    ).toEqual([]);
+  });
+
+  // Every commit on main must get its OWN verdict. A concurrency group keyed on
+  // `github.ref` is one group for the whole branch, so a busy main cancels its
+  // own runs and only the last commit is ever checked — and the losers render as
+  // `cancelled`, which this repo already cannot distinguish from a real failure.
+  //
+  // This asserts the group VARIES per commit, the only property that matters;
+  // `github.sha` is the way to say that in a GitHub expression.
+  it('gives each commit on main its own concurrency group', () => {
+    for (const { file, doc } of workflows) {
+      if (!triggersOnPushToMain(doc)) continue;
+      const group = doc.concurrency?.group;
+      const cancels = doc.concurrency?.['cancel-in-progress'];
+      if (group === undefined) continue; // no grouping at all: nothing cancels anything
+      if (cancels === false || cancels === undefined) continue; // grouped but never cancels
+      expect(
+        group,
+        `${file} cancels in-progress runs and its concurrency group does not vary per commit, so commits on main would cancel each other and only the last would be checked.`
+      ).toContain('github.sha');
+    }
+  });
+});


### PR DESCRIPTION
ci: give a commit on `main` a CI verdict again, and pin that it keeps one

Nothing has produced a CI verdict for a commit on `main` since 2026-06-14. The
cause was not a decision: `.github/workflows/pr-check.yml` was the only workflow
this repo has ever had with `push: branches: [main]`, and #2547 deleted it while
moving PR checks to Tekton. Every workflow written since — lint (#3362),
submodule-pin-guard, schema-drift (#3643), windows-dev-env (#4162) — is
`pull_request`-only, so the main-push trigger was never rebuilt and nothing said
it was gone.

Tekton does not close the gap. Its `pr-check` pipeline is driven by a resource
that watches open pull requests targeting `main`; the only main-branch trigger
builds a container image for the staging deployment, runs no test suite and
posts no commit status. "Tekton covers main" is the assumption that let this
persist for two months.

The old June runs stayed `success`, so "is main green?" went on answering yes.
That is the expensive half: the signal was not wrong, it was stale, and
staleness is invisible unless you read the dates. a3e790ff2e was pushed straight
to `main` with no PR, broke model-file-scan.service.test.ts, and sat undetected
for ~7 hours — surfacing only when unrelated PRs inherited it through their
merge commits, which reads as a CI outage rather than as one bad commit.

What changes

- `lint.yml` also runs on `push` to `main`. Reusing this file rather than adding
  a second workflow keeps one definition of each tier; a duplicate would drift.
- `eslint` is gated to pull requests. Every step in it diffs against
  `origin/$BASE_REF`, and `github.base_ref` is empty on a push, so on `main` it
  would fail for reasons unrelated to the code. The consequence is stated in the
  file rather than left implied: the added-file lint/Prettier gate and the
  stray-migrations guard stay reachable only through a PR.
- `typecheck` gains an explicit push arm. It is redundant today only because
  `github.event.pull_request` is null on a push, which is an accident of
  null-comparison semantics rather than a decision.
- `unit` is report-only on pull requests exactly as before, and renders its real
  verdict on `main`. `continue-on-error` makes a run report `success` while the
  step underneath fails — on `main` that would replace the stale TRUE with a
  live one, which is worse. Whether the PR side flips to blocking is a separate,
  deliberately-unmade decision and is untouched here.
- The concurrency group varies per commit on a push. Keyed on `github.ref` it is
  one group for the whole branch, so a busy `main` would cancel its own runs,
  leave only the last commit checked, and render the losers as `cancelled` — a
  status this repo already cannot distinguish from a real failure.

Coverage

`scripts/__tests__/main-branch-ci-coverage.test.ts` asserts the outcome, not the
spelling: it names no workflow file and no job, and asks whether a push to
`main` reaches a whole-repo typecheck and the unit suite at all. Splitting or
renaming things keeps it green; losing main coverage does not, however it is
lost. It also pins the three ways this would decay quietly — an unconditionally
report-only job on the push path, a job whose steps consume PR-only context, and
a branch-wide concurrency group.

Six mutants, each killed by the test that owns the property: reverting the
workflow to its pre-change state (the historical defect) fails the coverage
assertions; `continue-on-error: true`, an un-gated base-ref consumer, a
`github.ref` concurrency group, and gating either the typecheck or the unit tier
away from push each fail exactly one test, by name.

---

Verification

- The push path was exercised on a real `push` event from a throwaway branch (`zach/ci-main-verify`, deleted after) carrying the same job definitions with its own name temporarily added to `push.branches`. Run IDs are in the PR discussion below.
- The guard test: 6 mutants, each killed by the test that owns the property. Green at HEAD, red when the workflow is reverted to its pre-change state.
- `actionlint` clean on the workflow, with a positive control confirming it can go red.
