### PR TITLE
fix(session): a failed cache bust must not 500 a write that already committed (#4304)

### DIFF
--- a/src/server/controllers/__tests__/user.controller.leaderboard-showcase.test.ts
+++ b/src/server/controllers/__tests__/user.controller.leaderboard-showcase.test.ts
@@ -27,7 +27,12 @@ vi.mock('~/server/search-index', () => ({
   usersSearchIndex: { queueUpdate: vi.fn() },
 }));
 vi.mock('~/server/cloudflare/client', () => ({ purgeCache: vi.fn(() => ({ catch: vi.fn() })) }));
-vi.mock('~/server/auth/session-invalidation', () => ({ refreshSession: vi.fn() }));
+// `refreshSession` is `async`, so the stub has to return a PROMISE — a bare `vi.fn()` returns
+// undefined, which type-checks past the mock boundary and then explodes on any `.then`/`.catch`
+// the caller attaches. Matches the global stub in `src/__tests__/setup.ts`.
+vi.mock('~/server/auth/session-invalidation', () => ({
+  refreshSession: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { updateUserHandler } from '~/server/controllers/user.controller';
 

--- a/src/server/controllers/__tests__/user.controller.session-bust-failure.test.ts
+++ b/src/server/controllers/__tests__/user.controller.session-bust-failure.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as UserService from '~/server/services/user.service';
+import type * as ErrorHandling from '~/server/utils/errorHandling';
+
+/**
+ * A cache-invalidation failure must not turn a COMMITTED write into a 500 (#4304).
+ *
+ * The chain under test is real, not stubbed:
+ *
+ *   <handler>  ──▶ refreshSession ──▶ updateSessionState ──▶ clearSessionCache
+ *                                                              ├─ sessionClient.invalidate(userId)
+ *                                                              │    └─ .catch(() => redis.del(sessionKey))
+ *                                                              └─ redis.del(<3 more per-user keys>)
+ *
+ * `updateSessionState` is deliberately fail-open on BOTH sysRedis legs (its own comments say so),
+ * but `clearSessionCache` is awaited OUTSIDE that guard and only the hub hop has a `.catch` — and
+ * that `.catch` falls back to a bare `redis.del`. So when the cache redis is unreachable, the
+ * fallback rejects, `refreshSession` rejects, and at an unguarded call site the rejection lands in
+ * the handler's own `catch { throwDbError }`. The row is already written at that point: the user is
+ * told the mutation failed, and a retrying client re-applies a write that already succeeded.
+ *
+ * 🔴 These assert the OUTCOME, not the presence of a `.catch`. A `.catch(e => { throw e })` passes a
+ * structural check and fails every test here. The logging assertion is the other half: the guard has
+ * to degrade to TTL-bounded staleness *visibly*, never silently.
+ *
+ * The pre-existing `session-invalidation.test.ts` cannot see any of this — it mocks
+ * `../session-cache` to a resolved no-op, so the one leg that can throw is stubbed out.
+ */
+
+// Defeat the global stub from `src/__tests__/setup.ts`; without it `refreshSession` is a `vi.fn()`
+// that resolves, the failure below is never injected, and every test here passes vacuously.
+vi.unmock('~/server/auth/session-invalidation');
+
+const {
+  sharedCache,
+  hubInvalidate,
+  mockHandleLogError,
+  mockUpdateUserById,
+  mockGetUserById,
+  mockGetUserSettings,
+  mockPatchUserSettings,
+  mockQueueUpdate,
+  mockUpdateLeaderboardRank,
+} = vi.hoisted(() => ({
+  sharedCache: new Map<string, unknown>(),
+  hubInvalidate: vi.fn(),
+  mockHandleLogError: vi.fn(),
+  mockUpdateUserById: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockGetUserSettings: vi.fn(),
+  mockPatchUserSettings: vi.fn(),
+  mockQueueUpdate: vi.fn(),
+  mockUpdateLeaderboardRank: vi.fn(),
+}));
+
+vi.mock('~/server/auth/session-client', () => ({
+  sessionClient: { invalidate: hubInvalidate },
+}));
+vi.mock('~/server/services/orchestrator/civitai', () => ({
+  invalidateCivitaiUser: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('~/utils/signal-client', () => ({
+  signalClient: { send: vi.fn().mockResolvedValue(undefined) },
+}));
+// Spread the original: the controller pulls `throwDbError` / `throwAuthorizationError` / … from
+// here, and a wholesale stub would make a thrown TRPCError indistinguishable from a stub artifact.
+vi.mock('~/server/utils/errorHandling', async (importOriginal) => ({
+  ...(await importOriginal<typeof ErrorHandling>()),
+  handleLogError: mockHandleLogError,
+}));
+vi.mock('~/server/services/user.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof UserService>()),
+  getUserById: mockGetUserById,
+  updateUserById: mockUpdateUserById,
+  updateLeaderboardRankForUsers: mockUpdateLeaderboardRank,
+  equipCosmetic: vi.fn(),
+  unequipCosmeticByType: vi.fn(),
+  createUserReferral: vi.fn(),
+  isUsernamePermitted: vi.fn(async () => true),
+  getUserSettings: mockGetUserSettings,
+  patchUserSettings: mockPatchUserSettings,
+  queueModelMetricPrivacyReindex: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ingestImage: vi.fn(),
+  deleteImageById: vi.fn(),
+}));
+vi.mock('~/server/search-index', () => ({ usersSearchIndex: { queueUpdate: mockQueueUpdate } }));
+vi.mock('~/server/cloudflare/client', () => ({ purgeCache: vi.fn(() => ({ catch: vi.fn() })) }));
+
+import { REDIS_KEYS } from '@civitai/redis';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { OnboardingSteps } from '~/server/common/enums';
+import {
+  completeOnboardingHandler,
+  setUserSettingHandler,
+  updateUserHandler,
+} from '~/server/controllers/user.controller';
+
+const USER_ID = 5;
+const sessionKey = (userId: number) => `${REDIS_KEYS.USER.SESSION}:${userId}`;
+const REDIS_DOWN = 'cache redis unreachable';
+
+/** The cache redis is gone: every `del` rejects, so `clearSessionCache`'s hub FALLBACK rejects too. */
+const breakCacheRedis = () => {
+  hubInvalidate.mockRejectedValue(new Error('hub unreachable'));
+  redisMock.redis.del.mockRejectedValue(new Error(REDIS_DOWN));
+};
+
+const ctx = () => ({ user: { id: USER_ID }, features: {}, domain: 'blue' } as never);
+
+const completeOnboarding = () =>
+  completeOnboardingHandler({
+    ctx: { user: { id: USER_ID, onboarding: 0 }, domain: 'blue' },
+    input: { step: OnboardingSteps.BrowsingLevels },
+  } as never);
+
+const updateUser = () =>
+  updateUserHandler({
+    ctx: ctx(),
+    input: { id: USER_ID, username: 'ada-renamed' },
+  } as never);
+
+const setSetting = () => setUserSettingHandler({ ctx: ctx(), input: { allowAds: false } } as never);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sharedCache.clear();
+
+  mockGetUserById.mockResolvedValue({ profilePictureId: null });
+  mockUpdateUserById.mockResolvedValue({ id: USER_ID, username: 'ada-renamed' });
+  mockGetUserSettings.mockResolvedValue({ allowAds: true });
+  mockPatchUserSettings.mockResolvedValue({ allowAds: false });
+  mockQueueUpdate.mockResolvedValue(undefined);
+  mockUpdateLeaderboardRank.mockResolvedValue(undefined);
+
+  // Healthy default — a real keyspace so a successful bust is OBSERVABLE (the positive control).
+  redisMock.redis.del.mockImplementation(async (key: string) => (sharedCache.delete(key) ? 1 : 0));
+  redisMock.sysRedis.hScanNoValues.mockResolvedValue({ cursor: '0', fields: [] });
+  hubInvalidate.mockImplementation(async (userId: number) => {
+    sharedCache.delete(sessionKey(userId));
+  });
+});
+
+describe('positive control — the injection reaches a real bust', () => {
+  it('a HEALTHY cache redis actually busts the session entry', async () => {
+    // Without this the "resolves" assertions below would be indistinguishable from a chain wired to
+    // nothing: a `refreshSession` that never touches redis also never rejects.
+    sharedCache.set(sessionKey(USER_ID), { id: USER_ID });
+
+    await updateUser();
+
+    expect(sharedCache.has(sessionKey(USER_ID))).toBe(false);
+  });
+
+  it('a BROKEN cache redis makes refreshSession itself reject', async () => {
+    // The premise of #4304, asserted directly rather than assumed: `updateSessionState` is fail-open
+    // on its sysRedis legs, but `clearSessionCache` is not, so this rejects.
+    breakCacheRedis();
+    const { refreshSession } = await import('~/server/auth/session-invalidation');
+
+    await expect(refreshSession(USER_ID, { sendSignal: false })).rejects.toThrow(REDIS_DOWN);
+  });
+});
+
+describe('completeOnboardingHandler', () => {
+  it('still resolves when the session bust fails, after the step is committed', async () => {
+    breakCacheRedis();
+
+    await expect(completeOnboarding()).resolves.not.toThrow();
+  });
+
+  it('reports the failed bust instead of swallowing it', async () => {
+    breakCacheRedis();
+
+    await completeOnboarding();
+
+    expect(mockHandleLogError).toHaveBeenCalledTimes(1);
+    expect(mockHandleLogError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect((mockHandleLogError.mock.calls[0][0] as Error).message).toContain(REDIS_DOWN);
+  });
+
+  it('logs nothing when the bust succeeds', async () => {
+    await completeOnboarding();
+
+    expect(mockHandleLogError).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateUserHandler (the Promise.all batch)', () => {
+  it('still returns the updated user when the session bust fails', async () => {
+    breakCacheRedis();
+
+    // The row is written before the batch runs, so the only correct response is the written row.
+    await expect(updateUser()).resolves.toMatchObject({ id: USER_ID, username: 'ada-renamed' });
+    expect(mockUpdateUserById).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not take the rest of the batch down with it', async () => {
+    // `Promise.all` rejects on the FIRST rejection. Guarding the member (rather than the batch)
+    // is what keeps the other post-update work reportable on its own terms.
+    breakCacheRedis();
+
+    await updateUser();
+
+    expect(mockQueueUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('STILL fails when a different batch member fails — the guard is narrow', async () => {
+    // The counterpart property. Guarding the whole `Promise.all` would have swallowed this too,
+    // which is the failure mode "don't make it fail silently" is about.
+    mockUpdateLeaderboardRank.mockRejectedValue(new Error('leaderboard write failed'));
+
+    await expect(
+      updateUserHandler({
+        ctx: ctx(),
+        input: { id: USER_ID, username: 'ada-renamed', leaderboardShowcase: 'overall' },
+      } as never)
+    ).rejects.toThrow();
+  });
+});
+
+describe('setUserSettingHandler', () => {
+  it('still returns the stored settings when the session bust fails', async () => {
+    breakCacheRedis();
+
+    await expect(setSetting()).resolves.toMatchObject({ allowAds: false });
+    expect(mockPatchUserSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the failed bust instead of swallowing it', async () => {
+    breakCacheRedis();
+
+    await setSetting();
+
+    expect(mockHandleLogError).toHaveBeenCalledTimes(1);
+    expect((mockHandleLogError.mock.calls[0][0] as Error).message).toContain(REDIS_DOWN);
+  });
+});

--- a/src/server/controllers/__tests__/user.controller.session-bust-failure.test.ts
+++ b/src/server/controllers/__tests__/user.controller.session-bust-failure.test.ts
@@ -207,6 +207,20 @@ describe('updateUserHandler (the Promise.all batch)', () => {
     expect(mockQueueUpdate).toHaveBeenCalledTimes(1);
   });
 
+  it('reports the failed bust instead of swallowing it', async () => {
+    // Without this the site is killed by `.catch(handleLogError)` → `.catch(() => undefined)` only
+    // if some OTHER assertion happens to notice — and none would. A silent swallow inside a
+    // `Promise.all` member is the most invisible variant of this defect: nothing throws, nothing
+    // logs, and a cache outage looks exactly like a healthy deploy.
+    breakCacheRedis();
+
+    await updateUser();
+
+    expect(mockHandleLogError).toHaveBeenCalledTimes(1);
+    expect(mockHandleLogError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect((mockHandleLogError.mock.calls[0][0] as Error).message).toContain(REDIS_DOWN);
+  });
+
   it('STILL fails when a different batch member fails — the guard is narrow', async () => {
     // The counterpart property. Guarding the whole `Promise.all` would have swallowed this too,
     // which is the failure mode "don't make it fail silently" is about.

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -461,7 +461,13 @@ export const completeOnboardingHandler = async ({
     // in the database with the old one in the session for the rest of its 4h TTL. Bust on either condition.
     const wroteSessionIdentity =
       input.step === OnboardingSteps.Profile && (!!input.username || !!input.email);
-    if (changed || wroteSessionIdentity) await refreshSession(id, { caller: 'profile' });
+    // Best-effort, like the sibling call in `user.service.ts:updateUserContentSettings`. The onboarding
+    // step above is already COMMITTED by the time we get here, so letting an invalidation failure reach
+    // the `catch` below would `throwDbError` a mutation that succeeded — the client is told the step
+    // failed and re-submits an already-applied write. A failed bust degrades to staleness bounded by the
+    // entry's own 4h TTL, which is strictly better than that. Logged, never swallowed silently.
+    if (changed || wroteSessionIdentity)
+      await refreshSession(id, { caller: 'profile' }).catch(handleLogError);
 
     const isComplete = onboarding === OnboardingComplete;
     if (isComplete && changed && onboardingCompletedCounter) onboardingCompletedCounter.inc();
@@ -631,7 +637,11 @@ export const updateUserHandler = async ({
 
     purgeCache({ tags: [`user-creator-${id}`] }).catch();
 
-    postUpdatePromises.push(refreshSession(id, { caller: 'profile' }));
+    // The `.catch` is attached BEFORE the push, not around the `Promise.all` below: this batch runs after
+    // the user row is already written, and `Promise.all` rejects on the FIRST rejection, so an unguarded
+    // cache bust here both `throwDbError`s a committed write and masks whatever the other members did.
+    // Guarding this one member keeps the rest of the batch reporting its own failures normally.
+    postUpdatePromises.push(refreshSession(id, { caller: 'profile' }).catch(handleLogError));
 
     await Promise.all(postUpdatePromises);
 
@@ -1498,7 +1508,11 @@ export const setUserSettingHandler = async ({
     const sessionProjectedSettingChanged = SESSION_PROJECTED_SETTING_KEYS.some(
       (key) => key in restInput && restSettings[key] !== restInput[key]
     );
-    if (sessionProjectedSettingChanged) await refreshSession(id, { caller: 'profile' });
+    // Best-effort — the settings write above has already committed, so an invalidation failure must not
+    // reach the `throwDbError` below and report a succeeded mutation as a 500. Staleness is bounded by
+    // the cached entry's own TTL; a misreported write is not bounded by anything.
+    if (sessionProjectedSettingChanged)
+      await refreshSession(id, { caller: 'profile' }).catch(handleLogError);
 
     return newSettings;
   } catch (error) {

--- a/src/server/routers/__tests__/user.router.browsing-mode-session-bust.test.ts
+++ b/src/server/routers/__tests__/user.router.browsing-mode-session-bust.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import type * as UserService from '~/server/services/user.service';
+import type * as ErrorHandling from '~/server/utils/errorHandling';
+
+/**
+ * `user.updateBrowsingMode` — the fourth site of #4304's defect class, and the one the issue did
+ * not list because it lives in the router rather than the controller.
+ *
+ * The shape is identical: `updateUserById` commits, then the session cache bust is awaited with
+ * nothing catching it, so an unreachable cache redis turns a succeeded mutation into a 500. A
+ * browsing-mode toggle is one of the highest-frequency writes on the site and the client re-submits
+ * on failure, so this is the site most likely to actually produce the re-applied-write symptom.
+ *
+ * Driven through the REAL router with `createCaller`, so the assertion is about what a caller
+ * observes rather than about how the procedure was written.
+ */
+
+const { mockUpdateUserById, mockHandleLogError } = vi.hoisted(() => ({
+  mockUpdateUserById: vi.fn(),
+  mockHandleLogError: vi.fn(),
+}));
+
+vi.mock('~/server/services/user.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof UserService>()),
+  updateUserById: mockUpdateUserById,
+}));
+
+vi.mock('~/server/utils/errorHandling', async (importOriginal) => ({
+  ...(await importOriginal<typeof ErrorHandling>()),
+  handleLogError: mockHandleLogError,
+}));
+
+import { refreshSession } from '~/server/auth/session-invalidation';
+import { userRouter } from '~/server/routers/user.router';
+
+const USER_ID = 31;
+const REDIS_DOWN = 'cache redis unreachable';
+
+// `guardedProcedure` = protected + onboarded + not-muted, so the fixture user has to satisfy all
+// three or the test measures the middleware rather than the handler.
+const user = {
+  id: USER_ID,
+  isModerator: false,
+  tier: 'free',
+  username: 'ada',
+  muted: false,
+  onboarding: 0xff,
+};
+
+const caller = () =>
+  userRouter.createCaller({
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} },
+    res: { setHeader: () => undefined },
+    cache: { edgeTTL: 0 },
+    features: {},
+    track: undefined,
+  } as never);
+
+const refreshSessionMock = vi.mocked(refreshSession);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUpdateUserById.mockResolvedValue({ id: USER_ID });
+  refreshSessionMock.mockResolvedValue(undefined);
+});
+
+describe('user.updateBrowsingMode', () => {
+  it('positive control — the bust is actually reached on the happy path', async () => {
+    await caller().updateBrowsingMode({ showNsfw: true });
+
+    expect(refreshSessionMock).toHaveBeenCalledWith(USER_ID, { caller: 'browsing-mode' });
+  });
+
+  it('still resolves when the session bust fails, after the toggle is committed', async () => {
+    refreshSessionMock.mockRejectedValue(new Error(REDIS_DOWN));
+
+    await expect(caller().updateBrowsingMode({ showNsfw: true })).resolves.not.toThrow();
+    expect(mockUpdateUserById).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs the failed bust rather than swallowing it', async () => {
+    refreshSessionMock.mockRejectedValue(new Error(REDIS_DOWN));
+
+    await caller().updateBrowsingMode({ showNsfw: true });
+
+    expect(mockHandleLogError).toHaveBeenCalledTimes(1);
+    expect((mockHandleLogError.mock.calls[0][0] as Error).message).toBe(REDIS_DOWN);
+  });
+
+  it('still FAILS when the toggle write itself fails', async () => {
+    mockUpdateUserById.mockRejectedValue(new Error('db write failed'));
+
+    await expect(caller().updateBrowsingMode({ showNsfw: true })).rejects.toThrow();
+  });
+});

--- a/src/server/routers/user.router.ts
+++ b/src/server/routers/user.router.ts
@@ -106,6 +106,7 @@ import {
 import { CacheTTL } from '~/server/common/constants';
 import { edgeCacheIt, rateLimit } from '~/server/middleware.trpc';
 import { refreshSession } from '~/server/auth/session-invalidation';
+import { handleLogError } from '~/server/utils/errorHandling';
 import { createTipaltiPayee } from '~/server/services/user-payment-configuration.service';
 import { addSystemPermission } from '~/server/services/system-cache';
 import { createNotification } from '~/server/services/notification.service';
@@ -224,7 +225,9 @@ export const userRouter = router({
         data: input,
         updateSource: 'updateBrowsingMode',
       });
-      await refreshSession(ctx.user.id, { caller: 'browsing-mode' });
+      // Same shape as the controller sites: the row is written above, so an unreachable cache redis
+      // must not turn a committed write into a 500 the client retries. Best-effort + logged.
+      await refreshSession(ctx.user.id, { caller: 'browsing-mode' }).catch(handleLogError);
     }),
   delete: protectedProcedure
     .meta({ requiredScope: TokenScope.Full })

--- a/src/server/services/__tests__/creator-program.service.test.ts
+++ b/src/server/services/__tests__/creator-program.service.test.ts
@@ -95,6 +95,13 @@ vi.mock('~/server/prom/client', () => ({ userUpdateCounter: { inc: vi.fn() } }))
 vi.mock('~/utils/errorHandling', () => ({
   withRetries: vi.fn(async (fn: () => Promise<any>) => fn()),
 }));
+// NOTE: a DIFFERENT module from `~/utils/errorHandling` above — this is the server-side one that
+// owns `handleLogError` / `throwBadRequestError`. Spread the original so the throw helpers stay real.
+const { mockHandleLogError } = vi.hoisted(() => ({ mockHandleLogError: vi.fn() }));
+vi.mock('~/server/utils/errorHandling', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/server/utils/errorHandling')>()),
+  handleLogError: mockHandleLogError,
+}));
 
 // ── Import the service under test ──────────────────────────────────────────────
 import {
@@ -110,6 +117,8 @@ import {
 } from '~/server/services/creator-program.service';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
+// Globally stubbed in `src/__tests__/setup.ts` — imported here only to drive its rejection.
+import { refreshSession } from '~/server/auth/session-invalidation';
 const mockDbWrite = dbMock.dbWrite;
 const mockSysRedis = redisMock.sysRedis;
 
@@ -274,6 +283,59 @@ describe('joinCreatorsProgram', () => {
     );
 
     await expect(joinCreatorsProgram(userId)).rejects.toThrow();
+  });
+
+  // ── #4304: a failed cache bust must not 500 a committed join ────────────────
+  //
+  // Same shape as the five sites in the issue's PR, and the same COLUMN as
+  // `completeOnboardingHandler`: the `onboarding` bitmask is written by the raw UPDATE above, then
+  // the session cache is busted. Reachable from tRPC `creatorProgram.joinCreatorsProgram`
+  // (protectedProcedure) and `pages/api/v1/creator-program/join.ts`, so an unreachable cache redis
+  // used to hand the user a 500 for a membership they had already joined — and the client's retry
+  // re-runs a requirements check that now passes against a row that already has the flag set.
+  const armJoin = () => {
+    mockDbWrite.$queryRaw.mockResolvedValueOnce([
+      { score: MIN_CREATOR_SCORE + 1000, membership: 'silver' },
+    ]);
+    mockDbWrite.user.findFirstOrThrow.mockResolvedValueOnce(mockUser());
+    mockDbWrite.$executeRaw.mockResolvedValueOnce(undefined);
+  };
+
+  it('positive control — the bust is actually reached on the happy path', async () => {
+    armJoin();
+
+    await joinCreatorsProgram(userId);
+
+    expect(vi.mocked(refreshSession)).toHaveBeenCalledWith(userId, { caller: 'membership' });
+  });
+
+  it('still resolves when the session bust fails, after the join is committed', async () => {
+    armJoin();
+    vi.mocked(refreshSession).mockRejectedValueOnce(new Error('cache redis unreachable'));
+
+    await expect(joinCreatorsProgram(userId)).resolves.not.toThrow();
+    // The bitmask really was written — that is what makes a 500 here a lie rather than a warning.
+    expect(mockDbWrite.$executeRaw).toHaveBeenCalled();
+  });
+
+  it('logs the failed bust rather than swallowing it', async () => {
+    armJoin();
+    vi.mocked(refreshSession).mockRejectedValueOnce(new Error('cache redis unreachable'));
+
+    await joinCreatorsProgram(userId);
+
+    expect(mockHandleLogError).toHaveBeenCalledTimes(1);
+    expect((mockHandleLogError.mock.calls[0][0] as Error).message).toBe('cache redis unreachable');
+  });
+
+  it('STILL fails when the join write itself fails — the guard is narrow', async () => {
+    mockDbWrite.$queryRaw.mockResolvedValueOnce([
+      { score: MIN_CREATOR_SCORE + 1000, membership: 'silver' },
+    ]);
+    mockDbWrite.user.findFirstOrThrow.mockResolvedValueOnce(mockUser());
+    mockDbWrite.$executeRaw.mockRejectedValueOnce(new Error('db write failed'));
+
+    await expect(joinCreatorsProgram(userId)).rejects.toThrow('db write failed');
   });
 });
 

--- a/src/server/services/__tests__/email-verification.session-bust-failure.test.ts
+++ b/src/server/services/__tests__/email-verification.session-bust-failure.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as ErrorHandling from '~/server/utils/errorHandling';
+
+/**
+ * The email-change pair, same defect class as #4304's controller sites.
+ *
+ * `confirmEmailChange` is the worst instance in the codebase: by the time it busts the session
+ * cache the email column is written AND the one-time token has been deleted from redis. A
+ * rejection there does not merely misreport a committed write — it misreports one the user
+ * CANNOT retry, because the link in their inbox is already spent. `requestEmailChange` is the
+ * same shape one step earlier: the verification email has been sent and the token issued.
+ *
+ * Asserted as OUTCOMES (the call resolves, with its success payload, and the failure is logged),
+ * not as the presence of a `.catch` — `.catch(e => { throw e })` would satisfy a structural check
+ * and fail every test here.
+ */
+
+const { mockHandleLogError } = vi.hoisted(() => ({ mockHandleLogError: vi.fn() }));
+
+vi.mock('~/server/utils/errorHandling', async (importOriginal) => ({
+  ...(await importOriginal<typeof ErrorHandling>()),
+  handleLogError: mockHandleLogError,
+}));
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }));
+vi.mock('~/server/email/templates/emailVerification.email', () => ({
+  emailVerificationEmail: { send: mockSend },
+}));
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { refreshSession } from '~/server/auth/session-invalidation';
+import { confirmEmailChange, requestEmailChange } from '../email-verification.service';
+
+const USER_ID = 77;
+const NEW_EMAIL = 'ada@example.test';
+const TOKEN = 'deadbeef';
+const REDIS_DOWN = 'cache redis unreachable';
+
+/** The global setup stub; `.mockRejectedValue` models the whole chain in `session-invalidation`. */
+const refreshSessionMock = vi.mocked(refreshSession);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  refreshSessionMock.mockResolvedValue(undefined);
+  mockSend.mockResolvedValue(undefined);
+
+  dbMock.dbRead.user.findFirst.mockResolvedValue(null);
+  dbMock.dbRead.user.findUnique.mockResolvedValue({ email: 'old@example.test', username: 'ada' });
+  dbMock.dbWrite.user.update.mockResolvedValue({ id: USER_ID });
+
+  redisMock.redis.set.mockResolvedValue('OK');
+  redisMock.redis.get.mockResolvedValue(
+    JSON.stringify({ userId: USER_ID, newEmail: NEW_EMAIL, createdAt: new Date().toISOString() })
+  );
+  redisMock.redis.del.mockResolvedValue(1);
+});
+
+describe('confirmEmailChange', () => {
+  it('positive control — the refresh is actually reached on the happy path', async () => {
+    // Without this, "still resolves" below is indistinguishable from a call that never happens.
+    await confirmEmailChange(TOKEN);
+
+    expect(refreshSessionMock).toHaveBeenCalledWith(USER_ID, { caller: 'email-verification' });
+  });
+
+  it('still reports success when the session bust fails', async () => {
+    refreshSessionMock.mockRejectedValue(new Error(REDIS_DOWN));
+
+    await expect(confirmEmailChange(TOKEN)).resolves.toMatchObject({ success: true });
+    // The email really was changed — that is what makes a 500 here a lie, not a warning.
+    expect(dbMock.dbWrite.user.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs the failed bust rather than swallowing it', async () => {
+    refreshSessionMock.mockRejectedValue(new Error(REDIS_DOWN));
+
+    await confirmEmailChange(TOKEN);
+
+    expect(mockHandleLogError).toHaveBeenCalledTimes(1);
+    expect((mockHandleLogError.mock.calls[0][0] as Error).message).toBe(REDIS_DOWN);
+  });
+
+  it('still FAILS when the email write itself fails', async () => {
+    // The guard has to stay on the cache bust. A real write failure must still surface.
+    dbMock.dbWrite.user.update.mockRejectedValue(new Error('db write failed'));
+
+    await expect(confirmEmailChange(TOKEN)).rejects.toThrow('db write failed');
+  });
+});
+
+describe('requestEmailChange', () => {
+  it('still reports success when the session bust fails, after the email is sent', async () => {
+    refreshSessionMock.mockRejectedValue(new Error(REDIS_DOWN));
+
+    await expect(requestEmailChange(USER_ID, NEW_EMAIL)).resolves.toMatchObject({ success: true });
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('still FAILS when sending the verification email fails', async () => {
+    mockSend.mockRejectedValue(new Error('smtp down'));
+
+    await expect(requestEmailChange(USER_ID, NEW_EMAIL)).rejects.toThrow('smtp down');
+  });
+});

--- a/src/server/services/__tests__/email-verification.session-bust-failure.test.ts
+++ b/src/server/services/__tests__/email-verification.session-bust-failure.test.ts
@@ -97,6 +97,18 @@ describe('requestEmailChange', () => {
     expect(mockSend).toHaveBeenCalledTimes(1);
   });
 
+  it('logs the failed bust rather than swallowing it', async () => {
+    // The sibling of the `confirmEmailChange` assertion below. Without it, `.catch(handleLogError)`
+    // here is indistinguishable from `.catch(() => undefined)` — degrading to TTL-bounded staleness
+    // is only acceptable because the degradation is VISIBLE.
+    refreshSessionMock.mockRejectedValue(new Error(REDIS_DOWN));
+
+    await requestEmailChange(USER_ID, NEW_EMAIL);
+
+    expect(mockHandleLogError).toHaveBeenCalledTimes(1);
+    expect((mockHandleLogError.mock.calls[0][0] as Error).message).toBe(REDIS_DOWN);
+  });
+
   it('still FAILS when sending the verification email fails', async () => {
     mockSend.mockRejectedValue(new Error('smtp down'));
 

--- a/src/server/services/creator-program.service.ts
+++ b/src/server/services/creator-program.service.ts
@@ -44,7 +44,7 @@ import {
   getWithdrawalFee,
   getWithdrawalRefCode,
 } from '~/server/utils/creator-program.utils';
-import { throwBadRequestError } from '~/server/utils/errorHandling';
+import { handleLogError, throwBadRequestError } from '~/server/utils/errorHandling';
 import { refreshSession } from '~/server/auth/session-invalidation';
 import type { CapDefinition } from '~/shared/constants/creator-program.constants';
 import {
@@ -311,7 +311,11 @@ export async function joinCreatorsProgram(userId: number) {
 
   userUpdateCounter?.inc({ location: 'creator-program.service:completeOnboarding' });
 
-  await refreshSession(userId, { caller: 'membership' });
+  // Best-effort — the `onboarding` bitmask write above has already committed, and it is the SAME
+  // column `completeOnboardingHandler` writes, so an unguarded bust here fails a joined-and-recorded
+  // membership with a 500 and invites the client to re-join. Staleness is bounded by the session
+  // entry's own TTL. Logged, never swallowed silently.
+  await refreshSession(userId, { caller: 'membership' }).catch(handleLogError);
 }
 
 async function getPoolValue(month?: Date) {

--- a/src/server/services/email-verification.service.ts
+++ b/src/server/services/email-verification.service.ts
@@ -112,7 +112,12 @@ export async function requestEmailChange(userId: number, newEmail: string) {
   // Send verification email
   await sendVerificationEmail(newEmail, user.username || 'User', token);
 
-  // Invalidate the user's session to ensure they re-authenticate after email change.
+  // Refresh the cached session shape. 🔴 This does NOT log the user out or force a re-authentication
+  // — `refreshSession` marks the user's tokens `refresh` and busts the shaped session-user entry;
+  // only `invalidateSession` marks them `invalid`. (The comment here used to claim re-authentication,
+  // which would make the `.catch` below read as downgrading a security control. There is no such
+  // control on this path, and nothing on the user row has changed yet at this point.)
+  //
   // Best-effort: the verification email has already been SENT and the token issued, so a failed
   // cache bust must not 500 this call — the user would see "failed", re-request, and receive a
   // second email for work that already succeeded. Logged rather than swallowed.
@@ -134,7 +139,8 @@ export async function confirmEmailChange(token: string) {
 
   userUpdateCounter?.inc({ location: 'email-verification.service:confirmEmailChange' });
 
-  // Invalidate the user's session after successful email change.
+  // Refresh the cached session shape so the new email is served rather than the old one. As above,
+  // this is a REFRESH, not a logout — see the note in `requestEmailChange`.
   // 🔴 Best-effort is load-bearing here: the email column is already written AND the one-time token
   // has been consumed, so a throw would report a permanent failure for a change that succeeded and
   // that the user can no longer retry (the link is spent). Staleness is bounded by the session

--- a/src/server/services/email-verification.service.ts
+++ b/src/server/services/email-verification.service.ts
@@ -2,7 +2,11 @@ import { randomBytes } from 'crypto';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { env } from '~/env/server';
 import { emailVerificationEmail } from '~/server/email/templates/emailVerification.email';
-import { throwBadRequestError, throwNotFoundError } from '~/server/utils/errorHandling';
+import {
+  handleLogError,
+  throwBadRequestError,
+  throwNotFoundError,
+} from '~/server/utils/errorHandling';
 import { REDIS_KEYS, redis } from '~/server/redis/client';
 import { refreshSession } from '~/server/auth/session-invalidation';
 import { userUpdateCounter } from '~/server/prom/client';
@@ -108,8 +112,11 @@ export async function requestEmailChange(userId: number, newEmail: string) {
   // Send verification email
   await sendVerificationEmail(newEmail, user.username || 'User', token);
 
-  // Invalidate the user's session to ensure they re-authenticate after email change
-  await refreshSession(userId, { caller: 'email-verification' });
+  // Invalidate the user's session to ensure they re-authenticate after email change.
+  // Best-effort: the verification email has already been SENT and the token issued, so a failed
+  // cache bust must not 500 this call — the user would see "failed", re-request, and receive a
+  // second email for work that already succeeded. Logged rather than swallowed.
+  await refreshSession(userId, { caller: 'email-verification' }).catch(handleLogError);
 
   return { success: true, message: 'Verification email sent' };
 }
@@ -127,8 +134,12 @@ export async function confirmEmailChange(token: string) {
 
   userUpdateCounter?.inc({ location: 'email-verification.service:confirmEmailChange' });
 
-  // Invalidate the user's session after successful email change
-  await refreshSession(userId, { caller: 'email-verification' });
+  // Invalidate the user's session after successful email change.
+  // 🔴 Best-effort is load-bearing here: the email column is already written AND the one-time token
+  // has been consumed, so a throw would report a permanent failure for a change that succeeded and
+  // that the user can no longer retry (the link is spent). Staleness is bounded by the session
+  // entry's own TTL; a misreported, unretryable write is not.
+  await refreshSession(userId, { caller: 'email-verification' }).catch(handleLogError);
 
   return { success: true, message: 'Email address updated successfully' };
 }

--- a/src/server/services/orchestrator/__tests__/promptAuditing.soft-block.test.ts
+++ b/src/server/services/orchestrator/__tests__/promptAuditing.soft-block.test.ts
@@ -55,7 +55,12 @@ vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() })
 vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
 vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
 vi.mock('~/server/services/user.service', () => ({ updateUserById: mockUpdateUserById }));
-vi.mock('~/server/auth/session-invalidation', () => ({ refreshSession: vi.fn() }));
+// `refreshSession` is `async`, so the stub must return a PROMISE — a bare `vi.fn()` returns
+// undefined and explodes on any `.then`/`.catch` a caller attaches. Latent here today; the same
+// stub in user.controller.leaderboard-showcase.test.ts broke the moment a `.catch` was added.
+vi.mock('~/server/auth/session-invalidation', () => ({
+  refreshSession: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock('~/server/utils/cache-helpers', () => ({
   fetchThroughCache: vi.fn(),
   bustFetchThroughCache: vi.fn(),


### PR DESCRIPTION
Closes #4304.

## The premise, verified end to end

The issue's mechanism holds. Reading the chain rather than trusting the description:

- `updateSessionState` is **deliberately fail-open on both sysRedis legs** — the HSCAN read is wrapped in `withSysReadDeadline` + try/catch, and the `hSetMultiWithTTL` write swallows its error. Both log a `sysredis-fail-open` event. Its own comments say a throw there "would 500 the user-facing request".
- But it then `await`s `clearSessionCache(userId)` **outside** that guard, and `clearSessionCache` is a `Promise.all` of five legs of which only the first has a `.catch` — and that `.catch` falls back to a bare `redis.del`. The other three `redis.del` calls are unguarded. (`invalidateCivitaiUser`, the fifth, never throws.)

So when the cache redis is unreachable, the fallback rejects → `refreshSession` rejects → at an unguarded call site the rejection lands in the handler's own `catch { throwDbError }`, **after the database write has committed**. Reproduced in the new controller suite as exactly `TRPCError { code: 'INTERNAL_SERVER_ERROR' }` caused by `Error: cache redis unreachable`.

Worth noting why this was never caught: the existing `session-invalidation.test.ts` mocks `../session-cache` to a resolved no-op, so the one leg that can throw is stubbed out of the only suite that tests this function's fail-open posture. The suite's header presents it as covering "the outer function does not throw" — which it does faithfully for the two legs that were *already* guarded, while stubbing the third. A suite scoped to the mechanism someone already fixed passes vacuously over the sibling leg nobody fixed, and its reassuring name is what stops anyone looking.

## The fix

`.catch(handleLogError)` at each site — the established pattern in this repo (44 other call sites, 5 of them already in `user.controller.ts`), and the posture the sibling `user.service.ts:updateUserContentSettings` already takes. `handleLogError` logs to Axiom in prod rather than the sibling's `console.error`, so the failure stays visible. The degradation is staleness bounded by the cached entry's own TTL.

## Sites changed (6)

| Site | Committed before the bust |
|---|---|
| `user.controller.ts` `completeOnboardingHandler` | the onboarding step (+ username/email on the Profile step) |
| `user.controller.ts` `updateUserHandler` | the user row |
| `user.controller.ts` `setUserSettingHandler` | the settings patch |
| `user.router.ts` `updateBrowsingMode` | the browsing-mode row |
| `email-verification.service.ts` `requestEmailChange` / `confirmEmailChange` | the verification email sent / the email column written **and the one-time token consumed** |
| `creator-program.service.ts` `joinCreatorsProgram` | the `onboarding` bitmask (raw `UPDATE`) |

**Three of these were not in the issue.**

- **`updateBrowsingMode`** — same shape (`updateUserById` commits, then an unguarded awaited `refreshSession`), and the highest-frequency write of the six with a client that re-submits on failure, so it is the site most likely to actually produce the re-applied-write symptom.
- **`confirmEmailChange`** is the worst instance. By the time it busts, the email column is written *and* `verifyEmailChangeToken` has deleted the token from redis (`:75` delete → `:130` write → `:142` bust). A rejection misreports a committed write that the user cannot retry *via that link*, because it is spent. Scope note, since severity claims deserve one: I confirmed the deletion in code but did not exercise a second click end-to-end, and `requestEmailChange` can re-issue — so the accurate claim is "unretryable by that link", not "unrecoverable".
- **`joinCreatorsProgram`** was missed by my first sweep and found by review. It writes the **same `onboarding` bitmask** as `completeOnboardingHandler`, which I did fix — so the original PR left a site that is not merely analogous but touches the identical column. Reachable from tRPC `creatorProgram.joinCreatorsProgram` (protectedProcedure) and `pages/api/v1/creator-program/join.ts`.

**Correction to an earlier version of this description:** it claimed "every `refreshSession` / `invalidateSession` caller in `src/` was read". That claim was false — `joinCreatorsProgram` is the counterexample. What I can support is that every caller has now been read *and* that the six above are the ones matching the criterion below; I am not restating the stronger claim.

**Out of scope, with reasons:**

- **Moderator / security paths** — `user.service.ts:2104` `toggleContestBan`, `strike.service.ts:500,795`, `user-restriction-resolve.service.ts:66,88`, and the `pages/api/{admin,mod}/*` routes. Same mechanical shape, different judgement: these are operator-facing, and for a ban/mute the invalidation is security-load-bearing, so failing loudly and having a moderator retry is defensible. Flipping them to best-effort is a security-posture decision that deserves its own PR.
- **Webhooks** — `stripe.service.ts:63,293,302`, `paddle.service.ts:76`. A throw makes the provider **retry**, which is correct; swallowing it would lose the invalidation entirely.
- **Background jobs** — `jobs/confirm-mutes.ts`, `jobs/prepaid-membership-jobs.ts`. Not request paths.
- **`redeemableCode.service.ts:279`** — sits in the *already-redeemed* branch, which writes nothing on this call, so the "reports a committed write as failed" argument does not apply.
- **`membership-gift.service.ts:350,569,638`** — `keepGiftMembership` (`:638`) is genuinely user-facing and does 500 after Stripe has already un-cancelled the subscription. Left for a follow-up **because the right fix is a deletion, not a guard**: each of these already calls `invalidateSubscriptionCaches`, which runs `refreshSession` under `allSettled`, so the second call is redundant. Removing it is a different change with its own reasoning and its own blast radius; adding a `.catch` would entrench the redundancy instead.

## The `Promise.all` site specifically

`updateUserHandler` pushes `refreshSession(...)` into `postUpdatePromises`, then `await Promise.all(postUpdatePromises)`. Two things follow, pushing the same way:

1. `Promise.all` rejects on the **first** rejection, so an unguarded bust both `throwDbError`s the committed write *and* masks whatever the other members did.
2. Guarding the **whole `Promise.all`** would be wrong — it would swallow a genuine `ingestImage` / search-index / referral failure too.

So the `.catch` is attached to the member **before the push**. Pinned both ways: one test asserts the other members still run when the bust fails, another asserts the handler **still fails** when a different member (`updateLeaderboardRankForUsers`) fails.

## Test matrix

```
npx vitest run --project 'unit*' \
  src/server/controllers/__tests__/user.controller.session-bust-failure.test.ts \
  src/server/services/__tests__/email-verification.session-bust-failure.test.ts \
  src/server/routers/__tests__/user.router.browsing-mode-session-bust.test.ts \
  src/server/services/__tests__/creator-program.service.test.ts
```

| Tree | Result |
|---|---|
| the four source files at `origin/main`, tests applied | **15 failed / 49 passed — 64 executed** |
| HEAD | **64 passed — 64 executed** |

Across all six affected suites at HEAD: **88 executed, 88 passed.** Full unit suite: **1357 files, 21339 passed, 25 skipped, 0 failed.**

The tests that pass in the base arm are the controls, and they are why the numbers are readable: a positive control that a *healthy* redis really busts the entry (so "resolves" is not a claim about a chain wired to nothing), a direct assertion that `refreshSession` itself rejects when redis is broken, and per-site narrowness controls. Base-arm failures carry the right cause:

```
AssertionError: promise rejected "TRPCError: cache redis unreachable { code: '…' }" instead of resolving
Caused by: TRPCError: cache redis unreachable
Serialized Error: { code: 'INTERNAL_SERVER_ERROR' }
Caused by: Error: cache redis unreachable
```

### Mutation check — two classes, per site, one guard at a time

| Site | drop the `.catch` | `.catch(() => undefined)` |
|---|---|---|
| `completeOnboarding` | 2 killed | 1 killed |
| `updateUser` (the push) | 3 killed | 1 killed — **was SURVIVED** |
| `setUserSetting` | 2 killed | 1 killed |
| `updateBrowsingMode` | 2 killed | 1 killed |
| `requestEmailChange` | 2 killed | 1 killed — **was SURVIVED** |
| `confirmEmailChange` | 2 killed | 1 killed |
| `joinCreatorsProgram` | 2 killed | 1 killed |

Every mutant dies with the cache-redis error rather than an unrelated assertion, and each kills a **disjoint** set, so attribution is per-guard.

**The second class is there because the first was not sufficient, and review caught that.** Dropping the `.catch` entirely is killed by the "still resolves" assertions at every site. But replacing it with a silent swallow is a *different* mutant, and it survived at two sites whose failure tests had no logging assertion — passing the entire suite while making a cache-invalidation failure completely invisible. That is precisely the outcome this PR argues against, and the description already claimed to prevent it. Both sites now carry the assertion.

### Not a spelled guard

Assertions are on the **outcome** — the handler resolves, with its success payload, and the underlying write is observably done. `.catch(e => { throw e })` satisfies a structural "is there a `.catch`" check and kills 11 of 20 of the original tests.

## Incidental fixes

- **`user.controller.leaderboard-showcase.test.ts`** mocked the `async` `refreshSession` as a bare `vi.fn()` returning `undefined`, so attaching any `.catch` threw `Cannot read properties of undefined (reading 'catch')`. Fixed to `.mockResolvedValue(undefined)`.
- **`promptAuditing.soft-block.test.ts`** carried the same stub — latent today, fixed for the same reason.
- **`email-verification.service.ts` comments** claimed the session is invalidated so the user must "re-authenticate". It is not: `refreshSession` marks tokens `refresh` and busts the cached shape; only `invalidateSession` marks them `invalid`. Left uncorrected, adding "best-effort" beside it would read as downgrading a security control that never existed.

## Wider checks

- `pnpm typecheck` — **0 errors**. Instrument validated: an injected `TS2345` on a changed line made it report **1 error / rc=2**.
- Full unit suite — **21339 passed, 25 skipped, 0 failed**.
- `pnpm test:lint-rules` — 12 files, 294 passed.
- **Added** files (the blocking half of the lint job) — **0 ESLint errors, 0 Prettier diffs**.
- **Modified** files land in the `continue-on-error` steps. One thing to know rather than discover: `creator-program.service.ts` carries a **pre-existing** `local-rules/no-module-scope-cache` **error**, confirmed present at `origin/main` before this PR touched the file. It is report-only by the workflow's design and is not introduced here.

## A note on the issue's line numbers

They had drifted (`:460`/`:622`/`:1489` → `:464`/`:634`/`:1501` on `main`), as expected. The substantive correction is scope: six request-path sites, not three.
