### PR TITLE
perf(image): bound the CONNECTIONS branch of getEntityCoverImage to one row per entity

### DIFF
--- a/src/server/services/__tests__/entity-cover-image-connections-distinct.test.ts
+++ b/src/server/services/__tests__/entity-cover-image-connections-distinct.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The `CONNECTIONS` branch of `getEntityCoverImage`'s UNION is the only one of the
+ * six that can emit more than one row per entity: `ImageConnection` holds one row
+ * per linked image, so the branch fans out (p50 1, p99 11, max 525 on production)
+ * and the result set stops being bounded by the number of entities requested.
+ *
+ * De-duplicating it has a trap. The `ingestion`/`needsReview` predicate used to sit
+ * in the outer WHERE, i.e. *after* the UNION, so every connection's image was
+ * emitted and the JS join picked the first surviving row. A `DISTINCT ON` added
+ * without moving that predicate inward picks its row *before* the filter runs: land
+ * on an unscanned image and the entity loses its cover entirely, where today a
+ * sibling connection would have supplied one. That is a user-visible regression, so
+ * it gets its own assertion below.
+ *
+ * None of this is observable from a fixture. The de-duplication and the ordering are
+ * decided by Postgres, and this suite has no database -- feed the mock two rows for
+ * one entity and the first still wins, which is a statement about the fixture rather
+ * than about the query. So the query text is the artifact under test, and the branch
+ * is pinned as a whole normalised string: a loose regex is satisfied by SQL that is
+ * semantically inverted, and this is exactly the shape where that matters.
+ */
+
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/services/cosmetic.service', () => ({
+  getCosmeticsForEntity: vi.fn().mockResolvedValue({}),
+}));
+
+import { getEntityCoverImage } from '../image.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const ENTITY = { entityId: 1, entityType: 'Bounty' as const };
+
+const RAW_ROW = {
+  id: 1,
+  name: 'x',
+  url: 'x',
+  nsfwLevel: 1,
+  width: 1,
+  height: 1,
+  hash: 'x',
+  hideMeta: false,
+  hasMeta: false,
+  hasPositivePrompt: false,
+  createdAt: new Date(0),
+  mimeType: 'image/jpeg',
+  type: 'image',
+  metadata: null,
+  scannedAt: new Date(0),
+  needsReview: null,
+  userId: 1,
+  index: 0,
+  postId: null,
+  entityId: ENTITY.entityId,
+  entityType: ENTITY.entityType,
+};
+
+/** Runs the service and returns the query text it built. */
+async function captureQuery() {
+  const queryRaw = dbMock.dbRead.$queryRaw as unknown as ReturnType<typeof vi.fn>;
+  let strings: TemplateStringsArray | undefined;
+  queryRaw.mockImplementation((s: TemplateStringsArray) => {
+    strings = s;
+    return Promise.resolve([RAW_ROW]);
+  });
+
+  const result = await getEntityCoverImage({ entities: [ENTITY] });
+
+  // Positive control: an early return or a throw would leave every assertion below
+  // a statement about nothing.
+  expect(strings, 'getEntityCoverImage never issued its query').toBeDefined();
+  expect(result).toHaveLength(1);
+
+  return (strings as TemplateStringsArray).join('?');
+}
+
+/**
+ * The text of the CONNECTIONS branch alone, whitespace-normalised.
+ *
+ * The end marker is the outer join onto the UNION's output (`t."imageId"`), which is
+ * distinct from the branch's own join (`ic."imageId"`) -- so the slice deliberately
+ * stops short of the outer WHERE. That is what lets the eligibility assertion below
+ * distinguish "inside the branch" from "after the UNION": leave the predicate where
+ * it used to be and it falls outside this slice.
+ */
+function connectionsBranch(sql: string) {
+  const start = sql.indexOf('-- CONNECTIONS');
+  const end = sql.indexOf('JOIN "Image" i ON i.id = t."imageId"');
+
+  // Positive control on the slice itself. A marker that stopped matching would hand
+  // every assertion below a garbage string, and `.not.toMatch` assertions would pass
+  // against it.
+  expect(start, 'the CONNECTIONS branch marker is gone -- re-anchor this slice').toBeGreaterThan(
+    -1
+  );
+  expect(end, 'the outer UNION join is gone -- re-anchor this slice').toBeGreaterThan(start);
+
+  return sql.slice(start, end);
+}
+
+/**
+ * The branch with comments dropped and whitespace normalised -- the SQL as Postgres
+ * sees it. Comments have to go before the newlines do: a `--` comment runs to end of
+ * line, so stripping it after normalising would swallow the statement behind it.
+ */
+function connectionsSql(sql: string) {
+  return connectionsBranch(sql)
+    .split('\n')
+    .map((line) => line.replace(/--.*$/, ''))
+    .join('\n')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+describe('getEntityCoverImage bounds the CONNECTIONS branch to one row per entity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('de-duplicates the branch instead of emitting one row per connection', async () => {
+    const branch = connectionsSql(await captureQuery());
+
+    // Without this the branch fans out with `ImageConnection`, and the JS join
+    // downstream degrades to a scan of an unbounded result set per entity.
+    expect(
+      branch,
+      'the CONNECTIONS branch emits one row per connection, not one per entity'
+    ).toMatch(/SELECT DISTINCT ON \(/);
+  });
+
+  it('keys the de-duplication on entityType as well as entityId', async () => {
+    const branch = connectionsSql(await captureQuery());
+
+    // The other five branches each pin a single `entityType`, so `entityId` alone
+    // identifies a row for them. This branch joins on the pair, so an id can recur
+    // across types -- dropping `entityType` here would collapse two distinct
+    // entities into one and hand one of them the other's cover image.
+    const key = branch.match(/SELECT DISTINCT ON \(([^)]*)\)/)?.[1];
+    expect(key, 'no DISTINCT ON key list to inspect').toBeDefined();
+    expect(key, 'DISTINCT ON drops entityType, so ids collide across entity types').toContain(
+      'e."entityType"'
+    );
+    expect(key).toContain('e."entityId"');
+  });
+
+  it('filters ineligible images inside the branch, before de-duplication', async () => {
+    const branch = connectionsSql(await captureQuery());
+
+    // The trap this file exists for. DISTINCT ON picks before the outer WHERE runs,
+    // so if the predicate is left outside, an entity whose connections hold an
+    // unscanned image alongside an eligible one can have the unscanned one picked
+    // and then filtered away -- losing a cover image it has today.
+    expect(
+      branch,
+      'the eligibility predicate is outside the branch, so DISTINCT ON can pick an ineligible image and drop the entity'
+    ).toContain(`WHERE i."ingestion" = 'Scanned' AND i."needsReview" IS NULL`);
+  });
+
+  it('orders by the DISTINCT ON key columns first, then a total-order tiebreak', async () => {
+    const branch = connectionsSql(await captureQuery());
+
+    // Postgres requires the ORDER BY to lead with the DISTINCT ON expressions; the
+    // trailing key decides which row survives. `i.id` is the primary key, so it is
+    // never null and leaves no residual tie.
+    expect(branch, 'the surviving connection row is not deterministic').toContain(
+      'ORDER BY e."entityId", e."entityType", i.id'
+    );
+  });
+
+  it('pins the whole branch, so a reword cannot leave it semantically inverted', async () => {
+    const branch = connectionsSql(await captureQuery());
+
+    // A partial pattern is satisfied by SQL that means the opposite -- a predicate
+    // negated, a key column reordered out of the DISTINCT ON, an ORDER BY direction
+    // flipped. This is the machine-readable claim; the assertions above exist to say
+    // which property broke when it goes red. Cosmetic edits to the branch must
+    // update this string.
+    expect(branch).toBe(
+      'SELECT * FROM ( ' +
+        'SELECT DISTINCT ON (e."entityId", e."entityType") ' +
+        'e."entityId", e."entityType", i.id AS "imageId", 0 "order1", 0 "order2", 0 "order3" ' +
+        'FROM entities e ' +
+        'JOIN "ImageConnection" ic ON ic."entityId" = e."entityId" AND ic."entityType" = e."entityType" ' +
+        'JOIN "Image" i ON i.id = ic."imageId" ' +
+        `WHERE i."ingestion" = 'Scanned' AND i."needsReview" IS NULL ` +
+        'ORDER BY e."entityId", e."entityType", i.id ' +
+        ') t ) t'
+    );
+  });
+
+  it('keeps the first row for an entity when two branches both supply one', async () => {
+    // An Article is served by its own branch (the cover) and by CONNECTIONS (its
+    // content images), so the UNION can still hand this function two rows for one
+    // entity. The JS join is indexed rather than scanned now, and first-wins has to
+    // survive that: a plain `set` per row would silently switch to last-wins.
+    const first = { ...RAW_ROW, id: 10, entityId: 7, entityType: 'Article' };
+    const second = { ...RAW_ROW, id: 20, entityId: 7, entityType: 'Article' };
+
+    const queryRaw = dbMock.dbRead.$queryRaw as unknown as ReturnType<typeof vi.fn>;
+    queryRaw.mockResolvedValue([first, second]);
+
+    const result = await getEntityCoverImage({
+      entities: [{ entityId: 7, entityType: 'Article' }],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id, 'the indexed join changed which row an entity resolves to').toBe(10);
+  });
+});

--- a/src/server/services/__tests__/entity-cover-image-connections-distinct.test.ts
+++ b/src/server/services/__tests__/entity-cover-image-connections-distinct.test.ts
@@ -124,6 +124,20 @@ function connectionsBranch(sql: string) {
 }
 
 /**
+ * Everything from the outer join onto the UNION's output to the end of the query,
+ * whitespace-normalised -- the far side of the boundary `connectionsBranch` stops at.
+ */
+function outerFilter(sql: string) {
+  const start = sql.indexOf('JOIN "Image" i ON i.id = t."imageId"');
+
+  // Same positive control as above: a marker that stopped matching would make the
+  // assertion below a statement about an empty string.
+  expect(start, 'the outer UNION join is gone -- re-anchor this slice').toBeGreaterThan(-1);
+
+  return sql.slice(start).replace(/\s+/g, ' ').trim();
+}
+
+/**
  * The branch with comments dropped and whitespace normalised -- the SQL as Postgres
  * sees it. Comments have to go before the newlines do: a `--` comment runs to end of
  * line, so stripping it after normalising would swallow the statement behind it.
@@ -230,5 +244,55 @@ describe('getEntityCoverImage bounds the CONNECTIONS branch to one row per entit
 
     expect(result).toHaveLength(1);
     expect(result[0].id, 'the indexed join changed which row an entity resolves to').toBe(10);
+  });
+
+  it('keys the JS join on entityType too, so one id under two types cannot collide', async () => {
+    // The SQL keeps the pair apart -- that is what the composite DISTINCT ON above is
+    // for -- and the JS join underneath it has to do the same, or the work is undone
+    // one line later. This is not a hypothetical: the endpoint accepts eleven entity
+    // types and callers mix them in a single request (`getUserCosmeticsHandler` builds
+    // its list from a user's equipped cosmetics across several types), so one
+    // `entityId` recurring under two types is ordinary traffic. Keyed on `entityId`
+    // alone both rows collapse onto one map entry, and first-wins then hands the
+    // second entity the first one's cover image.
+    //
+    // The first-wins test above cannot see this -- both of its rows are Articles.
+    const article = { ...RAW_ROW, id: 10, entityId: 7, entityType: 'Article' };
+    const bounty = { ...RAW_ROW, id: 20, entityId: 7, entityType: 'Bounty' };
+
+    const queryRaw = dbMock.dbRead.$queryRaw as unknown as ReturnType<typeof vi.fn>;
+    queryRaw.mockResolvedValue([article, bounty]);
+
+    const result = await getEntityCoverImage({
+      entities: [
+        { entityId: 7, entityType: 'Article' },
+        { entityId: 7, entityType: 'Bounty' },
+      ],
+    });
+
+    expect(result).toHaveLength(2);
+    expect(
+      result.map((r) => [r.entityType, r.id]),
+      "the JS join collapses two entity types onto one key, so an entity was handed another entity type's cover image"
+    ).toEqual([
+      ['Article', 10],
+      ['Bounty', 20],
+    ]);
+  });
+
+  it('keeps the outer eligibility filter, the only one guarding the IMAGES branch', async () => {
+    // Pre-existing, and pinned here because this file is now the only thing looking at
+    // this query. The IMAGES branch (`entityType = 'Image'`, where the entity *is* the
+    // image) carries no predicate of its own, so this outer WHERE is the sole check
+    // that stops an unscanned or needs-review image being served as a cover. Every
+    // other branch filters in-branch, which is exactly why deleting this line leaves
+    // the rest of the suite green.
+    expect(
+      outerFilter(await captureQuery()),
+      'the outer eligibility filter is gone, so the IMAGES branch can serve unscanned or needs-review images'
+    ).toBe(
+      'JOIN "Image" i ON i.id = t."imageId" ' +
+        `WHERE i."ingestion" = 'Scanned' AND i."needsReview" IS NULL`
+    );
   });
 });

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -7424,11 +7424,17 @@ export const getEntityCoverImage = async ({
           -- "entityType", so "entityId" alone identifies a row there; this branch
           -- joins on the pair, so one id can legitimately recur across types.
           --
-          -- "ImageConnection" carries no ordering column of its own, so the tiebreak
-          -- is the image id: a total order (primary key, never null, no residual
-          -- ties), and since links are inserted in the order the author submitted
-          -- them, the lowest id is the first image attached to the entity -- the
-          -- closest analogue to the "index"-based first-image rule used above.
+          -- "ImageConnection" carries no ordering column of its own -- no index, no
+          -- timestamp -- so nothing on the link records which image the author meant
+          -- to come first. The tiebreak is the image id, chosen for the properties
+          -- that can actually be guaranteed: it is a primary key, so the order is
+          -- total, never null, and leaves no residual tie for the planner to settle
+          -- arbitrarily. It is deliberately NOT claimed to be a first-attached rule.
+          -- "updateEntityImages" links already-existing images -- with arbitrary older
+          -- ids -- ahead of the ones it creates in the same call, so attaching an older
+          -- image on a later edit lowers the minimum and promotes that image to cover.
+          -- What the tiebreak buys is a stable, deterministic choice, not a
+          -- semantically-first one.
           SELECT DISTINCT ON (e."entityId", e."entityType")
               e."entityId",
               e."entityType",

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -7408,28 +7408,57 @@ export const getEntityCoverImage = async ({
         UNION
         -- CONNECTIONS
         SELECT * FROM (
-          SELECT
+          -- There is one "ImageConnection" row per linked image, so this branch --
+          -- alone among the six -- can emit many rows per entity (fan-out p50 1,
+          -- p99 11, max 525). DISTINCT ON collapses it to the single row the JS
+          -- join below would have consumed anyway, which is what keeps the size of
+          -- this result set proportional to the number of entities requested.
+          --
+          -- The eligibility predicate belongs HERE rather than in the outer WHERE.
+          -- DISTINCT ON picks its row before any later filter runs, so collapsing
+          -- first and filtering afterwards could settle on an unscanned image and
+          -- leave the entity with no cover at all, even though a sibling connection
+          -- was eligible the whole time.
+          --
+          -- Both key columns are required. Every other branch pins a single
+          -- "entityType", so "entityId" alone identifies a row there; this branch
+          -- joins on the pair, so one id can legitimately recur across types.
+          --
+          -- "ImageConnection" carries no ordering column of its own, so the tiebreak
+          -- is the image id: a total order (primary key, never null, no residual
+          -- ties), and since links are inserted in the order the author submitted
+          -- them, the lowest id is the first image attached to the entity -- the
+          -- closest analogue to the "index"-based first-image rule used above.
+          SELECT DISTINCT ON (e."entityId", e."entityType")
               e."entityId",
               e."entityType",
               i.id AS "imageId",
               0 "order1",
-	          0 "order2",
-	          0 "order3"
+              0 "order2",
+              0 "order3"
           FROM entities e
           JOIN "ImageConnection" ic ON ic."entityId" = e."entityId" AND ic."entityType" = e."entityType"
           JOIN "Image" i ON i.id = ic."imageId"
+          WHERE i."ingestion" = 'Scanned'
+            AND i."needsReview" IS NULL
+          ORDER BY e."entityId", e."entityType", i.id
         ) t
     ) t
     JOIN "Image" i ON i.id = t."imageId"
     WHERE i."ingestion" = 'Scanned' AND i."needsReview" IS NULL`;
 
+  // Index once instead of scanning `imagesRaw` per entity. `set` is guarded so the
+  // first row for a key wins, matching what `.find()` returned: an entity can still
+  // draw rows from two branches at once (an Article has both a cover image and
+  // content-image connections), and this must not silently switch which one is kept.
+  const imagesByEntity = new Map<string, GetEntityImageRaw>();
+  for (const image of imagesRaw) {
+    const key = `${image.entityId}:${image.entityType}`;
+    if (!imagesByEntity.has(key)) imagesByEntity.set(key, image);
+  }
+
   const images = entities
-    .map((e) => {
-      const image = imagesRaw.find(
-        (i) => i.entityId === e.entityId && i.entityType === e.entityType
-      );
-      return image ?? null;
-    })
+    .map((e) => imagesByEntity.get(`${e.entityId}:${e.entityType}`) ?? null)
     .filter(isDefined);
 
   let tagsVar: (VotableTagModel & { imageId: number })[] | undefined = [];


### PR DESCRIPTION
## Summary

`getEntityCoverImage` builds its `imagesRaw` set from a six-branch raw-SQL `UNION`. Five of the six yield **at most one row per entity** — four via `SELECT DISTINCT ON (e."entityId")` under a single pinned `entityType`, and the `IMAGES` branch trivially, because the entity *is* the image.

The `CONNECTIONS` branch does not. `ImageConnection` holds one row per linked image, so the branch emits **one row per connection**:

```sql
SELECT e."entityId", e."entityType", i.id AS "imageId", 0 "order1", 0 "order2", 0 "order3"
FROM entities e
JOIN "ImageConnection" ic ON ic."entityId" = e."entityId" AND ic."entityType" = e."entityType"
JOIN "Image" i ON i.id = ic."imageId"
```

So `imagesRaw` is not bounded by the number of entities requested, and the JS join underneath it walks that whole list once per entity. Fan-out on `ImageConnection` is **p50 1, p99 11, max 525**, so the result set can be far larger than the answer it produces, and is then scanned repeatedly.

> **Correction (round 2).** An earlier version of this description said the input has a *"documented 500-entity ceiling"*. **There is no such cap.** `getEntitiesCoverImage` in `src/server/schema/image.schema.ts` declares `entities: z.array(…)` with no `.max()`; the input size is whatever each caller passes. The sentence has been dropped rather than re-stated with a different number.

## The fix

De-duplicate inside the branch:

```sql
SELECT DISTINCT ON (e."entityId", e."entityType")
    e."entityId", e."entityType", i.id AS "imageId", 0 "order1", 0 "order2", 0 "order3"
FROM entities e
JOIN "ImageConnection" ic ON ic."entityId" = e."entityId" AND ic."entityType" = e."entityType"
JOIN "Image" i ON i.id = ic."imageId"
WHERE i."ingestion" = 'Scanned'
  AND i."needsReview" IS NULL
ORDER BY e."entityId", e."entityType", i.id
```

Three things are load-bearing and worth calling out separately.

### 1. The eligibility predicate had to move *into* the branch

This is the part that would have been a user-visible regression if it had been skipped.

The `ingestion`/`needsReview` predicate previously sat only in the outer `WHERE`, i.e. **after** the `UNION`. Today every connection's image is emitted, the outer filter drops the ineligible ones, and the JS join picks the first **surviving** row.

`DISTINCT ON` picks its row *before* that filter runs. Adding it without moving the predicate inward means an entity whose connections include an unscanned image alongside an eligible one could have the unscanned one selected and then filtered away — leaving the entity with **no cover image at all**, where today a sibling connection supplies one.

The predicate is therefore reproduced verbatim inside the branch. This matches what the bounties search index already does with the same join. The outer `WHERE` is left alone, since the other branches still rely on it — and it is now pinned by a test of its own (see the matrix below), because the `IMAGES` branch carries no eligibility predicate at all and that outer clause is the only thing guarding it.

### 2. `DISTINCT ON` needs both key columns — and so does the JS join

The other branches each pin a single `entityType` in their own `WHERE`, so `entityId` alone identifies a row for them. This branch is **not** filtered by type — it joins on the pair — so the same `entityId` can legitimately recur under different `entityType`s (`Bounty`, `BountyEntry`, `Article`). Keying on `entityId` alone would collapse two distinct entities into one and hand one of them the other's cover image. Both columns are in the `DISTINCT ON` and lead the `ORDER BY`.

The `Map` on the JS side has to key on the same pair, or the work is undone one line later. This is ordinary input, not a corner case: `getUserCosmeticsHandler` builds its entity list from a user's equipped cosmetics across several types, so one `entityId` recurring under two types reaches this function routinely. Both halves are now pinned separately.

### 3. The tiebreak

`ImageConnection` has no ordering column at all — its primary key is `(imageId, entityType, entityId)` and it carries no index or timestamp. The other branches order by a semantic index (`mv.index`, `p.id`, `i.index`); there is no equivalent here.

The tiebreak chosen is **`i.id` ascending**, for the two properties that can actually be guaranteed:

- it is a **total order** — primary key, never null, unique, so no residual tie is left for the planner to resolve arbitrarily;
- it is **stable** — the same connection set resolves to the same image on every call.

> **Correction (round 2).** An earlier version of this section, and the code comment beside the query, claimed that *"`updateEntityImages` inserts links in the order the author submitted them, so the lowest id is the first image attached to the entity"*. **That is not what `updateEntityImages` does.** It builds its link list by putting already-existing images being newly linked — which carry arbitrary older ids — *ahead* of the ones it creates in the same call, and the `findMany` that collects the newly created ones has no `orderBy`. So attaching an older existing image on a later edit lowers the minimum and **promotes that image to cover**.
>
> **The tiebreak itself is unchanged** — `min(id)` is still total, non-null and stable, which is what it was picked for. Only the false ordering claim is dropped, from both the PR text and the comment. What the tiebreak buys is a deterministic choice, not a semantically-first one.

`Image.index` was considered and rejected: it is post-relative and optional, so for a connection-linked image it carries no meaning scoped to the connection. Using it would invent a semantic that isn't there.

## Behaviour change — please read

**This is not purely behaviour-preserving, and I don't want to present it as such.**

There is no outer `ORDER BY` on the `UNION`, so `imagesRaw` row order is unspecified. For any entity with more than one connection, the row `.find()` returns today is **already nondeterministic** — it is whatever the planner happened to emit first. Ordering the branch makes that choice deterministic and stable, which is an improvement, but it does mean **a given entity may now resolve to a different cover image than the one it happened to return before**. For fan-out-1 entities (p50) nothing changes at all.

### Remaining nondeterminism, pre-existing and out of scope

`Article` is served by **two** branches at once — its own (the article cover, via `a."coverId"`) and `CONNECTIONS` (its content images). Each now contributes at most one row, but which of the two the JS join picks is still decided by unspecified UNION order. This PR reduces the nondeterminism from "any content image" to "cover or first content image"; it does not eliminate it. Settling that means deciding a cross-branch priority, which is a product question rather than a query-shape one, so I've deliberately left it alone.

## The other five branches

Checked — **none of them share either issue**, so nothing else is touched here:

| Branch | Fans out? | Predicate placement |
|---|---|---|
| `MODEL` | No — `DISTINCT ON` | Already in-branch |
| `MODEL VERSION` | No — `DISTINCT ON` | Already in-branch |
| `ARTICLES` | No — `DISTINCT ON`, and `a."coverId"` is 1:1 anyway | Already in-branch |
| `POSTS` | No — `DISTINCT ON` | Already in-branch |
| `IMAGES` | No — the entity is the image | N/A: single candidate, no alternative to pick |
| `CONNECTIONS` | **Yes** | **Was outer — moved in-branch by this PR** |

`CONNECTIONS` was the only branch that both fanned out *and* deferred its filter.

## JS side

The join was `imagesRaw.find(...)` per entity. With the result set now bounded that is at worst quadratic in the number of entities requested, which is fine at the sizes callers actually pass, but it is three lines to index it into a `Map` and the intent reads better. The key is the `(entityId, entityType)` pair, mirroring the composite `DISTINCT ON` above, and the `set` is **guarded so the first row for a key wins**, preserving exactly what `.find()` returned — the Article case above means two rows for one entity is still reachable, and this must not silently flip to last-wins. Both properties are pinned by tests.

No changes to the tag-association helper or its call sites.

## Tests

New: `src/server/services/__tests__/entity-cover-image-connections-distinct.test.ts` (8 tests).

De-duplication and ordering are decided by Postgres, and this suite has no database — feeding the mock two rows for one entity proves something about the fixture, not about the query. So, following the precedent in `entity-cover-image-hidemeta.test.ts`, the query text is the artifact under test. The branch is pinned as a **whole normalised string** (a loose regex is satisfied by semantically inverted SQL); the narrower assertions alongside it exist to say *which* property broke when it goes red. Each slice carries its own positive control, so a marker that stopped matching fails loudly instead of handing every assertion a garbage string.

The two things that *are* fixture-testable — first-wins in the new `Map`, and that the `Map` key separates two entity types sharing an id — are tested behaviourally.

### Mutation matrix

Every guard was watched to fail, for its own assertion:

| Mutation | Result | Failing assertion |
|---|---|---|
| (a) remove `DISTINCT ON` | ✅ 3 failed | *"the CONNECTIONS branch emits one row per connection, not one per entity"* |
| (b) move eligibility predicate back outside | ✅ 2 failed | *"the eligibility predicate is outside the branch, so DISTINCT ON can pick an ineligible image and drop the entity"* |
| (c) drop `entityType` from `DISTINCT ON` | ✅ 2 failed | *"DISTINCT ON drops entityType, so ids collide across entity types"* — and (a)'s assertion **passes**, isolating this case |
| (d) `Map.set` unguarded (last-wins) | ✅ 1 failed | *"the indexed join changed which row an entity resolves to"* (expected 20 to be 10) |
| (e) drop the `i.id` tiebreak from `ORDER BY` | ✅ 2 failed | *"the surviving connection row is not deterministic"* |
| **(f) drop `entityType` from *both* `Map` key expressions** | **✅ 1 failed** *(was SURVIVED before round 2)* | *"the JS join collapses two entity types onto one key, so an entity was handed another entity type's cover image"* |
| **(g) delete the outer eligibility `WHERE`** | **✅ 1 failed** *(was SURVIVED before round 2)* | *"the outer eligibility filter is gone, so the IMAGES branch can serve unscanned or needs-review images"* |
| harness control: rename the slice's start marker | ✅ 5 failed | *"the CONNECTIONS branch marker is gone — re-anchor this slice"* |

Each mutant kills exactly the assertion written for it and no other. Source restored byte-identical after each (md5 verified), green again at 8/8.

**Deliberately not pinned:** deleting `DISTINCT ON` from the `ARTICLES` branch also survives this suite, and is left that way. It is a semantic no-op there — both of that branch's joins are on primary keys (`Article.id`, and `Article.coverId` is a nullable **unique** scalar FK to `Image.id`), so the branch emits at most one row per `entities` row by construction, and the enclosing `UNION` would collapse a duplicate anyway. A pin there would be a change-detector on a branch this PR does not own, guarding a hazard that cannot occur.

## Validation

- `pnpm test:unit` — **1364 files passed / 1 skipped; 21476 tests passed / 25 skipped; 0 failed** (+2 on the previous run, the two new tests)
- `node scripts/typecheck.mjs` — **0 type errors** (69s, 8192 MB heap cap)
- `eslint` — new test file **clean (rc 0)**; `image.service.ts` findings **diffed line-for-line against the base blob and identical** (27 problems, 3 errors, all pre-existing)
- `prettier` — delta vs the base blob **identical**: one pre-existing deviation at line 6551, nowhere near this change. No new deviations introduced.

## Merge notes

Based directly on `main`, not stacked. The diff is confined to the `CONNECTIONS` branch, the join immediately below it, and the new test file, so it should merge independently of #4321, which touches this file at different hunks.
