### PR TITLE
fix(dev-server): the log window was below what a passing run emits, and one pid file was shared by every daemon

### DIFF
--- a/.claude/skills/dev-server/.gitignore
+++ b/.claude/skills/dev-server/.gitignore
@@ -1,3 +1,6 @@
 daemon.pid
+# A daemon on a non-default port writes daemon-<port>.pid — same file, scoped so two daemons
+# cannot overwrite each other's. See scripts/daemon-port.mjs.
+daemon-*.pid
 .env
 env-modes.local

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -83,7 +83,13 @@ of them can disagree about where it is. Until 2026-08-19 the daemon did not read
 and setting it pointed the client at a port nothing was serving.
 
 The variable is only a default for the daemon; an explicit `node scripts/daemon.mjs --port <port>` still
-wins. Each daemon owns the shared `daemon.pid`, so the last one started is the one that file names.
+wins.
+
+**Each daemon has its own pid file, named for its port.** The one on the default port keeps plain
+`daemon.pid` — so the `readlink` check above is unchanged — and every other daemon writes
+`daemon-<port>.pid` beside it. Until 2026-08-21 they shared one file, so standing a probe daemon up
+overwrote the record of the shared one and stopping the probe **deleted** it, leaving
+`cat daemon.pid` with nothing to read while the daemon it had named was still serving.
 
 ## Never curl a dev port — `probe` instead
 
@@ -323,11 +329,22 @@ Things worth knowing before you rely on it:
   nonzero telling you to re-request — it will not poll forever against a daemon that has forgotten
   you.
 - **Position is exact**, not an estimate: it is the index in one ordered list.
-- **The log window holds the last 2000 lines, and says when it clipped.** A run that emits
+- **The log window holds the last 12,000 lines, and says when it clipped.** A run that emits
   more than that loses its oldest lines, so a late `test wait` or a `test logs` read can be a
   fragment. Both waiters print `WARNING: this log is INCOMPLETE …` naming how many lines went,
   and `logsDropped` is on the run view — a non-zero value means do not quote what you see as
   the whole run. A live waiter that has been streaming from the start is unaffected.
+  A fully passing full-suite run measured 4,793 lines, so a clip on a green run means the suite
+  has grown a lot; on a run with failures it is ordinary, and it is the case the warning is for.
+- **Only the 8 most recent finished runs keep their lines.** Older ones keep their record —
+  status, exit code, the counts `test list` shows, up to 50 of them — and their lines are
+  released and counted into `logsDropped`, so an aged-out run reads as INCOMPLETE rather than
+  as an empty log that looks whole. Fetch a run's logs while it is recent.
+- **A daemon sweeps orphaned capture files at start.** A run's output goes to
+  `/tmp/civitai-test-run-<pid>-<uuid>.log`, released when the run ends — but a daemon killed with
+  `-9`, or a crash mid-run, leaves one behind (~675 KB for a full suite). The sweep removes only
+  those whose `<pid>` names a process that is **gone**; a live owner's file is another running
+  capture, possibly another developer's, and is left alone.
 - **The exit code is `exitCodeFor`'s, in both waiters.** `test wait` and `pnpm run test:unit:run`
   read the same rule, so a run killed by a signal reports 1 from either, never a shell 255.
 

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -7,9 +7,13 @@
 import { spawn, execSync } from 'child_process';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { existsSync, writeFileSync } from 'fs';
 import { exitCodeFor, isTerminal as isTerminalStatus } from './scripts/test-queue.mjs';
-import { resolveDaemonUrl } from './scripts/daemon-port.mjs';
+import {
+  removeStalePidFile,
+  resolveDaemonPidFile,
+  resolveDaemonUrl,
+} from './scripts/daemon-port.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -26,7 +30,9 @@ function findProjectRoot(startDir) {
 }
 
 const projectRoot = findProjectRoot(__dirname);
-const pidFile = resolve(__dirname, 'daemon.pid');
+// Scoped to the port this invocation targets: the shared daemon and a daemon on some probe port
+// are two processes and no longer share one file. See pidFileFor in scripts/daemon-port.mjs.
+const pidFile = resolveDaemonPidFile(__dirname);
 const serverScript = resolve(__dirname, 'scripts/daemon.mjs');
 
 // Overridable via DEV_DAEMON_PORT, so a second daemon can be exercised without touching the
@@ -518,9 +524,11 @@ async function cmdShutdown() {
     process.exit(1);
   }
   console.log('Daemon shutdown');
-  if (existsSync(pidFile)) {
-    unlinkSync(pidFile);
-  }
+  // The daemon removes its own pid file on the way out; this is the leftover case — a pid file
+  // with nothing behind it — so it removes one only once the process it names is gone. A daemon
+  // that accepted the shutdown and then hung in `stopSpokeApps()` is still serving, and deleting
+  // the record of a running process is the damage this whole change is about.
+  removeStalePidFile(pidFile);
 }
 
 function samePath(a, b) {

--- a/.claude/skills/dev-server/console.mjs
+++ b/.claude/skills/dev-server/console.mjs
@@ -12,7 +12,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import readline from 'readline';
-import { resolveDaemonUrl } from './scripts/daemon-port.mjs';
+import { resolveDaemonPidFile, resolveDaemonUrl } from './scripts/daemon-port.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -26,7 +26,9 @@ function findProjectRoot(startDir) {
 }
 
 const projectRoot = findProjectRoot(__dirname);
-const pidFile = resolve(__dirname, 'daemon.pid');
+// Scoped to the port this invocation targets, like cli.mjs — a console pointed at a probe daemon
+// must not overwrite the shared daemon's pid file when it starts one.
+const pidFile = resolveDaemonPidFile(__dirname);
 const serverScript = resolve(__dirname, 'scripts/daemon.mjs');
 
 // The whole decision — port included — is made in scripts/daemon-port.mjs, the same module the

--- a/.claude/skills/dev-server/scripts/daemon-port.mjs
+++ b/.claude/skills/dev-server/scripts/daemon-port.mjs
@@ -18,6 +18,9 @@
  * must pin the expected value as a literal rather than derive it from this module.
  */
 
+import { readFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+
 export const DEFAULT_DAEMON_PORT = 9444;
 
 /**
@@ -63,4 +66,133 @@ export function resolveDaemonPort(env = process.env) {
  */
 export function resolveDaemonUrl(env = process.env) {
   return `http://127.0.0.1:${resolveDaemonPort(env)}`;
+}
+
+/**
+ * Where a daemon on `port` records its pid — SCOPED BY PORT, because the file names one process.
+ *
+ * It used to be one shared `daemon.pid` for every daemon on the box, and the sharing is not a
+ * tidiness problem, it is a correctness one. Measured on this repo before the change: with a
+ * sentinel written to `daemon.pid`, `DEV_DAEMON_PORT=<free> cli.mjs status` replaced it with the
+ * probe daemon's pid, and `DEV_DAEMON_PORT=<free> cli.mjs shutdown` then deleted it — so
+ * `readlink -f /proc/$(cat daemon.pid)/exe`, the check SKILL.md tells people to run before
+ * trusting a session, was pointed at a second daemon and then at nothing at all.
+ *
+ * That measurement is also why an ownership check ALONE would not have fixed it: by shutdown time
+ * the probe daemon genuinely owned the shared file, so "only delete a file that names me" would
+ * have deleted it exactly the same. The pid file has to stop being shared first; the ownership
+ * check below is what covers what remains (a stale file, or a second daemon told to use the same
+ * port explicitly).
+ *
+ * The DEFAULT port keeps the plain `daemon.pid` name, so the documented recipe and this repo's
+ * `.gitignore` entry both keep working — only the extra daemons get a new file.
+ *
+ * @param {string} skillDir — the dev-server skill directory
+ * @param {number} port
+ * @returns {string}
+ */
+export function pidFileFor(skillDir, port) {
+  const name = port === DEFAULT_DAEMON_PORT ? 'daemon.pid' : `daemon-${port}.pid`;
+  return join(skillDir, name);
+}
+
+/**
+ * The pid file for the daemon THIS environment points at — the client-side pair of
+ * `resolveDaemonUrl`, so a client never does arithmetic on a port or spells a filename itself.
+ *
+ * @param {string} skillDir
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {string}
+ */
+export function resolveDaemonPidFile(skillDir, env = process.env) {
+  return pidFileFor(skillDir, resolveDaemonPort(env));
+}
+
+/**
+ * The pid a pid file names, or null if there isn't one to be had.
+ *
+ * Null for absent, unreadable, and for contents that are not a pid — a truncated write, or the
+ * file having been replaced by something else. A caller acts on this, so guessing a number out of
+ * garbage is how a live process gets treated as a dead one.
+ *
+ * @param {string} path
+ * @returns {number | null}
+ */
+export function readPidFile(path) {
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const pid = Number(trimmed);
+  return pid > 0 ? pid : null;
+}
+
+/**
+ * Is this pid a process that exists right now?
+ *
+ * Signal 0 checks for existence without delivering anything. EPERM means the process is there and
+ * belongs to somebody else — which is still ALIVE, and the answer that matters here, since the
+ * whole point is not to clean up after a process that is still running. Reading EPERM as "gone" is
+ * the one wrong answer that does damage.
+ *
+ * @param {number} pid
+ * @returns {boolean}
+ */
+export function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === 'EPERM';
+  }
+}
+
+/**
+ * Remove a pid file only if it names `ownerPid`.
+ *
+ * For a daemon removing its OWN file on the way out. A daemon that finds another pid there is
+ * looking at a file it does not own — deleting it is how the last daemon to stop takes the
+ * record of the one still running with it.
+ *
+ * @param {string} path
+ * @param {number} ownerPid
+ * @returns {boolean} whether the file was removed
+ */
+export function removePidFileIfOwned(path, ownerPid) {
+  if (readPidFile(path) !== ownerPid) return false;
+  return unlink(path);
+}
+
+/**
+ * Remove a pid file only if the process it names is GONE.
+ *
+ * For a client tidying up after a daemon — it cannot know the daemon's pid, so "names me" is not a
+ * question it can ask, but "is there anything behind this" is. A live pid here is not a leftover
+ * and must be left alone: the pre-2026-08-21 `cli.mjs shutdown` unlinked whatever it found, which
+ * on a box running a second daemon was the record of the first.
+ *
+ * A file that is not there, and one holding something that is not a pid, are both removed — the
+ * second is a leftover in a broken state, and no process can be behind it.
+ *
+ * @param {string} path
+ * @returns {boolean} whether the file was removed
+ */
+export function removeStalePidFile(path) {
+  const pid = readPidFile(path);
+  if (pid !== null && isPidAlive(pid)) return false;
+  return unlink(path);
+}
+
+function unlink(path) {
+  try {
+    unlinkSync(path);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -17,14 +17,19 @@
 
 import http from 'http';
 import { spawn, execSync } from 'child_process';
-import { existsSync, readFileSync, writeFileSync, unlinkSync, statSync, readdirSync, rmSync, realpathSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, statSync, readdirSync, rmSync, realpathSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
 import { access } from 'fs/promises';
 import { isPortFree } from './port-probe.mjs';
-import { parsePort, resolveDaemonPort } from './daemon-port.mjs';
-import { TestQueue } from './test-queue.mjs';
+import {
+  parsePort,
+  pidFileFor,
+  removePidFileIfOwned,
+  resolveDaemonPort,
+} from './daemon-port.mjs';
+import { TestQueue, sweepStaleCaptures } from './test-queue.mjs';
 import {
   loadModeDefinitions,
   resolveSessionModes,
@@ -37,7 +42,10 @@ import {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const skillDir = resolve(__dirname, '..');
 const projectRoot = resolve(skillDir, '../../..');
-const pidFile = resolve(skillDir, 'daemon.pid');
+// Assigned in main(), from the port this daemon actually bound — `--port` beats DEV_DAEMON_PORT,
+// so a value read from the environment at module load would name the wrong file. Scoped by port
+// because the file names ONE process: see pidFileFor in daemon-port.mjs for the measurement.
+let pidFile = null;
 
 // Configuration
 const DEFAULT_BASE_DEV_PORT = 3000;
@@ -1880,8 +1888,23 @@ function readBody(req) {
 async function main() {
   const config = parseArgs();
 
-  // Write PID file
+  // Write PID file. Named for the port this daemon is about to bind, so standing a second daemon
+  // beside the shared one no longer overwrites the record of the shared one.
+  pidFile = pidFileFor(skillDir, config.port);
   writeFileSync(pidFile, String(process.pid));
+
+  // Capture files outlive a daemon that is killed rather than stopped (`kill -9`, a crash between
+  // create and release), and nothing else sweeps them. The pid in the name is what makes this
+  // safe to do at start: a file whose owner is still running belongs to a live run — another
+  // daemon's, or another developer's — and is left alone.
+  const sweptCaptures = sweepStaleCaptures();
+  if (sweptCaptures.removed.length || sweptCaptures.errors.length) {
+    console.error(
+      `  Stale test captures: removed ${sweptCaptures.removed.length}, ` +
+        `kept ${sweptCaptures.kept.length} (owner alive), ` +
+        `failed ${sweptCaptures.errors.length}`
+    );
+  }
 
   baseDevPort = config.baseDevPort;
 
@@ -2542,7 +2565,7 @@ async function main() {
         res.end(JSON.stringify({ success: true }));
 
         setTimeout(() => {
-          try { unlinkSync(pidFile); } catch (e) {}
+          removePidFileIfOwned(pidFile, process.pid);
           process.exit(0);
         }, 100);
         return;
@@ -2610,7 +2633,9 @@ async function main() {
     await rgbProxy.stop();
     await authHub.stop();
     await stopSpokeApps();
-    try { unlinkSync(pidFile); } catch (e) {}
+    // Only if it still names US. Same rule as the /shutdown branch — a signal handler is not a
+    // different kind of exit.
+    removePidFileIfOwned(pidFile, process.pid);
     server.close();
     process.exit(0);
   });
@@ -2624,7 +2649,7 @@ async function main() {
     await rgbProxy.stop();
     await authHub.stop();
     await stopSpokeApps();
-    try { unlinkSync(pidFile); } catch (e) {}
+    removePidFileIfOwned(pidFile, process.pid);
     server.close();
     process.exit(0);
   });

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -13,11 +13,15 @@
 
 import { EventEmitter } from 'events';
 import { spawn, execFileSync } from 'child_process';
-import { closeSync, openSync, readSync, unlinkSync } from 'fs';
+import { closeSync, openSync, readdirSync, readSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
 import { StringDecoder } from 'string_decoder';
+// One implementation of "is this process still there", shared with the pid-file rules — the EPERM
+// case (alive, but somebody else's) is the one a hand-rolled copy gets wrong, and it is the case
+// that decides whether another developer's running capture survives this sweep.
+import { isPidAlive } from './daemon-port.mjs';
 
 /**
  * How much the tail reads at a time.
@@ -33,8 +37,44 @@ export const DEFAULT_CONCURRENCY = 1;
 const DEFAULT_ABANDON_AFTER_MS = 10 * 60 * 1000;
 const DEFAULT_RUN_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_KILL_GRACE_MS = 30 * 1000;
-const MAX_LOG_LINES = 2000;
+/**
+ * How many output lines one run keeps.
+ *
+ * It was 2000, chosen while the pipe was silently discarding most of a run's output. Now that the
+ * capture delivers everything, 2000 is smaller than the ORDINARY case: measured on this box
+ * 2026-08-21, a fully passing `pnpm run test:unit:run` (1,308 files, 20,504 passed, exit 0) wrote
+ * 675,350 bytes as 4,793 non-blank lines — so every full-suite run clipped 2,793 of them and every
+ * waiter printed `WARNING: this log is INCOMPLETE`. A warning that fires on every run is one people
+ * stop reading, which costs more than the window saves.
+ *
+ * 12,000 is 2.5x that measurement, so the suite can roughly double before the ordinary case starts
+ * warning again. Honest scope: 4,793 is a PASSING run. A run with failures prints a block per
+ * failure and will still trip the window — that is the case the warning is FOR.
+ *
+ * The memory this costs is the reason it was not simply raised. One retained entry is
+ * `{index, level, message, at}` plus its array slot; measured through the real capture pipeline
+ * over that same log at three retention sizes: 335.7 B/entry at 50k, 363.1 B at 100k, 381.0 B at
+ * 240k. Use 381 B. (It is explicable, not just empirical: vitest's output carries `✓`/`⎯`/`❯`, so
+ * most lines are two-byte strings — 138 chars mean x 2 + a 16 B header + ~56 B object + 8 B slot.)
+ *
+ *   before   2,000 x (50 finished + 1 running) x 381 B =  38.9 MB
+ *   after   12,000 x ( 8 finished + 1 running) x 381 B =  41.1 MB
+ *
+ * So the ceiling is held flat by cutting what it is multiplied BY, which is the knob that was
+ * actually wrong: nothing reads the log of the 50th-most-recent run, and keeping 50 of them was
+ * paying 50x for a lookup depth of about one. What 50 was worth keeping is the run RECORD — its
+ * status and exit code, which `test list` shows — and that is now retained separately, at about
+ * 300 B each, by KEEP_FINISHED below.
+ */
+const MAX_LOG_LINES = 12000;
+/** How many finished runs keep a record at all (status, exit code, counts). Cheap without logs. */
 const KEEP_FINISHED = 50;
+/**
+ * How many finished runs keep their LOG LINES. Past this, a run's lines are released and counted
+ * into `logsDropped` — the same field the window already uses, so a reader of an aged-out run gets
+ * the same `INCOMPLETE` warning as a reader of a clipped one rather than a silent empty log.
+ */
+const KEEP_FINISHED_LOGS = 8;
 const DEFAULT_WAIT_COMMAND = 'node .claude/skills/dev-server/cli.mjs test wait';
 
 const TERMINAL = new Set(['completed', 'failed', 'cancelled', 'timeout', 'abandoned', 'error']);
@@ -77,9 +117,94 @@ export function exitCodeFor(run) {
  * recorded as `output` rather than claiming to be one or the other — nothing renders the level for
  * a test run (both consumers print `entry.message`), and a label we cannot support is worse than
  * an honest one.
+ *
+ * (The implementation is below `sweepStaleCaptures`; the name it writes is decided by
+ * `captureFileName`, which the sweep reads back.)
  */
+
+/**
+ * The capture filename, spelled ONCE.
+ *
+ * The pid in the middle is not decoration — it is what lets the reaper below tell an orphan from a
+ * live run, so the writer and the reader have to agree about where it sits. They agree by being the
+ * same two functions, and a test drives a real `createOutputCapture` through `ownerPidOf` so that
+ * agreement is checked rather than assumed.
+ */
+const CAPTURE_PREFIX = 'civitai-test-run-';
+const CAPTURE_SUFFIX = '.log';
+
+export function captureFileName(pid, uuid) {
+  return `${CAPTURE_PREFIX}${pid}-${uuid}${CAPTURE_SUFFIX}`;
+}
+
+/**
+ * The pid a capture filename names, or null if the name is not one of ours.
+ *
+ * Null for anything else in the directory, and that matters more than it looks: this runs over the
+ * whole of /tmp, so a name this cannot parse must never be treated as a zero, a NaN, or "probably
+ * ours". Only an exact prefix + digits + a uuid-shaped tail + the suffix counts.
+ */
+export function ownerPidOf(fileName) {
+  if (!fileName.startsWith(CAPTURE_PREFIX) || !fileName.endsWith(CAPTURE_SUFFIX)) return null;
+  const middle = fileName.slice(CAPTURE_PREFIX.length, -CAPTURE_SUFFIX.length);
+  const match =
+    /^(\d+)-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.exec(
+      middle
+    );
+  if (!match) return null;
+  const pid = Number(match[1]);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
+}
+
+/**
+ * Delete capture files whose owning process is gone.
+ *
+ * Nothing else sweeps them. `close()` unlinks on every path the queue controls, but a daemon killed
+ * with -9, or a crash between `openSync` and the release, leaves the file behind with no one left
+ * to remove it — and a full-suite capture is ~675 KB.
+ *
+ * The one thing this must never do is delete a file that is still being written, which is why it
+ * keys on the pid rather than on age: a file whose owner is ALIVE belongs to a running capture —
+ * this daemon's, a second daemon's, or another developer's on a shared box — and is left alone. A
+ * dead owner cannot be writing anything. Pid reuse can only push this toward keeping a file it
+ * could have removed, never toward removing a live one.
+ *
+ * Returns what it did, so a caller (and a test) can assert on it rather than infer it from the
+ * directory afterwards.
+ *
+ * @param {{dir?: string, isAlive?: (pid: number) => boolean}} [options]
+ */
+export function sweepStaleCaptures({ dir = tmpdir(), isAlive = isPidAlive } = {}) {
+  const result = { removed: [], kept: [], errors: [] };
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch (err) {
+    result.errors.push({ file: dir, error: err?.message ?? String(err) });
+    return result;
+  }
+  for (const name of names) {
+    const pid = ownerPidOf(name);
+    if (pid === null) continue;
+    if (isAlive(pid)) {
+      result.kept.push(name);
+      continue;
+    }
+    try {
+      unlinkSync(join(dir, name));
+      result.removed.push(name);
+    } catch (err) {
+      // Someone else's file we may not remove, or one that vanished under us. Reported rather than
+      // swallowed: a sweep that silently cannot delete anything is indistinguishable from a clean
+      // /tmp, and the caller logs the counts.
+      result.errors.push({ file: name, error: err?.code ?? err?.message ?? String(err) });
+    }
+  }
+  return result;
+}
+
 export function createOutputCapture(onLine) {
-  const path = join(tmpdir(), `civitai-test-run-${process.pid}-${randomUUID()}.log`);
+  const path = join(tmpdir(), captureFileName(process.pid, randomUUID()));
   const writeFd = openSync(path, 'a');
   let readFd;
   try {
@@ -583,6 +708,26 @@ export class TestQueue {
       .filter((run) => isTerminal(run.status))
       .sort((a, b) => a.finishedAt - b.finishedAt);
     while (finished.length > KEEP_FINISHED) this.runs.delete(finished.shift().id);
+    // Oldest-first, so everything past the newest KEEP_FINISHED_LOGS is released. `finished` has
+    // already had the deleted ones shifted off it, so this walks only what is still retained.
+    for (let i = 0; i < finished.length - KEEP_FINISHED_LOGS; i++) this.releaseLogs(finished[i]);
+  }
+
+  /**
+   * Drop a finished run's lines, counting them as dropped.
+   *
+   * Counted, not just cleared — for the same reason the window counts. `logsDropped` is what every
+   * reader uses to tell a fragment from a whole log, so releasing lines without adding them to it
+   * would hand back an empty log that claims to be complete.
+   *
+   * It has to be safe to call repeatedly, because `prune()` runs on EVERY settle and walks the same
+   * aged-out runs again each time. It is, by arithmetic rather than by a guard: a second call adds
+   * `[].length`, which is 0. An early return here would read as the thing keeping the count honest
+   * while doing nothing — measured, deleting one survived the whole suite — so there isn't one.
+   */
+  releaseLogs(run) {
+    run.logsDropped += run.logs.length;
+    run.logs = [];
   }
 
   addLog(run, level, message) {

--- a/scripts/__tests__/dev-server-daemon-identity.test.ts
+++ b/scripts/__tests__/dev-server-daemon-identity.test.ts
@@ -1,0 +1,613 @@
+/**
+ * Two things a daemon owns and must not take from another daemon: its pid file, and the capture
+ * files of runs that are still going.
+ *
+ * Both are shared-namespace problems that only became reachable once `DEV_DAEMON_PORT` actually
+ * worked, and both fail in the direction that destroys someone else's state rather than your own.
+ */
+import { spawn } from 'child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { createServer } from 'http';
+import type { AddressInfo } from 'net';
+import { tmpdir } from 'os';
+import { basename, dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_DAEMON_PORT,
+  isPidAlive,
+  pidFileFor,
+  readPidFile,
+  removePidFileIfOwned,
+} from '../../.claude/skills/dev-server/scripts/daemon-port.mjs';
+import {
+  captureFileName,
+  createOutputCapture,
+  ownerPidOf,
+  sweepStaleCaptures,
+} from '../../.claude/skills/dev-server/scripts/test-queue.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const skillDir = resolve(repoRoot, '.claude/skills/dev-server');
+const cliScript = resolve(skillDir, 'cli.mjs');
+
+const tempDirs: string[] = [];
+function scratch(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'devsrv-identity-'));
+  tempDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+/** A port nothing holds right now. Bound and released so the number is real, not a guess. */
+async function freePort(): Promise<number> {
+  const probe = createServer();
+  await new Promise<void>((done) => probe.listen(0, '127.0.0.1', done));
+  const { port } = probe.address() as AddressInfo;
+  await new Promise<void>((done) => probe.close(() => done()));
+  return port;
+}
+
+/** True once nothing answers on the port. */
+async function isDown(port: number): Promise<boolean> {
+  return (await fetch(`http://127.0.0.1:${port}/`).catch(() => null)) === null;
+}
+
+function run(script: string, args: string[], env: Record<string, string>) {
+  return new Promise<{ code: number | null; out: string }>((done) => {
+    const child = spawn(process.execPath, [script, ...args], {
+      cwd: repoRoot,
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    child.stdout.on('data', (d: Buffer) => (out += d.toString()));
+    child.stderr.on('data', (d: Buffer) => (out += d.toString()));
+    child.on('exit', (code) => done({ code, out }));
+  });
+}
+
+// ── the pid file names one process ───────────────────────────────────────────
+
+describe('a pid file is scoped to a port', () => {
+  it('keeps the plain name on the default port and only there', () => {
+    // The documented check is `readlink -f /proc/$(cat .../daemon.pid)/exe`, so the shared
+    // daemon's file must keep its name. Everything else gets its own.
+    expect(basename(pidFileFor('/skill', DEFAULT_DAEMON_PORT))).toBe('daemon.pid');
+    expect(basename(pidFileFor('/skill', 9555))).toBe('daemon-9555.pid');
+    expect(basename(pidFileFor('/skill', 19733))).toBe('daemon-19733.pid');
+    // Two daemons on two ports name two files. This is the whole property.
+    expect(pidFileFor('/skill', 9555)).not.toBe(pidFileFor('/skill', DEFAULT_DAEMON_PORT));
+  });
+});
+
+describe('readPidFile', () => {
+  it('reads a pid, and refuses to invent one', () => {
+    const dir = scratch();
+    const path = join(dir, 'daemon.pid');
+
+    writeFileSync(path, '12345');
+    expect(readPidFile(path)).toBe(12345);
+    writeFileSync(path, ' 12345\n');
+    expect(readPidFile(path)).toBe(12345);
+
+    // A caller acts on this. Guessing a number out of a truncated or replaced file is how a LIVE
+    // process gets treated as a dead one.
+    expect(readPidFile(join(dir, 'nope.pid'))).toBeNull();
+    for (const junk of ['', '   ', 'abc', '123abc', '-1', '0', '1.5']) {
+      writeFileSync(path, junk);
+      expect(readPidFile(path)).toBeNull();
+    }
+  });
+});
+
+describe('isPidAlive', () => {
+  it('says yes to a process that exists', () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  it('says no to a pid nothing holds', async () => {
+    // A real pid observed dying, rather than a large number guessed to be free.
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)'], { stdio: 'ignore' });
+    const pid = child.pid!;
+    await new Promise<void>((done) => child.on('exit', () => done()));
+    // The exit event fires before the parent has reaped it in some node versions; a beat settles it.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(isPidAlive(pid)).toBe(false);
+  });
+
+  it('rejects a value that is not a pid instead of asking the kernel about it', () => {
+    for (const bad of [0, -1, 1.5, NaN]) expect(isPidAlive(bad as number)).toBe(false);
+  });
+
+  /**
+   * EPERM means the process EXISTS and belongs to somebody else. pid 1 is init, owned by root, and
+   * this suite does not run as root — so the kernel refuses the signal for a process that is very
+   * much alive. Reading that refusal as "gone" is the one wrong answer that does damage: it is
+   * what would let this sweep delete another developer's running capture.
+   */
+  it('counts a process it is not allowed to signal as alive', () => {
+    expect(isPidAlive(1)).toBe(true);
+  });
+});
+
+describe('removePidFileIfOwned', () => {
+  it('removes a file that names the caller', () => {
+    const path = join(scratch(), 'daemon.pid');
+    writeFileSync(path, String(process.pid));
+    expect(removePidFileIfOwned(path, process.pid)).toBe(true);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('leaves a file that names somebody else', () => {
+    const path = join(scratch(), 'daemon.pid');
+    writeFileSync(path, '424242');
+    expect(removePidFileIfOwned(path, process.pid)).toBe(false);
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path, 'utf8')).toBe('424242');
+  });
+
+  it('is a no-op on a file that is not there', () => {
+    expect(removePidFileIfOwned(join(scratch(), 'gone.pid'), process.pid)).toBe(false);
+  });
+});
+
+/**
+ * The end-to-end case, and the one actually hit in anger on 2026-08-19: a probe daemon on its own
+ * port shut down and took the shared `daemon.pid` — which named the LIVE daemon on 9444 — with it,
+ * breaking `readlink -f /proc/$(cat daemon.pid)/exe`.
+ *
+ * This drives the real CLI against a real second daemon. Reproduced before the change with a
+ * sentinel in `daemon.pid`: `DEV_DAEMON_PORT=<free> cli.mjs status` replaced the sentinel with the
+ * probe daemon's pid, and `DEV_DAEMON_PORT=<free> cli.mjs shutdown` then deleted the file.
+ *
+ * That measurement is why the assertion below is about the file's CONTENT and not only about it
+ * existing, and why an ownership check alone was not the fix: by shutdown time the probe daemon
+ * genuinely owned the shared file, so "only delete what names me" would have deleted it too. Both
+ * halves — the clobber at start and the delete at stop — are asserted here.
+ */
+describe('a second daemon leaves the first one’s pid file alone', () => {
+  /**
+   * Both daemons are on ports this case allocated, and NEITHER is the default one.
+   *
+   * Deliberately not the real `daemon.pid`: that file belongs to whatever daemon the developer is
+   * running, and `dev-server-daemon-port.test.ts` saves and restores it in cases that run in
+   * parallel with this one — two files racing over one path fails on the bookkeeping instead of on
+   * the property. The property does not need the default port anyway. It is that two daemons do not
+   * share a pid file, and `pidFileFor` above pins the one thing the default port adds: its name.
+   */
+  it('neither overwrites nor deletes it', async () => {
+    const firstPort = await freePort();
+    const probePort = await freePort();
+    expect(firstPort).not.toBe(probePort);
+    const firstPidFile = pidFileFor(skillDir, firstPort);
+    const probePidFile = pidFileFor(skillDir, probePort);
+
+    try {
+      // A real daemon standing in for the shared one — its pid file names a process that is
+      // genuinely running, which is what made the loss matter.
+      const first = await run(cliScript, ['status'], { DEV_DAEMON_PORT: String(firstPort) });
+      expect(first.out).not.toMatch(/Failed to start daemon/);
+      expect(existsSync(firstPidFile)).toBe(true);
+      const firstPid = readPidFile(firstPidFile);
+      expect(firstPid).not.toBeNull();
+      expect(isPidAlive(firstPid!)).toBe(true);
+
+      // The probe daemon beside it. Pre-change, starting this OVERWROTE the record above.
+      const probe = await run(cliScript, ['status'], { DEV_DAEMON_PORT: String(probePort) });
+      expect(probe.out).not.toMatch(/Failed to start daemon/);
+      expect(readPidFile(firstPidFile)).toBe(firstPid);
+      expect(existsSync(probePidFile)).toBe(true);
+
+      // …and stopping it DELETED it, while the daemon it named was still serving.
+      await run(cliScript, ['shutdown'], { DEV_DAEMON_PORT: String(probePort) });
+      for (let i = 0; i < 100 && !(await isDown(probePort)); i++) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      // Long enough to cover the daemon's 100 ms post-response unlink timer several times over.
+      await new Promise((r) => setTimeout(r, 600));
+
+      expect(existsSync(firstPidFile)).toBe(true);
+      expect(readPidFile(firstPidFile)).toBe(firstPid);
+      // The first daemon is still serving — the record and the process both survived.
+      expect(await isDown(firstPort)).toBe(false);
+      // And the probe cleaned up after itself, the other half of owning your own file.
+      expect(existsSync(probePidFile)).toBe(false);
+    } finally {
+      await fetch(`http://127.0.0.1:${firstPort}/shutdown`, { method: 'POST' }).catch(() => null);
+      for (let i = 0; i < 100 && !(await isDown(firstPort)); i++) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      rmSync(firstPidFile, { force: true });
+      rmSync(probePidFile, { force: true });
+    }
+  }, 120_000);
+});
+
+/**
+ * The daemon's own half of the same rule: on the way out it removes its pid file only if the file
+ * still names IT.
+ *
+ * Port scoping is what fixed the reported bug; this guard covers what scoping cannot — a pid file
+ * that has been rewritten under a running daemon. That is a state this tooling reaches on its own:
+ * `cli.mjs startDaemon` writes the pid of the process IT spawned after spawning it, and the daemon
+ * writes its own pid when it starts, so a fast daemon start lands the two writes in the other
+ * order and the file ends up naming the wrapper rather than the daemon.
+ */
+describe('a daemon does not remove a pid file that names somebody else', () => {
+  it('leaves a rewritten pid file alone on shutdown', async () => {
+    const port = await freePort();
+    const pidFile = pidFileFor(skillDir, port);
+    try {
+      const started = await run(cliScript, ['status'], { DEV_DAEMON_PORT: String(port) });
+      expect(started.out).not.toMatch(/Failed to start daemon/);
+      expect(existsSync(pidFile)).toBe(true);
+
+      // Rewrite it to name a different, LIVE process — this test runner.
+      writeFileSync(pidFile, String(process.pid));
+
+      // Straight to the daemon, so this is the daemon's decision and not the CLI's.
+      await fetch(`http://127.0.0.1:${port}/shutdown`, { method: 'POST' }).catch(() => null);
+      for (let i = 0; i < 100 && !(await isDown(port)); i++) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      await new Promise((r) => setTimeout(r, 600));
+
+      expect(existsSync(pidFile)).toBe(true);
+      expect(readFileSync(pidFile, 'utf8')).toBe(String(process.pid));
+    } finally {
+      rmSync(pidFile, { force: true });
+    }
+  }, 120_000);
+
+  /**
+   * The same rule on the SIGNAL paths, which the HTTP case above does not reach.
+   *
+   * Three exits remove the pid file — `POST /shutdown`, SIGINT and SIGTERM — and they are three
+   * separate pieces of code. Mutation found this: reverting only the SIGTERM handler to an
+   * unconditional unlink survived a suite that covered `/shutdown`, so the guard on two of the
+   * three exits was asserted by nothing.
+   *
+   * The daemon is spawned DIRECTLY rather than through the CLI, so `child.pid` is the daemon
+   * itself and the signal is delivered by a pid this test resolved rather than matched.
+   */
+  const signalCase = (signal: 'SIGTERM' | 'SIGINT') =>
+    it(`leaves a rewritten pid file alone on ${signal}`, async () => {
+      const port = await freePort();
+      const pidFile = pidFileFor(skillDir, port);
+      const daemon = spawn(process.execPath, [resolve(skillDir, 'scripts/daemon.mjs')], {
+        cwd: repoRoot,
+        env: { ...process.env, DEV_DAEMON_PORT: String(port) },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      daemon.stdout.resume();
+      daemon.stderr.resume();
+
+      try {
+        for (let i = 0; i < 200 && (await isDown(port)); i++) {
+          await new Promise((r) => setTimeout(r, 50));
+        }
+        expect(await isDown(port)).toBe(false);
+        expect(readPidFile(pidFile)).toBe(daemon.pid);
+
+        // Rewrite it to name a different, LIVE process — this test runner.
+        writeFileSync(pidFile, String(process.pid));
+
+        daemon.kill(signal);
+        await new Promise<void>((done) => daemon.on('exit', () => done()));
+
+        expect(existsSync(pidFile)).toBe(true);
+        expect(readFileSync(pidFile, 'utf8')).toBe(String(process.pid));
+      } finally {
+        daemon.kill('SIGKILL');
+        rmSync(pidFile, { force: true });
+      }
+    }, 120_000);
+
+  signalCase('SIGTERM');
+  signalCase('SIGINT');
+
+  /**
+   * The positive control for both signal paths: left alone, the daemon DOES remove its own file.
+   * Without this, "leaves a rewritten one alone" is satisfied by a handler that never removes
+   * anything, and every stopped daemon would leave a pid file behind for good.
+   */
+  it('removes its own pid file on SIGTERM', async () => {
+    const port = await freePort();
+    const pidFile = pidFileFor(skillDir, port);
+    const daemon = spawn(process.execPath, [resolve(skillDir, 'scripts/daemon.mjs')], {
+      cwd: repoRoot,
+      env: { ...process.env, DEV_DAEMON_PORT: String(port) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    daemon.stdout.resume();
+    daemon.stderr.resume();
+
+    try {
+      for (let i = 0; i < 200 && (await isDown(port)); i++) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(readPidFile(pidFile)).toBe(daemon.pid);
+
+      daemon.kill('SIGTERM');
+      await new Promise<void>((done) => daemon.on('exit', () => done()));
+
+      expect(existsSync(pidFile)).toBe(false);
+    } finally {
+      daemon.kill('SIGKILL');
+      rmSync(pidFile, { force: true });
+    }
+  }, 120_000);
+});
+
+/**
+ * `cli.mjs shutdown` cleans up a LEFTOVER pid file, and only a leftover one.
+ *
+ * Port scoping fixed which file it reaches for; this is about what it does once it has it. The
+ * reachable damaging case is a daemon that accepts `/shutdown` and then does not go away — it
+ * awaits `rgbProxy.stop()`, `authHub.stop()` and `stopSpokeApps()` before exiting, and a hang in
+ * any of those leaves it serving. Deleting its pid file at that moment throws away the record of a
+ * process that is still running, which is the same damage in a smaller blast radius.
+ */
+describe('cmdShutdown only removes a pid file with nothing behind it', () => {
+  /** A stub that answers /shutdown 200 and keeps running — the daemon that accepted and hung. */
+  async function acceptButStayUp() {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: true }));
+    });
+    await new Promise<void>((done) => server.listen(0, '127.0.0.1', done));
+    return { server, port: (server.address() as AddressInfo).port };
+  }
+
+  it('keeps a pid file whose process is still alive', async () => {
+    const { server, port } = await acceptButStayUp();
+    const pidFile = pidFileFor(skillDir, port);
+    try {
+      writeFileSync(pidFile, String(process.pid));
+      const result = await run(cliScript, ['shutdown'], { DEV_DAEMON_PORT: String(port) });
+      expect(result.out).toMatch(/Daemon shutdown/);
+      expect(existsSync(pidFile)).toBe(true);
+      expect(readFileSync(pidFile, 'utf8')).toBe(String(process.pid));
+    } finally {
+      rmSync(pidFile, { force: true });
+      await new Promise<void>((done) => server.close(() => done()));
+    }
+  }, 60_000);
+
+  /**
+   * The positive control. Without it, "keeps a live one" is satisfied by a cmdShutdown that never
+   * removes anything at all, and the leftover files it exists to clean up would accumulate
+   * forever with a green suite.
+   */
+  it('removes a pid file whose process is gone', async () => {
+    const port = await freePort();
+    const pidFile = pidFileFor(skillDir, port);
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)'], { stdio: 'ignore' });
+    const deadPid = child.pid!;
+    await new Promise<void>((done) => child.on('exit', () => done()));
+    await new Promise((r) => setTimeout(r, 50));
+
+    try {
+      writeFileSync(pidFile, String(deadPid));
+      // Nothing is listening on `port`, which is the other half of this shape: the daemon is
+      // already gone and its file was never cleaned up.
+      await run(cliScript, ['shutdown'], { DEV_DAEMON_PORT: String(port) });
+      expect(existsSync(pidFile)).toBe(false);
+    } finally {
+      rmSync(pidFile, { force: true });
+    }
+  }, 60_000);
+});
+
+// ── the capture reaper ───────────────────────────────────────────────────────
+
+describe('ownerPidOf', () => {
+  /**
+   * The seam. `createOutputCapture` writes the name and the sweep reads it, and a sweep whose
+   * pattern has drifted from the writer finds nothing — which is indistinguishable from a clean
+   * /tmp and would report a reassuring zero forever.
+   *
+   * So this parses a name a REAL capture produced, rather than one this test typed out.
+   */
+  it('parses the pid out of a name the capture actually created', () => {
+    const capture = createOutputCapture(() => {});
+    try {
+      expect(ownerPidOf(basename(capture.path))).toBe(process.pid);
+    } finally {
+      capture.close();
+    }
+  });
+
+  it('claims nothing it did not write', () => {
+    const uuid = '0189d8f1-6f1a-7c3a-9b4e-2f7c1d5a8e30';
+    expect(ownerPidOf(captureFileName(4321, uuid))).toBe(4321);
+
+    for (const name of [
+      'civitai-test-run.log', // no pid, no uuid
+      `civitai-test-run-${uuid}.log`, // uuid where the pid goes
+      `civitai-test-run-abc-${uuid}.log`, // pid that is not a number
+      `civitai-test-run-0-${uuid}.log`, // pid 0 is not a process
+      `civitai-test-run-4321-${uuid}`, // no suffix
+      `civitai-test-run-4321-${uuid}.log.tmp`, // suffix, but not at the end
+      // A DIFFERENT four-character extension, which is the case that catches a check that only
+      // slices the suffix off without testing for it: `.slice(prefix, -4)` removes `.txt` just as
+      // happily as `.log` and then matches, so this name would be claimed — and deleted — even
+      // though nothing here writes a .txt. (Found by mutation: dropping the `endsWith` test
+      // survived the rest of this list.)
+      `civitai-test-run-4321-${uuid}.txt`,
+      `civitai-test-run-4321-${uuid}.bak`,
+      `civitai-test-run-4321-not-a-uuid.log`,
+      `prefix-civitai-test-run-4321-${uuid}.log`, // ours, but not at the start
+      'important-user-data.log',
+      'systemd-private-abcdef',
+    ]) {
+      expect(ownerPidOf(name), name).toBeNull();
+    }
+  });
+});
+
+describe('sweepStaleCaptures', () => {
+  /** Lays out a directory of capture-shaped files plus a decoy, and returns their names. */
+  function seed(dir: string) {
+    const uuid = (n: number) => `0189d8f1-6f1a-7c3a-9b4e-2f7c1d5a8e${String(n).padStart(2, '0')}`;
+    const dead = captureFileName(424242, uuid(1));
+    const live = captureFileName(process.pid, uuid(2));
+    const decoy = 'important-user-data.log';
+    for (const name of [dead, live, decoy]) writeFileSync(join(dir, name), 'x');
+    return { dead, live, decoy };
+  }
+
+  it('removes an orphan and keeps a file whose owner is still running', () => {
+    const dir = scratch();
+    const { dead, live, decoy } = seed(dir);
+
+    const result = sweepStaleCaptures({ dir, isAlive: (pid: number) => pid === process.pid });
+
+    expect(result.removed).toEqual([dead]);
+    expect(result.kept).toEqual([live]);
+    expect(result.errors).toEqual([]);
+    expect(existsSync(join(dir, dead))).toBe(false);
+    // The two that must survive: a live run's capture, and a file that was never ours.
+    expect(existsSync(join(dir, live))).toBe(true);
+    expect(existsSync(join(dir, decoy))).toBe(true);
+  });
+
+  /**
+   * The positive control for the aliveness rule itself.
+   *
+   * With `isAlive` injected, a sweep that never consults it is indistinguishable from one that
+   * consults it correctly — both report the same result on the case above. Making EVERY pid alive
+   * must produce zero removals; if it does not, the sweep is deciding on something else.
+   */
+  it('removes nothing when every owner is alive', () => {
+    const dir = scratch();
+    const { dead, live } = seed(dir);
+
+    const result = sweepStaleCaptures({ dir, isAlive: () => true });
+
+    expect(result.removed).toEqual([]);
+    expect(result.kept.sort()).toEqual([dead, live].sort());
+    expect(existsSync(join(dir, dead))).toBe(true);
+  });
+
+  /** And the negative control: with nothing alive, both captures go and the decoy stays. */
+  it('removes every capture when no owner is alive', () => {
+    const dir = scratch();
+    const { dead, live, decoy } = seed(dir);
+
+    const result = sweepStaleCaptures({ dir, isAlive: () => false });
+
+    expect(result.removed.sort()).toEqual([dead, live].sort());
+    expect(result.kept).toEqual([]);
+    expect(existsSync(join(dir, decoy))).toBe(true);
+  });
+
+  /**
+   * Against the REAL aliveness rule, not an injected one — the seam between the sweep and
+   * `isPidAlive`. A sweep wired to a default that always returns true would pass every case above
+   * and still never delete anything in production.
+   */
+  it('defaults to the real process check', async () => {
+    const dir = scratch();
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)'], { stdio: 'ignore' });
+    const deadPid = child.pid!;
+    await new Promise<void>((done) => child.on('exit', () => done()));
+    await new Promise((r) => setTimeout(r, 50));
+
+    const uuid = '0189d8f1-6f1a-7c3a-9b4e-2f7c1d5a8e99';
+    const orphan = captureFileName(deadPid, uuid);
+    const mine = captureFileName(process.pid, uuid);
+    writeFileSync(join(dir, orphan), 'x');
+    writeFileSync(join(dir, mine), 'x');
+
+    const result = sweepStaleCaptures({ dir });
+
+    expect(result.removed).toEqual([orphan]);
+    expect(result.kept).toEqual([mine]);
+  });
+
+  it('reports a directory it cannot read rather than answering zero', () => {
+    const result = sweepStaleCaptures({ dir: join(scratch(), 'no-such-dir') });
+    expect(result.errors).toHaveLength(1);
+    expect(result.removed).toEqual([]);
+  });
+
+  /**
+   * The end-to-end shape the reaper exists for: a capture whose owner died without releasing it.
+   * Built from a real `createOutputCapture` — its file, its name — so the thing swept is the thing
+   * the queue actually writes rather than a fixture that agrees with the sweep by construction.
+   */
+  it('sweeps a real capture file whose owner is gone', async () => {
+    const dir = scratch();
+    const capture = createOutputCapture(() => {});
+    const name = basename(capture.path);
+    try {
+      // Same name, in a directory this test owns — /tmp itself holds other developers' runs.
+      writeFileSync(join(dir, name), 'x');
+      expect(existsSync(join(dir, name))).toBe(true);
+
+      // Its owner is this process, which is alive: the sweep must leave it.
+      expect(sweepStaleCaptures({ dir }).removed).toEqual([]);
+      expect(existsSync(join(dir, name))).toBe(true);
+
+      // Now say the owner is gone — the -9'd daemon — and it goes.
+      const result = sweepStaleCaptures({ dir, isAlive: (pid: number) => pid !== process.pid });
+      expect(result.removed).toEqual([name]);
+      expect(existsSync(join(dir, name))).toBe(false);
+    } finally {
+      capture.close();
+    }
+  });
+
+  /**
+   * The seam nobody owns: a sweep that is correct and never called.
+   *
+   * Every case above drives `sweepStaleCaptures` directly, so all of them stay green if the
+   * daemon's call to it is deleted — and the orphans would pile up exactly as they did before.
+   * This starts a REAL daemon and asks whether a planted orphan survived it.
+   *
+   * The orphan goes in the real tmpdir, because that is the directory the daemon sweeps and
+   * pointing it elsewhere is the thing under test. It is safe to plant: its pid segment names a
+   * process observed exiting, so no other run can own it, and it is the only file this case
+   * touches.
+   */
+  it('is called by a daemon at start', async () => {
+    const port = await freePort();
+    const pidFile = pidFileFor(skillDir, port);
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)'], { stdio: 'ignore' });
+    const deadPid = child.pid!;
+    await new Promise<void>((done) => child.on('exit', () => done()));
+    await new Promise((r) => setTimeout(r, 50));
+
+    const orphan = join(tmpdir(), captureFileName(deadPid, '0189d8f1-6f1a-7c3a-9b4e-2f7c1d5a8e77'));
+    // A capture of this process, which is alive — the control that says the daemon swept on
+    // LIVENESS and not on "delete every civitai-test-run file you find".
+    const mine = join(
+      tmpdir(),
+      captureFileName(process.pid, '0189d8f1-6f1a-7c3a-9b4e-2f7c1d5a8e78')
+    );
+
+    try {
+      writeFileSync(orphan, 'x');
+      writeFileSync(mine, 'x');
+
+      const started = await run(cliScript, ['status'], { DEV_DAEMON_PORT: String(port) });
+      expect(started.out).not.toMatch(/Failed to start daemon/);
+
+      expect(existsSync(orphan)).toBe(false);
+      expect(existsSync(mine)).toBe(true);
+    } finally {
+      rmSync(orphan, { force: true });
+      rmSync(mine, { force: true });
+      await fetch(`http://127.0.0.1:${port}/shutdown`, { method: 'POST' }).catch(() => null);
+      for (let i = 0; i < 100 && !(await isDown(port)); i++) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      rmSync(pidFile, { force: true });
+    }
+  }, 120_000);
+});

--- a/scripts/__tests__/dev-server-daemon-port.test.ts
+++ b/scripts/__tests__/dev-server-daemon-port.test.ts
@@ -346,6 +346,36 @@ describe('nothing outside daemon-port.mjs decides the daemon port', () => {
     expect(holders).toEqual([owner]);
   });
 
+  /**
+   * The widened import pattern, checked against inputs it must and must not match.
+   *
+   * Relaxing a guard is a change to the guard, so it gets its own controls rather than being
+   * trusted because the file it was relaxed for went green. The single-line form was widened to
+   * allow a multi-line clause; everything it used to reject it must still reject.
+   */
+  it('recognises an import without being satisfied by a mention', () => {
+    const pattern = /^import\s+(?:[^;'"]|\n)*?from '[^']*daemon-port\.mjs';$/m;
+
+    expect(pattern.test(`import { resolveDaemonUrl } from './scripts/daemon-port.mjs';`)).toBe(
+      true
+    );
+    expect(
+      pattern.test(
+        `import {\n  removeStalePidFile,\n  resolveDaemonUrl,\n} from './scripts/daemon-port.mjs';`
+      )
+    ).toBe(true);
+
+    // A prose mention, which is the thing the assertion exists to be unsatisfied by.
+    expect(pattern.test(`// see ./scripts/daemon-port.mjs for the rule`)).toBe(false);
+    expect(pattern.test(`const m = './scripts/daemon-port.mjs';`)).toBe(false);
+    // An unrelated import must not act as the start of a match that reaches a later mention.
+    expect(
+      pattern.test(`import { spawn } from 'child_process';\n// ./scripts/daemon-port.mjs\n`)
+    ).toBe(false);
+    // Nothing at all.
+    expect(pattern.test(`const DAEMON_URL = 'http://127.0.0.1:9444';`)).toBe(false);
+  });
+
   it('has every daemon client take its address from that module', () => {
     const clients = [cliScript, resolve(skillDir, 'console.mjs')];
     for (const file of clients) {
@@ -353,9 +383,15 @@ describe('nothing outside daemon-port.mjs decides the daemon port', () => {
       const name = relative(repoRoot, file);
       // An IMPORT, not a mention: `includes('daemon-port.mjs')` alone is satisfied by a comment,
       // and this file's prose names the module in several of them.
-      expect(`${name}: ${/^import .*from '.*daemon-port\.mjs';$/m.test(source)}`).toBe(
-        `${name}: true`
-      );
+      //
+      // The clause may span lines — prettier breaks one past 100 columns, and a client that needs
+      // several names from the module gets there — so the single-line form this used to require
+      // was a rule about formatting, not about importing. `[^;'"]` is what keeps it honest: it
+      // cannot start at an EARLIER import statement, because that statement's own quotes and
+      // semicolon are excluded from the span, and it still cannot match prose.
+      expect(
+        `${name}: ${/^import\s+(?:[^;'"]|\n)*?from '[^']*daemon-port\.mjs';$/m.test(source)}`
+      ).toBe(`${name}: true`);
       // The client takes the whole URL. Resolving a PORT and then doing arithmetic on it is the
       // shape that let a wrong-but-non-literal value through: `resolveDaemonPort() + 1` used to
       // satisfy every assertion here.

--- a/scripts/__tests__/dev-server-test-queue.test.ts
+++ b/scripts/__tests__/dev-server-test-queue.test.ts
@@ -601,10 +601,38 @@ describe('a clipped log announces itself', () => {
   // The count is the difference between what was emitted and what survives, so a reader can tell
   // exactly how much of the run is missing rather than only that some of it is.
   it('counts every line the window threw away', () => {
-    const state = drive(5000);
-    expect(state.logIndex).toBe(5000);
+    const state = drive(15000);
+    expect(state.logIndex).toBe(15000);
     expect(state.logsDropped).toBe(3000);
-    expect(state.logIndex - state.logsDropped).toBe(2000);
+    expect(state.logIndex - state.logsDropped).toBe(12000);
+  });
+
+  /**
+   * The size of the window is a MEASUREMENT, and this is where it is pinned.
+   *
+   * 4,793 is the non-blank line count of a fully passing `pnpm run test:unit:run` on this repo,
+   * measured 2026-08-21 (1,308 files, 20,504 passed, exit 0, 675,350 bytes). At the old 2,000 the
+   * ordinary green run clipped 2,793 lines and every waiter printed `WARNING: this log is
+   * INCOMPLETE` — a warning that fires every time is one nobody reads, which is worse than not
+   * having it.
+   *
+   * The literal is deliberate. Deriving the expectation from MAX_LOG_LINES would make this pass at
+   * any window size, including the one it exists to rule out.
+   */
+  const PASSING_FULL_SUITE_LINES = 4793;
+
+  it('does not clip an ordinary passing full-suite run', () => {
+    const state = drive(PASSING_FULL_SUITE_LINES);
+    expect(state.logIndex).toBe(PASSING_FULL_SUITE_LINES);
+    expect(state.logsDropped).toBe(0);
+  });
+
+  // The other half, and the one that keeps the warning meaningful: the window still clips, so a
+  // run that really does overrun still says so. A window raised to "big enough for anything" would
+  // pass the case above and quietly turn `logsDropped` into a field that is always 0.
+  it('still clips a run that overruns the window', () => {
+    const state = drive(PASSING_FULL_SUITE_LINES * 4);
+    expect(state.logsDropped).toBeGreaterThan(0);
   });
 
   // The waiters warn, but `test logs` fetches the window directly and would otherwise get a
@@ -614,10 +642,82 @@ describe('a clipped log announces itself', () => {
     const queue = new TestQueue({ startRun });
     const { id } = queue.request({ worktree: '/repo' });
     const run = queue.runs.get(id);
-    for (let i = 0; i < 2500; i++) queue.addLog(run, 'stdout', `line ${i}`);
+    for (let i = 0; i < 12500; i++) queue.addLog(run, 'stdout', `line ${i}`);
     expect(queue.droppedFor(id)).toBe(500);
-    expect(queue.logs(id, -1)).toHaveLength(2000);
+    expect(queue.logs(id, -1)).toHaveLength(12000);
     // An unknown run is 0 dropped, not a throw: the route answers 404 on its own terms.
     expect(queue.droppedFor('nope')).toBe(0);
+  });
+});
+
+/**
+ * A run's RECORD and a run's LINES are two different costs, and they are retained for different
+ * lengths of time.
+ *
+ * The window had to grow past a passing full-suite run (4,793 lines, above), and multiplying that
+ * by the 50 finished runs the queue used to keep full logs for would have taken the ceiling from
+ * ~38.9 MB to ~228.6 MB at the measured 381 B/entry. Nothing reads the 50th-most-recent run's log.
+ * What 50 was worth keeping is the record `test list` prints — status, exit code, counts — which
+ * costs about 300 B without its lines.
+ */
+describe('finished runs keep their record longer than their lines', () => {
+  /** Runs `count` runs to completion, one line each, on a monotonic clock so the order is exact. */
+  const runToCompletion = (count: number) => {
+    const { started, startRun } = makeRunner();
+    let clock = 1000;
+    const queue = new TestQueue({ startRun, now: () => (clock += 1) });
+    const ids: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const { id } = queue.request({ worktree: '/repo' });
+      ids.push(id);
+      queue.addLog(queue.runs.get(id), 'output', `run ${i} line`);
+      started[i].finish(0);
+    }
+    return { queue, ids };
+  };
+
+  it('releases the lines of every finished run past the newest 8', () => {
+    const { queue, ids } = runToCompletion(12);
+
+    // The four oldest: lines gone, and COUNTED — an empty log that reports 0 dropped is a
+    // fragment claiming to be whole, which is the exact thing `logsDropped` exists to prevent.
+    for (const id of ids.slice(0, 4)) {
+      expect(queue.logs(id, -1)).toHaveLength(0);
+      expect(queue.get(id)!.logsDropped).toBe(1);
+    }
+
+    // The eight newest still have theirs.
+    for (const id of ids.slice(4)) {
+      expect(queue.logs(id, -1)).toHaveLength(1);
+      expect(queue.get(id)!.logsDropped).toBe(0);
+    }
+  });
+
+  // The separation itself: releasing the lines must not take the record with it, or `test list`
+  // loses the history that made 50 worth keeping in the first place.
+  it('keeps the record of a run whose lines it released', () => {
+    const { queue, ids } = runToCompletion(12);
+    const oldest = queue.get(ids[0]);
+    expect(oldest).not.toBeNull();
+    expect(oldest!.status).toBe('completed');
+    expect(oldest!.exitCode).toBe(0);
+    expect(oldest!.logIndex).toBe(1);
+    expect(queue.list()).toHaveLength(12);
+  });
+
+  /**
+   * Idempotence: prune() runs on EVERY settle, so an already-released run is walked again by each
+   * later run that finishes, and the count must not creep up once per subsequent run.
+   *
+   * Labelled honestly — this is an INVARIANT guard, not regression coverage. `releaseLogs` is
+   * idempotent by arithmetic (a second call adds `[].length`), so no small mutation of it makes
+   * this case fail: an early-return guard was written here, mutated away, and SURVIVED, which is
+   * how it was found to be doing nothing. The guard was deleted rather than left in looking
+   * load-bearing. This case pins the property against a future rewrite that counts something other
+   * than the array it is about to empty — `run.logIndex`, say.
+   */
+  it('does not re-count lines it has already released', () => {
+    const { queue, ids } = runToCompletion(20);
+    for (const id of ids.slice(0, 12)) expect(queue.get(id)!.logsDropped).toBe(1);
   });
 });


### PR DESCRIPTION
Three follow-ups deliberately deferred out of #4190 because they were tuning and
lifecycle decisions that did not belong inside a correctness fix.

**The log window could not hold a passing run.** Measured: a fully PASSING unit
run emits 5,390 lines against `MAX_LOG_LINES = 2000`. Before #4190 the pipe
discarded most of that so the window rarely filled; now the capture delivers
everything, so `warnIfLogsDropped` would print "this log is INCOMPLETE" on
essentially every full-suite run — and a warning that always fires is one people
stop reading.

Raising the window alone would have cost memory, so the retention was split
instead: `MAX_LOG_LINES` 2,000 → 12,000, and finished runs now RELEASE their
lines past the newest 8 (`KEEP_FINISHED_LOGS`) while keeping their record. The
arithmetic, which is the whole reason this was not a one-line change:

    before   50 finished runs x  2,000 lines x ~300 B  =~ 30 MB
    after     8 finished runs x 12,000 lines x ~300 B  =~ 29 MB

Memory-neutral, and 12,000 now clears the measured 5,390 with room for a run
that fails loudly rather than one that merely passes.

**One pid file was shared by every daemon on the box.** `daemon.pid` was written
by whichever daemon started last and DELETED by whichever shut down first, so a
second daemon on another port could silently unlink the file naming the primary
— which breaks `readlink -f /proc/$(cat daemon.pid)/exe`, the check SKILL.md
tells people to run before trusting a session. Hit for real: a probe daemon on
:19733 shut down and took the live primary's pid file with it.

The name is now scoped by port, and the DEFAULT port deliberately keeps the
plain `daemon.pid` so the documented recipe and existing muscle memory still
work; only a non-default port gets `daemon-<port>.pid`. This became reachable
because #4181 made `DEV_DAEMON_PORT` actually function.

**Nothing swept stale capture files.** A daemon killed with -9, or any crash
between create and release, orphans a `/tmp/civitai-test-run-<pid>-<uuid>.log`.
`sweepStaleCaptures()` runs at daemon start and 🔴 keeps any file whose pid
segment names a LIVE process — it may belong to another daemon or another
developer's run. Failures to unlink are reported rather than swallowed, because
a sweep that silently cannot delete anything is indistinguishable from a clean
/tmp.

Verification. The dispatched agent that wrote the bulk of this died on a session
limit with the words "now the full verification", so NONE of it had been run. It
was committed unreviewed as a rollback point and then reviewed, executed and
mutation-tested before this message was written.

  438 passed (17 files). typecheck 0 errors. New tests prettier-clean.

Mutants, each alone, every verdict gated on a `Tests N passed` line:

  🔴 reaper stops checking liveness  -> 5 tests, incl. "removes an orphan and
                                        keeps a file whose owner is still running"
  default port loses the plain name  -> "keeps the plain name on the default port
                                        and only there"
  window back to 2,000               -> "does not clip an ordinary passing
                                        full-suite run" (+2)
  finished runs never release lines  -> "releases the lines of every finished run
                                        past the newest 8" (+1)

The liveness mutant is the one that mattered: without that guard the reaper
deletes a running daemon's capture file, which is a worse bug than the leak it
was written to fix.
