### PR TITLE
docs(tracker): record that ClickHouse deviceId is empty by design

### DIFF
--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -173,6 +173,10 @@ export const ActionType = [
 ] as const;
 export type ActionType = (typeof ActionType)[number];
 
+// No deviceId here. The browser fingerprint that populated the ClickHouse `deviceId`
+// columns was removed in ab6d406f1e (2026-05-11); every row written since 2026-05-14
+// carries an empty string, so `uniqExact(deviceId)` returns 1 and a per-device
+// denominator yields a nonsense rate rather than an error.
 export type TrackRequest = {
   userId: number;
   ip: string;


### PR DESCRIPTION
One comment, one file.

`actions.deviceId` in prod ClickHouse is an empty string on every row. That is **by design**, not a broken collector, and nothing in the repo said so.

**`ab6d406f1e`** (2026-05-11) removed the broprint.js browser fingerprint that populated it. Nothing read the value, and the commit records that it was too crude to be worth fixing: 67% of users collapsed onto 14 collision-wall fingerprints, so the abuse detection it was built for would have run at a 95%+ false positive rate. The ClickHouse columns were deliberately left in place.

## Why this needed a sentence in the code

A column that is empty by design and one that is empty by accident look identical from the data. `uniqExact(deviceId)` returns **1**, because the single distinct value is the empty string, so a per-device denominator built on it produces a rate in the thousands of percent with **no error and no warning**.

Found while measuring feed tag bar click-through (ClickUp `868kv1b9m`), where it was nearly used as a denominator.

## Why the SHA is the load-bearing part

The removal is close to unfindable from the column name. The field was called `fingerprint` in the app and only becomes `deviceId` at the ClickHouse column, so `git log -S deviceId` over this file returns nothing at all. The file was also `src/server/clickhouse/client.ts` back in May, so a search scoped to its current path misses the commit too. The comment names the SHA so the next reader gets to the reasoning in one hop instead of repeating the search.

## Verification

Timeline confirmed against prod ClickHouse. It is one deploy, not a decline:

| Date | rows | non-empty deviceId |
|---|---|---|
| 2026-05-11 | 23,539 | 23,539 |
| 2026-05-12 | 18,364 | 18,364 |
| 2026-05-13 | 12,882 | 11,930 |
| 2026-05-14 | 13,322 | **0** |
| 2026-05-16 / 17 | | 5 / 1 |
| since | | 0 |

Last 7 days: 4,417,461 rows, zero non-empty. All-time 85,636,311 rows with 26,979,470 non-empty, so the column did work before this.

No test and no typecheck run: this is a four-line comment with no code change, and `git diff --stat` is `1 file changed, 4 insertions(+)`.

ClickUp: https://app.clickup.com/t/868kw5eb8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
