### PR TITLE
perf(db): index UserProfile.sfwCoverImageId — the unindexed FK behind post-delete P2028 (289 h of seq scans)

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260821140000_user_profile_sfw_cover_image_fk_index/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260821140000_user_profile_sfw_cover_image_fk_index/migration.sql
@@ -1,0 +1,51 @@
+-- "UserProfile"."sfwCoverImageId" has a foreign key to "Image" with ON DELETE SET
+-- NULL and no index on the referencing column. Postgres has to run the referential
+-- integrity trigger once per deleted Image row, and with nothing to serve
+-- `WHERE $1 = "sfwCoverImageId"` each of those is a sequential scan of the whole
+-- 1673 MB / ~3.44M-row table.
+--
+-- Measured on the primary, over the 11 days since the FK was created:
+--   calls 1,645,243 | mean 634.3 ms | total 289.9 HOURS | ~193,719 buffers/call
+-- ...for which it has set 12 rows to NULL in total. The scan is ~100% shared-buffer
+-- hits, so it burns CPU rather than IO and does not show up as a disk problem.
+--
+-- User-visible as Prisma P2028 "Transaction already closed" on post deletion: the
+-- deletes are batched inside one transaction, so at 634 ms per image the failure is
+-- deterministic by post size. Even with the transaction budget at 30s, a post of
+-- ~48 images or more cannot finish. The bulk `deleteImages()` path is worse -- p50
+-- 62.7s on 100-image batches.
+--
+-- Introduced by be0c4ac83f ("feat(profile): add .com-only cover image, announcement
+-- and bio overrides"). Prisma does not create an index for a relation scalar, so a
+-- @relation with onDelete: SetNull silently ships this shape unless the @@index is
+-- written by hand. The neighbouring "coverImageId" column on this same table shows
+-- both halves of the mistake: it has the index but no foreign key, while
+-- "sfwCoverImageId" has the foreign key but no index.
+--
+-- CONCURRENTLY, so building it cannot lock out profile writes. Three consequences
+-- for whoever applies this by hand:
+--
+--   1. It must NOT be wrapped in a transaction block -- run this statement on its own.
+--
+--   2. Do not apply it under a session with a lock_timeout set. CREATE INDEX
+--      CONCURRENTLY briefly takes a lock at both ends of the build, and a timeout
+--      there fails DIRTY: it leaves an INVALID index behind. `SET lock_timeout = 0`
+--      for this session.
+--
+--   3. IF NOT EXISTS matches on the NAME. If a previous attempt left an invalid
+--      index, this statement reports success and creates nothing. Check for that
+--      before retrying, and drop it first:
+--        SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+--        DROP INDEX CONCURRENTLY "UserProfile_sfwCoverImageId_idx";
+--      An invalid index is maintained by every write and used by no query, so
+--      leaving one costs writes and buys nothing.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "UserProfile_sfwCoverImageId_idx"
+  ON "UserProfile" ("sfwCoverImageId");
+
+-- VERIFY against the primary, by the flag rather than the exit code -- a sibling
+-- migration having been applied is not evidence this one was:
+--   SELECT indisvalid FROM pg_index
+--   WHERE indexrelid = '"UserProfile_sfwCoverImageId_idx"'::regclass;
+--
+-- If that returns false: REINDEX INDEX CONCURRENTLY "UserProfile_sfwCoverImageId_idx";
+-- or DROP INDEX CONCURRENTLY and re-run the statement above.

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -6851,6 +6851,10 @@ model UserProfile {
   showcaseItems           Json      @default("[]")
 
   @@id([userId])
+  // Serves the ON DELETE SET NULL referential-integrity trigger for the
+  // sfwCoverImage relation. Without it every Image delete sequentially scans this
+  // whole table. Prisma does not index relation scalars on its own.
+  @@index([sfwCoverImageId])
 }
 
 /// @view


### PR DESCRIPTION
## The defect

`"UserProfile"."sfwCoverImageId"` has a foreign key to `"Image"` with **`ON DELETE SET NULL`** and **no index on the referencing column**. The table is **1673 MB / ~3.44M rows**.

Postgres runs the referential-integrity trigger once per deleted `Image` row, and with nothing to serve `WHERE $1 = "sfwCoverImageId"` each one is a sequential scan of the entire table. Measured on the primary over the 11 days since the FK was created:

```
UPDATE ONLY "public"."UserProfile" SET "sfwCoverImageId" = $2
  WHERE $1 OPERATOR(pg_catalog.=) "sfwCoverImageId"

calls 1,645,243 | mean 634.3 ms | total 289.9 HOURS | ~193,719 buffers/call
```

...for which it has set **12 rows** to NULL in total. The scan is ~100% shared-buffer hits, so it burns CPU rather than IO and never looked like a disk problem.

It is the most expensive referential-integrity statement in the database by three orders of magnitude — the next one totals 0.96 h.

### User impact

Post deletion fails with Prisma **P2028 "Transaction already closed"**. The image deletes share one transaction, so at 634 ms per image the failure is **deterministic by post size**, not intermittent. With the transaction budget raised from 10s to 30s in `00346e6c8`, posts of **~48 images or more** still cannot finish. The bulk `deleteImages()` path is worse: **p50 62.7 s** on 100-image batches.

### Origin

Introduced by `be0c4ac83f` ("feat(profile): add .com-only cover image, announcement and bio overrides"). The `pg_stat_statements` entry for the statement above first appears **3.4 seconds** after that commit.

Prisma does not create an index for a relation scalar, so a `@relation` with `onDelete: SetNull` ships this shape unless the `@@index` is written by hand. Both halves of the mistake are visible on this one table: `coverImageId` has an index but **no** FK, while `sfwCoverImageId` has an FK but **no** index.

## The change

- New migration `20260821140000_user_profile_sfw_cover_image_fk_index`, using `CREATE INDEX CONCURRENTLY` — the existing convention here (37 prior migrations in this directory use it).
- Matching `@@index([sfwCoverImageId])` on `model UserProfile` in `schema.full.prisma`, so a database rebuilt from the schema gets it too. Prisma's default name for that declaration is `UserProfile_sfwCoverImageId_idx`, which is exactly the name the migration creates, so no `map:` is needed. (`schema.prisma` is generated and gitignored — not committed.)

Verified: `prisma validate` passes on the edited schema, and fails at that exact line when the column name is corrupted (so the check is not vacuous).

## 🔴 Notes for whoever applies this

This is **not** applied by CI. Three things about `CREATE INDEX CONCURRENTLY`, all also written into the migration file itself:

1. **It cannot run inside a transaction block.** Run the statement on its own.

2. **Do not apply it under a session that has a `lock_timeout` set.** CIC briefly takes a lock at both ends of the build; a timeout there **fails dirty**, leaving an **INVALID** index that must be `DROP INDEX CONCURRENTLY`-ed before retrying. Please `SET lock_timeout = 0` for the applying session. This is worth calling out because a 30s `lock_timeout` was recently added to the role these migrations run as, which makes this the default outcome rather than bad luck.

3. **`IF NOT EXISTS` matches on the NAME.** If a previous attempt left an invalid index behind, a retry reports success and creates nothing. Check first:
   ```sql
   SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
   ```
   Verify by the flag, not the exit code:
   ```sql
   SELECT indisvalid FROM pg_index
   WHERE indexrelid = '"UserProfile_sfwCoverImageId_idx"'::regclass;
   ```

An invalid index is maintained by every write and used by no query, so leaving one costs writes and buys nothing.

## Sweep: the same defect elsewhere

Since the likely cause is systemic (Prisma not indexing relation scalars), I enumerated **every** FK in the database whose referencing column cannot serve the RI lookup. **123 of 464** foreign keys qualify.

Two corrections to the naive `pg_catalog` query, both of which change the answer:

- The index must have the FK column as its **leading** key. `attnum = ANY(indkey)` also counts composites like `(other, fkcol)`, which cannot serve `WHERE fkcol = $1`. The naive form reports 88; the correct one reports 125.
- A **partial** index still qualifies when its predicate is `fkcol IS NOT NULL`, because the planner proves `$1 = fkcol` implies it. Missing this produced a false positive on `ModelVersion.vaeId`, which looked like the #2 offender by table size but actually runs at **0.00 ms / 2 buffers** per call — it is served by `ModelVersion_vaeId_idx`, a partial index. That correction takes 125 down to **123**.

Ranked by **observed** cost (`pg_stat_statements`), not by modeled exposure:

| # | Child table | FK column | Parent | On delete | Heap | RI calls | Total | Mean | Buffers/call |
|---|---|---|---|---|---|---|---|---|---|
| 1 | `UserProfile` | `sfwCoverImageId` | `Image` | SET NULL | 1524 MB | 1,645,243 | **289.89 h** | **634.32 ms** | **193,719** |
| 2 | `ModelVersionEngagement` | `modelVersionId` | `ModelVersion` | CASCADE | 71 MB | 153,530 | 0.96 h | 22.38 ms | 4,937 |
| 3 | `RecommendedResource` | `resourceId` | `ModelVersion` | CASCADE | 22 MB | 153,530 | 0.53 h | 12.45 ms | 2,866 |
| 4 | `Challenge` | `coverImageId` | `Image` | SET NULL | 1448 kB | 5,440,470 | 0.27 h | 0.18 ms | 188 |
| 5 | `FeaturedModelVersion` | `modelVersionId` | `ModelVersion` | CASCADE | 4224 kB | 153,530 | 0.15 h | 3.41 ms | 506 |
| 6 | `DonationGoal` | `modelVersionId` | `ModelVersion` | SET NULL | 4464 kB | 153,530 | 0.03 h | 0.65 ms | 177 |
| 7 | `CollectionItem` | `articleId` | `Article` | CASCADE | 15 GB | 149 | 0.001 h | 14.94 ms | 958 |

Reading of that:

- **#1 is in a class of its own.** Fixing it is worth ~1000× the rest combined. I've deliberately scoped this PR to it alone.
- **#2, #3, #5, #6 all fire on `ModelVersion` delete** and together cost ~1.66 h. A single follow-up PR indexing all four is cheap and worth doing, but it is not urgent.
- **#4 is the same shape as the bug being fixed here** — an unindexed `Image` FK with SET NULL, on the same image-delete path, hit 5.4M times. It is cheap *only* because `Challenge` is 1448 kB. It is a landmine if that table ever grows, and it is the clearest evidence the cause is systemic rather than a one-off.
- **#7** scans a small partial index rather than the 15 GB heap, which is why a 15 GB table costs only 14.94 ms. Low frequency (636 article deletes).

The remaining ~116 are **latent** — never yet exercised. The largest group is FKs to `User` (`CollectionItem.reviewedById` on 15 GB, `UserEngagement.targetUserId` on 2274 MB, `CommentV2.userId` on 561 MB, and ~20 more), all of which show `n_tup_del = 0` on `User`: user rows are not hard-deleted today. They are only a problem if that ever changes — at which point several would be far worse than this one.

### On the 2026-08-10 migration wave

I checked it specifically. The other migrations dated 2026-08-08…08-12 do **not** repeat this defect — `20260810140000_app_listing_collaborators` and `20260811170000_rekey_app_collaborators_step_b_*` create their own indexes alongside their FKs, and `20260811090000_challenge_judging_engines` indexes `challengeId` where it adds the FK. `sfwCoverImageId` is the only one in that wave that shipped an FK without an index.

## What I could not determine

Nothing blocking. The CIC-in-a-transaction question has a clear, well-established precedent in this repo (37 migrations, several with explicit prose about the invalid-index hazard), so I followed it rather than presenting options.

Two things I noticed but did **not** act on, both out of scope:

- `UserProfile.coverImageId` is declared in Prisma with `@relation(..., onDelete: SetNull)` but has **no FK constraint** in the database. That is declared-but-not-enforced drift, and the kind of thing `pnpm --filter @civitai/db-schema drift` exists to catch.
- The RI statement for `Challenge.coverImageId` (#4 above) suggests it is worth deciding whether new `Image` FKs should get an index by default rather than case-by-case.

## Not applied

Per the migration policy for this database, nothing here has been applied. No `CREATE INDEX`, no `ALTER`, no `prisma migrate`. All measurements above are `SELECT`-only against `pg_catalog` / `pg_stat_*`.
