### PR TITLE
fix(collections): the add-content picker no longer offers unpublished images

### DIFF
--- a/src/components/Collections/AddUserContentModal.tsx
+++ b/src/components/Collections/AddUserContentModal.tsx
@@ -170,6 +170,10 @@ export function AddUserContentModal({ collectionId }: Props) {
                   userId: currentUser?.id,
                   period: 'AllTime',
                   sort: ImageSort.Newest,
+                  // The feed carves out the caller's own unpublished posts, which is right
+                  // for a profile and wrong for a picker: an unpublished image cannot be
+                  // added to a collection.
+                  publishedOnly: true,
                   hidden: undefined,
                   types: undefined,
                   withMeta: undefined,


### PR DESCRIPTION
Ships **one** of the two tickets it was scoped for. The other does not reproduce — see below.

## 868kuaf2c — collections picker offers draft images (fixed)

https://app.clickup.com/t/868kuaf2c

`AddUserContentModal` passed a filter object with no `publishedOnly` key at all. The image feed deliberately carves out the caller's own unpublished posts — right for a profile, wrong for a picker, because a collection cannot hold an unpublished image. So the modal offered images whose submission would be refused.

One line. `publishedOnly: true`, the same correction the remix submit picker took in #4148 (`6ee57fa330`). Deliberately **not** refactored into a shared builder with the remix picker: that builder also carries rating and sort decisions this modal has not asked for.

### Verification

- **The modal sends the flag.** Playwright against a real collection page on a local dev server, request log cleared after page load, picker opened from the plus icon, and the modal's own `image.getInfinite` request captured: `{"userId":…,"period":"AllTime","sort":"Newest","publishedOnly":true,"browsingLevel":3,…}`. Present and true on the wire, which is the part this diff is responsible for.
- **Server-side behaviour is covered by existing suites, not by that run** — `src/server/services/__tests__/bitdex-feed-source.test.ts` and `src/server/services/__tests__/image-search-published-only.test.ts`, including `does not hand a publishedOnly caller their own unpublished row`. Both green.
- **The local dev instance could not confirm it end to end.** Its feed index carries stale publication state, so an on/off control over the flag returns identical results there — that environment cannot distinguish the two cases either way. Not thin data: the account used has 2602 drafts. The controls that isolate it are filed as an agent follow-up rather than here.

`typecheck` clean, `prettier:write` clean, full unit suite green (1301 files, 20405 passed, 27 skipped).

## 868kumr17 — model wizard step bar (NOT fixed, and deliberately so)

https://app.clickup.com/t/868kumr17

The scoped fix was to copy `wrap` from `Wizard.tsx` onto the inline Steppers in `ModelWizard` and `ModelVersionWizard`. That change would do nothing, for two independent reasons:

1. **`wrap` is already the Mantine default.** `@mantine/core` 7.17.8, `esm/components/Stepper/Stepper.mjs`: `defaultProps = { orientation: 'horizontal', iconPosition: 'left', allowNextStepsSelect: true, wrap: true }`. The prop on `Wizard.tsx:20` is decorative.
2. **It does not reproduce.** Measured in the browser on unmodified code at 320 / 375 / 414 / 640 / 768 / 1280: `flex-wrap: wrap` and `data-wrap="true"` at every width, `scrollWidth === clientWidth` at every width, and every step's right edge inside `clientWidth`. At 375 the bar wraps to two rows and all four steps are visible.

A click on the step right of Info at 414 found it not disabled, hit-testable (`elementFromPoint` returns the step itself) and clickable — the wizard simply does not move, because forward steps are gated on real state: `allowStepSelect={!!model}`, `!!hasVersions`, `hasVersions && (hasFiles || skipFiles)`, with `allowNextStepsSelect={false}`. On `/models/create` there is no model yet, so they correctly refuse. That is product behaviour and `wrap` does not touch it.

Shipping the prop anyway would have closed the ticket while leaving whatever the reporter saw untouched. The ticket stays open pending the reporter's URL and viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


