### PR TITLE
fix(stickers): put the free badge on the sticker, and keep both marks visible at the edges

### DIFF
--- a/src/components/Placement/PlacementFreeBadge.tsx
+++ b/src/components/Placement/PlacementFreeBadge.tsx
@@ -4,8 +4,9 @@ import Link from 'next/link';
 /**
  * That this one cost nothing, and where the owner changes that.
  *
- * Shared by both review queues and the sticker overlay so the fact reads the
- * same everywhere it appears — same colour, same words, same explanation.
+ * Shared by both review queues so the fact reads the same in each — same colour,
+ * same words, same explanation. The overlay states it on the sticker instead,
+ * where a popover has nothing to open from: that layer is pointer-events-none.
  *
  * The popover exists because a queue is where a creator first meets a free
  * placement, arriving from a notification, and "why is this free and how do I
@@ -14,15 +15,8 @@ import Link from 'next/link';
 export function PlacementFreeBadge({
   /** What was placed here: `placement` on stickers, `submission` on galleries. */
   noun,
-  /**
-   * Solid rather than tinted. `light` is a translucent fill, which is legible on
-   * a queue card and unreadable over artwork — so the copy on an image asks for
-   * this, and nothing else should need it.
-   */
-  solid = false,
 }: {
   noun: 'placement' | 'submission';
-  solid?: boolean;
 }) {
   return (
     // `withinPortal` explicitly: the repo theme sets `withinPortal: false` for
@@ -36,7 +30,7 @@ export function PlacementFreeBadge({
           component="button"
           type="button"
           size="sm"
-          variant={solid ? 'filled' : 'light'}
+          variant="light"
           color="blue"
           className="w-fit cursor-pointer"
         >

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -6,10 +6,10 @@ import type { PlacedSticker } from '~/components/Sticker/placement.util';
 import { orderPlacements, placementRevealDelays } from '~/components/Sticker/placement-order';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { placementControlPosition } from '~/components/Sticker/placement-control-position';
+import { placementMarkLayout } from '~/components/Sticker/placement-mark-layout';
 import { PENDING_CONTROL_Z } from '~/components/Sticker/placement-layers';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
 import { StickerPlacementHoverCard } from '~/components/Sticker/StickerPlacementHoverCard';
-import { PlacementFreeBadge } from '~/components/Placement/PlacementFreeBadge';
 import { freeMarkerVisible } from '~/components/Sticker/free-marker';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import {
@@ -38,6 +38,20 @@ import {
  * so a gap measured to the pixel is a gap the sticker moves into.
  */
 const CONTROL_GAP_PX = 14;
+
+/** Shared so the two in-box marks cannot drift apart in size or weight. */
+const PLACEMENT_MARK_CLASS =
+  'truncate rounded px-1.5 py-0.5 text-[10px] font-semibold leading-tight';
+
+/**
+ * Follow from `PLACEMENT_MARK_CLASS` and the `top-1`/`bottom-1`/`gap-0.5` below
+ * — change those and change these. They only feed `placementMarkLayout`, whose
+ * questions (is a mark entirely outside, is there room for two) a pixel either
+ * way does not answer differently.
+ */
+const PLACEMENT_MARK_HEIGHT_PX = 17;
+const PLACEMENT_MARK_INSET_PX = 4;
+const PLACEMENT_MARK_GAP_PX = 2;
 
 /**
  * Placed stickers, drawn over the content they were placed on.
@@ -190,9 +204,15 @@ export function StickerPlacementOverlay({
   //
   // Only pending placements are measured; nothing else is positioned relative to
   // a sticker's edge.
-  const [stickerHeights, setStickerHeights] = useState<Record<number, number>>({});
+  const [stickerBoxes, setStickerBoxes] = useState<
+    Record<number, { height: number; width: number }>
+  >({});
   /**
-   * The box the controls have to stay inside, and how big each control is.
+   * The media box everything here stays inside, and how big each control is.
+   *
+   * Read off the sticker layer, not the owner's control layer — that one mounts
+   * only when there is a control to draw, and the marks need the box whether or
+   * not the viewer is the owner.
    *
    * Both are needed before the position can be clamped, and neither is knowable
    * from CSS: the control's width depends on which buttons the owner gets, and
@@ -251,7 +271,6 @@ export function StickerPlacementOverlay({
   const measureSticker = useCallback(
     (placement: PlacedSticker) => (node: HTMLDivElement | null) => {
       const placementId = placement.id;
-      const radians = (placement.data.rotation * Math.PI) / 180;
       const existing = disposers.current.get(placementId);
       if (existing) {
         existing();
@@ -259,7 +278,7 @@ export function StickerPlacementOverlay({
       }
       if (!node) return;
 
-      const read = () =>
+      const record = () => {
         // `offsetHeight`/`offsetWidth`, deliberately: they are LAYOUT numbers and
         // ignore transforms. A bounding rect would be simpler and is wrong here,
         // because the artwork animates — it pops from 0.72 to 1.06 on arrival and
@@ -267,19 +286,17 @@ export function StickerPlacementOverlay({
         // frame that landed on, and a sticker measured mid-pop reports too small
         // and the controls sit on top of it.
         //
-        // The rotation is then added back by hand: a tilted rectangle's visual
-        // height is h·|cos r| + w·|sin r|, and ignoring the second term is what
-        // put the buttons over the artwork on anything more than slightly
-        // turned.
-        node.offsetHeight * Math.abs(Math.cos(radians)) +
-        node.offsetWidth * Math.abs(Math.sin(radians));
-
-      const record = () => {
-        const height = read();
+        // Stored unrotated. The two consumers want different things from it: the
+        // controls sit outside the sticker and need the rotated extent, the marks
+        // sit on the box's own edges and need the box. Deriving the first from
+        // this is arithmetic; recovering this from the first is not.
+        const box = { height: node.offsetHeight, width: node.offsetWidth };
         // Guarded, because writing state from a ResizeObserver that the write
         // then resizes is how a resize loop starts.
-        setStickerHeights((current) =>
-          current[placementId] === height ? current : { ...current, [placementId]: height }
+        setStickerBoxes((current) =>
+          current[placementId]?.height === box.height && current[placementId]?.width === box.width
+            ? current
+            : { ...current, [placementId]: box }
         );
       };
 
@@ -334,6 +351,7 @@ export function StickerPlacementOverlay({
           the z-index it had before this change, and the ordering inside it is
           purely internal. */}
       <div
+        ref={measureBox}
         className={clsx('pointer-events-none absolute inset-0 isolate overflow-hidden', className)}
       >
         {visible.map((placement, index) => {
@@ -383,6 +401,51 @@ export function StickerPlacementOverlay({
           // at full strength once approved, which is exactly what the floor
           // exists to prevent. The dashed outline carries "awaiting review" now.
           const appearance = stickerArtworkStyle(placement.data);
+
+          // The owner gets approve/decline instead of "Pending": it says the
+          // same thing and can be acted on.
+          // What the controls need, and only they: a tilted rectangle's visual
+          // height is h·|cos r| + w·|sin r|, and dropping the second term is what
+          // put the buttons over the artwork on anything more than slightly
+          // turned.
+          const radians = (placement.data.rotation * Math.PI) / 180;
+          const measured = stickerBoxes[placement.id];
+          const stickerExtent = measured
+            ? measured.height * Math.abs(Math.cos(radians)) +
+              measured.width * Math.abs(Math.sin(radians))
+            : 0;
+
+          const hasPending = placement.isPending && interactive && !isOwner;
+          const side = placementMarkLayout({
+            y: placement.data.y,
+            stickerHeight: stickerBoxes[placement.id]?.height ?? 0,
+            rotation: placement.data.rotation,
+            markHeight: PLACEMENT_MARK_HEIGHT_PX,
+            inset: PLACEMENT_MARK_INSET_PX,
+            gap: PLACEMENT_MARK_GAP_PX,
+            box: controlBox,
+            hasFree: showsFree,
+            hasPending,
+          });
+          // Free first, pending second: within either stack this puts the mark
+          // that flipped inboard of the one already on that edge.
+          const marks = [
+            side.free && {
+              key: 'free',
+              side: side.free,
+              label: 'Free placement',
+              className: 'bg-blue-6 text-white',
+            },
+            side.pending && {
+              // "Pending", not the queues' "Awaiting review" — the longer
+              // wording truncates inside a sticker at its default size, and the
+              // hover card carries the detail.
+              key: 'pending',
+              side: side.pending,
+              label: 'Pending',
+              className: 'bg-yellow-6 text-dark-9',
+            },
+          ].filter((mark) => !!mark);
 
           const artworkImage = (
             <EdgeImage
@@ -460,51 +523,40 @@ export function StickerPlacementOverlay({
                 />
               )}
 
-              {/* A label, not a control — the placer cannot act on it — so it
-                  needs neither the pending-controls layer nor an escape from the
-                  box's transform. Counter-rotated because rotation runs to ±180
-                  and a label riding it reads upside down.
+              {/* Marks, not controls — nobody can act on either — so they need
+                  neither the pending-controls layer nor an escape from the box's
+                  transform. Which edge each sits on, and whether there is room
+                  at all, is `placementMarkLayout`.
 
-                  🔴 `max-w-full` + `truncate` is the containment, and it is the
-                  point of the whole block. `whitespace-nowrap` alone makes
-                  min-content equal max-content, so the box's width constrains
-                  nothing and an ~85px label hangs over both edges of a sticker
-                  placed below about scale 0.10 — which is the collision this was
-                  moved to avoid, just sideways. Truncated it degrades to
-                  "Awaiting…" and the dashed ring carries the rest. */}
-              {placement.isPending && interactive && !isOwner && (
-                <div
-                  className="pointer-events-none absolute bottom-1 left-1/2 flex max-w-full items-center gap-1"
-                  style={{ transform: `translateX(-50%) rotate(${-placement.data.rotation}deg)` }}
-                >
-                  {/* "Pending", not the "Awaiting review" the queues use: the
-                      longer wording truncates inside a sticker at its default
-                      size, and the hover card carries the detail. */}
-                  <span className="truncate rounded bg-yellow-6 px-1.5 py-0.5 text-[10px] font-semibold leading-tight text-dark-9">
-                    Pending
-                  </span>
-                  {/* Stated, not explained: the popover on `PlacementFreeBadge`
-                      answers "why is this free and how do I stop it", which is
-                      the owner's question. `shrink-0` so the shorter, more
-                      surprising fact is the one that survives a small sticker. */}
-                  {showsFree && (
-                    <span className="shrink-0 rounded bg-blue-6 px-1.5 py-0.5 text-[10px] font-semibold leading-tight text-white">
-                      Free
-                    </span>
-                  )}
-                </div>
-              )}
-
-              {/* Card only. A card draws no controls and no label, so this is
-                  the whole pending signal there, and it goes inside the box for
-                  the same reason the ring does — a card clips anything outset.
-                  On the detail view the fact is carried beside whichever of the
-                  two the viewer gets. */}
-              {showsFree && !interactive && (
-                <div className="absolute bottom-0 left-1/2 -translate-x-1/2 whitespace-nowrap">
-                  <PlacementFreeBadge noun="placement" solid />
-                </div>
-              )}
+                  🔴 `inset-x-0` + `truncate` is the containment. Anchored
+                  `left-1/2` instead, a mark's shrink-to-fit width is measured
+                  against the half of the box to its right, so `Free placement`
+                  truncated at sizes where it would have fitted; with
+                  `whitespace-nowrap` and no cap at all it hung over both edges
+                  of a small sticker — the collision these were moved inside to
+                  avoid, sideways. */}
+              {(['top', 'bottom'] as const).map((edge) => {
+                const stack = marks.filter((mark) => mark.side === edge);
+                if (!stack.length) return null;
+                return (
+                  <div
+                    key={edge}
+                    className={clsx(
+                      'pointer-events-none absolute inset-x-0 flex flex-col items-center gap-0.5',
+                      edge === 'top' ? 'top-1' : 'bottom-1'
+                    )}
+                    // Counter-rotated: rotation runs to ±180 and a mark riding
+                    // the sticker's own transform reads upside down.
+                    style={{ transform: `rotate(${-placement.data.rotation}deg)` }}
+                  >
+                    {stack.map((mark) => (
+                      <span key={mark.key} className={clsx(PLACEMENT_MARK_CLASS, mark.className)}>
+                        {mark.label}
+                      </span>
+                    ))}
+                  </div>
+                );
+              })}
             </div>
           );
 
@@ -539,13 +591,13 @@ export function StickerPlacementOverlay({
           const clamped = placementControlPosition({
             x: placement.data.x,
             y: placement.data.y,
-            stickerHeight: stickerHeights[placement.id],
+            stickerHeight: stickerExtent,
             gap: CONTROL_GAP_PX,
             control: controlSizes[placement.id] ?? { width: 0, height: 0 },
             box: controlBox,
           });
 
-          if (isOwner && stickerHeights[placement.id] > 0)
+          if (isOwner && stickerExtent > 0)
             pendingControls.push(
               <div key={placement.id}>
                 {/* ⚠️ Known wrong, and left wrong deliberately.
@@ -560,15 +612,14 @@ export function StickerPlacementOverlay({
 
                 Anchoring inside the sticker's own box fixes the arithmetic and
                 costs three worse things:
-                  - the badge lands inside the hover-card trigger, whose 400px
-                    dropdown opens over the owner's approve/decline — fixed by
-                    having the hover card wrap only the artwork;
+                  - it lands inside the hover-card trigger, whose 400px dropdown
+                    opens over it. The marks live there and are fine — nobody can
+                    act on them, so a dropdown covering them costs nothing;
                   - anchoring BELOW the box (`top-full`) rides the rotation: at
                     180° the local bottom edge is the screen top, at 90° it is
                     off to the side. Counter-rotation keeps it upright but does
-                    not move it back below. An anchor inside the box — the
-                    placer's label above — avoids this; a control has to sit
-                    outside;
+                    not move it back below. An anchor inside the box — the two
+                    marks above — avoids this; a control has to sit outside;
                   - `body`'s transform makes it a stacking context, so a z-index
                     inside it stops out-ranking other placements — a sticker
                     placed later then covers the owner's buttons. Nothing done
@@ -611,7 +662,7 @@ export function StickerPlacementOverlay({
                     top: clamped
                       ? clamped.top
                       : `calc(${placement.data.y * 100}% + ${
-                          stickerHeights[placement.id] / 2 + CONTROL_GAP_PX
+                          stickerExtent / 2 + CONTROL_GAP_PX
                         }px)`,
                     // Above every sticker, not just above the one it belongs to:
                     // the layer order means anything placed later covers this
@@ -620,13 +671,7 @@ export function StickerPlacementOverlay({
                     ...delayStyle,
                   }}
                 >
-                  {/* In the control row rather than on the sticker. Anchored to
-                      the artwork it was clipped by the same edge that clipped
-                      the buttons — and it landed on top of them, since both were
-                      measured off the sticker's bottom. Here it inherits the
-                      clamp `placementControlPosition` already applies. */}
-                  <div className="flex items-center gap-1">
-                    {showsFree && <PlacementFreeBadge noun="placement" solid />}
+                  <div>
                     <StickerPlacementActions
                       placementIds={[placement.id]}
                       hasComment={placement.hasComment}
@@ -656,7 +701,6 @@ export function StickerPlacementOverlay({
           (DRAFT_STICKER_Z > PENDING_CONTROL_Z): whatever is under the cursor wins. */}
       {pendingControls.length > 0 && (
         <div
-          ref={measureBox}
           className="pointer-events-none absolute inset-0 overflow-hidden"
           style={{ zIndex: PENDING_CONTROL_Z }}
         >

--- a/src/components/Sticker/__tests__/placement-mark-layout.test.ts
+++ b/src/components/Sticker/__tests__/placement-mark-layout.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { placementMarkLayout } from '~/components/Sticker/placement-mark-layout';
+
+/**
+ * A power-of-two box throughout, deliberately: `y` is a FRACTION, so a boundary
+ * case only lands on the boundary if `y * box.height` is exact. On the 886px
+ * detail box the natural flush value comes out at 31.999999999999996 — close
+ * enough that the assertion still passes, and close enough that a `<=`→`<`
+ * mutant survives at one edge while being caught at the other.
+ */
+const BOX = { width: 1024, height: 1024 };
+const STICKER = 128;
+const MARK = 17;
+const INSET = 4;
+const GAP = 2;
+
+const layout = (y: number, over: Partial<Parameters<typeof placementMarkLayout>[0]> = {}) =>
+  placementMarkLayout({
+    y,
+    stickerHeight: STICKER,
+    rotation: 0,
+    markHeight: MARK,
+    inset: INSET,
+    gap: GAP,
+    box: BOX,
+    hasFree: true,
+    hasPending: true,
+    ...over,
+  });
+
+/** The `y` that puts the sticker's own top edge this far past the box's top. */
+const topEdgePast = (px: number) => (STICKER / 2 - px) / BOX.height;
+const bottomEdgePast = (px: number) => (BOX.height + px - STICKER / 2) / BOX.height;
+
+describe('placementMarkLayout', () => {
+  it('keeps each mark on its own edge in the middle of the image', () => {
+    expect(layout(0.5)).toEqual({ free: 'top', pending: 'bottom' });
+  });
+
+  it('leaves a partly cropped mark where it is', () => {
+    // 18px past the top: the mark spans -14..3, so 3px of it still reads.
+    // Cropping with the artwork is the intended behaviour.
+    expect(layout(topEdgePast(18)).free).toBe('top');
+    expect(layout(bottomEdgePast(18)).pending).toBe('bottom');
+  });
+
+  it('flips a mark to the other edge once its own edge is entirely outside', () => {
+    expect(layout(topEdgePast(25))).toEqual({ free: 'bottom', pending: 'bottom' });
+    expect(layout(bottomEdgePast(25))).toEqual({ free: 'top', pending: 'top' });
+  });
+
+  it('is exact at the boundary — a mark flush with the edge has gone', () => {
+    // `topEdgePast` counts pixels OUTSIDE the box, so a larger `y` pulls the
+    // sticker back in — hence `+ 1 / height` here and `- 1 / height` below.
+    const flushTop = topEdgePast(INSET + MARK);
+    expect(layout(flushTop).free).toBe('bottom');
+    expect(layout(flushTop + 1 / BOX.height).free).toBe('top');
+
+    const flushBottom = bottomEdgePast(INSET + MARK);
+    expect(layout(flushBottom).pending).toBe('top');
+    expect(layout(flushBottom - 1 / BOX.height).pending).toBe('bottom');
+  });
+
+  it('moves neither mark when the sticker covers both edges', () => {
+    // Every position is equally cropped, so a flip would only trade one gone
+    // edge for another.
+    expect(layout(0.5, { stickerHeight: BOX.height * 4 })).toEqual({
+      free: 'top',
+      pending: 'bottom',
+    });
+  });
+
+  describe('rotation', () => {
+    /**
+     * 🔴 The marks are anchored in the sticker's OWN rotated frame, so a side
+     * decided in screen space and applied there is inverted past ±90°. Without
+     * the projection these cases move a fully visible mark off-image.
+     */
+    it('flips the mark that is really off-image, not the one named top', () => {
+      // Upside down: the sticker's local top renders at the screen BOTTOM, so
+      // the local-bottom mark is the one that has left the top of the image.
+      const y = topEdgePast(25);
+      expect(layout(y, { rotation: 180 })).toEqual({ free: 'top', pending: 'top' });
+      // Same sticker the right way up flips the other one.
+      expect(layout(y, { rotation: 0 })).toEqual({ free: 'bottom', pending: 'bottom' });
+    });
+
+    it('does not flip at ±90, where neither edge is the one being cropped', () => {
+      const y = topEdgePast(25);
+      expect(layout(y, { rotation: 90 })).toEqual({ free: 'top', pending: 'bottom' });
+      expect(layout(y, { rotation: -90 })).toEqual({ free: 'top', pending: 'bottom' });
+    });
+
+    it('shrinks the reach as the sticker tilts', () => {
+      // At 60° the local edges project to half their distance, so a sticker
+      // whose upright top edge is gone still has its tilted one in frame.
+      const y = topEdgePast(25);
+      expect(layout(y, { rotation: 0 }).free).toBe('bottom');
+      expect(layout(y, { rotation: 60 }).free).toBe('top');
+    });
+  });
+
+  describe('room', () => {
+    it('draws nothing on a sticker too short to hold both marks', () => {
+      // Two marks need 2×17 + 2×4 + 2 = 44px.
+      expect(layout(0.5, { stickerHeight: 43 })).toEqual({ free: null, pending: null });
+      expect(layout(0.5, { stickerHeight: 44 })).toEqual({ free: 'top', pending: 'bottom' });
+    });
+
+    it('needs less room for one mark than for two', () => {
+      const oneMark = { hasPending: false, stickerHeight: 30 };
+      expect(layout(0.5, oneMark)).toEqual({ free: 'top', pending: null });
+      expect(layout(0.5, { ...oneMark, hasPending: true })).toEqual({ free: null, pending: null });
+    });
+
+    it('asks for nothing when neither mark applies', () => {
+      expect(layout(0.5, { hasFree: false, hasPending: false })).toEqual({
+        free: null,
+        pending: null,
+      });
+    });
+  });
+
+  it('draws nothing until the sticker and the box have been measured', () => {
+    expect(layout(0.02, { box: { width: 0, height: 0 } })).toEqual({ free: null, pending: null });
+    expect(layout(0.02, { stickerHeight: 0 })).toEqual({ free: null, pending: null });
+    expect(layout(0.02, { markHeight: 0 })).toEqual({ free: null, pending: null });
+  });
+});

--- a/src/components/Sticker/placement-mark-layout.ts
+++ b/src/components/Sticker/placement-mark-layout.ts
@@ -1,0 +1,90 @@
+import type { ControlBox } from '~/components/Sticker/placement-control-position';
+
+export type MarkSide = 'top' | 'bottom';
+
+/**
+ * Where a pending sticker's marks go, and whether there is room to draw them.
+ *
+ * "Free placement" wants the sticker's top edge and "Pending" the bottom, both
+ * inside its box. Two things can spoil that, and this answers both.
+ *
+ * **The edge can be off-image.** Being cropped with the artwork is fine and
+ * deliberate — the sticker is half off-image too. Being cropped *entirely* is
+ * not: the mark is then absent, with nothing to say it was ever there. So a
+ * mark moves to the opposite edge when its own edge is fully outside and the
+ * other one is not. When both are gone neither moves, because the far side is
+ * no better.
+ *
+ * **The sticker can be too small to hold them.** At `STICKER_PLACEMENT_MIN_SCALE`
+ * a sticker is tens of pixels tall, and two marks anchored to opposite edges of
+ * that overlap each other in the middle. `null` then, and the dashed ring and
+ * the hover card carry it — a mark on top of another mark states nothing.
+ *
+ * 🔴 ROTATION IS WHY THIS TAKES `rotation` AND AN UNROTATED HEIGHT. The marks
+ * live inside the sticker's own rotated box, so `'top'` is its LOCAL top — at
+ * 180° that renders at the bottom of the screen. A flip decided in screen space
+ * and applied in that frame is inverted for anything past ±90°: it would take a
+ * mark that was fully visible and move it to the edge that is off-image. So the
+ * local offsets are projected through `cos` before the test, which also makes
+ * ±90° a no-op, correctly — the local top edge is a screen SIDE there, and
+ * neither vertical edge is the one being cropped.
+ *
+ * Pixels against the media box, for the reason `placement-control-position.ts`
+ * spells out: `y` resolves against the box's height while a sticker is sized
+ * from its width, so the two cannot be reconciled on the fractions.
+ */
+export function placementMarkLayout({
+  y,
+  stickerHeight,
+  rotation,
+  markHeight,
+  inset,
+  gap,
+  box,
+  hasFree,
+  hasPending,
+}: {
+  /** 0–1, the sticker's centre as a fraction of the box's height. */
+  y: number;
+  /**
+   * The sticker's UNROTATED layout height in px — `offsetHeight`, not the
+   * rotation-expanded extent `placementControlPosition` wants. The marks sit on
+   * the box's own edges, so the local box is what they measure against.
+   */
+  stickerHeight: number;
+  /** Degrees, ±180. */
+  rotation: number;
+  markHeight: number;
+  /** Distance from the sticker's edge to the mark, matching the CSS inset. */
+  inset: number;
+  /** Space between two marks stacked on the same edge. */
+  gap: number;
+  box: ControlBox;
+  hasFree: boolean;
+  hasPending: boolean;
+}): { free: MarkSide | null; pending: MarkSide | null } {
+  const absent = { free: null, pending: null };
+  const marks = (hasFree ? 1 : 0) + (hasPending ? 1 : 0);
+  // Unmeasured draws nothing rather than drawing in the wrong place: a mark that
+  // appears at the sticker's centre and then jumps is worse than one arriving a
+  // frame late. The room test below covers an unmeasured sticker too — zero is
+  // never tall enough — so only the box needs its own guard.
+  if (!(box.height > 0) || !(markHeight > 0) || !marks) return absent;
+  if (stickerHeight < marks * markHeight + 2 * inset + (marks - 1) * gap) return absent;
+
+  const cos = Math.cos((rotation * Math.PI) / 180);
+  const centre = y * box.height;
+  // Distance from the sticker's centre to a mark's own centre, in the sticker's
+  // frame, then projected onto the screen's vertical.
+  const reach = (stickerHeight / 2 - inset - markHeight / 2) * cos;
+  const half = markHeight / 2;
+  const gone = (screenY: number) => screenY + half <= 0 || screenY - half >= box.height;
+
+  const topGone = gone(centre - reach);
+  const bottomGone = gone(centre + reach);
+
+  return {
+    free: hasFree ? (topGone && !bottomGone ? 'bottom' : 'top') : null,
+    pending: hasPending ? (bottomGone && !topGone ? 'top' : 'bottom') : null,
+  };
+}


### PR DESCRIPTION
## The free-placement badge, and what happens when a mark's edge is off-image

Follow-up to #4266 and #4286, on Justin's direction after looking at the merged result.

### What moved

| mark | was | now |
|---|---|---|
| Free placement | owner: inline in the approve/decline row, pushing the buttons across. card: a `PlacementFreeBadge` inside the box | the **top** edge inside the sticker's box, every surface |
| Pending | bottom edge inside the box | unchanged |

A free placement awaiting an answer now shows both at once — Justin's ask. Both go through one class, so size, weight, padding and radius cannot drift apart, and both counter-rotate with the sticker.

### `placementMarkLayout`

A pure function deciding which edge each mark gets, and whether to draw them at all. Three things it answers, two of which the review lanes found:

**Cropping.** A mark cropped by the image edge is fine and deliberate — the artwork is cropped there too, and Justin ruled on this explicitly. A mark cropped *entirely* is not: it is absent, with nothing to say it was ever there. So it moves to the opposite edge, and only when that edge is actually better. Both edges gone means neither moves.

**Rotation.** 🔴 The marks live inside the sticker's own **rotated** box, so `'top'` is its *local* top — at 180° that renders at the bottom of the screen. A side decided in screen space and applied in that frame is inverted past ±90°: it takes a mark that was fully visible and moves it to the edge that is off-image. Local offsets are now projected through `cos` before the test, which also makes ±90° a no-op — correctly, since the local top edge is a screen *side* there and neither vertical edge is the one being cropped.

**Room.** `STICKER_PLACEMENT_MIN_SCALE` is 0.05, which on the 886px detail box is a 44px-wide sticker. Each mark occupies `inset + height = 21px` from its edge, so two of them on opposite edges of anything shorter than 44px overlap in the middle — and the previous revision drew them anyway. Nothing is drawn when there is no room; the dashed ring and the hover card carry it.

### Two smaller fixes

- The stack is anchored `inset-x-0`, not `left-1/2`. Anchored at the half, an absolutely positioned element's shrink-to-fit width is measured against the half of the box to its **right**, so `Free placement` truncated at sizes where it fitted comfortably. `max-w-full` never bound.
- The sticker measurement stores the **unrotated** layout box. The controls want the rotation-expanded extent (`h·|cos| + w·|sin|`) and the marks want the box's own edges; deriving the first from the second is arithmetic, the reverse is not.

`measureBox` also moved from the owner's control layer — which mounts only when there is a control to draw — onto the sticker layer, so a non-owner has a box to judge against at all.

### Verified

Headless Chromium, viewport pinned 1600×1000, signed in, reveal primed (`868kv2hpp`).

- Both marks inside the sticker's box, 12px and 29px clear on each side, neither truncated. Screenshot looked at.
- End-to-end flip: a pending free placement moved to `y = 0.03` on dev puts its box top 27px above the media box; `Free placement` renders on the **bottom**, above `Pending`, both fully visible at 16.5px. Row restored to its original `y` afterwards.

### Tests

`placement-mark-layout.test.ts`, 12 cases. Mutated ten ways — inverting each flip, dropping the `cos` projection, `Math.abs` on `cos` (which is what "handles rotation" looks like if you only think about ±90), dropping `inset`/`markHeight` from either edge, loosening `<=`/`>=`, swapping the two edges' tests, and gutting the room check. All ten go red.

The boundary cases use a **1024px** box, deliberately: `y` is a fraction, so a boundary case only lands on the boundary if `y × box.height` is exact. On the 886px box the flush value comes out at `31.999999999999996`, which passes but lets a `<=`→`<` mutant survive at one edge while being caught at the other. That is not hypothetical — it happened in the first draft of this test and the comment review caught the write-up before the maths.

### Known and not fixed here

On a **feed card** the box the flip is judged against is `mediaContentRectOf`, which deliberately overflows the element for `cover` crops, so the rect that actually clips is smaller than the one measured. The flip is therefore inert on cards — a mark in the cropped-away band stays absent. That matches the surface's existing behaviour (`CardStickerOverlay` already documents that a sticker placed low on a tall image is not shown in a feed) and fixing it means plumbing the visible rect down. Filed rather than folded in.

Also filed: `RemixSubmissionQueue` states the free fact twice in one file, blue-with-popover at :272 and a hand-rolled green badge at :412.

### Migrations

None.
