### PR TITLE
fix(image): bound `entities` on getEntitiesCoverImage

### DIFF
--- a/src/components/Notifications/__tests__/useNotificationThumbnails.test.ts
+++ b/src/components/Notifications/__tests__/useNotificationThumbnails.test.ts
@@ -61,6 +61,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
 }));
 
 import { useNotificationThumbnails } from '~/components/Notifications/notification-thumbnails';
+import { MAX_ENTITIES_COVER_IMAGE, getEntitiesCoverImage } from '~/server/schema/image.schema';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 function renderHook<T>(useHook: () => T) {
@@ -148,5 +149,36 @@ describe('resolving the image a notification is about', () => {
     renderHook(() => useNotificationThumbnails([{ details: { placementId: 1 } }]));
 
     expect(state.useQuery.mock.calls[0][1]).toMatchObject({ enabled: false });
+  });
+
+  // The panel is an infinite list with no `maxPages`, so the id list grows with
+  // scroll depth. `getEntitiesCoverImage` bounds `entities`, and a refused query
+  // leaves `data` undefined with no error branch — every thumbnail would vanish,
+  // including the ones under the bound, and stay gone for the session because each
+  // re-render sends the same list. So the hook has to clamp before asking.
+  it('asks for no more entities than the query accepts, however deep the panel is', () => {
+    // Ids are far above the bound so a length that happened to be clamped by
+    // something keyed on the id value could not pass this.
+    const deepPanel = Array.from({ length: MAX_ENTITIES_COVER_IMAGE + 25 }, (_, i) => ({
+      details: { imageId: 900_000 + i },
+    }));
+
+    renderHook(() => useNotificationThumbnails(deepPanel));
+
+    const { entities } = state.useQuery.mock.calls[0][0] as {
+      entities: { entityType: string; entityId: number }[];
+    };
+
+    expect(entities).toHaveLength(MAX_ENTITIES_COVER_IMAGE);
+    // The kept ids are the panel's first, not an arbitrary slice: the newest
+    // notifications are the ones the user is looking at.
+    expect(entities[0]).toEqual({ entityType: 'Image', entityId: 900_000 });
+    expect(entities[MAX_ENTITIES_COVER_IMAGE - 1]).toEqual({
+      entityType: 'Image',
+      entityId: 900_000 + MAX_ENTITIES_COVER_IMAGE - 1,
+    });
+    // The clamp has to leave a request the schema will actually accept, not merely a
+    // shorter one — this is the assertion that fails if the two ever drift apart.
+    expect(getEntitiesCoverImage.safeParse({ entities }).success).toBe(true);
   });
 });

--- a/src/components/Notifications/notification-thumbnails.ts
+++ b/src/components/Notifications/notification-thumbnails.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { MAX_ENTITIES_COVER_IMAGE } from '~/server/schema/image.schema';
 import { trpc } from '~/utils/trpc';
 
 type WithDetails = { details?: Record<string, unknown> | null };
@@ -55,9 +56,24 @@ export function notificationImageIds(items: WithDetails[]) {
 export function useNotificationThumbnails(items: WithDetails[]) {
   const imageIds = useMemo(() => notificationImageIds(items), [items]);
 
+  // The panel is an infinite list with no `maxPages`, so `items` — and with it
+  // `imageIds` — grows with scroll depth and has no ceiling of its own. Clamping to
+  // the schema's own bound here, rather than letting the query be refused, is what
+  // keeps a deep scroll from blanking the whole panel: a refused query leaves `data`
+  // undefined, there is no error branch, and every re-render sends the same over-cap
+  // list, so the thumbnails would stay gone — including the ones under the cap — for
+  // the rest of the session. Clamped, they simply stop past the cap.
+  const entities = useMemo(
+    () =>
+      imageIds
+        .slice(0, MAX_ENTITIES_COVER_IMAGE)
+        .map((entityId) => ({ entityType: 'Image' as const, entityId })),
+    [imageIds]
+  );
+
   const { data } = trpc.image.getEntitiesCoverImage.useQuery(
-    { entities: imageIds.map((entityId) => ({ entityType: 'Image' as const, entityId })) },
-    { enabled: imageIds.length > 0, trpc: { context: { skipBatch: true } } }
+    { entities },
+    { enabled: entities.length > 0, trpc: { context: { skipBatch: true } } }
   );
 
   const withTagIds = useMemo(

--- a/src/components/Profile/Sections/ShowcaseSection.tsx
+++ b/src/components/Profile/Sections/ShowcaseSection.tsx
@@ -3,6 +3,7 @@ import type { ProfileSectionProps } from '~/components/Profile/ProfileSection';
 import { ProfileSection, ProfileSectionPreview } from '~/components/Profile/ProfileSection';
 import { IconHeart } from '@tabler/icons-react';
 import React, { useMemo } from 'react';
+import { MAX_ENTITIES_COVER_IMAGE } from '~/server/schema/image.schema';
 import type { ShowcaseItemSchema } from '~/server/schema/user-profile.schema';
 import { trpc } from '~/utils/trpc';
 import { GenericImageCard } from '~/components/Cards/GenericImageCard';
@@ -15,14 +16,22 @@ import clsx from 'clsx';
 export const ShowcaseSection = ({ user }: ProfileSectionProps) => {
   const [ref, inView] = useInViewDynamic({ id: 'profile-showcase-section' });
   const showcaseItems = user.profile.showcaseItems as ShowcaseItemSchema[];
+  // Clamped to the schema's own bound rather than sent whole. `isNullState` below is
+  // computed from `!coverImages.length`, so a refused query would take the entire
+  // Showcase section off the profile — and it would stay off, since each render sends
+  // the same list. Clamped, a showcase longer than the bound just shows its first
+  // `MAX_ENTITIES_COVER_IMAGE` items. `addEntityToShowcase` truncates to 32, but
+  // `userProfile.update` does not bound `showcaseItems`, so a stored showcase is not
+  // guaranteed to be short.
+  const entities = useMemo(() => showcaseItems.slice(0, MAX_ENTITIES_COVER_IMAGE), [showcaseItems]);
   const {
     data: _coverImages,
     isLoading,
     isRefetching,
   } = trpc.image.getEntitiesCoverImage.useQuery(
-    { entities: showcaseItems },
+    { entities },
     {
-      enabled: showcaseItems.length > 0 && inView,
+      enabled: entities.length > 0 && inView,
       placeholderData: keepPreviousData,
       trpc: { context: { skipBatch: true } },
     }

--- a/src/components/Profile/ShowcaseItemsInput.tsx
+++ b/src/components/Profile/ShowcaseItemsInput.tsx
@@ -3,6 +3,7 @@ import type { InputWrapperProps } from '@mantine/core';
 import { Box, Button, Center, Input, Loader, Paper, Stack, Text } from '@mantine/core';
 import React, { useMemo, useState } from 'react';
 import { useDidUpdate } from '@mantine/hooks';
+import { MAX_ENTITIES_COVER_IMAGE } from '~/server/schema/image.schema';
 import type { ShowcaseItemSchema } from '~/server/schema/user-profile.schema';
 import { QuickSearchDropdown } from '~/components/Search/QuickSearchDropdown';
 import { quoteMeiliValue } from '~/components/Search/meili-filter';
@@ -34,13 +35,24 @@ export const ShowcaseItemsInput = ({
   const [showcaseItems, setShowcaseItems] = useState<ShowcaseItemSchema[]>(value || []);
   const [error, setError] = useState('');
   // Sort them so that we don't retrigger a query when the order changes.
+  //
+  // Clamped to the query's own bound after sorting, never before: the sort is what
+  // keeps a drag-reorder from re-querying, and slicing an unsorted list would make
+  // the requested set depend on display order and undo that. This narrows the cover
+  // images that get loaded, not the items — `showcaseItems` is what `onChange` saves
+  // and it is left whole, so editing a showcase longer than the bound cannot silently
+  // truncate it. Without the clamp an over-long list is refused outright and every
+  // item falls back to "There was a problem loading the cover image", including the
+  // ones that would have resolved.
   const sortedShowcaseItems = useMemo(() => {
-    return [...showcaseItems].sort((a, b) => {
-      const aType = `${a.entityType}-${a.entityId}`;
-      const bType = `${b.entityType}-${b.entityId}`;
+    return [...showcaseItems]
+      .sort((a, b) => {
+        const aType = `${a.entityType}-${a.entityId}`;
+        const bType = `${b.entityType}-${b.entityId}`;
 
-      return aType.localeCompare(bType);
-    });
+        return aType.localeCompare(bType);
+      })
+      .slice(0, MAX_ENTITIES_COVER_IMAGE);
   }, [showcaseItems]);
 
   const {

--- a/src/server/schema/__tests__/get-entities-cover-image.schema.test.ts
+++ b/src/server/schema/__tests__/get-entities-cover-image.schema.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest';
 /**
  * `getEntitiesCoverImage` backs a `publicProcedure`, so `entities` is a list whose
  * length is chosen by the caller. The cap is sized off what the real callers can
- * produce — a profile showcase is capped at 32 server-side, and the notification
+ * produce — `addEntityToShowcase` truncates a showcase to 32, and the notification
  * panel dedupes image ids out of a 30-per-page infinite list — so the bound is far
- * above anything in the repo and only refuses lists nothing here builds.
+ * above anything in the repo and only refuses lists nothing here builds. Each caller
+ * clamps its own list to `MAX_ENTITIES_COVER_IMAGE` before querying, so the bound is
+ * a backstop rather than something a session can walk into.
  *
  * The numbers below are written as literals rather than read off the schema: they are
  * the contract, so changing the cap should show up here as a failure rather than
@@ -16,8 +18,14 @@ import { getEntitiesCoverImage } from '~/server/schema/image.schema';
 
 const MAX = 500;
 
+// Ids sit far above the cap and never co-vary with the array index, which is what
+// makes this suite able to see WHICH bound it is testing. Built as `i + 1` the ids
+// run 1..n, so a `.max(500)` moved off the array and onto `entityId` refuses exactly
+// the same inputs — the suite stays green while the array itself is unbounded, and
+// every real request (image ids are far above 500) 400s. At 900_000 + i a relocated
+// bound rejects the accepted cases too, so the mutant cannot hide.
 const entities = (n: number) =>
-  Array.from({ length: n }, (_, i) => ({ entityType: 'Image' as const, entityId: i + 1 }));
+  Array.from({ length: n }, (_, i) => ({ entityType: 'Image' as const, entityId: 900_000 + i }));
 
 const parse = (n: number) => getEntitiesCoverImage.safeParse({ entities: entities(n) });
 
@@ -33,16 +41,21 @@ describe('getEntitiesCoverImage bounds `entities`', () => {
     const result = parse(MAX + 1);
 
     expect(result.success).toBe(false);
-    // Pinned to the `entities` path so this fails on the missing cap specifically,
-    // rather than passing on some other issue the schema happens to raise.
+    // Pinned to the whole issue, not `path[0]`: a length bound relocated onto
+    // `entityId` raises `too_big` at `['entities', 500, 'entityId']`, which also has
+    // `entities` at path[0]. Requiring the path to BE `['entities']` is what makes
+    // this an assertion about the array's own length rather than about any bound
+    // that happens to live somewhere under `entities`.
     if (!result.success)
-      expect(result.error.issues.some((issue) => issue.path[0] === 'entities')).toBe(true);
+      expect(
+        result.error.issues.map((issue) => ({ code: issue.code, path: issue.path }))
+      ).toContainEqual({ code: 'too_big', path: ['entities'] });
   });
 
   it('accepts the largest list a caller can build', () => {
-    // The control for the refusal above: 32 is the showcase cap
-    // (`constants.profile.showcaseItemsLimit`) and the largest fixed-size input any
-    // caller has. The cap is not narrowing a real call site.
+    // The control for the refusal above: 32 is what `addEntityToShowcase` truncates a
+    // showcase to (`constants.profile.showcaseItemsLimit`), i.e. the size the ordinary
+    // showcase path produces. The cap is not narrowing a real call site.
     expect(parse(32).success).toBe(true);
   });
 

--- a/src/server/schema/__tests__/get-entities-cover-image.schema.test.ts
+++ b/src/server/schema/__tests__/get-entities-cover-image.schema.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `getEntitiesCoverImage` backs a `publicProcedure`, so `entities` is a list whose
+ * length is chosen by the caller. The cap is sized off what the real callers can
+ * produce — a profile showcase is capped at 32 server-side, and the notification
+ * panel dedupes image ids out of a 30-per-page infinite list — so the bound is far
+ * above anything in the repo and only refuses lists nothing here builds.
+ *
+ * The numbers below are written as literals rather than read off the schema: they are
+ * the contract, so changing the cap should show up here as a failure rather than
+ * silently re-derive itself.
+ */
+
+import { getEntitiesCoverImage } from '~/server/schema/image.schema';
+
+const MAX = 500;
+
+const entities = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ entityType: 'Image' as const, entityId: i + 1 }));
+
+const parse = (n: number) => getEntitiesCoverImage.safeParse({ entities: entities(n) });
+
+describe('getEntitiesCoverImage bounds `entities`', () => {
+  it(`accepts ${MAX} entities`, () => {
+    const result = parse(MAX);
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.entities).toHaveLength(MAX);
+  });
+
+  it(`rejects ${MAX + 1} entities`, () => {
+    const result = parse(MAX + 1);
+
+    expect(result.success).toBe(false);
+    // Pinned to the `entities` path so this fails on the missing cap specifically,
+    // rather than passing on some other issue the schema happens to raise.
+    if (!result.success)
+      expect(result.error.issues.some((issue) => issue.path[0] === 'entities')).toBe(true);
+  });
+
+  it('accepts the largest list a caller can build', () => {
+    // The control for the refusal above: 32 is the showcase cap
+    // (`constants.profile.showcaseItemsLimit`) and the largest fixed-size input any
+    // caller has. The cap is not narrowing a real call site.
+    expect(parse(32).success).toBe(true);
+  });
+
+  it('accepts an empty list', () => {
+    // Deliberately not `.min(1)`. `getEntityCoverImage` early-returns [] for an empty
+    // array, and every caller already guards on length, so refusing it would turn a
+    // supported no-op into a 400 for token clients and buy nothing.
+    expect(getEntitiesCoverImage.safeParse({ entities: [] }).success).toBe(true);
+  });
+});

--- a/src/server/schema/image.schema.ts
+++ b/src/server/schema/image.schema.ts
@@ -492,6 +492,30 @@ export const removeImageResourceSchema = z.object({
   modelVersionId: z.number(),
 });
 
+/**
+ * Ceiling on the `entities` list `getEntitiesCoverImage` will accept.
+ *
+ * Sized off what the callers can actually produce, with room to spare. The two UI
+ * callers are a profile showcase and the notification panel; neither has a fixed
+ * ceiling of its own that this could narrow:
+ *
+ * - `addEntityToShowcase` truncates the showcase it writes to
+ *   `constants.profile.showcaseItemsLimit` (32). That is the only write path that
+ *   truncates — `userProfile.update` takes `showcaseItems` unbounded and the service
+ *   stores it as given, so a stored showcase is not guaranteed to be at or under 32.
+ * - The notification panel dedupes image ids out of a 30-per-page infinite list, so
+ *   500 is ~16 pages deep, and in practice more, since only notifications naming an
+ *   image contribute an id.
+ *
+ * Each caller clamps its own list to this before querying, so exceeding it is a caller
+ * bug rather than something a session can walk into — which matters because a refused
+ * query has no error branch in any of them.
+ *
+ * An empty array is deliberately still accepted: `getEntityCoverImage` returns [] for
+ * it, and this is a token-reachable read where that is a valid no-op.
+ */
+export const MAX_ENTITIES_COVER_IMAGE = 500;
+
 export type GetEntitiesCoverImage = z.infer<typeof getEntitiesCoverImage>;
 export const getEntitiesCoverImage = z.object({
   entities: z
@@ -501,14 +525,7 @@ export const getEntitiesCoverImage = z.object({
         entityId: z.number(),
       })
     )
-    // Sized off what the callers can actually produce, with room to spare. A profile
-    // showcase is capped server-side at `constants.profile.showcaseItemsLimit` (32,
-    // applied in `addEntityToShowcase`), and the notification panel dedupes image ids
-    // out of a 30-per-page infinite list, so 500 is ~16 pages deep. No caller in the
-    // repo comes near it; it exists so the array has a ceiling at all.
-    // An empty array is deliberately still accepted: `getEntityCoverImage` returns []
-    // for it, and this is a token-reachable read where that is a valid no-op.
-    .max(500),
+    .max(MAX_ENTITIES_COVER_IMAGE),
 });
 
 export type ScanJobsOutput = z.output<typeof scanJobsSchema>;

--- a/src/server/schema/image.schema.ts
+++ b/src/server/schema/image.schema.ts
@@ -494,12 +494,21 @@ export const removeImageResourceSchema = z.object({
 
 export type GetEntitiesCoverImage = z.infer<typeof getEntitiesCoverImage>;
 export const getEntitiesCoverImage = z.object({
-  entities: z.array(
-    z.object({
-      entityType: z.union([z.enum(SearchIndexEntityTypes), z.enum(['ModelVersion', 'Post'])]),
-      entityId: z.number(),
-    })
-  ),
+  entities: z
+    .array(
+      z.object({
+        entityType: z.union([z.enum(SearchIndexEntityTypes), z.enum(['ModelVersion', 'Post'])]),
+        entityId: z.number(),
+      })
+    )
+    // Sized off what the callers can actually produce, with room to spare. A profile
+    // showcase is capped server-side at `constants.profile.showcaseItemsLimit` (32,
+    // applied in `addEntityToShowcase`), and the notification panel dedupes image ids
+    // out of a 30-per-page infinite list, so 500 is ~16 pages deep. No caller in the
+    // repo comes near it; it exists so the array has a ceiling at all.
+    // An empty array is deliberately still accepted: `getEntityCoverImage` returns []
+    // for it, and this is a token-reachable read where that is a valid no-op.
+    .max(500),
 });
 
 export type ScanJobsOutput = z.output<typeof scanJobsSchema>;


### PR DESCRIPTION
Adds an upper bound to `entities` on `getEntitiesCoverImage` in `src/server/schema/image.schema.ts`, and has the three call sites clamp their own list to the same number so a list over the bound degrades instead of failing.

The array had neither a `.max()` nor a `.min()`, while comparable list inputs in the same area are bounded — `paginationSchema`'s `limit` is `.min(1).max(200)`, `getInfiniteImagesSchema`'s `limit` is `.min(0).max(200)`, `reportCsamImagesSchema.imageIds` is `.min(1)`. This just brings it in line.

### Why 500

The number is sized off what the callers can actually build, taken from the code rather than picked:

- **Profile showcase** — `ShowcaseSection` and `ShowcaseItemsInput` both pass `user.profile.showcaseItems`. `addEntityToShowcase` truncates that to `constants.profile.showcaseItemsLimit` (**32**) on every write (`src/server/controllers/user-profile.controller.ts`), and the edit modal advertises the same 32.
- **Notification panel** — `useNotificationThumbnails` passes deduped `details.imageId` values from the loaded notification list. That list is an infinite query at **30 per page** (`NotificationsComposed.tsx`, the only render site of `NotificationList`), so the count grows with scroll depth. 500 is a little over 16 pages, and in practice more, since only notifications that name an image contribute an id.

500 is ~16x the showcase cap and well past any realistic panel session, so it does not narrow any call site; it just gives the array a ceiling.

Note that 32 is enforced on **one** of the two showcase write paths. `userProfile.update` takes `showcaseItems: z.array(showcaseItemSchema).optional()` with no `.max()` (`src/server/schema/user-profile.schema.ts`) and the service stores it as given, so a stored showcase is not guaranteed to be at or under 32. The schema comment says which path enforces what rather than claiming the cap outright. **Follow-up, deliberately not in this PR:** bounding `showcaseItems` on `userProfile.update` is a behaviour change on a different endpoint and belongs in its own change.

### Callers clamp their own list

A refusal is not a degraded render in any of the three call sites — none has an `onError` or an error branch — and it does not recover on its own, because each re-render sends the same list:

- `useNotificationThumbnails` — on a refusal `data` is `undefined` and **every** thumbnail disappears, including the ones under the bound.
- `ShowcaseSection` — `isNullState` is computed from `!coverImages.length`, so a refusal takes the **entire Showcase section** off the profile.
- `ShowcaseItemsInput` — degrades better already (a per-item "There was a problem loading the cover image" fallback), but on a refusal every item shows it, including those that would have resolved.

So each slices to `MAX_ENTITIES_COVER_IMAGE`, now exported from the schema module so the number lives in one place instead of three. Thumbnails simply stop past the bound.

`ShowcaseItemsInput` clamps only the **query input** — the `showcaseItems` state that `onChange` saves is left whole, so editing a showcase longer than the bound cannot silently truncate it — and slices **after** the sort, since the sort is what keeps a drag-reorder from re-querying.

### `.min()`

Deliberately not added. `getEntityCoverImage` early-returns `[]` for an empty array, all three callers already guard on `length > 0`, and the procedure is reachable with a `MediaRead` token — so refusing an empty list would turn a supported no-op into a 400 for existing clients and buy nothing. There is a test pinning that empty stays accepted.

### Callers checked

Grepped the repo for `getEntitiesCoverImage` / `getEntityCoverImage`. Every path through this schema is the tRPC procedure, and its callers are the three above. `getUserCosmeticsHandler` calls the `getEntityCoverImage` **service** directly (bounded by the user's own equipped cosmetics) and does not go through this schema, so it is unaffected either way.

### Tests

`src/server/schema/__tests__/get-entities-cover-image.schema.test.ts` — at the bound, one over it (with the issue pinned), the size the ordinary showcase path produces (32), and the empty case.

The fixture ids are `900_000 + i`, deliberately far above the bound and not co-varying with the array index. **The earlier version of this test could not tell which bound it was certifying**: built as `i + 1` the ids ran `1..n`, so a `.max(500)` relocated from the array onto `entityId` accepts and refuses exactly the same inputs, and the old assertion `issue.path[0] === 'entities'` is equally true of `['entities', 500, 'entityId']`. That relocation leaves the array unbounded and 400s every real request (image ids are far above 500) — and the suite stayed green at 4/4. The rejection case now pins the whole issue, `{ code: 'too_big', path: ['entities'] }`, not its first path segment.

Verified by mutation on the shipped bytes:

| mutation | result |
|---|---|
| `.max()` removed | `rejects 501 entities` fails |
| `.max()` **relocated** onto `entityId`, array left unbounded | `accepts 500 entities`, `rejects 501 entities` and `accepts the largest list a caller can build` all fail (**3 of 4**) |
| `.max(100000)` | `rejects 501 entities` fails |
| `.max(499)` | `accepts 500 entities` fails |
| `.min(1)` added | `accepts an empty list` fails |
| unmutated | 4 passed |

The relocation row is the one the previous table was missing, and it was the one that mattered: against the **old** fixture that same mutant passes 4/4, which is what made the old table an overstatement of the evidence.

`src/components/Notifications/__tests__/useNotificationThumbnails.test.ts` gains a case for the caller-side clamp — a panel deeper than the bound must still produce a request the schema accepts, keeping its first ids. Dropping the `.slice` fails it (`expected […(525)] to have a length of 500`) and nothing else in that file.

Full unit suite: 21473 passed, 25 skipped, 1364 files. `node scripts/typecheck.mjs`: 0 errors. ESLint on the changed files is unchanged from the base commit (5 warnings, 0 errors, all pre-existing `no-unused-vars`); Prettier clean.
