### PR TITLE
refactor(moderator): retire the legacy strike read now the import has run

### DIFF
--- a/apps/moderator/src/lib/components/AccountHistory.svelte
+++ b/apps/moderator/src/lib/components/AccountHistory.svelte
@@ -16,7 +16,6 @@
     userId,
     civitaiUrl,
     strikes,
-    legacyStrikeCount,
     modActivity,
     ratingActivity,
     retoolActivity,
@@ -26,7 +25,6 @@
     userId: number;
     civitaiUrl: string;
     strikes: LiveStrike[];
-    legacyStrikeCount: number;
     /** Enforcement rows only. The rating/tagging ones are `ratingActivity` — two separately limited
      *  queries, because filtering one merged window drops rows the window was already truncated by. */
     modActivity: ModActivityRow[];
@@ -104,18 +102,9 @@
 
 <div class="mb-4">
   <h3 class="mb-2 text-xs tracking-wide text-dark-2 uppercase">Strikes ({strikes.length})</h3>
-  <StrikeList
-    {strikes}
-    empty={legacyStrikeCount > 0
-      ? 'No strikes issued since the Retool cutover.'
-      : 'No strikes on this account.'}
-  />
-  {#if legacyStrikeCount > 0}
-    <p class="mt-1 text-xs text-dark-2">
-      Plus {legacyStrikeCount} from the Retool era, in User Lookup — that table is history and is not
-      part of the counts above.
-    </p>
-  {/if}
+  <!-- One store since the 2026-08-21 import: every Retool-era strike is a `UserStrike` row and shows
+       in the list above. There is no "plus N elsewhere" left to say. -->
+  <StrikeList {strikes} empty="No strikes on this account." />
 </div>
 
 <div class="mb-4 grid gap-4 sm:grid-cols-2">

--- a/apps/moderator/src/lib/server/account-history.ts
+++ b/apps/moderator/src/lib/server/account-history.ts
@@ -1,4 +1,4 @@
-import { getUserNotes, getUserStrikes } from './moderation-memory.service';
+import { getUserNotes } from './moderation-memory.service';
 import { getLiveStrikes } from './user-lookup.service';
 import { getModActivity, getRetoolActivity } from './user-account.service';
 import { getReportsOnUser } from './user-reports.service';
@@ -12,13 +12,12 @@ import { DEFAULT_REPORT_REASONS } from '$lib/reports';
 export type AccountHistoryData = Awaited<ReturnType<typeof loadAccountHistory>>;
 
 export async function loadAccountHistory(userId: number, viewerUsername: string | null) {
-  const [strikes, legacyStrikes, notes, modActivity, ratingActivity, retoolActivity, reportsOnUser] =
+  const [strikes, notes, modActivity, ratingActivity, retoolActivity, reportsOnUser] =
     await Promise.all([
       // The MAIN APP's strikes, not the moderator database's Retool-era table — that one is written by
       // nothing, so this panel read 0 on an account carrying ten live strikes, which is the worst
       // possible number to be wrong about on the screen where the next one is issued.
       getLiveStrikes(userId),
-      getUserStrikes(userId),
       // Deciding on a strike without the prior note is the thing notes exist to stop, and "it is in
       // User Lookup" is a different screen.
       getUserNotes(userId, viewerUsername),
@@ -38,7 +37,6 @@ export async function loadAccountHistory(userId: number, viewerUsername: string 
 
   return {
     strikes,
-    legacyStrikeCount: legacyStrikes.length,
     notes,
     modActivity,
     ratingActivity,

--- a/apps/moderator/src/lib/server/moderation-memory.service.ts
+++ b/apps/moderator/src/lib/server/moderation-memory.service.ts
@@ -27,13 +27,6 @@ export type UserNote = {
   isMine: boolean;
 };
 
-export type UserStrike = {
-  id: number;
-  reason: string | null;
-  createdAt: Date | null;
-  createdBy: string | null;
-};
-
 export async function getUserNotes(userId: number, viewer: string | null): Promise<UserNote[]> {
   const rows = await getModeratorDb()
     .selectFrom('UserNotes')
@@ -64,10 +57,9 @@ export async function getModerationFlags(userId: number): Promise<ModerationFlag
 /**
  * Legacy ids that have ALREADY been copied into the main store by `migrate-legacy-strikes.ts`.
  *
- * Both legacy readers below subtract these, which is what lets the import run at any time without a
- * second deploy behind it: before it, history comes from here; after it, from `UserStrike`; part-way
- * through, each row is counted on exactly one side. Without this the two stores would both report the
- * same strike and the panel would say "plus N from the Retool era" about rows sitting directly above it.
+ * `strikeCountsByUserIds` subtracts these so a strike is counted on exactly one side: it spans both
+ * stores, and the import moved every row across on 2026-08-21 without a deploy behind it. Kept rather
+ * than assumed-empty because the migration doc documents a rollback, which would put rows back.
  */
 async function importedLegacyIds(userIds: number[]): Promise<Set<number>> {
   if (!userIds.length) return new Set();
@@ -84,24 +76,6 @@ async function importedLegacyIds(userIds: number[]): Promise<Set<number>> {
       return id === null ? [] : [id];
     })
   );
-}
-
-// READ ONLY, deliberately. `UserStrikes` in the moderator database is Retool-era history; strikes are
-// issued against the main app's system (`issueStrike`), which has escalation, points, expiry, the typed
-// notification and a void path. Nothing here writes this table.
-//
-// Returns only what the main store does NOT already hold — see `importedLegacyIds`.
-export async function getUserStrikes(userId: number): Promise<UserStrike[]> {
-  const [rows, imported] = await Promise.all([
-    getModeratorDb()
-      .selectFrom('UserStrikes')
-      .select(['id', 'reason', 'createdAt', 'createdBy'])
-      .where('userId', '=', userId)
-      .orderBy('createdAt', 'desc')
-      .execute(),
-    importedLegacyIds([userId]),
-  ]);
-  return rows.filter((r) => !imported.has(r.id));
 }
 
 /**

--- a/apps/moderator/src/lib/server/user-lookup.service.ts
+++ b/apps/moderator/src/lib/server/user-lookup.service.ts
@@ -122,7 +122,10 @@ export type UserLookupResult = {
   ranks: LeaderboardRank[];
   /** Retool-era strikes, from the moderator database. Historical: the main app's strike system does
    *  NOT write here, so this alone reads 0 on an account carrying active strikes. */
-  legacyStrikeCount: number;
+  /** Every strike the account has ever had, across both stores and all statuses — NOT the active
+   *  count beside it. `strikeCountsByUserIds` spans both by design; since the 2026-08-21 import the
+   *  legacy half is empty, so in practice this is the all-time `UserStrike` total. */
+  strikeCountAllTime: number;
   /** The number that means "how much rope is left": active, unexpired, unvoided main-app strikes and
    *  their points. */
   strikes: { count: number; points: number };
@@ -249,7 +252,7 @@ export async function getUserLookup(userId: number): Promise<UserLookupResult | 
     subscription,
     curator,
     ranks,
-    legacyStrikes,
+    strikeCountAllTime,
     modContact,
     strikes,
   ] = await Promise.all([
@@ -283,7 +286,7 @@ export async function getUserLookup(userId: number): Promise<UserLookupResult | 
         subscription,
         curator,
         ranks,
-        legacyStrikeCount: legacyStrikes.get(userId) ?? 0,
+        strikeCountAllTime: strikeCountAllTime.get(userId) ?? 0,
         strikes,
         modContact,
       }

--- a/apps/moderator/src/routes/api/user-memory/[userId]/+server.ts
+++ b/apps/moderator/src/routes/api/user-memory/[userId]/+server.ts
@@ -1,11 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { requireUserIdParam } from '$lib/server/api-guard';
-import {
-  getModerationFlags,
-  getUserNotes,
-  getUserStrikes,
-} from '$lib/server/moderation-memory.service';
+import { getModerationFlags, getUserNotes } from '$lib/server/moderation-memory.service';
 import { getLiveStrikes } from '$lib/server/user-lookup.service';
 
 // Notes and strikes come from the MODERATOR database — a second connection, so it is fetched
@@ -13,9 +9,8 @@ import { getLiveStrikes } from '$lib/server/user-lookup.service';
 export const GET: RequestHandler = async ({ params, locals }) => {
   const userId = requireUserIdParam(locals, params, '/retool/user-lookup');
 
-  const [notes, strikes, liveStrikes, flags] = await Promise.all([
+  const [notes, liveStrikes, flags] = await Promise.all([
     getUserNotes(userId, locals.user.username ?? null),
-    getUserStrikes(userId),
     // Caught rather than left to reject: the one call here that crosses to the MAIN database, and a
     // shared rejection would take the notes and account flags down with it. `null` so the panel can
     // say "could not check" — an empty array would assert the account is clean.
@@ -23,5 +18,5 @@ export const GET: RequestHandler = async ({ params, locals }) => {
     getModerationFlags(userId),
   ]);
 
-  return json({ notes, strikes, liveStrikes, flags });
+  return json({ notes, liveStrikes, flags });
 };

--- a/apps/moderator/src/routes/retool/user-lookup/+layout.svelte
+++ b/apps/moderator/src/routes/retool/user-lookup/+layout.svelte
@@ -125,10 +125,11 @@
         ({data.result.strikes.points} pt{data.result.strikes.points > 1 ? 's' : ''})
       </Badge>
     {/if}
-    <!-- Retool-era strikes are a DIFFERENT table that the live strike system never writes. Shown apart
-         so the two are not read as one number. -->
-    {#if data.result?.legacyStrikeCount}
-      <Badge variant="secondary">{data.result.legacyStrikeCount} legacy</Badge>
+    <!-- All-time beside active, so a cleared account still shows its history. It was labelled
+         "legacy" and fed by a count that spans BOTH stores, so it read as Retool-era while including
+         every modern strike too — and after the 2026-08-21 import there is no separate era to name. -->
+    {#if data.result?.strikeCountAllTime}
+      <Badge variant="secondary">{data.result.strikeCountAllTime} all-time</Badge>
     {/if}
     {#if data.result?.subscription?.productName}
       <!-- Status is carried, not assumed: a cancelled subscription must not read as a paying one. -->

--- a/apps/moderator/src/routes/retool/user-lookup/ModerationMemoryPanel.svelte
+++ b/apps/moderator/src/routes/retool/user-lookup/ModerationMemoryPanel.svelte
@@ -203,35 +203,7 @@
           Could not check strikes — treat as unknown, not none.
         </p>
       {:else}
-        <StrikeList
-          strikes={result.liveStrikes}
-          empty={result.strikes.length > 0
-            ? 'No strikes issued since the Retool cutover.'
-            : 'No strikes on this account.'}
-        />
-
-        {#if result.strikes.length > 0}
-          <details class="mt-3 border-t border-dark-4 pt-3">
-            <summary class="text-xs text-dark-2">
-              {result.strikes.length} from the Retool era — history, not part of the list above
-            </summary>
-            <ul class="mt-2 space-y-2">
-              {#each result.strikes as strike (strike.id)}
-                <li class="text-sm">
-                  <div class="flex flex-wrap items-baseline gap-x-2">
-                    <Badge variant="outline">legacy</Badge>
-                    <span class="text-xs text-dark-2">
-                      {strike.createdBy ?? 'unknown'} · {dateTime(strike.createdAt)}
-                    </span>
-                  </div>
-                  {#if strike.reason}
-                    <p class="text-dark-0">{strike.reason}</p>
-                  {/if}
-                </li>
-              {/each}
-            </ul>
-          </details>
-        {/if}
+        <StrikeList strikes={result.liveStrikes} empty="No strikes on this account." />
       {/if}
     {:catch}
       <p class="text-sm text-red-300">Could not load strikes.</p>

--- a/apps/moderator/src/routes/retool/user-lookup/user-memory.ts
+++ b/apps/moderator/src/routes/retool/user-lookup/user-memory.ts
@@ -6,14 +6,10 @@ import type { Jsonified } from '$lib/format';
 import type {
   ModerationFlags as ServerModerationFlags,
   UserNote,
-  UserStrike,
 } from '$lib/server/moderation-memory.service';
 import type { LiveStrike as ServerLiveStrike } from '$lib/server/user-lookup.service';
 
 export type Note = Jsonified<UserNote>;
-
-/** A Retool-era row from the moderator database's `UserStrikes`. History; nothing writes it. */
-export type Strike = Jsonified<UserStrike>;
 
 /** A row from the main app's `UserStrike` — what "Issue strike" writes. */
 export type LiveStrike = Jsonified<ServerLiveStrike>;
@@ -22,7 +18,6 @@ export type ModerationFlags = ServerModerationFlags;
 
 export type Memory = {
   notes: Note[];
-  strikes: Strike[];
   /** `null` means the main database could not be reached — NOT that the account has no strikes. */
   liveStrikes: LiveStrike[] | null;
   flags: ModerationFlags;

--- a/docs/moderator-app/legacy-strike-migration.md
+++ b/docs/moderator-app/legacy-strike-migration.md
@@ -108,5 +108,13 @@ Until then they cost one indexed query and are what makes an un-migrated environ
 ## Status
 
 - [ ] Applied to **preview**
-- [ ] Applied to **production**
-- [ ] Legacy read retired (after both of the above)
+- [x] Applied to **production** — 2026-08-21. 12,902 rows across 10,690 accounts, matching `UserStrikes`
+      exactly, no marker twice. Checked against the main database rather than trusting the script's own
+      `verify()`: 0 non-Expired, 0 with points, 0 with `expiresAt <> createdAt`, 0 countable by
+      escalation (`Active AND expiresAt > NOW()`).
+- [ ] Legacy read retired — **now the outstanding half.** `getLiveStrikes` has no status filter, so the
+      imported rows already show in the strike list, while `AccountHistory` still adds "Plus N from the
+      Retool era … not part of the counts above" and User Lookup still shows an `N legacy` badge. Both
+      now double-report the same rows on all 10,690 accounts. Not urgent — the largest account holds 10
+      strikes against a 50-row cap, so nothing is hidden and no enforcement reads the count — but the
+      line is false as written.

--- a/docs/moderator-app/mod-studio-feedback-2026-08-21.md
+++ b/docs/moderator-app/mod-studio-feedback-2026-08-21.md
@@ -102,10 +102,13 @@ this repo is public (CLAUDE.md → Security). The private triage keeps attributi
       widened from `/retool/user-lookup` alone to also accept the two report queues, which render the
       same panel.
 
-- [ ] **Legacy strikes migrated into the main database.** ⚠️ **The script is written; the migration has not
-      been run anywhere.** The decision is settled and the write side was already correct — this
-      app has written only `UserStrike` since `d0820283c0`. What was outstanding is the ~12.9k Retool-era
-      rows, and there is now one typed script for them:
+- [x] **Legacy strikes migrated into the main database.** ✅ **Run against production 2026-08-21:
+      12,902 rows imported across 10,690 accounts** — exactly the `UserStrikes` row count, so nothing was
+      skipped, and no marker appears twice. Verified independently of the script's own `verify()`: zero
+      rows are non-Expired, zero carry points, zero have `expiresAt <> createdAt`, and zero are
+      `Active AND expiresAt > NOW()` — so nothing an escalation can count. The write side was already
+      correct — this app has written only `UserStrike` since `d0820283c0`. The ~12.9k Retool-era rows
+      were what remained, and the script that moved them is:
       `apps/moderator/moderator-db/migrate-legacy-strikes.ts` (dry run by default), with the reasoning in
       [`legacy-strike-migration.md`](legacy-strike-migration.md).
 
@@ -113,6 +116,12 @@ this repo is public (CLAUDE.md → Security). The private triage keeps attributi
       production database, raw SQL over untypechecked identifiers. That shape existed only because the
       moderator database had no schema and no generated types. It has both now, so the migration is one
       script over two Kysely connections, checked by `pnpm run typecheck:scripts`.
+
+      ⚠️ **The panel has not caught up.** `AccountHistory` still prints "Plus N from the Retool era …
+      not part of the counts above", and `getLiveStrikes` has no status filter — so on all 10,690
+      accounts those rows now appear in the strike list AND are counted again by that line, which is
+      now false. Nothing is truncated (the largest account has 10 strikes against a 50-row cap) and no
+      enforcement is affected, but the footnote and User Lookup's `N legacy` badge both need retiring.
 
       🔴 **Imported rows land Expired and zero-point so escalation cannot count them**, and the
       verification pass after `--apply` fails the run if any is countable. There is no ordering


### PR DESCRIPTION
`migrate-legacy-strikes.ts` ran against production on 2026-08-21: 12,902 rows across 10,690 accounts, matching `UserStrikes` exactly, every source id present as a marker, none twice. Verified against the main database rather than trusting the script's own `verify()` — 0 non-Expired, 0 with points, 0 with `expiresAt <> createdAt`, and 0 countable by escalation. So the strikes are visible in a strike list and countable by nothing, which is the design.

The moderator app no longer reads `UserStrikes` for display anywhere. `getUserStrikes` subtracted already-imported ids, so it began returning empty for every account the moment the import finished — leaving two panels rendering a permanently-false branch and two cross-database queries on hot paths for a number fixed at zero. Both panels, the `/api/user-memory` payload, and the reader itself are gone; `AccountHistory` also stops crossing to the second database in a page load that re-runs on every queue row click.

`importedLegacyIds` stays. `strikeCountsByUserIds` spans both stores by design — the shared-IP and shared-link panels are the only place their number appears and have no `getLiveStrikes` beside them — so it must keep subtracting, and the migration doc documents a rollback that would put rows back.

The User Lookup badge was the real defect and predates the import: it read `N legacy` but was fed by that both-stores count, so every modern strike was reported as Retool-era. It is `N all-time` now, beside the existing active-strike badge, and the field is renamed to match what it holds.

Docs record the run: the round file's box is ticked with the numbers and the verification, and the migration doc's Status has production ticked and "legacy read retired" closed by this commit. Preview is still unticked — it was never run there.