### PR TITLE
fix(articles): 404 hidden/draft articles server-side instead of an indexable soft 404

### DIFF
--- a/src/components/Meta/Meta.tsx
+++ b/src/components/Meta/Meta.tsx
@@ -51,6 +51,7 @@ type MetaBaseProps<TImage> = {
   imageUrl?: string;
   ogEndpoint?: string;
   keywords?: string | string[];
+  ogType?: 'website' | 'article' | 'profile' | 'video.other';
 };
 
 export type MetaProps<TImage> = MetaBaseProps<TImage> &
@@ -70,6 +71,7 @@ export function Meta<TImage extends { nsfwLevel: number; url: string; type?: Med
   imageUrl,
   ogEndpoint,
   keywords,
+  ogType = 'website',
 }: MetaProps<TImage>) {
   const _images = images ? ([] as TImage[]).concat(images) : undefined;
   const _image = _images?.find((image) => getIsSafeBrowsingLevel(image.nsfwLevel));
@@ -106,7 +108,7 @@ export function Meta<TImage extends { nsfwLevel: number; url: string; type?: Med
         </>
       )}
       {stringifiedKeywords && <meta name="keywords" content={stringifiedKeywords} />}
-      <meta property="og:type" content="website" />
+      <meta property="og:type" content={ogType} />
       <meta property="twitter:card" content="summary_large_image" />
       {_ogImageUrl && (
         <>

--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -83,6 +83,11 @@ import classes from './[[...slug]].module.scss';
 import { RenderRichText } from '~/components/RichTextEditor/RenderRichText';
 import { useInView } from 'react-intersection-observer';
 
+const NOT_FOUND = Symbol('article-not-found');
+
+const isNotFoundError = (error: unknown) =>
+  (error as { code?: string } | null | undefined)?.code === 'NOT_FOUND';
+
 const querySchema = z.object({
   id: z.preprocess(parseNumericString, z.number()),
   slug: z.array(z.string()).optional(),
@@ -109,7 +114,15 @@ export const getServerSideProps = createServerSideProps({
 
     if (ssg) {
       // Fetch article to check slug and prefetch for client hydration
-      const article = await ssg.article.getById.fetch({ id: result.data.id }).catch(() => null);
+      const article = await ssg.article.getById
+        .fetch({ id: result.data.id })
+        .catch((error) => (isNotFoundError(error) ? NOT_FOUND : null));
+
+      // `getById` is viewer-scoped: it resolves for the owner and moderators and throws
+      // NOT_FOUND for everyone else, so this 404s a draft/hidden article for crawlers while
+      // its author still loads it. Only NOT_FOUND — any other failure keeps the 200 and lets
+      // the client refetch, rather than 404ing a live article on a transient error.
+      if (article === NOT_FOUND) return { notFound: true };
 
       if (article) {
         gating = { contentNsfwLevel: article.nsfwLevel };
@@ -333,6 +346,7 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
         canonical: `/articles/${article.id}/${slugit(article.title)}`,
         alternate: `/articles/${article.id}`,
         schema: articleSchema,
+        ogType: 'article' as const,
         deIndex: !article?.publishedAt || article?.availability === Availability.Unsearchable,
       }}
     >

--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -63,6 +63,7 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { constants } from '~/server/common/constants';
 import { unpublishReasons, type UnpublishReason } from '~/server/common/moderation-helpers';
+import { isArticlePublished } from '~/server/services/article.service';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { getBrowsingLevelLabel } from '~/shared/constants/browsingLevel.constants';
 import {
@@ -85,8 +86,11 @@ import { useInView } from 'react-intersection-observer';
 
 const NOT_FOUND = Symbol('article-not-found');
 
-const isNotFoundError = (error: unknown) =>
-  (error as { code?: string } | null | undefined)?.code === 'NOT_FOUND';
+const isNotFoundError = (error: unknown) => {
+  // `code` at the top level is a server-side `TRPCError`; `data.code` is a `TRPCClientError`.
+  const err = error as { code?: string; data?: { code?: string } } | null | undefined;
+  return err?.code === 'NOT_FOUND' || err?.data?.code === 'NOT_FOUND';
+};
 
 const querySchema = z.object({
   id: z.preprocess(parseNumericString, z.number()),
@@ -114,15 +118,20 @@ export const getServerSideProps = createServerSideProps({
 
     if (ssg) {
       // Fetch article to check slug and prefetch for client hydration
-      const article = await ssg.article.getById
+      const fetched = await ssg.article.getById
         .fetch({ id: result.data.id })
         .catch((error) => (isNotFoundError(error) ? NOT_FOUND : null));
 
       // `getById` is viewer-scoped: it resolves for the owner and moderators and throws
       // NOT_FOUND for everyone else, so this 404s a draft/hidden article for crawlers while
-      // its author still loads it. Only NOT_FOUND — any other failure keeps the 200 and lets
-      // the client refetch, rather than 404ing a live article on a transient error.
-      if (article === NOT_FOUND) return { notFound: true };
+      // its author still loads it. The publish check keeps a live article out of that branch —
+      // `getById` also throws NOT_FOUND while a published article is being re-scanned after an
+      // edit, and a 404 on an indexed URL is not a state to enter transiently. Any other
+      // failure keeps the 200 and lets the client refetch.
+      if (fetched === NOT_FOUND && !(await isArticlePublished(result.data.id)))
+        return { notFound: true };
+
+      const article = fetched === NOT_FOUND ? null : fetched;
 
       if (article) {
         gating = { contentNsfwLevel: article.nsfwLevel };

--- a/src/server/__tests__/article-page-ssr.test.ts
+++ b/src/server/__tests__/article-page-ssr.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * `/articles/<id>` SSR: which article states reach a crawler as a 200.
+ *
+ * `article.getById` is viewer-scoped — it resolves for the owner and moderators and throws
+ * NOT_FOUND for everyone else — so the resolver's handling of that rejection is the whole
+ * owner-vs-crawler distinction. Asserted here rather than through the component, because the
+ * client render happens after the status code is already committed.
+ */
+
+type Resolver = (ctx: any) => Promise<any>;
+
+let capturedResolver: Resolver | undefined;
+
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  createServerSideProps: ({ resolver }: { resolver: Resolver }) => {
+    capturedResolver = resolver;
+    return vi.fn();
+  },
+}));
+
+const ARTICLE_ID = 33867;
+const SLUG = 'pixel-forge-basics';
+
+const article = {
+  id: ARTICLE_ID,
+  title: 'Pixel Forge Basics',
+  nsfwLevel: 1,
+  publishedAt: null,
+  user: { id: 42 },
+};
+
+const run = async (fetchImpl: () => Promise<unknown>) => {
+  if (!capturedResolver) await import('~/pages/articles/[id]/[[...slug]]');
+  if (!capturedResolver) throw new Error('resolver was never captured');
+
+  return capturedResolver({
+    ctx: { query: { id: String(ARTICLE_ID), slug: [SLUG] } },
+    isClient: false,
+    ssg: {
+      article: { getById: { fetch: vi.fn(fetchImpl) } },
+      hiddenPreferences: { getHidden: { prefetch: vi.fn(async () => undefined) } },
+    },
+  });
+};
+
+const trpcError = (code: string) => Object.assign(new Error(code), { code, name: 'TRPCError' });
+
+describe('article detail SSR', () => {
+  it('404s an article the viewer cannot see, instead of a 200 with no content', async () => {
+    const result = await run(async () => {
+      throw trpcError('NOT_FOUND');
+    });
+
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it('serves the article to a viewer who can see it — the owner reading their own draft', async () => {
+    const result = await run(async () => article);
+
+    expect(result.notFound).toBeUndefined();
+    expect(result.redirect).toBeUndefined();
+    expect(result.props).toMatchObject({ id: ARTICLE_ID });
+  });
+
+  it('keeps serving the page when the fetch fails for a reason other than NOT_FOUND', async () => {
+    const result = await run(async () => {
+      throw trpcError('INTERNAL_SERVER_ERROR');
+    });
+
+    expect(result.notFound).toBeUndefined();
+    expect(result.props).toMatchObject({ id: ARTICLE_ID });
+  });
+});

--- a/src/server/__tests__/article-page-ssr.test.ts
+++ b/src/server/__tests__/article-page-ssr.test.ts
@@ -1,29 +1,46 @@
+import { TRPCError } from '@trpc/server';
 import { describe, expect, it, vi } from 'vitest';
+import type * as ArticleService from '~/server/services/article.service';
 
 /**
- * `/articles/<id>` SSR: which article states reach a crawler as a 200.
+ * `/articles/<id>` SSR: which article states reach a crawler as a 200, and which as a 404.
  *
  * `article.getById` is viewer-scoped — it resolves for the owner and moderators and throws
  * NOT_FOUND for everyone else — so the resolver's handling of that rejection is the whole
  * owner-vs-crawler distinction. Asserted here rather than through the component, because the
  * client render happens after the status code is already committed.
+ *
+ * This covers the resolver only. `createServerSideProps` turning `{ notFound: true }` into a Next
+ * 404 is pinned in `session-props.test.ts`, since driving it for real needs a wholesale router
+ * mock the mock-surface guard bans.
  */
 
 type Resolver = (ctx: any) => Promise<any>;
 
-let capturedResolver: Resolver | undefined;
+// `vi.hoisted` so these exist before the hoisted page import below runs the module factory.
+const captured = vi.hoisted(() => ({ resolver: undefined as Resolver | undefined }));
+const isArticlePublishedMock = vi.hoisted(() => vi.fn(async () => false));
 
 vi.mock('~/server/utils/server-side-helpers', () => ({
   createServerSideProps: ({ resolver }: { resolver: Resolver }) => {
-    capturedResolver = resolver;
+    captured.resolver = resolver;
     return vi.fn();
   },
 }));
 
+vi.mock('~/server/services/article.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ArticleService>()),
+  isArticlePublished: (...args: [number]) => isArticlePublishedMock(...args),
+}));
+
+// Module scope, not inside a test: transforming the page's graph (Mantine, tabler, the SCSS
+// module) inside the first test's clock is what makes a file like this red on a busy box.
+import '~/pages/articles/[id]/[[...slug]]';
+
 const ARTICLE_ID = 33867;
 const SLUG = 'pixel-forge-basics';
 
-const article = {
+const draft = {
   id: ARTICLE_ID,
   title: 'Pixel Forge Basics',
   nsfwLevel: 1,
@@ -31,33 +48,53 @@ const article = {
   user: { id: 42 },
 };
 
-const run = async (fetchImpl: () => Promise<unknown>) => {
-  if (!capturedResolver) await import('~/pages/articles/[id]/[[...slug]]');
-  if (!capturedResolver) throw new Error('resolver was never captured');
+const run = async ({
+  fetchImpl,
+  published = false,
+  clientNav = false,
+}: {
+  fetchImpl?: () => Promise<unknown>;
+  published?: boolean;
+  clientNav?: boolean;
+}) => {
+  if (!captured.resolver) throw new Error('resolver was never captured');
+  isArticlePublishedMock.mockResolvedValue(published);
 
-  return capturedResolver({
+  return captured.resolver({
     ctx: { query: { id: String(ARTICLE_ID), slug: [SLUG] } },
-    isClient: false,
-    ssg: {
-      article: { getById: { fetch: vi.fn(fetchImpl) } },
-      hiddenPreferences: { getHidden: { prefetch: vi.fn(async () => undefined) } },
-    },
+    isClient: clientNav,
+    ssg: clientNav
+      ? undefined
+      : {
+          article: { getById: { fetch: vi.fn(fetchImpl) } },
+          hiddenPreferences: { getHidden: { prefetch: vi.fn(async () => undefined) } },
+        },
   });
 };
 
-const trpcError = (code: string) => Object.assign(new Error(code), { code, name: 'TRPCError' });
+const rejectWith = (code: TRPCError['code']) => async () => {
+  throw new TRPCError({ code });
+};
 
 describe('article detail SSR', () => {
-  it('404s an article the viewer cannot see, instead of a 200 with no content', async () => {
-    const result = await run(async () => {
-      throw trpcError('NOT_FOUND');
-    });
+  it('404s an article the viewer cannot see and nobody else can either', async () => {
+    const result = await run({ fetchImpl: rejectWith('NOT_FOUND'), published: false });
 
     expect(result).toEqual({ notFound: true });
   });
 
   it('serves the article to a viewer who can see it — the owner reading their own draft', async () => {
-    const result = await run(async () => article);
+    const result = await run({ fetchImpl: async () => draft });
+
+    expect(result.notFound).toBeUndefined();
+    expect(result.redirect).toBeUndefined();
+    expect(result.props).toMatchObject({ id: ARTICLE_ID });
+    expect(result.suppressAds).toBe(true);
+    expect(result.gating).toEqual({ contentNsfwLevel: draft.nsfwLevel });
+  });
+
+  it('keeps serving a published article that is only unreadable while it re-scans', async () => {
+    const result = await run({ fetchImpl: rejectWith('NOT_FOUND'), published: true });
 
     expect(result.notFound).toBeUndefined();
     expect(result.redirect).toBeUndefined();
@@ -65,9 +102,15 @@ describe('article detail SSR', () => {
   });
 
   it('keeps serving the page when the fetch fails for a reason other than NOT_FOUND', async () => {
-    const result = await run(async () => {
-      throw trpcError('INTERNAL_SERVER_ERROR');
-    });
+    const result = await run({ fetchImpl: rejectWith('INTERNAL_SERVER_ERROR') });
+
+    expect(result.notFound).toBeUndefined();
+    expect(result.redirect).toBeUndefined();
+    expect(result.props).toMatchObject({ id: ARTICLE_ID });
+  });
+
+  it('leaves client-side navigation alone — the status code is an SSR-only decision', async () => {
+    const result = await run({ clientNav: true });
 
     expect(result.notFound).toBeUndefined();
     expect(result.props).toMatchObject({ id: ARTICLE_ID });

--- a/src/server/__tests__/session-props.test.ts
+++ b/src/server/__tests__/session-props.test.ts
@@ -101,6 +101,13 @@ describe('jsonSafeSession', () => {
       expect(source()).toContain('session: jsonSafeSession(session)');
     });
 
+    // A resolver's `notFound` must reach Next, or every page's 404 silently becomes a 200 with
+    // props — the soft-404 the article page was fixed for. Pinned by text for the same reason as
+    // above; a rename of `result` or `notFound` here needs this line changed with it.
+    it('returns a resolver notFound instead of falling through to props', () => {
+      expect(source()).toContain('if (result.notFound) return { notFound: result.notFound };');
+    });
+
     // `session` must stay the LAST key in the props object: a later spread would re-add the raw
     // session over the sanitized one, which leaves the call above present but dead.
     it('keeps it last, so nothing can spread a raw session over it', () => {

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -656,6 +656,24 @@ export const getCivitaiEvents = async () => {
   return events;
 };
 
+/**
+ * Does the article exist as a published article for anyone, regardless of ingestion state?
+ *
+ * `getArticleById` additionally requires `ingestion = Scanned` for non-owners, so editing a live
+ * article (which sets `Rescan`) makes it throw NOT_FOUND to the public for the length of the scan
+ * — minutes, or longer when a scan is stranded. SSR uses this to tell "nobody can ever see this"
+ * apart from "temporarily unrenderable", so only the first becomes a 404.
+ */
+export const isArticlePublished = async (id: number) => {
+  const db = await getDbWithoutLag('article', id);
+  const article = await db.article.findFirst({
+    where: { id, publishedAt: { not: null }, status: ArticleStatus.Published },
+    select: { id: true },
+  });
+
+  return !!article;
+};
+
 export type ArticleGetById = AsyncReturnType<typeof getArticleById>;
 export const getArticleById = async ({
   id,


### PR DESCRIPTION
ClickUp: https://app.clickup.com/t/868ku7pzd

## Problem

`article.getById` is viewer-scoped: it resolves for the owner and moderators, and throws `NOT_FOUND` for everyone else (draft, unpublished, not-yet-scanned, or author-blocked-you). The article page's `getServerSideProps` caught that rejection and returned props anyway, so the response was a **200** whose client render stopped at `if (isLoading) return <PageLoader />` — before the `<Gated meta={...}>` that emits the head tags. Crawlers got site-default meta, no `noindex`, and no content: an indexable soft 404.

## Change

- `getServerSideProps` returns `notFound: true` when the SSR fetch rejects `NOT_FOUND` **and** no published row exists for that id (`isArticlePublished`). Both halves matter: the fetch runs with the requester's session, so this only fires for viewers who could never see the article, and the publish check keeps a live-but-re-scanning article out of the 404 branch — `getById` also requires `ingestion = Scanned` for non-owners, and editing a published article sets `Rescan`.
- Any other rejection keeps the previous behaviour (200, client refetches), so a transient DB/tRPC error does not 404 a live article.
- `Meta` gains an optional `ogType` (default `'website'`, so every other page is unchanged) and the article page passes `'article'`.

## Who is affected

| Viewer / state | Before | After |
|---|---|---|
| Author viewing own draft | 200, article renders | unchanged — fetch resolves |
| Moderator viewing hidden article | 200, article renders | unchanged — fetch resolves |
| Published article mid-rescan, anon | 200, empty page | unchanged — 200 |
| Draft / unpublished / never-scanned, anon or crawler | 200, empty page, indexable | 404 |

## Tests

`src/server/__tests__/article-page-ssr.test.ts` drives the captured resolver over five branches. Each was mutation-verified, and each mutation is caught by the case that names it:

| Mutation | Fails |
|---|---|
| Remove the guard (true revert) | crawler 404 case |
| Widen the predicate to every error | transient-error case |
| 404 on `!publishedAt` instead | owner-draft case |
| Drop the `isArticlePublished` half | re-scan case |

All four fail with clean assertions in under a second — no hangs, no crashes. `session-props.test.ts` also pins `if (result.notFound) return { notFound: result.notFound };` in `createServerSideProps`; deleting that line previously left this whole suite green while restoring the bug for every page in the app.

- `pnpm run typecheck` — 0 errors
- `pnpm run test:lint-rules` — 261 passed
- `pnpm run test:unit:run` — 1302 files, 20411 passed, 0 failed