### PR TITLE
fix(user): defer the reap of a replaced profile picture instead of destroying it inline

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260822120000_job_queue_replaced_image_delete/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260822120000_job_queue_replaced_image_delete/migration.sql
@@ -1,0 +1,5 @@
+-- Replacing a profile picture used to destroy the previous image inline (row + stored
+-- object), so every cached reference to it became a 404 rather than merely stale. The
+-- replacement is now queued here and reaped by `remove-replaced-images` after a window
+-- comfortably longer than the image CDN's 24h redirect TTL.
+ALTER TYPE "JobQueueType" ADD VALUE IF NOT EXISTS 'ReplacedImageDelete';

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -5473,6 +5473,7 @@ enum JobQueueType {
   ModerationRequest
   BlockedImageDelete
   ImageScan
+  ReplacedImageDelete
 }
 
 model JobQueue {

--- a/packages/civitai-db-schema/src/enums.ts
+++ b/packages/civitai-db-schema/src/enums.ts
@@ -902,6 +902,7 @@ export const JobQueueType = {
   ModerationRequest: 'ModerationRequest',
   BlockedImageDelete: 'BlockedImageDelete',
   ImageScan: 'ImageScan',
+  ReplacedImageDelete: 'ReplacedImageDelete',
 } as const;
 
 export type JobQueueType = (typeof JobQueueType)[keyof typeof JobQueueType];

--- a/packages/civitai-db-schema/src/kysely/enums.ts
+++ b/packages/civitai-db-schema/src/kysely/enums.ts
@@ -723,6 +723,7 @@ export const JobQueueType = {
   ModerationRequest: 'ModerationRequest',
   BlockedImageDelete: 'BlockedImageDelete',
   ImageScan: 'ImageScan',
+  ReplacedImageDelete: 'ReplacedImageDelete',
 } as const;
 export type JobQueueType = (typeof JobQueueType)[keyof typeof JobQueueType];
 export const VaultItemStatus = {

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -178,7 +178,7 @@ export type PurchasableRewardUsage = "SingleUse" | "MultiUse";
 
 export type EntityType = "Image" | "Post" | "Article" | "Bounty" | "BountyEntry" | "ModelVersion" | "Model" | "Collection" | "Comment" | "CommentV2" | "User" | "UserProfile" | "ResourceReview" | "ChatMessage" | "Model3D";
 
-export type JobQueueType = "CleanUp" | "UpdateMetrics" | "UpdateNsfwLevel" | "UpdateSearchIndex" | "CleanIfEmpty" | "ModerationRequest" | "BlockedImageDelete" | "ImageScan";
+export type JobQueueType = "CleanUp" | "UpdateMetrics" | "UpdateNsfwLevel" | "UpdateSearchIndex" | "CleanIfEmpty" | "ModerationRequest" | "BlockedImageDelete" | "ImageScan" | "ReplacedImageDelete";
 
 export type VaultItemStatus = "Pending" | "Stored" | "Failed";
 

--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -112,6 +112,7 @@ import { updateModelVersionNsfwLevelsJob } from '~/server/jobs/update-model-vers
 import { updateUserScore } from '~/server/jobs/update-user-score';
 import { userDeletedCleanup } from '~/server/jobs/user-deleted-cleanup';
 import { removeDeletedUserImages } from '~/server/jobs/remove-deleted-user-images';
+import { removeReplacedImages } from '~/server/jobs/remove-replaced-images';
 import { restoreUserImages } from '~/server/jobs/restore-user-images';
 import { expireStrikesJob, processTimedUnmutesJob } from '~/server/jobs/process-strikes';
 import { processEnqueuedComicPanelsJob } from '~/server/jobs/process-enqueued-comic-panels';
@@ -146,6 +147,7 @@ export const jobs: Job[] = [
   ...leaderboardJobs,
   ingestImages,
   removeBlockedImages,
+  removeReplacedImages,
   processScheduledPublishing,
   // refreshImageGenerationCoverage,
   cleanImageResources,

--- a/src/server/controllers/__tests__/user.controller.profile-picture-deferred-reap.test.ts
+++ b/src/server/controllers/__tests__/user.controller.profile-picture-deferred-reap.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as UserService from '~/server/services/user.service';
+
+/**
+ * #4272 — replacing a profile picture must not DESTROY the previous one.
+ *
+ * The old behaviour hard-deleted the previous `Image` row and its stored object inline, the
+ * moment the new picture saved. The write is instant; the references are not — the image CDN
+ * caches its redirect for 24h, the account-switcher roster in localStorage is durable by
+ * design, and other surfaces hold rendered avatar urls. None of those are bugs on their own:
+ * they only became user-visible breakage because the target was *gone* rather than merely
+ * *stale*. A stale-but-present avatar is invisible; a deleted one is a broken image.
+ *
+ * These tests pin the BEHAVIOUR on the writer side of the seam — nothing about the
+ * replacement destroys the old image, and the id is handed to the deferred reaper with the
+ * key that reaper reads. The reader side (the window actually closing, and a re-adopted
+ * image surviving it) is `src/server/jobs/__tests__/remove-replaced-images.test.ts`; both
+ * files address the queue through the same `EntityType`/`JobQueueType` constants, so a
+ * drift between writer and reader fails one of them rather than shipping.
+ *
+ * `queueReplacedImageDeletion` is deliberately NOT mocked: this file loads the real
+ * `image.service` (`importOriginal`) so the assertion is about the statement that reaches
+ * the database, not about a spy having been called.
+ */
+
+const {
+  mockUpdateUserById,
+  mockGetUserById,
+  mockIngestImage,
+  mockDeleteImageById,
+  mockDeleteImages,
+} = vi.hoisted(() => ({
+  mockUpdateUserById: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockIngestImage: vi.fn(),
+  mockDeleteImageById: vi.fn(),
+  mockDeleteImages: vi.fn(),
+}));
+
+vi.mock('~/server/services/orchestrator/civitai', () => ({
+  invalidateCivitaiUser: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('~/utils/signal-client', () => ({
+  signalClient: { send: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock('~/server/services/user.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof UserService>()),
+  getUserById: mockGetUserById,
+  updateUserById: mockUpdateUserById,
+  updateLeaderboardRankForUsers: vi.fn(),
+  equipCosmetic: vi.fn(),
+  unequipCosmeticByType: vi.fn(),
+  createUserReferral: vi.fn(),
+  isUsernamePermitted: vi.fn(async () => true),
+  queueModelMetricPrivacyReindex: vi.fn(),
+}));
+// Only the two destroyers and the scanner hop are stubbed. `queueReplacedImageDeletion` is
+// the real implementation, running against the canonical db mock.
+vi.mock('~/server/services/image.service', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ingestImage: mockIngestImage,
+  deleteImageById: mockDeleteImageById,
+  deleteImages: mockDeleteImages,
+}));
+vi.mock('~/server/search-index', () => ({ usersSearchIndex: { queueUpdate: vi.fn() } }));
+vi.mock('~/server/cloudflare/client', () => ({ purgeCache: vi.fn(() => ({ catch: vi.fn() })) }));
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
+import { updateUserHandler } from '~/server/controllers/user.controller';
+import { EntityType, JobQueueType } from '~/shared/utils/prisma/enums';
+
+const USER_ID = 5;
+const OLD_PICTURE_ID = 42;
+const NEW_PICTURE_ID = 99;
+// A real profile picture url is a CF Images UUID — `verifyAvatar` drops anything else, and a
+// dropped url takes the whole replacement branch with it, so a plausible-looking https fixture
+// would make every assertion below pass vacuously.
+const NEW_AVATAR = '5c4d0f2e-7a91-4b6d-8e33-2f1c9ab07d54';
+
+/** Every `$executeRaw` the handler issued, as `{ sql, values }`. */
+function writes() {
+  return dbMock.dbWrite.$executeRaw.mock.calls.map((call: unknown[]) => ({
+    sql: (call[0] as TemplateStringsArray).join('?'),
+    values: call.slice(1),
+  }));
+}
+
+function queueInsert() {
+  return writes().find((w) => w.sql.includes('INSERT INTO "JobQueue"'));
+}
+
+const replacePicture = (pictureId = NEW_PICTURE_ID) =>
+  updateUserHandler({
+    ctx: { user: { id: USER_ID } },
+    input: {
+      id: USER_ID,
+      profilePicture: { id: pictureId, url: NEW_AVATAR, type: 'image', width: 256, height: 256 },
+    },
+  } as never);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserById.mockResolvedValue({ profilePictureId: OLD_PICTURE_ID });
+  mockUpdateUserById.mockResolvedValue({ id: USER_ID, profilePictureId: NEW_PICTURE_ID });
+  mockIngestImage.mockResolvedValue(undefined);
+});
+
+describe('profile picture replacement (#4272)', () => {
+  it('does not destroy the previous image — no row delete, no object delete', async () => {
+    await replacePicture();
+
+    // The two paths that would take the old picture off the internet. Either one firing here
+    // reinstates the 404: the CDN keeps serving its cached redirect to a url that is gone.
+    expect(mockDeleteImageById).not.toHaveBeenCalled();
+    expect(mockDeleteImages).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.image.delete).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.image.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('queues the previous image for a deferred reap, addressed the way the reaper reads it', async () => {
+    await replacePicture();
+
+    const insert = queueInsert();
+    expect(insert).toBeDefined();
+    // The id, and the exact (entityType, type) pair `remove-replaced-images` selects on. A
+    // queue row written under any other key is invisible to the reaper, which would leak the
+    // image forever rather than reap it late.
+    const bound = insert!.values.flatMap((v) =>
+      // Prisma.sql fragments arrive as one value carrying its own `values`.
+      Array.isArray((v as { values?: unknown[] })?.values)
+        ? (v as { values: unknown[] }).values
+        : [v]
+    );
+    expect(bound).toContain(OLD_PICTURE_ID);
+    expect(bound).toContain(EntityType.Image);
+    expect(bound).toContain(JobQueueType.ReplacedImageDelete);
+  });
+
+  it('restarts the retention window when an image is queued a second time', async () => {
+    await replacePicture();
+
+    // A user can re-select a picture they previously replaced away from, so the same id can
+    // reach the queue twice. `ON CONFLICT DO NOTHING` would leave the FIRST replacement's
+    // clock in place, and the second replacement would then get no retention at all — the
+    // bug this whole change exists to remove, re-created on a slower path.
+    expect(queueInsert()!.sql).toMatch(/ON CONFLICT[\s\S]*DO UPDATE SET "createdAt" = NOW\(\)/);
+  });
+
+  it('still applies the new picture immediately', async () => {
+    await replacePicture();
+
+    // Deferral must not be visible on the happy path: the user's new avatar takes effect on
+    // save, exactly as before.
+    const data = mockUpdateUserById.mock.calls[0][0].data;
+    expect(data.profilePicture.connectOrCreate.where).toEqual({ id: NEW_PICTURE_ID });
+    expect(mockIngestImage).toHaveBeenCalled();
+  });
+
+  it('queues nothing when the picture is unchanged', async () => {
+    // Re-saving the same picture is not a replacement. Queuing here would schedule the
+    // CURRENT avatar for deletion.
+    mockGetUserById.mockResolvedValue({ profilePictureId: NEW_PICTURE_ID });
+
+    await replacePicture(NEW_PICTURE_ID);
+
+    expect(queueInsert()).toBeUndefined();
+    expect(mockDeleteImageById).not.toHaveBeenCalled();
+  });
+
+  it('queues nothing when the user had no previous picture', async () => {
+    mockGetUserById.mockResolvedValue({ profilePictureId: null });
+
+    await replacePicture();
+
+    expect(queueInsert()).toBeUndefined();
+  });
+
+  it('still saves the profile when the enqueue itself fails', async () => {
+    // The enqueue runs inside the `Promise.all` that decides whether the save reports
+    // success, and the save has already COMMITTED by then. A rejecting enqueue would
+    // therefore turn a successful save into "error updating your profile" — which is also
+    // exactly what a deploy that lands before the enum migration would do on every avatar
+    // change. Failing to queue is a leaked object, not a user-visible failure.
+    dbMock.dbWrite.$executeRaw.mockRejectedValueOnce(
+      new Error('invalid input value for enum "JobQueueType"')
+    );
+
+    await expect(replacePicture()).resolves.toMatchObject({ id: USER_ID });
+    expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'queue-replaced-image-deletion-failed' })
+    );
+  });
+});

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -138,7 +138,11 @@ import {
   computeUserFeatureFlagsOverlay,
   defaultToggleableFeatures,
 } from '../services/feature-flags.service';
-import { deleteImageById, getEntityCoverImage, ingestImage } from '../services/image.service';
+import {
+  getEntityCoverImage,
+  ingestImage,
+  queueReplacedImageDeletion,
+} from '../services/image.service';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 
 export const getAllUsersHandler = async ({
@@ -566,9 +570,17 @@ export const updateUserHandler = async ({
     // Post-update operations â€” parallelize independent work
     const postUpdatePromises: Promise<unknown>[] = [];
 
-    // Delete old profilePic and ingest new one
+    // Queue the old profilePic for a DEFERRED reap, and ingest the new one.
+    //
+    // This used to be an inline `deleteImageById`, which destroyed the row and the stored
+    // object the instant the new picture saved. The write is instant; the references are
+    // not — the image CDN caches its redirect for 24h, the account-switcher roster in
+    // localStorage is durable by design, and other surfaces hold rendered avatar urls. None
+    // of those are bugs on their own; they only became user-visible breakage because the
+    // target was *gone* rather than merely *stale*. Queuing instead keeps the old picture
+    // fetchable for the retention window, so every one of those caches self-corrects.
     if (user.profilePictureId && profilePicture && user.profilePictureId !== profilePicture.id) {
-      postUpdatePromises.push(deleteImageById({ id: user.profilePictureId }));
+      postUpdatePromises.push(queueReplacedImageDeletion([user.profilePictureId]));
     }
 
     if (

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:3867':
+  'server/services/image.service.ts:3925':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:3997':
+  'server/services/image.service.ts:4055':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4707':
+  'server/services/image.service.ts:4765':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5817':
+  'server/services/image.service.ts:5875':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -206,7 +206,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:3997')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4055')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/jobs/__tests__/remove-replaced-images.test.ts
+++ b/src/server/jobs/__tests__/remove-replaced-images.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * #4272, reader side — the deferred reap for images that were REPLACED rather than deleted.
+ *
+ * `updateUserHandler` no longer destroys the previous profile picture inline; it writes a
+ * `JobQueue(ReplacedImageDelete, Image)` row and this job collects it later. The properties
+ * that matter, and that a green suite would otherwise not distinguish:
+ *
+ *   1. the window actually CLOSES — a queued image past retention is really destroyed, so
+ *      deferring is not a storage leak dressed up as a fix;
+ *   2. the window is 30 days, measured from the queue row's `createdAt` — an image queued
+ *      29 days ago is still fetchable, which is the whole point (the image CDN's redirect is
+ *      `max-age=86400`, and the account-switcher roster in localStorage outlives that by a
+ *      lot);
+ *   3. a RE-ADOPTED image is never reaped. A user can re-select a picture they previously
+ *      replaced away from; the stale queue row from that earlier replacement then points at
+ *      a live avatar, and deleting it would be a strictly worse version of the original bug;
+ *   4. both cohorts leave the queue, so a re-adopted image cannot be re-examined every run;
+ *   5. a non-prod database is never mass-deleted.
+ *
+ * The fixture drives the retention filter for real — the stubbed `jobQueue.findMany` applies
+ * the `createdAt` bound the job passes — so a mutant that widens, narrows, inverts or drops
+ * the cutoff changes WHICH ids get destroyed, rather than merely changing an argument nobody
+ * reads. The day offsets straddle the boundary on both sides and are not multiples of it.
+ */
+
+const DAY = 24 * 60 * 60 * 1000;
+const daysAgo = (n: number) => new Date(Date.now() - n * DAY);
+
+const EXPIRED_ID = 1; // queued 40d ago, unreferenced -> destroyed
+const JUST_EXPIRED_ID = 2; // queued 31d ago, unreferenced -> destroyed
+const READOPTED_ID = 3; // queued 40d ago, but live again -> kept, dequeued
+const JUST_INSIDE_ID = 4; // queued 29d ago -> still fetchable
+const RECENT_ID = 5; // queued 25d ago -> still fetchable
+
+const QUEUE = [
+  { entityId: EXPIRED_ID, createdAt: daysAgo(40) },
+  { entityId: JUST_EXPIRED_ID, createdAt: daysAgo(31) },
+  { entityId: READOPTED_ID, createdAt: daysAgo(40) },
+  { entityId: JUST_INSIDE_ID, createdAt: daysAgo(29) },
+  { entityId: RECENT_ID, createdAt: daysAgo(25) },
+];
+
+/** Images that are somebody's CURRENT profile picture, i.e. what the User table would return. */
+const LIVE_PROFILE_PICTURE_IDS = [READOPTED_ID];
+
+const { mockDeleteImages, mockEnv } = vi.hoisted(() => ({
+  mockDeleteImages: vi.fn(async () => undefined),
+  mockEnv: { DATABASE_IS_PROD: true },
+}));
+
+// Hand-listed rather than spread from the real module: image.service is ~8k lines and builds
+// module-scope caches on import.
+vi.mock('~/server/services/image.service', () => ({ deleteImages: mockDeleteImages }));
+vi.mock('~/env/other', () => ({ isProd: true }));
+vi.mock('~/env/server', () => ({ env: mockEnv }));
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import {
+  REPLACED_IMAGE_RETENTION_DAYS,
+  removeReplacedImages,
+} from '~/server/jobs/remove-replaced-images';
+import { EntityType, JobQueueType } from '~/shared/utils/prisma/enums';
+
+const ctx = {} as Parameters<typeof removeReplacedImages.run>[0];
+const runJob = () =>
+  removeReplacedImages.run(ctx).result as Promise<Partial<{ deleted: number; readopted: number }>>;
+
+/** Ids handed to the destructive call — i.e. the images that stopped being fetchable. */
+const destroyedIds = () => (mockDeleteImages.mock.calls[0]?.[0] as number[] | undefined) ?? [];
+
+/** Every `$executeRaw` the job issued, as `{ sql, values }`. */
+const writes = () =>
+  dbMock.dbWrite.$executeRaw.mock.calls.map((call: unknown[]) => ({
+    sql: (call[0] as TemplateStringsArray).join('?'),
+    values: call.slice(1),
+  }));
+
+const dequeue = () => writes().find((w) => w.sql.includes('DELETE FROM "JobQueue"'));
+const dequeuedIds = () => (dequeue()?.values.find(Array.isArray) as number[] | undefined) ?? [];
+
+/** The `where` the job asked the queue with — the retention bound lives here. */
+const queueWhere = () => dbMock.dbRead.jobQueue.findMany.mock.calls[0]?.[0]?.where;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnv.DATABASE_IS_PROD = true;
+
+  type QueueQuery = { where?: { createdAt?: { lt?: Date } } };
+  dbMock.dbRead.jobQueue.findMany.mockImplementation(async ({ where }: QueueQuery) => {
+    // Stands in for the DB applying the retention bound the job asked for. If the job stops
+    // passing one, every row comes back and the "still fetchable" cases below are destroyed.
+    const before: Date | undefined = where?.createdAt?.lt;
+    return QUEUE.filter((q) => !before || q.createdAt < before).map(({ entityId }) => ({
+      entityId,
+    }));
+  });
+  // Declared on dbWrite only. The re-adoption probe has to read the primary — a re-adoption
+  // that landed inside replica lag is invisible on the replica, and the job would then delete
+  // the avatar the user just chose. Reading dbRead here returns the canonical mock's empty
+  // default, so that mistake fails the re-adoption test rather than passing quietly.
+  dbMock.dbWrite.$queryRaw.mockImplementation(
+    async (strings: TemplateStringsArray, ...values: unknown[]) => {
+      if (!strings.join('').includes('FROM "User"')) return [];
+      const ids = (values.find(Array.isArray) as number[]) ?? [];
+      return LIVE_PROFILE_PICTURE_IDS.filter((id) => ids.includes(id)).map((id) => ({ id }));
+    }
+  );
+});
+
+describe('remove-replaced-images', () => {
+  it('destroys a replaced image once its window has elapsed', async () => {
+    await runJob();
+
+    // The window closes. Without this the "fix" would just be an unbounded storage leak.
+    expect(destroyedIds()).toContain(EXPIRED_ID);
+    expect(destroyedIds()).toContain(JUST_EXPIRED_ID);
+  });
+
+  it('leaves a replaced image fetchable for the whole 30-day window', async () => {
+    await runJob();
+
+    // 29 and 25 days: both past the CDN's 24h redirect TTL, both still inside retention. This
+    // is the property the issue is about — the old url must resolve, not 404, while any cache
+    // can still be holding it.
+    expect(destroyedIds()).not.toContain(JUST_INSIDE_ID);
+    expect(destroyedIds()).not.toContain(RECENT_ID);
+    expect(dequeuedIds()).not.toContain(JUST_INSIDE_ID);
+    expect(dequeuedIds()).not.toContain(RECENT_ID);
+  });
+
+  it('measures the window from the queue row, at the declared retention', async () => {
+    await runJob();
+
+    const cutoff: Date = queueWhere().createdAt.lt;
+    const expected = Date.now() - REPLACED_IMAGE_RETENTION_DAYS * DAY;
+    expect(REPLACED_IMAGE_RETENTION_DAYS).toBe(30);
+    expect(Math.abs(cutoff.getTime() - expected)).toBeLessThan(60_000);
+    expect(queueWhere()).toMatchObject({
+      type: JobQueueType.ReplacedImageDelete,
+      entityType: EntityType.Image,
+    });
+  });
+
+  it("never reaps an image that is somebody's profile picture again", async () => {
+    const result = await runJob();
+
+    // Re-adoption: the queue row is 40 days old, but the image is live. Destroying it would
+    // break the avatar of a user who never replaced anything.
+    expect(destroyedIds()).not.toContain(READOPTED_ID);
+    expect(result.readopted).toBe(1);
+  });
+
+  it('dequeues the re-adopted image so it is not re-examined every run', async () => {
+    await runJob();
+
+    expect(dequeuedIds()).toContain(READOPTED_ID);
+    expect(dequeuedIds()).toContain(EXPIRED_ID);
+    expect(dequeuedIds()).toContain(JUST_EXPIRED_ID);
+  });
+
+  it('addresses the queue with the same key the writer uses', async () => {
+    await runJob();
+
+    expect(dequeue()!.values).toContain(JobQueueType.ReplacedImageDelete);
+    expect(dequeue()!.values).toContain(EntityType.Image);
+  });
+
+  it('deletes nothing against a non-prod database', async () => {
+    mockEnv.DATABASE_IS_PROD = false;
+
+    await runJob();
+
+    expect(mockDeleteImages).not.toHaveBeenCalled();
+    expect(dequeue()).toBeUndefined();
+  });
+});

--- a/src/server/jobs/remove-replaced-images.ts
+++ b/src/server/jobs/remove-replaced-images.ts
@@ -1,0 +1,112 @@
+import { isProd } from '~/env/other';
+import { env } from '~/env/server';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { createJob } from '~/server/jobs/job';
+import { logToAxiom } from '~/server/logging/client';
+import { deleteImages } from '~/server/services/image.service';
+import { EntityType, JobQueueType } from '~/shared/utils/prisma/enums';
+import { decreaseDate } from '~/utils/date-helpers';
+
+/**
+ * Reaps images that were REPLACED rather than deleted — currently profile pictures swapped
+ * out by `updateUserHandler`, which queues the old id instead of destroying it inline.
+ *
+ * The window has to outlast every cache that can still be holding the old url. The binding
+ * one is the image CDN's redirect (`max-age=86400`), but the account-switcher roster in
+ * localStorage is durable across sessions and only refreshed when the user next signs in,
+ * so the right order of magnitude is days, not hours. 30 days is also what the repo already
+ * uses for the same replaced-then-purge problem on model files (`purge-replaced-files`).
+ */
+export const REPLACED_IMAGE_RETENTION_DAYS = 30;
+
+/** Bounds how much of a backlog one run pulls in. Oldest-first, so the remainder drains later. */
+const BATCH_SIZE = 5000;
+
+type QueueRow = { entityId: number };
+
+/**
+ * Ids from `ids` that are STILL somebody's profile picture and therefore must not be reaped.
+ *
+ * A user can re-select an image they previously replaced away from. That leaves a queue row
+ * whose clock started at the earlier replacement pointing at an image that is live again —
+ * so without this check the job would delete the user's CURRENT avatar, which is a strictly
+ * worse version of the bug it exists to fix. Checked at reap time rather than at re-select
+ * time on purpose: one guard on the destructive side beats keeping every adoption path in
+ * sync with the queue.
+ */
+export async function getStillReferencedImageIds(ids: number[]) {
+  if (!ids.length) return [];
+  // dbWrite, not dbRead: the queue row is 30 days old but a re-adoption can be seconds old, and
+  // one that landed inside replica lag would be invisible here — the job would then delete the
+  // avatar the user just chose. `User.profilePictureId` is `@unique`, so this is an index probe.
+  const rows = await dbWrite.$queryRaw<{ id: number }[]>`
+    SELECT "profilePictureId" AS id
+    FROM "User"
+    WHERE "profilePictureId" = ANY(${ids}::integer[])
+  `;
+  return rows.map((r) => r.id);
+}
+
+export const removeReplacedImages = createJob(
+  'remove-replaced-images',
+  '25 5 * * *',
+  async () => {
+    const cutoff = decreaseDate(new Date(), REPLACED_IMAGE_RETENTION_DAYS, 'days');
+
+    // The cutoff is applied in the query, not after the take: filtering afterwards would let
+    // rows still inside their window occupy the oldest-first batch and starve the ones past it.
+    const jobQueue = await dbRead.jobQueue.findMany({
+      where: {
+        type: JobQueueType.ReplacedImageDelete,
+        entityType: EntityType.Image,
+        createdAt: { lt: cutoff },
+      },
+      select: { entityId: true },
+      take: BATCH_SIZE,
+      orderBy: { createdAt: 'asc' },
+    });
+
+    if (!jobQueue.length) return { deleted: 0, readopted: 0 };
+
+    const queuedIds = (jobQueue as QueueRow[]).map((j) => j.entityId);
+    const readoptedIds = await getStillReferencedImageIds(queuedIds);
+    const readopted = new Set(readoptedIds);
+    const deletableIds = queuedIds.filter((id) => !readopted.has(id));
+
+    // Same two guards `remove-blocked-images` carries: a local run, or an app pointed at a
+    // non-prod copy, must never mass-delete production media out of a restored snapshot.
+    if (!isProd) return { wouldDelete: deletableIds.length, readopted: readopted.size };
+    if (!env.DATABASE_IS_PROD)
+      return { wouldDelete: deletableIds.length, readopted: readopted.size };
+
+    if (deletableIds.length) {
+      // Deletes the row, the stored object, and the caches keyed on it. Past the retention
+      // window there is nothing left to preserve, so this is the same destruction the inline
+      // call used to do — just late enough that no live cache can still be pointing at it.
+      await deleteImages(deletableIds);
+    }
+
+    // Both cohorts leave the queue: the deleted ones are done, and a re-adopted one has no
+    // pending replacement to reap. If it is replaced again, the enqueue re-inserts it with a
+    // fresh clock (ON CONFLICT DO UPDATE in `queueReplacedImageDeletion`).
+    await dbWrite.$executeRaw`
+      DELETE FROM "JobQueue"
+      WHERE type = ${JobQueueType.ReplacedImageDelete}::"JobQueueType"
+        AND "entityType" = ${EntityType.Image}::"EntityType"
+        AND "entityId" = ANY(${queuedIds}::integer[])
+    `;
+
+    logToAxiom({
+      name: 'remove-replaced-images',
+      type: 'info',
+      message: 'finished',
+      deleted: deletableIds.length,
+      readopted: readopted.size,
+    }).catch(() => undefined);
+
+    return { deleted: deletableIds.length, readopted: readopted.size };
+  },
+  // A full batch means thousands of S3 deletes; a second pod grabbing the default 5-minute
+  // lock mid-run would double-delete against S3 and the DB.
+  { lockExpiration: 20 * 60 }
+);

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -588,6 +588,64 @@ export const deleteImageById = async ({
   }
 };
 
+/**
+ * Queue an image that has been REPLACED (not deleted) for destruction later, instead of
+ * destroying it inline.
+ *
+ * A replacement is not a deletion: nobody asked for the old picture to stop existing, they
+ * asked for a new one to start being used. Destroying the old row + stored object at that
+ * moment turns every reference still holding its url into a 404 — and several such caches
+ * are legitimate and long-lived (the image CDN's redirect is `max-age=86400`, the
+ * account-switcher roster in localStorage is durable by design, feeds and embeds hold
+ * rendered urls). A stale-but-present avatar is invisible to a user; a deleted one is a
+ * broken image. Deferring the reap makes the whole class self-correcting rather than
+ * permanently broken until every cache is individually fixed.
+ *
+ * The queue row is the clock: `remove-replaced-images` measures the retention window from
+ * its `createdAt`, exactly as `remove-blocked-images` does for `BlockedImageDelete`.
+ *
+ * `DO UPDATE` rather than `DO NOTHING` (which is what `enqueueJobs` uses) is load-bearing.
+ * A user can re-select a previously-replaced image, so the same id can be queued twice; on
+ * conflict the row must RESTART its window, not inherit the first replacement's clock, or
+ * the second replacement gets no retention at all.
+ *
+ * Errors are swallowed and logged, like `deleteImageById` above. The one caller runs inside
+ * the `Promise.all` that decides whether a profile save reports success, and a save that has
+ * already committed must not surface as "error updating your profile" because a cleanup
+ * enqueue failed. The failure direction is also the safe one: the image stays fetchable and
+ * is not reaped, so the worst case is one leaked object with a log line naming it — never a
+ * broken avatar.
+ */
+export async function queueReplacedImageDeletion(ids: number[]) {
+  // Deduped and chunked like `enqueueJobs`, whose statement shape this otherwise copies. The
+  // dedupe is not hygiene: `DO UPDATE` cannot touch the same row twice in one statement, so a
+  // repeated id in a single call would fail the whole insert.
+  const batches = chunk(uniq(ids), 500);
+  for (const batch of batches) {
+    try {
+      await dbWrite.$executeRaw`
+        INSERT INTO "JobQueue" ("entityId", "entityType", "type")
+        VALUES ${Prisma.join(
+          batch.map(
+            (entityId) =>
+              Prisma.sql`(${entityId}::integer, ${EntityType.Image}::"EntityType", ${JobQueueType.ReplacedImageDelete}::"JobQueueType")`
+          )
+        )}
+        ON CONFLICT ("entityType", "entityId", "type")
+        DO UPDATE SET "createdAt" = NOW()
+      `;
+    } catch (error) {
+      await logToAxiom({
+        type: 'error',
+        name: 'queue-replaced-image-deletion-failed',
+        message: 'replaced image was not queued for deletion; it will not be reaped',
+        imageIds: batch,
+        error: safeError(error),
+      }).catch(() => undefined);
+    }
+  }
+}
+
 export async function deleteImages(ids: number[], updatePosts = true) {
   const images = await Limiter({ batchSize: 100 }).process(ids, async (ids, batchIndex) => {
     const results = await dbWrite.$queryRaw<


### PR DESCRIPTION
Closes #4272.

## The change

Replacing a profile picture called `deleteImageById` on the previous one, which hard-deletes the `Image` row **and** the stored object in the same breath. The write is instant; the references are not — the image CDN caches its redirect for 24h, the account-switcher roster in localStorage is durable by design, and other surfaces hold rendered avatar urls. None of those are bugs on their own. They only became user-visible breakage because the target was *gone* rather than merely *stale*, and a stale-but-present avatar is invisible to a user while a deleted one is a broken image.

The replacement now writes a `JobQueue(ReplacedImageDelete, Image)` row, and a daily `remove-replaced-images` job collects it after 30 days.

## Mechanism reused, not invented

This is the same shape `remove-blocked-images` already uses for `BlockedImageDelete`: the queue row is the clock, retention is measured from its `createdAt`, the batch is oldest-first and bounded, and `deleteImages` does the destruction at the end. `Image` has no soft-delete or tombstone column, and adding one would have meant a nullable column plus an index on a very large table to make the sweep findable; the queue is already indexed by its primary key and already drained by a job family that exists for exactly this.

**Why 30 days.** The CDN's `max-age=86400` redirect is the floor, not the target — the localStorage roster is only refreshed when the user next signs in, so the right order of magnitude is days. 30 days is also the grace period `purge-replaced-files` uses for the identical replaced-then-purge problem on `ModelFile`.

## Scope

Scoped to the profile-picture replacement path, **not** to `deleteImageById`. Its other callers — `imageController.deleteImageById`, `/api/admin/delete-images`, account deletion, article deletion, article orphaned-content-image cleanup — are all answering an explicit "destroy this", where an inline delete is correct and a 30-day tail would be wrong. Only replacement has the property that nobody asked for the old thing to stop existing.

## Re-adoption

A user can re-select an image they previously replaced away from, so two guards:

- the enqueue is `ON CONFLICT … DO UPDATE SET "createdAt" = NOW()`, not `DO NOTHING`. A second replacement restarts the window instead of inheriting the first one's already-expired clock — which would give it no retention at all, i.e. the original bug on a slower path.
- the reaper re-checks `User.profilePictureId` before deleting, and dequeues rather than reaps anything still live. It reads the **primary**: the queue row is 30 days old but a re-adoption can be seconds old, and one inside replica lag would otherwise be invisible.

## Failure direction

The enqueue swallows and logs its own errors (like `deleteImageById` directly above it). Its one caller sits inside the `Promise.all` that decides whether an already-committed profile save reports success, so a rejection would turn a successful save into "error updating your profile". The safe direction is also the useful one: on failure the image stays fetchable and is not reaped, so the worst case is one leaked object with a log line naming it — never a broken avatar.

## Migration

`ReplacedImageDelete` is a new `JobQueueType` value (`ALTER TYPE … ADD VALUE IF NOT EXISTS`). Apply it before the enum is written to. If code lands first, the enqueue logs `queue-replaced-image-deletion-failed` and the old picture is simply retained — which is the behaviour this PR is asking for anyway, just without the eventual cleanup.

## Test matrix

`npx vitest run --project 'unit*' src/server/controllers/__tests__/user.controller.profile-picture-deferred-reap.test.ts src/server/jobs/__tests__/remove-replaced-images.test.ts`

| | executed | result |
|---|---|---|
| `origin/main` (`efd449fc18`), both test files copied in | 7 | **4 failed / 3 passed** — the job file cannot resolve `~/server/jobs/remove-replaced-images` (new module), so it collects 0; the controller file collects 7 and fails 4, headline `expected "vi.fn()" to not be called at all, but actually been called 1 times` on `deleteImageById` |
| HEAD | 14 | **14 passed** |

Wider: `src/server/{jobs,controllers,services,schema}/__tests__` → 393 files / **5183 passed**, 8 skipped, 0 failed. `pnpm typecheck` → 0 `error TS`. eslint on the three new/changed source files → 0 errors (image.service and user.controller carry the same 4 pre-existing errors at base). The `@civitai/*` project has 8 pre-existing failures, identical at base (DB-backed EXPLAIN tests, no database here).

## Mutation check

Nine mutants, each killed by the test whose name states the property, with that test's own assertion message. Control run green (14/14) between batches.

| mutant | killed by | message |
|---|---|---|
| reinstate the inline `deleteImageById` | does not destroy the previous image | `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| invert `!==` → `===` on the replacement branch | queues the previous image / queues nothing when unchanged | `expected undefined to be defined` |
| `DO UPDATE` → `DO NOTHING` | restarts the retention window | `expected '… INSERT INTO "JobQueue" …' to match /ON CONFLICT[\s\S]*DO UPDATE SET "createdAt" = NOW\(\)/` |
| invert the cutoff (`lt` → `gt`) | leaves a replaced image fetchable for the whole 30-day window | `expected [ 1, 2, 4, 5 ] to not include 4` |
| retention 30 → 1 day | same, plus the declared-retention test | `expected [ 1, 2, 4, 5 ] to not include 4` |
| drop the re-adoption guard | never reaps an image that is somebody's profile picture again | `expected [ 1, 2, 3 ] to not include 3` |
| dequeue `deletableIds` instead of `queuedIds` (stale rebind) | dequeues the re-adopted image | `expected [ 1, 2 ] to include 3` |
| re-adoption probe on the replica instead of the primary | never reaps an image that is somebody's profile picture again | `expected [ 1, 2, 3 ] to not include 3` |
| remove the enqueue's try/catch | still saves the profile when the enqueue fails | `promise rejected "TRPCError: invalid input value for enum "JobQueueType"" instead of resolving` |

The job test's fixture drives the retention filter for real — the stubbed `findMany` applies the `createdAt` bound the job passes — so a cutoff mutant changes *which* ids are destroyed rather than an argument nobody reads. Offsets straddle the boundary at 29/31 days and are not multiples of it.

## Other user-replaceable images

- **Profile cover / SFW cover** (`updateUserProfile`) — already safe, and by accident: it `connectOrCreate`s the new image and never deletes the old one, so the previous cover is orphaned rather than destroyed. Nothing to fix for this issue; it leaks instead.
- **Article cover** (`updateArticle`) — **same defect class**: `if (article.coverId !== coverId && article.coverId)` → `deleteImageById`, inline, on replacement. Not fixed here — the reaper's re-adoption guard is written against `User.profilePictureId`, so covering articles means generalising the reference check, and the reported breakage is the avatar path. Worth a follow-up.
- Article deletion and account deletion also call `deleteImageById`, but those are genuine deletions, not replacements.

## Note on an existing test

`user.controller.session-avatar-bust.test.ts` has a comment claiming its fixture takes "the replacement branch, which is the one that hard-deletes the previous image (#4272)". It does not: its avatar url is an `https://images.example.test/…` string, which `verifyAvatar` rejects (a real profile picture url is a CF Images UUID), so `profilePicture` is dropped before the branch. Harmless — that suite asserts session busting and nothing there depends on the branch — but it is why this PR's fixture uses a UUID.
