### PR TITLE
feat(moderator): accept a second, inbound-only service token

### DIFF
--- a/apps/moderator/.env.example
+++ b/apps/moderator/.env.example
@@ -30,10 +30,22 @@ AUTH_INTERNAL_TOKEN=
 # --- Main-app callbacks ---
 # Shared secret for the main app's token-guarded internal endpoints (e.g. the Meilisearch re-index
 # callback /api/internal/search-index-update). Must match the main app's WEBHOOK_TOKEN. Unset = sync no-ops.
-# Also guards every endpoint wrapped in WebhookEndpoint ($lib/server/webhook-endpoint) — /api/mod/* and the
-# XGuard agent API. Those answer 503 while it is unset. There is no user behind it: nothing it reaches may
-# attribute a write, and revoking access means rotating it for every holder.
+# Also ACCEPTED inbound on every endpoint wrapped in WebhookEndpoint ($lib/server/webhook-endpoint) —
+# /api/mod/* and the XGuard agent API. There is no user behind it: nothing it reaches may attribute a
+# write, and revoking access means rotating it for every holder.
+# 🔴 OUTBOUND USE IS WHY THIS CANNOT SIMPLY BE ROTATED. Four services here present it TO the main app,
+# so its value is pinned by the main app's and is not ours to change independently. Prefer
+# MOD_INBOUND_TOKEN below for anything that only calls IN.
 WEBHOOK_TOKEN=
+
+# Inbound-only service token — accepted on the same WebhookEndpoint routes as WEBHOOK_TOKEN, and
+# equivalent to it inside this app, but it reaches NOTHING beyond this app: no outbound caller sends
+# it and the main app does not know it. Hand this one to a service that only ever calls in (the
+# abuse-detection cronjobs posting to /api/mod/abuse-report) so a leak there cannot touch the main
+# app's admin surface.
+# Either variable alone is a complete configuration; the endpoints answer 503 only while BOTH are unset.
+# A variable set to an EMPTY value counts as unset, so blanking one cannot open the endpoints up.
+MOD_INBOUND_TOKEN=
 
 
 # Signals service, same value as the main app's SIGNALS_ENDPOINT. Session invalidation posts here so a

--- a/apps/moderator/.env.example
+++ b/apps/moderator/.env.example
@@ -45,6 +45,12 @@ WEBHOOK_TOKEN=
 # app's admin surface.
 # Either variable alone is a complete configuration; the endpoints answer 503 only while BOTH are unset.
 # A variable set to an EMPTY value counts as unset, so blanking one cannot open the endpoints up.
+#
+# 🔴 MIGRATING OFF WEBHOOK_TOKEN IS A CODE CHANGE, NOT AN UNSET. Removing it from `acceptedTokens()`
+# in $lib/server/webhook-endpoint stops accepting it INBOUND and is safe. UNSETTING the variable also
+# strips it from the four OUTBOUND callers above — and two of them (Meilisearch sync, KoNO finalize)
+# only console.warn and skip, so that failure is silent. Inbound would keep working on
+# MOD_INBOUND_TOKEN the whole time, so nothing loud tells you.
 MOD_INBOUND_TOKEN=
 
 

--- a/apps/moderator/src/lib/server/__tests__/webhook-endpoint.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/webhook-endpoint.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { authenticateWebhookToken } from '$lib/server/webhook-endpoint';
+
+/**
+ * Inbound service-token authentication — the ONLY place this app verifies a token. `WebhookEndpoint`
+ * and `defineWebhookEndpoint` only assert the verdict this function produced (`locals.tokenClient`),
+ * so everything about which credentials are accepted is decided here.
+ *
+ * Two tiers below, labelled, because they are not the same kind of evidence:
+ *
+ *   REGRESSION — the MOD_INBOUND_TOKEN cases. Red before the change (the function read only
+ *     `env.WEBHOOK_TOKEN`), green after.
+ *   INVARIANT  — the WEBHOOK_TOKEN, fail-closed and rejection cases. These passed before the change
+ *     too. They are here because the change's whole point is that they must KEEP passing: the main
+ *     app presents WEBHOOK_TOKEN on every call into this app, so accepting a second token must not
+ *     stop accepting the first.
+ *
+ * `$env/dynamic/private` is aliased to `src/test/env.mock.ts`, which is `process.env` itself, and
+ * `acceptedTokens()` re-reads it per call — so assigning here really does change what the function
+ * sees.
+ */
+
+const LEGACY = 'legacy-shared-token';
+const INBOUND = 'inbound-only-token';
+
+function eventWith(presented: { query?: string; authorization?: string }) {
+  const url = new URL('https://moderator.civitai.com/api/mod/abuse-report');
+  if (presented.query !== undefined) url.searchParams.set('token', presented.query);
+  const headers = new Headers();
+  if (presented.authorization !== undefined) headers.set('authorization', presented.authorization);
+  return { url, request: new Request(url, { method: 'POST', headers }) };
+}
+
+/** Both variables are deleted rather than blanked — blank is a case under test in its own right. */
+function setEnv(vars: { WEBHOOK_TOKEN?: string; MOD_INBOUND_TOKEN?: string }) {
+  delete process.env.WEBHOOK_TOKEN;
+  delete process.env.MOD_INBOUND_TOKEN;
+  if (vars.WEBHOOK_TOKEN !== undefined) process.env.WEBHOOK_TOKEN = vars.WEBHOOK_TOKEN;
+  if (vars.MOD_INBOUND_TOKEN !== undefined) process.env.MOD_INBOUND_TOKEN = vars.MOD_INBOUND_TOKEN;
+}
+
+const saved = {
+  WEBHOOK_TOKEN: process.env.WEBHOOK_TOKEN,
+  MOD_INBOUND_TOKEN: process.env.MOD_INBOUND_TOKEN,
+};
+
+beforeEach(() => setEnv({ WEBHOOK_TOKEN: LEGACY, MOD_INBOUND_TOKEN: INBOUND }));
+afterEach(() => setEnv(saved));
+
+describe('authenticateWebhookToken', () => {
+  it('INVARIANT: returns "none" when no credential is presented, so the session guard runs', () => {
+    expect(authenticateWebhookToken(eventWith({}))).toBe('none');
+  });
+
+  it('INVARIANT: accepts WEBHOOK_TOKEN via ?token= — the main app calls in this way', () => {
+    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toBe('webhook');
+  });
+
+  it('INVARIANT: accepts WEBHOOK_TOKEN via Authorization: Bearer', () => {
+    expect(authenticateWebhookToken(eventWith({ authorization: `Bearer ${LEGACY}` }))).toBe(
+      'webhook'
+    );
+  });
+
+  it('REGRESSION: accepts MOD_INBOUND_TOKEN via ?token=', () => {
+    expect(authenticateWebhookToken(eventWith({ query: INBOUND }))).toBe('webhook');
+  });
+
+  it('REGRESSION: accepts MOD_INBOUND_TOKEN via Authorization: Bearer', () => {
+    expect(authenticateWebhookToken(eventWith({ authorization: `Bearer ${INBOUND}` }))).toBe(
+      'webhook'
+    );
+  });
+
+  it('REGRESSION: MOD_INBOUND_TOKEN alone is a complete configuration — the post-migration state', () => {
+    setEnv({ MOD_INBOUND_TOKEN: INBOUND });
+    expect(authenticateWebhookToken(eventWith({ query: INBOUND }))).toBe('webhook');
+  });
+
+  it('INVARIANT: WEBHOOK_TOKEN alone is a complete configuration — the pre-migration state', () => {
+    setEnv({ WEBHOOK_TOKEN: LEGACY });
+    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toBe('webhook');
+  });
+
+  it('REGRESSION: the two tokens are independent — presenting one does not depend on the other being set', async () => {
+    setEnv({ MOD_INBOUND_TOKEN: INBOUND });
+    const refused = authenticateWebhookToken(eventWith({ query: LEGACY }));
+    expect(refused).toBeInstanceOf(Response);
+    expect((refused as Response).status).toBe(401);
+  });
+
+  it('INVARIANT: refuses an unrecognised token with 401', async () => {
+    const result = authenticateWebhookToken(eventWith({ query: 'not-either-of-them' }));
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(401);
+  });
+
+  it('INVARIANT: refuses a token that is a PREFIX of an accepted one', async () => {
+    const result = authenticateWebhookToken(eventWith({ query: INBOUND.slice(0, -1) }));
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(401);
+  });
+
+  it('INVARIANT: fails CLOSED with 503 when neither variable is configured', async () => {
+    setEnv({});
+    const result = authenticateWebhookToken(eventWith({ query: LEGACY }));
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(503);
+  });
+
+  it('REGRESSION: the 503 names BOTH variables, so an operator knows either would fix it', async () => {
+    setEnv({});
+    const result = authenticateWebhookToken(eventWith({ query: LEGACY })) as Response;
+    await expect(result.json()).resolves.toMatchObject({
+      message: expect.stringContaining('MOD_INBOUND_TOKEN'),
+    });
+  });
+
+  it('INVARIANT: a variable set to empty is NOT configured — an empty presented token is refused', async () => {
+    // The dangerous shape: blanking the secret must not make every wrapped endpoint open. With both
+    // blank there is nothing to accept, so this is the 503 fail-closed path, NOT a match.
+    setEnv({ WEBHOOK_TOKEN: '', MOD_INBOUND_TOKEN: '' });
+    const result = authenticateWebhookToken(eventWith({ query: '' }));
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(503);
+  });
+
+  it('INVARIANT: a blank MOD_INBOUND_TOKEN does not become a usable credential alongside a real one', async () => {
+    setEnv({ WEBHOOK_TOKEN: LEGACY, MOD_INBOUND_TOKEN: '' });
+    const empty = authenticateWebhookToken(eventWith({ query: '' }));
+    expect(empty).toBeInstanceOf(Response);
+    expect((empty as Response).status).toBe(401);
+    // …and the real one still works.
+    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toBe('webhook');
+  });
+
+  it('INVARIANT: a WEBHOOK_TOKEN injected with surrounding whitespace still matches what a caller sends', () => {
+    setEnv({ WEBHOOK_TOKEN: `  ${LEGACY}\n` });
+    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toBe('webhook');
+  });
+
+  it('REGRESSION: the same whitespace tolerance applies to MOD_INBOUND_TOKEN', () => {
+    setEnv({ MOD_INBOUND_TOKEN: `  ${INBOUND}\n` });
+    expect(authenticateWebhookToken(eventWith({ query: INBOUND }))).toBe('webhook');
+  });
+
+  it('INVARIANT: a non-Bearer Authorization scheme is refused rather than treated as a token', async () => {
+    const result = authenticateWebhookToken(eventWith({ authorization: `Basic ${INBOUND}` }));
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(401);
+  });
+});

--- a/apps/moderator/src/lib/server/__tests__/webhook-endpoint.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/webhook-endpoint.test.ts
@@ -7,14 +7,17 @@ import { authenticateWebhookToken } from '$lib/server/webhook-endpoint';
  * and `defineWebhookEndpoint` only assert the verdict this function produced (`locals.tokenClient`),
  * so everything about which credentials are accepted is decided here.
  *
- * Two tiers below, labelled, because they are not the same kind of evidence:
+ * Two tiers below, labelled, because they are not the same kind of evidence. The tiers are defined by
+ * the MATRIX, not by subject matter — run this file against `origin/main`'s webhook-endpoint.ts and
+ * exactly the REGRESSION set fails:
  *
- *   REGRESSION — the MOD_INBOUND_TOKEN cases. Red before the change (the function read only
- *     `env.WEBHOOK_TOKEN`), green after.
- *   INVARIANT  — the WEBHOOK_TOKEN, fail-closed and rejection cases. These passed before the change
- *     too. They are here because the change's whole point is that they must KEEP passing: the main
- *     app presents WEBHOOK_TOKEN on every call into this app, so accepting a second token must not
- *     stop accepting the first.
+ *   REGRESSION — red before the change, green after. Mostly the MOD_INBOUND_TOKEN cases, plus the
+ *     whitespace-only-secret case, which is not about the new variable at all: it pins an auth bypass
+ *     the change closed as a side effect.
+ *   INVARIANT  — green on BOTH sides: the WEBHOOK_TOKEN, fail-closed and rejection cases. They are
+ *     here because the change's whole point is that they must KEEP passing — the main app presents
+ *     WEBHOOK_TOKEN on every call into this app, so accepting a second token must not stop accepting
+ *     the first.
  *
  * `$env/dynamic/private` is aliased to `src/test/env.mock.ts`, which is `process.env` itself, and
  * `acceptedTokens()` re-reads it per call — so assigning here really does change what the function
@@ -111,7 +114,7 @@ describe('authenticateWebhookToken', () => {
     expect((result as Response).status).toBe(401);
   });
 
-  it('INVARIANT: both variables set to the SAME value still authenticates exactly once', () => {
+  it('INVARIANT: both variables set to the SAME value still authenticates', () => {
     setEnv({ WEBHOOK_TOKEN: LEGACY, MOD_INBOUND_TOKEN: LEGACY });
     expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toBe('webhook');
   });

--- a/apps/moderator/src/lib/server/__tests__/webhook-endpoint.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/webhook-endpoint.test.ts
@@ -102,6 +102,32 @@ describe('authenticateWebhookToken', () => {
     expect((result as Response).status).toBe(401);
   });
 
+  it('INVARIANT: refuses a token that is a SUPERSTRING of an accepted one', async () => {
+    // The mirror of the prefix case, and the one that exercises the length check as an EQUALITY
+    // rather than a floor: relaxing `===` to `>=` makes timingSafeEqual throw on this input, which
+    // is a 500 out of the hook instead of a 401.
+    const result = authenticateWebhookToken(eventWith({ query: `${INBOUND}x` }));
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(401);
+  });
+
+  it('INVARIANT: both variables set to the SAME value still authenticates exactly once', () => {
+    setEnv({ WEBHOOK_TOKEN: LEGACY, MOD_INBOUND_TOKEN: LEGACY });
+    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toBe('webhook');
+  });
+
+  it('REGRESSION: a WHITESPACE-ONLY secret is not configured — this closed a real bypass', async () => {
+    // 🔴 The case that made the `.filter()` load-bearing rather than tidy. Before this change the
+    // guard was `if (!expected)`, which a whitespace-only value passes as truthy; the secret was then
+    // `.trim()`ed to ZERO length, and timingSafeEqual(<empty>, <empty>) is TRUE — so a request
+    // presenting `?token=` with no value authenticated as 'webhook' and every wrapped endpoint was
+    // open. Latent (a real deployment holds a real value) but real, and pinned here so it stays shut.
+    setEnv({ WEBHOOK_TOKEN: '   ' });
+    const result = authenticateWebhookToken(eventWith({ query: '' }));
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(503);
+  });
+
   it('INVARIANT: fails CLOSED with 503 when neither variable is configured', async () => {
     setEnv({});
     const result = authenticateWebhookToken(eventWith({ query: LEGACY }));

--- a/apps/moderator/src/lib/server/api-endpoint.ts
+++ b/apps/moderator/src/lib/server/api-endpoint.ts
@@ -19,8 +19,8 @@ import type { EndpointDoc } from './api-guard';
 // Two builders rather than one with an `auth` option, because who may call is not a detail of an
 // endpoint, it is the first thing about it — and because the two need different things:
 //
-//   defineWebhookEndpoint — a service holding an accepted service token. A moderator's browser session
-//     is REFUSED,
+//   defineWebhookEndpoint — a service holding an accepted service token. A moderator's browser
+//     session is REFUSED,
 //     matching the main app's WebhookEndpoint. Nobody is behind the call, so it can attribute nothing,
 //     which is what keeps `human_judgement` out of reach.
 //   defineEndpoint — a signed-in moderator holding the `page` grant. A token is refused.

--- a/apps/moderator/src/lib/server/api-endpoint.ts
+++ b/apps/moderator/src/lib/server/api-endpoint.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { error, json, type RequestEvent } from '@sveltejs/kit';
 import { requireAccess } from './access';
+import { SEND_A_TOKEN } from './webhook-endpoint';
 import type { EndpointDoc } from './api-guard';
 
 // ENDPOINT DEFINITIONS — one declaration per HTTP method, replacing a hand-written `_doc` beside a
@@ -18,7 +19,8 @@ import type { EndpointDoc } from './api-guard';
 // Two builders rather than one with an `auth` option, because who may call is not a detail of an
 // endpoint, it is the first thing about it — and because the two need different things:
 //
-//   defineWebhookEndpoint — a service holding WEBHOOK_TOKEN. A moderator's browser session is REFUSED,
+//   defineWebhookEndpoint — a service holding an accepted service token. A moderator's browser session
+//     is REFUSED,
 //     matching the main app's WebhookEndpoint. Nobody is behind the call, so it can attribute nothing,
 //     which is what keeps `human_judgement` out of reach.
 //   defineEndpoint — a signed-in moderator holding the `page` grant. A token is refused.
@@ -98,13 +100,12 @@ function build<S extends z.ZodType, E extends RequestEvent>(
   return Object.assign(handle, { spec });
 }
 
-/** Service-authenticated: a verified WEBHOOK_TOKEN, set by hooks.server.ts. No user. */
+/** Service-authenticated: any accepted service token, verified in hooks.server.ts. No user. */
 export function defineWebhookEndpoint<S extends z.ZodType, E extends RequestEvent>(
   def: Definition<S, E>
 ) {
   return build(def, { kind: 'webhook' }, (event) => {
-    if (event.locals.tokenClient !== 'webhook')
-      error(401, 'Send a valid service token as `?token=` or `Authorization: Bearer <token>`.');
+    if (event.locals.tokenClient !== 'webhook') error(401, SEND_A_TOKEN);
   });
 }
 

--- a/apps/moderator/src/lib/server/api-endpoint.ts
+++ b/apps/moderator/src/lib/server/api-endpoint.ts
@@ -104,7 +104,7 @@ export function defineWebhookEndpoint<S extends z.ZodType, E extends RequestEven
 ) {
   return build(def, { kind: 'webhook' }, (event) => {
     if (event.locals.tokenClient !== 'webhook')
-      error(401, 'Send WEBHOOK_TOKEN as `?token=` or `Authorization: Bearer <token>`.');
+      error(401, 'Send a valid service token as `?token=` or `Authorization: Bearer <token>`.');
   });
 }
 

--- a/apps/moderator/src/lib/server/webhook-endpoint.ts
+++ b/apps/moderator/src/lib/server/webhook-endpoint.ts
@@ -28,10 +28,18 @@ import { env } from '$env/dynamic/private';
 //     what lets an inbound-only caller hold something narrower.
 //
 // So this is a MIGRATION SEAM, not a permission model. Move each inbound caller to MOD_INBOUND_TOKEN,
-// and once none present WEBHOOK_TOKEN inbound, drop it from `acceptedTokens` — outbound callers are
-// unaffected by that. 🔴 Dropping it here is NOT the same as unsetting the variable: four services in
-// this app present it outbound, and two of them degrade by WARNING rather than failing. Scoping a
-// token to particular endpoints is a separate, later change: `EndpointAuth` is already
+// and once none present WEBHOOK_TOKEN inbound, drop it from `acceptedTokens`.
+//
+// 🔴 TWO WAYS TO GET THAT REMOVAL WRONG, and neither is visible from this file alone:
+//   1. "None present it inbound" is a claim about THE MAIN APP, not about this repo. The main app
+//      presents WEBHOOK_TOKEN on every call into this app, from its own codebase — so grepping HERE,
+//      finding no inbound presenter and concluding the migration is done 401s every delegated
+//      moderation action. Nothing in this app records WHICH credential authenticated, so there is
+//      also no runtime signal to check it against; add one before you rely on the answer.
+//   2. Dropping it from `acceptedTokens` is NOT the same as unsetting the variable. Four services in
+//      this app present it OUTBOUND, and two of them degrade by WARNING rather than failing.
+//
+// Scoping a token to particular endpoints is a separate, later change: `EndpointAuth` is already
 // `{kind:'webhook'} | {kind:'session'; page}` (api-endpoint.ts), so `{kind:'webhook'; scope}` has
 // somewhere to go.
 //

--- a/apps/moderator/src/lib/server/webhook-endpoint.ts
+++ b/apps/moderator/src/lib/server/webhook-endpoint.ts
@@ -22,21 +22,30 @@ import { env } from '$env/dynamic/private';
 // TWO CREDENTIALS ARE ACCEPTED, and the difference is reach, not privilege — inside this app they
 // authorise exactly the same thing:
 //
-//   MOD_INBOUND_TOKEN — inbound-only, and the one to hand out. It appears NOWHERE else: no outbound
-//     caller reads it and the main app does not know it, so a holder can reach this app and nothing
-//     beyond it. A service that only ever calls IN should hold this and only this.
-//   WEBHOOK_TOKEN  — kept accepted for COMPATIBILITY, because this app is on BOTH ends of it. The main
-//     app presents it when it calls in, and four services here present it when they call out
-//     (user-actions.service.ts, search-index.ts, kono.ts, training-moderation.service.ts) — see
-//     .env.example, which requires it to match the main app's. One variable, two directions, so its
-//     value is not ours to change independently: that is why the fix is a second accepted token and
-//     not a rotation.
+//   MOD_INBOUND_TOKEN — inbound-only, and the one to prefer for anything that only calls IN.
+//   WEBHOOK_TOKEN     — accepted for COMPATIBILITY. This app is on both ends of it, so its value is
+//     shared rather than local (see .env.example) and a second accepted token, not a rotation, is
+//     what lets an inbound-only caller hold something narrower.
 //
 // So this is a MIGRATION SEAM, not a permission model. Move each inbound caller to MOD_INBOUND_TOKEN,
-// and once none present WEBHOOK_TOKEN inbound, drop it from `acceptedTokens` — the outbound callers
-// keep using it and are unaffected. Scoping a token to particular endpoints is a separate, later
-// change: `EndpointAuth` is already `{kind:'webhook'} | {kind:'session'; page}` (api-endpoint.ts),
-// so `{kind:'webhook'; scope}` has somewhere to go.
+// and once none present WEBHOOK_TOKEN inbound, drop it from `acceptedTokens` — outbound callers are
+// unaffected by that. 🔴 Dropping it here is NOT the same as unsetting the variable: four services in
+// this app present it outbound, and two of them degrade by WARNING rather than failing. Scoping a
+// token to particular endpoints is a separate, later change: `EndpointAuth` is already
+// `{kind:'webhook'} | {kind:'session'; page}` (api-endpoint.ts), so `{kind:'webhook'; scope}` has
+// somewhere to go.
+//
+// Operational rationale for the split lives in the private infra repo, not here.
+
+/**
+ * The 401 body, shared by the hook and by both endpoint wrappers. One constant because all three
+ * must say the same thing: this PR had to edit the literal in three places, which is the tell.
+ *
+ * Deliberately does NOT name a variable. Which credentials a deployment accepts is a deployment
+ * detail, and the caller does not need it to fix a bad token.
+ */
+export const SEND_A_TOKEN =
+  'Send a valid service token as `?token=` or `Authorization: Bearer <token>`.';
 
 function presentedToken(event: { url: URL; request: Request }): Buffer {
   const query = event.url.searchParams.get('token');
@@ -92,18 +101,15 @@ export function authenticateWebhookToken(event: {
     );
 
   const provided = presentedToken(event);
-  // Every candidate is compared, with no early exit on a match, so the time taken does not reveal WHICH
-  // credential was presented or how many are configured. Length is checked first because
-  // timingSafeEqual THROWS on a length mismatch; that leaks only the length, not the secret.
+  // Every candidate is compared with no early exit on a match, so WHICH credential matched is not
+  // revealed by how long the comparison takes. (It does not hide how many candidates share the
+  // presented token's LENGTH — that is not a property being claimed here.) Length is checked first
+  // because timingSafeEqual THROWS on a length mismatch; that leaks only the length, not the secret.
   let matched = false;
   for (const secret of accepted)
     if (provided.length === secret.length && timingSafeEqual(provided, secret)) matched = true;
 
-  if (!matched)
-    return Response.json(
-      { message: 'Send a valid service token as `?token=` or `Authorization: Bearer <token>`.' },
-      { status: 401 }
-    );
+  if (!matched) return Response.json({ message: SEND_A_TOKEN }, { status: 401 });
 
   return 'webhook';
 }
@@ -117,8 +123,7 @@ export function WebhookEndpoint<E extends RequestEvent, R>(
     // The hook already verified the token; this is the opt-in that makes THIS endpoint token-callable.
     // A signed-in moderator hitting it is refused too — like the main app's WebhookEndpoint, these are
     // service endpoints, and there is no user behind one.
-    if (event.locals.tokenClient !== 'webhook')
-      error(401, 'Send a valid service token as `?token=` or `Authorization: Bearer <token>`.');
+    if (event.locals.tokenClient !== 'webhook') error(401, SEND_A_TOKEN);
     return handler(event);
   };
 }

--- a/apps/moderator/src/lib/server/webhook-endpoint.ts
+++ b/apps/moderator/src/lib/server/webhook-endpoint.ts
@@ -4,20 +4,39 @@ import { env } from '$env/dynamic/private';
 
 // WEBHOOK ENDPOINTS — the spoke's equivalent of the main app's WebhookEndpoint
 // (src/server/utils/endpoint-helpers.ts). Wrap any `/api/*` handler to make it callable by a service
-// holding the shared WEBHOOK_TOKEN instead of by a signed-in moderator:
+// holding an accepted service token instead of by a signed-in moderator:
 //
 //   export const POST = WebhookEndpoint(async (event) => ok(await doTheThing()));
 //
 // The token is read from `?token=` (what the main app sends) or `Authorization: Bearer` (what
 // @civitai/moderation sends), so either convention works against the same endpoint.
 //
-// The token is VERIFIED in hooks.server.ts, not here: there is one secret, so the hook can check it
-// without knowing which endpoint the request is for, and an invalid token is refused before any handler
-// runs. This wrapper asserts the hook's verdict, which is what makes an endpoint token-callable —
-// an unwrapped endpoint refuses a token even when the token is valid.
+// The token is VERIFIED in hooks.server.ts, not here: the hook can check it without knowing which
+// endpoint the request is for, and an invalid token is refused before any handler runs. This wrapper
+// asserts the hook's verdict, which is what makes an endpoint token-callable — an unwrapped endpoint
+// refuses a token even when the token is valid.
 //
 // There is NO USER behind the token. `locals.user` is deliberately never populated here, so anything
 // reached this way cannot attribute a write — which is what keeps `human_judgement` human-only.
+//
+// TWO CREDENTIALS ARE ACCEPTED, and the difference is reach, not privilege — inside this app they
+// authorise exactly the same thing:
+//
+//   MOD_INBOUND_TOKEN — inbound-only, and the one to hand out. It appears NOWHERE else: no outbound
+//     caller reads it and the main app does not know it, so a holder can reach this app and nothing
+//     beyond it. A service that only ever calls IN should hold this and only this.
+//   WEBHOOK_TOKEN  — kept accepted for COMPATIBILITY, because this app is on BOTH ends of it. The main
+//     app presents it when it calls in, and four services here present it when they call out
+//     (user-actions.service.ts, search-index.ts, kono.ts, training-moderation.service.ts) — see
+//     .env.example, which requires it to match the main app's. One variable, two directions, so its
+//     value is not ours to change independently: that is why the fix is a second accepted token and
+//     not a rotation.
+//
+// So this is a MIGRATION SEAM, not a permission model. Move each inbound caller to MOD_INBOUND_TOKEN,
+// and once none present WEBHOOK_TOKEN inbound, drop it from `acceptedTokens` — the outbound callers
+// keep using it and are unaffected. Scoping a token to particular endpoints is a separate, later
+// change: `EndpointAuth` is already `{kind:'webhook'} | {kind:'session'; page}` (api-endpoint.ts),
+// so `{kind:'webhook'; scope}` has somewhere to go.
 
 function presentedToken(event: { url: URL; request: Request }): Buffer {
   const query = event.url.searchParams.get('token');
@@ -25,6 +44,25 @@ function presentedToken(event: { url: URL; request: Request }): Buffer {
   const header = (event.request.headers.get('authorization') ?? '').trim();
   const scheme = header.slice(0, 7).toLowerCase();
   return Buffer.from(scheme === 'bearer ' ? header.slice(7).trim() : '');
+}
+
+/**
+ * The credentials this deployment accepts inbound, as comparable buffers.
+ *
+ * Trimmed to match what a caller sends: a secret injected with a trailing newline would otherwise
+ * differ in length from the byte-identical token a caller presents, and every request would 401
+ * blaming the caller.
+ *
+ * 🔴 EMPTY IS NOT CONFIGURED. A variable that is set but blank is dropped rather than accepted, so a
+ * caller presenting `?token=` with no value cannot match it — without this filter, blanking the
+ * secret would turn every wrapped endpoint into an open one, which is the opposite of the
+ * fail-closed behaviour the 503 below exists to provide.
+ */
+function acceptedTokens(): Buffer[] {
+  return [env.MOD_INBOUND_TOKEN, env.WEBHOOK_TOKEN]
+    .map((value) => (value ?? '').trim())
+    .filter((value) => value.length > 0)
+    .map((value) => Buffer.from(value));
 }
 
 /**
@@ -42,23 +80,28 @@ export function authenticateWebhookToken(event: {
   if (!event.url.searchParams.has('token') && !event.request.headers.has('authorization'))
     return 'none';
 
-  const expected = env.WEBHOOK_TOKEN;
-  // Fails CLOSED — an unset secret makes every wrapped endpoint unreachable rather than unguarded. 503
-  // rather than 401 so an operator reading logs sees a deployment problem, not a caller with a bad token.
-  if (!expected)
+  const accepted = acceptedTokens();
+  // Fails CLOSED — with NO secret configured every wrapped endpoint is unreachable rather than
+  // unguarded. 503 rather than 401 so an operator reading logs sees a deployment problem, not a caller
+  // with a bad token. Either variable alone is a complete configuration: WEBHOOK_TOKEN alone is the
+  // state before migration, MOD_INBOUND_TOKEN alone the state after.
+  if (accepted.length === 0)
     return Response.json(
-      { message: 'WEBHOOK_TOKEN is not configured on this deployment.' },
+      { message: 'Neither MOD_INBOUND_TOKEN nor WEBHOOK_TOKEN is configured on this deployment.' },
       { status: 503 }
     );
 
   const provided = presentedToken(event);
-  // Trimmed to match: a secret injected with a trailing newline would otherwise differ in length from the
-  // byte-identical token a caller sends, and every request would 401 blaming the caller.
-  const secret = Buffer.from(expected.trim());
-  // Length first because timingSafeEqual throws on a mismatch; it leaks only the length, not the secret.
-  if (provided.length !== secret.length || !timingSafeEqual(provided, secret))
+  // Every candidate is compared, with no early exit on a match, so the time taken does not reveal WHICH
+  // credential was presented or how many are configured. Length is checked first because
+  // timingSafeEqual THROWS on a length mismatch; that leaks only the length, not the secret.
+  let matched = false;
+  for (const secret of accepted)
+    if (provided.length === secret.length && timingSafeEqual(provided, secret)) matched = true;
+
+  if (!matched)
     return Response.json(
-      { message: 'Send WEBHOOK_TOKEN as `?token=` or `Authorization: Bearer <token>`.' },
+      { message: 'Send a valid service token as `?token=` or `Authorization: Bearer <token>`.' },
       { status: 401 }
     );
 
@@ -75,7 +118,7 @@ export function WebhookEndpoint<E extends RequestEvent, R>(
     // A signed-in moderator hitting it is refused too — like the main app's WebhookEndpoint, these are
     // service endpoints, and there is no user behind one.
     if (event.locals.tokenClient !== 'webhook')
-      error(401, 'Send WEBHOOK_TOKEN as `?token=` or `Authorization: Bearer <token>`.');
+      error(401, 'Send a valid service token as `?token=` or `Authorization: Bearer <token>`.');
     return handler(event);
   };
 }

--- a/apps/moderator/src/routes/api/mod/[action]/+server.ts
+++ b/apps/moderator/src/routes/api/mod/[action]/+server.ts
@@ -4,7 +4,7 @@ import { WebhookEndpoint } from '$lib/server/webhook-endpoint';
 import { modActions } from '$lib/server/mod-actions/registry';
 
 // Ingress the main app POSTs to, delegating a mutation the spoke owns. Authenticated by WEBHOOK_TOKEN in
-// hooks.server.ts ($lib/server/token-auth), not here. The caller already gated on `moderatorProcedure`,
+// hooks.server.ts ($lib/server/webhook-endpoint), not here. The caller already gated on `moderatorProcedure`,
 // so the body's `userId` is trusted here.
 export const POST: RequestHandler = WebhookEndpoint(async ({ params, request }) => {
   // Object.hasOwn so a params.action of `__proto__`/`constructor` can't resolve to an inherited member.

--- a/apps/moderator/src/routes/api/mod/[action]/+server.ts
+++ b/apps/moderator/src/routes/api/mod/[action]/+server.ts
@@ -3,9 +3,9 @@ import type { RequestHandler } from './$types';
 import { WebhookEndpoint } from '$lib/server/webhook-endpoint';
 import { modActions } from '$lib/server/mod-actions/registry';
 
-// Ingress the main app POSTs to, delegating a mutation the spoke owns. Authenticated by WEBHOOK_TOKEN in
-// hooks.server.ts ($lib/server/webhook-endpoint), not here. The caller already gated on `moderatorProcedure`,
-// so the body's `userId` is trusted here.
+// Ingress the main app POSTs to, delegating a mutation the spoke owns. Authenticated by any accepted
+// service token in hooks.server.ts ($lib/server/webhook-endpoint), not here. The caller already gated
+// on `moderatorProcedure`, so the body's `userId` is trusted here.
 export const POST: RequestHandler = WebhookEndpoint(async ({ params, request }) => {
   // Object.hasOwn so a params.action of `__proto__`/`constructor` can't resolve to an inherited member.
   if (!Object.hasOwn(modActions, params.action))


### PR DESCRIPTION
## What

`authenticateWebhookToken` — the only place this app verifies an inbound token — now accepts a second variable, `MOD_INBOUND_TOKEN`, alongside `WEBHOOK_TOKEN`. Inside the app the two are equivalent; the difference is **reach**, not privilege.

## Why

`WEBHOOK_TOKEN` is shared rather than local to this app: it is used in both directions (see `.env.example`), so its value is not ours to change independently and a service that only ever calls *in* had nothing narrower it could be given. `MOD_INBOUND_TOKEN` is inbound-only — nothing here sends it — so a service holding only that one can reach this app and nothing beyond it.

## Migration seam, not a permission model

Either variable alone is a complete configuration. So: move inbound callers over one at a time, then delete `WEBHOOK_TOKEN` from `acceptedTokens()` once none present it.

🔴 **That last step is a code change, not an unset.** Dropping it from `acceptedTokens()` stops accepting it inbound and is safe. *Unsetting the variable* also strips it from this app's outbound callers, two of which degrade by warning rather than failing — and inbound would keep working the whole time, so nothing would be loud. `.env.example` says this at the variable.

Per-endpoint scoping is a separate later change — `EndpointAuth` is already `{kind:'webhook'} | {kind:'session'; page}`, so `{kind:'webhook'; scope}` has somewhere to go.

## This closes a latent auth bypass

Not the goal of the PR — found while auditing it, and now pinned by a test.

`acceptedTokens()` treats an **empty-after-trim** value as unconfigured. The previous guard was `if (!expected)`, which a **whitespace-only** secret passes as truthy; the value was then trimmed to a zero-length buffer, and a zero-length `timingSafeEqual` comparison succeeds. A request presenting `?token=` with no value therefore authenticated, opening every wrapped endpoint.

Verified by probe against both versions, with controls (a real secret still 401s an empty token on both). **Latent only** — a real deployment holds a real value, which I checked before writing this. It is the `REGRESSION: a WHITESPACE-ONLY secret is not configured` test.

## Behaviour worth reviewing

- **Empty is not configured** — otherwise blanking a secret opens every wrapped endpoint. Three tests.
- **No early exit** on a match: every configured candidate is compared, so which credential matched is not revealed by comparison order.
- **503 fail-closed** now requires *both* to be unset, and names both so an operator knows either would fix it.

## Verification

Tests are a **matrix**, not an assertion — this module had no tests before, so both arms were run:

| | at `origin/main` | on this branch |
|---|---|---|
| 7 `REGRESSION:` cases | **all 7 fail** | pass |
| 13 `INVARIANT:` cases | pass | pass |

The invariant tier is the point: accepting a second token must not stop accepting the first.

**Mutation battery**, re-run after the audit fix round (a fix round resets the gate). 9 mutants, each asserted present on disk immediately before its run, source restored byte-identical after, with a positive control in the batch:

- **7 killed**, each attributed to a named test — including the dropped-`.filter()` and disarmed-fail-closed mutants, both killed by the new whitespace-only test.
- **2 survive and are equivalent mutants**: array order and early-return-on-match. Neither is observable through the function's return value. Naming them rather than hiding them — if you think the no-early-exit property deserves a pin, it currently has none.

Also: `app:moderator` 198 passed / 35 skipped (the EXPLAIN tier needs a DB), `pnpm check` 9350 files 0 errors, eslint 3 files 0 errors (read from `--format json`, not an exit code), prettier clean.

## Not in this PR

- **No deployment change.** Nothing sets `MOD_INBOUND_TOKEN` yet, so behaviour in every environment is identical until it does.
- **No credential attribution.** Nothing records *which* token authenticated, so there is no signal that says when the migration is complete. That is a prerequisite for *removing* the legacy token, not for adding the new one — it belongs in the follow-up, where it will have a consumer. Flagging it because the removal step is the one that can break callers.
- **The XGuard docs page still asks operators for `WEBHOOK_TOKEN`.** That audience is an inbound-only consumer and should be moved, but the page cannot point at a variable that does not exist yet.

## Review history

Adversarially audited, then a delta re-audit of the fix round. Findings acted on in `7bc129c748`; two were deliberately deferred, listed above with reasons.
