### PR TITLE
fix(auth): bust the shaped session cache for every session-carried field it writes

### DIFF
--- a/src/server/auth/session-invalidation.ts
+++ b/src/server/auth/session-invalidation.ts
@@ -94,6 +94,10 @@ async function updateSessionState(
 
   let chunksWritten = 0;
   let chunksTotal = 0;
+  // This is where the hub's shaped session-user entry (`session:data2:{userId}`, 4h TTL) gets busted —
+  // `clearSessionCache` asks the hub to drop it, so the next read re-produces from the DB. It runs on
+  // BOTH the 'refresh' and 'invalid' paths, and unconditionally (not gated on the token scan above), so
+  // every per-user caller of refreshSession/invalidateSession gets a fresh shape on the next read.
   await clearSessionCache(userId);
   if (userTokens.length > 0) {
     // Atomic multi-field set+TTL — single EVAL replaces the sequential
@@ -151,6 +155,24 @@ async function sendSessionSignal(userId: number, type: 'refresh' | 'invalid') {
   }
 }
 
+/**
+ * Mark a user's tokens for refresh, bust their cached session state, and signal active sessions.
+ *
+ * 🔴 This DOES bust the hub's shaped session-user entry (`session:data2:{userId}`) — via
+ * `updateSessionState` → `clearSessionCache` → `sessionClient.invalidate`, which POSTs the hub's
+ * `/api/auth/identity` and lands in the hub's own `invalidateSessionUser`. So a caller that edits a
+ * field carried on the SessionUser shape (username, image/profilePicture, onboarding, settings, …)
+ * only has to call this; the next session read re-produces from the DB rather than serving the
+ * cached shape for the remainder of its 4h TTL.
+ *
+ * The main app reaches the hub's `invalidateSessionUser` over HTTP, not by import — grepping for that
+ * function name in `src/` finds nothing and reads as "no main-app path busts the cache", which is how
+ * this got misdiagnosed in #4298. The seam is pinned by
+ * `src/server/controllers/__tests__/user.controller.session-avatar-bust.test.ts`.
+ *
+ * Contrast `invalidateAllSessions` below, which deliberately does NOT wipe the shape — that exemption
+ * is specific to the MASS path and does not apply here.
+ */
 export async function refreshSession(
   userId: number,
   { sendSignal = true, caller = 'unspecified' }: RefreshSessionOptions = {}
@@ -198,7 +220,9 @@ export async function invalidateSession(
 export async function invalidateAllSessions() {
   // Mass invalidation is hub-owned: set the global revocation cutoff (the shared SESSION.ALL marker the hub
   // registry owns) through the hub rather than writing it directly — revokes every token signed before now.
-  // The shared session:data2 cache is NOT wiped — its 4h TTL bounds data staleness (see the hub handler).
+  // 🔴 THIS MASS PATH ONLY: the shared session:data2 cache is NOT wiped, because a cluster-wide SCAN+del
+  // costs far more than the freshness it buys and its 4h TTL bounds the staleness. The PER-USER paths above
+  // (refreshSession / invalidateSession) DO wipe it — do not read this sentence as a statement about them.
   await sessionClient.invalidateAll();
   log(`Scheduling session refresh for all users`);
 }

--- a/src/server/controllers/__tests__/user.controller.session-avatar-bust.test.ts
+++ b/src/server/controllers/__tests__/user.controller.session-avatar-bust.test.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as UserService from '~/server/services/user.service';
+
+/**
+ * SEAM test for #4298 — "changing the avatar leaves the session serving the old (now deleted) url".
+ *
+ * The relationship under test spans two applications and therefore no single-surface test can see it:
+ *
+ *   main app                                        auth hub
+ *   ────────                                        ────────
+ *   updateUserHandler (avatar write)
+ *     └─ refreshSession
+ *          └─ clearSessionCache
+ *               └─ sessionClient.invalidate(userId) ──▶ invalidateSessionUser
+ *                                                        └─ del `session:data2:{userId}`
+ *                                                             ▲
+ *                          produceSessionUser writes ─────────┘  (4h TTL)
+ *
+ * Every OTHER suite in this repo is structurally blind to it, because `src/__tests__/setup.ts`
+ * globally mocks `~/server/auth/session-invalidation` down to a no-op `refreshSession`. A test
+ * written against that stub can only assert that the CALL happens — it cannot distinguish a call
+ * that busts the right key from one that busts nothing, or the wrong key. That is exactly the
+ * failure mode #4298 describes, so this file unmocks it and asserts the EFFECT instead.
+ *
+ * What is deliberately real here: the whole main-app chain (`refreshSession` → `updateSessionState`
+ * → `clearSessionCache`), and the KEY both sides address, derived on each side from the single
+ * shared `REDIS_KEYS.USER.SESSION` namespace in `@civitai/redis`. The hub's HTTP hop is stood in
+ * for by `hubInvalidate`, which deletes from the same fake keyspace using the hub's own key
+ * derivation — so a namespace drift between the two apps fails this test rather than shipping.
+ */
+
+// Defeat the global stub from `src/__tests__/setup.ts`. Without this line the entire chain below is
+// replaced by `vi.fn()` and every assertion here passes vacuously.
+vi.unmock('~/server/auth/session-invalidation');
+
+const {
+  sharedCache,
+  hubInvalidate,
+  mockUpdateUserById,
+  mockGetUserById,
+  mockIngestImage,
+  mockDeleteImageById,
+  mockGetUserSettings,
+  mockPatchUserSettings,
+} = vi.hoisted(() => ({
+  sharedCache: new Map<string, unknown>(),
+  hubInvalidate: vi.fn(),
+  mockUpdateUserById: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockIngestImage: vi.fn(),
+  mockDeleteImageById: vi.fn(),
+  mockGetUserSettings: vi.fn(),
+  mockPatchUserSettings: vi.fn(),
+}));
+
+// The hub hop. `clearSessionCache` calls this first and only falls back to a direct `redis.del` when
+// it rejects — both arms are exercised below.
+vi.mock('~/server/auth/session-client', () => ({
+  sessionClient: { invalidate: hubInvalidate },
+}));
+vi.mock('~/server/services/orchestrator/civitai', () => ({
+  invalidateCivitaiUser: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('~/utils/signal-client', () => ({
+  signalClient: { send: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock('~/server/services/user.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof UserService>()),
+  getUserById: mockGetUserById,
+  updateUserById: mockUpdateUserById,
+  updateLeaderboardRankForUsers: vi.fn(),
+  equipCosmetic: vi.fn(),
+  unequipCosmeticByType: vi.fn(),
+  createUserReferral: vi.fn(),
+  isUsernamePermitted: vi.fn(async () => true),
+  getUserSettings: mockGetUserSettings,
+  patchUserSettings: mockPatchUserSettings,
+  queueModelMetricPrivacyReindex: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ingestImage: mockIngestImage,
+  deleteImageById: mockDeleteImageById,
+}));
+vi.mock('~/server/search-index', () => ({ usersSearchIndex: { queueUpdate: vi.fn() } }));
+vi.mock('~/server/cloudflare/client', () => ({ purgeCache: vi.fn(() => ({ catch: vi.fn() })) }));
+
+import { REDIS_KEYS } from '@civitai/redis';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { OnboardingSteps } from '~/server/common/enums';
+import {
+  completeOnboardingHandler,
+  setUserSettingHandler,
+  updateUserHandler,
+} from '~/server/controllers/user.controller';
+
+const USER_ID = 5;
+// The hub's own derivation (`sessionCacheKey` in @civitai/auth, and `produceSessionUser`'s write in
+// apps/auth) — built here from the same shared constant, NOT from the string the main app builds.
+const hubKey = (userId: number) => `${REDIS_KEYS.USER.SESSION}:${userId}`;
+
+const OLD_AVATAR = 'https://images.example.test/old-avatar.jpg';
+const NEW_AVATAR = 'https://images.example.test/new-avatar.jpg';
+
+const warmSessionCache = () =>
+  sharedCache.set(hubKey(USER_ID), { id: USER_ID, username: 'ada', image: OLD_AVATAR });
+
+const changeAvatar = () =>
+  updateUserHandler({
+    ctx: { user: { id: USER_ID } },
+    input: {
+      id: USER_ID,
+      profilePicture: { id: 99, url: NEW_AVATAR, type: 'image', width: 256, height: 256 },
+    },
+  } as never);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sharedCache.clear();
+
+  // The user had a DIFFERENT profile picture before this save — the replacement branch, which is the
+  // one that hard-deletes the previous image (#4272) and so makes staleness a 404 rather than a
+  // merely-old avatar.
+  mockGetUserById.mockResolvedValue({ profilePictureId: 42 });
+  mockUpdateUserById.mockResolvedValue({ id: USER_ID, profilePictureId: 99 });
+  mockIngestImage.mockResolvedValue(undefined);
+  mockDeleteImageById.mockResolvedValue(undefined);
+  mockGetUserSettings.mockResolvedValue({});
+  mockPatchUserSettings.mockResolvedValue({});
+
+  // Back the canonical redis mock with a real keyspace so a bust is OBSERVABLE. Left as the default
+  // `del: () => 0` spy, every assertion below would be about a call rather than an effect.
+  redisMock.redis.del.mockImplementation(async (key: string) => (sharedCache.delete(key) ? 1 : 0));
+  // `updateSessionState` scans the user's token hash before busting; an empty set is the shape that
+  // matters here (this test is about the cache entry, not token revocation).
+  redisMock.sysRedis.hScanNoValues.mockResolvedValue({ cursor: '0', fields: [] });
+
+  hubInvalidate.mockImplementation(async (userId: number) => {
+    sharedCache.delete(hubKey(userId));
+  });
+});
+
+describe('avatar change → shaped session-user cache (#4298)', () => {
+  it('busts the hub-owned session:data2 entry, so the next read cannot serve the deleted avatar', async () => {
+    warmSessionCache();
+    expect(sharedCache.has(hubKey(USER_ID))).toBe(true);
+
+    await changeAvatar();
+
+    // The property is the ABSENCE of the entry — not that some function was called. A bust that
+    // addressed the wrong key, or that never reached redis, leaves this entry in place and the
+    // session keeps serving OLD_AVATAR for the remaining 4h of its TTL.
+    expect(sharedCache.has(hubKey(USER_ID))).toBe(false);
+  });
+
+  it('addresses the same key the hub writes, even when the hub hop fails', async () => {
+    // `clearSessionCache` falls back to a hand-built key string on a hub blip. That string is a
+    // SECOND spelling of a hub-owned namespace, so it can drift from the hub's own derivation
+    // silently; this pins the two together.
+    hubInvalidate.mockRejectedValue(new Error('hub unreachable'));
+    warmSessionCache();
+
+    await changeAvatar();
+
+    expect(sharedCache.has(hubKey(USER_ID))).toBe(false);
+  });
+
+  it('busts only AFTER the new avatar is written, so the re-produce reads the new row', async () => {
+    warmSessionCache();
+
+    await changeAvatar();
+
+    // Ordering is the whole property: busting before the write lets a concurrent read re-produce the
+    // OLD row into the cache with a fresh 4h TTL, which is the same observable as never busting.
+    expect(mockUpdateUserById.mock.invocationCallOrder[0]).toBeLessThan(
+      hubInvalidate.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('busts on a username change too — same shaped entry, same 4h window', async () => {
+    warmSessionCache();
+
+    await updateUserHandler({
+      ctx: { user: { id: USER_ID } },
+      input: { id: USER_ID, username: 'ada-new' },
+    } as never);
+
+    expect(sharedCache.has(hubKey(USER_ID))).toBe(false);
+  });
+});
+
+/**
+ * The same defect class as #4298, found by enumerating the shaped SessionUser's fields against their
+ * writers rather than by re-reading the avatar path: a handler whose bust GATE is narrower than the
+ * set of session-carried fields it WRITES. Both of these were live gaps.
+ */
+describe('user.setSettings — session-projected settings keys', () => {
+  const setSetting = (input: Record<string, unknown>) =>
+    setUserSettingHandler({
+      ctx: { user: { id: USER_ID }, features: {} },
+      input,
+    } as never);
+
+  it('busts when allowAds changes — it is projected onto the session, like isEarlyAdopter', async () => {
+    // The gap: `allowAds` is folded into the SessionUser by the hub's shapeSessionUser, but the bust
+    // used to fire only for `isEarlyAdopter`. Turning ads off therefore kept `allowAds: true` in the
+    // session — and in every Flipt context built from it — for the rest of the 4h TTL.
+    mockGetUserSettings.mockResolvedValue({ allowAds: true });
+    warmSessionCache();
+
+    await setSetting({ allowAds: false });
+
+    expect(sharedCache.has(hubKey(USER_ID))).toBe(false);
+  });
+
+  it('still busts when isEarlyAdopter changes', async () => {
+    mockGetUserSettings.mockResolvedValue({ isEarlyAdopter: false });
+    warmSessionCache();
+
+    await setSetting({ isEarlyAdopter: true });
+
+    expect(sharedCache.has(hubKey(USER_ID))).toBe(false);
+  });
+
+  it('does NOT bust for a settings key the session does not carry', async () => {
+    // The gate has to stay narrow. Busting on every unrelated toggle would re-produce the whole
+    // shaped user (a DB round trip) on each one, which is the cost the change-gate exists to avoid.
+    mockGetUserSettings.mockResolvedValue({ hideDonationGoals: false });
+    warmSessionCache();
+
+    await setSetting({ hideDonationGoals: true });
+
+    expect(sharedCache.has(hubKey(USER_ID))).toBe(true);
+  });
+
+  it('does NOT bust when a projected key is re-sent unchanged', async () => {
+    mockGetUserSettings.mockResolvedValue({ allowAds: true });
+    warmSessionCache();
+
+    await setSetting({ allowAds: true });
+
+    expect(sharedCache.has(hubKey(USER_ID))).toBe(true);
+  });
+});
+
+describe('user.completeOnboarding — Profile step writes identity unconditionally', () => {
+  it('busts on a Profile re-submit even when the onboarding bit is already set', async () => {
+    // The Profile step writes `username`/`email` whether or not the bitmask advances, but the bust
+    // used to be gated on the bitmask alone. A re-submit therefore changed the username in the
+    // database and left the old one in the session for the rest of its 4h TTL.
+    warmSessionCache();
+
+    await completeOnboardingHandler({
+      ctx: { user: { id: USER_ID, onboarding: OnboardingSteps.Profile }, domain: 'blue' },
+      input: { step: OnboardingSteps.Profile, username: 'ada-renamed' },
+    } as never);
+
+    expect(sharedCache.has(hubKey(USER_ID))).toBe(false);
+  });
+
+  it('still busts when the step genuinely advances the bitmask', async () => {
+    warmSessionCache();
+
+    await completeOnboardingHandler({
+      ctx: { user: { id: USER_ID, onboarding: 0 }, domain: 'blue' },
+      input: { step: OnboardingSteps.BrowsingLevels },
+    } as never);
+
+    expect(sharedCache.has(hubKey(USER_ID))).toBe(false);
+  });
+
+  it('does NOT bust on a no-op re-submit that writes no session field', async () => {
+    warmSessionCache();
+
+    await completeOnboardingHandler({
+      ctx: { user: { id: USER_ID, onboarding: OnboardingSteps.BrowsingLevels }, domain: 'blue' },
+      input: { step: OnboardingSteps.BrowsingLevels },
+    } as never);
+
+    expect(sharedCache.has(hubKey(USER_ID))).toBe(true);
+  });
+});

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -450,7 +450,14 @@ export const completeOnboardingHandler = async ({
     // main app READS the cached SessionUser, it no longer recomputes it per request. Bust that cache so the
     // client's next session read reflects the advanced step — without this the stale cached `onboarding` makes a
     // NEW user repeat the same step forever ("can't get through account creation"). Mirrors updateUserHandler.
-    if (changed) await refreshSession(id, { caller: 'profile' });
+    //
+    // 🔴 Gating on `changed` ALONE is narrower than what this handler WRITES. The Profile step writes
+    // `username`/`email` unconditionally (see the switch above), and both are carried on the session shape — so a
+    // re-submit of a step whose bit is already set advanced nothing, skipped the bust, and left the new username
+    // in the database with the old one in the session for the rest of its 4h TTL. Bust on either condition.
+    const wroteSessionIdentity =
+      input.step === OnboardingSteps.Profile && (!!input.username || !!input.email);
+    if (changed || wroteSessionIdentity) await refreshSession(id, { caller: 'profile' });
 
     const isComplete = onboarding === OnboardingComplete;
     if (isComplete && changed && onboardingCompletedCounter) onboardingCompletedCounter.inc();
@@ -1409,6 +1416,16 @@ export const getUserSettingsHandler = async ({ ctx }: { ctx: ProtectedContext })
   }
 };
 
+/**
+ * Settings keys that `setUserSettingsInput` can write AND that the auth hub folds into the cached
+ * SessionUser (`apps/auth/src/lib/server/auth/session-shape.ts` — its `settingsSchema` reads
+ * `allowAds`, `redBrowsingLevel`, `isEarlyAdopter`). Writing one of these without busting
+ * `session:data2:{id}` leaves the session serving the old value for the rest of its 4h TTL.
+ * Keep this in sync with that schema; `redBrowsingLevel` is intentionally excluded because this
+ * endpoint cannot write it (see the gate below).
+ */
+const SESSION_PROJECTED_SETTING_KEYS = ['allowAds', 'isEarlyAdopter'] as const;
+
 export const setUserSettingHandler = async ({
   input,
   ctx,
@@ -1442,14 +1459,23 @@ export const setUserSettingHandler = async ({
     );
     if (metricPrivacyChanged) await queueModelMetricPrivacyReindex(id);
 
-    // `isEarlyAdopter` is the one settings key PROJECTED ONTO THE SESSION (auth hub
-    // `shapeSessionUser` → `SessionUser.isEarlyAdopter` → `buildFliptContext`), and the
-    // hub caches that projection in `session:data2:{id}` for 4h. Without this the toggle
-    // reads as instantly applied client-side (the `getSettings` cache is patched
-    // optimistically) while every Flipt evaluation keeps the OLD value until the cache
-    // expires — the toggle appears to do nothing. `refreshSession` busts that cache and
-    // signals the browser to re-pull. Awaited so the bust lands before the mutation
-    // returns; same reason `updateContentSettings` awaits its own call.
+    // Some settings keys are PROJECTED ONTO THE SESSION by the auth hub — `shapeSessionUser`
+    // reads `allowAds`, `redBrowsingLevel` and `isEarlyAdopter` out of `User.settings` and
+    // folds them into the SessionUser — and the hub caches that projection in
+    // `session:data2:{id}` for 4h. Without a bust the toggle reads as instantly applied
+    // client-side (the `getSettings` cache is patched optimistically) while every session
+    // read — and every Flipt evaluation built from it — keeps the OLD value until the entry
+    // expires: the toggle appears to do nothing. `refreshSession` busts that cache and
+    // signals the browser to re-pull. Awaited so the bust lands before the mutation returns;
+    // same reason `updateContentSettings` awaits its own call.
+    //
+    // 🔴 This used to name `isEarlyAdopter` as "the one settings key projected onto the
+    // session". It was not: `allowAds` is projected too and is writable through THIS
+    // endpoint's schema, so turning ads off left the session serving `allowAds: true` for up
+    // to 4h. The gate is a set now, so adding a projected key is one edit here rather than a
+    // silent re-introduction of the same bug (#4298's defect class).
+    // `redBrowsingLevel` is deliberately absent — it is not part of `setUserSettingsInput`;
+    // it is written by `updateContentSettings`, which performs its own bust.
     //
     // Gated on a CHANGE, not on key presence, and compared against `restInput` — the keys
     // THIS request sent — rather than against the stored blob. Mirrors the
@@ -1457,9 +1483,10 @@ export const setUserSettingHandler = async ({
     // whole blob, so a presence check on it would no longer fire on unrelated toggles the
     // way it did when this handler rewrote everything; the change comparison is still the
     // right test, because re-sending the value a user already holds is not a change.)
-    const earlyAdopterChanged =
-      'isEarlyAdopter' in restInput && restSettings.isEarlyAdopter !== restInput.isEarlyAdopter;
-    if (earlyAdopterChanged) await refreshSession(id, { caller: 'profile' });
+    const sessionProjectedSettingChanged = SESSION_PROJECTED_SETTING_KEYS.some(
+      (key) => key in restInput && restSettings[key] !== restInput[key]
+    );
+    if (sessionProjectedSettingChanged) await refreshSession(id, { caller: 'profile' });
 
     return newSettings;
   } catch (error) {


### PR DESCRIPTION
Closes #4298 — but not in the way the issue describes. Please read the first section before reviewing the diff.

## The reported mechanism is not what the code does

#4298 says the profile-picture update path never busts the hub's shaped session-user entry, so `user.image` stays stale for up to 4h. The chain is actually wired, and has been since the hub cutover:

```
updateUserHandler (user.update)
  └─ refreshSession
       └─ updateSessionState          ← unconditional, on both 'refresh' and 'invalid'
            └─ clearSessionCache
                 └─ sessionClient.invalidate(userId)
                      └─ POST {hub}/api/auth/identity  { userId }
                           └─ invalidateSessionUser → del session:data2:{userId}
```

The issue's evidence — "the only callers of `invalidateSessionUser` are inside the auth app; no main-app path calls it" — is true of the **function name** and false of the **effect**. The main app reaches it over HTTP, not by import, so grepping `src/` for the identifier finds nothing and reads as "nothing busts the cache". I made the same inference before tracing it.

I verified this rather than reasoning about it. The four avatar tests in this PR are **green against pristine `origin/main`**, and a mutation that deletes the bust from `clearSessionCache` turns all four red — so they can see the described defect, and the described defect is not present.

The second piece of evidence in the issue — the comment reading *"The shared session:data2 cache is NOT wiped — its 4h TTL bounds data staleness"* — is scoped to `invalidateAllSessions`, the **mass** path, where it is true and deliberate (a cluster-wide SCAN+del is not worth the freshness). It reads as a statement about the file's per-user paths, which do wipe it. That comment is corrected here; it is the proximate cause of the misdiagnosis.

### On the measurement in the issue

The measurements were taken on a preview environment, and the divergence there has a different cause than a TTL. `getServerAuthSession` already documents it in-tree (`src/server/auth/get-server-auth-session.ts`, the `getLegacySession` preview-fallback comment): a preview runs against a different database than the one the hub resolves identity from. So the profile page (preview's own DB, freshly written) and the session (hub-resolved) read from **two different stores** — they do not converge after 4h, or ever. That fits every row of the issue's table, including "the divergence persisted well past ingestion", better than TTL staleness does, and no cache bust can close it.

That does not make the underlying user report invalid — it means the preview measurement is not evidence for the production mechanism it was read as.

## What was actually broken

Enumerating the shaped SessionUser's fields (`apps/auth/.../session-shape.ts`) against their writers — rather than re-reading the avatar path — found two live instances of the defect class the issue names: **a handler whose bust gate is narrower than the set of session-carried fields it writes.**

**1. `user.setSettings` — `allowAds` (user-visible)**

The bust fired only when `isEarlyAdopter` changed, on the stated premise that it was *"the one settings key PROJECTED ONTO THE SESSION"*. It is not. The hub's `settingsSchema` reads three keys out of `User.settings` — `allowAds`, `redBrowsingLevel`, `isEarlyAdopter` — and `allowAds` is writable through this endpoint's own schema. Turning ads off therefore left the session, and every Flipt context built from it, serving `allowAds: true` for up to 4h.

The gate is now a named `SESSION_PROJECTED_SETTING_KEYS` set, so adding a projected key is one edit rather than a silent re-introduction. `redBrowsingLevel` is deliberately excluded — this endpoint cannot write it; `updateContentSettings` does, and busts on its own.

Reachability note: the live ads UI routes through `updateContentSettings` (which busts), so this was an API-reachable hole rather than a broken button in today's UI. It is still a real gap on a `UserWrite`-scoped mutation.

**2. `user.completeOnboarding` — Profile step**

The Profile step writes `username` and `email` **unconditionally**, but the bust was gated on the onboarding bitmask advancing. Re-submitting a step whose bit is already set changed the username in the database and left the old one in the session for the rest of its 4h TTL.

## Which option I chose, and what I rejected

The issue offered four directions. Given the above:

- **Option 2/3 (hub endpoint / shared package) is already the implemented architecture** — `@civitai/auth`'s `createSessionClient.invalidate` is the shared implementation, and `POST /api/auth/identity` is the hub endpoint. Nothing to build.
- **Option 1 (main app writes the hub-owned key directly)** — rejected as the primary path. It is already present as the *fallback* inside `clearSessionCache`, which is the right shape: the hub owns the key, the main app asks; the direct `del` only covers a hub blip, where busting a key the hub re-produces is safe from either side. Promoting it to primary would duplicate a hub-owned namespace in a second app for no gain. I did add a test pinning that fallback's hand-built string against the shared namespace constant, since it is a second spelling that can drift silently.
- **Option 4 (source the avatar from `profilePictureCache` instead)** — rejected. It forks `user.image` away from the single-producer architecture the hub cutover established, so the avatar would follow different invalidation rules from every other session field, and the 4h bound would remain wrong for the fields that genuinely need busting. It treats the symptom on one field.

**So the TTL-bounded staleness is left intact** — it is correct for slow-moving fields, and it is not what was broken. What is fixed is two gates that were narrower than their handlers' writes.

## Tests — the seam, not one side of it

Every existing suite is *structurally* blind to this relationship: `src/__tests__/setup.ts` globally stubs `~/server/auth/session-invalidation` down to a no-op `refreshSession`. A test written against that stub can assert the **call** but cannot distinguish a bust that addresses the right key from one that busts nothing, or the wrong key.

The new file `vi.unmock`s it and drives the real chain — `refreshSession → updateSessionState → clearSessionCache` — against a fake shared keyspace, asserting the **absence of the entry** rather than a call. The hub hop is stood in for by a fake whose key is derived from the shared `REDIS_KEYS.USER.SESSION` namespace, so a namespace drift between the two apps fails here.

### Matrix

`npx vitest run --project 'unit*' src/server/controllers/__tests__/user.controller.session-avatar-bust.test.ts` — **11 tests executed** both times:

| | result |
|---|---|
| pristine `origin/main` | **2 failed** \| 9 passed |
| this branch | **11 passed** |

The two reds at base are the two real gaps (`allowAds`; onboarding Profile re-submit), each `AssertionError: expected true to be false` — i.e. the session entry survived the write.

**Honest labelling:** the four *avatar* tests are green at base. They are an **invariant guard**, not a regression test — the avatar defect is not present, and mutation testing (below) is what demonstrates they would catch it. I have not counted them as regression coverage.

### Mutation checks

| mutation | result |
|---|---|
| remove the `session:data2` bust from `clearSessionCache` entirely (reproduces the defect #4298 describes) | **all 4** avatar tests red — 3 on `expected true to be false` (entry survived), 1 on the bust never firing |
| keep the hub call, drift **only** the fallback key namespace | **exactly 1** red — the test that pins the fallback. The other 3 stay green |

The second is the narrow one: it isolates a single expression and kills exactly the assertion that covers it, so the tests are independently reachable rather than all dying to one upstream failure.

### Wider verification

- `src/server/` unit suite: **14495 passed / 0 failed** (923 files, 1 skipped)
- `pnpm typecheck`: **0 type errors**
- `pnpm eslint` on the three changed files: **0 errors** (4 pre-existing warnings, all on lines this PR does not touch)

Note `isolate: true` is in force for the unit project, so the `vi.unmock` cannot leak into sibling files — that was checked, not assumed.

## Other session fields with the same window — reported, not fixed

I enumerated the full shaped SessionUser against its writers. Everything else is covered, with one low-severity exception:

- **`referral`** — `createUserReferral` at `src/server/auth/login-side-effects.ts:42` creates the `UserReferral` row with no bust. Only matters if the session entry was produced before the referral row landed. Not fixed here; happy to, in a follow-up, if you think it's worth the round trip.

Confirmed covered: `username`, `image`/`profilePicture`, `email`/`emailVerified`, `autoplayGifs`, `filePreferences`, `leaderboardShowcase` (all via `updateUserHandler`); `showNsfw`/`blurNsfw`/`browsingLevel`/`redBrowsingLevel` (via `updateBrowsingMode` and `updateContentSettings`); `onboarding`; `name`, `isModerator`, `muted`, `bannedAt`, `deletedAt`, `customerId`, `paddleCustomerId`, `tier`/`subscriptions` (moderation, billing and subscription paths, all bust). `roles` has no writer in `src/` — it is hub-owned.

`updateUserProfileHandler` / `updateUserProfile` write **nothing** on the shaped SessionUser (only `publicSettings.creatorCardStatsPreferences`, `UserLink` and `UserProfile` rows — the `User.image` / `leaderboardShowcase` writes there are commented out and moved to `updateUserHandler`). Its lack of a bust is correct, not a gap.

## Scope

Does not touch `src/components/CivitaiWrapped/AccountProvider.tsx`, so no overlap with #4260 or #4274. Branched directly off `main`, not stacked.

The roster in the account switcher resolves each linked account through the same shared cache (`getOrProduceSessionUser`), so it mirrors the session by construction — consistent with the issue's observation, and fixed by the same bust wherever the bust was missing.
