### PR TITLE
fix(post): raise deletePost transaction budget 10s → 30s to stop user-visible delete failures

### DIFF
--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -943,7 +943,22 @@ export const deletePost = async ({ id, isModerator }: GetByIdInput & { isModerat
 
       return { post, deletedImages };
     },
-    { timeout: 10000 }
+    // TEMPORARY (2026-08-21): raised 10s -> 30s to stop user-visible failures while the
+    // underlying slowness is investigated. Post deletion has been failing with Prisma
+    // P2028 "Transaction already closed" — the DELETE below routinely outlives the
+    // transaction's own budget, so the whole delete is rolled back and the user sees an
+    // error. Measured over a 14.28h window: 767 executions of that DELETE, mean 6.6s,
+    // 218 (28.4%) over 10s, and ZERO over 30s — so 30s covers every execution observed
+    // while 10s misses more than a quarter of them.
+    //
+    // 🔴 THIS IS A MITIGATION, NOT A FIX. It converts "the deletion failed" into "the
+    // deletion was slow"; it does nothing about why a delete of one post's images takes
+    // seconds. Do not treat a quiet error rate as the problem being solved.
+    //
+    // REVERT THIS once the slowness is root-caused — the number is derived from a
+    // 14.28h sample and is not a budget anyone designed. A larger post, or a further
+    // regression, walks straight through 30s the same way it walked through 10s.
+    { timeout: 30000 }
   );
 
   // Phase 2: Side effects after successful transaction


### PR DESCRIPTION
**Temporary mitigation, not a fix.**

Users are reporting failures when deleting a post. The cause is Prisma **P2028 "Transaction already closed"**: `deletePost` wraps its work in `dbWrite.$transaction(…, { timeout: 10000 })`, and the `DELETE FROM "Image" … RETURNING id, url` inside it routinely outlives that 10s budget. The transaction is then aborted and the whole delete is rolled back, so the user sees an error.

## Why 30s

Measured over a **14.28h** window on that statement:

| | |
|---|---|
| executions | **767** |
| mean | **6.6s** |
| over 10s | **218 (28.4%)** |
| over 30s | **0** |

The current 10s budget misses **more than a quarter** of real executions. 30s covers every execution observed in that window.

## 🔴 What this does and does not do

It converts *"the deletion failed"* into *"the deletion was slow."* It does **nothing** about why deleting one post's images takes seconds — and a quiet error rate must not be read as the problem being solved.

The number is derived from a 14.28h sample, not a designed budget. A larger post, or a further regression, walks through 30s exactly as it walked through 10s.

**Revert this once the slowness is root-caused.** That investigation is running separately; the open question is whether the statement genuinely regressed or was always this slow.

## One thing that is already fine

The current failure mode is at least safe: the transaction rolls back cleanly, so a failed delete leaves no partial state (no orphaned images, no half-deleted post). This change does not alter that.

## Scope

One value changed, plus an explanatory comment carrying the measurement and the revert condition:

```diff
-    { timeout: 10000 }
+    { timeout: 30000 }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)