### PR TITLE
fix(creator-studio): explain the impressions start date on the analytics detail pages

### DIFF
--- a/apps/creator-studio/src/lib/server/analytics.ts
+++ b/apps/creator-studio/src/lib/server/analytics.ts
@@ -458,15 +458,6 @@ const impressionArms = () =>
     .map((e) => `'${e}'`)
     .join(', ');
 
-// Impressions land in their own table rather than `daily_views`, so this cannot reuse `viewTrackingLive`.
-// Deliberately uncached, and deliberately NOT part of the cached ContentAnalytics payload — see below.
-export async function impressionTrackingLive(): Promise<boolean> {
-  const rows = await getClickhouse().$query<{ one: number }>(
-    `SELECT 1 AS one FROM impressions_daily_by_owner WHERE entityType IN (${impressionArms()}) LIMIT 1`
-  );
-  return rows.length > 0;
-}
-
 function netReactionsDailySql(uid: number, from: string, to: string): string {
   return `SELECT toDate(time) AS date, ${netReactions} AS value FROM reactions WHERE ownerId = ${uid} AND toDate(time) >= toDate('${from}') AND toDate(time) <= toDate('${to}') GROUP BY date`;
 }

--- a/apps/creator-studio/src/routes/(app)/analytics/content/article/[articleId]/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/analytics/content/article/[articleId]/+page.svelte
@@ -9,6 +9,7 @@
   import ChartTypeToggle from '$lib/components/ChartTypeToggle.svelte';
   import DeltaChip from '$lib/components/DeltaChip.svelte';
   import AnalyticsHeader from '$lib/components/AnalyticsHeader.svelte';
+  import ImpressionsNotice from '$lib/components/ImpressionsNotice.svelte';
   import { chartType } from '$lib/stores/chart-type';
   import { formatRange, dayDiff, shiftIso } from '$lib/date-range';
   import { IconArrowLeft, IconExternalLink } from '@tabler/icons-svelte';
@@ -120,6 +121,8 @@
     {article.publishedAt ? `Published ${article.publishedAt.slice(0, 10)}` : 'Not published'}
   </p>
 </div>
+
+<ImpressionsNotice />
 
 <div class="mb-4 flex flex-wrap gap-4">
   {#if article.coverUrl}

--- a/apps/creator-studio/src/routes/(app)/analytics/content/image/[imageId]/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/analytics/content/image/[imageId]/+page.svelte
@@ -9,6 +9,7 @@
   import ChartTypeToggle from '$lib/components/ChartTypeToggle.svelte';
   import DeltaChip from '$lib/components/DeltaChip.svelte';
   import AnalyticsHeader from '$lib/components/AnalyticsHeader.svelte';
+  import ImpressionsNotice from '$lib/components/ImpressionsNotice.svelte';
   import { chartType } from '$lib/stores/chart-type';
   import { formatRange, dayDiff, shiftIso } from '$lib/date-range';
   import { IconArrowLeft, IconExternalLink } from '@tabler/icons-svelte';
@@ -99,8 +100,6 @@
     };
   }
 
-  // Images and videos are both tracked for impressions, so 0 here is a real zero and stays on screen — the
-  // absent case is an entity TYPE with no impression arm, which never reaches this page.
   const engagementCharts = $derived([
     {
       title: 'Feed impressions',
@@ -148,6 +147,8 @@
     </a>
   </h2>
 </div>
+
+<ImpressionsNotice />
 
 <div class="mb-4 flex flex-wrap gap-4">
   <div class="w-40 shrink-0 overflow-hidden rounded-lg border border-dark-4 bg-dark-7">


### PR DESCRIPTION
`impressions_daily_by_owner` only starts **2026-08-17**, so on the analytics **detail** pages any earlier period renders "No feed impressions {period}" — a confident zero for a metric that was not collecting.

The explanation already exists. `ImpressionsNotice` says *"Feed impressions are new. We started counting on … and reached every visitor on …"* — but it was mounted only on the two **list** pages (`analytics/content`, `analytics/models`).

## Changes

- Mount the existing `ImpressionsNotice` on `analytics/content/article/[articleId]` and `analytics/content/image/[imageId]`, directly above the tile grid that holds the Feed impressions tile. No new copy, no new component, no flag.
- Delete `impressionTrackingLive` from `lib/server/analytics.ts`. It has zero callers (verified repo-wide), and it is all-time scoped — precisely the bug `viewTrackingSql`'s own comment says it replaced, so wiring it would have reintroduced that. The notice makes it redundant. `impressionArms()` is still used by `impressionsDailySql`, so nothing dangles.
- Delete the image page's *"0 here is a real zero and stays on screen"* comment. A zero for a period before the start date is exactly not a real zero, which is what the notice now says; the surviving half of the claim reads straight off `IMPRESSION_ENTITY`.

No gating on either page: `entityImpressionsSql` records that Image, Model **and** Article all carry real impression volume, so both detail pages legitimately show impressions — unlike the list pages, which gate for comics/3D.

## Verification

- `pnpm run typecheck` (svelte-check) in `apps/creator-studio` — 8970 files, 0 errors, 0 warnings
- `pnpm run test:apps:run` — 80 files, 825 passed / 35 skipped
- App-local Prettier 3 clean on all three files

ClickUp `868ku7wed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)