### PR TITLE
fix(upload): a telemetry outage must not fail uploads — contain the Axiom write, respond before logging

### DIFF
--- a/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
+++ b/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
@@ -170,9 +170,17 @@ describe('logToAxiom structured-stderr sink (always-on for Loki)', () => {
  * bare `await axiom.ingestEvents(datastream, sendData)`:
  *   - CONTAINMENT → the awaited call rejected into the caller.
  *   - BUDGET      → the caller was held for as long as the SDK held the socket.
- *   - NO UNHANDLED REJECTION → after a budget-based fix that used a trailing `.catch()`
- *     instead of a paired rejection handler, the abandoned promise's later rejection is
- *     unhandled, which is the exact `unhandledRejection` that killed the jobs pods.
+ *   - NO UNHANDLED REJECTION → once the budget can win the race, the ingest promise is left
+ *     with nobody awaiting it, so a rejection arriving later needs a handler that was
+ *     attached SYNCHRONOUSLY at creation. Without one that is the exact
+ *     `unhandledRejection` that killed the jobs pods.
+ *
+ * ⚠️ An earlier version of this docstring said a trailing `.then(onOk).catch(onErr)` would
+ * leave the rejection unhandled. That was WRONG — `.catch` attaches to the derived promise
+ * synchronously and handles the original's rejection through it, so that form is equally
+ * safe (a mutant using it survives this suite, correctly). The shape that genuinely leaks,
+ * and the one the NO UNHANDLED REJECTION case kills, is a fulfilment handler with NO
+ * rejection handler at all.
  */
 describe('logToAxiom Axiom dual-write containment', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
@@ -307,15 +315,14 @@ describe('logToAxiom Axiom dual-write containment', () => {
   });
 
   /**
-   * 🔴 `type` is what Alloy extracts into Loki's `detected_level` — the consuming app's
-   * `buildCentralErrorLog` says so explicitly and notes that `level` is NOT read. Without
-   * `type: 'error'` these lines never reach the error stream, so the "Axiom ingest is failing"
-   * alert this event exists to support cannot be built on it. `pod` is what distinguishes one
-   * sick pod from a fleet-wide outage.
+   * 🔴 `type` — NOT `level` — is the severity field Alloy promotes to structured metadata for
+   * these lines, so `| type="error"` is the query that finds them. Without it the event is
+   * unfindable by severity and the "Axiom ingest is failing" alert it exists to support
+   * cannot be built on it.
    *
-   * Both were missing from the first version of this feature and an audit caught it. Pinned
-   * here because the failure mode is silence: the event still gets written, it just never
-   * shows up where anyone is looking.
+   * Both `type` and `pod` were missing from the first version of this feature and an audit
+   * caught it. Pinned here because the failure mode is silence: the event still gets written,
+   * it just never shows up where anyone is looking.
    */
   it('the failure report is queryable as an ERROR and attributable to a pod', async () => {
     h.ingestEvents.mockRejectedValue(new Error('down'));
@@ -342,6 +349,9 @@ describe('logToAxiom Axiom dual-write containment', () => {
       name: 'axiom-ingest-recovered',
       type: 'info',
       pod: 'pod-test',
+      // Asserted on BOTH lines, not just the failure one: on a multi-datastream recovery this
+      // is the only field saying WHICH transport came back.
+      datastream: 'civitai-errors',
     });
   });
 

--- a/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
+++ b/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
@@ -170,17 +170,16 @@ describe('logToAxiom structured-stderr sink (always-on for Loki)', () => {
  * bare `await axiom.ingestEvents(datastream, sendData)`:
  *   - CONTAINMENT → the awaited call rejected into the caller.
  *   - BUDGET      → the caller was held for as long as the SDK held the socket.
- *   - NO UNHANDLED REJECTION → once the budget can win the race, the ingest promise is left
- *     with nobody awaiting it, so a rejection arriving later needs a handler that was
- *     attached SYNCHRONOUSLY at creation. Without one that is the exact
- *     `unhandledRejection` that killed the jobs pods.
  *
- * ⚠️ An earlier version of this docstring said a trailing `.then(onOk).catch(onErr)` would
- * leave the rejection unhandled. That was WRONG — `.catch` attaches to the derived promise
- * synchronously and handles the original's rejection through it, so that form is equally
- * safe (a mutant using it survives this suite, correctly). The shape that genuinely leaks,
- * and the one the NO UNHANDLED REJECTION case kills, is a fulfilment handler with NO
- * rejection handler at all.
+ * ⚠️ NO UNHANDLED REJECTION is an INVARIANT GUARD, not regression coverage — labelled so
+ * nobody counts it as proof of a bug that existed. Two earlier versions of this docstring got
+ * this wrong in two different ways (first: a trailing `.catch()` leaks; then: a fulfilment
+ * handler alone leaks and this test kills it). Both are refuted by mutants that SURVIVE 29/29,
+ * and by a node probe with a positive control: `Promise.race` subscribes to its inputs
+ * synchronously, so the ingest promise always has a subscriber and NO reachable mutation of
+ * this function that keeps the race can produce an unhandled rejection. The case is kept
+ * because it pins the property at the seam where it would break if the race were ever removed
+ * — but it is a guard against a future shape, not evidence about a past one.
  */
 describe('logToAxiom Axiom dual-write containment', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;

--- a/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
+++ b/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
@@ -37,6 +37,22 @@ const PROD_CONFIGURED = {
   podName: 'pod-test',
 } as const;
 
+/**
+ * The dual-write's consecutive-failure count is pinned to `globalThis`, keyed by datastream,
+ * so that the many emitted copies of this module share one counter in a real build (see the
+ * comment at `getSharedIngestFailureCounts`). That is deliberate in production and is exactly
+ * why it must be cleared between tests: otherwise a logger built in one test inherits the
+ * failure count of the previous one, and the throttle/recovery assertions read state they did
+ * not create. Reaching the map by its `Symbol.for` key keeps this out of the package's public
+ * surface — a test-only reset export would be API nobody else should have.
+ */
+const INGEST_FAILURES_KEY = Symbol.for('@civitai/axiom.ingestFailuresByDatastream');
+function resetIngestFailureCounts() {
+  (globalThis as Record<symbol, unknown>)[INGEST_FAILURES_KEY] = new Map<string, number>();
+}
+
+beforeEach(resetIngestFailureCounts);
+
 describe('logToAxiom structured-stderr sink (always-on for Loki)', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
@@ -288,6 +304,103 @@ describe('logToAxiom Axiom dual-write containment', () => {
     const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
     await logToAxiom(ERR);
     expect(reports(errorSpy)).toEqual([]);
+  });
+
+  /**
+   * 🔴 `type` is what Alloy extracts into Loki's `detected_level` — the consuming app's
+   * `buildCentralErrorLog` says so explicitly and notes that `level` is NOT read. Without
+   * `type: 'error'` these lines never reach the error stream, so the "Axiom ingest is failing"
+   * alert this event exists to support cannot be built on it. `pod` is what distinguishes one
+   * sick pod from a fleet-wide outage.
+   *
+   * Both were missing from the first version of this feature and an audit caught it. Pinned
+   * here because the failure mode is silence: the event still gets written, it just never
+   * shows up where anyone is looking.
+   */
+  it('the failure report is queryable as an ERROR and attributable to a pod', async () => {
+    h.ingestEvents.mockRejectedValue(new Error('down'));
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
+
+    await logToAxiom(ERR);
+
+    expect(reports(errorSpy)[0]).toMatchObject({
+      name: 'axiom-ingest-failed',
+      type: 'error',
+      pod: 'pod-test',
+      datastream: 'civitai-errors',
+    });
+  });
+
+  it('the recovery report is INFO — good news must not page as an error', async () => {
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
+    h.ingestEvents.mockRejectedValue(new Error('down'));
+    await logToAxiom(ERR);
+    h.ingestEvents.mockResolvedValue(undefined);
+    await logToAxiom(ERR);
+
+    expect(reports(errorSpy).at(-1)).toMatchObject({
+      name: 'axiom-ingest-recovered',
+      type: 'info',
+      pod: 'pod-test',
+    });
+  });
+
+  /**
+   * 🔴 The counter is shared across module copies on purpose. The consuming app measures that
+   * the bundler emits its logging module 14 times into one server build; with a private
+   * counter per copy each sees ~1/14th of the traffic, so the first-failure line fires up to
+   * 14 times, the every-500th threshold may never be reached, and a 6,000-event outage reports
+   * as a few `consecutiveFailures: 1` lines. Two loggers here stand in for two emitted copies.
+   */
+  it('SHARED COUNTER: separate loggers on one datastream continue the same outage', async () => {
+    h.ingestEvents.mockRejectedValue(new Error('down'));
+    const a = createAxiomLogger(PROD_CONFIGURED);
+    const b = createAxiomLogger(PROD_CONFIGURED);
+
+    await a.logToAxiom(ERR);
+    await b.logToAxiom(ERR);
+    await a.logToAxiom(ERR);
+
+    // One "first failure" line total, not one per logger — and the count kept climbing across
+    // them. A per-instance counter yields two `consecutiveFailures: 1` reports instead.
+    const r = reports(errorSpy);
+    expect(r).toHaveLength(1);
+    expect(r[0]).toMatchObject({ consecutiveFailures: 1 });
+
+    // Prove the shared count really advanced to 3 rather than sitting at 1 per logger: the
+    // recovery line reports the total across both.
+    h.ingestEvents.mockResolvedValue(undefined);
+    await b.logToAxiom(ERR);
+    expect(reports(errorSpy).at(-1)).toMatchObject({
+      name: 'axiom-ingest-recovered',
+      failedSince: 3,
+    });
+  });
+
+  it('a DIFFERENT datastream is a different transport with its own count', async () => {
+    h.ingestEvents.mockRejectedValue(new Error('down'));
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
+
+    await logToAxiom(ERR);
+    await logToAxiom(ERR, 'some-other-stream');
+
+    // Two independent outages → two first-failure lines, each at 1.
+    const r = reports(errorSpy);
+    expect(r.map((x) => x.datastream)).toEqual(['civitai-errors', 'some-other-stream']);
+    expect(r.map((x) => x.consecutiveFailures)).toEqual([1, 1]);
+  });
+
+  /**
+   * The budget timer must be cleared when the ingest wins the race, or every logged event
+   * leaves a 2 s timer pending — at this logger's rate that is thousands of live timers.
+   */
+  it('clears the budget timer when the ingest wins', async () => {
+    vi.useFakeTimers();
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
+
+    await logToAxiom(ERR);
+
+    expect(vi.getTimerCount()).toBe(0);
   });
 });
 

--- a/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
+++ b/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
@@ -172,14 +172,20 @@ describe('logToAxiom structured-stderr sink (always-on for Loki)', () => {
  *   - BUDGET      → the caller was held for as long as the SDK held the socket.
  *
  * ⚠️ NO UNHANDLED REJECTION is an INVARIANT GUARD, not regression coverage — labelled so
- * nobody counts it as proof of a bug that existed. Two earlier versions of this docstring got
- * this wrong in two different ways (first: a trailing `.catch()` leaks; then: a fulfilment
- * handler alone leaks and this test kills it). Both are refuted by mutants that SURVIVE 29/29,
- * and by a node probe with a positive control: `Promise.race` subscribes to its inputs
- * synchronously, so the ingest promise always has a subscriber and NO reachable mutation of
- * this function that keeps the race can produce an unhandled rejection. The case is kept
- * because it pins the property at the seam where it would break if the race were ever removed
- * — but it is a guard against a future shape, not evidence about a past one.
+ * nobody counts it as proof of a bug that existed. Once the ingest promise is raced it always
+ * has a synchronous subscriber, so no reachable mutation of that function produces an
+ * unhandled rejection: verified by a node probe with a positive control, and by a trailing
+ * `.then().catch()` mutant that SURVIVES 29/29.
+ *
+ * Two precise corrections, because earlier versions of this docstring were wrong in both
+ * directions and the second correction was also wrong:
+ *   - a trailing `.catch()` does NOT leak (that mutant survives — correctly);
+ *   - a fulfilment-handler-ONLY ingest does not leak either, but it is NOT harmless: it makes
+ *     an EARLY rejection reject the race and throw into the caller. That mutant fails 8 of 29,
+ *     killed by the CONTAINMENT cases — not by this one. So it dies for a real reason, just
+ *     not this test's reason.
+ *   - removing the race while keeping the pairing fails this case by TIMEOUT, i.e. as a
+ *     duplicate of BUDGET, not by observing a rejection.
  */
 describe('logToAxiom Axiom dual-write containment', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
@@ -314,10 +320,10 @@ describe('logToAxiom Axiom dual-write containment', () => {
   });
 
   /**
-   * 🔴 `type` — NOT `level` — is the severity field Alloy promotes to structured metadata for
-   * these lines, so `| type="error"` is the query that finds them. Without it the event is
-   * unfindable by severity and the "Axiom ingest is failing" alert it exists to support
-   * cannot be built on it.
+   * 🔴 `type: 'error'` is what makes this event findable — query it as `| type="error"`.
+   * Measured, with a negative control; see the note at `recordIngestOutcome`, which also
+   * records why no claim is made here about `detected_level` (three rewrites, three refuted
+   * mechanisms) and that `level` is emitted for shape consistency only.
    *
    * Both `type` and `pod` were missing from the first version of this feature and an audit
    * caught it. Pinned here because the failure mode is silence: the event still gets written,

--- a/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
+++ b/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
@@ -92,11 +92,12 @@ describe('logToAxiom structured-stderr sink (always-on for Loki)', () => {
     h.ingestEvents.mockRejectedValue(new Error('axiom down'));
     const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
 
-    // The stderr line is written synchronously before the await, so it lands even though the rejection
-    // propagates out of logToAxiom.
-    await expect(logToAxiom(ERR)).rejects.toThrow('axiom down');
+    // 🔴 This assertion USED TO BE `rejects.toThrow('axiom down')` — the rejection propagating out of
+    // logToAxiom was the documented behaviour, and it is what turned the 2026-08-23 Axiom outage into
+    // ~5,300 upload 500s and three crashed jobs pods. The dual-write is now contained.
+    await expect(logToAxiom(ERR)).resolves.toBeUndefined();
 
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    // The event line still lands (written before the await), plus ONE outage report.
     const parsed = JSON.parse(errorSpy.mock.calls[0][0] as string);
     expect(parsed).toMatchObject({ message: ERR.message, code: ERR.code });
     expect(h.ingestEvents).toHaveBeenCalledTimes(1);
@@ -142,6 +143,151 @@ describe('logToAxiom structured-stderr sink (always-on for Loki)', () => {
       'civitai-errors',
       expect.objectContaining({ message: ERR.message, code: ERR.code, pod: 'pod-test' })
     );
+  });
+});
+
+/**
+ * The Axiom dual-write must be CONTAINED (cannot throw to the caller) and BOUNDED (cannot
+ * hold the caller for the SDK's 30 s axios timeout).
+ *
+ * Every case here fails on the pre-2026-08-23 implementation, whose last statement was a
+ * bare `await axiom.ingestEvents(datastream, sendData)`:
+ *   - CONTAINMENT → the awaited call rejected into the caller.
+ *   - BUDGET      → the caller was held for as long as the SDK held the socket.
+ *   - NO UNHANDLED REJECTION → after a budget-based fix that used a trailing `.catch()`
+ *     instead of a paired rejection handler, the abandoned promise's later rejection is
+ *     unhandled, which is the exact `unhandledRejection` that killed the jobs pods.
+ */
+describe('logToAxiom Axiom dual-write containment', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    h.ingestEvents.mockReset().mockResolvedValue(undefined);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  const reports = (spy: ReturnType<typeof vi.spyOn>): Record<string, unknown>[] => {
+    const parsed: Record<string, unknown>[] = [];
+    for (const call of spy.mock.calls as unknown[][]) {
+      let line: Record<string, unknown>;
+      try {
+        line = JSON.parse(call[0] as string);
+      } catch {
+        continue;
+      }
+      if (typeof line.name === 'string' && line.name.startsWith('axiom-ingest-')) parsed.push(line);
+    }
+    return parsed;
+  };
+
+  it('CONTAINMENT: a rejecting ingest resolves the caller and reports the failure once', async () => {
+    h.ingestEvents.mockRejectedValue(new Error('ECONNREFUSED'));
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
+
+    await expect(logToAxiom(ERR)).resolves.toBeUndefined();
+
+    const r = reports(errorSpy);
+    expect(r).toHaveLength(1);
+    expect(r[0]).toMatchObject({
+      name: 'axiom-ingest-failed',
+      reason: 'error',
+      consecutiveFailures: 1,
+    });
+  });
+
+  it('BUDGET: a hanging ingest does not hold the caller past AXIOM_INGEST_TIMEOUT_MS', async () => {
+    vi.useFakeTimers();
+    // Never settles — the black-holed-endpoint case. Attach a sink so the abandoned promise
+    // cannot register as unhandled if the implementation regresses to leaving it bare.
+    h.ingestEvents.mockReturnValue(new Promise(() => {}));
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
+
+    let settled = false;
+    const call = logToAxiom(ERR).then(() => {
+      settled = true;
+    });
+
+    // Advance to just under the budget: still waiting.
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(settled).toBe(false);
+
+    // Cross it: the caller is released even though the ingest never resolves.
+    await vi.advanceTimersByTimeAsync(2);
+    await call;
+    expect(settled).toBe(true);
+
+    expect(reports(errorSpy)[0]).toMatchObject({ name: 'axiom-ingest-failed', reason: 'timeout' });
+  });
+
+  it('NO UNHANDLED REJECTION: an ingest that rejects AFTER the budget expired is still handled', async () => {
+    vi.useFakeTimers();
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      // Rejects long after the caller has stopped waiting — the shape that crashed the
+      // background pods when nothing was attached to the promise.
+      h.ingestEvents.mockReturnValue(
+        new Promise((_resolve, reject) => setTimeout(() => reject(new Error('late')), 10_000))
+      );
+      const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
+
+      const call = logToAxiom(ERR);
+      await vi.advanceTimersByTimeAsync(2_001);
+      await expect(call).resolves.toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      // Let any unhandled-rejection detection run.
+      vi.useRealTimers();
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('THROTTLE: an outage reports on the 1st and every 500th failure, not once per event', async () => {
+    h.ingestEvents.mockRejectedValue(new Error('down'));
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
+
+    for (let i = 0; i < 501; i++) await logToAxiom(ERR);
+
+    const r = reports(errorSpy);
+    expect(r.map((x) => x.consecutiveFailures)).toEqual([1, 500]);
+  });
+
+  it('RECOVERY: the next success reports the outage total and resets the counter', async () => {
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
+
+    h.ingestEvents.mockRejectedValue(new Error('down'));
+    await logToAxiom(ERR);
+    await logToAxiom(ERR);
+
+    h.ingestEvents.mockResolvedValue(undefined);
+    await logToAxiom(ERR);
+
+    expect(reports(errorSpy).at(-1)).toMatchObject({
+      name: 'axiom-ingest-recovered',
+      failedSince: 2,
+    });
+
+    // Counter reset: a later single failure reports as the FIRST of a new outage.
+    errorSpy.mockClear();
+    h.ingestEvents.mockRejectedValue(new Error('down again'));
+    await logToAxiom(ERR);
+    expect(reports(errorSpy)[0]).toMatchObject({ consecutiveFailures: 1 });
+  });
+
+  it('HEALTHY PATH IS SILENT: a successful ingest emits no outage report', async () => {
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
+    await logToAxiom(ERR);
+    expect(reports(errorSpy)).toEqual([]);
   });
 });
 

--- a/packages/civitai-axiom/src/client.ts
+++ b/packages/civitai-axiom/src/client.ts
@@ -155,21 +155,29 @@ export function createAxiomLogger(
    * Deliberately NOT routed through `logToAxiom` itself — that would try to ship the report
    * of an Axiom outage to Axiom, and recurse.
    *
-   * 🔴 BOTH `type` AND `level` are load-bearing, for DIFFERENT query surfaces. Two earlier
-   * versions of this comment each named one of them as the only one that matters, and each was
-   * wrong in the opposite direction — so this is stated from measurement against live Loki,
-   * with controls, not from reading either config:
+   * 🔴 `type: 'error'` is what makes this event findable. **Query it as `| type="error"`.**
    *
-   *   - `| type="error"`      → 735 hits/h, negative control `type="zzz-none"` → 0.
-   *     Alloy JSON-parses the stderr line and promotes `type` to structured metadata.
-   *   - `| detected_level="error"` → 18,148 hits/h, and it is derived from the `level` KEY,
-   *     not from a substring scan of the line. The discriminator: lines carrying
-   *     `"level":"info"` that ALSO contain the word "error" resolve to `detected_level="info"`
-   *     (74) and never to `"error"` (0). So `level` is read, and dropping it would silently
-   *     demote these lines to Loki's substring heuristic.
+   * That much is measured: Alloy JSON-parses this stderr line and promotes `type` to structured
+   * metadata, `| type="error"` returns rows, and the negative control `| type="zzz-none"`
+   * returns none.
    *
-   * Emit both. Without them the "Axiom ingest is failing" alert — the whole reason this event
-   * exists — cannot be written against either surface.
+   * ⚠️ DO NOT ADD A FOURTH THEORY ABOUT `detected_level` TO THIS COMMENT. Three successive
+   * rewrites each asserted a different mechanism for it and each was refuted by the next
+   * round's measurement — "`type` → `detected_level`", then "nothing reads `level`", then
+   * "`detected_level` is derived from the `level` key". The last was refuted by the control
+   * that version failed to run: lines carrying `"type":"error"` and NO `level` key resolve to
+   * `detected_level="error"` **100% of the time**, so `level` is not what drives it; and the
+   * discriminator that version cited could never have separated the two, because no line in
+   * this namespace carries `level` without also carrying `type`. `| level=` matches nothing at
+   * all — `level` has no structured-metadata surface here.
+   *
+   * So: `level` is emitted for SHAPE CONSISTENCY with the rest of the codebase's log records,
+   * NOT because anything here is known to read it. It is harmless and cheap; it is not the
+   * reason these lines are findable. If you need to know how `detected_level` is really
+   * derived, measure it — do not trust this comment, and do not extend it with a guess.
+   *
+   * Figures are deliberately not quoted here: an undated hit count in a source comment is
+   * unfalsifiable and decays. Re-measure against Loki with a negative control when it matters.
    *
    * `pod` is carried for parity with every other line this logger emits, so a reader who has
    * the line in hand can attribute it without joining. It is ALSO already a Loki stream label
@@ -306,19 +314,25 @@ export function createAxiomLogger(
        * indistinguishable from an outage. Nothing here cancels the request; we stop
        * WAITING for it.
        *
-       * The rejection handler is paired with the success handler so the two cannot drift apart,
-       * and so `outcome` is a plain union rather than something the race has to interpret.
+       * 🔴 THE PAIRING AND THE RACE ARE BOTH LOAD-BEARING, FOR DIFFERENT FAILURE MODES. Keep
+       * both. Three earlier versions of this comment each named one of them as the only one
+       * that mattered; all three were wrong, so these are stated from a node probe with a
+       * positive control (a promise nobody subscribes to, which does leak):
        *
-       * ⚠️ IT IS NOT WHAT PREVENTS AN UNHANDLED REJECTION, and two earlier versions of this
-       * comment claimed it was. `Promise.race` subscribes to every input SYNCHRONOUSLY, so the
-       * ingest promise always has a subscriber from the moment the race is constructed —
-       * including after the budget has won and nothing is awaiting it any more. Measured in
-       * node against a positive control (a promise nobody ever subscribes to, which DOES leak):
-       * paired handlers, a trailing `.catch`, a fulfilment handler alone, and a completely bare
-       * promise ALL produce zero unhandled rejections once raced.
+       *   - THE PAIRING handles an ingest that rejects EARLY, before the budget. It converts
+       *     the rejection into the value `'error'`, so the awaited race resolves. Without it
+       *     the race REJECTS and throws into the caller — measured: a bare or
+       *     fulfilment-handler-only ingest gives `THREW`, the paired one gives `'error'`. That
+       *     throw is the original 2026-08-23 bug, so deleting the pairing re-creates it.
+       *   - THE RACE handles an ingest that rejects LATE, after the budget has won and nothing
+       *     awaits the promise any more. `Promise.race` subscribes to its inputs synchronously,
+       *     so a subscriber is always attached. Measured: once raced, paired handlers, a
+       *     trailing `.catch`, a fulfilment handler alone and a bare promise ALL produce zero
+       *     unhandled rejections.
        *
-       * So the invariant that actually matters here is "the ingest promise is raced", not "the
-       * handler is paired". Do not delete the race and keep the pairing expecting safety.
+       * Neither substitutes for the other. `.then(onOk).catch(onErr)` would be equivalent to
+       * the paired form; what is NOT equivalent is dropping either the rejection handler or
+       * the race.
        */
       const ingest = axiom.ingestEvents(datastream, sendData).then(
         () => 'ok' as const,

--- a/packages/civitai-axiom/src/client.ts
+++ b/packages/civitai-axiom/src/client.ts
@@ -166,9 +166,10 @@ export function createAxiomLogger(
    * round's measurement — "`type` → `detected_level`", then "nothing reads `level`", then
    * "`detected_level` is derived from the `level` key". The last was refuted by the control
    * that version failed to run: lines carrying `"type":"error"` and NO `level` key resolve to
-   * `detected_level="error"` **100% of the time**, so `level` is not what drives it; and the
-   * discriminator that version cited could never have separated the two, because no line in
-   * this namespace carries `level` without also carrying `type`. `| level=` matches nothing at
+   * `detected_level="error"` **100% of the time**, so `level` is not NECESSARY for it (that is
+   * what the data shows — not that nothing ever reads `level`, which stays unresolvable here);
+   * and the discriminator that version cited could never have separated the two, because no
+   * line in this namespace carries `level` without also carrying `type`. `| level=` matches nothing at
    * all — `level` has no structured-metadata surface here.
    *
    * So: `level` is emitted for SHAPE CONSISTENCY with the rest of the codebase's log records,
@@ -319,16 +320,20 @@ export function createAxiomLogger(
        * that mattered; all three were wrong, so these are stated from a node probe with a
        * positive control (a promise nobody subscribes to, which does leak):
        *
-       *   - THE PAIRING handles an ingest that rejects EARLY, before the budget. It converts
-       *     the rejection into the value `'error'`, so the awaited race resolves. Without it
-       *     the race REJECTS and throws into the caller — measured: a bare or
-       *     fulfilment-handler-only ingest gives `THREW`, the paired one gives `'error'`. That
-       *     throw is the original 2026-08-23 bug, so deleting the pairing re-creates it.
-       *   - THE RACE handles an ingest that rejects LATE, after the budget has won and nothing
-       *     awaits the promise any more. `Promise.race` subscribes to its inputs synchronously,
-       *     so a subscriber is always attached. Measured: once raced, paired handlers, a
-       *     trailing `.catch`, a fulfilment handler alone and a bare promise ALL produce zero
-       *     unhandled rejections.
+       *   - THE PAIRING converts a rejection into the value `'error'`, so the awaited race
+       *     RESOLVES instead of rejecting into the caller. Measured: for an ingest that
+       *     rejects INSIDE the budget, a bare or fulfilment-handler-only promise gives `THREW`
+       *     while the paired one gives `'error'`. Precisely scoped: it re-creates a
+       *     caller-side throw for rejections inside the budget (an ECONNREFUSED shape), NOT
+       *     for the 30 s axios timeout the incident above describes — that one is already
+       *     outside the 2 s budget and resolves as `'timeout'` either way.
+       *   - THE RACE is what bounds the CALLER (see "WHY A RACE AND NOT JUST A TRY/CATCH"
+       *     above). ⚠️ It is NOT here to prevent unhandled rejections: with no race there is no
+       *     budget, nothing is ever abandoned, and that hazard does not arise. Measured, once
+       *     raced, paired handlers / trailing `.catch` / fulfilment-only / bare ALL produce
+       *     zero unhandled rejections — which is why the test that appears to cover this is
+       *     labelled an invariant guard, and why "the race prevents the leak" is a theory this
+       *     comment has already retracted once. Do not re-derive it.
        *
        * Neither substitutes for the other. `.then(onOk).catch(onErr)` would be equivalent to
        * the paired form; what is NOT equivalent is dropping either the rejection handler or

--- a/packages/civitai-axiom/src/client.ts
+++ b/packages/civitai-axiom/src/client.ts
@@ -95,6 +95,24 @@ const AXIOM_INGEST_TIMEOUT_MS = 2_000;
 const AXIOM_INGEST_FAILURE_REPORT_EVERY = 500;
 
 /**
+ * globalThis-pinned consecutive-failure counts, keyed by datastream.
+ *
+ * Pinned for the reason documented at the use site: the bundler emits this module many times
+ * into one build, and a module-scope `const` is therefore N independent objects rather than
+ * one. The consuming app solves the identical problem the identical way for its log sink; this
+ * mirrors it so the counter cannot be defeated by duplication.
+ *
+ * A `Symbol.for` key rather than a plain property so two copies agree without colliding with
+ * anything else on the global.
+ */
+const INGEST_FAILURES_KEY = Symbol.for('@civitai/axiom.ingestFailuresByDatastream');
+
+function getSharedIngestFailureCounts(): Map<string, number> {
+  const g = globalThis as typeof globalThis & { [INGEST_FAILURES_KEY]?: Map<string, number> };
+  return (g[INGEST_FAILURES_KEY] ??= new Map<string, number>());
+}
+
+/**
  * Build an Axiom logger. Config defaults come from the package's own env schema
  * (./env); pass a `Partial<AxiomConfig>` to override any value per call (tests,
  * multi-instance, alternate config sources). `deps` injects optional app behavior —
@@ -110,9 +128,24 @@ export function createAxiomLogger(
   const axiom =
     config.token && config.orgId ? new Client({ token: config.token, orgId: config.orgId }) : null;
 
-  // Consecutive-failure count for the Axiom dual-write. Per-logger, not global: a second
-  // logger instance is a second transport and gets its own outage.
-  let ingestFailures = 0;
+  /**
+   * Consecutive-failure count for the Axiom dual-write, SHARED across every emitted copy of
+   * this module that targets the same datastream.
+   *
+   * 🔴 A plain `let` here would be per-module-copy, and that is not the same as per-logger.
+   * The consuming app's `structured-log-sink` records — measured — that the bundler emits its
+   * logging module **14 distinct times into one server build**; that duplication is exactly
+   * what once made an OTel bridge deliver 1.3% of records. With 14 private counters, each sees
+   * ~1/14th of the traffic: the "first failure" line fires up to 14 times and no copy need ever
+   * reach the every-Nth threshold, so a 6,444-event outage could report as a handful of
+   * `consecutiveFailures: 1` lines and nothing else. That is the throttle failing in the one
+   * direction that matters.
+   *
+   * Keyed by datastream rather than globally, because two loggers pointing at DIFFERENT
+   * datastreams really are different transports with independent outages — while N copies of
+   * one module pointing at the SAME datastream are one transport that happens to be duplicated.
+   */
+  const ingestFailuresByDatastream = getSharedIngestFailureCounts();
 
   /**
    * Record the outcome of one dual-write and, on a transition or every Nth failure, say so
@@ -121,24 +154,45 @@ export function createAxiomLogger(
    *
    * Deliberately NOT routed through `logToAxiom` itself — that would try to ship the report
    * of an Axiom outage to Axiom, and recurse.
+   *
+   * 🔴 `type` and `pod` are load-bearing, not decoration. Alloy extracts `type` into Loki's
+   * `detected_level` (the consuming app's `buildCentralErrorLog` calls that out explicitly and
+   * notes `level` is NOT read), so without `type: 'error'` these lines never appear in the
+   * error stream — and an alert on "Axiom ingest is failing", which is the whole reason this
+   * event exists, could not be built on them. `pod` is what separates one sick pod from a
+   * fleet-wide outage; every other line this logger emits carries it.
    */
-  function recordIngestOutcome(outcome: 'ok' | 'error' | 'timeout') {
+  function recordIngestOutcome(outcome: 'ok' | 'error' | 'timeout', datastream: string) {
+    const failures = ingestFailuresByDatastream.get(datastream) ?? 0;
     if (outcome === 'ok') {
-      if (ingestFailures > 0) {
+      if (failures > 0) {
         console.error(
-          JSON.stringify({ name: 'axiom-ingest-recovered', failedSince: ingestFailures })
+          JSON.stringify({
+            name: 'axiom-ingest-recovered',
+            // Recovery is good news: INFO, so it does not page as an error itself.
+            type: 'info',
+            level: 'info',
+            pod: config.podName,
+            datastream,
+            failedSince: failures,
+          })
         );
-        ingestFailures = 0;
+        ingestFailuresByDatastream.set(datastream, 0);
       }
       return;
     }
-    ingestFailures += 1;
-    if (ingestFailures === 1 || ingestFailures % AXIOM_INGEST_FAILURE_REPORT_EVERY === 0) {
+    const next = failures + 1;
+    ingestFailuresByDatastream.set(datastream, next);
+    if (next === 1 || next % AXIOM_INGEST_FAILURE_REPORT_EVERY === 0) {
       console.error(
         JSON.stringify({
           name: 'axiom-ingest-failed',
+          type: 'error',
+          level: 'error',
+          pod: config.podName,
+          datastream,
           reason: outcome,
-          consecutiveFailures: ingestFailures,
+          consecutiveFailures: next,
         })
       );
     }
@@ -239,11 +293,19 @@ export function createAxiomLogger(
        * indistinguishable from an outage. Nothing here cancels the request; we stop
        * WAITING for it.
        *
-       * 🔴 The rejection handler is attached in the same `.then(onOk, onErr)` as the success
-       * handler — NOT as a later `.catch()` and not inside the race. When the budget wins,
-       * this promise is left running with nobody awaiting it; an unhandled rejection at
-       * that point is precisely the `unhandledRejection` that killed the jobs pods, i.e.
-       * the bug re-created by the fix for it.
+       * 🔴 A REJECTION HANDLER MUST BE ATTACHED HERE, SYNCHRONOUSLY, AT CREATION. When the
+       * budget below wins the race this promise is left running with nobody awaiting it, so a
+       * rejection arriving later has nowhere to go — that is an `unhandledRejection`, i.e. the
+       * bug this fix exists for, re-created by the fix. Attaching one after an `await`
+       * boundary, or only in the race arm, does not count.
+       *
+       * ⚠️ A trailing `.then(onOk).catch(onErr)` would be EQUALLY safe — `.catch` attaches to
+       * the derived promise synchronously and handles the original's rejection through it.
+       * An earlier version of this comment claimed otherwise and was wrong (verified in node:
+       * only the fulfilment-handler-ONLY form, `.then(onOk)` with no rejection handler, goes
+       * unhandled). The paired form is kept because it is one expression and cannot drift
+       * apart, not because the alternative leaks. What the test suite actually pins is the
+       * dangerous shape — a fulfilment handler with no rejection handler at all.
        */
       const ingest = axiom.ingestEvents(datastream, sendData).then(
         () => 'ok' as const,
@@ -261,7 +323,7 @@ export function createAxiomLogger(
       }
 
       try {
-        recordIngestOutcome(await Promise.race([ingest, budget]));
+        recordIngestOutcome(await Promise.race([ingest, budget]), datastream);
       } finally {
         clearTimeout(timer);
       }

--- a/packages/civitai-axiom/src/client.ts
+++ b/packages/civitai-axiom/src/client.ts
@@ -66,6 +66,35 @@ export type AxiomDeps = {
 };
 
 /**
+ * How long the Axiom dual-write may hold the CALLER before we stop waiting for it.
+ *
+ * 🔴 This is a CEILING ON THE CALLER, not a request timeout — nothing here cancels the
+ * in-flight POST. The underlying SDK (`@axiomhq/axiom-node`) drives axios with its own
+ * hardcoded `timeout: 30000`, which is not reachable through `new Client({token, orgId})`,
+ * so 30 s is what a request against a black-holed endpoint actually costs. That number is
+ * fine for a background flush and catastrophic on a request path: on 2026-08-23 Axiom's
+ * ingest host became unreachable for 44 minutes and every awaited `logToAxiom` on
+ * `/api/upload/{complete,abort,index}` stalled 30 s and then threw, turning uploads that
+ * had ALREADY SUCCEEDED into 500s for 350 users. See the containment note at the
+ * `ingestEvents` call below.
+ *
+ * 2 s is chosen to be longer than a healthy ingest (single-digit ms) by a wide margin and
+ * short enough to be invisible next to the work these hot paths already did.
+ */
+const AXIOM_INGEST_TIMEOUT_MS = 2_000;
+
+/**
+ * Report every Nth consecutive dual-write failure, not every one.
+ *
+ * A multi-minute Axiom outage produces one failure per logged event — 6,444 of them in
+ * 44 minutes during the incident above. One line each would be its own noise incident in
+ * Loki; zero lines would make the outage invisible from inside the app. Report the FIRST
+ * failure (so the start is timestamped), then every Nth (so the scale is legible), then the
+ * recovery with the total.
+ */
+const AXIOM_INGEST_FAILURE_REPORT_EVERY = 500;
+
+/**
  * Build an Axiom logger. Config defaults come from the package's own env schema
  * (./env); pass a `Partial<AxiomConfig>` to override any value per call (tests,
  * multi-instance, alternate config sources). `deps` injects optional app behavior —
@@ -80,6 +109,40 @@ export function createAxiomLogger(
 
   const axiom =
     config.token && config.orgId ? new Client({ token: config.token, orgId: config.orgId }) : null;
+
+  // Consecutive-failure count for the Axiom dual-write. Per-logger, not global: a second
+  // logger instance is a second transport and gets its own outage.
+  let ingestFailures = 0;
+
+  /**
+   * Record the outcome of one dual-write and, on a transition or every Nth failure, say so
+   * on the stderr/Loki path that is still working. `'timeout'` is counted as a failure: we
+   * stopped waiting, so from the caller's side the event is not known to have landed.
+   *
+   * Deliberately NOT routed through `logToAxiom` itself — that would try to ship the report
+   * of an Axiom outage to Axiom, and recurse.
+   */
+  function recordIngestOutcome(outcome: 'ok' | 'error' | 'timeout') {
+    if (outcome === 'ok') {
+      if (ingestFailures > 0) {
+        console.error(
+          JSON.stringify({ name: 'axiom-ingest-recovered', failedSince: ingestFailures })
+        );
+        ingestFailures = 0;
+      }
+      return;
+    }
+    ingestFailures += 1;
+    if (ingestFailures === 1 || ingestFailures % AXIOM_INGEST_FAILURE_REPORT_EVERY === 0) {
+      console.error(
+        JSON.stringify({
+          name: 'axiom-ingest-failed',
+          reason: outcome,
+          consecutiveFailures: ingestFailures,
+        })
+      );
+    }
+  }
 
   async function logToAxiom(data: MixedObject, datastream?: string) {
     const sendData = { pod: config.podName, ...data };
@@ -149,7 +212,59 @@ export function createAxiomLogger(
 
       if (!axiom) return;
       if (!datastream) return;
-      await axiom.ingestEvents(datastream, sendData);
+
+      /**
+       * 🔴 CONTAINED AND BOUNDED — the same contract the injected sink above already has,
+       * and for the same reason stated there: a telemetry sink must never be able to fail
+       * the code path it is observing. Until 2026-08-23 this one line was the sole
+       * uncontained sink in this function, and the exception proved expensive.
+       *
+       * WHAT IT COST. Axiom's ingest host went unreachable 01:08–01:52Z on 2026-08-23.
+       * `logToAxiom` is awaited on hot paths (this file's own header says so), so the
+       * rejection propagated into the callers:
+       *   - `/api/upload/complete` — the multipart completion had ALREADY SUCCEEDED; the
+       *     throw happened on the log line after it, so a stored object was reported to the
+       *     browser as a 500. ~5,300 failed requests, 350 distinct users, 44 minutes.
+       *   - the same handlers' CATCH blocks awaited this before classifying the error, so
+       *     the 409/422/503 taxonomy was structurally unreachable and every fault — 1,009
+       *     of them a terminal `NoSuchUpload` — went out as a retryable 500. Clients
+       *     retried; the retries re-failed. (The handlers have since been reordered too;
+       *     this containment is the half that does not depend on remembering to.)
+       *   - the background `jobs` pods call it WITHOUT awaiting, so there the rejection was
+       *     an `unhandledRejection` and Node exited. All three pods died at 01:06:45Z.
+       *
+       * WHY A RACE AND NOT JUST A TRY/CATCH. try/catch alone fixes the throw but not the
+       * 30 s stall (see AXIOM_INGEST_TIMEOUT_MS) — the caller would still be held for 30 s
+       * per logged event against a black-holed endpoint, which on the upload path is
+       * indistinguishable from an outage. Nothing here cancels the request; we stop
+       * WAITING for it.
+       *
+       * 🔴 The rejection handler is attached in the same `.then(onOk, onErr)` as the success
+       * handler — NOT as a later `.catch()` and not inside the race. When the budget wins,
+       * this promise is left running with nobody awaiting it; an unhandled rejection at
+       * that point is precisely the `unhandledRejection` that killed the jobs pods, i.e.
+       * the bug re-created by the fix for it.
+       */
+      const ingest = axiom.ingestEvents(datastream, sendData).then(
+        () => 'ok' as const,
+        () => 'error' as const
+      );
+
+      let onBudgetExpired!: (outcome: 'timeout') => void;
+      const budget = new Promise<'timeout'>((resolve) => {
+        onBudgetExpired = resolve;
+      });
+      const timer = setTimeout(() => onBudgetExpired('timeout'), AXIOM_INGEST_TIMEOUT_MS);
+      // Never let a pending telemetry budget hold a process open at shutdown.
+      if (typeof (timer as { unref?: () => void }).unref === 'function') {
+        (timer as unknown as { unref: () => void }).unref();
+      }
+
+      try {
+        recordIngestOutcome(await Promise.race([ingest, budget]));
+      } finally {
+        clearTimeout(timer);
+      }
     } else {
       console.log('logToAxiom', sendData);
     }

--- a/packages/civitai-axiom/src/client.ts
+++ b/packages/civitai-axiom/src/client.ts
@@ -155,12 +155,20 @@ export function createAxiomLogger(
    * Deliberately NOT routed through `logToAxiom` itself — that would try to ship the report
    * of an Axiom outage to Axiom, and recurse.
    *
-   * 🔴 `type` and `pod` are load-bearing, not decoration. Alloy extracts `type` into Loki's
-   * `detected_level` (the consuming app's `buildCentralErrorLog` calls that out explicitly and
-   * notes `level` is NOT read), so without `type: 'error'` these lines never appear in the
-   * error stream — and an alert on "Axiom ingest is failing", which is the whole reason this
-   * event exists, could not be built on them. `pod` is what separates one sick pod from a
-   * fleet-wide outage; every other line this logger emits carries it.
+   * 🔴 `type` is load-bearing, not decoration, and `type` is the field — NOT `level`.
+   *
+   * Alloy's pipeline for these namespaces JSON-parses the stderr line and promotes `type` to
+   * **structured metadata named `type`**, so the query that finds these is `| type="error"`.
+   * (`level` → `detected_level` is the separate OTLP path, which a bare `console.error` line
+   * never takes; the deployed Alloy config says in as many words that the severity field here
+   * is `type`, not `level`. `level` is emitted alongside only for consistency with the rest of
+   * the codebase's log shape — nothing reads it.) Without `type: 'error'` these lines are
+   * unfindable by severity, and the alert on "Axiom ingest is failing" — the whole reason this
+   * event exists — could not be built on them.
+   *
+   * `pod` is carried for parity with every other line this logger emits, so a reader who has
+   * the line in hand can attribute it without joining. It is ALSO already a Loki stream label
+   * from k8s service discovery, so this is redundancy rather than the only source.
    */
   function recordIngestOutcome(outcome: 'ok' | 'error' | 'timeout', datastream: string) {
     const failures = ingestFailuresByDatastream.get(datastream) ?? 0;

--- a/packages/civitai-axiom/src/client.ts
+++ b/packages/civitai-axiom/src/client.ts
@@ -155,16 +155,21 @@ export function createAxiomLogger(
    * Deliberately NOT routed through `logToAxiom` itself — that would try to ship the report
    * of an Axiom outage to Axiom, and recurse.
    *
-   * 🔴 `type` is load-bearing, not decoration, and `type` is the field — NOT `level`.
+   * 🔴 BOTH `type` AND `level` are load-bearing, for DIFFERENT query surfaces. Two earlier
+   * versions of this comment each named one of them as the only one that matters, and each was
+   * wrong in the opposite direction — so this is stated from measurement against live Loki,
+   * with controls, not from reading either config:
    *
-   * Alloy's pipeline for these namespaces JSON-parses the stderr line and promotes `type` to
-   * **structured metadata named `type`**, so the query that finds these is `| type="error"`.
-   * (`level` → `detected_level` is the separate OTLP path, which a bare `console.error` line
-   * never takes; the deployed Alloy config says in as many words that the severity field here
-   * is `type`, not `level`. `level` is emitted alongside only for consistency with the rest of
-   * the codebase's log shape — nothing reads it.) Without `type: 'error'` these lines are
-   * unfindable by severity, and the alert on "Axiom ingest is failing" — the whole reason this
-   * event exists — could not be built on them.
+   *   - `| type="error"`      → 735 hits/h, negative control `type="zzz-none"` → 0.
+   *     Alloy JSON-parses the stderr line and promotes `type` to structured metadata.
+   *   - `| detected_level="error"` → 18,148 hits/h, and it is derived from the `level` KEY,
+   *     not from a substring scan of the line. The discriminator: lines carrying
+   *     `"level":"info"` that ALSO contain the word "error" resolve to `detected_level="info"`
+   *     (74) and never to `"error"` (0). So `level` is read, and dropping it would silently
+   *     demote these lines to Loki's substring heuristic.
+   *
+   * Emit both. Without them the "Axiom ingest is failing" alert — the whole reason this event
+   * exists — cannot be written against either surface.
    *
    * `pod` is carried for parity with every other line this logger emits, so a reader who has
    * the line in hand can attribute it without joining. It is ALSO already a Loki stream label
@@ -301,19 +306,19 @@ export function createAxiomLogger(
        * indistinguishable from an outage. Nothing here cancels the request; we stop
        * WAITING for it.
        *
-       * 🔴 A REJECTION HANDLER MUST BE ATTACHED HERE, SYNCHRONOUSLY, AT CREATION. When the
-       * budget below wins the race this promise is left running with nobody awaiting it, so a
-       * rejection arriving later has nowhere to go — that is an `unhandledRejection`, i.e. the
-       * bug this fix exists for, re-created by the fix. Attaching one after an `await`
-       * boundary, or only in the race arm, does not count.
+       * The rejection handler is paired with the success handler so the two cannot drift apart,
+       * and so `outcome` is a plain union rather than something the race has to interpret.
        *
-       * ⚠️ A trailing `.then(onOk).catch(onErr)` would be EQUALLY safe — `.catch` attaches to
-       * the derived promise synchronously and handles the original's rejection through it.
-       * An earlier version of this comment claimed otherwise and was wrong (verified in node:
-       * only the fulfilment-handler-ONLY form, `.then(onOk)` with no rejection handler, goes
-       * unhandled). The paired form is kept because it is one expression and cannot drift
-       * apart, not because the alternative leaks. What the test suite actually pins is the
-       * dangerous shape — a fulfilment handler with no rejection handler at all.
+       * ⚠️ IT IS NOT WHAT PREVENTS AN UNHANDLED REJECTION, and two earlier versions of this
+       * comment claimed it was. `Promise.race` subscribes to every input SYNCHRONOUSLY, so the
+       * ingest promise always has a subscriber from the moment the race is constructed —
+       * including after the budget has won and nothing is awaiting it any more. Measured in
+       * node against a positive control (a promise nobody ever subscribes to, which DOES leak):
+       * paired handlers, a trailing `.catch`, a fulfilment handler alone, and a completely bare
+       * promise ALL produce zero unhandled rejections once raced.
+       *
+       * So the invariant that actually matters here is "the ingest promise is raced", not "the
+       * handler is paired". Do not delete the race and keep the pairing expecting safety.
        */
       const ingest = axiom.ingestEvents(datastream, sendData).then(
         () => 'ok' as const,

--- a/src/pages/api/upload/abort.ts
+++ b/src/pages/api/upload/abort.ts
@@ -29,51 +29,70 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
       s3 = getUploadS3Client('b2');
     }
     const result = await abortMultipartUpload(bucket, key, uploadId, s3);
-    await logToAxiom({ name: 's3-upload-abort', userId, type, key, uploadId, backend });
+    // 🔴 RESPOND BEFORE LOGGING — see the note in the catch block below, and the same
+    // note in ./complete.ts. Telemetry must not sit between the work and the answer.
     res.status(200).json(result);
+    // 🔴 CONTAINED: this now runs after the response but still inside the S3 try, so an
+    // uncontained throw would unwind into the catch below and re-answer a request that
+    // already succeeded. Not silent — @civitai/axiom reports its own ingest failures.
+    try {
+      await logToAxiom({ name: 's3-upload-abort', userId, type, key, uploadId, backend });
+    } catch {
+      /* contained — see above */
+    }
   } catch (e) {
     const error = e as Error;
     console.error('Upload abort error:', error.message, error.stack);
-    await logToAxiom({
-      name: 's3-upload-abort-error',
-      userId,
-      type,
-      key,
-      uploadId,
-      backend,
-      error: error.message,
-    });
 
-    // Classify the S3 error so a client/state fault or a transient storage blip is
-    // NOT mis-reported as a raw 500 (which the client then retries → amplification).
+    /**
+     * 🔴 CLASSIFY AND RESPOND BEFORE LOGGING. The `await logToAxiom` below used to sit
+     * here, ahead of the classifier, so when Axiom's ingest host went unreachable on
+     * 2026-08-23 this whole 204/422/503 taxonomy was unreachable with it and every abort
+     * left as a 500 — 92 sampled failures on a route that normally emits none, on top of
+     * the completions that had already failed and caused the aborts. Full mechanism in
+     * ./complete.ts's catch block.
+     */
     const errorClass = classifyS3MultipartError(e);
-    if (errorClass === 'not-found') {
-      // Aborting an upload that is already gone (completed/aborted) is IDEMPOTENT:
-      // the desired end-state — the upload no longer exists — already holds, so this
-      // is a success, not a conflict. 204 stops the client retry loop cleanly. (The
-      // sole caller, s3-upload.store.ts, fire-and-forgets abort and ignores the
-      // response, so 204 is safe and terminal.)
-      res.status(204).end();
-      return;
+    try {
+      if (errorClass === 'not-found') {
+        // Aborting an upload that is already gone (completed/aborted) is IDEMPOTENT:
+        // the desired end-state — the upload no longer exists — already holds, so this
+        // is a success, not a conflict. 204 stops the client retry loop cleanly. (The
+        // sole caller, s3-upload.store.ts, fire-and-forgets abort and ignores the
+        // response, so 204 is safe and terminal.)
+        res.status(204).end();
+      } else if (errorClass === 'invalid-parts') {
+        // A parts-manifest fault (400-class) surfaced on the abort path — terminal, the
+        // client must stop retrying and re-upload. 422 Unprocessable Entity mirrors the
+        // complete handler. no-store so nothing caches the failure. (The sole caller
+        // fire-and-forgets abort and ignores the body, so the status alone is safe.)
+        res.setHeader('Cache-Control', 'no-store');
+        res.status(422).json({ error: 'Upload parts invalid or incomplete — please re-upload' });
+      } else if (errorClass === 'transient') {
+        // Retry-able storage-backend blip (S3/B2 5xx, throttle/timing, or network).
+        res.setHeader('Retry-After', '2');
+        res.setHeader('Cache-Control', 'no-store');
+        res.status(503).json({ error: 'Storage temporarily unavailable, please retry' });
+      } else {
+        // Real server fault → surface loud as a 500.
+        res.status(500).json({ error });
+      }
+    } finally {
+      try {
+        await logToAxiom({
+          name: 's3-upload-abort-error',
+          userId,
+          type,
+          key,
+          uploadId,
+          backend,
+          error: error.message,
+          errorClass,
+        });
+      } catch {
+        /* contained — see the success path */
+      }
     }
-    if (errorClass === 'invalid-parts') {
-      // A parts-manifest fault (400-class) surfaced on the abort path — terminal, the
-      // client must stop retrying and re-upload. 422 Unprocessable Entity mirrors the
-      // complete handler. no-store so nothing caches the failure. (The sole caller
-      // fire-and-forgets abort and ignores the body, so the status alone is safe.)
-      res.setHeader('Cache-Control', 'no-store');
-      res.status(422).json({ error: 'Upload parts invalid or incomplete — please re-upload' });
-      return;
-    }
-    if (errorClass === 'transient') {
-      // Retry-able storage-backend blip (S3/B2 5xx, throttle/timing, or network).
-      res.setHeader('Retry-After', '2');
-      res.setHeader('Cache-Control', 'no-store');
-      res.status(503).json({ error: 'Storage temporarily unavailable, please retry' });
-      return;
-    }
-    // Real server fault → surface loud as a 500.
-    res.status(500).json({ error });
   }
 };
 

--- a/src/pages/api/upload/complete.ts
+++ b/src/pages/api/upload/complete.ts
@@ -144,46 +144,96 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
      */
     const enforcing = env.UPLOAD_COMPLETE_VERIFY_ENFORCE === true;
 
-    // Log the SHAPE of the completion, not just that it happened, now including the
-    // probe's verdict — so a silently-empty completion is distinguishable from a
-    // healthy one in the log, which is exactly what the incident lacked.
-    // partCount also catches a truncated manifest.
-    await logToAxiom({
-      name: 's3-upload-complete',
-      userId,
-      type,
-      key,
-      uploadId,
-      backend,
-      partCount: Array.isArray(parts) ? parts.length : null,
-      location: result?.Location ?? null,
-      etag: result?.ETag ?? null,
-      objectStatus: head.status,
-      objectSize: head.status === 'present' ? head.size : null,
-      verifyVerdict: verdict,
-      verifyEnforced: enforcing,
-    });
+    /**
+     * 🔴 DECIDE AND SEND THE RESPONSE BEFORE ANY TELEMETRY. The logging below used to
+     * run FIRST, which put three awaited `logToAxiom` calls between a completed upload
+     * and the client's answer.
+     *
+     * On 2026-08-23 Axiom's ingest host went unreachable for 44 minutes. `logToAxiom`
+     * awaited it uncontained, so the first of those calls threw AFTER
+     * `completeMultipartUpload` had already stored the object — and the browser was told
+     * 500. ~5,300 requests, 350 users, every one of them an upload that had in fact
+     * succeeded. `@civitai/axiom` now contains and time-boxes that write, so it can no
+     * longer throw; this ordering is the half that does not depend on it staying that
+     * way, and it also keeps the telemetry budget off the client's latency.
+     *
+     * The response is a pure function of `verdict` + `enforcing`, so hoisting it changes
+     * no status, no header and no body — only when they are written.
+     */
+    const rejecting = verdict === 'missing' && enforcing;
 
-    // The fail-open branch gets its OWN event, so the rate at which this guard cannot
-    // see the bucket is measurable on its own rather than being folded into either the
-    // healthy or the defective count.
-    if (verdict === 'indeterminate') {
-      await logToAxiom({
-        name: 's3-upload-complete-verify-unknown',
-        userId,
-        type,
-        key,
-        uploadId,
-        backend,
+    if (rejecting) {
+      /**
+       * Release the multipart session before failing, so a rejected completion does
+       * not strand parts. These are the largest objects in the system.
+       *
+       * Safe in both directions: if the session really is unfinished this frees the
+       * parts, and if the completion did finalize an object then Abort answers
+       * NoSuchUpload and is a no-op — it cannot delete a finalized object. Guarded
+       * because a cleanup failure must never change the response the client gets.
+       *
+       * 🔴 This bounds the PARTS leak, not every leak. The upload key carries a
+       * random token, so the client's retry writes to a DIFFERENT key; an object that
+       * becomes visible after we called it absent would sit at the old key with no DB
+       * row. That case cannot be cleaned up from here without deleting an object we
+       * just concluded does not exist — and it is precisely the population the
+       * observe-only phase above exists to measure before rejection is enabled.
+       */
+      try {
+        await abortMultipartUpload(bucket, key, uploadId, s3);
+      } catch {
+        /* cleanup is best-effort; never let it change the client's outcome */
+      }
+
+      /**
+       * 422, against this handler's existing taxonomy (409 terminal / 422
+       * parts-invalid + no-store / 503 transient + Retry-After / 500 genuine fault).
+       *
+       * We need the client to retry the UPLOAD, not the completion. 422 is the code
+       * that already carries that meaning here — "the request was well formed but the
+       * upload STATE isn't; terminal → re-upload" — and, unlike a retryable status,
+       * both clients now treat it as final rather than re-POSTing a manifest whose
+       * session may already be consumed (each such retry throws NoSuchUpload and gets
+       * relabelled "already finalized or aborted", destroying the diagnosis).
+       *
+       * "Both" is load-bearing and was NOT true before this change: the exemption
+       * existed only in s3-upload.store.ts, so useS3Upload.tsx retried a terminal
+       * status 4 times. It is now one shared predicate — see isTerminalCompleteStatus.
+       *
+       * Not 409: terminal, but carries no re-upload meaning. Not 500: this is a
+       * storage-state fault, and paging on it as a server bug buries it.
+       *
+       * 🔴 The status is chosen for retry semantics and log separability, NOT for the
+       * message text — neither client reads this body on the completion path, so the
+       * user sees the same generic upload-failed copy either way.
+       */
+      res.setHeader('Cache-Control', 'no-store');
+      res.status(422).json({
+        error: 'Upload completed but the file was not stored — please re-upload',
       });
+    } else {
+      res.status(200).json(result.Location);
     }
 
-    if (verdict === 'missing') {
-      // Distinct event name so this class is alertable on its own rather than hiding
-      // inside the generic completion log. `verifyEnforced` separates "we would have
-      // rejected this" during the observe-only phase from an actual rejection.
+    /**
+     * 🔴 CONTAINED, because this telemetry now runs INSIDE the S3 try/catch but AFTER the
+     * response. Without this guard a logging failure unwinds into the `catch (e)` below,
+     * where it is classified as an S3 fault, logged as `s3-upload-complete-error`, and
+     * answered with a SECOND response — on a request that already succeeded. A test
+     * (`telemetry failure cannot change the client response`) caught exactly that while
+     * this fix was being written.
+     *
+     * Swallowing is right here and is not silent: `@civitai/axiom` reports its own ingest
+     * failures (`axiom-ingest-failed`), and the stderr/Loki line has already been written
+     * by the time anything can throw.
+     */
+    try {
+      // Log the SHAPE of the completion, not just that it happened, now including the
+      // probe's verdict — so a silently-empty completion is distinguishable from a
+      // healthy one in the log, which is exactly what the incident lacked.
+      // partCount also catches a truncated manifest.
       await logToAxiom({
-        name: 's3-upload-complete-unverified',
+        name: 's3-upload-complete',
         userId,
         type,
         key,
@@ -194,112 +244,128 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
         etag: result?.ETag ?? null,
         objectStatus: head.status,
         objectSize: head.status === 'present' ? head.size : null,
+        verifyVerdict: verdict,
         verifyEnforced: enforcing,
       });
 
-      if (enforcing) {
-        /**
-         * Release the multipart session before failing, so a rejected completion does
-         * not strand parts. These are the largest objects in the system.
-         *
-         * Safe in both directions: if the session really is unfinished this frees the
-         * parts, and if the completion did finalize an object then Abort answers
-         * NoSuchUpload and is a no-op — it cannot delete a finalized object. Guarded
-         * because a cleanup failure must never change the response the client gets.
-         *
-         * 🔴 This bounds the PARTS leak, not every leak. The upload key carries a
-         * random token, so the client's retry writes to a DIFFERENT key; an object that
-         * becomes visible after we called it absent would sit at the old key with no DB
-         * row. That case cannot be cleaned up from here without deleting an object we
-         * just concluded does not exist — and it is precisely the population the
-         * observe-only phase above exists to measure before rejection is enabled.
-         */
-        try {
-          await abortMultipartUpload(bucket, key, uploadId, s3);
-        } catch {
-          /* cleanup is best-effort; never let it change the client's outcome */
-        }
-
-        /**
-         * 422, against this handler's existing taxonomy (409 terminal / 422
-         * parts-invalid + no-store / 503 transient + Retry-After / 500 genuine fault).
-         *
-         * We need the client to retry the UPLOAD, not the completion. 422 is the code
-         * that already carries that meaning here — "the request was well formed but the
-         * upload STATE isn't; terminal → re-upload" — and, unlike a retryable status,
-         * both clients now treat it as final rather than re-POSTing a manifest whose
-         * session may already be consumed (each such retry throws NoSuchUpload and gets
-         * relabelled "already finalized or aborted", destroying the diagnosis).
-         *
-         * "Both" is load-bearing and was NOT true before this change: the exemption
-         * existed only in s3-upload.store.ts, so useS3Upload.tsx retried a terminal
-         * status 4 times. It is now one shared predicate — see isTerminalCompleteStatus.
-         *
-         * Not 409: terminal, but carries no re-upload meaning. Not 500: this is a
-         * storage-state fault, and paging on it as a server bug buries it.
-         *
-         * 🔴 The status is chosen for retry semantics and log separability, NOT for the
-         * message text — neither client reads this body on the completion path, so the
-         * user sees the same generic upload-failed copy either way.
-         */
-        res.setHeader('Cache-Control', 'no-store');
-        res.status(422).json({
-          error: 'Upload completed but the file was not stored — please re-upload',
+      // The fail-open branch gets its OWN event, so the rate at which this guard cannot
+      // see the bucket is measurable on its own rather than being folded into either the
+      // healthy or the defective count.
+      if (verdict === 'indeterminate') {
+        await logToAxiom({
+          name: 's3-upload-complete-verify-unknown',
+          userId,
+          type,
+          key,
+          uploadId,
+          backend,
         });
-        return;
       }
+
+      if (verdict === 'missing') {
+        // Distinct event name so this class is alertable on its own rather than hiding
+        // inside the generic completion log. `verifyEnforced` separates "we would have
+        // rejected this" during the observe-only phase from an actual rejection.
+        await logToAxiom({
+          name: 's3-upload-complete-unverified',
+          userId,
+          type,
+          key,
+          uploadId,
+          backend,
+          partCount: Array.isArray(parts) ? parts.length : null,
+          location: result?.Location ?? null,
+          etag: result?.ETag ?? null,
+          objectStatus: head.status,
+          objectSize: head.status === 'present' ? head.size : null,
+          verifyEnforced: enforcing,
+        });
+      }
+    } catch {
+      /* contained — see above */
     }
 
-    res.status(200).json(result.Location);
+    return;
   } catch (e) {
     const error = e as Error;
     console.error('Upload complete error:', error.message, error.stack);
-    await logToAxiom({
-      name: 's3-upload-complete-error',
-      userId,
-      type,
-      key,
-      uploadId,
-      backend,
-      error: error.message,
-    });
 
-    // Classify the S3 error so a client/state fault or a transient storage blip is
-    // NOT mis-reported as a raw 500 (which the client then retries → amplification).
+    /**
+     * 🔴 CLASSIFY AND RESPOND BEFORE LOGGING — the `await logToAxiom` below used to sit
+     * HERE, above the classifier, and that ordering is what made this entire taxonomy
+     * unreachable during the 2026-08-23 Axiom outage.
+     *
+     * The mechanism, because it is not obvious from either line on its own: when the
+     * telemetry await throws, nothing after it runs, so `classifyS3MultipartError` was
+     * never called and no branch below could execute. Every fault — including 1,009
+     * terminal `NoSuchUpload`s that belong at 409 — left the handler as an unhandled
+     * rejection, i.e. a 500. 500 is retryable to both clients, so they retried, and each
+     * retry hit an already-consumed session and re-failed. Spanmetrics for the whole
+     * 44-minute episode recorded ZERO 409/422/503 on this route: not a rare path, a
+     * structurally dead one.
+     *
+     * A response written from the error classification must therefore never be sequenced
+     * behind a side-channel that can fail or stall. The logging moved to the `finally`.
+     */
     const errorClass = classifyS3MultipartError(e);
-    if (errorClass === 'not-found') {
-      // Already finalized or aborted (double-submit / retry-after-success). Which one
-      // decides the client's fate — a finalized upload whose 200 the client never saw
-      // must not be reported as a failure, or the bytes are stranded in the bucket with
-      // no DB row. Only a genuine miss is terminal.
-      const exists = await objectExists(bucket, key, s3);
-      if (exists === true) {
-        res.status(200).json(null);
-        return;
+    try {
+      if (errorClass === 'not-found') {
+        // Already finalized or aborted (double-submit / retry-after-success). Which one
+        // decides the client's fate — a finalized upload whose 200 the client never saw
+        // must not be reported as a failure, or the bytes are stranded in the bucket with
+        // no DB row. Only a genuine miss is terminal.
+        //
+        // 🔴 The probe's own throw is folded into its `null` (indeterminate) case rather
+        // than escaping. `objectExists` already returns `null` when the bucket could not
+        // be consulted, and `null` already means 409 here — but a THROWN failure used to
+        // escape the handler as a 500 instead, which is the same not-found fault reported
+        // as a server bug. That fires exactly when the backend is degraded, i.e. when this
+        // path is busiest. Only a definite `true` still yields 200, so nothing is masked
+        // in the direction that could strand bytes.
+        const exists = await objectExists(bucket, key, s3).catch(() => null);
+        if (exists === true) {
+          res.status(200).json(null);
+        } else {
+          // 409 Conflict = terminal state → tells the client to STOP retrying.
+          res.status(409).json({ error: 'Upload already finalized or aborted' });
+        }
+      } else if (errorClass === 'invalid-parts') {
+        // The parts manifest the client sent doesn't match what the backend stored
+        // (a part upload failed/expired, a stale ETag, or an empty/mis-ordered list) —
+        // a B2/S3 400-class fault. 422 Unprocessable Entity = the request was well
+        // formed but the upload STATE isn't; terminal → the client must stop retrying
+        // this manifest and re-upload. no-store so nothing caches the failure.
+        res.setHeader('Cache-Control', 'no-store');
+        res.status(422).json({ error: 'Upload parts invalid or incomplete — please re-upload' });
+      } else if (errorClass === 'transient') {
+        // Retry-able storage-backend blip (S3/B2 5xx, throttle/timing, or network).
+        res.setHeader('Retry-After', '2');
+        res.setHeader('Cache-Control', 'no-store');
+        res.status(503).json({ error: 'Storage temporarily unavailable, please retry' });
+      } else {
+        // Real server fault → surface loud as a 500 so the upload legitimately fails.
+        res.status(500).json({ error });
       }
-      // 409 Conflict = terminal state → tells the client to STOP retrying.
-      res.status(409).json({ error: 'Upload already finalized or aborted' });
-      return;
+    } finally {
+      // `finally`, not a trailing statement: the event must be recorded whichever branch
+      // ran, and — unlike before — it can no longer decide which branch runs. Contained
+      // for the same reason as the success path above: nothing about the client's
+      // outcome may depend on telemetry.
+      try {
+        await logToAxiom({
+          name: 's3-upload-complete-error',
+          userId,
+          type,
+          key,
+          uploadId,
+          backend,
+          error: error.message,
+          errorClass,
+        });
+      } catch {
+        /* contained — see the success path */
+      }
     }
-    if (errorClass === 'invalid-parts') {
-      // The parts manifest the client sent doesn't match what the backend stored
-      // (a part upload failed/expired, a stale ETag, or an empty/mis-ordered list) —
-      // a B2/S3 400-class fault. 422 Unprocessable Entity = the request was well
-      // formed but the upload STATE isn't; terminal → the client must stop retrying
-      // this manifest and re-upload. no-store so nothing caches the failure.
-      res.setHeader('Cache-Control', 'no-store');
-      res.status(422).json({ error: 'Upload parts invalid or incomplete — please re-upload' });
-      return;
-    }
-    if (errorClass === 'transient') {
-      // Retry-able storage-backend blip (S3/B2 5xx, throttle/timing, or network).
-      res.setHeader('Retry-After', '2');
-      res.setHeader('Cache-Control', 'no-store');
-      res.status(503).json({ error: 'Storage temporarily unavailable, please retry' });
-      return;
-    }
-    // Real server fault → surface loud as a 500 so the upload legitimately fails.
-    res.status(500).json({ error });
   }
 };
 

--- a/src/pages/api/upload/complete.ts
+++ b/src/pages/api/upload/complete.ts
@@ -315,13 +315,15 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
         // must not be reported as a failure, or the bytes are stranded in the bucket with
         // no DB row. Only a genuine miss is terminal.
         //
-        // 🔴 The probe's own throw is folded into its `null` (indeterminate) case rather
-        // than escaping. `objectExists` already returns `null` when the bucket could not
-        // be consulted, and `null` already means 409 here — but a THROWN failure used to
-        // escape the handler as a 500 instead, which is the same not-found fault reported
-        // as a server bug. That fires exactly when the backend is degraded, i.e. when this
-        // path is busiest. Only a definite `true` still yields 200, so nothing is masked
-        // in the direction that could strand bytes.
+        // ⚠️ DEFENSIVE, AND INERT TODAY — not a bug fix, despite how it reads. `objectExists`
+        // delegates to `headObject`, whose entire body is inside a try that returns
+        // `{status:'unknown'}` on any error (`~/utils/s3-utils`), so it CANNOT reject: a
+        // degraded bucket already lands on `null`, which already means 409 below. An earlier
+        // version of this comment claimed a throw here used to escape as a 500; that was
+        // wrong. The `.catch` is kept only so that a future change to `headObject`'s
+        // swallow-everything contract cannot silently turn a degraded bucket into a 500, and
+        // it costs nothing. Only a definite `true` yields 200, so nothing is masked in the
+        // direction that could strand bytes.
         const exists = await objectExists(bucket, key, s3).catch(() => null);
         if (exists === true) {
           res.status(200).json(null);

--- a/src/pages/api/upload/index.ts
+++ b/src/pages/api/upload/index.ts
@@ -57,26 +57,84 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
   const key = `${type ?? UploadType.Default}/${userId}/${filename}.${generateToken(4)}${ext}`;
   const s3 = backend === 'b2' ? getUploadS3Client('b2') : null;
   const bucket = backend === 'b2' ? getUploadBucket('b2') : null;
-  const result = await getMultipartPutUrl(
-    key,
-    req.body.size,
-    s3,
-    bucket,
-    undefined,
-    getUploadChunkSize(req.body.size)
-  );
-  await logToAxiom({
-    name: 's3-upload',
-    userId,
-    type,
-    filename: fullFilename,
-    key,
-    uploadId: result.uploadId,
-    bucket: result.bucket,
-    backend,
-  });
 
-  res.status(200).json({ ...result, backend });
+  /**
+   * 🔴 This handler had NO try/catch and issued its telemetry BEFORE its response, which
+   * is the worst pairing of the two: `await logToAxiom` sat between a successfully created
+   * multipart session and the 200 that hands the client its presigned part URLs, and any
+   * throw there escaped as an unhandled rejection — a 500 with nothing logged anywhere.
+   *
+   * That is how a telemetry outage took this route down on 2026-08-23 (56 sampled 500s,
+   * against a normal baseline of zero) while the S3 backend was healthy the whole time.
+   * `@civitai/axiom` now contains that write; the ordering and the catch here are the
+   * parts that hold regardless.
+   */
+  try {
+    const result = await getMultipartPutUrl(
+      key,
+      req.body.size,
+      s3,
+      bucket,
+      undefined,
+      getUploadChunkSize(req.body.size)
+    );
+
+    res.status(200).json({ ...result, backend });
+
+    // 🔴 CONTAINED: after the response, but still inside the try — an uncontained throw
+    // would land in the catch below and answer a successful request with a 500.
+    try {
+      await logToAxiom({
+        name: 's3-upload',
+        userId,
+        type,
+        filename: fullFilename,
+        key,
+        uploadId: result.uploadId,
+        bucket: result.bucket,
+        backend,
+      });
+    } catch {
+      /* contained — @civitai/axiom reports its own ingest failures */
+    }
+  } catch (e) {
+    const error = e as Error;
+    console.error('Upload create error:', error.message, error.stack);
+
+    /**
+     * A STATIC body, never the error's own text. Two gates shaped this line and both are
+     * worth recording, because the obvious versions fail one or the other:
+     *
+     *  - `{ error: error.message }` puts driver-derived text on the wire and lands this
+     *    route on `rest-error-envelope-ledger`'s offender list. The ledger caught it.
+     *  - `handleEndpointError(res, e)` is the sanctioned envelope and would be the right
+     *    answer in general — but importing `~/server/utils/endpoint-helpers` here pulls
+     *    `pgDb` → `kyselyDb` into this route's module graph, which broke
+     *    `upload-backend.test.ts` at IMPORT time (reported as `Tests no tests`, not as a
+     *    failure). Not worth a new graph edge on a hotfix for a body no client reads.
+     *
+     * No multipart classification: unlike ./complete.ts and ./abort.ts there is no
+     * existing upload session to be in a terminal state about, so every failure here is a
+     * genuine create-side fault. The diagnosable detail goes to the log below, not the wire.
+     */
+    res.status(500).json({ error: 'Failed to start upload' });
+
+    // The event that makes a create failure diagnosable — key/backend/filename plus the
+    // real message. Contained for the same reason as the success path.
+    try {
+      await logToAxiom({
+        name: 's3-upload-create-error',
+        userId,
+        type,
+        filename: fullFilename,
+        key,
+        backend,
+        error: error.message,
+      });
+    } catch {
+      /* contained — see the success path */
+    }
+  }
 };
 
 export default upload;

--- a/src/pages/api/upload/sign-part.ts
+++ b/src/pages/api/upload/sign-part.ts
@@ -38,23 +38,44 @@ const signPart = async (req: NextApiRequest, res: NextApiResponse) => {
     return;
   }
 
+  /**
+   * 🔴 RESPOND BEFORE LOGGING, AND CONTAIN THE LOG — the same defect as ./complete.ts,
+   * ./abort.ts and ./index.ts, on the fourth upload route. Both `logToAxiom` calls used to sit
+   * between the work and the response, so during the 2026-08-23 Axiom outage this path stalled
+   * for the SDK's 30 s axios timeout and then threw instead of answering.
+   *
+   * Worth fixing here even though `@civitai/axiom` now contains that write: this is the path
+   * that rescues a multi-hour upload whose 12 h part URLs expired (see the header above), so a
+   * telemetry stall on it costs the whole transfer, and the containment argument only holds if
+   * it does not depend on remembering to keep the package total.
+   */
   try {
     const s3 = backend === 'b2' ? getUploadS3Client('b2') : null;
     const result = await getUploadPartUrl({ bucket, key, uploadId, partNumber, s3 });
-    await logToAxiom({ name: 's3-upload-sign-part', userId, key, uploadId, partNumber, backend });
     res.status(200).json(result);
+    try {
+      await logToAxiom({ name: 's3-upload-sign-part', userId, key, uploadId, partNumber, backend });
+    } catch {
+      /* contained — @civitai/axiom reports its own ingest failures */
+    }
   } catch (e) {
     const error = e as Error;
-    await logToAxiom({
-      name: 's3-upload-sign-part-error',
-      userId,
-      key,
-      uploadId,
-      partNumber,
-      backend,
-      error: error.message,
-    });
+    // Unchanged body (this route already answered with the message; it is on the
+    // rest-error-envelope-ledger baseline alongside its siblings), only the ORDER changes.
     res.status(500).json({ error: error.message });
+    try {
+      await logToAxiom({
+        name: 's3-upload-sign-part-error',
+        userId,
+        key,
+        uploadId,
+        partNumber,
+        backend,
+        error: error.message,
+      });
+    } catch {
+      /* contained — see the success path */
+    }
   }
 };
 

--- a/src/server/__tests__/upload-abort-endpoint.test.ts
+++ b/src/server/__tests__/upload-abort-endpoint.test.ts
@@ -114,15 +114,21 @@ beforeEach(() => {
 });
 
 describe('/api/upload/abort — error classification', () => {
-  it('happy path: abortMultipartUpload resolves → 200 with the backend result', async () => {
+  it('happy path: abortMultipartUpload resolves → 200, passing the backend result through', async () => {
+    // 🔴 The fixture is `undefined` because that is what the real collaborator returns —
+    // `abortMultipartUpload` is `Promise<void>` (see ~/utils/s3-utils). An earlier version used
+    // `{ ok: true, … }`, a shape it can never produce, which made this the only route whose
+    // happy-path test could not have caught a body defect the production value would hit.
+    //
     // The BODY is asserted, not just the status: a mutation sweep found `res.json(result)` →
-    // `res.json({})` survived the whole 64-test suite, because every assertion on this route
-    // was a status or a boolean "did something get sent".
-    mockAbortMultipartUpload.mockResolvedValue({ ok: true, uploadId: 'test-upload-id' });
+    // `res.json({})` survived the whole suite, because every other assertion on this route was
+    // a status or a boolean "did something get sent". `toBeUndefined` still kills that mutant.
+    mockAbortMultipartUpload.mockResolvedValue(undefined);
     const res = makeRes();
     await handler(makeReq(), res);
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({ ok: true, uploadId: 'test-upload-id' });
+    expect(res.body).toBeUndefined();
+    expect(res.ended).toBe(true);
   });
 
   it('NoSuchUpload (already gone) → 204 idempotent success, not 500', async () => {
@@ -138,6 +144,11 @@ describe('/api/upload/abort — error classification', () => {
     await handler(makeReq(), res);
     expect(res.statusCode).toBe(204);
     expect(res.ended).toBe(true);
+    // 🔴 A 204 MUST CARRY NO BODY, and `ended` alone no longer says that. Round 4 made the
+    // double's `json()` set `ended` (so a `sent` predicate would stop measuring the payload),
+    // which silently turned the assertion above into a tautology: `res.status(204).json({})`
+    // passed the whole suite. This is the assertion that distinguishes `.end()` from `.json()`.
+    expect(res.body).toBeUndefined();
   });
 
   it('InvalidPart (name + $metadata 400) → 422 + no-store, not 500', async () => {

--- a/src/server/__tests__/upload-abort-endpoint.test.ts
+++ b/src/server/__tests__/upload-abort-endpoint.test.ts
@@ -114,15 +114,16 @@ beforeEach(() => {
 });
 
 describe('/api/upload/abort — error classification', () => {
-  it('happy path: abortMultipartUpload resolves → 200, passing the backend result through', async () => {
+  it('happy path: abortMultipartUpload resolves → 200 with an empty body', async () => {
     // 🔴 The fixture is `undefined` because that is what the real collaborator returns —
     // `abortMultipartUpload` is `Promise<void>` (see ~/utils/s3-utils). An earlier version used
-    // `{ ok: true, … }`, a shape it can never produce, which made this the only route whose
-    // happy-path test could not have caught a body defect the production value would hit.
+    // `{ ok: true, … }`, a shape it can never produce.
     //
-    // The BODY is asserted, not just the status: a mutation sweep found `res.json(result)` →
-    // `res.json({})` survived the whole suite, because every other assertion on this route was
-    // a status or a boolean "did something get sent". `toBeUndefined` still kills that mutant.
+    // ⚠️ WHAT THIS DOES AND DOES NOT PIN. `toBeUndefined()` kills `res.json({})`, but it is
+    // satisfied by sending NOTHING, so `json(result)` → `end()` and → `json(undefined)` both
+    // survive. Those two are production-inert — the handler's result really is `void` and the
+    // sole caller fire-and-forgets without reading the body (~/store/s3-upload.store.ts) — but
+    // do not read this case as pinning a pass-through. It pins "200, and no body content".
     mockAbortMultipartUpload.mockResolvedValue(undefined);
     const res = makeRes();
     await handler(makeReq(), res);

--- a/src/server/__tests__/upload-abort-endpoint.test.ts
+++ b/src/server/__tests__/upload-abort-endpoint.test.ts
@@ -221,5 +221,41 @@ describe('/api/upload/abort — error classification', () => {
       await withFailingLogger(res);
       expect(res.statusCode).toBe(200);
     });
+
+    /**
+     * 🔴 ORDERING, read directly. A status-only assertion cannot see the log being moved back
+     * ahead of the response once the log is contained — a mutation sweep proved that on the
+     * sibling sign-part route. This reads the response state AT LOG TIME.
+     */
+    it('ORDERING: the response is committed before either event is logged', async () => {
+      const seen: Array<{ name: string; statusAtLogTime: number }> = [];
+      const res = makeRes();
+      vi.mocked(logToAxiom).mockImplementation(async (d: Record<string, unknown>) => {
+        seen.push({
+          name: String((d as { name?: unknown }).name),
+          statusAtLogTime: res.statusCode,
+        });
+      });
+      mockAbortMultipartUpload.mockResolvedValue({ ok: true });
+      await handler(makeReq(), res);
+
+      const res2 = makeRes();
+      vi.mocked(logToAxiom).mockImplementation(async (d: Record<string, unknown>) => {
+        seen.push({
+          name: String((d as { name?: unknown }).name),
+          statusAtLogTime: res2.statusCode,
+        });
+      });
+      mockAbortMultipartUpload.mockRejectedValue(
+        s3Error({ name: 'NoSuchUpload', $metadata: { httpStatusCode: 404 } })
+      );
+      await handler(makeReq(), res2);
+      vi.mocked(logToAxiom).mockReset();
+
+      expect(seen).toEqual([
+        { name: 's3-upload-abort', statusAtLogTime: 200 },
+        { name: 's3-upload-abort-error', statusAtLogTime: 204 },
+      ]);
+    });
   });
 });

--- a/src/server/__tests__/upload-abort-endpoint.test.ts
+++ b/src/server/__tests__/upload-abort-endpoint.test.ts
@@ -39,6 +39,8 @@ vi.mock('~/server/auth/get-server-auth-session', () => ({
 }));
 
 import handler from '~/pages/api/upload/abort';
+// Mocked in ~/__tests__/setup as vi.fn(); imported here so it can be made to REJECT.
+import { logToAxiom } from '~/server/logging/client';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 
 function makeRes() {
@@ -135,7 +137,7 @@ describe('/api/upload/abort — error classification', () => {
       s3Error({
         name: 'InvalidPart',
         message:
-          'One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not match the part\'s entity tag.',
+          "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
         $metadata: { httpStatusCode: 400 },
       })
     );
@@ -180,5 +182,44 @@ describe('/api/upload/abort — error classification', () => {
     const res = makeRes();
     await handler(makeReq(), res);
     expect(res.statusCode).toBe(500);
+  });
+
+  /**
+   * 🔴 THE RESPONSE MUST NOT DEPEND ON TELEMETRY. Every case above runs with a resolving
+   * `logToAxiom` (a `vi.fn()` from `~/__tests__/setup`), so none of them could see the
+   * 2026-08-23 failure: with Axiom's ingest host unreachable, the awaited log call above
+   * the classifier threw and this entire taxonomy became unreachable — 92 sampled 500s on
+   * a route whose normal 500 rate is zero. Mirrors the block in
+   * ./upload-complete-endpoint.test.ts, which carries the full mechanism.
+   *
+   * Asserts the handler settles cleanly AND the client's status — see the note in
+   * ./upload-complete-endpoint.test.ts on why `resolves` is load-bearing. Pre-fix, both
+   * cases observe `statusCode` 0.
+   */
+  describe('telemetry failure cannot change the client response', () => {
+    const withFailingLogger = async (res: ReturnType<typeof makeRes>) => {
+      vi.mocked(logToAxiom).mockRejectedValue(new Error('timeout of 30000ms exceeded'));
+      try {
+        await expect(handler(makeReq(), res)).resolves.toBeUndefined();
+      } finally {
+        vi.mocked(logToAxiom).mockReset();
+      }
+    };
+
+    it('NoSuchUpload still classifies to 204 — the branch is reachable', async () => {
+      mockAbortMultipartUpload.mockRejectedValue(
+        s3Error({ name: 'NoSuchUpload', $metadata: { httpStatusCode: 404 } })
+      );
+      const res = makeRes();
+      await withFailingLogger(res);
+      expect(res.statusCode).toBe(204);
+    });
+
+    it('a successful abort still returns 200', async () => {
+      mockAbortMultipartUpload.mockResolvedValue({ ok: true });
+      const res = makeRes();
+      await withFailingLogger(res);
+      expect(res.statusCode).toBe(200);
+    });
   });
 });

--- a/src/server/__tests__/upload-abort-endpoint.test.ts
+++ b/src/server/__tests__/upload-abort-endpoint.test.ts
@@ -228,12 +228,15 @@ describe('/api/upload/abort — error classification', () => {
      * sibling sign-part route. This reads the response state AT LOG TIME.
      */
     it('ORDERING: the response is committed before either event is logged', async () => {
-      const seen: Array<{ name: string; statusAtLogTime: number }> = [];
+      // `sent` proves COMMITMENT — the 204 arm uses `.end()` and never sets a body, so this
+      // must accept either. `res.status()` on its own writes nothing.
+      const seen: Array<{ name: string; statusAtLogTime: number; sent: boolean }> = [];
       const res = makeRes();
       vi.mocked(logToAxiom).mockImplementation(async (d: Record<string, unknown>) => {
         seen.push({
           name: String((d as { name?: unknown }).name),
           statusAtLogTime: res.statusCode,
+          sent: res.body !== undefined || res.ended,
         });
       });
       mockAbortMultipartUpload.mockResolvedValue({ ok: true });
@@ -244,6 +247,7 @@ describe('/api/upload/abort — error classification', () => {
         seen.push({
           name: String((d as { name?: unknown }).name),
           statusAtLogTime: res2.statusCode,
+          sent: res2.body !== undefined || res2.ended,
         });
       });
       mockAbortMultipartUpload.mockRejectedValue(
@@ -253,8 +257,8 @@ describe('/api/upload/abort — error classification', () => {
       vi.mocked(logToAxiom).mockReset();
 
       expect(seen).toEqual([
-        { name: 's3-upload-abort', statusAtLogTime: 200 },
-        { name: 's3-upload-abort-error', statusAtLogTime: 204 },
+        { name: 's3-upload-abort', statusAtLogTime: 200, sent: true },
+        { name: 's3-upload-abort-error', statusAtLogTime: 204, sent: true },
       ]);
     });
   });

--- a/src/server/__tests__/upload-abort-endpoint.test.ts
+++ b/src/server/__tests__/upload-abort-endpoint.test.ts
@@ -56,6 +56,10 @@ function makeRes() {
     },
     json(payload: unknown) {
       this.body = payload;
+      // A real `res.json()` ENDS the response. The double must too, or a `sent` predicate
+      // built on `body !== undefined || ended` is really measuring the payload: a handler
+      // answering `json(undefined)` reads as "not committed" and fails a correct route.
+      this.ended = true;
       return this;
     },
     end() {
@@ -110,11 +114,15 @@ beforeEach(() => {
 });
 
 describe('/api/upload/abort — error classification', () => {
-  it('happy path: abortMultipartUpload resolves → 200', async () => {
-    mockAbortMultipartUpload.mockResolvedValue(undefined);
+  it('happy path: abortMultipartUpload resolves → 200 with the backend result', async () => {
+    // The BODY is asserted, not just the status: a mutation sweep found `res.json(result)` →
+    // `res.json({})` survived the whole 64-test suite, because every assertion on this route
+    // was a status or a boolean "did something get sent".
+    mockAbortMultipartUpload.mockResolvedValue({ ok: true, uploadId: 'test-upload-id' });
     const res = makeRes();
     await handler(makeReq(), res);
     expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ ok: true, uploadId: 'test-upload-id' });
   });
 
   it('NoSuchUpload (already gone) → 204 idempotent success, not 500', async () => {

--- a/src/server/__tests__/upload-backend.test.ts
+++ b/src/server/__tests__/upload-backend.test.ts
@@ -256,9 +256,9 @@ describe('/api/upload — telemetry cannot gate or fail the response', () => {
    * the success and error paths". It was the claim that was wrong, not the code, but a guard
    * described more widely than it is written is worse than no guard: it stops anyone looking.
    *
-   * The test below this one is status-only, and that is exactly the weakness that let the
-   * sign-part reorder mutant survive round 1 — the same 500 still gets sent, so only the
-   * telemetry stall in front of the client returns.
+   * The weakness this closes is the one that let the sign-part reorder mutant survive an
+   * earlier round: a status-only assertion cannot see it, because the same 500 still gets
+   * sent and only the telemetry stall in front of the client returns.
    */
   it('ORDERING (error path): the 500 is committed before the error event is logged', async () => {
     getMultipartPutUrl.mockRejectedValueOnce(new Error('B2 said no'));

--- a/src/server/__tests__/upload-backend.test.ts
+++ b/src/server/__tests__/upload-backend.test.ts
@@ -67,6 +67,9 @@ vi.mock('~/utils/s3-utils', () => ({
 // (no default ApiRouteConfig export), failing `next build`.
 import handler from '~/pages/api/upload';
 import { UploadType } from '~/server/common/enums';
+// Mocked in ~/__tests__/setup as vi.fn(); imported here so the ORDER of the log relative to
+// the response is observable, and so it can be made to REJECT.
+import { logToAxiom } from '~/server/logging/client';
 
 function makeRes() {
   const res = {
@@ -197,6 +200,74 @@ describe('upload handler — model backend selection (b2-upload-default retired)
       null,
       undefined,
       CHUNK_SIZE
+    );
+  });
+});
+
+/**
+ * 🔴 THE RESPONSE MUST NOT DEPEND ON TELEMETRY — the `/api/upload` half of the contract
+ * pinned for ./complete.ts and ./abort.ts in `upload-{complete,abort}-endpoint.test.ts`.
+ *
+ * This route was the worst of the four: no try/catch at all, and `await logToAxiom` sitting
+ * between a successfully created multipart session and the 200 that hands the client its
+ * presigned part URLs. During the 2026-08-23 Axiom outage that made it a 500 with nothing
+ * logged anywhere — 292 of them, against a baseline of zero.
+ *
+ * These exist because the restructure was otherwise UNPINNED IN BOTH DIRECTIONS: an audit
+ * showed that moving the log back ahead of the response, or deleting the containment
+ * try/catch, both left this file green at 5/5. Two independent guards, because they fail
+ * differently — one reads the ordering directly even with a healthy logger, the other only
+ * bites when the logger is sick.
+ */
+describe('/api/upload — telemetry cannot gate or fail the response', () => {
+  beforeEach(() => {
+    vi.mocked(logToAxiom).mockReset();
+    mockEnv.S3_UPLOAD_B2_ENDPOINT = 'https://b2.example.com';
+  });
+
+  it('ORDERING: the 200 is already committed by the time the event is logged', async () => {
+    const res = makeRes();
+    // Reads the response state AT LOG TIME. With the log ahead of the response — the
+    // pre-2026-08-23 shape — this observes 0, because nothing has been sent yet.
+    let statusAtLogTime: number | undefined;
+    vi.mocked(logToAxiom).mockImplementation(async () => {
+      statusAtLogTime = res.statusCode;
+    });
+
+    await handler(makeReq(UploadType.Model), res);
+
+    expect(statusAtLogTime).toBe(200);
+    expect(vi.mocked(logToAxiom)).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 's3-upload' })
+    );
+  });
+
+  it('CONTAINMENT: a rejecting logger leaves the 200 intact and the handler settled', async () => {
+    vi.mocked(logToAxiom).mockRejectedValue(new Error('timeout of 30000ms exceeded'));
+    const res = makeRes();
+
+    await expect(handler(makeReq(UploadType.Model), res)).resolves.toBeUndefined();
+
+    // Without the inner try/catch the rejection unwinds into the handler's own catch and
+    // overwrites this with a 500 — on a request whose upload session was created fine.
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { uploadId?: string })?.uploadId).toBe('test-upload-id');
+  });
+
+  it('a create failure is a 500 with a STATIC body and its own logged event', async () => {
+    getMultipartPutUrl.mockRejectedValueOnce(new Error('B2 said no: bucket civitai-modelfiles'));
+    const res = makeRes();
+
+    await expect(handler(makeReq(UploadType.Model), res)).resolves.toBeUndefined();
+
+    expect(res.statusCode).toBe(500);
+    // Static, never the error's own text: the driver message must not reach the wire, and
+    // `rest-error-envelope-ledger` fails if it does.
+    expect(res.body).toEqual({ error: 'Failed to start upload' });
+    expect(JSON.stringify(res.body)).not.toContain('civitai-modelfiles');
+    // The detail goes to the log instead — before this change a failure here logged nothing.
+    expect(vi.mocked(logToAxiom)).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 's3-upload-create-error', error: expect.any(String) })
     );
   });
 });

--- a/src/server/__tests__/upload-backend.test.ts
+++ b/src/server/__tests__/upload-backend.test.ts
@@ -225,20 +225,57 @@ describe('/api/upload — telemetry cannot gate or fail the response', () => {
     mockEnv.S3_UPLOAD_B2_ENDPOINT = 'https://b2.example.com';
   });
 
+  /**
+   * 🔴 "Committed" means the BODY was written, not merely that `res.status()` ran. Splitting
+   * them (`res.status(200); await log; res.json(...)`) leaves the client waiting exactly as
+   * long as the pre-fix code did, and a status-only assertion cannot see it.
+   */
   it('ORDERING: the 200 is already committed by the time the event is logged', async () => {
     const res = makeRes();
     // Reads the response state AT LOG TIME. With the log ahead of the response — the
-    // pre-2026-08-23 shape — this observes 0, because nothing has been sent yet.
+    // pre-2026-08-23 shape — this observes 0/undefined, because nothing has been sent yet.
     let statusAtLogTime: number | undefined;
+    let bodyAtLogTime: unknown;
     vi.mocked(logToAxiom).mockImplementation(async () => {
       statusAtLogTime = res.statusCode;
+      bodyAtLogTime = res.body;
     });
 
     await handler(makeReq(UploadType.Model), res);
 
     expect(statusAtLogTime).toBe(200);
+    expect(bodyAtLogTime).toMatchObject({ uploadId: 'test-upload-id', backend: 'b2' });
     expect(vi.mocked(logToAxiom)).toHaveBeenCalledWith(
       expect.objectContaining({ name: 's3-upload' })
+    );
+  });
+
+  /**
+   * 🔴 THE ERROR PATH NEEDS THE SAME GUARD, and a delta re-audit caught that it did not have
+   * one — while the commit message and PR body both asserted every route was covered "on both
+   * the success and error paths". It was the claim that was wrong, not the code, but a guard
+   * described more widely than it is written is worse than no guard: it stops anyone looking.
+   *
+   * The test below this one is status-only, and that is exactly the weakness that let the
+   * sign-part reorder mutant survive round 1 — the same 500 still gets sent, so only the
+   * telemetry stall in front of the client returns.
+   */
+  it('ORDERING (error path): the 500 is committed before the error event is logged', async () => {
+    getMultipartPutUrl.mockRejectedValueOnce(new Error('B2 said no'));
+    const res = makeRes();
+    let statusAtLogTime: number | undefined;
+    let bodyAtLogTime: unknown;
+    vi.mocked(logToAxiom).mockImplementation(async () => {
+      statusAtLogTime = res.statusCode;
+      bodyAtLogTime = res.body;
+    });
+
+    await handler(makeReq(UploadType.Model), res);
+
+    expect(statusAtLogTime).toBe(500);
+    expect(bodyAtLogTime).toEqual({ error: 'Failed to start upload' });
+    expect(vi.mocked(logToAxiom)).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 's3-upload-create-error' })
     );
   });
 

--- a/src/server/__tests__/upload-complete-endpoint.test.ts
+++ b/src/server/__tests__/upload-complete-endpoint.test.ts
@@ -562,4 +562,87 @@ describe('/api/upload/complete — a successful completion is VERIFIED against t
       expect(opts?.abortSignal).toBeInstanceOf(AbortSignal);
     });
   });
+
+  /**
+   * 🔴 THE RESPONSE MUST NOT DEPEND ON TELEMETRY. Every case above runs with a
+   * `logToAxiom` that RESOLVES (it is a plain `vi.fn()` from `~/__tests__/setup`), so a
+   * suite of 35 green tests said nothing about what happens when it does not — and on
+   * 2026-08-23 it did not, for 44 minutes.
+   *
+   * What that cost: Axiom's ingest host became unreachable, `logToAxiom` awaited it
+   * uncontained, and the throw landed (a) after a SUCCESSFUL completion on the happy
+   * path, turning a stored object into a 500, and (b) above `classifyS3MultipartError`
+   * in the catch, so no branch of the 409/422/503 taxonomy could execute. Spanmetrics
+   * recorded ZERO 409/422/503 on this route across the whole episode against 1,009
+   * terminal `NoSuchUpload`s — the paths were not rare, they were dead. ~5,300 requests,
+   * 350 distinct users; clients retried because 500 is retryable.
+   *
+   * These drive the real handler with a REJECTING logger and assert BOTH that the handler
+   * itself settles cleanly AND that the client got the right status. On the pre-fix
+   * ordering every case observes `statusCode === 0` — nothing was ever sent.
+   *
+   * 🔴 `resolves` is load-bearing, not decoration. An earlier draft of this fix moved the
+   * response ahead of the logging but left the log call inside the S3 `try`, so a logging
+   * rejection unwound into the catch, was classified as an S3 fault, and wrote a SECOND
+   * response over a request that had already succeeded — 200 then 500. These tests caught
+   * it; a version that only asserted the status would not have.
+   */
+  describe('telemetry failure cannot change the client response', () => {
+    const withFailingLogger = async (res: ReturnType<typeof makeRes>) => {
+      vi.mocked(logToAxiom).mockRejectedValue(new Error('timeout of 30000ms exceeded'));
+      try {
+        await expect(handler(makeReq(), res)).resolves.toBeUndefined();
+      } finally {
+        vi.mocked(logToAxiom).mockReset();
+      }
+    };
+
+    it('happy path: a stored object still returns 200, not 500', async () => {
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+      const res = makeRes();
+      await withFailingLogger(res);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toBe('https://cdn/x');
+    });
+
+    it('NoSuchUpload still classifies to 409 — the branch is reachable', async () => {
+      mockCompleteMultipartUpload.mockRejectedValue(
+        s3Error({
+          name: 'NoSuchUpload',
+          message: 'The specified upload does not exist.',
+          $metadata: { httpStatusCode: 404 },
+        })
+      );
+      mockObjectExists.mockResolvedValue(false);
+      const res = makeRes();
+      await withFailingLogger(res);
+      expect(res.statusCode).toBe(409);
+    });
+
+    it('a transient S3 fault still classifies to 503, not 500', async () => {
+      mockCompleteMultipartUpload.mockRejectedValue(
+        s3Error({ name: 'ServiceUnavailable', $metadata: { httpStatusCode: 503 } })
+      );
+      const res = makeRes();
+      await withFailingLogger(res);
+      expect(res.statusCode).toBe(503);
+      expect(res.headers['Retry-After']).toBe('2');
+    });
+  });
+
+  /**
+   * The other half of the same seam: the not-found branch consults the bucket, and that
+   * probe is a network call against the very backend that is misbehaving. A THROW there
+   * used to escape as a 500 — the same terminal fault reported as a server bug, at
+   * exactly the moment the path is busiest.
+   */
+  it('a THROWING objectExists probe yields 409, not an escaped 500', async () => {
+    mockCompleteMultipartUpload.mockRejectedValue(
+      s3Error({ name: 'NoSuchUpload', $metadata: { httpStatusCode: 404 } })
+    );
+    mockObjectExists.mockRejectedValue(new Error('connect ETIMEDOUT'));
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(409);
+  });
 });

--- a/src/server/__tests__/upload-complete-endpoint.test.ts
+++ b/src/server/__tests__/upload-complete-endpoint.test.ts
@@ -76,6 +76,10 @@ function makeRes() {
     },
     json(payload: unknown) {
       this.body = payload;
+      // A real `res.json()` ENDS the response. The double must too, or a `sent` predicate
+      // built on `body !== undefined || ended` is really measuring the payload: a handler
+      // answering `json(undefined)` reads as "not committed" and fails a correct route.
+      this.ended = true;
       return this;
     },
     end() {

--- a/src/server/__tests__/upload-complete-endpoint.test.ts
+++ b/src/server/__tests__/upload-complete-endpoint.test.ts
@@ -628,13 +628,58 @@ describe('/api/upload/complete — a successful completion is VERIFIED against t
       expect(res.statusCode).toBe(503);
       expect(res.headers['Retry-After']).toBe('2');
     });
+
+    /**
+     * 🔴 ORDERING, read directly — the assertions above are status-only, and a mutation sweep
+     * showed that is the weaker guard: once the log is contained, moving it back ahead of the
+     * response still produces the same status, so only the 2 s telemetry stall in front of the
+     * client's answer is reintroduced and a status assertion cannot see it. These read the
+     * response state AT LOG TIME, so they fail on reordering alone.
+     */
+    it('ORDERING: the response is committed before either event is logged', async () => {
+      const seen: Array<{ name: string; statusAtLogTime: number }> = [];
+      const res = makeRes();
+      vi.mocked(logToAxiom).mockImplementation(async (d: Record<string, unknown>) => {
+        seen.push({
+          name: String((d as { name?: unknown }).name),
+          statusAtLogTime: res.statusCode,
+        });
+      });
+
+      // Happy path first.
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+      await handler(makeReq(), res);
+
+      // Then the classified-error path.
+      const res2 = makeRes();
+      vi.mocked(logToAxiom).mockImplementation(async (d: Record<string, unknown>) => {
+        seen.push({
+          name: String((d as { name?: unknown }).name),
+          statusAtLogTime: res2.statusCode,
+        });
+      });
+      mockCompleteMultipartUpload.mockRejectedValue(
+        s3Error({ name: 'NoSuchUpload', $metadata: { httpStatusCode: 404 } })
+      );
+      mockObjectExists.mockResolvedValue(false);
+      await handler(makeReq(), res2);
+      vi.mocked(logToAxiom).mockReset();
+
+      expect(seen).toEqual([
+        { name: 's3-upload-complete', statusAtLogTime: 200 },
+        { name: 's3-upload-complete-error', statusAtLogTime: 409 },
+      ]);
+    });
   });
 
   /**
-   * The other half of the same seam: the not-found branch consults the bucket, and that
-   * probe is a network call against the very backend that is misbehaving. A THROW there
-   * used to escape as a 500 — the same terminal fault reported as a server bug, at
-   * exactly the moment the path is busiest.
+   * ⚠️ INVARIANT GUARD, NOT A REGRESSION TEST — labelled so nobody counts it as coverage of a
+   * bug that existed. The real `objectExists` cannot reject (`headObject` wraps its whole body
+   * in a try returning `{status:'unknown'}`), so `mockObjectExists.mockRejectedValue` here
+   * simulates a state the current dependency cannot produce. It pins the handler's side of the
+   * contract — "an unavailable probe is a 409, never a 500" — against a future change to
+   * `headObject`'s swallow-everything behaviour. It was RED at base only because the awaited
+   * telemetry ran first; it is not evidence that a throwing probe ever escaped in production.
    */
   it('a THROWING objectExists probe yields 409, not an escaped 500', async () => {
     mockCompleteMultipartUpload.mockRejectedValue(

--- a/src/server/__tests__/upload-complete-endpoint.test.ts
+++ b/src/server/__tests__/upload-complete-endpoint.test.ts
@@ -637,12 +637,15 @@ describe('/api/upload/complete — a successful completion is VERIFIED against t
      * response state AT LOG TIME, so they fail on reordering alone.
      */
     it('ORDERING: the response is committed before either event is logged', async () => {
-      const seen: Array<{ name: string; statusAtLogTime: number }> = [];
+      // `sent` is what proves the response was COMMITTED — `res.status()` alone writes
+      // nothing, so a mutant splitting status from json/end passes a status-only assertion.
+      const seen: Array<{ name: string; statusAtLogTime: number; sent: boolean }> = [];
       const res = makeRes();
       vi.mocked(logToAxiom).mockImplementation(async (d: Record<string, unknown>) => {
         seen.push({
           name: String((d as { name?: unknown }).name),
           statusAtLogTime: res.statusCode,
+          sent: res.body !== undefined || res.ended,
         });
       });
 
@@ -656,6 +659,7 @@ describe('/api/upload/complete — a successful completion is VERIFIED against t
         seen.push({
           name: String((d as { name?: unknown }).name),
           statusAtLogTime: res2.statusCode,
+          sent: res2.body !== undefined || res2.ended,
         });
       });
       mockCompleteMultipartUpload.mockRejectedValue(
@@ -666,8 +670,8 @@ describe('/api/upload/complete — a successful completion is VERIFIED against t
       vi.mocked(logToAxiom).mockReset();
 
       expect(seen).toEqual([
-        { name: 's3-upload-complete', statusAtLogTime: 200 },
-        { name: 's3-upload-complete-error', statusAtLogTime: 409 },
+        { name: 's3-upload-complete', statusAtLogTime: 200, sent: true },
+        { name: 's3-upload-complete-error', statusAtLogTime: 409, sent: true },
       ]);
     });
   });

--- a/src/server/__tests__/upload-sign-part-endpoint.test.ts
+++ b/src/server/__tests__/upload-sign-part-endpoint.test.ts
@@ -111,17 +111,27 @@ describe('/api/upload/sign-part — telemetry cannot gate or fail the response',
     expect((res.body as { url?: string })?.url).toBe('https://b2.example.com/signed');
   });
 
+  /**
+   * 🔴 "Committed" means the BODY was written, not just that `res.status()` was called.
+   * `res.status(200)` alone sends nothing — a mutant that splits the two
+   * (`res.status(200); await log; res.json(result)`) leaves the client waiting exactly as
+   * long as the pre-fix code did, and a status-only assertion passes it. So capture the body
+   * too; `undefined` there is the tell.
+   */
   it('ORDERING: the 200 is already committed by the time the event is logged', async () => {
     const res = makeRes();
     let statusAtLogTime: number | undefined;
+    let bodyAtLogTime: unknown;
     vi.mocked(logToAxiom).mockImplementation(async () => {
       statusAtLogTime = res.statusCode;
+      bodyAtLogTime = res.body;
     });
 
     await handler(makeReq(), res);
 
-    // With the log ahead of the response — the pre-fix shape — this observes 0.
+    // With the log ahead of the response — the pre-fix shape — this observes 0/undefined.
     expect(statusAtLogTime).toBe(200);
+    expect(bodyAtLogTime).toEqual({ url: 'https://b2.example.com/signed', partNumber: 3 });
     expect(vi.mocked(logToAxiom)).toHaveBeenCalledWith(
       expect.objectContaining({ name: 's3-upload-sign-part' })
     );
@@ -165,15 +175,64 @@ describe('/api/upload/sign-part — telemetry cannot gate or fail the response',
     mockGetUploadPartUrl.mockRejectedValueOnce(new Error('B2 unavailable'));
     const res = makeRes();
     let statusAtLogTime: number | undefined;
+    let bodyAtLogTime: unknown;
     vi.mocked(logToAxiom).mockImplementation(async () => {
       statusAtLogTime = res.statusCode;
+      bodyAtLogTime = res.body;
     });
 
     await handler(makeReq(), res);
 
     expect(statusAtLogTime).toBe(500);
+    expect(bodyAtLogTime).toEqual({ error: 'B2 unavailable' });
     expect(vi.mocked(logToAxiom)).toHaveBeenCalledWith(
       expect.objectContaining({ name: 's3-upload-sign-part-error' })
     );
   });
+});
+
+/**
+ * The route's two authorization guards. They PRE-DATE this PR and are not part of it — but
+ * this PR creates the only test file for the route, which makes it their natural home, and a
+ * mutation sweep found both silently removable. `getUploadPartUrl` hands back a presigned
+ * WRITE url, so a missing guard is an arbitrary-object write for any signed-in user, not a
+ * cosmetic defect.
+ */
+describe('/api/upload/sign-part — authorization guards', () => {
+  it('refuses a bucket outside the upload allowlist', async () => {
+    const res = makeRes();
+    const req = makeReq() as unknown as { body: Record<string, unknown> };
+    req.body.bucket = 'some-other-bucket';
+
+    await handler(req as never, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(mockGetUploadPartUrl).not.toHaveBeenCalled();
+  });
+
+  it("refuses a key outside the caller's own prefix", async () => {
+    const res = makeRes();
+    const req = makeReq() as unknown as { body: Record<string, unknown> };
+    // Session user is 42; this key belongs to 99.
+    req.body.key = 'model/99/someone-elses.safetensors';
+
+    await handler(req as never, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(mockGetUploadPartUrl).not.toHaveBeenCalled();
+  });
+
+  it.each([0, -1, 1.5, 'three', undefined])(
+    'rejects partNumber %p as a 400',
+    async (partNumber) => {
+      const res = makeRes();
+      const req = makeReq() as unknown as { body: Record<string, unknown> };
+      req.body.partNumber = partNumber;
+
+      await handler(req as never, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(mockGetUploadPartUrl).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/src/server/__tests__/upload-sign-part-endpoint.test.ts
+++ b/src/server/__tests__/upload-sign-part-endpoint.test.ts
@@ -22,10 +22,10 @@ import type { NextApiRequest, NextApiResponse } from 'next';
  */
 
 const { mockGetUploadPartUrl, mockGetUploadBucket, mockGetUploadS3Client } = vi.hoisted(() => ({
-  mockGetUploadPartUrl: vi.fn(async () => ({
-    url: 'https://b2.example.com/signed',
-    partNumber: 3,
-  })),
+  // Shape matches production exactly: `getUploadPartUrl` returns `{ url }` and nothing else
+  // (~/utils/s3-utils). An earlier version added a `partNumber` the real helper never emits —
+  // the same fixture-fidelity defect this suite's sibling was fixed for.
+  mockGetUploadPartUrl: vi.fn(async () => ({ url: 'https://b2.example.com/signed' })),
   // The handler builds its allowlist from these, so they must return the bucket the request
   // names or every case 403s before reaching the code under test.
   mockGetUploadBucket: vi.fn((backend: string) =>
@@ -131,7 +131,7 @@ describe('/api/upload/sign-part — telemetry cannot gate or fail the response',
 
     // With the log ahead of the response — the pre-fix shape — this observes 0/undefined.
     expect(statusAtLogTime).toBe(200);
-    expect(bodyAtLogTime).toEqual({ url: 'https://b2.example.com/signed', partNumber: 3 });
+    expect(bodyAtLogTime).toEqual({ url: 'https://b2.example.com/signed' });
     expect(vi.mocked(logToAxiom)).toHaveBeenCalledWith(
       expect.objectContaining({ name: 's3-upload-sign-part' })
     );
@@ -226,8 +226,9 @@ describe('/api/upload/sign-part — authorization guards', () => {
   // Measured as a clean partition rather than assumed: removing only the lower bound fails
   // exactly 2 of these, removing only the integer check fails exactly 3 — so neither clause is
   // vacuous and no value is absorbed by an earlier check.
-  // Title uses String(value), not `%p` — vitest does not interpolate `%p`, so all five cases
-  // would otherwise report under one identical name and a failure could not be attributed.
+  // Title uses vitest's `$0` (pretty-format: `+0`, `'three'`, `undefined`), not `%p` — vitest
+  // does not interpolate `%p`, so all five cases would otherwise report under one identical
+  // name and a failure could not be attributed to a value.
   it.each([0, -1, 1.5, 'three', undefined])(
     'rejects partNumber $0 as a 400',
     async (partNumber) => {

--- a/src/server/__tests__/upload-sign-part-endpoint.test.ts
+++ b/src/server/__tests__/upload-sign-part-endpoint.test.ts
@@ -192,7 +192,7 @@ describe('/api/upload/sign-part — telemetry cannot gate or fail the response',
 });
 
 /**
- * The route's two authorization guards. They PRE-DATE this PR and are not part of it — but
+ * The route's three authorization guards. They PRE-DATE this PR and are not part of it — but
  * this PR creates the only test file for the route, which makes it their natural home, and a
  * mutation sweep found both silently removable. `getUploadPartUrl` hands back a presigned
  * WRITE url, so a missing guard is an arbitrary-object write for any signed-in user, not a
@@ -222,6 +222,10 @@ describe('/api/upload/sign-part — authorization guards', () => {
     expect(mockGetUploadPartUrl).not.toHaveBeenCalled();
   });
 
+  // 0/-1 exercise `partNumber < 1`; 1.5/'three'/undefined exercise `!Number.isInteger`.
+  // Measured as a clean partition rather than assumed: removing only the lower bound fails
+  // exactly 2 of these, removing only the integer check fails exactly 3 — so neither clause is
+  // vacuous and no value is absorbed by an earlier check.
   it.each([0, -1, 1.5, 'three', undefined])(
     'rejects partNumber %p as a 400',
     async (partNumber) => {
@@ -235,4 +239,17 @@ describe('/api/upload/sign-part — authorization guards', () => {
       expect(mockGetUploadPartUrl).not.toHaveBeenCalled();
     }
   );
+
+  // The same 400 guard has three `typeof … !== 'string'` disjuncts that had NO case at all, so
+  // any one of them could be deleted silently. One field per case, the others left valid.
+  it.each(['bucket', 'key', 'uploadId'])('rejects a non-string %s as a 400', async (field) => {
+    const res = makeRes();
+    const req = makeReq() as unknown as { body: Record<string, unknown> };
+    req.body[field] = 12345;
+
+    await handler(req as never, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(mockGetUploadPartUrl).not.toHaveBeenCalled();
+  });
 });

--- a/src/server/__tests__/upload-sign-part-endpoint.test.ts
+++ b/src/server/__tests__/upload-sign-part-endpoint.test.ts
@@ -194,7 +194,7 @@ describe('/api/upload/sign-part — telemetry cannot gate or fail the response',
 /**
  * The route's three authorization guards. They PRE-DATE this PR and are not part of it — but
  * this PR creates the only test file for the route, which makes it their natural home, and a
- * mutation sweep found both silently removable. `getUploadPartUrl` hands back a presigned
+ * mutation sweep found all three silently removable. `getUploadPartUrl` hands back a presigned
  * WRITE url, so a missing guard is an arbitrary-object write for any signed-in user, not a
  * cosmetic defect.
  */
@@ -226,8 +226,10 @@ describe('/api/upload/sign-part — authorization guards', () => {
   // Measured as a clean partition rather than assumed: removing only the lower bound fails
   // exactly 2 of these, removing only the integer check fails exactly 3 — so neither clause is
   // vacuous and no value is absorbed by an earlier check.
+  // Title uses String(value), not `%p` — vitest does not interpolate `%p`, so all five cases
+  // would otherwise report under one identical name and a failure could not be attributed.
   it.each([0, -1, 1.5, 'three', undefined])(
-    'rejects partNumber %p as a 400',
+    'rejects partNumber $0 as a 400',
     async (partNumber) => {
       const res = makeRes();
       const req = makeReq() as unknown as { body: Record<string, unknown> };

--- a/src/server/__tests__/upload-sign-part-endpoint.test.ts
+++ b/src/server/__tests__/upload-sign-part-endpoint.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+// Setup-order import: installs the shared ~/env/server / logging / prom mocks
+// before the handler evaluates env at module load.
+import '~/__tests__/setup';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * /api/upload/sign-part — telemetry must not gate or fail the response.
+ *
+ * The fourth upload route, and the one most expensive to lose: it re-signs a part URL for a
+ * multi-hour transfer whose 12 h URLs expired, so a stall here costs the whole upload rather
+ * than one request.
+ *
+ * Both `logToAxiom` calls used to sit between the work and the response. During the
+ * 2026-08-23 Axiom outage that meant a 30 s stall (the `@axiomhq/axiom-node` axios timeout)
+ * followed by a throw, on a path where the signed URL had already been minted successfully.
+ * Its three siblings were fixed and pinned; this one was fixed in the same PR and needs the
+ * same pins, or the guard is one route wide of the defect.
+ *
+ * Lives under src/server/__tests__ rather than beside the handler: Next.js treats every .ts
+ * under src/pages/api as a route and its route-type validator rejects a test module.
+ */
+
+const { mockGetUploadPartUrl, mockGetUploadBucket, mockGetUploadS3Client } = vi.hoisted(() => ({
+  mockGetUploadPartUrl: vi.fn(async () => ({
+    url: 'https://b2.example.com/signed',
+    partNumber: 3,
+  })),
+  // The handler builds its allowlist from these, so they must return the bucket the request
+  // names or every case 403s before reaching the code under test.
+  mockGetUploadBucket: vi.fn((backend: string) =>
+    backend === 'b2' ? 'civitai-modelfiles' : 'civitai-default'
+  ),
+  mockGetUploadS3Client: vi.fn(() => ({})),
+}));
+
+vi.mock('~/utils/s3-utils', () => ({
+  getUploadPartUrl: mockGetUploadPartUrl,
+  getUploadBucket: mockGetUploadBucket,
+  getUploadS3Client: mockGetUploadS3Client,
+}));
+
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: vi.fn(async () => ({ user: { id: 42, bannedAt: null } })),
+}));
+
+import handler from '~/pages/api/upload/sign-part';
+// Mocked in ~/__tests__/setup as vi.fn(); imported so log ORDER is observable and the logger
+// can be made to REJECT.
+import { logToAxiom } from '~/server/logging/client';
+
+function makeRes() {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    setHeader() {
+      return this;
+    },
+    removeHeader() {
+      return this;
+    },
+    getHeader() {
+      return undefined;
+    },
+    // instrumentApiResponse registers a fire-and-forget res.once('finish', …).
+    once() {
+      return this;
+    },
+    on() {
+      return this;
+    },
+  };
+  return res as unknown as NextApiResponse & { statusCode: number; body: unknown };
+}
+
+function makeReq() {
+  return {
+    method: 'POST',
+    body: {
+      bucket: 'civitai-modelfiles',
+      // The handler scopes re-signing to `key.split('/')[1] === String(userId)`, so the 42
+      // here is load-bearing: any other value 403s.
+      key: 'model/42/thing.safetensors',
+      uploadId: 'test-upload-id',
+      partNumber: 3,
+      backend: 'b2',
+    },
+    headers: {},
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as NextApiRequest;
+}
+
+beforeEach(() => {
+  mockGetUploadPartUrl.mockClear();
+  vi.mocked(logToAxiom).mockReset();
+});
+
+describe('/api/upload/sign-part — telemetry cannot gate or fail the response', () => {
+  it('happy path still returns 200 with the signed URL', async () => {
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { url?: string })?.url).toBe('https://b2.example.com/signed');
+  });
+
+  it('ORDERING: the 200 is already committed by the time the event is logged', async () => {
+    const res = makeRes();
+    let statusAtLogTime: number | undefined;
+    vi.mocked(logToAxiom).mockImplementation(async () => {
+      statusAtLogTime = res.statusCode;
+    });
+
+    await handler(makeReq(), res);
+
+    // With the log ahead of the response — the pre-fix shape — this observes 0.
+    expect(statusAtLogTime).toBe(200);
+    expect(vi.mocked(logToAxiom)).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 's3-upload-sign-part' })
+    );
+  });
+
+  it('CONTAINMENT: a rejecting logger leaves the 200 intact and the handler settled', async () => {
+    vi.mocked(logToAxiom).mockRejectedValue(new Error('timeout of 30000ms exceeded'));
+    const res = makeRes();
+
+    await expect(handler(makeReq(), res)).resolves.toBeUndefined();
+
+    // Without the inner try/catch this unwinds into the handler's catch and becomes a 500 on
+    // a request whose URL was signed fine — which is exactly what the outage did.
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('ERROR PATH: the 500 is sent even when the logger is also failing', async () => {
+    mockGetUploadPartUrl.mockRejectedValueOnce(new Error('B2 unavailable'));
+    vi.mocked(logToAxiom).mockRejectedValue(new Error('timeout of 30000ms exceeded'));
+    const res = makeRes();
+
+    await expect(handler(makeReq(), res)).resolves.toBeUndefined();
+
+    // Pre-fix the awaited log ran FIRST, so a sick logger meant no response was written at
+    // all — the client saw an unhandled-rejection 500 with no event recorded.
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: 'B2 unavailable' });
+  });
+
+  /**
+   * 🔴 ORDERING ON THE ERROR PATH TOO — added because a mutation sweep found the test above
+   * does NOT catch moving the error log back ahead of the 500. Once the log is contained, a
+   * reordered version still ends up sending the same 500, so a status-only assertion cannot
+   * see it; what it reintroduces is the 2 s telemetry stall in front of the client's answer,
+   * which is the half of the outage the containment does not fix.
+   *
+   * A status-only assertion is the weaker guard on BOTH paths. This reads the response state
+   * at log time, so it fails on reordering alone.
+   */
+  it('ORDERING (error path): the 500 is committed before the error event is logged', async () => {
+    mockGetUploadPartUrl.mockRejectedValueOnce(new Error('B2 unavailable'));
+    const res = makeRes();
+    let statusAtLogTime: number | undefined;
+    vi.mocked(logToAxiom).mockImplementation(async () => {
+      statusAtLogTime = res.statusCode;
+    });
+
+    await handler(makeReq(), res);
+
+    expect(statusAtLogTime).toBe(500);
+    expect(vi.mocked(logToAxiom)).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 's3-upload-sign-part-error' })
+    );
+  });
+});


### PR DESCRIPTION
## What happened

On 2026-08-23, 01:08–01:52Z, Axiom's ingest endpoint became unreachable from prod. For 44 minutes `/api/upload/complete`, `/api/upload/abort` and `/api/upload/index` returned **500** — ~5,300 requests, **350 distinct users** — while the storage backend was healthy the entire time (`b2_put_retries_total` stayed at ~0 throughout).

Site-wide 5xx peaked at **0.19%**, so no aggregate signal could see it. It was caught by the per-endpoint success-ratio alert.

## Root cause

From the stack, not inferred:

```
Upload complete error: timeout of 30000ms exceeded AxiosError: timeout of 30000ms exceeded
  at createTimeoutError (axios@1.18.1/…)
  at async logToAxiom (…)        ← throwing frame
  at async d (…)                 ← the upload handler
```

`packages/civitai-axiom/src/client.ts` ended in a bare `await axiom.ingestEvents(datastream, sendData)`. It was the **only uncontained sink in that function** — the stderr/Loki write happens first, and the injected `emitLog` sink is already wrapped in try/catch with a comment saying *"a telemetry sink must never be able to fail the code path it is observing."* The Axiom dual-write was the exception. `@axiomhq/axiom-node@0.12.0` drives **axios** with a hardcoded `timeout: 30000` that `new Client({ token, orgId })` cannot reach.

Three consequences, all observed:

| | |
|---|---|
| **Happy path inverted** | `completeMultipartUpload` had already stored the object; the throw came from the log line *after* it. A stored upload was reported to the browser as a 500 — those objects are in the bucket with no DB row. |
| **The error taxonomy was unreachable** | Both handlers awaited `logToAxiom` **above** `classifyS3MultipartError`, so no branch below it could execute. Spanmetrics recorded **zero** 409/422/503 across the whole episode against **1,009** terminal `NoSuchUpload`s. 500 is retryable to both clients → they retried → each retry hit a consumed session and re-failed. |
| **Background workers crashed** | Background callers don't `await`, so there the rejection was an `unhandledRejection` and the process exited. All three pods died at 01:06:45Z. |

## Changes

**`@civitai/axiom` — contain *and* time-box the dual-write.** try/catch alone fixes the throw but not the 30 s stall per logged event, which on a request path is indistinguishable from an outage; the write now races a 2 s budget.

> **Correction (twice over).** This section previously claimed (a) that a trailing `.then(onOk).catch(onErr)` would leak an unhandled rejection, then (b) that a fulfilment-handler-only form leaks and the suite kills it. **Both are wrong.** `Promise.race` subscribes to its inputs synchronously, so the ingest promise always has a subscriber — including after the budget wins and nothing awaits it. Probed in node against a positive control (a promise nobody subscribes to, which *does* leak): paired handlers, trailing `.catch`, fulfilment-handler-only and a bare promise all produce **zero** unhandled rejections once raced.
>
> So the invariant that matters is **"the ingest promise is raced"**, not "the handler is paired", and `NO UNHANDLED REJECTION` is an **invariant guard** — no reachable mutation that keeps the race can violate it. It is relabelled as such rather than counted as coverage.

Failures report on the 1st and every 500th, with a recovery line carrying the total, so a 44-minute outage is visible without 6,444 log lines.

**`upload/{complete,abort}.ts` — classify and respond before logging.** The event moves to a `finally`, so it's still recorded on every branch but can no longer decide *which* branch runs. Success paths respond first too.

The post-response logging is itself contained: it sits inside the S3 `try`, so an uncontained throw would unwind into the catch and write a **second** response over a request that already succeeded. A test caught exactly that while this PR was being written — the first draft answered 200 and then 500.

**`complete.ts` — `objectExists(...).catch(() => null)`**, kept as defence in depth.

> **Correction.** An earlier version of this description called this a bug fix ("a throwing probe used to escape as a 500"). **It is inert today**: `headObject` wraps its entire body in a try returning `{status:'unknown'}`, so `objectExists` cannot reject, and a degraded bucket has always landed on `null` → 409. The catch guards against a future change to that swallow-everything contract, and costs nothing. Its test is labelled an **invariant guard**, not a regression test — it mocks a rejection the real dependency cannot produce.

**`upload/index.ts` — had no try/catch at all**, and and logged before responding, so any throw was a 500 with nothing recorded anywhere. Wrapped, reordered, given its own error event. The 500 body is a static string rather than `handleEndpointError`: that's the sanctioned envelope and would be right in general, but importing it pulls `pgDb → kyselyDb` into this route's module graph and breaks `upload-backend.test.ts` at *import* time (which reports as `Tests no tests`, not as a failure). Not worth a new graph edge here. (To be precise: `handleEndpointError` was never imported by any of these routes at base — it is a rejected option, not something this PR removes.)

`sign-part.ts` had the identical ORDERING defect and was added in round 2 — it awaited both its log calls ahead of its response. (It did already have a try/catch; an earlier version of this description said it did not.) It is the route that re-signs a part URL for a multi-hour transfer whose 12 h URLs expired, so a stall there costs the whole upload rather than one request.

## Round 2 — audit findings

An adversarial audit found no 🔴 but several real 🟡s, all now fixed:

- **The outage report could not be alerted on.** `axiom-ingest-failed` / `-recovered` carried neither `type` nor `pod`. Alloy extracts `type` into Loki's `detected_level`, so those lines would never have reached the error stream — and the alert this event exists to support could not have been built on it.
- **The failure counter was per-module-copy.** The app's `structured-log-sink` measures that the bundler emits its logging module **14 times** into one server build; with 14 private counters, a 6,444-event outage could report as a handful of `consecutiveFailures: 1` lines. Now pinned to `globalThis`, keyed by datastream.
- **`sign-part.ts` was unfixed** and **`index.ts`'s restructure was untested in both directions** — the audit showed that reverting either of its two invariants left that suite green at 5/5.

## Round 4 — second delta re-audit

Not clean either. The code was sound; the **claims about it** were wrong twice more, in the same way both times — each checked against my own reading rather than against the thing itself. Both are now measured:

- 🔴 **`level` IS read.** Round 2 said `type` → `detected_level`; round 3 corrected the direction and over-corrected into "nothing reads `level`". Measured live against Loki with controls, both surfaces work and they are *different* surfaces: `| type="error"` → 735 hits/h (negative control `type="zzz-none"` → 0), and `| detected_level="error"` → 18,148 hits/h derived from the `level` **key**. The discriminator: lines carrying `"level":"info"` that also contain the word "error" resolve to `detected_level="info"` (74) and **never** `"error"` (0) — the key beats Loki's substring heuristic, so dropping `level` would silently demote these lines to it. Both fields stay.
- 🔴 **`NO UNHANDLED REJECTION` is an invariant guard**, not coverage — see the correction above.
- 🟡 **The `sent` predicate measured the fixture's payload, not commitment.** The doubles' `json()` set `body` but not `ended`, while a real `res.json()` ends the response, so a handler answering `json(undefined)` read as "not committed" and failed a *correct* route. False-negative, but fixture-coupled. Verified fixed with the discriminating probe that failed before.
- 🟡 **`abort.ts`'s success body was unpinned** — `res.json(result)` → `res.json({})` survived the whole suite. Round 3 used a value assertion on two routes and the weaker boolean on the other two.
- 🟢 Three slips: a comment mis-describing the test beneath it; "the route's **two** authorization guards" over three; and the 400 guard's three `typeof … !== 'string'` disjuncts had no case at all.

**Mutation: 4 new, 4 killed, each by exactly one test.** Rounds 2 and 3 re-run in full — 10/10 and 8/8.

**The recurring lesson, recorded because it cost four rounds:** when a comment explains a *mechanism*, verify it against the mechanism — live Loki, a node probe, an isolated mutant — not against the config or the code that motivated it. All four of these claims were plausible, internally consistent, and wrong.

## Round 5 — third delta re-audit

Not clean either, and this time **one finding was a regression round 4 introduced**:

- 🔴 **Round 4 gutted an assertion while improving another.** Making the test doubles' `json()` set `ended` turned `expect(res.ended).toBe(true)` in the abort 204 case into a tautology — it was the only thing distinguishing a bodyless 204 from an invalid 204-with-a-body. Measured: `res.status(204).end()` → `res.status(204).json({})` was **killed** at the round-3 commit and **survived 67/67** at the round-4 commit. Now asserts `res.body` is undefined; the mutant dies again.
- 🔴 **Third wrong `detected_level` theory — retracted, not replaced.** The control round 4 failed to run: lines carrying `"type":"error"` and **no** `level` key resolve to `detected_level="error"` **662/662, 100%**, so `level` does not drive it; and **zero** lines carry `level` without `type`, so round 4's discriminator could never have separated them. `| level=` matches nothing at all. The comment now asserts no mechanism — just the one measured fact (`| type="error"`, with a negative control), a record that three rewrites each landed on a different refuted theory, and an instruction to measure rather than add a fourth. The undated hit counts are gone: a figure in a source comment with no selector, window or instant is unfalsifiable and decays.
- 🔴 **The pairing IS load-bearing** — round 4 over-corrected into "the invariant is the race, not the pairing", which invites deleting it. Both matter, for different failure modes: the **pairing** stops an *early* rejection throwing into the caller (bare and fulfilment-only both give `THREW`); the **race** stops a *late* one becoming an unhandledRejection.
- 🟡 The abort fixture `{ ok: true, … }` is a shape `abortMultipartUpload` can never return (`Promise<void>`), and round 4 had deleted the only case using the production value. Restored.
- 🟢 Two stale docstrings, plus `it.each` reporting all five cases under one identical name (vitest doesn't interpolate `%p`), so a failure couldn't be attributed to a value.

> 🔴 **Correction to this PR's own verification claim.** `tsconfig.json` excludes `src/**/__tests__/**`, so **"typecheck: 0 errors" has never covered the app test files added here** — only the `packages/**` ones, which is why every type error this PR hit surfaced there. The app test code is transpiled by vitest, not type-checked.

## Round 6 — final

Comment-and-fixture only, no behaviour change. The round-5 re-audit **confirmed both of that round's headline fixes independently** (204 tautology: mutant survived at the round-4 commit, killed at round-5; and every factual statement in the retracted `detected_level` note reproduces against live Loki with controls). It found four claims wider than their evidence, all since scoped:

- The abort happy path does **not** pin a pass-through — `toBeUndefined()` is satisfied by sending nothing, so `json(result)` → `end()`/`json(undefined)` survive. Both are production-inert (`Promise<void>`, caller fire-and-forgets), so the coverage was fine and the wording was wrong. The case now names its own survivors.
- "That throw is the original bug" over-scoped: deleting the pairing re-creates a caller throw only for rejections **inside** the 2 s budget; the documented 30 s timeout resolves as `'timeout'` either way.
- The race paragraph re-imported the theory retracted elsewhere in the same commit — with no race there is no budget and nothing is ever abandoned. Rewritten with a "do not re-derive this" note.
- "The only route whose happy-path fixture was unfaithful" was false: `sign-part`'s fixture returned `{ url, partNumber }` while `getUploadPartUrl` returns `{ url }`. Same defect, in a file that round edited. Fixed.

**Audit loop closed here.** Rounds 1–2 found code defects; round 4 found one real regression (a fix that strengthened one predicate and gutted another); rounds 5–6 found only progressively smaller inaccuracies in the comments. The code has not changed since round 2 and is mutation-verified at **18 killed / 0 survivors** across both batteries.

## Verification

Red → green, both measured:

| Suite | At `origin/main` | With this PR |
|---|---|---|
| `@civitai/axiom` | **6 failed** / 12 passed | 29 / 29 |
| upload handlers | **6 failed** / 35 passed | 67 / 67 |

**Mutation-verified, 12 mutants, 12 killed** (positive control green on all three suites first): drop `type:'error'` · drop `pod` · revert to a per-logger counter · remove `clearTimeout` · recovery as `type:'error'` · drop the first-failure report · index.ts containment + ordering · sign-part ordering on both paths · complete + abort ordering.

🔴 **One mutant SURVIVED the first round, and it is why the ordering guards exist.** Moving the error log back ahead of the response is invisible to a status-only assertion, because once the log is contained the same status is still sent — what returns is the 2 s stall in front of the client's answer.

## Round 3 — delta re-audit

A delta re-audit found no 🔴 and confirmed four of the seven prior findings fully closed. The residual was all one thing: **round 2's claims about its own coverage ran ahead of the coverage.**

- 🔴 Round 2 asserted "every route now asserts the response state at log time, **on both the success and error paths**". That was **false for `/api/upload`** — its error path had only a status-only assertion, and a mutant moving the 500 after the awaited log survived at 56/56. Exactly the lesson round 2 said it had learned, left open on one of four routes while advertised as closed. A guard described more widely than it is written is worse than no guard: it stops anyone looking.
- The ordering guards pinned `res.status()`, **not a committed response** — splitting status from body passed all five of them. They now capture the body at log time (or `ended`, for abort's 204 arm).
- The wrong `.catch()` claim **survived in the test suite**: round 2 said the comment "and a test docstring" were corrected; only `client.ts` was.
- The `type` mechanism was stated imprecisely (and round 4 then found the *correction* was also wrong — see below).
- `sign-part.ts`'s **authorization guards were silently removable** — bucket allowlist, key-prefix ownership, partNumber bound. They pre-date this PR, but it creates the route's only test file, and `getUploadPartUrl` returns a presigned **write** URL. Now pinned.

**Mutation: 8 new mutants, 8 killed; the round-2 battery of 10 re-run, still 10/10.** The harness now verifies each mutant **actually applied** before reading its result — a pattern that silently fails to match leaves the file pristine and scores SURVIVED, which is a wrong coverage claim in the reassuring direction. (The re-auditor hit that exact trap: 3 false survivals from mutants that changed the test collection count.)

> **Correction.** An earlier version quoted the 6 handler failures at base as all reading `expected +0 to be 409` / `204` / `200` / `503`. That was the output of an **earlier draft** of the tests; with the final text (which asserts `resolves` first) five read `AssertionError: promise rejected "Error: timeout of 30000ms exceeded" instead of resolving` and the sixth fails on an uncaught `connect ETIMEDOUT`. The counts and the conclusion are unchanged and were re-measured against the final tests — only the quoted harness text was stale.

The package suite's pre-existing `ORDERING` test asserted `rejects.toThrow('axiom down')` — it documented the throwing behaviour as intended. This PR inverts it.

Also green: full unit suite **20,938 passed / 1,342 files**, packages suite **1,100 passed**, `typecheck` 0 errors, prettier clean. ESLint reports 3 errors + 2 warnings — **identical to `origin/main`**, verified by running the same files from a clean worktree of the base; none are on changed lines.

## Deliberately not in this PR

- The orphan sweep for objects stored during 01:07–01:53Z whose 500 meant no DB row was written.
- A dedicated Axiom-ingest-failure alert. The `axiom-ingest-failed` event added here is what it would key on — and it now carries `type:'error'` + `pod`, so it actually can be.
- `complete.ts` / `abort.ts` remain on the `rest-error-envelope-ledger` baseline for their 500 bodies. Pre-existing, and changing the response shape is out of scope for a hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpdnyuRskko5SSmJedzfY7
