### PR TITLE
fix(models): remove the dead LLM content-scan call

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -649,9 +649,6 @@ export const serverSchema = z
     CLOUDFLARE_TURNSTILE_SECRET: z.string().optional(),
     CF_INVISIBLE_TURNSTILE_SECRET: z.string().optional(),
     CF_MANAGED_TURNSTILE_SECRET: z.string().optional(),
-    CONTENT_SCAN_ENDPOINT: isProd ? z.string() : z.string().optional(),
-    CONTENT_SCAN_CALLBACK_URL: z.string().optional(),
-    CONTENT_SCAN_MODEL: z.string().optional(),
     // TIPALTI. It uses a lot of little env vars, so we group them here.
     // iFrame Related:
     TIPALTI_PAYER_NAME: z.string().optional(),

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -1490,8 +1490,7 @@ export const requestReviewHandler = async ({ input }: { input: GetByIdInput }) =
 
     const meta = (model.meta as ModelMeta | null) || {};
     // Deliberately not upsertModel: this only sets meta, and routing it through the full
-    // upsert ran the non-moderator profanity filter over the model name and re-triggered
-    // ingestModel (the select omits `description`, so descriptionChanged was always true).
+    // upsert ran the non-moderator profanity filter over the model name.
     const updatedModel = await updateModelById({
       id: model.id,
       data: { meta: { ...meta, needsReview: true } as Prisma.JsonObject },

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -496,17 +496,6 @@ export const migrateResourceToCollectionSchema = z.object({
   collectionName: z.string().optional(),
 });
 
-export type IngestModelInput = z.input<typeof ingestModelSchema>;
-export const ingestModelSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  description: z.coerce.string(),
-  poi: z.coerce.boolean(),
-  nsfw: z.coerce.boolean(),
-  minor: z.coerce.boolean(),
-  sfwOnly: z.coerce.boolean(),
-});
-
 export type LimitOnly = z.input<typeof limitOnly>;
 export const limitOnly = z.object({
   take: z.number().optional(),

--- a/src/server/services/__tests__/bust-public-model-response-cache.service.test.ts
+++ b/src/server/services/__tests__/bust-public-model-response-cache.service.test.ts
@@ -53,7 +53,6 @@ vi.mock('~/server/services/notification.service', () => ({ createNotification: v
 vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
 vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
 vi.mock('~/server/services/model.service', () => ({
-  ingestModelById: vi.fn(),
   updateModelLastVersionAt: vi.fn(),
 }));
 vi.mock('~/server/services/model-file.service', () => ({

--- a/src/server/services/__tests__/model-flag-side-effects.service.test.ts
+++ b/src/server/services/__tests__/model-flag-side-effects.service.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Unit tests for applyModelFlagSideEffects — the post-update flag fan-out
 // extracted from upsertModel (model tag/search-index refresh, gallery cache
-// bust, ingestModel, and minor/poi propagation onto the model's images).
+// bust, and minor/poi propagation onto the model's images).
 // model.service.ts has a very large import graph, so most of its transitive
 // service/db/search dependencies are stubbed out below to keep this a real
 // unit test rather than an integration test.
@@ -133,7 +133,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockDbWrite.modelVersion.findMany.mockResolvedValue([{ id: 100 }]);
   mockDbWrite.$queryRaw.mockResolvedValue([{ id: 900 }]);
-  mockDbWrite.model.update.mockResolvedValue({});
 });
 
 describe('applyModelFlagSideEffects — image propagation', () => {
@@ -325,68 +324,3 @@ describe('applyModelFlagSideEffects — gallery browsing-level cache bust', () =
   });
 });
 
-describe('applyModelFlagSideEffects — ingestModel gating', () => {
-  // ingestModel is a same-module function (not separately mockable); with
-  // CONTENT_SCAN_ENDPOINT unset (the test-env default) it short-circuits to
-  // stamping scannedAt via dbWrite.model.update — the observable proof it ran.
-  const ranIngest = () =>
-    mockDbWrite.model.update.mock.calls.some(
-      (call) => call[0]?.where?.id === 42 && 'scannedAt' in (call[0]?.data ?? {})
-    );
-
-  it('fires for a Published model when a flag changed', async () => {
-    await applyModelFlagSideEffects({
-      before: baseBefore,
-      after: { ...baseAfter, status: 'Published', minor: true },
-    });
-
-    expect(ranIngest()).toBe(true);
-  });
-
-  it('fires for a Scheduled model when a flag changed', async () => {
-    await applyModelFlagSideEffects({
-      before: baseBefore,
-      after: { ...baseAfter, status: 'Scheduled', poi: true },
-    });
-
-    expect(ranIngest()).toBe(true);
-  });
-
-  it('does not fire for a Draft model even when a flag changed', async () => {
-    await applyModelFlagSideEffects({
-      before: baseBefore,
-      after: { ...baseAfter, status: 'Draft', minor: true },
-    });
-
-    expect(ranIngest()).toBe(false);
-  });
-
-  it('does not fire for a Published model when nothing relevant changed', async () => {
-    await applyModelFlagSideEffects({
-      before: baseBefore,
-      after: { ...baseAfter, status: 'Published' },
-    });
-
-    expect(ranIngest()).toBe(false);
-  });
-
-  it('fires for a Published model on a name-only change', async () => {
-    await applyModelFlagSideEffects({
-      before: baseBefore,
-      after: { ...baseAfter, status: 'Published' },
-      nameChanged: true,
-    });
-
-    expect(ranIngest()).toBe(true);
-  });
-
-  it('fires for a Published model on a description-only change', async () => {
-    await applyModelFlagSideEffects({
-      before: baseBefore,
-      after: { ...baseAfter, status: 'Published' },
-      descriptionChanged: true,
-    });
-
-    expect(ranIngest()).toBe(true);
-  });
-});

--- a/src/server/services/__tests__/model-locked-properties.service.test.ts
+++ b/src/server/services/__tests__/model-locked-properties.service.test.ts
@@ -149,8 +149,6 @@ const baseInput = {
   description: 'A description',
   type: ModelType.Checkpoint,
   uploadType: ModelUploadType.Created,
-  // Draft keeps applyModelFlagSideEffects out of the ingest path so the only
-  // dbWrite.model.update call in a test is the upsert itself.
   status: ModelStatus.Draft,
 } satisfies Partial<ModelUpsertInput>;
 

--- a/src/server/services/__tests__/model-moderation.upsert-wiring.test.ts
+++ b/src/server/services/__tests__/model-moderation.upsert-wiring.test.ts
@@ -135,8 +135,6 @@ const storedModel = {
 const baseInput = {
   type: ModelType.Checkpoint,
   uploadType: ModelUploadType.Created,
-  // Draft keeps applyModelFlagSideEffects's ingest/search-index side effects out of the
-  // update path so this scaffold's mocked collaborators stay untouched.
   status: ModelStatus.Draft,
 } satisfies Partial<ModelUpsertInput>;
 

--- a/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
+++ b/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
@@ -88,7 +88,6 @@ vi.mock('~/server/services/notification.service', () => ({ createNotification: v
 vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
 vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
 vi.mock('~/server/services/model.service', () => ({
-  ingestModelById: vi.fn(),
   updateModelLastVersionAt: vi.fn(),
 }));
 vi.mock('~/server/services/model-file.service', () => ({

--- a/src/server/services/__tests__/model-version.deregister.service.test.ts
+++ b/src/server/services/__tests__/model-version.deregister.service.test.ts
@@ -40,7 +40,6 @@ vi.mock('~/server/services/notification.service', () => ({ createNotification: v
 vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
 vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
 vi.mock('~/server/services/model.service', () => ({
-  ingestModelById: vi.fn(),
   updateModelLastVersionAt: vi.fn(),
 }));
 // Keep the real paid-access module (which reads REDIS_KEYS.CACHES.PAID_ACCESS at import) out of the graph.

--- a/src/server/services/__tests__/model-version.donation-goals-cache.service.test.ts
+++ b/src/server/services/__tests__/model-version.donation-goals-cache.service.test.ts
@@ -55,7 +55,6 @@ vi.mock('~/server/services/notification.service', () => ({ createNotification: v
 vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
 vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
 vi.mock('~/server/services/model.service', () => ({
-  ingestModelById: vi.fn(),
   updateModelLastVersionAt: vi.fn(),
 }));
 vi.mock('~/server/services/model-file.service', () => ({

--- a/src/server/services/__tests__/model-version.idempotent.service.test.ts
+++ b/src/server/services/__tests__/model-version.idempotent.service.test.ts
@@ -77,7 +77,6 @@ vi.mock('~/server/services/notification.service', () => ({ createNotification: v
 vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
 vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
 vi.mock('~/server/services/model.service', () => ({
-  ingestModelById: vi.fn(),
   updateModelLastVersionAt: vi.fn(),
 }));
 vi.mock('~/server/services/model-file.service', () => ({

--- a/src/server/services/__tests__/model-version.linked-component.service.test.ts
+++ b/src/server/services/__tests__/model-version.linked-component.service.test.ts
@@ -46,7 +46,6 @@ vi.mock('~/server/services/notification.service', () => ({ createNotification: v
 vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
 vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
 vi.mock('~/server/services/model.service', () => ({
-  ingestModelById: vi.fn(),
   updateModelLastVersionAt: vi.fn(),
 }));
 vi.mock('~/server/services/model-file.service', () => ({

--- a/src/server/services/__tests__/model-version.purge-by-hash.service.test.ts
+++ b/src/server/services/__tests__/model-version.purge-by-hash.service.test.ts
@@ -89,9 +89,6 @@ vi.mock('~/server/services/notification.service', () => ({ createNotification: v
 vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
 vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
 vi.mock('~/server/services/model.service', () => ({
-  // publish runs `ingestModelById(...).catch(...)` fire-and-forget, so the mock
-  // must return a promise.
-  ingestModelById: vi.fn().mockResolvedValue(undefined),
   updateModelLastVersionAt: vi.fn(),
 }));
 vi.mock('~/server/services/model-file.service', () => ({

--- a/src/server/services/__tests__/model-version.unpublish-refund.service.test.ts
+++ b/src/server/services/__tests__/model-version.unpublish-refund.service.test.ts
@@ -76,7 +76,6 @@ vi.mock('~/server/services/notification.service', () => ({ createNotification: v
 vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
 vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
 vi.mock('~/server/services/model.service', () => ({
-  ingestModelById: vi.fn().mockResolvedValue(undefined),
   updateModelLastVersionAt: vi.fn(),
 }));
 vi.mock('~/server/services/model-file.service', () => ({

--- a/src/server/services/__tests__/model-version.unpublish-scope.service.test.ts
+++ b/src/server/services/__tests__/model-version.unpublish-scope.service.test.ts
@@ -55,7 +55,6 @@ vi.mock('~/server/services/notification.service', () => ({ createNotification: v
 vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
 vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
 vi.mock('~/server/services/model.service', () => ({
-  ingestModelById: vi.fn().mockResolvedValue(undefined),
   updateModelLastVersionAt: vi.fn(),
 }));
 vi.mock('~/server/services/model-file.service', () => ({

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -144,7 +144,7 @@ import {
 } from '~/shared/utils/prisma/enums';
 import type { LicensingFeeSettlementCurrency, LicensingFeeType } from '~/shared/utils/prisma/enums';
 import { isDefined } from '~/utils/type-guards';
-import { ingestModelById, updateModelLastVersionAt } from './model.service';
+import { updateModelLastVersionAt } from './model.service';
 import { markFileReplaced, deleteFilesForModelVersionCache } from './model-file.service';
 import { getBuzzTransactionSupportedAccountTypes } from '~/utils/buzz';
 import { deleteModelFileObjects } from '~/utils/s3-utils';
@@ -905,11 +905,6 @@ export const upsertModelVersion = async ({
       tracker.entityChanges(changeRows).catch(() => null);
     }
 
-    // Run it in the background to avoid blocking the request.
-    ingestModelById({ id: version.modelId }).catch((error) =>
-      logToAxiom({ type: 'error', name: 'model-ingestion', error, modelId: version.modelId })
-    );
-
     // The orchestrator caches fee + payoutEnabled per version, and payoutEnabled now derives from the
     // fee, so a fee change that doesn't invalidate it keeps pricing and paying against the old value.
     // Never rejects: the write has already committed, and a failed bust must not surface as a failed save.
@@ -1019,10 +1014,6 @@ export const updateModelVersionPaidAccess = async ({
     });
     tracker.entityChanges(changeRows).catch(() => null);
   }
-
-  ingestModelById({ id: modelId }).catch((error) =>
-    logToAxiom({ type: 'error', name: 'model-ingestion', error, modelId })
-  );
 
   return { id, modelId };
 };
@@ -1652,11 +1643,6 @@ export const publishModelVersionById = async ({
   );
   await imagesMetricsSearchIndex.queueUpdate(
     images.map((image) => ({ id: image.id, action: SearchIndexUpdateQueueAction.Update }))
-  );
-
-  // Run it in the background to avoid blocking the request.
-  ingestModelById({ id: version.modelId }).catch((error) =>
-    logToAxiom({ type: 'error', name: 'model-ingestion', error, modelId: version.modelId })
   );
 
   return version;

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -5,7 +5,6 @@ import { isEmpty, uniq } from 'lodash-es';
 import dayjs from '~/shared/utils/dayjs';
 import type { SearchParams, SearchResponse } from 'meilisearch';
 import type { SessionUser } from '~/types/session';
-import { env } from '~/env/server';
 import { clickhouse, Tracker } from '~/server/clickhouse/client';
 import type { BaseModelType } from '~/server/common/constants';
 import {
@@ -55,7 +54,6 @@ import type {
   GetAllModelsOutput,
   GetModelVersionsSchema,
   GetMyTrainingModelsSchema,
-  IngestModelInput,
   LimitOnly,
   MigrateResourceToCollectionInput,
   ModelGallerySettingsSchema,
@@ -73,7 +71,6 @@ import type {
   TransferModelOwnershipInput,
   UnpublishModelSchema,
 } from '~/server/schema/model.schema';
-import { ingestModelSchema } from '~/server/schema/model.schema';
 import { isNotTag, isTag } from '~/server/schema/tag.schema';
 import {
   collectionsSearchIndex,
@@ -189,7 +186,6 @@ import type {
 } from './../schema/model.schema';
 import { Flags } from '~/shared/utils/flags';
 import { isGenerationDisabled } from '~/shared/constants/model-version-flags.constants';
-import { isDev } from '~/env/other';
 import { pgDbRead } from '~/server/db/pgDb';
 
 export const getModel = async <TSelect extends Prisma.ModelSelect>({
@@ -2096,8 +2092,6 @@ export async function applyModelFlagSideEffects({
   before,
   after,
   tagsChanged = false,
-  nameChanged = false,
-  descriptionChanged = false,
 }: {
   before: {
     poi: boolean;
@@ -2118,13 +2112,10 @@ export async function applyModelFlagSideEffects({
     gallerySettings: Prisma.JsonValue;
   };
   tagsChanged?: boolean;
-  nameChanged?: boolean;
-  descriptionChanged?: boolean;
 }): Promise<void> {
   const { id } = after;
   const poiChanged = after.poi !== before.poi;
   const minorChanged = after.minor !== before.minor || after.sfwOnly !== before.sfwOnly;
-  const nsfwChanged = after.nsfw !== before.nsfw;
 
   // Update search index if listing changes
   if (tagsChanged || poiChanged || minorChanged) {
@@ -2138,18 +2129,6 @@ export async function applyModelFlagSideEffects({
   const galleryBrowsingLevelChanged = prevGallerySettings?.level !== newGallerySettings?.level;
 
   if (galleryBrowsingLevelChanged) await redis.del(`${REDIS_KEYS.MODEL.GALLERY_SETTINGS}:${id}`);
-
-  // Ingest model if it's published and any of the following fields have changed:
-  if (
-    (after.status === 'Published' || after.status === 'Scheduled') &&
-    (poiChanged || minorChanged || nsfwChanged || nameChanged || descriptionChanged)
-  ) {
-    const parsedModel = ingestModelSchema.parse(after);
-    // Run it in the background to prevent blocking the request
-    ingestModel({ ...parsedModel }).catch((error) =>
-      logToAxiom({ type: 'error', name: 'model-ingestion', error, modelId: parsedModel.id })
-    );
-  }
 
   if (minorChanged || poiChanged) {
     const modelVersions = await dbWrite.modelVersion.findMany({
@@ -2584,8 +2563,6 @@ export const upsertModel = async (
       before: beforeUpdate,
       after: result,
       tagsChanged: !!tagsOnModels,
-      nameChanged: input.name !== beforeUpdate.name,
-      descriptionChanged: input.description !== beforeUpdate.description,
     });
 
     if (showcaseCollectionChanged) {
@@ -2832,14 +2809,6 @@ export const publishModelById = async ({
   await imagesMetricsSearchIndex.queueUpdate(
     images.map((x) => ({ id: x.id, action: SearchIndexUpdateQueueAction.Update }))
   );
-
-  // Run it in the background to prevent blocking the request
-  if (!republishing) {
-    const parsedModel = ingestModelSchema.parse(model);
-    ingestModel({ ...parsedModel }).catch((error) =>
-      logToAxiom({ type: 'error', name: 'model-ingestion', error, modelId: parsedModel.id })
-    );
-  }
 
   return model;
 };
@@ -4132,79 +4101,6 @@ export async function migrateResourceToCollection({
   );
 
   return { ok: true };
-}
-
-export async function ingestModelById({ id }: GetByIdInput) {
-  const model = await dbRead.model.findUnique({
-    where: { id },
-    select: {
-      id: true,
-      name: true,
-      description: true,
-      poi: true,
-      nsfw: true,
-      minor: true,
-      sfwOnly: true,
-    },
-  });
-  if (!model) throw new TRPCError({ code: 'NOT_FOUND' });
-
-  const parsedModel = ingestModelSchema.parse(model);
-  return await ingestModel({ ...parsedModel });
-}
-
-export async function ingestModel(data: IngestModelInput) {
-  if (!env.CONTENT_SCAN_ENDPOINT || isDev) {
-    console.log('Skipping model ingestion');
-    await dbWrite.model.update({
-      where: { id: data.id },
-      data: { scannedAt: new Date() },
-    });
-    return true;
-  }
-
-  // get version data
-  const db = await getDbWithoutLag('model', data.id);
-  const versions = await db.modelVersion.findMany({
-    where: { modelId: data.id, status: { in: [ModelStatus.Published, ModelStatus.Scheduled] } },
-    select: { description: true, trainedWords: true },
-  });
-
-  const versionDescriptions = versions.map((x) => x.description || null).filter(isDefined);
-  const triggerWords = versions.flatMap((x) => x.trainedWords);
-
-  const payload = {
-    callbackUrl:
-      env.CONTENT_SCAN_CALLBACK_URL ??
-      `${env.NEXTAUTH_URL}/api/webhooks/model-scan-result?token=${env.WEBHOOK_TOKEN}`,
-    request: {
-      llm_model: env.CONTENT_SCAN_MODEL ?? 'gpt-4o-mini',
-      content: {
-        id: data.id,
-        name: data.name,
-        content: [data.description, ...versionDescriptions].join('\n'),
-        POI: data.poi,
-        NSFW: data.nsfw,
-        minor: data.minor,
-        sfwOnly: data.sfwOnly,
-        triggerwords: triggerWords,
-      },
-    },
-  };
-
-  const response = await fetch(`${env.CONTENT_SCAN_ENDPOINT}/scan_model`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-  if (!response.ok)
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'Failed to scan model. Service is unavailable.',
-    });
-
-  if (response.status === 202) return true;
-  else return false;
 }
 
 export type GetFeaturedModels = AsyncReturnType<typeof getFeaturedModels>;


### PR DESCRIPTION
## What

Removes the outbound model LLM content-scan call. `ingestModel` has POSTed to `${CONTENT_SCAN_ENDPOINT}/scan_model` on every model publish and flag change since the scan service was retired on **2026-05-02**, and every call has failed since.

Prod Axiom, `name == 'model-ingestion'`:

| day | errors |
|---|---|
| 2026-08-16 | 7,341 |
| 2026-08-17 | 7,373 |
| 2026-08-18 | 6,727 |
| 2026-08-19 | 6,705 |
| 2026-08-20 | 6,566 |
| **total 08-06 → 08-20** | **100,565** |

~46K wasted round-trips a week, plus an equal number of Axiom error events that carry no diagnostic (`logToAxiom` receives a raw `TRPCError`, whose `message`/`stack` are non-enumerable, so every one lands as `"error": {}`).

Every call site already wraps the call in `.catch(logToAxiom)`, so nothing downstream has depended on its result for three months. No user-visible behaviour changes.

## What is removed

- `ingestModel()` and `ingestModelById()` (`model.service.ts`)
- five call sites — two in `model.service.ts` (flag-change fan-out, publish), three in `model-version.service.ts`
- `ingestModelSchema` / `IngestModelInput` (`model.schema.ts`) — orphaned by the above
- `CONTENT_SCAN_ENDPOINT`, `CONTENT_SCAN_CALLBACK_URL`, `CONTENT_SCAN_MODEL` (`env/server-schema.ts`) — read nowhere else
- `applyModelFlagSideEffects`'s `nameChanged` / `descriptionChanged` params, which existed only to feed the ingest gate
- the six tests covering that gate, whose subject no longer exists

## Why removing the env entries is the safe direction

`CONTENT_SCAN_ENDPOINT` was `isProd ? z.string() : optional()` — **required at prod boot**. Dropping the schema entry makes the still-set prod value inert and harmless. The reverse order is the dangerous one: if infra removed the var while the schema still required it, prod would fail to start. So this ships first, and the var can be cleaned up whenever.

## On `Model.scannedAt`

`Model.scannedAt` has no reader anywhere in `src/` — every other `scannedAt` reference is `Image.scannedAt`, `ModelFile.scannedAt`, or XGuard's `meta.textModeration.scannedAt`.

In prod this path never stamped it: the stamping branch runs only when `CONTENT_SCAN_ENDPOINT` is **unset**, and prod has it set. So the 99.6%-unscanned ratio is unchanged by this PR and survives as the record of the outage.

## This does NOT mean XGuard now covers model scanning

Stated plainly so the removal is not misread. As of this PR, XGuard has replaced **none** of the three text-moderation systems on models:

| System | Status | Produces |
|---|---|---|
| Profanity filter (`upsertModel`) | live | `Model.nsfw` + `lockedProperties` |
| Clavata (`entity-moderation` job, `Model` entry) | live | `Report{reason:Automated, externalType:Clavata}` |
| LLM model scan | dead — removed here | ModelFlag rows (poi/nsfw/minor/sfwOnly/triggerWords/poiName) |
| XGuard model adapter | shadow only | nothing yet; `Model.nsfw` once the apply flag is armed |

PR #4151 added XGuard *alongside* Clavata rather than replacing it. Three gaps remain even once the apply flag reaches 100%:

1. **No reports.** `ExternalModerationType` (`src/server/common/enums.ts`) has one member, `Clavata`. No moderation adapter calls `createReport`. The plumbing does not exist.
2. **`Young` and `Celebrity` are scanned but inert.** Both are in `MODEL_MODERATION_SCAN_LABELS`; D3 limits v1 to the three level labels, so the labels that would carry `minor` / `poi` are collected and discarded.
3. **`triggerWords`, `poiName` and `sfwOnly` have no XGuard label at all** — not scanned, no producer anywhere.

So arming the apply flag replaces exactly one thing: the profanity filter's `nsfw` flip.

## Deliberately not in scope

`src/pages/api/webhooks/model-scan-result.ts`, `upsertModelFlag`, `ModelFlag` and `FlaggedModelsList` are all left untouched **on purpose**.

After this PR nothing in the codebase points a callback at that webhook, so it reads as orphaned — it is not. It is the reference implementation for the eventual XGuard port: it records the response contract, the `ModerationRule` evaluation, and exactly what the old system did with each flag. **Do not remove it in a dead-code sweep.** (The *request* payload shape is deleted here; recover it from this PR's parent commit if the port needs it.)

Related and unchanged: the 147 enabled `ModerationRule` rows (`entityType='Model'`, `action='Block'`) only ever evaluated inside that webhook and have been inert since 2026-05-02. They need re-homing regardless of this PR.

One correction to the ticket's framing while we are here: the poi/minor gap is roughly **16 months, not 3.5**. The scanner died 2026-05-02, but its sink died earlier — `upsertModelFlag`'s malformed INSERT (2025-04-25) meant every flagged scan threw before writing. Newest `ModelFlag` row is 2025-04-28. Nothing has been deleted here that was reaching a consumer.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run test:unit:run` — **1,302 files, 20,426 tests, 0 failures**, no file collecting zero tests (`blocks.router.workflow.test.ts` collected 350, confirming the worktree's submodule is initialised)
- `model-flag-side-effects.service.test.ts` went 22 → 16 tests, exactly the six deleted
- `eslint` on the five touched source files — 0 errors; the 14 `no-unused-vars` warnings are all pre-existing and unrelated (`HiddenModelMetrics`, `CacheTTL`, `limitConcurrency`, …)

Post-merge signal: Axiom `name == 'model-ingestion'` should go to zero.

Refs CU 868kgv279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
