### PR TITLE
fix(tipalti): drop the dead local isBlockedTipaltiStatus

### DIFF
--- a/src/server/services/user-payment-configuration.service.ts
+++ b/src/server/services/user-payment-configuration.service.ts
@@ -290,10 +290,6 @@ export async function createTipaltiPayee({ userId }: { userId: number }) {
   }
 }
 
-// Two spellings of the same terminal state, so a move between them is not a new rejection.
-const isBlockedTipaltiStatus = (status: string) =>
-  status === TipaltiStatus.Blocked || status === TipaltiStatus.BlockedByProvider;
-
 export async function updateByTipaltiAccount({
   tipaltiAccountId,
   tipaltiAccountStatus,


### PR DESCRIPTION
`main` is currently red on both typecheck and unit tests, and the cause is a leftover from #5c9870d106.

That commit moved `isBlockedTipaltiStatus` into `~/server/common/enums` and narrowed `TipaltiStatus` to a **type-only** import — but left the previous local `const` behind:

```ts
import { isBlockedTipaltiStatus, ..., type TipaltiStatus } from '~/server/common/enums';
...
const isBlockedTipaltiStatus = (status: string) =>
  status === TipaltiStatus.Blocked || status === TipaltiStatus.BlockedByProvider;
```

A type-only import is erased at runtime, so the leftover throws `ReferenceError: TipaltiStatus is not defined` as soon as it runs — and because a local declaration shadows the import, it *was* the copy being called.

### This is a production bug, not only a red check

`updateByTipaltiAccount` is the Tipalti webhook path. On `main` today, a payee moving to `Blocked` or `BlockedByProvider` throws before its rejection notification is sent.

### Fix

Delete the local copy. The file already imports the shared helper, so nothing else changes.

### Verification

| | before | after |
|---|---|---|
| `pnpm run typecheck` | 3 errors (TS2440 + 2× TS1361) | **0 errors** |
| `user-payment-configuration.tipalti-status.test.ts` | 5 failed | **32 passed** |
| full unit suite | — | **20,560 passed / 0 failed** |

Reproduced against pristine `origin/main` in a clean worktree first, to confirm it was inherited rather than introduced by an in-flight branch.

### Worth a separate look

This landed despite being a `TS2440`, which is not subtle. On the PRs I checked, `Typecheck (main pushes / fork PRs / non-main base)` reports `skipping`, and `tekton / typecheck` reports `typecheck passed (tsc --noEmit)` on this exact code. One of those is not gating what it says it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeeJXStZA5ebfrCMVsxrRn