### PR TITLE
fix(image-feed): Scheduled filter returned every unpublished image you own

### DIFF
--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:3952':
+  'server/services/image.service.ts:3968':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4082':
+  'server/services/image.service.ts:4098':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4792':
+  'server/services/image.service.ts:4810':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5902':
+  'server/services/image.service.ts:5924':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -206,7 +206,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4082')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4098')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/services/__tests__/image-search-scheduled-owner.test.ts
+++ b/src/server/services/__tests__/image-search-scheduled-owner.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The `scheduled` owner carve-out in both Meilisearch filter builders was a bare
+// `userId = me` with no publish predicate, so turning Scheduled on returned every
+// unpublished row the caller owns — drafts, bounty entry uploads, orphans — and not
+// just the scheduled ones (ClickUp 868kt9y1w). A user with 0 scheduled images got 6
+// extra images, all in draft posts.
+//
+// Asserted on the filter string handed to Meili rather than on returned rows, for the
+// same reason as image-search-published-only.test.ts: the string IS the fix, and rows
+// from a fake cannot tell a working filter from an absent one.
+//
+// Mock preamble mirrors image-search-published-only.test.ts — the smallest set of stubs
+// that lets image.service import without booting real infra.
+
+import type * as MeilisearchClient from '~/server/meilisearch/client';
+
+const { fetchDocumentsAbortableMock } = vi.hoisted(() => ({
+  fetchDocumentsAbortableMock: vi.fn(),
+}));
+
+vi.mock('~/server/meilisearch/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof MeilisearchClient>();
+  return {
+    ...actual,
+    metricsSearchClient: {},
+    getMetricsSearchClient: () => ({}),
+    fetchDocumentsAbortable: fetchDocumentsAbortableMock,
+  };
+});
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+import { getImagesFromSearchPreFilter, getImagesFromSearchPostFilter } from '../image.service';
+
+const OWNER = 8675309;
+
+const baseInput = {
+  currentUserId: OWNER,
+  isModerator: false,
+  limit: 20,
+  period: 'AllTime',
+  sort: 'Newest',
+  browsingLevel: 31,
+  include: [] as string[],
+  headers: { src: 'test' },
+};
+
+type SearchArg = Parameters<typeof getImagesFromSearchPreFilter>[0];
+
+// Matches the publication clause whether or not the carve-out is nested, so the
+// broken shape `(publishedAtUnix <= N OR userId = N)` is captured and reported
+// rather than falling out as "no match" — an unreadable failure on revert.
+const PUBLICATION_CLAUSE = /\(publishedAtUnix <= \d+(?: OR (?:\([^)]*\)|[^)]*))?\)/;
+
+const publicationClauseFor = async (
+  fn: typeof getImagesFromSearchPreFilter | typeof getImagesFromSearchPostFilter,
+  input: Record<string, unknown>
+) => {
+  await expect(fn(input as unknown as SearchArg)).rejects.toThrow('stop here');
+  // Not just "called": the BitDex path runs a parallel own-content pass, and if that
+  // shape ever reaches a Meili builder `calls[0]` becomes whichever fired first.
+  expect(fetchDocumentsAbortableMock).toHaveBeenCalledTimes(1);
+  const [, request] = fetchDocumentsAbortableMock.mock.calls[0];
+  const filter = String((request as { filter: string }).filter);
+  const clause = filter.match(PUBLICATION_CLAUSE);
+  // Unconditional on every branch under test, so its absence means the filter moved
+  // and this test is now asserting about nothing.
+  expect(clause, `no publication clause in: ${filter}`).not.toBeNull();
+  return clause![0];
+};
+
+// The snapped timestamp is read back off the clause rather than pinned with fake
+// timers: the builders snap `Date.now()` to the minute themselves, and a test that
+// recomputes it races the minute boundary.
+const snappedNowIn = (clause: string) => {
+  const match = clause.match(/publishedAtUnix <= (\d+)/);
+  expect(match, `no snapped timestamp in: ${clause}`).not.toBeNull();
+  return match![1];
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Thrown so the test stops at the seam it is about. The filter is fully formed on
+  // the recorded arguments by then.
+  fetchDocumentsAbortableMock.mockRejectedValue(new Error('stop here'));
+});
+
+// Three branches, three copies of this carve-out before the fix. Each is exercised
+// separately because a fix applied to one leaves the others serving drafts on
+// whichever path the caller reaches.
+describe.each([
+  [
+    'getImagesFromSearchPreFilter, general feed',
+    getImagesFromSearchPreFilter,
+    {} as Record<string, unknown>,
+  ],
+  [
+    'getImagesFromSearchPostFilter, general feed',
+    getImagesFromSearchPostFilter,
+    {} as Record<string, unknown>,
+  ],
+  [
+    // `userId === currentUserId` is the own-profile branch, which exists only in the
+    // post-filter builder and is the surface the bug was reported on.
+    'getImagesFromSearchPostFilter, own profile',
+    getImagesFromSearchPostFilter,
+    { userId: OWNER } as Record<string, unknown>,
+  ],
+])('%s scheduled owner carve-out', (_name, fn, extraInput) => {
+  it('carves out only own content whose publish date is still in the future', async () => {
+    const clause = await publicationClauseFor(fn, {
+      ...baseInput,
+      ...extraInput,
+      scheduled: true,
+    });
+    const snappedNow = snappedNowIn(clause);
+
+    expect(clause).toBe(
+      `(publishedAtUnix <= ${snappedNow} OR (userId = ${OWNER} AND publishedAtUnix > ${snappedNow}))`
+    );
+  });
+
+  it('does not carve out own content at all without the scheduled opt-in', async () => {
+    // The control. Without it the assertion above passes against a build that emits
+    // no carve-out on any input, which would be a different bug — an owner losing
+    // sight of their own scheduled posts entirely — rather than this fix.
+    const clause = await publicationClauseFor(fn, { ...baseInput, ...extraInput });
+    const snappedNow = snappedNowIn(clause);
+
+    expect(clause).toBe(`(publishedAtUnix <= ${snappedNow})`);
+  });
+});

--- a/src/server/services/__tests__/image-search-scheduled-owner.test.ts
+++ b/src/server/services/__tests__/image-search-scheduled-owner.test.ts
@@ -96,6 +96,12 @@ const publicationClauseFor = async (
 // The snapped timestamp is read back off the clause rather than pinned with fake
 // timers: the builders snap `Date.now()` to the minute themselves, and a test that
 // recomputes it races the minute boundary.
+//
+// This pins that the two arms carry the SAME timestamp — a helper computing its own
+// `Date.now()` fails the `toBe` below. It cannot see the value or the unit, so a
+// switch from milliseconds to seconds keeps every case green. The index writes
+// `publishedAtUnix` in milliseconds (`metrics-images.search-index.ts`), and nothing
+// here would catch that changing.
 const snappedNowIn = (clause: string) => {
   const match = clause.match(/publishedAtUnix <= (\d+)/);
   expect(match, `no snapped timestamp in: ${clause}`).not.toBeNull();
@@ -125,7 +131,11 @@ describe.each([
   ],
   [
     // `userId === currentUserId` is the own-profile branch, which exists only in the
-    // post-filter builder and is the surface the bug was reported on.
+    // post-filter builder and is the surface the bug was reported on. It does reach
+    // that branch and does catch a revert of it — but all three branches emit a
+    // byte-identical clause, so these assertions cannot tell you WHICH branch ran.
+    // Deleting the own-profile branch and falling through to the general one would
+    // keep every case here green.
     'getImagesFromSearchPostFilter, own profile',
     getImagesFromSearchPostFilter,
     { userId: OWNER } as Record<string, unknown>,

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2980,6 +2980,22 @@ export const makeMeiliImageSearchFilter = (
 ): MeiliImageFilter => {
   return `${field} ${criteria}`;
 };
+/**
+ * Owner carve-out for a `scheduled` request: own content whose publish date is
+ * still in the future.
+ *
+ * The publish predicate is the whole point. A bare `userId = me` admits every
+ * unpublished row the caller owns — drafts, bounty entry uploads, orphans — so
+ * turning Scheduled on filled a creator's own profile with work they never
+ * posted (ClickUp 868kt9y1w). Shared rather than inlined because all three
+ * call sites had their own copy and only one of them would have been fixed.
+ */
+const makeOwnScheduledMeiliFilter = (currentUserId: number, snappedNow: number) =>
+  `(${makeMeiliImageSearchFilter('userId', `= ${currentUserId}`)} AND ${makeMeiliImageSearchFilter(
+    'publishedAtUnix',
+    `> ${snappedNow}`
+  )})`;
+
 type MeiliImageSort = `${MetricsImageSortableAttribute}:${'asc' | 'desc'}`;
 export const makeMeiliImageSearchSort = (
   field: MetricsImageSortableAttribute,
@@ -4632,9 +4648,11 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     // their own scheduled/unpublished content pinned to feeds. The `scheduled`
     // flag is opt-in: when set, OR-in the owner carve-out so the user-own
     // second pass surfaces own scheduled hits.
-    const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
+    const publishedFilters: string[] = [
+      makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`),
+    ];
     if (currentUserId && scheduled) {
-      publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
+      publishedFilters.push(makeOwnScheduledMeiliFilter(currentUserId, snappedNow));
     }
     filters.push(`(${publishedFilters.join(' OR ')})`);
   }
@@ -5559,21 +5577,25 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
       filters.push(`(${publishedFilters.join(' OR ')})`);
     }
   } else if (userId) {
-    const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
+    const publishedFilters: string[] = [
+      makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`),
+    ];
     // For own user's profile view, only surface own scheduled content when the
     // caller explicitly opted in via the `scheduled` flag. Without opt-in, the
     // strict published filter applies even to own profile.
     if (currentUserId && userId === currentUserId && scheduled) {
-      publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
+      publishedFilters.push(makeOwnScheduledMeiliFilter(currentUserId, snappedNow));
     }
     filters.push(`(${publishedFilters.join(' OR ')})`);
   } else {
     // General feed queries - strict published filter for caching by default.
     // When `scheduled` is opt-in, OR-in the owner carve-out so own scheduled
     // hits surface in the main feed.
-    const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
+    const publishedFilters: string[] = [
+      makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`),
+    ];
     if (currentUserId && scheduled) {
-      publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
+      publishedFilters.push(makeOwnScheduledMeiliFilter(currentUserId, snappedNow));
     }
     filters.push(`(${publishedFilters.join(' OR ')})`);
   }
@@ -6575,9 +6597,7 @@ export const getImagesForModelVersion = async ({
       i.poi,
       t."modelVersionId",
       ${Prisma.raw(
-        include.includes('meta')
-          ? 'CASE WHEN i."hideMeta" THEN NULL ELSE i.meta END AS meta,'
-          : ''
+        include.includes('meta') ? 'CASE WHEN i."hideMeta" THEN NULL ELSE i.meta END AS meta,' : ''
       )}
       p."availability",
       (


### PR DESCRIPTION
Closes ClickUp [868kt9y1w](https://app.clickup.com/t/868kt9y1w).

## The bug

The `scheduled` owner carve-out in both Meilisearch image filter builders was a bare `userId = <me>` with no publish predicate:

```
(publishedAtUnix <= now OR userId = me)
```

That second clause matches everything the caller owns in the index regardless of state, so turning the **Scheduled** filter on returned every unpublished image you own — drafts, bounty entry uploads, storage posts, orphans — not just the scheduled ones. A creator saw a gallery full of work they never posted and reasonably concluded something was broken.

The comment above it said "only surface own scheduled content". The code did not do that.

Owner-only, so nothing leaked to other users.

Reported by Zlia (2133559) via Discord DM 2026-08-17, and reproduced on a second account with **0 scheduled images**: 37 results with the filter off, 43 with it on. All 6 extras were in draft posts (134005479, 133843513, 133583877, 133583889, 132917296, 132755872) — none scheduled, none with a bounty connection.

## The fix

```
(publishedAtUnix <= now OR (userId = me AND publishedAtUnix > now))
```

`publishedAtUnix > now` is the same predicate the moderator branch directly above already uses for `scheduled`, so the two branches now agree on what "scheduled" means.

**Three sites, one helper.** All three carried their own copy of this clause and a fix applied to one would have left the others serving drafts on whichever path the caller reached:

- `getImagesFromSearchPreFilter` — general-feed branch
- `getImagesFromSearchPostFilter` — own-profile branch (`userId === currentUserId`), the surface the bug was reported on
- `getImagesFromSearchPostFilter` — general-feed branch, which put all your unpublished content into the **main** feed rather than just your profile

They now share `makeOwnScheduledMeiliFilter`. That duplication is [868kuaf2k](https://app.clickup.com/t/868kuaf2k) — the two builders are 506 of 672 lines byte-identical — and this PR does not attempt that consolidation, it just declines to add a fourth copy.

**Not touched:** the moderator branches above these. Their carve-out is deliberate and governed by `publishedOnly` (#4148).

## Verification

`src/server/services/__tests__/image-search-scheduled-owner.test.ts` asserts the **exact filter string** handed to Meili rather than returned rows, for the same reason as its sibling `image-search-published-only.test.ts`: the string *is* the fix, and rows from a fake cannot tell a working filter from an absent one.

**The control — reverting the fix fails 3 of 6 with the wrong value named**, not with a timeout or a hang:

```
AssertionError: expected '(publishedAtUnix <= 1787596320000 OR …' to be '(publishedAtUnix <= 1787596320000 OR …'
Expected: "(publishedAtUnix <= 1787596320000 OR (userId = 8675309 AND publishedAtUnix > 1787596320000))"
Received: "(publishedAtUnix <= 1787596320000 OR userId = 8675309)"

Test Files  1 failed (1)
     Tests  3 failed | 3 passed (6)
```

The 3 no-opt-in control tests keep passing on revert, so they are not merely co-failing with their neighbours. Their job is to prove the assertion above can distinguish *this* fix from a build that emits no carve-out at all — which would be a different bug (an owner losing sight of their own scheduled posts entirely), not a fix.

Full unit suite, green and accounting for every file:

```
Test Files  1372 passed | 1 skipped (1373)
     Tests  21529 passed | 27 skipped (21556)
```

`blocks.router.workflow.test.ts` collected **358** tests, so the submodule was initialised and that suite really ran. `pnpm run typecheck` reports 0 errors. The 3 eslint errors in `image.service.ts` are at lines 204 / 4754 / 6661 and are pre-existing — none is in this diff.

## Why `flipt-eval-context.test.ts` is in the diff

Its `ENTITY_WITHOUT_CONTEXT_LEDGER` pins Flipt call sites by `file:LINE`, and inserting the shared helper shifted four `image.service.ts` rows (+16, +16, +18, +22 — the deltas differ because each edit only moves what is below it). Line numbers updated; **no Flipt behaviour changed**, and the gate is back to 12/12.

Worth knowing for anyone editing this file: that gate fails in a file your diff never touched, which reads like a broken `main`. Run it before the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Re-verified after rebase (2026-08-24)

This branch went `CONFLICTING / DIRTY` while open: `main` moved 5.1.36 → 5.1.39 and shifted the four `image.service.ts` ledger rows in `flipt-eval-context.test.ts` that this PR also edits. **A conflicted PR gets no CI in this repo**, so it was unverifiable, not merely unmergeable — and every number in the description above was measured against 5.1.36.

Rebased onto current `main`. The conflict was in the Flipt ledger only; `image.service.ts` auto-merged. Resolved by taking **main's** numbers and re-deriving the offsets from what the gate itself printed rather than editing them by hand:

```
ledger: 3952  4082  4792  5902
actual: 3968  4098  4810  5924
```

Deltas +16 / +16 / +18 / +22, matching the original insertion pattern — which is what shows the resolution is correct rather than merely green.

**Current SHA is `52df67dc42`.** The previously reviewed `9640aff4b8` no longer exists; a reviewer should re-read against the new one.

Suite numbers above are superseded by this run on the rebased branch:

```
Test Files  1389 passed | 1 skipped (1390)
Tests       21780 passed | 27 skipped (21807)
```

1389 + 1 = 1390, so every file is accounted for. Zero `ELIFECYCLE`, exit 0 read from the printed line rather than from the harness notification (which has reported exit 0 over a failing run four times today).

Note for anyone reading a red run on this branch: `user-payment-configuration.tipalti-status.test.ts` and `home-block-fetch-sizing.test.ts` fail 7 tests intermittently under full-suite parallelism and pass `39 passed (39)` when run alone. Confirmed **pre-existing** — a full suite on unmodified `origin/main` in the same worktree produced the identical 2 files / 7 tests. They happened to pass in the run quoted above.
