### PR TITLE
docs(dev-server): rename GREETME.md to README.md

### DIFF
--- a/.claude/skills/dev-server/README.md
+++ b/.claude/skills/dev-server/README.md
@@ -1,10 +1,11 @@
-# dev-server: what changed, in one page
+# dev-server, in one page
 
-_Written 2026-08-24, against the change that added per-worktree app support._
+The dev server runs the main Next.js app and the **moderator** and **creator-studio** apps, each from
+whatever worktree you are standing in. This is the short version for people who have to use it —
+`SKILL.md` is the reference.
 
-The dev server used to boot one thing: the main Next.js app. It now boots the **moderator** and
-**creator-studio** apps too, from whatever worktree you are standing in. This is the short version
-for people who have to use it — `SKILL.md` is the long version.
+_Written 2026-08-24, when per-worktree app support landed; the "what changed" notes below are
+relative to that._
 
 ## The commands
 


### PR DESCRIPTION
Renames the dev-server handoff page to the name it was meant to have. `GREETME` came from a voice transcript of "README" that arrived as "greetme.nd" and I took it literally instead of flagging it.

Nothing referenced the old name — no code, no docs, no skill.

One wording change came along with the rename: the file opened "what changed, in one page", which reads as a changelog rather than a README to the next person. It now says what the thing is, and keeps a dated note recording which change the "used to" comparisons below are relative to.

Follows #4324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)