### PR TITLE
feat(feed): bring back the tag bar on /images and /videos, instrumented

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2094,6 +2094,7 @@ const REDIS_KEYS_UNPREFIXED = {
     TAGS_NEEDING_REVIEW: 'system:tags-needing-review',
     TAGS_BLOCKED: 'system:tags-blocked',
     HOME_EXCLUDED_TAGS: 'system:home-excluded-tags',
+    FEED_TAG_BAR_TAGS: 'system:feed-tag-bar-tags',
     BLOCKLIST: 'system:blocklist',
     PROMPT_ALLOWLIST: 'packed:system:prompt-allowlist',
     NOTIFICATION_COUNTS: 'system:notification-counts',

--- a/src/components/CategoryTags/CategoryTags.tsx
+++ b/src/components/CategoryTags/CategoryTags.tsx
@@ -1,8 +1,7 @@
-import { Button, useComputedColorScheme } from '@mantine/core';
-
 import { useModelQueryParams } from '~/components/Model/model.utils';
+import type { TagChipRowItem } from '~/components/Tags/TagChipRow';
+import { TagChipRow } from '~/components/Tags/TagChipRow';
 import { useCategoryTags } from '~/components/Tags/tag.utils';
-import { TwScrollX } from '~/components/TwScrollX/TwScrollX';
 import { TagTarget } from '~/shared/utils/prisma/enums';
 
 // `selected` without `setSelected` would be silently discarded — the bar reads the URL
@@ -23,18 +22,9 @@ export function CategoryTags({
   filter,
   includeAll = true,
 }: CategoryTagsProps) {
-  const colorScheme = useComputedColorScheme('dark');
   const { set, tag: tagQuery } = useModelQueryParams();
 
   const { data: categories } = useCategoryTags({ entityType: TagTarget.Model });
-
-  // Reserve the row height while the client-side `useCategoryTags` query and the hidden
-  // preferences resolve. Returning null lets the chip row pop in and shove the feed down —
-  // the shift `docs/cls-remediation-plan.md` measured at 0.65 on /images. That fix landed
-  // in TagScroller, which these surfaces never used. 26px is Mantine's
-  // `--button-height-compact-sm`; both states must carry it or the row shifts one way or
-  // the other.
-  if (!categories.length) return <div className="min-h-[26px]" />;
 
   const handleSetTag = (tag: string | undefined) => set({ tag });
 
@@ -45,36 +35,24 @@ export function CategoryTags({
   const _tag = controlled ? selected : tagQuery;
   const _setTag = setSelected ?? handleSetTag;
 
+  // This bar identifies a category by NAME — `?tag=` carries the name, not the id — so the
+  // row's id is the name here. Tag names are unique, so it is still a stable key.
+  const items = categories
+    .filter((x) => (filter ? filter(x.name) : true))
+    .map((tag) => ({ id: tag.name, label: tag.name }));
+
+  const handleSelect = (item: TagChipRowItem) => _setTag(_tag === item.id ? undefined : item.label);
+
   return (
-    <TwScrollX className="flex min-h-[26px] gap-1">
-      {includeAll && (
-        <Button
-          className="overflow-visible uppercase"
-          variant={!_tag ? 'filled' : colorScheme === 'dark' ? 'filled' : 'light'}
-          color={!_tag ? 'blue' : 'gray'}
-          onClick={() => _setTag(undefined)}
-          size="compact-sm"
-        >
-          All
-        </Button>
-      )}
-      {categories
-        .filter((x) => (filter ? filter(x.name) : true))
-        .map((tag) => {
-          const active = _tag === tag.name;
-          return (
-            <Button
-              key={tag.id}
-              className="overflow-visible uppercase"
-              variant={active ? 'filled' : colorScheme === 'dark' ? 'filled' : 'light'}
-              color={active ? 'blue' : 'gray'}
-              onClick={() => _setTag(!active ? tag.name : undefined)}
-              size="compact-sm"
-            >
-              {tag.name}
-            </Button>
-          );
-        })}
-    </TwScrollX>
+    <TagChipRow
+      items={items}
+      activeId={_tag}
+      onSelect={handleSelect}
+      onClear={() => _setTag(undefined)}
+      includeAll={includeAll}
+      // Pre-filter, deliberately: a `filter` that empties the list still leaves the All
+      // chip rendered, which is what this bar did before the row was shared.
+      loading={!categories.length}
+    />
   );
 }

--- a/src/components/Image/Filters/ImageFeedTagBar.tsx
+++ b/src/components/Image/Filters/ImageFeedTagBar.tsx
@@ -1,0 +1,77 @@
+import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { useImageQueryParams } from '~/components/Image/image.utils';
+import type { TagChipRowItem } from '~/components/Tags/TagChipRow';
+import { TagChipRow } from '~/components/Tags/TagChipRow';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
+import { trpc } from '~/utils/trpc';
+
+type FeedTagBarFeed = 'images' | 'videos';
+
+/**
+ * Single-select tag row for `/images` and `/videos`, writing `?tags=<id>`.
+ *
+ * Single-select rather than the ctrl-click stacking the old `TagScroller` had: two chips
+ * is an AND across tags, which lands on an empty feed for most pairs here, and it was
+ * undiscoverable anyway.
+ *
+ * The `All` chip is not decoration — it is the only UI on these feeds that can widen a
+ * `?tags=` deep link back out (`ActiveTagFilter`, written for that job, is mounted
+ * nowhere; ClickUp 868kuq3jk). It clears whatever is in `?tags=`, including ids that are
+ * not chips on this bar.
+ */
+export function ImageFeedTagBar({ feed }: { feed: FeedTagBarFeed }) {
+  const { trackAction } = useTrackEvent();
+
+  // The same hook the feed itself filters through (`useImageFilters` → `query.tags`).
+  // Reading `router.query` directly here instead would give the chips and the feed two
+  // different parsers for one param, and the symptom of them drifting is a chip that
+  // looks unselected while the feed is filtered.
+  const { query, replace } = useImageQueryParams();
+  const tagIds = query.tags ?? [];
+
+  const { data } = trpc.tag.getFeedTagBar.useQuery();
+  const { items: tags, loadingPreferences } = useApplyHiddenPreferences({
+    type: 'tags',
+    data,
+  });
+
+  // A chip is active only when it is the sole filter — anything else came from a deep
+  // link this bar cannot represent, and lighting one chip of several would misdescribe it.
+  const activeId = tagIds.length === 1 ? tagIds[0] : undefined;
+
+  const emit = (item: { id: number; name: string } | undefined) =>
+    trackAction({
+      type: 'Feed_TagBar_Click',
+      details: {
+        feed,
+        tag: item?.name ?? null,
+        tagId: item?.id ?? null,
+        action: item ? 'select' : 'clear',
+      },
+    }).catch(() => undefined);
+
+  const handleSelect = (item: TagChipRowItem) => {
+    const id = item.id as number;
+    const active = activeId === id;
+    emit(active ? undefined : { id, name: item.label });
+    replace({ tags: active ? [] : [id] });
+  };
+
+  const handleClear = () => {
+    emit(undefined);
+    replace({ tags: [] });
+  };
+
+  return (
+    <TagChipRow
+      items={tags.map((tag) => ({ id: tag.id, label: tag.name }))}
+      activeId={activeId}
+      onSelect={handleSelect}
+      onClear={handleClear}
+      // Holding the row until preferences resolve keeps a tag the viewer has personally
+      // hidden from flashing as a chip: the chip list is edge-cached and the preferences
+      // are a per-user fetch, so the list usually wins the race.
+      loading={loadingPreferences || !tags.length}
+    />
+  );
+}

--- a/src/components/Image/Filters/__tests__/ImageFeedTagBar.test.ts
+++ b/src/components/Image/Filters/__tests__/ImageFeedTagBar.test.ts
@@ -1,0 +1,409 @@
+// @vitest-environment happy-dom
+import fs from 'fs';
+import path from 'path';
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as HiddenPreferences from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import type * as TrackUtils from '~/components/TrackView/track.utils';
+import type * as TrpcModule from '~/utils/trpc';
+
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+  pathname: '/images',
+  query: {} as Record<string, unknown>,
+  tags: [] as { id: number; name: string; nsfwLevel: number }[],
+  hiddenTagIds: [] as number[],
+  loadingPreferences: false,
+  maxNsfwLevel: 1,
+  trackAction: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ query: mocks.query, pathname: mocks.pathname, replace: mocks.replace }),
+}));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: { tag: { getFeedTagBar: { useQuery: () => ({ data: mocks.tags }) } } },
+}));
+
+// Stands in for the real hidden-preferences provider, which needs a session + query
+// client. `hiddenTagIds` drives it so the bar's use of it is observable rather than
+// assumed — a bar that ignored the hook would keep rendering a hidden chip.
+vi.mock('~/components/HiddenPreferences/useApplyHiddenPreferences', async (importOriginal) => ({
+  ...(await importOriginal<typeof HiddenPreferences>()),
+  useApplyHiddenPreferences: ({ data }: { data?: { id: number; nsfwLevel?: number }[] }) => ({
+    // Models the two arms the bar depends on: the viewer's own hidden tags, and the
+    // browsing-level cut the real hook makes on `tag.nsfwLevel`. The level arm is why
+    // `getFeedTagBarTags` ships that field at all, so a stand-in that ignored it would
+    // leave the reason the column is selected untested.
+    items: (data ?? []).filter(
+      (x) => !mocks.hiddenTagIds.includes(x.id) && (x.nsfwLevel ?? 1) <= mocks.maxNsfwLevel
+    ),
+    loadingPreferences: mocks.loadingPreferences,
+  }),
+}));
+
+vi.mock('~/components/TrackView/track.utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrackUtils>()),
+  useTrackEvent: () => ({
+    trackAction: mocks.trackAction,
+    trackSearch: vi.fn(),
+    trackShare: vi.fn(),
+  }),
+}));
+
+import { MantineProvider } from '@mantine/core';
+
+import { ImageFeedTagBar } from '~/components/Image/Filters/ImageFeedTagBar';
+import { FEED_TAG_BAR_TAG_NAMES } from '~/server/common/feed-tag-bar.constants';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function render(feed: 'images' | 'videos' = 'images') {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    createRoot(container).render(
+      createElement(
+        MantineProvider,
+        { forceColorScheme: 'light' },
+        createElement(ImageFeedTagBar, { feed })
+      )
+    );
+  });
+  return container;
+}
+
+function buttonLabels(container: HTMLElement) {
+  return Array.from(container.querySelectorAll('button')).map((b) => b.textContent?.trim());
+}
+
+function clickButton(container: HTMLElement, label: string) {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    (b) => b.textContent?.trim() === label
+  );
+  if (!button) throw new Error(`no button labelled ${label}; found ${buttonLabels(container)}`);
+  act(() => {
+    button.click();
+  });
+}
+
+function reservedRows(container: HTMLElement) {
+  return Array.from(container.querySelectorAll('div')).filter((el) =>
+    el.className.includes('min-h-[26px]')
+  );
+}
+
+function lastReplacedQuery() {
+  const [target] = mocks.replace.mock.calls[mocks.replace.mock.calls.length - 1];
+  return (target as { query: Record<string, unknown> }).query;
+}
+
+describe('ImageFeedTagBar', () => {
+  beforeEach(() => {
+    mocks.replace.mockClear();
+    mocks.trackAction.mockClear();
+    mocks.pathname = '/images';
+    mocks.query = {};
+    mocks.hiddenTagIds = [];
+    mocks.maxNsfwLevel = 1;
+    mocks.loadingPreferences = false;
+    mocks.tags = [
+      { id: 4, name: 'anime', nsfwLevel: 1 },
+      { id: 5248, name: 'realistic', nsfwLevel: 1 },
+    ];
+  });
+
+  it('renders the All chip plus every tag, in the order the server sent them', () => {
+    const container = render();
+    expect(buttonLabels(container)).toEqual(['All', 'anime', 'realistic']);
+  });
+
+  it('writes ?tags=<id> on select, preserving the rest of the query', () => {
+    mocks.query = { sort: 'Newest' };
+    const container = render();
+
+    clickButton(container, 'anime');
+
+    expect(mocks.replace).toHaveBeenCalledTimes(1);
+    expect(lastReplacedQuery()).toEqual({ sort: 'Newest', tags: [4] });
+  });
+
+  it('replaces rather than stacks when a second chip is chosen', () => {
+    mocks.query = { tags: ['4'] };
+    const container = render();
+
+    clickButton(container, 'realistic');
+
+    expect(lastReplacedQuery()).toEqual({ tags: [5248] });
+  });
+
+  it('toggles the active chip back off', () => {
+    mocks.query = { tags: ['4'], sort: 'Newest' };
+    const container = render();
+
+    clickButton(container, 'anime');
+
+    expect(lastReplacedQuery()).toEqual({ sort: 'Newest' });
+    expect(lastReplacedQuery()).not.toHaveProperty('tags');
+  });
+
+  // The reason the All chip is not decoration: ActiveTagFilter is mounted nowhere
+  // (868kuq3jk), so before this bar a ?tags= deep link on /images could not be widened
+  // by any UI. An id that is not a chip here is exactly that case.
+  it('clears a ?tags= deep link whose id is not one of the chips', () => {
+    mocks.query = { tags: ['999999'], sort: 'Newest' };
+    const container = render();
+
+    expect(buttonLabels(container)).toEqual(['All', 'anime', 'realistic']);
+
+    clickButton(container, 'All');
+
+    expect(lastReplacedQuery()).toEqual({ sort: 'Newest' });
+  });
+
+  // Named for what it asserts: the press DOES write, with `tags` absent. `lastReplacedQuery`
+  // throws when `replace` was never called, so the explicit call-count assertion goes
+  // first — otherwise adding a no-op guard to `handleClear` fails here as an unreadable
+  // TypeError rather than a named expectation.
+  it('writes an empty query when All is pressed on an already-unfiltered feed', () => {
+    const container = render();
+
+    clickButton(container, 'All');
+
+    expect(mocks.replace).toHaveBeenCalledTimes(1);
+    expect(lastReplacedQuery()).toEqual({});
+  });
+
+  it('drops a chip the viewer has hidden, keeping the rest', () => {
+    mocks.hiddenTagIds = [4];
+    const container = render();
+
+    expect(buttonLabels(container)).toEqual(['All', 'realistic']);
+  });
+
+  // `getFeedTagBarTags` resolves each chip's nsfwLevel through the parent-tag rollup and
+  // ships it precisely so this cut can happen. Without a case, the curated list could
+  // gain a chip whose effective level is above the viewer's browsing level and nothing
+  // would notice.
+  it('drops a chip whose nsfwLevel is above the viewer browsing level', () => {
+    mocks.tags = [
+      { id: 4, name: 'anime', nsfwLevel: 1 },
+      { id: 5140, name: 'furry', nsfwLevel: 16 },
+    ];
+    const container = render();
+
+    expect(buttonLabels(container)).toEqual(['All', 'anime']);
+
+    // Positive control: the same chip renders for a viewer whose level admits it, so the
+    // absence above is the level cut and not a broken fixture.
+    mocks.maxNsfwLevel = 16;
+    expect(buttonLabels(render())).toEqual(['All', 'anime', 'furry']);
+  });
+
+  // The bar writes ONE id, Next serialises that as `?tags=4`, and Next parses a single
+  // occurrence back as a bare string — not an array. That round-trip is the one the bar
+  // creates for itself every time someone shares or reloads a filtered link, so the
+  // array-shaped fixtures elsewhere never exercise it.
+  it('reads a single-occurrence ?tags= that arrives as a bare string', () => {
+    mocks.query = { tags: '4' };
+    const container = render();
+
+    clickButton(container, 'anime');
+
+    // Active, so the press toggles it off — which only happens if '4' parsed to 4.
+    expect(lastReplacedQuery()).not.toHaveProperty('tags');
+  });
+
+  // The component is mounted on two routes and its whole reason for a `feed` prop is that
+  // it is shared. Asserting only `.query` leaves a hardcoded pathname — which would send
+  // every /videos chip click to /images — completely invisible. `shallow`/`scroll` ride
+  // along here for the same reason: dropping either is silent and user-visible (a full
+  // refetch, or the feed jumping to the top on every press).
+  it('replaces on the route it is mounted on, shallow and without scrolling', () => {
+    mocks.pathname = '/videos';
+    const container = render('videos');
+
+    clickButton(container, 'realistic');
+
+    expect(mocks.replace).toHaveBeenCalledWith(
+      { pathname: '/videos', query: { tags: [5248] } },
+      undefined,
+      { shallow: true, scroll: false }
+    );
+  });
+
+  it('reserves the row height before the tags resolve', () => {
+    mocks.tags = [];
+    const container = render();
+
+    expect(container.querySelector('button')).toBeNull();
+    expect(reservedRows(container)).toHaveLength(1);
+  });
+
+  // The chip list is edge-cached and the hidden preferences are a per-user fetch, so the
+  // list usually wins the race. Rendering during that window flashes a chip for a tag the
+  // viewer has personally hidden.
+  it('renders no chips until hidden preferences resolve', () => {
+    mocks.loadingPreferences = true;
+    const container = render();
+
+    expect(container.querySelector('button')).toBeNull();
+    // Positive control: the same data renders chips once preferences have loaded, so this
+    // is not passing because the fixture is empty.
+    expect(reservedRows(container)).toHaveLength(1);
+
+    mocks.loadingPreferences = false;
+    expect(buttonLabels(render())).toEqual(['All', 'anime', 'realistic']);
+  });
+});
+
+/**
+ * The bar ships on the condition that its click-through is measurable — under 10% of
+ * feed viewers pressing a chip and it comes back out. Every assertion here is about
+ * that number existing at all.
+ */
+describe('ImageFeedTagBar click-through instrumentation', () => {
+  beforeEach(() => {
+    mocks.replace.mockClear();
+    mocks.trackAction.mockClear();
+    mocks.pathname = '/images';
+    mocks.query = {};
+    mocks.hiddenTagIds = [];
+    mocks.maxNsfwLevel = 1;
+    mocks.loadingPreferences = false;
+    mocks.tags = [
+      { id: 4, name: 'anime', nsfwLevel: 1 },
+      { id: 5248, name: 'realistic', nsfwLevel: 1 },
+    ];
+  });
+
+  it('emits Feed_TagBar_Click naming the chip and the feed on select', () => {
+    const container = render('images');
+
+    clickButton(container, 'anime');
+
+    expect(mocks.trackAction).toHaveBeenCalledTimes(1);
+    expect(mocks.trackAction).toHaveBeenCalledWith({
+      type: 'Feed_TagBar_Click',
+      details: { feed: 'images', tag: 'anime', tagId: 4, action: 'select' },
+    });
+  });
+
+  // Same component on two routes; a hardcoded feed would make the two indistinguishable
+  // in ClickHouse and there is no other column that separates them.
+  it('carries the videos feed through', () => {
+    mocks.pathname = '/videos';
+    const container = render('videos');
+
+    clickButton(container, 'realistic');
+
+    expect(mocks.trackAction).toHaveBeenCalledWith({
+      type: 'Feed_TagBar_Click',
+      details: { feed: 'videos', tag: 'realistic', tagId: 5248, action: 'select' },
+    });
+  });
+
+  it('records the All chip as a clear, with no tag', () => {
+    mocks.query = { tags: ['4'] };
+    const container = render();
+
+    clickButton(container, 'All');
+
+    expect(mocks.trackAction).toHaveBeenCalledWith({
+      type: 'Feed_TagBar_Click',
+      details: { feed: 'images', tag: null, tagId: null, action: 'clear' },
+    });
+  });
+
+  it('records toggling the active chip off as a clear', () => {
+    mocks.query = { tags: ['4'] };
+    const container = render();
+
+    clickButton(container, 'anime');
+
+    expect(mocks.trackAction).toHaveBeenCalledWith({
+      type: 'Feed_TagBar_Click',
+      details: { feed: 'images', tag: null, tagId: null, action: 'clear' },
+    });
+  });
+
+  it('fires exactly one event per press', () => {
+    const container = render();
+
+    clickButton(container, 'anime');
+    clickButton(container, 'realistic');
+
+    expect(mocks.trackAction).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * Rendering the component directly leaves every test above green if the JSX is deleted
+ * from the pages — which is how #4141 shipped ActiveTagFilter with a passing suite and
+ * no mount point anywhere. This is the only assertion that the bar is on the feeds.
+ */
+describe('the image and video feeds mount the tag bar', () => {
+  it.each([
+    ['src/pages/images/index.tsx', 'images'],
+    ['src/pages/videos/index.tsx', 'videos'],
+  ])('%s renders <ImageFeedTagBar feed="%s" />', (relative, feed) => {
+    const repoRoot = path.resolve(__dirname, '../../../../..');
+    const source = fs.readFileSync(path.join(repoRoot, ...relative.split('/')), 'utf-8');
+
+    // Commenting the mount out is likelier than deleting it, and leaves the string in
+    // place. Block comments are stripped first because that is what an editor's comment
+    // command produces over a multi-line selection.
+    //
+    // ⚠️ Known limits, both of which pass this guard while the bar renders for nobody:
+    // `{false && <ImageFeedTagBar … />}`, and — more reachable — `{features.someFlag &&
+    // <ImageFeedTagBar … />}`, since a missing Flipt flag reads as false here. Scanning
+    // source cannot see either. Worth knowing given this guard exists precisely because
+    // #4141 shipped a component mounted nowhere.
+    const code = source.replace(/\{\/\*[\s\S]*?\*\/\}/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+    const mounted = code
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.includes('<ImageFeedTagBar') && !line.startsWith('//'));
+
+    expect(source).toContain("from '~/components/Image/Filters/ImageFeedTagBar'");
+    expect(mounted).toHaveLength(1);
+    expect(mounted[0]).toContain(`feed="${feed}"`);
+  });
+});
+
+/**
+ * The chip set is curated, and the exclusions are the point of the curation: terms that
+ * would rank highly on demand are deliberately absent, and the guard exists so a later
+ * edit cannot quietly reintroduce one. A negative assertion alone passes against an
+ * empty list, so each is paired with a positive control.
+ */
+describe('FEED_TAG_BAR_TAG_NAMES', () => {
+  const names: readonly string[] = FEED_TAG_BAR_TAG_NAMES;
+
+  it('carries the curated chips', () => {
+    expect(names).toContain('anime');
+    expect(names).toContain('furry');
+    expect(names).toContain('realistic');
+    // Low-demand and kept on purpose — the instrumentation is what settles it, so a
+    // silent drop would remove the thing being measured. This is what pins it.
+    expect(names).toContain('mecha');
+    // Exact, not a floor: the set is deliberate, and >= 20 let any two unpinned chips
+    // be deleted silently.
+    expect(names).toHaveLength(22);
+  });
+
+  it.each(['teen', 'school'])('excludes %s', (excluded) => {
+    expect(names).toHaveLength(22);
+    expect(names).not.toContain(excluded);
+  });
+
+  it('holds lowercase, unique names', () => {
+    expect(names).toHaveLength(22);
+    expect(names).toEqual(names.map((n) => n.trim().toLowerCase()));
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/src/components/Tags/TagChipRow.tsx
+++ b/src/components/Tags/TagChipRow.tsx
@@ -1,0 +1,94 @@
+import { Button, useComputedColorScheme } from '@mantine/core';
+
+import { TwScrollX } from '~/components/TwScrollX/TwScrollX';
+
+// Mantine's `--button-height-compact-sm`, which is the size every chip below uses.
+//
+// 🔴 This number and that size are one fact in two places, and they have already drifted
+// apart once: the fix that reserves the row lived in the deleted `TagScroller`, so
+// `CategoryTags` never had it and the row popped in above the feed — the 0.65 CLS on
+// /images that `docs/cls-remediation-plan.md` measured. Both the empty and populated
+// states carry the reservation, because a row that collapses when it holds no chips
+// shifts the feed exactly as badly as one that appears late.
+const CHIP_ROW_MIN_HEIGHT = 'min-h-[26px]';
+
+function TagChip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const colorScheme = useComputedColorScheme('dark');
+
+  // In dark mode every chip is `filled`, so colour is the only thing separating active
+  // from inactive there.
+  return (
+    <Button
+      className="overflow-visible uppercase"
+      variant={active ? 'filled' : colorScheme === 'dark' ? 'filled' : 'light'}
+      color={active ? 'blue' : 'gray'}
+      onClick={onClick}
+      size="compact-sm"
+    >
+      {label}
+    </Button>
+  );
+}
+
+export type TagChipRowItem = { id: number | string; label: string };
+
+/**
+ * The chip row every tag filter bar is made of — the scroller, the height reservation,
+ * the optional All chip and the chips themselves.
+ *
+ * Shared because this row existed as two hand-maintained copies (`CategoryTags` and the
+ * deleted `TagScroller`) and the CLS fix went missing between them. Callers own the URL:
+ * what a chip means, and where the selection is stored, differs per surface.
+ */
+export function TagChipRow({
+  items,
+  activeId,
+  onSelect,
+  onClear,
+  includeAll = true,
+  loading = false,
+}: {
+  items: TagChipRowItem[];
+  /** `undefined` means nothing is selected, which is what fills the All chip. */
+  activeId?: number | string;
+  onSelect: (item: TagChipRowItem) => void;
+  onClear: () => void;
+  includeAll?: boolean;
+  /**
+   * Render the reservation and no chips. The CALLER decides this rather than the row
+   * inferring it from `items.length`: a caller that filters its own list can legitimately
+   * end up with zero chips and still want the All chip rendered, and that is what
+   * `CategoryTags` did before this row was extracted.
+   */
+  loading?: boolean;
+}) {
+  // The reservation sits on ONE wrapper both branches share, rather than on the
+  // placeholder and the scroller separately. Two elements holding the same height is a
+  // coupling nothing points at: give `TwScrollX` a border or padding later and the loaded
+  // branch grows while the placeholder does not, and the shift comes back.
+  return (
+    <div className={CHIP_ROW_MIN_HEIGHT}>
+      {!loading && (
+        <TwScrollX className="flex gap-1">
+          {includeAll && <TagChip label="All" active={activeId === undefined} onClick={onClear} />}
+          {items.map((item) => (
+            <TagChip
+              key={item.id}
+              label={item.label}
+              active={activeId === item.id}
+              onClick={() => onSelect(item)}
+            />
+          ))}
+        </TwScrollX>
+      )}
+    </div>
+  );
+}

--- a/src/pages/images/index.tsx
+++ b/src/pages/images/index.tsx
@@ -1,6 +1,7 @@
 import { Title } from '@mantine/core';
 import { FeedLayout } from '~/components/AppLayout/FeedLayout';
 import { Page } from '~/components/AppLayout/Page';
+import { ImageFeedTagBar } from '~/components/Image/Filters/ImageFeedTagBar';
 import { useImageQueryParams } from '~/components/Image/image.utils';
 import ImagesInfinite from '~/components/Image/Infinite/ImagesInfinite';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
@@ -23,6 +24,7 @@ export default Page(
           {/* <Announcements /> */}
           {hidden && <Title>Your Hidden Images</Title>}
           <div className="flex flex-col gap-2.5">
+            <ImageFeedTagBar feed="images" />
             <ImagesInfinite showEof showAds showFeedbackPrompt />
           </div>
         </MasonryContainer>

--- a/src/pages/videos/index.tsx
+++ b/src/pages/videos/index.tsx
@@ -1,6 +1,7 @@
 import { Stack, Title } from '@mantine/core';
 import { FeedLayout } from '~/components/AppLayout/FeedLayout';
 import { Page } from '~/components/AppLayout/Page';
+import { ImageFeedTagBar } from '~/components/Image/Filters/ImageFeedTagBar';
 import { useImageFilters } from '~/components/Image/image.utils';
 import ImagesInfinite from '~/components/Image/Infinite/ImagesInfinite';
 import { IsClient } from '~/components/IsClient/IsClient';
@@ -20,6 +21,7 @@ function VideosPage() {
       <MasonryContainer>
         {hidden && <Title>Your Hidden Videos</Title>}
         <Stack gap="xs">
+          <ImageFeedTagBar feed="videos" />
           <IsClient>
             <ImagesInfinite
               filterType="videos"

--- a/src/server/clickhouse/__tests__/action-type-enum-drift.test.ts
+++ b/src/server/clickhouse/__tests__/action-type-enum-drift.test.ts
@@ -1,0 +1,142 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { ActionType } from '~/server/clickhouse/tracker';
+import { trackActionSchema } from '~/server/schema/track.schema';
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '../migrations');
+
+/**
+ * `actions.type` is an Enum16 in ClickHouse. Emitting a value the column does not carry
+ * fails at the tracker service, which the app POSTs to fire-and-forget — so the browser
+ * sees a successful beacon, nothing is logged here, and the row never exists. The event
+ * looks instrumented and produces zero rows.
+ *
+ * Nothing else in the repo can catch that: typecheck is happy, the emitting component's
+ * tests are happy, and the query that comes up empty does so weeks later. This is the
+ * only place a new action type is forced to arrive with the DDL that lets it land.
+ */
+describe('actions.type enum drift', () => {
+  // 🔴 `--` comment lines are stripped first. These migrations carry the value in prose
+  // as well as in the DDL — a rationale, a verification snippet — so scanning the raw
+  // file stays green on a migration whose ALTER was deleted and whose comments were not.
+  // Measured: removing the `'Feed_TagBar_Click' = 22` arm left this guard passing.
+  const migrationSql = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .map((f) => fs.readFileSync(path.join(MIGRATIONS_DIR, f), 'utf-8'))
+    .join('\n')
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('--'))
+    .join('\n');
+
+  // 🔴 The enum is PARSED, not substring-matched. `toContain("'Feed_TagBar_Click'")` is a
+  // far weaker property than "a migration widens actions.type with this value", and four
+  // destructive edits were measured passing under it: renumbering the new value onto an
+  // index already in use, retargeting the ALTER at a different table, dropping a
+  // pre-existing value from the restated list, and gutting the ALTER while leaving the
+  // name in a `SELECT`.
+  //
+  // The dropped-value case is the one to understand: `MODIFY COLUMN Enum16(...)` REPLACES
+  // the whole definition, so any name missing from the restated list is removed from a
+  // live column. Nothing else in the repo asserts that list is complete.
+  const enumBlocks = [
+    ...migrationSql.matchAll(
+      /ALTER\s+TABLE\s+([\w.]+)\s+MODIFY\s+COLUMN\s+`?type`?\s+Enum16\s*\(([^)]*)\)/gi
+    ),
+  ].map((m) => ({
+    table: m[1].toLowerCase(),
+    arms: new Map<string, number>(
+      [...m[2].matchAll(/'([A-Za-z0-9_]+)'\s*=\s*(\d+)/g)].map((a) => [a[1], Number(a[2])])
+    ),
+  }));
+
+  const actionsBlock = enumBlocks.find((b) => b.table === 'default.actions');
+
+  // The prod indices this guard was written against (SHOW CREATE TABLE actions,
+  // 2026-08-21). These predate the migrations directory, so no file here introduces them
+  // — but any migration that RESTATES the column must reproduce them exactly, because a
+  // MODIFY COLUMN is a replacement.
+  //
+  // 🔴 Do not add a name here to silence a failing case. That is the one-line bypass of
+  // this whole guard, and it produces exactly the "looks instrumented, writes no rows"
+  // outcome the file exists to stop. A new type belongs in a migration.
+  const PRE_EXISTING: ReadonlyMap<string, number> = new Map([
+    ['AddToBounty_Click', 1],
+    ['AddToBounty_Confirm', 2],
+    ['AwardBounty_Click', 3],
+    ['AwardBounty_Confirm', 4],
+    ['Tip_Click', 5],
+    ['Tip_Confirm', 6],
+    ['TipInteractive_Click', 7],
+    ['TipInteractive_Cancel', 8],
+    ['NotEnoughFunds', 9],
+    ['PurchaseFunds_Cancel', 10],
+    ['PurchaseFunds_Confirm', 11],
+    ['LoginRedirect', 12],
+    ['Membership_Cancel', 13],
+    ['CSAM_Help_Triggered', 14],
+    ['Membership_Downgrade', 15],
+    ['ProfanitySearch', 16],
+    ['BuzzLimit_Set', 17],
+    ['Model_Create_Click', 18],
+    ['Image_Remix_Click', 19],
+    ['Generator_Submit', 20],
+    ['Generator_JobLinked', 21],
+  ]);
+
+  it('freezes the pre-existing baseline', () => {
+    // Growing this map is how a new type gets exempted without a migration, so the size
+    // is pinned. If prod legitimately gains a value outside these migrations, update it
+    // deliberately and say why.
+    expect(PRE_EXISTING.size).toBe(21);
+  });
+
+  it('found an ALTER on default.actions to scan', () => {
+    // Scoped to THIS table, not to "some ALTER TABLE somewhere". The directory holds
+    // other migrations, so a `/ALTER TABLE/` control passes even when the actions
+    // migration has been reduced to a bare SELECT — measured.
+    expect(
+      actionsBlock,
+      'no MODIFY COLUMN on default.actions found in any migration'
+    ).toBeDefined();
+    expect(actionsBlock!.arms.size).toBeGreaterThan(0);
+  });
+
+  it.each([...ActionType].filter((t) => !PRE_EXISTING.has(t)))(
+    '%s is widened into the actions enum by a migration',
+    (type) => {
+      expect([...actionsBlock!.arms.keys()]).toContain(type);
+    }
+  );
+
+  it('restates every pre-existing value at the index it already has', () => {
+    // A MODIFY COLUMN replaces the definition: a name left out is dropped from a live
+    // column, and a name given a different index silently remaps existing rows. The
+    // migration's own header forbids both; this is what makes that enforceable.
+    for (const [name, index] of PRE_EXISTING) {
+      expect(actionsBlock!.arms.get(name), `${name} missing from the restated enum`).toBe(index);
+    }
+  });
+
+  it('assigns every value a distinct index', () => {
+    const indices = [...actionsBlock!.arms.values()];
+    expect(new Set(indices).size).toBe(indices.length);
+  });
+
+  // Every type the client is allowed to SEND must be one the Tracker can WRITE. The
+  // reverse does not hold — `BuzzLimit_Set` is emitted server-side and has no client
+  // schema arm — so this is containment, not equality.
+  it('every trackActionSchema arm is an ActionType', () => {
+    const schemaTypes = trackActionSchema.options.map(
+      (option) => option.shape.type.value as string
+    );
+
+    expect(schemaTypes.length).toBeGreaterThan(0);
+    expect(schemaTypes).toContain('Feed_TagBar_Click');
+    expect(
+      schemaTypes.filter((t) => !ActionType.includes(t as (typeof ActionType)[number]))
+    ).toEqual([]);
+  });
+});

--- a/src/server/clickhouse/migrations/2026-08-21-feed-tag-bar-action.sql
+++ b/src/server/clickhouse/migrations/2026-08-21-feed-tag-bar-action.sql
@@ -1,0 +1,55 @@
+-- Feed tag bar click-through — ClickHouse DDL.
+--
+-- Apply this MANUALLY, BEFORE the app code that emits `Feed_TagBar_Click` is deployed. We do
+-- not auto-run DDL (same policy as the Postgres migrations).
+--
+-- 🔴 ORDER IS LOAD-BEARING AND THE FAILURE IS SILENT. `actions.type` is an Enum16. The app
+-- POSTs to the tracker service, which inserts; a value the column does not carry is rejected
+-- THERE, so the browser sees a successful beacon, the app logs nothing, and the row simply
+-- never exists. The bar would ship looking instrumented and produce zero rows to judge it by
+-- — which is the one outcome the 10%-click-through deal cannot survive.
+--
+-- 21 is the last index in use ('Generator_JobLinked'), so this appends at 22. Appending at an
+-- unused index is a metadata-only ALTER: no data is rewritten and no mutation is scheduled. Do
+-- NOT renumber or rename any existing value; that WOULD rewrite the whole table.
+--
+-- `actions` has no dependent materialized view (verified 2026-08-21 against
+-- `system.tables`), so unlike the `views` widening there is no MV whose SELECT also has to be
+-- updated with MODIFY QUERY. If that ever changes, a widened source column with a stale MV
+-- query drops the new value at the MV instead — same silent shape, different place.
+
+ALTER TABLE default.actions
+  MODIFY COLUMN `type` Enum16(
+    'AddToBounty_Click' = 1,
+    'AddToBounty_Confirm' = 2,
+    'AwardBounty_Click' = 3,
+    'AwardBounty_Confirm' = 4,
+    'Tip_Click' = 5,
+    'Tip_Confirm' = 6,
+    'TipInteractive_Click' = 7,
+    'TipInteractive_Cancel' = 8,
+    'NotEnoughFunds' = 9,
+    'PurchaseFunds_Cancel' = 10,
+    'PurchaseFunds_Confirm' = 11,
+    'LoginRedirect' = 12,
+    'Membership_Cancel' = 13,
+    'CSAM_Help_Triggered' = 14,
+    'Membership_Downgrade' = 15,
+    'ProfanitySearch' = 16,
+    'BuzzLimit_Set' = 17,
+    'Model_Create_Click' = 18,
+    'Image_Remix_Click' = 19,
+    'Generator_Submit' = 20,
+    'Generator_JobLinked' = 21,
+    'Feed_TagBar_Click' = 22
+  );
+
+-- Verify the value landed before deploying. This must return 1 row:
+--
+--   SELECT 1 FROM system.columns
+--   WHERE database = 'default' AND table = 'actions' AND name = 'type'
+--     AND position(type, 'Feed_TagBar_Click') > 0;
+--
+-- And after the deploy, that rows are actually arriving:
+--
+--   SELECT count() FROM actions WHERE type = 'Feed_TagBar_Click' AND time > now() - INTERVAL 1 HOUR;

--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -164,6 +164,12 @@ export const ActionType = [
   'Model_Create_Click',
   'Image_Remix_Click',
   'Generator_Submit',
+  // Image/video feed tag bar. 🔴 `actions.type` is an Enum16 in ClickHouse: a value
+  // the column does not carry is dropped by the tracker with no error here and no
+  // row there. The widening migration
+  // (src/server/clickhouse/migrations/2026-08-21-feed-tag-bar-action.sql) must be
+  // applied to prod BEFORE this deploys, or the bar ships blind.
+  'Feed_TagBar_Click',
 ] as const;
 export type ActionType = (typeof ActionType)[number];
 

--- a/src/server/common/feed-tag-bar.constants.ts
+++ b/src/server/common/feed-tag-bar.constants.ts
@@ -1,0 +1,47 @@
+/**
+ * The image/video feed tag bar's chip set, in display order.
+ *
+ * 🔴 CURATED BY HAND. Do not derive this list from search volume, and do not extend it
+ * by sorting a log and taking the top N — ranking by demand is what puts terms on a
+ * public category bar that must never appear there. Every addition has to be reviewed
+ * as a general-subject term, and `Tag.nsfwLevel` cannot make that judgement for you.
+ * The curation rationale, the demand analysis and the excluded classes live on the
+ * ClickUp ticket, not here.
+ *
+ * Entries also have to clear supply, not just demand: a term with real interest and
+ * almost nothing tagged lands users on an empty feed.
+ *
+ * A deliberately low-demand chip is kept in the set. That is not an oversight — the
+ * click-through instrumentation on this bar exists to settle whether such a chip earns
+ * its place once it is in front of people, rather than guessing.
+ *
+ * These are `Tag.name` values, resolved to ids at request time by `getFeedTagBarTags`.
+ * Several are not `image category` tags and several are `UserGenerated` rather than
+ * `Label`, which is why the bar does not reuse the category list.
+ */
+export const FEED_TAG_BAR_TAG_NAMES = [
+  'animal',
+  'anime',
+  'beach',
+  'cartoon',
+  'cat',
+  'comics',
+  'cosplay',
+  'cyberpunk',
+  'dog',
+  'dragon',
+  'elf',
+  'fantasy',
+  'furry',
+  'maid',
+  'manga',
+  'mecha',
+  'monster',
+  'portrait',
+  'realistic',
+  'robot',
+  'selfie',
+  'steampunk',
+] as const;
+
+export type FeedTagBarTagName = (typeof FEED_TAG_BAR_TAG_NAMES)[number];

--- a/src/server/routers/tag.router.ts
+++ b/src/server/routers/tag.router.ts
@@ -26,7 +26,8 @@ import {
   getVotableTagsSchema,
   removeTagVotesSchema,
 } from '~/server/schema/tag.schema';
-import { getTag } from '~/server/services/tag.service';
+import { FEED_TAG_BAR_EDGE_TAG, getTag } from '~/server/services/tag.service';
+import { getFeedTagBarTags } from '~/server/services/system-cache';
 import { moderatorProcedure, protectedProcedure, publicProcedure, router } from '~/server/trpc';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 
@@ -54,6 +55,12 @@ export const tagRouter = router({
       })
     )
     .query(getAllTagsHandler),
+  // No input: the chip set is server-owned (see feed-tag-bar.constants), which is
+  // what keeps this edge-cacheable for everyone and keeps a caller from widening it.
+  getFeedTagBar: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .use(edgeCacheIt({ ttl: CacheTTL.hour, tags: () => [FEED_TAG_BAR_EDGE_TAG] }))
+    .query(() => getFeedTagBarTags()),
   getHomeExcluded: publicProcedure
     .meta({ requiredScope: TokenScope.MediaRead })
     .use(edgeCacheIt({ ttl: 24 * 60 * 60 }))

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -587,6 +587,28 @@ const generatorSubmitSchema = z.object({
 // single request; the browser flushes well below this cap (see trackEventBuffer).
 // `trackBatchEventSchema` / `trackBatchSchema` are declared at the bottom of this
 // file (after `trackActionSchema`, which the action arm references).
+// Image/video feed tag bar click-through. This event is the CONDITION the bar ships
+// under — a click-through floor was agreed, and the bar is removed if it is not met
+// (ClickUp 868kv0cdr). The denominator is `pageViews` on /images and /videos; query
+// strings never reach that table, so the path alone identifies the feed.
+//
+// `tag` is null for the All chip, which clears the filter rather than setting one.
+// It is still a press, so it is recorded; a query measuring intent to NARROW
+// should filter it out rather than assume it is absent.
+const feedTagBarClickSchema = z.object({
+  type: z.literal('Feed_TagBar_Click'),
+  details: z.object({
+    // Which feed the bar was pressed on.
+    feed: z.enum(['images', 'videos']),
+    // Chip name, or null for All. Bounded server-side by FEED_TAG_BAR_TAG_NAMES;
+    // capped here so a tampered client cannot bloat the `details` String column.
+    tag: z.string().trim().max(64).nullable(),
+    tagId: z.number().nullable(),
+    // Whether the press selected a chip or cleared back to the whole feed.
+    action: z.enum(['select', 'clear']),
+  }),
+});
+
 export const TRACK_BATCH_MAX = 100;
 
 export type TrackActionInput = z.infer<typeof trackActionSchema>;
@@ -610,6 +632,7 @@ export const trackActionSchema = z.discriminatedUnion('type', [
   modelCreateClickSchema,
   imageRemixClickSchema,
   generatorSubmitSchema,
+  feedTagBarClickSchema,
 ]);
 
 // Feed impression event — an entity was actually SEEN in a feed, as opposed to

--- a/src/server/services/__tests__/feed-tag-bar-tags.test.ts
+++ b/src/server/services/__tests__/feed-tag-bar-tags.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { REDIS_KEYS } from '~/server/redis/client';
+
+const redisGet = redisMock.redis.get;
+const redisSet = redisMock.redis.set;
+const redisDel = redisMock.redis.del;
+// The service reads through `dbRead` only; aliasing both clients would let a write-path
+// regression pass on the read client's calls.
+const queryRaw = dbMock.dbRead.$queryRaw;
+
+const CACHE_KEY = REDIS_KEYS.SYSTEM.FEED_TAG_BAR_TAGS;
+
+const row = (id: number, name: string, nsfwLevel = 1) => ({ id, name, nsfwLevel });
+
+async function load() {
+  vi.resetModules();
+  return await import('~/server/services/system-cache');
+}
+
+/**
+ * The chip list feeds a client-side gate on `nsfwLevel`, so the number this returns is a
+ * browsing-level decision, not a display detail.
+ */
+describe('getFeedTagBarTags', () => {
+  beforeEach(() => {
+    redisGet.mockReset().mockResolvedValue(null);
+    redisSet.mockReset().mockResolvedValue('OK');
+    redisDel.mockReset().mockResolvedValue(1);
+    queryRaw.mockReset().mockResolvedValue([]);
+  });
+
+  // 🔴 The one that matters. No app path writes `Tag."nsfwLevel"`; a tag's effective level
+  // is raised by attaching it to a mature parent in `TagsOnTags`, and `getTags` resolves it
+  // with exactly this COALESCE. Selecting the bare column instead reports a stale level
+  // permanently — not for a cache window — and the client would keep the chip at every
+  // browsing level.
+  it('resolves nsfwLevel through the parent-tag rollup, not the raw column', async () => {
+    const { getFeedTagBarTags } = await load();
+    await getFeedTagBarTags();
+
+    // $queryRaw is a tagged template: arg 0 is the strings array (the SQL), the rest are
+    // the interpolated values. Joining the strings DROPS the values, so the tag names are
+    // asserted separately below — do not read this join as "the whole query".
+    const sql = (queryRaw.mock.calls[0][0] as unknown as string[]).join(' ');
+
+    expect(sql).toMatch(/TagsOnTags/);
+    expect(sql).toMatch(/MAX\(pt\."nsfwLevel"\)/);
+    expect(sql).toMatch(/COALESCE/);
+  });
+
+  it('asks for exactly the curated names', async () => {
+    const { getFeedTagBarTags } = await load();
+    const { FEED_TAG_BAR_TAG_NAMES } = await import('~/server/common/feed-tag-bar.constants');
+    await getFeedTagBarTags();
+
+    // One `= ANY($1)` array parameter, so the names arrive as a single template value —
+    // not as 22, and not inside the SQL string. Asserting on the string join would find
+    // nothing and pass for the wrong reason.
+    const names = queryRaw.mock.calls[0][1] as unknown as string[];
+    expect(names).toEqual([...FEED_TAG_BAR_TAG_NAMES]);
+  });
+
+  it('returns the curated display order, not the order the DB happened to return', async () => {
+    queryRaw.mockResolvedValue([row(1776, 'steampunk'), row(4, 'anime'), row(111768, 'animal')]);
+    const { getFeedTagBarTags } = await load();
+
+    expect((await getFeedTagBarTags()).map((t) => t.name)).toEqual([
+      'animal',
+      'anime',
+      'steampunk',
+    ]);
+  });
+
+  it('carries the rollup level through to the caller', async () => {
+    queryRaw.mockResolvedValue([row(4, 'anime', 8), row(111768, 'animal', 1)]);
+    const { getFeedTagBarTags } = await load();
+
+    expect(await getFeedTagBarTags()).toEqual([
+      { id: 111768, name: 'animal', nsfwLevel: 1 },
+      { id: 4, name: 'anime', nsfwLevel: 8 },
+    ]);
+  });
+
+  it('drops a name that resolves to no row, keeping the rest', async () => {
+    queryRaw.mockResolvedValue([row(4, 'anime'), row(111768, 'animal')]);
+    const { getFeedTagBarTags } = await load();
+
+    const names = (await getFeedTagBarTags()).map((t) => t.name);
+    expect(names).toEqual(['animal', 'anime']);
+    expect(names).not.toContain('steampunk');
+  });
+
+  it('serves the redis blob without touching the DB', async () => {
+    redisGet.mockResolvedValue(JSON.stringify([row(4, 'anime')]));
+    const { getFeedTagBarTags } = await load();
+
+    expect(await getFeedTagBarTags()).toEqual([{ id: 4, name: 'anime', nsfwLevel: 1 }]);
+    expect(queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('writes the resolved list back to redis', async () => {
+    queryRaw.mockResolvedValue([row(4, 'anime')]);
+    const { getFeedTagBarTags } = await load();
+    await getFeedTagBarTags();
+
+    expect(redisSet).toHaveBeenCalledWith(
+      CACHE_KEY,
+      JSON.stringify([{ id: 4, name: 'anime', nsfwLevel: 1 }]),
+      expect.objectContaining({ EX: expect.any(Number) })
+    );
+  });
+});
+
+/**
+ * Without this the corrected level could not be pushed at all — the redis blob holds for
+ * 4h and the per-pod memo would keep serving the value it already had.
+ */
+describe('clearFeedTagBarTagsCache', () => {
+  beforeEach(() => {
+    redisGet.mockReset().mockResolvedValue(null);
+    redisSet.mockReset().mockResolvedValue('OK');
+    redisDel.mockReset().mockResolvedValue(1);
+    queryRaw.mockReset().mockResolvedValue([]);
+  });
+
+  it('deletes the redis blob and re-reads on the next call', async () => {
+    queryRaw.mockResolvedValue([row(4, 'anime')]);
+    const { getFeedTagBarTags, clearFeedTagBarTagsCache } = await load();
+
+    await getFeedTagBarTags();
+    await getFeedTagBarTags();
+    // Positive control: the memo is doing its job, so a second query below can only come
+    // from the clear.
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+
+    await clearFeedTagBarTagsCache();
+    expect(redisDel).toHaveBeenCalledWith(CACHE_KEY);
+
+    await getFeedTagBarTags();
+    expect(queryRaw).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/server/services/__tests__/get-tags-cache.test.ts
+++ b/src/server/services/__tests__/get-tags-cache.test.ts
@@ -49,6 +49,7 @@ vi.mock('~/server/services/system-cache', () => ({
   getSystemTags,
   getReplacedTagIds,
   getCategoryTags,
+  clearFeedTagBarTagsCache: vi.fn(),
 }));
 
 vi.mock('~/server/redis/caches', () => ({

--- a/src/server/services/__tests__/tag.service.security.test.ts
+++ b/src/server/services/__tests__/tag.service.security.test.ts
@@ -30,6 +30,7 @@ vi.mock('~/server/services/system-cache', () => ({
   getCategoryTags: vi.fn(),
   getReplacedTagIds: vi.fn(),
   getSystemTags: vi.fn().mockResolvedValue([]),
+  clearFeedTagBarTagsCache: vi.fn(),
 }));
 vi.mock('~/server/services/tagsOnImageNew.service', () => ({ upsertTagsOnImageNew: vi.fn() }));
 vi.mock('~/server/services/user-preferences.service', () => ({

--- a/src/server/services/__tests__/tag.service.unlisted.test.ts
+++ b/src/server/services/__tests__/tag.service.unlisted.test.ts
@@ -340,7 +340,12 @@ describe('getVotableTags — model votable-tags cache invalidation contract', ()
     await deleteTags({ tags: [304, 305] });
     expect(redisDel).toHaveBeenCalledWith('packed:caches:tag-with-model-count:anime');
     expect(redisDel).toHaveBeenCalledWith('packed:caches:tag-with-model-count:nude');
-    expect(redisDel).toHaveBeenCalledTimes(2);
+    // Plus the feed tag bar's chip list, which `deleteTags` also busts — a deleted tag
+    // must not keep serving as a chip. The count stays exact rather than becoming a
+    // `>=`: it is what catches a bust being dropped, and naming the third key here is
+    // what tells the next reader which one arrived.
+    expect(redisDel).toHaveBeenCalledWith('system:feed-tag-bar-tags');
+    expect(redisDel).toHaveBeenCalledTimes(3);
   });
 
   it('a vote on an IMAGE does not bust the model cache', async () => {

--- a/src/server/services/system-cache.ts
+++ b/src/server/services/system-cache.ts
@@ -1,4 +1,5 @@
 import { NsfwLevel } from '~/server/common/enums';
+import { FEED_TAG_BAR_TAG_NAMES } from '~/server/common/feed-tag-bar.constants';
 import { dbRead, dbWrite } from '~/server/db/client';
 import {
   redis,
@@ -91,40 +92,45 @@ export type SystemModerationTag = {
 // in-proc memo cuts both the redis GET and the msgpackr decode per call. This
 // key is NOT redis.del-invalidated anywhere (only the 4h EX), so the extra
 // in-proc TTL is purely additive to the already-eventual 4h staleness.
-const getModeratedTagsMemo = createTtlMemo<SystemModerationTag[]>(async () => {
-  const cachedTags = await redis.packed.get<SystemModerationTag[]>(
-    REDIS_KEYS.SYSTEM.MODERATED_TAGS
-  );
-  if (cachedTags) return cachedTags;
+const getModeratedTagsMemo = createTtlMemo<SystemModerationTag[]>(
+  async () => {
+    const cachedTags = await redis.packed.get<SystemModerationTag[]>(
+      REDIS_KEYS.SYSTEM.MODERATED_TAGS
+    );
+    if (cachedTags) return cachedTags;
 
-  log('getting moderation tags');
-  const tags = await dbRead.tag.findMany({
-    where: { nsfwLevel: { gt: NsfwLevel.PG } },
-    select: { id: true, name: true, nsfwLevel: true },
-  });
+    log('getting moderation tags');
+    const tags = await dbRead.tag.findMany({
+      where: { nsfwLevel: { gt: NsfwLevel.PG } },
+      select: { id: true, name: true, nsfwLevel: true },
+    });
 
-  const tagsOnTags = await dbRead.tagsOnTags.findMany({
-    where: { fromTagId: { in: tags.map((x) => x.id) }, type: 'Parent' },
-    select: { fromTagId: true, toTag: { select: { id: true, name: true } } },
-  });
+    const tagsOnTags = await dbRead.tagsOnTags.findMany({
+      where: { fromTagId: { in: tags.map((x) => x.id) }, type: 'Parent' },
+      select: { fromTagId: true, toTag: { select: { id: true, name: true } } },
+    });
 
-  const normalizedTagsOnTags = tagsOnTags
-    .map(({ fromTagId, toTag }) => {
-      const parentTag = tags.find((x) => x.id === fromTagId);
-      if (!parentTag) return null;
-      return { ...toTag, nsfwLevel: parentTag.nsfwLevel, parentId: fromTagId };
-    })
-    .filter(isDefined);
+    const normalizedTagsOnTags = tagsOnTags
+      .map(({ fromTagId, toTag }) => {
+        const parentTag = tags.find((x) => x.id === fromTagId);
+        if (!parentTag) return null;
+        return { ...toTag, nsfwLevel: parentTag.nsfwLevel, parentId: fromTagId };
+      })
+      .filter(isDefined);
 
-  const combined: SystemModerationTag[] = [...tags, ...normalizedTagsOnTags];
+    const combined: SystemModerationTag[] = [...tags, ...normalizedTagsOnTags];
 
-  await redis.packed.set(REDIS_KEYS.SYSTEM.MODERATED_TAGS, combined, {
-    EX: SYSTEM_CACHE_EXPIRY,
-  });
+    await redis.packed.set(REDIS_KEYS.SYSTEM.MODERATED_TAGS, combined, {
+      EX: SYSTEM_CACHE_EXPIRY,
+    });
 
-  log('got moderation tags');
-  return combined;
-}, SYSTEM_CACHE_INPROC_TTL_MS, undefined, { freeze: true });
+    log('got moderation tags');
+    return combined;
+  },
+  SYSTEM_CACHE_INPROC_TTL_MS,
+  undefined,
+  { freeze: true }
+);
 
 export async function getModeratedTags(): Promise<SystemModerationTag[]> {
   return getModeratedTagsMemo();
@@ -327,33 +333,38 @@ export async function getCategoryTags(type: CategoryTagType) {
 // real value (redis hit, or a DB fetch that rewrites the key) or throws on a
 // redis/DB failure — it never swallows an error into an empty list — so the
 // in-proc memo only ever caches a genuine value. Not redis.del-invalidated.
-const getBlockedBrowsingTagsMemo = createTtlMemo<{ id: number; name: string }[]>(async () => {
-  const cached = await redis.get(REDIS_KEYS.SYSTEM.BLOCKED_BROWSING_TAGS);
-  if (cached) {
-    // Fail open on a corrupt ops-set value (this getter is on the hot feed +
-    // tag-page path); fall through to the DB fetch, which rewrites the key.
-    try {
-      const parsed = JSON.parse(cached);
-      if (Array.isArray(parsed)) return parsed as { id: number; name: string }[];
-    } catch (err) {
-      logSysRedisFailOpen('read-degraded', 'getBlockedBrowsingTags', err, {
-        cachedSample: cached.slice(0, 64),
-      });
+const getBlockedBrowsingTagsMemo = createTtlMemo<{ id: number; name: string }[]>(
+  async () => {
+    const cached = await redis.get(REDIS_KEYS.SYSTEM.BLOCKED_BROWSING_TAGS);
+    if (cached) {
+      // Fail open on a corrupt ops-set value (this getter is on the hot feed +
+      // tag-page path); fall through to the DB fetch, which rewrites the key.
+      try {
+        const parsed = JSON.parse(cached);
+        if (Array.isArray(parsed)) return parsed as { id: number; name: string }[];
+      } catch (err) {
+        logSysRedisFailOpen('read-degraded', 'getBlockedBrowsingTags', err, {
+          cachedSample: cached.slice(0, 64),
+        });
+      }
     }
-  }
 
-  log('getting blocked browsing tags');
-  const tags = await dbRead.tag.findMany({
-    where: { id: { in: BLOCKED_BROWSING_TAG_IDS } },
-    select: { id: true, name: true },
-  });
-  await redis.set(REDIS_KEYS.SYSTEM.BLOCKED_BROWSING_TAGS, JSON.stringify(tags), {
-    EX: SYSTEM_CACHE_EXPIRY,
-  });
+    log('getting blocked browsing tags');
+    const tags = await dbRead.tag.findMany({
+      where: { id: { in: BLOCKED_BROWSING_TAG_IDS } },
+      select: { id: true, name: true },
+    });
+    await redis.set(REDIS_KEYS.SYSTEM.BLOCKED_BROWSING_TAGS, JSON.stringify(tags), {
+      EX: SYSTEM_CACHE_EXPIRY,
+    });
 
-  log('got blocked browsing tags');
-  return tags;
-}, SYSTEM_CACHE_INPROC_TTL_MS, undefined, { freeze: true });
+    log('got blocked browsing tags');
+    return tags;
+  },
+  SYSTEM_CACHE_INPROC_TTL_MS,
+  undefined,
+  { freeze: true }
+);
 
 export async function getBlockedBrowsingTags(): Promise<{ id: number; name: string }[]> {
   return getBlockedBrowsingTagsMemo();
@@ -361,25 +372,105 @@ export async function getBlockedBrowsingTags(): Promise<{ id: number; name: stri
 
 // Global, effectively static (['woman', 'women']) home-page tag exclusion.
 // Not redis.del-invalidated; resolves to a real value or throws.
-const getHomeExcludedTagsMemo = createTtlMemo<{ id: number; name: string }[]>(async () => {
-  const cachedTags = await redis.get(REDIS_KEYS.SYSTEM.HOME_EXCLUDED_TAGS);
-  if (cachedTags) return JSON.parse(cachedTags) as { id: number; name: string }[];
+const getHomeExcludedTagsMemo = createTtlMemo<{ id: number; name: string }[]>(
+  async () => {
+    const cachedTags = await redis.get(REDIS_KEYS.SYSTEM.HOME_EXCLUDED_TAGS);
+    if (cachedTags) return JSON.parse(cachedTags) as { id: number; name: string }[];
 
-  log('getting home excluded tags');
-  const tags = await dbWrite.tag.findMany({
-    where: { name: { in: ['woman', 'women'] } },
-    select: { id: true, name: true },
-  });
-  await redis.set(REDIS_KEYS.SYSTEM.HOME_EXCLUDED_TAGS, JSON.stringify(tags), {
-    EX: SYSTEM_CACHE_EXPIRY,
-  });
+    log('getting home excluded tags');
+    const tags = await dbWrite.tag.findMany({
+      where: { name: { in: ['woman', 'women'] } },
+      select: { id: true, name: true },
+    });
+    await redis.set(REDIS_KEYS.SYSTEM.HOME_EXCLUDED_TAGS, JSON.stringify(tags), {
+      EX: SYSTEM_CACHE_EXPIRY,
+    });
 
-  log('got home excluded tags');
-  return tags;
-}, SYSTEM_CACHE_INPROC_TTL_MS, undefined, { freeze: true });
+    log('got home excluded tags');
+    return tags;
+  },
+  SYSTEM_CACHE_INPROC_TTL_MS,
+  undefined,
+  { freeze: true }
+);
 
 export async function getHomeExcludedTags() {
   return getHomeExcludedTagsMemo();
+}
+
+export type FeedTagBarTag = { id: number; name: string; nsfwLevel: number };
+
+// The image/video feed tag bar's chips, resolved from the curated names.
+//
+// 🔴 `nsfwLevel` is the PARENT-TAG ROLLUP, not `Tag."nsfwLevel"`. A tag's effective level
+// is raised by attaching it to a mature parent in `TagsOnTags` — no app path writes the
+// column directly — so reading the column alone reports a stale level FOREVER, not for a
+// cache window, and `useApplyHiddenPreferences` would keep showing the chip at every
+// browsing level. `getTags` resolves it with this same COALESCE (tag.service.ts); the two
+// must agree or the bar disagrees with every other tag surface about the same tag.
+//
+// Deliberately does NOT filter `unfeatured` or clamp to PG the way `getTags` does with no
+// `query`: `furry` is unfeatured and is the highest-demand chip on the bar. The curated
+// list is the gate here; hidden preferences are applied client-side.
+const getFeedTagBarTagsMemo = createTtlMemo<FeedTagBarTag[]>(
+  async () => {
+    const cached = await redis.get(REDIS_KEYS.SYSTEM.FEED_TAG_BAR_TAGS);
+    if (cached) return JSON.parse(cached) as FeedTagBarTag[];
+
+    // `= ANY($1)` rather than `Prisma.join`: the names go as one array parameter, so this
+    // module needs no `@prisma/client` import. Most services pull in system-cache, so its
+    // load graph is worth keeping narrow.
+    log('getting feed tag bar tags');
+    const rows = await dbRead.$queryRaw<FeedTagBarTag[]>`
+      SELECT t.id,
+             t.name,
+             COALESCE(
+               (
+                 SELECT MAX(pt."nsfwLevel")
+                 FROM "TagsOnTags" tot
+                 JOIN "Tag" pt ON tot."fromTagId" = pt.id
+                 WHERE tot."toTagId" = t.id
+               ),
+               t."nsfwLevel"
+             )::int "nsfwLevel"
+      FROM "Tag" t
+      WHERE t.name = ANY(${FEED_TAG_BAR_TAG_NAMES as unknown as string[]})
+    `;
+
+    // Curated display order, not the DB's. A name that resolves to no row is dropped —
+    // the drift guard for that is the constants test plus the review of this list, since
+    // a chip vanishing is visible and a wrong level is not.
+    const byName = new Map(rows.map((t) => [t.name, t]));
+    const tags = FEED_TAG_BAR_TAG_NAMES.map((name) => byName.get(name)).filter(isDefined);
+
+    await redis.set(REDIS_KEYS.SYSTEM.FEED_TAG_BAR_TAGS, JSON.stringify(tags), {
+      EX: SYSTEM_CACHE_EXPIRY,
+    });
+
+    log('got feed tag bar tags');
+    return tags;
+  },
+  SYSTEM_CACHE_INPROC_TTL_MS,
+  undefined,
+  { freeze: true }
+);
+
+export async function getFeedTagBarTags() {
+  return getFeedTagBarTagsMemo();
+}
+
+/**
+ * Drops the cached chip list. The edge response is purged separately by
+ * `bustFeedTagBarTagsCache` in tag.service, which is where the tag mutations live —
+ * without both, a corrected nsfwLevel could not be pushed at all: the redis blob holds
+ * for 4h and the edge response for an hour.
+ *
+ * `clear()` is per-pod. Other pods pick the change up within
+ * SYSTEM_CACHE_INPROC_TTL_MS of the redis key going away, same as every other blob here.
+ */
+export async function clearFeedTagBarTagsCache() {
+  getFeedTagBarTagsMemo.clear();
+  await redis.del(REDIS_KEYS.SYSTEM.FEED_TAG_BAR_TAGS);
 }
 
 export async function setLiveNow(isLive: boolean) {

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -30,7 +30,12 @@ import type {
   GetVotableTagsSchema,
   GetVotableTagsSchema2,
 } from '~/server/schema/tag.schema';
-import { getCategoryTags, getReplacedTagIds, getSystemTags } from '~/server/services/system-cache';
+import {
+  clearFeedTagBarTagsCache,
+  getCategoryTags,
+  getReplacedTagIds,
+  getSystemTags,
+} from '~/server/services/system-cache';
 import { upsertTagsOnImageNew } from '~/server/services/tagsOnImageNew.service';
 import {
   HiddenImages,
@@ -218,6 +223,24 @@ export async function getTagPageSeoData({ name }: { name: string }): Promise<Tag
     },
     { ttl: CacheTTL.day }
   );
+}
+
+// The edge-cache handle for `tag.getFeedTagBar`. Without it the chip list — including the
+// nsfwLevel the client gates chips on — is unpurgeable for an hour.
+export const FEED_TAG_BAR_EDGE_TAG = 'feed-tag-bar';
+
+/**
+ * Drops the chip list everywhere it is held: the per-pod memo, the redis blob, and the
+ * edge response. Called alongside `bustGetTagsCache` on every taxonomy change, because a
+ * `TagsOnTags` edge is what moves a chip's effective nsfwLevel.
+ */
+export async function bustFeedTagBarTagsCache() {
+  await clearFeedTagBarTagsCache();
+
+  // Deferred, not a top-level import: `~/server/cloudflare/client` pulls the `cloudflare`
+  // SDK at module load, and `tag.service` is imported widely. Only the bust path needs it.
+  const { purgeCache } = await import('~/server/cloudflare/client');
+  await purgeCache({ tags: [FEED_TAG_BAR_EDGE_TAG] });
 }
 
 export const getTag = ({ id }: { id: number }) => {
@@ -790,6 +813,7 @@ export const addTags = async ({ tags, entityIds, entityType, relationship }: Adj
     // Adding a TagsOnTags edge changes category membership + the nsfwLevel rollup
     // that the cached `getTags` listings compute — bust the listing cache.
     await bustGetTagsCache();
+    await bustFeedTagBarTagsCache();
   }
 };
 
@@ -879,6 +903,7 @@ export const disableTags = async ({ tags, entityIds, entityType }: AdjustTagsSch
     // Removing a TagsOnTags edge changes category membership + the nsfwLevel rollup
     // that the cached `getTags` listings compute — bust the listing cache.
     await bustGetTagsCache();
+    await bustFeedTagBarTagsCache();
   }
 };
 
@@ -946,6 +971,7 @@ export const deleteTags = async ({ tags }: DeleteTagsSchema) => {
   // Deleting a Tag removes it from the cached `getTags` listings (and cascades its
   // TagsOnTags edges, changing category membership / nsfwLevel rollup) — bust.
   await bustGetTagsCache();
+  await bustFeedTagBarTagsCache();
 };
 
 // unused
@@ -968,4 +994,3 @@ export const getTypeCategories = async ({
 
   return categories;
 };
-

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -210,6 +210,7 @@ export const CACHEABLE_PROCEDURES: ReadonlySet<string> = new Set([
   'system.getCreationBlockedTags',
   'system.getDbKV',
   'system.getLiveNow',
+  'tag.getFeedTagBar',
   'tag.getHomeExcluded',
   'technique.getAll',
   'tool.getAll',


### PR DESCRIPTION
## What

A tag filter row on `/images` and `/videos`. 22 curated chips, single-select, writing `?tags=<id>`, plus an **All** chip that clears. Every press emits a `Feed_TagBar_Click` ClickHouse action.

## Why the instrumentation is the deal, not a nice-to-have

Justin, 2026-08-21: *"We'll bring it back and then we can track what percentage of people hit the buttons. And if it's less than 10%, I want to get rid of it."*

So the number has to exist and has to be findable. Where it lands:

| | |
|---|---|
| Numerator | `actions` where `type = 'Feed_TagBar_Click'`, `details.feed` splitting images from videos |
| Denominator | `pageViews` on `/images` and `/videos` — query strings never reach that table, so the path alone identifies the feed |
| Saved query | Metabase question linked in a comment below, so nobody writes this by hand in three weeks |

### 🔴 The migration must be applied BEFORE this deploys

`actions.type` is an `Enum16`. The app POSTs fire-and-forget to the tracker service, which does the insert — so a value the column does not carry is rejected **there**: the browser sees a successful beacon, nothing is logged here, and the row simply never exists. The bar would look instrumented and produce zero rows, which is the one outcome this deal cannot survive.

`src/server/clickhouse/migrations/2026-08-21-feed-tag-bar-action.sql` appends `'Feed_TagBar_Click' = 22`. Appending at an unused index is a metadata-only ALTER. `actions` has **no dependent materialized view** (verified against `system.tables`), so unlike the `views` widening there is no `MODIFY QUERY` to pair with it.

Verification snippets are in the migration file: one that the value landed in the column, one that rows are arriving after the deploy.

## The chips

22 chips, alphabetical, from the curation work on `868kumr1c`. All 22 resolve against prod (`Tag.name`, verified) and all are `nsfwLevel = 1`.

The list is curated **by hand and deliberately not derived from search demand** — ranking by demand is exactly what puts terms on a public category bar that must never appear there, and `Tag.nsfwLevel` cannot make that cut. Chips also had to clear supply as well as demand, so a term with real interest and nothing tagged is excluded rather than landing users on an empty feed. **The demand figures and the excluded classes stay on the ticket; this repo is public.**

- **One deliberately low-demand chip is kept.** That is the case the 10% rule exists to settle, so dropping it quietly would remove the thing being measured.
- **`furry` is `unfeatured = true` in the DB.** That matters below.

## Why a new procedure rather than `tag.getAll`

Two independent reasons, either one sufficient:

1. **`getTags` would silently drop `furry`.** With no `query`, that path forces `NOT t.unfeatured` and clamps to PG — and `furry` is the highest-demand chip on the bar. It would have vanished from the row with nothing to show for it.
2. **A `names` filter on the public input would be an unbounded cache key.** `getTags` caches on a hash of its arguments, so a caller-supplied name array on a public procedure is exactly the key-space explosion that `excludedTagIds` already bypasses the cache to avoid.

So `tag.getFeedTagBar` takes **no input** — bounded by construction, `edgeCacheIt` for an hour, and registered in `CACHEABLE_PROCEDURES` (the `trpc-batching` guard fails CI otherwise, since batching appends `?batch=1` and `edgeCacheIt` refuses a batched request). Server-side it is a 22-row indexed `name IN (...)` behind a 1h in-process memo.

**Nothing was added to `getInfiniteImages`.** `?tags=` already filtered both feeds; this PR only restores UI that sets and clears it. The hot feed query is untouched.

## The `868kuq3jk` collision — it resolves it, for these two surfaces

`ActiveTagFilter`'s own docstring calls it *"the ONLY way to unset `?tags=`"* and it is mounted nowhere. A tag bar that sets a filter nothing can clear would be worse than none, so the **All** chip clears whatever is in `?tags=` — including ids that are not chips on this bar, which is exactly the deep-link case. There is a test for that.

`/posts` and `/articles` are still exposed. `868kuq3jk` stays open for them; this PR does not touch either.

## Reuse

`CategoryTags` (the models bar, #4222) and the deleted `TagScroller` were two copies of the same chip row, and the light-mode `light`-vs-`filled` swap is the kind of detail that went missing between them. Rather than adding a third copy, the chip is extracted to `src/components/Tags/TagChip.tsx` and `CategoryTags` now renders it. Pure presentational extraction — identical markup and classes, and `CategoryTags`' 14 existing tests pass unchanged, including the variant/background assertions in both colour schemes.

## Design calls

- **Single-select**, not the old ctrl-click stacking. Two chips is an AND across tags, which lands on an empty feed for most pairs in this set, and it was undiscoverable.
- **The All press is recorded too**, as `action: 'clear'` with a null tag. It is still a press. A query measuring intent-to-narrow should filter it out rather than assume it is absent — that is written into the schema comment.
- **CLS**: both the empty and populated states carry `min-h-[26px]`. Returning null while the client-side query resolves is what let the row pop in and shove the feed down — the shift `docs/cls-remediation-plan.md` measured at 0.65 on `/images`.
- Hidden-tag preferences are applied, so a viewer who hid a tag does not get a chip for it.

## Tests

36 new, in two files.

**Mutation-checked — each of these was applied and the named test went red:**

| Mutation | Result |
|---|---|
| `feed` hardcoded to `'images'` | `carries the videos feed through` fails |
| `setTagIds(active ? [] : [tag.id])` → stack | `replaces rather than stacks` + `toggles the active chip back off` fail |
| All chip deleted | 5 tests fail |
| `'Feed_TagBar_Click' = 22` removed from the migration | enum-drift guard fails |

🔴 **That last one is worth reading.** The enum-drift guard passed the first time with the ALTER gutted — it scanned the raw `.sql`, and the file names the value in its comments as well as its DDL. Comment lines are stripped before the scan now, and the mutation was re-run to confirm it bites. Red-when-removed was not red-when-wrong.

The exclusion assertions (`excludes teen`, `excludes school`) are each paired with a positive control on the list length, because a negative assertion passes for free against an empty list.

There is a mount guard counting `<ImageFeedTagBar>` per page with comments stripped — the same shape as #4222's, and the reason it exists is that #4141 shipped `ActiveTagFilter` with a green suite and no mount point anywhere.

`src/server/clickhouse/__tests__/action-type-enum-drift.test.ts` is general, not specific to this PR: any **new** `ActionType` must arrive with a migration widening the column. Pre-existing types are baselined against the prod DDL.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm exec eslint <touched files>` — no new issues (`tag.service.ts`, `track.schema.ts`, `tracker.ts`, `trpc.ts` carry pre-existing warnings; counts identical stashed vs unstashed)
- `pnpm run test:unit:run` — 1309 files, **20524 passed, 0 failed**; `blocks.router.workflow.test.ts` collected **350**
- `pnpm run test:lint-rules` — 265 passed

## Not done here

- `/posts` and `/articles` still have no way to clear a `?tags=` deep link — `868kuq3jk`.
- The chip-id vs tag-name mismatch between the browse feed (`?tags=<id>`) and search (`?tags=<name>`) is untouched: selecting a chip and then typing in the search box still drops the tag. Raised on `868kumr1c` and it is a bigger change than this bar.

ClickUp: https://app.clickup.com/t/868kv0cdr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Fix round — five review lanes (`5d75566e04`)

## 🔴 The one that mattered: the chips gated on the wrong nsfwLevel

`getFeedTagBarTags` selected `Tag."nsfwLevel"` directly. **Nothing in the app writes that column.** A tag's effective level is raised by attaching it to a mature parent in `TagsOnTags` — which is exactly why `getTags` resolves it as `COALESCE((SELECT MAX(pt."nsfwLevel") FROM "TagsOnTags" …), t."nsfwLevel")`.

So the bar would have reported a stale level **permanently**, not for a cache window: every other tag surface would drop the chip and the bar would keep serving it at every browsing level, including a SFW-only viewer. Not triggered today — all 22 chips are `nsfwLevel = 1` in prod, raw and rollup agree — but latent, and the gate is a browsing-level decision, not a display detail.

The lookup now uses the same COALESCE as `getTags`. Mutation-checked: reverting it to the bare column fails `resolves nsfwLevel through the parent-tag rollup, not the raw column`.

## Nothing could push a corrected level, either

Two caches held it with no handle: a per-pod memo nothing cleared, and an `edgeCacheIt` with no purge tag. A level corrected out-of-band would have taken ~2h to reach browsers with no way to shorten it.

The list moved into `system-cache.ts` beside `getHomeExcludedTags` — redis under a 30s in-proc memo, the pattern every other global blob here uses — and `deleteTags` / `addTags` / `disableTags` now call `bustFeedTagBarTagsCache` alongside `bustGetTagsCache`, which clears the memo, drops the redis blob and purges the edge tag.

## Also fixed

- **The bar rendered before hidden preferences resolved.** The chip list is edge-cached and preferences are a per-user fetch, so the list usually wins that race — a tag the viewer had personally hidden flashed as a chip. Now gated on `loadingPreferences`. Mutation-checked.
- **`?tags=` was parsed twice.** The bar read `router.query.tags` by hand while the feed reads it through `useImageQueryParams`. One param, two parsers; the symptom of drift is a chip that looks unselected while the feed is filtered. Now one hook, which also brings `shallow`/`scroll` handling and the empty-array clear for free.
- **The chip row was a third copy.** `CategoryTags` and the deleted `TagScroller` were two hand-maintained copies of the same row, and the CLS reservation had already gone missing between them once. Extracted to `TagChipRow`, which owns the 26px reservation on a **single wrapper** rather than on the placeholder and the scroller separately — the coupling that lets the shift come back.

## Findings I checked and did not act on

- **`ActiveTagFilter` is now dead-ish.** It duplicates this bar's clear, line for line, and is mounted nowhere. Deleting it belongs to `868kuq3jk`, which owns the `/posts` and `/articles` half; removing it here would take the escape hatch off the table for those surfaces before anyone has decided.
- **`replaceParams` uses `schema.parse`, not `safeParse`**, so a malformed sibling query param would make a chip click throw. Pre-existing and shared with every other filter writer on these pages — an argument for fixing the hook, not for keeping a private copy.
- **The hook's tag gate is `nsfwLevel > PG13`, a magnitude test rather than a `Flags` check.** 14 prod tags sit exactly at PG13; none is on this bar. Pre-existing in the shared hook.

## ⚠️ Perf: `image-index-feed` is no longer a free kill switch — `868kv2kgq`

Measured on the prod replica. `?tags=` never reaches Postgres while that flag is on (100% rollout, verified anonymously), so **the live path is unaffected and `getInfiniteImages` is not in this diff**.

On the **DB fallback** path a tag filter sets `isPersonalized`, which disables the query cache, and `/videos` intersects badly: `furry` 23.2 s and `steampunk` 54.1 s against a 20 s statement ceiling — past which the user gets an **empty feed**, not an error. `/images` is fine (29–905 ms). Counter-intuitively the *thin* chip is the worst one: density of the intersection decides it, not tag volume.

That cost predates this PR, but the bar turns it from a hand-typed URL into one click above the fold. Filed rather than fixed here — refusing or dropping the tag filter on the DB branch is a product call.

## Verification (fix round)

- `pnpm run typecheck` — 0 errors
- `pnpm exec eslint <touched>` — no new issues (`tag.service.ts` back to its 2-warning baseline)
- `pnpm run test:unit:run` — **1310 files, 20533 passed, 0 failed**; `blocks.router.workflow.test.ts` collected **350**
- `pnpm run test:lint-rules` — 265 passed
- Re-verified live after the refactor: 22 chips + All render, select writes `?tags=`, All clears a non-chip deep link, and the beacons carry the exact payload the Metabase query extracts.

⚠️ Two earlier full-suite runs showed 2–3 unrelated failures (`home-block-fetch-sizing`, `user-payment-configuration.tipalti-status`, `comment-permalink.ssr`) with a **different set each run**, all timeouts rather than assertions. `home-block-fetch-sizing` fails the same way on pristine `main` run alone. They were another suite competing for workers; the queued run above is clean.

## Notes for whoever applies the DDL

Already applied to prod on 2026-08-21 and verified from `system.columns`: `'Feed_TagBar_Click' = 22`, 0 mutations scheduled. The migration file is kept as the record.



---

# Second review round — tests and intent (`61dd634a20`)

## 🔴 The reusable lesson from this diff

**A guard passing its own author's mutation is not the same as it being sound.**

The enum-drift guard shipped blind, I found that, fixed it, mutated the deletion case, watched it go red, and called it done. The test lane then measured **four** destructive migration edits still passing:

| mutation | before | now |
|---|---|---|
| delete the `'Feed_TagBar_Click' = 22` arm | FAIL ✅ | FAIL ✅ |
| **renumber it onto `= 19`**, clobbering `Image_Remix_Click` | **PASS** 🔴 | FAIL ✅ |
| **retarget the ALTER at `default.views`** | **PASS** 🔴 | FAIL ✅ |
| **drop `'Membership_Cancel' = 13`** from the restated list | **PASS** 🔴 | FAIL ✅ |
| gut the ALTER, leave `SELECT 'Feed_TagBar_Click';` | **PASS** 🔴 | FAIL ✅ |

`toContain("'Feed_TagBar_Click'")` asserts *the string appears somewhere in some non-comment line of some `.sql` file* — a much weaker property than "a migration widens `actions.type` with this value". The dropped-value row is the sharp one: **`MODIFY COLUMN Enum16(...)` replaces the whole definition**, so any name missing from the restatement is removed from a live column, and nothing in the repo asserted that list was complete.

The guard now parses the ALTER — extracts the block, checks it targets `default.actions`, requires every non-baseline `ActionType`, requires every pre-existing name **at the index it already has**, and requires distinct indices. The baseline map is frozen at 21 so it cannot be grown to silence a failing case, which was the one-line bypass of the whole thing.

## The other test-lane finding worth naming

**The tests asserted only `.query` on the replace target, never the pathname** — so a hardcoded `pathname: '/images'` would have sent every `/videos` chip press to `/images`, invisibly, on a component whose entire reason for a `feed` prop is that it is shared by two routes. Now asserts the whole call, which covers `shallow`/`scroll` too (dropping either is silent and user-visible: a full refetch, or the feed jumping to the top on every press). Mutation-verified.

Also added: a fixture for the bare-string `?tags=4` shape the bar creates for itself on every share or reload; a browsing-level case, which is the reason `nsfwLevel` is selected and shipped at all; and a rename for a test named after a no-op that asserted the opposite.

## 🔴 Curation analysis was published here and has been removed

The chip-set constant, the tracking schema, the test file and this PR body carried the term-level curation analysis — which terms rank highest on image-feed search demand, per-term figures, and the analyst by name. That is two private-repo classes at once under `CLAUDE.md`: a **carve-out term list** (naming what a content filter deliberately excludes is an evasion guide) and **staff-attributed internal analysis**.

Removed from all four. What remains is the mechanism a maintainer needs — curated by hand, never derive from demand, `Tag.nsfwLevel` cannot make this cut — with the figures and excluded classes on the ticket.

**Removal is not remediation.** The branch was public for roughly two hours and it is in this branch's history permanently. Treat it as disclosed.

## Settled: page loads are the denominator

The ratio answers "share of feed visitors who pressed a chip" rather than "share of people who saw the bar". Raised as a decision because those differ by whether the bar was seen, and a sub-10% reading that cannot separate them would retire the feature on evidence that does not support the conclusion.

**Justin's call: page loads, and the premise holds.** The bar sits at the top of the page rather than below the fold, it appears on other surfaces too, and the mobile share of the user base is small — so treating everyone who loads `/images` or `/videos` as having had the chance to press a chip is a fair denominator. No impression event; the saved questions above are the measurement as-is.

He also confirmed there is no problem with the evaluation itself being public: *"I really don't care if people know that we're trying to determine whether or not the bar should stay."* The curation term-level detail was the part that needed to come out, and it has.

## Verification (second round)

- `pnpm run typecheck` — 0 errors
- `pnpm run test:unit:run` (queued) — **1310 files, 20539 passed, 0 failed**; `blocks.router.workflow.test.ts` collected **350**
- `pnpm run test:lint-rules` — 265 passed

