### PR TITLE
perf(tags): trim tag.getAll's cache key, and carry ctx dimensions in cacheIt keys

### DIFF
--- a/src/server/__tests__/middleware.trpc.cacheit.test.ts
+++ b/src/server/__tests__/middleware.trpc.cacheit.test.ts
@@ -111,3 +111,83 @@ describe('cacheIt cache-write fail-open', () => {
     expect(logSysRedisFailOpen).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Cache-key composition — the mechanism only. These pass their own options in, so
+ * they cannot see any one procedure's configuration; `tag.router.cache-key.test.ts`
+ * covers that call site against the real router.
+ */
+type KeyInput = {
+  excludedTagIds?: number[];
+  excludedImageIds?: number[];
+  excludedUserIds?: number[];
+  excludedModelIds?: number[];
+};
+
+async function keyFor(input?: KeyInput, adminTags?: boolean) {
+  const mw = cacheIt<KeyInput>({
+    ttl: 60,
+    excludeKeys: ['excludedImageIds', 'excludedUserIds', 'excludedModelIds'],
+    varyBy: (ctx) => ({ adminTags: ctx.features.adminTags }),
+  }) as unknown as (opts: {
+    input?: KeyInput;
+    ctx: unknown;
+    next: () => unknown;
+    path: string;
+  }) => Promise<unknown>;
+
+  await mw({
+    input,
+    ctx: { cache: { canCache: true }, user: undefined, features: { adminTags } },
+    next: vi.fn().mockResolvedValue(COMPUTED),
+    path: 'tag.getAll',
+  });
+
+  return redisFake.packed.get.mock.calls.at(-1)![0] as string;
+}
+
+describe('cacheIt cache-key composition', () => {
+  it.each(['excludedImageIds', 'excludedUserIds', 'excludedModelIds'] as const)(
+    'the key does NOT move when %s changes',
+    async (field) => {
+      const base = await keyFor({ excludedTagIds: [7] });
+      const withField = await keyFor({ excludedTagIds: [7], [field]: [1, 2, 3] });
+
+      expect(withField).toBe(base);
+    }
+  );
+
+  it('the key DOES move when excludedTagIds changes', async () => {
+    const a = await keyFor({ excludedTagIds: [7] });
+    const b = await keyFor({ excludedTagIds: [7, 8] });
+
+    expect(b).not.toBe(a);
+  });
+
+  it('the key DOES move with adminTags — the response drops the adminOnly filter on it', async () => {
+    const asAdmin = await keyFor({ excludedTagIds: [7] }, true);
+    const asAnon = await keyFor({ excludedTagIds: [7] }, undefined);
+
+    expect(asAdmin).not.toBe(asAnon);
+  });
+
+  it('refuses an input key that collides with a varyBy dimension', async () => {
+    await expect(
+      keyFor({ excludedTagIds: [7], ...({ adminTags: true } as object) })
+    ).rejects.toThrow(/collides with an input key/);
+  });
+
+  it('array order and duplicates do not move the key', async () => {
+    const a = await keyFor({ excludedTagIds: [7, 8] });
+    const b = await keyFor({ excludedTagIds: [8, 7, 7, 8] });
+
+    expect(b).toBe(a);
+  });
+
+  it('does not mutate the caller input array', async () => {
+    const excludedTagIds = [9, 3, 9];
+    await keyFor({ excludedTagIds });
+
+    expect(excludedTagIds).toEqual([9, 3, 9]);
+  });
+});

--- a/src/server/__tests__/middleware.trpc.cacheit.test.ts
+++ b/src/server/__tests__/middleware.trpc.cacheit.test.ts
@@ -177,6 +177,63 @@ describe('cacheIt cache-key composition', () => {
     ).rejects.toThrow(/collides with an input key/);
   });
 
+  // The collision is with the INPUT, not with what survived into the key — these
+  // three inputs all contribute nothing to it and would otherwise be overwritten
+  // in silence.
+  it.each([
+    ['false', false],
+    ['zero', 0],
+    ['empty string', ''],
+    ['undefined', undefined],
+  ])('refuses a colliding input key whose value is %s', async (_label, value) => {
+    await expect(
+      keyFor({ excludedTagIds: [7], ...({ adminTags: value } as object) })
+    ).rejects.toThrow(/collides with an input key/);
+  });
+
+  it('refuses a colliding input key that is itself excluded from the key', async () => {
+    const mw = cacheIt<KeyInput>({
+      ttl: 60,
+      excludeKeys: ['excludedModelIds'],
+      varyBy: () => ({ excludedModelIds: [1] }),
+    }) as unknown as (opts: {
+      input?: unknown;
+      ctx: unknown;
+      next: () => unknown;
+      path: string;
+    }) => Promise<unknown>;
+
+    await expect(
+      mw({
+        input: { excludedModelIds: [2] },
+        ctx: { cache: { canCache: true }, user: undefined, features: {} },
+        next: vi.fn().mockResolvedValue(COMPUTED),
+        path: 'tag.getAll',
+      })
+    ).rejects.toThrow(/collides with an input key/);
+  });
+
+  it('does not mistake an inherited property for a collision', async () => {
+    const mw = cacheIt<KeyInput>({
+      ttl: 60,
+      varyBy: () => ({ toString: 'x', constructor: 'y', valueOf: 'z' }),
+    }) as unknown as (opts: {
+      input?: unknown;
+      ctx: unknown;
+      next: () => unknown;
+      path: string;
+    }) => Promise<unknown>;
+
+    await expect(
+      mw({
+        input: { excludedTagIds: [7] },
+        ctx: { cache: { canCache: true }, user: undefined, features: {} },
+        next: vi.fn().mockResolvedValue(COMPUTED),
+        path: 'tag.getAll',
+      })
+    ).resolves.toBeDefined();
+  });
+
   it('array order and duplicates do not move the key', async () => {
     const a = await keyFor({ excludedTagIds: [7, 8] });
     const b = await keyFor({ excludedTagIds: [8, 7, 7, 8] });

--- a/src/server/controllers/__tests__/model.paged-simple-cacheability.test.ts
+++ b/src/server/controllers/__tests__/model.paged-simple-cacheability.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type * as ModelService from '~/server/services/model.service';
+
+const { getModels } = vi.hoisted(() => ({ getModels: vi.fn() }));
+
+vi.mock('~/server/services/model.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModelService>()),
+  getModels,
+}));
+
+import { getModelsPagedSimpleHandler } from '~/server/controllers/model.controller';
+
+/**
+ * `getModels` reports a caller-dependent row set through `isPrivate` — the shape
+ * no cache key can carry, since it turns on the caller's identity rather than a
+ * role. getModelsInfiniteHandler has always acted on it; this handler shares the
+ * result and must too.
+ */
+async function canCacheAfter(isPrivate: boolean) {
+  getModels.mockResolvedValue({ items: [], isPrivate });
+  const ctx = { user: undefined, cache: { canCache: true } };
+
+  await getModelsPagedSimpleHandler({ input: { limit: 10 }, ctx } as never);
+
+  return ctx.cache.canCache;
+}
+
+describe('getModelsPagedSimpleHandler cacheability', () => {
+  it('refuses caching when getModels reports a caller-dependent row set', async () => {
+    await expect(canCacheAfter(true)).resolves.toBe(false);
+  });
+
+  it('leaves caching enabled otherwise', async () => {
+    await expect(canCacheAfter(false)).resolves.toBe(true);
+  });
+});

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -632,6 +632,10 @@ export const getModelsPagedSimpleHandler = async ({
     },
   });
 
+  // Same signal getModelsInfiniteHandler acts on: getModels reports when the row
+  // set it returned depends on who asked, which no cache key can express.
+  if (results.isPrivate && ctx.cache) ctx.cache.canCache = false;
+
   const isModerator = ctx?.user?.isModerator;
   const parsedResults = {
     ...results,

--- a/src/server/middleware.trpc.ts
+++ b/src/server/middleware.trpc.ts
@@ -7,6 +7,7 @@ import { logToAxiom } from '~/server/logging/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { hSetWithTTL, sAddWithExpireGe } from '~/server/redis/atomic';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
+import type { Context } from '~/server/createContext';
 import type { UserPreferencesInput } from '~/server/schema/base.schema';
 import { getAllHiddenForUser } from '~/server/services/user-preferences.service';
 import { middleware } from '~/server/trpc';
@@ -56,12 +57,17 @@ type CacheItProps<TInput extends object> = {
   key?: string;
   ttl?: number;
   excludeKeys?: (keyof TInput)[];
+  // Response dimensions that live on ctx rather than on the input — the `Vary`
+  // header's job. A procedure whose output varies on something the input never
+  // carries has to declare it here or the key cannot tell two callers apart.
+  varyBy?: (ctx: Context) => Record<string, unknown>;
   tags?: (input: TInput) => string[];
 };
 export function cacheIt<TInput extends object>({
   key,
   ttl,
   excludeKeys,
+  varyBy,
   tags,
 }: CacheItProps<TInput> = {}) {
   ttl ??= 60 * 3;
@@ -72,10 +78,14 @@ export function cacheIt<TInput extends object>({
     if (_input) {
       for (const [key, value] of Object.entries(_input)) {
         if (excludeKeys?.includes(key as keyof TInput)) continue;
-        if (Array.isArray(value)) cacheKeyObj[key] = [...new Set(value.sort())];
-
-        if (value) cacheKeyObj[key] = value;
+        if (Array.isArray(value)) cacheKeyObj[key] = [...new Set(value)].sort();
+        else if (value) cacheKeyObj[key] = value;
       }
+    }
+    for (const [varyKey, varyValue] of Object.entries(varyBy?.(ctx) ?? {})) {
+      if (varyKey in cacheKeyObj)
+        throw new Error(`cacheIt: varyBy key "${varyKey}" collides with an input key on ${path}`);
+      cacheKeyObj[varyKey] = varyValue;
     }
     const hash = withSpan('trpc:middleware:cacheIt:hash', () => hashifyObject(cacheKeyObj));
     const cacheKey = `${REDIS_KEYS.TRPC.BASE}:${key ?? path.replace('.', ':')}:${hash}` as const;

--- a/src/server/middleware.trpc.ts
+++ b/src/server/middleware.trpc.ts
@@ -83,7 +83,7 @@ export function cacheIt<TInput extends object>({
       }
     }
     for (const [varyKey, varyValue] of Object.entries(varyBy?.(ctx) ?? {})) {
-      if (varyKey in cacheKeyObj)
+      if (_input && Object.prototype.hasOwnProperty.call(_input, varyKey))
         throw new Error(`cacheIt: varyBy key "${varyKey}" collides with an input key on ${path}`);
       cacheKeyObj[varyKey] = varyValue;
     }

--- a/src/server/routers/__tests__/leaderboard.router.cache-key.test.ts
+++ b/src/server/routers/__tests__/leaderboard.router.cache-key.test.ts
@@ -1,0 +1,76 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { leaderboardRouter } from '~/server/routers/leaderboard.router';
+
+/**
+ * These procedures resolve `isModerator` from ctx and hand it to the service,
+ * which uses it to widen the board set. Their inputs cannot express that, so the
+ * key has to carry it separately.
+ */
+type Middleware = (opts: {
+  input?: unknown;
+  ctx: unknown;
+  next: () => unknown;
+  path: string;
+}) => Promise<unknown>;
+
+const redisFake = redisMock.redis;
+
+const proceduresOf = (
+  leaderboardRouter as unknown as {
+    _def: { procedures: Record<string, { _def: { middlewares: Middleware[] } }> };
+  }
+)._def.procedures;
+
+async function readKey(mw: Middleware, path: string, input: unknown, isModerator?: boolean) {
+  redisFake.packed.get.mockClear();
+  redisFake.packed.get.mockResolvedValue(null);
+  await mw({
+    input,
+    ctx: {
+      cache: { canCache: false },
+      user: isModerator === undefined ? undefined : { id: 1, isModerator },
+      features: {},
+    },
+    next: async () => ({ ok: true, data: { x: 1 } }),
+    path,
+  });
+  const needle = `:${path.replace('.', ':')}:`;
+  return redisFake.packed.get.mock.calls.map((call) => call[0] as string).find((k) => k.includes(needle));
+}
+
+// By behaviour, not position: these chains also carry a domain middleware and an
+// edge-cache one, either of which could move.
+async function resolveCacheMiddleware(procedure: string, path: string, probe: unknown) {
+  for (const mw of proceduresOf[procedure]._def.middlewares) {
+    const key = await readKey(mw, path, probe).catch(() => undefined);
+    if (key) return mw;
+  }
+  throw new Error(`${path} has no middleware reading a cache key`);
+}
+
+describe.each([
+  ['getLeaderboardPositions', 'leaderboard.getLeaderboardPositions', { userId: 1 }],
+  ['getLeaderboard', 'leaderboard.getLeaderboard', { id: 'overall', maxPosition: 1000 }],
+])('%s cache key', (procedure, path, input) => {
+  let mw: Middleware;
+  beforeAll(async () => {
+    mw = await resolveCacheMiddleware(procedure, path, input);
+  });
+
+  it('moves when the caller is a moderator', async () => {
+    const asModerator = await readKey(mw, path, input, true);
+    const asAnonymous = await readKey(mw, path, input, undefined);
+
+    expect(asModerator).toBeDefined();
+    expect(asModerator).not.toBe(asAnonymous);
+  });
+
+  it('does not move between an anonymous and a non-moderator caller', async () => {
+    const asUser = await readKey(mw, path, input, false);
+    const asAnonymous = await readKey(mw, path, input, undefined);
+
+    expect(asUser).toBe(asAnonymous);
+  });
+});

--- a/src/server/routers/__tests__/leaderboard.router.cache-key.test.ts
+++ b/src/server/routers/__tests__/leaderboard.router.cache-key.test.ts
@@ -37,7 +37,9 @@ async function readKey(mw: Middleware, path: string, input: unknown, isModerator
     path,
   });
   const needle = `:${path.replace('.', ':')}:`;
-  return redisFake.packed.get.mock.calls.map((call) => call[0] as string).find((k) => k.includes(needle));
+  return redisFake.packed.get.mock.calls
+    .map((call) => call[0] as string)
+    .find((k) => k.includes(needle));
 }
 
 // By behaviour, not position: these chains also carry a domain middleware and an

--- a/src/server/routers/__tests__/model.router.cache-key.test.ts
+++ b/src/server/routers/__tests__/model.router.cache-key.test.ts
@@ -1,0 +1,74 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { modelRouter } from '~/server/routers/model.router';
+
+/**
+ * getModelsPagedSimpleHandler filters each row's meta through
+ * `filterModelMetaForClient` / `filterSensitiveProfanityData` by the caller's
+ * moderator status, after the service has returned. The input cannot express
+ * that, so the key has to.
+ */
+type Middleware = (opts: {
+  input?: unknown;
+  ctx: unknown;
+  next: () => unknown;
+  path: string;
+}) => Promise<unknown>;
+
+const PATH = 'model.getAllPagedSimple';
+const redisFake = redisMock.redis;
+
+const middlewares = (
+  modelRouter as unknown as {
+    _def: { procedures: Record<string, { _def: { middlewares: Middleware[] } }> };
+  }
+)._def.procedures.getAllPagedSimple._def.middlewares;
+
+async function readKey(mw: Middleware, input: unknown, isModerator?: boolean) {
+  redisFake.packed.get.mockClear();
+  redisFake.packed.get.mockResolvedValue(null);
+  await mw({
+    input,
+    ctx: {
+      cache: { canCache: false },
+      user: isModerator === undefined ? undefined : { id: 1, isModerator },
+      features: {},
+    },
+    next: async () => ({ ok: true, data: { x: 1 } }),
+    path: PATH,
+  });
+  return redisFake.packed.get.mock.calls
+    .map((call) => call[0] as string)
+    .find((k) => k.includes(':model:getAllPagedSimple:'));
+}
+
+let mw: Middleware;
+
+beforeAll(async () => {
+  for (const candidate of middlewares) {
+    const key = await readKey(candidate, { limit: 10 }).catch(() => undefined);
+    if (key) {
+      mw = candidate;
+      return;
+    }
+  }
+  throw new Error(`${PATH} has no middleware reading a cache key`);
+});
+
+describe('model.getAllPagedSimple cache key', () => {
+  it('moves when the caller is a moderator', async () => {
+    const asModerator = await readKey(mw, { limit: 10 }, true);
+    const asAnonymous = await readKey(mw, { limit: 10 }, undefined);
+
+    expect(asModerator).toBeDefined();
+    expect(asModerator).not.toBe(asAnonymous);
+  });
+
+  it('does not move between an anonymous and a non-moderator caller', async () => {
+    const asUser = await readKey(mw, { limit: 10 }, false);
+    const asAnonymous = await readKey(mw, { limit: 10 }, undefined);
+
+    expect(asUser).toBe(asAnonymous);
+  });
+});

--- a/src/server/routers/__tests__/tag.router.cache-key.test.ts
+++ b/src/server/routers/__tests__/tag.router.cache-key.test.ts
@@ -1,0 +1,87 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { tagRouter } from '~/server/routers/tag.router';
+
+/**
+ * The cache-key decision lives at the `cacheIt` call site, so this drives the
+ * real procedure's middleware chain. The sibling suite over `cacheIt` itself
+ * passes its own options in, and so cannot see this router's configuration
+ * change.
+ *
+ * No `vi.mock` here on purpose: mocking `~/server/trpc` — as that sibling does
+ * to unwrap `middleware()` — would take `router()` and `publicProcedure` with
+ * it, and there would be no router left to import.
+ */
+type Middleware = (opts: {
+  input?: unknown;
+  ctx: unknown;
+  next: () => unknown;
+  path: string;
+}) => Promise<unknown>;
+
+const redisFake = redisMock.redis;
+
+const middlewares = (
+  tagRouter as unknown as {
+    _def: { procedures: { getAll: { _def: { middlewares: Middleware[] } } } };
+  }
+)._def.procedures.getAll._def.middlewares;
+
+async function readKey(mw: Middleware, input: unknown, adminTags?: boolean) {
+  redisFake.packed.get.mockClear();
+  redisFake.packed.get.mockResolvedValue(null);
+  await mw({
+    input,
+    // canCache false so the miss path stops at the read.
+    ctx: { cache: { canCache: false }, user: undefined, features: { adminTags } },
+    next: async () => ({ ok: true, data: { x: 1 } }),
+    path: 'tag.getAll',
+  });
+  return redisFake.packed.get.mock.calls
+    .map((call) => call[0] as string)
+    .find((key) => key.includes(':tag:getAll:'));
+}
+
+// Found by what it does, not by its position in the chain — a middleware added
+// or reordered above it must not silently retarget this suite.
+let cacheMiddleware: Middleware;
+
+beforeAll(async () => {
+  for (const mw of middlewares) {
+    const key = await readKey(mw, {}).catch(() => undefined);
+    if (key) {
+      cacheMiddleware = mw;
+      return;
+    }
+  }
+  throw new Error('tag.getAll has no middleware reading a tag:getAll cache key');
+});
+
+const keyFor = (input: unknown, adminTags?: boolean) => readKey(cacheMiddleware, input, adminTags);
+
+describe('tag.getAll cache key', () => {
+  it.each(['excludedImageIds', 'excludedUserIds', 'excludedModelIds'] as const)(
+    'does NOT move when %s changes — getTags never reads it',
+    async (field) => {
+      const base = await keyFor({ excludedTagIds: [7] });
+      const withField = await keyFor({ excludedTagIds: [7], [field]: [1, 2, 3] });
+
+      expect(withField).toBe(base);
+    }
+  );
+
+  it('moves when excludedTagIds changes', async () => {
+    const a = await keyFor({ excludedTagIds: [7] });
+    const b = await keyFor({ excludedTagIds: [7, 8] });
+
+    expect(b).not.toBe(a);
+  });
+
+  it('moves when the adminTags dimension changes', async () => {
+    const asAdmin = await keyFor({ excludedTagIds: [7] }, true);
+    const asAnon = await keyFor({ excludedTagIds: [7] }, undefined);
+
+    expect(asAdmin).not.toBe(asAnon);
+  });
+});

--- a/src/server/routers/leaderboard.router.ts
+++ b/src/server/routers/leaderboard.router.ts
@@ -19,9 +19,9 @@ const leaderboardEdgeCache = edgeCacheIt({
   ttl: CacheTTL.xs,
 });
 
-// `applyRequestDomainColor` must be `.use()`d BEFORE `cacheIt` on every procedure
-// here: cacheIt hashes the input to build its Redis key, so a domain stamped
-// after it would leave one entry shared across colors.
+// `applyRequestBoardDomainColor` must be `.use()`d BEFORE `cacheIt` on every
+// procedure here: cacheIt hashes the input to build its Redis key, so a domain
+// stamped after it would leave one entry shared across colors.
 export const leaderboardRouter = router({
   getLeaderboards: publicProcedure
     .meta({ requiredScope: TokenScope.MediaRead })
@@ -34,7 +34,13 @@ export const leaderboardRouter = router({
     .meta({ requiredScope: TokenScope.MediaRead })
     .input(getLeaderboardPositionsSchema)
     .use(applyRequestBoardDomainColor)
-    .use(cacheIt({ ttl: CacheTTL.day, tags: () => ['leaderboard', 'leaderboard-positions'] }))
+    .use(
+      cacheIt({
+        ttl: CacheTTL.day,
+        tags: () => ['leaderboard', 'leaderboard-positions'],
+        varyBy: (ctx) => ({ isModerator: ctx.user?.isModerator ?? false }),
+      })
+    )
     .query(({ input, ctx }) =>
       getLeaderboardPositions({
         ...input,
@@ -50,6 +56,7 @@ export const leaderboardRouter = router({
       cacheIt({
         ttl: CacheTTL.day,
         tags: (input: GetLeaderboardInput) => ['leaderboard', `leaderboard-${input.id}`],
+        varyBy: (ctx) => ({ isModerator: ctx.user?.isModerator ?? false }),
       })
     )
     .use(leaderboardEdgeCache)

--- a/src/server/routers/model.router.ts
+++ b/src/server/routers/model.router.ts
@@ -157,7 +157,12 @@ export const modelRouter = router({
   getAllPagedSimple: publicProcedure
     .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getAllModelsSchema.extend({ cursor: z.never().optional() }))
-    .use(cacheIt({ ttl: 60 }))
+    .use(
+      cacheIt({
+        ttl: 60,
+        varyBy: (ctx) => ({ isModerator: ctx.user?.isModerator ?? false }),
+      })
+    )
     .query(getModelsPagedSimpleHandler),
   getAllInfiniteSimple: guardedProcedure
     .meta({ requiredScope: TokenScope.ModelsRead })

--- a/src/server/routers/tag.router.ts
+++ b/src/server/routers/tag.router.ts
@@ -13,7 +13,9 @@ import {
   getHomeExcludedTagsHandler,
 } from '~/server/controllers/tag.controller';
 import { applyUserPreferences, cacheIt, edgeCacheIt } from '~/server/middleware.trpc';
+import type { UserPreferencesInput } from '~/server/schema/base.schema';
 import { getByIdSchema } from '~/server/schema/base.schema';
+import type { GetTagsInput } from '~/server/schema/tag.schema';
 import {
   addTagVotesSchema,
   adjustTagsSchema,
@@ -41,7 +43,16 @@ export const tagRouter = router({
     .meta({ requiredScope: TokenScope.MediaRead })
     .input(getTagsInput.optional())
     .use(applyUserPreferences)
-    .use(cacheIt({ ttl: 60 }))
+    .use(
+      // applyUserPreferences injects four id lists; getTags reads only
+      // excludedTagIds. Hashing the other three cost up to 213ms of synchronous
+      // event-loop block per request for accounts with large hidden sets.
+      cacheIt<GetTagsInput & UserPreferencesInput>({
+        ttl: 60,
+        excludeKeys: ['excludedImageIds', 'excludedUserIds', 'excludedModelIds'],
+        varyBy: (ctx) => ({ adminTags: ctx.features.adminTags }),
+      })
+    )
     .query(getAllTagsHandler),
   getHomeExcluded: publicProcedure
     .meta({ requiredScope: TokenScope.MediaRead })

--- a/src/server/schema/leaderboard.schema.ts
+++ b/src/server/schema/leaderboard.schema.ts
@@ -1,26 +1,32 @@
 import * as z from 'zod';
 import { DomainColor } from '~/shared/utils/prisma/enums';
 
-// Stamped by `applyRequestDomainColor`, never sent by the client. It has to reach
+// Stamped by `applyRequestBoardDomainColor`, never sent by the client. It has to reach
 // `cacheIt`'s key: a domain read off ctx.req inside the service would leave one
 // cache entry shared across colors, and .red would serve .com's boards. Carrying
 // it on the input is one way; `cacheIt`'s `varyBy` is the other.
 const domainColorEnum = z.enum(DomainColor);
 
-export type GetLeaderboardPositionsInput = z.infer<typeof getLeaderboardPositionsSchema>;
+// `isModerator` is resolved from ctx by the router and is deliberately absent from
+// these two wire schemas: a client value would be overwritten anyway, and leaving
+// it in the input puts it in `cacheIt`'s key as the constant the schema defaults
+// it to. The procedures declare it through `varyBy` instead.
+export type GetLeaderboardPositionsInput = z.infer<typeof getLeaderboardPositionsSchema> & {
+  isModerator?: boolean;
+};
 export const getLeaderboardPositionsSchema = z.object({
   userId: z.number().optional(), // This is ok, it's used for caching purposes
   date: z.date().optional(),
   top: z.number().optional(),
-  isModerator: z.boolean().optional().default(false),
   domain: domainColorEnum.optional(),
 });
 
-export type GetLeaderboardInput = z.infer<typeof getLeaderboardSchema>;
+export type GetLeaderboardInput = z.infer<typeof getLeaderboardSchema> & {
+  isModerator?: boolean;
+};
 export const getLeaderboardSchema = z.object({
   id: z.string(),
   date: z.date().optional(),
-  isModerator: z.boolean().optional().default(false),
   maxPosition: z.number().optional().default(1000),
   domain: domainColorEnum.optional(),
 });

--- a/src/server/schema/leaderboard.schema.ts
+++ b/src/server/schema/leaderboard.schema.ts
@@ -1,11 +1,10 @@
 import * as z from 'zod';
 import { DomainColor } from '~/shared/utils/prisma/enums';
 
-// Stamped by `applyRequestDomainColor`, never sent by the client. It must live on
-// the INPUT rather than be read from ctx.req inside the service: `cacheIt` builds
-// its Redis key by hashing the input object only, so a domain resolved off the
-// request would leave one cache entry shared across colors and .red would serve
-// .com's boards.
+// Stamped by `applyRequestDomainColor`, never sent by the client. It has to reach
+// `cacheIt`'s key: a domain read off ctx.req inside the service would leave one
+// cache entry shared across colors, and .red would serve .com's boards. Carrying
+// it on the input is one way; `cacheIt`'s `varyBy` is the other.
 const domainColorEnum = z.enum(DomainColor);
 
 export type GetLeaderboardPositionsInput = z.infer<typeof getLeaderboardPositionsSchema>;

--- a/src/server/services/leaderboard.service.ts
+++ b/src/server/services/leaderboard.service.ts
@@ -3,7 +3,6 @@ import type { CosmeticSource, CosmeticType } from '~/shared/utils/prisma/enums';
 import { DomainColor } from '~/shared/utils/prisma/enums';
 import dayjs from '~/shared/utils/dayjs';
 import { dbRead, dbWrite } from '~/server/db/client';
-import { isModerator } from '~/server/routers/base.router';
 import type {
   GetLeaderboardInput,
   GetLeaderboardPositionsInput,
@@ -74,7 +73,11 @@ export async function getLeaderboards(input: GetLeaderboardsInput) {
       description: true,
       scoringDescription: true,
       domain: true,
-      public: isModerator ? true : undefined,
+      // Unconditional: the `where` above already limits non-moderators to public
+      // boards, and UserProfileEditModal filters its showcase options on this
+      // field — selecting it only for moderators would blank that list for
+      // everyone else.
+      public: true,
     },
     orderBy: {
       index: 'asc',


### PR DESCRIPTION
Closes [868kuq9y7](https://app.clickup.com/t/8459928/868kuq9y7).

Two related changes to `cacheIt`: one takes out key material nothing reads, the other puts in key material that was missing.

## 1. `tag.getAll` — three id lists in the key that the query never reads

`applyUserPreferences` pushes four id lists onto `tag.getAll`'s already-parsed input. `getTags` reads exactly one of them.

`excludedImageIds`, `excludedUserIds` and `excludedModelIds` are not declared in `getTagsInput`, are injected after the zod parse, and never reach the query. Their only effect is that `cacheIt` sorts, `Set`s and hashes them on the single Next.js thread, once per request. `excludedTagIds` stays in the key — it is the one the query actually reads.

`#4222` put this procedure back on a per-page-view route, which is what makes it worth doing now. The cost is entirely in the dead three:

| list | p99 | max | users with ≥1 |
|---|---|---|---|
| hidden models (`ModelEngagement type='Hide'`) | 590 | 447,184 | 98,596 |
| hidden tags (`TagEngagement type='Hide'`) | 16 | 6,561 | 1,150,116 |

Sort + `Set` + stringify + hash, benchmarked on node:

| hidden models | sync block |
|---|---|
| 590 (p99) | 0.67 ms |
| 5,000 | 1.95 ms |
| 50,000 | 19.4 ms |
| 447,184 (max) | 188.5 ms |

So roughly twenty accounts each buy a ~190 ms event-loop stall per `/models` load, and that stall blocks every concurrent request on the pod. The same case measures 1.7 ms with the three excluded.

`excludeKeys` already existed on `cacheIt` but had no callers anywhere — this is its first use, which is why the call site needs the widened generic (`TInput` otherwise infers to its `object` constraint, making `keyof TInput` `never`).

## 2. `varyBy` — dimensions a response varies on that the input cannot carry

`cacheIt` composes its key from the input alone. Several cached procedures resolve a value from ctx and use it to shape the response, so it gains `varyBy` for exactly those — the `Vary` header's job.

- **`tag.getAll`** — `getAllTagsHandler` passes `ctx.features.adminTags` into `getTags`, where it widens the row set. (`adminTags` is `['mod', 'granted']` with no `fliptKey`, so evaluating it is a role and region check with no network — which matters because on a cache hit the handler no longer runs, making `varyBy` the only reader.)
- **`leaderboard.getLeaderboardPositions`** and **`leaderboard.getLeaderboard`** — both resolve `isModerator` from ctx and hand it to the service, which uses it to widen the board set. `getLeadboardLegends` shares a schema with `getLeaderboard`, but its service never reads `isModerator`, so it gets no `varyBy`.
- **`model.getAllPagedSimple`** — `getModelsPagedSimpleHandler` filters each row's meta through `filterModelMetaForClient` and `filterSensitiveProfanityData` by the caller's moderator status, after `getModels` returns.

### `isModerator` leaves two wire schemas

`getLeaderboardPositionsSchema` and `getLeaderboardSchema` both declared `isModerator: z.boolean().optional().default(false)`, while the router overrode it from ctx on every call. A client value was discarded, and the schema default was the only thing that ever reached the key. Keeping it in the input and adding `varyBy` would have been two sources for one value — so it comes out of the two schemas that back `.input()`, and the service-facing types keep the field. The two schemas never used as `.input()` (`getLeaderboardsSchema`, `getLeaderboardsWithResultsSchema`) are unchanged.

### `model.getAllPagedSimple` needs more than a key

`getModels` already reports `isPrivate` when the row set it returned was shaped by *who asked* rather than by their role — per-user collections, favourites, hidden. `getModelsInfiniteHandler` acts on it (`ctx.cache.canCache = false`); `getModelsPagedSimpleHandler` spreads the same result and never consulted it. It does now.

The two are not substitutes. `varyBy` handles a role, which has few enough values to be worth keying on; `isPrivate` handles caller identity, which a key cannot express without degenerating into a per-user cache. Each covers what the other cannot.

### Collisions are refused

A `varyBy` name that collides with an input key throws. Both sources are legitimate, so picking a quiet winner in either direction is wrong — a future `varyBy: (ctx) => ({ domain })` on a leaderboard procedure would otherwise silently clobber what `applyRequestBoardDomainColor` stamped, with no type error and no failing test.

The check is against **own properties of the raw input**, not against the assembled key object: an input key whose value is falsy, or one listed in `excludeKeys`, contributes nothing to the key and would otherwise be overwritten in silence. Using `in` also walked the prototype chain, so a `varyBy` key named `toString` or `constructor` threw against any input at all.

## 3. Also in here

The array branch of the key builder had no `else`:

```js
if (Array.isArray(value)) cacheKeyObj[key] = [...new Set(value.sort())];
if (value) cacheKeyObj[key] = value;
```

Arrays are truthy, so the second line always overwrote the first. Only the in-place `.sort()` survived — so duplicates stayed in the key, and `cacheIt` mutated its caller's array. Deduplicating a copy fixes both.

**This is not a speed change.** Benchmarked against the old effective behaviour it is within noise — 1.7563 ms vs 1.7400 ms at 6,561 shuffled ids — because ~95% of the cost is `JSON.stringify` plus the per-character hash loop, which dedup only shrinks when there are real duplicates. `excludedTagIds` cannot have any (`TagEngagement` is unique on `(userId, tagId)`). The entire saving in this PR is `excludeKeys`; this hunk is a correctness fix.

Two consequences for the other `cacheIt` procedures, neither of which I believe bites:
- **Rekey:** only array inputs *containing duplicates* move. The long-TTL sites take no array input at all — `get404Images` has no `.input()`, and the leaderboard and event schemas are scalar-only.
- **Handlers now receive caller-order arrays** where they previously arrived pre-sorted, because the old in-place `.sort()` survived the overwrite. Every consumer feeds them through `Prisma.join` into an `IN`, so ordering is immaterial — but a reviewer of those procedures otherwise gets no signal that what they *receive* changed, not just what gets hashed.

Two comments naming `applyRequestDomainColor` where the code uses `applyRequestBoardDomainColor` are corrected, in `leaderboard.schema.ts` and `leaderboard.router.ts`. Both middlewares exist, so the name was pointing at the wrong one.

`getLeaderboards` selected `public: isModerator ? true : undefined`, where `isModerator` was the **tRPC middleware** imported from `~/server/routers/base.router` — not `input.isModerator`, which is what every other site in that file reads. A function object is always truthy, so the ternary was a constant.

Not a leak, and the value is narrow: the `where` above already restricts non-moderators to public boards, so every row they receive has `public = true`. It is a latent bug neither TypeScript nor ESLint can see — the import is real and genuinely used — that would become real if the expression ever moved into a `where`.

It is now `public: true` rather than `input.isModerator`, because the field has exactly one reader: `UserProfileEditModal` filters the leaderboard-showcase options on `board.public`, for every user, so gating the select on moderator status would leave it `undefined` for everyone else and empty that list. The `where` already makes it constant-true for non-moderators. The emitted query is unchanged, so there is no new behaviour to test. Line 77 was the import's only consumer, so the import goes too.

## Testing

Call-site suites drive the **real routers'** middleware chains, locating the `cacheIt` entry by behaviour (the one reading that procedure's key) rather than by index, so a middleware added or reordered above it cannot silently retarget them. No `vi.mock` in any of the three.

- `tag.router.cache-key.test.ts` — 5
- `leaderboard.router.cache-key.test.ts` — 4 (including that an anonymous and a non-moderator caller still share a key, so this does not fragment the cache)
- `model.router.cache-key.test.ts` — 2
- `model.paged-simple-cacheability.test.ts` — 2, over the `isPrivate` handling
- `middleware.trpc.cacheit.test.ts` — 17, the mechanism itself

The split between the call-site suites and the mechanism suite is deliberate: the mechanism suite passes its own options in, so it cannot see any one procedure's configuration. Reverting `tag.getAll`'s call site to `cacheIt({ ttl: 60 })` leaves it **11/11 green** while the call-site suite fails 4 by name.

Every hunk was revert-checked rather than assumed:

| revert | result |
|---|---|
| `tag.getAll` call site → `cacheIt({ ttl: 60 })` | 4 failed |
| drop the `excludeKeys` skip | 3 failed |
| restore the dropped dedup | 2 failed |
| remove `varyBy` from the key | 1 failed |
| collision guard → silent `Object.assign` | 1 failed |
| collision guard → `varyKey in cacheKeyObj` | 6 failed |
| leaderboard `varyBy` (both procedures) | 2 failed |
| model `varyBy` | 1 failed |
| model `isPrivate` handling | 1 failed |

All sub-second, all with legible assertion messages, none hanging.

- covering set (4 cache-key/cacheability + 3 middleware + 3 tag service + leaderboard, home-block, session-props, board-color + router canary) — **484 passed, 0 failed**
- `pnpm run test:lint-rules` — 265 passed
- `pnpm run typecheck` — 0 errors
- `eslint` — 0 errors; all 11 warnings on these files pre-exist on `main` at identical lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeeJXStZA5ebfrCMVsxrRn

