### PR TITLE
fix(search-index-cleanup): stop the nightly scan ending mid-index, and report when it does

### DIFF
--- a/src/server/jobs/__tests__/search-index-cleanup.test.ts
+++ b/src/server/jobs/__tests__/search-index-cleanup.test.ts
@@ -26,7 +26,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { cleanupAllIndexes } = vi.hoisted(() => ({ cleanupAllIndexes: vi.fn() }));
 
-vi.mock('~/server/meilisearch/cleanup', () => ({ cleanupAllIndexes }));
+// Spreads the original so `CLEANUP_INDEXES` is the REAL configured list — the
+// never-attempted check below compares against it, and a hand-written stand-in
+// would make that assertion a statement about the fixture instead.
+vi.mock('~/server/meilisearch/cleanup', async (importOriginal) => ({
+  ...(await importOriginal<typeof CleanupModule>()),
+  cleanupAllIndexes,
+}));
+
+import type * as CleanupModule from '~/server/meilisearch/cleanup';
+import { CLEANUP_INDEXES } from '~/server/meilisearch/cleanup';
 
 // `~/server/logging/client` is a CANONICAL shared-module mock: src/__tests__/setup.ts
 // registers it once, globally, spreading the real module and overriding only
@@ -309,6 +318,128 @@ describe('search-index-cleanup: a truncated scan is loud and says so precisely',
         'scanned 700, stale 21, deleted 13'
     );
     expect(String(payload?.message)).not.toContain('STOPPED EARLY');
+  });
+});
+
+describe('search-index-cleanup: the coverage band is calibrated, not incidental', () => {
+  // The backstop is `shortfall > FLOOR && shortfall > total * RATIO`. In a
+  // fixture where both clauses agree, either constant can be mutated freely
+  // and the suite stays green — they shadow each other. These three cases are
+  // chosen so exactly ONE clause is decisive in each, which is what makes each
+  // constant independently observable.
+
+  it('does not flag a shortfall that clears the RATIO but not the absolute FLOOR', async () => {
+    // total 2000, scanned 1200 -> shortfall 800.
+    //   ratio: 800 > 500   TRUE   (would flag)
+    //   floor: 800 > 1000  FALSE  (blocks)
+    // So the floor is the only thing keeping this quiet: lowering or deleting
+    // it turns this into an error. A small index must not go loud over a few
+    // hundred documents.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'tools',
+        idsScanned: 1200,
+        staleFound: 17,
+        deleted: 9,
+        totalInIndex: 2000,
+        stoppedEarly: false,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    expect(payloadFor('tools')?.type).toBe('info');
+    expect(payloadFor('tools')?.incomplete).toBe(false);
+  });
+
+  it('does not flag a large absolute shortfall that is a small PROPORTION', async () => {
+    // total 100000, scanned 90000 -> shortfall 10000.
+    //   floor: 10000 > 1000   TRUE  (would flag, and stays true however the
+    //                                floor is lowered)
+    //   ratio: 10000 > 25000  FALSE (blocks)
+    // The ratio is the only thing keeping this quiet: loosening it to 0.05, or
+    // deleting the clause, turns a 90%-covered run into a nightly error.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'bounties',
+        idsScanned: 90000,
+        staleFound: 31,
+        deleted: 12,
+        totalInIndex: 100000,
+        stoppedEarly: false,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    expect(payloadFor('bounties')?.type).toBe('info');
+    expect(payloadFor('bounties')?.incomplete).toBe(false);
+  });
+
+  it('DOES flag a shortfall that clears the ratio band', async () => {
+    // total 100000, scanned 60000 -> shortfall 40000.
+    //   floor: 40000 > 1000   TRUE
+    //   ratio: 40000 > 25000  TRUE  -> flagged
+    // Pins the band from the other side: widening the ratio to 0.95 (or
+    // raising the floor above 40000) silences a run that missed 40% of the
+    // index. Together with the two cases above, each constant is now
+    // independently observable in both directions.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'comics',
+        idsScanned: 60000,
+        staleFound: 23,
+        deleted: 8,
+        totalInIndex: 100000,
+        stoppedEarly: false,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    expect(payloadFor('comics')?.type).toBe('error');
+    expect(payloadFor('comics')?.incomplete).toBe(true);
+    expect(payloadFor('comics')?.message).toBe(
+      'comics: scan reached the end of the index but covered only 60000 of 100000 document(s) — ' +
+        'scanned 60000, stale 23, deleted 8'
+    );
+  });
+});
+
+describe('search-index-cleanup: an index the run never reached is reported', () => {
+  it('names every configured index that was never attempted', async () => {
+    // `cleanupAllIndexes` stops iterating on cancellation, so the indexes it
+    // never opened produce no per-index line. A per-index `stoppedEarly` flag
+    // cannot cover this: there is no result object to carry it.
+    const [first, second, ...rest] = CLEANUP_INDEXES;
+    cleanupAllIndexes.mockResolvedValue([
+      stats({ key: first.key, idsScanned: 40, staleFound: 3, deleted: 1, totalInIndex: 40 }),
+      stats({ key: second.key, idsScanned: 22, staleFound: 5, deleted: 2, totalInIndex: 22 }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const missedLine = logged().find((p) => p.indexesMissed !== undefined);
+    expect(missedLine?.type).toBe('error');
+    expect(missedLine?.indexesConfigured).toBe(CLEANUP_INDEXES.length);
+    expect(missedLine?.indexesAttempted).toBe(2);
+    expect(missedLine?.indexesMissed).toEqual(rest.map((c) => c.key));
+    expect(missedLine?.message).toBe(
+      `run ENDED BEFORE ${rest.length} of ${CLEANUP_INDEXES.length} configured index(es) ` +
+        `were attempted: ${rest.map((c) => c.key).join(', ')}`
+    );
+  });
+
+  it('says nothing when every configured index was attempted', async () => {
+    cleanupAllIndexes.mockResolvedValue(
+      CLEANUP_INDEXES.map((c, i) =>
+        stats({ key: c.key, idsScanned: 10 + i, staleFound: 2, deleted: 1, totalInIndex: 10 + i })
+      )
+    );
+
+    await searchIndexCleanupJob.run({}).result;
+
+    expect(logged().find((p) => p.indexesMissed !== undefined)).toBeUndefined();
   });
 });
 

--- a/src/server/jobs/__tests__/search-index-cleanup.test.ts
+++ b/src/server/jobs/__tests__/search-index-cleanup.test.ts
@@ -2,14 +2,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * The nightly search-index cleanup job used to emit NOTHING about what it did.
- * `cleanupIndex` computed per-index scanned / stale / deleted / total counters
- * and the job handed them back in its return value, but nothing logged them
- * and the runner records only a duration — so a pass that covered a fraction
- * of an index and then reported success was completely unobservable.
+ * `cleanupIndex` computed per-index counters and the job handed them back in
+ * its return value, but nothing logged them and the runner records only a
+ * duration — so a pass that covered a fraction of an index and then reported
+ * success was completely unobservable.
  *
- * These tests pin two things: the per-index stats reach the log sink at all,
- * and an INCOMPLETE pass (`idsScanned < totalInIndex`) is loud rather than
- * buried in a success line.
+ * What the log has to get right is subtler than "scanned < total":
+ *
+ *  - `totalInIndex` is a snapshot taken BEFORE a scan that then runs for a long
+ *    time, against indexes another job deletes from every five minutes. A
+ *    shortfall is normal, so raising an error on it would produce a nightly
+ *    error that is usually wrong — which trains people to ignore it.
+ *  - "stopped early" and "skipped some batches" are different facts with
+ *    different fixes, and the cursor advances past a skipped batch, so a scan
+ *    can reach the very end having skipped some.
+ *  - an index the engine cannot serve at all yields NO total, so a
+ *    count-based verdict files the worst case as healthy.
+ *
+ * Fixture values below are deliberately PAIRWISE DISTINCT — scanned, stale,
+ * deleted, errors and total never coincide — so a payload that reports one
+ * field's value under another field's name is observable.
  */
 
 const { cleanupAllIndexes } = vi.hoisted(() => ({ cleanupAllIndexes: vi.fn() }));
@@ -51,8 +63,13 @@ type Stats = {
   deleted: number;
   totalInIndex: number | null;
   errors: number;
+  stoppedEarly: boolean;
+  idsSkipped: number;
+  rescuedByPrimary: number;
+  indexingAtStart: boolean | null;
 };
 
+/** A healthy, complete pass by default; each test overrides only what it means. */
 function stats(over: Partial<Stats> & { key: string }): Stats {
   return {
     indexName: `${over.key}_v1`,
@@ -62,6 +79,10 @@ function stats(over: Partial<Stats> & { key: string }): Stats {
     deleted: 0,
     totalInIndex: 0,
     errors: 0,
+    stoppedEarly: false,
+    idsSkipped: 0,
+    rescuedByPrimary: 0,
+    indexingAtStart: false,
     ...over,
   };
 }
@@ -69,6 +90,10 @@ function stats(over: Partial<Stats> & { key: string }): Stats {
 /** Every logToAxiom payload from the run, as plain objects. */
 function logged() {
   return logToAxiom.mock.calls.map((c) => c[0] as Record<string, unknown>);
+}
+
+function payloadFor(key: string) {
+  return logged().find((p) => p.key === key);
 }
 
 beforeEach(() => {
@@ -81,57 +106,74 @@ beforeEach(() => {
 });
 
 describe('search-index-cleanup: per-index stats are logged', () => {
-  it('emits one payload per index carrying key, scanned, stale, deleted, errors and total', async () => {
+  it('emits one payload per index whose every field carries its OWN counter', async () => {
+    // Pairwise-distinct on purpose: 811 / 42 / 37 / 3 / 907 share no value, so
+    // a payload that reports `total` under `scanned` (or `stale` under
+    // `deleted`) is visible here rather than hidden by equal fixtures.
     cleanupAllIndexes.mockResolvedValue([
       stats({
         key: 'models',
-        idsScanned: 800,
-        staleFound: 40,
-        deleted: 40,
-        totalInIndex: 800,
-        errors: 0,
+        idsScanned: 811,
+        staleFound: 42,
+        deleted: 37,
+        errors: 3,
+        totalInIndex: 907,
       }),
       stats({
         key: 'articles',
         idsScanned: 250,
-        staleFound: 3,
-        deleted: 3,
-        totalInIndex: 250,
-        errors: 1,
+        staleFound: 11,
+        deleted: 6,
+        errors: 0,
+        totalInIndex: 264,
       }),
     ]);
 
     await searchIndexCleanupJob.run({}).result;
 
-    const models = logged().find((p) => p.key === 'models');
-    const articles = logged().find((p) => p.key === 'articles');
-
-    expect(models).toMatchObject({
+    expect(payloadFor('models')).toMatchObject({
       name: 'search-index-cleanup',
       key: 'models',
-      scanned: 800,
-      stale: 40,
-      deleted: 40,
-      errors: 0,
-      total: 800,
+      scanned: 811,
+      stale: 42,
+      deleted: 37,
+      errors: 3,
+      total: 907,
     });
-    expect(articles).toMatchObject({
+    expect(payloadFor('articles')).toMatchObject({
       name: 'search-index-cleanup',
       key: 'articles',
       scanned: 250,
-      stale: 3,
-      deleted: 3,
-      errors: 1,
-      total: 250,
+      stale: 11,
+      deleted: 6,
+      errors: 0,
+      total: 264,
     });
+  });
+
+  it('reports `scanned` from idsScanned, not from the index total', async () => {
+    // A complete pass whose scanned count differs from the pre-scan total —
+    // which is the NORMAL case, because documents are deleted from under the
+    // cursor while the scan runs.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({ key: 'tools', idsScanned: 480, staleFound: 9, deleted: 4, totalInIndex: 512 }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    expect(payloadFor('tools')?.scanned).toBe(480);
+    expect(payloadFor('tools')?.total).toBe(512);
   });
 
   it('INVARIANT GUARD (green on unfixed code): leaves the job return value unchanged', async () => {
     // Not a regression test — the return value was already correct. It is
     // pinned so the logging added alongside it cannot quietly change the
     // HTTP response body the runner hands back.
+    // Pairwise-distinct here too: the return value is a second copy of the
+    // same field list, and equal fixture values would let a field report
+    // another field's number undetected.
     cleanupAllIndexes.mockResolvedValue([
-      stats({ key: 'tools', idsScanned: 12, staleFound: 2, deleted: 2, totalInIndex: 12 }),
+      stats({ key: 'tools', idsScanned: 12, staleFound: 5, deleted: 2, totalInIndex: 20 }),
     ]);
 
     const result = (await searchIndexCleanupJob.run({}).result) as {
@@ -139,13 +181,13 @@ describe('search-index-cleanup: per-index stats are logged', () => {
     };
 
     expect(result).toEqual({
-      indexes: [{ key: 'tools', scanned: 12, stale: 2, deleted: 2, errors: 0, total: 12 }],
+      indexes: [{ key: 'tools', scanned: 12, stale: 5, deleted: 2, errors: 0, total: 20 }],
     });
   });
 });
 
-describe('search-index-cleanup: an incomplete pass is loud', () => {
-  it('logs a truncated scan at error level with BOTH the scanned and total counts', async () => {
+describe('search-index-cleanup: a truncated scan is loud and says so precisely', () => {
+  it('logs a stopped-early scan at error level with the WHOLE message pinned', async () => {
     cleanupAllIndexes.mockResolvedValue([
       stats({
         key: 'users',
@@ -153,52 +195,176 @@ describe('search-index-cleanup: an incomplete pass is loud', () => {
         staleFound: 17346,
         deleted: 17346,
         totalInIndex: 11600000,
-        errors: 0,
+        stoppedEarly: true,
       }),
     ]);
 
     await searchIndexCleanupJob.run({}).result;
 
-    const payload = logged().find((p) => p.key === 'users');
+    const payload = payloadFor('users');
     expect(payload?.type).toBe('error');
     expect(payload?.incomplete).toBe(true);
-    expect(String(payload?.message)).toContain('INCOMPLETE SCAN');
-    expect(String(payload?.message)).toContain('4300000');
-    expect(String(payload?.message)).toContain('11600000');
+    expect(payload?.stoppedEarly).toBe(true);
+    // The WHOLE normalised string, not a pair of order-insensitive `toContain`
+    // calls — those cannot see the two numbers being swapped.
+    expect(payload?.message).toBe(
+      'users: scan STOPPED EARLY after 4300000 id(s) of 11600000 at the start of the run — ' +
+        'scanned 4300000, stale 17346, deleted 17346'
+    );
   });
 
-  it('does NOT flag a complete pass', async () => {
+  it('does NOT call a healthy complete pass incomplete just because the total moved', async () => {
+    // The false-positive class: `totalInIndex` is snapshotted before a scan
+    // that runs for hours while another job deletes from the same index. A
+    // verdict of `idsScanned < totalInIndex` fires an error every night.
     cleanupAllIndexes.mockResolvedValue([
       stats({
         key: 'collections',
-        idsScanned: 500,
-        staleFound: 5,
-        deleted: 5,
-        totalInIndex: 500,
+        idsScanned: 498000,
+        staleFound: 120,
+        deleted: 95,
+        totalInIndex: 500000,
+        stoppedEarly: false,
       }),
     ]);
 
     await searchIndexCleanupJob.run({}).result;
 
-    const payload = logged().find((p) => p.key === 'collections');
+    const payload = payloadFor('collections');
     expect(payload?.type).toBe('info');
     expect(payload?.incomplete).toBe(false);
-    expect(String(payload?.message)).not.toContain('INCOMPLETE');
+    expect(payload?.message).toBe('collections: scanned 498000, stale 120, deleted 95');
   });
 
-  it('does NOT flag a pass whose index total could not be read', async () => {
-    // `totalInIndex: null` means the stats call failed. Completeness is then
-    // unknowable, so the run must not assert either way.
+  it('still flags a completed loop that covered implausibly little', async () => {
+    // The backstop for the case `stoppedEarly` cannot see: the loop claims it
+    // reached the end, but only a third of the documents were examined.
     cleanupAllIndexes.mockResolvedValue([
-      stats({ key: 'bounties', idsScanned: 90, staleFound: 0, deleted: 0, totalInIndex: null }),
+      stats({
+        key: 'bounties',
+        idsScanned: 30000,
+        staleFound: 12,
+        deleted: 7,
+        totalInIndex: 900000,
+        stoppedEarly: false,
+      }),
     ]);
 
     await searchIndexCleanupJob.run({}).result;
 
-    const payload = logged().find((p) => p.key === 'bounties');
+    const payload = payloadFor('bounties');
+    expect(payload?.type).toBe('error');
+    expect(payload?.incomplete).toBe(true);
+    expect(payload?.message).toBe(
+      'bounties: scan reached the end of the index but covered only 30000 of 900000 document(s) — ' +
+        'scanned 30000, stale 12, deleted 7'
+    );
+  });
+
+  it('does not read a shortfall as truncation while the engine was mid-ingest', async () => {
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'comics',
+        idsScanned: 30000,
+        staleFound: 12,
+        deleted: 7,
+        totalInIndex: 900000,
+        stoppedEarly: false,
+        indexingAtStart: true,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    expect(payloadFor('comics')?.type).toBe('info');
+    expect(payloadFor('comics')?.incomplete).toBe(false);
+  });
+
+  it('reports skipped batches as SKIPPED, not as an early stop', async () => {
+    // `idsScanned` only increments when the eligibility lookup succeeds, but
+    // the cursor advances regardless — so a scan can reach the very end of the
+    // index with batches missing. Saying "the pass ended before reaching the
+    // end" there is a diagnosis that is simply false.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'articles',
+        idsScanned: 700,
+        staleFound: 21,
+        deleted: 13,
+        totalInIndex: 900,
+        stoppedEarly: false,
+        idsSkipped: 200,
+        errors: 2,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const payload = payloadFor('articles');
+    expect(payload?.type).toBe('error');
+    expect(payload?.stoppedEarly).toBe(false);
+    expect(payload?.skipped).toBe(200);
+    expect(payload?.message).toBe(
+      'articles: 200 id(s) SKIPPED — eligibility lookup failed; 2 error(s) — ' +
+        'scanned 700, stale 21, deleted 13'
+    );
+    expect(String(payload?.message)).not.toContain('STOPPED EARLY');
+  });
+});
+
+describe('search-index-cleanup: an unreadable index is not filed as healthy', () => {
+  it('escalates on errors even when no document total could be read', async () => {
+    // The worst case: the engine could not serve the index, so BOTH the stats
+    // call and the settings call failed. There is no total to compare against,
+    // so a count-based verdict would call an index that was not cleaned at all
+    // healthy.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'users',
+        idsScanned: 0,
+        staleFound: 0,
+        deleted: 0,
+        totalInIndex: null,
+        errors: 1,
+        stoppedEarly: true,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const payload = payloadFor('users');
+    expect(payload?.type).toBe('error');
+    expect(payload?.total).toBe(null);
+    expect(payload?.message).toBe(
+      'users: scan STOPPED EARLY after 0 id(s) (index document count unavailable); ' +
+        '1 error(s) — scanned 0, stale 0, deleted 0'
+    );
+  });
+
+  it('does not invent a coverage verdict when the total is unknown but the scan finished', async () => {
+    // `getStats` can fail on its own while the scan itself runs fine. Coverage
+    // is then unknowable — the run must claim neither completeness nor
+    // truncation. This is what the `total === null` branch is FOR; without it
+    // the comparison silently becomes `scanned < 0`, which is never true.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'collections',
+        idsScanned: 4000,
+        staleFound: 8,
+        deleted: 3,
+        totalInIndex: null,
+        errors: 0,
+        stoppedEarly: false,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const payload = payloadFor('collections');
     expect(payload?.type).toBe('info');
     expect(payload?.incomplete).toBe(false);
-    expect(payload?.total).toBe(null);
+    expect(payload?.coverage).toBe(null);
+    expect(payload?.message).toBe('collections: scanned 4000, stale 8, deleted 3');
   });
 });
 
@@ -212,5 +378,37 @@ describe('search-index-cleanup: the requested scan batch', () => {
     const opts = cleanupAllIndexes.mock.calls[0][1] as { batch: number; apply: boolean };
     expect(opts.batch).toBe(10000);
     expect(opts.apply).toBe(true);
+  });
+});
+
+describe('search-index-cleanup: a failing log sink cannot leak an unhandled rejection', () => {
+  it('handles a rejected logToAxiom instead of passing it through', async () => {
+    // `.catch()` with NO argument is `then(undefined, undefined)` — a
+    // pass-through that leaves the rejection unhandled. Only `.catch(() => undefined)`
+    // actually swallows it. Nothing awaits these calls, so the observable is
+    // the process-level `unhandledRejection` event.
+    const seen: unknown[] = [];
+    const marker = new Error('axiom-down-marker');
+    const onUnhandled = (reason: unknown) => {
+      if (reason === marker) seen.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      logToAxiom.mockImplementation(() => Promise.reject(marker));
+      cleanupAllIndexes.mockResolvedValue([
+        stats({ key: 'tools', idsScanned: 5, staleFound: 2, deleted: 1, totalInIndex: 5 }),
+      ]);
+
+      await searchIndexCleanupJob.run({}).result;
+      // Let the microtask queue drain and give Node a macrotask turn, which is
+      // when it decides a rejection went unhandled.
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(seen).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+      // Restore the canonical default for the rest of the file.
+      logToAxiom.mockImplementation(() => Promise.resolve(undefined));
+    }
   });
 });

--- a/src/server/jobs/__tests__/search-index-cleanup.test.ts
+++ b/src/server/jobs/__tests__/search-index-cleanup.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The nightly search-index cleanup job used to emit NOTHING about what it did.
+ * `cleanupIndex` computed per-index scanned / stale / deleted / total counters
+ * and the job handed them back in its return value, but nothing logged them
+ * and the runner records only a duration — so a pass that covered a fraction
+ * of an index and then reported success was completely unobservable.
+ *
+ * These tests pin two things: the per-index stats reach the log sink at all,
+ * and an INCOMPLETE pass (`idsScanned < totalInIndex`) is loud rather than
+ * buried in a success line.
+ */
+
+const { cleanupAllIndexes, logToAxiom } = vi.hoisted(() => ({
+  cleanupAllIndexes: vi.fn(),
+  // Declare the payload parameter so `logToAxiom.mock.calls[n][0]` is typed as
+  // the payload rather than as an element of an empty tuple.
+  logToAxiom: vi.fn<(payload: Record<string, unknown>) => Promise<void>>(() =>
+    Promise.resolve()
+  ),
+}));
+
+vi.mock('~/server/meilisearch/cleanup', () => ({ cleanupAllIndexes }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom }));
+
+// ./job pulls in the Prisma client + prom registry at module load. Only the
+// invoke contract matters here.
+vi.mock('~/server/jobs/job', () => ({
+  createJob: (name: string, cron: string, fn: (ctx: unknown) => Promise<unknown>) => ({
+    name,
+    cron,
+    run: () => ({
+      result: fn({ status: 'running', on: () => undefined, checkIfCanceled: () => undefined }),
+      cancel: () => Promise.resolve(),
+    }),
+    options: {},
+  }),
+}));
+
+import { searchIndexCleanupJob } from '~/server/jobs/search-index-cleanup';
+
+type Stats = {
+  key: string;
+  indexName: string;
+  batchesProcessed: number;
+  idsScanned: number;
+  staleFound: number;
+  deleted: number;
+  totalInIndex: number | null;
+  errors: number;
+};
+
+function stats(over: Partial<Stats> & { key: string }): Stats {
+  return {
+    indexName: `${over.key}_v1`,
+    batchesProcessed: 1,
+    idsScanned: 0,
+    staleFound: 0,
+    deleted: 0,
+    totalInIndex: 0,
+    errors: 0,
+    ...over,
+  };
+}
+
+/** Every logToAxiom payload from the run, as plain objects. */
+function logged() {
+  return logToAxiom.mock.calls.map((c) => c[0]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  logToAxiom.mockImplementation(() => Promise.resolve());
+});
+
+describe('search-index-cleanup: per-index stats are logged', () => {
+  it('emits one payload per index carrying key, scanned, stale, deleted, errors and total', async () => {
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'models',
+        idsScanned: 800,
+        staleFound: 40,
+        deleted: 40,
+        totalInIndex: 800,
+        errors: 0,
+      }),
+      stats({
+        key: 'articles',
+        idsScanned: 250,
+        staleFound: 3,
+        deleted: 3,
+        totalInIndex: 250,
+        errors: 1,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const models = logged().find((p) => p.key === 'models');
+    const articles = logged().find((p) => p.key === 'articles');
+
+    expect(models).toMatchObject({
+      name: 'search-index-cleanup',
+      key: 'models',
+      scanned: 800,
+      stale: 40,
+      deleted: 40,
+      errors: 0,
+      total: 800,
+    });
+    expect(articles).toMatchObject({
+      name: 'search-index-cleanup',
+      key: 'articles',
+      scanned: 250,
+      stale: 3,
+      deleted: 3,
+      errors: 1,
+      total: 250,
+    });
+  });
+
+  it('INVARIANT GUARD (green on unfixed code): leaves the job return value unchanged', async () => {
+    // Not a regression test — the return value was already correct. It is
+    // pinned so the logging added alongside it cannot quietly change the
+    // HTTP response body the runner hands back.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({ key: 'tools', idsScanned: 12, staleFound: 2, deleted: 2, totalInIndex: 12 }),
+    ]);
+
+    const result = (await searchIndexCleanupJob.run({}).result) as {
+      indexes: Record<string, unknown>[];
+    };
+
+    expect(result).toEqual({
+      indexes: [{ key: 'tools', scanned: 12, stale: 2, deleted: 2, errors: 0, total: 12 }],
+    });
+  });
+});
+
+describe('search-index-cleanup: an incomplete pass is loud', () => {
+  it('logs a truncated scan at error level with BOTH the scanned and total counts', async () => {
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'users',
+        idsScanned: 4300000,
+        staleFound: 17346,
+        deleted: 17346,
+        totalInIndex: 11600000,
+        errors: 0,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const payload = logged().find((p) => p.key === 'users');
+    expect(payload?.type).toBe('error');
+    expect(payload?.incomplete).toBe(true);
+    expect(String(payload?.message)).toContain('INCOMPLETE SCAN');
+    expect(String(payload?.message)).toContain('4300000');
+    expect(String(payload?.message)).toContain('11600000');
+  });
+
+  it('does NOT flag a complete pass', async () => {
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'collections',
+        idsScanned: 500,
+        staleFound: 5,
+        deleted: 5,
+        totalInIndex: 500,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const payload = logged().find((p) => p.key === 'collections');
+    expect(payload?.type).toBe('info');
+    expect(payload?.incomplete).toBe(false);
+    expect(String(payload?.message)).not.toContain('INCOMPLETE');
+  });
+
+  it('does NOT flag a pass whose index total could not be read', async () => {
+    // `totalInIndex: null` means the stats call failed. Completeness is then
+    // unknowable, so the run must not assert either way.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({ key: 'bounties', idsScanned: 90, staleFound: 0, deleted: 0, totalInIndex: null }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const payload = logged().find((p) => p.key === 'bounties');
+    expect(payload?.type).toBe('info');
+    expect(payload?.incomplete).toBe(false);
+    expect(payload?.total).toBe(null);
+  });
+});
+
+describe('search-index-cleanup: the requested scan batch', () => {
+  it('asks for a page size large enough for a multi-million-document index', async () => {
+    cleanupAllIndexes.mockResolvedValue([]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    expect(cleanupAllIndexes).toHaveBeenCalledTimes(1);
+    const opts = cleanupAllIndexes.mock.calls[0][1] as { batch: number; apply: boolean };
+    expect(opts.batch).toBe(10000);
+    expect(opts.apply).toBe(true);
+  });
+});

--- a/src/server/jobs/__tests__/search-index-cleanup.test.ts
+++ b/src/server/jobs/__tests__/search-index-cleanup.test.ts
@@ -16,9 +16,7 @@ const { cleanupAllIndexes, logToAxiom } = vi.hoisted(() => ({
   cleanupAllIndexes: vi.fn(),
   // Declare the payload parameter so `logToAxiom.mock.calls[n][0]` is typed as
   // the payload rather than as an element of an empty tuple.
-  logToAxiom: vi.fn<(payload: Record<string, unknown>) => Promise<void>>(() =>
-    Promise.resolve()
-  ),
+  logToAxiom: vi.fn<(payload: Record<string, unknown>) => Promise<void>>(() => Promise.resolve()),
 }));
 
 vi.mock('~/server/meilisearch/cleanup', () => ({ cleanupAllIndexes }));

--- a/src/server/jobs/__tests__/search-index-cleanup.test.ts
+++ b/src/server/jobs/__tests__/search-index-cleanup.test.ts
@@ -12,15 +12,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * buried in a success line.
  */
 
-const { cleanupAllIndexes, logToAxiom } = vi.hoisted(() => ({
-  cleanupAllIndexes: vi.fn(),
-  // Declare the payload parameter so `logToAxiom.mock.calls[n][0]` is typed as
-  // the payload rather than as an element of an empty tuple.
-  logToAxiom: vi.fn<(payload: Record<string, unknown>) => Promise<void>>(() => Promise.resolve()),
-}));
+const { cleanupAllIndexes } = vi.hoisted(() => ({ cleanupAllIndexes: vi.fn() }));
 
 vi.mock('~/server/meilisearch/cleanup', () => ({ cleanupAllIndexes }));
-vi.mock('~/server/logging/client', () => ({ logToAxiom }));
+
+// `~/server/logging/client` is a CANONICAL shared-module mock: src/__tests__/setup.ts
+// registers it once, globally, spreading the real module and overriding only
+// `logToAxiom` with this stable spy. This file must NOT mock it itself — a per-file
+// spy pools its call counts across every file sharing a worker under `isolate: false`,
+// and a per-file factory freezes the module's export shape for the whole worker.
+// See docs/testing/shared-module-mocks.md.
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
+
+const logToAxiom = loggingMock.logToAxiom;
 
 // ./job pulls in the Prisma client + prom registry at module load. Only the
 // invoke contract matters here.
@@ -64,12 +68,16 @@ function stats(over: Partial<Stats> & { key: string }): Stats {
 
 /** Every logToAxiom payload from the run, as plain objects. */
 function logged() {
-  return logToAxiom.mock.calls.map((c) => c[0]);
+  return logToAxiom.mock.calls.map((c) => c[0] as Record<string, unknown>);
 }
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  logToAxiom.mockImplementation(() => Promise.resolve());
+  cleanupAllIndexes.mockReset();
+  // MUTATE the canonical node, never replace it. `mockClear` and not `mockReset`:
+  // the canonical mock's registered default is what makes `logToAxiom(...)` return
+  // a promise, and the job calls `.catch()` on it — a reset here would strip that
+  // default and every case would die on `.catch of undefined`.
+  logToAxiom.mockClear();
 });
 
 describe('search-index-cleanup: per-index stats are logged', () => {

--- a/src/server/jobs/search-index-cleanup.ts
+++ b/src/server/jobs/search-index-cleanup.ts
@@ -1,5 +1,5 @@
 import { createJob } from './job';
-import { cleanupAllIndexes } from '~/server/meilisearch/cleanup';
+import { CLEANUP_INDEXES, cleanupAllIndexes } from '~/server/meilisearch/cleanup';
 import { logToAxiom } from '~/server/logging/client';
 
 // Page size REQUESTED per keyset scan. `cleanupIndex` clamps this down to each
@@ -136,6 +136,31 @@ export const searchIndexCleanupJob = createJob(
         skipped: r.idsSkipped,
         rescuedByPrimary: r.rescuedByPrimary,
         indexingAtStart: r.indexingAtStart,
+      }).catch(() => undefined);
+    }
+
+    // An index the run never REACHED emits no per-index line at all, because
+    // `cleanupAllIndexes` stops iterating on cancellation and this loop only
+    // sees what came back. "We stopped at index 4 of 7" would otherwise be
+    // visible only by noticing four payloads instead of seven — and it is the
+    // one truncation mode in exactly the class this job's reporting exists for
+    // that `stoppedEarly` structurally CANNOT see, since a per-index flag
+    // cannot be set for an index that was never opened.
+    //
+    // It also got likelier with the fixes around it: full coverage plus a
+    // primary re-check per delete chunk makes every index strictly slower.
+    const attempted = new Set(results.map((r) => r.key));
+    const missed = CLEANUP_INDEXES.filter((c) => !attempted.has(c.key)).map((c) => c.key);
+    if (missed.length > 0) {
+      logToAxiom({
+        type: 'error',
+        name: 'search-index-cleanup',
+        message:
+          `run ENDED BEFORE ${missed.length} of ${CLEANUP_INDEXES.length} configured index(es) ` +
+          `were attempted: ${missed.join(', ')}`,
+        indexesConfigured: CLEANUP_INDEXES.length,
+        indexesAttempted: results.length,
+        indexesMissed: missed,
       }).catch(() => undefined);
     }
 

--- a/src/server/jobs/search-index-cleanup.ts
+++ b/src/server/jobs/search-index-cleanup.ts
@@ -2,13 +2,23 @@ import { createJob } from './job';
 import { cleanupAllIndexes } from '~/server/meilisearch/cleanup';
 import { logToAxiom } from '~/server/logging/client';
 
+// Page size REQUESTED per keyset scan. `cleanupIndex` clamps this down to each
+// index's own `pagination.maxTotalHits`, so asking for a large page is safe on
+// indexes that cannot serve it — they fall back to their own ceiling.
+//
+// It has to be large: a multi-million-document index at the old 1,000 needs
+// thousands of sequential round trips, and seven indexes' worth of that does
+// not fit in one nightly run. 10,000 matches `deleteChunkSize`, which is the
+// id-list size this code already sends to Postgres and to the engine.
+const SCAN_BATCH = 10000;
+
 export const searchIndexCleanupJob = createJob(
   'search-index-cleanup',
   '0 2 * * *',
   async (jobContext) => {
     const results = await cleanupAllIndexes(null, {
       apply: true,
-      batch: 1000,
+      batch: SCAN_BATCH,
       jobContext,
       onError: ({ key, offset, error }) => {
         // `offset === -1` is the sentinel for preflight or delete-phase
@@ -22,6 +32,35 @@ export const searchIndexCleanupJob = createJob(
         }).catch();
       },
     });
+
+    // Emit the per-index outcome. Until this existed the run's only observable
+    // was its duration, so a pass that covered a fraction of an index and
+    // deleted only the stale documents it happened to reach was indistinguish-
+    // able from a complete one — the shortfall had to be reconstructed from the
+    // engine's own task history after the fact.
+    for (const r of results) {
+      // `totalInIndex` is null when the stats call failed, in which case we
+      // cannot say whether the pass was complete — do not claim either way.
+      const incomplete = r.totalInIndex !== null && r.idsScanned < r.totalInIndex;
+      logToAxiom({
+        // An incomplete pass is a defect, not a statistic: it must not be
+        // filed under the same level as a healthy run, or it stays invisible.
+        type: incomplete ? 'error' : 'info',
+        name: 'search-index-cleanup',
+        message: incomplete
+          ? `INCOMPLETE SCAN: ${r.key} scanned ${r.idsScanned} of ${r.totalInIndex} documents — ` +
+            `the pass ended before reaching the end of the index, so stale documents past the ` +
+            `stopping point were not deleted`
+          : `${r.key}: scanned ${r.idsScanned}, stale ${r.staleFound}, deleted ${r.deleted}`,
+        key: r.key,
+        scanned: r.idsScanned,
+        stale: r.staleFound,
+        deleted: r.deleted,
+        errors: r.errors,
+        total: r.totalInIndex,
+        incomplete,
+      }).catch();
+    }
 
     return {
       indexes: results.map((r) => ({

--- a/src/server/jobs/search-index-cleanup.ts
+++ b/src/server/jobs/search-index-cleanup.ts
@@ -8,9 +8,33 @@ import { logToAxiom } from '~/server/logging/client';
 //
 // It has to be large: a multi-million-document index at the old 1,000 needs
 // thousands of sequential round trips, and seven indexes' worth of that does
-// not fit in one nightly run. 10,000 matches `deleteChunkSize`, which is the
-// id-list size this code already sends to Postgres and to the engine.
+// not fit in one nightly run.
+//
+// What bounds it from above is that this same number is the length of the
+// `id IN (...)` list handed to Postgres once per page, in `fetchValidIds`.
+// (It is NOT bounded by `deleteChunkSize`, which sizes only the delete calls
+// made against the search engine and applies to the far smaller stale set.)
 const SCAN_BATCH = 10000;
+
+/**
+ * How far `idsScanned` may fall short of the pre-scan document count before the
+ * run is called incomplete on the counts alone.
+ *
+ * A shortfall is NORMAL: `totalInIndex` is a snapshot taken before a scan that
+ * then runs for a long time, and a separate cleanup job issues delete-by-filter
+ * against most of these indexes every five minutes, so documents legitimately
+ * disappear from under the cursor. The authoritative truncation signal is
+ * `stoppedEarly` — a fact about how the loop exited, immune to that drift —
+ * and this band is only the backstop for "the loop claimed to finish but
+ * covered implausibly little".
+ *
+ * The band is a judgement, not a measurement, and it is deliberately loose:
+ * the real incident it has to catch was a 63% shortfall. Every run logs
+ * `scanned`, `total` and `coverage`, so it can be re-derived from data rather
+ * than re-guessed.
+ */
+const COVERAGE_SHORTFALL_RATIO = 0.25;
+const COVERAGE_SHORTFALL_FLOOR = 1000;
 
 export const searchIndexCleanupJob = createJob(
   'search-index-cleanup',
@@ -29,7 +53,10 @@ export const searchIndexCleanupJob = createJob(
           type: 'error',
           name: 'search-index-cleanup',
           message: `error in ${key} (${phase}): ${error.message}`,
-        }).catch();
+          // `.catch(() => undefined)` and NOT a bare `.catch()`: `catch(undefined)` is
+          // `then(undefined, undefined)`, a pass-through that leaves the
+          // rejection unhandled. A bare one swallows nothing.
+        }).catch(() => undefined);
       },
     });
 
@@ -39,27 +66,77 @@ export const searchIndexCleanupJob = createJob(
     // able from a complete one — the shortfall had to be reconstructed from the
     // engine's own task history after the fact.
     for (const r of results) {
-      // `totalInIndex` is null when the stats call failed, in which case we
-      // cannot say whether the pass was complete — do not claim either way.
-      const incomplete = r.totalInIndex !== null && r.idsScanned < r.totalInIndex;
+      // Three INDEPENDENT facts, kept independent because each has a different
+      // cause and a different fix, and because a message that asserts the wrong
+      // one is worse than a message that just reports numbers.
+      //
+      //  - stoppedEarly: the loop exited without reaching a confirmed end of
+      //    the index. Authoritative, and the reason a scanned-vs-total
+      //    comparison is not the primary signal.
+      //  - idsSkipped: ids fetched but never judged, because their eligibility
+      //    lookup failed. The cursor advanced past them, so this can be
+      //    non-zero on a scan that DID reach the end.
+      //  - lowCoverage: the loop finished, but covered implausibly little.
+      const coverage = r.totalInIndex && r.totalInIndex > 0 ? r.idsScanned / r.totalInIndex : null;
+      const shortfall = r.totalInIndex === null ? null : r.totalInIndex - r.idsScanned;
+      const lowCoverage =
+        !r.stoppedEarly &&
+        shortfall !== null &&
+        // A count taken while the engine was mid-ingest is a moving number, so
+        // a shortfall against it is not evidence of anything.
+        r.indexingAtStart !== true &&
+        shortfall > COVERAGE_SHORTFALL_FLOOR &&
+        shortfall > (r.totalInIndex as number) * COVERAGE_SHORTFALL_RATIO;
+
+      const incomplete = r.stoppedEarly || lowCoverage;
+      // `errors > 0` escalates on its own. The case that forces this: an index
+      // the engine cannot serve at all fails BOTH `getStats` and `getSettings`,
+      // so `totalInIndex` stays null and no coverage comparison is possible —
+      // an index that was not cleaned at all would otherwise be filed as a
+      // healthy `info` line.
+      const level = incomplete || r.errors > 0 ? 'error' : 'info';
+
+      const problems: string[] = [];
+      if (r.stoppedEarly) {
+        problems.push(
+          `scan STOPPED EARLY after ${r.idsScanned} id(s)` +
+            (r.totalInIndex === null
+              ? ' (index document count unavailable)'
+              : ` of ${r.totalInIndex} at the start of the run`)
+        );
+      } else if (lowCoverage) {
+        problems.push(
+          `scan reached the end of the index but covered only ${r.idsScanned} of ` +
+            `${r.totalInIndex} document(s)`
+        );
+      }
+      if (r.idsSkipped > 0) {
+        problems.push(`${r.idsSkipped} id(s) SKIPPED — eligibility lookup failed`);
+      }
+      if (r.errors > 0) problems.push(`${r.errors} error(s)`);
+
       logToAxiom({
-        // An incomplete pass is a defect, not a statistic: it must not be
-        // filed under the same level as a healthy run, or it stays invisible.
-        type: incomplete ? 'error' : 'info',
+        type: level,
         name: 'search-index-cleanup',
-        message: incomplete
-          ? `INCOMPLETE SCAN: ${r.key} scanned ${r.idsScanned} of ${r.totalInIndex} documents — ` +
-            `the pass ended before reaching the end of the index, so stale documents past the ` +
-            `stopping point were not deleted`
-          : `${r.key}: scanned ${r.idsScanned}, stale ${r.staleFound}, deleted ${r.deleted}`,
+        message:
+          problems.length > 0
+            ? `${r.key}: ${problems.join('; ')} — scanned ${r.idsScanned}, stale ${
+                r.staleFound
+              }, deleted ${r.deleted}`
+            : `${r.key}: scanned ${r.idsScanned}, stale ${r.staleFound}, deleted ${r.deleted}`,
         key: r.key,
         scanned: r.idsScanned,
         stale: r.staleFound,
         deleted: r.deleted,
         errors: r.errors,
         total: r.totalInIndex,
+        coverage,
         incomplete,
-      }).catch();
+        stoppedEarly: r.stoppedEarly,
+        skipped: r.idsSkipped,
+        rescuedByPrimary: r.rescuedByPrimary,
+        indexingAtStart: r.indexingAtStart,
+      }).catch(() => undefined);
     }
 
     return {

--- a/src/server/meilisearch/__tests__/cleanup.test.ts
+++ b/src/server/meilisearch/__tests__/cleanup.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression coverage for the `cleanupIndex` keyset scan loop.
+ *
+ * The loop used to end a scan on two signals that do not mean "end of index":
+ *
+ *  (b) a SHORT page — fewer hits than the requested `limit`. The engine caps a
+ *      page at the index's own `pagination.maxTotalHits`, and may return fewer
+ *      for reasons of its own, so "short" and "done" are different statements.
+ *  (c) the FIRST empty page — which the engine can also produce transiently
+ *      while it is concurrently applying document additions/deletions.
+ *
+ * Either one ends the scan mid-index while the run reports success, so the
+ * stale documents past the stopping point are never deleted. A third defect
+ * (a) sits alongside them: the requested page size was never clamped to the
+ * index's real ceiling, so raising it truncated pages instead of speeding the
+ * scan up — and, combined with (b), ended the scan after a single page.
+ *
+ * Every expectation below is a literal page sequence / count written from the
+ * fixture, never read back off the implementation.
+ */
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+// `$queryRaw` answers "which of these ids are still valid?". Returning an
+// empty row set means every scanned id counts as stale, which makes
+// `staleFound` equal `idsScanned` and gives the tests a second, independent
+// witness of how far the scan actually got.
+const { queryRaw } = vi.hoisted(() => ({ queryRaw: vi.fn(async () => [] as { id: number }[]) }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: queryRaw },
+  dbWrite: { $queryRaw: queryRaw },
+}));
+
+// The index handle the scan drives. Swapped per test via `setFakeIndex`.
+const { indexHolder } = vi.hoisted(() => ({ indexHolder: { current: null as unknown } }));
+vi.mock('~/server/meilisearch/client', () => ({
+  searchClient: { index: () => indexHolder.current },
+  metricsSearchClient: { index: () => indexHolder.current },
+}));
+
+import { CLEANUP_INDEXES, cleanupIndex } from '~/server/meilisearch/cleanup';
+
+// ─── Fake index ─────────────────────────────────────────────────────────────
+
+type SearchParams = { filter: string; limit: number; sort?: string[] };
+
+/**
+ * A stand-in for one Meilisearch index.
+ *
+ * `docs` is the full ascending contents. A search is answered by walking past
+ * the `id > N` cursor in the filter, then truncating to the smallest of:
+ *   - the `limit` the caller asked for,
+ *   - `maxTotalHits` (the engine's real per-index page ceiling),
+ *   - `pageCap` (an extra, deliberately-short page, to model an engine that
+ *     simply returns fewer than asked for).
+ *
+ * `emptyOnCalls` forces specific 1-based search calls to answer with an empty
+ * page regardless of contents — the transient-empty case.
+ */
+function makeFakeIndex(opts: {
+  docs: number[];
+  pageCap?: number;
+  maxTotalHits?: number | null;
+  emptyOnCalls?: number[];
+}) {
+  const searchCalls: { filter: string; limit: number }[] = [];
+  const deleted: number[][] = [];
+  let calls = 0;
+
+  const index = {
+    getStats: async () => ({ numberOfDocuments: opts.docs.length }),
+    getSettings: async () => ({
+      filterableAttributes: ['id'],
+      sortableAttributes: ['id'],
+      ...(opts.maxTotalHits === undefined
+        ? {}
+        : { pagination: { maxTotalHits: opts.maxTotalHits } }),
+    }),
+    search: async (_q: string, params: SearchParams) => {
+      calls += 1;
+      searchCalls.push({ filter: params.filter, limit: params.limit });
+      if (opts.emptyOnCalls?.includes(calls)) return { hits: [] as { id: number }[] };
+      const match = /^id > (-?\d+)$/.exec(params.filter);
+      if (!match) throw new Error(`unexpected filter: ${params.filter}`);
+      const cursor = Number(match[1]);
+      const cap = Math.min(
+        params.limit,
+        opts.maxTotalHits ?? Number.POSITIVE_INFINITY,
+        opts.pageCap ?? Number.POSITIVE_INFINITY
+      );
+      const hits = opts.docs
+        .filter((d) => d > cursor)
+        .slice(0, cap)
+        .map((id) => ({ id }));
+      return { hits };
+    },
+    deleteDocuments: async (ids: number[]) => {
+      deleted.push([...ids]);
+      return { taskUid: 1 };
+    },
+  };
+
+  return { index, searchCalls, deleted };
+}
+
+function setFakeIndex(fake: { index: unknown }) {
+  indexHolder.current = fake.index;
+}
+
+// A real config, so the scan runs the production Prisma predicate rather than
+// a hand-written stand-in.
+const modelsCfg = CLEANUP_INDEXES.find((c) => c.key === 'models');
+if (!modelsCfg) throw new Error('models cleanup config missing');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryRaw.mockImplementation(async () => []);
+});
+
+// ─── (b) a short page is not the end of the index ───────────────────────────
+
+describe('cleanupIndex: a SHORT page does not end the scan', () => {
+  it('reaches the last document when every page comes back shorter than the requested batch', async () => {
+    // 10 documents, batch of 10 requested, but the engine only ever hands back
+    // 3 per page. Pre-fix, page 1 (3 hits < batch 10) ended the scan and the
+    // remaining 7 documents were never examined.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], pageCap: 3 });
+    setFakeIndex(fake);
+
+    const stats = await cleanupIndex(modelsCfg, { apply: false, batch: 10 });
+
+    expect(stats.idsScanned).toBe(10);
+    expect(stats.staleFound).toBe(10);
+    expect(stats.batchesProcessed).toBe(4);
+    expect(stats.totalInIndex).toBe(10);
+    expect(stats.errors).toBe(0);
+
+    // Literal cursor walk: four content pages, then an empty page and its
+    // confirmation at the same cursor.
+    expect(fake.searchCalls.map((c) => c.filter)).toEqual([
+      'id > -1',
+      'id > 3',
+      'id > 6',
+      'id > 9',
+      'id > 10',
+      'id > 10',
+    ]);
+  });
+});
+
+// ─── (c) one empty page is not the end of the index ─────────────────────────
+
+describe('cleanupIndex: a single empty page does not end the scan', () => {
+  it('continues past a transient empty page and still scans every document', async () => {
+    // 6 documents at a batch of 2, so every content page is FULL — this test
+    // is isolated from the short-page defect. Search call #2 answers empty
+    // even though ids 3..6 are still ahead of the cursor. Pre-fix that ended
+    // the scan at 2 of 6 documents and the run reported success.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6], emptyOnCalls: [2] });
+    setFakeIndex(fake);
+
+    const stats = await cleanupIndex(modelsCfg, { apply: false, batch: 2 });
+
+    expect(stats.idsScanned).toBe(6);
+    expect(stats.staleFound).toBe(6);
+    expect(stats.batchesProcessed).toBe(3);
+    expect(stats.errors).toBe(0);
+
+    // Call 2 is the transient empty; call 3 re-asks the SAME cursor and gets
+    // rows, so the scan carries on. Calls 5 and 6 are the genuine end.
+    expect(fake.searchCalls.map((c) => c.filter)).toEqual([
+      'id > -1',
+      'id > 2',
+      'id > 2',
+      'id > 4',
+      'id > 6',
+      'id > 6',
+    ]);
+  });
+
+  it('ends the scan when the empty page is confirmed empty (two in a row)', async () => {
+    // Guards the other direction: the confirmation must not turn the
+    // terminator into an infinite loop. 3 documents, batch 3.
+    const fake = makeFakeIndex({ docs: [1, 2, 3] });
+    setFakeIndex(fake);
+
+    const stats = await cleanupIndex(modelsCfg, { apply: false, batch: 3 });
+
+    expect(stats.idsScanned).toBe(3);
+    expect(stats.batchesProcessed).toBe(1);
+    expect(fake.searchCalls.map((c) => c.filter)).toEqual(['id > -1', 'id > 3', 'id > 3']);
+  });
+});
+
+// ─── (a) the batch is clamped to the index's own ceiling ────────────────────
+
+describe('cleanupIndex: the effective batch is clamped to pagination.maxTotalHits', () => {
+  it('clamps a requested batch above the index ceiling and still completes the scan', async () => {
+    // The index will not serve a page larger than 5. Asking for 1000 pre-fix
+    // meant every page came back at 5 — short — and the scan stopped after
+    // one page with 7 of the 12 documents unexamined.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], maxTotalHits: 5 });
+    setFakeIndex(fake);
+
+    const stats = await cleanupIndex(modelsCfg, { apply: false, batch: 1000 });
+
+    expect(stats.idsScanned).toBe(12);
+    expect(stats.batchesProcessed).toBe(3);
+    expect(stats.errors).toBe(0);
+
+    // Every request asks for the ceiling, not the (unservable) 1000.
+    expect(fake.searchCalls.map((c) => c.limit)).toEqual([5, 5, 5, 5, 5]);
+    expect(fake.searchCalls.map((c) => c.filter)).toEqual([
+      'id > -1',
+      'id > 5',
+      'id > 10',
+      'id > 12',
+      'id > 12',
+    ]);
+  });
+
+  it('INVARIANT GUARD (green on unfixed code): a ceiling above the requested batch does not raise it', async () => {
+    // Not a regression test — the pre-change code also sent limit 2 here,
+    // because it never read the ceiling at all. Kept to pin the clamp as a
+    // MINIMUM rather than an assignment.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4], maxTotalHits: 100000 });
+    setFakeIndex(fake);
+
+    const stats = await cleanupIndex(modelsCfg, { apply: false, batch: 2 });
+
+    expect(fake.searchCalls.every((c) => c.limit === 2)).toBe(true);
+    expect(stats.idsScanned).toBe(4);
+  });
+});

--- a/src/server/meilisearch/__tests__/cleanup.test.ts
+++ b/src/server/meilisearch/__tests__/cleanup.test.ts
@@ -23,24 +23,33 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
+// The index handle the scan drives. Swapped per test via `setFakeIndex`.
+// Spreads the original so every other export of the client module stays real —
+// only the `searchClient` seam is replaced.
+const { indexHolder } = vi.hoisted(() => ({ indexHolder: { current: null as unknown } }));
+vi.mock('~/server/meilisearch/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof MeiliClient>()),
+  searchClient: { index: () => indexHolder.current },
+}));
+
+import type * as MeiliClient from '~/server/meilisearch/client';
+// `~/server/db/client` is a CANONICAL shared-module mock: it is registered once,
+// globally, in src/__tests__/setup.ts and reset per test file. This file must not
+// mock it itself — a per-file mock object freezes that file's shape for every
+// later file that shares the worker. See docs/testing/shared-module-mocks.md.
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+import { CLEANUP_INDEXES, cleanupIndex } from '~/server/meilisearch/cleanup';
+
 // `$queryRaw` answers "which of these ids are still valid?". Returning an
 // empty row set means every scanned id counts as stale, which makes
 // `staleFound` equal `idsScanned` and gives the tests a second, independent
 // witness of how far the scan actually got.
-const { queryRaw } = vi.hoisted(() => ({ queryRaw: vi.fn(async () => [] as { id: number }[]) }));
-vi.mock('~/server/db/client', () => ({
-  dbRead: { $queryRaw: queryRaw },
-  dbWrite: { $queryRaw: queryRaw },
-}));
-
-// The index handle the scan drives. Swapped per test via `setFakeIndex`.
-const { indexHolder } = vi.hoisted(() => ({ indexHolder: { current: null as unknown } }));
-vi.mock('~/server/meilisearch/client', () => ({
-  searchClient: { index: () => indexHolder.current },
-  metricsSearchClient: { index: () => indexHolder.current },
-}));
-
-import { CLEANUP_INDEXES, cleanupIndex } from '~/server/meilisearch/cleanup';
+//
+// The scan reads through `dbRead` only. `dbRead` and `dbWrite` are DISTINCT
+// nodes in the canonical mock, so naming the wrong one here would silently
+// assert nothing.
+const queryRaw = dbMock.dbRead.$queryRaw;
 
 // ─── Fake index ─────────────────────────────────────────────────────────────
 
@@ -115,8 +124,12 @@ const modelsCfg = CLEANUP_INDEXES.find((c) => c.key === 'models');
 if (!modelsCfg) throw new Error('models cleanup config missing');
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  queryRaw.mockImplementation(async () => []);
+  // MUTATE the canonical node, never replace it: consumer modules captured this
+  // exact function identity when they were first evaluated and will not re-read
+  // it. `mockClear` drops call history but keeps the implementation, which is
+  // why it is used here in place of `mockReset`.
+  queryRaw.mockClear();
+  queryRaw.mockResolvedValue([]);
 });
 
 // ─── (b) a short page is not the end of the index ───────────────────────────

--- a/src/server/meilisearch/__tests__/cleanup.test.ts
+++ b/src/server/meilisearch/__tests__/cleanup.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * Regression coverage for the `cleanupIndex` keyset scan loop.
+ * Regression coverage for `cleanupIndex`: the keyset scan loop, and the delete
+ * path it feeds.
  *
  * The loop used to end a scan on two signals that do not mean "end of index":
  *
@@ -11,14 +12,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  *  (c) the FIRST empty page — which the engine can also produce transiently
  *      while it is concurrently applying document additions/deletions.
  *
- * Either one ends the scan mid-index while the run reports success, so the
- * stale documents past the stopping point are never deleted. A third defect
- * (a) sits alongside them: the requested page size was never clamped to the
- * index's real ceiling, so raising it truncated pages instead of speeding the
- * scan up — and, combined with (b), ended the scan after a single page.
+ * Either one ends the scan mid-index while the run reports success. A third
+ * defect (a) sits alongside them: the requested page size was never clamped to
+ * the index's real ceiling.
  *
- * Every expectation below is a literal page sequence / count written from the
- * fixture, never read back off the implementation.
+ * Making the scan run to the end then created two hazards of its own, and the
+ * `apply: true` suites below exist for those:
+ *
+ *  (d) deletions used to be accumulated for the WHOLE index and flushed only
+ *      after the scan, so a cancelled run deleted NOTHING — strictly worse than
+ *      the truncated behaviour it replaced.
+ *  (e) eligibility is judged from a read replica, and a scan that now reaches
+ *      the freshly-written high-id tail can call an unreplicated row stale and
+ *      delete a live document.
+ *
+ * Every expectation below is a literal page/chunk sequence or count written
+ * from the fixture, never read back off the implementation.
  */
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
@@ -41,15 +50,17 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
 
 import { CLEANUP_INDEXES, cleanupIndex } from '~/server/meilisearch/cleanup';
 
-// `$queryRaw` answers "which of these ids are still valid?". Returning an
-// empty row set means every scanned id counts as stale, which makes
-// `staleFound` equal `idsScanned` and gives the tests a second, independent
-// witness of how far the scan actually got.
-//
-// The scan reads through `dbRead` only. `dbRead` and `dbWrite` are DISTINCT
-// nodes in the canonical mock, so naming the wrong one here would silently
-// assert nothing.
-const queryRaw = dbMock.dbRead.$queryRaw;
+// The two eligibility lookups the code makes, and they are DIFFERENT questions:
+//   dbRead  — the cheap filter run over every scanned page.
+//   dbWrite — the primary, re-asked over the small stale set immediately before
+//             deleting, so replication lag cannot delete a live document.
+// `dbRead` and `dbWrite` are distinct nodes in the canonical mock, so naming
+// the wrong one silently asserts nothing. Each returns the rows that ARE still
+// eligible; anything scanned and absent from that answer is stale.
+const readQuery = dbMock.dbRead.$queryRaw;
+const writeQuery = dbMock.dbWrite.$queryRaw;
+
+const rows = (ids: number[]) => ids.map((id) => ({ id }));
 
 // ─── Fake index ─────────────────────────────────────────────────────────────
 
@@ -66,20 +77,33 @@ type SearchParams = { filter: string; limit: number; sort?: string[] };
  *     simply returns fewer than asked for).
  *
  * `emptyOnCalls` forces specific 1-based search calls to answer with an empty
- * page regardless of contents — the transient-empty case.
+ * page regardless of contents — the transient-empty case. `frozenPage` ignores
+ * the cursor entirely and always answers with the same ids, which is the
+ * non-advancing-cursor case the monotonicity guard exists for.
  */
 function makeFakeIndex(opts: {
   docs: number[];
   pageCap?: number;
   maxTotalHits?: number | null;
   emptyOnCalls?: number[];
+  frozenPage?: number[];
+  isIndexing?: boolean;
+  onSearch?: (call: number) => void;
 }) {
   const searchCalls: { filter: string; limit: number }[] = [];
   const deleted: number[][] = [];
+  // How many searches had been issued at the moment each delete was made. This
+  // is what distinguishes "deleted while scanning" from "deleted after the
+  // scan": the CHUNK LIST alone cannot, because accumulating everything and
+  // then chunking produces exactly the same chunks in the same order.
+  const deletedAfterSearches: number[] = [];
   let calls = 0;
 
   const index = {
-    getStats: async () => ({ numberOfDocuments: opts.docs.length }),
+    getStats: async () => ({
+      numberOfDocuments: opts.docs.length,
+      isIndexing: opts.isIndexing ?? false,
+    }),
     getSettings: async () => ({
       filterableAttributes: ['id'],
       sortableAttributes: ['id'],
@@ -90,6 +114,8 @@ function makeFakeIndex(opts: {
     search: async (_q: string, params: SearchParams) => {
       calls += 1;
       searchCalls.push({ filter: params.filter, limit: params.limit });
+      opts.onSearch?.(calls);
+      if (opts.frozenPage) return { hits: rows(opts.frozenPage) };
       if (opts.emptyOnCalls?.includes(calls)) return { hits: [] as { id: number }[] };
       const match = /^id > (-?\d+)$/.exec(params.filter);
       if (!match) throw new Error(`unexpected filter: ${params.filter}`);
@@ -99,23 +125,32 @@ function makeFakeIndex(opts: {
         opts.maxTotalHits ?? Number.POSITIVE_INFINITY,
         opts.pageCap ?? Number.POSITIVE_INFINITY
       );
-      const hits = opts.docs
-        .filter((d) => d > cursor)
-        .slice(0, cap)
-        .map((id) => ({ id }));
-      return { hits };
+      return { hits: rows(opts.docs.filter((d) => d > cursor).slice(0, cap)) };
     },
     deleteDocuments: async (ids: number[]) => {
       deleted.push([...ids]);
+      deletedAfterSearches.push(calls);
       return { taskUid: 1 };
     },
   };
 
-  return { index, searchCalls, deleted };
+  return { index, searchCalls, deleted, deletedAfterSearches };
 }
 
 function setFakeIndex(fake: { index: unknown }) {
   indexHolder.current = fake.index;
+}
+
+/** A JobContext whose status the test can flip, matching `createJob`'s contract. */
+function makeJobContext() {
+  const ctx = {
+    status: 'running' as 'running' | 'canceled' | 'finished',
+    on: () => undefined,
+    checkIfCanceled: () => {
+      if (ctx.status !== 'running') throw new Error('Job has ended');
+    },
+  };
+  return ctx;
 }
 
 // A real config, so the scan runs the production Prisma predicate rather than
@@ -124,12 +159,17 @@ const modelsCfg = CLEANUP_INDEXES.find((c) => c.key === 'models');
 if (!modelsCfg) throw new Error('models cleanup config missing');
 
 beforeEach(() => {
-  // MUTATE the canonical node, never replace it: consumer modules captured this
-  // exact function identity when they were first evaluated and will not re-read
-  // it. `mockClear` drops call history but keeps the implementation, which is
-  // why it is used here in place of `mockReset`.
-  queryRaw.mockClear();
-  queryRaw.mockResolvedValue([]);
+  // MUTATE the canonical nodes, never replace them: consumer modules captured
+  // these exact function identities when they were first evaluated and will not
+  // re-read them. `mockClear` drops call history but keeps the implementation,
+  // which is why it is used here in place of `mockReset`.
+  readQuery.mockClear();
+  writeQuery.mockClear();
+  // Default for the scan suites: nothing is eligible, so every scanned id is
+  // stale. That makes `staleFound` equal `idsScanned` and gives those tests a
+  // second, independent witness of how far the scan got.
+  readQuery.mockResolvedValue([]);
+  writeQuery.mockResolvedValue([]);
 });
 
 // ─── (b) a short page is not the end of the index ───────────────────────────
@@ -149,6 +189,7 @@ describe('cleanupIndex: a SHORT page does not end the scan', () => {
     expect(stats.batchesProcessed).toBe(4);
     expect(stats.totalInIndex).toBe(10);
     expect(stats.errors).toBe(0);
+    expect(stats.stoppedEarly).toBe(false);
 
     // Literal cursor walk: four content pages, then an empty page and its
     // confirmation at the same cursor.
@@ -180,6 +221,7 @@ describe('cleanupIndex: a single empty page does not end the scan', () => {
     expect(stats.staleFound).toBe(6);
     expect(stats.batchesProcessed).toBe(3);
     expect(stats.errors).toBe(0);
+    expect(stats.stoppedEarly).toBe(false);
 
     // Call 2 is the transient empty; call 3 re-asks the SAME cursor and gets
     // rows, so the scan carries on. Calls 5 and 6 are the genuine end.
@@ -203,6 +245,7 @@ describe('cleanupIndex: a single empty page does not end the scan', () => {
 
     expect(stats.idsScanned).toBe(3);
     expect(stats.batchesProcessed).toBe(1);
+    expect(stats.stoppedEarly).toBe(false);
     expect(fake.searchCalls.map((c) => c.filter)).toEqual(['id > -1', 'id > 3', 'id > 3']);
   });
 });
@@ -245,5 +288,222 @@ describe('cleanupIndex: the effective batch is clamped to pagination.maxTotalHit
 
     expect(fake.searchCalls.every((c) => c.limit === 2)).toBe(true);
     expect(stats.idsScanned).toBe(4);
+  });
+});
+
+// ─── a failed eligibility lookup skips a batch without ending the scan ──────
+
+describe('cleanupIndex: a batch whose eligibility lookup fails is SKIPPED, not fatal', () => {
+  it('counts the skipped ids, advances past them, and still reaches the end of the index', async () => {
+    // The distinction the job's log depends on: the cursor advances past a
+    // batch whose lookup failed, so the scan CAN reach the end of the index
+    // having skipped some ids. "Stopped early" and "skipped a batch" are
+    // therefore different facts and must be counted separately.
+    //
+    // Three consecutive rejections exhaust the retry envelope for page 1.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6] });
+    setFakeIndex(fake);
+    readQuery
+      .mockRejectedValueOnce(new Error('replica blip'))
+      .mockRejectedValueOnce(new Error('replica blip'))
+      .mockRejectedValueOnce(new Error('replica blip'))
+      .mockResolvedValue([]);
+
+    const stats = await cleanupIndex(modelsCfg, { apply: false, batch: 3 });
+
+    // Page 1 (ids 1-3) was fetched but never judged; page 2 (ids 4-6) was.
+    expect(stats.idsSkipped).toBe(3);
+    expect(stats.idsScanned).toBe(3);
+    expect(stats.staleFound).toBe(3);
+    expect(stats.batchesProcessed).toBe(1);
+    expect(stats.errors).toBe(1);
+    // The whole point: the scan did NOT stop early.
+    expect(stats.stoppedEarly).toBe(false);
+    expect(fake.searchCalls.map((c) => c.filter)).toEqual([
+      'id > -1',
+      'id > 3',
+      'id > 6',
+      'id > 6',
+    ]);
+  });
+});
+
+// ─── the index's own indexing state is carried through ──────────────────────
+
+describe('cleanupIndex: isIndexing is reported, not assumed', () => {
+  it('carries the engine-reported indexing state into the stats', async () => {
+    // The job suppresses its coverage verdict when the count was taken
+    // mid-ingest, so this flag has to be the engine's answer rather than a
+    // constant.
+    const busy = makeFakeIndex({ docs: [1, 2], isIndexing: true });
+    setFakeIndex(busy);
+    expect((await cleanupIndex(modelsCfg, { apply: false, batch: 2 })).indexingAtStart).toBe(true);
+
+    const idle = makeFakeIndex({ docs: [1, 2], isIndexing: false });
+    setFakeIndex(idle);
+    expect((await cleanupIndex(modelsCfg, { apply: false, batch: 2 })).indexingAtStart).toBe(false);
+  });
+});
+
+// ─── the cursor must strictly advance ───────────────────────────────────────
+
+describe('cleanupIndex: the cursor must strictly advance', () => {
+  it('aborts with an error instead of spinning when a page does not advance the cursor', async () => {
+    // `frozenPage` ignores the filter and answers [7] forever. Termination now
+    // rests entirely on the cursor, so without the guard this re-issues the
+    // identical query until `maxBatches` — which is Infinity from the cron.
+    // `maxBatches` is set here ONLY so the unguarded behaviour fails an
+    // assertion quickly instead of hanging the suite for the whole timeout.
+    const fake = makeFakeIndex({ docs: [7], frozenPage: [7] });
+    setFakeIndex(fake);
+
+    const stats = await cleanupIndex(modelsCfg, { apply: false, batch: 5, maxBatches: 50 });
+
+    // Batch 1 is judged (cursor -1 → 7 advances). Batch 2 returns 7 again, so
+    // the guard fires and the scan stops.
+    expect(stats.batchesProcessed).toBe(1);
+    expect(stats.idsScanned).toBe(1);
+    expect(stats.errors).toBe(1);
+    expect(stats.stoppedEarly).toBe(true);
+    expect(fake.searchCalls.map((c) => c.filter)).toEqual(['id > -1', 'id > 7']);
+  });
+});
+
+// ─── the delete path: only stale ids, and only what the PRIMARY confirms ────
+
+describe('cleanupIndex: only stale documents are deleted', () => {
+  it('deletes exactly the ineligible ids and leaves every eligible one alone', async () => {
+    // 10 documents; the even ones are still eligible. Nothing about the
+    // fixture makes stale == scanned, so a mutation that marks every scanned
+    // document for deletion changes the observed delete list.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
+    setFakeIndex(fake);
+    readQuery.mockResolvedValue(rows([2, 4, 6, 8, 10]));
+    writeQuery.mockResolvedValue(rows([2, 4, 6, 8, 10]));
+
+    const stats = await cleanupIndex(modelsCfg, { apply: true, batch: 10 });
+
+    expect(fake.deleted).toEqual([[1, 3, 5, 7, 9]]);
+    expect(stats.idsScanned).toBe(10);
+    expect(stats.staleFound).toBe(5);
+    expect(stats.deleted).toBe(5);
+    expect(stats.rescuedByPrimary).toBe(0);
+    expect(stats.errors).toBe(0);
+
+    // Stated separately and positively: no eligible id was passed to a delete.
+    const everyDeletedId = fake.deleted.flat();
+    for (const eligible of [2, 4, 6, 8, 10]) expect(everyDeletedId).not.toContain(eligible);
+  });
+
+  it('does not delete an id the PRIMARY still says is eligible (replication lag)', async () => {
+    // The replica has not caught up on 3 and 4, so it reports them ineligible.
+    // The primary knows better. Only 1 and 2 may be deleted.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6] });
+    setFakeIndex(fake);
+    readQuery.mockResolvedValue(rows([5, 6]));
+    writeQuery.mockResolvedValue(rows([3, 4, 5, 6]));
+
+    const stats = await cleanupIndex(modelsCfg, { apply: true, batch: 6 });
+
+    expect(fake.deleted).toEqual([[1, 2]]);
+    expect(stats.staleFound).toBe(4);
+    expect(stats.deleted).toBe(2);
+    expect(stats.rescuedByPrimary).toBe(2);
+    const everyDeletedId = fake.deleted.flat();
+    expect(everyDeletedId).not.toContain(3);
+    expect(everyDeletedId).not.toContain(4);
+  });
+
+  it('deletes NOTHING when the primary re-check cannot be completed', async () => {
+    // The safe failure direction: an undeleted stale document is picked up by
+    // the next run; a wrongly deleted live one is not.
+    const fake = makeFakeIndex({ docs: [1, 2, 3] });
+    setFakeIndex(fake);
+    readQuery.mockResolvedValue([]);
+    writeQuery.mockRejectedValue(new Error('primary unreachable'));
+
+    const stats = await cleanupIndex(modelsCfg, { apply: true, batch: 3 });
+
+    expect(fake.deleted).toEqual([]);
+    expect(stats.deleted).toBe(0);
+    expect(stats.staleFound).toBe(3);
+    expect(stats.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it('INVARIANT GUARD (green on unfixed code): apply:false never calls deleteDocuments', async () => {
+    const fake = makeFakeIndex({ docs: [1, 2, 3] });
+    setFakeIndex(fake);
+
+    const stats = await cleanupIndex(modelsCfg, { apply: false, batch: 3 });
+
+    expect(fake.deleted).toEqual([]);
+    expect(stats.deleted).toBe(0);
+    expect(stats.staleFound).toBe(3);
+  });
+});
+
+// ─── (d) deletions are flushed as the scan runs ─────────────────────────────
+
+describe('cleanupIndex: deletions are flushed incrementally', () => {
+  it('deletes in chunks while the scan is still running, not once at the end', async () => {
+    // 9 documents, 3 per page, chunk size 2. Everything is stale.
+    // Pages [1,2,3] [4,5,6] [7,8,9]; the pending list is drained to whole
+    // chunks after each page, and the remainder goes out in the final flush.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9] });
+    setFakeIndex(fake);
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: true,
+      batch: 3,
+      deleteChunkSize: 2,
+    });
+
+    expect(fake.deleted).toEqual([[1, 2], [3, 4], [5, 6], [7, 8], [9]]);
+
+    // 🔴 The load-bearing assertion, and it comes FIRST deliberately. The chunk
+    // LIST above is identical whether
+    // deletions are flushed as the scan runs or accumulated and chunked at the
+    // end, so on its own it proves nothing. This pins WHEN each delete
+    // happened, counted in searches already issued: the first chunk goes out
+    // after page 1, not after the whole index has been walked.
+    //
+    // Pages are searches 1-3; 4 is the empty page and 5 its confirmation, so
+    // the trailing 5 is the final flush of the remainder. Accumulating first
+    // would make every entry 5.
+    expect(fake.deletedAfterSearches).toEqual([1, 2, 2, 3, 5]);
+
+    expect(stats.deleted).toBe(9);
+    expect(stats.stoppedEarly).toBe(false);
+  });
+
+  it('KEEPS what it already deleted when the job is cancelled mid-scan', async () => {
+    // The regression this exists for: batching every deletion until after the
+    // scan made a cancelled run delete NOTHING — the scan broke, then the
+    // delete loop broke at chunk 0. That is strictly worse than the truncated
+    // behaviour it replaced, which at least deleted the prefix it reached.
+    //
+    // Cancellation is raised from `onBatch` after the 2nd page, which is the
+    // point the request socket closing would reach — before that page's flush.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9] });
+    setFakeIndex(fake);
+    const jobContext = makeJobContext();
+    let batchesSeen = 0;
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: true,
+      batch: 3,
+      deleteChunkSize: 2,
+      jobContext: jobContext as never,
+      onBatch: () => {
+        batchesSeen += 1;
+        if (batchesSeen === 2) jobContext.status = 'canceled';
+      },
+    });
+
+    // Page 1 flushed [1,2] before the cancellation; page 2's flush and the
+    // final flush both bail. The point is that this is NOT empty.
+    expect(batchesSeen).toBe(2);
+    expect(fake.deleted).toEqual([[1, 2]]);
+    expect(stats.deleted).toBe(2);
   });
 });

--- a/src/server/meilisearch/cleanup.ts
+++ b/src/server/meilisearch/cleanup.ts
@@ -207,7 +207,10 @@ export async function cleanupIndex(
   if (!searchClient) throw new Error('searchClient not configured');
   const index = searchClient.index(cfg.indexName);
 
-  const batch = opts.batch ?? 1000;
+  // The requested page size is only a ceiling REQUEST. The engine caps a
+  // search `limit` at the index's `pagination.maxTotalHits`, so the effective
+  // page size is clamped to that in the preflight below.
+  let batch = opts.batch ?? 1000;
   const maxBatches = opts.maxBatches ?? Infinity;
   const deleteChunkSize = opts.deleteChunkSize ?? 10000;
 
@@ -233,10 +236,21 @@ export async function cleanupIndex(
   // sortable on the index. If either is missing, the scan would 4xx every
   // batch — bail out early with a logged error so the cron doesn't waste
   // retries and the missing-setting cause is surfaced clearly.
+  //
+  // The same call is where we learn the index's real page ceiling: a search
+  // `limit` above `pagination.maxTotalHits` is silently truncated to it, and
+  // that ceiling is PER-INDEX (an index left at the default is far lower than
+  // one that has been raised). Clamping here means a large requested batch is
+  // safe to ask for everywhere — indexes that can serve it do, and the ones
+  // that cannot fall back to their own ceiling instead of being truncated.
   try {
     const indexSettings = await index.getSettings();
     const filt = indexSettings.filterableAttributes ?? [];
     const sort = indexSettings.sortableAttributes ?? [];
+    const maxTotalHits = indexSettings.pagination?.maxTotalHits;
+    if (typeof maxTotalHits === 'number' && Number.isFinite(maxTotalHits) && maxTotalHits > 0) {
+      batch = Math.min(batch, maxTotalHits);
+    }
     if (!filt.includes('id') || !sort.includes('id')) {
       stats.errors += 1;
       opts.onError?.({
@@ -300,6 +314,23 @@ export async function cleanupIndex(
   const MAX_CONSECUTIVE_PG_FAILURES = 10;
   let consecutivePgFailures = 0;
 
+  // One keyset page, already reduced to the numeric ids it carried.
+  const fetchPage = async (cursor: number): Promise<number[]> => {
+    const page = await withRetries(() =>
+      index.search<{ id: number }>('', {
+        filter: `id > ${cursor}`,
+        sort: ['id:asc'],
+        limit: batch,
+        attributesToRetrieve: ['id'],
+      })
+    );
+    return page.hits.map((r) => r.id).filter((n): n is number => Number.isFinite(n));
+  };
+
+  // How long to wait before re-asking the same cursor after an empty page.
+  // See the confirmation below for why an empty page is not trusted first time.
+  const EMPTY_PAGE_CONFIRM_DELAY_MS = 500;
+
   while (stats.batchesProcessed < maxBatches) {
     if (opts.jobContext?.status === 'canceled') break;
 
@@ -307,22 +338,21 @@ export async function cleanupIndex(
     // the whole index. The original concurrent-offset code naturally
     // tolerated a single bad batch (other concurrent batches still made
     // progress); sequential keyset has no such redundancy.
-    //
-    // Note: `limit` is capped at the Meilisearch index `maxTotalHits`
-    // setting (default 1000). Bumping `batch` past 1000 without also
-    // raising `maxTotalHits` would silently truncate the page. Keyset
-    // would still advance correctly on the last returned id, so we
-    // wouldn't miss docs — just halve throughput.
-    let page: Awaited<ReturnType<typeof index.search<{ id: number }>>>;
+    let docIds: number[];
     try {
-      page = await withRetries(() =>
-        index.search<{ id: number }>('', {
-          filter: `id > ${lastId}`,
-          sort: ['id:asc'],
-          limit: batch,
-          attributesToRetrieve: ['id'],
-        })
-      );
+      docIds = await fetchPage(lastId);
+
+      // An empty page is the ONLY terminator, and it is not trusted on its
+      // first appearance. The engine can be concurrently applying document
+      // additions and deletions while we scan, and a transient empty reply
+      // at a cursor that still has documents past it would otherwise end the
+      // scan early — silently, and reported as success. Re-ask the SAME
+      // cursor once after a short pause; only a second empty reply ends the
+      // scan. Costs one extra query per index per run.
+      if (docIds.length === 0) {
+        await new Promise((r) => setTimeout(r, EMPTY_PAGE_CONFIRM_DELAY_MS));
+        docIds = await fetchPage(lastId);
+      }
     } catch (err) {
       // Cancellation surfaced from withRetries is a clean stop, not a failure.
       if (opts.jobContext && opts.jobContext.status !== 'running') break;
@@ -331,10 +361,6 @@ export async function cleanupIndex(
       // Out of retries — without advancing the cursor we'd loop on the same page.
       break;
     }
-
-    const docIds = page.hits
-      .map((r) => r.id)
-      .filter((n): n is number => Number.isFinite(n));
 
     if (docIds.length === 0) break;
 
@@ -383,9 +409,15 @@ export async function cleanupIndex(
 
     // ids come back sorted asc; advance cursor. Length is guaranteed > 0
     // by the empty-check above, so the access is safe.
+    //
+    // A SHORT page is deliberately NOT a terminator. "Fewer hits than I asked
+    // for" and "no more documents" are different statements: the engine caps a
+    // page at the index's own ceiling, and can return fewer for reasons of its
+    // own. Treating short as done ended a scan at whatever page happened to
+    // come back small and reported the run as complete. The cursor advances
+    // correctly either way, so the only cost of dropping that shortcut is one
+    // additional (empty, then confirmed-empty) query per index.
     lastId = docIds[docIds.length - 1];
-
-    if (docIds.length < batch) break;
   }
 
   if (opts.apply && allStaleIds.length > 0) {

--- a/src/server/meilisearch/cleanup.ts
+++ b/src/server/meilisearch/cleanup.ts
@@ -378,7 +378,12 @@ export async function cleanupIndex(
       if (staleIds.length > 0) allStaleIds.push(...staleIds);
 
       // `offset` in the callback reports the cursor (last id seen before this batch).
-      opts.onBatch?.({ key: cfg.key, offset: lastId, scanned: docIds.length, stale: staleIds.length });
+      opts.onBatch?.({
+        key: cfg.key,
+        offset: lastId,
+        scanned: docIds.length,
+        stale: staleIds.length,
+      });
     } catch (err) {
       // Cancellation surfaced from withRetries is a clean stop, not a
       // Postgres failure — don't pollute the consecutivePgFailures counter
@@ -457,9 +462,7 @@ export async function cleanupAllIndexes(
   keys: CleanupIndexKey[] | null,
   opts: CleanupOptions
 ): Promise<CleanupIndexStats[]> {
-  const selected = keys
-    ? CLEANUP_INDEXES.filter((i) => keys.includes(i.key))
-    : CLEANUP_INDEXES;
+  const selected = keys ? CLEANUP_INDEXES.filter((i) => keys.includes(i.key)) : CLEANUP_INDEXES;
   const results: CleanupIndexStats[] = [];
   for (const cfg of selected) {
     if (opts.jobContext?.status === 'canceled') break;

--- a/src/server/meilisearch/cleanup.ts
+++ b/src/server/meilisearch/cleanup.ts
@@ -1,5 +1,5 @@
 import { Prisma } from '@prisma/client';
-import { dbRead } from '~/server/db/client';
+import { dbRead, dbWrite } from '~/server/db/client';
 import {
   ARTICLES_SEARCH_INDEX,
   BOUNTIES_SEARCH_INDEX,
@@ -188,11 +188,47 @@ export type CleanupIndexStats = {
   deleted: number;
   totalInIndex: number | null;
   errors: number;
+  /**
+   * TRUE when the scan ended for any reason other than reaching a confirmed
+   * end of the index. This — not a scanned-vs-total comparison — is the
+   * authoritative "the pass did not cover the index" signal: `totalInIndex` is
+   * a snapshot taken before a scan that then runs for hours against an index
+   * other jobs are concurrently deleting from, so the two numbers legitimately
+   * disagree on a perfectly complete run.
+   */
+  stoppedEarly: boolean;
+  /**
+   * Ids that were fetched from the index but whose eligibility lookup failed,
+   * so they were neither judged nor deleted. The cursor still advanced past
+   * them. Distinct from `stoppedEarly`: a scan can reach the very end of the
+   * index having skipped batches along the way.
+   */
+  idsSkipped: number;
+  /**
+   * Ids the read replica called stale that the PRIMARY then said were still
+   * eligible, so they were NOT deleted. A non-zero value is replication lag
+   * being caught, which is exactly what the primary re-check exists for.
+   */
+  rescuedByPrimary: number;
+  /** `isIndexing` as reported alongside the document count, or null if unread. */
+  indexingAtStart: boolean | null;
 };
 
-async function fetchValidIds(cfg: IndexConfig, ids: number[]): Promise<Set<number>> {
+/**
+ * Which of `ids` still BELONG in the index, according to `client`.
+ *
+ * The client is a parameter because the two call sites ask different
+ * questions. The scan asks the read replica (cheap, and a wrong answer only
+ * costs a document being re-examined tomorrow); the delete path re-asks the
+ * PRIMARY, because there a wrong answer destroys a document.
+ */
+async function fetchValidIds(
+  cfg: IndexConfig,
+  ids: number[],
+  client: typeof dbRead | typeof dbWrite
+): Promise<Set<number>> {
   if (ids.length === 0) return new Set();
-  const rows = await dbRead.$queryRaw<{ id: number }[]>`
+  const rows = await client.$queryRaw<{ id: number }[]>`
     SELECT ${Prisma.raw(`${cfg.alias}.id`)}::int AS id
     FROM ${Prisma.raw(`"${cfg.tableName}"`)} ${Prisma.raw(cfg.alias)}
     WHERE ${cfg.where(ids)}
@@ -223,11 +259,19 @@ export async function cleanupIndex(
     deleted: 0,
     totalInIndex: null,
     errors: 0,
+    stoppedEarly: true,
+    idsSkipped: 0,
+    rescuedByPrimary: 0,
+    indexingAtStart: null,
   };
 
   try {
     const statsRes = await index.getStats();
     stats.totalInIndex = statsRes.numberOfDocuments;
+    // Recorded because it changes how the document count should be read: a
+    // count taken while the engine is mid-ingest is a moving number, so a
+    // shortfall against it is not evidence of a truncated scan.
+    stats.indexingAtStart = statsRes.isIndexing ?? null;
   } catch {
     // non-fatal
   }
@@ -274,7 +318,14 @@ export async function cleanupIndex(
   // Meilisearch regardless of depth — replaces offset pagination where
   // deep pages were saturating LMDB read I/O on the search host.
   let lastId = -1;
-  const allStaleIds: number[] = [];
+
+  // Stale ids awaiting deletion. Deliberately NOT an accumulator for the whole
+  // index: deletions are flushed as the scan runs, so a run that is cancelled
+  // part-way keeps everything it has already deleted. Batching all deletions
+  // until after the scan made the job all-or-nothing — a cancellation (the
+  // request socket closing) broke the scan, then broke the delete loop at
+  // chunk 0, and the index got ZERO deletions for the run.
+  const pendingStaleIds: number[] = [];
 
   // Retry helper: run `fn` up to MAX_ATTEMPTS times with linear backoff.
   // Re-throws immediately if the job is canceled mid-retry — otherwise the
@@ -331,6 +382,82 @@ export async function cleanupIndex(
   // See the confirmation below for why an empty page is not trusted first time.
   const EMPTY_PAGE_CONFIRM_DELAY_MS = 500;
 
+  let chunkIdx = 0;
+
+  /**
+   * Delete whole chunks of `pendingStaleIds`; with `final`, delete the
+   * remainder too.
+   *
+   * 🔴 Every id is re-verified against the PRIMARY immediately before it is
+   * deleted, and only ids the primary ALSO calls ineligible are sent.
+   *
+   * The scan judges eligibility from `dbRead`, a read replica. A document
+   * indexed moments ago whose row has not replicated yet looks like it belongs
+   * to nothing and is classified stale — and the fix that made this scan reach
+   * the end of the index is precisely what makes it reach that freshly-written
+   * high-id tail for the first time. The replica read stays because it is the
+   * cheap filter over millions of ids; this is the expensive check over the
+   * few thousand that filter selects, where being wrong destroys a document
+   * rather than costing a re-examination tomorrow.
+   *
+   * If the primary cannot be reached the chunk is NOT deleted. The safe
+   * failure direction here is to delete nothing: an undeleted stale document
+   * is picked up by the next nightly run, a wrongly deleted live one is not.
+   */
+  const flushDeletions = async (final: boolean) => {
+    if (!opts.apply) return;
+    while (pendingStaleIds.length >= deleteChunkSize || (final && pendingStaleIds.length > 0)) {
+      // Bail before submitting more delete tasks if the job is no longer
+      // running. (`!== 'running'` mirrors what `createJob.checkIfCanceled`
+      // actually throws on: status flipped to either `canceled` or `finished`.)
+      //
+      // ⚠️ REDUNDANT, and deliberately kept: `withRetries` calls
+      // `checkIfCanceled()` before its first attempt, so a cancelled job stops
+      // here either way. Mutation-testing confirms it — removing this line
+      // kills no test, because the throw from `withRetries` reaches the same
+      // early `return`. It is an explicit cheap check in front of an expensive
+      // one, not a correctness guard; do not read its presence as evidence
+      // that the path below is otherwise unprotected.
+      if (opts.jobContext && opts.jobContext.status !== 'running') return;
+
+      const chunk = pendingStaleIds.splice(0, deleteChunkSize);
+
+      let confirmed: number[];
+      try {
+        const stillValid = await withRetries(() => fetchValidIds(cfg, chunk, dbWrite));
+        confirmed = chunk.filter((id) => !stillValid.has(id));
+        stats.rescuedByPrimary += chunk.length - confirmed.length;
+      } catch (err) {
+        if (opts.jobContext && opts.jobContext.status !== 'running') return;
+        stats.errors += 1;
+        opts.onError?.({
+          key: cfg.key,
+          offset: -1,
+          error: new Error(
+            `skipped deleting ${chunk.length} id(s) from ${cfg.indexName}: ` +
+              `primary re-check failed (${(err as Error).message})`
+          ),
+        });
+        continue;
+      }
+
+      if (confirmed.length === 0) continue;
+
+      try {
+        opts.jobContext?.checkIfCanceled();
+        await index.deleteDocuments(confirmed);
+        stats.deleted += confirmed.length;
+        opts.onDelete?.({ key: cfg.key, chunk: chunkIdx, ids: confirmed.length });
+      } catch (err) {
+        // Treat cancellation thrown mid-deleteDocuments as a clean stop.
+        if (opts.jobContext && opts.jobContext.status !== 'running') return;
+        stats.errors += 1;
+        opts.onError?.({ key: cfg.key, offset: -1, error: err as Error });
+      }
+      chunkIdx += 1;
+    }
+  };
+
   while (stats.batchesProcessed < maxBatches) {
     if (opts.jobContext?.status === 'canceled') break;
 
@@ -362,12 +489,42 @@ export async function cleanupIndex(
       break;
     }
 
-    if (docIds.length === 0) break;
+    if (docIds.length === 0) {
+      // The one clean terminator: a confirmed-empty page at the cursor.
+      stats.stoppedEarly = false;
+      break;
+    }
+
+    // 🔴 The cursor MUST strictly advance, and that is asserted rather than
+    // assumed — BEFORE the page is judged, so a non-advancing page is never
+    // examined (or deleted from) twice.
+    //
+    // Termination now rests entirely on the cursor: `maxBatches` is Infinity
+    // from the cron, and dropping the short-page break removed the accidental
+    // bound that used to exist. A page whose last id is not greater than the
+    // cursor would re-issue the identical query forever, holding a Postgres
+    // connection and a Meilisearch reader for the life of the process.
+    //
+    // ids come back sorted asc, so the last one is the highest.
+    const nextId = docIds[docIds.length - 1];
+    if (!(nextId > lastId)) {
+      stats.errors += 1;
+      opts.onError?.({
+        key: cfg.key,
+        offset: lastId,
+        error: new Error(
+          `aborting ${cfg.indexName} scan: cursor did not advance ` +
+            `(last id ${nextId} is not greater than cursor ${lastId}); ` +
+            `the index is not returning ids in ascending order past the filter`
+        ),
+      });
+      break;
+    }
 
     // Same retry envelope on the Postgres side. A connection blip or short
     // replica-lag spike shouldn't drop ~10M docs of users cleanup.
     try {
-      const validIds = await withRetries(() => fetchValidIds(cfg, docIds));
+      const validIds = await withRetries(() => fetchValidIds(cfg, docIds, dbRead));
       const staleIds = docIds.filter((id) => !validIds.has(id));
 
       stats.batchesProcessed += 1;
@@ -375,7 +532,7 @@ export async function cleanupIndex(
       stats.staleFound += staleIds.length;
       consecutivePgFailures = 0;
 
-      if (staleIds.length > 0) allStaleIds.push(...staleIds);
+      if (staleIds.length > 0) pendingStaleIds.push(...staleIds);
 
       // `offset` in the callback reports the cursor (last id seen before this batch).
       opts.onBatch?.({
@@ -384,6 +541,11 @@ export async function cleanupIndex(
         scanned: docIds.length,
         stale: staleIds.length,
       });
+
+      // Flush whole chunks as they accumulate, so progress survives a
+      // cancellation. Only complete chunks here — the remainder goes out in
+      // the final flush after the loop.
+      await flushDeletions(false);
     } catch (err) {
       // Cancellation surfaced from withRetries is a clean stop, not a
       // Postgres failure — don't pollute the consecutivePgFailures counter
@@ -396,6 +558,11 @@ export async function cleanupIndex(
       // failures so a hard outage doesn't grind through millions of ids.
       stats.errors += 1;
       consecutivePgFailures += 1;
+      // These ids were fetched but never judged. The cursor advances past them
+      // regardless, so the scan can still reach the end of the index — which
+      // is why this is counted separately from `stoppedEarly` rather than
+      // folded into one "incomplete" verdict.
+      stats.idsSkipped += docIds.length;
       opts.onError?.({ key: cfg.key, offset: lastId, error: err as Error });
       if (consecutivePgFailures >= MAX_CONSECUTIVE_PG_FAILURES) {
         opts.onError?.({
@@ -405,15 +572,14 @@ export async function cleanupIndex(
             `aborting ${cfg.indexName} scan: ${consecutivePgFailures} consecutive Postgres errors`
           ),
         });
-        // ids come back sorted asc; advance cursor so a possible retry of
-        // the outer cron picks up where we left off.
-        lastId = docIds[docIds.length - 1];
+        // Advance the cursor so a possible retry of the outer cron picks up
+        // where we left off. `nextId` is the guarded, strictly-greater value.
+        lastId = nextId;
         break;
       }
     }
 
-    // ids come back sorted asc; advance cursor. Length is guaranteed > 0
-    // by the empty-check above, so the access is safe.
+    // Advance the cursor, already proven to move forward by the guard above.
     //
     // A SHORT page is deliberately NOT a terminator. "Fewer hits than I asked
     // for" and "no more documents" are different statements: the engine caps a
@@ -422,38 +588,12 @@ export async function cleanupIndex(
     // come back small and reported the run as complete. The cursor advances
     // correctly either way, so the only cost of dropping that shortcut is one
     // additional (empty, then confirmed-empty) query per index.
-    lastId = docIds[docIds.length - 1];
+    lastId = nextId;
   }
 
-  if (opts.apply && allStaleIds.length > 0) {
-    let chunkIdx = 0;
-    for (let i = 0; i < allStaleIds.length; i += deleteChunkSize) {
-      // Bail before submitting more delete tasks if the job is no longer
-      // running. Without this, every remaining chunk logs a separate
-      // "Job has ended" error via the catch below — for a ~10M-doc index
-      // with hundreds of thousands of stale ids that's tens of duplicate
-      // Axiom errors per cancellation. (`!== 'running'` mirrors what
-      // `createJob.checkIfCanceled` actually throws on: status flipped to
-      // either `canceled` or `finished`. Phrased this way to avoid TS's
-      // control-flow narrowing inside the catch below, which would
-      // otherwise reject the equivalent `=== 'canceled'` comparison.)
-      if (opts.jobContext && opts.jobContext.status !== 'running') break;
-      const chunk = allStaleIds.slice(i, i + deleteChunkSize);
-      try {
-        opts.jobContext?.checkIfCanceled();
-        await index.deleteDocuments(chunk);
-        stats.deleted += chunk.length;
-        opts.onDelete?.({ key: cfg.key, chunk: chunkIdx, ids: chunk.length });
-      } catch (err) {
-        // Treat cancellation thrown mid-deleteDocuments as a clean stop,
-        // not an error. See the comment above for the !== 'running' form.
-        if (opts.jobContext && opts.jobContext.status !== 'running') break;
-        stats.errors += 1;
-        opts.onError?.({ key: cfg.key, offset: -1, error: err as Error });
-      }
-      chunkIdx += 1;
-    }
-  }
+  // Whatever is left over after the loop, including the tail of a scan that
+  // stopped early. A cancelled run returns from inside the flush instead.
+  await flushDeletions(true);
 
   return stats;
 }

--- a/src/server/meilisearch/cleanup.ts
+++ b/src/server/meilisearch/cleanup.ts
@@ -325,6 +325,12 @@ export async function cleanupIndex(
   // until after the scan made the job all-or-nothing — a cancellation (the
   // request socket closing) broke the scan, then broke the delete loop at
   // chunk 0, and the index got ZERO deletions for the run.
+  //
+  // Nothing is pushed here under `apply: false`, or the sentence above would be
+  // false in that mode: `flushDeletions` returns immediately without applying,
+  // so the list would never drain and would grow to hold every stale id in the
+  // index — exactly the accumulator this replaced. `staleFound` is counted
+  // independently, so the dry-run figures are unaffected.
   const pendingStaleIds: number[] = [];
 
   // Retry helper: run `fn` up to MAX_ATTEMPTS times with linear backoff.
@@ -532,7 +538,7 @@ export async function cleanupIndex(
       stats.staleFound += staleIds.length;
       consecutivePgFailures = 0;
 
-      if (staleIds.length > 0) pendingStaleIds.push(...staleIds);
+      if (opts.apply && staleIds.length > 0) pendingStaleIds.push(...staleIds);
 
       // `offset` in the callback reports the cursor (last id seen before this batch).
       opts.onBatch?.({


### PR DESCRIPTION
## What's wrong

The nightly search-index cleanup job (`0 2 * * *`) can finish, report success, and have scanned only a fraction of a large index. It deletes exactly the stale documents it reached and silently leaves the rest — the residual is a clean step function in the primary-key space (zero below one id, non-zero above), the signature of a scan that stopped at a cursor while reporting success.

Two independent defects combine to produce that.

### Defect 1 — the run reports nothing, so truncation is invisible

`cleanupIndex` already computes per-index `idsScanned`, `staleFound`, `deleted`, `totalInIndex`, `errors` and `batchesProcessed`, and the job hands them back in its response body. Nothing logs them, and the job runner records only a duration. So "scanned a third of the index" and "scanned all of it" are indistinguishable from the outside, and the shortfall has to be reconstructed from the search engine's own task history after the fact.

### Defect 2 — the scan cannot cover a large index, and terminates early without saying so

Three interacting problems in the keyset `while` loop:

**(a) The requested page size was never clamped to the index's real ceiling.** A search `limit` above the index's `pagination.maxTotalHits` is truncated to it, and that ceiling is **per-index**. A page size of 1,000 means a multi-million-document index needs thousands of sequential round trips, which does not fit alongside six other indexes in one run — but simply raising it is not safe either, because an index left at the default ceiling would get a truncated page back and, via (b), end its scan after a single page. An in-code comment asserted the ceiling was always 1000, which is not true.

**(b) `if (docIds.length < batch) break;` is an unsafe terminator.** "Fewer hits than I asked for" and "no more documents" are different statements — the first is exactly what a clamped or engine-shortened page looks like.

**(c) `if (docIds.length === 0) break;` cannot distinguish end-of-index from a transient empty page.** The engine was concurrently applying document additions and deletions when the observed run stopped.

## The fix

**Logging (defect 1).** The job now emits one `logToAxiom` payload per index carrying `key`, `scanned`, `stale`, `deleted`, `errors`, `total` and an `incomplete` flag. An **incomplete pass** — `idsScanned < totalInIndex`, with the total known — is logged at **error** level with both numbers in the message, not buried in a success line. When `totalInIndex` is `null` (the stats call failed) completeness is unknowable and nothing is claimed either way. The job's return value is unchanged.

**Loop (defect 2).**

- **(a) Clamp, then raise.** The preflight already fetches the index settings for the filterable/sortable check; it now reads `pagination.maxTotalHits` from the same call and clamps the effective batch to it. With that in place the job can request a genuinely useful page size (10,000, matching the id-list size already used for deletes) and each index gets the largest page it can actually serve, instead of a truncated one. The stale comment is corrected.
- **(b)** The short-page terminator is removed. The cursor advances on the last returned id either way, so the only cost is one extra query per index.
- **(c)** An empty page now has to **confirm itself**: the same cursor is re-issued once after a short pause, and only a second empty reply ends the scan. If the confirmation returns rows the scan continues. This is the leading (unproven) hypothesis for the observed stop; it is cheap and it removes the class regardless of whether it fired.

Cross-run cursor persistence is deliberately **not** added — with (a) fixed, a full pass fits in one run.

Note one intentional consequence: an index that fails the filterable/sortable preflight scans zero documents, so it will now also be reported as an incomplete pass. That is accurate — it is not being cleaned at all — and it sits alongside the existing preflight error that explains why.

## Test matrix

Every new test was run against the **pre-change** source first and watched to fail, then against the fixed source. Two suites, 11 tests.

| Test | At `origin/main` | At HEAD | Failure at base |
|---|---|---|---|
| `cleanup.test.ts` › short page does not end the scan | 🔴 FAIL | ✅ PASS | `expected 3 to be 10` — scan stopped after page 1 of 4 |
| `cleanup.test.ts` › continues past a transient empty page | 🔴 FAIL | ✅ PASS | `expected 2 to be 6` — scan stopped at the injected empty page |
| `cleanup.test.ts` › ends the scan on a *confirmed* empty page | 🔴 FAIL | ✅ PASS | `expected ['id > -1','id > 3'] to deeply equal ['id > -1','id > 3','id > 3']` — no confirmation query |
| `cleanup.test.ts` › clamps a batch above the index ceiling and still completes | 🔴 FAIL | ✅ PASS | `expected 5 to be 12` — unclamped `limit`, short page, stopped after one page |
| `cleanup.test.ts` › INVARIANT GUARD: a ceiling *above* the batch does not raise it | ✅ pass | ✅ PASS | — labelled in the test as an invariant guard, not regression coverage |
| `search-index-cleanup.test.ts` › per-index stats reach the log sink | 🔴 FAIL | ✅ PASS | `expected undefined to match object {...}` — nothing logged |
| `search-index-cleanup.test.ts` › truncated scan logged at error level with both counts | 🔴 FAIL | ✅ PASS | `expected undefined to be 'error'` |
| `search-index-cleanup.test.ts` › does NOT flag a complete pass | 🔴 FAIL | ✅ PASS | `expected undefined to be 'info'` |
| `search-index-cleanup.test.ts` › does NOT flag a pass with an unknown total | 🔴 FAIL | ✅ PASS | `expected undefined to be 'info'` |
| `search-index-cleanup.test.ts` › requests a page size large enough for a big index | 🔴 FAIL | ✅ PASS | `expected 1000 to be 10000` |
| `search-index-cleanup.test.ts` › INVARIANT GUARD: job return value unchanged | ✅ pass | ✅ PASS | — labelled in the test as an invariant guard |

**9 red at base, 2 pre-existing-green invariant guards (both labelled as such in the test name and a comment). 11 green at HEAD.**

The clamp test deliberately covers the combination that matters: an index whose ceiling is **below** the requested batch **and** which holds more documents than one page — it asserts every request asks for the ceiling (not the unservable larger value) *and* that the scan reaches the last document.

Expectations are literal page sequences and counts written from the fixture (exact `id > N` cursor walks, exact scanned/batch counts), not read back off the implementation.

### Verification

- `pnpm typecheck` — **0 errors**.
- `tsc -p tsconfig.tests.json` (test files, excluded from the above) — **887 pre-existing errors with the new files removed, 887 with them added; delta 0**, and no diagnostic names either new file.
- `eslint` on all four changed files — **0 problems**.
- Unit run: **11 passed, 0 failed**, counted from the verbose reporter's per-test lines rather than an exit code.

**Not verified:** nothing here has been exercised against a live search engine. The loop behaviour is proven only against a fake index; the throughput claim for the larger page size is an expectation, not a measurement. The first nightly run after this merges is the real check — and it is now the first one that can report its own coverage.
