### PR TITLE
chore(hubs): one invalidation set, one visibility rule, and scope assertions

### DIFF
--- a/src/components/Filters/FeedFilters/HubFeedFilters.tsx
+++ b/src/components/Filters/FeedFilters/HubFeedFilters.tsx
@@ -8,6 +8,7 @@ import { FilterButton } from '~/components/Buttons/FilterButton';
 import classes from '~/components/Filters/FeedFilters/FeedFilters.module.scss';
 import { SortFilter } from '~/components/Filters/SortFilter';
 import { buildHubFilterSave } from '~/components/Hubs/hub-filter-save';
+import { useInvalidateHub } from '~/components/Hubs/hub.utils';
 import { useHubSort } from '~/components/Hubs/useHubSort';
 import { hubExcludedFilterKeys } from '~/components/Image/Filters/media-filter-keys';
 import { MediaFiltersDropdown } from '~/components/Image/Filters/MediaFiltersDropdown';
@@ -41,7 +42,7 @@ export function HubFeedFilters({ ...groupProps }: GroupProps) {
   const router = useRouter();
   const hubId = Number(router.query.id);
   const [sourcesOpen, setSourcesOpen] = useState(false);
-  const utils = trpc.useUtils();
+  const invalidateHub = useInvalidateHub();
 
   const { data: hub } = trpc.userHub.getById.useQuery(
     { id: hubId },
@@ -50,12 +51,7 @@ export function HubFeedFilters({ ...groupProps }: GroupProps) {
   const sort = useHubSort(hub?.sort);
 
   const upsert = trpc.userHub.upsert.useMutation({
-    onSuccess: async () => {
-      await utils.userHub.getById.invalidate({ id: hubId });
-      // Scoped to this hub: an unkeyed invalidate refetches every mounted
-      // image.getInfinite query, not only the feed behind this filter.
-      await utils.image.getInfinite.invalidate({ hubId });
-    },
+    onSuccess: () => invalidateHub(hubId),
     onError: (error) =>
       showErrorNotification({ title: 'Could not save hub', error: new Error(error.message) }),
   });

--- a/src/components/Hubs/AddToHubModal.tsx
+++ b/src/components/Hubs/AddToHubModal.tsx
@@ -12,47 +12,38 @@ import {
 } from '@mantine/core';
 import { useState } from 'react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
+import { useInvalidateHub } from '~/components/Hubs/hub.utils';
+import type { AddUserHubSourceInput } from '~/server/schema/user-hub.schema';
 import { hubLimits } from '~/server/schema/user-hub.schema';
-import type { UserHubSourceType } from '~/shared/utils/prisma/enums';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
-type HubSourceTarget = {
-  type: UserHubSourceType;
-  targetId: number;
-  alias?: string | null;
-};
-
-export default function AddToHubModal({ source }: { source: HubSourceTarget }) {
+export default function AddToHubModal({
+  source,
+}: {
+  source: Omit<AddUserHubSourceInput, 'hubId'>;
+}) {
   const dialog = useDialogContext();
-  const utils = trpc.useUtils();
+  const invalidateHub = useInvalidateHub();
   const [name, setName] = useState('');
 
   const { data: hubs, isLoading } = trpc.userHub.getAll.useQuery();
-
-  const invalidate = async (hubId: number) => {
-    await Promise.all([
-      utils.userHub.getAll.invalidate(),
-      utils.userHub.getById.invalidate({ id: hubId }),
-    ]);
-    await utils.image.getInfinite.invalidate({ hubId });
-  };
 
   const onError = (title: string) => (error: { message: string }) =>
     showErrorNotification({ title, error: new Error(error.message) });
 
   const addSource = trpc.userHub.addSource.useMutation({
-    onSuccess: (_, variables) => invalidate(variables.hubId),
+    onSuccess: (_, variables) => invalidateHub(variables.hubId),
     onError: onError('Could not add to hub'),
   });
   const removeSource = trpc.userHub.removeSource.useMutation({
-    onSuccess: (_, variables) => invalidate(variables.hubId),
+    onSuccess: (_, variables) => invalidateHub(variables.hubId),
     onError: onError('Could not remove from hub'),
   });
   const createHub = trpc.userHub.upsert.useMutation({
     onSuccess: async (hub) => {
       setName('');
-      await invalidate(hub.id);
+      await invalidateHub(hub.id);
     },
     onError: onError('Could not create hub'),
   });

--- a/src/components/Hubs/HubSourcePanel.tsx
+++ b/src/components/Hubs/HubSourcePanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { HubSourceValue } from '~/components/Hubs/HubSourceEditor';
 import { HubSourceEditor } from '~/components/Hubs/HubSourceEditor';
+import { useInvalidateHub } from '~/components/Hubs/hub.utils';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -15,19 +16,13 @@ export function HubSourcePanel({
   maxSources: number;
   hideAdd?: boolean;
 }) {
-  const utils = trpc.useUtils();
+  const invalidateHub = useInvalidateHub();
   const [pending, setPending] = useState<HubSourceValue[] | null>(null);
   const current = pending ?? sources;
 
   const upsert = trpc.userHub.upsert.useMutation({
     onSuccess: async () => {
-      await Promise.all([
-        utils.userHub.getById.invalidate({ id: hubId }),
-        utils.userHub.getAll.invalidate(),
-      ]);
-      // The feed is keyed on hubId, not on the source list, so it will not refetch
-      // on its own when the sources behind it change.
-      await utils.image.getInfinite.invalidate({ hubId });
+      await invalidateHub(hubId);
       setPending(null);
     },
     onError: (error) => {

--- a/src/components/Hubs/HubUpsertModal.tsx
+++ b/src/components/Hubs/HubUpsertModal.tsx
@@ -29,8 +29,10 @@ export default function HubUpsertModal({
 
   const upsert = trpc.userHub.upsert.useMutation({
     onSuccess: async (saved) => {
-      await invalidateHub(saved.id);
+      // Closed first: invalidating the feed waits on its refetch, and nothing this
+      // modal saves is something the feed reads.
       dialog.onClose();
+      await invalidateHub(saved.id);
       if (!editing) await router.push(`/hubs/${saved.id}`);
     },
     onError: (error) =>

--- a/src/components/Hubs/HubUpsertModal.tsx
+++ b/src/components/Hubs/HubUpsertModal.tsx
@@ -6,6 +6,7 @@ import type { HubSourceValue } from '~/components/Hubs/HubSourceEditor';
 import { HubSourceEditor } from '~/components/Hubs/HubSourceEditor';
 import { useSortAvailability } from '~/components/Filters/useSortAvailability';
 import { defaultHubSort } from '~/components/Hubs/hub-sort';
+import { useInvalidateHub } from '~/components/Hubs/hub.utils';
 import { hubLimits } from '~/server/schema/user-hub.schema';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -18,7 +19,7 @@ export default function HubUpsertModal({
 }) {
   const dialog = useDialogContext();
   const router = useRouter();
-  const utils = trpc.useUtils();
+  const invalidateHub = useInvalidateHub();
   const editing = !!hub;
   const defaultSort = defaultHubSort(useSortAvailability());
 
@@ -28,10 +29,7 @@ export default function HubUpsertModal({
 
   const upsert = trpc.userHub.upsert.useMutation({
     onSuccess: async (saved) => {
-      await Promise.all([
-        utils.userHub.getAll.invalidate(),
-        utils.userHub.getById.invalidate({ id: saved.id }),
-      ]);
+      await invalidateHub(saved.id);
       dialog.onClose();
       if (!editing) await router.push(`/hubs/${saved.id}`);
     },

--- a/src/components/Hubs/hub.utils.ts
+++ b/src/components/Hubs/hub.utils.ts
@@ -1,24 +1,17 @@
 import { trpc } from '~/utils/trpc';
 
 /**
- * The caches every hub write moves. The feed is keyed on hubId, not on the source
- * list, so it will not refetch on its own when the sources behind it change — which
- * is the key each call site had been forgetting one at a time.
- *
- * `hubId` is omitted only when the write's target is unknown (a failed create).
+ * The image feed's query key carries `hubId`, not the source list, so it does not
+ * refetch on its own when a hub's sources change.
  */
 export function useInvalidateHub() {
   const utils = trpc.useUtils();
 
-  return async (hubId?: number) => {
+  return async (hubId: number) => {
     await Promise.all([
       utils.userHub.getAll.invalidate(),
-      ...(hubId != null
-        ? [
-            utils.userHub.getById.invalidate({ id: hubId }),
-            utils.image.getInfinite.invalidate({ hubId }),
-          ]
-        : []),
+      utils.userHub.getById.invalidate({ id: hubId }),
+      utils.image.getInfinite.invalidate({ hubId }),
     ]);
   };
 }

--- a/src/components/Hubs/hub.utils.ts
+++ b/src/components/Hubs/hub.utils.ts
@@ -1,0 +1,24 @@
+import { trpc } from '~/utils/trpc';
+
+/**
+ * The caches every hub write moves. The feed is keyed on hubId, not on the source
+ * list, so it will not refetch on its own when the sources behind it change — which
+ * is the key each call site had been forgetting one at a time.
+ *
+ * `hubId` is omitted only when the write's target is unknown (a failed create).
+ */
+export function useInvalidateHub() {
+  const utils = trpc.useUtils();
+
+  return async (hubId?: number) => {
+    await Promise.all([
+      utils.userHub.getAll.invalidate(),
+      ...(hubId != null
+        ? [
+            utils.userHub.getById.invalidate({ id: hubId }),
+            utils.image.getInfinite.invalidate({ hubId }),
+          ]
+        : []),
+    ]);
+  };
+}

--- a/src/server/routers/__tests__/user-hub.router.gate.test.ts
+++ b/src/server/routers/__tests__/user-hub.router.gate.test.ts
@@ -135,6 +135,10 @@ describe('every hub procedure declares the scope it needs', () => {
     const scope = requiredScopes[name];
 
     it(`${name} accepts a token scoped to exactly what it declares`, async () => {
+      // Without this, a procedure missing from the map calls `caller` with
+      // undefined, which defaults to Full and passes both of these for free.
+      expect(scope).toBeDefined();
+
       await expect(caller(scope, 999)[name](inputs[name])).resolves.not.toThrow();
     });
 

--- a/src/server/routers/__tests__/user-hub.router.gate.test.ts
+++ b/src/server/routers/__tests__/user-hub.router.gate.test.ts
@@ -54,13 +54,13 @@ const procedureNames = Object.keys(
   (userHubRouter as unknown as { _def: { procedures: Record<string, unknown> } })._def.procedures
 );
 
-const caller = () =>
+const caller = (tokenScope: number = TokenScope.Full, apiKeyId: number | null = null) =>
   userHubRouter.createCaller({
     user: { id: 7, isModerator: false },
     ip: '1.2.3.4',
     acceptableOrigin: true,
-    tokenScope: TokenScope.Full,
-    apiKeyId: null,
+    tokenScope,
+    apiKeyId,
     features: {},
   } as never) as unknown as Record<string, (input?: unknown) => Promise<unknown>>;
 
@@ -90,6 +90,58 @@ describe('every hub procedure is behind the userHubs flag', () => {
       getFeatureFlagsMock.mockReturnValue({ userHubs: true });
 
       await expect(caller()[name](inputs[name])).resolves.not.toThrow();
+    });
+  }
+});
+
+/**
+ * The scope gate, which the suite above cannot see: its caller carries
+ * `TokenScope.Full`, and `enforceTokenScope` skips the check outright for Full. So
+ * deleting `.meta({ requiredScope })` from a hub procedure — which downgrades it to
+ * the implicit Full requirement, locking every scoped token out — passes every test
+ * above, and so does swapping a write procedure's scope for the read one.
+ *
+ * Hubs have no scope of their own; they ride on `UserRead` / `UserWrite`. The map is
+ * written out by hand rather than read off the router, because a map derived from
+ * `.meta()` asserts the router against itself and passes whatever it says.
+ */
+const requiredScopes: Record<string, number> = {
+  getAll: TokenScope.UserRead,
+  getById: TokenScope.UserRead,
+  sourceSuggestions: TokenScope.UserRead,
+  resolveSource: TokenScope.UserRead,
+  upsert: TokenScope.UserWrite,
+  addSource: TokenScope.UserWrite,
+  removeSource: TokenScope.UserWrite,
+  delete: TokenScope.UserWrite,
+  setOrder: TokenScope.UserWrite,
+};
+
+// `UserRead` and `UserWrite` are independent bits, so each is the other's negative
+// control: a read-scoped token must be refused every write procedure and vice versa.
+const otherScope = (scope: number) =>
+  scope === TokenScope.UserRead ? TokenScope.UserWrite : TokenScope.UserRead;
+
+describe('every hub procedure declares the scope it needs', () => {
+  beforeEach(() => {
+    getFeatureFlagsMock.mockReturnValue({ userHubs: true });
+  });
+
+  it('covers every procedure the router actually exposes', () => {
+    expect(procedureNames.slice().sort()).toEqual(Object.keys(requiredScopes).sort());
+  });
+
+  for (const name of procedureNames) {
+    const scope = requiredScopes[name];
+
+    it(`${name} accepts a token scoped to exactly what it declares`, async () => {
+      await expect(caller(scope, 999)[name](inputs[name])).resolves.not.toThrow();
+    });
+
+    it(`${name} refuses a token carrying only the other user scope`, async () => {
+      await expect(caller(otherScope(scope), 999)[name](inputs[name])).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+      });
     });
   }
 });

--- a/src/server/routers/user-hub.router.ts
+++ b/src/server/routers/user-hub.router.ts
@@ -48,7 +48,13 @@ export const userHubRouter = router({
   sourceSuggestions: userHubProcedure
     .meta({ requiredScope: TokenScope.UserRead })
     .input(getHubSourceSuggestionsSchema)
-    .query(({ input, ctx }) => getHubSourceSuggestions({ ...input, userId: ctx.user.id })),
+    .query(({ input, ctx }) =>
+      getHubSourceSuggestions({
+        ...input,
+        userId: ctx.user.id,
+        isModerator: ctx.user.isModerator,
+      })
+    ),
   resolveSource: userHubProcedure
     .meta({ requiredScope: TokenScope.UserRead })
     .input(resolveHubSourceSchema)

--- a/src/server/services/__tests__/user-hub.service.test.ts
+++ b/src/server/services/__tests__/user-hub.service.test.ts
@@ -663,9 +663,7 @@ describe('source suggestions stay inside the viewer', () => {
     await resolveHubSourceFromUrl({ url: 'https://civitai.com/models/2', userId: 5 });
     const resolved = dbMock.dbRead.model.findFirst.mock.calls[0][0].where;
 
-    // Read off the resolve path rather than written out here, so the two cannot
-    // drift apart again: a bookmark or a bell outlives the model going private or
-    // back to draft, and the picker was offering by name what the link refuses.
+    // Read off the resolve path rather than written out here, so the two cannot drift.
     expect(suggested.deletedAt).toEqual(resolved.deletedAt);
     expect(suggested.OR).toEqual(resolved.OR);
     // The control: two undefined visibility clauses would satisfy the pair above.

--- a/src/server/services/__tests__/user-hub.service.test.ts
+++ b/src/server/services/__tests__/user-hub.service.test.ts
@@ -650,6 +650,48 @@ describe('source suggestions stay inside the viewer', () => {
     expect(names.orderBy).toEqual({ name: 'asc' });
   });
 
+  it('offers only the models the paste-a-link path would resolve', async () => {
+    dbMock.dbRead.collection.findFirst.mockResolvedValue(null);
+    dbMock.dbRead.model.findMany.mockResolvedValue([{ id: 1 }]);
+    dbMock.dbRead.modelEngagement.findMany.mockResolvedValue([{ modelId: 2 }]);
+    dbMock.dbRead.collectionItem.findMany.mockResolvedValue([]);
+
+    await getHubSourceSuggestions({ userId: 5, type: UserHubSourceType.Model });
+    const suggested = dbMock.dbRead.model.findMany.mock.calls[1][0].where;
+
+    dbMock.dbRead.model.findFirst.mockResolvedValue(null);
+    await resolveHubSourceFromUrl({ url: 'https://civitai.com/models/2', userId: 5 });
+    const resolved = dbMock.dbRead.model.findFirst.mock.calls[0][0].where;
+
+    // Read off the resolve path rather than written out here, so the two cannot
+    // drift apart again: a bookmark or a bell outlives the model going private or
+    // back to draft, and the picker was offering by name what the link refuses.
+    expect(suggested.deletedAt).toEqual(resolved.deletedAt);
+    expect(suggested.OR).toEqual(resolved.OR);
+    // The control: two undefined visibility clauses would satisfy the pair above.
+    expect(resolved.OR).toEqual([
+      { userId: 5 },
+      { status: ModelStatus.Published, availability: { not: Availability.Private } },
+    ]);
+  });
+
+  it('lifts the visibility filter for a moderator, as the link path does', async () => {
+    dbMock.dbRead.collection.findFirst.mockResolvedValue(null);
+    dbMock.dbRead.model.findMany.mockResolvedValue([{ id: 1 }]);
+    dbMock.dbRead.modelEngagement.findMany.mockResolvedValue([]);
+    dbMock.dbRead.collectionItem.findMany.mockResolvedValue([]);
+
+    await getHubSourceSuggestions({
+      userId: 5,
+      type: UserHubSourceType.Model,
+      isModerator: true,
+    });
+
+    const suggested = dbMock.dbRead.model.findMany.mock.calls[1][0].where;
+    expect(suggested.OR).toBeUndefined();
+    expect(suggested.deletedAt).toBeNull();
+  });
+
   it('offers no collections while the write path refuses them', async () => {
     expect(HUB_COLLECTION_SOURCES_ENABLED).toBe(false);
 

--- a/src/server/services/user-hub.service.ts
+++ b/src/server/services/user-hub.service.ts
@@ -572,7 +572,8 @@ export async function getHubSourceSuggestions({
   userId,
   type,
   query,
-}: GetHubSourceSuggestionsInput & { userId: number }) {
+  isModerator,
+}: GetHubSourceSuggestionsInput & { userId: number; isModerator?: boolean }) {
   const term = query?.trim();
 
   if (type === UserHubSourceType.User) {
@@ -694,7 +695,10 @@ export async function getHubSourceSuggestions({
   const models = await dbRead.model.findMany({
     where: {
       id: { in: scopedIds },
-      deletedAt: null,
+      // The same visibility the paste-a-link path applies. A bookmark or a bell
+      // outlives the model going private or back to draft, so without this the
+      // picker offers by name what `resolveSource` refuses by link.
+      ...visibleModel(userId, isModerator),
       ...(term ? { name: { contains: term, mode: 'insensitive' as const } } : {}),
     },
     select: { id: true, name: true },

--- a/src/server/services/user-hub.service.ts
+++ b/src/server/services/user-hub.service.ts
@@ -637,6 +637,11 @@ export async function getHubSourceSuggestions({
     const collections = await dbRead.collection.findMany({
       where: {
         id: { in: collectionIds },
+        // Unreachable while the switch above is off, and here so that flipping it
+        // does not reopen the models divergence on this arm: a VIEW contributor on
+        // a private collection is someone both the link path and the write path
+        // refuse.
+        read: { not: CollectionReadConfiguration.Private },
         ...(term ? { name: { contains: term, mode: 'insensitive' as const } } : {}),
       },
       select: { id: true, name: true },
@@ -695,9 +700,8 @@ export async function getHubSourceSuggestions({
   const models = await dbRead.model.findMany({
     where: {
       id: { in: scopedIds },
-      // The same visibility the paste-a-link path applies. A bookmark or a bell
-      // outlives the model going private or back to draft, so without this the
-      // picker offers by name what `resolveSource` refuses by link.
+      // A bookmark or a bell outlives the model going private or back to draft, so
+      // without this the picker offers by name what `resolveSource` refuses by link.
       ...visibleModel(userId, isModerator),
       ...(term ? { name: { contains: term, mode: 'insensitive' as const } } : {}),
     },


### PR DESCRIPTION
Three cleanups out of the tester round on `/hubs`. Nothing here changes what a
tester sees except the stale feed noted below, so it does not touch what the
replies in the feedback thread promise.

### One invalidation set

`getAll` + `getById({id})` + `image.getInfinite({hubId})` was written out in
`HubSourcePanel`, `HubUpsertModal` and `AddToHubModal`, and had already
diverged — the upsert modal was missing the feed key, so creating a hub with
sources from it landed on a feed that had already been cached empty.

Now `useInvalidateHub` in a new `src/components/Hubs/hub.utils.ts`, which is
the file collections have had all along as `collection.utils.ts`.

`AddToHubModal` also declared its own `{ type, targetId, alias }` — the fourth
inline copy of that shape. It takes `Omit<AddUserHubSourceInput, 'hubId'>` now.

### One visibility rule for the source picker

`getHubSourceSuggestions` filtered candidate models on `deletedAt: null` alone;
`resolveHubSourceFromUrl` used `visibleModel(userId, isModerator)`. A bookmark
or a bell outlives the model going private or back to draft, so the picker
offered by name what the paste-a-link path refuses. Both share `visibleModel`
now, and the router passes `isModerator` so a moderator sees one list, not two.

This is a consistency bug, not a leak: the suggestion carries a name the viewer
had already bookmarked or followed, and the feed applies its own visibility.

### Scope is asserted, not assumed

Hubs have **no scope of their own** — every procedure rides on
`TokenScope.UserRead` / `UserWrite`. The existing gate test proved the feature
flag only: its caller carries `TokenScope.Full`, and `enforceTokenScope` skips
the check outright for Full, so deleting `.meta({ requiredScope })` from a hub
procedure was invisible to the whole suite.

Added a second describe that calls every procedure with a token scoped to
exactly what it declares (must pass) and to the other user scope (must be
FORBIDDEN), from a map written out by hand — a map read off `.meta()` would
assert the router against itself.

### Verified

Each new assertion was checked against the mutation it is supposed to catch:

| mutation | result |
| --- | --- |
| drop `.meta({ requiredScope })` from `getAll` | 1 failed / 37 passed |
| downgrade `upsert` to `UserRead` | 2 failed / 36 passed |
| revert the suggestions visibility filter | 1 failed |

Full unit suite green (20924 passed, 0 failed, 249s), typecheck clean apart
from the pre-existing `packages/civitai-telemetry` error on `main`, eslint and
prettier clean.

### Noted, not fixed

`addUserHubSource` enforces the per-hub source cap as a read-check-write with
no constraint behind it. Both reads go through the writer, so it takes two
genuinely concurrent adds to exceed the cap by one, and the excess row is
harmless. Left alone deliberately.

Tickets: 868kv6n05, 868kv6mzy, 868kv6n0e.
