### PR TITLE
docs(claudedocs): correct five claims, including one this repo's own convention introduced

### DIFF
--- a/claudedocs/README.md
+++ b/claudedocs/README.md
@@ -40,7 +40,8 @@ followed by the evidence:
 
 When a status has changed since the doc was written, state the correction **in place**
 rather than silently editing out the old claim. Use the pattern from
-`runner-scouting-2026-08-15.md`:
+`typecheck-tests-gap-2026-08-12.md` or `turbopack-chunk-hash-collision-2026-08-18.md`,
+which carry a real `(corrected …)` status line:
 
 ```markdown
 **Status (corrected YYYY-MM-DD):** <new status>. <evidence>.

--- a/claudedocs/notifications-test-coverage-audit-2026-07-03.md
+++ b/claudedocs/notifications-test-coverage-audit-2026-07-03.md
@@ -1,6 +1,13 @@
 # Notifications App — Test Coverage Audit (2026-07-03)
 
-**Status (added 2026-08-21):** Historical snapshot. Coverage numbers measured at the stated commit; NOT VERIFIED against current `main`.
+**Status (corrected 2026-08-22):** Superseded — the top three gaps this audit ranked have all
+been closed. G1 (`poll-loop`, "0%") by `apps/notifications/src/worker/poll-loop.behavioral.test.ts`;
+G2 (`create.ts`, "0%") by `create.behavioral.test.ts`; G3 (`markNotificationsRead`) by
+`operations.markNotificationsRead.test.ts`; G4/G6 partly by the `countNotifications` and
+`createNotificationsBulk` suites. **Kept for the METHOD, not the status** — gaps ranked by blast
+radius, the fake-`PoolClient` recorder, and the "assert on behaviour, never on the emitted string"
+critique, which is what produced those suites. The original percentages are a point-in-time
+measurement and were NOT re-run.
 
 **Scope:** `apps/notifications` (`@civitai/notifications-app`) — the Fastify + raw-pg fan-out/producer service.
 **Method:** ran `corepack pnpm exec vitest run --coverage` (v8 provider, worked) + static analysis of every source module and test. Read-only; no source or tests changed.

--- a/claudedocs/services-a-m-handover.md
+++ b/claudedocs/services-a-m-handover.md
@@ -1,6 +1,15 @@
 # Handover — `src/server/services/__tests__` a–m shared-mock migration
 
-**Status (added 2026-08-21):** Historical handover log. 127 of 129 files migrated at time of handover; 2 hold-outs remained. The branch `perf/test-mock-migration-services-a-m` is the reference.
+**Status (corrected 2026-08-22):** Historical handover log, superseded in two respects.
+Landed as **PR #3973** (merged 2026-08-16), squash commit `533640662d` — cite those, not a branch.
+The reference branch `perf/services-a-m-mock-migration` was deleted on merge, and the commit this
+document names for it, `632a3da432`, no longer resolves in this repository at all.
+🔴 An earlier version of this line named `perf/test-mock-migration-services-a-m` as the reference.
+That is the STALE remote this document's own "Landing state" section warns about — it predates the
+rebase, its history diverges, and it still sits at `19e95f05b5`. The status line pointed a successor
+at the one branch the body says not to trust.
+Also superseded: the "2 hold-outs remaining" count is now 0 (converted in #4281), and the
+`TEST_ENV_DEFAULTS` seeding fix this document reports as not landed DID land, also in #4281.
 
 josh, 2026-08-15, continued and closed out by liz through batches 6–9 (her sections are marked).
 Kept as a LOG rather than rewritten to current state: which claims were superseded, and by what, is
@@ -466,6 +475,12 @@ and `REPLICATION_LAG_DELAY` is a zod `.default(0)` key **absent from `TEST_ENV_D
 canonical env reads `undefined` and `undefined <= 0` is `false` where `0 <= 0` is `true`. Checked
 against the base on 2026-08-15, not inherited: `TEST_ENV_DEFAULTS` is still hand-enumerated, so the
 seeding fix has not landed. **When it does, these two become ordinary entry-point conversions.**
+
+📌 **CORRECTED 2026-08-22: it landed.** `TEST_ENV_DEFAULTS` now derives from `serverSchema.shape`
+(`src/__tests__/mocks/env.mock.ts`), shipped in **PR #4281**, and both hold-outs were converted in
+the same PR — so the count above is 0, not 2. They remain on the generated allowlist for a
+different reason (a direct redis-client mock, and a logging-client one), addressed by **PR #4293**
+(open at the time of writing — check its state before relying on this).
 
 ### ⚠️ #3973 is a STACKED PR — the retarget after #3959 lands is load-bearing
 

--- a/claudedocs/services-a-m-parameterised-client-analysis.md
+++ b/claudedocs/services-a-m-parameterised-client-analysis.md
@@ -110,7 +110,23 @@ population at risk cannot be read off which files converted cleanly.
 
 Drives `BlockRegistry.resolveBlockInstance` and `BlockRegistry.applyPinnedVersion`, no `db` option →
 **`dbWrite`** for `blockUserSubscription.findUnique` and `appBlockPublishRequest.findFirst`.
-`model.findUnique` resolves to `dbRead` in the service source directly.
+~~`model.findUnique` resolves to `dbRead` in the service source directly.~~
+
+📌 **CORRECTED 2026-08-22 — this line was false, and it cost a red batch.** It does not resolve to
+`dbRead` on this path. `resolveBlockInstance` (`block-registry.service:1354`) takes its client as a
+parameter at `:1362` and uses that local for everything downstream, including
+`db.model.findUnique` at `:1451`. The `dbRead.model.findUnique` spelling cited above is at `:2617`,
+in a function these tests never call.
+
+Acting on it routed `model`/`modelVersion` to `dbRead`, so the code read the canonical `null` on a
+client it never touches and `if (!model) return null` fired everywhere — six tests across two files,
+all `expected null not to be null`. Fifteen sites were corrected to `dbWrite`. Full account:
+`services-a-m-handover.md` § "The red, and the routing table that caused it".
+
+🔴 **The lesson the handover draws is about THIS document.** A citation was present, it looked
+checked, and the cited line was not on the path — and the rest of this table is right, which is what
+made trusting it easy. Verify a routing claim against the call path the test actually drives, not
+against a matching spelling elsewhere in the file.
 
 🔴 Negative assertion: `expect(mockDb.appBlockPublishRequest.findFirst).not.toHaveBeenCalled()`
 (×2). Routed to `dbRead` it would pass **whatever the code did**, because the code only ever calls

--- a/claudedocs/typecheck-tests-gap-2026-08-12.md
+++ b/claudedocs/typecheck-tests-gap-2026-08-12.md
@@ -196,10 +196,18 @@ src/server/db/__tests__/kysely-prisma-parity.test.ts(5,29):
 ```
 
 `kysely` is not a dependency of this repository (only `prisma-kysely` is) and is not installed.
-That import cannot resolve at runtime either, so this suite contributes zero tests — the exact
+~~That import cannot resolve at runtime either, so this suite contributes zero tests~~ — the exact
 failure class already documented in the repo's own notes about suites that fail to _collect_
 and therefore report "no tests" rather than a failure. The typecheck would have named it on the
 day it landed.
+
+📌 **CORRECTED 2026-08-22 — the runtime half of that is wrong.** At this document's own measurement
+commit `f19574a9cb` the import was already `import type { Kysely } from 'kysely'` — type-only, so it
+is erased at transpile and cannot fail at runtime. The TS2307 is real; the runtime consequence does
+not follow from it. The suite does contribute zero _executed_ tests, but for an unrelated and
+deliberate reason: `describe.skipIf(!parityUrl)`, gated on `KYSELY_PARITY_DATABASE_URL`. Both facts
+are unchanged on current `main`. The section's headline finding — that the typecheck cannot see
+these files — is untouched.
 
 ### By area
 


### PR DESCRIPTION
Follow-up to the audit of `claudedocs/`. Five claims were false. Each is corrected **in place** per `claudedocs/README.md` rather than silently edited out.

## The one that cost real work

**`services-a-m-parameterised-client-analysis.md:113`** — *"`model.findUnique` resolves to `dbRead` in the service source directly"*. False on the path those tests drive, and it caused a red batch: **six tests across two files, all `expected null not to be null`, fifteen sites corrected to `dbWrite`**.

`resolveBlockInstance` takes its client as a parameter and uses that local for everything downstream; the `dbRead.model.findUnique` spelling cited sits at `:2617`, in a function the tests never call. The handover already recorded this — the analysis was never updated.

It matters because that doc is cited three times *by* the handover, and the handover's own lesson is the sharp one:

> a document that is right 95% of the time is more dangerous than one that is obviously rough, because trusting it is easier.

## 🔴 The one I introduced

**`services-a-m-handover.md:3`** — the status line **PR #4280 added** said:

> The branch `perf/test-mock-migration-services-a-m` is the reference.

That is the **stale** remote this same document's "Landing state" section warns about — it predates the rebase, its history diverges, and it still sits at `19e95f05b5`. The status line pointed a successor at the one branch the body says not to trust, added by the very change whose purpose was making status claims checkable.

Now cites **#3973** and squash commit `533640662d`.

## Three more

- **Same doc** — "2 hold-outs remaining" is now 0, and "the seeding fix has not landed" landed. Both in #4281.
- **`notifications-test-coverage-audit`** — its top three ranked gaps are all closed by five behavioural suites. Reframed from "NOT VERIFIED" to superseded, and kept explicitly for its **method** (blast-radius ranking, the fake-`PoolClient` recorder, the assert-on-behaviour-not-strings critique) rather than its status.
- **`typecheck-tests-gap` §3** — *"that import cannot resolve at runtime either"* is wrong. At the doc's own measurement commit it was already `import type`, so it is erased at transpile. The suite does execute zero tests, but because of a deliberate `describe.skipIf` on `KYSELY_PARITY_DATABASE_URL`. The section's headline finding is untouched.
- **`README.md`** — repoints the correction exemplar. It named `runner-scouting`, which does not use a `(corrected …)` status line; its corrections live in a body blockquote.

## Two of my own citations did not survive verification

Checked before committing, and worth stating since this PR is about checkable claims:

- I wrote *"closed by #4293"* — that PR is still **OPEN**. Reworded to "addressed by", with a note to check its state.
- The handover names commit `632a3da432` as its reference. **That object does not resolve in this repository at all** — its branch was deleted. Replaced with `533640662d`, which does, and the dead SHA is now called out rather than repeated.