### PR TITLE
fix(creator-studio): exclude soft-deleted chapter reads from the comics panel

### DIFF
--- a/apps/creator-studio/src/lib/server/__tests__/comics-analytics-unread.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/comics-analytics-unread.test.ts
@@ -23,12 +23,8 @@ vi.mock('$lib/server/db', () => ({ dbRead: {}, dbWrite: {} }));
 // Narrow fakes rather than spreads of the real modules: `cache` builds a Redis client at import and
 // `clickhouse` opens a connection, and this test asserts on a query string that neither participates in.
 vi.mock('$lib/server/cache', () => ({
-  createCache:
-    <A, R>({ fetch }: { fetch: (args: A) => Promise<R> }) =>
-    ({ get: fetch }),
-  createSysCache:
-    <A, R>({ fetch }: { fetch: (args: A) => Promise<R> }) =>
-    ({ get: fetch }),
+  createCache: <A, R>({ fetch }: { fetch: (args: A) => Promise<R> }) => ({ get: fetch }),
+  createSysCache: <A, R>({ fetch }: { fetch: (args: A) => Promise<R> }) => ({ get: fetch }),
 }));
 
 vi.mock('$lib/server/clickhouse', () => ({

--- a/apps/creator-studio/src/lib/server/__tests__/comics-analytics-unread.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/comics-analytics-unread.test.ts
@@ -80,8 +80,16 @@ describe('comics analytics excludes soft-deleted chapter reads', () => {
     expect(sql).toMatch(/LEFT JOIN "ComicChapterRead"/i);
 
     // From the FROM clause on, so the aggregate's own `FILTER (WHERE ...)` — which sits in the select list,
-    // above it — is not mistaken for the statement's WHERE.
-    const fromOnwards = sql.slice(sql.search(/FROM "ComicProject"/i));
-    expect(fromOnwards.slice(fromOnwards.search(/\bWHERE\b/i))).not.toMatch(/unread/i);
+    // above it — is not mistaken for the statement's WHERE. Both offsets are asserted before slicing:
+    // `search` returns -1 on a miss and `slice(-1)` is the last CHARACTER, which no assertion can fail
+    // against. A refactor scoping the creator through a CTE would land there and stop this guarding.
+    const fromIndex = sql.search(/FROM "ComicProject"/i);
+    expect(fromIndex, 'the comics query no longer selects FROM ComicProject').toBeGreaterThanOrEqual(0);
+
+    const fromOnwards = sql.slice(fromIndex);
+    const whereIndex = fromOnwards.search(/\bWHERE\b/i);
+    expect(whereIndex, 'the comics query no longer has a statement WHERE').toBeGreaterThanOrEqual(0);
+
+    expect(fromOnwards.slice(whereIndex)).not.toMatch(/unread/i);
   });
 });

--- a/apps/creator-studio/src/lib/server/__tests__/comics-analytics-unread.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/comics-analytics-unread.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `ComicChapterRead.unread` is the row's soft delete — the platform's own comic metrics count a read as
+ * `unread = false`. Creator Studio's comics panel counted every row, so an un-read chapter would still be
+ * counted as read. Prod holds 0 such rows today, which is exactly why this needs a test rather than a look at
+ * the screen: the defect is invisible until the first un-read and the numbers stay plausible afterwards.
+ */
+
+const state = vi.hoisted(() => ({ queries: [] as string[] }));
+
+// The `sql` tag itself, so the query text is observable without standing up a Kysely executor. Interpolations
+// come back as `?` rather than being dropped, so a predicate built out of a bound value stays visible.
+vi.mock('@civitai/db/kysely', () => ({
+  sql: (strings: TemplateStringsArray) => {
+    state.queries.push(strings.join('?'));
+    return { execute: async () => ({ rows: [] }) };
+  },
+}));
+
+vi.mock('$lib/server/db', () => ({ dbRead: {}, dbWrite: {} }));
+
+// Narrow fakes rather than spreads of the real modules: `cache` builds a Redis client at import and
+// `clickhouse` opens a connection, and this test asserts on a query string that neither participates in.
+vi.mock('$lib/server/cache', () => ({
+  createCache:
+    <A, R>({ fetch }: { fetch: (args: A) => Promise<R> }) =>
+    ({ get: fetch }),
+  createSysCache:
+    <A, R>({ fetch }: { fetch: (args: A) => Promise<R> }) =>
+    ({ get: fetch }),
+}));
+
+vi.mock('$lib/server/clickhouse', () => ({
+  getClickhouse: () => ({ $query: async () => [] }),
+}));
+
+const { getComics } = await import('../analytics');
+
+/**
+ * The comics panel's own query, identified by what it selects rather than by call order, with `--` comments
+ * stripped. The stripping is load-bearing: the query is commented, and a comment mentioning the predicate
+ * would satisfy every assertion below without the predicate existing.
+ */
+async function comicsQuery() {
+  state.queries.length = 0;
+  await getComics({ userId: 1818607, from: '2026-08-01', to: '2026-08-21' });
+  const query = state.queries.find((q) => q.includes('"ComicProject"'));
+  expect(query, 'the comics panel never issued its Postgres query').toBeDefined();
+  return (query as string)
+    .replace(/--[^\n]*/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Everything from the ComicChapterRead join up to the next clause. */
+function readJoinClause(sql: string) {
+  const match = sql.match(/LEFT JOIN "ComicChapterRead"[\s\S]*?(?=LEFT JOIN|WHERE|GROUP BY|$)/i);
+  expect(match, 'the comics query no longer joins ComicChapterRead').not.toBeNull();
+  return (match as RegExpMatchArray)[0];
+}
+
+describe('comics analytics excludes soft-deleted chapter reads', () => {
+  beforeEach(() => {
+    state.queries.length = 0;
+  });
+
+  it('filters the read rows on unread', async () => {
+    expect(readJoinClause(await comicsQuery())).toMatch(/unread/i);
+  });
+
+  // `unread = true` would satisfy a bare /unread/ match while counting exactly the rows that must not count,
+  // so the polarity is asserted separately from the presence of the predicate.
+  it('keeps the rows that are NOT un-read', async () => {
+    const clause = readJoinClause(await comicsQuery());
+    expect(clause).toMatch(/"?unread"?\s*=\s*false|not\s+r?\.?"?unread"?/i);
+    expect(clause).not.toMatch(/"?unread"?\s*=\s*true/i);
+  });
+
+  // In WHERE instead of ON, the predicate turns the LEFT JOIN inner and every comic nobody has read
+  // disappears from the creator's list — a worse bug than the one being fixed.
+  it('applies the filter on the join, not in WHERE', async () => {
+    const sql = await comicsQuery();
+    expect(sql).toMatch(/LEFT JOIN "ComicChapterRead"/i);
+
+    // From the FROM clause on, so the aggregate's own `FILTER (WHERE ...)` — which sits in the select list,
+    // above it — is not mistaken for the statement's WHERE.
+    const fromOnwards = sql.slice(sql.search(/FROM "ComicProject"/i));
+    expect(fromOnwards.slice(fromOnwards.search(/\bWHERE\b/i))).not.toMatch(/unread/i);
+  });
+});

--- a/apps/creator-studio/src/lib/server/analytics.ts
+++ b/apps/creator-studio/src/lib/server/analytics.ts
@@ -882,7 +882,9 @@ async function fetchComics(userId: number, from: string, to: string): Promise<Co
            )                                           AS "newReaders"
     FROM "ComicProject" p
     LEFT JOIN "ComicChapter" c ON c."projectId" = p.id
-    LEFT JOIN "ComicChapterRead" r ON r."chapterId" = c.id
+    -- unread is ComicChapterRead's soft delete, and the platform metrics count a read as unread = false.
+    -- On the join rather than in WHERE, or a comic nobody has read drops off the list entirely.
+    LEFT JOIN "ComicChapterRead" r ON r."chapterId" = c.id AND r."unread" = false
     LEFT JOIN "Image" i ON i.id = p."coverImageId"
     WHERE p."userId" = ${uid}
       -- Comic deletion is soft and lives in status, not in a deletedAt column like the sibling entities.


### PR DESCRIPTION
Closes item 1 of [868ku89ga](https://app.clickup.com/t/868ku89ga). Item 2 of that ticket turned out to have a wrong premise and is being closed with the measurement rather than fixed — see below.

### The fix

`ComicChapterRead.unread` is the row's soft delete. The platform's own comic metrics count a read as `unread = false` (`src/server/metrics/comic.metrics.ts`); Creator Studio's comics panel counted every row, so an un-read chapter still counted as read in both `readers` and `newReaders`.

Prod holds 0 un-read rows across 362,108, so nothing is wrong on screen today. That is the argument for a test rather than for leaving it: the defect only appears after the first un-read, and the numbers stay plausible when it does.

The predicate goes on the join, not in `WHERE` — as a `WHERE` predicate it turns the `LEFT JOIN` inner and every comic nobody has read drops off the creator's list, which is a worse bug than the one being fixed.

### Test

`comics-analytics-unread.test.ts` captures the query text by faking the `sql` tag (interpolations come back as `?` rather than being dropped) and asserts on the join clause. Comments are stripped from the captured SQL first, and that is load-bearing — without it the explanatory comment beside the predicate satisfied every assertion on its own. It did, until it was fixed.

Mutation matrix, each mutation confirmed landed by grepping the file afterwards:

| mutation | result |
|---|---|
| predicate removed | 2 of 3 fail |
| `unread = true` | 1 of 3 fails — the polarity test, alone, as intended |
| moved from the join into `WHERE` | 3 of 3 fail |
| rewritten as `AND NOT r.unread` | 3 of 3 **pass** — equivalent spelling, not a regression |

The last row is the one that says the guard pins the behaviour rather than my spelling of it.

### Two findings that change their tickets

**868ku89ga item 2 — the views stat card cannot disagree with its chart.** The claim is that the card includes an incomplete final day the chart clamps away. It cannot: `ownerViewsDailySql`'s `least(to, sealed)` bounds the `WITH FILL` range, not which rows are summed, and the rollup holds no rows past its seal. Measured on prod — seal `2026-08-20`, today `2026-08-21` — the card query and the chart series sum identically over a range spanning today: **15529 / 15529** for owner 1818607, `2026-08-01`..`2026-08-21`. No change made.

**868ku7wed — `impressionTrackingLive` is worse than dead, and I am not fixing it here.** It has zero callers, as filed. It is also all-time scoped (`... WHERE entityType IN (...) LIMIT 1`, no date bound), which is precisely the bug `viewTrackingSql`'s own comment says it replaced: for a period predating the data it answers "live" and the surface renders a confident zero. And it matters now, because `impressions_daily_by_owner` starts **2026-08-17** — four days of data — so every earlier period on the article and image pages renders "No feed impressions {period}" for a metric that was not collecting.

Wiring it correctly means a date bound plus new user-facing copy on two surfaces, and the image page carries a comment deliberately deciding that a zero there is real. That is Justin's call about what a creator is told, not a drive-by fix, so it stays open with these measurements on it.

### Verification

- `pnpm run typecheck` in `apps/creator-studio` (svelte-check) — 8964 files, 0 errors, 0 warnings
- `pnpm run test:apps:run` — 69 files, 694 passed
- `pnpm exec prettier --write` with the app's own Prettier 3
