### PR TITLE
fix(api): only mark a PublicEndpoint response publicly cacheable when it is

### DIFF
--- a/src/server/middleware/api-cache.middleware.ts
+++ b/src/server/middleware/api-cache.middleware.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server';
 import { createMiddleware } from '~/server/middleware/middleware-utils';
+import { PRIVATE_CACHE_CONTROL } from '~/shared/constants/cache-control.constants';
 
 export const apiCacheMiddleware = createMiddleware({
   matcher: ['/api/trpc/:path*', '/api/v1/:path*'],
   handler: async () => {
     const response = NextResponse.next();
-    response.headers.set('Cache-Control', 'max-age=0, private, no-cache'); // Default cache control
+    response.headers.set('Cache-Control', PRIVATE_CACHE_CONTROL); // Default cache control
     if (process.env.PODNAME) response.headers.set('X-Handled-By', process.env.PODNAME);
 
     return response;

--- a/src/server/middleware/api-cache.middleware.ts
+++ b/src/server/middleware/api-cache.middleware.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { createMiddleware } from '~/server/middleware/middleware-utils';
-import { PRIVATE_CACHE_CONTROL } from '~/shared/constants/cache-control.constants';
+import { createMiddleware, PRIVATE_CACHE_CONTROL } from '~/server/middleware/middleware-utils';
 
 export const apiCacheMiddleware = createMiddleware({
   matcher: ['/api/trpc/:path*', '/api/v1/:path*'],

--- a/src/server/middleware/middleware-utils.ts
+++ b/src/server/middleware/middleware-utils.ts
@@ -1,5 +1,18 @@
 import type { NextRequest, NextResponse } from 'next/server';
 
+/**
+ * The platform's safe default `Cache-Control` for API responses: usable by the
+ * caller's own browser only, and revalidated every time.
+ *
+ * `apiCacheMiddleware` states it for the prefixes its matcher covers; the
+ * endpoint wrappers in `~/server/utils/endpoint-helpers` state the same string
+ * for the routes that sit outside those prefixes. Single-sourced here — the
+ * module that already defines the middleware contract, is already loaded by the
+ * proxy graph, and imports nothing but a `next/server` type — so the two cannot
+ * drift and no additional module is pulled into either graph.
+ */
+export const PRIVATE_CACHE_CONTROL = 'max-age=0, private, no-cache';
+
 export type Middleware = {
   matcher: string[];
   shouldRun?: (request: NextRequest) => boolean;

--- a/src/server/utils/__tests__/mixed-auth-endpoint-cache.test.ts
+++ b/src/server/utils/__tests__/mixed-auth-endpoint-cache.test.ts
@@ -17,7 +17,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  *   2. **The credentialed arm states a header.** It previously stated nothing and
  *      relied on `apiCacheMiddleware`, whose matcher is `/api/trpc/*` and
  *      `/api/v1/*` only. Two of this wrapper's twelve routes sit outside that:
- *      `/api/auth/freshdesk` (a 302 whose `Location` carries a per-user JWT),
+ *      `/api/auth/freshdesk`, a redirect whose target is caller-specific and
  *      which had no `Cache-Control` at all, and the 404 arms of
  *      `/api/blocks/screenshot/[appBlockId]/[file]` — whose 200 arm sets its own
  *      header and still wins, as the override test below pins.

--- a/src/server/utils/__tests__/mixed-auth-endpoint-cache.test.ts
+++ b/src/server/utils/__tests__/mixed-auth-endpoint-cache.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `MixedAuthEndpoint` decides the same thing `PublicEndpoint` decides — whether a
+ * response may be marked publicly cacheable — but it used to decide it on a
+ * different axis, and to say less.
+ *
+ * Three properties are pinned here:
+ *
+ *   1. **The branch is on the CREDENTIAL, not on the resolved session.** The old
+ *      `if (!session) addPublicCacheHeaders(...)` asks whether the credential
+ *      WORKED; this asks whether one was PRESENTED. They disagree exactly when a
+ *      credential is presented and fails to resolve — an expired cookie, a
+ *      revoked api key, a session-store miss — and on that disagreement the old
+ *      form takes the public arm. The `credential presented, session null` case
+ *      below is the one that separates them.
+ *   2. **The credentialed arm states a header.** It previously stated nothing and
+ *      relied on `apiCacheMiddleware`, whose matcher is `/api/trpc/*` and
+ *      `/api/v1/*` only. Two of this wrapper's twelve routes sit outside that:
+ *      `/api/auth/freshdesk` (a 302 whose `Location` carries a per-user JWT),
+ *      which had no `Cache-Control` at all, and the 404 arms of
+ *      `/api/blocks/screenshot/[appBlockId]/[file]` — whose 200 arm sets its own
+ *      header and still wins, as the override test below pins.
+ *   3. **Every response declares a `Vary`.** It previously declared none.
+ *
+ * The anonymous arm is UNCHANGED, and the first test is what proves it: a change
+ * that stopped edge-caching the logged-out population would be a straight
+ * regression, which is a worse outcome than the gap being closed.
+ *
+ * Expected header values are LITERALS, never re-derived from the implementation's
+ * constants, so this file is meaningful against code that predates them.
+ */
+
+vi.mock('@civitai/next-axiom', () => ({
+  withAxiom:
+    (handler: (...args: unknown[]) => unknown) =>
+    (...args: unknown[]) =>
+      handler(...args),
+}));
+vi.mock('~/env/server', () => ({
+  env: new Proxy(
+    { TRPC_ORIGINS: [] as string[], NEXTAUTH_URL: undefined } as Record<string, unknown>,
+    { get: (t, p: string) => (p in t ? t[p] : undefined) }
+  ),
+}));
+vi.mock('~/server/db/db-helpers', () => ({ checkNotUpToDate: vi.fn(async () => false) }));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/auth/get-server-auth-session', () => ({ getServerAuthSession: vi.fn() }));
+vi.mock('~/server/utils/key-generator', () => ({ generateSecretHash: vi.fn() }));
+vi.mock('~/server/utils/server-domain', () => ({ getAllServerHosts: vi.fn(() => []) }));
+vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
+vi.mock('~/server/utils/errorHandling', () => ({ isClientAbortError: vi.fn(() => false) }));
+
+import { sessionCookieName } from '@civitai/auth';
+import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
+import { MixedAuthEndpoint } from '../endpoint-helpers';
+import { createRealApiPair } from './real-api-response';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const PUBLIC_DEFAULT = 'public, s-maxage=300, stale-while-revalidate=150';
+const PRIVATE_DEFAULT = 'max-age=0, private, no-cache';
+const ANONYMOUS_VARY = 'Authorization';
+const CREDENTIALED_VARY = 'Authorization, Cookie';
+
+const SESSION_COOKIE = sessionCookieName(true);
+const A_SESSION = { user: { id: 1, username: 'someone' } } as never;
+
+const mockedSession = vi.mocked(getServerAuthSession);
+
+type HeaderBag = Record<string, string | string[]>;
+type ReqArgs = {
+  method?: string;
+  cookies?: Record<string, string>;
+  headers?: Record<string, string>;
+  query?: Record<string, string | string[]>;
+  url?: string;
+};
+
+function makeReqRes({
+  method = 'GET',
+  cookies,
+  headers: reqHeaders = {},
+  query = {},
+  url = '/api/v1/articles',
+}: ReqArgs = {}) {
+  const headers: HeaderBag = {};
+  const req = { method, headers: reqHeaders, query, url, cookies } as never;
+  const res = {
+    setHeader: vi.fn((k: string, v: string | string[]) => {
+      headers[k] = v;
+    }),
+    getHeader: (k: string) => headers[k],
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+    end: vi.fn().mockReturnThis(),
+    redirect: vi.fn().mockReturnThis(),
+  } as never;
+  return { req, res, headers };
+}
+
+async function runMixedAuth(args: ReqArgs, allowedMethods: string[] = ['GET']) {
+  const { req, res, headers } = makeReqRes(args);
+  await MixedAuthEndpoint(async () => undefined, allowedMethods)(req, res);
+  return headers;
+}
+
+describe('MixedAuthEndpoint — the anonymous arm is preserved', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedSession.mockResolvedValue(null);
+  });
+
+  it('PRESERVES the public edge cache for an anonymous request', async () => {
+    const headers = await runMixedAuth({});
+    expect(headers['Cache-Control']).toBe(PUBLIC_DEFAULT);
+  });
+
+  it('PRESERVES the public edge cache when only unrelated cookies are present', async () => {
+    // Negative control: a predicate that answered "credentialed" for any cookie —
+    // or unconditionally — fails here while passing every positive case below.
+    const headers = await runMixedAuth({
+      cookies: { _ga_ABC: '1', theme: 'dark', 'civ-token-decoy': 'x' },
+      headers: { cookie: '_ga_ABC=1; theme=dark; civ-token-decoy=x' },
+    });
+    expect(headers['Cache-Control']).toBe(PUBLIC_DEFAULT);
+  });
+
+  it('never names Cookie in the Vary of a publicly cacheable response', async () => {
+    const headers = await runMixedAuth({ cookies: { _ga_ABC: '1', __cf_bm: 'x' } });
+    expect(headers['Cache-Control']).toBe(PUBLIC_DEFAULT);
+    expect(headers['Vary']).toBe(ANONYMOUS_VARY);
+    expect(String(headers['Vary'])).not.toContain('Cookie');
+  });
+});
+
+describe('MixedAuthEndpoint — a credentialed request is not publicly cacheable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedSession.mockResolvedValue(A_SESSION);
+  });
+
+  it.each<[string, ReqArgs]>([
+    ['session cookie', { cookies: { [SESSION_COOKIE]: 'abc' } }],
+    ['Authorization header', { headers: { authorization: 'Bearer abc' } }],
+    ['?token= api key', { query: { token: 'abc' }, url: '/api/v1/articles?token=abc' }],
+  ])('states the private default for a %s', async (_label, args) => {
+    const headers = await runMixedAuth(args);
+    expect(headers['Cache-Control']).toBe(PRIVATE_DEFAULT);
+    expect(headers['Cache-Control']).not.toContain('public');
+    expect(headers['Cache-Control']).not.toContain('s-maxage');
+  });
+
+  it('declares Vary: Authorization, Cookie on the credentialed arm', async () => {
+    const headers = await runMixedAuth({ cookies: { [SESSION_COOKIE]: 'abc' } });
+    expect(headers['Vary']).toBe(CREDENTIALED_VARY);
+  });
+
+  it('states the private default on a route outside the /api/v1 matcher', async () => {
+    // `/api/auth/freshdesk` is the sharp one: the proxy default does not reach it,
+    // so before this it answered with no `Cache-Control` at all.
+    const headers = await runMixedAuth({
+      url: '/api/auth/freshdesk?nonce=n&state=s',
+      cookies: { [SESSION_COOKIE]: 'abc' },
+    });
+    expect(headers['Cache-Control']).toBe(PRIVATE_DEFAULT);
+  });
+});
+
+describe('MixedAuthEndpoint — a credential that does not resolve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The discriminating fixture: a credential IS presented and the session store
+    // returns nothing. Branching on `!session` takes the PUBLIC arm here;
+    // branching on the credential takes the private one.
+    mockedSession.mockResolvedValue(null);
+  });
+
+  it('does not fall back to the public arm when a presented session cookie fails to resolve', async () => {
+    const headers = await runMixedAuth({ cookies: { [SESSION_COOKIE]: 'expired' } });
+    expect(headers['Cache-Control']).toBe(PRIVATE_DEFAULT);
+    expect(headers['Cache-Control']).not.toContain('s-maxage');
+  });
+
+  it('does not fall back to the public arm when a presented api key fails to resolve', async () => {
+    const headers = await runMixedAuth({
+      query: { token: 'revoked' },
+      url: '/api/v1/articles?token=revoked',
+    });
+    expect(headers['Cache-Control']).toBe(PRIVATE_DEFAULT);
+  });
+});
+
+describe('MixedAuthEndpoint — a handler override still wins', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedSession.mockResolvedValue(null);
+  });
+
+  it.each<[string, ReqArgs]>([
+    ['anonymous', {}],
+    ['credentialed', { cookies: { [SESSION_COOKIE]: 'abc' } }],
+  ])('lets a handler set its own Cache-Control (%s)', async (_label, args) => {
+    // `/api/blocks/screenshot/…` does exactly this on its 200 arm, and must keep
+    // doing it: the wrapper states a default, the handler states the truth.
+    const { req, res, headers } = makeReqRes(args);
+    await MixedAuthEndpoint(
+      async (_req, response) => {
+        response.setHeader('Cache-Control', 'public, max-age=300');
+        response.status(200).send('bytes');
+      },
+      ['GET']
+    )(req, res);
+
+    expect(headers['Cache-Control']).toBe('public, max-age=300');
+  });
+});
+
+/**
+ * 🔴 Driven through a REAL `http.ServerResponse` — see `real-api-response.ts` for
+ * why a fake cannot express this. `addCorsHeaders` ends an OPTIONS preflight, and
+ * against the real class every later `setHeader` throws `ERR_HTTP_HEADERS_SENT`.
+ *
+ * This wrapper reaches that path only for a route that lists OPTIONS in its
+ * allowed methods (an OPTIONS request to a `['GET']` route is answered 405 before
+ * CORS runs), so the allowed set is stated explicitly here.
+ */
+describe('MixedAuthEndpoint against a real http.ServerResponse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedSession.mockResolvedValue(null);
+  });
+
+  it('answers an OPTIONS preflight with no post-end() header write', async () => {
+    const { req, res, header } = createRealApiPair({ method: 'OPTIONS' });
+    const handler = vi.fn(async () => undefined);
+
+    await expect(MixedAuthEndpoint(handler, ['GET', 'OPTIONS'])(req, res)).resolves.toBeUndefined();
+
+    expect(res.headersSent, 'the preflight must have been answered').toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(header('Vary')).toBe(ANONYMOUS_VARY);
+    expect(handler).not.toHaveBeenCalled();
+    // The preflight must not have paid for a session resolve it cannot use.
+    expect(mockedSession).not.toHaveBeenCalled();
+  });
+
+  it('sets both headers on a GET, where nothing has ended the response', async () => {
+    // The positive control for the fixture: without it, the case above cannot
+    // distinguish "the ordering is right" from "no headers are written at all".
+    const { req, res, header } = createRealApiPair({ method: 'GET' });
+
+    await expect(
+      MixedAuthEndpoint(async () => undefined, ['GET'])(req, res)
+    ).resolves.toBeUndefined();
+
+    expect(res.headersSent, 'a GET must not have flushed headers').toBe(false);
+    expect(header('Cache-Control')).toBe(PUBLIC_DEFAULT);
+    expect(header('Vary')).toBe(ANONYMOUS_VARY);
+  });
+});

--- a/src/server/utils/__tests__/public-endpoint-credential-detection.test.ts
+++ b/src/server/utils/__tests__/public-endpoint-credential-detection.test.ts
@@ -68,6 +68,33 @@ describe('requestCarriesCallerCredentials — recognises a credential', () => {
     ).toBe(true);
   });
 
+  it('is true for a ?token= api key in req.query', () => {
+    expect(
+      requestCarriesCallerCredentials({
+        headers: {},
+        query: { token: 'abc' },
+        url: '/api/v1/users?token=abc',
+      } as never)
+    ).toBe(true);
+  });
+
+  it('is true for a ?token= present only on req.url', () => {
+    // `getServerAuthSession` reads `req.url` rather than Next's parsed `req.query`,
+    // so a context that skips that parsing must not read as anonymous.
+    expect(
+      requestCarriesCallerCredentials({
+        headers: {},
+        url: '/api/v1/users?page=2&token=abc',
+      } as never)
+    ).toBe(true);
+  });
+
+  it('is true for a repeated ?token= arriving as an array', () => {
+    expect(
+      requestCarriesCallerCredentials({ headers: {}, query: { token: ['', 'abc'] } } as never)
+    ).toBe(true);
+  });
+
   it('tolerates a malformed cookie segment with no "=" alongside a real one', () => {
     expect(
       requestCarriesCallerCredentials({
@@ -110,5 +137,33 @@ describe('requestCarriesCallerCredentials — does not over-match', () => {
         cookies: { [sessionCookieName(true)]: '' },
       } as never)
     ).toBe(false);
+  });
+
+  it('is false for query parameters that merely look like a token', () => {
+    // The discriminator must be the `token` parameter, not the presence of a
+    // query string — otherwise every paged public request leaves the cached arm.
+    expect(
+      requestCarriesCallerCredentials({
+        headers: {},
+        query: { page: '2', tokenizer: 'x', access_token_hint: 'y' },
+        url: '/api/v1/users?page=2&tokenizer=x&access_token_hint=y',
+      } as never)
+    ).toBe(false);
+  });
+
+  it('is false for an empty ?token= value', () => {
+    expect(
+      requestCarriesCallerCredentials({
+        headers: {},
+        query: { token: '' },
+        url: '/api/v1/users?token=',
+      } as never)
+    ).toBe(false);
+  });
+
+  it('is false for a url with no query string at all', () => {
+    expect(requestCarriesCallerCredentials({ headers: {}, url: '/api/v1/users' } as never)).toBe(
+      false
+    );
   });
 });

--- a/src/server/utils/__tests__/public-endpoint-credential-detection.test.ts
+++ b/src/server/utils/__tests__/public-endpoint-credential-detection.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Direct unit tests for the credential predicate `PublicEndpoint` branches on.
+ *
+ * The wrapper-level contract lives in `public-endpoint-credentialed-cache.test.ts`;
+ * this file exercises the predicate in isolation so a mutation to it fails with
+ * an assertion naming the predicate rather than a downstream header value.
+ *
+ * The predicate is deliberately header-only and PESSIMISTIC — it says "yes" for
+ * a credential that would turn out to be expired or bogus. A false positive
+ * costs one uncached response; a false negative marks a caller-specific body
+ * publicly cacheable. The asymmetry is the whole design, so the cases below pin
+ * BOTH directions: every credential spelling is recognised, and nothing else is.
+ */
+
+vi.mock('@civitai/next-axiom', () => ({
+  withAxiom:
+    (handler: (...args: unknown[]) => unknown) =>
+    (...args: unknown[]) =>
+      handler(...args),
+}));
+vi.mock('~/env/server', () => ({
+  env: new Proxy(
+    { TRPC_ORIGINS: [] as string[], NEXTAUTH_URL: undefined } as Record<string, unknown>,
+    { get: (t, p: string) => (p in t ? t[p] : undefined) }
+  ),
+}));
+vi.mock('~/server/db/db-helpers', () => ({ checkNotUpToDate: vi.fn() }));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/auth/get-server-auth-session', () => ({ getServerAuthSession: vi.fn() }));
+vi.mock('~/server/utils/key-generator', () => ({ generateSecretHash: vi.fn() }));
+vi.mock('~/server/utils/server-domain', () => ({ getAllServerHosts: vi.fn(() => []) }));
+vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
+vi.mock('~/server/utils/errorHandling', () => ({ isClientAbortError: vi.fn(() => false) }));
+
+import { legacySessionCookieName, sessionCookieName } from '@civitai/auth';
+import { requestCarriesCallerCredentials } from '../endpoint-helpers';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const CREDENTIAL_COOKIES: [string, string][] = [
+  ['current secure session cookie', sessionCookieName(true)],
+  ['current dev session cookie', sessionCookieName(false)],
+  ['legacy secure session cookie', legacySessionCookieName(true)],
+  ['legacy dev session cookie', legacySessionCookieName(false)],
+];
+
+describe('requestCarriesCallerCredentials — recognises a credential', () => {
+  it.each(CREDENTIAL_COOKIES)('is true for the %s in req.cookies', (_label, cookieName) => {
+    expect(
+      requestCarriesCallerCredentials({ headers: {}, cookies: { [cookieName]: 'abc' } } as never)
+    ).toBe(true);
+  });
+
+  it.each(CREDENTIAL_COOKIES)('is true for the %s on the raw Cookie header', (_l, cookieName) => {
+    expect(
+      requestCarriesCallerCredentials({
+        headers: { cookie: `ga_session=1; ${cookieName}=abc; other=2` },
+      } as never)
+    ).toBe(true);
+  });
+
+  it('is true for an Authorization header with no cookies at all', () => {
+    expect(
+      requestCarriesCallerCredentials({ headers: { authorization: 'Bearer abc' } } as never)
+    ).toBe(true);
+  });
+
+  it('tolerates a malformed cookie segment with no "=" alongside a real one', () => {
+    expect(
+      requestCarriesCallerCredentials({
+        headers: { cookie: `broken; ${sessionCookieName(true)}=abc` },
+      } as never)
+    ).toBe(true);
+  });
+});
+
+describe('requestCarriesCallerCredentials — does not over-match', () => {
+  it('is false for a bare request', () => {
+    expect(requestCarriesCallerCredentials({ headers: {} } as never)).toBe(false);
+  });
+
+  it('is false for unrelated cookies, including near-miss names', () => {
+    const decoys = {
+      ga_session: '1',
+      theme: 'dark',
+      'civ-token-decoy': 'x',
+      'x-civ-token': 'y',
+    };
+    expect(
+      requestCarriesCallerCredentials({
+        headers: { cookie: 'ga_session=1; theme=dark; civ-token-decoy=x; x-civ-token=y' },
+        cookies: decoys,
+      } as never)
+    ).toBe(false);
+  });
+
+  it('is false for an empty Authorization header', () => {
+    expect(requestCarriesCallerCredentials({ headers: { authorization: '' } } as never)).toBe(
+      false
+    );
+  });
+
+  it('is false for an empty session cookie value', () => {
+    expect(
+      requestCarriesCallerCredentials({
+        headers: {},
+        cookies: { [sessionCookieName(true)]: '' },
+      } as never)
+    ).toBe(false);
+  });
+});

--- a/src/server/utils/__tests__/public-endpoint-credential-detection.test.ts
+++ b/src/server/utils/__tests__/public-endpoint-credential-detection.test.ts
@@ -68,6 +68,27 @@ describe('requestCarriesCallerCredentials — recognises a credential', () => {
     ).toBe(true);
   });
 
+  // 🔴 ANY non-empty Authorization value, not just `Bearer `. `getServerAuthSession`
+  // resolves the key with `req.headers.authorization.split(' ')[1]`, which never
+  // inspects the scheme — so `bearer <key>` (lowercase), `Basic <key>` and
+  // `token <key>` all authenticate, and a bare `<key>` with no scheme reaches the
+  // same code path. Narrowing this predicate to a `Bearer ` prefix would put every
+  // one of those callers on the PUBLIC arm: a credentialed body, marked publicly
+  // cacheable, on a shared cache key. That is the exposure this whole change closes.
+  //
+  // The shipped predicate has no prefix check, so this is a REGRESSION PIN rather
+  // than a bug fix. It exists because every other positive fixture here uses the
+  // literal 'Bearer abc', which made two narrowing mutants — `.startsWith('Bearer ')`
+  // and `.toLowerCase().startsWith('bearer ')` — survive the full suite.
+  it.each([
+    ['a lowercase bearer scheme', 'bearer abc'],
+    ['a Basic scheme', 'Basic dXNlcjpwYXNz'],
+    ['a token scheme', 'token abc'],
+    ['a bare value with no scheme', 'abc'],
+  ])('is true for %s in Authorization', (_label, authorization) => {
+    expect(requestCarriesCallerCredentials({ headers: { authorization } } as never)).toBe(true);
+  });
+
   it('is true for a ?token= api key in req.query', () => {
     expect(
       requestCarriesCallerCredentials({

--- a/src/server/utils/__tests__/public-endpoint-credentialed-cache.test.ts
+++ b/src/server/utils/__tests__/public-endpoint-credentialed-cache.test.ts
@@ -12,11 +12,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  *   1. the anonymous arm is UNCHANGED — a change that stopped caching for
  *      everyone would be a regression, and the first tests are what prove it did
  *      not happen;
- *   2. a request carrying a session cookie or an `Authorization` header gets the
- *      platform's private default instead;
- *   3. every response declares `Vary: Cookie, Authorization`, on both arms;
+ *   2. a request carrying a session cookie, an `Authorization` header or a
+ *      `?token=` api key gets the platform's private default instead;
+ *   3. each arm declares its own `Vary`, pinned as an exact string;
  *   4. a handler's own `Cache-Control` still wins, so the `no-store` error arms
- *      stay authoritative.
+ *      stay authoritative;
+ *   5. an OPTIONS preflight, exercised against a REAL `http.ServerResponse`, is
+ *      answered without a post-`end()` header write.
  *
  * Every expected header value below is a LITERAL, never re-derived from the
  * implementation's own constants — so this file is meaningful run against code
@@ -56,11 +58,19 @@ vi.mock('~/server/utils/errorHandling', () => ({ isClientAbortError: vi.fn(() =>
 
 import { legacySessionCookieName, sessionCookieName } from '@civitai/auth';
 import { PublicEndpoint } from '../endpoint-helpers';
+import { createRealApiPair } from './real-api-response';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 
 const PUBLIC_DEFAULT = 'public, s-maxage=300, stale-while-revalidate=150';
 const PRIVATE_DEFAULT = 'max-age=0, private, no-cache';
-const EXPECTED_VARY = 'Cookie, Authorization';
+// Pinned as exact strings, per arm. `Cookie` is deliberately absent from the
+// anonymous arm: a logged-out browser's cookie jar changes per pageview, so
+// keying a shared cache on it would fragment the anonymous population into one
+// entry per browser per cookie-rotation window. It is named on the credentialed
+// arm, where the response is already `private, no-cache` and there is no shared
+// entry left to fragment.
+const ANONYMOUS_VARY = 'Authorization';
+const CREDENTIALED_VARY = 'Authorization, Cookie';
 
 const SECURE_SESSION_COOKIE = sessionCookieName(true);
 const DEV_SESSION_COOKIE = sessionCookieName(false);
@@ -79,11 +89,19 @@ type ReqArgs = {
   method?: string;
   cookies?: Record<string, string>;
   headers?: Record<string, string>;
+  query?: Record<string, string | string[]>;
+  url?: string;
 };
 
-function makeReqRes({ method = 'GET', cookies, headers: reqHeaders = {} }: ReqArgs = {}) {
+function makeReqRes({
+  method = 'GET',
+  cookies,
+  headers: reqHeaders = {},
+  query = {},
+  url = '/api/test',
+}: ReqArgs = {}) {
   const headers: HeaderBag = {};
-  const req = { method, headers: reqHeaders, query: {}, cookies } as never;
+  const req = { method, headers: reqHeaders, query, url, cookies } as never;
   const res = {
     setHeader: vi.fn((k: string, v: string | string[]) => {
       headers[k] = v;
@@ -163,6 +181,32 @@ describe('PublicEndpoint cache headers by caller', () => {
     expect(headers['Cache-Control']).not.toContain('s-maxage');
   });
 
+  it('does NOT mark the response publicly cacheable for a ?token= api key in req.query', async () => {
+    // `getServerAuthSession` accepts `?token=` as a bearer credential, so the
+    // predicate must too — otherwise an api-key caller lands on the anonymous arm.
+    const headers = await runPublicEndpoint({
+      query: { token: 'abc' },
+      url: '/api/v1/users?token=abc',
+    });
+    expect(headers['Cache-Control']).toBe(PRIVATE_DEFAULT);
+    expect(headers['Cache-Control']).not.toContain('s-maxage');
+  });
+
+  it('does NOT mark the response publicly cacheable for a ?token= present only on req.url', async () => {
+    const headers = await runPublicEndpoint({ query: {}, url: '/api/v1/users?page=2&token=abc' });
+    expect(headers['Cache-Control']).toBe(PRIVATE_DEFAULT);
+  });
+
+  it('PRESERVES the public edge cache for an unrelated query parameter', async () => {
+    // Negative control for the pair above: the discriminator must be the `token`
+    // parameter specifically, not "the request has a query string".
+    const headers = await runPublicEndpoint({
+      query: { page: '2', tokenizer: 'x' },
+      url: '/api/v1/users?page=2&tokenizer=x',
+    });
+    expect(headers['Cache-Control']).toBe(PUBLIC_DEFAULT);
+  });
+
   it('does NOT mark the response publicly cacheable when the session cookie arrives only on the raw Cookie header', async () => {
     // `req.cookies` is what Next parses for an API route; the raw header is the
     // fallback read, and it must not quietly degrade to "anonymous".
@@ -187,21 +231,83 @@ describe('PublicEndpoint Vary', () => {
 
   it.each<[string, ReqArgs]>([
     ['anonymous', {}],
-    ['session cookie', { cookies: { [SECURE_SESSION_COOKIE]: 'abc' } }],
-    ['Authorization header', { headers: { authorization: 'Bearer abc' } }],
     ['unrelated cookies', { cookies: { theme: 'dark' } }],
-  ])('declares Vary on the %s arm', async (_label, args) => {
+  ])('declares exactly %s → Vary: Authorization', async (_label, args) => {
     const headers = await runPublicEndpoint(args);
-    expect(headers['Vary']).toBe(EXPECTED_VARY);
+    expect(headers['Vary']).toBe(ANONYMOUS_VARY);
   });
 
-  it('declares Vary on an OPTIONS preflight, which returns before the handler', async () => {
-    const { req, res, headers } = makeReqRes({ method: 'OPTIONS' });
-    const handler = vi.fn(async () => undefined);
-    await PublicEndpoint(handler, ['GET'])(req, res);
+  it.each<[string, ReqArgs]>([
+    ['session cookie', { cookies: { [SECURE_SESSION_COOKIE]: 'abc' } }],
+    ['Authorization header', { headers: { authorization: 'Bearer abc' } }],
+  ])('declares exactly %s → Vary: Authorization, Cookie', async (_label, args) => {
+    const headers = await runPublicEndpoint(args);
+    expect(headers['Vary']).toBe(CREDENTIALED_VARY);
+  });
 
-    expect(headers['Vary']).toBe(EXPECTED_VARY);
+  it('never names Cookie on a publicly cacheable response', async () => {
+    // The property that matters for the shared-cache hit rate, stated directly:
+    // whatever the anonymous `Vary` says, it must not fragment on the cookie jar.
+    const headers = await runPublicEndpoint({ cookies: { _ga_ABC: '1', __cf_bm: 'x' } });
+    expect(headers['Cache-Control']).toBe(PUBLIC_DEFAULT);
+    expect(String(headers['Vary'])).not.toContain('Cookie');
+  });
+});
+
+/**
+ * 🔴 Driven through a REAL `http.ServerResponse`, on purpose.
+ *
+ * `addCorsHeaders` answers an OPTIONS preflight with `res.status(200).end()`.
+ * Against the real class that flushes the header block, so every later
+ * `setHeader` throws `ERR_HTTP_HEADERS_SENT`; against a fake whose `end()` is a
+ * no-op it is invisible, and an ordering guard written on such a fake passes for
+ * every ordering. Both facts were measured (see `real-api-response.ts`).
+ *
+ * So these two cases carry the ordering contract, and the fake-based cases above
+ * carry the value contract.
+ */
+describe('PublicEndpoint against a real http.ServerResponse', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('answers an OPTIONS preflight with no post-end() header write, and Vary already declared', async () => {
+    const { req, res, header } = createRealApiPair({ method: 'OPTIONS' });
+    const handler = vi.fn(async () => undefined);
+
+    // The assertion that kills BOTH mutants this test exists for:
+    //   - moving the `Vary` write below `addCorsHeaders`
+    //   - moving the `Cache-Control` write above the early return
+    // Either one writes a header after `end()`, and the wrapper's promise then
+    // rejects with ERR_HTTP_HEADERS_SENT instead of resolving.
+    await expect(PublicEndpoint(handler, ['GET'])(req, res)).resolves.toBeUndefined();
+
+    expect(res.headersSent, 'the preflight must have been answered').toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(header('Vary')).toBe(ANONYMOUS_VARY);
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('sets both headers on a GET, where nothing has ended the response', async () => {
+    // The other half of the pair. Without it, the preflight case alone cannot
+    // distinguish "the ordering is right" from "the wrapper writes no headers".
+    const { req, res, header } = createRealApiPair({ method: 'GET' });
+
+    await expect(PublicEndpoint(async () => undefined, ['GET'])(req, res)).resolves.toBeUndefined();
+
+    expect(res.headersSent, 'a GET must not have flushed headers').toBe(false);
+    expect(header('Cache-Control')).toBe(PUBLIC_DEFAULT);
+    expect(header('Vary')).toBe(ANONYMOUS_VARY);
+  });
+
+  it('sets the private header on a credentialed GET against a real response', async () => {
+    const { req, res, header } = createRealApiPair({
+      method: 'GET',
+      cookies: { [SECURE_SESSION_COOKIE]: 'abc' },
+    });
+
+    await expect(PublicEndpoint(async () => undefined, ['GET'])(req, res)).resolves.toBeUndefined();
+
+    expect(header('Cache-Control')).toBe(PRIVATE_DEFAULT);
+    expect(header('Vary')).toBe(CREDENTIALED_VARY);
   });
 });
 

--- a/src/server/utils/__tests__/public-endpoint-credentialed-cache.test.ts
+++ b/src/server/utils/__tests__/public-endpoint-credentialed-cache.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `PublicEndpoint` stamps `Cache-Control: public, s-maxage=…` before the handler
+ * runs. `public` is a claim that any caller may be served this exact body — but
+ * several routes on this wrapper resolve the session themselves and shape their
+ * response around it, so the claim only holds for a request that presented no
+ * credential.
+ *
+ * This suite pins both halves of the resulting contract:
+ *
+ *   1. the anonymous arm is UNCHANGED — a change that stopped caching for
+ *      everyone would be a regression, and the first tests are what prove it did
+ *      not happen;
+ *   2. a request carrying a session cookie or an `Authorization` header gets the
+ *      platform's private default instead;
+ *   3. every response declares `Vary: Cookie, Authorization`, on both arms;
+ *   4. a handler's own `Cache-Control` still wins, so the `no-store` error arms
+ *      stay authoritative.
+ *
+ * Every expected header value below is a LITERAL, never re-derived from the
+ * implementation's own constants — so this file is meaningful run against code
+ * that predates them.
+ *
+ * The cookie names ARE resolved through `@civitai/auth`, exactly as the
+ * implementation resolves them, and then asserted against their literal
+ * spellings — so a rename on either side is visible rather than silent.
+ *
+ * Exercises the REAL `PublicEndpoint` wrapper with only the heavy module-load
+ * imports stubbed (mirrors public-endpoint-cache-override.test.ts).
+ */
+
+vi.mock('@civitai/next-axiom', () => ({
+  withAxiom:
+    (handler: (...args: unknown[]) => unknown) =>
+    (...args: unknown[]) =>
+      handler(...args),
+}));
+// `allowedOrigins` at module load spreads `env.TRPC_ORIGINS` (must be iterable)
+// and reads `env.NEXTAUTH_URL`; default everything else to undefined.
+vi.mock('~/env/server', () => ({
+  env: new Proxy(
+    { TRPC_ORIGINS: [] as string[], NEXTAUTH_URL: undefined } as Record<string, unknown>,
+    { get: (t, p: string) => (p in t ? t[p] : undefined) }
+  ),
+}));
+vi.mock('~/server/db/db-helpers', () => ({ checkNotUpToDate: vi.fn() }));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/auth/get-server-auth-session', () => ({ getServerAuthSession: vi.fn() }));
+vi.mock('~/server/utils/key-generator', () => ({ generateSecretHash: vi.fn() }));
+vi.mock('~/server/utils/server-domain', () => ({ getAllServerHosts: vi.fn(() => []) }));
+vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
+vi.mock('~/server/utils/errorHandling', () => ({ isClientAbortError: vi.fn(() => false) }));
+
+import { legacySessionCookieName, sessionCookieName } from '@civitai/auth';
+import { PublicEndpoint } from '../endpoint-helpers';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const PUBLIC_DEFAULT = 'public, s-maxage=300, stale-while-revalidate=150';
+const PRIVATE_DEFAULT = 'max-age=0, private, no-cache';
+const EXPECTED_VARY = 'Cookie, Authorization';
+
+const SECURE_SESSION_COOKIE = sessionCookieName(true);
+const DEV_SESSION_COOKIE = sessionCookieName(false);
+const SECURE_LEGACY_COOKIE = legacySessionCookieName(true);
+const DEV_LEGACY_COOKIE = legacySessionCookieName(false);
+
+const CREDENTIAL_COOKIES: [string, string][] = [
+  ['current secure session cookie', SECURE_SESSION_COOKIE],
+  ['current dev session cookie', DEV_SESSION_COOKIE],
+  ['legacy secure session cookie', SECURE_LEGACY_COOKIE],
+  ['legacy dev session cookie', DEV_LEGACY_COOKIE],
+];
+
+type HeaderBag = Record<string, string | string[]>;
+type ReqArgs = {
+  method?: string;
+  cookies?: Record<string, string>;
+  headers?: Record<string, string>;
+};
+
+function makeReqRes({ method = 'GET', cookies, headers: reqHeaders = {} }: ReqArgs = {}) {
+  const headers: HeaderBag = {};
+  const req = { method, headers: reqHeaders, query: {}, cookies } as never;
+  const res = {
+    setHeader: vi.fn((k: string, v: string | string[]) => {
+      headers[k] = v;
+    }),
+    getHeader: (k: string) => headers[k],
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+    end: vi.fn().mockReturnThis(),
+  } as never;
+  return { req, res, headers };
+}
+
+async function runPublicEndpoint(args: ReqArgs, opts: { maxAge?: number } = {}) {
+  const { req, res, headers } = makeReqRes(args);
+  await PublicEndpoint(async () => undefined, ['GET'], opts)(req, res);
+  return headers;
+}
+
+describe('auth cookie names are derived from @civitai/auth, not spelled out', () => {
+  // The implementation must resolve these through the same helpers. A hardcoded
+  // literal in the implementation keeps matching and keeps looking correct right
+  // up until the cookie is renamed — which has already happened once, hence this
+  // pair of assertions naming BOTH the current and the retired base.
+  it('resolves the current session cookie in both the secure and dev spellings', () => {
+    expect(SECURE_SESSION_COOKIE).toBe('__Secure-civ-token');
+    expect(DEV_SESSION_COOKIE).toBe('civ-token');
+  });
+
+  it('resolves the legacy session cookie in both spellings', () => {
+    expect(SECURE_LEGACY_COOKIE).toBe('__Secure-civitai-token');
+    expect(DEV_LEGACY_COOKIE).toBe('civitai-token');
+  });
+
+  it('keeps the current and legacy names distinct', () => {
+    expect(SECURE_SESSION_COOKIE).not.toBe(SECURE_LEGACY_COOKIE);
+  });
+});
+
+describe('PublicEndpoint cache headers by caller', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('PRESERVES the public edge cache for an anonymous request', async () => {
+    const headers = await runPublicEndpoint({});
+    expect(headers['Cache-Control']).toBe(PUBLIC_DEFAULT);
+  });
+
+  it('PRESERVES the public edge cache when only unrelated cookies are present', async () => {
+    // Negative control for the credential check: a guard that answered "has
+    // credentials" for any cookie at all — or unconditionally — fails here while
+    // passing every positive case below.
+    const headers = await runPublicEndpoint({
+      cookies: { ga_session: '1', theme: 'dark', 'civ-token-decoy': 'x' },
+      headers: { cookie: 'ga_session=1; theme=dark; civ-token-decoy=x' },
+    });
+    expect(headers['Cache-Control']).toBe(PUBLIC_DEFAULT);
+  });
+
+  it('PRESERVES the per-endpoint maxAge override on the anonymous arm', async () => {
+    const headers = await runPublicEndpoint({}, { maxAge: 3600 });
+    expect(headers['Cache-Control']).toBe('public, s-maxage=3600, stale-while-revalidate=1800');
+  });
+
+  it.each(CREDENTIAL_COOKIES)(
+    'does NOT mark the response publicly cacheable for a %s',
+    async (_label, cookieName) => {
+      const headers = await runPublicEndpoint({ cookies: { [cookieName]: 'abc' } });
+      expect(headers['Cache-Control']).toBe(PRIVATE_DEFAULT);
+      expect(headers['Cache-Control']).not.toContain('public,');
+      expect(headers['Cache-Control']).not.toContain('s-maxage');
+    }
+  );
+
+  it('does NOT mark the response publicly cacheable for an Authorization header', async () => {
+    const headers = await runPublicEndpoint({ headers: { authorization: 'Bearer abc' } });
+    expect(headers['Cache-Control']).toBe(PRIVATE_DEFAULT);
+    expect(headers['Cache-Control']).not.toContain('s-maxage');
+  });
+
+  it('does NOT mark the response publicly cacheable when the session cookie arrives only on the raw Cookie header', async () => {
+    // `req.cookies` is what Next parses for an API route; the raw header is the
+    // fallback read, and it must not quietly degrade to "anonymous".
+    const headers = await runPublicEndpoint({
+      headers: { cookie: `ga_session=1; ${SECURE_SESSION_COOKIE}=abc; other=2` },
+    });
+    expect(headers['Cache-Control']).toBe(PRIVATE_DEFAULT);
+    expect(headers['Cache-Control']).not.toContain('s-maxage');
+  });
+
+  it('never lets a longer per-endpoint maxAge re-enable public caching for a credentialed caller', async () => {
+    const headers = await runPublicEndpoint(
+      { cookies: { [SECURE_SESSION_COOKIE]: 'abc' } },
+      { maxAge: 86400 }
+    );
+    expect(headers['Cache-Control']).toBe(PRIVATE_DEFAULT);
+  });
+});
+
+describe('PublicEndpoint Vary', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each<[string, ReqArgs]>([
+    ['anonymous', {}],
+    ['session cookie', { cookies: { [SECURE_SESSION_COOKIE]: 'abc' } }],
+    ['Authorization header', { headers: { authorization: 'Bearer abc' } }],
+    ['unrelated cookies', { cookies: { theme: 'dark' } }],
+  ])('declares Vary on the %s arm', async (_label, args) => {
+    const headers = await runPublicEndpoint(args);
+    expect(headers['Vary']).toBe(EXPECTED_VARY);
+  });
+
+  it('declares Vary on an OPTIONS preflight, which returns before the handler', async () => {
+    const { req, res, headers } = makeReqRes({ method: 'OPTIONS' });
+    const handler = vi.fn(async () => undefined);
+    await PublicEndpoint(handler, ['GET'])(req, res);
+
+    expect(headers['Vary']).toBe(EXPECTED_VARY);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe('PublicEndpoint handler override still wins (error arms stay uncacheable)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each<[string, ReqArgs]>([
+    ['anonymous', {}],
+    ['session cookie', { cookies: { [SECURE_SESSION_COOKIE]: 'abc' } }],
+    ['Authorization header', { headers: { authorization: 'Bearer abc' } }],
+  ])('lets a handler set no-store over the wrapper default (%s)', async (_label, args) => {
+    // Mirrors the shed/error arms: `handleEndpointError`'s `no-store, max-age=0`
+    // and the 503 arms in v1/images + v1/users, all of which set the header from
+    // INSIDE the handler and must remain authoritative on either arm.
+    const { req, res, headers } = makeReqRes(args);
+    await PublicEndpoint(
+      async (_req, response) => {
+        response.setHeader('Cache-Control', 'no-store');
+        response.status(503).json({ error: 'Server busy, please retry shortly.' });
+      },
+      ['GET']
+    )(req, res);
+
+    expect(headers['Cache-Control']).toBe('no-store');
+    expect(headers['Cache-Control']).not.toContain('s-maxage');
+  });
+});

--- a/src/server/utils/__tests__/real-api-response.ts
+++ b/src/server/utils/__tests__/real-api-response.ts
@@ -1,0 +1,89 @@
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { Socket } from 'node:net';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * A req/res pair built from the REAL `node:http` classes, with the small amount
+ * of sugar Next's `apiResolver` bolts onto a response (`status`/`json`/`send`).
+ *
+ * 🔴 Why this exists, rather than another hand-rolled fake.
+ *
+ * The endpoint wrappers write headers around a helper that can END the response
+ * mid-way (`addCorsHeaders` answers an OPTIONS preflight with
+ * `res.status(200).end()`). Whether a later `setHeader` is harmless or fatal is
+ * therefore the whole contract — and it is a property of `ServerResponse`, not of
+ * the wrapper. A fake whose `end()` is a no-op and whose `setHeader` always
+ * succeeds cannot express it: every ordering looks identical, so a guard written
+ * against such a fake is spelled rather than structural. Measured against a
+ * hand-rolled fake, moving the `Vary` write to after `addCorsHeaders` left the
+ * whole suite green, including the test whose name says it pins that ordering.
+ *
+ * Against the real class, `end()` flushes the header block (`headersSent`
+ * becomes true) and a subsequent `setHeader` throws `ERR_HTTP_HEADERS_SENT`, so
+ * the ordering is observable. No socket is assigned: `ServerResponse` buffers its
+ * output when it has none, which is all these tests need and keeps the fixture
+ * synchronous.
+ *
+ * A GET is the other half of the pair — nothing ends the response, so
+ * `headersSent` stays false and every write lands. Both cases must be exercised;
+ * one alone cannot tell an ordering guard from a coincidence.
+ */
+export type RealApiPair = {
+  req: NextApiRequest;
+  res: NextApiResponse;
+  /** Header names/values actually recorded on the response. */
+  header: (name: string) => number | string | string[] | undefined;
+};
+
+export function createRealApiPair({
+  method = 'GET',
+  url = '/api/test',
+  cookies = {},
+  query = {},
+  headers = {},
+}: {
+  method?: string;
+  url?: string;
+  cookies?: Record<string, string>;
+  query?: Record<string, string | string[]>;
+  headers?: Record<string, string>;
+} = {}): RealApiPair {
+  const incoming = new IncomingMessage(new Socket());
+  incoming.method = method;
+  incoming.url = url;
+  for (const [k, v] of Object.entries(headers)) incoming.headers[k.toLowerCase()] = v;
+
+  const req = incoming as unknown as NextApiRequest;
+  (req as unknown as { cookies: unknown }).cookies = cookies;
+  (req as unknown as { query: unknown }).query = query;
+
+  const response = new ServerResponse(incoming);
+  // The three methods Next adds on top of ServerResponse, in the same shapes:
+  // `status` only mutates `statusCode` (it does NOT flush), while `json`/`send`
+  // end the response. Getting that split right is what makes the fixture able to
+  // reproduce `res.status(200).end()` faithfully.
+  const sugar = response as unknown as {
+    status: (code: number) => unknown;
+    json: (body: unknown) => unknown;
+    send: (body: unknown) => unknown;
+  };
+  sugar.status = (code: number) => {
+    response.statusCode = code;
+    return sugar;
+  };
+  sugar.json = (body: unknown) => {
+    if (!response.headersSent) response.setHeader('Content-Type', 'application/json');
+    response.end(JSON.stringify(body));
+    return sugar;
+  };
+  sugar.send = (body: unknown) => {
+    response.end(typeof body === 'string' ? body : JSON.stringify(body));
+    return sugar;
+  };
+
+  return {
+    req,
+    res: response as unknown as NextApiResponse,
+    header: (name: string) => response.getHeader(name),
+  };
+}

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@civitai/next-axiom';
 import { withAxiom } from '@civitai/next-axiom';
+import { legacySessionCookieName, sessionCookieName } from '@civitai/auth';
 import { TRPCError } from '@trpc/server';
 import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import dayjs from '~/shared/utils/dayjs';
@@ -17,6 +18,7 @@ import type { Partner } from '~/shared/utils/prisma/models';
 import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { isClientAbortError, isDriverAuthoredMessage } from '~/server/utils/errorHandling';
 import { isDefined } from '~/utils/type-guards';
+import { PRIVATE_CACHE_CONTROL } from '~/shared/constants/cache-control.constants';
 import { logToAxiom, buildCentralErrorLog, wasServerFaultLogged } from '~/server/logging/client';
 import {
   GENERIC_CLIENT_ERROR_BY_STATUS,
@@ -284,6 +286,75 @@ const addPublicCacheHeaders = (
   );
 };
 
+/**
+ * The request dimensions a `PublicEndpoint` body can legitimately depend on.
+ *
+ * `Cookie` and `Authorization` are the two the wrapper itself branches on below,
+ * so they are the two it must declare. A response that can differ by credential
+ * and does not say so is, per RFC 9111 §4.1, indistinguishable to a shared cache
+ * from one that cannot — the cache has no way to know a second dimension exists.
+ */
+const CALLER_DEPENDENT_VARY = 'Cookie, Authorization';
+
+/**
+ * Cookie names that can carry a session, hence make a response caller-dependent.
+ *
+ * 🔴 DERIVED, never spelled out. `@civitai/auth` owns the naming, and it varies
+ * along two axes: the current thin-session cookie vs the legacy next-auth one
+ * (both are still honoured by `getServerAuthSession`), and the `__Secure-`
+ * prefix, which is applied when serving over https and dropped for http dev. All
+ * four spellings are enumerated by calling the helpers with an explicit boolean,
+ * rather than letting the env-derived default pick one — the guard must hold in
+ * dev and prod alike, and it must not silently narrow if a deploy's env changes.
+ *
+ * A hardcoded literal here is the precise failure mode this list exists to avoid:
+ * it keeps matching, keeps looking correct, and stops meaning anything the moment
+ * the cookie is renamed. `packages/civitai-auth/src/__tests__/cookies.test.ts`
+ * pins the values on the other side.
+ */
+const SESSION_COOKIE_NAMES = Array.from(
+  new Set([
+    sessionCookieName(true),
+    sessionCookieName(false),
+    legacySessionCookieName(true),
+    legacySessionCookieName(false),
+  ])
+);
+
+/**
+ * Does this request carry a credential that can change the response body?
+ *
+ * Intentionally CHEAP and PESSIMISTIC: it inspects headers only — no session
+ * decode, no db/redis hop — and answers "yes" for a credential that turns out to
+ * be expired or bogus. The cost of a false positive is one uncached response;
+ * the cost of a false negative is a caller-specific body marked publicly
+ * cacheable. Those are not symmetric, so the cheap over-approximation is the
+ * right one.
+ *
+ * `req.cookies` is what Next populates for an API route and is the primary read.
+ * The raw `Cookie` header is parsed as a fallback so the check cannot quietly
+ * degrade to "no credentials" in any context that skips that parsing.
+ */
+export function requestCarriesCallerCredentials(req: NextApiRequest): boolean {
+  if (req.headers?.authorization) return true;
+
+  const parsed = req.cookies as Record<string, string | undefined> | undefined;
+  if (parsed) {
+    for (const name of SESSION_COOKIE_NAMES) if (parsed[name]) return true;
+  }
+
+  const raw = req.headers?.cookie;
+  if (raw) {
+    for (const pair of raw.split(';')) {
+      const eq = pair.indexOf('=');
+      const name = (eq === -1 ? pair : pair.slice(0, eq)).trim();
+      if (name && SESSION_COOKIE_NAMES.includes(name)) return true;
+    }
+  }
+
+  return false;
+}
+
 export function PublicEndpoint(
   handler: (req: AxiomAPIRequest, res: NextApiResponse) => Promise<void | NextApiResponse>,
   allowedMethods: string[] = ['GET'],
@@ -293,8 +364,36 @@ export function PublicEndpoint(
   { maxAge }: { maxAge?: number } = {}
 ) {
   return withApiMetrics(async (req: AxiomAPIRequest, res: NextApiResponse) => {
+    // Set FIRST: `addCorsHeaders` can end an OPTIONS preflight, after which no
+    // further header write lands. Every response out of this wrapper declares the
+    // same dimensions, cacheable or not — a `Vary` that appears only on the
+    // cacheable arm would itself be a caller-dependent header.
+    res.setHeader('Vary', CALLER_DEPENDENT_VARY);
+
     const shouldStop = addCorsHeaders(req, res, allowedMethods);
-    addPublicCacheHeaders(req, res, maxAge);
+
+    // 🔴 `public, s-maxage` is a claim that ANY caller may be served this exact
+    // body. Several routes on this wrapper resolve the session themselves and
+    // shape their response around it (`user/settings`, `user/getHiddenPreferences`,
+    // `v1/images`, `download/models/[modelVersionId]`, …), so that claim is only
+    // true for a request that presented no credential. Make the header follow the
+    // claim instead of asserting it unconditionally.
+    //
+    // The fallback is the platform default rather than nothing. `apiCacheMiddleware`
+    // already sets exactly this string, but its matcher covers only `/api/trpc/*`,
+    // `/api/v1/*` and `/api/testing/*` (verified in `src/proxy.ts`) — and this
+    // wrapper is used well outside those prefixes (`/api/user/*`, `/api/generation/*`,
+    // `/api/track/*`, `/api/download/*`, `/api/internal/*`). Relying on the proxy
+    // would leave those with no `Cache-Control` at all, which is a weaker
+    // statement than the one they need, so state it here too.
+    //
+    // A handler that sets its own `Cache-Control` still wins either way: headers
+    // are not flushed until it responds, and last write wins. That is what keeps
+    // the `no-store` error arms (`handleEndpointError`, and the 503 sheds in
+    // `v1/images`/`v1/users`) authoritative.
+    if (requestCarriesCallerCredentials(req)) res.setHeader('Cache-Control', PRIVATE_CACHE_CONTROL);
+    else addPublicCacheHeaders(req, res, maxAge);
+
     if (shouldStop) return;
     await handler(req, res);
   });

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -18,7 +18,7 @@ import type { Partner } from '~/shared/utils/prisma/models';
 import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { isClientAbortError, isDriverAuthoredMessage } from '~/server/utils/errorHandling';
 import { isDefined } from '~/utils/type-guards';
-import { PRIVATE_CACHE_CONTROL } from '~/shared/constants/cache-control.constants';
+import { PRIVATE_CACHE_CONTROL } from '~/server/middleware/middleware-utils';
 import { logToAxiom, buildCentralErrorLog, wasServerFaultLogged } from '~/server/logging/client';
 import {
   GENERIC_CLIENT_ERROR_BY_STATUS,
@@ -287,14 +287,37 @@ const addPublicCacheHeaders = (
 };
 
 /**
- * The request dimensions a `PublicEndpoint` body can legitimately depend on.
+ * `Vary` for a response that carries the PUBLIC cache header — i.e. one produced
+ * for a request that presented no credential.
  *
- * `Cookie` and `Authorization` are the two the wrapper itself branches on below,
- * so they are the two it must declare. A response that can differ by credential
- * and does not say so is, per RFC 9111 §4.1, indistinguishable to a shared cache
- * from one that cannot — the cache has no way to know a second dimension exists.
+ * 🔴 `Vary` is DOCUMENTATION here, not the control. What keeps a caller-specific
+ * body out of a shared cache is `Cache-Control: private` on the other arm; this
+ * header only describes which request dimension the wrapper branched on. Do not
+ * read it as enforcement, and do not weaken the `Cache-Control` split on the
+ * strength of it.
+ *
+ * `Authorization` only, deliberately. It is stable per caller and has tiny
+ * cardinality (present / absent for practically every caller of these routes), so
+ * declaring it costs nothing. `Cookie` does not belong on this arm: an ordinary
+ * logged-out browser carries analytics and bot-management cookies whose values
+ * change per pageview and rotate on a timer, so keying a shared cache on the
+ * whole `Cookie` header would give roughly one entry per browser per rotation
+ * window — the anonymous hit rate would collapse, and cheap 304 revalidations
+ * would turn into full 200s. The anonymous body is by construction the same for
+ * every caller who presented nothing, so there is nothing to fragment for.
  */
-const CALLER_DEPENDENT_VARY = 'Cookie, Authorization';
+const ANONYMOUS_VARY = 'Authorization';
+
+/**
+ * `Vary` for a response that carries the PRIVATE cache header — i.e. one produced
+ * for a request that presented a credential.
+ *
+ * `Cookie` is added here and only here. This arm is already `private, no-cache`,
+ * so there is no shared-cache entry for the extra dimension to fragment; naming
+ * it is free, and it states honestly that the body was shaped by the cookie the
+ * caller sent.
+ */
+const CREDENTIALED_VARY = 'Authorization, Cookie';
 
 /**
  * Cookie names that can carry a session, hence make a response caller-dependent.
@@ -334,6 +357,15 @@ const SESSION_COOKIE_NAMES = Array.from(
  * `req.cookies` is what Next populates for an API route and is the primary read.
  * The raw `Cookie` header is parsed as a fallback so the check cannot quietly
  * degrade to "no credentials" in any context that skips that parsing.
+ *
+ * 🔴 The `?token=` query parameter is a credential HERE because
+ * `getServerAuthSession` treats it as one — it reads `req.url`'s `token` param
+ * and resolves it through `getSessionFromBearerToken`, exactly as it would an
+ * `Authorization` header. Omitting it would make `MixedAuthEndpoint` call an
+ * api-key request anonymous and hand it the public header, which is the arm it
+ * has never been on. The set of credential spellings this predicate recognises
+ * must stay a superset of the set `getServerAuthSession` accepts; when one grows,
+ * so must the other.
  */
 export function requestCarriesCallerCredentials(req: NextApiRequest): boolean {
   if (req.headers?.authorization) return true;
@@ -352,6 +384,21 @@ export function requestCarriesCallerCredentials(req: NextApiRequest): boolean {
     }
   }
 
+  if (hasNonEmpty((req.query as Record<string, unknown> | undefined)?.token)) return true;
+
+  // Same fallback rationale as the raw `Cookie` header above: `req.query` is
+  // Next's parse, and `getServerAuthSession` reads `req.url` directly, so the two
+  // reads must both be covered or the predicate can silently narrow.
+  const queryString = req.url?.split('?')[1];
+  if (queryString && hasNonEmpty(new URLSearchParams(queryString).get('token'))) return true;
+
+  return false;
+}
+
+/** Truthy for a non-empty string, or an array containing one. */
+function hasNonEmpty(value: unknown): boolean {
+  if (typeof value === 'string') return value.length > 0;
+  if (Array.isArray(value)) return value.some((v) => typeof v === 'string' && v.length > 0);
   return false;
 }
 
@@ -364,13 +411,22 @@ export function PublicEndpoint(
   { maxAge }: { maxAge?: number } = {}
 ) {
   return withApiMetrics(async (req: AxiomAPIRequest, res: NextApiResponse) => {
-    // Set FIRST: `addCorsHeaders` can end an OPTIONS preflight, after which no
-    // further header write lands. Every response out of this wrapper declares the
-    // same dimensions, cacheable or not — a `Vary` that appears only on the
-    // cacheable arm would itself be a caller-dependent header.
-    res.setHeader('Vary', CALLER_DEPENDENT_VARY);
+    const credentialed = requestCarriesCallerCredentials(req);
 
-    const shouldStop = addCorsHeaders(req, res, allowedMethods);
+    // Set BEFORE `addCorsHeaders`: that helper ends an OPTIONS preflight itself,
+    // and once a response is ended `setHeader` throws `ERR_HTTP_HEADERS_SENT`
+    // rather than quietly doing nothing. A preflight therefore has exactly one
+    // window in which a header can be declared, and this is it.
+    res.setHeader('Vary', credentialed ? CREDENTIALED_VARY : ANONYMOUS_VARY);
+
+    // 🔴 The early return belongs HERE, above the `Cache-Control` write — not
+    // below it. `addCorsHeaders` answers an OPTIONS preflight with
+    // `res.status(200).end()`, so every header write placed after it runs against
+    // an already-sent response and throws. That has always been true of whatever
+    // sat in this position (it is not introduced by the cache split below); the
+    // client still got its 200, at the cost of a thrown exception per preflight.
+    // A preflight carries no body, so it needs no cache directive at all.
+    if (addCorsHeaders(req, res, allowedMethods)) return;
 
     // 🔴 `public, s-maxage` is a claim that ANY caller may be served this exact
     // body. Several routes on this wrapper resolve the session themselves and
@@ -391,10 +447,9 @@ export function PublicEndpoint(
     // are not flushed until it responds, and last write wins. That is what keeps
     // the `no-store` error arms (`handleEndpointError`, and the 503 sheds in
     // `v1/images`/`v1/users`) authoritative.
-    if (requestCarriesCallerCredentials(req)) res.setHeader('Cache-Control', PRIVATE_CACHE_CONTROL);
+    if (credentialed) res.setHeader('Cache-Control', PRIVATE_CACHE_CONTROL);
     else addPublicCacheHeaders(req, res, maxAge);
 
-    if (shouldStop) return;
     await handler(req, res);
   });
 }
@@ -432,10 +487,36 @@ export function MixedAuthEndpoint(
     if (!req.method || !allowedMethods.includes(req.method))
       return res.status(405).json({ error: 'Method not allowed' });
 
-    const shouldStop = addCorsHeaders(req, res, allowedMethods);
+    // Same two properties as `PublicEndpoint`, for the same reasons — see the
+    // comments there. Two differences worth naming, because this wrapper used to
+    // decide on a different axis:
+    //
+    //  1. **The branch is on the CREDENTIAL, not on the resolved session.** This
+    //     used to read `if (!session) addPublicCacheHeaders(...)`, which asks
+    //     whether the credential WORKED. Those two questions have different
+    //     answers whenever a credential is presented and does not resolve — an
+    //     expired cookie, a revoked token, a redis miss — and only one of them is
+    //     conservative. `requestCarriesCallerCredentials` is a header-only read,
+    //     so it also runs before any session work.
+    //  2. **The credentialed arm now states a header.** It previously stated
+    //     nothing and left the response to `apiCacheMiddleware`, whose matcher
+    //     covers `/api/v1/*` and `/api/trpc/*` only. Two of the twelve routes on
+    //     this wrapper sit outside that: `/api/auth/freshdesk`, which answered
+    //     with no `Cache-Control` at all, and
+    //     `/api/blocks/screenshot/[appBlockId]/[file]`, whose 200 arm sets its
+    //     own header (and still wins) but whose 404 arms did not.
+    const credentialed = requestCarriesCallerCredentials(req);
+    res.setHeader('Vary', credentialed ? CREDENTIALED_VARY : ANONYMOUS_VARY);
+
+    // Early return above every later header write — see `PublicEndpoint`. This
+    // also stops a preflight doing a pointless session resolve after the 200 has
+    // already gone out.
+    if (addCorsHeaders(req, res, allowedMethods)) return;
+
+    if (credentialed) res.setHeader('Cache-Control', PRIVATE_CACHE_CONTROL);
+    else addPublicCacheHeaders(req, res);
+
     const session = await getServerAuthSession({ req, res });
-    if (!session) addPublicCacheHeaders(req, res);
-    if (shouldStop) return;
 
     if (!!req.query?.etag && req.query.etag !== '') {
       const isNotUpToDate = await checkNotUpToDate(

--- a/src/shared/constants/cache-control.constants.ts
+++ b/src/shared/constants/cache-control.constants.ts
@@ -1,0 +1,9 @@
+/**
+ * The platform's safe default `Cache-Control` for API responses: usable by the
+ * caller's own browser only, and revalidated every time.
+ *
+ * Single-sourced so the proxy-level default (`apiCacheMiddleware`) and the
+ * endpoint wrappers that fall back to it cannot drift apart. Deliberately a bare
+ * string constant with no imports — the proxy graph loads it too.
+ */
+export const PRIVATE_CACHE_CONTROL = 'max-age=0, private, no-cache';

--- a/src/shared/constants/cache-control.constants.ts
+++ b/src/shared/constants/cache-control.constants.ts
@@ -1,9 +1,0 @@
-/**
- * The platform's safe default `Cache-Control` for API responses: usable by the
- * caller's own browser only, and revalidated every time.
- *
- * Single-sourced so the proxy-level default (`apiCacheMiddleware`) and the
- * endpoint wrappers that fall back to it cannot drift apart. Deliberately a bare
- * string constant with no imports — the proxy graph loads it too.
- */
-export const PRIVATE_CACHE_CONTROL = 'max-age=0, private, no-cache';


### PR DESCRIPTION
## What

`PublicEndpoint` stamps `Cache-Control: public, s-maxage=300, stale-while-revalidate=150` on **every** response, unconditionally, **before the handler runs** — and sets no `Vary` at all.

`public` is a claim that any caller may be served that exact body. But **9 of the 27 routes on this wrapper call `getServerAuthSession` themselves** and shape their response around the result (`user/settings`, `user/getHiddenPreferences`, `generation/data`, `generation/resources`, `v1/images`, `download/models/[modelVersionId]`, `download/attachments/[fileId]`, `track/block-render`, `application-error`). For those, the claim only holds for a request that presented no credential. And a response whose body can differ by credential without a `Vary` is, to a shared cache, indistinguishable from one that cannot — per RFC 9111 §4.1 there is no way for the cache to learn a second dimension exists.

`MixedAuthEndpoint` decides the same thing and had the same gap in a different shape, so it gets the same treatment. And the wrapper position being edited turned out to carry a pre-existing bug, fixed here and called out separately below.

This makes the header follow the claim.

## Change

All in `src/server/utils/endpoint-helpers.ts` unless noted.

1. **Conditional public caching, on both wrappers.** A request carrying a session cookie, an `Authorization` header or a `?token=` api key gets the platform's private default (`max-age=0, private, no-cache`) instead of the public one. Anything else is unchanged.

2. **`Vary` per arm.** The publicly cacheable arm declares `Vary: Authorization`; the private arm declares `Vary: Authorization, Cookie`.

   `Cookie` is deliberately **not** on the cacheable arm. A logged-out browser carries analytics and bot-management cookies whose values change per pageview and rotate on a timer, so keying a shared cache on the whole `Cookie` header would produce roughly one entry per browser per rotation window — the anonymous hit rate would collapse and cheap 304 revalidations would become full 200s. That arm's body does not depend on a cookie by construction, so there is nothing to fragment for. On the private arm the response is already `no-cache`, so there is no shared entry left to fragment and naming `Cookie` is free.

   The comment now states explicitly that **`Vary` is documentation and `Cache-Control` is the control** — the previous wording read as though `Vary` were doing enforcement work, which invited weakening the split it depends on.

3. **`MixedAuthEndpoint` moves onto the same predicate.** It branched on `if (!session)` — whether the credential *resolved* — where `PublicEndpoint` branches on whether one was *presented*. Those disagree exactly when a credential is presented and does not resolve (expired cookie, revoked api key, session-store miss), and on that disagreement the old form took the **public** arm. It also emitted **no `Vary` at all**, and on its authenticated arm emitted **nothing**, relying on `apiCacheMiddleware` — whose matcher covers `/api/v1/*` and `/api/trpc/*` only.

   **12 route files are on this wrapper.** 10 are under `/api/v1/*` (`apps/index`, `apps/[slug]`, `articles/[id]`, `articles/index`, `collections/[id]`, `collections/index`, `model-files/[id]/tensor-metadata`, `models/index`, `model-versions/[id]`, `model-versions/mini/[id]`) and 2 are not: `/api/auth/freshdesk`, whose redirect target is caller-specific and which returned **no `Cache-Control` at all**, and `/api/blocks/screenshot/[appBlockId]/[file]`, whose 200 arm sets its own header (and still wins — pinned by a test) but whose 404 arms had none.

4. **`?token=` counts as a credential.** `getServerAuthSession` reads `req.url`'s `token` parameter and resolves it through `getSessionFromBearerToken`, exactly as it would an `Authorization` header. Without this, an api-key request to a `MixedAuthEndpoint` route would have landed on the anonymous arm — an arm it has never been on. Both `req.query` and the raw `req.url` query string are read, for the same reason the cookie check reads both `req.cookies` and the raw header. A negative control pins that the discriminator is the `token` parameter and not "the request has a query string".

5. **The private default is single-sourced in `src/server/middleware/middleware-utils.ts`**, which `apiCacheMiddleware` already imports and which pulls in nothing but a `next/server` type. `PRIVATE_CACHE_CONTROL` and the string in `api-cache.middleware.ts` therefore cannot drift, with no additional module in either graph.

## Pre-existing fix, in the position being edited

**On an `OPTIONS` preflight, both wrappers threw.** `addCorsHeaders` answers a preflight with `res.status(200).end()`; the wrapper then wrote a header, and against a real `http.ServerResponse` a post-`end()` `setHeader` throws `ERR_HTTP_HEADERS_SENT`.

**This is not a regression from this branch** — it is identical on `main`, where `addPublicCacheHeaders` sat in the same position. The client still received its 200; the cost was one thrown exception per preflight, on all 27 `PublicEndpoint` routes and on any `MixedAuthEndpoint` route that lists `OPTIONS` in its allowed methods. The early return now sits **above** the header write, which also stops a preflight paying for a session resolve it cannot use.

Reproduced at the base commit by a test that drives the real class: it fails there with `ERR_HTTP_HEADERS_SENT` raised inside `addPublicCacheHeaders`, on both wrappers.

## What is deliberately NOT changed

- **The anonymous arm's `Cache-Control` is byte-identical**, per-endpoint `maxAge` included. Its `Vary` is **new** — every anonymous response now carries `Vary: Authorization`, which it did not have before; that is the one header difference an anonymous caller sees. A change that stopped edge-caching for everyone would be a straight regression, and several tests in each suite exist only to prove that did not happen.
- **A handler's own `Cache-Control` still wins** on either arm — headers aren't flushed until the handler responds, so `handleEndpointError`'s `no-store, max-age=0`, the 503 sheds in `v1/images` / `v1/users`, and `blocks/screenshot`'s own `public, max-age=300` all stay authoritative. Covered by tests on both wrappers and both arms.
- **No route file is edited.**

## Blast radius

| | count |
|---|---|
| route files wrapped in `PublicEndpoint` | **27** |
| …of which resolve a session in the handler | 9 |
| …under `/api/v1/*` (proxy default already applies) | 12 |
| …outside `/api/v1/*` (proxy default does **not** apply) | 15 |
| …that already set their own `Cache-Control` | 4 |
| route files wrapped in `MixedAuthEndpoint` | **12** |
| …under `/api/v1/*` | 10 |
| …outside `/api/v1/*` (previously no `Cache-Control` on the authed arm) | 2 |

For an anonymous caller — including every crawler and every logged-out browser — the cache directive is unchanged on all 39 routes; only the new `Vary: Authorization` is added.

## Tests

Three files, 61 cases:

- `public-endpoint-credentialed-cache.test.ts` (27) — the `PublicEndpoint` contract: the anonymous arm preserved (incl. the `maxAge` override and a decoy-cookie negative control), each of the four credential cookie spellings, `Authorization`, the raw-`Cookie`-header fallback, `?token=` in both readings plus a look-alike-query negative control, the exact `Vary` string per arm, and the handler `no-store` override on both arms.
- `public-endpoint-credential-detection.test.ts` (20) — the predicate in isolation, pinning both directions: every credential spelling is recognised, and near-miss cookie names, empty values and token-shaped query parameters are not.
- `mixed-auth-endpoint-cache.test.ts` (14) — the same contract for the second wrapper, including the case that separates the two axes: a credential **is** presented and the session store returns nothing, where branching on `!session` takes the public arm.

Every expected header value is a **literal**, never re-derived from the implementation's own constants, so each suite is meaningful against code that predates them.

### The ordering guard is driven through a real `http.ServerResponse`

The preflight-ordering test previously ran against a hand-rolled fake whose `end()` is a no-op and whose `setHeader` never throws. Measured by reconstructing the previous commit's tree and moving the `Vary` write to below `addCorsHeaders`: **`src/server/utils/__tests__/` stayed fully green, 66 files / 1003 tests**, including the case whose name says it pins that ordering. The guard was spelled, not structural — the property it claims to test is a property of `ServerResponse`, which no fake in the file implemented.

`src/server/utils/__tests__/real-api-response.ts` builds a req/res pair from the real `node:http` classes with the three methods Next adds (`status`/`json`/`send`) in their real shapes. Against it, `end()` flushes the header block and a later `setHeader` throws, so the ordering is observable. Both wrappers now have an OPTIONS case and a GET case on the real class — the GET is the positive control, without which the preflight case cannot distinguish "the ordering is right" from "no headers are written at all".

### Red → green

Run at base `891f5382a6` with only the implementation reverted:

| file | at base | at HEAD |
|---|---|---|
| `public-endpoint-credentialed-cache.test.ts` | 16 failed / 11 passed | 27 passed |
| `public-endpoint-credential-detection.test.ts` | 20 failed | 20 passed |
| `mixed-auth-endpoint-cache.test.ts` | 10 failed / 4 passed | 14 passed |
| **total** | **46 failed / 15 passed (61)** | **61 passed** |

The 15 that pass at base are the controls, which are supposed to be green on both sides: the cookie-name assertions, the "anonymous arm preserved" cases and the handler-override cases.

*(An earlier revision of this section said "12 failed / 9 passed". That figure counted one file and omitted the other entirely.)*

### Mutation results

Eleven mutants, each killed by the assertion it should be killed by, with the pristine tree green (61/61) as the positive control:

| mutant | result |
|---|---|
| invert the branch | 16 failed — both directions: the credential arms *and* the anonymous-preservation cases |
| replace the derived cookie names with the retired literal | 15 failed — only the **current**-cookie cases; the legacy ones still pass, which is what proves the mutant ran and that the current name is the discriminator |
| drop the raw-`Cookie`-header fallback | 6 failed, all and only the raw-header cases |
| drop the `Vary` header | 11 failed — `expected undefined to be 'Authorization'` / `'Authorization, Cookie'` |
| make the predicate always return `true` | 21 failed, incl. every anonymous-preservation case |
| **move the `Vary` write to after `addCorsHeaders`** | **1 failed** — the real-`ServerResponse` preflight case, `ERR_HTTP_HEADERS_SENT`. This is the mutant that SURVIVED a fully green suite before the fixture change |
| move the `Cache-Control` write above the early return | 1 failed — same case, same error code: the pre-existing bug, re-introduced |
| drop the `?token=` detection | 7 failed, all and only the api-key cases |
| revert `MixedAuthEndpoint` to branching on `!session` | 6 failed, incl. both credential-does-not-resolve cases |
| add `Cookie` to the anonymous `Vary` | 8 failed — `expected 'Authorization, Cookie' not to contain 'Cookie'` |
| drop `Cookie` from the credentialed `Vary` | 4 failed |

Each mutant's application is anchor-checked (a mutation that fails to match its anchor aborts rather than scoring SURVIVED), and the file is restored and sha256-verified between runs.

Also run: `src/server/utils/__tests__/` + `src/tests/api/` + `src/server/middleware/__tests__/` → 151 files / 2338 tests green; `pnpm test:lint-rules` → 11 files / 281 green; `pnpm typecheck` → 0 errors; prettier + eslint clean on every changed file (0 errors). The mutation battery and the suites were both re-run on Node 24.19, the version CI uses.
