### PR TITLE
fix(users): stop offering Hide on a blocked user, and reconcile a refused hide

### DIFF
--- a/src/components/Account/HiddenUsersSection.browser.test.tsx
+++ b/src/components/Account/HiddenUsersSection.browser.test.tsx
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as HiddenPreferences from '~/hooks/hidden-preferences';
+import type * as TrpcModule from '~/utils/trpc';
+
+/**
+ * 868kurj0y. This search box is a second `kind: 'user'` writer and NOT a
+ * `HideUserButton` call site, so the block gate on that component does not reach it.
+ *
+ * `toHideableOptions` is unit-tested beside it; what this covers is the argument
+ * that connects it to `blockedUsers` — passing `[]` there leaves the helper green
+ * and the box still offering blocked users.
+ */
+
+const mocks = vi.hoisted(() => ({
+  blockedUsers: [] as Array<{ id: number }>,
+  users: [] as Array<{ id: number; username: string | null }>,
+}));
+
+vi.mock('~/hooks/hidden-preferences', async (importOriginal) => ({
+  ...(await importOriginal<typeof HiddenPreferences>()),
+  useHiddenPreferencesData: () => ({ hiddenUsers: [], blockedUsers: mocks.blockedUsers }),
+  useToggleHiddenPreferences: () => ({ mutateAsync: vi.fn().mockResolvedValue({}) }),
+}));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    user: {
+      getAll: { useQuery: () => ({ data: mocks.users, isLoading: false, isFetching: false }) },
+    },
+  },
+}));
+
+vi.mock('~/components/MasonryGrid/BasicMasonryGrid', () => ({
+  BasicMasonryGrid: () => <div data-testid="grid" />,
+}));
+
+const { HiddenUsersSection } = await import('./HiddenUsersSection');
+
+beforeEach(() => {
+  mocks.blockedUsers = [];
+  // A shared prefix so one query returns both — Mantine filters the dropdown by the
+  // input text, so unrelated names would hide the anchor rather than the subject.
+  mocks.users = [
+    { id: 1, username: 'tester_alice' },
+    { id: 2, username: 'tester_bob' },
+  ];
+});
+
+describe('HiddenUsersSection — blocked users are not offered as hideable', () => {
+  const openOptions = async () => {
+    const input = page.getByPlaceholder('Search users to hide');
+    await input.click();
+    await input.fill('tester');
+    return input;
+  };
+
+  test('a blocked user is absent from the options', async () => {
+    mocks.blockedUsers = [{ id: 2 }];
+
+    renderWithProviders(<HiddenUsersSection />);
+    await openOptions();
+
+    // `tester_alice` proves the dropdown actually opened, so `bob`'s absence is a real
+    // exclusion rather than an unrendered list.
+    await expect.element(page.getByRole('option', { name: 'tester_alice' })).toBeInTheDocument();
+    expect(page.getByRole('option', { name: 'tester_bob' }).elements()).toHaveLength(0);
+  });
+
+  // Negative control: passing `[]` for blockedUsers passes the test above only if
+  // this one is absent.
+  test('an unblocked user is offered', async () => {
+    renderWithProviders(<HiddenUsersSection />);
+    await openOptions();
+
+    await expect.element(page.getByRole('option', { name: 'tester_bob' })).toBeInTheDocument();
+  });
+});

--- a/src/components/Account/HiddenUsersSection.tsx
+++ b/src/components/Account/HiddenUsersSection.tsx
@@ -3,6 +3,7 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { IconSearch, IconX } from '@tabler/icons-react';
 import { useMemo, useRef, useState } from 'react';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { toHideableOptions } from '~/components/Account/hidden-users-options';
 import { BasicMasonryGrid } from '~/components/MasonryGrid/BasicMasonryGrid';
 import { useHiddenPreferencesData, useToggleHiddenPreferences } from '~/hooks/hidden-preferences';
 
@@ -14,7 +15,7 @@ export function HiddenUsersSection() {
   const [debouncedSearch] = useDebouncedValue(search, 300);
   const [sort, setSort] = useState<string>('newest');
 
-  const hiddenUsers = useHiddenPreferencesData().hiddenUsers;
+  const { hiddenUsers, blockedUsers } = useHiddenPreferencesData();
 
   const sortedHiddenUsers = useMemo(() => {
     if (sort === 'newest') return hiddenUsers;
@@ -39,9 +40,7 @@ export function HiddenUsersSection() {
     { query: debouncedSearch.trim(), limit: 10 },
     { enabled: debouncedSearch !== '' }
   );
-  const options =
-    data?.filter((x) => x.username).map(({ id, username }) => ({ id, value: username ?? '' })) ??
-    [];
+  const options = toHideableOptions(data, blockedUsers);
 
   const toggleHiddenMutation = useToggleHiddenPreferences();
 

--- a/src/components/Account/__tests__/hidden-users-options.test.ts
+++ b/src/components/Account/__tests__/hidden-users-options.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { toHideableOptions } from '~/components/Account/hidden-users-options';
+
+// 868kurj0y. This search box is a second `kind: 'user'` writer that is not a
+// HideUserButton call site, so the block gate on that component does not reach it.
+describe('toHideableOptions', () => {
+  const users = [
+    { id: 1, username: 'alice' },
+    { id: 2, username: 'bob' },
+  ];
+
+  it('drops a blocked user', () => {
+    expect(toHideableOptions(users, [{ id: 2 }])).toEqual([{ id: 1, value: 'alice' }]);
+  });
+
+  // Negative control: returning [] unconditionally would pass the case above.
+  it('keeps an unblocked user', () => {
+    expect(toHideableOptions(users, [])).toEqual([
+      { id: 1, value: 'alice' },
+      { id: 2, value: 'bob' },
+    ]);
+  });
+
+  it('still drops a null username', () => {
+    expect(toHideableOptions([{ id: 3, username: null }], [])).toEqual([]);
+  });
+
+  it('handles the query not having resolved', () => {
+    expect(toHideableOptions(undefined, [])).toEqual([]);
+  });
+});

--- a/src/components/Account/hidden-users-options.ts
+++ b/src/components/Account/hidden-users-options.ts
@@ -1,0 +1,15 @@
+/**
+ * A block already hides the target and outranks a hide, so the server refuses a
+ * hide over one. Offering a blocked user as hideable produces no badge and no
+ * toast, so they are dropped from the search results entirely.
+ */
+export function toHideableOptions(
+  data: Array<{ id: number; username: string | null }> | undefined,
+  blockedUsers: Array<{ id: number }>
+) {
+  return (
+    data
+      ?.filter((x) => x.username && !blockedUsers.some((b) => b.id === x.id))
+      .map(({ id, username }) => ({ id, value: username ?? '' })) ?? []
+  );
+}

--- a/src/components/HideUserButton/HideUserButton.browser.test.tsx
+++ b/src/components/HideUserButton/HideUserButton.browser.test.tsx
@@ -1,0 +1,162 @@
+import { Menu } from '@mantine/core';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * 868kurj0y — `Block > Hide > Follow`, so a hide over an existing block is refused
+ * server-side (#4230). The control must not be offered on a user the viewer has
+ * already blocked.
+ *
+ * Both states here are stable: neither the rendered control nor its absence is
+ * torn down on a timer, so there is no self-deleting state to race. The absence
+ * assertions still await a sibling anchor first, so "not found" cannot pass merely
+ * because nothing has mounted yet.
+ */
+
+const mocks = vi.hoisted(() => ({
+  hiddenUsers: [] as Array<{ id: number }>,
+  blockedUsers: [] as Array<{ id: number }>,
+  currentUser: { id: 1 } as { id: number } | null,
+  toggleResult: {} as { hidden?: boolean },
+  showSuccess: vi.fn(),
+}));
+
+vi.mock('~/hooks/hidden-preferences', () => ({
+  useHiddenPreferencesData: () => ({
+    hiddenUsers: mocks.hiddenUsers,
+    blockedUsers: mocks.blockedUsers,
+  }),
+  useToggleHiddenPreferences: () => ({
+    mutateAsync: () => Promise.resolve(mocks.toggleResult),
+    isPending: false,
+  }),
+}));
+
+vi.mock('~/utils/notifications', () => ({ showSuccessNotification: mocks.showSuccess }));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => mocks.currentUser }));
+
+vi.mock('~/components/LoginRedirect/LoginRedirect', () => ({
+  LoginRedirect: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const { HideUserButton } = await import('./HideUserButton');
+
+const TARGET = 42;
+
+const renderButton = () =>
+  renderWithProviders(
+    <div>
+      <HideUserButton userId={TARGET} />
+      <span data-testid="anchor">rendered</span>
+    </div>
+  );
+
+const renderMenuItem = () =>
+  renderWithProviders(
+    <Menu opened>
+      <Menu.Dropdown>
+        <HideUserButton userId={TARGET} as="menu-item" />
+        <Menu.Item data-testid="anchor">rendered</Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+
+beforeEach(() => {
+  mocks.hiddenUsers = [];
+  mocks.blockedUsers = [];
+  mocks.currentUser = { id: 1 };
+  mocks.toggleResult = {};
+  mocks.showSuccess.mockClear();
+});
+
+describe('HideUserButton — a blocked target is not offered the Hide control', () => {
+  test('button variant is absent when the target is blocked', async () => {
+    mocks.blockedUsers = [{ id: TARGET }];
+
+    renderButton();
+
+    await expect.element(page.getByTestId('anchor')).toBeInTheDocument();
+    expect(page.getByRole('button', { name: /hide/i }).elements()).toHaveLength(0);
+  });
+
+  test('menu-item variant is absent when the target is blocked', async () => {
+    mocks.blockedUsers = [{ id: TARGET }];
+
+    renderMenuItem();
+
+    await expect.element(page.getByTestId('anchor')).toBeInTheDocument();
+    expect(page.getByText(/content from this user/).elements()).toHaveLength(0);
+  });
+
+  // Negative control: without these, deleting the whole component body would also
+  // make the two assertions above pass.
+  test('button variant is present when the target is NOT blocked', async () => {
+    renderButton();
+
+    await expect.element(page.getByRole('button', { name: 'Hide' })).toBeInTheDocument();
+  });
+
+  test('menu-item variant is present when the target is NOT blocked', async () => {
+    renderMenuItem();
+
+    await expect.element(page.getByText('Hide content from this user')).toBeInTheDocument();
+  });
+
+  // The gate reads a React-Query cache that is EMPTY while `getHidden` is in flight,
+  // so the control does render on a blocked user on a cold client. The toast is then
+  // the last thing that can lie about what happened.
+  test('a refused hide reports NOT hidden, not success', async () => {
+    mocks.toggleResult = { hidden: false };
+
+    renderButton();
+
+    await page.getByRole('button', { name: 'Hide' }).click();
+
+    await vi.waitFor(() => expect(mocks.showSuccess).toHaveBeenCalled());
+    expect(mocks.showSuccess).toHaveBeenCalledTimes(1);
+    const { title, message } = mocks.showSuccess.mock.calls[0][0];
+    expect(title).toBe('User marked as show');
+    expect(message).toContain('will show up in your feed');
+  });
+
+  // Negative control: pinning only the refusal would pass with the copy inverted.
+  test('a granted hide reports hidden', async () => {
+    mocks.toggleResult = { hidden: true };
+
+    renderButton();
+
+    await page.getByRole('button', { name: 'Hide' }).click();
+
+    await vi.waitFor(() => expect(mocks.showSuccess).toHaveBeenCalled());
+    expect(mocks.showSuccess).toHaveBeenCalledTimes(1);
+    const { title, message } = mocks.showSuccess.mock.calls[0][0];
+    expect(title).toBe('User marked as hidden');
+    expect(message).toContain('will not show up in your feed');
+  });
+
+  // The phantom state this PR cleans up puts the id in BOTH lists at once (an
+  // optimistic hide over a block, before onSuccess lands). Gating on `blocked &&
+  // !alreadyHiding` passes every other test here and still renders "Unhide".
+  test('control is absent when the target is blocked AND in the hidden list', async () => {
+    mocks.blockedUsers = [{ id: TARGET }];
+    mocks.hiddenUsers = [{ id: TARGET }];
+
+    renderButton();
+
+    await expect.element(page.getByTestId('anchor')).toBeInTheDocument();
+    expect(page.getByRole('button', { name: /hide/i }).elements()).toHaveLength(0);
+  });
+
+  // A hidden-but-not-blocked target keeps the control, in its Unhide state — the
+  // block gate must not be wired to the hidden list by accident.
+  test('a hidden target still gets the control, as Unhide', async () => {
+    mocks.hiddenUsers = [{ id: TARGET }];
+
+    renderButton();
+
+    await expect.element(page.getByRole('button', { name: 'Unhide' })).toBeInTheDocument();
+  });
+});

--- a/src/components/HideUserButton/HideUserButton.browser.test.tsx
+++ b/src/components/HideUserButton/HideUserButton.browser.test.tsx
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import type * as HiddenPreferences from '~/hooks/hidden-preferences';
+import type * as Notifications from '~/utils/notifications';
 
 /**
  * 868kurj0y — `Block > Hide > Follow`, so a hide over an existing block is refused
@@ -34,7 +36,10 @@ vi.mock('~/hooks/hidden-preferences', () => ({
   }),
 }));
 
-vi.mock('~/utils/notifications', () => ({ showSuccessNotification: mocks.showSuccess }));
+vi.mock('~/utils/notifications', async (importOriginal) => ({
+  ...(await importOriginal<typeof Notifications>()),
+  showSuccessNotification: mocks.showSuccess,
+}));
 
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => mocks.currentUser }));
 
@@ -107,8 +112,10 @@ describe('HideUserButton — a blocked target is not offered the Hide control', 
 
   // The gate reads a React-Query cache that is EMPTY while `getHidden` is in flight,
   // so the control does render on a blocked user on a cold client. The toast is then
-  // the last thing that can lie about what happened.
-  test('a refused hide reports NOT hidden, not success', async () => {
+  // the last thing that can lie about what happened — and the server refuses in
+  // exactly one case, where the content IS suppressed. Telling the viewer it "will
+  // show up in your feed" denies a block they set.
+  test('a refused hide never says the content will show up', async () => {
     mocks.toggleResult = { hidden: false };
 
     renderButton();
@@ -118,8 +125,8 @@ describe('HideUserButton — a blocked target is not offered the Hide control', 
     await vi.waitFor(() => expect(mocks.showSuccess).toHaveBeenCalled());
     expect(mocks.showSuccess).toHaveBeenCalledTimes(1);
     const { title, message } = mocks.showSuccess.mock.calls[0][0];
-    expect(title).toBe('User marked as show');
-    expect(message).toContain('will show up in your feed');
+    expect(message).not.toMatch(/will show up in your feed/);
+    expect(`${title} ${message}`).toMatch(/block/i);
   });
 
   // Negative control: pinning only the refusal would pass with the copy inverted.
@@ -159,4 +166,20 @@ describe('HideUserButton — a blocked target is not offered the Hide control', 
 
     await expect.element(page.getByRole('button', { name: 'Unhide' })).toBeInTheDocument();
   });
+});
+
+// `importOriginal` is the house style for this, but spreading the real barrel loads
+// `~/utils/trpc` and drags CivitaiSessionContext into the render — every test above
+// then fails at the matcher ceiling. This is the same protection without the import:
+// the mock above hand-lists two of the barrel's exports, and a new one appearing
+// silently hands `undefined` to whichever consumer starts using it.
+test('the mock still covers the whole hidden-preferences barrel', async () => {
+  const actual = await vi.importActual<typeof HiddenPreferences>('~/hooks/hidden-preferences');
+
+  expect(Object.keys(actual).sort()).toEqual([
+    'useHiddenPreferencesData',
+    'useQueryHiddenPreferences',
+    'useToggleHiddenPreferences',
+    'useUpdateHiddenPreferences',
+  ]);
 });

--- a/src/components/HideUserButton/HideUserButton.browser.test.tsx
+++ b/src/components/HideUserButton/HideUserButton.browser.test.tsx
@@ -140,7 +140,7 @@ describe('HideUserButton — a blocked target is not offered the Hide control', 
     await vi.waitFor(() => expect(mocks.showSuccess).toHaveBeenCalled());
     expect(mocks.showSuccess).toHaveBeenCalledTimes(1);
     const { title, message } = mocks.showSuccess.mock.calls[0][0];
-    expect(title).toBe('User marked as hidden');
+    expect(title).toBe('User hidden');
     expect(message).toContain('will not show up in your feed');
   });
 

--- a/src/components/HideUserButton/HideUserButton.tsx
+++ b/src/components/HideUserButton/HideUserButton.tsx
@@ -20,16 +20,27 @@ export function HideUserButton({ userId, as = 'button', onToggleHide, ...props }
     e.preventDefault();
     e.stopPropagation();
 
+    const wantHidden = !alreadyHiding;
+
     toggleHiddenMutation
       .mutateAsync({
         kind: 'user',
         data: [{ id: userId }],
-        hidden: !alreadyHiding,
+        hidden: wantHidden,
       })
       .then(({ hidden }) => {
-        // The server refuses a hide it ranks below an existing block, so report its
-        // outcome rather than the one we asked for.
-        const nowHidden = hidden ?? !alreadyHiding;
+        // A refused hide means a block already covers this user. The un-hide copy
+        // would say their content will show up in their feed — the opposite of what
+        // the block they set is doing.
+        if (wantHidden && hidden === false) {
+          showSuccessNotification({
+            title: 'User already blocked',
+            message: 'Your block already keeps this user out of your feed',
+          });
+          return;
+        }
+
+        const nowHidden = hidden ?? wantHidden;
         showSuccessNotification({
           title: `User marked as ${nowHidden ? 'hidden' : 'show'}`,
           message: `Content from this user will${nowHidden ? ' not' : ''} show up in your feed`,

--- a/src/components/HideUserButton/HideUserButton.tsx
+++ b/src/components/HideUserButton/HideUserButton.tsx
@@ -42,7 +42,7 @@ export function HideUserButton({ userId, as = 'button', onToggleHide, ...props }
 
         const nowHidden = hidden ?? wantHidden;
         showSuccessNotification({
-          title: `User marked as ${nowHidden ? 'hidden' : 'show'}`,
+          title: nowHidden ? 'User hidden' : 'User unhidden',
           message: `Content from this user will${nowHidden ? ' not' : ''} show up in your feed`,
         });
       });

--- a/src/components/HideUserButton/HideUserButton.tsx
+++ b/src/components/HideUserButton/HideUserButton.tsx
@@ -11,8 +11,9 @@ import { showSuccessNotification } from '~/utils/notifications';
 export function HideUserButton({ userId, as = 'button', onToggleHide, ...props }: Props) {
   const currentUser = useCurrentUser();
 
-  const users = useHiddenPreferencesData().hiddenUsers;
-  const alreadyHiding = users.some((x) => x.id === userId);
+  const { hiddenUsers, blockedUsers } = useHiddenPreferencesData();
+  const alreadyHiding = hiddenUsers.some((x) => x.id === userId);
+  const blocked = blockedUsers.some((x) => x.id === userId);
   const toggleHiddenMutation = useToggleHiddenPreferences();
 
   const handleHideClick: MouseEventHandler<HTMLElement> = (e) => {
@@ -25,12 +26,13 @@ export function HideUserButton({ userId, as = 'button', onToggleHide, ...props }
         data: [{ id: userId }],
         hidden: !alreadyHiding,
       })
-      .then(() => {
+      .then(({ hidden }) => {
+        // The server refuses a hide it ranks below an existing block, so report its
+        // outcome rather than the one we asked for.
+        const nowHidden = hidden ?? !alreadyHiding;
         showSuccessNotification({
-          title: `User marked as ${alreadyHiding ? 'show' : 'hidden'}`,
-          message: `Content from this user will${
-            alreadyHiding ? ' ' : ' not'
-          } show up in your feed`,
+          title: `User marked as ${nowHidden ? 'hidden' : 'show'}`,
+          message: `Content from this user will${nowHidden ? ' not' : ''} show up in your feed`,
         });
       });
 
@@ -38,6 +40,9 @@ export function HideUserButton({ userId, as = 'button', onToggleHide, ...props }
   };
 
   if (currentUser != null && userId === currentUser.id) return null;
+  // Block outranks Hide, so the server refuses a hide over one and this control
+  // would report a change it cannot make.
+  if (blocked) return null;
 
   return as === 'button' ? (
     <LoginRedirect reason="hide-content">

--- a/src/hooks/hidden-preferences/useToggleHiddenPreferences.ts
+++ b/src/hooks/hidden-preferences/useToggleHiddenPreferences.ts
@@ -1,23 +1,12 @@
 import type { ToggleHiddenSchemaOutput } from '~/server/schema/user-preferences.schema';
 import {
   applyOptimisticHiddenToggle,
+  applyToggleSuccess,
+  EMPTY_HIDDEN_CACHE,
   HIDDEN_KIND_TO_KEY,
-  reconcileHiddenToggle,
+  planToggleRollback,
 } from '~/shared/hidden-preferences/compact';
 import { trpc } from '~/utils/trpc';
-
-// Legacy (object-wrapped) empty cache — used only when the query cache is empty
-// during an optimistic write (rare; getHidden is prefetched). A real fetch
-// overwrites this, and `expandHiddenPreferences` reads the legacy shape fine.
-const emptyLegacy = {
-  hiddenImages: [],
-  hiddenModels: [],
-  hiddenModel3Ds: [],
-  hiddenUsers: [],
-  hiddenTags: [],
-  blockedUsers: [],
-  blockedByUsers: [],
-};
 
 export const useToggleHiddenPreferences = () => {
   const queryUtils = trpc.useUtils();
@@ -33,29 +22,31 @@ export const useToggleHiddenPreferences = () => {
 
       return { previous };
     },
-    onSuccess: async (result, { kind, data }) => {
-      queryUtils.hiddenPreferences.getHidden.setData(undefined, (old = emptyLegacy as any) =>
-        reconcileHiddenToggle(old, kind, data, result)
+    onSuccess: async (result, variables) => {
+      queryUtils.hiddenPreferences.getHidden.setData(undefined, (old) =>
+        applyToggleSuccess(old as any, variables, result)
       );
 
       // Invalidate user lists when user or blockedUser preferences change
-      if (kind === 'user' || kind === 'blockedUser') {
+      if (variables.kind === 'user' || variables.kind === 'blockedUser') {
         await queryUtils.user.getLists.invalidate();
         await queryUtils.user.getList.invalidate();
       }
     },
-    onError: (_error, _variables, context) => {
-      queryUtils.hiddenPreferences.getHidden.setData(undefined, context?.previous);
+    onError: async (_error, _variables, context) => {
+      const plan = planToggleRollback(context?.previous as any);
+      if ('restore' in plan)
+        queryUtils.hiddenPreferences.getHidden.setData(undefined, plan.restore as any);
+      else await queryUtils.hiddenPreferences.getHidden.invalidate();
     },
   });
-  // trpc.hiddenPreferences.getHidden.useQuery();
 };
 
 export const useUpdateHiddenPreferences = () => {
   const queryUtils = trpc.useUtils();
   const updateHiddenPreferences = ({ kind, data, hidden }: ToggleHiddenSchemaOutput) => {
     const key = HIDDEN_KIND_TO_KEY[kind];
-    queryUtils.hiddenPreferences.getHidden.setData(undefined, (old = emptyLegacy as any) =>
+    queryUtils.hiddenPreferences.getHidden.setData(undefined, (old = EMPTY_HIDDEN_CACHE as any) =>
       applyOptimisticHiddenToggle(old, key, data, hidden)
     );
   };

--- a/src/hooks/hidden-preferences/useToggleHiddenPreferences.ts
+++ b/src/hooks/hidden-preferences/useToggleHiddenPreferences.ts
@@ -1,18 +1,10 @@
 import type { ToggleHiddenSchemaOutput } from '~/server/schema/user-preferences.schema';
 import {
   applyOptimisticHiddenToggle,
-  applyServerHiddenToggle,
+  HIDDEN_KIND_TO_KEY,
+  reconcileHiddenToggle,
 } from '~/shared/hidden-preferences/compact';
 import { trpc } from '~/utils/trpc';
-
-const kindMap = {
-  image: 'hiddenImages',
-  model: 'hiddenModels',
-  model3d: 'hiddenModel3Ds',
-  tag: 'hiddenTags',
-  user: 'hiddenUsers',
-  blockedUser: 'blockedUsers',
-} as const;
 
 // Legacy (object-wrapped) empty cache — used only when the query cache is empty
 // during an optimistic write (rare; getHidden is prefetched). A real fetch
@@ -41,12 +33,9 @@ export const useToggleHiddenPreferences = () => {
 
       return { previous };
     },
-    onSuccess: async ({ added, removed }, { kind }) => {
-      const key = kindMap[kind];
-      // Shape-aware: `applyServerHiddenToggle` writes bare ids for the compact
-      // id-only sets and `{ id, hidden }` objects for the legacy / object sets.
+    onSuccess: async (result, { kind, data }) => {
       queryUtils.hiddenPreferences.getHidden.setData(undefined, (old = emptyLegacy as any) =>
-        applyServerHiddenToggle(old, key, added, removed)
+        reconcileHiddenToggle(old, kind, data, result)
       );
 
       // Invalidate user lists when user or blockedUser preferences change
@@ -65,7 +54,7 @@ export const useToggleHiddenPreferences = () => {
 export const useUpdateHiddenPreferences = () => {
   const queryUtils = trpc.useUtils();
   const updateHiddenPreferences = ({ kind, data, hidden }: ToggleHiddenSchemaOutput) => {
-    const key = kindMap[kind];
+    const key = HIDDEN_KIND_TO_KEY[kind];
     queryUtils.hiddenPreferences.getHidden.setData(undefined, (old = emptyLegacy as any) =>
       applyOptimisticHiddenToggle(old, key, data, hidden)
     );

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -79,6 +79,7 @@ const TransferModelOwnership = dynamic(
   { ssr: false }
 );
 import { HideModelButton } from '~/components/HideModelButton/HideModelButton';
+import { BlockUserButton } from '~/components/HideUserButton/BlockUserButton';
 import { HideUserButton } from '~/components/HideUserButton/HideUserButton';
 import { IconBadge } from '~/components/IconBadge/IconBadge';
 import { StatHoverCard } from '~/components/Stats/StatHoverCard';
@@ -1192,6 +1193,7 @@ export default function ModelDetailsV2({
                           <>
                             <Menu.Label>Moderation</Menu.Label>
                             <HideUserButton as="menu-item" userId={model.user.id} />
+                            <BlockUserButton as="menu-item" userId={model.user.id} />
                             <HideModelButton as="menu-item" modelId={model.id} />
                             <Menu.Item
                               leftSection={<IconTagOff size={14} stroke={1.5} />}

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -104,7 +104,6 @@ import {
   toggleContestBan,
   toggleFollowUser,
   toggleModelEngagement,
-  toggleModelHide,
   toggleModelNotify,
   toggleReview,
   toggleUserArticleEngagement,
@@ -877,33 +876,6 @@ export const getUserHiddenListHandler = async ({ ctx }: { ctx: ProtectedContext 
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
-  }
-};
-
-export const toggleHideModelHandler = async ({
-  input,
-  ctx,
-}: {
-  input: ToggleModelEngagementInput;
-  ctx: ProtectedContext;
-}) => {
-  try {
-    const { id: userId } = ctx.user;
-    const result = await toggleModelHide({ ...input, userId });
-    if (result) {
-      await ctx.track.modelEngagement({
-        type: 'Hide',
-        modelId: input.modelId,
-      });
-    } else {
-      await ctx.track.modelEngagement({
-        type: 'Delete',
-        modelId: input.modelId,
-      });
-    }
-    await redis.del(`${REDIS_KEYS.USER.BASE}:${userId}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`);
-  } catch (error) {
-    throw throwDbError(error);
   }
 };
 

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -103,7 +103,6 @@ import {
   toggleBookmarked,
   toggleContestBan,
   toggleFollowUser,
-  toggleHideUser,
   toggleModelEngagement,
   toggleModelHide,
   toggleModelNotify,
@@ -878,36 +877,6 @@ export const getUserHiddenListHandler = async ({ ctx }: { ctx: ProtectedContext 
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
-  }
-};
-
-// Registered on no router: every hide in the product goes through
-// `toggleHidden({ kind: 'user' })`. Kept and fixed rather than deleted, but the
-// second writer on that table is a hazard in itself — 868kurrfj weighs removing
-// this and `toggleHideUser` in user.service together.
-export const toggleHideUserHandler = async ({
-  input,
-  ctx,
-}: {
-  input: ToggleFollowUserSchema;
-  ctx: ProtectedContext;
-}) => {
-  try {
-    const { id: userId } = ctx.user;
-    const result = await toggleHideUser({ ...input, userId });
-    if (result) {
-      await ctx.track.userEngagement({
-        type: 'Hide',
-        targetUserId: input.targetUserId,
-      });
-    } else {
-      await ctx.track.userEngagement({
-        type: 'Delete',
-        targetUserId: input.targetUserId,
-      });
-    }
-  } catch (error) {
-    throw throwDbError(error);
   }
 };
 

--- a/src/server/services/__tests__/engagement-toggle.idempotent.service.test.ts
+++ b/src/server/services/__tests__/engagement-toggle.idempotent.service.test.ts
@@ -215,3 +215,57 @@ describe('toggleUserBountyEngagement — idempotent on P2002 race (sibling)', ()
     ).rejects.toThrow('boom');
   });
 });
+
+/**
+ * The update branch (`setTo && engagement.type !== type`) converts a row in place and
+ * was the only branch that never refreshed the hidden-models cache. Both directions
+ * change hidden-ness, and the delete/create branches' `type === 'Hide'` test only sees
+ * the NEW type — so copying it here would have fixed one direction and left the other.
+ *
+ * Reachable from the live `user.toggleNotifyModel`: `toggleModelEngagementInput`
+ * declares `type` as the full `ModelEngagementType` enum, Hide included, plus `setTo`.
+ */
+describe('toggleModelEngagement — the update branch refreshes the hidden-models cache', () => {
+  it('Notify -> Hide refreshes it, or the model keeps showing in the feed', async () => {
+    mockDbWrite.modelEngagement.findUnique.mockResolvedValueOnce({ type: 'Notify' });
+
+    const result = await toggleModelEngagement({
+      userId: 42,
+      modelId: 10,
+      type: 'Hide',
+      setTo: true,
+    });
+
+    expect(mockDbWrite.modelEngagement.update).toHaveBeenCalledTimes(1);
+    expect(refreshCache).toHaveBeenCalledWith({ userId: 42 });
+    expect(result).toBe(true);
+  });
+
+  it('Hide -> Notify refreshes it, or the model stays filtered out', async () => {
+    mockDbWrite.modelEngagement.findUnique.mockResolvedValueOnce({ type: 'Hide' });
+
+    const result = await toggleModelEngagement({
+      userId: 42,
+      modelId: 10,
+      type: 'Notify',
+      setTo: true,
+    });
+
+    expect(mockDbWrite.modelEngagement.update).toHaveBeenCalledTimes(1);
+    // The new type is not Hide — only the OLD one is, which is why the guard has to
+    // read both sides.
+    expect(refreshCache).toHaveBeenCalledWith({ userId: 42 });
+    expect(result).toBe(true);
+  });
+
+  // Negative control: refreshing unconditionally would pass both cases above and
+  // spend a Redis round-trip on every favourite/notify conversion.
+  it('Favorite -> Notify does NOT refresh it — neither side is Hide', async () => {
+    mockDbWrite.modelEngagement.findUnique.mockResolvedValueOnce({ type: 'Favorite' });
+
+    await toggleModelEngagement({ userId: 42, modelId: 10, type: 'Notify', setTo: true });
+
+    expect(mockDbWrite.modelEngagement.update).toHaveBeenCalledTimes(1);
+    expect(refreshCache).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/toggle-hidden-set-to.service.test.ts
+++ b/src/server/services/__tests__/toggle-hidden-set-to.service.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import {
+  HiddenImages,
+  HiddenModel3Ds,
+  HiddenModels,
+  toggleHidden,
+} from '~/server/services/user-preferences.service';
+
+/**
+ * `toggleHidden` forwarded the caller's `hidden` only for `kind: 'user'`; image,
+ * model and model3d got the id alone and blind-flipped off whatever row they found.
+ * So an explicit un-hide of an unengaged entity CREATED a Hide, and an explicit hide
+ * of an already-hidden one DELETED it — both the inverse of the request. Same defect
+ * #4230 fixed for users, three tables over.
+ *
+ * Every in-app caller omits `hidden` (HideModelButton, HideImageButton,
+ * HideModel3DButton), so the flip is the path the product actually uses and the
+ * compatibility cases below are the ones that would break real behaviour.
+ */
+
+const userId = 42;
+const id = 7;
+
+const KINDS = [
+  {
+    kind: 'model' as const,
+    delegate: dbMock.dbWrite.modelEngagement,
+    cache: HiddenModels,
+    pk: { userId_modelId: { userId, modelId: id } },
+    created: { userId, modelId: id, type: 'Hide' },
+  },
+  {
+    kind: 'image' as const,
+    delegate: dbMock.dbWrite.imageEngagement,
+    cache: HiddenImages,
+    pk: { userId_imageId: { userId, imageId: id } },
+    created: { userId, imageId: id, type: 'Hide' },
+  },
+  {
+    kind: 'model3d' as const,
+    delegate: dbMock.dbWrite.model3DEngagement,
+    cache: HiddenModel3Ds,
+    pk: { userId_model3dId: { userId, model3dId: id } },
+    created: { userId, model3dId: id, type: 'Hide' },
+  },
+];
+
+const toggle = (kind: (typeof KINDS)[number]['kind'], hidden?: boolean) =>
+  toggleHidden({ kind, data: [{ id }], hidden, userId } as Parameters<typeof toggleHidden>[0]);
+
+describe.each(KINDS)('toggleHidden kind=$kind — honours the caller intent', (k) => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    k.delegate.findUnique.mockResolvedValue(null);
+    k.delegate.create.mockResolvedValue({});
+    k.delegate.update.mockResolvedValue({});
+    k.delegate.delete.mockResolvedValue({});
+    vi.spyOn(k.cache, 'refreshCache').mockResolvedValue(undefined);
+  });
+
+  const noWrites = () => {
+    expect(k.delegate.create).not.toHaveBeenCalled();
+    expect(k.delegate.update).not.toHaveBeenCalled();
+    expect(k.delegate.delete).not.toHaveBeenCalled();
+  };
+
+  // The three compatibility cases: every in-app caller omits `hidden`, so these are
+  // the paths the product uses today and they must be byte-identical to before.
+  it('omitted hidden on an unengaged entity still creates the Hide', async () => {
+    await toggle(k.kind);
+
+    expect(k.delegate.create).toHaveBeenCalledWith({ data: k.created });
+  });
+
+  it('omitted hidden on a hidden entity still deletes it', async () => {
+    k.delegate.findUnique.mockResolvedValue({ type: 'Hide' });
+
+    await toggle(k.kind);
+
+    expect(k.delegate.delete).toHaveBeenCalledWith({ where: k.pk });
+  });
+
+  it('omitted hidden on a non-Hide row still converts it to Hide', async () => {
+    k.delegate.findUnique.mockResolvedValue({ type: 'Favorite' });
+
+    await toggle(k.kind);
+
+    expect(k.delegate.update).toHaveBeenCalledWith({ where: k.pk, data: { type: 'Hide' } });
+  });
+
+  it('hidden=false on an unengaged entity writes NOTHING and reports not hidden', async () => {
+    await expect(toggle(k.kind, false)).resolves.toMatchObject({ hidden: false });
+
+    noWrites();
+  });
+
+  it('hidden=false on a non-Hide row writes nothing — an un-hide must not hide', async () => {
+    k.delegate.findUnique.mockResolvedValue({ type: 'Favorite' });
+
+    await expect(toggle(k.kind, false)).resolves.toMatchObject({ hidden: false });
+
+    noWrites();
+  });
+
+  it('hidden=true on an already-hidden entity leaves it hidden', async () => {
+    k.delegate.findUnique.mockResolvedValue({ type: 'Hide' });
+
+    await expect(toggle(k.kind, true)).resolves.toMatchObject({ hidden: true });
+
+    // The bug this replaces: the blind flip DELETED the row here, so asking to hide
+    // an already-hidden entity un-hid it.
+    noWrites();
+  });
+
+  it('hidden=false on a hidden entity deletes it and reports not hidden', async () => {
+    k.delegate.findUnique.mockResolvedValue({ type: 'Hide' });
+
+    await expect(toggle(k.kind, false)).resolves.toMatchObject({ hidden: false });
+
+    expect(k.delegate.delete).toHaveBeenCalledWith({ where: k.pk });
+  });
+
+  it('refreshes the hidden cache even on the no-write path', async () => {
+    await toggle(k.kind, false);
+
+    // The client drops its optimistic entry off the response; the server-side feed
+    // filter reads this cache, so skipping it here would diverge the two.
+    expect(k.cache.refreshCache).toHaveBeenCalledWith({ userId });
+  });
+});

--- a/src/server/services/__tests__/toggle-hide-user.service.test.ts
+++ b/src/server/services/__tests__/toggle-hide-user.service.test.ts
@@ -3,7 +3,7 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
 import { UserEngagementType } from '~/shared/utils/prisma/enums';
 import { HiddenUsers, toggleHidden } from '~/server/services/user-preferences.service';
 import { userFollowsCache } from '~/server/redis/caches';
-import { toggleFollowUser, toggleHideUser } from '~/server/services/user.service';
+import { toggleFollowUser } from '~/server/services/user.service';
 import { clearUserEngagement, setUserEngagement } from '~/server/services/user-engagement';
 
 const { Prisma } = await import('@prisma/client');
@@ -98,17 +98,6 @@ describe('UserEngagement writers are all scoped by type', () => {
   );
 
   it.each(['Block', 'Follow', 'Hide'] as const)(
-    'toggleHideUser issues no PK-addressed write over a %s row',
-    async (type) => {
-      engagement.findUnique.mockResolvedValue({ type });
-
-      await toggleHideUser({ userId, targetUserId });
-
-      expect(unqualified()).toEqual([]);
-    }
-  );
-
-  it.each(['Block', 'Follow', 'Hide'] as const)(
     'toggleFollowUser issues no PK-addressed write over a %s row',
     async (type) => {
       engagement.findUnique.mockResolvedValue({ type });
@@ -147,7 +136,7 @@ describe('toggleHidden kind=user — a Block outranks a Hide', () => {
     // Nothing matched the update and the insert conflicts with the block — the
     // intended end state either way, so the toggle must not 500 on a safety
     // control.
-    await expect(hide(true)).resolves.toEqual({ added: [], removed: [] });
+    await expect(hide(true)).resolves.toEqual({ added: [], removed: [], hidden: false });
   });
 
   it('still surfaces a create failure that is not the conflict', async () => {
@@ -239,67 +228,36 @@ describe('toggleHidden kind=user — honours the caller intent', () => {
   });
 });
 
-// 868kumcfc. The OTHER `toggleHideUser` — same name, different file, opposite
-// failure: over a Block it matched no branch, wrote nothing, and returned falsy, so
-// the caller logged the hide as a removal.
-describe('toggleHideUser (user.service) — reports what it did', () => {
-  it('reports a blocked user as hidden without touching the row', async () => {
+// 868kurj0y. The client marks the target hidden optimistically on click, and the
+// `added`/`removed` diff cannot correct it: five of the six kinds return both empty
+// on every call, so an empty diff is indistinguishable from a refusal. Both
+// polarities, or a hardcoded `hidden: false` passes the refusal case alone.
+describe('toggleHidden kind=user — reports the outcome the client must trust', () => {
+  it('reports hidden=false when a Block refuses the hide', async () => {
     engagement.findUnique.mockResolvedValue({ type: 'Block' });
-
-    await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(true);
-
-    expect(engagement.updateMany).not.toHaveBeenCalled();
-    expect(engagement.deleteMany).not.toHaveBeenCalled();
-    expect(engagement.create).not.toHaveBeenCalled();
-  });
-
-  it('hiding a followed user reports HIDDEN, not removed', async () => {
-    engagement.findUnique.mockResolvedValue({ type: 'Follow' });
-
-    // The old branch converted the row and returned false, so the tracking event
-    // recorded a `Delete` for a write that established a Hide.
-    await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(true);
-
-    expect(engagement.updateMany).toHaveBeenCalledWith({
-      where: { ...scoped, type: { notIn: ['Block'] } },
-      data: { type: 'Hide' },
-    });
-  });
-
-  it('un-hiding removes a Hide and only a Hide', async () => {
-    engagement.findUnique.mockResolvedValue({ type: 'Hide' });
-
-    await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(false);
-
-    expect(engagement.deleteMany).toHaveBeenCalledWith({ where: { ...scoped, type: 'Hide' } });
-  });
-
-  // The dominant real path — hiding someone you have no engagement with — and the
-  // one every other test in this describe routes past, because they all supply a
-  // row and leave `updateMany` matching it.
-  it('hiding a user with no engagement creates the row', async () => {
-    engagement.updateMany.mockResolvedValue({ count: 0 });
-
-    await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(true);
-
-    expect(engagement.create).toHaveBeenCalledWith({
-      data: { type: 'Hide', targetUserId, userId },
-    });
-  });
-
-  it('survives the create losing to a Block that arrived in between', async () => {
     everyPassFails();
 
-    await expect(toggleHideUser({ userId, targetUserId })).resolves.toBe(true);
+    await expect(hide(true)).resolves.toMatchObject({ hidden: false });
   });
 
-  it('still surfaces a create failure that is not the conflict', async () => {
-    engagement.updateMany.mockResolvedValue({ count: 0 });
-    engagement.create.mockRejectedValue(new Error('connection terminated'));
+  it('reports hidden=true when the hide lands', async () => {
+    await expect(hide(true)).resolves.toMatchObject({ hidden: true });
+  });
 
-    // Control for the test above: `catch(() => {})` passes that one and swallows
-    // every real write failure with it, reporting a hide that never happened.
-    await expect(toggleHideUser({ userId, targetUserId })).rejects.toThrow('connection terminated');
+  // The distinguishing case for the whole field: `findUnique` saw NOTHING, so a
+  // `hidden` re-derived from that read reports true. Only the write's own answer
+  // reports false. Without this, `hidden = hiding && engagement?.type !== 'Block'`
+  // passes every other test in this file.
+  it('reports hidden=false when a Block arrives AFTER the read', async () => {
+    everyPassFails();
+
+    await expect(hide(true)).resolves.toMatchObject({ hidden: false });
+  });
+
+  it('reports hidden=false on an un-hide', async () => {
+    engagement.findUnique.mockResolvedValue({ type: 'Hide' });
+
+    await expect(hide(false)).resolves.toMatchObject({ hidden: false });
   });
 });
 
@@ -391,13 +349,16 @@ describe('cache invalidation on the Hide set', () => {
     expect(hidden).toHaveBeenCalledWith({ userId });
   });
 
-  it('refreshes HiddenUsers when toggleHideUser writes the Hide', async () => {
-    const hidden = vi.spyOn(HiddenUsers, 'refreshCache').mockResolvedValue(undefined);
+  it.each([true, false])(
+    'refreshes HiddenUsers on the toggleHidden path (hidden=%s)',
+    async (setTo) => {
+      const hidden = vi.spyOn(HiddenUsers, 'refreshCache').mockResolvedValue(undefined);
 
-    await toggleHideUser({ userId, targetUserId });
+      await hide(setTo);
 
-    expect(hidden).toHaveBeenCalledWith({ userId });
-  });
+      expect(hidden).toHaveBeenCalledWith({ userId });
+    }
+  );
 });
 
 // The write sequence is two passes, never more. Pass two exists for one schedule:
@@ -506,14 +467,6 @@ describe('cache invalidation on the follow set', () => {
     const follows = vi.spyOn(userFollowsCache, 'refresh').mockResolvedValue(undefined);
 
     await toggleFollowUser({ userId, targetUserId });
-
-    expect(follows).toHaveBeenCalledWith(userId);
-  });
-
-  it('refreshes it on a hide too', async () => {
-    const follows = vi.spyOn(userFollowsCache, 'refresh').mockResolvedValue(undefined);
-
-    await toggleHideUser({ userId, targetUserId });
 
     expect(follows).toHaveBeenCalledWith(userId);
   });

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -302,6 +302,14 @@ type HiddenPreferencesKind =
 interface HiddenPreferencesDiff {
   added: Array<HiddenPreferencesKind>;
   removed: Array<HiddenPreferencesKind>;
+  /**
+   * Whether the entity ends up in the corresponding hidden list. Set only by
+   * toggles the server can REFUSE, where the client's optimistic write would
+   * otherwise stand as a state that does not exist. `added`/`removed` cannot
+   * carry this: five of the six kinds return them empty on every call, so an
+   * empty diff means "this kind does not report", not "nothing happened".
+   */
+  hidden?: boolean;
 }
 
 export type HiddenPreferenceTypes = {
@@ -728,7 +736,9 @@ async function toggleHideUser({
   // type a hide must never overwrite. Un-hiding removes a Hide and only a Hide:
   // unqualified, it deleted whatever Follow or Block held the pair, and unfiltered
   // on intent it created a Hide row when asked to un-hide a pair that had none.
-  if (hiding) await setUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide });
+  let hidden = false;
+  if (hiding)
+    hidden = await setUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide });
   else await clearUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide });
 
   await userFollowsCache.refresh(userId);
@@ -737,6 +747,7 @@ async function toggleHideUser({
   return {
     added: [],
     removed: [],
+    hidden,
   };
 }
 

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -525,11 +525,11 @@ export async function toggleHidden({
 }: ToggleHiddenSchemaOutput & { userId: number }): Promise<HiddenPreferencesDiff> {
   switch (kind) {
     case 'image':
-      return await toggleHideImage({ userId, imageId: data[0].id });
+      return await toggleHideImage({ userId, imageId: data[0].id, setTo: hidden });
     case 'model':
-      return await toggleHideModel({ userId, modelId: data[0].id });
+      return await toggleHideModel({ userId, modelId: data[0].id, setTo: hidden });
     case 'model3d':
-      return await toggleHideModel3D({ userId, model3dId: data[0].id });
+      return await toggleHideModel3D({ userId, model3dId: data[0].id, setTo: hidden });
     case 'user':
       return await toggleHideUser({ userId, targetUserId: data[0].id, setTo: hidden });
     case 'tag':
@@ -634,16 +634,26 @@ async function toggleHiddenTags({
 async function toggleHideModel({
   userId,
   modelId,
+  setTo,
 }: {
   userId: number;
   modelId: number;
+  setTo?: boolean;
 }): Promise<HiddenPreferencesDiff> {
   const engagement = await dbWrite.modelEngagement.findUnique({
     where: { userId_modelId: { userId, modelId } },
     select: { type: true },
   });
+  // `setTo` carries the caller's INTENT; fall back to flipping only when none was
+  // supplied, which is what every in-app caller does today. Without it, an explicit
+  // un-hide of a model with no row CREATED one, and an explicit hide of an
+  // already-hidden model deleted it — both the inverse of what was asked.
+  const hiding = setTo ?? engagement?.type !== 'Hide';
 
-  if (!engagement)
+  if (!hiding) {
+    if (engagement?.type === 'Hide')
+      await dbWrite.modelEngagement.delete({ where: { userId_modelId: { userId, modelId } } });
+  } else if (!engagement)
     await dbWrite.modelEngagement
       .create({ data: { userId, modelId, type: 'Hide' } })
       // Toggle racing itself → P2002 on the (userId, modelId) PK. The Hide row
@@ -651,9 +661,7 @@ async function toggleHideModel({
       .catch((error) => {
         if (!isPrismaUniqueViolation(error)) throw error;
       });
-  else if (engagement.type === 'Hide')
-    await dbWrite.modelEngagement.delete({ where: { userId_modelId: { userId, modelId } } });
-  else
+  else if (engagement.type !== 'Hide')
     await dbWrite.modelEngagement.update({
       where: { userId_modelId: { userId, modelId } },
       data: { type: 'Hide' },
@@ -667,6 +675,7 @@ async function toggleHideModel({
   return {
     added: [],
     removed: [],
+    hidden: hiding,
   };
 }
 
@@ -677,16 +686,24 @@ async function toggleHideModel({
 async function toggleHideModel3D({
   userId,
   model3dId,
+  setTo,
 }: {
   userId: number;
   model3dId: number;
+  setTo?: boolean;
 }): Promise<HiddenPreferencesDiff> {
   const engagement = await dbWrite.model3DEngagement.findUnique({
     where: { userId_model3dId: { userId, model3dId } },
     select: { type: true },
   });
+  const hiding = setTo ?? engagement?.type !== 'Hide';
 
-  if (!engagement)
+  if (!hiding) {
+    if (engagement?.type === 'Hide')
+      await dbWrite.model3DEngagement.delete({
+        where: { userId_model3dId: { userId, model3dId } },
+      });
+  } else if (!engagement)
     await dbWrite.model3DEngagement
       .create({ data: { userId, model3dId, type: 'Hide' } })
       // Toggle racing itself → P2002 on the (userId, model3dId) PK. Idempotent
@@ -694,11 +711,7 @@ async function toggleHideModel3D({
       .catch((error) => {
         if (!isPrismaUniqueViolation(error)) throw error;
       });
-  else if (engagement.type === 'Hide')
-    await dbWrite.model3DEngagement.delete({
-      where: { userId_model3dId: { userId, model3dId } },
-    });
-  else
+  else if (engagement.type !== 'Hide')
     await dbWrite.model3DEngagement.update({
       where: { userId_model3dId: { userId, model3dId } },
       data: { type: 'Hide' },
@@ -709,6 +722,7 @@ async function toggleHideModel3D({
   return {
     added: [],
     removed: [],
+    hidden: hiding,
   };
 }
 
@@ -881,15 +895,24 @@ async function toggleBlockUser({
 async function toggleHideImage({
   userId,
   imageId,
+  setTo,
 }: {
   userId: number;
   imageId: number;
+  setTo?: boolean;
 }): Promise<HiddenPreferencesDiff> {
   const engagement = await dbWrite.imageEngagement.findUnique({
     where: { userId_imageId: { userId, imageId } },
     select: { type: true },
   });
-  if (!engagement)
+  const hiding = setTo ?? engagement?.type !== 'Hide';
+
+  if (!hiding) {
+    if (engagement?.type === 'Hide')
+      await dbWrite.imageEngagement.delete({
+        where: { userId_imageId: { userId, imageId } },
+      });
+  } else if (!engagement)
     await dbWrite.imageEngagement
       .create({ data: { userId, imageId, type: 'Hide' } })
       // Toggle racing itself → P2002 on the (userId, imageId) PK. Idempotent
@@ -897,11 +920,7 @@ async function toggleHideImage({
       .catch((error) => {
         if (!isPrismaUniqueViolation(error)) throw error;
       });
-  else if (engagement.type === 'Hide')
-    await dbWrite.imageEngagement.delete({
-      where: { userId_imageId: { userId, imageId } },
-    });
-  else
+  else if (engagement.type !== 'Hide')
     await dbWrite.imageEngagement.update({
       where: { userId_imageId: { userId, imageId } },
       data: { type: 'Hide' },
@@ -915,5 +934,6 @@ async function toggleHideImage({
   return {
     added: [],
     removed: [],
+    hidden: hiding,
   };
 }

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -291,7 +291,7 @@ export interface HiddenImage extends HiddenPreferenceBase {
   hidden?: boolean;
 }
 
-type HiddenPreferencesKind =
+export type HiddenPreferencesKind =
   | ({ kind: 'tag' } & HiddenTag)
   | ({ kind: 'model' } & HiddenModel)
   | ({ kind: 'model3d' } & HiddenModel3D)

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -875,6 +875,11 @@ export const toggleModelEngagement = async ({
         where: { userId_modelId: { userId, modelId } },
         data: { type, createdAt: new Date() },
       });
+      // EITHER side of the conversion changes hidden-ness, so the other branches'
+      // `type === 'Hide'` test is not enough here: converting away from Hide leaves
+      // the model filtered out of the feed, and converting to it leaves it showing.
+      if (type === 'Hide' || engagement.type === 'Hide')
+        await HiddenModels.refreshCache({ userId });
       return true;
     }
     return true; // no change

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -91,7 +91,7 @@ import {
   HiddenModels,
   HiddenUsers,
 } from '~/server/services/user-preferences.service';
-import { clearUserEngagement, setUserEngagement } from '~/server/services/user-engagement';
+import { clearUserEngagement } from '~/server/services/user-engagement';
 import { createCachedObject, fetchThroughCache } from '~/server/utils/cache-helpers';
 import { bustRatingTotalsCache } from '~/server/services/resourceReview.cache';
 import { getResourceReviewsByUserId } from '~/server/services/resourceReview.service';
@@ -978,37 +978,6 @@ export const toggleFollowUser = async ({
   }
 
   return true;
-};
-
-export const toggleHideUser = async ({
-  userId,
-  targetUserId,
-}: {
-  userId: number;
-  targetUserId: number;
-}) => {
-  const engagement = await dbWrite.userEngagement.findUnique({
-    where: { userId_targetUserId: { targetUserId, userId } },
-    select: { type: true },
-  });
-
-  // A Block already hides the target and is strictly stronger, so a hide over one
-  // leaves it alone and reports the target as hidden — which it is. Previously
-  // this matched neither branch, wrote nothing, and returned falsy, so the caller
-  // logged the hide as a removal.
-  if (engagement?.type === UserEngagementType.Block) return true;
-
-  const hiding = engagement?.type !== UserEngagementType.Hide;
-
-  // Scoped by `type`, never by the PK alone: the row read above may already be a
-  // Block, and an unqualified `delete`/`update` would destroy it while reporting
-  // success.
-  if (hiding) await setUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide });
-  else await clearUserEngagement({ userId, targetUserId, type: UserEngagementType.Hide });
-
-  await userFollowsCache.refresh(userId);
-  await HiddenUsers.refreshCache({ userId });
-  return hiding;
 };
 
 export const getUserList = async ({ username, type, limit, page }: GetUserListSchema) => {

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -894,9 +894,6 @@ export const toggleModelEngagement = async ({
 export const toggleModelNotify = async ({ userId, modelId }: { userId: number; modelId: number }) =>
   toggleModelEngagement({ userId, modelId, type: 'Notify' });
 
-export const toggleModelHide = async ({ userId, modelId }: { userId: number; modelId: number }) =>
-  toggleModelEngagement({ userId, modelId, type: 'Hide' });
-
 export const toggleFollowUser = async ({
   userId,
   targetUserId,

--- a/src/shared/hidden-preferences/__tests__/compact.test.ts
+++ b/src/shared/hidden-preferences/__tests__/compact.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import type { HiddenPreferenceTypes } from '~/server/services/user-preferences.service';
 import {
   applyOptimisticHiddenToggle,
-  applyServerHiddenToggle,
   expandHiddenPreferences,
+  reconcileHiddenToggle,
   HIDDEN_PREFS_COMPACT_VERSION,
   isCompactHiddenPreferences,
   toCompactHiddenPreferences,
@@ -175,14 +175,69 @@ describe('optimistic cache mutation — shape parity (compact vs legacy)', () =>
     expect(res.hiddenUsers).toContainEqual({ id: 30, username: 'dave', hidden: true });
   });
 
+  // 868kurj0y. The click optimistically hides the target; the server can refuse a
+  // hide it ranks below an existing block. `added`/`removed` cannot express that
+  // refusal — five of the six kinds return both empty on every call — so `hidden`
+  // carries it, and without this the phantom state survives until the next refetch.
+  it('a REFUSED hide (hidden=false) drops the optimistic entry across shapes', () => {
+    const res = bothShapesAgree('hiddenUsers', (cache) =>
+      reconcileHiddenToggle(
+        applyOptimisticHiddenToggle(cache, 'hiddenUsers', [{ id: 30 }], true),
+        'user',
+        [{ id: 30 }],
+        { added: [], removed: [], hidden: false }
+      )
+    );
+    expect(res.hiddenUsers.map((x) => x.id)).not.toContain(30);
+  });
+
+  it('a GRANTED hide (hidden=true) keeps the optimistic entry across shapes', () => {
+    const res = bothShapesAgree('hiddenUsers', (cache) =>
+      reconcileHiddenToggle(
+        applyOptimisticHiddenToggle(cache, 'hiddenUsers', [{ id: 30 }], true),
+        'user',
+        [{ id: 30 }],
+        { added: [], removed: [], hidden: true }
+      )
+    );
+    expect(res.hiddenUsers.map((x) => x.id)).toContain(30);
+  });
+
+  // The five kinds that never report an outcome must keep the optimistic write,
+  // or every model/image hide would revert on its own success.
+  it('an omitted `hidden` leaves the optimistic entry alone across shapes', () => {
+    const res = bothShapesAgree('hiddenModels', (cache) =>
+      reconcileHiddenToggle(
+        applyOptimisticHiddenToggle(cache, 'hiddenModels', [{ id: 999 }], true),
+        'model',
+        [{ id: 999 }],
+        { added: [], removed: [] }
+      )
+    );
+    expect(res.hiddenModels.map((x) => x.id)).toContain(999);
+  });
+
+  // The add-direction twin above is idempotent under `hidden ?? true`, so it cannot
+  // catch that coercion. This one can: re-applying `true` to an optimistic un-hide
+  // puts the entry back, which is the same phantom-state bug one direction over.
+  it('an omitted `hidden` leaves an optimistic UN-hide alone across shapes', () => {
+    const res = bothShapesAgree('hiddenModels', (cache) =>
+      reconcileHiddenToggle(
+        applyOptimisticHiddenToggle(cache, 'hiddenModels', [{ id: 100 }], false),
+        'model',
+        [{ id: 100 }],
+        { added: [], removed: [] }
+      )
+    );
+    expect(res.hiddenModels.map((x) => x.id)).not.toContain(100);
+  });
+
   it('server-diff reconcile (added/removed) matches across shapes', () => {
     const res = bothShapesAgree('hiddenModels', (cache) =>
-      applyServerHiddenToggle(
-        cache,
-        'hiddenModels',
-        [{ kind: 'model', id: 500, hidden: true }],
-        [{ kind: 'model', id: 100, hidden: true }]
-      )
+      reconcileHiddenToggle(cache, 'model', [], {
+        added: [{ kind: 'model', id: 500, hidden: true }],
+        removed: [{ kind: 'model', id: 100, hidden: true }],
+      })
     );
     const ids = res.hiddenModels.map((x) => x.id);
     expect(ids).toContain(500);

--- a/src/shared/hidden-preferences/__tests__/compact.test.ts
+++ b/src/shared/hidden-preferences/__tests__/compact.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import type { HiddenPreferenceTypes } from '~/server/services/user-preferences.service';
 import {
   applyOptimisticHiddenToggle,
+  applyToggleSuccess,
   expandHiddenPreferences,
+  planToggleRollback,
   reconcileHiddenToggle,
   HIDDEN_PREFS_COMPACT_VERSION,
   isCompactHiddenPreferences,
@@ -242,5 +244,76 @@ describe('optimistic cache mutation — shape parity (compact vs legacy)', () =>
     const ids = res.hiddenModels.map((x) => x.id);
     expect(ids).toContain(500);
     expect(ids).not.toContain(100);
+  });
+});
+
+/**
+ * The mutation's cache wiring. It lives in this module rather than inline in
+ * `useToggleHiddenPreferences` because no test in the repo runs that hook — the
+ * mutations below all passed against the inline version.
+ */
+describe('toggleHidden cache wiring', () => {
+  const hidden30 = () =>
+    applyOptimisticHiddenToggle(structuredClone(legacy), 'hiddenUsers', [{ id: 30 }], true);
+
+  it('forwards the toggled ids, so a refusal actually reaches them', () => {
+    // Mutating the call to pass `[]` reinstates the exact phantom state this PR
+    // removes, and every other test in this file stays green.
+    const res = applyToggleSuccess(
+      hidden30(),
+      { kind: 'user', data: [{ id: 30 }] },
+      { added: [], removed: [], hidden: false }
+    );
+
+    expect(res.hiddenUsers.map((x) => x.id)).not.toContain(30);
+  });
+
+  it('forwards the kind, so the override lands on the right set', () => {
+    const res = applyToggleSuccess(
+      hidden30(),
+      { kind: 'user', data: [{ id: 30 }] },
+      { added: [], removed: [], hidden: true }
+    );
+
+    expect(res.hiddenUsers.map((x) => x.id)).toContain(30);
+    expect(res.hiddenModels.map((x) => x.id)).not.toContain(30);
+  });
+
+  it('substitutes an empty cache when getHidden has not populated', () => {
+    const res = applyToggleSuccess(
+      undefined,
+      { kind: 'user', data: [{ id: 30 }] },
+      { added: [], removed: [], hidden: true }
+    );
+
+    expect(res.hiddenUsers.map((x) => x.id)).toEqual([30]);
+  });
+
+  // 🔴 Identity, not contents. The accepted path must return the SAME object:
+  // `expandHiddenPreferences` is a useMemo keyed on it and HiddenPreferencesProvider
+  // rebuilds every Map when it changes — measured ~93ms of main-thread stall per
+  // click at the tail if this breaks. Membership assertions cannot see it.
+  it('returns the base cache BY REFERENCE when nothing changes', () => {
+    const cache = hidden30();
+
+    expect(
+      reconcileHiddenToggle(cache, 'user', [{ id: 30 }], {
+        added: [],
+        removed: [],
+        hidden: true,
+      })
+    ).toBe(cache);
+  });
+
+  // React Query reads an `undefined` updater result as "no update", so restoring a
+  // missing snapshot would leave the optimistic write standing forever.
+  it('plans a refetch when onMutate captured no snapshot', () => {
+    expect(planToggleRollback(undefined)).toEqual({ invalidate: true });
+  });
+
+  it('restores the snapshot when there is one', () => {
+    const snapshot = structuredClone(legacy);
+
+    expect(planToggleRollback(snapshot)).toEqual({ restore: snapshot });
   });
 });

--- a/src/shared/hidden-preferences/__tests__/compact.test.ts
+++ b/src/shared/hidden-preferences/__tests__/compact.test.ts
@@ -234,6 +234,20 @@ describe('optimistic cache mutation — shape parity (compact vs legacy)', () =>
     expect(res.hiddenModels.map((x) => x.id)).not.toContain(100);
   });
 
+  // `applyServerHiddenToggle` writes the item minus `kind`, and the account pages
+  // render what it carries. immer's draft is `any`, so narrowing that write to
+  // `{ id }` type-checks — this is the only thing that catches it.
+  it('a server-added user keeps its username', () => {
+    const res = bothShapesAgree('hiddenUsers', (cache) =>
+      reconcileHiddenToggle(cache, 'user', [], {
+        added: [{ kind: 'user', id: 30, username: 'dave', hidden: true }],
+        removed: [],
+      })
+    );
+
+    expect(res.hiddenUsers).toContainEqual({ id: 30, username: 'dave', hidden: true });
+  });
+
   it('server-diff reconcile (added/removed) matches across shapes', () => {
     const res = bothShapesAgree('hiddenModels', (cache) =>
       reconcileHiddenToggle(cache, 'model', [], {

--- a/src/shared/hidden-preferences/compact.ts
+++ b/src/shared/hidden-preferences/compact.ts
@@ -37,6 +37,7 @@
 import produce from 'immer';
 import type {
   HiddenImage,
+  HiddenPreferencesKind,
   HiddenPreferenceTypes,
   HiddenTag,
   HiddenUser,
@@ -212,6 +213,15 @@ export function applyOptimisticHiddenToggle(
  * Apply the server's `added`/`removed` diff. Same shape-branching as the optimistic
  * path; object sets replace-in-place to pick up server-provided fields.
  *
+ * The item type is the server's, not `{ id: number }`, because what goes into the
+ * cache is the whole item minus `kind` — a tag's `name`/`nsfwLevel`, a user's
+ * `username`, all of which the account pages render. The narrower type could not
+ * describe that and needed a cast to an index signature to compile.
+ *
+ * The compiler still cannot enforce it: immer's draft is `any`, so dropping the
+ * payload type-checks. The test asserting `username` survives a server diff is the
+ * guard.
+ *
  * Module-private on purpose: it ignores `hidden`, so a caller that reaches for it
  * instead of `reconcileHiddenToggle` silently keeps an optimistic write the server
  * refused. Go through `reconcileHiddenToggle`.
@@ -219,8 +229,8 @@ export function applyOptimisticHiddenToggle(
 function applyServerHiddenToggle(
   cache: HiddenCache,
   key: string,
-  added: Array<{ id: number }>,
-  removed: Array<{ id: number }>
+  added: Array<HiddenPreferencesKind>,
+  removed: Array<HiddenPreferencesKind>
 ): HiddenCache {
   return produce(cache, (draft: any) => {
     if (isCompactIdKey(draft, key)) {
@@ -229,12 +239,12 @@ function applyServerHiddenToggle(
       for (const { id } of removed) toggleCompactId(arr, id, false);
       return;
     }
-    for (const { kind, id, ...props } of added as Array<Record<string, unknown> & { id: number }>) {
-      const index = draft[key].findIndex((x: any) => x.id === id && x.hidden);
-      if (index === -1) draft[key].push({ id, ...props });
-      else draft[key][index] = { id, ...props };
+    for (const { kind, ...item } of added) {
+      const index = draft[key].findIndex((x: any) => x.id === item.id && x.hidden);
+      if (index === -1) draft[key].push(item);
+      else draft[key][index] = item;
     }
-    for (const { kind, id, ...props } of removed as Array<Record<string, unknown> & { id: number }>) {
+    for (const { id } of removed) {
       const index = draft[key].findIndex((x: any) => x.id === id && x.hidden);
       if (index > -1) draft[key].splice(index, 1);
     }
@@ -269,7 +279,11 @@ export function reconcileHiddenToggle(
   cache: HiddenCache,
   kind: HiddenToggleKind,
   items: Array<{ id: number }>,
-  result: { added: Array<{ id: number }>; removed: Array<{ id: number }>; hidden?: boolean }
+  result: {
+    added: Array<HiddenPreferencesKind>;
+    removed: Array<HiddenPreferencesKind>;
+    hidden?: boolean;
+  }
 ): HiddenCache {
   const key = HIDDEN_KIND_TO_KEY[kind];
   const next = applyServerHiddenToggle(cache, key, result.added, result.removed);
@@ -301,7 +315,11 @@ export const EMPTY_HIDDEN_CACHE = {
 export function applyToggleSuccess(
   cache: HiddenCache | undefined,
   variables: { kind: HiddenToggleKind; data: Array<{ id: number }> },
-  result: { added: Array<{ id: number }>; removed: Array<{ id: number }>; hidden?: boolean }
+  result: {
+    added: Array<HiddenPreferencesKind>;
+    removed: Array<HiddenPreferencesKind>;
+    hidden?: boolean;
+  }
 ): HiddenCache {
   return reconcileHiddenToggle(cache ?? EMPTY_HIDDEN_CACHE, variables.kind, variables.data, result);
 }

--- a/src/shared/hidden-preferences/compact.ts
+++ b/src/shared/hidden-preferences/compact.ts
@@ -258,8 +258,8 @@ export type HiddenToggleKind = keyof typeof HIDDEN_KIND_TO_KEY;
  * from `onMutate` — the `added`/`removed` diff cannot, because five of the six
  * kinds return both empty on every call.
  *
- * Takes the whole `result` rather than a destructured `hidden` so a caller cannot
- * drop the field and silently make the override inert.
+ * Takes the whole `result` rather than a destructured `hidden`, which removes one
+ * way to make the override inert — not the only one; see `applyToggleSuccess`.
  *
  * `hidden` is one flag for the whole batch, matching the server, which inspects
  * only `data[0]` for the kinds that send it. Both current senders pass a single
@@ -275,4 +275,44 @@ export function reconcileHiddenToggle(
   const next = applyServerHiddenToggle(cache, key, result.added, result.removed);
   if (result.hidden === undefined) return next;
   return applyOptimisticHiddenToggle(next, key, items, result.hidden);
+}
+
+/**
+ * The empty legacy cache used when `getHidden` has not populated yet. Rare —
+ * `getHidden` is prefetched — and a real fetch overwrites it; `expandHiddenPreferences`
+ * reads the legacy shape fine.
+ */
+export const EMPTY_HIDDEN_CACHE = {
+  hiddenImages: [],
+  hiddenModels: [],
+  hiddenModel3Ds: [],
+  hiddenUsers: [],
+  hiddenTags: [],
+  blockedUsers: [],
+  blockedByUsers: [],
+} as unknown as HiddenCache;
+
+/**
+ * The whole of the mutation's `onSuccess` cache write, so the wiring is executable
+ * without React Query. Kept here rather than inline in the hook because nothing in
+ * the repo runs that hook: mutating the arguments of the inline version left the
+ * entire suite green while reinstating the phantom state this exists to prevent.
+ */
+export function applyToggleSuccess(
+  cache: HiddenCache | undefined,
+  variables: { kind: HiddenToggleKind; data: Array<{ id: number }> },
+  result: { added: Array<{ id: number }>; removed: Array<{ id: number }>; hidden?: boolean }
+): HiddenCache {
+  return reconcileHiddenToggle(cache ?? EMPTY_HIDDEN_CACHE, variables.kind, variables.data, result);
+}
+
+/**
+ * What `onError` must do with the cache. React Query treats an `undefined` updater
+ * result as "no update", so handing back a missing snapshot silently leaves the
+ * optimistic write standing forever — refetching is the only correct fallback.
+ */
+export function planToggleRollback(
+  previous: HiddenCache | undefined
+): { restore: HiddenCache } | { invalidate: true } {
+  return previous === undefined ? { invalidate: true } : { restore: previous };
 }

--- a/src/shared/hidden-preferences/compact.ts
+++ b/src/shared/hidden-preferences/compact.ts
@@ -209,11 +209,14 @@ export function applyOptimisticHiddenToggle(
 }
 
 /**
- * Reconcile the cache with the server's authoritative `added`/`removed` diff
- * (the `toggleHidden` mutation result). Same shape-branching as the optimistic
+ * Apply the server's `added`/`removed` diff. Same shape-branching as the optimistic
  * path; object sets replace-in-place to pick up server-provided fields.
+ *
+ * Module-private on purpose: it ignores `hidden`, so a caller that reaches for it
+ * instead of `reconcileHiddenToggle` silently keeps an optimistic write the server
+ * refused. Go through `reconcileHiddenToggle`.
  */
-export function applyServerHiddenToggle(
+function applyServerHiddenToggle(
   cache: HiddenCache,
   key: string,
   added: Array<{ id: number }>,
@@ -236,4 +239,40 @@ export function applyServerHiddenToggle(
       if (index > -1) draft[key].splice(index, 1);
     }
   });
+}
+
+export const HIDDEN_KIND_TO_KEY = {
+  image: 'hiddenImages',
+  model: 'hiddenModels',
+  model3d: 'hiddenModel3Ds',
+  tag: 'hiddenTags',
+  user: 'hiddenUsers',
+  blockedUser: 'blockedUsers',
+} as const;
+
+export type HiddenToggleKind = keyof typeof HIDDEN_KIND_TO_KEY;
+
+/**
+ * Fold a `toggleHidden` response into the cache. `hidden`, when the toggle sends
+ * one, is the server's authoritative outcome and overrides the optimistic write
+ * from `onMutate` — the `added`/`removed` diff cannot, because five of the six
+ * kinds return both empty on every call.
+ *
+ * Takes the whole `result` rather than a destructured `hidden` so a caller cannot
+ * drop the field and silently make the override inert.
+ *
+ * `hidden` is one flag for the whole batch, matching the server, which inspects
+ * only `data[0]` for the kinds that send it. Both current senders pass a single
+ * id; a multi-select hide would need it keyed by id first.
+ */
+export function reconcileHiddenToggle(
+  cache: HiddenCache,
+  kind: HiddenToggleKind,
+  items: Array<{ id: number }>,
+  result: { added: Array<{ id: number }>; removed: Array<{ id: number }>; hidden?: boolean }
+): HiddenCache {
+  const key = HIDDEN_KIND_TO_KEY[kind];
+  const next = applyServerHiddenToggle(cache, key, result.added, result.removed);
+  if (result.hidden === undefined) return next;
+  return applyOptimisticHiddenToggle(next, key, items, result.hidden);
 }


### PR DESCRIPTION
Closes ClickUp 868kurj0y. **Also closes 868kurrfj** — that ticket's entire subject is
the dead-code pair deleted in part 3, and it asked for the affected test cases to be
repointed rather than dropped, which is what happened.

Follow-up to #4230, which fixed the server side of the Block > Hide > Follow levels
and explicitly left the UI out of scope. Precedence confirmed with Justin on
2026-08-20: the three engagement types behave as levels with Block highest, and the UI
should not offer Hide on a user you have already blocked.

## 1. The Hide control is no longer offered on a blocked user

`HideUserButton` returns `null` when the viewer has blocked the target. Fixed inside
the component rather than at each of its 10 call sites — it already calls
`useHiddenPreferencesData()`, which carries `blockedUsers` (exactly what the sibling
`BlockUserButton` reads), so one gate covers every call site.

Hidden rather than disabled: a disabled item owes the reader a reason, and the reason
is a three-level precedence model that does not fit in a menu tooltip.

**This is not unconditional, and that matters.** `blockedUsers` comes from the
`getHidden` React-Query cache, which is empty while that query is in flight, so on a
cold client — or in a tab open since before the block was set on another device — the
control still renders. Parts 2 and the toast below are the backstops for exactly that
window.

`src/pages/models/[id]/[[...slug]].tsx` was the one call site of ten with no sibling
`BlockUserButton`, so hiding the control there would have made it vanish with no
unblock in that menu. It now has one.

## 2. A refused hide no longer leaves phantom client state

The ticket recorded pressing Hide on a blocked user as "now harmless". It was not:
`onMutate` optimistically marks the target hidden, the server refuses, and
`onSuccess` → `applyServerHiddenToggle(old, key, [], [])` is a **no-op on empty
arrays** — so the optimistic write was never reconciled away and the success toast
fired anyway.

**The obvious fix — treat an empty diff as a refusal — would have shipped a
regression.** `{added: [], removed: []}` is the *normal* return for five of the six
`toggleHidden` kinds (`toggleHiddenTags` is the only one computing a real diff), so
"empty diff ⇒ refused" is inverted for the common case: every successful model, image,
model3d and blockedUser hide would have visually undone itself on success.

Instead `HiddenPreferencesDiff` gains an optional `hidden` — the authoritative
outcome, sent only by toggles the server can refuse. `toggleHideUser` populates it from
`setUserEngagement`'s boolean return, which was previously discarded. That distinction
is load-bearing: `hidden` is the *write's* answer, not a re-derivation of the
pre-write read, so a Block arriving between the two is reported correctly.

**The toast now has three outcomes, not two.** The server refuses in exactly one case —
the viewer has already blocked the target — so the content genuinely is suppressed.
Mapping that onto the un-hide copy told the viewer a block they set was not in effect.
It now says the block is already covering them.

The other two titles were rewritten with it, since the set has to read together:
"User hidden" / "User unhidden" / "User already blocked". The old copy produced
"User marked as show", which is not grammatical, and the new pair matches the
control's own Hide/Unhide labels so the confirmation names what the button did.
(A pre-existing double space in the message is fixed too.)

## 3. Dead code removed

`toggleHideUserHandler` was exported from `user.controller.ts` and wired to no router.
Deleting it orphaned `toggleHideUser` in `user.service.ts` — a second writer on
`UserEngagement`, which `user-engagement.ts`'s header comment calls out as a hazard in
its own right; with it gone, that comment's "three sanctioned outside writers" count is
now accurate rather than aspirational.

No telemetry is lost: the handler was on no router, so user-hide engagement was never
tracked in ClickHouse, before or after.

The same pair exists one table over and goes with it: `toggleHideModelHandler` is on no
router either, and deleting it orphans `toggleModelHide` — the `type: 'Hide'`
specialisation of `toggleModelEngagement`. The general function stays; it is live via
`toggleModelNotify` and two controller call sites, and covered by
`engagement-toggle.idempotent.service.test.ts`. No tests referenced either deleted pair,
so none needed repointing.

`toggleFollowUser` still converts a Hide row into a Follow — left alone deliberately per
the ticket.

## 4. The same intent bug, three tables over

`toggleHidden` forwarded the caller's `hidden` only for `kind: 'user'`. The `image`,
`model` and `model3d` cases got the id alone and blind-flipped off whatever row they
found, so **an explicit un-hide of an unengaged entity created a Hide row**, and an
explicit hide of an already-hidden one deleted it. Both are the inverse of the request,
and both are reachable from any caller of `hiddenPreferences.toggleHidden`.

Each now derives `hiding` from `setTo ?? engagement?.type !== 'Hide'` — the shape the
user path already had — and reports the outcome as `hidden`, so a client whose
optimistic flip disagreed with the row is corrected instead of keeping phantom state.

**Every in-app caller omits `hidden`**, so the flip is the path the product uses and
nothing about today's UI behaviour changes:

| Caller | kind | sends `hidden`? |
| --- | --- | --- |
| `HideModelButton`, `HideImageButton`, `HideModel3DButton` | model / image / model3d | no — ids only |
| `HiddenTagsSection` (×2), `VotableTag` | tag | no |
| `HiddenUsersSection` (×2) | user | no |
| `HideUserButton` | user | yes |
| `BlockUserButton` (×2) | blockedUser | yes |
| `BlockModelTagsModal`, `BrowsingCategories` | tag | yes |

The compatibility case — omitted `hidden` still flips exactly as before — is asserted
per kind rather than assumed.

`toggleModelEngagement`'s update branch converted a row in place and never refreshed
the hidden-models cache. The delete and create branches test the **new** type, which is
not enough here: `Notify → Hide` left the model showing, and `Hide → Notify` left it
filtered out. Both are reachable from the live `user.toggleNotifyModel`, whose input
declares the full `ModelEngagementType` enum plus `setTo`.

## Scope beyond the ticket — flagged, not buried

- **`src/components/Account/HiddenUsersSection.tsx`** — the "Search users to hide"
  autocomplete is a *second* `kind: 'user'` writer and not a `HideUserButton` call site,
  so the gate above does not reach it. It offered exactly the defect in this ticket's
  title, and part 2 made it worse: the optimistic badge now correctly reverts and that
  component shows no toast, so hiding a blocked user there produced **no feedback at
  all**. Blocked users are now filtered out of its options. **This is the one change in
  a file the ticket never names — say the word and I'll split it out.**
- **The mutation's cache wiring moved into `compact.ts`** (`applyToggleSuccess`,
  `planToggleRollback`, `HIDDEN_KIND_TO_KEY`). Nothing in the repo runs
  `useToggleHiddenPreferences`, so the fix in part 2 originally lived in a line no test
  could observe — mutating its arguments left the whole suite green while reinstating
  the phantom state. The hook is now a pass-through. `onError` moved for the same
  reason: React Query reads an `undefined` updater result as "no update", so restoring a
  missing snapshot would have left an optimistic hide standing permanently.
- `applyServerHiddenToggle` is now module-private — it ignores `hidden`, so a future
  caller reaching past `reconcileHiddenToggle` would silently reintroduce the phantom
  state this PR removes.
- **`added`/`removed` now carry the server's own item type** rather than
  `Array<{ id: number }>`. The bodies destructure `...props` off those items and write
  the result into the cache, which the narrow type could not describe — each loop had
  a cast to `Array<Record<string, unknown> & { id: number }>` to compile. Both casts are
  gone. The compiler still cannot enforce the payload (immer's draft is `any`), so a
  test asserting a server-added user keeps its `username` is the actual guard.

## Tests

- `HideUserButton.browser.test.tsx` (new, 9) — absent for a blocked target in both
  variants, present when not blocked, still present as "Unhide" when hidden-not-blocked,
  absent when in **both** lists (the phantom state itself), and the toast in all three
  outcomes including that a refusal never claims the content will show up.
- `HiddenUsersSection.browser.test.tsx` (new, 2) — covers the *argument* wiring the
  helper's own unit tests cannot see.
- `compact.test.ts` (+11) — refusal, grant, and an omitted `hidden` in **both**
  directions; the wiring layer's kind/ids forwarding and empty-cache substitution; the
  rollback plan; and that the accepted path returns the base cache **by reference**,
  which is what keeps `expandHiddenPreferences` and the provider's Maps from rebuilding;
  and that a server-added user keeps its `username` through the diff.
- `hidden-users-options.test.ts` (new, 4), and outcome assertions plus a
  Block-arrives-after-the-read case in `toggle-hide-user.service.test.ts`.

Every fix is mutation-checked and fails fast and legibly rather than by timeout.

One deviation worth naming: the `~/hooks/hidden-preferences` mock in the button test is
hand-listed rather than `importOriginal`, because spreading the real barrel loads
`~/utils/trpc` and drags `CivitaiSessionContext` into the render, failing all nine tests
at the matcher ceiling. A barrel-surface assertion gives the same protection without the
import — and it immediately caught a hand-listed `~/utils/notifications` mock that was
hiding `showErrorNotification`, which is now `importOriginal`.

Original tickets: 868kun67j / 868kunqg5 / 868kumcfc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeeJXStZA5ebfrCMVsxrRn
