### PR TITLE
fix(models): show the moderation card on models pending publish

### DIFF
--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -963,9 +963,6 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                   </div>
                 </Stack>
               </Card>
-              {user?.isModerator && (
-                <ModelModerationCard modelId={model.id} versionFlags={version.flags} />
-              )}
               {/* Component-only model message */}
               {isComponentOnlyModel && (
                 <AlertWithIcon
@@ -986,6 +983,11 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
               />
               {downloadSection}
             </Stack>
+          )}
+          {/* Outside the branch ternary on purpose: `publish-pending` is the branch a
+              moderator reviewing an unpublished or draft model lands in. */}
+          {user?.isModerator && (
+            <ModelModerationCard modelId={model.id} versionFlags={version.flags} />
           )}
           {/* Download-related alert */}
           {hideDownload && (


### PR DESCRIPTION
Fixes [868kv3qn5](https://app.clickup.com/t/8459928/868kv3qn5).

## The bug

The mod-only moderation card on a model page renders inside the `default` arm of the action column's branch ternary in `ModelVersionDetails`. That column picks one of three branches:

| branch | when |
|---|---|
| `request-review` | non-moderator owner of TOS-violating content |
| `publish-pending` | owner-or-moderator, model/version not published, has files + posts, not private |
| `default` | everything else |

A moderator opening an unpublished, draft or scheduled model lands in `publish-pending` — so the card never rendered for the exact state a moderator opens the page to review. That hides the flags row (minor / POI / NSFW / needs-review / cannot-publish / promo-banned / comments-locked plus the version flag badges), the locked-properties row, the profanity and text-moderation footer, the unpublish/takedown/delete timestamps, and the change-history entry point.

Reported against https://civitai.red/models/2883496/jacky.

## The fix

Hoist the render out of the ternary so it sits in the sidebar `Stack` unconditionally, gated only on `user?.isModerator` as before. It now shows in every branch.

`request-review` is unaffected: `showRequestReview` requires `!user?.isModerator`, so a moderator is never in that branch.

This is the same class of regression as the download section, which was pulled out of this ternary into `getModelVersionActionLayout` for the same reason — an owner or moderator reviewing an unpublished model silently lost every download control.

## Note on the scope of the bug

It is broader than the title of the report. Any model routed to `publish-pending` loses the card, which includes drafts and scheduled versions, not only unpublished ones.

## Testing

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` on the changed file — clean
- `pnpm run test:unit:run` — 1374 files / 21547 tests passed, 0 failed
- `model-version-layout.test.ts` — 9 passed

No test was added. The card's visibility is decided by JSX placement, not by a pure function, so a unit test against `getModelVersionActionLayout` would pass whether or not the card sits inside a branch — it would pin nothing. Mounting the real ~1900-line `ModelVersionDetails` in browser mode is not practical here (see the scope note in `ModelVersionDetails.browser.test.tsx`). The comment left at the call site names the invariant instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
