### PR TITLE
fix(account-switcher): stop the device-account set overwriting the signed-in user's roster entry

### DIFF
--- a/src/components/CivitaiWrapped/AccountProvider.deviceRoster.browser.test.tsx
+++ b/src/components/CivitaiWrapped/AccountProvider.deviceRoster.browser.test.tsx
@@ -1,0 +1,234 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { AccountProvider, useAccountContext } from '~/components/CivitaiWrapped/AccountProvider';
+import { SessionProvider } from '~/providers/SessionProvider';
+import type { Session } from '~/types/session';
+
+/**
+ * ACCOUNT-SWITCHER ROSTER vs. THE HUB DEVICE SET (issue #4265).
+ *
+ * 🔴 THE DEFECT THIS SUITE EXISTS FOR. The roster-upsert effect upserts the SESSION user first and then loops
+ * over `deviceAccounts`, but `upsert` compares each candidate against `prev` — the state the effect started
+ * from — not against the `next` accumulator it is building. So when both branches touch the SAME id (the
+ * signed-in user is also linked on this device) the loop, running second, wins regardless of which value is
+ * fresher. The hub device set is a cache: right after a profile-picture change it can still be serving the
+ * PREVIOUS avatar url, and changing a picture hard-deletes the old image, so the loop restores a url that
+ * 404s. The fix makes the session authoritative for its own id and skips that id in the loop.
+ *
+ * This path is structurally invisible to `AccountProvider.browser.test.tsx`'s fixture, which uses
+ * `accounts: []` — the dominant production shape. Everything here needs a NON-EMPTY device set that
+ * CONTAINS the current user, which is why it lives in its own file.
+ *
+ * The load-bearing control in every case is `SIBLING_ID`: asserting that a second, non-current device account
+ * DID reach the roster proves the device payload actually landed and the loop still runs. Without it, "the
+ * avatar stayed fresh" would be indistinguishable from the device query never having resolved at all.
+ */
+
+const USER_ID = 4242;
+const SIBLING_ID = 777;
+const ROSTER_KEY = 'civitai-account-roster';
+const LEGACY_ACCOUNTS_KEY = 'civitai-accounts';
+// Synthetic fixtures — never a real avatar url.
+const STALE_AVATAR = 'device-roster-test-stale-avatar.png';
+const FRESH_AVATAR = 'device-roster-test-fresh-avatar.png';
+const USERNAME = 'device-roster-test-user';
+const SIBLING_USERNAME = 'device-roster-test-sibling';
+
+type RosterEntry = { id: number; username: string; avatarUrl?: string };
+type DeviceRow = { userId: number; username?: string; image?: string };
+
+function sessionWith(image: string | undefined): Session {
+  return {
+    user: {
+      id: USER_ID,
+      username: USERNAME,
+      image,
+      showNsfw: false,
+      blurNsfw: false,
+      browsingLevel: 1,
+      onboarding: 0,
+    },
+    expires: '2999-01-01T00:00:00.000Z',
+  };
+}
+
+const jsonOk = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body } as unknown as Response);
+
+/** What the durable roster actually holds in localStorage — the thing the switcher rows render from. */
+function readRoster(): Record<string, RosterEntry> {
+  const raw = window.localStorage.getItem(ROSTER_KEY);
+  return raw ? (JSON.parse(raw) as Record<string, RosterEntry>) : {};
+}
+
+/** The hub device-set payload, swapped mid-test to model the cache moving while the avatar stays stale. */
+let deviceRows: DeviceRow[] = [];
+let accountFetches = 0;
+let probeRenders = 0;
+/** Captured from the probe so a test can force the device query to refetch past its 60s staleTime. */
+let invalidateAccounts: (() => Promise<unknown>) | null = null;
+
+function Probe() {
+  const queryClient = useQueryClient();
+  const { accounts } = useAccountContext();
+  invalidateAccounts = () => queryClient.invalidateQueries({ queryKey: ['device-accounts'] });
+  probeRenders++;
+  const entry = accounts[String(USER_ID)];
+  // Mirror what UserMenu reads off the context for a switcher row.
+  return (
+    <div
+      data-testid="probe"
+      data-avatar={entry?.avatarUrl ?? ''}
+      data-sibling={accounts[String(SIBLING_ID)]?.username ?? ''}
+    />
+  );
+}
+
+const probeAttr = (name: 'avatar' | 'sibling') =>
+  document.querySelector('[data-testid="probe"]')?.getAttribute(`data-${name}`) ?? null;
+
+function renderProvider(initial: Session) {
+  return renderWithProviders(
+    <SessionProvider session={initial} refetchOnWindowFocus={false}>
+      <AccountProvider>
+        <Probe />
+      </AccountProvider>
+    </SessionProvider>
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.removeItem(ROSTER_KEY);
+  window.localStorage.removeItem(LEGACY_ACCOUNTS_KEY);
+  accountFetches = 0;
+  probeRenders = 0;
+  invalidateAccounts = null;
+  // The hub still reports the PREVIOUS avatar for the current user — the read-after-write window.
+  deviceRows = [
+    { userId: USER_ID, username: USERNAME, image: STALE_AVATAR },
+    { userId: SIBLING_ID, username: SIBLING_USERNAME, image: undefined },
+  ];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+          ? input.href
+          : String((input as Request)?.url ?? input);
+      // The session is seeded and never refetched here — the device set is the moving part.
+      if (url.includes('/api/auth/session')) return jsonOk(sessionWith(FRESH_AVATAR));
+      if (url.includes('/api/auth/accounts')) {
+        accountFetches++;
+        return jsonOk({ accounts: deviceRows });
+      }
+      throw new Error(`unexpected fetch in AccountProvider device-roster test: ${url}`);
+    })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.localStorage.removeItem(ROSTER_KEY);
+  window.localStorage.removeItem(LEGACY_ACCOUNTS_KEY);
+});
+
+describe('AccountProvider roster — the device set must not clobber the current user', () => {
+  test('🔴 a stale device-set avatar does not overwrite the session avatar on first load', async () => {
+    // Empty roster: the session branch seeds the entry with the FRESH avatar on the first effect pass, then
+    // the device query resolves and the loop runs over the same id with the hub's STALE copy.
+    renderProvider(sessionWith(FRESH_AVATAR));
+
+    // Positive control FIRST: wait for the device payload to have landed, so the assertion below is taken
+    // AFTER the moment the loop would have clobbered — not before it.
+    await vi.waitFor(() => {
+      expect(readRoster()[String(SIBLING_ID)]?.username).toBe(SIBLING_USERNAME);
+    });
+    expect(accountFetches).toBeGreaterThan(0);
+
+    expect(readRoster()[String(USER_ID)]?.avatarUrl).toBe(FRESH_AVATAR);
+    expect(probeAttr('avatar')).toBe(FRESH_AVATAR);
+  });
+
+  test('🔴 a device payload whose identity moves while the avatar stays stale does not regress a corrected entry', async () => {
+    // Start from an ALREADY-correct roster, so the only thing that can move the avatar is the device loop.
+    window.localStorage.setItem(
+      ROSTER_KEY,
+      JSON.stringify({
+        [String(USER_ID)]: { id: USER_ID, username: USERNAME, avatarUrl: FRESH_AVATAR },
+      })
+    );
+    renderProvider(sessionWith(FRESH_AVATAR));
+
+    await vi.waitFor(() => {
+      expect(readRoster()[String(SIBLING_ID)]?.username).toBe(SIBLING_USERNAME);
+    });
+    expect(readRoster()[String(USER_ID)]?.avatarUrl).toBe(FRESH_AVATAR);
+
+    // The hub payload changes — a sibling's username updates — while the current user's avatar is STILL the
+    // deleted one. A deeply-equal payload would keep its reference (react-query structural sharing) and the
+    // effect would not re-run at all; moving a field is what makes the identity change and the effect fire.
+    const movedSiblingUsername = `${SIBLING_USERNAME}-renamed`;
+    deviceRows = [
+      { userId: USER_ID, username: USERNAME, image: STALE_AVATAR },
+      { userId: SIBLING_ID, username: movedSiblingUsername, image: undefined },
+    ];
+    await invalidateAccounts?.();
+
+    await vi.waitFor(() => {
+      expect(readRoster()[String(SIBLING_ID)]?.username).toBe(movedSiblingUsername);
+    });
+    expect(readRoster()[String(USER_ID)]?.avatarUrl).toBe(FRESH_AVATAR);
+    expect(probeAttr('avatar')).toBe(FRESH_AVATAR);
+  });
+
+  // Scoped to the DEVICE-LOOP vector on purpose: the roster is seeded with NO avatar, which neuters the
+  // loop's `?? prev[id]?.avatarUrl` fallback, leaving the hub's own `a.avatarUrl` (STALE_AVATAR) as the only
+  // thing that could put a deleted picture back — exactly what the `continue` on `sessionOwnedId` stops.
+  // There is no session-branch avatar fallback left to exercise: #4260 removed its `?? prev`, and this change
+  // deliberately adds no device-set one, so `session.user.image` is now the sole source for the current
+  // user's roster avatar. (The username still falls back; the avatar does not.)
+  test('🔴 the device set cannot resurrect an avatar the user removed', async () => {
+    window.localStorage.setItem(
+      ROSTER_KEY,
+      JSON.stringify({
+        [String(USER_ID)]: { id: USER_ID, username: USERNAME, avatarUrl: undefined },
+      })
+    );
+    // The session says: no profile picture. The hub still has the old one.
+    renderProvider(sessionWith(undefined));
+
+    await vi.waitFor(() => {
+      expect(readRoster()[String(SIBLING_ID)]?.username).toBe(SIBLING_USERNAME);
+    });
+    expect(readRoster()[String(USER_ID)]?.avatarUrl).toBeUndefined();
+    expect(probeAttr('avatar')).toBe('');
+  });
+
+  // INVARIANT GUARD, not regression coverage — this one passes before the fix too. It exists so that skipping
+  // an id in the loop can't quietly disable the loop, and so the `changed` bail-out (which is what keeps this
+  // effect from re-rendering forever) stays intact.
+  test('a non-current device account is still upserted, and the effect settles', async () => {
+    renderProvider(sessionWith(FRESH_AVATAR));
+
+    await vi.waitFor(() => {
+      expect(probeAttr('sibling')).toBe(SIBLING_USERNAME);
+    });
+    // The sibling's identity is remembered in full, not just its key.
+    expect(readRoster()[String(SIBLING_ID)]).toEqual({
+      id: SIBLING_ID,
+      username: SIBLING_USERNAME,
+      avatarUrl: undefined,
+    });
+
+    // Quiescence: an unbounded re-render loop keeps committing after the value has settled.
+    const settled = probeRenders;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(probeRenders).toBe(settled);
+    // And the whole mount costs a bounded number of commits, not dozens.
+    expect(settled).toBeLessThan(25);
+  });
+});

--- a/src/components/CivitaiWrapped/AccountProvider.tsx
+++ b/src/components/CivitaiWrapped/AccountProvider.tsx
@@ -151,21 +151,45 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
           changed = true;
         }
       };
-      // NB: skip the current user while IMPERSONATING — the "current user" is then the impersonated target, not
-      // a real account linked on this device, so it must never enter the switcher roster (impersonation also
-      // never touches the hub device set, so deviceAccounts below won't reintroduce it).
-      if (currentUserId && hasSessionUser && !isImpersonating) {
-        upsert(String(currentUserId), {
+      // Which id the SESSION branch owns, if any — computed ONCE, from the hoisted session primitives,
+      // because the deviceAccounts loop below has to skip it. NB: `null` while IMPERSONATING — the "current
+      // user" is then the impersonated target, not a real account linked on this device, so it must never
+      // enter the switcher roster (impersonation also never touches the hub device set, so the loop below
+      // won't reintroduce it either way).
+      const sessionOwnedId =
+        currentUserId && hasSessionUser && !isImpersonating ? String(currentUserId) : null;
+      // The `currentUserId` re-test is only there to narrow `number | undefined` for the `id` field below;
+      // `sessionOwnedId` is already the authority on whether this branch runs.
+      if (sessionOwnedId && currentUserId) {
+        upsert(sessionOwnedId, {
           id: currentUserId,
-          username: sessionUsername ?? prev[String(currentUserId)]?.username ?? '',
-          // NO `?? prev` fallback for the avatar here (unlike the deviceAccounts loop below). In THIS branch
-          // the session user is known-present, so its `image` is authoritative: `undefined` means "this user
-          // has no profile picture", not "no data". Falling back to the remembered value made removing a
-          // profile picture impossible to reflect — the switcher kept rendering the deleted avatar forever.
+          // Session first; the device set and the remembered roster are only consulted when the session
+          // carries no username (`SessionUser.username` is optional). `||` past the first term because the
+          // device set stores `''` for an unknown username, and '' is not a username.
+          username:
+            sessionUsername ??
+            (deviceAccounts[sessionOwnedId]?.username || prev[sessionOwnedId]?.username || ''),
+          // NO fallback of ANY kind for the avatar here (unlike the username above and the deviceAccounts
+          // loop below) — not the remembered roster value, not the device set. In THIS branch the session
+          // user is known-present, so its `image` is authoritative: `undefined` means "this user has no
+          // profile picture", not "no data". Falling back made removing a profile picture impossible to
+          // reflect (the switcher kept rendering the deleted avatar forever), and the device set is a 30-day
+          // cache that would happily hand back the deleted url in the read-after-write window.
           avatarUrl: sessionAvatarUrl,
         });
       }
       for (const [id, a] of Object.entries(deviceAccounts)) {
+        // 🔴 The signed-in user's own entry belongs to the session branch above — never let the device set
+        // overwrite it. `upsert` compares each candidate against `prev` (the state this effect started from),
+        // NOT against the `next` it is accumulating, so when both branches touch one id the LAST writer wins
+        // regardless of which value is fresher. The hub device set is a cache (30-day rolling, 60s client
+        // staleTime) and can still be serving the PREVIOUS avatar url in the read-after-write window right
+        // after a profile-picture change — and changing a picture hard-deletes the old image, so the loser of
+        // that race is a url that 404s. The session is the copy the rest of the app already renders from.
+        // Skipping the id also means every id is written at most ONCE, which is what keeps comparing against
+        // `prev` correct — and keeps `changed` exact, so a no-op pass still returns the SAME object and
+        // setRoster bails (no re-render / no localStorage churn / no render loop).
+        if (id === sessionOwnedId) continue;
         upsert(id, {
           id: a.id,
           username: a.username || prev[id]?.username || '',


### PR DESCRIPTION
Closes #4265. Pre-existing defect — split out of #4260, and **based directly on `main`, not stacked on it**.

## The defect

The roster-upsert effect in `AccountProvider.tsx` upserts the session user first and then loops over the hub device set, but `upsert` compares each candidate against `prev` — the state the effect started from — not against the `next` accumulator it is building. So when both branches touch the same id (the signed-in user is also linked on this device) the loop, running second, wins regardless of which value is fresher.

The device set is a cache (30-day rolling, 60s client staleTime), so right after a profile-picture change it can still be reporting the previous avatar url. Changing a picture hard-deletes the old image, so the value that wins that race is a url that 404s. The loop's `?? prev[id]?.avatarUrl` fallback is a second route to the same place: it can put back an avatar the user has just removed.

## Which fix, and why

The issue offers two options. **They are not equivalent, and only one of them fixes this** — worth stating plainly because the other one reads like it does:

- **Compare against `next` instead of `prev`** — does *not* fix it. Changing the baseline changes which writes are recorded as changes; it does not change **who writes last**. The device entry still differs from the session entry, so the loop still overwrites it. All this option really moves is the `changed` bookkeeping — and it moves it in the wrong direction: a write-then-revert (device puts back exactly what `prev` held) would leave `changed === true` with a `next` that is value-equal to `prev`, so the effect returns a **new object** for a no-op pass. That object identity is precisely what the `changed ? next : prev` bail-out exists to withhold, and this file has a documented history of loop bugs.

- **Make the session authoritative for its own id** — what this PR does. The session is the copy the rest of the app already renders from (the header avatar, the menu), so a roster that disagrees with it is wrong by construction; and the freshness ordering is not a coin flip, the session is the live value and the device set is a cache of it.

Concretely: hoist the "does the session own an entry, and which id" decision into `sessionOwnedId` (still `null` while impersonating, unchanged), and `continue` past that id in the device loop.

A useful second-order property: with the skip, **every id is written at most once**, so comparing against `prev` is comparing against the correct baseline again — which is why option 1 is not additionally needed — and `changed` stays exact, so a no-op pass still returns the *same* object and `setRoster` bails.

Nothing is lost by skipping. The device set stays a fallback source for the **username**, consulted only when the session carries none (`SessionUser.username` is optional — without this the skip would regress that case to `''`). Deliberately **not** for the avatar: an absent session `image` can mean "the user removed their profile picture", and a device-set fallback would hand the deleted one straight back.

## Tests

`src/components/CivitaiWrapped/AccountProvider.deviceRoster.browser.test.tsx` — a new file rather than an addition to the one in #4260, because #4260 is still open (its file is not on `main`) and because every case here needs a **non-empty device set containing the current user**, which the `accounts: []` fixture cannot express. Same harness and patterns: real `SessionProvider`, real `AccountProvider`, real `useLocalStorage` roster, real device query, only `fetch` stubbed.

The load-bearing control in every case is a **second, non-current device account**: asserting it reached the roster proves the device payload actually landed and the loop still ran. Without it, "the avatar stayed fresh" would be indistinguishable from the device query never resolving.

```
pnpm vitest run --project component \
  src/components/CivitaiWrapped/AccountProvider.deviceRoster.browser.test.tsx
```

| | tests executed | result |
|---|---|---|
| at `2bfc1971cf` (this PR's parent, component file only) | **4** | **3 failed**, 1 passed |
| at this branch's HEAD | **4** | **4 passed** |

All three regression failures at base are the stale device avatar clobbering the fresh session one, e.g. `expected 'device-roster-test-stale-avatar.png' to be 'device-roster-test-fresh-avatar.png'`.

The fourth test passes on **both** sides and is labelled in-file as an **invariant guard, not regression coverage**: a non-current device account is still upserted in full, commits stay bounded (<25) and quiesce over a 300 ms window after the value settles. It is there so the skip cannot quietly disable the loop, and so the `changed` bail-out that prevents a re-render loop stays pinned.

## Checks

- `pnpm typecheck` — **0 type errors** (57 s, heap cap 8192 MB).
- `pnpm prettier:check` — clean. Note this reformats two pre-existing lines in `AccountProvider.tsx` that were already prettier-dirty on `main` (the `upsert` condition and the `rows.map`); the repo's gate checks changed files, so touching the file requires it. Those two hunks are the same reformat #4260 carries.
- `eslint` on both changed files — **2 files linted, 0 errors, 0 warnings** (file count read from `--format json`, not from the exit code). Repo-wide `pnpm lint` is red at **4354 problems / 364 errors** on `main` today; none are in these files.

## Merge note

This overlaps #4260 textually — both rewrite the session-user upsert — so whichever lands second will need a small conflict resolution. They are complementary, not competing: #4260 makes the effect *re-run* when the session avatar changes and drops the session branch's own stale-value fallback; this one stops the device loop from undoing that. The avatar-removal test here is deliberately scoped to the device-loop vector (the roster is seeded with no avatar), so it does not depend on #4260 having landed.
