### PR TITLE
fix(stickers): keep the pending markings inside the sticker they belong to

### DIFF
--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -39,6 +39,7 @@ import {
 } from '~/components/Sticker/free-offer';
 import { payoutCopy, stickerPurchaseCopy } from '~/components/Sticker/payout-copy';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
+import { DRAFT_STICKER_Z } from '~/components/Sticker/placement-layers';
 import { useCreateStickerPlacement } from '~/components/Sticker/placement.util';
 import { purchaseCanBeRetriedFresh, useBuyStickerUses } from '~/components/Sticker/sticker.util';
 import type { ResolvedSticker } from '~/components/Sticker/sticker.util';
@@ -696,10 +697,14 @@ export function DraftSticker({
         width: `${draft.scale * 100}%`,
         transform: `translate(-50%, -50%) rotate(${draft.rotation}deg)`,
         touchAction: 'none',
-        // The one thing selection still decides. Two drafts close together have
+        // Above the owner's pending controls, not merely above the placed
+        // stickers: those controls sit in their own layer at PENDING_CONTROL_Z
+        // and were covering the sticker being dragged past them.
+        //
+        // Selection still decides between two drafts — close together they have
         // overlapping buy buttons, and the one just touched should be the one
         // the next click reaches.
-        zIndex: selected ? 1 : undefined,
+        zIndex: selected ? DRAFT_STICKER_Z + 1 : DRAFT_STICKER_Z,
       }}
       onPointerDown={begin('move')}
     >

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -697,10 +697,7 @@ export function DraftSticker({
         width: `${draft.scale * 100}%`,
         transform: `translate(-50%, -50%) rotate(${draft.rotation}deg)`,
         touchAction: 'none',
-        // Above the owner's pending controls, not merely above the placed
-        // stickers: those controls sit in their own layer at PENDING_CONTROL_Z
-        // and were covering the sticker being dragged past them.
-        //
+        // Above the owner's pending controls (see placement-layers.ts).
         // Selection still decides between two drafts — close together they have
         // overlapping buy buttons, and the one just touched should be the one
         // the next click reaches.

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -6,6 +6,7 @@ import type { PlacedSticker } from '~/components/Sticker/placement.util';
 import { orderPlacements, placementRevealDelays } from '~/components/Sticker/placement-order';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { placementControlPosition } from '~/components/Sticker/placement-control-position';
+import { PENDING_CONTROL_Z } from '~/components/Sticker/placement-layers';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
 import { StickerPlacementHoverCard } from '~/components/Sticker/StickerPlacementHoverCard';
 import { PlacementFreeBadge } from '~/components/Placement/PlacementFreeBadge';
@@ -28,15 +29,6 @@ import {
   type CSSProperties,
   type ReactElement,
 } from 'react';
-
-/**
- * The pending controls' layer, above the stickers and above the draft.
- *
- * Only has to clear the draft sticker's own z-index, which is 1 — the number is
- * this far clear of it so a later hand-written z-index nearby does not silently
- * bury the owner's only way to answer a pending placement.
- */
-const PENDING_CONTROL_Z = 1000;
 
 /**
  * Clear air between the bottom of a pending sticker and the owner's controls.
@@ -472,6 +464,27 @@ export function StickerPlacementOverlay({
                 />
               )}
 
+              {/* Inside the sticker's own box, never outside it. This is a
+                  label, not a control — the placer cannot act on it — so unlike
+                  the owner's approve/decline it does not need to out-rank a
+                  draft or escape the transform. Anchored outside the box it
+                  claimed area the sticker did not occupy, and that area is what
+                  collided with the sticker being placed beside it.
+
+                  Counter-rotated because the box is rotated with the artwork and
+                  rotation runs to ±180, so a label that rode it would read
+                  upside down. */}
+              {placement.isPending && !isOwner && (
+                <div
+                  className="pointer-events-none absolute bottom-1 left-1/2 whitespace-nowrap"
+                  style={{ transform: `translateX(-50%) rotate(${-placement.data.rotation}deg)` }}
+                >
+                  <span className="rounded bg-yellow-6 px-2 py-0.5 text-[10px] font-semibold text-dark-9">
+                    Awaiting review
+                  </span>
+                </div>
+              )}
+
               {/* Centred under the sticker, directly above the owner's approve
                   and decline controls — those are positioned off the sticker's
                   measured height, so this rides the same edge they start from.
@@ -529,7 +542,11 @@ export function StickerPlacementOverlay({
             box: controlBox,
           });
 
-          if (stickerHeights[placement.id] > 0)
+          // Owner only. The placer's "Awaiting review" label used to be pushed
+          // here too, which put a non-interactive label in the layer that exists
+          // to keep a control reachable — outside the sticker's box, and above
+          // the draft.
+          if (isOwner && stickerHeights[placement.id] > 0)
             pendingControls.push(
               <div key={placement.id}>
                 {/* ⚠️ Known wrong, and left wrong deliberately.
@@ -597,18 +614,12 @@ export function StickerPlacementOverlay({
                   }}
                 >
                   <div>
-                    {isOwner ? (
-                      <StickerPlacementActions
-                        placementIds={[placement.id]}
-                        hasComment={placement.hasComment}
-                        free={placement.free}
-                        compact
-                      />
-                    ) : (
-                      <span className="whitespace-nowrap rounded bg-yellow-6 px-2 py-0.5 text-[10px] font-semibold text-dark-9">
-                        Awaiting review
-                      </span>
-                    )}
+                    <StickerPlacementActions
+                      placementIds={[placement.id]}
+                      hasComment={placement.hasComment}
+                      free={placement.free}
+                      compact
+                    />
                   </div>
                 </div>
               </div>

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -319,21 +319,17 @@ export function StickerPlacementOverlay({
 
   const visible = step == null ? ordered : ordered.slice(0, step + 1);
 
-  // The owner's approve/decline for each pending placement, collected here and
-  // drawn in their own layer below. They cannot live in the isolated layer: they
-  // have to out-rank the draft sticker as well as every placed one, and the
-  // isolation that keeps the layer order from leaking would trap them under it.
+  // The owner's approve/decline, drawn in their own layer below so they out-rank
+  // every placed sticker and not just the one they belong to; isolation would cap
+  // them at the layer's own z-index.
   const pendingControls: ReactElement[] = [];
 
   return (
     <>
       {/* `isolate` is load-bearing. Without it these z-indexes are hoisted into
           whatever context the surface provides and compete with everything else
-          in it: on the detail view the draft being dragged (which is a sibling
-          with z-index 1 at most, so every sticker above the first would cover
-          it, along with its buy button and its hit area), and on a feed card the
-          header and footer, which are absolutely positioned with no z-index of
-          their own and rely on DOM order — AspectRatioImageCard states "under
+          in it: on a feed card the header and footer, which are absolutely
+          positioned with no z-index of their own and rely on DOM order — AspectRatioImageCard states "under
           the header and footer" as a contract. Contained, the whole layer keeps
           the z-index it had before this change, and the ordering inside it is
           purely internal. */}
@@ -464,41 +460,48 @@ export function StickerPlacementOverlay({
                 />
               )}
 
-              {/* Inside the sticker's own box, never outside it. This is a
-                  label, not a control — the placer cannot act on it — so unlike
-                  the owner's approve/decline it does not need to out-rank a
-                  draft or escape the transform. Anchored outside the box it
-                  claimed area the sticker did not occupy, and that area is what
-                  collided with the sticker being placed beside it.
+              {/* A label, not a control — the placer cannot act on it — so it
+                  needs neither the pending-controls layer nor an escape from the
+                  box's transform. Counter-rotated because rotation runs to ±180
+                  and a label riding it reads upside down.
 
-                  Counter-rotated because the box is rotated with the artwork and
-                  rotation runs to ±180, so a label that rode it would read
-                  upside down. */}
-              {placement.isPending && !isOwner && (
+                  🔴 `max-w-full` + `truncate` is the containment, and it is the
+                  point of the whole block. `whitespace-nowrap` alone makes
+                  min-content equal max-content, so the box's width constrains
+                  nothing and an ~85px label hangs over both edges of a sticker
+                  placed below about scale 0.10 — which is the collision this was
+                  moved to avoid, just sideways. Truncated it degrades to
+                  "Awaiting…" and the dashed ring carries the rest. */}
+              {placement.isPending && interactive && !isOwner && (
                 <div
-                  className="pointer-events-none absolute bottom-1 left-1/2 whitespace-nowrap"
+                  className="pointer-events-none absolute bottom-1 left-1/2 flex max-w-full items-center gap-1"
                   style={{ transform: `translateX(-50%) rotate(${-placement.data.rotation}deg)` }}
                 >
-                  <span className="rounded bg-yellow-6 px-2 py-0.5 text-[10px] font-semibold text-dark-9">
-                    Awaiting review
+                  {/* "Pending", not the "Awaiting review" the queues use: the
+                      longer wording truncates inside a sticker at its default
+                      size, and the hover card carries the detail. */}
+                  <span className="truncate rounded bg-yellow-6 px-1.5 py-0.5 text-[10px] font-semibold leading-tight text-dark-9">
+                    Pending
                   </span>
+                  {/* Stated, not explained: the popover on `PlacementFreeBadge`
+                      answers "why is this free and how do I stop it", which is
+                      the owner's question. `shrink-0` so the shorter, more
+                      surprising fact is the one that survives a small sticker. */}
+                  {showsFree && (
+                    <span className="shrink-0 rounded bg-blue-6 px-1.5 py-0.5 text-[10px] font-semibold leading-tight text-white">
+                      Free
+                    </span>
+                  )}
                 </div>
               )}
 
-              {/* Centred under the sticker, directly above the owner's approve
-                  and decline controls — those are positioned off the sticker's
-                  measured height, so this rides the same edge they start from.
-
-                  Inside the artwork's box on a card for the same reason the
-                  pending ring is: a card clips anything outset. */}
-              {showsFree && (
-                <div
-                  className={clsx(
-                    'absolute left-1/2 -translate-x-1/2 whitespace-nowrap',
-                    interactive && 'pointer-events-auto',
-                    surface === 'card' ? 'bottom-0' : '-bottom-3'
-                  )}
-                >
+              {/* Card only. A card draws no controls and no label, so this is
+                  the whole pending signal there, and it goes inside the box for
+                  the same reason the ring does — a card clips anything outset.
+                  On the detail view the fact is carried beside whichever of the
+                  two the viewer gets. */}
+              {showsFree && !interactive && (
+                <div className="absolute bottom-0 left-1/2 -translate-x-1/2 whitespace-nowrap">
                   <PlacementFreeBadge noun="placement" solid />
                 </div>
               )}
@@ -542,10 +545,6 @@ export function StickerPlacementOverlay({
             box: controlBox,
           });
 
-          // Owner only. The placer's "Awaiting review" label used to be pushed
-          // here too, which put a non-interactive label in the layer that exists
-          // to keep a control reachable — outside the sticker's box, and above
-          // the draft.
           if (isOwner && stickerHeights[placement.id] > 0)
             pendingControls.push(
               <div key={placement.id}>
@@ -560,22 +559,23 @@ export function StickerPlacementOverlay({
                 square media box clears the sticker by half its height again.
 
                 Anchoring inside the sticker's own box fixes the arithmetic and
-                costs three worse things, and the third is why the obvious
-                restructure is not enough on its own:
+                costs three worse things:
                   - the badge lands inside the hover-card trigger, whose 400px
                     dropdown opens over the owner's approve/decline — fixed by
                     having the hover card wrap only the artwork;
-                  - rotation is clamped to ±180, so the badge goes upside down
-                    AND ends up above the sticker. Counter-rotating fixes only
-                    the first half; `top-full` is the local bottom edge, which
-                    at 180° is the screen top and at 90° is off to the side.
-                    Staying upright and staying below are two separate fixes;
+                  - anchoring BELOW the box (`top-full`) rides the rotation: at
+                    180° the local bottom edge is the screen top, at 90° it is
+                    off to the side. Counter-rotation keeps it upright but does
+                    not move it back below. An anchor inside the box — the
+                    placer's label above — avoids this; a control has to sit
+                    outside;
                   - `body`'s transform makes it a stacking context, so a z-index
-                    inside it stops out-ranking other placements — a draft
-                    dragged over a pending one then swallows the owner's
-                    buttons. Nothing done INSIDE the box can fix that; it needs
-                    the badge kept outside the transform (what this does) or a
-                    z-index on the pending wrapper itself. */}
+                    inside it stops out-ranking other placements — a sticker
+                    placed later then covers the owner's buttons. Nothing done
+                    INSIDE the box can fix that; it needs the controls kept
+                    outside the transform (what this does) or a z-index on the
+                    pending wrapper itself. A draft covers them either way now,
+                    which is DRAFT_STICKER_Z doing what it says. */}
                 {/* Not rendered at all until the sticker has been measured.
                   Rendering it early would put it at the sticker's centre — on
                   top of the artwork — and then jump when the measurement lands.
@@ -586,7 +586,14 @@ export function StickerPlacementOverlay({
                 <div
                   ref={measureControl(placement.id)}
                   className={clsx(
-                    'pointer-events-auto absolute',
+                    // `w-max` is load-bearing, not tidying. Absolutely positioned
+                    // with no width, this shrink-to-fits against the space left
+                    // between its `left` and the container's right edge — so near
+                    // that edge it comes back NARROWER than its content, the
+                    // measurement feeding the clamp is that squeezed width, and
+                    // the clamp concludes it fits while the buttons are cut off.
+                    // The wider the row, the further in it starts happening.
+                    'pointer-events-auto absolute w-max',
                     // The translate goes with the clamp: a clamped `left` is the
                     // control's own left edge, stated against the box, so
                     // shifting it by half its width afterwards would put it back
@@ -613,7 +620,13 @@ export function StickerPlacementOverlay({
                     ...delayStyle,
                   }}
                 >
-                  <div>
+                  {/* In the control row rather than on the sticker. Anchored to
+                      the artwork it was clipped by the same edge that clipped
+                      the buttons — and it landed on top of them, since both were
+                      measured off the sticker's bottom. Here it inherits the
+                      clamp `placementControlPosition` already applies. */}
+                  <div className="flex items-center gap-1">
+                    {showsFree && <PlacementFreeBadge noun="placement" solid />}
                     <StickerPlacementActions
                       placementIds={[placement.id]}
                       hasComment={placement.hasComment}
@@ -638,10 +651,9 @@ export function StickerPlacementOverlay({
         })}
       </div>
 
-      {/* Outside the isolated layer, and above the draft: an owner arranging
-          their own sticker must not lose the buttons that answer someone
-          else's. Deliberately NOT inside the layer above — isolation would trap
-          these under the draft along with everything else. */}
+      {/* Outside the isolated layer so these out-rank every placed sticker, not
+          just the one they belong to. Below the draft on purpose
+          (DRAFT_STICKER_Z > PENDING_CONTROL_Z): whatever is under the cursor wins. */}
       {pendingControls.length > 0 && (
         <div
           ref={measureBox}

--- a/src/components/Sticker/placement-layers.ts
+++ b/src/components/Sticker/placement-layers.ts
@@ -1,13 +1,14 @@
 /**
  * The stacking order of the layers drawn over one image's media box.
  *
- * Shared because the two files that set these numbers are the two that must not
- * be read separately: `StickerPlacementOverlay` raised the owner's controls
- * above everything so a placement could always be answered, and that silently
- * put them above the sticker someone is currently dragging.
+ * Shared because the two files that set these numbers only make sense read
+ * together. Both are page-context numbers on paper: what actually keeps them
+ * off the app's own ladder (`shared/constants/app-layout.constants.ts`) is the
+ * centring transform on `ImageStickerOverlay`'s surface div, which makes that
+ * div a stacking context. Restyle it to flex centring and these escape.
  */
 
-/** The owner's approve/decline, above the placed stickers and the draft. */
+/** The owner's approve/decline, above every placed sticker; below the draft. */
 export const PENDING_CONTROL_Z = 1000;
 
 /**

--- a/src/components/Sticker/placement-layers.ts
+++ b/src/components/Sticker/placement-layers.ts
@@ -1,0 +1,20 @@
+/**
+ * The stacking order of the layers drawn over one image's media box.
+ *
+ * Shared because the two files that set these numbers are the two that must not
+ * be read separately: `StickerPlacementOverlay` raised the owner's controls
+ * above everything so a placement could always be answered, and that silently
+ * put them above the sticker someone is currently dragging.
+ */
+
+/** The owner's approve/decline, above the placed stickers and the draft. */
+export const PENDING_CONTROL_Z = 1000;
+
+/**
+ * The sticker being placed, above every pending control.
+ *
+ * Justin's call: whatever is under the cursor wins. The controls stay reachable
+ * the moment the draft is put down or bought, and a draft only exists while
+ * someone is actively arranging one.
+ */
+export const DRAFT_STICKER_Z = 2000;


### PR DESCRIPTION
## The pending markings took up space the sticker did not occupy

Fixes `868kv53pk` (reported by Ellie via DM, 2026-08-21): *"this does make it difficult to place multiple stickers at once next to each other — placement should overlap."*

Two markings on a pending placement were anchored **outside** the sticker's box, and one of them sat above the sticker being dragged. That extra footprint is what a neighbouring placement collides with.

### What was where

| marking | who sees it | was | now |
|---|---|---|---|
| "Awaiting review" | the placer | pushed into the pending-controls layer — outside the box, `z-index: 1000`, above the draft | inside the sticker's box, counter-rotated, reading "Pending" |
| approve / decline | the owner | outside the box, clamped by #4266 | unchanged, except the free badge joins its row |
| "Free placement" | either | `-bottom-3`, outside the box, on top of the controls | owner: inside the control row. placer: a compact `Free` chip beside the pending label |
| dashed ring | both | unchanged | unchanged |

The label is a **label**, not a control. Only a control needs to escape the box's transform and out-rank every placement — so only the owner's buttons still do.

`DRAFT_STICKER_Z` (2000) puts the draft above `PENDING_CONTROL_Z` (1000): whatever is under the cursor wins, which was Justin's other instruction. Both constants moved into `placement-layers.ts` because the two files that set them only make sense read together.

### Two defects this surfaced

**`w-max` on the control row.** Absolutely positioned with no width, it shrink-to-fits against the space between its `left` and the container's right edge — so near that edge it measures **narrower than its content**, and that squeezed width is what feeds `placementControlPosition`. The clamp then concludes it fits while the buttons are cut off. Pre-existing; adding the badge widened the row enough to make it visible. Measured at `x = 0.97`: the row reported **145px** against a 232px content width and was truncated on screen. With `w-max` all four rows measure 232 and clamp correctly.

**`max-w-full` + `truncate` on the label.** `whitespace-nowrap` makes min-content equal max-content, so the sticker's box constrained the label's width not at all — an ~85px label hung over both edges of anything below about `scale 0.10` (`STICKER_PLACEMENT_MIN_SCALE` is 0.05). That is the same collision the ticket describes, rotated 90°. Shortened to "Pending" so it fits untruncated at the default size and degrades gracefully below it.

### Verified in a real browser

Headless Chromium, viewport pinned **1600×1000**, signed in as userId 1, reveal primed in `localStorage` (stickers are hidden by default — `868kv2hpp`).

- **Containment**: sticker box 106px, label row 84px, **0 overflow on either edge**. Box forced to 45px (min scale): row 45px, still 0 overflow, label truncates rather than escaping.
- **Z-order**: dragged a draft onto a pending sticker; `elementsFromPoint` at that point returns the draft (`z=2001`) above the placement (`z=1`). The label is `pointer-events-none`, so for it the check is paint order in a screenshot, not hit-testing.
- **Clamp**: four pending placements at the four extremes, every control row inside the clip box (the right edge overshoots by 1px, matching #4266's own table).

### Tests

None, deliberately. The claim is paint order plus which box a label is anchored in. Paint order is not observable from any runner here; the anchoring half needs a fixture mounting the real `StickerPlacementOverlay` — which no suite does today, both nearby suites mock it wholesale — and browser tests run in no CI job. A constants test (`DRAFT_STICKER_Z > PENDING_CONTROL_Z`) stays **green on the actual revert**, so it would assert coverage that does not exist.

Existing suites confirmed unaffected: `src/components/Sticker/__tests__/` 233 passed; the six relevant browser suites 52 passed. `"Awaiting review"` and `zIndex` appear in no sticker test file.

### Deferred

Filed rather than folded in: three hand-rolled pending badges across the two queues and the hover card that `PlacementFreeBadge` is the precedent for consolidating, and a browser test for the `w-max` shrink-to-fit defect, which `placement-control-position.test.ts` structurally cannot see (it takes the control's width as an input).

### Migrations

None.
