### PR TITLE
fix(schema-drift): a declared table that does not exist is now a finding, not silence

### DIFF
--- a/packages/civitai-db-schema/src/schema-drift/README.md
+++ b/packages/civitai-db-schema/src/schema-drift/README.md
@@ -78,9 +78,19 @@ regardless of `--strict` rather than reporting a reassuring zero.
 - **Block attributes are read with comments stripped.** `@@map` / `@@ignore` / `@@unique`
   are matched against the model body, so a stray `// @@ignore` left behind by a revert
   would otherwise skip an entire model and every constraint on it, silently.
-- **Models mapped to a view or to a table that does not exist are skipped**, along with
-  models carrying `@@ignore`. They are counted and listed (`--verbose`), not reported as
-  drift: there is no table for a constraint to live on.
+- **Models mapped to a view are skipped**, along with models carrying `@@ignore`: there is
+  no table for a constraint to live on. **A model mapped to nothing at all is a
+  `missing-table` finding**, not a skip. Those two used to be the same branch, and that
+  inverted the tool: an absent column was at least a pending finding, so the bigger the
+  divergence the quieter it got — appending a model on an invented table produced output
+  byte-identical to a clean run. The discriminator is the catalog's `views` list.
+- **Every skipped model is printed, by both the report and the gate**, with its count. A
+  verdict that lists no finding for a model is otherwise indistinguishable from one that
+  never looked at it. On the 2026-08-03 snapshot that is 45 of 316 models.
+- **A snapshot with no `views` key cannot classify a skip**, and says so rather than
+  guessing. Reading an absent list as an empty one would accuse all 24 view-backed models in
+  that snapshot of being missing tables — fabricated findings, in the direction that looks
+  like progress.
 - **Partial unique indexes do not count.** A `WHERE`-clause index enforces uniqueness only
   over the rows it matches; a `@unique` declaration is a promise about every row.
 - **Expression indexes are dropped** rather than matched by name, so a `lower(email)` index
@@ -180,28 +190,44 @@ pnpm --filter @civitai/db-schema drift \
 ```
 
 ```
-declared owning-side relations : 509
+declared owning-side relations : 512
 checked against the database   : 448
-skipped (view / absent table)  : 61
+skipped (view / absent table)  : 64
 MISSING foreign key            : 40
 wrong referential action       : 0   <- see below
-MISSING column                 : 18
-nullability checked            : 2348
+models NOT compared at all     : 45
+MISSING table                  : 0   <- see below
+view or absent, not classified : 45
+MISSING column                 : 23
+nullability checked            : 2345
 nullability drift              : 13
-uniqueness declarations checked: 122
+uniqueness declarations checked: 120
 missing unique index           : 1
 ```
 
-72 findings in total. The 13 nullability findings are `Purchase.userId`,
+77 findings in total. **`MISSING table: 0` is "not measured", not "clean"** — this snapshot
+predates the `views` query, so all 45 skipped models are unclassifiable and the check cannot
+fire. Measured against production on 2026-08-24, those 45 are 24 views and **21 ordinary
+tables that exist right now**, absent here only because the capture is 21 days old. A
+recapture turns that 0 into 21 and gives the 21 tables their first comparison of any kind. The 13 nullability findings are `Purchase.userId`,
 `ChallengeEvent.createdById`, nine `*Metric.updatedAt` columns, and
 `CosmeticShopItem.cosmeticId` / `UserCosmeticShopPurchases.cosmeticId`. Those last two are
 artefacts of the snapshot's age, not live drift: the packs migration made them nullable on
-2026-08-04 and the database has it. A recapture drops them. The 18 missing columns are
+2026-08-04 and the database has it. A recapture drops them. The 23 missing columns are
 `ModelFlag.sfwOnly`, `UserCosmeticShopPurchases.meta`, `Challenge.judgingEngine`,
 `ChallengeJudge.judgingEngine`, `Collection.collaborationDisabledAt`,
 `CollectionItem.rejectionDetail`, three `Announcement.*`, three `Cosmetic.pHash*`,
-four `UserProfile.sfw*`, and two `app_block_publish_requests.source*`. The single uniqueness finding is
-`ImageResource(modelVersionId, name, imageId)`.
+three `ChatMember.*`, `ChatMessage.deletedAt`, four `UserProfile.sfw*`,
+two `app_block_publish_requests.source*`, and `app_listings.source_repo_url`. The single
+uniqueness finding is `ImageResource(modelVersionId, name, imageId)`.
+
+The three `Announcement.*` are worth knowing about, because they are the state the pending
+tier is NOT describing. `userId`, `coverId` and `profileOnly` are all present in production
+(checked 2026-08-24) and **no committed migration adds any of them** — an applied change with
+no migration, rather than a migration awaiting application. Both look identical here, which is
+why "the migrations directory says so" is not a sound discriminator for phantom declarations
+in either direction: measured on this pair, 3 of 3 columns with no migration were real, and 23
+of 23 models with no `CREATE TABLE` were views.
 
 **Nullability was 246 when this tool shipped.** #3592 then marked the seven `*Rank` families'
 columns optional to match the database and 235 of them went away — a real remediation, and
@@ -240,8 +266,9 @@ it looks like a usable substitute until you enumerate the foreign keys.
 ### A note on `/// @view`
 
 The tool does not read the `/// @view` annotation, and does not need to. Whether a model is
-backed by a view is decided from the catalog — `relkind IN ('r','p')` — so a model on a view
-is skipped because the database says it is a view, not because the schema says so. That
+backed by a view is decided from the catalog — `relkind IN ('v','m')`, captured alongside the
+`('r','p')` tables — so a model on a view is skipped because the database says it is a view,
+not because the schema says so. That
 matters, because the annotation is unreliable: the strip regex in
 `scripts/prisma-migrate-with-views-workaround.mjs` requires `/// @view` to be immediately
 followed by `model`, and 26 of the 32 annotated models have a blank line in between.
@@ -366,7 +393,17 @@ that **already exists**?
 | **enforced** | the columns are in the catalog and the constraint is not       | **fails the check** |
 | **pending**  | the column is not in the catalog, so the schema is ahead of it | warns               |
 
-`missing-column` is always pending by construction — the column's absence _is_ the finding.
+`missing-column` and `missing-table` are always pending by construction — the absence _is_ the
+finding.
+
+🔴 **Pending means the check exits 0, so a green run is not evidence that nothing was found.**
+That is the deliberate consequence of the split above, and it is worth stating plainly because
+it reads exactly like a clean run to anyone checking CI: on `main` today the gate prints 17 new
+pending findings and exits 0. Whether `missing-column` should be promoted out of pending is
+tracked in ClickUp `868ku7w6f`; it is a policy decision, and the blast radius is that those 17
+unbaselined findings go red for everyone until they are triaged. What the gate does do is print
+what it did not enforce, and what it did not look at.
+
 `nullability` and `uniqueness` are always enforced by construction — the differ only emits
 them for columns it found. `missing-foreign-key` is the only kind that can be either, decided
 by looking **every** one of its constrained columns up in the catalog: a composite key with one

--- a/packages/civitai-db-schema/src/schema-drift/__tests__/catalog.test.ts
+++ b/packages/civitai-db-schema/src/schema-drift/__tests__/catalog.test.ts
@@ -15,6 +15,7 @@ function fakeRunner(rows: {
   columns?: unknown[];
   foreignKeys?: unknown[];
   uniqueIndexes?: unknown[];
+  views?: unknown[];
 }): CatalogQueryRunner & { schemas: string[] } {
   const schemas: string[] = [];
   return {
@@ -24,6 +25,10 @@ function fakeRunner(rows: {
       if (text.includes('pg_constraint')) return { rows: (rows.foreignKeys ?? []) as R[] };
       if (text.includes('pg_index')) return { rows: (rows.uniqueIndexes ?? []) as R[] };
       if (text.includes('pg_attribute a')) return { rows: (rows.columns ?? []) as R[] };
+      // Tables and views differ only by their relkind list, so route on that rather than on
+      // the relation names — otherwise the view query falls through and is answered with the
+      // TABLE rows, which reads as a working view capture on a fake that never had one.
+      if (text.includes("'v', 'm'")) return { rows: (rows.views ?? []) as R[] };
       return { rows: (rows.tables ?? []) as R[] };
     },
   };
@@ -33,7 +38,18 @@ describe('readCatalog', () => {
   it('passes the requested schema to every query', async () => {
     const runner = fakeRunner({});
     await readCatalog(runner, 'some_schema');
-    expect(runner.schemas).toEqual(Array(4).fill('some_schema'));
+    expect(runner.schemas).toEqual(Array(5).fill('some_schema'));
+  });
+
+  it('captures views separately from tables', async () => {
+    const catalog = await readCatalog(
+      fakeRunner({
+        tables: [{ table_name: 'Model' }],
+        views: [{ table_name: 'ModelStat' }],
+      })
+    );
+    expect(catalog.tables).toEqual(['Model']);
+    expect(catalog.views).toEqual(['ModelStat']);
   });
 
   it('reads nullability from is_not_null, not a reserved-word alias', async () => {

--- a/packages/civitai-db-schema/src/schema-drift/__tests__/compare.test.ts
+++ b/packages/civitai-db-schema/src/schema-drift/__tests__/compare.test.ts
@@ -310,3 +310,72 @@ describe('assessCoverage', () => {
     expect(assessCoverage(report)).toEqual([]);
   });
 });
+
+/**
+ * A model mapped to something that is not there at all.
+ *
+ * Until the catalog carried a view list, a model on a view and a model on nothing arrived
+ * here as the same thing — "no table of that name" — and both were dropped in silence. That
+ * inverted what the tool is for: an absent COLUMN was at least a pending finding, so the
+ * bigger the divergence the quieter it got. Measured on the 2026-08-03 production snapshot,
+ * appending a model on an invented table produced output byte-identical to a clean run.
+ */
+describe('a declared table that is neither a table nor a view', () => {
+  const parsed = parsePrismaSchema(readFileSync(join(here, 'fixtures/fixture.prisma'), 'utf8'));
+
+  function withViews(views: string[]): DbCatalog {
+    return { ...loadCatalog('catalog-aligned.json'), views };
+  }
+
+  // A missing-table finding is about the whole relation, so it carries no columns and
+  // `ids()` would render it with a trailing dot. Read the table names instead.
+  function missingTables(report: { findings: DriftFinding[] }): string[] {
+    return report.findings.filter((f) => f.kind === 'missing-table').map((f) => f.table);
+  }
+
+  it('is reported as missing-table, and says what went unchecked', () => {
+    const report = compareSchemaToCatalog(parsed, withViews([]));
+    expect(missingTables(report)).toEqual(['report_view']);
+    expect(report.counts.missingTables).toBe(1);
+    const finding = report.findings.find((f) => f.kind === 'missing-table');
+    expect(finding?.actual).toBe('no such table or view');
+    expect(finding?.detail).toMatch(/unchecked/);
+    expect(report.skippedModels.find((s) => s.model === 'ReportView')?.classification).toBe(
+      'absent'
+    );
+  });
+
+  // The pair that makes the assertion above mean something: the SAME model, the SAME
+  // catalog, with the one table named as a view instead. If this also reported a finding,
+  // the check above would be firing on "skipped" rather than on "absent".
+  it('is NOT reported when the same table is a view', () => {
+    const report = compareSchemaToCatalog(parsed, withViews(['report_view']));
+    expect(missingTables(report)).toEqual([]);
+    expect(report.counts.missingTables).toBe(0);
+    expect(report.skippedModels.find((s) => s.model === 'ReportView')?.classification).toBe('view');
+  });
+
+  // 🔴 Do not "simplify" this by defaulting `views` to `[]`. Every catalog captured before
+  // the view query existed has no view list, and reading its absence as "there are no
+  // views" would accuse all 24 view-backed models in the production snapshot of being
+  // missing tables — 24 fabricated findings, in the one direction that looks like progress.
+  it('reports NOTHING when the snapshot cannot say (no view list)', () => {
+    const report = compareSchemaToCatalog(parsed, loadCatalog('catalog-aligned.json'));
+    expect(loadCatalog('catalog-aligned.json').views).toBeUndefined();
+    expect(missingTables(report)).toEqual([]);
+    expect(report.counts.missingTables).toBe(0);
+    expect(report.counts.modelsUnclassified).toBe(1);
+    expect(report.skippedModels.find((s) => s.model === 'ReportView')?.classification).toBe(
+      'unclassified'
+    );
+  });
+
+  // @@ignore is a statement about Prisma's management, not about the database, and it wins
+  // over both. LegacyThing's table IS in the catalog.
+  it('classifies an @@ignore model as ignored, whatever the catalog says', () => {
+    const report = compareSchemaToCatalog(parsed, withViews([]));
+    expect(report.skippedModels.find((s) => s.model === 'LegacyThing')?.classification).toBe(
+      'ignored'
+    );
+  });
+});

--- a/packages/civitai-db-schema/src/schema-drift/__tests__/gate.test.ts
+++ b/packages/civitai-db-schema/src/schema-drift/__tests__/gate.test.ts
@@ -122,6 +122,14 @@ describe('tierOf', () => {
     ).toBe('pending');
   });
 
+  it('treats a missing table as pending, never as blocking', () => {
+    // Same reasoning as a missing column: the table's absence IS the finding, so it can only
+    // mean the schema is ahead of the snapshot. Whether that should stay non-blocking is a
+    // policy call recorded in ClickUp 868ku7w6f; this pins the tier the gate ships with, so
+    // a change to it is a deliberate edit rather than a side effect.
+    expect(tierOf(finding({ kind: 'missing-table', columns: [] }), catalog)).toBe('pending');
+  });
+
   it('treats nullability and uniqueness as enforced', () => {
     expect(tierOf(finding({ kind: 'nullability' }), catalog)).toBe('enforced');
     expect(tierOf(finding({ kind: 'uniqueness' }), catalog)).toBe('enforced');

--- a/packages/civitai-db-schema/src/schema-drift/__tests__/production-snapshot.test.ts
+++ b/packages/civitai-db-schema/src/schema-drift/__tests__/production-snapshot.test.ts
@@ -179,4 +179,53 @@ describe('production catalog snapshot (2026-08-03)', () => {
       expect.arrayContaining(['QuestionRank', 'AnswerRank'])
     );
   });
+
+  /**
+   * How much of the schema this pair says NOTHING about.
+   *
+   * 45 of 316 models take the skip branch and are compared on nothing — no column, no
+   * relation, no unique declaration. `assessCoverage` does not object, correctly: its
+   * threshold is half the relations, and this is 64 of 512. So the number is real, tolerable,
+   * and was invisible in every output the tool produced until it was printed.
+   *
+   * Not pinned exactly, for the reason stated at the top of this file: a model added tomorrow
+   * is on a table this frozen snapshot does not have, so the count only grows.
+   */
+  it('says how much of the schema it compared nothing about', () => {
+    expect(report.skippedModels.length).toBeGreaterThanOrEqual(45);
+    expect(report.skippedModels.length).toBeLessThan(schema.models.length / 2);
+  });
+
+  /**
+   * 🔴 THIS SNAPSHOT CANNOT TELL A VIEW FROM AN ABSENT TABLE, and that is what the zero
+   * below means. It carries no `views` key, so every skip is `unclassified` and
+   * `missing-table` cannot fire at all — the zero is "not measured", not "clean".
+   *
+   * Measured against production on 2026-08-24, those 45 split 24 views / 21 ordinary tables
+   * that exist right now and are missing only because this capture is 21 days old. So a
+   * recapture is what turns this assertion from a zero into 21 findings; if you are here
+   * because this test failed after recapturing, that is the tool working.
+   */
+  it('reports no missing tables, because this snapshot cannot say', () => {
+    expect(catalog.views).toBeUndefined();
+    expect(report.counts.modelsUnclassified).toBe(report.skippedModels.length);
+    expect(report.counts.missingTables).toBe(0);
+    expect(found('missing-table')).toEqual([]);
+  });
+
+  /**
+   * The positive control on the zero above, and the reason it is not vacuous: the same
+   * schema against the same catalog WITH a view list reports the absent tables. Without
+   * this, `missing-table: 0` would be indistinguishable from a differ that never emits one.
+   */
+  it('does report them once the snapshot can say (positive control)', () => {
+    const classified = compareSchemaToCatalog(schema, { ...catalog, views: ['QuestionRank'] });
+    expect(classified.counts.missingTables).toBeGreaterThan(20);
+    expect(classified.counts.modelsUnclassified).toBe(0);
+    // Named as a view, so it is skipped rather than reported — the discriminator is the list,
+    // not the table's name or its shape.
+    expect(
+      classified.findings.filter((f) => f.kind === 'missing-table').map((f) => f.table)
+    ).not.toContain('QuestionRank');
+  });
 });

--- a/packages/civitai-db-schema/src/schema-drift/catalog.ts
+++ b/packages/civitai-db-schema/src/schema-drift/catalog.ts
@@ -34,6 +34,24 @@ const TABLES_SQL = `
 `;
 
 /**
+ * Views and materialised views.
+ *
+ * Captured so the differ can tell a model mapped to a view (correctly unmanaged) from a model
+ * mapped to nothing at all (the largest divergence there is). Without this list both look the
+ * same to the differ and both are dropped in silence — see `classifySkip` in compare.ts.
+ *
+ * A snapshot captured before this query existed has no `views` key, and that is treated as
+ * "could not classify" rather than "there are no views" — reading an absent list as an empty
+ * one would report every view-backed model as a missing table.
+ */
+const VIEWS_SQL = `
+  SELECT c.relname AS table_name
+  FROM pg_catalog.pg_class c
+  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = $1 AND c.relkind IN ('v', 'm')
+`;
+
+/**
  * Nullability.
  *
  * The result column is `is_not_null`, NOT `notnull`. `NOTNULL` is a reserved word in
@@ -156,8 +174,9 @@ export async function readCatalog(
   runner: CatalogQueryRunner,
   dbSchema: string = DEFAULT_DB_SCHEMA
 ): Promise<DbCatalog> {
-  const [tableRows, columnRows, fkRows, uniqueRows] = await Promise.all([
+  const [tableRows, viewRows, columnRows, fkRows, uniqueRows] = await Promise.all([
     runner.query<{ table_name: string }>(TABLES_SQL, [dbSchema]),
+    runner.query<{ table_name: string }>(VIEWS_SQL, [dbSchema]),
     runner.query<{ table_name: string; column_name: string; is_not_null: boolean }>(COLUMNS_SQL, [
       dbSchema,
     ]),
@@ -209,6 +228,7 @@ export async function readCatalog(
 
   return {
     tables: tableRows.rows.map((r) => r.table_name),
+    views: viewRows.rows.map((r) => r.table_name),
     columns,
     foreignKeys,
     uniqueIndexes,

--- a/packages/civitai-db-schema/src/schema-drift/compare.ts
+++ b/packages/civitai-db-schema/src/schema-drift/compare.ts
@@ -6,6 +6,7 @@ import type {
   DriftReport,
   ParsedModel,
   ParsedSchema,
+  SkipClassification,
   SkippedModel,
   SkippedRelation,
 } from './types';
@@ -79,6 +80,8 @@ export function assessCoverage(report: DriftReport): string[] {
 
 interface CatalogIndex {
   tables: Set<string>;
+  /** `null` when the snapshot carries no view list — unclassifiable, not empty. */
+  views: Set<string> | null;
   columns: Map<string, boolean>;
   foreignKeys: Map<string, CatalogForeignKey>;
   uniqueIndexes: Set<string>;
@@ -98,7 +101,13 @@ function indexCatalog(catalog: DbCatalog): CatalogIndex {
   const uniqueIndexes = new Set<string>();
   for (const u of catalog.uniqueIndexes) uniqueIndexes.add(key([u.table, ...u.columns]));
 
-  return { tables: new Set(catalog.tables), columns, foreignKeys, uniqueIndexes };
+  return {
+    tables: new Set(catalog.tables),
+    views: catalog.views ? new Set(catalog.views) : null,
+    columns,
+    foreignKeys,
+    uniqueIndexes,
+  };
 }
 
 function columnFor(model: ParsedModel, fieldName: string): string | null {
@@ -116,6 +125,8 @@ function emptyCounts(): DriftCounts {
     referentialActionUnknown: 0,
     columnsChecked: 0,
     missingColumns: 0,
+    missingTables: 0,
+    modelsUnclassified: 0,
     nullabilityDrifts: 0,
     uniqueDeclarationsChecked: 0,
     uniquenessDrifts: 0,
@@ -141,24 +152,45 @@ export function compareSchemaToCatalog(schema: ParsedSchema, catalog: DbCatalog)
   for (const model of schema.models) {
     counts.declaredRelations += model.relations.length;
 
-    // A model Prisma does not manage, or one backed by a view or a table that no longer
-    // exists, is skipped wholesale. Reporting it would be noise, not drift: there is no
-    // table for a constraint to live on.
-    const unmanaged = model.ignored
-      ? 'model carries @@ignore'
-      : !live.tables.has(model.table)
-      ? `table "${model.table}" is not an ordinary table (view, or absent)`
-      : null;
+    // A model Prisma does not manage, or one backed by a view, is skipped wholesale:
+    // reporting it would be noise, not drift, because there is no table for a constraint to
+    // live on. A model backed by NOTHING is the opposite — it is the largest divergence this
+    // tool can encounter — and until the catalog carried a view list the two arrived here
+    // indistinguishable and were both silently dropped. Measured on the 2026-08-03 snapshot:
+    // 45 of 316 models took this branch, the gate printed none of them, and appending a model
+    // on an invented table produced output byte-identical to a clean run.
+    const skip = classifySkip(model, live);
 
-    if (unmanaged) {
-      skippedModels.push({ model: model.name, table: model.table, reason: unmanaged });
+    if (skip) {
+      skippedModels.push({
+        model: model.name,
+        table: model.table,
+        classification: skip.classification,
+        reason: skip.reason,
+      });
+      if (skip.classification === 'absent') {
+        counts.missingTables += 1;
+        findings.push({
+          kind: 'missing-table',
+          table: model.table,
+          columns: [],
+          model: model.name,
+          declared: `model ${model.name} mapped to table "${model.table}"`,
+          actual: 'no such table or view',
+          detail:
+            `nothing about ${model.name} was compared — its ${model.fields.length} field(s), ` +
+            `${model.relations.length} relation(s) and ${model.uniques.length} unique ` +
+            'declaration(s) are all unchecked',
+        });
+      }
+      if (skip.classification === 'unclassified') counts.modelsUnclassified += 1;
       counts.relationsSkipped += model.relations.length;
       for (const relation of model.relations) {
         skippedRelations.push({
           model: model.name,
           table: model.table,
           field: relation.field,
-          reason: unmanaged,
+          reason: skip.reason,
         });
       }
       continue;
@@ -170,6 +202,27 @@ export function compareSchemaToCatalog(schema: ParsedSchema, catalog: DbCatalog)
   }
 
   return { counts, findings, skippedRelations, skippedModels };
+}
+
+function classifySkip(
+  model: ParsedModel,
+  live: CatalogIndex
+): { classification: SkipClassification; reason: string } | null {
+  if (model.ignored) return { classification: 'ignored', reason: 'model carries @@ignore' };
+  if (live.tables.has(model.table)) return null;
+  if (live.views === null) {
+    return {
+      classification: 'unclassified',
+      reason: `table "${model.table}" is not an ordinary table (view, or absent — this snapshot carries no view list)`,
+    };
+  }
+  if (live.views.has(model.table)) {
+    return { classification: 'view', reason: `"${model.table}" is a view` };
+  }
+  return {
+    classification: 'absent',
+    reason: `"${model.table}" is neither a table nor a view in this catalog`,
+  };
 }
 
 function checkRelations(

--- a/packages/civitai-db-schema/src/schema-drift/gate.ts
+++ b/packages/civitai-db-schema/src/schema-drift/gate.ts
@@ -40,7 +40,14 @@
  * by being structurally unmeasurable rather than by being waved through, and the gate says
  * so on its own line rather than printing a clean zero. See `assertMeasuredSomething`.
  */
-import type { CatalogColumn, DbCatalog, DriftFinding, DriftReport } from './types';
+import type {
+  CatalogColumn,
+  DbCatalog,
+  DriftFinding,
+  DriftReport,
+  SkipClassification,
+  SkippedModel,
+} from './types';
 
 export type GateTier = 'enforced' | 'pending';
 
@@ -93,6 +100,15 @@ export interface GateResult {
   total: number;
   /** Referential-action comparisons the catalog could not support. */
   referentialActionUnknown: number;
+  /**
+   * Models the differ compared nothing about.
+   *
+   * Printed on every run for the same reason `matched of N` is: a verdict that lists no
+   * findings for a model is indistinguishable from one that never looked at it. On the
+   * 2026-08-03 snapshot this is 45 of 316 models, and none of them appeared anywhere in the
+   * gate's output before.
+   */
+  skipped: SkippedModel[];
 }
 
 export interface EscalatedFinding {
@@ -189,8 +205,9 @@ export function tierOf(finding: DriftFinding, catalog: DbCatalog): GateTier {
 function tierWith(finding: DriftFinding, known: Set<string>): GateTier {
   switch (finding.kind) {
     case 'missing-column':
-      // The column's absence IS the finding, so this is always the schema running ahead of
-      // the snapshot. Never blocking.
+    case 'missing-table':
+      // The absence IS the finding, so this is always the schema running ahead of the
+      // snapshot. Never blocking.
       return 'pending';
     case 'nullability':
     case 'uniqueness':
@@ -316,6 +333,7 @@ export function evaluateGate(
     matched,
     total: report.findings.length,
     referentialActionUnknown: report.counts.referentialActionUnknown,
+    skipped: report.skippedModels,
   };
 }
 
@@ -429,9 +447,45 @@ export function snapshotAge(capturedAt: string | null | undefined, now: Date): S
 export const STALE_AFTER_DAYS = 90;
 
 function describe(finding: DriftFinding): string {
-  const where = `${finding.table}.${finding.columns.join('+')}`;
+  // A missing-table finding is about the whole relation, so it carries no columns.
+  const where =
+    finding.columns.length === 0 ? finding.table : `${finding.table}.${finding.columns.join('+')}`;
   const via = finding.field ? ` (${finding.model}.${finding.field})` : ` (${finding.model})`;
   return `${finding.kind}  ${where}${via}\n      declared: ${finding.declared}\n      database: ${finding.actual}`;
+}
+
+/**
+ * What the run did not look at.
+ *
+ * A gate that lists no finding for a model reads exactly like a gate that found it clean.
+ * These lines are the difference, and they are printed unconditionally for the same reason
+ * the snapshot's age is: a coverage hole that is only shown once it crosses a threshold is
+ * one nobody has a feel for when it does.
+ */
+function skippedLines(skipped: readonly SkippedModel[]): string[] {
+  if (skipped.length === 0) return [];
+  const by = (c: SkipClassification) => skipped.filter((s) => s.classification === c);
+  const ignored = by('ignored');
+  const views = by('view');
+  const absent = by('absent');
+  const unclassified = by('unclassified');
+
+  const lines: string[] = ['', `Models NOT compared at all — ${skipped.length}`];
+  if (ignored.length > 0) lines.push(`  @@ignore                 : ${ignored.length}`);
+  if (views.length > 0) lines.push(`  backed by a view         : ${views.length}`);
+  if (absent.length > 0) {
+    lines.push(`  table absent entirely    : ${absent.length}  <- reported as missing-table`);
+  }
+  if (unclassified.length > 0) {
+    lines.push(
+      `  view or absent, unknown  : ${unclassified.length}\n` +
+        '  This snapshot carries no view list, so a model on a view and a model on nothing\n' +
+        '  are indistinguishable here and BOTH are unchecked. Recapture the catalog\n' +
+        '  (`drift --dump-catalog`) to split them.'
+    );
+    for (const s of unclassified) lines.push(`    ${s.model} -> ${s.table}`);
+  }
+  return lines;
 }
 
 export function formatGateResult(
@@ -471,6 +525,8 @@ export function formatGateResult(
       lines.push(`  STALE: ${note}`);
     }
   }
+
+  lines.push(...skippedLines(result.skipped));
 
   if (result.escalated.length > 0) {
     lines.push('');

--- a/packages/civitai-db-schema/src/schema-drift/report.ts
+++ b/packages/civitai-db-schema/src/schema-drift/report.ts
@@ -5,6 +5,7 @@ const KIND_TITLES: Record<DriftKind, string> = {
   'referential-action':
     'Referential-action drift (foreign key present, ON DELETE/UPDATE differs from the schema)',
   'missing-column': 'Missing columns (declared in the schema, absent from the table)',
+  'missing-table': 'Missing tables (a model mapped to something that is neither table nor view)',
   nullability: 'Nullability drift (schema optionality vs column NOT NULL)',
   uniqueness: 'Uniqueness drift (@unique/@@unique with no total unique index)',
 };
@@ -12,12 +13,15 @@ const KIND_TITLES: Record<DriftKind, string> = {
 const KIND_ORDER: DriftKind[] = [
   'missing-foreign-key',
   'referential-action',
+  'missing-table',
   'missing-column',
   'nullability',
   'uniqueness',
 ];
 
 function label(finding: DriftFinding): string {
+  // A missing-table finding is about the whole relation, so it carries no columns.
+  if (finding.columns.length === 0) return finding.table;
   return `${finding.table}.${finding.columns.join('+')}`;
 }
 
@@ -37,6 +41,15 @@ export function formatReport(report: DriftReport, options: { verbose?: boolean }
   if (counts.referentialActionUnknown > 0) {
     lines.push(
       `  action not comparable          : ${counts.referentialActionUnknown} (catalog carried no ON DELETE/UPDATE data)`
+    );
+  }
+  lines.push('');
+  lines.push('Tables');
+  lines.push(`  models NOT compared at all     : ${report.skippedModels.length}`);
+  lines.push(`  MISSING table                  : ${counts.missingTables}`);
+  if (counts.modelsUnclassified > 0) {
+    lines.push(
+      `  view or absent, not classified : ${counts.modelsUnclassified} (this catalog carries no view list)`
     );
   }
   lines.push('');

--- a/packages/civitai-db-schema/src/schema-drift/types.ts
+++ b/packages/civitai-db-schema/src/schema-drift/types.ts
@@ -171,8 +171,21 @@ export interface DbCatalog {
    * without a date that decay is invisible. `snapshotAge` in `gate.ts` is the guard.
    */
   capturedAt?: string;
-  /** Ordinary + partitioned tables. Views are deliberately absent: see the README. */
+  /** Ordinary + partitioned tables. Views are listed separately, in `views`. */
   tables: string[];
+  /**
+   * Views and materialised views, so a model mapped to one can be told apart from a model
+   * mapped to a table that is not there at all.
+   *
+   * ABSENT IS NOT EMPTY, and the differ must not read it as one. Until this field existed
+   * both cases arrived as the same thing — "no table of that name" — and both were skipped
+   * wholesale with the reason "view, or absent". A model on a view is correctly unmanaged;
+   * a model on a nothing is drift, and the larger the drift the quieter the tool got. A
+   * snapshot captured before this field carries `undefined`, which means unclassifiable, and
+   * the differ degrades to the old lumped reason rather than accusing 23 views of being
+   * missing tables.
+   */
+  views?: string[];
   columns: CatalogColumn[];
   foreignKeys: CatalogForeignKey[];
   uniqueIndexes: CatalogUniqueIndex[];
@@ -186,6 +199,7 @@ export type DriftKind =
   | 'missing-foreign-key'
   | 'referential-action'
   | 'missing-column'
+  | 'missing-table'
   | 'nullability'
   | 'uniqueness';
 
@@ -214,9 +228,18 @@ export interface SkippedRelation {
   reason: string;
 }
 
+/**
+ * Why a model was skipped, as a value rather than as prose.
+ *
+ * `unclassified` is the one that matters: it means the snapshot carries no `views` list, so
+ * `view` and `absent` could not be told apart. Counting it as either would be a guess.
+ */
+export type SkipClassification = 'ignored' | 'view' | 'absent' | 'unclassified';
+
 export interface SkippedModel {
   model: string;
   table: string;
+  classification: SkipClassification;
   reason: string;
 }
 
@@ -236,6 +259,10 @@ export interface DriftCounts {
   columnsChecked: number;
   /** Scalar fields whose column is absent from the table entirely. */
   missingColumns: number;
+  /** Models whose table is neither a table nor a view in the catalog. */
+  missingTables: number;
+  /** Models skipped because the snapshot could not say whether the table is a view. */
+  modelsUnclassified: number;
   nullabilityDrifts: number;
   uniqueDeclarationsChecked: number;
   uniquenessDrifts: number;


### PR DESCRIPTION
Appending a model on an invented table — with an `@id`, a foreign key and a `@@unique` — produced output **byte-identical to a clean run** of `drift:gate`. An absent *column* was at least a pending finding; an absent *table* was nothing at all, so the larger the divergence, the quieter the tool got.

Found while working ClickUp `868ku7w6f` and `868ku8a1g`.

## What was wrong

The catalog captured `relkind IN ('r','p')` only, so "backed by a view" and "backed by nothing" reached the differ as the same thing — `!live.tables.has(model.table)` — and both were skipped wholesale under one reason string. Nothing in the gate's output mentioned skipped models either, which is what kept the branch invisible from both ends.

**45 of 316 models take that branch.** Every column, relation and unique declaration on them is unchecked, and none of them appeared anywhere in the gate's output. `assessCoverage` does not object and is right not to: its threshold is half the relations, and this is 64 of 512.

Measured against production on 2026-08-24 with `pg_catalog.pg_class`:

| | |
| --- | --- |
| views (correctly unmanaged) | 24 |
| **ordinary tables that exist in production right now** | **21** |
| genuinely absent | 0 |

The 21 — `Feedback`, the four `Placement*`, both `UserHub*`, `ModelVersionSale*`, `CollectionInvite`, four `UserCosmeticShop*`, `app_collaborators` and the rest — are missing only because the committed snapshot is from 2026-08-03 and they were created after it (`Feedback`'s migration is `20260813180000_feedback`). So snapshot staleness is not only a shrinking of *blocking* coverage, as the README said. It removes whole tables from coverage, silently.

## What this changes

1. `catalog.ts` captures views (`relkind IN ('v','m')`) into a new optional `DbCatalog.views`.
2. `compare.ts` classifies each skip as `ignored` / `view` / `absent` / `unclassified`, and emits a new **`missing-table`** finding for `absent`, saying how many fields, relations and unique declarations went unchecked with it.
3. The gate and the text report print what they skipped, with counts, on **every** run.
4. 🔴 A snapshot with **no `views` key reports nothing and says so.** Reading an absent list as an empty one would accuse all 24 view-backed models of being missing tables — fabricated findings, in the direction that looks like progress. `missing-table` is therefore **inert until the catalog is recaptured**, which the README now states rather than leaving as a reassuring zero.

## What this deliberately does NOT change

**The exit code.** `missing-table` is `pending`, like `missing-column`, so the gate still exits 0 over both. Promoting either tier is a policy decision (ClickUp `868ku7w6f`) with a measured blast radius: 17 unbaselined pending findings on `main` today would turn the check red for everyone until they are triaged. This PR does not make that call — it makes the gate say what it did not enforce and what it did not look at.

No baseline regeneration. The committed baseline is untouched, and the gate's verdict on `main` is unchanged.

## Controls

With a view-carrying catalog built from the live view list:

| | `NEW pending` |
| --- | --- |
| unmutated schema | **0** |
| + one `model TotallyFakeTable` | **1**, naming `missing-table TotallyFakeTable` |

Reverting the classification in `compare.ts` (forcing every absent table back to `unclassified`) reds three tests with assertions naming wrong values rather than timing out:

```
expected [] to deeply equal [ 'report_view' ]
expected 'unclassified' to be 'view'
expected 0 to be greater than 20
Test Files  2 failed | 15 passed (17)
```

## Verification

- `pnpm run typecheck` — OK, 0 type errors
- `pnpm run lint` / `lint:packages` — no new problems; the 6 `lint:packages` errors are pre-existing and in `civitai-buzz` / `civitai-db-queries`
- `pnpm exec prettier --write <the ten files>` — all already formatted
- `pnpm run test:packages:run` — `Test Files 79 passed | 3 skipped (82)`, `Tests 1118 passed | 8 skipped (1126)`, exit 0
- `pnpm run test:unit:run` — `Test Files 1371 passed | 1 skipped (1372)`, `Tests 21523 passed | 27 skipped (21550)`, exit 0
- `blocks.router.workflow.test.ts` collected **358** tests (submodule present)

## Two things found on the way that are not in this diff

- **ClickUp `868ku8a1g` is wrong about `QuestionRank` / `AnswerRank`.** They are not absent from production — both are **views**. And the four Rank tables it proposes cleaning up have **no all-NULL column between them**: ClubRank 42 rows / 16 cols, BountyEntryRank 119,021 / 46, TagRank 388,494 / 31, CollectionRank 1,158,355 / 16, all populated. UserRank's pattern does not generalise.
- **"Does a migration exist for it" is not a sound discriminator for a phantom declaration**, in either direction. 3 of 23 missing-column findings have no migration and all three columns exist in production (`Announcement.userId`, `.coverId`, `.profileOnly` — applied by hand); 23 of 45 skipped models have no `CREATE TABLE` and all 23 are views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
