### PR TITLE
perf(preferences): membership sets in the pre-cache hidden-preferences path

### DIFF
--- a/src/server/__tests__/middleware.trpc.apply-user-preferences.test.ts
+++ b/src/server/__tests__/middleware.trpc.apply-user-preferences.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * `applyUserPreferences` decides which hidden images reach the query, and it runs
+ * AHEAD of `cacheIt` — so it executes on cache hits too. The membership test it
+ * performs is the part worth pinning: an implicitly-hidden image carries the tag
+ * that caused it, and it is only excluded when the viewer still hides that tag.
+ *
+ * The failure this guards is a lookup built over the wrong values (tag objects
+ * rather than tag ids), which never matches and silently un-hides every
+ * tag-implied image while leaving the explicit ones correct.
+ */
+
+const { capturedHandlers, mockGetAllHiddenForUser } = vi.hoisted(() => ({
+  capturedHandlers: [] as Array<(arg: unknown) => Promise<unknown>>,
+  mockGetAllHiddenForUser: vi.fn(),
+}));
+
+vi.mock('~/server/trpc', () => ({
+  middleware: (handler: (arg: unknown) => Promise<unknown>) => {
+    capturedHandlers.push(handler);
+    return handler;
+  },
+}));
+
+vi.mock('~/server/services/user-preferences.service', () => ({
+  getAllHiddenForUser: mockGetAllHiddenForUser,
+}));
+
+await import('~/server/middleware.trpc');
+
+// applyUserPreferences is the first middleware() call in the module.
+const applyUserPreferencesHandler = capturedHandlers[0];
+
+const invoke = async (input: Record<string, unknown>, cookies: Record<string, string> = {}) => {
+  const next = vi.fn(async () => ({ ok: true }));
+  await applyUserPreferencesHandler({
+    input,
+    ctx: { user: { id: 7 }, req: { cookies } },
+    next,
+    path: 'tag.getAll',
+  });
+  return input as { excludedImageIds?: number[]; excludedTagIds?: number[] };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAllHiddenForUser.mockResolvedValue({
+    hiddenTags: [
+      { id: 100, hidden: true },
+      { id: 200, hidden: true },
+      { id: 300, hidden: false },
+    ],
+    hiddenImages: [
+      { id: 1 }, // explicit hide, no tag
+      { id: 2, tagId: 100 }, // implied by a tag the viewer hides
+      { id: 3, tagId: 300 }, // implied by a tag the viewer does NOT hide
+      { id: 4, tagId: 999 }, // implied by a tag absent from the list entirely
+    ],
+    hiddenModels: [],
+    hiddenUsers: [],
+  });
+});
+
+describe('applyUserPreferences — which hidden images reach the query', () => {
+  it('excludes an explicitly hidden image, which carries no tag', async () => {
+    expect((await invoke({})).excludedImageIds).toContain(1);
+  });
+
+  it('excludes a tag-implied image while the viewer still hides that tag', async () => {
+    expect((await invoke({})).excludedImageIds).toContain(2);
+  });
+
+  // The discriminating cases: a lookup over the wrong values matches nothing, so
+  // these two start passing while the two above still hold.
+  it('does NOT exclude an image implied by a tag the viewer no longer hides', async () => {
+    expect((await invoke({})).excludedImageIds).not.toContain(3);
+  });
+
+  it('does NOT exclude an image whose tag is absent from the hidden list', async () => {
+    expect((await invoke({})).excludedImageIds).not.toContain(4);
+  });
+
+  it('drops every tag-implied image when disableHidden is set, keeping explicit ones', async () => {
+    const out = await invoke({}, { disableHidden: 'true' });
+    expect(out.excludedTagIds).toEqual([]);
+    expect(out.excludedImageIds).toEqual([1]);
+  });
+
+  it('appends to caller-supplied ids rather than replacing them', async () => {
+    const out = await invoke({ excludedImageIds: [42] });
+    expect(out.excludedImageIds?.[0]).toBe(42);
+  });
+});

--- a/src/server/middleware.trpc.ts
+++ b/src/server/middleware.trpc.ts
@@ -33,9 +33,12 @@ export const applyUserPreferences = middleware(async ({ input, ctx, next }) => {
       });
 
       const tagsToHide = hiddenTags.filter((x) => !disableHidden && x.hidden).map((x) => x.id);
+      // Membership set, not a scan: this runs ahead of `cacheIt`, so it is paid on
+      // cache hits too, and both inputs are unbounded per user.
+      const tagsToHideSet = new Set(tagsToHide);
 
       const imagesToHide = hiddenImages
-        .filter((x) => !x.tagId || tagsToHide.findIndex((tagId) => tagId === x.tagId) > -1)
+        .filter((x) => !x.tagId || tagsToHideSet.has(x.tagId))
         .map((x) => x.id);
 
       _input.excludedTagIds = [...(_input.excludedTagIds ?? []), ...tagsToHide];

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -148,8 +148,10 @@ const getVotedHideImages = async ({
     Instead of returning every image the user has voted on that matches their hidden preferences, only return the images the user has voted on where the tag hasn't been applied to the image yet (due to scoring, moderator controls)
     tagsOnImageDetails.disabled indicates that the tag isn't applied
   */
-  const hidden = votedHideImages.filter((x) => hiddenTagIds.includes(x.tagId));
-  const moderated = votedHideImages.filter((x) => moderatedTagIds.includes(x.tagId));
+  const hiddenSet = new Set(hiddenTagIds);
+  const moderatedSet = new Set(moderatedTagIds);
+  const hidden = votedHideImages.filter((x) => hiddenSet.has(x.tagId));
+  const moderated = votedHideImages.filter((x) => moderatedSet.has(x.tagId));
   const combined = [...hidden, ...moderated].map((x) => ({ id: x.imageId, tagId: x.tagId }));
   return combined as HiddenImage[];
 };


### PR DESCRIPTION
Found by the perf review of #4248. Pre-existing.

### The shape

`applyUserPreferences` (`src/server/middleware.trpc.ts`) resolved which hidden images reach the query with a linear scan inside a filter over a different array:

```ts
.filter((x) => !x.tagId || tagsToHide.findIndex((tagId) => tagId === x.tagId) > -1)
```

That is O(hiddenImages × hiddenTags). `getVotedHideImages` (`src/server/services/user-preferences.service.ts`) had the same shape twice, partitioning voted images with `Array.includes` per element.

`applyUserPreferences` runs **ahead of `cacheIt`**, so it executes even when the response is served from Redis and the resolver never runs — on `tag.getAll`, `tag.getTrending`, and both `post.router.ts` call sites. The `getVotedHideImages` half sits behind the `ImplicitHiddenImages` cache, so it is per cache miss rather than per request.

### Sizing — smaller than it first looks

The per-dimension maxima are large (hidden tags max 6,561; voted-hide images max 529,465), but **those are different accounts**, and multiplying two maxima overstates this by three orders of magnitude. Against the *joint* distribution, among users who have both:

| | value |
|---|---|
| worst actual product | **6.78M comparisons** |
| max hidden tags among those users | 1,469 |
| max voted images among those users | 142,089 |
| users above 1M comparisons | **9** |
| users above 10M comparisons | **0** |

Benchmarked old vs new across that range (identical output asserted at each size):

| case | old | new | |
|---|---|---|---|
| p50 — 3 tags, 2 imgs | 0.00011 ms | 0.00008 ms | 1.37× |
| p99 — 16 tags, 405 imgs | 0.00411 ms | 0.00314 ms | 1.31× |
| p999 — 64 tags, 5,438 imgs | 0.07210 ms | 0.03927 ms | 1.84× |
| 200 tags, 50,000 imgs | 2.35031 ms | 1.31218 ms | 1.79× |

**Never slower, including p50** — which was the thing worth checking, since this adds a `Set` allocation on every request for every user to help a handful.

So: this saves microseconds for almost everyone and well under a millisecond for the nine accounts at the top. It is a small win on its merits, **not** a hot-path rescue. The value is removing an O(n×m) shape from a pre-cache path where both inputs are unbounded per user, before either grows — `getVotedHideImages` matches against hidden tags **∪ the global moderated tag list**, so the heavy cohort tracks tagging activity rather than hiding preferences, and it grows with moderation volume.

Reviewers should feel free to call this not worth the diff. I would rather it be judged on the real numbers than on the ones I first published, which multiplied two unrelated maxima.

### The test

Behaviour is unchanged, so a behavioural test cannot catch a speed regression — reverting to `findIndex` leaves it green, correctly.

What it pins is the way *this* refactor breaks: a set built over tag objects rather than tag ids matches nothing, silently ending exclusion for every tag-implied image while explicitly-hidden ones keep working. Mutating `new Set(tagsToHide)` → `new Set(hiddenTags)` fails exactly one test by name in 3 ms:

```
× excludes a tag-implied image while the viewer still hides that tag
```

### Verification

- full unit suite **20,763 passed / 0 failed**, submodule canary 350
- `pnpm run typecheck` — 0 errors
- eslint — 0 errors; the 4 `no-explicit-any` warnings in `middleware.trpc.ts` are at lines 80/97/154/283, inside `cacheIt`/`edgeCacheIt`, and pre-exist this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeeJXStZA5ebfrCMVsxrRn