### PR TITLE
fix(apps): surface the OAuth prerequisite at the choice, align the submit flow on "Standalone", and stop Cancel discarding silently

### DIFF
--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -9,11 +9,9 @@ import {
 import type { Icon } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useState } from 'react';
+import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import { AppDetailsModal } from '~/components/Apps/AppDetailsModal';
-import {
-  CATEGORY_ICONS,
-  FALLBACK_CATEGORY_ICON,
-} from '~/components/Apps/marketplaceCategoryIcons';
+import { CATEGORY_ICONS, FALLBACK_CATEGORY_ICON } from '~/components/Apps/marketplaceCategoryIcons';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import {
   isMarketplaceCategory,
@@ -215,7 +213,7 @@ export function AppBlockCard({
                 size="sm"
                 leftSection={<IconExternalLink size={12} />}
               >
-                Standalone
+                {STANDALONE_KIND_LABEL}
               </Badge>
             )}
             {/* Mod-assigned marketplace category (+ its icon). NULL until a mod

--- a/src/components/Apps/AppEarningsPanel.browser.test.tsx
+++ b/src/components/Apps/AppEarningsPanel.browser.test.tsx
@@ -86,8 +86,14 @@ describe('AppEarningsPanelView', () => {
     test('the three messages are DISTINCT — no branch inherits another’s copy', () => {
       const messages = REASONS.map((r) => earningsUnavailableMessage(r));
       expect(new Set(messages).size).toBe(REASONS.length);
-      // …and the off-site one names the actual reason rather than an access refusal.
-      expect(earningsUnavailableMessage('unsupportedKind')).toMatch(/External apps/i);
+      // …and the standalone one names the actual reason rather than an access
+      // refusal. Pinned as the WHOLE string, not a keyword: the store's kind label was
+      // realigned on "Standalone" (it read "External apps" here while the store card
+      // beside it said "Standalone"), and a keyword guard is exactly what let those
+      // two surfaces drift apart in the first place.
+      expect(earningsUnavailableMessage('unsupportedKind')).toBe(
+        'Standalone apps don\u2019t earn Buzz through Civitai, so there are no earnings to show.'
+      );
       expect(earningsUnavailableMessage('notPermitted')).toMatch(/access/i);
     });
   });

--- a/src/components/Apps/AppEarningsPanel.tsx
+++ b/src/components/Apps/AppEarningsPanel.tsx
@@ -1,6 +1,7 @@
 import { Alert, Card, Center, Group, Loader, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import { IconAlertTriangle, IconCoin } from '@tabler/icons-react';
 
+import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import type { AppEarningsResult } from '~/server/services/blocks/app-collaborator-earnings.service';
 import { trpc } from '~/utils/trpc';
 
@@ -50,7 +51,7 @@ export function earningsUnavailableMessage(reason: Unavailable): string {
     case 'notFound':
       return 'This app listing could not be found.';
     case 'unsupportedKind':
-      return 'External apps don’t earn Buzz through Civitai, so there are no earnings to show.';
+      return `${STANDALONE_KIND_LABEL} apps don’t earn Buzz through Civitai, so there are no earnings to show.`;
     default: {
       const exhaustive: never = reason;
       return exhaustive;

--- a/src/components/Apps/AppInvitesBody.tsx
+++ b/src/components/Apps/AppInvitesBody.tsx
@@ -15,6 +15,7 @@ import { IconAlertTriangle, IconCoin, IconMailOpened } from '@tabler/icons-react
 import { inviteDisclosureItems } from '~/components/Apps/AppCollaboratorsPanelView';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import type { ReactNode } from 'react';
+import { listingKindAppLabel } from '~/components/Apps/listingKindLabels';
 import { listingEditHref } from '~/components/Apps/appListingEditorTabs';
 import type { ListingKind } from '~/shared/constants/app-capabilities.constants';
 import { capabilitiesForKind } from '~/shared/constants/app-capabilities.constants';
@@ -127,7 +128,7 @@ export function AppInvitesBodyView({
                 <Group gap="xs">
                   <Text fw={600}>{invite.slug}</Text>
                   <Badge variant="light" color={invite.kind === 'onsite' ? 'blue' : 'grape'}>
-                    {invite.kind === 'onsite' ? 'On-site app' : 'External app'}
+                    {listingKindAppLabel(invite.kind)}
                   </Badge>
                 </Group>
                 {/* A real chip, like every sibling surface — a raw numeric id told the

--- a/src/components/Apps/AppTransferOffersView.tsx
+++ b/src/components/Apps/AppTransferOffersView.tsx
@@ -2,6 +2,7 @@ import { Alert, Badge, Button, Group, List, Paper, Stack, Text, Title } from '@m
 import { IconAlertTriangle, IconArrowsExchange } from '@tabler/icons-react';
 import type { ReactNode } from 'react';
 
+import { listingKindAppLabel } from '~/components/Apps/listingKindLabels';
 import type { IncomingTransferView } from '~/server/services/blocks/app-ownership-transfer.service';
 import type { ListingKind } from '~/shared/constants/app-capabilities.constants';
 import { capabilitiesForKind } from '~/shared/constants/app-capabilities.constants';
@@ -200,7 +201,7 @@ export function AppTransferOffersView({
                     Ownership transfer
                   </Badge>
                   <Badge variant="light" color={transfer.kind === 'onsite' ? 'blue' : 'grape'}>
-                    {transfer.kind === 'onsite' ? 'On-site app' : 'External app'}
+                    {listingKindAppLabel(transfer.kind)}
                   </Badge>
                 </Group>
                 <Group

--- a/src/components/Apps/CliSubmitCta.browser.test.tsx
+++ b/src/components/Apps/CliSubmitCta.browser.test.tsx
@@ -3,9 +3,12 @@ import { page, userEvent } from 'vitest/browser';
 import { CliSubmitCta } from '~/components/Apps/CliSubmitCta';
 import {
   CIVITAI_CLI_GITHUB_URL,
+  CIVITAI_CLI_RELEASES_URL,
   CLI_CREATE_COMMAND,
   CLI_CREATE_SAMPLE_COMMAND,
   CLI_INSTALL_BREW,
+  CLI_INSTALL_GO,
+  CLI_INSTALL_NPM,
   CLI_SUBMIT_COMMAND,
 } from '~/components/Apps/cliCommands';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
@@ -119,10 +122,34 @@ async function settleCopy() {
   } while (Date.now() < deadline);
 }
 
+/**
+ * 🔴 THE TWO FLOW-A DEFECTS THIS FILE NOW PINS.
+ *
+ * (1) The panel was headed "Recommended: use the Civitai CLI". "Recommended" implies
+ *     an alternative, and this page offers none — the manual ZIP flow does not exist
+ *     here. Advertising a choice that is not on offer sends the reader looking for
+ *     the other option. The heading is asserted BOTH ways: the honest text is present
+ *     AND the retired promise is absent, because "the new string renders" would also
+ *     pass if the old one still rendered beside it.
+ *
+ * (2) The only install path shown was `brew`, which stops a Windows developer at
+ *     step 1 of 3. Every route asserted below was verified against the CLI's own
+ *     release artefacts (see the provenance block in `cliCommands.ts`) — the tests
+ *     pin what the page CLAIMS, and the provenance is what makes the claim true.
+ */
 describe('CliSubmitCta (CLI-first submit primary CTA)', () => {
-  test('promotes the Civitai CLI as the recommended path', async () => {
+  test('🔴 the heading no longer promises an alternative that does not exist', async () => {
     renderWithProviders(<CliSubmitCta />);
-    await expect.element(page.getByText('Recommended: use the Civitai CLI')).toBeInTheDocument();
+    // Settle on the honest heading first, so the absence assertion below runs against
+    // a mounted tree rather than an empty one.
+    await expect
+      .element(page.getByText('Use the Civitai CLI', { exact: true }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText('Recommended: use the Civitai CLI'))
+      .not.toBeInTheDocument();
+    // The word itself is gone from the panel, not merely moved out of the heading.
+    await expect.element(page.getByText(/Recommended/)).not.toBeInTheDocument();
   });
 
   test('renders the "Get the Civitai CLI" button linking to github.com/civitai/cli', async () => {
@@ -153,8 +180,45 @@ describe('CliSubmitCta (CLI-first submit primary CTA)', () => {
     await expect.element(page.getByText(`$ ${CLI_SUBMIT_COMMAND}`)).toBeInTheDocument();
   });
 
-  test('the install command is the brew tap one-liner', async () => {
+  /**
+   * 🔴 THE PLATFORM-COVERAGE GUARD. The literal one-liners are pinned, NOT derived
+   * from the constants they render — `expect(rendered).toBe(CLI_INSTALL_NPM)` would
+   * pass for any value the constant happened to hold, including a command that does
+   * not exist.
+   */
+  test('🔴 every platform has an install route (npm covers Windows)', async () => {
+    renderWithProviders(<CliSubmitCta />);
+    await expect.element(page.getByText('$ npm install -g @civitai/cli')).toBeInTheDocument();
+    await expect.element(page.getByText('$ brew install civitai/tap/civitai')).toBeInTheDocument();
+    await expect
+      .element(page.getByText('$ go install github.com/civitai/cli/cmd/civitai@latest'))
+      .toBeInTheDocument();
+
+    // Each route says WHO it is for, so a reader can pick without guessing.
+    await expect
+      .element(page.getByText('Windows, macOS or Linux (needs Node):', { exact: true }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText('macOS or Linux, with Homebrew:', { exact: true }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText('From source (Go 1.25+):', { exact: true }))
+      .toBeInTheDocument();
+
+    // The no-toolchain route, and it names Windows explicitly.
+    const binary = page.getByTestId('apps-cli-install-binary');
+    await expect.element(binary).toBeInTheDocument();
+    expect(binary.element().textContent).toContain('Windows');
+    const releases = page.getByRole('link', { name: 'the CLI releases page' });
+    await expect.element(releases).toBeInTheDocument();
+    expect(releases.element().getAttribute('href')).toBe('https://github.com/civitai/cli/releases');
+  });
+
+  test('the install commands are the real one-liners', () => {
+    expect(CLI_INSTALL_NPM).toBe('npm install -g @civitai/cli');
     expect(CLI_INSTALL_BREW).toBe('brew install civitai/tap/civitai');
+    expect(CLI_INSTALL_GO).toBe('go install github.com/civitai/cli/cmd/civitai@latest');
+    expect(CIVITAI_CLI_RELEASES_URL).toBe('https://github.com/civitai/cli/releases');
     expect(CLI_CREATE_COMMAND).toBe('civitai app create');
     expect(CLI_SUBMIT_COMMAND).toBe('civitai app submit');
   });

--- a/src/components/Apps/CliSubmitCta.tsx
+++ b/src/components/Apps/CliSubmitCta.tsx
@@ -15,8 +15,11 @@ import {
 import { IconBrandGithub, IconCheck, IconClipboard, IconTerminal2 } from '@tabler/icons-react';
 import {
   CIVITAI_CLI_GITHUB_URL,
+  CIVITAI_CLI_RELEASES_URL,
   CLI_CREATE_COMMAND,
   CLI_INSTALL_BREW,
+  CLI_INSTALL_GO,
+  CLI_INSTALL_NPM,
   CLI_SUBMIT_COMMAND,
 } from '~/components/Apps/cliCommands';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -50,12 +53,25 @@ function CopyableCommand({ command }: { command: string }) {
 }
 
 /**
- * CLI-first submit CTA — the primary, recommended path for authoring and
- * submitting an App Block. Pure presentational (props-only, no network / no
- * tRPC), so it renders in isolation in component tests.
+ * CLI-first submit CTA — the ONLY path for authoring and submitting an on-platform
+ * App. Pure presentational (props-only, no network / no tRPC), so it renders in
+ * isolation in component tests.
  *
- * The manual ZIP-upload flow is rendered separately and de-emphasized as a
- * secondary option (see /apps/submit).
+ * ## 🔴 IT NO LONGER SAYS "Recommended"
+ *
+ * "Recommended: use the Civitai CLI" implies an alternative, and this page offers
+ * none — the manual ZIP-upload flow does not exist here. Advertising a choice that
+ * is not on offer sends the reader looking for the other option. The heading now
+ * states what is true: this IS the way. (Of the two fixes available — drop the word,
+ * or genuinely present the alternative — dropping it is the honest one, because
+ * there is no alternative to present.)
+ *
+ * ## 🔴 EVERY PLATFORM GETS AN INSTALL ROUTE
+ *
+ * The single `brew` one-liner stopped a Windows or non-Homebrew Linux developer at
+ * step 1 of 3. `npm` leads because it is the only one-liner that covers Windows;
+ * brew and the prebuilt-binary download follow. Provenance for every route (and the
+ * verification that they exist) is in {@link file://./cliCommands.ts}.
  */
 export function CliSubmitCta() {
   return (
@@ -67,23 +83,44 @@ export function CliSubmitCta() {
       title={
         <Group gap={6}>
           <Title order={4} m={0}>
-            Recommended: use the Civitai CLI
+            Use the Civitai CLI
           </Title>
         </Group>
       }
     >
       <Stack gap="md">
         <Text size="sm">
-          The fastest way to author and ship an app is the <Code>civitai</Code> command-line tool.
-          It scaffolds a block, runs it locally, packages your source, and submits it for review —
-          no manual ZIP to build.
+          Apps are authored and submitted with the <Code>civitai</Code> command-line tool. It
+          scaffolds a block, runs it locally, packages your source, and submits it for review — no
+          manual ZIP to build.
         </Text>
 
         <Stack gap={6}>
           <Text size="sm" fw={600}>
             1. Install
           </Text>
+          {/* 🔴 Pick ONE — but every platform must find itself here. npm is first
+              because it is the only one-liner that works on Windows too. */}
+          <Text size="xs" c="dimmed" data-testid="apps-cli-install-npm-label">
+            Windows, macOS or Linux (needs Node):
+          </Text>
+          <CopyableCommand command={CLI_INSTALL_NPM} />
+          <Text size="xs" c="dimmed" data-testid="apps-cli-install-brew-label">
+            macOS or Linux, with Homebrew:
+          </Text>
           <CopyableCommand command={CLI_INSTALL_BREW} />
+          <Text size="xs" c="dimmed" data-testid="apps-cli-install-go-label">
+            From source (Go 1.25+):
+          </Text>
+          <CopyableCommand command={CLI_INSTALL_GO} />
+          <Text size="xs" c="dimmed" data-testid="apps-cli-install-binary">
+            No toolchain? Download a prebuilt binary for Windows, macOS or Linux (amd64 or arm64)
+            from{' '}
+            <Anchor href={CIVITAI_CLI_RELEASES_URL} target="_blank" rel="noopener noreferrer">
+              the CLI releases page
+            </Anchor>
+            , then put it on your PATH.
+          </Text>
         </Stack>
 
         <Stack gap={6}>

--- a/src/components/Apps/ConnectScopesPanel.tsx
+++ b/src/components/Apps/ConnectScopesPanel.tsx
@@ -47,7 +47,7 @@ export function ConnectScopesPanel({
           <Tooltip
             multiline
             w={300}
-            label="The account permissions this external app asks to be granted when a user connects it. They are bounded by the OAuth client's allowed-scope ceiling; the per-scope note is the developer's stated reason and is not verified by the platform."
+            label="The account permissions this standalone app asks to be granted when a user connects it. They are bounded by the OAuth client's allowed-scope ceiling; the per-scope note is the developer's stated reason and is not verified by the platform."
           >
             <ThemeIcon size="xs" variant="subtle" color="gray">
               <IconInfoCircle size={13} />

--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -1,3 +1,4 @@
+import Router from 'next/router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
@@ -130,6 +131,17 @@ vi.mock('~/utils/notifications', () => ({
 
 const { ExternalSubmitForm } = await import('./ExternalSubmitForm');
 
+/**
+ * The stubbed pages-router SINGLETON (see `test/component-setup.tsx`). `Cancel` is no
+ * longer a `<Link>` — it is a real button that decides whether to navigate — so the
+ * navigation itself is now an observable this suite asserts on.
+ *
+ * Reached through the DEFAULT export rather than `useRouter()`: the setup file's mock
+ * returns the same object from both (`default: router`, `useRouter: () => router`), and
+ * calling a hook at module scope is a rules-of-hooks violation even against a stub.
+ */
+const routerMock = Router as unknown as { push: ReturnType<typeof vi.fn> };
+
 beforeEach(() => {
   mocks.submit.mockClear();
   mocks.mutate.mockClear();
@@ -142,6 +154,12 @@ beforeEach(() => {
   mocks.search = { data: { items: [], nextCursor: undefined }, isFetching: false };
   // Default caller: NOT a moderator → own-clients dropdown (existing tests unchanged).
   mocks.currentUser = null;
+  // 🔴 The setup file's `next/router` stub is a module-level SINGLETON shared by every
+  // test in the run, so its `push` spy accumulates calls across tests. Without this
+  // clear, the "Cancel did NOT navigate" assertions would read a previous test's call
+  // and go red for the wrong reason — or, worse, a genuinely broken Cancel would be
+  // masked by an earlier test's legitimate navigation.
+  routerMock.push.mockClear();
 });
 
 /** Fill a valid App URL on step 0 and advance to the App & scopes step. */
@@ -225,7 +243,9 @@ describe('ExternalSubmitForm — redesigned wizard', () => {
     await expect.element(page.getByTestId('apps-offsite-justification-1')).toBeInTheDocument();
     // Next is BLOCKED until the sensitive justification is filled.
     await expect.element(page.getByTestId('apps-offsite-wizard-next-app')).toBeDisabled();
-    await page.getByTestId('apps-offsite-justification-1').fill('reads the profile to greet the user');
+    await page
+      .getByTestId('apps-offsite-justification-1')
+      .fill('reads the profile to greet the user');
     await expect.element(page.getByTestId('apps-offsite-wizard-next-app')).toBeEnabled();
   });
 
@@ -286,9 +306,7 @@ describe('ExternalSubmitForm — redesigned wizard', () => {
     // 🔴 The VALUE half is untouched: the mutation still carries the stored key.
     // The pair is the point — a mutant that mapped the value instead of the label
     // would satisfy the assertion above and break this one.
-    expect(mocks.mutate).toHaveBeenCalledWith(
-      expect.objectContaining({ contentRating: 'pg13' })
-    );
+    expect(mocks.mutate).toHaveBeenCalledWith(expect.objectContaining({ contentRating: 'pg13' }));
 
     // The "Draft created" summary badge echoes the same LABEL back to the author.
     const assets = page.getByTestId('apps-offsite-wizard-assets-panel');
@@ -321,7 +339,9 @@ describe('ExternalSubmitForm — redesigned wizard', () => {
       .element(page.getByTestId('apps-offsite-submit-name'))
       .toHaveValue('Civitai Cosmetic Studio');
     // Slug still derives from the URL host (hyphenated — slugs keep hyphens).
-    await expect.element(page.getByRole('textbox', { name: /^Slug/ })).toHaveValue('cosmetic-studio');
+    await expect
+      .element(page.getByRole('textbox', { name: /^Slug/ }))
+      .toHaveValue('cosmetic-studio');
     // og:description autofills the (empty) Description field.
     await expect
       .element(page.getByTestId('apps-offsite-submit-description'))
@@ -351,7 +371,9 @@ describe('ExternalSubmitForm — redesigned wizard', () => {
     await expect
       .element(page.getByTestId('apps-offsite-submit-name'))
       .toHaveValue('Cosmetic Studio');
-    await expect.element(page.getByRole('textbox', { name: /^Slug/ })).toHaveValue('cosmetic-studio');
+    await expect
+      .element(page.getByRole('textbox', { name: /^Slug/ }))
+      .toHaveValue('cosmetic-studio');
   });
 
   test('when the meta fetch ERRORS, the Name still falls back to the de-hyphenated host name', async () => {
@@ -394,7 +416,13 @@ describe('ExternalSubmitForm — redesigned wizard', () => {
 
   test('autofill does NOT clobber a description the user already typed', async () => {
     mocks.meta = {
-      data: { name: undefined, tagline: undefined, description: 'OG desc', coverImageUrl: undefined, iconImageUrl: undefined },
+      data: {
+        name: undefined,
+        tagline: undefined,
+        description: 'OG desc',
+        coverImageUrl: undefined,
+        iconImageUrl: undefined,
+      },
       isFetching: false,
       isSuccess: true,
     };
@@ -748,5 +776,158 @@ describe('ExternalSubmitForm — auto-trigger, status, re-pull, data-URI icon', 
     await expect
       .element(page.getByTestId('apps-offsite-submit-name'))
       .toHaveValue('User Typed Name');
+  });
+});
+
+/**
+ * 🔴 CANCEL USED TO DISCARD EVERYTHING SILENTLY.
+ *
+ * `Cancel` was a plain `<Button component={Link} href="/apps/mine">`: one click and
+ * every field entered — URL, name, description, scope justifications — was gone, with
+ * no warning and no undo. It now confirms first.
+ *
+ * BOTH DIRECTIONS ARE THE REQUIREMENT. A confirmation that also fires on an untouched
+ * wizard is a nag, and a nag is dismissed reflexively — which would make the dialog
+ * worthless on the one occasion it protects real work. The pristine case below is not
+ * a nice-to-have; it is half the behaviour.
+ */
+describe('ExternalSubmitForm — Cancel confirms before discarding', () => {
+  test('🔴 PRISTINE form: Cancel leaves immediately, no confirmation', async () => {
+    renderWithProviders(<ExternalSubmitForm />);
+    const cancel = page.getByTestId('apps-offsite-wizard-cancel');
+    await expect.element(cancel).toBeInTheDocument();
+    await cancel.click();
+
+    // It navigated…
+    await vi.waitFor(() => expect(routerMock.push).toHaveBeenCalledWith('/apps/mine'));
+    // …and the modal was never raised. Asserted AFTER the navigation settled, so this
+    // is a real absence in a mounted tree rather than a first-empty-observation pass.
+    await expect.element(page.getByTestId('apps-offsite-discard-confirm')).not.toBeInTheDocument();
+  });
+
+  test('🔴 DIRTY form: Cancel prompts instead of navigating', async () => {
+    renderWithProviders(<ExternalSubmitForm />);
+    await page.getByTestId('apps-offsite-submit-url').fill('https://vitrine.civitai.com');
+
+    await page.getByTestId('apps-offsite-wizard-cancel').click();
+
+    // The prompt is up…
+    await expect.element(page.getByText('Discard this submission?')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-offsite-discard-confirm')).toBeInTheDocument();
+    // …and NOTHING was discarded yet: no navigation happened on the Cancel click.
+    expect(routerMock.push).not.toHaveBeenCalled();
+  });
+
+  test('🔴 "Keep editing" dismisses the prompt and PRESERVES the input', async () => {
+    renderWithProviders(<ExternalSubmitForm />);
+    // A URL carrying a PATH, deliberately: clicking Cancel blurs the input, which
+    // fires the existing canonicalisation, and a bare origin comes back with a
+    // trailing slash. Using a path form keeps this test about "the input survived the
+    // prompt" instead of quietly pinning URL-normalisation behaviour it does not own.
+    await page.getByTestId('apps-offsite-submit-url').fill('https://vitrine.civitai.com/app');
+    await page.getByTestId('apps-offsite-wizard-cancel').click();
+    await expect.element(page.getByTestId('apps-offsite-discard-cancel')).toBeInTheDocument();
+
+    await page.getByTestId('apps-offsite-discard-cancel').click();
+
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-url'))
+      .toHaveValue('https://vitrine.civitai.com/app');
+    expect(routerMock.push).not.toHaveBeenCalled();
+  });
+
+  test('🔴 "Discard and leave" is what actually navigates away', async () => {
+    renderWithProviders(<ExternalSubmitForm />);
+    await page.getByTestId('apps-offsite-submit-url').fill('https://vitrine.civitai.com');
+    await page.getByTestId('apps-offsite-wizard-cancel').click();
+    await page.getByTestId('apps-offsite-discard-confirm').click();
+
+    await vi.waitFor(() => expect(routerMock.push).toHaveBeenCalledWith('/apps/mine'));
+  });
+
+  /**
+   * Dirtiness is measured across the WHOLE form, not just the visible step — a
+   * confirmation that only noticed step-1 input would silently discard the name,
+   * description and justifications entered on later steps.
+   */
+  test('🔴 input entered on a LATER step still triggers the confirmation', async () => {
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl();
+    await pickClient();
+    await page.getByTestId('apps-offsite-wizard-next-app').click();
+    await page.getByTestId('apps-offsite-submit-name').fill('My App');
+
+    // Back to the step that owns Cancel.
+    await page.getByTestId('apps-offsite-wizard-back-details').click();
+    await page.getByTestId('apps-offsite-wizard-back-app').click();
+    await page.getByTestId('apps-offsite-wizard-cancel').click();
+
+    await expect.element(page.getByTestId('apps-offsite-discard-confirm')).toBeInTheDocument();
+    expect(routerMock.push).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * 🔴 STEP 2 EXPLAINS WHAT AN OAUTH APP IS.
+ *
+ * "Your OAuth app" assumed prior knowledge. A developer listing a standalone app may
+ * never have registered an OAuth client and has no reason to know why listing needs
+ * one — the picker previously named the requirement without ever explaining it.
+ */
+describe('ExternalSubmitForm — the OAuth requirement is explained', () => {
+  test('🔴 step 2 explains the relationship in plain language', async () => {
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl();
+
+    const explainer = page.getByTestId('apps-offsite-oauth-explainer');
+    await expect.element(explainer).toBeInTheDocument();
+    // The WHOLE normalised sentence, pinned literally. A guard on a keyword like
+    // "OAuth" is walkable by rewording, and rewording is exactly what happens to
+    // prose. Written out here rather than compared to the constant, so the constant
+    // cannot define its own expectation.
+    expect(explainer.element().textContent).toBe(
+      'An OAuth app is the registration that lets people sign in to your app with their Civitai account, and that decides what your app may read or do on their behalf. Every standalone listing links to one, so visitors can see up front what they would be granting.'
+    );
+  });
+
+  test('🔴 it is shown BEFORE the picker, to a user who already has a client', async () => {
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl();
+    await expect.element(page.getByTestId('apps-offsite-client-select')).toBeInTheDocument();
+    // Not conditional on the empty state — the explanation is for everyone.
+    await expect.element(page.getByTestId('apps-offsite-oauth-explainer')).toBeInTheDocument();
+  });
+
+  /**
+   * 🔴 DEFENCE IN DEPTH, DELIBERATELY STILL REACHABLE. The mode selector now surfaces
+   * this prerequisite before any work, but a client can be deleted mid-flow, so the
+   * step-2 empty state must NOT become unreachable-by-construction. This is the test
+   * that would go red if a future "the selector already handles it" cleanup removed it.
+   */
+  test('🔴 the step-2 empty state survives (a client can be deleted mid-flow)', async () => {
+    mocks.clients = { data: [], isLoading: false };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl();
+
+    const empty = page.getByTestId('apps-offsite-no-clients');
+    await expect.element(empty).toBeInTheDocument();
+    expect(empty.element().textContent).toBe(
+      'You have no eligible OAuth apps. Register one in your account settings first, then come back to list it.'
+    );
+  });
+
+  /**
+   * 🔴 A PENDING FETCH IS NOT AN EMPTY LIST — the same invariant the mode selector
+   * carries, asserted at the second surface that depends on it. `data: undefined` is
+   * the unsettled shape; it must render the loader, never the "you have none" alert.
+   */
+  test('🔴 an UNSETTLED clients query renders the loader, not "you have none"', async () => {
+    mocks.clients = { data: undefined, isLoading: true };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl();
+
+    // Settle on the loader, then assert the alert's absence in a mounted tree.
+    await expect.element(page.getByTestId('apps-offsite-clients-loading')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-offsite-no-clients')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Apps/ExternalSubmitForm.tsx
+++ b/src/components/Apps/ExternalSubmitForm.tsx
@@ -6,6 +6,7 @@ import {
   Code,
   Group,
   Loader,
+  Modal,
   Select,
   Stack,
   Text,
@@ -24,6 +25,7 @@ import {
   IconWorld,
 } from '@tabler/icons-react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import {
   OFFSITE_CATEGORY_OPTIONS,
@@ -35,11 +37,14 @@ import {
   isClientStepComplete,
   isCreateDetailsStepComplete,
   isCreateUrlStepComplete,
+  isOffsiteSubmitFormDirty,
   toSubmitExternalInput,
   validateExternalCreateForm,
   type OffsiteSubmitFormErrors,
   type OffsiteSubmitFormValues,
 } from '~/components/Apps/offsiteSubmitFormConfig';
+import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
+import { useEligibleOauthClients } from '~/components/Apps/useEligibleOauthClients';
 import { DerivedScopesDisclosure } from '~/components/Apps/DerivedScopesDisclosure';
 import { ListingAssetStep } from '~/components/Apps/ListingAssetStep';
 import { describeMissingChannels } from '~/components/Apps/listingAutofillStatus';
@@ -49,7 +54,6 @@ import { FadeIn } from '~/components/Apps/wizardMotion';
 import type { ListingEditContext } from '~/components/Apps/offsiteEditConfig';
 import type { MarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
 import type { OffsiteContentRating } from '~/server/schema/blocks/offsite-listing.schema';
-import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constants';
 import { offsiteContentRatingLabel } from '~/shared/constants/browsingLevel.constants';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -98,6 +102,23 @@ type ModClientOption = {
 
 type Submitted = { listingId: string; publishRequestId: string; slug: string };
 
+/**
+ * Plain-language answer to "what is an OAuth app and why does listing need one?".
+ *
+ * Pinned as a constant so the test asserts the WHOLE normalised sentence rather than
+ * a keyword — a guard on words is walkable by rewording, and this string's job is to
+ * carry an explanation, not a vocabulary.
+ */
+export const OAUTH_REQUIREMENT_EXPLAINER =
+  'An OAuth app is the registration that lets people sign in to your app with their Civitai account, and that decides what your app may read or do on their behalf. Every standalone listing links to one, so visitors can see up front what they would be granting.';
+
+/** Where Cancel / "View my submissions" go. One constant, two call sites. */
+const MY_APPS_HREF = '/apps/mine';
+
+/** The exact sentence shown when the author owns no eligible OAuth client. */
+export const NO_ELIGIBLE_CLIENTS_TEXT =
+  'You have no eligible OAuth apps. Register one in your account settings first, then come back to list it.';
+
 /** Wizard step indices — App URL → App & scopes → Details → Assets. */
 const STEP_URL = 0;
 const STEP_APP = 1;
@@ -138,18 +159,11 @@ function ExternalCreateForm() {
   const currentUser = useCurrentUser();
   const isModerator = !!currentUser?.isModerator;
 
-  const clientsQuery = trpc.oauthClient.getAll.useQuery(undefined, {
-    retry: false,
-    refetchOnWindowFocus: false,
-  });
-
-  // The caller's OWN OAuth clients, EXCLUDING App-Block clients (managed by the App
-  // Blocks flow — never a hand-authored target). `getAll` is already scoped to the
-  // caller (`userId`), so this is the ownership filter + the app-block exclude.
-  const clients = useMemo(
-    () => (clientsQuery.data ?? []).filter((c) => !isAppBlockOauthClientId(c.id)),
-    [clientsQuery.data]
-  );
+  // 🔴 ONE eligibility predicate, shared with the mode selector — the two surfaces
+  // that tell an author about this prerequisite must not be able to disagree. The
+  // filter (own clients, App-Block clients excluded) lives in the hook, not here.
+  const eligibleClients = useEligibleOauthClients();
+  const clients = eligibleClients.clients;
 
   // MODERATOR picker: a debounced async global search over ALL non-App-Block clients.
   // An empty search returns the mod's own clients (server default), so mods get the
@@ -241,9 +255,7 @@ function ExternalCreateForm() {
     // resolve from their own client list, unchanged.
     let nextAllowed = 0;
     if (isModerator) {
-      const nextClient = clientId
-        ? modOptionClients.find((c) => c.id === clientId) ?? null
-        : null;
+      const nextClient = clientId ? modOptionClients.find((c) => c.id === clientId) ?? null : null;
       setSelectedClientData(nextClient);
       nextAllowed = nextClient?.allowedScopes ?? 0;
     } else {
@@ -333,7 +345,11 @@ function ExternalCreateForm() {
     if (Object.keys(nextErrors).length > 0) {
       // Steer the author back to the step carrying the first error.
       if (nextErrors.externalUrl) setActive(STEP_URL);
-      else if (nextErrors.connectClientId || nextErrors.requestedScopes || nextErrors.scopeJustifications) {
+      else if (
+        nextErrors.connectClientId ||
+        nextErrors.requestedScopes ||
+        nextErrors.scopeJustifications
+      ) {
         setShowScopeErrors(true);
         setActive(STEP_APP);
       }
@@ -353,6 +369,34 @@ function ExternalCreateForm() {
     ) {
       setActive(STEP_DETAILS);
     }
+  }
+
+  /**
+   * 🔴 CANCEL DISCARDS EVERYTHING, SILENTLY — so confirm, but ONLY when there is
+   * something to lose.
+   *
+   * `Cancel` used to be a plain `<Button component={Link} href="/apps/mine">`: one
+   * click and every field entered (URL, name, description, the scope justifications)
+   * was gone with no warning and no undo. It is now a real button that asks first.
+   *
+   * It deliberately does NOT ask on a pristine form. A confirmation that fires on an
+   * untouched wizard is a nag, and a nag is dismissed reflexively — which would make
+   * the dialog worthless on the one occasion it matters. {@link isOffsiteSubmitFormDirty}
+   * owns that predicate.
+   */
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
+  const router = useRouter();
+
+  function leaveToMyApps() {
+    void router.push(MY_APPS_HREF);
+  }
+
+  function handleCancel() {
+    if (isOffsiteSubmitFormDirty(values)) {
+      setConfirmDiscard(true);
+      return;
+    }
+    leaveToMyApps();
   }
 
   const busy = submitMutation.isPending;
@@ -392,24 +436,53 @@ function ExternalCreateForm() {
   // exists for. The actionable affordance is the persistent link rendered below.
   const noClientsFoundMessage = (
     <Text size="xs" c="dimmed" data-testid="apps-offsite-client-search-empty">
-      No matching apps. Use the “Create an OAuth client” link below the picker to register
-      one.
+      No matching apps. Use the “Create an OAuth client” link below the picker to register one.
     </Text>
   );
 
   return (
     <Stack gap="md" data-testid="apps-offsite-submit-form">
+      {/* An INLINE Mantine Modal rather than `@mantine/modals`' openConfirmModal:
+          this component is rendered in isolation by the browser suite, which has no
+          ModalsProvider, and a confirmation nobody can test is a confirmation nobody
+          can trust. */}
+      <Modal
+        opened={confirmDiscard}
+        onClose={() => setConfirmDiscard(false)}
+        title="Discard this submission?"
+        data-testid="apps-offsite-discard-modal"
+      >
+        <Stack gap="md">
+          <Text size="sm">
+            You’ve entered details for this listing and nothing has been saved yet. Leaving now
+            discards them.
+          </Text>
+          <Group justify="flex-end">
+            <Button
+              variant="default"
+              onClick={() => setConfirmDiscard(false)}
+              data-testid="apps-offsite-discard-cancel"
+            >
+              Keep editing
+            </Button>
+            <Button color="red" onClick={leaveToMyApps} data-testid="apps-offsite-discard-confirm">
+              Discard and leave
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+
       <Alert
         color="blue"
         variant="light"
         icon={<IconPlugConnected size={16} />}
-        title="List an external app"
+        title={`List a ${STANDALONE_KIND_LABEL} app`}
       >
         <Text size="sm">
-          List a standalone app hosted elsewhere by linking your registered OAuth app so users can
-          grant it access. Start with your app’s URL — we’ll pull in a name, description and images
-          you can tweak. A moderator reviews it before it appears. This does not change what your
-          app can do: your OAuth client’s allowed scopes stay the limit.
+          List a {STANDALONE_KIND_LABEL} app hosted elsewhere by linking your registered OAuth app
+          so users can grant it access. Start with your app’s URL — we’ll pull in a name,
+          description and images you can tweak. A moderator reviews it before it appears. This does
+          not change what your app can do: your OAuth client’s allowed scopes stay the limit.
         </Text>
       </Alert>
 
@@ -486,8 +559,8 @@ function ExternalCreateForm() {
                 <Text size="xs" c="dimmed" data-testid="apps-offsite-submit-autofill-partial">
                   Pulled what your link exposed — {describeMissingChannels(autofill.result.missing)}{' '}
                   {(autofill.result.missing?.length ?? 0) > 1 ? 'were' : 'was'} not found; add{' '}
-                  {(autofill.result.missing?.length ?? 0) > 1 ? 'those' : 'that'} manually. Check the
-                  Details and Assets steps for what we found.
+                  {(autofill.result.missing?.length ?? 0) > 1 ? 'those' : 'that'} manually. Check
+                  the Details and Assets steps for what we found.
                 </Text>
               )}
               {!autofill.loading && autofill.result?.status === 'applied' && (
@@ -498,8 +571,8 @@ function ExternalCreateForm() {
                   data-testid="apps-offsite-submit-autofill-applied"
                 >
                   <Text size="sm">
-                    Pulled the latest details from your link — check the Details step for the
-                    name and description, and the Assets step for the suggested icon/cover.
+                    Pulled the latest details from your link — check the Details step for the name
+                    and description, and the Assets step for the suggested icon/cover.
                   </Text>
                 </Alert>
               )}
@@ -507,9 +580,9 @@ function ExternalCreateForm() {
               <Group justify="space-between">
                 <Button
                   variant="default"
-                  component={Link}
-                  href="/apps/mine"
+                  onClick={handleCancel}
                   disabled={busy}
+                  data-testid="apps-offsite-wizard-cancel"
                 >
                   Cancel
                 </Button>
@@ -533,6 +606,14 @@ function ExternalCreateForm() {
         >
           <FadeIn>
             <Stack gap="md" mt="md">
+              {/* 🔴 "Your OAuth app" assumes prior knowledge. A developer listing a
+                  standalone app may never have registered an OAuth client and has no
+                  reason to know why listing needs one. Explain the RELATIONSHIP in
+                  plain language, before the picker, rather than after a failure. */}
+              <Text size="sm" c="dimmed" data-testid="apps-offsite-oauth-explainer">
+                {OAUTH_REQUIREMENT_EXPLAINER}
+              </Text>
+
               {isModerator ? (
                 // MOD: async global search over ALL non-App-Block clients. Empty search
                 // returns the mod's own clients (server default). Server does the
@@ -556,7 +637,7 @@ function ExternalCreateForm() {
                   rightSection={modSearchQuery.isFetching ? <Loader size={14} /> : undefined}
                   data-testid="apps-offsite-client-search"
                 />
-              ) : clientsQuery.isLoading ? (
+              ) : eligibleClients.status === 'unknown' ? (
                 <Group gap={8} data-testid="apps-offsite-clients-loading">
                   <Loader size={16} />
                   <Text size="sm" c="dimmed">
@@ -564,11 +645,12 @@ function ExternalCreateForm() {
                   </Text>
                 </Group>
               ) : clients.length === 0 ? (
+                // 🔴 DEFENCE IN DEPTH, deliberately still reachable. The mode
+                // selector now surfaces this prerequisite BEFORE any work, but a
+                // client can be deleted mid-flow (or the selector's read can be
+                // stale), so this must not become unreachable-by-construction.
                 <Alert color="gray" variant="light" data-testid="apps-offsite-no-clients">
-                  <Text size="sm">
-                    You have no eligible OAuth apps. Register one in your account settings first,
-                    then come back to list it.
-                  </Text>
+                  <Text size="sm">{NO_ELIGIBLE_CLIENTS_TEXT}</Text>
                 </Alert>
               ) : (
                 <Select
@@ -623,7 +705,9 @@ function ExternalCreateForm() {
           label="Details"
           description="Name & metadata"
           allowStepClick={
-            !submitted && isCreateUrlStepComplete(values) && isClientStepComplete(values, allowedScopes)
+            !submitted &&
+            isCreateUrlStepComplete(values) &&
+            isClientStepComplete(values, allowedScopes)
           }
           data-testid="apps-offsite-wizard-step-details"
         >
@@ -654,7 +738,7 @@ function ExternalCreateForm() {
               )}
               <TextInput
                 label="Name"
-                placeholder="My External App"
+                placeholder="My App"
                 value={values.name}
                 onChange={(e) => setField('name', e.currentTarget.value)}
                 onKeyDown={handleDetailsKeyDown}
@@ -789,9 +873,9 @@ function ExternalCreateForm() {
                     title="Draft created"
                   >
                     <Text size="sm">
-                      <Code>{submitted.slug}</Code> is a pending standalone submission. Attach an
-                      icon and a cover below to be approved — screenshots are recommended but
-                      optional and can be added later. Content rating:{' '}
+                      <Code>{submitted.slug}</Code> is a pending {STANDALONE_KIND_LABEL} submission.
+                      Attach an icon and a cover below to be approved — screenshots are recommended
+                      but optional and can be added later. Content rating:{' '}
                       <Badge size="xs">{offsiteContentRatingLabel(values.contentRating)}</Badge>
                     </Text>
                   </Alert>

--- a/src/components/Apps/KindFilterButtons.tsx
+++ b/src/components/Apps/KindFilterButtons.tsx
@@ -1,5 +1,6 @@
 import { Button, Group } from '@mantine/core';
 import { IconApps, IconExternalLink, IconLayoutGrid } from '@tabler/icons-react';
+import { LISTING_KIND_LABELS } from '~/components/Apps/listingKindLabels';
 import type { ListingKindFilter } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
@@ -17,8 +18,8 @@ import type { ListingKindFilter } from '~/server/schema/blocks/app-listing-read.
  */
 const KIND_OPTIONS: { value: ListingKindFilter; label: string; icon: typeof IconApps }[] = [
   { value: 'all', label: 'All apps', icon: IconLayoutGrid },
-  { value: 'onsite', label: 'On-site', icon: IconApps },
-  { value: 'offsite', label: 'Standalone', icon: IconExternalLink },
+  { value: 'onsite', label: LISTING_KIND_LABELS.onsite, icon: IconApps },
+  { value: 'offsite', label: LISTING_KIND_LABELS.offsite, icon: IconExternalLink },
 ];
 
 export interface KindFilterButtonsProps {

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -46,6 +46,7 @@ import {
   ReasonGatedSubmitButton,
   reasonMeetsMin,
 } from '~/components/Apps/ReasonGatedActionModal';
+import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import { getOffsiteReviewChecklist } from '~/components/Apps/offsiteReviewChecklist';
 import {
   assetSlotDriftLabel,
@@ -199,8 +200,8 @@ export function OffsiteReviewQueue() {
         labelPosition="left"
       />
       <Text size="xs" c="dimmed">
-        Standalone apps — a lighter, content-only review (no code / bundle). Approving requires an
-        asset-complete draft (icon + cover + ≥1 screenshot).
+        {STANDALONE_KIND_LABEL} apps — a lighter, content-only review (no code / bundle). Approving
+        requires an asset-complete draft (icon + cover + ≥1 screenshot).
       </Text>
 
       {queue.isLoading ? (
@@ -245,7 +246,9 @@ export function OffsiteReviewQueue() {
                     </Text>
                   </Table.Td>
                   <Table.Td onClick={() => setSelected(r)}>
-                    <Text size="xs">{r.submittedBy?.username ?? `#${r.submittedBy?.id ?? '?'}`}</Text>
+                    <Text size="xs">
+                      {r.submittedBy?.username ?? `#${r.submittedBy?.id ?? '?'}`}
+                    </Text>
                   </Table.Td>
                   <Table.Td onClick={() => setSelected(r)}>
                     <Group gap={4}>
@@ -532,8 +535,7 @@ export function OffsiteReviewModalBody({
     ? [!hasIcon ? 'icon' : null, !hasCover ? 'cover' : null].filter((v): v is string => v != null)
     : [];
   const belowFloor = missingFloor.length > 0;
-  const missingScreenshotsOnly =
-    !assetsQuery.isLoading && !belowFloor && screenshotCount < 1;
+  const missingScreenshotsOnly = !assetsQuery.isLoading && !belowFloor && screenshotCount < 1;
 
   // Scan-clean dimension (Item 1): the go-live `assertAssetsScanClean` gate refuses
   // to approve until EVERY attached asset is terminally `Scanned` (none pending, none
@@ -568,244 +570,243 @@ export function OffsiteReviewModalBody({
 
   return (
     <Stack gap="md">
-        {isOnsite && (
-          <Text size="xs" c="dimmed" data-testid="apps-offsite-onsite-note">
-            Listing media update — the on-site app’s media (icon / cover / screenshots)
-            changed. Content-only review; the media must not exceed the app’s rating.
-          </Text>
-        )}
-        <Group gap="xs">
-          <Text size="xs" c="dimmed">
-            Submitter:
-          </Text>
-          <Text size="xs">{request.submittedBy?.username ?? `#${request.submittedBy?.id ?? '?'}`}</Text>
-          <Text size="xs" c="dimmed">
-            · {formatSubmittedDate(request.submittedAt)}
-          </Text>
-        </Group>
+      {isOnsite && (
+        <Text size="xs" c="dimmed" data-testid="apps-offsite-onsite-note">
+          Listing media update — the on-site app’s media (icon / cover / screenshots) changed.
+          Content-only review; the media must not exceed the app’s rating.
+        </Text>
+      )}
+      <Group gap="xs">
+        <Text size="xs" c="dimmed">
+          Submitter:
+        </Text>
+        <Text size="xs">
+          {request.submittedBy?.username ?? `#${request.submittedBy?.id ?? '?'}`}
+        </Text>
+        <Text size="xs" c="dimmed">
+          · {formatSubmittedDate(request.submittedAt)}
+        </Text>
+      </Group>
 
-        <Card withBorder p="sm">
-          <Stack gap={6}>
-            {request.appListing?.name && (
-              <Text size="md" fw={600}>
-                {request.appListing.name}
+      <Card withBorder p="sm">
+        <Stack gap={6}>
+          {request.appListing?.name && (
+            <Text size="md" fw={600}>
+              {request.appListing.name}
+            </Text>
+          )}
+          {request.appListing?.externalUrl && (
+            <Group gap={6}>
+              <Text size="xs" c="dimmed">
+                URL
               </Text>
-            )}
-            {request.appListing?.externalUrl && (
-              <Group gap={6}>
-                <Text size="xs" c="dimmed">
-                  URL
+              {validateExternalUrl(request.appListing.externalUrl).ok ? (
+                <Anchor
+                  href={request.appListing.externalUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  size="sm"
+                >
+                  <Group gap={4} wrap="nowrap">
+                    {request.appListing.externalUrl}
+                    <IconExternalLink size={12} />
+                  </Group>
+                </Anchor>
+              ) : (
+                // Non-https (defense-in-depth) → render as INERT text, never a
+                // clickable link on the moderator surface.
+                <Text size="sm" c="red">
+                  {request.appListing.externalUrl} (not a valid https link)
                 </Text>
-                {validateExternalUrl(request.appListing.externalUrl).ok ? (
-                  <Anchor
-                    href={request.appListing.externalUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    size="sm"
-                  >
-                    <Group gap={4} wrap="nowrap">
-                      {request.appListing.externalUrl}
-                      <IconExternalLink size={12} />
-                    </Group>
-                  </Anchor>
-                ) : (
-                  // Non-https (defense-in-depth) → render as INERT text, never a
-                  // clickable link on the moderator surface.
-                  <Text size="sm" c="red">
-                    {request.appListing.externalUrl} (not a valid https link)
-                  </Text>
-                )}
-              </Group>
-            )}
-            <Group gap={24}>
-              {request.appListing?.category && (
-                <Group gap={6}>
-                  <Text size="xs" c="dimmed">
-                    Category
-                  </Text>
-                  <Badge size="sm" variant="light">
-                    {marketplaceCategoryLabel(request.appListing.category)}
-                  </Badge>
-                </Group>
-              )}
-              {request.appListing?.contentRating && (
-                <Group gap={6}>
-                  <Text size="xs" c="dimmed">
-                    Content rating
-                  </Text>
-                  <Badge size="sm" color="gray" variant="light">
-                    {offsiteContentRatingLabel(request.appListing.contentRating)}
-                  </Badge>
-                  <Text size="xs" c="dimmed">
-                    {isOnsite ? 'app rating (cap)' : 'declared'}
-                  </Text>
-                </Group>
-              )}
-              {!assetsQuery.isLoading && (
-                <Group gap={6}>
-                  <Text size="xs" c="dimmed">
-                    Detected from assets
-                  </Text>
-                  <Badge
-                    size="sm"
-                    color={ratingMismatch ? 'red' : 'blue'}
-                    variant="light"
-                    data-testid="apps-offsite-derived-rating"
-                  >
-                    {offsiteContentRatingLabel(derivedRating)}
-                  </Badge>
-                </Group>
               )}
             </Group>
-            {request.changelog && (
-              <Stack gap={2}>
+          )}
+          <Group gap={24}>
+            {request.appListing?.category && (
+              <Group gap={6}>
                 <Text size="xs" c="dimmed">
-                  Submitter note
+                  Category
                 </Text>
-                <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
-                  {request.changelog}
-                </Text>
-              </Stack>
+                <Badge size="sm" variant="light">
+                  {marketplaceCategoryLabel(request.appListing.category)}
+                </Badge>
+              </Group>
             )}
-          </Stack>
-        </Card>
-
-        {/* 🔴 The BEFORE, immediately above the AFTER. Renders nothing unless the
-            request targets a shadow revision (`revisionOfId` set). */}
-        <RevisionDriftSection request={request} />
-
-        <ListingPreviewSection request={request} />
-
-        {isConnect && (
-          <ConnectScopesPanel
-            connectClientName={request.appListing?.connectClient?.name ?? null}
-            requestedScopes={request.appListing?.connectRequestedScopes ?? 0}
-            justifications={request.appListing?.connectScopeJustifications ?? null}
-          />
-        )}
-
-        <Stack gap={4}>
-          <Text size="sm" fw={600}>
-            Content review checklist
-          </Text>
-          <List spacing={4} size="sm" center>
-            {checklist.map((item) => (
-              <List.Item
-                key={item.id}
-                icon={
-                  <ThemeIcon
-                    size={18}
-                    radius="xl"
-                    color={item.status === 'ok' ? 'green' : item.status === 'warn' ? 'red' : 'gray'}
-                    variant={item.status === 'todo' ? 'light' : 'filled'}
-                  >
-                    {item.status === 'ok' ? (
-                      <IconCheck size={12} />
-                    ) : item.status === 'warn' ? (
-                      <IconX size={12} />
-                    ) : (
-                      <IconQuestionMark size={12} />
-                    )}
-                  </ThemeIcon>
-                }
-              >
-                <Text size="sm">{item.label}</Text>
+            {request.appListing?.contentRating && (
+              <Group gap={6}>
                 <Text size="xs" c="dimmed">
-                  {item.hint}
+                  Content rating
                 </Text>
-              </List.Item>
-            ))}
-          </List>
+                <Badge size="sm" color="gray" variant="light">
+                  {offsiteContentRatingLabel(request.appListing.contentRating)}
+                </Badge>
+                <Text size="xs" c="dimmed">
+                  {isOnsite ? 'app rating (cap)' : 'declared'}
+                </Text>
+              </Group>
+            )}
+            {!assetsQuery.isLoading && (
+              <Group gap={6}>
+                <Text size="xs" c="dimmed">
+                  Detected from assets
+                </Text>
+                <Badge
+                  size="sm"
+                  color={ratingMismatch ? 'red' : 'blue'}
+                  variant="light"
+                  data-testid="apps-offsite-derived-rating"
+                >
+                  {offsiteContentRatingLabel(derivedRating)}
+                </Badge>
+              </Group>
+            )}
+          </Group>
+          {request.changelog && (
+            <Stack gap={2}>
+              <Text size="xs" c="dimmed">
+                Submitter note
+              </Text>
+              <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+                {request.changelog}
+              </Text>
+            </Stack>
+          )}
         </Stack>
+      </Card>
 
-        {belowFloor && (
-          <Alert
-            color="red"
-            variant="light"
-            icon={<IconAlertTriangle size={16} />}
-            data-testid="apps-offsite-assets-below-floor"
-          >
-            <Text size="sm">
-              Missing: {missingFloor.join(', ')}. Approve will be rejected by the server until an
-              icon and cover are attached (screenshots are optional).
-            </Text>
-          </Alert>
-        )}
+      {/* 🔴 The BEFORE, immediately above the AFTER. Renders nothing unless the
+            request targets a shadow revision (`revisionOfId` set). */}
+      <RevisionDriftSection request={request} />
 
-        {missingScreenshotsOnly && (
-          <Alert
-            color="blue"
-            variant="light"
-            icon={<IconInfoCircle size={16} />}
-            data-testid="apps-offsite-assets-missing-screenshots"
-          >
-            <Text size="sm">
-              Missing: screenshots. This is optional — you can approve now; the author can add
-              screenshots later.
-            </Text>
-          </Alert>
-        )}
+      <ListingPreviewSection request={request} />
 
-        {hasBlockedAsset && (
-          <Alert
-            color="red"
-            variant="light"
-            icon={<IconAlertTriangle size={16} />}
-            data-testid="apps-offsite-assets-scan-blocked"
-          >
-            <Text size="sm">
-              Blocked media: {blockedScanKinds.join(', ')}. This media was rejected during scanning
-              (prohibited content). Approve will be rejected by the server until the author replaces
-              it — reject this submission and ask them to swap the blocked {blockedScanKinds.join(
-                ', '
-              )}
-              .
-            </Text>
-          </Alert>
-        )}
+      {isConnect && (
+        <ConnectScopesPanel
+          connectClientName={request.appListing?.connectClient?.name ?? null}
+          requestedScopes={request.appListing?.connectRequestedScopes ?? 0}
+          justifications={request.appListing?.connectScopeJustifications ?? null}
+        />
+      )}
 
-        {!hasBlockedAsset && hasPendingScan && (
-          <Alert
-            color="yellow"
-            variant="light"
-            icon={<IconInfoCircle size={16} />}
-            data-testid="apps-offsite-assets-scan-pending"
-          >
-            <Text size="sm">
-              Still scanning: {pendingScanKinds.join(', ')}. Approve will be rejected by the server
-              until every asset finishes scanning cleanly — wait a moment and retry.
-            </Text>
-          </Alert>
-        )}
-
-        {ratingMismatch && (
-          <Alert
-            color="red"
-            variant="light"
-            icon={<IconAlertTriangle size={16} />}
-            data-testid="apps-offsite-rating-mismatch"
-          >
-            {isOnsite ? (
-              <Text size="sm">
-                Media assets are rated higher ({offsiteContentRatingLabel(derivedRating)}) than
-                the app’s rating (
-                {declaredRating ? offsiteContentRatingLabel(declaredRating) : '—'}). Listing media
-                must not exceed the app’s rating — reject this revision or ask the author to trim
-                the over-rated assets.
+      <Stack gap={4}>
+        <Text size="sm" fw={600}>
+          Content review checklist
+        </Text>
+        <List spacing={4} size="sm" center>
+          {checklist.map((item) => (
+            <List.Item
+              key={item.id}
+              icon={
+                <ThemeIcon
+                  size={18}
+                  radius="xl"
+                  color={item.status === 'ok' ? 'green' : item.status === 'warn' ? 'red' : 'gray'}
+                  variant={item.status === 'todo' ? 'light' : 'filled'}
+                >
+                  {item.status === 'ok' ? (
+                    <IconCheck size={12} />
+                  ) : item.status === 'warn' ? (
+                    <IconX size={12} />
+                  ) : (
+                    <IconQuestionMark size={12} />
+                  )}
+                </ThemeIcon>
+              }
+            >
+              <Text size="sm">{item.label}</Text>
+              <Text size="xs" c="dimmed">
+                {item.hint}
               </Text>
-            ) : (
-              <Text size="sm">
-                Assets contain higher-maturity content (
-                {offsiteContentRatingLabel(derivedRating)}) than the declared rating (
-                {declaredRating ? offsiteContentRatingLabel(declaredRating) : '—'}). The final
-                rating defaults to the detected value; rate it at least that high.
-              </Text>
-            )}
-          </Alert>
-        )}
+            </List.Item>
+          ))}
+        </List>
+      </Stack>
 
-        {!readOnly &&
-          (actionMode === 'reject' ? (
+      {belowFloor && (
+        <Alert
+          color="red"
+          variant="light"
+          icon={<IconAlertTriangle size={16} />}
+          data-testid="apps-offsite-assets-below-floor"
+        >
+          <Text size="sm">
+            Missing: {missingFloor.join(', ')}. Approve will be rejected by the server until an icon
+            and cover are attached (screenshots are optional).
+          </Text>
+        </Alert>
+      )}
+
+      {missingScreenshotsOnly && (
+        <Alert
+          color="blue"
+          variant="light"
+          icon={<IconInfoCircle size={16} />}
+          data-testid="apps-offsite-assets-missing-screenshots"
+        >
+          <Text size="sm">
+            Missing: screenshots. This is optional — you can approve now; the author can add
+            screenshots later.
+          </Text>
+        </Alert>
+      )}
+
+      {hasBlockedAsset && (
+        <Alert
+          color="red"
+          variant="light"
+          icon={<IconAlertTriangle size={16} />}
+          data-testid="apps-offsite-assets-scan-blocked"
+        >
+          <Text size="sm">
+            Blocked media: {blockedScanKinds.join(', ')}. This media was rejected during scanning
+            (prohibited content). Approve will be rejected by the server until the author replaces
+            it — reject this submission and ask them to swap the blocked{' '}
+            {blockedScanKinds.join(', ')}.
+          </Text>
+        </Alert>
+      )}
+
+      {!hasBlockedAsset && hasPendingScan && (
+        <Alert
+          color="yellow"
+          variant="light"
+          icon={<IconInfoCircle size={16} />}
+          data-testid="apps-offsite-assets-scan-pending"
+        >
+          <Text size="sm">
+            Still scanning: {pendingScanKinds.join(', ')}. Approve will be rejected by the server
+            until every asset finishes scanning cleanly — wait a moment and retry.
+          </Text>
+        </Alert>
+      )}
+
+      {ratingMismatch && (
+        <Alert
+          color="red"
+          variant="light"
+          icon={<IconAlertTriangle size={16} />}
+          data-testid="apps-offsite-rating-mismatch"
+        >
+          {isOnsite ? (
+            <Text size="sm">
+              Media assets are rated higher ({offsiteContentRatingLabel(derivedRating)}) than the
+              app’s rating ({declaredRating ? offsiteContentRatingLabel(declaredRating) : '—'}).
+              Listing media must not exceed the app’s rating — reject this revision or ask the
+              author to trim the over-rated assets.
+            </Text>
+          ) : (
+            <Text size="sm">
+              Assets contain higher-maturity content ({offsiteContentRatingLabel(derivedRating)})
+              than the declared rating (
+              {declaredRating ? offsiteContentRatingLabel(declaredRating) : '—'}). The final rating
+              defaults to the detected value; rate it at least that high.
+            </Text>
+          )}
+        </Alert>
+      )}
+
+      {!readOnly &&
+        (actionMode === 'reject' ? (
           <Stack gap="xs">
             <ReasonGatedField
               value={rejectionReason}
@@ -926,8 +927,8 @@ export function OffsiteReviewModalBody({
               </Button>
             </Tooltip>
           </Group>
-          ))}
-      </Stack>
+        ))}
+    </Stack>
   );
 }
 
@@ -1262,7 +1263,7 @@ export function OffsiteReportsQueue() {
           <Group gap={6}>
             <IconFlag size={14} />
             <Text size="sm" fw={600}>
-              Standalone listing reports
+              {STANDALONE_KIND_LABEL} listing reports
             </Text>
             <Badge size="sm" variant="light" color={items.length > 0 ? 'red' : 'gray'}>
               {items.length}
@@ -1347,9 +1348,7 @@ export function OffsiteReportsQueue() {
                       )}
                     </Table.Td>
                     <Table.Td>
-                      <Text size="xs">
-                        {r.reporter?.username ?? `#${r.reporter?.id ?? '?'}`}
-                      </Text>
+                      <Text size="xs">{r.reporter?.username ?? `#${r.reporter?.id ?? '?'}`}</Text>
                     </Table.Td>
                     <Table.Td>
                       <Group gap={4}>
@@ -1471,7 +1470,8 @@ function ReportActionModal({
   const isClaim = action === 'claim';
   const destructive = isDestructiveAction(action);
   const trimmed = text.trim();
-  const validTarget = typeof targetUserId === 'number' && Number.isInteger(targetUserId) && targetUserId > 0;
+  const validTarget =
+    typeof targetUserId === 'number' && Number.isInteger(targetUserId) && targetUserId > 0;
 
   function reset() {
     setText('');
@@ -1630,7 +1630,9 @@ function ModerationHistoryModal({
       title={
         <Group gap={6}>
           <IconHistory size={16} />
-          <Text fw={600}>Moderation history — {report.appListing?.slug ?? report.appListingId}</Text>
+          <Text fw={600}>
+            Moderation history — {report.appListing?.slug ?? report.appListingId}
+          </Text>
         </Group>
       }
       size="lg"

--- a/src/components/Apps/SubmitModeSelector.browser.test.tsx
+++ b/src/components/Apps/SubmitModeSelector.browser.test.tsx
@@ -1,40 +1,208 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import { SubmitModeSelector, type SubmitMode } from '~/components/Apps/SubmitModeSelector';
+import { APP_BLOCK_OAUTH_CLIENT_ID_PREFIX } from '~/shared/constants/block-scope.constants';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+// Type-only: gives the `importOriginal` spread below the real module's type
+// without an `import()` type annotation (banned by consistent-type-imports).
+import type * as TrpcModule from '~/utils/trpc';
 
 /**
- * W13 — /apps/submit type-picker cards. Browser-mode surface test (report-only
- * in Tekton): both type cards render, and clicking each fires `onSelect` with the
- * right mode id (the on-platform "App" keeps the historical `block` id). The former
- * separate "Connect an app" card was MERGED into the External card (every external
- * app IS an OAuth app). Presentational + props-only, so it renders in isolation.
+ * W13 — /apps/submit type-picker cards.
+ *
+ * Covers the two cards + their mode ids (unchanged), the aligned "Standalone"
+ * wording, and the OAUTH PREREQUISITE now surfaced HERE rather than at wizard step 2.
+ *
+ * ## 🔴 THE DEFECT THESE TESTS WOULD HAVE CAUGHT
+ *
+ * Measured on production: a developer picked the standalone card, typed a URL, hit
+ * Next (firing a server-side metadata fetch), landed on step 2 — and only there read
+ * "You have no eligible OAuth apps", with `Next` disabled. A dead-end reachable only
+ * after doing work. The prerequisite is a property of the CHOICE, so it is asserted
+ * at the choice.
+ *
+ * ## 🔴 AND THE ONE A NAIVE FIX WOULD HAVE INTRODUCED
+ *
+ * "Show the notice when the client list is empty" is wrong, because an in-flight
+ * query ALSO has an empty list. That would tell a developer who owns three OAuth
+ * clients that they own none, every time, for the duration of the fetch. The loading
+ * case below is a first-class test, not a footnote.
  */
+
+const OWN_CLIENT = { id: 'oauth-client-1', name: 'My OAuth App', allowedScopes: 4 };
+
+const mocks = vi.hoisted(() => ({
+  // `data: undefined` is the LOADING/unsettled shape — the hook branches on whether
+  // the query settled with data, so `undefined` here is what "we don't know yet" is.
+  clients: { data: undefined as unknown } as { data: unknown },
+}));
+
+// Only the `trpc` client itself is overridden — every other `~/utils/trpc` export is
+// kept real via importOriginal. A wholesale factory silently breaks this whole FILE
+// (0 tests collected, no failing assertion) the day the module gains an export some
+// other file in this test's graph imports. See local-rules/no-wholesale-module-mock.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
+  return {
+    ...actual,
+    trpc: {
+      oauthClient: {
+        getAll: { useQuery: () => mocks.clients },
+      },
+    },
+  };
+});
+
+beforeEach(() => {
+  mocks.clients = { data: undefined };
+});
+
 describe('SubmitModeSelector', () => {
-  test('renders both type cards (App + external app), no separate Connect card', async () => {
+  test('renders both type cards, no separate Connect card', async () => {
+    mocks.clients = { data: [OWN_CLIENT] };
     renderWithProviders(<SubmitModeSelector onSelect={vi.fn()} />);
     await expect.element(page.getByTestId('apps-submit-mode-card-app')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-submit-mode-card-external')).toBeInTheDocument();
     await expect.element(page.getByText('App', { exact: true })).toBeInTheDocument();
-    await expect
-      .element(page.getByText('List an external app (connect your OAuth app)', { exact: true }))
-      .toBeInTheDocument();
     // The merged model has no standalone connect card.
     expect(document.querySelector('[data-testid="apps-submit-mode-card-connect"]')).toBeNull();
   });
 
+  /**
+   * 🔴 THE WHOLE NORMALISED STRING, not a keyword. The measured defect WAS a wording
+   * disagreement inside this one card — its title said "external app" while its own
+   * body said "standalone app" — so a guard that matched the word "standalone"
+   * anywhere would have passed on the broken render. Both strings are pinned in full.
+   */
+  test('both halves of the standalone card say "Standalone", in full', async () => {
+    mocks.clients = { data: [OWN_CLIENT] };
+    renderWithProviders(<SubmitModeSelector onSelect={vi.fn()} />);
+    await expect
+      .element(page.getByText('List a Standalone app (connect your OAuth app)', { exact: true }))
+      .toBeInTheDocument();
+    await expect
+      .element(
+        page.getByText(
+          'List a Standalone app hosted elsewhere by linking your registered OAuth app so users can grant it access. Disclose the scopes your app requests and why, add an optional homepage link — a moderator reviews before it appears.',
+          { exact: true }
+        )
+      )
+      .toBeInTheDocument();
+  });
+
   test('picking "App" calls onSelect("block") — code id unchanged', async () => {
+    mocks.clients = { data: [OWN_CLIENT] };
     const onSelect = vi.fn<(mode: SubmitMode) => void>();
     renderWithProviders(<SubmitModeSelector onSelect={onSelect} />);
     await page.getByTestId('apps-submit-mode-card-app').click();
     expect(onSelect).toHaveBeenCalledWith('block');
   });
 
-  test('picking the external-app card calls onSelect("external")', async () => {
+  test('picking the standalone card calls onSelect("external") — code id unchanged', async () => {
+    mocks.clients = { data: [OWN_CLIENT] };
     const onSelect = vi.fn<(mode: SubmitMode) => void>();
     renderWithProviders(<SubmitModeSelector onSelect={onSelect} />);
     await page.getByTestId('apps-submit-mode-card-external').click();
     expect(onSelect).toHaveBeenCalledWith('external');
+  });
+});
+
+describe('SubmitModeSelector — the OAuth prerequisite is surfaced at the CHOICE', () => {
+  test('🔴 zero eligible clients: the card states the requirement UP FRONT', async () => {
+    mocks.clients = { data: [] };
+    renderWithProviders(<SubmitModeSelector onSelect={vi.fn()} />);
+
+    const notice = page.getByTestId('apps-submit-mode-external-prerequisite');
+    await expect.element(notice).toBeInTheDocument();
+    // 🔴 The WHOLE sentence, typed out — NOT compared against the component's own
+    // exported constant, which would make the assertion true for whatever the
+    // component happens to say. A reworded explanation is a deliberate edit that
+    // fails here first.
+    expect(notice.element().textContent).toContain(
+      'Listing a standalone app requires an OAuth app — that is what lets people sign in to your app with their Civitai account. You do not have one yet.'
+    );
+  });
+
+  test('🔴 the notice ROUTES to account settings, in a new tab', async () => {
+    mocks.clients = { data: [] };
+    renderWithProviders(<SubmitModeSelector onSelect={vi.fn()} />);
+    const link = page.getByTestId('apps-submit-mode-external-prerequisite-link');
+    await expect.element(link).toBeInTheDocument();
+    const el = link.element();
+    expect(el.getAttribute('href')).toBe('/user/account');
+    // A new tab so an in-progress choice / wizard state is not lost.
+    expect(el.getAttribute('target')).toBe('_blank');
+    expect(el.getAttribute('rel')).toContain('noopener');
+    expect(el.getAttribute('rel')).toContain('noreferrer');
+  });
+
+  /**
+   * 🔴 THE CARD IS NOT DISABLED — asserted, because "just disable it" is the obvious
+   * alternative fix and it is the wrong one: the notice is driven by a client-side
+   * read that can be stale or errored, a disabled control leaves the tab order (so a
+   * keyboard user gets the block without the reason), and step 2 already gates
+   * submission. The card informs and offers the fix; it does not refuse.
+   */
+  test('🔴 the card stays CLICKABLE with no eligible clients (informs, does not refuse)', async () => {
+    mocks.clients = { data: [] };
+    const onSelect = vi.fn<(mode: SubmitMode) => void>();
+    renderWithProviders(<SubmitModeSelector onSelect={onSelect} />);
+    await expect
+      .element(page.getByTestId('apps-submit-mode-external-prerequisite'))
+      .toBeInTheDocument();
+
+    const card = page.getByTestId('apps-submit-mode-card-external');
+    expect(card.element().hasAttribute('disabled')).toBe(false);
+    await card.click();
+    expect(onSelect).toHaveBeenCalledWith('external');
+  });
+
+  /**
+   * 🔴 A PENDING FETCH MUST NOT READ AS "YOU HAVE NONE".
+   *
+   * SETTLE-THEN-ASSERT: `.not.toBeInTheDocument()` resolves on the FIRST empty
+   * observation, so asserted straight after `render()` it passes against a DOM that
+   * has not mounted yet — a vacuous green in ~6ms. Awaiting the card first proves the
+   * component rendered, so the absence below is a real absence in a real tree. The
+   * zero-clients test above is the positive control that this assertion CAN observe
+   * the notice when it exists.
+   */
+  test('🔴 LOADING does NOT render as "you have no OAuth apps"', async () => {
+    mocks.clients = { data: undefined }; // in flight — not settled, not empty
+    renderWithProviders(<SubmitModeSelector onSelect={vi.fn()} />);
+
+    // Settle: the component has really rendered its card.
+    await expect.element(page.getByTestId('apps-submit-mode-card-external')).toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-submit-mode-external-prerequisite'))
+      .not.toBeInTheDocument();
+  });
+
+  /** THE NEGATIVE CONTROL: a developer who HAS a client is told nothing. */
+  test('🔴 with an eligible client, NO prerequisite notice is shown', async () => {
+    mocks.clients = { data: [OWN_CLIENT] };
+    renderWithProviders(<SubmitModeSelector onSelect={vi.fn()} />);
+
+    await expect.element(page.getByTestId('apps-submit-mode-card-external')).toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-submit-mode-external-prerequisite'))
+      .not.toBeInTheDocument();
+  });
+
+  /**
+   * An auto-provisioned App-Block client is managed by the App Blocks flow and is
+   * never a hand-authored listing target — owning only those is owning NONE, and the
+   * prerequisite must fire. This is the eligibility PREDICATE, exercised through the
+   * UI that depends on it.
+   */
+  test('🔴 owning ONLY an App-Block client counts as having none', async () => {
+    mocks.clients = {
+      data: [{ id: `${APP_BLOCK_OAUTH_CLIENT_ID_PREFIX}abc`, name: 'Block', allowedScopes: 4 }],
+    };
+    renderWithProviders(<SubmitModeSelector onSelect={vi.fn()} />);
+    await expect
+      .element(page.getByTestId('apps-submit-mode-external-prerequisite'))
+      .toBeInTheDocument();
   });
 });

--- a/src/components/Apps/SubmitModeSelector.tsx
+++ b/src/components/Apps/SubmitModeSelector.tsx
@@ -1,25 +1,66 @@
-import { Card, SimpleGrid, Stack, Text, ThemeIcon, UnstyledButton } from '@mantine/core';
-import { IconExternalLink, IconTerminal2 } from '@tabler/icons-react';
-import type { ReactNode } from 'react';
+import {
+  Alert,
+  Anchor,
+  Card,
+  SimpleGrid,
+  Stack,
+  Text,
+  ThemeIcon,
+  UnstyledButton,
+} from '@mantine/core';
+import { IconExternalLink, IconInfoCircle, IconTerminal2 } from '@tabler/icons-react';
+import type { MouseEvent, ReactNode } from 'react';
+import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
+import { useEligibleOauthClients } from '~/components/Apps/useEligibleOauthClients';
 
 /**
  * /apps/submit type-picker (W13). The author first picks HOW to list their app:
- * an on-platform **App** (authored + submitted with the `civitai` CLI) or an
- * **External app** (a marketplace card that links the caller's OAuth app, with an
+ * an on-platform **App** (authored + submitted with the `civitai` CLI) or a
+ * **Standalone** app (a marketplace card that links the caller's OAuth app, with an
  * optional homepage link). Each type is a large selectable card; picking one calls
  * `onSelect`, and the page reveals that flow + a "choose a different type" affordance.
  *
- * Presentational only (no tRPC / no server imports) so it renders in isolation
- * for the component test.
- *
  * The internal mode id keeps the historical `block` value for the on-platform
  * app — only the label/copy is "App"; the code id is never renamed. The former
- * separate `'connect'` mode was MERGED into `'external'` (every external app IS an
+ * separate `'connect'` mode was MERGED into `'external'` (every standalone app IS an
  * OAuth app — one listing links the OAuth client + carries an optional homepage URL).
+ * `'external'` likewise stays the mode ID: the WORD changed, the VALUE did not.
+ *
+ * ## 🔴 THE PREREQUISITE IS SURFACED HERE, BEFORE ANY WORK
+ *
+ * Measured on production: a developer picked the standalone card, typed a URL, hit
+ * Next (which fires a server-side metadata fetch), landed on step 2 — and only THERE
+ * learned they own no eligible OAuth client, with `Next` disabled. A hard dead-end,
+ * reached only after doing work. The requirement is a property of the CHOICE, so it
+ * belongs at the choice.
+ *
+ * ## 🔴 WHY THE CARD STAYS CLICKABLE (and is not disabled)
+ *
+ * Deliberate, and the more conservative of the two options:
+ *  - the notice is driven by a CLIENT-SIDE read that can be wrong (an error, a stale
+ *    cache, a race with a client the user just registered). Disabling on it would
+ *    manufacture an unrecoverable dead-end WORSE than the one being fixed — the user
+ *    could not even reach the step that explains itself;
+ *  - a `disabled` control is removed from the tab order, so a keyboard / screen-reader
+ *    user would get the block without ever hearing the reason;
+ *  - nothing invalid can be submitted anyway: step 2 still gates `Next` on a selected
+ *    client, and the server re-checks ownership at submit.
+ * So the card informs and offers the fix, rather than refusing.
  */
 export type SubmitMode = 'block' | 'external';
 
+/** The exact prerequisite sentence. Pinned by test; reworded only deliberately. */
+export const STANDALONE_OAUTH_PREREQUISITE_TEXT =
+  'Listing a standalone app requires an OAuth app — that is what lets people sign in to your app with their Civitai account. You do not have one yet.';
+
 export function SubmitModeSelector({ onSelect }: { onSelect: (mode: SubmitMode) => void }) {
+  const oauthClients = useEligibleOauthClients();
+
+  // 🔴 A confirmed-empty list is the ONLY state that shows the notice. `'unknown'`
+  // (loading OR errored) must render nothing — an in-flight fetch is not evidence
+  // that the developer owns no OAuth app.
+  const showPrerequisite = oauthClients.status === 'ready' && !oauthClients.hasEligibleClient;
+
   return (
     <SimpleGrid cols={{ base: 1, xs: 2 }} spacing="md" data-testid="apps-submit-mode-selector">
       <ModeCard
@@ -31,10 +72,39 @@ export function SubmitModeSelector({ onSelect }: { onSelect: (mode: SubmitMode) 
       />
       <ModeCard
         icon={<IconExternalLink size={22} />}
-        title="List an external app (connect your OAuth app)"
-        description="List a standalone app hosted elsewhere by linking your registered OAuth app so users can grant it access. Disclose the scopes your app requests and why, add an optional homepage link — a moderator reviews before it appears."
+        title={`List a ${STANDALONE_KIND_LABEL} app (connect your OAuth app)`}
+        description={`List a ${STANDALONE_KIND_LABEL} app hosted elsewhere by linking your registered OAuth app so users can grant it access. Disclose the scopes your app requests and why, add an optional homepage link — a moderator reviews before it appears.`}
         onSelect={() => onSelect('external')}
         testId="apps-submit-mode-card-external"
+        footer={
+          showPrerequisite ? (
+            <Alert
+              color="yellow"
+              variant="light"
+              p="xs"
+              icon={<IconInfoCircle size={16} />}
+              data-testid="apps-submit-mode-external-prerequisite"
+            >
+              <Text size="xs">
+                {STANDALONE_OAUTH_PREREQUISITE_TEXT}{' '}
+                <Anchor
+                  href="/user/account"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  size="xs"
+                  // Stop the click bubbling to the card's own button — the link is a
+                  // DIFFERENT destination, and picking the mode as a side effect of
+                  // opening account settings would be a surprise.
+                  onClick={(e: MouseEvent<HTMLAnchorElement>) => e.stopPropagation()}
+                  data-testid="apps-submit-mode-external-prerequisite-link"
+                >
+                  Register an OAuth app in your account settings
+                </Anchor>
+                , then come back — this opens in a new tab.
+              </Text>
+            </Alert>
+          ) : null
+        }
       />
     </SimpleGrid>
   );
@@ -46,12 +116,14 @@ function ModeCard({
   description,
   onSelect,
   testId,
+  footer,
 }: {
   icon: ReactNode;
   title: string;
   description: string;
   onSelect: () => void;
   testId: string;
+  footer?: ReactNode;
 }) {
   return (
     <UnstyledButton onClick={onSelect} data-testid={testId} h="100%" style={{ height: '100%' }}>
@@ -66,6 +138,7 @@ function ModeCard({
           <Text size="sm" c="dimmed">
             {description}
           </Text>
+          {footer}
         </Stack>
       </Card>
     </UnstyledButton>

--- a/src/components/Apps/__tests__/offsiteSubmitFormDirty.test.ts
+++ b/src/components/Apps/__tests__/offsiteSubmitFormDirty.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  emptyOffsiteSubmitForm,
+  isOffsiteSubmitFormDirty,
+} from '~/components/Apps/offsiteSubmitFormConfig';
+
+/**
+ * The predicate behind the create wizard's Cancel confirmation.
+ *
+ * WHY IT MATTERS BOTH WAYS. `Cancel` navigates away and discards every field with no
+ * undo, so a dirty form must confirm. But a confirmation that fires on an UNTOUCHED
+ * form is a nag, and a nag is dismissed reflexively — which would make the dialog
+ * worthless on the one occasion it protects real work. Both directions are asserted
+ * here; neither alone is the requirement.
+ */
+describe('isOffsiteSubmitFormDirty', () => {
+  it('a freshly-initialised form is PRISTINE', () => {
+    expect(isOffsiteSubmitFormDirty(emptyOffsiteSubmitForm())).toBe(false);
+  });
+
+  /**
+   * 🔴 THE ONE THAT KILLS THE OBVIOUS WRONG IMPLEMENTATION.
+   *
+   * `contentRating` starts at `'g'` — it is the only field whose blank value is
+   * truthy. An `Object.values(values).some(Boolean)` shortcut (or any "is anything
+   * set?" check) therefore reports a brand-new form as dirty and nags every single
+   * author on their first click. This case is the difference between the predicate
+   * and that shortcut, and it is why the comparison is against the DEFAULT rather
+   * than against emptiness.
+   */
+  it('the non-empty DEFAULT contentRating does not make a pristine form dirty', () => {
+    const values = emptyOffsiteSubmitForm();
+    expect(values.contentRating).toBe('g'); // the default is genuinely non-empty
+    expect(isOffsiteSubmitFormDirty(values)).toBe(false);
+  });
+
+  it.each([
+    ['externalUrl', 'https://example.com/app'],
+    ['name', 'My App'],
+    ['slug', 'my-app'],
+    ['tagline', 'Does a thing'],
+    ['description', 'A longer description.'],
+    ['changelog', 'A note for the reviewer.'],
+  ] as const)('typing into `%s` makes the form dirty', (field, value) => {
+    expect(isOffsiteSubmitFormDirty({ ...emptyOffsiteSubmitForm(), [field]: value })).toBe(true);
+  });
+
+  it('CHANGING the content rating away from the default makes it dirty', () => {
+    expect(isOffsiteSubmitFormDirty({ ...emptyOffsiteSubmitForm(), contentRating: 'r' })).toBe(
+      true
+    );
+  });
+
+  it('picking a category makes it dirty', () => {
+    expect(
+      isOffsiteSubmitFormDirty({ ...emptyOffsiteSubmitForm(), category: 'productivity' })
+    ).toBe(true);
+  });
+
+  it('picking an OAuth client makes it dirty', () => {
+    expect(
+      isOffsiteSubmitFormDirty({ ...emptyOffsiteSubmitForm(), connectClientId: 'oauth-client-1' })
+    ).toBe(true);
+  });
+
+  it('derived requested scopes make it dirty', () => {
+    expect(isOffsiteSubmitFormDirty({ ...emptyOffsiteSubmitForm(), requestedScopes: 4 })).toBe(
+      true
+    );
+  });
+
+  it('a written scope justification makes it dirty', () => {
+    expect(
+      isOffsiteSubmitFormDirty({
+        ...emptyOffsiteSubmitForm(),
+        scopeJustifications: { UserRead: 'To greet the user by name.' },
+      })
+    ).toBe(true);
+  });
+
+  /**
+   * Picking a client RE-KEYS `scopeJustifications` to empty strings before the author
+   * writes anything. Those empty entries are not work, so they must not, on their
+   * own, be what makes the form dirty — `connectClientId` already reports that choice.
+   */
+  it('EMPTY re-keyed justifications are not, by themselves, dirt', () => {
+    expect(
+      isOffsiteSubmitFormDirty({
+        ...emptyOffsiteSubmitForm(),
+        scopeJustifications: { UserRead: '', ModelsRead: '' },
+      })
+    ).toBe(false);
+  });
+
+  it('whitespace-only input is not dirt (a stray space is not work)', () => {
+    expect(isOffsiteSubmitFormDirty({ ...emptyOffsiteSubmitForm(), name: '   ' })).toBe(false);
+    expect(
+      isOffsiteSubmitFormDirty({
+        ...emptyOffsiteSubmitForm(),
+        scopeJustifications: { UserRead: '  \n ' },
+      })
+    ).toBe(false);
+  });
+});

--- a/src/components/Apps/__tests__/standaloneWordingCallSites.test.ts
+++ b/src/components/Apps/__tests__/standaloneWordingCallSites.test.ts
@@ -1,0 +1,477 @@
+import fs from 'fs';
+import path from 'path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import {
+  LISTING_KIND_APP_LABELS,
+  LISTING_KIND_LABELS,
+  STANDALONE_KIND_LABEL,
+  listingKindAppLabel,
+  listingKindLabel,
+} from '~/components/Apps/listingKindLabels';
+import { listingKindFilterSchema } from '~/server/schema/blocks/app-listing-read.schema';
+import { APP_LISTINGS_PUBLIC_EXTERNAL_FLAG } from '~/server/services/app-blocks-flag';
+import {
+  STORE_LISTING_KINDS,
+  STORE_VISIBILITY_SCOPES,
+} from '~/shared/utils/store-visibility-scope';
+
+/**
+ * 🔒 THE ENROLMENT LEDGER for the App-store listing-KIND display label.
+ *
+ * Modelled on its sibling `listingLabelCallSites.test.ts`, for the same measured
+ * reason and in the same shape.
+ *
+ * ## WHY THIS FILE EXISTS — measured, not hypothetical
+ *
+ * The public store shipped the word **"Standalone"** for `kind='offsite'`, but the
+ * label was hardcoded at each surface. Two of them said "Standalone"
+ * (`AppBlockCard`'s badge, `KindFilterButtons`' toggle) while the submit flow, the
+ * invites table and the transfer-offers table still said "external app". One single
+ * card carried BOTH at once: `SubmitModeSelector`'s title read "List an external app
+ * (connect your OAuth app)" directly above its own body text reading "List a
+ * standalone app hosted elsewhere". Same component, same render, two words.
+ *
+ * Fixing the strings does not remove that condition — the next surface to render the
+ * kind will hardcode whichever word its author last saw. So this asserts the
+ * RELATIONSHIP rather than any one string:
+ *
+ *   (1) NO user-facing string anywhere in the App-store tree carries the retired
+ *       wording — it fails when the set GROWS;
+ *   (2) EVERY surface that renders the kind label resolves it from the ONE source
+ *       module — it fails when the set SHRINKS (an enrolled site reverts to a
+ *       hardcoded literal, which rule (1) alone would not see, because the literal
+ *       it reverts to is the CORRECT word);
+ *   (3) the whole normalised strings are pinned, not keywords — a guard on words is
+ *       walkable by rewording, and prose is exactly the artifact that gets reworded;
+ *   (4) 🔴 the LOGIC VALUES were not renamed along with the copy.
+ *
+ * ## 🔴 WHY (4) IS IN A COPY TEST
+ *
+ * The single most damaging way to "align the wording" is to align it in the database
+ * column, the public `/api/v1/apps` response enum, the TypeScript unions or the Flipt
+ * flag key. Those are contracts with consumers who never see this UI. A copy change
+ * that renamed `'offsite'` would typecheck, render correctly, and break the public
+ * API. So the constraint is asserted here, next to the change that would violate it.
+ *
+ * ## 🔴 WHAT THIS DOES NOT DO
+ *
+ * Rule (2) is structural: it proves a surface does not hardcode the word, not that
+ * the helper received the right `kind`. `listingKindLabel(somethingElse)` passes it.
+ * Behavioural cover lives alongside and is deliberately not replaced by it —
+ * `SubmitModeSelector.browser.test.tsx`, `CliSubmitCta.browser.test.tsx` and
+ * `ExternalSubmitForm.browser.test.tsx`. Read this as a reversion guard.
+ */
+
+const SRC = path.resolve(__dirname, '../../..');
+
+/** Every App-store surface that can render a listing kind to a human. */
+const SCAN_ROOTS = ['components/Apps', 'components/AppBlocks', 'pages/apps'];
+
+/**
+ * The retired wordings, as WHOLE PHRASES.
+ *
+ * 🔴 Deliberately NOT a bare `offsite` / `external`. `'offsite'` is a stored VALUE
+ * (the Prisma column, the REST enum, the `StoreListingKind` union) and appears in
+ * hundreds of legitimate places; a rule that matched it would either be allowlisted
+ * into uselessness or would push someone into renaming the value to satisfy it —
+ * which is the one outcome rule (4) exists to prevent. Every phrase below is
+ * unambiguously prose: none of them is, or can be, a value.
+ */
+const RETIRED_WORDINGS: RegExp[] = [/external app/i, /off-site/i, /offsite app/i];
+
+/**
+ * The kind label as a human reads it. Capital-S `Standalone` as a whole word is the
+ * kind's NAME; lowercase `standalone` is an ordinary English adverb/adjective and is
+ * deliberately NOT matched — see ALLOWED_LOWERCASE_PROSE for why that distinction is
+ * load-bearing rather than lazy.
+ */
+const KIND_LABEL_WORD = /\bStandalone\b/;
+
+/**
+ * 🔴 WHY LOWERCASE `standalone` IS OUT OF SCOPE, recorded so nobody "tightens" this
+ * rule into a wrong one.
+ *
+ * `pages/apps/[appBlockId]/index.tsx` renders, in the NON-external branch, "Preview
+ * of the standalone block at …" and "this standalone preview does not". That
+ * `standalone` means *served from its own origin, apart from the model page* — it is
+ * describing an **on-site** app. Capitalising it would label an on-site app with the
+ * offsite kind's name: not a cosmetic slip, an actively false statement on a public
+ * listing page. `components/AppBlocks/AppAnalyticsPanel.tsx` ("Page apps run
+ * standalone and are not installed onto a model") is the same word in the same
+ * ordinary sense.
+ *
+ * So the rule keys on the CAPITALISED whole word, which only ever names the kind.
+ */
+const ALLOWED_LOWERCASE_PROSE =
+  'lowercase `standalone` is ordinary English (an on-site app served at its own origin), not the kind name';
+
+/**
+ * Files whose retired-wording string is CORRECT and must stay. Each needs a reason —
+ * an allowlist without one is how a real defect gets parked.
+ *
+ * Empty by design: every occurrence found in the sweep was genuine copy drift and was
+ * fixed rather than parked. A future entry is a decision that has to be argued.
+ */
+const ALLOWED_RETIRED_WORDING: Record<string, string> = {};
+
+/**
+ * 🔒 THE ENROLMENT SET: every surface that renders the kind label to a human.
+ *
+ * A file in this list must resolve the word from `listingKindLabels`. A file NOT in
+ * this list must not contain the word at all. Both halves are asserted, which is what
+ * makes the ledger fail on a GROW *and* on a SHRINK.
+ */
+const ENROLLED: Record<string, string> = {
+  'components/Apps/AppBlockCard.tsx': 'store card kind badge',
+  'components/Apps/KindFilterButtons.tsx': 'store kind filter toggles',
+  'components/Apps/AppInvitesBody.tsx': 'collaborator-invite kind badge',
+  'components/Apps/AppTransferOffersView.tsx': 'ownership-transfer kind badge',
+  'components/Apps/AppEarningsPanel.tsx': 'earnings-unavailable explanation',
+  'components/Apps/SubmitModeSelector.tsx': 'submit mode-picker card title + body',
+  'components/Apps/ExternalSubmitForm.tsx': 'submit wizard header + draft-created note',
+  'pages/apps/submit.tsx': 'submit page subtitle',
+  'pages/apps/[appBlockId]/index.tsx': 'public listing external-destination disclosure',
+  // 🔴 THE FOUR THIS LEDGER FOUND. None of them was in the reported defect, and
+  // none was reachable by reading the submit flow — they were spelling the CORRECT
+  // word, so no copy sweep would have surfaced them either. `appListingCardView`
+  // and `appListingDetailRows` each carried a comment claiming to mirror the other's
+  // wording, and they did not: the badge said "Standalone" while the detail row said
+  // "On-site app" / "Standalone" — the suffix on one branch and not the other.
+  'components/Apps/appListingCardView.ts': 'store card kind badge label',
+  'components/Apps/appListingDetailRows.ts': 'listing detail "Kind" row',
+  'components/Apps/OffsiteReviewQueue.tsx': 'moderator queue + reports section headings',
+};
+
+/** The one module allowed to spell the word as a literal. */
+const LABEL_SOURCE_REL = 'components/Apps/listingKindLabels.ts';
+const LABEL_SOURCE_IMPORT = '~/components/Apps/listingKindLabels';
+
+function parseTsx(fileName: string, text: string): ts.SourceFile {
+  return ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(entry.name) && !/\.(test|browser\.test)\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Every string a HUMAN could read in this source, as `{ line, text }`.
+ *
+ * 🔴 COMMENTS ARE STRUCTURALLY EXCLUDED, and that is the reason this is an AST walk
+ * rather than a grep. This very file, and most files it scans, discuss the retired
+ * wording at length in their own docstrings — the phrase "external app" appears in
+ * the prose explaining why it was retired. A regex over raw text would flag every one
+ * of those, the rule would be silenced with an allowlist, and it would then be blind
+ * to the real thing. TypeScript's AST does not surface comments as nodes here, so the
+ * exclusion is a property of the walk and cannot be forgotten.
+ *
+ * Collects string / no-substitution-template literals, template SPANS (the literal
+ * chunks around `${…}`), and JSX text.
+ */
+function userFacingStrings(fileName: string, text: string): { line: number; text: string }[] {
+  const sf = parseTsx(fileName, text);
+  const out: { line: number; text: string }[] = [];
+  const at = (n: ts.Node) => sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1;
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      // An import/export specifier is a module path, never copy.
+      const p = node.parent;
+      if (!ts.isImportDeclaration(p) && !ts.isExportDeclaration(p)) {
+        out.push({ line: at(node), text: node.text });
+      }
+    } else if (ts.isTemplateHead(node) || ts.isTemplateMiddle(node) || ts.isTemplateTail(node)) {
+      out.push({ line: at(node), text: node.text });
+    } else if (ts.isJsxText(node)) {
+      const t = node.text.trim();
+      if (t.length > 0) out.push({ line: at(node), text: t });
+    }
+    node.forEachChild(visit);
+  };
+  visit(sf);
+  return out;
+}
+
+/** Retired-wording hits in one source, as `line:phrase` strings. */
+function findRetiredWording(fileName: string, text: string): string[] {
+  return userFacingStrings(fileName, text).flatMap(({ line, text: s }) => {
+    const hit = RETIRED_WORDINGS.find((re) => re.test(s));
+    return hit ? [`${line}:${hit.source}`] : [];
+  });
+}
+
+/** Hardcoded kind-label hits in one source, as `line` strings. */
+function findHardcodedKindLabel(fileName: string, text: string): string[] {
+  return userFacingStrings(fileName, text).flatMap(({ line, text: s }) =>
+    KIND_LABEL_WORD.test(s) ? [String(line)] : []
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 🔴 VALIDATE THE INSTRUMENT BEFORE READING ITS VERDICT.
+//
+// The assertions this file exists for are ZEROS, and a reassuring zero is
+// indistinguishable from a scanner wired to nothing. Every control below runs
+// against a SYNTHETIC source, so none of them can go stale when the tree changes.
+// ---------------------------------------------------------------------------
+describe('🔴 the scanner (negative + positive controls)', () => {
+  it('POSITIVE CONTROL: it FINDS every retired-wording shape', () => {
+    const bad = `
+      export function S() {
+        const heading = 'List an external app';
+        const sub = \`a pending off-site listing for \${name}\`;
+        return (
+          <div>
+            <Badge title="External App">On-site and external</Badge>
+            <Text>This is an offsite app that opens elsewhere.</Text>
+            <Alert label={'Off-Site destination'} />
+          </div>
+        );
+      }`;
+    const hits = findRetiredWording('bad.tsx', bad);
+    // 'external app', 'off-site', 'External App', 'offsite app', 'Off-Site' = 5.
+    // (The JSX text "On-site and external" is NOT a hit — "external" alone is not a
+    // banned phrase, which is exactly the narrowness the rule needs to stay usable.)
+    expect(hits).toHaveLength(5);
+  });
+
+  it('POSITIVE CONTROL: it FINDS a hardcoded kind label in every render shape', () => {
+    const bad = `
+      export function S() {
+        const opts = [{ value: 'offsite', label: 'Standalone' }];
+        return (
+          <div>
+            <Badge>Standalone</Badge>
+            <Text title="Standalone app" />
+            <Text>{\`a pending Standalone submission\`}</Text>
+          </div>
+        );
+      }`;
+    expect(findHardcodedKindLabel('bad.tsx', bad)).toHaveLength(4);
+  });
+
+  it('NEGATIVE CONTROL: the ENROLLED form is not flagged', () => {
+    const good = `
+      import { STANDALONE_KIND_LABEL, listingKindAppLabel } from '~/components/Apps/listingKindLabels';
+      export function S({ kind }: { kind: 'onsite' | 'offsite' }) {
+        return (
+          <div>
+            <Badge>{STANDALONE_KIND_LABEL}</Badge>
+            <Badge>{listingKindAppLabel(kind)}</Badge>
+            <Text>{\`List a \${STANDALONE_KIND_LABEL} app hosted elsewhere\`}</Text>
+          </div>
+        );
+      }`;
+    expect(findRetiredWording('good.tsx', good)).toEqual([]);
+    expect(findHardcodedKindLabel('good.tsx', good)).toEqual([]);
+  });
+
+  /**
+   * 🔴 THE CONTROL THAT MAKES THIS AN AST WALK. A grep-based version of this rule
+   * flags its own explanatory comments, gets allowlisted, and goes blind. If comments
+   * ever start being scanned, this goes red and names the reason.
+   */
+  it('NEGATIVE CONTROL: prose in COMMENTS is never scanned', () => {
+    const commented = `
+      // The old copy said "List an external app" and the badge said Standalone.
+      /**
+       * An off-site listing used to be called an external app. Retired wording:
+       * "External App", "off-site", "Standalone".
+       */
+      export const x = 1;`;
+    expect(findRetiredWording('commented.tsx', commented)).toEqual([]);
+    expect(findHardcodedKindLabel('commented.tsx', commented)).toEqual([]);
+  });
+
+  /**
+   * 🔴 THE CONTROL FOR RULE (4)'s BLAST RADIUS. The stored value must survive the
+   * copy rule — if the scanner ever matched a bare `offsite`, the only way to make a
+   * normal component pass would be to rename the value, which is the failure this
+   * whole file is guarding against.
+   */
+  it('NEGATIVE CONTROL: the stored VALUE `offsite` is never flagged as copy', () => {
+    const values = `
+      export function S({ kind }: { kind: string }) {
+        const isExternal = kind === 'offsite';
+        mutate({ kind: 'offsite', scope: 'public-external' });
+        return <Select value={kind} data={[{ value: 'offsite', label: LABELS.offsite }]} />;
+      }`;
+    expect(findRetiredWording('values.tsx', values)).toEqual([]);
+    expect(findHardcodedKindLabel('values.tsx', values)).toEqual([]);
+  });
+
+  it('lowercase `standalone` is deliberately NOT the kind label', () => {
+    const prose = `
+      export function S() {
+        return <Text>Preview of the standalone block at its own origin.</Text>;
+      }`;
+    expect(findHardcodedKindLabel('prose.tsx', prose)).toEqual([]);
+    expect(ALLOWED_LOWERCASE_PROSE.length).toBeGreaterThan(20);
+  });
+});
+
+const SCANNED = SCAN_ROOTS.flatMap((root) => walk(path.join(SRC, root))).map((file) => ({
+  rel: path.relative(SRC, file).split(path.sep).join('/'),
+  raw: fs.readFileSync(file, 'utf8'),
+}));
+
+describe('🔒 the App-store kind label has ONE source', () => {
+  /**
+   * 🔴 A ROW FLOOR ON THE SCANNER ITSELF. Without it, a `SCAN_ROOTS` typo or a
+   * directory rename turns this whole file into a green no-op — the exact failure
+   * mode the ledger is here to prevent, one level up.
+   */
+  it('POSITIVE CONTROL: the scan actually visited the App-store tree', () => {
+    expect(SCANNED.length).toBeGreaterThan(60);
+    const rels = SCANNED.map((s) => s.rel);
+    for (const rel of Object.keys(ENROLLED)) expect(rels).toContain(rel);
+    expect(rels).toContain(LABEL_SOURCE_REL);
+  });
+
+  it('🔴 no user-facing string carries the retired wording', () => {
+    const offenders = SCANNED.flatMap(({ rel, raw }) =>
+      rel in ALLOWED_RETIRED_WORDING ? [] : findRetiredWording(rel, raw).map((h) => `${rel}:${h}`)
+    );
+    // Listed in full on failure: the message IS the fix instructions.
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * 🔴 THE "GROWS" HALF. A new surface that hardcodes `'Standalone'` — the CORRECT
+   * word, so the rule above cannot see it — is caught here and only here.
+   */
+  it('🔴 GROWS: no un-enrolled surface hardcodes the kind label', () => {
+    const offenders = SCANNED.flatMap(({ rel, raw }) =>
+      rel === LABEL_SOURCE_REL || rel in ENROLLED
+        ? []
+        : findHardcodedKindLabel(rel, raw).map((line) => `${rel}:${line}`)
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * 🔴 THE "SHRINKS" HALF. An enrolled surface that stops importing the source has
+   * reverted to a literal (or dropped the label entirely) — invisible to both rules
+   * above, because a hardcoded `'Standalone'` in an ENROLLED file is exempted by the
+   * rule above and is the right word for the rule before it.
+   */
+  it('🔴 SHRINKS: every enrolled surface resolves the label from the ONE source', () => {
+    const unenrolled = Object.keys(ENROLLED).filter((rel) => {
+      const raw = fs.readFileSync(path.join(SRC, rel), 'utf8');
+      return !raw.includes(LABEL_SOURCE_IMPORT);
+    });
+    expect(unenrolled).toEqual([]);
+  });
+
+  it('🔴 SHRINKS: no enrolled surface re-hardcodes the label beside the import', () => {
+    // Importing the source and ALSO spelling the word is the half-revert: it looks
+    // enrolled to the rule above while rendering a literal.
+    const offenders = Object.keys(ENROLLED).flatMap((rel) => {
+      const raw = fs.readFileSync(path.join(SRC, rel), 'utf8');
+      return findHardcodedKindLabel(rel, raw).map((line) => `${rel}:${line}`);
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it('the allowlist stays empty, and its lowercase-prose reason is recorded', () => {
+    // An allowlist that can grow silently is a second unenrolment channel.
+    expect(Object.keys(ALLOWED_RETIRED_WORDING)).toEqual([]);
+    expect(ALLOWED_LOWERCASE_PROSE).toContain('not the kind name');
+  });
+
+  it('every enrolled entry names a file that exists, with a reason', () => {
+    for (const [rel, reason] of Object.entries(ENROLLED)) {
+      expect(fs.existsSync(path.join(SRC, rel))).toBe(true);
+      expect(reason.length).toBeGreaterThan(10);
+    }
+  });
+});
+
+describe('🔒 the label constants, pinned as WHOLE normalised strings', () => {
+  /**
+   * 🔴 PINNED LITERALLY, NOT DERIVED. Writing `expect(listingKindLabel('offsite'))
+   * .toBe(LISTING_KIND_LABELS.offsite)` would pass for every possible value of the
+   * constant — it asserts the implementation against itself. These are the words as
+   * a human reads them, typed out.
+   */
+  it('the kind labels are exactly these words', () => {
+    expect(LISTING_KIND_LABELS).toEqual({ onsite: 'On-site', offsite: 'Standalone' });
+    expect(LISTING_KIND_APP_LABELS).toEqual({
+      onsite: 'On-site app',
+      offsite: 'Standalone app',
+    });
+    expect(STANDALONE_KIND_LABEL).toBe('Standalone');
+    expect(listingKindLabel('offsite')).toBe('Standalone');
+    expect(listingKindLabel('onsite')).toBe('On-site');
+    expect(listingKindAppLabel('offsite')).toBe('Standalone app');
+    expect(listingKindAppLabel('onsite')).toBe('On-site app');
+  });
+
+  /**
+   * 🔴 "On-site" IS DELIBERATELY UNCHANGED. Renaming it to "Embedded" was considered
+   * and deferred — "Embedded" collides with "Embedding" (TextualInversion) one panel
+   * away in `AppSettingsModal`. This pins the deferral so it is a decision, not drift.
+   */
+  it('the on-site label was NOT reworded', () => {
+    expect(LISTING_KIND_LABELS.onsite).toBe('On-site');
+    expect(LISTING_KIND_LABELS.onsite).not.toContain('Embedded');
+    expect(LISTING_KIND_APP_LABELS.onsite).not.toContain('Embedded');
+  });
+
+  it('every kind in the closed set has a label (no kind can render undefined)', () => {
+    for (const kind of STORE_LISTING_KINDS) {
+      expect(typeof listingKindLabel(kind)).toBe('string');
+      expect(listingKindLabel(kind).length).toBeGreaterThan(0);
+      expect(typeof listingKindAppLabel(kind)).toBe('string');
+      expect(listingKindAppLabel(kind).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+/**
+ * 🔴 RULE (4): THE COPY CHANGE DID NOT TOUCH ANY VALUE.
+ *
+ * Every assertion here pins a string that crosses a boundary this UI does not own —
+ * a database column, a public REST enum, a compile-time union's runtime source, a
+ * Flipt key. If a future "let's finish the rename" commit reaches any of them, it
+ * fails here rather than in a consumer's integration.
+ */
+describe('🔴 no ENUM / UNION / FLAG KEY / API contract value was renamed', () => {
+  it('the stored kind values are still `onsite` / `offsite`', () => {
+    expect(STORE_LISTING_KINDS).toEqual(['onsite', 'offsite']);
+    expect([...STORE_LISTING_KINDS]).not.toContain('standalone');
+  });
+
+  it('the public /api/v1/apps kind filter still accepts all|onsite|offsite', () => {
+    expect(listingKindFilterSchema.options).toEqual(['all', 'onsite', 'offsite']);
+    expect(listingKindFilterSchema.parse('offsite')).toBe('offsite');
+    expect(listingKindFilterSchema.parse('onsite')).toBe('onsite');
+    // A renamed value would be REJECTED by the contract, which is the point.
+    expect(listingKindFilterSchema.safeParse('standalone').success).toBe(false);
+  });
+
+  it('the visibility scope is still `public-external`', () => {
+    expect(STORE_VISIBILITY_SCOPES).toEqual(['full', 'public-external', 'none']);
+  });
+
+  it('the Flipt flag key is still `app-listings-public-external`', () => {
+    expect(APP_LISTINGS_PUBLIC_EXTERNAL_FLAG).toBe('app-listings-public-external');
+  });
+
+  it('the mode id in the submit page is still `external`, not the display word', () => {
+    // The wizard's mode union and every `mode === 'external'` branch key on the ID.
+    const raw = fs.readFileSync(path.join(SRC, 'components/Apps/SubmitModeSelector.tsx'), 'utf8');
+    expect(raw).toContain("export type SubmitMode = 'block' | 'external'");
+    expect(raw).toContain("onSelect('external')");
+    expect(raw).toContain("onSelect('block')");
+  });
+});

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -45,6 +45,7 @@ import type {
   ListingCard,
   ListingRecommendRollup,
 } from '~/server/schema/blocks/app-listing-read.schema';
+import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import type { AppListingStatus } from '~/server/services/blocks/app-listing-status.constants';
 
 /** Kind badge shown on the card face. */
@@ -66,7 +67,7 @@ export type ListingBadge = { label: string; kind: ListingBadgeKind };
  */
 export function getListingBadge(card: Pick<ListingCard, 'kind' | 'kindData'>): ListingBadge {
   if (card.kindData.kind === 'onsite') return { label: 'App', kind: 'onsite' };
-  return { label: 'Standalone', kind: 'offsite' };
+  return { label: STANDALONE_KIND_LABEL, kind: 'offsite' };
 }
 
 /**
@@ -75,10 +76,7 @@ export function getListingBadge(card: Pick<ListingCard, 'kind' | 'kindData'>): L
  * rather than a misleading "0% recommend". Otherwise a Steam-style
  * "N% recommend (M)" with the review count.
  */
-export function getRecommendLabel(
-  recommend: ListingRecommendRollup,
-  reviewCount: number
-): string {
+export function getRecommendLabel(recommend: ListingRecommendRollup, reviewCount: number): string {
   if (recommend.recommendPct == null) return 'No reviews yet';
   const pct = Math.round(recommend.recommendPct * 100);
   return `${pct}% recommend (${reviewCount.toLocaleString()})`;
@@ -211,9 +209,7 @@ export function getOwnerEditHref(
   listingId: string
 ): string | null {
   if (kindData.kind === 'onsite') {
-    return kindData.appBlockId
-      ? `/apps/${encodeURIComponent(kindData.appBlockId)}/edit`
-      : null;
+    return kindData.appBlockId ? `/apps/${encodeURIComponent(kindData.appBlockId)}/edit` : null;
   }
   return `/apps/submit?edit=${encodeURIComponent(listingId)}`;
 }

--- a/src/components/Apps/appListingDetailRows.ts
+++ b/src/components/Apps/appListingDetailRows.ts
@@ -35,6 +35,7 @@
  * thresholds. See that module's header.
  */
 
+import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import { getRatingLabel } from '~/utils/rating-label';
 import { marketplaceCategoryLabel } from '~/server/services/blocks/marketplace-categories.constants';
 import { offsiteContentRatingLabel } from '~/shared/constants/browsingLevel.constants';
@@ -64,7 +65,7 @@ export type ListingDetailRow = {
  * filter uses.
  */
 function kindLabel(detail: Pick<ListingDetail, 'kindData'>): string {
-  return detail.kindData.kind === 'onsite' ? 'On-site app' : 'Standalone';
+  return detail.kindData.kind === 'onsite' ? 'On-site app' : STANDALONE_KIND_LABEL;
 }
 
 /**

--- a/src/components/Apps/cliCommands.ts
+++ b/src/components/Apps/cliCommands.ts
@@ -16,8 +16,31 @@ export const BLOCKS_REACT_NPM_URL = 'https://www.npmjs.com/package/@civitai/bloc
 export const APP_SDK_NPM_URL = 'https://www.npmjs.com/package/@civitai/app-sdk';
 
 // --- Install ---
+/**
+ * 🔴 EVERY ROUTE BELOW WAS VERIFIED AGAINST THE CLI's OWN RELEASE ARTEFACTS, not
+ * assumed — the previous submit CTA advertised ONLY `brew`, which stops a Windows
+ * developer at step 1 of 3.
+ *
+ * Verified 2026-08-21 against `civitai/cli` (README "## Install", plus the `v0.1.99`
+ * release assets and the npm registry):
+ *  - npm      — `@civitai/cli` is published (60 versions, `latest` = 0.1.99); the
+ *               package is a thin wrapper that downloads the matching prebuilt binary
+ *               and verifies its sha256 against the release `checksums.txt`. It is the
+ *               only ONE-LINER that covers Windows, so it leads.
+ *  - brew     — macOS / Linux only, by construction.
+ *  - releases — the release carries `windows_amd64` / `windows_arm64` (.exe + .zip)
+ *               alongside linux/darwin × amd64/arm64, so a no-toolchain download is a
+ *               real Windows route and is named as one.
+ *  - go       — from source, Go 1.25+ (already used by the get-started page).
+ *
+ * The CLI publishes no machine-readable manifest, so these stay MANUALLY in sync;
+ * the `*.browser.test.tsx` suites pin the exact strings so a change is deliberate.
+ */
+export const CLI_INSTALL_NPM = 'npm install -g @civitai/cli';
 export const CLI_INSTALL_BREW = 'brew install civitai/tap/civitai';
 export const CLI_INSTALL_GO = 'go install github.com/civitai/cli/cmd/civitai@latest';
+/** Prebuilt binaries — linux, macOS and **windows** × amd64/arm64. */
+export const CIVITAI_CLI_RELEASES_URL = 'https://github.com/civitai/cli/releases';
 
 // --- Author / run / submit ---
 /** Bare `civitai app create` (the submit CTA's form). */

--- a/src/components/Apps/listingKindLabels.ts
+++ b/src/components/Apps/listingKindLabels.ts
@@ -1,0 +1,61 @@
+import type { StoreListingKind } from '~/shared/utils/store-visibility-scope';
+
+/**
+ * 🔒 THE SINGLE SOURCE for the human-readable name of an App-store listing KIND.
+ *
+ * ## Why this module exists
+ *
+ * The store shipped the word **"Standalone"** for `kind='offsite'`, but the label
+ * was hardcoded at each surface that rendered it — `AppBlockCard`'s badge and
+ * `KindFilterButtons`' toggle said "Standalone" while the submit flow, the invites
+ * table and the transfer-offers table still said "external app" / "External app".
+ * One measured card carried BOTH: `SubmitModeSelector`'s title read "List an
+ * external app (…)" directly above its own body text reading "List a standalone
+ * app hosted elsewhere". A display rule open-coded at N sites is typically wrong at
+ * N−1 of them, and unifying them is what makes the disagreement audible.
+ *
+ * ## 🔴 THIS IS A DISPLAY LABEL. IT IS NOT A VALUE.
+ *
+ * The stored/transported value stays `'onsite'` / `'offsite'` — the Prisma column,
+ * the `/api/v1/apps` public response enum (a consumer-facing contract), the
+ * `StoreListingKind` / `ListingKindFilter` unions, the `'public-external'` visibility
+ * scope and the `app-listings-public-external` Flipt key are ALL untouched by this
+ * module and must stay that way. Map for display at the render site; never rename
+ * the value. `__tests__/standaloneWordingCallSites.test.ts` pins that constraint.
+ *
+ * ## 🔴 "On-site" is DELIBERATELY unchanged
+ *
+ * Renaming "On-site" → "Embedded" was considered and DEFERRED: "Embedded" collides
+ * with "Embedding" (TextualInversion) one panel away in `AppSettingsModal`. This
+ * module carries the on-site label only so both kinds resolve from one place — it is
+ * not a licence to reword it.
+ */
+
+/** kind → the bare noun a human reads. */
+export const LISTING_KIND_LABELS: Record<StoreListingKind, string> = {
+  onsite: 'On-site',
+  offsite: 'Standalone',
+};
+
+/** kind → the label as a full noun phrase ("… app"), for table cells and badges. */
+export const LISTING_KIND_APP_LABELS: Record<StoreListingKind, string> = {
+  onsite: 'On-site app',
+  offsite: 'Standalone app',
+};
+
+/**
+ * The offsite label on its own. Exported so prose that names the kind in a sentence
+ * ("List a Standalone app hosted elsewhere") composes from the same constant the
+ * badge uses, instead of re-typing the word.
+ */
+export const STANDALONE_KIND_LABEL = LISTING_KIND_LABELS.offsite;
+
+/** kind → bare display label. */
+export function listingKindLabel(kind: StoreListingKind): string {
+  return LISTING_KIND_LABELS[kind];
+}
+
+/** kind → "<label> app" display label. */
+export function listingKindAppLabel(kind: StoreListingKind): string {
+  return LISTING_KIND_APP_LABELS[kind];
+}

--- a/src/components/Apps/offsiteSubmitFormConfig.ts
+++ b/src/components/Apps/offsiteSubmitFormConfig.ts
@@ -126,6 +126,45 @@ export function emptyOffsiteSubmitForm(): OffsiteSubmitFormValues {
 }
 
 /**
+ * Has the author entered ANYTHING that a Cancel would throw away?
+ *
+ * 🔴 The point of this predicate is what it must NOT report. `Cancel` in the create
+ * wizard navigates away and silently discards every field; confirming that is right,
+ * but confirming an UNTOUCHED form is a nag, and a confirmation people learn to
+ * dismiss protects nothing. So dirtiness is measured against the blank state, field
+ * by field — NOT against "did the component mount".
+ *
+ * 🔴 `contentRating` is compared to its DEFAULT (`'g'`), not to emptiness. It is the
+ * one field that starts non-empty, so an `Object.values(...).some(Boolean)` shortcut
+ * would call a pristine form dirty from the very first render and nag every single
+ * author. That is the mutation this predicate is written to survive.
+ *
+ * Whitespace-only text does not count as input: a stray space is not work worth a
+ * modal. `scopeJustifications` counts only if some entry has real text — the object
+ * is re-keyed (to empty strings) merely by picking a client, which `connectClientId`
+ * already reports.
+ */
+export function isOffsiteSubmitFormDirty(values: OffsiteSubmitFormValues): boolean {
+  const blank = emptyOffsiteSubmitForm();
+  const texts: Array<keyof OffsiteSubmitFormValues> = [
+    'slug',
+    'name',
+    'externalUrl',
+    'tagline',
+    'description',
+    'changelog',
+  ];
+  if (texts.some((k) => String(values[k] ?? '').trim().length > 0)) return true;
+  if (values.category !== blank.category) return true;
+  if (values.contentRating !== blank.contentRating) return true;
+  if (values.connectClientId !== blank.connectClientId) return true;
+  if (values.requestedScopes !== blank.requestedScopes) return true;
+  return Object.values(values.scopeJustifications ?? {}).some(
+    (v) => String(v ?? '').trim().length > 0
+  );
+}
+
+/**
  * Validate the METADATA fields client-side, mirroring `submitExternalListingSchema`'s
  * display shape. Returns a per-field error map (empty = valid). Delegates the URL
  * shape to the shared `validateExternalUrl` (https-only, length-bounded) ONLY WHEN a

--- a/src/components/Apps/useEligibleOauthClients.ts
+++ b/src/components/Apps/useEligibleOauthClients.ts
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constants';
+import { trpc } from '~/utils/trpc';
+
+/** The projection of an OAuth client both submit surfaces need. */
+export type EligibleOauthClient = { id: string; name: string; allowedScopes: number };
+
+/**
+ * Tri-state, because "we don't know yet" and "you have none" must NEVER collapse.
+ *
+ * 🔴 This is the whole point of the type. A pending fetch rendered as a confirmed
+ * empty list is the measured defect this module exists to make unrepresentable: it
+ * would tell a developer who owns three OAuth clients that they own none, at the very
+ * moment they are choosing how to list their app. `'unknown'` covers BOTH loading and
+ * error — an errored query is equally not evidence of absence, and the honest UI for
+ * both is the same: say nothing about the prerequisite.
+ */
+export type EligibleOauthClientsState =
+  | { status: 'unknown'; clients: readonly EligibleOauthClient[]; hasEligibleClient: null }
+  | { status: 'ready'; clients: readonly EligibleOauthClient[]; hasEligibleClient: boolean };
+
+/**
+ * 🔒 THE ONE ELIGIBILITY PREDICATE for "an OAuth client this author may list".
+ *
+ * `oauthClient.getAll` is already scoped to the caller (`userId`), so ownership is
+ * the server's job; the client-side rule is the App-Block exclusion — an
+ * auto-provisioned App-Block client is managed by the App Blocks flow and is never a
+ * hand-authored listing target.
+ *
+ * ## Why a shared hook rather than two `useQuery` calls
+ *
+ * The prerequisite is now surfaced in TWO places — the mode selector (before any work)
+ * and the wizard's step-2 empty state (defence in depth, because a client can be
+ * deleted mid-flow). Open-coding the filter at both would let them disagree, which is
+ * precisely how the selector could invite a developer into a flow that then dead-ends.
+ * They share one query key too, so the selector's fetch warms the wizard's.
+ */
+export function useEligibleOauthClients(): EligibleOauthClientsState {
+  const query = trpc.oauthClient.getAll.useQuery(undefined, {
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  const clients = useMemo(
+    () =>
+      ((query.data ?? []) as EligibleOauthClient[]).filter((c) => !isAppBlockOauthClientId(c.id)),
+    [query.data]
+  );
+
+  // 🔴 Branch on "did the fetch SETTLE with data", not on `isLoading`. A query that
+  // is disabled, errored, or paused is not loading and has no data — and every one of
+  // those states must read as `unknown`, never as an empty list.
+  const settled = query.data !== undefined;
+  if (!settled) return { status: 'unknown', clients: [], hasEligibleClient: null };
+  return { status: 'ready', clients, hasEligibleClient: clients.length > 0 };
+}

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -30,6 +30,7 @@ import { useMemo } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppBlockReviews } from '~/components/Apps/AppBlockReviews';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
+import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import {
   approvedListingSlugQuery,
   resolveLegacyAppRoute,
@@ -482,7 +483,7 @@ export default function AppDetailPage() {
                   <Stack gap="xs">
                     <Title order={4}>External site</Title>
                     <Text size="sm" c="dimmed">
-                      This standalone app opens an external link in a new tab:{' '}
+                      This {STANDALONE_KIND_LABEL} app opens an external link in a new tab:{' '}
                       <Anchor href={externalUrl!} target="_blank" rel="noopener noreferrer">
                         {externalUrl!.replace(/^https?:\/\//, '')}
                       </Anchor>

--- a/src/pages/apps/mine.tsx
+++ b/src/pages/apps/mine.tsx
@@ -48,7 +48,7 @@ export default function MyAppsPage() {
       <AppsPageLayout
         size={MY_APPS_CONTAINER_SIZE}
         title="My apps"
-        subtitle="Apps you own and apps you collaborate on, on-site and external. Open a row to see its submission history."
+        subtitle="Apps you own and apps you collaborate on, on-site and standalone. Open a row to see its submission history."
         actions={
           <Button component={Link} href="/apps/submit" rightSection={<IconArrowRight size={16} />}>
             Submit a new app

--- a/src/pages/apps/submit.tsx
+++ b/src/pages/apps/submit.tsx
@@ -8,10 +8,8 @@ import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
 import { AppsSubmitEditView } from '~/components/Apps/AppsSubmitEditView';
 import { CliSubmitCta } from '~/components/Apps/CliSubmitCta';
 import { ExternalSubmitForm } from '~/components/Apps/ExternalSubmitForm';
-import {
-  SubmitModeSelector,
-  type SubmitMode,
-} from '~/components/Apps/SubmitModeSelector';
+import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
+import { SubmitModeSelector, type SubmitMode } from '~/components/Apps/SubmitModeSelector';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
@@ -78,13 +76,12 @@ export default function SubmitAppPage() {
         subtitle={
           mode === null ? (
             <>
-              Choose how you want to list your app. Author an on-platform{' '}
-              <strong>App</strong> with the <Code>civitai</Code> CLI, or list an{' '}
-              <strong>external app</strong> by connecting your OAuth app. A moderator reviews
-              every submission before it appears.
+              Choose how you want to list your app. Author an on-platform <strong>App</strong> with
+              the <Code>civitai</Code> CLI, or list a <strong>{STANDALONE_KIND_LABEL} app</strong>{' '}
+              by connecting your OAuth app. A moderator reviews every submission before it appears.
             </>
           ) : (
-            <>Submitting {mode === 'external' ? 'an external app' : 'an App'}.</>
+            <>Submitting {mode === 'external' ? `a ${STANDALONE_KIND_LABEL} app` : 'an App'}.</>
           )
         }
       >

--- a/src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx
+++ b/src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx
@@ -204,7 +204,8 @@ describe('the payload fake honours its input (positive control)', () => {
     const card = page.getByTestId('apps-transfer-aot_2');
     await expect.element(card).toBeInTheDocument();
     await expect.element(card).toHaveTextContent('Other Thing');
-    await expect.element(card).toHaveTextContent(/External app/i);
+    // The kind badge, realigned on the store's own word (see listingKindLabels).
+    await expect.element(card).toHaveTextContent('Standalone app');
     // The card the OTHER arm rendered is not in this tree, so the two are genuinely
     // distinct renders rather than one cached DOM read twice.
     expect(page.getByTestId('apps-transfer-aot_1').elements()).toHaveLength(0);


### PR DESCRIPTION
Four UX fixes to the App-store submit flow, plus the single-source consolidation the second one turned out to need.

---

## 1. The OAuth prerequisite moves to the mode selector

**Measured:** a developer picks the standalone card, types a URL, clicks **Next** (which fires a server-side metadata fetch), reaches step 2 — and only *there* reads *"You have no eligible OAuth apps"*, with `Next` disabled. A hard dead-end, reachable only after doing work.

The requirement is a property of the **choice**, so it is now stated at the choice, with a link to `/user/account` (new tab, so nothing in flight is lost).

### Decision: the card stays CLICKABLE, it is not disabled

Deliberate, and the more conservative of the two options:

- the notice is driven by a **client-side read that can be wrong** — an error, a stale cache, a race with a client the user just registered. Disabling on it manufactures an *unrecoverable* dead-end, strictly worse than the one being fixed: the user could not even reach the step that explains itself.
- a `disabled` control is **removed from the tab order**, so a keyboard or screen-reader user would get the block without ever hearing the reason.
- nothing invalid can be submitted anyway — step 2 still gates `Next` on a selected client, and the server re-checks ownership at submit.

So the card **informs and offers the fix**, rather than refusing. Asserted as a test, because "just disable it" is the obvious alternative and it is the wrong one.

### A pending fetch must never read as "you have none"

The naive fix — *"show the notice when the client list is empty"* — is wrong, because an in-flight query also has an empty list. It would tell a developer who owns three OAuth clients that they own none, every time, for the duration of the fetch.

`useEligibleOauthClients` is therefore **tri-state**: `unknown` covers loading *and* error (an errored query is equally not evidence of absence), `ready` carries a real answer. That makes the confusion unrepresentable rather than merely avoided.

It is also the **one eligibility predicate**, now shared with the wizard — which previously open-coded the same "own clients, minus App-Block clients" filter. Two surfaces telling an author about the same prerequisite must not be able to disagree.

### Step 2 keeps its empty state

Defence in depth: a client can be deleted mid-flow, and the selector's read can be stale. It is pinned by a test (`the step-2 empty state survives`) precisely so a future *"the selector already handles it"* cleanup cannot make it unreachable-by-construction.

---

## 2. Copy aligned on "Standalone" — and the label gets ONE source

The store shipped **"Standalone"**, but the label was hardcoded at every surface, so they disagreed. `SubmitModeSelector` carried both at once: title *"List an external app (connect your OAuth app)"* directly above its own body text *"List a standalone app hosted elsewhere"*. Same component, same render, two words.

New `src/components/Apps/listingKindLabels.ts` is the single source; every user-facing site is enrolled on it.

### Writing the ledger found four more sites nobody had reported

None was reachable by reading the submit flow, and none would have shown up in a copy sweep — **they were already spelling the correct word**:

| Site | What it actually said |
|---|---|
| `appListingCardView.ts` (`getListingBadge`) | `'Standalone'`, hardcoded |
| `appListingDetailRows.ts` (`kindLabel`) | `'On-site app'` / `'Standalone'` — the `app` suffix on one branch and not the other |
| `OffsiteReviewQueue.tsx` ×2 | moderator queue + reports headings, hardcoded |

The first two each carried a comment claiming to mirror the other's wording. They did not. That is the consolidation-as-bug-finding effect: a rule open-coded at N sites is typically wrong at N−1, and unifying is what makes the disagreement audible.

### Files whose user-facing copy changed

`SubmitModeSelector.tsx` · `ExternalSubmitForm.tsx` · `pages/apps/submit.tsx` · `pages/apps/mine.tsx` · `pages/apps/[appBlockId]/index.tsx` · `AppInvitesBody.tsx` · `AppTransferOffersView.tsx` · `AppEarningsPanel.tsx` · `ConnectScopesPanel.tsx` · `AppBlockCard.tsx` · `KindFilterButtons.tsx` · `appListingCardView.ts` · `appListingDetailRows.ts` · `OffsiteReviewQueue.tsx`

### 🔴 No value was renamed

**Explicitly: no enum, no union member, no Prisma column value, no public `/api/v1/apps` response value, no mode id and no feature-flag key changed in this PR.** `'onsite'` / `'offsite'` / `'public-external'` / `app-listings-public-external` / `SubmitMode = 'block' | 'external'` are all untouched.

That constraint is *asserted*, not just intended — a "let's finish the rename" commit reaching a stored value would typecheck, render correctly, and break a consumer contract silently. Four tests pin it, and each has a mutant proving it fires.

### "On-site" is deliberately unchanged

Renaming it to "Embedded" was considered and **deferred** — "Embedded" collides with "Embedding" (TextualInversion) one panel away in `AppSettingsModal`. The deferral is pinned by a test so it stays a decision rather than drift.

### Lowercase `standalone` is deliberately out of scope

`pages/apps/[appBlockId]/index.tsx` renders, in the **non**-external branch, *"Preview of the standalone block at …"*. That `standalone` means *served from its own origin, apart from the model page* — it describes an **on-site** app. Capitalising it would label an on-site app with the offsite kind's name: not a cosmetic slip, a false statement on a public listing page. The rule keys on the capitalised whole word, which only ever names the kind, and the reasoning is recorded in the ledger so nobody "tightens" it into a wrong rule.

---

## 3. The CLI panel

- **"Recommended: use the Civitai CLI" → "Use the Civitai CLI".** "Recommended" implies an alternative, and this page offers none — the manual ZIP flow does not exist here. Of the two available fixes (drop the word, or genuinely present the alternative), dropping it is the honest one, because there is no alternative to present.
- **Every platform now has an install route.** The lone `brew` one-liner stopped a Windows or non-Homebrew Linux developer at step 1 of 3.

**Each route was verified against the CLI's own artefacts before being documented — none is invented:**

| Route | Verification |
|---|---|
| `npm install -g @civitai/cli` | live on the npm registry (60 versions, `latest` = 0.1.99); the only one-liner that covers Windows, so it leads |
| `brew install civitai/tap/civitai` | CLI README "Install"; macOS / Linux by construction |
| `go install github.com/civitai/cli/cmd/civitai@latest` | CLI README; already used by the get-started page |
| prebuilt binary | release `v0.1.99` ships `windows_amd64` / `windows_arm64` (`.exe` + `.zip`) alongside linux/darwin × amd64/arm64 |

Each is labelled with **who it is for**, so a reader picks without guessing. No platform is silently omitted.

---

## 4. Cancel confirms, and step 2 explains itself

- **Cancel** was `<Button component={Link} href="/apps/mine">`: one click discarded every field — URL, name, description, scope justifications — with no warning and no undo. It now asks first.
- **But only when there is unsaved input.** A confirmation that fires on an untouched wizard is a nag, and a nag is dismissed reflexively, which would make the dialog worthless on the one occasion it protects real work. Both directions are the requirement; both are tested. `isOffsiteSubmitFormDirty` compares against the blank state field by field — notably `contentRating` against its **default** (`'g'`), not against emptiness, which is the one line separating it from an `Object.values(...).some(Boolean)` shortcut that would nag every author on their first click.
- **Step 2 now explains the OAuth relationship** in plain language, for everyone — not only on the empty path.

The dialog is an inline Mantine `Modal` rather than `@mantine/modals`' `openConfirmModal`: the component is rendered in isolation by the browser suite, which has no `ModalsProvider`, and a confirmation nobody can test is a confirmation nobody can trust.

---

## Not done / deliberately out of scope

- "On-site" → "Embedded" (see above; deferred, and pinned as deferred).
- Step-1 `Next` validation — already correct, confirmed and left alone.
- The step-2 recovery link's `target="_blank" rel="noopener noreferrer"` — already correct, preserved.
- `AppDetailsModal` / `AppListingDetailBody` comments still say "off-site"; those are code comments, not rendered copy, and the ledger's scanner structurally excludes comments (otherwise the rule flags its own explanation and gets allowlisted into blindness).
