### PR TITLE
fix(moderator): make blocklist entries findable and removable

### DIFF
--- a/apps/moderator/src/lib/__tests__/blocklist.test.ts
+++ b/apps/moderator/src/lib/__tests__/blocklist.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { visibleBlocklistItems } from '../blocklist';
+
+// Alphabetical, so `zzz-late.example` sorts past any cap applied before the filter.
+const bigList = [
+  ...Array.from({ length: 300 }, (_, i) => `aaa-${String(i).padStart(3, '0')}.example`),
+  'zzz-late.example',
+];
+
+describe('visibleBlocklistItems', () => {
+  it('returns everything up to the cap when no filter is set', () => {
+    const { matches, visible } = visibleBlocklistItems(bigList, '', 200);
+    expect(matches).toHaveLength(301);
+    expect(visible).toHaveLength(200);
+  });
+
+  it('searches the WHOLE list, not just the first `limit` entries', () => {
+    // Capping before filtering would drop this entry — it sits at index 300 of 301.
+    const { matches, visible } = visibleBlocklistItems(bigList, 'zzz-late', 200);
+    expect(matches).toEqual(['zzz-late.example']);
+    expect(visible).toEqual(['zzz-late.example']);
+  });
+
+  it('still caps a filter that matches more than the limit', () => {
+    const { matches, visible } = visibleBlocklistItems(bigList, 'aaa-', 200);
+    expect(matches).toHaveLength(300);
+    expect(visible).toHaveLength(200);
+  });
+
+  it('matches case-insensitively in both directions', () => {
+    const list = ['MixedCase.example', 'lower.example'];
+    expect(visibleBlocklistItems(list, 'mixedcase', 10).matches).toEqual(['MixedCase.example']);
+    expect(visibleBlocklistItems(list, 'LOWER', 10).matches).toEqual(['lower.example']);
+  });
+
+  it('ignores surrounding whitespace in the filter', () => {
+    expect(visibleBlocklistItems(['spam.example'], '  spam  ', 10).matches).toEqual([
+      'spam.example',
+    ]);
+  });
+
+  it('treats a whitespace-only filter as no filter', () => {
+    expect(visibleBlocklistItems(['a.example', 'b.example'], '   ', 10).matches).toHaveLength(2);
+  });
+});

--- a/apps/moderator/src/lib/blocklist.ts
+++ b/apps/moderator/src/lib/blocklist.ts
@@ -24,6 +24,11 @@ const PHRASE_GAP_RULE =
   ' happens the flag you see may name the phrase itself.';
 
 export const BLOCKLIST_DESCRIPTIONS: Partial<Record<BlocklistType, string>> = {
+  EmailDomain:
+    'Disposable-email domains blocked at signup. 🔴 A weekly job re-syncs this list from the' +
+    ' upstream disposable-email-domains project, and it re-adds anything it still carries. So' +
+    ' removing a domain that is on the upstream list holds until the next Sunday run and then' +
+    ' silently comes back. Removing one the upstream list does not carry is permanent.',
   PromptBenignPhrase:
     'Whole phrases in the positive prompt that innocently contain a minor/POI detection word (proper nouns, technical terms). Each phrase is blanked from the prompt before the scan audit runs, so it never false-flags an image for review. Enter the full phrase — e.g. "teen titans", "minor barrel distortion".' + PHRASE_GAP_RULE,
   NegativeBenignPhrase:
@@ -31,18 +36,3 @@ export const BLOCKLIST_DESCRIPTIONS: Partial<Record<BlocklistType, string>> = {
   ProfanityBenignWord:
     'Single words that innocently contain a profanity token — "spreadsheet" contains "spread", "cockpit" contains "cock". The whole word is exempted from the profanity filter. One word per entry, not a phrase. This list REPLACES the one shipped with the site (it was seeded from it), so removing an entry here really does remove it. Applies to search; the generation gate still uses the shipped list.',
 };
-
-/**
- * The visible slice of a blocklist, filtered then capped.
- *
- * 🔴 Order matters: `EmailDomain` is 8295 entries in production, so the cap exists to keep the
- * page renderable — but capping BEFORE the filter would search only the first `limit` entries
- * alphabetically, and a moderator searching for anything past that would be told it is not on
- * the list. The cap bounds what is drawn, never what is searched.
- */
-export function visibleBlocklistItems(items: string[], filter: string, limit: number) {
-  const needle = filter.trim().toLowerCase();
-  const matches =
-    needle.length === 0 ? items : items.filter((item) => item.toLowerCase().includes(needle));
-  return { matches, visible: matches.slice(0, limit) };
-}

--- a/apps/moderator/src/lib/blocklist.ts
+++ b/apps/moderator/src/lib/blocklist.ts
@@ -31,3 +31,18 @@ export const BLOCKLIST_DESCRIPTIONS: Partial<Record<BlocklistType, string>> = {
   ProfanityBenignWord:
     'Single words that innocently contain a profanity token — "spreadsheet" contains "spread", "cockpit" contains "cock". The whole word is exempted from the profanity filter. One word per entry, not a phrase. This list REPLACES the one shipped with the site (it was seeded from it), so removing an entry here really does remove it. Applies to search; the generation gate still uses the shipped list.',
 };
+
+/**
+ * The visible slice of a blocklist, filtered then capped.
+ *
+ * 🔴 Order matters: `EmailDomain` is 8295 entries in production, so the cap exists to keep the
+ * page renderable — but capping BEFORE the filter would search only the first `limit` entries
+ * alphabetically, and a moderator searching for anything past that would be told it is not on
+ * the list. The cap bounds what is drawn, never what is searched.
+ */
+export function visibleBlocklistItems(items: string[], filter: string, limit: number) {
+  const needle = filter.trim().toLowerCase();
+  const matches =
+    needle.length === 0 ? items : items.filter((item) => item.toLowerCase().includes(needle));
+  return { matches, visible: matches.slice(0, limit) };
+}

--- a/apps/moderator/src/lib/server/__tests__/blocklist-remove.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/blocklist-remove.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `removeBlocklistItems` used to return void while its caller reported `count: items.length` — the
+ * number SUBMITTED. So a removal that matched nothing still rendered "Removed 1 item." above a chip
+ * that was still there. These pin the count against what the row actually lost.
+ */
+
+type Call = [string, unknown[]];
+
+/** Rows keyed by id, so a query scoped to the wrong id resolves to nothing rather than passing. */
+let rows: Record<number, string[]>;
+const updateSpy = vi.fn();
+const setSpy = vi.fn();
+
+const wheres = (calls: Call[]) => calls.filter(([m]) => m === 'where').map(([, a]) => a);
+const scopedId = (calls: Call[]) => {
+  const match = wheres(calls).find(([column, op]) => column === 'id' && op === '=');
+  return match?.[2] as number | undefined;
+};
+
+function chain(record: (calls: Call[]) => void, resolve: (calls: Call[]) => unknown) {
+  const calls: Call[] = [];
+  const builder: Record<string, unknown> = {};
+  for (const method of ['select', 'set', 'where', 'orderBy', 'returning']) {
+    builder[method] = (...args: unknown[]) => {
+      calls.push([method, args]);
+      return builder;
+    };
+  }
+  const settle = async () => {
+    record(calls);
+    return resolve(calls);
+  };
+  builder.executeTakeFirst = settle;
+  builder.executeTakeFirstOrThrow = settle;
+  builder.execute = async () => {
+    record(calls);
+    const id = scopedId(calls);
+    // `readBlocklistRow` selects by TYPE, not id, and expects an array.
+    return id === undefined
+      ? Object.entries(rows).map(([rowId, data]) => ({
+          id: Number(rowId),
+          type: 'EmailDomain',
+          data,
+        }))
+      : [];
+  };
+  return builder;
+}
+
+vi.mock('../db', () => ({
+  dbRead: {},
+  dbWrite: {
+    selectFrom: () =>
+      chain(
+        () => undefined,
+        (calls) => {
+          const id = scopedId(calls);
+          return id !== undefined && rows[id] ? { data: rows[id] } : undefined;
+        }
+      ),
+    updateTable: () =>
+      chain(
+        (calls) => updateSpy(calls),
+        (calls) => {
+          const id = scopedId(calls);
+          expect(id, 'an UPDATE here must be scoped to a single row').toBeDefined();
+          const set = calls.find(([m]) => m === 'set')?.[1][0] as { data: string[] };
+          rows[id as number] = set.data;
+          return { id, type: 'EmailDomain', data: set.data };
+        }
+      ),
+  },
+}));
+
+vi.mock('../redis', () => ({ getRedis: () => ({ get: async () => null, set: setSpy }) }));
+vi.mock('../axiom', () => ({ logToAxiom: vi.fn() }));
+
+const { removeBlocklistItems } = await import('../blocklist.service');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rows = { 1: ['spam.example', 'junk.example', 'trash.example'] };
+});
+
+describe('removeBlocklistItems', () => {
+  it('returns how many entries the row actually lost', async () => {
+    const removed = await removeBlocklistItems({ id: 1, items: ['spam.example'] });
+
+    expect(removed).toBe(1);
+    expect(rows[1]).toEqual(['junk.example', 'trash.example']);
+  });
+
+  it('returns 0 for an entry that is not on the list, and writes nothing', async () => {
+    const removed = await removeBlocklistItems({ id: 1, items: ['never-added.example'] });
+
+    expect(removed).toBe(0);
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(rows[1]).toHaveLength(3);
+  });
+
+  it('returns 0 for a stale row id rather than reporting the submitted count', async () => {
+    const removed = await removeBlocklistItems({ id: 999, items: ['spam.example'] });
+
+    expect(removed).toBe(0);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('counts only the entries that were present, not the whole submission', async () => {
+    const removed = await removeBlocklistItems({
+      id: 1,
+      items: ['spam.example', 'never-added.example'],
+    });
+
+    expect(removed).toBe(1);
+  });
+
+  it('does not re-cache when nothing was removed', async () => {
+    await removeBlocklistItems({ id: 1, items: ['never-added.example'] });
+
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/moderator/src/lib/server/blocklist.service.ts
+++ b/apps/moderator/src/lib/server/blocklist.service.ts
@@ -116,22 +116,31 @@ export async function upsertBlocklist({
   await setCache(await readBlocklistRow(result.type));
 }
 
+/**
+ * Returns how many entries were actually dropped, which is NOT the number submitted: a stale `id`
+ * (the DTO is Redis-cached for a month), an entry already gone, or one stored in a case the
+ * lowercased needle cannot match all end in zero. The page reports this number, so "Removed 1
+ * item." above a chip that is still there is a state the UI can no longer reach.
+ */
 export async function removeBlocklistItems({
   id,
   items,
 }: {
   id: number;
   items: string[];
-}): Promise<void> {
+}): Promise<number> {
   const lower = items.map((x) => x.toLowerCase());
   const row = await dbWrite
     .selectFrom('Blocklist')
     .select('data')
     .where('id', '=', id)
     .executeTakeFirst();
-  if (!row) return;
+  if (!row) return 0;
 
   const filtered = row.data.filter((item) => !lower.includes(item));
+  const removed = row.data.length - filtered.length;
+  if (removed === 0) return 0;
+
   const updated = await dbWrite
     .updateTable('Blocklist')
     .set({ data: filtered, updatedAt: new Date() })
@@ -139,4 +148,5 @@ export async function removeBlocklistItems({
     .returning(['id', 'type', 'data'])
     .executeTakeFirstOrThrow();
   await setCache(await readBlocklistRow(updated.type));
+  return removed;
 }

--- a/apps/moderator/src/routes/blocklists/+page.server.ts
+++ b/apps/moderator/src/routes/blocklists/+page.server.ts
@@ -50,7 +50,14 @@ export const actions: Actions = {
     if (!id) return fail(400, { error: 'Nothing to remove from.' });
     if (items.length === 0) return fail(400, { error: 'No items to remove.' });
 
-    await removeBlocklistItems({ id, items });
-    return { success: true, action: 'remove', count: items.length };
+    const count = await removeBlocklistItems({ id, items });
+    // A submitted-but-unmatched removal is a failure, not a quiet "Removed 0 items." The list is
+    // served from a month-long Redis cache, so the likeliest cause is that this page is stale.
+    if (count === 0)
+      return fail(409, {
+        error: 'Nothing was removed — those entries are no longer on this list. Reload the page.',
+      });
+
+    return { success: true, action: 'remove', count };
   },
 };

--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -23,16 +23,6 @@
   let removing = $state<string | null>(null);
   let confirming = $state<string | null>(null);
 
-  // TEMPORARY DIAGNOSTIC — remove before merge. Justin and I could not establish whether we were
-  // looking at the same build. `hydrated` only ever becomes true from an effect, which does not run
-  // during SSR, so "idle" means the client JS never took over.
-  const BUILD_MARKER = 'BLK-7';
-  let hydrated = $state(false);
-  let lastEvent = $state('none');
-  $effect(() => {
-    hydrated = true;
-  });
-
   // EmailDomain is 8295 entries in production. Rendering the whole list is both unusable and
   // enough DOM to stall the tab, so the list is filtered first and then capped.
   const CHIP_LIMIT = 200;
@@ -109,11 +99,6 @@
 <header class="page-header">
   <h1>Blocklists</h1>
 </header>
-
-<!-- TEMPORARY DIAGNOSTIC — remove before merge. -->
-<p class="mb-3 rounded border border-amber-500/30 bg-amber-500/10 p-1 text-xs text-amber-200">
-  build {BUILD_MARKER} · js {hydrated ? 'LIVE' : 'IDLE'} · last event: {lastEvent}
-</p>
 
 <Tabs
   value={data.type}
@@ -221,10 +206,7 @@
                   disabled={removing !== null}
                   aria-label="Remove {item}"
                   title="Remove {item}"
-                  onclick={() => {
-                    lastEvent = 'x:' + item;
-                    confirming = item;
-                  }}
+                  onclick={() => (confirming = item)}
                 >
                   &times;
                 </Button>

--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -6,14 +6,11 @@
   import type { SubmitFunction } from '@sveltejs/kit';
   import { Tabs, TabsList, TabsTrigger } from '@civitai/ui/components/ui/tabs/index.js';
   import { Textarea } from '@civitai/ui/components/ui/textarea/index.js';
-  import { Input } from '@civitai/ui/components/ui/input/index.js';
   import { Button } from '@civitai/ui/components/ui/button/index.js';
-  import {
-    BLOCKLIST_TYPES,
-    BLOCKLIST_DESCRIPTIONS,
-    humanizeBlocklistType,
-    visibleBlocklistItems,
-  } from '$lib/blocklist';
+  import { badgeVariants } from '@civitai/ui/components/ui/badge/index.js';
+  import ListFilterBar from '$lib/components/ListFilterBar.svelte';
+  import { BLOCKLIST_TYPES, BLOCKLIST_DESCRIPTIONS, humanizeBlocklistType } from '$lib/blocklist';
+  import { visibleBlocklistItems } from './filter';
   import type { ActionData, PageData } from './$types';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
 
@@ -21,7 +18,8 @@
 
   let mode = $state<'add' | 'remove'>('add');
   let text = $state('');
-  let filter = $state('');
+  let filters = $state<Record<string, string>>({});
+  let removing = $state<string | null>(null);
 
   // EmailDomain is 8295 entries in production. Rendering the whole list is both unusable and
   // enough DOM to stall the tab, so the list is filtered first and then capped.
@@ -33,22 +31,27 @@
   const subject = $derived(page.url.search);
   $effect(() => {
     subject;
-    untrack(() => {
-      text = '';
-      mode = 'add';
-      filter = '';
-    });
+    untrack(resetForTab);
   });
 
-  const sortedItems = $derived([...data.blocklist.data].sort());
-  const shown = $derived(visibleBlocklistItems(sortedItems, filter, CHIP_LIMIT));
-  const matches = $derived(shown.matches);
-  const visibleItems = $derived(shown.visible);
+  function resetForTab() {
+    text = '';
+    mode = 'add';
+    filters = {};
+  }
 
   function setMode(next: 'add' | 'remove') {
     mode = next;
     text = '';
   }
+
+  // Duplicates are reachable: `upsertBlocklist` dedupes only on its update branch, so the first save
+  // of a type persists whatever was submitted. They would collide as `{#each}` keys, and each chip
+  // now carries a remove control identified by that same string.
+  const sortedItems = $derived(
+    [...new Set(data.blocklist.data)].sort((a, b) => a.localeCompare(b))
+  );
+  const shown = $derived(visibleBlocklistItems(sortedItems, filters.q ?? '', CHIP_LIMIT));
 
   const submit: SubmitFunction = () => async ({ result, update }) => {
     if (result.type === 'success') text = '';
@@ -56,17 +59,35 @@
   };
 
   // Deliberately does NOT clear `text`: a chip is its own form, so wiping the textarea would throw
-  // away a bulk edit the moderator is part-way through typing.
-  const submitChip: SubmitFunction = () => async ({ update }) => {
-    await update();
-  };
+  // away a bulk edit the moderator is part-way through typing. `removing` disables every chip for
+  // the duration, because two overlapping removals read-modify-write the same array and the later
+  // write restores what the earlier one dropped.
+  const submitChip =
+    (item: string): SubmitFunction =>
+    () => {
+      removing = item;
+      return async ({ update }) => {
+        await update();
+        removing = null;
+      };
+    };
 </script>
 
 <header class="page-header">
   <h1>Blocklists</h1>
 </header>
 
-<Tabs value={data.type} onValueChange={(v) => v && goto(`?type=${v}`)} class="mb-4">
+<Tabs
+  value={data.type}
+  onValueChange={(v) => {
+    if (!v) return;
+    // Reset here as well as in the effect: the effect runs after the DOM is written, so on a tab
+    // change the new type's entries would render against the old tab's filter for a frame.
+    resetForTab();
+    goto(`?type=${v}`);
+  }}
+  class="mb-4"
+>
   <TabsList>
     {#each BLOCKLIST_TYPES as t (t)}
       <TabsTrigger value={t}>{humanizeBlocklistType(t)}</TabsTrigger>
@@ -75,7 +96,7 @@
 </Tabs>
 
 {#if BLOCKLIST_DESCRIPTIONS[data.type]}
-  <p class="mb-4 max-w-xl text-sm text-muted-foreground">{BLOCKLIST_DESCRIPTIONS[data.type]}</p>
+  <p class="mb-4 max-w-xl text-sm text-dark-2">{BLOCKLIST_DESCRIPTIONS[data.type]}</p>
 {/if}
 
 {#if form?.error}
@@ -125,39 +146,48 @@
   </div>
 
   {#if sortedItems.length === 0}
-    <p class="text-sm text-muted-foreground">No items in this blocklist.</p>
+    <p class="text-sm text-dark-2">No items in this blocklist.</p>
   {:else}
     <div class="flex flex-col gap-2">
-      <span class="text-sm font-medium">{humanizeBlocklistType(data.type)} ({sortedItems.length})</span>
-      <Input bind:value={filter} placeholder="Filter entries" />
-      {#if matches.length === 0}
-        <p class="text-sm text-muted-foreground">No entry contains "{filter.trim()}".</p>
+      <span class="text-sm font-medium">{humanizeBlocklistType(data.type)}</span>
+      <ListFilterBar
+        fields={[{ kind: 'search', key: 'q', label: 'Filter entries' }]}
+        bind:values={filters}
+        matched={shown.matches.length}
+        total={sortedItems.length}
+      />
+      {#if shown.matches.length === 0}
+        <p class="text-sm text-dark-2">Nothing on this list matches "{(filters.q ?? '').trim()}".</p>
       {:else}
         <div class="flex flex-wrap gap-2">
-          {#each visibleItems as item (item)}
-            <span
-              class="flex items-center gap-1 rounded-md bg-muted py-1 pl-3 pr-1 text-xs font-medium text-muted-foreground ring-1 ring-inset ring-border"
+          {#each shown.visible as item (item)}
+            <form
+              method="POST"
+              action="?/remove"
+              use:enhance={submitChip(item)}
+              class="{badgeVariants({ variant: 'secondary' })} gap-1 py-1 pl-3 pr-1"
             >
+              <input type="hidden" name="id" value={data.blocklist.id} />
+              <input type="hidden" name="blocklist" value={item} />
               {item}
-              <form method="POST" action="?/remove" use:enhance={submitChip} class="flex">
-                <input type="hidden" name="id" value={data.blocklist.id} />
-                <input type="hidden" name="blocklist" value={item} />
-                <button
-                  type="submit"
-                  aria-label="Remove {item}"
-                  title="Remove {item}"
-                  class="rounded px-1 leading-none text-muted-foreground hover:bg-red-500/15 hover:text-red-300"
-                >
-                  &times;
-                </button>
-              </form>
-            </span>
+              <Button
+                type="submit"
+                variant="ghost"
+                size="icon"
+                class="size-4"
+                disabled={removing !== null}
+                aria-label="Remove {item}"
+                title="Remove {item}"
+              >
+                &times;
+              </Button>
+            </form>
           {/each}
         </div>
-        {#if matches.length > visibleItems.length}
-          <p class="text-xs text-muted-foreground">
-            Showing {visibleItems.length} of {matches.length} matches. Narrow the filter to reach the
-            rest.
+        {#if shown.matches.length > shown.visible.length}
+          <p class="text-xs text-dark-2">
+            Showing {shown.visible.length} of {shown.matches.length} matches. Narrow the filter to
+            reach the rest.
           </p>
         {/if}
       {/if}

--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -23,6 +23,16 @@
   let removing = $state<string | null>(null);
   let confirming = $state<string | null>(null);
 
+  // TEMPORARY DIAGNOSTIC — remove before merge. Justin and I could not establish whether we were
+  // looking at the same build. `hydrated` only ever becomes true from an effect, which does not run
+  // during SSR, so "idle" means the client JS never took over.
+  const BUILD_MARKER = 'BLK-5';
+  let hydrated = $state(false);
+  let lastEvent = $state('none');
+  $effect(() => {
+    hydrated = true;
+  });
+
   // EmailDomain is 8295 entries in production. Rendering the whole list is both unusable and
   // enough DOM to stall the tab, so the list is filtered first and then capped.
   const CHIP_LIMIT = 200;
@@ -99,6 +109,11 @@
 <header class="page-header">
   <h1>Blocklists</h1>
 </header>
+
+<!-- TEMPORARY DIAGNOSTIC — remove before merge. -->
+<p class="mb-3 rounded border border-amber-500/30 bg-amber-500/10 p-1 text-xs text-amber-200">
+  build {BUILD_MARKER} · js {hydrated ? 'LIVE' : 'IDLE'} · last event: {lastEvent}
+</p>
 
 <Tabs
   value={data.type}
@@ -201,7 +216,10 @@
                 disabled={removing !== null}
                 aria-label="Remove {item}"
                 title="Remove {item}"
-                onclick={() => (confirming = item)}
+                onclick={() => {
+                  lastEvent = 'x:' + item;
+                  confirming = item;
+                }}
               >
                 &times;
               </Button>

--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -6,8 +6,14 @@
   import type { SubmitFunction } from '@sveltejs/kit';
   import { Tabs, TabsList, TabsTrigger } from '@civitai/ui/components/ui/tabs/index.js';
   import { Textarea } from '@civitai/ui/components/ui/textarea/index.js';
+  import { Input } from '@civitai/ui/components/ui/input/index.js';
   import { Button } from '@civitai/ui/components/ui/button/index.js';
-  import { BLOCKLIST_TYPES, BLOCKLIST_DESCRIPTIONS, humanizeBlocklistType } from '$lib/blocklist';
+  import {
+    BLOCKLIST_TYPES,
+    BLOCKLIST_DESCRIPTIONS,
+    humanizeBlocklistType,
+    visibleBlocklistItems,
+  } from '$lib/blocklist';
   import type { ActionData, PageData } from './$types';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
 
@@ -15,38 +21,44 @@
 
   let mode = $state<'add' | 'remove'>('add');
   let text = $state('');
+  let filter = $state('');
+
+  // EmailDomain is 8295 entries in production. Rendering the whole list is both unusable and
+  // enough DOM to stall the tab, so the list is filtered first and then capped.
+  const CHIP_LIMIT = 200;
 
   // Keyed on the URL — the tab is `?type=`. Depending on `data` instead meant every successful add or
-  // remove (which invalidates) also forced `mode` back to 'add', so a moderator working in Remove mode
-  // was silently returned to Add and their next clicks staged nothing.
+  // remove (which invalidates) also forced `mode` back to 'add', so a moderator part-way through a
+  // bulk removal was silently returned to Add.
   const subject = $derived(page.url.search);
   $effect(() => {
     subject;
     untrack(() => {
       text = '';
       mode = 'add';
+      filter = '';
     });
   });
 
   const sortedItems = $derived([...data.blocklist.data].sort());
+  const shown = $derived(visibleBlocklistItems(sortedItems, filter, CHIP_LIMIT));
+  const matches = $derived(shown.matches);
+  const visibleItems = $derived(shown.visible);
 
   function setMode(next: 'add' | 'remove') {
     mode = next;
     text = '';
   }
 
-  function stageForRemoval(item: string) {
-    if (mode !== 'remove') return;
-    const current = text
-      .split(',')
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0);
-    if (!current.includes(item)) text = [...current, item].join(', ');
-  }
-
   const submit: SubmitFunction = () => async ({ result, update }) => {
     if (result.type === 'success') text = '';
     await update(); // re-runs load → fresh blocklist (and the shared Redis cache is already updated)
+  };
+
+  // Deliberately does NOT clear `text`: a chip is its own form, so wiping the textarea would throw
+  // away a bulk edit the moderator is part-way through typing.
+  const submitChip: SubmitFunction = () => async ({ update }) => {
+    await update();
   };
 </script>
 
@@ -117,21 +129,38 @@
   {:else}
     <div class="flex flex-col gap-2">
       <span class="text-sm font-medium">{humanizeBlocklistType(data.type)} ({sortedItems.length})</span>
-      <div class="flex flex-wrap gap-2">
-        {#each sortedItems as item (item)}
-          <button
-            type="button"
-            disabled={mode !== 'remove'}
-            onclick={() => stageForRemoval(item)}
-            class="rounded-md bg-muted px-3 py-1 text-xs font-medium text-muted-foreground ring-1 ring-inset ring-border {mode ===
-            'remove'
-              ? 'cursor-pointer hover:bg-red-500/15 hover:text-red-300'
-              : 'cursor-default'}"
-          >
-            {item}
-          </button>
-        {/each}
-      </div>
+      <Input bind:value={filter} placeholder="Filter entries" />
+      {#if matches.length === 0}
+        <p class="text-sm text-muted-foreground">No entry contains "{filter.trim()}".</p>
+      {:else}
+        <div class="flex flex-wrap gap-2">
+          {#each visibleItems as item (item)}
+            <span
+              class="flex items-center gap-1 rounded-md bg-muted py-1 pl-3 pr-1 text-xs font-medium text-muted-foreground ring-1 ring-inset ring-border"
+            >
+              {item}
+              <form method="POST" action="?/remove" use:enhance={submitChip} class="flex">
+                <input type="hidden" name="id" value={data.blocklist.id} />
+                <input type="hidden" name="blocklist" value={item} />
+                <button
+                  type="submit"
+                  aria-label="Remove {item}"
+                  title="Remove {item}"
+                  class="rounded px-1 leading-none text-muted-foreground hover:bg-red-500/15 hover:text-red-300"
+                >
+                  &times;
+                </button>
+              </form>
+            </span>
+          {/each}
+        </div>
+        {#if matches.length > visibleItems.length}
+          <p class="text-xs text-muted-foreground">
+            Showing {visibleItems.length} of {matches.length} matches. Narrow the filter to reach the
+            rest.
+          </p>
+        {/if}
+      {/if}
     </div>
   {/if}
 </div>

--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -56,6 +56,14 @@
   );
   const shown = $derived(visibleBlocklistItems(sortedItems, filters.q ?? '', CHIP_LIMIT));
 
+  // A confirm may only stand for a chip that is still on screen. Without this it survives a filter
+  // change: open the confirm, type in the filter so that chip unmounts, clear the filter later, and
+  // the stale confirm returns unprompted — absolutely positioned at z-50 over whatever chip now
+  // occupies that space, so a click meant for a neighbour's X lands on removing the old entry.
+  $effect(() => {
+    if (confirming && !shown.visible.includes(confirming)) untrack(() => (confirming = null));
+  });
+
   const submit: SubmitFunction = () => async ({ result, update }) => {
     if (result.type === 'success') text = '';
     await update(); // re-runs load → fresh blocklist (and the shared Redis cache is already updated)
@@ -206,6 +214,8 @@
                   disabled={removing !== null}
                   aria-label="Remove {item}"
                   title="Remove {item}"
+                  aria-haspopup="true"
+                  aria-expanded={confirming === item}
                   onclick={() => (confirming = item)}
                 >
                   &times;
@@ -214,10 +224,11 @@
 
               <!-- Anchored inside the form rather than portalled: a portalled confirm is outside the
                    <form> in the DOM, so its submit button loses the implicit association and posts
-                   nothing. Absolute so opening it cannot reflow a 200-chip wrapped list.
-                   🔴 Opens DOWNWARD. Upward put it underneath the filter bar's input, which paints
-                   over it — the confirm was there and invisible, so the X read as a dead control.
-                   z-50 for the same reason: it has to clear the chips it overlaps. -->
+                   nothing. Absolute so opening it cannot reflow a 200-chip wrapped list, and z-50
+                   so it clears the chips it overlaps. Opens downward so it never covers the chip
+                   being acted on.
+                   🔴 Nothing here may sit inside an element with `overflow-hidden` — see the span
+                   above. -->
               {#if confirming === item}
                 <div
                   class="absolute left-0 top-full z-50 mt-1 flex w-max items-center gap-2 rounded-md border bg-popover p-2 text-popover-foreground shadow-md"
@@ -226,10 +237,14 @@
                   <Button type="submit" size="sm" variant="destructive" disabled={removing !== null}>
                     Remove
                   </Button>
+                  <!-- Disabled once the removal is in flight. `enhance` has already issued the
+                       fetch and nothing aborts it, so a live Cancel closes the popover with the
+                       affordance of having stopped something that then happens anyway. -->
                   <Button
                     type="button"
                     size="sm"
                     variant="outline"
+                    disabled={removing !== null}
                     onclick={() => (confirming = null)}
                   >
                     Cancel

--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -26,7 +26,7 @@
   // TEMPORARY DIAGNOSTIC — remove before merge. Justin and I could not establish whether we were
   // looking at the same build. `hydrated` only ever becomes true from an effect, which does not run
   // during SSR, so "idle" means the client JS never took over.
-  const BUILD_MARKER = 'BLK-5';
+  const BUILD_MARKER = 'BLK-7';
   let hydrated = $state(false);
   let lastEvent = $state('none');
   $effect(() => {
@@ -203,33 +203,42 @@
               method="POST"
               action="?/remove"
               use:enhance={submitChip(item)}
-              class="{badgeVariants({ variant: 'secondary' })} relative gap-1 py-1 pl-3 pr-1"
+              class="relative"
             >
               <input type="hidden" name="id" value={data.blocklist.id} />
               <input type="hidden" name="blocklist" value={item} />
-              {item}
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                class="size-4"
-                disabled={removing !== null}
-                aria-label="Remove {item}"
-                title="Remove {item}"
-                onclick={() => {
-                  lastEvent = 'x:' + item;
-                  confirming = item;
-                }}
-              >
-                &times;
-              </Button>
+              <!-- The badge styling stays on this span, NOT on the form. `badgeVariants` carries
+                   `overflow-hidden` and a fixed `h-5`, so a confirm rendered inside a badge-styled
+                   element is clipped away to nothing: present in the DOM, invisible on screen, and
+                   the X reads as a dead control. That cost several review rounds. -->
+              <span class="{badgeVariants({ variant: 'secondary' })} gap-1 py-1 pl-3 pr-1">
+                {item}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  class="size-4"
+                  disabled={removing !== null}
+                  aria-label="Remove {item}"
+                  title="Remove {item}"
+                  onclick={() => {
+                    lastEvent = 'x:' + item;
+                    confirming = item;
+                  }}
+                >
+                  &times;
+                </Button>
+              </span>
 
               <!-- Anchored inside the form rather than portalled: a portalled confirm is outside the
                    <form> in the DOM, so its submit button loses the implicit association and posts
-                   nothing. Absolute so opening it cannot reflow a 200-chip wrapped list. -->
+                   nothing. Absolute so opening it cannot reflow a 200-chip wrapped list.
+                   🔴 Opens DOWNWARD. Upward put it underneath the filter bar's input, which paints
+                   over it — the confirm was there and invisible, so the X read as a dead control.
+                   z-50 for the same reason: it has to clear the chips it overlaps. -->
               {#if confirming === item}
                 <div
-                  class="absolute bottom-full left-0 z-10 mb-1 flex w-max items-center gap-2 rounded-md border bg-popover p-2 text-popover-foreground shadow-md"
+                  class="absolute left-0 top-full z-50 mt-1 flex w-max items-center gap-2 rounded-md border bg-popover p-2 text-popover-foreground shadow-md"
                 >
                   <span class="text-xs">Remove <strong>{item}</strong>?</span>
                   <Button type="submit" size="sm" variant="destructive" disabled={removing !== null}>

--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -9,6 +9,7 @@
   import { Button } from '@civitai/ui/components/ui/button/index.js';
   import { badgeVariants } from '@civitai/ui/components/ui/badge/index.js';
   import ListFilterBar from '$lib/components/ListFilterBar.svelte';
+  import { num } from '$lib/format';
   import { BLOCKLIST_TYPES, BLOCKLIST_DESCRIPTIONS, humanizeBlocklistType } from '$lib/blocklist';
   import { visibleBlocklistItems } from './filter';
   import type { ActionData, PageData } from './$types';
@@ -20,6 +21,7 @@
   let text = $state('');
   let filters = $state<Record<string, string>>({});
   let removing = $state<string | null>(null);
+  let confirming = $state<string | null>(null);
 
   // EmailDomain is 8295 entries in production. Rendering the whole list is both unusable and
   // enough DOM to stall the tab, so the list is filtered first and then capped.
@@ -38,6 +40,7 @@
     text = '';
     mode = 'add';
     filters = {};
+    confirming = null;
   }
 
   function setMode(next: 'add' | 'remove') {
@@ -69,9 +72,21 @@
       return async ({ update }) => {
         await update();
         removing = null;
+        // Cleared here rather than in the confirm button's own click handler. Svelte flushes effects
+        // synchronously after a DOM event handler, so clearing it there unmounts the submitter through
+        // its `{#if}` before the browser runs the form's activation behaviour — the submit never fires
+        // and "Remove" behaves exactly like "Cancel", silently. Same trap as `ConfirmSubmit.svelte`.
+        confirming = null;
       };
     };
 </script>
+
+<!-- One window listener rather than one per chip: at CHIP_LIMIT that would be 200 of them. -->
+<svelte:window
+  onkeydown={(e) => {
+    if (e.key === 'Escape') confirming = null;
+  }}
+/>
 
 <header class="page-header">
   <h1>Blocklists</h1>
@@ -165,29 +180,52 @@
               method="POST"
               action="?/remove"
               use:enhance={submitChip(item)}
-              class="{badgeVariants({ variant: 'secondary' })} gap-1 py-1 pl-3 pr-1"
+              class="{badgeVariants({ variant: 'secondary' })} relative gap-1 py-1 pl-3 pr-1"
             >
               <input type="hidden" name="id" value={data.blocklist.id} />
               <input type="hidden" name="blocklist" value={item} />
               {item}
               <Button
-                type="submit"
+                type="button"
                 variant="ghost"
                 size="icon"
                 class="size-4"
                 disabled={removing !== null}
                 aria-label="Remove {item}"
                 title="Remove {item}"
+                onclick={() => (confirming = item)}
               >
                 &times;
               </Button>
+
+              <!-- Anchored inside the form rather than portalled: a portalled confirm is outside the
+                   <form> in the DOM, so its submit button loses the implicit association and posts
+                   nothing. Absolute so opening it cannot reflow a 200-chip wrapped list. -->
+              {#if confirming === item}
+                <div
+                  class="absolute bottom-full left-0 z-10 mb-1 flex w-max items-center gap-2 rounded-md border bg-popover p-2 text-popover-foreground shadow-md"
+                >
+                  <span class="text-xs">Remove <strong>{item}</strong>?</span>
+                  <Button type="submit" size="sm" variant="destructive" disabled={removing !== null}>
+                    Remove
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onclick={() => (confirming = null)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              {/if}
             </form>
           {/each}
         </div>
         {#if shown.matches.length > shown.visible.length}
           <p class="text-xs text-dark-2">
-            Showing {shown.visible.length} of {shown.matches.length} matches. Narrow the filter to
-            reach the rest.
+            Showing {num(shown.visible.length)} of {num(shown.matches.length)} matches. Narrow the
+            filter to reach the rest.
           </p>
         {/if}
       {/if}

--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -70,13 +70,21 @@
     () => {
       removing = item;
       return async ({ update }) => {
-        await update();
-        removing = null;
-        // Cleared here rather than in the confirm button's own click handler. Svelte flushes effects
-        // synchronously after a DOM event handler, so clearing it there unmounts the submitter through
-        // its `{#if}` before the browser runs the form's activation behaviour — the submit never fires
-        // and "Remove" behaves exactly like "Cancel", silently. Same trap as `ConfirmSubmit.svelte`.
-        confirming = null;
+        // `finally`, not a bare sequence. Every chip's control is disabled while `removing` is set,
+        // so a submit that throws — a rejected fetch, a cross-origin refusal — would otherwise leave
+        // it set forever and kill EVERY remove control on the page until a reload, with the click
+        // doing nothing and no error to read.
+        try {
+          await update();
+        } finally {
+          removing = null;
+          // Cleared here rather than in the confirm button's own click handler. Svelte flushes
+          // effects synchronously after a DOM event handler, so clearing it there unmounts the
+          // submitter through its `{#if}` before the browser runs the form's activation behaviour —
+          // the submit never fires and "Remove" behaves exactly like "Cancel", silently. Same trap
+          // as `ConfirmSubmit.svelte`.
+          confirming = null;
+        }
       };
     };
 </script>

--- a/apps/moderator/src/routes/blocklists/__tests__/filter.test.ts
+++ b/apps/moderator/src/routes/blocklists/__tests__/filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { visibleBlocklistItems } from '../blocklist';
+import { visibleBlocklistItems } from '../filter';
 
 // Alphabetical, so `zzz-late.example` sorts past any cap applied before the filter.
 const bigList = [
@@ -41,5 +41,24 @@ describe('visibleBlocklistItems', () => {
 
   it('treats a whitespace-only filter as no filter', () => {
     expect(visibleBlocklistItems(['a.example', 'b.example'], '   ', 10).matches).toHaveLength(2);
+  });
+  // The lists do not all enforce in the same direction: UsernamePartial and MessagePattern
+  // enforce `input.includes(entry)`, so the entry is a substring of what the moderator types.
+  it('finds the short entry that blocks a long value the moderator pastes', () => {
+    const list = ['scammer', 'unrelated'];
+    expect(visibleBlocklistItems(list, 'xXscammerXx', 10).matches).toEqual(['scammer']);
+  });
+
+  it('still finds a long entry from a short needle', () => {
+    const list = ['scammer', 'unrelated'];
+    expect(visibleBlocklistItems(list, 'scam', 10).matches).toEqual(['scammer']);
+  });
+
+  it('does not match an entry that is neither a substring nor a superstring', () => {
+    expect(visibleBlocklistItems(['scammer'], 'legitimate', 10).matches).toEqual([]);
+  });
+
+  it('matches bidirectionally without regard to case', () => {
+    expect(visibleBlocklistItems(['Scammer'], 'xXSCAMMERXx', 10).matches).toEqual(['Scammer']);
   });
 });

--- a/apps/moderator/src/routes/blocklists/filter.ts
+++ b/apps/moderator/src/routes/blocklists/filter.ts
@@ -1,0 +1,25 @@
+/**
+ * The visible slice of a blocklist, filtered then capped.
+ *
+ * 🔴 Order matters: `EmailDomain` is 8295 entries in production, so the cap exists to keep the
+ * page renderable — but capping BEFORE the filter would search only the first `limit` entries
+ * alphabetically, and a moderator searching for anything past that would be told it is not on
+ * the list. The cap bounds what is drawn, never what is searched.
+ *
+ * 🔴 The match is BIDIRECTIONAL because the lists do not all enforce in the same direction.
+ * `UsernamePartial` enforces `username.includes(entry)` (`user.service.ts`) and `MessagePattern`
+ * enforces `value.includes(pattern)` (`blocklist.service.ts`), so a moderator pasting the
+ * username they were asked about — `xXscammerXx` — must be shown the entry `scammer` that
+ * blocks it. A one-directional `entry.includes(needle)` answers "No entry contains that", which
+ * is true and reads as "not on the list".
+ */
+export function visibleBlocklistItems(items: string[], filter: string, limit: number) {
+  const needle = filter.trim().toLowerCase();
+  if (needle.length === 0) return { matches: items, visible: items.slice(0, limit) };
+
+  const matches = items.filter((item) => {
+    const lower = item.toLowerCase();
+    return lower.includes(needle) || needle.includes(lower);
+  });
+  return { matches, visible: matches.slice(0, limit) };
+}


### PR DESCRIPTION
Closes ClickUp `868kv0cmc`.

## What was actually wrong

The ticket says the block list has no remove control. A remove path did exist — an Add/Remove toggle, where flipping to Remove made the chips clickable so they staged into the textarea. That is the trial-and-error behind the ticket.

The real problem is one layer down: **`EmailDomain` is 8295 entries in production, all rendered as chips with no filter.** A one-click delete on a chip you cannot locate fixes nothing, so the filter is the load-bearing half.

## What this does

- Reuses `ListFilterBar` over the entry list — label, Clear button, formatted "N of M" counts.
- Caps rendered chips at 200, with a line saying how many matches are not drawn. The filter runs over the **whole** list before the cap; capping first would search only the first 200 alphabetically and report anything past that as absent.
- Each chip carries its own one-click remove. The Add/Remove toggle stays but now drives only the textarea, so each surface has one mechanism: chip removes one entry, textarea does bulk add or bulk remove.

## What review found that the ticket did not

**The filter matched in the opposite direction to how two of the lists enforce.** `UsernamePartial` enforces `username.includes(entry)` (`user.service.ts:428`) and `MessagePattern` enforces `value.includes(pattern)` (`blocklist.service.ts:215`). So a moderator pasting `xXscammerXx` into the filter got `No entry contains that` while the entry `scammer` that blocks it sat on the list. The match is now bidirectional.

**The remove action reported a count it never verified.** It returned `count: items.length` — the number *submitted*. A removal that matched nothing still rendered "Removed 1 item." above a chip that was still there. Reachable by double-clicking, and by a stale row id (the DTO is Redis-cached for a **month**). `removeBlocklistItems` now returns the real count and the action fails when it is zero.

**Entries are deduped before rendering.** `upsertBlocklist` dedupes only on its update branch, so the first save of a type persists whatever was submitted. Duplicates would collide as `{#each}` keys, and each chip is now identified by its own value.

## 🔴 One finding this PR only warns about

`sync-email-blocklist` (`src/server/jobs/sync-email-blocklist.ts:77`, `0 3 * * 0`) computes `additions = upstream.filter(d => !existingSet.has(d))`. **A domain a moderator removes is by definition absent from `existingSet`, so it is re-added on the next Sunday run.** The job bails when there is more than one `EmailDomain` row; production has exactly one, so nothing protects it there.

Not introduced here — made *reachable* here, on the exact list this change is motivated by. This PR adds a description on the EmailDomain tab saying so. The durable fix is an exclusion set the cron respects, which lives in the main app and belongs in its own ticket.

(Note for anyone testing: **dev has two `EmailDomain` rows, so the cron skips there** and this cannot be reproduced against the dev DB.)

## Verification

- `pnpm --filter ./apps/moderator run typecheck` — 0 errors, 0 warnings. Mutation-proved it can fail.
- `pnpm --filter ./apps/moderator run lint` — clean.
- `pnpm --filter ./apps/moderator exec vitest run` — 56 pass, 0 fail (35 skipped, pre-existing).
- 15 new tests. Every one checked by mutating the source and reading the file back to confirm the mutation landed: cap-before-filter (3 red), case-sensitivity (1 red), dropping the reverse match direction (2 red), and reporting the submitted count again (3 red).

Reviewed with `svelte-review` — correctness, idiom and abstraction lanes, each prompted to refute.

## Open

Whether the chip `×` should remove immediately (as built) or keep a staged flow behind the toggle is Justin's call; the staged variant is a small revert. Not yet demoed on a dev server — that needs a moderator account to log in as.
