### PR TITLE
feat(feed): put the /images and /videos tag bar behind a Flipt kill switch

### DIFF
--- a/src/components/Image/Filters/ImageFeedTagBar.tsx
+++ b/src/components/Image/Filters/ImageFeedTagBar.tsx
@@ -3,6 +3,7 @@ import { useImageQueryParams } from '~/components/Image/image.utils';
 import type { TagChipRowItem } from '~/components/Tags/TagChipRow';
 import { TagChipRow } from '~/components/Tags/TagChipRow';
 import { useTrackEvent } from '~/components/TrackView/track.utils';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { trpc } from '~/utils/trpc';
 
 type FeedTagBarFeed = 'images' | 'videos';
@@ -21,6 +22,7 @@ type FeedTagBarFeed = 'images' | 'videos';
  */
 export function ImageFeedTagBar({ feed }: { feed: FeedTagBarFeed }) {
   const { trackAction } = useTrackEvent();
+  const features = useFeatureFlags();
 
   // The same hook the feed itself filters through (`useImageFilters` → `query.tags`).
   // Reading `router.query` directly here instead would give the chips and the feed two
@@ -29,7 +31,7 @@ export function ImageFeedTagBar({ feed }: { feed: FeedTagBarFeed }) {
   const { query, replace } = useImageQueryParams();
   const tagIds = query.tags ?? [];
 
-  const { data } = trpc.tag.getFeedTagBar.useQuery();
+  const { data } = trpc.tag.getFeedTagBar.useQuery(undefined, { enabled: features.feedTagBar });
   const { items: tags, loadingPreferences } = useApplyHiddenPreferences({
     type: 'tags',
     data,
@@ -61,6 +63,8 @@ export function ImageFeedTagBar({ feed }: { feed: FeedTagBarFeed }) {
     emit(undefined);
     replace({ tags: [] });
   };
+
+  if (!features.feedTagBar) return null;
 
   return (
     <TagChipRow

--- a/src/components/Image/Filters/ImageFeedTagBar.tsx
+++ b/src/components/Image/Filters/ImageFeedTagBar.tsx
@@ -31,7 +31,11 @@ export function ImageFeedTagBar({ feed }: { feed: FeedTagBarFeed }) {
   const { query, replace } = useImageQueryParams();
   const tagIds = query.tags ?? [];
 
-  const { data } = trpc.tag.getFeedTagBar.useQuery(undefined, { enabled: features.feedTagBar });
+  // `!!` is load-bearing: FeatureAccess is sparse, so an off flag is `undefined` rather
+  // than `false`, and react-query reads `enabled: undefined` as enabled.
+  const { data } = trpc.tag.getFeedTagBar.useQuery(undefined, {
+    enabled: !!features.feedTagBar,
+  });
   const { items: tags, loadingPreferences } = useApplyHiddenPreferences({
     type: 'tags',
     data,

--- a/src/components/Image/Filters/__tests__/ImageFeedTagBar.test.ts
+++ b/src/components/Image/Filters/__tests__/ImageFeedTagBar.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type * as HiddenPreferences from '~/components/HiddenPreferences/useApplyHiddenPreferences';
 import type * as TrackUtils from '~/components/TrackView/track.utils';
+import type * as FeatureFlagsProvider from '~/providers/FeatureFlagsProvider';
 import type * as TrpcModule from '~/utils/trpc';
 
 const mocks = vi.hoisted(() => ({
@@ -18,6 +19,8 @@ const mocks = vi.hoisted(() => ({
   loadingPreferences: false,
   maxNsfwLevel: 1,
   trackAction: vi.fn(() => Promise.resolve()),
+  feedTagBar: true,
+  getFeedTagBar: vi.fn(),
 }));
 
 vi.mock('next/router', () => ({
@@ -26,7 +29,25 @@ vi.mock('next/router', () => ({
 
 vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof TrpcModule>()),
-  trpc: { tag: { getFeedTagBar: { useQuery: () => ({ data: mocks.tags }) } } },
+  trpc: {
+    tag: {
+      getFeedTagBar: {
+        // Records the options so a test can assert the request is SKIPPED when the flag
+        // is off. It returns the tags either way, which is deliberately unlike
+        // react-query (a disabled query yields no data) — a gate that only hid the
+        // markup would still be caught here rather than looking like a skipped fetch.
+        useQuery: (input: unknown, options?: { enabled?: boolean }) => {
+          mocks.getFeedTagBar(input, options);
+          return { data: mocks.tags };
+        },
+      },
+    },
+  },
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsProvider>()),
+  useFeatureFlags: () => ({ feedTagBar: mocks.feedTagBar }),
 }));
 
 // Stands in for the real hidden-preferences provider, which needs a session + query
@@ -106,6 +127,8 @@ describe('ImageFeedTagBar', () => {
   beforeEach(() => {
     mocks.replace.mockClear();
     mocks.trackAction.mockClear();
+    mocks.getFeedTagBar.mockClear();
+    mocks.feedTagBar = true;
     mocks.pathname = '/images';
     mocks.query = {};
     mocks.hiddenTagIds = [];
@@ -120,6 +143,30 @@ describe('ImageFeedTagBar', () => {
   it('renders the All chip plus every tag, in the order the server sent them', () => {
     const container = render();
     expect(buttonLabels(container)).toEqual(['All', 'anime', 'realistic']);
+  });
+
+  // Gated so the bar can be switched off without a deploy, after its click-through came
+  // in under the floor it shipped on (868kv1b9m). `feedTagBar` fails OPEN, so the case
+  // that needs pinning is that OFF actually removes it.
+  it('renders nothing when the feedTagBar flag is off', () => {
+    mocks.feedTagBar = false;
+    const container = render();
+
+    expect(buttonLabels(container)).toEqual([]);
+    // The reserved row too, not just the chips: the bar holds height while its tags load,
+    // so a gate that only emptied the chip list would still push the feed down by 26px.
+    expect(reservedRows(container)).toHaveLength(0);
+  });
+
+  it('does not request the chip list when the flag is off, and does when it is on', () => {
+    mocks.feedTagBar = false;
+    render();
+    expect(mocks.getFeedTagBar).toHaveBeenCalledWith(undefined, { enabled: false });
+
+    mocks.getFeedTagBar.mockClear();
+    mocks.feedTagBar = true;
+    render();
+    expect(mocks.getFeedTagBar).toHaveBeenCalledWith(undefined, { enabled: true });
   });
 
   it('writes ?tags=<id> on select, preserving the rest of the query', () => {
@@ -270,6 +317,8 @@ describe('ImageFeedTagBar click-through instrumentation', () => {
   beforeEach(() => {
     mocks.replace.mockClear();
     mocks.trackAction.mockClear();
+    mocks.getFeedTagBar.mockClear();
+    mocks.feedTagBar = true;
     mocks.pathname = '/images';
     mocks.query = {};
     mocks.hiddenTagIds = [];

--- a/src/components/Image/Filters/__tests__/ImageFeedTagBar.test.ts
+++ b/src/components/Image/Filters/__tests__/ImageFeedTagBar.test.ts
@@ -19,7 +19,9 @@ const mocks = vi.hoisted(() => ({
   loadingPreferences: false,
   maxNsfwLevel: 1,
   trackAction: vi.fn(() => Promise.resolve()),
-  feedTagBar: true,
+  // Sparse, exactly as FeatureAccess is: an off flag is ABSENT, so it reads `undefined`.
+  // Driving the off case with `false` would test a state production never produces.
+  feedTagBar: true as boolean | undefined,
   getFeedTagBar: vi.fn(),
 }));
 
@@ -149,7 +151,7 @@ describe('ImageFeedTagBar', () => {
   // in under the floor it shipped on (868kv1b9m). `feedTagBar` fails OPEN, so the case
   // that needs pinning is that OFF actually removes it.
   it('renders nothing when the feedTagBar flag is off', () => {
-    mocks.feedTagBar = false;
+    mocks.feedTagBar = undefined;
     const container = render();
 
     expect(buttonLabels(container)).toEqual([]);
@@ -159,13 +161,21 @@ describe('ImageFeedTagBar', () => {
   });
 
   it('does not request the chip list when the flag is off, and does when it is on', () => {
-    mocks.feedTagBar = false;
+    // `undefined`, not `false` — see the note on `mocks.feedTagBar`.
+    mocks.feedTagBar = undefined;
     render();
-    expect(mocks.getFeedTagBar).toHaveBeenCalledWith(undefined, { enabled: false });
+    // Strictly `false`, not merely falsy: react-query reads `enabled: undefined` as
+    // ENABLED, so a gate that forwarded the sparse flag straight through would fetch.
+    // Zero calls satisfies this too, so hoisting the gate above the hook stays green.
+    for (const [, options] of mocks.getFeedTagBar.mock.calls) {
+      expect(options?.enabled).toBe(false);
+    }
 
     mocks.getFeedTagBar.mockClear();
     mocks.feedTagBar = true;
     render();
+    // The control. Without it the arm above passes for a bar that can never fetch.
+    expect(mocks.getFeedTagBar).toHaveBeenCalledTimes(1);
     expect(mocks.getFeedTagBar).toHaveBeenCalledWith(undefined, { enabled: true });
   });
 

--- a/src/server/services/__tests__/feed-tag-bar-flag-gate.test.ts
+++ b/src/server/services/__tests__/feed-tag-bar-flag-gate.test.ts
@@ -1,0 +1,102 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import type { IncomingMessage } from 'http';
+import type { NextApiRequest } from 'next';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * The mirror image of `user-hubs-flag-gate`, and the reason it needs its own test:
+ * `feedTagBar` gates a bar that is ALREADY shipped and visible to everyone, so it must
+ * fail OPEN. `isEnabledSync` returns null for a missing flag and for an unreachable
+ * Flipt alike, and `availability: ['public']` is what makes the static layer answer
+ * true rather than false.
+ *
+ * A shipped feature that reads as OFF when its flag is absent removes itself on deploy.
+ */
+
+vi.hoisted(() => {
+  process.env.SERVER_DOMAIN_GREEN = 'civitai.com';
+  process.env.SERVER_DOMAIN_BLUE = 'civitai.blue';
+  process.env.SERVER_DOMAIN_RED = 'civitai.red';
+});
+
+const { fliptResult } = vi.hoisted(() => ({
+  fliptResult: { value: null as boolean | null },
+}));
+
+vi.mock('~/server/flipt/client', () => ({
+  isFliptSync: () => fliptResult.value,
+  ensureFliptInitialized: async () => undefined,
+}));
+
+import { getFeatureFlags, getFeatureFlagsAsync } from '../feature-flags.service';
+
+type Ctx = { user?: SessionUser; req: NextApiRequest | IncomingMessage };
+
+const req = (host = 'civitai.com') =>
+  ({ headers: { host, 'cf-ipcountry': 'US' } } as unknown as NextApiRequest);
+
+// `getFeatureFlags` memoizes for 10s on (user identity, host, region), and the Flipt
+// result is NOT part of that key — so two cases sharing an identity would share one
+// answer. Every case takes a fresh id.
+let nextUserId = 5000;
+
+const user = (over: Partial<SessionUser> = {}): SessionUser =>
+  ({
+    id: nextUserId++,
+    username: 'u',
+    isModerator: false,
+    tier: 'free',
+    permissions: [],
+    onboarding: 0,
+    ...over,
+  } as SessionUser);
+
+const contexts: { name: string; ctx: () => Ctx }[] = [
+  { name: 'anonymous', ctx: () => ({ req: req(`anon-${nextUserId++}.civitai.com`) }) },
+  { name: 'free user', ctx: () => ({ user: user(), req: req() }) },
+  { name: 'paying member', ctx: () => ({ user: user({ tier: 'gold' }), req: req() }) },
+  { name: 'moderator', ctx: () => ({ user: user({ isModerator: true }), req: req() }) },
+  { name: 'red domain', ctx: () => ({ user: user(), req: req('civitai.red') }) },
+];
+
+beforeAll(async () => {
+  // Primes the service's lazily imported flipt module with the mock. Without it the
+  // Flipt branch is skipped outright, every case below passes on the static layer
+  // alone, and the test is blind to a flag that turns the bar off when it should not.
+  fliptResult.value = null;
+  await getFeatureFlagsAsync({ req: req('prime.example.invalid') });
+});
+
+describe('feedTagBar with no `feed-tag-bar` flag in Flipt', () => {
+  for (const { name, ctx } of contexts) {
+    it(`stays ON for ${name}`, () => {
+      fliptResult.value = null;
+
+      expect(getFeatureFlags(ctx()).feedTagBar).toBe(true);
+    });
+  }
+
+  it('turns off when the flag exists and evaluates false', () => {
+    // The control. Without it every case above passes for a flag that can never turn
+    // the bar off at all, which is not a kill switch.
+    fliptResult.value = false;
+
+    expect(getFeatureFlags({ user: user(), req: req() }).feedTagBar).toBeFalsy();
+  });
+
+  it('turns off for a moderator too, so the switch cannot be verified from a mod browser', () => {
+    // Flipt's answer is returned before any isModerator consideration. Stated as a test
+    // because the usual shape of a Civitai flag is the opposite: a `moderators` segment
+    // rollout leaves a feature on for every mod, and a mod checking their own view would
+    // then report the bar as still live after throwing the switch.
+    fliptResult.value = false;
+
+    expect(getFeatureFlags({ user: user({ isModerator: true }), req: req() }).feedTagBar).toBeFalsy();
+  });
+
+  it('stays on when the flag exists and evaluates true', () => {
+    fliptResult.value = true;
+
+    expect(getFeatureFlags({ user: user(), req: req() }).feedTagBar).toBe(true);
+  });
+});

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -173,6 +173,16 @@ const featureFlags = createFeatureFlags({
   // and part count; instant rollback = set the cohort to 0, which stops the
   // browser observing at all rather than merely dropping rows server-side.
   feedImpressions: { availability: [], fliptKey: 'feed-impressions' },
+  // Kill switch for the /images and /videos tag bar, whose click-through was measured at
+  // 3.1% of feed pageviews and 7.3% of daily feed viewers against a 10% floor it had to
+  // clear to stay (868kv1b9m). `['public']` and NOT `[]`, which is the usual shape for a
+  // new flag: this gates something already shipped and visible to everyone, so it must
+  // fail OPEN. Dark-by-default would hide the bar the moment this deploys and again on
+  // any Flipt outage, turning a pending product decision into an accidental removal.
+  // Flipt's result overrides role checks in both directions, so a `feed-tag-bar` boolean
+  // with `enabled: false` and no rollout hides the bar for everyone, moderators included.
+  // Until that flag exists, evaluation returns null and static evaluation keeps it on.
+  feedTagBar: { availability: ['public'], fliptKey: 'feed-tag-bar' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },


### PR DESCRIPTION
Puts the `/images` and `/videos` tag bar behind a Flipt kill switch. **No visible change** — the flag is on and the bar renders exactly as it does today.

## Why

The bar shipped 2026-08-21 (#4253) on the condition that it clear a 10% click-through floor (ClickUp `868kv1b9m`). Measured against prod ClickHouse for 2026-08-23, its first full day live:

| Denominator | Rate | Numerator / denominator |
|---|---|---|
| Feed pageviews | 3.06% | 10,551 / 345,368 |
| Unique daily feed viewers | 7.31% | 3,702 / 50,633 |

Every defensible denominator lands between 2.66% and 8.84%. For scale on the same day and the same query shape, `Model_Create_Click` on model pages is 14.5% of unique viewers and `Image_Remix_Click` is 6.9% — so the shape can clear 10%, and the tag bar out-clicks Remix while losing to Create.

The removal decision is still open. This decouples it from a deploy: whoever decides can act on it in Flipt in one click, in either direction, without shipping code.

## Why `availability: ['public']` and not `[]`

This is the opposite of the usual posture for a new flag, and it is deliberate.

`[]` means dark-by-default and fails **closed**. That is right for something not yet shipped. This gates something **already shipped and visible to everyone**, so it has to fail **open** — otherwise merging this PR would itself remove the bar, and so would any Flipt outage, turning a pending product decision into an accidental removal.

The mechanism that makes it safe: `isEnabledSync` returns **`null`**, not `false`, for a flag that does not exist or cannot be evaluated (`feature-flags.service.ts:781`). Flipt short-circuits the static evaluation only when it has a real answer; otherwise `['public']` decides and the bar stays on. If that returned `false` this exact code would hide the bar on deploy.

## The switch

`feed-tag-bar` is live in `flipt-state` (civitai/flipt-state#78) at `enabled: true` with **no rollout**, so it is a no-op today. Off is `enabled: false`, still no rollout.

Not a segment. A `moderators` or `testers` rollout leaves the bar on for every moderator, and a moderator checking their own browser would then report it as still live.

## The gate

Inside `ImageFeedTagBar`, so one gate covers both feeds, and after every hook so the hook order is unconditional. It also passes `enabled` to the chip-list query rather than only hiding the markup — an off bar should cost the feed no request, and this is the hot feed path.

## A bug the review found, and the fix

The first version of this PR had `enabled: features.feedTagBar`, which **did not disable the query**. `FeatureAccess` is sparse — an off flag is absent, so it reads `undefined`, not `false` (`feature-flags.service.ts:999`) — and React Query resolves `enabled` as `!== false` rather than by truthiness. So with the switch off the bar disappeared and `tag.getFeedTagBar` was still fetched on every hard load of the two feeds.

The test did not catch it because it drove the off case with a literal `false`, a value production never produces for an off flag. The mock manufactured the passing condition. It now uses `undefined` and asserts `enabled` is strictly `false` — `toBeFalsy()` passes with the bug present, since `undefined` is falsy.

Fixed as `enabled: !!features.feedTagBar`. ~14 older call sites in `src/` carry the same latent shape; filed separately rather than widened into this PR.

## Two things left deliberately undone

- **`tag.getFeedTagBar` stays a bare `publicProcedure`.** The client gate stops the request; the endpoint remains callable with the flag off. `isFlagProtected` exists (`src/server/trpc.ts:422`) but using it would make the procedure fail **closed** against a flag deliberately built to fail **open**, which is backwards. Off is a UI kill switch, not a server gate. If the decision later becomes *remove*, the endpoint and `feed-tag-bar.constants.ts` are that work, not this.
- **Verify the switch with an anonymous evaluation, not a moderator browser.** The Flipt answer is returned before any `isModerator` consideration, so `enabled: false` with no rollout does hide the bar for mods too — but the house shape for a Civitai flag is `enabled: false` **plus** a testers/moderators segment, under which every mod still matches. A mod checking their own view would then report the bar as still live. There is now a test pinning the mod case.

## Verification

- `ImageFeedTagBar.test.ts`: **25 passed** (23 existing, 2 new). Runs in the `unit` project, so CI covers it — not a `.browser.test.tsx`.
- **Mutation check.** Removed the `return null` and the `enabled` option: exactly the 2 new tests fail, the other 23 pass. A green suite says nothing about how it fails, so this is the part that shows the tests protect something.
- `pnpm run typecheck`: 0 errors.
- `eslint` and `prettier --check` on the three changed files: clean. (Repo-wide lint is pre-existing noise in ~1,400 files.)
- `feed-tag-bar-flag-gate.test.ts` (new): with no `feed-tag-bar` flag in Flipt the bar stays ON for anonymous, free, member, moderator and the red domain, and goes off when the flag evaluates false. **Mutation-checked**: `availability: []` fails five of those while the three controls stay green.
- Full unit suite: run separately; see the comment below for its result.

ClickUp: https://app.clickup.com/t/868kv1b9m

🤖 Generated with [Claude Code](https://claude.com/claude-code)
