### PR TITLE
fix(tipalti): fire payments-enabled only on the payability change

### DIFF
--- a/packages/civitai-db-schema/src/enums.ts
+++ b/packages/civitai-db-schema/src/enums.ts
@@ -22,7 +22,8 @@ export const ReferralRedemptionType = {
   MembershipPerks: 'MembershipPerks',
 } as const;
 
-export type ReferralRedemptionType = (typeof ReferralRedemptionType)[keyof typeof ReferralRedemptionType];
+export type ReferralRedemptionType =
+  (typeof ReferralRedemptionType)[keyof typeof ReferralRedemptionType];
 
 export const BuzzWithdrawalRequestStatus = {
   Requested: 'Requested',
@@ -34,14 +35,16 @@ export const BuzzWithdrawalRequestStatus = {
   ExternallyResolved: 'ExternallyResolved',
 } as const;
 
-export type BuzzWithdrawalRequestStatus = (typeof BuzzWithdrawalRequestStatus)[keyof typeof BuzzWithdrawalRequestStatus];
+export type BuzzWithdrawalRequestStatus =
+  (typeof BuzzWithdrawalRequestStatus)[keyof typeof BuzzWithdrawalRequestStatus];
 
 export const UserPaymentConfigurationProvider = {
   Stripe: 'Stripe',
   Tipalti: 'Tipalti',
 } as const;
 
-export type UserPaymentConfigurationProvider = (typeof UserPaymentConfigurationProvider)[keyof typeof UserPaymentConfigurationProvider];
+export type UserPaymentConfigurationProvider =
+  (typeof UserPaymentConfigurationProvider)[keyof typeof UserPaymentConfigurationProvider];
 
 export const CashWithdrawalStatus = {
   Paid: 'Paid',
@@ -89,7 +92,8 @@ export const CryptoTransactionStatus = {
   Complete: 'Complete',
 } as const;
 
-export type CryptoTransactionStatus = (typeof CryptoTransactionStatus)[keyof typeof CryptoTransactionStatus];
+export type CryptoTransactionStatus =
+  (typeof CryptoTransactionStatus)[keyof typeof CryptoTransactionStatus];
 
 export const RewardsEligibility = {
   Eligible: 'Eligible',
@@ -267,7 +271,8 @@ export const ModelVersionSponsorshipSettingsType = {
   Bidding: 'Bidding',
 } as const;
 
-export type ModelVersionSponsorshipSettingsType = (typeof ModelVersionSponsorshipSettingsType)[keyof typeof ModelVersionSponsorshipSettingsType];
+export type ModelVersionSponsorshipSettingsType =
+  (typeof ModelVersionSponsorshipSettingsType)[keyof typeof ModelVersionSponsorshipSettingsType];
 
 export const ModelVersionMonetizationType = {
   PaidAccess: 'PaidAccess',
@@ -278,7 +283,8 @@ export const ModelVersionMonetizationType = {
   Sponsored: 'Sponsored',
 } as const;
 
-export type ModelVersionMonetizationType = (typeof ModelVersionMonetizationType)[keyof typeof ModelVersionMonetizationType];
+export type ModelVersionMonetizationType =
+  (typeof ModelVersionMonetizationType)[keyof typeof ModelVersionMonetizationType];
 
 export const LicensingFeeType = {
   PerImageBuzz: 'PerImageBuzz',
@@ -291,13 +297,15 @@ export const LicensingFeeSettlementCurrency = {
   Cash: 'Cash',
 } as const;
 
-export type LicensingFeeSettlementCurrency = (typeof LicensingFeeSettlementCurrency)[keyof typeof LicensingFeeSettlementCurrency];
+export type LicensingFeeSettlementCurrency =
+  (typeof LicensingFeeSettlementCurrency)[keyof typeof LicensingFeeSettlementCurrency];
 
 export const ModelVersionEngagementType = {
   Notify: 'Notify',
 } as const;
 
-export type ModelVersionEngagementType = (typeof ModelVersionEngagementType)[keyof typeof ModelVersionEngagementType];
+export type ModelVersionEngagementType =
+  (typeof ModelVersionEngagementType)[keyof typeof ModelVersionEngagementType];
 
 export const ModelHashType = {
   AutoV1: 'AutoV1',
@@ -384,7 +392,8 @@ export const ImageGenerationProcess = {
   inpainting: 'inpainting',
 } as const;
 
-export type ImageGenerationProcess = (typeof ImageGenerationProcess)[keyof typeof ImageGenerationProcess];
+export type ImageGenerationProcess =
+  (typeof ImageGenerationProcess)[keyof typeof ImageGenerationProcess];
 
 export const NsfwLevel = {
   None: 'None',
@@ -432,7 +441,8 @@ export const EntityModerationStatus = {
   Canceled: 'Canceled',
 } as const;
 
-export type EntityModerationStatus = (typeof EntityModerationStatus)[keyof typeof EntityModerationStatus];
+export type EntityModerationStatus =
+  (typeof EntityModerationStatus)[keyof typeof EntityModerationStatus];
 
 export const ImageEngagementType = {
   Favorite: 'Favorite',
@@ -560,7 +570,8 @@ export const CosmeticShopItemStatus = {
   Archived: 'Archived',
 } as const;
 
-export type CosmeticShopItemStatus = (typeof CosmeticShopItemStatus)[keyof typeof CosmeticShopItemStatus];
+export type CosmeticShopItemStatus =
+  (typeof CosmeticShopItemStatus)[keyof typeof CosmeticShopItemStatus];
 
 export const CosmeticEntity = {
   Model: 'Model',
@@ -600,14 +611,16 @@ export const ArticleIngestionStatus = {
   Rescan: 'Rescan',
 } as const;
 
-export type ArticleIngestionStatus = (typeof ArticleIngestionStatus)[keyof typeof ArticleIngestionStatus];
+export type ArticleIngestionStatus =
+  (typeof ArticleIngestionStatus)[keyof typeof ArticleIngestionStatus];
 
 export const ArticleEngagementType = {
   Favorite: 'Favorite',
   Hide: 'Hide',
 } as const;
 
-export type ArticleEngagementType = (typeof ArticleEngagementType)[keyof typeof ArticleEngagementType];
+export type ArticleEngagementType =
+  (typeof ArticleEngagementType)[keyof typeof ArticleEngagementType];
 
 export const GenerationSchedulers = {
   EulerA: 'EulerA',
@@ -638,7 +651,8 @@ export const CollectionWriteConfiguration = {
   Review: 'Review',
 } as const;
 
-export type CollectionWriteConfiguration = (typeof CollectionWriteConfiguration)[keyof typeof CollectionWriteConfiguration];
+export type CollectionWriteConfiguration =
+  (typeof CollectionWriteConfiguration)[keyof typeof CollectionWriteConfiguration];
 
 export const CollectionReadConfiguration = {
   Private: 'Private',
@@ -646,7 +660,8 @@ export const CollectionReadConfiguration = {
   Unlisted: 'Unlisted',
 } as const;
 
-export type CollectionReadConfiguration = (typeof CollectionReadConfiguration)[keyof typeof CollectionReadConfiguration];
+export type CollectionReadConfiguration =
+  (typeof CollectionReadConfiguration)[keyof typeof CollectionReadConfiguration];
 
 export const CollectionType = {
   Model: 'Model',
@@ -693,14 +708,16 @@ export const CollectionContributorPermission = {
   MANAGE: 'MANAGE',
 } as const;
 
-export type CollectionContributorPermission = (typeof CollectionContributorPermission)[keyof typeof CollectionContributorPermission];
+export type CollectionContributorPermission =
+  (typeof CollectionContributorPermission)[keyof typeof CollectionContributorPermission];
 
 export const CollectionCollaboratorRole = {
   Contributor: 'Contributor',
   Manager: 'Manager',
 } as const;
 
-export type CollectionCollaboratorRole = (typeof CollectionCollaboratorRole)[keyof typeof CollectionCollaboratorRole];
+export type CollectionCollaboratorRole =
+  (typeof CollectionCollaboratorRole)[keyof typeof CollectionCollaboratorRole];
 
 export const CollectionInviteStatus = {
   Pending: 'Pending',
@@ -708,7 +725,8 @@ export const CollectionInviteStatus = {
   Declined: 'Declined',
 } as const;
 
-export type CollectionInviteStatus = (typeof CollectionInviteStatus)[keyof typeof CollectionInviteStatus];
+export type CollectionInviteStatus =
+  (typeof CollectionInviteStatus)[keyof typeof CollectionInviteStatus];
 
 export const HomeBlockType = {
   Collection: 'Collection',
@@ -797,7 +815,8 @@ export const EntityCollaboratorStatus = {
   Rejected: 'Rejected',
 } as const;
 
-export type EntityCollaboratorStatus = (typeof EntityCollaboratorStatus)[keyof typeof EntityCollaboratorStatus];
+export type EntityCollaboratorStatus =
+  (typeof EntityCollaboratorStatus)[keyof typeof EntityCollaboratorStatus];
 
 export const ClubAdminPermission = {
   ManageMemberships: 'ManageMemberships',
@@ -844,7 +863,8 @@ export const PurchasableRewardUsage = {
   MultiUse: 'MultiUse',
 } as const;
 
-export type PurchasableRewardUsage = (typeof PurchasableRewardUsage)[keyof typeof PurchasableRewardUsage];
+export type PurchasableRewardUsage =
+  (typeof PurchasableRewardUsage)[keyof typeof PurchasableRewardUsage];
 
 export const EntityType = {
   Image: 'Image',
@@ -996,7 +1016,8 @@ export const ChallengeReviewCostType = {
   Flat: 'Flat',
 } as const;
 
-export type ChallengeReviewCostType = (typeof ChallengeReviewCostType)[keyof typeof ChallengeReviewCostType];
+export type ChallengeReviewCostType =
+  (typeof ChallengeReviewCostType)[keyof typeof ChallengeReviewCostType];
 
 export const ChallengeIngestionStatus = {
   Pending: 'Pending',
@@ -1005,19 +1026,22 @@ export const ChallengeIngestionStatus = {
   Error: 'Error',
 } as const;
 
-export type ChallengeIngestionStatus = (typeof ChallengeIngestionStatus)[keyof typeof ChallengeIngestionStatus];
+export type ChallengeIngestionStatus =
+  (typeof ChallengeIngestionStatus)[keyof typeof ChallengeIngestionStatus];
 
 export const ChallengeEngagementType = {
   Notify: 'Notify',
 } as const;
 
-export type ChallengeEngagementType = (typeof ChallengeEngagementType)[keyof typeof ChallengeEngagementType];
+export type ChallengeEngagementType =
+  (typeof ChallengeEngagementType)[keyof typeof ChallengeEngagementType];
 
 export const EntityMetric_EntityType_Type = {
   Image: 'Image',
 } as const;
 
-export type EntityMetric_EntityType_Type = (typeof EntityMetric_EntityType_Type)[keyof typeof EntityMetric_EntityType_Type];
+export type EntityMetric_EntityType_Type =
+  (typeof EntityMetric_EntityType_Type)[keyof typeof EntityMetric_EntityType_Type];
 
 export const EntityMetric_MetricType_Type = {
   ReactionLike: 'ReactionLike',
@@ -1029,7 +1053,8 @@ export const EntityMetric_MetricType_Type = {
   Buzz: 'Buzz',
 } as const;
 
-export type EntityMetric_MetricType_Type = (typeof EntityMetric_MetricType_Type)[keyof typeof EntityMetric_MetricType_Type];
+export type EntityMetric_MetricType_Type =
+  (typeof EntityMetric_MetricType_Type)[keyof typeof EntityMetric_MetricType_Type];
 
 export const ComicProjectStatus = {
   Active: 'Active',
@@ -1106,7 +1131,8 @@ export const UserRestrictionStatus = {
   Overturned: 'Overturned',
 } as const;
 
-export type UserRestrictionStatus = (typeof UserRestrictionStatus)[keyof typeof UserRestrictionStatus];
+export type UserRestrictionStatus =
+  (typeof UserRestrictionStatus)[keyof typeof UserRestrictionStatus];
 
 export const StrikeReason = {
   BlockedContent: 'BlockedContent',
@@ -1142,7 +1168,8 @@ export const WildcardSetAuditStatus = {
   Dirty: 'Dirty',
 } as const;
 
-export type WildcardSetAuditStatus = (typeof WildcardSetAuditStatus)[keyof typeof WildcardSetAuditStatus];
+export type WildcardSetAuditStatus =
+  (typeof WildcardSetAuditStatus)[keyof typeof WildcardSetAuditStatus];
 
 export const WildcardSetCategoryAuditStatus = {
   Pending: 'Pending',
@@ -1150,7 +1177,8 @@ export const WildcardSetCategoryAuditStatus = {
   Dirty: 'Dirty',
 } as const;
 
-export type WildcardSetCategoryAuditStatus = (typeof WildcardSetCategoryAuditStatus)[keyof typeof WildcardSetCategoryAuditStatus];
+export type WildcardSetCategoryAuditStatus =
+  (typeof WildcardSetCategoryAuditStatus)[keyof typeof WildcardSetCategoryAuditStatus];
 
 export const ReviewVerdict = {
   TruePositive: 'TruePositive',
@@ -1177,14 +1205,16 @@ export const Model3DEngagementType = {
   Notify: 'Notify',
 } as const;
 
-export type Model3DEngagementType = (typeof Model3DEngagementType)[keyof typeof Model3DEngagementType];
+export type Model3DEngagementType =
+  (typeof Model3DEngagementType)[keyof typeof Model3DEngagementType];
 
 export const ShopifyMerchOrderStatus = {
   Pending: 'Pending',
   Granted: 'Granted',
 } as const;
 
-export type ShopifyMerchOrderStatus = (typeof ShopifyMerchOrderStatus)[keyof typeof ShopifyMerchOrderStatus];
+export type ShopifyMerchOrderStatus =
+  (typeof ShopifyMerchOrderStatus)[keyof typeof ShopifyMerchOrderStatus];
 
 export const OutboxEntity = {
   Article: 'Article',

--- a/src/server/services/__tests__/user-payment-configuration.tipalti-status.test.ts
+++ b/src/server/services/__tests__/user-payment-configuration.tipalti-status.test.ts
@@ -64,9 +64,9 @@ describe('updateByTipaltiAccount notifications', () => {
     mockCreateNotification.mockClear();
   });
 
-  // 🔴 The regression this guards: TipaltiStatus.Active used to be 'ACTIVE' while Tipalti stores
-  // 'Active', so this comparison could never be true and the notification fired on EVERY payable
-  // webhook for the creators who were already payable.
+  // 🔴 The incident: this branch compared the stored status against TipaltiStatus.Active, which was
+  // spelled 'ACTIVE' while Tipalti stores 'Active'. Never true, so every payable webhook re-notified
+  // all 291 payable creators. The enum casing is pinned below; this asserts the branch itself.
   it('does not re-notify an account that was already active and payable', async () => {
     await update({
       storedStatus: WEBHOOK_STATUS.active,
@@ -89,6 +89,32 @@ describe('updateByTipaltiAccount notifications', () => {
     expect(notificationTypes()).toContain('creators-program-payments-enabled');
   });
 
+  // Tipalti sends payeeDetailsChanged for edits that move nothing (a new address, a new payment
+  // method), so "already payable, still payable" is the ordinary repeat delivery, not an edge case.
+  it('does not re-notify a payable account whose status is not literally Active', async () => {
+    await update({
+      storedStatus: WEBHOOK_STATUS.pendingOnboarding,
+      storedPayable: true,
+      incomingStatus: WEBHOOK_STATUS.pendingOnboarding,
+      incomingPayable: true,
+    });
+
+    expect(notificationTypes()).not.toContain('creators-program-payments-enabled');
+  });
+
+  // The tax-form path below this branch takes payable -> unpayable at an unchanged Active status;
+  // resolving the form is the same move back, and a status comparison cannot see either one.
+  it('notifies when payability is restored without the status changing', async () => {
+    await update({
+      storedStatus: WEBHOOK_STATUS.active,
+      storedPayable: false,
+      incomingStatus: WEBHOOK_STATUS.active,
+      incomingPayable: true,
+    });
+
+    expect(notificationTypes()).toContain('creators-program-payments-enabled');
+  });
+
   it.each([WEBHOOK_STATUS.blocked, WEBHOOK_STATUS.blockedByProvider])(
     'notifies rejection for %s',
     async (incomingStatus) => {
@@ -102,6 +128,21 @@ describe('updateByTipaltiAccount notifications', () => {
       expect(notificationTypes()).toContain('creators-program-rejected-tipalti');
     }
   );
+
+  it.each([
+    [WEBHOOK_STATUS.blocked, WEBHOOK_STATUS.blocked],
+    [WEBHOOK_STATUS.blocked, WEBHOOK_STATUS.blockedByProvider],
+    [WEBHOOK_STATUS.blockedByProvider, WEBHOOK_STATUS.blocked],
+  ])('does not re-notify rejection for %s -> %s', async (storedStatus, incomingStatus) => {
+    await update({
+      storedStatus,
+      storedPayable: false,
+      incomingStatus,
+      incomingPayable: false,
+    });
+
+    expect(notificationTypes()).not.toContain('creators-program-rejected-tipalti');
+  });
 });
 
 // The webhook writes Tipalti's `eventData.status` verbatim, so the enum is a contract with an

--- a/src/server/services/user-payment-configuration.service.ts
+++ b/src/server/services/user-payment-configuration.service.ts
@@ -285,6 +285,10 @@ export async function createTipaltiPayee({ userId }: { userId: number }) {
   }
 }
 
+// Two spellings of the same terminal state, so a move between them is not a new rejection.
+const isBlockedTipaltiStatus = (status: string) =>
+  status === TipaltiStatus.Blocked || status === TipaltiStatus.BlockedByProvider;
+
 export async function updateByTipaltiAccount({
   tipaltiAccountId,
   tipaltiAccountStatus,
@@ -321,8 +325,11 @@ export async function updateByTipaltiAccount({
     },
   });
 
+  // Tipalti re-sends payeeDetailsChanged for any payee edit, at an unchanged status — so each of
+  // these has to compare the stored row against this event and fire only on the move. Nothing
+  // downstream will collapse a repeat: the notification key carries a fresh uuid.
   if (tipaltiPaymentsEnabled) {
-    if (userPaymentConfig.tipaltiAccountStatus !== TipaltiStatus.Active) {
+    if (!userPaymentConfig.tipaltiPaymentsEnabled) {
       await createNotification({
         userId: userPaymentConfig.userId,
         type: 'creators-program-payments-enabled',
@@ -331,19 +338,18 @@ export async function updateByTipaltiAccount({
         details: {},
       }).catch();
     }
-  } else if (
-    tipaltiAccountStatus === TipaltiStatus.BlockedByProvider ||
-    tipaltiAccountStatus === TipaltiStatus.Blocked
-  ) {
-    await createNotification({
-      userId: userPaymentConfig.userId,
-      type: 'creators-program-rejected-tipalti',
-      category: NotificationCategory.System,
-      key: `creators-program-rejected-tipalti:${uuid()}`,
-      details: {},
-    }).catch(() => {
-      log({ method: 'createNotification', userId: userPaymentConfig.userId });
-    });
+  } else if (isBlockedTipaltiStatus(tipaltiAccountStatus)) {
+    if (!isBlockedTipaltiStatus(userPaymentConfig.tipaltiAccountStatus)) {
+      await createNotification({
+        userId: userPaymentConfig.userId,
+        type: 'creators-program-rejected-tipalti',
+        category: NotificationCategory.System,
+        key: `creators-program-rejected-tipalti:${uuid()}`,
+        details: {},
+      }).catch(() => {
+        log({ method: 'createNotification', userId: userPaymentConfig.userId });
+      });
+    }
   }
 
   // If the user just transitioned from payable -> not payable because of a Tax issue,


### PR DESCRIPTION
The payments-enabled branch compared the stored status against `TipaltiStatus.Active` ('ACTIVE' vs Tipalti's 'Active'), so it was never a no-op and every payable `payeeDetailsChanged` webhook re-notified all 291 payable creators; it now gates on the stored `tipaltiPaymentsEnabled` flag, which also covers payability restored at an unchanged status. Rejection notifications get the same treatment via `isBlockedTipaltiStatus`, so moving between Blocked and BlockedByProvider no longer counts as a new rejection.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868ktup66`). Reviewed locally before push.