### PR TITLE
fix(models): move PaidAccess and DonationGoal owners with a model transfer

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260822160000_backfill_owner_copies_after_transfer/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260822160000_backfill_owner_copies_after_transfer/migration.sql
@@ -1,0 +1,63 @@
+-- Backfill: the two denormalised owner copies that model transfers used to leave behind.
+--
+-- NOT AUTO-APPLIED. Migrations in this repo are run by hand — see CLAUDE.md → Database.
+--
+-- transferModelOwnership moved Model.userId and left both of these on the previous owner:
+--
+--   PaidAccess.ownerId   decides who generates free from a gated version and whose scheduled sales may
+--                        reprice it, while the model-card sale badge resolves the owner from
+--                        Model.userId — so a stale row makes those two answers disagree.
+--   DonationGoal.userId  is who a donation PAYS (donation-goal.service). A stale row means a donation
+--                        made on the new owner's model page pays the previous owner.
+--
+-- Both statements are idempotent and no-ops once the transfer fix is deployed. Safe to run before or
+-- after that deploy: each only ever moves a row to the owner the model already has.
+--
+-- Measured on the prod replica 2026-08-22, before the fix shipped:
+--   PaidAccess    0 stale, against 4773 ModelVersion gates that all matched and 0 orphans (so the
+--                 query could see a mismatch, and there were none)
+--   DonationGoal  92 stale, 68 of them still active, against 21996 that matched
+
+-- Counts, before changing anything:
+--   SELECT COUNT(*) FROM "PaidAccess" pa
+--     JOIN "ModelVersion" mv ON mv.id = pa."entityId"
+--     JOIN "Model" m ON m.id = mv."modelId"
+--    WHERE pa."entityType" = 'ModelVersion' AND pa."ownerId" <> m."userId";
+--
+--   SELECT COUNT(*) FILTER (WHERE dg.active) AS active, COUNT(*) AS total
+--     FROM "DonationGoal" dg
+--     JOIN "ModelVersion" mv ON mv.id = dg."modelVersionId"
+--     JOIN "Model" m ON m.id = mv."modelId"
+--    WHERE dg."userId" <> m."userId";
+
+UPDATE "PaidAccess" pa
+SET "ownerId" = m."userId", "updatedAt" = NOW()
+FROM "ModelVersion" mv
+JOIN "Model" m ON m.id = mv."modelId"
+WHERE pa."entityType" = 'ModelVersion'
+  AND pa."entityId" = mv.id
+  AND pa."ownerId" <> m."userId";
+
+-- The goal's target is dual-written (legacy modelVersionId + polymorphic entityType/entityId), so both
+-- spellings are matched. Inactive and completed goals move too: a stale userId on one has no upside,
+-- and a goal can be reactivated.
+UPDATE "DonationGoal" dg
+SET "userId" = m."userId"
+FROM "ModelVersion" mv
+JOIN "Model" m ON m.id = mv."modelId"
+WHERE (
+    dg."modelVersionId" = mv.id
+    OR (dg."entityType" = 'ModelVersion' AND dg."entityId" = mv.id)
+  )
+  AND dg."userId" <> m."userId";
+
+-- After running: purge the caches, or the previous owner is authorised — and displayed — for up to
+-- another hour.
+--   packed:caches:paid-access:ModelVersion:*                 the gate row (TTL 1h, SWR off)
+--   packed:caches:paid-access:ModelSales:*                   the model-card sale badge
+--   the modelVersionPublicDonationGoals cache                carries the goal's userId
+--
+-- ComicChapter PaidAccess rows are deliberately untouched: nothing transfers a comic's owner, so a
+-- mismatch there would mean something else is wrong and should not be papered over by this.
+--
+-- Donation rows are history and are NOT retargeted — only who the NEXT donation pays changes.

--- a/packages/civitai-db-schema/prisma/migrations/20260822160000_backfill_owner_copies_after_transfer/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260822160000_backfill_owner_copies_after_transfer/migration.sql
@@ -2,21 +2,20 @@
 --
 -- NOT AUTO-APPLIED. Migrations in this repo are run by hand — see CLAUDE.md → Database.
 --
--- transferModelOwnership moved Model.userId and left both of these on the previous owner:
---
---   PaidAccess.ownerId   decides who generates free from a gated version and whose scheduled sales may
---                        reprice it, while the model-card sale badge resolves the owner from
---                        Model.userId — so a stale row makes those two answers disagree.
---   DonationGoal.userId  is who a donation PAYS (donation-goal.service). A stale row means a donation
---                        made on the new owner's model page pays the previous owner.
+-- PaidAccess.ownerId and DonationGoal.userId are denormalised copies of Model.userId. Model transfers
+-- moved the model and left both copies behind; the transfer now moves them in the same transaction
+-- (src/server/services/model.service.ts). This resyncs anything transferred before that.
 --
 -- Both statements are idempotent and no-ops once the transfer fix is deployed. Safe to run before or
 -- after that deploy: each only ever moves a row to the owner the model already has.
 --
--- Measured on the prod replica 2026-08-22, before the fix shipped:
---   PaidAccess    0 stale, against 4773 ModelVersion gates that all matched and 0 orphans (so the
---                 query could see a mismatch, and there were none)
---   DonationGoal  92 stale, 68 of them still active, against 21996 that matched
+-- Expected size, measured on the prod replica 2026-08-22:
+--   PaidAccess    0 rows out of step, against 4773 ModelVersion gates in step and 0 orphans (so the
+--                 query could see one, and there were none)
+--   DonationGoal  92 rows out of step (68 active), against 21996 in step. Counted with the same
+--                 predicate the statements below use — 0 rows are polymorphic-only today, so both
+--                 spellings give the same number, but only the wider one stays true once phase 2
+--                 drops modelVersionId.
 
 -- Counts, before changing anything:
 --   SELECT COUNT(*) FROM "PaidAccess" pa
@@ -24,9 +23,10 @@
 --     JOIN "Model" m ON m.id = mv."modelId"
 --    WHERE pa."entityType" = 'ModelVersion' AND pa."ownerId" <> m."userId";
 --
---   SELECT COUNT(*) FILTER (WHERE dg.active) AS active, COUNT(*) AS total
+--   SELECT COUNT(DISTINCT dg.id) AS total, COUNT(DISTINCT dg.id) FILTER (WHERE dg.active) AS active
 --     FROM "DonationGoal" dg
---     JOIN "ModelVersion" mv ON mv.id = dg."modelVersionId"
+--     JOIN "ModelVersion" mv ON (dg."modelVersionId" = mv.id
+--                            OR (dg."entityType" = 'ModelVersion' AND dg."entityId" = mv.id))
 --     JOIN "Model" m ON m.id = mv."modelId"
 --    WHERE dg."userId" <> m."userId";
 
@@ -39,23 +39,33 @@ WHERE pa."entityType" = 'ModelVersion'
   AND pa."ownerId" <> m."userId";
 
 -- The goal's target is dual-written (legacy modelVersionId + polymorphic entityType/entityId), so both
--- spellings are matched. Inactive and completed goals move too: a stale userId on one has no upside,
--- and a goal can be reactivated.
+-- spellings move. Two statements rather than one OR: an OR across them makes the planner drive from
+-- DonationGoal and seq-scan the whole table (176ms/155k buffers on prod, against ~20ms/3k split), and
+-- the `userId <> m."userId"` guard makes the second a no-op for anything the first already moved.
+-- The ORDER is load-bearing: for a goal whose two spellings point at versions of DIFFERENT models, the
+-- second statement wins, so the polymorphic target decides the owner. That is the going-forward
+-- identity and the column phase 2 keeps. Swapping these two silently flips that precedence.
+-- Inactive and completed goals move too: a stale userId on one has no upside, and it can be reactivated.
 UPDATE "DonationGoal" dg
 SET "userId" = m."userId"
 FROM "ModelVersion" mv
 JOIN "Model" m ON m.id = mv."modelId"
-WHERE (
-    dg."modelVersionId" = mv.id
-    OR (dg."entityType" = 'ModelVersion' AND dg."entityId" = mv.id)
-  )
+WHERE dg."modelVersionId" = mv.id
   AND dg."userId" <> m."userId";
 
--- After running: purge the caches, or the previous owner is authorised — and displayed — for up to
--- another hour.
---   packed:caches:paid-access:ModelVersion:*                 the gate row (TTL 1h, SWR off)
---   packed:caches:paid-access:ModelSales:*                   the model-card sale badge
---   the modelVersionPublicDonationGoals cache                carries the goal's userId
+UPDATE "DonationGoal" dg
+SET "userId" = m."userId"
+FROM "ModelVersion" mv
+JOIN "Model" m ON m.id = mv."modelId"
+WHERE dg."entityType" = 'ModelVersion'
+  AND dg."entityId" = mv.id
+  AND dg."userId" <> m."userId";
+
+-- After running: purge the caches that carry an owner, or they serve the old one until they expire.
+--   packed:caches:entity-availability:model-versions:*   Model.userId, TTL 1 DAY — the longest-lived
+--   packed:caches:paid-access:ModelVersion:*             the gate row (TTL 1h, SWR off)
+--   packed:caches:paid-access:ModelSales:*               the model-card sale badge
+--   the modelVersionPublicDonationGoals cache            carries the goal's userId
 --
 -- ComicChapter PaidAccess rows are deliberately untouched: nothing transfers a comic's owner, so a
 -- mismatch there would mean something else is wrong and should not be papered over by this.

--- a/src/server/services/__tests__/model.service.transfer-paid-access-owner.test.ts
+++ b/src/server/services/__tests__/model.service.transfer-paid-access-owner.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
+import type * as ModelVersionService from '~/server/services/model-version.service';
 
 /**
  * `PaidAccess.ownerId` is a denormalised copy of the model owner. It decides who generates free from a
@@ -27,12 +28,14 @@ const PARAM = ' ?? ';
 
 const {
   mockBustPaidAccessCache,
-  mockBustModelSaleCache,
+  mockBustMvCache,
+  mockQueueModelsIndex,
   mockBustDonationGoals,
   mockDeleteBasicDataForUser,
 } = vi.hoisted(() => ({
   mockBustPaidAccessCache: vi.fn(),
-  mockBustModelSaleCache: vi.fn(),
+  mockBustMvCache: vi.fn(),
+  mockQueueModelsIndex: vi.fn(),
   mockBustDonationGoals: vi.fn(),
   mockDeleteBasicDataForUser: vi.fn(),
 }));
@@ -49,7 +52,8 @@ vi.mock('~/server/services/model-file.service', () => ({
 vi.mock('~/server/services/image.service', () => ({
   getImagesForModelVersion: vi.fn(),
   getImagesForModelVersionCache: vi.fn().mockResolvedValue({}),
-  queueImageSearchIndexUpdate: vi.fn(),
+  // Returns a promise for real, and the transfer now attaches a .catch to it.
+  queueImageSearchIndexUpdate: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn().mockResolvedValue(false) }));
 vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
@@ -59,7 +63,10 @@ vi.mock('~/server/services/paid-access.service', () => ({
   getPaidAccess: vi.fn(),
   getPublicPaidAccessForModelVersions: vi.fn().mockResolvedValue({}),
   bustPaidAccessCache: mockBustPaidAccessCache,
-  bustModelSaleCache: mockBustModelSaleCache,
+}));
+vi.mock('~/server/services/model-version.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModelVersionService>()),
+  bustMvCache: mockBustMvCache,
 }));
 vi.mock('~/server/services/creator-program.service', () => ({
   getValidCreatorMembershipMap: vi.fn().mockResolvedValue(new Map()),
@@ -89,24 +96,72 @@ vi.mock('~/server/search-index', () => ({
   collectionsSearchIndex: { queueUpdate: vi.fn() },
   imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
   imagesSearchIndex: { queueUpdate: vi.fn() },
-  modelsSearchIndex: { queueUpdate: vi.fn() },
+  modelsSearchIndex: { queueUpdate: mockQueueModelsIndex },
 }));
 
 import { transferModelOwnership } from '~/server/services/model.service';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 
 /** The operations handed to the ONE $transaction call, in order. */
 let transactionOps: unknown[] = [];
 
-function statementFor(table: string): RawCall | undefined {
+function statementsFor(table: string): RawCall[] {
   const ops = transactionOps as { __raw?: RawCall }[];
-  return ops.map((op) => op?.__raw).find((raw) => raw?.sql.includes(`"${table}"`));
+  return ops
+    .map((op) => op?.__raw)
+    .filter((raw): raw is RawCall => !!raw?.sql.includes(`"${table}"`));
 }
 
-const paidAccessStatement = () => statementFor('PaidAccess');
-const donationGoalStatement = () => statementFor('DonationGoal');
+const paidAccessStatement = () => statementsFor('PaidAccess')[0];
+/** Two, one per dual-written target spelling. */
+const donationGoalStatements = () => statementsFor('DonationGoal');
+
+/** Ticks on the transaction and on each bust, so the busts can be pinned AFTER the commit. */
+let clock = 0;
+let transactionAt = 0;
+const bustAt: number[] = [];
+
+/** Every value interpolated after a fragment matching `pattern`, in statement order. */
+function valuesAfter(statement: RawCall, pattern: RegExp) {
+  const fragments = statement.sql.split(PARAM);
+  return fragments
+    .map((fragment, i) => (pattern.test(fragment) ? statement.values[i] : undefined))
+    .filter((v) => v !== undefined);
+}
+
+function valueAfter(statement: RawCall, pattern: RegExp) {
+  const found = valuesAfter(statement, pattern);
+  expect(found, `no interpolated value follows ${pattern}`).toHaveLength(1);
+  return found[0];
+}
+
+/** Both statements are scoped to the transferred models and skip rows already on the target. */
+function expectScopedToTransfer(statement: RawCall) {
+  expect(valueAfter(statement, /"modelId"\s*=\s*ANY\($/)).toEqual(MODEL_IDS);
+  expect((statement as RawCall).sql).toMatch(/mv\."modelId"\s*=\s*ANY\(/);
+  // The guard is `<>`. Flipped to `=`, the statement matches only rows that are already correct —
+  // a permanent no-op that leaves every value, position and fragment in this test unchanged.
+  expect(valueAfter(statement, /"userId"\s*<>\s*$|"ownerId"\s*<>\s*$/)).toBe(TARGET_USER_ID);
+}
 
 beforeEach(() => {
+  // The hoisted spies live for the whole file — without this their call counts accumulate across
+  // tests, and toHaveBeenCalledExactlyOnceWith is the assertion that notices.
+  vi.clearAllMocks();
   transactionOps = [];
+  clock = 0;
+  transactionAt = 0;
+  bustAt.length = 0;
+  for (const bust of [
+    mockBustPaidAccessCache,
+    mockBustMvCache,
+    mockBustDonationGoals,
+    mockQueueModelsIndex,
+  ])
+    bust.mockImplementation(() => {
+      bustAt.push(++clock);
+      return Promise.resolve();
+    });
 
   dbMock.dbWrite.user.findFirst.mockResolvedValue({ id: TARGET_USER_ID });
   dbMock.dbWrite.model.findMany.mockResolvedValue(
@@ -119,8 +174,11 @@ beforeEach(() => {
     args,
   }));
   // Posts, then images.
+  // mockReset drops the canonical default too, so a third read on this path would return undefined
+  // and die on .map far from its cause — hence the trailing default.
   dbMock.dbWrite.$queryRaw
     .mockReset()
+    .mockResolvedValue([])
     .mockResolvedValueOnce([{ id: 501 }])
     .mockResolvedValueOnce([{ id: 601 }]);
   // A tagged-template stand-in for Prisma's $executeRaw. The marker it returns is what lands in the
@@ -133,6 +191,7 @@ beforeEach(() => {
   );
   dbMock.dbWrite.$transaction.mockImplementation(async (ops: unknown[]) => {
     transactionOps = ops;
+    transactionAt = ++clock;
     // One result per operation, distinguishable so an index shift in the caller is visible.
     // Raw statements resolve to a row count, Prisma ops to { count } — as they do for real.
     return ops.map((op, i) =>
@@ -159,7 +218,7 @@ describe('transferModelOwnership moves the PaidAccess owner', () => {
     expect((transactionOps as { __op?: string }[]).some((op) => op?.__op === 'model')).toBe(true);
   });
 
-  it('sets ownerId to the target user for every version of the transferred models', async () => {
+  it('sets ownerId to the target user, scoped to the transferred models', async () => {
     await transferModelOwnership({
       modelIds: MODEL_IDS,
       targetUserId: TARGET_USER_ID,
@@ -171,19 +230,17 @@ describe('transferModelOwnership moves the PaidAccess owner', () => {
     // Values are matched to the fragment they follow, not merely to the value list: the id being
     // written and the ids being matched are both in that list, so a statement that assigned the wrong
     // one of them would still contain every value this test expects.
-    const fragments = (statement as RawCall).sql.split(PARAM);
-    const valueAfter = (pattern: RegExp) => {
-      const i = fragments.findIndex((fragment) => pattern.test(fragment));
-      expect(i, `no interpolated value follows ${pattern}`).toBeGreaterThanOrEqual(0);
-      return (statement as RawCall).values[i];
-    };
-    expect(valueAfter(/SET\s+"ownerId"\s*=\s*$/)).toBe(TARGET_USER_ID);
-    // Scoped through ModelVersion to the models being transferred, not to a user or a version list.
-    expect((statement as RawCall).sql).toMatch(/FROM\s+"ModelVersion"/);
-    expect(valueAfter(/mv\."modelId"\s*=\s*ANY\($/)).toEqual(MODEL_IDS);
-    expect((statement as RawCall).values).not.toContain(SOURCE_USER_ID);
+    expect(valueAfter(statement, /SET\s+"ownerId"\s*=\s*$/)).toBe(TARGET_USER_ID);
+    // 🔴 The join predicate, not just the FROM. Without `pa."entityId" = mv.id` this is a cross join
+    // and EVERY ModelVersion gate on the site moves to the target user — and `FROM "ModelVersion"`
+    // alone still matches, so the FROM is the half that cannot be wrong.
+    expect(statement.sql).toMatch(/FROM\s+"ModelVersion"/);
+    expect(statement.sql).toMatch(/pa\."entityId"\s*=\s*mv\.id/);
+    // The enum literal is load-bearing: a ComicChapter gate has no transfer path and must not move.
+    expect(statement.sql).toMatch(/pa\."entityType"\s*=\s*'ModelVersion'::"PaidAccessEntityType"/);
+    expectScopedToTransfer(statement);
     // updatedAt is @updatedAt in Prisma, which a raw UPDATE does not apply.
-    expect((statement as RawCall).sql).toMatch(/"updatedAt"\s*=\s*NOW\(\)/);
+    expect(statement.sql).toMatch(/"updatedAt"\s*=\s*NOW\(\)/);
   });
 
   it('busts every owner-derived cache for the transferred versions', async () => {
@@ -193,9 +250,27 @@ describe('transferModelOwnership moves the PaidAccess owner', () => {
       modUserId: MOD_USER_ID,
     });
 
-    expect(mockBustPaidAccessCache).toHaveBeenCalledWith('ModelVersion', VERSION_IDS);
-    expect(mockBustModelSaleCache).toHaveBeenCalledWith(VERSION_IDS);
-    expect(mockBustDonationGoals).toHaveBeenCalledWith(VERSION_IDS);
+    expect(mockBustPaidAccessCache).toHaveBeenCalledExactlyOnceWith('ModelVersion', VERSION_IDS);
+    expect(mockBustDonationGoals).toHaveBeenCalledExactlyOnceWith(VERSION_IDS);
+    // modelVersionAccessCache holds Model.userId for a day and hasEntityAccess grants owner access
+    // from it; bustMvCache is what reaches it, and it carries the model search-index update too.
+    expect(mockBustMvCache).toHaveBeenCalledExactlyOnceWith(VERSION_IDS, MODEL_IDS);
+    // The ids come from this read, so a narrowed query (say, published versions only) would leave the
+    // rest holding a stale owner for the full hour while every assertion above still passed.
+    expect(dbMock.dbWrite.modelVersion.findMany).toHaveBeenCalledWith({
+      where: { modelId: { in: MODEL_IDS } },
+      select: { id: true },
+    });
+    // 🔴 AFTER the commit. Busting first lets a concurrent read repopulate from pre-transfer rows,
+    // which is the whole failure the busts exist to prevent — and the arguments are identical either
+    // way, so nothing else here can tell the difference.
+    expect(transactionAt).toBeGreaterThan(0);
+    expect(Math.min(...bustAt)).toBeGreaterThan(transactionAt);
+    // Enqueued here rather than only inside bustMvCache, where four throwable awaits sit in front of
+    // it — and it is the one leg whose loss is permanent, since Meilisearch has no TTL to heal on.
+    expect(mockQueueModelsIndex).toHaveBeenCalledWith(
+      MODEL_IDS.map((id) => ({ id, action: SearchIndexUpdateQueueAction.Update }))
+    );
   });
 
   it('moves DonationGoal.userId in the same transaction, on both target spellings', async () => {
@@ -205,19 +280,44 @@ describe('transferModelOwnership moves the PaidAccess owner', () => {
       modUserId: MOD_USER_ID,
     });
 
-    const statement = donationGoalStatement();
+    const statements = donationGoalStatements();
     expect(
-      statement,
-      'no UPDATE "DonationGoal" statement in the transfer transaction — a donation on the transferred model still pays the previous owner'
+      statements.length,
+      'the DonationGoal target is dual-written; one statement covers one spelling and leaves the other half of the goals paying the previous owner'
+    ).toBe(2);
+    const legacy = statements.find((st) => /dg\."modelVersionId"\s*=\s*mv\.id/.test(st.sql));
+    const polymorphic = statements.find((st) => /dg\."entityId"\s*=\s*mv\.id/.test(st.sql));
+    expect(legacy, 'no statement matches the legacy modelVersionId target').toBeDefined();
+    expect(
+      polymorphic,
+      'no statement matches the polymorphic entityType/entityId target'
     ).toBeDefined();
-    const fragments = (statement as RawCall).sql.split(PARAM);
-    const i = fragments.findIndex((fragment) => /SET\s+"userId"\s*=\s*$/.test(fragment));
-    expect(i).toBeGreaterThanOrEqual(0);
-    expect((statement as RawCall).values[i]).toBe(TARGET_USER_ID);
-    // The goal's target is dual-written; matching only one spelling leaves the other half behind.
-    expect((statement as RawCall).sql).toMatch(/dg\."modelVersionId"\s*=\s*mv\.id/);
-    expect((statement as RawCall).sql).toMatch(/dg\."entityId"\s*=\s*mv\.id/);
-    expect((statement as RawCall).values).not.toContain(SOURCE_USER_ID);
+    expect((polymorphic as RawCall).sql).toMatch(
+      /dg\."entityType"\s*=\s*'ModelVersion'::"PaidAccessEntityType"/
+    );
+
+    for (const statement of statements) {
+      expect(valueAfter(statement, /SET\s+"userId"\s*=\s*$/)).toBe(TARGET_USER_ID);
+      // 🔴 Without this the statement retargets every donation goal on the site to the transferee,
+      // and every other assertion here still passes.
+      expectScopedToTransfer(statement);
+    }
+  });
+
+  it('does not fail a COMMITTED transfer when an invalidation throws', async () => {
+    mockBustPaidAccessCache.mockRejectedValue(new Error('redis down'));
+
+    const result = await transferModelOwnership({
+      modelIds: MODEL_IDS,
+      targetUserId: TARGET_USER_ID,
+      modUserId: MOD_USER_ID,
+    });
+
+    // The transaction already committed, and the pre-flight guard refuses a retry once the models
+    // belong to the target — so a throw here strands the operator with a transfer that succeeded and
+    // an error saying it did not. A stale cache expires on its own.
+    expect(result.modelsUpdated).toBeDefined();
+    expect(mockBustMvCache).toHaveBeenCalledTimes(1);
   });
 
   it('reports each count from its own operation', async () => {
@@ -231,11 +331,25 @@ describe('transferModelOwnership moves the PaidAccess owner', () => {
     const positionOf = (predicate: (op: unknown) => boolean) => transactionOps.findIndex(predicate);
     const modelPos = positionOf((op) => (op as { __op?: string })?.__op === 'model');
     const metricPos = positionOf((op) => (op as { __op?: string })?.__op === 'modelMetric');
-    const rawPos = (table: string) =>
-      positionOf((op) => !!(op as { __raw?: RawCall })?.__raw?.sql.includes(`"${table}"`));
+    const rawPositions = (table: string) =>
+      transactionOps
+        .map((op, i) => ((op as { __raw?: RawCall })?.__raw?.sql.includes(`"${table}"`) ? i : -1))
+        .filter((i) => i >= 0);
+    const postsPos = positionOf(
+      (op) => !!(op as { __raw?: RawCall })?.__raw?.sql.includes('UPDATE "Post"')
+    );
+    const imagesPos = positionOf(
+      (op) => !!(op as { __raw?: RawCall })?.__raw?.sql.includes('UPDATE "Image"')
+    );
     expect(result.modelsUpdated).toBe(1000 + modelPos);
     expect(result.metricsUpdated).toBe(1000 + metricPos);
-    expect(result.paidAccessUpdated).toBe(1000 + rawPos('PaidAccess'));
-    expect(result.donationGoalsUpdated).toBe(1000 + rawPos('DonationGoal'));
+    expect(result.paidAccessUpdated).toBe(1000 + rawPositions('PaidAccess')[0]);
+    // Both legs, summed — the `userId <> target` guard makes them disjoint, so a dual-written goal
+    // is counted once.
+    expect(result.donationGoalsUpdated).toBe(
+      rawPositions('DonationGoal').reduce((sum, i) => sum + 1000 + i, 0)
+    );
+    expect(result.postsUpdated).toBe(1000 + postsPos);
+    expect(result.imagesUpdated).toBe(1000 + imagesPos);
   });
 });

--- a/src/server/services/__tests__/model.service.transfer-paid-access-owner.test.ts
+++ b/src/server/services/__tests__/model.service.transfer-paid-access-owner.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * `PaidAccess.ownerId` is a denormalised copy of the model owner. It decides who generates free from a
+ * gated version (`generation/paid-access-gating.ts`) and whose scheduled sales may reprice it
+ * (`getSalesFor`), while the model-card sale badge resolves the owner from `Model.userId` instead — so a
+ * transfer that moves one and not the other leaves those two answers disagreeing.
+ *
+ * A revert here is the statement disappearing from the transaction array, which the first assertion
+ * reports by name rather than as a shape mismatch further down.
+ *
+ * Same import-the-real-model.service scaffold as `model.service.vae-append-no-mutation.test.ts`; only
+ * the I/O surfaces are stubbed.
+ */
+
+const MODEL_IDS = [11, 12];
+const VERSION_IDS = [101, 102];
+const SOURCE_USER_ID = 5;
+const TARGET_USER_ID = 9;
+const MOD_USER_ID = 1;
+
+type RawCall = { sql: string; values: unknown[] };
+
+/** Where an interpolated value sat, so a value can be tied to the fragment it followed. */
+const PARAM = ' ?? ';
+
+const {
+  mockBustPaidAccessCache,
+  mockBustModelSaleCache,
+  mockBustDonationGoals,
+  mockDeleteBasicDataForUser,
+} = vi.hoisted(() => ({
+  mockBustPaidAccessCache: vi.fn(),
+  mockBustModelSaleCache: vi.fn(),
+  mockBustDonationGoals: vi.fn(),
+  mockDeleteBasicDataForUser: vi.fn(),
+}));
+
+vi.mock('~/server/db/pgDb', () => ({
+  pgDbRead: { cancellableQuery: vi.fn() },
+  pgDbWrite: {},
+  pgDbReadLong: {},
+}));
+vi.mock('~/server/services/model-file.service', () => ({
+  getFilesForModelVersionCache: vi.fn(),
+  deleteFilesForModelVersionCache: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(),
+  getImagesForModelVersionCache: vi.fn().mockResolvedValue({}),
+  queueImageSearchIndexUpdate: vi.fn(),
+}));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn().mockResolvedValue(false) }));
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTagsForModels: vi.fn().mockResolvedValue({ emptyResult: false }),
+}));
+vi.mock('~/server/services/paid-access.service', () => ({
+  getPaidAccess: vi.fn(),
+  getPublicPaidAccessForModelVersions: vi.fn().mockResolvedValue({}),
+  bustPaidAccessCache: mockBustPaidAccessCache,
+  bustModelSaleCache: mockBustModelSaleCache,
+}));
+vi.mock('~/server/services/creator-program.service', () => ({
+  getValidCreatorMembershipMap: vi.fn().mockResolvedValue(new Map()),
+  getUserMetricPrivacyDefaultsMap: vi.fn().mockResolvedValue(new Map()),
+}));
+vi.mock('~/server/services/user.service', () => ({
+  deleteBasicDataForUser: mockDeleteBasicDataForUser,
+  getCosmeticsForUsers: vi.fn().mockResolvedValue({}),
+  getProfilePicturesForUsers: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('~/server/services/cosmetic.service', () => ({ getCosmeticsForEntity: vi.fn() }));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: { fetch: vi.fn() },
+  modelVersionPublicDonationGoalsCache: { fetch: vi.fn(), bust: mockBustDonationGoals },
+  modelTagCache: { fetch: vi.fn(), bust: vi.fn() },
+  modelVotableTagsCache: { fetch: vi.fn(), bust: vi.fn() },
+  userBasicCache: { fetch: vi.fn().mockResolvedValue({}), bust: vi.fn() },
+  userModelCountCache: { fetch: vi.fn(), bust: vi.fn() },
+}));
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: {},
+  Tracker: class {
+    modelEvent = vi.fn();
+  },
+}));
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+  imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+  modelsSearchIndex: { queueUpdate: vi.fn() },
+}));
+
+import { transferModelOwnership } from '~/server/services/model.service';
+
+/** The operations handed to the ONE $transaction call, in order. */
+let transactionOps: unknown[] = [];
+
+function statementFor(table: string): RawCall | undefined {
+  const ops = transactionOps as { __raw?: RawCall }[];
+  return ops.map((op) => op?.__raw).find((raw) => raw?.sql.includes(`"${table}"`));
+}
+
+const paidAccessStatement = () => statementFor('PaidAccess');
+const donationGoalStatement = () => statementFor('DonationGoal');
+
+beforeEach(() => {
+  transactionOps = [];
+
+  dbMock.dbWrite.user.findFirst.mockResolvedValue({ id: TARGET_USER_ID });
+  dbMock.dbWrite.model.findMany.mockResolvedValue(
+    MODEL_IDS.map((id) => ({ id, userId: SOURCE_USER_ID, nsfw: false }))
+  );
+  dbMock.dbWrite.modelVersion.findMany.mockResolvedValue(VERSION_IDS.map((id) => ({ id })));
+  dbMock.dbWrite.model.updateMany.mockImplementation((args: unknown) => ({ __op: 'model', args }));
+  dbMock.dbWrite.modelMetric.updateMany.mockImplementation((args: unknown) => ({
+    __op: 'modelMetric',
+    args,
+  }));
+  // Posts, then images.
+  dbMock.dbWrite.$queryRaw
+    .mockReset()
+    .mockResolvedValueOnce([{ id: 501 }])
+    .mockResolvedValueOnce([{ id: 601 }]);
+  // A tagged-template stand-in for Prisma's $executeRaw. The marker it returns is what lands in the
+  // $transaction array, so a statement can be identified there by its own SQL. Interpolated values are
+  // kept SEPARATE from the SQL: joining the template strings drops every one of them.
+  dbMock.dbWrite.$executeRaw.mockImplementation(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      __raw: { sql: strings.join(PARAM), values },
+    })
+  );
+  dbMock.dbWrite.$transaction.mockImplementation(async (ops: unknown[]) => {
+    transactionOps = ops;
+    // One result per operation, distinguishable so an index shift in the caller is visible.
+    // Raw statements resolve to a row count, Prisma ops to { count } — as they do for real.
+    return ops.map((op, i) =>
+      (op as { __raw?: unknown })?.__raw ? 1000 + i : { count: 1000 + i }
+    );
+  });
+});
+
+describe('transferModelOwnership moves the PaidAccess owner', () => {
+  it('updates PaidAccess in the SAME transaction as the Model row', async () => {
+    await transferModelOwnership({
+      modelIds: MODEL_IDS,
+      targetUserId: TARGET_USER_ID,
+      modUserId: MOD_USER_ID,
+    });
+
+    expect(dbMock.dbWrite.$transaction).toHaveBeenCalledTimes(1);
+    const statement = paidAccessStatement();
+    expect(
+      statement,
+      'no UPDATE "PaidAccess" statement in the transfer transaction — the gate owner is left on the previous owner'
+    ).toBeDefined();
+    // The Model update is in the same array, so the two can never be committed apart.
+    expect((transactionOps as { __op?: string }[]).some((op) => op?.__op === 'model')).toBe(true);
+  });
+
+  it('sets ownerId to the target user for every version of the transferred models', async () => {
+    await transferModelOwnership({
+      modelIds: MODEL_IDS,
+      targetUserId: TARGET_USER_ID,
+      modUserId: MOD_USER_ID,
+    });
+
+    const statement = paidAccessStatement();
+    expect(statement).toBeDefined();
+    // Values are matched to the fragment they follow, not merely to the value list: the id being
+    // written and the ids being matched are both in that list, so a statement that assigned the wrong
+    // one of them would still contain every value this test expects.
+    const fragments = (statement as RawCall).sql.split(PARAM);
+    const valueAfter = (pattern: RegExp) => {
+      const i = fragments.findIndex((fragment) => pattern.test(fragment));
+      expect(i, `no interpolated value follows ${pattern}`).toBeGreaterThanOrEqual(0);
+      return (statement as RawCall).values[i];
+    };
+    expect(valueAfter(/SET\s+"ownerId"\s*=\s*$/)).toBe(TARGET_USER_ID);
+    // Scoped through ModelVersion to the models being transferred, not to a user or a version list.
+    expect((statement as RawCall).sql).toMatch(/FROM\s+"ModelVersion"/);
+    expect(valueAfter(/mv\."modelId"\s*=\s*ANY\($/)).toEqual(MODEL_IDS);
+    expect((statement as RawCall).values).not.toContain(SOURCE_USER_ID);
+    // updatedAt is @updatedAt in Prisma, which a raw UPDATE does not apply.
+    expect((statement as RawCall).sql).toMatch(/"updatedAt"\s*=\s*NOW\(\)/);
+  });
+
+  it('busts every owner-derived cache for the transferred versions', async () => {
+    await transferModelOwnership({
+      modelIds: MODEL_IDS,
+      targetUserId: TARGET_USER_ID,
+      modUserId: MOD_USER_ID,
+    });
+
+    expect(mockBustPaidAccessCache).toHaveBeenCalledWith('ModelVersion', VERSION_IDS);
+    expect(mockBustModelSaleCache).toHaveBeenCalledWith(VERSION_IDS);
+    expect(mockBustDonationGoals).toHaveBeenCalledWith(VERSION_IDS);
+  });
+
+  it('moves DonationGoal.userId in the same transaction, on both target spellings', async () => {
+    await transferModelOwnership({
+      modelIds: MODEL_IDS,
+      targetUserId: TARGET_USER_ID,
+      modUserId: MOD_USER_ID,
+    });
+
+    const statement = donationGoalStatement();
+    expect(
+      statement,
+      'no UPDATE "DonationGoal" statement in the transfer transaction — a donation on the transferred model still pays the previous owner'
+    ).toBeDefined();
+    const fragments = (statement as RawCall).sql.split(PARAM);
+    const i = fragments.findIndex((fragment) => /SET\s+"userId"\s*=\s*$/.test(fragment));
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect((statement as RawCall).values[i]).toBe(TARGET_USER_ID);
+    // The goal's target is dual-written; matching only one spelling leaves the other half behind.
+    expect((statement as RawCall).sql).toMatch(/dg\."modelVersionId"\s*=\s*mv\.id/);
+    expect((statement as RawCall).sql).toMatch(/dg\."entityId"\s*=\s*mv\.id/);
+    expect((statement as RawCall).values).not.toContain(SOURCE_USER_ID);
+  });
+
+  it('reports each count from its own operation', async () => {
+    const result = await transferModelOwnership({
+      modelIds: MODEL_IDS,
+      targetUserId: TARGET_USER_ID,
+      modUserId: MOD_USER_ID,
+    });
+
+    // $transaction returns 1000 + position, so a stale index reads a neighbouring statement's count.
+    const positionOf = (predicate: (op: unknown) => boolean) => transactionOps.findIndex(predicate);
+    const modelPos = positionOf((op) => (op as { __op?: string })?.__op === 'model');
+    const metricPos = positionOf((op) => (op as { __op?: string })?.__op === 'modelMetric');
+    const rawPos = (table: string) =>
+      positionOf((op) => !!(op as { __raw?: RawCall })?.__raw?.sql.includes(`"${table}"`));
+    expect(result.modelsUpdated).toBe(1000 + modelPos);
+    expect(result.metricsUpdated).toBe(1000 + metricPos);
+    expect(result.paidAccessUpdated).toBe(1000 + rawPos('PaidAccess'));
+    expect(result.donationGoalsUpdated).toBe(1000 + rawPos('DonationGoal'));
+  });
+});

--- a/src/server/services/__tests__/model.service.vae-append-no-mutation.test.ts
+++ b/src/server/services/__tests__/model.service.vae-append-no-mutation.test.ts
@@ -88,8 +88,12 @@ vi.mock('~/server/services/user.service', () => ({
   getProfilePicturesForUsers: vi.fn().mockResolvedValue({}),
 }));
 vi.mock('~/server/services/cosmetic.service', () => ({ getCosmeticsForEntity: vi.fn() }));
+// This list must track model.service's own import list from this module. A missing name is not a
+// test failure — vitest throws it during module evaluation, so the file collects ZERO tests and the
+// run stays green with this guard silently absent.
 vi.mock('~/server/redis/caches', () => ({
   dataForModelsCache: { fetch: vi.fn() },
+  modelVersionPublicDonationGoalsCache: { fetch: vi.fn(), bust: vi.fn() },
   modelTagCache: { fetch: vi.fn(), bust: vi.fn() },
   modelVotableTagsCache: { fetch: vi.fn(), bust: vi.fn() },
   userBasicCache: { fetch: vi.fn().mockResolvedValue({}), bust: vi.fn() },

--- a/src/server/services/__tests__/model.service.vae-append-no-mutation.test.ts
+++ b/src/server/services/__tests__/model.service.vae-append-no-mutation.test.ts
@@ -75,6 +75,7 @@ vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
 vi.mock('~/server/services/paid-access.service', () => ({
   getPaidAccess: vi.fn(),
   getPublicPaidAccessForModelVersions: vi.fn().mockResolvedValue({}),
+  bustPaidAccessCache: vi.fn(),
   bustModelSaleCache: vi.fn(),
 }));
 vi.mock('~/server/services/creator-program.service', () => ({

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -47,6 +47,7 @@ import {
 import {
   dataForModelsCache,
   modelTagCache,
+  modelVersionPublicDonationGoalsCache,
   modelVotableTagsCache,
   userBasicCache,
   userModelCountCache,
@@ -174,6 +175,8 @@ import {
 import { decreaseDate } from '~/utils/date-helpers';
 import { isPaidAccessActive } from '@civitai/buzz';
 import {
+  bustModelSaleCache,
+  bustPaidAccessCache,
   getPaidAccess,
   getPublicPaidAccessForModelVersions,
 } from '~/server/services/paid-access.service';
@@ -4767,6 +4770,34 @@ export async function transferModelOwnership({
       where: { id: { in: modelIds } },
       data: { userId: targetUserId },
     }),
+    // PaidAccess.ownerId is a denormalised copy of the model owner, and it is what decides who
+    // generates free from a gated version and whose scheduled sales may reprice it. Left behind, the
+    // previous owner keeps both over a model they no longer hold. Joined against ModelVersion rather
+    // than a pre-read id list so a version created between the read and this statement is still moved.
+    dbWrite.$executeRaw`
+      UPDATE "PaidAccess" pa
+      SET "ownerId" = ${targetUserId}, "updatedAt" = NOW()
+      FROM "ModelVersion" mv
+      WHERE pa."entityType" = 'ModelVersion'::"PaidAccessEntityType"
+        AND pa."entityId" = mv.id
+        AND mv."modelId" = ANY(${modelIds}::int[])
+        AND pa."ownerId" <> ${targetUserId}
+    `,
+    // DonationGoal.userId is the other owner copy the transfer used to miss, and this one routes
+    // money: a donation pays goal.userId, so a donation on a transferred model paid the previous
+    // owner. The target is dual-written (legacy modelVersionId + polymorphic entityType/entityId), so
+    // both spellings are matched.
+    dbWrite.$executeRaw`
+      UPDATE "DonationGoal" dg
+      SET "userId" = ${targetUserId}
+      FROM "ModelVersion" mv
+      WHERE mv."modelId" = ANY(${modelIds}::int[])
+        AND (
+          dg."modelVersionId" = mv.id
+          OR (dg."entityType" = 'ModelVersion'::"PaidAccessEntityType" AND dg."entityId" = mv.id)
+        )
+        AND dg."userId" <> ${targetUserId}
+    `,
     dbWrite.modelMetric.updateMany({
       where: { modelId: { in: modelIds } },
       data: { userId: targetUserId },
@@ -4788,10 +4819,23 @@ export async function transferModelOwnership({
     await tracker.modelEvent({ type: 'Transfer', modelId: m.id, nsfw: m.nsfw });
   }
 
+  const affectedVersionIds = (
+    await dbWrite.modelVersion.findMany({
+      where: { modelId: { in: modelIds } },
+      select: { id: true },
+    })
+  ).map((v) => v.id);
+
   await Promise.all([
     modelsSearchIndex.queueUpdate(
       modelIds.map((id) => ({ id, action: SearchIndexUpdateQueueAction.Update }))
     ),
+    // Every one of these holds an owner-derived value for an hour with SWR off: the gate row carries
+    // ownerId itself, the public donation goal carries userId, and the model sale badge is resolved
+    // through Model.userId.
+    bustPaidAccessCache('ModelVersion', affectedVersionIds),
+    bustModelSaleCache(affectedVersionIds),
+    modelVersionPublicDonationGoalsCache.bust(affectedVersionIds),
     affectedImageIds.length
       ? queueImageSearchIndexUpdate({
           ids: affectedImageIds,
@@ -4810,9 +4854,11 @@ export async function transferModelOwnership({
       sourceUserIds,
       modUserId,
       modelsUpdated: result[0].count,
-      metricsUpdated: result[1].count,
-      postsUpdated: Number(result[2]),
-      imagesUpdated: Number(result[3]),
+      paidAccessUpdated: Number(result[1]),
+      donationGoalsUpdated: Number(result[2]),
+      metricsUpdated: result[3].count,
+      postsUpdated: Number(result[4]),
+      imagesUpdated: Number(result[5]),
     },
   }).catch(() => null);
 
@@ -4820,8 +4866,10 @@ export async function transferModelOwnership({
 
   return {
     modelsUpdated: result[0].count,
-    metricsUpdated: result[1].count,
-    postsUpdated: Number(result[2]),
-    imagesUpdated: Number(result[3]),
+    paidAccessUpdated: Number(result[1]),
+    donationGoalsUpdated: Number(result[2]),
+    metricsUpdated: result[3].count,
+    postsUpdated: Number(result[4]),
+    imagesUpdated: Number(result[5]),
   };
 }

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -175,7 +175,6 @@ import {
 import { decreaseDate } from '~/utils/date-helpers';
 import { isPaidAccessActive } from '@civitai/buzz';
 import {
-  bustModelSaleCache,
   bustPaidAccessCache,
   getPaidAccess,
   getPublicPaidAccessForModelVersions,
@@ -4774,6 +4773,11 @@ export async function transferModelOwnership({
     // generates free from a gated version and whose scheduled sales may reprice it. Left behind, the
     // previous owner keeps both over a model they no longer hold. Joined against ModelVersion rather
     // than a pre-read id list so a version created between the read and this statement is still moved.
+    //
+    // ModelVersionSale.userId deliberately does NOT move: a sale is the previous owner's pricing
+    // decision. getSalesFor re-checks it against the owner resolved here, so their running sale stops
+    // applying to a transferred version — the version reprices to full at the transfer, and that is the
+    // intended outcome, not an oversight.
     dbWrite.$executeRaw`
       UPDATE "PaidAccess" pa
       SET "ownerId" = ${targetUserId}, "updatedAt" = NOW()
@@ -4786,16 +4790,28 @@ export async function transferModelOwnership({
     // DonationGoal.userId is the other owner copy the transfer used to miss, and this one routes
     // money: a donation pays goal.userId, so a donation on a transferred model paid the previous
     // owner. The target is dual-written (legacy modelVersionId + polymorphic entityType/entityId), so
-    // both spellings are matched.
+    // both spellings have to move — as two statements, not one OR, because an OR across them makes the
+    // planner drive from DonationGoal and seq-scan the whole table on every transfer regardless of how
+    // many models it names (measured on prod: 176ms/155k buffers as an OR, ~20ms/3k buffers split).
+    // The `userId <> target` guard also makes the two disjoint, so their counts sum without
+    // double-counting a dual-written row — which holds only because these run in ONE transaction, in
+    // THIS order, with that guard: leg 1 writes the target, so leg 2 no longer matches the row. Move
+    // either statement out of the array or reorder them and the sum silently double-counts.
     dbWrite.$executeRaw`
       UPDATE "DonationGoal" dg
       SET "userId" = ${targetUserId}
       FROM "ModelVersion" mv
       WHERE mv."modelId" = ANY(${modelIds}::int[])
-        AND (
-          dg."modelVersionId" = mv.id
-          OR (dg."entityType" = 'ModelVersion'::"PaidAccessEntityType" AND dg."entityId" = mv.id)
-        )
+        AND dg."modelVersionId" = mv.id
+        AND dg."userId" <> ${targetUserId}
+    `,
+    dbWrite.$executeRaw`
+      UPDATE "DonationGoal" dg
+      SET "userId" = ${targetUserId}
+      FROM "ModelVersion" mv
+      WHERE mv."modelId" = ANY(${modelIds}::int[])
+        AND dg."entityType" = 'ModelVersion'::"PaidAccessEntityType"
+        AND dg."entityId" = mv.id
         AND dg."userId" <> ${targetUserId}
     `,
     dbWrite.modelMetric.updateMany({
@@ -4826,21 +4842,50 @@ export async function transferModelOwnership({
     })
   ).map((v) => v.id);
 
+  // Fail-open, individually. These run AFTER the commit, so a throw here reports failure for a
+  // transfer that already happened — and the retry is refused by the pre-flight guard above, leaving
+  // the operator with no in-product way to finish the invalidation. A logged stale cache expires on
+  // its own; nothing here can misroute money, because both payout paths read the primary fresh.
+  const invalidation = (name: string, work: Promise<unknown>) =>
+    work.catch((error) =>
+      logToAxiom({
+        type: 'error',
+        name: 'model-ownership-transfer-invalidation',
+        message: `${name} failed after a committed transfer`,
+        error: { name, modelIds, targetUserId, error: String(error) },
+      }).catch(() => null)
+    );
+
   await Promise.all([
-    modelsSearchIndex.queueUpdate(
-      modelIds.map((id) => ({ id, action: SearchIndexUpdateQueueAction.Update }))
+    // Everything keyed off the owner. modelVersionAccessCache is the one that matters most here: it
+    // holds Model.userId for a DAY, and hasEntityAccess grants "owners always have access" from it, so
+    // without this the previous owner keeps reaching a gated version the UPDATE above just moved.
+    // Also queues the model search-index update these transferred models need.
+    invalidation('bustMvCache', bustMvCache(affectedVersionIds, modelIds)),
+    // Deliberately duplicated with the queueUpdate inside bustMvCache. That one sits behind four
+    // awaits that can throw, and it is the only leg here whose loss is permanent — every cache
+    // self-heals on a TTL, while the Meilisearch document keeps the previous owner until something
+    // else touches the model. A duplicate enqueue is free: processQueues dedupes with a Set.
+    invalidation(
+      'modelsSearchIndex.queueUpdate',
+      modelsSearchIndex.queueUpdate(
+        modelIds.map((id) => ({ id, action: SearchIndexUpdateQueueAction.Update }))
+      )
     ),
-    // Every one of these holds an owner-derived value for an hour with SWR off: the gate row carries
-    // ownerId itself, the public donation goal carries userId, and the model sale badge is resolved
-    // through Model.userId.
-    bustPaidAccessCache('ModelVersion', affectedVersionIds),
-    bustModelSaleCache(affectedVersionIds),
-    modelVersionPublicDonationGoalsCache.bust(affectedVersionIds),
+    // Not covered by bustMvCache: the gate row carries ownerId, the public donation goal carries userId.
+    invalidation('bustPaidAccessCache', bustPaidAccessCache('ModelVersion', affectedVersionIds)),
+    invalidation(
+      'bustPublicDonationGoals',
+      modelVersionPublicDonationGoalsCache.bust(affectedVersionIds)
+    ),
     affectedImageIds.length
-      ? queueImageSearchIndexUpdate({
-          ids: affectedImageIds,
-          action: SearchIndexUpdateQueueAction.Update,
-        })
+      ? invalidation(
+          'queueImageSearchIndexUpdate',
+          queueImageSearchIndexUpdate({
+            ids: affectedImageIds,
+            action: SearchIndexUpdateQueueAction.Update,
+          })
+        )
       : Promise.resolve(),
   ]);
 
@@ -4855,10 +4900,10 @@ export async function transferModelOwnership({
       modUserId,
       modelsUpdated: result[0].count,
       paidAccessUpdated: Number(result[1]),
-      donationGoalsUpdated: Number(result[2]),
-      metricsUpdated: result[3].count,
-      postsUpdated: Number(result[4]),
-      imagesUpdated: Number(result[5]),
+      donationGoalsUpdated: Number(result[2]) + Number(result[3]),
+      metricsUpdated: result[4].count,
+      postsUpdated: Number(result[5]),
+      imagesUpdated: Number(result[6]),
     },
   }).catch(() => null);
 
@@ -4867,9 +4912,9 @@ export async function transferModelOwnership({
   return {
     modelsUpdated: result[0].count,
     paidAccessUpdated: Number(result[1]),
-    donationGoalsUpdated: Number(result[2]),
-    metricsUpdated: result[3].count,
-    postsUpdated: Number(result[4]),
-    imagesUpdated: Number(result[5]),
+    donationGoalsUpdated: Number(result[2]) + Number(result[3]),
+    metricsUpdated: result[4].count,
+    postsUpdated: Number(result[5]),
+    imagesUpdated: Number(result[6]),
   };
 }


### PR DESCRIPTION
`PaidAccess.ownerId` is a denormalised copy of the model owner, written when the gate is created.
`transferModelOwnership` moved `Model.userId` and left those rows on the previous owner, so a
transferred model answered "who owns this gate?" differently depending on which path asked.

Closes CU 868kv6nz1.

## Every reader of the column

Enumerated before changing anything — 5 call sites read it, 2 of them decide authorization:

| Reader | What the stale value did |
|---|---|
| `generation/paid-access-gating.ts` — `isOwnerOrMod(row.ownerId)` | the **previous** owner kept free generation on a gated version they no longer own; the new owner was charged for their own model |
| `getSalesFor` — `sale.userId !== ownerOfVersion` | a sale scheduled by the **new** owner never applied. The model-card badge (`querySalesForModels`) resolves the owner from `m."userId"` instead, so the card advertised a discount the version page and the charge did not give — the one case `getActiveSalesForModels` says must never happen |
| `model-version.service.ts` `earlyAccessPurchase` → `getFreshSalesForPermanentGate(…, paidAccess.ownerId)` | same sale mismatch, on the charge itself |
| `getViewerMonetization`'s `ownerOf` fallback | cap tier resolved against the old owner when the caller passes no `ownerId` (the generation path) |
| `getPaidAccess` consumers that ignore `ownerId` (`common.service`, `file.service`, `donation-goal.service`, the v1 API) | unaffected |

Money itself was never misrouted: `earlyAccessPurchase` pays `modelVersion.model.userId` and caps
against that same user. The damage was authorization and pricing.

## The fix

Three statements in the **same** `$transaction` as the `Model` update — one for `PaidAccess`, and one
per dual-written `DonationGoal` target spelling — each joined through `ModelVersion` so a version
created between the read and the write is still covered. `updatedAt` is set explicitly on `PaidAccess`:
`@updatedAt` is a Prisma-side default and a raw UPDATE does not apply it.

The two `DonationGoal` legs are two statements rather than one `OR` because the `OR` made the planner
drive from `DonationGoal` and seq-scan the whole table on every transfer *regardless of how many models
it named* — measured on prod: 176ms / 155k buffers as an `OR`, ~20ms / 3k split. Their counts sum
without double-counting because the `userId <> target` guard makes them disjoint, which holds only
while they stay in one transaction in this order.

Invalidation runs after the commit, **fail-open per leg**. It has to be post-commit and it has to not
throw: the pre-flight guard refuses a retry once the models belong to the target, so a redis blip
throwing here left the moderator with a committed transfer, an error saying otherwise, and no way to
finish. Each leg logs its own failure to Axiom instead.

`bustMvCache` carries most of it — including `modelVersionAccessCache`, which caches `Model.userId` for
a **day** and is what `hasEntityAccess` grants "owners always have access" from. That one is the reason
this section exists: without it the previous owner kept reaching a gated version for 24h after the
column moved. The gate row and the public donation-goal cache are busted alongside it, and the
search-index enqueue is kept explicit even though `bustMvCache` also does it: inside, it sits behind
four awaits that can throw, and it is the only leg with no TTL to heal on.

## Other owner copies, and why they are not in here

- **`ModelVersionSale.userId`** — deliberately left. A sale is the previous owner's pricing decision;
  with this fix in, it stops applying to a model they no longer hold, which is the safe outcome.
  Moving it would hand the new owner a discount they never authored.
- **`DonationGoal.userId`** — found mid-work and **folded into this PR on Justin's call**: it routes
  money (`donation-goal.service.ts` pays `goal.userId`), so it is the half of this bug that needs the
  backfill. 92 rows out of step on prod, 68 active.
- **`BlockBuzzAttribution` / `BlockSpendAttribution` / `Donation`** — historical payment records. Must
  not move.

## Backfill

`packages/civitai-db-schema/prisma/migrations/20260822160000_backfill_owner_copies_after_transfer/migration.sql`
— **not auto-applied**, needs a human. Idempotent, and a no-op once this is deployed.

🔴 **Merging this does not finish the job.** Measured on the prod replica 2026-08-22:

| | out of step | in step |
|---|---|---|
| `PaidAccess` | **0** | 4,773 (and 0 orphans — so the query could see one) |
| `DonationGoal` | **92** (68 active) | 21,996 |

Those 92 stay as they are until someone runs the migration. The file lists the caches to purge
afterwards, including the day-TTL one.

## Review

Five lanes. The findings that changed the code: the day-long access cache above (reuse), the `OR`
seq-scan (perf), the unrecoverable post-commit throw and the search-index enqueue (correctness), and
four WHERE-clause mutations the tests did not catch (test).

One further owner copy came out of it and is filed rather than folded in: `Placement.ownerId` is copied
from `image.userId` and is what escrow pays, and this transaction moves those images. Measured first —
1,496 image placements, **0** out of step against 1,330 comparable rows — so there is nothing to
remediate today. CU 868kv6rhx.

Left for a decision rather than guessed: `modelIds` has no `.max()`, and the post-commit tail now fans
out one orchestrator HTTP invalidation per resource.

## Tests

`model.service.transfer-paid-access-owner.test.ts` drives the real `transferModelOwnership` and asserts
on the operations handed to `$transaction`. Positive controls run against the actual code:

**12 of 12 mutations caught**, each run against the real code rather than reasoned about. Four of them
passed the first version of this suite, including two that are site-wide takeovers:

- dropping `pa."entityId" = mv.id` — a cross join that moves **every gate on the site** to the
  transferee
- dropping the model scope from a `DonationGoal` leg — **every donation goal on the site** retargeted
- `<>` flipped to `=` — the whole fix becomes a permanent no-op
- the `PaidAccessEntityType` literal changed — moves nothing

The rest: deleting either statement, narrowing the version read, swapping the renumbered
`postsUpdated`/`imagesUpdated` indices, `mv."modelId"` → `mv.id`, moving the busts *before* the
transaction, and unguarding one bust.

The original weakness was that the assertions covered the SET clause and almost none of the WHERE,
which is where the blast radius lives. Values are now tied to the SQL fragment they follow — the first
version passed a wrong-owner mutation because the target id also appears in the `ownerId <> …` guard,
so the value list contained it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
