### PR TITLE
fix(stickers): keep the approve/decline controls inside the image

### DIFF
--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -5,6 +5,7 @@ import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import type { PlacedSticker } from '~/components/Sticker/placement.util';
 import { orderPlacements, placementRevealDelays } from '~/components/Sticker/placement-order';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
+import { placementControlPosition } from '~/components/Sticker/placement-control-position';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
 import { StickerPlacementHoverCard } from '~/components/Sticker/StickerPlacementHoverCard';
 import { PlacementFreeBadge } from '~/components/Placement/PlacementFreeBadge';
@@ -198,6 +199,52 @@ export function StickerPlacementOverlay({
   // Only pending placements are measured; nothing else is positioned relative to
   // a sticker's edge.
   const [stickerHeights, setStickerHeights] = useState<Record<number, number>>({});
+  /**
+   * The box the controls have to stay inside, and how big each control is.
+   *
+   * Both are needed before the position can be clamped, and neither is knowable
+   * from CSS: the control's width depends on which buttons the owner gets, and
+   * the box is the media rectangle this overlay was drawn over. Until they land,
+   * `placementControlPosition` returns null and the unclamped position stands.
+   */
+  const [controlBox, setControlBox] = useState({ width: 0, height: 0 });
+  const [controlSizes, setControlSizes] = useState<
+    Record<number, { width: number; height: number }>
+  >({});
+
+  const measureBox = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    const read = () =>
+      setControlBox((current) =>
+        current.width === node.offsetWidth && current.height === node.offsetHeight
+          ? current
+          : { width: node.offsetWidth, height: node.offsetHeight }
+      );
+    read();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(read);
+    observer.observe(node);
+    boxObserver.current?.disconnect();
+    boxObserver.current = observer;
+  }, []);
+  const boxObserver = useRef<ResizeObserver | null>(null);
+  useEffect(() => () => boxObserver.current?.disconnect(), []);
+
+  const measureControl = useCallback(
+    (placementId: number) => (node: HTMLDivElement | null) => {
+      if (!node) return;
+      // `offsetWidth`/`offsetHeight` for the same reason the sticker is measured
+      // that way: they are layout numbers and ignore the reveal animation's
+      // transform.
+      const size = { width: node.offsetWidth, height: node.offsetHeight };
+      setControlSizes((current) =>
+        current[placementId]?.width === size.width && current[placementId]?.height === size.height
+          ? current
+          : { ...current, [placementId]: size }
+      );
+    },
+    []
+  );
   // Disposers rather than observers, because the no-`ResizeObserver` path has
   // its own thing to unhook.
   const disposers = useRef(new Map<number, () => void>());
@@ -470,6 +517,18 @@ export function StickerPlacementOverlay({
           // number that says nothing about where the sticker's edge is. Treating
           // it as valid put the controls 14px below the sticker's CENTRE, on top
           // of the artwork, until the image landed and moved them.
+          // Clamped into the media box, once both it and the control have been
+          // measured. Null until then, and the unclamped position below stands —
+          // see `placementControlPosition` for why this exists at all.
+          const clamped = placementControlPosition({
+            x: placement.data.x,
+            y: placement.data.y,
+            stickerHeight: stickerHeights[placement.id],
+            gap: CONTROL_GAP_PX,
+            control: controlSizes[placement.id] ?? { width: 0, height: 0 },
+            box: controlBox,
+          });
+
           if (stickerHeights[placement.id] > 0)
             pendingControls.push(
               <div key={placement.id}>
@@ -508,17 +567,28 @@ export function StickerPlacementOverlay({
                   fighting over the same property. Absent beats hidden here:
                   there is nothing to interact with either. */}
                 <div
-                  className={clsx('pointer-events-auto absolute -translate-x-1/2', revealClassName)}
+                  ref={measureControl(placement.id)}
+                  className={clsx(
+                    'pointer-events-auto absolute',
+                    // The translate goes with the clamp: a clamped `left` is the
+                    // control's own left edge, stated against the box, so
+                    // shifting it by half its width afterwards would put it back
+                    // outside on the very edges this fixes.
+                    !clamped && '-translate-x-1/2',
+                    revealClassName
+                  )}
                   style={{
-                    left: `${placement.data.x * 100}%`,
+                    left: clamped ? clamped.left : `${placement.data.x * 100}%`,
                     // Measured half-height plus a gap, in pixels. No percentage
                     // arithmetic: a percentage in `top` resolves against the box's
                     // height while the sticker is sized from its width, and every
                     // attempt to reconcile the two by calculation has been wrong on
                     // some aspect ratio.
-                    top: `calc(${placement.data.y * 100}% + ${
-                      stickerHeights[placement.id] / 2 + CONTROL_GAP_PX
-                    }px)`,
+                    top: clamped
+                      ? clamped.top
+                      : `calc(${placement.data.y * 100}% + ${
+                          stickerHeights[placement.id] / 2 + CONTROL_GAP_PX
+                        }px)`,
                     // Above every sticker, not just above the one it belongs to:
                     // the layer order means anything placed later covers this
                     // sticker, and it would cover the owner's only way to answer.
@@ -563,6 +633,7 @@ export function StickerPlacementOverlay({
           these under the draft along with everything else. */}
       {pendingControls.length > 0 && (
         <div
+          ref={measureBox}
           className="pointer-events-none absolute inset-0 overflow-hidden"
           style={{ zIndex: PENDING_CONTROL_Z }}
         >

--- a/src/components/Sticker/__tests__/placement-control-position.test.ts
+++ b/src/components/Sticker/__tests__/placement-control-position.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { placementControlPosition } from '~/components/Sticker/placement-control-position';
+
+/**
+ * The measurements this exists because of, taken from the running page with a
+ * pending placement at each edge: the media box was 658 x 986 and the
+ * approve/decline pair 122 x 22. A sticker at `y = 0.95` put both buttons 59px
+ * BELOW the box; `x = 0.03` and `x = 0.97` put one button 42px past the side.
+ * Three edges out of four, all of them clipped away by the layer's
+ * `overflow-hidden`.
+ */
+const BOX = { width: 658, height: 986 };
+const CONTROL = { width: 122, height: 22 };
+const GAP = 14;
+const STICKER = 80;
+
+const at = (
+  x: number,
+  y: number,
+  overrides: Partial<Parameters<typeof placementControlPosition>[0]> = {}
+) =>
+  placementControlPosition({
+    x,
+    y,
+    stickerHeight: STICKER,
+    gap: GAP,
+    control: CONTROL,
+    box: BOX,
+    ...overrides,
+  });
+
+const inside = (position: { left: number; top: number } | null) => {
+  expect(position).not.toBeNull();
+  if (!position) return;
+  expect(position.left).toBeGreaterThanOrEqual(0);
+  expect(position.top).toBeGreaterThanOrEqual(0);
+  expect(position.left + CONTROL.width).toBeLessThanOrEqual(BOX.width);
+  expect(position.top + CONTROL.height).toBeLessThanOrEqual(BOX.height);
+};
+
+describe('placementControlPosition', () => {
+  it('keeps the controls below the sticker when there is room', () => {
+    const position = at(0.5, 0.05);
+
+    // The preferred side, and the one the controls have always been on: below
+    // the artwork, clear of the thing being judged.
+    expect(position?.top).toBe(0.05 * BOX.height + STICKER / 2 + GAP);
+    inside(position);
+  });
+
+  it('flips above the sticker when below would leave the box', () => {
+    // The reported bug. Unclamped this was 996, which is 59px past the bottom
+    // edge and entirely clipped.
+    const position = at(0.5, 0.95);
+
+    expect(position?.top).toBe(0.95 * BOX.height - STICKER / 2 - GAP - CONTROL.height);
+    expect(position?.top).toBeLessThan(0.95 * BOX.height);
+    inside(position);
+  });
+
+  it('clamps into the left edge', () => {
+    // Unclamped: 0.03 * 658 - 61 = -41, i.e. 41px outside.
+    const position = at(0.03, 0.5);
+
+    expect(position?.left).toBe(0);
+    inside(position);
+  });
+
+  it('clamps into the right edge', () => {
+    // Unclamped: 0.97 * 658 - 61 = 577, and 577 + 122 = 699 against a 658 box.
+    const position = at(0.97, 0.5);
+
+    expect(position?.left).toBe(BOX.width - CONTROL.width);
+    inside(position);
+  });
+
+  it('centres on the sticker when nothing is in the way', () => {
+    // The clamp must not move a control that fits — a clamp that always fires is
+    // indistinguishable from one that never does, and both pass an
+    // is-it-inside-the-box assertion.
+    const position = at(0.5, 0.5);
+
+    expect(position?.left).toBe(0.5 * BOX.width - CONTROL.width / 2);
+  });
+
+  it('stays inside when neither side has room', () => {
+    // A sticker scaled to most of a short box. Clamping is the only honest
+    // answer here: the controls end up over the artwork, which is worse-looking
+    // and better than unreachable.
+    const position = placementControlPosition({
+      x: 0.5,
+      y: 0.5,
+      stickerHeight: 300,
+      gap: GAP,
+      control: CONTROL,
+      box: { width: 300, height: 120 },
+    });
+
+    expect(position).not.toBeNull();
+    expect(position?.top).toBeGreaterThanOrEqual(0);
+    expect((position?.top ?? 0) + CONTROL.height).toBeLessThanOrEqual(120);
+  });
+
+  it('returns null until the control has been measured', () => {
+    // Not a guess at 0,0: the caller keeps its unclamped position, so the
+    // controls arrive in the right place slightly late rather than jumping.
+    expect(at(0.5, 0.5, { control: { width: 0, height: 0 } })).toBeNull();
+  });
+
+  it('returns null until the box has been measured', () => {
+    expect(at(0.5, 0.5, { box: { width: 0, height: 0 } })).toBeNull();
+  });
+
+  it('lands the control top-left when it is larger than the box', () => {
+    // Only reachable on a thumbnail. A max/min in the wrong order returns a
+    // negative coordinate here, which is the unreachable state again.
+    const position = placementControlPosition({
+      x: 0.5,
+      y: 0.5,
+      stickerHeight: 10,
+      gap: GAP,
+      control: { width: 400, height: 200 },
+      box: { width: 100, height: 100 },
+    });
+
+    expect(position).toEqual({ left: 0, top: 0 });
+  });
+});

--- a/src/components/Sticker/placement-control-position.ts
+++ b/src/components/Sticker/placement-control-position.ts
@@ -1,0 +1,85 @@
+export type ControlSize = { width: number; height: number };
+export type ControlBox = { width: number; height: number };
+
+/**
+ * Where the owner's approve/decline controls go, in pixels, for a sticker
+ * anchored anywhere on the image.
+ *
+ * 🔴 THE CLAMP IS THE WHOLE POINT. The controls used to be positioned purely
+ * from the sticker — `left: x%`, `top: y% + halfStickerHeight + gap` — inside a
+ * layer with `overflow-hidden`. Measured on a real placement at each edge: a
+ * sticker at `y = 0.95` put both buttons **59px below** the box, entirely
+ * clipped, and stickers at `x = 0.03` / `x = 0.97` put one button **42px past**
+ * the side. Three edges out of four, and the owner's only in-image way to answer
+ * a placement with them. The container was truncating what the anchor had
+ * already pushed outside; nothing was reconciling the two.
+ *
+ * Below the sticker stays the preferred position — that is where the control has
+ * always been and it is out of the artwork's way. It flips ABOVE only when below
+ * does not fit, because a control laid over the sticker is a control over the
+ * thing being judged.
+ *
+ * Pixels rather than percentages, matching the existing `top` calculation and
+ * for the same reason: a percentage in `top` resolves against the box's height
+ * while a sticker is sized from its width, and every attempt to reconcile those
+ * by arithmetic has been wrong on some aspect ratio.
+ *
+ * Returns `null` when anything needed has not been measured yet. The caller then
+ * keeps its unclamped position, which is the behaviour that shipped — a control
+ * that jumps once on measurement is better than one that is briefly at 0,0.
+ */
+export function placementControlPosition({
+  x,
+  y,
+  stickerHeight,
+  gap,
+  control,
+  box,
+}: {
+  /** 0–1, fraction of the box's width. The sticker's centre. */
+  x: number;
+  /** 0–1, fraction of the box's height. */
+  y: number;
+  /** The sticker's measured visual height in px, rotation included. */
+  stickerHeight: number;
+  /** Clear air between the sticker and the controls. */
+  gap: number;
+  control: ControlSize;
+  box: ControlBox;
+}): { left: number; top: number } | null {
+  if (!(box.width > 0) || !(box.height > 0)) return null;
+  if (!(control.width > 0) || !(control.height > 0)) return null;
+
+  const centreY = y * box.height;
+  const halfSticker = stickerHeight / 2;
+
+  const below = centreY + halfSticker + gap;
+  const above = centreY - halfSticker - gap - control.height;
+
+  /**
+   * Fits below, fits above, or neither.
+   *
+   * The third case is real rather than defensive: a sticker scaled large on a
+   * short box can leave no room on either side, and clamping is then the only
+   * honest answer — the controls end up overlapping the artwork, which is worse
+   * than the alternative of being unreachable.
+   */
+  const top = below + control.height <= box.height ? below : above >= 0 ? above : below;
+
+  return {
+    // The caller drops its `-translate-x-1/2`: this is the control's LEFT edge,
+    // so the clamp can be stated against the box rather than against a
+    // half-width the transform hides.
+    left: clamp(x * box.width - control.width / 2, 0, box.width - control.width),
+    top: clamp(top, 0, box.height - control.height),
+  };
+}
+
+/**
+ * `max` before `min`, so a control taller or wider than the box lands at the
+ * top-left rather than at a negative coordinate. Only reachable on a box smaller
+ * than the buttons, which is a thumbnail rather than a review surface.
+ */
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), Math.max(min, max));
+}


### PR DESCRIPTION
## Approve/decline unreachable when a sticker sits low on an image

Fixes `868kut2bd` (reported by Demian, 2026-08-20).

### The diagnosis, from measurements rather than from reading

The ticket says the controls are anchored to the sticker and overflow the container. Justin says they are truncated to fit inside the image. **Both describe the same defect, in sequence** — so this is one fix, not a choice between two.

`StickerPlacementOverlay` positions the pending controls at `left: x%` (with a half-width transform) and `top: calc(y% + halfStickerHeight + 14px)`, with **no clamp**, inside a layer that is `overflow-hidden`. The anchor puts them outside; the container then truncates them.

Four pending placements at the four extremes, measured in a browser against the clip box (`196,60 → 854,1046`):

| placement | outside the box by | after |
|---|---|---|
| bottom, `y = 0.95` | **+59px below** — both buttons gone | −136 (flipped above) |
| top, `y = 0.05` | inside | inside |
| left, `x = 0.03` | **+42px past the left edge** — Approve half cut | 0 |
| right, `x = 0.97` | **+42px past the right edge** — Decline half cut | −1 |

**Three edges, not one.** A fix verified only against the reported bottom edge would have shipped with the sides still cut.

### The fix

`placementControlPosition` — a pure function returning `{ left, top }` in px:

- below the sticker stays preferred; it flips **above** only when below would leave the box, because a control laid over the sticker covers the thing being judged
- both axes clamped into the box
- returns `null` until the control and the box have been measured, so the current position stands rather than the controls jumping from `0,0`

The component measures the control and the media box the way it already measures sticker height — `offsetWidth`/`offsetHeight` (layout numbers, so the reveal animation's transform does not corrupt them) with a `ResizeObserver` and a no-observer fallback.

`overflow-hidden` stays. Removing it would spill the owner's buttons over whatever sits below the image.

### Tests

`placement-control-position.test.ts`, nine cases, using the measured numbers above. Four mutations of the clamp's **arithmetic** — not its existence — all go red: clamping `top` against the box's width, dropping the gap, inverting the flip threshold, and clamping `left` to the box width rather than to `width - control.width`. The both-directions-blocked branch and the control-larger-than-the-box branch have their own cases.

Geometry rather than a rendered box, deliberately: the numbers in the table are what the fix has to change, and a browser test of this runs in no CI job.

### Not fixed here, and worth knowing

The same reported symptom has a **second, independent cause**: `useStickerRevealStore` defaults to off, so pending placements — and the owner's only in-image control with them — do not render at all until the viewer turns stickers on. An owner arriving from a placement notification sees an image that looks untouched. That is `868kv2hpp`, filed separately; fixing the geometry alone will not make the controls appear for someone who has never revealed stickers.

### Note on CI

`main` is currently broken (`868kv37v9`, `TipaltiStatus` imported as a type and used as a value), so this branch inherits three type errors and a red unit check in `user-payment-configuration.tipalti-status.test.ts` that are not from this diff.

### Migrations

None.
