### PR TITLE
docs(CLAUDE.md): never open an issue you cannot state a closing condition for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,15 @@ We use markdown documents to discuss plans. Documentation goes in the `docs/` fo
 ### Inline Comments
 Comments from us are marked with `@dev:` and you can leave comments as well with `@ai:`.
 
+### Filing follow-up work
+🔴 **Never open an issue or ticket you cannot state a CLOSING CONDITION for.** Name what ends it **and** who or what checks it — either a mechanical check (a merged PR, a passing command, a metric back under threshold) **or** a named human judgement over named evidence ("X reviews the diff" — never "someone will decide"). If you can name neither, it is **not a work item**: say so in your reply, with why, instead of opening something nobody can close.
+
+Why: a complete sweep of this org's open GitHub objects found that agent-filed **issues** survive dramatically longer than pull requests. The PRs close; the follow-up issues they spawn do not. Duplication turned out **not** to be the problem — closability was. The dominant pattern is *"merge a PR, then file follow-ups"*, and a follow-up filed at merge time is precisely the object born with no closing condition and no owner. Most such issues were also opened with no labels and no comments, so nothing downstream could triage them either.
+
+**If you are an automated producer** — a bot, a scheduled job, or an agent that opens issues — also label what you create `agent/<producer>` and put a machine-readable marker in the body naming the producer and the closing condition, so the object can be reconciled and closed later instead of accumulating. Apply the label on **create only**; never let an update overwrite labels a human has set.
+
+🔴 **Nothing enforces this.** There is no gate, no hook, and no CI check — it binds only the agents and people who read this file. If you are adding a new issue-creating producer, stamp it at the create site, because nothing will catch you if you don't.
+
 ## Tech Stack Overview
 
 ### Core Technologies


### PR DESCRIPTION
Adds one subsection to `CLAUDE.md` → **How to work with us**: never open an issue or ticket you cannot state a closing condition for.

## Why

A complete sweep of this org's open GitHub objects found that agent-filed **issues** survive dramatically longer than pull requests. The PRs close; the follow-up issues they spawn do not.

**Duplication turned out not to be the problem — closability was.** That was the surprise: a dedup-first design was drafted and cut on the measurement. The dominant pattern is *"merge a PR, then file follow-ups"*, and a follow-up filed at merge time is precisely the object born with no closing condition and no owner. Most were also opened with no labels and no comments, so nothing downstream could triage them either.

The rule was already adopted operator-side, but it lived in a per-machine rules file that **does not ship to anyone else** — so it bound one person's sessions while the leak is org-wide. This is the half that reaches every agent and teammate working in *this* repo, which is where the largest single share of those issues was opened.

## What it says

1. **The rule** — name what ends the object **and** who or what checks it. Two accepted forms: a mechanical check (a merged PR, a passing command, a metric back under threshold), **or** a named human judgement over *named evidence* ("X reviews the diff" — never "someone will decide"). Name neither and it isn't a work item: say so in your reply, with why.
2. **For automated producers** — also label `agent/<producer>` and put a machine-readable marker in the body, so an object can be reconciled and closed later instead of accumulating. **Create only**, so an update can never overwrite labels a human has set.
3. 🔴 **Nothing enforces this.** No gate, no hook, no CI check. A reader who assumes something will catch them is the failure the paragraph exists to prevent — a guard that reads as coverage while providing none is worse than none, because it stops anyone looking.

## 🔴 Deliberately qualitative — please keep it that way

This repo is **public** and the underlying measurement was taken over the org's issue trackers. **No absolute volumes, survival percentages, repo names, per-repo figures or internal doc paths appear here.** The shape of the finding is what justifies the rule, and the shape is all that is needed.

Please don't "improve" this by pasting the numbers in. The same mistake was made once already in another public repo during this work and had to be redacted.

## Scope

Documentation only — one subsection, no code, no config, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
