### PR TITLE
fix(api): booleanString over z.coerce.boolean, plus a guard so it stops recurring

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "test:packages:run": "vitest run --project '@civitai/*'",
     "test:apps": "vitest --project 'app:*'",
     "test:apps:run": "vitest run --project 'app:*'",
-    "test:lint-rules": "vitest run --project 'unit*' src/server/services/__tests__/hub-filter-parity.test.ts src/server/services/__tests__/no-io-in-transaction.test.ts src/server/services/__tests__/no-module-scope-cache.test.ts src/server/services/__tests__/no-server-infra-in-app-graph.test.ts src/server/services/__tests__/no-stale-moderator-route-probe.test.ts src/server/services/__tests__/no-unbounded-paging-fake.test.ts src/server/services/__tests__/no-unloadable-image-fixture.test.ts src/server/services/__tests__/no-wholesale-module-mock.test.ts",
+    "test:lint-rules": "vitest run --project 'unit*' src/server/services/__tests__/hub-filter-parity.test.ts src/server/services/__tests__/no-coerce-boolean-in-api.test.ts src/server/services/__tests__/no-io-in-transaction.test.ts src/server/services/__tests__/no-module-scope-cache.test.ts src/server/services/__tests__/no-server-infra-in-app-graph.test.ts src/server/services/__tests__/no-stale-moderator-route-probe.test.ts src/server/services/__tests__/no-unbounded-paging-fake.test.ts src/server/services/__tests__/no-unloadable-image-fixture.test.ts src/server/services/__tests__/no-wholesale-module-mock.test.ts",
     "test:component": "vitest run --project component",
     "test:component:watch": "vitest --project component",
     "meilisearch:migrate": "NODE_ENV=development tsx scripts/oneoffs/meilisearch-migration.ts",

--- a/src/pages/api/mod/daily-challenge/backfill-theme-elements.ts
+++ b/src/pages/api/mod/daily-challenge/backfill-theme-elements.ts
@@ -11,11 +11,15 @@ import { parseChallengeMetadata } from '~/server/schema/challenge.schema';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import { createLogger } from '~/utils/logging';
+import { booleanString } from '~/utils/zod-helpers';
 
 const log = createLogger('api:backfill-theme-elements', 'cyan');
 
 const schema = z.object({
-  force: z.coerce.boolean().optional().default(false),
+  // booleanString, not z.coerce.boolean: this schema is parsed against req.query, where
+  // coerce runs JS Boolean() and makes `?force=false` TRUE — regenerating theme elements for
+  // every themed Active/Scheduled challenge instead of only the ones missing them.
+  force: booleanString().optional().default(false),
 });
 
 type ChallengeRow = {

--- a/src/pages/api/testing/backfill-stale-nsfw-rollups.ts
+++ b/src/pages/api/testing/backfill-stale-nsfw-rollups.ts
@@ -40,6 +40,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { booleanString } from '~/utils/zod-helpers';
 
 const actionSchema = z.enum(['count', 'enqueue', 'verify']);
 
@@ -48,7 +49,10 @@ const schema = z
     action: actionSchema,
     modelId: z.coerce.number().int().positive().optional(),
     limit: z.coerce.number().int().positive().max(50_000).optional(),
-    dryRun: z.coerce.boolean().optional(),
+    // booleanString, not z.coerce.boolean: this schema is parsed against req.query, where
+    // coerce runs JS Boolean() and makes `?dryRun=false` TRUE — enqueue then writes nothing
+    // and reports a preview, so the backfill looks done without a single row queued.
+    dryRun: booleanString().optional(),
   })
   .superRefine((data, ctx) => {
     if (data.action === 'verify' && data.limit !== undefined) {

--- a/src/pages/api/v1/models/index.ts
+++ b/src/pages/api/v1/models/index.ts
@@ -1,10 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { Session } from '~/types/session';
-import * as z from 'zod';
-
 import { CollectionType } from '~/shared/utils/prisma/enums';
 import type { GetAllModelsInput } from '~/server/schema/model.schema';
-import { getAllModelsSchema } from '~/server/schema/model.schema';
+import { modelsEndpointSchema } from '~/server/schema/model.schema';
 import {
   ModelSearchMeiliTimeoutError,
   resolveModelSearchIds,
@@ -18,7 +16,6 @@ import {
   publicBrowsingLevelsFlag,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
-import { booleanString } from '~/utils/zod-helpers';
 import { getUserBookmarkCollections } from '~/server/services/user.service';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 
@@ -36,14 +33,6 @@ export const config = {
 };
 
 const authedOnlyOptions: Array<keyof GetAllModelsInput> = ['favorites', 'hidden'];
-
-export const modelsEndpointSchema = getAllModelsSchema.extend({
-  limit: z.preprocess((val) => Number(val), z.number().min(0).max(100)).default(100),
-  nsfw: booleanString().optional(),
-  primaryFileOnly: booleanString().optional(),
-  favorites: booleanString().optional().default(false),
-  hidden: booleanString().optional().default(false),
-});
 
 export default MixedAuthEndpoint(async function handler(
   req: NextApiRequest,

--- a/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
+++ b/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type * as z from 'zod';
-import { getAllModelsSchema } from '~/server/schema/model.schema';
-import { modelsEndpointSchema } from '~/pages/api/v1/models';
+import { getAllModelsSchema, modelsEndpointSchema } from '~/server/schema/model.schema';
 
 /**
  * /api/v1/models parses this schema straight off `req.query`, where every value is a

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -139,6 +139,15 @@ export const getAllModelsSchema = z.object({
 export type GetAllModelsInput = z.input<typeof getAllModelsSchema>;
 export type GetAllModelsOutput = z.infer<typeof getAllModelsSchema>;
 
+/** Query contract for /api/v1/models, which parses it off `req.query` where every value is a string. */
+export const modelsEndpointSchema = getAllModelsSchema.extend({
+  limit: z.preprocess((val) => Number(val), z.number().min(0).max(100)).default(100),
+  nsfw: booleanString().optional(),
+  primaryFileOnly: booleanString().optional(),
+  favorites: booleanString().optional().default(false),
+  hidden: booleanString().optional().default(false),
+});
+
 export type ModelInput = z.infer<typeof modelSchema>;
 export const modelSchema = licensingSchema.extend({
   id: z.number().optional(),

--- a/src/server/services/__tests__/__fixtures__/coerce-boolean-fixture.ts
+++ b/src/server/services/__tests__/__fixtures__/coerce-boolean-fixture.ts
@@ -1,0 +1,7 @@
+// Fixture for no-coerce-boolean-in-api.test.ts: the shape the guard must catch. Kept out of
+// src/pages/api so it is a control for the matcher, not a violation of the rule.
+import * as z from 'zod';
+
+export const schema = z.object({
+  dryRun: z.coerce.boolean().optional(),
+});

--- a/src/server/services/__tests__/no-coerce-boolean-in-api.test.ts
+++ b/src/server/services/__tests__/no-coerce-boolean-in-api.test.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Convention guard: no `z.coerce.boolean()` under src/pages/api.
+ *
+ * These handlers parse `req.query`, where every value is a string, and
+ * `z.coerce.boolean()` is JS `Boolean()` — so `?flag=false` parses as TRUE and the
+ * caller gets the opposite of what it asked for, with no error. It has shipped four
+ * separate times (deliver-prepaid-buzz, permission, backfill-theme-elements,
+ * backfill-stale-nsfw-rollups), which is why the ban is enforced here rather than
+ * fixed one site at a time.
+ *
+ * If this fails: use `booleanString()` from ~/utils/zod-helpers, which accepts the
+ * string spellings and rejects the rest.
+ */
+
+const API_DIR = path.resolve(__dirname, '../../../pages/api');
+
+/** Matches `z.coerce.boolean(`, `zod.coerce.boolean(` and a bare destructured `coerce.boolean(`. */
+const COERCE_BOOLEAN = /\bcoerce\s*\.\s*boolean\s*\(/;
+
+/**
+ * The four fixed sites each carry a comment naming `z.coerce.boolean`, so a scan over raw
+ * text reports the documentation as the violation. Line comments are only stripped when the
+ * `//` is not preceded by `:`, to leave `https://` inside a string alone.
+ */
+function stripComments(source: string) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+function walk(dir: string, files: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, files);
+    else if (/\.tsx?$/.test(entry.name)) files.push(full);
+  }
+  return files;
+}
+
+function findViolations(files: string[]) {
+  const hits: string[] = [];
+  for (const file of files) {
+    const lines = stripComments(fs.readFileSync(file, 'utf-8')).split('\n');
+    lines.forEach((line, i) => {
+      if (COERCE_BOOLEAN.test(line))
+        hits.push(`${path.relative(API_DIR, file)}:${i + 1}: ${line.trim()}`);
+    });
+  }
+  return hits;
+}
+
+/**
+ * A floor on the scan's reach, not a census. A guard whose walk silently stops finding
+ * files passes by seeing nothing, which is the failure mode this whole file exists to
+ * avoid — so the scan must prove it read the tree before it is allowed to report clean.
+ */
+const MIN_SCANNED_FILES = 200;
+
+describe('no z.coerce.boolean under src/pages/api', () => {
+  it('can read the api tree', () => {
+    // Fail closed: a missing or moved directory is a broken guard, not a clean one.
+    expect(fs.existsSync(API_DIR)).toBe(true);
+    expect(walk(API_DIR).length).toBeGreaterThanOrEqual(MIN_SCANNED_FILES);
+  });
+
+  it('detects the pattern it is looking for', () => {
+    // Without this, every assertion below is satisfiable by a matcher that matches nothing.
+    const detected = findViolations([
+      path.join(__dirname, '__fixtures__/coerce-boolean-fixture.ts'),
+    ]);
+    expect(detected).toHaveLength(1);
+  });
+
+  it('does not report the fixed sites, which name the pattern in their comments', () => {
+    expect(findViolations([path.resolve(API_DIR, 'admin/permission.ts')])).toEqual([]);
+    expect(
+      findViolations([path.resolve(API_DIR, 'mod/daily-challenge/backfill-theme-elements.ts')])
+    ).toEqual([]);
+  });
+
+  it('reports no violations', () => {
+    expect(findViolations(walk(API_DIR))).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two ClickUp follow-ups, both under `src/pages/api`.

- https://app.clickup.com/t/868kuqjy7
- https://app.clickup.com/t/868kunn0f

## 868kuqjy7 — `z.coerce.boolean()` inverts `?flag=false`

`z.coerce.boolean()` is JS `Boolean()`, so any non-empty query string — including `"false"` — parses as `true`. Two call sites the earlier sweep missed now use `booleanString()`, matching `admin/deliver-prepaid-buzz.ts` and `admin/permission.ts`:

- `testing/backfill-stale-nsfw-rollups.ts` — `dryRun`. `?dryRun=false` forced a preview, so the enqueue reported counts without queueing a row.
- `mod/daily-challenge/backfill-theme-elements.ts` — `force`. `?force=false` took the overwrite branch, regenerating theme elements for every themed Active/Scheduled challenge instead of only the ones missing them.

### The guard (the point of the task)

This was the fourth instance, so `src/server/services/__tests__/no-coerce-boolean-in-api.test.ts` scans `src/pages/api/**` for the pattern instead. Registered in the `test:lint-rules` script.

Notes on how it is built:

- **Comments are stripped before matching.** All four fixed sites name `z.coerce.boolean` in prose explaining why they don't use it — a raw text scan reports the documentation as the violation.
- **It fails closed.** A missing/moved directory throws rather than reporting clean, and the scan asserts it read at least 200 files (currently 335). A walk that silently stops finding files is the same failure mode the guard exists to prevent.
- **Positive control.** A fixture outside `src/pages/api` holds the banned shape, and one test asserts the matcher finds it — otherwise every "no violations" assertion is satisfiable by a regex that matches nothing.

**Red-check performed:** added `redCheckProbe: z.coerce.boolean().optional()` to `backfill-stale-nsfw-rollups.ts`, ran the guard, got `AssertionError: expected [ Array(1) ] to deeply equal []` naming the file and line. Removed it and the guard went green again.

## 868kunn0f — move `modelsEndpointSchema` out of the route

It lived in `src/pages/api/v1/models/index.ts`, and `get-all-models.boolean-params.schema.test.ts` imported it from there — pulling the page graph into a schema test. Moved to `src/server/schema/model.schema.ts` beside `getAllModelsSchema`, which it extends. Route and test import from the new home; the now-unused `zod` and `booleanString` imports are dropped from the route. Pure move, no behaviour change.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run test:lint-rules` — 9 files, 265 tests, green
- `pnpm run test:unit:run` — 1302 files, 20409 passed, 0 failed
- `pnpm exec eslint` over the changed files — clean
- `pnpm run prettier:write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
