### PR TITLE
fix(blocks): shape workflow `resources` into resourceSchema form before graph validation (#4159)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -475,6 +475,12 @@ import { TransactionType } from '~/shared/constants/buzz.constants';
 // honest about the shape it consumes.
 import { createModelSubstitutionCollector } from '~/shared/data-graph/generation/model-substitution';
 import type { ModelSubstitutionReason } from '~/shared/data-graph/generation/model-substitution';
+// #4159 — the REAL validator. `createWorkflowStepsFromGraphInput` is mocked for
+// this whole file, which is exactly why the LoRA defect was invisible here; the
+// regression suite re-arms `generationGraph.safeParse` inside that mock so the
+// input the router builds is graded by the thing that actually rejected it in
+// production. NOT mocked anywhere, so this is the shipped graph.
+import { generationGraph } from '~/shared/data-graph/generation/generation-graph';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { loggingMock } from '~/__tests__/mocks/logging.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
@@ -4405,6 +4411,248 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
       expect(mockResolveCanGenerateForVersions).not.toHaveBeenCalled();
       expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // REGRESSION — issue #4159: `additionalResources` was dead for EVERY LoRA
+    // that survived the compatibility gate.
+    //
+    // 🔴 WHY THE REST OF THIS FILE COULD NOT SEE IT. `createWorkflowStepsFromGraphInput`
+    // is mocked at the module boundary for the whole suite, so the generation
+    // graph — the thing that rejected the built input — never ran. Every test
+    // above that submits a compatible LoRA is green on `main` while production
+    // returns HTTP 400. So these tests re-arm the ONE step that was stubbed out:
+    // the mock runs the REAL `generationGraph.safeParse` on the input the router
+    // actually built, and reproduces `validateInput`'s throw on failure (same
+    // `Validation failed: <key>: <message>` shape). Nothing else is unmocked.
+    //
+    // The defect: `buildImageWorkflowInput` emitted `{ id, strength }`, which
+    // satisfies the resources node's loose INPUT schema but not its OUTPUT
+    // schema (`resourceSchema`, which requires `model: { type }`) — the enrichment
+    // that fills `model` runs AFTER validation. Observable as
+    // `Validation failed: resources: Invalid input: expected object, received undefined`.
+    // ─────────────────────────────────────────────────────────────────────────
+    describe('REGRESSION #4159 — a compatible LoRA survives REAL graph validation', () => {
+      // A free viewer's server-shaped generation context — the same fields
+      // `buildGenerationContext` produces, hand-built so this stays off DB/redis.
+      // (Mirrors `baseCtx` in model-substitution.test.ts.)
+      const graphCtx = {
+        limits: { maxQuantity: 4, maxResources: 10, vidQuantity: 1 },
+        user: { isMember: false, tier: 'free' },
+        flags: {},
+        selfHostedDisabledEcosystems: [],
+        selfHostedMode: 'enabled',
+        gateRules: [],
+      };
+
+      /**
+       * Re-arm the step builder with REAL graph validation. Returns the parse
+       * results so a test can assert on them directly as well as through the
+       * procedure's outcome.
+       */
+      function withRealGraphValidation() {
+        const parses: Array<{ success: boolean; errors?: Record<string, { message: string }> }> =
+          [];
+        mockCreateStepsFromGraph.mockImplementation(
+          async ({ input }: { input: Record<string, unknown> }) => {
+            const result = generationGraph.safeParse(input as never, graphCtx as never) as {
+              success: boolean;
+              errors?: Record<string, { message: string }>;
+              data?: Record<string, unknown>;
+            };
+            parses.push({ success: result.success, errors: result.errors });
+            if (!result.success) {
+              // Byte-for-byte the message shape `validateInput` throws, which is
+              // what reached the block as the failure snapshot's `error`.
+              const errorMessages = Object.entries(result.errors ?? {})
+                .map(([key, error]) => `${key}: ${error.message}`)
+                .join(', ');
+              throw new TRPCError({
+                code: 'BAD_REQUEST',
+                message: `Validation failed: ${errorMessages}`,
+              });
+            }
+            return {
+              steps: [{ $type: 'textToImage', name: 's1', input: {} }],
+              workflowMetadata: undefined,
+            };
+          }
+        );
+        return parses;
+      }
+
+      // 🔴 THE ARM THAT WAS RED BEFORE THE FIX. A compatible SDXL LoRA on an
+      // SDXL checkpoint must price. On `main` this rejects with
+      // `Validation failed: resources: Invalid input: expected object, received undefined`.
+      it('estimate: a COMPATIBLE LoRA prices — the graph accepts the built resources', async () => {
+        mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+        versionRows({ 201: sdxlLora(201) });
+        happyUser();
+        const parses = withRealGraphValidation();
+        mockSubmitWorkflow.mockResolvedValueOnce({
+          id: '',
+          status: 'succeeded',
+          cost: { total: 7 },
+          steps: [],
+        });
+        const caller = blocksRouter.createCaller(fakeCtx() as never);
+        const result = await caller.estimateWorkflow({
+          blockToken: 'tok',
+          body: bodyWithLoras([{ modelVersionId: 201, strength: 0.8 }]),
+        });
+        // The block's fail-closed guard is `typeof cost.total === 'number'`.
+        expect(typeof result.snapshot.cost?.total).toBe('number');
+        expect(result.snapshot.cost?.total).toBe(7);
+        // The graph really ran, really succeeded, and really carried the LoRA
+        // (a positive control: a validator wired to nothing would record none).
+        expect(parses).toHaveLength(1);
+        expect(parses[0].success).toBe(true);
+        // …and the input it accepted carries the resolved type, not a placeholder.
+        const stepArg = mockCreateStepsFromGraph.mock.calls[0][0];
+        expect(stepArg.input.resources).toEqual([
+          { id: 201, strength: 0.8, model: { type: 'LORA' } },
+        ]);
+      });
+
+      it('submit: the SAME builder feeds submitWorkflow, so it must pass the SAME validation', async () => {
+        mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+        versionRows({ 201: sdxlLora(201) });
+        happyUser();
+        const parses = withRealGraphValidation();
+        mockSysRedis.incrBy.mockResolvedValue(9);
+        mockSubmitWorkflow
+          .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 9 }, steps: [] })
+          .mockResolvedValueOnce({
+            id: 'wf_real',
+            status: 'unassigned',
+            cost: { total: 9 },
+            steps: [],
+          });
+        const caller = blocksRouter.createCaller(fakeCtx() as never);
+        const result = await caller.submitWorkflow({
+          blockToken: 'tok',
+          body: bodyWithLoras([{ modelVersionId: 201, strength: 1.1 }]),
+        });
+        expect(result.snapshot.workflowId).toBe('wf_real');
+        // whatIf preflight + real submit both validated, both succeeded.
+        expect(parses.every((p) => p.success)).toBe(true);
+        expect(parses.length).toBeGreaterThanOrEqual(1);
+      });
+
+      // NEGATIVE CONTROL for the harness above: the same re-armed validator must
+      // be able to go RED. Without this, a green first arm is indistinguishable
+      // from a `safeParse` that cannot fail.
+      it('CONTROL: the re-armed validator DOES reject a genuinely invalid graph input', async () => {
+        const bad = generationGraph.safeParse(
+          {
+            workflow: 'txt2img',
+            ecosystem: 'SDXL',
+            model: { id: 99 },
+            // The pre-fix shape, verbatim.
+            resources: [{ id: 201, strength: 0.8 }],
+            prompt: 'a cat',
+            sampler: 'Euler',
+            steps: 25,
+            quantity: 1,
+            priority: 'low',
+          } as never,
+          graphCtx as never
+        ) as { success: boolean; errors?: Record<string, { message: string }> };
+        expect(bad.success).toBe(false);
+        // The exact string the issue records off the wire.
+        expect(bad.errors?.resources?.message).toMatch(/expected object, received undefined/);
+      });
+
+      // The compatibility gate is upstream of graph validation and must keep its
+      // clean, intentional rejection — the fix must not widen it.
+      it('an INCOMPATIBLE LoRA still gets the existing clean rejection (gate not widened)', async () => {
+        mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+        // SD 1.5 LoRA against the SDXL checkpoint — no SD1→SDXL LORA rule.
+        versionRows({ 201: sdxlLora(201, { baseModel: 'SD 1.5' }) });
+        happyUser();
+        withRealGraphValidation();
+        const caller = blocksRouter.createCaller(fakeCtx() as never);
+        await expect(
+          caller.estimateWorkflow({
+            blockToken: 'tok',
+            body: bodyWithLoras([{ modelVersionId: 201 }]),
+          })
+        ).rejects.toMatchObject({
+          code: 'BAD_REQUEST',
+          message: 'a selected LoRA is not compatible with the checkpoint base model',
+        });
+        expect(mockCreateStepsFromGraph).not.toHaveBeenCalled();
+        expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      });
+
+      // CONTROL: a no-LoRA estimate priced before the fix and must still price —
+      // so a green suite cannot be explained by the LoRA arm having been made
+      // trivially reachable.
+      it('CONTROL: a no-LoRA estimate still prices under the same real validation', async () => {
+        mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+        versionRows({});
+        happyUser();
+        const parses = withRealGraphValidation();
+        mockSubmitWorkflow.mockResolvedValueOnce({
+          id: '',
+          status: 'succeeded',
+          cost: { total: 4 },
+          steps: [],
+        });
+        const caller = blocksRouter.createCaller(fakeCtx() as never);
+        const result = await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+        expect(result.snapshot.cost?.total).toBe(4);
+        expect(parses[0].success).toBe(true);
+        const stepArg = mockCreateStepsFromGraph.mock.calls[0][0];
+        expect(stepArg.input.resources).toEqual([]);
+      });
+
+      // 🔴 WIDER THAN THE ISSUE TITLE. The bound-model network takes the SAME
+      // `resources.push`, so a block bound to a LoRA (rather than a Checkpoint)
+      // was equally dead — with NO `additionalResources` at all. Also RED on
+      // `main`, with the identical message.
+      it('a LoRA-BOUND body (no additionalResources) also prices — same push, same defect', async () => {
+        mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+        // Body model 99 is itself an SDXL LoRA, so the builder pushes it into
+        // `resources` and resolves a DIFFERENT checkpoint (500) as the anchor.
+        versionRows({
+          99: {
+            id: 99,
+            baseModel: 'SDXL 1.0',
+            modelId: 7,
+            status: 'Published',
+            availability: 'Public',
+            usageControl: 'Download',
+            meta: null,
+            generationCoverage: { covered: true },
+            model: { id: 7, type: 'LORA', userId: 1 },
+          },
+        });
+        happyUser();
+        clearCheckpointOverrides();
+        mockDbRead.modelMetric.findFirst.mockResolvedValue({
+          modelId: 300,
+          model: {
+            id: 300,
+            name: 'Popular SDXL',
+            modelVersions: [{ id: 500, name: 'v1', baseModel: 'SDXL 1.0' }],
+          },
+        });
+        const parses = withRealGraphValidation();
+        mockSubmitWorkflow.mockResolvedValueOnce({
+          id: '',
+          status: 'succeeded',
+          cost: { total: 5 },
+          steps: [],
+        });
+        const caller = blocksRouter.createCaller(fakeCtx() as never);
+        const result = await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+        expect(result.snapshot.cost?.total).toBe(5);
+        expect(parses[0].success).toBe(true);
+        const stepArg = mockCreateStepsFromGraph.mock.calls[0][0];
+        expect(stepArg.input.model.id).toBe(500);
+        expect(stepArg.input.resources).toEqual([{ id: 99, strength: 1, model: { type: 'LORA' } }]);
+      });
     });
 
     // ── Model-path guard: additionalResources is page-only ─────────────────

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -4514,6 +4514,83 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
         ]);
       });
 
+      // 🔴 MUTANT-KILLER for the ROUTER's half of the thread. Every other
+      // fixture in this file is LORA-typed (`sdxlLora`), so replacing
+      // `resourceTypes.set(id, lora.modelType)` with the literal `'LORA'`
+      // SURVIVED a 4168-test sweep — the builder-side LoCon test pins only the
+      // BOUND model, not the additional-resource map. Without this, the
+      // fail-closed throw guards nothing: a hardcoded `'LORA'` would be
+      // indistinguishable from a resolved one. Two DISTINCT non-LORA types, so
+      // no single literal can satisfy the assertion.
+      it('the resolved type is THREADED per-resource — a LoCon + DoRA stack is not flattened to LORA', async () => {
+        mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+        versionRows({
+          202: sdxlLora(202, { model: { id: 302, type: 'LoCon', userId: 2 } }),
+          203: sdxlLora(203, { model: { id: 303, type: 'DoRA', userId: 2 } }),
+        });
+        happyUser();
+        const parses = withRealGraphValidation();
+        mockSubmitWorkflow.mockResolvedValueOnce({
+          id: '',
+          status: 'succeeded',
+          cost: { total: 11 },
+          steps: [],
+        });
+        const caller = blocksRouter.createCaller(fakeCtx() as never);
+        const result = await caller.estimateWorkflow({
+          blockToken: 'tok',
+          body: bodyWithLoras([
+            { modelVersionId: 202, strength: 0.6 },
+            { modelVersionId: 203, strength: 0.4 },
+          ]),
+        });
+        expect(result.snapshot.cost?.total).toBe(11);
+        expect(parses[0].success).toBe(true);
+        const stepArg = mockCreateStepsFromGraph.mock.calls[0][0];
+        expect(stepArg.input.resources).toEqual([
+          { id: 202, strength: 0.6, model: { type: 'LoCon' } },
+          { id: 203, strength: 0.4, model: { type: 'DoRA' } },
+        ]);
+      });
+
+      // The bound-model push is now type-bounded: a type the graph routes to its
+      // OWN singleton node (Upscaler/VAE) must be refused, not billed as an
+      // additional network. Reviving the push without this would have widened
+      // the surface well past what the fix describes.
+      it('a bound model whose type belongs in a SINGLETON graph slot is refused, not billed as a network', async () => {
+        mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+        versionRows({
+          99: {
+            id: 99,
+            baseModel: 'SDXL 1.0',
+            modelId: 7,
+            status: 'Published',
+            availability: 'Public',
+            usageControl: 'Download',
+            meta: null,
+            generationCoverage: { covered: true },
+            model: { id: 7, type: 'VAE', userId: 1 },
+          },
+        });
+        happyUser();
+        clearCheckpointOverrides();
+        mockDbRead.modelMetric.findFirst.mockResolvedValue({
+          modelId: 300,
+          model: {
+            id: 300,
+            name: 'Popular SDXL',
+            modelVersions: [{ id: 500, name: 'v1', baseModel: 'SDXL 1.0' }],
+          },
+        });
+        withRealGraphValidation();
+        const caller = blocksRouter.createCaller(fakeCtx() as never);
+        await expect(
+          caller.estimateWorkflow({ blockToken: 'tok', body: validBody() })
+        ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: /bound to a VAE model/ });
+        // Refused before the orchestrator is reached — no whatIf, no spend.
+        expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      });
+
       it('submit: the SAME builder feeds submitWorkflow, so it must pass the SAME validation', async () => {
         mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
         versionRows({ 201: sdxlLora(201) });

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -617,15 +617,23 @@ function buildGateVersion(gate: {
 // the page body model — for a non-Checkpoint page body those differ.
 //
 // Returns the per-LoRA gate bags so the caller can pass checkpoint + every LoRA
-// through the entitlement gate in ONE call. Throws BAD_REQUEST (non-LoRA /
-// not platform-compatible incl. unknown baseModel), NOT_FOUND
+// through the entitlement gate in ONE call, AND the resolved `modelVersionId →
+// ModelType` map. The map is not a second lookup: it is the `model.type` this
+// function has already read off each version, handed to `buildTextToImageInput`
+// so the graph input satisfies the resources node's OUTPUT schema
+// (`resourceSchema` requires `model:{type}` — issue #4159). Throws BAD_REQUEST
+// (non-LoRA / not platform-compatible incl. unknown baseModel), NOT_FOUND
 // (missing/unpublished version) — all BEFORE any cost/spend.
 async function resolvePageLoraGates(opts: {
   additionalResources: { modelVersionId: number; strength: number }[] | undefined;
   checkpointBaseModel: string;
-}): Promise<ReturnType<typeof buildGateVersion>[]> {
+}): Promise<{
+  gates: ReturnType<typeof buildGateVersion>[];
+  resourceTypes: ReadonlyMap<number, string>;
+}> {
   const { additionalResources, checkpointBaseModel } = opts;
-  if (!additionalResources?.length) return [];
+  const resourceTypes = new Map<number, string>();
+  if (!additionalResources?.length) return { gates: [], resourceTypes };
   // FAIL-CLOSED on the 'Other' ecosystem group. getResourceGenerationSupport's
   // null check does NOT catch the platform's recognized 'Other' baseModel
   // record (it resolves to a real ECO.Other ecosystem and short-circuits to
@@ -680,8 +688,11 @@ async function resolvePageLoraGates(opts: {
       });
     }
     gates.push(buildGateVersion(lora.gate));
+    // Recorded only after every reject above has passed, so the map can never
+    // describe a resource this gate refused.
+    resourceTypes.set(lora.modelVersionId, lora.modelType);
   }
-  return gates;
+  return { gates, resourceTypes };
 }
 
 // ---- Cumulative Buzz-spend cap (audit A7 / design-gaps H1) -----------------
@@ -4017,14 +4028,20 @@ export const blocksRouter = router({
       // the domain currency, derived from the SAME authoritative ceiling as the
       // output clamp. SFW → blue/green; mature → blue/yellow.
       const currencies = resolveBlockCurrencies(isGreen);
+      // #4159: the resolved `modelVersionId → ModelType` for the LoRA stack.
+      // Declared out here because `buildTextToImageInput` below needs it to emit
+      // graph-valid `resources` entries; on the MODEL path `additionalResources`
+      // is rejected outright, so an empty map is the correct value there.
+      let additionalResourceTypes: ReadonlyMap<number, string> = new Map();
       if (isPage) {
         // Resolve + validate the LoRA stack first (LoRA-only + family-match)
         // so a bad resource fails BEFORE the entitlement gate / any cost.
         // Family-match anchors on the RESOLVED checkpoint's baseModel.
-        const loraGates = await resolvePageLoraGates({
+        const { gates: loraGates, resourceTypes } = await resolvePageLoraGates({
           additionalResources: input.body.additionalResources,
           checkpointBaseModel: checkpoint.baseModel,
         });
+        additionalResourceTypes = resourceTypes;
         await assertViewerCanGeneratePageResources({
           gates: [buildGateVersion(resolved.gate), ...loraGates],
           viewer: { id: userId, isModerator: !!user.isModerator },
@@ -4040,6 +4057,7 @@ export const blocksRouter = router({
         ...resolved,
         checkpointVersionId: checkpoint.versionId,
         checkpointBaseModel: checkpoint.baseModel,
+        additionalResourceTypes,
       });
       // whatIf: no `metadata` on the body — matches the normal path
       // (`generateFromGraph` builds workflowMetadata only for real submits) and
@@ -4268,11 +4286,16 @@ export const blocksRouter = router({
       // rejected; absent → Auto (unchanged). See resolveBlockCurrenciesForAccount.
       const currencies = resolveBlockCurrenciesForAccount(isGreen, input.body.accountType);
 
+      // #4159 — see estimateWorkflow above. submitWorkflow builds the SAME graph
+      // input through the SAME builder, so it carried the identical defect and
+      // takes the identical fix; keeping the two in step is the point.
+      let additionalResourceTypes: ReadonlyMap<number, string> = new Map();
       if (isPage) {
-        const loraGates = await resolvePageLoraGates({
+        const { gates: loraGates, resourceTypes } = await resolvePageLoraGates({
           additionalResources: input.body.additionalResources,
           checkpointBaseModel: checkpoint.baseModel,
         });
+        additionalResourceTypes = resourceTypes;
         await assertViewerCanGeneratePageResources({
           gates: [buildGateVersion(resolved.gate), ...loraGates],
           viewer: { id: userId, isModerator: !!user.isModerator },
@@ -4301,6 +4324,7 @@ export const blocksRouter = router({
         ...resolved,
         checkpointVersionId: checkpoint.versionId,
         checkpointBaseModel: checkpoint.baseModel,
+        additionalResourceTypes,
       });
 
       // Cost preflight. Build a whatIf step for the cost estimate, then a

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -688,8 +688,10 @@ async function resolvePageLoraGates(opts: {
       });
     }
     gates.push(buildGateVersion(lora.gate));
-    // Recorded only after every reject above has passed, so the map can never
-    // describe a resource this gate refused.
+    // ORDERING, not a guard — do not read this as one. Every reject above
+    // THROWS, so the builder never runs on a refused resource whatever order
+    // this line sits in (moving it above the rejects survives the suite). It is
+    // placed here because that is where the value is unambiguously final.
     resourceTypes.set(lora.modelVersionId, lora.modelType);
   }
   return { gates, resourceTypes };

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -779,18 +779,21 @@ describe('buildTextToImageInput', () => {
     modelType: 'Checkpoint',
     checkpointVersionId: 99,
     checkpointBaseModel: 'SDXL 1.0',
+    additionalResourceTypes: new Map<number, string>(),
   };
   const sd1CheckpointResolved = {
     baseModel: 'SD 1.5',
     modelType: 'Checkpoint',
     checkpointVersionId: 99,
     checkpointBaseModel: 'SD 1.5',
+    additionalResourceTypes: new Map<number, string>(),
   };
   const fluxLoraResolved = {
     baseModel: 'Flux.1 D',
     modelType: 'LORA',
     checkpointVersionId: 691639,
     checkpointBaseModel: 'Flux.1 D',
+    additionalResourceTypes: new Map<number, string>(),
   };
 
   // New shape: the function now emits the flat generation-graph `input`
@@ -871,6 +874,29 @@ describe('buildTextToImageInput', () => {
     });
     expect(out.resources).toEqual([{ id: 99, strength: 1, model: { type: 'LoCon' } }]);
   });
+
+  // #4159 scope bound. Reviving the bound-model push must not let a type the
+  // graph routes to its OWN singleton node be submitted as an additional
+  // network. Both singleton types are covered — one is not evidence about the
+  // other, and a mutant naming only one would otherwise survive.
+  it.each([['VAE'], ['Upscaler']])(
+    'refuses a bound model of singleton-slot type %s rather than billing it as a network',
+    (modelType) => {
+      expect(() =>
+        buildTextToImageInput(baseBody as never, { ...fluxLoraResolved, modelType })
+      ).toThrow(new RegExp(`bound to a ${modelType} model`));
+    }
+  );
+
+  // …and the LoRA family is NOT caught by that guard — otherwise the guard
+  // would pass by rejecting everything, including the case the fix exists for.
+  it.each([['LORA'], ['LoCon'], ['DoRA'], ['TextualInversion']])(
+    'still admits an additional-network bound type (%s)',
+    (modelType) => {
+      const out = buildTextToImageInput(baseBody as never, { ...fluxLoraResolved, modelType });
+      expect(out.resources).toEqual([{ id: 99, strength: 1, model: { type: modelType } }]);
+    }
+  );
 
   it('forwards block-supplied sampler/steps/seed overrides', () => {
     const body = {
@@ -1199,6 +1225,7 @@ describe('block input yields populated workflow metadata params (real graph path
       modelType: 'Checkpoint',
       checkpointVersionId: 99,
       checkpointBaseModel: 'SDXL 1.0',
+      additionalResourceTypes: new Map<number, string>(),
     };
 
     // REAL translator → REAL graph validation → REAL param snapshot.
@@ -1241,6 +1268,7 @@ describe('block input yields populated workflow metadata params (real graph path
       modelType: 'Checkpoint',
       checkpointVersionId: 99,
       checkpointBaseModel: 'SD 1.5',
+      additionalResourceTypes: new Map<number, string>(),
     };
     const input = buildTextToImageInput(body as never, resolved);
     const { params } = paramsFromRealGraph(input);
@@ -1272,6 +1300,7 @@ describe('block input yields populated workflow metadata params (real graph path
       modelType: 'Checkpoint',
       checkpointVersionId: 99,
       checkpointBaseModel: 'SDXL 1.0',
+      additionalResourceTypes: new Map<number, string>(),
     };
     const input = buildImageWorkflowInput(body as never, resolved);
     const result = generationGraph.safeParse(input, externalCtx);
@@ -1357,6 +1386,7 @@ describe('buildImageWorkflowInput (generalized image-workflow bridge)', () => {
     modelType: 'Checkpoint',
     checkpointVersionId: 99,
     checkpointBaseModel: 'SDXL 1.0',
+    additionalResourceTypes: new Map<number, string>(),
   };
   const validSourceImage = {
     url: 'https://image.civitai.com/abc/def.jpeg',

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -856,7 +856,20 @@ describe('buildTextToImageInput', () => {
     // fixture); the host doesn't second-guess what the resolver returned. The
     // bound LoRA (body model 99) is the only additional network.
     expect(out.model).toEqual({ id: 691639 });
-    expect(out.resources).toEqual([{ id: 99, strength: 1 }]);
+    // #4159 — `model.type` is the RESOLVED type, carried from
+    // `resolveBlockVersionContext`, not a literal. `resourceSchema` (the
+    // resources node's OUTPUT schema) requires it.
+    expect(out.resources).toEqual([{ id: 99, strength: 1, model: { type: 'LORA' } }]);
+  });
+
+  // #4159 — the resolved type is THREADED, not hardcoded. A LoCon-bound install
+  // must emit `LoCon`, so a mutant that pins the literal `'LORA'` dies here.
+  it('carries the bound model’s own resolved type (LoCon, not a hardcoded LORA)', () => {
+    const out = buildTextToImageInput(baseBody as never, {
+      ...fluxLoraResolved,
+      modelType: 'LoCon',
+    });
+    expect(out.resources).toEqual([{ id: 99, strength: 1, model: { type: 'LoCon' } }]);
   });
 
   it('forwards block-supplied sampler/steps/seed overrides', () => {
@@ -871,6 +884,14 @@ describe('buildTextToImageInput', () => {
   });
 
   // ── Page-LoRA (Increment 1): fan additionalResources into `resources` ──────
+  //
+  // #4159 — every entry now carries `model: { type }`, taken from the caller's
+  // resolved `additionalResourceTypes` map (the types `resolvePageLoraGates`
+  // already read). Types are deliberately MIXED across the fixtures below so a
+  // hardcoded literal cannot satisfy them.
+  const types = (m: Record<number, string>) =>
+    new Map<number, string>(Object.entries(m).map(([k, v]) => [Number(k), v]));
+
   it('fans N additional LoRAs into the resources array (checkpoint stays on `model`)', () => {
     const body = {
       ...baseBody,
@@ -880,13 +901,32 @@ describe('buildTextToImageInput', () => {
         { modelVersionId: 203, strength: -0.5 },
       ],
     };
-    const out = buildTextToImageInput(body as never, checkpointResolved);
+    const out = buildTextToImageInput(body as never, {
+      ...checkpointResolved,
+      additionalResourceTypes: types({ 201: 'LORA', 202: 'LoCon', 203: 'DoRA' }),
+    });
     expect(out.model).toEqual({ id: 99 });
     expect(out.resources).toEqual([
-      { id: 201, strength: 0.8 },
-      { id: 202, strength: 1.2 },
-      { id: 203, strength: -0.5 },
+      { id: 201, strength: 0.8, model: { type: 'LORA' } },
+      { id: 202, strength: 1.2, model: { type: 'LoCon' } },
+      { id: 203, strength: -0.5, model: { type: 'DoRA' } },
     ]);
+  });
+
+  // #4159 fail-closed: a resource whose type the caller did not resolve is a
+  // server wiring bug, not something to paper over with a default that would
+  // mis-slot a non-LoRA once the deferred VAE/embedding increment lands.
+  it('throws rather than guessing when an additionalResource has no resolved type', () => {
+    const body = {
+      ...baseBody,
+      additionalResources: [{ modelVersionId: 201, strength: 0.8 }],
+    };
+    expect(() =>
+      buildTextToImageInput(body as never, {
+        ...checkpointResolved,
+        additionalResourceTypes: types({ 999: 'LORA' }),
+      })
+    ).toThrow(/additional resource type was not resolved/);
   });
 
   it('does NOT duplicate the checkpoint when an additionalResource repeats it', () => {
@@ -897,11 +937,14 @@ describe('buildTextToImageInput', () => {
         { modelVersionId: 201, strength: 1 },
       ],
     };
-    const out = buildTextToImageInput(body as never, checkpointResolved);
+    const out = buildTextToImageInput(body as never, {
+      ...checkpointResolved,
+      additionalResourceTypes: types({ 99: 'LORA', 201: 'LORA' }),
+    });
     // The checkpoint stays as the `model` anchor (no double-bill); only the
     // genuinely-new LoRA lands in resources.
     expect(out.model).toEqual({ id: 99 });
-    expect(out.resources).toEqual([{ id: 201, strength: 1 }]);
+    expect(out.resources).toEqual([{ id: 201, strength: 1, model: { type: 'LORA' } }]);
   });
 
   it('does NOT duplicate the bound-model network when the body model is a LoRA', () => {
@@ -916,11 +959,14 @@ describe('buildTextToImageInput', () => {
         { modelVersionId: 300, strength: 0.9 }, // genuinely new
       ],
     };
-    const out = buildTextToImageInput(body as never, fluxLoraResolved);
+    const out = buildTextToImageInput(body as never, {
+      ...fluxLoraResolved,
+      additionalResourceTypes: types({ 691639: 'LORA', 99: 'LORA', 300: 'DoRA' }),
+    });
     expect(out.model).toEqual({ id: 691639 });
     expect(out.resources).toEqual([
-      { id: 99, strength: 1 },
-      { id: 300, strength: 0.9 },
+      { id: 99, strength: 1, model: { type: 'LORA' } },
+      { id: 300, strength: 0.9, model: { type: 'DoRA' } },
     ]);
   });
 
@@ -932,8 +978,12 @@ describe('buildTextToImageInput', () => {
         { modelVersionId: 201, strength: 0.9 }, // duplicate id
       ],
     };
-    const out = buildTextToImageInput(body as never, checkpointResolved);
-    expect(out.resources).toEqual([{ id: 201, strength: 0.3 }]); // first occurrence kept
+    const out = buildTextToImageInput(body as never, {
+      ...checkpointResolved,
+      additionalResourceTypes: types({ 201: 'LoCon' }),
+    });
+    // first occurrence kept
+    expect(out.resources).toEqual([{ id: 201, strength: 0.3, model: { type: 'LoCon' } }]);
   });
 
   it('emits no additional resources when additionalResources is absent', () => {
@@ -1408,12 +1458,18 @@ describe('buildImageWorkflowInput (generalized image-workflow bridge)', () => {
         { modelVersionId: 202, strength: 1.2 },
       ],
     };
-    const out = buildImageWorkflowInput(body as never, checkpointResolved);
+    const out = buildImageWorkflowInput(body as never, {
+      ...checkpointResolved,
+      additionalResourceTypes: new Map([
+        [201, 'LORA'],
+        [202, 'DoRA'],
+      ]),
+    });
     expect(out.workflow).toBe('img2img');
     expect(out.model).toEqual({ id: 99 });
     expect(out.resources).toEqual([
-      { id: 201, strength: 0.8 },
-      { id: 202, strength: 1.2 },
+      { id: 201, strength: 0.8, model: { type: 'LORA' } },
+      { id: 202, strength: 1.2, model: { type: 'DoRA' } },
     ]);
     // The init image rides alongside the resources — both are present.
     expect(out.images).toHaveLength(1);

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -15,6 +15,7 @@ import {
 } from '~/shared/data-graph/generation/model-substitution';
 import { getImagesLimit } from '~/shared/data-graph/generation/images-limit';
 import { ModelType } from '~/shared/utils/prisma/enums';
+import { isSingletonSlotResource } from '~/shared/utils/resource.utils';
 import type {
   BlockSourceImage,
   BlockWorkflowBody,
@@ -843,10 +844,17 @@ export function buildImageWorkflowInput(
     /**
      * `modelVersionId → ModelType` for every entry in `body.additionalResources`,
      * resolved by the caller (`resolvePageLoraGates` already reads each version).
-     * REQUIRED whenever `additionalResources` is non-empty — see the fail-closed
-     * branch in the resource assembly below.
+     *
+     * REQUIRED, not optional — an empty map is the correct value on a path that
+     * accepts no additional resources (the MODEL branch rejects them outright).
+     * Optional would let a future call site omit it, type-check cleanly, and
+     * fail at runtime with a 500.
+     *
+     * ⚠️ That protection covers PRODUCTION call sites only. `tsconfig.json`
+     * excludes `src/**\/__tests__/**`, so a test that omits this still compiles;
+     * it fails at runtime instead. Keep the fixtures supplying it.
      */
-    additionalResourceTypes?: ReadonlyMap<number, string>;
+    additionalResourceTypes: ReadonlyMap<number, string>;
   },
   workflowTypeOverride?: string
 ): Record<string, unknown> {
@@ -937,10 +945,39 @@ export function buildImageWorkflowInput(
   // comes from the caller's own `resolveBlockVersionContext`, and each
   // additional resource's from the per-item version read the router already
   // performs in `resolvePageLoraGates`. No second enrichment is introduced.
+  //
+  // ⚠️ SCOPE OF THE `model.type` VALUE, stated precisely so nobody over-reads it.
+  // On THIS path the value is inert for the orchestrator payload today:
+  // `stable-diffusion.handler.ts` folds `resources` + `vae` into one
+  // AIR-keyed `additionalNetworks` map carrying only `{ strength }`, and
+  // `splitResourcesByType` runs on ENRICHED resources elsewhere, never on this
+  // graph input. So a wrong type here could not mis-route or mis-bill TODAY —
+  // the schema requirement is what makes it load-bearing, and correctness of
+  // the value is future-proofing for the deferred VAE/embedding increment,
+  // which does slot by `model.type`.
   const resources: Array<{ id: number; strength: number; model: { type: string } }> = [];
   // The bound model is itself a LoRA (LoRA install) — push it as a network.
   // A Checkpoint-bound install has no additional network here.
   if (resolved.modelType !== 'Checkpoint') {
+    // 🔴 BOUND THE SURFACE THIS FIX REVIVES. Before the `model.type` fix every
+    // non-Checkpoint-bound request failed graph validation, so in practice
+    // blocks generation only ever worked for Checkpoint-bound blocks. Reviving
+    // the push without a type rule would let ANY bound type — Upscaler, VAE —
+    // proceed to whatIf and to billing as an additional network, gated only by
+    // coverage/entitlement. Those types have their OWN singleton graph nodes,
+    // so `resources` is the wrong slot for them by the platform's own routing
+    // table (`SINGLETON_SLOT_BY_MODEL_TYPE`) — read through
+    // `isSingletonSlotResource` rather than restated, so this cannot drift from
+    // it. Fail closed with a legible message instead. This cannot regress a
+    // working flow: every one of these requests 400s on `main` today.
+    if (isSingletonSlotResource(resolved.modelType)) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message:
+          `a block bound to a ${resolved.modelType} model cannot generate — ` +
+          `bind it to a checkpoint or an additional-network resource`,
+      });
+    }
     resources.push({
       id: body.modelVersionId,
       strength: 1,
@@ -961,11 +998,13 @@ export function buildImageWorkflowInput(
       // FAIL-CLOSED rather than defaulting to 'LORA'. Today every accepted
       // additional resource is in the LoRA family and all three types share the
       // graph's catch-all `resources` slot, so a default would be invisible —
-      // but the deferred VAE/embedding increment slots by `model.type`
-      // (`SINGLETON_SLOT_BY_MODEL_TYPE`), where a wrong type silently routes a
-      // resource to the wrong node and bills for it. A missing entry is a
+      // and (see the note above) the value is inert on the orchestrator payload,
+      // so it could not mis-route or mis-bill today either. The reason to refuse
+      // a default is the deferred VAE/embedding increment, which DOES slot by
+      // `model.type` (`SINGLETON_SLOT_BY_MODEL_TYPE`): a default would go on
+      // silently working until the day it silently didn't. A missing entry is a
       // server-side wiring bug, never anything a caller can provoke.
-      const modelType = resolved.additionalResourceTypes?.get(r.modelVersionId);
+      const modelType = resolved.additionalResourceTypes.get(r.modelVersionId);
       if (!modelType) {
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -840,6 +840,13 @@ export function buildImageWorkflowInput(
     modelType: string;
     checkpointVersionId: number;
     checkpointBaseModel: string;
+    /**
+     * `modelVersionId → ModelType` for every entry in `body.additionalResources`,
+     * resolved by the caller (`resolvePageLoraGates` already reads each version).
+     * REQUIRED whenever `additionalResources` is non-empty — see the fail-closed
+     * branch in the resource assembly below.
+     */
+    additionalResourceTypes?: ReadonlyMap<number, string>;
   },
   workflowTypeOverride?: string
 ): Record<string, unknown> {
@@ -913,24 +920,59 @@ export function buildImageWorkflowInput(
   const height = body.params.height ?? dims.height;
 
   // LoRAs only — the checkpoint is the `model` anchor, not a `resources` entry.
-  const resources: Array<{ id: number; strength: number }> = [];
+  //
+  // 🔴 `model.type` IS REQUIRED, NOT DECORATIVE (issue #4159). The generation
+  // graph's `resources` node validates its OUTPUT against `resourceSchema`,
+  // which requires `model: { type: string }` — the loose `{ id }` INPUT schema
+  // is not what the parse is graded on. Emitting `{ id, strength }` therefore
+  // failed EVERY workflow carrying an additional resource with
+  // `Validation failed: resources: Invalid input: expected object, received
+  // undefined`, i.e. a 400 for every LoRA that survived the compatibility gate.
+  // (The `model` anchor escaped this because the checkpoint node's own input
+  // schema fills `model: { type: 'Checkpoint' }` in a transform; the resources
+  // node has no such transform.) The on-site generator form never hit it either
+  // — its state already holds fully-shaped resource objects.
+  //
+  // The type is the resolved Prisma `ModelType`, NOT a guess: the bound model's
+  // comes from the caller's own `resolveBlockVersionContext`, and each
+  // additional resource's from the per-item version read the router already
+  // performs in `resolvePageLoraGates`. No second enrichment is introduced.
+  const resources: Array<{ id: number; strength: number; model: { type: string } }> = [];
   // The bound model is itself a LoRA (LoRA install) — push it as a network.
   // A Checkpoint-bound install has no additional network here.
   if (resolved.modelType !== 'Checkpoint') {
-    resources.push({ id: body.modelVersionId, strength: 1 });
+    resources.push({
+      id: body.modelVersionId,
+      strength: 1,
+      model: { type: resolved.modelType },
+    });
   }
 
   // Page-LoRA (Increment 1): fan each caller-supplied additional resource into
-  // `resources` as { id, strength }. DEDUPE against the checkpoint anchor AND
-  // the bound-model network already present so a LoRA that coincides with the
-  // anchor isn't double-billed / double-counted in strength. A LoRA that
+  // `resources` as { id, strength, model:{type} }. DEDUPE against the checkpoint
+  // anchor AND the bound-model network already present so a LoRA that coincides
+  // with the anchor isn't double-billed / double-counted in strength. A LoRA that
   // duplicates another LoRA keeps its first occurrence (first-wins).
   if (body.additionalResources?.length) {
     const seen = new Set<number>([resolved.checkpointVersionId, ...resources.map((r) => r.id)]);
     for (const r of body.additionalResources) {
       if (seen.has(r.modelVersionId)) continue;
       seen.add(r.modelVersionId);
-      resources.push({ id: r.modelVersionId, strength: r.strength });
+      // FAIL-CLOSED rather than defaulting to 'LORA'. Today every accepted
+      // additional resource is in the LoRA family and all three types share the
+      // graph's catch-all `resources` slot, so a default would be invisible —
+      // but the deferred VAE/embedding increment slots by `model.type`
+      // (`SINGLETON_SLOT_BY_MODEL_TYPE`), where a wrong type silently routes a
+      // resource to the wrong node and bills for it. A missing entry is a
+      // server-side wiring bug, never anything a caller can provoke.
+      const modelType = resolved.additionalResourceTypes?.get(r.modelVersionId);
+      if (!modelType) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'additional resource type was not resolved',
+        });
+      }
+      resources.push({ id: r.modelVersionId, strength: r.strength, model: { type: modelType } });
     }
   }
 

--- a/src/shared/utils/resource.utils.ts
+++ b/src/shared/utils/resource.utils.ts
@@ -49,6 +49,18 @@ const SINGLETON_SLOT_BY_MODEL_TYPE: Partial<Record<string, Exclude<ResourceNodeK
     VAE: 'vae',
   };
 
+/**
+ * True when `modelType` belongs in one of the graph's SINGLETON resource nodes
+ * (`model` / `upscaler` / `vae`) rather than the `resources` catchall.
+ *
+ * Reads the same table `splitResourcesByType` routes on, so a caller that needs
+ * to know "may this type be an additional network?" cannot drift from the
+ * routing rule. Additive — no existing consumer's behaviour changes.
+ */
+export function isSingletonSlotResource(modelType: string): boolean {
+  return SINGLETON_SLOT_BY_MODEL_TYPE[modelType] !== undefined;
+}
+
 // =============================================================================
 // Split: flat resources[] → { model, resources, vae }
 // =============================================================================


### PR DESCRIPTION
Fixes #4159.

## The defect

Every App Blocks workflow carrying an additional resource failed with

```
Validation failed: resources: Invalid input: expected object, received undefined
```

(HTTP 400 `BAD_REQUEST`), so `additionalResources` was dead for **every** value
that survived the compatibility gate — no LoRA could be priced through a block,
and therefore none could be run through one either.

`buildImageWorkflowInput` (`src/server/services/blocks/workflow.service.ts`)
assembled entries as `{ id, strength }`. That satisfies the generation graph's
`resources` node **input** schema (`resourceInputSchema`, a loose
`{ id: number }`) but not its **output** schema — `resourceSchema` requires
`model: { type: string }` — and `generationGraph.safeParse` is graded on the
output. The field is populated by `getResourceData`, which on this path runs
inside `validateAndEnrichResources` **after** validation, over resources taken
from graph output.

The `model` anchor escaped this because the checkpoint node's own input schema
fills `model: { type: 'Checkpoint' }` in a transform; the resources node has no
such transform. The on-site generator never hit it either — its form state
already holds fully-shaped resource objects, so it satisfies the output schema
by construction. Only the blocks bridge synthesises `{ id, strength }`.

## What changed

The resolved Prisma `ModelType` is threaded through to the builder rather than a
second enrichment pass being added:

- `resolvePageLoraGates` (`blocks.router.ts`) already reads each version to
  gate it, so it now returns the `modelVersionId → ModelType` map alongside the
  gate bags.
- `buildImageWorkflowInput` stamps `model: { type }` on each `resources` entry —
  the bound model's from `resolveBlockVersionContext`, each additional
  resource's from that map. The parameter is **required**, so a future
  production call site cannot omit it and 500 at runtime. (`tsconfig.json`
  excludes `src/**/__tests__/**`, so that protects production call sites only —
  noted in place.)
- An additional resource with no resolved type **throws** rather than defaulting
  to `LORA`.

## Two things wider than the issue title

1. **`submitWorkflow` shared the defect.** It builds the same input through the
   same builder, so it returned the same 400 and takes the same fix. Both call
   sites are covered.
2. **A LoRA-BOUND block body was equally dead, with no `additionalResources` at
   all.** The bound model goes through the same `resources.push`, so any block
   installed against a non-Checkpoint model hit the identical error. Covered by
   its own test.

## Recorded decision: the revived surface is bounded, not left to the belts

Because every non-Checkpoint-bound request failed graph validation before this
PR, in practice App Blocks generation only ever worked for **Checkpoint-bound
blocks**. Reviving the bound-model push therefore widens the surface to bound
types that have never reached the orchestrator: without a rule, an `Upscaler`
or `VAE`-bound block would proceed to whatIf and to billing as an additional
network, bounded only by `generationCoverage.covered` / `canGenerate` and
`assertViewerCanGeneratePageResources`.

Those belts are real and run before spend, but "coverage is the gate" is a weak
position for a resource the graph routes to a *different node*. So the push is
now **type-bounded**: a bound model whose type belongs in a singleton graph slot
(`model` / `upscaler` / `vae`) is refused with a legible `BAD_REQUEST` instead.
The rule reads `SINGLETON_SLOT_BY_MODEL_TYPE` through a new
`isSingletonSlotResource` rather than restating the list, so it cannot drift
from the routing table it is derived from.

This cannot regress a working flow — every one of those requests 400s on `main`
today. The LoRA family and `TextualInversion` (all catch-all `resources` types)
are explicitly still admitted, and tested, so the guard cannot pass by
rejecting everything.

## Correction: what `model.type` does and does not do today

An earlier revision of this description said a wrong `model.type` would
"mis-route and mis-bill". **That overstated the exposure and has been
corrected in the code comments.** On this path the value is currently inert for
the orchestrator payload: `stable-diffusion.handler.ts` folds `resources` and
`vae` into a single AIR-keyed `additionalNetworks` map carrying only
`{ strength }`, and `splitResourcesByType` runs on **enriched** resources
elsewhere, never on this graph input. Verified by reading both.

So a wrong type could not mis-route or mis-bill today. What makes the field
load-bearing is the **schema requirement** — that is the whole bug. Correctness
of the *value* is future-proofing for the deferred VAE/embedding increment,
which does slot by `model.type`.

## Tests — red → green matrix

The existing suite could not have caught this, and the reason is structural:
`src/server/routers/__tests__/blocks.router.workflow.test.ts` mocks
`createWorkflowStepsFromGraphInput` at the module boundary for the whole file, so
the generation graph — the thing that rejected the input — never ran. Every
compatible-LoRA test in that file is green on `main` while production returns
400.

The new regression suite re-arms exactly that one step: the mock runs the **real**
`generationGraph.safeParse` on the input the router actually built and reproduces
`validateInput`'s throw (same `Validation failed: <key>: <message>` shape).
Nothing else is unmocked.

| | base `ad8c7b56bf` | HEAD |
|---|---|---|
| `estimate: a COMPATIBLE LoRA prices` | **FAIL** — `TRPCError: Validation failed: resources: Invalid input: expected object, received undefined` | pass |
| `submit: the SAME builder feeds submitWorkflow` | **FAIL** — same message | pass |
| `a LoRA-BOUND body (no additionalResources) also prices` | **FAIL** — same message | pass |
| `the resolved type is THREADED per-resource (LoCon + DoRA)` | **FAIL** — same message | pass |
| `a bound model in a SINGLETON graph slot is refused` | **FAIL** | pass |
| `refuses a bound model of singleton-slot type VAE / Upscaler` | **FAIL** ×2 | pass |
| `still admits an additional-network bound type` (LORA/LoCon/DoRA/TextualInversion) | **FAIL** ×4 | pass |
| `CONTROL: the re-armed validator DOES reject a genuinely invalid graph input` | pass | pass |
| `an INCOMPATIBLE LoRA still gets the existing clean rejection` | pass | pass |
| `CONTROL: a no-LoRA estimate still prices` | pass | pass |
| remaining `buildTextToImageInput` shape assertions | **FAIL** ×7 | pass |

Measured by checking the source files out at the named ref while keeping the
tests, then restoring:

- **base `ad8c7b56bf`**: `18 failed | 517 passed (535)` across the two files.
- **HEAD**: `535 passed (535)`.

For the audit-round delta specifically, vs the first commit `e19fdaac16`:
`3 failed | 532 passed` — the three singleton-slot tests. **The LoCon+DoRA
threading test passes at `e19fdaac16`**: that commit already threaded the type
correctly, so it is mutation coverage rather than a regression test for a defect
present there. It is red at `ad8c7b56bf` with everything else.

### Mutation battery — 10 mutants, 10 killed

Baseline green first as the positive control (4176 tests, 0 failed), each mutant
run under a fresh sweep with its full failing-test list recorded.

| mutant | verdict | failing |
|---|---|---|
| M1 router: hardcode the additional-resource type to `'LORA'` | KILLED | 1 — the new LoCon+DoRA test alone |
| M2 builder: hardcode the BOUND model type to `'LORA'` | KILLED | 4 |
| M3 builder: drop `model.type` from additional resources | KILLED | 8 |
| M4 builder: remove the fail-closed throw | KILLED | 1 |
| M5 builder: remove the singleton-slot guard | KILLED | 3 |
| M6 builder: invert the singleton-slot guard | KILLED | 18 |
| M7 utils: `isSingletonSlotResource` always false | KILLED | 3 |
| M8 utils: singleton table loses `VAE` | KILLED | 2 |
| M9 router: never record any resolved type | KILLED | 9 |
| M10 builder: emit the CHECKPOINT's type instead of the resource's | KILLED | 7 |

**M1 is the one the audit found surviving a 4168-test sweep on `e19fdaac16`.**
Reproduced that survival first, then confirmed it dies to the new test
specifically.

### Suite and static checks at HEAD

- `vitest run --project unit src/server/routers/__tests__ src/server/services/blocks/__tests__ src/shared/data-graph src/shared/utils` → **210 files passed, 4590 tests passed, 0 failed**.
- `pnpm typecheck` → **0 type errors** (60s, heap cap 8192 MB).
- `prettier --check` on the five changed files → clean. `eslint` reports 3
  errors, all pre-existing at `ad8c7b56bf` in untouched regions (verified
  against the base file); none introduced here.

The `no-cost` producer described in the issue's first comment is untouched —
this fixes the `failed` producer, which the second comment establishes as the
one behind the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
