### PR TITLE
feat(hubs): add a model or a creator to a hub from its own page

### DIFF
--- a/src/components/Dialog/triggers/add-to-hub.ts
+++ b/src/components/Dialog/triggers/add-to-hub.ts
@@ -1,0 +1,6 @@
+import dynamic from 'next/dynamic';
+import { createDialogTrigger } from '~/components/Dialog/dialogStore';
+
+const AddToHubModal = dynamic(() => import('~/components/Hubs/AddToHubModal'), { ssr: false });
+
+export const openAddToHubModal = createDialogTrigger(AddToHubModal);

--- a/src/components/Hubs/AddToHubModal.tsx
+++ b/src/components/Hubs/AddToHubModal.tsx
@@ -76,8 +76,11 @@ export default function AddToHubModal({ source }: { source: HubSourceTarget }) {
           ) : (
             <Stack gap="xs">
               {hubs.map((hub) => {
+                // Membership here means "this hub shows me that source", so a row the
+                // owner switched off in the rail reads as unticked: the hub is not
+                // showing it, and ticking is what turns it back on.
                 const checked = hub.sources.some(
-                  (s) => s.type === source.type && s.targetId === source.targetId
+                  (s) => s.type === source.type && s.targetId === source.targetId && s.enabled
                 );
                 const full = hub.sources.length >= hubLimits.sourcesPerHub;
                 return (

--- a/src/components/Hubs/AddToHubModal.tsx
+++ b/src/components/Hubs/AddToHubModal.tsx
@@ -1,0 +1,163 @@
+import {
+  Button,
+  Center,
+  Checkbox,
+  Divider,
+  Group,
+  Loader,
+  Modal,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
+import { useState } from 'react';
+import { useDialogContext } from '~/components/Dialog/DialogProvider';
+import { hubLimits } from '~/server/schema/user-hub.schema';
+import type { UserHubSourceType } from '~/shared/utils/prisma/enums';
+import { showErrorNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+type HubSourceTarget = {
+  type: UserHubSourceType;
+  targetId: number;
+  alias?: string | null;
+};
+
+export default function AddToHubModal({ source }: { source: HubSourceTarget }) {
+  const dialog = useDialogContext();
+  const utils = trpc.useUtils();
+  const [name, setName] = useState('');
+
+  const { data: hubs, isLoading } = trpc.userHub.getAll.useQuery();
+
+  const invalidate = async (hubId: number) => {
+    await Promise.all([
+      utils.userHub.getAll.invalidate(),
+      utils.userHub.getById.invalidate({ id: hubId }),
+    ]);
+    await utils.image.getInfinite.invalidate({ hubId });
+  };
+
+  const onError = (title: string) => (error: { message: string }) =>
+    showErrorNotification({ title, error: new Error(error.message) });
+
+  const addSource = trpc.userHub.addSource.useMutation({
+    onSuccess: (_, variables) => invalidate(variables.hubId),
+    onError: onError('Could not add to hub'),
+  });
+  const removeSource = trpc.userHub.removeSource.useMutation({
+    onSuccess: (_, variables) => invalidate(variables.hubId),
+    onError: onError('Could not remove from hub'),
+  });
+  const createHub = trpc.userHub.upsert.useMutation({
+    onSuccess: async (hub) => {
+      setName('');
+      await invalidate(hub.id);
+    },
+    onError: onError('Could not create hub'),
+  });
+
+  const pending = addSource.isPending || removeSource.isPending || createHub.isPending;
+  const trimmed = name.trim();
+  const atHubLimit = (hubs?.length ?? 0) >= hubLimits.hubsPerUser;
+
+  return (
+    <Modal {...dialog} title={<Text fw={600}>Add to hub</Text>} size="md">
+      {isLoading ? (
+        <Center py="xl">
+          <Loader />
+        </Center>
+      ) : (
+        <Stack gap="md">
+          {!hubs?.length ? (
+            <Text c="dimmed" size="sm">
+              You do not have any hubs yet. Name one below and this goes in it.
+            </Text>
+          ) : (
+            <Stack gap="xs">
+              {hubs.map((hub) => {
+                const checked = hub.sources.some(
+                  (s) => s.type === source.type && s.targetId === source.targetId
+                );
+                const full = hub.sources.length >= hubLimits.sourcesPerHub;
+                return (
+                  <Checkbox
+                    key={hub.id}
+                    checked={checked}
+                    disabled={pending || (full && !checked)}
+                    label={
+                      <Group gap={6} wrap="nowrap">
+                        <Text size="sm">{hub.name}</Text>
+                        <Text size="xs" c="dimmed">
+                          {full && !checked
+                            ? 'Full'
+                            : `${hub.sources.length}/${hubLimits.sourcesPerHub}`}
+                        </Text>
+                      </Group>
+                    }
+                    onChange={() =>
+                      checked
+                        ? removeSource.mutate({
+                            hubId: hub.id,
+                            type: source.type,
+                            targetId: source.targetId,
+                          })
+                        : addSource.mutate({
+                            hubId: hub.id,
+                            type: source.type,
+                            targetId: source.targetId,
+                            alias: source.alias,
+                          })
+                    }
+                  />
+                );
+              })}
+            </Stack>
+          )}
+
+          <Divider label="New hub" labelPosition="left" />
+          <Group gap="xs" wrap="nowrap">
+            <TextInput
+              className="flex-1"
+              placeholder="Name a new hub"
+              value={name}
+              maxLength={hubLimits.nameLength}
+              disabled={pending || atHubLimit}
+              onChange={(event) => setName(event.currentTarget.value)}
+            />
+            <Button
+              loading={createHub.isPending}
+              disabled={!trimmed || atHubLimit}
+              onClick={() =>
+                createHub.mutate({
+                  name: trimmed,
+                  sources: [
+                    {
+                      type: source.type,
+                      targetId: source.targetId,
+                      alias: source.alias,
+                      index: 0,
+                    },
+                  ],
+                })
+              }
+            >
+              Create
+            </Button>
+          </Group>
+          {atHubLimit && (
+            <Text size="xs" c="dimmed">
+              You already have {hubLimits.hubsPerUser} hubs, which is the limit.
+            </Text>
+          )}
+
+          <Group justify="flex-end">
+            <Button variant="default" onClick={dialog.onClose}>
+              Done
+            </Button>
+          </Group>
+        </Stack>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/MenuItems/AddToHubMenuItem.tsx
+++ b/src/components/MenuItems/AddToHubMenuItem.tsx
@@ -5,6 +5,9 @@ import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 
 export function AddToHubMenuItem({ onClick }: { onClick: VoidFunction }) {
   const features = useFeatureFlags();
+  // Gated here rather than at each call site: the flag is tester-only, and a call site
+  // added without the check would ship the action to everyone.
+  if (!features.userHubs) return null;
 
   return (
     <LoginRedirect reason="add-to-hub">

--- a/src/components/MenuItems/AddToHubMenuItem.tsx
+++ b/src/components/MenuItems/AddToHubMenuItem.tsx
@@ -1,0 +1,24 @@
+import { Menu } from '@mantine/core';
+import { IconLayoutGrid } from '@tabler/icons-react';
+import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+
+export function AddToHubMenuItem({ onClick }: { onClick: VoidFunction }) {
+  const features = useFeatureFlags();
+
+  return (
+    <LoginRedirect reason="add-to-hub">
+      <Menu.Item
+        leftSection={<IconLayoutGrid size={14} stroke={1.5} />}
+        onClick={(e: React.MouseEvent) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onClick();
+        }}
+        className={!features.canWrite ? 'pointer-events-none' : undefined}
+      >
+        Add to hub
+      </Menu.Item>
+    </LoginRedirect>
+  );
+}

--- a/src/components/Profile/UserContextMenu.tsx
+++ b/src/components/Profile/UserContextMenu.tsx
@@ -375,21 +375,19 @@ export const UserContextMenu = ({ username }: { username: string }) => {
               Gift a membership
             </Menu.Item>
           )}
-          {features.userHubs && (
-            <AddToHubMenuItem
-              onClick={() =>
-                openAddToHubModal({
-                  props: {
-                    source: {
-                      type: UserHubSourceType.User,
-                      targetId: user.id,
-                      alias: user.username,
-                    },
+          <AddToHubMenuItem
+            onClick={() =>
+              openAddToHubModal({
+                props: {
+                  source: {
+                    type: UserHubSourceType.User,
+                    targetId: user.id,
+                    alias: user.username,
                   },
-                })
-              }
-            />
-          )}
+                },
+              })
+            }
+          />
           {!isSameUser && <BlockUserButton userId={user.id} as="menu-item" />}
           {isSameUser && (
             <Menu.Item component={Link} href={`/user/${username}/manage-categories`}>

--- a/src/components/Profile/UserContextMenu.tsx
+++ b/src/components/Profile/UserContextMenu.tsx
@@ -20,6 +20,7 @@ import {
 } from '@tabler/icons-react';
 import React from 'react';
 import { useAccountContext } from '~/components/CivitaiWrapped/AccountProvider';
+import { openAddToHubModal } from '~/components/Dialog/triggers/add-to-hub';
 import { openReportModal } from '~/components/Dialog/triggers/report';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { BlockUserButton } from '~/components/HideUserButton/BlockUserButton';
@@ -37,7 +38,9 @@ import { showErrorNotification } from '~/utils/notifications';
 import { postgresSlugify } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { AddToHubMenuItem } from '~/components/MenuItems/AddToHubMenuItem';
 import { ModeratorLookupMenuItem } from '~/components/Moderation/ModeratorLookupMenuItem';
+import { UserHubSourceType } from '~/shared/utils/prisma/enums';
 
 export const UserContextMenu = ({ username }: { username: string }) => {
   const queryUtils = trpc.useUtils();
@@ -371,6 +374,21 @@ export const UserContextMenu = ({ username }: { username: string }) => {
             >
               Gift a membership
             </Menu.Item>
+          )}
+          {features.userHubs && (
+            <AddToHubMenuItem
+              onClick={() =>
+                openAddToHubModal({
+                  props: {
+                    source: {
+                      type: UserHubSourceType.User,
+                      targetId: user.id,
+                      alias: user.username,
+                    },
+                  },
+                })
+              }
+            />
           )}
           {!isSameUser && <BlockUserButton userId={user.id} as="menu-item" />}
           {isSameUser && (

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -60,6 +60,7 @@ import {
 import { ButtonTooltip } from '~/components/CivitaiWrapped/ButtonTooltip';
 import { Collection } from '~/components/Collection/Collection';
 import { openAddToCollectionModal } from '~/components/Dialog/triggers/add-to-collection';
+import { openAddToHubModal } from '~/components/Dialog/triggers/add-to-hub';
 import { openBlockModelTagsModal } from '~/components/Dialog/triggers/block-model-tags';
 import { openReportModal } from '~/components/Dialog/triggers/report';
 import { openUnpublishModal } from '~/components/Dialog/triggers/unpublish';
@@ -88,6 +89,7 @@ import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
 // import { ImageFiltersDropdown } from '~/components/Image/Infinite/ImageFiltersDropdown';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { AddToCollectionMenuItem } from '~/components/MenuItems/AddToCollectionMenuItem';
+import { AddToHubMenuItem } from '~/components/MenuItems/AddToHubMenuItem';
 import { ToggleSearchableMenuItem } from '~/components/MenuItems/ToggleSearchableMenuItem';
 import { Gated } from '~/components/Gated/Gated';
 import { ReorderVersionsModal } from '~/components/Modals/ReorderVersionsModal';
@@ -134,7 +136,13 @@ import {
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 import { ModelModifier } from '~/shared/utils/prisma/enums';
-import { Availability, CollectionType, ModelStatus, ModelType } from '~/shared/utils/prisma/enums';
+import {
+  Availability,
+  CollectionType,
+  ModelStatus,
+  ModelType,
+  UserHubSourceType,
+} from '~/shared/utils/prisma/enums';
 import { formatDate, isFutureDate } from '~/utils/date-helpers';
 import {
   showErrorNotification,
@@ -1106,6 +1114,21 @@ export default function ModelDetailsV2({
                                 props: {
                                   modelId: model.id,
                                   type: CollectionType.Model,
+                                },
+                              })
+                            }
+                          />
+                        )}
+                        {features.userHubs && (
+                          <AddToHubMenuItem
+                            onClick={() =>
+                              openAddToHubModal({
+                                props: {
+                                  source: {
+                                    type: UserHubSourceType.Model,
+                                    targetId: model.id,
+                                    alias: model.name,
+                                  },
                                 },
                               })
                             }

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -1119,21 +1119,19 @@ export default function ModelDetailsV2({
                             }
                           />
                         )}
-                        {features.userHubs && (
-                          <AddToHubMenuItem
-                            onClick={() =>
-                              openAddToHubModal({
-                                props: {
-                                  source: {
-                                    type: UserHubSourceType.Model,
-                                    targetId: model.id,
-                                    alias: model.name,
-                                  },
+                        <AddToHubMenuItem
+                          onClick={() =>
+                            openAddToHubModal({
+                              props: {
+                                source: {
+                                  type: UserHubSourceType.Model,
+                                  targetId: model.id,
+                                  alias: model.name,
                                 },
-                              })
-                            }
-                          />
-                        )}
+                              },
+                            })
+                          }
+                        />
                         {isOwner && (
                           <AddToShowcaseMenuItem
                             key="add-to-showcase"

--- a/src/server/routers/__tests__/user-hub.router.gate.test.ts
+++ b/src/server/routers/__tests__/user-hub.router.gate.test.ts
@@ -28,6 +28,8 @@ vi.mock('~/server/services/user-hub.service', () => ({
   setUserHubOrder: vi.fn().mockResolvedValue(undefined),
   getHubSourceSuggestions: vi.fn().mockResolvedValue([]),
   resolveHubSourceFromUrl: vi.fn().mockResolvedValue(null),
+  addUserHubSource: vi.fn().mockResolvedValue({ hubId: 1, added: true }),
+  removeUserHubSource: vi.fn().mockResolvedValue({ hubId: 1, removed: true }),
 }));
 
 import { userHubRouter } from '~/server/routers/user-hub.router';
@@ -44,6 +46,8 @@ const inputs: Record<string, unknown> = {
   setOrder: { ids: [] },
   sourceSuggestions: { type: 'User', query: 'a' },
   resolveSource: { url: 'https://civitai.com/user/someone' },
+  addSource: { hubId: 1, type: 'User', targetId: 2 },
+  removeSource: { hubId: 1, type: 'User', targetId: 2 },
 };
 
 const procedureNames = Object.keys(

--- a/src/server/routers/user-hub.router.ts
+++ b/src/server/routers/user-hub.router.ts
@@ -1,15 +1,19 @@
 import { getByIdSchema } from '~/server/schema/base.schema';
 import {
+  addUserHubSourceSchema,
   getHubSourceSuggestionsSchema,
   resolveHubSourceSchema,
   setUserHubOrderSchema,
   upsertUserHubSchema,
+  userHubSourceRefSchema,
 } from '~/server/schema/user-hub.schema';
 import {
+  addUserHubSource,
   deleteUserHub,
   getUserHubById,
   getHubSourceSuggestions,
   getUserHubs,
+  removeUserHubSource,
   resolveHubSourceFromUrl,
   setUserHubOrder,
   upsertUserHub,
@@ -29,6 +33,14 @@ export const userHubRouter = router({
     .meta({ requiredScope: TokenScope.UserWrite })
     .input(upsertUserHubSchema)
     .mutation(({ input, ctx }) => upsertUserHub({ ...input, userId: ctx.user.id })),
+  addSource: userHubProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(addUserHubSourceSchema)
+    .mutation(({ input, ctx }) => addUserHubSource({ ...input, userId: ctx.user.id })),
+  removeSource: userHubProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(userHubSourceRefSchema)
+    .mutation(({ input, ctx }) => removeUserHubSource({ ...input, userId: ctx.user.id })),
   delete: userHubProcedure
     .meta({ requiredScope: TokenScope.UserWrite })
     .input(getByIdSchema)

--- a/src/server/schema/user-hub.schema.ts
+++ b/src/server/schema/user-hub.schema.ts
@@ -149,3 +149,21 @@ export const getHubSourceSuggestionsSchema = z.object({
 export type HubSuggestionType = z.infer<typeof hubSuggestionTypeSchema>;
 
 export type GetHubSourceSuggestionsInput = z.infer<typeof getHubSourceSuggestionsSchema>;
+
+// One source at a time, addressed by what it points at rather than by row id: the
+// caller is a model or creator page that knows the target and nothing about the
+// hub's rows. Distinct from `upsertUserHubSchema.sources`, which REPLACES the list
+// and so cannot be used by a caller that has not loaded it.
+export const userHubSourceRefSchema = z.object({
+  hubId: z.number().int().positive(),
+  type: z.enum(UserHubSourceType),
+  targetId: z.number().int().positive(),
+});
+
+export const addUserHubSourceSchema = userHubSourceRefSchema.extend({
+  alias: userHubSourceSchema.shape.alias,
+});
+
+export type UserHubSourceRefInput = z.infer<typeof userHubSourceRefSchema>;
+
+export type AddUserHubSourceInput = z.infer<typeof addUserHubSourceSchema>;

--- a/src/server/services/__tests__/user-hub.service.test.ts
+++ b/src/server/services/__tests__/user-hub.service.test.ts
@@ -15,7 +15,9 @@ vi.mock('~/server/services/collection.service', () => ({
 }));
 
 import {
+  addUserHubSource,
   getHubSourceSuggestions,
+  removeUserHubSource,
   getUserHubById,
   resolveHubSourceFromUrl,
   resolveHubSources,
@@ -627,5 +629,91 @@ describe('taken-down models', () => {
     expect(source).toBeNull();
     const where = dbMock.dbRead.modelVersion.findFirst.mock.calls[0][0].where;
     expect(where.model.deletedAt).toBeNull();
+  });
+});
+
+describe('addUserHubSource', () => {
+  const source = { type: UserHubSourceType.User, targetId: 42, alias: 'someone' };
+
+  it('refuses a hub the viewer does not own', async () => {
+    findFirstHub.mockResolvedValue(null);
+
+    await expect(addUserHubSource({ userId: 999, hubId: 1, ...source })).rejects.toThrow();
+    expect(dbMock.dbWrite.userHubSource.create).not.toHaveBeenCalled();
+    expect(findFirstHub).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 1, userId: 999 } })
+    );
+  });
+
+  it('is a no-op when the hub already has that source', async () => {
+    findFirstHub.mockResolvedValue({
+      id: 1,
+      sources: [{ type: UserHubSourceType.User, targetId: 42, index: 0 }],
+    });
+
+    const result = await addUserHubSource({ userId: 5, hubId: 1, ...source });
+
+    expect(result).toEqual({ hubId: 1, added: false });
+    expect(dbMock.dbWrite.userHubSource.create).not.toHaveBeenCalled();
+  });
+
+  it('adds past the highest existing index, not past the count', async () => {
+    // Indexes are not dense — removing a source leaves a gap — so appending at
+    // `length` collides with a row that is still there.
+    findFirstHub.mockResolvedValue({
+      id: 1,
+      sources: [
+        { type: UserHubSourceType.Model, targetId: 1, index: 0 },
+        { type: UserHubSourceType.Model, targetId: 2, index: 7 },
+      ],
+    });
+
+    await addUserHubSource({ userId: 5, hubId: 1, ...source });
+
+    expect(dbMock.dbWrite.userHubSource.create).toHaveBeenCalledWith({
+      data: { hubId: 1, type: UserHubSourceType.User, targetId: 42, alias: 'someone', index: 8 },
+    });
+  });
+
+  it('refuses to go past the per-hub source cap', async () => {
+    findFirstHub.mockResolvedValue({
+      id: 1,
+      sources: Array.from({ length: hubLimits.sourcesPerHub }, (_, i) => ({
+        type: UserHubSourceType.Model,
+        targetId: i + 1,
+        index: i,
+      })),
+    });
+
+    await expect(addUserHubSource({ userId: 5, hubId: 1, ...source })).rejects.toThrow();
+    expect(dbMock.dbWrite.userHubSource.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeUserHubSource', () => {
+  it('refuses a hub the viewer does not own', async () => {
+    findFirstHub.mockResolvedValue(null);
+
+    await expect(
+      removeUserHubSource({ userId: 999, hubId: 1, type: UserHubSourceType.User, targetId: 42 })
+    ).rejects.toThrow();
+    expect(dbMock.dbWrite.userHubSource.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('deletes only the named source in that hub', async () => {
+    findFirstHub.mockResolvedValue({ id: 1 });
+    dbMock.dbWrite.userHubSource.deleteMany.mockResolvedValue({ count: 1 });
+
+    const result = await removeUserHubSource({
+      userId: 5,
+      hubId: 1,
+      type: UserHubSourceType.User,
+      targetId: 42,
+    });
+
+    expect(result).toEqual({ hubId: 1, removed: true });
+    expect(dbMock.dbWrite.userHubSource.deleteMany).toHaveBeenCalledWith({
+      where: { hubId: 1, type: UserHubSourceType.User, targetId: 42 },
+    });
   });
 });

--- a/src/server/services/__tests__/user-hub.service.test.ts
+++ b/src/server/services/__tests__/user-hub.service.test.ts
@@ -38,6 +38,9 @@ import {
 import { ImageSort } from '~/server/common/enums';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 const findFirstHub = dbMock.dbRead.userHub.findFirst;
+// The source mutations read the hub through the WRITER — the duplicate check, the cap
+// and the next index all come off that row.
+const writerHub = dbMock.dbWrite.userHub.findFirst;
 const findManyCollections = dbMock.dbRead.collection.findMany;
 const queryRaw = dbMock.dbRead.$queryRaw;
 
@@ -636,35 +639,88 @@ describe('addUserHubSource', () => {
   const source = { type: UserHubSourceType.User, targetId: 42, alias: 'someone' };
 
   it('refuses a hub the viewer does not own', async () => {
-    findFirstHub.mockResolvedValue(null);
+    writerHub.mockResolvedValue(null);
 
     await expect(addUserHubSource({ userId: 999, hubId: 1, ...source })).rejects.toThrow();
     expect(dbMock.dbWrite.userHubSource.create).not.toHaveBeenCalled();
-    expect(findFirstHub).toHaveBeenCalledWith(
+    expect(writerHub).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: 1, userId: 999 } })
     );
   });
 
   it('is a no-op when the hub already has that source', async () => {
-    findFirstHub.mockResolvedValue({
+    writerHub.mockResolvedValue({
       id: 1,
-      sources: [{ type: UserHubSourceType.User, targetId: 42, index: 0 }],
+      sources: [{ id: 9, type: UserHubSourceType.User, targetId: 42, enabled: true, index: 0 }],
     });
 
     const result = await addUserHubSource({ userId: 5, hubId: 1, ...source });
 
     expect(result).toEqual({ hubId: 1, added: false });
     expect(dbMock.dbWrite.userHubSource.create).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.userHubSource.update).not.toHaveBeenCalled();
+  });
+
+  it('re-enables a source the owner had switched off, rather than reporting a no-op', async () => {
+    // A disabled source is invisible to the feed, so "already there" would be a success
+    // message for a hub that still shows the viewer nothing from that creator.
+    writerHub.mockResolvedValue({
+      id: 1,
+      sources: [{ id: 9, type: UserHubSourceType.User, targetId: 42, enabled: false, index: 0 }],
+    });
+
+    const result = await addUserHubSource({ userId: 5, hubId: 1, ...source });
+
+    expect(result).toEqual({ hubId: 1, added: true });
+    expect(dbMock.dbWrite.userHubSource.update).toHaveBeenCalledWith({
+      where: { id: 9 },
+      data: { enabled: true },
+    });
+    expect(dbMock.dbWrite.userHubSource.create).not.toHaveBeenCalled();
+  });
+
+  it('tells two sources apart by type as well as target', async () => {
+    // Matching on targetId alone would report Model 42 as already present in a hub that
+    // holds User 42, and the checkbox would never tick with nothing to explain it.
+    writerHub.mockResolvedValue({
+      id: 1,
+      sources: [{ id: 9, type: UserHubSourceType.Model, targetId: 42, enabled: true, index: 3 }],
+    });
+
+    const result = await addUserHubSource({ userId: 5, hubId: 1, ...source });
+
+    expect(result).toEqual({ hubId: 1, added: true });
+    expect(dbMock.dbWrite.userHubSource.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ type: UserHubSourceType.User, targetId: 42, index: 4 }),
+    });
+  });
+
+  it('refuses a Collection source while collection sources are switched off', async () => {
+    // The router accepts the whole enum, so this is reachable even though the modal
+    // never sends it. `assertHubSourcesUsable` is the only thing that refuses it, and
+    // deleting that call from the add path is otherwise invisible.
+    writerHub.mockResolvedValue({ id: 1, sources: [] });
+
+    await expect(
+      addUserHubSource({
+        userId: 5,
+        hubId: 1,
+        type: UserHubSourceType.Collection,
+        targetId: 7,
+        alias: null,
+      })
+    ).rejects.toThrow();
+    expect(dbMock.dbWrite.userHubSource.create).not.toHaveBeenCalled();
   });
 
   it('adds past the highest existing index, not past the count', async () => {
     // Indexes are not dense — removing a source leaves a gap — so appending at
     // `length` collides with a row that is still there.
-    findFirstHub.mockResolvedValue({
+    writerHub.mockResolvedValue({
       id: 1,
       sources: [
-        { type: UserHubSourceType.Model, targetId: 1, index: 0 },
-        { type: UserHubSourceType.Model, targetId: 2, index: 7 },
+        { id: 1, type: UserHubSourceType.Model, targetId: 1, enabled: true, index: 0 },
+        { id: 2, type: UserHubSourceType.Model, targetId: 2, enabled: true, index: 7 },
       ],
     });
 
@@ -676,11 +732,13 @@ describe('addUserHubSource', () => {
   });
 
   it('refuses to go past the per-hub source cap', async () => {
-    findFirstHub.mockResolvedValue({
+    writerHub.mockResolvedValue({
       id: 1,
       sources: Array.from({ length: hubLimits.sourcesPerHub }, (_, i) => ({
+        id: i + 1,
         type: UserHubSourceType.Model,
-        targetId: i + 1,
+        targetId: i + 100,
+        enabled: true,
         index: i,
       })),
     });
@@ -692,16 +750,21 @@ describe('addUserHubSource', () => {
 
 describe('removeUserHubSource', () => {
   it('refuses a hub the viewer does not own', async () => {
-    findFirstHub.mockResolvedValue(null);
+    writerHub.mockResolvedValue(null);
 
     await expect(
       removeUserHubSource({ userId: 999, hubId: 1, type: UserHubSourceType.User, targetId: 42 })
     ).rejects.toThrow();
     expect(dbMock.dbWrite.userHubSource.deleteMany).not.toHaveBeenCalled();
+    // The scope has to be IN the lookup. Asserting only that a null hub throws passes
+    // just as well when the lookup stops asking whose hub it is.
+    expect(writerHub).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 1, userId: 999 } })
+    );
   });
 
   it('deletes only the named source in that hub', async () => {
-    findFirstHub.mockResolvedValue({ id: 1 });
+    writerHub.mockResolvedValue({ id: 1 });
     dbMock.dbWrite.userHubSource.deleteMany.mockResolvedValue({ count: 1 });
 
     const result = await removeUserHubSource({
@@ -712,8 +775,10 @@ describe('removeUserHubSource', () => {
     });
 
     expect(result).toEqual({ hubId: 1, removed: true });
+    // Owner-scoped on the DELETE too, not only in the lookup above it — dropping it
+    // there is a cross-owner delete the moment `UserHub.userId` can move.
     expect(dbMock.dbWrite.userHubSource.deleteMany).toHaveBeenCalledWith({
-      where: { hubId: 1, type: UserHubSourceType.User, targetId: 42 },
+      where: { hubId: 1, type: UserHubSourceType.User, targetId: 42, hub: { userId: 5 } },
     });
   });
 });

--- a/src/server/services/user-hub.service.ts
+++ b/src/server/services/user-hub.service.ts
@@ -183,33 +183,64 @@ export async function addUserHubSource({
   hubId,
   ...source
 }: AddUserHubSourceInput & { userId: number }) {
-  const hub = await dbRead.userHub.findFirst({
+  // Read through the WRITER, like `upsertUserHub` above and for the same reason: the
+  // duplicate check, the cap and the next index all come off this row, and a modal of
+  // checkboxes invites a second write inside the replica's lag window.
+  const hub = await dbWrite.userHub.findFirst({
     where: { id: hubId, userId },
-    select: { id: true, sources: { select: { type: true, targetId: true, index: true } } },
+    select: {
+      id: true,
+      sources: { select: { id: true, type: true, targetId: true, enabled: true, index: true } },
+    },
   });
   if (!hub) throw throwNotFoundError('Hub not found');
 
   const existing = hub.sources.find(
     (s) => s.type === source.type && s.targetId === source.targetId
   );
-  if (existing) return { hubId, added: false };
+  if (existing) {
+    // A source the owner switched off is invisible to the feed — `resolveHubSources`
+    // selects enabled rows only — so reporting "already there" and leaving it off is a
+    // success message for nothing happening.
+    if (existing.enabled) return { hubId, added: false };
+
+    await dbWrite.userHubSource.update({ where: { id: existing.id }, data: { enabled: true } });
+    return { hubId, added: true };
+  }
 
   if (hub.sources.length >= hubLimits.sourcesPerHub)
     throw throwBadRequestError(`A hub can hold at most ${hubLimits.sourcesPerHub} sources`);
 
   await assertHubSourcesUsable({ sources: [{ ...source, enabled: true, index: 0 }], userId });
 
-  await dbWrite.userHubSource.create({
-    data: {
-      hubId,
-      type: source.type,
-      targetId: source.targetId,
-      alias: source.alias ?? null,
-      index: hub.sources.reduce((max, s) => Math.max(max, s.index + 1), 0),
-    },
-  });
+  try {
+    await dbWrite.userHubSource.create({
+      data: {
+        hubId,
+        type: source.type,
+        targetId: source.targetId,
+        alias: source.alias ?? null,
+        index: hub.sources.reduce((max, s) => Math.max(max, s.index + 1), 0),
+      },
+    });
+  } catch (error) {
+    // Two writes genuinely in flight. NOT `isPrismaUniqueViolation`, whose own doc
+    // restricts it to sites where P2002 can only mean the row we wanted: `id` is a
+    // unique key here too, so a sequence behind the table collides while saying nothing
+    // about this source, and swallowing that would report a write that never happened.
+    if (!isDuplicateSourceError(error)) throw error;
+    return { hubId, added: false };
+  }
 
   return { hubId, added: true };
+}
+
+function isDuplicateSourceError(error: unknown) {
+  if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== 'P2002')
+    return false;
+
+  const target = error.meta?.target;
+  return Array.isArray(target) && target.includes('targetId');
 }
 
 export async function removeUserHubSource({
@@ -218,13 +249,18 @@ export async function removeUserHubSource({
   type,
   targetId,
 }: UserHubSourceRefInput & { userId: number }) {
-  const hub = await dbRead.userHub.findFirst({
+  const hub = await dbWrite.userHub.findFirst({
     where: { id: hubId, userId },
     select: { id: true },
   });
   if (!hub) throw throwNotFoundError('Hub not found');
 
-  const { count } = await dbWrite.userHubSource.deleteMany({ where: { hubId, type, targetId } });
+  // Owner-scoped on the DELETE as well as in the read above, per the argument this file
+  // already makes for `upsert`: a check in a prior SELECT is a check that can disagree
+  // with the write the moment `UserHub.userId` can move.
+  const { count } = await dbWrite.userHubSource.deleteMany({
+    where: { hubId, type, targetId, hub: { userId } },
+  });
   return { hubId, removed: count > 0 };
 }
 

--- a/src/server/services/user-hub.service.ts
+++ b/src/server/services/user-hub.service.ts
@@ -1,11 +1,13 @@
 import { dbRead, dbWrite } from '~/server/db/client';
 import { Prisma } from '@prisma/client';
 import type {
+  AddUserHubSourceInput,
   GetHubSourceSuggestionsInput,
   ResolveHubSourceInput,
   SetUserHubOrderInput,
   UpsertUserHubInput,
   UserHubSourceInput,
+  UserHubSourceRefInput,
 } from '~/server/schema/user-hub.schema';
 import {
   HUB_COLLECTION_SOURCES_ENABLED,
@@ -174,6 +176,56 @@ export async function upsertUserHub({ userId, ...input }: UpsertUserHubInput & {
     });
   });
   return toHubDetail(updated);
+}
+
+export async function addUserHubSource({
+  userId,
+  hubId,
+  ...source
+}: AddUserHubSourceInput & { userId: number }) {
+  const hub = await dbRead.userHub.findFirst({
+    where: { id: hubId, userId },
+    select: { id: true, sources: { select: { type: true, targetId: true, index: true } } },
+  });
+  if (!hub) throw throwNotFoundError('Hub not found');
+
+  const existing = hub.sources.find(
+    (s) => s.type === source.type && s.targetId === source.targetId
+  );
+  if (existing) return { hubId, added: false };
+
+  if (hub.sources.length >= hubLimits.sourcesPerHub)
+    throw throwBadRequestError(`A hub can hold at most ${hubLimits.sourcesPerHub} sources`);
+
+  await assertHubSourcesUsable({ sources: [{ ...source, enabled: true, index: 0 }], userId });
+
+  await dbWrite.userHubSource.create({
+    data: {
+      hubId,
+      type: source.type,
+      targetId: source.targetId,
+      alias: source.alias ?? null,
+      index: hub.sources.reduce((max, s) => Math.max(max, s.index + 1), 0),
+    },
+  });
+
+  return { hubId, added: true };
+}
+
+export async function removeUserHubSource({
+  userId,
+  hubId,
+  type,
+  targetId,
+}: UserHubSourceRefInput & { userId: number }) {
+  const hub = await dbRead.userHub.findFirst({
+    where: { id: hubId, userId },
+    select: { id: true },
+  });
+  if (!hub) throw throwNotFoundError('Hub not found');
+
+  const { count } = await dbWrite.userHubSource.deleteMany({ where: { hubId, type, targetId } });
+  return { hubId, removed: count > 0 };
 }
 
 export async function deleteUserHub({ id, userId }: { id: number; userId: number }) {

--- a/src/utils/login-helpers.ts
+++ b/src/utils/login-helpers.ts
@@ -23,6 +23,7 @@ export const loginRedirectReasons = {
   'favorite-article': 'You need to be logged in to like an article',
   'post-images': 'You need to be logged in to create a post',
   'add-to-collection': 'You must be logged in to add this resource to a collection',
+  'add-to-hub': 'You must be logged in to add this to a hub',
   'create-bounty': 'You need to be logged in to create a new bounty',
   'perform-action': 'You need to be logged in to perform this action',
   'purchase-buzz': 'You need to be logged in to purchase Buzz',


### PR DESCRIPTION
Asked for in the tester thread: an **Add to hub** option next to Save, on model pages and creator pages. Justin confirmed the scope, including collections later once collection sources can be switched on.

## What it does

A menu item beside Save on a model page, and in the creator context menu, both gated on `userHubs`. It opens a modal listing your hubs with a tick for the ones that already hold this target, a source count against the per-hub cap, and a box to name a new hub that gets created with this source already in it.

## Why two new procedures rather than `upsert`

`upsert` **replaces** a hub's whole source list. A model page has not loaded the hub, so using it would mean fetching every source for every hub first, and any list it did send would clobber sources added since it fetched. That is the same clobbering the `sources`-is-optional comment on the schema already warns about.

So the modal addresses a source by what it points at:

- **`addSource`** returns `{ added: false }` when the hub already holds that target rather than throwing, so a double-tick is not an error. Refuses at `hubLimits.sourcesPerHub`.
- **`removeSource`** deletes only the named target in that hub.

Both read the hub scoped by `userId`, so someone else's hub id is a not-found and never a write.

The new source lands **one past the highest existing index**, not at `sources.length` — removing a source leaves a gap, so appending at the count collides with a row that is still there. There is a test for exactly that.

Membership is read off `getAll`, which already returns each hub's sources, so no new query.

## Verification

- `TYPECHECK_HEAP_MB=12288 pnpm run typecheck` — clean apart from the pre-existing `packages/civitai-telemetry` error on `main`
- `npx eslint <changed files>` — clean (3 pre-existing `no-unused-vars` in the model page's `getServerSideProps`)
- `pnpm run test:unit:run` — 1337 files / 20865 tests, all green
- The router gate test derives its procedure list from the router, so both new procedures are covered by it rather than added to a hand-written list
- **Browser, `civitai-dev.blue`**: ticked a hub from a model page and confirmed the row in the database with the right type and alias, unticked it and confirmed it was gone; same from a creator page, which wrote `type: User, targetId: 3, alias: Maxfield`