### PR TITLE
fix(collections): gate 'Use as cover image' on manage, and fail loudly when refused

### DIFF
--- a/src/components/Collections/Collection.tsx
+++ b/src/components/Collections/Collection.tsx
@@ -59,6 +59,7 @@ import { SortFilter } from '~/components/Filters';
 import { AdaptiveFiltersDropdown } from '~/components/Filters/AdaptiveFiltersDropdown';
 import { ImageContextMenuProvider } from '~/components/Image/ContextMenu/ImageContextMenuProvider';
 import { MediaFiltersDropdown } from '~/components/Image/Filters/MediaFiltersDropdown';
+import { useUpdateCollectionCoverImage } from '~/components/Image/hooks/useUpdateCollectionCoverImage';
 import { useImageQueryParams } from '~/components/Image/image.utils';
 import ImagesInfinite from '~/components/Image/Infinite/ImagesInfinite';
 import { IsClient } from '~/components/IsClient/IsClient';
@@ -92,10 +93,8 @@ import type { CollectionByIdModel } from '~/types/router';
 import { getRandom } from '~/utils/array-helpers';
 import { formatDate } from '~/utils/date-helpers';
 import { containerQuery } from '~/utils/mantine-css-helpers';
-import { showSuccessNotification } from '~/utils/notifications';
 import { abbreviateNumber } from '~/utils/number-helpers';
 import { removeTags } from '~/utils/string-helpers';
-import { trpc } from '~/utils/trpc';
 import { isDefined } from '~/utils/type-guards';
 import { Gated } from '~/components/Gated/Gated';
 import { BrowsingSettingsAddonsProvider } from '~/providers/BrowsingSettingsAddonsProvider';
@@ -219,8 +218,7 @@ const ImageCollection = ({
     query.sort && imageCollectionSortOptions.includes(query.sort) ? query.sort : ImageSort.Newest;
   const sort = isContestCollection ? ImageSort.Random : defaultSort;
   const period = query.period ?? MetricTimeframe.AllTime;
-  const updateCollectionCoverImageMutation = trpc.collection.updateCoverImage.useMutation();
-  const utils = trpc.useUtils();
+  const updateCollectionCoverImage = useUpdateCollectionCoverImage();
   const currentUser = useCurrentUser();
 
   const [toolSearchOpened, setToolSearchOpened] = useState(false);
@@ -254,7 +252,7 @@ const ImageCollection = ({
   return (
     <ImageContextMenuProvider
       additionalMenuItemsBefore={(image) => {
-        const canUpdateCover = !permissions || !permissions.manage || !image.id;
+        const canUpdateCover = !!permissions?.manage && !!image.id;
 
         return (
           <>
@@ -268,21 +266,10 @@ const ImageCollection = ({
                 onClick={(e: React.MouseEvent) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  updateCollectionCoverImageMutation.mutate(
-                    {
-                      id: collection.id,
-                      imageId: image.id,
-                    },
-                    {
-                      onSuccess: async () => {
-                        showSuccessNotification({
-                          title: 'Cover image updated',
-                          message: 'Collection cover image has been updated',
-                        });
-                        await utils.collection.getById.invalidate({ id: collection.id });
-                      },
-                    }
-                  );
+                  updateCollectionCoverImage({
+                    collectionId: collection.id,
+                    imageId: image.id,
+                  });
                 }}
               >
                 Use as cover image

--- a/src/components/Image/hooks/useUpdateCollectionCoverImage.ts
+++ b/src/components/Image/hooks/useUpdateCollectionCoverImage.ts
@@ -1,20 +1,26 @@
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
-import { showSuccessNotification } from '~/utils/notifications';
 
 export function useUpdateCollectionCoverImage() {
   const utils = trpc.useUtils();
 
   const updateCollectionCoverImageMutation = trpc.collection.updateCoverImage.useMutation({
-    onSuccess: async () => {
+    onSuccess: async (_, { id }) => {
       showSuccessNotification({
         title: 'Cover image updated',
         message: 'Collection cover image has been updated',
       });
+      await utils.collection.getById.invalidate({ id });
+    },
+    onError: (error) => {
+      showErrorNotification({
+        title: 'Unable to update cover image',
+        error: new Error(error.message),
+      });
     },
   });
 
-  return async function ({ collectionId, imageId }: { collectionId: number; imageId: number }) {
-    updateCollectionCoverImageMutation.mutateAsync({ id: collectionId, imageId });
-    await utils.collection.getById.invalidate({ id: collectionId });
+  return function ({ collectionId, imageId }: { collectionId: number; imageId: number }) {
+    updateCollectionCoverImageMutation.mutate({ id: collectionId, imageId });
   };
 }

--- a/src/server/services/__tests__/collection-cover-image-authorization.test.ts
+++ b/src/server/services/__tests__/collection-cover-image-authorization.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const mockDbRead = dbMock.dbRead;
+const mockDbWrite = dbMock.dbWrite;
+
+const { updateCollectionCoverImage } = await import('~/server/services/collection.service');
+
+const COLLECTION_ID = 10;
+const OWNER_ID = 999;
+const OUTSIDER_ID = 12_345;
+const IMAGE_ID = 55;
+
+// `getUserCollectionPermissionsByIds` reads the collection row through `$queryRaw`; `manage` is
+// derived from it, so the row is the only input that decides authorization here.
+function arrangeCollection({
+  contributorPermissions = null,
+}: { contributorPermissions?: string[] | null } = {}) {
+  mockDbRead.$queryRaw.mockReset();
+  mockDbWrite.collection.update.mockReset();
+  mockDbRead.$queryRaw.mockResolvedValue([
+    {
+      id: COLLECTION_ID,
+      read: 'Public',
+      write: 'Private',
+      userId: OWNER_ID,
+      type: 'Image',
+      mode: null,
+      contributorPermissions,
+    },
+  ]);
+  mockDbWrite.collection.update.mockResolvedValue({
+    id: COLLECTION_ID,
+    image: { id: IMAGE_ID, url: 'abc', ingestion: 'Scanned', type: 'image' },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('updateCollectionCoverImage authorization', () => {
+  // The regression: this used to `return` instead of throwing, so tRPC resolved cleanly and the
+  // client's `onSuccess` reported "Cover image updated" for a write the server had just refused.
+  it('rejects a viewer without manage instead of resolving silently', async () => {
+    arrangeCollection();
+
+    await expect(
+      updateCollectionCoverImage({
+        input: { id: COLLECTION_ID, imageId: IMAGE_ID, userId: OUTSIDER_ID },
+      })
+    ).rejects.toThrowError(/permission/i);
+
+    expect(mockDbWrite.collection.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the cover for a user who holds manage', async () => {
+    arrangeCollection();
+
+    const result = await updateCollectionCoverImage({
+      input: { id: COLLECTION_ID, imageId: IMAGE_ID, userId: OWNER_ID },
+    });
+
+    expect(result).toMatchObject({ id: COLLECTION_ID });
+    expect(mockDbWrite.collection.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: COLLECTION_ID },
+        data: { image: { connect: { id: IMAGE_ID } } },
+      })
+    );
+  });
+});

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -1499,7 +1499,7 @@ export const updateCollectionCoverImage = async ({
   });
 
   if (!permission.manage) {
-    return;
+    throw throwAuthorizationError('You do not have permission to manage this collection');
   }
 
   // TODO if necessary, check image ownership here


### PR DESCRIPTION
Fixes [868kv5b2d](https://app.clickup.com/t/8459928/868kv5b2d).

## The bug

"Use as cover image" in the image kebab inside a collection was shown to exactly the wrong users, and reported success for a write the server had refused. Two independent defects that happened to cancel each other out.

**1. The visibility condition was inverted** — `src/components/Collections/Collection.tsx`

```ts
const canUpdateCover = !permissions || !permissions.manage || !image.id;
```

Named "can update cover", true precisely when the viewer does *not* have `manage`. That is both halves of the report: the option rendered on every collection the reporter did not own, and was missing from their own. Introduced in `7023184f5d4` (2024-08-27).

**2. The service refused silently** — `src/server/services/collection.service.ts`

```ts
if (!permission.manage) {
  return;
}
```

An early return rather than a throw. tRPC saw a clean resolve, the mutation's `onSuccess` fired, and the UI showed "Cover image updated" for a declined write — on the site's main Featured collection, in the reported case. Predates the inverted boolean (`81438599688`, 2023-08-23) and was harmless until the button started appearing for unauthorised users.

**No unauthorised cover was ever written.** The two conditions are mutually exclusive: the menu item only rendered when you lacked `manage`, and the handler only acted when you had it. This is a trust and correctness problem, not a security one.

## The fix

- `canUpdateCover` becomes `!!permissions?.manage && !!image.id`.
- The service throws `throwAuthorizationError` instead of returning, matching the neighbouring `manage` check in `upsertCollection` (which already throws).
- The click path now goes through the existing `useUpdateCollectionCoverImage` hook instead of a second inline copy of the same mutation.

That last one is not cleanup for its own sake. The hook was dead code — zero callers — and carried its own version of this bug: no `onError`, and an un-awaited `mutateAsync` followed by an unconditional cache invalidation. Once the service starts throwing, that shape becomes an unhandled rejection with no user-visible feedback. Rather than leave a second broken copy in the tree, the hook gains an `onError` and moves the invalidation into `onSuccess`, where a refused write can no longer trigger it. `Collection.tsx` drops its local mutation, `trpc.useUtils()` and its now-unused imports.

## The sweep the task asked for

The neighbouring `manage` check at `collection.service.ts:1211` already throws — no change needed. Sweeping the rest of the service for the same `return;`-instead-of-throw shape turned up three other bare returns, none of them permission checks:

- the moderated-auto-tag refusal, which is a deliberate skip already logged to Axiom
- a missing-metadata guard
- a nothing-to-do guard on empty id arrays

## Testing

Adds `src/server/services/__tests__/collection-cover-image-authorization.test.ts` covering both directions of the service's permission check.

Verified it fails on a revert rather than passing vacuously — restoring the `return;` produces:

```
Error: promise resolved "undefined" instead of rejecting
```

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` on the changed files — clean (2 pre-existing unused-import warnings in `Collection.tsx`, untouched)
- `pnpm run test:unit:run` — 1375 files / 21549 tests passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
