### PR TITLE
fix(creator-studio): pass a targeting context to every Flipt evaluation

### DIFF
--- a/apps/creator-studio/src/lib/server/__tests__/flipt-context-guard.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/flipt-context-guard.test.ts
@@ -1,0 +1,79 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const SRC = fileURLToPath(new URL('../../../', import.meta.url));
+const EVAL_METHODS = ['isEnabled', 'isEnabledSync', 'getBoolean', 'getVariant'];
+
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return entry === 'node_modules' ? [] : walk(full);
+    return /\.(ts|svelte)$/.test(entry) && !entry.includes('.test.') ? [full] : [];
+  });
+}
+
+/** Slice the argument list of `name(` starting at `from`, balancing parens. */
+function callArgs(source: string, from: number): string {
+  let depth = 0;
+  for (let i = from; i < source.length; i++) {
+    if (source[i] === '(') depth++;
+    else if (source[i] === ')') {
+      depth--;
+      if (depth === 0) return source.slice(from + 1, i);
+    }
+  }
+  return source.slice(from);
+}
+
+function topLevelArgs(args: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of args) {
+    if ('([{'.includes(ch)) depth++;
+    else if (')]}'.includes(ch)) depth--;
+    if (ch === ',' && depth === 0) {
+      out.push(current.trim());
+      current = '';
+    } else current += ch;
+  }
+  if (current.trim()) out.push(current.trim());
+  return out;
+}
+
+// 🔴 The defect this exists for: a Flipt segment matches on CONTEXT PROPERTIES, never on the
+// entity id, so `isEnabled(flag, String(user.id))` matches no segment and returns the flag's
+// `enabled` value — false for every segmented flag we ship. That 404'd creator-announcements and
+// scheduled-model-sales for every Creator Studio user, moderators included, while the flag itself
+// read as correctly configured. Reviewing a call site does not catch it; nothing else does either.
+describe('every Flipt evaluation in the Studio passes a targeting context', () => {
+  const offenders: string[] = [];
+  const checked: string[] = [];
+
+  for (const file of walk(SRC)) {
+    // The shim is where fliptContext is defined; it evaluates nothing.
+    if (relative(SRC, file) === join('lib', 'server', 'flipt.ts')) continue;
+    const source = readFileSync(file, 'utf8');
+    for (const method of EVAL_METHODS) {
+      let index = source.indexOf(`.${method}(`);
+      while (index !== -1) {
+        const args = topLevelArgs(callArgs(source, index + method.length + 1));
+        const where = `${relative(SRC, file).split(sep).join('/')} .${method}(${args[0] ?? ''})`;
+        checked.push(where);
+        if (args.length < 3 || !args[2].includes('fliptContext')) offenders.push(where);
+        index = source.indexOf(`.${method}(`, index + 1);
+      }
+    }
+  }
+
+  it('finds the evaluations to check', () => {
+    // Guards the guard: a walk that silently matches nothing would pass the assertion below.
+    expect(checked.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('leaves none of them context-less', () => {
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/creator-studio/src/lib/server/announcements.ts
+++ b/apps/creator-studio/src/lib/server/announcements.ts
@@ -1,7 +1,7 @@
 import type { SessionUser } from '@civitai/auth';
 import { dbRead } from '$lib/server/db';
 import { callMainApp, type MainAppResult } from '$lib/server/main-app';
-import { getFlipt } from '$lib/server/flipt';
+import { getFlipt, fliptContext } from '$lib/server/flipt';
 import type { AnnouncementAllowance } from '$lib/announcements';
 import { allowanceSchema, type AnnouncementForm } from './announcements-schema';
 
@@ -26,7 +26,7 @@ export async function announcementsEnabled(user: SessionUser): Promise<boolean> 
   const flipt = getFlipt();
   await flipt.ensureInitialized();
 
-  const evaluated = flipt.isEnabledSync(ANNOUNCEMENTS_FLAG, String(user.id));
+  const evaluated = flipt.isEnabledSync(ANNOUNCEMENTS_FLAG, String(user.id), fliptContext(user));
   return evaluated ?? user.isModerator === true;
 }
 

--- a/apps/creator-studio/src/lib/server/flipt.ts
+++ b/apps/creator-studio/src/lib/server/flipt.ts
@@ -1,5 +1,7 @@
 import { safeError } from '@civitai/axiom';
 import { createFliptClient, type FliptFeatureFlags } from '@civitai/flipt';
+import { buildFliptContext } from '@civitai/flipt/context';
+import type { SessionUser } from '@civitai/auth';
 import { getLogger } from './logger';
 
 // App shim around `@civitai/flipt`. Reads FLIPT_URL + FLIPT_FETCHER_SECRET from process.env (the
@@ -20,4 +22,13 @@ export function getFlipt(): FliptFeatureFlags {
     });
   }
   return g.flipt;
+}
+
+/**
+ * 🔴 Every evaluation must pass this. Segment constraints match on context properties, not on the
+ * entity id, so a context-less call matches no segment and returns the flag's `enabled` value —
+ * `false` for every segmented flag we ship. Omitting it 404'd the whole feature for everyone.
+ */
+export function fliptContext(user: SessionUser): Record<string, string> {
+  return buildFliptContext(user);
 }

--- a/apps/creator-studio/src/routes/(app)/+layout.server.ts
+++ b/apps/creator-studio/src/routes/(app)/+layout.server.ts
@@ -1,9 +1,8 @@
-import { redirect } from '@sveltejs/kit';
 import { hubLogoutUrl } from '@civitai/auth';
 import { env } from '$env/dynamic/private';
 import type { LayoutServerLoad } from './$types';
 import { resolveMembership, TEST_MEMBERSHIP_COOKIE } from '$lib/server/membership';
-import { getFlipt } from '$lib/server/flipt';
+import { getFlipt, fliptContext } from '$lib/server/flipt';
 import { TEST_MODELS_SCORE_COOKIE } from '$lib/server/creator-score';
 import { ANNOUNCEMENTS_FLAG, announcementsEnabled } from '$lib/server/announcements';
 import { SALES_FLAG } from '$lib/nav';
@@ -20,16 +19,12 @@ export const load: LayoutServerLoad = async ({ locals, url, cookies }) => {
   // Resolved here rather than per page: the nav has to know, and flag reads are cached in-process.
   const [announcements, sales] = await Promise.all([
     announcementsEnabled(user),
-    getFlipt().isEnabled(SALES_FLAG, String(user.id)),
+    getFlipt().isEnabled(SALES_FLAG, String(user.id), fliptContext(user)),
   ]);
   const enabledFlags = [
     ...(announcements ? [ANNOUNCEMENTS_FLAG] : []),
     ...(sales ? [SALES_FLAG] : []),
   ];
-
-  // Read here rather than per page: the nav has to know, and a link to a page that answers "not
-  // available on your account" is a worse gate than no link at all. Flag reads are cached in-process.
-  const salesEnabled = await getFlipt().isEnabled('scheduled-model-sales', String(user.id));
 
   return {
     enabledFlags,

--- a/apps/creator-studio/src/routes/(app)/models/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/models/+page.server.ts
@@ -46,7 +46,7 @@ import {
   TEST_MODELS_SCORE_COOKIE,
 } from '$lib/server/creator-score';
 import { getCreatorSales, getSalesByVersion } from '$lib/server/monetization/sales';
-import { getFlipt } from '$lib/server/flipt';
+import { getFlipt, fliptContext } from '$lib/server/flipt';
 import { getSaleLimitOverrides } from '$lib/server/monetization/sale-limits';
 import { canSetGenerationOnlyFresh } from '$lib/server/generation-only';
 import {
@@ -138,7 +138,11 @@ export const load: PageServerLoad = async ({ locals, parent, url, cookies }) => 
       ),
       // Per-user entityId so the feature can open to a few creators before everyone. `isEnabled` rather
       // than `getBoolean`: only the former honours FLIPT_LOCAL_OVERRIDES, so this is togglable locally.
-      getFlipt().isEnabled('scheduled-model-sales', String(locals.user.id)),
+      getFlipt().isEnabled(
+        'scheduled-model-sales',
+        String(locals.user.id),
+        fliptContext(locals.user)
+      ),
     ]);
 
   // Sales are read ONLY when the feature is on. Migrations here are applied by hand, so on any

--- a/apps/creator-studio/src/routes/(app)/sales/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/sales/+page.server.ts
@@ -17,7 +17,8 @@ import {
 } from '$lib/server/monetization/sales';
 import { resolveCreatorScore, TEST_CREATOR_SCORE_COOKIE } from '$lib/server/creator-score';
 import { minCreatorScoreForSale } from '@civitai/buzz';
-import { getFlipt } from '$lib/server/flipt';
+import type { SessionUser } from '@civitai/auth';
+import { getFlipt, fliptContext } from '$lib/server/flipt';
 
 // Managing scheduled sales. Starting one lives on the models page, where the selection is — this page is
 // where they are listed and changed, and clicking one opens a side panel (the same interaction the models
@@ -64,8 +65,8 @@ const firstError = (e: z.ZodError) => e.issues[0]?.message ?? 'Invalid input.';
 
 // Gates every action, not just the reads: with the flag off as a kill switch, editing an existing sale has
 // to stop too, or the switch only stops new ones.
-const salesOff = async (userId: number) =>
-  !(await getFlipt().isEnabled('scheduled-model-sales', String(userId)));
+const salesOff = async (user: SessionUser) =>
+  !(await getFlipt().isEnabled('scheduled-model-sales', String(user.id), fliptContext(user)));
 
 // 🔴 THIS is the gate. Hiding the nav link is cosmetics: the model-page banner links straight here for
 // every owner with a live sale, and those owners may not be in the flag's segment — so a bookmark, that
@@ -73,7 +74,11 @@ const salesOff = async (userId: number) =>
 // page. Every action re-checks for the same reason.
 export const load: PageServerLoad = async ({ locals, parent, cookies }) => {
   const { membership } = await parent();
-  const salesEnabled = await getFlipt().isEnabled('scheduled-model-sales', String(locals.user.id));
+  const salesEnabled = await getFlipt().isEnabled(
+    'scheduled-model-sales',
+    String(locals.user.id),
+    fliptContext(locals.user)
+  );
 
   // Read only when the feature is on: migrations here are applied by hand, so an unconditional read
   // throws for every creator on an environment where the tables do not exist yet.
@@ -114,7 +119,7 @@ export const actions: Actions = {
   // What the sale form needs about a selection it can't see: how much of it is early access (a sale
   // can't cover that) and the cheapest price among the rest (a fixed discount must stay under it).
   salePreview: async ({ request, locals, cookies }) => {
-    if (await salesOff(locals.user.id))
+    if (await salesOff(locals.user))
       return fail(403, { error: 'Scheduled sales are not available yet.' });
     const form = await request.formData();
     const parsed = versionIdsSchema.safeParse(form.get('versionIds'));
@@ -131,7 +136,7 @@ export const actions: Actions = {
   },
 
   scheduleSale: async ({ request, locals, cookies }) => {
-    if (await salesOff(locals.user.id))
+    if (await salesOff(locals.user))
       return fail(403, { error: 'Scheduled sales are not available yet.' });
 
     const form = await request.formData();
@@ -182,7 +187,7 @@ export const actions: Actions = {
   },
 
   cancelSale: async ({ request, locals }) => {
-    if (await salesOff(locals.user.id))
+    if (await salesOff(locals.user))
       return fail(403, { error: 'Scheduled sales are not available yet.' });
     const form = await request.formData();
     const parsed = saleIdSchema.safeParse(form.get('saleId'));
@@ -195,7 +200,7 @@ export const actions: Actions = {
   },
 
   shortenSale: async ({ request, locals }) => {
-    if (await salesOff(locals.user.id))
+    if (await salesOff(locals.user))
       return fail(403, { error: 'Scheduled sales are not available yet.' });
     const form = await request.formData();
     const parsed = shortenSaleSchema.safeParse(Object.fromEntries(form));
@@ -212,7 +217,7 @@ export const actions: Actions = {
   },
 
   deepenSale: async ({ request, locals, cookies }) => {
-    if (await salesOff(locals.user.id))
+    if (await salesOff(locals.user))
       return fail(403, { error: 'Scheduled sales are not available yet.' });
     const form = await request.formData();
     const parsed = deepenSaleSchema.safeParse(Object.fromEntries(form));

--- a/packages/civitai-flipt/package.json
+++ b/packages/civitai-flipt/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./context": "./src/context.ts"
+  },
   "types": "./src/index.ts",
   "scripts": {
     "test": "vitest run",

--- a/packages/civitai-flipt/src/__tests__/context.test.ts
+++ b/packages/civitai-flipt/src/__tests__/context.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildFliptContext } from '../context';
+
+describe('buildFliptContext', () => {
+  const original = process.env.FLIPT_DEPLOYMENT_ID;
+  afterEach(() => {
+    if (original === undefined) delete process.env.FLIPT_DEPLOYMENT_ID;
+    else process.env.FLIPT_DEPLOYMENT_ID = original;
+  });
+
+  it('emits the properties the shared segments constrain on', () => {
+    const ctx = buildFliptContext({ id: 583956, isModerator: false, tier: 'gold' });
+    // `testers` is ANY_MATCH over exactly these two — a context missing either can never match it.
+    expect(ctx.userId).toBe('583956');
+    expect(ctx.isModerator).toBe('false');
+    expect(ctx.tier).toBe('gold');
+    expect(ctx.isMember).toBe('true');
+    expect(ctx.isLoggedIn).toBe('true');
+    expect(ctx.isEarlyAdopter).toBe('false');
+  });
+
+  it('defaults a tierless user to free and not a member', () => {
+    const ctx = buildFliptContext({ id: 1 });
+    expect(ctx.tier).toBe('free');
+    expect(ctx.isMember).toBe('false');
+  });
+
+  it('emits isLoggedIn=false and no userId for an anonymous request', () => {
+    const ctx = buildFliptContext();
+    expect(ctx.isLoggedIn).toBe('false');
+    expect(ctx.userId).toBeUndefined();
+  });
+
+  it('merges extra properties the caller owns', () => {
+    const ctx = buildFliptContext({ id: 7 }, { isInCreatorProgram: 'true' });
+    expect(ctx.isInCreatorProgram).toBe('true');
+    expect(ctx.userId).toBe('7');
+  });
+
+  it('carries deploymentId when the env names one', () => {
+    process.env.FLIPT_DEPLOYMENT_ID = 'datapacket';
+    expect(buildFliptContext({ id: 1 }).deploymentId).toBe('datapacket');
+    delete process.env.FLIPT_DEPLOYMENT_ID;
+    expect(buildFliptContext({ id: 1 }).deploymentId).toBeUndefined();
+  });
+});

--- a/packages/civitai-flipt/src/context.ts
+++ b/packages/civitai-flipt/src/context.ts
@@ -1,0 +1,37 @@
+/**
+ * Targeting properties for a Flipt evaluation.
+ *
+ * 🔴 Segment constraints match on THESE properties, never on `entityId` — that is only the
+ * percentage-rollout hash input. An evaluation called without a context therefore matches no
+ * segment and falls through to the flag's `enabled` value, which for every segmented boolean
+ * flag here is `false`. That reads as "the rollout is missing" and is how creator-announcements
+ * and scheduled-model-sales were dark for every Creator Studio user, moderators included.
+ */
+export type FliptTargetUser = {
+  id: number | string;
+  isModerator?: boolean;
+  tier?: string;
+  isEarlyAdopter?: boolean;
+};
+
+export function buildFliptContext(
+  user?: FliptTargetUser | null,
+  extra?: Record<string, string>
+): Record<string, string> {
+  const ctx: Record<string, string> = {};
+  if (user) {
+    ctx.userId = String(user.id);
+    ctx.isModerator = String(!!user.isModerator);
+    ctx.tier = user.tier ?? 'free';
+    ctx.isLoggedIn = 'true';
+    ctx.isMember = String(!!user.tier && user.tier !== 'free');
+    // Always emitted for a logged-in user (never opted in ⇒ 'false') so a segment can match on
+    // the string equally rather than on key presence — same shape as `isModerator`.
+    ctx.isEarlyAdopter = String(!!user.isEarlyAdopter);
+  } else {
+    ctx.isLoggedIn = 'false';
+  }
+  const deploymentId = process.env.FLIPT_DEPLOYMENT_ID;
+  if (deploymentId) ctx.deploymentId = deploymentId;
+  return extra ? { ...ctx, ...extra } : ctx;
+}

--- a/packages/civitai-flipt/src/index.ts
+++ b/packages/civitai-flipt/src/index.ts
@@ -9,3 +9,4 @@ export {
   type FliptTuning,
 } from './env';
 export { TtlCache, fliptCacheKey, type TtlCacheStats } from './cache';
+export { buildFliptContext, type FliptTargetUser } from './context';

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage } from 'http';
+import { buildFliptContext as buildSharedFliptContext } from '@civitai/flipt/context';
 import type * as FliptClient from '~/server/flipt/client';
 import { camelCase } from 'lodash-es';
 import type { NextApiRequest } from 'next';
@@ -715,27 +716,18 @@ if (typeof window === 'undefined') {
 }
 
 export function buildFliptContext(user?: SessionUser): Record<string, string> {
-  const ctx: Record<string, string> = {};
-  if (user) {
-    ctx.userId = String(user.id);
-    ctx.isModerator = String(!!user.isModerator);
-    ctx.tier = user.tier ?? 'free';
-    ctx.isLoggedIn = 'true';
-    ctx.isMember = String(!!user.tier && user.tier !== 'free');
-    // Creator Program membership is recorded as an onboarding-step bit
-    // (set on join in creator-program.service, cleared on leave).
-    ctx.isInCreatorProgram = String(Flags.hasFlag(user.onboarding, OnboardingSteps.CreatorProgram));
-    // Early-adopter opt-in, stored in `User.settings` and projected onto the session by
-    // the auth hub. Always emitted for a logged-in user (never opted in ⇒ 'false'), so a
-    // Flipt segment can match on the string EQUALLY rather than on key presence — same
-    // shape as `isModerator` above. Absent entirely for an anonymous request.
-    ctx.isEarlyAdopter = String(!!user.isEarlyAdopter);
-  } else {
-    ctx.isLoggedIn = 'false';
-  }
-  const deploymentId = process.env.FLIPT_DEPLOYMENT_ID;
-  if (deploymentId) ctx.deploymentId = deploymentId;
-  return ctx;
+  return buildSharedFliptContext(
+    user,
+    user
+      ? {
+          // Creator Program membership is recorded as an onboarding-step bit (set on join in
+          // creator-program.service, cleared on leave) — the bit lives in the app, not the package.
+          isInCreatorProgram: String(
+            Flags.hasFlag(user.onboarding, OnboardingSteps.CreatorProgram)
+          ),
+        }
+      : undefined
+  );
 }
 
 const hasFeature = (


### PR DESCRIPTION
## The bug

Creator Studio evaluated every flag with `isEnabled(flag, String(user.id))` and **no context**. Flipt segments match on **context properties**, never on `entityId` — that is only the percentage-rollout hash input. So the `testers` segment could not match, and each flag fell through to its `enabled` value, which is `false` for every segmented flag we ship.

Verified against live Flipt, `creator-announcements`, entity `583956`:

| call | result |
|---|---|
| no context (what the Studio sent) | `enabled:false`, `DEFAULT_EVALUATION_REASON`, `segmentKeys: []` |
| `{userId, isModerator}` | `enabled:true`, `MATCH_EVALUATION_REASON`, `segmentKeys: ["testers"]` |
| non-tester + context | `enabled:false` |

`/announcements` therefore 404'd for **every** user, moderators included — the `?? user.isModerator` fallback never fires, because the evaluation returns `false`, not `null`. `scheduled-model-sales` was dark on the same bug, at three more call sites.

Two testers hit the 404 in Discord; no feedback landed on the feature because nobody could open it.

## The change

- `buildFliptContext` moves into `@civitai/flipt`, exported as `@civitai/flipt/context` — a subpath, so importing it does not drag the Flipt SDK into the main app's client bundle.
- The main app delegates to it and keeps ownership of `isInCreatorProgram`, whose onboarding bit lives in app code. Its emitted context is unchanged.
- All five Studio evaluations pass `fliptContext(user)`. `salesOff` now takes the user rather than the id.
- Drops a duplicate `scheduled-model-sales` evaluation in the layout load that was computed and never returned, plus an unused import beside it.

## Guard

`flipt-context-guard.test.ts` walks the Studio source, finds every `.isEnabled` / `.isEnabledSync` / `.getBoolean` / `.getVariant` call, and requires a third argument mentioning `fliptContext`. It also asserts the walk found at least four calls, so a walk that silently matches nothing cannot pass.

**Mutation-proven:** stripping the context off `models/+page.server.ts` fails it with the offending file named. Restored and re-verified by reading the file.

## Verification

- `@civitai/flipt` 26 passed
- `apps/creator-studio` 139 passed
- creator-studio `svelte-check` — 0 errors, 0 warnings
- `pnpm run typecheck` — 0 errors
- full unit suite — 20855 passed, 0 failed
- eslint clean on every changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)