### PR TITLE
perf(image): index tags by imageId instead of rescanning the tag array per image

### DIFF
--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:3925':
+  'server/services/image.service.ts:3952':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4055':
+  'server/services/image.service.ts:4082':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4765':
+  'server/services/image.service.ts:4792':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5875':
+  'server/services/image.service.ts:5902':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -206,7 +206,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4055')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4082')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/services/__tests__/image-tag-association.test.ts
+++ b/src/server/services/__tests__/image-tag-association.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * `getImagesByEntity` and `getEntityCoverImage` used to associate tags to images
+ * with `tagsVar?.filter((x) => x.imageId === i.id)` — a full scan of the tag
+ * array once per image. `getImageTagsForImages` fetches the tags for EVERY image
+ * in the batch, so the tag array grows with the image count and the join is
+ * quadratic. `attachTagsToImages` indexes once and looks up.
+ *
+ * The behaviour that has to survive the rewrite:
+ *   - each image gets exactly its OWN tags (ids, not positions);
+ *   - an image with no tags gets `[]`, which is what `.filter()` returned, NOT
+ *     the `undefined` a bare `Map.get()` hands back.
+ *
+ * Fixture discipline: every `imageId` here is deliberately distinct from its
+ * index in both the image array and the tag array, so an off-by-one or an
+ * index-vs-id mix-up cannot pass by coincidence.
+ */
+
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/services/cosmetic.service', () => ({
+  getCosmeticsForEntity: vi.fn().mockResolvedValue({}),
+}));
+
+// Only `imageTagsCache.fetch` is replaced; every other export of the caches
+// module is carried through, so nothing else in image.service's import graph
+// silently loses a binding.
+const { imageTagsFetch } = vi.hoisted(() => ({ imageTagsFetch: vi.fn() }));
+vi.mock('~/server/redis/caches', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  imageTagsCache: { fetch: imageTagsFetch, bust: vi.fn() },
+}));
+
+import {
+  attachTagsToImages,
+  getImagesByEntity,
+  getEntityCoverImage,
+} from '~/server/services/image.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+// ---------------------------------------------------------------------------
+// The association step itself
+// ---------------------------------------------------------------------------
+
+describe('attachTagsToImages', () => {
+  it('gives every image exactly its own tags, from an interleaved tag array', () => {
+    // Ids are pairwise distinct from the array indices (0,1,2) on BOTH arrays,
+    // and the tags arrive out of order and interleaved between images.
+    const images = [{ id: 70 }, { id: 41 }, { id: 93 }];
+    const tags = [
+      { imageId: 93, name: 'c1' },
+      { imageId: 70, name: 'a1' },
+      { imageId: 41, name: 'b1' },
+      { imageId: 70, name: 'a2' },
+      { imageId: 93, name: 'c2' },
+      { imageId: 41, name: 'b2' },
+      { imageId: 70, name: 'a3' },
+    ];
+
+    const result = attachTagsToImages(images, tags);
+
+    expect(result).toEqual([
+      {
+        id: 70,
+        tags: [
+          { imageId: 70, name: 'a1' },
+          { imageId: 70, name: 'a2' },
+          { imageId: 70, name: 'a3' },
+        ],
+      },
+      {
+        id: 41,
+        tags: [
+          { imageId: 41, name: 'b1' },
+          { imageId: 41, name: 'b2' },
+        ],
+      },
+      {
+        id: 93,
+        tags: [
+          { imageId: 93, name: 'c1' },
+          { imageId: 93, name: 'c2' },
+        ],
+      },
+    ]);
+  });
+
+  it('preserves the relative order of an image’s own tags', () => {
+    // `.filter()` kept source order; a grouping pass must too, because the tag
+    // array arrives sorted by score and the client renders it as given.
+    const result = attachTagsToImages(
+      [{ id: 8 }],
+      [
+        { imageId: 8, name: 'first' },
+        { imageId: 5, name: 'other' },
+        { imageId: 8, name: 'second' },
+        { imageId: 8, name: 'third' },
+      ]
+    );
+
+    expect(result[0].tags.map((t) => t.name)).toEqual(['first', 'second', 'third']);
+  });
+
+  it('returns [] — not undefined — for an image with no tags', () => {
+    // 🔴 THE regression test. `tagsByImageId?.get(i.id)` without `?? []` yields
+    // `undefined` here, which is a different value on the wire from the `[]`
+    // that `.filter()` produced. Images with no tags are common.
+    const result = attachTagsToImages([{ id: 12 }], [{ imageId: 99, name: 'not-mine' }]);
+
+    expect(result[0].tags, 'an image with no tags must receive [], not undefined').toEqual([]);
+    expect(result[0].tags, 'an image with no tags must receive [], not undefined').not.toBe(
+      undefined
+    );
+  });
+
+  it('mixes tagged and untagged images in the same call', () => {
+    const result = attachTagsToImages(
+      [{ id: 31 }, { id: 64 }, { id: 22 }],
+      [
+        { imageId: 22, name: 'z' },
+        { imageId: 31, name: 'x' },
+      ]
+    );
+
+    expect(result[0].tags).toEqual([{ imageId: 31, name: 'x' }]);
+    expect(result[1].tags, 'the middle image has no tags and must get []').toEqual([]);
+    expect(result[2].tags).toEqual([{ imageId: 22, name: 'z' }]);
+  });
+
+  it('returns [] for every image when no tags were fetched at all', () => {
+    // The `include` flag not asking for tags leaves `tagsVar` as `[]`; the
+    // `undefined` arm is the defensive one. Both must land on `[]`, which is
+    // what both call sites shipped before.
+    for (const tags of [[] as { imageId: number }[], undefined]) {
+      const result = attachTagsToImages([{ id: 3 }, { id: 77 }], tags);
+      expect(result.map((r) => r.tags)).toEqual([[], []]);
+    }
+  });
+
+  it('carries the image’s other fields through untouched', () => {
+    const result = attachTagsToImages([{ id: 5, url: 'u', nsfwLevel: 1 }], [{ imageId: 5, x: 1 }]);
+
+    expect(result[0]).toMatchObject({ id: 5, url: 'u', nsfwLevel: 1 });
+  });
+
+  it('does not mutate the tag array it was handed', () => {
+    const tags = [{ imageId: 2, name: 'a' }];
+    attachTagsToImages([{ id: 2 }], tags);
+
+    expect(tags).toEqual([{ imageId: 2, name: 'a' }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The two call sites, end to end
+// ---------------------------------------------------------------------------
+
+/** Minimal rows in the shape each service's `$queryRaw` returns. */
+const baseRow = {
+  name: 'x',
+  url: 'x',
+  nsfwLevel: 1,
+  width: 1,
+  height: 1,
+  hash: 'x',
+  hideMeta: false,
+  hasMeta: true,
+  hasPositivePrompt: true,
+  createdAt: new Date(0),
+  mimeType: 'image/jpeg',
+  type: 'image',
+  metadata: null,
+  ingestion: 'Scanned',
+  scannedAt: new Date(0),
+  needsReview: null,
+  userId: 1,
+  index: 0,
+};
+
+/** Shapes `imageTagsCache.fetch`'s return so `getImageTagsForImages` builds tags. */
+function cachedTags(byImage: Record<number, string[]>) {
+  return Object.fromEntries(
+    Object.entries(byImage).map(([imageId, names]) => [
+      imageId,
+      {
+        imageId: Number(imageId),
+        tags: names.map((tagName, i) => ({
+          tagId: 1000 + i,
+          tagName,
+          tagType: 'UserGenerated',
+          tagNsfwLevel: 1,
+          score: 1,
+          upVotes: 0,
+          downVotes: 0,
+        })),
+      },
+    ])
+  );
+}
+
+describe('getImagesByEntity associates tags per image', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('gives each image its own tags and [] to the untagged one', async () => {
+    const rows = [
+      { ...baseRow, id: 70, entityId: 1, poi: false, minor: false },
+      { ...baseRow, id: 41, entityId: 1, poi: false, minor: false },
+      { ...baseRow, id: 93, entityId: 1, poi: false, minor: false },
+    ];
+    (dbMock.dbRead.$queryRaw as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(rows);
+    // 41 is deliberately absent: it is the empty case, in the middle.
+    imageTagsFetch.mockResolvedValue(cachedTags({ 70: ['a1', 'a2'], 93: ['c1'] }));
+
+    const result = await getImagesByEntity({ id: 1, type: 'Bounty', include: ['tags'] });
+
+    // Positive control: an early return would make every assertion below a
+    // statement about nothing.
+    expect(result, 'getImagesByEntity returned no rows').toHaveLength(3);
+    expect(imageTagsFetch, 'the tag fetch never ran').toHaveBeenCalledTimes(1);
+
+    expect(result[0].tags.map((t) => t.name)).toEqual(['a1', 'a2']);
+    expect(result[1].tags, 'an image with no tags must receive [], not undefined').toEqual([]);
+    expect(result[2].tags.map((t) => t.name)).toEqual(['c1']);
+    expect(result.map((r) => r.id)).toEqual([70, 41, 93]);
+  });
+
+  it('returns [] for every image when tags were not requested', async () => {
+    (dbMock.dbRead.$queryRaw as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { ...baseRow, id: 70, entityId: 1, poi: false, minor: false },
+    ]);
+
+    const result = await getImagesByEntity({ id: 1, type: 'Bounty' });
+
+    expect(result).toHaveLength(1);
+    expect(imageTagsFetch).not.toHaveBeenCalled();
+    expect(result[0].tags, 'no `include` must still yield [], as `.filter()` did').toEqual([]);
+  });
+});
+
+describe('getEntityCoverImage associates tags per image', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('gives each image its own tags, [] to the untagged one, and keeps cosmetic', async () => {
+    const rows = [
+      { ...baseRow, id: 70, postId: null, entityId: 11, entityType: 'Model' },
+      { ...baseRow, id: 41, postId: null, entityId: 22, entityType: 'Model' },
+      { ...baseRow, id: 93, postId: null, entityId: 33, entityType: 'Model' },
+    ];
+    (dbMock.dbRead.$queryRaw as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(rows);
+    imageTagsFetch.mockResolvedValue(cachedTags({ 70: ['a1', 'a2'], 93: ['c1'] }));
+
+    const result = await getEntityCoverImage({
+      entities: [
+        { entityId: 11, entityType: 'Model' },
+        { entityId: 22, entityType: 'Model' },
+        { entityId: 33, entityType: 'Model' },
+      ],
+      include: ['tags'],
+    });
+
+    expect(result, 'getEntityCoverImage returned no rows').toHaveLength(3);
+    expect(imageTagsFetch, 'the tag fetch never ran').toHaveBeenCalledTimes(1);
+
+    expect(result[0].tags.map((t) => t.name)).toEqual(['a1', 'a2']);
+    expect(result[1].tags, 'an image with no tags must receive [], not undefined').toEqual([]);
+    expect(result[2].tags.map((t) => t.name)).toEqual(['c1']);
+
+    // The cosmetic key is attached at this call site only; the rewrite must not
+    // have dropped it.
+    expect(result[0]).toHaveProperty('cosmetic');
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -541,6 +541,33 @@ async function getImageTagsForImages(
   );
 }
 
+/**
+ * Associates already-fetched tags to their images in O(N + M).
+ *
+ * `getImageTagsForImages` returns the tags for EVERY image in the batch, so a
+ * per-image `tags.filter(x => x.imageId === i.id)` rescans the whole array once
+ * per image — O(N x M), and M grows with N. CPU profiles of the production API
+ * showed that construct dominating multi-second event-loop stalls.
+ *
+ * 🔴 The empty case must stay `[]`, NOT `undefined`. `.filter()` returned `[]`
+ * for an image with no tags and `Map.get()` returns `undefined`; those are
+ * different values in the API response, and images with no tags are common.
+ * That is what the `?? []` is for — do not "simplify" it away.
+ */
+export function attachTagsToImages<TImage extends { id: number }, TTag extends { imageId: number }>(
+  images: TImage[],
+  tags: TTag[] | undefined
+): (TImage & { tags: TTag[] })[] {
+  const tagsByImageId = tags?.reduce((acc, tag) => {
+    const arr = acc.get(tag.imageId);
+    if (arr) arr.push(tag);
+    else acc.set(tag.imageId, [tag]);
+    return acc;
+  }, new Map<number, TTag[]>());
+
+  return images.map((i) => ({ ...i, tags: tagsByImageId?.get(i.id) ?? [] }));
+}
+
 export const deleteImageById = async ({
   id,
   updatePost,
@@ -7080,10 +7107,7 @@ export const getImagesByEntity = async ({
     tagsVar = await getImageTagsForImages(imageIds);
   }
 
-  return images.map((i) => ({
-    ...i,
-    tags: tagsVar?.filter((x) => x.imageId === i.id),
-  }));
+  return attachTagsToImages(images, tagsVar);
 };
 
 export async function createImage({
@@ -7440,9 +7464,8 @@ export const getEntityCoverImage = async ({
 
   const cosmetics = await getCosmeticsForEntity({ ids: images.map((i) => i.id), entity: 'Image' });
 
-  return images.map((i) => ({
+  return attachTagsToImages(images, tagsVar).map((i) => ({
     ...i,
-    tags: tagsVar?.filter((x) => x.imageId === i.id),
     cosmetic: cosmetics[i.id],
   }));
 };


### PR DESCRIPTION
## The defect

`getImagesByEntity` and `getEntityCoverImage` both associated tags to images like this:

```ts
return images.map((i) => ({
  ...i,
  tags: tagsVar?.filter((x) => x.imageId === i.id),
}));
```

`getImageTagsForImages(imageIds)` fetches the tags for **every** image in the batch, so the
array being scanned grows with the image count. The scan runs once per image, which makes the
join **O(N x M)** with M proportional to N — quadratic in the batch size, on top of a
per-element property compare.

CPU profiling of production API servers showed this construct dominating multi-second
event-loop stalls: roughly **33–41% of application CPU** in sampled stall profiles, and about
**93% of the single worst one**.

## The fix

No new idea — this adopts the idiom that already exists in the same file. `getAllImages` and
the search-result path both build a `Map<imageId, tags[]>` once and then look up per image.
This lifts that block into one exported helper, `attachTagsToImages`, and uses it at both
sites, so the predicate lives in one place instead of three.

```ts
export function attachTagsToImages<TImage extends { id: number }, TTag extends { imageId: number }>(
  images: TImage[],
  tags: TTag[] | undefined
): (TImage & { tags: TTag[] })[] {
  const tagsByImageId = tags?.reduce((acc, tag) => {
    const arr = acc.get(tag.imageId);
    if (arr) arr.push(tag);
    else acc.set(tag.imageId, [tag]);
    return acc;
  }, new Map<number, TTag[]>());

  return images.map((i) => ({ ...i, tags: tagsByImageId?.get(i.id) ?? [] }));
}
```

O(N + M), one pass to index and one to look up.

## 🔴 The `[]`-vs-`undefined` semantic, deliberately preserved

`.filter()` returns **`[]`** when nothing matches. `Map.get()` returns **`undefined`**. Those
are different values in the API response, and an image with no tags is common — so the
`?? []` is load-bearing, not cosmetic. Both call sites shipped `[]` before this PR and ship
`[]` after it, including the `include`-does-not-ask-for-tags case (`tagsVar` is initialised to
`[]`, so `.filter()` yielded `[]` for every image; the index is then empty and `?? []` yields
the same).

**Observation, not changed here:** the two existing index sites in this file disagree with
each other on exactly this point. The search-result site writes `tagsByImageId?.get(sr.id) ?? []`
— correct. The `getAllImages` site writes `tagsByImageId?.get(i.id)` with no fallback, which
`876284e59d` introduced when it replaced a `.filter()` there; an untagged image in that
response gets `undefined` where it previously got `[]`. That is a pre-existing latent behaviour
change on a much hotter path and is deliberately **out of scope for this PR** — flagging it so
it is a decision rather than an oversight.

## Tests

New: `src/server/services/__tests__/image-tag-association.test.ts` — 10 tests.

The helper, directly:
- correct association at N>1 with an interleaved, out-of-order tag array. Every `imageId` is
  pairwise distinct from its index in **both** arrays, so an off-by-one or an index-vs-id
  mix-up cannot pass by coincidence
- an image's own tags keep their relative order (they arrive score-sorted)
- an image with no matching tags gets `[]`, not `undefined`
- tagged and untagged images mixed in one call
- `[]` for every image when tags were not fetched at all (both the `[]` and the `undefined` arm)
- the image's other fields survive; the input tag array is not mutated

Both call sites, end to end (real service, `$queryRaw` and the tag cache stubbed): each image
receives its own tags, the untagged one in the middle receives `[]`, and
`getEntityCoverImage` still attaches `cosmetic`.

### Red → green matrix

Each mutation was applied to the helper, the suite watched go red, then reverted and watched
go green.

| Mutation | Result |
|---|---|
| baseline (as merged) | **10 passed / 0 failed** |
| drop the fallback: `tagsByImageId?.get(i.id) as TTag[]` | **6 failed / 4 passed** — each with its own assertion message, e.g. `an image with no tags must receive [], not undefined: expected undefined to deeply equal []` |
| look up by position: `tagsByImageId?.get(idx) ?? []` | **5 failed / 5 passed** — the association and ordering cases |
| restored | **10 passed / 0 failed** |

## Validation

- `vitest run --project 'unit*'` (full unit suite): **21078 passed / 0 failed / 25 skipped**
  across 1351 files (1350 passed, 1 skipped).
- `node scripts/typecheck.mjs`: **0 type errors**.
- Prettier: the added code is clean. The one remaining warning in `image.service.ts` is
  pre-existing on `main` and untouched here.

## Why `flipt-eval-context.test.ts` is in this diff

That suite's `ENTITY_WITHOUT_CONTEXT_LEDGER` keys ledgered Flipt call sites by
`file:line`, and four of its rows point into `image.service.ts`. Adding the helper shifted
those four lines by +27, so the ledger's own "a fixed or moved site must be removed from it"
check went red. The four keys are re-pointed at the same four unchanged call sites; no ledger
row was added, dropped, or re-justified.
