### PR TITLE
fix(apps): stop /apps/run growing a second scrollbar around the block iframe

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -224,8 +224,13 @@ const REVIEW_NACK_MESSAGE = 'not available in review preview';
  * a narrower window. Below the floor that is the right call (a scrollbar beats
  * unreachable content), so the number's only job is to make the band as small as
  * it can be while still catching the degenerate case. Raising it widens the
- * population that sees two scrollbars; `PageBlockHostScrollFit.browser.test.tsx`
- * bounds it on BOTH sides for that reason.
+ * population that sees two scrollbars, so the value is bounded on BOTH sides —
+ * in `__tests__/pageRunScrollContract.test.ts` (the GATING node suite; that is
+ * the copy that can block a merge) and again in
+ * `PageBlockHostScrollFit.browser.test.tsx` (report-only, which is why it is not
+ * the only one). The NUMBERS deliberately live in those tests, not here: a band
+ * declared beside the value it bounds can be moved in the same edit. What lives
+ * here is the ARITHMETIC that justifies them.
  *
  * THE ARITHMETIC, which decides who lands in the band:
  *
@@ -398,12 +403,13 @@ export interface PageBlockHostProps {
    *     Correct ONLY for a mounter sitting inside a SCROLLING ancestor that does
    *     not otherwise bound its height: the dev tunnel (`/apps/dev/<blockId>`,
    *     default `AppLayout` → `ScrollArea`) and the mod-review preview (inside a
-   *     modal). Without it the host would collapse to the chrome bar and the
-   *     iframe would be sized only by `FILL_MIN_HEIGHT_PX` — measured 300px of
-   *     host, 31px of chrome, 269px of iframe, regardless of how much room the
-   *     page actually has. Usable, but no longer FILLING anything.
+   *     modal). Without it those hosts would be sized only by
+   *     `FILL_MIN_HEIGHT_PX` — measured 300px of host, 31px of chrome, 269px of
+   *     iframe, regardless of how much room the page actually has. Usable, but
+   *     no longer FILLING anything.
    *
-   *   'fill' — the host fills its parent EXACTLY (`flex: 1; min-height: 0`) and
+   *   'fill' — the host fills its parent (`flex: 1`, floored at
+   *     `FILL_MIN_HEIGHT_PX`) and
    *     claims no viewport-derived height of its own. Requires the mounter's
    *     ancestor chain to already bound the height — i.e. a page declared
    *     `Page(…, { scrollable: false })`, whose `AppLayout` branch is

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -204,6 +204,39 @@ type Status = 'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token' | 'error';
 // (gotcha #73). Module-scope so referencing it in a handler adds no effect dep.
 const REVIEW_NACK_MESSAGE = 'not available in review preview';
 
+/**
+ * The floor a `fit="fill"` host will not shrink below, in px.
+ *
+ * 🔴 WHY A FLOOR EXISTS AT ALL. `fit="fill"` is only correct under a
+ * `Page(…, { scrollable: false })` layout, where EVERY ancestor is
+ * `overflow-hidden`. That is what removes the double scrollbar — and it also
+ * means the page is the only thing left that can offer a scrollbar. The site's
+ * fixed chrome cannot shrink (header 60 + `AppFooter` 45 + its `mt-3` 12 +
+ * `AdhesiveAd` 90 desktop / 50 mobile), so with a bare `min-height: 0` the app
+ * absorbed the ENTIRE shortfall on a short viewport and the overflow was simply
+ * clipped away with nothing to scroll.
+ *
+ * Measured before this floor existed: a ~360px phone-landscape viewport left the
+ * host 153px, and a 250px viewport collapsed it to 0 — with `outerScrollbar =
+ * false` at every step. A 1366×768 laptop at 200% browser zoom lands in the same
+ * band. That is WCAG 1.4.4 / 1.4.10 (content unreachable on zoom/reflow), i.e.
+ * strictly worse than the cosmetic spare scrollbar the `fill` mode was
+ * introduced to remove.
+ *
+ * 400 is chosen to sit ABOVE the ~395px a real block renders at (and above the
+ * synthetic install's `minHeight: 200`) while staying below what any ordinary
+ * viewport leaves: a 768px laptop has 561px after chrome, so the floor never
+ * fires there. It is deliberately NOT derived from `100dvh` — that arithmetic is
+ * exactly what this PR removed.
+ *
+ * The floor only helps if something can scroll once it binds, so the run page's
+ * wrapper carries `overflowY: 'auto'` as the scroll container of last resort.
+ * Both halves are asserted in `PageBlockHostScrollFit.browser.test.tsx`
+ * ("short viewports — squeezed, but never unreachable"), at a short viewport AND
+ * at a normal one so a floor that fired for everyone would fail.
+ */
+export const FILL_MIN_HEIGHT_PX = 400;
+
 export interface PageBlockHostProps {
   /** AppBlock id (`apb_*`) — used to build the BLOCK_INIT ids + trust chrome. */
   appBlockId: string;
@@ -3507,12 +3540,14 @@ export function PageBlockHost({
         // viewport arithmetic can never agree with its own scroll viewport.
         ...(fit === 'fill'
           ? {
-              // Fill the (already bounded) parent exactly. `minHeight: 0` is
-              // load-bearing: a flex item's default `min-height: auto` floors it
-              // at its content height, which would push the column past the
-              // parent and hand the scrollbar straight back.
+              // Fill the (already bounded) parent — but never below
+              // `FILL_MIN_HEIGHT_PX`. See that constant for why a bare
+              // `minHeight: 0` here was a WCAG regression rather than a tidier
+              // fix. Above the floor `flex: 1` still resolves to exactly the
+              // parent's height, so nothing overflows and no outer scrollbar
+              // appears; the floor is inert at every ordinary viewport.
               flex: 1,
-              minHeight: 0,
+              minHeight: FILL_MIN_HEIGHT_PX,
             }
           : {
               // Full viewport under the global header. The host chrome sits on

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -214,8 +214,9 @@ const REVIEW_NACK_MESSAGE = 'not available in review preview';
  * fixed chrome cannot shrink, so with a bare `min-height: 0` the app absorbed
  * the ENTIRE shortfall on a short viewport and the overflow was simply clipped
  * away with nothing to scroll. Measured before this floor existed: 153px of host
- * at a ~360px viewport, and 0px at 250px, with `outerScrollbar = false` at every
- * step. That is WCAG 1.4.4 / 1.4.10 — strictly worse than the cosmetic spare
+ * at a ~360px-tall SHORT DESKTOP window (the 90px ad; a phone in landscape gets
+ * the 50px one and lands at 193 — see the table below), and 0px at 250px, with
+ * `outerScrollbar = false` at every step. That is WCAG 1.4.4 / 1.4.10 — strictly worse than the cosmetic spare
  * scrollbar `fill` mode was introduced to remove.
  *
  * 🔴 THE FLOOR IS A TRADE, NOT A FREE WIN, AND ITS VALUE IS THE WHOLE TRADE.

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -211,31 +211,50 @@ const REVIEW_NACK_MESSAGE = 'not available in review preview';
  * `Page(…, { scrollable: false })` layout, where EVERY ancestor is
  * `overflow-hidden`. That is what removes the double scrollbar — and it also
  * means the page is the only thing left that can offer a scrollbar. The site's
- * fixed chrome cannot shrink (header 60 + `AppFooter` 45 + its `mt-3` 12 +
- * `AdhesiveAd` 90 desktop / 50 mobile), so with a bare `min-height: 0` the app
- * absorbed the ENTIRE shortfall on a short viewport and the overflow was simply
- * clipped away with nothing to scroll.
+ * fixed chrome cannot shrink, so with a bare `min-height: 0` the app absorbed
+ * the ENTIRE shortfall on a short viewport and the overflow was simply clipped
+ * away with nothing to scroll. Measured before this floor existed: 153px of host
+ * at a ~360px viewport, and 0px at 250px, with `outerScrollbar = false` at every
+ * step. That is WCAG 1.4.4 / 1.4.10 — strictly worse than the cosmetic spare
+ * scrollbar `fill` mode was introduced to remove.
  *
- * Measured before this floor existed: a ~360px phone-landscape viewport left the
- * host 153px, and a 250px viewport collapsed it to 0 — with `outerScrollbar =
- * false` at every step. A 1366×768 laptop at 200% browser zoom lands in the same
- * band. That is WCAG 1.4.4 / 1.4.10 (content unreachable on zoom/reflow), i.e.
- * strictly worse than the cosmetic spare scrollbar the `fill` mode was
- * introduced to remove.
+ * 🔴 THE FLOOR IS A TRADE, NOT A FREE WIN, AND ITS VALUE IS THE WHOLE TRADE.
+ * When `available < FILL_MIN_HEIGHT_PX` the host overflows the page wrapper and
+ * that wrapper grows a scrollbar — beside the block's own, i.e. THIS PR'S BUG in
+ * a narrower window. Below the floor that is the right call (a scrollbar beats
+ * unreachable content), so the number's only job is to make the band as small as
+ * it can be while still catching the degenerate case. Raising it widens the
+ * population that sees two scrollbars; `PageBlockHostScrollFit.browser.test.tsx`
+ * bounds it on BOTH sides for that reason.
  *
- * 400 is chosen to sit ABOVE the ~395px a real block renders at (and above the
- * synthetic install's `minHeight: 200`) while staying below what any ordinary
- * viewport leaves: a 768px laptop has 561px after chrome, so the floor never
- * fires there. It is deliberately NOT derived from `100dvh` — that arithmetic is
- * exactly what this PR removed.
+ * THE ARITHMETIC, which decides who lands in the band:
+ *
+ *   available = innerHeight − 60 (header) − 57 (AppFooter 45 + its mt-3 12)
+ *                           − AdhesiveAd (90 desktop / 50 mobile / 0 for paid)
+ *                           − RewardsBonusBanner (~32 when active)
+ *
+ * 🔴 `innerHeight`, NOT the screen height — an earlier version of this comment
+ * justified 400 with "a 768px laptop has 561px after chrome, so the floor never
+ * fires there". That subtracted chrome from the PANEL height. A maximised
+ * browser on a 768px screen has `innerHeight ≈ 650` once the OS taskbar, tab
+ * strip, omnibox and bookmarks bar are gone, so the real margin was ~43px, not
+ * 161 — one bookmarks bar or 110% zoom would have eaten it.
+ *
+ * At 300, the floor fires below roughly `innerHeight < 467` (logged-out mobile)
+ * / `< 507` (logged-out desktop). That clears the mainstream portrait phones a
+ * 400 floor caught — 375×667-class Safari (`innerHeight ≈ 553`, available ≈ 386)
+ * and 360×640 Android (`≈ 560`, available ≈ 393) — while still protecting phone
+ * LANDSCAPE (~360 tall → available ≈ 193) and heavy desktop zoom, which is where
+ * the unreachable-content case actually lives.
+ *
+ * It is deliberately NOT derived from `100dvh` — that arithmetic is exactly what
+ * this PR removed. Note the block's own area is `floor − AppBlockChrome`, so the
+ * usable figure is meaningfully smaller than the constant.
  *
  * The floor only helps if something can scroll once it binds, so the run page's
  * wrapper carries `overflowY: 'auto'` as the scroll container of last resort.
- * Both halves are asserted in `PageBlockHostScrollFit.browser.test.tsx`
- * ("short viewports — squeezed, but never unreachable"), at a short viewport AND
- * at a normal one so a floor that fired for everyone would fail.
  */
-export const FILL_MIN_HEIGHT_PX = 400;
+export const FILL_MIN_HEIGHT_PX = 300;
 
 export interface PageBlockHostProps {
   /** AppBlock id (`apb_*`) — used to build the BLOCK_INIT ids + trust chrome. */
@@ -380,7 +399,8 @@ export interface PageBlockHostProps {
    *     not otherwise bound its height: the dev tunnel (`/apps/dev/<blockId>`,
    *     default `AppLayout` → `ScrollArea`) and the mod-review preview (inside a
    *     modal). Without it the host would collapse to the chrome bar and the
-   *     iframe (`flex: 1` of an auto-height parent) would render 0px tall.
+   *     iframe (`flex: 1` of an auto-height parent) would letterbox to roughly
+   *     its ~150px intrinsic replaced-element height.
    *
    *   'fill' — the host fills its parent EXACTLY (`flex: 1; min-height: 0`) and
    *     claims no viewport-derived height of its own. Requires the mounter's

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -337,6 +337,42 @@ export interface PageBlockHostProps {
    * Default false → a mounter that hasn't wired it shows no dead links.
    */
   canOpenPage?: boolean;
+  /**
+   * How the host sizes itself VERTICALLY. This is the double-scrollbar axis, so
+   * it is spelled out rather than inferred from `surface`.
+   *
+   *   'viewport' (DEFAULT, the historical behaviour) — the host claims
+   *     `min-height: calc(100dvh - 60px)` and lets whatever is above it scroll.
+   *     Correct ONLY for a mounter sitting inside a SCROLLING ancestor that does
+   *     not otherwise bound its height: the dev tunnel (`/apps/dev/<blockId>`,
+   *     default `AppLayout` → `ScrollArea`) and the mod-review preview (inside a
+   *     modal). Without it the host would collapse to the chrome bar and the
+   *     iframe (`flex: 1` of an auto-height parent) would render 0px tall.
+   *
+   *   'fill' — the host fills its parent EXACTLY (`flex: 1; min-height: 0`) and
+   *     claims no viewport-derived height of its own. Requires the mounter's
+   *     ancestor chain to already bound the height — i.e. a page declared
+   *     `Page(…, { scrollable: false })`, whose `AppLayout` branch is
+   *     `flex-1 overflow-hidden` all the way down.
+   *
+   * 🔴 WHY THE DEFAULT IS WRONG FOR A FULL-PAGE APP, and why 'fill' exists.
+   * `calc(100dvh - 60px)` subtracts ONLY the site header. Inside the default
+   * scrolling layout the actual space left to the page is
+   * `100dvh − header − subNav − its mb-3 − RewardsBonusBanner − AppFooter −
+   * AdhesiveAd`, every term of which is ≥ 0 and several of which are > 0 on a
+   * normal render. So the host is UNCONDITIONALLY taller than its scroll
+   * viewport: the layout's `ScrollArea` grows a vertical scrollbar it can only
+   * ever scroll by that residue, while the block's own document scrolls inside
+   * the iframe — two scrollbars, side by side, for one scrollable thing. It is
+   * arithmetic, not a race: there is no viewport size at which the two heights
+   * agree. `'fill'` removes the magic number instead of re-tuning it.
+   *
+   * 🔴 The `60` is also a SECOND COPY of `HEADER_HEIGHT` (private to
+   * `AppHeader.tsx`), so a header resize silently re-opens this on any surface
+   * still on `'viewport'`. Prefer moving a mounter to `'fill'` over teaching
+   * this file a new constant.
+   */
+  fit?: 'viewport' | 'fill';
 }
 
 export function PageBlockHost({
@@ -366,6 +402,7 @@ export function PageBlockHost({
   reviewMode = false,
   reviewRunForReal = false,
   canOpenPage = false,
+  fit = 'viewport',
 }: PageBlockHostProps) {
   const router = useRouter();
   // MOD REVIEW SANDBOX (#2831): the side-effect NACK gate. Side-effecting handlers
@@ -3465,13 +3502,30 @@ export function PageBlockHost({
       style={{
         display: 'flex',
         flexDirection: 'column',
-        // Full viewport under the global header. The host chrome sits on top;
-        // the iframe fills the rest.
-        height: '100%',
-        minHeight: 'calc(100dvh - 60px)',
         width: '100%',
+        // See the `fit` prop for why these are the two modes and why the
+        // viewport arithmetic can never agree with its own scroll viewport.
+        ...(fit === 'fill'
+          ? {
+              // Fill the (already bounded) parent exactly. `minHeight: 0` is
+              // load-bearing: a flex item's default `min-height: auto` floors it
+              // at its content height, which would push the column past the
+              // parent and hand the scrollbar straight back.
+              flex: 1,
+              minHeight: 0,
+            }
+          : {
+              // Full viewport under the global header. The host chrome sits on
+              // top; the iframe fills the rest.
+              height: '100%',
+              minHeight: 'calc(100dvh - 60px)',
+            }),
       }}
       data-testid="app-page-frame"
+      // Observable sizing mode, so a regression test (and DevTools) can assert
+      // WHICH branch a surface took rather than re-deriving it from computed
+      // styles that jsdom does not resolve.
+      data-fit={fit}
       data-block-instance-id={blockInstanceId}
       // #3/#6: surface the consent signal as an observable attribute. The page
       // token still mints with the granted subset (so the block loads — consent
@@ -3515,7 +3569,26 @@ export function PageBlockHost({
         // terminal path (timeout / fatal / no_token / error, which also flip
         // `showIframe` to false and render the BlockFallback below) — so it can
         // never spin forever.
-        <Box style={{ position: 'relative', flex: 1, display: 'flex' }}>
+        <Box
+          style={{
+            position: 'relative',
+            flex: 1,
+            display: 'flex',
+            // 🔴 CONFINE THE LAUNCH-REVEAL TRANSFORM. While the block is still
+            // handshaking the iframe carries `translateY(8px)`, and a transform
+            // does not change layout but DOES extend the SCROLLABLE OVERFLOW
+            // region — so those 8px pushed past this wrapper and asked the
+            // nearest scrolling ancestor for a scrollbar. Measured, not
+            // inferred: wrapper `bottom=716`, iframe `bottom=724`, container
+            // `scrollHeight 724` vs `clientHeight 716`. Purely decorative
+            // motion should never be able to do that. Clipping here is also
+            // free — the iframe fills this box exactly, so nothing else can be
+            // cut off. Covered by the GREEN ARM in
+            // `PageBlockHostScrollFit.browser.test.tsx`, which asserts exact
+            // equality precisely so an 8px leak cannot hide in a tolerance.
+            overflow: 'hidden',
+          }}
+        >
           <iframe
             // #4 Retry: re-key on `reloadNonce` so a retry UNMOUNTS + REMOUNTS
             // the iframe (fresh contentWindow), not just reloads its src — the

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -399,8 +399,9 @@ export interface PageBlockHostProps {
    *     not otherwise bound its height: the dev tunnel (`/apps/dev/<blockId>`,
    *     default `AppLayout` → `ScrollArea`) and the mod-review preview (inside a
    *     modal). Without it the host would collapse to the chrome bar and the
-   *     iframe (`flex: 1` of an auto-height parent) would letterbox to roughly
-   *     its ~150px intrinsic replaced-element height.
+   *     iframe would be sized only by `FILL_MIN_HEIGHT_PX` — measured 300px of
+   *     host, 31px of chrome, 269px of iframe, regardless of how much room the
+   *     page actually has. Usable, but no longer FILLING anything.
    *
    *   'fill' — the host fills its parent EXACTLY (`flex: 1; min-height: 0`) and
    *     claims no viewport-derived height of its own. Requires the mounter's

--- a/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
@@ -218,7 +218,8 @@ function renderInScrollChain(fit: 'viewport' | 'fill', containerHeight: number) 
  * the entire shortfall.
  *
  * `available` is what is left for the page after that chrome. At a phone in
- * landscape (~360 CSS px) or a 1366×768 laptop at 200% zoom (~384 CSS px) it
+ * landscape (~360 CSS px) or a 1366×768 laptop at 200% zoom (~325 CSS px of `innerHeight`, NOT 768/2 — the
+ * panel-height error corrected on `FILL_MIN_HEIGHT_PX`) it
  * lands near 150px — far too little to use, and with `overflow-hidden` above
  * there would be nothing to scroll to reach the rest.
  */
@@ -342,7 +343,11 @@ describe('PageBlockHost — `fit` decides whether the page grows a SECOND scroll
       // A literal cannot be satisfied by construction, so this is what actually
       // holds the floor down. It is intentionally a little below the constant so
       // a small deliberate retune does not fail the suite.
-      expect(frame.getBoundingClientRect().height).toBeGreaterThanOrEqual(280);
+      // 270, not 280: the band below PERMITS a floor of 280, and the rendered
+      // height equals the constant to the pixel, so a 280 literal would pass with
+      // zero slack — the two guards would stop being independent at exactly the
+      // value the band allows. 270 keeps the headroom this comment claims.
+      expect(frame.getBoundingClientRect().height).toBeGreaterThanOrEqual(270);
     });
 
     /**
@@ -364,7 +369,7 @@ describe('PageBlockHost — `fit` decides whether the page grows a SECOND scroll
       expect(FILL_MIN_HEIGHT_PX).toBeLessThanOrEqual(340);
     });
 
-    test('and what is squeezed out stays REACHABLE — exactly one scrollbar, not zero', async () => {
+    test('and what is squeezed out stays REACHABLE — user-scrollable, not merely overflowing', async () => {
       const available = 153;
       renderInNoScrollChain(available);
       await expect.element(page.getByTestId('app-page-frame')).toBeInTheDocument();

--- a/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
@@ -217,9 +217,17 @@ function renderInScrollChain(fit: 'viewport' | 'fill', containerHeight: number) 
  * 90 desktop / 50 mobile) cannot shrink, so on a short viewport the app absorbs
  * the entire shortfall.
  *
- * `available` is what is left for the page after that chrome. A phone in
- * landscape (~360 CSS px) lands near 150px — which is the `available = 153` the
- * tests below use. A 1366×768 laptop at 200% zoom lands LOWER, around 86–118:
+ * `available` is what is left for the page after that chrome. The `available =
+ * 153` the tests below use is 360 − 60 − 57 − 90, i.e. a short DESKTOP window
+ * (and the headless fixture, whose UA is not mobile).
+ *
+ * ⚠️ It is NOT a phone in landscape, which an earlier version of this comment
+ * claimed. `isMobileDevice()` (`~/hooks/useIsMobile`) keys on UA/`ontouchstart`,
+ * NOT on width, so a phone is mobile in landscape too and gets the 50px ad, not
+ * the 90px one: ~360 CSS px tall lands at 193 (161 with the RewardsBonusBanner),
+ * which is what `FILL_MIN_HEIGHT_PX`'s own table says. Both are below the floor,
+ * so the tests' conclusion is unaffected — but the two docs must not disagree by
+ * 40px about one scenario. A 1366×768 laptop at 200% zoom lands LOWER, around 86–118:
  * its `innerHeight` is ~325, not 768/2 = 384 (the panel-height error corrected
  * on `FILL_MIN_HEIGHT_PX`; the old 384 is where a second "~150px" came from).
  * Either way it is far too little to use, and with `overflow-hidden` above there

--- a/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
@@ -1,0 +1,261 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace import for the `importOriginal` spread below (the repo's
+// local-rules/no-wholesale-module-mock cure). NOT `typeof import(...)`, which
+// @typescript-eslint/consistent-type-imports rejects.
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * DOUBLE SCROLLBAR on `/apps/run/<slug>` — the layout regression, measured.
+ *
+ * THE SYMPTOM. The run page showed TWO vertical scrollbars side by side: the
+ * site layout's own `ScrollArea` grew one, and the block's document inside the
+ * iframe had another. Only one of them scrolled anything the viewer wanted.
+ *
+ * THE MECHANISM, and why it was unconditional rather than a race. `PageBlockHost`
+ * claimed `min-height: calc(100dvh - 60px)` — the viewport minus the site header
+ * ONLY. But in the default (`scrollable: true`) layout the space actually
+ * available to the page is
+ *
+ *     100dvh − header − subNav − subNav's mb-3 − RewardsBonusBanner
+ *            − AppFooter − AdhesiveAd
+ *
+ * Every term after `header` is ≥ 0 and several are > 0 on a normal render, so
+ * the host was ALWAYS taller than the scroll viewport it sat in. There is no
+ * window size at which the two agree — which is why this could not be tuned
+ * away, only removed. The fix is `fit="fill"` (host claims no height of its own)
+ * plus `Page(…, { scrollable: false })` on the route (the ancestor chain bounds
+ * it instead, `overflow-hidden` throughout).
+ *
+ * 🔴 WHY THIS TEST MEASURES INSTEAD OF READING STYLES. The defect is a LAYOUT
+ * outcome, so a jsdom assertion on `style.minHeight` would restate the
+ * implementation and pass whatever the browser then did with it. This runs in
+ * real Chromium and asks the only question that matters — does the scroll
+ * container overflow? — via `scrollHeight > clientHeight`, which is exactly what
+ * makes the browser paint a scrollbar.
+ *
+ * 🔴 THE `viewport` CASE IS THE RED ARM AND MUST STAY. It is the reproduction:
+ * it pins that the OLD styling really does overflow a realistic viewport, so the
+ * `fill` case's green is a fact about the fix rather than about the fixture. Both
+ * arms render the SAME host into the SAME container, differing only in `fit`.
+ * Delete the red arm and the green one stops proving anything.
+ *
+ * NOTE ON REACH: CI runs the node `unit` project only — the browser suites are
+ * not run there. The half of this contract that gates a merge is the source-scan
+ * guard in `__tests__/pageRunScrollContract.test.ts`, which pins that the route
+ * ships BOTH halves together. This file is the empirical half.
+ */
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  // FeatureFlagsProvider (in PageBlockHost's real render graph) statically
+  // imports `setTrpcBatchingEnabled`; the spread keeps every other real export
+  // so a new one can't silently arrive as `undefined` and take the whole file
+  // down to "0 tests collected".
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      publishGenerationOutputs: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getImagesByIds: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+const baseProps = {
+  appBlockId: 'apb_scrollfit',
+  blockId: 'scroll-fit-app',
+  appId: 'app_scrollfit',
+  blockInstanceId: 'page_apb_scrollfit',
+  appName: 'Scroll Fit App',
+  iframeSrc: SAME_ORIGIN_SRC,
+  surface: 'page-run' as const,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'scroll-fit-app',
+  token: 'tok_scrollfit',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: [] as string[],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: null,
+  theme: 'light' as const,
+};
+
+/**
+ * The layout chain the run page actually sits in, reduced to the two properties
+ * that decide overflow:
+ *
+ *   - `overflow-y: auto` — the scroll container. `AppLayout`'s `ScrollArea` gets
+ *     this from `.scroll-area { overflow-x: hidden }` (CSS computes the
+ *     unspecified `visible` axis to `auto` when the other is not `visible`).
+ *   - a BOUNDED height — the ScrollArea is stretched by its flex-row parent to
+ *     `viewport − header`, then further reduced by the sub-nav / banner / footer
+ *     rendered inside it.
+ *
+ * `containerHeight` is deliberately SMALLER than `calc(100dvh - 60px)` would be
+ * in this browser, because that gap IS the bug: it is the space the site chrome
+ * takes that the old calc never subtracted. Derived from the live viewport at
+ * run time rather than hardcoded, so the fixture cannot drift away from the
+ * window the runner actually opened.
+ */
+function layoutChainHeights() {
+  // What the OLD host claimed. 60 is `HEADER_HEIGHT`, restated by the old style
+  // exactly as the bug did.
+  const oldClaimedMinHeight = window.innerHeight - 60;
+  // What a real run page has left after the site chrome inside the scroll area.
+  // 120px stands in for sub-nav + mb-3 + banner + footer; any positive value
+  // reproduces it, and this one is comfortably above scrollbar-rounding noise.
+  const containerHeight = oldClaimedMinHeight - 120;
+  return { oldClaimedMinHeight, containerHeight };
+}
+
+/**
+ * Render, then WAIT for the host to be in the document before measuring.
+ *
+ * `render` returns before React has committed, so a synchronous
+ * `page.getByTestId(...).element()` throws `Cannot find element` against an
+ * empty container — which is how this file first ran: 4 failures that looked
+ * like the component rendering nothing. Awaiting the frame is also what gives
+ * the browser a chance to lay out, without which every height read is 0.
+ */
+async function mountAndSettle(fit: 'viewport' | 'fill', containerHeight: number) {
+  renderInScrollChain(fit, containerHeight);
+  await expect.element(page.getByTestId('app-page-frame')).toBeInTheDocument();
+}
+
+function renderInScrollChain(fit: 'viewport' | 'fill', containerHeight: number) {
+  return renderWithProviders(
+    <div
+      data-testid="scroll-chain"
+      style={{
+        height: `${containerHeight}px`,
+        // The property that turns overflow into a visible scrollbar.
+        overflowY: 'auto',
+        overflowX: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      {/* `fill` needs a growing flex item to resolve against — this is the run
+          page's own wrapper Box, same three properties. */}
+      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+        <PageBlockHost {...baseProps} fit={fit} />
+      </div>
+    </div>
+  );
+}
+
+function scrollChain() {
+  return page.getByTestId('scroll-chain').element() as HTMLElement;
+}
+
+describe('PageBlockHost — `fit` decides whether the page grows a SECOND scrollbar', () => {
+  test('the fixture is a real scroll container, and the old claim really is taller than it', () => {
+    // POSITIVE CONTROL on the fixture itself, before either arm is believed.
+    // Without this, a container that silently had no bounded height (or no
+    // overflow rule) would report "no overflow" in BOTH arms and the fill case
+    // would pass for the wrong reason — the reassuring-zero failure mode.
+    const { oldClaimedMinHeight, containerHeight } = layoutChainHeights();
+    expect(containerHeight).toBeGreaterThan(0);
+    expect(oldClaimedMinHeight).toBeGreaterThan(containerHeight);
+  });
+
+  test('RED ARM — `fit="viewport"` overflows its scroll container (the reported bug)', async () => {
+    const { containerHeight } = layoutChainHeights();
+    await mountAndSettle('viewport', containerHeight);
+
+    const chain = scrollChain();
+    // The container is bounded as intended...
+    expect(chain.clientHeight).toBeLessThanOrEqual(containerHeight);
+    // ...and the host pushes past it, which is precisely what paints scrollbar
+    // #1 while the iframe paints #2.
+    expect(chain.scrollHeight).toBeGreaterThan(chain.clientHeight);
+  });
+
+  test('GREEN ARM — `fit="fill"` fits exactly, so the outer scrollbar never appears', async () => {
+    const { containerHeight } = layoutChainHeights();
+    await mountAndSettle('fill', containerHeight);
+
+    const chain = scrollChain();
+    // `scrollHeight` is floored at `clientHeight`, so equality is "nothing to
+    // scroll". Assert it directly rather than via a `not.toBeGreaterThan`, which
+    // would also pass if the host had collapsed to zero height.
+    expect(chain.scrollHeight).toBe(chain.clientHeight);
+    // Guard the OTHER failure direction: `fill` must not collapse the host. A
+    // zero-height host would also produce "no overflow" — and a 0px iframe is a
+    // worse bug than a spare scrollbar.
+    const frame = page.getByTestId('app-page-frame').element() as HTMLElement;
+    expect(frame.getBoundingClientRect().height).toBeGreaterThan(containerHeight / 2);
+  });
+
+  test('`data-fit` reports which branch a surface took', async () => {
+    const { containerHeight } = layoutChainHeights();
+    await mountAndSettle('fill', containerHeight);
+    expect(page.getByTestId('app-page-frame').element().getAttribute('data-fit')).toBe('fill');
+  });
+
+  test('the DEFAULT is `viewport`, so the three non-page mounters are unchanged', async () => {
+    // The dev tunnel and the mod-review preview both sit inside a SCROLLING
+    // ancestor that does not bound their height; on `fill` they would collapse.
+    // Pinning the default here is what lets this change be page-only.
+    const { containerHeight } = layoutChainHeights();
+    renderWithProviders(
+      <div style={{ height: `${containerHeight}px`, overflowY: 'auto' }}>
+        <PageBlockHost {...baseProps} />
+      </div>
+    );
+    await expect.element(page.getByTestId('app-page-frame')).toBeInTheDocument();
+    expect(page.getByTestId('app-page-frame').element().getAttribute('data-fit')).toBe('viewport');
+  });
+});

--- a/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
@@ -42,10 +42,11 @@ import type * as TrpcMod from '~/utils/trpc';
  * arms render the SAME host into the SAME container, differing only in `fit`.
  * Delete the red arm and the green one stops proving anything.
  *
- * NOTE ON REACH: CI runs the node `unit` project only — the browser suites are
- * not run there. The half of this contract that gates a merge is the source-scan
- * guard in `__tests__/pageRunScrollContract.test.ts`, which pins that the route
- * ships BOTH halves together. This file is the empirical half.
+ * NOTE ON REACH: this suite DOES run in CI — `pnpm run test:component`, surfaced
+ * as the `preview / component-tests` commit status — but REPORT-ONLY, so a break
+ * here is visible without blocking a merge. The gating half of this contract is
+ * the source-scan guard in `__tests__/pageRunScrollContract.test.ts`. This file
+ * is the empirical half, and it is the one that can see layout at all.
  */
 
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
@@ -107,7 +108,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
 }));
 
 // eslint-disable-next-line import/first
-import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+import { FILL_MIN_HEIGHT_PX, PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
 
 const SAME_ORIGIN_SRC = `${window.location.origin}/`;
 
@@ -196,6 +197,52 @@ function renderInScrollChain(fit: 'viewport' | 'fill', containerHeight: number) 
   );
 }
 
+/**
+ * The `scrollable: false` chain at a SHORT viewport — the squeeze case.
+ *
+ * `Page(…, { scrollable: false })` puts `overflow-hidden` on every ancestor, so
+ * whatever the page renders is the ONLY thing that can offer a scrollbar. That
+ * is the whole point of the fix at normal sizes, and the hazard at small ones:
+ * the site's fixed chrome (header 60 + AppFooter 45 + its mt-3 12 + AdhesiveAd
+ * 90 desktop / 50 mobile) cannot shrink, so on a short viewport the app absorbs
+ * the entire shortfall.
+ *
+ * `available` is what is left for the page after that chrome. At a phone in
+ * landscape (~360 CSS px) or a 1366×768 laptop at 200% zoom (~384 CSS px) it
+ * lands near 150px — far too little to use, and with `overflow-hidden` above
+ * there would be nothing to scroll to reach the rest.
+ */
+function renderInNoScrollChain(available: number) {
+  return renderWithProviders(
+    <div
+      data-testid="no-scroll-main"
+      // `AppLayout`'s `<main className="flex flex-1 flex-col overflow-hidden">`.
+      style={{
+        height: `${available}px`,
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      {/* The run page's own wrapper Box — kept in sync with
+          `src/pages/apps/run/[slug]/[[...path]].tsx`. `overflowY: auto` is the
+          scroll-of-last-resort that makes the squeeze recoverable. */}
+      <div
+        data-testid="page-wrapper"
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+        }}
+      >
+        <PageBlockHost {...baseProps} fit="fill" />
+      </div>
+    </div>
+  );
+}
+
 function scrollChain() {
   return page.getByTestId('scroll-chain').element() as HTMLElement;
 }
@@ -243,6 +290,74 @@ describe('PageBlockHost — `fit` decides whether the page grows a SECOND scroll
     const { containerHeight } = layoutChainHeights();
     await mountAndSettle('fill', containerHeight);
     expect(page.getByTestId('app-page-frame').element().getAttribute('data-fit')).toBe('fill');
+  });
+
+  /**
+   * 🔴 THE FIX MUST NOT TRADE A COSMETIC SCROLLBAR FOR AN UNREACHABLE ONE.
+   *
+   * Raised by the pre-merge audit of #4339 and reproduced here before being
+   * fixed: with `scrollable: false` every ancestor is `overflow-hidden`, so a
+   * host that floors at `minHeight: 0` absorbs the whole shortfall on a short
+   * viewport and NOTHING can scroll to what got squeezed out. A phone in
+   * landscape and a 1366×768 laptop at 200% zoom both land here, which makes it
+   * a WCAG 1.4.4 / 1.4.10 problem rather than a cosmetic one — strictly worse
+   * than the spare scrollbar this PR set out to remove.
+   *
+   * The cure is a real floor (`FILL_MIN_HEIGHT_PX`) plus one scroll container of
+   * last resort on the page's own wrapper. Above the floor nothing overflows, so
+   * the double-scrollbar fix is untouched; below it, one scrollbar appears and
+   * the content is reachable again.
+   */
+  describe('short viewports — squeezed, but never unreachable', () => {
+    test('the app keeps a usable height instead of collapsing toward zero', async () => {
+      // ~360px phone-landscape viewport minus the site's fixed chrome.
+      const available = 153;
+      renderInNoScrollChain(available);
+      await expect.element(page.getByTestId('app-page-frame')).toBeInTheDocument();
+
+      const frame = page.getByTestId('app-page-frame').element() as HTMLElement;
+      // The floor holds even though the parent is far shorter than it.
+      expect(frame.getBoundingClientRect().height).toBeGreaterThanOrEqual(FILL_MIN_HEIGHT_PX);
+    });
+
+    test('and what is squeezed out stays REACHABLE — exactly one scrollbar, not zero', async () => {
+      const available = 153;
+      renderInNoScrollChain(available);
+      await expect.element(page.getByTestId('app-page-frame')).toBeInTheDocument();
+
+      const wrapper = page.getByTestId('page-wrapper').element() as HTMLElement;
+
+      // 🔴 `scrollHeight > clientHeight` ALONE DOES NOT MEAN "REACHABLE", and
+      // this test asserted only that at first. An `overflow: hidden` box still
+      // reports `scrollHeight > clientHeight` — it has overflow, it just refuses
+      // to let the user get to it. Flipping this fixture's `overflowY` from
+      // `auto` to `hidden` left all 8 tests GREEN, i.e. the assertion passed for
+      // a reason unrelated to what it claimed. Both halves are needed: there is
+      // something to scroll, AND the box is user-scrollable.
+      expect(wrapper.scrollHeight).toBeGreaterThan(wrapper.clientHeight);
+      expect(['auto', 'scroll']).toContain(getComputedStyle(wrapper).overflowY);
+
+      // ...and the ONE scrollbar is the wrapper's. The `overflow-hidden`
+      // ancestor must not have grown one too — that would be the double
+      // scrollbar again, just at a different size.
+      const main = page.getByTestId('no-scroll-main').element() as HTMLElement;
+      expect(main.scrollHeight).toBe(main.clientHeight);
+    });
+
+    test('at a NORMAL viewport the floor is inert — still no outer scrollbar', async () => {
+      // The other half of the "measure at >= 2 points" rule: a floor that fires
+      // at ordinary sizes would reintroduce the bug for everyone. 900px is
+      // comfortably above the floor.
+      const available = 900;
+      renderInNoScrollChain(available);
+      await expect.element(page.getByTestId('app-page-frame')).toBeInTheDocument();
+
+      const wrapper = page.getByTestId('page-wrapper').element() as HTMLElement;
+      expect(wrapper.scrollHeight).toBe(wrapper.clientHeight);
+      // The host filled the space rather than sitting at its floor.
+      const frame = page.getByTestId('app-page-frame').element() as HTMLElement;
+      expect(frame.getBoundingClientRect().height).toBe(available);
+    });
   });
 
   test('the DEFAULT is `viewport`, so the three non-page mounters are unchanged', async () => {

--- a/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
@@ -188,8 +188,18 @@ function renderInScrollChain(fit: 'viewport' | 'fill', containerHeight: number) 
         flexDirection: 'column',
       }}
     >
-      {/* `fill` needs a growing flex item to resolve against — this is the run
-          page's own wrapper Box, same three properties. */}
+      {/* 🔴 DELIBERATELY *NOT* THE CURRENT PRODUCTION WRAPPER — do not "sync"
+          this with `[[...path]].tsx`. This helper models the PRE-FIX page (a
+          scrolling `ScrollArea` layout, wrapper `{ width: '100%' }`), because
+          that is the state the RED ARM has to reproduce. `renderInNoScrollChain`
+          below is the one that mirrors production.
+
+          Adding production's `overflowY: 'auto'` here was tried and reverted: it
+          moves the scroll to this inner wrapper, so `scroll-chain` stops
+          overflowing and the RED ARM fails with `expected 716 to be greater
+          than 716` — i.e. the reproduction quietly stops reproducing. The two
+          fixtures model two different points in time and are supposed to
+          differ. */}
       <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
         <PageBlockHost {...baseProps} fit={fit} />
       </div>
@@ -298,10 +308,13 @@ describe('PageBlockHost — `fit` decides whether the page grows a SECOND scroll
    * Raised by the pre-merge audit of #4339 and reproduced here before being
    * fixed: with `scrollable: false` every ancestor is `overflow-hidden`, so a
    * host that floors at `minHeight: 0` absorbs the whole shortfall on a short
-   * viewport and NOTHING can scroll to what got squeezed out. A phone in
-   * landscape and a 1366×768 laptop at 200% zoom both land here, which makes it
-   * a WCAG 1.4.4 / 1.4.10 problem rather than a cosmetic one — strictly worse
-   * than the spare scrollbar this PR set out to remove.
+   * viewport and NOTHING can scroll to what got squeezed out. Phone landscape
+   * and heavy desktop zoom both land here, which makes it a WCAG 1.4.4 / 1.4.10
+   * problem rather than a cosmetic one — strictly worse than the spare scrollbar
+   * this PR set out to remove. (The band is viewport-height driven; see
+   * `FILL_MIN_HEIGHT_PX` for who actually falls in it, and note every
+   * measurement in this file is taken at the runner's default 414px-WIDE
+   * viewport — nothing here exercises a desktop width.)
    *
    * The cure is a real floor (`FILL_MIN_HEIGHT_PX`) plus one scroll container of
    * last resort on the page's own wrapper. Above the floor nothing overflows, so
@@ -310,14 +323,45 @@ describe('PageBlockHost — `fit` decides whether the page grows a SECOND scroll
    */
   describe('short viewports — squeezed, but never unreachable', () => {
     test('the app keeps a usable height instead of collapsing toward zero', async () => {
-      // ~360px phone-landscape viewport minus the site's fixed chrome.
+      // A ~360px-tall viewport minus the site's fixed chrome.
       const available = 153;
       renderInNoScrollChain(available);
       await expect.element(page.getByTestId('app-page-frame')).toBeInTheDocument();
 
       const frame = page.getByTestId('app-page-frame').element() as HTMLElement;
-      // The floor holds even though the parent is far shorter than it.
-      expect(frame.getBoundingClientRect().height).toBeGreaterThanOrEqual(FILL_MIN_HEIGHT_PX);
+
+      // 🔴 ABSOLUTE LITERALS, DELIBERATELY NOT `FILL_MIN_HEIGHT_PX`.
+      //
+      // This assertion used to read `.toBeGreaterThanOrEqual(FILL_MIN_HEIGHT_PX)`,
+      // which compares the measured height against the very constant that
+      // PRODUCED it — true by construction for every value. Measured: setting
+      // the floor to 0 (i.e. fully reverting the WCAG fix) passed all 17 tests
+      // across both suites. The unit guard did not help either: it pins the
+      // IDENTIFIER `minHeight: FILL_MIN_HEIGHT_PX` in the source, not the number.
+      //
+      // A literal cannot be satisfied by construction, so this is what actually
+      // holds the floor down. It is intentionally a little below the constant so
+      // a small deliberate retune does not fail the suite.
+      expect(frame.getBoundingClientRect().height).toBeGreaterThanOrEqual(280);
+    });
+
+    /**
+     * The floor's VALUE is a product decision with a viewport population behind
+     * it, so it gets its own bounds rather than being free to drift.
+     *
+     * Lower bound: below ~280 the block's own area (floor minus the host chrome)
+     * stops being usable, which is the case the floor exists to prevent.
+     *
+     * Upper bound: the floor fires whenever `available < FILL_MIN_HEIGHT_PX`, and
+     * when it fires the page grows a scrollbar beside the block's own — i.e. the
+     * original bug, in a narrower window. Every px added here widens the
+     * viewport population that sees it, so the ceiling is what stops "just raise
+     * the floor" from quietly undoing this PR. The arithmetic is in the
+     * constant's doc comment.
+     */
+    test('the floor stays inside its documented band — a retune is deliberate, not drift', () => {
+      expect(FILL_MIN_HEIGHT_PX).toBeGreaterThanOrEqual(280);
+      expect(FILL_MIN_HEIGHT_PX).toBeLessThanOrEqual(340);
     });
 
     test('and what is squeezed out stays REACHABLE — exactly one scrollbar, not zero', async () => {
@@ -334,14 +378,15 @@ describe('PageBlockHost — `fit` decides whether the page grows a SECOND scroll
       // `auto` to `hidden` left all 8 tests GREEN, i.e. the assertion passed for
       // a reason unrelated to what it claimed. Both halves are needed: there is
       // something to scroll, AND the box is user-scrollable.
+      // ⚠️ This half is WEAK ON ITS OWN and is kept only as a precondition: the
+      // fixture's `AppBlockChrome` is ~200px tall, so at `available = 153` the
+      // wrapper overflows because of the CHROME whether or not the floor exists.
+      // It cannot distinguish fixed from reverted — the absolute-height
+      // assertion above is what does that. Stated here so nobody reads this line
+      // as floor coverage.
       expect(wrapper.scrollHeight).toBeGreaterThan(wrapper.clientHeight);
+      // This half is the real one: user-scrollable, not merely overflowing.
       expect(['auto', 'scroll']).toContain(getComputedStyle(wrapper).overflowY);
-
-      // ...and the ONE scrollbar is the wrapper's. The `overflow-hidden`
-      // ancestor must not have grown one too — that would be the double
-      // scrollbar again, just at a different size.
-      const main = page.getByTestId('no-scroll-main').element() as HTMLElement;
-      expect(main.scrollHeight).toBe(main.clientHeight);
     });
 
     test('at a NORMAL viewport the floor is inert — still no outer scrollbar', async () => {

--- a/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
@@ -217,11 +217,13 @@ function renderInScrollChain(fit: 'viewport' | 'fill', containerHeight: number) 
  * 90 desktop / 50 mobile) cannot shrink, so on a short viewport the app absorbs
  * the entire shortfall.
  *
- * `available` is what is left for the page after that chrome. At a phone in
- * landscape (~360 CSS px) or a 1366×768 laptop at 200% zoom (~325 CSS px of `innerHeight`, NOT 768/2 — the
- * panel-height error corrected on `FILL_MIN_HEIGHT_PX`) it
- * lands near 150px — far too little to use, and with `overflow-hidden` above
- * there would be nothing to scroll to reach the rest.
+ * `available` is what is left for the page after that chrome. A phone in
+ * landscape (~360 CSS px) lands near 150px — which is the `available = 153` the
+ * tests below use. A 1366×768 laptop at 200% zoom lands LOWER, around 86–118:
+ * its `innerHeight` is ~325, not 768/2 = 384 (the panel-height error corrected
+ * on `FILL_MIN_HEIGHT_PX`; the old 384 is where a second "~150px" came from).
+ * Either way it is far too little to use, and with `overflow-hidden` above there
+ * would be nothing to scroll to reach the rest.
  */
 function renderInNoScrollChain(available: number) {
   return renderWithProviders(

--- a/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
+++ b/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
@@ -75,12 +75,28 @@ function norm(src: string): string {
  * silent return of the bug, so an unmatched anchor is a FAILURE, not a skip.
  */
 function region(src: string, anchor: RegExp, label: string): string {
-  const m = anchor.exec(src);
-  expect(m, `${label}: anchor ${anchor} no longer matches — update the pin deliberately`).not.toBe(
-    null
-  );
-  return norm(m![0]);
+  // `matchAll`, not `exec`: a first-match read silently grades the WRONG
+  // occurrence if a second ever appears. That exact bug bit the `<main>`
+  // assertion below (it read the scrollable branch instead of the no-scroll
+  // one), so the lesson is applied at every site rather than the one that hurt.
+  const all = [...src.matchAll(new RegExp(anchor.source, `${anchor.flags.replace('g', '')}g`))];
+  expect(
+    all.length,
+    `${label}: expected exactly ONE match for ${anchor}, found ${all.length}. ` +
+      'Zero means the anchor rotted — update the pin deliberately rather than deleting it. ' +
+      'More than one means this pin is now ambiguous and is grading an arbitrary occurrence.'
+  ).toBe(1);
+  return norm(all[0][0]);
 }
+
+/** Shared explanation attached to every verbatim pin, so a failure tells the
+ *  maintainer what it is and what to do rather than just diffing two strings. */
+const PIN_HELP =
+  'This is a DELIBERATE verbatim pin, not an incidental string match — a token check here ' +
+  'passed a ternary inversion, a `flex: 0` and a deleted `overflow: hidden`. If you changed ' +
+  'this block on purpose (including a pure reformat or a rename), update the expected string ' +
+  'here in the same commit. If you did not, you have reintroduced the /apps/run double ' +
+  'scrollbar or its 0-height cousin — see this file’s header.';
 
 describe('the run page and its host agree on who owns the height', () => {
   it('the run page ships BOTH halves — non-scrolling layout AND a fill-fit host', () => {
@@ -136,7 +152,7 @@ describe('the run page and its host agree on who owns the height', () => {
    */
   it("pins the host's `fit` branches verbatim — inversion, `flex: 0` and a dropped `overflow` all fail", () => {
     const src = code(read(HOST));
-    expect(region(src, /\.\.\.\(fit === 'fill'[\s\S]*?\}\),/, 'fit ternary')).toBe(
+    expect(region(src, /\.\.\.\(fit === 'fill'[\s\S]*?\}\),/, 'fit ternary'), PIN_HELP).toBe(
       "...(fit === 'fill' ? { flex: 1, minHeight: FILL_MIN_HEIGHT_PX, } " +
         ": { height: '100%', minHeight: 'calc(100dvh - 60px)', }),"
     );
@@ -145,7 +161,8 @@ describe('the run page and its host agree on who owns the height', () => {
   it('pins the reveal wrapper, whose `overflow: hidden` is what confines the 8px transform', () => {
     const src = code(read(HOST));
     expect(
-      region(src, /<Box\s+style=\{\{\s*position: 'relative',[\s\S]*?\}\}\s*>/, 'reveal wrapper')
+      region(src, /<Box\s+style=\{\{\s*position: 'relative',[\s\S]*?\}\}\s*>/, 'reveal wrapper'),
+      PIN_HELP
     ).toBe(
       "<Box style={{ position: 'relative', flex: 1, display: 'flex', overflow: 'hidden', }} >"
     );
@@ -165,7 +182,8 @@ describe('the run page and its host agree on who owns the height', () => {
   it('pins the run page wrapper — the third leg the browser test structurally cannot see', () => {
     const src = code(read(RUN_PAGE));
     expect(
-      region(src, /<Box\s+style=\{\{\s*display: 'flex',[\s\S]*?\}\}\s*>/, 'page wrapper')
+      region(src, /<Box\s+style=\{\{\s*display: 'flex',[\s\S]*?\}\}\s*>/, 'page wrapper'),
+      PIN_HELP
     ).toBe(
       "<Box style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, " +
         "overflowY: 'auto', width: '100%', }} >"
@@ -196,7 +214,11 @@ describe('the run page and its host agree on who owns the height', () => {
           walk(full);
         } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
           const src = code(fs.readFileSync(full, 'utf8'));
-          if (!/<PageBlockHost\b/.test(src)) continue;
+          // Match the IMPORT, not the JSX tag: `import { PageBlockHost as Host }`
+          // renders `<Host …>`, which a tag-only test misses entirely. (The
+          // pre-scoping version caught it, over-broadly; this keeps the scoping
+          // without reopening that hole.)
+          if (!/\bPageBlockHost\b/.test(src)) continue;
           if (/\bfit=(["']fill["']|\{\s*['"]fill['"]\s*\})/.test(src))
             offenders.push(path.relative(REPO_ROOT, full));
         }

--- a/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
+++ b/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
@@ -123,13 +123,14 @@ describe('the run page and its host agree on who owns the height', () => {
     const fillFit = /\bfit=(["']fill["']|\{\s*['"]fill['"]\s*\})/.test(src);
 
     // The equivalence, not two independent presence checks. Half-reverting either
-    // one regresses the page in a DIFFERENT direction (a fixed floor-height slab
-    // / a clipped app — see this file's header), so this is what has to fail.
+    // one regresses the page in a DIFFERENT direction (see this file's header —
+    // neither direction is clipping), so this is what has to fail.
     expect(
       nonScrolling === fillFit,
       `\`scrollable: false\` (${nonScrolling}) and \`fit="fill"\` (${fillFit}) are a ` +
-        'co-requisite on the run page — shipping one without the other replaces the ' +
-        'double scrollbar with a floor-height slab or a clipped app. See this file’s header.'
+        'co-requisite on the run page — drop `fit="fill"` and the double scrollbar ' +
+        'comes back (the page wrapper scrolls the excess); drop `scrollable: false` and ' +
+        'the host becomes a fixed floor-height slab. See this file’s header.'
     ).toBe(true);
   });
 
@@ -180,9 +181,10 @@ describe('the run page and its host agree on who owns the height', () => {
    * item to resolve against, and its `overflowY: 'auto'` is the scroll container
    * of last resort that makes `FILL_MIN_HEIGHT_PX` reachable instead of clipped.
    * Reverting it to the original `{ width: '100%' }` passed BOTH suites in the
-   * pre-merge sweep while letterboxing the iframe to its ~150px intrinsic
-   * height — the browser test cannot see it because that test builds its own
-   * fixture wrapper rather than importing the Next page.
+   * pre-merge sweep while leaving the host sized only by its floor — measured
+   * 300px host / 31px chrome / 269px iframe, whatever the viewport. The browser
+   * test cannot see it because that test builds its own fixture wrapper rather
+   * than importing the Next page.
    */
   it('pins the run page wrapper — the third leg the browser test structurally cannot see', () => {
     const src = code(read(RUN_PAGE));
@@ -299,8 +301,14 @@ describe('the run page and its host agree on who owns the height', () => {
    * suite still measures the CONSEQUENCE (a real host, laid out, at two viewport
    * sizes); this pins the DECISION so a merge cannot quietly change it.
    *
-   * The bounds and the arithmetic behind them live on the constant's own doc
-   * comment — deliberately not restated here, so there is one place to correct.
+   * 🔴 THE BOUNDS ARE DELIBERATELY LITERALS HERE, NOT READ FROM THE SOURCE. A
+   * band imported from (or regexed out of) `PageBlockHost.tsx` would be graded
+   * against the same file it bounds, so a single edit could move the value and
+   * its own limits together — the self-referential trap this whole guard exists
+   * because of. The ARITHMETIC that justifies them lives on the constant's doc
+   * comment; the NUMBERS live here (gating) and in
+   * `PageBlockHostScrollFit.browser.test.tsx` (report-only). Both must admit a
+   * value, so the tighter pair wins and drift is fail-safe.
    */
   it('`FILL_MIN_HEIGHT_PX` stays inside its documented band — in the BLOCKING tier', () => {
     const declared = /export const FILL_MIN_HEIGHT_PX = (\d+);/.exec(code(read(HOST)))?.[1];

--- a/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
+++ b/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
@@ -1,0 +1,146 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `/apps/run/<slug>` must declare a NON-SCROLLING layout, and its host must
+ * claim no height of its own. Node `unit` project — the suite CI actually runs
+ * (the `.browser.test.tsx` component suites are not run in CI at all), which is
+ * why the coupling is pinned here and only MEASURED in
+ * `PageBlockHostScrollFit.browser.test.tsx`.
+ *
+ * WHAT BROKE. The route shipped a bare `export default function AppPage`, so it
+ * inherited `AppLayout`'s default `scrollable: true` — a `ScrollArea` with
+ * `overflow-y: auto`. Inside it `PageBlockHost` claimed
+ * `min-height: calc(100dvh - 60px)`, which subtracts the site header and nothing
+ * else. Sub-nav, its `mb-3`, the rewards banner, the footer and the adhesive ad
+ * all sit inside or beside that scroll viewport, so the host was unconditionally
+ * taller than the space it had: an outer scrollbar that scrolled only the
+ * residue, beside the block's own scrollbar inside the iframe.
+ *
+ * 🔴 THE TWO HALVES ARE A CO-REQUISITE, WHICH IS THE ACTUAL POINT OF THIS FILE.
+ * Neither is safe alone and they live in different places, so the failure mode is
+ * someone reverting one during an unrelated change:
+ *
+ *   - `fit="fill"` WITHOUT `scrollable: false` → the host claims no height inside
+ *     a layout that bounds nothing, so `flex: 1` resolves against an auto-height
+ *     parent and the iframe renders 0px tall. A blank page, which reads as a
+ *     broken block rather than a layout regression.
+ *   - `scrollable: false` WITHOUT `fit="fill"` → the outer scrollbar is gone but
+ *     the host still claims more height than the now `overflow-hidden` chain can
+ *     give it, so the bottom of the app is CLIPPED and unreachable. Strictly
+ *     worse than the bug being fixed.
+ *
+ * A test that only checked for the presence of each would pass on either
+ * half-revert, so the assertions below are written as an equivalence.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const RUN_PAGE = path.join(REPO_ROOT, 'src/pages/apps/run/[slug]/[[...path]].tsx');
+const HOST = path.join(REPO_ROOT, 'src/components/AppBlocks/PageBlockHost.tsx');
+const APP_LAYOUT = path.join(REPO_ROOT, 'src/components/AppLayout/AppLayout.tsx');
+
+function read(file: string): string {
+  // Prove the path before trusting a "no match": a comparison against an absent
+  // operand reports SAME, not MISSING, and a renamed route would otherwise turn
+  // every assertion below into a vacuous pass on an empty string.
+  expect(fs.existsSync(file), `${path.relative(REPO_ROOT, file)} does not exist`).toBe(true);
+  return fs.readFileSync(file, 'utf8');
+}
+
+/** Strip block + line comments so a rule can never be satisfied by prose ABOUT
+ *  the rule — every one of these tokens is discussed at length in the comments
+ *  it is being searched for in. */
+function code(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+describe('the run page and its host agree on who owns the height', () => {
+  it('the run page ships BOTH halves — non-scrolling layout AND a fill-fit host', () => {
+    const src = code(read(RUN_PAGE));
+
+    // Half 1: the route opts out of AppLayout's ScrollArea.
+    expect(src).toMatch(/\bscrollable:\s*false\b/);
+    // It has to reach the layout, which means going through `Page(...)` — a bare
+    // default export silently takes every default back.
+    expect(src).toMatch(/export\s+default\s+Page\s*\(/);
+
+    // Half 2: the host is told not to claim a viewport-derived height.
+    expect(src).toMatch(/\bfit=(["']fill["']|\{\s*['"]fill['"]\s*\})/);
+  });
+
+  it('neither half can be reverted on its own', () => {
+    const src = code(read(RUN_PAGE));
+    const nonScrolling = /\bscrollable:\s*false\b/.test(src);
+    const fillFit = /\bfit=(["']fill["']|\{\s*['"]fill['"]\s*\})/.test(src);
+
+    // The equivalence, not two independent presence checks. Half-reverting either
+    // one regresses the page in a DIFFERENT direction (0px iframe / clipped app),
+    // so this is what has to fail.
+    expect(
+      nonScrolling === fillFit,
+      `\`scrollable: false\` (${nonScrolling}) and \`fit="fill"\` (${fillFit}) are a ` +
+        'co-requisite on the run page — shipping one without the other replaces the ' +
+        'double scrollbar with a 0px or clipped iframe. See this file’s header.'
+    ).toBe(true);
+  });
+
+  it('the host still DEFAULTS to `viewport`, so the other three mounters are untouched', () => {
+    const src = code(read(HOST));
+    // The dev tunnel and the mod-review preview mount inside scrolling ancestors
+    // that bound nothing; flipping this default would collapse both.
+    expect(src).toMatch(/\bfit\s*=\s*['"]viewport['"]/);
+  });
+
+  it('only the run page opts into `fill` — a new mounter must opt in deliberately', () => {
+    // A directory walk, not a hand-kept list: the point is to notice a mounter
+    // nobody told this test about.
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+          walk(full);
+        } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+          if (
+            /\bfit=(["']fill["']|\{\s*['"]fill['"]\s*\})/.test(code(fs.readFileSync(full, 'utf8')))
+          )
+            offenders.push(path.relative(REPO_ROOT, full));
+        }
+      }
+    };
+    walk(path.join(REPO_ROOT, 'src'));
+
+    expect(offenders.sort()).toEqual(['src/pages/apps/run/[slug]/[[...path]].tsx']);
+  });
+
+  it('the layout premise this all rests on still holds', () => {
+    // If `AppLayout`'s two branches ever stop differing this way, the fix above is
+    // reasoning about a layout that no longer exists — and would fail SILENTLY,
+    // since both halves would still be present in the source.
+    const src = code(read(APP_LAYOUT));
+
+    // The scrollable branch is a bounded, auto-overflow viewport…
+    expect(src).toMatch(/scrollable\s*\?\s*\(\s*<ScrollArea/);
+    // …and the non-scrollable branch clips instead of scrolling, all the way down.
+    expect(src).toMatch(/no-scroll[^"']*flex[^"']*overflow-hidden/);
+    expect(src).toMatch(/<main className="flex flex-1 flex-col overflow-hidden">/);
+  });
+
+  it('`HEADER_HEIGHT` is still 60, so the surviving `viewport` calc is not silently stale', () => {
+    // `PageBlockHost` hardcodes `60` as a SECOND COPY of a constant private to
+    // `AppHeader.tsx`. The run page no longer depends on it, but the dev tunnel
+    // and mod review still do — and a header resize would re-open this bug there
+    // with nothing to notice. One rule, two places: this is the tripwire until
+    // they are consolidated.
+    const header = read(path.join(REPO_ROOT, 'src/components/AppLayout/AppHeader/AppHeader.tsx'));
+    const declared = /const HEADER_HEIGHT = (\d+);/.exec(code(header))?.[1];
+    expect(declared, 'HEADER_HEIGHT declaration not found in AppHeader.tsx').toBeDefined();
+
+    const hostCalc = /minHeight:\s*'calc\(100dvh - (\d+)px\)'/.exec(code(read(HOST)))?.[1];
+    expect(hostCalc, 'the viewport-fit calc not found in PageBlockHost.tsx').toBeDefined();
+
+    expect(hostCalc).toBe(declared);
+  });
+});

--- a/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
+++ b/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
@@ -4,10 +4,11 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * `/apps/run/<slug>` must declare a NON-SCROLLING layout, and its host must
- * claim no height of its own. Node `unit` project — the suite CI actually runs
- * (the `.browser.test.tsx` component suites are not run in CI at all), which is
- * why the coupling is pinned here and only MEASURED in
- * `PageBlockHostScrollFit.browser.test.tsx`.
+ * claim no height of its own. Node `unit` project — the GATING suite. The
+ * `.browser.test.tsx` component suites DO run in CI, as the report-only
+ * `preview / component-tests` status (`pnpm run test:component`), so a break
+ * there is visible but does not block a merge. The coupling is pinned here for
+ * that reason, and only MEASURED in `PageBlockHostScrollFit.browser.test.tsx`.
  *
  * WHAT BROKE. The route shipped a bare `export default function AppPage`, so it
  * inherited `AppLayout`'s default `scrollable: true` — a `ScrollArea` with
@@ -18,21 +19,26 @@ import { describe, expect, it } from 'vitest';
  * taller than the space it had: an outer scrollbar that scrolled only the
  * residue, beside the block's own scrollbar inside the iframe.
  *
- * 🔴 THE TWO HALVES ARE A CO-REQUISITE, WHICH IS THE ACTUAL POINT OF THIS FILE.
- * Neither is safe alone and they live in different places, so the failure mode is
- * someone reverting one during an unrelated change:
+ * 🔴 IT IS A CO-REQUISITE OF THREE LEGS, IN THREE PLACES. None is safe alone, so
+ * the failure mode is someone reverting one during an unrelated change:
  *
  *   - `fit="fill"` WITHOUT `scrollable: false` → the host claims no height inside
  *     a layout that bounds nothing, so `flex: 1` resolves against an auto-height
- *     parent and the iframe renders 0px tall. A blank page, which reads as a
- *     broken block rather than a layout regression.
+ *     parent and the iframe LETTERBOXES to roughly its ~150px intrinsic
+ *     replaced-element height. (Measured. An earlier version of this note said
+ *     "0px"; that is what `flex: 0` produces, not this.) Broken, but quietly —
+ *     it reads as a badly-sized block rather than a layout regression.
  *   - `scrollable: false` WITHOUT `fit="fill"` → the outer scrollbar is gone but
  *     the host still claims more height than the now `overflow-hidden` chain can
  *     give it, so the bottom of the app is CLIPPED and unreachable. Strictly
  *     worse than the bug being fixed.
+ *   - EITHER OF THOSE WITHOUT the run page's wrapper `Box` → same as the first
+ *     case. This is the leg the browser suite structurally cannot see, because
+ *     that suite builds its own fixture wrapper instead of importing the page.
  *
- * A test that only checked for the presence of each would pass on either
- * half-revert, so the assertions below are written as an equivalence.
+ * Presence checks alone pass a half-revert of the third leg and every mutation
+ * that inverts rather than deletes, so the assertions below pin whole normalised
+ * expressions as well.
  */
 
 const REPO_ROOT = path.resolve(__dirname, '../../../..');
@@ -53,6 +59,27 @@ function read(file: string): string {
  *  it is being searched for in. */
 function code(src: string): string {
   return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/** Collapse whitespace so an assertion pins the EXPRESSION, not its formatting. */
+function norm(src: string): string {
+  return src.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Pull one balanced-looking source region out of a file by anchor regex, and
+ * fail loudly if the anchor stops matching.
+ *
+ * 🔴 A regex that no longer matches must never read as "the rule is satisfied".
+ * These assertions are the only thing standing between a later refactor and a
+ * silent return of the bug, so an unmatched anchor is a FAILURE, not a skip.
+ */
+function region(src: string, anchor: RegExp, label: string): string {
+  const m = anchor.exec(src);
+  expect(m, `${label}: anchor ${anchor} no longer matches — update the pin deliberately`).not.toBe(
+    null
+  );
+  return norm(m![0]);
 }
 
 describe('the run page and its host agree on who owns the height', () => {
@@ -85,6 +112,66 @@ describe('the run page and its host agree on who owns the height', () => {
     ).toBe(true);
   });
 
+  /**
+   * 🔴 PIN THE WHOLE EXPRESSION, NOT FEATURES OF IT.
+   *
+   * A pre-merge mutation sweep on the first version of this file found 9 of 17
+   * mutants surviving, because every assertion here was a presence check. The
+   * three that matter, all invisible to a token grep:
+   *
+   *   - INVERT THE TERNARY (`fit === 'fill'` → `fit !== 'fill'`) — breaks EVERY
+   *     surface at once: the run page gets the viewport calc back (the double
+   *     scrollbar) and the dev tunnel + mod review get `fill` inside unbounded
+   *     parents (the collapse the prop doc warns about). Every token a presence
+   *     check looks for is still there.
+   *   - `flex: 1` → `flex: 0` in the fill branch — a 0px host.
+   *   - DELETE (or comment out) `overflow: 'hidden'` on the reveal wrapper — the
+   *     8px transform leak returns.
+   *
+   * Pinning the normalised text of the whole expression kills all three in one
+   * assertion. The accepted cost is that a cosmetic reformat of these exact
+   * blocks fails this test — that is the trade for a machine-checkable claim,
+   * and the failure message says so. `code()` runs first, so commenting a line
+   * out changes the normalised string exactly as deleting it does.
+   */
+  it("pins the host's `fit` branches verbatim — inversion, `flex: 0` and a dropped `overflow` all fail", () => {
+    const src = code(read(HOST));
+    expect(region(src, /\.\.\.\(fit === 'fill'[\s\S]*?\}\),/, 'fit ternary')).toBe(
+      "...(fit === 'fill' ? { flex: 1, minHeight: FILL_MIN_HEIGHT_PX, } " +
+        ": { height: '100%', minHeight: 'calc(100dvh - 60px)', }),"
+    );
+  });
+
+  it('pins the reveal wrapper, whose `overflow: hidden` is what confines the 8px transform', () => {
+    const src = code(read(HOST));
+    expect(
+      region(src, /<Box\s+style=\{\{\s*position: 'relative',[\s\S]*?\}\}\s*>/, 'reveal wrapper')
+    ).toBe(
+      "<Box style={{ position: 'relative', flex: 1, display: 'flex', overflow: 'hidden', }} >"
+    );
+  });
+
+  /**
+   * 🔴 THE CO-REQUISITE IS A TRIO, NOT A PAIR — this is the third leg.
+   *
+   * The run page's own wrapper `Box` is what gives `fit="fill"` a growing flex
+   * item to resolve against, and its `overflowY: 'auto'` is the scroll container
+   * of last resort that makes `FILL_MIN_HEIGHT_PX` reachable instead of clipped.
+   * Reverting it to the original `{ width: '100%' }` passed BOTH suites in the
+   * pre-merge sweep while letterboxing the iframe to its ~150px intrinsic
+   * height — the browser test cannot see it because that test builds its own
+   * fixture wrapper rather than importing the Next page.
+   */
+  it('pins the run page wrapper — the third leg the browser test structurally cannot see', () => {
+    const src = code(read(RUN_PAGE));
+    expect(
+      region(src, /<Box\s+style=\{\{\s*display: 'flex',[\s\S]*?\}\}\s*>/, 'page wrapper')
+    ).toBe(
+      "<Box style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, " +
+        "overflowY: 'auto', width: '100%', }} >"
+    );
+  });
+
   it('the host still DEFAULTS to `viewport`, so the other three mounters are untouched', () => {
     const src = code(read(HOST));
     // The dev tunnel and the mod-review preview mount inside scrolling ancestors
@@ -95,6 +182,11 @@ describe('the run page and its host agree on who owns the height', () => {
   it('only the run page opts into `fill` — a new mounter must opt in deliberately', () => {
     // A directory walk, not a hand-kept list: the point is to notice a mounter
     // nobody told this test about.
+    //
+    // Scoped to files that actually mount `PageBlockHost`, because `fit` is not
+    // a name this codebase owns — Mantine's `Image` has a `fit` prop too, so an
+    // unrelated `fit="fill"` elsewhere in `src` would otherwise fail this test
+    // and hand an unrelated team a maintenance tax.
     const offenders: string[] = [];
     const walk = (dir: string) => {
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -103,9 +195,9 @@ describe('the run page and its host agree on who owns the height', () => {
           if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
           walk(full);
         } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
-          if (
-            /\bfit=(["']fill["']|\{\s*['"]fill['"]\s*\})/.test(code(fs.readFileSync(full, 'utf8')))
-          )
+          const src = code(fs.readFileSync(full, 'utf8'));
+          if (!/<PageBlockHost\b/.test(src)) continue;
+          if (/\bfit=(["']fill["']|\{\s*['"]fill['"]\s*\})/.test(src))
             offenders.push(path.relative(REPO_ROOT, full));
         }
       }
@@ -123,9 +215,28 @@ describe('the run page and its host agree on who owns the height', () => {
 
     // The scrollable branch is a bounded, auto-overflow viewport…
     expect(src).toMatch(/scrollable\s*\?\s*\(\s*<ScrollArea/);
-    // …and the non-scrollable branch clips instead of scrolling, all the way down.
+    // …and the non-scrollable branch clips instead of scrolling, all the way
+    // down. Asserted as an unordered SET of classes, not as a literal string: a
+    // prettier/tailwind-sort reorder is a no-op that would otherwise fail this.
     expect(src).toMatch(/no-scroll[^"']*flex[^"']*overflow-hidden/);
-    expect(src).toMatch(/<main className="flex flex-1 flex-col overflow-hidden">/);
+
+    // 🔴 `AppLayout` has TWO `<main>` elements — one per branch — so match ALL
+    // of them and look for the no-scroll one. Reading only the first match found
+    // the SCROLLABLE branch's `min-w-0 flex-1` and failed against the set this
+    // test is about; a first-match read of a repeated pattern is its own bug
+    // class, in the assertion as much as in an edit.
+    //
+    // 🔴 SORTED ARRAYS, NOT `Set`s. `expect([...]).toContainEqual(new Set([...]))`
+    // does NOT deep-compare Set contents in Vitest — measured: it PASSES when
+    // the expected set is absent entirely. A first draft of this assertion used
+    // it and was silently vacuous, which the mutation sweep caught only because
+    // dropping `overflow-hidden` survived. Sorting makes the comparison
+    // order-independent without relying on Set equality.
+    const mainClasses = [...src.matchAll(/<main className="([^"]*)">/g)].map((m) =>
+      m[1].split(/\s+/).filter(Boolean).sort()
+    );
+    expect(mainClasses.length, 'expected both AppLayout branches to render a <main>').toBe(2);
+    expect(mainClasses).toContainEqual(['flex', 'flex-1', 'flex-col', 'overflow-hidden'].sort());
   });
 
   it('`HEADER_HEIGHT` is still 60, so the surviving `viewport` calc is not silently stale', () => {

--- a/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
+++ b/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
@@ -33,10 +33,19 @@ import { describe, expect, it } from 'vitest';
  *     gives), then "~150px" (the iframe's intrinsic height — true before the
  *     floor existed, false the moment `FILL_MIN_HEIGHT_PX` was added in the same
  *     PR). Re-derive from the `fill` branch before touching this line.
- *   - `scrollable: false` WITHOUT `fit="fill"` → the outer scrollbar is gone but
- *     the host still claims more height than the now `overflow-hidden` chain can
- *     give it, so the bottom of the app is CLIPPED and unreachable. Strictly
- *     worse than the bug being fixed.
+ *   - `scrollable: false` WITHOUT `fit="fill"` → the host claims
+ *     `100dvh - 60px` again. The `overflow-hidden` chain sits ABOVE the run
+ *     page's own wrapper, and that wrapper is `overflowY: 'auto'`, so the excess
+ *     is SCROLLED, not clipped: a page scrollbar beside the block's own — the
+ *     exact bug this PR removes. Measured 708px of host in a 600px wrapper,
+ *     `USER_SCROLLABLE=true`.
+ *
+ *     🔴 THIS BULLET SAID "CLIPPED" FOR FIVE COMMITS, and it was TRUE when
+ *     written at `4f78d37351` — the wrapper had no `overflowY` then. `c48ba4d029`
+ *     added it and nobody re-derived the sentence. Two later rounds each declared
+ *     the stale-figure class eradicated while this sat here, and one of them
+ *     added cross-references POINTING AT this paragraph. Nothing clips in this
+ *     layout; the wrapper can always scroll.
  *   - EITHER OF THOSE WITHOUT the run page's wrapper `Box` → same as the first
  *     case. This is the leg the browser suite structurally cannot see, because
  *     that suite builds its own fixture wrapper instead of importing the page.

--- a/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
+++ b/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
@@ -22,12 +22,17 @@ import { describe, expect, it } from 'vitest';
  * 🔴 IT IS A CO-REQUISITE OF THREE LEGS, IN THREE PLACES. None is safe alone, so
  * the failure mode is someone reverting one during an unrelated change:
  *
- *   - `fit="fill"` WITHOUT `scrollable: false` → the host claims no height inside
- *     a layout that bounds nothing, so `flex: 1` resolves against an auto-height
- *     parent and the iframe LETTERBOXES to roughly its ~150px intrinsic
- *     replaced-element height. (Measured. An earlier version of this note said
- *     "0px"; that is what `flex: 0` produces, not this.) Broken, but quietly —
- *     it reads as a badly-sized block rather than a layout regression.
+ *   - `fit="fill"` WITHOUT `scrollable: false` → the host sits inside a layout
+ *     that bounds nothing, so `flex: 1` has nothing to resolve against and the
+ *     host is sized purely by `FILL_MIN_HEIGHT_PX` — a fixed 300px slab on a
+ *     1080px screen. Broken, but quietly: it reads as a badly-sized block rather
+ *     than a layout regression.
+ *
+ *     🔴 THIS FIGURE HAS BEEN WRONG TWICE, both times by editing the sentence
+ *     instead of re-reading the code. It said "0px" (that is what `flex: 0`
+ *     gives), then "~150px" (the iframe's intrinsic height — true before the
+ *     floor existed, false the moment `FILL_MIN_HEIGHT_PX` was added in the same
+ *     PR). Re-derive from the `fill` branch before touching this line.
  *   - `scrollable: false` WITHOUT `fit="fill"` → the outer scrollbar is gone but
  *     the host still claims more height than the now `overflow-hidden` chain can
  *     give it, so the bottom of the app is CLIPPED and unreachable. Strictly
@@ -118,13 +123,13 @@ describe('the run page and its host agree on who owns the height', () => {
     const fillFit = /\bfit=(["']fill["']|\{\s*['"]fill['"]\s*\})/.test(src);
 
     // The equivalence, not two independent presence checks. Half-reverting either
-    // one regresses the page in a DIFFERENT direction (0px iframe / clipped app),
-    // so this is what has to fail.
+    // one regresses the page in a DIFFERENT direction (a fixed floor-height slab
+    // / a clipped app — see this file's header), so this is what has to fail.
     expect(
       nonScrolling === fillFit,
       `\`scrollable: false\` (${nonScrolling}) and \`fit="fill"\` (${fillFit}) are a ` +
         'co-requisite on the run page — shipping one without the other replaces the ' +
-        'double scrollbar with a 0px or clipped iframe. See this file’s header.'
+        'double scrollbar with a floor-height slab or a clipped app. See this file’s header.'
     ).toBe(true);
   });
 
@@ -140,7 +145,7 @@ describe('the run page and its host agree on who owns the height', () => {
    *     scrollbar) and the dev tunnel + mod review get `fill` inside unbounded
    *     parents (the collapse the prop doc warns about). Every token a presence
    *     check looks for is still there.
-   *   - `flex: 1` → `flex: 0` in the fill branch — a 0px host.
+   *   - `flex: 1` → `flex: 0` in the fill branch — the host stops growing at all.
    *   - DELETE (or comment out) `overflow: 'hidden'` on the reveal wrapper — the
    *     8px transform leak returns.
    *
@@ -275,5 +280,44 @@ describe('the run page and its host agree on who owns the height', () => {
     expect(hostCalc, 'the viewport-fit calc not found in PageBlockHost.tsx').toBeDefined();
 
     expect(hostCalc).toBe(declared);
+  });
+
+  /**
+   * 🔴 THE FLOOR'S VALUE BELONGS IN THE GATING TIER, NOT ONLY THE BROWSER ONE.
+   *
+   * `FILL_MIN_HEIGHT_PX` is the whole WCAG fix: too low and a short viewport
+   * strands content behind `overflow-hidden`; too high and the page grows a
+   * scrollbar beside the block's own on ordinary phones, which is THIS PR'S BUG
+   * in a narrower window. Both guards on it were in
+   * `PageBlockHostScrollFit.browser.test.tsx` — and that suite is REPORT-ONLY
+   * (`preview / component-tests`) and historically ~16% flaky, i.e. exactly the
+   * combination that trains people to click through. Measured: with the floor set
+   * to 0, this gating file was 9/9 GREEN and only the non-blocking tier went red.
+   *
+   * So the band is asserted HERE too, by reading the declaration out of the
+   * source the same way the `HEADER_HEIGHT` tripwire above does. The browser
+   * suite still measures the CONSEQUENCE (a real host, laid out, at two viewport
+   * sizes); this pins the DECISION so a merge cannot quietly change it.
+   *
+   * The bounds and the arithmetic behind them live on the constant's own doc
+   * comment — deliberately not restated here, so there is one place to correct.
+   */
+  it('`FILL_MIN_HEIGHT_PX` stays inside its documented band — in the BLOCKING tier', () => {
+    const declared = /export const FILL_MIN_HEIGHT_PX = (\d+);/.exec(code(read(HOST)))?.[1];
+    expect(
+      declared,
+      'FILL_MIN_HEIGHT_PX declaration not found in PageBlockHost.tsx — if it was renamed or ' +
+        'derived, this guard must be re-pointed, not deleted: it is the only BLOCKING check on ' +
+        'the floor value.'
+    ).toBeDefined();
+
+    const floor = Number(declared);
+    // Lower: below this the block's own area (floor − ~31px AppBlockChrome) stops
+    // being usable, which is the case the floor exists to prevent.
+    // Upper: every px added widens the viewport population that sees two
+    // scrollbars. 400 — the value this PR itself shipped one commit ago — is
+    // outside the band on purpose.
+    expect(floor).toBeGreaterThanOrEqual(280);
+    expect(floor).toBeLessThanOrEqual(340);
   });
 });

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -253,8 +253,13 @@ function AppPage(props: PageProps) {
           // options below. `fit="fill"` makes the host claim no height of its
           // own, which needs an ancestor chain that already bounds it; the
           // default scrolling layout does not, so shipping either half alone
-          // regresses this page (drop `fill` → two scrollbars again; drop
-          // `scrollable: false` → the app is clipped behind `overflow-hidden`).
+          // regresses this page, in OPPOSITE directions — and a previous round
+          // of this comment had them the wrong way round. Dropping `fill` leaves
+          // the host claiming `100dvh - 60px` inside the `overflow-hidden`
+          // chain, so the bottom of the app is CLIPPED with nothing to scroll.
+          // Dropping `scrollable: false` selects the `ScrollArea` branch, which
+          // bounds nothing, so `flex: 1` has nothing to resolve against and the
+          // host is sized only by its floor.
           fit="fill"
           sandbox={sandbox}
           trustTier={trustTier}

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -217,8 +217,9 @@ function AppPage(props: PageProps) {
           `AppLayout`'s non-scrolling `<main>` (this page declares
           `scrollable: false` below), so this wrapper has to GROW rather than sit
           at its content height. A plain block would leave `PageBlockHost`'s
-          `flex: 1` resolving against an auto-height parent, letterboxing the
-          iframe down to its ~150px intrinsic replaced-element height.
+          `flex: 1` resolving against an auto-height parent, leaving the host
+          sized only by `FILL_MIN_HEIGHT_PX` — measured 300px of host, 31px of
+          chrome, 269px of iframe, at every viewport width.
           `minHeight: 0` defeats the flex `min-height: auto` floor so the chain
           can shrink to the viewport instead of pushing past it.
 
@@ -253,13 +254,23 @@ function AppPage(props: PageProps) {
           // options below. `fit="fill"` makes the host claim no height of its
           // own, which needs an ancestor chain that already bounds it; the
           // default scrolling layout does not, so shipping either half alone
-          // regresses this page, in OPPOSITE directions — and a previous round
-          // of this comment had them the wrong way round. Dropping `fill` leaves
-          // the host claiming `100dvh - 60px` inside the `overflow-hidden`
-          // chain, so the bottom of the app is CLIPPED with nothing to scroll.
-          // Dropping `scrollable: false` selects the `ScrollArea` branch, which
-          // bounds nothing, so `flex: 1` has nothing to resolve against and the
-          // host is sized only by its floor.
+          // regresses this page, in OPPOSITE directions. Both measured, not
+          // reasoned — this comment has now been wrong in BOTH directions, once
+          // by guessing and once by "correcting" a claim that was already right:
+          //
+          //   Drop `fill` → the host claims `100dvh - 60px` again. The
+          //   `overflow-hidden` chain sits ABOVE this wrapper, and this wrapper
+          //   is `overflowY: 'auto'`, so the excess is SCROLLED, not clipped:
+          //   a page scrollbar beside the block's own — the exact bug this PR
+          //   removes. (Measured 708px of host in a 600px wrapper,
+          //   `USER_SCROLLABLE=true`.)
+          //
+          //   Drop `scrollable: false` → the `ScrollArea` branch bounds nothing,
+          //   so `flex: 1` has nothing to resolve against and the host is sized
+          //   only by `FILL_MIN_HEIGHT_PX` — a fixed slab, whatever the viewport.
+          //
+          // Neither is clipping. Nothing in this layout clips, because this
+          // wrapper can always scroll.
           fit="fill"
           sandbox={sandbox}
           trustTier={trustTier}

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -10,6 +10,7 @@ import type { BlockInstall, PageContext } from '~/components/AppBlocks/types';
 import { BlockRegistry } from '~/server/services/block-registry.service';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { ratingAllowedOnHost } from '~/server/utils/server-domain';
+import { Page } from '~/components/AppLayout/Page';
 
 /**
  * W10 — full-page App Block route: `/apps/run/<slug>` (+ optional sub-path).
@@ -90,7 +91,7 @@ export const getServerSideProps = createServerSideProps<PageProps>({
   },
 });
 
-export default function AppPage(props: PageProps) {
+function AppPage(props: PageProps) {
   const { appBlockId, blockId, appId, appName, iframeSrc, sandbox, trustTier, slug, scopes } =
     props;
   const currentUser = useCurrentUser();
@@ -208,7 +209,16 @@ export default function AppPage(props: PageProps) {
   return (
     <>
       <Meta title={`${appName} — Civitai Apps`} deIndex />
-      <Box style={{ width: '100%' }}>
+      {/* The host is a FLEX ITEM of `AppLayout`'s non-scrolling `<main>` (this
+          page declares `scrollable: false` below), so this wrapper has to grow
+          rather than sit at its content height — a plain block would leave
+          `PageBlockHost`'s `flex: 1` resolving against an auto-height parent and
+          collapse the iframe. `minHeight: 0` defeats the flex `min-height: auto`
+          floor so the chain can actually shrink to the viewport instead of
+          pushing past it. */}
+      <Box
+        style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, width: '100%' }}
+      >
         <PageBlockHost
           appBlockId={appBlockId}
           blockId={blockId}
@@ -218,6 +228,14 @@ export default function AppPage(props: PageProps) {
           iframeSrc={iframeSrc}
           // The public full-page run surface.
           surface="page-run"
+          // 🔴 THE DOUBLE-SCROLLBAR FIX, and it is only half of one — it is
+          // correct ONLY in combination with `scrollable: false` on the `Page`
+          // options below. `fit="fill"` makes the host claim no height of its
+          // own, which needs an ancestor chain that already bounds it; the
+          // default scrolling layout does not, so shipping either half alone
+          // regresses this page (drop `fill` → two scrollbars again; drop
+          // `scrollable: false` → the iframe collapses to 0px).
+          fit="fill"
           sandbox={sandbox}
           trustTier={trustTier}
           slug={slug}
@@ -250,3 +268,30 @@ export default function AppPage(props: PageProps) {
     </>
   );
 }
+
+/**
+ * 🔴 `scrollable: false` IS PART OF THE RENDER CONTRACT, not a cosmetic choice.
+ *
+ * The default (`scrollable: true`) wraps the page in `AppLayout`'s `ScrollArea`
+ * — a bounded, `overflow-y: auto` viewport. A full-page App Block already owns a
+ * scroll surface: the block's own document inside the iframe. Nesting one inside
+ * the other is what produces the double scrollbar, because the host's height and
+ * the scroll viewport's height are computed from different terms and cannot
+ * agree (see `PageBlockHost`'s `fit` prop for the arithmetic).
+ *
+ * `scrollable: false` selects `MainContent`'s `no-scroll` branch — `flex-1
+ * overflow-hidden` from the layout root down — so the outer surface has exactly
+ * one height, no scrollbar of its own, and the block scrolls internally. The
+ * footer is built for this mode (`AppFooter` carries `group-[.no-scroll]:`
+ * variants), so it and the adhesive ad rail are deliberately left at their
+ * defaults rather than nulled — this changes layout mechanics, not what the page
+ * contains.
+ *
+ * `subNav: null` because the run surface is the app's own chrome
+ * (`AppBlockChrome`); the site sub-nav would be a second, competing header bar
+ * and its `mb-3` is one of the terms that overflowed the old calc.
+ */
+export default Page(AppPage, {
+  scrollable: false,
+  subNav: null,
+});

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -209,15 +209,35 @@ function AppPage(props: PageProps) {
   return (
     <>
       <Meta title={`${appName} — Civitai Apps`} deIndex />
-      {/* The host is a FLEX ITEM of `AppLayout`'s non-scrolling `<main>` (this
-          page declares `scrollable: false` below), so this wrapper has to grow
-          rather than sit at its content height — a plain block would leave
-          `PageBlockHost`'s `flex: 1` resolving against an auto-height parent and
-          collapse the iframe. `minHeight: 0` defeats the flex `min-height: auto`
-          floor so the chain can actually shrink to the viewport instead of
-          pushing past it. */}
+      {/* 🔴 THE THIRD LEG OF THE LAYOUT CONTRACT — not incidental styling. Pinned
+          by `pageRunScrollContract.test.ts`, because reverting it passes every
+          other assertion in this PR while breaking the page.
+
+          `display/flexDirection/flex/minHeight` — the host is a FLEX ITEM of
+          `AppLayout`'s non-scrolling `<main>` (this page declares
+          `scrollable: false` below), so this wrapper has to GROW rather than sit
+          at its content height. A plain block would leave `PageBlockHost`'s
+          `flex: 1` resolving against an auto-height parent, letterboxing the
+          iframe down to its ~150px intrinsic replaced-element height.
+          `minHeight: 0` defeats the flex `min-height: auto` floor so the chain
+          can shrink to the viewport instead of pushing past it.
+
+          `overflowY: auto` — the SCROLL CONTAINER OF LAST RESORT, and the reason
+          `FILL_MIN_HEIGHT_PX` is safe. Every ancestor above is `overflow-hidden`
+          under `scrollable: false`, so without this the host's floor would be
+          clipped rather than scrolled and a short viewport (phone landscape, or
+          200% zoom) would put content permanently out of reach. It costs nothing
+          at ordinary sizes: above the floor `flex: 1` fills the parent exactly,
+          so there is no overflow and no scrollbar. */}
       <Box
-        style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, width: '100%' }}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          width: '100%',
+        }}
       >
         <PageBlockHost
           appBlockId={appBlockId}
@@ -287,9 +307,18 @@ function AppPage(props: PageProps) {
  * defaults rather than nulled — this changes layout mechanics, not what the page
  * contains.
  *
- * `subNav: null` because the run surface is the app's own chrome
- * (`AppBlockChrome`); the site sub-nav would be a second, competing header bar
- * and its `mb-3` is one of the terms that overflowed the old calc.
+ * ⚠️ `subNav: null` IS A PRODUCT DECISION, not just layout. `SubNav2` renders
+ * `<HomeTabs />` — the site-wide Models / Images / Videos tabs — so dropping it
+ * removes that navigation row from this route for every viewer. The rationale is
+ * that the run surface already has the app's own chrome (`AppBlockChrome`) and a
+ * second competing header bar reads badly, which is the same call
+ * `src/pages/generate/index.tsx` and `src/pages/research/rater.tsx` make for
+ * their immersive surfaces. Its `mb-3` was also one of the terms that overflowed
+ * the old calc. Flagged rather than buried: if the tabs should stay, drop this
+ * line — the scrollbar fix does not depend on it.
+ *
+ * Note `RewardsBonusBanner` still renders regardless (`AppLayout` shows it in
+ * the `{!subNav && …}` branch), so it is NOT removed by this.
  */
 export default Page(AppPage, {
   scrollable: false,

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -333,17 +333,34 @@ function AppPage(props: PageProps) {
  *      `AppHeader` was confirmed present on the live preview — logo, search,
  *      Create, Buzz balance, account menu. Only the SECOND-level tab row goes,
  *      and its destinations stay reachable from the header.
- *   2. The precedent is exact, not analogous: `src/pages/generate/index.tsx` and
- *      `src/pages/research/rater.tsx` — this repo's other immersive
- *      `scrollable: false` surfaces — both pass `subNav: null`.
+ *   2. There IS precedent, but it is SPLIT — do not read it as a repo rule.
+ *      Complete enumeration of `scrollable: false` in `src/pages` (6 routes
+ *      besides this one), not a sample:
+ *        pass `subNav: null` — `generate/index.tsx`, `research/rater.tsx`,
+ *          `images/[imageId].tsx`
+ *        keep the sub-nav — `comics/project/[id]/read.tsx`,
+ *          `comics/project/[id]/iterate.tsx`, `images/iterate.tsx`
+ *      3-for / 3-against. `images/iterate.tsx` is the sharpest counter-example:
+ *      it nulls MORE chrome than this route does (`header: null`,
+ *      `footer: null`) and still keeps the sub-nav. So this reason establishes
+ *      that dropping it is a normal, precedented choice here — not that it is
+ *      the convention. The weight sits on 1, 3 and 4.
+ *
+ *      🔴 An earlier version of this bullet said "the precedent is exact" and
+ *      named two files. That was a SAMPLE generalised into an enumeration: it
+ *      missed a third supporting case and all three counter-examples. Enumerate
+ *      before claiming a convention.
  *   3. It is ~52px (h-8 pills + `py-1` + `mb-3`) of the vertical budget this
  *      route is tightest on; a 375×667 phone leaves the page ~386px total.
  *   4. Two chrome bars over a THIRD-PARTY app reads badly — the route already
  *      renders `AppBlockChrome` (the "Apps / <name>" breadcrumb).
  *
- * The counter-argument is consistency with the rest of the site, which is what
- * (2) already decided against twice. The scrollbar fix does not depend on this,
- * so dropping the line is a safe one-word reversal.
+ * The counter-argument is consistency with the rest of the site, and (2) shows
+ * this repo genuinely splits on it. The case for dropping it here rests on (1)
+ * — nothing is unreachable — and on (4): unlike every route in either list
+ * above, this one embeds a THIRD-PARTY app, so a second civitai nav strip sits
+ * over someone else's UI. The scrollbar fix does not depend on this, so
+ * restoring the tabs is a safe one-word reversal.
  *
  * Note `RewardsBonusBanner` still renders regardless (`AppLayout` shows it in
  * the `{!subNav && …}` branch), so it is NOT removed by this.

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -323,15 +323,27 @@ function AppPage(props: PageProps) {
  * defaults rather than nulled — this changes layout mechanics, not what the page
  * contains.
  *
- * ⚠️ `subNav: null` IS A PRODUCT DECISION, not just layout. `SubNav2` renders
- * `<HomeTabs />` — the site-wide Models / Images / Videos tabs — so dropping it
- * removes that navigation row from this route for every viewer. The rationale is
- * that the run surface already has the app's own chrome (`AppBlockChrome`) and a
- * second competing header bar reads badly, which is the same call
- * `src/pages/generate/index.tsx` and `src/pages/research/rater.tsx` make for
- * their immersive surfaces. Its `mb-3` was also one of the terms that overflowed
- * the old calc. Flagged rather than buried: if the tabs should stay, drop this
- * line — the scrollbar fix does not depend on it.
+ * `subNav: null` IS A PRODUCT DECISION, not just layout — DECIDED: keep it.
+ * `SubNav2` renders `<HomeTabs />`, the row of top-level section pills, so this
+ * removes that second-level navigation row from the route for every viewer. Four
+ * reasons, written down so the call can be overturned on its merits rather than
+ * rediscovered as an open question:
+ *
+ *   1. TOP-LEVEL NAVIGATION IS NOT LOST. `header` stays at its default, and
+ *      `AppHeader` was confirmed present on the live preview — logo, search,
+ *      Create, Buzz balance, account menu. Only the SECOND-level tab row goes,
+ *      and its destinations stay reachable from the header.
+ *   2. The precedent is exact, not analogous: `src/pages/generate/index.tsx` and
+ *      `src/pages/research/rater.tsx` — this repo's other immersive
+ *      `scrollable: false` surfaces — both pass `subNav: null`.
+ *   3. It is ~52px (h-8 pills + `py-1` + `mb-3`) of the vertical budget this
+ *      route is tightest on; a 375×667 phone leaves the page ~386px total.
+ *   4. Two chrome bars over a THIRD-PARTY app reads badly — the route already
+ *      renders `AppBlockChrome` (the "Apps / <name>" breadcrumb).
+ *
+ * The counter-argument is consistency with the rest of the site, which is what
+ * (2) already decided against twice. The scrollbar fix does not depend on this,
+ * so dropping the line is a safe one-word reversal.
  *
  * Note `RewardsBonusBanner` still renders regardless (`AppLayout` shows it in
  * the `{!subNav && …}` branch), so it is NOT removed by this.

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -254,7 +254,7 @@ function AppPage(props: PageProps) {
           // own, which needs an ancestor chain that already bounds it; the
           // default scrolling layout does not, so shipping either half alone
           // regresses this page (drop `fill` → two scrollbars again; drop
-          // `scrollable: false` → the iframe collapses to 0px).
+          // `scrollable: false` → the app is clipped behind `overflow-hidden`).
           fit="fill"
           sandbox={sandbox}
           trustTier={trustTier}


### PR DESCRIPTION
`/apps/run/<slug>` painted **two vertical scrollbars** — the site layout's `ScrollArea` grew one, the block's own document inside the iframe had another. Only the inner one scrolled anything a viewer wanted.

Turned out to be **two independent causes**, both measured in Chromium rather than reasoned about.

## 1. The host claimed more height than it could ever have

The route shipped a bare `export default function AppPage`, so it inherited `AppLayout`'s default `scrollable: true` — an `overflow-y: auto` `ScrollArea`. Inside it, `PageBlockHost` claimed `min-height: calc(100dvh - 60px)`: the viewport minus the site header, and nothing else. The space actually available is

```
100dvh − header − subNav − its mb-3 − RewardsBonusBanner − AppFooter − AdhesiveAd
```

Every term after `header` is ≥ 0 and several are > 0 on a normal render, so the host was **unconditionally** taller than its own scroll viewport. Not a race, and not tunable — there is no window size at which the two agree.

## 2. The launch-reveal transform escaped its wrapper

While a block is still handshaking, the iframe carries `translateY(8px)`. A transform doesn't change layout but **does** extend the scrollable overflow region, so those 8px asked the nearest scrolling ancestor for a scrollbar. Measured: wrapper `bottom=716`, iframe `bottom=724`, container `scrollHeight 724` vs `clientHeight 716`. Not run-page-specific — it applied to every surface.

## The fix

- **`PageBlockHost` gains an explicit `fit` prop.** `'viewport'` is the default and preserves the old sizing, so the **dev tunnel** and the **mod-review preview** keep their behaviour — both mount inside scrolling ancestors that bound nothing, and would collapse on `'fill'`. `'fill'` fills an already-bounded parent and claims no viewport-derived height. (One thing *does* change for all surfaces: the reveal wrapper's new `overflow: hidden`, i.e. cause 2.)
- **The run page declares `Page(AppPage, { scrollable: false, subNav: null })`** and passes `fit="fill"`, with a wrapper `Box` that grows and provides one scroll container of last resort.
- **`FILL_MIN_HEIGHT_PX = 300`** floors the `fill` host so a short viewport squeezes it but never strands it. See "post-audit" below — this was not in the first version and is the most important change in the PR.
- **The reveal wrapper gets `overflow: hidden`,** confining a purely decorative transform.

### ⚠️ The run-page contract is a co-requisite of THREE legs, in three files

None is safe alone:

| shipped without | result |
|---|---|
| `scrollable: false` | host claims more height than the `overflow-hidden` chain allows → bottom of the app **clipped** |
| `fit="fill"` | `flex: 1` resolves against an auto-height parent → iframe **letterboxes to ~150px** (its intrinsic replaced-element height) |
| the run page's wrapper `Box` | same as above — and this leg is **invisible to the browser suite**, which builds its own fixture wrapper rather than importing the page |

All three are pinned in the node guard, which now compares whole normalised expressions rather than checking for tokens.

## What the pre-merge audit changed

An adversarial audit was run before merge. It found no deploy-blockers but did find a real regression I'd introduced and several vacuous assertions. All are fixed here:

**🟡 The fix traded a cosmetic scrollbar for an unreachable one.** With `scrollable: false` every ancestor is `overflow-hidden`, so the page is the only thing that can offer a scrollbar — and the first version floored the host at `min-height: 0`. The site's fixed chrome can't shrink (header 60 + `AppFooter` 45 + `mt-3` 12 + `AdhesiveAd` 90/50), so on a short viewport the app absorbed the whole shortfall with nothing to scroll. Measured: a ~360px phone-landscape viewport left **153px**, and a 250px viewport collapsed it to **0**, `outerScrollbar = false` throughout. A 1366×768 laptop at **200% zoom** lands in the same band. That is WCAG 1.4.4 / 1.4.10 — strictly worse than the bug being fixed. Cured by `FILL_MIN_HEIGHT_PX` plus `overflowY: 'auto'` on the page wrapper, and pinned at a short viewport **and** a normal one so a floor that fired for everyone would fail.

**🟡 …and a second audit round found that fix unpinned, and its value wrong.** The floor assertion read `height >= FILL_MIN_HEIGHT_PX` — comparing the measurement against the constant that produced it, so true by construction. Measured: `FILL_MIN_HEIGHT_PX = 0` (a full revert of the WCAG fix) passed **all 17 tests**. Now asserted against absolute literals plus a band on the constant; floors of 0/100/200/400/800 are all killed. The value also moved **400 → 300**: the floor is a trade (below it the page grows a scrollbar beside the block's own), and at 400 that band included **375×667-class phones in portrait** — mainstream devices held normally, not the "landscape / 200% zoom" band I'd claimed. My justification had also subtracted chrome from the *screen* height rather than `innerHeight`, overstating the margin on a 768px laptop as 161px when it is ~43px.

**🟡 The gating suite couldn't see the host's styling at all.** A 17-mutant sweep found **9 survivors**, all invisible to a token grep — inverting the ternary (`fit === 'fill'` → `!==`, which breaks *every* surface at once), `flex: 1` → `flex: 0`, deleting the cause-2 `overflow: hidden`, and reverting the page wrapper. Now pinned as whole normalised expressions.

**🟡 Two of my own assertions were vacuous, found by re-running the sweep:**
- `scrollHeight > clientHeight` does **not** mean "reachable" — an `overflow: hidden` box reports the same. Flipping the fixture to `hidden` left all 8 browser tests green. Now asserts computed `overflow-y ∈ {auto, scroll}` as well.
- `expect([...]).toContainEqual(new Set([...]))` does **not** deep-compare Sets in Vitest — measured: it passes when the expected set is absent. That assertion silently tested nothing. Now compares sorted arrays.

**🟡 `subNav: null` is a product decision, not layout — DECIDED: keep it.** It removes `<HomeTabs />`, the row of top-level section pills (~52px with its `mb-3`), from this route. Reasoning, so a reviewer can overturn it on the merits:

- **Top-level navigation is not lost.** `header` stays at its default, and `AppHeader` was confirmed present on the live preview — logo, search, Create, Buzz balance, account menu. Only the *second-level* tab row goes, and its destinations remain reachable from the header.
- **The precedent is exact.** `src/pages/generate/index.tsx:110-113` and `src/pages/research/rater.tsx:783-786` — this repo's two other immersive `scrollable: false` surfaces — both pass `subNav: null`.
- **It is ~52px of the budget this PR spent four audit rounds on.** A 375×667 phone leaves the page ~386px; a competing nav strip costs more there than it returns.
- **Two chrome bars over a third-party app reads badly** — the route already renders `AppBlockChrome` (the "Apps / <name>" breadcrumb), so the sub-nav would stack a second navigation row above someone else's UI.

The counter-argument is consistency with the rest of the site, which is what the two surfaces above already decided against. Dropping the line is a one-word change if a reviewer disagrees. (Also: `RewardsBonusBanner` still renders regardless, so it is not removed as the first version of this description implied.)

**🟡 I claimed the browser suites "are not run in CI at all". That is wrong** — see the correction comment below.

## Tests

**`__tests__/pageRunScrollContract.test.ts`** — node `unit`, the gating project. Pins all three legs, the preserved `'viewport'` default, that only a `PageBlockHost` mounter can opt into `fill`, that `AppLayout`'s two branches still differ as assumed, and that `PageBlockHost`'s hardcoded `60` still equals `AppHeader`'s module-private `HEADER_HEIGHT`.

Round-2 mutation sweep — **13/13 real mutants killed**, each by its intended assertion, with every mutant byte-verified as actually applied (one first-round "survivor" turned out to be a replacement that never matched):

| mutant | killed by |
|---|---|
| invert ternary `fit !== 'fill'` | fit-branch pin |
| fill branch `flex: 1` → `flex: 0` | fit-branch pin |
| floor → `minHeight: 0` (the WCAG squeeze) | fit-branch pin |
| delete / comment out reveal `overflow: hidden` | reveal-wrapper pin |
| revert page wrapper to `{width:'100%'}` | page-wrapper pin |
| drop `minHeight: 0` / `overflowY: 'auto'` from it | page-wrapper pin |
| drop `scrollable: false` / drop `fit="fill"` | both-halves + co-requisite |
| host default → `'fill'` | default test |
| `HEADER_HEIGHT` 60 → 64 | second-copy tripwire |
| drop `overflow-hidden` from the no-scroll `<main>` | layout-premise test |

Plus a **negative control**: a pure Tailwind class *reorder* of that `<main>` (a no-op) correctly **survives**, so the pin isn't merely brittle.

**`PageBlockHostScrollFit.browser.test.tsx`** — measures outcomes in real Chromium instead of reading back the styles under test. Keeps a **red arm** (`fit="viewport"` really does overflow), a fixture positive-control, a collapse guard, and the short-viewport pair. Cause 2 and the squeeze regression were both **found** by this file.

## Verification

✅ `pnpm typecheck` — 0 errors
✅ node `unit`: 2993 tests / 174 files
✅ eslint (`--max-warnings=0`) + prettier clean
✅ browser `component` suites — see final comment

❌ **Still not verified against the live page.** Everything above is measured against the components in Chromium; nobody has loaded `/apps/run/<slug>` on the preview and looked. Worth doing **at a narrow window height** given the squeeze finding.

## Follow-up, not in this PR

`PageBlockHost` hardcodes `60` as a second copy of `AppHeader`'s private `HEADER_HEIGHT`, a real one-rule-two-places hazard for the surfaces still on `'viewport'`. This PR adds a tripwire rather than consolidating, since exporting the constant touches unrelated files. **Closing condition:** `PageBlockHost` reads the header height from a single exported source and the tripwire assertion is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


