### PR TITLE
feat(model-files): correct file precision and type from the tensor header

### DIFF
--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -6,9 +6,11 @@ import { dbRead } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { REDIS_KEYS } from '~/server/redis/client';
 import { getFileForModelVersion } from '~/server/services/file.service';
+import { correctModelFileFromTensorHeader } from '~/server/services/model-file-header-correction.service';
 import { getFullTensorAnalysisCached } from '~/server/services/tensor-metadata.service';
 import { fetchThroughCache } from '~/server/utils/cache-helpers';
 import { MixedAuthEndpoint } from '~/server/utils/endpoint-helpers';
+import type { ModelTensorAnalysis } from '~/utils/model-tensor-metadata';
 import {
   inferTensorMetadataFormat,
   parseModelTensorMetadata,
@@ -61,6 +63,7 @@ export default MixedAuthEndpoint(async function handler(
       id: true,
       modelVersionId: true,
       name: true,
+      url: true,
       type: true,
       sizeKB: true,
       metadata: true,
@@ -141,6 +144,33 @@ export default MixedAuthEndpoint(async function handler(
         )
       );
 
+    // Repair on demand: the header is the source of truth for precision, and for file
+    // type where it is unambiguous, so a viewed file with a wrong stored value is
+    // corrected here. Deliberately NOT awaited before responding — the read must not
+    // wait on a write, and a failed correction is retried by the next viewer.
+    const correct = (analysis: Pick<ModelTensorAnalysis, 'dtypeCounts' | 'detectedModelType'>) =>
+      correctModelFileFromTensorHeader({
+        fileId: file.id,
+        fileUrl: file.url,
+        modelVersionId: file.modelVersionId,
+        format,
+        dtypeCounts: analysis.dtypeCounts,
+        detectedModelType: analysis.detectedModelType,
+        currentFp: (file.metadata as BasicFileMetadata | null)?.fp,
+        currentFileType: file.type,
+        modelType: file.modelVersion.model.type,
+      }).catch((error) =>
+        logToAxiom({
+          name: 'model-file-tensor-metadata',
+          type: 'error',
+          message: `header correction failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          fileId: id,
+          modelVersionId: file.modelVersionId,
+        }).catch(() => undefined)
+      );
+
     if (summaryOnly) {
       const summary = await fetchThroughCache(
         `${REDIS_KEYS.CACHES.TENSOR_METADATA_SUMMARY}:${id}`,
@@ -152,12 +182,14 @@ export default MixedAuthEndpoint(async function handler(
         { ttl: CacheTTL.month }
       );
       res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
-      return res.status(200).json(summary);
+      res.status(200).json(summary);
+      return void correct(summary);
     }
 
     const analysis = await fetchFull();
     res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
     res.status(200).json(analysis);
+    return void correct(analysis);
   } catch (error) {
     // The upstream byte-range fetch fails transiently. If this 422 ever inherits the immutable
     // header, Cloudflare freezes the error for a year and the file's panel never recovers.

--- a/src/server/services/__tests__/model-file-header-correction.service.test.ts
+++ b/src/server/services/__tests__/model-file-header-correction.service.test.ts
@@ -26,6 +26,17 @@ const target = {
 };
 
 const bf16Counts = [{ dtype: 'BF16', count: 300, bytes: 4_000_000 }];
+const fp8Counts = [{ dtype: 'F8_E4M3FN', count: 300, bytes: 4_000_000 }];
+const mxfp8Counts = [
+  { dtype: 'F8_E4M3', count: 300, bytes: 4_000_000 },
+  { dtype: 'F8_E8M0', count: 300, bytes: 125_000 },
+];
+/** How bitsandbytes stores an nf4 checkpoint: 4-bit weights packed into U8, which the
+ *  dtype map deliberately does not resolve, plus F16 auxiliary tensors that do. */
+const nf4Counts = [
+  { dtype: 'U8', count: 300, bytes: 4_000_000 },
+  { dtype: 'F16', count: 60, bytes: 200_000 },
+];
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -33,7 +44,7 @@ beforeEach(() => {
   deleteFilesForModelVersionCache.mockResolvedValue(undefined);
 });
 
-describe('getModelFileHeaderCorrections', () => {
+describe('getModelFileHeaderCorrections — precision', () => {
   it('corrects a stored precision the header disagrees with', () => {
     expect(
       getModelFileHeaderCorrections({
@@ -54,37 +65,18 @@ describe('getModelFileHeaderCorrections', () => {
     ).toEqual({});
   });
 
-  // 🔴 Deliberate, and the reason is in FP_CONSISTENT_WITH_HEADER: an F8 dtype is
-  // equally fp8, fp8_scaled or fp8_mixed, so "header wins" would round every scaled
-  // file down to plain fp8 on every read. Do not "fix" this to expect { fp: 'fp8' }.
-  it('keeps a scaled fp8 value that an F8 header cannot contradict', () => {
+  // The backlog this feature exists to fill: a file with no precision recorded at all.
+  it.each([undefined, null] as const)('fills in a missing precision (%s)', (currentFp) => {
     expect(
-      getModelFileHeaderCorrections({
-        format: 'SafeTensor',
-        dtypeCounts: [{ dtype: 'F8_E4M3FN', count: 300, bytes: 4_000_000 }],
-        currentFp: 'fp8_scaled',
-      })
-    ).toEqual({});
-  });
-
-  it('still corrects a stored fp8_scaled when the header positively says mxfp8', () => {
-    expect(
-      getModelFileHeaderCorrections({
-        format: 'SafeTensor',
-        dtypeCounts: [
-          { dtype: 'F8_E4M3', count: 300, bytes: 4_000_000 },
-          { dtype: 'F8_E8M0', count: 300, bytes: 125_000 },
-        ],
-        currentFp: 'fp8_scaled',
-      })
-    ).toEqual({ fp: 'mxfp8' });
+      getModelFileHeaderCorrections({ format: 'SafeTensor', dtypeCounts: bf16Counts, currentFp })
+    ).toEqual({ fp: 'bf16' });
   });
 
   it('corrects an fp16 record whose header is plain fp8', () => {
     expect(
       getModelFileHeaderCorrections({
         format: 'SafeTensor',
-        dtypeCounts: [{ dtype: 'F8_E4M3FN', count: 300, bytes: 4_000_000 }],
+        dtypeCounts: fp8Counts,
         currentFp: 'fp16',
       })
     ).toEqual({ fp: 'fp8' });
@@ -94,16 +86,56 @@ describe('getModelFileHeaderCorrections', () => {
     expect(
       getModelFileHeaderCorrections({
         format: 'SafeTensor',
-        dtypeCounts: [
-          { dtype: 'F8_E4M3', count: 300, bytes: 4_000_000 },
-          { dtype: 'F8_E8M0', count: 300, bytes: 125_000 },
-        ],
+        dtypeCounts: mxfp8Counts,
         currentFp: 'fp16',
       })
     ).toEqual({ fp: 'mxfp8' });
   });
 
-  it('leaves type alone when the caller does not know the detected type', () => {
+  // 🔴 The whole point of FP_HEADER_CANNOT_STATE. Each of these is a value no safetensors
+  // header can express, so the header is SILENT about it rather than disagreeing. Because
+  // the correction runs on read, overwriting one re-applies over any manual fix — the
+  // creator can never get their record back. Do not "fix" these to expect a correction.
+  it.each([
+    ['fp8_scaled', fp8Counts],
+    ['fp8_mixed', fp8Counts],
+    ['nf4', nf4Counts],
+    ['nvfp4', mxfp8Counts],
+    ['int4', nf4Counts],
+  ] as const)('never overwrites a stored %s', (currentFp, dtypeCounts) => {
+    expect(getModelFileHeaderCorrections({ format: 'SafeTensor', dtypeCounts, currentFp })).toEqual(
+      {}
+    );
+  });
+
+  // The complement: the list must not be so wide it protects values the header CAN state.
+  it.each(['fp32', 'fp16', 'bf16', 'fp8', 'mxfp8', 'int8'] as const)(
+    'still corrects a stored %s, which the header can state',
+    (currentFp) => {
+      expect(
+        getModelFileHeaderCorrections({
+          format: 'SafeTensor',
+          dtypeCounts: bf16Counts,
+          currentFp,
+        }).fp ?? 'bf16'
+      ).toBe('bf16');
+    }
+  );
+
+  it('proposes nothing for a GGUF file even when its dtypes would map', () => {
+    // F16 maps to fp16, so this fails the moment the `format !== 'SafeTensor'` guard goes.
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'GGUF',
+        dtypeCounts: [{ dtype: 'F16', count: 300, bytes: 4_000_000 }],
+        currentFp: 'fp32',
+      })
+    ).toEqual({});
+  });
+});
+
+describe('getModelFileHeaderCorrections — type', () => {
+  it('leaves type alone when the caller has no detected type', () => {
     expect(
       getModelFileHeaderCorrections({
         format: 'SafeTensor',
@@ -128,14 +160,57 @@ describe('getModelFileHeaderCorrections', () => {
     ).toEqual({ type: 'VAE' });
   });
 
-  it('proposes nothing for a GGUF file', () => {
+  // 🔴 The detection misreads whole architectures: an LLM's own weights match the
+  // embed_tokens + layers.N text-encoder rule, and a vision-language model's match
+  // VisionEncoder. Relabelling those drops the file out of primaryFileTypesByModelType,
+  // so it stops being the version's primary file on the download path. A correction may
+  // never demote a file that is already primary. Do not remove this guard.
+  it.each([
+    ['LLM', 'Model', 'TextEncoder'],
+    ['VisionLanguage', 'Model', 'VisionEncoder'],
+    ['MotionModule', 'Model', 'LoRA'],
+  ] as const)(
+    'refuses a %s correction that would drop the file out of the primary set',
+    (modelType, currentFileType, detectedModelType) => {
+      expect(
+        getModelFileHeaderCorrections({
+          format: 'SafeTensor',
+          dtypeCounts: bf16Counts,
+          detectedModelType,
+          currentFp: 'bf16',
+          currentFileType,
+          modelType,
+        })
+      ).toEqual({});
+    }
+  );
+
+  it('still corrects a non-primary file on a model type with a primary set', () => {
+    // 'Other' is not primary for LLM, so nothing is demoted and the fix goes through.
     expect(
       getModelFileHeaderCorrections({
-        format: 'GGUF',
-        dtypeCounts: [{ dtype: 'Q4_K', count: 300, bytes: 4_000_000 }],
-        currentFp: 'fp16',
+        format: 'SafeTensor',
+        dtypeCounts: bf16Counts,
+        detectedModelType: 'TextEncoder',
+        currentFp: 'bf16',
+        currentFileType: 'Other',
+        modelType: 'LLM',
       })
-    ).toEqual({});
+    ).toEqual({ type: 'Text Encoder' });
+  });
+
+  it('allows a correction that stays inside the primary set', () => {
+    // 'Diffusion Model' is primary for Checkpoint alongside 'Model', so this is not a demotion.
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'SafeTensor',
+        dtypeCounts: bf16Counts,
+        detectedModelType: 'DiffusionModel',
+        currentFp: 'bf16',
+        currentFileType: 'Model',
+        modelType: 'Checkpoint',
+      })
+    ).toEqual({ type: 'Diffusion Model' });
   });
 });
 
@@ -157,8 +232,45 @@ describe('applyModelFileHeaderCorrections', () => {
     const query = executeRaw.mock.calls[0][0];
     expect(query.sql).toContain('"url" =');
     expect(query.sql).not.toContain('"type" =');
-    expect(query.values).toEqual([JSON.stringify({ fp: 'bf16' }), target.fileId, target.fileUrl]);
+    // A plain `||` onto SQL NULL yields NULL, so dropping the COALESCE/NULLIF wipes the
+    // whole metadata object instead of merging into it.
+    expect(query.sql).toContain("COALESCE(NULLIF(\"metadata\", 'null'::jsonb), '{}'::jsonb)");
+    // Without the shape guard the statement throws on a row whose metadata is a scalar.
+    expect(query.sql).toContain('jsonb_typeof');
+    expect(query.values).toEqual([
+      JSON.stringify({ fp: 'bf16' }),
+      target.fileId,
+      target.fileUrl,
+      'bf16',
+    ]);
+    expect(deleteFilesForModelVersionCache).toHaveBeenCalledTimes(1);
     expect(deleteFilesForModelVersionCache).toHaveBeenCalledWith(7);
+  });
+
+  // 🔴 Postgres counts rows MATCHED, so a no-op UPDATE returns 1. Without these
+  // predicates every viewer in the replica-lag window rewrites the same values and busts
+  // the cache again, and `updated > 0` stops meaning "something changed".
+  it('makes the statement a genuine no-op when the stored values already match', async () => {
+    await expect(
+      applyModelFileHeaderCorrections({ ...target, corrections: { fp: 'bf16', type: 'VAE' } })
+    ).resolves.toBe(true);
+
+    const { sql } = executeRaw.mock.calls[0][0];
+    expect(sql).toContain(`"metadata"->>'fp' IS DISTINCT FROM`);
+    expect(sql).toContain('"type" IS DISTINCT FROM');
+  });
+
+  // The shape guard belongs to the jsonb merge only. Gating a type-only correction on it
+  // gave rows with scalar metadata an UPDATE matching 0 rows on every read, forever.
+  it('does not gate a type-only correction on the metadata shape', async () => {
+    await expect(
+      applyModelFileHeaderCorrections({ ...target, corrections: { type: 'VAE' } })
+    ).resolves.toBe(true);
+
+    const { sql, values } = executeRaw.mock.calls[0][0];
+    expect(sql).not.toContain('jsonb_typeof');
+    expect(sql).toContain('"type" =');
+    expect(values).toEqual(['VAE', target.fileId, target.fileUrl, 'VAE']);
   });
 
   it('writes precision and type in the same statement', async () => {
@@ -174,6 +286,8 @@ describe('applyModelFileHeaderCorrections', () => {
       'VAE',
       target.fileId,
       target.fileUrl,
+      'bf16',
+      'VAE',
     ]);
   });
 

--- a/src/server/services/__tests__/model-file-header-correction.service.test.ts
+++ b/src/server/services/__tests__/model-file-header-correction.service.test.ts
@@ -1,16 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
 import type * as ModelFileService from '~/server/services/model-file.service';
 
-const { executeRaw, deleteFilesForModelVersionCache } = vi.hoisted(() => ({
-  executeRaw: vi.fn(),
+const { deleteFilesForModelVersionCache } = vi.hoisted(() => ({
   deleteFilesForModelVersionCache: vi.fn(),
 }));
 
-vi.mock('~/server/db/client', () => ({ dbWrite: { $executeRaw: executeRaw } }));
 vi.mock('~/server/services/model-file.service', async (importOriginal) => ({
   ...(await importOriginal<typeof ModelFileService>()),
   deleteFilesForModelVersionCache,
 }));
+
+const executeRaw = dbMock.dbWrite.$executeRaw;
 
 import {
   applyModelFileHeaderCorrections,

--- a/src/server/services/__tests__/model-file-header-correction.service.test.ts
+++ b/src/server/services/__tests__/model-file-header-correction.service.test.ts
@@ -108,17 +108,17 @@ describe('getModelFileHeaderCorrections — precision', () => {
     );
   });
 
-  // The complement: the list must not be so wide it protects values the header CAN state.
-  it.each(['fp32', 'fp16', 'bf16', 'fp8', 'mxfp8', 'int8'] as const)(
+  // The complement, and it must be able to FAIL: an earlier version of this asserted
+  // `.fp ?? 'bf16'`, which collapsed "corrected to bf16" and "not corrected at all" into
+  // the same pass, so adding any of these to FP_HEADER_CANNOT_STATE stayed green. That is
+  // the direction with the asymmetric cost — over-widening the list silently stops
+  // correcting across the whole corpus, with no signal at all.
+  it.each(['fp32', 'fp16', 'fp8'] as const)(
     'still corrects a stored %s, which the header can state',
     (currentFp) => {
       expect(
-        getModelFileHeaderCorrections({
-          format: 'SafeTensor',
-          dtypeCounts: bf16Counts,
-          currentFp,
-        }).fp ?? 'bf16'
-      ).toBe('bf16');
+        getModelFileHeaderCorrections({ format: 'SafeTensor', dtypeCounts: bf16Counts, currentFp })
+      ).toEqual({ fp: 'bf16' });
     }
   );
 
@@ -271,6 +271,25 @@ describe('applyModelFileHeaderCorrections', () => {
     expect(sql).not.toContain('jsonb_typeof');
     expect(sql).toContain('"type" =');
     expect(values).toEqual(['VAE', target.fileId, target.fileUrl, 'VAE']);
+  });
+
+  /**
+   * 🔴 The regression a previous fix round introduced. Moving the shape guard out of the
+   * shared WHERE and into its own OR-branch left the jsonb merge UNGUARDED: a row matched
+   * on its `type` branch alone still ran it, which raises on scalar metadata and silently
+   * appends to an array. Only an fp AND type correction together reaches it, which is why
+   * the two single-column tests above could not see it. Assert the CASE, not the merge.
+   */
+  it('guards the metadata merge even when a type correction matched the row', async () => {
+    await expect(
+      applyModelFileHeaderCorrections({ ...target, corrections: { fp: 'bf16', type: 'VAE' } })
+    ).resolves.toBe(true);
+
+    const { sql } = executeRaw.mock.calls[0][0];
+    const setClause = sql.slice(sql.indexOf('SET'), sql.indexOf('WHERE'));
+    expect(setClause).toContain('CASE WHEN');
+    expect(setClause).toContain('jsonb_typeof');
+    expect(setClause).toContain('ELSE "metadata" END');
   });
 
   it('writes precision and type in the same statement', async () => {

--- a/src/server/services/__tests__/model-file-header-correction.service.test.ts
+++ b/src/server/services/__tests__/model-file-header-correction.service.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as ModelFileService from '~/server/services/model-file.service';
+
+const { executeRaw, deleteFilesForModelVersionCache } = vi.hoisted(() => ({
+  executeRaw: vi.fn(),
+  deleteFilesForModelVersionCache: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbWrite: { $executeRaw: executeRaw } }));
+vi.mock('~/server/services/model-file.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModelFileService>()),
+  deleteFilesForModelVersionCache,
+}));
+
+import {
+  applyModelFileHeaderCorrections,
+  correctModelFileFromTensorHeader,
+  getModelFileHeaderCorrections,
+} from '~/server/services/model-file-header-correction.service';
+
+const target = {
+  fileId: 42,
+  fileUrl: 'https://example.com/model.safetensors',
+  modelVersionId: 7,
+};
+
+const bf16Counts = [{ dtype: 'BF16', count: 300, bytes: 4_000_000 }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  executeRaw.mockResolvedValue(1);
+  deleteFilesForModelVersionCache.mockResolvedValue(undefined);
+});
+
+describe('getModelFileHeaderCorrections', () => {
+  it('corrects a stored precision the header disagrees with', () => {
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'SafeTensor',
+        dtypeCounts: bf16Counts,
+        currentFp: 'fp16',
+      })
+    ).toEqual({ fp: 'bf16' });
+  });
+
+  it('proposes nothing when the stored precision already matches the header', () => {
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'SafeTensor',
+        dtypeCounts: bf16Counts,
+        currentFp: 'bf16',
+      })
+    ).toEqual({});
+  });
+
+  // 🔴 Deliberate, and the reason is in FP_CONSISTENT_WITH_HEADER: an F8 dtype is
+  // equally fp8, fp8_scaled or fp8_mixed, so "header wins" would round every scaled
+  // file down to plain fp8 on every read. Do not "fix" this to expect { fp: 'fp8' }.
+  it('keeps a scaled fp8 value that an F8 header cannot contradict', () => {
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'SafeTensor',
+        dtypeCounts: [{ dtype: 'F8_E4M3FN', count: 300, bytes: 4_000_000 }],
+        currentFp: 'fp8_scaled',
+      })
+    ).toEqual({});
+  });
+
+  it('still corrects a stored fp8_scaled when the header positively says mxfp8', () => {
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'SafeTensor',
+        dtypeCounts: [
+          { dtype: 'F8_E4M3', count: 300, bytes: 4_000_000 },
+          { dtype: 'F8_E8M0', count: 300, bytes: 125_000 },
+        ],
+        currentFp: 'fp8_scaled',
+      })
+    ).toEqual({ fp: 'mxfp8' });
+  });
+
+  it('corrects an fp16 record whose header is plain fp8', () => {
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'SafeTensor',
+        dtypeCounts: [{ dtype: 'F8_E4M3FN', count: 300, bytes: 4_000_000 }],
+        currentFp: 'fp16',
+      })
+    ).toEqual({ fp: 'fp8' });
+  });
+
+  it('reads MXFP8 from its scale tensors rather than byte share', () => {
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'SafeTensor',
+        dtypeCounts: [
+          { dtype: 'F8_E4M3', count: 300, bytes: 4_000_000 },
+          { dtype: 'F8_E8M0', count: 300, bytes: 125_000 },
+        ],
+        currentFp: 'fp16',
+      })
+    ).toEqual({ fp: 'mxfp8' });
+  });
+
+  it('leaves type alone when the caller does not know the detected type', () => {
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'SafeTensor',
+        dtypeCounts: bf16Counts,
+        currentFp: 'bf16',
+        currentFileType: 'Other',
+        modelType: 'Checkpoint',
+      })
+    ).toEqual({});
+  });
+
+  it('corrects an unambiguous file type', () => {
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'SafeTensor',
+        dtypeCounts: bf16Counts,
+        detectedModelType: 'VAE',
+        currentFp: 'bf16',
+        currentFileType: 'Other',
+        modelType: 'Checkpoint',
+      })
+    ).toEqual({ type: 'VAE' });
+  });
+
+  it('proposes nothing for a GGUF file', () => {
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'GGUF',
+        dtypeCounts: [{ dtype: 'Q4_K', count: 300, bytes: 4_000_000 }],
+        currentFp: 'fp16',
+      })
+    ).toEqual({});
+  });
+});
+
+describe('applyModelFileHeaderCorrections', () => {
+  it('does not touch the database or the cache when there is nothing to correct', async () => {
+    await expect(applyModelFileHeaderCorrections({ ...target, corrections: {} })).resolves.toBe(
+      false
+    );
+
+    expect(executeRaw).not.toHaveBeenCalled();
+    expect(deleteFilesForModelVersionCache).not.toHaveBeenCalled();
+  });
+
+  it('merges precision into metadata under a url guard and busts the file cache', async () => {
+    await expect(
+      applyModelFileHeaderCorrections({ ...target, corrections: { fp: 'bf16' } })
+    ).resolves.toBe(true);
+
+    const query = executeRaw.mock.calls[0][0];
+    expect(query.sql).toContain('"url" =');
+    expect(query.sql).not.toContain('"type" =');
+    expect(query.values).toEqual([JSON.stringify({ fp: 'bf16' }), target.fileId, target.fileUrl]);
+    expect(deleteFilesForModelVersionCache).toHaveBeenCalledWith(7);
+  });
+
+  it('writes precision and type in the same statement', async () => {
+    await expect(
+      applyModelFileHeaderCorrections({ ...target, corrections: { fp: 'bf16', type: 'VAE' } })
+    ).resolves.toBe(true);
+
+    expect(executeRaw).toHaveBeenCalledTimes(1);
+    const query = executeRaw.mock.calls[0][0];
+    expect(query.sql).toContain('"type" =');
+    expect(query.values).toEqual([
+      JSON.stringify({ fp: 'bf16' }),
+      'VAE',
+      target.fileId,
+      target.fileUrl,
+    ]);
+  });
+
+  it('does not bust the cache when the url guard rejected the write', async () => {
+    executeRaw.mockResolvedValue(0);
+
+    await expect(
+      applyModelFileHeaderCorrections({ ...target, corrections: { fp: 'bf16' } })
+    ).resolves.toBe(false);
+
+    expect(deleteFilesForModelVersionCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('correctModelFileFromTensorHeader', () => {
+  it('derives and writes the corrected precision in one call', async () => {
+    await expect(
+      correctModelFileFromTensorHeader({
+        ...target,
+        format: 'SafeTensor',
+        dtypeCounts: bf16Counts,
+        currentFp: 'fp16',
+        currentFileType: 'Model',
+        modelType: 'Checkpoint',
+      })
+    ).resolves.toEqual({ corrections: { fp: 'bf16' }, applied: true });
+
+    expect(executeRaw.mock.calls[0][0].values).toContain(JSON.stringify({ fp: 'bf16' }));
+  });
+
+  it('writes nothing when the record already agrees with the header', async () => {
+    await expect(
+      correctModelFileFromTensorHeader({
+        ...target,
+        format: 'SafeTensor',
+        dtypeCounts: bf16Counts,
+        detectedModelType: 'Checkpoint',
+        currentFp: 'bf16',
+        currentFileType: 'Model',
+        modelType: 'Checkpoint',
+      })
+    ).resolves.toEqual({ corrections: {}, applied: false });
+
+    expect(executeRaw).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/model-file-header-correction.service.ts
+++ b/src/server/services/model-file-header-correction.service.ts
@@ -1,0 +1,147 @@
+import { Prisma } from '@prisma/client';
+import type { ModelFileType } from '~/server/common/constants';
+import { dbWrite } from '~/server/db/client';
+import { deleteFilesForModelVersionCache } from '~/server/services/model-file.service';
+import { getDominantFpFromDtypes } from '~/utils/file-helpers';
+import type {
+  DetectedModelTensorType,
+  ModelTensorDtypeSummary,
+} from '~/utils/model-tensor-metadata';
+import { getModelFileTypeCorrection } from '~/utils/model-tensor-metadata';
+
+export type ModelFileHeaderCorrections = {
+  fp?: ModelFileFp;
+  type?: ModelFileType;
+};
+
+type HeaderCorrectionInput = {
+  format: string | null;
+  dtypeCounts: ModelTensorDtypeSummary[];
+  /**
+   * Absent when the caller only has a summary — `tensors[]` is dropped there, and
+   * entries cached before detection existed carry no value either. Undefined means
+   * "not known", which leaves `type` alone; null means "the header had no opinion".
+   */
+  detectedModelType?: DetectedModelTensorType | null;
+  currentFp?: ModelFileFp | null;
+  currentFileType?: string | null;
+  modelType?: string | null;
+};
+
+type FileTarget = {
+  fileId: number;
+  fileUrl: string;
+  modelVersionId: number;
+};
+
+/**
+ * Stored precisions a given header answer does NOT contradict.
+ *
+ * 🔴 The header carries a dtype, and several of the values a creator can pick are
+ * scaling schemes layered on one — an F8 tensor is equally an `fp8`, an `fp8_scaled`
+ * or an `fp8_mixed` file. Reading "header wins" literally there rounds every one of
+ * them down to plain `fp8` and destroys a distinction nothing can recover, because
+ * the correction runs on read and would re-apply after any manual fix. So the header
+ * only overrides a stored value it genuinely disagrees with.
+ *
+ * `mxfp8` is not in the fp8 set: it is identified positively, by its F8_E8M0 scale
+ * tensors, so a header saying fp8 (without them) does contradict a stored mxfp8.
+ */
+const FP_CONSISTENT_WITH_HEADER: Record<string, readonly string[]> = {
+  fp8: ['fp8', 'fp8_scaled', 'fp8_mixed'],
+};
+
+function isStoredFpConsistentWithHeader(stored: ModelFileFp | null | undefined, header: string) {
+  if (!stored) return false;
+  return (FP_CONSISTENT_WITH_HEADER[header] ?? [header]).includes(stored);
+}
+
+/**
+ * What the tensor header says should change on a file record. Pure — split from the
+ * write below so upload-time auto-detect can reuse the judgement without a database.
+ */
+export function getModelFileHeaderCorrections({
+  format,
+  dtypeCounts,
+  detectedModelType,
+  currentFp,
+  currentFileType,
+  modelType,
+}: HeaderCorrectionInput): ModelFileHeaderCorrections {
+  const corrections: ModelFileHeaderCorrections = {};
+  if (format !== 'SafeTensor') return corrections;
+
+  const fp = getDominantFpFromDtypes(dtypeCounts ?? []);
+  if (fp && !isStoredFpConsistentWithHeader(currentFp, fp)) corrections.fp = fp;
+
+  if (detectedModelType !== undefined) {
+    const type = getModelFileTypeCorrection({ detectedModelType, modelType, currentFileType });
+    if (type) corrections.type = type;
+  }
+
+  return corrections;
+}
+
+/**
+ * Writes the corrections in one statement, guarded on `url` so a file whose content
+ * was replaced between the header read and this write keeps its own values.
+ */
+export async function applyModelFileHeaderCorrections({
+  fileId,
+  fileUrl,
+  modelVersionId,
+  corrections,
+}: FileTarget & { corrections: ModelFileHeaderCorrections }) {
+  const { fp, type } = corrections;
+  if (!fp && !type) return false;
+
+  const assignments: Prisma.Sql[] = [];
+  if (fp)
+    assignments.push(
+      Prisma.sql`"metadata" = COALESCE(NULLIF("metadata", 'null'::jsonb), '{}'::jsonb) || ${JSON.stringify(
+        { fp }
+      )}::jsonb`
+    );
+  if (type) assignments.push(Prisma.sql`"type" = ${type}`);
+
+  const updated = await dbWrite.$executeRaw(
+    Prisma.sql`
+      UPDATE "ModelFile"
+      SET ${Prisma.join(assignments, ', ')}
+      WHERE "id" = ${fileId}
+        AND "url" = ${fileUrl}
+        AND (
+          "metadata" IS NULL OR
+          "metadata" = 'null'::jsonb OR
+          jsonb_typeof("metadata") = 'object'
+        )
+    `
+  );
+
+  // Only on a real write. A 0-row result means the `url` guard rejected us — and since
+  // this runs on every read of the file, busting unconditionally would re-bust the
+  // version-file cache on every request for as long as the guard keeps failing.
+  if (updated > 0) await deleteFilesForModelVersionCache(modelVersionId);
+  return updated > 0;
+}
+
+/**
+ * Derive and apply in one call. The entry point for anything holding a parsed header
+ * and a file record — today the tensor-metadata endpoint, next the upload path.
+ */
+export async function correctModelFileFromTensorHeader({
+  fileId,
+  fileUrl,
+  modelVersionId,
+  ...input
+}: FileTarget & HeaderCorrectionInput) {
+  const corrections = getModelFileHeaderCorrections(input);
+  const applied = await applyModelFileHeaderCorrections({
+    fileId,
+    fileUrl,
+    modelVersionId,
+    corrections,
+  });
+
+  return { corrections, applied };
+}

--- a/src/server/services/model-file-header-correction.service.ts
+++ b/src/server/services/model-file-header-correction.service.ts
@@ -2,6 +2,8 @@ import { Prisma } from '@prisma/client';
 import type { ModelFileType } from '~/server/common/constants';
 import { dbWrite } from '~/server/db/client';
 import { deleteFilesForModelVersionCache } from '~/server/services/model-file.service';
+import type { ModelType } from '~/shared/utils/prisma/enums';
+import { primaryFileTypesByModelType } from '~/utils/file-display-helpers';
 import { getDominantFpFromDtypes } from '~/utils/file-helpers';
 import type {
   DetectedModelTensorType,
@@ -17,11 +19,7 @@ export type ModelFileHeaderCorrections = {
 type HeaderCorrectionInput = {
   format: string | null;
   dtypeCounts: ModelTensorDtypeSummary[];
-  /**
-   * Absent when the caller only has a summary — `tensors[]` is dropped there, and
-   * entries cached before detection existed carry no value either. Undefined means
-   * "not known", which leaves `type` alone; null means "the header had no opinion".
-   */
+  /** Absent when the caller has only a summary, or a cache entry predating detection. */
   detectedModelType?: DetectedModelTensorType | null;
   currentFp?: ModelFileFp | null;
   currentFileType?: string | null;
@@ -35,25 +33,60 @@ type FileTarget = {
 };
 
 /**
- * Stored precisions a given header answer does NOT contradict.
+ * Precisions a safetensors header can never state, so a stored one is never overwritten.
  *
- * 🔴 The header carries a dtype, and several of the values a creator can pick are
- * scaling schemes layered on one — an F8 tensor is equally an `fp8`, an `fp8_scaled`
- * or an `fp8_mixed` file. Reading "header wins" literally there rounds every one of
- * them down to plain `fp8` and destroys a distinction nothing can recover, because
- * the correction runs on read and would re-apply after any manual fix. So the header
- * only overrides a stored value it genuinely disagrees with.
+ * 🔴 The header carries a dtype, and these values are not dtypes. Two ways they hide:
  *
- * `mxfp8` is not in the fp8 set: it is identified positively, by its F8_E8M0 scale
- * tensors, so a header saying fp8 (without them) does contradict a stored mxfp8.
+ * - `fp8_scaled` / `fp8_mixed` are scaling schemes layered on an F8 dtype. The header
+ *   reads F8 and says nothing about the scaling.
+ * - `nf4` / `nvfp4` / `int4` are packed into `U8` (bitsandbytes) or `I32` (GPTQ/AWQ),
+ *   which `SAFETENSORS_DTYPE_TO_FP` deliberately leaves unmapped. The quantized bulk
+ *   therefore contributes NOTHING to the vote, and the winner is whatever the auxiliary
+ *   layernorm/embedding/scale tensors are — typically fp16.
+ *
+ * In both cases the header is SILENT, not contradicting, and taking it literally writes
+ * a wrong value over a right one. It is unrecoverable rather than merely wrong: this runs
+ * on read, so it re-applies over any correction the creator makes by hand.
+ *
+ * The list is the complement of what `getDominantFpFromDtypes` can emit — fp32, fp16,
+ * bf16, fp8, mxfp8, int8. Adding a dtype to that mapper means removing its value here.
+ *
+ * Traded away knowingly: an earlier shape keyed on the HEADER's answer instead, which let a
+ * positive mxfp8 identification (F8_E8M0 scale tensors, which the header does state)
+ * overwrite a stored `fp8_scaled`. That case is now refused with the rest. Correcting a
+ * mislabelled mxfp8 file is worth little; getting the list wrong in the other direction
+ * destroys a creator's value permanently, because this runs on read. Prefer the refusal.
  */
-const FP_CONSISTENT_WITH_HEADER: Record<string, readonly string[]> = {
-  fp8: ['fp8', 'fp8_scaled', 'fp8_mixed'],
-};
+const FP_HEADER_CANNOT_STATE: readonly string[] = [
+  'fp8_scaled',
+  'fp8_mixed',
+  'nf4',
+  'nvfp4',
+  'int4',
+];
 
-function isStoredFpConsistentWithHeader(stored: ModelFileFp | null | undefined, header: string) {
-  if (!stored) return false;
-  return (FP_CONSISTENT_WITH_HEADER[header] ?? [header]).includes(stored);
+/**
+ * A type correction must never move a file OUT of the primary set for its model type.
+ *
+ * 🔴 The detection is heuristic and reads several architectures wrongly: an LLM's own
+ * weights match `hasLlmTextEncoder` (embed_tokens + layers.N), and a vision-language
+ * model's match VisionEncoder. Relabelling those to 'Text Encoder'/'CLIPVision' drops
+ * the file out of `primaryFileTypesByModelType[LLM|VisionLanguage]`, so it stops being
+ * the version's primary file and loses the download-path scoring bonus.
+ *
+ * A file that is NOT currently primary is the mis-filed case this feature exists for and
+ * stays correctable. This only refuses to demote one that already is.
+ */
+function wouldDemoteFromPrimary(
+  modelType: string | null | undefined,
+  currentFileType: string | null | undefined,
+  correctedType: ModelFileType
+) {
+  const primary = primaryFileTypesByModelType[modelType as ModelType] as
+    | readonly string[]
+    | undefined;
+  if (!primary) return false;
+  return primary.includes(currentFileType ?? '') && !primary.includes(correctedType);
 }
 
 /**
@@ -72,12 +105,11 @@ export function getModelFileHeaderCorrections({
   if (format !== 'SafeTensor') return corrections;
 
   const fp = getDominantFpFromDtypes(dtypeCounts ?? []);
-  if (fp && !isStoredFpConsistentWithHeader(currentFp, fp)) corrections.fp = fp;
+  if (fp && fp !== currentFp && !FP_HEADER_CANNOT_STATE.includes(currentFp ?? ''))
+    corrections.fp = fp;
 
-  if (detectedModelType !== undefined) {
-    const type = getModelFileTypeCorrection({ detectedModelType, modelType, currentFileType });
-    if (type) corrections.type = type;
-  }
+  const type = getModelFileTypeCorrection({ detectedModelType, modelType, currentFileType });
+  if (type && !wouldDemoteFromPrimary(modelType, currentFileType, type)) corrections.type = type;
 
   return corrections;
 }
@@ -96,13 +128,29 @@ export async function applyModelFileHeaderCorrections({
   if (!fp && !type) return false;
 
   const assignments: Prisma.Sql[] = [];
-  if (fp)
+  // 🔴 Both guards below are per-column and belong in the SET/WHERE, not around the call.
+  const changed: Prisma.Sql[] = [];
+
+  if (fp) {
     assignments.push(
       Prisma.sql`"metadata" = COALESCE(NULLIF("metadata", 'null'::jsonb), '{}'::jsonb) || ${JSON.stringify(
         { fp }
       )}::jsonb`
     );
-  if (type) assignments.push(Prisma.sql`"type" = ${type}`);
+    // The shape guard only gates the jsonb merge — a `type`-only correction has nothing
+    // to do with metadata, and gating it on this made a row with scalar metadata issue an
+    // UPDATE matching 0 rows on every single read, forever.
+    changed.push(
+      Prisma.sql`(
+        ("metadata" IS NULL OR "metadata" = 'null'::jsonb OR jsonb_typeof("metadata") = 'object')
+        AND "metadata"->>'fp' IS DISTINCT FROM ${fp}
+      )`
+    );
+  }
+  if (type) {
+    assignments.push(Prisma.sql`"type" = ${type}`);
+    changed.push(Prisma.sql`"type" IS DISTINCT FROM ${type}`);
+  }
 
   const updated = await dbWrite.$executeRaw(
     Prisma.sql`
@@ -110,17 +158,15 @@ export async function applyModelFileHeaderCorrections({
       SET ${Prisma.join(assignments, ', ')}
       WHERE "id" = ${fileId}
         AND "url" = ${fileUrl}
-        AND (
-          "metadata" IS NULL OR
-          "metadata" = 'null'::jsonb OR
-          jsonb_typeof("metadata") = 'object'
-        )
+        AND (${Prisma.join(changed, ' OR ')})
     `
   );
 
-  // Only on a real write. A 0-row result means the `url` guard rejected us — and since
-  // this runs on every read of the file, busting unconditionally would re-bust the
-  // version-file cache on every request for as long as the guard keeps failing.
+  // 🔴 `updated` is rows MATCHED, not rows whose values differed — Postgres reports a
+  // no-op UPDATE as 1. The `IS DISTINCT FROM` predicates above are what make this mean
+  // "something actually changed". Without them, every concurrent viewer inside the
+  // replica-lag window after the first correction rewrites the same values and busts the
+  // cache again: N dead tuples and N busts per window on a hot file.
   if (updated > 0) await deleteFilesForModelVersionCache(modelVersionId);
   return updated > 0;
 }

--- a/src/server/services/model-file-header-correction.service.ts
+++ b/src/server/services/model-file-header-correction.service.ts
@@ -48,18 +48,29 @@ type FileTarget = {
  * a wrong value over a right one. It is unrecoverable rather than merely wrong: this runs
  * on read, so it re-applies over any correction the creator makes by hand.
  *
- * The list is the complement of what `getDominantFpFromDtypes` can emit — fp32, fp16,
- * bf16, fp8, mxfp8, int8. Adding a dtype to that mapper means removing its value here.
+ * 🔴 The test is SILENCE, not "can the mapper emit it". Those come apart, and where they
+ * do the emittable-means-safe proxy fails open:
  *
- * Traded away knowingly: an earlier shape keyed on the HEADER's answer instead, which let a
- * positive mxfp8 identification (F8_E8M0 scale tensors, which the header does state)
- * overwrite a stored `fp8_scaled`. That case is now refused with the rest. Correcting a
- * mislabelled mxfp8 file is worth little; getting the list wrong in the other direction
- * destroys a creator's value permanently, because this runs on read. Prefer the refusal.
+ * - `mxfp8` is emittable but is not a dtype either — it is inferred from F8_E8M0-typed
+ *   scale tensors. An exporter that stores those scales as `U8` (permitted: E8M0 is
+ *   byte-wide) leaves no signal, the vote returns plain `fp8`, and a correct value is lost.
+ * - `int8` is emittable from `I8`, but GPTQ/AWQ at 8 bits packs into the unmapped `I32` —
+ *   the same mechanism as int4, with leftover fp16 tensors winning the vote.
+ *
+ * Both are on the list for that reason. The cost is only that a file ALREADY labelled
+ * mxfp8 or int8 is never re-corrected; an empty `fp` is still filled from the header, and
+ * a wrong fp32/fp16/bf16/fp8 is still fixed.
+ *
+ * Traded away knowingly: keying on the HEADER's answer instead would let a positive mxfp8
+ * identification overwrite a stored `fp8_scaled`. Correcting a mislabelled file is worth
+ * little next to destroying a right value permanently, and this runs on read, so a bad
+ * overwrite re-applies over any manual fix. Prefer the refusal in both directions.
  */
 const FP_HEADER_CANNOT_STATE: readonly string[] = [
   'fp8_scaled',
   'fp8_mixed',
+  'mxfp8',
+  'int8',
   'nf4',
   'nvfp4',
   'int4',
@@ -128,24 +139,29 @@ export async function applyModelFileHeaderCorrections({
   if (!fp && !type) return false;
 
   const assignments: Prisma.Sql[] = [];
-  // 🔴 Both guards below are per-column and belong in the SET/WHERE, not around the call.
   const changed: Prisma.Sql[] = [];
+  const metadataIsObject = Prisma.sql`(
+    "metadata" IS NULL OR "metadata" = 'null'::jsonb OR jsonb_typeof("metadata") = 'object'
+  )`;
 
   if (fp) {
+    // 🔴 The shape guard travels with the ASSIGNMENT, not with the row match, and the CASE
+    // is what makes that true. Putting it only in the WHERE looks equivalent and is not:
+    // the branches are OR-ed, so a row matched on its `type` branch alone still runs this
+    // merge — and `'"legacy"'::jsonb || '{...}'::jsonb` raises on a scalar, while a jsonb
+    // ARRAY concatenates silently and appends the object as an element, corrupting the
+    // column with nothing to log. Reached only by an fp AND type correction together.
     assignments.push(
-      Prisma.sql`"metadata" = COALESCE(NULLIF("metadata", 'null'::jsonb), '{}'::jsonb) || ${JSON.stringify(
-        { fp }
-      )}::jsonb`
+      Prisma.sql`"metadata" = CASE WHEN ${metadataIsObject}
+        THEN COALESCE(NULLIF("metadata", 'null'::jsonb), '{}'::jsonb) || ${JSON.stringify({
+          fp,
+        })}::jsonb
+        ELSE "metadata" END`
     );
-    // The shape guard only gates the jsonb merge — a `type`-only correction has nothing
-    // to do with metadata, and gating it on this made a row with scalar metadata issue an
-    // UPDATE matching 0 rows on every single read, forever.
-    changed.push(
-      Prisma.sql`(
-        ("metadata" IS NULL OR "metadata" = 'null'::jsonb OR jsonb_typeof("metadata") = 'object')
-        AND "metadata"->>'fp' IS DISTINCT FROM ${fp}
-      )`
-    );
+    // Kept in the WHERE too, so an fp-only correction we cannot apply does not match the
+    // row at all. Gating the TYPE branch on it was the bug: a scalar-metadata row then
+    // issued an UPDATE matching 0 rows on every read, forever.
+    changed.push(Prisma.sql`(${metadataIsObject} AND "metadata"->>'fp' IS DISTINCT FROM ${fp})`);
   }
   if (type) {
     assignments.push(Prisma.sql`"type" = ${type}`);

--- a/src/tests/api/tier1-public-route-disclosure.test.ts
+++ b/src/tests/api/tier1-public-route-disclosure.test.ts
@@ -99,6 +99,12 @@ vi.mock('~/server/services/user.service', () => ({
 vi.mock('~/server/services/tensor-metadata.service', () => ({
   getFullTensorAnalysisCached: mockGetFullTensorAnalysisCached,
 }));
+// Stubbed for its import graph, not its behaviour: the real module reaches
+// `model-file.service`, which builds a `createCachedObject` at module scope and so
+// needs a wider cache-helpers mock than this file's. It never touches the response.
+vi.mock('~/server/services/model-file-header-correction.service', () => ({
+  correctModelFileFromTensorHeader: vi.fn().mockResolvedValue({ corrections: {}, applied: false }),
+}));
 vi.mock('~/server/utils/cache-helpers', () => ({
   fetchThroughCache: mockFetchThroughCache,
 }));

--- a/src/tests/api/v1/model-files/tensor-metadata-cache-headers.test.ts
+++ b/src/tests/api/v1/model-files/tensor-metadata-cache-headers.test.ts
@@ -14,10 +14,13 @@ import { redisMock } from '~/__tests__/mocks/redis.mock';
 const IMMUTABLE = 'public, max-age=31536000, s-maxage=31536000, immutable';
 const NO_STORE = 'private, no-store';
 
-const { mockGetFileForModelVersion, mockGetFullTensorAnalysisCached } = vi.hoisted(() => ({
-  mockGetFileForModelVersion: vi.fn(),
-  mockGetFullTensorAnalysisCached: vi.fn(),
-}));
+const { mockGetFileForModelVersion, mockGetFullTensorAnalysisCached, mockCorrect } = vi.hoisted(
+  () => ({
+    mockGetFileForModelVersion: vi.fn(),
+    mockGetFullTensorAnalysisCached: vi.fn(),
+    mockCorrect: vi.fn(),
+  })
+);
 const mockFindUnique = dbMock.dbRead.modelFile.findUnique;
 
 vi.mock('~/server/utils/endpoint-helpers', () => ({
@@ -32,12 +35,13 @@ vi.mock('~/server/services/tensor-metadata.service', () => ({
   getFullTensorAnalysisCached: (...args: any[]) => mockGetFullTensorAnalysisCached(...args),
 }));
 
-// Stubbed for its import graph, not its behaviour: the real module reaches
-// `model-file.service`, which builds a `createCachedObject` at module scope and so
-// needs a cache-helpers mock wider than this file's deliberate pass-through.
-// The correction contract lives in model-file-header-correction.service.test.ts.
+// Stubbed rather than run: the real module reaches `model-file.service`, which builds a
+// `createCachedObject` at module scope and so needs a cache-helpers mock wider than this
+// file's deliberate pass-through. What the correction DECIDES is pinned in
+// model-file-header-correction.service.test.ts; what this file pins is that the endpoint
+// calls it at all, and with the file's own values.
 vi.mock('~/server/services/model-file-header-correction.service', () => ({
-  correctModelFileFromTensorHeader: vi.fn().mockResolvedValue({ corrections: {}, applied: false }),
+  correctModelFileFromTensorHeader: (...args: any[]) => mockCorrect(...args),
 }));
 
 // Both caches are pass-through here: this test pins response headers, not cache behaviour
@@ -50,7 +54,8 @@ const analysis = {
   format: 'SafeTensor',
   tensorCount: 1,
   totalTensorBytes: 8,
-  dtypes: [],
+  dtypeCounts: [{ dtype: 'F16', count: 1, bytes: 8 }],
+  detectedModelType: null,
   largestTensor: null,
   vramEstimate: null,
   tensors: [{ name: 'weight', shape: [2, 2], dtype: 'F16', sizeBytes: 8 }],
@@ -102,9 +107,11 @@ describe('/api/v1/model-files/[id]/tensor-metadata cache headers', () => {
       name: 'moody-cutie-mix.safetensors',
       type: 'Model',
       sizeKB: 24_000_000,
-      metadata: { format: 'SafeTensor' },
+      url: 'https://storage.example/moody-cutie-mix.safetensors',
+      metadata: { format: 'SafeTensor', fp: 'fp32' },
       modelVersion: { model: { type: 'Checkpoint' } },
     });
+    mockCorrect.mockResolvedValue({ corrections: {}, applied: false });
     mockGetFileForModelVersion.mockResolvedValue({
       status: 'success',
       url: 'https://delivery.example/file.safetensors',
@@ -154,6 +161,64 @@ describe('/api/v1/model-files/[id]/tensor-metadata cache headers', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res._getHeader('Cache-Control')).toBe(IMMUTABLE);
+  });
+
+  /**
+   * 🔴 The endpoint is the correction's ONLY production caller, and three plausible
+   * one-line edits kill it silently: dropping either `return void correct(...)`, dropping
+   * `url: true` from the select (the url guard then matches nothing and every write is a
+   * no-op), or swapping `currentFileType` and `modelType`. None of those changes a
+   * response, a status or a log, so without this test the feature can go inert unnoticed.
+   */
+  it.each([
+    ['full', {}],
+    ['summary', { summaryOnly: 'true' }],
+  ])('hands the %s path the file’s own values to correct', async (_label, extra) => {
+    const res = await invoke({ id: '3057178', ...extra });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockCorrect).toHaveBeenCalledTimes(1);
+
+    const arg = mockCorrect.mock.calls[0][0];
+    expect(arg.fileId).toBe(3057178);
+    expect(arg.modelVersionId).toBe(3176604);
+    // Not the delivery url getFileForModelVersion resolved — the stored one the guard needs.
+    expect(arg.fileUrl).toBe('https://storage.example/moody-cutie-mix.safetensors');
+    // Asserted as distinct literals: a single objectContaining would pass with these two swapped.
+    expect(arg.currentFileType).toBe('Model');
+    expect(arg.modelType).toBe('Checkpoint');
+    expect(arg.currentFp).toBe('fp32');
+    expect(arg.format).toBe('SafeTensor');
+  });
+
+  /**
+   * 🔴 Asserted on the SELECT, not on the value, and that is the whole point. `findUnique`
+   * is mocked, so the mock returns the whole fixture whatever the select asks for — drop
+   * `url: true` from the handler and every behavioural assertion above still passes while
+   * `fileUrl` is `undefined` in production, the `AND "url" =` guard matches nothing, and
+   * the feature is inert forever with no error, no log and no changed response. Measured:
+   * with this test absent, deleting that line left all 10 tests green.
+   */
+  it('selects the columns the correction needs', async () => {
+    await invoke({ id: '3057178' });
+
+    const { select } = mockFindUnique.mock.calls[0][0];
+    expect(select).toMatchObject({ url: true, type: true, metadata: true });
+    expect(select.modelVersion).toMatchObject({ select: { model: { select: { type: true } } } });
+  });
+
+  it.each([
+    ['the 422', () => mockGetFullTensorAnalysisCached.mockRejectedValue(new Error('boom'))],
+    [
+      'an access denial',
+      () => mockGetFileForModelVersion.mockResolvedValue({ status: 'no-access' }),
+    ],
+  ])('does not correct on %s', async (_label, arrange) => {
+    arrange();
+
+    await invoke({ id: '3057178' });
+
+    expect(mockCorrect).not.toHaveBeenCalled();
   });
 
   it('does not cache the access-denied response', async () => {

--- a/src/tests/api/v1/model-files/tensor-metadata-cache-headers.test.ts
+++ b/src/tests/api/v1/model-files/tensor-metadata-cache-headers.test.ts
@@ -14,12 +14,10 @@ import { redisMock } from '~/__tests__/mocks/redis.mock';
 const IMMUTABLE = 'public, max-age=31536000, s-maxage=31536000, immutable';
 const NO_STORE = 'private, no-store';
 
-const { mockGetFileForModelVersion, mockGetFullTensorAnalysisCached } = vi.hoisted(
-  () => ({
-    mockGetFileForModelVersion: vi.fn(),
-    mockGetFullTensorAnalysisCached: vi.fn(),
-  })
-);
+const { mockGetFileForModelVersion, mockGetFullTensorAnalysisCached } = vi.hoisted(() => ({
+  mockGetFileForModelVersion: vi.fn(),
+  mockGetFullTensorAnalysisCached: vi.fn(),
+}));
 const mockFindUnique = dbMock.dbRead.modelFile.findUnique;
 
 vi.mock('~/server/utils/endpoint-helpers', () => ({
@@ -32,6 +30,14 @@ vi.mock('~/server/services/file.service', () => ({
 
 vi.mock('~/server/services/tensor-metadata.service', () => ({
   getFullTensorAnalysisCached: (...args: any[]) => mockGetFullTensorAnalysisCached(...args),
+}));
+
+// Stubbed for its import graph, not its behaviour: the real module reaches
+// `model-file.service`, which builds a `createCachedObject` at module scope and so
+// needs a cache-helpers mock wider than this file's deliberate pass-through.
+// The correction contract lives in model-file-header-correction.service.test.ts.
+vi.mock('~/server/services/model-file-header-correction.service', () => ({
+  correctModelFileFromTensorHeader: vi.fn().mockResolvedValue({ corrections: {}, applied: false }),
 }));
 
 // Both caches are pass-through here: this test pins response headers, not cache behaviour

--- a/src/tests/api/v1/model-files/tensor-metadata-cache-headers.test.ts
+++ b/src/tests/api/v1/model-files/tensor-metadata-cache-headers.test.ts
@@ -94,9 +94,12 @@ function fakeRes() {
 
 async function invoke(query: Record<string, unknown>) {
   const res = fakeRes();
+  lastRes = res;
   await handler({ method: 'GET', query } as unknown as NextApiRequest, res);
   return res;
 }
+
+let lastRes: ReturnType<typeof fakeRes> | undefined;
 
 describe('/api/v1/model-files/[id]/tensor-metadata cache headers', () => {
   beforeEach(() => {
@@ -199,11 +202,41 @@ describe('/api/v1/model-files/[id]/tensor-metadata cache headers', () => {
    * the feature is inert forever with no error, no log and no changed response. Measured:
    * with this test absent, deleting that line left all 10 tests green.
    */
+  /**
+   * 🔴 Pins that the correction is fired AFTER the response, which the handler comment
+   * calls deliberate. `await correct(...)` before `res.json` leaves every other assertion
+   * green while a hot public read starts blocking on a write to the primary. Recorded as a
+   * status observed at call time rather than by ordering promises, so the mutation fails
+   * on a value instead of hanging.
+   */
+  it('does not make the read wait on the write', async () => {
+    let statusWhenCorrectRan: number | undefined;
+    mockCorrect.mockImplementation(() => {
+      statusWhenCorrectRan = lastRes?.statusCode;
+      return Promise.resolve({ corrections: {}, applied: false });
+    });
+
+    await invoke({ id: '3057178' });
+
+    expect(statusWhenCorrectRan).toBe(200);
+  });
+
   it('selects the columns the correction needs', async () => {
     await invoke({ id: '3057178' });
 
     const { select } = mockFindUnique.mock.calls[0][0];
-    expect(select).toMatchObject({ url: true, type: true, metadata: true });
+    // Every column, not just the correction's: the mock returns the whole fixture whatever
+    // the select asks for, so dropping `name` (format inference reads it) or `sizeKB`
+    // (`sizeKB * 1024` becomes NaN) is invisible in exactly the same way.
+    expect(select).toMatchObject({
+      id: true,
+      modelVersionId: true,
+      name: true,
+      url: true,
+      type: true,
+      sizeKB: true,
+      metadata: true,
+    });
     expect(select.modelVersion).toMatchObject({ select: { model: { select: { type: true } } } });
   });
 

--- a/src/utils/__tests__/model-tensor-metadata-detection.test.ts
+++ b/src/utils/__tests__/model-tensor-metadata-detection.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectModelTypeFromTensors,
+  getModelFileTypeCorrection,
+} from '~/utils/model-tensor-metadata';
+
+const named = (...names: string[]) => names.map((name) => ({ name }));
+
+describe('detectModelTypeFromTensors', () => {
+  it('detects a LoRA from its paired down/up weights', () => {
+    expect(
+      detectModelTypeFromTensors(
+        named(
+          'lora_unet_input_blocks_1.lora_down.weight',
+          'lora_unet_input_blocks_1.lora_up.weight'
+        )
+      )
+    ).toBe('LoRA');
+  });
+
+  it('does not call a half-paired LoRA a LoRA', () => {
+    expect(detectModelTypeFromTensors(named('lora_unet_input_blocks_1.lora_down.weight'))).toBe(
+      null
+    );
+  });
+
+  it('detects a full checkpoint from the diffusion namespace plus its components', () => {
+    expect(
+      detectModelTypeFromTensors(
+        named(
+          'model.diffusion_model.input_blocks.0.0.weight',
+          'first_stage_model.encoder.conv_in.weight'
+        )
+      )
+    ).toBe('Checkpoint');
+  });
+
+  it('detects a standalone VAE', () => {
+    expect(
+      detectModelTypeFromTensors(
+        named(
+          'encoder.conv_in.weight',
+          'encoder.down.0.block.0.norm1.weight',
+          'decoder.conv_out.weight',
+          'decoder.up.0.block.0.norm1.weight',
+          'quant_conv.weight',
+          'post_quant_conv.weight'
+        )
+      )
+    ).toBe('VAE');
+  });
+
+  it('detects a CLIP text encoder', () => {
+    expect(
+      detectModelTypeFromTensors(
+        named(
+          'text_model.embeddings.token_embedding.weight',
+          'text_model.encoder.layers.0.mlp.fc1.weight'
+        )
+      )
+    ).toBe('TextEncoder');
+  });
+
+  it('detects a bare UNet', () => {
+    expect(
+      detectModelTypeFromTensors(
+        named(
+          'input_blocks.0.0.weight',
+          'middle_block.0.in_layers.0.weight',
+          'output_blocks.0.0.weight'
+        )
+      )
+    ).toBe('UNet');
+  });
+
+  it('detects a Flux-style diffusion transformer', () => {
+    expect(
+      detectModelTypeFromTensors(
+        named('double_blocks.0.img_attn.qkv.weight', 'single_blocks.0.linear1.weight')
+      )
+    ).toBe('DiffusionModel');
+  });
+
+  it('returns null for a file it does not recognise', () => {
+    expect(detectModelTypeFromTensors(named('some.random.tensor', 'another.one'))).toBe(null);
+  });
+});
+
+describe('getModelFileTypeCorrection', () => {
+  it('proposes nothing when the header had no opinion', () => {
+    expect(
+      getModelFileTypeCorrection({
+        detectedModelType: null,
+        modelType: 'Checkpoint',
+        currentFileType: 'Other',
+      })
+    ).toBe(null);
+  });
+
+  it('relabels a VAE mis-filed on a checkpoint', () => {
+    expect(
+      getModelFileTypeCorrection({
+        detectedModelType: 'VAE',
+        modelType: 'Checkpoint',
+        currentFileType: 'Other',
+      })
+    ).toBe('VAE');
+  });
+
+  it("leaves a VAE model's own weights filed as Model", () => {
+    expect(
+      getModelFileTypeCorrection({
+        detectedModelType: 'VAE',
+        modelType: 'VAE',
+        currentFileType: 'Model',
+      })
+    ).toBe(null);
+  });
+
+  it('accepts Pruned Model as compatible with a detected checkpoint', () => {
+    expect(
+      getModelFileTypeCorrection({
+        detectedModelType: 'Checkpoint',
+        modelType: 'Checkpoint',
+        currentFileType: 'Pruned Model',
+      })
+    ).toBe(null);
+  });
+
+  it('files a LoRA found on a non-LoRA model as an Enhancement LoRA', () => {
+    expect(
+      getModelFileTypeCorrection({
+        detectedModelType: 'LoRA',
+        modelType: 'Checkpoint',
+        currentFileType: 'Model',
+      })
+    ).toBe('Enhancement LoRA');
+  });
+});

--- a/src/utils/__tests__/model-tensor-metadata-detection.test.ts
+++ b/src/utils/__tests__/model-tensor-metadata-detection.test.ts
@@ -214,3 +214,147 @@ describe('getDominantFpFromDtypes', () => {
     expect(getDominantFpFromDtypes([{ dtype: 'F32', bytes: Number.NaN }])).toBe(null);
   });
 });
+
+describe('detectModelTypeFromTensors — rule precedence', () => {
+  /**
+   * 🔴 These fixtures satisfy MORE THAN ONE rule on purpose, and that is the whole point.
+   * Every other fixture in this file is the minimum that matches exactly one rule, so it
+   * cannot tell you anything about the ORDER the rules are tried in — and order is the
+   * entire design of this function. A real full checkpoint carries all three UNet block
+   * families as well as `first_stage_model.`, so moving the UNet check above the Checkpoint
+   * check would misfile every checkpoint on the site while the minimal fixtures stayed green.
+   */
+  const fullCheckpoint = named(
+    'model.diffusion_model.input_blocks.0.0.weight',
+    'model.diffusion_model.middle_block.0.in_layers.0.weight',
+    'model.diffusion_model.output_blocks.0.0.weight',
+    'first_stage_model.encoder.conv_in.weight',
+    'first_stage_model.decoder.conv_out.weight',
+    'cond_stage_model.transformer.text_model.embeddings.token_embedding.weight',
+    'cond_stage_model.transformer.text_model.encoder.layers.0.mlp.fc1.weight'
+  );
+
+  it('calls a full checkpoint a Checkpoint, not a UNet or a TextEncoder', () => {
+    expect(detectModelTypeFromTensors(fullCheckpoint)).toBe('Checkpoint');
+  });
+
+  it('calls a ControlNet a ControlNet even when it carries checkpoint-shaped blocks', () => {
+    expect(
+      detectModelTypeFromTensors([
+        ...named('control_model.input_blocks.0.0.weight'),
+        ...fullCheckpoint,
+      ])
+    ).toBe('ControlNet');
+  });
+
+  it('calls a LoRA a LoRA before anything else it also matches', () => {
+    expect(
+      detectModelTypeFromTensors([
+        ...named(
+          'lora_unet_input_blocks_1.lora_down.weight',
+          'lora_unet_input_blocks_1.lora_up.weight'
+        ),
+        ...fullCheckpoint,
+      ])
+    ).toBe('LoRA');
+  });
+
+  it('prefers VisionEncoder over TextEncoder for a file carrying both towers', () => {
+    // A CLIP model has both; the vision check runs first and that is deliberate.
+    expect(
+      detectModelTypeFromTensors(
+        named(
+          'vision_model.embeddings.patch_embedding.weight',
+          'vision_model.encoder.layers.0.mlp.fc1.weight',
+          'text_model.embeddings.token_embedding.weight',
+          'text_model.encoder.layers.0.mlp.fc1.weight'
+        )
+      )
+    ).toBe('VisionEncoder');
+  });
+});
+
+describe('detectModelTypeFromTensors — remaining branches', () => {
+  it.each([
+    ['control_model.', 'control_model.input_blocks.0.0.weight'],
+    ['controlnet_blocks.', 'controlnet_blocks.0.weight'],
+    ['controlnet_down_blocks.', 'controlnet_down_blocks.0.weight'],
+    ['controlnet_mid_block.', 'controlnet_mid_block.weight'],
+    ['zero_convs.', 'zero_convs.0.0.weight'],
+    ['input_hint_block.', 'input_hint_block.0.weight'],
+  ])('detects a ControlNet from %s', (_label, name) => {
+    expect(detectModelTypeFromTensors(named(name))).toBe('ControlNet');
+  });
+
+  it('detects a decoder-style LLM text encoder', () => {
+    expect(
+      detectModelTypeFromTensors(
+        named(
+          'model.embed_tokens.weight',
+          'model.layers.0.mlp.up_proj.weight',
+          'model.layers.1.mlp.up_proj.weight'
+        )
+      )
+    ).toBe('TextEncoder');
+  });
+
+  it('detects a T5 text encoder', () => {
+    expect(
+      detectModelTypeFromTensors(
+        named(
+          'shared.weight',
+          'encoder.block.0.layer.0.SelfAttention.q.weight',
+          'encoder.block.1.layer.0.SelfAttention.q.weight'
+        )
+      )
+    ).toBe('TextEncoder');
+  });
+
+  it('detects an MMDiT joint-block transformer', () => {
+    expect(
+      detectModelTypeFromTensors(
+        named('joint_blocks.0.context_block.attn.qkv.weight', 'x_embedder.proj.weight')
+      )
+    ).toBe('DiffusionModel');
+  });
+
+  it('detects a diffusers-style transformer', () => {
+    expect(
+      detectModelTypeFromTensors(
+        named('transformer_blocks.0.attn.to_q.weight', 'patch_embed.proj.weight')
+      )
+    ).toBe('DiffusionModel');
+  });
+});
+
+describe('getModelFileTypeCorrection — remaining mappings', () => {
+  /**
+   * 🔴 The LORA branch compares against the Prisma enum spelling, which is `LORA`. Writing
+   * it `'LoRA'` — the spelling used everywhere in prose, and in this function's own
+   * DetectedModelTensorType union two lines up — relabels every LoRA model's own weights
+   * file as an Enhancement LoRA across the whole corpus. `modelType` is typed `string`, so
+   * the typechecker does not catch it. This test is the only thing that does.
+   */
+  it.each(['LORA', 'DoRA', 'LoCon'])('leaves a %s model own weights file alone', (modelType) => {
+    expect(
+      getModelFileTypeCorrection({ detectedModelType: 'LoRA', modelType, currentFileType: 'Model' })
+    ).toBe(null);
+  });
+
+  it.each([
+    ['TextEncoder', 'Checkpoint', 'Text Encoder'],
+    ['TextEncoder', 'TextEncoder', 'Model'],
+    ['VisionEncoder', 'Checkpoint', 'CLIPVision'],
+    ['VisionEncoder', 'CLIPVision', 'Model'],
+    ['VisionEncoder', 'CLIP', 'Vision Encoder'],
+    ['UNet', 'Checkpoint', 'UNet'],
+    ['UNet', 'UNet', 'Model'],
+    ['DiffusionModel', 'UNet', 'Model'],
+    ['ControlNet', 'Checkpoint', 'ControlNet'],
+    ['ControlNet', 'Controlnet', 'Model'],
+  ] as const)('maps %s on a %s model to %s', (detectedModelType, modelType, expected) => {
+    expect(
+      getModelFileTypeCorrection({ detectedModelType, modelType, currentFileType: 'Other' })
+    ).toBe(expected);
+  });
+});

--- a/src/utils/__tests__/model-tensor-metadata-detection.test.ts
+++ b/src/utils/__tests__/model-tensor-metadata-detection.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { getDominantFpFromDtypes } from '~/utils/file-helpers';
 import {
+  analyzeModelTensors,
   detectModelTypeFromTensors,
   getModelFileTypeCorrection,
 } from '~/utils/model-tensor-metadata';
@@ -135,5 +137,80 @@ describe('getModelFileTypeCorrection', () => {
         currentFileType: 'Model',
       })
     ).toBe('Enhancement LoRA');
+  });
+});
+
+describe('analyzeModelTensors', () => {
+  const tensor = (name: string, dtype = 'BF16') => ({
+    name,
+    shape: [2, 2],
+    dtype,
+    sizeBytes: 8,
+  });
+
+  // Nothing else proves the detector is ever CALLED. Without this, changing the field to
+  // `undefined` — or deleting it — leaves every other suite green while type correction
+  // silently never fires again, because the summary cache drops `tensors[]` and the
+  // correction has no other way back to the names.
+  it('populates detectedModelType for a safetensors analysis', () => {
+    const analysis = analyzeModelTensors(
+      'SafeTensor',
+      [tensor('encoder.conv_in.weight'), tensor('decoder.conv_out.weight')],
+      { estimateVram: false }
+    );
+
+    expect(analysis.detectedModelType).toBe(null);
+
+    const vae = analyzeModelTensors(
+      'SafeTensor',
+      [
+        tensor('encoder.conv_in.weight'),
+        tensor('encoder.down.0.block.0.norm1.weight'),
+        tensor('decoder.conv_out.weight'),
+        tensor('decoder.up.0.block.0.norm1.weight'),
+        tensor('quant_conv.weight'),
+        tensor('post_quant_conv.weight'),
+      ],
+      { estimateVram: false }
+    );
+
+    expect(vae.detectedModelType).toBe('VAE');
+  });
+
+  it('never claims a detected type for GGUF, whose names follow other conventions', () => {
+    const analysis = analyzeModelTensors(
+      'GGUF',
+      [
+        tensor('encoder.conv_in.weight'),
+        tensor('encoder.down.0.block.0.norm1.weight'),
+        tensor('decoder.conv_out.weight'),
+        tensor('decoder.up.0.block.0.norm1.weight'),
+        tensor('quant_conv.weight'),
+        tensor('post_quant_conv.weight'),
+      ],
+      { estimateVram: false }
+    );
+
+    expect(analysis.detectedModelType).toBe(null);
+  });
+});
+
+describe('getDominantFpFromDtypes', () => {
+  // 🔴 A dtype whose byte count we could not measure must never win. NaN poisons its
+  // accumulator and `NaN > bestBytes` is false against every value including the initial
+  // -1, which is what makes it lose. Coercing NaN to 0 — the obvious "tidy-up" — lets it
+  // win outright when it is the only mapped dtype, so the upload form would auto-fill a
+  // precision derived from a header it could not read.
+  it('lets a measurable dtype beat an unmeasurable one', () => {
+    expect(
+      getDominantFpFromDtypes([
+        { dtype: 'F32', bytes: Number.NaN },
+        { dtype: 'BF16', bytes: 8 },
+      ])
+    ).toBe('bf16');
+  });
+
+  it('returns null when every mapped dtype is unmeasurable', () => {
+    expect(getDominantFpFromDtypes([{ dtype: 'F32', bytes: Number.NaN }])).toBe(null);
   });
 });

--- a/src/utils/file-helpers.ts
+++ b/src/utils/file-helpers.ts
@@ -42,7 +42,10 @@ export function getDominantFpFromDtypes(
   for (const { dtype, bytes } of entries) {
     const fp = safetensorsDtypeToFp(dtype);
     if (!fp) continue;
-    bytesByFp.set(fp, (bytesByFp.get(fp) ?? 0) + Math.max(Number.isFinite(bytes) ? bytes : 0, 0));
+    // NaN is left to poison this fp's total on purpose: `NaN > bestBytes` is false for
+    // every comparison including the initial -1, so a dtype we could not measure can
+    // never win. Coercing it to 0 would let it win outright when it is the only one.
+    bytesByFp.set(fp, (bytesByFp.get(fp) ?? 0) + Math.max(bytes, 0));
   }
 
   let best: string | null = null;

--- a/src/utils/file-helpers.ts
+++ b/src/utils/file-helpers.ts
@@ -31,6 +31,38 @@ function safetensorsDtypeToFp(dtype: string): string | null {
 }
 
 /**
+ * The dtype→precision core, shared by the client-side upload probe below and the
+ * server-side tensor-header correction. Callers supply whatever dtype/byte pairs
+ * they already have — a parsed safetensors header, or an analysis' `dtypeCounts`.
+ */
+export function getDominantFpFromDtypes(
+  entries: { dtype: string; bytes: number }[]
+): ModelFileFp | null {
+  const bytesByFp = new Map<string, number>();
+  for (const { dtype, bytes } of entries) {
+    const fp = safetensorsDtypeToFp(dtype);
+    if (!fp) continue;
+    bytesByFp.set(fp, (bytesByFp.get(fp) ?? 0) + Math.max(Number.isFinite(bytes) ? bytes : 0, 0));
+  }
+
+  let best: string | null = null;
+  let bestBytes = -1;
+  for (const [fp, bytes] of bytesByFp) {
+    if (bytes > bestBytes) {
+      best = fp;
+      bestBytes = bytes;
+    }
+  }
+
+  // MXFP8 stores weights as F8_E4M3 with F8_E8M0 shared-exponent scales (~1 byte
+  // per 32 elements), so the scale tensors' presence identifies it, not byte share.
+  if (best === 'fp8' && bytesByFp.has('mxfp8')) best = 'mxfp8';
+
+  // Precision options are mod-managed at runtime; the union lags behind them.
+  return best as ModelFileFp | null;
+}
+
+/**
  * Read a .safetensors file's header (client-side) and infer the dominant weight
  * precision. Returns null when it can't be determined.
  * Only the JSON header is read — never the tensor data — so this is cheap.
@@ -53,32 +85,15 @@ export async function inferSafetensorsPrecision(file: File): Promise<ModelFileFp
       { dtype?: string; data_offsets?: [number, number] }
     >;
 
-    // Pick the dtype that accounts for the most bytes of tensor data.
-    const bytesByFp = new Map<string, number>();
+    const entries: { dtype: string; bytes: number }[] = [];
     for (const [key, value] of Object.entries(header)) {
       if (key === '__metadata__' || !value?.dtype) continue;
-      const fp = safetensorsDtypeToFp(value.dtype);
-      if (!fp) continue;
       const offsets = value.data_offsets;
-      const size = Array.isArray(offsets) && offsets.length === 2 ? offsets[1] - offsets[0] : 1;
-      bytesByFp.set(fp, (bytesByFp.get(fp) ?? 0) + Math.max(size, 0));
+      const bytes = Array.isArray(offsets) && offsets.length === 2 ? offsets[1] - offsets[0] : 1;
+      entries.push({ dtype: value.dtype, bytes });
     }
 
-    let best: string | null = null;
-    let bestBytes = -1;
-    for (const [fp, bytes] of bytesByFp) {
-      if (bytes > bestBytes) {
-        best = fp;
-        bestBytes = bytes;
-      }
-    }
-
-    // MXFP8 stores weights as F8_E4M3 with F8_E8M0 shared-exponent scales (~1 byte
-    // per 32 elements), so the scale tensors' presence identifies it, not byte share.
-    if (best === 'fp8' && bytesByFp.has('mxfp8')) best = 'mxfp8';
-
-    // Precision options are mod-managed at runtime; the union lags behind them.
-    return best as ModelFileFp | null;
+    return getDominantFpFromDtypes(entries);
   } catch {
     return null;
   }

--- a/src/utils/model-tensor-metadata.ts
+++ b/src/utils/model-tensor-metadata.ts
@@ -1,3 +1,5 @@
+import type { ModelFileType } from '~/server/common/constants';
+
 const MiB = 1024 * 1024;
 const GiB = 1024 * MiB;
 
@@ -52,11 +54,27 @@ export type ModelVramEstimate = {
   dynamicVramPageBytes: number;
 };
 
+export type DetectedModelTensorType =
+  | 'Checkpoint'
+  | 'LoRA'
+  | 'VAE'
+  | 'TextEncoder'
+  | 'VisionEncoder'
+  | 'UNet'
+  | 'DiffusionModel'
+  | 'ControlNet';
+
 export type ModelTensorAnalysis = {
   format: ModelTensorFormat;
   tensorCount: number;
   totalTensorBytes: number;
   dtypeCounts: ModelTensorDtypeSummary[];
+  /**
+   * Derived once here rather than per request: it scans every tensor name, and the
+   * summary cache drops `tensors[]`, so a caller reading a summary has no way back
+   * to it. Optional because entries cached before it existed will not carry it.
+   */
+  detectedModelType?: DetectedModelTensorType | null;
   largestTensor: ModelTensorInfo | null;
   vramEstimate: ModelVramEstimate | null;
   tensors: ModelTensorInfo[];
@@ -115,10 +133,164 @@ export function analyzeModelTensors(
     tensorCount: tensors.length,
     totalTensorBytes,
     dtypeCounts: [...dtypeCounts.values()].sort((a, b) => b.bytes - a.bytes),
+    detectedModelType: format === 'SafeTensor' ? detectModelTypeFromTensors(tensors) : null,
     largestTensor,
     vramEstimate: estimateVram ? estimateComfyDynamicOffloadVram(tensors) : null,
     tensors,
   };
+}
+
+/**
+ * Classify a safetensors file by the shape of its tensor names. Returns null unless
+ * one architecture matches unambiguously — an unrecognised file must read as "no
+ * opinion", never as a guess, because callers write the answer to the file record.
+ */
+export function detectModelTypeFromTensors(
+  tensors: Pick<ModelTensorInfo, 'name'>[]
+): DetectedModelTensorType | null {
+  const names = tensors.map(({ name }) => name.toLowerCase());
+  const has = (predicate: (name: string) => boolean) => names.some(predicate);
+  const count = (predicate: (name: string) => boolean) => names.filter(predicate).length;
+  const startsWithAny = (name: string, prefixes: string[]) =>
+    prefixes.some((prefix) => name.startsWith(prefix));
+
+  const hasLoraA = has((name) => /\.lora_(?:a|down)\.weight$/.test(name));
+  const hasLoraB = has((name) => /\.lora_(?:b|up)\.weight$/.test(name));
+  if (hasLoraA && hasLoraB) return 'LoRA';
+
+  if (
+    has((name) =>
+      startsWithAny(name, [
+        'control_model.',
+        'controlnet_blocks.',
+        'controlnet_down_blocks.',
+        'controlnet_mid_block.',
+        'zero_convs.',
+        'input_hint_block.',
+      ])
+    )
+  )
+    return 'ControlNet';
+
+  const hasDiffusionNamespace = has((name) =>
+    startsWithAny(name, ['model.diffusion_model.', 'diffusion_model.'])
+  );
+  const hasCheckpointComponents = has((name) =>
+    startsWithAny(name, ['first_stage_model.', 'cond_stage_model.', 'conditioner.embedders.'])
+  );
+  if (hasDiffusionNamespace && hasCheckpointComponents) return 'Checkpoint';
+
+  const encoderCount = count((name) => name.startsWith('encoder.'));
+  const decoderCount = count((name) => name.startsWith('decoder.'));
+  const hasVaeEncoderStructure = has((name) =>
+    /^(?:encoder\.(?:down|downsamples|conv_in|mid)|quant_conv\.)/.test(name)
+  );
+  const hasVaeDecoderStructure = has((name) =>
+    /^(?:decoder\.(?:up|upsamples|conv_out|mid)|post_quant_conv\.)/.test(name)
+  );
+  if (encoderCount >= 2 && decoderCount >= 2 && hasVaeEncoderStructure && hasVaeDecoderStructure)
+    return 'VAE';
+
+  if (
+    has((name) => name.includes('vision_model.embeddings.')) &&
+    has((name) => name.includes('vision_model.encoder.'))
+  )
+    return 'VisionEncoder';
+
+  const hasClipTextEncoder =
+    has((name) => name.includes('text_model.embeddings.')) &&
+    has((name) => name.includes('text_model.encoder.'));
+  const hasLlmTextEncoder =
+    has((name) => name.endsWith('embed_tokens.weight')) &&
+    count((name) => /(?:^|\.)layers\.\d+\./.test(name)) >= 2;
+  const hasT5TextEncoder =
+    has((name) => name === 'shared.weight' || name.endsWith('.shared.weight')) &&
+    count((name) => /(?:^|\.)encoder\.block\.\d+\./.test(name)) >= 2;
+  if (hasClipTextEncoder || hasLlmTextEncoder || hasT5TextEncoder) return 'TextEncoder';
+
+  const unetPrefix = '(?:(?:model\\.)?diffusion_model\\.)?';
+  const hasInputBlocks = has((name) => new RegExp(`^${unetPrefix}input_blocks\\.`).test(name));
+  const hasMiddleBlock = has((name) => new RegExp(`^${unetPrefix}middle_block\\.`).test(name));
+  const hasOutputBlocks = has((name) => new RegExp(`^${unetPrefix}output_blocks\\.`).test(name));
+  if (hasInputBlocks && hasMiddleBlock && hasOutputBlocks) return 'UNet';
+
+  const hasFluxBlocks =
+    has((name) => name.startsWith('double_blocks.')) &&
+    has((name) => name.startsWith('single_blocks.'));
+  const hasJointTransformer =
+    has((name) => name.startsWith('joint_blocks.')) &&
+    has((name) => /^(?:x|context)_embedder\./.test(name));
+  const hasDiffusersTransformer =
+    has((name) => name.startsWith('transformer_blocks.')) &&
+    has((name) => /^(?:patch_embed|pos_embed|proj_in|x_embedder)\./.test(name));
+  if (hasFluxBlocks || hasJointTransformer || hasDiffusersTransformer) return 'DiffusionModel';
+
+  return null;
+}
+
+/**
+ * The correction the header justifies, or null to leave `ModelFile.type` alone.
+ *
+ * Null covers two different cases on purpose: the header said nothing, and the
+ * header agrees with a type already valid for this model. A component file on a
+ * matching model is filed as 'Model' rather than by its architecture, so e.g. a
+ * VAE detected inside a VAE model is already correct and must not be relabelled.
+ */
+export function getModelFileTypeCorrection({
+  detectedModelType,
+  modelType,
+  currentFileType,
+}: {
+  detectedModelType: DetectedModelTensorType | null | undefined;
+  modelType?: string | null;
+  currentFileType?: string | null;
+}): ModelFileType | null {
+  if (!detectedModelType) return null;
+
+  let canonicalType: ModelFileType;
+  let compatibleTypes: readonly string[] = [];
+
+  switch (detectedModelType) {
+    case 'Checkpoint':
+      canonicalType = 'Model';
+      compatibleTypes = modelType === 'Checkpoint' ? ['Model', 'Pruned Model'] : ['Model'];
+      break;
+    case 'LoRA':
+      if (modelType === 'LORA' || modelType === 'DoRA' || modelType === 'LoCon') {
+        canonicalType = 'Model';
+        compatibleTypes = ['Model', 'Pruned Model'];
+      } else {
+        canonicalType = 'Enhancement LoRA';
+      }
+      break;
+    case 'VAE':
+      canonicalType = modelType === 'VAE' ? 'Model' : 'VAE';
+      break;
+    case 'TextEncoder':
+      canonicalType = modelType === 'TextEncoder' ? 'Model' : 'Text Encoder';
+      break;
+    case 'VisionEncoder':
+      canonicalType =
+        modelType === 'CLIPVision'
+          ? 'Model'
+          : modelType === 'CLIP'
+          ? 'Vision Encoder'
+          : 'CLIPVision';
+      break;
+    case 'UNet':
+      canonicalType = modelType === 'UNet' ? 'Model' : 'UNet';
+      break;
+    case 'DiffusionModel':
+      canonicalType = modelType === 'UNet' ? 'Model' : 'Diffusion Model';
+      break;
+    case 'ControlNet':
+      canonicalType = modelType === 'Controlnet' ? 'Model' : 'ControlNet';
+      break;
+  }
+
+  if (currentFileType === canonicalType || compatibleTypes.includes(currentFileType ?? ''))
+    return null;
+  return canonicalType;
 }
 
 export function supportsTensorVramEstimate({ modelType, fileType }: ModelTensorVramSupport) {


### PR DESCRIPTION
Closes [868kbt78b](https://app.clickup.com/t/868kbt78b). **Supersedes #3113 and #3046** (both @rmatif). His #3113 covers the same ticket and his detection logic is the basis for the type half here — but its base was 2251 commits behind `main` and it was `CONFLICTING`, which in this repo means it had never had CI at all. Justin's call was a fresh PR using his as reference. Co-authored below.

## What it does

The safetensors header is the source of truth. Where the stored record disagrees, it is corrected on read:

- **precision** — `ModelFile.metadata.fp`
- **type** — `ModelFile.type`, only where the header is unambiguous *and* the correction is safe (below)

It runs where the header is already parsed, so a file is repaired the first time anyone views it. No backfill, no migration.

## Reuse rather than a second implementation

`src/utils/file-helpers.ts` already had the dtype→precision mapper backing the upload form, and it encodes two things a fresh implementation gets wrong: **U8 stays unmapped** (bitsandbytes packs nf4/fp4 there, so guessing `int8` fills in a wrong supported value) and **MXFP8 is identified by its `F8_E8M0` scale tensors**, not by byte share. Extracted as `getDominantFpFromDtypes()`; upload and server now share one owner.

## Two safety rules that narrow "the header wins", deliberately

**1. The header never overwrites a value it cannot state.** `fp8_scaled`/`fp8_mixed` are scaling schemes layered on an F8 dtype. `nf4`/`nvfp4`/`int4` — and GPTQ/AWQ `int8` — pack their weights into `U8`/`I32`, which the dtype map deliberately leaves unmapped, so the quantized bulk contributes **nothing** to the vote and the winner is whatever leftover fp16 housekeeping tensors are present. Without this rule a creator's `nf4` becomes `fp16` on the first anonymous view, and again after every manual fix. `mxfp8` is on the list too: it is inferred from a side channel an exporter may not provide.

The test is **silence, not emittability** — those come apart, and the emittable-means-safe proxy fails open. Cost: a file already labelled with one of those seven is never re-corrected. An empty `fp` is still filled; a wrong `fp32`/`fp16`/`bf16`/`fp8` is still fixed.

**2. A type correction may never demote a file out of its model type's primary set.** The detection reads an LLM's own weights as a text encoder (`embed_tokens` + `layers.N`) and a VLM's as a vision encoder. Relabelling either drops the file out of `primaryFileTypesByModelType` and off the download path. A file that is *not* currently primary stays correctable — that is the mis-filed case this exists for.

## Shape

- `getModelFileHeaderCorrections()` — pure, no database. Upload-time can reuse the judgement as-is.
- `applyModelFileHeaderCorrections()` — one `UPDATE`, guarded on `id` **and** `url`, with `IS DISTINCT FROM` predicates so `updated > 0` means what it says (Postgres reports a no-op update as 1). The jsonb shape guard is a `CASE` on the **assignment**, not the row match: the `changed` branches are OR-ed, so a row matched on `type` alone would otherwise still run the merge — which raises on scalar metadata and *silently appends to a jsonb array*.
- `correctModelFileFromTensorHeader()` — derive + apply.

`detectedModelType` is computed once in `analyzeModelTensors` so it lands in the cache instead of re-scanning every tensor name per request. Optional: pre-existing cache entries carry no value, which reads as "not known". Precision comes from `dtypeCounts`, which every entry has, so it corrects on both the summary and full paths. The correction is fired **after** the response — a read must not wait on a write.

## Verification

```
pnpm run typecheck                      OK — 0 type errors
pnpm exec eslint <changed files>        0 errors (11 pre-existing warnings in two test files)
affected suites                         Test Files 5 passed (5) / Tests 141 passed (141)
blocks.router.workflow.test.ts          358 tests — submodule confirmed present
```

⏳ **The full unit suite is still queued** on the shared box at the time of opening; I will post the `Test Files` line verbatim with its exit code as a comment when it returns. The previous full run on this branch was `Test Files 1 failed | 1375 passed | 1 skipped (1377)` — the single failure was mine (`no-direct-shared-module-mock`) and is fixed in `fc037b9a3d`.

**Thirteen positive controls, each reverted deliberately, each red with a legible assertion** — not "I added an assertion and it passed":

| reverted | failure |
|---|---|
| endpoint drops both `correct()` calls | `expected "vi.fn()" to be called 1 times, but got 0` |
| endpoint drops `url: true` from the select | `expected { Object } to match object { url: true, … }` |
| endpoint swaps `currentFileType`/`modelType` | `expected 'Checkpoint' to be 'Model'` |
| `await correct()` before the response | `expected undefined to be 200` |
| never-overwrite list removed | 5 red, `expected { fp: 'fp8' } to deeply equal {}` |
| list over-widened with `fp32` | `expected {} to deeply equal { fp: 'bf16' }` |
| `wouldDemoteFromPrimary` removed | 3 red, `expected { type: 'Text Encoder' } to deeply equal {}` |
| `IS DISTINCT FROM` removed | 4 red |
| `CASE WHEN` on the merge removed | `expected 'SET "metadata" = COALESCE(…' to contain 'CASE WHEN'` |
| `analyzeModelTensors` stops detecting | `expected null to be 'VAE'` |
| NaN coerced to 0 | `expected 'fp32' to be null` |
| UNet checked before Checkpoint | `expected 'TextEncoder' to be 'Checkpoint'` |
| `'LORA'` mis-spelled `'LoRA'` | `expected 'Enhancement LoRA' to be null` |

🔴 **One of those controls initially stayed GREEN**, and it is the reason this list exists. Deleting `url: true` left all ten endpoint tests passing — because `findUnique` is mocked, it returns the whole fixture whatever the `select` asks for, so **no behavioural assertion of any kind could ever see that line vanish**, and the feature would have gone silently inert with no error, no log and no changed response. It is now asserted on the `select` argument itself, for all seven columns.

## Known limitation, not fixed here

The tensor caches (month TTL) are never invalidated when `updateFile` swaps a file's `url` in place. After a file replace, a stale analysis can be written against the fresh url. This is **pre-existing**; this change escalates it from stale panel display to a stale value written to the record. The fix belongs in `updateFile`, outside this lane — filed as [868kw8dre](https://app.clickup.com/t/868kw8dre).

## Deliberately not ported from #3113

- `weightPrecision`, a second precision string alongside `fp`.
- A `blocks.N` + `first.weight` + `last.linear.weight` signature for `DiffusionModel` — too thin to write to a creator's record on.
- `TENSOR_METADATA_SUMMARY_VERSION`, a second cache-key version, unnecessary once the derived field is optional.

Reviewed adversarially by two agents prompted to refute; both reports are addressed above.

Co-authored-by: rmatif <rmatif@users.noreply.github.com>
