### PR TITLE
fix(buzz): a perkless grant must not strip a paid member's multiplier, and a string forId must not vanish

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260824180000_referral_grant_tier_multipliers/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260824180000_referral_grant_tier_multipliers/migration.sql
@@ -9,6 +9,13 @@
 -- stipend and no badge. Only the two advertised multipliers are added.
 --
 -- Every numeric value in Product.metadata is stored Stripe-style, as a string.
+--
+-- 🔴 AFTER APPLYING: purge the multiplier cache. userMultipliersCache has a 1-day TTL and is only
+-- busted per user; nothing invalidates it when a Product changes. Without a purge, grant holders
+-- keep the perkless multiplier for up to 24h at whatever rate their entries happen to expire:
+--
+--   purge the 'packed:caches:multipliers-for-user' prefix (REDIS_KEYS.CACHES.MULTIPLIERS_FOR_USER)
+--   with the cache-purge skill, then POST /api/admin/refresh-user-sessions
 
 UPDATE "Product"
 SET metadata = metadata || '{"rewardsMultiplier":"1.5","purchasesMultiplier":"1.05"}'::jsonb

--- a/packages/civitai-db-schema/prisma/migrations/20260824180000_referral_grant_tier_multipliers/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260824180000_referral_grant_tier_multipliers/migration.sql
@@ -14,8 +14,20 @@
 -- busted per user; nothing invalidates it when a Product changes. Without a purge, grant holders
 -- keep the perkless multiplier for up to 24h at whatever rate their entries happen to expire:
 --
---   purge the 'packed:caches:multipliers-for-user' prefix (REDIS_KEYS.CACHES.MULTIPLIERS_FOR_USER)
---   with the cache-purge skill, then POST /api/admin/refresh-user-sessions
+-- Confirm 3 rows were updated. A 0-row UPDATE reports success, and these ids exist only in the
+-- database — nothing in src/ references them, so a typo has nothing to fail against:
+--
+--   SELECT id, metadata->>'rewardsMultiplier', metadata->>'purchasesMultiplier'
+--   FROM "Product" WHERE metadata->>'referralGrantable' = 'true';
+--
+-- Then bust the cache for the affected users only. There were 32 active referral grants at the
+-- time of writing, so 32 exact DELs on 'packed:caches:multipliers-for-user:<userId>'
+-- (REDIS_KEYS.CACHES.MULTIPLIERS_FOR_USER) beat a cluster-wide SCAN of the whole prefix:
+--
+--   SELECT "userId" FROM "CustomerSubscription" cs JOIN "Product" p ON p.id = cs."productId"
+--   WHERE p.metadata->>'referralGrantable' = 'true' AND cs.status IN ('active','trialing');
+--
+-- then POST /api/admin/refresh-user-sessions for those ids.
 
 UPDATE "Product"
 SET metadata = metadata || '{"rewardsMultiplier":"1.5","purchasesMultiplier":"1.05"}'::jsonb

--- a/packages/civitai-db-schema/prisma/migrations/20260824180000_referral_grant_tier_multipliers/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260824180000_referral_grant_tier_multipliers/migration.sql
@@ -1,0 +1,23 @@
+-- Referral grants deliver the tier multipliers the referral dashboard advertises.
+--
+-- The three `civitai-referral-*` placeholder products carried no multipliers, so a redeemed
+-- grant delivered neither the "1.5x daily rewards" nor the "1.05x purchases" its own
+-- redemption card promises (ClickUp 868kv5az9). Decision by Justin, 2026-08-24: make the
+-- product match the copy rather than change the copy.
+--
+-- `monthlyBuzz: 0` and `badgeType: "none"` stay as they are — the grant still conveys no Buzz
+-- stipend and no badge. Only the two advertised multipliers are added.
+--
+-- Every numeric value in Product.metadata is stored Stripe-style, as a string.
+
+UPDATE "Product"
+SET metadata = metadata || '{"rewardsMultiplier":"1.5","purchasesMultiplier":"1.05"}'::jsonb
+WHERE id = 'civitai-referral-bronze';
+
+UPDATE "Product"
+SET metadata = metadata || '{"rewardsMultiplier":"2.5","purchasesMultiplier":"1.10"}'::jsonb
+WHERE id = 'civitai-referral-silver';
+
+UPDATE "Product"
+SET metadata = metadata || '{"rewardsMultiplier":"4","purchasesMultiplier":"1.20"}'::jsonb
+WHERE id = 'civitai-referral-gold';

--- a/src/server/clickhouse/migrations/2026-08-24-buzz-events-multiplier-width.sql
+++ b/src/server/clickhouse/migrations/2026-08-24-buzz-events-multiplier-width.sql
@@ -1,0 +1,38 @@
+-- buzzEvents.multiplier cannot hold the value the app computes.
+--
+-- The column is Decimal(3, 2) — 3 digits total, 2 after the point — so its ceiling is 9.99.
+-- The stored value is the tier multiplier TIMES the global bonus event, and gold's 4 against
+-- MAX_GLOBAL_BONUS of 5 is 20. Inserts run async_insert=1 with wait_for_async_insert=0, so a row
+-- ClickHouse cannot parse is dropped server-side while the app sees success.
+--
+-- This is a payout value, not an audit one: for the four processable rewards
+-- (imagePostedToModel, goodContent, collectedContent, reportAccepted) process-rewards reads the
+-- multiplier back out and sendAward pays awardAmount * multiplier from it.
+--
+-- Not currently reachable — the live bonus event is 2x, so gold members write 8, and the maximum
+-- across 90 days is exactly 8 with no row at or above 9. Any bonus event above 2.5x tips it over.
+--
+-- Widening to Decimal(4, 2) raises the ceiling to 99.99. Both are backed by Decimal32, so the
+-- underlying storage width does not change. Same two decimal places; the extra room is entirely
+-- to the left of the point.
+--
+-- Blast radius measured 2026-08-24: buzzEvents is 1,456,442,533 rows / 13.61 GiB across 63 active
+-- parts, but the multiplier column itself is 22.03 MiB on disk. NOTHING else in the database
+-- references buzzEvents — zero views and zero materialized views — so there is no MODIFY QUERY to
+-- pair with this.
+
+ALTER TABLE buzzEvents MODIFY COLUMN multiplier Decimal(4, 2) DEFAULT 1;
+
+-- Verify the type changed. This must return Decimal(4, 2):
+--
+--   SELECT type FROM system.columns
+--   WHERE database = 'default' AND table = 'buzzEvents' AND name = 'multiplier';
+--
+-- If ClickHouse schedules a mutation rather than treating this as metadata-only, watch it finish
+-- before considering the change applied:
+--
+--   SELECT command, parts_to_do, is_done, latest_fail_reason
+--   FROM system.mutations WHERE table = 'buzzEvents' AND NOT is_done;
+--
+-- The clamp in src/server/rewards/base.reward.ts stays afterwards as a backstop under the new
+-- ceiling, and keeps its log line. Do not remove it with this.

--- a/src/server/clickhouse/migrations/2026-08-24-buzz-events-multiplier-width.sql
+++ b/src/server/clickhouse/migrations/2026-08-24-buzz-events-multiplier-width.sql
@@ -1,38 +1,79 @@
 -- buzzEvents.multiplier cannot hold the value the app computes.
 --
--- The column is Decimal(3, 2) — 3 digits total, 2 after the point — so its ceiling is 9.99.
--- The stored value is the tier multiplier TIMES the global bonus event, and gold's 4 against
+-- The column is Decimal(3, 2) — 3 digits total, 2 after the point — so its ceiling is 9.99. The
+-- stored value is the tier multiplier TIMES the global bonus event, and gold's 4 against
 -- MAX_GLOBAL_BONUS of 5 is 20. Inserts run async_insert=1 with wait_for_async_insert=0, so a row
 -- ClickHouse cannot parse is dropped server-side while the app sees success.
 --
--- This is a payout value, not an audit one: for the four processable rewards
--- (imagePostedToModel, goodContent, collectedContent, reportAccepted) process-rewards reads the
--- multiplier back out and sendAward pays awardAmount * multiplier from it.
+-- This is a payout value, not an audit one: for the four processable rewards (imagePostedToModel,
+-- goodContent, collectedContent, reportAccepted) process-rewards reads the multiplier back out and
+-- sendAward pays awardAmount * multiplier from it.
 --
--- Not currently reachable — the live bonus event is 2x, so gold members write 8, and the maximum
--- across 90 days is exactly 8 with no row at or above 9. Any bonus event above 2.5x tips it over.
+-- Not reachable today. The live bonus event is 2x, so gold members write 8, and the maximum across
+-- 90 days is exactly 8 with no row at or above 9. Any bonus event above 2.5x tips it over.
 --
--- Widening to Decimal(4, 2) raises the ceiling to 99.99. Both are backed by Decimal32, so the
--- underlying storage width does not change. Same two decimal places; the extra room is entirely
--- to the left of the point.
+-- ⚠️ THERE IS NO REHEARSAL ENVIRONMENT. Dev and preview both write to the production ClickHouse
+-- cluster. Every step below runs once, in production, with no dry run available.
 --
--- Blast radius measured 2026-08-24: buzzEvents is 1,456,442,533 rows / 13.61 GiB across 63 active
--- parts, but the multiplier column itself is 22.03 MiB on disk. NOTHING else in the database
--- references buzzEvents — zero views and zero materialized views — so there is no MODIFY QUERY to
--- pair with this.
+-- Measured 2026-08-24:
+--   buzzEvents         1,456,460,568 rows, 13.61 GiB on disk, 61 active parts, 36 partitions
+--   multiplier column  22.03 MiB compressed, 5.13 GiB UNCOMPRESSED  <-- the mutation rewrites this
+--   views or materialized views referencing buzzEvents: 0
+--     (control: the same query with the filter removed finds 57 views in the database, so the
+--      zero is a finding rather than a broken filter — there is no MODIFY QUERY to pair with this)
+--
+-- WHY NOT `MODIFY COLUMN`: because this table records someone doing exactly this before, and they
+-- chose otherwise. system.mutations still holds it:
+--   2024-04-04 06:01  UPDATE multiplier = CAST(multiplier_old, 'Decimal(3, 2)') WHERE 1 = 1
+--   2024-04-04 06:41  DROP COLUMN multiplier_old
+-- Three reversible steps with an observable state between each, instead of one in-place rewrite
+-- that cannot be inspected halfway through. Their reasoning is not recorded but their choice is,
+-- and it means nobody has to know what KILL MUTATION does to a half-finished rewrite — there is
+-- never a half-finished rewrite. Until the final DROP, the original column is intact and
+-- authoritative, so the worst case at every step is a wasted rewrite rather than a damaged ledger.
 
-ALTER TABLE buzzEvents MODIFY COLUMN multiplier Decimal(4, 2) DEFAULT 1;
+-- STEP 1 — rename and add, in ONE statement.
+--
+-- 🔴 Do not split this into two. Between a bare RENAME and a bare ADD there is no column named
+-- `multiplier`, and an insert naming it would fail to parse — which, on the async path, is a
+-- silently dropped row. One statement, no window.
+--
+-- ⚠️ VERIFY BEFORE RUNNING: `DEFAULT multiplier_old` is what makes unmutated parts read correctly
+-- while step 3 is still running. Without it the new column reads its own default of 1 for every
+-- row the cast has not reached yet, and process-rewards would pay those pending rows at 1x — an
+-- underpay caused by the migration itself. Confirm ClickHouse accepts a DEFAULT expression
+-- referencing another column here; if it does not, step 3 must complete before any pending row is
+-- processed, and this needs a quiet window rather than a checkpoint.
 
--- Verify the type changed. This must return Decimal(4, 2):
---
---   SELECT type FROM system.columns
---   WHERE database = 'default' AND table = 'buzzEvents' AND name = 'multiplier';
---
--- If ClickHouse schedules a mutation rather than treating this as metadata-only, watch it finish
--- before considering the change applied:
---
+ALTER TABLE buzzEvents
+  RENAME COLUMN multiplier TO multiplier_old,
+  ADD COLUMN multiplier Decimal(4, 2) DEFAULT multiplier_old;
+
+-- CHECKPOINT 1 — both columns present, new one reading the old values:
+--   SELECT name, type, default_expression FROM system.columns
+--   WHERE database = 'default' AND table = 'buzzEvents' AND name LIKE 'multiplier%';
+--   SELECT countIf(multiplier != multiplier_old) FROM buzzEvents WHERE time > now() - INTERVAL 1 DAY;
+-- The second must be 0. If it is not, STOP — do not run step 2.
+
+-- STEP 2 — materialise the values. This is the mutation, and the only expensive step:
+-- 1.4 billion rows, 5.13 GiB uncompressed.
+
+ALTER TABLE buzzEvents UPDATE multiplier = CAST(multiplier_old, 'Decimal(4, 2)') WHERE 1 = 1;
+
+-- CHECKPOINT 2 — watch it to completion. Do not treat the ALTER returning as done:
 --   SELECT command, parts_to_do, is_done, latest_fail_reason
 --   FROM system.mutations WHERE table = 'buzzEvents' AND NOT is_done;
 --
--- The clamp in src/server/rewards/base.reward.ts stays afterwards as a backstop under the new
--- ceiling, and keeps its log line. Do not remove it with this.
+-- If it goes wrong: KILL MUTATION WHERE table = 'buzzEvents' AND NOT is_done, then drop the new
+-- column and start over. `multiplier_old` still holds every value, so nothing is lost.
+
+-- STEP 3 — only once checkpoint 2 shows is_done = 1 and the values agree.
+--
+-- 🔴 Not the same day. Leaving `multiplier_old` in place for a while costs 22 MiB and is the only
+-- rollback that exists after this runs.
+
+-- ALTER TABLE buzzEvents DROP COLUMN multiplier_old;
+
+-- AFTERWARDS: the clamp in src/server/rewards/base.reward.ts stays as a backstop under the new
+-- ceiling, and keeps its log line. It is applied by hand, so the code has to remain correct on a
+-- database where this has not been run.

--- a/src/server/clickhouse/migrations/2026-08-24-buzz-events-multiplier-width.sql
+++ b/src/server/clickhouse/migrations/2026-08-24-buzz-events-multiplier-width.sql
@@ -1,3 +1,17 @@
+-- ⛔ NOT BEING APPLIED. Justin's call, 2026-08-24: the ceiling is not currently reachable, so this
+-- is not worth a production mutation on a 1.4-billion-row table. It is kept as the written record
+-- of the numbers, the hazards and the precedent, so that whoever needs it next does not re-derive
+-- any of it.
+--
+-- 🔴 WHAT THAT MEANS FOR THE CODE: the clamp in src/server/rewards/base.reward.ts is no longer a
+-- backstop, it is the ONLY guard. CLICKHOUSE_MAX_MULTIPLIER = 9.99 is correct and must stay
+-- correct — it has to equal the ceiling of the deployed column, which this file does not change.
+-- Do not raise it while this is unapplied: a value the column cannot hold is a row ClickHouse
+-- drops server-side while sendAward pays anyway.
+--
+-- Reopen this if a global bonus event above 2.5x is ever scheduled — see ClickUp 868kw9m36, which
+-- carries that trigger.
+
 -- buzzEvents.multiplier cannot hold the value the app computes.
 --
 -- The column is Decimal(3, 2) — 3 digits total, 2 after the point — so its ceiling is 9.99. The
@@ -74,6 +88,16 @@ ALTER TABLE buzzEvents UPDATE multiplier = CAST(multiplier_old, 'Decimal(4, 2)')
 
 -- ALTER TABLE buzzEvents DROP COLUMN multiplier_old;
 
--- AFTERWARDS: the clamp in src/server/rewards/base.reward.ts stays as a backstop under the new
--- ceiling, and keeps its log line. It is applied by hand, so the code has to remain correct on a
--- database where this has not been run.
+-- 🔴 AFTERWARDS — THIS MIGRATION BUYS NOTHING WITHOUT IT.
+--
+-- CLICKHOUSE_MAX_MULTIPLIER in src/server/rewards/base.reward.ts is 9.99 and clamps to it, and
+-- that clamp is what pays: process-rewards reads the multiplier back out and sendAward computes
+-- awardAmount * multiplier from it. Widening the column and leaving the constant alone means a
+-- 1.4-billion-row rewrite that changes nothing — gold members are still paid half during a 5x
+-- bonus event, just against a column with room to spare.
+--
+-- Raise it to 99.99 and deploy, IN THAT ORDER, after step 2 completes. Not before: the constant
+-- has to match the column that is actually deployed, and this file is applied by hand.
+--
+-- Keep the clamp itself. It is the backstop, and the code must stay correct on a database where
+-- this has not been run.

--- a/src/server/redis/__tests__/user-multipliers.test.ts
+++ b/src/server/redis/__tests__/user-multipliers.test.ts
@@ -117,7 +117,9 @@ describe('foldUserMultipliers', () => {
 describe('userMultipliersCache wiring', () => {
   const source = fs.readFileSync(path.join(process.cwd(), 'src/server/redis/caches.ts'), 'utf-8');
   const start = source.indexOf('export const userMultipliersCache');
-  const end = source.indexOf('type UserBasicLookup');
+  // The next declaration, not a named neighbour: anchoring on an unrelated symbol reds this test
+  // when that symbol is renamed, which says nothing about the multiplier lookup.
+  const end = source.indexOf('export const ', start + 1);
   const lookup = source.slice(start, end);
 
   it('reads the source it is meant to read', () => {
@@ -128,8 +130,30 @@ describe('userMultipliersCache wiring', () => {
     expect(lookup).toContain('MULTIPLIERS_FOR_USER');
   });
 
-  it('resolves multipliers through foldUserMultipliers, not a single winning row', () => {
+  // 🔴 A TRIPWIRE, NOT COVERAGE. The bug (ClickUp 868kv4q7t) lives in the SQL: the old query used
+  // ROW_NUMBER() to pick ONE winning subscription row, so a perkless referral grant could shadow a
+  // paid membership. `foldUserMultipliers` only helps if the query hands it EVERY active row, and
+  // no unit test can see that — it would take a database.
+  //
+  // So this lists the ways single-winner selection gets reintroduced. It was written after the
+  // first version, which pinned the literal string 'ROW_NUMBER()', passed a mutation to
+  // `SELECT DISTINCT ON (u.id)` that restored the bug completely: 11 of 11 green, exit 0.
+  // If you add a case, add it because you found another way through, not to be thorough.
+  const singleWinnerIdioms = [
+    /row_number\s*\(/i,
+    /distinct\s+on/i,
+    /\blimit\s+1\b/i,
+    /\blateral\b/i,
+  ];
+
+  it.each(singleWinnerIdioms.map((re) => [re.source, re] as const))(
+    'does not reintroduce single-winner selection via %s',
+    (_label, re) => {
+      expect(re.test(lookup)).toBe(false);
+    }
+  );
+
+  it('resolves multipliers through foldUserMultipliers', () => {
     expect(lookup).toContain('foldUserMultipliers(');
-    expect(lookup).not.toContain('ROW_NUMBER()');
   });
 });

--- a/src/server/redis/__tests__/user-multipliers.test.ts
+++ b/src/server/redis/__tests__/user-multipliers.test.ts
@@ -1,0 +1,116 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import type { UserMultiplierRow } from '~/server/redis/user-multipliers';
+import { foldUserMultipliers } from '~/server/redis/user-multipliers';
+
+const paidBronze = (userId: number): UserMultiplierRow => ({
+  userId,
+  rewardsIneligible: false,
+  rewardsMultiplier: 1.5,
+  purchasesMultiplier: 1.05,
+});
+
+const referralGrant = (userId: number): UserMultiplierRow => ({
+  userId,
+  rewardsIneligible: false,
+  rewardsMultiplier: null,
+  purchasesMultiplier: null,
+});
+
+const buzzPurchaseGrant = (userId: number): UserMultiplierRow => ({
+  userId,
+  rewardsIneligible: false,
+  rewardsMultiplier: 1,
+  purchasesMultiplier: 1,
+});
+
+describe('foldUserMultipliers', () => {
+  it('a perkless referral grant must not shadow a paid membership', () => {
+    // Do not "simplify" this back to picking one winning row. A referral grant conveys a tier and
+    // no perks, and out-ranked the paid row on the currentPeriodEnd tiebreak (ClickUp 868kv4q7t).
+    const result = foldUserMultipliers([referralGrant(1), paidBronze(1)]);
+
+    expect(result[1].rewardsMultiplier).toBe(1.5);
+    expect(result[1].purchasesMultiplier).toBe(1.05);
+  });
+
+  it('is order-independent, because row order is not part of the contract', () => {
+    const result = foldUserMultipliers([paidBronze(2), referralGrant(2)]);
+
+    expect(result[2].rewardsMultiplier).toBe(1.5);
+    expect(result[2].purchasesMultiplier).toBe(1.05);
+  });
+
+  it('a civitai-buzz-* grant carrying an explicit 1 must not shadow it either', () => {
+    const result = foldUserMultipliers([buzzPurchaseGrant(3), paidBronze(3)]);
+
+    expect(result[3].rewardsMultiplier).toBe(1.5);
+    expect(result[3].purchasesMultiplier).toBe(1.05);
+  });
+
+  it('falls back to 1 when the only active row carries no perks', () => {
+    const result = foldUserMultipliers([referralGrant(4)]);
+
+    expect(result[4].rewardsMultiplier).toBe(1);
+    expect(result[4].purchasesMultiplier).toBe(1);
+  });
+
+  it('takes the best across tiers rather than the highest tier', () => {
+    const activeGoldGrant: UserMultiplierRow = {
+      userId: 5,
+      rewardsIneligible: false,
+      rewardsMultiplier: null,
+      purchasesMultiplier: null,
+    };
+    const paidSilver: UserMultiplierRow = {
+      userId: 5,
+      rewardsIneligible: false,
+      rewardsMultiplier: 2.5,
+      purchasesMultiplier: 1.1,
+    };
+
+    const result = foldUserMultipliers([activeGoldGrant, paidSilver]);
+
+    expect(result[5].rewardsMultiplier).toBe(2.5);
+  });
+
+  it('zeroes rewards for an ineligible user without touching purchases', () => {
+    const result = foldUserMultipliers([
+      { ...paidBronze(6), rewardsIneligible: true },
+      { ...referralGrant(6), rewardsIneligible: true },
+    ]);
+
+    expect(result[6].rewardsMultiplier).toBe(0);
+    expect(result[6].purchasesMultiplier).toBe(1.05);
+    expect(result[6].rewardsIneligible).toBe(true);
+  });
+
+  it('keeps users separate', () => {
+    const result = foldUserMultipliers([paidBronze(7), referralGrant(8)]);
+
+    expect(result[7].rewardsMultiplier).toBe(1.5);
+    expect(result[8].rewardsMultiplier).toBe(1);
+  });
+
+  it('returns nothing for no rows', () => {
+    expect(foldUserMultipliers([])).toEqual({});
+  });
+});
+
+describe('userMultipliersCache wiring', () => {
+  const source = fs.readFileSync(path.join(process.cwd(), 'src/server/redis/caches.ts'), 'utf-8');
+  const lookup = source.slice(
+    source.indexOf('export const userMultipliersCache'),
+    source.indexOf('type UserBasicLookup')
+  );
+
+  it('reads the source it is meant to read', () => {
+    expect(lookup).toContain('MULTIPLIERS_FOR_USER');
+  });
+
+  it('resolves multipliers through foldUserMultipliers, not a single winning row', () => {
+    expect(lookup).toContain('foldUserMultipliers(');
+    expect(lookup).not.toContain('ROW_NUMBER()');
+  });
+});

--- a/src/server/redis/__tests__/user-multipliers.test.ts
+++ b/src/server/redis/__tests__/user-multipliers.test.ts
@@ -93,6 +93,22 @@ describe('foldUserMultipliers', () => {
     expect(result[8].rewardsMultiplier).toBe(1);
   });
 
+  it('keeps a multiplier below 1 rather than flooring it to 1', () => {
+    // A penalty tier is not in the catalogue today, but the query this replaced honoured a value
+    // below 1 and nothing should quietly turn one into a no-op if it is ever added.
+    const penalty: UserMultiplierRow = {
+      userId: 9,
+      rewardsIneligible: false,
+      rewardsMultiplier: 0.5,
+      purchasesMultiplier: 0.5,
+    };
+
+    const result = foldUserMultipliers([penalty]);
+
+    expect(result[9].rewardsMultiplier).toBe(0.5);
+    expect(result[9].purchasesMultiplier).toBe(0.5);
+  });
+
   it('returns nothing for no rows', () => {
     expect(foldUserMultipliers([])).toEqual({});
   });
@@ -100,12 +116,15 @@ describe('foldUserMultipliers', () => {
 
 describe('userMultipliersCache wiring', () => {
   const source = fs.readFileSync(path.join(process.cwd(), 'src/server/redis/caches.ts'), 'utf-8');
-  const lookup = source.slice(
-    source.indexOf('export const userMultipliersCache'),
-    source.indexOf('type UserBasicLookup')
-  );
+  const start = source.indexOf('export const userMultipliersCache');
+  const end = source.indexOf('type UserBasicLookup');
+  const lookup = source.slice(start, end);
 
   it('reads the source it is meant to read', () => {
+    // Both bounds asserted: `indexOf` returning -1 makes `slice` widen to the whole file, and the
+    // assertions below would then keep passing while bounding nothing.
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
     expect(lookup).toContain('MULTIPLIERS_FOR_USER');
   });
 

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -47,6 +47,8 @@ import { getModelClient } from '~/server/services/orchestrator/models';
 import type { CachedObject } from '~/server/utils/cache-helpers';
 import { createCachedObject } from '~/server/utils/cache-helpers';
 import { L1_CACHE_BYTE_BUDGETS } from '~/server/redis/l1-cache-budget';
+import type { UserMultiplierRow, UserMultipliers } from '~/server/redis/user-multipliers';
+import { foldUserMultipliers } from '~/server/redis/user-multipliers';
 import { getPrimaryFile } from '~/server/utils/model-helpers';
 import type { BaseModel } from '~/shared/constants/basemodel.constants';
 import { stringifyAIR } from '~/shared/utils/air';
@@ -332,12 +334,7 @@ export const cosmeticEntityCaches = Object.fromEntries(
   ])
 ) as Record<CosmeticEntity, CachedObject<WithClaimKey<ContentDecorationCosmetic>>>;
 
-type CachedUserMultiplier = {
-  userId: number;
-  rewardsMultiplier: number;
-  purchasesMultiplier: number;
-  rewardsIneligible: boolean;
-};
+type CachedUserMultiplier = UserMultipliers;
 export const userMultipliersCache = createCachedObject<CachedUserMultiplier>({
   key: REDIS_KEYS.CACHES.MULTIPLIERS_FOR_USER,
   idKey: 'userId',
@@ -347,63 +344,20 @@ export const userMultipliersCache = createCachedObject<CachedUserMultiplier>({
     if (!goodIds.length) return {};
 
     const db = fromWrite ? dbWrite : dbRead;
-    // Get the highest tier subscription for each user
-    // Tier priority: founder > gold > silver > bronze > free
-    const multipliers = await db.$queryRaw<CachedUserMultiplier[]>`
-      WITH ranked_subscriptions AS (
-        SELECT
-          cs."userId",
-          cs.status,
-          p.metadata,
-          CASE (p.metadata->>'tier')::text
-            WHEN 'gold' THEN 4
-            WHEN 'silver' THEN 3
-            WHEN 'bronze' THEN 2
-            WHEN 'founder' THEN 2
-            ELSE 1
-          END as tier_rank,
-          ROW_NUMBER() OVER (
-            PARTITION BY cs."userId"
-            ORDER BY
-              -- Active/trialing subs take priority so a stale expired_claimable
-              -- record can't out-rank a current sub at the same tier.
-              CASE WHEN cs.status IN ('active', 'trialing') THEN 0 ELSE 1 END,
-              CASE (p.metadata->>'tier')::text
-                WHEN 'gold' THEN 4
-                WHEN 'silver' THEN 3
-                WHEN 'bronze' THEN 2
-                WHEN 'founder' THEN 2
-                ELSE 1
-              END DESC,
-              cs."currentPeriodEnd" DESC NULLS LAST
-          ) as rn
-        FROM "CustomerSubscription" cs
-        JOIN "Product" p ON p.id = cs."productId"
-        WHERE cs."userId" IN (${Prisma.join(goodIds)})
-          AND cs.status NOT IN ('canceled', 'expired_claimable', 'paused')
-      )
+    const rows = await db.$queryRaw<UserMultiplierRow[]>`
       SELECT
         u.id as "userId",
-        CASE
-          WHEN u."rewardsEligibility" = 'Ineligible'::"RewardsEligibility" THEN 0
-          WHEN rs.status IS NULL OR rs.status NOT IN ('active', 'trialing') THEN 1
-          ELSE COALESCE((rs.metadata->>'rewardsMultiplier')::float, 1)
-        END as "rewardsMultiplier",
-        CASE
-          WHEN rs.status IS NULL OR rs.status NOT IN ('active', 'trialing') THEN 1
-          ELSE COALESCE((rs.metadata->>'purchasesMultiplier')::float, 1)
-        END as "purchasesMultiplier",
-        (u."rewardsEligibility" = 'Ineligible'::"RewardsEligibility") as "rewardsIneligible"
+        (u."rewardsEligibility" = 'Ineligible'::"RewardsEligibility") as "rewardsIneligible",
+        (p.metadata->>'rewardsMultiplier')::float as "rewardsMultiplier",
+        (p.metadata->>'purchasesMultiplier')::float as "purchasesMultiplier"
       FROM "User" u
-      LEFT JOIN ranked_subscriptions rs ON u.id = rs."userId" AND rs.rn = 1
+      LEFT JOIN "CustomerSubscription" cs
+        ON cs."userId" = u.id AND cs.status IN ('active', 'trialing')
+      LEFT JOIN "Product" p ON p.id = cs."productId"
       WHERE u.id IN (${Prisma.join(goodIds)});
     `;
 
-    const records: Record<number, CachedUserMultiplier> = Object.fromEntries(
-      multipliers.map((m) => [m.userId, m])
-    );
-
-    return records;
+    return foldUserMultipliers(rows);
   },
 });
 

--- a/src/server/redis/user-multipliers.ts
+++ b/src/server/redis/user-multipliers.ts
@@ -23,6 +23,10 @@ const BASE_MULTIPLIER = 1;
  *
  * A row with no multiplier counts as 1, but the result is NOT floored at 1 — a product priced
  * below 1 keeps its value, as it did when this was one COALESCE over a single winning row.
+ *
+ * `rewardsIneligible` is taken from the first row seen for a user, which is safe only because the
+ * query computes it off `User`, so every row for a user carries the same value. Move that
+ * expression to a joined table and this needs to fold rather than take the first.
  */
 export function foldUserMultipliers(rows: UserMultiplierRow[]): Record<number, UserMultipliers> {
   const records: Record<number, UserMultipliers> = {};

--- a/src/server/redis/user-multipliers.ts
+++ b/src/server/redis/user-multipliers.ts
@@ -1,0 +1,54 @@
+export type UserMultipliers = {
+  userId: number;
+  rewardsMultiplier: number;
+  purchasesMultiplier: number;
+  rewardsIneligible: boolean;
+};
+
+export type UserMultiplierRow = {
+  userId: number;
+  rewardsIneligible: boolean;
+  rewardsMultiplier: number | null;
+  purchasesMultiplier: number | null;
+};
+
+const BASE_MULTIPLIER = 1;
+
+/**
+ * Takes the best multiplier across every active subscription a user holds rather than the one
+ * highest-ranked row. A referral grant (civitai-referral-*) and a buzz-purchase grant
+ * (civitai-buzz-*) are placeholders that convey a tier and no perks, and either can out-rank a
+ * paid membership at the same tier on the date tiebreak — silently zeroing the multiplier the
+ * member is paying for. See ClickUp 868kv4q7t / 868kr8bh3.
+ */
+export function foldUserMultipliers(rows: UserMultiplierRow[]): Record<number, UserMultipliers> {
+  const records: Record<number, UserMultipliers> = {};
+
+  for (const row of rows) {
+    const existing = records[row.userId];
+    if (!existing) {
+      records[row.userId] = {
+        userId: row.userId,
+        rewardsIneligible: row.rewardsIneligible,
+        rewardsMultiplier: Math.max(BASE_MULTIPLIER, row.rewardsMultiplier ?? BASE_MULTIPLIER),
+        purchasesMultiplier: Math.max(BASE_MULTIPLIER, row.purchasesMultiplier ?? BASE_MULTIPLIER),
+      };
+      continue;
+    }
+
+    existing.rewardsMultiplier = Math.max(
+      existing.rewardsMultiplier,
+      row.rewardsMultiplier ?? BASE_MULTIPLIER
+    );
+    existing.purchasesMultiplier = Math.max(
+      existing.purchasesMultiplier,
+      row.purchasesMultiplier ?? BASE_MULTIPLIER
+    );
+  }
+
+  for (const record of Object.values(records)) {
+    if (record.rewardsIneligible) record.rewardsMultiplier = 0;
+  }
+
+  return records;
+}

--- a/src/server/redis/user-multipliers.ts
+++ b/src/server/redis/user-multipliers.ts
@@ -20,6 +20,9 @@ const BASE_MULTIPLIER = 1;
  * (civitai-buzz-*) are placeholders that convey a tier and no perks, and either can out-rank a
  * paid membership at the same tier on the date tiebreak — silently zeroing the multiplier the
  * member is paying for. See ClickUp 868kv4q7t / 868kr8bh3.
+ *
+ * A row with no multiplier counts as 1, but the result is NOT floored at 1 — a product priced
+ * below 1 keeps its value, as it did when this was one COALESCE over a single winning row.
  */
 export function foldUserMultipliers(rows: UserMultiplierRow[]): Record<number, UserMultipliers> {
   const records: Record<number, UserMultipliers> = {};
@@ -30,8 +33,8 @@ export function foldUserMultipliers(rows: UserMultiplierRow[]): Record<number, U
       records[row.userId] = {
         userId: row.userId,
         rewardsIneligible: row.rewardsIneligible,
-        rewardsMultiplier: Math.max(BASE_MULTIPLIER, row.rewardsMultiplier ?? BASE_MULTIPLIER),
-        purchasesMultiplier: Math.max(BASE_MULTIPLIER, row.purchasesMultiplier ?? BASE_MULTIPLIER),
+        rewardsMultiplier: row.rewardsMultiplier ?? BASE_MULTIPLIER,
+        purchasesMultiplier: row.purchasesMultiplier ?? BASE_MULTIPLIER,
       };
       continue;
     }

--- a/src/server/rewards/__tests__/appBlockReview.reward.test.ts
+++ b/src/server/rewards/__tests__/appBlockReview.reward.test.ts
@@ -48,6 +48,7 @@ vi.mock('~/shared/constants/buzz.constants', () => ({
 }));
 vi.mock('~/utils/string-helpers', () => ({
   hashifyObject: (o: any) => `hash:${JSON.stringify(o)}`,
+  hashify: (str: string) => str.length,
 }));
 
 // Import AFTER mocks.
@@ -81,7 +82,14 @@ describe('appBlockReviewReward', () => {
       type: 'appBlockReview',
       toUserId: 7,
       byUserId: 7,
-      forId: 'ab_42',
+      // `appBlockId` is a string and `buzzEvents.forId` is Int32, so the row is
+      // coerced on the way in. Asserting the raw string here pinned a row
+      // ClickHouse silently drops (ClickUp 868ktbnjh); the string is preserved
+      // in `transactionDetails.forIdRaw` and in the transaction id below.
+      forId: expect.any(Number),
+    });
+    expect(JSON.parse(inserted.values[0].transactionDetails)).toMatchObject({
+      forIdRaw: 'ab_42',
     });
 
     // Award granted to the BLUE account.

--- a/src/server/rewards/__tests__/base.reward.config.test.ts
+++ b/src/server/rewards/__tests__/base.reward.config.test.ts
@@ -204,12 +204,19 @@ describe('process() does not pay out a disabled reward’s backlog', () => {
     expect(toProcess.map((x) => x.status)).toEqual(['unqualified', 'unqualified']);
     expect(toProcess.map((x) => x.awardAmount)).toEqual([0, 0]);
     expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
-    // The rows are written back, or the sweep is a local mutation nobody sees.
+    // The rows are written back, or the sweep is a local mutation nobody sees. `unqualified` is
+    // not in the buzzEvents Enum8, and an async insert drops the whole chunk over it without an
+    // error — so it goes over the wire as the nearest legal value with its own name preserved
+    // (ClickUp 868ktbnjh). Asserting `status: 'unqualified'` here pinned a write nobody received.
     expect(h.insertImpl).toHaveBeenCalledWith(
       expect.objectContaining({
-        values: toProcess.map(() => expect.objectContaining({ status: 'unqualified' })),
+        values: toProcess.map(() => expect.objectContaining({ status: 'capped' })),
       })
     );
+    const written = h.insertImpl.mock.calls.at(-1)?.[0] as { values: BuzzEventLog[] };
+    expect(JSON.parse(written.values[0].transactionDetails ?? '{}')).toMatchObject({
+      statusRaw: 'unqualified',
+    });
   });
 
   it('holds for a real processable reward, not only the local fixture', async () => {

--- a/src/server/rewards/__tests__/base.reward.failsoft.test.ts
+++ b/src/server/rewards/__tests__/base.reward.failsoft.test.ts
@@ -74,6 +74,7 @@ vi.mock('~/shared/constants/buzz.constants', () => ({
 
 vi.mock('~/utils/string-helpers', () => ({
   hashifyObject: (o: any) => `hash:${JSON.stringify(o)}`,
+  hashify: (str: string) => str.length,
 }));
 
 // Import AFTER mocks are registered.

--- a/src/server/rewards/__tests__/base.reward.forid.test.ts
+++ b/src/server/rewards/__tests__/base.reward.forid.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// WHY THIS SUITE EXISTS
+//
+// `buzzEvents.forId` is Int32 and the app inserts with `async_insert=1,
+// wait_for_async_insert=0`. A reward whose key carries a string forId therefore
+// produces a row ClickHouse drops server-side while the HTTP insert returns
+// success — the Buzz is still paid and no error reaches the app. 4M
+// generation-feedback payouts wrote zero event rows this way (ClickUp 868ktbnjh),
+// and 92,729 `ParsingError` batches in a 2-day window were the only trace.
+//
+// These tests assert on what is handed to `clickhouse.insert`, not on a helper
+// in isolation, because the defect was in what reached the wire.
+// ---------------------------------------------------------------------------
+
+const h = vi.hoisted(() => ({
+  insertImpl: vi.fn(async () => undefined),
+  queryImpl: vi.fn(async () => [] as unknown[]),
+  evalImpl: vi.fn(async () => 0 as number),
+  hGetImpl: vi.fn(async () => '{}'),
+  createBuzzTransactionMany: vi.fn(async () => ({ transactions: [] })),
+  getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: {
+    insert: (...args: any[]) => h.insertImpl(...args),
+    $query: (...args: any[]) => h.queryImpl(...args),
+    query: vi.fn(async () => ({ json: async () => [] })),
+  },
+}));
+
+vi.mock('~/server/prom/client', () => ({
+  rewardFailedCounter: { inc: vi.fn() },
+  rewardGivenCounter: { inc: vi.fn() },
+  clickhouseFailSoftCounter: { inc: vi.fn() },
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: (...args: any[]) => h.createBuzzTransactionMany(...args),
+  getMultipliersForUser: (...args: any[]) => h.getMultipliersForUser(...args),
+}));
+
+import { createBuzzEvent } from '~/server/rewards/base.reward';
+import { invalidateRewardConfigCache } from '~/server/rewards/reward-config';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+redisMock.redis.eval.mockImplementation((...args: any[]) => h.evalImpl(...args));
+redisMock.redis.hGet.mockImplementation((...args: any[]) => h.hGetImpl(...args));
+
+const AWARD_AMOUNT = 4;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  invalidateRewardConfigCache();
+  dbMock.dbRead.keyValue.findUnique.mockResolvedValue(null);
+  h.insertImpl.mockResolvedValue(undefined as any);
+  h.evalImpl.mockResolvedValue(AWARD_AMOUNT as any);
+  h.hGetImpl.mockResolvedValue('{}');
+  h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 1 });
+});
+
+const stringKeyReward = () =>
+  createBuzzEvent<{ userId: number; jobId: string }>({
+    type: 'testStringForId',
+    description: 'Test reward keyed on a string',
+    awardAmount: AWARD_AMOUNT,
+    cap: 40,
+    onDemand: true,
+    getKey: async (input) => ({
+      toUserId: input.userId,
+      forId: input.jobId,
+      byUserId: input.userId,
+    }),
+  });
+
+const insertedRow = () => {
+  const call = h.insertImpl.mock.calls.find((args: any[]) => args[0]?.table === 'buzzEvents') as
+    | any[]
+    | undefined;
+  if (!call) throw new Error('no buzzEvents insert was attempted');
+  return call[0].values[0];
+};
+
+describe('buzzEvents forId must be an Int32 by the time it reaches ClickHouse', () => {
+  it('inserts a number for a non-numeric key, so the row is not silently dropped', async () => {
+    await stringKeyReward().apply({ userId: 7, jobId: 'S34PXN0E7NNXGPBWM2G883Z0F0.jpeg' });
+
+    const row = insertedRow();
+    expect(typeof row.forId).toBe('number');
+    expect(Number.isInteger(row.forId)).toBe(true);
+    expect(Math.abs(row.forId)).toBeLessThanOrEqual(2147483647);
+  });
+
+  it('keeps the original key so a dropped row can still be traced back', async () => {
+    await stringKeyReward().apply({ userId: 7, jobId: 'S34PXN0E7NNXGPBWM2G883Z0F0.jpeg' });
+
+    expect(JSON.parse(insertedRow().transactionDetails)).toMatchObject({
+      forIdRaw: 'S34PXN0E7NNXGPBWM2G883Z0F0.jpeg',
+    });
+  });
+
+  it('is stable, so the same key always lands on the same id', async () => {
+    await stringKeyReward().apply({ userId: 7, jobId: 'job-abc' });
+    const first = insertedRow().forId;
+
+    h.insertImpl.mockClear();
+    await stringKeyReward().apply({ userId: 8, jobId: 'job-abc' });
+
+    expect(insertedRow().forId).toBe(first);
+  });
+
+  it('reads a numeric key as that number rather than hashing it', async () => {
+    await stringKeyReward().apply({ userId: 7, jobId: '12345' });
+
+    expect(insertedRow().forId).toBe(12345);
+  });
+
+  it('leaves the money path alone — the transaction still keys on the raw value', async () => {
+    await stringKeyReward().apply({ userId: 7, jobId: 'job-abc' });
+
+    const [transactions] = h.createBuzzTransactionMany.mock.calls[0] as any[];
+    expect(transactions[0].externalTransactionId).toBe('testStringForId:job-abc-7-7');
+    expect(transactions[0].details.forId).toBe('job-abc');
+  });
+
+  it('leaves a numeric forId untouched', async () => {
+    const numericReward = createBuzzEvent<{ userId: number; entityId: number }>({
+      type: 'testNumericForId',
+      description: 'Test reward keyed on a number',
+      awardAmount: AWARD_AMOUNT,
+      cap: 40,
+      onDemand: true,
+      getKey: async (input) => ({
+        toUserId: input.userId,
+        forId: input.entityId,
+        byUserId: input.userId,
+      }),
+    });
+
+    await numericReward.apply({ userId: 7, entityId: 991 });
+
+    const row = insertedRow();
+    expect(row.forId).toBe(991);
+    expect(row.transactionDetails).toBe('{}');
+  });
+});

--- a/src/server/rewards/__tests__/base.reward.forid.test.ts
+++ b/src/server/rewards/__tests__/base.reward.forid.test.ts
@@ -84,6 +84,29 @@ const insertedRow = () => {
   return call[0].values[0];
 };
 
+describe('buzzEvents columns narrower than BuzzEventLog', () => {
+  it('clamps a multiplier past the Decimal(3, 2) ceiling instead of losing the row', async () => {
+    // gold's 4 times MAX_GLOBAL_BONUS of 5 is 20, against a column that stops at 9.99.
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 20 });
+    h.evalImpl.mockResolvedValue(80 as any);
+
+    await stringKeyReward().apply({ userId: 7, jobId: 'job-abc' });
+
+    const row = insertedRow();
+    expect(row.multiplier).toBe(9.99);
+    expect(JSON.parse(row.transactionDetails)).toMatchObject({ multiplierRaw: 20 });
+  });
+
+  it('leaves a multiplier the column can hold alone', async () => {
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 4 });
+    h.evalImpl.mockResolvedValue(16 as any);
+
+    await stringKeyReward().apply({ userId: 7, jobId: 'job-abc' });
+
+    expect(insertedRow().multiplier).toBe(4);
+  });
+});
+
 describe('buzzEvents forId must be an Int32 by the time it reaches ClickHouse', () => {
   it('inserts a number for a non-numeric key, so the row is not silently dropped', async () => {
     await stringKeyReward().apply({ userId: 7, jobId: 'S34PXN0E7NNXGPBWM2G883Z0F0.jpeg' });
@@ -124,6 +147,18 @@ describe('buzzEvents forId must be an Int32 by the time it reaches ClickHouse', 
     const [transactions] = h.createBuzzTransactionMany.mock.calls[0] as any[];
     expect(transactions[0].externalTransactionId).toBe('testStringForId:job-abc-7-7');
     expect(transactions[0].details.forId).toBe('job-abc');
+  });
+
+  it('reads a whitespace-padded key as a hash, not as the same number', async () => {
+    // buzzEvents is ORDER BY (type, toUserId, forId, byUserId) on a ReplacingMergeTree, so two
+    // distinct keys collapsing to one id replace each other instead of both landing.
+    await stringKeyReward().apply({ userId: 7, jobId: ' 42 ' });
+    const padded = insertedRow().forId;
+
+    h.insertImpl.mockClear();
+    await stringKeyReward().apply({ userId: 7, jobId: '42' });
+
+    expect(padded).not.toBe(insertedRow().forId);
   });
 
   it('leaves a numeric forId untouched', async () => {

--- a/src/server/rewards/__tests__/base.reward.forid.test.ts
+++ b/src/server/rewards/__tests__/base.reward.forid.test.ts
@@ -161,6 +161,65 @@ describe('buzzEvents forId must be an Int32 by the time it reaches ClickHouse', 
     expect(padded).not.toBe(insertedRow().forId);
   });
 
+  it('hashes a numeric string past the Int32 ceiling instead of sending it', async () => {
+    // Deleting the range check leaves every fixture in this suite green, because they are all
+    // short. An orchestrator job id or a snowflake is not.
+    await stringKeyReward().apply({ userId: 7, jobId: '9999999999' });
+
+    const row = insertedRow();
+    expect(Math.abs(row.forId)).toBeLessThanOrEqual(2147483647);
+    expect(row.forId).not.toBe(9999999999);
+    expect(JSON.parse(row.transactionDetails)).toMatchObject({ forIdRaw: '9999999999' });
+  });
+
+  it('hashes a NUMBER past the Int32 ceiling, which short-circuited the whole function', async () => {
+    const bigNumericReward = createBuzzEvent<{ userId: number; entityId: number }>({
+      type: 'testOversizeNumericForId',
+      description: 'Test reward keyed on an oversize number',
+      awardAmount: AWARD_AMOUNT,
+      cap: 40,
+      onDemand: true,
+      getKey: async (input) => ({
+        toUserId: input.userId,
+        forId: input.entityId,
+        byUserId: input.userId,
+      }),
+    });
+
+    await bigNumericReward.apply({ userId: 7, entityId: 9999999999 });
+
+    const row = insertedRow();
+    expect(Math.abs(row.forId)).toBeLessThanOrEqual(2147483647);
+    expect(JSON.parse(row.transactionDetails)).toMatchObject({ forIdRaw: 9999999999 });
+  });
+
+  it('preserves the reward payload alongside the coerced value', async () => {
+    // Every other fixture here starts from '{}', so replacing `{ ...details, ...coerced }` with
+    // `coerced` alone stays green. goodContent, collectedContent and imagePostedToModel all define
+    // getTransactionDetails and all reach the coerced path.
+    const detailedReward = createBuzzEvent<{ userId: number; jobId: string }>({
+      type: 'testDetailsReward',
+      description: 'Test reward carrying transaction details',
+      awardAmount: AWARD_AMOUNT,
+      cap: 40,
+      onDemand: true,
+      getKey: async (input) => ({
+        toUserId: input.userId,
+        forId: input.jobId,
+        byUserId: input.userId,
+      }),
+      getTransactionDetails: async () => ({ modelVersionId: 991, note: 'keep me' }),
+    });
+
+    await detailedReward.apply({ userId: 7, jobId: 'job-abc' });
+
+    expect(JSON.parse(insertedRow().transactionDetails)).toMatchObject({
+      modelVersionId: 991,
+      note: 'keep me',
+      forIdRaw: 'job-abc',
+    });
+  });
+
   it('leaves a numeric forId untouched', async () => {
     const numericReward = createBuzzEvent<{ userId: number; entityId: number }>({
       type: 'testNumericForId',

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -556,22 +556,59 @@ export function createBuzzEvent<T>({
   };
 }
 
+const INT32_MAX = 2147483647;
+// `buzzEvents` is narrower than `BuzzEventLog`: `forId` is Int32, `status` is
+// Enum8('pending','awarded','capped') and `multiplier` is Decimal(3, 2).
+const CLICKHOUSE_STATUSES = new Set(['pending', 'awarded', 'capped']);
+const CLICKHOUSE_MAX_MULTIPLIER = 9.99;
+
 /**
- * `buzzEvents.forId` is Int32, but a reward key may carry a string (generation-feedback's jobId,
- * ad-watched's token). Inserts run with `async_insert=1, wait_for_async_insert=0`, so ClickHouse
- * accepts the request, fails to parse the row server-side and drops it — the app sees success and
- * still pays the Buzz. That is how 4M generation-feedback payouts recorded zero events, with no
- * 500 and no alert (ClickUp 868ktbnjh). Coerce here rather than at the key, so `sendAward`'s
- * `externalTransactionId` keeps the value it has always used.
+ * Fit an event to the `buzzEvents` column types before it goes over the wire.
+ *
+ * Inserts run `async_insert=1, wait_for_async_insert=0`, so ClickHouse accepts the request, parses
+ * the batch server-side afterwards, and drops it — the app sees success and `sendAward` still pays.
+ * A value the column cannot hold therefore costs a row, or a whole 1000-row chunk, with no error
+ * anywhere. Three fields could do it, and all three were doing it (ClickUp 868ktbnjh):
+ *
+ *   forId       a reward keyed on a string (generation-feedback's jobId, ad-watched's token,
+ *               appBlockReview's appBlockId). 4M payouts, zero event rows.
+ *   status      `unqualified` is not in the enum, so a chunk carrying one loses the awarded and
+ *               capped updates riding with it and those rows stay `pending` forever.
+ *   multiplier  gold's 4 times MAX_GLOBAL_BONUS of 5 is 20, against a ceiling of 9.99.
+ *
+ * The original value is kept in `transactionDetails` so a coerced row is still traceable, and the
+ * event itself is left alone so `sendAward`'s `externalTransactionId` keeps the value it has
+ * always used.
  */
 export function toClickhouseBuzzEvent(event: BuzzEventLog): BuzzEventLog {
-  if (typeof event.forId === 'number') return event;
+  const coerced: MixedObject = {};
 
-  const asNumber = Number(event.forId);
-  const forId =
-    Number.isInteger(asNumber) && Math.abs(asNumber) <= 2147483647
-      ? asNumber
-      : hashify(event.forId);
+  let forId = event.forId;
+  if (typeof forId !== 'number') {
+    coerced.forIdRaw = forId;
+    // Strict digits only: `Number('')` is 0 and `Number(' 42 ')` is 42, and buzzEvents is ordered
+    // by (type, toUserId, forId, byUserId), so two keys collapsing to one id replace each other.
+    forId =
+      /^-?\d+$/.test(forId) && Math.abs(Number(forId)) <= INT32_MAX
+        ? Number(forId)
+        : hashify(forId);
+  }
+
+  let status = event.status;
+  if (status && !CLICKHOUSE_STATUSES.has(status)) {
+    coerced.statusRaw = status;
+    // `unqualified` and `capped` both mean seen and paid nothing. Recording it as the nearest
+    // legal value keeps the row; widening the enum would let it keep its own name.
+    status = 'capped';
+  }
+
+  let multiplier = event.multiplier;
+  if (multiplier !== undefined && multiplier > CLICKHOUSE_MAX_MULTIPLIER) {
+    coerced.multiplierRaw = multiplier;
+    multiplier = CLICKHOUSE_MAX_MULTIPLIER;
+  }
+
+  if (Object.keys(coerced).length === 0) return event;
 
   let details: MixedObject;
   try {
@@ -583,7 +620,9 @@ export function toClickhouseBuzzEvent(event: BuzzEventLog): BuzzEventLog {
   return {
     ...event,
     forId,
-    transactionDetails: JSON.stringify({ ...details, forIdRaw: event.forId }),
+    status,
+    multiplier,
+    transactionDetails: JSON.stringify({ ...details, ...coerced }),
   };
 }
 

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -560,6 +560,13 @@ const INT32_MAX = 2147483647;
 // `buzzEvents` is narrower than `BuzzEventLog`: `forId` is Int32, `status` is
 // Enum8('pending','awarded','capped') and `multiplier` is Decimal(3, 2).
 const CLICKHOUSE_STATUSES = new Set(['pending', 'awarded', 'capped']);
+// 🔴 This must equal the ceiling of the DEPLOYED `buzzEvents.multiplier` column, which is
+// Decimal(3, 2). Raising it sends a value the column cannot hold, and an unparseable row is
+// dropped server-side while `sendAward` pays anyway — so this is the ONLY guard, not a backstop.
+// Widening the column was costed and declined (2026-08-24): the ceiling is not reachable today,
+// and it was not worth a mutation over 1.4 billion rows. If that changes, the column moves first
+// and this follows in the same window — never the other way round.
+// See src/server/clickhouse/migrations/2026-08-24-buzz-events-multiplier-width.sql.
 const CLICKHOUSE_MAX_MULTIPLIER = 9.99;
 
 /**
@@ -615,18 +622,9 @@ export function toClickhouseBuzzEvent(event: BuzzEventLog): BuzzEventLog {
     multiplier = CLICKHOUSE_MAX_MULTIPLIER;
     // On the batch path this value is not audit — `process-rewards` reads it back out and
     // `sendAward` pays `awardAmount * multiplier` from it, so a clamp UNDERPAYS rather than
-    // rounding a record. Gold's 4 x MAX_GLOBAL_BONUS 5 is 20, against a Decimal(3, 2) ceiling
-    // of 9.99.
-    //
-    // 🔴 Keep this even once the column is widened, and do not drop the log with it. The clamp is
-    // the backstop; 2026-08-24-buzz-events-multiplier-width.sql raises the ceiling to 99.99, and
-    // the two are not the same guarantee — that migration is applied by hand, so this code has to
-    // be correct on a database where it has not been applied yet.
-    log(event, {
-      message: 'Buzz event multiplier exceeded the ClickHouse column and was clamped',
-      multiplierRaw: coerced.multiplierRaw,
-      clampedTo: CLICKHOUSE_MAX_MULTIPLIER,
-    });
+    // rounding a record. Reported once per batch by the caller, not here: the condition becomes
+    // reachable when a site-wide bonus event switches on, which clamps every gold member's pending
+    // events at once, and this function runs per event per retry.
   }
 
   if (Object.keys(coerced).length === 0) return event;
@@ -647,6 +645,29 @@ export function toClickhouseBuzzEvent(event: BuzzEventLog): BuzzEventLog {
   };
 }
 
+/** Fits a batch to the column types and reports a clamped multiplier once, with a count. */
+function toClickhouseBuzzEvents(events: BuzzEventLog[]): BuzzEventLog[] {
+  let clamped = 0;
+  const rows = events.map((event) => {
+    const row = toClickhouseBuzzEvent(event);
+    if (row.multiplier !== event.multiplier) clamped++;
+    return row;
+  });
+
+  if (clamped > 0) {
+    logToAxiom({
+      name: 'buzz-rewards',
+      type: 'error',
+      message: 'Buzz event multiplier exceeded the ClickHouse column and was clamped',
+      clampedEvents: clamped,
+      batchSize: events.length,
+      clampedTo: CLICKHOUSE_MAX_MULTIPLIER,
+    }).catch(() => null);
+  }
+
+  return rows;
+}
+
 // TODO: sometimes this can cause duplicate entries.
 //  hypothesis is that this occurs due to a combination of
 //  async inserts + ch's merge strategy
@@ -659,7 +680,7 @@ async function addBuzzEvent(
     async () =>
       await clickhouse?.insert({
         table: 'buzzEvents',
-        values: [toClickhouseBuzzEvent(event)],
+        values: toClickhouseBuzzEvents([event]),
         format: 'JSONEachRow',
       }),
     retries,
@@ -673,7 +694,7 @@ async function updateBuzzEvents(events: BuzzEventLog[]) {
     async () =>
       await clickhouse?.insert({
         table: 'buzzEvents',
-        values: events.map(toClickhouseBuzzEvent),
+        values: toClickhouseBuzzEvents(events),
         format: 'JSONEachRow',
       }),
     5,

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -15,7 +15,7 @@ import { TransactionType } from '~/shared/constants/buzz.constants';
 import { createBuzzTransactionMany, getMultipliersForUser } from '~/server/services/buzz.service';
 import type { ResolvedRewardConfig, RewardConfig } from '~/server/rewards/reward-config';
 import { resolveFromConfig, resolveRewardConfig } from '~/server/rewards/reward-config';
-import { hashifyObject } from '~/utils/string-helpers';
+import { hashify, hashifyObject } from '~/utils/string-helpers';
 import { isClickHouseConnectionError, withRetries } from '../utils/errorHandling';
 
 // Retry budget for the batch `process` (cron) path — can afford to block.
@@ -556,6 +556,37 @@ export function createBuzzEvent<T>({
   };
 }
 
+/**
+ * `buzzEvents.forId` is Int32, but a reward key may carry a string (generation-feedback's jobId,
+ * ad-watched's token). Inserts run with `async_insert=1, wait_for_async_insert=0`, so ClickHouse
+ * accepts the request, fails to parse the row server-side and drops it — the app sees success and
+ * still pays the Buzz. That is how 4M generation-feedback payouts recorded zero events, with no
+ * 500 and no alert (ClickUp 868ktbnjh). Coerce here rather than at the key, so `sendAward`'s
+ * `externalTransactionId` keeps the value it has always used.
+ */
+export function toClickhouseBuzzEvent(event: BuzzEventLog): BuzzEventLog {
+  if (typeof event.forId === 'number') return event;
+
+  const asNumber = Number(event.forId);
+  const forId =
+    Number.isInteger(asNumber) && Math.abs(asNumber) <= 2147483647
+      ? asNumber
+      : hashify(event.forId);
+
+  let details: MixedObject;
+  try {
+    details = JSON.parse(event.transactionDetails ?? '{}');
+  } catch {
+    details = {};
+  }
+
+  return {
+    ...event,
+    forId,
+    transactionDetails: JSON.stringify({ ...details, forIdRaw: event.forId }),
+  };
+}
+
 // TODO: sometimes this can cause duplicate entries.
 //  hypothesis is that this occurs due to a combination of
 //  async inserts + ch's merge strategy
@@ -568,7 +599,7 @@ async function addBuzzEvent(
     async () =>
       await clickhouse?.insert({
         table: 'buzzEvents',
-        values: [event],
+        values: [toClickhouseBuzzEvent(event)],
         format: 'JSONEachRow',
       }),
     retries,
@@ -582,7 +613,7 @@ async function updateBuzzEvents(events: BuzzEventLog[]) {
     async () =>
       await clickhouse?.insert({
         table: 'buzzEvents',
-        values: events,
+        values: events.map(toClickhouseBuzzEvent),
         format: 'JSONEachRow',
       }),
     5,

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -584,7 +584,14 @@ export function toClickhouseBuzzEvent(event: BuzzEventLog): BuzzEventLog {
   const coerced: MixedObject = {};
 
   let forId = event.forId;
-  if (typeof forId !== 'number') {
+  if (typeof forId === 'number') {
+    // A number the column cannot hold is dropped exactly like a string would be, so the range
+    // check belongs on both branches, not only on the parsed one.
+    if (!Number.isInteger(forId) || Math.abs(forId) > INT32_MAX) {
+      coerced.forIdRaw = forId;
+      forId = hashify(String(forId));
+    }
+  } else {
     coerced.forIdRaw = forId;
     // Strict digits only: `Number('')` is 0 and `Number(' 42 ')` is 42, and buzzEvents is ordered
     // by (type, toUserId, forId, byUserId), so two keys collapsing to one id replace each other.
@@ -606,6 +613,20 @@ export function toClickhouseBuzzEvent(event: BuzzEventLog): BuzzEventLog {
   if (multiplier !== undefined && multiplier > CLICKHOUSE_MAX_MULTIPLIER) {
     coerced.multiplierRaw = multiplier;
     multiplier = CLICKHOUSE_MAX_MULTIPLIER;
+    // On the batch path this value is not audit — `process-rewards` reads it back out and
+    // `sendAward` pays `awardAmount * multiplier` from it, so a clamp UNDERPAYS rather than
+    // rounding a record. Gold's 4 x MAX_GLOBAL_BONUS 5 is 20, against a Decimal(3, 2) ceiling
+    // of 9.99.
+    //
+    // 🔴 Keep this even once the column is widened, and do not drop the log with it. The clamp is
+    // the backstop; 2026-08-24-buzz-events-multiplier-width.sql raises the ceiling to 99.99, and
+    // the two are not the same guarantee — that migration is applied by hand, so this code has to
+    // be correct on a database where it has not been applied yet.
+    log(event, {
+      message: 'Buzz event multiplier exceeded the ClickHouse column and was clamped',
+      multiplierRaw: coerced.multiplierRaw,
+      clampedTo: CLICKHOUSE_MAX_MULTIPLIER,
+    });
   }
 
   if (Object.keys(coerced).length === 0) return event;

--- a/src/server/services/referral.service.ts
+++ b/src/server/services/referral.service.ts
@@ -1174,7 +1174,18 @@ export async function advanceReferralSubscriptions(now: Date = new Date()) {
     // for up to 24h. That cost nothing while the referral products carried no multipliers; it
     // costs real Buzz now that they do (ClickUp 868kv5az9).
     if (result !== 'noop') {
-      await invalidateSubscriptionCaches(sub.userId).catch(() => undefined);
+      await invalidateSubscriptionCaches(sub.userId).catch((error) => {
+        // The helper allSettles its six steps and logs each rejection itself, so the only way it
+        // rejects is a SYNCHRONOUS throw from one of them — which aborts the map, leaves the
+        // remaining steps unrun, and logs nothing. Swallowing that silently would leave the user
+        // with a stale multiplier and no trace.
+        logToAxiom({
+          name: 'referral-advance-cache-invalidation-failed',
+          type: 'error',
+          userId: sub.userId,
+          error: (error as Error)?.message,
+        }).catch(() => undefined);
+      });
     }
   }
 

--- a/src/server/services/referral.service.ts
+++ b/src/server/services/referral.service.ts
@@ -1168,6 +1168,14 @@ export async function advanceReferralSubscriptions(now: Date = new Date()) {
 
     if (result === 'advanced') advanced++;
     else if (result === 'canceled') canceled++;
+
+    // The tier this row confers just changed. `userMultipliersCache` has a 1-day TTL and nothing
+    // else busts it on this path, so a demoted or cancelled grant keeps paying its old multiplier
+    // for up to 24h. That cost nothing while the referral products carried no multipliers; it
+    // costs real Buzz now that they do (ClickUp 868kv5az9).
+    if (result !== 'noop') {
+      await invalidateSubscriptionCaches(sub.userId).catch(() => undefined);
+    }
   }
 
   return { advanced, canceled };


### PR DESCRIPTION
Lane 4 — referrals and Buzz correctness. Closes `868kv4q7t`, `868kv5az9`, `868ktbnjh`. **`868kuyu5t` is diagnosed in this lane but has no code here** — see the last section.

## 1. A referral grant outranked a paid membership (`868kv4q7t`)

`userMultipliersCache` ranked a user's subscription rows and read the multiplier off the single winner. Two active rows at the same tier tie on status and tier, so `currentPeriodEnd DESC` decided it — and a `civitai-referral-*` product carries no `rewardsMultiplier`, so `COALESCE(..., 1)` quietly paid a Bronze member 1x.

It now takes the **best multiplier across the user's active subscriptions**, which also covers the `civitai-buzz-*` family in `868kr8bh3`.

**Old query vs new, over every subscriber on the prod replica:**

| users | changed | up | down |
|---|---|---|---|
| 74,575 | 1 | 1 | 0 |

**Blast radius, as the brief required before fixing:** 32 active referral grants; 4 users hold a grant *and* a paid membership; **1** is losing a multiplier today. Historically, 11 redemptions across 10 users show a multiplier drop coincident with the redemption (detector: max multiplier 3 days before vs the 30h–5d window after, run over all 102 rows of `ReferralRedemption`).

**Compensation, decided by Justin 2026-08-24:** pay user 9736923 only — 692 Buzz at last measure, from `buzzTransactions` (270 reward transactions, 1,384 paid, 2,076 owed), still accruing until the fix deploys. The ticket says Green; **all 270 of his reward transactions are `toAccountType: blue`**, so blue is what gets paid. The other nine are not paid: for most, the paid period had already lapsed, and the 1.5x they lost was itself coming from an `active`-status row with a long-expired period.

## 2. The dashboard advertised perks the grants did not deliver (`868kv5az9`)

Justin's call: make the product match the copy rather than trim the copy, and where a grant's multiplier beats the active subscription's, the grant wins. The max-across-active-rows fix gives the second half; the migration adds the two advertised multipliers to the three referral products.

**Both changes together, simulated over the same 74,575 subscribers: 29 gain a multiplier, 0 lose one.**

🔴 **Do not apply that migration before the deploy.** Measured, not reasoned: the deployed build reads `rewardsMultiplier` off the winning row, and for the 26 grant-only users the referral row *is* the winner. Running the **old** query with the migration simulated changes the same 29 users. So applying it early delivers the whole change on the old code path, spread unevenly over 24h with no session refresh — and before the cache-bust fix below exists, an expiring grant would keep paying for a day.

## 3. generation-feedback paid out and recorded nothing (`868ktbnjh`)

`buzzEvents.forId` is `Int32`. Inserts run `async_insert=1, wait_for_async_insert=0`, so ClickHouse accepts the HTTP request, fails to parse the row **server-side**, and drops it — no error reaches the app, and `sendAward` pays anyway.

**Measured:**

| | |
|---|---|
| `buzzTransactions`, 90 days, that description | **4,101,303** transactions / 38,456 users / 20,093,124 Buzz |
| `buzzEvents` rows of type `generation-feedback`, **all time** | **1**, dated 2024-08-01 |
| `system.asynchronous_insert_log`, 2 days | 1,398,041 `Ok` / **92,911 `ParsingError`**, the exception naming `forId` |

Three rewards carry a string key — `generation-feedback` (jobId), `ad-watched` (token), `appBlockReview` (appBlockId) — and none appears in `buzzEvents` in 30 days. That is an enumeration of the reward definitions plus their absence from the table, not a proof that no fourth path exists.

Coercion happens at the insert boundary only, so `sendAward`'s `externalTransactionId` keeps the value it has always used; the raw string is preserved in `transactionDetails.forIdRaw`.

**Two more columns, found by review, both latent:** `status` has no `unqualified` in its `Enum8` (nothing writes it today — live `rewards:config` is `{"rewards": {}}` and the other writer is dead code), and `multiplier` is `Decimal(3,2)` with a ceiling of 9.99 while gold 4 × `MAX_GLOBAL_BONUS` 5 reaches 20. **The multiplier one is a payout, not an audit value** — `process-rewards` reads it back out and `sendAward` pays from it — so the clamp now logs when it fires. `src/server/clickhouse/migrations/2026-08-24-buzz-events-multiplier-width.sql` widens it, as a three-step column swap following the precedent recorded in this table's own `system.mutations` from 2024-04-04.

## 4. `868kuyu5t` — diagnosed, deliberately no code here

The reaction-count read path is an **event-engine** cache defect, not a main-app one. `metrics:Image:140276941` in prod holds `Like 1` while `entityMetricDailyAgg_v2` holds `Like 6, Heart 4`. It cannot self-heal: `MetricService` repopulates only on a *missing* key, and a 10% per-read TTL slide keeps a viewed image's entry alive indefinitely. Three candidate fixes are on the ticket; all require restarting a service every agent's dev server depends on, so it is left as a decision rather than done quietly.

## Applied by hand — two migrations, in this order, after the deploy

1. `20260824180000_referral_grant_tier_multipliers` (Postgres) — then confirm **3** rows changed, then 32 exact `DEL`s on `packed:caches:multipliers-for-user:<userId>`, then `POST /api/admin/refresh-user-sessions`.
2. `2026-08-24-buzz-events-multiplier-width.sql` (ClickHouse) — three steps with a stop condition at each. **There is no rehearsal environment**: dev and preview both write to the production cluster.

## What this does NOT fix

- The ~4M historical `generation-feedback` rows are gone. No backfill.
- ~3,167 rows stuck at `pending` (2,209 `goodContent:image` back to 2026-07-25) stay stuck. Cause unknown — the leading hypothesis is on `868ktbnjh`, recorded as a hypothesis.
- `buzzEvents` has a second writer this PR cannot reach: `apps/moderator/src/lib/server/rewards.ts:38`, unclamped. Filed as `868kw9b31`.
- Ineligible users are still paid — `sendAward` turns the fold's correct 0 back into 1. 551 rows / 23 users / 6,238 Buzz in 7 days. Pre-existing. Filed as `868kw9kfk`.

## Review

Five-lane `civitai-review` over `0759aa09c1`, plus an earlier adversarial pass over `6ae7d8a1b6`. All five lanes accounted for by name; two went idle without delivering and were chased. Findings fixed in `3477512f13`.

**The fix round is not itself re-reviewed.**

Every test here was checked by reverting the fix and reading the failure. The wiring guard is a **tripwire, not coverage** — it is a source scan, and its first version pinned one spelling and passed a mutation to `SELECT DISTINCT ON (u.id)` that restored the bug completely. It now checks four idioms, each proven by a mutation asserted to have applied first.

```
typecheck: OK — 0 type errors
Test Files  1373 passed | 1 skipped (1374)      exit 0, counts sum
Tests  21553 passed | 27 skipped (21580)
test:lint-rules  17 files / 323 tests           exit 0
blocks.router.workflow.test.ts  358 tests       (submodule initialised)
```

Two earlier full-suite runs came back red and both background notifications reported exit 0 over them: a vitest worker died, and the file counts gave it away — `1370 passed | 1 skipped` against a total of `1374`. `--max-workers=8` produced the run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🔴 Provenance of the final commits — read this before trusting "reviewed"

The five-lane review ran against **`0759aa09c1`**, and a follow-up correctness pass against **`cc1adcfed4`**. Three commits landed after those and were **not** covered by any review pass:

| commit | contents | evidence it shipped on |
|---|---|---|
| `3477512f13` | the fix round for the five-lane findings | re-reviewed at `cc1adcfed4` ✅ |
| `cc1adcfed4` | migration rewritten as the column swap (`.sql` only) | re-review ✅ |
| `6f3948aefc` | **batch-log refactor** + the ClickHouse-cancelled comments | covering suites (240 tests) + clean typecheck — **no full suite, no review** |

`6f3948aefc` moved the clamp's Axiom log from per-event to once-per-batch and changed both `clickhouse.insert` call sites from `toClickhouseBuzzEvent(event)` to `toClickhouseBuzzEvents([event])`.

**It was merged before its full suite finished** — that run was still queued behind another agent's when the merge went in, on Justin's explicit instruction. **The run completed green shortly afterwards**, so the evidence exists, it just post-dates the merge:

```
UNIT_EXIT=0                                   (the command's own status, read immediately)
Test Files  1373 passed | 1 skipped (1374)    1373 + 1 = 1374, counts sum
Tests  21553 passed | 27 skipped (21580)      21553 + 27 = 21580
no "Worker exited", no failing files
blocks.router.workflow.test.ts  358 tests     submodule live
```

Still no *review* pass over that commit. Recorded here so nobody six weeks from now infers coverage from timestamps.
