### PR TITLE
fix(search): keep banned accounts out of user search and out of the collaborator invite picker

### DIFF
--- a/src/components/Apps/AppCollaboratorsPanel.browser.test.tsx
+++ b/src/components/Apps/AppCollaboratorsPanel.browser.test.tsx
@@ -28,6 +28,8 @@ const state = vi.hoisted(() => ({
   ineligible: [] as number[],
   /** Ids the picker reported as being on offer. */
   screenedInput: [] as number[],
+  /** The listing the screening query was keyed to. */
+  screenedListing: null as string | null,
   /** Every `invite` mutation actually fired. */
   inviteCalls: [] as unknown[],
   /** The last `filters` string handed to the picker. */
@@ -36,6 +38,8 @@ const state = vi.hoisted(() => ({
   select: null as ((item: unknown, data: unknown) => void) | null,
   /** The picker's `onHits`, so a test can drive what is on offer. */
   reportHits: null as ((ids: number[]) => void) | null,
+  /** Whether the screening query was enabled on the last render. */
+  screenEnabled: false,
 }));
 
 /**
@@ -83,8 +87,10 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
         list: { useQuery: () => ({ data: [], isLoading: false, error: null }) },
         getPendingTransfer: { useQuery: () => ({ data: null, isLoading: false, error: null }) },
         ineligibleTargets: {
-          useQuery: (input: { userIds: number[] }) => {
+          useQuery: (input: { appListingId: string; userIds: number[] }, opts?: any) => {
             state.screenedInput = input.userIds;
+            state.screenedListing = input.appListingId;
+            state.screenEnabled = opts?.enabled !== false;
             return { data: state.ineligible, isLoading: false, error: null };
           },
         },
@@ -101,11 +107,11 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
 
 const { AppCollaboratorsPanel } = await import('~/components/Apps/AppCollaboratorsPanel');
 
-const render = () =>
+const render = (role: 'owner' | 'editor' = 'owner') =>
   renderWithProviders(
     <AppCollaboratorsPanel
       appListingId="apl_seam"
-      role="owner"
+      role={role}
       capabilities={capabilitiesForKind('onsite')}
       listing={{ kind: 'onsite', connectClientId: null }}
     />
@@ -114,6 +120,8 @@ const render = () =>
 beforeEach(() => {
   state.ineligible = [];
   state.screenedInput = [];
+  state.screenedListing = null;
+  state.screenEnabled = false;
   state.inviteCalls = [];
   state.pickerFilters = null;
   state.select = null;
@@ -132,6 +140,28 @@ describe('AppCollaboratorsPanel — candidate screening reaches the picker', () 
     await vi.waitFor(() => {
       expect(state.screenedInput).toEqual([FINE_ID, INELIGIBLE_ID]);
     });
+    // Keyed to the listing the proc asserts ownership of — without it the call 400s on the
+    // schema and every candidate reads as eligible.
+    expect(state.screenedListing).toBe('apl_seam');
+  });
+
+  /**
+   * 🔴 The proc asserts the caller OWNS the listing, and only an owner is shown the invite
+   * picker. An editor issuing it would 403 on every render of a tab they are allowed to see.
+   */
+  test('an EDITOR does not issue the screening query at all', async () => {
+    render('editor');
+    await vi.waitFor(() => expect(state.screenEnabled).toBe(false));
+    // The editor is not shown the invite picker, so there is nothing to screen.
+    expect(state.reportHits).toBeNull();
+  });
+
+  /** The control arm for the test above — an OWNER does issue it. */
+  test('an OWNER does issue the screening query', async () => {
+    render();
+    await expect.element(page.getByTestId('stub-invite-picker')).toBeInTheDocument();
+    state.reportHits!([FINE_ID]);
+    await vi.waitFor(() => expect(state.screenEnabled).toBe(true));
   });
 
   test('an id the server calls ineligible is filtered OUT of the picker', async () => {

--- a/src/components/Apps/AppCollaboratorsPanel.browser.test.tsx
+++ b/src/components/Apps/AppCollaboratorsPanel.browser.test.tsx
@@ -40,6 +40,8 @@ const state = vi.hoisted(() => ({
   reportHits: null as ((ids: number[]) => void) | null,
   /** Whether the screening query was enabled on the last render. */
   screenEnabled: false,
+  /** How many times the screening hook ran — the positive control for the assertion below. */
+  screenCalls: 0,
 }));
 
 /**
@@ -91,6 +93,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
             state.screenedInput = input.userIds;
             state.screenedListing = input.appListingId;
             state.screenEnabled = opts?.enabled !== false;
+            state.screenCalls += 1;
             return { data: state.ineligible, isLoading: false, error: null };
           },
         },
@@ -122,6 +125,7 @@ beforeEach(() => {
   state.screenedInput = [];
   state.screenedListing = null;
   state.screenEnabled = false;
+  state.screenCalls = 0;
   state.inviteCalls = [];
   state.pickerFilters = null;
   state.select = null;
@@ -151,7 +155,14 @@ describe('AppCollaboratorsPanel — candidate screening reaches the picker', () 
    */
   test('an EDITOR does not issue the screening query at all', async () => {
     render('editor');
-    await vi.waitFor(() => expect(state.screenEnabled).toBe(false));
+
+    // 🔴 ANCHOR ON THE RENDER FIRST. `screenEnabled` starts false, so waiting for it to BE
+    // false passes before the component has mounted — a poll that cannot tell "not yet" from
+    // "settled". Wait for the panel, prove the hook actually ran, THEN read the flag.
+    await expect.element(page.getByTestId('apps-collaborators-panel')).toBeInTheDocument();
+    await vi.waitFor(() => expect(state.screenCalls).toBeGreaterThan(0));
+
+    expect(state.screenEnabled).toBe(false);
     // The editor is not shown the invite picker, so there is nothing to screen.
     expect(state.reportHits).toBeNull();
   });
@@ -160,6 +171,9 @@ describe('AppCollaboratorsPanel — candidate screening reaches the picker', () 
   test('an OWNER does issue the screening query', async () => {
     render();
     await expect.element(page.getByTestId('stub-invite-picker')).toBeInTheDocument();
+    // Before any hits are reported the owner's query is idle too — the interesting transition is
+    // that reporting hits ENABLES it, which is the opposite of the editor arm above.
+    expect(state.screenEnabled).toBe(false);
     state.reportHits!([FINE_ID]);
     await vi.waitFor(() => expect(state.screenEnabled).toBe(true));
   });

--- a/src/components/Apps/AppCollaboratorsPanel.browser.test.tsx
+++ b/src/components/Apps/AppCollaboratorsPanel.browser.test.tsx
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { capabilitiesForKind } from '~/shared/constants/app-capabilities.constants';
+
+/**
+ * 🔴 THE SEAM BETWEEN THE SCREENING CALL AND THE PICKER.
+ *
+ * The View's helpers are pure and tested on their own; the service that answers "which of these
+ * accounts cannot hold a seat" is tested on its own. Both can be perfectly correct while the
+ * container never joins them — the answer arrives and nothing reads it, and every other test in
+ * this feature still passes, because none of them loads both surfaces.
+ *
+ * So these mount the CONTAINER, hand it a screening answer, and assert the answer actually
+ * reaches the picker and the selection guard. The real picker is replaced by a stand-in that
+ * records the props it was given — the real one resolves a search host at import time and cannot
+ * be mounted here at all.
+ */
+
+const OWNER_ID = 7001;
+const INELIGIBLE_ID = 7002;
+const FINE_ID = 7003;
+
+const state = vi.hoisted(() => ({
+  /** What the screening query answers with. */
+  ineligible: [] as number[],
+  /** Ids the picker reported as being on offer. */
+  screenedInput: [] as number[],
+  /** Every `invite` mutation actually fired. */
+  inviteCalls: [] as unknown[],
+  /** The last `filters` string handed to the picker. */
+  pickerFilters: null as string | null,
+  /** The picker's `onItemSelected`, so a test can drive a selection. */
+  select: null as ((item: unknown, data: unknown) => void) | null,
+  /** The picker's `onHits`, so a test can drive what is on offer. */
+  reportHits: null as ((ids: number[]) => void) | null,
+}));
+
+/**
+ * The panel mounts TWO of these — the invite picker and the ownership-transfer picker. Only the
+ * invite one is in frame here, so the stand-in keys on its placeholder; recording both would let
+ * the transfer picker's (deliberately unscreened) props answer for the invite picker's.
+ */
+const INVITE_PLACEHOLDER = 'Search for a community member to invite';
+
+vi.mock('~/components/Search/QuickSearchDropdown', () => ({
+  QuickSearchDropdown: (props: any) => {
+    const isInvitePicker = props.placeholder === INVITE_PLACEHOLDER;
+    if (isInvitePicker) {
+      state.pickerFilters = props.filters ?? null;
+      state.select = props.onItemSelected ?? null;
+      state.reportHits = props.onHits ?? null;
+    }
+    return <div data-testid={isInvitePicker ? 'stub-invite-picker' : 'stub-other-picker'} />;
+  },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: OWNER_ID }) }));
+
+const { errorNotifications } = vi.hoisted(() => ({ errorNotifications: [] as any[] }));
+vi.mock('~/utils/notifications', () => ({
+  showErrorNotification: (args: unknown) => errorNotifications.push(args),
+  showSuccessNotification: () => undefined,
+}));
+
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const mutation = (record?: (args: unknown) => void) => ({
+    useMutation: () => ({ mutate: (args: unknown) => record?.(args), isPending: false }),
+  });
+  return {
+    ...actual,
+    trpc: {
+      useUtils: () => ({
+        appCollaborators: {
+          list: { invalidate: async () => undefined },
+          getPendingTransfer: { invalidate: async () => undefined },
+        },
+      }),
+      appCollaborators: {
+        list: { useQuery: () => ({ data: [], isLoading: false, error: null }) },
+        getPendingTransfer: { useQuery: () => ({ data: null, isLoading: false, error: null }) },
+        ineligibleTargets: {
+          useQuery: (input: { userIds: number[] }) => {
+            state.screenedInput = input.userIds;
+            return { data: state.ineligible, isLoading: false, error: null };
+          },
+        },
+        invite: mutation((args) => state.inviteCalls.push(args)),
+        remove: mutation(),
+        setDisplayed: mutation(),
+        leave: mutation(),
+        initiateTransfer: mutation(),
+        cancelTransfer: mutation(),
+      },
+    },
+  };
+});
+
+const { AppCollaboratorsPanel } = await import('~/components/Apps/AppCollaboratorsPanel');
+
+const render = () =>
+  renderWithProviders(
+    <AppCollaboratorsPanel
+      appListingId="apl_seam"
+      role="owner"
+      capabilities={capabilitiesForKind('onsite')}
+      listing={{ kind: 'onsite', connectClientId: null }}
+    />
+  );
+
+beforeEach(() => {
+  state.ineligible = [];
+  state.screenedInput = [];
+  state.inviteCalls = [];
+  state.pickerFilters = null;
+  state.select = null;
+  state.reportHits = null;
+  errorNotifications.length = 0;
+});
+
+describe('AppCollaboratorsPanel — candidate screening reaches the picker', () => {
+  test('the picker reports what it is offering, and that is what gets screened', async () => {
+    render();
+    await expect.element(page.getByTestId('stub-invite-picker')).toBeInTheDocument();
+
+    expect(state.reportHits).not.toBeNull();
+    state.reportHits!([FINE_ID, INELIGIBLE_ID]);
+
+    await vi.waitFor(() => {
+      expect(state.screenedInput).toEqual([FINE_ID, INELIGIBLE_ID]);
+    });
+  });
+
+  test('an id the server calls ineligible is filtered OUT of the picker', async () => {
+    state.ineligible = [INELIGIBLE_ID];
+    render();
+    await expect.element(page.getByTestId('stub-invite-picker')).toBeInTheDocument();
+
+    await vi.waitFor(() => {
+      expect(state.pickerFilters).toContain(`NOT id=${INELIGIBLE_ID}`);
+    });
+    // The presence half: an empty filter string contains no id at all and would pass the line
+    // above only if it were also missing the owner's own exclusion, which it is not.
+    expect(state.pickerFilters).toContain(`NOT id=${OWNER_ID}`);
+    expect(state.pickerFilters).not.toContain(`NOT id=${FINE_ID}`);
+  });
+
+  test('choosing an ineligible candidate does NOT fire the invite', async () => {
+    state.ineligible = [INELIGIBLE_ID];
+    render();
+    await expect.element(page.getByTestId('stub-invite-picker')).toBeInTheDocument();
+
+    await vi.waitFor(() => expect(state.select).not.toBeNull());
+    state.select!({}, { id: INELIGIBLE_ID, username: 'someone' });
+
+    await vi.waitFor(() => expect(errorNotifications).toHaveLength(1));
+    expect(errorNotifications[0].title).toMatch(/not eligible/i);
+    expect(state.inviteCalls).toHaveLength(0);
+  });
+
+  /**
+   * The control arm. Without it, a container that refuses EVERY selection passes the test above
+   * while making the picker useless.
+   */
+  test('choosing an eligible candidate DOES fire the invite', async () => {
+    state.ineligible = [INELIGIBLE_ID];
+    render();
+    await expect.element(page.getByTestId('stub-invite-picker')).toBeInTheDocument();
+
+    await vi.waitFor(() => expect(state.select).not.toBeNull());
+    state.select!({}, { id: FINE_ID, username: 'someone-else' });
+
+    await vi.waitFor(() => expect(state.inviteCalls).toHaveLength(1));
+    expect(state.inviteCalls[0]).toEqual({ appListingId: 'apl_seam', targetUserId: FINE_ID });
+    expect(errorNotifications).toHaveLength(0);
+  });
+});

--- a/src/components/Apps/AppCollaboratorsPanel.tsx
+++ b/src/components/Apps/AppCollaboratorsPanel.tsx
@@ -1,3 +1,4 @@
+import { keepPreviousData } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 
 import { QuickSearchDropdown } from '~/components/Search/QuickSearchDropdown';
@@ -17,14 +18,8 @@ import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import type { AppRole, ListingCapability } from '~/shared/constants/app-capabilities.constants';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { SCREENED_USER_ID_LIMIT } from '~/server/schema/blocks/app-collaborator.schema';
 import { trpc } from '~/utils/trpc';
-
-/**
- * How many candidate ids the panel keeps screened at once. Must not exceed the `max()` on
- * `screenAppCollaboratorTargetsSchema`, or the screening query starts 400ing and every
- * candidate reads as eligible.
- */
-const SCREENED_USER_ID_LIMIT = 100;
 
 /**
  * Data container. Owns the `appCollaborators.*` calls this surface wires: `list`,
@@ -147,8 +142,19 @@ export function AppCollaboratorsPanel({
     });
   }, []);
   const screenQuery = trpc.appCollaborators.ineligibleTargets.useQuery(
-    { userIds: screenedUserIds },
-    { enabled: screenedUserIds.length > 0, staleTime: 60_000, retry: false }
+    { appListingId, userIds: screenedUserIds },
+    {
+      // Owner-only: the proc asserts ownership of the listing, and only an owner is shown the
+      // invite picker at all, so an editor must not issue this at all rather than 403 on every
+      // render of a tab they are allowed to see.
+      enabled: role === 'owner' && screenedUserIds.length > 0,
+      staleTime: 60_000,
+      retry: false,
+      // 🔴 Without this, `data` snaps back to undefined on every key change, so an id already
+      // known ineligible briefly returns to the picker and is selectable until the new round
+      // trip lands. The server still refuses it, but the picker should not offer it at all.
+      placeholderData: keepPreviousData,
+    }
   );
   const ineligibleUserIds = screenQuery.data ?? [];
 

--- a/src/components/Apps/AppCollaboratorsPanel.tsx
+++ b/src/components/Apps/AppCollaboratorsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { QuickSearchDropdown } from '~/components/Search/QuickSearchDropdown';
 import type { SearchIndexDataMap } from '~/components/Search/search.utils2';
@@ -18,6 +18,13 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import type { AppRole, ListingCapability } from '~/shared/constants/app-capabilities.constants';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
+
+/**
+ * How many candidate ids the panel keeps screened at once. Must not exceed the `max()` on
+ * `screenAppCollaboratorTargetsSchema`, or the screening query starts 400ing and every
+ * candidate reads as eligible.
+ */
+const SCREENED_USER_ID_LIMIT = 100;
 
 /**
  * Data container. Owns the `appCollaborators.*` calls this surface wires: `list`,
@@ -119,6 +126,32 @@ export function AppCollaboratorsPanel({
     onError: (error) => setTransferErrorMessage(error.message ?? 'Something went wrong.'),
   });
 
+  /**
+   * 🔴 SCREEN THE CANDIDATES THE PICKER IS OFFERING, AGAINST THE SERVER.
+   *
+   * The picker's candidates come out of user search, and a search hit is a cached document —
+   * it can be out of date about the account it describes, including about its NAME. So the
+   * picker cannot conclude anything about an account from the fact that search returned it,
+   * and an owner choosing the top result must not be able to act on a document that is wrong.
+   *
+   * The ids are accumulated rather than replaced so an id already found ineligible stays
+   * excluded as the query text changes — dropping it would put it back in the Meili filter,
+   * back into the hits, and back on offer. Bounded by the screening call's own cap.
+   */
+  const [screenedUserIds, setScreenedUserIds] = useState<number[]>([]);
+  const handlePickerHits = useCallback((ids: number[]) => {
+    setScreenedUserIds((prev) => {
+      const added = ids.filter((id) => !prev.includes(id));
+      if (!added.length) return prev; // identical set -> same array, so the query does not re-issue
+      return [...prev, ...added].slice(-SCREENED_USER_ID_LIMIT);
+    });
+  }, []);
+  const screenQuery = trpc.appCollaborators.ineligibleTargets.useQuery(
+    { userIds: screenedUserIds },
+    { enabled: screenedUserIds.length > 0, staleTime: 60_000, retry: false }
+  );
+  const ineligibleUserIds = screenQuery.data ?? [];
+
   const rows = (listQuery.data ?? []) as CollaboratorRosterRow[];
   const busy = invite.isPending || remove.isPending || setDisplayed.isPending || leave.isPending;
   const transferBusy = initiateTransfer.isPending || cancelTransfer.isPending;
@@ -146,7 +179,7 @@ export function AppCollaboratorsPanel({
             const selected = item as SearchIndexDataMap['users'][number];
             // Both the guard and the picker filter read the SAME two pure helpers, so they
             // cannot disagree about who is offerable — and a REJECTED seat is offerable.
-            const blocked = inviteBlockedReason(rows, selected.id);
+            const blocked = inviteBlockedReason(rows, selected.id, ineligibleUserIds);
             if (blocked) {
               showErrorNotification({
                 title: blocked.title,
@@ -156,7 +189,8 @@ export function AppCollaboratorsPanel({
             }
             invite.mutate({ appListingId, targetUserId: selected.id });
           }}
-          filters={[currentUser?.id, ...pickerExcludedUserIds(rows)]
+          onHits={handlePickerHits}
+          filters={[currentUser?.id, ...pickerExcludedUserIds(rows, ineligibleUserIds)]
             .filter((id): id is number => !!id)
             .map((id) => `AND NOT id=${id}`)
             .join(' ')

--- a/src/components/Apps/AppCollaboratorsPanelView.browser.test.tsx
+++ b/src/components/Apps/AppCollaboratorsPanelView.browser.test.tsx
@@ -411,10 +411,7 @@ describe('inviteBlockedReason / pickerExcludedUserIds', () => {
 describe('inviteBlockedReason / pickerExcludedUserIds — server-screened candidates', () => {
   const INELIGIBLE = 4242;
   const FINE = 4343;
-  const rows = [
-    seat({ userId: 1, status: 'accepted' }),
-    seat({ userId: 3, status: 'rejected' }),
-  ];
+  const rows = [seat({ userId: 1, status: 'accepted' }), seat({ userId: 3, status: 'rejected' })];
 
   test('an ineligible candidate is blocked, and an eligible one is still offerable', () => {
     const blocked = inviteBlockedReason(rows, INELIGIBLE, [INELIGIBLE]);

--- a/src/components/Apps/AppCollaboratorsPanelView.browser.test.tsx
+++ b/src/components/Apps/AppCollaboratorsPanelView.browser.test.tsx
@@ -401,6 +401,65 @@ describe('inviteBlockedReason / pickerExcludedUserIds', () => {
 });
 
 /**
+ * 🔴 AN ACCOUNT THE SERVER HAS SAID IS INELIGIBLE MUST NOT BE OFFERED.
+ *
+ * The candidates come from user search, which serves cached documents — so an account that has
+ * changed state, INCLUDING ITS NAME, can still be presented under its old identity. The panel
+ * screens the ids on offer against the server and feeds the answer to both readers below; these
+ * pin that the answer is actually honoured, and that it outranks every roster reason.
+ */
+describe('inviteBlockedReason / pickerExcludedUserIds — server-screened candidates', () => {
+  const INELIGIBLE = 4242;
+  const FINE = 4343;
+  const rows = [
+    seat({ userId: 1, status: 'accepted' }),
+    seat({ userId: 3, status: 'rejected' }),
+  ];
+
+  test('an ineligible candidate is blocked, and an eligible one is still offerable', () => {
+    const blocked = inviteBlockedReason(rows, INELIGIBLE, [INELIGIBLE]);
+    expect(blocked).not.toBeNull();
+    expect(blocked!.message).toMatch(/not eligible/i);
+    // The presence half: without it, a helper that blocks EVERYTHING passes the line above.
+    expect(inviteBlockedReason(rows, FINE, [INELIGIBLE])).toBeNull();
+  });
+
+  test('the picker hides the ineligible id and keeps the eligible one on offer', () => {
+    const excluded = pickerExcludedUserIds(rows, [INELIGIBLE]);
+    expect(excluded).toContain(INELIGIBLE);
+    expect(excluded).not.toContain(FINE);
+    // The re-invitable declined seat is unaffected — this is an ADDITIONAL exclusion, not a
+    // replacement of the roster rule.
+    expect(excluded).not.toContain(3);
+    expect(excluded).toContain(1);
+  });
+
+  /**
+   * 🔴 The precedence case, and the one that would silently fail: a `rejected` seat is
+   * re-invitable BY ROSTER RULE, so a guard that consults the roster first hands an ineligible
+   * account back as offerable.
+   */
+  test('ineligibility beats the re-invitable rejected seat', () => {
+    expect(inviteBlockedReason(rows, 3)).toBeNull();
+    expect(inviteBlockedReason(rows, 3, [3])).not.toBeNull();
+    expect(pickerExcludedUserIds(rows, [3])).toContain(3);
+  });
+
+  test('an empty screening answer changes nothing', () => {
+    expect(inviteBlockedReason(rows, INELIGIBLE, [])).toBeNull();
+    expect(pickerExcludedUserIds(rows, [])).toEqual(pickerExcludedUserIds(rows));
+  });
+
+  test('🔴 the guard and the picker AGREE about a screened-out account', () => {
+    for (const userId of [INELIGIBLE, FINE, 1, 3]) {
+      const blocked = inviteBlockedReason(rows, userId, [INELIGIBLE]) !== null;
+      const hidden = pickerExcludedUserIds(rows, [INELIGIBLE]).includes(userId);
+      expect(blocked, `disagreement on user ${userId}`).toBe(hidden);
+    }
+  });
+});
+
+/**
  * 🔴 OWNERSHIP TRANSFER — THE OWNER HALF of the Collaborators tab.
  *
  * The product rule this pins: a COLLABORATOR cannot transfer the app. The panel says so

--- a/src/components/Apps/AppCollaboratorsPanelView.tsx
+++ b/src/components/Apps/AppCollaboratorsPanelView.tsx
@@ -180,8 +180,19 @@ export function inviteDisclosureItems(
  */
 export function inviteBlockedReason(
   rows: CollaboratorRosterRow[],
-  userId: number
+  userId: number,
+  ineligibleUserIds: readonly number[] = []
 ): { title: string; message: string } | null {
+  // 🔴 INELIGIBILITY OUTRANKS EVERY ROSTER REASON, including the re-invitable `rejected` seat.
+  // A declined seat is re-offerable because the person may say yes next time; an account the
+  // server has told us cannot hold a seat is not, and checking the roster first would hand a
+  // `rejected` row back as offerable.
+  if (ineligibleUserIds.includes(userId)) {
+    return {
+      title: 'Not eligible',
+      message: 'That account is not eligible for a collaborator seat.',
+    };
+  }
   const row = rows.find((r) => r.userId === userId);
   if (!row || row.status === 'rejected') return null;
   return row.status === 'accepted'
@@ -189,9 +200,19 @@ export function inviteBlockedReason(
     : { title: 'Already invited', message: 'That user already has a pending invitation.' };
 }
 
-/** The roster ids the picker hides. A REJECTED seat stays offerable — see above. */
-export function pickerExcludedUserIds(rows: CollaboratorRosterRow[]): number[] {
-  return rows.filter((r) => r.status !== 'rejected').map((r) => r.userId);
+/**
+ * The ids the picker hides. A REJECTED seat stays offerable — see above.
+ *
+ * `ineligibleUserIds` is what the server said about the accounts currently on offer, and it is
+ * a SEPARATE list from the roster on purpose: an ineligible account usually has no roster row
+ * at all, so there is nothing in `rows` that could ever express it.
+ */
+export function pickerExcludedUserIds(
+  rows: CollaboratorRosterRow[],
+  ineligibleUserIds: readonly number[] = []
+): number[] {
+  const excluded = rows.filter((r) => r.status !== 'rejected').map((r) => r.userId);
+  return [...new Set([...excluded, ...ineligibleUserIds])];
 }
 
 /** `pending`/`rejected` are inert; say so rather than letting a badge imply access. */

--- a/src/components/Search/QuickSearchDropdown.onHits.browser.test.tsx
+++ b/src/components/Search/QuickSearchDropdown.onHits.browser.test.tsx
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * 🔴 THE HALF OF THE SCREENING SEAM THAT NOTHING ELSE WATCHES.
+ *
+ * `AppCollaboratorsPanel` screens the ids this dropdown is offering against the server before
+ * offering them. The panel's own test proves it PASSES `onHits`; every other test that touches
+ * this component replaces it with a stand-in. So deleting the effect that CALLS `onHits` left
+ * the entire suite green while making the panel-side feature completely inert: the id set never
+ * populates, the screening query never enables, the picker is never filtered and the selection
+ * guard never blocks. No signal anywhere.
+ *
+ * This mounts the real component with only the search transport stubbed, so the effect itself
+ * is exercised.
+ */
+
+const HITS = vi.hoisted(() => [
+  { id: 8801, username: 'first-candidate', image: null, deletedAt: null, cosmetics: [] },
+  { id: 8802, username: 'second-candidate', image: null, deletedAt: null, cosmetics: [] },
+]);
+
+// The transport. Nothing here talks to Meilisearch; `useHitsTransformed` is where results would
+// have arrived from, so it is the one seam that has to be faked.
+// `NEXT_PUBLIC_SEARCH_HOST` is unset in the component environment, and both this module and
+// `search.client` build a client from it at IMPORT time — which throws before any test runs.
+vi.mock('@meilisearch/instant-meilisearch', () => ({
+  instantMeiliSearch: () => ({ search: async () => ({ results: [] }) }),
+}));
+vi.mock('react-instantsearch', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    // The provider is the only piece that would reach a real search transport.
+    InstantSearch: (props: any) => props.children,
+    useSearchBox: () => ({ query: '', refine: () => undefined, isSearchStalled: false }),
+  };
+});
+vi.mock('~/components/Search/CustomSearchComponents', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, BrowsingLevelFilter: () => null };
+});
+vi.mock('~/components/Search/search.utils2', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    // The REAL index name: the component maps `results.index` back to a render item, and an
+    // unrecognised one silently falls back to the MODEL renderer, which then chokes on a
+    // user-shaped hit. That fallback is a real code path, so feeding it the wrong name here
+    // would be testing the wrong component.
+    useHitsTransformed: () => ({ hits: HITS, results: { index: 'users_v3' } }),
+  };
+});
+// The OPTION RENDERER is out of frame — it drags in the session context, avatars and cosmetics,
+// none of which this seam is about, and it has its own coverage. Replaced with a marker so the
+// dropdown can render its list at all.
+vi.mock('~/components/AutocompleteSearch/renderItems/users', async () => {
+  const React = await import('react');
+  return {
+    UserSearchItem: React.forwardRef((props: any, ref: any) =>
+      React.createElement('div', { ref, 'data-testid': `option-${props.value}` })
+    ),
+  };
+});
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  // Every flag on. The index selector is hidden here, so nothing branches on a specific one.
+  return { ...actual, useFeatureFlags: () => new Proxy({}, { get: () => true }) };
+});
+vi.mock('~/components/HiddenPreferences/useApplyHiddenPreferences', () => ({
+  useApplyHiddenPreferences: ({ data }: { data: unknown[] }) => ({ items: data }),
+}));
+
+const { QuickSearchDropdown } = await import('~/components/Search/QuickSearchDropdown');
+
+let reported: number[][];
+
+beforeEach(() => {
+  reported = [];
+});
+
+const render = (onHits?: (ids: number[]) => void) =>
+  renderWithProviders(
+    <QuickSearchDropdown
+      disableInitialSearch
+      supportedIndexes={['users']}
+      startingIndex="users"
+      showIndexSelect={false}
+      dropdownItemLimit={25}
+      placeholder="Search"
+      onItemSelected={() => undefined}
+      onHits={onHits}
+    />
+  );
+
+describe('QuickSearchDropdown — onHits', () => {
+  test('reports the ids currently on offer', async () => {
+    render((ids) => reported.push(ids));
+
+    await vi.waitFor(() => expect(reported.length).toBeGreaterThan(0));
+    expect(reported.at(-1)).toEqual([8801, 8802]);
+  });
+
+  /**
+   * The presence/absence pair for the prop being OPTIONAL: a component that only works when the
+   * callback is supplied would be caught by the test above, but one that CRASHES without it
+   * would not — and nine of the ten call sites do not pass it.
+   */
+  test('renders fine when no callback is supplied', async () => {
+    render(undefined);
+    await expect.element(page.getByPlaceholder('Search')).toBeInTheDocument();
+    expect(reported).toEqual([]);
+  });
+});

--- a/src/components/Search/QuickSearchDropdown.onHits.browser.test.tsx
+++ b/src/components/Search/QuickSearchDropdown.onHits.browser.test.tsx
@@ -59,11 +59,11 @@ vi.mock('~/components/Search/search.utils2', async (importOriginal) => {
 // dropdown can render its list at all.
 vi.mock('~/components/AutocompleteSearch/renderItems/users', async () => {
   const React = await import('react');
-  return {
-    UserSearchItem: React.forwardRef((props: any, ref: any) =>
-      React.createElement('div', { ref, 'data-testid': `option-${props.value}` })
-    ),
-  };
+  const UserSearchItem = React.forwardRef((props: any, ref: any) =>
+    React.createElement('div', { ref, 'data-testid': `option-${props.value}` })
+  );
+  UserSearchItem.displayName = 'UserSearchItemStub';
+  return { UserSearchItem };
 });
 vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;

--- a/src/components/Search/QuickSearchDropdown.tsx
+++ b/src/components/Search/QuickSearchDropdown.tsx
@@ -132,6 +132,15 @@ export type QuickSearchDropdownProps = Omit<AutocompleteProps, 'data'> & {
   showIndexSelect?: boolean;
   placeholder?: string;
   disableInitialSearch?: boolean;
+  /**
+   * The ids currently on offer, whenever that set changes. OPTIONAL and inert by default.
+   *
+   * Exists so a caller whose selection GRANTS something can screen the candidates against the
+   * server before offering them — a search hit is a cached document, so "search returned it"
+   * is not a statement about the account's current state. Pass a STABLE callback (`useCallback`);
+   * it fires on every hit change.
+   */
+  onHits?: (ids: number[]) => void;
 };
 
 export const QuickSearchDropdown = ({
@@ -179,6 +188,7 @@ function QuickSearchDropdownContent<TIndex extends SearchIndexKey>({
   dropdownItemLimit = 5,
   showIndexSelect = true,
   placeholder,
+  onHits,
   ...autocompleteProps
 }: QuickSearchDropdownProps & {
   indexName: TIndex;
@@ -223,6 +233,20 @@ function QuickSearchDropdownContent<TIndex extends SearchIndexKey>({
     }));
     return items;
   }, [filtered]);
+
+  // Report what is on offer. Keyed on the joined id list rather than on `items`, whose identity
+  // changes on every re-render of the memo's inputs — re-firing on an unchanged set would make a
+  // caller that turns this into a query re-issue it forever.
+  const hitIds = useMemo(
+    () => items.map((item) => Number(item.value)).filter((id) => Number.isFinite(id)),
+    [items]
+  );
+  const hitIdsKey = hitIds.join(',');
+  useEffect(() => {
+    if (!onHits) return;
+    onHits(hitIdsKey.length ? hitIdsKey.split(',').map(Number) : []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hitIdsKey, onHits]);
 
   const getItemFromValue = useCallback(
     (value: string) => {

--- a/src/server/meilisearch/cleanup.ts
+++ b/src/server/meilisearch/cleanup.ts
@@ -10,6 +10,7 @@ import {
   USERS_SEARCH_INDEX,
 } from '~/server/common/constants';
 import { searchClient } from '~/server/meilisearch/client';
+import { userSearchIndexEligibilitySql } from '~/server/search-index/user-index-eligibility';
 import type { JobContext } from '~/server/jobs/job';
 import {
   ArticleIngestionStatus,
@@ -67,10 +68,13 @@ export const CLEANUP_INDEXES: IndexConfig[] = [
     indexName: USERS_SEARCH_INDEX,
     tableName: 'User',
     alias: 'u',
+    // Shares its predicate with the write side (`users.search-index.ts`) so the reconciler
+    // and the indexer cannot disagree about who belongs in the index. This is the half that
+    // EVICTS an account that changed state after it was indexed — the incremental sync keys
+    // its range scan on `createdAt`, so it never revisits an existing row.
     where: (ids) => Prisma.sql`
       u.id IN (${Prisma.join(ids)})
-      AND u.id != -1
-      AND u."deletedAt" IS NULL
+      AND ${userSearchIndexEligibilitySql()}
     `,
   },
   {

--- a/src/server/routers/app-collaborators.router.ts
+++ b/src/server/routers/app-collaborators.router.ts
@@ -9,6 +9,7 @@ import {
   listAppCollaboratorsSchema,
   removeAppCollaboratorSchema,
   respondToAppInviteSchema,
+  screenAppCollaboratorTargetsSchema,
   setCollaboratorDisplayedSchema,
   transferIdSchema,
 } from '~/server/schema/blocks/app-collaborator.schema';
@@ -134,6 +135,24 @@ export const appCollaboratorsRouter = router({
           actorUserId: ctx.user!.id,
         })
       );
+    }),
+
+  /**
+   * OWNER: screen the ids the invite picker is currently offering, and say which of them
+   * cannot hold a seat.
+   *
+   * A QUERY, not a mutation, and it returns ids only — no reason, nothing about accounts that
+   * are fine. The picker uses it to stop offering candidates the invite is going to refuse;
+   * `invite` re-checks the same thing and is what actually prevents the grant.
+   */
+  ineligibleTargets: appDeveloperProcedure
+    .input(screenAppCollaboratorTargetsSchema)
+    .query(async ({ ctx, input }) => {
+      assertNotBanned(ctx.user as SessionUser);
+      const { getIneligibleCollaboratorTargets } = await import(
+        '~/server/services/blocks/app-collaborator.service'
+      );
+      return run(() => getIneligibleCollaboratorTargets({ userIds: input.userIds }));
     }),
 
   /** OWNER: remove a collaborator (any status). Revokes their repo write. */

--- a/src/server/routers/app-collaborators.router.ts
+++ b/src/server/routers/app-collaborators.router.ts
@@ -144,15 +144,34 @@ export const appCollaboratorsRouter = router({
    * A QUERY, not a mutation, and it returns ids only — no reason, nothing about accounts that
    * are fine. The picker uses it to stop offering candidates the invite is going to refuse;
    * `invite` re-checks the same thing and is what actually prevents the grant.
+   *
+   * 🔴 Owner-keyed (the service asserts ownership of `appListingId`) AND rate-limited, like its
+   * `invite` sibling. Neither is load-bearing against today's audience — both exist so this
+   * cannot quietly become an account-state enumeration endpoint the day the authoring flag
+   * widens. The limit is set well above what the picker can generate: the query re-issues only
+   * when the accumulated id set actually changes, not per keystroke.
    */
   ineligibleTargets: appDeveloperProcedure
+    .use(
+      rateLimit({
+        limit: 600,
+        period: 3600,
+        errorMessage: 'Too many collaborator lookups — slow down.',
+      })
+    )
     .input(screenAppCollaboratorTargetsSchema)
     .query(async ({ ctx, input }) => {
       assertNotBanned(ctx.user as SessionUser);
       const { getIneligibleCollaboratorTargets } = await import(
         '~/server/services/blocks/app-collaborator.service'
       );
-      return run(() => getIneligibleCollaboratorTargets({ userIds: input.userIds }));
+      return run(() =>
+        getIneligibleCollaboratorTargets({
+          appListingId: input.appListingId,
+          actorUserId: ctx.user!.id,
+          userIds: input.userIds,
+        })
+      );
     }),
 
   /** OWNER: remove a collaborator (any status). Revokes their repo write. */

--- a/src/server/schema/blocks/app-collaborator.schema.ts
+++ b/src/server/schema/blocks/app-collaborator.schema.ts
@@ -33,13 +33,28 @@ export const inviteAppCollaboratorSchema = z.object({
 export type InviteAppCollaboratorInput = z.infer<typeof inviteAppCollaboratorSchema>;
 
 /**
+ * How many candidate ids may be screened in one call.
+ *
+ * 🔴 ONE DEFINITION, IMPORTED BY THE CLIENT. The panel caps the set it accumulates and this
+ * schema caps what it will accept; when those were two independent literals, a divergence was a
+ * FAIL-OPEN — the panel would send more than the schema allows, every call would 400, and the
+ * picker would read every candidate as eligible.
+ */
+export const SCREENED_USER_ID_LIMIT = 100;
+
+/**
  * The ids currently on offer in the invite picker, asked about in one round trip.
+ *
+ * Keyed on the LISTING, which the service asserts the caller owns. Without that, this would
+ * answer questions about arbitrary account ids for anyone holding the authoring flag — an
+ * enumeration surface waiting for that audience to widen.
  *
  * Capped at the picker's own page size with headroom — this is a screening call for what is
  * on screen, not a bulk user-state export, and the cap is what keeps it from becoming one.
  */
 export const screenAppCollaboratorTargetsSchema = z.object({
-  userIds: z.array(userId).min(1).max(100),
+  appListingId,
+  userIds: z.array(userId).min(1).max(SCREENED_USER_ID_LIMIT),
 });
 export type ScreenAppCollaboratorTargetsInput = z.infer<typeof screenAppCollaboratorTargetsSchema>;
 

--- a/src/server/schema/blocks/app-collaborator.schema.ts
+++ b/src/server/schema/blocks/app-collaborator.schema.ts
@@ -32,6 +32,19 @@ export const inviteAppCollaboratorSchema = z.object({
 });
 export type InviteAppCollaboratorInput = z.infer<typeof inviteAppCollaboratorSchema>;
 
+/**
+ * The ids currently on offer in the invite picker, asked about in one round trip.
+ *
+ * Capped at the picker's own page size with headroom — this is a screening call for what is
+ * on screen, not a bulk user-state export, and the cap is what keeps it from becoming one.
+ */
+export const screenAppCollaboratorTargetsSchema = z.object({
+  userIds: z.array(userId).min(1).max(100),
+});
+export type ScreenAppCollaboratorTargetsInput = z.infer<
+  typeof screenAppCollaboratorTargetsSchema
+>;
+
 export const respondToAppInviteSchema = z.object({
   appListingId,
   accept: z.boolean(),

--- a/src/server/schema/blocks/app-collaborator.schema.ts
+++ b/src/server/schema/blocks/app-collaborator.schema.ts
@@ -41,9 +41,7 @@ export type InviteAppCollaboratorInput = z.infer<typeof inviteAppCollaboratorSch
 export const screenAppCollaboratorTargetsSchema = z.object({
   userIds: z.array(userId).min(1).max(100),
 });
-export type ScreenAppCollaboratorTargetsInput = z.infer<
-  typeof screenAppCollaboratorTargetsSchema
->;
+export type ScreenAppCollaboratorTargetsInput = z.infer<typeof screenAppCollaboratorTargetsSchema>;
 
 export const respondToAppInviteSchema = z.object({
   appListingId,

--- a/src/server/search-index/__tests__/user-index-eligibility.test.ts
+++ b/src/server/search-index/__tests__/user-index-eligibility.test.ts
@@ -21,7 +21,6 @@ vi.mock('~/server/meilisearch/client', () => ({
   metricsSearchClient: null,
   updateDocs: vi.fn(async () => undefined),
 }));
-vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 
 const { USER_SEARCH_INDEX_ELIGIBILITY, userSearchIndexEligibilitySql } = await import(
   '~/server/search-index/user-index-eligibility'

--- a/src/server/search-index/__tests__/user-index-eligibility.test.ts
+++ b/src/server/search-index/__tests__/user-index-eligibility.test.ts
@@ -16,7 +16,11 @@ import { describe, expect, it, vi } from 'vitest';
 
 // The reconciler module reaches for the search client and the db client at import time; neither
 // is needed to read its predicate.
-vi.mock('~/server/meilisearch/client', () => ({ searchClient: null }));
+vi.mock('~/server/meilisearch/client', () => ({
+  searchClient: null,
+  metricsSearchClient: null,
+  updateDocs: vi.fn(async () => undefined),
+}));
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 
 const { USER_SEARCH_INDEX_ELIGIBILITY, userSearchIndexEligibilitySql } = await import(
@@ -63,6 +67,23 @@ describe('user search index eligibility', () => {
       expect(sql).toContain('u."bannedAt" IS NULL');
       expect(sql).toContain('u."deletedAt" IS NULL');
       expect(sql).toContain('u.id != -1');
+    });
+
+    /**
+     * The OTHER half of the seam. `M1c`: an indexer that keeps its own copy of the predicate,
+     * ban clause dropped, is invisible to every assertion above — the shared module is still
+     * correct and the reconciler still uses it, so nothing else goes red while every write
+     * re-inserts the accounts the reconciler just removed.
+     */
+    it('the INDEXER writes on the same predicate it is reconciled against', async () => {
+      const { USERS_INDEX_WHERE } = await import('~/server/search-index/users.search-index');
+      expect(norm(Prisma.join(USERS_INDEX_WHERE, ' AND ').sql)).toBe(
+        norm(userSearchIndexEligibilitySql().sql)
+      );
+      // Pinned literally as well, so the two sides agreeing on the WRONG predicate is not a pass.
+      expect(norm(Prisma.join(USERS_INDEX_WHERE, ' AND ').sql)).toBe(
+        'u.id != -1 AND u."deletedAt" IS NULL AND u."bannedAt" IS NULL'
+      );
     });
 
     /**

--- a/src/server/search-index/__tests__/user-index-eligibility.test.ts
+++ b/src/server/search-index/__tests__/user-index-eligibility.test.ts
@@ -10,12 +10,25 @@ import { describe, expect, it, vi } from 'vitest';
  *   - the WRITE side decides what gets put in (rebuild, range scan, every queued update);
  *   - the RECONCILER decides what gets to stay.
  *
- * They are asserted TOGETHER here, against one shared predicate, because that pairing is the
- * fix. Two separately-correct-looking filters that disagree is the failure mode.
+ * 🔴 EVERY ASSERTION HERE PINS A WHOLE NORMALISED WHERE CLAUSE WITH `toBe`, and the write-side
+ * ones pin the SQL THAT REACHES `$queryRaw` rather than any constant the query is supposed to
+ * be built from. Both choices are scar tissue from an adversarial round that walked the
+ * previous version of this file twice, with the guard's text still present each time:
+ *
+ *   - `toContain('u."bannedAt" IS NULL')` is satisfied by any statement that merely MENTIONS
+ *     the clause. `AND (<eligibility> OR u."bannedAt" IS NOT NULL)` makes the reconciler keep
+ *     every banned document and still contains the substring — suite green.
+ *   - Pinning an exported constant says nothing about the queries. The module had a local
+ *     alias beside the constant, and the alias was what the queries read; re-binding the alias
+ *     to a two-element copy dropped the ban clause from every write-side query — suite green.
+ *
+ * So: whole strings, and observed at the boundary. A cosmetic rewording of a predicate will
+ * fail these — that is the price of a machine-readable claim, and it is worth paying here.
+ * (Only the WHERE is pinned, not the whole statement, so adding a SELECT column stays free.)
  */
 
-// The reconciler module reaches for the search client and the db client at import time; neither
-// is needed to read its predicate.
+// The reconciler module reaches for the search client at import time; it is not needed to read
+// a predicate, and the index module pulls `updateDocs` from the same place.
 vi.mock('~/server/meilisearch/client', () => ({
   searchClient: null,
   metricsSearchClient: null,
@@ -25,28 +38,110 @@ vi.mock('~/server/meilisearch/client', () => ({
 const { USER_SEARCH_INDEX_ELIGIBILITY, userSearchIndexEligibilitySql } = await import(
   '~/server/search-index/user-index-eligibility'
 );
+const { buildUsersIndexWhere, prepareUsersBatches, pullUsersData } = await import(
+  '~/server/search-index/users.search-index'
+);
 const { CLEANUP_INDEXES } = await import('~/server/meilisearch/cleanup');
 const { Prisma } = await import('@prisma/client');
 
 /** Collapse whitespace so an assertion is about the PREDICATE, not about indentation. */
 const norm = (sql: string) => sql.replace(/\s+/g, ' ').trim();
 
+const ELIGIBILITY = 'u.id != -1 AND u."deletedAt" IS NULL AND u."bannedAt" IS NULL';
+
+/**
+ * Re-compose a Prisma tagged-template call into readable SQL. Nested `Prisma.Sql` values expose
+ * their own text; scalar bind params become `?`, exactly as the driver would render them.
+ */
+const renderTag = (strings: TemplateStringsArray, values: unknown[]) => {
+  let out = '';
+  strings.forEach((str, i) => {
+    out += str;
+    if (i < values.length) {
+      const v = values[i] as { sql?: string };
+      out += v && typeof v === 'object' && 'sql' in v ? v.sql : '?';
+    }
+  });
+  return out;
+};
+
+/** Every WHERE clause in a statement, normalised — the part an eligibility bug lives in. */
+const whereClausesOf = (statement: string) =>
+  [...norm(statement).matchAll(/\bWHERE\b\s+(.*?)(?=\s+ORDER BY\b|\s*\)\s*as\b|$)/g)].map(
+    (m) => m[1]
+  );
+
+/** Drives the real query builders and hands back the SQL they issued. */
+async function captureQueries(
+  run: (ctx: { db: unknown; logger: () => void }) => Promise<unknown>
+): Promise<string[]> {
+  const captured: string[] = [];
+  const db = {
+    $queryRaw: (strings: TemplateStringsArray, ...values: unknown[]) => {
+      captured.push(renderTag(strings, values));
+      // `prepareBatches` destructures `data[0]`; a bare `[]` would throw before we could read
+      // what it asked for.
+      return Promise.resolve([{ startId: 1, endId: 2 }]);
+    },
+  };
+  await run({ db, logger: () => undefined });
+  return captured;
+}
+
 describe('user search index eligibility', () => {
-  /**
-   * The whole normalised predicate, pinned. Deliberately not a substring match: a substring
-   * assertion is satisfied by a clause that is present but AND-ed with something that makes it
-   * unreachable, and it says nothing about a clause being dropped.
-   */
   it('is exactly: not the deleted-content sentinel, not soft-deleted, and NOT BANNED', () => {
-    expect(norm(Prisma.join(USER_SEARCH_INDEX_ELIGIBILITY, ' AND ').sql)).toBe(
-      'u.id != -1 AND u."deletedAt" IS NULL AND u."bannedAt" IS NULL'
-    );
+    expect(norm(Prisma.join(USER_SEARCH_INDEX_ELIGIBILITY, ' AND ').sql)).toBe(ELIGIBILITY);
   });
 
   it('exposes the same predicate as one joined fragment', () => {
-    expect(norm(userSearchIndexEligibilitySql().sql)).toBe(
-      'u.id != -1 AND u."deletedAt" IS NULL AND u."bannedAt" IS NULL'
-    );
+    expect(norm(userSearchIndexEligibilitySql().sql)).toBe(ELIGIBILITY);
+  });
+
+  /**
+   * The write side, observed at the query boundary. These are the assertions that survive a
+   * re-bind: they do not care what the module calls anything, only what it asks the database.
+   */
+  describe('the queries the indexer actually issues', () => {
+    it('a TARGETED update — the shape the metrics refresh enqueues — filters banned accounts', async () => {
+      const [statement] = await captureQueries((ctx) =>
+        pullUsersData(ctx as never, { type: 'update', ids: [11, 22] }, 0)
+      );
+      expect(whereClausesOf(statement)).toEqual([`${ELIGIBILITY} AND u.id IN (?,?)`]);
+    });
+
+    it('a full RANGE scan filters banned accounts', async () => {
+      const [statement] = await captureQueries((ctx) =>
+        pullUsersData(ctx as never, { type: 'new', startId: 5, endId: 9 }, 0)
+      );
+      expect(whereClausesOf(statement)).toEqual([`${ELIGIBILITY} AND u.id >= ? AND u.id <= ?`]);
+    });
+
+    it('BOTH bounds queries that size an incremental batch filter banned accounts', async () => {
+      const [statement] = await captureQueries((ctx) =>
+        prepareUsersBatches(ctx as never, new Date('2026-01-01T00:00:00.000Z'))
+      );
+      // Two sub-selects, and a fix applied to only one of them is the obvious half-fix.
+      expect(whereClausesOf(statement)).toEqual([
+        `${ELIGIBILITY} AND u."createdAt" >= ?`,
+        `${ELIGIBILITY} AND u."createdAt" >= ?`,
+      ]);
+    });
+
+    it('…and so does a full rebuild, which passes no narrowing clause at all', async () => {
+      const [statement] = await captureQueries((ctx) => prepareUsersBatches(ctx as never));
+      expect(whereClausesOf(statement)).toEqual([ELIGIBILITY, ELIGIBILITY]);
+    });
+
+    /**
+     * Narrowing clauses come AFTER eligibility and never replace it. Pinned separately from the
+     * queries above so the ORDER is a stated contract rather than an accident of two call sites.
+     */
+    it('appends narrowing clauses to the eligibility predicate rather than replacing it', () => {
+      const built = buildUsersIndexWhere(Prisma.sql`u.id = 5`, undefined, Prisma.sql`u.id < 9`);
+      expect(norm(Prisma.join(built, ' AND ').sql)).toBe(
+        `${ELIGIBILITY} AND u.id = 5 AND u.id < 9`
+      );
+    });
   });
 
   describe('the nightly reconciler keeps the same accounts the indexer writes', () => {
@@ -57,38 +152,18 @@ describe('user search index eligibility', () => {
     });
 
     /**
-     * The seam. The reconciler is what actually EVICTS a document for an account that changed
-     * state after it was indexed, so its predicate carrying the ban clause is the load-bearing
-     * assertion — not the write-side filter, which only stops NEW writes.
+     * The seam, and the half that actually EVICTS an account which changed state after it was
+     * indexed — the incremental sync keys its range scan on `createdAt`, so it never revisits an
+     * existing row. Pinned whole: a widened predicate that keeps banned documents is the
+     * mutation this exists to catch, and it leaves every substring intact.
      */
-    it('reconciles users on the shared eligibility predicate, ban clause included', () => {
-      const sql = norm(usersConfig!.where([11, 22]).sql);
-      expect(sql).toContain('u."bannedAt" IS NULL');
-      expect(sql).toContain('u."deletedAt" IS NULL');
-      expect(sql).toContain('u.id != -1');
+    it('reconciles users on exactly the shared eligibility predicate', () => {
+      expect(norm(usersConfig!.where([11, 22]).sql)).toBe(`u.id IN (?,?) AND ${ELIGIBILITY}`);
     });
 
     /**
-     * The OTHER half of the seam. `M1c`: an indexer that keeps its own copy of the predicate,
-     * ban clause dropped, is invisible to every assertion above — the shared module is still
-     * correct and the reconciler still uses it, so nothing else goes red while every write
-     * re-inserts the accounts the reconciler just removed.
-     */
-    it('the INDEXER writes on the same predicate it is reconciled against', async () => {
-      const { USERS_INDEX_WHERE } = await import('~/server/search-index/users.search-index');
-      expect(norm(Prisma.join(USERS_INDEX_WHERE, ' AND ').sql)).toBe(
-        norm(userSearchIndexEligibilitySql().sql)
-      );
-      // Pinned literally as well, so the two sides agreeing on the WRONG predicate is not a pass.
-      expect(norm(Prisma.join(USERS_INDEX_WHERE, ' AND ').sql)).toBe(
-        'u.id != -1 AND u."deletedAt" IS NULL AND u."bannedAt" IS NULL'
-      );
-    });
-
-    /**
-     * The presence half of the ban assertion above. An empty/near-empty predicate would satisfy
-     * "does not mention bannedAt" for every OTHER index too, so a mutant that guts the shared
-     * module has to be caught by something that still expects real content elsewhere.
+     * The presence half. An empty or gutted predicate would satisfy "does not mention bannedAt"
+     * for every other index too, so something still has to expect real content elsewhere.
      */
     it('leaves the other indexes untouched — this predicate is user-scoped', () => {
       const models = CLEANUP_INDEXES.find((c) => c.key === 'models');

--- a/src/server/search-index/__tests__/user-index-eligibility.test.ts
+++ b/src/server/search-index/__tests__/user-index-eligibility.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * WHO BELONGS IN THE USER SEARCH INDEX.
+ *
+ * A banned account must not be discoverable through user search. Two independent halves have
+ * to agree for that to hold, and a bug in either one alone is enough to put a banned account
+ * back in front of users:
+ *
+ *   - the WRITE side decides what gets put in (rebuild, range scan, every queued update);
+ *   - the RECONCILER decides what gets to stay.
+ *
+ * They are asserted TOGETHER here, against one shared predicate, because that pairing is the
+ * fix. Two separately-correct-looking filters that disagree is the failure mode.
+ */
+
+// The reconciler module reaches for the search client and the db client at import time; neither
+// is needed to read its predicate.
+vi.mock('~/server/meilisearch/client', () => ({ searchClient: null }));
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
+const { USER_SEARCH_INDEX_ELIGIBILITY, userSearchIndexEligibilitySql } = await import(
+  '~/server/search-index/user-index-eligibility'
+);
+const { CLEANUP_INDEXES } = await import('~/server/meilisearch/cleanup');
+const { Prisma } = await import('@prisma/client');
+
+/** Collapse whitespace so an assertion is about the PREDICATE, not about indentation. */
+const norm = (sql: string) => sql.replace(/\s+/g, ' ').trim();
+
+describe('user search index eligibility', () => {
+  /**
+   * The whole normalised predicate, pinned. Deliberately not a substring match: a substring
+   * assertion is satisfied by a clause that is present but AND-ed with something that makes it
+   * unreachable, and it says nothing about a clause being dropped.
+   */
+  it('is exactly: not the deleted-content sentinel, not soft-deleted, and NOT BANNED', () => {
+    expect(norm(Prisma.join(USER_SEARCH_INDEX_ELIGIBILITY, ' AND ').sql)).toBe(
+      'u.id != -1 AND u."deletedAt" IS NULL AND u."bannedAt" IS NULL'
+    );
+  });
+
+  it('exposes the same predicate as one joined fragment', () => {
+    expect(norm(userSearchIndexEligibilitySql().sql)).toBe(
+      'u.id != -1 AND u."deletedAt" IS NULL AND u."bannedAt" IS NULL'
+    );
+  });
+
+  describe('the nightly reconciler keeps the same accounts the indexer writes', () => {
+    const usersConfig = CLEANUP_INDEXES.find((c) => c.key === 'users');
+
+    it('has a users config at all', () => {
+      expect(usersConfig).toBeDefined();
+    });
+
+    /**
+     * The seam. The reconciler is what actually EVICTS a document for an account that changed
+     * state after it was indexed, so its predicate carrying the ban clause is the load-bearing
+     * assertion — not the write-side filter, which only stops NEW writes.
+     */
+    it('reconciles users on the shared eligibility predicate, ban clause included', () => {
+      const sql = norm(usersConfig!.where([11, 22]).sql);
+      expect(sql).toContain('u."bannedAt" IS NULL');
+      expect(sql).toContain('u."deletedAt" IS NULL');
+      expect(sql).toContain('u.id != -1');
+    });
+
+    /**
+     * The presence half of the ban assertion above. An empty/near-empty predicate would satisfy
+     * "does not mention bannedAt" for every OTHER index too, so a mutant that guts the shared
+     * module has to be caught by something that still expects real content elsewhere.
+     */
+    it('leaves the other indexes untouched — this predicate is user-scoped', () => {
+      const models = CLEANUP_INDEXES.find((c) => c.key === 'models');
+      expect(models).toBeDefined();
+      const modelsSql = norm(models!.where([11]).sql);
+      expect(modelsSql).toContain('m.status =');
+      expect(modelsSql).not.toContain('bannedAt');
+    });
+  });
+});

--- a/src/server/search-index/__tests__/user-index-eligibility.test.ts
+++ b/src/server/search-index/__tests__/user-index-eligibility.test.ts
@@ -25,6 +25,13 @@ import { describe, expect, it, vi } from 'vitest';
  * So: whole strings, and observed at the boundary. A cosmetic rewording of a predicate will
  * fail these — that is the price of a machine-readable claim, and it is worth paying here.
  * (Only the WHERE is pinned, not the whole statement, so adding a SELECT column stays free.)
+ *
+ * 🔴 AND THEY ARE A LEDGER OVER EVERY QUERY, NOT A SPOT-CHECK ON THE FIRST ONE. Each assertion
+ * pins the COUNT of statements issued as well as their predicates, because a third walk of the
+ * same class is "add a second, unfiltered `$queryRaw` beside the guarded one": every existing
+ * predicate stays correct, the new writer is simply not looked at, and a description promising
+ * "the SQL that reaches `$queryRaw`" reads as coverage it does not provide. A new query here is
+ * meant to break these — check its WHERE and add it to the expected list.
  */
 
 // The reconciler module reaches for the search client at import time; it is not needed to read
@@ -71,7 +78,7 @@ const whereClausesOf = (statement: string) =>
     (m) => m[1]
   );
 
-/** Drives the real query builders and hands back the SQL they issued. */
+/** Drives the real query builders and hands back EVERY statement they issued, in order. */
 async function captureQueries(
   run: (ctx: { db: unknown; logger: () => void }) => Promise<unknown>
 ): Promise<string[]> {
@@ -103,33 +110,39 @@ describe('user search index eligibility', () => {
    */
   describe('the queries the indexer actually issues', () => {
     it('a TARGETED update — the shape the metrics refresh enqueues — filters banned accounts', async () => {
-      const [statement] = await captureQueries((ctx) =>
+      const statements = await captureQueries((ctx) =>
         pullUsersData(ctx as never, { type: 'update', ids: [11, 22] }, 0)
       );
-      expect(whereClausesOf(statement)).toEqual([`${ELIGIBILITY} AND u.id IN (?,?)`]);
+      expect(statements).toHaveLength(1);
+      expect(statements.flatMap(whereClausesOf)).toEqual([`${ELIGIBILITY} AND u.id IN (?,?)`]);
     });
 
     it('a full RANGE scan filters banned accounts', async () => {
-      const [statement] = await captureQueries((ctx) =>
+      const statements = await captureQueries((ctx) =>
         pullUsersData(ctx as never, { type: 'new', startId: 5, endId: 9 }, 0)
       );
-      expect(whereClausesOf(statement)).toEqual([`${ELIGIBILITY} AND u.id >= ? AND u.id <= ?`]);
+      expect(statements).toHaveLength(1);
+      expect(statements.flatMap(whereClausesOf)).toEqual([
+        `${ELIGIBILITY} AND u.id >= ? AND u.id <= ?`,
+      ]);
     });
 
     it('BOTH bounds queries that size an incremental batch filter banned accounts', async () => {
-      const [statement] = await captureQueries((ctx) =>
+      const statements = await captureQueries((ctx) =>
         prepareUsersBatches(ctx as never, new Date('2026-01-01T00:00:00.000Z'))
       );
+      expect(statements).toHaveLength(1);
       // Two sub-selects, and a fix applied to only one of them is the obvious half-fix.
-      expect(whereClausesOf(statement)).toEqual([
+      expect(statements.flatMap(whereClausesOf)).toEqual([
         `${ELIGIBILITY} AND u."createdAt" >= ?`,
         `${ELIGIBILITY} AND u."createdAt" >= ?`,
       ]);
     });
 
     it('…and so does a full rebuild, which passes no narrowing clause at all', async () => {
-      const [statement] = await captureQueries((ctx) => prepareUsersBatches(ctx as never));
-      expect(whereClausesOf(statement)).toEqual([ELIGIBILITY, ELIGIBILITY]);
+      const statements = await captureQueries((ctx) => prepareUsersBatches(ctx as never));
+      expect(statements).toHaveLength(1);
+      expect(statements.flatMap(whereClausesOf)).toEqual([ELIGIBILITY, ELIGIBILITY]);
     });
 
     /**

--- a/src/server/search-index/base.search-index.ts
+++ b/src/server/search-index/base.search-index.ts
@@ -27,7 +27,7 @@ import { createLogger } from '~/utils/logging';
 const DEFAULT_UPDATE_INTERVAL = 30 * 1000;
 const logger = createLogger(`search-index-processor`);
 
-type SearchIndexContext = {
+export type SearchIndexContext = {
   db: PrismaClient;
   pg: AugmentedPool;
   ch?: CustomClickHouseClient;
@@ -35,7 +35,7 @@ type SearchIndexContext = {
   jobContext?: JobContext;
   logger: ReturnType<typeof createLogger>;
 };
-type SearchIndexPullBatch =
+export type SearchIndexPullBatch =
   | { type: 'new'; startId: number; endId: number }
   | { type: 'update'; ids: number[] };
 type SearchIndexSetup = (context: { indexName: string }) => Promise<void>;

--- a/src/server/search-index/user-index-eligibility.ts
+++ b/src/server/search-index/user-index-eligibility.ts
@@ -1,0 +1,32 @@
+import { Prisma } from '@prisma/client';
+
+/**
+ * The ONE definition of "this account belongs in the user search index".
+ *
+ * Kept a leaf module — no meilisearch client, no db client — so a test can read it without
+ * pulling the search-index runtime in, and so the two places that decide index membership
+ * cannot disagree:
+ *
+ *   1. `users.search-index.ts` — what gets WRITTEN (full rebuild, the createdAt range scan,
+ *      and every targeted `Update` drained from the queue).
+ *   2. `meilisearch/cleanup.ts` — what gets KEPT by the nightly reconciler; a document whose
+ *      id this predicate no longer returns is deleted.
+ *
+ * 🔴 BOTH HALVES ARE LOAD-BEARING, and the pair is the fix. A write-side filter alone leaves
+ * documents that were indexed before the account changed state sitting there forever, because
+ * the incremental range scan keys on `createdAt` — an existing row is never re-pulled by it.
+ * A reconciler-side filter alone is undone on the next write, because the metrics refresh
+ * enqueues an `Update` for every account whose counters moved, which re-inserts it.
+ *
+ * `bannedAt IS NULL` is here because a banned account must not be discoverable through user
+ * search, and because search results are consumed BY ID by pickers that grant access.
+ */
+export const USER_SEARCH_INDEX_ELIGIBILITY: Prisma.Sql[] = [
+  Prisma.sql`u.id != -1`,
+  Prisma.sql`u."deletedAt" IS NULL`,
+  Prisma.sql`u."bannedAt" IS NULL`,
+];
+
+/** The same predicate as a single `AND`-joined fragment, for callers building one WHERE. */
+export const userSearchIndexEligibilitySql = () =>
+  Prisma.join(USER_SEARCH_INDEX_ELIGIBILITY, ' AND ');

--- a/src/server/search-index/users.search-index.ts
+++ b/src/server/search-index/users.search-index.ts
@@ -99,9 +99,18 @@ type UserRank = {
   leaderboardCosmetic: string;
 };
 
-// Shared with the nightly reconciler in `~/server/meilisearch/cleanup.ts` — see that module's
-// header for why the write-side filter and the reconciler-side filter have to be the same list.
-const WHERE = [...USER_SEARCH_INDEX_ELIGIBILITY];
+/**
+ * Who this index is allowed to hold. Shared with the nightly reconciler in
+ * `~/server/meilisearch/cleanup.ts` — see that module's header for why the write-side filter
+ * and the reconciler-side filter have to be the same list.
+ *
+ * Exported so a test can hold the two sides against each other. Both `prepareBatches` and
+ * `pullData` build their WHERE from it, so a targeted update drained from the queue is filtered
+ * exactly like a full rebuild — which matters, because the metrics refresh enqueues an update
+ * for every account whose counters moved.
+ */
+export const USERS_INDEX_WHERE = [...USER_SEARCH_INDEX_ELIGIBILITY];
+const WHERE = USERS_INDEX_WHERE;
 
 const transformData = async ({
   users,

--- a/src/server/search-index/users.search-index.ts
+++ b/src/server/search-index/users.search-index.ts
@@ -4,6 +4,10 @@ import { usersFilterableAttributes } from '~/server/search-index/filterable-attr
 import { updateDocs } from '~/server/meilisearch/client';
 
 import { getOrCreateIndex } from '~/server/meilisearch/util';
+import type {
+  SearchIndexContext,
+  SearchIndexPullBatch,
+} from '~/server/search-index/base.search-index';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
 import { USER_SEARCH_INDEX_ELIGIBILITY } from '~/server/search-index/user-index-eligibility';
 import { getCosmeticsForUsers, getProfilePicturesForUsers } from '~/server/services/user.service';
@@ -100,17 +104,19 @@ type UserRank = {
 };
 
 /**
- * Who this index is allowed to hold. Shared with the nightly reconciler in
- * `~/server/meilisearch/cleanup.ts` — see that module's header for why the write-side filter
- * and the reconciler-side filter have to be the same list.
+ * The WHERE every read in this index is built from: the eligibility predicate shared with the
+ * nightly reconciler (`~/server/meilisearch/cleanup.ts`), plus whatever clause narrows this
+ * particular batch. Narrowing clauses come AFTER, so eligibility can never be dropped by one.
  *
- * Exported so a test can hold the two sides against each other. Both `prepareBatches` and
- * `pullData` build their WHERE from it, so a targeted update drained from the queue is filtered
- * exactly like a full rebuild — which matters, because the metrics refresh enqueues an update
- * for every account whose counters moved.
+ * 🔴 A FUNCTION, AND THE ONLY NAME FOR THIS. It was previously an exported constant with a local
+ * alias beside it, and the alias — not the constant — was what the queries consumed. A test
+ * pinning the constant therefore said nothing about the queries: re-binding the alias to a
+ * two-element copy dropped `bannedAt IS NULL` from every write-side query with the whole suite
+ * green. One name removes the gap, and the tests now pin the SQL that reaches `$queryRaw`
+ * rather than anything declared here.
  */
-export const USERS_INDEX_WHERE = [...USER_SEARCH_INDEX_ELIGIBILITY];
-const WHERE = USERS_INDEX_WHERE;
+export const buildUsersIndexWhere = (...narrowing: (Prisma.Sql | undefined)[]) =>
+  [...USER_SEARCH_INDEX_ELIGIBILITY, ...narrowing].filter(isDefined);
 
 const transformData = async ({
   users,
@@ -140,17 +146,21 @@ const transformData = async ({
 
 export type UserSearchIndexRecord = Awaited<ReturnType<typeof transformData>>[number];
 
-export const usersSearchIndex = createSearchIndexUpdateProcessor({
-  indexName: INDEX_ID,
-  setup: onIndexSetup,
-  workerCount: 25,
-  prepareBatches: async ({ db, logger }, lastUpdatedAt) => {
-    const where = [
-      ...WHERE,
-      lastUpdatedAt ? Prisma.sql`u."createdAt" >= ${lastUpdatedAt}` : undefined,
-    ].filter(isDefined);
+/**
+ * Hoisted out of the processor config and exported so a test can drive it and read the SQL it
+ * actually issues. Pinning a constant these functions are *supposed* to use is one indirection
+ * short of pinning what they do — and that indirection is exactly what an adversarial round
+ * walked through.
+ */
+export const prepareUsersBatches = async (
+  { db, logger }: SearchIndexContext,
+  lastUpdatedAt?: Date
+) => {
+  const where = buildUsersIndexWhere(
+    lastUpdatedAt ? Prisma.sql`u."createdAt" >= ${lastUpdatedAt}` : undefined
+  );
 
-    const data = await db.$queryRaw<{ startId: number; endId: number }[]>`
+  const data = await db.$queryRaw<{ startId: number; endId: number }[]>`
       SELECT
         (
           SELECT u.id
@@ -168,31 +178,37 @@ export const usersSearchIndex = createSearchIndexUpdateProcessor({
         ) as "endId"
     `;
 
-    const { startId, endId } = data[0];
+  const { startId, endId } = data[0];
 
-    logger(
-      `PrepareBatches :: Prepared batch: ${startId} - ${endId} ... Last updated: ${lastUpdatedAt}`
-    );
+  logger(
+    `PrepareBatches :: Prepared batch: ${startId} - ${endId} ... Last updated: ${lastUpdatedAt}`
+  );
 
-    return {
-      batchSize: READ_BATCH_SIZE,
-      startId,
-      endId,
-    };
-  },
-  pullSteps: 4,
-  pullData: async ({ db, logger }, batch, step, prevData) => {
+  return {
+    batchSize: READ_BATCH_SIZE,
+    startId,
+    endId,
+  };
+};
+
+/** Hoisted and exported for the same reason as {@link prepareUsersBatches}. */
+export const pullUsersData = async (
+  { db, logger }: SearchIndexContext,
+  batch: SearchIndexPullBatch,
+  step?: number,
+  prevData?: any
+) => {
+  {
     logger(
       `PullData :: Pulling data for batch`,
       batch.type === 'new' ? `${batch.startId} - ${batch.endId}` : batch.ids.length
     );
-    const where = [
-      ...WHERE,
+    const where = buildUsersIndexWhere(
       batch.type === 'update' ? Prisma.sql`u.id IN (${Prisma.join(batch.ids)})` : undefined,
       batch.type === 'new'
         ? Prisma.sql`u.id >= ${batch.startId} AND u.id <= ${batch.endId}`
-        : undefined,
-    ].filter(isDefined);
+        : undefined
+    );
 
     const userIds = prevData ? (prevData as { users: BaseUser[] }).users.map((u) => u.id) : [];
 
@@ -288,7 +304,16 @@ export const usersSearchIndex = createSearchIndexUpdateProcessor({
     }
 
     return prevData;
-  },
+  }
+};
+
+export const usersSearchIndex = createSearchIndexUpdateProcessor({
+  indexName: INDEX_ID,
+  setup: onIndexSetup,
+  workerCount: 25,
+  prepareBatches: prepareUsersBatches,
+  pullSteps: 4,
+  pullData: pullUsersData,
   transformData,
   pushData: async ({ indexName, jobContext }, records) => {
     await updateDocs({

--- a/src/server/search-index/users.search-index.ts
+++ b/src/server/search-index/users.search-index.ts
@@ -5,6 +5,7 @@ import { updateDocs } from '~/server/meilisearch/client';
 
 import { getOrCreateIndex } from '~/server/meilisearch/util';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
+import { USER_SEARCH_INDEX_ELIGIBILITY } from '~/server/search-index/user-index-eligibility';
 import { getCosmeticsForUsers, getProfilePicturesForUsers } from '~/server/services/user.service';
 
 import { isDefined } from '~/utils/type-guards';
@@ -98,7 +99,9 @@ type UserRank = {
   leaderboardCosmetic: string;
 };
 
-const WHERE = [Prisma.sql`u.id != -1`, Prisma.sql`u."deletedAt" IS NULL`];
+// Shared with the nightly reconciler in `~/server/meilisearch/cleanup.ts` — see that module's
+// header for why the write-side filter and the reconciler-side filter have to be the same list.
+const WHERE = [...USER_SEARCH_INDEX_ELIGIBILITY];
 
 const transformData = async ({
   users,

--- a/src/server/services/__tests__/toggle-ban-search-index.test.ts
+++ b/src/server/services/__tests__/toggle-ban-search-index.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
 
 /**
  * BANNING REMOVES AN ACCOUNT FROM USER SEARCH — SO LIFTING A BAN HAS TO PUT IT BACK.
@@ -10,22 +11,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  */
 
 const {
-  mockDb,
   mockQueueUpdate,
   mockRemoveContent,
   mockInvalidateSession,
   mockCacheRefresh,
   mockSettingsBust,
 } = vi.hoisted(() => ({
-  mockDb: {
-    user: {
-      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
-      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
-      update: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 0 })),
-    },
-    userLink: { deleteMany: vi.fn(async () => ({ count: 0 })) },
-    image: { updateMany: vi.fn(async () => ({ count: 0 })) },
-  },
   mockQueueUpdate: vi.fn(async () => undefined),
   mockRemoveContent: vi.fn(async () => undefined),
   mockInvalidateSession: vi.fn(async () => undefined),
@@ -33,7 +24,6 @@ const {
   mockSettingsBust: vi.fn(async () => undefined),
 }));
 
-vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
 vi.mock('~/server/search-index', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return { ...actual, usersSearchIndex: { queueUpdate: mockQueueUpdate } };
@@ -69,6 +59,16 @@ const USER_ID = 5501;
 const ACTOR_ID = 5502;
 const ALREADY_BANNED_AT = new Date('2026-01-02T03:04:05.000Z');
 
+// `getUserById` reads the REPLICA; `updateUserById` writes the PRIMARY. Named separately so a
+// write cannot satisfy a read assertion.
+const userFindUnique = dbMock.dbRead.user.findUnique;
+const userUpdate = dbMock.dbWrite.user.update;
+const userFindFirst = dbMock.dbWrite.user.findFirst;
+// The ban branch fans out to these and chains `.catch` on each; the canonical mock has no
+// default for a write verb, so an undeclared one returns `undefined` and the fan-out throws.
+const userLinkDeleteMany = dbMock.dbWrite.userLink.deleteMany;
+const imageUpdateMany = dbMock.dbWrite.image.updateMany;
+
 const call = () =>
   toggleBan({
     id: USER_ID,
@@ -79,14 +79,16 @@ const call = () =>
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockDb.user.update.mockResolvedValue({ id: USER_ID, paddleCustomerId: null });
-  mockDb.user.findFirst.mockResolvedValue(null);
+  userUpdate.mockResolvedValue({ id: USER_ID, paddleCustomerId: null });
+  userFindFirst.mockResolvedValue(null);
+  userLinkDeleteMany.mockResolvedValue({ count: 0 });
+  imageUpdateMany.mockResolvedValue({ count: 0 });
 });
 
 describe('toggleBan -> user search index', () => {
   it('UNBANNING puts the account back in user search', async () => {
     // An account that is currently banned — so this call is the LIFT.
-    mockDb.user.findUnique.mockResolvedValue({
+    userFindUnique.mockResolvedValue({
       bannedAt: ALREADY_BANNED_AT,
       meta: {},
       username: 'someone',
@@ -108,7 +110,7 @@ describe('toggleBan -> user search index', () => {
    * is asserted here so "nothing happened" cannot pass for "the right thing happened".
    */
   it('BANNING removes instead — no refresh enqueued', async () => {
-    mockDb.user.findUnique.mockResolvedValue({
+    userFindUnique.mockResolvedValue({
       bannedAt: null,
       meta: {},
       username: 'someone',

--- a/src/server/services/__tests__/toggle-ban-search-index.test.ts
+++ b/src/server/services/__tests__/toggle-ban-search-index.test.ts
@@ -118,9 +118,7 @@ describe('toggleBan -> user search index', () => {
     await call();
 
     expect(mockRemoveContent).toHaveBeenCalledTimes(1);
-    expect(mockRemoveContent).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: USER_ID })
-    );
+    expect(mockRemoveContent).toHaveBeenCalledWith(expect.objectContaining({ userId: USER_ID }));
     expect(mockQueueUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/toggle-ban-search-index.test.ts
+++ b/src/server/services/__tests__/toggle-ban-search-index.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * BANNING REMOVES AN ACCOUNT FROM USER SEARCH — SO LIFTING A BAN HAS TO PUT IT BACK.
+ *
+ * Nothing else would. The incremental user-index sync scans on `createdAt`, so it never revisits
+ * an existing row, and the nightly reconciler only ever deletes. Without an explicit enqueue on
+ * the unban branch the exclusion is a ONE-WAY DOOR: the account is restored everywhere except
+ * search, indefinitely, and no signal says so.
+ */
+
+const {
+  mockDb,
+  mockQueueUpdate,
+  mockRemoveContent,
+  mockInvalidateSession,
+  mockCacheRefresh,
+  mockSettingsBust,
+} = vi.hoisted(() => ({
+  mockDb: {
+    user: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      update: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 0 })),
+    },
+    userLink: { deleteMany: vi.fn(async () => ({ count: 0 })) },
+    image: { updateMany: vi.fn(async () => ({ count: 0 })) },
+  },
+  mockQueueUpdate: vi.fn(async () => undefined),
+  mockRemoveContent: vi.fn(async () => undefined),
+  mockInvalidateSession: vi.fn(async () => undefined),
+  mockCacheRefresh: vi.fn(async () => undefined),
+  mockSettingsBust: vi.fn(async () => undefined),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/search-index', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, usersSearchIndex: { queueUpdate: mockQueueUpdate } };
+});
+vi.mock('~/server/meilisearch/util', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, removeUserContentFromSearchIndex: mockRemoveContent };
+});
+vi.mock('~/server/auth/session-invalidation', () => ({
+  invalidateSession: mockInvalidateSession,
+}));
+vi.mock('~/server/redis/caches', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    userBasicCache: { refresh: mockCacheRefresh },
+    userSettingsCache: () => ({ bust: mockSettingsBust }),
+  };
+});
+vi.mock('~/server/services/subscriptions.service', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    cancelSubscription: vi.fn(async () => undefined),
+    reinstateSubscription: vi.fn(async () => undefined),
+  };
+});
+
+const { toggleBan } = await import('~/server/services/user.service');
+const { BanReasonCode } = await import('~/server/common/enums');
+
+const USER_ID = 5501;
+const ACTOR_ID = 5502;
+const ALREADY_BANNED_AT = new Date('2026-01-02T03:04:05.000Z');
+
+const call = () =>
+  toggleBan({
+    id: USER_ID,
+    reasonCode: BanReasonCode.Other,
+    userId: ACTOR_ID,
+    isModerator: true,
+  } as Parameters<typeof toggleBan>[0]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.user.update.mockResolvedValue({ id: USER_ID, paddleCustomerId: null });
+  mockDb.user.findFirst.mockResolvedValue(null);
+});
+
+describe('toggleBan -> user search index', () => {
+  it('UNBANNING puts the account back in user search', async () => {
+    // An account that is currently banned — so this call is the LIFT.
+    mockDb.user.findUnique.mockResolvedValue({
+      bannedAt: ALREADY_BANNED_AT,
+      meta: {},
+      username: 'someone',
+      email: null,
+    });
+
+    await call();
+
+    expect(mockQueueUpdate).toHaveBeenCalledTimes(1);
+    const [items] = mockQueueUpdate.mock.calls[0] as unknown as [
+      Array<{ id: number; action: string }>
+    ];
+    expect(items).toEqual([{ id: USER_ID, action: 'Update' }]);
+  });
+
+  /**
+   * The other arm. Banning must NOT enqueue a refresh — a refresh would re-write the very
+   * document the ban is removing. Removal goes through the content-removal path instead, which
+   * is asserted here so "nothing happened" cannot pass for "the right thing happened".
+   */
+  it('BANNING removes instead — no refresh enqueued', async () => {
+    mockDb.user.findUnique.mockResolvedValue({
+      bannedAt: null,
+      meta: {},
+      username: 'someone',
+      email: null,
+    });
+
+    await call();
+
+    expect(mockRemoveContent).toHaveBeenCalledTimes(1);
+    expect(mockRemoveContent).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID })
+    );
+    expect(mockQueueUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/toggle-ban-search-index.test.ts
+++ b/src/server/services/__tests__/toggle-ban-search-index.test.ts
@@ -16,13 +16,20 @@ const {
   mockInvalidateSession,
   mockCacheRefresh,
   mockSettingsBust,
+  mockSendModerationEmail,
 } = vi.hoisted(() => ({
   mockQueueUpdate: vi.fn(async () => undefined),
   mockRemoveContent: vi.fn(async () => undefined),
   mockInvalidateSession: vi.fn(async () => undefined),
   mockCacheRefresh: vi.fn(async () => undefined),
   mockSettingsBust: vi.fn(async () => undefined),
+  mockSendModerationEmail: vi.fn(async (..._a: unknown[]) => undefined),
 }));
+
+vi.mock('~/server/email/templates', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, moderationActionEmail: { send: mockSendModerationEmail } };
+});
 
 vi.mock('~/server/search-index', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -102,6 +109,30 @@ describe('toggleBan -> user search index', () => {
       Array<{ id: number; action: string }>
     ];
     expect(items).toEqual([{ id: USER_ID, action: 'Update' }]);
+  });
+
+  /**
+   * 🔴 A REDIS BLIP MUST NOT BREAK THE UNBAN. `queueUpdate` is a Redis write placed AFTER the
+   * unban has committed and BEFORE the `account-unbanned` email; unguarded, its rejection
+   * propagates and the user is never told their ban was lifted, while the moderator sees a 500
+   * for an action that in fact succeeded.
+   */
+  it('survives a failing search-index enqueue and still sends the unban email', async () => {
+    userFindUnique.mockResolvedValue({
+      bannedAt: ALREADY_BANNED_AT,
+      meta: {},
+      username: 'someone',
+      email: 'someone@example.com',
+    });
+    mockQueueUpdate.mockRejectedValueOnce(new Error('redis is down'));
+
+    await expect(call()).resolves.toEqual({ id: USER_ID, paddleCustomerId: null });
+
+    expect(mockSendModerationEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendModerationEmail.mock.calls[0]?.[0]).toMatchObject({
+      kind: 'account-unbanned',
+      to: 'someone@example.com',
+    });
   });
 
   /**

--- a/src/server/services/__tests__/user-identity-rename-search-index.test.ts
+++ b/src/server/services/__tests__/user-identity-rename-search-index.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A MODERATOR-FORCED RENAME HAS TO REACH USER SEARCH.
+ *
+ * Nothing else takes it there. The incremental user-index sync scans on `createdAt`, so it never
+ * revisits an existing row, and the nightly reconciler only decides whether an id still belongs —
+ * it never refreshes a field. Without an explicit enqueue here, user search keeps serving the
+ * account's OLD name for as long as the document lives, which is how a renamed account goes on
+ * being found under the name it was renamed away from.
+ *
+ * The self-serve profile save has always enqueued this. This is the moderator path.
+ */
+
+const { mockDbWrite, mockCacheRefresh, mockQueueUpdate, mockInvalidateSession } = vi.hoisted(
+  () => ({
+    mockDbWrite: { user: { update: vi.fn() } },
+    mockCacheRefresh: vi.fn(async () => undefined),
+    mockQueueUpdate: vi.fn(async () => undefined),
+    mockInvalidateSession: vi.fn(async () => undefined),
+  })
+);
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbWrite, dbWrite: mockDbWrite }));
+vi.mock('~/server/redis/caches', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, userBasicCache: { refresh: mockCacheRefresh } };
+});
+vi.mock('~/server/search-index', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, usersSearchIndex: { queueUpdate: mockQueueUpdate } };
+});
+vi.mock('~/server/auth/session-invalidation', () => ({
+  invalidateSession: mockInvalidateSession,
+}));
+
+const { forceUpdateUserIdentity } = await import('~/server/services/user.service');
+
+const USER_ID = 8317;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDbWrite.user.update.mockResolvedValue({ id: USER_ID });
+});
+
+describe('forceUpdateUserIdentity -> user search index', () => {
+  it('enqueues a search-index refresh when a moderator changes the username', async () => {
+    await forceUpdateUserIdentity({ userId: USER_ID, username: 'renamed-by-a-moderator' });
+
+    expect(mockQueueUpdate).toHaveBeenCalledTimes(1);
+    const [items] = mockQueueUpdate.mock.calls[0] as unknown as [
+      Array<{ id: number; action: string }>
+    ];
+    expect(items).toEqual([{ id: USER_ID, action: 'Update' }]);
+  });
+
+  it('enqueues a refresh when the display name changes', async () => {
+    await forceUpdateUserIdentity({ userId: USER_ID, name: 'New Display Name' });
+
+    expect(mockQueueUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The negative half. Without it, a mutant that enqueues unconditionally passes both tests
+   * above, and an email-only correction would churn the index for nothing.
+   */
+  it('does NOT enqueue when only the email changes — no searchable field moved', async () => {
+    await forceUpdateUserIdentity({ userId: USER_ID, email: 'new@example.com' });
+
+    expect(mockDbWrite.user.update).toHaveBeenCalledTimes(1);
+    expect(mockQueueUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does nothing at all when there is nothing to change', async () => {
+    await expect(forceUpdateUserIdentity({ userId: USER_ID })).resolves.toEqual({
+      updated: false,
+    });
+    expect(mockDbWrite.user.update).not.toHaveBeenCalled();
+    expect(mockQueueUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/user-identity-rename-search-index.test.ts
+++ b/src/server/services/__tests__/user-identity-rename-search-index.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
 
 /**
  * A MODERATOR-FORCED RENAME HAS TO REACH USER SEARCH.
@@ -12,16 +13,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * The self-serve profile save has always enqueued this. This is the moderator path.
  */
 
-const { mockDbWrite, mockCacheRefresh, mockQueueUpdate, mockInvalidateSession } = vi.hoisted(
-  () => ({
-    mockDbWrite: { user: { update: vi.fn() } },
-    mockCacheRefresh: vi.fn(async () => undefined),
-    mockQueueUpdate: vi.fn(async () => undefined),
-    mockInvalidateSession: vi.fn(async () => undefined),
-  })
-);
+const { mockCacheRefresh, mockQueueUpdate, mockInvalidateSession } = vi.hoisted(() => ({
+  mockCacheRefresh: vi.fn(async () => undefined),
+  mockQueueUpdate: vi.fn(async () => undefined),
+  mockInvalidateSession: vi.fn(async () => undefined),
+}));
 
-vi.mock('~/server/db/client', () => ({ dbRead: mockDbWrite, dbWrite: mockDbWrite }));
 vi.mock('~/server/redis/caches', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return { ...actual, userBasicCache: { refresh: mockCacheRefresh } };
@@ -38,9 +35,12 @@ const { forceUpdateUserIdentity } = await import('~/server/services/user.service
 
 const USER_ID = 8317;
 
+/** The moderator write goes to the PRIMARY. */
+const userUpdate = dbMock.dbWrite.user.update;
+
 beforeEach(() => {
   vi.clearAllMocks();
-  mockDbWrite.user.update.mockResolvedValue({ id: USER_ID });
+  userUpdate.mockResolvedValue({ id: USER_ID });
 });
 
 describe('forceUpdateUserIdentity -> user search index', () => {
@@ -67,7 +67,7 @@ describe('forceUpdateUserIdentity -> user search index', () => {
   it('does NOT enqueue when only the email changes — no searchable field moved', async () => {
     await forceUpdateUserIdentity({ userId: USER_ID, email: 'new@example.com' });
 
-    expect(mockDbWrite.user.update).toHaveBeenCalledTimes(1);
+    expect(userUpdate).toHaveBeenCalledTimes(1);
     expect(mockQueueUpdate).not.toHaveBeenCalled();
   });
 
@@ -75,7 +75,7 @@ describe('forceUpdateUserIdentity -> user search index', () => {
     await expect(forceUpdateUserIdentity({ userId: USER_ID })).resolves.toEqual({
       updated: false,
     });
-    expect(mockDbWrite.user.update).not.toHaveBeenCalled();
+    expect(userUpdate).not.toHaveBeenCalled();
     expect(mockQueueUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/user-identity-rename-search-index.test.ts
+++ b/src/server/services/__tests__/user-identity-rename-search-index.test.ts
@@ -71,6 +71,23 @@ describe('forceUpdateUserIdentity -> user search index', () => {
     expect(mockQueueUpdate).not.toHaveBeenCalled();
   });
 
+  /**
+   * 🔴 A REDIS BLIP MUST NOT BREAK THE RENAME. `queueUpdate` is a Redis write and the rename has
+   * already committed by the time it runs; unguarded, its rejection propagates BEFORE
+   * `invalidateSession`, so the account is renamed and its old session stays live while the
+   * moderator sees a 500. A stale search document is by far the smaller failure.
+   */
+  it('survives a failing search-index enqueue and still invalidates the session', async () => {
+    mockQueueUpdate.mockRejectedValueOnce(new Error('redis is down'));
+
+    await expect(
+      forceUpdateUserIdentity({ userId: USER_ID, username: 'renamed-anyway' })
+    ).resolves.toEqual({ updated: true, user: { id: USER_ID } });
+
+    // The step that used to be skipped by the unguarded throw.
+    expect(mockInvalidateSession).toHaveBeenCalledWith(USER_ID, 'moderation');
+  });
+
   it('does nothing at all when there is nothing to change', async () => {
     await expect(forceUpdateUserIdentity({ userId: USER_ID })).resolves.toEqual({
       updated: false,

--- a/src/server/services/blocks/__tests__/app-collaborator.screen-targets.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.screen-targets.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * SCREENING THE INVITE PICKER'S CANDIDATES.
+ *
+ * The picker's candidate list comes out of user search, which serves cached documents. This is
+ * the call that lets the picker stop offering accounts the invite would refuse, WITHOUT asking
+ * the search index anything — which is the whole point, since the search index is the thing
+ * that can be wrong.
+ */
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    user: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/services/blocks/app-repo-access', () => ({
+  grantAppRepoWrite: vi.fn(async () => undefined),
+  revokeAppRepoWrite: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/blocks/app-collaborator-notify', () => ({
+  notifyAppCollaborator: vi.fn(async () => undefined),
+}));
+
+const { getIneligibleCollaboratorTargets } = await import(
+  '~/server/services/blocks/app-collaborator.service'
+);
+
+/** Ids chosen pairwise-distinct, and distinct from every count this file asserts. */
+const FINE = 4101;
+const BANNED = 4102;
+const SOFT_DELETED = 4103;
+const MISSING = 4104;
+const ALSO_FINE = 4105;
+
+const BAN_DATE = new Date('2026-03-04T05:06:07.000Z');
+const DELETE_DATE = new Date('2026-05-06T07:08:09.000Z');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.user.findMany.mockImplementation(async (args: any) => {
+    const asked: number[] = args?.where?.id?.in ?? [];
+    const rows = [
+      { id: FINE, bannedAt: null, deletedAt: null },
+      { id: ALSO_FINE, bannedAt: null, deletedAt: null },
+      { id: BANNED, bannedAt: BAN_DATE, deletedAt: null },
+      { id: SOFT_DELETED, bannedAt: null, deletedAt: DELETE_DATE },
+    ];
+    return rows.filter((r) => asked.includes(r.id));
+  });
+});
+
+describe('getIneligibleCollaboratorTargets', () => {
+  /**
+   * The pair. The `not.toContain` half alone is walked by a mutant that returns `[]` for
+   * everything; the `toContain` half is what makes that mutant die.
+   */
+  it('names the banned account and does NOT name the accounts that are fine', async () => {
+    const result = await getIneligibleCollaboratorTargets({
+      userIds: [FINE, BANNED, ALSO_FINE],
+    });
+
+    expect(result).toContain(BANNED);
+    expect(result).not.toContain(FINE);
+    expect(result).not.toContain(ALSO_FINE);
+    expect(result).toHaveLength(1);
+  });
+
+  it('names a soft-deleted account too', async () => {
+    const result = await getIneligibleCollaboratorTargets({ userIds: [FINE, SOFT_DELETED] });
+    expect(result).toEqual([SOFT_DELETED]);
+  });
+
+  /**
+   * FAILS CLOSED on an id with no row. A search document can outlive the account it describes,
+   * and "we found nothing, so it must be fine" is precisely the wrong reading of that.
+   */
+  it('names an id that has no account row at all', async () => {
+    const result = await getIneligibleCollaboratorTargets({ userIds: [FINE, MISSING] });
+    expect(result).toEqual([MISSING]);
+  });
+
+  it('returns nothing when every candidate is fine', async () => {
+    await expect(
+      getIneligibleCollaboratorTargets({ userIds: [FINE, ALSO_FINE] })
+    ).resolves.toEqual([]);
+  });
+
+  it('does not query at all for an empty candidate list', async () => {
+    await expect(getIneligibleCollaboratorTargets({ userIds: [] })).resolves.toEqual([]);
+    expect(mockDb.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it('asks about each id once even when the picker repeats one', async () => {
+    await getIneligibleCollaboratorTargets({ userIds: [FINE, FINE, BANNED, BANNED] });
+    const asked = (mockDb.user.findMany.mock.calls[0]?.[0] as any)?.where?.id?.in;
+    expect(asked).toEqual([FINE, BANNED]);
+  });
+
+  /**
+   * It must not read a ban state out of anything cached. The only table it may consult is the
+   * account table itself — this pins that the read happens, and against `user`.
+   */
+  it('reads the account rows themselves', async () => {
+    await getIneligibleCollaboratorTargets({ userIds: [BANNED] });
+    expect(mockDb.user.findMany).toHaveBeenCalledTimes(1);
+    const args = mockDb.user.findMany.mock.calls[0]?.[0] as any;
+    expect(args.select).toMatchObject({ bannedAt: true, deletedAt: true });
+  });
+});

--- a/src/server/services/blocks/__tests__/app-collaborator.screen-targets.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.screen-targets.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
 
 /**
  * SCREENING THE INVITE PICKER'S CANDIDATES.
@@ -9,15 +10,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * that can be wrong.
  */
 
-const { mockDb } = vi.hoisted(() => ({
-  mockDb: {
-    user: {
-      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
-    },
-  },
-}));
-
-vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
 vi.mock('~/server/services/blocks/app-repo-access', () => ({
   grantAppRepoWrite: vi.fn(async () => undefined),
   revokeAppRepoWrite: vi.fn(async () => undefined),
@@ -40,9 +32,12 @@ const ALSO_FINE = 4105;
 const BAN_DATE = new Date('2026-03-04T05:06:07.000Z');
 const DELETE_DATE = new Date('2026-05-06T07:08:09.000Z');
 
+/** `getIneligibleCollaboratorTargets` must read the REPLICA — naming it here proves which. */
+const findMany = dbMock.dbRead.user.findMany;
+
 beforeEach(() => {
   vi.clearAllMocks();
-  mockDb.user.findMany.mockImplementation(async (args: any) => {
+  findMany.mockImplementation(async (args: any) => {
     const asked: number[] = args?.where?.id?.in ?? [];
     const rows = [
       { id: FINE, bannedAt: null, deletedAt: null },
@@ -92,12 +87,12 @@ describe('getIneligibleCollaboratorTargets', () => {
 
   it('does not query at all for an empty candidate list', async () => {
     await expect(getIneligibleCollaboratorTargets({ userIds: [] })).resolves.toEqual([]);
-    expect(mockDb.user.findMany).not.toHaveBeenCalled();
+    expect(findMany).not.toHaveBeenCalled();
   });
 
   it('asks about each id once even when the picker repeats one', async () => {
     await getIneligibleCollaboratorTargets({ userIds: [FINE, FINE, BANNED, BANNED] });
-    const asked = (mockDb.user.findMany.mock.calls[0]?.[0] as any)?.where?.id?.in;
+    const asked = (findMany.mock.calls[0]?.[0] as any)?.where?.id?.in;
     expect(asked).toEqual([FINE, BANNED]);
   });
 
@@ -107,8 +102,8 @@ describe('getIneligibleCollaboratorTargets', () => {
    */
   it('reads the account rows themselves', async () => {
     await getIneligibleCollaboratorTargets({ userIds: [BANNED] });
-    expect(mockDb.user.findMany).toHaveBeenCalledTimes(1);
-    const args = mockDb.user.findMany.mock.calls[0]?.[0] as any;
+    expect(findMany).toHaveBeenCalledTimes(1);
+    const args = findMany.mock.calls[0]?.[0] as any;
     expect(args.select).toMatchObject({ bannedAt: true, deletedAt: true });
   });
 });

--- a/src/server/services/blocks/__tests__/app-collaborator.screen-targets.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.screen-targets.test.ts
@@ -85,9 +85,9 @@ describe('getIneligibleCollaboratorTargets', () => {
   });
 
   it('returns nothing when every candidate is fine', async () => {
-    await expect(
-      getIneligibleCollaboratorTargets({ userIds: [FINE, ALSO_FINE] })
-    ).resolves.toEqual([]);
+    await expect(getIneligibleCollaboratorTargets({ userIds: [FINE, ALSO_FINE] })).resolves.toEqual(
+      []
+    );
   });
 
   it('does not query at all for an empty candidate list', async () => {

--- a/src/server/services/blocks/__tests__/app-collaborator.screen-targets.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.screen-targets.test.ts
@@ -18,7 +18,7 @@ vi.mock('~/server/services/blocks/app-collaborator-notify', () => ({
   notifyAppCollaborator: vi.fn(async () => undefined),
 }));
 
-const { getIneligibleCollaboratorTargets } = await import(
+const { getIneligibleCollaboratorTargets, AppCollaboratorError } = await import(
   '~/server/services/blocks/app-collaborator.service'
 );
 
@@ -29,14 +29,31 @@ const SOFT_DELETED = 4103;
 const MISSING = 4104;
 const ALSO_FINE = 4105;
 
+const OWNER = 4200;
+const STRANGER = 4201;
+const LISTING = 'apl_screen';
+
 const BAN_DATE = new Date('2026-03-04T05:06:07.000Z');
 const DELETE_DATE = new Date('2026-05-06T07:08:09.000Z');
 
-/** `getIneligibleCollaboratorTargets` must read the REPLICA — naming it here proves which. */
+/** `getIneligibleCollaboratorTargets` reads accounts off the REPLICA. */
 const findMany = dbMock.dbRead.user.findMany;
+const listingFindUnique = dbMock.dbRead.appListing.findUnique;
+
+const screen = (userIds: number[], actorUserId = OWNER) =>
+  getIneligibleCollaboratorTargets({ appListingId: LISTING, actorUserId, userIds });
 
 beforeEach(() => {
   vi.clearAllMocks();
+  listingFindUnique.mockResolvedValue({
+    id: LISTING,
+    slug: 'a-listing',
+    kind: 'onsite',
+    userId: OWNER,
+    appBlockId: null,
+    revisionOfId: null,
+    appBlock: null,
+  });
   findMany.mockImplementation(async (args: any) => {
     const asked: number[] = args?.where?.id?.in ?? [];
     const rows = [
@@ -55,9 +72,7 @@ describe('getIneligibleCollaboratorTargets', () => {
    * everything; the `toContain` half is what makes that mutant die.
    */
   it('names the banned account and does NOT name the accounts that are fine', async () => {
-    const result = await getIneligibleCollaboratorTargets({
-      userIds: [FINE, BANNED, ALSO_FINE],
-    });
+    const result = await screen([FINE, BANNED, ALSO_FINE]);
 
     expect(result).toContain(BANNED);
     expect(result).not.toContain(FINE);
@@ -66,8 +81,7 @@ describe('getIneligibleCollaboratorTargets', () => {
   });
 
   it('names a soft-deleted account too', async () => {
-    const result = await getIneligibleCollaboratorTargets({ userIds: [FINE, SOFT_DELETED] });
-    expect(result).toEqual([SOFT_DELETED]);
+    await expect(screen([FINE, SOFT_DELETED])).resolves.toEqual([SOFT_DELETED]);
   });
 
   /**
@@ -75,35 +89,58 @@ describe('getIneligibleCollaboratorTargets', () => {
    * and "we found nothing, so it must be fine" is precisely the wrong reading of that.
    */
   it('names an id that has no account row at all', async () => {
-    const result = await getIneligibleCollaboratorTargets({ userIds: [FINE, MISSING] });
-    expect(result).toEqual([MISSING]);
+    await expect(screen([FINE, MISSING])).resolves.toEqual([MISSING]);
   });
 
   it('returns nothing when every candidate is fine', async () => {
-    await expect(getIneligibleCollaboratorTargets({ userIds: [FINE, ALSO_FINE] })).resolves.toEqual(
-      []
-    );
+    await expect(screen([FINE, ALSO_FINE])).resolves.toEqual([]);
   });
 
   it('does not query at all for an empty candidate list', async () => {
-    await expect(getIneligibleCollaboratorTargets({ userIds: [] })).resolves.toEqual([]);
+    await expect(screen([])).resolves.toEqual([]);
     expect(findMany).not.toHaveBeenCalled();
   });
 
   it('asks about each id once even when the picker repeats one', async () => {
-    await getIneligibleCollaboratorTargets({ userIds: [FINE, FINE, BANNED, BANNED] });
+    await screen([FINE, FINE, BANNED, BANNED]);
     const asked = (findMany.mock.calls[0]?.[0] as any)?.where?.id?.in;
     expect(asked).toEqual([FINE, BANNED]);
   });
 
   /**
-   * It must not read a ban state out of anything cached. The only table it may consult is the
-   * account table itself — this pins that the read happens, and against `user`.
+   * It must not read a ban state out of anything cached. The only table it may consult for that
+   * is the account table itself — this pins that the read happens, and against `user`.
    */
   it('reads the account rows themselves', async () => {
-    await getIneligibleCollaboratorTargets({ userIds: [BANNED] });
+    await screen([BANNED]);
     expect(findMany).toHaveBeenCalledTimes(1);
     const args = findMany.mock.calls[0]?.[0] as any;
     expect(args.select).toMatchObject({ bannedAt: true, deletedAt: true });
+  });
+
+  describe('it is keyed to a listing the caller owns', () => {
+    /**
+     * 🔴 The refusal, and the ORDER of it: ownership is asserted BEFORE any account is read, so
+     * a non-owner cannot learn anything about the ids they asked about — not even by timing.
+     */
+    it('refuses a caller who does not own the listing, without reading any account', async () => {
+      await expect(screen([FINE, BANNED], STRANGER)).rejects.toBeInstanceOf(AppCollaboratorError);
+      expect(findMany).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the listing does not exist', async () => {
+      listingFindUnique.mockResolvedValue(null);
+      await expect(screen([FINE])).rejects.toBeInstanceOf(AppCollaboratorError);
+      expect(findMany).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The presence half of both refusals above: without it, a mutant that throws for EVERY
+     * caller passes them while making the picker permanently unscreened.
+     */
+    it('…and the owner still gets an answer', async () => {
+      await expect(screen([FINE, BANNED])).resolves.toEqual([BANNED]);
+      expect(findMany).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
@@ -454,6 +454,30 @@ describe('inviteCollaborator', () => {
   });
 
   /**
+   * 🔴 THE GUARD AND ITS DATA SOURCE, PINNED TOGETHER. Prisma's `select` is EXCLUSIVE: narrow it
+   * back to `{ id, bannedAt }` and `target.deletedAt` is `undefined` in production, so the branch
+   * above is dead — while every test here still passes, because the mock answers the same object
+   * whatever is selected. Guard text present, data source dead, suite green; the same shape that
+   * walked two earlier guards in this change. `app-collaborator.screen-targets.test.ts` pins the
+   * screening side's `select` for the identical reason, so the two sides stay symmetric.
+   */
+  it('🔴 …and it SELECTS the columns those two refusals read', async () => {
+    mockDb.user.findUnique.mockResolvedValue({ id: TARGET, bannedAt: null, deletedAt: null });
+    await inviteCollaborator({
+      appListingId: LISTING,
+      targetUserId: TARGET,
+      actorUserId: OWNER,
+      now: NOW,
+    });
+
+    const call = mockDb.user.findUnique.mock.calls.find(
+      (c: unknown[]) => (c[0] as any)?.where?.id === TARGET
+    );
+    expect(call, 'the invite never looked the target account up').toBeDefined();
+    expect((call![0] as any).select).toMatchObject({ bannedAt: true, deletedAt: true });
+  });
+
+  /**
    * The presence half of both refusals: a live account with neither flag IS seatable. Without
    * it, a mutant refusing every target passes the ban and soft-delete cases above.
    */

--- a/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
@@ -429,6 +429,45 @@ describe('inviteCollaborator', () => {
     expect(mockDb.appCollaborator.upsert).not.toHaveBeenCalled();
   });
 
+  /**
+   * 🔴 The enforcement point and the picker's screening call must refuse the SAME set. The
+   * screen rejected banned, soft-deleted and missing while this selected only `{id, bannedAt}`
+   * and let a soft-deleted account through — so the two disagreed and a comment claimed they
+   * did not. Refused as NOT FOUND, not as a ban: to anyone outside moderation the account is
+   * gone, and a distinct refusal would disclose that it exists.
+   */
+  it('🔴 a SOFT-DELETED target cannot be seated either, and reads as not-found', async () => {
+    mockDb.user.findUnique.mockResolvedValue({
+      id: TARGET,
+      bannedAt: null,
+      deletedAt: new Date(),
+    });
+    await expect(
+      inviteCollaborator({
+        appListingId: LISTING,
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+        now: NOW,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_TARGET' });
+    expect(mockDb.appCollaborator.upsert).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The presence half of both refusals: a live account with neither flag IS seatable. Without
+   * it, a mutant refusing every target passes the ban and soft-delete cases above.
+   */
+  it('…while a live target with neither flag is seated', async () => {
+    mockDb.user.findUnique.mockResolvedValue({ id: TARGET, bannedAt: null, deletedAt: null });
+    await inviteCollaborator({
+      appListingId: LISTING,
+      targetUserId: TARGET,
+      actorUserId: OWNER,
+      now: NOW,
+    });
+    expect(mockDb.appCollaborator.upsert).toHaveBeenCalledTimes(1);
+  });
+
   it('re-inviting an ALREADY ACCEPTED collaborator is ALREADY_SEATED', async () => {
     mockDb.appCollaborator.findUnique.mockResolvedValue({
       status: 'accepted',

--- a/src/server/services/blocks/app-collaborator.service.ts
+++ b/src/server/services/blocks/app-collaborator.service.ts
@@ -324,33 +324,6 @@ export type InviteCollaboratorResult = {
 };
 
 /**
- * OWNER: invite a user to an editor seat.
- *
- * Idempotent. A repeat invite for a standing `pending` row does NOT reset the row; it
- * only (throttled) re-notifies. A repeat invite for an `accepted` row is
- * ALREADY_SEATED. A repeat invite for a `rejected` row RE-OPENS it as `pending` —
- * declining is not permanent, and the invitee must consent again.
- *
- * 🔴 A SHADOW REVISION IS REFUSED OUTRIGHT — the seat-creation half of the
- * parent-only invariant. Silently hopping to the parent here would be *safe* but
- * *wrong to teach*: an owner who thinks they are seating "the revision" would be
- * seating the live listing, and the UI would have to explain a hop the product does
- * not have. Refusing names the truth: collaborators are a property of the LISTING.
- * The other direction — a seat that landed on a shadow being destroyed by
- * `applyApprovedRevision`'s CASCADE delete — is what makes this a safety guard and not
- * a nicety.
- *
- * 🔴 BAN POLICY (decided, and applied consistently across this feature): a BANNED user
- * may neither be invited nor accept. Rationale: on an on-site listing a seat grants
- * Forgejo `write` on the app repo plus visibility of the app's earnings, and
- * `getMyAppRepo` already refuses to issue a push credential to a banned account
- * (`blocks.router.ts:5579`). Seating a banned user would mint exactly the credential
- * that gate exists to withhold. An EXISTING seat is NOT auto-revoked on ban (that
- * would need a ban-hook this PR does not add) — but every capability the seat unlocks
- * re-checks `bannedAt` at the proc, so a banned editor can hold an inert row and do
- * nothing with it.
- */
-/**
  * Of the supplied ids, the ones that CANNOT hold a collaborator seat right now.
  *
  * 🔴 THE POINT OF THIS FUNCTION IS THAT IT DOES NOT READ THE SEARCH INDEX. The invite picker's
@@ -360,17 +333,32 @@ export type InviteCollaboratorResult = {
  * from the fact that search returned it. This reads the account rows themselves and hands back
  * the ids the invite mutation is going to refuse, so the picker can stop offering them.
  *
- * It is DEFENCE IN DEPTH, never the enforcement point: `inviteCollaborator` re-checks
- * `bannedAt` on the actual invite and is what makes the grant impossible. This exists so the
- * user is not offered a choice the server will reject, and so a stale search document cannot
- * put an ineligible account in front of an owner as a plausible one.
+ * It is DEFENCE IN DEPTH, never the enforcement point: `inviteCollaborator` re-checks the same
+ * state on the actual invite and is what makes the grant impossible. This exists so the user is
+ * not offered a choice the server will reject, and so a stale search document cannot put an
+ * ineligible account in front of an owner as a plausible one.
+ *
+ * 🔴 THE TWO SIDES REFUSE THE SAME SET — banned, soft-deleted, and an id with no account row.
+ * They did NOT at first: the screen rejected all three while `inviteCollaborator` selected only
+ * `{ id, bannedAt }` and let a soft-deleted account through. Narrowing the screen to match would
+ * have been the smaller diff and would have REMOVED a protection, so the enforcement point was
+ * widened instead. Keep them aligned; a comment claiming they mirror each other is not a check.
+ *
+ * 🔴 OWNER-KEYED. It takes the listing and asserts ownership rather than answering about
+ * arbitrary ids, so it cannot be used to enumerate account state. That coupling is the point:
+ * without it, the only thing standing between this and an enumeration endpoint is who happens
+ * to hold the authoring flag today.
  *
  * Deliberately returns ONLY ids, never a reason and never anything about accounts that are
  * fine. An id the caller already had is not new information; a ban reason would be.
  */
 export async function getIneligibleCollaboratorTargets(opts: {
+  appListingId: string;
+  actorUserId: number;
   userIds: number[];
 }): Promise<number[]> {
+  await assertOwner(opts.appListingId, opts.actorUserId);
+
   const userIds = [...new Set(opts.userIds)];
   if (!userIds.length) return [];
 
@@ -389,6 +377,35 @@ export async function getIneligibleCollaboratorTargets(opts: {
   return userIds.filter((id) => !eligible.has(id));
 }
 
+/**
+ * OWNER: invite a user to an editor seat.
+ *
+ * Idempotent. A repeat invite for a standing `pending` row does NOT reset the row; it
+ * only (throttled) re-notifies. A repeat invite for an `accepted` row is
+ * ALREADY_SEATED. A repeat invite for a `rejected` row RE-OPENS it as `pending` —
+ * declining is not permanent, and the invitee must consent again.
+ *
+ * 🔴 A SHADOW REVISION IS REFUSED OUTRIGHT — the seat-creation half of the
+ * parent-only invariant. Silently hopping to the parent here would be *safe* but
+ * *wrong to teach*: an owner who thinks they are seating "the revision" would be
+ * seating the live listing, and the UI would have to explain a hop the product does
+ * not have. Refusing names the truth: collaborators are a property of the LISTING.
+ * The other direction — a seat that landed on a shadow being destroyed by
+ * `applyApprovedRevision`'s CASCADE delete — is what makes this a safety guard and not
+ * a nicety.
+ *
+ * 🔴 BAN POLICY (decided, and applied consistently across this feature): a BANNED user
+ * may neither be invited nor accept — and neither may a SOFT-DELETED one, refused as
+ * not-found so the refusal does not disclose that the account exists. Rationale: on an
+ * on-site listing a seat grants
+ * Forgejo `write` on the app repo plus visibility of the app's earnings, and
+ * `getMyAppRepo` already refuses to issue a push credential to a banned account
+ * (`blocks.router.ts:5579`). Seating a banned user would mint exactly the credential
+ * that gate exists to withhold. An EXISTING seat is NOT auto-revoked on ban (that
+ * would need a ban-hook this PR does not add) — but every capability the seat unlocks
+ * re-checks `bannedAt` at the proc, so a banned editor can hold an inert row and do
+ * nothing with it.
+ */
 export async function inviteCollaborator(opts: {
   appListingId: string;
   targetUserId: number;
@@ -421,9 +438,11 @@ export async function inviteCollaborator(opts: {
   }
   const target = await dbRead.user.findUnique({
     where: { id: opts.targetUserId },
-    select: { id: true, bannedAt: true },
+    select: { id: true, bannedAt: true, deletedAt: true },
   });
-  if (!target) {
+  // A soft-deleted account is refused as NOT FOUND rather than as a ban: to everyone outside
+  // moderation the account is gone, and saying anything else would leak that it exists.
+  if (!target || target.deletedAt) {
     throw new AppCollaboratorError('INVALID_TARGET', 'That user could not be found');
   }
   if (target.bannedAt) {

--- a/src/server/services/blocks/app-collaborator.service.ts
+++ b/src/server/services/blocks/app-collaborator.service.ts
@@ -350,6 +350,45 @@ export type InviteCollaboratorResult = {
  * re-checks `bannedAt` at the proc, so a banned editor can hold an inert row and do
  * nothing with it.
  */
+/**
+ * Of the supplied ids, the ones that CANNOT hold a collaborator seat right now.
+ *
+ * 🔴 THE POINT OF THIS FUNCTION IS THAT IT DOES NOT READ THE SEARCH INDEX. The invite picker's
+ * candidate list comes from user search, and a search document is a CACHE of an account's state
+ * at the moment it was last written — it can be stale, and the account's own name is part of
+ * what can be stale. So the picker must not be allowed to conclude "this account is fine"
+ * from the fact that search returned it. This reads the account rows themselves and hands back
+ * the ids the invite mutation is going to refuse, so the picker can stop offering them.
+ *
+ * It is DEFENCE IN DEPTH, never the enforcement point: `inviteCollaborator` re-checks
+ * `bannedAt` on the actual invite and is what makes the grant impossible. This exists so the
+ * user is not offered a choice the server will reject, and so a stale search document cannot
+ * put an ineligible account in front of an owner as a plausible one.
+ *
+ * Deliberately returns ONLY ids, never a reason and never anything about accounts that are
+ * fine. An id the caller already had is not new information; a ban reason would be.
+ */
+export async function getIneligibleCollaboratorTargets(opts: {
+  userIds: number[];
+}): Promise<number[]> {
+  const userIds = [...new Set(opts.userIds)];
+  if (!userIds.length) return [];
+
+  const rows = await dbRead.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, bannedAt: true, deletedAt: true },
+  });
+
+  const eligible = new Set(
+    rows.filter((r) => r.bannedAt == null && r.deletedAt == null).map((r) => r.id)
+  );
+
+  // Anything we did not positively confirm eligible comes back as ineligible — including an id
+  // with no row at all. A search hit whose account no longer exists is exactly the shape this
+  // is here to catch, and treating "not found" as fine would fail open on it.
+  return userIds.filter((id) => !eligible.has(id));
+}
+
 export async function inviteCollaborator(opts: {
   appListingId: string;
   targetUserId: number;

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -588,6 +588,14 @@ export async function forceUpdateUserIdentity({
 
   if (data.username !== undefined || data.name !== undefined) {
     await deleteBasicDataForUser(userId);
+    // 🔴 A moderator-forced rename has to reach the search index, and NOTHING else will take
+    // it there. The incremental user-index sync scans on `createdAt`, so it never revisits an
+    // existing row, and the nightly reconciler only checks whether an id still qualifies — it
+    // never refreshes a field. Without this enqueue the index serves the OLD username
+    // indefinitely, which is exactly how a renamed account keeps being found (and acted on by
+    // id) under the name it was renamed away from. The self-serve profile save has always
+    // enqueued this; the moderator path did not.
+    await usersSearchIndex.queueUpdate([{ id: userId, action: SearchIndexUpdateQueueAction.Update }]);
   }
 
   const { invalidateSession } = await import('~/server/auth/session-invalidation');
@@ -1973,6 +1981,12 @@ export const toggleBan = async ({
     await reinstateSubscription({ userId: id }).catch((error) =>
       logToAxiom({ name: 'reinstate-stripe-subscription', type: 'error', message: error.message })
     );
+
+    // 🔴 Put the account BACK in user search. Ban removes the document, and nothing else ever
+    // re-adds it: the incremental sync's range scan keys on `createdAt`, so an existing row is
+    // never re-pulled, and the reconciler only deletes. Without this, a lifted ban leaves the
+    // account permanently unfindable — a one-way door.
+    await usersSearchIndex.queueUpdate([{ id, action: SearchIndexUpdateQueueAction.Update }]);
   }
 
   // Notify the user by email of the ban/unban decision. Skip the admin

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -595,7 +595,9 @@ export async function forceUpdateUserIdentity({
     // indefinitely, which is exactly how a renamed account keeps being found (and acted on by
     // id) under the name it was renamed away from. The self-serve profile save has always
     // enqueued this; the moderator path did not.
-    await usersSearchIndex.queueUpdate([{ id: userId, action: SearchIndexUpdateQueueAction.Update }]);
+    await usersSearchIndex.queueUpdate([
+      { id: userId, action: SearchIndexUpdateQueueAction.Update },
+    ]);
   }
 
   const { invalidateSession } = await import('~/server/auth/session-invalidation');

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -595,9 +595,20 @@ export async function forceUpdateUserIdentity({
     // indefinitely, which is exactly how a renamed account keeps being found (and acted on by
     // id) under the name it was renamed away from. The self-serve profile save has always
     // enqueued this; the moderator path did not.
-    await usersSearchIndex.queueUpdate([
-      { id: userId, action: SearchIndexUpdateQueueAction.Update },
-    ]);
+    // 🔴 NEVER LET THE ENQUEUE BREAK THE RENAME. It is a Redis write, and the rename has
+    // already committed by the time it runs — a blip would throw here, BEFORE
+    // `invalidateSession` below, leaving the account renamed with its old session still live
+    // while the moderator sees a 500. Every other side effect in this file is isolated the
+    // same way; a stale search document is the smallest of the failures available here.
+    await usersSearchIndex
+      .queueUpdate([{ id: userId, action: SearchIndexUpdateQueueAction.Update }])
+      .catch((error) =>
+        logToAxiom({
+          type: 'error',
+          name: 'force-update-identity-search-index',
+          message: (error as Error).message,
+        })
+      );
   }
 
   const { invalidateSession } = await import('~/server/auth/session-invalidation');
@@ -1988,7 +1999,18 @@ export const toggleBan = async ({
     // re-adds it: the incremental sync's range scan keys on `createdAt`, so an existing row is
     // never re-pulled, and the reconciler only deletes. Without this, a lifted ban leaves the
     // account permanently unfindable — a one-way door.
-    await usersSearchIndex.queueUpdate([{ id, action: SearchIndexUpdateQueueAction.Update }]);
+    // Isolated for the same reason as the rename path: the unban has already committed, and an
+    // unguarded throw here would skip the `account-unbanned` email below and hand the moderator
+    // a 500 for an action that succeeded.
+    await usersSearchIndex
+      .queueUpdate([{ id, action: SearchIndexUpdateQueueAction.Update }])
+      .catch((error) =>
+        logToAxiom({
+          type: 'error',
+          name: 'unban-user-search-index',
+          message: (error as Error).message,
+        })
+      );
   }
 
   // Notify the user by email of the ban/unban decision. Skip the admin

--- a/src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx
+++ b/src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx
@@ -189,6 +189,10 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
         getPendingTransfer: {
           useQuery: () => ({ data: state.pendingTransfer, isLoading: false, error: null }),
         },
+        // The invite picker screens the candidates it is offering against the server. Nothing
+        // here exercises that answer — these cases are about transfer — but the panel calls it
+        // on every render, so an absent entry renders the whole tab as an empty <div>.
+        ineligibleTargets: { useQuery: () => ({ data: [], isLoading: false, error: null }) },
         invite: mutation(),
         remove: mutation(),
         setDisplayed: mutation(),


### PR DESCRIPTION
## The problem

A banned account could stay in the user search index indefinitely, and could stay there under the username it had **before** a moderator renamed it. So a moderation action was invisible to every surface that reads user search — public user search, and any picker built on it.

That matters most where a search result is acted on **by id**: the app-listing collaborator invite picker submits the id of the row you choose, so an account that search is describing incorrectly is an account you can pick incorrectly.

## Root cause — two independent mechanisms, both real

**1. Nothing removed a banned account from the index, and things put it back.**
The predicate deciding who belongs in the user index was `id != -1 AND deletedAt IS NULL` — no ban condition — in both the indexer (`users.search-index.ts`) and the nightly reconciler (`meilisearch/cleanup.ts`). Ban does enqueue a filtered removal, but the user-metrics refresh enqueues a search-index update for **every** account whose counters moved, and that update re-indexed a banned account straight back in. A full rebuild did the same.

**2. A moderator-forced rename never reached the index.**
`forceUpdateUserIdentity` writes the new username and enqueues nothing. The incremental sync's range scan keys on **`createdAt`**, so it never revisits an existing row, and the nightly reconciler only decides whether an id still qualifies — it never refreshes a field. So the index kept serving the old name for as long as the document lived. The self-serve profile save has always enqueued an update; the moderator path did not.

Both were confirmed by reading the code paths, not inferred from the symptom.

## What changed

### Index membership
- One shared eligibility predicate (`search-index/user-index-eligibility.ts`), now including `bannedAt IS NULL`, used by **both** the indexer and the nightly reconciler. Both halves are load-bearing: the write-side filter alone leaves an already-indexed account there forever, and the reconciler-side filter alone is undone by the next metrics-driven update. The reconciler half is what evicts documents that are already there, with no manual reindex.
- A moderator-forced username/display-name change now enqueues a search-index refresh.
- Lifting a ban re-adds the account to search, so the exclusion is not a one-way door.
- Both of those enqueues are Redis writes that run *after* their transaction has committed and *before* a later step (session invalidation; the unban email), so they are isolated like every other side effect in that file — a Redis blip cannot skip the step after them or fail an action that already succeeded.

### Collaborator invite picker
- The picker's candidates come from user search, i.e. from cached documents, so it must not conclude anything about an account from the fact that search returned it. The panel now screens the ids it is offering against the account rows themselves (`appCollaborators.ineligibleTargets`) and stops offering the ones a seat would be refused for. Ineligibility outranks every roster reason, including the re-invitable declined seat, and an id with no account row at all is treated as ineligible rather than fine.
- That screening call is keyed to a listing the caller **owns** and is rate-limited, so it cannot become an account-state enumeration surface if the authoring audience widens. Only owners are shown the picker, so only owners issue it.
- `inviteCollaborator` now refuses a **soft-deleted** target as well as a banned one, as not-found. The screen and the enforcement point previously disagreed about that set while a comment claimed they matched; the enforcement point was widened rather than the screen narrowed, so no protection was removed.
- `QuickSearchDropdown` gains one optional, inert-by-default `onHits` prop. No other call site changes behaviour.
- **Defence in depth only.** `inviteCollaborator` remains the enforcement point that makes the grant impossible.

## Tests

New coverage, each shown failing on pre-change code:

| test file | at base | at HEAD |
|---|---|---|
| `search-index/__tests__/user-index-eligibility.test.ts` | fails to load (module absent) | 10 pass |
| `services/blocks/__tests__/app-collaborator.screen-targets.test.ts` | 7 fail (function absent) | 10 pass |
| `services/__tests__/user-identity-rename-search-index.test.ts` | 2 fail, 2 pass | 5 pass |
| `services/__tests__/toggle-ban-search-index.test.ts` | 1 fail, 1 pass | 3 pass |
| `components/Apps/AppCollaboratorsPanel.browser.test.tsx` | new file — the seam did not exist | 6 pass |
| `components/Search/QuickSearchDropdown.onHits.browser.test.tsx` | new file | 2 pass |
| `AppCollaboratorsPanelView.browser.test.tsx` (+5) | 3 fail, 2 pass | 35 pass |
| `app-collaborator.service.test.ts` (+2, soft-delete) | 1 fail, 1 pass | 116 pass |

Base-passing tests are labelled in-file as invariant guards rather than counted as regression coverage.

### Mutation testing

An adversarial review found **two survivors** in the first round, both with the guard's own text still present, which is why the assertions here are shaped the way they are:

- the write side was pinned by the **name** of a constant while a local alias was what the queries actually consumed — re-binding the alias dropped the ban clause from every write-side query, suite green. There is now one name, it is a function, and the tests drive the real query builders and pin the SQL that reaches the driver.
- the reconciler assertion used `toContain`, which any statement that merely *mentions* the clause satisfies — widening the predicate to `(<eligibility> OR bannedAt IS NOT NULL)` made it keep every banned document, suite green. Now pinned whole with `toBe`.

Both are killed now, and the sweep was re-derived from the expression's semantic failure modes (re-bind, clause-preserving inversion, operand inversion, comment-out, argument drop, half-fix, refuse-everything) rather than from deletion alone. Every absence assertion is paired with a presence assertion.

`tsc -p tsconfig.tests.json`: no new errors attributable to this branch.

## Not covered

- The `role === 'owner'` half of the screening query's `enabled` condition is redundant with the `ids.length > 0` half — an editor is never shown the picker, so the id set is always empty for them. It states intent and is defence in depth; it has no independently-killing mutation, and that is deliberate rather than an oversight.
- Removing already-indexed banned accounts happens on the nightly reconciler pass; nothing here was run against a live index.
