### PR TITLE
fix(skills): a flag with no value is an error, not a silent true

### DIFF
--- a/.claude/skills/cloudflare/SKILL.md
+++ b/.claude/skills/cloudflare/SKILL.md
@@ -52,6 +52,10 @@ node .claude/skills/cloudflare/query.mjs <command> [options]
 | `--pro-compat` | Strip Enterprise-only syntax to fit Pro/Free target zones (see below) |
 | `--apply` | Actually write. Without this, `port-rules` is a dry run |
 
+Only `--skip-disabled`, `--pro-compat` and `--apply` carry no value. Every other flag must be given one —
+a bare flag, or one whose value starts with `--`, is an error rather than the string `'true'` it used to
+become. Use `--flag=value` for a value that legitimately starts with `--`.
+
 ### Examples
 
 ```bash

--- a/.claude/skills/cloudflare/SKILL.md
+++ b/.claude/skills/cloudflare/SKILL.md
@@ -52,9 +52,10 @@ node .claude/skills/cloudflare/query.mjs <command> [options]
 | `--pro-compat` | Strip Enterprise-only syntax to fit Pro/Free target zones (see below) |
 | `--apply` | Actually write. Without this, `port-rules` is a dry run |
 
-Only `--skip-disabled`, `--pro-compat` and `--apply` carry no value. Every other flag must be given one —
-a bare flag, or one whose value starts with `--`, is an error rather than the string `'true'` it used to
-become. Use `--flag=value` for a value that legitimately starts with `--`.
+Only `--skip-disabled`, `--pro-compat` and `--apply` carry no value; each also accepts an explicit
+`--apply true` / `--apply false`. Every other flag must be given one — a bare flag, or one whose value
+starts with `--`, is an error rather than the string `'true'` it used to become. Use `--flag=value` for a
+value that legitimately starts with `--`.
 
 ### Examples
 

--- a/.claude/skills/cloudflare/parse-flags.mjs
+++ b/.claude/skills/cloudflare/parse-flags.mjs
@@ -22,16 +22,29 @@ export function parseFlags(args) {
       continue;
     }
 
-    // `--key=value` first, so a value that legitimately starts with `--` is still expressible.
+    // `--key=value` first, so a value that legitimately starts with `--` is still expressible. An empty
+    // right-hand side is rejected here too — this is the form the error below sends people to, so it is
+    // the last place that should have a hole in it.
     const eq = arg.indexOf('=');
     if (eq > 2) {
-      flags[arg.slice(2, eq)] = arg.slice(eq + 1);
+      const eqKey = arg.slice(2, eq);
+      const eqValue = arg.slice(eq + 1);
+      if (eqValue === '') throw new Error(`--${eqKey}= was given an empty value.`);
+      flags[eqKey] = eqValue;
       continue;
     }
 
     const key = arg.slice(2);
     if (BOOLEAN_FLAGS.has(key)) {
-      flags[key] = 'true';
+      // `--apply true` worked before and still does: an explicit true/false is consumed rather than
+      // left to become a positional, which would shift `positional[1]` on the commands that take one.
+      const spelled = args[i + 1];
+      if (spelled === 'true' || spelled === 'false') {
+        flags[key] = spelled;
+        i++;
+      } else {
+        flags[key] = 'true';
+      }
       continue;
     }
 

--- a/.claude/skills/cloudflare/parse-flags.mjs
+++ b/.claude/skills/cloudflare/parse-flags.mjs
@@ -1,0 +1,52 @@
+// Flag parsing for query.mjs. Its own module so a test can import it — query.mjs runs the CLI on import.
+
+// The flags that carry no value; each is read as `=== 'true'` by the CLI. Any other flag must be given
+// one, so a missing or `--`-prefixed value is an error rather than the string 'true'.
+export const BOOLEAN_FLAGS = new Set(['skip-disabled', 'pro-compat', 'apply']);
+
+/**
+ * 🔴 A value-taking flag whose value was missing or started with `--` used to become the STRING 'true',
+ * which is worse than a boolean here: it is a plausible value. `--path --json` filtered on the literal
+ * "true", matched nothing, and reported an empty result rather than an error.
+ *
+ * Throws rather than exiting, so the failure is observable to a test and to any future caller.
+ */
+export function parseFlags(args) {
+  const flags = {};
+  const positional = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith('--')) {
+      positional.push(arg);
+      continue;
+    }
+
+    // `--key=value` first, so a value that legitimately starts with `--` is still expressible.
+    const eq = arg.indexOf('=');
+    if (eq > 2) {
+      flags[arg.slice(2, eq)] = arg.slice(eq + 1);
+      continue;
+    }
+
+    const key = arg.slice(2);
+    if (BOOLEAN_FLAGS.has(key)) {
+      flags[key] = 'true';
+      continue;
+    }
+
+    const next = args[i + 1];
+    if (next === undefined || next === '' || next.startsWith('--')) {
+      const got =
+        next === undefined ? 'nothing followed it' : next === '' ? 'it was empty' : `got "${next}"`;
+      throw new Error(
+        `--${key} needs a value (${got}). A value starting with "--" is read as the next flag — ` +
+          `pass it as --${key}=<value> instead.`
+      );
+    }
+    flags[key] = next;
+    i++;
+  }
+
+  return { flags, positional };
+}

--- a/.claude/skills/cloudflare/query.mjs
+++ b/.claude/skills/cloudflare/query.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { parseFlags } from './parse-flags.mjs';
 
 /**
  * Cloudflare Analytics Query Tool
@@ -655,17 +656,14 @@ async function cmdListZones() {
 // --- CLI ---
 
 const args = process.argv.slice(2);
-const flags = {};
-const positional = [];
 
-for (let i = 0; i < args.length; i++) {
-  if (args[i].startsWith('--')) {
-    const key = args[i].slice(2);
-    const val = args[i + 1] && !args[i + 1].startsWith('--') ? args[++i] : 'true';
-    flags[key] = val;
-  } else {
-    positional.push(args[i]);
-  }
+let flags;
+let positional;
+try {
+  ({ flags, positional } = parseFlags(args));
+} catch (err) {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
 }
 
 const cmd = positional[0];

--- a/.claude/skills/metabase/SKILL.md
+++ b/.claude/skills/metabase/SKILL.md
@@ -13,9 +13,9 @@ Create questions, dashboards, and public links on Civitai's Metabase instance.
 node .claude/skills/metabase/metabase.mjs <command> [options]
 ```
 
-**A value that starts with `--` needs `--flag=value`.** Every flag except `--required` takes a value, and
-a bare `--flag` (or one whose value begins with `--`) is an error rather than a silent `true`. This bites
-most often with SQL opening on a `--` comment line:
+**A value that starts with `--` needs `--flag=value`.** Every flag except `--required` and `--json` takes a
+value, and a bare `--flag` (or one whose value begins with `--`) is an error rather than a silent `true`.
+This bites most often with SQL opening on a `--` comment line:
 
 ```bash
 --query="-- daily totals

--- a/.claude/skills/metabase/SKILL.md
+++ b/.claude/skills/metabase/SKILL.md
@@ -13,6 +13,17 @@ Create questions, dashboards, and public links on Civitai's Metabase instance.
 node .claude/skills/metabase/metabase.mjs <command> [options]
 ```
 
+**A value that starts with `--` needs `--flag=value`.** Every flag except `--required` takes a value, and
+a bare `--flag` (or one whose value begins with `--`) is an error rather than a silent `true`. This bites
+most often with SQL opening on a `--` comment line:
+
+```bash
+--query="-- daily totals
+SELECT ..."
+```
+
+`create-question` reads the card back after creating it and fails if the stored SQL is not what was sent.
+
 ## Commands
 
 ### run-query — Ad-hoc SQL query

--- a/.claude/skills/metabase/metabase.mjs
+++ b/.claude/skills/metabase/metabase.mjs
@@ -185,7 +185,12 @@ async function createQuestion(opts) {
   // query at all, and such a card renders blank — indistinguishable from a permissions problem, which is
   // how it was read the first time. The server rewrites the legacy `dataset_query.native.query` we post
   // into a `stages[0].native` string, so both shapes are accepted here.
-  const stored = await api('GET', `/card/${card.id}`);
+  const stored = await readCard(card.id);
+  if (stored === null) {
+    console.error(`Card ${card.id} was created but could not be read back, so it is unverified.`);
+    console.error(`  Check it: ${METABASE_URL}/question/${card.id}`);
+    process.exit(1);
+  }
   const storedQuery = storedNativeQuery(stored);
   if (storedQuery !== query) {
     console.error(`Card ${card.id} was created but does not carry the SQL that was sent.`);
@@ -204,6 +209,19 @@ async function createQuestion(opts) {
     console.log(`  Variables: ${Object.keys(templateTags).join(', ')}`);
   }
   return card;
+}
+
+// Read a card without `api()`'s exit-on-failure: a GET that fails must not be reported as a create that
+// failed, since the card exists either way and the difference decides what the operator does next.
+async function readCard(id) {
+  try {
+    const res = await fetch(`${METABASE_URL}/api/card/${id}`, {
+      headers: { 'x-api-key': METABASE_API_KEY },
+    });
+    return res.ok ? await res.json() : null;
+  } catch {
+    return null;
+  }
 }
 
 // The SQL a saved card actually carries, in either shape the API returns. Anything that is not a string —

--- a/.claude/skills/metabase/metabase.mjs
+++ b/.claude/skills/metabase/metabase.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { parseOpts } from './parse-opts.mjs';
 
 /**
  * Metabase Skill — create questions, dashboards, and manage public sharing
@@ -179,14 +180,38 @@ async function createQuestion(opts) {
   }
 
   const card = await api('POST', '/card', body);
+
+  // Read the card back rather than trusting the create. The API reports success for a card carrying no
+  // query at all, and such a card renders blank — indistinguishable from a permissions problem, which is
+  // how it was read the first time. The server rewrites the legacy `dataset_query.native.query` we post
+  // into a `stages[0].native` string, so both shapes are accepted here.
+  const stored = await api('GET', `/card/${card.id}`);
+  const storedQuery = storedNativeQuery(stored);
+  if (storedQuery !== query) {
+    console.error(`Card ${card.id} was created but does not carry the SQL that was sent.`);
+    console.error(`  stored: ${storedQuery === undefined ? '(no query at all)' : JSON.stringify(storedQuery)}`);
+    console.error(`  sent:   ${JSON.stringify(query)}`);
+    console.error(`  URL: ${METABASE_URL}/question/${card.id}`);
+    process.exit(1);
+  }
+
   console.log(`Question created successfully!`);
   console.log(`  ID: ${card.id}`);
   console.log(`  Name: ${card.name}`);
   console.log(`  URL: ${METABASE_URL}/question/${card.id}`);
+  console.log(`  Verified: the stored query matches what was sent`);
   if (Object.keys(templateTags).length > 0) {
     console.log(`  Variables: ${Object.keys(templateTags).join(', ')}`);
   }
   return card;
+}
+
+// The SQL a saved card actually carries, in either shape the API returns. Anything that is not a string —
+// the boolean a degraded flag value used to produce, most of all — comes back undefined.
+function storedNativeQuery(card) {
+  const stage = card?.dataset_query?.native ?? card?.dataset_query?.stages?.[0];
+  const sql = typeof stage === 'string' ? stage : (stage?.query ?? stage?.native);
+  return typeof sql === 'string' ? sql : undefined;
 }
 
 async function createDashboard(opts) {
@@ -591,26 +616,13 @@ Common Options:
   process.exit(1);
 }
 
-// Parse remaining args into key-value opts
-function parseOpts(args) {
-  const opts = {};
-  for (let i = 1; i < args.length; i++) {
-    const arg = args[i];
-    if (arg.startsWith('--')) {
-      const key = arg.slice(2);
-      const next = args[i + 1];
-      if (next && !next.startsWith('--')) {
-        opts[key] = next;
-        i++;
-      } else {
-        opts[key] = true;
-      }
-    }
-  }
-  return opts;
+let opts;
+try {
+  opts = parseOpts(args);
+} catch (err) {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
 }
-
-const opts = parseOpts(args);
 
 const commands = {
   'run-query': runQuery,

--- a/.claude/skills/metabase/parse-opts.mjs
+++ b/.claude/skills/metabase/parse-opts.mjs
@@ -1,9 +1,13 @@
 // Flag parsing for metabase.mjs. Its own module so a test can import it — metabase.mjs runs the CLI on
 // import and exits when its credentials are unset.
 
-// The only flag that carries no value. Everything else must be given one, and this list is what lets a
-// missing value be an error rather than a silent `true`.
-export const BOOLEAN_FLAGS = new Set(['required']);
+// The flags that carry no value. Everything else must be given one, and this list is what lets a missing
+// value be an error rather than a silent `true`.
+//
+// `json` is here because the CLI's own usage text advertises `--json` as a common option. Nothing reads it
+// — it was silently ignored before and still is — but making the documented form exit 1 would be a
+// regression introduced by the fix rather than by the bug.
+export const BOOLEAN_FLAGS = new Set(['required', 'json']);
 
 /**
  * 🔴 A value-taking flag whose value is missing, empty, or starts with `--` used to become boolean `true`,
@@ -20,10 +24,15 @@ export function parseOpts(args, { startIndex = 1 } = {}) {
     const arg = args[i];
     if (!arg.startsWith('--')) continue;
 
-    // `--key=value` first, so a value that legitimately starts with `--` is still expressible.
+    // `--key=value` first, so a value that legitimately starts with `--` is still expressible. An empty
+    // right-hand side is rejected here too — this is the form the error below sends people to, so it is
+    // the last place that should have a hole in it.
     const eq = arg.indexOf('=');
     if (eq > 2) {
-      opts[arg.slice(2, eq)] = arg.slice(eq + 1);
+      const key = arg.slice(2, eq);
+      const value = arg.slice(eq + 1);
+      if (value === '') throw new Error(`--${key}= was given an empty value.`);
+      opts[key] = value;
       continue;
     }
 

--- a/.claude/skills/metabase/parse-opts.mjs
+++ b/.claude/skills/metabase/parse-opts.mjs
@@ -1,0 +1,49 @@
+// Flag parsing for metabase.mjs. Its own module so a test can import it — metabase.mjs runs the CLI on
+// import and exits when its credentials are unset.
+
+// The only flag that carries no value. Everything else must be given one, and this list is what lets a
+// missing value be an error rather than a silent `true`.
+export const BOOLEAN_FLAGS = new Set(['required']);
+
+/**
+ * 🔴 A value-taking flag whose value is missing, empty, or starts with `--` used to become boolean `true`,
+ * and every guard downstream tests truthiness — so `create-question --query` with a swallowed value posted
+ * `native: { query: true }`, which the API accepted and stored as a card with no query on it. It opened
+ * blank, which reads as a permissions problem; two people nearly shipped a production DDL over it. SQL that
+ * opens with a `--` comment line hits this with nothing wrong at the call site.
+ *
+ * Throws rather than exiting, so the failure is observable to a test and to any future caller.
+ */
+export function parseOpts(args, { startIndex = 1 } = {}) {
+  const opts = {};
+  for (let i = startIndex; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith('--')) continue;
+
+    // `--key=value` first, so a value that legitimately starts with `--` is still expressible.
+    const eq = arg.indexOf('=');
+    if (eq > 2) {
+      opts[arg.slice(2, eq)] = arg.slice(eq + 1);
+      continue;
+    }
+
+    const key = arg.slice(2);
+    if (BOOLEAN_FLAGS.has(key)) {
+      opts[key] = true;
+      continue;
+    }
+
+    const next = args[i + 1];
+    if (next === undefined || next === '' || next.startsWith('--')) {
+      const got =
+        next === undefined ? 'nothing followed it' : next === '' ? 'it was empty' : `got "${next}"`;
+      throw new Error(
+        `--${key} needs a value (${got}). A value starting with "--" is read as the next flag — ` +
+          `pass it as --${key}=<value> instead.`
+      );
+    }
+    opts[key] = next;
+    i++;
+  }
+  return opts;
+}

--- a/scripts/__tests__/skill-cli-flag-values.test.ts
+++ b/scripts/__tests__/skill-cli-flag-values.test.ts
@@ -63,7 +63,9 @@ describe.each(PARSERS)('%s flag values', (name, parse) => {
 // a boolean flag left off it starts erroring, and a value-taking flag added to it silently degrades again.
 describe('boolean flags keep working', () => {
   it('metabase --required', () => {
-    expect(metabase.parseOpts(['cmd', '--id', '1', '--required'])).toMatchObject({ required: true });
+    expect(metabase.parseOpts(['cmd', '--id', '1', '--required'])).toMatchObject({
+      required: true,
+    });
     expect(metabase.BOOLEAN_FLAGS.has('required')).toBe(true);
   });
 

--- a/scripts/__tests__/skill-cli-flag-values.test.ts
+++ b/scripts/__tests__/skill-cli-flag-values.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Both skill CLIs degraded a flag whose value was missing, empty, or `--`-prefixed into a truthy
+ * placeholder — `true` in metabase, the string `'true'` in cloudflare — which every downstream guard
+ * then accepted. The metabase case created Metabase cards carrying no query at all: the API reported
+ * success, the card opened blank, and that reads as a permissions problem rather than a malformed
+ * request. It cost a day and nearly a production DDL.
+ *
+ * The parsers live in their own modules because both CLIs run on import (each exits when its
+ * credentials are unset), so this is the only way to exercise them without spawning a process.
+ *
+ * They are deliberately NOT one shared module: no skill in this repo imports from another skill's
+ * directory, and creating that coupling for thirty lines is the worse trade. Both are covered here,
+ * so a fix to one that is not made to the other is visible.
+ */
+
+const metabase = await import('../../.claude/skills/metabase/parse-opts.mjs');
+const cloudflare = await import('../../.claude/skills/cloudflare/parse-flags.mjs');
+
+/** Each parser reduced to `(args) => flags`, so the same cases run against both. */
+const PARSERS = [
+  // metabase's CLI passes the command as args[0], so its parser starts at index 1.
+  ['metabase', (args: string[]) => metabase.parseOpts(['cmd', ...args])] as const,
+  ['cloudflare', (args: string[]) => cloudflare.parseFlags(args).flags] as const,
+];
+
+describe.each(PARSERS)('%s flag values', (name, parse) => {
+  it('rejects a flag whose value was swallowed by the next flag', () => {
+    // The real shape: SQL opening with a `--` comment line, or a shell that ate the value.
+    expect(() => parse(['--query', '--database', '3'])).toThrowError(/--query needs a value/);
+  });
+
+  it('rejects a flag at the end of the line with no value', () => {
+    expect(() => parse(['--query'])).toThrowError(/--query needs a value/);
+  });
+
+  it('rejects an empty value', () => {
+    expect(() => parse(['--query', ''])).toThrowError(/--query needs a value/);
+  });
+
+  // The escape hatch the error message names. If this stops working the message sends people nowhere.
+  it('accepts a --`--`-prefixed value through --key=value', () => {
+    expect(parse(['--query=--comment first', '--database', '3'])).toMatchObject({
+      query: '--comment first',
+      database: '3',
+    });
+  });
+
+  it('still parses an ordinary flag', () => {
+    expect(parse(['--database', '3'])).toMatchObject({ database: '3' });
+  });
+
+  it('never yields a non-string value for a value-taking flag', () => {
+    const parsed = parse(['--database', '3', '--query=SELECT 1']);
+    for (const [key, value] of Object.entries(parsed)) {
+      expect(typeof value, `${name} parsed --${key} as ${typeof value}`).toBe('string');
+    }
+  });
+});
+
+// Each CLI has flags that genuinely carry no value, and the whole fix rests on that list being right:
+// a boolean flag left off it starts erroring, and a value-taking flag added to it silently degrades again.
+describe('boolean flags keep working', () => {
+  it('metabase --required', () => {
+    expect(metabase.parseOpts(['cmd', '--id', '1', '--required'])).toMatchObject({ required: true });
+    expect(metabase.BOOLEAN_FLAGS.has('required')).toBe(true);
+  });
+
+  it('cloudflare --apply, --skip-disabled and --pro-compat', () => {
+    const { flags } = cloudflare.parseFlags(['port-rules', '--apply', '--skip-disabled']);
+    // The CLI reads these as `=== 'true'`, so the string is the contract, not a boolean.
+    expect(flags).toMatchObject({ apply: 'true', 'skip-disabled': 'true' });
+    expect([...cloudflare.BOOLEAN_FLAGS].sort()).toEqual(['apply', 'pro-compat', 'skip-disabled']);
+  });
+
+  it('cloudflare keeps positional arguments', () => {
+    const { positional } = cloudflare.parseFlags(['top-paths', '--limit', '5', 'extra']);
+    expect(positional).toEqual(['top-paths', 'extra']);
+  });
+});

--- a/scripts/__tests__/skill-cli-flag-values.test.ts
+++ b/scripts/__tests__/skill-cli-flag-values.test.ts
@@ -51,6 +51,11 @@ describe.each(PARSERS)('%s flag values', (name, parse) => {
     expect(parse(['--database', '3'])).toMatchObject({ database: '3' });
   });
 
+  // The `=` form is where the error message sends people, so a hole in it is the worst place to have one.
+  it('rejects an empty value in the --key=value form too', () => {
+    expect(() => parse(['--query='])).toThrowError(/empty value/);
+  });
+
   it('never yields a non-string value for a value-taking flag', () => {
     const parsed = parse(['--database', '3', '--query=SELECT 1']);
     for (const [key, value] of Object.entries(parsed)) {
@@ -79,5 +84,22 @@ describe('boolean flags keep working', () => {
   it('cloudflare keeps positional arguments', () => {
     const { positional } = cloudflare.parseFlags(['top-paths', '--limit', '5', 'extra']);
     expect(positional).toEqual(['top-paths', 'extra']);
+  });
+
+  // `--apply true` parsed as apply='true' before this change. Left unconsumed, the `true` becomes a
+  // positional and shifts positional[1] on every command that takes one.
+  it('cloudflare consumes an explicitly spelled boolean', () => {
+    const { flags, positional } = cloudflare.parseFlags(['ip', '--apply', 'true', '1.2.3.4']);
+    expect(flags).toMatchObject({ apply: 'true' });
+    expect(positional).toEqual(['ip', '1.2.3.4']);
+  });
+
+  // metabase's own usage text advertises --json, so making the documented form exit 1 would be a
+  // regression introduced by this fix rather than by the bug it repairs.
+  it('metabase --json is advertised, so it must parse', () => {
+    expect(metabase.parseOpts(['list', '--collection', '232', '--json'])).toMatchObject({
+      collection: '232',
+      json: true,
+    });
   });
 });


### PR DESCRIPTION
Closes [868kv1de8](https://app.clickup.com/t/868kv1de8), whose reported mechanism turned out to be wrong — and the real one is in a second skill too.

### What the ticket said, and what is actually true

The ticket says `create-question` writes `"native": true` where the SQL belongs. It does not: the posted body is the correct legacy `dataset_query.native.query` shape, and the server rewrites it into a `stages[0].native` string. Verified by creating a card through the skill and reading it back — stored `{"stages":[{"lib/type":"mbql.stage/native","native":"SELECT 1 AS one"}],...}`, `POST /api/card/<id>/query` → `completed`, rows `[[1]]`.

**The defect is one layer up, in the argument parser** (`metabase.mjs:595`):

```js
const next = args[i + 1];
if (next && !next.startsWith('--')) { opts[key] = next; i++; }
else { opts[key] = true; }
```

A value-taking flag whose value is missing, empty, or **starts with `--`** silently became boolean `true`. `createQuestion` then guards `if (!name || !dbId || !query)` — and `true` is truthy — so it posted `native: { query: true }`. Metabase accepted that and stored a card with no query on it. The card exists, opens, and renders blank, which is indistinguishable from a permissions problem; it was read as one, and two people were about to fix it with a production DDL.

The most likely way to hit it is ordinary: **SQL that opens with a `--` comment line.**

### It is not one skill

`cloudflare/query.mjs:664` had the same construction with a worse fallback — the *string* `'true'`:

```js
const val = args[i + 1] && !args[i + 1].startsWith('--') ? args[++i] : 'true';
```

A boolean at least looks wrong under a debugger. `'true'` is a plausible filter value: `--path --json` filtered paths matching the literal `"true"`, matched nothing, and printed an empty result rather than an error.

`civitai-orchestration/civitai-client.js:55` has a third variant, but it only degrades an `=`-less flag and its flags are genuinely boolean, so it is left alone rather than churned.

`dev-server/cli.mjs:137` already does this correctly (`if (!value || value.startsWith('--')) throw`), and `mod-actions/lib.mjs` keeps an explicit boolean-flag list. Both patterns are what this copies.

### What changed

Each parser moves into its own module and rejects a missing value instead of inventing one. `--key=value` is now accepted so a value that legitimately starts with `--` is still expressible — that is the escape hatch the error message names, and it is tested, because an error message pointing at something that does not work is worse than no message.

`create-question` **reads the card back** and fails if the stored SQL is not what was sent. A create that cannot fail is the defect class the whole ticket is about.

They are deliberately **not** one shared module: no skill in this repo imports from another skill's directory (only `clickup/` imports across its own subdirectories), and creating that coupling for thirty lines is the worse trade. Both are covered by one test file, so a fix made to one and not the other is visible.

### Proof, not assertion

The read-back was checked by **reintroducing the original defect** — hard-coding `query: true` in the posted body — and running it against real Metabase:

```
Card 3137 was created but does not carry the SQL that was sent.
  stored: (no query at all)
  sent:   "SELECT 3 AS three"
```

Exit code 1. Before this change that same run printed `Question created successfully!`. Both probe cards were deleted afterwards (`DELETE` → 204, `GET` → 404).

Parser mutation matrix, each mutation confirmed landed by reading the file:

| mutation | result |
|---|---|
| metabase back to boolean `true` | 3 fail — **all metabase-side**, 0 cloudflare |
| cloudflare back to string `'true'` | 3 fail — **all cloudflare-side**, 0 metabase |
| metabase `BOOLEAN_FLAGS` emptied | 1 fail — `--required` |
| cloudflare `--apply` dropped from booleans | 1 fail |
| `--key=value` support removed from both | 4 fail |

The first two rows are the point: each parser is covered independently, so fixing one and forgetting the other cannot pass.

### Verification

- End-to-end against real Metabase: the degraded flag now errors (`--query needs a value (got "--database")`), an ordinary `run-query` still returns rows, `create-question` prints `Verified: the stored query matches what was sent`
- `pnpm run typecheck` — 0 errors · `pnpm exec eslint` on the new test — no issues · full unit suite green
- Both `SKILL.md` files document the rule, since the failure is at a call site rather than in the code

### Not in this change

The `dev-server` half of the tooling batch (`868kur8gm` unwedge purging one cache of two, `868ku8uyr` `wt rm` timing out half-removed) — PR #4251 is open on `cli.mjs` and two agents in one file is how the corruption in `868kut17b` happened.
