### PR TITLE
fix(filters): the sort a viewer cannot pick was still the one the feed ran on

### DIFF
--- a/src/components/Filters/SortFilter.tsx
+++ b/src/components/Filters/SortFilter.tsx
@@ -1,6 +1,6 @@
 import type { ButtonProps } from '@mantine/core';
 import { useRouter } from 'next/router';
-import { isSortAvailable } from '~/components/Filters/sort-availability';
+import { isSortAvailable, resolveFeedSort } from '~/components/Filters/sort-availability';
 import { useSortAvailability } from '~/components/Filters/useSortAvailability';
 import { SelectMenuV2 } from '~/components/SelectMenu/SelectMenu';
 import type { FilterSubTypes } from '~/providers/FiltersProvider';
@@ -71,12 +71,15 @@ type DumbProps = {
 
 function DumbSortFilter({ type, value, onChange, ignoreNsfwLevel, options, ...props }: DumbProps) {
   const availability = useSortAvailability();
+  // The menu below drops what this viewer may not sort by, so a value outside it
+  // would label the control with a sort its own menu will not offer.
+  const resolved = resolveFeedSort({ type, value }, { ...availability, ignoreNsfwLevel });
 
   return (
     <SelectMenuV2
-      label={value}
+      label={resolved}
       onClick={onChange}
-      value={value}
+      value={resolved}
       options={(options ?? sortOptions[type].map((x) => ({ label: x, value: x }))).filter((x) =>
         isSortAvailable({ type, value: x.value }, { ...availability, ignoreNsfwLevel })
       )}

--- a/src/components/Filters/__tests__/sort-availability.test.ts
+++ b/src/components/Filters/__tests__/sort-availability.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { isSortAvailable, resolveFeedSort } from '~/components/Filters/sort-availability';
+import { ImageSort, ModelSort } from '~/server/common/enums';
+
+// The three availabilities the rule distinguishes. `.green` is the domain that
+// withholds Newest and Oldest outright; SFW-by-choice withholds Newest on the
+// images feed alone; a moderator is offered everything.
+const green = { isModerator: false, canViewNsfw: false, showNsfw: false };
+const sfwByChoice = { isModerator: false, canViewNsfw: true, showNsfw: false };
+const moderator = { isModerator: true, canViewNsfw: false, showNsfw: false };
+
+describe('resolveFeedSort', () => {
+  it('replaces a sort the menu withholds, on every image-bearing feed', () => {
+    for (const type of ['images', 'videos', 'modelImages'] as const) {
+      expect(resolveFeedSort({ type, value: ImageSort.Newest }, green)).toBe(
+        ImageSort.MostReactions
+      );
+      expect(resolveFeedSort({ type, value: ImageSort.Oldest }, green)).toBe(
+        ImageSort.MostReactions
+      );
+    }
+  });
+
+  it('leaves a sort the menu offers alone', () => {
+    expect(resolveFeedSort({ type: 'images', value: ImageSort.MostReactions }, green)).toBe(
+      ImageSort.MostReactions
+    );
+    expect(resolveFeedSort({ type: 'images', value: ImageSort.Newest }, moderator)).toBe(
+      ImageSort.Newest
+    );
+    // Oldest survives SFW-by-choice: that half of the rule is about a freshly
+    // posted image, and an oldest-first feed does not front one.
+    expect(resolveFeedSort({ type: 'images', value: ImageSort.Oldest }, sfwByChoice)).toBe(
+      ImageSort.Oldest
+    );
+  });
+
+  it('does not touch a feed that is not made of images', () => {
+    // The control for the loop above: `isSortAvailable` withholds Newest from
+    // these types too, so an unscoped resolver would rewrite them and this is the
+    // only assertion that would catch it.
+    expect(isSortAvailable({ type: 'models', value: ModelSort.Newest }, green)).toBe(false);
+    expect(resolveFeedSort({ type: 'models', value: ModelSort.Newest }, green)).toBe(
+      ModelSort.Newest
+    );
+    expect(resolveFeedSort({ type: 'threads', value: 'Newest' }, green)).toBe('Newest');
+  });
+
+  it('never returns a sort the menu would hide', () => {
+    // The property the whole thing exists for, over every images sort the menu
+    // can offer and all three availabilities.
+    const sorts = Object.values(ImageSort).filter((s) => s !== ImageSort.Random);
+    expect(sorts).toHaveLength(5);
+
+    for (const availability of [green, sfwByChoice, moderator]) {
+      for (const value of sorts) {
+        const resolved = resolveFeedSort({ type: 'images', value }, availability);
+        expect(isSortAvailable({ type: 'images', value: resolved }, availability)).toBe(true);
+      }
+    }
+  });
+});

--- a/src/components/Filters/sort-availability.ts
+++ b/src/components/Filters/sort-availability.ts
@@ -1,3 +1,4 @@
+import { ImageSort } from '~/server/common/enums';
 import type { FilterSubTypes } from '~/providers/FiltersProvider';
 
 export type SortAvailability = {
@@ -16,4 +17,29 @@ export function isSortAvailable(
   if (!canViewNsfw && (value === 'Newest' || value === 'Oldest')) return false;
   if (type === 'images' && !showNsfw && value === 'Newest') return false;
   return true;
+}
+
+// The feeds whose sort is resolved on read. The rule below withholds Newest and
+// Oldest from every feed type, but it exists because a freshly posted IMAGE may
+// not be rated yet — so a feed of anything else keeps whatever it holds.
+const resolvedSortTypes: FilterSubTypes[] = ['images', 'videos', 'modelImages'];
+
+/**
+ * The sort a viewer is actually served. Filtering the menu options hides a
+ * withheld sort from the picker but leaves it selected AND running the query, so
+ * every read of an image feed's sort goes through here.
+ *
+ * Most Reactions rather than the next sort in the menu: it is the one images sort
+ * nothing withholds, and reaching for Oldest would put the viewer back in front of
+ * what the rule exists to keep away.
+ *
+ * Resolved on read and never written back, so regaining NSFW browsing returns the
+ * feed to the sort its viewer chose.
+ */
+export function resolveFeedSort<T extends string>(
+  { type, value }: { type: FilterSubTypes; value: T },
+  availability: SortAvailability
+): T | ImageSort.MostReactions {
+  if (!resolvedSortTypes.includes(type)) return value;
+  return isSortAvailable({ type, value }, availability) ? value : ImageSort.MostReactions;
 }

--- a/src/components/Hubs/hub-sort.ts
+++ b/src/components/Hubs/hub-sort.ts
@@ -1,27 +1,18 @@
 import type { SortAvailability } from '~/components/Filters/sort-availability';
-import { isSortAvailable } from '~/components/Filters/sort-availability';
+import { resolveFeedSort } from '~/components/Filters/sort-availability';
 import { ImageSort } from '~/server/common/enums';
 import type { HubSort } from '~/server/schema/user-hub.schema';
 import { hubSortSchema } from '~/server/schema/user-hub.schema';
 
 /**
- * The images sort menu hides Newest and Oldest from viewers who cannot view NSFW,
- * because a freshly posted image may not be rated yet. A hub stored as Newest handed
- * those viewers a sort they were never offered again.
- *
- * Most Reactions rather than the next sort in the list: Oldest is withheld wherever
- * Newest is and for the same reason, so reaching for it would put the viewer back in
- * front of what the rule exists to keep away. Most Reactions is never itself withheld,
- * which the tests pin — if that changes, this hands back a sort the menu will not show.
- *
- * Resolved on read and never written back, so regaining NSFW browsing returns the hub
- * to the sort its owner chose.
+ * A hub carries its own stored sort, so it can hold one this viewer is not offered
+ * — the sort is theirs, the availability is the domain's. Resolved on read and
+ * never written back, so regaining NSFW browsing returns the hub to the sort its
+ * owner chose.
  */
 export function resolveHubSort(stored: unknown, availability: SortAvailability): HubSort {
   const sort = hubSortSchema.catch(ImageSort.Newest).parse(stored);
-  if (isSortAvailable({ type: 'images', value: sort }, availability)) return sort;
-
-  return ImageSort.MostReactions;
+  return resolveFeedSort({ type: 'images', value: sort }, availability);
 }
 
 /** What a hub this viewer creates is sorted by, so it is never stored on one they cannot pick. */

--- a/src/components/Image/__tests__/useImageFilters-sort.test.ts
+++ b/src/components/Image/__tests__/useImageFilters-sort.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as SortAvailability from '~/components/Filters/sort-availability';
+
+/**
+ * Filtering the sort MENU is not the fix — the withheld sort stays selected and
+ * stays in the query. This suite covers the query half: what a feed asks the
+ * server for, from the store, from a `?sort=` link, and from the schema default.
+ *
+ * `resolveFeedSort` is left real: mocking it would leave the rule under test
+ * unexercised, which is the failure this file exists to prevent.
+ */
+const state = vi.hoisted(() => ({
+  storeFilters: {} as Record<string, unknown>,
+  queryParams: {} as Record<string, unknown>,
+  availability: { isModerator: false, canViewNsfw: false, showNsfw: false },
+}));
+
+vi.mock('~/providers/FiltersProvider', () => ({
+  useFiltersContext: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ modelImages: state.storeFilters, images: state.storeFilters }),
+}));
+
+vi.mock('~/components/Filters/useSortAvailability', () => ({
+  useSortAvailability: () => state.availability,
+}));
+
+vi.mock('~/hooks/useZodRouteParams', () => ({
+  useZodRouteParams: () => ({ query: state.queryParams }),
+}));
+
+import { useImageFilters } from '~/components/Image/image.utils';
+import { ImageSort } from '~/server/common/enums';
+
+function renderHook<T>(useCb: () => T) {
+  const root = createRoot(document.createElement('div'));
+  const ref: { current: T | undefined } = { current: undefined };
+  function Probe() {
+    ref.current = useCb();
+    return null;
+  }
+  act(() => root.render(React.createElement(Probe)));
+  act(() => root.unmount());
+  return ref.current as T;
+}
+
+beforeEach(() => {
+  state.storeFilters = {};
+  state.queryParams = {};
+  state.availability = { isModerator: false, canViewNsfw: false, showNsfw: false };
+});
+
+describe('useImageFilters — the sort the query actually runs on', () => {
+  it('replaces a stored sort this viewer is not offered', () => {
+    state.storeFilters = { sort: ImageSort.Newest, period: 'AllTime' };
+
+    const filters = renderHook(() => useImageFilters('modelImages'));
+
+    expect(filters.sort).toBe(ImageSort.MostReactions);
+    // Nothing else about the filters moved.
+    expect(filters.period).toBe('AllTime');
+  });
+
+  it('replaces one arriving in the url, which the store never sees', () => {
+    state.storeFilters = { sort: ImageSort.MostReactions };
+    state.queryParams = { sort: ImageSort.Newest };
+
+    expect(renderHook(() => useImageFilters('images')).sort).toBe(ImageSort.MostReactions);
+  });
+
+  it('leaves the viewer their own choice when the menu offers it', () => {
+    // The control: without this, a resolver that returned MostReactions for
+    // everything would pass both assertions above.
+    state.storeFilters = { sort: ImageSort.MostCollected };
+
+    expect(renderHook(() => useImageFilters('modelImages')).sort).toBe(ImageSort.MostCollected);
+
+    state.availability = { isModerator: false, canViewNsfw: true, showNsfw: true };
+    state.storeFilters = { sort: ImageSort.Newest };
+
+    expect(renderHook(() => useImageFilters('modelImages')).sort).toBe(ImageSort.Newest);
+  });
+});
+
+describe('resolveFeedSort is what does it', () => {
+  it('is the same rule the sort menu filters its options with', async () => {
+    const sortAvailability = await vi.importActual<typeof SortAvailability>(
+      '~/components/Filters/sort-availability'
+    );
+
+    state.storeFilters = { sort: ImageSort.Newest };
+    const filters = renderHook(() => useImageFilters('modelImages'));
+
+    expect(
+      sortAvailability.isSortAvailable(
+        { type: 'modelImages', value: filters.sort },
+        state.availability
+      )
+    ).toBe(true);
+  });
+});

--- a/src/components/Image/image.utils.ts
+++ b/src/components/Image/image.utils.ts
@@ -1,3 +1,5 @@
+import { resolveFeedSort } from '~/components/Filters/sort-availability';
+import { useSortAvailability } from '~/components/Filters/useSortAvailability';
 import { withPlaceholderData } from '~/hooks/trpcHelpers';
 import { closeModal, openConfirmModal } from '@mantine/modals';
 import { hideNotification, showNotification } from '@mantine/notifications';
@@ -121,8 +123,12 @@ export const getDefaultMediaTypes = (
 export const useImageFilters = (type: FilterKeys<'images' | 'videos' | 'modelImages'>) => {
   const storeFilters = useFiltersContext((state) => state[type]);
   const { query } = useImageQueryParams(); // router params are the overrides
+  const availability = useSortAvailability();
 
-  return removeEmpty({ ...storeFilters, ...query });
+  const filters = removeEmpty({ ...storeFilters, ...query });
+  // A sort the menu withholds is still a sort the query runs on, whether it came
+  // from the store, a link or the schema default.
+  return { ...filters, sort: resolveFeedSort({ type, value: filters.sort }, availability) };
 };
 
 export const useDumbImageFilters = (defaultFilters?: Partial<GetInfiniteImagesInput>) => {

--- a/src/providers/FiltersProvider.tsx
+++ b/src/providers/FiltersProvider.tsx
@@ -103,7 +103,9 @@ const imageFilterSchema = z.object({
 
 type ModelImageFilterSchema = z.infer<typeof modelImageFilterSchema>;
 const modelImageFilterSchema = imageFilterSchema.extend({
-  sort: z.enum(ImageSort).default(ImageSort.Newest), // Default sort for model images should be newest
+  // Most Reactions, not Newest: a model gallery opening on Newest fronts images
+  // that may not be rated yet, which is the sort SFW viewers are not offered.
+  sort: z.enum(ImageSort).default(ImageSort.MostReactions),
   period: z.enum(MetricTimeframe).default(MetricTimeframe.AllTime), //Default period for model details should be all time
   types: z.array(z.enum(MediaType)).default([]),
 });


### PR DESCRIPTION
Your call from the request card: image and video feeds only, and change the model
gallery's default. Both are here — the default change alone does not reach anyone
who already picked Newest, since that choice is persisted per browser.

### What was wrong

`DumbSortFilter` filtered the sort **menu** through `isSortAvailable` and passed
the **selected value** through untouched. Nothing else in the app called that rule
— only this component and `hub-sort.ts` — so `useImageFilters` handed the withheld
sort straight to the query.

So a viewer without `canViewNsfw` on a model page saw a control reading "Newest"
above a menu offering only Most Reactions / Most Comments / Most Collected, and a
gallery that really was sorted newest-first. Not a wrong label: the sort the rule
exists to withhold was the sort in force.

### What changed

- `modelImages` defaults to `MostReactions` (it was `Newest`, deliberately).
- `resolveFeedSort` in `sort-availability.ts` returns Most Reactions when the menu
  will not offer what it is given, and both reads of an image feed's sort go
  through it — the control in `DumbSortFilter`, and the query in `useImageFilters`.
  Resolved on read, never written back, so regaining NSFW browsing hands the
  viewer their own choice again.
- `resolveHubSort` is now that same function. Hub behaviour is unchanged and its
  existing suite pins that.

**Scope.** Only `images`, `videos` and `modelImages`. The rule withholds
Newest/Oldest from every feed type, but it exists because a freshly posted *image*
may not be rated yet — so models, threads, tools, generation and buzz withdrawals
keep whatever they hold, per your "I'm fine with newest on all of those other
places".

### Who sees a change

| viewer | before | after |
| --- | --- | --- |
| SFW domain, model gallery | control said Newest, feed *was* newest-first | Most Reactions, and the menu agrees |
| NSFW-capable, model gallery, no saved choice | Newest | Most Reactions (the default change you asked for) |
| anyone with a saved sort the menu offers | their choice | unchanged |
| `?sort=Newest` link opened on a SFW domain | ran Newest | Most Reactions |
| hubs | — | unchanged |

### Verified

Reverting each half turns the new suites red — without `resolveFeedSort` 6 tests
fail across the two files, without the `useImageFilters` call 3 fail. Both suites
carry a control that would catch a resolver returning Most Reactions for
everything.

Full unit suite green (20961 passed, 0 failed). Typecheck clean apart from the
pre-existing `packages/civitai-telemetry` error on `main`. eslint and prettier
clean.

Not covered: `ResourceSelectSort` in the generation resource picker is a third
hand-rolled copy of this rule with no moderator bypass. Left out on purpose —
it changes generator behaviour. Ticket 868kv6mzm.

Ticket: 868kv6mz9.
