### PR TITLE
fix(test): derive TEST_ENV_DEFAULTS from the env schema instead of hand-enumerating it

### DIFF
--- a/src/__tests__/mocks/env.mock.ts
+++ b/src/__tests__/mocks/env.mock.ts
@@ -1,3 +1,5 @@
+import { serverSchema } from '~/env/server-schema';
+
 /**
  * Canonical mock for `~/env/server`.
  *
@@ -20,6 +22,27 @@
  */
 const defaults: Record<string, unknown> = {};
 const overrides = new Map<string, unknown>();
+
+/**
+ * Extract every schema field's default value by parsing `undefined` through each field.
+ * Fields without a .default() (required fields, optional-without-default) throw on
+ * `parse(undefined)` and are skipped — those need explicit test values below.
+ *
+ * This is the single source of truth: a key gaining a `.default()` in the schema
+ * automatically appears here, so the hand-enumerated list can never silently diverge.
+ */
+function schemaDefaults(): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, field] of Object.entries(serverSchema.shape)) {
+    try {
+      const parsed = field.parse(undefined);
+      if (parsed !== undefined) result[key] = parsed;
+    } catch {
+      // Required fields or optional fields without .default() — need explicit test values
+    }
+  }
+  return result;
+}
 
 /** Worker-level, applied before any test file runs. For values a module reads at import. */
 export function setEnvDefaults(values: Record<string, unknown>) {
@@ -90,56 +113,33 @@ export const env: Record<string, unknown> = new Proxy(
 export const envMock = { set: setEnv, setDefaults: setEnvDefaults, reset: resetEnv };
 
 /**
- * The defaults every test starts from. A Proxy rather than an enumerated object was the
- * original point: production code reads a long tail of URL/endpoint vars at module load, and
- * enumerating all of them is how the previous per-file mocks became partial.
+ * The defaults every test starts from. Derived from the env schema's own .default()
+ * values, with test-specific overrides layered on top for values the schema leaves
+ * required (no default) or where the test needs a different value.
+ *
+ * 🔴 The schema-derived base means a key gaining a `.default()` in the schema
+ * automatically appears here — the hand-enumerated divergence that caused OC-317
+ * (REPLICATION_LAG_DELAY missing, read as undefined under test) cannot recur.
  */
 export const TEST_ENV_DEFAULTS: Record<string, unknown> = {
-  TIER_METADATA_KEY: 'tier',
-  BUZZ_ENDPOINT: 'http://mock-buzz-endpoint',
-  // meilisearch/client.ts feeds this straight into pLimit() at module load — an undefined
-  // value makes p-limit throw "Expected concurrency to be a number". Mirrors the production
-  // default (server-schema.ts: .default(50)).
-  MEILI_CALL_CONCURRENCY: 50,
-  MEILI_RESOURCE_SELECT_CONCURRENCY: 500,
-  SIGNALS_CALL_CONCURRENCY: 30,
-  LOGGING: '',
-  FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com',
-  APPS_DOMAIN: 'civit.ai',
+  // Schema-derived defaults (every .default() from serverSchema)
+  ...schemaDefaults(),
+
+  // ── Test-specific overrides ──────────────────────────────────────────────
+  // Required fields the schema leaves without defaults — tests need values:
   DATABASE_URL: 'postgres://user:pass@localhost:5432/db',
   NOTIFICATION_DB_URL: 'postgres://user:pass@localhost:5432/notif',
-  DATABASE_SSL: false,
-  DATABASE_POOL_MAX: 10,
-  DATABASE_POOL_IDLE_TIMEOUT: 30000,
-  DATABASE_CONNECTION_TIMEOUT: 5000,
-  DATABASE_WRITE_TIMEOUT: 10000,
-  DATABASE_READ_TIMEOUT: 10000,
   REDIS_URL: 'redis://localhost:6379',
   REDIS_SYS_URL: 'redis://localhost:6379',
-  REDIS_SYS_SOCKET_TIMEOUT_MS: 0,
-  REDIS_SYS_READ_TIMEOUT_MS: 2000,
-  REDIS_SYS_COMMANDS_QUEUE_MAX_LENGTH: 10000,
   NEXTAUTH_URL: 'http://localhost:3000',
   NEXTAUTH_SECRET: 'test-secret',
-  // endpoint-helpers spreads TRPC_ORIGINS at module load, so an undefined value makes
-  // importing ANY api page throw "is not iterable". Non-empty tokens below so a request that
-  // omits `?token=` genuinely fails the check rather than matching `undefined !== undefined`.
-  TRPC_ORIGINS: [] as string[],
   WEBHOOK_TOKEN: 'test-webhook-token',
   JOB_TOKEN: 'test-job-token',
   S3_UPLOAD_ENDPOINT: 'http://localhost:9000',
   S3_IMAGE_UPLOAD_ENDPOINT: 'http://localhost:9000',
   ORCHESTRATOR_ENDPOINT: 'http://localhost:8080',
-  // orchestrator.caller constructs an OrchestratorCaller at MODULE scope and throws
-  // `Missing ORCHESTRATOR_ACCESS_TOKEN env` without this, so any suite whose graph
-  // reaches it (e.g. importing orchestrator.router) fails to collect. Worker-level for
-  // the same reason as the endpoint above — a per-file override arrives too late.
   ORCHESTRATOR_ACCESS_TOKEN: 'test-orchestrator-token',
   SIGNALS_ENDPOINT: 'http://localhost:8081',
-  // Read by clickhouse/client.ts at MODULE scope, so it has to be a worker-level default: a
-  // per-file override arrives after that module was already evaluated for the worker. This
-  // is the class that distinguishes env from the call-surface mocks — see the KNOWN LIMIT
-  // note at the top.
   CLICKHOUSE_TRACKER_URL: 'http://tracker.test',
   FLIPT_URL: 'http://localhost:8082',
   EMAIL_HOST: 'smtp.localhost',
@@ -147,6 +147,15 @@ export const TEST_ENV_DEFAULTS: Record<string, unknown> = {
   S3_UPLOAD_SECRET: 'test-secret',
   S3_IMAGE_UPLOAD_KEY: 'test-key',
   S3_IMAGE_UPLOAD_SECRET: 'test-secret',
+  BUZZ_ENDPOINT: 'http://mock-buzz-endpoint',
+  LOGGING: '',
+
+  // Schema defaults overridden for test speed/behaviour:
+  DATABASE_SSL: false, // schema default: true — tests don't need SSL
+  DATABASE_POOL_MAX: 10, // schema default: 20 — smaller pool for tests
+  DATABASE_CONNECTION_TIMEOUT: 5000, // schema default: 0 — give tests a real timeout
+  DATABASE_WRITE_TIMEOUT: 10000, // schema has no default (optional) — tests need a value
+  DATABASE_READ_TIMEOUT: 10000, // schema has no default (optional) — tests need a value
 };
 
 setEnvDefaults(TEST_ENV_DEFAULTS);

--- a/src/server/db/__tests__/db-lag-helpers.regression.test.ts
+++ b/src/server/db/__tests__/db-lag-helpers.regression.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Regression test for OC-317: REPLICATION_LAG_DELAY is a zod .default(0) key
+ * that was absent from the hand-enumerated TEST_ENV_DEFAULTS. Under test the
+ * canonical env read undefined, and `undefined <= 0` is false where `0 <= 0` is
+ * true — so every test reaching getDbWithoutLag without stubbing db-lag-helpers
+ * took a replication-staleness branch that production never takes.
+ *
+ * This test proves the specific defect is closed:
+ * 1. The env default is 0 (not undefined) — the direct fix
+ * 2. getDbWithoutLag returns dbRead via the short-circuit path
+ *
+ * Red at 312a91ad7c: env.REPLICATION_LAG_DELAY was undefined, so
+ * expect(undefined).toBe(0) failed.
+ *
+ * Green at HEAD: TEST_ENV_DEFAULTS now derives REPLICATION_LAG_DELAY: 0 from
+ * the env schema, so expect(0).toBe(0) passes and getDbWithoutLag short-circuits.
+ */
+
+// Uses the CANONICAL shared redis mock, not a hand-rolled one. Mocking the redis
+// client specifier directly here would add a new entry to the canonical allowlist,
+// and the migration ratchet then refuses to regenerate — so this file's own mock
+// would have blocked the two conversions it ships alongside.
+//
+// Note for anyone editing this comment: the ratchet detects violations with a plain
+// regex over the file's TEXT, so spelling the forbidden call out literally — even
+// inside a comment — re-triggers it. Describe it, do not quote it.
+import '~/__tests__/mocks/redis.mock';
+
+import { env } from '~/env/server';
+import { getDbWithoutLag } from '~/server/db/db-lag-helpers';
+import { dbRead } from '~/server/db/client';
+
+describe('OC-317: REPLICATION_LAG_DELAY defaults to 0 in test env', () => {
+  it('env.REPLICATION_LAG_DELAY is 0, not undefined', () => {
+    expect(env.REPLICATION_LAG_DELAY).toBe(0);
+  });
+
+  it('getDbWithoutLag returns dbRead without consulting the lag tracker', async () => {
+    const result = await getDbWithoutLag('model', 123);
+    expect(result).toBe(dbRead);
+  });
+
+  it('getDbWithoutLag returns dbRead even without type/id args', async () => {
+    const result = await getDbWithoutLag();
+    expect(result).toBe(dbRead);
+  });
+});

--- a/src/server/orchestrator/__tests__/get-orchestrator-token.sysredis-soft.test.ts
+++ b/src/server/orchestrator/__tests__/get-orchestrator-token.sysredis-soft.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * STEP-6 sysRedis soft-dependency — the cross-pod orchestrator-token READ in
@@ -46,11 +46,22 @@ vi.mock('~/server/orchestrator/orchestrator-token-cache', () => ({
 vi.mock('~/server/services/api-key.service', () => ({ getTemporaryUserApiKey: mockGetTempKey }));
 
 import { getOrchestratorToken } from '~/server/orchestrator/get-orchestrator-token';
+import { resetEnv, setEnv } from '~/__tests__/mocks/env.mock';
 
 const ctx = { req: {} as any, res: {} as any };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // 🔴 PIN THE MODE. `get-orchestrator-token.ts` short-circuits on
+  // `env.ORCHESTRATOR_MODE === 'dev'` and returns the static
+  // ORCHESTRATOR_ACCESS_TOKEN without ever reaching sysRedis — which is the
+  // entire path this file tests. That branch used to be unreachable here only
+  // BY ACCIDENT: ORCHESTRATOR_MODE was missing from the hand-enumerated
+  // TEST_ENV_DEFAULTS, so it read `undefined`. Once the defaults were derived
+  // from the schema (which declares `.default('dev')`) the accident ended and
+  // all three cases returned 'test-orchestrator-token'. Pin it explicitly so
+  // the suite states what it depends on instead of inheriting a gap.
+  setEnv({ ORCHESTRATOR_MODE: 'prod' });
   mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
   // The mint path (used on DOWN/SLOW) — coalesced mint returns a fresh token.
   mockGetOrMint.mockImplementation(async (_userId: number, mint: () => Promise<string>) => mint());
@@ -95,4 +106,8 @@ describe('getOrchestratorToken — sysRedis read soft-dependency', () => {
     expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
     expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('token-mint-amplification');
   });
+});
+
+afterAll(() => {
+  resetEnv();
 });

--- a/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
+++ b/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
@@ -1,17 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type * as RedisClient from '@civitai/redis/client';
+import { dbMock } from '~/__tests__/mocks/db.mock';
 
 // Blue Buzz for paid access. A blue purchase must credit the owner blue, or it turns non-withdrawable
 // credit into withdrawable currency. `toAccountType` defaults to yellow in buzz.service.
-
-const { mockDbWrite } = vi.hoisted(() => ({
-  mockDbWrite: {
-    modelVersion: { findUnique: vi.fn() },
-    entityAccess: { findFirst: vi.fn(), upsert: vi.fn() },
-    donation: { create: vi.fn() },
-    $queryRaw: vi.fn(),
-  },
-}));
 
 const {
   mockCreateMultiAccountBuzzTransaction,
@@ -33,7 +25,6 @@ const {
   mockCheckDonationGoalComplete: vi.fn(),
 }));
 
-vi.mock('~/server/db/client', () => ({ dbRead: mockDbWrite, dbWrite: mockDbWrite }));
 vi.mock('~/server/prom/client', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return { ...actual, dbReadFallbackCounter: { inc: vi.fn() } };
@@ -109,14 +100,19 @@ const seed = ({
   acceptsBlueBuzz = false,
   goal = null as { id: number; active: boolean } | null,
 } = {}) => {
-  mockDbWrite.modelVersion.findUnique.mockResolvedValue({
+  const versionRow = {
     id: VERSION_ID,
     status: 'Published',
     name: 'v1',
     meta: { hadEarlyAccessPurchase: true },
     baseModel: 'SDXL 1.0',
     model: { id: 1, name: 'Model', userId: OWNER, nsfw: false },
-  });
+  };
+  // getDbWithoutLag('modelVersion', id) returns dbRead when REPLICATION_LAG_DELAY=0;
+  // earlyAccessPurchase calls getVersionById which uses it. Set up both sides so
+  // the test is correct regardless of which client the service routes through.
+  dbMock.dbRead.modelVersion.findUnique.mockResolvedValue(versionRow);
+  dbMock.dbWrite.modelVersion.findUnique.mockResolvedValue(versionRow);
   mockGetPaidAccess.mockResolvedValue({
     [VERSION_ID]: {
       entityType: 'ModelVersion',
@@ -130,8 +126,10 @@ const seed = ({
   });
   mockGetOwnerDonationGoals.mockResolvedValue(goal ? { [VERSION_ID]: goal } : {});
   mockHasEntityAccess.mockResolvedValue([{ hasAccess: false, permissions: 0, meta: null }]);
-  mockDbWrite.entityAccess.findFirst.mockResolvedValue(null);
-  mockDbWrite.entityAccess.upsert.mockResolvedValue({});
+  dbMock.dbRead.entityAccess.findFirst.mockResolvedValue(null);
+  dbMock.dbRead.entityAccess.upsert.mockResolvedValue({});
+  dbMock.dbWrite.entityAccess.findFirst.mockResolvedValue(null);
+  dbMock.dbWrite.entityAccess.upsert.mockResolvedValue({});
   mockCreateMultiAccountBuzzTransaction.mockResolvedValue({
     transactionCount: 1,
     transactionIds: [],
@@ -203,7 +201,7 @@ describe('earlyAccessPurchase — Blue Buzz', () => {
       buzzType: 'blue',
     });
 
-    expect(mockDbWrite.donation.create).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.donation.create).not.toHaveBeenCalled();
     expect(mockCheckDonationGoalComplete).not.toHaveBeenCalled();
   });
 
@@ -217,7 +215,7 @@ describe('earlyAccessPurchase — Blue Buzz', () => {
       buzzType: 'green',
     });
 
-    expect(mockDbWrite.donation.create).toHaveBeenCalledTimes(1);
+    expect(dbMock.dbWrite.donation.create).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -285,14 +283,16 @@ describe('earlyAccessPurchase — a scheduled sale is priced from the PRIMARY, n
     // this, a resolver that charged before validating would pass every assertion in this file.
     seed();
     mockGetFreshSalesForPermanentGate.mockResolvedValue([liveSale]);
-    mockDbWrite.modelVersion.findUnique.mockResolvedValue({
+    const draftVersion = {
       id: VERSION_ID,
       status: 'Draft',
       name: 'v1',
       meta: {},
       baseModel: 'SDXL 1.0',
       model: { id: 1, name: 'Model', userId: OWNER, nsfw: false },
-    });
+    };
+    dbMock.dbRead.modelVersion.findUnique.mockResolvedValue(draftVersion);
+    dbMock.dbWrite.modelVersion.findUnique.mockResolvedValue(draftVersion);
 
     await expect(
       earlyAccessPurchase({
@@ -304,7 +304,7 @@ describe('earlyAccessPurchase — a scheduled sale is priced from the PRIMARY, n
     ).rejects.toThrow();
 
     expect(mockCreateMultiAccountBuzzTransaction).not.toHaveBeenCalled();
-    expect(mockDbWrite.entityAccess.upsert).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.entityAccess.upsert).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/__tests__/model-version.purge-by-hash.service.test.ts
+++ b/src/server/services/__tests__/model-version.purge-by-hash.service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
 
 // Verifies the by-hash edge-cache purge hook: on delete AND unpublish, the
 // service purges the `GET /api/v1/model-versions/by-hash/[hash]` PublicEndpoint
@@ -6,39 +7,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // resolving by-hash before the cache TTL expires. The purge is best-effort — a
 // purge failure must NOT fail the (already-committed) mutation.
 
-const { mockDb } = vi.hoisted(() => {
-  const mk = () => ({
-    findFirst: vi.fn(),
-    findFirstOrThrow: vi.fn(),
-    findUnique: vi.fn(),
-    findUniqueOrThrow: vi.fn(),
-    findMany: vi.fn(),
-    create: vi.fn(),
-    update: vi.fn(),
-    updateMany: vi.fn(),
-    delete: vi.fn(),
-    deleteMany: vi.fn(),
-    groupBy: vi.fn(),
-    count: vi.fn(),
-  });
-  const db = {
-    modelVersion: mk(),
-    modelFile: mk(),
-    modelFileHash: mk(),
-    entityAccess: mk(),
-    paidAccess: mk(),
-    post: mk(),
-    image: mk(),
-    $queryRaw: vi.fn(),
-    $executeRaw: vi.fn(),
-    $transaction: vi.fn(),
-  };
-  return { mockDb: db };
-});
-
 const { mockPurgeCache } = vi.hoisted(() => ({ mockPurgeCache: vi.fn() }));
 
-vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
 vi.mock('~/server/cloudflare/client', () => ({ purgeCache: mockPurgeCache }));
 vi.mock('~/server/utils/url-helpers', () => ({
   getBaseUrl: () => 'https://civitai.com',
@@ -61,9 +31,8 @@ vi.mock('~/server/redis/caches', () => ({
   modelVersionResourceCache: {},
 }));
 vi.mock('~/server/redis/client', async () => {
-  const actual = await vi.importActual<typeof import('@civitai/redis/client')>(
-    '@civitai/redis/client'
-  );
+  const actual =
+    await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
   return {
     ...actual,
     redis: { get: vi.fn(), set: vi.fn(), del: vi.fn() },
@@ -124,29 +93,20 @@ import {
   unpublishModelVersionById,
 } from '~/server/services/model-version.service';
 
-// Drive the interactive transaction: invoke the callback with a `tx` that maps
-// to our mocked db delegates.
-function wireTransaction() {
-  mockDb.$transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
-    cb(mockDb)
-  );
-}
-
 const VERSION_ID = 4242;
 const MODEL_ID = 7;
 const USER_ID = 99;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  wireTransaction();
   mockPurgeCache.mockResolvedValue(undefined);
 });
 
 function stubDeleteRows(files: { url: string; hashes: string[] }[]) {
-  mockDb.modelFile.findMany.mockResolvedValue(
+  dbMock.dbWrite.modelFile.findMany.mockResolvedValue(
     files.map((f) => ({ url: f.url, hashes: f.hashes.map((hash) => ({ hash })) }))
   );
-  mockDb.modelVersion.findFirstOrThrow.mockResolvedValue({
+  dbMock.dbWrite.modelVersion.findFirstOrThrow.mockResolvedValue({
     id: VERSION_ID,
     modelId: MODEL_ID,
     status: 'Published',
@@ -154,8 +114,8 @@ function stubDeleteRows(files: { url: string; hashes: string[] }[]) {
     earlyAccessEndsAt: null,
     meta: {},
   });
-  mockDb.entityAccess.deleteMany.mockResolvedValue({ count: 0 });
-  mockDb.modelVersion.delete.mockResolvedValue({ id: VERSION_ID, modelId: MODEL_ID });
+  dbMock.dbWrite.entityAccess.deleteMany.mockResolvedValue({ count: 0 });
+  dbMock.dbWrite.modelVersion.delete.mockResolvedValue({ id: VERSION_ID, modelId: MODEL_ID });
 }
 
 describe('deleteVersionById — by-hash edge-cache purge', () => {
@@ -222,20 +182,21 @@ describe('deleteVersionById — by-hash edge-cache purge', () => {
 
 describe('unpublishModelVersionById — by-hash edge-cache purge', () => {
   function stubUnpublish() {
-    mockDb.modelVersion.update.mockResolvedValue({
+    dbMock.dbWrite.modelVersion.update.mockResolvedValue({
       id: VERSION_ID,
       model: { id: MODEL_ID, userId: USER_ID, nsfw: false },
     });
-    mockDb.$executeRaw.mockResolvedValue(0);
-    mockDb.post.findMany.mockResolvedValue([]);
-    mockDb.image.findMany.mockResolvedValue([]);
+    dbMock.dbWrite.$executeRaw.mockResolvedValue(0);
+    dbMock.dbWrite.post.findMany.mockResolvedValue([]);
+    dbMock.dbWrite.image.findMany.mockResolvedValue([]);
     // Rows still exist on unpublish — resolved by-hash via modelFileHash.findMany.
-    mockDb.modelFileHash.findMany.mockResolvedValue([{ hash: 'DEADBEEF' }]);
+    // purgeModelVersionByHashCacheById uses dbRead (not dbWrite), so stub there.
+    dbMock.dbRead.modelFileHash.findMany.mockResolvedValue([{ hash: 'DEADBEEF' }]);
     // Nothing was ever bought here, so the refund gate finds no obligation and lets the
     // unpublish through — this file is about the cache purge, not the gate.
-    mockDb.modelVersion.findMany.mockResolvedValue([{ id: VERSION_ID, meta: null }]);
+    dbMock.dbWrite.modelVersion.findMany.mockResolvedValue([{ id: VERSION_ID, meta: null }]);
     // An ordinary published version, so the moderator-status guard does not preserve anything.
-    mockDb.modelVersion.findUniqueOrThrow.mockResolvedValue({ status: 'Published' });
+    dbMock.dbWrite.modelVersion.findUniqueOrThrow.mockResolvedValue({ status: 'Published' });
   }
 
   it('resolves the version hashes and purges the by-hash URL(s)', async () => {
@@ -243,7 +204,7 @@ describe('unpublishModelVersionById — by-hash edge-cache purge', () => {
 
     await unpublishModelVersionById({ id: VERSION_ID, user: { id: USER_ID } as never });
 
-    expect(mockDb.modelFileHash.findMany).toHaveBeenCalledWith({
+    expect(dbMock.dbRead.modelFileHash.findMany).toHaveBeenCalledWith({
       where: { file: { modelVersionId: VERSION_ID } },
       select: { hash: true },
     });
@@ -280,7 +241,8 @@ describe('publishModelVersionById — by-hash edge-cache purge', () => {
   // on publish, so hashes are resolved via modelFileHash.findMany.
   function stubPublish() {
     // currentVersion read (findUniqueOrThrow, then post-tx reads use dbWrite).
-    mockDb.modelVersion.findUniqueOrThrow.mockResolvedValue({
+    // publishModelVersionById tries dbRead first, falls back to dbWrite on failure.
+    dbMock.dbRead.modelVersion.findUniqueOrThrow.mockResolvedValue({
       id: VERSION_ID,
       name: 'v1',
       baseModel: 'SD 1.5',
@@ -295,17 +257,18 @@ describe('publishModelVersionById — by-hash edge-cache purge', () => {
       },
     });
     // In-transaction update returns the shape the post-commit code reads.
-    mockDb.modelVersion.update.mockResolvedValue({
+    dbMock.dbWrite.modelVersion.update.mockResolvedValue({
       id: VERSION_ID,
       modelId: MODEL_ID,
       baseModel: 'SD 1.5',
       model: { userId: USER_ID, id: MODEL_ID, type: 'Checkpoint', nsfw: false },
     });
-    mockDb.$executeRaw.mockResolvedValue(0);
-    mockDb.post.findMany.mockResolvedValue([]);
-    mockDb.image.findMany.mockResolvedValue([]);
+    dbMock.dbWrite.$executeRaw.mockResolvedValue(0);
+    dbMock.dbWrite.post.findMany.mockResolvedValue([]);
+    dbMock.dbWrite.image.findMany.mockResolvedValue([]);
     // Rows still exist on publish — resolved by-hash via modelFileHash.findMany.
-    mockDb.modelFileHash.findMany.mockResolvedValue([{ hash: 'CAFED00D' }]);
+    // purgeModelVersionByHashCacheById uses dbRead (not dbWrite), so stub there.
+    dbMock.dbRead.modelFileHash.findMany.mockResolvedValue([{ hash: 'CAFED00D' }]);
   }
 
   it('resolves the version hashes and purges the by-hash URL(s) on publish', async () => {
@@ -313,7 +276,7 @@ describe('publishModelVersionById — by-hash edge-cache purge', () => {
 
     await publishModelVersionById({ id: VERSION_ID });
 
-    expect(mockDb.modelFileHash.findMany).toHaveBeenCalledWith({
+    expect(dbMock.dbRead.modelFileHash.findMany).toHaveBeenCalledWith({
       where: { file: { modelVersionId: VERSION_ID } },
       select: { hash: true },
     });


### PR DESCRIPTION
`TEST_ENV_DEFAULTS` was hand-maintained, so a key that gained a `.default()` in the env schema silently read `undefined` under test.

`REPLICATION_LAG_DELAY` is the caught instance, and the consequence is **a wrongly-decided branch, not a missing value**:

```
undefined <= 0   is  false
0 <= 0           is  true
```

So every test reaching `getDbWithoutLag` without stubbing the lag helpers took a replication-staleness path production never takes.

## The fix

Derive the base from `serverSchema.shape` via `field.parse(undefined)`, with test-specific overrides layered on top. A new schema default now appears in the test env automatically. **~50 keys** that were absent from the hand-written list are now present.

This is deliberately *not* the one-line fix. Adding `REPLICATION_LAG_DELAY: 0` to the hand list closes one key and leaves the mechanism.

## Verification

**Regression test** — `src/server/db/__tests__/db-lag-helpers.regression.test.ts`, watched to fail on pre-change code:

| | |
|---|---|
| red at `312a91ad7c` | `AssertionError: expected undefined to be +0` |
| green at HEAD | 3 collected, 3 passed |

**Behaviour-change control.** The three suites reported as pre-existing failures were measured in **two arms on this tree, with only `env.mock.ts` swapped**: identical `16 failed / 8 passed` either way. So they are unaffected by this change.

🔴 That is a claim about **three files, not the full 1315-file suite**, which has not been run in two arms. Given the change widens the test env by ~50 keys, CI is the real check here — flagging it rather than implying wider coverage than I measured.

## Also in this PR

Moves `model-version.blue-buzz-purchase` and `model-version.purge-by-hash` off their direct `~/server/db/client` mocks and onto the canonical `dbMock` (13/13 and 8/8 collected and passing).

## Known incomplete

🔴 **Those two files do NOT yet drop out of the generated allowlist.** They still mock `~/server/redis/client` directly, which is also a canonical specifier, so `gen-mock-allowlist.mjs` reports `217 -> 217 (0 migrated)`. Completing that conversion is follow-up work and is recorded in the commit rather than papered over.

One note for reviewers editing the new test: the migration ratchet detects violations with a plain **regex over file text**, so spelling the forbidden mock call literally — even inside a comment — re-triggers it. There's a comment in the file saying so.