### PR TITLE
test(images): pin that every caller knob moves the filter in both Meili builders

### DIFF
--- a/src/server/services/__tests__/image-search-builder-knob-parity.test.ts
+++ b/src/server/services/__tests__/image-search-builder-knob-parity.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * `getImagesFromSearchPreFilter` and `getImagesFromSearchPostFilter` are 506 of 672 lines
+ * byte-identical, and PR #4148 hit what that costs: `publishedOnly` was honoured by the DB path and
+ * ignored by BOTH builders, each carrying its own copy of the branch, so fixing one would silently
+ * have left the other.
+ *
+ * 🔴 This does NOT assert the two build the same filter. They deliberately do not — the pre-filter
+ * carries availability, blocked-resource and POI owner carve-outs the post-filter leaves to the
+ * post-pass, and the two handle unscanned content differently. An equivalence test would either fail
+ * on day one or force one of them to be wrong.
+ *
+ * What it asserts instead is the property that actually broke: a knob the caller can set has to
+ * MOVE the filter in EVERY builder. A knob honoured in one and dropped in the other fails here,
+ * named, without anyone having to notice the copies drifted.
+ */
+
+import type * as MeilisearchClient from '~/server/meilisearch/client';
+
+const { fetchDocumentsAbortableMock } = vi.hoisted(() => ({
+  fetchDocumentsAbortableMock: vi.fn(),
+}));
+
+vi.mock('~/server/meilisearch/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof MeilisearchClient>();
+  return {
+    ...actual,
+    metricsSearchClient: {},
+    getMetricsSearchClient: () => ({}),
+    fetchDocumentsAbortable: fetchDocumentsAbortableMock,
+  };
+});
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+import { getImagesFromSearchPreFilter, getImagesFromSearchPostFilter } from '../image.service';
+
+const CURRENT_USER = 4321;
+
+const baseInput = {
+  currentUserId: CURRENT_USER,
+  isModerator: false,
+  limit: 20,
+  period: 'AllTime',
+  sort: 'Newest',
+  browsingLevel: 31,
+  include: [] as string[],
+  headers: { src: 'test' },
+};
+
+/**
+ * Each knob, with a value that must change the filter.
+ *
+ * `base` carries anything the knob needs to be reachable — the three publication knobs only mean
+ * anything to a moderator — and BOTH sides of the comparison get it, so the difference measured is
+ * the knob and never the role that made it reachable.
+ *
+ * Not covered, deliberately: `hidden` and `followed` resolve their ids from Postgres and return
+ * early when the lookup is empty, so they never reach the filter at all without a `dbRead` fake.
+ * Their observable is that early return rather than a clause, which is a different property from
+ * the one this file is about.
+ */
+const KNOBS: Array<{ name: string; base?: Record<string, unknown>; on: Record<string, unknown> }> =
+  [
+    { name: 'publishedOnly', base: { isModerator: true }, on: { publishedOnly: true } },
+    { name: 'notPublished', base: { isModerator: true }, on: { notPublished: true } },
+    { name: 'scheduled', base: { isModerator: true }, on: { scheduled: true } },
+    { name: 'types', on: { types: ['video'] } },
+    { name: 'withMeta', on: { withMeta: true } },
+    { name: 'fromPlatform', on: { fromPlatform: true } },
+    { name: 'baseModels', on: { baseModels: ['SDXL 1.0'] } },
+    { name: 'tools', on: { tools: [7] } },
+    { name: 'techniques', on: { techniques: [3] } },
+    { name: 'modelVersionId', on: { modelVersionId: 12345 } },
+    { name: 'postIds', on: { postIds: [777] } },
+  ];
+
+const BUILDERS = [
+  ['getImagesFromSearchPreFilter', getImagesFromSearchPreFilter],
+  ['getImagesFromSearchPostFilter', getImagesFromSearchPostFilter],
+] as const;
+
+type SearchArg = Parameters<typeof getImagesFromSearchPreFilter>[0];
+
+describe.each(BUILDERS)('%s honours every caller knob', (_name, fn) => {
+  /**
+   * The filter the builder handed Meili, with timestamps blanked. `snapToInterval(Date.now())` puts a
+   * clock-derived number in the publication clause, so two calls either side of an interval boundary
+   * differ for a reason that has nothing to do with the knob under test.
+   */
+  const filterFor = async (input: Record<string, unknown>) => {
+    vi.clearAllMocks();
+    fetchDocumentsAbortableMock.mockRejectedValue(new Error('stop here'));
+
+    await expect(fn(input as unknown as SearchArg)).rejects.toThrow('stop here');
+    expect(fetchDocumentsAbortableMock).toHaveBeenCalledTimes(1);
+
+    const [, request] = fetchDocumentsAbortableMock.mock.calls[0];
+    return String((request as { filter: string }).filter).replace(/\d{10,}/g, '<ts>');
+  };
+
+  // Without this the comparisons below are meaningless: if the filter varied on its own, every knob
+  // would "move" it and the whole suite would pass against a builder that reads none of them.
+  it('builds a stable filter for a stable input', async () => {
+    expect(await filterFor(baseInput)).toBe(await filterFor(baseInput));
+  });
+
+  it.each(KNOBS.map((k) => [k.name, k.base ?? {}, k.on] as const))(
+    '%s changes the filter',
+    async (_knob, base, on) => {
+      const off = await filterFor({ ...baseInput, ...base });
+      const withKnob = await filterFor({ ...baseInput, ...base, ...on });
+
+      expect(withKnob, `the filter is identical with and without it:\n${off}`).not.toBe(off);
+    }
+  );
+});


### PR DESCRIPTION
Closes [868kuaf2k](https://app.clickup.com/t/868kuaf2k) — with a different test than the one it asked for, and the reason is the finding.

### The ticket's suggested mitigation would not have worked

It proposes "a test that asserts the two builders produce equivalent output for the same input". They are 506 of 672 lines byte-identical, so that reads as reasonable — but they are **not** supposed to agree. Diffed in full, `getImagesFromSearchPreFilter` carries clauses `getImagesFromSearchPostFilter` deliberately omits:

- the private-availability and blocked-resource carve-outs (`(NOT availability = Private OR "userId" = me)`)
- the POI owner carve-out — pre-filter emits `(NOT poi = true OR "userId" = me)`, post-filter emits `(NOT poi = true)` under a comment reading *"Past POI cut-off, don't even return for owners"*
- a different rule for unscanned content: pre-filter admits `nsfwLevel = 0` for the caller globally, post-filter only on the caller's own profile

An equivalence assertion would fail on day one, and "fixing" it would mean making one of those wrong.

### What is pinned instead

The property that actually broke in #4148: **a knob the caller sets has to move the filter in every builder.** `publishedOnly` was honoured by the DB path and ignored by both Meili copies; each carried its own branch, so a fix to one would silently have left the other.

Eleven knobs × two builders, asserted on the filter string handed to Meili. Timestamps are blanked before comparison — `snapToInterval(Date.now())` puts a clock-derived number in the publication clause, so two calls either side of an interval boundary would otherwise differ for a reason unrelated to the knob.

Three knobs carry a `base` of `isModerator: true`, applied to **both** sides, because the publication knobs mean nothing to a non-moderator. Getting that wrong is what my first run caught: with a non-moderator base, `publishedOnly` changed nothing and the test failed against correct code.

`hidden` and `followed` are excluded and the file says why — they resolve ids from Postgres and return early on an empty lookup, so they never reach the filter without a `dbRead` fake. Their observable is that early return, a different property.

### Red when wrong, per builder

The point of the test is catching a knob dropped in **one** copy, so that is what was mutated.

**Mutated by line number, not by string replace** — worth stating because it is the only way to mutate one of two near-identical functions honestly. A `replace` of `if (withMeta) filters.push(...)` matches in both builders; a replace-first hits whichever comes first, so you mutate one copy and believe you mutated the other, and the test that goes red is not the one you were reasoning about. Editing line 4523 and line 5453 separately is what makes each row below attributable.

| mutation | result |
|---|---|
| `withMeta` dropped in `getImagesFromSearchPreFilter` (line 4523) | 1 of 24 fails — **`getImagesFromSearchPreFilter … withMeta`** |
| `withMeta` dropped in `getImagesFromSearchPostFilter` (line 5453) | 1 of 24 fails — **`getImagesFromSearchPostFilter … withMeta`** |

Each mutation fails exactly one test, and it names the builder that drifted. There is also a stability control (`same input → same filter`) without which every knob would appear to "move" the filter and the suite would pass against a builder reading none of them.

### Verification

- The new file: 24 passed
- `pnpm run typecheck` reports **4 errors, all pre-existing on this base and none in this diff** — three are `TipaltiStatus` in `user-payment-configuration.service.ts` (ClickUp `868kv37v9`, from `3a1ad0c417`, which this branch's base includes) and one is `forceFlush` in `packages/civitai-telemetry`. This PR adds a single test file and touches nothing else.
- Full unit suite run separately; the same `868kv37v9` failure is expected from main and is not this change.

### Not in this change

The extraction itself. These sit on the image search hot path, the ticket says not to do it casually, and this makes the next divergence fail loudly — which is what it asked for as the interim step.
