### PR TITLE
fix(sales): card badge shows the deepest sale, and /sales stops conflating two states

### DIFF
--- a/apps/creator-studio/src/routes/(app)/sales/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/sales/+page.svelte
@@ -19,7 +19,7 @@
   import SaleFields from '$lib/components/monetization/SaleFields.svelte';
   import { resolveSaleDraft, type SaleDraftInput } from '$lib/monetization/sales';
   import { isSaleActive, remainingSaleDays, type ModelVersionSaleWindow } from '@civitai/buzz';
-  import { budgetMonthOf, shortenBounds } from '$lib/monetization/sales';
+  import { budgetMonthOf, minCreatorScoreForSale, shortenBounds } from '$lib/monetization/sales';
   import type { PageData } from './$types';
 
   // Scheduled sales, listed and managed. Starting one lives on the Models tab, where the selection is;
@@ -168,6 +168,10 @@
       });
   });
 
+  // Three states share this page and read as one another otherwise: not switched on, switched on but
+  // under the score floor, and eligible with nothing scheduled. A tester read the first as the third.
+  const minScore = $derived(minCreatorScoreForSale(data.saleLimits));
+
   const draft = $derived(
     resolveSaleDraft(
       sale,
@@ -218,8 +222,18 @@
 
   {#if !data.salesEnabled}
     <p class="rounded-lg border border-dark-4 p-4 text-sm text-dark-2">
-      Scheduled sales aren't available on your account yet.
+      Scheduled sales aren't switched on for your account yet.
     </p>
+  {:else if data.creatorScore < minScore}
+    <div class="flex flex-col items-start gap-2 rounded-lg border border-dark-4 p-6">
+      <span class="text-sm font-medium text-white">
+        Scheduling a sale needs a creator score of {minScore.toLocaleString()}
+      </span>
+      <p class="text-sm text-dark-2">
+        You're at {data.creatorScore.toLocaleString()}. Score comes from followers, model usage and
+        engagement, so it climbs as people use what you publish.
+      </p>
+    </div>
   {:else if data.manageableSales.length === 0}
     <div class="flex flex-col items-start gap-2 rounded-lg border border-dark-4 p-6">
       <span class="text-sm font-medium text-white">No sales running or scheduled</span>

--- a/src/server/services/__tests__/paid-access.model-sales.service.test.ts
+++ b/src/server/services/__tests__/paid-access.model-sales.service.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as SubscriptionsService from '~/server/services/subscriptions.service';
+import { getCapTier } from '~/server/services/subscriptions.service';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 
 // The card badge runs on a raw $queryRaw that no other suite reaches: the sales-query suite drives the
@@ -8,6 +10,11 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
 // constants and redis/client have canonical mocks registered globally, so this file must not mock them
 // itself — a per-file mock of a shared module leaks into other files under --no-isolate. cache-helpers
 // is mocked deliberately: running lookupFn is the whole point here, and the canonical fake never calls it.
+vi.mock('~/server/services/subscriptions.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof SubscriptionsService>()),
+  getCapTier: vi.fn(async () => 'gold'),
+}));
+
 vi.mock('~/server/utils/cache-helpers', () => ({
   createCachedObject: ({
     lookupFn,
@@ -21,17 +28,23 @@ vi.mock('~/server/utils/cache-helpers', () => ({
 
 import { getActiveSalesForModels } from '~/server/services/paid-access.service';
 
+// The anchor is the capped price, so the owner's tier is an input. Gold is uncapped, which keeps the
+// fixtures below about the picker; the free-tier case gets its own test.
+const capTier = vi.mocked(getCapTier);
+
 const queryRaw = dbMock.dbRead.$queryRaw;
 
 let nextSaleId = 1;
 const row = (over: Record<string, unknown> = {}) => ({
   modelId: 7,
   saleId: nextSaleId++,
+  ownerId: 42,
+  baseModel: 'SDXL 1.0',
+  terms: { download: { price: 1000 } },
   startsAt: new Date('2026-03-01T00:00:00.000Z'),
   endsAt: new Date('2026-03-08T00:00:00.000Z'),
   discountType: 'Percent',
   discountAmount: 25,
-  anchorPrice: 1000,
   ...over,
 });
 
@@ -43,6 +56,8 @@ const sqlText = () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  nextSaleId = 1;
+  capTier.mockResolvedValue('gold');
   queryRaw.mockResolvedValue([]);
 });
 
@@ -91,12 +106,14 @@ describe('getActiveSalesForModels — the card badge', () => {
     expect(sql).toContain('s."canceledAt" IS NULL');
   });
 
+  // Every fixture below puts the expected winner FIRST. The cache kept the last row per model before
+  // this change, so a winner in last position is answered correctly by "keep whatever came last" too.
   it('badges the DEEPEST overlapping sale, not the one ending soonest', async () => {
     // Overlapping sales are legal (a sale crossing a month boundary meets the next month's) and the page
-    // charges the deepest. A card advertising the shallower one under-promises against its own model page.
+    // charges the deepest. A card advertising the shallower one under-promises against its own page.
     queryRaw.mockResolvedValue([
-      row({ endsAt: new Date('2026-03-04T00:00:00.000Z'), discountAmount: 10 }),
       row({ endsAt: new Date('2026-03-20T00:00:00.000Z'), discountAmount: 40 }),
+      row({ endsAt: new Date('2026-03-04T00:00:00.000Z'), discountAmount: 10 }),
     ]);
 
     const out = await getActiveSalesForModels([7], now);
@@ -109,13 +126,64 @@ describe('getActiveSalesForModels — the card badge', () => {
   });
 
   it('compares a percent against a fixed amount at the price, not against each other', async () => {
-    // 20% of 1000 is 200, so the 300 ⚡ sale is deeper despite the smaller-looking number.
+    // 50% of 1000 is 500, so the percent is the deeper of the two while carrying the SMALLER number.
+    // Comparing discountAmount alone picks the 300 Buzz sale and is wrong.
     queryRaw.mockResolvedValue([
-      row({ discountType: 'Percent', discountAmount: 20 }),
+      row({ discountType: 'Percent', discountAmount: 50 }),
       row({
         endsAt: new Date('2026-03-09T00:00:00.000Z'),
         discountType: 'Fixed',
         discountAmount: 300,
+      }),
+    ]);
+
+    const out = await getActiveSalesForModels([7], now);
+
+    expect(out[7]).toEqual({
+      endsAt: new Date('2026-03-08T00:00:00.000Z'),
+      discountType: 'Percent',
+      discountAmount: 50,
+    });
+  });
+
+  it('measures each sale against the price of the versions IT covers', async () => {
+    // Same discount type, so only the anchor separates them: 20% of 1000 is 200 and beats 40% of 100.
+    // Dropping anchorPrice from the comparison picks the 40.
+    queryRaw.mockResolvedValue([
+      row({ endsAt: new Date('2026-03-11T00:00:00.000Z'), discountAmount: 20 }),
+      row({ discountAmount: 40, terms: { download: { price: 100 } } }),
+    ]);
+
+    const out = await getActiveSalesForModels([7], now);
+
+    expect(out[7]).toEqual({
+      endsAt: new Date('2026-03-11T00:00:00.000Z'),
+      discountType: 'Percent',
+      discountAmount: 20,
+    });
+  });
+
+  it('badges nothing when the deepest active sale takes nothing off', async () => {
+    // A gate carrying no price: the page applies no discount, so the card must not claim one.
+    queryRaw.mockResolvedValue([row({ terms: { download: { price: 0 } } })]);
+
+    const out = await getActiveSalesForModels([7], now);
+
+    expect(out[7]).toBeUndefined();
+  });
+
+  it('anchors on the price a BUYER pays, not the price the creator stored', async () => {
+    // A lapsed creator's permanent gate is clamped to the free ceiling for buyers. Anchored on the
+    // stored 5000 the percent looks deeper (1000 vs 300); at the 500 a buyer actually pays it is 100,
+    // and the page charges the fixed sale. The card must name the same one.
+    capTier.mockResolvedValue(null);
+    queryRaw.mockResolvedValue([
+      row({ discountType: 'Percent', discountAmount: 20, terms: { download: { price: 5000 } } }),
+      row({
+        endsAt: new Date('2026-03-09T00:00:00.000Z'),
+        discountType: 'Fixed',
+        discountAmount: 300,
+        terms: { download: { price: 5000 } },
       }),
     ]);
 
@@ -128,10 +196,23 @@ describe('getActiveSalesForModels — the card badge', () => {
     });
   });
 
-  it('badges a running sale even when an unstarted one would sort ahead of it', async () => {
-    // The query bounds endsAt only, so a scheduled sale can be the soonest-ending row for the model.
-    // Collapsing to it in SQL and then dropping it on the start check left the card with no badge at
-    // all while a sale was genuinely running.
+  it('takes a sale at its dearest covered version, across the rows it spans', async () => {
+    // One sale, two covered versions: the 1000 one decides what the sale is worth, not the 100 one.
+    queryRaw.mockResolvedValue([
+      row({ saleId: 1, discountAmount: 30, terms: { download: { price: 100 } } }),
+      row({ saleId: 1, discountAmount: 30, terms: { download: { price: 1000 } } }),
+      row({ saleId: 2, endsAt: new Date('2026-03-14T00:00:00.000Z'), discountAmount: 25 }),
+    ]);
+
+    const out = await getActiveSalesForModels([7], now);
+
+    // 30% of 1000 beats 25% of 1000; anchoring sale 1 on its cheapest version would flip it.
+    expect(out[7]?.discountAmount).toBe(30);
+  });
+
+  it('badges a running sale even when an unstarted one is deeper', async () => {
+    // Lead time is up to 14 days and the query bounds endsAt only, so a scheduled sale reaches this
+    // function. It must lose to a running one however deep it is, and must not blank the badge.
     queryRaw.mockResolvedValue([
       row({
         startsAt: new Date('2026-03-05T00:00:00.000Z'),
@@ -150,14 +231,29 @@ describe('getActiveSalesForModels — the card badge', () => {
     });
   });
 
-  it('asks the database for the anchor price the deepest-wins pick needs', async () => {
+  it('keeps each model to its own sales when several are batched', async () => {
+    queryRaw.mockResolvedValue([
+      row({ discountAmount: 15 }),
+      row({ modelId: 9, endsAt: new Date('2026-03-12T00:00:00.000Z'), discountAmount: 35 }),
+    ]);
+
+    const out = await getActiveSalesForModels([7, 9], now);
+
+    expect(out[7]?.discountAmount).toBe(15);
+    expect(out[9]?.discountAmount).toBe(35);
+  });
+
+  it('asks the database for the raw terms the anchor is computed from', async () => {
     await getActiveSalesForModels([7], now);
 
     const sql = sqlText();
-    expect(sql).toContain(`terms->'download'->>'price'`);
-    expect(sql).toContain(`terms->'generation'->>'price'`);
-    // One row per (model, sale): collapsing in SQL would decide "deepest" before the price is known.
-    expect(sql).toContain('GROUP BY mv."modelId", s.id');
+    // Prices come back as raw terms and are read in JS: a jsonb `::int` hard-errors the whole batch on
+    // a fractional price, which nothing at the write boundary rejects.
+    expect(sql).toContain('pa.terms AS "terms"');
+    expect(sql).toContain('m."userId" AS "ownerId"');
+    expect(sql).not.toContain('::int');
+    // Collapsing per model in SQL decides "deepest" before the price is known - the bug this replaced.
+    expect(sql).not.toContain('DISTINCT ON');
   });
 
   it('never queries at all for an empty id list', async () => {

--- a/src/server/services/__tests__/paid-access.model-sales.service.test.ts
+++ b/src/server/services/__tests__/paid-access.model-sales.service.test.ts
@@ -23,12 +23,15 @@ import { getActiveSalesForModels } from '~/server/services/paid-access.service';
 
 const queryRaw = dbMock.dbRead.$queryRaw;
 
+let nextSaleId = 1;
 const row = (over: Record<string, unknown> = {}) => ({
   modelId: 7,
+  saleId: nextSaleId++,
   startsAt: new Date('2026-03-01T00:00:00.000Z'),
   endsAt: new Date('2026-03-08T00:00:00.000Z'),
   discountType: 'Percent',
   discountAmount: 25,
+  anchorPrice: 1000,
   ...over,
 });
 
@@ -86,6 +89,75 @@ describe('getActiveSalesForModels — the card badge', () => {
     expect(sql).toContain('pa."timeframeDays" IS NULL');
     expect(sql).toContain(`mv.status = 'Published'`);
     expect(sql).toContain('s."canceledAt" IS NULL');
+  });
+
+  it('badges the DEEPEST overlapping sale, not the one ending soonest', async () => {
+    // Overlapping sales are legal (a sale crossing a month boundary meets the next month's) and the page
+    // charges the deepest. A card advertising the shallower one under-promises against its own model page.
+    queryRaw.mockResolvedValue([
+      row({ endsAt: new Date('2026-03-04T00:00:00.000Z'), discountAmount: 10 }),
+      row({ endsAt: new Date('2026-03-20T00:00:00.000Z'), discountAmount: 40 }),
+    ]);
+
+    const out = await getActiveSalesForModels([7], now);
+
+    expect(out[7]).toEqual({
+      endsAt: new Date('2026-03-20T00:00:00.000Z'),
+      discountType: 'Percent',
+      discountAmount: 40,
+    });
+  });
+
+  it('compares a percent against a fixed amount at the price, not against each other', async () => {
+    // 20% of 1000 is 200, so the 300 ⚡ sale is deeper despite the smaller-looking number.
+    queryRaw.mockResolvedValue([
+      row({ discountType: 'Percent', discountAmount: 20 }),
+      row({
+        endsAt: new Date('2026-03-09T00:00:00.000Z'),
+        discountType: 'Fixed',
+        discountAmount: 300,
+      }),
+    ]);
+
+    const out = await getActiveSalesForModels([7], now);
+
+    expect(out[7]).toEqual({
+      endsAt: new Date('2026-03-09T00:00:00.000Z'),
+      discountType: 'Fixed',
+      discountAmount: 300,
+    });
+  });
+
+  it('badges a running sale even when an unstarted one would sort ahead of it', async () => {
+    // The query bounds endsAt only, so a scheduled sale can be the soonest-ending row for the model.
+    // Collapsing to it in SQL and then dropping it on the start check left the card with no badge at
+    // all while a sale was genuinely running.
+    queryRaw.mockResolvedValue([
+      row({
+        startsAt: new Date('2026-03-05T00:00:00.000Z'),
+        endsAt: new Date('2026-03-06T00:00:00.000Z'),
+        discountAmount: 50,
+      }),
+      row({ discountAmount: 15 }),
+    ]);
+
+    const out = await getActiveSalesForModels([7], now);
+
+    expect(out[7]).toEqual({
+      endsAt: new Date('2026-03-08T00:00:00.000Z'),
+      discountType: 'Percent',
+      discountAmount: 15,
+    });
+  });
+
+  it('asks the database for the anchor price the deepest-wins pick needs', async () => {
+    await getActiveSalesForModels([7], now);
+
+    const sql = sqlText();
+    expect(sql).toContain(`terms->'download'->>'price'`);
+    expect(sql).toContain(`terms->'generation'->>'price'`);
+    // One row per (model, sale): collapsing in SQL would decide "deepest" before the price is known.
+    expect(sql).toContain('GROUP BY mv."modelId", s.id');
   });
 
   it('never queries at all for an empty id list', async () => {

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -241,7 +241,10 @@ type CachedModelSale = {
 // the price this is only a label — the charge never reads it.
 function createModelSaleCache() {
   return createCachedObject<CachedModelSale>({
-    key: `${REDIS_KEYS.CACHES.PAID_ACCESS}:ModelSales`,
+    // v2: the value shape changed from one window to a list of them. An entry written by the previous
+    // build is a cache HIT that reads as no sales, so the key moves with the shape rather than serving a
+    // minute of missing badges after a deploy.
+    key: `${REDIS_KEYS.CACHES.PAID_ACCESS}:ModelSales:v2`,
     idKey: 'modelId',
     ttl: CacheTTL.xs,
     staleWhileRevalidate: false,
@@ -258,31 +261,38 @@ function modelSaleCache() {
   return (modelSaleCacheInstance ??= createModelSaleCache());
 }
 
+/** The price a sale is resolved against: whichever chargeable tier this gate actually has. */
+const saleAnchorPrice = (terms: ModelVersionTerms | undefined): number => {
+  const { download, generation } = gatePrices(terms);
+  return Math.max(download, generation);
+};
+
 async function querySalesForModels(modelIds: number[]): Promise<CachedModelSale[]> {
   if (!modelIds.length) return [];
   const now = new Date();
-  // One row per (model, sale), not per model: overlapping sales are legal and the deepest of them wins,
-  // which is a decision the cached window cannot make for itself because "deepest" moves with the price.
-  // The anchor mirrors saleAnchorPrice — the dearer of the two gate prices — taken across the versions
-  // this sale covers on this model.
+  // One row per (model, sale, covered version), not per model: overlapping sales are legal and the
+  // deepest of them wins, which is a decision the cached window cannot make for itself because "deepest"
+  // moves with the price. Prices come back as raw terms and are read in JS — `gatePrices` owns the shape,
+  // and a jsonb `::int` in SQL would hard-error the whole batch on a fractional price the write path
+  // never rejected.
   const rows = await dbRead.$queryRaw<
     {
       modelId: number;
       saleId: number;
+      ownerId: number;
+      baseModel: string | null;
+      terms: unknown;
       startsAt: Date;
       endsAt: Date;
       discountType: SaleDiscountKind;
       discountAmount: number;
-      anchorPrice: number;
     }[]
   >`
     SELECT
-      mv."modelId" AS "modelId", s.id AS "saleId", s."startsAt" AS "startsAt", s."endsAt" AS "endsAt",
-      s."discountType" AS "discountType", s."discountAmount" AS "discountAmount",
-      MAX(GREATEST(
-        COALESCE((pa.terms->'download'->>'price')::int, 0),
-        COALESCE((pa.terms->'generation'->>'price')::int, 0)
-      )) AS "anchorPrice"
+      mv."modelId" AS "modelId", s.id AS "saleId", m."userId" AS "ownerId",
+      mv."baseModel" AS "baseModel", pa.terms AS "terms",
+      s."startsAt" AS "startsAt", s."endsAt" AS "endsAt",
+      s."discountType" AS "discountType", s."discountAmount" AS "discountAmount"
     FROM "ModelVersionSaleItem" si
     JOIN "ModelVersionSale" s ON s.id = si."saleId"
     JOIN "ModelVersion" mv ON mv.id = si."modelVersionId"
@@ -294,21 +304,40 @@ async function querySalesForModels(modelIds: number[]): Promise<CachedModelSale[
       AND s."userId" = m."userId"
       AND s."endsAt" > ${now}
       AND (s."canceledAt" IS NULL OR s."canceledAt" > ${now})
-    GROUP BY mv."modelId", s.id, s."startsAt", s."endsAt", s."discountType", s."discountAmount"
     ORDER BY mv."modelId", s."endsAt"
   `;
+  // The CAPPED price, not the stored one — the same anchor getViewerMonetization resolves against. A
+  // lapsed creator's stored price can be many times what a buyer is charged, and anchoring on it lets the
+  // card name one sale while the page charges another.
+  const capTiers = await getCapTiers(rows.map((r) => Number(r.ownerId)));
   const byModel = new Map<number, CachedModelSale>();
   for (const r of rows) {
     const modelId = Number(r.modelId);
+    const saleId = Number(r.saleId);
+    const terms = (r.terms ?? undefined) as ModelVersionTerms | undefined;
+    const anchorPrice = terms
+      ? saleAnchorPrice(
+          cappedTerms(terms, capTiers.get(Number(r.ownerId)) ?? null, {
+            permanent: true,
+            mediaType: capMediaType(r.baseModel),
+          })
+        )
+      : 0;
     const entry = byModel.get(modelId) ?? { modelId, sales: [] };
-    entry.sales.push({
-      saleId: Number(r.saleId),
-      startsAtMs: r.startsAt.getTime(),
-      endsAtMs: r.endsAt.getTime(),
-      discountType: r.discountType,
-      discountAmount: r.discountAmount,
-      anchorPrice: Number(r.anchorPrice ?? 0),
-    });
+    const existing = entry.sales.find((sale) => sale.saleId === saleId);
+    if (existing) {
+      // A sale covers many versions of one model; it is worth whatever its dearest covered version is.
+      existing.anchorPrice = Math.max(existing.anchorPrice, anchorPrice);
+    } else {
+      entry.sales.push({
+        saleId,
+        startsAtMs: r.startsAt.getTime(),
+        endsAtMs: r.endsAt.getTime(),
+        discountType: r.discountType,
+        discountAmount: r.discountAmount,
+        anchorPrice,
+      });
+    }
     byModel.set(modelId, entry);
   }
   return [...byModel.values()];
@@ -344,7 +373,10 @@ export async function getActiveSalesForModels(
         discountType: sale.discountType,
         discountAmount: sale.discountAmount,
       });
-      if (!best || off > bestOff) {
+      // `off > bestOff` with bestOff starting at 0, exactly as bestSaleFor does it: a sale that takes
+      // nothing off (a gate carrying no price) badges nothing, rather than the card advertising a
+      // discount the page does not apply.
+      if (off > bestOff) {
         best = sale;
         bestOff = off;
       }
@@ -492,12 +524,6 @@ const isOwnerOrModView = (viewer: PaidAccessViewer, ownerId: number) =>
 const hasChargeablePrice = (terms: PaidAccessTerms | undefined) => {
   const { download, generation } = gatePrices(terms as ModelVersionTerms | undefined);
   return download > 0 || generation > 0;
-};
-
-/** The price a sale is resolved against: whichever chargeable tier this gate actually has. */
-const saleAnchorPrice = (terms: ModelVersionTerms | undefined): number => {
-  const { download, generation } = gatePrices(terms);
-  return Math.max(download, generation);
 };
 
 export type ViewerMonetization = {

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -6,6 +6,7 @@ import {
   effectiveLicensingFee,
   gatePrices,
   bestSaleFor,
+  saleDiscountFor,
   discountedTerms,
   type ModelVersionSaleWindow,
   type SaleDiscountKind,
@@ -205,7 +206,7 @@ function paidAccessCache(entityType: PaidAccessEntityType) {
 }
 
 /**
- * Which of these models currently have a sale running, and when the soonest one ends.
+ * Which of these models currently have a sale running, and the deepest one.
  *
  * Fetched separately from the models themselves. The feed query has several FROM variants and is a hot
  * path, and a sale is time-varying data that would have to be re-indexed at every window edge to ride
@@ -215,12 +216,23 @@ function paidAccessCache(entityType: PaidAccessEntityType) {
  * Same predicate as the resolver, for the same reasons: permanent gates only (a timed early-access
  * window is never discounted), and the sale's author must own the model.
  */
-type CachedModelSale = {
-  modelId: number;
+type CachedModelSaleWindow = {
+  saleId: number;
   startsAtMs: number;
   endsAtMs: number;
   discountType: SaleDiscountKind;
   discountAmount: number;
+  /**
+   * The dearest covered price on this model, which is what the discount is measured against. A percent
+   * and a fixed amount have no order until you know the price they apply to, so the deepest-wins pick
+   * cannot be made without it.
+   */
+  anchorPrice: number;
+};
+
+type CachedModelSale = {
+  modelId: number;
+  sales: CachedModelSaleWindow[];
 };
 
 // Same bucket-per-entity pattern as the other model-side caches, and the same rule as the gate cache:
@@ -249,18 +261,28 @@ function modelSaleCache() {
 async function querySalesForModels(modelIds: number[]): Promise<CachedModelSale[]> {
   if (!modelIds.length) return [];
   const now = new Date();
+  // One row per (model, sale), not per model: overlapping sales are legal and the deepest of them wins,
+  // which is a decision the cached window cannot make for itself because "deepest" moves with the price.
+  // The anchor mirrors saleAnchorPrice — the dearer of the two gate prices — taken across the versions
+  // this sale covers on this model.
   const rows = await dbRead.$queryRaw<
     {
       modelId: number;
+      saleId: number;
       startsAt: Date;
       endsAt: Date;
       discountType: SaleDiscountKind;
       discountAmount: number;
+      anchorPrice: number;
     }[]
   >`
-    SELECT DISTINCT ON (mv."modelId")
-      mv."modelId" AS "modelId", s."startsAt" AS "startsAt", s."endsAt" AS "endsAt",
-      s."discountType" AS "discountType", s."discountAmount" AS "discountAmount"
+    SELECT
+      mv."modelId" AS "modelId", s.id AS "saleId", s."startsAt" AS "startsAt", s."endsAt" AS "endsAt",
+      s."discountType" AS "discountType", s."discountAmount" AS "discountAmount",
+      MAX(GREATEST(
+        COALESCE((pa.terms->'download'->>'price')::int, 0),
+        COALESCE((pa.terms->'generation'->>'price')::int, 0)
+      )) AS "anchorPrice"
     FROM "ModelVersionSaleItem" si
     JOIN "ModelVersionSale" s ON s.id = si."saleId"
     JOIN "ModelVersion" mv ON mv.id = si."modelVersionId"
@@ -272,15 +294,24 @@ async function querySalesForModels(modelIds: number[]): Promise<CachedModelSale[
       AND s."userId" = m."userId"
       AND s."endsAt" > ${now}
       AND (s."canceledAt" IS NULL OR s."canceledAt" > ${now})
+    GROUP BY mv."modelId", s.id, s."startsAt", s."endsAt", s."discountType", s."discountAmount"
     ORDER BY mv."modelId", s."endsAt"
   `;
-  return rows.map((r) => ({
-    modelId: Number(r.modelId),
-    startsAtMs: r.startsAt.getTime(),
-    endsAtMs: r.endsAt.getTime(),
-    discountType: r.discountType,
-    discountAmount: r.discountAmount,
-  }));
+  const byModel = new Map<number, CachedModelSale>();
+  for (const r of rows) {
+    const modelId = Number(r.modelId);
+    const entry = byModel.get(modelId) ?? { modelId, sales: [] };
+    entry.sales.push({
+      saleId: Number(r.saleId),
+      startsAtMs: r.startsAt.getTime(),
+      endsAtMs: r.endsAt.getTime(),
+      discountType: r.discountType,
+      discountAmount: r.discountAmount,
+      anchorPrice: Number(r.anchorPrice ?? 0),
+    });
+    byModel.set(modelId, entry);
+  }
+  return [...byModel.values()];
 }
 
 export async function getActiveSalesForModels(
@@ -297,14 +328,32 @@ export async function getActiveSalesForModels(
   > = {};
   for (const row of Object.values(cached)) {
     if (!row) continue;
-    // BOTH edges, evaluated per request against the cached window. Without the start bound a sale
-    // scheduled up to MAX_SALE_LEAD_DAYS out was badged from the moment it was saved, while the model
-    // page and the charge correctly showed full price — the one thing the spec says must never happen.
-    if (row.startsAtMs > now.getTime() || row.endsAtMs <= now.getTime()) continue;
+    let best: CachedModelSaleWindow | undefined;
+    let bestOff = 0;
+    for (const sale of row.sales ?? []) {
+      // BOTH edges, evaluated per request against the cached window. Without the start bound a sale
+      // scheduled up to MAX_SALE_LEAD_DAYS out was badged from the moment it was saved, while the model
+      // page and the charge correctly showed full price — the one thing the spec says must never happen.
+      if (sale.startsAtMs > now.getTime() || sale.endsAtMs <= now.getTime()) continue;
+      // Deepest wins, the same rule bestSaleFor applies on the page. Per sale rather than once for the
+      // model, because each carries the anchor of the versions it covers.
+      const off = saleDiscountFor(sale.anchorPrice, {
+        id: sale.saleId,
+        startsAt: new Date(sale.startsAtMs),
+        endsAt: new Date(sale.endsAtMs),
+        discountType: sale.discountType,
+        discountAmount: sale.discountAmount,
+      });
+      if (!best || off > bestOff) {
+        best = sale;
+        bestOff = off;
+      }
+    }
+    if (!best) continue;
     out[row.modelId] = {
-      endsAt: new Date(row.endsAtMs),
-      discountType: row.discountType,
-      discountAmount: row.discountAmount,
+      endsAt: new Date(best.endsAtMs),
+      discountType: best.discountType,
+      discountAmount: best.discountAmount,
     };
   }
   return out;


### PR DESCRIPTION
Two follow-ups from the scheduled-sales tester round. Justin's calls on both.

## The card badge picked the wrong sale

`querySalesForModels` collapsed with `DISTINCT ON (modelId) ... ORDER BY endsAt`, so with two overlapping sales the card advertised whichever ended first. Overlapping sales are legal (a sale crossing a month boundary meets the next month's, both spent their own budget) and the model page charges the deepest, so a card could promise 10% off a model its own page sells at 40% off.

Percent and fixed have no order until you know the price they apply to — the reason `bestSaleFor` takes one. So the query now returns one row per (model, sale) with the dearest covered gate price as an anchor, and `getActiveSalesForModels` runs `saleDiscountFor` per candidate at request time and keeps the deepest. Same rule as the page, applied to the same numbers.

**Second bug, same code, found while reading it:** the `WHERE` bounds `endsAt` only. A sale scheduled up to 14 days out could therefore be the soonest-ending row for a model, win the collapse in SQL, and then be dropped by the per-request start check — leaving the card with *no* badge while a different sale was genuinely running. Not collapsing in SQL fixes it; there's a test.

## /sales said one thing and meant two

`Scheduled sales aren't available on your account yet.` fired purely on the flag, while the empty state sat in a separate branch below it. A tester read it as "you have no sales yet" and asked which it was. Three states now:

- not switched on for the account
- switched on, but under the creator score floor — names the floor and their current score
- eligible with nothing scheduled (the existing empty state)

## Verification

- New tests: deepest wins over soonest-ending; a fixed amount beating a percent at the price; a running sale badged when an unstarted one would sort ahead; and the SQL assertions for the anchor and the per-sale grouping
- Positive control: reverting the picker to first-active fails two of them. The four pre-existing predicate/window tests still pass
- `pnpm run typecheck` clean, `svelte-check` 0 errors 0 warnings, apps suite 868 passed, full unit suite 20,907 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)