### PR TITLE
docs(creator-program): explain the banking cap window onsite

### DIFF
--- a/src/components/Buzz/CreatorProgramV2/CreatorProgramV2.modals.tsx
+++ b/src/components/Buzz/CreatorProgramV2/CreatorProgramV2.modals.tsx
@@ -9,6 +9,7 @@ import {
   CAP_DEFINITIONS,
   EXTRACTION_FEES,
   MIN_CAP,
+  PEAK_EARNING_WINDOW,
   WITHDRAWAL_FEES,
 } from '~/shared/constants/creator-program.constants';
 import { getCapForDefinition, getNextCapDefinition } from '~/shared/utils/creator-program.utils';
@@ -312,11 +313,19 @@ export const CreatorProgramCapsInfo = ({ onUpgrade }: { onUpgrade?: () => void }
             </p>
             <p>
               <span className="font-bold">Peak Earning Month:</span>{' '}
-              <CurrencyIcon currency={Currency.BUZZ} className="inline" />
-              {abbreviateNumber(banked.cap.peakEarning.earned)}{' '}
-              <span className="opacity-50">
-                ({formatDate(banked.cap.peakEarning.month, 'MMM YYYY')})
-              </span>
+              {peakEarned > 0 ? (
+                <>
+                  <CurrencyIcon currency={Currency.BUZZ} className="inline" />
+                  {abbreviateNumber(peakEarned)}{' '}
+                  <span className="opacity-50">
+                    ({formatDate(banked.cap.peakEarning.month, 'MMM YYYY')})
+                  </span>
+                </>
+              ) : (
+                // With no qualifying earnings the service falls back to the CURRENT month, which the
+                // copy below says cannot count. Show no month rather than that contradiction.
+                <span className="opacity-50">None yet</span>
+              )}
             </p>
             <p>
               <span className="font-bold">Tier Cap:</span>{' '}
@@ -352,6 +361,27 @@ export const CreatorProgramCapsInfo = ({ onUpgrade }: { onUpgrade?: () => void }
           )}
         </>
       )}
+
+      <div className="flex flex-col gap-2">
+        <p className="font-bold">How your Peak Earning Month is picked</p>
+        <p>
+          We take your best month of generation compensation and Buzz other people spent on your
+          work, in the last {PEAK_EARNING_WINDOW} <span className="font-bold">completed</span>{' '}
+          months. Tips and rewards can still be Banked, but they do not set your peak.
+        </p>
+        <ul className="list-disc pl-4">
+          <li>
+            <span className="font-bold">The month you are in does not count.</span> Buzz earned
+            today cannot raise today&apos;s Cap, so your Cap holds steady.
+          </li>
+          <li>
+            <span className="font-bold">
+              The last {PEAK_EARNING_WINDOW} completed months are what count.
+            </span>{' '}
+            The Cap follows what you earn now, keeping the Pool shared between active creators.
+          </li>
+        </ul>
+      </div>
     </div>
   );
 };
@@ -360,10 +390,18 @@ export const CreatorProgramCapsInfoModal = () => {
   const dialog = useDialogContext();
 
   return (
-    <Modal {...dialog} size="lg" radius="md" withCloseButton={false}>
-      <p className="text-center text-lg font-bold">Creator Banking Caps</p>
+    <Modal
+      {...dialog}
+      size="lg"
+      radius="md"
+      title="Creator Banking Caps"
+      classNames={{
+        title: 'font-bold',
+        header: 'border-b border-gray-3 pb-3 dark:border-dark-4',
+        body: 'pt-4',
+      }}
+    >
       <CreatorProgramCapsInfo onUpgrade={dialog.onClose} />
-      <Button onClick={dialog.onClose}>Close</Button>
     </Modal>
   );
 };

--- a/src/pages/creator-program/index.tsx
+++ b/src/pages/creator-program/index.tsx
@@ -57,6 +57,7 @@ import {
 } from '~/components/Buzz/CreatorProgramV2/CreatorProgram.util';
 import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
 import { CreatorProgramCapsInfo } from '~/components/Buzz/CreatorProgramV2/CreatorProgramV2.modals';
+import { MIN_CAP, PEAK_EARNING_WINDOW } from '~/shared/constants/creator-program.constants';
 import { getCreatorProgramAvailability } from '~/server/utils/creator-program.utils';
 import { Flags } from '~/shared/utils/flags';
 import { OnboardingSteps } from '~/server/common/enums';
@@ -740,6 +741,20 @@ const faq: { q: string; a: string | React.ReactNode }[] = [
   {
     q: 'Would buying a higher Membership Tier (Silver or Gold) increase my earnings?',
     a: 'Not your earnings, as such, but it does increase the maximum you can Bank each month.',
+  },
+  {
+    q: 'How is my Banking Cap calculated?',
+    a: `Your Cap is your Peak Earning Month multiplied by your membership tier's percentage, up to that tier's ceiling where it has one. Your Peak Earning Month is the single best month of generation compensation and Buzz other people spent on your work that you have had in the last ${PEAK_EARNING_WINDOW} completed months; Tips and rewards can still be Banked, but they do not set your peak. Tiers with a fixed Cap stay at that number, and every member has a minimum Cap of ${abbreviateNumber(
+      MIN_CAP
+    )} Buzz, however small their peak.`,
+  },
+  {
+    q: "Why doesn't this month's earning count toward my Cap?",
+    a: `Only completed months are eligible, so a great month raises your Cap the month after it finishes rather than while it is still running. That way your Peak Earning Month is settled before it is used, and it stays fixed for the whole month while every creator is banking against the same pool. If you are earning more than ever this month, your Cap will reflect it next month with nothing for you to claim or apply for.`,
+  },
+  {
+    q: `Why does the Cap look at the last ${PEAK_EARNING_WINDOW} months?`,
+    a: `Because the Cap is meant to track what you are earning now, not what you earned once. The Compensation Pool is split between everyone who banks into it that month, so a rolling window keeps it shared between creators who are actively earning. The window rolls forward with you, so beating your current peak inside it raises your Cap again.`,
   },
   {
     q: 'Will I get my Banked Buzz back?',


### PR DESCRIPTION
Closes [868kuwp1v](https://app.clickup.com/t/868kuwp1v).

## Why

A creator reported two things about the Peak Earning Month behind Creator Banking Caps, believing both were bugs: the current month is not considered, and the lookback is only 12 months. Both are as designed. He accepted the design in a single message once he had the reasoning — the rules were fine, the explanation was missing.

## What the audit found

Something already existed, and it was buried. `CreatorProgramCapsInfo` renders the tier table, a creator's Peak Earning Month figure with its date, their Cap, and an upgrade nudge. On the Buzz dashboard it is reachable only by clicking the small underlined "`{x}` Cap" text inside the Estimated Earnings table; on `/creator-program` it sits inline under "Creator Banking Caps".

**Neither ever stated that the current month is excluded, neither stated the 12-month window, and neither gave a reason for either.** A creator could read every word onsite and still conclude both were bugs.

## What this adds

- A "How your Peak Earning Month is picked" block in `CreatorProgramCapsInfo`, so it appears in both places at once — the two rules and why each exists.
- Three FAQ entries on `/creator-program` next to the banking and cash-out questions: how the Cap is calculated, why the current month does not count, and why the window is the last 12 months.

The window and the minimum cap are interpolated from `PEAK_EARNING_WINDOW` and `MIN_CAP` rather than written as numbers, so they cannot drift from the code.

## Three corrections found reviewing the copy against the implementation

An adversarial pass over the first draft caught three claims that were wrong, each verified against the source before changing:

1. **"bankable earnings" was inaccurate.** The peak query (`creator-program.service.ts`) counts `type IN ('compensation')` and `type = 'purchase' AND fromAccountId != 0`. Standalone `Tip` and `Reward` rows are excluded deliberately — generation tips already arrive inside the daily `compensation` payout. But the existing FAQ says Banking "includes Buzz from sources such as Early Access, Tips, and Generator Compensation", so "best month of bankable earnings" named a figure that excludes what the page calls bankable. The copy now says what actually counts and notes that Tips and rewards are still bankable but do not set the peak.
2. **"multiplied by your tier's percentage" overstated Silver by up to 2.5x.** Silver has both `percentOfPeakEarning: 1.25` and `limit: 1_000_000`, and `getCapForDefinition` takes the `Math.min`. A Silver member with a 2M peak gets 1M, not 2.5M.
3. **"your Cap stays fixed for the whole month" was false.** A tier change busts the cap cache immediately (`subscription.utils.ts`, `paddle.ts`), and this same modal sells that upgrade. It is the *Peak Earning Month* that is fixed for the month, not the Cap.

## Two fixes beyond the copy

- **Peak Earning Month row.** With no qualifying earnings the service falls back to `{ month: new Date(), earned: 0 }`, so the row rendered "0 (Aug 2026)" — the current month — directly above new copy saying the current month cannot count. It now shows "None yet". Fixed in the display layer rather than the service, because narrowing `month` to nullable would ripple through the cache type and the tRPC output for no gain.
- **Modal chrome.** `CreatorProgramCapsInfoModal` passed `withCloseButton={false}` and rendered its own `Close` button, which left no X and sat flush against the text. The title moves into Mantine's `title` prop, giving the standard header, an X, and click-outside to close.

## Verification

- `pnpm run typecheck` — `0 type errors`, exit 0.
- `pnpm run lint` on the two changed files — exit 0, no output. Repo-wide lint is red at `4346 problems (362 errors)` both before and after this change, and names neither file; that is the existing baseline.
- `pnpm run test:unit:run` — `Test Files 1374 passed | 1 skipped (1375)`, `Tests 21546 passed | 27 skipped (21573)`, exit 0.
- `blocks.router.workflow.test.ts` collected **358 tests**, confirming the worktree's submodule is initialised and the run was real.

No tests added: the change is user-facing copy plus one render conditional, and a component test for it would land in the `*.browser.test.tsx` project, which runs in no CI job.

## Not fixed here

`BANKABLE_BUZZ_TYPES_STRING` in `creator-program.service.ts` hard-codes `'yellow','green'` where `buzz.service.ts` derives the same list from `buzzBankTypes`, so a third bankable type would be silently missed by the peak query. Out of scope for a copy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
