### PR TITLE
fix(images): v1 model-version endpoints no longer serve meta a creator hid

### DIFF
--- a/src/server/services/__tests__/images-for-model-version-hidemeta.test.ts
+++ b/src/server/services/__tests__/images-for-model-version-hidemeta.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * `getImagesForModelVersion` feeds the public v1 model-version endpoints, which
+ * spread the raw row into the response. Nothing downstream re-filters it, so the
+ * `hideMeta` decision has to be made in SQL and the query text is the only
+ * observable — a fixture-driven assertion would describe the fixture instead.
+ *
+ * It gates the column rather than dropping it, unlike `getImagesByEntity` and
+ * `getEntityCoverImage`: `images[].meta` is a documented v1 field, so dropping it
+ * breaks every caller rather than the hidden rows. Filtering the rows out — what
+ * `getAllImages` does, where `include: ['meta']` is a caller-facing filter rather
+ * than a redaction — would silently shorten the `images` array instead.
+ */
+
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+import { getImagesForModelVersion } from '../image.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const MODEL_VERSION_ID = 1;
+
+/**
+ * Removes every expression that reads `i.meta` legitimately — the gated
+ * projection, the two derived booleans, the `onSite` fragment and the `remixOfId`
+ * extraction. Anything still naming the column afterwards is an ungated
+ * projection, in whatever spelling it was reintroduced.
+ */
+function stripMetaReaders(sql: string) {
+  return sql
+    .replace(/CASE\s+WHEN\s+i\."hideMeta"\s+THEN\s+NULL\s+ELSE\s+i\.meta\s+END\s+AS\s+meta/g, '')
+    .replace(/\(\s*CASE[\s\S]*?END\s*\)/g, '')
+    .replace(/\(\s*i\.meta[\s\S]*?\)\s*as\s+"onSite"/g, '')
+    .replace(/i\."meta"[^,]*as\s+"remixOfId"/g, '');
+}
+
+/** Runs the service and returns the query text it built. */
+async function captureQuery(include: Array<'meta' | 'tags'>) {
+  const queryRaw = dbMock.dbRead.$queryRaw as unknown as ReturnType<typeof vi.fn>;
+  let query: { strings: string[] } | undefined;
+  queryRaw.mockImplementation((q: { strings: string[] }) => {
+    query = q;
+    return Promise.resolve([]);
+  });
+
+  await getImagesForModelVersion({ modelVersionIds: [MODEL_VERSION_ID], include });
+
+  expect(query, 'getImagesForModelVersion never issued its query').toBeDefined();
+  const sql = (query as { strings: string[] }).strings.join('?');
+
+  // The negative assertions below hold over any text, the empty string included.
+  expect(sql, 'captured a query other than the model-version one').toContain('t."modelVersionId"');
+
+  return sql;
+}
+
+describe('getImagesForModelVersion withholds meta the creator chose to hide', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('gates the projected meta column on hideMeta', async () => {
+    expect(
+      await captureQuery(['meta']),
+      'getImagesForModelVersion projects meta without consulting hideMeta'
+    ).toMatch(/CASE\s+WHEN\s+i\."hideMeta"\s+THEN\s+NULL\s+ELSE\s+i\.meta\s+END\s+AS\s+meta\b/);
+  });
+
+  // Both branches, because the `include: []` one reaches far more callers — the
+  // day-long `imagesForModelVersionsCache`, the model cards, vault and webhooks.
+  it('projects the column nowhere else, with or without include', async () => {
+    for (const include of [['meta'], []] as Array<Array<'meta' | 'tags'>>) {
+      const where = `include: ${JSON.stringify(include)}`;
+      const rest = stripMetaReaders(await captureQuery(include));
+
+      expect(rest, `${where} — selects the meta column ungated, which ships to the client`).not.toMatch(
+        /\bmeta\b/
+      );
+
+      // A wildcard names no column, so the assertion above passes over `i.*`
+      // while every column including meta ships.
+      expect(rest, `${where} — selects whole rows, which carries meta past the check above`).not.toMatch(
+        /\bi\.\*/
+      );
+    }
+  });
+
+  it('derives hasMeta from hideMeta, matching the other read paths', async () => {
+    const sql = await captureQuery(['meta']);
+
+    // Drop the `i."hideMeta"` term from the CASE and this goes red naming it —
+    // a `hasMeta` that ignores the flag is the same leak one level down.
+    expect(sql).toMatch(/OR i\."hideMeta" THEN FALSE[\s\S]{0,80}?AS "hasMeta"/);
+    expect(sql).toMatch(/AND NOT i\."hideMeta"[\s\S]{0,160}?AS "hasPositivePrompt"/);
+  });
+
+  // The redaction is per row, not per result set. Adopting `getAllImages`' filter
+  // here would drop hidden-meta images out of the public `images` array entirely,
+  // changing its length for every version that has one.
+  it('redacts the column rather than filtering the row out', async () => {
+    const sql = await captureQuery(['meta']);
+    const rowSelection = sql.slice(0, sql.indexOf('LIMIT'));
+
+    expect(rowSelection, 'sliced past the row-selection predicate').toContain('p."publishedAt"');
+    expect(rowSelection, 'hidden-meta rows are excluded from the result set').not.toMatch(
+      /hideMeta/
+    );
+  });
+});

--- a/src/server/services/__tests__/images-for-model-version-hidemeta.test.ts
+++ b/src/server/services/__tests__/images-for-model-version-hidemeta.test.ts
@@ -79,15 +79,17 @@ describe('getImagesForModelVersion withholds meta the creator chose to hide', ()
       const where = `include: ${JSON.stringify(include)}`;
       const rest = stripMetaReaders(await captureQuery(include));
 
-      expect(rest, `${where} — selects the meta column ungated, which ships to the client`).not.toMatch(
-        /\bmeta\b/
-      );
+      expect(
+        rest,
+        `${where} — selects the meta column ungated, which ships to the client`
+      ).not.toMatch(/\bmeta\b/);
 
       // A wildcard names no column, so the assertion above passes over `i.*`
       // while every column including meta ships.
-      expect(rest, `${where} — selects whole rows, which carries meta past the check above`).not.toMatch(
-        /\bi\.\*/
-      );
+      expect(
+        rest,
+        `${where} — selects whole rows, which carries meta past the check above`
+      ).not.toMatch(/\bi\.\*/);
     }
   });
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -6361,7 +6361,7 @@ export type ImagesForModelVersions = {
   height: number;
   hash: string;
   modelVersionId: number;
-  // meta: ImageMetaProps | null;
+  meta?: ImageMetaProps | null;
   type: MediaType;
   metadata: ImageMetadata | VideoMetadata | null;
   tags?: number[];
@@ -6489,7 +6489,11 @@ export const getImagesForModelVersion = async ({
       i.minor,
       i.poi,
       t."modelVersionId",
-      ${Prisma.raw(include.includes('meta') ? 'i.meta,' : '')}
+      ${Prisma.raw(
+        include.includes('meta')
+          ? 'CASE WHEN i."hideMeta" THEN NULL ELSE i.meta END AS meta,'
+          : ''
+      )}
       p."availability",
       (
         CASE
@@ -6592,6 +6596,8 @@ export const imagesForModelVersionsCache = createCachedObject<CachedImagesForMod
     // the lag-aware helper so a cache miss right after image upload doesn't
     // poison the entry with `images: []` for a full TTL cycle.
     const db = fromWrite ? dbWrite : await getDbWithoutLagBatch('modelVersion', ids);
+    // No `include: ['meta']`: these rows reach the Meilisearch model document and
+    // the model.getAll wire, and GETALL_DROPPED_IMAGE_FIELDS does not drop meta.
     const images = await getImagesForModelVersion({
       modelVersionIds: ids,
       imagesPerVersion: 20,


### PR DESCRIPTION
Closes [868kux3xf](https://app.clickup.com/t/8459928/868kux3xf).

## The problem

`getImagesForModelVersion` selected `i.meta` as a raw, ungated column whenever the caller passed `include: ['meta']`. The two callers that pass it are both public v1 endpoints — `/api/v1/model-versions/[id]` and `/api/v1/model-versions/by-hash` — and both spread the row straight into their JSON response.

So an image whose creator set `hideMeta` had its generation metadata returned anyway, sitting next to the `hasMeta: false` that was supposed to describe it. The two derived booleans on the same row (`hasMeta`, `hasPositivePrompt`) both consulted `hideMeta` correctly; only the raw column did not. Confirmed against production before the fix.

This is the third of the same class: #4233 (`getEntityCoverImage`) and #4241 (`getImagesByEntity`) closed the other two.

## Why gate the column instead of dropping it

Both of those sibling fixes dropped the `meta` column outright, and the ticket suggested a third option — copy `getAllImages`, which filters the rows out. Neither fits this call site:

- **Dropping the column** would remove `images[].meta` from the public v1 response for *every* image. It is a documented field that external tooling reads, so this breaks every caller rather than the hidden rows.
- **Filtering the rows** would silently shorten the `images` array for any version with a hidden-meta showcase image. At `getAllImages:1736` that behaviour is correct because `include: ['meta']` there is the caller-facing `withMeta` *filter* ("only images that have prompts"), not a redaction. It is the wrong precedent for this path.

Gating per row changes only the hidden rows, and `meta: null` is a shape consumers already handle — the column was already `null` for images with no stored metadata. It is also the same construction `imageMetaCache` (`redis/caches.ts`) already uses for this exact decision, which is what feeds `/api/v1/images`.

No owner or moderator bypass: `hideMeta` is absolute everywhere else in this file, and neither endpoint threads a session into this call anyway.

## Also here

- `ImagesForModelVersions` had `// meta: ImageMetaProps | null;` **commented out**, so the type denied a column the SQL selected. That is why the `...image` spread in `prepareModelVersionResponse` carried it invisibly and nothing caught it. Declared `meta?:` — optional, because only these two of the six callers ask for it.
- One comment on `imagesForModelVersionsCache.lookupFn` recording that its omission of `include: ['meta']` is deliberate. Making the field legal on the type removed the error that would otherwise stop someone adding it there, and those rows reach the Meilisearch model document and the `model.getAll` wire, neither of which drops `meta`.

## Test

New `images-for-model-version-hidemeta.test.ts`, matching the two siblings. The gate is only observable as query text, so that is what it asserts.

Verified by mutation rather than by passing — each of these was run against the suite:

| mutation | result |
| --- | --- |
| revert to ungated `i.meta` | 2 red |
| ungated `i.meta` in the `else` branch only | 1 red |
| ungated in both branches | 2 red |
| second ungated projection beside the gate | 1 red |
| row filter instead of the column gate | 1 red |

The `else`-branch case matters most: that branch feeds far more callers than this fix does (the day-long cache, model cards, vault, webhooks), so the assertions run over both the `include: ['meta']` and `include: []` query text.

The last row is what keeps the row-vs-column decision from being undone silently — it pins that the row-selection predicate never mentions `hideMeta`.

## Checks

- `pnpm run typecheck` — 0 errors
- `eslint` on both changed files — 0 issues in the changed regions; the new test file is clean (the 27 pre-existing warnings in `image.service.ts` are all elsewhere in the file)
- Targeted suites, including both siblings and the v1 endpoint test — 51 passed

## Note for deploy

`/api/v1/model-versions/[id]` stamps `s-maxage=300, stale-while-revalidate=150` for anonymous requests, so pre-fix bodies can be served from the edge for a few minutes after this lands. Self-healing; a targeted purge is the lever if that window matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeeJXStZA5ebfrCMVsxrRn
