### PR TITLE
fix(account-switcher): refresh the roster avatar when the session's profile picture changes

### DIFF
--- a/src/components/CivitaiWrapped/AccountProvider.browser.test.tsx
+++ b/src/components/CivitaiWrapped/AccountProvider.browser.test.tsx
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { AccountProvider, useAccountContext } from '~/components/CivitaiWrapped/AccountProvider';
+import { SessionProvider, useSession } from '~/providers/SessionProvider';
+import type { Session } from '~/types/session';
+
+/**
+ * ACCOUNT-SWITCHER ROSTER vs. A PROFILE-PICTURE CHANGE.
+ *
+ * 🔴 THE DEFECT THIS SUITE EXISTS FOR. The roster-upsert effect copies the session user's `image` into the
+ * durable `civitai-account-roster` entry, but its dep array was `[currentUserId, deviceAccounts]` — and
+ * NEITHER of those changes when a user updates their profile picture. The session refetches in place (same
+ * user id), and the device-account query sits inside its 60s staleTime, so the effect never re-ran and the
+ * roster kept serving the PREVIOUS avatar url. Changing a profile picture hard-deletes the previous image,
+ * so the switcher then requests a url whose object is gone.
+ *
+ * This suite drives the REAL path: the real `SessionProvider` re-fetching `/api/auth/session` (which is what
+ * the server-side session refresh triggers on the client), the real `AccountProvider`, the real
+ * `useLocalStorage` roster and the real device-account query. Only `fetch` — the network boundary — is
+ * stubbed.
+ *
+ * The load-bearing control is `accountFetches`: it proves the roster moved because the SESSION value moved,
+ * not because the device-account query happened to refetch and mint a new `deviceAccounts` object. Without
+ * it a green result would be indistinguishable from the pre-fix behaviour getting lucky.
+ */
+
+const USER_ID = 4242;
+const ROSTER_KEY = 'civitai-account-roster';
+const LEGACY_ACCOUNTS_KEY = 'civitai-accounts';
+// Synthetic fixtures — never a real avatar url.
+const OLD_AVATAR = 'roster-test-old-avatar.png';
+const NEW_AVATAR = 'roster-test-new-avatar.png';
+const USERNAME = 'roster-test-user';
+
+type RosterEntry = { id: number; username: string; avatarUrl?: string };
+
+function sessionWith(image: string | undefined): Session {
+  return {
+    user: {
+      id: USER_ID,
+      username: USERNAME,
+      image,
+      showNsfw: false,
+      blurNsfw: false,
+      browsingLevel: 1,
+      onboarding: 0,
+    },
+    expires: '2999-01-01T00:00:00.000Z',
+  };
+}
+
+const jsonOk = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body } as unknown as Response);
+
+/** What the durable roster actually holds in localStorage — the thing the switcher rows render from. */
+function readRoster(): Record<string, RosterEntry> {
+  const raw = window.localStorage.getItem(ROSTER_KEY);
+  return raw ? (JSON.parse(raw) as Record<string, RosterEntry>) : {};
+}
+
+/** The server-side session value, swapped mid-test to model a profile-picture change. */
+let currentAvatar: string | undefined;
+let accountFetches = 0;
+let probeRenders = 0;
+/** Captured from the probe so the test can drive a session refetch without a synthetic DOM event. */
+let sessionUpdate: (() => Promise<unknown>) | null = null;
+
+function Probe() {
+  const { update } = useSession();
+  const { accounts } = useAccountContext();
+  sessionUpdate = update;
+  probeRenders++;
+  const entry = accounts[String(USER_ID)];
+  // Mirror what UserMenu reads off the context for a switcher row.
+  return <div data-testid="probe" data-avatar={entry?.avatarUrl ?? ''} />;
+}
+
+const probeAvatar = () =>
+  document.querySelector('[data-testid="probe"]')?.getAttribute('data-avatar') ?? null;
+
+function renderProvider(initial: Session) {
+  return renderWithProviders(
+    <SessionProvider session={initial} refetchOnWindowFocus={false}>
+      <AccountProvider>
+        <Probe />
+      </AccountProvider>
+    </SessionProvider>
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.removeItem(ROSTER_KEY);
+  window.localStorage.removeItem(LEGACY_ACCOUNTS_KEY);
+  currentAvatar = OLD_AVATAR;
+  accountFetches = 0;
+  probeRenders = 0;
+  sessionUpdate = null;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+          ? input.href
+          : String((input as Request)?.url ?? input);
+      if (url.includes('/api/auth/session')) return jsonOk(sessionWith(currentAvatar));
+      if (url.includes('/api/auth/accounts')) {
+        accountFetches++;
+        // No seamlessly-switchable siblings — keeps `deviceAccounts` out of the picture entirely.
+        return jsonOk({ accounts: [] });
+      }
+      throw new Error(`unexpected fetch in AccountProvider test: ${url}`);
+    })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.localStorage.removeItem(ROSTER_KEY);
+  window.localStorage.removeItem(LEGACY_ACCOUNTS_KEY);
+});
+
+describe('AccountProvider roster — session avatar changes', () => {
+  test('🔴 a new avatar reaches the roster while currentUserId and deviceAccounts stay put', async () => {
+    renderProvider(sessionWith(OLD_AVATAR));
+
+    await vi.waitFor(() => {
+      expect(readRoster()[String(USER_ID)]?.avatarUrl).toBe(OLD_AVATAR);
+      expect(probeAvatar()).toBe(OLD_AVATAR);
+    });
+    const accountFetchesAfterMount = accountFetches;
+    expect(accountFetchesAfterMount).toBeGreaterThan(0); // positive control: the query really ran
+
+    // The user changes their profile picture. Server-side the session is re-shaped and the client pulls the
+    // fresh copy in place — same user id, and the device-account query is still inside its staleTime.
+    currentAvatar = NEW_AVATAR;
+    await sessionUpdate?.();
+
+    await vi.waitFor(() => {
+      expect(probeAvatar()).toBe(NEW_AVATAR);
+    });
+    expect(readRoster()[String(USER_ID)]?.avatarUrl).toBe(NEW_AVATAR);
+    // 🔴 The control. Had `deviceAccounts` refetched, a NEW object identity would have re-run the effect and
+    // the pre-fix code would have passed this test for the wrong reason.
+    expect(accountFetches).toBe(accountFetchesAfterMount);
+  });
+
+  test('REMOVING the profile picture clears the roster avatar (no stale-value fallback)', async () => {
+    renderProvider(sessionWith(OLD_AVATAR));
+
+    await vi.waitFor(() => {
+      expect(readRoster()[String(USER_ID)]?.avatarUrl).toBe(OLD_AVATAR);
+    });
+    const accountFetchesAfterMount = accountFetches;
+
+    currentAvatar = undefined;
+    await sessionUpdate?.();
+
+    await vi.waitFor(() => {
+      expect(probeAvatar()).toBe('');
+    });
+    expect(readRoster()[String(USER_ID)]?.avatarUrl).toBeUndefined();
+    // Identity is still remembered — only the avatar was cleared.
+    expect(readRoster()[String(USER_ID)]?.username).toBe(USERNAME);
+    expect(accountFetches).toBe(accountFetchesAfterMount);
+  });
+
+  test('the effect settles — a widened dep list does not loop', async () => {
+    renderProvider(sessionWith(OLD_AVATAR));
+    await vi.waitFor(() => {
+      expect(readRoster()[String(USER_ID)]?.avatarUrl).toBe(OLD_AVATAR);
+    });
+
+    currentAvatar = NEW_AVATAR;
+    await sessionUpdate?.();
+    await vi.waitFor(() => {
+      expect(probeAvatar()).toBe(NEW_AVATAR);
+    });
+
+    // Quiescence: an unbounded re-render loop keeps committing after the value has settled.
+    const settled = probeRenders;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(probeRenders).toBe(settled);
+    // And the whole mount + one avatar change costs a bounded number of commits, not dozens.
+    expect(settled).toBeLessThan(25);
+  });
+});

--- a/src/components/CivitaiWrapped/AccountProvider.tsx
+++ b/src/components/CivitaiWrapped/AccountProvider.tsx
@@ -79,6 +79,14 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
   const router = useRouter();
   const queryClient = useQueryClient();
   const currentUserId = userData?.user?.id;
+  // The session-derived values the roster effect below reads, hoisted out as PRIMITIVES on purpose.
+  // `userData` itself is a fresh object on every session refetch, so depending on the OBJECT would re-run a
+  // state-writing effect on every poll (the `EMPTY_ROSTER` note above is the same hazard, one store over).
+  // Depending on the VALUES gets the effect re-run exactly when the data it copies actually changed.
+  const hasSessionUser = !!userData?.user;
+  const isImpersonating = !!userData?.impersonatedBy;
+  const sessionUsername = userData?.user?.username;
+  const sessionAvatarUrl = userData?.user?.image;
 
   // The seamlessly-switchable set (hub device set, 30d rolling). Empty until authenticated. `?? EMPTY_ROSTER`
   // (not a `= {}` default) keeps the reference STABLE across renders so the effects below don't loop.
@@ -89,7 +97,10 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
     queryFn: async () => {
       const rows = await authProxy.listAccounts();
       return Object.fromEntries(
-        rows.map((a) => [String(a.userId), { id: a.userId, username: a.username ?? '', avatarUrl: a.image }])
+        rows.map((a) => [
+          String(a.userId),
+          { id: a.userId, username: a.username ?? '', avatarUrl: a.image },
+        ])
       );
     },
   });
@@ -130,7 +141,12 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
       let changed = false;
       const upsert = (id: string, entry: RosterEntry) => {
         const cur = prev[id];
-        if (!cur || cur.id !== entry.id || cur.username !== entry.username || cur.avatarUrl !== entry.avatarUrl) {
+        if (
+          !cur ||
+          cur.id !== entry.id ||
+          cur.username !== entry.username ||
+          cur.avatarUrl !== entry.avatarUrl
+        ) {
           next[id] = entry;
           changed = true;
         }
@@ -138,11 +154,15 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
       // NB: skip the current user while IMPERSONATING — the "current user" is then the impersonated target, not
       // a real account linked on this device, so it must never enter the switcher roster (impersonation also
       // never touches the hub device set, so deviceAccounts below won't reintroduce it).
-      if (currentUserId && userData?.user && !userData.impersonatedBy) {
+      if (currentUserId && hasSessionUser && !isImpersonating) {
         upsert(String(currentUserId), {
           id: currentUserId,
-          username: userData.user.username ?? prev[String(currentUserId)]?.username ?? '',
-          avatarUrl: userData.user.image ?? prev[String(currentUserId)]?.avatarUrl,
+          username: sessionUsername ?? prev[String(currentUserId)]?.username ?? '',
+          // NO `?? prev` fallback for the avatar here (unlike the deviceAccounts loop below). In THIS branch
+          // the session user is known-present, so its `image` is authoritative: `undefined` means "this user
+          // has no profile picture", not "no data". Falling back to the remembered value made removing a
+          // profile picture impossible to reflect — the switcher kept rendering the deleted avatar forever.
+          avatarUrl: sessionAvatarUrl,
         });
       }
       for (const [id, a] of Object.entries(deviceAccounts)) {
@@ -154,8 +174,22 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
       }
       return changed ? next : prev;
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUserId, deviceAccounts]);
+    // Every value this effect reads is listed — no `exhaustive-deps` suppression, deliberately. The
+    // suppression that used to sit here hid a real defect: the deps were `[currentUserId, deviceAccounts]`,
+    // and NEITHER changes when a user updates their profile picture, so the roster went on serving the
+    // previous avatar url until the device-account query happened to refetch (60s staleTime). Changing a
+    // profile picture HARD-DELETES the previous image, so that url 404s for the whole window — and the CDN
+    // caches the failure well beyond it. `setRoster` is stable (useLocalStorage memoizes it on `key`), and
+    // the rest are primitives, so a complete dep list cannot loop.
+  }, [
+    currentUserId,
+    deviceAccounts,
+    hasSessionUser,
+    isImpersonating,
+    sessionUsername,
+    sessionAvatarUrl,
+    setRoster,
+  ]);
 
   // Drop legacy tokens once that account is in the device set (migrated). The roster keeps the account.
   useEffect(() => {


### PR DESCRIPTION
## The bug

`AccountProvider` keeps a durable, credential-free account-switcher roster in `localStorage`
(`{ id, username, avatarUrl }`), and the switcher rows render their avatars from it. The effect that
upserts the current user into that roster depended on `[currentUserId, deviceAccounts]`.

Neither of those changes when a user updates their profile picture:

- the session refetches **in place** — same `user.id`, so `currentUserId` is unchanged;
- the device-account query has a 60s `staleTime`, so `deviceAccounts` keeps the same object identity.

So the effect never re-ran, and the roster went on serving the **previous** avatar url. The
`// eslint-disable-next-line react-hooks/exhaustive-deps` sitting directly above the dep array
suppressed the warning that would have caught it.

The stale value is not harmless. Saving a new profile picture **hard-deletes** the old image —
`updateUserHandler` calls `deleteImageById`, which does a real `image.delete` plus `deleteImageFromS3` —
so the switcher requests an object that no longer exists and gets a 404, which the CDN then caches well
beyond the window that produced it.

## The fix

Hoist the session values the effect actually reads into **primitives** (`hasSessionUser`,
`isImpersonating`, `sessionUsername`, `sessionAvatarUrl`) and list all of them, plus the stable
`setRoster`, in the dep array. The effect now re-runs exactly when the data it copies changes.

Deliberately **not** the `userData` object: it is a fresh object on every session refetch, so an object
dep would re-run a state-writing effect on every poll. This file has been bitten by unstable object
identity before — see the `EMPTY_ROSTER` note about a `= {}` default minting a new object every render.
The `upsert` helper still returns the SAME `prev` object when nothing changed, so `setState` bails; the
third test below pins that the widened dep list settles instead of looping.

With a complete dep list the `exhaustive-deps` suppression is gone, which restores the lint signal for
this effect. (Verified as a control: shrinking the array back to `[currentUserId, deviceAccounts]` now
produces `react-hooks/exhaustive-deps` naming all five missing deps.)

## The `?? prev` fallback — changed, for the current-user branch only

Inside `if (currentUserId && hasSessionUser && !isImpersonating)` the session user is **known-present**,
so `image` is authoritative: `undefined` means "this user has no profile picture", not "no data". With
`image ?? prev[...].avatarUrl`, a user who **removes** their profile picture could never clear the stale
roster avatar — it would render the deleted image forever. Dropped it.

The `deviceAccounts` loop's fallback is untouched, because there a missing field genuinely does mean
"no data".

Degrading is graceful: `useGetEdgeUrl(undefined)` returns `undefined` and Mantine's `Avatar` falls back
to the user's initials.

## Second item investigated — no change needed

It was suspected that the session's `image` field returns the raw legacy `User.image` column (empty for
anyone with a modern `profilePictureId`) and needed to coalesce `profilePicture?.url ?? image`.
**It already coalesces, and this PR changes nothing there.**

The main app has no session producer at all any more — there is no `[...nextauth].ts`, no `next-auth`
dependency, no `callbacks.session`/`callbacks.jwt`. The auth app is the sole producer, and the coalesce
lives in exactly one place:

- `apps/auth/src/lib/server/auth/session-shape.ts:154` — `image: row.profilePicture?.url ?? row.image ?? undefined,`
  inside `shapeSessionUser()`, fed by the `profilePicture` lateral join in
  `apps/auth/src/lib/server/auth/session-producer.ts:48-53`.
- Already unit-tested: `apps/auth/src/lib/server/auth/__tests__/session-shape.test.ts:84-86` pins all
  three cases (profile picture wins, legacy column as fallback, `undefined` when neither).
- The main app only reads the shaped object (`src/server/auth/session-client.ts:46`) and passes it
  through (`src/pages/api/auth/session.ts`); the token itself carries no `image`, so there is no path
  that could bypass the coalesce. The account-list endpoint reuses the same producer, so roster avatars
  arriving that way are coalesced too.

Adding a second coalesce in the main app would have been redundant, so it isn't in this PR.

## Tests

`src/components/CivitaiWrapped/AccountProvider.browser.test.tsx` (Vitest browser-mode `component`
project, the repo's existing harness — no new scaffold). It drives the **real** `SessionProvider`, the
**real** `AccountProvider`, the real `useLocalStorage` roster and the real device-account query; only
`fetch`, the network boundary, is stubbed.

1. **a new avatar reaches the roster while `currentUserId` and `deviceAccounts` stay put** — mount,
   settle, change the served session `image`, pull it in via `useSession().update()` (the same call the
   session-refresh signal makes), assert both the context-visible `avatarUrl` and the persisted
   `localStorage` entry follow.
   The load-bearing control is `expect(accountFetches).toBe(accountFetchesAfterMount)`: it proves the
   device-account query did **not** refetch, so a new `deviceAccounts` identity cannot be what moved the
   roster. Without that control a green result would be indistinguishable from the pre-fix code getting
   lucky.
2. **removing the profile picture clears the roster avatar** — covers the `?? prev` change, and asserts
   the username is still remembered.
3. **the effect settles — a widened dep list does not loop** — after the change settles, renders are
   quiescent over 300ms and the whole mount-plus-one-change costs a bounded number of commits.

### Red at base / green at HEAD

Same command both times, only `src/components/CivitaiWrapped/AccountProvider.tsx` swapped:

```
npx vitest run --project component src/components/CivitaiWrapped/AccountProvider.browser.test.tsx
```

| tree | result |
|---|---|
| `origin/main` copy of `AccountProvider.tsx` + this test | **Test Files 1 failed / Tests 3 failed** — all three `AssertionError: expected 'roster-test-old-avatar.png' to be 'roster-test-new-avatar.png'` (and `... to be ''` for the removal case) |
| this branch | **Test Files 1 passed / Tests 3 passed** |

The failures are the defect itself: the roster keeps the old avatar.

## Gates

- `pnpm typecheck` — `typecheck: OK — 0 type errors in 61s (heap cap 8192 MB)`.
- `pnpm lint` — **0 problems in the two changed files** (checked in the full-run output, not just a
  targeted run). The repo-wide pre-existing baseline is unchanged.
- `pnpm prettier:check` flagged `AccountProvider.tsx`; `prettier:write` reformatted my lines **and two
  pre-existing blocks** that were already non-conformant on `main` (the `rows.map` in the query fn and
  the `upsert` comparison). Those two re-wraps are the only unrelated hunks in the diff — the
  changed-file prettier gate cannot pass while they stay as they are.
