### PR TITLE
fix(search): hoist useModelSaleBadges above the early returns — React #310 crashing /search/models

### DIFF
--- a/src/pages/search/models.tsx
+++ b/src/pages/search/models.tsx
@@ -141,6 +141,10 @@ export function ModelsHitList() {
     }
   }, [modelId, status, showMore, isLastPage, hits]);
 
+  // Must stay above every early return below — a hook called after one changes the hook
+  // count between the loading and loaded renders (React error #310).
+  const salesByModelId = useModelSaleBadges((items as { id: number }[]).map((x) => x.id));
+
   if (hits.length === 0) {
     const NotFound = (
       <div className="flex items-center justify-center">
@@ -193,8 +197,6 @@ export function ModelsHitList() {
       </div>
     );
   }
-
-  const salesByModelId = useModelSaleBadges((items as { id: number }[]).map((x) => x.id));
 
   return (
     <Stack>


### PR DESCRIPTION
## Problem

`#4112` added `useModelSaleBadges` to `ModelsHitList` in `src/pages/search/models.tsx`, but placed the call **after** three early returns:

| Line | Early return |
|---|---|
| 144 | `if (hits.length === 0)` |
| 167 | `if (loading)` |
| 187 | `if (loadingPreferences)` |
| **197** | 🔴 `const salesByModelId = useModelSaleBadges(...)` |

So the hook runs on the loaded render and **not** on the loading render. The hook count changes between renders and React throws **error #310** — *"Rendered more hooks than during the previous render"* — which takes down the model-search page.

Every model search transitions `loading → loaded`, so this fires on essentially every query. Production client error reporting went from a **4–191 per 30m** baseline to **14,665 per 30m** (~7–10/s sustained) immediately after 5.1.32 rolled out; 99.9% of all reported application errors in that window are this single stack:

```
Minified React error #310
    at L (src/pages/search/models.tsx:121:67)
    at ev.Content (src/components/Search/SearchLayout.tsx:418:50)
    ...
```

Server-side error rates are unaffected (5xx stayed at ~0.01%) — the server returns 200 and the browser then crashes, so this is invisible to server-side error metrics.

## Fix

A pure statement hoist — move the hook above every early return.

`items` already comes from `useApplyHiddenPreferences` at the top of the component (line 128), above all three returns, and the hook self-disables on an empty list (`enabled: ids.length > 0`), so calling it earlier is safe and changes no behaviour on the loaded path.

A comment records the invariant so the next edit doesn't reintroduce it.

## Verification

Ran the rule that describes this exact defect against the pre-fix and post-fix files:

```
$ eslint --rule '{"react-hooks/rules-of-hooks":"error"}' <pre-fix> <post-fix>

<pre-fix>
  197:26  error  React Hook "useModelSaleBadges" is called conditionally.
                 React Hooks must be called in the exact same order in every
                 component render  react-hooks/rules-of-hooks

✖ 1 problem (1 error, 0 warnings)
```

Post-fix file: clean. So the control goes red for this rule's own reason, and the fix clears it.

**Not verified**: I have not exercised the page in a browser. The change is a statement move with no behavioural delta on the loaded path, but a reviewer with a dev environment may want to confirm the sale badges still render on `/search/models`.

## Other call sites are fine

The two other `useModelSaleBadges` call sites added by #4112 already sit above their early returns:

| Call site | Position | Verdict |
|---|---|---|
| `src/components/Model/Infinite/ModelsInfinite.tsx:52` | before any return | ✅ |
| `src/components/Profile/Sections/OnSaleSection.tsx:36` | before `if (isNullState) return null` (line 40) | ✅ |
| `src/pages/search/models.tsx:197` | after 3 early returns | 🔴 fixed here |

## Follow-up (not in this PR): why CI didn't block it

`react-hooks/rules-of-hooks` is enabled (via `next/core-web-vitals`) and, as shown above, catches this. It didn't block #4112 because `.github/workflows/lint.yml` gates ESLint asymmetrically:

- **added** files → blocking
- **modified** files → `continue-on-error: true`, report-only

`models.tsx` was a modified file, so the error was printed as a non-blocking annotation and merged. The stated rationale is sound (≈10% of recently-touched files carry a pre-existing error-severity finding, so a hard gate would block unrelated work), but the consequence is that a **newly introduced** error is indistinguishable from the pre-existing backlog.

Worth considering: make the modified-file step a **delta** gate — compute findings at the merge base and at HEAD, and fail only on findings the PR *introduces*, leaving pre-existing ones as warnings. That keeps the backlog non-blocking while making a regression like this one impossible to merge. Happy to open that separately if there's appetite.
