### PR TITLE
feat(app-listings): the mod control the `exclude` column was added for — and the counter it has to move

### DIFF
--- a/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
@@ -354,6 +354,15 @@ describe('setReviewExclude — the per-review mod hide control', () => {
   // a branch where `setReviewExclude` was never added — it would prove the gate
   // without the gate existing. Pinning FORBIDDEN / UNAUTHORIZED is what makes these
   // fail at the base commit.
+  //
+  // 🟡 …but only the TESTER case tests the MOD gate. `moderatorProcedure` is
+  // `protectedProcedure.use(isMod)`, so an ANONYMOUS caller is rejected by `isAuthed`
+  // with UNAUTHORIZED before `isMod` is ever reached — and that is equally true if the
+  // gate is downgraded to `protectedProcedure`. The anonymous case is therefore
+  // STRUCTURALLY incapable of discriminating mod-gated from merely-authenticated, and
+  // is measured to survive that mutation. It is an AUTH guard; the tester case below
+  // is the mod guard. Labelled rather than deleted because "anon cannot reach this"
+  // is still worth pinning — just not as evidence of moderator-only.
   it('a tester is FORBIDDEN and the service is NOT called (a user cannot hide a review)', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
     await expect(caller.setReviewExclude({ reviewId: 7, exclude: true })).rejects.toMatchObject({

--- a/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
@@ -27,6 +27,7 @@ const {
   mockListReports,
   mockResetOnsite,
   mockPreviewForReview,
+  mockSetReviewExclude,
   mockIsAppBlocksEnabled,
   mockIsAppBlocksAuthorEnabled,
 } = vi.hoisted(() => ({
@@ -45,6 +46,12 @@ const {
   mockReport: vi.fn(async () => ({ reportId: 'alrp_1' })),
   mockListReports: vi.fn(async () => ({ items: [], nextCursor: null })),
   mockPreviewForReview: vi.fn(async () => ({ card: {}, detail: {} })),
+  mockSetReviewExclude: vi.fn(async () => ({
+    id: 7,
+    appListingId: 'apl_1',
+    exclude: true,
+    changed: true,
+  })),
   mockIsAppBlocksEnabled: vi.fn(),
   mockIsAppBlocksAuthorEnabled: vi.fn(),
 }));
@@ -65,6 +72,12 @@ vi.mock('~/server/services/blocks/offsite-moderation.service', () => ({
 // mock just that export so the mod-gate authz can be exercised without a DB.
 vi.mock('~/server/services/blocks/app-listing.service', () => ({
   getListingPreviewForReview: mockPreviewForReview,
+}));
+// The per-review mod hide/un-hide control is dynamically imported by
+// `setReviewExclude`; mock just that export so the mod gate can be exercised
+// without a DB. (The user-facing review procs in this router are not called here.)
+vi.mock('~/server/services/blocks/app-listing-review.service', () => ({
+  setAppListingReviewExclude: mockSetReviewExclude,
 }));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: mockIsAppBlocksEnabled,
@@ -157,6 +170,14 @@ const MOD_ACTIONS: Array<{
     name: 'resetOnsiteListingToPending',
     mock: mockResetOnsite,
     call: (c) => c.resetOnsiteListingToPending({ appListingId: 'apl_1', reason: REASON }),
+  },
+  {
+    // W13 per-REVIEW mod control — hide/un-hide one `AppListingReview` and move the
+    // denormalized recommend counters. Same `moderatorProcedure` + `isModerator`
+    // recheck boundary as every action above, so it belongs in this ledger.
+    name: 'setReviewExclude',
+    mock: mockSetReviewExclude,
+    call: (c) => c.setReviewExclude({ reviewId: 7, exclude: true }),
   },
 ];
 
@@ -323,6 +344,70 @@ describe('getListingPreviewForReview — moderator-only read', () => {
         .procedures
     );
     expect(procs).toContain('getListingPreviewForReview');
+  });
+});
+
+describe('setReviewExclude — the per-review mod hide control', () => {
+  // 🔴 These two assert the SPECIFIC code, not merely `instanceof TRPCError`. A
+  // caller invoking a proc that does not exist also rejects with a TRPCError
+  // (`NOT_FOUND`, "No procedure found on path"), so the loose assertion is GREEN on
+  // a branch where `setReviewExclude` was never added — it would prove the gate
+  // without the gate existing. Pinning FORBIDDEN / UNAUTHORIZED is what makes these
+  // fail at the base commit.
+  it('a tester is FORBIDDEN and the service is NOT called (a user cannot hide a review)', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
+    await expect(caller.setReviewExclude({ reviewId: 7, exclude: true })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockSetReviewExclude).not.toHaveBeenCalled();
+  });
+
+  it('anonymous is UNAUTHORIZED and the service is NOT called', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.setReviewExclude({ reviewId: 7, exclude: true })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(mockSetReviewExclude).not.toHaveBeenCalled();
+  });
+
+  it('a moderator passes, and the target state is forwarded verbatim (hide AND un-hide)', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.setReviewExclude({ reviewId: 7, exclude: true })).resolves.toMatchObject({
+      changed: true,
+    });
+    await caller.setReviewExclude({ reviewId: 9, exclude: false });
+    // An EXPLICIT target state, never a toggle — that is what makes a retry safe, so
+    // the router must not translate it into anything else on the way through.
+    expect(mockSetReviewExclude.mock.calls[0][0]).toEqual({ reviewId: 7, exclude: true });
+    expect(mockSetReviewExclude.mock.calls[1][0]).toEqual({ reviewId: 9, exclude: false });
+  });
+
+  it('rejects a non-positive / non-integer reviewId and a missing target at the SCHEMA boundary', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    for (const bad of [
+      { reviewId: 0, exclude: true },
+      { reviewId: -1, exclude: true },
+      { reviewId: 1.5, exclude: true },
+      { reviewId: 7 } as unknown as { reviewId: number; exclude: boolean },
+    ]) {
+      // BAD_REQUEST specifically — a missing proc would reject with NOT_FOUND, so a
+      // bare `instanceof TRPCError` here would be green with no schema at all.
+      await expect(caller.setReviewExclude(bad)).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    }
+    expect(mockSetReviewExclude).not.toHaveBeenCalled();
+  });
+
+  it('there is EXACTLY ONE review-exclude endpoint (no protectedProcedure self-hide)', () => {
+    const procs = Object.keys(
+      (appListingsRouter as unknown as { _def: { procedures: Record<string, unknown> } })._def
+        .procedures
+    );
+    expect(procs).toContain('setReviewExclude');
+    // Assert by absence: a review author must not be able to hide their own (or
+    // anyone's) review — the mod gate is the whole boundary, as with claimListing.
+    expect(procs.filter((p) => /exclude/i.test(p))).toEqual(['setReviewExclude']);
+    // And no delete path was introduced alongside it — the soft-hide IS the control.
+    expect(procs.filter((p) => /^delete.*review|review.*delete/i.test(p))).toEqual([]);
   });
 });
 

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -20,6 +20,7 @@ import {
 import {
   getMyAppListingReviewSchema,
   listAppListingReviewsSchema,
+  setAppListingReviewExcludeSchema,
   upsertAppListingReviewSchema,
 } from '~/server/schema/blocks/app-listing-review.schema';
 import {
@@ -1511,9 +1512,10 @@ export const appListingsRouter = router({
   // (`app-listings-public-external`) can now submit the reviews the store already
   // let them see — the gate's own header has the history.
   //
-  // FOLLOW-UP (deferred): a MOD exclude/report path for individual reviews.
-  // `listReviews` ALREADY filters `exclude`/`tosViolation`, so a future mod action
-  // takes effect on the visible list with no read-path change.
+  // MOD control (`setReviewExclude`, below): the deferred per-review exclude path,
+  // now built. `listReviews` ALREADY filters `exclude`/`tosViolation`, so the mod
+  // action takes effect on the visible list with no read-path change. The report
+  // half is still deferred.
   // -------------------------------------------------------------------------
 
   /**
@@ -1582,5 +1584,35 @@ export const appListingsRouter = router({
         '~/server/services/blocks/app-listing-review.service'
       );
       return listAppListingReviews(input, { scope });
+    }),
+
+  /**
+   * MOD: hide / un-hide a single review (`AppListingReview.exclude`) and move the
+   * denormalized recommend counters to match, in one tx.
+   *
+   * Gate: `moderatorProcedure` + the inner `isModerator` recheck — the SAME idiom
+   * as the delist/relist/claim/purge actions above, and the WHOLE trust boundary.
+   * Deliberately NOT `enforceAppListingsWriteFlag`: that flag darkens the store UI
+   * and mods bypass it anyway, so it would be inert here (matching the mod-action
+   * block's own reasoning).
+   *
+   * NOT a delete. A hard delete would leave the denormalized aggregate permanently
+   * wrong, and would let the same user file a fresh FIRST review for the listing —
+   * see `setAppListingReviewExclude`'s header for the full reasoning.
+   *
+   * `exclude` is an explicit target state, so the mutation is IDEMPOTENT: re-hiding
+   * an already-hidden review writes nothing and moves no counter. Returns
+   * `changed:false` in that case rather than erroring.
+   */
+  setReviewExclude: moderatorProcedure
+    .input(setAppListingReviewExcludeSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Moderating app reviews is restricted to civitai team');
+      }
+      const { setAppListingReviewExclude } = await import(
+        '~/server/services/blocks/app-listing-review.service'
+      );
+      return setAppListingReviewExclude(input);
     }),
 });

--- a/src/server/schema/blocks/app-listing-review.schema.ts
+++ b/src/server/schema/blocks/app-listing-review.schema.ts
@@ -45,6 +45,29 @@ export const upsertAppListingReviewSchema = z.object({
 });
 export type UpsertAppListingReviewInput = z.infer<typeof upsertAppListingReviewSchema>;
 
+/**
+ * MOD set a single review's `exclude` flag (hide / unhide) — the moderator control
+ * the `AppListingReview.exclude` column was added for.
+ *
+ * Keyed on the review's own `id`, NOT (appListingId, userId): the id is what the
+ * public list (`listReviews`) already projects, so a moderator acts on exactly the
+ * row they are looking at with one opaque handle, and cannot mis-pair a listing
+ * with the wrong reviewer. It also matches the existing `resourceReview.toggleExclude`
+ * shape.
+ *
+ * 🔴 `exclude` is an EXPLICIT TARGET STATE, not a toggle — deliberately diverging
+ * from `resourceReview.toggleExclude`. A toggle is not safely re-runnable: a
+ * double-submit, a retry after a timeout, or two moderators acting on the same
+ * report flip the row back and move the aggregate twice. An explicit target makes
+ * the mutation idempotent (a no-op transition applies ZERO metric delta), which is
+ * what makes a retry safe.
+ */
+export const setAppListingReviewExcludeSchema = z.object({
+  reviewId: z.number().int().positive(),
+  exclude: z.boolean(),
+});
+export type SetAppListingReviewExcludeInput = z.infer<typeof setAppListingReviewExcludeSchema>;
+
 /** USER read of their OWN review for a listing (form prefill), or null. */
 export const getMyAppListingReviewSchema = z.object({ appListingId });
 export type GetMyAppListingReviewInput = z.infer<typeof getMyAppListingReviewSchema>;

--- a/src/server/services/blocks/__tests__/app-listing-review.mod-exclude.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-review.mod-exclude.test.ts
@@ -7,6 +7,8 @@ import {
   setAppListingReviewExclude,
   upsertAppListingReview,
 } from '~/server/services/blocks/app-listing-review.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { resetHybridNodes } from '~/__tests__/mocks/hybrid';
 
 /**
  * W13 — the MODERATOR hide/un-hide control for an AppListing review
@@ -22,56 +24,37 @@ import {
  *   3. the flag flip and the counter move happen in ONE transaction, off the
  *      PRIMARY (a replica-lag read of `exclude` would decide the delta wrongly).
  *
- * All DB deps are mocked — no real Prisma. `dbWrite.$transaction` runs its callback
- * against the SAME `dbWrite` mock (the tx client) so a test asserts the exact writes
- * made inside the tx, and `dbRead`/`dbWrite` are DISTINCT mocks so a test can prove
- * which client a read went to.
+ * All DB deps come from the CANONICAL `dbMock` (registered globally in
+ * `src/__tests__/setup.ts`) — no real Prisma, and no per-file `vi.mock` of
+ * `~/server/db/client`, which `no-direct-shared-module-mock` forbids. Its
+ * `dbWrite.$transaction` default runs the callback with `dbMock.dbWrite`, so a test
+ * asserts the exact writes made inside the tx; `dbRead` and `dbWrite` are DISTINCT
+ * nodes, so a test can prove which client a read went to.
  */
 
-type WriteMock = {
-  $transaction: ReturnType<typeof vi.fn>;
-  appListingReview: {
-    findUnique: ReturnType<typeof vi.fn>;
-    update: ReturnType<typeof vi.fn>;
-    upsert: ReturnType<typeof vi.fn>;
-  };
-  appListingMetric: { upsert: ReturnType<typeof vi.fn>; updateMany: ReturnType<typeof vi.fn> };
-};
-type ReadMock = {
-  appListing: { findUnique: ReturnType<typeof vi.fn> };
-  appListingReview: {
-    findUnique: ReturnType<typeof vi.fn>;
-    findFirst: ReturnType<typeof vi.fn>;
-    findMany: ReturnType<typeof vi.fn>;
-  };
-};
-
-const { mockRead, mockWrite, mockBust } = vi.hoisted(() => {
-  const write: WriteMock = {
-    $transaction: vi.fn(),
-    appListingReview: {
-      findUnique: vi.fn(async () => null),
-      update: vi.fn(async () => ({})),
-      upsert: vi.fn(async () => ({})),
-    },
-    appListingMetric: {
-      upsert: vi.fn(async () => ({})),
-      updateMany: vi.fn(async () => ({ count: 0 })),
-    },
-  };
-  const read: ReadMock = {
-    appListing: { findUnique: vi.fn(async () => null) },
-    appListingReview: {
-      findUnique: vi.fn(async () => null),
-      findFirst: vi.fn(async () => null),
-      findMany: vi.fn(async () => []),
-    },
-  };
-  return { mockRead: read, mockWrite: write, mockBust: vi.fn(async () => undefined) };
-});
-
-vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+const { mockBust } = vi.hoisted(() => ({ mockBust: vi.fn(async () => undefined) }));
 vi.mock('~/server/utils/cache-helpers', () => ({ bustCacheTag: mockBust }));
+
+const mockWrite = {
+  $transaction: dbMock.dbWrite.$transaction,
+  appListingReview: {
+    findUnique: dbMock.dbWrite.appListingReview.findUnique,
+    update: dbMock.dbWrite.appListingReview.update,
+    upsert: dbMock.dbWrite.appListingReview.upsert,
+  },
+  appListingMetric: {
+    upsert: dbMock.dbWrite.appListingMetric.upsert,
+    updateMany: dbMock.dbWrite.appListingMetric.updateMany,
+  },
+};
+const mockRead = {
+  appListing: { findUnique: dbMock.dbRead.appListing.findUnique },
+  appListingReview: {
+    findUnique: dbMock.dbRead.appListingReview.findUnique,
+    findFirst: dbMock.dbRead.appListingReview.findFirst,
+    findMany: dbMock.dbRead.appListingReview.findMany,
+  },
+};
 
 const REVIEW_ID = 7;
 const APP_ID = 'apl_target';
@@ -88,26 +71,22 @@ function reviewRow(over: Partial<{ recommended: boolean; exclude: boolean }> = {
 }
 
 beforeEach(() => {
-  // 🔴 resetAllMocks, NOT clearAllMocks. `mockClear` leaves the `mockResolvedValueOnce`
+  // 🔴 A full RESET, not `mockClear`. `mockClear` leaves the `mockResolvedValueOnce`
   // QUEUE intact, so a test that throws before consuming its queued values leaks them
-  // into the NEXT test — which then runs against a row it never configured and can
-  // pass or fail for a reason that has nothing to do with the code. (Observed for
-  // real while measuring this file against the base branch.) Every implementation is
-  // re-established immediately below, so the reset costs nothing.
-  vi.resetAllMocks();
+  // into the NEXT test — which then runs against a row it never configured and can pass
+  // or fail for a reason that has nothing to do with the code. (Observed for real while
+  // measuring this file against the base branch.) `resetSharedMocks()` runs per FILE,
+  // not per test, so the per-test reset has to be explicit — `resetHybridNodes()` clears
+  // every canonical node's implementation AND call history and re-applies its registered
+  // default, which is what restores the `$transaction` callback runner below.
+  resetHybridNodes();
+  mockBust.mockReset();
   mockBust.mockResolvedValue(undefined);
-  mockWrite.$transaction.mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) =>
-    cb(mockWrite)
-  );
   mockWrite.appListingReview.findUnique.mockResolvedValue(reviewRow());
   mockWrite.appListingReview.update.mockResolvedValue({});
   mockWrite.appListingReview.upsert.mockResolvedValue({});
   mockWrite.appListingMetric.upsert.mockResolvedValue({});
   mockWrite.appListingMetric.updateMany.mockResolvedValue({ count: 0 });
-  mockRead.appListing.findUnique.mockResolvedValue(null);
-  mockRead.appListingReview.findUnique.mockResolvedValue(null);
-  mockRead.appListingReview.findFirst.mockResolvedValue(null);
-  mockRead.appListingReview.findMany.mockResolvedValue([]);
 });
 
 function metricUpdateArgs() {

--- a/src/server/services/blocks/__tests__/app-listing-review.mod-exclude.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-review.mod-exclude.test.ts
@@ -1,0 +1,485 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getMyAppListingReview,
+  listAppListingReviews,
+  recommendMetricDelta,
+  setAppListingReviewExclude,
+  upsertAppListingReview,
+} from '~/server/services/blocks/app-listing-review.service';
+
+/**
+ * W13 — the MODERATOR hide/un-hide control for an AppListing review
+ * (`AppListingReview.exclude`) and its denormalized-counter bookkeeping.
+ *
+ * `AppListingMetric.thumbsUp/DownCount` has NO rollup job — it is exactly the sum
+ * of the ±1 deltas its writers applied. So the properties under test are not
+ * "does it set a boolean" but:
+ *   1. a hide moves EXACTLY ONE counter by EXACTLY 1, in the bucket matching the
+ *      row's `recommended`, and an un-hide moves it back;
+ *   2. a NO-OP transition applies a ZERO delta and writes NOTHING — the property
+ *      that makes a retry / double-submit / two-moderators-on-one-report safe;
+ *   3. the flag flip and the counter move happen in ONE transaction, off the
+ *      PRIMARY (a replica-lag read of `exclude` would decide the delta wrongly).
+ *
+ * All DB deps are mocked — no real Prisma. `dbWrite.$transaction` runs its callback
+ * against the SAME `dbWrite` mock (the tx client) so a test asserts the exact writes
+ * made inside the tx, and `dbRead`/`dbWrite` are DISTINCT mocks so a test can prove
+ * which client a read went to.
+ */
+
+type WriteMock = {
+  $transaction: ReturnType<typeof vi.fn>;
+  appListingReview: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+  };
+  appListingMetric: { upsert: ReturnType<typeof vi.fn>; updateMany: ReturnType<typeof vi.fn> };
+};
+type ReadMock = {
+  appListing: { findUnique: ReturnType<typeof vi.fn> };
+  appListingReview: {
+    findUnique: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
+};
+
+const { mockRead, mockWrite, mockBust } = vi.hoisted(() => {
+  const write: WriteMock = {
+    $transaction: vi.fn(),
+    appListingReview: {
+      findUnique: vi.fn(async () => null),
+      update: vi.fn(async () => ({})),
+      upsert: vi.fn(async () => ({})),
+    },
+    appListingMetric: {
+      upsert: vi.fn(async () => ({})),
+      updateMany: vi.fn(async () => ({ count: 0 })),
+    },
+  };
+  const read: ReadMock = {
+    appListing: { findUnique: vi.fn(async () => null) },
+    appListingReview: {
+      findUnique: vi.fn(async () => null),
+      findFirst: vi.fn(async () => null),
+      findMany: vi.fn(async () => []),
+    },
+  };
+  return { mockRead: read, mockWrite: write, mockBust: vi.fn(async () => undefined) };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/utils/cache-helpers', () => ({ bustCacheTag: mockBust }));
+
+const REVIEW_ID = 7;
+const APP_ID = 'apl_target';
+
+/** A stored review row as the service selects it. */
+function reviewRow(over: Partial<{ recommended: boolean; exclude: boolean }> = {}) {
+  return {
+    id: REVIEW_ID,
+    appListingId: APP_ID,
+    recommended: true,
+    exclude: false,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  // 🔴 resetAllMocks, NOT clearAllMocks. `mockClear` leaves the `mockResolvedValueOnce`
+  // QUEUE intact, so a test that throws before consuming its queued values leaks them
+  // into the NEXT test — which then runs against a row it never configured and can
+  // pass or fail for a reason that has nothing to do with the code. (Observed for
+  // real while measuring this file against the base branch.) Every implementation is
+  // re-established immediately below, so the reset costs nothing.
+  vi.resetAllMocks();
+  mockBust.mockResolvedValue(undefined);
+  mockWrite.$transaction.mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) =>
+    cb(mockWrite)
+  );
+  mockWrite.appListingReview.findUnique.mockResolvedValue(reviewRow());
+  mockWrite.appListingReview.update.mockResolvedValue({});
+  mockWrite.appListingReview.upsert.mockResolvedValue({});
+  mockWrite.appListingMetric.upsert.mockResolvedValue({});
+  mockWrite.appListingMetric.updateMany.mockResolvedValue({ count: 0 });
+  mockRead.appListing.findUnique.mockResolvedValue(null);
+  mockRead.appListingReview.findUnique.mockResolvedValue(null);
+  mockRead.appListingReview.findFirst.mockResolvedValue(null);
+  mockRead.appListingReview.findMany.mockResolvedValue([]);
+});
+
+function metricUpdateArgs() {
+  return mockWrite.appListingMetric.upsert.mock.calls[0][0] as {
+    where: { appListingId: string };
+    create: { thumbsUpCount: number; thumbsDownCount: number };
+    update: { thumbsUpCount?: { increment: number }; thumbsDownCount?: { increment: number } };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The shared delta rule, as a pure truth table.
+//
+// Both writers (`upsertAppListingReview` and `setAppListingReviewExclude`) route
+// their arithmetic through this one function, so pinning it here pins BOTH. The
+// cases are chosen so each is distinguishable from the others: a mutant that
+// hardcodes a bucket, drops a sign, or collapses the two branches breaks at least
+// one row.
+// ---------------------------------------------------------------------------
+describe('recommendMetricDelta — the one delta rule, both writers share it', () => {
+  it.each([
+    // [label, prior contribution, next contribution, expected delta]
+    ['nothing → nothing (no-op)', null, null, { upDelta: 0, downDelta: 0 }],
+    [
+      'nothing → recommend (new/unhidden up)',
+      null,
+      { recommended: true },
+      { upDelta: 1, downDelta: 0 },
+    ],
+    [
+      'nothing → not-recommend (new/unhidden down)',
+      null,
+      { recommended: false },
+      { upDelta: 0, downDelta: 1 },
+    ],
+    [
+      'recommend → nothing (hide an up)',
+      { recommended: true },
+      null,
+      { upDelta: -1, downDelta: 0 },
+    ],
+    [
+      'not-recommend → nothing (hide a down)',
+      { recommended: false },
+      null,
+      { upDelta: 0, downDelta: -1 },
+    ],
+    [
+      'recommend → recommend (details-only edit)',
+      { recommended: true },
+      { recommended: true },
+      { upDelta: 0, downDelta: 0 },
+    ],
+    [
+      'not-recommend → not-recommend (details-only edit)',
+      { recommended: false },
+      { recommended: false },
+      { upDelta: 0, downDelta: 0 },
+    ],
+    [
+      'recommend → not-recommend (flip)',
+      { recommended: true },
+      { recommended: false },
+      { upDelta: -1, downDelta: 1 },
+    ],
+    [
+      'not-recommend → recommend (flip)',
+      { recommended: false },
+      { recommended: true },
+      { upDelta: 1, downDelta: -1 },
+    ],
+  ])('%s', (_label, prior, next, expected) => {
+    expect(recommendMetricDelta(prior, next)).toEqual(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HIDING — false → true.
+// ---------------------------------------------------------------------------
+describe('setAppListingReviewExclude — hiding (false → true)', () => {
+  it('a RECOMMENDED review: sets exclude and decrements thumbsUp by exactly 1', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValue(
+      reviewRow({ recommended: true, exclude: false })
+    );
+
+    const res = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
+
+    expect(res).toEqual({ id: REVIEW_ID, appListingId: APP_ID, exclude: true, changed: true });
+    expect(mockWrite.appListingReview.update).toHaveBeenCalledWith({
+      where: { id: REVIEW_ID },
+      data: { exclude: true },
+    });
+
+    const m = metricUpdateArgs();
+    expect(m.where).toEqual({ appListingId: APP_ID });
+    // EXACTLY ONE counter moves, by EXACTLY 1 — the down bucket key must be ABSENT,
+    // not merely zero (an `{ increment: 0 }` would still bump `updatedAt`).
+    expect(m.update).toEqual({ thumbsUpCount: { increment: -1 } });
+    expect(m.update.thumbsDownCount).toBeUndefined();
+    // A decrement fired → the defensive non-negative clamp runs for that bucket only.
+    expect(mockWrite.appListingMetric.updateMany).toHaveBeenCalledWith({
+      where: { appListingId: APP_ID, thumbsUpCount: { lt: 0 } },
+      data: { thumbsUpCount: 0 },
+    });
+    expect(mockWrite.appListingMetric.updateMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('a NOT-RECOMMENDED review: decrements thumbsDown by exactly 1 (the other counter)', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValue(
+      reviewRow({ recommended: false, exclude: false })
+    );
+
+    await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
+
+    const m = metricUpdateArgs();
+    expect(m.update).toEqual({ thumbsDownCount: { increment: -1 } });
+    expect(m.update.thumbsUpCount).toBeUndefined();
+    expect(mockWrite.appListingMetric.updateMany).toHaveBeenCalledWith({
+      where: { appListingId: APP_ID, thumbsDownCount: { lt: 0 } },
+      data: { thumbsDownCount: 0 },
+    });
+    expect(mockWrite.appListingMetric.updateMany).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UN-HIDING — true → false.
+// ---------------------------------------------------------------------------
+describe('setAppListingReviewExclude — un-hiding (true → false)', () => {
+  it('a RECOMMENDED review: clears exclude and re-increments thumbsUp by exactly 1', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValue(
+      reviewRow({ recommended: true, exclude: true })
+    );
+
+    const res = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: false });
+
+    expect(res).toEqual({ id: REVIEW_ID, appListingId: APP_ID, exclude: false, changed: true });
+    expect(mockWrite.appListingReview.update).toHaveBeenCalledWith({
+      where: { id: REVIEW_ID },
+      data: { exclude: false },
+    });
+
+    const m = metricUpdateArgs();
+    expect(m.update).toEqual({ thumbsUpCount: { increment: 1 } });
+    expect(m.update.thumbsDownCount).toBeUndefined();
+    // No decrement anywhere → the clamp must NOT run.
+    expect(mockWrite.appListingMetric.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('a NOT-RECOMMENDED review: re-increments thumbsDown by exactly 1', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValue(
+      reviewRow({ recommended: false, exclude: true })
+    );
+
+    await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: false });
+
+    const m = metricUpdateArgs();
+    expect(m.update).toEqual({ thumbsDownCount: { increment: 1 } });
+    expect(m.update.thumbsUpCount).toBeUndefined();
+    expect(mockWrite.appListingMetric.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('hide-then-unhide of the same row returns the counter to where it started (round trip)', async () => {
+    // Two calls against the row's two states; the deltas must sum to zero on the
+    // bucket that moved, and never touch the other bucket.
+    mockWrite.appListingReview.findUnique.mockResolvedValueOnce(
+      reviewRow({ recommended: true, exclude: false })
+    );
+    await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
+    mockWrite.appListingReview.findUnique.mockResolvedValueOnce(
+      reviewRow({ recommended: true, exclude: true })
+    );
+    await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: false });
+
+    const calls = mockWrite.appListingMetric.upsert.mock.calls.map(
+      (c) => (c[0] as { update: { thumbsUpCount?: { increment: number } } }).update
+    );
+    expect(calls).toEqual([
+      { thumbsUpCount: { increment: -1 } },
+      { thumbsUpCount: { increment: 1 } },
+    ]);
+    const net = calls.reduce((sum, u) => sum + (u.thumbsUpCount?.increment ?? 0), 0);
+    expect(net).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IDEMPOTENCE — the case most likely to be wrong, and what makes a re-run safe.
+// ---------------------------------------------------------------------------
+describe('setAppListingReviewExclude — a NO-OP transition applies ZERO delta', () => {
+  it('hiding an ALREADY-hidden review writes nothing at all (no row update, no counter, no bust)', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValue(
+      reviewRow({ recommended: true, exclude: true })
+    );
+
+    const res = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
+
+    expect(res).toEqual({ id: REVIEW_ID, appListingId: APP_ID, exclude: true, changed: false });
+    expect(mockWrite.appListingReview.update).not.toHaveBeenCalled();
+    expect(mockWrite.appListingMetric.upsert).not.toHaveBeenCalled();
+    expect(mockWrite.appListingMetric.updateMany).not.toHaveBeenCalled();
+    expect(mockBust).not.toHaveBeenCalled();
+  });
+
+  it('un-hiding an already-VISIBLE review writes nothing at all', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValue(
+      reviewRow({ recommended: false, exclude: false })
+    );
+
+    const res = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: false });
+
+    expect(res).toMatchObject({ exclude: false, changed: false });
+    expect(mockWrite.appListingReview.update).not.toHaveBeenCalled();
+    expect(mockWrite.appListingMetric.upsert).not.toHaveBeenCalled();
+    expect(mockWrite.appListingMetric.updateMany).not.toHaveBeenCalled();
+    expect(mockBust).not.toHaveBeenCalled();
+  });
+
+  it('hiding TWICE moves the counter exactly ONCE (a retry cannot double-count)', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValueOnce(
+      reviewRow({ recommended: true, exclude: false })
+    );
+    const first = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
+    // Second call sees the row in its NEW state — the realistic retry.
+    mockWrite.appListingReview.findUnique.mockResolvedValueOnce(
+      reviewRow({ recommended: true, exclude: true })
+    );
+    const second = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
+
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(mockWrite.appListingMetric.upsert).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingReview.update).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Atomicity + not-found.
+// ---------------------------------------------------------------------------
+describe('setAppListingReviewExclude — transaction + lookup', () => {
+  it('reads the row and writes BOTH the flag and the counter inside ONE transaction, on the PRIMARY', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValue(
+      reviewRow({ recommended: true, exclude: false })
+    );
+
+    await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
+
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
+    // The `exclude` read decides the delta, so it must NOT come off the replica —
+    // a lagging read would recompute a delta that was already applied.
+    expect(mockRead.appListingReview.findUnique).not.toHaveBeenCalled();
+    expect(mockRead.appListingReview.findFirst).not.toHaveBeenCalled();
+    expect(mockWrite.appListingReview.findUnique).toHaveBeenCalledWith({
+      where: { id: REVIEW_ID },
+      select: { id: true, appListingId: true, recommended: true, exclude: true },
+    });
+  });
+
+  it('a missing review → NOT_FOUND, with no row or counter write', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValue(null);
+
+    await expect(
+      setAppListingReviewExclude({ reviewId: 12345, exclude: true })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    expect(mockWrite.appListingReview.update).not.toHaveBeenCalled();
+    expect(mockWrite.appListingMetric.upsert).not.toHaveBeenCalled();
+    expect(mockBust).not.toHaveBeenCalled();
+  });
+
+  it('a real transition busts the store-wide recommend-mean cache', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValue(
+      reviewRow({ recommended: true, exclude: false })
+    );
+    await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
+    expect(mockBust).toHaveBeenCalledWith(['app-listing:recommend-global-mean']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SEAM: the user write path and the mod path share one delta rule.
+//
+// Verifying each in isolation cannot see a disagreement BETWEEN them, so this
+// asserts the relationship: the same (recommended, excluded) state produces the
+// same counter language from both writers.
+//
+// 🟡 LABEL: green at the base commit too — the user path already honoured a
+// pre-existing `exclude`. It is an INVARIANT GUARD, not regression coverage: it
+// pins the property the mod control now DEPENDS on (a hidden review stays hidden
+// from the aggregate when its author edits it), which nothing asserted before
+// anything could set `exclude` in the first place.
+// ---------------------------------------------------------------------------
+describe('seam — the user write path still routes through the shared rule', () => {
+  it('a mod-EXCLUDED prior review stays un-counted when its author edits it (no delta)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue({
+      id: APP_ID,
+      userId: 99,
+      status: 'approved',
+    });
+    mockWrite.appListingReview.findUnique.mockResolvedValue({
+      id: REVIEW_ID,
+      recommended: true,
+      exclude: true,
+    });
+    mockWrite.appListingReview.upsert.mockResolvedValue({
+      id: REVIEW_ID,
+      appListingId: APP_ID,
+      userId: 42,
+      recommended: false,
+      details: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await upsertAppListingReview({
+      userId: 42,
+      input: { appListingId: APP_ID, recommended: false },
+      scope: 'full',
+    });
+
+    // An author cannot restore their own hidden review to the aggregate by editing
+    // it — the mod decision survives the edit.
+    expect(mockWrite.appListingMetric.upsert).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// READ-PATH INVARIANT GUARDS.
+//
+// 🟡 LABEL: these two pin behaviour that ALREADY holds on `main`. They are
+// INVARIANT GUARDS, not regression coverage for this change — they are green
+// before it and after it. They exist because the mod control makes both properties
+// load-bearing for the first time: hiding a review must remove it from the public
+// list, and must NOT remove it from its own author's edit form.
+// ---------------------------------------------------------------------------
+describe('read-path invariants the mod control depends on', () => {
+  it('INVARIANT: getMyAppListingReview does NOT filter exclude — an author still sees their hidden review', async () => {
+    mockRead.appListingReview.findFirst.mockResolvedValue({
+      id: REVIEW_ID,
+      recommended: true,
+      details: 'hidden but mine',
+      createdAt: new Date(),
+    });
+
+    const res = await getMyAppListingReview(APP_ID, 42, { scope: 'full' });
+
+    // The row comes back even though the mod hid it...
+    expect(res).toMatchObject({ id: REVIEW_ID, details: 'hidden but mine' });
+    // ...because the query carries NO `exclude` predicate. Deliberate: this is the
+    // edit-form prefill, and blanking it would invite a "new" review that the DB
+    // unique silently turns into an update of the row they cannot see.
+    const where = mockRead.appListingReview.findFirst.mock.calls[0][0].where as Record<
+      string,
+      unknown
+    >;
+    expect(where).not.toHaveProperty('exclude');
+    expect(where).not.toHaveProperty('tosViolation');
+    expect(where).toMatchObject({ appListingId: APP_ID, userId: 42 });
+  });
+
+  it('INVARIANT: listAppListingReviews DOES filter exclude — a hidden review leaves the public list', async () => {
+    mockRead.appListingReview.findMany.mockResolvedValue([]);
+
+    await listAppListingReviews({ appListingId: APP_ID, limit: 20 }, { scope: 'full' });
+
+    const where = mockRead.appListingReview.findMany.mock.calls[0][0].where as Record<
+      string,
+      unknown
+    >;
+    // `exclude: false` is what makes the mod action take effect on the visible list
+    // with no read-path change. Assert the exact value, not merely the key.
+    expect(where.exclude).toBe(false);
+    expect(where.tosViolation).toBe(false);
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing-review.mod-exclude.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-review.mod-exclude.test.ts
@@ -1,4 +1,4 @@
-import { globSync, readFileSync } from 'fs';
+import { globSync, readFileSync, statSync } from 'fs';
 import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -596,9 +596,22 @@ describe('writer-set ledger — who may move the recommend counters', () => {
    * code flags the very file whose comment promises it does not write them. Measured:
    * without this, the repo-wide scan below returned 3 files, 2 of them comment-only
    * false positives. A guard that cries wolf on its own documentation gets deleted.
+   *
+   * 🔴 LINE-ORIENTED, deliberately — the obvious non-greedy block-comment regex FAILS
+   * OPEN. An open-comment marker inside a STRING or REGEX literal starts a match that
+   * runs to the next genuine close marker, deleting every line between it — including
+   * a real write. Reproduced against a three-line fixture: the `appListingMetric`
+   * call vanished and the scan would have reported "no other writers" with total
+   * confidence. Deciding per LINE cannot run away like that. The trade is that an
+   * INLINE block comment sitting on a code line is not stripped — which fails CLOSED
+   * (a false positive a human reads), the only direction a guard may be wrong in.
+   * Both behaviours are controlled below, and the fail-open fixture is one of them.
    */
   function stripComments(src: string) {
-    return src.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+    return src
+      .split('\n')
+      .map((line) => (/^\s*(\/\/|\/\*|\*)/.test(line) ? '' : line.replace(/(^|[^:])\/\/.*$/, '$1')))
+      .join('\n');
   }
 
   const REPO_ROOT = path.resolve(__dirname, '../../../../..');
@@ -621,12 +634,20 @@ describe('writer-set ledger — who may move the recommend counters', () => {
    * is "nobody is": neither carries information. Controlled both ways below.
    */
   function writesThumbs(src: string) {
-    const prismaWrite = /appListingMetric\.(upsert|update|updateMany|create|createMany)\s*\(/.test(
-      src
-    );
+    // DELETE counts: removing a review row destroys its contribution to the counters
+    // just as surely as an increment moves them.
+    const prismaWrite =
+      /appListingMetric\.(upsert|update|updateMany|create|createMany|delete|deleteMany)\s*\(/.test(
+        src
+      );
+    // Kysely reaches the same table without ever naming the Prisma model.
+    const kyselyWrite =
+      /(insertInto|updateTable|deleteFrom)\s*\(\s*['"`]app_listing_metrics['"`]/.test(src);
     const rawWrite =
-      /(\bINSERT\s+INTO\b|\bUPDATE\s)[\s\S]{0,400}?(thumbs_up_count|thumbs_down_count)/i.test(src);
-    return prismaWrite || rawWrite;
+      /(\bINSERT\s+INTO\b|\bUPDATE\s|\bDELETE\s+FROM\b)[\s\S]{0,400}?(thumbs_up_count|thumbs_down_count)/i.test(
+        src
+      );
+    return prismaWrite || kyselyWrite || rawWrite;
   }
 
   /**
@@ -673,10 +694,18 @@ describe('writer-set ledger — who may move the recommend counters', () => {
     // NEGATIVE CONTROL — it MUST detect each shape a third writer could take.
     expect(writesThumbs('await tx.appListingMetric.upsert({ where: {} })')).toBe(true);
     expect(writesThumbs('await db.appListingMetric.updateMany({ where: {} })')).toBe(true);
+    // A DELETE is a counter write too: removing the row destroys the accumulated value.
+    expect(writesThumbs('await db.appListingMetric.deleteMany({ where: {} })')).toBe(true);
+    // Kysely reaches the table without ever naming the Prisma model.
+    expect(writesThumbs("db.updateTable('app_listing_metrics').set({}).execute()")).toBe(true);
+    expect(writesThumbs("db.deleteFrom('app_listing_metrics').execute()")).toBe(true);
     expect(
       writesThumbs('UPDATE "app_listing_metrics" SET "thumbs_up_count" = 5 WHERE id = $1')
     ).toBe(true);
     expect(writesThumbs('INSERT INTO "app_listing_metrics" ("thumbs_down_count") VALUES (1)')).toBe(
+      true
+    );
+    expect(writesThumbs('DELETE FROM "app_listing_metrics" WHERE "thumbs_up_count" = 0')).toBe(
       true
     );
 
@@ -687,6 +716,30 @@ describe('writer-set ledger — who may move the recommend counters', () => {
       writesThumbs('SELECT m."thumbs_up_count", m."updated_at" FROM app_listing_metrics m')
     ).toBe(false);
     expect(writesThumbs('const n = metric.thumbsUpCount ?? 0;')).toBe(false);
+    expect(writesThumbs("selectFrom('app_listing_metrics').select('thumbs_up_count')")).toBe(false);
+  });
+
+  it('CONTROL: the stripper cannot be walked past by an open-comment marker in a string', () => {
+    // 🔴 THE FAIL-OPEN CASE. A cross-line block-comment regex matches from the marker
+    // inside this string literal to the close marker on the last line and deletes the
+    // write between them — reporting "no other writers" while a writer sits right
+    // there. Assembled from pieces so this file can contain the fixture at all.
+    const OPEN = '/' + '*';
+    const CLOSE = '*' + '/';
+    const tricky = [
+      `const marker = '${OPEN}';`,
+      'await db.appListingMetric.upsert({ where: {} });',
+      `${OPEN} an ordinary trailing comment ${CLOSE}`,
+    ].join('\n');
+
+    expect(writesThumbs(stripComments(tricky))).toBe(true);
+
+    // And the property that motivated stripping at all still holds: PROSE describing a
+    // write is not a write.
+    expect(writesThumbs(stripComments('// await db.appListingMetric.upsert({});'))).toBe(false);
+    expect(
+      writesThumbs(stripComments([' * never writes thumbs_up_count via', ' * UPDATE'].join('\n')))
+    ).toBe(false);
   });
 
   it('the delta writer has EXACTLY the ledgered callers — fails if the set grows OR shrinks', () => {
@@ -704,11 +757,25 @@ describe('writer-set ledger — who may move the recommend counters', () => {
     // processor legitimately touches the TABLE (install_count) and is held to the
     // thumbs half of the contract by its OWN guard, so this scan targets the thumbs
     // columns and the Prisma model — not the table name.
-    const files = globSync('src/server/**/*.ts', { cwd: REPO_ROOT }).filter(
-      (f: string) => !f.includes('__tests__')
-    );
+    // Scope widened past `src/server/**`: an API route, a client-side helper or a
+    // workspace package can all reach this table. The audit enumerated the repo and
+    // found no writer outside `src/server` today, so this is closing a COVERAGE limit
+    // before it becomes a gap, not chasing a live one.
+    const files = [
+      ...globSync('src/**/*.ts', { cwd: REPO_ROOT }),
+      ...globSync('src/**/*.tsx', { cwd: REPO_ROOT }),
+      ...globSync('packages/*/src/**/*.ts', { cwd: REPO_ROOT }),
+    ]
+      .filter((f: string) => !f.includes('__tests__') && !f.includes('node_modules'))
+      // A widened glob can yield a DIRECTORY whose name ends in `.ts` (and a full-suite
+      // run can create one mid-walk), which reaches `readFileSync` as EISDIR and takes
+      // the guard down with an error that looks nothing like its subject. Same skip the
+      // repo's `no-direct-shared-module-mock` walk uses.
+      .filter((f: string) =>
+        statSync(path.join(REPO_ROOT, f), { throwIfNoEntry: false })?.isFile()
+      );
     // POSITIVE CONTROL on the walk itself.
-    expect(files.length).toBeGreaterThan(200);
+    expect(files.length).toBeGreaterThan(2000);
 
     const writers = files.filter((rel: string) => writesThumbs(stripComments(readRel(rel))));
 

--- a/src/server/services/blocks/__tests__/app-listing-review.mod-exclude.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-review.mod-exclude.test.ts
@@ -1,3 +1,5 @@
+import { globSync, readFileSync } from 'fs';
+import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -14,39 +16,61 @@ import { resetHybridNodes } from '~/__tests__/mocks/hybrid';
  * W13 — the MODERATOR hide/un-hide control for an AppListing review
  * (`AppListingReview.exclude`) and its denormalized-counter bookkeeping.
  *
- * `AppListingMetric.thumbsUp/DownCount` has NO rollup job — it is exactly the sum
- * of the ±1 deltas its writers applied. So the properties under test are not
- * "does it set a boolean" but:
+ * `AppListingMetric.thumbsUp/DownCount` is denormalized and nothing recomputes it —
+ * it is exactly the sum of the ±1 deltas its writers applied. So the properties
+ * under test are not "does it set a boolean" but:
  *   1. a hide moves EXACTLY ONE counter by EXACTLY 1, in the bucket matching the
  *      row's `recommended`, and an un-hide moves it back;
- *   2. a NO-OP transition applies a ZERO delta and writes NOTHING — the property
- *      that makes a retry / double-submit / two-moderators-on-one-report safe;
- *   3. the flag flip and the counter move happen in ONE transaction, off the
- *      PRIMARY (a replica-lag read of `exclude` would decide the delta wrongly).
+ *   2. a transition that WE did not perform — already in the target state, or a
+ *      concurrent racer got there first — applies a ZERO delta and writes nothing;
+ *   3. the flag flip and the counter move happen INSIDE one transaction, on the
+ *      PRIMARY (a replica-lag read of `exclude` would decide the delta wrongly);
+ *   4. the set of functions allowed to write those counters is fixed.
  *
  * All DB deps come from the CANONICAL `dbMock` (registered globally in
  * `src/__tests__/setup.ts`) — no real Prisma, and no per-file `vi.mock` of
- * `~/server/db/client`, which `no-direct-shared-module-mock` forbids. Its
- * `dbWrite.$transaction` default runs the callback with `dbMock.dbWrite`, so a test
- * asserts the exact writes made inside the tx; `dbRead` and `dbWrite` are DISTINCT
- * nodes, so a test can prove which client a read went to.
+ * `~/server/db/client`, which `no-direct-shared-module-mock` forbids. `dbRead` and
+ * `dbWrite` are DISTINCT nodes, so a test can prove which client a read went to.
+ *
+ * 🔴 THE TX CLIENT IS A SEPARATE SENTINEL OBJECT, not `dbMock.dbWrite`.
+ * The canonical `$transaction` default hands the callback `dbMock.dbWrite` itself,
+ * which makes `tx.x.y()` and `dbWrite.x.y()` land on the SAME spy — so a test can
+ * assert a call happened but NOT that it happened inside the transaction, and a
+ * change that moved a write out of the tx would stay green. Overriding the default
+ * to pass `txMock` gives the two paths different spies: every in-tx assertion below
+ * is against `txMock`, and `outOfTxWrites` pins that the non-transactional client
+ * was never touched.
  */
 
 const { mockBust } = vi.hoisted(() => ({ mockBust: vi.fn(async () => undefined) }));
 vi.mock('~/server/utils/cache-helpers', () => ({ bustCacheTag: mockBust }));
 
-const mockWrite = {
-  $transaction: dbMock.dbWrite.$transaction,
+/**
+ * The sentinel transaction client. Distinct identities from `dbMock.dbWrite`, so
+ * "inside the tx" is observable rather than assumed.
+ */
+const txMock = {
+  $queryRaw: vi.fn(),
   appListingReview: {
-    findUnique: dbMock.dbWrite.appListingReview.findUnique,
-    update: dbMock.dbWrite.appListingReview.update,
-    upsert: dbMock.dbWrite.appListingReview.upsert,
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    upsert: vi.fn(),
   },
-  appListingMetric: {
-    upsert: dbMock.dbWrite.appListingMetric.upsert,
-    updateMany: dbMock.dbWrite.appListingMetric.updateMany,
-  },
+  appListingMetric: { upsert: vi.fn(), updateMany: vi.fn() },
 };
+
+/** The same method names on the NON-transactional client — must stay untouched. */
+const outOfTxWrites = [
+  dbMock.dbWrite.appListingReview.findUnique,
+  dbMock.dbWrite.appListingReview.update,
+  dbMock.dbWrite.appListingReview.updateMany,
+  dbMock.dbWrite.appListingReview.upsert,
+  dbMock.dbWrite.appListingMetric.upsert,
+  dbMock.dbWrite.appListingMetric.updateMany,
+];
+
+const mockWrite = txMock;
 const mockRead = {
   appListing: { findUnique: dbMock.dbRead.appListing.findUnique },
   appListingReview: {
@@ -70,6 +94,26 @@ function reviewRow(over: Partial<{ recommended: boolean; exclude: boolean }> = {
   };
 }
 
+/**
+ * Arm the mod-hide path for a row in `before`, transitioning to `target`.
+ *
+ * The conditional UPDATE is the guard, so the DB — not the service — decides whether
+ * a transition happened. `won` models `count`: 1 = we transitioned it, 0 = it was
+ * already in the target state OR a concurrent racer beat us to it.
+ */
+function armExcludeRow(
+  before: { recommended: boolean; exclude: boolean },
+  opts: { won: boolean; observedAfter?: boolean } = { won: true }
+) {
+  txMock.appListingReview.updateMany.mockResolvedValue({ count: opts.won ? 1 : 0 });
+  txMock.appListingReview.findUnique.mockResolvedValue(
+    reviewRow({
+      recommended: before.recommended,
+      exclude: opts.observedAfter ?? (opts.won ? !before.exclude : before.exclude),
+    })
+  );
+}
+
 beforeEach(() => {
   // 🔴 A full RESET, not `mockClear`. `mockClear` leaves the `mockResolvedValueOnce`
   // QUEUE intact, so a test that throws before consuming its queued values leaks them
@@ -78,15 +122,27 @@ beforeEach(() => {
   // measuring this file against the base branch.) `resetSharedMocks()` runs per FILE,
   // not per test, so the per-test reset has to be explicit — `resetHybridNodes()` clears
   // every canonical node's implementation AND call history and re-applies its registered
-  // default, which is what restores the `$transaction` callback runner below.
+  // default, which the override below then replaces.
   resetHybridNodes();
+  for (const spy of Object.values(txMock)) {
+    if (typeof spy === 'function') spy.mockReset();
+    else for (const inner of Object.values(spy)) inner.mockReset();
+  }
   mockBust.mockReset();
   mockBust.mockResolvedValue(undefined);
-  mockWrite.appListingReview.findUnique.mockResolvedValue(reviewRow());
-  mockWrite.appListingReview.update.mockResolvedValue({});
-  mockWrite.appListingReview.upsert.mockResolvedValue({});
-  mockWrite.appListingMetric.upsert.mockResolvedValue({});
-  mockWrite.appListingMetric.updateMany.mockResolvedValue({ count: 0 });
+
+  // Hand the callback the SENTINEL client, not `dbMock.dbWrite`.
+  dbMock.dbWrite.$transaction.mockImplementation(async (cb: unknown) =>
+    typeof cb === 'function' ? (cb as (tx: unknown) => unknown)(txMock) : undefined
+  );
+
+  txMock.$queryRaw.mockResolvedValue([]);
+  txMock.appListingReview.findUnique.mockResolvedValue(reviewRow());
+  txMock.appListingReview.update.mockResolvedValue({});
+  txMock.appListingReview.updateMany.mockResolvedValue({ count: 1 });
+  txMock.appListingReview.upsert.mockResolvedValue({});
+  txMock.appListingMetric.upsert.mockResolvedValue({});
+  txMock.appListingMetric.updateMany.mockResolvedValue({ count: 0 });
 });
 
 function metricUpdateArgs() {
@@ -168,17 +224,20 @@ describe('recommendMetricDelta — the one delta rule, both writers share it', (
 // ---------------------------------------------------------------------------
 describe('setAppListingReviewExclude — hiding (false → true)', () => {
   it('a RECOMMENDED review: sets exclude and decrements thumbsUp by exactly 1', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValue(
-      reviewRow({ recommended: true, exclude: false })
-    );
+    armExcludeRow({ recommended: true, exclude: false }, { won: true });
 
     const res = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
 
     expect(res).toEqual({ id: REVIEW_ID, appListingId: APP_ID, exclude: true, changed: true });
-    expect(mockWrite.appListingReview.update).toHaveBeenCalledWith({
-      where: { id: REVIEW_ID },
+    // 🔴 The transition is the UPDATE's own predicate — `exclude: { not: target }` is
+    // what makes the DB, not this process, decide who transitioned the row. A plain
+    // `update({ where: { id } })` would re-open the read-then-branch race.
+    expect(mockWrite.appListingReview.updateMany).toHaveBeenCalledWith({
+      where: { id: REVIEW_ID, exclude: { not: true } },
       data: { exclude: true },
     });
+    // An unconditional update must NOT be how this is done.
+    expect(mockWrite.appListingReview.update).not.toHaveBeenCalled();
 
     const m = metricUpdateArgs();
     expect(m.where).toEqual({ appListingId: APP_ID });
@@ -195,9 +254,7 @@ describe('setAppListingReviewExclude — hiding (false → true)', () => {
   });
 
   it('a NOT-RECOMMENDED review: decrements thumbsDown by exactly 1 (the other counter)', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValue(
-      reviewRow({ recommended: false, exclude: false })
-    );
+    armExcludeRow({ recommended: false, exclude: false }, { won: true });
 
     await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
 
@@ -217,17 +274,16 @@ describe('setAppListingReviewExclude — hiding (false → true)', () => {
 // ---------------------------------------------------------------------------
 describe('setAppListingReviewExclude — un-hiding (true → false)', () => {
   it('a RECOMMENDED review: clears exclude and re-increments thumbsUp by exactly 1', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValue(
-      reviewRow({ recommended: true, exclude: true })
-    );
+    armExcludeRow({ recommended: true, exclude: true }, { won: true });
 
     const res = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: false });
 
     expect(res).toEqual({ id: REVIEW_ID, appListingId: APP_ID, exclude: false, changed: true });
-    expect(mockWrite.appListingReview.update).toHaveBeenCalledWith({
-      where: { id: REVIEW_ID },
+    expect(mockWrite.appListingReview.updateMany).toHaveBeenCalledWith({
+      where: { id: REVIEW_ID, exclude: { not: false } },
       data: { exclude: false },
     });
+    expect(mockWrite.appListingReview.update).not.toHaveBeenCalled();
 
     const m = metricUpdateArgs();
     expect(m.update).toEqual({ thumbsUpCount: { increment: 1 } });
@@ -237,9 +293,7 @@ describe('setAppListingReviewExclude — un-hiding (true → false)', () => {
   });
 
   it('a NOT-RECOMMENDED review: re-increments thumbsDown by exactly 1', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValue(
-      reviewRow({ recommended: false, exclude: true })
-    );
+    armExcludeRow({ recommended: false, exclude: true }, { won: true });
 
     await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: false });
 
@@ -251,14 +305,11 @@ describe('setAppListingReviewExclude — un-hiding (true → false)', () => {
 
   it('hide-then-unhide of the same row returns the counter to where it started (round trip)', async () => {
     // Two calls against the row's two states; the deltas must sum to zero on the
-    // bucket that moved, and never touch the other bucket.
-    mockWrite.appListingReview.findUnique.mockResolvedValueOnce(
-      reviewRow({ recommended: true, exclude: false })
-    );
+    // bucket that moved, and never touch the other bucket. Both WIN their conditional
+    // update (they are genuinely opposite transitions), so both apply a delta.
+    armExcludeRow({ recommended: true, exclude: false }, { won: true });
     await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
-    mockWrite.appListingReview.findUnique.mockResolvedValueOnce(
-      reviewRow({ recommended: true, exclude: true })
-    );
+    armExcludeRow({ recommended: true, exclude: true }, { won: true });
     await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: false });
 
     const calls = mockWrite.appListingMetric.upsert.mock.calls.map(
@@ -277,49 +328,98 @@ describe('setAppListingReviewExclude — un-hiding (true → false)', () => {
 // IDEMPOTENCE — the case most likely to be wrong, and what makes a re-run safe.
 // ---------------------------------------------------------------------------
 describe('setAppListingReviewExclude — a NO-OP transition applies ZERO delta', () => {
-  it('hiding an ALREADY-hidden review writes nothing at all (no row update, no counter, no bust)', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValue(
-      reviewRow({ recommended: true, exclude: true })
-    );
+  it('hiding an ALREADY-hidden review writes no counter and busts no cache', async () => {
+    armExcludeRow({ recommended: true, exclude: true }, { won: false });
 
     const res = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
 
     expect(res).toEqual({ id: REVIEW_ID, appListingId: APP_ID, exclude: true, changed: false });
-    expect(mockWrite.appListingReview.update).not.toHaveBeenCalled();
     expect(mockWrite.appListingMetric.upsert).not.toHaveBeenCalled();
     expect(mockWrite.appListingMetric.updateMany).not.toHaveBeenCalled();
     expect(mockBust).not.toHaveBeenCalled();
   });
 
-  it('un-hiding an already-VISIBLE review writes nothing at all', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValue(
-      reviewRow({ recommended: false, exclude: false })
-    );
+  it('un-hiding an already-VISIBLE review writes no counter and busts no cache', async () => {
+    armExcludeRow({ recommended: false, exclude: false }, { won: false });
 
     const res = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: false });
 
     expect(res).toMatchObject({ exclude: false, changed: false });
-    expect(mockWrite.appListingReview.update).not.toHaveBeenCalled();
     expect(mockWrite.appListingMetric.upsert).not.toHaveBeenCalled();
     expect(mockWrite.appListingMetric.updateMany).not.toHaveBeenCalled();
     expect(mockBust).not.toHaveBeenCalled();
   });
 
-  it('hiding TWICE moves the counter exactly ONCE (a retry cannot double-count)', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValueOnce(
-      reviewRow({ recommended: true, exclude: false })
-    );
+  it('hiding TWICE moves the counter exactly ONCE (a SEQUENTIAL retry cannot double-count)', async () => {
+    armExcludeRow({ recommended: true, exclude: false }, { won: true });
     const first = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
-    // Second call sees the row in its NEW state — the realistic retry.
-    mockWrite.appListingReview.findUnique.mockResolvedValueOnce(
-      reviewRow({ recommended: true, exclude: true })
-    );
+    // Second call: the row is already hidden, so its conditional update matches nothing.
+    armExcludeRow({ recommended: true, exclude: true }, { won: false });
     const second = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
 
     expect(first.changed).toBe(true);
     expect(second.changed).toBe(false);
     expect(mockWrite.appListingMetric.upsert).toHaveBeenCalledTimes(1);
-    expect(mockWrite.appListingReview.update).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CONCURRENCY — the case the sequential retry above CANNOT see.
+//
+// 🔴 `$transaction` here is Postgres READ COMMITTED (nothing in src/server sets an
+// `isolationLevel`), which does not serialize a read against a concurrent committer.
+// Under a read-then-branch guard, two moderators hiding the same review both read
+// `exclude=false`, both pass the guard, and both apply −1 — permanent drift, masked
+// by the ≥0 clamp only at zero. The sequential test above models the SECOND call
+// seeing the FIRST's committed result, which is exactly the interleaving that does
+// not happen in the race, so it is structurally blind to this.
+//
+// The fix is that the transition is the UPDATE's own predicate: the loser gets
+// `count === 0` and must apply NOTHING. These tests drive that branch directly.
+// ---------------------------------------------------------------------------
+describe('setAppListingReviewExclude — losing a concurrent race applies ZERO delta', () => {
+  it('LOSER: the row read back is already hidden but our conditional matched 0 rows → no delta', async () => {
+    // The pre-state was `exclude:false` — a read-then-branch guard would have seen
+    // that and applied −1. We lost the race, so the counter must not move.
+    armExcludeRow({ recommended: true, exclude: false }, { won: false, observedAfter: true });
+
+    const res = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
+
+    expect(res.changed).toBe(false);
+    // Reports the OBSERVED state, not the requested target — the winner's write stands.
+    expect(res.exclude).toBe(true);
+    expect(mockWrite.appListingMetric.upsert).not.toHaveBeenCalled();
+    expect(mockWrite.appListingMetric.updateMany).not.toHaveBeenCalled();
+    expect(mockBust).not.toHaveBeenCalled();
+  });
+
+  it('two racing hides of the same review move the counter exactly ONCE in total', async () => {
+    // Both callers start from `exclude:false`. Exactly one conditional update matches.
+    armExcludeRow({ recommended: true, exclude: false }, { won: true });
+    const winner = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
+    armExcludeRow({ recommended: true, exclude: false }, { won: false, observedAfter: true });
+    const loser = await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
+
+    expect([winner.changed, loser.changed]).toEqual([true, false]);
+    // ONE −1, not two. This is the assertion the whole conditional-update shape exists for.
+    const increments = mockWrite.appListingMetric.upsert.mock.calls.map(
+      (c) => (c[0] as { update: { thumbsUpCount?: { increment: number } } }).update.thumbsUpCount
+    );
+    expect(increments).toEqual([{ increment: -1 }]);
+  });
+
+  it('reads `recommended` AFTER taking the row lock, so a racing edit cannot misdirect the delta', async () => {
+    armExcludeRow({ recommended: true, exclude: false }, { won: true });
+
+    await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
+
+    // ORDER IS THE GUARD: the conditional update takes the row lock, and only then is
+    // `recommended` read. Reading first would let a concurrent author flip land between
+    // the two and send the −1 to the wrong bucket. Pinned so a "tidy-up" that hoists the
+    // read back above the update fails here rather than in production.
+    const updateOrder = mockWrite.appListingReview.updateMany.mock.invocationCallOrder[0];
+    const readOrder = mockWrite.appListingReview.findUnique.mock.invocationCallOrder[0];
+    expect(updateOrder).toBeLessThan(readOrder);
   });
 });
 
@@ -327,16 +427,21 @@ describe('setAppListingReviewExclude — a NO-OP transition applies ZERO delta',
 // Atomicity + not-found.
 // ---------------------------------------------------------------------------
 describe('setAppListingReviewExclude — transaction + lookup', () => {
-  it('reads the row and writes BOTH the flag and the counter inside ONE transaction, on the PRIMARY', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValue(
-      reviewRow({ recommended: true, exclude: false })
-    );
+  it('makes EVERY write through the transaction client, never the plain dbWrite', async () => {
+    armExcludeRow({ recommended: true, exclude: false }, { won: true });
 
     await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
 
-    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
-    // The `exclude` read decides the delta, so it must NOT come off the replica —
-    // a lagging read would recompute a delta that was already applied.
+    expect(dbMock.dbWrite.$transaction).toHaveBeenCalledTimes(1);
+    // 🔴 THIS is what makes the name of the test true. `$transaction` was called is a
+    // claim about one line; that the flag flip and the counter move BOTH landed on the
+    // sentinel `tx` handle — and that the non-transactional client saw NOTHING — is the
+    // claim that a change moving either write outside the tx would break.
+    expect(mockWrite.appListingReview.updateMany).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingMetric.upsert).toHaveBeenCalledTimes(1);
+    for (const spy of outOfTxWrites) expect(spy).not.toHaveBeenCalled();
+    // And the delta-deciding read must NOT come off the replica — a lagging read would
+    // recompute a delta that was already applied.
     expect(mockRead.appListingReview.findUnique).not.toHaveBeenCalled();
     expect(mockRead.appListingReview.findFirst).not.toHaveBeenCalled();
     expect(mockWrite.appListingReview.findUnique).toHaveBeenCalledWith({
@@ -345,22 +450,20 @@ describe('setAppListingReviewExclude — transaction + lookup', () => {
     });
   });
 
-  it('a missing review → NOT_FOUND, with no row or counter write', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValue(null);
+  it('a missing review → NOT_FOUND, with no counter write', async () => {
+    txMock.appListingReview.updateMany.mockResolvedValue({ count: 0 });
+    txMock.appListingReview.findUnique.mockResolvedValue(null);
 
     await expect(
       setAppListingReviewExclude({ reviewId: 12345, exclude: true })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
 
-    expect(mockWrite.appListingReview.update).not.toHaveBeenCalled();
     expect(mockWrite.appListingMetric.upsert).not.toHaveBeenCalled();
     expect(mockBust).not.toHaveBeenCalled();
   });
 
   it('a real transition busts the store-wide recommend-mean cache', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValue(
-      reviewRow({ recommended: true, exclude: false })
-    );
+    armExcludeRow({ recommended: true, exclude: false }, { won: true });
     await setAppListingReviewExclude({ reviewId: REVIEW_ID, exclude: true });
     expect(mockBust).toHaveBeenCalledWith(['app-listing:recommend-global-mean']);
   });
@@ -386,11 +489,9 @@ describe('seam — the user write path still routes through the shared rule', ()
       userId: 99,
       status: 'approved',
     });
-    mockWrite.appListingReview.findUnique.mockResolvedValue({
-      id: REVIEW_ID,
-      recommended: true,
-      exclude: true,
-    });
+    // The prior review is read with `SELECT … FOR UPDATE` (raw, because Prisma has no
+    // row lock on `findUnique`), so it arrives as an array of rows.
+    txMock.$queryRaw.mockResolvedValue([{ id: REVIEW_ID, recommended: true, exclude: true }]);
     mockWrite.appListingReview.upsert.mockResolvedValue({
       id: REVIEW_ID,
       appListingId: APP_ID,
@@ -460,5 +561,161 @@ describe('read-path invariants the mod control depends on', () => {
     // with no read-path change. Assert the exact value, not merely the key.
     expect(where.exclude).toBe(false);
     expect(where.tosViolation).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WRITER-SET LEDGER — the seam the whole delta design rests on.
+//
+// 🔴 `thumbsUpCount`/`thumbsDownCount` have NO recompute: the stored value is the
+// sum of the ±1 deltas its writers applied, so a THIRD writer that does not share
+// this file's `countedContribution` rule silently desynchronises the counter from
+// the rows, and no test above would notice — every one of them verifies a single
+// writer in isolation.
+//
+// The prose said "a future job MUST NOT become a third" and nothing enforced it.
+// This does, and it fails in BOTH directions: the assertion is an EQUALITY against
+// the ledger, so removing a writer (a refactor that quietly stops feeding the
+// metric) is as red as adding one.
+//
+// This is one half of a TWO-SIDED contract. The other half — that the metric
+// processor `src/server/metrics/appListing.metrics.sql.ts` never names the thumbs
+// columns — is pinned in `src/server/metrics/__tests__/appListing.metrics.test.ts`
+// ("NEVER writes thumbs_up_count / thumbs_down_count"). Neither guard alone is
+// enough; each names the other so the pair stays discoverable.
+// ---------------------------------------------------------------------------
+describe('writer-set ledger — who may move the recommend counters', () => {
+  const SERVICE_REL = 'src/server/services/blocks/app-listing-review.service.ts';
+
+  /** The ONLY functions permitted to apply a recommend-counter delta. */
+  const LEDGER = ['setAppListingReviewExclude', 'upsertAppListingReview'];
+
+  /**
+   * 🔴 Strip comments before scanning. Both files in `src/server/metrics/` DESCRIBE
+   * the thumbs columns in a prose ownership note — and a scanner that reads prose as
+   * code flags the very file whose comment promises it does not write them. Measured:
+   * without this, the repo-wide scan below returned 3 files, 2 of them comment-only
+   * false positives. A guard that cries wolf on its own documentation gets deleted.
+   */
+  function stripComments(src: string) {
+    return src.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+  }
+
+  const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+
+  function readRel(rel: string) {
+    return readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+  }
+
+  function serviceSource() {
+    return stripComments(readRel(SERVICE_REL));
+  }
+
+  /**
+   * Does this (comment-stripped) source WRITE the recommend counters?
+   *
+   * 🔴 `\bUPDATE\s`, not `UPDATE`. The bare form matches the `update` inside
+   * `updated_at`, which appears in every metrics SELECT — so the first version of
+   * this flagged `app-listing.service.ts`, a file that only READS the rollup. A
+   * scanner whose verdict is "everyone is a writer" is the same as one whose verdict
+   * is "nobody is": neither carries information. Controlled both ways below.
+   */
+  function writesThumbs(src: string) {
+    const prismaWrite = /appListingMetric\.(upsert|update|updateMany|create|createMany)\s*\(/.test(
+      src
+    );
+    const rawWrite =
+      /(\bINSERT\s+INTO\b|\bUPDATE\s)[\s\S]{0,400}?(thumbs_up_count|thumbs_down_count)/i.test(src);
+    return prismaWrite || rawWrite;
+  }
+
+  /**
+   * Every CALL of `applyRecommendMetricDelta`, attributed to the nearest preceding
+   * `function <name>` — which is the enclosing top-level function, because the
+   * callbacks in between are anonymous arrows.
+   */
+  function deltaCallers(src: string) {
+    const lines = src.split('\n');
+    const callers: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      // A call, not the declaration itself and not a mention inside a comment.
+      if (!/(?<![\w.])applyRecommendMetricDelta\s*\(/.test(lines[i])) continue;
+      if (/^\s*(\*|\/\/)/.test(lines[i])) continue;
+      if (/function\s+applyRecommendMetricDelta/.test(lines[i])) continue;
+      for (let j = i; j >= 0; j--) {
+        const m = /function\s+([A-Za-z0-9_$]+)\s*\(/.exec(lines[j]);
+        if (m && m[1] !== 'applyRecommendMetricDelta') {
+          callers.push(m[1]);
+          break;
+        }
+      }
+    }
+    return callers;
+  }
+
+  it('POSITIVE CONTROL: the scan finds the service, its call sites, and its real writes', () => {
+    // Without this, a broken path or a renamed helper makes every claim below
+    // vacuously true — an empty set trivially equals an empty set.
+    const src = serviceSource();
+    expect(src).toContain('applyRecommendMetricDelta');
+    expect(deltaCallers(src).length).toBeGreaterThan(0);
+    // NEGATIVE CONTROL on the comment stripper: it must remove PROSE without eating
+    // the CODE the repo-wide scan below is looking for. If this line ever fails, the
+    // scan's "no other writers" verdict is worthless — it would be finding nothing
+    // anywhere, including here.
+    expect(src).toContain('appListingMetric.upsert(');
+    expect(stripComments('// appListingMetric.upsert( in a comment\nconst a = 1;')).not.toContain(
+      'appListingMetric'
+    );
+  });
+
+  it('CONTROLS: the writer predicate goes red on a real write and stays quiet on a read', () => {
+    // NEGATIVE CONTROL — it MUST detect each shape a third writer could take.
+    expect(writesThumbs('await tx.appListingMetric.upsert({ where: {} })')).toBe(true);
+    expect(writesThumbs('await db.appListingMetric.updateMany({ where: {} })')).toBe(true);
+    expect(
+      writesThumbs('UPDATE "app_listing_metrics" SET "thumbs_up_count" = 5 WHERE id = $1')
+    ).toBe(true);
+    expect(writesThumbs('INSERT INTO "app_listing_metrics" ("thumbs_down_count") VALUES (1)')).toBe(
+      true
+    );
+
+    // POSITIVE CONTROL that it is not simply always-true — a pure READ of the same
+    // columns is not a write, and neither is the `updated_at` that appears beside them
+    // in every metrics SELECT (the exact false positive this predicate had at first).
+    expect(
+      writesThumbs('SELECT m."thumbs_up_count", m."updated_at" FROM app_listing_metrics m')
+    ).toBe(false);
+    expect(writesThumbs('const n = metric.thumbsUpCount ?? 0;')).toBe(false);
+  });
+
+  it('the delta writer has EXACTLY the ledgered callers — fails if the set grows OR shrinks', () => {
+    const callers = [...new Set(deltaCallers(serviceSource()))].sort();
+    expect(
+      callers,
+      'A third writer of thumbsUp/DownCount desynchronises a counter nothing recomputes. ' +
+        'Add one only together with a full recompute — and update this ledger deliberately.'
+    ).toEqual(LEDGER);
+  });
+
+  it('no OTHER module writes the thumbs counters on appListingMetric', () => {
+    // The counters are addressed as `appListingMetric.<method>` through Prisma, or as
+    // the raw `thumbs_up_count` / `thumbs_down_count` columns in SQL. The metric
+    // processor legitimately touches the TABLE (install_count) and is held to the
+    // thumbs half of the contract by its OWN guard, so this scan targets the thumbs
+    // columns and the Prisma model — not the table name.
+    const files = globSync('src/server/**/*.ts', { cwd: REPO_ROOT }).filter(
+      (f: string) => !f.includes('__tests__')
+    );
+    // POSITIVE CONTROL on the walk itself.
+    expect(files.length).toBeGreaterThan(200);
+
+    const writers = files.filter((rel: string) => writesThumbs(stripComments(readRel(rel))));
+
+    expect(
+      writers.map((f: string) => f.replace(/\\/g, '/')).sort(),
+      'Only the review service may write the recommend counters — see the two-sided ' +
+        'contract at the top of app-listing-review.service.ts.'
+    ).toEqual([SERVICE_REL]);
   });
 });

--- a/src/server/services/blocks/__tests__/app-listing-review.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-review.service.test.ts
@@ -204,6 +204,73 @@ describe('upsertAppListingReview — editing an existing review', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// THE PRIOR READ IS A LOCKED READ — asserted on the SQL TEXT.
+//
+// 🔴 Every other test in this file mocks `$queryRaw` away, which means the SQL
+// STRING is never asserted and never executed: measured, three mutations on that
+// template all SURVIVED the full 21k-test suite —
+//   • deleting `FOR UPDATE`  → silently reverts the race fix this commit exists for
+//   • `app_listing_reviews` → `app_listing_review` → a hard runtime failure, zero CI signal
+//   • dropping `"exclude"` from the SELECT → `prior.exclude` is `undefined`, so a
+//     mod-hidden review starts counting again and the delta is wrong
+// None of them touch a mocked RESULT, so no behavioural assertion can see them. The
+// conditional-update half of this fix has four kills plus an ordering pin; this half
+// had none. Asserting the tagged template's static strings closes it with no DB.
+//
+// `$queryRaw` is called as a tagged template, so `calls[0][0]` is the
+// TemplateStringsArray (the static text) and the rest are the BOUND values.
+// ---------------------------------------------------------------------------
+describe('upsertAppListingReview — the prior read is a LOCKED read (SQL text)', () => {
+  function priorReadCall() {
+    expect(mockWrite.$queryRaw).toHaveBeenCalledTimes(1);
+    const call = mockWrite.$queryRaw.mock.calls[0] as [string[], ...unknown[]];
+    return { sql: call[0].join('?'), values: call.slice(1) };
+  }
+
+  beforeEach(async () => {
+    await upsertAppListingReview({
+      userId: CALLER,
+      input: { appListingId: APP_ID, recommended: true },
+      scope: 'full',
+    });
+  });
+
+  it('POSITIVE CONTROL: the assertion is reading real SQL, not an empty string', () => {
+    const { sql } = priorReadCall();
+    // Without this, every `toContain` below is a claim about `''` and passes only
+    // because nothing was there to contradict it.
+    expect(sql.length).toBeGreaterThan(40);
+    expect(sql).toMatch(/\bSELECT\b/);
+  });
+
+  it('takes a ROW LOCK — the clause whose deletion silently reverts the fix', () => {
+    expect(priorReadCall().sql).toMatch(/\bFOR\s+UPDATE\b/);
+  });
+
+  it('reads the right TABLE, quoted', () => {
+    expect(priorReadCall().sql).toContain('"app_listing_reviews"');
+  });
+
+  it('selects every column the delta needs — `exclude` above all', () => {
+    const { sql } = priorReadCall();
+    // `exclude` is the one that fails QUIETLY: dropped, `prior.exclude` is undefined,
+    // `countedContribution` reads it as falsy, and a mod-hidden review re-enters the
+    // aggregate on its author's next edit.
+    for (const col of ['"id"', '"recommended"', '"exclude"']) expect(sql).toContain(col);
+    expect(sql).toContain('"app_listing_id"');
+    expect(sql).toContain('"user_id"');
+  });
+
+  it('passes the lookup keys as BOUND parameters, never interpolated text', () => {
+    const { sql, values } = priorReadCall();
+    expect(values).toEqual([APP_ID, CALLER]);
+    // The ids must not appear in the static half — that would mean string-built SQL.
+    expect(sql).not.toContain(APP_ID);
+    expect(sql).not.toContain(String(CALLER));
+  });
+});
+
 describe('upsertAppListingReview — eligibility + input gates', () => {
   it('self-review is rejected (owner) with no write', async () => {
     mockRead.appListing.findUnique.mockResolvedValue({

--- a/src/server/services/blocks/__tests__/app-listing-review.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-review.service.test.ts
@@ -22,6 +22,10 @@ import { LISTING_REVIEW_DETAILS_MAX } from '~/server/schema/blocks/app-listing-r
 
 type WriteMock = {
   $transaction: ReturnType<typeof vi.fn>;
+  // The prior review is read with `SELECT … FOR UPDATE` (raw — Prisma has no row lock
+  // on `findUnique`), so the delta cannot be computed against a stale `exclude` that a
+  // concurrent moderator hide has already changed. It returns ROWS, not a row.
+  $queryRaw: ReturnType<typeof vi.fn>;
   appListingReview: { findUnique: ReturnType<typeof vi.fn>; upsert: ReturnType<typeof vi.fn> };
   appListingMetric: { upsert: ReturnType<typeof vi.fn>; updateMany: ReturnType<typeof vi.fn> };
 };
@@ -49,6 +53,7 @@ const SAVED_REVIEW = {
 const { mockRead, mockWrite } = vi.hoisted(() => {
   const write: WriteMock = {
     $transaction: vi.fn(),
+    $queryRaw: vi.fn(async () => []),
     appListingReview: {
       findUnique: vi.fn(async () => null),
       upsert: vi.fn(async () => SAVED_REVIEW),
@@ -89,6 +94,7 @@ beforeEach(() => {
   mockWrite.$transaction.mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) =>
     cb(mockWrite)
   );
+  mockWrite.$queryRaw.mockResolvedValue([]);
   mockWrite.appListingReview.findUnique.mockResolvedValue(null);
   mockWrite.appListingReview.upsert.mockResolvedValue(SAVED_REVIEW);
   mockWrite.appListingMetric.upsert.mockResolvedValue({});
@@ -153,11 +159,7 @@ describe('upsertAppListingReview — new review (no prior)', () => {
 
 describe('upsertAppListingReview — editing an existing review', () => {
   it('details-only edit (same recommend) does NOT touch the metric (no double-count)', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValue({
-      id: 7,
-      recommended: true,
-      exclude: false,
-    });
+    mockWrite.$queryRaw.mockResolvedValue([{ id: 7, recommended: true, exclude: false }]);
     const res = await upsertAppListingReview({
       userId: CALLER,
       input: { appListingId: APP_ID, recommended: true, details: 'nice app' },
@@ -170,11 +172,7 @@ describe('upsertAppListingReview — editing an existing review', () => {
   });
 
   it('flipping recommend true→false moves the count (−1 up, +1 down) and clamps up ≥0', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValue({
-      id: 7,
-      recommended: true,
-      exclude: false,
-    });
+    mockWrite.$queryRaw.mockResolvedValue([{ id: 7, recommended: true, exclude: false }]);
     await upsertAppListingReview({
       userId: CALLER,
       input: { appListingId: APP_ID, recommended: false },
@@ -195,11 +193,7 @@ describe('upsertAppListingReview — editing an existing review', () => {
   });
 
   it('a mod-EXCLUDED prior review is treated as un-counted → editing it makes no delta', async () => {
-    mockWrite.appListingReview.findUnique.mockResolvedValue({
-      id: 7,
-      recommended: true,
-      exclude: true,
-    });
+    mockWrite.$queryRaw.mockResolvedValue([{ id: 7, recommended: true, exclude: true }]);
     await upsertAppListingReview({
       userId: CALLER,
       input: { appListingId: APP_ID, recommended: false },

--- a/src/server/services/blocks/app-listing-review.service.ts
+++ b/src/server/services/blocks/app-listing-review.service.ts
@@ -344,21 +344,37 @@ export async function upsertAppListingReview(opts: {
   const review = await dbWrite.$transaction(async (tx) => {
     // Read the prior review (if any) to compute the metric delta — LOCKED.
     //
-    // 🔴 `SELECT … FOR UPDATE`, not `findUnique`. A concurrent first-review by the
-    // SAME user is impossible (they are one user), which is why this used to be an
-    // unlocked read — but that reasoning only covered the OTHER instance of this
-    // path. It does not cover the OTHER WRITER: under READ COMMITTED a moderator's
-    // `setAppListingReviewExclude` committing between this read and the upsert below
-    // makes the delta be computed against an `exclude` value that is already stale,
-    // so the author's ±1 lands on a row that is no longer counted. Taking the row
-    // lock here forces the two writers into a serial order on this row.
+    // 🔴 `SELECT … FOR UPDATE`, not `findUnique`, because of the OTHER WRITER: under
+    // READ COMMITTED a moderator's `setAppListingReviewExclude` committing between
+    // this read and the upsert below would make the delta be computed against an
+    // `exclude` value that is already stale, so the author's ±1 would land on a row
+    // that is no longer counted. Taking the row lock forces the two writers into a
+    // serial order on this row.
+    //
+    // 🟡 THIS SERIALIZES THE UPDATE PATH ONLY — say so plainly, because the obvious
+    // reading ("the row is locked, so this is safe") is wrong on the create branch.
+    // `FOR UPDATE` locks NOTHING when the row does not exist. Two in-flight FIRST
+    // reviews from one user (double-submit, a retry, two tabs) therefore both read
+    // `prior = null` and both compute +1; the DB unique lets exactly one INSERT win,
+    // and the loser either resolves into an update — applying a second +1, a
+    // permanent over-count the ≥0 clamp cannot mask, since it errs high — or fails
+    // the constraint and 500s. That is the same class as the mod-hide race, on the
+    // branch a row lock cannot reach. It is PRE-EXISTING and deliberately NOT fixed
+    // here: closing it means an advisory lock (or an INSERT … ON CONFLICT that
+    // returns the pre-image), i.e. a behavioural change to the author write path.
+    // The wholesale recompute in #4320 retires this drift class along with the
+    // others, which is the better trade than narrowing it twice.
     //
     // Prisma has no `FOR UPDATE` on `findUnique`, hence raw SQL. Identifiers are
     // quoted because `exclude` is a SQL keyword; values are interpolated by the
-    // tagged template, so they are bound parameters, not string-concatenated.
+    // tagged template, so they are bound parameters, not string-concatenated. The
+    // template's TEXT is asserted by test — mocked-away SQL is otherwise invisible to
+    // CI, and dropping `FOR UPDATE` or a selected column reverts this fix silently.
     //
     // LOCK ORDER — review row, then metric row — is the same in BOTH writers, which
-    // is what keeps them deadlock-free against each other.
+    // is what keeps them deadlock-free against each other. Both transactions run on
+    // Prisma's default 5000 ms interactive budget, and these lock waits sit inside
+    // it: under real contention this surfaces as a P2028 timeout rather than a queue.
     const priorRows = await tx.$queryRaw<
       Array<{ id: number; recommended: boolean; exclude: boolean }>
     >`

--- a/src/server/services/blocks/app-listing-review.service.ts
+++ b/src/server/services/blocks/app-listing-review.service.ts
@@ -1,3 +1,5 @@
+import type { Prisma } from '@prisma/client';
+
 import { dbRead, dbWrite } from '~/server/db/client';
 import type { StoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import {
@@ -10,6 +12,7 @@ import {
   type AppListingReviewListItem,
   type ListAppListingReviewsInput,
   type MyAppListingReview,
+  type SetAppListingReviewExcludeInput,
   type UpsertAppListingReviewInput,
 } from '~/server/schema/blocks/app-listing-review.schema';
 import { bustCacheTag } from '~/server/utils/cache-helpers';
@@ -39,6 +42,12 @@ import {
  * card/detail goes live the instant a review lands. The metric row is CREATED
  * (zeros) if absent — most listings have no row today (no writer before this).
  *
+ * MODERATOR CONTROL: `setAppListingReviewExclude` sets the `exclude` flag the table
+ * has always carried and moves the same counters by the same shared delta rule — a
+ * SOFT HIDE, never a delete (a delete would strand the denormalized counters and
+ * re-open the once-per-(user, listing) first-review window; see that function's
+ * header). It is `moderatorProcedure`-gated at the router.
+ *
  * DARK: all surfaces are gated at the router (the mod-segmented App Blocks flag);
  * this service does no auth of its own beyond the owner / approved-state gates.
  */
@@ -61,6 +70,119 @@ async function bustRecommendMeanCache(): Promise<void> {
 /** The compound-unique lookup key for `AppListingReview(appListingId, userId)`. */
 function reviewKey(appListingId: string, userId: number) {
   return { appListingId_userId: { appListingId, userId } };
+}
+
+// ---------------------------------------------------------------------------
+// The ONE recommend-aggregate delta rule, and the ONE write that applies it.
+//
+// `AppListingMetric.thumbsUp/DownCount` is DENORMALIZED and has no rollup job —
+// it is whatever the sum of the ±1 deltas its writers have applied says it is.
+// So every writer MUST agree on (a) which review rows count and (b) how a
+// transition maps to a delta. There are now TWO writers (`upsertAppListingReview`
+// and `setAppListingReviewExclude`) and a second copy of this arithmetic is how
+// the counter silently drifts from the rows — so it is written once, here, and
+// both call it.
+// ---------------------------------------------------------------------------
+
+/** A review's CONTRIBUTION to the recommend aggregate; `null` = contributes nothing. */
+type CountedReview = { recommended: boolean } | null;
+
+/** The per-bucket adjustment to apply to `AppListingMetric`. */
+type RecommendMetricDelta = { upDelta: number; downDelta: number };
+
+/**
+ * Does this review row feed the recommend aggregate, and into which bucket?
+ *
+ * 🔴 `exclude` ONLY — deliberately NOT `tosViolation`, even though
+ * {@link listAppListingReviews} hides both. The counters have never tracked
+ * `tosViolation` (nothing writes it today), so folding it in here would make the
+ * live counters disagree with the rows they were accumulated from, with no
+ * recount job to repair the difference. If a `tosViolation` writer ever lands it
+ * must come with a recount, and this predicate is the single place to widen.
+ */
+function countedContribution(
+  row: { recommended: boolean; exclude: boolean } | null | undefined
+): CountedReview {
+  if (row == null || row.exclude) return null;
+  return { recommended: row.recommended };
+}
+
+/**
+ * The delta a single review's transition applies to the recommend counters.
+ *
+ * Exported for direct unit test: it is a pure function of the BEFORE and AFTER
+ * contributions, so every transition either writer can produce — create, edit,
+ * recommend flip, mod hide, mod unhide, and every no-op — is one call here.
+ *
+ * IDEMPOTENCE falls out of the shape rather than being bolted on: identical
+ * `prior` and `next` contributions cancel to `{0,0}`, so a repeated hide (or a
+ * details-only edit) is a zero-delta no-op by construction.
+ */
+export function recommendMetricDelta(
+  prior: CountedReview,
+  next: CountedReview
+): RecommendMetricDelta {
+  let upDelta = 0;
+  let downDelta = 0;
+  if (prior) {
+    if (prior.recommended) upDelta -= 1;
+    else downDelta -= 1;
+  }
+  if (next) {
+    if (next.recommended) upDelta += 1;
+    else downDelta += 1;
+  }
+  return { upDelta, downDelta };
+}
+
+/**
+ * Apply a computed delta to `AppListingMetric` INSIDE the caller's transaction.
+ *
+ * Only touches the row when there is a real delta (a zero-delta transition leaves
+ * the counters and their `updatedAt` alone). The upsert CREATES the row (clamped
+ * ≥0) when absent, else applies the atomic per-counter increments.
+ *
+ * Concurrency note: two users filing the first-ever reviews on a listing with no
+ * metric row both take the create branch; this is safe ONLY because Prisma emits a
+ * native INSERT … ON CONFLICT DO UPDATE for a single-PK upsert (the loser's insert
+ * converts to the increment). If Prisma ever falls back to select-then-insert, the
+ * loser's tx would 500 once (retriable — the row then exists).
+ */
+async function applyRecommendMetricDelta(
+  tx: Pick<Prisma.TransactionClient, 'appListingMetric'>,
+  appListingId: string,
+  { upDelta, downDelta }: RecommendMetricDelta
+): Promise<void> {
+  if (upDelta === 0 && downDelta === 0) return;
+
+  await tx.appListingMetric.upsert({
+    where: { appListingId },
+    create: {
+      appListingId,
+      thumbsUpCount: Math.max(0, upDelta),
+      thumbsDownCount: Math.max(0, downDelta),
+    },
+    update: {
+      ...(upDelta !== 0 ? { thumbsUpCount: { increment: upDelta } } : {}),
+      ...(downDelta !== 0 ? { thumbsDownCount: { increment: downDelta } } : {}),
+    },
+  });
+
+  // Defensive clamp — a counter must NEVER go negative even if the metric row
+  // drifted out of sync with the review rows. Each updateMany is atomic; it's a
+  // no-op in the normal (consistent) case.
+  if (upDelta < 0) {
+    await tx.appListingMetric.updateMany({
+      where: { appListingId, thumbsUpCount: { lt: 0 } },
+      data: { thumbsUpCount: 0 },
+    });
+  }
+  if (downDelta < 0) {
+    await tx.appListingMetric.updateMany({
+      where: { appListingId, thumbsDownCount: { lt: 0 } },
+      data: { thumbsDownCount: 0 },
+    });
+  }
 }
 
 /**
@@ -217,22 +339,15 @@ export async function upsertAppListingReview(opts: {
     });
 
     // A prior review contributes to a bucket ONLY when it is non-excluded. The
-    // freshly written review keeps the prior `exclude` (create → false); we never
-    // flip `exclude` on the write path (that's the deferred mod control), so
-    // "will count" == "prior wasn't excluded" (or a brand-new, non-excluded row).
-    const priorCounted = prior != null && !prior.exclude;
-    const willCount = prior != null ? !prior.exclude : true;
-
-    let upDelta = 0;
-    let downDelta = 0;
-    if (priorCounted) {
-      if (prior!.recommended) upDelta -= 1;
-      else downDelta -= 1;
-    }
-    if (willCount) {
-      if (recommended) upDelta += 1;
-      else downDelta += 1;
-    }
+    // freshly written review keeps the prior `exclude` (create → false); this path
+    // never FLIPS `exclude` (that is `setAppListingReviewExclude`'s job), so the
+    // AFTER contribution is "the new recommend value, at the prior exclude state".
+    // Both sides go through the ONE shared rule so this path and the mod-hide path
+    // cannot drift.
+    const { upDelta, downDelta } = recommendMetricDelta(
+      countedContribution(prior),
+      countedContribution({ recommended, exclude: prior?.exclude ?? false })
+    );
 
     const saved = await tx.appListingReview.upsert({
       where: reviewKey(appListingId, userId),
@@ -249,50 +364,117 @@ export async function upsertAppListingReview(opts: {
       },
     });
 
-    // Feed the metric in the SAME tx. Only touch it when there's a real delta (a
-    // details-only edit leaves the counters untouched). The upsert CREATES the row
-    // (clamped ≥0) when absent, else applies the atomic per-counter increments.
-    // Concurrency note: two users filing the first-ever reviews on a listing with no
-    // metric row both take the create branch; this is safe ONLY because Prisma emits a
-    // native INSERT … ON CONFLICT DO UPDATE for a single-PK upsert (the loser's insert
-    // converts to the increment). If Prisma ever falls back to select-then-insert, the
-    // loser's tx would 500 once (retriable — the row then exists). Single writer today
-    // (no P5 rollup job); a future job MUST NOT also write thumbsUp/DownCount here.
-    if (upDelta !== 0 || downDelta !== 0) {
-      await tx.appListingMetric.upsert({
-        where: { appListingId },
-        create: {
-          appListingId,
-          thumbsUpCount: Math.max(0, upDelta),
-          thumbsDownCount: Math.max(0, downDelta),
-        },
-        update: {
-          ...(upDelta !== 0 ? { thumbsUpCount: { increment: upDelta } } : {}),
-          ...(downDelta !== 0 ? { thumbsDownCount: { increment: downDelta } } : {}),
-        },
-      });
-      // Defensive clamp — a counter must NEVER go negative even if the metric row
-      // drifted out of sync with the review rows (e.g. a future mod re-count). Each
-      // updateMany is atomic; it's a no-op in the normal (consistent) case.
-      if (upDelta < 0) {
-        await tx.appListingMetric.updateMany({
-          where: { appListingId, thumbsUpCount: { lt: 0 } },
-          data: { thumbsUpCount: 0 },
-        });
-      }
-      if (downDelta < 0) {
-        await tx.appListingMetric.updateMany({
-          where: { appListingId, thumbsDownCount: { lt: 0 } },
-          data: { thumbsDownCount: 0 },
-        });
-      }
-    }
+    // Feed the metric in the SAME tx, through the ONE shared writer (a details-only
+    // edit computes {0,0} and touches nothing). No rollup job exists — the two
+    // callers of `applyRecommendMetricDelta` are the ONLY writers of
+    // thumbsUp/DownCount, and a future job MUST NOT become a third.
+    await applyRecommendMetricDelta(tx, appListingId, { upDelta, downDelta });
 
     return { saved, isNewReview: prior == null };
   });
 
   await bustRecommendMeanCache().catch(() => undefined);
   return { review: review.saved, isNewReview: review.isNewReview };
+}
+
+export type SetAppListingReviewExcludeResult = {
+  id: number;
+  appListingId: string;
+  exclude: boolean;
+  /**
+   * False when the row was ALREADY in the requested state — the no-op transition,
+   * in which case nothing at all was written (no row update, no metric delta, no
+   * cache bust). Lets the caller distinguish "I hid it" from "it was already hidden"
+   * without making the second case an error.
+   */
+  changed: boolean;
+};
+
+/**
+ * MODERATOR: hide (or un-hide) a single review — set `AppListingReview.exclude`
+ * and move the denormalized recommend counters to match, in ONE transaction.
+ *
+ * This is the write half of the `exclude` column the schema has carried since the
+ * table was created ("Moderator controls: keep abusive reviews out of the
+ * recommend-% aggregate"), indexed by `app_listing_reviews_listing_agg_idx`.
+ * {@link listAppListingReviews} already filters `exclude`, so hiding takes effect
+ * on the visible list with no read-path change.
+ *
+ * 🔴 SOFT-HIDE, NOT DELETE — three independent reasons, recorded because "just
+ * delete the row" is the obvious alternative:
+ *   1. `AppListingMetric.thumbsUp/DownCount` is DENORMALIZED with no rollup job,
+ *      so a raw delete leaves the displayed "N% recommend (M)" permanently wrong.
+ *      Any correct delete has to do this same delta anyway.
+ *   2. Removing the row would let the same user file a NEW first review for the
+ *      same listing. The sibling app-review reward documents its once-ever
+ *      guarantee as "the DB-unique + isFirstReview belt" (the only other guard is a
+ *      same-day Redis dedup that expires), and this service already returns
+ *      `isNewReview` for exactly that hook — so delete→recreate is a Buzz loop
+ *      waiting for the reward to be wired to listings.
+ *   3. `exclude` preserves the audit trail (the abusive text stays readable to
+ *      moderators) and matches the `tosViolation` sibling flag's semantics.
+ *
+ * IDEMPOTENT: setting `exclude` to the value the row already holds writes NOTHING
+ * and applies a ZERO delta. That is what makes a retry, a double-submit, or two
+ * moderators working the same report safe — the counters cannot be moved twice.
+ * The delta itself is {@link recommendMetricDelta}, the SAME function the user
+ * write path uses; there is no second copy of the arithmetic.
+ *
+ * NO STORE-SCOPE THREADING, deliberately: this is `moderatorProcedure`-gated at the
+ * router and moderators resolve `full` scope, which admits every listing kind — a
+ * scope parameter here could only ever be `full`, and a defaulted one would be an
+ * authorization decision (see the note on `upsertAppListingReview`'s `scope`).
+ * The trust boundary is the mod gate, and it is the whole boundary.
+ *
+ * NO `AppListingModerationEvent` is written: that table's `action` column is
+ * CHECK-constrained in SQL and a new action value would need a manual-apply
+ * migration, which is out of scope here. The `exclude` flag is itself the durable
+ * record; wiring an audit event is a follow-up that needs the DDL first.
+ */
+export async function setAppListingReviewExclude(
+  input: SetAppListingReviewExcludeInput
+): Promise<SetAppListingReviewExcludeResult> {
+  const { reviewId, exclude } = input;
+
+  const result = await dbWrite.$transaction(async (tx) => {
+    // Read the row INSIDE the tx: the metric delta depends on both its current
+    // `exclude` and its `recommended` bucket, so the decision and the writes must
+    // see one consistent snapshot.
+    const row = await tx.appListingReview.findUnique({
+      where: { id: reviewId },
+      select: { id: true, appListingId: true, recommended: true, exclude: true },
+    });
+    if (!row) throw throwNotFoundError('Review not found');
+
+    // The no-op transition. Return BEFORE any write so "already in this state"
+    // provably costs zero delta rather than relying on the arithmetic cancelling.
+    if (row.exclude === exclude) {
+      return { id: row.id, appListingId: row.appListingId, exclude, changed: false };
+    }
+
+    await tx.appListingReview.update({ where: { id: reviewId }, data: { exclude } });
+
+    // BEFORE vs AFTER contribution, through the one shared rule. Hiding a
+    // recommended review is −1 thumbsUp; hiding a not-recommended one is −1
+    // thumbsDown; un-hiding re-adds the same bucket. The `recommended` value is
+    // untouched, so exactly one counter moves by exactly 1.
+    await applyRecommendMetricDelta(
+      tx,
+      row.appListingId,
+      recommendMetricDelta(
+        countedContribution(row),
+        countedContribution({ recommended: row.recommended, exclude })
+      )
+    );
+
+    return { id: row.id, appListingId: row.appListingId, exclude, changed: true };
+  });
+
+  // Only a real transition shifts the aggregate, so only a real transition needs
+  // the store-wide recommend-mean cache busting. Fire-and-forget, as on the write
+  // path (a cache-bus outage must never fail a moderation action).
+  if (result.changed) await bustRecommendMeanCache().catch(() => undefined);
+  return result;
 }
 
 /**
@@ -304,6 +486,13 @@ export async function upsertAppListingReview(opts: {
  * must not read back their own review of a listing their scope hides — the row can
  * predate a scope change, so "they wrote it once" is not evidence they may see it
  * now.
+ *
+ * 🔴 DELIBERATELY DOES NOT FILTER `exclude` — an author still reads back their own
+ * mod-hidden review. This is the prefill for the edit form, so hiding the row here
+ * would present the form as empty and invite them to file a "new" review that the
+ * DB unique turns into an update of the very row they cannot see. Their review is
+ * removed from the PUBLIC list and from the aggregate; it is not removed from them.
+ * (Pinned by test — it is a behaviour, not an oversight.)
  *
  * 🔴 `findFirst`, not `findUnique`: a relation filter cannot be expressed on a
  * unique-key lookup. The (appListingId, userId) pair is still the DB unique, so at

--- a/src/server/services/blocks/app-listing-review.service.ts
+++ b/src/server/services/blocks/app-listing-review.service.ts
@@ -75,13 +75,25 @@ function reviewKey(appListingId: string, userId: number) {
 // ---------------------------------------------------------------------------
 // The ONE recommend-aggregate delta rule, and the ONE write that applies it.
 //
-// `AppListingMetric.thumbsUp/DownCount` is DENORMALIZED and has no rollup job —
-// it is whatever the sum of the ±1 deltas its writers have applied says it is.
-// So every writer MUST agree on (a) which review rows count and (b) how a
-// transition maps to a delta. There are now TWO writers (`upsertAppListingReview`
-// and `setAppListingReviewExclude`) and a second copy of this arithmetic is how
-// the counter silently drifts from the rows — so it is written once, here, and
-// both call it.
+// `AppListingMetric.thumbsUp/DownCount` is DENORMALIZED and has no recompute — it
+// is whatever the sum of the ±1 deltas its writers have applied says it is. So
+// every writer MUST agree on (a) which review rows count and (b) how a transition
+// maps to a delta. There are exactly TWO (`upsertAppListingReview` and
+// `setAppListingReviewExclude`) and a second copy of this arithmetic is how the
+// counter silently drifts from the rows — so it is written once, here, and both
+// call it.
+//
+// 🔴 "No recompute" is a TWO-SIDED contract, not a property of this file. The
+// `app_listing_metrics` row is ALSO written by the metric processor
+// (`src/server/metrics/appListing.metrics.sql.ts`), which deliberately names only
+// `install_count` in its INSERT and ON CONFLICT lists so a row created here
+// survives the rollup untouched. Each side pins the other:
+//   - that side is pinned by `src/server/metrics/__tests__/appListing.metrics.test.ts`
+//     ("NEVER writes thumbs_up_count / thumbs_down_count");
+//   - this side is pinned by the writer-set ledger in
+//     `src/server/services/blocks/__tests__/app-listing-review.mod-exclude.test.ts`,
+//     which fails if the caller set GROWS or SHRINKS.
+// A third writer is only safe if it brings a full recompute with it.
 // ---------------------------------------------------------------------------
 
 /** A review's CONTRIBUTION to the recommend aggregate; `null` = contributes nothing. */
@@ -330,13 +342,32 @@ export async function upsertAppListingReview(opts: {
   }
 
   const review = await dbWrite.$transaction(async (tx) => {
-    // Read the prior review (if any) to compute the metric delta. The DB unique
-    // makes the upsert itself atomic; a concurrent first-review by the SAME user
-    // is impossible (they're one user) so the read-then-upsert is race-safe here.
-    const prior = await tx.appListingReview.findUnique({
-      where: reviewKey(appListingId, userId),
-      select: { id: true, recommended: true, exclude: true },
-    });
+    // Read the prior review (if any) to compute the metric delta — LOCKED.
+    //
+    // 🔴 `SELECT … FOR UPDATE`, not `findUnique`. A concurrent first-review by the
+    // SAME user is impossible (they are one user), which is why this used to be an
+    // unlocked read — but that reasoning only covered the OTHER instance of this
+    // path. It does not cover the OTHER WRITER: under READ COMMITTED a moderator's
+    // `setAppListingReviewExclude` committing between this read and the upsert below
+    // makes the delta be computed against an `exclude` value that is already stale,
+    // so the author's ±1 lands on a row that is no longer counted. Taking the row
+    // lock here forces the two writers into a serial order on this row.
+    //
+    // Prisma has no `FOR UPDATE` on `findUnique`, hence raw SQL. Identifiers are
+    // quoted because `exclude` is a SQL keyword; values are interpolated by the
+    // tagged template, so they are bound parameters, not string-concatenated.
+    //
+    // LOCK ORDER — review row, then metric row — is the same in BOTH writers, which
+    // is what keeps them deadlock-free against each other.
+    const priorRows = await tx.$queryRaw<
+      Array<{ id: number; recommended: boolean; exclude: boolean }>
+    >`
+      SELECT "id", "recommended", "exclude"
+      FROM "app_listing_reviews"
+      WHERE "app_listing_id" = ${appListingId} AND "user_id" = ${userId}
+      FOR UPDATE
+    `;
+    const prior = priorRows[0] ?? null;
 
     // A prior review contributes to a bucket ONLY when it is non-excluded. The
     // freshly written review keeps the prior `exclude` (create → false); this path
@@ -365,9 +396,9 @@ export async function upsertAppListingReview(opts: {
     });
 
     // Feed the metric in the SAME tx, through the ONE shared writer (a details-only
-    // edit computes {0,0} and touches nothing). No rollup job exists — the two
-    // callers of `applyRecommendMetricDelta` are the ONLY writers of
-    // thumbsUp/DownCount, and a future job MUST NOT become a third.
+    // edit computes {0,0} and touches nothing). The two callers of
+    // `applyRecommendMetricDelta` are the ONLY writers of thumbsUp/DownCount — see
+    // the two-sided contract at the top of this file; the ledger test enforces it.
     await applyRecommendMetricDelta(tx, appListingId, { upDelta, downDelta });
 
     return { saved, isNewReview: prior == null };
@@ -414,10 +445,14 @@ export type SetAppListingReviewExcludeResult = {
  *   3. `exclude` preserves the audit trail (the abusive text stays readable to
  *      moderators) and matches the `tosViolation` sibling flag's semantics.
  *
- * IDEMPOTENT: setting `exclude` to the value the row already holds writes NOTHING
- * and applies a ZERO delta. That is what makes a retry, a double-submit, or two
- * moderators working the same report safe — the counters cannot be moved twice.
- * The delta itself is {@link recommendMetricDelta}, the SAME function the user
+ * IDEMPOTENT, AND THE IDEMPOTENCE IS SERIALIZED: the transition is expressed as the
+ * UPDATE's own predicate (`exclude: { not: exclude }`), so the database decides who
+ * transitioned the row, and the delta is applied only by the caller that did. Setting
+ * `exclude` to the value the row already holds writes NOTHING and applies a ZERO
+ * delta — and so does LOSING a race, which is the case a read-then-branch guard gets
+ * wrong. That is what makes a retry, a double-submit, or two moderators working the
+ * same report safe under READ COMMITTED; see the comment on the update itself for the
+ * mechanism. The delta is {@link recommendMetricDelta}, the SAME function the user
  * write path uses; there is no second copy of the arithmetic.
  *
  * NO STORE-SCOPE THREADING, deliberately: this is `moderatorProcedure`-gated at the
@@ -437,32 +472,54 @@ export async function setAppListingReviewExclude(
   const { reviewId, exclude } = input;
 
   const result = await dbWrite.$transaction(async (tx) => {
-    // Read the row INSIDE the tx: the metric delta depends on both its current
-    // `exclude` and its `recommended` bucket, so the decision and the writes must
-    // see one consistent snapshot.
+    // 🔴 THE TRANSITION IS THE UPDATE'S OWN PREDICATE — never a read-then-branch.
+    //
+    // `$transaction` here is Postgres READ COMMITTED (nothing in this codebase sets
+    // an `isolationLevel`), which does NOT serialize a read against a concurrent
+    // committer. A `findUnique` + `if (row.exclude === exclude)` guard is a
+    // read-modify-write: two moderators hiding the same review both read
+    // `exclude=false`, both pass the guard, and both apply −1 — permanent counter
+    // drift, and the ≥0 clamp only masks it at zero. The same window lets a mod hide
+    // race the author's `recommended` flip and decrement the WRONG bucket.
+    //
+    // A conditional UPDATE closes it with no extra locking primitive: the row lock is
+    // taken by the update itself, and under READ COMMITTED Postgres RE-EVALUATES the
+    // WHERE against the newly-committed row version after acquiring that lock
+    // (EvalPlanQual). So of two racers exactly one sees `count === 1` and the loser
+    // sees `count === 0` — the delta is gated on being the winner.
+    const { count } = await tx.appListingReview.updateMany({
+      where: { id: reviewId, exclude: { not: exclude } },
+      data: { exclude },
+    });
+
+    // Read AFTER the conditional update, deliberately. When `count === 1` we now hold
+    // the row lock, so `recommended` cannot be changed underneath the delta by a
+    // concurrent author edit — which is the second half of the race above. (Ordering
+    // is pinned by test; reading first would reintroduce it.)
     const row = await tx.appListingReview.findUnique({
       where: { id: reviewId },
       select: { id: true, appListingId: true, recommended: true, exclude: true },
     });
     if (!row) throw throwNotFoundError('Review not found');
 
-    // The no-op transition. Return BEFORE any write so "already in this state"
-    // provably costs zero delta rather than relying on the arithmetic cancelling.
-    if (row.exclude === exclude) {
-      return { id: row.id, appListingId: row.appListingId, exclude, changed: false };
+    // `count === 0` means WE did not transition the row: it was already in the target
+    // state, or a concurrent racer got there first. Both are the same no-op — nothing
+    // written, zero delta — and reporting the OBSERVED `row.exclude` rather than the
+    // requested target keeps the return honest about what is actually stored.
+    if (count === 0) {
+      return { id: row.id, appListingId: row.appListingId, exclude: row.exclude, changed: false };
     }
 
-    await tx.appListingReview.update({ where: { id: reviewId }, data: { exclude } });
-
-    // BEFORE vs AFTER contribution, through the one shared rule. Hiding a
-    // recommended review is −1 thumbsUp; hiding a not-recommended one is −1
-    // thumbsDown; un-hiding re-adds the same bucket. The `recommended` value is
-    // untouched, so exactly one counter moves by exactly 1.
+    // BEFORE vs AFTER contribution, through the one shared rule. The BEFORE state is
+    // `!exclude` by construction — the conditional matched, so that is what the row
+    // held when we locked it. Hiding a recommended review is −1 thumbsUp; hiding a
+    // not-recommended one is −1 thumbsDown; un-hiding re-adds the same bucket. The
+    // `recommended` value is untouched, so exactly one counter moves by exactly 1.
     await applyRecommendMetricDelta(
       tx,
       row.appListingId,
       recommendMetricDelta(
-        countedContribution(row),
+        countedContribution({ recommended: row.recommended, exclude: !exclude }),
         countedContribution({ recommended: row.recommended, exclude })
       )
     );


### PR DESCRIPTION
## What this is

`AppListingReview.exclude` has carried the comment *"Moderator controls: keep abusive reviews out of the recommend-% aggregate"* and an index on `[appListingId, exclude]` since the table was created. `listReviews` has always filtered it. **Nothing has ever written it** — there was no delete, hide, or moderation path for an app-listing review at all. The service even said so: *"we never flip `exclude` on the write path (that's the deferred mod control)"*.

This builds that control.

- **Service** — `setAppListingReviewExclude({ reviewId, exclude })` in `app-listing-review.service.ts`: sets the flag and applies the matching `AppListingMetric` delta in **one transaction**.
- **Router** — `appListings.setReviewExclude`, `moderatorProcedure` + the inner `isModerator` recheck (the same idiom as `delistListing` / `relistListing` / `claimListing` / `purgeListing` in this router). Added to that file's asserted mod-action ledger.
- **No migration.** The column already exists. Nothing in this PR touches the DB.

## The part that is easy to get wrong: the counter

`AppListingMetric.thumbsUpCount` / `thumbsDownCount` are **denormalized with no rollup job** — they are exactly the sum of the ±1 deltas their writers have applied. So flipping `exclude` *without* adjusting the counter leaves the displayed "N% recommend (M)" permanently wrong, with nothing to repair it.

Rather than write a second copy of that arithmetic, the delta computation and the metric write are **extracted out of `upsertReview`** into `recommendMetricDelta` (a pure function of the BEFORE/AFTER contributions) and `applyRecommendMetricDelta`, and **both writers call them**. `upsertReview` behaves identically — its 33 pre-existing tests pass unchanged.

Properties:

- **Both directions.** Hiding decrements the bucket matching the row's `recommended`; un-hiding re-increments the same bucket. Exactly one counter moves, by exactly 1 — the other bucket's key is *absent* from the update, not set to `increment: 0`.
- **Idempotent, and serialized.** `exclude` is an **explicit target state, not a toggle** (a deliberate divergence from `resourceReview.toggleExclude`), and the transition is expressed as the UPDATE's own predicate — `updateMany({ where: { id, exclude: { not: exclude } } })`. Postgres re-evaluates that WHERE against the newly-committed row version after taking the row lock (EvalPlanQual), so of two concurrent hides exactly one sees `count === 1`; the delta is gated on being that one. A retry, a double-submit, **or two moderators working the same report** therefore move the aggregate exactly once. `recommended` is read *after* the conditional update, i.e. under the lock, so a racing author edit cannot misdirect the delta.
- Clamped at zero the way the existing metric write is.
- Keyed on the **review id**, which is what `listReviews` already projects: the moderator acts on exactly the row they are looking at, via one opaque handle, and cannot mis-pair a listing with the wrong reviewer.

## Why a soft hide and not a delete

1. **The denormalized counter.** A raw `delete` leaves `thumbsUp/DownCount` permanently wrong — there is no recount job. Any *correct* delete would have to do this same delta anyway, so the delta is the real work either way.
2. **It re-opens the once-ever review reward.** The sibling app-review reward documents its once-per-(user, app) guarantee as *"the DB-unique + `isFirstReview` belt"*; the only other guard is a same-day Redis dedup that expires. Removing the row lets the same user file a fresh **first** review, so delete→recreate becomes a Buzz loop. (Precisely: that reward is currently wired to `AppBlockReview`, not `AppListingReview` — but `upsertAppListingReview` already returns `isNewReview` for exactly that hook, so this is a trap laid for the moment it is wired, not a hypothetical.)
3. **Audit trail + consistency.** `exclude` keeps the abusive text readable to moderators and matches the semantics of its sibling `tosViolation` flag on the same row.

## Tests — red-at-base matrix

Base = `origin/main` @ `c227e78d71`. Measured by reverting **only** the three source files to base and re-running the new test files in place.

| | at base | at HEAD |
|---|---|---|
| `app-listing-review.mod-exclude.test.ts` (23 tests, new file) | **20 failed**, 3 passed | 23 passed |
| `app-listings.router.mod-actions-authz.test.ts` (8 new cases; 40 → 48 tests) | **6 of the 8 failed** | 48 passed |
| `app-listing-review.service.test.ts` (18) + `.store-scope.test.ts` (15) | 33 passed | 33 passed |

That last row is the check on the refactor: `upsertReview`'s existing assertions are unchanged and green both before and after the delta extraction. (Their *arrangement* changed in the follow-up commit — the prior-review read became `SELECT … FOR UPDATE`, so three tests now stub `$queryRaw` instead of `findUnique`. No assertion was weakened; the mutant that removes the row lock is killed by three of them.)

**Honest caveat on that matrix:** most of those 26 base failures are red *because the symbol does not exist there*, which is weak evidence about the assertions themselves. The mutation sweep below is the real one.

The 2 new router cases that stay green at base are the generic `MOD_ACTIONS` ledger loop's "tester is FORBIDDEN" / "anonymous is rejected" entries, which assert only `instanceof TRPCError` — a pre-existing looseness in that loop, deliberately not widened here. The dedicated `setReviewExclude` describe covers the same ground with exact codes and does fail at base.

**3 cases are green at base — labelled in the file as INVARIANT GUARDS, not regression coverage:**

- `getMyAppListingReview` does **not** filter `exclude` — an author still sees their own hidden review (deliberate: the edit form prefills from it, and blanking it would invite a "new" review that the DB unique silently turns into an update of the row they cannot see).
- `listAppListingReviews` **does** filter `exclude` — a hidden review leaves the public list. This is what makes the mod action take effect with no read-path change.
- A mod-excluded prior review stays un-counted when its author edits it — an author cannot restore their own hidden review to the aggregate.

All three already held; they are pinned because the mod control makes them load-bearing for the first time.

Two of the router authz assertions were initially **green at base for the wrong reason**: calling a proc that does not exist also rejects with a `TRPCError` (`NOT_FOUND`, *"No procedure found on path"*), so `rejects.toBeInstanceOf(TRPCError)` proved the gate without the gate existing. They now pin `FORBIDDEN` / `UNAUTHORIZED` / `BAD_REQUEST` specifically, and fail at base.

## Mutation sweep

**23 isolated mutants** (each the narrowest expression that can be wrong), plus unmutated positive controls. **All 23 killed; controls green (117/117).** Every killer below is the measured test name, not an attribution I assumed.

| mutant | killed by |
|---|---|
| race guard (`count === 0`) removed | the 3 no-op cases **+ both concurrency cases** |
| conditional predicate dropped (`where: { id }`) | both direction cases (call-shape assertion) |
| conditional update deleted entirely | 13 tests |
| AFTER contribution → wrong bucket | truth table + both writers' direction cases |
| BEFORE contribution `-=` → `+=` | truth table + `upsertReview`'s flip case |
| BEFORE state computed from the post-update value | all four direction cases |
| zero-delta write guard removed | the *user write path's* details-only-edit tests (proves the shared helper is reachable from both writers) |
| non-negative clamp removed | hide case + the pre-existing flip case |
| **counter write moved out of the transaction** | all four direction cases (this is what the sentinel tx client buys) |
| **author-side prior read loses `FOR UPDATE`** | 3 `upsertReview` cases + the seam case |
| requested target ignored (always hides) | un-hide case |
| NOT_FOUND removed | the missing-review case |
| cache bust made unconditional | the two no-op cases + the race-loser case |
| `moderatorProcedure` → `protectedProcedure` | the **tester** refusal case (in the ledger loop and in the dedicated describe) |
| `exclude: false` dropped from the public list | the public-list invariant guard + a pre-existing case |
| `exclude: false` added to `getMyReview` | the author-visibility invariant guard + 3 pre-existing cases |
| **a third caller of the delta writer appears** | the writer-set ledger |
| **`FOR UPDATE` deleted from the prior read** | the SQL-text row-lock assertion |
| **prior-read table name typo'd** | the SQL-text table assertion |
| **`"exclude"` dropped from the prior SELECT** | the SQL-text column assertion |
| `stripComments` reverted to the cross-line regex | the fail-open stripper control |
| `delete`/`deleteMany` dropped from the writer predicate | the writer-predicate controls |
| Kysely reach-around dropped from the writer predicate | the writer-predicate controls |

### The guard that protects the fix had no guard

Worth stating because it is the PR's own subject one level up. The conditional-update half of the race fix has four kills plus an ordering pin. The `SELECT … FOR UPDATE` half had **none** — every test mocks `$queryRaw`, so the SQL string was never asserted and never executed, and three mutations on it **survived the full 21k-test suite**: deleting `FOR UPDATE` (silently reverts the fix), typo'ing the table name (hard runtime failure, zero CI signal), and dropping `"exclude"` from the SELECT (`prior.exclude` becomes `undefined`, so a mod-hidden review re-enters the aggregate). Asserting the tagged template's static strings — the lock clause, the quoted table, every selected column, and that the lookup keys arrive as **bound parameters** rather than interpolated text — kills all three with no database. Each now dies to its own dedicated assertion, not collateral.

### Correction: the anonymous case does not test the mod gate

An earlier version of this table said the `protectedProcedure` mutant was killed by "both non-mod refusal tests". Measured, only the **tester** case goes red. `moderatorProcedure` is `protectedProcedure.use(isMod)`, so an anonymous caller is rejected by `isAuthed` with `UNAUTHORIZED` before `isMod` is reached — and that is equally true under the mutant. The anonymous case is **structurally incapable** of discriminating moderator-only from merely-authenticated, so it cannot be made to discriminate cheaply; it is now labelled in the test file as an **auth** guard rather than counted as evidence of the mod gate.

## Limits / not verified

- **Mocked Prisma only** — no test in this repo exercises real Prisma for this service, so the call shapes are pinned, not the emitted SQL. Consistent with the existing tests in the same file. Concretely: the concurrency tests drive the `count === 0` / `count === 1` branches directly, and the conditional-update *shape* is asserted — but **no test executes real EvalPlanQual**. The serialization argument rests on Postgres semantics plus the pinned call shape, not on an observed interleaving.
- The `$transaction` mock now hands the callback a **distinct sentinel client**, so "inside the transaction" is witnessed: a mutant moving the counter write onto the plain `dbWrite` is caught. (It survived before this was added.)
- **No `AppListingModerationEvent` is written.** That table's `action` column is CHECK-constrained in SQL, so a new action value needs a manual-apply migration — out of scope here. The `exclude` flag is itself the durable record; the audit event is a follow-up that needs the DDL first.
- `tosViolation` is deliberately **not** folded into the "does this row count" predicate. `listReviews` hides both flags, but the counters have only ever tracked `exclude`, and nothing writes `tosViolation` today — widening it without a recount would make the live counters disagree with the rows they were accumulated from. The predicate is now a single function, so that is a one-line change *when* someone brings the recount.
- **No UI.** Backend only, consistent with the rest of this surface being dark.
- 🟡 **The `FOR UPDATE` serializes the UPDATE path only — the CREATE path is not serialized, and this PR does not close it.** `FOR UPDATE` locks nothing when the row does not exist, so two in-flight *first* reviews from one user (double-submit, retry, two tabs) both read `prior = null` and both compute `+1`: either a permanent over-count that the `≥0` clamp cannot mask (it errs high), or the loser 500s on the unique. Same class as the bug fixed above, on the branch a row lock cannot reach. It is **pre-existing**, and closing it means an advisory lock or an `INSERT … ON CONFLICT` returning the pre-image — a behavioural change to the author write path. #4320's wholesale recompute retires this drift class along with the others, which is the better trade than narrowing it twice. The code comment now says this instead of the previous claim that the case was impossible.
- **Transaction budget, recorded so it is not a surprise later:** both `$transaction` calls use Prisma's default 5000 ms interactive budget, and the new lock waits sit inside it. Under real contention this surfaces as a **`P2028` timeout rather than queueing**. Fine at current volume.
- **The writer set is now pinned, in both directions.** `applyRecommendMetricDelta` is module-private with exactly two callers and a comment saying a third must never appear; nothing enforced that. A ledger test now asserts the caller set as an **equality** (shrinking is as red as growing) and scans `src/server/**` for any other module writing the thumbs counters. It is one half of a two-sided contract — the metric processor `src/server/metrics/appListing.metrics.sql.ts` deliberately names only `install_count`, already guarded by `appListing.metrics.test.ts`; each guard now names the other.
- **The ledger scan needed three rounds of instrument validation, recorded because the failure modes are instructive.** v1 flagged 3 files: 2 were comment-only matches — including the very file whose comment *promises* it does not write thumbs. v2 (comment-stripped) still flagged `app-listing.service.ts`, a read-only consumer, because a bare `UPDATE` matches the `update` inside `updated_at`. v3 fixed the stripper itself: the cross-line block-comment regex **fails open** — an open marker inside a string literal matches to the next real close marker and deletes the lines between it, including a genuine write, so the scan would report "no other writers" with total confidence. It is now line-oriented (cannot run away; an unstripped inline block comment fails *closed* instead). The predicate also gained `delete`/`deleteMany` (deleting a review destroys its counters) and Kysely's `updateTable`/`insertInto`/`deleteFrom`, and the walk widened past `src/server/**` to `src/**` (incl. `.tsx` and `src/pages/api/**`) and `packages/*/src/**`. Still exactly one writer, so that widening closes a **coverage limit, not a live gap**. All of it is controlled: eight write shapes it must detect, three reads it must ignore, the fail-open fixture, and each hardening proven load-bearing by reverting it and watching its own control go red.
- **Not in this PR, filed separately:** a wholesale thumbs recompute in `appListing.metrics.sql.ts`. The sibling `ResourceReview` has exactly that, which is *why* `resourceReview.toggleExclude` needs no delta arithmetic at all. That would make the scheme self-healing and retire this drift class rather than narrowing it — a bigger change deserving its own review.

## Gates

`pnpm typecheck` 0 errors · ESLint clean on the touched files · Prettier clean on the touched files (the pre-existing formatting drift elsewhere in `app-listings.router.mod-actions-authz.test.ts` is untouched — it is present verbatim at base) · full local `pnpm test:unit:run` → **1346 files / 21007 tests, 0 failures**.

### Note on the second commit

The first push failed CI on exactly one test, in exactly this PR's new file: `no-direct-shared-module-mock`, a ratchet that forbids a per-file `vi.mock('~/server/db/client', …)` because under `isolate: false` it freezes that file's mock shape into every later file in the same worker. The new test file has been migrated to the canonical `dbMock` (`src/__tests__/mocks/db.mock.ts`) — same 23 assertions, and the mutation sweep above was re-run against the migrated file with identical results.

Worth recording because it is the interesting kind of miss: the targeted local run covered `src/server/services/blocks/__tests__/` and `src/server/routers/__tests__/`, and the guard lives in `src/server/services/__tests__/` — one directory outside the selection. A directory-scoped local run is structurally blind to a repo-wide ratchet. The full suite is now the check.
