### PR TITLE
fix(images): getImagesByEntity no longer returns meta a creator hid, and the hub guards throw a typed error

### DIFF
--- a/src/components/Bounty/BountyEntryUpsertForm.tsx
+++ b/src/components/Bounty/BountyEntryUpsertForm.tsx
@@ -269,7 +269,7 @@ export function BountyEntryUpsertForm({ bountyEntry, bounty }: Props) {
                     <IconTrash size={26} strokeWidth={2.5} />
                   </LegacyActionIcon>
                 </div>
-                {image.meta && (
+                {image.hasMeta && (
                   <div style={{ position: 'absolute', bottom: 12, right: 12 }}>
                     <ImageMetaPopover2 imageId={image.id} type={image.type}>
                       <LegacyActionIcon component="div" variant="light" color="dark" size="lg">

--- a/src/components/Bounty/BountyEntryUpsertForm.tsx
+++ b/src/components/Bounty/BountyEntryUpsertForm.tsx
@@ -269,7 +269,10 @@ export function BountyEntryUpsertForm({ bountyEntry, bounty }: Props) {
                     <IconTrash size={26} strokeWidth={2.5} />
                   </LegacyActionIcon>
                 </div>
-                {image.hasMeta && (
+                {/* hasMeta is false whenever hideMeta is set, but this form is the
+                    owner's own, and getMediaGenerationData serves the owner their
+                    hidden prompt. */}
+                {(image.hasMeta || image.hideMeta) && (
                   <div style={{ position: 'absolute', bottom: 12, right: 12 }}>
                     <ImageMetaPopover2 imageId={image.id} type={image.type}>
                       <LegacyActionIcon component="div" variant="light" color="dark" size="lg">

--- a/src/components/Cards/BountyEntryCard.tsx
+++ b/src/components/Cards/BountyEntryCard.tsx
@@ -14,8 +14,6 @@ import type { Currency } from '~/shared/utils/prisma/enums';
 import HoverActionButton from '~/components/Cards/components/HoverActionButton';
 import { IconFiles } from '@tabler/icons-react';
 import { Reactions } from '~/components/Reaction/Reactions';
-import { truncate } from 'lodash-es';
-import { constants } from '~/server/common/constants';
 import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
 import { getSkipValue } from '~/components/EdgeMedia/EdgeMedia.util';
 import clsx from 'clsx';
@@ -129,11 +127,7 @@ export function BountyEntryCard({ data, currency, renderActions }: Props) {
                       name={image.name ?? image.id.toString()}
                       type={image.type}
                       imageId={image.id}
-                      alt={
-                        image.meta
-                          ? truncate(image.meta.prompt, { length: constants.altTruncateLength })
-                          : image.name ?? undefined
-                      }
+                      alt={image.name ?? undefined}
                       width={IMAGE_CARD_WIDTH}
                       className={cardClasses.image}
                       wrapperProps={{ style: { height: 'calc(100% - 60px)' } }}

--- a/src/server/controllers/bountyEntry.controller.ts
+++ b/src/server/controllers/bountyEntry.controller.ts
@@ -22,7 +22,6 @@ import type {
   UpsertBountyEntryInput,
 } from '~/server/schema/bounty-entry.schema';
 import { Currency, MediaType } from '~/shared/utils/prisma/enums';
-import type { ImageMetaProps } from '~/server/schema/image.schema';
 import { getReactionsSelectV2 } from '~/server/selectors/reaction.selector';
 import { getBountyById } from '../services/bounty.service';
 import { bountiesSearchIndex } from '~/server/search-index';
@@ -87,7 +86,6 @@ export const getBountyEntryHandler = async ({
       ...entry,
       images: images.map((i) => ({
         ...i,
-        meta: i.meta as ImageMetaProps,
         metadata: i.metadata as MixedObject,
       })),
       files,

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:3864':
+  'server/services/image.service.ts:3867':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:3994':
+  'server/services/image.service.ts:3997':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4704':
+  'server/services/image.service.ts:4707':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5814':
+  'server/services/image.service.ts:5817':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -206,7 +206,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:3994')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:3997')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/services/__tests__/hub-feed-filter.test.ts
+++ b/src/server/services/__tests__/hub-feed-filter.test.ts
@@ -218,27 +218,33 @@ describe('the post-filter builder has the same guard', () => {
 });
 
 describe('builders that cannot serve a hub refuse it', () => {
-  // A bare `Error` here reaches the client as raw 500 text through throwDbError,
-  // so the code matters as much as the message.
-  const expectBadRequest = async (promise: Promise<unknown>) => {
+  // The dispatcher sends every hubId down the index path, so reaching either of
+  // these is a server routing bug and not something a caller can provoke: it
+  // stays 5xx, where the alerting is, and the REST layer genericizes the message
+  // rather than handing an anonymous caller the function name. A bare `Error`
+  // gets re-wrapped by throwDbError; the TRPCError propagates intact.
+  const expectInternalError = async (promise: Promise<unknown>) => {
     const error = await promise.then(
       () => undefined,
       (e) => e
     );
 
-    expect(error, 'the builder resolved instead of refusing the hub').toBeInstanceOf(TRPCError);
-    expect((error as TRPCError).code).toBe('BAD_REQUEST');
+    expect(
+      error,
+      'the builder refused with the wrong error type, or did not refuse at all'
+    ).toBeInstanceOf(TRPCError);
+    expect((error as TRPCError).code).toBe('INTERNAL_SERVER_ERROR');
     expect((error as TRPCError).message).toMatch(/cannot serve a hub/i);
   };
 
   it('getAllImages throws rather than returning an unfiltered page', async () => {
     // The backstop for the controller routing change: this path has no way to
     // express a hub, so arriving here means the dispatcher sent it wrongly.
-    await expectBadRequest(getAllImages(input(1)));
+    await expectInternalError(getAllImages(input(1)));
   });
 
   it('getImagesFromFeedSearch throws rather than returning an unfiltered page', async () => {
-    await expectBadRequest(getImagesFromFeedSearch(input(1)));
+    await expectInternalError(getImagesFromFeedSearch(input(1)));
   });
 });
 

--- a/src/server/services/__tests__/hub-feed-filter.test.ts
+++ b/src/server/services/__tests__/hub-feed-filter.test.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from '@trpc/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // The highest-consequence property in the hubs diff: a hub query must never reach
@@ -217,14 +218,27 @@ describe('the post-filter builder has the same guard', () => {
 });
 
 describe('builders that cannot serve a hub refuse it', () => {
+  // A bare `Error` here reaches the client as raw 500 text through throwDbError,
+  // so the code matters as much as the message.
+  const expectBadRequest = async (promise: Promise<unknown>) => {
+    const error = await promise.then(
+      () => undefined,
+      (e) => e
+    );
+
+    expect(error, 'the builder resolved instead of refusing the hub').toBeInstanceOf(TRPCError);
+    expect((error as TRPCError).code).toBe('BAD_REQUEST');
+    expect((error as TRPCError).message).toMatch(/cannot serve a hub/i);
+  };
+
   it('getAllImages throws rather than returning an unfiltered page', async () => {
     // The backstop for the controller routing change: this path has no way to
     // express a hub, so arriving here means the dispatcher sent it wrongly.
-    await expect(getAllImages(input(1))).rejects.toThrow(/cannot serve a hub/i);
+    await expectBadRequest(getAllImages(input(1)));
   });
 
   it('getImagesFromFeedSearch throws rather than returning an unfiltered page', async () => {
-    await expect(getImagesFromFeedSearch(input(1))).rejects.toThrow(/cannot serve a hub/i);
+    await expectBadRequest(getImagesFromFeedSearch(input(1)));
   });
 });
 

--- a/src/server/services/__tests__/images-by-entity-hidemeta.test.ts
+++ b/src/server/services/__tests__/images-by-entity-hidemeta.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * `getImagesByEntity` backs the bounty and bounty-entry read paths, whose
+ * handlers spread the raw row to the client. Nothing downstream re-filters it,
+ * so the `hideMeta` decision has to be made in SQL.
+ *
+ * The gate is therefore only observable as query text. A fixture-driven test
+ * would prove nothing — feed it a row carrying `meta` and the row leaks, which
+ * is a statement about the fixture rather than about the query.
+ */
+
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/services/cosmetic.service', () => ({
+  getCosmeticsForEntity: vi.fn().mockResolvedValue({}),
+}));
+
+import { getImagesByEntity } from '../image.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const ENTITY_ID = 1;
+
+const RAW_ROW = {
+  id: 1,
+  name: 'x',
+  url: 'x',
+  nsfwLevel: 1,
+  width: 1,
+  height: 1,
+  hash: 'x',
+  hideMeta: true,
+  hasMeta: false,
+  hasPositivePrompt: false,
+  createdAt: new Date(0),
+  mimeType: 'image/jpeg',
+  type: 'image',
+  metadata: null,
+  ingestion: 'Scanned',
+  scannedAt: new Date(0),
+  needsReview: null,
+  userId: 1,
+  index: 0,
+  poi: false,
+  minor: false,
+  entityId: ENTITY_ID,
+};
+
+/** Runs the service and returns the query text it built. */
+async function captureQuery() {
+  const queryRaw = dbMock.dbRead.$queryRaw as unknown as ReturnType<typeof vi.fn>;
+  let strings: TemplateStringsArray | undefined;
+  queryRaw.mockImplementation((s: TemplateStringsArray) => {
+    strings = s;
+    return Promise.resolve([RAW_ROW]);
+  });
+
+  const result = await getImagesByEntity({ id: ENTITY_ID, type: 'BountyEntry' });
+
+  // Positive control: the `!id && !ids` early return would leave every assertion
+  // below a statement about nothing.
+  expect(strings, 'getImagesByEntity never issued its query').toBeDefined();
+  expect(result).toHaveLength(1);
+
+  return { sql: (strings as TemplateStringsArray).join('?'), row: result[0] };
+}
+
+describe('getImagesByEntity withholds meta the creator chose to hide', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not select the meta column at all', async () => {
+    const { sql } = await captureQuery();
+
+    // The two CASE blocks read `i.meta` legitimately, so they come out first and
+    // whatever remains must not mention the column in any spelling. Pinning one
+    // spelling instead — `i.meta,` — would pass on `i."meta",`, on
+    // `i.meta AS meta,` and on a trailing `i.meta` with no comma, each of which
+    // re-opens the leak this file exists to catch. `metadata` and `hideMeta`
+    // survive the word boundary and the case respectively.
+    const withoutDerivations = sql.replace(/\(\s*CASE[\s\S]*?END\s*\)/g, '');
+
+    expect(
+      withoutDerivations,
+      'getImagesByEntity selects the meta column, which ships to the client'
+    ).not.toMatch(/\bmeta\b/);
+  });
+
+  it('derives hasMeta from hideMeta, matching the other read paths', async () => {
+    const { sql } = await captureQuery();
+
+    // Drop the `i."hideMeta"` term from the CASE and this goes red naming it —
+    // a `hasMeta` that ignores the flag is the same leak one level down.
+    expect(sql).toMatch(/OR i\."hideMeta" THEN FALSE[\s\S]{0,80}?AS "hasMeta"/);
+    expect(sql).toMatch(/AND NOT i\."hideMeta"[\s\S]{0,160}?AS "hasPositivePrompt"/);
+  });
+
+  // Pairs with the query assertions above: the gate is in SQL, but it is worth
+  // nothing if the return map stops spreading the derived columns through.
+  // Deliberately no `meta` absence check here — the fixture decides that, so it
+  // passes just as happily against the leaking query.
+  it('spreads the derived booleans through the return map', async () => {
+    const { row } = await captureQuery();
+
+    expect(row).toMatchObject({ hideMeta: true, hasMeta: false, hasPositivePrompt: false });
+  });
+});

--- a/src/server/services/__tests__/images-by-entity-hidemeta.test.ts
+++ b/src/server/services/__tests__/images-by-entity-hidemeta.test.ts
@@ -8,6 +8,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * The gate is therefore only observable as query text. A fixture-driven test
  * would prove nothing — feed it a row carrying `meta` and the row leaks, which
  * is a statement about the fixture rather than about the query.
+ *
+ * The subject is the STATIC template text, so a select list moved into an
+ * interpolated `Prisma.sql` fragment arrives here as `?` and this file stops
+ * guarding anything. Keep the columns spelled out in the literal.
  */
 
 vi.mock('../../../../event-engine-common/services/metrics', () => ({
@@ -108,6 +112,13 @@ describe('getImagesByEntity withholds meta the creator chose to hide', () => {
       withoutDerivations,
       'getImagesByEntity selects the meta column, which ships to the client'
     ).not.toMatch(/\bmeta\b/);
+
+    // A wildcard names no column, so the assertion above passes over `i.*` while
+    // every column including meta ships.
+    expect(
+      withoutDerivations,
+      'getImagesByEntity selects whole rows, which carries meta past the check above'
+    ).not.toMatch(/\bi\.\*/);
   });
 
   it('derives hasMeta from hideMeta, matching the other read paths', async () => {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -6894,7 +6894,6 @@ type GetImageConnectionRaw = {
   width: number;
   height: number;
   hash: string;
-  meta: ImageMetaProps; // TODO - remove
   hideMeta: boolean;
   createdAt: Date;
   mimeType: string;
@@ -6907,7 +6906,7 @@ type GetImageConnectionRaw = {
   metadata: ImageMetadata | VideoMetadata;
   entityId: number;
   hasMeta: boolean;
-  hasPositivePrompt?: boolean;
+  hasPositivePrompt: boolean;
   poi?: boolean;
   minor?: boolean;
 };
@@ -6978,7 +6977,6 @@ export const getImagesByEntity = async ({
       i.width,
       i.height,
       i.hash,
-      i.meta,
       i."hideMeta",
       i."createdAt",
       i."mimeType",

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -179,6 +179,7 @@ import {
   throwAuthorizationError,
   throwBadRequestError,
   throwDbError,
+  throwInternalServerError,
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
 import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
@@ -1543,8 +1544,8 @@ export const getAllImages = async (
   // so a hubId arriving means the dispatcher routed wrongly. Returning results
   // would hand the caller the global feed labelled as their hub.
   if (input.hubId)
-    throw throwBadRequestError(
-      'getAllImages cannot serve a hub; hub queries must use the index path'
+    throw throwInternalServerError(
+      new Error('getAllImages cannot serve a hub; hub queries must use the index path')
     );
 
   const blockedEnforcement = await enforceBlockedBrowsingTags(input, {
@@ -3978,8 +3979,8 @@ export async function getImagesFromFeedSearch(
   // describes. Adding the key to that schema without a clause here would serve an
   // unfiltered feed from one of three branches, so fail loudly instead.
   if (input.hubId)
-    throw throwBadRequestError(
-      'getImagesFromFeedSearch cannot serve a hub; hub queries must use the index path'
+    throw throwInternalServerError(
+      new Error('getImagesFromFeedSearch cannot serve a hub; hub queries must use the index path')
     );
 
   try {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1543,7 +1543,9 @@ export const getAllImages = async (
   // so a hubId arriving means the dispatcher routed wrongly. Returning results
   // would hand the caller the global feed labelled as their hub.
   if (input.hubId)
-    throw new Error('getAllImages cannot serve a hub; hub queries must use the index path');
+    throw throwBadRequestError(
+      'getAllImages cannot serve a hub; hub queries must use the index path'
+    );
 
   const blockedEnforcement = await enforceBlockedBrowsingTags(input, {
     id: input.user?.id,
@@ -3976,7 +3978,7 @@ export async function getImagesFromFeedSearch(
   // describes. Adding the key to that schema without a clause here would serve an
   // unfiltered feed from one of three branches, so fail loudly instead.
   if (input.hubId)
-    throw new Error(
+    throw throwBadRequestError(
       'getImagesFromFeedSearch cannot serve a hub; hub queries must use the index path'
     );
 


### PR DESCRIPTION
Two follow-ups that both live in `src/server/services/image.service.ts`, grouped into one PR because they touch the same file.

ClickUp: https://app.clickup.com/t/868kut1mt
ClickUp: https://app.clickup.com/t/868kub4gr (the error-typing half only)

## 1. `getImagesByEntity` no longer returns meta a creator hid

The query selected `i.meta` and both handlers spread the raw row, so an image with `hideMeta` set had its generation metadata served anyway. The same query already derived `hasMeta` and `hasPositivePrompt` from `hideMeta`; the column is dropped and those stand, matching `getEntityCoverImage` (#4233) and the other read paths in the file.

Two client reads of the raw column moved to the shape the rest of the app uses:

- `BountyEntryCard` built its alt text from `image.meta.prompt`; it now falls back to the image name, as `Collection.tsx` does when there is no meta.
- `BountyEntryUpsertForm` gated its info popover on `image.meta`; it now gates on `hasMeta`. It was already rendering `ImageMetaPopover2`, which fetches the meta itself.

`bounty.controller.ts` spreads `...i` and `bountyEntry.controller.ts` mapped `meta: i.meta as ImageMetaProps` — the cast is gone, and nothing else downstream read the column (typecheck confirms).

### The test is not the vacuous one

#4233's second commit removed a meta-absence assertion that was green either way, because the fixture — not the query — decided whether a `meta` key existed. `images-by-entity-hidemeta.test.ts` asserts on the query text instead: strip the two CASE blocks that read `i.meta` legitimately, and reject any mention of the column in what remains.

Verified red by reverting the fix in four spellings, one at a time, restoring after each:

| re-added as | test |
|---|---|
| `i.meta,` | red |
| `i."meta",` | red |
| `i.meta AS meta,` | red |
| trailing `i.meta` (no comma) | red |
| `i.*` | red |

The first four were re-run independently by a reviewer, who also found that `i.*` names no column and so walked past the token check; the assertion for it was added and verified red the same way. The guard reads the static template text, so a select list moved into an interpolated `Prisma.sql` fragment would arrive as `?` and disarm the file — noted in the file's header comment.

## 2. Hub guards throw a typed error

`getAllImages` and `getImagesFromFeedSearch` threw a bare `Error` when a `hubId` reached a builder that cannot express one, and `throwDbError` re-wraps that on the way out. Both now use `throwInternalServerError`, so the `TRPCError` propagates intact through the `instanceof TRPCError` checks in the controllers.

It stays 5xx deliberately. `image.controller.ts:307` sends every `hubId` down the index path, so reaching either guard is a server routing bug no caller can provoke: a 400 would drop the invariant out of 5xx alerting, and `api/v1/images/index.ts:238` passes 4xx messages to the wire verbatim — which would hand an anonymous caller a function name and the feed topology.

The existing assertions in `hub-feed-filter.test.ts` matched only the message, so they stayed green through a revert to `new Error`. They now assert the `TRPCError` and its code — verified red against `new Error`.

`BountyEntryUpsertForm` gates its popover on `hasMeta || hideMeta`, not `hasMeta` alone. `hasMeta` is false whenever `hideMeta` is set, but that form is the owner's own and `getMediaGenerationData` serves the owner their hidden prompt (`generation.service.ts:460`), so gating on `hasMeta` alone took the affordance from the one person entitled to it.

Not in scope: the `hubId` query param on `imagesQueryParamSchema` (`image.utils.ts:57`), which is the other half of 868kub4gr.

## Also in the diff

`flipt-eval-context.test.ts` pins four `image.service.ts` line numbers in its ledger of entity-keyed Flipt calls. The guard change shifted all four by +3; the ledger is updated to match, which is what that test asks for when a site moves.

## Verification

- `pnpm run typecheck` — clean
- `pnpm run test:unit:run` — full suite
- `pnpm run prettier:write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
