### PR TITLE
fix(scan-files): bound the fallback scan retry loop (fairness, backoff, run budget)

### DIFF
--- a/src/server/jobs/__tests__/scan-files.test.ts
+++ b/src/server/jobs/__tests__/scan-files.test.ts
@@ -304,9 +304,27 @@ describe('scanFilesFallbackJob fairness ordering', () => {
     // Asserted as a literal so replacing it with the bare form fails here.
     expect(mockDbWrite.modelFile.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        orderBy: [{ scanRequestedAt: { sort: 'asc', nulls: 'first' } }],
+        orderBy: [{ scanRequestedAt: { sort: 'asc', nulls: 'first' } }, { id: 'asc' }],
       })
     );
+  });
+
+  it('breaks ties on id ascending so the batch is a total, stable order', async () => {
+    mockDbWrite.modelFile.findMany.mockResolvedValue([]);
+
+    await runJob(scanFilesFallbackJob);
+
+    // Sorting on a single nullable column leaves big ties — every NULL ties with
+    // every other NULL, and the upfront updateMany stamps one identical
+    // timestamp across the whole batch. Postgres may break those ties
+    // arbitrarily and differently each run, so the tiebreaker is what makes the
+    // batch deterministic. Asserted by position and direction, not just presence.
+    const [args] = mockDbWrite.modelFile.findMany.mock.calls[0];
+    expect(args.orderBy).toHaveLength(2);
+    expect(args.orderBy[1]).toEqual({ id: 'asc' });
+    // Descending would prefer the NEWEST row inside a tie — the inverse of
+    // "longest-waiting first".
+    expect(args.orderBy[1]).not.toEqual({ id: 'desc' });
   });
 
   it('does not pass the bare asc form, which would sort nulls last', async () => {
@@ -374,6 +392,51 @@ describe('scanFilesFallbackJob per-run budget', () => {
     });
   });
 
+  // 🔴 Boundary pair. These two are what pin the budget's VALUE behaviourally.
+  // Without them the constant is only pinned by the `runBudgetMs` field in the
+  // Axiom payload — an observability field, and itself hardcodable — so the
+  // budget could be anything under the test's overshoot and still run green.
+  // The literals are written out rather than derived from the constant, so
+  // moving the constant in either direction fails one of these.
+  it('still submits at one millisecond under the budget', async () => {
+    mockDbWrite.modelFile.findMany.mockResolvedValue(twoFiles);
+    mockCreateModelFileScanRequest.mockImplementation(async () => {
+      vi.setSystemTime(new Date(FIXED_NOW.getTime() + 179_999));
+    });
+
+    const result = await runJob(scanFilesFallbackJob);
+
+    expect(mockCreateModelFileScanRequest).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ submitted: 2, failed: 0, skipped: 0 });
+  });
+
+  it('still submits at exactly the budget (the bound is exclusive)', async () => {
+    mockDbWrite.modelFile.findMany.mockResolvedValue(twoFiles);
+    mockCreateModelFileScanRequest.mockImplementation(async () => {
+      vi.setSystemTime(new Date(FIXED_NOW.getTime() + 180_000));
+    });
+
+    const result = await runJob(scanFilesFallbackJob);
+
+    // Pins `>` rather than `>=`. Without this the two differ only at this exact
+    // millisecond, which no other test visits, so flipping the operator is
+    // otherwise invisible.
+    expect(mockCreateModelFileScanRequest).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ submitted: 2, failed: 0, skipped: 0 });
+  });
+
+  it('skips at one millisecond over the budget', async () => {
+    mockDbWrite.modelFile.findMany.mockResolvedValue(twoFiles);
+    mockCreateModelFileScanRequest.mockImplementation(async () => {
+      vi.setSystemTime(new Date(FIXED_NOW.getTime() + 180_001));
+    });
+
+    const result = await runJob(scanFilesFallbackJob);
+
+    expect(mockCreateModelFileScanRequest).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ submitted: 1, failed: 0, skipped: 1 });
+  });
+
   it('does not skip when the run stays inside the budget', async () => {
     mockDbWrite.modelFile.findMany.mockResolvedValue(twoFiles);
     // Well inside 180s, and a different magnitude from PAST_BUDGET_MS.
@@ -387,27 +450,49 @@ describe('scanFilesFallbackJob per-run budget', () => {
     expect(result).toEqual({ submitted: 2, failed: 0, skipped: 0 });
   });
 
-  it('reports the truncated run to Axiom so the bound is observable', async () => {
-    mockDbWrite.modelFile.findMany.mockResolvedValue(twoFiles);
-    mockCreateModelFileScanRequest.mockImplementation(async () => {
-      vi.setSystemTime(new Date(FIXED_NOW.getTime() + PAST_BUDGET_MS));
-    });
+  // 🔴 Run at TWO different batch sizes. One size is not enough: with a single
+  // fixture the asserted `batchSize` equals that fixture's own length, so a
+  // mutant hardcoding the literal survives — and simply picking a bigger single
+  // fixture just relocates the coincidence instead of removing it. Across two
+  // sizes no constant can satisfy both, so `batchSize` and `skipped` have to be
+  // derived. Within each case every asserted number is distinct as well, so no
+  // field can be satisfied by another field's value.
+  it.each([
+    { size: 3, expectedSkipped: 2 },
+    { size: 5, expectedSkipped: 4 },
+  ])(
+    'reports the truncated run to Axiom so the bound is observable (batch of $size)',
+    async ({ size, expectedSkipped }) => {
+      mockDbWrite.modelFile.findMany.mockResolvedValue(
+        Array.from({ length: size }, (_, i) => ({
+          id: i + 1,
+          modelVersion: {
+            id: (i + 1) * 10,
+            baseModel: 'SD 1.5',
+            model: { id: (i + 1) * 100, type: 'Checkpoint' },
+          },
+        }))
+      );
+      mockCreateModelFileScanRequest.mockImplementation(async () => {
+        vi.setSystemTime(new Date(FIXED_NOW.getTime() + PAST_BUDGET_MS));
+      });
 
-    await runJob(scanFilesFallbackJob);
+      await runJob(scanFilesFallbackJob);
 
-    expect(mockLogToAxiom).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'warning',
-        name: 'scan-files-fallback',
-        skipped: 1,
-        submitted: 1,
-        failed: 0,
-        batchSize: 2,
-        runBudgetMs: 180_000,
-      }),
-      'webhooks'
-    );
-  });
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'warning',
+          name: 'scan-files-fallback',
+          skipped: expectedSkipped,
+          submitted: 1,
+          failed: 0,
+          batchSize: size,
+          runBudgetMs: 180_000,
+        }),
+        'webhooks'
+      );
+    }
+  );
 
   it('emits no budget warning on a run that skips nothing', async () => {
     mockDbWrite.modelFile.findMany.mockResolvedValue(twoFiles);

--- a/src/server/jobs/__tests__/scan-files.test.ts
+++ b/src/server/jobs/__tests__/scan-files.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const { mockCreateModelFileScanRequest, mockModelFileScanSubmissionError, mockLimitConcurrency } =
   vi.hoisted(() => {
@@ -44,6 +44,21 @@ const mockLogToAxiom = loggingMock.logToAxiom;
 
 const ctx = {} as Parameters<typeof scanFilesFallbackJob.run>[0];
 
+// Fixed clock so the backoff timestamp can be pinned as a LITERAL rather than
+// recomputed with the same dayjs expression the implementation uses.
+// Deliberately not on a round minute/second: the expected backoff instant must
+// not coincide with `now`, with `now - 1 day`, or with any round value a
+// hardcoding mutant might produce.
+const FIXED_NOW = new Date('2026-03-05T12:07:13.000Z');
+
+// FIXED_NOW - 1 day + 30 min. Written out literally, NOT derived from dayjs.
+const EXPECTED_BACKOFF_AT = new Date('2026-03-04T12:37:13.000Z');
+
+// Distinct from the 180s budget and from the 300s job lock, and strictly
+// between them: a mutant that confuses the budget with `lockExpiration` fails
+// to skip at this elapsed time, so it dies rather than surviving.
+const PAST_BUDGET_MS = 240_000;
+
 // createJob wraps the function so .run() returns { result, cancel }.
 // Await `.result` to get the actual return value of the inner async fn.
 async function runJob<T extends { run: (ctx: any) => { result: Promise<unknown> } }>(
@@ -53,6 +68,8 @@ async function runJob<T extends { run: (ctx: any) => { result: Promise<unknown> 
 }
 
 beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
   // Reset call records but keep mockResolvedValue defaults set above.
   mockDbWrite.modelFile.findMany.mockReset().mockResolvedValue([]);
   mockDbWrite.modelFile.updateMany.mockReset().mockResolvedValue({ count: 0 });
@@ -61,6 +78,10 @@ beforeEach(() => {
   mockCreateModelFileScanRequest.mockReset();
   mockLogToAxiom.mockReset().mockResolvedValue(undefined);
   // limitConcurrency stays as our sequential runner — never reset
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('scanFilesFallbackJob', () => {
@@ -114,23 +135,29 @@ describe('scanFilesFallbackJob', () => {
       baseModel: 'SD 1.5',
       priority: 'low',
     });
-    expect(result).toEqual({ submitted: 1, failed: 0 });
+    expect(result).toEqual({ submitted: 1, failed: 0, skipped: 0 });
   });
 
-  it('skips files with a null modelVersion (soft-deleted) and resets scanRequestedAt', async () => {
+  it('backs off files with a null modelVersion (soft-deleted) instead of resetting them', async () => {
     mockDbWrite.modelFile.findMany.mockResolvedValue([{ id: 99, modelVersion: null }]);
 
     const result = await runJob(scanFilesFallbackJob);
 
     expect(mockCreateModelFileScanRequest).not.toHaveBeenCalled();
+    // A soft-deleted ModelVersion never starts resolving again, so a null reset
+    // would re-pick this file every 5 minutes forever.
     expect(mockDbWrite.modelFile.update).toHaveBeenCalledWith({
+      where: { id: 99 },
+      data: { scanRequestedAt: EXPECTED_BACKOFF_AT },
+    });
+    expect(mockDbWrite.modelFile.update).not.toHaveBeenCalledWith({
       where: { id: 99 },
       data: { scanRequestedAt: null },
     });
-    expect(result).toEqual({ submitted: 0, failed: 1 });
+    expect(result).toEqual({ submitted: 0, failed: 1, skipped: 0 });
   });
 
-  it('on submission failure, resets scanRequestedAt and logs to Axiom', async () => {
+  it('on submission failure, backs off scanRequestedAt and logs to Axiom', async () => {
     mockDbWrite.modelFile.findMany.mockResolvedValue([
       {
         id: 5,
@@ -143,7 +170,7 @@ describe('scanFilesFallbackJob', () => {
 
     expect(mockDbWrite.modelFile.update).toHaveBeenCalledWith({
       where: { id: 5 },
-      data: { scanRequestedAt: null },
+      data: { scanRequestedAt: EXPECTED_BACKOFF_AT },
     });
     expect(mockLogToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -153,7 +180,7 @@ describe('scanFilesFallbackJob', () => {
       }),
       'webhooks'
     );
-    expect(result).toEqual({ submitted: 0, failed: 1 });
+    expect(result).toEqual({ submitted: 0, failed: 1, skipped: 0 });
   });
 
   it('on ModelFileScanSubmissionError code=not-found, tombstones via exists=false (no scanRequestedAt reset)', async () => {
@@ -179,11 +206,15 @@ describe('scanFilesFallbackJob', () => {
       where: { id: 7 },
       data: { exists: false },
     });
-    // And the scanRequestedAt-reset path does NOT fire — the file exits the
-    // scan poll permanently via the WHERE-clause `exists` filter.
+    // And neither retry path fires — the file exits the scan poll permanently
+    // via the WHERE-clause `exists` filter.
     expect(mockDbWrite.modelFile.update).not.toHaveBeenCalledWith({
       where: { id: 7 },
       data: { scanRequestedAt: null },
+    });
+    expect(mockDbWrite.modelFile.update).not.toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: { scanRequestedAt: EXPECTED_BACKOFF_AT },
     });
     expect(mockLogToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -192,10 +223,10 @@ describe('scanFilesFallbackJob', () => {
       }),
       'webhooks'
     );
-    expect(result).toEqual({ submitted: 0, failed: 1 });
+    expect(result).toEqual({ submitted: 0, failed: 1, skipped: 0 });
   });
 
-  it('on ModelFileScanSubmissionError code=transient, resets scanRequestedAt (no tombstone)', async () => {
+  it('on ModelFileScanSubmissionError code=transient, backs off scanRequestedAt (no tombstone)', async () => {
     mockDbWrite.modelFile.findMany.mockResolvedValue([
       {
         id: 8,
@@ -214,7 +245,16 @@ describe('scanFilesFallbackJob', () => {
 
     expect(mockDbWrite.modelFile.update).toHaveBeenCalledWith({
       where: { id: 8 },
+      data: { scanRequestedAt: EXPECTED_BACKOFF_AT },
+    });
+    // Not `null` (retried every 5 min) and not `now` (hidden for 24h).
+    expect(mockDbWrite.modelFile.update).not.toHaveBeenCalledWith({
+      where: { id: 8 },
       data: { scanRequestedAt: null },
+    });
+    expect(mockDbWrite.modelFile.update).not.toHaveBeenCalledWith({
+      where: { id: 8 },
+      data: { scanRequestedAt: FIXED_NOW },
     });
     expect(mockDbWrite.modelFile.update).not.toHaveBeenCalledWith({
       where: { id: 8 },
@@ -227,7 +267,7 @@ describe('scanFilesFallbackJob', () => {
       }),
       'webhooks'
     );
-    expect(result).toEqual({ submitted: 0, failed: 1 });
+    expect(result).toEqual({ submitted: 0, failed: 1, skipped: 0 });
   });
 
   it('processes mixed batches: counts per-file successes and failures correctly', async () => {
@@ -248,6 +288,133 @@ describe('scanFilesFallbackJob', () => {
 
     const result = await runJob(scanFilesFallbackJob);
 
-    expect(result).toEqual({ submitted: 1, failed: 2 });
+    expect(result).toEqual({ submitted: 1, failed: 2, skipped: 0 });
+  });
+});
+
+describe('scanFilesFallbackJob fairness ordering', () => {
+  it('orders never-submitted files first via an explicit NULLS FIRST sort', async () => {
+    mockDbWrite.modelFile.findMany.mockResolvedValue([]);
+
+    await runJob(scanFilesFallbackJob);
+
+    // 🔴 The `{ sort, nulls }` object form is load-bearing. Postgres orders ASC
+    // with NULLS LAST by default, so the bare `'asc'` string would sort
+    // never-submitted files LAST — the exact inverse of what fairness needs.
+    // Asserted as a literal so replacing it with the bare form fails here.
+    expect(mockDbWrite.modelFile.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ scanRequestedAt: { sort: 'asc', nulls: 'first' } }],
+      })
+    );
+  });
+
+  it('does not pass the bare asc form, which would sort nulls last', async () => {
+    mockDbWrite.modelFile.findMany.mockResolvedValue([]);
+
+    await runJob(scanFilesFallbackJob);
+
+    const [args] = mockDbWrite.modelFile.findMany.mock.calls[0];
+    expect(args.orderBy).not.toEqual([{ scanRequestedAt: 'asc' }]);
+    expect(args.orderBy).not.toEqual({ scanRequestedAt: 'asc' });
+  });
+});
+
+describe('scanFilesFallbackJob per-run budget', () => {
+  // Two files; the first submission burns PAST_BUDGET_MS of wall clock, so the
+  // second must be refused admission rather than started.
+  const twoFiles = [
+    {
+      id: 1,
+      modelVersion: { id: 10, baseModel: 'SD 1.5', model: { id: 100, type: 'Checkpoint' } },
+    },
+    {
+      id: 2,
+      modelVersion: { id: 20, baseModel: 'SDXL', model: { id: 200, type: 'LORA' } },
+    },
+  ];
+
+  it('stops starting new submissions once the run budget is spent', async () => {
+    mockDbWrite.modelFile.findMany.mockResolvedValue(twoFiles);
+    mockCreateModelFileScanRequest.mockImplementation(async () => {
+      vi.setSystemTime(new Date(FIXED_NOW.getTime() + PAST_BUDGET_MS));
+    });
+
+    const result = await runJob(scanFilesFallbackJob);
+
+    // File 1 was admitted; file 2 was not even attempted.
+    expect(mockCreateModelFileScanRequest).toHaveBeenCalledTimes(1);
+    expect(mockCreateModelFileScanRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ fileId: 1 })
+    );
+    expect(mockCreateModelFileScanRequest).not.toHaveBeenCalledWith(
+      expect.objectContaining({ fileId: 2 })
+    );
+    expect(result).toEqual({ submitted: 1, failed: 0, skipped: 1 });
+  });
+
+  it('releases a budget-skipped file with scanRequestedAt=null, not the retry backoff', async () => {
+    mockDbWrite.modelFile.findMany.mockResolvedValue(twoFiles);
+    mockCreateModelFileScanRequest.mockImplementation(async () => {
+      vi.setSystemTime(new Date(FIXED_NOW.getTime() + PAST_BUDGET_MS));
+    });
+
+    await runJob(scanFilesFallbackJob);
+
+    // It was never attempted, so it must be immediately eligible again — the
+    // backoff is for files that were tried and failed. The upfront updateMany
+    // already stamped it, so without this reset it hides for the 24h window.
+    expect(mockDbWrite.modelFile.update).toHaveBeenCalledWith({
+      where: { id: 2 },
+      data: { scanRequestedAt: null },
+    });
+    expect(mockDbWrite.modelFile.update).not.toHaveBeenCalledWith({
+      where: { id: 2 },
+      data: { scanRequestedAt: EXPECTED_BACKOFF_AT },
+    });
+  });
+
+  it('does not skip when the run stays inside the budget', async () => {
+    mockDbWrite.modelFile.findMany.mockResolvedValue(twoFiles);
+    // Well inside 180s, and a different magnitude from PAST_BUDGET_MS.
+    mockCreateModelFileScanRequest.mockImplementation(async () => {
+      vi.setSystemTime(new Date(FIXED_NOW.getTime() + 1_000));
+    });
+
+    const result = await runJob(scanFilesFallbackJob);
+
+    expect(mockCreateModelFileScanRequest).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ submitted: 2, failed: 0, skipped: 0 });
+  });
+
+  it('reports the truncated run to Axiom so the bound is observable', async () => {
+    mockDbWrite.modelFile.findMany.mockResolvedValue(twoFiles);
+    mockCreateModelFileScanRequest.mockImplementation(async () => {
+      vi.setSystemTime(new Date(FIXED_NOW.getTime() + PAST_BUDGET_MS));
+    });
+
+    await runJob(scanFilesFallbackJob);
+
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'warning',
+        name: 'scan-files-fallback',
+        skipped: 1,
+        submitted: 1,
+        failed: 0,
+        batchSize: 2,
+        runBudgetMs: 180_000,
+      }),
+      'webhooks'
+    );
+  });
+
+  it('emits no budget warning on a run that skips nothing', async () => {
+    mockDbWrite.modelFile.findMany.mockResolvedValue(twoFiles);
+    mockCreateModelFileScanRequest.mockResolvedValue(undefined);
+
+    await runJob(scanFilesFallbackJob);
+
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
   });
 });

--- a/src/server/jobs/__tests__/scan-files.test.ts
+++ b/src/server/jobs/__tests__/scan-files.test.ts
@@ -293,48 +293,39 @@ describe('scanFilesFallbackJob', () => {
 });
 
 describe('scanFilesFallbackJob fairness ordering', () => {
-  it('orders never-submitted files first via an explicit NULLS FIRST sort', async () => {
+  it('sorts unattempted files first, then oldest id, as one total order', async () => {
     mockDbWrite.modelFile.findMany.mockResolvedValue([]);
 
     await runJob(scanFilesFallbackJob);
 
-    // 🔴 The `{ sort, nulls }` object form is load-bearing. Postgres orders ASC
-    // with NULLS LAST by default, so the bare `'asc'` string would sort
-    // never-submitted files LAST — the exact inverse of what fairness needs.
-    // Asserted as a literal so replacing it with the bare form fails here.
+    // ONE assertion deliberately, on the whole array literal. Array deep
+    // equality pins length, element order and element identity at once, so this
+    // single expectation covers every way the sort can be wrong:
+    //
+    //  - `nulls: 'first'` replaced or dropped. Load-bearing: Postgres orders ASC
+    //    with NULLS LAST by default, so the bare `'asc'` string sorts
+    //    unattempted files LAST — the exact inverse of what fairness needs.
+    //  - `sort` flipped to 'desc'.
+    //  - the `{ id: 'asc' }` tiebreaker removed, reversed, or moved to another
+    //    column. It is what makes the order TOTAL: sorting on the nullable
+    //    column alone leaves big ties (every NULL ties with every other NULL,
+    //    and the upfront updateMany stamps one identical timestamp across the
+    //    whole batch) that Postgres may break arbitrarily and differently on
+    //    each run.
+    //  - the array collapsed to a bare object.
+    //
+    // 🔴 Earlier revisions of this file split those into extra tests that
+    // re-checked pieces of this same literal. They contributed no unique kill,
+    // and adding the tiebreaker silently made one of them VACUOUS: it asserted
+    // `orderBy` was not the one-element bare form, which a two-element array can
+    // never equal regardless of what is inside it. A test that reads as coverage
+    // while providing none is worse than no test, so they are gone rather than
+    // left to reassure the next reader.
     expect(mockDbWrite.modelFile.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         orderBy: [{ scanRequestedAt: { sort: 'asc', nulls: 'first' } }, { id: 'asc' }],
       })
     );
-  });
-
-  it('breaks ties on id ascending so the batch is a total, stable order', async () => {
-    mockDbWrite.modelFile.findMany.mockResolvedValue([]);
-
-    await runJob(scanFilesFallbackJob);
-
-    // Sorting on a single nullable column leaves big ties — every NULL ties with
-    // every other NULL, and the upfront updateMany stamps one identical
-    // timestamp across the whole batch. Postgres may break those ties
-    // arbitrarily and differently each run, so the tiebreaker is what makes the
-    // batch deterministic. Asserted by position and direction, not just presence.
-    const [args] = mockDbWrite.modelFile.findMany.mock.calls[0];
-    expect(args.orderBy).toHaveLength(2);
-    expect(args.orderBy[1]).toEqual({ id: 'asc' });
-    // Descending would prefer the NEWEST row inside a tie — the inverse of
-    // "longest-waiting first".
-    expect(args.orderBy[1]).not.toEqual({ id: 'desc' });
-  });
-
-  it('does not pass the bare asc form, which would sort nulls last', async () => {
-    mockDbWrite.modelFile.findMany.mockResolvedValue([]);
-
-    await runJob(scanFilesFallbackJob);
-
-    const [args] = mockDbWrite.modelFile.findMany.mock.calls[0];
-    expect(args.orderBy).not.toEqual([{ scanRequestedAt: 'asc' }]);
-    expect(args.orderBy).not.toEqual({ scanRequestedAt: 'asc' });
   });
 });
 
@@ -437,6 +428,28 @@ describe('scanFilesFallbackJob per-run budget', () => {
     expect(result).toEqual({ submitted: 1, failed: 0, skipped: 1 });
   });
 
+  it('counts time spent in the batch query against the budget', async () => {
+    // 🔴 This pins WHERE the run clock starts, which is the whole point of
+    // moving `runStartedAt` above the batch query. The job lock is already
+    // running during the select and the upfront stamp, so that time has to
+    // count; if the clock started afterwards, two DB round-trips would fall
+    // outside the bound and quietly overspend it.
+    //
+    // Observable precisely because the query is a mock: advancing the clock
+    // INSIDE it makes the query itself consume the entire budget. With the
+    // clock started before the query, nothing may be admitted; with it started
+    // after, elapsed time reads as 0 and everything is admitted.
+    mockDbWrite.modelFile.findMany.mockImplementation(async () => {
+      vi.setSystemTime(new Date(FIXED_NOW.getTime() + 180_001));
+      return twoFiles;
+    });
+
+    const result = await runJob(scanFilesFallbackJob);
+
+    expect(mockCreateModelFileScanRequest).not.toHaveBeenCalled();
+    expect(result).toEqual({ submitted: 0, failed: 0, skipped: 2 });
+  });
+
   it('does not skip when the run stays inside the budget', async () => {
     mockDbWrite.modelFile.findMany.mockResolvedValue(twoFiles);
     // Well inside 180s, and a different magnitude from PAST_BUDGET_MS.
@@ -450,19 +463,27 @@ describe('scanFilesFallbackJob per-run budget', () => {
     expect(result).toEqual({ submitted: 2, failed: 0, skipped: 0 });
   });
 
-  // 🔴 Run at TWO different batch sizes. One size is not enough: with a single
-  // fixture the asserted `batchSize` equals that fixture's own length, so a
-  // mutant hardcoding the literal survives — and simply picking a bigger single
-  // fixture just relocates the coincidence instead of removing it. Across two
-  // sizes no constant can satisfy both, so `batchSize` and `skipped` have to be
-  // derived. Within each case every asserted number is distinct as well, so no
-  // field can be satisfied by another field's value.
+  // 🔴 Run TWO cases in which EVERY asserted count differs. One case is not
+  // enough: with a single fixture the asserted `batchSize` equals that fixture's
+  // own length, so a mutant hardcoding the literal survives — and simply picking
+  // a bigger single fixture just relocates the coincidence instead of removing
+  // it. But varying only the SIZE is also not enough: it pins `batchSize` and
+  // `skipped` while leaving `submitted` and `failed` identical across cases, so
+  // hardcoding either of those still survives. (Measured — both did.) So the
+  // second case also fails its one attempted submission, which moves
+  // submitted 1→0 and failed 0→1. Across the pair every field takes two
+  // different values, so no constant satisfies both, and within each case all
+  // four counts are mutually distinct so no field can be satisfied by another
+  // field's value.
+  //
+  // This payload is the only signal that the queue is oversubscribed — the whole
+  // motivation for the bound — so a lie in it is not cosmetic.
   it.each([
-    { size: 3, expectedSkipped: 2 },
-    { size: 5, expectedSkipped: 4 },
+    { size: 5, firstAttemptFails: false, submitted: 1, failed: 0, skipped: 4 },
+    { size: 3, firstAttemptFails: true, submitted: 0, failed: 1, skipped: 2 },
   ])(
-    'reports the truncated run to Axiom so the bound is observable (batch of $size)',
-    async ({ size, expectedSkipped }) => {
+    'reports the truncated run to Axiom so the bound is observable (batch $size, failing=$firstAttemptFails)',
+    async ({ size, firstAttemptFails, submitted, failed, skipped }) => {
       mockDbWrite.modelFile.findMany.mockResolvedValue(
         Array.from({ length: size }, (_, i) => ({
           id: i + 1,
@@ -473,8 +494,11 @@ describe('scanFilesFallbackJob per-run budget', () => {
           },
         }))
       );
+      // Burn the budget on the first attempt either way; only its OUTCOME
+      // differs between the two cases.
       mockCreateModelFileScanRequest.mockImplementation(async () => {
         vi.setSystemTime(new Date(FIXED_NOW.getTime() + PAST_BUDGET_MS));
+        if (firstAttemptFails) throw new Error('orchestrator down');
       });
 
       await runJob(scanFilesFallbackJob);
@@ -483,9 +507,9 @@ describe('scanFilesFallbackJob per-run budget', () => {
         expect.objectContaining({
           type: 'warning',
           name: 'scan-files-fallback',
-          skipped: expectedSkipped,
-          submitted: 1,
-          failed: 0,
+          submitted,
+          failed,
+          skipped,
           batchSize: size,
           runBudgetMs: 180_000,
         }),

--- a/src/server/jobs/scan-files.ts
+++ b/src/server/jobs/scan-files.ts
@@ -82,6 +82,11 @@ const retryBackoffAt = () =>
 // pre-deprecation cron registry. The legacy `scan-files` job was removed when
 // the orchestrator path became the only scan path.
 export const scanFilesFallbackJob = createJob('scan-files-fallback', '*/5 * * * *', async () => {
+  // Started here, not after the batch query: the budget is sized against the
+  // job LOCK, which is already running during the select and the upfront stamp.
+  // Starting the clock later would let two DB round-trips fall outside the
+  // bound and quietly overspend it.
+  const runStartedAt = Date.now();
   const scanCutOff = dayjs().subtract(1, 'day').toDate();
 
   const files = await dbWrite.modelFile.findMany({
@@ -121,8 +126,6 @@ export const scanFilesFallbackJob = createJob('scan-files-fallback', '*/5 * * * 
     where: { id: { in: files.map((f) => f.id) } },
     data: { scanRequestedAt: new Date() },
   });
-
-  const runStartedAt = Date.now();
 
   let submitted = 0;
   let failed = 0;

--- a/src/server/jobs/scan-files.ts
+++ b/src/server/jobs/scan-files.ts
@@ -22,9 +22,17 @@ import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 // (giving up permanently) is the `exists=false` tombstone that left Published,
 // Public files permanently unscanned. Since we cannot bound the queue by dropping
 // work, we bound the WORK PER RUN instead, on three axes:
-//   1. fairness  — nulls-first ordering, so never-submitted files always win a slot
+//   1. fairness  — nulls-first ordering, so a file that has never been attempted
+//                  sorts ahead of every file already tried and backed off
 //   2. backoff   — a failing file costs a slot every 30 min, not every 5 min
 //   3. budget    — a fully-failing batch stops starting work before its lock expires
+//
+// 🔴 Bound 1 is NOT a guarantee that a new upload is scanned on the next tick.
+// The budget releases files it never attempted back to `scanRequestedAt = null`
+// (see below), so in a truncating run the NULL group holds those released files
+// as well as genuinely-new uploads, and they compete for the same slots. What
+// nulls-first buys is that neither of them ever queues behind the backed-off
+// failures — not that a new upload wins immediately.
 const SCAN_FALLBACK_CONCURRENCY = 10;
 const SCAN_FALLBACK_BATCH_SIZE = 200;
 
@@ -108,14 +116,22 @@ export const scanFilesFallbackJob = createJob('scan-files-fallback', '*/5 * * * 
         },
       },
     },
-    // Fairness: never-submitted files (scanRequestedAt IS NULL) first, then the
+    // Fairness: unattempted files (scanRequestedAt IS NULL) first, then the
     // longest-waiting. Without an explicit order the batch is whatever Postgres
     // hands back, so a failing population larger than SCAN_FALLBACK_BATCH_SIZE
     // can fill every batch with the same files and starve new uploads forever.
     // 🔴 `nulls: 'first'` is load-bearing and NOT the default — Postgres orders
     // ASC with NULLS LAST, so a bare `{ scanRequestedAt: 'asc' }` would sort
-    // never-submitted files LAST and make the starvation worse, not better.
-    orderBy: [{ scanRequestedAt: { sort: 'asc', nulls: 'first' } }],
+    // unattempted files LAST and make the starvation worse, not better.
+    //
+    // `id` is the tiebreaker, and it is what makes the order TOTAL. Sorting on
+    // scanRequestedAt alone leaves large ties that Postgres may break
+    // arbitrarily and differently run-to-run: every NULL ties with every other
+    // NULL, and the upfront updateMany below stamps one identical timestamp
+    // across the whole batch, so those rows tie too. `id` is unique and
+    // monotonic with insertion, so it both breaks every tie and makes "oldest
+    // first" real rather than incidental.
+    orderBy: [{ scanRequestedAt: { sort: 'asc', nulls: 'first' } }, { id: 'asc' }],
     take: SCAN_FALLBACK_BATCH_SIZE,
   });
 

--- a/src/server/jobs/scan-files.ts
+++ b/src/server/jobs/scan-files.ts
@@ -16,8 +16,67 @@ import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 // or whose scans stalled. Runs every 5 minutes, picks up files where:
 // - virusScanResult is still Pending
 // - scanRequestedAt is null (never submitted) or older than 1 day (stalled)
+//
+// This job is the ONLY drain on the pending-scan queue, and a file that cannot be
+// submitted stays in that queue indefinitely — by design, because the alternative
+// (giving up permanently) is the `exists=false` tombstone that left Published,
+// Public files permanently unscanned. Since we cannot bound the queue by dropping
+// work, we bound the WORK PER RUN instead, on three axes:
+//   1. fairness  — nulls-first ordering, so never-submitted files always win a slot
+//   2. backoff   — a failing file costs a slot every 30 min, not every 5 min
+//   3. budget    — a fully-failing batch stops starting work before its lock expires
 const SCAN_FALLBACK_CONCURRENCY = 10;
 const SCAN_FALLBACK_BATCH_SIZE = 200;
+
+/**
+ * How long a file waits after a non-`not-found` submission failure before this
+ * job considers it again.
+ *
+ * 🔴 ENCODING — do NOT "simplify" the `now() - 1 day + backoff` arithmetic below.
+ * This job's eligibility predicate is
+ *   `scanRequestedAt IS NULL OR scanRequestedAt < now() - 1 day`
+ * and it recomputes `now() - 1 day` on every run, so that cutoff is a MOVING
+ * target. Writing a timestamp of `now() - 1 day + BACKOFF` therefore parks the
+ * row just ahead of the cutoff and lets it become eligible again in exactly
+ * BACKOFF, while leaving the 24h stale-recovery semantics untouched for every
+ * other file. The two obvious "simplifications" are both wrong:
+ *   - `null`  — the previous behaviour. Re-eligible on the very next 5-minute
+ *     tick, and each retry can burn a concurrency slot for 60s inside the
+ *     submission pre-flight's resolve→sleep→resolve path. A permanently-failing
+ *     file is then retried 288x/day, forever, crowding out real work.
+ *   - `now()` — hides the file for the full 24h stale window, which is far too
+ *     long for the transient orchestrator/resolver outages that are the common
+ *     cause of submission failure.
+ */
+const SCAN_FALLBACK_RETRY_BACKOFF_MINUTES = 30;
+
+/**
+ * Wall-clock budget for a single run. Once spent, the job stops STARTING new
+ * submissions; files it never attempted are released for the next tick.
+ *
+ * Sized against the job's own lock, which is `lockExpiration: 5 * 60` = 300s
+ * (the `createJob` default — this job passes no options). The budget must leave
+ * room for the LAST task admitted to finish after it starts:
+ *   - the submission pre-flight sleeps a fixed 60s between its two
+ *     `resolveDownloadUrl` attempts, which is the one tail component this code
+ *     can actually bound, plus
+ *   - two resolver round-trips and the final DB write.
+ * 180s spends at most 60% of the lock on admitting work and reserves the
+ * remaining 120s for that tail.
+ *
+ * 🔴 This bounds work STARTED, not run duration: the resolver calls use `fetch`
+ * with no explicit timeout, so a hung request can still outlive the lock. The
+ * budget makes a fully-failing 200-file batch stop at ~180s instead of running
+ * 200/10 x 60s ~ 20 minutes against a 300s lock; it is not a hard deadline.
+ */
+const SCAN_FALLBACK_RUN_BUDGET_MS = 180 * 1000;
+
+/**
+ * Timestamp that re-opens a file for retry in ~SCAN_FALLBACK_RETRY_BACKOFF_MINUTES.
+ * See SCAN_FALLBACK_RETRY_BACKOFF_MINUTES for why it is expressed this way.
+ */
+const retryBackoffAt = () =>
+  dayjs().subtract(1, 'day').add(SCAN_FALLBACK_RETRY_BACKOFF_MINUTES, 'minute').toDate();
 
 // Job key kept as `scan-files-fallback` for operational continuity with the
 // pre-deprecation cron registry. The legacy `scan-files` job was removed when
@@ -44,6 +103,14 @@ export const scanFilesFallbackJob = createJob('scan-files-fallback', '*/5 * * * 
         },
       },
     },
+    // Fairness: never-submitted files (scanRequestedAt IS NULL) first, then the
+    // longest-waiting. Without an explicit order the batch is whatever Postgres
+    // hands back, so a failing population larger than SCAN_FALLBACK_BATCH_SIZE
+    // can fill every batch with the same files and starve new uploads forever.
+    // 🔴 `nulls: 'first'` is load-bearing and NOT the default — Postgres orders
+    // ASC with NULLS LAST, so a bare `{ scanRequestedAt: 'asc' }` would sort
+    // never-submitted files LAST and make the starvation worse, not better.
+    orderBy: [{ scanRequestedAt: { sort: 'asc', nulls: 'first' } }],
     take: SCAN_FALLBACK_BATCH_SIZE,
   });
 
@@ -55,16 +122,36 @@ export const scanFilesFallbackJob = createJob('scan-files-fallback', '*/5 * * * 
     data: { scanRequestedAt: new Date() },
   });
 
+  const runStartedAt = Date.now();
+
   let submitted = 0;
   let failed = 0;
+  let skipped = 0;
   await limitConcurrency(
     files.map((file) => async () => {
+      // Run budget: stop admitting new submissions once the run has spent its
+      // wall-clock allowance. This file was never attempted, so release it with
+      // scanRequestedAt=null — it should be immediately eligible on the next
+      // tick, NOT pushed behind the retry backoff (which is for files that were
+      // tried and failed). The upfront updateMany already stamped it, so
+      // without this reset it would be hidden for the full 24h stale window.
+      if (Date.now() - runStartedAt > SCAN_FALLBACK_RUN_BUDGET_MS) {
+        skipped++;
+        await dbWrite.modelFile
+          .update({ where: { id: file.id }, data: { scanRequestedAt: null } })
+          .catch(() => null);
+        return;
+      }
+
       // Defensive: a soft-deleted ModelVersion would null this out and crash
       // the whole batch. Skip and count as failed instead.
       if (!file.modelVersion) {
         failed++;
+        // Back off rather than reset: a soft-deleted ModelVersion never starts
+        // resolving again, so a null reset re-picks this file every 5 minutes
+        // forever. The 24h stale sweep still recovers it if that ever changes.
         await dbWrite.modelFile
-          .update({ where: { id: file.id }, data: { scanRequestedAt: null } })
+          .update({ where: { id: file.id }, data: { scanRequestedAt: retryBackoffAt() } })
           .catch(() => null);
         return;
       }
@@ -90,13 +177,16 @@ export const scanFilesFallbackJob = createJob('scan-files-fallback', '*/5 * * * 
             .update({ where: { id: file.id }, data: { exists: false } })
             .catch(() => null);
         } else {
-          // Reset scanRequestedAt so the next 5-min tick retries this file.
-          // Without this, the upfront updateMany above would leave it Pending
-          // for the 24h stale-cutoff window — too long for transient
-          // orchestrator outages, which are the common case for submission
+          // Transient failure: back this file off instead of resetting it, so
+          // the next attempt lands in ~SCAN_FALLBACK_RETRY_BACKOFF_MINUTES
+          // rather than on the next 5-min tick. A null reset here is what let a
+          // permanently-failing file re-enter every single run and burn a
+          // concurrency slot in the 60s pre-flight each time; the 24h
+          // stale-cutoff window on its own is too long for the transient
+          // orchestrator outages that are the common case for submission
           // failures (vs. workflow-level failures handled by D4).
           await dbWrite.modelFile
-            .update({ where: { id: file.id }, data: { scanRequestedAt: null } })
+            .update({ where: { id: file.id }, data: { scanRequestedAt: retryBackoffAt() } })
             .catch(() => null);
         }
         logToAxiom(
@@ -116,5 +206,24 @@ export const scanFilesFallbackJob = createJob('scan-files-fallback', '*/5 * * * 
     SCAN_FALLBACK_CONCURRENCY
   );
 
-  return { submitted, failed };
+  // Only emitted when the budget actually truncated a run — i.e. the queue is
+  // oversubscribed for the batch size. Silent on a healthy run.
+  if (skipped > 0) {
+    logToAxiom(
+      {
+        type: 'warning',
+        name: 'scan-files-fallback',
+        message: `Run budget exhausted; ${skipped} file(s) deferred to the next tick`,
+        submitted,
+        failed,
+        skipped,
+        batchSize: files.length,
+        runBudgetMs: SCAN_FALLBACK_RUN_BUDGET_MS,
+        elapsedMs: Date.now() - runStartedAt,
+      },
+      'webhooks'
+    ).catch();
+  }
+
+  return { submitted, failed, skipped };
 });


### PR DESCRIPTION
## Why

`scanFilesFallbackJob` is the only thing that drains the pending-scan queue.

PR #4221 fixed a real defect: the submission pre-flight classified *any* resolver failure (5xx, timeout, rate-limit, DNS, transport reject) as `not-found`, and the job wrote `exists = false`. That tombstone removes the file from this job's `WHERE` clause **permanently**, so Published, Public files ended up downloadable and never scanned. After #4221 only a positively-reported 404/410 tombstones.

That fix was right, but it removed the only drain on the queue and did not add a bounded one. A file that cannot be submitted now stays in the queue indefinitely — deliberately, because the alternative is the tombstone we just removed. So the queue can no longer be bounded by dropping work, and the **work per run** has to be bounded instead. Today it is not, in three ways:

1. **No fairness ordering.** The batch `findMany` has no `orderBy`, so the rows are whatever Postgres returns. Once the failing population is larger than `SCAN_FALLBACK_BATCH_SIZE` (200), the same failing files can fill every batch and newly-uploaded files are never scanned at all.
2. **No backoff.** Both retry paths reset `scanRequestedAt` to `null`, which makes the file eligible again on the very next 5-minute tick. Each retry can burn a concurrency slot for 60s inside the pre-flight's `resolve → sleep 60s → resolve` path, so a permanently-failing file is retried 288×/day forever.
3. **No per-run bound.** A fully-failing 200-file batch takes `200/10 × 60s ≈ 20 minutes` against a 300s job lock.

Not urgent today — the eligible set is currently ~20 against a batch size of 200, so nothing is being starved. It becomes reachable as soon as the eligible set approaches 200, which a planned backfill of ~261 existing tombstones would do.

## What changed

All three in `src/server/jobs/scan-files.ts`.

**1. Fairness ordering**

```ts
orderBy: [{ scanRequestedAt: { sort: 'asc', nulls: 'first' } }, { id: 'asc' }],
```

Unattempted files first, then longest-waiting. The `nulls` option is load-bearing rather than cosmetic: Postgres orders `ASC` with `NULLS LAST` by default, so a bare `{ scanRequestedAt: 'asc' }` would sort unattempted files **last** and make the starvation worse.

`id` is the tiebreaker and it is what makes the order **total**. Sorting on the nullable column alone leaves large ties that Postgres may break arbitrarily and differently run-to-run: every NULL ties with every other NULL, and the upfront `updateMany` stamps one identical timestamp across the whole batch, so those rows tie too.

**What this does and does not buy.** It does *not* guarantee a new upload is scanned on the next tick. The budget releases unattempted files back to `scanRequestedAt = null`, so in a truncating run the NULL group holds both released files and genuinely-new uploads, and they compete for the same slots. What nulls-first buys is that neither ever queues behind the backed-off failures.

**2. 30-minute backoff on transient failure**

The two `scanRequestedAt: null` resets become a computed timestamp of `now() - 1 day + 30 min`. The eligibility predicate is `scanRequestedAt IS NULL OR scanRequestedAt < now() - 1 day` and it recomputes that cutoff every run, so parking the row just ahead of the moving cutoff re-opens it in exactly 30 minutes while leaving the 24h stale-recovery semantics untouched for every other file. The encoding is non-obvious, so it carries a comment explaining why it is neither `null` (no backoff at all) nor `now()` (hidden for a full 24h).

Applied to **both** reset sites — including the defensive `!file.modelVersion` branch.

> **Correction.** An earlier version of this description justified that second site by saying a soft-deleted `ModelVersion` left the file re-picked every 5 minutes. **That was wrong.** `ModelFile.modelVersion` is a *required* relation with `onDelete: Cascade`, so a deleted `ModelVersion` takes the `ModelFile` row with it rather than leaving a null relation, and a `status`-based soft delete does not null the relation object either — such a file goes down the normal submission path. Prisma types the field non-null: deleting the guard and dereferencing the relation unguarded typechecks with 0 errors. So this branch is unreachable short of FK corruption, and the test fixture for it is a shape the real query cannot produce. The backoff there is **defence-in-depth on an unreachable branch**, not a fix for observed churn. Keeping it because it is harmless and the branch already existed; the claim about its impact was the error.

**3. 180s per-run wall-clock budget**

Before each file's submission, if the run has spent its budget the file is counted as `skipped`, released with `scanRequestedAt = null` (**not** the backoff — it was never attempted, so it should be immediately eligible), and returned without calling `createModelFileScanRequest`.

180s is sized against the 300s `lockExpiration`: it spends at most 60% of the lock admitting work and reserves 120s for the last-admitted task's tail, whose one genuinely bounded component is the pre-flight's fixed 60s sleep. This bounds work **started**, not run duration — the resolver calls use `fetch` with no explicit timeout, so a hung request can still outlive the lock. It turns the ~20-minute worst case into ~180s.

The job now returns `skipped` alongside `submitted`/`failed`, and emits a single run-level warning when the budget actually truncates a run, so an oversubscribed queue is visible rather than silent.

## Deliberately not doing

**No attempt cap.** Giving up on a file permanently is exactly what the `exists = false` tombstone did, and that is the defect #4221 removed. A file that cannot be scanned must keep its place in the queue; the fix is to make it cost less, not to drop it.

**No schema migration.** All three bounds are expressible in the existing `scanRequestedAt` column, so nothing here needs a column, an attempt counter, or a `metadata` stash. Migrations in this repo are applied by hand per environment, so a migration would have left this PR inert until someone ran the SQL.

## Testing

Extends the existing `scan-files` suite, following its established mocking style. 19 tests, all green.

Real regression coverage — **red at `origin/main`, green at HEAD**, each failing at base for the bound's own reason:

| Test | Fails at base on |
|---|---|
| backs off a null-`modelVersion` file instead of resetting | `scanRequestedAt` `null` vs the backoff instant |
| transient failure backs off `scanRequestedAt` | same |
| `code=transient` backs off (no tombstone) | same |
| sorts unattempted files first, then oldest id | no `orderBy` passed at all |
| budget stops starting new submissions | submitted 2 files instead of 1 |
| budget-skipped file released with `null`, not the backoff | the release write never happened |
| truncated run reported for observability | the warning was never emitted |
| batch-query time counts against the budget | all files admitted instead of none |

Green at base — **invariant guards, not regression coverage**, listed separately because they prove nothing about this change:

- `not-found` still tombstones via `exists: false` — the #4221 behaviour. Its tombstone assertions pass at base; only the added `skipped` key in the return shape differs.
- empty-queue early return; the upfront batch stamp; no budget warning on a clean run.

**Mutation results.** 41 mutants, each isolated to the narrowest expression that can be wrong. **39 killed, 2 survivors**, each survivor classified below. The battery is bracketed by two controls: a no-op comment edit that must survive (so a survivor is reachable at all, and the kills are not a harness artifact) and a broken `submitted++` that must die (so the harness can go red). Both behaved.

A representative sample of the kills, with the assertion each died on:

| Mutant | Died on |
|---|---|
| `nulls: 'first'` → `'last'` | `"nulls": "first"` vs `"last"` in the `orderBy` |
| object form → bare `'asc'` | the consolidated whole-`orderBy` array assertion |
| drop `.add(30, 'minute')` | expected `12:37:13Z`, received `12:07:13Z` |
| drop `.subtract(1, 'day')` | expected `2026-03-04T12:37:13Z`, received `2026-03-05T...` |
| transient site → `null` | expected backoff instant, received `null` (only the 2 transient tests) |
| `!modelVersion` site → `null` | same, and **only** that test — the sites are independently covered |
| tiebreaker removed / reversed / wrong field | the consolidated whole-`orderBy` array assertion |
| budget → 120s / 179s / 181s / 200s / 300s | one of the three boundary cases |
| `>` → `>=` | "still submits at exactly the budget" |
| budget skip writes backoff instead of `null` | expected `null`, received the backoff instant |
| budget check removed | `expected 1 call, got 2` |
| `batchSize` hardcoded to 2, or to 5 | the other batch size's case |
| `not-found` classification inverted / tombstone deleted | the #4221 tombstone assertions |

**The two survivors, classified honestly:**

1. **The no-op control** — expected to survive; that is its job.
2. **`runBudgetMs: SCAN_FALLBACK_RUN_BUDGET_MS` → the literal `180_000`.** A genuinely **equivalent mutant**: the literal equals the constant's own value, so the mutation is semantically inert and no test can distinguish it. Now that the budget's value is pinned behaviourally by the boundary trio, killing this would mean contriving a test for a difference that does not exist, so it is left alive and named here.

No genuinely-uncovered mutant remains. Two earlier survivors were closed after review: the run-clock placement is now tested (advancing the clock inside the `findMany` mock makes the batch query consume the whole budget, which is observable precisely because the query is a mock), and the warning payload's `submitted`/`failed` fields — which a size-only parameterisation left hardcodable — are now pinned by a second case that fails its attempted submission.

The mutation harness asserts an exact occurrence count before replacing, which caught one mutant that would otherwise have silently matched a comment instead of the code. Fixture values are kept distinct from the constants they exercise: the clock is pinned to a non-round instant so the expected backoff cannot coincide with `now`, `now - 1 day`, or a round value; the budget is pinned by a boundary trio rather than by a single overshoot; and the observability payload is asserted across two cases in which every field — batch size, skipped, submitted and failed — takes a different value, so no hardcoded constant can satisfy both.

## Known limitations

- **The budget does not consult the job's cancellation channel.** `createJob` passes the function a context with `checkIfCanceled()`, wired to the request-close path that also releases the job lock. This job ignores that argument entirely and always has. So on a client disconnect the lock frees while the loop runs on to its own 180s budget. Pre-existing rather than introduced here — but this PR is what adds a deadline, and hanging it on the real cancellation signal would have been the more complete fix. Recorded as known; not addressed in this PR.
- **`elapsedMs` in the warning payload is unpinned.** Hardcoding it to `0`, negating the subtraction, substituting the budget constant, and deleting the field outright all survive the suite — the `expect.objectContaining` never inspects it (nor the `message` string). Pre-existing, and it also means the commit subject "pin the *whole* warning payload" overstates: the four counts are pinned, `elapsedMs` and `message` are not. It is deterministic under the fixed clock, so it is pinnable; not done here.
- **The `if (skipped > 0)` emit guard is pinned only on its false side.** Mutating it to `skipped > 1` survives: every test asserting the warning fires skips 2 or 4, and the two tests that skip exactly 1 never assert that `logToAxiom` was called. A run deferring exactly one file could go silent with the suite green. Pre-existing; the budget comparison itself does have an explicit boundary pair, this guard's 0→1 boundary does not.

**Typecheck, stated at the scope actually measured:** 0 errors at `origin/main` and 0 on this branch under the repo's own `pnpm typecheck`, validated with a negative control that reported `2 type error(s)` and exited non-zero. 🔴 That program **excludes `src/**/__tests__/**`**, so it says nothing about this PR's test file. The tests tier (`tsconfig.tests.json`, the one `scripts/ci/typecheck-tests-gate.mjs` runs) was therefore checked separately, also with a working control (927 → 928 errors, the extra one naming `src/server/jobs/__tests__/scan-files.test.ts`): the changed test file contributes **zero**.

**`NULLS FIRST` verification:** confirmed against a real Postgres with Prisma query logging on the same client version this repo installs. The emitted SQL is `ORDER BY "scanRequestedAt" ASC NULLS FIRST`; a control arm using the bare form emitted plain `ASC`, and a direct SQL comparison confirmed bare `ASC` places `NULL` last while `ASC NULLS FIRST` places it first — i.e. the inverse of what fairness needs.

