### PR TITLE
fix(metrics): publish every cron job's series at zero so a dead job is visible

### DIFF
--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -563,5 +563,39 @@ export const jobErrorsCounter = registerCounterWithLabels({
   labelNames: ['job'] as const,
 });
 
+// Job names already seeded in THIS module instance. `Histogram.zero()` overwrites the
+// series rather than merging into it, so a second call for a name that has since been
+// observed would silently wipe that job's buckets. Seeding is once-per-name by
+// construction today (createJob runs at each job module's top level), but the failure
+// mode is invisible in the data, so it is closed here rather than assumed away.
+const seededJobs = new Set<string>();
+
+/**
+ * Seed both cron metrics' series for `job` at zero.
+ *
+ * 🔴 WHY THIS EXISTS: a prom-client metric declared with `labelNames` emits NO series at
+ * all for a label value it has never observed. So before a job's first completed run —
+ * and, for the error counter, before its first FAILURE — neither series appears in the
+ * /metrics response, and the two metrics above cannot answer the question they were added
+ * to answer. Their own help text promises that a dead cron shows up as a flatlined
+ * duration histogram next to a live `job_errors_total`; without seeding, a cron that is
+ * dead, a cron that has not run since this pod started, and a cron that was deleted from
+ * the codebase are all the SAME observation — an absent series. `absent()` and `rate()`
+ * alerts written against them are unreliable for the same reason, and a healthy zero is
+ * indistinguishable from an instrument that was never wired up.
+ *
+ * Seeding at job-construction time makes every `createJob` job an observable zero from the
+ * moment its module is loaded, so absence once again means "no such job".
+ *
+ * This mirrors the seeding the /metrics route already does for its own counters, and the
+ * same reasoning is written out at each of those call sites.
+ */
+export function seedJobMetrics(job: string) {
+  if (seededJobs.has(job)) return;
+  seededJobs.add(job);
+  jobDurationHistogram.zero({ job });
+  jobErrorsCounter.inc({ job }, 0);
+}
+
 // NOTE: the DB pool-depth gauges live in the app (src/server/prom/client.ts) — they
 // compose the db pools + these prom helpers, which is app-level glue, not infra.

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -162,6 +162,11 @@ const promMetricStub = () => {
     dec: vi.fn(),
     set: vi.fn(),
     observe: vi.fn(),
+    // `Histogram.zero(labels)` — used by seedJobMetrics to publish a job's series before
+    // its first observation. Stubbed here for the same reason as its neighbours: the stub
+    // has to cover every prom-client surface our code touches, or a caller dies on
+    // `zero is not a function` far from whatever the test was written to check.
+    zero: vi.fn(),
     startTimer: vi.fn(() => vi.fn()),
     labels: vi.fn(() => child),
   };
@@ -234,6 +239,11 @@ vi.mock('~/server/prom/client', () => ({
   // Cron runner + image-ingestion cron metrics (job.ts / image-ingestion.ts).
   jobDurationHistogram: promMetricStub(),
   jobErrorsCounter: promMetricStub(),
+  // Not a metric — the helper `createJob` calls at module scope to publish each job's
+  // series at zero. Re-exported from '@civitai/telemetry/client', so this
+  // module-replacing mock drops it, and EVERY suite that reaches a job module would die
+  // during evaluation with `No "seedJobMetrics" export is defined on the mock`.
+  seedJobMetrics: vi.fn(),
   imageIngestCronCounter: promMetricStub(),
   imageIngestCronQueueDepth: promMetricStub(),
   imageScanWebhookCounter: promMetricStub(),

--- a/src/server/jobs/__tests__/job-metrics-exposure.test.ts
+++ b/src/server/jobs/__tests__/job-metrics-exposure.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+import client from 'prom-client';
+
+// 🔴 WHY THIS FILE MOCKS `~/server/prom/client` WITH THE REAL PACKAGE.
+//
+// The shared setup replaces that module wholesale with call-recording stubs, so under the
+// default harness `jobDurationHistogram` is a `vi.fn()` bag and there is no registry to
+// read. A test written against that could only assert that createJob CALLED something —
+// which is a claim about the fake, not about what a scrape returns, and would stay green
+// if the metric were registered on a registry nobody serves.
+//
+// The app shim's only unsafe part is the DB-pool glue it builds at module scope; the two
+// job metrics come from '@civitai/telemetry/client', which imports nothing but prom-client.
+// Substituting the real package therefore gives real metrics on prom-client's real default
+// registry — the same registry `src/pages/api/metrics.ts` renders — so every assertion
+// below reads actual Prometheus exposition text rather than a mock's call log.
+vi.mock('~/server/prom/client', async () => await import('@civitai/telemetry/client'));
+
+import { createJob } from '~/server/jobs/job';
+// A REAL job, imported for its own sake: `scan-files-fallback` is created at this module's
+// top level, which is exactly how all ~146 jobs are created and the only place the seeding
+// can run. Asserting on a job the test itself declares would not prove that.
+import { scanFilesFallbackJob } from '~/server/jobs/scan-files';
+
+/** The scraped `/metrics` body, as Prometheus would receive it. */
+async function scrape() {
+  return await client.register.metrics();
+}
+
+function sampleLinesFor(text: string, job: string) {
+  return text.split('\n').filter((l) => !l.startsWith('#') && l.includes(`job="${job}"`));
+}
+
+describe('cron job metrics are exposed on the scraped endpoint', () => {
+  it('exposes a zero-valued series for a real job that has never run (scan-files-fallback)', async () => {
+    const text = await scrape();
+
+    // The two lines a dashboard or alert actually reads. Pinned as whole normalised
+    // strings — including the trailing ` 0` — because a guard that only checked the
+    // metric NAME would pass on a series carrying any value, and a guard that only
+    // checked "some line mentions this job" would pass on the `_bucket` lines alone.
+    expect(text).toContain('civitai_app_job_duration_seconds_count{job="scan-files-fallback"} 0');
+    expect(text).toContain('civitai_app_job_errors_total{job="scan-files-fallback"} 0');
+
+    // Sanity: the name asserted above is the job's real registered name, not a literal
+    // that drifted away from the code.
+    expect(scanFilesFallbackJob.name).toBe('scan-files-fallback');
+  });
+
+  it('exposes the full histogram (every bucket + sum + count) so rate()/histogram_quantile have a series to read', async () => {
+    const text = await scrape();
+    const lines = sampleLinesFor(text, 'scan-files-fallback');
+
+    // 10 declared buckets + `+Inf` + `_sum` + `_count` + the errors counter = 14.
+    // An exact count, not a lower bound: a partially-seeded histogram is a real failure
+    // mode (`zero()` writing an empty bucket map would still satisfy `toContain` on the
+    // `_count` line above), and only counting catches it.
+    expect(lines).toHaveLength(14);
+    for (const bucket of [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300]) {
+      expect(text).toContain(
+        `civitai_app_job_duration_seconds_bucket{le="${bucket}",job="scan-files-fallback"} 0`
+      );
+    }
+    expect(text).toContain(
+      'civitai_app_job_duration_seconds_bucket{le="+Inf",job="scan-files-fallback"} 0'
+    );
+    expect(text).toContain('civitai_app_job_duration_seconds_sum{job="scan-files-fallback"} 0');
+  });
+
+  it('does it for EVERY job createJob builds, not just the one job under test', async () => {
+    // The defect is a class: any job whose module has been loaded must be observable, and
+    // a job-specific fix would leave the other ~145 invisible. Three fresh names, created
+    // exactly as a job module creates them.
+    const names = ['class-probe-alpha', 'class-probe-beta', 'class-probe-gamma'];
+    for (const name of names) createJob(name, '* * * * *', async () => undefined);
+
+    const text = await scrape();
+    for (const name of names) {
+      expect(text).toContain(`civitai_app_job_duration_seconds_count{job="${name}"} 0`);
+      expect(text).toContain(`civitai_app_job_errors_total{job="${name}"} 0`);
+    }
+  });
+
+  it('NEGATIVE CONTROL: a label value no job ever declared emits nothing', async () => {
+    // Proves the assertions above are observing the seeding rather than some blanket
+    // property of the metric — a labelled prom-client metric emits NO series for an
+    // unseen label value, which is the mechanism this whole change exists to fix. If this
+    // ever starts matching, the tests above have stopped discriminating.
+    const text = await scrape();
+    expect(text).not.toContain('job="a-job-that-was-never-created"');
+    expect(sampleLinesFor(text, 'a-job-that-was-never-created')).toHaveLength(0);
+  });
+
+  it('seeding does not clobber a real observation: a completed run still increments _count', async () => {
+    const job = createJob('observed-probe-job', '* * * * *', async () => undefined);
+
+    const before = await scrape();
+    expect(before).toContain('civitai_app_job_duration_seconds_count{job="observed-probe-job"} 0');
+
+    await job.run({}).result;
+
+    const after = await scrape();
+    expect(after).toContain('civitai_app_job_duration_seconds_count{job="observed-probe-job"} 1');
+    // A successful run must not touch the error counter — it stays an observable zero.
+    expect(after).toContain('civitai_app_job_errors_total{job="observed-probe-job"} 0');
+  });
+
+  it('a throwing run increments the (already-seeded) error counter', async () => {
+    const job = createJob('failing-probe-job', '* * * * *', async () => {
+      throw new Error('boom');
+    });
+
+    await expect(job.run({}).result).rejects.toThrow('boom');
+
+    const after = await scrape();
+    expect(after).toContain('civitai_app_job_errors_total{job="failing-probe-job"} 1');
+    expect(after).toContain('civitai_app_job_duration_seconds_count{job="failing-probe-job"} 1');
+  });
+});

--- a/src/server/jobs/job.ts
+++ b/src/server/jobs/job.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
-import { jobDurationHistogram, jobErrorsCounter } from '~/server/prom/client';
+import { jobDurationHistogram, jobErrorsCounter, seedJobMetrics } from '~/server/prom/client';
 import { longTaskLabelsArmed, runWithLongTaskLabel } from '~/server/eventloop-longtask';
 import { applySourceMaps } from '~/server/utils/errorHandling';
 
@@ -59,6 +59,20 @@ export function createJob(
   fn: (e: JobContext) => Promise<MixedObject | void>,
   options: Partial<JobOptions> = {}
 ) {
+  // Publish this job's series at zero NOW, rather than leaving it absent until the job
+  // first completes (or first throws). See seedJobMetrics for why an absent series and a
+  // healthy zero must be distinguishable here.
+  //
+  // Guarded because this runs at the MODULE scope of every job file, which the run-jobs
+  // route imports eagerly: an exception escaping here would fail that import and take
+  // EVERY cron job down. Losing a seeded zero is a legibility regression; losing the
+  // route is an outage, so the telemetry must never be able to cause one.
+  try {
+    seedJobMetrics(name);
+  } catch {
+    // Intentionally swallowed — see above.
+  }
+
   return {
     name,
     cron,


### PR DESCRIPTION
## Problem

`job_duration_seconds` and `job_errors_total` (defined in `@civitai/telemetry`, driven by `createJob` in `src/server/jobs/job.ts`) are both declared with a `job` label.

A prom-client metric declared with `labelNames` emits **no series at all** for a label value it has never observed. The metric is registered and its `# HELP` / `# TYPE` lines are exposed, but there are zero sample lines beneath them. Concretely:

- a job's **duration** series does not exist until it has completed a run in this process;
- a job's **error** series does not exist until it has actually thrown.

So the two metrics cannot answer the question the code comment says they were added for:

> Makes a dead/erroring cron visible: `job_errors_total` spikes and the duration histogram flatlines when a job stops running.

A cron that is dead, a cron that has not run since the process started, and a cron that was deleted from the codebase are all the **same observation** — an absent series, not a flatline. `absent()` and `rate()` alerts inherit the same ambiguity, and a healthy zero on the error counter is indistinguishable from an instrument that was never wired up.

The gap is not hypothetical: far fewer job names carry a duration series than there are `createJob` call sites in `src/server/jobs/`, and only a handful carry an error series at all — those being the only jobs that have ever failed.

## Fix

Fix the class, not one job. `createJob` now publishes both series at zero when the job is **constructed** — which is module scope for every job file — so a job becomes observable the moment its module is loaded, rather than after its first run:

```ts
seedJobMetrics(name);   // jobDurationHistogram.zero({ job }); jobErrorsCounter.inc({ job }, 0);
```

Two details that are load-bearing rather than incidental:

- **Seeding is once-per-name.** `Histogram.zero()` overwrites the series rather than merging into it, so a second call for a name that has since been observed would silently wipe that job's buckets. Closed with a `Set` rather than assumed away, because the failure mode is invisible in the data.
- **The call is wrapped in `try/catch`.** It runs at the module scope of every job file, which the run-jobs route imports eagerly — an exception escaping there would fail that import and take *every* cron job down. Losing a seeded zero is a legibility regression; losing the route is an outage, so the telemetry must never be able to cause one.

This mirrors the zero-seeding the metrics endpoint already does for its own counters, for the same stated reason.

## Tests

`src/server/jobs/__tests__/job-metrics-exposure.test.ts` asserts against **real Prometheus exposition text** rendered from prom-client's real default registry — the same registry the metrics endpoint serves — rather than against a mock's call log. The shared test setup replaces `~/server/prom/client` with call-recording stubs, so this file substitutes the real `@civitai/telemetry/client` instead; a test written against the stubs could only show that `createJob` *called* something, and would stay green even if the metric were registered on a registry nobody serves.

Six cases: a real job (`scan-files-fallback`) seeded before it has ever run; the full histogram (every bucket + `_sum` + `_count`, asserted by exact line count so a partially-seeded histogram cannot pass); the class case across three distinct fresh job names; a negative control proving an undeclared label value still emits nothing; and two cases showing seeding does not clobber a subsequent real run or a real failure.

**Test matrix** — red at `origin/main`, green at HEAD:

| | `origin/main` | HEAD |
|---|---|---|
| exposure tests (4) | ❌ fail | ✅ pass |
| negative control + throwing-run behaviour (2) | ✅ pass (by design) | ✅ pass |

The two that pass at base do so deliberately: the negative control must hold on both sides or it is not discriminating, and the throwing-run case pins existing behaviour rather than the new fix.

**Mutation results** — five mutants, each killed by an assertion specific to the defect it introduces:

| Mutant | Killed by |
|---|---|
| remove the `seedJobMetrics()` call | 4 tests, on the seeded-zero assertions |
| seed only the counter, not the histogram | the exact-line-count assertion (14 → 1) |
| register the metrics on a registry the endpoint does not serve | 5 tests |
| seed a hardcoded job name instead of the real one | the class test (3 distinct names) |
| dedupe `Set` ignores the name, so only the first job seeds | the class test |

The last two survive the single-job test and are caught only by the multi-name class case — which is why the fixtures are distinct names rather than repeats of the job under test.

## Checks

- `pnpm typecheck`: unchanged vs base (same error count both sides; verified the program actually sees both changed files by planting deliberate errors and watching the count move).
- Tests tier (`tsconfig.tests.json`, which `pnpm typecheck` is structurally blind to): file list identical to base; verified the gate sees the new test file by the same planted-error control.
- ESLint + Prettier clean on all four changed files (file counts read from the tools, not inferred from exit codes).
- The shared `~/server/prom/client` stub gains `zero` and `seedJobMetrics` so it keeps modelling the real module surface.
