### PR TITLE
feat(dev-server): boot moderator and creator-studio from the worktree you are in

### DIFF
--- a/.claude/skills/dev-server/.env.example
+++ b/.claude/skills/dev-server/.env.example
@@ -11,7 +11,8 @@ HEALTH_CHECK_TIMEOUT=120000
 RGB_PROXY_ENABLED=false
 RGB_PROXY_PATH=../rgb-proxy
 
-# Auth hub — auto-start the centralized login hub (apps/auth, SvelteKit) when the daemon boots.
+# Auth hub — auto-start the centralized login hub (apps/auth, SvelteKit) when the daemon boots, and
+# whenever an app is started, since an app cannot log anyone in without it.
 # The main app is verify-only now, so a fresh dev login needs the hub running on :5173.
 # One-time setup (keypair + apps/auth/.env + root .env spoke config): see SKILL.md "Auth Hub".
 AUTH_HUB_ENABLED=false

--- a/.claude/skills/dev-server/GREETME.md
+++ b/.claude/skills/dev-server/GREETME.md
@@ -1,5 +1,7 @@
 # dev-server: what changed, in one page
 
+_Written 2026-08-24, against the change that added per-worktree app support._
+
 The dev server used to boot one thing: the main Next.js app. It now boots the **moderator** and
 **creator-studio** apps too, from whatever worktree you are standing in. This is the short version
 for people who have to use it — `SKILL.md` is the long version.
@@ -13,7 +15,7 @@ node .claude/skills/dev-server/cli.mjs logs   --app moderator
 node .claude/skills/dev-server/cli.mjs tail   --app moderator   # follows, like tail on a session
 node .claude/skills/dev-server/cli.mjs stop   --app moderator
 node .claude/skills/dev-server/cli.mjs app                      # what is running, and where
-node .claude/skills/dev-server/cli.mjs status                   # sessions AND apps, one table
+node .claude/skills/dev-server/cli.mjs status                   # full JSON: sessions, apps, hub
 ```
 
 - `--app <name>` works on `start`, `logs`, `tail`, `stop`, `restart`.
@@ -26,7 +28,7 @@ node .claude/skills/dev-server/cli.mjs status                   # sessions AND a
 **Ports are preferred, not fixed.** moderator 5174, creator-studio 5175. A second worktree starting
 the same app drifts to the next free port instead of dying on EADDRINUSE, so you can run two
 branches of one app side by side. Nothing needs rewriting to follow the drift — neither app's `.env`
-carries its own port, and in dev the auth hub trusts loopback by host.
+carries its own port or base URL.
 
 **🔴 Read the `path` field, not just that it started.** An app serving the wrong checkout answers
 200s and looks completely healthy. `path` is the only thing that contradicts you. This is the bug
@@ -40,10 +42,10 @@ start at all. That base may be a production database. The app now prints its `DA
 on startup and carries it as `dbHost` in `app` / `status` output. Host only, never the credential.
 **Read it before you click anything that writes.**
 
-**The main app's `.env` now falls through too.** Previously a worktree `.env` *replaced* the project
-root's outright, so a file written to override two keys started the server with no `DATABASE_URL` and
-no secrets. Now the root's is the base and the worktree's overrides it key by key — a worktree file
-only needs to restate what it changes.
+**The main app's `.env` now falls through too.** Previously a worktree `.env` *replaced* the primary
+checkout's outright, so a file written to override two keys started the server with no `DATABASE_URL`
+and no secrets. Now the primary's is the base and the worktree's overrides it key by key — a worktree
+file only needs to restate what it changes.
 
 **Starting an app starts the auth hub**, if it is enabled and not already running. It does **not**
 start the main app: the apps reach it over REST, and a cold Next.js compile is not something to
@@ -88,15 +90,12 @@ node .claude/skills/dev-server/scripts/branch-watch.selftest.mjs
 node .claude/skills/dev-server/scripts/probe.selftest.mjs
 ```
 
-If you change any of this, mutate it and check the test goes red. Several of these were written,
-looked green, and could not have failed — the concurrency check passed on the broken code until it
-counted the right thing.
+If you change any of this, mutate it and check the test goes red.
 
 ⚠️ **Nothing else reads `cli.mjs`.** `pnpm typecheck` is scoped to `src/`, CI's ESLint filters by
-path prefix, and every other selftest imports `daemon.mjs` and friends. A refactor once deleted
-`cmdStop` and `cmdRestart` and left both call sites: `node --check` passed, five review rounds and
-29 mutants missed it, and `stop <session-id>` threw ReferenceError for everyone on the branch.
-`cli-verbs.selftest.mjs` is the only thing looking at that file — run it after touching it.
+path prefix, and every other selftest imports `daemon.mjs` and friends. `node --check` will not catch
+a deleted function whose call site remains — that is a ReferenceError, not a syntax error.
+`cli-verbs.selftest.mjs` is the only thing looking at that file. Run it after touching it.
 
 ## If something looks wrong
 

--- a/.claude/skills/dev-server/GREETME.md
+++ b/.claude/skills/dev-server/GREETME.md
@@ -83,6 +83,7 @@ Standalone scripts, no vitest. Run any of them directly:
 node .claude/skills/dev-server/scripts/env-chain.selftest.mjs      # .env layering + which object is read
 node .claude/skills/dev-server/scripts/app-registry.selftest.mjs   # registry, ports, path identity, the lock
 node .claude/skills/dev-server/scripts/db-host.selftest.mjs        # the DB host line never emits a credential
+node .claude/skills/dev-server/scripts/cli-verbs.selftest.mjs      # every dispatch target in cli.mjs exists
 node .claude/skills/dev-server/scripts/branch-watch.selftest.mjs
 node .claude/skills/dev-server/scripts/probe.selftest.mjs
 ```
@@ -90,6 +91,12 @@ node .claude/skills/dev-server/scripts/probe.selftest.mjs
 If you change any of this, mutate it and check the test goes red. Several of these were written,
 looked green, and could not have failed — the concurrency check passed on the broken code until it
 counted the right thing.
+
+⚠️ **Nothing else reads `cli.mjs`.** `pnpm typecheck` is scoped to `src/`, CI's ESLint filters by
+path prefix, and every other selftest imports `daemon.mjs` and friends. A refactor once deleted
+`cmdStop` and `cmdRestart` and left both call sites: `node --check` passed, five review rounds and
+29 mutants missed it, and `stop <session-id>` threw ReferenceError for everyone on the branch.
+`cli-verbs.selftest.mjs` is the only thing looking at that file — run it after touching it.
 
 ## If something looks wrong
 

--- a/.claude/skills/dev-server/GREETME.md
+++ b/.claude/skills/dev-server/GREETME.md
@@ -1,0 +1,102 @@
+# dev-server: what changed, in one page
+
+The dev server used to boot one thing: the main Next.js app. It now boots the **moderator** and
+**creator-studio** apps too, from whatever worktree you are standing in. This is the short version
+for people who have to use it — `SKILL.md` is the long version.
+
+## The commands
+
+```bash
+node .claude/skills/dev-server/cli.mjs start                    # main app, this worktree (unchanged)
+node .claude/skills/dev-server/cli.mjs start --app moderator    # moderator, this worktree
+node .claude/skills/dev-server/cli.mjs logs   --app moderator
+node .claude/skills/dev-server/cli.mjs tail   --app moderator   # follows, like tail on a session
+node .claude/skills/dev-server/cli.mjs stop   --app moderator
+node .claude/skills/dev-server/cli.mjs app                      # what is running, and where
+node .claude/skills/dev-server/cli.mjs status                   # sessions AND apps, one table
+```
+
+- `--app <name>` works on `start`, `logs`, `tail`, `stop`, `restart`.
+- `app <name> <subcmd>` is the same thing spelled the other way.
+- Both default to the current directory's worktree. `app <name> <subcmd> <worktree>` names another.
+- Two apps are registered: `moderator` and `creator-studio`. The auth hub keeps its own `auth` verb.
+
+## Five things worth knowing
+
+**Ports are preferred, not fixed.** moderator 5174, creator-studio 5175. A second worktree starting
+the same app drifts to the next free port instead of dying on EADDRINUSE, so you can run two
+branches of one app side by side. Nothing needs rewriting to follow the drift — neither app's `.env`
+carries its own port, and in dev the auth hub trusts loopback by host.
+
+**🔴 Read the `path` field, not just that it started.** An app serving the wrong checkout answers
+200s and looks completely healthy. `path` is the only thing that contradicts you. This is the bug
+the change exists to remove — `app <name> start` used to *always* run the primary checkout, silently,
+whatever worktree you typed it from.
+
+**⚠️ `.env` falls through, and the base may point at production.** An app reads
+`<primary>/apps/<name>/.env` as its base, with `<worktree>/apps/<name>/.env` layered on top if the
+worktree has one. Both are gitignored, so a fresh worktree has neither — the base is what lets it
+start at all. That base may be a production database. The app now prints its `DATABASE_URL` **host**
+on startup and carries it as `dbHost` in `app` / `status` output. Host only, never the credential.
+**Read it before you click anything that writes.**
+
+**The main app's `.env` now falls through too.** Previously a worktree `.env` *replaced* the project
+root's outright, so a file written to override two keys started the server with no `DATABASE_URL` and
+no secrets. Now the root's is the base and the worktree's overrides it key by key — a worktree file
+only needs to restate what it changes.
+
+**Starting an app starts the auth hub**, if it is enabled and not already running. It does **not**
+start the main app: the apps reach it over REST, and a cold Next.js compile is not something to
+trigger on your behalf. Start it yourself if the page you are looking at needs it.
+
+## What an app is NOT
+
+An app is a `vite dev` process with a log buffer and a port. It is **not** a `DevSession`, so none of
+this applies to it:
+
+- no `pnpm install` on a lockfile change
+- no `db:generate` on a schema change
+- no branch watching
+- no prewarm, no probe
+
+Switch branches under a running moderator and nothing reinstalls. Restart it yourself.
+
+## Gone
+
+`storage` and `notifications` were registered and **could never start** — no `vite.config.ts` (their
+dev script is `tsx watch src/server.ts`) and no `.env`, so every attempt died at the `.env` precheck
+reporting an auth-hub problem. They are deregistered until someone runs them properly. A selftest now
+fails if a registered app lacks a `vite.config.ts`, so this cannot come back quietly.
+
+## `wt` knows about apps now
+
+`wt stale` lists a running app as a reason to keep a worktree, and `wt rm` refuses to delete a tree
+serving one (`--stop-server` stops it). It also now takes the primary worktree from `git worktree
+list` rather than the directory it was invoked from — run through a worktree's own copy of the CLI it
+used to offer **the real main checkout** as removable.
+
+## Tests
+
+Standalone scripts, no vitest. Run any of them directly:
+
+```bash
+node .claude/skills/dev-server/scripts/env-chain.selftest.mjs      # .env layering + which object is read
+node .claude/skills/dev-server/scripts/app-registry.selftest.mjs   # registry, ports, path identity, the lock
+node .claude/skills/dev-server/scripts/db-host.selftest.mjs        # the DB host line never emits a credential
+node .claude/skills/dev-server/scripts/branch-watch.selftest.mjs
+node .claude/skills/dev-server/scripts/probe.selftest.mjs
+```
+
+If you change any of this, mutate it and check the test goes red. Several of these were written,
+looked green, and could not have failed — the concurrency check passed on the broken code until it
+counted the right thing.
+
+## If something looks wrong
+
+| Symptom | Look at |
+|---|---|
+| App shows `main` when you are on a branch | the `path` field — wrong checkout |
+| App starts, then 500s on a missing `DATABASE_URL` | `primaryCheckout` in `status`; git may have failed and the fall-through has no base |
+| Port is not the documented one | another worktree holds it; `app` shows who |
+| `EADDRINUSE` on a port nothing lists | an orphaned child. `stop` says so with the port when it sees one |
+| Two servers on one worktree | shouldn't happen — path casing is canonicalised. Report it |

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -184,6 +184,7 @@ Self-tests — run all three after touching `probe.mjs` or the hook:
 ```bash
 node .claude/skills/dev-server/scripts/env-chain.selftest.mjs          # .env layering, both directions
 node .claude/skills/dev-server/scripts/app-registry.selftest.mjs       # registry, port reservation, primaryOf
+node .claude/skills/dev-server/scripts/db-host.selftest.mjs            # the DB host line never emits a credential
 node .claude/skills/dev-server/scripts/probe.selftest.mjs              # the classifier, pure
 node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs  # the real probe() end to end
 node .claude/hooks/check-writable.selftest.mjs                         # the hook, both directions

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -183,7 +183,7 @@ Self-tests — run all three after touching `probe.mjs` or the hook:
 
 ```bash
 node .claude/skills/dev-server/scripts/env-chain.selftest.mjs          # .env layering, both directions
-node .claude/skills/dev-server/scripts/app-registry.selftest.mjs       # registry, port reservation, primaryOf
+node .claude/skills/dev-server/scripts/app-registry.selftest.mjs       # registry, ports, path identity, the lock
 node .claude/skills/dev-server/scripts/db-host.selftest.mjs            # the DB host line never emits a credential
 node .claude/skills/dev-server/scripts/probe.selftest.mjs              # the classifier, pure
 node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs  # the real probe() end to end

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -185,6 +185,7 @@ Self-tests — run all three after touching `probe.mjs` or the hook:
 node .claude/skills/dev-server/scripts/env-chain.selftest.mjs          # .env layering, both directions
 node .claude/skills/dev-server/scripts/app-registry.selftest.mjs       # registry, ports, path identity, the lock
 node .claude/skills/dev-server/scripts/db-host.selftest.mjs            # the DB host line never emits a credential
+node .claude/skills/dev-server/scripts/cli-verbs.selftest.mjs          # every dispatch target in cli.mjs exists
 node .claude/skills/dev-server/scripts/probe.selftest.mjs              # the classifier, pure
 node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs  # the real probe() end to end
 node .claude/hooks/check-writable.selftest.mjs                         # the hook, both directions

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -179,13 +179,15 @@ and prints each timing. It costs a guaranteed ~45s rebuild, so it is not automat
 guess a session: name the id, because the session you did not name is usually the one someone is
 looking at.
 
-Self-tests — run all three after touching `probe.mjs` or the hook:
+Self-tests. Standalone scripts, no vitest — run the ones your change touches, and `cli-verbs`
+after any edit to `cli.mjs`:
 
 ```bash
 node .claude/skills/dev-server/scripts/env-chain.selftest.mjs          # .env layering, both directions
 node .claude/skills/dev-server/scripts/app-registry.selftest.mjs       # registry, ports, path identity, the lock
 node .claude/skills/dev-server/scripts/db-host.selftest.mjs            # the DB host line never emits a credential
 node .claude/skills/dev-server/scripts/cli-verbs.selftest.mjs          # every dispatch target in cli.mjs exists
+node .claude/skills/dev-server/scripts/branch-watch.selftest.mjs       # HEAD watching + the restart decision
 node .claude/skills/dev-server/scripts/probe.selftest.mjs              # the classifier, pure
 node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs  # the real probe() end to end
 node .claude/hooks/check-writable.selftest.mjs                         # the hook, both directions
@@ -206,10 +208,10 @@ fails.** Anything that adds a new signal belongs in the integration file, not ju
 | `status` | Check daemon status and list all sessions |
 | `list` | List all dev sessions |
 | `start [worktree] [--app name] [--prod a,b] [--dev a,b]` | Start a dev server (default: the main app, current directory) |
-| `logs [session-id]` | Get logs for a session |
-| `tail [session-id]` | Tail logs continuously |
-| `stop <session-id>` | Stop a session |
-| `restart <session-id>` | Restart a session |
+| `logs [session-id] [--app name]` | Get logs for a session, or for an app in this worktree |
+| `tail [session-id] [--app name]` | Tail logs continuously |
+| `stop <session-id>` \| `stop --app name` | Stop a session or an app |
+| `restart <session-id>` \| `restart --app name` | Restart a session or an app |
 | `rgb [subcmd]` | RGB proxy control (`status`\|`start`\|`stop`\|`restart`\|`logs`) |
 | `app` | List running apps, their worktree, and what is available |
 | `app <name> [subcmd] [worktree]` | App control (`status`\|`start`\|`stop`\|`restart`\|`logs`) |
@@ -244,10 +246,14 @@ node .claude/skills/dev-server/cli.mjs start --prod all
 node .claude/skills/dev-server/cli.mjs start --prod all --dev search
 ```
 
-The groups are whatever `env-modes.local` defines. `env-modes.example` documents several, but
-**what is actually defined on this box is one: `db`.** So today `--prod`/`--dev` moves the primary
-database and nothing else, however many services the mechanism could carry. Adding one is an edit to
-`env-modes.local` (gitignored, holds credentials), not to the code.
+`--prod`/`--dev` can only move the groups **your own** `env-modes.local` defines, and that file is
+gitignored — a fresh copy of `env-modes.example` defines none, so `--prod all` is a no-op until you
+fill it in. Adding a service is an edit to that file, not to the code.
+
+⚠️ **`env-modes.local` does not fall through** the way `.env` now does. It is read from the skill
+directory of the daemon that is running (`env-modes.mjs`), so a daemon started from a worktree's own
+copy of the CLI finds none and applies no overlay at all. Start the daemon from the primary checkout,
+or the groups simply will not exist.
 
 Several services have **no dev counterpart to move to at all** — `env-modes.mjs` lists orchestrator,
 payments, s3, clickhouse, notifications, feeds and opensearch in `PROD_ONLY_GROUPS`, and `auth-hub`
@@ -454,7 +460,8 @@ node .claude/skills/dev-server/cli.mjs app moderator restart
 node .claude/skills/dev-server/cli.mjs app moderator stop
 ```
 
-`--app <name>` works on `start`, `logs`, `stop` and `restart`, so one gesture covers the lifecycle;
+`--app <name>` works on `start`, `logs`, `tail`, `stop` and `restart`, so one gesture covers the
+lifecycle;
 `app <name> <subcmd>` is the same thing spelled the other way. Both default to the current
 directory's worktree, and `app <name> <subcmd> <worktree>` names a different one. Running apps also
 appear under `apps` in `status`, beside the main-app sessions.
@@ -467,9 +474,8 @@ appear under `apps` in `status`, beside the main-app sessions.
 **Preferred, not fixed.** The first worktree to start an app gets the number in that table; a second
 worktree starting the same app drifts to the next free port instead of dying on EADDRINUSE, so two
 branches of the same app can run side by side. Nothing has to be rewritten to follow the drift:
-neither app's `.env` carries its own port or base URL, and in dev the auth hub trusts loopback by
-**host**, so a drifted origin is still a first-party client. Every app's preferred port is held back
-from the drift search, so moderator drifting never displaces creator-studio.
+neither app's `.env` carries its own port or base URL. Every app's preferred port is held back from
+the drift search, so moderator drifting never displaces creator-studio.
 
 🔴 **Read the `path` field, not just the fact that it started.** An app serving the wrong checkout
 answers 200s and looks completely healthy — the only thing that contradicts you is `path`.
@@ -508,9 +514,12 @@ Vite compiles routes on demand in dev. The first hit on a cold app can take **25
 (the auth hub's `/login` is the worst offender); every hit after is a few hundred milliseconds. A
 browser sitting on a white page right after startup is usually this, not a hang.
 
+The dashboard shows main-app sessions only. Apps started with `--app` do not appear there — use
+`cli.mjs app` or `cli.mjs status`.
+
 ## Auth Hub
 
-Authentication was split into a standalone **login hub** (`apps/auth`, SvelteKit on port **5173**). The main app is now a **verify-only spoke**: it validates the hub's `civ-token` via the hub's JWKS and no longer runs next-auth sign-in itself. So a *fresh* login in dev needs the hub running. The daemon boots and manages it as a sidecar, same as the RGB proxy.
+Authentication was split into a standalone **login hub** (`apps/auth`, SvelteKit on port **5173**). The main app is now a **verify-only spoke**: it validates the hub's `civ-token` via the hub's JWKS and no longer runs next-auth sign-in itself. So a *fresh* login in dev needs the hub running. The daemon boots and manages it as a sidecar, and starting an app (`start --app <name>`) starts it too when `AUTH_HUB_ENABLED` is set and it is not already running.
 
 ### Control
 
@@ -529,7 +538,7 @@ In the dashboard TUI press `A` to toggle it; the session line shows `AUTH: ready
 
 ```env
 AUTH_HUB_ENABLED=true      # auto-start the hub when the daemon boots
-AUTH_HUB_PATH=apps/auth    # path relative to project root
+AUTH_HUB_PATH=apps/auth    # relative to the PRIMARY checkout, not the tree the daemon runs from
 AUTH_HUB_PORT=5173         # hub dev port (matches AUTH_JWT_ISSUER)
 ```
 

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -182,6 +182,7 @@ looking at.
 Self-tests — run all three after touching `probe.mjs` or the hook:
 
 ```bash
+node .claude/skills/dev-server/scripts/env-chain.selftest.mjs          # .env layering, both directions
 node .claude/skills/dev-server/scripts/probe.selftest.mjs              # the classifier, pure
 node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs  # the real probe() end to end
 node .claude/hooks/check-writable.selftest.mjs                         # the hook, both directions
@@ -201,14 +202,14 @@ fails.** Anything that adds a new signal belongs in the integration file, not ju
 | `unwedge <session-id>` | Stop, purge the build dir, restart, wait, re-probe (~45s) |
 | `status` | Check daemon status and list all sessions |
 | `list` | List all dev sessions |
-| `start [worktree] [--prod a,b] [--dev a,b]` | Start dev server (default: current directory) |
+| `start [worktree] [--app name] [--prod a,b] [--dev a,b]` | Start a dev server (default: the main app, current directory) |
 | `logs [session-id]` | Get logs for a session |
 | `tail [session-id]` | Tail logs continuously |
 | `stop <session-id>` | Stop a session |
 | `restart <session-id>` | Restart a session |
 | `rgb [subcmd]` | RGB proxy control (`status`\|`start`\|`stop`\|`restart`\|`logs`) |
-| `app` | List the spoke apps and their state |
-| `app <name> [subcmd]` | Spoke app control (`status`\|`start`\|`stop`\|`restart`\|`logs`) |
+| `app` | List running apps, their worktree, and what is available |
+| `app <name> [subcmd] [worktree]` | App control (`status`\|`start`\|`stop`\|`restart`\|`logs`) |
 | `auth [subcmd]` | Auth hub control (`status`\|`start`\|`stop`\|`restart`\|`logs`) |
 | `test run [worktree]` | Queue a unit-test run; returns position + the command to wait on it |
 | `test wait <run-id>` | Block until that run finishes; exits with the run's exit code |
@@ -427,49 +428,60 @@ In the dashboard TUI, press `R` to toggle the proxy.
 
 Redbird binds ports 80 and 443. On Windows the daemon must be launched from an elevated terminal; on macOS/Linux start it with `sudo`. If it fails the daemon surfaces `lastError` via `/rgb` status and in RGB proxy logs.
 
-## Spoke Apps
+## Apps
 
-The SvelteKit apps under `apps/` (moderator, creator-studio, storage, notifications) run through the
-daemon the same way the auth hub does, so their logs land in the same place and either a human or an
-agent can start one and read the output.
+`moderator` and `creator-studio` run through the daemon the same way the main app does — started
+from the worktree you are in, logs in the same place, port reserved by the same allocator.
 
 ```bash
-node .claude/skills/dev-server/cli.mjs app                      # list all, with state and URL
-node .claude/skills/dev-server/cli.mjs app moderator start
+node .claude/skills/dev-server/cli.mjs start --app moderator    # from the worktree you are in
+node .claude/skills/dev-server/cli.mjs app                      # what is running, and where
 node .claude/skills/dev-server/cli.mjs app moderator logs
 node .claude/skills/dev-server/cli.mjs app moderator restart
 node .claude/skills/dev-server/cli.mjs app moderator stop
 ```
 
-| App | Port |
-|-----|------|
+`start --app <name>` and `app <name> start` are the same thing. Both default to the current
+directory's worktree; `app <name> <subcmd> <worktree>` names a different one.
+
+| App | Preferred port |
+|-----|----------------|
 | moderator | 5174 |
 | creator-studio | 5175 |
-| storage | 5176 |
-| notifications | 5177 |
 
-Ports are fixed rather than auto-assigned, so a redirect between two apps (moderator sends you to the
-auth hub to sign in) always lands in the same place. `--strictPort` means a collision fails loudly
-instead of silently drifting to the next free port.
+**Preferred, not fixed.** The first worktree to start an app gets the number in that table; a second
+worktree starting the same app drifts to the next free port instead of dying on EADDRINUSE, so two
+branches of the same app can run side by side. Nothing has to be rewritten to follow the drift:
+neither app's `.env` carries its own port or base URL, and in dev the auth hub trusts loopback by
+**host**, so a drifted origin is still a first-party client. Every app's preferred port is held back
+from the drift search, so moderator drifting never displaces creator-studio.
 
-Each app needs its own `.env` in its directory — vite loads it, the daemon does not inject it. Start
-from that app's `.env.example`.
+🔴 **Read the `path` field, not just the fact that it started.** An app serving the wrong checkout
+answers 200s and looks completely healthy — the only thing that contradicts you is `path`.
 
-**Most spoke pages need the auth hub running**, since they redirect to it to sign in:
+**`.env` falls through from the primary checkout.** An app reads `<primary>/apps/<name>/.env` as its
+base, with `<worktree>/apps/<name>/.env` layered on top when the worktree has one. Those files are
+gitignored, so a fresh worktree has neither — the base is what makes it start at all. Both of the
+primary checkout's copies point at the **production** database.
 
-```bash
-node .claude/skills/dev-server/cli.mjs auth start
-node .claude/skills/dev-server/cli.mjs app moderator start
-```
+`storage` and `notifications` are **not** here. They were registered and could never start: no
+`vite.config.ts` (their dev script is `tsx watch src/server.ts`) and no `.env`, so every attempt died
+at the `.env` precheck reporting an auth-hub problem. Register them properly or not at all.
 
-### They bind to 127.0.0.1, deliberately
+**Starting an app starts the auth hub** if it is enabled and not already running — an app cannot log
+anyone in without it. The **main app is not** started: the apps reach it over REST when they need it,
+and a cold Next.js compile is not something to trigger on someone's behalf. Start it yourself if the
+page you are looking at needs it.
 
-The daemon starts every vite sidecar with `--host 127.0.0.1`. Vite's default binds IPv6 loopback
-only (`[::1]`), and a Windows hosts file that defines `localhost` explicitly lists `127.0.0.1`
-first — so the browser dials an IPv4 socket nothing is listening on and hangs with no error
-anywhere. curl papers over it by falling back to `::1` after a couple hundred milliseconds, which
-makes it look like a slow server rather than a broken one. Forcing the IPv4 bind removes the whole
-class of problem.
+### They bind `::`, deliberately
+
+The daemon starts every vite sidecar with `--host ::`. Bound to `127.0.0.1` they answered on v4 and
+nothing on `[::1]`; Windows resolves `localhost` to `::1` first, so the browser got
+connection-refused while curl — which falls back to v4 — reported the server perfectly healthy.
+`--host localhost` is **not** the fix either: it resolves to `::1` only, moving the outage onto every
+caller that hardcodes `127.0.0.1`. `::` accepts v4-mapped addresses, so `localhost`, `127.0.0.1` and
+`[::1]` all answer, and it matches what `next dev` already binds on 3000. Tradeoff: `::` also listens
+on LAN interfaces, where the old bind was loopback-only.
 
 ### First request is slow
 
@@ -602,9 +614,17 @@ node .claude/skills/dev-server/cli.mjs start /path/to/worktree
 
 What's already handled:
 
-- **A worktree's own `.env` wins.** A session loads `<worktree>/.env` when one exists, and falls back to the project root's `.env` only when it doesn't — so a worktree with no `.env` still boots healthy. The chosen file is logged as `Env: <path>` at session start and returned as `envPath` in session status.
+- **A worktree's own `.env` layers on the primary's.** The primary checkout's `.env` is the base of every session; `<worktree>/.env` (or an explicit `--env`) overrides it key by key. So a worktree file needs to restate only what it wants to change, and one that restates nothing is a no-op rather than an outage. The whole chain is logged as `Env: <base> <- <overlay>` at session start and returned as `envPaths` in session status (`envPath` remains the top of the chain).
 
-  **The two are not merged.** Whichever file is chosen supplies every key; nothing is inherited from the other. A worktree `.env` that is a partial copy will therefore be missing whatever it doesn't restate, and different files can point a session at a different database — check the `Env:` line if a session behaves unlike its neighbours.
+  Before this they were **not** merged — the worktree file replaced the primary outright, so a two-key override file started the server with no `DATABASE_URL` and no secrets, failing in a way that looked nothing like the edit that caused it.
+
+  **"Primary checkout" is resolved from git, not from where the daemon was launched.** The skill
+  directory is committed, so every worktree has its own copy of `daemon.mjs` — a daemon started from
+  one would otherwise treat that worktree as the primary and fall back to a `.env` it does not have.
+  `git rev-parse --git-common-dir` answers the same from inside any worktree. `wt stale` / `wt rm`
+  take the primary from the first entry of `git worktree list`, which git guarantees is the main
+  worktree; before that, running them through a worktree's own CLI copy inverted every check and
+  offered the real main checkout as removable.
 - **Auth on secondary ports.** `NEXTAUTH_URL`, `NEXTAUTH_URL_INTERNAL`, and `NEXT_PUBLIC_BASE_URL` are rewritten to `http://localhost:<port>`, so logins work on non-3000 sessions instead of bouncing to the primary.
 - **Independent branch watching + prewarming** per session.
 - **Port allocation sees listeners the daemon does not own.** The picker connects to both loopback

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -183,6 +183,7 @@ Self-tests — run all three after touching `probe.mjs` or the hook:
 
 ```bash
 node .claude/skills/dev-server/scripts/env-chain.selftest.mjs          # .env layering, both directions
+node .claude/skills/dev-server/scripts/app-registry.selftest.mjs       # registry, port reservation, primaryOf
 node .claude/skills/dev-server/scripts/probe.selftest.mjs              # the classifier, pure
 node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs  # the real probe() end to end
 node .claude/hooks/check-writable.selftest.mjs                         # the hook, both directions
@@ -220,9 +221,9 @@ fails.** Anything that adds a new signal belongs in the integration file, not ju
 
 ## Env modes — which services a session talks to
 
-A session picks one `.env` (its worktree's if present, otherwise the project root's) and then
-applies a per-service **overlay** on top of it. The overlay only restates the keys for the services
-it names, so nothing else in the chosen `.env` moves — the two `.env` files are still never merged.
+A session layers its `.env` files — the primary checkout's as the base, the worktree's own on top —
+and then applies a per-service **overlay** on that. The overlay only restates the keys for the
+services it names, so nothing else in the chain moves.
 
 **No `env-modes.local` means no overlay at all** — not "everything on dev". The file is gitignored,
 so it never comes with a checkout: until it exists, every start runs on the base `.env` exactly as
@@ -241,9 +242,19 @@ node .claude/skills/dev-server/cli.mjs start --prod all
 node .claude/skills/dev-server/cli.mjs start --prod all --dev search
 ```
 
-The groups are whatever `env-modes.local` defines — today `db`, `buzz`, `search`, `signals`,
-`redis`. Copy `env-modes.example` to `env-modes.local` (gitignored, holds credentials) and fill it
-in; adding a service is an edit to that file, not to the code.
+The groups are whatever `env-modes.local` defines. `env-modes.example` documents several, but
+**what is actually defined on this box is one: `db`.** So today `--prod`/`--dev` moves the primary
+database and nothing else, however many services the mechanism could carry. Adding one is an edit to
+`env-modes.local` (gitignored, holds credentials), not to the code.
+
+Several services have **no dev counterpart to move to at all** — `env-modes.mjs` lists orchestrator,
+payments, s3, clickhouse, notifications, feeds and opensearch in `PROD_ONLY_GROUPS`, and `auth-hub`
+in `UNMOVABLE_GROUPS` (it is one shared process reading its own `.env`, so an overlay there would
+repoint the app at a hub that is not running). `mode: dev` therefore never means "nothing here is
+production".
+
+⚠️ **Apps have no env modes.** `--prod`/`--dev` apply to the main app only; an app runs on its `.env`
+chain with no overlay. `start --app <name> --prod db` is refused rather than silently ignored.
 
 **Defaults.** Every group defaults to `dev`. Move a default in the skill's own `.env` when a dev
 service is unreliable:
@@ -441,8 +452,10 @@ node .claude/skills/dev-server/cli.mjs app moderator restart
 node .claude/skills/dev-server/cli.mjs app moderator stop
 ```
 
-`start --app <name>` and `app <name> start` are the same thing. Both default to the current
-directory's worktree; `app <name> <subcmd> <worktree>` names a different one.
+`--app <name>` works on `start`, `logs`, `stop` and `restart`, so one gesture covers the lifecycle;
+`app <name> <subcmd>` is the same thing spelled the other way. Both default to the current
+directory's worktree, and `app <name> <subcmd> <worktree>` names a different one. Running apps also
+appear under `apps` in `status`, beside the main-app sessions.
 
 | App | Preferred port |
 |-----|----------------|
@@ -461,8 +474,12 @@ answers 200s and looks completely healthy — the only thing that contradicts yo
 
 **`.env` falls through from the primary checkout.** An app reads `<primary>/apps/<name>/.env` as its
 base, with `<worktree>/apps/<name>/.env` layered on top when the worktree has one. Those files are
-gitignored, so a fresh worktree has neither — the base is what makes it start at all. Both of the
-primary checkout's copies point at the **production** database.
+gitignored, so a fresh worktree has neither — the base is what makes it start at all.
+
+⚠️ **That base may point at a production database**, and the fall-through means a fresh worktree
+inherits it without anyone choosing it. The app prints the `DATABASE_URL` **host** (never the
+credential) on startup and carries it as `dbHost` in `app` / `status` output — read it before you
+click anything that writes.
 
 `storage` and `notifications` are **not** here. They were registered and could never start: no
 `vite.config.ts` (their dev script is `tsx watch src/server.ts`) and no `.env`, so every attempt died

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -270,6 +270,34 @@ async function cmdTail(sessionId) {
   await followLogs((since) => `/sessions/${sessionId}/logs?since=${since}`);
 }
 
+async function cmdStop(sessionId) {
+  await ensureDaemon();
+  if (!sessionId) {
+    console.error('Session ID required');
+    process.exit(1);
+  }
+  const result = await daemonRequest(`/sessions/${sessionId}`, { method: 'DELETE' });
+  if (!result.ok) {
+    console.error('Error:', result.error || result.data?.error);
+    process.exit(1);
+  }
+  console.log(JSON.stringify(result.data, null, 2));
+}
+
+async function cmdRestart(sessionId) {
+  await ensureDaemon();
+  if (!sessionId) {
+    console.error('Session ID required');
+    process.exit(1);
+  }
+  const result = await daemonRequest(`/sessions/${sessionId}/restart`, { method: 'POST' });
+  if (!result.ok) {
+    console.error('Error:', result.error || result.data?.error);
+    process.exit(1);
+  }
+  console.log(JSON.stringify(result.data, null, 2));
+}
+
 async function cmdRgb(subcmd) {
   await ensureDaemon();
   const action = subcmd || 'status';

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -119,11 +119,10 @@ async function cmdList() {
 
 // `--prod db,buzz` / `--dev search`, repeatable. Groups come from env-modes.local, so the daemon
 // validates the names — this only has to get the shape right.
-// Flags on `start` and the app verbs that consume the following token. Named once because three
-// places have to agree: parseModeFlags, appFromFlags, and the positional scan. A fourth value-flag
-// added to the parser alone would have its value silently eaten as the worktree.
+// Flags on `start` and the app verbs that consume the following token. A fourth value-flag added to
+// parseModeFlags without being added here has its value silently eaten as the worktree.
 //
-// Not to be confused with `probe`'s own VALUE_FLAGS further down — different verb, different set.
+// Not `probe`'s own VALUE_FLAGS further down — different verb, different set.
 const SESSION_VALUE_FLAGS = new Set(['--app', '--prod', '--dev']);
 
 function parseModeFlags(flags) {
@@ -989,10 +988,14 @@ Commands:
                       [--session id] [--port n] [--timeout ms] [--json]
   unwedge <session>   Stop, delete the build dir, restart, wait for ready, re-probe.
                       ~45s of downtime — only after probe says WEDGED.
-  logs [session-id]   Get logs for a session
-  tail [session-id]   Tail logs continuously
-  stop <session-id>   Stop a session
-  restart <session-id> Restart a session
+  logs [session-id] [--app name]
+                      Get logs for a session, or for an app in this worktree
+  tail [session-id] [--app name]
+                      Tail logs continuously
+  stop <session-id> | stop --app name
+                      Stop a session or an app
+  restart <session-id> | restart --app name
+                      Restart a session or an app
   rgb [subcmd]        RGB proxy control (status|start|stop|restart|logs)
   auth [subcmd]       Auth hub control (status|start|stop|restart|logs)
   app                 List running apps and what is available (moderator, creator-studio)

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -120,9 +120,23 @@ async function cmdList() {
 // `--prod db,buzz` / `--dev search`, repeatable. Groups come from env-modes.local, so the daemon
 // validates the names — this only has to get the shape right.
 function parseModeFlags(flags) {
-  const modes = { prod: [], dev: [] };
+  const modes = { prod: [], dev: [], app: null };
   for (let i = 0; i < flags.length; i++) {
     const flag = flags[i];
+    const inlineApp = flag.match(/^--app=(.*)$/);
+    if (inlineApp) {
+      if (!inlineApp[1].trim()) throw new Error('--app= needs an app name, e.g. --app=moderator');
+      modes.app = inlineApp[1].trim();
+      continue;
+    }
+    if (flag === '--app') {
+      const value = flags[++i];
+      if (!value || value.startsWith('--')) {
+        throw new Error('--app needs an app name, e.g. --app moderator');
+      }
+      modes.app = value;
+      continue;
+    }
     const inline = flag.match(/^--(prod|dev)=(.*)$/);
     if (inline) {
       // `--prod=` would otherwise be an empty, silent no-op while the spaced form errors.
@@ -140,27 +154,16 @@ function parseModeFlags(flags) {
       modes[flag.slice(2)].push(value);
       continue;
     }
-    throw new Error(`Unknown option "${flag}". Usage: start [worktree] [--prod a,b] [--dev a,b]`);
+    throw new Error(
+      `Unknown option "${flag}". Usage: start [worktree] [--app name] [--prod a,b] [--dev a,b]`
+    );
   }
-  return { prod: modes.prod.join(','), dev: modes.dev.join(',') };
+  return { app: modes.app, prod: modes.prod.join(','), dev: modes.dev.join(',') };
 }
 
 async function cmdStart(worktree, flags = []) {
   await ensureDaemon();
   const cwd = worktree ? resolve(worktree) : process.cwd();
-
-  // `start --app moderator` is the same gesture as `start`, aimed at a different app in the same
-  // worktree. It routes to /app/<name>/start rather than /sessions: an app is not a Next.js session
-  // and has no build dir, prewarm or branch watching to configure.
-  const appIndex = flags.indexOf('--app');
-  if (appIndex !== -1) {
-    const app = flags[appIndex + 1];
-    if (!app || app.startsWith('--')) {
-      console.error('Error: --app needs an app name (e.g. --app moderator)');
-      process.exit(1);
-    }
-    return cmdAppStart(app, cwd);
-  }
 
   let modes;
   try {
@@ -170,15 +173,50 @@ async function cmdStart(worktree, flags = []) {
     process.exit(1);
   }
 
+  // `start --app moderator` is the same gesture as `start`, aimed at a different app in the same
+  // worktree. It routes to /app/<name>/start rather than /sessions: an app is not a Next.js session
+  // and has no build dir, prewarm or branch watching to configure.
+  //
+  // Parsing happens BEFORE the branch so an unknown flag still fails here, and so a mode flag on an
+  // app start is refused rather than silently dropped — apps get the raw env chain, with no overlay
+  // applied, which is precisely the difference a `--prod db` would be trying to express.
+  const { app, ...sessionModes } = modes;
+  if (app) {
+    if (sessionModes.prod || sessionModes.dev) {
+      console.error(
+        `Error: --prod/--dev are not supported with --app. Apps run on the .env chain with no ` +
+          `overlay; only the main app has env modes.`
+      );
+      process.exit(1);
+    }
+    return cmdAppStart(app, cwd);
+  }
+
   const result = await daemonRequest('/sessions', {
     method: 'POST',
-    body: JSON.stringify({ worktree: cwd, ...modes }),
+    body: JSON.stringify({ worktree: cwd, ...sessionModes }),
   });
   if (!result.ok) {
     console.error('Error:', result.error || result.data?.error);
     process.exit(1);
   }
   console.log(JSON.stringify(result.data, null, 2));
+}
+
+// `--app <name>` on a session verb means "the app in this worktree", so the whole lifecycle uses one
+// gesture rather than `start --app x` followed by `app x stop`. Returns null when no --app was given.
+function appFromFlags(flags = []) {
+  const i = flags.indexOf('--app');
+  if (i !== -1) {
+    const value = flags[i + 1];
+    if (!value || value.startsWith('--')) {
+      console.error('Error: --app needs an app name, e.g. --app moderator');
+      process.exit(1);
+    }
+    return value;
+  }
+  const inline = flags.find((f) => f.startsWith('--app='));
+  return inline ? inline.slice('--app='.length) : null;
 }
 
 async function cmdLogs(sessionId, since) {
@@ -803,6 +841,9 @@ async function cmdWorktree(rest) {
 // Parse arguments
 const args = process.argv.slice(2);
 const command = args[0];
+// One gesture for the whole lifecycle: `start --app x` then `logs --app x`, `stop --app x`. Without
+// this only `start` took --app and everything after it needed the second `app <name> …` vocabulary.
+const appFlag = appFromFlags(args.slice(1));
 const arg1 = args[1];
 const arg2 = args[2];
 
@@ -818,16 +859,19 @@ switch (command) {
     else cmdStart(arg1, args.slice(2));
     break;
   case 'logs':
-    cmdLogs(arg1, arg2);
+    if (appFlag) cmdApp(appFlag, 'logs');
+    else cmdLogs(arg1, arg2);
     break;
   case 'tail':
     cmdTail(arg1);
     break;
   case 'stop':
-    cmdStop(arg1);
+    if (appFlag) cmdApp(appFlag, 'stop');
+    else cmdStop(arg1);
     break;
   case 'restart':
-    cmdRestart(arg1);
+    if (appFlag) cmdApp(appFlag, 'restart');
+    else cmdRestart(arg1);
     break;
   case 'rgb':
     cmdRgb(arg1);

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -414,6 +414,16 @@ async function cmdAppTail(name, worktree) {
 
 async function cmdApp(name, subcmd, worktreeArg) {
   await ensureDaemon();
+  // The positional on an app verb is a worktree, and only that. `logs --app moderator 500` reads
+  // like `logs <session> <since>` and would otherwise become a worktree, 404ing with
+  // "moderator is not running in <cwd>/500" — which sends the reader looking for the app rather
+  // than at what they typed. Fails closed either way; this says which.
+  if (worktreeArg && !existsSync(resolve(worktreeArg))) {
+    console.error(`Error: "${worktreeArg}" is not a directory.`);
+    console.error(`Usage: app <name> [status|start|stop|restart|logs] [worktree]`);
+    console.error(`The positional on an app command is a worktree path — there is no "since" here.`);
+    process.exit(1);
+  }
   const cwd = worktreeArg ? resolve(worktreeArg) : process.cwd();
 
   // `app` with no name lists what is registered and what is running where.

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -385,6 +385,33 @@ async function cmdAppStart(name, worktree) {
   console.log(JSON.stringify(result.data, null, 2));
 }
 
+// `tail` differs from `logs` only in that it follows. Routing --app to the one-shot printer made the
+// verb quietly mean the other one, and an agent reads that snapshot as "the app stopped producing
+// output". The /app/<name>/logs endpoint already takes `since`, so following it is the same loop.
+async function cmdAppTail(name, worktree) {
+  await ensureDaemon();
+  const query = `?worktree=${encodeURIComponent(worktree)}`;
+  let lastIndex = 0;
+
+  const poll = async () => {
+    const result = await daemonRequest(`/app/${name}/logs${query}&since=${lastIndex}`);
+    if (!result.ok) {
+      console.error('Error:', result.error || result.data?.error || JSON.stringify(result.data));
+      if (result.data?.running?.length) {
+        console.error(`${name} is running in: ${result.data.running.join(', ')}`);
+      }
+      process.exit(1);
+    }
+    for (const log of result.data.logs) {
+      console.log(`[${log.level}] ${log.message}`);
+      lastIndex = log.index;
+    }
+  };
+
+  await poll();
+  setInterval(poll, 1000);
+}
+
 async function cmdApp(name, subcmd, worktreeArg) {
   await ensureDaemon();
   const cwd = worktreeArg ? resolve(worktreeArg) : process.cwd();
@@ -854,7 +881,23 @@ const command = args[0];
 const APP_FLAG_VERBS = new Set(['start', 'logs', 'tail', 'stop', 'restart']);
 const appFlag = APP_FLAG_VERBS.has(command) ? appFromFlags(args.slice(1)) : null;
 // `stop <worktree> --app moderator` must mean the same tree as `start <worktree> --app moderator`.
-const positional = args.slice(1).find((a) => !a.startsWith('--') && a !== appFlag);
+//
+// Skipped by POSITION, not by value. Excluding the flag's value by equality dropped the worktree
+// whenever its path happened to equal the app name — `stop moderator --app moderator`, naming a
+// worktree directory after the app in it, which is the obvious way to name one — and silently
+// targeted the cwd instead.
+const positional = (() => {
+  const rest = args.slice(1);
+  for (let i = 0; i < rest.length; i++) {
+    if (rest[i] === '--app' || rest[i] === '--prod' || rest[i] === '--dev') {
+      i++;
+      continue;
+    }
+    if (rest[i].startsWith('--')) continue;
+    return rest[i];
+  }
+  return undefined;
+})();
 const arg1 = args[1];
 const arg2 = args[2];
 
@@ -874,7 +917,7 @@ switch (command) {
     else cmdLogs(arg1, arg2);
     break;
   case 'tail':
-    if (appFlag) cmdApp(appFlag, 'logs', positional);
+    if (appFlag) cmdAppTail(appFlag, positional ? resolve(positional) : process.cwd());
     else cmdTail(arg1);
     break;
   case 'stop':

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -7,7 +7,7 @@
 import { spawn, execSync } from 'child_process';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, statSync } from 'fs';
 import { exitCodeFor, isTerminal as isTerminalStatus } from './scripts/test-queue.mjs';
 import { resolveDaemonUrl } from './scripts/daemon-port.mjs';
 
@@ -119,6 +119,13 @@ async function cmdList() {
 
 // `--prod db,buzz` / `--dev search`, repeatable. Groups come from env-modes.local, so the daemon
 // validates the names — this only has to get the shape right.
+// Flags on `start` and the app verbs that consume the following token. Named once because three
+// places have to agree: parseModeFlags, appFromFlags, and the positional scan. A fourth value-flag
+// added to the parser alone would have its value silently eaten as the worktree.
+//
+// Not to be confused with `probe`'s own VALUE_FLAGS further down — different verb, different set.
+const SESSION_VALUE_FLAGS = new Set(['--app', '--prod', '--dev']);
+
 function parseModeFlags(flags) {
   const modes = { prod: [], dev: [], app: null };
   for (let i = 0; i < flags.length; i++) {
@@ -260,50 +267,7 @@ async function cmdTail(sessionId) {
     sessionId = running ? running.id : listResult.data.sessions[0].id;
   }
 
-  let lastIndex = -1;
-
-  const poll = async () => {
-    const result = await daemonRequest(`/sessions/${sessionId}/logs?since=${lastIndex}`);
-    if (!result.ok) {
-      console.error('Error:', result.error || result.data?.error);
-      process.exit(1);
-    }
-    for (const log of result.data.logs) {
-      console.log(`[${log.level}] ${log.message}`);
-      lastIndex = log.index;
-    }
-  };
-
-  await poll();
-  setInterval(poll, 1000);
-}
-
-async function cmdStop(sessionId) {
-  await ensureDaemon();
-  if (!sessionId) {
-    console.error('Session ID required');
-    process.exit(1);
-  }
-  const result = await daemonRequest(`/sessions/${sessionId}`, { method: 'DELETE' });
-  if (!result.ok) {
-    console.error('Error:', result.error || result.data?.error);
-    process.exit(1);
-  }
-  console.log(JSON.stringify(result.data, null, 2));
-}
-
-async function cmdRestart(sessionId) {
-  await ensureDaemon();
-  if (!sessionId) {
-    console.error('Session ID required');
-    process.exit(1);
-  }
-  const result = await daemonRequest(`/sessions/${sessionId}/restart`, { method: 'POST' });
-  if (!result.ok) {
-    console.error('Error:', result.error || result.data?.error);
-    process.exit(1);
-  }
-  console.log(JSON.stringify(result.data, null, 2));
+  await followLogs((since) => `/sessions/${sessionId}/logs?since=${since}`);
 }
 
 async function cmdRgb(subcmd) {
@@ -387,18 +351,16 @@ async function cmdAppStart(name, worktree) {
 
 // `tail` differs from `logs` only in that it follows. Routing --app to the one-shot printer made the
 // verb quietly mean the other one, and an agent reads that snapshot as "the app stopped producing
-// output". The /app/<name>/logs endpoint already takes `since`, so following it is the same loop.
-async function cmdAppTail(name, worktree) {
-  await ensureDaemon();
-  const query = `?worktree=${encodeURIComponent(worktree)}`;
+// output". Both endpoints take `since`, so one loop serves both — written once so a colour, a level
+// filter or a --since added later cannot land on only one of them.
+async function followLogs(urlFor) {
   let lastIndex = 0;
-
   const poll = async () => {
-    const result = await daemonRequest(`/app/${name}/logs${query}&since=${lastIndex}`);
+    const result = await daemonRequest(urlFor(lastIndex));
     if (!result.ok) {
       console.error('Error:', result.error || result.data?.error || JSON.stringify(result.data));
       if (result.data?.running?.length) {
-        console.error(`${name} is running in: ${result.data.running.join(', ')}`);
+        console.error(`Running in: ${result.data.running.join(', ')}`);
       }
       process.exit(1);
     }
@@ -407,24 +369,44 @@ async function cmdAppTail(name, worktree) {
       lastIndex = log.index;
     }
   };
-
   await poll();
   setInterval(poll, 1000);
 }
 
-async function cmdApp(name, subcmd, worktreeArg) {
+async function cmdAppTail(name, worktreeArg) {
   await ensureDaemon();
-  // The positional on an app verb is a worktree, and only that. `logs --app moderator 500` reads
-  // like `logs <session> <since>` and would otherwise become a worktree, 404ing with
-  // "moderator is not running in <cwd>/500" — which sends the reader looking for the app rather
-  // than at what they typed. Fails closed either way; this says which.
-  if (worktreeArg && !existsSync(resolve(worktreeArg))) {
+  // Same validation as cmdApp. `tail` dispatches straight here rather than through it, so without
+  // this `tail --app moderator 500` still turned 500 into a worktree — the exact confusing 404 the
+  // validation was added to remove, left open on one verb.
+  const worktree = resolveWorktreeArg(worktreeArg);
+  const query = `?worktree=${encodeURIComponent(worktree)}`;
+  await followLogs((since) => `/app/${name}/logs${query}&since=${since}`);
+}
+
+// The positional on an app verb is a worktree, and only that. `logs --app moderator 500` reads like
+// `logs <session> <since>` and would otherwise become a worktree, 404ing with "moderator is not
+// running in <cwd>/500" — which sends the reader looking for the app rather than at what they typed.
+// Fails closed either way; this says which. statSync, not existsSync, so the message is true: a file
+// would otherwise pass the check and 404 anyway.
+function resolveWorktreeArg(worktreeArg) {
+  if (!worktreeArg) return process.cwd();
+  const resolved = resolve(worktreeArg);
+  let isDir = false;
+  try {
+    isDir = statSync(resolved).isDirectory();
+  } catch (e) {}
+  if (!isDir) {
     console.error(`Error: "${worktreeArg}" is not a directory.`);
     console.error(`Usage: app <name> [status|start|stop|restart|logs] [worktree]`);
     console.error(`The positional on an app command is a worktree path — there is no "since" here.`);
     process.exit(1);
   }
-  const cwd = worktreeArg ? resolve(worktreeArg) : process.cwd();
+  return resolved;
+}
+
+async function cmdApp(name, subcmd, worktreeArg) {
+  await ensureDaemon();
+  const cwd = resolveWorktreeArg(worktreeArg);
 
   // `app` with no name lists what is registered and what is running where.
   if (!name) {
@@ -899,7 +881,7 @@ const appFlag = APP_FLAG_VERBS.has(command) ? appFromFlags(args.slice(1)) : null
 const positional = (() => {
   const rest = args.slice(1);
   for (let i = 0; i < rest.length; i++) {
-    if (rest[i] === '--app' || rest[i] === '--prod' || rest[i] === '--dev') {
+    if (SESSION_VALUE_FLAGS.has(rest[i])) {
       i++;
       continue;
     }
@@ -927,7 +909,7 @@ switch (command) {
     else cmdLogs(arg1, arg2);
     break;
   case 'tail':
-    if (appFlag) cmdAppTail(appFlag, positional ? resolve(positional) : process.cwd());
+    if (appFlag) cmdAppTail(appFlag, positional);
     else cmdTail(arg1);
     break;
   case 'stop':

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -149,6 +149,19 @@ async function cmdStart(worktree, flags = []) {
   await ensureDaemon();
   const cwd = worktree ? resolve(worktree) : process.cwd();
 
+  // `start --app moderator` is the same gesture as `start`, aimed at a different app in the same
+  // worktree. It routes to /app/<name>/start rather than /sessions: an app is not a Next.js session
+  // and has no build dir, prewarm or branch watching to configure.
+  const appIndex = flags.indexOf('--app');
+  if (appIndex !== -1) {
+    const app = flags[appIndex + 1];
+    if (!app || app.startsWith('--')) {
+      console.error('Error: --app needs an app name (e.g. --app moderator)');
+      process.exit(1);
+    }
+    return cmdAppStart(app, cwd);
+  }
+
   let modes;
   try {
     modes = parseModeFlags(flags);
@@ -315,47 +328,71 @@ async function cmdAuth(subcmd) {
   console.log(JSON.stringify(result.data, null, 2));
 }
 
-async function cmdApp(name, subcmd) {
-  await ensureDaemon();
+// Shared by `start --app <name>` and `app <name> start`. The worktree travels with the request:
+// without it the daemon serves whichever checkout launched it, and does so silently.
+async function cmdAppStart(name, worktree) {
+  const result = await daemonRequest(`/app/${name}/start`, {
+    method: 'POST',
+    body: JSON.stringify({ worktree }),
+  });
+  if (!result.ok) {
+    console.error('Error:', result.error || result.data?.error || JSON.stringify(result.data));
+    if (result.data?.available) console.error('Available apps:', result.data.available.join(', '));
+    process.exit(1);
+  }
+  console.log(JSON.stringify(result.data, null, 2));
+}
 
-  // `app` with no name lists what is registered and what each one is doing.
+async function cmdApp(name, subcmd, worktreeArg) {
+  await ensureDaemon();
+  const cwd = worktreeArg ? resolve(worktreeArg) : process.cwd();
+
+  // `app` with no name lists what is registered and what is running where.
   if (!name) {
     const result = await daemonRequest('/apps');
     if (!result.ok) {
       console.error('Error:', result.error || JSON.stringify(result.data));
       process.exit(1);
     }
+    if (!result.data.apps.length) {
+      console.log(`No apps running. Available: ${result.data.available.join(', ')}`);
+      return;
+    }
     for (const app of result.data.apps) {
       const state = app.ready ? 'ready' : app.status;
-      console.log(`${app.name.padEnd(16)} ${state.padEnd(9)} ${app.url}`);
+      console.log(`${app.name.padEnd(16)} ${state.padEnd(9)} ${app.url.padEnd(24)} ${app.worktree}`);
       if (app.lastError) console.log(`${' '.repeat(16)} ${app.lastError}`);
     }
     return;
   }
 
   const action = subcmd || 'status';
+  if (action === 'start') return cmdAppStart(name, cwd);
+
   const routes = {
     status: ['', 'GET'],
     logs: ['/logs', 'GET'],
-    start: ['/start', 'POST'],
     stop: ['/stop', 'POST'],
     restart: ['/restart', 'POST'],
   };
   const route = routes[action];
   if (!route) {
     console.error(`Unknown app subcommand: ${action}`);
-    console.error('Usage: app <name> [status|start|stop|restart|logs]');
+    console.error('Usage: app <name> [status|start|stop|restart|logs] [worktree]');
     process.exit(1);
   }
 
   const [suffix, method] = route;
   const result = await daemonRequest(
-    `/app/${name}${suffix}`,
-    method === 'POST' ? { method } : undefined
+    `/app/${name}${suffix}?worktree=${encodeURIComponent(cwd)}`,
+    method === 'POST' ? { method, body: JSON.stringify({ worktree: cwd }) } : undefined
   );
   if (!result.ok) {
     console.error('Error:', result.error || result.data?.error || JSON.stringify(result.data));
     if (result.data?.available) console.error('Available apps:', result.data.available.join(', '));
+    if (result.data?.running?.length) {
+      console.error(`${name} is running in: ${result.data.running.join(', ')}`);
+    }
     process.exit(1);
   }
   console.log(JSON.stringify(result.data, null, 2));
@@ -799,7 +836,7 @@ switch (command) {
     cmdAuth(arg1);
     break;
   case 'app':
-    cmdApp(arg1, process.argv[4]);
+    cmdApp(arg1, args[2], args[3]);
     break;
   case 'shutdown':
     cmdShutdown();
@@ -822,8 +859,10 @@ switch (command) {
 Commands:
   status              Check daemon status and list sessions
   list                List all sessions
-  start [worktree] [--prod a,b] [--dev a,b]
-                      Start a dev server (default: current directory).
+  start [worktree] [--app name] [--prod a,b] [--dev a,b]
+                      Start a dev server (default: the main app, current directory).
+                      --app moderator|creator-studio starts that app from the same
+                      worktree instead, on its preferred port or the next free one.
                       Every env group defaults to dev; --prod moves named groups
                       (or "all") to production for this start only. See SKILL.md.
   probe [route]       Request a route with a hard timeout and say WHY it was slow.
@@ -837,8 +876,11 @@ Commands:
   restart <session-id> Restart a session
   rgb [subcmd]        RGB proxy control (status|start|stop|restart|logs)
   auth [subcmd]       Auth hub control (status|start|stop|restart|logs)
-  app                 List spoke apps (moderator, creator-studio, storage, notifications)
-  app <name> [subcmd] Spoke app control (status|start|stop|restart|logs)
+  app                 List running apps and what is available (moderator, creator-studio)
+  app <name> [subcmd] [worktree]
+                      App control (status|start|stop|restart|logs).
+                      Defaults to the current directory's worktree, not the
+                      checkout the daemon happens to have been started from.
   shutdown            Shutdown the daemon
   test run [wt]       Queue a unit-test run; returns position + the command to wait on it
   test wait <run-id>  Block until that run finishes; exits with the run's exit code

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -205,18 +205,22 @@ async function cmdStart(worktree, flags = []) {
 
 // `--app <name>` on a session verb means "the app in this worktree", so the whole lifecycle uses one
 // gesture rather than `start --app x` followed by `app x stop`. Returns null when no --app was given.
+//
+// It delegates to parseModeFlags rather than matching `--app` itself. A second hand-rolled matcher
+// was not equivalent to the first: it accepted `--app=` as empty and fell through, so `logs --app=`
+// silently tailed the MAIN app where `start --app=` errored — the same silent-wrong-target this
+// change exists to remove. One parser, one policy.
 function appFromFlags(flags = []) {
+  const appFlags = flags.filter((f) => f === '--app' || f.startsWith('--app='));
+  if (!appFlags.length) return null;
   const i = flags.indexOf('--app');
-  if (i !== -1) {
-    const value = flags[i + 1];
-    if (!value || value.startsWith('--')) {
-      console.error('Error: --app needs an app name, e.g. --app moderator');
-      process.exit(1);
-    }
-    return value;
+  const pair = i === -1 ? appFlags : ['--app', flags[i + 1]].filter((v) => v !== undefined);
+  try {
+    return parseModeFlags(pair).app;
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
   }
-  const inline = flags.find((f) => f.startsWith('--app='));
-  return inline ? inline.slice('--app='.length) : null;
 }
 
 async function cmdLogs(sessionId, since) {
@@ -843,7 +847,14 @@ const args = process.argv.slice(2);
 const command = args[0];
 // One gesture for the whole lifecycle: `start --app x` then `logs --app x`, `stop --app x`. Without
 // this only `start` took --app and everything after it needed the second `app <name> …` vocabulary.
-const appFlag = appFromFlags(args.slice(1));
+//
+// Only for the verbs that dispatch on it below. Parsing it for EVERY command would let a future
+// `--app` on `test`, `wt` or `probe` be intercepted into the app vocabulary before that verb's own
+// parser ever saw it.
+const APP_FLAG_VERBS = new Set(['start', 'logs', 'tail', 'stop', 'restart']);
+const appFlag = APP_FLAG_VERBS.has(command) ? appFromFlags(args.slice(1)) : null;
+// `stop <worktree> --app moderator` must mean the same tree as `start <worktree> --app moderator`.
+const positional = args.slice(1).find((a) => !a.startsWith('--') && a !== appFlag);
 const arg1 = args[1];
 const arg2 = args[2];
 
@@ -859,18 +870,19 @@ switch (command) {
     else cmdStart(arg1, args.slice(2));
     break;
   case 'logs':
-    if (appFlag) cmdApp(appFlag, 'logs');
+    if (appFlag) cmdApp(appFlag, 'logs', positional);
     else cmdLogs(arg1, arg2);
     break;
   case 'tail':
-    cmdTail(arg1);
+    if (appFlag) cmdApp(appFlag, 'logs', positional);
+    else cmdTail(arg1);
     break;
   case 'stop':
-    if (appFlag) cmdApp(appFlag, 'stop');
+    if (appFlag) cmdApp(appFlag, 'stop', positional);
     else cmdStop(arg1);
     break;
   case 'restart':
-    if (appFlag) cmdApp(appFlag, 'restart');
+    if (appFlag) cmdApp(appFlag, 'restart', positional);
     else cmdRestart(arg1);
     break;
   case 'rgb':

--- a/.claude/skills/dev-server/env-modes.example
+++ b/.claude/skills/dev-server/env-modes.example
@@ -13,6 +13,10 @@
 # ⚠️ These are the only services with a dev counterpart. The orchestrator, payments, S3,
 # ClickHouse, the notifications DB, the feeds proxy and OpenSearch have none — a session in `dev`
 # mode still talks to production for those. Pressing Generate spends real Buzz whatever this says.
+#
+# The auth hub is not movable at all, for a different reason: it is one shared process reading its
+# own apps/auth/.env, so an overlay here would only point the app at a hub nobody is running.
+# env-modes.mjs refuses an [auth-hub.*] section rather than honouring it.
 
 # A section must restate EVERY key that names the same service. The overlay only moves keys it
 # mentions, so an omitted one keeps its `.env` value — that is how you get writes on production and

--- a/.claude/skills/dev-server/scripts/app-registry.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/app-registry.selftest.mjs
@@ -207,6 +207,11 @@ check(
   true
 );
 check('a stopping entry lends nothing', inheritablePort({ status: 'running', port: 5174, stopping: true }), null);
+// The two questions appIsLive is asked are NOT the same, and this is the pair that proves it.
+// "May a start reuse this?" -> no. "Does shutdown still need to wait on it?" -> yes. A single
+// predicate serving both is how a stopping app gets skipped at exit and outlives the daemon.
+const stoppingEntry = { status: 'running', process: {}, port: 5174, stopping: true };
+check('shutdown must still wait on a stopping entry', appIsLive(stoppingEntry) || stoppingEntry.stopping, true);
 // A port of 0 must not short-circuit the allocator into an ephemeral bind. Unreachable today, but the
 // inline version this was lifted from treated 0 as falsy and the extraction must not change that.
 check('a port of 0 is not inheritable', inheritablePort({ status: 'crashed', process: null, port: 0 }), null);

--- a/.claude/skills/dev-server/scripts/app-registry.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/app-registry.selftest.mjs
@@ -8,11 +8,15 @@ import { tmpdir } from 'os';
 import { resolve } from 'path';
 import {
   APP_REGISTRY,
+  appEnvChain,
   appReservedPorts,
+  appSessionKey,
   appSessions,
   primaryCheckout,
+  primaryResolution,
+  withAppAllocation,
 } from './daemon.mjs';
-import { primaryOf } from './worktree.mjs';
+import { primaryOf, samePath } from './worktree.mjs';
 
 const failures = [];
 let checks = 0;
@@ -22,6 +26,14 @@ function check(name, actual, expected) {
   if (actual !== expected) {
     failures.push(`${name}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
   }
+}
+
+// First, because it changes what every failure below MEANS. Outside a git repo primaryCheckout
+// falls back and the registry checks go red reporting a missing app directory, which sends the
+// reader looking for apps/moderator when the real answer is that git could not be asked.
+check('primaryCheckout was derived from git, not fallen back', primaryResolution.derived, true);
+if (!primaryResolution.derived) {
+  console.error(`  (primary fell back to ${primaryCheckout}: ${primaryResolution.error})`);
 }
 
 // --- registry invariants ---
@@ -56,6 +68,10 @@ for (const name of names) {
   }
 }
 
+// True only because appSessions is empty in a fresh process — this asserts a property of the
+// environment alongside one of the function. Inserting a probe on an app's OWN preferred port before
+// this point would flip it.
+//
 // A live app session reserves its port for every app, including itself — that is what stops the main
 // app's allocator handing the same number out twice.
 const probeName = names[0];
@@ -83,6 +99,61 @@ try {
 } finally {
   rmSync(empty, { recursive: true, force: true });
 }
+
+// --- path identity ---
+// appSessionKey is what stopped two agents whose shells disagree on drive-letter casing getting two
+// vite processes on one worktree. It is pure; the live two-start control that found it is not
+// repeatable by the next person, so pin it here too.
+const upper = 'C:\\Dev\\Repos\\work\\worktrees\\x';
+const lower = 'c:\\dev\\repos\\work\\worktrees\\x';
+if (process.platform === 'win32') {
+  check('appSessionKey ignores drive-letter casing', appSessionKey(upper, 'moderator'), appSessionKey(lower, 'moderator'));
+  check('samePath ignores drive-letter casing', samePath(upper, lower), true);
+  // The chain dedupe has to answer path-equality the same way, or the same file lands in it twice.
+  check('appEnvChain dedupes across casing', appEnvChain(primaryCheckout.toLowerCase(), names[0]).length, 1);
+} else {
+  check('samePath is exact off win32', samePath(upper, lower), false);
+}
+check('samePath still separates genuinely different trees', samePath(upper, upper + 'y'), false);
+check('appSessionKey separates apps in one worktree', appSessionKey(upper, 'a') === appSessionKey(upper, 'b'), false);
+
+// --- the allocation lock ---
+// Two separate properties, and it is worth being exact about which line buys which, because the
+// obvious guess is wrong. The chain surviving a rejection is bought by `lock.then(fn, fn)` — its
+// reject arm runs the next callback even when the lock it chained from rejected. Measured: removing
+// the reject arm from the TAIL does not deadlock anything.
+//
+// What the tail's reject arm buys is that a rejected allocation never escapes as an unhandled
+// rejection, which in this daemon would be a process-level warning nobody attributes to app starts.
+// That is the property with no other guard, so it is asserted directly.
+const unhandled = [];
+const onUnhandled = (err) => unhandled.push(err);
+process.on('unhandledRejection', onUnhandled);
+
+const order = [];
+const first = withAppAllocation(async () => {
+  order.push('a-start');
+  await new Promise((r) => setTimeout(r, 20));
+  order.push('a-end');
+}).catch(() => order.push('a-rejected'));
+const second = withAppAllocation(async () => {
+  order.push('b');
+  throw new Error('deliberate');
+}).catch(() => order.push('b-rejected'));
+const third = withAppAllocation(async () => order.push('c'));
+await Promise.all([first, second, third]);
+check('the lock serialises, it does not interleave', order.join(','), 'a-start,a-end,b,b-rejected,c');
+check('a rejected allocation does not wedge the chain', order.includes('c'), true);
+
+// The rejecting call has to be the LAST one, and it has to be given real time to surface. A
+// following allocation attaches its own handler to the rejected lock, so a rejection sandwiched
+// between two others is handled either way and the check would pass whatever the tail does.
+await withAppAllocation(async () => {
+  throw new Error('deliberate trailing failure');
+}).catch(() => {});
+await new Promise((r) => setTimeout(r, 60));
+process.off('unhandledRejection', onUnhandled);
+check('a trailing rejected allocation does not escape as an unhandled rejection', unhandled.length, 0);
 
 if (failures.length) {
   console.error('FAIL');

--- a/.claude/skills/dev-server/scripts/app-registry.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/app-registry.selftest.mjs
@@ -16,7 +16,9 @@ import {
   primaryResolution,
   withAppAllocation,
 } from './daemon.mjs';
-import { primaryOf, samePath } from './worktree.mjs';
+import { primaryOf } from './worktree.mjs';
+// From the leaf module — the single definition that daemon.mjs and worktree.mjs now both import.
+import { samePath, canonicalPath } from './paths.mjs';
 
 const failures = [];
 let checks = 0;
@@ -115,6 +117,9 @@ if (process.platform === 'win32') {
   check('samePath is exact off win32', samePath(upper, lower), false);
 }
 check('samePath still separates genuinely different trees', samePath(upper, upper + 'y'), false);
+// The Map key and the comparator have to agree, or appSessionKey and samePath disagree about the
+// same two paths — which is the bug this PR fixed in four places.
+check('canonicalPath agrees with samePath', canonicalPath(upper) === canonicalPath(lower), samePath(upper, lower));
 check('appSessionKey separates apps in one worktree', appSessionKey(upper, 'a') === appSessionKey(upper, 'b'), false);
 
 // --- the allocation lock ---

--- a/.claude/skills/dev-server/scripts/app-registry.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/app-registry.selftest.mjs
@@ -9,10 +9,13 @@ import { resolve } from 'path';
 import {
   APP_REGISTRY,
   appEnvChain,
+  appIsLive,
   appReservedPorts,
   appSessionKey,
   appSessions,
   primaryCheckout,
+  inheritablePort,
+  releaseIfOurs,
   primaryResolution,
   withAppAllocation,
 } from './daemon.mjs';
@@ -123,14 +126,17 @@ check('canonicalPath agrees with samePath', canonicalPath(upper) === canonicalPa
 check('appSessionKey separates apps in one worktree', appSessionKey(upper, 'a') === appSessionKey(upper, 'b'), false);
 
 // --- the allocation lock ---
-// Two separate properties, and it is worth being exact about which line buys which, because the
-// obvious guess is wrong. The chain surviving a rejection is bought by `lock.then(fn, fn)` — its
-// reject arm runs the next callback even when the lock it chained from rejected. Measured: removing
-// the reject arm from the TAIL does not deadlock anything.
+// Two properties, and it is worth being exact about which line buys which — my first two attempts at
+// this comment each credited the wrong one.
 //
-// What the tail's reject arm buys is that a rejected allocation never escapes as an unhandled
-// rejection, which in this daemon would be a process-level warning nobody attributes to app starts.
-// That is the property with no other guard, so it is asserted directly.
+// `appAllocationLock` is always `run.then(() => {}, () => {})`, and both arms return undefined, so
+// that promise can never reject — which means the head's `lock.then(fn, fn)` reject arm is
+// UNREACHABLE in the shipped code. The chain surviving a rejection is bought by the tail. The two
+// are redundant with each other and both are kept, so that neither line is load-bearing alone.
+//
+// What the tail's reject arm ALSO buys, and nothing else does, is that a rejected allocation never
+// escapes as an unhandled rejection — a process-level warning nobody would attribute to app starts.
+// That is the property with no other guard, so it is the one asserted.
 const unhandled = [];
 const onUnhandled = (err) => unhandled.push(err);
 process.on('unhandledRejection', onUnhandled);
@@ -145,7 +151,11 @@ const second = withAppAllocation(async () => {
   order.push('b');
   throw new Error('deliberate');
 }).catch(() => order.push('b-rejected'));
-const third = withAppAllocation(async () => order.push('c'));
+const third = withAppAllocation(async () => order.push('c')).catch(() =>
+  // Symmetry with the two above. Without it a mutation that rejects here kills the run with a raw
+  // stack trace instead of a named failure — still red, but red in a way nobody can read.
+  order.push('c-rejected')
+);
 await Promise.all([first, second, third]);
 check('the lock serialises, it does not interleave', order.join(','), 'a-start,a-end,b,b-rejected,c');
 check('a rejected allocation does not wedge the chain', order.includes('c'), true);
@@ -156,9 +166,50 @@ check('a rejected allocation does not wedge the chain', order.includes('c'), tru
 await withAppAllocation(async () => {
   throw new Error('deliberate trailing failure');
 }).catch(() => {});
-await new Promise((r) => setTimeout(r, 60));
+// setImmediate, not a timer. Node publishes the unhandled-rejection list at the end of the tick,
+// after microtasks drain and before the check phase — so this is the FIRST hop that can observe it,
+// and observing it is a guarantee rather than a race. A timer can only ever be later, which is why
+// an arbitrary 60ms also worked; the problem with a number is that the instinct on a slow box is to
+// raise it, which is widening the budget rather than fixing anything.
+await new Promise((r) => setImmediate(r));
 process.off('unhandledRejection', onUnhandled);
 check('a trailing rejected allocation does not escape as an unhandled rejection', unhandled.length, 0);
+
+// --- the two decisions the concurrent-start fix turns on ---
+// These lived inline in the HTTP handler, where reverting the liveness rule to `status === 'running'`
+// — the exact bug fixed twice on this branch — left every check green. The only evidence was a live
+// control run once by hand, which the next person cannot repeat.
+check('no entry is not live', appIsLive(undefined), false);
+check('a starting entry IS live', appIsLive({ status: 'starting' }), true);
+check('a running entry with no process is still live', appIsLive({ status: 'running', process: null }), true);
+// proc.on('error') sets status without clearing the process, so status alone would call this dead
+// and hand its port to a second spawn.
+check('an errored entry holding a live process is live', appIsLive({ status: 'error', process: {} }), true);
+check('a crashed entry with no process is not live', appIsLive({ status: 'crashed', process: null }), false);
+
+check('a dead entry lends its port', inheritablePort({ status: 'crashed', process: null, port: 5174 }), 5174);
+check('a live entry lends nothing', inheritablePort({ status: 'starting', port: 5174 }), null);
+check('an errored-but-alive entry lends nothing', inheritablePort({ status: 'error', process: {}, port: 5174 }), null);
+check('no entry lends nothing', inheritablePort(undefined), null);
+
+// The release has to prove the entry is still the one it means to release. Every caller awaits
+// something first — five path probes, or stop()'s 800ms — and a start arriving in that window
+// replaces the entry. Releasing by key alone then deletes the NEW one and leaves its vite running
+// with nothing referencing it, which is the orphan this branch has now fixed in three places.
+const relKey = '__selftest__::release';
+const mine = { port: 6001 };
+const theirs = { port: 6002 };
+appSessions.set(relKey, mine);
+releaseIfOurs(relKey, mine);
+check('releases the entry when it is still ours', appSessions.has(relKey), false);
+
+appSessions.set(relKey, theirs);
+releaseIfOurs(relKey, mine);
+check('does NOT release an entry that was replaced underneath', appSessions.get(relKey), theirs);
+appSessions.delete(relKey);
+
+releaseIfOurs(relKey, mine);
+check('releasing a key that is not there is a no-op', appSessions.has(relKey), false);
 
 if (failures.length) {
   console.error('FAIL');

--- a/.claude/skills/dev-server/scripts/app-registry.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/app-registry.selftest.mjs
@@ -1,0 +1,92 @@
+// Guards for the app registry, the port-reservation math, and the primary-worktree detection.
+//
+// The registry check is the one the incident asks for: `storage` and `notifications` sat in this
+// registry for months and could never start, because neither has a vite.config.ts. Nothing noticed,
+// because the only way to find out was to run them and read an error worded as an auth-hub problem.
+import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { resolve } from 'path';
+import {
+  APP_REGISTRY,
+  appReservedPorts,
+  appSessions,
+  primaryCheckout,
+} from './daemon.mjs';
+import { primaryOf } from './worktree.mjs';
+
+const failures = [];
+let checks = 0;
+
+function check(name, actual, expected) {
+  checks++;
+  if (actual !== expected) {
+    failures.push(`${name}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+// --- registry invariants ---
+const names = Object.keys(APP_REGISTRY);
+check('registry is not empty', names.length > 0, true);
+
+for (const [name, spec] of Object.entries(APP_REGISTRY)) {
+  const appDir = resolve(primaryCheckout, spec.path);
+  check(`${name}: app directory exists`, existsSync(appDir), true);
+  // Every registered app is spawned with `vite dev`. One without a vite config cannot start, and the
+  // failure surfaces far from the registry entry that caused it.
+  check(`${name}: has a vite config`, existsSync(resolve(appDir, 'vite.config.ts')), true);
+  check(`${name}: preferredPort is a number`, Number.isInteger(spec.preferredPort), true);
+}
+
+const ports = names.map((n) => APP_REGISTRY[n].preferredPort);
+check('preferred ports are unique', new Set(ports).size, ports.length);
+
+// --- reservation math ---
+// The claim in appReservedPorts' comment is that EVERY OTHER app's preferred port is held back, so
+// one app drifting never displaces another from its documented number. Nothing checked it.
+for (const name of names) {
+  const reserved = appReservedPorts(name);
+  check(`${name}: its own preferred port is NOT reserved against it`, reserved.has(APP_REGISTRY[name].preferredPort), false);
+  for (const other of names) {
+    if (other === name) continue;
+    check(
+      `${name}: ${other}'s preferred port is held back`,
+      reserved.has(APP_REGISTRY[other].preferredPort),
+      true
+    );
+  }
+}
+
+// A live app session reserves its port for every app, including itself — that is what stops the main
+// app's allocator handing the same number out twice.
+const probeName = names[0];
+const probeKey = '__selftest__::probe';
+const probePort = 59999;
+appSessions.set(probeKey, { port: probePort, name: probeName, worktree: '__selftest__' });
+try {
+  check('a live app session reserves its port', appReservedPorts(probeName).has(probePort), true);
+} finally {
+  appSessions.delete(probeKey);
+}
+check('the probe released its reservation', appReservedPorts(probeName).has(probePort), false);
+
+// --- primaryOf ---
+// `wt rm` refuses to delete whatever this returns. Run through a worktree's own copy of the CLI it
+// used to return that worktree, which offered the real main checkout as removable.
+check(
+  'primaryOf takes the FIRST entry, not the caller directory',
+  primaryOf([{ path: 'C:/a' }, { path: 'C:/b' }], 'C:/b'),
+  'C:/a'
+);
+const empty = mkdtempSync(resolve(tmpdir(), 'primary-of-'));
+try {
+  check('primaryOf falls back to the resolved argument', primaryOf([], empty), resolve(empty));
+} finally {
+  rmSync(empty, { recursive: true, force: true });
+}
+
+if (failures.length) {
+  console.error('FAIL');
+  for (const f of failures) console.error('  ' + f);
+  process.exit(1);
+}
+console.log(`app-registry selftest: ${checks} checks passed`);

--- a/.claude/skills/dev-server/scripts/app-registry.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/app-registry.selftest.mjs
@@ -8,6 +8,7 @@ import { tmpdir } from 'os';
 import { resolve } from 'path';
 import {
   APP_REGISTRY,
+  AppSession,
   appEnvChain,
   appIsLive,
   appReservedPorts,
@@ -15,6 +16,7 @@ import {
   appSessions,
   primaryCheckout,
   inheritablePort,
+  settleDelayMs,
   releaseIfOurs,
   primaryResolution,
   withAppAllocation,
@@ -191,6 +193,34 @@ check('a dead entry lends its port', inheritablePort({ status: 'crashed', proces
 check('a live entry lends nothing', inheritablePort({ status: 'starting', port: 5174 }), null);
 check('an errored-but-alive entry lends nothing', inheritablePort({ status: 'error', process: {}, port: 5174 }), null);
 check('no entry lends nothing', inheritablePort(undefined), null);
+
+// A stop in flight owns its port until it proves the port came back. Without this a concurrent start
+// is handed `reused: true` for a server about to be killed, or inherits a port still being freed.
+check('a stopping entry is not live', appIsLive({ status: 'running', process: {}, stopping: true }), false);
+// The concurrent-start orphan in one line: a freshly constructed session goes into the map inside the
+// allocation lock, but start() is awaited outside it. If it is born dead, a second start inherits its
+// port and spawns a rival. Invisible whenever the auth hub is already running, because the await
+// between them is then a no-op — which is exactly why the live control missed it.
+check(
+  'a freshly constructed AppSession is already live',
+  appIsLive(new AppSession('moderator', primaryCheckout, 5174, [])),
+  true
+);
+check('a stopping entry lends nothing', inheritablePort({ status: 'running', port: 5174, stopping: true }), null);
+// A port of 0 must not short-circuit the allocator into an ephemeral bind. Unreachable today, but the
+// inline version this was lifted from treated 0 as falsy and the extraction must not change that.
+check('a port of 0 is not inheritable', inheritablePort({ status: 'crashed', process: null, port: 0 }), null);
+
+// --- the settle window's arithmetic ---
+// The constant itself is a property of spawn latency on this box and belongs in its comment, not in a
+// test. What IS testable is the claim the comment makes: that it waits only the REMAINDER.
+check('never spawned means no wait', settleDelayMs(null, 1_000_000, 3000), 0);
+check('spawned just now waits the whole window', settleDelayMs(1_000_000, 1_000_000, 3000), 3000);
+check('spawned 2900ms ago waits only the remainder', settleDelayMs(1_000_000, 1_002_900, 3000), 100);
+check('spawned long ago waits nothing', settleDelayMs(1_000_000, 9_000_000, 3000), 0);
+// A clock step or a VM resume between spawn and stop makes `now - spawnedAt` negative, and an
+// unclamped `settle - negative` waits LONGER than the window.
+check('a clock going backwards cannot extend the wait', settleDelayMs(1_000_000, 900_000, 3000), 3000);
 
 // The release has to prove the entry is still the one it means to release. Every caller awaits
 // something first — five path probes, or stop()'s 800ms — and a start arriving in that window

--- a/.claude/skills/dev-server/scripts/cli-verbs.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/cli-verbs.selftest.mjs
@@ -1,0 +1,69 @@
+// Every function the dispatch switch in cli.mjs calls must actually be defined in cli.mjs.
+//
+// This exists because a refactor deleted `cmdStop` and `cmdRestart` while leaving both call sites,
+// so `stop <session-id>` and `restart <session-id>` — the two most-used commands in the skill —
+// threw ReferenceError for everyone on that branch. Nothing in the chain saw it: `node --check`
+// passes (a missing binding is not a syntax error), `pnpm typecheck` is scoped to src/, CI's ESLint
+// filters by path prefix, and every other selftest imports daemon.mjs / worktree.mjs / paths.mjs.
+// Not one of them loads cli.mjs, so the file holding all the user-facing dispatch had no reader.
+//
+// It is a source check rather than a run of each verb, and that is deliberate: the first version
+// spawned the CLI once per verb, which took 56s AND started a real daemon, because most verbs call
+// ensureDaemon() before validating their own arguments. A test that boots servers to prove a symbol
+// exists is worse than the bug. Importing cli.mjs would not work either — the switch runs at import
+// and an unevaluated branch stays unevaluated.
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const cliPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'cli.mjs');
+const src = readFileSync(cliPath, 'utf-8');
+const failures = [];
+let checks = 0;
+
+// Everything callable that cli.mjs defines: `function f(`, `async function f(`, `const f = (`,
+// `const f = async (`, and the imports at the top.
+const defined = new Set();
+for (const re of [
+  /(?:^|\n)\s*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/g,
+  /(?:^|\n)\s*(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:\(|function)/g,
+  /import\s*\{([^}]*)\}\s*from/g,
+]) {
+  for (const m of src.matchAll(re)) {
+    for (const name of m[1].split(',')) {
+      const clean = name.trim().split(/\s+as\s+/).pop()?.trim();
+      if (clean) defined.add(clean);
+    }
+  }
+}
+
+// The dispatch switch is the surface a user reaches. Take everything it calls.
+const switchStart = src.indexOf('switch (command) {');
+if (switchStart === -1) {
+  failures.push('could not find the dispatch switch — this guard is looking at the wrong thing');
+}
+const switchBody = switchStart === -1 ? '' : src.slice(switchStart);
+
+const called = new Set();
+for (const m of switchBody.matchAll(/\b(cmd[A-Za-z0-9_$]*)\s*\(/g)) called.add(m[1]);
+
+// If this ever drops to a handful, the regex has stopped matching and the guard has gone quiet
+// without failing — the shape of an inert check.
+checks++;
+if (called.size < 8) {
+  failures.push(`only ${called.size} cmd* calls found in the switch — the extractor is probably broken`);
+}
+
+for (const name of [...called].sort()) {
+  checks++;
+  if (!defined.has(name)) {
+    failures.push(`the dispatch switch calls \`${name}(\` and cli.mjs does not define it`);
+  }
+}
+
+if (failures.length) {
+  console.error('FAIL');
+  for (const f of failures) console.error('  ' + f);
+  process.exit(1);
+}
+console.log(`cli-verbs selftest: ${checks} checks, ${called.size} dispatch targets all defined`);

--- a/.claude/skills/dev-server/scripts/cli-verbs.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/cli-verbs.selftest.mjs
@@ -28,6 +28,10 @@ for (const re of [
   /(?:^|\n)\s*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/g,
   /(?:^|\n)\s*(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:\(|function)/g,
   /import\s*\{([^}]*)\}\s*from/g,
+  // Destructuring, which the `const NAME =` pattern above does not match. cli.mjs reaches `cmdStale`
+  // and `cmdRemove` via `const { cmdStale, cmdRemove } = await import('./scripts/worktree.mjs')`,
+  // so without this the widened scan below reports both as undefined.
+  /(?:const|let|var)\s*\{([^}]*)\}\s*=/g,
 ]) {
   for (const m of src.matchAll(re)) {
     for (const name of m[1].split(',')) {
@@ -37,27 +41,31 @@ for (const re of [
   }
 }
 
-// The dispatch switch is the surface a user reaches. Take everything it calls.
-const switchStart = src.indexOf('switch (command) {');
-if (switchStart === -1) {
+// The WHOLE file, not just the dispatch switch. Scanning only the switch missed every helper reached
+// from another function — including `followLogs`, whose extraction is what deleted cmdStop and
+// cmdRestart in the first place. A slice running a few lines further would have taken it too, and a
+// switch-only guard would have stayed green over its own cause.
+const called = new Set();
+for (const m of src.matchAll(/\b((?:cmd|follow)[A-Za-z0-9_$]*)\s*\(/g)) called.add(m[1]);
+
+// The switch still has to be there. Without it this file is reading something that is not the CLI,
+// and every result below is meaningless rather than reassuring.
+checks++;
+if (!src.includes('switch (command) {')) {
   failures.push('could not find the dispatch switch — this guard is looking at the wrong thing');
 }
-const switchBody = switchStart === -1 ? '' : src.slice(switchStart);
-
-const called = new Set();
-for (const m of switchBody.matchAll(/\b(cmd[A-Za-z0-9_$]*)\s*\(/g)) called.add(m[1]);
 
 // If this ever drops to a handful, the regex has stopped matching and the guard has gone quiet
 // without failing — the shape of an inert check.
 checks++;
 if (called.size < 8) {
-  failures.push(`only ${called.size} cmd* calls found in the switch — the extractor is probably broken`);
+  failures.push(`only ${called.size} cmd*/follow* calls found — the extractor is probably broken`);
 }
 
 for (const name of [...called].sort()) {
   checks++;
   if (!defined.has(name)) {
-    failures.push(`the dispatch switch calls \`${name}(\` and cli.mjs does not define it`);
+    failures.push(`cli.mjs calls \`${name}(\` and does not define it`);
   }
 }
 
@@ -66,4 +74,4 @@ if (failures.length) {
   for (const f of failures) console.error('  ' + f);
   process.exit(1);
 }
-console.log(`cli-verbs selftest: ${checks} checks, ${called.size} dispatch targets all defined`);
+console.log(`cli-verbs selftest: ${checks} checks, ${called.size} call targets all defined`);

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -1782,7 +1782,7 @@ class AuthHub {
     const deadline = Date.now() + STOP_PORT_VERIFY_MS;
     while (Date.now() < deadline) {
       if (await isPortFree(this.port)) return this.getStatus();
-      await new Promise((r) => setTimeout(r, 250));
+      await new Promise((r) => setTimeout(r, PORT_RELEASE_POLL));
     }
     this.lastError =
       `${this.label} stopped but port ${this.port} is still held — a child may have outlived the ` +

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -1499,6 +1499,7 @@ class AuthHub {
     this.process = null;
     this.startPromise = null;
     this.spawnedAtMs = null;
+    this.spawnEnvCache = null;
     this.status = 'stopped'; // stopped | starting | running | crashed | error | disabled
     this.ready = false;
     this.readyAt = null;
@@ -1527,7 +1528,16 @@ class AuthHub {
   // chain is what lets it inherit the primary checkout's. Either way process.env is the floor, which
   // is why the DATABASE_URL warning has to be computed from this and not from the chain alone.
   spawnEnv() {
-    return this.envPaths.length ? { ...process.env, ...loadEnvChain(this.envPaths) } : process.env;
+    // Cached for the duration of one start. Three callers read this — the DATABASE_URL refusal, the
+    // host warning and the spawn options — and without the cache each one re-read every file in the
+    // chain from disk. Cheap either way (~200us a read), but the three must also agree with each
+    // other: the thing refused, the thing described and the thing handed to the child are one object.
+    if (!this.spawnEnvCache) {
+      this.spawnEnvCache = this.envPaths.length
+        ? { ...process.env, ...loadEnvChain(this.envPaths) }
+        : process.env;
+    }
+    return this.spawnEnvCache;
   }
 
   // `::` (dual-stack), not a single literal. Bound to `127.0.0.1` these servers answered on v4 and
@@ -1567,6 +1577,9 @@ class AuthHub {
   // thread, which is why probePath/checkPath exist; a fixed local path never reached that, a worktree
   // argument can. pathExists is the timeout-raced one.
   async #start() {
+    // Dropped per start, not per instance: a restart after an .env edit must see the new values.
+    this.spawnEnvCache = null;
+
     if (this.process) {
       this.addLog('info', `${this.label} already running`);
       return this.getStatus();
@@ -3058,6 +3071,7 @@ if (invokedDirectly) {
 
 export {
   APP_REGISTRY,
+  AppSession,
   appEnvChain,
   appIsLive,
   appSessionKey,

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -51,13 +51,19 @@ function resolvePrimaryCheckout() {
       cwd: projectRoot,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      // This runs at module load, before the listener exists, so a wedged git would hang the daemon
+      // where `ensureDaemon` reports a bare "Failed to start daemon" with nothing naming git.
+      timeout: 5000,
     }).trim();
-    if (gitCommonDir) return resolve(gitCommonDir, '..');
-  } catch (e) {}
-  return projectRoot;
+    if (gitCommonDir) return { path: resolve(gitCommonDir, '..'), derived: true, error: null };
+  } catch (e) {
+    return { path: projectRoot, derived: false, error: e.message };
+  }
+  return { path: projectRoot, derived: false, error: 'git named no common dir' };
 }
 
-const primaryCheckout = resolvePrimaryCheckout();
+const primaryResolution = resolvePrimaryCheckout();
+const primaryCheckout = primaryResolution.path;
 
 // Configuration
 const DEFAULT_BASE_DEV_PORT = 3000;
@@ -1533,13 +1539,17 @@ class AuthHub {
     return ['exec', 'vite', 'dev', '--host', '::', '--port', String(this.port), '--strictPort'];
   }
 
-  start() {
+  // Async because `this.path` is now caller-supplied — an app resolves it against whatever worktree
+  // the request named. A synchronous stat on an unreachable path measured 21s on this daemon's only
+  // thread, which is why probePath/checkPath exist; a fixed local path never reached that, a worktree
+  // argument can. pathExists is the timeout-raced one.
+  async start() {
     if (this.process) {
       this.addLog('info', `${this.label} already running`);
       return this.getStatus();
     }
 
-    if (!existsSync(this.path)) {
+    if (!(await pathExists(this.path))) {
       this.status = 'error';
       this.lastError = `${this.label} path not found: ${this.path}`;
       this.addLog('error', this.lastError);
@@ -1547,14 +1557,35 @@ class AuthHub {
     }
 
     // `null` means the app has no .env of its own to require — it inherits the chain instead.
-    if (this.requiredEnvPath && !existsSync(this.requiredEnvPath)) {
+    if (this.requiredEnvPath && !(await pathExists(this.requiredEnvPath))) {
       this.status = 'error';
       this.lastError = `${this.label} .env missing: ${this.requiredEnvPath}`;
       this.addLog('error', this.lastError);
       return this.getStatus();
     }
 
-    if (!existsSync(resolve(this.path, 'node_modules'))) {
+    // An app with no .env of its own inherits the chain — but a chain that resolves to nothing at all
+    // means primaryCheckout fell back (see resolvePrimaryCheckout) and the app would start with no
+    // DATABASE_URL, failing later inside SvelteKit where it reads as the app's bug. Refuse here.
+    if (!this.requiredEnvPath && this.envPaths.length) {
+      const present = [];
+      for (const envPath of this.envPaths) {
+        if (await pathExists(envPath)) present.push(envPath);
+      }
+      if (!present.length) {
+        this.status = 'error';
+        this.lastError =
+          `${this.label} has no env: none of ${this.envPaths.join(', ')} exist. ` +
+          (primaryResolution.derived
+            ? 'Copy one from the primary checkout.'
+            : `The primary checkout could not be resolved from git (${primaryResolution.error}), ` +
+              'so the fall-through has nothing to fall back to.');
+        this.addLog('error', this.lastError);
+        return this.getStatus();
+      }
+    }
+
+    if (!(await pathExists(resolve(this.path, 'node_modules')))) {
       this.status = 'error';
       this.lastError = `${this.label} dependencies not installed. Run: pnpm install`;
       this.addLog('error', this.lastError);
@@ -1566,6 +1597,15 @@ class AuthHub {
     this.readyAt = null;
     this.lastError = null;
     this.addLog('info', `Starting ${this.label} on port ${this.port}: ${this.path}`);
+
+    // A fresh worktree inherits the primary checkout's apps/<name>/.env, and those point at the
+    // production database. Nothing in the start output used to say so, and a moderator remove-click
+    // deletes live rows — so name the host here, where it is read at the moment it matters, rather
+    // than only in a doc nobody opens at start time.
+    if (this.envPaths.length) {
+      this.dbHost = describeDatabaseHost(loadEnvChain(this.envPaths));
+      if (this.dbHost) this.addLog('warn', `${this.label} DATABASE_URL host: ${this.dbHost}`);
+    }
 
     const isWindows = process.platform === 'win32';
     const pnpmCmd = isWindows ? 'pnpm.cmd' : 'pnpm';
@@ -1681,7 +1721,7 @@ class AuthHub {
 
   async restart() {
     await this.stop();
-    return this.start();
+    return await this.start();
   }
 
   getStatus() {
@@ -1733,11 +1773,33 @@ class AppSession extends AuthHub {
     // primary checkout instead of refusing to start, which is what `requiredEnvPath: null` buys.
     this.requiredEnvPath = null;
     this.envPaths = envPaths;
+    this.dbHost = null;
   }
 
   getStatus() {
     const { jwksUrl, ...rest } = super.getStatus();
-    return { ...rest, name: this.name, worktree: this.worktree, enabled: true };
+    return {
+      ...rest,
+      name: this.name,
+      worktree: this.worktree,
+      enabled: true,
+      // Host only — see describeDatabaseHost. Never the connection string.
+      dbHost: this.dbHost ?? null,
+    };
+  }
+}
+
+// Host only, never the credential. A DATABASE_URL is `postgres://user:pass@host:port/db`, so the
+// value must never be logged whole — this parses out the host and drops everything else on the
+// floor, and returns null rather than guessing if it cannot.
+function describeDatabaseHost(envVars) {
+  const url = envVars.DATABASE_URL;
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    return parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname;
+  } catch (e) {
+    return null;
   }
 }
 
@@ -1757,7 +1819,35 @@ function appEnvChain(worktree, name) {
 const appSessions = new Map();
 
 function appSessionKey(worktree, name) {
-  return `${worktree}::${name}`;
+  // Windows hands back whatever drive-letter casing the caller's shell used, so one tree arrives as
+  // `C:\Dev\...` from one agent and `c:\dev\...` from another. findSessionByWorktree already treats
+  // those as one tree; a raw string key here would treat them as two, put two vite processes on the
+  // same worktree, and leave the first addressable by nothing while it holds a port.
+  const canonical = process.platform === 'win32' ? worktree.toLowerCase() : worktree;
+  return `${canonical}::${name}`;
+}
+
+// Every app's preferred port is held back, not just the taken ones: moderator drifting off 5174
+// would otherwise land on 5175 and displace creator-studio from its own documented number for as
+// long as it ran.
+function appReservedPorts(name) {
+  const reserved = getUsedPorts();
+  for (const [other, spec] of Object.entries(APP_REGISTRY)) {
+    if (other !== name) reserved.add(spec.preferredPort);
+  }
+  return reserved;
+}
+
+// Allocating a port and reserving it are two steps with an await between them, so two starts landing
+// in the same tick both saw the port free and both claimed it — and the loser was reported `running`
+// before its --strictPort vite died on EADDRINUSE. Two worktrees starting the same app at once is
+// the headline case for this feature, so the pair is serialised. (The main-app path at POST
+// /sessions has the same window; it predates this and is not fixed here.)
+let appAllocationLock = Promise.resolve();
+function withAppAllocation(fn) {
+  const run = appAllocationLock.then(fn, fn);
+  appAllocationLock = run.then(() => {}, () => {});
+  return run;
 }
 
 function listAppSessions() {
@@ -2021,9 +2111,11 @@ async function main() {
           pid: process.pid,
           uptime: process.uptime(),
           sessions: await listSessions(),
+          apps: listAppSessions(),
           rgbProxy: rgbProxy.getStatus(),
           authHub: authHub.getStatus(),
           projectRoot,
+          primaryCheckout,
           daemonPort: config.port,
           baseDevPort: config.baseDevPort,
         }));
@@ -2105,11 +2197,19 @@ async function main() {
             return;
           }
         }
-        // Falling back to projectRoot is the failure this whole change exists to remove, so it is
-        // reached only when the caller named no worktree at all — never as the quiet result of a
-        // body that did not parse.
+        // No fallback. Defaulting to projectRoot IS the failure this change exists to remove, and a
+        // caller that omits the field would get the daemon's own checkout with a plausible-looking
+        // path in the response. POST /sessions already answers this input with a 400; match it.
         const requestedWorktree = body.worktree || url.searchParams.get('worktree');
-        const resolvedWorktree = requestedWorktree ? resolve(requestedWorktree) : projectRoot;
+        if (!requestedWorktree) {
+          res.writeHead(400);
+          res.end(JSON.stringify({
+            error: 'worktree required',
+            usage: 'POST /app/<name>/start { "worktree": "/path/to/worktree" }, or ?worktree= on GET',
+          }));
+          return;
+        }
+        const resolvedWorktree = resolve(requestedWorktree);
         const key = appSessionKey(resolvedWorktree, name);
         const existing = appSessions.get(key);
 
@@ -2129,32 +2229,33 @@ async function main() {
           // documented number. A second worktree drifts rather than dying on EADDRINUSE. Nothing
           // needs rewriting to follow it: neither spoke's .env carries its own port or base URL,
           // and the hub trusts loopback by HOST in dev, so the drifted origin is still first-party.
-          // Every app's preferred port is reserved against the drift search, not just the taken
-          // ones: moderator drifting off 5174 would otherwise land on 5175 and displace
-          // creator-studio from its own documented number for as long as it ran.
-          const reserved = getUsedPorts();
-          for (const [other, spec] of Object.entries(APP_REGISTRY)) {
-            if (other !== name) reserved.add(spec.preferredPort);
-          }
-          let port;
+          let app;
           try {
-            port = await findAvailablePort(APP_REGISTRY[name].preferredPort, reserved);
+            app = await withAppAllocation(async () => {
+              // A stale entry — crashed, or errored asynchronously — still holds its port in
+              // getUsedPorts, which is deliberately status-blind. Allocating around it would move the
+              // app off its documented number every time it crashed, permanently. Take the port it
+              // already reserved instead.
+              const stale = appSessions.get(key);
+              const port =
+                stale?.port ??
+                (await findAvailablePort(APP_REGISTRY[name].preferredPort, appReservedPorts(name)));
+              const fresh = new AppSession(name, resolvedWorktree, port, appEnvChain(resolvedWorktree, name));
+              appSessions.set(key, fresh);
+              return fresh;
+            });
           } catch (err) {
             res.writeHead(503);
             res.end(JSON.stringify({ error: err.message }));
             return;
           }
 
-          const envPaths = appEnvChain(resolvedWorktree, name);
-          const app = new AppSession(name, resolvedWorktree, port, envPaths);
-          appSessions.set(key, app);
-
           // Decision 2A: the hub is one shared, idempotent process and a spoke cannot log anyone in
           // without it. The main app is deliberately NOT started — the spokes reach it over REST when
           // they need it, and a cold Next.js compile is not something to trigger on someone's behalf.
-          if (skillConfig.authHubEnabled && authHub.status !== 'running') authHub.start();
+          if (skillConfig.authHubEnabled && authHub.status !== 'running') await authHub.start();
 
-          const status = app.start();
+          const status = await app.start();
           // A start that never spawned holds no process, so the map entry is a port reservation
           // against nothing — and since the entry is also the only way to address it, nothing can
           // release it either. A missing node_modules would burn the app's preferred port for the
@@ -2200,6 +2301,9 @@ async function main() {
         }
         if (action === 'restart' && req.method === 'POST') {
           const status = await existing.restart();
+          // Same reservation-against-nothing as the start path: a restart whose start half fails
+          // leaves a process-less entry holding a port that nothing can release.
+          if (status.status === 'error') appSessions.delete(key);
           res.writeHead(status.status === 'error' ? 500 : 200);
           res.end(JSON.stringify(status));
           return;
@@ -2227,7 +2331,7 @@ async function main() {
 
       // POST /auth/start - Start auth hub
       if (path === '/auth/start' && req.method === 'POST') {
-        const status = authHub.start();
+        const status = await authHub.start();
         res.writeHead(status.status === 'error' ? 500 : 200);
         res.end(JSON.stringify(status));
         return;
@@ -2751,7 +2855,10 @@ async function main() {
 
     if (skillConfig.authHubEnabled) {
       console.error('AUTH_HUB_ENABLED=true — starting auth hub...');
-      authHub.start();
+      // Not awaited: this is the listen callback, and the ready signal below is what every `cli`
+      // invocation waits on. start() records its own failures in lastError and the log buffer, so
+      // the catch is only here to stop an unexpected rejection becoming an unhandled one.
+      authHub.start().catch((err) => console.error(`Auth hub failed to start: ${err.message}`));
     }
 
     // Output ready signal to stdout for parsing
@@ -2829,10 +2936,15 @@ if (invokedDirectly) {
 }
 
 export {
+  APP_REGISTRY,
+  appEnvChain,
+  appReservedPorts,
+  appSessions,
   checkPath,
   claimPortForReuse,
   DevSession,
   loadEnvChain,
+  primaryCheckout,
   findSessionByWorktree,
   getUsedPorts,
   listSessions,

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -2299,7 +2299,12 @@ async function main() {
           // against nothing — and since the entry is also the only way to address it, nothing can
           // release it either. A missing node_modules would burn the app's preferred port for the
           // life of the daemon, and the next start would drift off a number that was free.
-          if (status.status === 'error') appSessions.delete(key);
+          //
+          // Guarded by identity, not by key: start() awaits five path probes, and a delete by key
+          // alone would remove whatever entry happens to be there now — which after a replacement is
+          // a live reservation belonging to someone else. Same rule as the exit handler's
+          // `this.process === proc`.
+          if (status.status === 'error' && appSessions.get(key) === app) appSessions.delete(key);
           res.writeHead(status.status === 'error' ? 500 : 200);
           res.end(JSON.stringify(status));
           return;
@@ -2340,9 +2345,9 @@ async function main() {
         }
         if (action === 'restart' && req.method === 'POST') {
           const status = await existing.restart();
-          // Same reservation-against-nothing as the start path: a restart whose start half fails
-          // leaves a process-less entry holding a port that nothing can release.
-          if (status.status === 'error') appSessions.delete(key);
+          // Same reservation-against-nothing as the start path, and the same identity guard: a
+          // restart awaits a stop and then five path probes, so the entry may not be ours any more.
+          if (status.status === 'error' && appSessions.get(key) === existing) appSessions.delete(key);
           res.writeHead(status.status === 'error' ? 500 : 200);
           res.end(JSON.stringify(status));
           return;
@@ -2977,6 +2982,7 @@ if (invokedDirectly) {
 export {
   APP_REGISTRY,
   appEnvChain,
+  appSessionKey,
   describeDatabaseHost,
   appReservedPorts,
   appSessions,
@@ -2985,6 +2991,9 @@ export {
   DevSession,
   loadEnvChain,
   primaryCheckout,
+  primaryResolution,
+  samePath,
+  withAppAllocation,
   findSessionByWorktree,
   getUsedPorts,
   listSessions,

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -1502,6 +1502,7 @@ class AuthHub {
     this.requiredEnvPath = resolve(this.path, '.env');
     this.envPaths = [];
     this.process = null;
+    this.startPromise = null;
     this.status = 'stopped'; // stopped | starting | running | crashed | error | disabled
     this.ready = false;
     this.readyAt = null;
@@ -1525,6 +1526,14 @@ class AuthHub {
     return logs;
   }
 
+  // The hub passes an empty chain and lets Vite load its own .env. An app started in a worktree
+  // passes one, because the worktree's copy of that .env is gitignored and usually absent — the
+  // chain is what lets it inherit the primary checkout's. Either way process.env is the floor, which
+  // is why the DATABASE_URL warning has to be computed from this and not from the chain alone.
+  spawnEnv() {
+    return this.envPaths.length ? { ...process.env, ...loadEnvChain(this.envPaths) } : process.env;
+  }
+
   // `::` (dual-stack), not a single literal. Bound to `127.0.0.1` these servers answered on v4 and
   // nothing on [::1]; Windows resolves `localhost` to ::1 first, so a browser typing the same `localhost`
   // URL the auth redirects use got connection-refused while curl — which falls back to v4 — reported the
@@ -1539,11 +1548,25 @@ class AuthHub {
     return ['exec', 'vite', 'dev', '--host', '::', '--port', String(this.port), '--strictPort'];
   }
 
+  // `if (this.process)` used to be a sufficient guard because start() was synchronous. It is not any
+  // more: four awaited path probes now sit between that check and the assignment, so two callers in
+  // the same tick both saw `null` and both spawned — with --strictPort one died and the survivor was
+  // referenced by nothing, which is the orphan `stopAppSessions` exists to prevent. Memoising the
+  // in-flight promise closes the window without a sentinel that every return path has to remember to
+  // clear.
+  start() {
+    if (this.startPromise) return this.startPromise;
+    this.startPromise = this.#start().finally(() => {
+      this.startPromise = null;
+    });
+    return this.startPromise;
+  }
+
   // Async because `this.path` is now caller-supplied — an app resolves it against whatever worktree
   // the request named. A synchronous stat on an unreachable path measured 21s on this daemon's only
   // thread, which is why probePath/checkPath exist; a fixed local path never reached that, a worktree
   // argument can. pathExists is the timeout-raced one.
-  async start() {
+  async #start() {
     if (this.process) {
       this.addLog('info', `${this.label} already running`);
       return this.getStatus();
@@ -1564,25 +1587,20 @@ class AuthHub {
       return this.getStatus();
     }
 
-    // An app with no .env of its own inherits the chain — but a chain that resolves to nothing at all
-    // means primaryCheckout fell back (see resolvePrimaryCheckout) and the app would start with no
-    // DATABASE_URL, failing later inside SvelteKit where it reads as the app's bug. Refuse here.
-    if (!this.requiredEnvPath && this.envPaths.length) {
-      const present = [];
-      for (const envPath of this.envPaths) {
-        if (await pathExists(envPath)) present.push(envPath);
-      }
-      if (!present.length) {
-        this.status = 'error';
-        this.lastError =
-          `${this.label} has no env: none of ${this.envPaths.join(', ')} exist. ` +
-          (primaryResolution.derived
-            ? 'Copy one from the primary checkout.'
-            : `The primary checkout could not be resolved from git (${primaryResolution.error}), ` +
-              'so the fall-through has nothing to fall back to.');
-        this.addLog('error', this.lastError);
-        return this.getStatus();
-      }
+    // An app with no .env of its own inherits the chain. If nothing in that chain — nor the daemon's
+    // own environment — supplies a DATABASE_URL, it would start and fail later inside SvelteKit,
+    // where it reads as the app's bug rather than as a missing file. The usual cause is
+    // primaryCheckout having fallen back (see resolvePrimaryCheckout), so name that when it is why.
+    if (!this.requiredEnvPath && !this.spawnEnv().DATABASE_URL) {
+      this.status = 'error';
+      this.lastError =
+        `${this.label} has no DATABASE_URL: none of ${this.envPaths.join(', ')} supply one. ` +
+        (primaryResolution.derived
+          ? 'Copy an .env from the primary checkout.'
+          : `The primary checkout could not be resolved from git (${primaryResolution.error}), ` +
+            'so the fall-through has nothing to fall back to.');
+      this.addLog('error', this.lastError);
+      return this.getStatus();
     }
 
     if (!(await pathExists(resolve(this.path, 'node_modules')))) {
@@ -1602,20 +1620,19 @@ class AuthHub {
     // production database. Nothing in the start output used to say so, and a moderator remove-click
     // deletes live rows — so name the host here, where it is read at the moment it matters, rather
     // than only in a doc nobody opens at start time.
-    if (this.envPaths.length) {
-      this.dbHost = describeDatabaseHost(loadEnvChain(this.envPaths));
-      if (this.dbHost) this.addLog('warn', `${this.label} DATABASE_URL host: ${this.dbHost}`);
-    }
+    //
+    // Describes the MERGED env, not the chain: the child gets `{ ...process.env, ...chain }`, so a
+    // DATABASE_URL inherited from the daemon's own environment is one the app will really use and
+    // nobody chose. Reporting null for it would read as "no database configured".
+    this.dbHost = describeDatabaseHost(this.spawnEnv());
+    if (this.dbHost) this.addLog('warn', `${this.label} DATABASE_URL host: ${this.dbHost}`);
 
     const isWindows = process.platform === 'win32';
     const pnpmCmd = isWindows ? 'pnpm.cmd' : 'pnpm';
 
-    // The hub passes an empty chain and lets Vite load its own .env. An app started in a
-    // worktree passes one, because the worktree's copy of that .env is gitignored and usually
-    // absent — the chain is what lets it inherit the primary checkout's.
     const spawnOptions = {
       cwd: this.path,
-      env: this.envPaths.length ? { ...process.env, ...loadEnvChain(this.envPaths) } : process.env,
+      env: this.spawnEnv(),
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: isWindows,
     };
@@ -1699,6 +1716,7 @@ class AuthHub {
     }
 
     this.addLog('info', `Stopping ${this.label}...`);
+    this.dbHost = null;
     // Detach eagerly so a subsequent start() never sees a stale process (the exit handler is guarded on
     // identity, so the late exit of this proc won't touch the fresh one).
     this.process = null;
@@ -1797,7 +1815,11 @@ function describeDatabaseHost(envVars) {
   if (!url) return null;
   try {
     const parsed = new URL(url);
-    return parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname;
+    const host = parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname;
+    // `|| null`, not `?? null`: a value with no `//` parses as an opaque path and yields an empty
+    // hostname, and `postgres://user:sec@ret` yields `ret` — password material that a reader would
+    // take for a host. Collapsing every degenerate shape into "could not read it" is the safe answer.
+    return host || null;
   } catch (e) {
     return null;
   }
@@ -1810,7 +1832,9 @@ function appEnvChain(worktree, name) {
   const relative = APP_REGISTRY[name].path;
   const paths = [resolve(primaryCheckout, relative, '.env')];
   const worktreeEnv = resolve(worktree, relative, '.env');
-  if (worktreeEnv !== paths[0]) paths.push(worktreeEnv);
+  // samePath, not `!==`: started from the primary checkout in the other drive-letter casing this
+  // would otherwise put the same file in the chain twice.
+  if (!samePath(worktreeEnv, paths[0])) paths.push(worktreeEnv);
   return paths;
 }
 
@@ -2219,34 +2243,49 @@ async function main() {
             res.end(JSON.stringify({ error: `Worktree not found: ${resolvedWorktree}` }));
             return;
           }
-          if (existing && existing.status === 'running') {
-            res.writeHead(200);
-            res.end(JSON.stringify({ reused: true, ...existing.getStatus() }));
-            return;
-          }
-
           // The preferred port is where the first worktree lands, so the common case stays the
           // documented number. A second worktree drifts rather than dying on EADDRINUSE. Nothing
           // needs rewriting to follow it: neither spoke's .env carries its own port or base URL,
           // and the hub trusts loopback by HOST in dev, so the drifted origin is still first-party.
+          //
+          // Read, decide and reserve all happen INSIDE the lock. Deciding outside it was the bug the
+          // lock was supposed to fix, moved one layer in: two starts of the same app both read no
+          // entry, both entered, and the second inherited the first's port while it was still coming
+          // up — two vite processes, one port, one orphan.
           let app;
+          let reused = null;
           try {
             app = await withAppAllocation(async () => {
-              // A stale entry — crashed, or errored asynchronously — still holds its port in
-              // getUsedPorts, which is deliberately status-blind. Allocating around it would move the
-              // app off its documented number every time it crashed, permanently. Take the port it
-              // already reserved instead.
-              const stale = appSessions.get(key);
+              const current = appSessions.get(key);
+              // `status === 'running'` is not enough, and sessionIsBusy's own comment says why: a
+              // session that is coming up reads `starting`. A live `process` is checked too, because
+              // proc.on('error') sets status without clearing it.
+              if (current && (sessionIsBusy(current) || current.process)) {
+                reused = current;
+                return null;
+              }
+              // Only an entry with no live process is a reservation worth inheriting. Doing so keeps
+              // a crashed app on its documented number instead of drifting it every crash, because
+              // getUsedPorts is deliberately status-blind and still counts the entry.
               const port =
-                stale?.port ??
+                (!current?.process && current?.port) ||
                 (await findAvailablePort(APP_REGISTRY[name].preferredPort, appReservedPorts(name)));
               const fresh = new AppSession(name, resolvedWorktree, port, appEnvChain(resolvedWorktree, name));
+              // Set before the lock is released: `start()` is awaited outside it, and an entry left
+              // reading `stopped` in between is one a third caller would treat as inheritable.
+              fresh.status = 'starting';
               appSessions.set(key, fresh);
               return fresh;
             });
           } catch (err) {
             res.writeHead(503);
             res.end(JSON.stringify({ error: err.message }));
+            return;
+          }
+
+          if (reused) {
+            res.writeHead(200);
+            res.end(JSON.stringify({ reused: true, ...reused.getStatus() }));
             return;
           }
 
@@ -2938,6 +2977,7 @@ if (invokedDirectly) {
 export {
   APP_REGISTRY,
   appEnvChain,
+  describeDatabaseHost,
   appReservedPorts,
   appSessions,
   checkPath,

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -2000,7 +2000,15 @@ async function stopAppSessions() {
   // Concurrently, because these are independent processes and the settle plus port-verify makes each
   // stop worth seconds. Sequentially, two apps could outlast a supervisor's grace period and be
   // SIGKILLed mid-loop, leaving the rest running — the orphan again, by a different door.
-  await Promise.all([...appSessions.values()].filter(appIsLive).map((app) => app.stop()));
+  // `appIsLive || stopping`, because the two questions are different and one predicate cannot serve
+  // both. appIsLive answers "may a second start reuse this, or take its port?" — a stopping entry
+  // answers NO. This function asks "is there anything here that still needs killing or waiting on?"
+  // — a stopping entry answers YES: its stop may be sitting in the settle timeout with taskkill not
+  // yet fired, and filtering it out lets process.exit run straight past it, leaving vite alive.
+  // That is the orphan this function exists to prevent, arriving through the predicate that was
+  // meant to fix it.
+  const pending = [...appSessions.values()].filter((app) => appIsLive(app) || app.stopping);
+  await Promise.all(pending.map((app) => app.stop()));
 }
 
 // Session manager

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -1489,8 +1489,7 @@ class AuthHub {
     // worktree — env-modes.mjs lists it in PROD_ONLY_GROUPS for exactly that reason — so a daemon
     // launched from a worktree must still run the primary's copy, which is also the only one with
     // the gitignored apps/auth/.env beside it.
-    // `path` FIRST — requiredEnvPath is derived from it below, so a subclass pointing at a different
-    // root must overwrite this before that. A subclass varies these four; the rest is identical.
+    // requiredEnvPath is derived from this.path below, so the two assignments cannot swap order.
     this.path = resolve(primaryCheckout, hubPath);
     this.port = port;
     this.label = 'Auth hub';
@@ -1528,19 +1527,17 @@ class AuthHub {
   // passes one, because the worktree's copy of that .env is gitignored and usually absent — the
   // chain is what lets it inherit the primary checkout's. Either way process.env is the floor, which
   // is why the DATABASE_URL warning has to be computed from this and not from the chain alone.
-  // A method rather than an inline assignment so the freshness rule has a seam a test can reach:
-  // dropping the clear meant a restart after an .env edit spawned with the OLD DATABASE_URL, and
-  // because dbHost is computed from the same cached object the warning line then confirmed the host
-  // you had just changed away from.
+  // Dropping this means a restart after an .env edit spawns with the OLD DATABASE_URL — and since
+  // dbHost is computed from the same cached object, the warning line then confirms the host you have
+  // just changed away from.
   invalidateSpawnEnv() {
     this.spawnEnvCache = null;
   }
 
   spawnEnv() {
-    // Cached for the duration of one start. Three callers read this — the DATABASE_URL refusal, the
-    // host warning and the spawn options — and without the cache each one re-read every file in the
-    // chain from disk. Cheap either way (~200us a read), but the three must also agree with each
-    // other: the thing refused, the thing described and the thing handed to the child are one object.
+    // Cached for the duration of one start. Not for speed — the three callers (the DATABASE_URL
+    // refusal, the host warning, the spawn options) must AGREE with each other: the thing refused,
+    // the thing described and the thing handed to the child have to be one object.
     if (!this.spawnEnvCache) {
       this.spawnEnvCache = this.envPaths.length
         ? { ...process.env, ...loadEnvChain(this.envPaths) }
@@ -1564,7 +1561,7 @@ class AuthHub {
   }
 
   // `if (this.process)` used to be a sufficient guard because start() was synchronous. It is not any
-  // more: four awaited path probes now sit between that check and the assignment, so two callers in
+  // more: awaited path probes now sit between that check and the assignment, so two callers in
   // the same tick both saw `null` and both spawned — with --strictPort one died and the survivor was
   // referenced by nothing, which is the orphan `stopAppSessions` exists to prevent. Memoising the
   // in-flight promise closes the window without a sentinel that every return path has to remember to
@@ -1582,11 +1579,10 @@ class AuthHub {
   }
 
   // Async because `this.path` is now caller-supplied — an app resolves it against whatever worktree
-  // the request named. A synchronous stat on an unreachable path measured 21s on this daemon's only
-  // thread, which is why probePath/checkPath exist; a fixed local path never reached that, a worktree
+  // the request named. A synchronous stat on an unreachable path is recorded in this file at 21s on
+  // the daemon's only thread, which is why probePath/checkPath exist; a fixed local path never reached that, a worktree
   // argument can. pathExists is the timeout-raced one.
   async #start() {
-    // Dropped per start, not per instance: a restart after an .env edit must see the new values.
     this.invalidateSpawnEnv();
     this.stopping = false;
 
@@ -1859,11 +1855,8 @@ class AppSession extends AuthHub {
     // primary checkout instead of refusing to start, which is what `requiredEnvPath: null` buys.
     this.requiredEnvPath = null;
     this.envPaths = envPaths;
-    // Born live. The handler puts a fresh entry in the map inside the allocation lock but calls
-    // start() outside it, with `await authHub.start()` in between — so an entry that begins life
-    // reading `stopped` is one a concurrent start sees as dead and inherits the port of. The handler
-    // sets this too; having the class guarantee it is what makes the invariant testable, and what
-    // stops a future caller reintroducing the gap by constructing one somewhere else.
+    // Born live: an entry reading `stopped` between the map insert and start() is one a concurrent
+    // start treats as dead and inherits the port of. The handler sets it too — see there for why.
     this.status = 'starting';
     this.dbHost = null;
   }
@@ -1893,7 +1886,7 @@ function describeDatabaseHost(envVars) {
     // `|| null`, not `?? null`. One shape needs it: a value with no `//` (`postgres:something`)
     // parses as an opaque path and yields an EMPTY hostname, which `??` would pass through as `""` —
     // falsy enough to skip the warning silently, but not null, so status would report it. Everything
-    // else degenerate throws and returns null from the catch above.
+    // else degenerate throws and returns null from the catch below.
     return host || null;
   } catch (e) {
     return null;
@@ -1917,14 +1910,12 @@ function appEnvChain(worktree, name) {
 // alone is what made them global singletons.
 const appSessions = new Map();
 
-// The two decisions the concurrent-start fix turns on. They lived inline in the HTTP handler, where
-// nothing could reach them: reverting the liveness rule to `status === 'running'` — the exact bug
-// this branch fixed twice — left every check green, and the only evidence was a live control run
-// once by hand.
+// The two decisions the concurrent-start fix turns on. Named because inline in the HTTP handler
+// nothing could reach them, and reverting the liveness rule to `status === 'running'` left every
+// check green.
 //
-// `status` alone is not enough (sessionIsBusy's own comment says so: a session coming up reads
-// `starting`), and a live `process` counts too because proc.on('error') sets status without
-// clearing it.
+// `status` alone is not enough: a session coming up reads `starting`. A live `process` counts
+// too, because proc.on('error') sets status without clearing it.
 function appIsLive(entry) {
   // A stopping entry is not live — it is about to be killed, so it must not be handed back as
   // `reused` — but its port is not inheritable either, which inheritablePort enforces separately.
@@ -1948,7 +1939,7 @@ function inheritablePort(entry) {
 }
 
 // Membership of the map IS the port reservation, and every release has to prove the entry is still
-// the one it means to release. Each caller awaits something first — five path probes, or stop()'s
+// the one it means to release. Each caller awaits something first — start()'s path probes, or stop()'s
 // 800ms — and the entry can be replaced underneath in that window.
 function releaseIfOurs(key, session) {
   if (appSessions.get(key) === session) appSessions.delete(key);
@@ -2052,8 +2043,8 @@ function getUsedPorts() {
 // leaves the node child to start and bind — a live server on a --strictPort port that no map entry,
 // no `status` row and no shutdown path can reach.
 //
-// Measured on this box, stop issued N seconds after start: 0s orphans every time, 2s and 5s are
-// clean. 3000 buys margin over the observed boundary without making an ordinary stop feel slow —
+// Measured on this box, stop issued N seconds after start: 0s orphaned in 3 of 3 observations,
+// 2s and 5s clean in 1 each. 3000 buys margin over the observed boundary without making an ordinary stop feel slow —
 // only a stop issued seconds after its own start waits at all.
 const SPAWN_SETTLE_MS = 3000;
 
@@ -2061,13 +2052,14 @@ const SPAWN_SETTLE_MS = 3000;
 // without a clock or a spawn — the claim that it "waits only the remainder" was stated in a comment
 // and checked by nothing.
 //
-// Clamped at both ends. A clock step or a VM resume between spawn and stop makes `now - spawnedAt`
+// Clamped upward. A clock step or a VM resume between spawn and stop makes `now - spawnedAt`
 // negative, and an unclamped `settle - negative` waits LONGER than the window, unbounded in principle.
 function settleDelayMs(spawnedAtMs, nowMs, settleMs = SPAWN_SETTLE_MS) {
   if (!spawnedAtMs) return 0;
   const since = nowMs - spawnedAtMs;
   if (since >= settleMs) return 0;
-  return Math.min(settleMs, Math.max(0, settleMs - since));
+  // No lower clamp: the early return above guarantees `since < settleMs`, so this is always > 0.
+  return Math.min(settleMs, settleMs - since);
 }
 // After the kill, how long to keep checking that the port actually came back. Nothing here can kill
 // a grandchild it has no pid for, so this exists to make a residual orphan LOUD rather than silent.
@@ -2449,7 +2441,7 @@ async function main() {
           // release it either. A missing node_modules would burn the app's preferred port for the
           // life of the daemon, and the next start would drift off a number that was free.
           //
-          // Guarded by identity, not by key: start() awaits five path probes, and a delete by key
+          // Guarded by identity, not by key: start() awaits path probes first, and a delete by key
           // alone would remove whatever entry happens to be there now — which after a replacement is
           // a live reservation belonging to someone else. Same rule as the exit handler's
           // `this.process === proc`.
@@ -2500,7 +2492,7 @@ async function main() {
         if (action === 'restart' && req.method === 'POST') {
           const status = await existing.restart();
           // Same reservation-against-nothing as the start path, and the same identity guard: a
-          // restart awaits a stop and then five path probes, so the entry may not be ours any more.
+          // restart awaits a stop and then start()'s probes, so the entry may not be ours any more.
           if (status.status === 'error') releaseIfOurs(key, existing);
           res.writeHead(status.status === 'error' ? 500 : 200);
           res.end(JSON.stringify(status));

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -23,6 +23,7 @@ import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
 import { access } from 'fs/promises';
 import { isPortFree } from './port-probe.mjs';
+import { samePath, canonicalPath } from './paths.mjs';
 import { parsePort, resolveDaemonPort } from './daemon-port.mjs';
 import { TestQueue } from './test-queue.mjs';
 import {
@@ -240,13 +241,6 @@ function parseArgs(argv = process.argv.slice(2)) {
 // Where the port scan starts. Set once from the parsed args so the session-side code paths — a
 // branch switch restarting itself, a session moved off a stolen port — can reach it too.
 let baseDevPort = DEFAULT_BASE_DEV_PORT;
-
-// Windows hands back whatever drive-letter and casing the caller typed.
-function samePath(a, b) {
-  return process.platform === 'win32'
-    ? resolve(a).toLowerCase() === resolve(b).toLowerCase()
-    : resolve(a) === resolve(b);
-}
 
 // Generate session ID
 function generateSessionId() {
@@ -1495,14 +1489,16 @@ class AuthHub {
     // worktree — env-modes.mjs lists it in PROD_ONLY_GROUPS for exactly that reason — so a daemon
     // launched from a worktree must still run the primary's copy, which is also the only one with
     // the gitignored apps/auth/.env beside it.
+    // `path` FIRST — requiredEnvPath is derived from it below, so a subclass pointing at a different
+    // root must overwrite this before that. A subclass varies these four; the rest is identical.
     this.path = resolve(primaryCheckout, hubPath);
     this.port = port;
-    // Subclasses vary these three; everything else about running a Vite app is identical.
     this.label = 'Auth hub';
     this.requiredEnvPath = resolve(this.path, '.env');
     this.envPaths = [];
     this.process = null;
     this.startPromise = null;
+    this.spawnedAtMs = null;
     this.status = 'stopped'; // stopped | starting | running | crashed | error | disabled
     this.ready = false;
     this.readyAt = null;
@@ -1556,6 +1552,10 @@ class AuthHub {
   // clear.
   start() {
     if (this.startPromise) return this.startPromise;
+    // Set here rather than in #start(), which does not reach its own assignment until after the path
+    // probes — a caller inspecting status in that window would see `stopped` for a start already
+    // under way. Keeping it in the class also means nothing outside has to write the field.
+    this.status = 'starting';
     this.startPromise = this.#start().finally(() => {
       this.startPromise = null;
     });
@@ -1648,6 +1648,7 @@ class AuthHub {
       return this.getStatus();
     }
     this.process = proc;
+    this.spawnedAtMs = Date.now();
 
     this.startedAt = new Date().toISOString();
     this.stoppedAt = null;
@@ -1708,6 +1709,14 @@ class AuthHub {
   }
 
   async stop() {
+    // A start sitting in its path probes has `this.process === null`, so the early return below would
+    // report `stopped` for a process that is about to exist — and the handler then deletes the map
+    // entry while `#start()` carries on and spawns. That leaves a live server on a --strictPort port
+    // with no entry: uncounted by getUsedPorts, unlisted by `app` and `status`, and unreachable by
+    // stopAppSessions at shutdown. Exactly the orphan that function exists to prevent, and reachable
+    // by `start --app x` followed promptly by `stop --app x`.
+    if (this.startPromise) await this.startPromise.catch(() => {});
+
     const proc = this.process;
     if (!proc) {
       this.status = 'stopped';
@@ -1715,8 +1724,18 @@ class AuthHub {
       return this.getStatus();
     }
 
+    // See SPAWN_SETTLE_MS: killing the tree before the shell has spawned its node child orphans the
+    // child. Only a stop that lands inside that window waits, and it waits only the remainder.
+    const sinceSpawn = this.spawnedAtMs ? Date.now() - this.spawnedAtMs : Infinity;
+    if (sinceSpawn < SPAWN_SETTLE_MS) {
+      const wait = SPAWN_SETTLE_MS - sinceSpawn;
+      this.addLog('info', `${this.label} spawned ${sinceSpawn}ms ago — settling ${wait}ms before kill`);
+      await new Promise((r) => setTimeout(r, wait));
+    }
+
     this.addLog('info', `Stopping ${this.label}...`);
     this.dbHost = null;
+    this.spawnedAtMs = null;
     // Detach eagerly so a subsequent start() never sees a stale process (the exit handler is guarded on
     // identity, so the late exit of this proc won't touch the fresh one).
     this.process = null;
@@ -1724,8 +1743,8 @@ class AuthHub {
     this.status = 'stopped';
     this.stoppedAt = new Date().toISOString();
 
-    return new Promise((resolve) => {
-      proc.once('exit', () => resolve(this.getStatus()));
+    await new Promise((resolve) => {
+      proc.once('exit', resolve);
       try {
         if (process.platform === 'win32') {
           spawn('taskkill', ['/pid', String(proc.pid), '/f', '/t'], { shell: true });
@@ -1733,8 +1752,22 @@ class AuthHub {
           process.kill(-proc.pid, 'SIGKILL');
         }
       } catch (e) {}
-      setTimeout(() => resolve(this.getStatus()), 800);
+      setTimeout(resolve, 800);
     });
+
+    // The port coming back is the only evidence the server is really gone — `exit` fires for the
+    // shell, which is not what was listening. An orphan that survives this is one nothing in the
+    // daemon can reach, so say so with the port in the message rather than reporting a clean stop.
+    const deadline = Date.now() + STOP_PORT_VERIFY_MS;
+    while (Date.now() < deadline) {
+      if (await isPortFree(this.port)) return this.getStatus();
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    this.lastError =
+      `${this.label} stopped but port ${this.port} is still held — a child may have outlived the ` +
+      `kill. Nothing tracks it; find and kill whatever is listening on ${this.port}.`;
+    this.addLog('error', this.lastError);
+    return this.getStatus();
   }
 
   async restart() {
@@ -1847,8 +1880,7 @@ function appSessionKey(worktree, name) {
   // `C:\Dev\...` from one agent and `c:\dev\...` from another. findSessionByWorktree already treats
   // those as one tree; a raw string key here would treat them as two, put two vite processes on the
   // same worktree, and leave the first addressable by nothing while it holds a port.
-  const canonical = process.platform === 'win32' ? worktree.toLowerCase() : worktree;
-  return `${canonical}::${name}`;
+  return `${canonicalPath(worktree)}::${name}`;
 }
 
 // Every app's preferred port is held back, not just the taken ones: moderator drifting off 5174
@@ -1922,6 +1954,19 @@ function getUsedPorts() {
 // URLs. Measured on this box, a killed listener releases the socket 630-668 ms after taskkill is
 // spawned, and stop() waits at most 500 ms — so the naive probe reads "held" on every restart. Wait
 // the port out instead, and move only when it stays held long past any plausible teardown.
+// `taskkill /t` kills the process tree that exists WHEN IT RUNS. `pnpm exec vite` is a shell that
+// spawns node a moment later, so a kill issued in the first couple of seconds takes the shell and
+// leaves the node child to start and bind — a live server on a --strictPort port that no map entry,
+// no `status` row and no shutdown path can reach.
+//
+// Measured on this box, stop issued N seconds after start: 0s orphans every time, 2s and 5s are
+// clean. 3000 buys margin over the observed boundary without making an ordinary stop feel slow —
+// only a stop issued seconds after its own start waits at all.
+const SPAWN_SETTLE_MS = 3000;
+// After the kill, how long to keep checking that the port actually came back. Nothing here can kill
+// a grandchild it has no pid for, so this exists to make a residual orphan LOUD rather than silent.
+const STOP_PORT_VERIFY_MS = 5000;
+
 const PORT_RELEASE_TIMEOUT = 8000;
 const PORT_RELEASE_POLL = 250;
 
@@ -2260,6 +2305,10 @@ async function main() {
               // `status === 'running'` is not enough, and sessionIsBusy's own comment says why: a
               // session that is coming up reads `starting`. A live `process` is checked too, because
               // proc.on('error') sets status without clearing it.
+              //
+              // sessionIsBusy reads four terms and an AppSession only ever sets two, so this
+              // degenerates to `running || starting`. That is the right answer today; a term added
+              // there for DevSession would silently not apply here.
               if (current && (sessionIsBusy(current) || current.process)) {
                 reused = current;
                 return null;
@@ -2271,9 +2320,6 @@ async function main() {
                 (!current?.process && current?.port) ||
                 (await findAvailablePort(APP_REGISTRY[name].preferredPort, appReservedPorts(name)));
               const fresh = new AppSession(name, resolvedWorktree, port, appEnvChain(resolvedWorktree, name));
-              // Set before the lock is released: `start()` is awaited outside it, and an entry left
-              // reading `stopped` in between is one a third caller would treat as inheritable.
-              fresh.status = 'starting';
               appSessions.set(key, fresh);
               return fresh;
             });
@@ -2992,7 +3038,6 @@ export {
   loadEnvChain,
   primaryCheckout,
   primaryResolution,
-  samePath,
   withAppAllocation,
   findSessionByWorktree,
   getUsedPorts,

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -1500,6 +1500,7 @@ class AuthHub {
     this.startPromise = null;
     this.spawnedAtMs = null;
     this.spawnEnvCache = null;
+    this.stopping = false;
     this.status = 'stopped'; // stopped | starting | running | crashed | error | disabled
     this.ready = false;
     this.readyAt = null;
@@ -1527,6 +1528,14 @@ class AuthHub {
   // passes one, because the worktree's copy of that .env is gitignored and usually absent — the
   // chain is what lets it inherit the primary checkout's. Either way process.env is the floor, which
   // is why the DATABASE_URL warning has to be computed from this and not from the chain alone.
+  // A method rather than an inline assignment so the freshness rule has a seam a test can reach:
+  // dropping the clear meant a restart after an .env edit spawned with the OLD DATABASE_URL, and
+  // because dbHost is computed from the same cached object the warning line then confirmed the host
+  // you had just changed away from.
+  invalidateSpawnEnv() {
+    this.spawnEnvCache = null;
+  }
+
   spawnEnv() {
     // Cached for the duration of one start. Three callers read this — the DATABASE_URL refusal, the
     // host warning and the spawn options — and without the cache each one re-read every file in the
@@ -1578,7 +1587,8 @@ class AuthHub {
   // argument can. pathExists is the timeout-raced one.
   async #start() {
     // Dropped per start, not per instance: a restart after an .env edit must see the new values.
-    this.spawnEnvCache = null;
+    this.invalidateSpawnEnv();
+    this.stopping = false;
 
     if (this.process) {
       this.addLog('info', `${this.label} already running`);
@@ -1745,12 +1755,16 @@ class AuthHub {
       return this.getStatus();
     }
 
+    // Declared before the settle wait. Without it the entry keeps a live process and `running`
+    // status for up to SPAWN_SETTLE_MS, so a concurrent start short-circuits and is handed
+    // `reused: true` for a server that is about to be killed.
+    this.stopping = true;
+
     // See SPAWN_SETTLE_MS: killing the tree before the shell has spawned its node child orphans the
     // child. Only a stop that lands inside that window waits, and it waits only the remainder.
-    const sinceSpawn = this.spawnedAtMs ? Date.now() - this.spawnedAtMs : Infinity;
-    if (sinceSpawn < SPAWN_SETTLE_MS) {
-      const wait = SPAWN_SETTLE_MS - sinceSpawn;
-      this.addLog('info', `${this.label} spawned ${sinceSpawn}ms ago — settling ${wait}ms before kill`);
+    const wait = settleDelayMs(this.spawnedAtMs, Date.now());
+    if (wait) {
+      this.addLog('info', `${this.label} settling ${wait}ms before kill`);
       await new Promise((r) => setTimeout(r, wait));
     }
 
@@ -1845,6 +1859,12 @@ class AppSession extends AuthHub {
     // primary checkout instead of refusing to start, which is what `requiredEnvPath: null` buys.
     this.requiredEnvPath = null;
     this.envPaths = envPaths;
+    // Born live. The handler puts a fresh entry in the map inside the allocation lock but calls
+    // start() outside it, with `await authHub.start()` in between — so an entry that begins life
+    // reading `stopped` is one a concurrent start sees as dead and inherits the port of. The handler
+    // sets this too; having the class guarantee it is what makes the invariant testable, and what
+    // stops a future caller reintroducing the gap by constructing one somewhere else.
+    this.status = 'starting';
     this.dbHost = null;
   }
 
@@ -1906,7 +1926,10 @@ const appSessions = new Map();
 // `starting`), and a live `process` counts too because proc.on('error') sets status without
 // clearing it.
 function appIsLive(entry) {
-  return !!entry && (sessionIsBusy(entry) || !!entry.process);
+  // A stopping entry is not live — it is about to be killed, so it must not be handed back as
+  // `reused` — but its port is not inheritable either, which inheritablePort enforces separately.
+  if (!entry || entry.stopping) return false;
+  return sessionIsBusy(entry) || !!entry.process;
 }
 
 // Only a dead entry's port is worth inheriting. Doing so keeps a crashed app on its documented
@@ -1914,7 +1937,14 @@ function appIsLive(entry) {
 // entry still counts against the allocator. Inheriting a LIVE entry's port is the bug: two vite
 // processes, one port, one orphan.
 function inheritablePort(entry) {
-  return appIsLive(entry) ? null : entry?.port ?? null;
+  // A stop in flight still owns its port until it proves the port came back, so nothing may inherit
+  // it — appIsLive says false for a stopping entry, so this needs the check of its own.
+  if (entry?.stopping) return null;
+  // `||`, not `??`. A port of 0 would otherwise be inherited as 0 and short-circuit the allocator
+  // into binding an ephemeral port. Unreachable today — findAvailablePort starts at 5174 and only
+  // climbs — but the inline version this was lifted from treated 0 as falsy, and a faithful
+  // extraction should not quietly change that.
+  return appIsLive(entry) ? null : entry?.port || null;
 }
 
 // Membership of the map IS the port reservation, and every release has to prove the entry is still
@@ -1962,9 +1992,15 @@ function listAppSessions() {
 // Apps bind with --strictPort, so one left running past daemon exit makes the next start of that
 // app fail with EADDRINUSE against a process nothing is tracking any more.
 async function stopAppSessions() {
-  for (const app of appSessions.values()) {
-    if (app.status === 'running') await app.stop();
-  }
+  // appIsLive, not `status === 'running'`. An app started seconds before a shutdown reads `starting`
+  // for its whole boot, and a `status` test skips it — so the daemon exits and vite keeps serving,
+  // which is the exact orphan this function exists to prevent. stop() already handles that case: it
+  // awaits startPromise and honours the settle window. It just never got called.
+  //
+  // Concurrently, because these are independent processes and the settle plus port-verify makes each
+  // stop worth seconds. Sequentially, two apps could outlast a supervisor's grace period and be
+  // SIGKILLed mid-loop, leaving the rest running — the orphan again, by a different door.
+  await Promise.all([...appSessions.values()].filter(appIsLive).map((app) => app.stop()));
 }
 
 // Session manager
@@ -2012,6 +2048,19 @@ function getUsedPorts() {
 // clean. 3000 buys margin over the observed boundary without making an ordinary stop feel slow —
 // only a stop issued seconds after its own start waits at all.
 const SPAWN_SETTLE_MS = 3000;
+
+// How much of the settle window is left. Separated from the wait so the arithmetic can be tested
+// without a clock or a spawn — the claim that it "waits only the remainder" was stated in a comment
+// and checked by nothing.
+//
+// Clamped at both ends. A clock step or a VM resume between spawn and stop makes `now - spawnedAt`
+// negative, and an unclamped `settle - negative` waits LONGER than the window, unbounded in principle.
+function settleDelayMs(spawnedAtMs, nowMs, settleMs = SPAWN_SETTLE_MS) {
+  if (!spawnedAtMs) return 0;
+  const since = nowMs - spawnedAtMs;
+  if (since >= settleMs) return 0;
+  return Math.min(settleMs, Math.max(0, settleMs - since));
+}
 // After the kill, how long to keep checking that the port actually came back. Nothing here can kill
 // a grandchild it has no pid for, so this exists to make a residual orphan LOUD rather than silent.
 const STOP_PORT_VERIFY_MS = 5000;
@@ -2359,6 +2408,13 @@ async function main() {
                 inheritablePort(current) ??
                 (await findAvailablePort(APP_REGISTRY[name].preferredPort, appReservedPorts(name)));
               const fresh = new AppSession(name, resolvedWorktree, port, appEnvChain(resolvedWorktree, name));
+              // Marked live BEFORE the lock releases. start() sets this too, but not soon enough:
+              // `await authHub.start()` sits between here and there, and through it the entry would
+              // sit in the map reading `stopped` with no process — which appIsLive calls dead, so a
+              // second start would inherit its port and spawn a rival on it. Moving the assignment
+              // into start() alone reopened exactly that, and it is invisible whenever the hub is
+              // already running, because then that await is a no-op.
+              fresh.status = 'starting';
               appSessions.set(key, fresh);
               return fresh;
             });
@@ -3075,6 +3131,7 @@ export {
   appEnvChain,
   appIsLive,
   appSessionKey,
+  settleDelayMs,
   inheritablePort,
   releaseIfOurs,
   describeDatabaseHost,

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -1624,8 +1624,15 @@ class AuthHub {
     // Describes the MERGED env, not the chain: the child gets `{ ...process.env, ...chain }`, so a
     // DATABASE_URL inherited from the daemon's own environment is one the app will really use and
     // nobody chose. Reporting null for it would read as "no database configured".
-    this.dbHost = describeDatabaseHost(this.spawnEnv());
-    if (this.dbHost) this.addLog('warn', `${this.label} DATABASE_URL host: ${this.dbHost}`);
+    // Only for a process whose env this daemon actually supplies. The auth hub passes an empty
+    // chain and lets Vite load apps/auth/.env itself, so spawnEnv() there is process.env verbatim —
+    // the line would name the daemon's inherited candidate, say nothing about the file the hub
+    // really reads, and stay silent when THAT is the one pointing at production. Saying nothing is
+    // the honest answer for the hub.
+    if (this.envPaths.length) {
+      this.dbHost = describeDatabaseHost(this.spawnEnv());
+      if (this.dbHost) this.addLog('warn', `${this.label} DATABASE_URL host: ${this.dbHost}`);
+    }
 
     const isWindows = process.platform === 'win32';
     const pnpmCmd = isWindows ? 'pnpm.cmd' : 'pnpm';
@@ -1721,6 +1728,7 @@ class AuthHub {
     if (!proc) {
       this.status = 'stopped';
       this.ready = false;
+      this.dbHost = null;
       return this.getStatus();
     }
 
@@ -1849,9 +1857,10 @@ function describeDatabaseHost(envVars) {
   try {
     const parsed = new URL(url);
     const host = parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname;
-    // `|| null`, not `?? null`: a value with no `//` parses as an opaque path and yields an empty
-    // hostname, and `postgres://user:sec@ret` yields `ret` — password material that a reader would
-    // take for a host. Collapsing every degenerate shape into "could not read it" is the safe answer.
+    // `|| null`, not `?? null`. One shape needs it: a value with no `//` (`postgres:something`)
+    // parses as an opaque path and yields an EMPTY hostname, which `??` would pass through as `""` —
+    // falsy enough to skip the warning silently, but not null, so status would report it. Everything
+    // else degenerate throws and returns null from the catch above.
     return host || null;
   } catch (e) {
     return null;
@@ -1874,6 +1883,33 @@ function appEnvChain(worktree, name) {
 // Keyed by worktree AND app, so two worktrees can serve the same app at once. A key on the app name
 // alone is what made them global singletons.
 const appSessions = new Map();
+
+// The two decisions the concurrent-start fix turns on. They lived inline in the HTTP handler, where
+// nothing could reach them: reverting the liveness rule to `status === 'running'` — the exact bug
+// this branch fixed twice — left every check green, and the only evidence was a live control run
+// once by hand.
+//
+// `status` alone is not enough (sessionIsBusy's own comment says so: a session coming up reads
+// `starting`), and a live `process` counts too because proc.on('error') sets status without
+// clearing it.
+function appIsLive(entry) {
+  return !!entry && (sessionIsBusy(entry) || !!entry.process);
+}
+
+// Only a dead entry's port is worth inheriting. Doing so keeps a crashed app on its documented
+// number instead of drifting it every crash — getUsedPorts is deliberately status-blind, so the
+// entry still counts against the allocator. Inheriting a LIVE entry's port is the bug: two vite
+// processes, one port, one orphan.
+function inheritablePort(entry) {
+  return appIsLive(entry) ? null : entry?.port ?? null;
+}
+
+// Membership of the map IS the port reservation, and every release has to prove the entry is still
+// the one it means to release. Each caller awaits something first — five path probes, or stop()'s
+// 800ms — and the entry can be replaced underneath in that window.
+function releaseIfOurs(key, session) {
+  if (appSessions.get(key) === session) appSessions.delete(key);
+}
 
 function appSessionKey(worktree, name) {
   // Windows hands back whatever drive-letter casing the caller's shell used, so one tree arrives as
@@ -2302,22 +2338,12 @@ async function main() {
           try {
             app = await withAppAllocation(async () => {
               const current = appSessions.get(key);
-              // `status === 'running'` is not enough, and sessionIsBusy's own comment says why: a
-              // session that is coming up reads `starting`. A live `process` is checked too, because
-              // proc.on('error') sets status without clearing it.
-              //
-              // sessionIsBusy reads four terms and an AppSession only ever sets two, so this
-              // degenerates to `running || starting`. That is the right answer today; a term added
-              // there for DevSession would silently not apply here.
-              if (current && (sessionIsBusy(current) || current.process)) {
+              if (appIsLive(current)) {
                 reused = current;
                 return null;
               }
-              // Only an entry with no live process is a reservation worth inheriting. Doing so keeps
-              // a crashed app on its documented number instead of drifting it every crash, because
-              // getUsedPorts is deliberately status-blind and still counts the entry.
               const port =
-                (!current?.process && current?.port) ||
+                inheritablePort(current) ??
                 (await findAvailablePort(APP_REGISTRY[name].preferredPort, appReservedPorts(name)));
               const fresh = new AppSession(name, resolvedWorktree, port, appEnvChain(resolvedWorktree, name));
               appSessions.set(key, fresh);
@@ -2350,7 +2376,7 @@ async function main() {
           // alone would remove whatever entry happens to be there now — which after a replacement is
           // a live reservation belonging to someone else. Same rule as the exit handler's
           // `this.process === proc`.
-          if (status.status === 'error' && appSessions.get(key) === app) appSessions.delete(key);
+          if (status.status === 'error') releaseIfOurs(key, app);
           res.writeHead(status.status === 'error' ? 500 : 200);
           res.end(JSON.stringify(status));
           return;
@@ -2384,7 +2410,12 @@ async function main() {
           const status = await existing.stop();
           // Membership of the map is the port reservation, so a stop that leaves the entry behind
           // holds a port nothing is serving — the same leak DELETE /sessions/:id exists to avoid.
-          appSessions.delete(key);
+          //
+          // Identity-guarded like the other two, and this is the widest window of the three: stop()
+          // waits up to 800ms by construction, and a start arriving inside it sees a stopped entry
+          // with no process, inherits its port and replaces it. Deleting by key alone would then
+          // remove the NEW entry and leave its vite running with nothing referencing it.
+          releaseIfOurs(key, existing);
           res.writeHead(200);
           res.end(JSON.stringify(status));
           return;
@@ -2393,7 +2424,7 @@ async function main() {
           const status = await existing.restart();
           // Same reservation-against-nothing as the start path, and the same identity guard: a
           // restart awaits a stop and then five path probes, so the entry may not be ours any more.
-          if (status.status === 'error' && appSessions.get(key) === existing) appSessions.delete(key);
+          if (status.status === 'error') releaseIfOurs(key, existing);
           res.writeHead(status.status === 'error' ? 500 : 200);
           res.end(JSON.stringify(status));
           return;
@@ -3028,7 +3059,10 @@ if (invokedDirectly) {
 export {
   APP_REGISTRY,
   appEnvChain,
+  appIsLive,
   appSessionKey,
+  inheritablePort,
+  releaseIfOurs,
   describeDatabaseHost,
   appReservedPorts,
   appSessions,

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -39,6 +39,26 @@ const skillDir = resolve(__dirname, '..');
 const projectRoot = resolve(skillDir, '../../..');
 const pidFile = resolve(skillDir, 'daemon.pid');
 
+// The checkout that owns the .git directory — the base of every env chain. This is NOT projectRoot:
+// the skill directory is committed, so a daemon launched from a worktree derives projectRoot as that
+// worktree, and the "fall back to the primary" half of every chain then points at a file the
+// worktree does not have. `git rev-parse --git-common-dir` resolves to the primary's `.git` from
+// inside any worktree, which is the only spelling of this that does not depend on where the process
+// was started. Falls back to projectRoot when git cannot answer, which is the pre-worktree behaviour.
+function resolvePrimaryCheckout() {
+  try {
+    const gitCommonDir = execSync('git rev-parse --path-format=absolute --git-common-dir', {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (gitCommonDir) return resolve(gitCommonDir, '..');
+  } catch (e) {}
+  return projectRoot;
+}
+
+const primaryCheckout = resolvePrimaryCheckout();
+
 // Configuration
 const DEFAULT_BASE_DEV_PORT = 3000;
 const MAX_LOG_LINES = 2000;
@@ -298,6 +318,17 @@ function loadEnvFile(envPath) {
   return env;
 }
 
+// Layer .env files, later paths winning key by key. A worktree's .env used to REPLACE the
+// primary checkout's outright, so a file written to override two keys started the server with
+// no DATABASE_URL and no secrets — a failure that looks nothing like the two-line edit that
+// caused it. A missing file contributes nothing rather than erroring, so the chain is also how
+// an app with no .env of its own inherits one.
+function loadEnvChain(paths) {
+  const env = {};
+  for (const path of paths) Object.assign(env, loadEnvFile(path));
+  return env;
+}
+
 // Get git branch for a directory
 function getGitBranch(dir) {
   try {
@@ -502,11 +533,12 @@ function lastErrorLog(session) {
 
 // Session class
 class DevSession {
-  constructor(id, worktree, port, envPath, modeOverrides = { prod: [], dev: [] }) {
+  constructor(id, worktree, port, envPaths, modeOverrides = { prod: [], dev: [] }) {
     this.id = id;
     this.worktree = worktree;
     this.port = port;
-    this.envPath = envPath;
+    // Base first, override last. A single path is still valid — it just has nothing under it.
+    this.envPaths = Array.isArray(envPaths) ? envPaths : [envPaths];
     this.modeOverrides = modeOverrides;
     // Pinned at creation. start() re-reads the skill .env for everything else, so without this an
     // edit to DEVSERVER_PROD_GROUPS would move a LIVE session onto production at its next
@@ -542,6 +574,11 @@ class DevSession {
     this.lockHash = null;
     this.schemaHash = null;
     this.depsBaselined = false;
+  }
+
+  // The top of the chain — what a reader means by "which .env is this session on".
+  get envPath() {
+    return this.envPaths[this.envPaths.length - 1];
   }
 
   lockfilePath() {
@@ -644,7 +681,7 @@ class DevSession {
     }
 
     // Load environment variables
-    let envVars = loadEnvFile(this.envPath);
+    let envVars = loadEnvChain(this.envPaths);
 
     // The overlay goes on before the port remap, so a mode that supplies its own auth URLs still
     // gets rewritten to this session's port like any other .env value would be.
@@ -709,7 +746,7 @@ class DevSession {
     this.addLog('info', `Starting dev server on port ${this.port}`);
     this.addLog('info', `Worktree: ${this.worktree}`);
     this.addLog('info', `Branch: ${this.branch}`);
-    this.addLog('info', `Env: ${this.envPath}`);
+    this.addLog('info', `Env: ${this.envPaths.join(' <- ')}`);
     this.addLog('info', `Env modes: ${this.modeSummary}`);
     this.addLog('info', `Build dir: ${this.distDir}`);
 
@@ -990,7 +1027,7 @@ class DevSession {
         from === head ? `Re-checking ${head} for dependency changes` : `Branch switch: ${from} -> ${head}`
       );
 
-      const env = { ...process.env, ...loadEnvFile(this.envPath) };
+      const env = { ...process.env, ...loadEnvChain(this.envPaths) };
       const log = (l, m) => this.addLog(l, m);
       const pnpmCmd = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 
@@ -1247,6 +1284,7 @@ class DevSession {
       worktree: this.worktree,
       branch: this.branch,
       envPath: this.envPath,
+      envPaths: this.envPaths,
       envModes: Object.fromEntries(
         Object.entries(this.modes).map(([group, choice]) => [group, choice.mode])
       ),
@@ -1447,8 +1485,16 @@ const rgbProxy = new RgbProxy(skillConfig.rgbProxyPath);
 // track logs/status. Ready is detected from Vite's startup line; a JWKS probe confirms it's live.
 class AuthHub {
   constructor(hubPath, port) {
-    this.path = resolve(projectRoot, hubPath);
+    // The primary checkout, never this daemon's own root. The hub is ONE shared process for every
+    // worktree — env-modes.mjs lists it in PROD_ONLY_GROUPS for exactly that reason — so a daemon
+    // launched from a worktree must still run the primary's copy, which is also the only one with
+    // the gitignored apps/auth/.env beside it.
+    this.path = resolve(primaryCheckout, hubPath);
     this.port = port;
+    // Subclasses vary these three; everything else about running a Vite app is identical.
+    this.label = 'Auth hub';
+    this.requiredEnvPath = resolve(this.path, '.env');
+    this.envPaths = [];
     this.process = null;
     this.status = 'stopped'; // stopped | starting | running | crashed | error | disabled
     this.ready = false;
@@ -1473,29 +1519,44 @@ class AuthHub {
     return logs;
   }
 
+  // `::` (dual-stack), not a single literal. Bound to `127.0.0.1` these servers answered on v4 and
+  // nothing on [::1]; Windows resolves `localhost` to ::1 first, so a browser typing the same `localhost`
+  // URL the auth redirects use got connection-refused while curl — which falls back to v4 — reported the
+  // server perfectly healthy. `localhost` is not the fix either: it resolves to ::1 *only*, which just
+  // moves the outage onto every caller that hardcodes 127.0.0.1. `::` accepts v4-mapped addresses, so both
+  // spellings work, and it matches what `next dev` already binds for the main app on 3000.
+  //
+  // `--strictPort` is what makes the port the daemon reserved the port the app actually binds.
+  // Without it Vite drifts to the next free one on its own and the reservation stops meaning
+  // anything — two apps would report ports neither of them is serving.
+  spawnArgs() {
+    return ['exec', 'vite', 'dev', '--host', '::', '--port', String(this.port), '--strictPort'];
+  }
+
   start() {
     if (this.process) {
-      this.addLog('info', 'Auth hub already running');
+      this.addLog('info', `${this.label} already running`);
       return this.getStatus();
     }
 
     if (!existsSync(this.path)) {
       this.status = 'error';
-      this.lastError = `Auth hub path not found: ${this.path}`;
+      this.lastError = `${this.label} path not found: ${this.path}`;
       this.addLog('error', this.lastError);
       return this.getStatus();
     }
 
-    if (!existsSync(resolve(this.path, '.env'))) {
+    // `null` means the app has no .env of its own to require — it inherits the chain instead.
+    if (this.requiredEnvPath && !existsSync(this.requiredEnvPath)) {
       this.status = 'error';
-      this.lastError = `Auth hub .env missing: ${resolve(this.path, '.env')}. See SKILL.md (Auth Hub setup).`;
+      this.lastError = `${this.label} .env missing: ${this.requiredEnvPath}`;
       this.addLog('error', this.lastError);
       return this.getStatus();
     }
 
     if (!existsSync(resolve(this.path, 'node_modules'))) {
       this.status = 'error';
-      this.lastError = `Auth hub dependencies not installed. Run: pnpm install`;
+      this.lastError = `${this.label} dependencies not installed. Run: pnpm install`;
       this.addLog('error', this.lastError);
       return this.getStatus();
     }
@@ -1504,14 +1565,17 @@ class AuthHub {
     this.ready = false;
     this.readyAt = null;
     this.lastError = null;
-    this.addLog('info', `Starting auth hub on port ${this.port}: ${this.path}`);
+    this.addLog('info', `Starting ${this.label} on port ${this.port}: ${this.path}`);
 
     const isWindows = process.platform === 'win32';
     const pnpmCmd = isWindows ? 'pnpm.cmd' : 'pnpm';
 
+    // The hub passes an empty chain and lets Vite load its own .env. An app started in a
+    // worktree passes one, because the worktree's copy of that .env is gitignored and usually
+    // absent — the chain is what lets it inherit the primary checkout's.
     const spawnOptions = {
       cwd: this.path,
-      env: process.env, // Vite loads apps/auth/.env itself — no injection
+      env: this.envPaths.length ? { ...process.env, ...loadEnvChain(this.envPaths) } : process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: isWindows,
     };
@@ -1519,17 +1583,7 @@ class AuthHub {
 
     let proc;
     try {
-      // `::` (dual-stack), not a single literal. Bound to `127.0.0.1` these servers answered on v4 and
-      // nothing on [::1]; Windows resolves `localhost` to ::1 first, so a browser typing the same `localhost`
-      // URL the auth redirects use got connection-refused while curl — which falls back to v4 — reported the
-      // server perfectly healthy. `localhost` is not the fix either: it resolves to ::1 *only*, which just
-      // moves the outage onto every caller that hardcodes 127.0.0.1. `::` accepts v4-mapped addresses, so both
-      // spellings work, and it matches what `next dev` already binds for the main app on 3000.
-      proc = spawn(
-        pnpmCmd,
-        ['exec', 'vite', 'dev', '--host', '::', '--port', String(this.port), '--strictPort'],
-        spawnOptions
-      );
+      proc = spawn(pnpmCmd, this.spawnArgs(), spawnOptions);
     } catch (err) {
       this.status = 'error';
       this.lastError = err.message;
@@ -1547,7 +1601,7 @@ class AuthHub {
       if (this.ready) return;
       this.ready = true;
       this.readyAt = new Date().toISOString();
-      this.addLog('info', `Auth hub ready on http://localhost:${this.port}`);
+      this.addLog('info', `${this.label} ready on http://localhost:${this.port}`);
     };
 
     proc.stdout.on('data', (data) => {
@@ -1575,7 +1629,7 @@ class AuthHub {
 
     proc.on('exit', (code, signal) => {
       this.exitCode = code;
-      this.addLog('info', `Auth hub exited (code=${code}, signal=${signal})`);
+      this.addLog('info', `${this.label} exited (code=${code}, signal=${signal})`);
       // Only mutate shared state if this is still the CURRENT process. A restart may have already
       // replaced it (Vite also self-restarts on .env change) — a late exit must not clobber the new one.
       if (this.process === proc) {
@@ -1604,7 +1658,7 @@ class AuthHub {
       return this.getStatus();
     }
 
-    this.addLog('info', 'Stopping auth hub...');
+    this.addLog('info', `Stopping ${this.label}...`);
     // Detach eagerly so a subsequent start() never sees a stale process (the exit handler is guarded on
     // identity, so the late exit of this proc won't touch the fresh one).
     this.process = null;
@@ -1652,39 +1706,68 @@ class AuthHub {
 
 const authHub = new AuthHub(skillConfig.authHubPath, skillConfig.authHubPort);
 
-// Every other SvelteKit app under apps/ runs the same way the auth hub does: `vite dev` in the app
-// directory, vite loads that app's own .env. AuthHub already encodes all of that plus the readiness
-// parsing, crash handling and log ring buffer, so a spoke is an AuthHub with a different label.
+// The SvelteKit spokes run the same way the auth hub does: `vite dev` in the app directory. AuthHub
+// already encodes that plus the readiness parsing, crash handling and log ring buffer, so an app is
+// an AuthHub with a different root, port and env chain.
 //
-// Ports are fixed per app rather than auto-assigned so a redirect between two of them (moderator ->
-// auth) always lands on the same place, and so `--strictPort` fails loudly on a collision instead of
-// silently drifting to the next free port.
-const SPOKE_APPS = {
-  moderator: { path: 'apps/moderator', port: 5174 },
-  'creator-studio': { path: 'apps/creator-studio', port: 5175 },
-  storage: { path: 'apps/storage', port: 5176 },
-  notifications: { path: 'apps/notifications', port: 5177 },
+// `storage` and `notifications` were registered here and could never start: they have no
+// vite.config.ts (their dev script is `tsx watch src/server.ts`) and no .env, so every attempt died
+// at the .env precheck reporting an auth-hub problem. They are out until someone runs them properly.
+const APP_REGISTRY = {
+  moderator: { path: 'apps/moderator', preferredPort: 5174 },
+  'creator-studio': { path: 'apps/creator-studio', preferredPort: 5175 },
 };
 
-class SpokeApp extends AuthHub {
-  constructor(name, appPath, port) {
-    super(appPath, port);
+// An app runs from the worktree it was started in. The previous class resolved its path against
+// `projectRoot` — derived from the daemon script's own location — so `app moderator start` typed in
+// a worktree served the primary checkout instead, silently: the app came up, answered 200s, and
+// showed `main`. Nothing in the output contradicted you unless you read the `path` field.
+class AppSession extends AuthHub {
+  constructor(name, worktree, port, envPaths) {
+    super('.', port);
     this.name = name;
+    this.worktree = worktree;
+    this.path = resolve(worktree, APP_REGISTRY[name].path);
+    this.label = name;
+    // The app's own .env is gitignored, so a fresh worktree has none. The chain supplies it from the
+    // primary checkout instead of refusing to start, which is what `requiredEnvPath: null` buys.
+    this.requiredEnvPath = null;
+    this.envPaths = envPaths;
   }
 
   getStatus() {
-    return { ...super.getStatus(), name: this.name, enabled: true };
+    const { jwksUrl, ...rest } = super.getStatus();
+    return { ...rest, name: this.name, worktree: this.worktree, enabled: true };
   }
 }
 
-const spokeApps = new Map(
-  Object.entries(SPOKE_APPS).map(([name, cfg]) => [name, new SpokeApp(name, cfg.path, cfg.port)])
-);
+// The primary checkout's copy of an app's .env is the base; the worktree's own, if it has one, wins
+// key by key. Both are gitignored, so the base is what a fresh worktree actually runs on — without
+// it the app refuses to start over a file that has never been in a checkout.
+function appEnvChain(worktree, name) {
+  const relative = APP_REGISTRY[name].path;
+  const paths = [resolve(primaryCheckout, relative, '.env')];
+  const worktreeEnv = resolve(worktree, relative, '.env');
+  if (worktreeEnv !== paths[0]) paths.push(worktreeEnv);
+  return paths;
+}
 
-// Spokes bind with --strictPort, so one left running past daemon exit makes the next start of
-// that app fail with EADDRINUSE against a process nothing is tracking any more.
-async function stopSpokeApps() {
-  for (const app of spokeApps.values()) {
+// Keyed by worktree AND app, so two worktrees can serve the same app at once. A key on the app name
+// alone is what made them global singletons.
+const appSessions = new Map();
+
+function appSessionKey(worktree, name) {
+  return `${worktree}::${name}`;
+}
+
+function listAppSessions() {
+  return [...appSessions.values()].map((a) => a.getStatus());
+}
+
+// Apps bind with --strictPort, so one left running past daemon exit makes the next start of that
+// app fail with EADDRINUSE against a process nothing is tracking any more.
+async function stopAppSessions() {
+  for (const app of appSessions.values()) {
     if (app.status === 'running') await app.stop();
   }
 }
@@ -1704,6 +1787,12 @@ function getUsedPorts() {
   const ports = new Set();
   for (const session of sessions.values()) {
     ports.add(session.port);
+  }
+  // App sessions reserve their port the same way. Leaving them out let the main app's allocator
+  // hand out a port a spoke was already bound to, and --strictPort turns that into a start that
+  // fails on a number nothing in `status` accounted for.
+  for (const app of appSessions.values()) {
+    ports.add(app.port);
   }
   return ports;
 }
@@ -1891,7 +1980,7 @@ async function main() {
   console.error(`  Project root: ${projectRoot}`);
 
   // Find the main .env file
-  const mainEnvPath = resolve(projectRoot, '.env');
+  const mainEnvPath = resolve(primaryCheckout, '.env');
 
   const handler = async (req, res) => {
     const url = new URL(req.url, `http://localhost:${config.port}`);
@@ -1984,53 +2073,133 @@ async function main() {
         return;
       }
 
-      // /app/<name>[/logs|/start|/stop|/restart] - spoke app control
+      // /app/<name>[/logs|/start|/stop|/restart] — per-worktree app control
       if (path === '/apps' && req.method === 'GET') {
         res.writeHead(200);
         res.end(JSON.stringify({
-          apps: [...spokeApps.values()].map((a) => a.getStatus()),
+          available: Object.keys(APP_REGISTRY),
+          apps: listAppSessions(),
         }));
         return;
       }
 
       if (path.startsWith('/app/')) {
         const [, , name, action] = path.split('/');
-        const app = spokeApps.get(name);
-        if (!app) {
+        if (!APP_REGISTRY[name]) {
           res.writeHead(404);
           res.end(JSON.stringify({
             error: `Unknown app: ${name}`,
-            available: [...spokeApps.keys()],
+            available: Object.keys(APP_REGISTRY),
+          }));
+          return;
+        }
+
+        let body = {};
+        if (req.method === 'POST') {
+          const raw = await readBody(req);
+          try {
+            body = JSON.parse(raw || '{}');
+          } catch (e) {
+            res.writeHead(400);
+            res.end(JSON.stringify({ error: 'Invalid JSON body' }));
+            return;
+          }
+        }
+        // Falling back to projectRoot is the failure this whole change exists to remove, so it is
+        // reached only when the caller named no worktree at all — never as the quiet result of a
+        // body that did not parse.
+        const requestedWorktree = body.worktree || url.searchParams.get('worktree');
+        const resolvedWorktree = requestedWorktree ? resolve(requestedWorktree) : projectRoot;
+        const key = appSessionKey(resolvedWorktree, name);
+        const existing = appSessions.get(key);
+
+        if (action === 'start' && req.method === 'POST') {
+          if (!(await pathExists(resolvedWorktree))) {
+            res.writeHead(400);
+            res.end(JSON.stringify({ error: `Worktree not found: ${resolvedWorktree}` }));
+            return;
+          }
+          if (existing && existing.status === 'running') {
+            res.writeHead(200);
+            res.end(JSON.stringify({ reused: true, ...existing.getStatus() }));
+            return;
+          }
+
+          // The preferred port is where the first worktree lands, so the common case stays the
+          // documented number. A second worktree drifts rather than dying on EADDRINUSE. Nothing
+          // needs rewriting to follow it: neither spoke's .env carries its own port or base URL,
+          // and the hub trusts loopback by HOST in dev, so the drifted origin is still first-party.
+          // Every app's preferred port is reserved against the drift search, not just the taken
+          // ones: moderator drifting off 5174 would otherwise land on 5175 and displace
+          // creator-studio from its own documented number for as long as it ran.
+          const reserved = getUsedPorts();
+          for (const [other, spec] of Object.entries(APP_REGISTRY)) {
+            if (other !== name) reserved.add(spec.preferredPort);
+          }
+          let port;
+          try {
+            port = await findAvailablePort(APP_REGISTRY[name].preferredPort, reserved);
+          } catch (err) {
+            res.writeHead(503);
+            res.end(JSON.stringify({ error: err.message }));
+            return;
+          }
+
+          const envPaths = appEnvChain(resolvedWorktree, name);
+          const app = new AppSession(name, resolvedWorktree, port, envPaths);
+          appSessions.set(key, app);
+
+          // Decision 2A: the hub is one shared, idempotent process and a spoke cannot log anyone in
+          // without it. The main app is deliberately NOT started — the spokes reach it over REST when
+          // they need it, and a cold Next.js compile is not something to trigger on someone's behalf.
+          if (skillConfig.authHubEnabled && authHub.status !== 'running') authHub.start();
+
+          const status = app.start();
+          // A start that never spawned holds no process, so the map entry is a port reservation
+          // against nothing — and since the entry is also the only way to address it, nothing can
+          // release it either. A missing node_modules would burn the app's preferred port for the
+          // life of the daemon, and the next start would drift off a number that was free.
+          if (status.status === 'error') appSessions.delete(key);
+          res.writeHead(status.status === 'error' ? 500 : 200);
+          res.end(JSON.stringify(status));
+          return;
+        }
+
+        if (!existing) {
+          res.writeHead(404);
+          res.end(JSON.stringify({
+            error: `${name} is not running in ${resolvedWorktree}`,
+            running: listAppSessions().filter((a) => a.name === name).map((a) => a.worktree),
           }));
           return;
         }
 
         if (!action && req.method === 'GET') {
           res.writeHead(200);
-          res.end(JSON.stringify(app.getStatus()));
+          res.end(JSON.stringify(existing.getStatus()));
           return;
         }
         if (action === 'logs' && req.method === 'GET') {
           const since = parseInt(url.searchParams.get('since') || '0', 10);
           const limit = parseInt(url.searchParams.get('limit') || '500', 10);
           res.writeHead(200);
-          res.end(JSON.stringify({ currentIndex: app.logIndex, logs: app.getLogs(since, limit) }));
-          return;
-        }
-        if (action === 'start' && req.method === 'POST') {
-          const status = app.start();
-          res.writeHead(status.status === 'error' ? 500 : 200);
-          res.end(JSON.stringify(status));
+          res.end(JSON.stringify({
+            currentIndex: existing.logIndex,
+            logs: existing.getLogs(since, limit),
+          }));
           return;
         }
         if (action === 'stop' && req.method === 'POST') {
-          const status = await app.stop();
+          const status = await existing.stop();
+          // Membership of the map is the port reservation, so a stop that leaves the entry behind
+          // holds a port nothing is serving — the same leak DELETE /sessions/:id exists to avoid.
+          appSessions.delete(key);
           res.writeHead(200);
           res.end(JSON.stringify(status));
           return;
         }
         if (action === 'restart' && req.method === 'POST') {
-          const status = await app.restart();
+          const status = await existing.restart();
           res.writeHead(status.status === 'error' ? 500 : 200);
           res.end(JSON.stringify(status));
           return;
@@ -2384,18 +2553,23 @@ async function main() {
           port = await findAvailablePort(config.baseDevPort, usedPorts);
         }
 
-        // A worktree's own .env is the one its branch was written against. Falling back to the
-        // daemon's project root hands every session whichever tree happened to launch the daemon.
+        // The primary checkout's .env is the base of every session; a worktree's own .env (or an
+        // explicit --env) layers on top of it. So a worktree file needs to restate only the keys
+        // it wants to change, and one that restates nothing is a no-op rather than an outage.
+        //
+        // "Present" is the safe answer for the top of the chain and the unsafe one for the base:
+        // a timed-out check must not DROP the primary file, because that is what leaves a session
+        // with no DATABASE_URL and no secrets, failing in a way that looks nothing like a slow
+        // filesystem.
         const worktreeEnvPath = resolve(resolvedWorktree, '.env');
-        const resolvedEnvPath = envPath
+        const overlayPath = envPath
           ? resolve(envPath)
-          : // "Present" is the safe answer for the worktree and the unsafe one here: picking a
-            // file that may not exist over a known-good fallback starts the server with no env at
-            // all — no DATABASE_URL, no secrets — failing in a way that looks nothing like a slow
-            // filesystem. So an unknown answer falls back to the main .env.
-            await checkPath(worktreeEnvPath).then((r) => r.exists && !r.timedOut)
+          : (await checkPath(worktreeEnvPath).then((r) => r.exists && !r.timedOut))
             ? worktreeEnvPath
-            : mainEnvPath;
+            : null;
+        const resolvedEnvPaths = [mainEnvPath, overlayPath].filter(
+          (p, i, all) => p && all.indexOf(p) === i
+        );
 
         // Create and start session
         const sessionId = generateSessionId();
@@ -2403,7 +2577,7 @@ async function main() {
           sessionId,
           resolvedWorktree,
           port,
-          resolvedEnvPath,
+          resolvedEnvPaths,
           modeOverrides
         );
         sessions.set(sessionId, session);
@@ -2536,7 +2710,7 @@ async function main() {
         testQueue.shutdown();
         await rgbProxy.stop();
         await authHub.stop();
-        await stopSpokeApps();
+        await stopAppSessions();
 
         res.writeHead(200);
         res.end(JSON.stringify({ success: true }));
@@ -2609,7 +2783,7 @@ async function main() {
     testQueue.shutdown();
     await rgbProxy.stop();
     await authHub.stop();
-    await stopSpokeApps();
+    await stopAppSessions();
     try { unlinkSync(pidFile); } catch (e) {}
     server.close();
     process.exit(0);
@@ -2623,7 +2797,7 @@ async function main() {
     testQueue.shutdown();
     await rgbProxy.stop();
     await authHub.stop();
-    await stopSpokeApps();
+    await stopAppSessions();
     try { unlinkSync(pidFile); } catch (e) {}
     server.close();
     process.exit(0);
@@ -2658,6 +2832,7 @@ export {
   checkPath,
   claimPortForReuse,
   DevSession,
+  loadEnvChain,
   findSessionByWorktree,
   getUsedPorts,
   listSessions,

--- a/.claude/skills/dev-server/scripts/db-host.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/db-host.selftest.mjs
@@ -47,9 +47,11 @@ check('a missing DATABASE_URL is null', describeDatabaseHost({}), null);
 check('an unparseable value is null, not a guess', describeDatabaseHost({ DATABASE_URL: 'not a url' }), null);
 check('an empty value is null', describeDatabaseHost({ DATABASE_URL: '' }), null);
 
-// Two degenerate shapes the correctness lane found. Both must be null, not a truncated string a
-// reader would take for a hostname — `postgres:whatever` parses as an opaque path with an empty
-// hostname, and `postgres://user:sec@ret` yields `ret`, which is password material.
+// Two degenerate shapes. Only the first is what `|| null` is for: `postgres:something` parses as an
+// opaque path with an EMPTY hostname, which `??` would pass through as `""`. The second throws and
+// returns null from the catch instead — worth pinning either way, but not for the reason the first
+// version of this comment gave. (`postgres://user:sec@ret` does parse, with `ret` as the genuine
+// hostname, not as password material.)
 check('a scheme with no // is null, not an empty string', describeDatabaseHost({ DATABASE_URL: 'postgres:something' }), null);
 check('userinfo with no host is null, not the password tail', describeDatabaseHost({ DATABASE_URL: 'postgres://myuser:sup3r-s3cret' }), null);
 

--- a/.claude/skills/dev-server/scripts/db-host.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/db-host.selftest.mjs
@@ -38,6 +38,11 @@ check(
   describeDatabaseHost({ DATABASE_URL: 'postgres://myuser:sup3r-s3cret@db.example.com/civitai_prod_db' }),
   'db.example.com'
 );
+check(
+  'an IPv6 literal keeps its brackets',
+  describeDatabaseHost({ DATABASE_URL: 'postgres://myuser:sup3r-s3cret@[::1]:5432/civitai_prod_db' }),
+  '[::1]:5432'
+);
 check('a missing DATABASE_URL is null', describeDatabaseHost({}), null);
 check('an unparseable value is null, not a guess', describeDatabaseHost({ DATABASE_URL: 'not a url' }), null);
 check('an empty value is null', describeDatabaseHost({ DATABASE_URL: '' }), null);

--- a/.claude/skills/dev-server/scripts/db-host.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/db-host.selftest.mjs
@@ -1,0 +1,66 @@
+// describeDatabaseHost must emit a HOST and never a credential. It exists because an app inherits
+// the primary checkout's .env, which may point at production, and the host is the only part of a
+// DATABASE_URL that is safe to put in a log line and a status object.
+//
+// The mutation this guards against is someone "improving" the line to be more informative — logging
+// the pathname, the search params, or the whole URL. Any of those carries the password.
+import { describeDatabaseHost } from './daemon.mjs';
+
+const failures = [];
+let checks = 0;
+
+function check(name, actual, expected) {
+  checks++;
+  if (actual !== expected) {
+    failures.push(`${name}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+// The secrets below are invented for this file. They are the assertion, not a fixture: every one
+// must be absent from the output.
+const SECRETS = ['sup3r-s3cret', 'myuser', 'tok3n-value', 'civitai_prod_db'];
+
+function checkNoLeak(name, url) {
+  checks++;
+  const out = describeDatabaseHost({ DATABASE_URL: url });
+  if (out === null) return;
+  const leaked = SECRETS.filter((s) => out.includes(s));
+  if (leaked.length) failures.push(`${name}: leaked ${leaked.join(', ')} in ${JSON.stringify(out)}`);
+}
+
+check(
+  'host and port, credentials dropped',
+  describeDatabaseHost({ DATABASE_URL: 'postgres://myuser:sup3r-s3cret@db.example.com:25060/civitai_prod_db' }),
+  'db.example.com:25060'
+);
+check(
+  'no port yields the bare host',
+  describeDatabaseHost({ DATABASE_URL: 'postgres://myuser:sup3r-s3cret@db.example.com/civitai_prod_db' }),
+  'db.example.com'
+);
+check('a missing DATABASE_URL is null', describeDatabaseHost({}), null);
+check('an unparseable value is null, not a guess', describeDatabaseHost({ DATABASE_URL: 'not a url' }), null);
+check('an empty value is null', describeDatabaseHost({ DATABASE_URL: '' }), null);
+
+// Two degenerate shapes the correctness lane found. Both must be null, not a truncated string a
+// reader would take for a hostname — `postgres:whatever` parses as an opaque path with an empty
+// hostname, and `postgres://user:sec@ret` yields `ret`, which is password material.
+check('a scheme with no // is null, not an empty string', describeDatabaseHost({ DATABASE_URL: 'postgres:something' }), null);
+check('userinfo with no host is null, not the password tail', describeDatabaseHost({ DATABASE_URL: 'postgres://myuser:sup3r-s3cret' }), null);
+
+// libpq keyword DSN — not a URL at all.
+check('a libpq keyword DSN is null', describeDatabaseHost({ DATABASE_URL: 'host=db.example.com password=sup3r-s3cret' }), null);
+
+checkNoLeak('password in userinfo', 'postgres://myuser:sup3r-s3cret@db.example.com:25060/civitai_prod_db');
+checkNoLeak('secret in the query string', 'postgres://u@h:5432/db?password=sup3r-s3cret&token=tok3n-value');
+checkNoLeak('db name in the path', 'postgres://u@h:5432/civitai_prod_db');
+checkNoLeak('password containing an @', 'postgres://myuser:sup3r-s3cret@x@db.example.com:25060/db');
+checkNoLeak('no scheme', 'myuser:sup3r-s3cret@db.example.com:25060/civitai_prod_db');
+checkNoLeak('credentials but no host', 'postgres://myuser:sup3r-s3cret@');
+
+if (failures.length) {
+  console.error('FAIL');
+  for (const f of failures) console.error('  ' + f);
+  process.exit(1);
+}
+console.log(`db-host selftest: ${checks} checks passed`);

--- a/.claude/skills/dev-server/scripts/env-chain.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/env-chain.selftest.mjs
@@ -1,36 +1,67 @@
-// Layering check for loadEnvChain. The regression this guards is not "the merge is wrong" but
+// Layering checks for the .env chain. The regression this guards is not "the merge is wrong" but
 // "the merge is gone": before it, a worktree .env REPLACED the primary, so a two-key override file
-// started the server with no DATABASE_URL. The first case fails loudly on exactly that revert.
-import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+// started the server with no DATABASE_URL.
+//
+// It deliberately covers BOTH halves. loadEnvChain honours the order of the array it is handed, and
+// appEnvChain decides what that order is — testing only the first leaves the mirror-image outage
+// (every worktree override silently ignored, primary always winning) passing green.
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { resolve } from 'path';
-import { loadEnvChain } from './daemon.mjs';
+import { loadEnvChain, appEnvChain, APP_REGISTRY, primaryCheckout } from './daemon.mjs';
 
 const dir = mkdtempSync(resolve(tmpdir(), 'env-chain-'));
 const base = resolve(dir, 'base.env');
 const overlay = resolve(dir, 'overlay.env');
 const failures = [];
+let checks = 0;
 
 function check(name, actual, expected) {
-  if (actual !== expected) failures.push(`${name}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  checks++;
+  if (actual !== expected) {
+    failures.push(`${name}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
 }
 
 try {
-  writeFileSync(base, 'DATABASE_URL=postgres://base\nSHARED=from-base\nREDIS_URL=redis://base\n');
-  writeFileSync(overlay, 'SHARED=from-overlay\n');
+  writeFileSync(base, 'DATABASE_URL=postgres://base\nSHARED=from-base\nREDIS_URL=redis://base\nBLANKED=real-secret\n');
+  writeFileSync(overlay, 'SHARED=from-overlay\nBLANKED=\n');
 
+  // --- loadEnvChain: the merge itself ---
   const merged = loadEnvChain([base, overlay]);
   check('overlay wins on a restated key', merged.SHARED, 'from-overlay');
   check('base survives a key the overlay omits', merged.DATABASE_URL, 'postgres://base');
   check('base survives a second omitted key', merged.REDIS_URL, 'redis://base');
 
+  // An empty value in the overlay UNSETS the base value rather than being skipped. Pinned because
+  // the plausible future edit here is "don't let a blank line clobber a real secret" (`if (v)`),
+  // which silently reverses this and passes every other check in this file.
+  check('an empty overlay value blanks the base value', merged.BLANKED, '');
+
   const missingOverlay = loadEnvChain([base, resolve(dir, 'nope.env')]);
   check('a missing overlay contributes nothing', missingOverlay.DATABASE_URL, 'postgres://base');
 
   check('an empty chain is empty', Object.keys(loadEnvChain([])).length, 0);
+  check('a chain of one is that one file', loadEnvChain([base]).SHARED, 'from-base');
 
-  // Order is the whole contract — assert it in both directions so a reversed loop is caught.
+  // Order is the contract, so assert it in both directions — a reversed loop passes a one-direction
+  // test whenever the fixtures happen to agree.
   check('reversed order reverses the winner', loadEnvChain([overlay, base]).SHARED, 'from-base');
+
+  // --- appEnvChain: who BUILDS the array ---
+  const worktree = resolve(dir, 'worktree');
+  mkdirSync(worktree, { recursive: true });
+  const chain = appEnvChain(worktree, 'moderator');
+  const relative = APP_REGISTRY.moderator.path;
+
+  check('app chain is base-then-overlay, two entries', chain.length, 2);
+  check('app chain BASE is the primary checkout', chain[0], resolve(primaryCheckout, relative, '.env'));
+  check('app chain TOP is the worktree', chain[chain.length - 1], resolve(worktree, relative, '.env'));
+
+  // Started from the primary checkout the two paths are identical; a duplicate would make the log
+  // read `Env: a <- a` and is pure noise.
+  const selfChain = appEnvChain(primaryCheckout, 'moderator');
+  check('the primary checkout does not chain onto itself', selfChain.length, 1);
 } finally {
   rmSync(dir, { recursive: true, force: true });
 }
@@ -40,4 +71,4 @@ if (failures.length) {
   for (const f of failures) console.error('  ' + f);
   process.exit(1);
 }
-console.log('env-chain selftest: 6 checks passed');
+console.log(`env-chain selftest: ${checks} checks passed`);

--- a/.claude/skills/dev-server/scripts/env-chain.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/env-chain.selftest.mjs
@@ -8,7 +8,7 @@
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { resolve } from 'path';
-import { loadEnvChain, appEnvChain, APP_REGISTRY, primaryCheckout } from './daemon.mjs';
+import { loadEnvChain, appEnvChain, APP_REGISTRY, primaryCheckout, AppSession } from './daemon.mjs';
 
 const dir = mkdtempSync(resolve(tmpdir(), 'env-chain-'));
 const base = resolve(dir, 'base.env');
@@ -62,6 +62,23 @@ try {
   // read `Env: a <- a` and is pure noise.
   const selfChain = appEnvChain(primaryCheckout, 'moderator');
   check('the primary checkout does not chain onto itself', selfChain.length, 1);
+
+  // --- WHICH OBJECT, not how it parses ---
+  // The DATABASE_URL warning and the "no env" refusal both read spawnEnv(), and the bug they were
+  // fixed for was not a parsing bug — it was reading the CHAIN when the child is handed
+  // `{ ...process.env, ...chain }`. Reverting to loadEnvChain(this.envPaths) passes every check in
+  // db-host.selftest.mjs, because all of those call the parser directly. This is the one that sees it.
+  const probe = new AppSession('moderator', worktree, 5174, [base]);
+  const env = probe.spawnEnv();
+  check('spawnEnv layers the chain over process.env', env.SHARED, 'from-base');
+  check('spawnEnv keeps a key only process.env has', env.PATH, process.env.PATH);
+  check('spawnEnv is stable within one start', probe.spawnEnv(), env);
+
+  // An empty chain means "this daemon does not supply this process's env" — the auth hub, which lets
+  // Vite load its own .env. spawnEnv must then be process.env itself, and the warning must stay
+  // quiet rather than naming an inherited candidate the process may not even use.
+  const hubLike = new AppSession('moderator', worktree, 5174, []);
+  check('an empty chain is process.env itself', hubLike.spawnEnv(), process.env);
 } finally {
   rmSync(dir, { recursive: true, force: true });
 }

--- a/.claude/skills/dev-server/scripts/env-chain.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/env-chain.selftest.mjs
@@ -1,0 +1,43 @@
+// Layering check for loadEnvChain. The regression this guards is not "the merge is wrong" but
+// "the merge is gone": before it, a worktree .env REPLACED the primary, so a two-key override file
+// started the server with no DATABASE_URL. The first case fails loudly on exactly that revert.
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { resolve } from 'path';
+import { loadEnvChain } from './daemon.mjs';
+
+const dir = mkdtempSync(resolve(tmpdir(), 'env-chain-'));
+const base = resolve(dir, 'base.env');
+const overlay = resolve(dir, 'overlay.env');
+const failures = [];
+
+function check(name, actual, expected) {
+  if (actual !== expected) failures.push(`${name}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+try {
+  writeFileSync(base, 'DATABASE_URL=postgres://base\nSHARED=from-base\nREDIS_URL=redis://base\n');
+  writeFileSync(overlay, 'SHARED=from-overlay\n');
+
+  const merged = loadEnvChain([base, overlay]);
+  check('overlay wins on a restated key', merged.SHARED, 'from-overlay');
+  check('base survives a key the overlay omits', merged.DATABASE_URL, 'postgres://base');
+  check('base survives a second omitted key', merged.REDIS_URL, 'redis://base');
+
+  const missingOverlay = loadEnvChain([base, resolve(dir, 'nope.env')]);
+  check('a missing overlay contributes nothing', missingOverlay.DATABASE_URL, 'postgres://base');
+
+  check('an empty chain is empty', Object.keys(loadEnvChain([])).length, 0);
+
+  // Order is the whole contract — assert it in both directions so a reversed loop is caught.
+  check('reversed order reverses the winner', loadEnvChain([overlay, base]).SHARED, 'from-base');
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+if (failures.length) {
+  console.error('FAIL');
+  for (const f of failures) console.error('  ' + f);
+  process.exit(1);
+}
+console.log('env-chain selftest: 6 checks passed');

--- a/.claude/skills/dev-server/scripts/env-chain.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/env-chain.selftest.mjs
@@ -79,6 +79,27 @@ try {
   // quiet rather than naming an inherited candidate the process may not even use.
   const hubLike = new AppSession('moderator', worktree, 5174, []);
   check('an empty chain is process.env itself', hubLike.spawnEnv(), process.env);
+
+  // Stability is the benign half; STALENESS is the half with teeth. Without the per-start
+  // invalidation, editing an .env to point away from production and restarting spawns with the old
+  // DATABASE_URL — and because dbHost reads the same cached object, the warning line then confirms
+  // the host you just changed away from.
+  writeFileSync(base, 'SHARED=edited-on-disk\n');
+  check('the cache does not notice a file edit on its own', probe.spawnEnv().SHARED, 'from-base');
+  probe.invalidateSpawnEnv();
+  check('invalidating picks up the edit', probe.spawnEnv().SHARED, 'edited-on-disk');
+
+  // The method is only half of it — #start() has to CALL it. Testable without spawning anything: a
+  // start against a path that does not exist invalidates first and then fails at the probes, so no
+  // child is ever created. Without the call, a restart after an .env edit spawns with the old
+  // DATABASE_URL, and dbHost reads the same cached object — so the warning line confirms the host
+  // you just changed away from.
+  writeFileSync(base, 'SHARED=edited-again\n');
+  const wired = new AppSession('moderator', resolve(dir, 'no-such-worktree'), 5174, [base]);
+  wired.spawnEnvCache = { SHARED: 'stale-from-a-previous-start' };
+  const result = await wired.start();
+  check('a start on a missing path errors without spawning', result.status, 'error');
+  check('start() invalidates the cached env', wired.spawnEnv().SHARED, 'edited-again');
 } finally {
   rmSync(dir, { recursive: true, force: true });
 }

--- a/.claude/skills/dev-server/scripts/paths.mjs
+++ b/.claude/skills/dev-server/scripts/paths.mjs
@@ -1,14 +1,12 @@
 // Path identity, in one place.
 //
-// This PR fixed the same comparison bug in four separate spots — the app session key, the .env chain
-// dedupe, the primary-worktree refusal, and the lookup immediately below that refusal — and left the
-// rule written twice, in daemon.mjs and worktree.mjs. Two copies means the next person to improve
-// one (trailing separators, UNC paths, `\\?\` prefixes) improves half the callers, and the
-// disagreement surfaces as `wt rm` refusing a tree the daemon is serving, or not refusing one it is.
+// A leaf module rather than a corner of daemon.mjs, because worktree.mjs and the selftests would
+// otherwise import a module that runs `execSync` and constructs AuthHub and RgbProxy at load, just
+// to reach six lines of string comparison.
 //
-// It lives in its own leaf module rather than in daemon.mjs because worktree.mjs and the selftests
-// would otherwise import a module that runs `execSync` and constructs AuthHub and RgbProxy at load
-// just to reach six lines of string comparison.
+// One definition, because the next person to improve it (trailing separators, UNC paths, `\\?\`
+// prefixes) has to improve every caller at once: a daemon and a `wt rm` that disagree about whether
+// two paths are the same tree is how `wt rm` deletes one the daemon is serving.
 import { resolve } from 'path';
 
 /**

--- a/.claude/skills/dev-server/scripts/paths.mjs
+++ b/.claude/skills/dev-server/scripts/paths.mjs
@@ -1,0 +1,31 @@
+// Path identity, in one place.
+//
+// This PR fixed the same comparison bug in four separate spots — the app session key, the .env chain
+// dedupe, the primary-worktree refusal, and the lookup immediately below that refusal — and left the
+// rule written twice, in daemon.mjs and worktree.mjs. Two copies means the next person to improve
+// one (trailing separators, UNC paths, `\\?\` prefixes) improves half the callers, and the
+// disagreement surfaces as `wt rm` refusing a tree the daemon is serving, or not refusing one it is.
+//
+// It lives in its own leaf module rather than in daemon.mjs because worktree.mjs and the selftests
+// would otherwise import a module that runs `execSync` and constructs AuthHub and RgbProxy at load
+// just to reach six lines of string comparison.
+import { resolve } from 'path';
+
+/**
+ * True when two paths name the same location.
+ *
+ * win32-only case folding, deliberately. An unconditional lowercase would make two genuinely
+ * different trees compare equal on a case-sensitive filesystem, and `wt rm --stop-server` would then
+ * stop the other one's servers.
+ */
+export function samePath(a, b) {
+  const x = resolve(a);
+  const y = resolve(b);
+  return process.platform === 'win32' ? x.toLowerCase() === y.toLowerCase() : x === y;
+}
+
+/** The canonical spelling of a path, for use as a Map key where samePath cannot be called. */
+export function canonicalPath(p) {
+  const resolved = resolve(p);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -163,8 +163,7 @@ async function fetchRunning(daemonRequest) {
 // While apps were global singletons they were invisible here, so `wt rm` would delete a worktree
 // out from under a running moderator and report a clean removal.
 function sessionsIn(worktreePath, running) {
-  const target = resolve(worktreePath).toLowerCase();
-  const inTree = (s) => s.worktree && resolve(s.worktree).toLowerCase() === target;
+  const inTree = (s) => s.worktree && samePath(s.worktree, worktreePath);
 
   const found = [];
   for (const s of running.sessions.filter(inTree)) {
@@ -191,9 +190,15 @@ export function primaryOf(trees, fallback) {
 
 // Windows preserves whatever drive-letter casing the caller typed, and git prints its own. The
 // primary-worktree refusal below is the guard that stops `wt rm` deleting a local main, so it must
-// not be defeated by `c:\dev\...` vs `C:/Dev/...`. sessionsIn already lowercases for this reason.
-function samePathCI(a, b) {
-  return resolve(a).toLowerCase() === resolve(b).toLowerCase();
+// not be defeated by `c:\dev\...` vs `C:/Dev/...`.
+//
+// win32-only, matching daemon.mjs's samePath. An unconditional lowercase would make two genuinely
+// different trees compare equal on a case-sensitive filesystem, and `wt rm --stop-server` would then
+// stop the other one's servers.
+function samePath(a, b) {
+  const x = resolve(a);
+  const y = resolve(b);
+  return process.platform === 'win32' ? x.toLowerCase() === y.toLowerCase() : x === y;
 }
 
 export async function inspect(primary, daemonRequest) {
@@ -202,7 +207,7 @@ export async function inspect(primary, daemonRequest) {
   const running = await fetchRunning(daemonRequest);
   const rows = [];
   for (const t of trees) {
-    const isPrimary = samePathCI(t.path, primaryPath);
+    const isPrimary = samePath(t.path, primaryPath);
     const sessions = sessionsIn(t.path, running);
     rows.push({
       path: t.path,
@@ -255,9 +260,9 @@ export async function cmdRemove(primary, targetArg, opts, daemonRequest) {
   const trees = listWorktrees(primary);
   const primaryPath = primaryOf(trees, primary);
 
-  if (samePathCI(target, primaryPath)) fail('refusing to remove the primary worktree');
+  if (samePath(target, primaryPath)) fail('refusing to remove the primary worktree');
 
-  const entry = trees.find((t) => t.path === target);
+  const entry = trees.find((t) => samePath(t.path, target));
   if (!entry) fail(`not a registered worktree: ${target}\nrun: git worktree list`);
 
   const sessions = sessionsIn(target, await fetchRunning(daemonRequest));

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -195,7 +195,7 @@ export function primaryOf(trees, fallback) {
 // win32-only, matching daemon.mjs's samePath. An unconditional lowercase would make two genuinely
 // different trees compare equal on a case-sensitive filesystem, and `wt rm --stop-server` would then
 // stop the other one's servers.
-function samePath(a, b) {
+export function samePath(a, b) {
   const x = resolve(a);
   const y = resolve(b);
   return process.platform === 'win32' ? x.toLowerCase() === y.toLowerCase() : x === y;

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -147,27 +147,36 @@ function lastCommit(worktreePath) {
 // Main-app sessions AND app sessions, because both hold a port and a live process in this tree.
 // While apps were global singletons they were invisible here, so `wt rm` would delete a worktree
 // out from under a running moderator and report a clean removal.
-async function sessionsFor(worktreePath, daemonRequest) {
+// Both lists, once, so a caller looping over worktrees does not re-fetch them per iteration.
+async function fetchRunning(daemonRequest) {
+  const [sessionRes, appRes] = await Promise.all([
+    daemonRequest('/sessions'),
+    daemonRequest('/apps'),
+  ]);
+  return {
+    sessions: sessionRes.ok ? sessionRes.data.sessions || [] : [],
+    apps: appRes.ok ? appRes.data.apps || [] : [],
+  };
+}
+
+// Main-app sessions AND app sessions, because both hold a port and a live process in this tree.
+// While apps were global singletons they were invisible here, so `wt rm` would delete a worktree
+// out from under a running moderator and report a clean removal.
+function sessionsIn(worktreePath, running) {
   const target = resolve(worktreePath).toLowerCase();
   const inTree = (s) => s.worktree && resolve(s.worktree).toLowerCase() === target;
 
   const found = [];
-  const sessionRes = await daemonRequest('/sessions');
-  if (sessionRes.ok) {
-    for (const s of (sessionRes.data.sessions || []).filter(inTree)) {
-      found.push({ id: s.id, port: s.port, status: s.status, stopPath: `/sessions/${s.id}` });
-    }
+  for (const s of running.sessions.filter(inTree)) {
+    found.push({ id: s.id, port: s.port, status: s.status, stopPath: `/sessions/${s.id}` });
   }
-  const appRes = await daemonRequest('/apps');
-  if (appRes.ok) {
-    for (const a of (appRes.data.apps || []).filter(inTree)) {
-      found.push({
-        id: `app:${a.name}`,
-        port: a.port,
-        status: a.status,
-        stopPath: `/app/${a.name}/stop?worktree=${encodeURIComponent(a.worktree)}`,
-      });
-    }
+  for (const a of running.apps.filter(inTree)) {
+    found.push({
+      id: `app:${a.name}`,
+      port: a.port,
+      status: a.status,
+      stopPath: `/app/${a.name}/stop?worktree=${encodeURIComponent(a.worktree)}`,
+    });
   }
   return found;
 }
@@ -176,17 +185,25 @@ async function sessionsFor(worktreePath, daemonRequest) {
 // directory git is run from — invoked through a worktree's own copy of the CLI it IS that worktree,
 // which inverts every isPrimary test: the real main checkout reads as a removable candidate and the
 // worktree you are standing in reads as the thing to protect.
-function primaryOf(trees, fallback) {
+export function primaryOf(trees, fallback) {
   return trees.length ? trees[0].path : resolve(fallback);
+}
+
+// Windows preserves whatever drive-letter casing the caller typed, and git prints its own. The
+// primary-worktree refusal below is the guard that stops `wt rm` deleting a local main, so it must
+// not be defeated by `c:\dev\...` vs `C:/Dev/...`. sessionsIn already lowercases for this reason.
+function samePathCI(a, b) {
+  return resolve(a).toLowerCase() === resolve(b).toLowerCase();
 }
 
 export async function inspect(primary, daemonRequest) {
   const trees = listWorktrees(primary);
   const primaryPath = primaryOf(trees, primary);
+  const running = await fetchRunning(daemonRequest);
   const rows = [];
   for (const t of trees) {
-    const isPrimary = t.path === primaryPath;
-    const sessions = await sessionsFor(t.path, daemonRequest);
+    const isPrimary = samePathCI(t.path, primaryPath);
+    const sessions = sessionsIn(t.path, running);
     rows.push({
       path: t.path,
       branch: t.branch,
@@ -238,12 +255,12 @@ export async function cmdRemove(primary, targetArg, opts, daemonRequest) {
   const trees = listWorktrees(primary);
   const primaryPath = primaryOf(trees, primary);
 
-  if (target === primaryPath) fail('refusing to remove the primary worktree');
+  if (samePathCI(target, primaryPath)) fail('refusing to remove the primary worktree');
 
   const entry = trees.find((t) => t.path === target);
   if (!entry) fail(`not a registered worktree: ${target}\nrun: git worktree list`);
 
-  const sessions = await sessionsFor(target, daemonRequest);
+  const sessions = sessionsIn(target, await fetchRunning(daemonRequest));
   const live = sessions.filter((s) => s.status === 'running');
   if (live.length && !opts.stopServer) {
     fail(

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -144,16 +144,45 @@ function lastCommit(worktreePath) {
   return gitQuiet(['log', '-1', '--format=%ci'], worktreePath);
 }
 
+// Main-app sessions AND app sessions, because both hold a port and a live process in this tree.
+// While apps were global singletons they were invisible here, so `wt rm` would delete a worktree
+// out from under a running moderator and report a clean removal.
 async function sessionsFor(worktreePath, daemonRequest) {
-  const res = await daemonRequest('/sessions');
-  if (!res.ok) return [];
   const target = resolve(worktreePath).toLowerCase();
-  return (res.data.sessions || []).filter((s) => resolve(s.worktree).toLowerCase() === target);
+  const inTree = (s) => s.worktree && resolve(s.worktree).toLowerCase() === target;
+
+  const found = [];
+  const sessionRes = await daemonRequest('/sessions');
+  if (sessionRes.ok) {
+    for (const s of (sessionRes.data.sessions || []).filter(inTree)) {
+      found.push({ id: s.id, port: s.port, status: s.status, stopPath: `/sessions/${s.id}` });
+    }
+  }
+  const appRes = await daemonRequest('/apps');
+  if (appRes.ok) {
+    for (const a of (appRes.data.apps || []).filter(inTree)) {
+      found.push({
+        id: `app:${a.name}`,
+        port: a.port,
+        status: a.status,
+        stopPath: `/app/${a.name}/stop?worktree=${encodeURIComponent(a.worktree)}`,
+      });
+    }
+  }
+  return found;
+}
+
+// `git worktree list` puts the main worktree first, always. The caller's `primary` is only the
+// directory git is run from — invoked through a worktree's own copy of the CLI it IS that worktree,
+// which inverts every isPrimary test: the real main checkout reads as a removable candidate and the
+// worktree you are standing in reads as the thing to protect.
+function primaryOf(trees, fallback) {
+  return trees.length ? trees[0].path : resolve(fallback);
 }
 
 export async function inspect(primary, daemonRequest) {
   const trees = listWorktrees(primary);
-  const primaryPath = resolve(primary);
+  const primaryPath = primaryOf(trees, primary);
   const rows = [];
   for (const t of trees) {
     const isPrimary = t.path === primaryPath;
@@ -205,12 +234,12 @@ export async function cmdStale(primary, daemonRequest) {
 }
 
 export async function cmdRemove(primary, targetArg, opts, daemonRequest) {
-  const primaryPath = resolve(primary);
   const target = resolve(targetArg);
+  const trees = listWorktrees(primary);
+  const primaryPath = primaryOf(trees, primary);
 
   if (target === primaryPath) fail('refusing to remove the primary worktree');
 
-  const trees = listWorktrees(primary);
   const entry = trees.find((t) => t.path === target);
   if (!entry) fail(`not a registered worktree: ${target}\nrun: git worktree list`);
 
@@ -224,8 +253,10 @@ export async function cmdRemove(primary, targetArg, opts, daemonRequest) {
     );
   }
   for (const s of sessions) {
-    await daemonRequest(`/sessions/${s.id}`, { method: 'DELETE' });
-    console.log(`stopped session ${s.id}`);
+    // An app stops through POST /app/<name>/stop; a main-app session through DELETE /sessions/<id>.
+    // Both release the port — the difference is only which endpoint owns the reservation.
+    await daemonRequest(s.stopPath, { method: s.id.startsWith('app:') ? 'POST' : 'DELETE' });
+    console.log(`stopped ${s.id}`);
   }
 
   const dirty = dirtyCount(target);

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -145,10 +145,7 @@ function lastCommit(worktreePath) {
   return gitQuiet(['log', '-1', '--format=%ci'], worktreePath);
 }
 
-// Main-app sessions AND app sessions, because both hold a port and a live process in this tree.
-// While apps were global singletons they were invisible here, so `wt rm` would delete a worktree
-// out from under a running moderator and report a clean removal.
-// Both lists, once, so a caller looping over worktrees does not re-fetch them per iteration.
+// Both lists in one round-trip, so a caller looping over worktrees does not re-fetch per iteration.
 async function fetchRunning(daemonRequest) {
   const [sessionRes, appRes] = await Promise.all([
     daemonRequest('/sessions'),

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -12,6 +12,7 @@
 
 import { execFileSync } from 'child_process';
 import { readdirSync, lstatSync, rmdirSync, rmSync, unlinkSync, existsSync } from 'fs';
+import { samePath } from './paths.mjs';
 import { resolve, sep } from 'path';
 
 function git(args, cwd) {
@@ -186,19 +187,6 @@ function sessionsIn(worktreePath, running) {
 // worktree you are standing in reads as the thing to protect.
 export function primaryOf(trees, fallback) {
   return trees.length ? trees[0].path : resolve(fallback);
-}
-
-// Windows preserves whatever drive-letter casing the caller typed, and git prints its own. The
-// primary-worktree refusal below is the guard that stops `wt rm` deleting a local main, so it must
-// not be defeated by `c:\dev\...` vs `C:/Dev/...`.
-//
-// win32-only, matching daemon.mjs's samePath. An unconditional lowercase would make two genuinely
-// different trees compare equal on a case-sensitive filesystem, and `wt rm --stop-server` would then
-// stop the other one's servers.
-export function samePath(a, b) {
-  const x = resolve(a);
-  const y = resolve(b);
-  return process.platform === 'win32' ? x.toLowerCase() === y.toLowerCase() : x === y;
 }
 
 export async function inspect(primary, daemonRequest) {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,9 @@ To add a new app, use the `scaffold-civitai-app` skill and follow `docs/packages
 
 ### Development
 **Always use the `/dev-server` skill** to manage dev servers. Never use `pnpm run dev` directly.
+That covers `moderator` and `creator-studio` too — `cli.mjs start --app <name>` runs them from the
+worktree you are in, on a port the daemon reserves, with the auth hub started for you. The other
+`apps/*` have no dev-server integration; use their own `pnpm dev:<name>`.
 
 ### Build & Deploy
 ```bash


### PR DESCRIPTION
`app <name> start` resolved the app path against `projectRoot` — derived from the daemon script's own location — so it **always ran the primary checkout**, whatever worktree you typed it from. The app came up, served 200s and showed `main`. Nothing in the output contradicted you unless you read the `path` field.

## What changes

An app is now a session keyed by `(worktree, app)`:

```bash
node .claude/skills/dev-server/cli.mjs start --app moderator   # from the worktree you are in
node .claude/skills/dev-server/cli.mjs app                     # what is running, and where
```

- **Ports are preferred, not fixed** (moderator 5174, creator-studio 5175), drifting to the next free port so two worktrees can serve one app at once. Nothing needs rewriting to follow the drift: neither app's `.env` carries its own port or base URL, and in dev the hub trusts loopback by **host**. Each app's preferred port is held back from the drift search so one never displaces another, and a start that fails to spawn releases its reservation.
- **`.env` falls through instead of replacing** — the primary checkout's file is the base, the worktree's overrides it key by key, for the main app and for apps alike. Before, a worktree `.env` written to override two keys started the server with no `DATABASE_URL` and no secrets. This is also what lets a fresh worktree start an app at all, since `apps/<name>/.env` is gitignored and therefore absent there.
- **"Primary checkout" comes from `git rev-parse --git-common-dir`**, not from where the daemon was launched. The skill directory is committed, so a daemon started from a worktree would otherwise fall back to a file that worktree does not have. The auth hub is anchored there too — it is one shared process for every worktree, which `env-modes.mjs` already records by listing it in `PROD_ONLY_GROUPS`.
- **Starting an app starts the auth hub** if enabled and not already running. The **main app is not** started: the apps reach it over REST, and a cold Next.js compile should not be triggered on someone's behalf.
- **`wt stale` / `wt rm` see app sessions**, so removing a worktree no longer deletes it out from under a running moderator. They also take the primary from the first entry of `git worktree list` rather than trusting the directory they were invoked from — through a worktree's own copy of the CLI that inverted every check and offered the real main checkout as removable.
- **`storage` and `notifications` are deregistered.** They were listed and could never start: no `vite.config.ts` (their dev script is `tsx watch src/server.ts`) and no `.env`, so every attempt died at the `.env` precheck reporting an auth-hub problem.

## Verification

Each of these was run, and each could have failed:

| Claim | How it was shown |
|---|---|
| Two worktrees serve one app at once | moderator on **5174** and **5176** simultaneously |
| Each serves **its own** tree | a marker header added to one tree's `vite.config.ts` only; present on 5176, absent on 5174. The first probe (an SSR 500) could not observe it, so it was replaced with one that could |
| A fresh worktree with no `apps/moderator/.env` works | started and **302**s to login. Before the primary-checkout fix the same tree **500**ed with `DATABASE_URL is not configured` |
| The hub auto-starts | hub stopped → `start --app moderator` → hub `running` |
| `wt` sees the app | `dev server app:moderator:5174` in the KEEP reason and in `wt rm`'s refusal; both clauses disappear when the app is stopped |
| The env layering test can fail | reverted to replace-not-merge → 3 assertions failed; restored → green |

`env-chain.selftest.mjs`, `branch-watch.selftest.mjs` and `probe.selftest.mjs` all pass.

## Not done

The auth hub still cannot follow a per-session env mode (`auth-hub` is in `UNMOVABLE_GROUPS`), so an app moved to the dev DB still logs in against whatever DB the hub is on. Out of scope here, flagged as the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
