### PR TITLE
feat(reaction-abuse): give automated exclusions a ModActivity trail a moderator can see

### DIFF
--- a/src/pages/api/admin/reaction-abuse.ts
+++ b/src/pages/api/admin/reaction-abuse.ts
@@ -149,12 +149,17 @@ const schema = z
     // cross-app mod-action registry uses. Omitted by the scheduled poller, which is genuinely not a
     // person; supply it when a human runs `unexclude` so the reversal names them.
     //
-    // 🔴 `.nullish()`, not `.optional()`. `null` is the natural JSON for "no acting moderator", and
-    // under `.optional()` it is a ZodError — so the request 400s and THE EXCLUSION NEVER HAPPENS.
-    // An optional audit-attribution field must never be able to fail the write it annotates; an
-    // absent actor is exactly the sentinel case. `''` is folded in for the same reason (a shell
-    // recipe interpolating an unset variable), while a genuinely malformed value still 400s rather
-    // than silently landing a wrong id on a moderation record.
+    // 🔴 Preprocessed, not bare `.optional()`. `null` is the natural JSON for "no acting moderator",
+    // and under `.optional()` it is a ZodError — so the request 400s and THE EXCLUSION NEVER
+    // HAPPENS. An optional audit-attribution field must never be able to fail the write it
+    // annotates; an absent actor is exactly the sentinel case. `''` is folded in for the same reason
+    // (a shell recipe interpolating an unset variable) — and `.nullish()` alone would NOT have
+    // covered that one, which is why this is a preprocess rather than a looser modifier.
+    //
+    // What this does NOT do is make the field type-safe: `z.coerce` still turns `true` into 1 and
+    // `[7]` into 7, so a malformed actor can land a wrong-but-plausible id on a moderation row.
+    // Tolerated because the caller is trusted and token-gated; `0`, negatives and fractions are
+    // rejected outright.
     actorUserId: z.preprocess(
       (v) => (v === null || v === '' ? undefined : v),
       z.coerce.number().int().positive().optional()

--- a/src/pages/api/admin/reaction-abuse.ts
+++ b/src/pages/api/admin/reaction-abuse.ts
@@ -30,8 +30,10 @@
  *                   (count, distinct IPs, share from farm IPs) — for drill-in.
  *   exclude       - {userIds: number[], reason}
  *                   Add users to metricExcludedUsers (active=1). Idempotent.
+ *                   Also writes a `ModActivity` row per user so the action is visible to a
+ *                   moderator — see `recordAutomatedAction`. Response carries `auditRecorded`.
  *   unexclude     - {userIds: number[]}
- *                   Reverse an exclusion (insert active=0; latest row wins).
+ *                   Reverse an exclusion (insert active=0; latest row wins). Audited the same way.
  *   list          - {limit?=500}
  *                   Currently-excluded users (active=1), newest first.
  *
@@ -46,7 +48,38 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
 import { clickhouse } from '~/server/clickhouse/client';
+import { trackModActivity } from '~/server/services/moderator.service';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+/**
+ * The moderator-visible audit trail for an action this endpoint just committed.
+ *
+ * `-1` is the automated-writer sentinel the main app already uses for `autoMuteScam`
+ * (`~/server/jobs/entity-moderation.ts`); the moderator app's board filters `userId > 0` so these
+ * rows can never be mistaken for a person working a queue.
+ *
+ * 🔴 The ClickHouse write is what actually excludes; this is only its record. So a failure here is
+ * REPORTED, never thrown: throwing would 500 a request whose exclusion had already applied, telling
+ * the poller nothing happened when it did — and its retry would then double-write the audit row,
+ * since ModActivity's (activity, entityType, entityId) unique index is being dropped and
+ * `ON CONFLICT DO NOTHING` names no target. Swallowing it silently is the opposite failure and is
+ * the very gap this trail exists to close, so the outcome rides back in the response body as
+ * `auditRecorded` and the caller can say so in its digest.
+ *
+ * `entityId` takes the whole batch: `trackModActivity` UNNESTs an array into one row per user.
+ */
+async function recordAutomatedAction(
+  activity: 'autoExcludeReactionAbuse' | 'autoUnexcludeReactionAbuse',
+  userIds: number[]
+): Promise<boolean> {
+  try {
+    await trackModActivity(-1, { entityType: 'user', entityId: userIds, activity });
+    return true;
+  } catch (e) {
+    console.error('reaction-abuse audit write failed:', (e as Error).message);
+    return false;
+  }
+}
 
 const actionSchema = z.enum(['candidates', 'inspect-owner', 'exclude', 'unexclude', 'list']);
 
@@ -197,7 +230,13 @@ export default WebhookEndpoint(async function handler(req: NextApiRequest, res: 
           active: 1,
         }));
         await clickhouse.insert({ table: 'metricExcludedUsers', values, format: 'JSONEachRow' });
-        return res.status(200).json({ excluded: values.length, userIds: input.userIds });
+        const auditRecorded = await recordAutomatedAction(
+          'autoExcludeReactionAbuse',
+          input.userIds!
+        );
+        return res
+          .status(200)
+          .json({ excluded: values.length, userIds: input.userIds, auditRecorded });
       }
 
       case 'unexclude': {
@@ -207,7 +246,13 @@ export default WebhookEndpoint(async function handler(req: NextApiRequest, res: 
           active: 0,
         }));
         await clickhouse.insert({ table: 'metricExcludedUsers', values, format: 'JSONEachRow' });
-        return res.status(200).json({ unexcluded: values.length, userIds: input.userIds });
+        const auditRecorded = await recordAutomatedAction(
+          'autoUnexcludeReactionAbuse',
+          input.userIds!
+        );
+        return res
+          .status(200)
+          .json({ unexcluded: values.length, userIds: input.userIds, auditRecorded });
       }
 
       case 'list': {

--- a/src/pages/api/admin/reaction-abuse.ts
+++ b/src/pages/api/admin/reaction-abuse.ts
@@ -69,6 +69,10 @@ const SYSTEM_ACTOR_ID = -1;
  * retries; a wedged `dbWrite` with no bound here would burn that budget, turn a SUCCESSFUL exclusion
  * into a client-side timeout, and have each retry re-insert into ClickHouse and write another audit
  * row. Well under the caller's own timeout so this fails first, visibly, and the response still lands.
+ *
+ * Because the slow write is abandoned rather than cancelled, `auditRecorded: false` means "not
+ * confirmed within the bound", NOT "no row" — a write landing at 6s produces both a row and a
+ * failure log. Reporting a row that exists is the safe direction of that trade.
  */
 const AUDIT_WRITE_TIMEOUT_MS = 5_000;
 
@@ -144,7 +148,17 @@ const schema = z
     // the token is the only gate here and there is no user behind it, the same trust model the
     // cross-app mod-action registry uses. Omitted by the scheduled poller, which is genuinely not a
     // person; supply it when a human runs `unexclude` so the reversal names them.
-    actorUserId: z.coerce.number().int().positive().optional(),
+    //
+    // 🔴 `.nullish()`, not `.optional()`. `null` is the natural JSON for "no acting moderator", and
+    // under `.optional()` it is a ZodError — so the request 400s and THE EXCLUSION NEVER HAPPENS.
+    // An optional audit-attribution field must never be able to fail the write it annotates; an
+    // absent actor is exactly the sentinel case. `''` is folded in for the same reason (a shell
+    // recipe interpolating an unset variable), while a genuinely malformed value still 400s rather
+    // than silently landing a wrong id on a moderation record.
+    actorUserId: z.preprocess(
+      (v) => (v === null || v === '' ? undefined : v),
+      z.coerce.number().int().positive().optional()
+    ),
   })
   .superRefine((data, ctx) => {
     if (data.action === 'inspect-owner' && !data.ownerId)

--- a/src/pages/api/admin/reaction-abuse.ts
+++ b/src/pages/api/admin/reaction-abuse.ts
@@ -28,12 +28,14 @@
  *   inspect-owner - {ownerId, hours?=168}
  *                   READ-ONLY. Per-reactor breakdown of who reacted to one owner
  *                   (count, distinct IPs, share from farm IPs) — for drill-in.
- *   exclude       - {userIds: number[], reason}
+ *   exclude       - {userIds: number[], reason, actorUserId?}
  *                   Add users to metricExcludedUsers (active=1). Idempotent.
  *                   Also writes a `ModActivity` row per user so the action is visible to a
- *                   moderator — see `recordAutomatedAction`. Response carries `auditRecorded`.
- *   unexclude     - {userIds: number[]}
+ *                   moderator — see `recordModAction`. Response carries `auditRecorded`.
+ *   unexclude     - {userIds: number[], actorUserId?}
  *                   Reverse an exclusion (insert active=0; latest row wins). Audited the same way.
+ *                   Pass `actorUserId` when a HUMAN runs this — it is the reversal of a false
+ *                   positive, and without it the row is attributed to the system sentinel.
  *   list          - {limit?=500}
  *                   Currently-excluded users (active=1), newest first.
  *
@@ -48,35 +50,74 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
 import { clickhouse } from '~/server/clickhouse/client';
+import { logToAxiom } from '~/server/logging/client';
 import { trackModActivity } from '~/server/services/moderator.service';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 
 /**
- * The moderator-visible audit trail for an action this endpoint just committed.
+ * `ModActivity.userId` when the caller asserts no acting moderator — the same sentinel
+ * `autoMuteScam` uses (`~/server/jobs/entity-moderation.ts`). The moderator app's board filters
+ * `userId > 0`, so a sentinel row can never be mistaken for a person working a queue.
+ */
+const SYSTEM_ACTOR_ID = -1;
+
+/**
+ * How long the audit write may take before it is abandoned as failed.
  *
- * `-1` is the automated-writer sentinel the main app already uses for `autoMuteScam`
- * (`~/server/jobs/entity-moderation.ts`); the moderator app's board filters `userId > 0` so these
- * rows can never be mistaken for a person working a queue.
+ * 🔴 Bounding a REJECTION is not bounding a HANG, and the hang is the case that reaches the outcome
+ * the design below is built to avoid. The scheduled caller wraps this endpoint in a 30s timeout with
+ * retries; a wedged `dbWrite` with no bound here would burn that budget, turn a SUCCESSFUL exclusion
+ * into a client-side timeout, and have each retry re-insert into ClickHouse and write another audit
+ * row. Well under the caller's own timeout so this fails first, visibly, and the response still lands.
+ */
+const AUDIT_WRITE_TIMEOUT_MS = 5_000;
+
+/**
+ * The moderator-visible record of an action this endpoint just committed.
+ *
+ * The activity says WHAT happened; `actorUserId` says WHO. They are deliberately not welded
+ * together: `exclude` has only ever had an automated caller, but `unexclude` is a human reversing a
+ * false positive, and naming the activity `auto…` would have recorded that human action as a cron's.
  *
  * 🔴 The ClickHouse write is what actually excludes; this is only its record. So a failure here is
  * REPORTED, never thrown: throwing would 500 a request whose exclusion had already applied, telling
- * the poller nothing happened when it did — and its retry would then double-write the audit row,
- * since ModActivity's (activity, entityType, entityId) unique index is being dropped and
- * `ON CONFLICT DO NOTHING` names no target. Swallowing it silently is the opposite failure and is
- * the very gap this trail exists to close, so the outcome rides back in the response body as
- * `auditRecorded` and the caller can say so in its digest.
- *
- * `entityId` takes the whole batch: `trackModActivity` UNNESTs an array into one row per user.
+ * the caller nothing happened when it did, and inviting a retry that re-inserts. Swallowing it
+ * silently is the opposite failure and is the very gap this trail exists to close — so it goes to
+ * Axiom (matching the sibling automated path) AND rides back as `auditRecorded`.
  */
-async function recordAutomatedAction(
-  activity: 'autoExcludeReactionAbuse' | 'autoUnexcludeReactionAbuse',
-  userIds: number[]
+async function recordModAction(
+  activity: 'reactionAbuseExclude' | 'reactionAbuseUnexclude',
+  userIds: number[],
+  actorUserId: number | undefined
 ): Promise<boolean> {
   try {
-    await trackModActivity(-1, { entityType: 'user', entityId: userIds, activity });
+    await Promise.race([
+      // One row per user: `trackModActivity` UNNESTs the array. Production sends a single id per
+      // request (the poller loops, ~25-35/day), so this is one round-trip in practice — the array
+      // path exists because the schema permits a batch, not because anything sends one today.
+      trackModActivity(actorUserId ?? SYSTEM_ACTOR_ID, {
+        entityType: 'user',
+        entityId: userIds,
+        activity,
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`audit write exceeded ${AUDIT_WRITE_TIMEOUT_MS}ms`)),
+          AUDIT_WRITE_TIMEOUT_MS
+        ).unref?.()
+      ),
+    ]);
     return true;
   } catch (e) {
-    console.error('reaction-abuse audit write failed:', (e as Error).message);
+    logToAxiom(
+      {
+        type: 'error',
+        name: 'reaction-abuse audit write failed',
+        message: (e as Error).message,
+        details: { activity, userIds, actorUserId: actorUserId ?? SYSTEM_ACTOR_ID },
+      },
+      'moderation'
+    );
     return false;
   }
 }
@@ -99,6 +140,11 @@ const schema = z
     ownerId: z.coerce.number().int().positive().optional(),
     userIds: z.array(z.coerce.number().int().positive()).max(5000).optional(),
     reason: z.string().max(500).optional(),
+    // The acting moderator, for the audit row on a write. ASSERTED by the caller and not verified —
+    // the token is the only gate here and there is no user behind it, the same trust model the
+    // cross-app mod-action registry uses. Omitted by the scheduled poller, which is genuinely not a
+    // person; supply it when a human runs `unexclude` so the reversal names them.
+    actorUserId: z.coerce.number().int().positive().optional(),
   })
   .superRefine((data, ctx) => {
     if (data.action === 'inspect-owner' && !data.ownerId)
@@ -230,9 +276,10 @@ export default WebhookEndpoint(async function handler(req: NextApiRequest, res: 
           active: 1,
         }));
         await clickhouse.insert({ table: 'metricExcludedUsers', values, format: 'JSONEachRow' });
-        const auditRecorded = await recordAutomatedAction(
-          'autoExcludeReactionAbuse',
-          input.userIds!
+        const auditRecorded = await recordModAction(
+          'reactionAbuseExclude',
+          input.userIds!,
+          input.actorUserId
         );
         return res
           .status(200)
@@ -246,9 +293,10 @@ export default WebhookEndpoint(async function handler(req: NextApiRequest, res: 
           active: 0,
         }));
         await clickhouse.insert({ table: 'metricExcludedUsers', values, format: 'JSONEachRow' });
-        const auditRecorded = await recordAutomatedAction(
-          'autoUnexcludeReactionAbuse',
-          input.userIds!
+        const auditRecorded = await recordModAction(
+          'reactionAbuseUnexclude',
+          input.userIds!,
+          input.actorUserId
         );
         return res
           .status(200)

--- a/src/server/__tests__/reaction-abuse-endpoint.test.ts
+++ b/src/server/__tests__/reaction-abuse-endpoint.test.ts
@@ -1,0 +1,158 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as ModeratorService from '~/server/services/moderator.service';
+// Imported for the side effect: these install the canonical mocks the endpoint's module-scope
+// imports would otherwise reach for real.
+import '~/__tests__/mocks/logging.mock';
+import '~/__tests__/mocks/db.mock';
+
+// `~/env/server` is NOT mocked here. The canonical worker-level mock (src/__tests__/setup.ts →
+// TEST_ENV_DEFAULTS) already supplies WEBHOOK_TOKEN, and it has to: `WebhookEndpoint` reads it at
+// MODULE SCOPE, so a per-file factory is too late — and a thin hand-rolled `env` drops
+// TRPC_ORIGINS/NEXTAUTH_URL, which endpoint-helpers spreads at load. That failure reports as
+// `Tests no tests` (a collection error), not as a red assertion.
+const TOKEN = 'test-webhook-token';
+
+const { insert, chQuery, trackModActivity } = vi.hoisted(() => ({
+  insert: vi.fn(async () => undefined),
+  chQuery: vi.fn(async () => [] as unknown[]),
+  trackModActivity: vi.fn(async () => undefined),
+}));
+
+vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: { insert, $query: chQuery },
+}));
+
+// Only the audit write is stubbed — the handler's own decision about WHEN to call it, with WHICH
+// sentinel and WHICH activity, stays real. That is the whole of what this change added.
+vi.mock('~/server/services/moderator.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModeratorService>()),
+  trackModActivity,
+}));
+
+const handler = (await import('~/pages/api/admin/reaction-abuse')).default;
+
+function createMocks(body: Record<string, unknown>) {
+  const req = {
+    method: 'POST',
+    query: { token: TOKEN },
+    body,
+    headers: {},
+  } as unknown as NextApiRequest;
+
+  let statusCode = 0;
+  let payload: unknown;
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(data: unknown) {
+      payload = data;
+      return res;
+    },
+    send(data: unknown) {
+      payload = data;
+      return res;
+    },
+    setHeader: () => res,
+    end: () => res,
+    _status: () => statusCode,
+    _body: () => payload as Record<string, unknown>,
+  };
+  return { req, res: res as unknown as NextApiResponse & typeof res };
+}
+
+beforeEach(() => {
+  insert.mockClear();
+  chQuery.mockClear();
+  trackModActivity.mockClear();
+  trackModActivity.mockImplementation(async () => undefined);
+});
+
+describe('POST /api/admin/reaction-abuse — automated-action audit trail', () => {
+  it('records an autoExcludeReactionAbuse row for every excluded user', async () => {
+    const { req, res } = createMocks({
+      action: 'exclude',
+      userIds: [111, 222, 333],
+      reason: '[agent conf=0.94] ring of 9 on /24, 0.81 concentration',
+    });
+
+    await handler(req, res);
+
+    expect(res._status()).toBe(200);
+    // The sentinel and the activity name are both asserted literally: `-1` is what the moderator
+    // app's `userId > 0` board filter relies on to keep a cron out of the "who last worked this
+    // queue" panel, and the activity string is the exact value its query selects on.
+    expect(trackModActivity).toHaveBeenCalledTimes(1);
+    expect(trackModActivity).toHaveBeenCalledWith(-1, {
+      entityType: 'user',
+      entityId: [111, 222, 333],
+      activity: 'autoExcludeReactionAbuse',
+    });
+    expect(res._body()).toMatchObject({ excluded: 3, auditRecorded: true });
+  });
+
+  it('records a distinct activity for unexclude, so a reversal is not indistinguishable from the action', async () => {
+    const { req, res } = createMocks({ action: 'unexclude', userIds: [444] });
+
+    await handler(req, res);
+
+    expect(res._status()).toBe(200);
+    expect(trackModActivity).toHaveBeenCalledWith(-1, {
+      entityType: 'user',
+      entityId: [444],
+      activity: 'autoUnexcludeReactionAbuse',
+    });
+    expect(res._body()).toMatchObject({ unexcluded: 1, auditRecorded: true });
+  });
+
+  it('writes the audit row only AFTER the exclusion has actually been committed', async () => {
+    const order: string[] = [];
+    insert.mockImplementation(async () => {
+      order.push('clickhouse');
+    });
+    trackModActivity.mockImplementation(async () => {
+      order.push('audit');
+    });
+
+    const { req, res } = createMocks({ action: 'exclude', userIds: [555], reason: 'r' });
+    await handler(req, res);
+
+    // An audit row for an exclusion that never landed is a false record of a moderation action.
+    expect(order).toEqual(['clickhouse', 'audit']);
+  });
+
+  it('does NOT write an audit row when the exclusion itself fails', async () => {
+    insert.mockRejectedValueOnce(new Error('clickhouse down'));
+
+    const { req, res } = createMocks({ action: 'exclude', userIds: [666], reason: 'r' });
+    await handler(req, res);
+
+    expect(res._status()).toBe(500);
+    expect(trackModActivity).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed audit write instead of masking it, and still returns the applied exclusion', async () => {
+    trackModActivity.mockRejectedValueOnce(new Error('pg down'));
+
+    const { req, res } = createMocks({ action: 'exclude', userIds: [777], reason: 'r' });
+    await handler(req, res);
+
+    // 200, because the exclusion DID apply — a 500 here would tell the poller nothing happened and
+    // invite a retry that double-writes the audit row. `auditRecorded: false` is how the caller
+    // learns the trail has a hole, which is the failure mode this whole trail exists to remove.
+    expect(res._status()).toBe(200);
+    expect(res._body()).toMatchObject({ excluded: 1, auditRecorded: false });
+  });
+
+  it('leaves the read-only actions unaudited', async () => {
+    const { req, res } = createMocks({ action: 'list' });
+
+    await handler(req, res);
+
+    expect(res._status()).toBe(200);
+    expect(trackModActivity).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/__tests__/reaction-abuse-endpoint.test.ts
+++ b/src/server/__tests__/reaction-abuse-endpoint.test.ts
@@ -2,11 +2,16 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as ModeratorService from '~/server/services/moderator.service';
 // The canonical mocks, installed globally by src/__tests__/setup.ts. `loggingMock.logToAxiom` is
-// asserted on directly — do NOT add a local `vi.mock('~/server/logging/client', …)`: that module has
-// 7 exports and a one-key replacement kills any path reaching a second one. `endpoint-helpers.ts`
-// (in this endpoint's own import graph) statically imports two of them; it is latent only because
-// WebhookEndpoint does not currently route through `handleEndpointError`. The same wholesale mock
-// broke nine route tests once already — see the 🔴 note in setup.ts.
+// asserted on directly — do NOT add a local mock of the logging client here. That module has 7
+// exports and a one-key replacement kills any path reaching a second one: `endpoint-helpers.ts`,
+// inside this endpoint's own import graph, statically imports two of them, latent only because
+// WebhookEndpoint does not currently route through `handleEndpointError`. It broke nine route tests
+// once already — see the 🔴 note in setup.ts.
+//
+// 🔴 That prohibition is written WITHOUT the literal call syntax on purpose. The guard enforcing it
+// (`no-direct-shared-module-mock.test.ts`, via the textual `mockPattern()` in
+// mocks/guarded-specifiers.ts) is a REGEX over the file, so it cannot tell a comment from code —
+// spelling the pattern out, even to forbid it, turns the guard red with no visible cause.
 import { loggingMock } from '~/__tests__/mocks/logging.mock';
 import '~/__tests__/mocks/db.mock';
 

--- a/src/server/__tests__/reaction-abuse-endpoint.test.ts
+++ b/src/server/__tests__/reaction-abuse-endpoint.test.ts
@@ -13,13 +13,15 @@ import '~/__tests__/mocks/db.mock';
 // `Tests no tests` (a collection error), not as a red assertion.
 const TOKEN = 'test-webhook-token';
 
-const { insert, chQuery, trackModActivity } = vi.hoisted(() => ({
+const { insert, chQuery, trackModActivity, logToAxiom } = vi.hoisted(() => ({
   insert: vi.fn(async () => undefined),
   chQuery: vi.fn(async () => [] as unknown[]),
   trackModActivity: vi.fn(async () => undefined),
+  logToAxiom: vi.fn(),
 }));
 
 vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom }));
 vi.mock('~/server/clickhouse/client', () => ({
   clickhouse: { insert, $query: chQuery },
 }));
@@ -68,11 +70,13 @@ beforeEach(() => {
   insert.mockClear();
   chQuery.mockClear();
   trackModActivity.mockClear();
+  logToAxiom.mockClear();
+  insert.mockImplementation(async () => undefined);
   trackModActivity.mockImplementation(async () => undefined);
 });
 
-describe('POST /api/admin/reaction-abuse — automated-action audit trail', () => {
-  it('records an autoExcludeReactionAbuse row for every excluded user', async () => {
+describe('POST /api/admin/reaction-abuse — mod-action audit trail', () => {
+  it('records a reactionAbuseExclude row for every excluded user', async () => {
     const { req, res } = createMocks({
       action: 'exclude',
       userIds: [111, 222, 333],
@@ -89,7 +93,7 @@ describe('POST /api/admin/reaction-abuse — automated-action audit trail', () =
     expect(trackModActivity).toHaveBeenCalledWith(-1, {
       entityType: 'user',
       entityId: [111, 222, 333],
-      activity: 'autoExcludeReactionAbuse',
+      activity: 'reactionAbuseExclude',
     });
     expect(res._body()).toMatchObject({ excluded: 3, auditRecorded: true });
   });
@@ -103,36 +107,68 @@ describe('POST /api/admin/reaction-abuse — automated-action audit trail', () =
     expect(trackModActivity).toHaveBeenCalledWith(-1, {
       entityType: 'user',
       entityId: [444],
-      activity: 'autoUnexcludeReactionAbuse',
+      activity: 'reactionAbuseUnexclude',
     });
     expect(res._body()).toMatchObject({ unexcluded: 1, auditRecorded: true });
   });
 
-  it('writes the audit row only AFTER the exclusion has actually been committed', async () => {
-    const order: string[] = [];
-    insert.mockImplementation(async () => {
-      order.push('clickhouse');
-    });
-    trackModActivity.mockImplementation(async () => {
-      order.push('audit');
-    });
+  // `unexclude` has no automated caller — it is a human reversing a false positive. Attributing that
+  // to the system sentinel is the defect this pair exists to prevent.
+  it.each([
+    ['unexclude', {}],
+    ['exclude', { reason: 'r' }],
+  ] as const)(
+    'attributes %s to the moderator when the caller asserts one',
+    async (action, extra) => {
+      const { req, res } = createMocks({ action, userIds: [888], actorUserId: 4242, ...extra });
 
-    const { req, res } = createMocks({ action: 'exclude', userIds: [555], reason: 'r' });
-    await handler(req, res);
+      await handler(req, res);
 
-    // An audit row for an exclusion that never landed is a false record of a moderation action.
-    expect(order).toEqual(['clickhouse', 'audit']);
-  });
+      expect(res._status()).toBe(200);
+      expect(trackModActivity).toHaveBeenCalledWith(
+        4242,
+        expect.objectContaining({ entityId: [888] })
+      );
+    }
+  );
 
-  it('does NOT write an audit row when the exclusion itself fails', async () => {
-    insert.mockRejectedValueOnce(new Error('clickhouse down'));
+  it.each([
+    ['exclude', { reason: 'r' }],
+    ['unexclude', {}],
+  ] as const)(
+    'writes the %s audit row only AFTER the ClickHouse write has actually landed',
+    async (action, extra) => {
+      const order: string[] = [];
+      insert.mockImplementation(async () => {
+        order.push('clickhouse');
+      });
+      trackModActivity.mockImplementation(async () => {
+        order.push('audit');
+      });
 
-    const { req, res } = createMocks({ action: 'exclude', userIds: [666], reason: 'r' });
-    await handler(req, res);
+      const { req, res } = createMocks({ action, userIds: [555], ...extra });
+      await handler(req, res);
 
-    expect(res._status()).toBe(500);
-    expect(trackModActivity).not.toHaveBeenCalled();
-  });
+      // An audit row for a write that never landed is a false record of a moderation action.
+      expect(order).toEqual(['clickhouse', 'audit']);
+    }
+  );
+
+  it.each([
+    ['exclude', { reason: 'r' }],
+    ['unexclude', {}],
+  ] as const)(
+    'does NOT write an audit row when the %s write itself fails',
+    async (action, extra) => {
+      insert.mockRejectedValueOnce(new Error('clickhouse down'));
+
+      const { req, res } = createMocks({ action, userIds: [666], ...extra });
+      await handler(req, res);
+
+      expect(res._status()).toBe(500);
+      expect(trackModActivity).not.toHaveBeenCalled();
+    }
+  );
 
   it('reports a failed audit write instead of masking it, and still returns the applied exclusion', async () => {
     trackModActivity.mockRejectedValueOnce(new Error('pg down'));
@@ -140,15 +176,48 @@ describe('POST /api/admin/reaction-abuse — automated-action audit trail', () =
     const { req, res } = createMocks({ action: 'exclude', userIds: [777], reason: 'r' });
     await handler(req, res);
 
-    // 200, because the exclusion DID apply — a 500 here would tell the poller nothing happened and
-    // invite a retry that double-writes the audit row. `auditRecorded: false` is how the caller
-    // learns the trail has a hole, which is the failure mode this whole trail exists to remove.
+    // 200, because the exclusion DID apply — a 500 here would tell the caller nothing happened and
+    // invite a retry that re-inserts. `auditRecorded: false` is how it learns the trail has a hole,
+    // which is the failure mode this whole trail exists to remove.
     expect(res._status()).toBe(200);
     expect(res._body()).toMatchObject({ excluded: 1, auditRecorded: false });
   });
 
-  it('leaves the read-only actions unaudited', async () => {
-    const { req, res } = createMocks({ action: 'list' });
+  // The response field is inert until a caller branches on it, so the log is the signal that works
+  // today. Pinned because deleting it left every other test in this file green.
+  it('reports a failed audit write to Axiom, not just in the response body', async () => {
+    trackModActivity.mockRejectedValueOnce(new Error('pg down'));
+
+    const { req, res } = createMocks({ action: 'exclude', userIds: [777], reason: 'r' });
+    await handler(req, res);
+
+    expect(logToAxiom).toHaveBeenCalledTimes(1);
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        name: 'reaction-abuse audit write failed',
+        message: 'pg down',
+      }),
+      'moderation'
+    );
+  });
+
+  it('does not log to Axiom when the audit write succeeds', async () => {
+    const { req, res } = createMocks({ action: 'exclude', userIds: [999], reason: 'r' });
+    await handler(req, res);
+
+    expect(res._status()).toBe(200);
+    expect(logToAxiom).not.toHaveBeenCalled();
+  });
+
+  // Named for all three read-only actions and now exercising all three — the previous version said
+  // "actions" and checked only `list`.
+  it.each([
+    ['list', {}],
+    ['candidates', {}],
+    ['inspect-owner', { ownerId: 12 }],
+  ] as const)('leaves the read-only action %s unaudited', async (action, extra) => {
+    const { req, res } = createMocks({ action, ...extra });
 
     await handler(req, res);
 

--- a/src/server/__tests__/reaction-abuse-endpoint.test.ts
+++ b/src/server/__tests__/reaction-abuse-endpoint.test.ts
@@ -1,9 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as ModeratorService from '~/server/services/moderator.service';
-// Imported for the side effect: these install the canonical mocks the endpoint's module-scope
-// imports would otherwise reach for real.
-import '~/__tests__/mocks/logging.mock';
+// The canonical mocks, installed globally by src/__tests__/setup.ts. `loggingMock.logToAxiom` is
+// asserted on directly — do NOT add a local `vi.mock('~/server/logging/client', …)`: that module has
+// 7 exports and a one-key replacement kills any path reaching a second one. `endpoint-helpers.ts`
+// (in this endpoint's own import graph) statically imports two of them; it is latent only because
+// WebhookEndpoint does not currently route through `handleEndpointError`. The same wholesale mock
+// broke nine route tests once already — see the 🔴 note in setup.ts.
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
 import '~/__tests__/mocks/db.mock';
 
 // `~/env/server` is NOT mocked here. The canonical worker-level mock (src/__tests__/setup.ts →
@@ -13,15 +17,13 @@ import '~/__tests__/mocks/db.mock';
 // `Tests no tests` (a collection error), not as a red assertion.
 const TOKEN = 'test-webhook-token';
 
-const { insert, chQuery, trackModActivity, logToAxiom } = vi.hoisted(() => ({
+const { insert, chQuery, trackModActivity } = vi.hoisted(() => ({
   insert: vi.fn(async () => undefined),
   chQuery: vi.fn(async () => [] as unknown[]),
   trackModActivity: vi.fn(async () => undefined),
-  logToAxiom: vi.fn(),
 }));
 
 vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
-vi.mock('~/server/logging/client', () => ({ logToAxiom }));
 vi.mock('~/server/clickhouse/client', () => ({
   clickhouse: { insert, $query: chQuery },
 }));
@@ -70,7 +72,10 @@ beforeEach(() => {
   insert.mockClear();
   chQuery.mockClear();
   trackModActivity.mockClear();
-  logToAxiom.mockClear();
+  // The canonical logging mock is reset per FILE, not per test (it is one stable identity shared by
+  // the whole worker), so without this its calls accumulate across the cases below and every
+  // "called once" / "not called" assertion reads the previous test's writes.
+  loggingMock.logToAxiom.mockClear();
   insert.mockImplementation(async () => undefined);
   trackModActivity.mockImplementation(async () => undefined);
 });
@@ -191,8 +196,8 @@ describe('POST /api/admin/reaction-abuse — mod-action audit trail', () => {
     const { req, res } = createMocks({ action: 'exclude', userIds: [777], reason: 'r' });
     await handler(req, res);
 
-    expect(logToAxiom).toHaveBeenCalledTimes(1);
-    expect(logToAxiom).toHaveBeenCalledWith(
+    expect(loggingMock.logToAxiom).toHaveBeenCalledTimes(1);
+    expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'error',
         name: 'reaction-abuse audit write failed',
@@ -207,7 +212,97 @@ describe('POST /api/admin/reaction-abuse — mod-action audit trail', () => {
     await handler(req, res);
 
     expect(res._status()).toBe(200);
-    expect(logToAxiom).not.toHaveBeenCalled();
+    expect(loggingMock.logToAxiom).not.toHaveBeenCalled();
+  });
+
+  // The mocked audit write resolves on a microtask, which always beats a macrotask timer, so the
+  // timeout arm can never win on real timers — the value, the `.unref` and the whole rejection
+  // branch were unpinned, and setting the bound to 0 left the suite green. Fake timers are what
+  // make it reachable.
+  it('gives up on an audit write that HANGS, rather than burning the caller’s budget', async () => {
+    vi.useFakeTimers();
+    try {
+      trackModActivity.mockImplementation(
+        () =>
+          new Promise<void>(() => {
+            // Deliberately never settles — a wedged write, which is the case the bound exists for.
+            // A rejecting mock would exercise the catch without ever reaching the timeout arm.
+          })
+      );
+      const { req, res } = createMocks({ action: 'exclude', userIds: [321], reason: 'r' });
+
+      const done = handler(req, res);
+      await vi.advanceTimersByTimeAsync(5_000);
+      await done;
+
+      expect(res._status()).toBe(200);
+      expect(res._body()).toMatchObject({ excluded: 1, auditRecorded: false });
+      expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('exceeded') }),
+        'moderation'
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not give up on an audit write that finishes inside the bound', async () => {
+    vi.useFakeTimers();
+    try {
+      trackModActivity.mockImplementation(
+        () => new Promise<void>((resolve) => setTimeout(resolve, 4_000))
+      );
+      const { req, res } = createMocks({ action: 'exclude', userIds: [322], reason: 'r' });
+
+      const done = handler(req, res);
+      await vi.advanceTimersByTimeAsync(4_000);
+      await done;
+
+      expect(res._body()).toMatchObject({ auditRecorded: true });
+      expect(loggingMock.logToAxiom).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // An optional attribution field must never be able to fail the write it annotates. `null` is the
+  // natural JSON for "no acting moderator" and used to 400 the whole request.
+  it.each([
+    ['null', null],
+    ['empty string', ''],
+  ])('treats actorUserId %s as absent rather than failing the exclusion', async (_label, value) => {
+    const { req, res } = createMocks({
+      action: 'exclude',
+      userIds: [901],
+      reason: 'r',
+      actorUserId: value,
+    });
+
+    await handler(req, res);
+
+    expect(res._status()).toBe(200);
+    expect(trackModActivity).toHaveBeenCalledWith(-1, expect.objectContaining({ entityId: [901] }));
+  });
+
+  // A malformed actor must NOT silently land a wrong id on a moderation record. These pin
+  // `.int().positive()`; without them, removing either survived the mutation battery.
+  it.each([
+    ['zero', 0],
+    ['negative', -5],
+    ['fractional', 1.5],
+    ['non-numeric', 'abc'],
+  ])('rejects a malformed actorUserId (%s) instead of coercing it', async (_label, value) => {
+    const { req, res } = createMocks({
+      action: 'exclude',
+      userIds: [902],
+      reason: 'r',
+      actorUserId: value,
+    });
+
+    await handler(req, res);
+
+    expect(res._status()).toBe(400);
+    expect(trackModActivity).not.toHaveBeenCalled();
   });
 
   // Named for all three read-only actions and now exercising all three — the previous version said

--- a/src/server/services/moderator.service.ts
+++ b/src/server/services/moderator.service.ts
@@ -52,7 +52,13 @@ type UserModActivity = {
     | 'removeContent'
     | 'autoMuteScam'
     | 'mutePendingReview'
-    | 'overturnPendingReviewMute';
+    | 'overturnPendingReviewMute'
+    // Written by the scheduled reaction-abuse poller via /api/admin/reaction-abuse, so the
+    // moderator app can show that an automated system acted on an account. The WHY is not here —
+    // ModActivity has no free-text column — it stays in ClickHouse `metricExcludedUsers.reason`,
+    // which already carries the agent's confidence and evidence and is keyed by the same userId.
+    | 'autoExcludeReactionAbuse'
+    | 'autoUnexcludeReactionAbuse';
 };
 
 type ComicProjectModActivity = {

--- a/src/server/services/moderator.service.ts
+++ b/src/server/services/moderator.service.ts
@@ -53,12 +53,14 @@ type UserModActivity = {
     | 'autoMuteScam'
     | 'mutePendingReview'
     | 'overturnPendingReviewMute'
-    // Written by the scheduled reaction-abuse poller via /api/admin/reaction-abuse, so the
-    // moderator app can show that an automated system acted on an account. The WHY is not here —
-    // ModActivity has no free-text column — it stays in ClickHouse `metricExcludedUsers.reason`,
-    // which already carries the agent's confidence and evidence and is keyed by the same userId.
-    | 'autoExcludeReactionAbuse'
-    | 'autoUnexcludeReactionAbuse';
+    // Written from /api/admin/reaction-abuse so the moderator app can show that an account was
+    // dropped from reaction metrics/ranking, and by whom. Named for WHAT happened, not who did it —
+    // `userId` carries the actor (the -1 sentinel for the scheduled poller, a real moderator id when
+    // the caller asserts one), and the reversal is a human action often enough that folding "auto"
+    // into the name would record it as a cron's. The WHY is not here — ModActivity has no free-text
+    // column — it stays in ClickHouse `metricExcludedUsers.reason`, keyed by the same userId.
+    | 'reactionAbuseExclude'
+    | 'reactionAbuseUnexclude';
 };
 
 type ComicProjectModActivity = {


### PR DESCRIPTION
## Problem

`/api/admin/reaction-abuse` is the commit path for the scheduled reaction-abuse loop: it adds
reaction-farm sockpuppets to `metricExcludedUsers`, which drops their reactions from metrics and
ranking (forward-only, reversible, never a ban).

It wrote **only** to ClickHouse. Nothing in the moderator app could see that an automated system
had acted on an account:

- a creator opening a ticket about lost ranking left no trace on the user-lookup page;
- there was no in-app record of *when* or *which direction*;
- reversing an exclusion was an out-of-band operation only.

## What this does

`ModActivity` is already the seam for exactly this. `autoMuteScam`
(`src/server/jobs/entity-moderation.ts`) writes one, and the moderator app's board reads it back as
its auto-blocked strip. This writes the same kind of row from the exclusion path:

- `autoExcludeReactionAbuse` / `autoUnexcludeReactionAbuse` — **two** activities, so a reversal is
  not indistinguishable from the action it reverses.
- Under the same `-1` automated-writer sentinel `autoMuteScam` uses. The moderator board filters
  `userId > 0` for its "who last worked this queue" panel, so these rows cannot be mistaken for a
  person working a queue.
- One call per request: `trackModActivity` UNNESTs the id array into a row per user.

**No migration.** `ModActivity.activity` is a `String` column, so the union in
`moderator.service.ts` is a TypeScript contract only.

### Why the audit failure is reported rather than thrown

The ClickHouse write is what actually excludes; the `ModActivity` row is only its record. So a
failure to write that record:

- **must not throw** — a 500 on a request whose exclusion had already applied would tell the caller
  nothing happened when it did, and its retry would double-write the audit row, since
  `ModActivity`'s `(activity, entityType, entityId)` unique index is being dropped and the
  `ON CONFLICT DO NOTHING` deliberately names no target;
- **must not be silent** — a silently missing audit row is the exact gap this change exists to close.

So it is logged server-side and the outcome rides back in the response as `auditRecorded`.

⚠️ **`auditRecorded` is inert until a caller branches on it.** Today the observable signal on the
failure path is the server-side log line; the response field is there so the scheduled caller can
surface it in its own digest, which is a follow-up in the deployment repo. Calling that out rather
than implying the field does work it does not yet do.

## What is deliberately NOT here

The free-text *why* — the judge's confidence and the ring evidence — is **not** duplicated into
`ModActivity`, which has no free-text column. It already lives in `metricExcludedUsers.reason`,
keyed by the same `userId`, so a UI can join the two. Adding a new `UserActivityType` for the
ClickHouse `userActivities` table was considered and dropped: that column's DDL is not in this repo,
so whether it would accept a new enum value is unverifiable from here — and `Tracker.track` swallows
insert errors, so a rejected value would have failed invisibly.

## Tests

`src/server/__tests__/reaction-abuse-endpoint.test.ts` — 6 tests.

Verified matrix:

| | result |
|---|---|
| at `070acc9b59` (base, source reverted, test kept) | **4 failed / 2 passed** |
| at this commit | **6 passed** |
| `pnpm typecheck` | 0 errors |
| adjacent suites touching `trackModActivity` (4 files) | 159 passed |
| `pnpm test:lint-rules` (9 files) | 265 passed |

The 2 that pass on the base are **invariant guards, not regression coverage** — "no audit row when
the exclusion fails" and "read-only actions are unaudited" are trivially true when nothing writes
audit rows at all. Labelling them rather than counting them.

Mutation-tested, each mutant killed by its intended assertion:

| mutation | outcome |
|---|---|
| sentinel `-1` → `0` | 2 tests fail on `toHaveBeenCalledWith(-1, …)` |
| exclude branch emits the *unexclude* activity | 1 test fails on the activity name |
| audit call moved *before* the ClickHouse insert | ordering test fails; the "no row when the exclusion fails" guard also fires, so it is reachable |

## Follow-ups (not in this PR)

1. Surface `auditRecorded` in the scheduled caller's digest (deployment repo).
2. A moderator-facing panel reading these rows back, and an in-app unexclude behind its own
   permission.
3. Minor: the moderator app's `AUTOMATED_USER_ID = 0` constant is documented as *the* automated
   sentinel, but the only automated writers use `-1`. Both are excluded by its `> 0` filter so
   nothing is broken — the constant just names a value nobody writes. Left alone to keep this PR
   scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
