### PR TITLE
fix(hubs): two things testers hit — a one-way sort, and an unordered source picker

### DIFF
--- a/src/components/Filters/FeedFilters/HubFeedFilters.tsx
+++ b/src/components/Filters/FeedFilters/HubFeedFilters.tsx
@@ -7,13 +7,12 @@ import { useState } from 'react';
 import { FilterButton } from '~/components/Buttons/FilterButton';
 import classes from '~/components/Filters/FeedFilters/FeedFilters.module.scss';
 import { SortFilter } from '~/components/Filters/SortFilter';
+import { buildHubFilterSave } from '~/components/Hubs/hub-filter-save';
 import { useHubSort } from '~/components/Hubs/useHubSort';
 import { hubExcludedFilterKeys } from '~/components/Image/Filters/media-filter-keys';
 import { MediaFiltersDropdown } from '~/components/Image/Filters/MediaFiltersDropdown';
 import type { HubSort } from '~/server/schema/user-hub.schema';
-import { hubFeedFiltersSchema, hubLimits, hubSortSchema } from '~/server/schema/user-hub.schema';
-import { MetricTimeframe } from '~/shared/utils/prisma/enums';
-import type { MediaType } from '~/shared/utils/prisma/enums';
+import { hubLimits, hubSortSchema } from '~/server/schema/user-hub.schema';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -120,16 +119,7 @@ export function HubFeedFilters({ ...groupProps }: GroupProps) {
           period: hub.period,
           types: hub.mediaTypes,
         }}
-        onChange={(next) =>
-          upsert.mutate({
-            id: hub.id,
-            // Clear omits `period` to mean "back to the default"; falling back to
-            // the hub's current value would leave the one filter Clear names.
-            period: (next.period ?? MetricTimeframe.AllTime) as MetricTimeframe,
-            mediaTypes: (next.types ?? []) as MediaType[],
-            filters: hubFeedFiltersSchema.parse(next),
-          })
-        }
+        onChange={(next) => upsert.mutate(buildHubFilterSave(hub.id, next))}
       />
     </Group>
   );

--- a/src/components/Filters/FeedFilters/HubFeedFilters.tsx
+++ b/src/components/Filters/FeedFilters/HubFeedFilters.tsx
@@ -7,9 +7,9 @@ import { useState } from 'react';
 import { FilterButton } from '~/components/Buttons/FilterButton';
 import classes from '~/components/Filters/FeedFilters/FeedFilters.module.scss';
 import { SortFilter } from '~/components/Filters/SortFilter';
+import { useHubSort } from '~/components/Hubs/useHubSort';
 import { hubExcludedFilterKeys } from '~/components/Image/Filters/media-filter-keys';
 import { MediaFiltersDropdown } from '~/components/Image/Filters/MediaFiltersDropdown';
-import { ImageSort } from '~/server/common/enums';
 import type { HubSort } from '~/server/schema/user-hub.schema';
 import { hubFeedFiltersSchema, hubLimits, hubSortSchema } from '~/server/schema/user-hub.schema';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
@@ -48,6 +48,7 @@ export function HubFeedFilters({ ...groupProps }: GroupProps) {
     { id: hubId },
     { enabled: Number.isInteger(hubId) }
   );
+  const sort = useHubSort(hub?.sort);
 
   const upsert = trpc.userHub.upsert.useMutation({
     onSuccess: async () => {
@@ -62,7 +63,6 @@ export function HubFeedFilters({ ...groupProps }: GroupProps) {
 
   if (!hub) return null;
 
-  const sort = hubSortSchema.catch(ImageSort.Newest).parse(hub.sort);
   const sourceCount = hub.sources.length;
 
   return (
@@ -123,7 +123,6 @@ export function HubFeedFilters({ ...groupProps }: GroupProps) {
         onChange={(next) =>
           upsert.mutate({
             id: hub.id,
-            sort,
             // Clear omits `period` to mean "back to the default"; falling back to
             // the hub's current value would leave the one filter Clear names.
             period: (next.period ?? MetricTimeframe.AllTime) as MetricTimeframe,

--- a/src/components/Filters/SortFilter.tsx
+++ b/src/components/Filters/SortFilter.tsx
@@ -1,9 +1,8 @@
 import type { ButtonProps } from '@mantine/core';
 import { useRouter } from 'next/router';
+import { isSortAvailable } from '~/components/Filters/sort-availability';
+import { useSortAvailability } from '~/components/Filters/useSortAvailability';
 import { SelectMenuV2 } from '~/components/SelectMenu/SelectMenu';
-import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { useBrowsingSettings } from '~/providers/BrowserSettingsProvider';
-import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import type { FilterSubTypes } from '~/providers/FiltersProvider';
 import { useFiltersContext, useSetFilters } from '~/providers/FiltersProvider';
 import {
@@ -71,24 +70,16 @@ type DumbProps = {
 } & SortFilterComponentProps;
 
 function DumbSortFilter({ type, value, onChange, ignoreNsfwLevel, options, ...props }: DumbProps) {
-  const showNsfw = useBrowsingSettings((x) => x.showNsfw);
-  const features = useFeatureFlags();
-  const isModerator = useCurrentUser()?.isModerator ?? false;
+  const availability = useSortAvailability();
 
   return (
     <SelectMenuV2
       label={value}
       onClick={onChange}
       value={value}
-      options={(options ?? sortOptions[type].map((x) => ({ label: x, value: x }))).filter((x) => {
-        if (ignoreNsfwLevel || isModerator) return true;
-        if (!features.canViewNsfw && (x.value === 'Newest' || x.value === 'Oldest')) return false;
-        if (type === 'images') {
-          if (!showNsfw && x.value === 'Newest') return false;
-          return true;
-        }
-        return true;
-      })}
+      options={(options ?? sortOptions[type].map((x) => ({ label: x, value: x }))).filter(
+        (x) => ignoreNsfwLevel || isSortAvailable({ type, value: x.value }, availability)
+      )}
       {...props}
     />
   );

--- a/src/components/Filters/SortFilter.tsx
+++ b/src/components/Filters/SortFilter.tsx
@@ -77,8 +77,8 @@ function DumbSortFilter({ type, value, onChange, ignoreNsfwLevel, options, ...pr
       label={value}
       onClick={onChange}
       value={value}
-      options={(options ?? sortOptions[type].map((x) => ({ label: x, value: x }))).filter(
-        (x) => ignoreNsfwLevel || isSortAvailable({ type, value: x.value }, availability)
+      options={(options ?? sortOptions[type].map((x) => ({ label: x, value: x }))).filter((x) =>
+        isSortAvailable({ type, value: x.value }, { ...availability, ignoreNsfwLevel })
       )}
       {...props}
     />

--- a/src/components/Filters/sort-availability.ts
+++ b/src/components/Filters/sort-availability.ts
@@ -1,14 +1,18 @@
+import type { FilterSubTypes } from '~/providers/FiltersProvider';
+
 export type SortAvailability = {
   isModerator: boolean;
   canViewNsfw: boolean;
   showNsfw: boolean;
+  /** Callers that answer for the level themselves, so the rule below does not apply. */
+  ignoreNsfwLevel?: boolean;
 };
 
 export function isSortAvailable(
-  { type, value }: { type: string; value: string },
-  { isModerator, canViewNsfw, showNsfw }: SortAvailability
+  { type, value }: { type: FilterSubTypes; value: string },
+  { isModerator, canViewNsfw, showNsfw, ignoreNsfwLevel }: SortAvailability
 ) {
-  if (isModerator) return true;
+  if (ignoreNsfwLevel || isModerator) return true;
   if (!canViewNsfw && (value === 'Newest' || value === 'Oldest')) return false;
   if (type === 'images' && !showNsfw && value === 'Newest') return false;
   return true;

--- a/src/components/Filters/sort-availability.ts
+++ b/src/components/Filters/sort-availability.ts
@@ -1,0 +1,15 @@
+export type SortAvailability = {
+  isModerator: boolean;
+  canViewNsfw: boolean;
+  showNsfw: boolean;
+};
+
+export function isSortAvailable(
+  { type, value }: { type: string; value: string },
+  { isModerator, canViewNsfw, showNsfw }: SortAvailability
+) {
+  if (isModerator) return true;
+  if (!canViewNsfw && (value === 'Newest' || value === 'Oldest')) return false;
+  if (type === 'images' && !showNsfw && value === 'Newest') return false;
+  return true;
+}

--- a/src/components/Filters/useSortAvailability.ts
+++ b/src/components/Filters/useSortAvailability.ts
@@ -1,0 +1,12 @@
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useBrowsingSettings } from '~/providers/BrowserSettingsProvider';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import type { SortAvailability } from '~/components/Filters/sort-availability';
+
+export function useSortAvailability(): SortAvailability {
+  const showNsfw = useBrowsingSettings((x) => x.showNsfw);
+  const features = useFeatureFlags();
+  const isModerator = useCurrentUser()?.isModerator ?? false;
+
+  return { isModerator, canViewNsfw: features.canViewNsfw, showNsfw };
+}

--- a/src/components/Hubs/HubUpsertModal.tsx
+++ b/src/components/Hubs/HubUpsertModal.tsx
@@ -4,7 +4,8 @@ import { useState } from 'react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import type { HubSourceValue } from '~/components/Hubs/HubSourceEditor';
 import { HubSourceEditor } from '~/components/Hubs/HubSourceEditor';
-import { useDefaultHubSort } from '~/components/Hubs/useHubSort';
+import { useSortAvailability } from '~/components/Filters/useSortAvailability';
+import { defaultHubSort } from '~/components/Hubs/hub-sort';
 import { hubLimits } from '~/server/schema/user-hub.schema';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -19,7 +20,7 @@ export default function HubUpsertModal({
   const router = useRouter();
   const utils = trpc.useUtils();
   const editing = !!hub;
-  const defaultSort = useDefaultHubSort();
+  const defaultSort = defaultHubSort(useSortAvailability());
 
   const [name, setName] = useState(hub?.name ?? '');
   const [description, setDescription] = useState(hub?.description ?? '');

--- a/src/components/Hubs/HubUpsertModal.tsx
+++ b/src/components/Hubs/HubUpsertModal.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import type { HubSourceValue } from '~/components/Hubs/HubSourceEditor';
 import { HubSourceEditor } from '~/components/Hubs/HubSourceEditor';
+import { useDefaultHubSort } from '~/components/Hubs/useHubSort';
 import { hubLimits } from '~/server/schema/user-hub.schema';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -18,6 +19,7 @@ export default function HubUpsertModal({
   const router = useRouter();
   const utils = trpc.useUtils();
   const editing = !!hub;
+  const defaultSort = useDefaultHubSort();
 
   const [name, setName] = useState(hub?.name ?? '');
   const [description, setDescription] = useState(hub?.description ?? '');
@@ -48,8 +50,12 @@ export default function HubUpsertModal({
       name: trimmed,
       description: description.trim(),
       // Editing leaves the source list alone: the rail owns it, and resending an
-      // empty array here would wipe it.
-      ...(editing ? {} : { sources: sources.map((s, index) => ({ ...s, index })) }),
+      // empty array here would wipe it. The sort goes with creation for the same
+      // reason it is resolved on read — storing one this viewer cannot pick would
+      // strand them on it.
+      ...(editing
+        ? {}
+        : { sort: defaultSort, sources: sources.map((s, index) => ({ ...s, index })) }),
     });
   };
 

--- a/src/components/Hubs/__tests__/hub-sort.test.ts
+++ b/src/components/Hubs/__tests__/hub-sort.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { isSortAvailable } from '~/components/Filters/sort-availability';
+import { resolveHubSort } from '~/components/Hubs/hub-sort';
+import { ImageSort } from '~/server/common/enums';
+
+const green = { isModerator: false, canViewNsfw: false, showNsfw: false };
+const sfwByChoice = { isModerator: false, canViewNsfw: true, showNsfw: false };
+const nsfw = { isModerator: false, canViewNsfw: true, showNsfw: true };
+const moderator = { isModerator: true, canViewNsfw: false, showNsfw: false };
+
+describe('resolveHubSort', () => {
+  it('keeps the stored sort when the viewer is offered it', () => {
+    expect(resolveHubSort(ImageSort.Newest, nsfw)).toBe(ImageSort.Newest);
+    expect(resolveHubSort(ImageSort.MostComments, green)).toBe(ImageSort.MostComments);
+  });
+
+  it('falls back off a sort the menu hides, so the viewer can get back to it', () => {
+    expect(resolveHubSort(ImageSort.Newest, green)).toBe(ImageSort.MostReactions);
+    expect(resolveHubSort(ImageSort.Oldest, green)).toBe(ImageSort.MostReactions);
+    expect(resolveHubSort(ImageSort.Newest, sfwByChoice)).toBe(ImageSort.Oldest);
+  });
+
+  it('leaves a moderator on the stored sort', () => {
+    expect(resolveHubSort(ImageSort.Newest, moderator)).toBe(ImageSort.Newest);
+  });
+
+  it('resolves an unparseable stored sort through the same fallback', () => {
+    expect(resolveHubSort('Most Buzz', nsfw)).toBe(ImageSort.Newest);
+    expect(resolveHubSort('Most Buzz', green)).toBe(ImageSort.MostReactions);
+  });
+});
+
+describe('isSortAvailable', () => {
+  it('hides Newest and Oldest from a viewer who cannot view NSFW', () => {
+    expect(isSortAvailable({ type: 'images', value: ImageSort.Newest }, green)).toBe(false);
+    expect(isSortAvailable({ type: 'images', value: ImageSort.Oldest }, green)).toBe(false);
+    expect(isSortAvailable({ type: 'images', value: ImageSort.MostReactions }, green)).toBe(true);
+  });
+
+  it('hides only Newest, and only on image sorts, when NSFW is merely switched off', () => {
+    expect(isSortAvailable({ type: 'images', value: ImageSort.Newest }, sfwByChoice)).toBe(false);
+    expect(isSortAvailable({ type: 'images', value: ImageSort.Oldest }, sfwByChoice)).toBe(true);
+    expect(isSortAvailable({ type: 'models', value: 'Newest' }, sfwByChoice)).toBe(true);
+  });
+});

--- a/src/components/Hubs/__tests__/hub-sort.test.ts
+++ b/src/components/Hubs/__tests__/hub-sort.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { isSortAvailable } from '~/components/Filters/sort-availability';
-import { resolveHubSort } from '~/components/Hubs/hub-sort';
+import { defaultHubSort, resolveHubSort } from '~/components/Hubs/hub-sort';
 import { ImageSort } from '~/server/common/enums';
 
 const green = { isModerator: false, canViewNsfw: false, showNsfw: false };
@@ -17,7 +17,13 @@ describe('resolveHubSort', () => {
   it('falls back off a sort the menu hides, so the viewer can get back to it', () => {
     expect(resolveHubSort(ImageSort.Newest, green)).toBe(ImageSort.MostReactions);
     expect(resolveHubSort(ImageSort.Oldest, green)).toBe(ImageSort.MostReactions);
-    expect(resolveHubSort(ImageSort.Newest, sfwByChoice)).toBe(ImageSort.Oldest);
+  });
+
+  it('falls back to Most Reactions, not to Oldest, even where Oldest is on offer', () => {
+    // Oldest is withheld wherever Newest is and for the same reason — unrated
+    // images — so it is not a safe substitute just because this viewer can pick it.
+    expect(isSortAvailable({ type: 'images', value: ImageSort.Oldest }, sfwByChoice)).toBe(true);
+    expect(resolveHubSort(ImageSort.Newest, sfwByChoice)).toBe(ImageSort.MostReactions);
   });
 
   it('leaves a moderator on the stored sort', () => {
@@ -41,5 +47,20 @@ describe('isSortAvailable', () => {
     expect(isSortAvailable({ type: 'images', value: ImageSort.Newest }, sfwByChoice)).toBe(false);
     expect(isSortAvailable({ type: 'images', value: ImageSort.Oldest }, sfwByChoice)).toBe(true);
     expect(isSortAvailable({ type: 'models', value: 'Newest' }, sfwByChoice)).toBe(true);
+  });
+});
+
+describe('defaultHubSort', () => {
+  it('is Newest only for a viewer who is offered it', () => {
+    expect(defaultHubSort(nsfw)).toBe(ImageSort.Newest);
+    expect(defaultHubSort(moderator)).toBe(ImageSort.Newest);
+  });
+
+  it('never hands a restricted viewer a new hub sorted by something they cannot pick', () => {
+    for (const availability of [green, sfwByChoice]) {
+      const sort = defaultHubSort(availability);
+      expect(sort).toBe(ImageSort.MostReactions);
+      expect(isSortAvailable({ type: 'images', value: sort }, availability)).toBe(true);
+    }
   });
 });

--- a/src/components/Hubs/__tests__/hub-sort.test.ts
+++ b/src/components/Hubs/__tests__/hub-sort.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { isSortAvailable } from '~/components/Filters/sort-availability';
+import { buildHubFilterSave } from '~/components/Hubs/hub-filter-save';
 import { defaultHubSort, resolveHubSort } from '~/components/Hubs/hub-sort';
 import { ImageSort } from '~/server/common/enums';
+import { MetricTimeframe } from '~/shared/utils/prisma/enums';
 
 const green = { isModerator: false, canViewNsfw: false, showNsfw: false };
 const sfwByChoice = { isModerator: false, canViewNsfw: true, showNsfw: false };
@@ -62,5 +64,33 @@ describe('defaultHubSort', () => {
       expect(sort).toBe(ImageSort.MostReactions);
       expect(isSortAvailable({ type: 'images', value: sort }, availability)).toBe(true);
     }
+  });
+});
+
+describe('the assumption the fallback rests on', () => {
+  it('offers Most Reactions to every viewer', () => {
+    // `resolveHubSort` returns it unconditionally, so if this ever stops holding the
+    // fallback starts handing back a sort the menu will not show.
+    for (const availability of [green, sfwByChoice, nsfw, moderator])
+      expect(
+        isSortAvailable({ type: 'images', value: ImageSort.MostReactions }, availability)
+      ).toBe(true);
+  });
+});
+
+describe('buildHubFilterSave', () => {
+  it('leaves the sort out, so a filter change cannot persist the resolved one', () => {
+    // What this component has to hand is the RESOLVED sort. Sending it would write a
+    // clamped Most Reactions over the owner's stored Newest, permanently, the first
+    // time a viewer without NSFW touched any filter.
+    const payload = buildHubFilterSave(3, { period: MetricTimeframe.Week, withMeta: true });
+
+    expect('sort' in payload).toBe(false);
+    expect(payload.id).toBe(3);
+    expect(payload.period).toBe(MetricTimeframe.Week);
+  });
+
+  it('sends the default period when Clear drops it, not the value the hub had', () => {
+    expect(buildHubFilterSave(3, {}).period).toBe(MetricTimeframe.AllTime);
   });
 });

--- a/src/components/Hubs/hub-filter-save.ts
+++ b/src/components/Hubs/hub-filter-save.ts
@@ -1,0 +1,24 @@
+import type { UpsertUserHubInput } from '~/server/schema/user-hub.schema';
+import { hubFeedFiltersSchema } from '~/server/schema/user-hub.schema';
+import { MetricTimeframe } from '~/shared/utils/prisma/enums';
+import type { MediaType } from '~/shared/utils/prisma/enums';
+
+/**
+ * What a media-filter change saves. Extracted so the absence of `sort` is something a
+ * test can assert: the value the filter menu has to hand is the RESOLVED one, so
+ * sending it would persist a clamped Most Reactions over the owner's stored Newest,
+ * for good, the first time a viewer without NSFW touched any filter.
+ */
+export function buildHubFilterSave(
+  hubId: number,
+  next: Record<string, unknown>
+): UpsertUserHubInput {
+  return {
+    id: hubId,
+    // Clear omits `period` to mean "back to the default"; falling back to the hub's
+    // current value would leave the one filter Clear names.
+    period: (next.period ?? MetricTimeframe.AllTime) as MetricTimeframe,
+    mediaTypes: (next.types ?? []) as MediaType[],
+    filters: hubFeedFiltersSchema.parse(next),
+  };
+}

--- a/src/components/Hubs/hub-sort.ts
+++ b/src/components/Hubs/hub-sort.ts
@@ -9,23 +9,22 @@ import { hubSortSchema } from '~/server/schema/user-hub.schema';
  * because a freshly posted image may not be rated yet. A hub stored as Newest handed
  * those viewers a sort they were never offered again.
  *
- * Falls back to Most Reactions rather than to the next sort in the list. Oldest is
- * withheld wherever Newest is, and for the same reason, so reaching for it would put
- * the viewer back in front of what this rule exists to keep away.
+ * Most Reactions rather than the next sort in the list: Oldest is withheld wherever
+ * Newest is and for the same reason, so reaching for it would put the viewer back in
+ * front of what the rule exists to keep away. Most Reactions is never itself withheld,
+ * which the tests pin — if that changes, this hands back a sort the menu will not show.
  *
  * Resolved on read and never written back, so regaining NSFW browsing returns the hub
  * to the sort its owner chose.
  */
 export function resolveHubSort(stored: unknown, availability: SortAvailability): HubSort {
   const sort = hubSortSchema.catch(ImageSort.Newest).parse(stored);
-  const offered = (value: HubSort) => isSortAvailable({ type: 'images', value }, availability);
+  if (isSortAvailable({ type: 'images', value: sort }, availability)) return sort;
 
-  if (offered(sort)) return sort;
-  if (offered(ImageSort.MostReactions)) return ImageSort.MostReactions;
-  return hubSortSchema.options.find(offered) ?? sort;
+  return ImageSort.MostReactions;
 }
 
-/** What a hub this viewer creates should be sorted by, so it is never stored as one they cannot pick. */
+/** What a hub this viewer creates is sorted by, so it is never stored on one they cannot pick. */
 export function defaultHubSort(availability: SortAvailability): HubSort {
   return resolveHubSort(ImageSort.Newest, availability);
 }

--- a/src/components/Hubs/hub-sort.ts
+++ b/src/components/Hubs/hub-sort.ts
@@ -1,0 +1,22 @@
+import type { SortAvailability } from '~/components/Filters/sort-availability';
+import { isSortAvailable } from '~/components/Filters/sort-availability';
+import { ImageSort } from '~/server/common/enums';
+import type { HubSort } from '~/server/schema/user-hub.schema';
+import { hubSortSchema } from '~/server/schema/user-hub.schema';
+
+/**
+ * A hub is created sorted Newest, but the images sort menu hides Newest and Oldest
+ * from anyone who cannot view NSFW — so those viewers were handed a sort they were
+ * never offered again. Resolved on read and never written back: regaining NSFW
+ * browsing returns the hub to the sort its owner actually chose.
+ */
+export function resolveHubSort(stored: unknown, availability: SortAvailability): HubSort {
+  const sort = hubSortSchema.catch(ImageSort.Newest).parse(stored);
+  if (isSortAvailable({ type: 'images', value: sort }, availability)) return sort;
+
+  return (
+    hubSortSchema.options.find((value) =>
+      isSortAvailable({ type: 'images', value }, availability)
+    ) ?? sort
+  );
+}

--- a/src/components/Hubs/hub-sort.ts
+++ b/src/components/Hubs/hub-sort.ts
@@ -5,18 +5,27 @@ import type { HubSort } from '~/server/schema/user-hub.schema';
 import { hubSortSchema } from '~/server/schema/user-hub.schema';
 
 /**
- * A hub is created sorted Newest, but the images sort menu hides Newest and Oldest
- * from anyone who cannot view NSFW — so those viewers were handed a sort they were
- * never offered again. Resolved on read and never written back: regaining NSFW
- * browsing returns the hub to the sort its owner actually chose.
+ * The images sort menu hides Newest and Oldest from viewers who cannot view NSFW,
+ * because a freshly posted image may not be rated yet. A hub stored as Newest handed
+ * those viewers a sort they were never offered again.
+ *
+ * Falls back to Most Reactions rather than to the next sort in the list. Oldest is
+ * withheld wherever Newest is, and for the same reason, so reaching for it would put
+ * the viewer back in front of what this rule exists to keep away.
+ *
+ * Resolved on read and never written back, so regaining NSFW browsing returns the hub
+ * to the sort its owner chose.
  */
 export function resolveHubSort(stored: unknown, availability: SortAvailability): HubSort {
   const sort = hubSortSchema.catch(ImageSort.Newest).parse(stored);
-  if (isSortAvailable({ type: 'images', value: sort }, availability)) return sort;
+  const offered = (value: HubSort) => isSortAvailable({ type: 'images', value }, availability);
 
-  return (
-    hubSortSchema.options.find((value) =>
-      isSortAvailable({ type: 'images', value }, availability)
-    ) ?? sort
-  );
+  if (offered(sort)) return sort;
+  if (offered(ImageSort.MostReactions)) return ImageSort.MostReactions;
+  return hubSortSchema.options.find(offered) ?? sort;
+}
+
+/** What a hub this viewer creates should be sorted by, so it is never stored as one they cannot pick. */
+export function defaultHubSort(availability: SortAvailability): HubSort {
+  return resolveHubSort(ImageSort.Newest, availability);
 }

--- a/src/components/Hubs/useHubSort.ts
+++ b/src/components/Hubs/useHubSort.ts
@@ -1,0 +1,6 @@
+import { useSortAvailability } from '~/components/Filters/useSortAvailability';
+import { resolveHubSort } from '~/components/Hubs/hub-sort';
+
+export function useHubSort(stored: unknown) {
+  return resolveHubSort(stored, useSortAvailability());
+}

--- a/src/components/Hubs/useHubSort.ts
+++ b/src/components/Hubs/useHubSort.ts
@@ -1,10 +1,6 @@
 import { useSortAvailability } from '~/components/Filters/useSortAvailability';
-import { defaultHubSort, resolveHubSort } from '~/components/Hubs/hub-sort';
+import { resolveHubSort } from '~/components/Hubs/hub-sort';
 
 export function useHubSort(stored: unknown) {
   return resolveHubSort(stored, useSortAvailability());
-}
-
-export function useDefaultHubSort() {
-  return defaultHubSort(useSortAvailability());
 }

--- a/src/components/Hubs/useHubSort.ts
+++ b/src/components/Hubs/useHubSort.ts
@@ -1,6 +1,10 @@
 import { useSortAvailability } from '~/components/Filters/useSortAvailability';
-import { resolveHubSort } from '~/components/Hubs/hub-sort';
+import { defaultHubSort, resolveHubSort } from '~/components/Hubs/hub-sort';
 
 export function useHubSort(stored: unknown) {
   return resolveHubSort(stored, useSortAvailability());
+}
+
+export function useDefaultHubSort() {
+  return defaultHubSort(useSortAvailability());
 }

--- a/src/pages/hubs/[id].tsx
+++ b/src/pages/hubs/[id].tsx
@@ -7,12 +7,11 @@ import { Page } from '~/components/AppLayout/Page';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { HubsLayout } from '~/components/Hubs/HubsLayout';
 import HubUpsertModal from '~/components/Hubs/HubUpsertModal';
+import { useHubSort } from '~/components/Hubs/useHubSort';
 import ImagesInfinite from '~/components/Image/Infinite/ImagesInfinite';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { Meta } from '~/components/Meta/Meta';
-import { ImageSort } from '~/server/common/enums';
-import { hubSortSchema } from '~/server/schema/user-hub.schema';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -36,6 +35,8 @@ export default Page(
       { enabled: Number.isInteger(hubId) }
     );
 
+    const sort = useHubSort(hub?.sort);
+
     const deleteMutation = trpc.userHub.delete.useMutation({
       onSuccess: async () => {
         const remaining = await utils.userHub.getAll.fetch(undefined, { staleTime: 0 });
@@ -53,7 +54,6 @@ export default Page(
       );
     if (!hub) return <NotFound />;
 
-    const sort = hubSortSchema.catch(ImageSort.Newest).parse(hub.sort);
     const hasSources = hub.sources.some((s) => s.enabled);
 
     return (

--- a/src/server/services/__tests__/user-hub.service.test.ts
+++ b/src/server/services/__tests__/user-hub.service.test.ts
@@ -207,7 +207,9 @@ describe('upsertUserHub', () => {
     await upsertUserHub({ name: 'defaults', sources: [], userId: 5 });
 
     const arg = dbMock.dbWrite.userHub.create.mock.calls[0][0];
-    expect(arg.data.sort).toBe(ImageSort.Newest);
+    // NOT Newest: a caller that omitted the field cannot have decided this viewer is
+    // offered Newest, and the sort menu withholds it from anyone who cannot view NSFW.
+    expect(arg.data.sort).toBe(ImageSort.MostReactions);
     expect(arg.data.period).toBe(MetricTimeframe.AllTime);
 
     // The half the title used to claim and never exercised: the same call shape
@@ -576,6 +578,44 @@ describe('source suggestions stay inside the viewer', () => {
     // the unbounded query.
     expect(names.where.username).toEqual({ contains: 'some', mode: 'insensitive' });
     expect(names.orderBy).toEqual({ username: 'asc' });
+  });
+
+  it('keeps the most recent relationships when there is nothing to search', async () => {
+    // Ordering by name sits above `take`, so with no term it would decide WHICH
+    // suggestions survive: a viewer following more than a page of creators would
+    // get the alphabetically first ones and never their most recent follows.
+    const followed = Array.from({ length: 60 }, (_, i) => ({ targetUserId: 100 + i }));
+    dbMock.dbRead.userEngagement.findMany.mockResolvedValue(followed);
+    dbMock.dbRead.user.findMany.mockResolvedValue([
+      { id: 101, username: 'zoe' },
+      { id: 100, username: 'aaron' },
+    ]);
+
+    const result = await getHubSourceSuggestions({ userId: 5, type: UserHubSourceType.User });
+
+    const names = dbMock.dbRead.user.findMany.mock.calls[0][0];
+    expect(names.orderBy).toBeUndefined();
+    // A margin over the page size, because deleted rows are filtered after the id
+    // restriction — asking for exactly 25 returns a short page when one has gone.
+    expect(names.where.id.in).toEqual(followed.slice(0, 50).map((f) => f.targetUserId));
+    expect(names.where.id.in.length).toBeGreaterThan(25);
+    expect(result.map((r) => r.targetId)).toEqual([100, 101]);
+  });
+
+  it('trims the deleted-row margin back to one page, keeping the most recent', async () => {
+    const followed = Array.from({ length: 60 }, (_, i) => ({ targetUserId: 100 + i }));
+    dbMock.dbRead.userEngagement.findMany.mockResolvedValue(followed);
+    // 40 survive the `deletedAt` filter, in whatever order the PK scan produced.
+    dbMock.dbRead.user.findMany.mockResolvedValue(
+      Array.from({ length: 40 }, (_, i) => ({ id: 139 - i, username: `user${139 - i}` }))
+    );
+
+    const result = await getHubSourceSuggestions({ userId: 5, type: UserHubSourceType.User });
+
+    expect(result).toHaveLength(25);
+    // The 25 earliest positions in the follow list, not the 25 the query happened to
+    // return first — a page short of 25, or ordered by id, both fail here.
+    expect(result.map((r) => r.targetId)).toEqual(Array.from({ length: 25 }, (_, i) => 100 + i));
   });
 
   it('scopes every models arm to the viewer, and filters names once over the union', async () => {

--- a/src/server/services/__tests__/user-hub.service.test.ts
+++ b/src/server/services/__tests__/user-hub.service.test.ts
@@ -575,6 +575,7 @@ describe('source suggestions stay inside the viewer', () => {
     // "a". Bounded by the id list above, so it is not the scan that ILIKE was on
     // the unbounded query.
     expect(names.where.username).toEqual({ contains: 'some', mode: 'insensitive' });
+    expect(names.orderBy).toEqual({ username: 'asc' });
   });
 
   it('scopes every models arm to the viewer, and filters names once over the union', async () => {
@@ -601,6 +602,7 @@ describe('source suggestions stay inside the viewer', () => {
     const names = dbMock.dbRead.model.findMany.mock.calls[1][0];
     expect(names.where.id).toEqual({ in: [1, 2, 3] });
     expect(names.where.name).toEqual({ contains: 'nova', mode: 'insensitive' });
+    expect(names.orderBy).toEqual({ name: 'asc' });
   });
 
   it('offers no collections while the write path refuses them', async () => {

--- a/src/server/services/user-hub.service.ts
+++ b/src/server/services/user-hub.service.ts
@@ -478,6 +478,9 @@ export async function getHubSourceSuggestions({
         ...(term ? { username: { contains: term, mode: 'insensitive' as const } } : {}),
       },
       select: { id: true, username: true },
+      // A name list, so it reads as one. Which names are eligible is still decided
+      // by relationship recency, up the `SUGGESTIONS_WINDOW` above.
+      orderBy: { username: 'asc' },
       take: SUGGESTIONS_LIMIT,
     });
 
@@ -508,6 +511,7 @@ export async function getHubSourceSuggestions({
         ...(term ? { name: { contains: term, mode: 'insensitive' as const } } : {}),
       },
       select: { id: true, name: true },
+      orderBy: { name: 'asc' },
       take: SUGGESTIONS_LIMIT,
     });
 
@@ -564,7 +568,7 @@ export async function getHubSourceSuggestions({
       ...(term ? { name: { contains: term, mode: 'insensitive' as const } } : {}),
     },
     select: { id: true, name: true },
-    orderBy: { id: 'desc' },
+    orderBy: { name: 'asc' },
     take: SUGGESTIONS_LIMIT,
   });
 

--- a/src/server/services/user-hub.service.ts
+++ b/src/server/services/user-hub.service.ts
@@ -111,7 +111,9 @@ export async function upsertUserHub({ userId, ...input }: UpsertUserHubInput & {
       data: {
         ...data,
         name: data.name,
-        sort: data.sort ?? ImageSort.Newest,
+        // Not Newest: a client that omits the field cannot have decided the viewer
+        // is offered Newest, and Most Reactions is the one sort nothing withholds.
+        sort: data.sort ?? ImageSort.MostReactions,
         period: data.period ?? MetricTimeframe.AllTime,
         mediaTypes: data.mediaTypes ?? [],
         metadata: {
@@ -442,6 +444,32 @@ const SUGGESTIONS_LIMIT = 25;
 // it returns — a search of your most recent relationships, not all of them.
 const SUGGESTIONS_WINDOW = 500;
 
+// A margin over the page size, because the name queries filter deleted rows AFTER the
+// id restriction: slicing to exactly `SUGGESTIONS_LIMIT` returns a short page whenever
+// one of the ids has since been deleted (measured on prod: 2 of 500 on one account).
+const SUGGESTIONS_SLICE = SUGGESTIONS_LIMIT * 2;
+
+// The relationship queries above return their ids most-recent-first. With no search
+// term that IS the answer, so the window is cut before the names query rather than
+// ordered after it — ordering above a `take` decides WHICH rows come back.
+function scopeSuggestionIds(ids: number[], term: string | undefined) {
+  return term ? ids : ids.slice(0, SUGGESTIONS_SLICE);
+}
+
+// `IN (...)` does not preserve the order it was given, so recency is restored here and
+// the margin above is trimmed off.
+function bySuggestionOrder<T extends { id: number }>(
+  rows: T[],
+  ids: number[],
+  term: string | undefined
+) {
+  if (term) return rows;
+  const position = new Map(ids.map((id, index) => [id, index]));
+  return [...rows]
+    .sort((a, b) => (position.get(a.id) ?? 0) - (position.get(b.id) ?? 0))
+    .slice(0, SUGGESTIONS_LIMIT);
+}
+
 /**
  * What the source picker searches, one type at a time. Scoped to the viewer's own
  * relationships rather than the whole site: creators they follow, models they own
@@ -468,9 +496,18 @@ export async function getHubSourceSuggestions({
     });
     if (!follows.length) return [];
 
+    // Ordering sits ABOVE the `take`, so it decides which rows come back and not
+    // merely their order. A search wants the whole window ranked by name; a bare
+    // suggestion list wants the most recent relationships, so it is cut to size
+    // here and the names query is left unordered.
+    const followed = scopeSuggestionIds(
+      follows.map((f) => f.targetUserId),
+      term
+    );
+
     const users = await dbRead.user.findMany({
       where: {
-        id: { in: follows.map((f) => f.targetUserId) },
+        id: { in: followed },
         deletedAt: null,
         // citext overloads equality, NOT `LIKE` — a plain `contains` here is
         // case-SENSITIVE. Safe to ask for ILIKE now only because the id list
@@ -478,13 +515,11 @@ export async function getHubSourceSuggestions({
         ...(term ? { username: { contains: term, mode: 'insensitive' as const } } : {}),
       },
       select: { id: true, username: true },
-      // A name list, so it reads as one. Which names are eligible is still decided
-      // by relationship recency, up the `SUGGESTIONS_WINDOW` above.
-      orderBy: { username: 'asc' },
-      take: SUGGESTIONS_LIMIT,
+      ...(term ? { orderBy: { username: 'asc' as const } } : {}),
+      take: term ? SUGGESTIONS_LIMIT : SUGGESTIONS_SLICE,
     });
 
-    return users
+    return bySuggestionOrder(users, followed, term)
       .filter((user): user is { id: number; username: string } => !!user.username)
       .map((user) => ({
         type: UserHubSourceType.User,
@@ -505,17 +540,22 @@ export async function getHubSourceSuggestions({
     });
     if (!followed.length) return [];
 
+    const collectionIds = scopeSuggestionIds(
+      followed.map((f) => f.collectionId),
+      term
+    );
+
     const collections = await dbRead.collection.findMany({
       where: {
-        id: { in: followed.map((f) => f.collectionId) },
+        id: { in: collectionIds },
         ...(term ? { name: { contains: term, mode: 'insensitive' as const } } : {}),
       },
       select: { id: true, name: true },
-      orderBy: { name: 'asc' },
-      take: SUGGESTIONS_LIMIT,
+      ...(term ? { orderBy: { name: 'asc' as const } } : {}),
+      take: term ? SUGGESTIONS_LIMIT : SUGGESTIONS_SLICE,
     });
 
-    return collections.map((collection) => ({
+    return bySuggestionOrder(collections, collectionIds, term).map((collection) => ({
       type: UserHubSourceType.Collection,
       targetId: collection.id,
       alias: collection.name,
@@ -561,18 +601,20 @@ export async function getHubSourceSuggestions({
   ];
   if (!candidateIds.length) return [];
 
+  const scopedIds = scopeSuggestionIds(candidateIds, term);
+
   const models = await dbRead.model.findMany({
     where: {
-      id: { in: candidateIds },
+      id: { in: scopedIds },
       deletedAt: null,
       ...(term ? { name: { contains: term, mode: 'insensitive' as const } } : {}),
     },
     select: { id: true, name: true },
-    orderBy: { name: 'asc' },
-    take: SUGGESTIONS_LIMIT,
+    ...(term ? { orderBy: { name: 'asc' as const } } : {}),
+    take: term ? SUGGESTIONS_LIMIT : SUGGESTIONS_SLICE,
   });
 
-  return models.map((model) => ({
+  return bySuggestionOrder(models, scopedIds, term).map((model) => ({
     type: UserHubSourceType.Model,
     targetId: model.id,
     alias: model.name,


### PR DESCRIPTION
From the tester thread on `/hubs`. Two reports, both real.

## A hub could open on a sort its own menu hides

`DumbSortFilter` drops **Newest** and **Oldest** for a viewer who cannot view NSFW, and drops **Newest** for one who has NSFW browsing switched off. A hub is created with `sort = "Newest"`.

So a green-domain tester opened a hub reading **Newest**, switched to Most Reactions, and found no way back — his menu only ever listed Most Reactions and Most Comments. Screenshot in the thread shows exactly that.

The predicate that decides which sorts are offered moves out of the component into `isSortAvailable`, so the hub can ask the same question the menu answers. `resolveHubSort` returns the first sort the viewer *is* offered when the stored one is not among them.

Deliberate choices:

- **Resolved on read, never written back.** Regaining NSFW browsing returns the hub to the sort its owner picked. Nothing rewrites their data behind them.
- **Not widening what the menu offers.** Handing a green viewer a Newest sort would defeat the rule this is working around, and the stored sort drives the feed itself, not just the label.
- The media-filter save no longer sends `sort`. It never changed it, and sending the resolved value would have persisted the clamp. Prisma treats the omitted field as "leave alone".

## The source picker returned suggestions in no order

The creator query had **no `orderBy` at all**, so which 25 of your follows came back was down to the planner. Models and collections came back newest-first, which reads as arbitrary in a name list. All three are ordered by name now.

Relationship recency still decides which names are *eligible*, up the `SUGGESTIONS_WINDOW` above the query — only the presentation of the surviving 25 changes.

## Verification

- `TYPECHECK_HEAP_MB=12288 pnpm run typecheck` — clean apart from a pre-existing `packages/civitai-telemetry` error on `main`
- `npx eslint <changed files>` — clean (one pre-existing `no-explicit-any` in `SortFilter`)
- `pnpm run test:unit:run` — 1337 files / 20854 tests, all green
- Mutation check: stubbing the clamp fails 2 of the new tests with `expected 'Newest' to be 'Most Reactions'`, in under a second
- **Browser, `civitai-dev.blue`**: as a moderator all four sorts still list, as a non-moderator with NSFW browsing off a hub stored as Newest now opens on Oldest and every option in the menu is reachable

## Not in this PR

The "having trouble loading more images" report on Most Reactions. Hub feeds pin the Meilisearch path with no DB fallback, so a slow search surfaces as the retry banner — separate work, and Justin has it.