### PR TITLE
fix(tests): unbreak the component tier — a stale wholesale mock killed ModelCard at IMPORT

### DIFF
--- a/src/components/Cards/ModelCard.browser.test.tsx
+++ b/src/components/Cards/ModelCard.browser.test.tsx
@@ -1,4 +1,6 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
+import type * as ModelCardContext from '~/components/Cards/ModelCardContext';
+import type * as TrpcModule from '~/utils/trpc';
 
 // =============================================================================
 // ModelCard — feed review-indicator now reads batched membership, not the
@@ -39,7 +41,15 @@ vi.mock('~/hooks/useEngagedModelMembership', () => ({
 }));
 
 // --- legacy endpoint spy (must never fire) ----------------------------------
-vi.mock('~/utils/trpc', () => ({
+// The `trpc` export is still replaced wholesale — that object IS the spy, and
+// keeping it bare is what makes "the card touched no other endpoint" observable
+// rather than merely unasserted. What changed is that the MODULE is spread, so
+// its other exports (`trpcVanilla`, `setTrpcBatchingEnabled`, …) survive. A
+// factory that omitted them handed `undefined` to every importer in this file's
+// module graph — the failure mode `local-rules/no-wholesale-module-mock` exists
+// to stop, which has silently disabled ~36 tests here before.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
   trpc: { user: { getEngagedModels: { useQuery: mocks.getEngagedModelsUseQuery } } },
 }));
 
@@ -61,8 +71,26 @@ vi.mock('~/components/Metrics', () => ({
   Metrics: ({ children, initial }: any) => children(initial),
   AnimatedCount: ({ value }: any) => <>{value}</>,
 }));
-vi.mock('~/components/Cards/ModelCardContext', () => ({
+// Spreads the real module rather than listing its exports, and that is the whole
+// point rather than tidiness. The hand-listed version of this mock supplied only
+// `useModelCardContext`; when #4112 gave `ModelCard.tsx` a second import from
+// here — `useModelSaleBadge` — the module the card linked against no longer had
+// it, and the file died at IMPORT with "does not provide an export named
+// 'useModelSaleBadge'". That reports as `Tests no tests`, not as a failure count,
+// so the whole component tier went red with nothing naming a broken assertion.
+// A spread cannot go stale the same way: a new export arrives on its own.
+//
+// The two sale hooks are then stubbed back out deliberately. Both route through
+// `trpc.model.getActiveSales.useQuery`, and the `~/utils/trpc` mock above is a
+// deliberately minimal spy that carries only `user.getEngagedModels` — so
+// running the real hooks would reach an undefined namespace. Stubbing them keeps
+// the spread from ever touching it. `undefined` is "no sale", the default state,
+// and the sale badge is shadowed here rather than under test.
+vi.mock('~/components/Cards/ModelCardContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModelCardContext>()),
   useModelCardContext: () => ({ useModelVersionRedirect: false, activeBaseModels: undefined }),
+  useModelSaleBadge: () => undefined,
+  useModelSaleBadges: () => undefined,
 }));
 vi.mock('~/components/Cards/ModelCardContextMenu', () => ({ ModelCardContextMenu: () => null }));
 vi.mock('~/components/Cards/components/RemixButton', () => ({ RemixButton: () => null }));

--- a/src/components/Cards/ModelCard.browser.test.tsx
+++ b/src/components/Cards/ModelCard.browser.test.tsx
@@ -110,6 +110,9 @@ vi.mock('~/components/Cards/model-card.utils', () => ({ getCardBaseModels: () =>
 
 import { renderWithProviders } from '../../../test/component-setup';
 import { ModelCard } from '~/components/Cards/ModelCard';
+// Value import, deliberately — this resolves to the MOCKED module (vi.mock is hoisted), and
+// the beforeEach below asserts the mock is wired the way the factory intends.
+import { trpc } from '~/utils/trpc';
 
 // Minimal fixture — only the fields ModelCardContent/ModelCardStats read.
 // thumbsUpCount>0 + locked:false is the gate that renders the review badge.
@@ -158,6 +161,27 @@ describe('ModelCard review indicator (batched membership)', () => {
     mocks.state.engaged = false;
     mocks.membershipMock.mockClear();
     mocks.getEngagedModelsUseQuery.mockClear();
+
+    // 🔴 The `trpc:` override MUST come after the `importOriginal` spread in the factory
+    // above, and nothing else enforces that. `local-rules/no-wholesale-module-mock` requires
+    // that *a* top-level spread exists, not that it comes first — so a merge, a formatter or
+    // a key-sort can silently reverse the two and hand every importer the REAL client.
+    //
+    // Measured: with the order reversed this file still reports 2 passed while the spy below
+    // is dead. The `not.toHaveBeenCalled()` guard — the one assertion this spec exists for —
+    // then never executes, and if production does regress it fails on an unrelated
+    // "Unable to find tRPC Context" after two 10s waitFor timeouts, naming neither the spy
+    // nor the endpoint. A vacuous guard that still reports success is worse than no guard,
+    // so assert the wiring itself rather than trusting the key order to survive.
+    // Cast, narrowly and deliberately: `user.getEngagedModels` is the LEGACY endpoint this
+    // spec exists to prove is never called, and it no longer exists on the real router's
+    // types (it is `getEngagedModelsByIds` now). The value import is typed against the REAL
+    // module while the runtime value is the mock, so the property is absent at type level and
+    // present at run time. Casting here is narrower than widening the mock's shape.
+    const spiedUseQuery = (
+      trpc.user as unknown as { getEngagedModels: { useQuery: unknown } }
+    ).getEngagedModels.useQuery;
+    expect(spiedUseQuery).toBe(mocks.getEngagedModelsUseQuery);
   });
 
   test('renders the reviewed indicator when the model is Recommended by the user', async () => {


### PR DESCRIPTION
`main` is red on the browser/component tier and has been since #4112. Nothing surfaced it, so it read as a per-PR flake on whichever PR happened to run next.

## It is a test regression, not a component regression

`ModelCardContext.tsx` exports `useModelSaleBadge`, and `ModelCard.tsx` imports and uses it. Both are correct and both typecheck — `tekton / typecheck` is green on every affected PR. What broke is the spec's mock:

```js
vi.mock('~/components/Cards/ModelCardContext', () => ({
  useModelCardContext: () => ({ ... }),      // the ONLY export it supplied
}));
```

#4112 (`feat(sales): scheduled model sales — the price half`) gave `ModelCard.tsx` a *second* import from that module. The hand-listed factory replaces the module wholesale, so the card linked against an object that no longer had the export:

```
Failed to import test file src/components/Cards/ModelCard.browser.test.tsx
Caused by: SyntaxError: The requested module '/src/components/Cards/ModelCardContext.tsx'
  does not provide an export named 'useModelSaleBadge'
```

That is a **link-time** failure, so the file collects **0 tests** and reports `Tests no tests` rather than a failure count. No assertion is ever named — which is exactly why the red check looked unattributable.

## Not the sticker PR

`#4231` was the leading suspect (it is the only recent `main` commit touching `*.browser.test.tsx`). It is **refuted**:

- The failing spec is `ModelCard.browser.test.tsx`, which #4231 never touched. Every sticker spec passes.
- `bf71f39af4` (#4112) is **11 commits before** `54587b5e29` (#4231) on `main`'s first-parent history.
- PR #4234 fails this check while **not containing** `df7733b99c` (#4233), which exonerates that commit too.

## The fix

Both mocks in the file now spread the real module via `importOriginal` and override only what they need, so neither can go stale the same way again. The two sale hooks are stubbed back out deliberately — both route through `trpc.model.getActiveSales.useQuery`, and this file's `~/utils/trpc` mock is a deliberately minimal spy, so running the real hooks would reach an undefined namespace.

The `~/utils/trpc` factory is converted for the same reason: it was **already an ESLint error on `main`** under the repo's own `local-rules/no-wholesale-module-mock`, and touching this file makes the changed-files lint gate see it. The `trpc` export itself is still replaced wholesale, because that bare object *is* the "legacy endpoint never fires" spy; only the module around it is preserved.

No production file is modified.

## Verification

The harness was validated in **both directions before trusting any result** — on NixOS a Playwright revision mismatch reports `no tests` rather than an error, so an unvalidated zero proves nothing. A known-good spec executed 9 tests, and a deliberately-wrong assertion was observed going red.

| | Test Files | Tests | rc |
|---|---|---|---|
| `origin/main` | **1 failed** \| 179 passed (180) | 1967 passed | 1 |
| this branch | **180 passed** (180) | 1969 passed | 0 |

`+2` is exactly the two tests the import failure was skipping.

**The restored coverage is live, not vacuous:** inverting `data-reviewed={hasReview}` in `ModelCard.tsx` turns both tests red with their own assertions (`expected 'false' to be 'true'` and its mirror). That mutation was reverted before committing — no production file is touched by this PR.

Also: `pnpm typecheck` → 0 errors; ESLint on the file → 1 error before, 0 after; prettier clean.

## Follow-up cards (not done here)

1. **The component tier has no main-branch signal.** It runs only in the Tekton preview pipeline, it is report-only there, and the Actions `unit` job excludes browser tests (no Chromium). A break on `main` is therefore invisible until it shows up as a red report-only check on unrelated PRs. Giving it a signal means running the browser project on `main` in an environment that has a version-matched Chromium — a post-merge Tekton task on `main` is the natural home, since the preview image already ships the right browser revision — and alerting on it, rather than letting it ride on PR previews.

2. **52 of the 180 browser specs still carry the same `local-rules/no-wholesale-module-mock` error.** Each is the same time bomb: it detonates the day its mocked module gains an export its consumer imports. The changed-files lint gate structurally cannot see a pre-existing one — it only fires when somebody happens to touch the file. Sweeping them (or ratcheting the rule repo-wide) would retire the whole class.
