### PR TITLE
perf(obs): put a timer on the orchestrator submit — 8-10% of all tRPC wall time had no instrument

### DIFF
--- a/packages/civitai-telemetry/src/otel-helpers.ts
+++ b/packages/civitai-telemetry/src/otel-helpers.ts
@@ -1,6 +1,48 @@
-import { trace, context, ROOT_CONTEXT, SpanStatusCode } from '@opentelemetry/api';
+import { trace, context, propagation, ROOT_CONTEXT, SpanStatusCode } from '@opentelemetry/api';
 
 const tracer = trace.getTracer('civitai-app');
+
+/**
+ * Set attributes on the CURRENTLY ACTIVE span, if there is one. For values only known after the
+ * work inside a `withSpan` callback has finished (a result count, an attempt count) — call it from
+ * INSIDE the callback, where the active span is the one `withSpan` opened; called outside, the
+ * active span is the caller's and the attribute lands on the wrong span. No-op when tracing is
+ * disabled or no span is active, and never throws.
+ */
+export function setActiveSpanAttributes(attrs: Record<string, string | number | boolean>): void {
+  try {
+    trace.getActiveSpan()?.setAttributes(attrs);
+  } catch {
+    // Telemetry must never fail the work it describes.
+  }
+}
+
+/**
+ * W3C trace-context headers (`traceparent`, and `tracestate` when present) for the
+ * CURRENTLY ACTIVE span, ready to merge into an outbound request's headers.
+ *
+ * WHY this exists as a manual helper rather than an auto-instrumentation: this app runs
+ * `HttpInstrumentation({ ignoreOutgoingRequestHook: () => true })` (instrumentation.node.ts)
+ * — outbound client spans, and with them traceparent injection, are deliberately suppressed
+ * on Node core http/https for their per-request `async_hooks` cost. The orchestrator and
+ * meilisearch clients use fetch/undici and were NEVER auto-instrumented at all, so no
+ * outbound call anywhere in the app currently carries a traceparent and no trace crosses a
+ * service boundary. Injecting per-call — only at the boundaries we care about — buys the
+ * cross-service linkage without re-introducing the whole-app span cost that was removed.
+ *
+ * TOTAL and cheap: it reads the ambient context and writes strings. When OTEL is disabled
+ * the global propagator is the API's no-op, so this returns `{}` and callers spread nothing.
+ * Never throws — a telemetry fault must not fail the request it is describing.
+ */
+export function traceContextHeaders(): Record<string, string> {
+  try {
+    const carrier: Record<string, string> = {};
+    propagation.inject(context.active(), carrier);
+    return carrier;
+  } catch {
+    return {};
+  }
+}
 
 export function withSpan<T>(name: string, fn: () => T): T;
 export function withSpan<T>(
@@ -13,8 +55,7 @@ export function withSpan<T>(
   attrsOrFn: Record<string, string | number | boolean> | (() => T),
   maybeFn?: () => T
 ): T {
-  const [attrs, fn] =
-    typeof attrsOrFn === 'function' ? [{}, attrsOrFn] : [attrsOrFn, maybeFn!];
+  const [attrs, fn] = typeof attrsOrFn === 'function' ? [{}, attrsOrFn] : [attrsOrFn, maybeFn!];
 
   return tracer.startActiveSpan(name, (span) => {
     try {

--- a/src/server/services/orchestrator/__tests__/submitWorkflow.instrumentation.test.ts
+++ b/src/server/services/orchestrator/__tests__/submitWorkflow.instrumentation.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Instrumentation contract for the orchestrator SUBMIT leg.
+ *
+ * WHY this file exists: `orchestrator.generateFromGraph` consumes ~9.5 server-s/s at the daily peak —
+ * ~12.6% of ALL dp-prod tRPC procedure wall time — and 82–98% of that latency sat in one contiguous
+ * interval with no span and no metric anywhere in it. The interval is structurally three things
+ * (pure-CPU metadata assembly, `refreshBlobUrlsInBody`, and the submit POST); the first two were
+ * excluded by live measurement, so the submit POST carries essentially the whole endpoint. These tests
+ * pin the four instruments that close that gap:
+ *
+ *   1. a `gen:submit:orchestrator` span around the retry-wrapped submit, plus a PER-ATTEMPT child span
+ *      (so a retried submit is distinguishable from a single slow one);
+ *   2. the `submit` op on the existing `civitai_app_orchestrator_read_duration_seconds` histogram;
+ *   3. the `onRetry` hook — which shipped with the retry wrapper and has had ZERO call sites, leaving a
+ *      3x latency multiplier completely uncounted — wired to a retries counter;
+ *   4. W3C trace-context propagation on the outbound call, so the (already-instrumented) orchestrator
+ *      can join the trace.
+ *
+ * 🔴 SCOPE OF WHAT THESE TESTS PROVE. They prove the CODE emits: a real (SDK-registered) span, a real
+ * prom-client observation on the shared registry, a real counter increment, and a real `traceparent` on
+ * the outbound options. They do NOT prove a span reaches Tempo in production — that additionally
+ * depends on `OTEL_ENABLED=true` and survives head sampling at ratio 0.1
+ * (`instrumentation.node.ts:182-185`), neither of which a unit test can exercise. To make the assertions
+ * meaningful rather than tautological, the span tests install a REAL `NodeTracerProvider` with an
+ * in-memory exporter and read back the exported spans — a `vi.fn()` stub for `withSpan` would prove
+ * only that we called our own wrapper.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import promClient from 'prom-client';
+import type * as TelemetryClient from '@civitai/telemetry/client';
+import {
+  NodeTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type ReadableSpan,
+} from '@opentelemetry/sdk-trace-node';
+
+const { mockSubmitWorkflow } = vi.hoisted(() => ({ mockSubmitWorkflow: vi.fn() }));
+
+vi.mock('@civitai/client', () => ({
+  submitWorkflow: mockSubmitWorkflow,
+  addWorkflowTag: vi.fn(),
+  deleteWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  patchWorkflow: vi.fn(),
+  queryWorkflows: vi.fn(),
+  removeWorkflowTag: vi.fn(),
+  updateWorkflow: vi.fn(),
+  refreshBlob: vi.fn(),
+  handleError: vi.fn((e: unknown) => (typeof e === 'string' ? e : 'err')),
+}));
+
+vi.mock('~/server/services/orchestrator/client', () => ({
+  createOrchestratorClient: vi.fn(() => ({})),
+  internalOrchestratorClient: {},
+}));
+
+vi.mock('~/env/other', () => ({ isDev: false, isProd: true }));
+
+// Use the REAL prom-client registry (not the global test stub in src/__tests__/setup.ts) so the
+// histogram/counter assertions read back what was ACTUALLY recorded on the shared `civitai_app_*`
+// registry that /api/metrics scrapes — the same technique as orchestrator-read-metrics.test.ts.
+vi.mock('~/server/prom/client', async () => {
+  const pkg = await vi.importActual<typeof TelemetryClient>('@civitai/telemetry/client');
+  return pkg;
+});
+
+import {
+  submitWorkflow,
+  submitWorkflowWithRetry,
+  withTraceHeaders,
+} from '~/server/services/orchestrator/workflows';
+import { withSpan } from '~/server/utils/otel-helpers';
+
+const DURATION = 'civitai_app_orchestrator_read_duration_seconds';
+const RETRIES = 'civitai_app_orchestrator_submit_retries_total';
+
+const exporter = new InMemorySpanExporter();
+let provider: NodeTracerProvider;
+
+beforeAll(() => {
+  // A REAL tracer provider. `.register()` installs the AsyncLocalStorage context manager AND the W3C
+  // propagator, i.e. the same two globals `instrumentation.node.ts` installs in production — so both
+  // the span assertions and the traceparent assertions below run against real machinery. Without a
+  // registered provider the `@opentelemetry/api` tracer is a no-op, the propagator injects nothing,
+  // and EVERY assertion in this file would pass vacuously; the first test is the positive control
+  // that proves it did not.
+  provider = new NodeTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
+  provider.register();
+});
+
+afterAll(async () => {
+  await provider.shutdown();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  exporter.reset();
+});
+
+const okResult = (id = 'wf-1') => ({ data: { id }, response: { status: 200 } });
+const serverErrorResult = (status = 500) => ({ data: undefined, response: { status } });
+const timeoutError = () =>
+  Object.assign(new Error('The operation was aborted due to timeout'), { name: 'TimeoutError' });
+const timeoutResolveResult = () => ({
+  data: undefined,
+  response: undefined,
+  error: timeoutError(),
+});
+
+const spanNames = (): string[] => exporter.getFinishedSpans().map((s: ReadableSpan) => s.name);
+const spansNamed = (name: string): ReadableSpan[] =>
+  exporter.getFinishedSpans().filter((s: ReadableSpan) => s.name === name);
+
+async function histCount(op: string, outcome: string): Promise<number> {
+  const metric = promClient.register.getSingleMetric(DURATION) as promClient.Histogram<string>;
+  if (!metric) return 0;
+  const data = await metric.get();
+  const row = data.values.find(
+    (v) =>
+      v.metricName === `${DURATION}_count` && v.labels.op === op && v.labels.outcome === outcome
+  );
+  return (row?.value as number) ?? 0;
+}
+
+async function retryCount(attempt: string, outcome: string): Promise<number> {
+  const metric = promClient.register.getSingleMetric(RETRIES) as promClient.Counter<string>;
+  if (!metric) return 0;
+  const data = await metric.get();
+  const row = data.values.find((v) => v.labels.attempt === attempt && v.labels.outcome === outcome);
+  return (row?.value as number) ?? 0;
+}
+
+// Backoff uses real setTimeout; skip it deterministically so a 3-attempt case doesn't cost ~2s.
+const runWithFakeTimers = async <T>(fn: () => Promise<T>): Promise<T> => {
+  vi.useFakeTimers();
+  try {
+    const p = fn();
+    await vi.runAllTimersAsync();
+    return await p;
+  } finally {
+    vi.useRealTimers();
+  }
+};
+
+describe('gen:submit:orchestrator — the span over the uninstrumented interval', () => {
+  it('emits a real, SDK-exported span around the submit (positive control: the exporter DOES see spans)', async () => {
+    mockSubmitWorkflow.mockResolvedValue(okResult());
+
+    await submitWorkflow({ token: 'tok', body: {} as never, query: {} as never });
+
+    // If the tracer provider were not registered this list would be empty and every other span
+    // assertion in this file would pass vacuously. Assert non-empty FIRST.
+    expect(exporter.getFinishedSpans().length).toBeGreaterThan(0);
+    expect(spanNames()).toContain('gen:submit:orchestrator');
+  });
+
+  it('records the attempts count on the parent span, so a 3x-retry park is distinguishable from one long attempt', async () => {
+    mockSubmitWorkflow
+      .mockResolvedValueOnce(serverErrorResult(500))
+      .mockResolvedValueOnce(serverErrorResult(503))
+      .mockResolvedValueOnce(okResult('wf-3'));
+
+    await runWithFakeTimers(() =>
+      submitWorkflow({ token: 'tok', body: {} as never, query: {} as never })
+    );
+
+    const parent = spansNamed('gen:submit:orchestrator');
+    expect(parent).toHaveLength(1);
+    // 🔴 The load-bearing attribute: `attempts` is what the wrapper has always returned and every
+    // caller has always discarded. Without it a ~95s span is unattributable between `3 x ~30s` and
+    // one ~95s attempt.
+    expect(parent[0].attributes['orchestrator.submit.attempts']).toBe(3);
+    expect(parent[0].attributes['orchestrator.submit.whatif']).toBe(false);
+  });
+
+  it('emits ONE per-attempt child span per attempt, numbered, nested under the parent', async () => {
+    mockSubmitWorkflow
+      .mockResolvedValueOnce(serverErrorResult(502))
+      .mockResolvedValueOnce(okResult('wf-2'));
+
+    await runWithFakeTimers(() =>
+      submitWorkflow({ token: 'tok', body: {} as never, query: {} as never })
+    );
+
+    const attempts = spansNamed('gen:submit:orchestrator:attempt');
+    expect(attempts).toHaveLength(2);
+    expect(attempts.map((s) => s.attributes['orchestrator.submit.attempt'])).toEqual([1, 2]);
+    // Nesting is the whole point: the children must sit UNDER the submit span, not beside it, or a
+    // trace cannot show three attempts adding up to one park.
+    const parent = spansNamed('gen:submit:orchestrator')[0];
+    for (const a of attempts) expect(a.parentSpanContext?.spanId).toBe(parent.spanContext().spanId);
+  });
+
+  it('a single slow submit produces exactly ONE attempt span (the discriminator this PR exists for)', async () => {
+    mockSubmitWorkflow.mockResolvedValue(okResult());
+
+    await submitWorkflow({ token: 'tok', body: {} as never, query: {} as never });
+
+    expect(spansNamed('gen:submit:orchestrator:attempt')).toHaveLength(1);
+    expect(
+      spansNamed('gen:submit:orchestrator')[0].attributes['orchestrator.submit.attempts']
+    ).toBe(1);
+  });
+});
+
+describe('civitai_app_orchestrator_read_duration_seconds{op="submit"} — sizing the leg', () => {
+  it('records exactly one ok observation per successful submit', async () => {
+    mockSubmitWorkflow.mockResolvedValue(okResult());
+    const before = await histCount('submit', 'ok');
+
+    await submitWorkflow({ token: 'tok', body: {} as never, query: {} as never });
+
+    expect(await histCount('submit', 'ok')).toBe(before + 1);
+  });
+
+  it('records ONE observation (not one per attempt) for a retried submit — the caller-visible interval', async () => {
+    mockSubmitWorkflow
+      .mockResolvedValueOnce(serverErrorResult(500))
+      .mockResolvedValueOnce(okResult());
+    const before = await histCount('submit', 'ok');
+
+    await runWithFakeTimers(() =>
+      submitWorkflow({ token: 'tok', body: {} as never, query: {} as never })
+    );
+
+    // Whole-call timing: 2 attempts, ONE observation. Anything else double-counts the leg against the
+    // procedure's own wall time, which is the single comparison this metric exists to support.
+    expect(await histCount('submit', 'ok')).toBe(before + 1);
+  });
+
+  it('classifies an exhausted per-attempt abort as outcome=timeout, not error', async () => {
+    mockSubmitWorkflow.mockResolvedValue(timeoutResolveResult());
+    const beforeTimeout = await histCount('submit', 'timeout');
+    const beforeError = await histCount('submit', 'error');
+
+    await runWithFakeTimers(() =>
+      submitWorkflow({ token: 'tok', body: {} as never, query: { whatif: true } as never }).catch(
+        (e) => e
+      )
+    );
+
+    expect(await histCount('submit', 'timeout')).toBe(beforeTimeout + 1);
+    expect(await histCount('submit', 'error')).toBe(beforeError);
+  });
+
+  it('records an error observation when the final attempt THROWS', async () => {
+    mockSubmitWorkflow.mockRejectedValue(new TypeError('boom'));
+    const before = await histCount('submit', 'error');
+
+    await runWithFakeTimers(() =>
+      submitWorkflow({ token: 'tok', body: {} as never, query: {} as never }).catch((e) => e)
+    );
+
+    expect(await histCount('submit', 'error')).toBe(before + 1);
+  });
+
+  it('carries buckets above 30s, or the entire population this metric was added to see collapses into +Inf', async () => {
+    const metric = promClient.register.getSingleMetric(DURATION) as promClient.Histogram<string>;
+    const data = await metric.get();
+    const buckets = new Set(
+      data.values
+        .filter((v) => v.metricName === `${DURATION}_bucket`)
+        .map((v) => String(v.labels.le))
+    );
+    // The generate submit has NO per-attempt timeout and its observed ceiling recurs at ~95s.
+    expect(buckets.has('45')).toBe(true);
+    expect(buckets.has('90')).toBe(true);
+    // Purely additive: every pre-existing boundary must survive, or existing read queries change meaning.
+    for (const le of ['0.005', '0.05', '0.5', '1', '2', '5', '10', '20', '30'])
+      expect(buckets.has(le)).toBe(true);
+  });
+});
+
+describe('onRetry → civitai_app_orchestrator_submit_retries_total (the 3x multiplier, finally counted)', () => {
+  it('increments once per fired retry, labeled by the FAILED attempt and its 5xx status', async () => {
+    mockSubmitWorkflow
+      .mockResolvedValueOnce(serverErrorResult(500))
+      .mockResolvedValueOnce(serverErrorResult(503))
+      .mockResolvedValueOnce(okResult());
+    const before1 = await retryCount('1', '500');
+    const before2 = await retryCount('2', '503');
+
+    await runWithFakeTimers(() =>
+      submitWorkflow({ token: 'tok', body: {} as never, query: {} as never })
+    );
+
+    // 🔴 The assertion the mutation test targets: a 3-attempt submit contributes exactly 2 retries,
+    // attributed to the attempt that failed and the status it failed with.
+    expect(await retryCount('1', '500')).toBe(before1 + 1);
+    expect(await retryCount('2', '503')).toBe(before2 + 1);
+  });
+
+  // ⚠️ INVARIANT GUARD, not regression coverage: this passes at the pre-change base too (the counter
+  // did not exist there, so 0 === 0). It pins that the counter stays quiet on the happy path — worth
+  // having, but it is NOT evidence the wiring works. The two tests above it are.
+  it('does NOT increment when the submit succeeds first try', async () => {
+    mockSubmitWorkflow.mockResolvedValue(okResult());
+    const before = await retryCount('1', '500');
+
+    await submitWorkflow({ token: 'tok', body: {} as never, query: {} as never });
+
+    expect(await retryCount('1', '500')).toBe(before);
+  });
+
+  it('labels a status-less failure (thrown network error / fired abort) as outcome=network', async () => {
+    mockSubmitWorkflow.mockRejectedValueOnce(timeoutError()).mockResolvedValueOnce(okResult());
+    const before = await retryCount('1', 'network');
+
+    await runWithFakeTimers(() =>
+      submitWorkflow({ token: 'tok', body: {} as never, query: {} as never })
+    );
+
+    expect(await retryCount('1', 'network')).toBe(before + 1);
+  });
+
+  // ⚠️ INVARIANT GUARD, not regression coverage: also green at the pre-change base, because the hook
+  // itself always worked — it simply had no call sites. It pins the hook's contract for the direct
+  // callers (orchestrator.service.ts, blocks.router.ts) so a future refactor of the wrapper cannot
+  // quietly drop the parameter that this PR's wiring now depends on.
+  it('still counts the retry when the caller passes its OWN onRetry (wiring must not be caller-exclusive)', async () => {
+    mockSubmitWorkflow
+      .mockResolvedValueOnce(serverErrorResult(504))
+      .mockResolvedValueOnce(okResult());
+    const seen: number[] = [];
+
+    await runWithFakeTimers(() =>
+      submitWorkflowWithRetry(
+        { client: {} as never, body: {} as never },
+        { baseDelayMs: 1, onRetry: ({ attempt, status }) => seen.push(status ?? attempt) }
+      )
+    );
+
+    expect(seen).toEqual([504]);
+  });
+});
+
+describe('W3C trace-context propagation on the outbound submit', () => {
+  it('sends a traceparent bound to the ATTEMPT span, so the orchestrator joins THIS trace', async () => {
+    mockSubmitWorkflow.mockResolvedValue(okResult());
+
+    await submitWorkflow({ token: 'tok', body: {} as never, query: {} as never });
+
+    const headers = mockSubmitWorkflow.mock.calls[0][0].headers as Record<string, string>;
+    expect(headers).toBeTruthy();
+    expect(headers.traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/);
+
+    // 🔴 Not just "a traceparent exists" — it must carry the ATTEMPT span's ids, or the orchestrator's
+    // spans parent onto nothing useful. A test asserting only the regex would pass on a hardcoded string.
+    const attemptSpan = spansNamed('gen:submit:orchestrator:attempt')[0];
+    const [, traceId, spanId] = headers.traceparent.split('-');
+    expect(traceId).toBe(attemptSpan.spanContext().traceId);
+    expect(spanId).toBe(attemptSpan.spanContext().spanId);
+  });
+
+  it('gives each ATTEMPT a distinct span id in its traceparent (same trace, different parent)', async () => {
+    mockSubmitWorkflow
+      .mockResolvedValueOnce(serverErrorResult(500))
+      .mockResolvedValueOnce(okResult());
+
+    await runWithFakeTimers(() =>
+      submitWorkflow({ token: 'tok', body: {} as never, query: {} as never })
+    );
+
+    const tp1 = (mockSubmitWorkflow.mock.calls[0][0].headers as Record<string, string>).traceparent;
+    const tp2 = (mockSubmitWorkflow.mock.calls[1][0].headers as Record<string, string>).traceparent;
+    expect(tp1.split('-')[1]).toBe(tp2.split('-')[1]); // same trace id
+    expect(tp1.split('-')[2]).not.toBe(tp2.split('-')[2]); // different span id per attempt
+  });
+
+  // 🔴 These MUST run inside an active span. Outside one the propagator injects nothing,
+  // `withTraceHeaders` short-circuits and returns its argument by reference, and every assertion below
+  // would pass while testing nothing at all — the merge branches would never execute.
+  it('withTraceHeaders never clobbers a caller-supplied header, in any of the three header shapes', () => {
+    withSpan('test:headers', () => {
+      // Plain record — the shape every caller in this repo uses.
+      const record = withTraceHeaders({ 'x-caller': 'keep', traceparent: 'caller-wins' }) as Record<
+        string,
+        string
+      >;
+      expect(record['x-caller']).toBe('keep');
+      expect(record.traceparent).toBe('caller-wins');
+
+      // A `Headers` instance would be silently EMPTIED by a naive object spread — pin that it is not,
+      // and that the trace header was still added alongside.
+      const asHeaders = withTraceHeaders(new Headers({ 'x-caller': 'keep' })) as Headers;
+      expect(asHeaders.get('x-caller')).toBe('keep');
+      expect(asHeaders.get('traceparent')).toMatch(/^00-[0-9a-f]{32}-/);
+
+      // A [name, value][] array would spread to INDEX keys — pin that it is normalized instead.
+      const asArray = withTraceHeaders([['x-caller', 'keep']] as unknown as Headers) as Headers;
+      expect(asArray.get('x-caller')).toBe('keep');
+      expect(asArray.get('traceparent')).toMatch(/^00-[0-9a-f]{32}-/);
+    });
+  });
+
+  it('withTraceHeaders is a pass-through when no span is active (tracing off ⇒ byte-identical behavior)', () => {
+    const original = { 'x-caller': 'keep' };
+    // No active span → the propagator injects nothing → the caller's value is returned BY REFERENCE.
+    // This is the negative control for the test above: it proves the merge branches are reached there
+    // because of the span, not unconditionally.
+    expect(withTraceHeaders(original)).toBe(original);
+    expect(withTraceHeaders(undefined)).toBeUndefined();
+  });
+});

--- a/src/server/services/orchestrator/__tests__/submitWorkflow.instrumentation.test.ts
+++ b/src/server/services/orchestrator/__tests__/submitWorkflow.instrumentation.test.ts
@@ -293,7 +293,7 @@ describe('onRetry → civitai_app_orchestrator_submit_retries_total (the 3x mult
 
   // ⚠️ INVARIANT GUARD, not regression coverage: this passes at the pre-change base too (the counter
   // did not exist there, so 0 === 0). It pins that the counter stays quiet on the happy path — worth
-  // having, but it is NOT evidence the wiring works. The two tests above it are.
+  // having, but it is NOT evidence the wiring works. The test above it is.
   it('does NOT increment when the submit succeeds first try', async () => {
     mockSubmitWorkflow.mockResolvedValue(okResult());
     const before = await retryCount('1', '500');
@@ -368,9 +368,11 @@ describe('W3C trace-context propagation on the outbound submit', () => {
     expect(tp1.split('-')[2]).not.toBe(tp2.split('-')[2]); // different span id per attempt
   });
 
-  // 🔴 These MUST run inside an active span. Outside one the propagator injects nothing,
-  // `withTraceHeaders` short-circuits and returns its argument by reference, and every assertion below
-  // would pass while testing nothing at all — the merge branches would never execute.
+  // 🔴 These MUST run inside an active span. Outside one the propagator injects nothing and
+  // `withTraceHeaders` short-circuits, returning its argument BY REFERENCE without entering any merge
+  // branch. The record case would then pass while testing nothing (it gets its own object back); the
+  // Headers and array cases would fail on the `traceparent` assertion rather than exercise the
+  // normalization. Either way the branches under test never run — hence the span.
   it('withTraceHeaders never clobbers a caller-supplied header, in any of the three header shapes', () => {
     withSpan('test:headers', () => {
       // Plain record — the shape every caller in this repo uses.

--- a/src/server/services/orchestrator/__tests__/submitWorkflow.instrumentation.test.ts
+++ b/src/server/services/orchestrator/__tests__/submitWorkflow.instrumentation.test.ts
@@ -17,10 +17,13 @@
  *   4. W3C trace-context propagation on the outbound call, so the (already-instrumented) orchestrator
  *      can join the trace.
  *
- * 🔴 EVERY instrument is recorded in `submitWorkflowWithRetry`, not in `submitWorkflow`. That is the
- * single funnel all submits pass through; `submitWorkflow` is NOT (image ingestion calls the wrapper
- * directly). Tests below pin that placement explicitly, because instrumenting a level up silently puts
- * the spans and the histogram on DIFFERENT populations and contaminates the attempts↔duration join.
+ * 🔴 EVERY instrument is recorded in `submitWorkflowWithRetry`, not in `submitWorkflow`. Every caller of
+ * `submitWorkflow` reaches the wrapper but not the reverse — image ingestion calls the wrapper directly —
+ * so the wrapper is the lower of the two funnels. Tests below pin that placement explicitly, because
+ * instrumenting a level up silently puts the spans and the histogram on DIFFERENT populations and
+ * contaminates the attempts↔duration join. (The wrapper is NOT the app's only route to the submit
+ * endpoint: five call sites use the generated client directly. That limit is documented on the metric
+ * help strings rather than tested here, because closing it would be a behaviour change.)
  *
  * 🔴 SCOPE OF WHAT THESE TESTS PROVE. They prove the CODE emits: a real (SDK-registered) span, a real
  * prom-client observation on the shared registry with a PLAUSIBLE value in the right unit, a real
@@ -77,7 +80,12 @@ import {
   withTraceHeaders,
 } from '~/server/services/orchestrator/workflows';
 import { observeOrchestratorRead } from '~/server/services/orchestrator/orchestrator-read-metrics';
-import { classifySubmitRetryOutcome } from '~/server/services/orchestrator/orchestrator-submit-metrics';
+import {
+  clampSubmitSource,
+  classifySubmitRetryOutcome,
+  submitSourceForSurface,
+} from '~/server/services/orchestrator/orchestrator-submit-metrics';
+import { GENERATION_SURFACES } from '~/shared/data-graph/generation/model-substitution';
 import { withSpan } from '~/server/utils/otel-helpers';
 
 const DURATION = 'civitai_app_orchestrator_submit_duration_seconds';
@@ -407,6 +415,22 @@ describe('the instruments live on the ONE funnel every submit passes through', (
     );
   });
 
+  // 🔴 The span's `attempts` attribute is claimed to settle "is a ~95s park 3x30s or one long attempt?".
+  // It was set only on the RESOLVE path, so the throw-shaped park — a network failure that exhausts every
+  // attempt — produced a span with NO attempt count, which is one of the exactly two shapes the attribute
+  // exists to tell apart. The fired-AbortSignal park resolves instead, which is why this read as covered.
+  it('stamps `attempts` on the parent span even when the submit exhausts its attempts by THROWING', async () => {
+    mockSubmitWorkflow.mockRejectedValue(new TypeError('socket hang up'));
+
+    await runWithFakeTimers(() =>
+      submitWorkflowWithRetry({ client: {} as never, body: {} as never }).catch((e) => e)
+    );
+
+    const parent = spansNamed('orchestrator:submit');
+    expect(parent).toHaveLength(1);
+    expect(parent[0].attributes['orchestrator.submit.attempts']).toBe(3);
+  });
+
   it('an unlabelled caller lands in `other`, never silently in `generate`', async () => {
     mockSubmitWorkflow.mockResolvedValue(okResult());
     const beforeOther = await histCount('other', 'ok');
@@ -434,6 +458,44 @@ describe('the instruments live on the ONE funnel every submit passes through', (
 
     expect(await histCount('whatIf', 'ok')).toBe(beforeWhatIf + 1);
     expect(await histCount('generate', 'ok')).toBe(beforeGenerate);
+  });
+
+  // The coercion lives in the WRAPPER, not in `submitWorkflow`, so it applies to a direct caller too.
+  // Pinning this is the difference between the label's docstring ("any submit carrying
+  // query.whatif === true") being true and being true-only-for-callers-who-took-the-long-way.
+  it('classifies a DIRECT wrapper call carrying query.whatif as whatIf, not as its declared source', async () => {
+    mockSubmitWorkflow.mockResolvedValue(okResult());
+    const beforeWhatIf = await histCount('whatIf', 'ok');
+    const beforeIngest = await histCount('imageIngest', 'ok');
+
+    await submitWorkflowWithRetry(
+      { client: {} as never, body: {} as never, query: { whatif: true } as never },
+      { source: 'imageIngest' }
+    );
+
+    expect(await histCount('whatIf', 'ok')).toBe(beforeWhatIf + 1);
+    expect(await histCount('imageIngest', 'ok')).toBe(beforeIngest);
+  });
+
+  // 🔴 The TYPE on `source` is a compile-time guarantee only, and excess-property checking does not
+  // apply to spread properties — so a call site doing `submitWorkflow({ ...opts, token })` where `opts`
+  // carries a stray `source` string would mint an unbounded label on a hot-path histogram with a fully
+  // green suite. The runtime clamp is what actually bounds it; this is the test that the clamp exists.
+  it('clamps an out-of-enum source to `other` rather than minting an unbounded label', async () => {
+    mockSubmitWorkflow.mockResolvedValue(okResult());
+    const beforeOther = await histCount('other', 'ok');
+
+    await submitWorkflowWithRetry(
+      { client: {} as never, body: {} as never },
+      { source: 'definitely-not-a-source' as never }
+    );
+
+    expect(await histCount('other', 'ok')).toBe(beforeOther + 1);
+    expect(await histCount('definitely-not-a-source', 'ok')).toBe(0);
+    // …and the retries counter shares the clamp, not just the histogram.
+    expect(clampSubmitSource('definitely-not-a-source')).toBe('other');
+    expect(clampSubmitSource(undefined)).toBe('other');
+    expect(clampSubmitSource('preset')).toBe('preset');
   });
 });
 
@@ -504,13 +566,13 @@ describe('onRetry → civitai_app_orchestrator_submit_retries_total (the 3x mult
     expect(await retryCount('other', '1', '504')).toBe(before + 1);
   });
 
-  it('counts the retry even when the caller-supplied onRetry THROWS (our count is not hostage to it)', async () => {
+  it('counts the retry even when the caller-supplied onRetry THROWS, and still surfaces that throw', async () => {
     mockSubmitWorkflow
       .mockResolvedValueOnce(serverErrorResult(502))
       .mockResolvedValueOnce(okResult());
     const before = await retryCount('other', '1', '502');
 
-    await runWithFakeTimers(() =>
+    const thrown = await runWithFakeTimers(() =>
       submitWorkflowWithRetry(
         { client: {} as never, body: {} as never },
         {
@@ -519,10 +581,46 @@ describe('onRetry → civitai_app_orchestrator_submit_retries_total (the 3x mult
             throw new Error('caller hook exploded');
           },
         }
-      ).catch((e) => e)
+      ).catch((e: unknown) => e)
     );
 
     expect(await retryCount('other', '1', '502')).toBe(before + 1);
+    // 🔴 BOTH halves. Asserting only the counter leaves the caller-visible behaviour unpinned, and the
+    // most natural future "hardening" — wrapping `onRetry?.(info)` in a try/catch — would swallow the
+    // throw and change what callers see while this test stayed green.
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe('caller hook exploded');
+  });
+});
+
+describe('submitSourceForSurface — keeping a CRON JOB out of the headline population', () => {
+  // 🔴 `generateFromGraph` has two entry points and only one is the tRPC procedure: the preset/comics
+  // path reaches the same code, and one of ITS callers is the `process-enqueued-comic-panels` cron job,
+  // which runs outside the request path entirely. If `source` were stamped flat as `generate` there, the
+  // number that gets divided against `orchestrator.generateFromGraph`'s wall time would include a
+  // background job — the same contamination the label exists to remove, one level further up.
+  it('splits `preset` out of `generate`, so `generate` is the tRPC procedure and nothing else', () => {
+    expect(submitSourceForSurface('preset')).toBe('preset');
+    expect(submitSourceForSurface('onsite')).toBe('generate');
+    expect(submitSourceForSurface('api')).toBe('generate');
+  });
+
+  it('falls to `other` on an absent surface — an unknown caller must never inflate `generate`', () => {
+    expect(submitSourceForSurface(undefined)).toBe('other');
+  });
+
+  // Pins the mapping to the WHOLE surface enum rather than the three values spelled above, so a surface
+  // added later cannot silently default into `generate` without this test being looked at.
+  it('maps every declared GenerationSurface, and only `preset` leaves the generate population', () => {
+    const mapped = Object.fromEntries(
+      GENERATION_SURFACES.map((x) => [x, submitSourceForSurface(x)])
+    );
+    expect(mapped).toEqual({
+      api: 'generate',
+      block: 'generate',
+      onsite: 'generate',
+      preset: 'preset',
+    });
   });
 });
 

--- a/src/server/services/orchestrator/__tests__/submitWorkflow.instrumentation.test.ts
+++ b/src/server/services/orchestrator/__tests__/submitWorkflow.instrumentation.test.ts
@@ -2,28 +2,34 @@
  * Instrumentation contract for the orchestrator SUBMIT leg.
  *
  * WHY this file exists: `orchestrator.generateFromGraph` consumes ~9.5 server-s/s at the daily peak —
- * ~12.6% of ALL dp-prod tRPC procedure wall time — and 82–98% of that latency sat in one contiguous
- * interval with no span and no metric anywhere in it. The interval is structurally three things
- * (pure-CPU metadata assembly, `refreshBlobUrlsInBody`, and the submit POST); the first two were
- * excluded by live measurement, so the submit POST carries essentially the whole endpoint. These tests
- * pin the four instruments that close that gap:
+ * ~12.6% of ALL tRPC procedure wall time — and 82–98% of that latency sat in one contiguous interval
+ * with no span and no metric anywhere in it. The interval is structurally three things (pure-CPU
+ * metadata assembly, `refreshBlobUrlsInBody`, and the submit POST); the first two were excluded by live
+ * measurement, so the submit POST carries essentially the whole endpoint. These tests pin the
+ * instruments that close that gap:
  *
- *   1. a `gen:submit:orchestrator` span around the retry-wrapped submit, plus a PER-ATTEMPT child span
+ *   1. an `orchestrator:submit` span around the retry-wrapped submit, plus a PER-ATTEMPT child span
  *      (so a retried submit is distinguishable from a single slow one);
- *   2. the `submit` op on the existing `civitai_app_orchestrator_read_duration_seconds` histogram;
+ *   2. a sibling `civitai_app_orchestrator_submit_duration_seconds{source,outcome}` histogram — its
+ *      VALUE as well as its count, because the whole deliverable of this work is a duration number;
  *   3. the `onRetry` hook — which shipped with the retry wrapper and has had ZERO call sites, leaving a
  *      3x latency multiplier completely uncounted — wired to a retries counter;
  *   4. W3C trace-context propagation on the outbound call, so the (already-instrumented) orchestrator
  *      can join the trace.
  *
+ * 🔴 EVERY instrument is recorded in `submitWorkflowWithRetry`, not in `submitWorkflow`. That is the
+ * single funnel all submits pass through; `submitWorkflow` is NOT (image ingestion calls the wrapper
+ * directly). Tests below pin that placement explicitly, because instrumenting a level up silently puts
+ * the spans and the histogram on DIFFERENT populations and contaminates the attempts↔duration join.
+ *
  * 🔴 SCOPE OF WHAT THESE TESTS PROVE. They prove the CODE emits: a real (SDK-registered) span, a real
- * prom-client observation on the shared registry, a real counter increment, and a real `traceparent` on
- * the outbound options. They do NOT prove a span reaches Tempo in production — that additionally
- * depends on `OTEL_ENABLED=true` and survives head sampling at ratio 0.1
- * (`instrumentation.node.ts:182-185`), neither of which a unit test can exercise. To make the assertions
- * meaningful rather than tautological, the span tests install a REAL `NodeTracerProvider` with an
- * in-memory exporter and read back the exported spans — a `vi.fn()` stub for `withSpan` would prove
- * only that we called our own wrapper.
+ * prom-client observation on the shared registry with a PLAUSIBLE value in the right unit, a real
+ * counter increment, and a real `traceparent` on the outbound options. They do NOT prove a span reaches
+ * Tempo in production — that additionally depends on `OTEL_ENABLED=true` and survives head sampling at
+ * ratio 0.1 (`instrumentation.node.ts:182-185`), neither of which a unit test can exercise. To make the
+ * assertions meaningful rather than tautological, the span tests install a REAL `NodeTracerProvider`
+ * with an in-memory exporter and read back the exported spans — a `vi.fn()` stub for `withSpan` would
+ * prove only that we called our own wrapper.
  */
 import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
 import promClient from 'prom-client';
@@ -70,10 +76,14 @@ import {
   submitWorkflowWithRetry,
   withTraceHeaders,
 } from '~/server/services/orchestrator/workflows';
+import { observeOrchestratorRead } from '~/server/services/orchestrator/orchestrator-read-metrics';
+import { classifySubmitRetryOutcome } from '~/server/services/orchestrator/orchestrator-submit-metrics';
 import { withSpan } from '~/server/utils/otel-helpers';
 
-const DURATION = 'civitai_app_orchestrator_read_duration_seconds';
+const DURATION = 'civitai_app_orchestrator_submit_duration_seconds';
+const READ_DURATION = 'civitai_app_orchestrator_read_duration_seconds';
 const RETRIES = 'civitai_app_orchestrator_submit_retries_total';
+const TIMEOUTS = 'civitai_app_orchestrator_submit_timeouts_total';
 
 const exporter = new InMemorySpanExporter();
 let provider: NodeTracerProvider;
@@ -95,6 +105,12 @@ afterAll(async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // 🔴 `clearAllMocks` clears CALLS but NOT the `mockResolvedValueOnce` queue. A test whose submit
+  // throws before consuming every queued value leaves the remainder in place, and the next test's own
+  // `…Once(…)` lands BEHIND it — so that test silently exercises the previous test's fixture and can
+  // pass or fail for a reason that has nothing to do with it. `mockReset` empties the queue. (Found by
+  // exactly that: the 600-status reachability test read a leftover success and counted no retry.)
+  mockSubmitWorkflow.mockReset();
   exporter.reset();
 });
 
@@ -112,24 +128,49 @@ const spanNames = (): string[] => exporter.getFinishedSpans().map((s: ReadableSp
 const spansNamed = (name: string): ReadableSpan[] =>
   exporter.getFinishedSpans().filter((s: ReadableSpan) => s.name === name);
 
-async function histCount(op: string, outcome: string): Promise<number> {
-  const metric = promClient.register.getSingleMetric(DURATION) as promClient.Histogram<string>;
+async function histRow(
+  metricName: string,
+  suffix: string,
+  match: (labels: Record<string, string | number>) => boolean
+): Promise<number> {
+  const metric = promClient.register.getSingleMetric(metricName) as promClient.Histogram<string>;
   if (!metric) return 0;
   const data = await metric.get();
   const row = data.values.find(
-    (v) =>
-      v.metricName === `${DURATION}_count` && v.labels.op === op && v.labels.outcome === outcome
+    (v) => v.metricName === `${metricName}${suffix}` && match(v.labels as never)
   );
   return (row?.value as number) ?? 0;
 }
 
-async function retryCount(attempt: string, outcome: string): Promise<number> {
-  const metric = promClient.register.getSingleMetric(RETRIES) as promClient.Counter<string>;
+const histCount = (source: string, outcome: string) =>
+  histRow(DURATION, '_count', (l) => l.source === source && l.outcome === outcome);
+/** `_sum` — the observed VALUE, in seconds. The one number this whole change exists to produce. */
+const histSum = (source: string, outcome: string) =>
+  histRow(DURATION, '_sum', (l) => l.source === source && l.outcome === outcome);
+const histBucket = (source: string, outcome: string, le: string) =>
+  histRow(
+    DURATION,
+    '_bucket',
+    (l) => l.source === source && l.outcome === outcome && String(l.le) === le
+  );
+
+async function counterValue(
+  metricName: string,
+  match: (labels: Record<string, string | number>) => boolean
+): Promise<number> {
+  const metric = promClient.register.getSingleMetric(metricName) as promClient.Counter<string>;
   if (!metric) return 0;
   const data = await metric.get();
-  const row = data.values.find((v) => v.labels.attempt === attempt && v.labels.outcome === outcome);
+  const row = data.values.find((v) => match(v.labels as never));
   return (row?.value as number) ?? 0;
 }
+
+const retryCount = (source: string, attempt: string, outcome: string) =>
+  counterValue(
+    RETRIES,
+    (l) => l.source === source && l.attempt === attempt && l.outcome === outcome
+  );
+const timeoutCount = (source: string) => counterValue(TIMEOUTS, (l) => l.source === source);
 
 // Backoff uses real setTimeout; skip it deterministically so a 3-attempt case doesn't cost ~2s.
 const runWithFakeTimers = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -143,7 +184,7 @@ const runWithFakeTimers = async <T>(fn: () => Promise<T>): Promise<T> => {
   }
 };
 
-describe('gen:submit:orchestrator — the span over the uninstrumented interval', () => {
+describe('orchestrator:submit — the span over the uninstrumented interval', () => {
   it('emits a real, SDK-exported span around the submit (positive control: the exporter DOES see spans)', async () => {
     mockSubmitWorkflow.mockResolvedValue(okResult());
 
@@ -152,7 +193,7 @@ describe('gen:submit:orchestrator — the span over the uninstrumented interval'
     // If the tracer provider were not registered this list would be empty and every other span
     // assertion in this file would pass vacuously. Assert non-empty FIRST.
     expect(exporter.getFinishedSpans().length).toBeGreaterThan(0);
-    expect(spanNames()).toContain('gen:submit:orchestrator');
+    expect(spanNames()).toContain('orchestrator:submit');
   });
 
   it('records the attempts count on the parent span, so a 3x-retry park is distinguishable from one long attempt', async () => {
@@ -162,16 +203,16 @@ describe('gen:submit:orchestrator — the span over the uninstrumented interval'
       .mockResolvedValueOnce(okResult('wf-3'));
 
     await runWithFakeTimers(() =>
-      submitWorkflow({ token: 'tok', body: {} as never, query: {} as never })
+      submitWorkflow({ token: 'tok', source: 'generate', body: {} as never, query: {} as never })
     );
 
-    const parent = spansNamed('gen:submit:orchestrator');
+    const parent = spansNamed('orchestrator:submit');
     expect(parent).toHaveLength(1);
     // 🔴 The load-bearing attribute: `attempts` is what the wrapper has always returned and every
     // caller has always discarded. Without it a ~95s span is unattributable between `3 x ~30s` and
     // one ~95s attempt.
     expect(parent[0].attributes['orchestrator.submit.attempts']).toBe(3);
-    expect(parent[0].attributes['orchestrator.submit.whatif']).toBe(false);
+    expect(parent[0].attributes['orchestrator.submit.source']).toBe('generate');
   });
 
   it('emits ONE per-attempt child span per attempt, numbered, nested under the parent', async () => {
@@ -183,12 +224,12 @@ describe('gen:submit:orchestrator — the span over the uninstrumented interval'
       submitWorkflow({ token: 'tok', body: {} as never, query: {} as never })
     );
 
-    const attempts = spansNamed('gen:submit:orchestrator:attempt');
+    const attempts = spansNamed('orchestrator:submit:attempt');
     expect(attempts).toHaveLength(2);
     expect(attempts.map((s) => s.attributes['orchestrator.submit.attempt'])).toEqual([1, 2]);
     // Nesting is the whole point: the children must sit UNDER the submit span, not beside it, or a
     // trace cannot show three attempts adding up to one park.
-    const parent = spansNamed('gen:submit:orchestrator')[0];
+    const parent = spansNamed('orchestrator:submit')[0];
     for (const a of attempts) expect(a.parentSpanContext?.spanId).toBe(parent.spanContext().spanId);
   });
 
@@ -197,42 +238,79 @@ describe('gen:submit:orchestrator — the span over the uninstrumented interval'
 
     await submitWorkflow({ token: 'tok', body: {} as never, query: {} as never });
 
-    expect(spansNamed('gen:submit:orchestrator:attempt')).toHaveLength(1);
-    expect(
-      spansNamed('gen:submit:orchestrator')[0].attributes['orchestrator.submit.attempts']
-    ).toBe(1);
+    expect(spansNamed('orchestrator:submit:attempt')).toHaveLength(1);
+    expect(spansNamed('orchestrator:submit')[0].attributes['orchestrator.submit.attempts']).toBe(1);
   });
 });
 
-describe('civitai_app_orchestrator_read_duration_seconds{op="submit"} — sizing the leg', () => {
+describe('civitai_app_orchestrator_submit_duration_seconds — sizing the leg', () => {
   it('records exactly one ok observation per successful submit', async () => {
     mockSubmitWorkflow.mockResolvedValue(okResult());
-    const before = await histCount('submit', 'ok');
+    const before = await histCount('generate', 'ok');
 
+    await submitWorkflow({
+      token: 'tok',
+      source: 'generate',
+      body: {} as never,
+      query: {} as never,
+    });
+
+    expect(await histCount('generate', 'ok')).toBe(before + 1);
+  });
+
+  // 🔴 THE VALUE TEST. Every other assertion in this file proves only that "a number was written" —
+  // which is exactly how a 1000x unit error ships green. Three mutants survive a suite without this
+  // test: the duration hardcoded to 0, the timer restarted immediately before the observation, and
+  // MILLISECONDS instead of seconds. All three are caught here, and by two independent assertions
+  // each (the `_sum` band and the bucket placement), because the entire deliverable of this change is
+  // a duration number and nothing else in the file constrains it.
+  it('observes the duration in SECONDS, and it tracks the real elapsed time', async () => {
+    const DELAY_MS = 60;
+    mockSubmitWorkflow.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(okResult()), DELAY_MS))
+    );
+    const beforeSum = await histSum('other', 'ok');
+    const beforeFast = await histBucket('other', 'ok', '0.05');
+    const beforeSlow = await histBucket('other', 'ok', '5');
+
+    // REAL timers: a faked clock would let a hardcoded observation coincide with a faked elapsed.
     await submitWorkflow({ token: 'tok', body: {} as never, query: {} as never });
 
-    expect(await histCount('submit', 'ok')).toBe(before + 1);
+    const observed = (await histSum('other', 'ok')) - beforeSum;
+    // Lower bound kills `0` and kills a timer restarted just before the observation (both ≈ 0).
+    // `setTimeout(60)` cannot fire earlier than 60ms, so 30ms is a floor with 2x of slack.
+    expect(observed).toBeGreaterThanOrEqual(DELAY_MS / 1000 / 2);
+    // Upper bound kills MILLISECONDS-instead-of-seconds, which would record ≈60 here. A 60ms sleep
+    // cannot take 5 real seconds even on a loaded runner, so this band is wide AND still 12x below
+    // the value the unit bug produces.
+    expect(observed).toBeLessThan(5);
+
+    // Independent of the sum: bucket placement. A ≥60ms observation in seconds MUST fall above the
+    // 0.05 boundary and at or below 5 — the exact inverse of where the millisecond bug puts it.
+    expect(await histBucket('other', 'ok', '0.05')).toBe(beforeFast);
+    expect(await histBucket('other', 'ok', '5')).toBe(beforeSlow + 1);
   });
 
   it('records ONE observation (not one per attempt) for a retried submit — the caller-visible interval', async () => {
     mockSubmitWorkflow
       .mockResolvedValueOnce(serverErrorResult(500))
       .mockResolvedValueOnce(okResult());
-    const before = await histCount('submit', 'ok');
+    const before = await histCount('generate', 'ok');
 
     await runWithFakeTimers(() =>
-      submitWorkflow({ token: 'tok', body: {} as never, query: {} as never })
+      submitWorkflow({ token: 'tok', source: 'generate', body: {} as never, query: {} as never })
     );
 
     // Whole-call timing: 2 attempts, ONE observation. Anything else double-counts the leg against the
     // procedure's own wall time, which is the single comparison this metric exists to support.
-    expect(await histCount('submit', 'ok')).toBe(before + 1);
+    expect(await histCount('generate', 'ok')).toBe(before + 1);
   });
 
-  it('classifies an exhausted per-attempt abort as outcome=timeout, not error', async () => {
+  it('classifies an exhausted per-attempt abort as outcome=timeout, and counts it on the timeouts counter', async () => {
     mockSubmitWorkflow.mockResolvedValue(timeoutResolveResult());
-    const beforeTimeout = await histCount('submit', 'timeout');
-    const beforeError = await histCount('submit', 'error');
+    const beforeTimeout = await histCount('whatIf', 'timeout');
+    const beforeError = await histCount('whatIf', 'error');
+    const beforeCounter = await timeoutCount('whatIf');
 
     await runWithFakeTimers(() =>
       submitWorkflow({ token: 'tok', body: {} as never, query: { whatif: true } as never }).catch(
@@ -240,22 +318,33 @@ describe('civitai_app_orchestrator_read_duration_seconds{op="submit"} — sizing
       )
     );
 
-    expect(await histCount('submit', 'timeout')).toBe(beforeTimeout + 1);
-    expect(await histCount('submit', 'error')).toBe(beforeError);
+    expect(await histCount('whatIf', 'timeout')).toBe(beforeTimeout + 1);
+    expect(await histCount('whatIf', 'error')).toBe(beforeError);
+    expect(await timeoutCount('whatIf')).toBe(beforeCounter + 1);
   });
 
   it('records an error observation when the final attempt THROWS', async () => {
     mockSubmitWorkflow.mockRejectedValue(new TypeError('boom'));
-    const before = await histCount('submit', 'error');
+    const before = await histCount('generate', 'error');
 
     await runWithFakeTimers(() =>
-      submitWorkflow({ token: 'tok', body: {} as never, query: {} as never }).catch((e) => e)
+      submitWorkflow({
+        token: 'tok',
+        source: 'generate',
+        body: {} as never,
+        query: {} as never,
+      }).catch((e) => e)
     );
 
-    expect(await histCount('submit', 'error')).toBe(before + 1);
+    expect(await histCount('generate', 'error')).toBe(before + 1);
   });
 
   it('carries buckets above 30s, or the entire population this metric was added to see collapses into +Inf', async () => {
+    // prom-client materializes bucket rows only for label sets that have been observed, so make one
+    // observation here rather than depending on an earlier test having run.
+    mockSubmitWorkflow.mockResolvedValue(okResult());
+    await submitWorkflowWithRetry({ client: {} as never, body: {} as never });
+
     const metric = promClient.register.getSingleMetric(DURATION) as promClient.Histogram<string>;
     const data = await metric.get();
     const buckets = new Set(
@@ -266,9 +355,85 @@ describe('civitai_app_orchestrator_read_duration_seconds{op="submit"} — sizing
     // The generate submit has NO per-attempt timeout and its observed ceiling recurs at ~95s.
     expect(buckets.has('45')).toBe(true);
     expect(buckets.has('90')).toBe(true);
-    // Purely additive: every pre-existing boundary must survive, or existing read queries change meaning.
-    for (const le of ['0.005', '0.05', '0.5', '1', '2', '5', '10', '20', '30'])
-      expect(buckets.has(le)).toBe(true);
+    // …and a low end fine enough to resolve the healthy population, or the metric only sees parks.
+    expect(buckets.has('0.05')).toBe(true);
+  });
+
+  // ⚠️ INVARIANT GUARD, not regression coverage — measured green at the pre-change base, because the
+  // base read family already looked like this. It pins the DESIGN DECISION that the submit lives in its own
+  // family: prom-client applies one bucket array family-wide, so putting `submit` on the read family
+  // would mint >30s boundaries for two funnels hard-capped at 20s (never anything but a copy of
+  // le=30), force every read query to filter `op!="submit"` forever, and make `sum by (le)`
+  // non-monotonic across a rollout. This test fails the moment someone merges the two back together.
+  it('leaves the READ family completely untouched — no submit op, no widened buckets', async () => {
+    // One real read observation, so the read histogram materializes its bucket rows and this test is
+    // reading the family's ACTUAL boundaries rather than an empty value list that would vacuously pass.
+    observeOrchestratorRead('getWorkflow', 'ok', 0.01);
+
+    const metric = promClient.register.getSingleMetric(
+      READ_DURATION
+    ) as promClient.Histogram<string>;
+    const data = await metric.get();
+    const buckets = new Set(
+      data.values
+        .filter((v) => v.metricName === `${READ_DURATION}_bucket`)
+        .map((v) => String(v.labels.le))
+    );
+    for (const le of ['45', '60', '90', '120']) expect(buckets.has(le)).toBe(false);
+    expect(buckets.has('20')).toBe(true);
+    expect(data.values.some((v) => v.labels.op === 'submit')).toBe(false);
+  });
+});
+
+describe('the instruments live on the ONE funnel every submit passes through', () => {
+  // 🔴 REGRESSION COVERAGE for the seam. Image ingestion calls `submitWorkflowWithRetry` DIRECTLY and
+  // never touches `submitWorkflow`. Instrumenting a level up gave the attempt spans one population and
+  // the duration histogram another — the two signals this change exists to JOIN. This test builds the
+  // direct-call state and demands both signals from it.
+  it('a direct wrapper call (the image-ingestion shape) gets BOTH the span and the histogram', async () => {
+    mockSubmitWorkflow.mockResolvedValue(okResult());
+    const before = await histCount('imageIngest', 'ok');
+
+    await submitWorkflowWithRetry(
+      { client: {} as never, body: {} as never },
+      { source: 'imageIngest' }
+    );
+
+    expect(await histCount('imageIngest', 'ok')).toBe(before + 1);
+    expect(spansNamed('orchestrator:submit')).toHaveLength(1);
+    expect(spansNamed('orchestrator:submit:attempt')).toHaveLength(1);
+    expect(spansNamed('orchestrator:submit')[0].attributes['orchestrator.submit.source']).toBe(
+      'imageIngest'
+    );
+  });
+
+  it('an unlabelled caller lands in `other`, never silently in `generate`', async () => {
+    mockSubmitWorkflow.mockResolvedValue(okResult());
+    const beforeOther = await histCount('other', 'ok');
+    const beforeGenerate = await histCount('generate', 'ok');
+
+    await submitWorkflowWithRetry({ client: {} as never, body: {} as never });
+
+    expect(await histCount('other', 'ok')).toBe(beforeOther + 1);
+    // The whole point of the label: `generate` must mean the generate leg and nothing else, or the
+    // comparison against generateFromGraph's own wall time is contaminated by every other funnel.
+    expect(await histCount('generate', 'ok')).toBe(beforeGenerate);
+  });
+
+  it('a whatIf is always its own population, even when the caller declares another source', async () => {
+    mockSubmitWorkflow.mockResolvedValue(okResult());
+    const beforeWhatIf = await histCount('whatIf', 'ok');
+    const beforeGenerate = await histCount('generate', 'ok');
+
+    await submitWorkflow({
+      token: 'tok',
+      source: 'generate',
+      body: {} as never,
+      query: { whatif: true } as never,
+    });
+
+    expect(await histCount('whatIf', 'ok')).toBe(beforeWhatIf + 1);
+    expect(await histCount('generate', 'ok')).toBe(beforeGenerate);
   });
 });
 
@@ -278,17 +443,17 @@ describe('onRetry → civitai_app_orchestrator_submit_retries_total (the 3x mult
       .mockResolvedValueOnce(serverErrorResult(500))
       .mockResolvedValueOnce(serverErrorResult(503))
       .mockResolvedValueOnce(okResult());
-    const before1 = await retryCount('1', '500');
-    const before2 = await retryCount('2', '503');
+    const before1 = await retryCount('generate', '1', '500');
+    const before2 = await retryCount('generate', '2', '503');
 
     await runWithFakeTimers(() =>
-      submitWorkflow({ token: 'tok', body: {} as never, query: {} as never })
+      submitWorkflow({ token: 'tok', source: 'generate', body: {} as never, query: {} as never })
     );
 
     // 🔴 The assertion the mutation test targets: a 3-attempt submit contributes exactly 2 retries,
     // attributed to the attempt that failed and the status it failed with.
-    expect(await retryCount('1', '500')).toBe(before1 + 1);
-    expect(await retryCount('2', '503')).toBe(before2 + 1);
+    expect(await retryCount('generate', '1', '500')).toBe(before1 + 1);
+    expect(await retryCount('generate', '2', '503')).toBe(before2 + 1);
   });
 
   // ⚠️ INVARIANT GUARD, not regression coverage: this passes at the pre-change base too (the counter
@@ -296,32 +461,34 @@ describe('onRetry → civitai_app_orchestrator_submit_retries_total (the 3x mult
   // having, but it is NOT evidence the wiring works. The test above it is.
   it('does NOT increment when the submit succeeds first try', async () => {
     mockSubmitWorkflow.mockResolvedValue(okResult());
-    const before = await retryCount('1', '500');
+    const before = await retryCount('generate', '1', '500');
 
-    await submitWorkflow({ token: 'tok', body: {} as never, query: {} as never });
+    await submitWorkflow({
+      token: 'tok',
+      source: 'generate',
+      body: {} as never,
+      query: {} as never,
+    });
 
-    expect(await retryCount('1', '500')).toBe(before);
+    expect(await retryCount('generate', '1', '500')).toBe(before);
   });
 
   it('labels a status-less failure (thrown network error / fired abort) as outcome=network', async () => {
     mockSubmitWorkflow.mockRejectedValueOnce(timeoutError()).mockResolvedValueOnce(okResult());
-    const before = await retryCount('1', 'network');
+    const before = await retryCount('generate', '1', 'network');
 
     await runWithFakeTimers(() =>
-      submitWorkflow({ token: 'tok', body: {} as never, query: {} as never })
+      submitWorkflow({ token: 'tok', source: 'generate', body: {} as never, query: {} as never })
     );
 
-    expect(await retryCount('1', 'network')).toBe(before + 1);
+    expect(await retryCount('generate', '1', 'network')).toBe(before + 1);
   });
 
-  // ⚠️ INVARIANT GUARD, not regression coverage: also green at the pre-change base, because the hook
-  // itself always worked — it simply had no call sites. It pins the hook's contract for the direct
-  // callers (orchestrator.service.ts, blocks.router.ts) so a future refactor of the wrapper cannot
-  // quietly drop the parameter that this PR's wiring now depends on.
-  it('still counts the retry when the caller passes its OWN onRetry (wiring must not be caller-exclusive)', async () => {
+  it('counts the retry even when the caller supplies its OWN onRetry — the hook cannot be displaced', async () => {
     mockSubmitWorkflow
       .mockResolvedValueOnce(serverErrorResult(504))
       .mockResolvedValueOnce(okResult());
+    const before = await retryCount('other', '1', '504');
     const seen: number[] = [];
 
     await runWithFakeTimers(() =>
@@ -331,7 +498,78 @@ describe('onRetry → civitai_app_orchestrator_submit_retries_total (the 3x mult
       )
     );
 
+    // Both must hold: the caller's hook still runs, AND our counter fired anyway. Before this change
+    // the built-in count was the CALLER's job, so a caller that supplied a hook got no counter at all.
     expect(seen).toEqual([504]);
+    expect(await retryCount('other', '1', '504')).toBe(before + 1);
+  });
+
+  it('counts the retry even when the caller-supplied onRetry THROWS (our count is not hostage to it)', async () => {
+    mockSubmitWorkflow
+      .mockResolvedValueOnce(serverErrorResult(502))
+      .mockResolvedValueOnce(okResult());
+    const before = await retryCount('other', '1', '502');
+
+    await runWithFakeTimers(() =>
+      submitWorkflowWithRetry(
+        { client: {} as never, body: {} as never },
+        {
+          baseDelayMs: 1,
+          onRetry: () => {
+            throw new Error('caller hook exploded');
+          },
+        }
+      ).catch((e) => e)
+    );
+
+    expect(await retryCount('other', '1', '502')).toBe(before + 1);
+  });
+});
+
+describe('classifySubmitRetryOutcome — the bound that keeps `outcome` a bounded label', () => {
+  // 🔴 The `>= 500 && <= 599` window is what caps this label at 102 values. Removing EITHER end lets a
+  // hot-path counter mint a new series for any integer an upstream proxy puts on the wire — and until
+  // these tests the bound was asserted only in prose, so deleting it left the suite fully green.
+  //
+  // ⚠️ SCOPE, measured: the three PURE cases below are green against the pre-change base as well, so
+  // they are NOT base-regression coverage — the classifier ships in this change and its guard was never
+  // absent. What they ARE is the kill for the mutant that removes the bound (verified: deleting
+  // `<= 599` turns the first one red with `expected '600' to be 'other'`). The REACHABILITY test at the
+  // end of the block is the one that is genuinely red at base, because the wiring it drives is new.
+  it('rejects a status ABOVE the 5xx window, so a rogue upstream cannot mint unbounded series', () => {
+    expect(classifySubmitRetryOutcome(600)).toBe('other');
+    expect(classifySubmitRetryOutcome(999)).toBe('other');
+    expect(classifySubmitRetryOutcome(599)).toBe('599');
+  });
+
+  it('rejects a status BELOW the 5xx window', () => {
+    expect(classifySubmitRetryOutcome(499)).toBe('other');
+    expect(classifySubmitRetryOutcome(0)).toBe('other');
+    expect(classifySubmitRetryOutcome(500)).toBe('500');
+  });
+
+  it('maps a missing status to `network`, and a non-integer status to `other`', () => {
+    expect(classifySubmitRetryOutcome(undefined)).toBe('network');
+    expect(classifySubmitRetryOutcome(503.5)).toBe('other');
+    expect(classifySubmitRetryOutcome(Number.NaN)).toBe('other');
+  });
+
+  // Reachability: the guard is not dead code behind an earlier check. The retry predicate is
+  // `status == null || status >= 500`, so a 600 IS retryable and DOES reach the classifier on the live
+  // path — proven here by driving the real wrapper rather than calling the classifier directly.
+  it('is REACHABLE from the live retry path: an out-of-window 5xx-ish status lands in `other`', async () => {
+    mockSubmitWorkflow
+      .mockResolvedValueOnce(serverErrorResult(600))
+      .mockResolvedValueOnce(okResult());
+    const beforeOther = await retryCount('other', '1', 'other');
+    const beforeLiteral = await retryCount('other', '1', '600');
+
+    await runWithFakeTimers(() =>
+      submitWorkflowWithRetry({ client: {} as never, body: {} as never }, { baseDelayMs: 1 })
+    );
+
+    expect(await retryCount('other', '1', 'other')).toBe(beforeOther + 1);
+    expect(await retryCount('other', '1', '600')).toBe(beforeLiteral);
   });
 });
 
@@ -347,7 +585,7 @@ describe('W3C trace-context propagation on the outbound submit', () => {
 
     // 🔴 Not just "a traceparent exists" — it must carry the ATTEMPT span's ids, or the orchestrator's
     // spans parent onto nothing useful. A test asserting only the regex would pass on a hardcoded string.
-    const attemptSpan = spansNamed('gen:submit:orchestrator:attempt')[0];
+    const attemptSpan = spansNamed('orchestrator:submit:attempt')[0];
     const [, traceId, spanId] = headers.traceparent.split('-');
     expect(traceId).toBe(attemptSpan.spanContext().traceId);
     expect(spanId).toBe(attemptSpan.spanContext().spanId);
@@ -373,6 +611,11 @@ describe('W3C trace-context propagation on the outbound submit', () => {
   // branch. The record case would then pass while testing nothing (it gets its own object back); the
   // Headers and array cases would fail on the `traceparent` assertion rather than exercise the
   // normalization. Either way the branches under test never run — hence the span.
+  //
+  // ⚠️ SCOPE: the Headers and array branches are UNREACHABLE from any call site in this repo today.
+  // Every caller passes a plain record, and one layer down the generated sdk spreads `headers` into a
+  // plain object anyway (`sdk.gen.js`), which would defeat a `Headers` return before it reached the
+  // wire. These two cases pin the helper's own contract, not a live path.
   it('withTraceHeaders never clobbers a caller-supplied header, in any of the three header shapes', () => {
     withSpan('test:headers', () => {
       // Plain record — the shape every caller in this repo uses.

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -1635,6 +1635,11 @@ export async function generateFromGraph({
   // Submit workflow to orchestrator
   const workflow = (await submitWorkflow({
     token,
+    // THE population this instrument exists to size: the submit leg of `generateFromGraph`, which
+    // carries 82–98% of that procedure's latency. Every other submit funnel in the app defaults to
+    // `other`, so `orchestrator_submit_duration_seconds{source="generate"}` is the generate leg and
+    // nothing else — which is what makes it comparable against the procedure's own wall time.
+    source: 'generate',
     body: {
       tags,
       steps,

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -91,6 +91,7 @@ import { randomInt } from 'crypto';
 import { MAX_RANDOM_SEED } from '~/shared/constants/generation.constants';
 import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
 import { createXGuardModerationRequest } from '~/server/services/orchestrator/orchestrator.service';
+import { submitSourceForSurface } from '~/server/services/orchestrator/orchestrator-submit-metrics';
 import { logToAxiom } from '~/server/logging/client';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import { expandSnippetsToTargets } from '~/server/services/wildcard-set-resolver.service';
@@ -1636,10 +1637,21 @@ export async function generateFromGraph({
   const workflow = (await submitWorkflow({
     token,
     // THE population this instrument exists to size: the submit leg of `generateFromGraph`, which
-    // carries 82–98% of that procedure's latency. Every other submit funnel in the app defaults to
-    // `other`, so `orchestrator_submit_duration_seconds{source="generate"}` is the generate leg and
-    // nothing else — which is what makes it comparable against the procedure's own wall time.
-    source: 'generate',
+    // carries 82–98% of that procedure's latency.
+    //
+    // 🔴 Derived from the request's OWN surface, not hardcoded. `generateFromGraph` has two entry
+    // points, and only one of them is the tRPC procedure: `preset-image-gen.service` reaches this exact
+    // code with surface `preset`, and one of ITS callers is the `process-enqueued-comic-panels` CRON
+    // JOB, which runs outside the tRPC request path entirely. Stamping a flat `generate` here would
+    // therefore have blended a background job into the very number that gets divided against
+    // `orchestrator.generateFromGraph`'s wall time — the same contamination this label exists to
+    // remove, one level up from where it was first looked for. Reusing `GenerationSurface` (already
+    // bounded, already tested, already fixed at context construction by the caller) rather than
+    // inventing a parallel vocabulary means the two can never drift apart.
+    // The mapping itself lives in the metrics module, where the `source` vocabulary is defined and
+    // where it is unit-tested; `modelSubstitutions` is optional on the ctx type and an absent collector
+    // resolves to `other`, never to `generate`.
+    source: submitSourceForSurface(externalCtx.modelSubstitutions?.surface),
     body: {
       tags,
       steps,

--- a/src/server/services/orchestrator/orchestrator-read-metrics.ts
+++ b/src/server/services/orchestrator/orchestrator-read-metrics.ts
@@ -15,63 +15,30 @@
 // /api/metrics), same as session_resolution_* / trpc_procedure_duration. Cardinality-safe: only the bounded
 // `op` / `outcome` labels, NEVER per-user or per-workflowId. This module owns the prom-client wiring; the
 // callers in workflows.ts time only the orchestrator client network call and hand the raw timing here.
-//
-// 🔴 The `submit` op (added here) is a WRITE, not a read, and it is deliberately carried on this
-// read-named metric rather than a sibling family. Rationale: `op` already enumerates the orchestrator
-// client funnels this module wraps and the submit was simply the one call not wrapped, so one family
-// keeps every orchestrator-client boundary comparable in a single query. The consequence to know
-// before writing a query: an unfiltered `sum(rate(civitai_app_orchestrator_read_duration_seconds_...))`
-// now BLENDS a write into a read total. Filter on `op` — always.
-//
-// WHY the submit op exists at all: `orchestrator.generateFromGraph` consumes ~9.5 server-s/s at peak
-// (~12.6% of all dp-prod tRPC wall time) and 82–98% of that latency sits in one contiguous interval
-// containing no spans and no metric at all. That interval is structurally three items — pure-CPU
-// metadata assembly, refreshBlobUrlsInBody, and the submit POST — and the first two were excluded by
-// measurement (blob refresh runs at 0.008 req/s against 4.44 submits/s). So the submit POST carries
-// essentially the whole endpoint, and until this metric existed the ONLY bound on it was subtraction.
-// The callee's own route metric cannot substitute: `POST /v2/consumer/workflows` serves App Blocks,
-// external API consumers (which can pass an uncapped `wait=N`), orchestration-next and training too —
-// its 202 population alone consumes 27.4 server-s/s against this procedure's total of 8.9, i.e. it is
-// biased at least 3x high and is arithmetically incapable of sizing the caller's leg.
 import { registerHistogram, registerCounterWithLabels } from '~/server/prom/client';
 
-// The orchestrator client funnels in workflows.ts. `getWorkflow` = the single-workflow read behind the
+// The two orchestrator READ funnels in workflows.ts. `getWorkflow` = the single-workflow read behind the
 // orchestrator.statusUpdate poll (fires continuously while a workflow runs — the most re-fetchable read we
-// have); `queryWorkflows` = the multi-workflow list behind queryGeneratedImages / queue-status / admin;
-// `submit` = the POST /v2/consumer/workflows WRITE behind generateFromGraph / whatIfFromGraph / the App
-// Blocks and image-ingestion submits. `submit` times the WHOLE `submitWorkflowWithRetry` call (all attempts
-// plus their backoff) because that is the interval the caller actually waits on and the only figure
-// directly comparable against the procedure's own wall time. Per-attempt resolution is carried by the
-// `gen:submit:orchestrator:attempt` spans and the retries counter below, not by this histogram.
-export type OrchestratorReadOp = 'getWorkflow' | 'queryWorkflows' | 'submit';
+// have); `queryWorkflows` = the multi-workflow list behind queryGeneratedImages / queue-status / admin.
+export type OrchestratorReadOp = 'getWorkflow' | 'queryWorkflows';
 // `ok` = a successful data result; `error` = any non-timeout failure (rejected non-timeout, or a !data result
 // with a non-2xx status / status-less non-timeout error); `timeout` = the fired read-backstop AbortSignal.timeout
-// (ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS), or on `submit` the whatIf/image-ingest
-// per-attempt AbortSignal.timeout of the FINAL attempt.
+// (ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS).
 export type OrchestratorReadOutcome = 'ok' | 'error' | 'timeout';
 
 // Sub-ms (cache/warm-hit read) → the 20s backstop cap → a >20s park in +Inf. Deliberately carries an EXTRA 20
 // bucket vs session_resolution_* so the p99 straddles the ORCHESTRATOR_*_TIMEOUT_MS cap cleanly: everything at
 // or under the cap lands ≤20, anything that beat the deadline (or a mid-body abort just past it) lands in +Inf.
-//
-// The 45/60/90/120 buckets are for the `submit` op ONLY and are purely ADDITIVE — every pre-existing `le`
-// remains, so no existing query or dashboard changes meaning. They exist because the generate submit is
-// UNBOUNDED (no per-attempt timeout on the write path) and its observed ceiling recurs at ~95s (Loki max
-// 94,800 ms), which is arithmetically consistent with 3 attempts x the Orleans 30s default response timeout
-// plus 0.5s + 1.5s of backoff. Without a bucket above 30 the entire population this metric was added to see
-// collapses into one +Inf bucket, and the histogram cannot distinguish a 32s submit from a 95s one.
-const ORCHESTRATOR_READ_BUCKETS = [0.005, 0.05, 0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120] as const;
+const ORCHESTRATOR_READ_BUCKETS = [0.005, 0.05, 0.5, 1, 2, 5, 10, 20, 30] as const;
 
 const durationHistogram = registerHistogram({
   name: 'orchestrator_read_duration_seconds',
   help:
-    'Duration (seconds) of an orchestrator client call — the getWorkflow (statusUpdate poll) and ' +
-    'queryWorkflows (queryGeneratedImages feed) READ funnels, and the submit WRITE (POST ' +
-    '/v2/consumer/workflows, whole retry-wrapped call incl. backoff). Times ONLY the awaited orchestrator ' +
-    'client call, not the surrounding handler. Labeled by op (getWorkflow|queryWorkflows|submit) + outcome ' +
-    '(ok|error|timeout). ALWAYS filter on op: submit is a WRITE and is far slower than either read, so an ' +
-    'unfiltered aggregate blends the two. The sub-20 buckets are the healthy read-latency tail (use to size ' +
-    'the ORCHESTRATOR_*_TIMEOUT_MS backstop); the 45-120 buckets exist for the unbounded generate submit.',
+    'Duration (seconds) of the orchestrator client READ network call — the getWorkflow (statusUpdate poll) ' +
+    'and queryWorkflows (queryGeneratedImages feed) funnels. Times ONLY the awaited orchestrator client call, ' +
+    'not the surrounding handler. Labeled by op (getWorkflow|queryWorkflows) + outcome (ok|error|timeout). ' +
+    'The sub-20 buckets are the healthy read-latency tail (use to size the ORCHESTRATOR_*_TIMEOUT_MS backstop); ' +
+    '+Inf is a park that beat the 20s cap.',
   labelNames: ['op', 'outcome'] as const,
   buckets: [...ORCHESTRATOR_READ_BUCKETS],
 });
@@ -79,34 +46,11 @@ const durationHistogram = registerHistogram({
 const timeoutsCounter = registerCounterWithLabels({
   name: 'orchestrator_read_timeouts_total',
   help:
-    'Count of orchestrator calls that hit a client-side deadline: the fired ' +
-    'ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS read backstop (#2883), or on op=submit the ' +
-    'whatIf / image-ingest per-attempt AbortSignal.timeout of the final attempt. Labeled by op ' +
-    '(getWorkflow|queryWorkflows|submit). The leading indicator for an orchestrator park HOL-blocking the ' +
-    'shared api pool — a nonzero rate means a funnel is parking and getting cut at its deadline. NOTE the ' +
-    'generate (non-whatIf) submit path has NO per-attempt timeout, so a parked generate submit is invisible ' +
-    'HERE and shows up only as a large duration observation on the histogram above.',
+    'Count of orchestrator READ calls that hit their read-backstop deadline (the fired ' +
+    'ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS AbortSignal.timeout, #2883). Labeled by op ' +
+    '(getWorkflow|queryWorkflows). The leading indicator for an orchestrator park HOL-blocking the shared api ' +
+    'pool — a nonzero rate means a read funnel is parking and getting cut at the backstop.',
   labelNames: ['op'] as const,
-});
-
-// The failure class of the ONE attempt that triggered a retry, bounded to a small enumeration so this label
-// can never take a value the callee chooses freely. `network` = the attempt produced no HTTP status at all
-// (a thrown fetch failure, or the resolve-with-no-response shape a fired AbortSignal.timeout produces);
-// a bare 3-digit 5xx string = that upstream status; `other` = anything else the retry predicate let through.
-export type OrchestratorSubmitRetryOutcome = 'network' | 'other' | `5${string}`;
-
-const submitRetriesCounter = registerCounterWithLabels({
-  name: 'orchestrator_submit_retries_total',
-  help:
-    'Count of orchestrator submit RETRIES actually fired by submitWorkflowWithRetry — one increment per ' +
-    'backoff, so a submit that succeeded first try contributes nothing and a fully-exhausted 3-attempt ' +
-    'submit contributes 2. Labeled by attempt (the 1-based index of the attempt that FAILED, so attempt=1 ' +
-    'means the first try failed and a second is about to run) + outcome (network | a 5xx status | other). ' +
-    'This settles whether the recurring ~95s generate-submit ceiling is a 3x retry multiplier or a single ' +
-    'long attempt: before this counter the retry wrapper had NO observability at all (its onRetry hook had ' +
-    'zero call sites and the attempts count was discarded), so a 3x amplification of every orchestrator ' +
-    'stall was entirely unmeasured. Compare rate(...) against the submit rate on the histogram above.',
-  labelNames: ['attempt', 'outcome'] as const,
 });
 
 /**
@@ -125,38 +69,5 @@ export function observeOrchestratorRead(
     if (outcome === 'timeout') timeoutsCounter.inc({ op });
   } catch {
     // Observability must never break the read path. Swallow any prom-client error.
-  }
-}
-
-/**
- * Normalize the failed attempt that triggered a retry into the bounded `outcome` enumeration. A retry only
- * fires when `retryable = !result.data && (status == null || status >= 500)`, so in practice this returns
- * `network` or a 5xx string; `other` exists so a future widening of the retry predicate cannot silently
- * introduce an unbounded label value.
- */
-export function classifySubmitRetryOutcome(
-  status: number | undefined
-): OrchestratorSubmitRetryOutcome {
-  if (status == null) return 'network';
-  if (Number.isInteger(status) && status >= 500 && status <= 599)
-    return String(status) as OrchestratorSubmitRetryOutcome;
-  return 'other';
-}
-
-/**
- * Record ONE fired orchestrator submit retry. Called from `submitWorkflowWithRetry`'s `onRetry` hook — the
- * hook existed as a parameter with zero call sites, which is why a 3x retry multiplier on the single most
- * expensive tRPC procedure on the platform had never been counted. `attempt` is stringified because
- * prom-client label values are strings; it is bounded by `maxAttempts` (default 3), so the series count is
- * (maxAttempts - 1) x |outcome|. Cheap + TOTAL (never throws) — it runs on the generation hot path.
- */
-export function observeOrchestratorSubmitRetry(
-  attempt: number,
-  outcome: OrchestratorSubmitRetryOutcome
-): void {
-  try {
-    submitRetriesCounter.inc({ attempt: String(attempt), outcome });
-  } catch {
-    // Observability must never break the submit path. Swallow any prom-client error.
   }
 }

--- a/src/server/services/orchestrator/orchestrator-read-metrics.ts
+++ b/src/server/services/orchestrator/orchestrator-read-metrics.ts
@@ -15,30 +15,63 @@
 // /api/metrics), same as session_resolution_* / trpc_procedure_duration. Cardinality-safe: only the bounded
 // `op` / `outcome` labels, NEVER per-user or per-workflowId. This module owns the prom-client wiring; the
 // callers in workflows.ts time only the orchestrator client network call and hand the raw timing here.
+//
+// 🔴 The `submit` op (added here) is a WRITE, not a read, and it is deliberately carried on this
+// read-named metric rather than a sibling family. Rationale: `op` already enumerates the orchestrator
+// client funnels this module wraps and the submit was simply the one call not wrapped, so one family
+// keeps every orchestrator-client boundary comparable in a single query. The consequence to know
+// before writing a query: an unfiltered `sum(rate(civitai_app_orchestrator_read_duration_seconds_...))`
+// now BLENDS a write into a read total. Filter on `op` — always.
+//
+// WHY the submit op exists at all: `orchestrator.generateFromGraph` consumes ~9.5 server-s/s at peak
+// (~12.6% of all dp-prod tRPC wall time) and 82–98% of that latency sits in one contiguous interval
+// containing no spans and no metric at all. That interval is structurally three items — pure-CPU
+// metadata assembly, refreshBlobUrlsInBody, and the submit POST — and the first two were excluded by
+// measurement (blob refresh runs at 0.008 req/s against 4.44 submits/s). So the submit POST carries
+// essentially the whole endpoint, and until this metric existed the ONLY bound on it was subtraction.
+// The callee's own route metric cannot substitute: `POST /v2/consumer/workflows` serves App Blocks,
+// external API consumers (which can pass an uncapped `wait=N`), orchestration-next and training too —
+// its 202 population alone consumes 27.4 server-s/s against this procedure's total of 8.9, i.e. it is
+// biased at least 3x high and is arithmetically incapable of sizing the caller's leg.
 import { registerHistogram, registerCounterWithLabels } from '~/server/prom/client';
 
-// The two orchestrator READ funnels in workflows.ts. `getWorkflow` = the single-workflow read behind the
+// The orchestrator client funnels in workflows.ts. `getWorkflow` = the single-workflow read behind the
 // orchestrator.statusUpdate poll (fires continuously while a workflow runs — the most re-fetchable read we
-// have); `queryWorkflows` = the multi-workflow list behind queryGeneratedImages / queue-status / admin.
-export type OrchestratorReadOp = 'getWorkflow' | 'queryWorkflows';
+// have); `queryWorkflows` = the multi-workflow list behind queryGeneratedImages / queue-status / admin;
+// `submit` = the POST /v2/consumer/workflows WRITE behind generateFromGraph / whatIfFromGraph / the App
+// Blocks and image-ingestion submits. `submit` times the WHOLE `submitWorkflowWithRetry` call (all attempts
+// plus their backoff) because that is the interval the caller actually waits on and the only figure
+// directly comparable against the procedure's own wall time. Per-attempt resolution is carried by the
+// `gen:submit:orchestrator:attempt` spans and the retries counter below, not by this histogram.
+export type OrchestratorReadOp = 'getWorkflow' | 'queryWorkflows' | 'submit';
 // `ok` = a successful data result; `error` = any non-timeout failure (rejected non-timeout, or a !data result
 // with a non-2xx status / status-less non-timeout error); `timeout` = the fired read-backstop AbortSignal.timeout
-// (ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS).
+// (ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS), or on `submit` the whatIf/image-ingest
+// per-attempt AbortSignal.timeout of the FINAL attempt.
 export type OrchestratorReadOutcome = 'ok' | 'error' | 'timeout';
 
 // Sub-ms (cache/warm-hit read) → the 20s backstop cap → a >20s park in +Inf. Deliberately carries an EXTRA 20
 // bucket vs session_resolution_* so the p99 straddles the ORCHESTRATOR_*_TIMEOUT_MS cap cleanly: everything at
 // or under the cap lands ≤20, anything that beat the deadline (or a mid-body abort just past it) lands in +Inf.
-const ORCHESTRATOR_READ_BUCKETS = [0.005, 0.05, 0.5, 1, 2, 5, 10, 20, 30] as const;
+//
+// The 45/60/90/120 buckets are for the `submit` op ONLY and are purely ADDITIVE — every pre-existing `le`
+// remains, so no existing query or dashboard changes meaning. They exist because the generate submit is
+// UNBOUNDED (no per-attempt timeout on the write path) and its observed ceiling recurs at ~95s (Loki max
+// 94,800 ms), which is arithmetically consistent with 3 attempts x the Orleans 30s default response timeout
+// plus 0.5s + 1.5s of backoff. Without a bucket above 30 the entire population this metric was added to see
+// collapses into one +Inf bucket, and the histogram cannot distinguish a 32s submit from a 95s one.
+const ORCHESTRATOR_READ_BUCKETS = [0.005, 0.05, 0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120] as const;
 
 const durationHistogram = registerHistogram({
   name: 'orchestrator_read_duration_seconds',
   help:
-    'Duration (seconds) of the orchestrator client READ network call — the getWorkflow (statusUpdate poll) ' +
-    'and queryWorkflows (queryGeneratedImages feed) funnels. Times ONLY the awaited orchestrator client call, ' +
-    'not the surrounding handler. Labeled by op (getWorkflow|queryWorkflows) + outcome (ok|error|timeout). ' +
-    'The sub-20 buckets are the healthy read-latency tail (use to size the ORCHESTRATOR_*_TIMEOUT_MS backstop); ' +
-    '+Inf is a park that beat the 20s cap.',
+    'Duration (seconds) of an orchestrator client call — the getWorkflow (statusUpdate poll) and ' +
+    'queryWorkflows (queryGeneratedImages feed) READ funnels, and the submit WRITE (POST ' +
+    '/v2/consumer/workflows, whole retry-wrapped call incl. backoff). Times ONLY the awaited orchestrator ' +
+    'client call, not the surrounding handler. Labeled by op (getWorkflow|queryWorkflows|submit) + outcome ' +
+    '(ok|error|timeout). ALWAYS filter on op: submit is a WRITE and is far slower than either read, so an ' +
+    'unfiltered aggregate blends the two. The sub-20 buckets are the healthy read-latency tail (use to size ' +
+    'the ORCHESTRATOR_*_TIMEOUT_MS backstop); the 45-120 buckets exist for the unbounded generate submit.',
   labelNames: ['op', 'outcome'] as const,
   buckets: [...ORCHESTRATOR_READ_BUCKETS],
 });
@@ -46,11 +79,34 @@ const durationHistogram = registerHistogram({
 const timeoutsCounter = registerCounterWithLabels({
   name: 'orchestrator_read_timeouts_total',
   help:
-    'Count of orchestrator READ calls that hit their read-backstop deadline (the fired ' +
-    'ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS AbortSignal.timeout, #2883). Labeled by op ' +
-    '(getWorkflow|queryWorkflows). The leading indicator for an orchestrator park HOL-blocking the shared api ' +
-    'pool — a nonzero rate means a read funnel is parking and getting cut at the backstop.',
+    'Count of orchestrator calls that hit a client-side deadline: the fired ' +
+    'ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS read backstop (#2883), or on op=submit the ' +
+    'whatIf / image-ingest per-attempt AbortSignal.timeout of the final attempt. Labeled by op ' +
+    '(getWorkflow|queryWorkflows|submit). The leading indicator for an orchestrator park HOL-blocking the ' +
+    'shared api pool — a nonzero rate means a funnel is parking and getting cut at its deadline. NOTE the ' +
+    'generate (non-whatIf) submit path has NO per-attempt timeout, so a parked generate submit is invisible ' +
+    'HERE and shows up only as a large duration observation on the histogram above.',
   labelNames: ['op'] as const,
+});
+
+// The failure class of the ONE attempt that triggered a retry, bounded to a small enumeration so this label
+// can never take a value the callee chooses freely. `network` = the attempt produced no HTTP status at all
+// (a thrown fetch failure, or the resolve-with-no-response shape a fired AbortSignal.timeout produces);
+// a bare 3-digit 5xx string = that upstream status; `other` = anything else the retry predicate let through.
+export type OrchestratorSubmitRetryOutcome = 'network' | 'other' | `5${string}`;
+
+const submitRetriesCounter = registerCounterWithLabels({
+  name: 'orchestrator_submit_retries_total',
+  help:
+    'Count of orchestrator submit RETRIES actually fired by submitWorkflowWithRetry — one increment per ' +
+    'backoff, so a submit that succeeded first try contributes nothing and a fully-exhausted 3-attempt ' +
+    'submit contributes 2. Labeled by attempt (the 1-based index of the attempt that FAILED, so attempt=1 ' +
+    'means the first try failed and a second is about to run) + outcome (network | a 5xx status | other). ' +
+    'This settles whether the recurring ~95s generate-submit ceiling is a 3x retry multiplier or a single ' +
+    'long attempt: before this counter the retry wrapper had NO observability at all (its onRetry hook had ' +
+    'zero call sites and the attempts count was discarded), so a 3x amplification of every orchestrator ' +
+    'stall was entirely unmeasured. Compare rate(...) against the submit rate on the histogram above.',
+  labelNames: ['attempt', 'outcome'] as const,
 });
 
 /**
@@ -69,5 +125,38 @@ export function observeOrchestratorRead(
     if (outcome === 'timeout') timeoutsCounter.inc({ op });
   } catch {
     // Observability must never break the read path. Swallow any prom-client error.
+  }
+}
+
+/**
+ * Normalize the failed attempt that triggered a retry into the bounded `outcome` enumeration. A retry only
+ * fires when `retryable = !result.data && (status == null || status >= 500)`, so in practice this returns
+ * `network` or a 5xx string; `other` exists so a future widening of the retry predicate cannot silently
+ * introduce an unbounded label value.
+ */
+export function classifySubmitRetryOutcome(
+  status: number | undefined
+): OrchestratorSubmitRetryOutcome {
+  if (status == null) return 'network';
+  if (Number.isInteger(status) && status >= 500 && status <= 599)
+    return String(status) as OrchestratorSubmitRetryOutcome;
+  return 'other';
+}
+
+/**
+ * Record ONE fired orchestrator submit retry. Called from `submitWorkflowWithRetry`'s `onRetry` hook — the
+ * hook existed as a parameter with zero call sites, which is why a 3x retry multiplier on the single most
+ * expensive tRPC procedure on the platform had never been counted. `attempt` is stringified because
+ * prom-client label values are strings; it is bounded by `maxAttempts` (default 3), so the series count is
+ * (maxAttempts - 1) x |outcome|. Cheap + TOTAL (never throws) — it runs on the generation hot path.
+ */
+export function observeOrchestratorSubmitRetry(
+  attempt: number,
+  outcome: OrchestratorSubmitRetryOutcome
+): void {
+  try {
+    submitRetriesCounter.inc({ attempt: String(attempt), outcome });
+  } catch {
+    // Observability must never break the submit path. Swallow any prom-client error.
   }
 }

--- a/src/server/services/orchestrator/orchestrator-submit-metrics.ts
+++ b/src/server/services/orchestrator/orchestrator-submit-metrics.ts
@@ -7,8 +7,9 @@
 // `refreshBlobUrlsInBody`, and the submit POST — and the first two were excluded by measurement, so the
 // submit POST carries essentially the whole endpoint. Until this metric existed the only bound on it was
 // subtraction. Four instruments were blind to it by construction: there is no app-side timer on the submit
-// leg, the call bypasses the edge (in-cluster service address), the api pool emits no client-kind spans so
-// trace context never reached the callee, and continuous profiling has no per-request label.
+// leg, the call bypasses the public edge (it uses an internal service address), the api pool emits no
+// client-kind spans so trace context never reached the callee, and continuous profiling has no
+// per-request label.
 //
 // The callee's own route metric cannot substitute: `POST /v2/consumer/workflows` also serves App Blocks,
 // external API consumers (which can pass an uncapped `wait=N`), the -next deployment and training. Its 202

--- a/src/server/services/orchestrator/orchestrator-submit-metrics.ts
+++ b/src/server/services/orchestrator/orchestrator-submit-metrics.ts
@@ -1,0 +1,177 @@
+// Orchestrator SUBMIT observability — the timer on `POST /v2/consumer/workflows`, the one orchestrator
+// client boundary that had no instrument of any kind.
+//
+// WHY this exists: `orchestrator.generateFromGraph` consumes ~9.5 server-s/s at the daily peak (~12.6% of
+// all tRPC procedure wall time) and 82–98% of that latency sits in ONE contiguous interval containing no
+// span and no metric. That interval is structurally three items — pure-CPU metadata assembly,
+// `refreshBlobUrlsInBody`, and the submit POST — and the first two were excluded by measurement, so the
+// submit POST carries essentially the whole endpoint. Until this metric existed the only bound on it was
+// subtraction. Four instruments were blind to it by construction: there is no app-side timer on the submit
+// leg, the call bypasses the edge (in-cluster service address), the api pool emits no client-kind spans so
+// trace context never reached the callee, and continuous profiling has no per-request label.
+//
+// The callee's own route metric cannot substitute: `POST /v2/consumer/workflows` also serves App Blocks,
+// external API consumers (which can pass an uncapped `wait=N`), the -next deployment and training. Its 202
+// population alone consumes 27.4 server-s/s against this procedure's TOTAL of 8.9 — arithmetically
+// impossible for a synchronous callee, i.e. biased at least 3x high.
+//
+// 🔴 WHY A SIBLING FAMILY, not a `submit` op on `orchestrator_read_duration_seconds`. The submit is a
+// WRITE, it is unbounded (no per-attempt timeout on the generate path) and its observed ceiling recurs
+// around 95 s, whereas both reads are hard-capped at 20 s by the #2883 backstop. Carrying it on the read
+// family would have meant:
+//   - prom-client applies ONE bucket array family-wide, so the >30 s boundaries the submit needs would also
+//     be minted for `getWorkflow`/`queryWorkflows`, where they can never be anything but a copy of `le=30`;
+//   - every honest read query would have to remember to filter `op!="submit"` forever — a footgun that has
+//     to be documented rather than designed away;
+//   - during a rollout, pods on the old and new bucket sets make `sum by (le)` non-monotonic, so quantiles
+//     read as capped until the fleet is homogeneous.
+// A separate family costs one more metric name and removes all three. Nothing about the read family
+// changes, so no existing query, dashboard or alert can change meaning.
+import { registerCounterWithLabels, registerHistogram } from '~/server/prom/client';
+
+/**
+ * WHICH submit population an observation belongs to. Bounded and closed — never derived from anything the
+ * callee or a user controls.
+ *
+ * 🔴 This label is load-bearing, not decoration. `submitWorkflowWithRetry` is the single funnel for EVERY
+ * orchestrator submit in the app: the generate leg, cost-estimate whatIfs, image ingestion (which calls the
+ * wrapper directly), training, App Blocks, comics chat, prompt enhancement and product badges. Those
+ * populations have wildly different latency distributions — whatIf is per-attempt-capped at 8 s, image
+ * ingestion at its own cap, generate is uncapped — so an UNLABELLED submit histogram could not be compared
+ * against `orchestrator.generateFromGraph`'s own wall time at all, which is the single comparison this
+ * metric exists to support. Filter on `source` for any figure you intend to attribute.
+ *
+ * - `generate`    — the `generateFromGraph` submit (`orchestration-new.service.ts`), the population this PR
+ *                   exists to size.
+ * - `whatIf`      — any submit carrying `query.whatif === true`: a side-effect-free cost estimate, bounded
+ *                   by `WHATIF_SUBMIT_ATTEMPT_TIMEOUT_MS` per attempt.
+ * - `imageIngest` — the image-ingestion submit, which calls `submitWorkflowWithRetry` DIRECTLY rather than
+ *                   through `submitWorkflow`.
+ * - `other`       — every other submit funnel (training, App Blocks, comics chat, prompt enhancement,
+ *                   product badge). The default, so a new caller can never silently land in `generate`.
+ */
+export type OrchestratorSubmitSource = 'generate' | 'whatIf' | 'imageIngest' | 'other';
+
+/**
+ * `ok` = the final attempt returned data. `timeout` = the final attempt's per-attempt
+ * `AbortSignal.timeout` fired (whatIf / image ingest only — the generate path sets no per-attempt
+ * deadline, so a parked generate submit is an `ok` or `error` with a large duration, never a `timeout`).
+ * `error` = any other failure of the final attempt.
+ */
+export type OrchestratorSubmitOutcome = 'ok' | 'error' | 'timeout';
+
+// 50 ms → 120 s. The low end resolves the healthy population (a warm submit is tens of ms); the top end
+// exists because the generate submit has NO per-attempt timeout and its observed ceiling recurs at ~95 s
+// (Loki max 94,800 ms), arithmetically consistent with 3 attempts x the Orleans 30 s default response
+// timeout plus 0.5 s + 1.5 s of backoff. Without a boundary above 30 the entire population this metric was
+// added to see would collapse into a single `+Inf` bucket, and a 32 s submit would be indistinguishable
+// from a 95 s one — which is exactly the distinction that decides whether the fix is "cap the attempt" or
+// "the callee hangs".
+const ORCHESTRATOR_SUBMIT_BUCKETS = [
+  0.05, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120,
+] as const;
+
+const submitDurationHistogram = registerHistogram({
+  name: 'orchestrator_submit_duration_seconds',
+  help:
+    'Duration (seconds) of an orchestrator workflow submit (POST /v2/consumer/workflows) as the CALLER ' +
+    'experiences it: the whole retry-wrapped call, all attempts plus their backoff. Recorded in ' +
+    'submitWorkflowWithRetry, so it covers EVERY submit funnel in the app. Labeled by source ' +
+    '(generate|whatIf|imageIngest|other) + outcome (ok|error|timeout). Filter on source before ' +
+    'attributing a figure to a procedure — these populations have different caps and different latency ' +
+    'distributions. Per-attempt resolution lives in the orchestrator:submit:attempt spans and in ' +
+    'orchestrator_submit_retries_total, not in this histogram.',
+  labelNames: ['source', 'outcome'] as const,
+  buckets: [...ORCHESTRATOR_SUBMIT_BUCKETS],
+});
+
+const submitTimeoutsCounter = registerCounterWithLabels({
+  name: 'orchestrator_submit_timeouts_total',
+  help:
+    'Count of orchestrator submits whose FINAL attempt was cut by its per-attempt AbortSignal.timeout. ' +
+    'Labeled by source (generate|whatIf|imageIngest|other). NOTE the generate path sets NO per-attempt ' +
+    'timeout, so source="generate" can never appear here by construction — a parked generate submit is ' +
+    'visible only as a large observation on orchestrator_submit_duration_seconds. This is the leading ' +
+    'indicator for the capped funnels (whatIf, image ingestion) parking against the orchestrator.',
+  labelNames: ['source'] as const,
+});
+
+// The failure class of the ONE attempt that triggered a retry, bounded to a small enumeration so this label
+// can never take a value the callee chooses freely. `network` = the attempt produced no HTTP status at all
+// (a thrown fetch failure, or the resolve-with-no-response shape a fired AbortSignal.timeout produces);
+// a bare 3-digit 5xx string = that upstream status; `other` = anything else the retry predicate let through.
+export type OrchestratorSubmitRetryOutcome = 'network' | 'other' | `5${string}`;
+
+const submitRetriesCounter = registerCounterWithLabels({
+  name: 'orchestrator_submit_retries_total',
+  help:
+    'Count of orchestrator submit RETRIES actually fired by submitWorkflowWithRetry — one increment per ' +
+    'backoff, so a submit that succeeded first try contributes nothing and a fully-exhausted 3-attempt ' +
+    'submit contributes 2. Labeled by source (generate|whatIf|imageIngest|other) + attempt (the 1-based ' +
+    'index of the attempt that FAILED, so attempt=1 means the first try failed and a second is about to ' +
+    'run) + outcome (network | a 5xx status | other). This settles whether the recurring ~95s ' +
+    'generate-submit ceiling is a 3x retry multiplier or a single long attempt: before this counter the ' +
+    'retry wrapper had NO observability at all (its onRetry hook had zero call sites and the attempts ' +
+    'count was discarded), so a 3x amplification of every orchestrator stall was entirely unmeasured. ' +
+    'Compare rate(...) against the submit rate on orchestrator_submit_duration_seconds at the same source.',
+  labelNames: ['source', 'attempt', 'outcome'] as const,
+});
+
+/**
+ * Record ONE orchestrator submit — exactly one call per `submitWorkflowWithRetry` invocation, whichever
+ * way it settled. Always observes the duration histogram; additionally increments the timeout counter when
+ * the final attempt was cut by its own deadline. Cheap + TOTAL (never throws) — it runs on the generation
+ * hot path, so a metrics-layer hiccup must not be able to take down a submit.
+ */
+export function observeOrchestratorSubmit(
+  source: OrchestratorSubmitSource,
+  outcome: OrchestratorSubmitOutcome,
+  durationSeconds: number
+): void {
+  try {
+    submitDurationHistogram.observe({ source, outcome }, durationSeconds);
+    if (outcome === 'timeout') submitTimeoutsCounter.inc({ source });
+  } catch {
+    // Observability must never break the submit path. Swallow any prom-client error.
+  }
+}
+
+/**
+ * Normalize the failed attempt that triggered a retry into the bounded `outcome` enumeration. A retry only
+ * fires when `retryable = !result.data && (status == null || status >= 500)`, so in practice this returns
+ * `network` or a 5xx string; `other` exists so a future widening of the retry predicate cannot silently
+ * introduce an unbounded label value.
+ *
+ * 🔴 The `>= 500 && <= 599` bound is what makes this label bounded, and BOTH ends are load-bearing, not
+ * decoration: without the upper bound any integer the callee (or a proxy in front of it) puts on the wire
+ * becomes a new series, so a misbehaving upstream could mint unbounded cardinality on a hot-path counter.
+ * With it, `outcome` has at most 102 values. Both ends are pinned by test, not only by this comment.
+ */
+export function classifySubmitRetryOutcome(
+  status: number | undefined
+): OrchestratorSubmitRetryOutcome {
+  if (status == null) return 'network';
+  if (Number.isInteger(status) && status >= 500 && status <= 599)
+    return String(status) as OrchestratorSubmitRetryOutcome;
+  return 'other';
+}
+
+/**
+ * Record ONE fired orchestrator submit retry. Called from `submitWorkflowWithRetry`'s `onRetry` hook — the
+ * hook existed as a parameter with zero call sites, which is why a 3x retry multiplier on the single most
+ * expensive tRPC procedure on the platform had never been counted. `attempt` is stringified because
+ * prom-client label values are strings; it is bounded by `maxAttempts` (default 3), so the series count is
+ * |source| x (maxAttempts - 1) x |outcome|. Cheap + TOTAL (never throws) — it runs on the generation hot
+ * path.
+ */
+export function observeOrchestratorSubmitRetry(
+  source: OrchestratorSubmitSource,
+  attempt: number,
+  outcome: OrchestratorSubmitRetryOutcome
+): void {
+  try {
+    submitRetriesCounter.inc({ source, attempt: String(attempt), outcome });
+  } catch {
+    // Observability must never break the submit path. Swallow any prom-client error.
+  }
+}

--- a/src/server/services/orchestrator/orchestrator-submit-metrics.ts
+++ b/src/server/services/orchestrator/orchestrator-submit-metrics.ts
@@ -20,7 +20,9 @@
 // around 95 s, whereas both reads are hard-capped at 20 s by the #2883 backstop. Carrying it on the read
 // family would have meant:
 //   - prom-client applies ONE bucket array family-wide, so the >30 s boundaries the submit needs would also
-//     be minted for `getWorkflow`/`queryWorkflows`, where they can never be anything but a copy of `le=30`;
+//     be minted for `getWorkflow`/`queryWorkflows`, which the backstop cuts at 20 s — above `le=30` those
+//     extra boundaries carry no information the existing ones do not (a mid-body abort landing just past
+//     the cap is already served by the family's deliberate `+Inf` overflow);
 //   - every honest read query would have to remember to filter `op!="submit"` forever — a footgun that has
 //     to be documented rather than designed away;
 //   - during a rollout, pods on the old and new bucket sets make `sum by (le)` non-monotonic, so quantiles
@@ -28,29 +30,86 @@
 // A separate family costs one more metric name and removes all three. Nothing about the read family
 // changes, so no existing query, dashboard or alert can change meaning.
 import { registerCounterWithLabels, registerHistogram } from '~/server/prom/client';
+import type { GenerationSurface } from '~/shared/data-graph/generation/model-substitution';
 
 /**
  * WHICH submit population an observation belongs to. Bounded and closed — never derived from anything the
  * callee or a user controls.
  *
- * 🔴 This label is load-bearing, not decoration. `submitWorkflowWithRetry` is the single funnel for EVERY
- * orchestrator submit in the app: the generate leg, cost-estimate whatIfs, image ingestion (which calls the
- * wrapper directly), training, App Blocks, comics chat, prompt enhancement and product badges. Those
- * populations have wildly different latency distributions — whatIf is per-attempt-capped at 8 s, image
- * ingestion at its own cap, generate is uncapped — so an UNLABELLED submit histogram could not be compared
- * against `orchestrator.generateFromGraph`'s own wall time at all, which is the single comparison this
- * metric exists to support. Filter on `source` for any figure you intend to attribute.
+ * 🔴 This label is load-bearing, not decoration. `submitWorkflowWithRetry` is the funnel for every submit
+ * that goes through the RETRY WRAPPER: the generate leg, cost-estimate whatIfs, image ingestion (which
+ * calls the wrapper directly), preset/comics generation, training's `training.orch` submits, App Blocks,
+ * comics chat and prompt enhancement. Those populations have wildly different latency distributions —
+ * whatIf is per-attempt-capped at 8 s, image ingestion at its own cap, generate is uncapped — so an
+ * UNLABELLED submit histogram could not be compared against `orchestrator.generateFromGraph`'s own wall
+ * time at all, which is the single comparison this metric exists to support. Filter on `source` for any
+ * figure you intend to attribute.
  *
- * - `generate`    — the `generateFromGraph` submit (`orchestration-new.service.ts`), the population this PR
- *                   exists to size.
+ * - `generate`    — the `generateFromGraph` submit reached from the tRPC `orchestrator.generateFromGraph`
+ *                   procedure (surface `onsite`/`api`), the population this metric exists to size.
+ * - `preset`      — the SAME `generateFromGraph` code reached through `preset-image-gen.service`
+ *                   (surface `preset`): the preset/comics submits, INCLUDING the
+ *                   `process-enqueued-comic-panels` cron job, which runs outside the tRPC request path.
+ *                   Split out precisely so `generate` can be divided against that procedure's wall time.
  * - `whatIf`      — any submit carrying `query.whatif === true`: a side-effect-free cost estimate, bounded
  *                   by `WHATIF_SUBMIT_ATTEMPT_TIMEOUT_MS` per attempt.
  * - `imageIngest` — the image-ingestion submit, which calls `submitWorkflowWithRetry` DIRECTLY rather than
  *                   through `submitWorkflow`.
- * - `other`       — every other submit funnel (training, App Blocks, comics chat, prompt enhancement,
- *                   product badge). The default, so a new caller can never silently land in `generate`.
+ * - `other`       — every other submit funnel through the wrapper (training's `training.orch` submits, App
+ *                   Blocks, comics chat, prompt enhancement). The default, so a new caller can never
+ *                   silently land in `generate`.
+ *
+ * 🔴 NOT COVERED AT ALL, and you must know this before writing a query: five call sites reach
+ * `POST /v2/consumer/workflows` by calling the generated SDK's `submitWorkflow` DIRECTLY, bypassing the
+ * retry wrapper and therefore every instrument here — the perceptual-hash (`mediaHash`), xGuard-moderation
+ * and model-scan submits in `orchestrator.service.ts`, the badge-resize submit in
+ * `product-badge.service.ts`, and the auto-label submit in `training.service.ts`. Three of those are
+ * per-image paths and may well be a LARGER population than the instrumented one. So
+ * `sum(rate(orchestrator_submit_duration_seconds_count))` is the wrapper's submit rate, NOT the app's.
+ * Extending coverage to them means giving them the retry wrapper, which is a behaviour change and
+ * deliberately out of scope here.
  */
-export type OrchestratorSubmitSource = 'generate' | 'whatIf' | 'imageIngest' | 'other';
+export type OrchestratorSubmitSource = 'generate' | 'preset' | 'whatIf' | 'imageIngest' | 'other';
+
+/**
+ * Runtime narrowing for the `source` label. The TYPE above is a compile-time guarantee only, and excess-
+ * property checking does NOT apply to spread properties — so the first call site that writes
+ * `submitWorkflow({ ...opts, token })` where `opts` carries a stray `source` string would mint an
+ * unbounded label on a hot-path histogram, silently and with a green suite. Its sibling
+ * `classifySubmitRetryOutcome` already clamps at runtime; this closes the same hole on the other label.
+ */
+const SUBMIT_SOURCES: ReadonlySet<string> = new Set<OrchestratorSubmitSource>([
+  'generate',
+  'preset',
+  'whatIf',
+  'imageIngest',
+  'other',
+]);
+
+export function clampSubmitSource(source: unknown): OrchestratorSubmitSource {
+  return typeof source === 'string' && SUBMIT_SOURCES.has(source)
+    ? (source as OrchestratorSubmitSource)
+    : 'other';
+}
+
+/**
+ * Map a request's `GenerationSurface` onto the submit `source`, for the two entry points that share
+ * `generateFromGraph`. Reusing the existing surface enum rather than inventing a parallel vocabulary is
+ * what keeps the two from drifting apart — `GENERATION_SURFACES` is already bounded, already tested, and
+ * already fixed at context construction by the caller that knows which surface it is.
+ *
+ * `preset` is split out because the preset/comics path includes a CRON JOB
+ * (`process-enqueued-comic-panels`) that runs outside the tRPC request path; leaving it in `generate`
+ * would blend a background job into the number that gets divided against
+ * `orchestrator.generateFromGraph`'s wall time. An ABSENT surface falls to `other`, never to `generate`:
+ * an unknown caller inflating the headline population is the failure nobody would notice.
+ */
+export function submitSourceForSurface(
+  surface: GenerationSurface | undefined
+): OrchestratorSubmitSource {
+  if (surface == null) return 'other';
+  return surface === 'preset' ? 'preset' : 'generate';
+}
 
 /**
  * `ok` = the final attempt returned data. `timeout` = the final attempt's per-attempt
@@ -75,12 +134,15 @@ const submitDurationHistogram = registerHistogram({
   name: 'orchestrator_submit_duration_seconds',
   help:
     'Duration (seconds) of an orchestrator workflow submit (POST /v2/consumer/workflows) as the CALLER ' +
-    'experiences it: the whole retry-wrapped call, all attempts plus their backoff. Recorded in ' +
-    'submitWorkflowWithRetry, so it covers EVERY submit funnel in the app. Labeled by source ' +
-    '(generate|whatIf|imageIngest|other) + outcome (ok|error|timeout). Filter on source before ' +
+    'experiences it: the whole retry-wrapped call, all attempts plus their backoff. Labeled by source ' +
+    '(generate|preset|whatIf|imageIngest|other) + outcome (ok|error|timeout). Filter on source before ' +
     'attributing a figure to a procedure — these populations have different caps and different latency ' +
-    'distributions. Per-attempt resolution lives in the orchestrator:submit:attempt spans and in ' +
-    'orchestrator_submit_retries_total, not in this histogram.',
+    'distributions; source=generate is exactly the tRPC orchestrator.generateFromGraph submit leg. ' +
+    'COVERAGE: recorded in submitWorkflowWithRetry, so it covers every submit that goes through the ' +
+    'retry wrapper and NOT the five that call the generated client directly (mediaHash / ' +
+    'xGuardModeration / modelClamScan / badge-resize / training auto-label) — an unfiltered rate here ' +
+    'is the WRAPPER submit rate, not the application total. Per-attempt resolution lives in the ' +
+    'orchestrator:submit:attempt spans and in orchestrator_submit_retries_total, not in this histogram.',
   labelNames: ['source', 'outcome'] as const,
   buckets: [...ORCHESTRATOR_SUBMIT_BUCKETS],
 });
@@ -88,11 +150,14 @@ const submitDurationHistogram = registerHistogram({
 const submitTimeoutsCounter = registerCounterWithLabels({
   name: 'orchestrator_submit_timeouts_total',
   help:
-    'Count of orchestrator submits whose FINAL attempt was cut by its per-attempt AbortSignal.timeout. ' +
-    'Labeled by source (generate|whatIf|imageIngest|other). NOTE the generate path sets NO per-attempt ' +
-    'timeout, so source="generate" can never appear here by construction — a parked generate submit is ' +
-    'visible only as a large observation on orchestrator_submit_duration_seconds. This is the leading ' +
-    'indicator for the capped funnels (whatIf, image ingestion) parking against the orchestrator.',
+    'Count of orchestrator submits whose FINAL attempt ended in a fired abort deadline (a TimeoutError / ' +
+    'AbortError). Labeled by source (generate|preset|whatIf|imageIngest|other). NOTE the generate path ' +
+    'sets no per-attempt timeout AND passes no signal of its own today, so source="generate" is not ' +
+    'expected here — a parked generate submit is visible only as a large observation on ' +
+    'orchestrator_submit_duration_seconds. Both halves of that matter: a caller-supplied options.signal ' +
+    'is composed with the per-attempt deadline, so adding one to the generate path WOULD make this ' +
+    'series appear. This is the leading indicator for the capped funnels (whatIf, image ingestion) ' +
+    'parking against the orchestrator.',
   labelNames: ['source'] as const,
 });
 
@@ -107,7 +172,8 @@ const submitRetriesCounter = registerCounterWithLabels({
   help:
     'Count of orchestrator submit RETRIES actually fired by submitWorkflowWithRetry — one increment per ' +
     'backoff, so a submit that succeeded first try contributes nothing and a fully-exhausted 3-attempt ' +
-    'submit contributes 2. Labeled by source (generate|whatIf|imageIngest|other) + attempt (the 1-based ' +
+    'submit contributes 2. Labeled by source (generate|preset|whatIf|imageIngest|other) + attempt (the ' +
+    '1-based ' +
     'index of the attempt that FAILED, so attempt=1 means the first try failed and a second is about to ' +
     'run) + outcome (network | a 5xx status | other). This settles whether the recurring ~95s ' +
     'generate-submit ceiling is a 3x retry multiplier or a single long attempt: before this counter the ' +
@@ -129,8 +195,9 @@ export function observeOrchestratorSubmit(
   durationSeconds: number
 ): void {
   try {
-    submitDurationHistogram.observe({ source, outcome }, durationSeconds);
-    if (outcome === 'timeout') submitTimeoutsCounter.inc({ source });
+    const safeSource = clampSubmitSource(source);
+    submitDurationHistogram.observe({ source: safeSource, outcome }, durationSeconds);
+    if (outcome === 'timeout') submitTimeoutsCounter.inc({ source: safeSource });
   } catch {
     // Observability must never break the submit path. Swallow any prom-client error.
   }
@@ -170,7 +237,11 @@ export function observeOrchestratorSubmitRetry(
   outcome: OrchestratorSubmitRetryOutcome
 ): void {
   try {
-    submitRetriesCounter.inc({ source, attempt: String(attempt), outcome });
+    submitRetriesCounter.inc({
+      source: clampSubmitSource(source),
+      attempt: String(attempt),
+      outcome,
+    });
   } catch {
     // Observability must never break the submit path. Swallow any prom-client error.
   }

--- a/src/server/services/orchestrator/orchestrator.service.ts
+++ b/src/server/services/orchestrator/orchestrator.service.ts
@@ -211,12 +211,10 @@ export async function createImageIngestionRequest({
     // that calls the retry wrapper directly instead of going through `submitWorkflow`, so without this
     // label its submits would be indistinguishable from the generate leg on the shared histogram — and
     // that histogram exists specifically to be compared against generateFromGraph's own wall time.
-    wait
-      ? { source: 'imageIngest' as const }
-      : {
-          perAttemptTimeoutMs: IMAGE_INGEST_SUBMIT_ATTEMPT_TIMEOUT_MS,
-          source: 'imageIngest' as const,
-        }
+    {
+      ...(wait ? {} : { perAttemptTimeoutMs: IMAGE_INGEST_SUBMIT_ATTEMPT_TIMEOUT_MS }),
+      source: 'imageIngest' as const,
+    }
   );
   const { data, response, attempts } = result;
   // `error` isn't present on every member of the result union — narrow with `in`.

--- a/src/server/services/orchestrator/orchestrator.service.ts
+++ b/src/server/services/orchestrator/orchestrator.service.ts
@@ -207,7 +207,16 @@ export async function createImageIngestionRequest({
       query: wait ? { wait } : undefined,
       body,
     },
-    wait ? undefined : { perAttemptTimeoutMs: IMAGE_INGEST_SUBMIT_ATTEMPT_TIMEOUT_MS }
+    // `source` labels every submit metric this call produces. Image ingestion is the ONE submit funnel
+    // that calls the retry wrapper directly instead of going through `submitWorkflow`, so without this
+    // label its submits would be indistinguishable from the generate leg on the shared histogram — and
+    // that histogram exists specifically to be compared against generateFromGraph's own wall time.
+    wait
+      ? { source: 'imageIngest' as const }
+      : {
+          perAttemptTimeoutMs: IMAGE_INGEST_SUBMIT_ATTEMPT_TIMEOUT_MS,
+          source: 'imageIngest' as const,
+        }
   );
   const { data, response, attempts } = result;
   // `error` isn't present on every member of the result union — narrow with `in`.

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -30,6 +30,7 @@ import type {
 import { createOrchestratorClient } from '~/server/services/orchestrator/client';
 import { observeOrchestratorRead } from '~/server/services/orchestrator/orchestrator-read-metrics';
 import {
+  clampSubmitSource,
   classifySubmitRetryOutcome,
   observeOrchestratorSubmit,
   observeOrchestratorSubmitRetry,
@@ -103,14 +104,17 @@ const ORCHESTRATOR_GET_TIMEOUT_MS = 20_000;
 // orchestrator-side root fix (stamp source dims / bound the download) is orch #261.
 const WHATIF_SUBMIT_ATTEMPT_TIMEOUT_MS = 8_000;
 
-// Classify an orchestrator READ failure as the fired read-backstop deadline (#2883,
-// ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS) vs any other error — for the additive read
-// metric ONLY (does NOT touch control flow / error mapping). A fired `AbortSignal.timeout()` surfaces as an
-// Error/DOMException named `TimeoutError` (or `AbortError` for a composed/manual abort). Because
-// `createOrchestratorClient` does NOT set `throwOnError`, this shape appears on BOTH the `.catch` reject path
-// (a mid-body abort rejects) AND the `if (!data)` resolve path (a pre-response abort RESOLVES with
-// `{ error: TimeoutError, response: undefined }`) — so both call sites classify with this. Walks the `.cause`
-// chain briefly since tRPC/undici nest the original.
+// Classify an orchestrator CLIENT failure as a fired abort deadline vs any other error — for the additive
+// metrics ONLY (does NOT touch control flow / error mapping). Originally the read-backstop classifier
+// (#2883, ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS); it now has FOUR call sites, two of
+// them on the SUBMIT path where it decides the `outcome` label and whether
+// `orchestrator_submit_timeouts_total` increments — so it is load-bearing for more than the read metric,
+// despite the name. A fired `AbortSignal.timeout()` surfaces as an Error/DOMException named `TimeoutError`
+// (or `AbortError` for a composed/manual abort), which is why a CALLER-supplied `options.signal` also lands
+// here. Because `createOrchestratorClient` does NOT set `throwOnError`, this shape appears on BOTH the
+// `.catch` reject path (a mid-body abort rejects) AND the `if (!data)` resolve path (a pre-response abort
+// RESOLVES with `{ error: TimeoutError, response: undefined }`) — so every call site classifies with this.
+// Walks the `.cause` chain briefly since tRPC/undici nest the original.
 function isOrchestratorReadTimeout(e: unknown): boolean {
   let cur = e as { name?: string; cause?: unknown } | undefined;
   for (let depth = 0; depth < 4 && cur && typeof cur === 'object'; depth++) {
@@ -329,8 +333,8 @@ export async function submitWorkflow({
   // `submitWorkflowWithRetry`, NOT here. That placement is deliberate: image ingestion calls the retry
   // wrapper directly and bypasses this function entirely, so instrumenting here would have left the
   // per-attempt spans and the duration histogram covering DIFFERENT populations — and the attempts↔duration
-  // join is the entire point of the instrument. All this function contributes is the `source` label, which
-  // is what makes the generate leg separable from every other submit funnel in the app.
+  // join is the entire point of the instrument. All this function forwards is the `source` label, which is
+  // what makes the generate leg separable from the other submit funnels that share the wrapper.
   let result: ClientSubmitResult & { attempts: number };
   try {
     result = await submitWorkflowWithRetry(
@@ -344,10 +348,11 @@ export async function submitWorkflow({
         // recover). For whatIf, additionally bound each attempt so a stuck img2img
         // source-download can't park ~30s × 3 (~90s) and head-of-line-block the api pool.
         ...(isWhatif ? { perAttemptTimeoutMs: WHATIF_SUBMIT_ATTEMPT_TIMEOUT_MS } : {}),
-        // A whatIf is always its own population regardless of what the caller declared: it is a
-        // side-effect-free cost estimate, per-attempt-capped at 8s, and blending it into `generate`
-        // would drag the very figure this metric exists to produce.
-        source: isWhatif ? 'whatIf' : source ?? 'other',
+        // Declared source only. The whatIf coercion is NOT applied here: it lives in the wrapper, which
+        // reads `options.query` itself, so a caller that goes DIRECT to the wrapper with a whatIf query
+        // is classified the same way this one is. Keeping it here would have made the label's own
+        // docstring ("any submit carrying query.whatif === true") false for exactly those callers.
+        source,
       }
     );
   } catch (e) {
@@ -538,23 +543,40 @@ export type SubmitWorkflowRetryOptions = {
  * (the orchestrator dedupes on `(userId, externalId)`); the same body — and thus
  * the same key — is reused across every retry here.
  *
- * 🔴 This is also where EVERY orchestrator submit is instrumented — the span, the duration histogram
- * and the retries counter all live here rather than in `submitWorkflow`, because this function is the
- * single funnel every submit passes through. `submitWorkflow` is NOT: image ingestion calls this
- * directly. Instrumenting a level up would have left the per-attempt spans covering one population and
- * the duration histogram covering another, contaminating exactly the attempts↔duration join the
- * instrument exists to make. Observability only — no control-flow, error-mapping or timing change.
+ * 🔴 This is where every RETRY-WRAPPED orchestrator submit is instrumented — the span, the duration
+ * histogram and the retries counter all live here rather than in `submitWorkflow`, because every caller
+ * of `submitWorkflow` reaches this function but not the reverse: image ingestion calls this directly.
+ * Instrumenting a level up would have left the per-attempt spans covering one population and the
+ * duration histogram covering another, contaminating exactly the attempts↔duration join the instrument
+ * exists to make. It is NOT the app's only route to `POST /v2/consumer/workflows` — five call sites use
+ * the generated client directly and are invisible to every instrument here; they are enumerated in
+ * `orchestrator-submit-metrics.ts`, and the metric help strings say so. Observability only — no
+ * control-flow, error-mapping or timing change.
  */
 export async function submitWorkflowWithRetry(
   options: SubmitOptions,
   retryOptions: SubmitWorkflowRetryOptions = {}
 ): Promise<ClientSubmitResult & { attempts: number }> {
-  const source = retryOptions.source ?? 'other';
+  // A whatIf is always its own population regardless of what the caller declared: it is a
+  // side-effect-free cost estimate, per-attempt-capped at 8s, and blending it into `generate` would drag
+  // the very figure this metric exists to produce. Derived HERE, from `options.query`, so a caller that
+  // reaches the wrapper directly is classified the same way one going through `submitWorkflow` is.
+  const source: OrchestratorSubmitSource =
+    (options.query as { whatif?: boolean } | undefined)?.whatif === true
+      ? 'whatIf'
+      : clampSubmitSource(retryOptions.source);
   // Whole-call timing: all attempts plus their backoff — the interval the CALLER actually parks on, and
   // the only figure directly comparable against a procedure's own wall time. Per-attempt resolution is
   // carried by the child spans and the retries counter, not by splitting this into N observations.
   const submitStart = performance.now();
   const elapsedSeconds = () => (performance.now() - submitStart) / 1000;
+  // Written by the loop at the top of every iteration, so the attempt count is readable even on the paths
+  // where the loop THROWS rather than returning a result that carries `attempts`. Without it the span's
+  // `attempts` attribute was absent on exactly one of the two park shapes it exists to tell apart: a
+  // network failure that exhausts all three attempts THROWS, so the ~95s span it produced carried no
+  // attempt count at all — while the comment below claimed the attribute settled that case. (The fired
+  // AbortSignal.timeout park RESOLVES instead, which is why the gap read as covered and was not.)
+  const progress = { attempts: 0 };
 
   return await withSpan(
     'orchestrator:submit',
@@ -562,7 +584,7 @@ export async function submitWorkflowWithRetry(
     async () => {
       let result: ClientSubmitResult & { attempts: number };
       try {
-        result = await submitWorkflowRetryLoop(options, retryOptions, source);
+        result = await submitWorkflowRetryLoop(options, retryOptions, source, progress);
       } catch (e) {
         // Exactly one observation per submit — here on the throw path, XOR on the resolve path below.
         // A throw out of the loop is the FINAL attempt's network/timeout/abort failure.
@@ -571,6 +593,7 @@ export async function submitWorkflowWithRetry(
           isOrchestratorReadTimeout(e) ? 'timeout' : 'error',
           elapsedSeconds()
         );
+        setActiveSpanAttributes({ 'orchestrator.submit.attempts': progress.attempts });
         throw e;
       }
       // Resolve path. `data` ⇒ ok; a `!data` result is either the status-less resolve shape a fired
@@ -605,7 +628,8 @@ export async function submitWorkflowWithRetry(
 async function submitWorkflowRetryLoop(
   options: SubmitOptions,
   { maxAttempts = 3, baseDelayMs = 500, perAttemptTimeoutMs, onRetry }: SubmitWorkflowRetryOptions,
-  source: OrchestratorSubmitSource
+  source: OrchestratorSubmitSource,
+  progress: { attempts: number }
 ): Promise<ClientSubmitResult & { attempts: number }> {
   let lastError: unknown;
 
@@ -619,6 +643,7 @@ async function submitWorkflowRetryLoop(
   };
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    progress.attempts = attempt;
     let result: ClientSubmitResult | undefined;
     try {
       // PER-ATTEMPT span. Without it a retried submit and a single slow submit are the same

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -28,11 +28,13 @@ import type {
   workflowUpdateSchema,
 } from '~/server/schema/orchestrator/workflows.schema';
 import { createOrchestratorClient } from '~/server/services/orchestrator/client';
+import { observeOrchestratorRead } from '~/server/services/orchestrator/orchestrator-read-metrics';
 import {
   classifySubmitRetryOutcome,
-  observeOrchestratorRead,
+  observeOrchestratorSubmit,
   observeOrchestratorSubmitRetry,
-} from '~/server/services/orchestrator/orchestrator-read-metrics';
+} from '~/server/services/orchestrator/orchestrator-submit-metrics';
+import type { OrchestratorSubmitSource } from '~/server/services/orchestrator/orchestrator-submit-metrics';
 import {
   setActiveSpanAttributes,
   traceContextHeaders,
@@ -284,7 +286,17 @@ export async function submitWorkflow({
   token,
   body,
   query,
-}: Options<SubmitWorkflowData> & { token: string }) {
+  source,
+}: Options<SubmitWorkflowData> & {
+  token: string;
+  /**
+   * Which submit population this call belongs to, for `orchestrator_submit_duration_seconds{source}`.
+   * Defaults to `other`, so a caller that does not opt in can never be silently counted as `generate`.
+   * A `query.whatif === true` call is always recorded as `whatIf` regardless of what is passed here —
+   * a cost estimate is per-attempt-capped and is a different latency population from a real submit.
+   */
+  source?: OrchestratorSubmitSource;
+}) {
   const client = createOrchestratorClient(token);
   if (!body) throw throwBadRequestError();
 
@@ -313,61 +325,32 @@ export async function submitWorkflow({
   // generation submit is never false-aborted (same marker used by the closed #2807).
   const isWhatif = (query as { whatif?: boolean } | undefined)?.whatif === true;
 
-  // 🔴 THE instrument this module was missing. `orchestrator.generateFromGraph` spends 82–98% of its
-  // latency in one contiguous interval that contained no span and no metric, and that interval is
-  // structurally three things: pure-CPU metadata assembly, refreshBlobUrlsInBody (measured at 0.008
-  // req/s against 4.44 submits/s — excluded), and THIS call. Four instruments were blind to it by
-  // construction: no app-side timer here, the call bypasses Traefik (in-cluster Service DNS), the api
-  // pool emits no client-kind spans so trace context never reached the orchestrator, and Pyroscope has
-  // no per-request label. The span makes the interval visible in a trace; the histogram observation
-  // below makes it a server-seconds-per-second figure directly comparable against the procedure's own
-  // wall time. Observability only — no control flow, no error mapping, and no timing behavior changes.
-  const submitStart = performance.now();
+  // 🔴 The span and the histogram that close this gap are recorded ONE LEVEL DOWN, inside
+  // `submitWorkflowWithRetry`, NOT here. That placement is deliberate: image ingestion calls the retry
+  // wrapper directly and bypasses this function entirely, so instrumenting here would have left the
+  // per-attempt spans and the duration histogram covering DIFFERENT populations — and the attempts↔duration
+  // join is the entire point of the instrument. All this function contributes is the `source` label, which
+  // is what makes the generate leg separable from every other submit funnel in the app.
   let result: ClientSubmitResult & { attempts: number };
   try {
-    result = await withSpan(
-      'gen:submit:orchestrator',
-      { 'orchestrator.submit.whatif': isWhatif },
-      async () => {
-        const r = await submitWorkflowWithRetry(
-          {
-            client,
-            body: { ...body, tags: ['civitai', ...(body.tags ?? [])] },
-            query,
-          },
-          {
-            // KEEP the default 3 retries on BOTH paths (transient orchestrator blips still
-            // recover). For whatIf, additionally bound each attempt so a stuck img2img
-            // source-download can't park ~30s × 3 (~90s) and head-of-line-block the api pool.
-            ...(isWhatif ? { perAttemptTimeoutMs: WHATIF_SUBMIT_ATTEMPT_TIMEOUT_MS } : {}),
-            // Wire the wrapper's `onRetry` hook, which shipped with the wrapper and has had ZERO call
-            // sites ever since — so a 3x latency multiplier on the most expensive tRPC procedure on the
-            // platform has been completely unobservable. Counting it settles, outright, whether the
-            // recurring ~95s ceiling is `3 x 30s + 0.5 + 1.5` (arithmetically consistent with the
-            // Orleans 30s default response timeout, for which no override exists anywhere in
-            // civitai-orchestration) or a single long attempt.
-            onRetry: ({ attempt, status }) =>
-              observeOrchestratorSubmitRetry(attempt, classifySubmitRetryOutcome(status)),
-          }
-        );
-        // Stamp the attempts count the wrapper has always returned and every caller has always
-        // discarded. Set INSIDE the callback, where `gen:submit:orchestrator` is the active span —
-        // outside it the active span is the caller's, and the attribute would land on the wrong span.
-        // On this span it correlates directly with the span's own duration, which is what
-        // distinguishes a ~95s park that is `3 x 30s` from one that is a single 95s attempt; a
-        // counter alone cannot make that join. Cardinality-free (a span attribute, not a label).
-        setActiveSpanAttributes({ 'orchestrator.submit.attempts': r.attempts });
-        return r;
+    result = await submitWorkflowWithRetry(
+      {
+        client,
+        body: { ...body, tags: ['civitai', ...(body.tags ?? [])] },
+        query,
+      },
+      {
+        // KEEP the default 3 retries on BOTH paths (transient orchestrator blips still
+        // recover). For whatIf, additionally bound each attempt so a stuck img2img
+        // source-download can't park ~30s × 3 (~90s) and head-of-line-block the api pool.
+        ...(isWhatif ? { perAttemptTimeoutMs: WHATIF_SUBMIT_ATTEMPT_TIMEOUT_MS } : {}),
+        // A whatIf is always its own population regardless of what the caller declared: it is a
+        // side-effect-free cost estimate, per-attempt-capped at 8s, and blending it into `generate`
+        // would drag the very figure this metric exists to produce.
+        source: isWhatif ? 'whatIf' : source ?? 'other',
       }
     );
   } catch (e) {
-    // Exactly one histogram observation per submit — here on the throw path, XOR on the resolve path
-    // below. A throw out of the wrapper is the FINAL attempt's network/timeout/abort failure.
-    observeOrchestratorRead(
-      'submit',
-      isOrchestratorReadTimeout(e) ? 'timeout' : 'error',
-      (performance.now() - submitStart) / 1000
-    );
     // The retry wrapper throws (rather than returning a `{ data:undefined }` result)
     // only on a network/timeout/abort failure of the FINAL attempt — there is no HTTP
     // status to map in the switch below. A recognized transient upstream failure
@@ -380,22 +363,6 @@ export async function submitWorkflow({
       throw throwServiceUnavailableError(ORCHESTRATOR_UNAVAILABLE_MESSAGE, e);
     throw e;
   }
-
-  // Resolve path (the `catch` above did NOT run). Exactly one observation per submit is recorded (here
-  // XOR in the catch). `data` ⇒ ok; a `!data` result is either the status-less resolve shape a fired
-  // per-attempt `AbortSignal.timeout` produces (`{ error: TimeoutError, response: undefined }` →
-  // timeout) or an upstream error. This is a WHOLE-CALL timing: all attempts plus their backoff, i.e.
-  // exactly the interval the caller parks on and the only figure comparable against the procedure's
-  // own wall time. Per-attempt resolution lives in the child spans and the retries counter.
-  observeOrchestratorRead(
-    'submit',
-    result.data
-      ? 'ok'
-      : isOrchestratorReadTimeout('error' in result ? result.error : undefined)
-      ? 'timeout'
-      : 'error',
-    (performance.now() - submitStart) / 1000
-  );
 
   // Narrow on `result.data` (not a destructured copy) so this always-throwing
   // guard both exposes `error`/`response` on the failure member here AND narrows
@@ -545,8 +512,18 @@ export type SubmitWorkflowRetryOptions = {
    * (current behavior; the generate/write path passes nothing and is byte-identical).
    */
   perAttemptTimeoutMs?: number;
-  /** Invoked right before each backoff sleep — useful for logging/metrics. */
+  /**
+   * Invoked right before each backoff sleep — useful for logging/metrics. This is ADDITIONAL to the
+   * built-in `orchestrator_submit_retries_total` increment, which fires first and unconditionally: a
+   * caller that supplies its own hook (or whose hook throws) can never suppress the counter.
+   */
   onRetry?: (info: { attempt: number; status?: number; delayMs: number }) => void;
+  /**
+   * Which submit population this call belongs to, for the `source` label on every submit metric.
+   * Defaults to `other` so a new caller can never be silently counted as `generate`. See
+   * `orchestrator-submit-metrics.ts` for why this label is load-bearing.
+   */
+  source?: OrchestratorSubmitSource;
 };
 
 /**
@@ -560,17 +537,86 @@ export type SubmitWorkflowRetryOptions = {
  * when a 500 actually created it server-side, the CALLER must set `body.externalId`
  * (the orchestrator dedupes on `(userId, externalId)`); the same body — and thus
  * the same key — is reused across every retry here.
+ *
+ * 🔴 This is also where EVERY orchestrator submit is instrumented — the span, the duration histogram
+ * and the retries counter all live here rather than in `submitWorkflow`, because this function is the
+ * single funnel every submit passes through. `submitWorkflow` is NOT: image ingestion calls this
+ * directly. Instrumenting a level up would have left the per-attempt spans covering one population and
+ * the duration histogram covering another, contaminating exactly the attempts↔duration join the
+ * instrument exists to make. Observability only — no control-flow, error-mapping or timing change.
  */
 export async function submitWorkflowWithRetry(
   options: SubmitOptions,
-  {
-    maxAttempts = 3,
-    baseDelayMs = 500,
-    perAttemptTimeoutMs,
-    onRetry,
-  }: SubmitWorkflowRetryOptions = {}
+  retryOptions: SubmitWorkflowRetryOptions = {}
+): Promise<ClientSubmitResult & { attempts: number }> {
+  const source = retryOptions.source ?? 'other';
+  // Whole-call timing: all attempts plus their backoff — the interval the CALLER actually parks on, and
+  // the only figure directly comparable against a procedure's own wall time. Per-attempt resolution is
+  // carried by the child spans and the retries counter, not by splitting this into N observations.
+  const submitStart = performance.now();
+  const elapsedSeconds = () => (performance.now() - submitStart) / 1000;
+
+  return await withSpan(
+    'orchestrator:submit',
+    { 'orchestrator.submit.source': source },
+    async () => {
+      let result: ClientSubmitResult & { attempts: number };
+      try {
+        result = await submitWorkflowRetryLoop(options, retryOptions, source);
+      } catch (e) {
+        // Exactly one observation per submit — here on the throw path, XOR on the resolve path below.
+        // A throw out of the loop is the FINAL attempt's network/timeout/abort failure.
+        observeOrchestratorSubmit(
+          source,
+          isOrchestratorReadTimeout(e) ? 'timeout' : 'error',
+          elapsedSeconds()
+        );
+        throw e;
+      }
+      // Resolve path. `data` ⇒ ok; a `!data` result is either the status-less resolve shape a fired
+      // per-attempt `AbortSignal.timeout` produces (`{ error: TimeoutError, response: undefined }` →
+      // timeout) or an upstream error.
+      observeOrchestratorSubmit(
+        source,
+        result.data
+          ? 'ok'
+          : isOrchestratorReadTimeout('error' in result ? result.error : undefined)
+          ? 'timeout'
+          : 'error',
+        elapsedSeconds()
+      );
+      // Stamp the attempts count the wrapper has always returned and every caller has always
+      // discarded. Set INSIDE the callback, where `orchestrator:submit` is the active span — outside
+      // it the active span is the caller's, and the attribute would land on the wrong span. On this
+      // span it correlates directly with the span's own duration, which is what distinguishes a ~95s
+      // park that is `3 x 30s` from one that is a single 95s attempt; a counter alone cannot make that
+      // join. Cardinality-free (a span attribute, not a label).
+      setActiveSpanAttributes({ 'orchestrator.submit.attempts': result.attempts });
+      return result;
+    }
+  );
+}
+
+/**
+ * The retry loop itself. Split out from `submitWorkflowWithRetry` purely so the whole-call timing and the
+ * parent span can bracket every exit path (return AND throw) without a `finally` that cannot see the
+ * outcome.
+ */
+async function submitWorkflowRetryLoop(
+  options: SubmitOptions,
+  { maxAttempts = 3, baseDelayMs = 500, perAttemptTimeoutMs, onRetry }: SubmitWorkflowRetryOptions,
+  source: OrchestratorSubmitSource
 ): Promise<ClientSubmitResult & { attempts: number }> {
   let lastError: unknown;
+
+  // Count the retry BEFORE handing control to the caller's own hook, so neither a caller that supplies
+  // one nor a caller whose hook throws can suppress the counter. Wiring this at all is the fix for a
+  // three-year blind spot: `onRetry` shipped with the wrapper and had ZERO call sites, so a 3x latency
+  // multiplier on the most expensive tRPC procedure on the platform was entirely unobservable.
+  const instrumentedOnRetry = (info: { attempt: number; status?: number; delayMs: number }) => {
+    observeOrchestratorSubmitRetry(source, info.attempt, classifySubmitRetryOutcome(info.status));
+    onRetry?.(info);
+  };
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     let result: ClientSubmitResult | undefined;
@@ -580,7 +626,7 @@ export async function submitWorkflowWithRetry(
       // ~30s children (the Orleans-default retry multiplier) or one ~95s child, which is the
       // difference between "cap the attempt" and "the callee hangs" as the correct fix.
       result = await withSpan(
-        'gen:submit:orchestrator:attempt',
+        'orchestrator:submit:attempt',
         { 'orchestrator.submit.attempt': attempt, 'orchestrator.submit.maxAttempts': maxAttempts },
         async () => {
           // Bound this attempt with a FRESH timeout signal (created inside the loop) so a
@@ -611,7 +657,12 @@ export async function submitWorkflowWithRetry(
       // Network failure / no response. Out of retries → surface it like a direct call would.
       lastError = e;
       if (attempt >= maxAttempts) throw e;
-      await submitWorkflowBackoff({ attempt, status: undefined, baseDelayMs, onRetry });
+      await submitWorkflowBackoff({
+        attempt,
+        status: undefined,
+        baseDelayMs,
+        onRetry: instrumentedOnRetry,
+      });
       continue;
     }
 
@@ -621,7 +672,7 @@ export async function submitWorkflowWithRetry(
       return Object.assign(result, { attempts: attempt });
     }
 
-    await submitWorkflowBackoff({ attempt, status, baseDelayMs, onRetry });
+    await submitWorkflowBackoff({ attempt, status, baseDelayMs, onRetry: instrumentedOnRetry });
   }
 
   // Only reachable if maxAttempts < 1 or every attempt threw without re-throwing above.

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -28,7 +28,16 @@ import type {
   workflowUpdateSchema,
 } from '~/server/schema/orchestrator/workflows.schema';
 import { createOrchestratorClient } from '~/server/services/orchestrator/client';
-import { observeOrchestratorRead } from '~/server/services/orchestrator/orchestrator-read-metrics';
+import {
+  classifySubmitRetryOutcome,
+  observeOrchestratorRead,
+  observeOrchestratorSubmitRetry,
+} from '~/server/services/orchestrator/orchestrator-read-metrics';
+import {
+  setActiveSpanAttributes,
+  traceContextHeaders,
+  withSpan,
+} from '~/server/utils/otel-helpers';
 import { refreshableBlobId } from '~/shared/orchestrator/blob-url';
 import {
   isUpstreamNetworkError,
@@ -304,20 +313,61 @@ export async function submitWorkflow({
   // generation submit is never false-aborted (same marker used by the closed #2807).
   const isWhatif = (query as { whatif?: boolean } | undefined)?.whatif === true;
 
+  // 🔴 THE instrument this module was missing. `orchestrator.generateFromGraph` spends 82–98% of its
+  // latency in one contiguous interval that contained no span and no metric, and that interval is
+  // structurally three things: pure-CPU metadata assembly, refreshBlobUrlsInBody (measured at 0.008
+  // req/s against 4.44 submits/s — excluded), and THIS call. Four instruments were blind to it by
+  // construction: no app-side timer here, the call bypasses Traefik (in-cluster Service DNS), the api
+  // pool emits no client-kind spans so trace context never reached the orchestrator, and Pyroscope has
+  // no per-request label. The span makes the interval visible in a trace; the histogram observation
+  // below makes it a server-seconds-per-second figure directly comparable against the procedure's own
+  // wall time. Observability only — no control flow, no error mapping, and no timing behavior changes.
+  const submitStart = performance.now();
   let result: ClientSubmitResult & { attempts: number };
   try {
-    result = await submitWorkflowWithRetry(
-      {
-        client,
-        body: { ...body, tags: ['civitai', ...(body.tags ?? [])] },
-        query,
-      },
-      // KEEP the default 3 retries on BOTH paths (transient orchestrator blips still
-      // recover). For whatIf, additionally bound each attempt so a stuck img2img
-      // source-download can't park ~30s × 3 (~90s) and head-of-line-block the api pool.
-      isWhatif ? { perAttemptTimeoutMs: WHATIF_SUBMIT_ATTEMPT_TIMEOUT_MS } : undefined
+    result = await withSpan(
+      'gen:submit:orchestrator',
+      { 'orchestrator.submit.whatif': isWhatif },
+      async () => {
+        const r = await submitWorkflowWithRetry(
+          {
+            client,
+            body: { ...body, tags: ['civitai', ...(body.tags ?? [])] },
+            query,
+          },
+          {
+            // KEEP the default 3 retries on BOTH paths (transient orchestrator blips still
+            // recover). For whatIf, additionally bound each attempt so a stuck img2img
+            // source-download can't park ~30s × 3 (~90s) and head-of-line-block the api pool.
+            ...(isWhatif ? { perAttemptTimeoutMs: WHATIF_SUBMIT_ATTEMPT_TIMEOUT_MS } : {}),
+            // Wire the wrapper's `onRetry` hook, which shipped with the wrapper and has had ZERO call
+            // sites ever since — so a 3x latency multiplier on the most expensive tRPC procedure on the
+            // platform has been completely unobservable. Counting it settles, outright, whether the
+            // recurring ~95s ceiling is `3 x 30s + 0.5 + 1.5` (arithmetically consistent with the
+            // Orleans 30s default response timeout, for which no override exists anywhere in
+            // civitai-orchestration) or a single long attempt.
+            onRetry: ({ attempt, status }) =>
+              observeOrchestratorSubmitRetry(attempt, classifySubmitRetryOutcome(status)),
+          }
+        );
+        // Stamp the attempts count the wrapper has always returned and every caller has always
+        // discarded. Set INSIDE the callback, where `gen:submit:orchestrator` is the active span —
+        // outside it the active span is the caller's, and the attribute would land on the wrong span.
+        // On this span it correlates directly with the span's own duration, which is what
+        // distinguishes a ~95s park that is `3 x 30s` from one that is a single 95s attempt; a
+        // counter alone cannot make that join. Cardinality-free (a span attribute, not a label).
+        setActiveSpanAttributes({ 'orchestrator.submit.attempts': r.attempts });
+        return r;
+      }
     );
   } catch (e) {
+    // Exactly one histogram observation per submit — here on the throw path, XOR on the resolve path
+    // below. A throw out of the wrapper is the FINAL attempt's network/timeout/abort failure.
+    observeOrchestratorRead(
+      'submit',
+      isOrchestratorReadTimeout(e) ? 'timeout' : 'error',
+      (performance.now() - submitStart) / 1000
+    );
     // The retry wrapper throws (rather than returning a `{ data:undefined }` result)
     // only on a network/timeout/abort failure of the FINAL attempt — there is no HTTP
     // status to map in the switch below. A recognized transient upstream failure
@@ -330,6 +380,22 @@ export async function submitWorkflow({
       throw throwServiceUnavailableError(ORCHESTRATOR_UNAVAILABLE_MESSAGE, e);
     throw e;
   }
+
+  // Resolve path (the `catch` above did NOT run). Exactly one observation per submit is recorded (here
+  // XOR in the catch). `data` ⇒ ok; a `!data` result is either the status-less resolve shape a fired
+  // per-attempt `AbortSignal.timeout` produces (`{ error: TimeoutError, response: undefined }` →
+  // timeout) or an upstream error. This is a WHOLE-CALL timing: all attempts plus their backoff, i.e.
+  // exactly the interval the caller parks on and the only figure comparable against the procedure's
+  // own wall time. Per-attempt resolution lives in the child spans and the retries counter.
+  observeOrchestratorRead(
+    'submit',
+    result.data
+      ? 'ok'
+      : isOrchestratorReadTimeout('error' in result ? result.error : undefined)
+      ? 'timeout'
+      : 'error',
+    (performance.now() - submitStart) / 1000
+  );
 
   // Narrow on `result.data` (not a destructured copy) so this always-throwing
   // guard both exposes `error`/`response` on the failure member here AND narrows
@@ -441,6 +507,30 @@ export async function submitWorkflow({
 type SubmitOptions = Options<SubmitWorkflowData, false>;
 type ClientSubmitResult = Awaited<ReturnType<typeof clientSubmitWorkflow>>;
 
+/**
+ * Merge the ambient W3C trace context into an outbound submit's headers WITHOUT clobbering anything the
+ * caller set (caller-supplied values always win, per-key).
+ *
+ * Why this is not a one-line spread: `@civitai/client`'s `headers` is a UNION — a plain record, a
+ * `Headers` instance, or a `[name, value][]` array. Spreading a `Headers` instance yields `{}`, which
+ * would silently DROP every header the caller set; spreading an array yields index keys. So the plain
+ * record (the only shape any caller in this repo actually uses today) is spread, and the other two are
+ * normalized through `new Headers()` and only filled in where a key is absent. When tracing is disabled
+ * the propagator is the API no-op, `traceContextHeaders()` is empty, and this returns the caller's value
+ * by reference — byte-identical behavior to before.
+ */
+export function withTraceHeaders(existing: SubmitOptions['headers']): SubmitOptions['headers'] {
+  const traceHeaders = traceContextHeaders();
+  if (Object.keys(traceHeaders).length === 0) return existing;
+  if (existing == null) return traceHeaders;
+  if (typeof existing === 'object' && !Array.isArray(existing) && !(existing instanceof Headers))
+    return { ...traceHeaders, ...(existing as Record<string, unknown>) };
+  const merged = new Headers(existing as HeadersInit);
+  for (const [key, value] of Object.entries(traceHeaders))
+    if (!merged.has(key)) merged.set(key, value);
+  return merged;
+}
+
 export type SubmitWorkflowRetryOptions = {
   /** Max total submit attempts (initial + retries). Default 3. */
   maxAttempts?: number;
@@ -485,19 +575,38 @@ export async function submitWorkflowWithRetry(
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     let result: ClientSubmitResult | undefined;
     try {
-      // Bound this attempt with a FRESH timeout signal (created inside the loop) so a
-      // fired deadline aborts only this attempt — the loop still retries with a new
-      // budget. If the caller already passed a signal, compose so either source aborts.
-      const attemptOptions =
-        perAttemptTimeoutMs == null
-          ? options
-          : {
-              ...options,
-              signal: options.signal
-                ? AbortSignal.any([options.signal, AbortSignal.timeout(perAttemptTimeoutMs)])
-                : AbortSignal.timeout(perAttemptTimeoutMs),
-            };
-      result = await clientSubmitWorkflow(attemptOptions);
+      // PER-ATTEMPT span. Without it a retried submit and a single slow submit are the same
+      // observation: one long parent interval. With it a ~95s park resolves into either three
+      // ~30s children (the Orleans-default retry multiplier) or one ~95s child, which is the
+      // difference between "cap the attempt" and "the callee hangs" as the correct fix.
+      result = await withSpan(
+        'gen:submit:orchestrator:attempt',
+        { 'orchestrator.submit.attempt': attempt, 'orchestrator.submit.maxAttempts': maxAttempts },
+        async () => {
+          // Bound this attempt with a FRESH timeout signal (created inside the loop) so a
+          // fired deadline aborts only this attempt — the loop still retries with a new
+          // budget. If the caller already passed a signal, compose so either source aborts.
+          const attemptOptions = {
+            ...options,
+            // Propagate W3C trace context ACROSS the service boundary. The api pool emits no
+            // client-kind spans at all (HttpInstrumentation is narrowed to inbound-only, and the
+            // orchestrator client is fetch/undici which was never auto-instrumented), so nothing
+            // outbound has ever carried a traceparent and the orchestrator — which IS instrumented —
+            // could never join the trace. Injected per ATTEMPT, inside the attempt span, so the
+            // orchestrator's spans parent onto the attempt that actually made the call rather than
+            // all three collapsing onto one id. Caller-supplied headers always win, per-key.
+            headers: withTraceHeaders(options.headers),
+            ...(perAttemptTimeoutMs == null
+              ? {}
+              : {
+                  signal: options.signal
+                    ? AbortSignal.any([options.signal, AbortSignal.timeout(perAttemptTimeoutMs)])
+                    : AbortSignal.timeout(perAttemptTimeoutMs),
+                }),
+          };
+          return clientSubmitWorkflow(attemptOptions);
+        }
+      );
     } catch (e) {
       // Network failure / no response. Out of retries → surface it like a direct call would.
       lastError = e;


### PR DESCRIPTION
## The gap this closes

`orchestrator.generateFromGraph` consumes **9.55 server-seconds/s at peak — 12.6% of all tRPC procedure wall time** — at only 4.1 req/s (mean 2305 ms). **82–98% of that latency sits in one contiguous interval that contains no spans at all.** Every instrumented `gen:*` span in the procedure is 0–13 ms; the gap grows in lockstep with total latency while the instrumented phases stay pinned.

Four instruments are blind to that interval *by construction*:

| instrument | why it cannot see the interval |
|---|---|
| app-side timers | there is no timer on the submit leg |
| edge access logs | the call bypasses the edge (internal service address) |
| distributed tracing | the api pool emits **no client-kind spans at all**, so trace context never reaches the orchestrator |
| continuous profiling | no per-request label |

The interval is **structurally exactly three items** (`orchestration-new.service.ts:1574 → 1655`): pure-CPU metadata assembly, `refreshBlobUrlsInBody`, and `submitWorkflow`. Two were eliminated by measurement — blob refresh runs at **0.008 req/s against 4.44 submits/s** (~1 refresh per 550 submits), and the orchestration→civitai callback loop at 0.0145/s. So **by elimination the gap is the submit POST**: an inference from a complete enumeration plus two exclusions, one span away from being a number.

Size of the thing nobody can see: **≈7.3–8.7 server-s/s, i.e. 8–10% of all tRPC wall time on its own.** Everything else in the procedure combined — the whole middleware chain, the graph parse, the prompt audit including its external moderation call, all of `createWorkflowStepsFromGraph`, the six-stage `getResourceData` run twice, and the response formatter — sums to ≈0.6–1.3 server-s/s.

Note the callee's own route metric **cannot** substitute for this: `POST /v2/consumer/workflows` also serves App Blocks, external API consumers (which can pass an uncapped `wait=N`), a second deployment and training. Its 202 population alone consumes 27.4 server-s/s against this procedure's *total* of 8.9 — arithmetically impossible for a synchronous callee, i.e. biased ≥3× high.

## What this PR adds — four additive, observability-only changes

Every instrument is recorded in **`submitWorkflowWithRetry`**, the lower of the two funnels: every caller of `submitWorkflow` reaches the wrapper, but not the reverse — image ingestion calls the wrapper directly (`orchestrator.service.ts:204`). Putting the instruments a level up would have left the spans and the histogram covering **different populations**, contaminating exactly the attempts↔duration join this change exists to make. See "The `source` label" below for why that mattered numerically.

🔴 **The wrapper is not the app's only route to the submit endpoint, and the help strings say so.** Five call sites reach `POST /v2/consumer/workflows` through the generated client directly and are invisible to every instrument here: the perceptual-hash (`mediaHash`), xGuard-moderation and model-scan submits in `orchestrator.service.ts`, the badge-resize submit in `product-badge.service.ts`, and the auto-label submit in `training.service.ts`. Three of those are per-image paths and may well be a *larger* population than the instrumented one. So `sum(rate(..._submit_duration_seconds_count))` is the **wrapper's** submit rate, not the application total — stated in the metric help string, not just here. Extending coverage means giving those paths the retry wrapper, which is a behaviour change and deliberately out of scope for an observability PR.

**1. `orchestrator:submit` span around the submit, plus a per-attempt child span.**
Without the per-attempt span, a retried submit and a single slow submit are the same observation: one long interval. With it, a ~95 s park resolves into either three ~30 s children or one ~95 s child — the difference between "cap the attempt" and "the callee hangs" as the correct fix. The parent also carries `orchestrator.submit.attempts`, the count the retry wrapper has always returned and every caller has always discarded, and `orchestrator.submit.source`.

**2. A sibling `civitai_app_orchestrator_submit_duration_seconds{source,outcome}` histogram.**
It times the **whole** retry-wrapped call (all attempts plus backoff) — the interval the caller actually parks on, and the only figure directly comparable against the procedure's own 8.912 server-s/s. Buckets run 0.05 s → 120 s: the low end resolves the healthy population, the top end exists because the generate submit has no per-attempt timeout and its observed ceiling recurs at ~95 s (Loki max 94,800 ms).

**The read family (`civitai_app_orchestrator_read_duration_seconds`) is byte-identical to `main`.** An earlier revision of this PR carried the submit as a `submit` op on that family; that is reverted. Reasons, all three of which a sibling family removes outright:
- prom-client applies **one bucket array family-wide**, so the >30 s boundaries the submit needs were also minted for `getWorkflow`/`queryWorkflows` — two funnels hard-capped at 20 s by the #2883 backstop, where ~912 of the ~3,500 new series could only ever be a byte-identical copy of `le="30"`, forever.
- Every honest read query would have had to remember `op!="submit"` **forever** — a footgun that has to be documented rather than designed away.
- During a rollout, pods on the 9-bucket and 13-bucket sets make `sum by (le)` **non-monotonic**, so quantiles read as capped at 30 s until the fleet is homogeneous. With a sibling family there is no mixed-bucket window at all, because the family is new on every pod that has it.

**The `source` label — bounded, closed, and load-bearing.** `generate | preset | whatIf | imageIngest | other`, defaulting to `other` so a new caller can never be silently counted as `generate`, and **clamped at runtime** — the type alone is not a guarantee, because excess-property checking does not apply to spread properties, so one `submitWorkflow({ ...opts, token })` carrying a stray `source` would mint an unbounded label on a hot-path histogram with a green suite.

`generate` means **exactly** the tRPC `orchestrator.generateFromGraph` submit leg. That took more than stamping a constant: `generateFromGraph` has *two* entry points, and one of them is `preset-image-gen.service` — whose callers include the `process-enqueued-comic-panels` **cron job**, documented in its own code as running outside the tRPC request path. A flat `generate` there would have blended a background job into the very number that gets divided against the procedure's wall time. The label is therefore derived from the request's own `GenerationSurface` (`onsite`/`api` → `generate`, `preset` → `preset`) — an enum that is already bounded, already tested, and already fixed at context construction — rather than from a parallel vocabulary that could drift. This is not decoration. `submitWorkflowWithRetry` serves the generate leg, whatIf cost estimates, image ingestion, training, App Blocks, comics chat, prompt enhancement and product badges — populations with wildly different caps (whatIf is per-attempt-bounded at 8 s, image ingest at 15 s, generate is unbounded). Measured over the peak hour, on `civitai_app_image_scan_submitted_total{lane="new"}` and the tRPC procedure counters:

| population | submits/s (peak hour) | submits/s (24 h mean) |
|---|---|---|
| generate (`orchestrator.generateFromGraph`) | 4.737 | 4.427 |
| whatIf (`orchestrator.whatIfFromGraph`) | 6.599 | 5.648 |
| **image ingestion** | **1.256** | **1.309** |

Image ingestion is **27% of generate submits and 21% of all executed orchestrator workflows** (whatIf persists nothing), and it is *diurnally flat* — the hourly ingest÷generate ratio stayed in 0.17–0.51 across all 24 hours, so its share is highest exactly when generate dips. An unlabelled submit histogram would have inflated the generate count by ~27% and blended in two differently-capped latency distributions. Cross-checked three ways at the same hour: the submit counter (1.256/s), the scan-result webhook counter (1.190/s, 94.7% return rate), and a read-only `SELECT` on new `Image` rows (1.171/s, 100% with `scanRequestedAt` set). Cron/backfill lanes are 1.5% of submits, so this is live upload traffic at ~1 workflow per image. App Blocks submits measured 0.00000/s.

*Caveat on the two tRPC figures: `civitai_app_trpc_procedure_duration_seconds` is opt-in per deployment, so any server-side `createCaller` invocation is structurally invisible to it. That biases the ratio **against** the headline (it can only make image ingestion's share look larger than it is), and client `/api/trpc` traffic is routed to the pools that do emit it.*

**3. `onRetry` wired — it had zero call sites.**
`SubmitWorkflowRetryOptions.onRetry` shipped with the retry wrapper and was never called by anyone, and `result.attempts` was `Object.assign`ed on and then discarded. So a **3× latency multiplier on the most expensive tRPC procedure on the platform was entirely unobservable.** It now feeds `civitai_app_orchestrator_submit_retries_total{source, attempt, outcome}` — one increment per fired backoff, so a first-try success contributes nothing and an exhausted 3-attempt submit contributes 2. The built-in count fires **before** any caller-supplied hook and composes with it, so a caller that supplies its own `onRetry` — or whose hook throws — cannot suppress the counter.

This settles a standing question outright: whether the recurring ~95 s ceiling (Loki max 94,800 ms; it recurs) is `3 × 30 s + 0.5 + 1.5`. That arithmetic is consistent with Orleans' 30 s default response timeout — verified that **no `ResponseTimeout` / `SiloMessagingOptions` / `ClientMessagingOptions` override exists anywhere in `civitai-orchestration`** — but it was never proven, and the counter-evidence is real: the *measured* 500s on that route are fast (184 ms mean), so the common retry costs ~2.5 s, not 95 s. The ~95 s ceiling requires the callee to **hang**, not to 500. The counter plus the attempt spans distinguish the two populations directly.

`outcome` is a bounded enumeration (`network` | a 5xx status string | `other`) so the callee can never choose a label value freely. Both ends of that `>= 500 && <= 599` window are now pinned by test — see F9 below.

**4. W3C trace-context propagation on the outbound call.**
`HttpInstrumentation` is narrowed to inbound-only (`ignoreOutgoingRequestHook: () => true`) and the orchestrator client is fetch/undici, which was never auto-instrumented at all — so **no outbound call anywhere in the app has ever carried a `traceparent`**, and the orchestrator, which *is* instrumented, could never join the trace. A new `traceContextHeaders()` in `@civitai/telemetry` injects it **per call at the boundaries we choose**, rather than re-enabling whole-app outbound instrumentation and re-introducing the per-request `async_hooks` cost that was deliberately removed.

`withTraceHeaders` handles all three shapes of the client's `headers` union. This is not pedantry: a naive object spread **silently empties a `Headers` instance** and index-keys an array. Caller-supplied values win per-key. (Scope note under "Known limits" — the non-record branches are unreachable from any call site today.)

## Verification

**Red → green matrix** — `submitWorkflow.instrumentation.test.ts`, 33 tests:

| ref | result |
|---|---|
| `origin/main` sources + the new metrics module | **25 failed / 8 passed** |
| HEAD | **33 passed / 33** |

The base run keeps the new (passive) metrics module in the tree so imports resolve — otherwise the file fails to *collect* and reports "no tests", which is not a failure count and proves nothing. Every failure is therefore attributable to the missing **wiring**, which is what is under test.

The **8 that pass at base are labelled in the file** as invariant guards or mutation coverage, not regression coverage:
- "does NOT increment when the submit succeeds first try" — passes vacuously at base (`0 === 0`, the counter did not exist).
- "leaves the READ family completely untouched" — pins the sibling-family decision; the base read family already looked like this. It fails the moment someone merges the two families back together.
- the three pure `classifySubmitRetryOutcome` bound cases and the three `submitSourceForSurface` mapping cases — both helpers ship in this change and their guards were never absent, so they cannot be red at base. What they *are* is the kill for the mutants that remove those guards.

Span assertions run against a **real `NodeTracerProvider` with an in-memory exporter**, not a `vi.fn()` stub for `withSpan` — a stub would prove only that we call our own wrapper. The first test asserts the exporter saw a non-empty span list *before* anything else, as the positive control: without a registered provider the API tracer is a no-op and every span assertion in the file would pass vacuously.

**Mutation results — 19 mutants, all killed, each by its intended assertion on a reachable input:**

| mutant | tests killed | failing assertion |
|---|---|---|
| M1 `onRetry` wiring removed | 5 | `retryCount('generate','1','500')` → `expected +0 to be 1` |
| M2 `attempt` label hardcoded to `'1'` | 1 | `retryCount('generate','2','503')` → `expected +0 to be 1` |
| M3 outcome classification collapsed to `network` | 7 | same `retryCount` assertion |
| M4 histogram observed per-attempt instead of whole-call | 6 | `expected 6 to be 5` |
| M5 trace-context injection dropped | 2 | `expected undefined to be truthy` on `headers` |
| M6 `attempt` span attribute constant | 1 | `expected [1,1] to deeply equal [1,2]` |
| M7 `attempts` attribute set outside the `withSpan` callback | 2 | `expected undefined to be 3` |
| **M8 duration hardcoded to `0`** | 1 | `expected 0 to be greater than or equal to 0.03` |
| **M9 timer restarted immediately before the observation** | 1 | `expected 4.01e-7 to be greater than or equal to 0.03` |
| **M10 milliseconds instead of seconds** | 1 | `expected 60.03 to be less than 5` |
| **M11 `<= 599` bound removed** | 2 | `expected '600' to be 'other'` |
| M12 `source` label hardcoded | 8 | `expected +0 to be 1` on the `imageIngest` row |
| M13 whatIf coercion dropped | 3 | `expected +0 to be 1` on the `whatIf` row |
| M14 `source` runtime clamp removed | 1 | `expected 6 to be 7` on the `other` row |
| M15 `attempts` not stamped on the throw path | 1 | `expected undefined to be 3` |
| M16 the attempt counter never advances | 1 | `expected +0 to be 3` |
| M17 `preset` not split out of `generate` | 2 | `expected 'generate' to be 'preset'` |
| M18 an absent surface defaults to `generate` | 1 | `expected 'generate' to be 'other'` |
| PC (positive control) parent span renamed | 6 | `expected […] to include 'orchestrator:submit'` |

M14–M18 are the guards added by the delta re-audit round; M8/M9/M10 are the three that **survived the earlier revision's entire suite** — a 1000× unit error shipped green because every assertion counted observations and none constrained the number. The new value test sleeps a known 60 ms on real timers and pins the `_sum` band *and* the bucket the observation must land in, so each of the three dies twice over. M2 and M6 are the fixture-distinctness controls: attempt 1 fails with 500 and attempt 2 with 503, so a mutant that hardcodes either coordinate dies on the other row. M11 also dies on a *reachability* case that drives a 600 through the live retry loop — the guard is not behind an earlier check that would make it dead code.

Each mutant's file hash was verified to change before its run and the sweep aborts on an anchor that matches zero or more than one site, so a mutant that never applied cannot be scored SURVIVED. A positive control that the suite is known to catch ran in the same batch. Between mutants the sources were restored from `cp` copies and re-checksummed byte-identical (`sha256sum` matched on all five files); a grep for mutation residue in `src/` and `packages/` is clean.

**Blast radius of the metric names** — checked, not assumed. `git grep` for `orchestrator_read` and `orchestrator_submit` across the infra repo returns **nothing**: no dashboard, alert rule or recording rule references any of these families. Positive control for that grep: the same search for a metric that *is* on dashboards (`civitai_app_session_resolution`) returns 3 files, so the search does find app metric names in that repo. The read family is unchanged anyway.

**Other gates**
- `pnpm typecheck` (the repo script, 8 GB heap cap — a bare `tsc --noEmit` OOMs at exit 134): `0 type errors in 58s`.
- Orchestrator + blocks-workflow + jobs + data-graph suites: `Test Files 85 passed (85) / Tests 1276 passed (1276)`.
- `@civitai/telemetry` package suite: `Test Files 2 passed (2) / Tests 28 passed (28)`.
- `eslint` on the changed files: **0 errors** (4 pre-existing warnings in `orchestration-new.service.ts`, none on changed lines). `prettier --write`: clean.

## 🔴 Known limits, and what I did NOT verify

- **Whether these spans reach the tracing backend.** They are gated by `OTEL_ENABLED` and head-sampled at ratio 0.1 (`instrumentation.node.ts:182-185`). A unit test proving the code emits a span through a real SDK provider is not proof one lands in the backend. **This needs a post-deploy check**: search for `orchestrator:submit` in traces, and confirm `civitai_app_orchestrator_submit_duration_seconds_count{source="generate"}` is non-zero on the first scrape after rollout. If the count moves but no trace appears, the sampler is the reason, not the code.
- **That the orchestrator actually parents onto the injected `traceparent`.** The test proves the header is sent and carries the attempt span's ids. Whether the callee's pipeline honours it is a claim about the other service and is unverified here.
- **Trace shape changes once civitai mints the trace id.** Today the orchestrator starts its own trace on this route and records ~10% of them (its own ratio sampler). Once we send a `traceparent`, its sampler becomes parent-based on our decision — and the two ratio samplers are independent (ours 0.1, its 0.05). The consequence is that **roughly 90–95% of the orchestrator's spans on this route become dangling-parent orphans**: our parent span was not sampled, so the child arrives with a `parentSpanId` that has no span behind it. This is **not data loss** — every span we sample gets a complete cross-service trace, which is the whole point — but it *is* a change in how orchestration traces read in the backend for anyone used to browsing them standalone. Flagging it because it is a real reviewer-visible side effect that no test covers.
- **The `traceparent` decision depends on an env var being set in each deployment environment.** The orchestrator's *code default* sampler is parent-based-always-on; production is safe only because a trace-sampler env var is configured there. Any environment that drops or typos it would go from ~5% recorded to 100% recorded the moment this ships. Worth confirming that variable is present wherever this rolls out.
- **Mixed-fleet reads during rollout.** The new family simply does not exist on pods running the old image, so during the roll `sum by (le)` over it is a partial-fleet aggregate, not a wrong one. (The *non-monotonic* version of this problem is the one the sibling family avoids — see F6 above.)
- **`withTraceHeaders`' `Headers` and array branches are unreachable today.** Every caller in this repo passes a plain record, and one layer down the generated sdk's `submitWorkflow` spreads `headers` into a plain object anyway, which would defeat a `Headers` return before it reached the wire. Those two cases pin the helper's own contract, not a live path; the tests say so.

- **Five submit call sites bypass the wrapper entirely** — see the coverage note at the top. This is a documented limit of the metric, not a bug in it, but it means the family cannot be used to answer "how many workflows does the app submit?".
- **`refreshBlobUrlsInBody` is excluded by inference, not by a bracket.** The exclusion rests on 0.008 network refreshes/s against 4.44 submits/s — but `collectBlobRefs` walks the whole body allocating a closure per key on **every** submit, and that walk is not what was measured. It is very likely still negligible; a single `performance.now()` bracket would make the enumeration complete rather than inferential. Not added here.
- **The magnitude claims in the "gap" section above** are re-stated from the prior measurement work, not re-derived in this PR.

## What the delta re-audit caught

The audit-fix round was itself re-audited, and it found two things the *fix* had newly got wrong — worth recording because both were claims, not logic:

1. **"The single funnel every submit passes through" was false**, and it had shipped into a Prometheus help string. Five call sites use the generated client directly (see the coverage note above). Narrowed in all four places it appeared, and the help string now enumerates the exclusions.
2. **`source: 'generate'` was a hardcoded constant** stamped inside `generateFromGraph` — which a cron job also reaches. That is the same contamination class F3 was raised for, one level further up, reintroduced by the fix for F3. Now derived from the existing `GenerationSurface`.

Plus four smaller ones: the `source` label had no runtime clamp (type-only guarantees do not survive a spread); the span's `attempts` attribute was missing on the throw-shaped park, which is one of the exactly two shapes it exists to distinguish; the whatIf coercion sat one level too high for its own docstring to be true; and the timeouts-counter help asserted "can never appear by construction" when the construction has two conditions and only one was stated.

## Not fixed here, worth recording

**The five direct-client submit call sites have no instrumentation at all** and are the obvious next increment — `mediaHash`, `xGuardModeration`, `modelClamScan`, badge-resize and training auto-label. Giving them the retry wrapper would instrument them for free, but it also gives them retries they do not have today, so it is a behaviour change and belongs in its own PR.


The app already ships a **full** outbound-boundary resilience instrument set — `civitai_app_meili_call_{duration_seconds,active,queue_depth,timeouts}` plus `civitai_app_meili_circuit_{state,trips,rejections}`, and a byte-identical set for `signals`. **The orchestrator boundary still has none of it** — no circuit breaker, no in-flight/queue-depth gauge. It is the boundary that has twice head-of-line-blocked the entire api pool on record. The pattern to copy is already in this codebase.

Also unaddressed (deliberately): the generate submit path still has **no per-attempt timeout**. That decision is recorded in the code and the objection behind it was real, but the precondition has since changed — the client now mints a per-submit `externalId` and the orchestrator dedupes on it, which is exactly the idempotency guarantee a safe cap needs. That is a behaviour change with a product tradeoff (it converts slow *successes* into 503s, and 99.7% of the ≥5 s population currently succeeds), so it belongs to a human and to a separate PR — **after** this instrument tells us whether the parks are `3 × 30 s` or one long attempt, because that changes the cap value completely.

Also noted while measuring: `createImageIngestionRequest` has **no submit-latency, retry or media-`type` instrumentation of its own**. It now inherits the submit histogram and the attempt spans from this change (that is a direct consequence of instrumenting the wrapper rather than `submitWorkflow`), but a `type` split — image vs video, where a video fans `wdTagging`+`mediaRating` over up to 50 extracted frames — would be a cheap follow-up.

## Cost

One span alloc + `context.with` per submit attempt, plus one parent span per submit. Measured: **+1.09 µs/submit with OTEL off, +3.7–4.7 µs on** — against the 9.55 server-s/s this procedure burns, that is ~2 ppm. Submit runs at ~4.4/s, three orders of magnitude below the redis command rate whose per-op instrumentation was removed for exactly this cost. Extra-bucket CPU is nil (358 vs 373 ns/observe — noise). No control-flow, error-mapping, or timing changes; `withTraceHeaders` returns the caller's value **by reference** when tracing is off, so the disabled path is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
