### PR TITLE
feat(apps/mine): Embedded/Standalone kind labels, no row kind badge, clickable row media, collapsible orphan group

### DIFF
--- a/src/components/Apps/AppListingsMarketplaceBody.urlState.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.urlState.browser.test.tsx
@@ -253,7 +253,7 @@ describe('(b) two fast filter clicks must not drop one', () => {
     renderWithProviders(<StatefulRouterHarness latencyMs={ROUTER_LATENCY_MS} />);
     await openFilters();
 
-    await userEvent.click(page.getByRole('button', { name: 'On-site' }));
+    await userEvent.click(page.getByRole('button', { name: 'Embedded' }));
     await userEvent.click(page.getByRole('button', { name: 'Generation' }));
 
     await vi.waitFor(() => {
@@ -262,7 +262,7 @@ describe('(b) two fast filter clicks must not drop one', () => {
     // …and the panel, which now renders FROM the url, shows both as pressed
     // rather than visibly reverting the first one.
     await expect
-      .element(page.getByRole('button', { name: 'On-site' }))
+      .element(page.getByRole('button', { name: 'Embedded' }))
       .toHaveAttribute('aria-pressed', 'true');
     await expect
       .element(page.getByRole('button', { name: 'Generation' }))

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -19,6 +19,7 @@ import type { OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';
 import { ModQueryError, isModAuthzError } from '~/components/Apps/ModQuerySurface';
 import { ReasonGatedActionModal } from '~/components/Apps/ReasonGatedActionModal';
 import { listingStatusChip } from '~/components/Apps/appListingModerationView';
+import { LISTING_KIND_LABELS } from '~/components/Apps/listingKindLabels';
 import {
   effectiveModerationStatus,
   isDestructiveListingModAction,
@@ -415,9 +416,11 @@ export function AppListingsModerationTable({
             value={kind}
             onChange={(v) => onKindChange(v as KindFilter)}
             data={[
+              // 🔴 The `value`s are STORED VALUES and are untouched; only the `label`s
+              // resolve from the one source. This control carried BOTH retired words.
               { label: 'All', value: 'all' },
-              { label: 'On-site', value: 'onsite' },
-              { label: 'External', value: 'offsite' },
+              { label: LISTING_KIND_LABELS.onsite, value: 'onsite' },
+              { label: LISTING_KIND_LABELS.offsite, value: 'offsite' },
             ]}
             aria-label="Filter by kind"
           />

--- a/src/components/Apps/AppsStoreFiltersDropdown.browser.test.tsx
+++ b/src/components/Apps/AppsStoreFiltersDropdown.browser.test.tsx
@@ -77,7 +77,7 @@ describe('AppsStoreFiltersDropdown — the panel', () => {
   test('selecting a kind emits ONLY the kind patch', async () => {
     const { onChange } = setup({ kind: 'all', category: null });
     await userEvent.click(trigger());
-    await userEvent.click(page.getByRole('button', { name: 'On-site' }));
+    await userEvent.click(page.getByRole('button', { name: 'Embedded' }));
     expect(onChange).toHaveBeenCalledWith({ kind: 'onsite' });
   });
 

--- a/src/components/Apps/MyAppsBody.browser.test.tsx
+++ b/src/components/Apps/MyAppsBody.browser.test.tsx
@@ -196,7 +196,7 @@ describe('🔴 one table, all three populations `/apps/my-submissions` could not
     await expect.element(page.getByTestId('apps-mine-role-apl_owned')).toHaveTextContent(/owner/i);
   });
 
-  test('ON-SITE and OFF-SITE render in the SAME table, each labelled by kind', async () => {
+  test('ON-SITE and OFF-SITE render in the SAME table', async () => {
     renderWithProviders(
       <MyAppsBodyView
         rows={[
@@ -207,11 +207,78 @@ describe('🔴 one table, all three populations `/apps/my-submissions` could not
     );
     const table = page.getByTestId('apps-mine-table');
     await expect.element(table).toBeInTheDocument();
-    await expect.element(page.getByTestId('apps-mine-kind-apl_on')).toHaveTextContent(/on-site/i);
-    await expect.element(page.getByTestId('apps-mine-kind-apl_off')).toHaveTextContent(/external/i);
+    await expect.element(page.getByTestId('apps-mine-row-apl_on')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-mine-row-apl_off')).toBeInTheDocument();
     // ONE table, not two sections: both rows are inside it.
     expect(table.element().querySelectorAll('[data-testid^="apps-mine-row-"]')).toHaveLength(2);
   });
+});
+
+/* ------------------------------------------------------------------ *
+ * The kind badge is GONE — pinned as an absence
+ * ------------------------------------------------------------------ */
+
+/**
+ * 🔴 THE KIND IS NOT SHOWN ON `/apps/mine` AT ALL, AND THIS PINS THE ABSENCE.
+ *
+ * The row used to carry a kind badge (`apps-mine-kind-<id>`) reading "On-site" /
+ * "External" — the second of those a RETIRED wording that survived the whole #4247
+ * sweep, because `myAppsView` shipped a shadowing `listingKindLabel` whose name
+ * collided with the canonical one. The badge is deleted: the author already knows what
+ * they built, and the kind still renders on the listing detail and edit pages, which
+ * are where the question gets asked.
+ *
+ * 🔴 AN ABSENCE NEEDS A TEST MORE THAN A PRESENCE DOES, not less. "Restore the kind
+ * badge, it's useful" is a one-line, entirely reasonable-looking change, and nothing
+ * else in this suite would go red for it — the enrolment ledger cannot see it either,
+ * because a restored badge composing from `listingKindLabels` would spell the CORRECT
+ * word. So the decision is asserted here, where it is visible as a decision.
+ */
+describe('🔴 no row shape renders a kind badge', () => {
+  /**
+   * Every dimension the deleted badge branched on, plus the two layouts. The old badge
+   * read `row.kind` for its text AND its colour, so a partial restore (one layout, one
+   * kind) has to fail too — a single-fixture version of this test would miss exactly
+   * that.
+   */
+  for (const compact of [false, true]) {
+    test(`neither kind, in the ${compact ? 'card' : 'table'} layout`, async () => {
+      const rows = [
+        row({ appListingId: 'apl_k_on', kind: 'onsite', status: 'approved' }),
+        row({ appListingId: 'apl_k_off', kind: 'offsite', status: 'pending' }),
+        row({ appListingId: 'apl_k_draft', kind: 'onsite', status: 'draft', role: 'editor' }),
+      ];
+      renderWithProviders(<MyAppsBodyView rows={rows} compact={compact} />);
+      // POSITIVE CONTROL: the rows really did render, so the zeros below are a fact
+      // about the badge and not about an empty page. Without this, deleting the whole
+      // table would satisfy every assertion in this test.
+      for (const r of rows) {
+        await expect
+          .element(page.getByTestId(`apps-mine-row-${r.appListingId}`))
+          .toBeInTheDocument();
+        // …and the badges that DID survive are still there, so "no kind badge" is not
+        // being satisfied by "no badges at all".
+        await expect
+          .element(page.getByTestId(`apps-mine-status-${r.appListingId}`))
+          .toBeInTheDocument();
+        await expect
+          .element(page.getByTestId(`apps-mine-role-${r.appListingId}`))
+          .toBeInTheDocument();
+        expect(
+          page.getByTestId(`apps-mine-kind-${r.appListingId}`).elements(),
+          `${r.appListingId} rendered a kind badge — see "no row shape renders a kind badge"`
+        ).toHaveLength(0);
+      }
+      // 🔴 AND THE TESTID NAMESPACE IS EMPTY, not just the three ids above. A restored
+      // badge under a NEW id would walk the per-row check; the prefix query cannot be
+      // walked that way as long as it keeps the name.
+      expect(document.querySelectorAll('[data-testid^="apps-mine-kind-"]')).toHaveLength(0);
+      // The retired word itself is absent from the rendered page, in either case. This
+      // is the behavioural half of the enrolment ledger's structural claim.
+      expect(document.body.textContent).not.toMatch(/\bExternal\b/);
+      expect(document.body.textContent).not.toMatch(/on-site/i);
+    });
+  }
 });
 
 /* ------------------------------------------------------------------ *
@@ -376,6 +443,299 @@ describe('icon + cover, and the placeholder path', () => {
       .element(page.getByTestId('apps-mine-icon-placeholder-apl_bare'))
       .toBeInTheDocument();
     expect(page.getByTestId('apps-mine-icon-apl_bare').elements()).toHaveLength(0);
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * The images open the viewer
+ * ------------------------------------------------------------------ */
+
+/**
+ * A media URL that RESOLVES and is DIFFERENT per call — the same technique
+ * `AppListingDetailBody.viewer.browser.test.tsx` uses, and both halves matter here.
+ *
+ * DISTINCT, because the whole claim is "the image you clicked is the one that opens":
+ * a shared fixture URL makes opening the WRONG image indistinguishable from opening the
+ * right one, which is the only way this feature can be broken without looking broken.
+ *
+ * LOADABLE (a `data:` URI, not http), because an unloadable http source fires a real
+ * `error` ~11 ms after mount and the viewer's own rescue effect would then navigate off
+ * it — so a green would be measuring the race, not the wiring
+ * (`local-rules/no-unloadable-image-fixture`).
+ */
+const okMedia = (tag: string) =>
+  `data:image/svg+xml;base64,${btoa(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" data-tag="${tag}"/>`
+  )}`;
+
+/** The viewer's dialog, read from the DOCUMENT — Mantine portals it out of the tree. */
+const mediaViewer = () =>
+  (document
+    .querySelector('[data-testid="apps-listing-screenshot-viewer"]')
+    ?.closest('[role="dialog"]') as HTMLElement | null) ?? null;
+
+const mediaViewerImage = () =>
+  document.querySelector<HTMLImageElement>('[data-testid="apps-listing-screenshot-viewer-image"]');
+
+const mediaViewerPosition = () =>
+  document
+    .querySelector('[data-testid="apps-listing-screenshot-position"]')
+    ?.textContent?.replace(/\s+/g, ' ')
+    .trim() ?? null;
+
+/** Wait until the viewer is showing exactly `url`. */
+async function expectViewerShowing(url: string, why: string) {
+  await vi.waitFor(() => {
+    const img = mediaViewerImage();
+    expect(img, `no viewer image — ${why}`).not.toBeNull();
+    expect(img!.getAttribute('src'), why).toBe(url);
+  });
+}
+
+describe('🔴 the row images open the shared listing image viewer', () => {
+  const COVER = okMedia('cover');
+  const ICON = okMedia('icon');
+
+  /**
+   * 🔴 THE HEADLINE, AND THE REASON THE INDEX IS COMPUTED RATHER THAN ASSUMED: clicking
+   * the ICON must open the ICON, not the first entry in the list. Cover is entry 0, so
+   * an "always open index 0" implementation renders a perfectly healthy modal showing
+   * the wrong picture — and with a shared fixture URL it would look correct.
+   */
+  test('clicking the ICON opens the viewer on the icon', async () => {
+    renderWithProviders(
+      <MyAppsBodyView
+        rows={[row({ appListingId: 'apl_v1', status: 'approved', iconUrl: ICON, coverUrl: COVER })]}
+      />
+    );
+    const btn = page.getByRole('button', { name: 'View icon image for Name apl_v1' });
+    await expect.element(btn).toBeInTheDocument();
+    // Nothing is open before the click — so the assertions after it are about the click.
+    expect(mediaViewer()).toBeNull();
+    await userEvent.click(btn.element());
+    await expectViewerShowing(ICON, 'the icon button must open the ICON');
+    // 🔴 SEEDED WITH BOTH IMAGES, so prev/next works instead of being a dead end. The
+    // position indicator counts what navigation can actually reach.
+    expect(mediaViewerPosition()).toBe('2 / 2');
+  });
+
+  test('clicking the COVER opens the viewer on the cover', async () => {
+    renderWithProviders(
+      <MyAppsBodyView
+        rows={[row({ appListingId: 'apl_v2', status: 'approved', iconUrl: ICON, coverUrl: COVER })]}
+      />
+    );
+    // 🔴 AWAIT THE ELEMENT BEFORE CLICKING. `renderWithProviders` commits
+    // asynchronously in browser mode, so a synchronous `.element()` here races the
+    // mount and reports "Cannot find element" against an empty <body>.
+    const btn2 = page.getByRole('button', { name: 'View cover image for Name apl_v2' });
+    await expect.element(btn2).toBeInTheDocument();
+    await userEvent.click(btn2.element());
+    await expectViewerShowing(COVER, 'the cover button must open the COVER');
+    expect(mediaViewerPosition()).toBe('1 / 2');
+  });
+
+  /**
+   * 🔴 THE POINT OF SEEDING BOTH IMAGES INTO ONE LIST. Two isolated single-image modals
+   * would render with both arrows permanently disabled and a `1 / 1` counter — which
+   * looks fine and is the whole regression. Navigating from the cover must land on the
+   * icon of the SAME row.
+   */
+  test('🔴 prev/next moves between the row’s two images', async () => {
+    renderWithProviders(
+      <MyAppsBodyView
+        rows={[
+          row({ appListingId: 'apl_v3', status: 'approved', iconUrl: ICON, coverUrl: COVER }),
+          // A second row with its OWN media, so a mutant that pools every row's images
+          // into one list produces a 4-entry viewer and fails the counter below.
+          //
+          // 🔴 ITS NAME IS NOT A PREFIX-EXTENSION OF THE FIRST ROW'S. `getByRole`'s
+          // `name` is a SUBSTRING match by default, so an id like `apl_v3b` makes
+          // "…for Name apl_v3" resolve to BOTH buttons and the query dies on a strict-
+          // mode violation — which reads exactly like the control being missing.
+          row({
+            appListingId: 'apl_other',
+            status: 'pending',
+            kind: 'offsite',
+            iconUrl: okMedia('icon-other'),
+            coverUrl: okMedia('cover-other'),
+          }),
+        ]}
+      />
+    );
+    const btn3 = page.getByRole('button', { name: 'View cover image for Name apl_v3' });
+    await expect.element(btn3).toBeInTheDocument();
+    await userEvent.click(btn3.element());
+    await expectViewerShowing(COVER, 'opened on the cover');
+    expect(mediaViewerPosition()).toBe('1 / 2');
+    const nextBtn = page.getByRole('button', { name: 'Next screenshot' });
+    await expect.element(nextBtn).toBeInTheDocument();
+    await userEvent.click(nextBtn.element());
+    await expectViewerShowing(ICON, 'next from the cover is THIS row’s icon');
+    expect(mediaViewerPosition()).toBe('2 / 2');
+    const prevBtn = page.getByRole('button', { name: 'Previous screenshot' });
+    await expect.element(prevBtn).toBeInTheDocument();
+    await userEvent.click(prevBtn.element());
+    await expectViewerShowing(COVER, 'prev goes back to the cover');
+  });
+
+  /**
+   * 🔴 A ROW WITH ONE IMAGE SEEDS ONE ENTRY, AND THE INDEX SHIFTS. With no cover, the
+   * icon is entry 0 — an implementation that hardcoded "icon = index 1" would open a
+   * viewer on an index that does not exist, and the rescue effect would silently close
+   * it. That failure reads as "the click did nothing".
+   */
+  test('a row with only an icon opens a ONE-entry viewer on that icon', async () => {
+    renderWithProviders(
+      <MyAppsBodyView
+        rows={[row({ appListingId: 'apl_v4', status: 'approved', iconUrl: ICON, coverUrl: null })]}
+      />
+    );
+    const btn4 = page.getByRole('button', { name: 'View icon image for Name apl_v4' });
+    await expect.element(btn4).toBeInTheDocument();
+    await userEvent.click(btn4.element());
+    await expectViewerShowing(ICON, 'the only image is the icon');
+    expect(mediaViewerPosition()).toBe('1 / 1');
+  });
+
+  /**
+   * 🔴 PLACEHOLDERS ARE NOT CLICKABLE — there is nothing to view. A focusable control
+   * that opens an empty modal is worse than none, and this table's rows are mostly
+   * incomplete listings (measured: all 11 `removed` listings have a null cover), so a
+   * placeholder button would add a dead tab stop to nearly every row.
+   *
+   * 🔴 LABELLED AN **INVARIANT GUARD**, NOT REGRESSION COVERAGE, and the distinction is
+   * measured rather than assumed: run against `origin/main` this test PASSES, because
+   * at base nothing on the row was clickable at all. It pins an invariant the bug never
+   * violated. Every OTHER test in this describe is red at base and green here; this one
+   * is not, and counting it as regression coverage would overstate what was proved.
+   * It still earns its place — it is the only thing standing between a future
+   * "simplify the two branches into one wrapper" refactor and a dead tab stop on every
+   * incomplete row — but it is a guard, not evidence.
+   */
+  test('INVARIANT GUARD: neither placeholder is a button, focusable, or clickable', async () => {
+    renderWithProviders(
+      <MyAppsBodyView
+        rows={[row({ appListingId: 'apl_v5', status: 'pending', iconUrl: null, coverUrl: null })]}
+      />
+    );
+    const iconPh = page.getByTestId('apps-mine-icon-placeholder-apl_v5');
+    await expect.element(iconPh).toBeInTheDocument();
+    const coverPh = page.getByTestId('apps-mine-cover-placeholder-apl_v5');
+    await expect.element(coverPh).toBeInTheDocument();
+
+    for (const [label, el] of [
+      ['icon', iconPh.element()],
+      ['cover', coverPh.element()],
+    ] as const) {
+      // Not a button, and not inside one — a wrapper button is the shape that would
+      // sneak past a tagName check on the placeholder itself.
+      expect(el.tagName, `${label} placeholder is a <${el.tagName.toLowerCase()}>`).toBe('DIV');
+      expect(el.closest('button'), `${label} placeholder is wrapped in a button`).toBeNull();
+      // Not keyboard-reachable, and offering no pointer affordance.
+      expect(el.getAttribute('tabindex'), `${label} placeholder is focusable`).toBeNull();
+      expect((el as HTMLElement).style.cursor, `${label} placeholder shows a cursor`).toBe('');
+    }
+
+    // 🔴 NEGATIVE CONTROL FOR THE WHOLE `getByRole` FAMILY ABOVE: no view-image button
+    // exists for this row at all, under EITHER name. Without this, the assertions above
+    // would be satisfied by a placeholder that is inert while some other element opened
+    // the viewer.
+    expect(
+      page.getByRole('button', { name: /^View (icon|cover) image for/ }).elements()
+    ).toHaveLength(0);
+    expect(mediaViewer()).toBeNull();
+  });
+
+  /**
+   * 🔴 THE HALF-EMPTY ROW, which is the common production shape rather than an edge
+   * case. The present image must still be clickable and the absent one must still be
+   * inert — an implementation that gates the buttons on "the row has media" rather than
+   * "THIS image exists" passes the both-present and both-absent tests and fails here.
+   */
+  test('🔴 a row with a cover and NO icon: cover clickable, icon inert', async () => {
+    renderWithProviders(
+      <MyAppsBodyView
+        rows={[row({ appListingId: 'apl_v6', status: 'approved', iconUrl: null, coverUrl: COVER })]}
+      />
+    );
+    await expect.element(page.getByTestId('apps-mine-icon-placeholder-apl_v6')).toBeInTheDocument();
+    expect(
+      page.getByRole('button', { name: 'View icon image for Name apl_v6' }).elements()
+    ).toHaveLength(0);
+    const btn6 = page.getByRole('button', { name: 'View cover image for Name apl_v6' });
+    await expect.element(btn6).toBeInTheDocument();
+    await userEvent.click(btn6.element());
+    await expectViewerShowing(COVER, 'the cover is still clickable with no icon');
+    expect(mediaViewerPosition()).toBe('1 / 1');
+  });
+
+  /**
+   * 🔴 THE ACCESSIBLE NAME NAMES THE APP, not just "image". Two rows both offering a
+   * button called "View cover image" is a screen-reader dead end, and it is also what
+   * makes every `getByRole` query in this file able to address ONE row.
+   */
+  test('🔴 the button names disambiguate BETWEEN rows', async () => {
+    renderWithProviders(
+      <MyAppsBodyView
+        rows={[
+          row({ appListingId: 'apl_v7a', name: 'Aardvark', status: 'approved', coverUrl: COVER }),
+          row({
+            appListingId: 'apl_v7b',
+            name: 'Basilisk',
+            status: 'pending',
+            kind: 'offsite',
+            coverUrl: okMedia('cover-b'),
+          }),
+        ]}
+      />
+    );
+    await expect
+      .element(page.getByRole('button', { name: 'View cover image for Aardvark' }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole('button', { name: 'View cover image for Basilisk' }))
+      .toBeInTheDocument();
+    // Each name addresses exactly ONE control.
+    expect(
+      page.getByRole('button', { name: 'View cover image for Aardvark' }).elements()
+    ).toHaveLength(1);
+  });
+
+  /**
+   * 🔴 KEYBOARD-OPERABLE, which is the property `UnstyledButton` buys and an
+   * `<img onClick>` does not. A mouse-only affordance that LOOKS wired up is exactly
+   * what the screenshot gallery's own wiring gate exists to prevent.
+   */
+  test('🔴 the control opens on Enter, not only on click', async () => {
+    renderWithProviders(
+      <MyAppsBodyView
+        rows={[row({ appListingId: 'apl_v8', status: 'approved', coverUrl: COVER })]}
+      />
+    );
+    const btn = page.getByRole('button', { name: 'View cover image for Name apl_v8' });
+    await expect.element(btn).toBeInTheDocument();
+    const el = btn.element() as HTMLElement;
+    el.focus();
+    expect(document.activeElement, 'the control is not focusable').toBe(el);
+    await userEvent.keyboard('{Enter}');
+    await expectViewerShowing(COVER, 'Enter must activate the control');
+  });
+
+  test('the viewer closes again', async () => {
+    renderWithProviders(
+      <MyAppsBodyView
+        rows={[row({ appListingId: 'apl_v9', status: 'approved', coverUrl: COVER })]}
+      />
+    );
+    const btn9 = page.getByRole('button', { name: 'View cover image for Name apl_v9' });
+    await expect.element(btn9).toBeInTheDocument();
+    await userEvent.click(btn9.element());
+    await expectViewerShowing(COVER, 'opened');
+    const closeBtn = page.getByRole('button', { name: 'Close screenshot viewer' });
+    await expect.element(closeBtn).toBeInTheDocument();
+    await userEvent.click(closeBtn.element());
+    await vi.waitFor(() => expect(mediaViewer()).toBeNull());
   });
 });
 
@@ -983,16 +1343,147 @@ describe('🔴 submissions without a listing', () => {
       .toHaveTextContent(/scope it never uses/i);
   });
 
-  test('the group is NOT hidden behind the Inactive collapse', async () => {
+  /**
+   * 🔴 THE RULE THIS TEST PINS CHANGED, SO THE TEST WAS REWRITTEN — NOT DELETED.
+   *
+   * It used to assert only "the group is NOT hidden behind the Inactive collapse",
+   * which was the whole rule when the group was unconditionally visible. The group is
+   * now its OWN collapse that opens itself when it holds something actionable. Both
+   * halves of the new rule are asserted here, and the first half is unchanged: this is
+   * still not nested under Inactive.
+   */
+  test('🔴 NOT inside the Inactive collapse, and OPEN without interaction when actionable', async () => {
     renderWithProviders(
       <MyAppsBodyView
-        rows={[row({ appListingId: 'apl_live' })]}
-        orphanedSubmissions={[orphan({ id: 'pubreq_x' })]}
+        // An INACTIVE row, so the Inactive collapse actually exists to be nested in —
+        // with no inactive rows there is no panel and the structural half would pass
+        // vacuously.
+        rows={[row({ appListingId: 'apl_rem', status: 'removed' })]}
+        orphanedSubmissions={[
+          orphan({ id: 'pubreq_x', rejectionReason: 'manifest declares an unused scope' }),
+        ]}
       />
     );
-    // Visible with no interaction at all: no toggle was clicked.
+    const group = page.getByTestId('apps-mine-orphaned');
+    await expect.element(group).toBeInTheDocument();
+
+    // 🔴 STRUCTURAL: the group is not a descendant of the Inactive panel. Asserted as
+    // containment rather than as "it is visible", because the Inactive collapse keeps
+    // its children mounted while closed — so a nested group would still be findable.
+    const inactivePanel = page.getByTestId('apps-mine-inactive-panel').element();
+    expect(inactivePanel, 'no Inactive panel to be nested in').not.toBeNull();
+    expect(
+      inactivePanel.contains(group.element()),
+      'the orphan group is nested inside the Inactive collapse'
+    ).toBe(false);
+
+    // 🔴 STATE: open on arrival, with NO toggle clicked. Read from `aria-expanded`
+    // rather than from the row's presence — Mantine's `Collapse` leaves its children in
+    // the DOM when closed, so `toBeInTheDocument` cannot tell open from closed and
+    // would pass against a permanently-collapsed group.
+    await expect
+      .element(page.getByTestId('apps-mine-orphaned-toggle'))
+      .toHaveAttribute('aria-expanded', 'true');
     await expect.element(page.getByTestId('apps-mine-orphaned-row-pubreq_x')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-mine-orphaned-count')).toHaveTextContent('1');
+  });
+
+  /**
+   * 🔴 THE PENDING+WITHDRAWABLE HALF of the auto-open rule — the OTHER shape, because a
+   * mutant that only checks `rejectionReason` passes the test above.
+   */
+  test('a PENDING withdrawable orphan also opens the group on arrival', async () => {
+    renderWithProviders(
+      <MyAppsBodyView
+        rows={[]}
+        orphanedSubmissions={[orphan({ id: 'pubreq_open2', status: 'pending', canWithdraw: true })]}
+        onWithdrawOrphan={() => undefined}
+      />
+    );
+    await expect
+      .element(page.getByTestId('apps-mine-orphaned-toggle'))
+      .toHaveAttribute('aria-expanded', 'true');
+  });
+
+  /**
+   * 🔴 THE CLOSED CASE, and it is the one that makes the whole feature more than a
+   * no-op. Settled history collapses — and the COUNT BADGE STAYS ON THE HEADER, because
+   * a closed group with no count is an unlabelled box, indistinguishable from the rows
+   * being gone. That is the exact impression this section exists to stop giving.
+   */
+  test('🔴 nothing actionable → CLOSED, but the count is still on the header', async () => {
+    renderWithProviders(
+      <MyAppsBodyView
+        rows={[]}
+        orphanedSubmissions={[
+          orphan({ id: 'pubreq_hist1', status: 'withdrawn' }),
+          orphan({ id: 'pubreq_hist2', status: 'approved' }),
+          // A rejection with NO reason attached: settled, and nothing to act on.
+          orphan({ id: 'pubreq_hist3', status: 'rejected', rejectionReason: null }),
+        ]}
+      />
+    );
+    await expect.element(page.getByTestId('apps-mine-orphaned')).toBeInTheDocument();
+    const toggle = page.getByTestId('apps-mine-orphaned-toggle');
+    await expect.element(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    // The signal survives the collapse — and it is COUNTING, not a hardcoded 1.
+    const count = page.getByTestId('apps-mine-orphaned-count');
+    await expect.element(count).toHaveTextContent('3');
+
+    /**
+     * 🔴 THE HALF THIS TEST'S NAME CLAIMS AND `toHaveTextContent` DOES NOT PROVE, found
+     * by mutation: moving the badge INSIDE the `Collapse` left this test fully green,
+     * because Mantine's `Collapse` keeps its children MOUNTED when closed. So "the
+     * count is still there" is true of a badge the user cannot see, and the assertion
+     * above reads as coverage while providing none.
+     *
+     * The checkable claim is CONTAINMENT: the badge is on the toggle (the always-
+     * visible header), not in the panel the toggle hides.
+     */
+    const panel = document.querySelector('[data-testid="apps-mine-orphaned-panel"]');
+    expect(panel, 'no collapse panel — the group is not collapsible at all').not.toBeNull();
+    expect(
+      panel!.contains(count.element()),
+      'the count badge is INSIDE the collapse, so a closed group shows no count at all — ' +
+        'an unlabelled box, indistinguishable from the rows being gone'
+    ).toBe(false);
+    expect(
+      toggle.element().contains(count.element()),
+      'the count badge is not on the toggle header'
+    ).toBe(true);
+  });
+
+  test('a closed group opens on click, and its rows are reachable', async () => {
+    renderWithProviders(
+      <MyAppsBodyView
+        rows={[]}
+        orphanedSubmissions={[orphan({ id: 'pubreq_cl', status: 'withdrawn' })]}
+      />
+    );
+    const toggle = page.getByTestId('apps-mine-orphaned-toggle');
+    await expect.element(toggle).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(toggle.element());
+    await expect.element(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect.element(page.getByTestId('apps-mine-orphaned-row-pubreq_cl')).toBeInTheDocument();
+  });
+
+  /**
+   * 🔴 `aria-controls` NAMES A REAL ELEMENT ID. A toggle pointing at nothing reports to
+   * assistive tech that the panel does not exist — the same rule the row-history toggle
+   * and the Inactive toggle already follow, applied to the third disclosure on the page.
+   */
+  test('the toggle’s aria-controls resolves to the panel it controls', async () => {
+    renderWithProviders(
+      <MyAppsBodyView rows={[]} orphanedSubmissions={[orphan({ id: 'pubreq_aria' })]} />
+    );
+    const toggle = page.getByTestId('apps-mine-orphaned-toggle');
+    await expect.element(toggle).toBeInTheDocument();
+    const id = toggle.element().getAttribute('aria-controls');
+    expect(id, 'the toggle controls nothing').toBeTruthy();
+    const panel = document.getElementById(id!);
+    expect(panel, `aria-controls="${id}" resolves to no element`).not.toBeNull();
+    expect(panel!.getAttribute('data-testid')).toBe('apps-mine-orphaned-panel');
   });
 
   test('a PENDING orphan offers Withdraw; a rejected one does not', async () => {

--- a/src/components/Apps/MyAppsBody.tsx
+++ b/src/components/Apps/MyAppsBody.tsx
@@ -32,12 +32,20 @@ import {
   showRepublish,
   showUnpublish,
 } from '~/components/Apps/myAppsAuthorActions';
-import type { MyAppRow } from '~/components/Apps/myAppsView';
+import { AppListingScreenshotViewer } from '~/components/Apps/AppListingScreenshotViewer';
+import {
+  NO_BROKEN_SCREENSHOTS,
+  withBrokenIndex,
+  type BrokenScreenshotIndexes,
+} from '~/components/Apps/appListingScreenshotNav';
+import type { MyAppMediaKind, MyAppRow } from '~/components/Apps/myAppsView';
 import {
   historyStatusColor,
-  listingKindLabel,
+  listingMediaIndex,
+  listingMediaShots,
   listingStatusColor,
   myAppListingHref,
+  orphanGroupStartsOpen,
   pageCount,
   pageSlice,
   partitionMyAppRows,
@@ -119,7 +127,56 @@ function formatWhen(value: string | Date | null | undefined): string {
   return formatDate(value, 'MMM D, YYYY');
 }
 
-function ListingIcon({ row }: { row: MyAppRow }) {
+/**
+ * 🔴 THE CLICK TARGET IS A REAL `<button>`, AND THE PLACEHOLDER IS NOT ONE.
+ *
+ * Both media components below wrap their image in `UnstyledButton` — which renders a
+ * real `<button type="button">`, so it is tab-reachable, Enter/Space-activatable and
+ * carries a focus ring. An `<img onClick>` would be a mouse-only affordance that LOOKS
+ * wired up; the screenshot gallery this viewer is shared with learned that already
+ * (`appListingScreenshotViewerWiring.test.ts`'s "the tile is a real button").
+ *
+ * 🔴 NOT Mantine `Anchor`. Its root sets `color: var(--mantine-color-anchor)`, which
+ * recolours every `currentColor` descendant — including the "No cover" glyph inside the
+ * placeholder. That bug is INVISIBLE on the has-image path (an `<img>` ignores `color`)
+ * and only appears on the no-image path, which is the path that must not be a link at
+ * all. It is also not a navigation: nothing gets an href.
+ *
+ * 🔴 A PLACEHOLDER IS INERT — no button, no `tabIndex`, no pointer cursor. There is
+ * nothing to view, and a focusable control that opens an empty modal is worse than no
+ * control: it adds a tab stop to every row of a table whose rows are mostly incomplete
+ * listings (measured: all 11 `removed` listings have a null cover).
+ */
+function MediaButton({
+  label,
+  onOpen,
+  children,
+}: {
+  label: string;
+  onOpen: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <UnstyledButton
+      onClick={onOpen}
+      aria-label={label}
+      // `display: flex` so the button box is exactly the image box — a default
+      // `display: block` UnstyledButton would add descender space under the image and
+      // make the focus ring taller than the thing it is outlining.
+      style={{ display: 'flex', cursor: 'zoom-in', borderRadius: 8 }}
+    >
+      {children}
+    </UnstyledButton>
+  );
+}
+
+function ListingIcon({
+  row,
+  onOpenMedia,
+}: {
+  row: MyAppRow;
+  onOpenMedia?: (row: MyAppRow, which: MyAppMediaKind) => void;
+}) {
   if (!row.iconUrl) {
     return (
       <div
@@ -135,7 +192,7 @@ function ListingIcon({ row }: { row: MyAppRow }) {
       />
     );
   }
-  return (
+  const img = (
     // 🔴 A PLAIN `<img>`, NOT `next/image`. The server already hands us a CDN-transformed
     // URL (`getEdgeUrl(..., { width })`), so `next/image` would put a SECOND optimizer in
     // front of an already-optimized asset — extra cost, no smaller bytes. The two things
@@ -154,9 +211,21 @@ function ListingIcon({ row }: { row: MyAppRow }) {
       style={{ borderRadius: 8, objectFit: 'cover', flex: `0 0 ${ICON_BOX}px` }}
     />
   );
+  if (!onOpenMedia) return img;
+  return (
+    <MediaButton label={`View icon image for ${row.name}`} onOpen={() => onOpenMedia(row, 'icon')}>
+      {img}
+    </MediaButton>
+  );
 }
 
-function ListingCover({ row }: { row: MyAppRow }) {
+function ListingCover({
+  row,
+  onOpenMedia,
+}: {
+  row: MyAppRow;
+  onOpenMedia?: (row: MyAppRow, which: MyAppMediaKind) => void;
+}) {
   if (!row.coverUrl) {
     return (
       <div
@@ -177,7 +246,7 @@ function ListingCover({ row }: { row: MyAppRow }) {
       </div>
     );
   }
-  return (
+  const img = (
     // Plain `<img>` for the same reason as the icon above — the URL is already a
     // width-transformed CDN URL, and the CLS/lazy properties are set explicitly.
     // eslint-disable-next-line @next/next/no-img-element
@@ -191,6 +260,15 @@ function ListingCover({ row }: { row: MyAppRow }) {
       decoding="async"
       style={{ borderRadius: 6, objectFit: 'cover' }}
     />
+  );
+  if (!onOpenMedia) return img;
+  return (
+    <MediaButton
+      label={`View cover image for ${row.name}`}
+      onOpen={() => onOpenMedia(row, 'cover')}
+    >
+      {img}
+    </MediaButton>
   );
 }
 
@@ -220,16 +298,26 @@ function ListingName({ row }: { row: MyAppRow }) {
   );
 }
 
+/**
+ * 🔴 THERE IS NO KIND BADGE HERE, AND ITS ABSENCE IS THE DECISION.
+ *
+ * `/apps/mine` used to render one (testid `apps-mine-kind-<id>`). It is DELETED: the
+ * author already knows what they built, the word cost a badge slot in a row that also
+ * carries role, status and the completeness advisory, and the page is not where anyone
+ * looks the kind up. The kind still renders on the listing DETAIL page
+ * (`appListingDetailRows`' "Kind" row) and on the edit surface, which are the places
+ * that answer a question about it.
+ *
+ * 🔴 SO THIS FILE IS DELIBERATELY **NOT** ENROLLED in
+ * `__tests__/standaloneWordingCallSites.test.ts`. Enrolling it would assert that it
+ * resolves the kind word from the one source — a claim that is only meaningful for a
+ * surface that renders one. The absence is pinned instead, by
+ * `MyAppsBody.browser.test.tsx`'s "no row shape renders a kind badge", so a future
+ * "helpfully restore the badge" change is visible rather than silent.
+ */
 function StatusBadges({ row }: { row: MyAppRow }) {
   return (
     <Group gap={6} wrap="nowrap">
-      <Badge
-        variant="light"
-        color={row.kind === 'onsite' ? 'blue' : 'grape'}
-        data-testid={`apps-mine-kind-${row.appListingId}`}
-      >
-        {listingKindLabel(row.kind)}
-      </Badge>
       {/* 🔴 The role badge is not decoration: an editor cannot invite, remove or transfer,
           so saying which one they are is what makes the missing controls legible rather
           than looking broken. */}
@@ -569,6 +657,8 @@ type RowRenderProps = {
   onUnpublish?: (row: MyAppRow) => void;
   onRepublish?: (row: MyAppRow) => void;
   republishing: boolean;
+  /** Open the row's image viewer at the image that was clicked. */
+  onOpenMedia?: (row: MyAppRow, which: MyAppMediaKind) => void;
 };
 
 function rowTestId(group: 'active' | 'inactive', appListingId: string): string {
@@ -585,7 +675,7 @@ function AppTableRow(props: RowRenderProps) {
       <Table.Tr data-testid={rowTestId(group, row.appListingId)}>
         <Table.Td>
           <Group gap="sm" wrap="nowrap">
-            <ListingIcon row={row} />
+            <ListingIcon row={row} onOpenMedia={props.onOpenMedia} />
             <Stack gap={0}>
               <ListingName row={row} />
               <Text size="xs" c="dimmed">
@@ -595,7 +685,7 @@ function AppTableRow(props: RowRenderProps) {
           </Group>
         </Table.Td>
         <Table.Td>
-          <ListingCover row={row} />
+          <ListingCover row={row} onOpenMedia={props.onOpenMedia} />
         </Table.Td>
         <Table.Td>
           <Stack gap={4} align="flex-start">
@@ -652,14 +742,14 @@ function AppCardRow(props: RowRenderProps) {
     <Paper withBorder p="sm" radius="md" data-testid={rowTestId(group, row.appListingId)}>
       <Stack gap="xs">
         <Group gap="sm" wrap="nowrap" align="flex-start">
-          <ListingIcon row={row} />
+          <ListingIcon row={row} onOpenMedia={props.onOpenMedia} />
           <Stack gap={0} style={{ minWidth: 0, flex: 1 }}>
             <ListingName row={row} />
             <Text size="xs" c="dimmed">
               {row.slug}
             </Text>
           </Stack>
-          <ListingCover row={row} />
+          <ListingCover row={row} onOpenMedia={props.onOpenMedia} />
         </Group>
         <StatusBadges row={row} />
         <ModRemovedNotice row={row} />
@@ -819,6 +909,37 @@ export function MyAppsBodyView({
   const [inactiveOpen, setInactiveOpen] = useState(false);
   const [inactivePage, setInactivePage] = useState(1);
 
+  /**
+   * The row whose images are open in the viewer, and which one is on screen.
+   *
+   * 🔴 ONE VIEWER FOR THE WHOLE PAGE, not one per row. A `<Modal>` per row would put
+   * `rows.length` dialogs in the DOM, each registering its own capture-phase `keydown`
+   * listener for Escape — and this table routinely renders dozens of rows.
+   *
+   * 🔴 `broken` IS RESET ON EVERY OPEN, because it is a set of indices into THIS row's
+   * `[cover, icon]` list. Carrying it across rows would mean "index 1 is broken" —
+   * learned from one listing's icon — silently hiding a different listing's icon. That
+   * is the same index-space rule the screenshot gallery states in
+   * `appListingScreenshotNav.ts`; here the list changes per row rather than per refetch.
+   */
+  const [mediaTarget, setMediaTarget] = useState<{ rowId: string; index: number } | null>(null);
+  const [mediaBroken, setMediaBroken] = useState<BrokenScreenshotIndexes>(NO_BROKEN_SCREENSHOTS);
+
+  const openMedia = useCallback((row: MyAppRow, which: MyAppMediaKind) => {
+    const index = listingMediaIndex(row, which);
+    // 🔴 `null` means that image is absent. Unreachable from the UI today (a placeholder
+    // renders no button at all), so this is the structural half of that guarantee rather
+    // than its only enforcement — an opened-on-nothing viewer is an empty modal.
+    if (index === null) return;
+    setMediaBroken(NO_BROKEN_SCREENSHOTS);
+    setMediaTarget({ rowId: row.appListingId, index });
+  }, []);
+  const closeMedia = useCallback(() => setMediaTarget(null), []);
+  const markMediaBroken = useCallback(
+    (index: number) => setMediaBroken((prev) => withBrokenIndex(prev, index)),
+    []
+  );
+
   // 🔴 GUARDED ON `> 0` so the initial render does not open the section — the prop defaults
   // to 0 and only a real unpublish bumps it. See `revealInactive` on the props type.
   useEffect(() => {
@@ -831,6 +952,12 @@ export function MyAppsBodyView({
   );
   const inactivePages = pageCount(inactive.length);
   const inactiveVisible = pageSlice(inactive, inactivePage);
+
+  // Resolved from `rows` rather than stored on open, so the viewer can never outlive
+  // the row it is showing (see the mount site).
+  const mediaRow = mediaTarget
+    ? rows.find((r) => r.appListingId === mediaTarget.rowId) ?? null
+    : null;
 
   const renderRow = useCallback(
     (row: MyAppRow, group: 'active' | 'inactive'): RowRenderProps => {
@@ -849,6 +976,7 @@ export function MyAppsBodyView({
         onUnpublish,
         onRepublish,
         republishing,
+        onOpenMedia: openMedia,
       };
     },
     [
@@ -863,6 +991,7 @@ export function MyAppsBodyView({
       onUnpublish,
       onRepublish,
       republishing,
+      openMedia,
     ]
   );
 
@@ -1037,6 +1166,32 @@ export function MyAppsBodyView({
           withdrawEnabled={withdrawEnabled}
         />
       )}
+
+      {/*
+        🔴 REUSED, NOT REBUILT — and the alternatives were rejected for a STRUCTURAL
+        reason, not by omission. `ImageViewer` and `ImageDetailModal` are keyed on a
+        numeric civitai `Image` id and driven by a `?imageId=` query param; a row here
+        carries a CDN URL STRING (`getEdgeUrl`) and no image id exists to hand them.
+        `AppListingScreenshotViewer` is URL-keyed, which is exactly the shape this page
+        has — see its own rejected-alternatives ledger for the longer version.
+
+        It is mounted OUTSIDE the row list so it survives pagination and the Inactive
+        collapse closing under it; `mediaRow` is looked up from `rows`, so a row that
+        leaves the list (a withdraw, a refetch) leaves `shots` empty and the viewer's
+        own rescue effect closes it rather than framing a dead URL.
+
+        Its `stackId` is INERT here — degrading cleanly with no `Modal.Stack` ancestor
+        is a documented property of that component, and `/apps/mine` nests no dialogs.
+      */}
+      <AppListingScreenshotViewer
+        shots={mediaRow ? listingMediaShots(mediaRow) : []}
+        name={mediaRow?.name ?? ''}
+        broken={mediaBroken}
+        index={mediaRow ? mediaTarget?.index ?? null : null}
+        onIndexChange={(index) => setMediaTarget((prev) => (prev ? { ...prev, index } : prev))}
+        onBroken={markMediaBroken}
+        onClose={closeMedia}
+      />
     </Stack>
   );
 }
@@ -1051,9 +1206,32 @@ export function MyAppsBodyView({
  * state — i.e. 100% of rejections were unreachable from anywhere in the product, including
  * from the "your app was rejected" notification that now points at this page.
  *
- * 🔴 ALWAYS VISIBLE, deliberately NOT behind the Inactive collapse. These rows are the
- * ones a developer arrives looking for, and the group is small and bounded; collapsing the
- * only surface that shows a rejection reason would re-create the defect in a nicer shape.
+ * 🔴 COLLAPSIBLE, BUT IT OPENS ITSELF WHENEVER IT HAS SOMETHING ACTIONABLE — and that
+ * conditional is what carries the old "ALWAYS VISIBLE" guarantee forward rather than
+ * dropping it. The previous rule was that this group must never sit behind a toggle,
+ * for three reasons that all still hold: it is the only surface in the product showing
+ * a REJECTION REASON, the "your app was rejected" notification deep-links to this page,
+ * and on production 2026-08-20 **3 of 3 rejected** and **27 of 33 withdrawn** on-site
+ * requests were unreachable from anywhere before it existed.
+ *
+ * Read those three reasons precisely: every one of them is about a row the author can
+ * still ACT ON. None of them is an argument for keeping an unbounded pile of settled
+ * history permanently expanded above the fold. So the rule is now:
+ *
+ *   - a row with a rejection reason, or a `pending` row the SERVER says this caller may
+ *     withdraw → the group is open on arrival, with no interaction. The notification
+ *     deep-link lands on an open group, which is the guarantee that mattered;
+ *   - nothing actionable → collapsed, because it is archive.
+ *
+ * 🔴 THE COUNT BADGE STAYS ON THE HEADER, closed or open. A collapsed group with no
+ * count is an unlabelled box, which is indistinguishable from the rows being GONE — the
+ * exact impression this whole section exists to stop giving. The predicate itself is
+ * `orphanGroupStartsOpen` in `myAppsView.ts`, in the blocking `unit` project.
+ *
+ * 🔴 STILL NOT INSIDE THE INACTIVE COLLAPSE. That has not changed and is not the same
+ * question: this is its OWN disclosure, whose open state it decides from its OWN rows.
+ * Nesting it under Inactive would put an actionable rejection two clicks deep behind a
+ * control that says nothing about it.
  */
 function OrphanedSubmissionsSection({
   rows,
@@ -1066,73 +1244,96 @@ function OrphanedSubmissionsSection({
   withdrawing: boolean;
   withdrawEnabled: boolean;
 }) {
+  /**
+   * Initial state ONLY — deliberately not re-derived on every `rows` change. Once the
+   * author has opened or closed this group, a refetch (or a withdraw removing the one
+   * actionable row) must not reach in and move it under their hands.
+   */
+  const [open, setOpen] = useState(() => orphanGroupStartsOpen(rows));
   return (
     <Stack gap="xs" data-testid="apps-mine-orphaned">
-      <Group gap={6}>
-        <Text fw={600} size="sm">
-          Submissions without a listing
-        </Text>
-        <Badge variant="light" color="gray" data-testid="apps-mine-orphaned-count">
-          {rows.length}
-        </Badge>
-      </Group>
-      <Text size="xs" c="dimmed">
-        These apps never got a store listing — a first version that was rejected or withdrawn
-        releases its slug, so there is no app page to show them on.
-      </Text>
-      <Stack gap="xs">
-        {rows.map((r) => (
-          <Paper
-            key={r.id}
-            withBorder
-            p="sm"
-            radius="md"
-            data-testid={`apps-mine-orphaned-row-${r.id}`}
-          >
-            <Group justify="space-between" wrap="wrap" gap="xs">
-              <Stack gap={2}>
-                <Text fw={600}>{r.slug}</Text>
-                <Text size="xs" c="dimmed">
-                  v{r.version} · submitted {formatWhen(r.submittedAt)}
-                </Text>
-              </Stack>
-              <Group gap="xs">
-                <Badge
-                  variant="outline"
-                  color={historyStatusColor(r.status)}
-                  data-testid={`apps-mine-orphaned-status-${r.id}`}
-                >
-                  {r.status}
-                </Badge>
-                {r.canWithdraw && onWithdraw && withdrawEnabled ? (
-                  <Button
-                    size="compact-xs"
-                    variant="subtle"
-                    color="gray"
-                    disabled={withdrawing}
-                    onClick={() => onWithdraw(r)}
-                    data-testid={`apps-mine-orphaned-withdraw-${r.id}`}
-                  >
-                    Withdraw
-                  </Button>
-                ) : null}
-              </Group>
-            </Group>
-            {/* 🔴 THE REVIEWER'S REASON IS THE POINT OF THIS GROUP. It is the only thing
+      <UnstyledButton
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="apps-mine-orphaned-panel"
+        data-testid="apps-mine-orphaned-toggle"
+      >
+        <Group gap={6}>
+          {open ? <IconChevronDown size={16} /> : <IconChevronRight size={16} />}
+          <Text fw={600} size="sm">
+            Submissions without a listing
+          </Text>
+          <Badge variant="light" color="gray" data-testid="apps-mine-orphaned-count">
+            {rows.length}
+          </Badge>
+        </Group>
+      </UnstyledButton>
+      <Collapse in={open}>
+        <Stack gap="xs" id="apps-mine-orphaned-panel" data-testid="apps-mine-orphaned-panel">
+          <Text size="xs" c="dimmed">
+            These apps never got a store listing — a first version that was rejected or withdrawn
+            releases its slug, so there is no app page to show them on.
+          </Text>
+          <Stack gap="xs">
+            {rows.map((r) => (
+              <Paper
+                key={r.id}
+                withBorder
+                p="sm"
+                radius="md"
+                data-testid={`apps-mine-orphaned-row-${r.id}`}
+              >
+                <Group justify="space-between" wrap="wrap" gap="xs">
+                  <Stack gap={2}>
+                    <Text fw={600}>{r.slug}</Text>
+                    <Text size="xs" c="dimmed">
+                      v{r.version} · submitted {formatWhen(r.submittedAt)}
+                    </Text>
+                  </Stack>
+                  <Group gap="xs">
+                    <Badge
+                      variant="outline"
+                      color={historyStatusColor(r.status)}
+                      data-testid={`apps-mine-orphaned-status-${r.id}`}
+                    >
+                      {r.status}
+                    </Badge>
+                    {r.canWithdraw && onWithdraw && withdrawEnabled ? (
+                      <Button
+                        size="compact-xs"
+                        variant="subtle"
+                        color="gray"
+                        disabled={withdrawing}
+                        onClick={() => onWithdraw(r)}
+                        data-testid={`apps-mine-orphaned-withdraw-${r.id}`}
+                      >
+                        Withdraw
+                      </Button>
+                    ) : null}
+                  </Group>
+                </Group>
+                {/* 🔴 THE REVIEWER'S REASON IS THE POINT OF THIS GROUP. It is the only thing
                 on the whole record that tells the developer what to change, and it was
                 unreachable before this section existed. */}
-            {r.rejectionReason ? (
-              <Text size="xs" c="red" mt={6} data-testid={`apps-mine-orphaned-notes-${r.id}`}>
-                {r.rejectionReason}
-              </Text>
-            ) : r.approvalNotes ? (
-              <Text size="xs" c="dimmed" mt={6} data-testid={`apps-mine-orphaned-notes-${r.id}`}>
-                {r.approvalNotes}
-              </Text>
-            ) : null}
-          </Paper>
-        ))}
-      </Stack>
+                {r.rejectionReason ? (
+                  <Text size="xs" c="red" mt={6} data-testid={`apps-mine-orphaned-notes-${r.id}`}>
+                    {r.rejectionReason}
+                  </Text>
+                ) : r.approvalNotes ? (
+                  <Text
+                    size="xs"
+                    c="dimmed"
+                    mt={6}
+                    data-testid={`apps-mine-orphaned-notes-${r.id}`}
+                  >
+                    {r.approvalNotes}
+                  </Text>
+                ) : null}
+              </Paper>
+            ))}
+          </Stack>
+        </Stack>
+      </Collapse>
     </Stack>
   );
 }

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -46,7 +46,7 @@ import {
   ReasonGatedSubmitButton,
   reasonMeetsMin,
 } from '~/components/Apps/ReasonGatedActionModal';
-import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
+import { EMBEDDED_KIND_LABEL, STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import { getOffsiteReviewChecklist } from '~/components/Apps/offsiteReviewChecklist';
 import {
   assetSlotDriftLabel,
@@ -572,8 +572,7 @@ export function OffsiteReviewModalBody({
     <Stack gap="md">
       {isOnsite && (
         <Text size="xs" c="dimmed" data-testid="apps-offsite-onsite-note">
-          Listing media update — the on-site app’s media (icon / cover / screenshots) changed.
-          Content-only review; the media must not exceed the app’s rating.
+          {`Listing media update — the ${EMBEDDED_KIND_LABEL} app’s media (icon / cover / screenshots) changed. Content-only review; the media must not exceed the app’s rating.`}
         </Text>
       )}
       <Group gap="xs">

--- a/src/components/Apps/UnifiedReviewList.browser.test.tsx
+++ b/src/components/Apps/UnifiedReviewList.browser.test.tsx
@@ -74,14 +74,14 @@ function renderList(overrides?: {
 }
 
 describe('UnifiedReviewList — renders both kinds with correct badges', () => {
-  test('both rows render with App / External kind badges', async () => {
+  test('both rows render with App / Standalone kind badges', async () => {
     renderList();
     await expect
       .element(page.getByTestId('apps-unified-review-kind-onsite:or1'))
       .toHaveTextContent('App');
     await expect
       .element(page.getByTestId('apps-unified-review-kind-offsite:fr1'))
-      .toHaveTextContent('External');
+      .toHaveTextContent('Standalone');
     // Both apps' names surface.
     await expect.element(page.getByText('My Onsite App')).toBeInTheDocument();
     await expect.element(page.getByText('My External App')).toBeInTheDocument();

--- a/src/components/Apps/UnifiedReviewList.browser.test.tsx
+++ b/src/components/Apps/UnifiedReviewList.browser.test.tsx
@@ -24,7 +24,7 @@ const ONSITE: OnsiteReviewRequest = {
   submittedAt: '2026-01-01T00:00:00Z', // older → first under asc
   bundleSizeBytes: '10',
   bundleSha256: 'sha',
-  manifest: { name: 'My Onsite App' },
+  manifest: { name: 'Lighthouse' },
   fileSummary: {},
   manifestDiffSummary: {},
   reviewRepoUrl: 'https://forgejo.example/repo',
@@ -39,7 +39,12 @@ const OFFSITE: OffsiteReviewRequest = {
   submittedAt: '2026-02-01T00:00:00Z', // newer → second under asc
   changelog: null,
   appListing: {
-    name: 'My External App',
+    // 🔴 A NEUTRAL NAME, DELIBERATELY. This fixture used to be called 'My External App'
+    // — a listing NAME that spells a retired kind wording, which (a) makes it
+    // indistinguishable from a copy defect to any scanner and (b) is exactly the
+    // fixture shape that can satisfy a kind-badge assertion by accident. Fixture values
+    // must be distinct from every constant an assertion names.
+    name: 'Wayfarer',
     externalUrl: 'https://ex.com',
     category: 'utility',
     contentRating: 'g',
@@ -83,8 +88,8 @@ describe('UnifiedReviewList — renders both kinds with correct badges', () => {
       .element(page.getByTestId('apps-unified-review-kind-offsite:fr1'))
       .toHaveTextContent('Standalone');
     // Both apps' names surface.
-    await expect.element(page.getByText('My Onsite App')).toBeInTheDocument();
-    await expect.element(page.getByText('My External App')).toBeInTheDocument();
+    await expect.element(page.getByText('Lighthouse')).toBeInTheDocument();
+    await expect.element(page.getByText('Wayfarer')).toBeInTheDocument();
   });
 
   test('oldest-first order under direction="asc" (on-site row precedes off-site)', async () => {

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -73,8 +73,12 @@ function offsiteCard(externalUrl: string | null): ListingCard {
 }
 
 describe('getListingBadge', () => {
-  it('on-site → "App"', () => {
-    expect(getListingBadge(onsiteCard({ hasPage: true }))).toEqual({ label: 'App', kind: 'onsite' });
+  // 🔴 PINNED LITERALLY, not derived from the constant it renders — writing
+  // `toBe(EMBEDDED_KIND_LABEL)` would pass for every possible value of that constant.
+  // The word a human reads, typed out. (Was `'App'` before the kind rename: not a
+  // retired wording, just a word that was not the kind's name at all.)
+  it('on-site → "Embedded"', () => {
+    expect(getListingBadge(onsiteCard({ hasPage: true }))).toEqual({ label: 'Embedded', kind: 'onsite' });
   });
   /**
    * 🔴 NEW BEHAVIOUR (not regression coverage): off-site used to badge as

--- a/src/components/Apps/__tests__/appListingDetailRows.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailRows.test.ts
@@ -53,7 +53,9 @@ describe('buildListingDetailRows — order', () => {
   it('labels and values are the display strings, not the raw fields', () => {
     const rows = buildListingDetailRows(detail(), { formatDate: fmt });
     const by = Object.fromEntries(rows.map((r) => [r.key, r]));
-    expect(by.kind).toMatchObject({ label: 'Kind', value: 'On-site app' });
+    // The `… app` form, not the bare word: the noun is what disambiguates "Embedded"
+    // from the `Embedding` model type. See `listingKindLabels`' header.
+    expect(by.kind).toMatchObject({ label: 'Kind', value: 'Embedded app' });
     // 🔴 DISPLAY labels, not the stored enum. The fixture stores `utility` / `pg`.
     expect(by.category).toMatchObject({ label: 'Category', value: 'Utility' });
     expect(by.rating).toMatchObject({ label: 'Rating', value: 'PG' });

--- a/src/components/Apps/__tests__/appListingModerationTableView.test.ts
+++ b/src/components/Apps/__tests__/appListingModerationTableView.test.ts
@@ -103,9 +103,13 @@ describe('action metadata', () => {
     expect(listingModActionLabel('purge')).toBe('Purge');
   });
 
-  it('kind chip distinguishes external vs on-site', () => {
-    expect(listingKindChip('offsite')).toEqual({ label: 'external', color: 'grape' });
-    expect(listingKindChip('onsite')).toEqual({ label: 'on-site', color: 'blue' });
+  // 🔴 THIS CHIP WAS A THIRD, DIVERGENT KIND-LABEL IMPLEMENTATION — lowercase
+  // `'external'` / `'on-site'`, hardcoded, while every other surface said something
+  // else. It now resolves from `listingKindLabels`; the words are pinned literally
+  // here, and the file is enrolled in `standaloneWordingCallSites.test.ts`.
+  it('kind chip distinguishes the two kinds, in the ONE vocabulary', () => {
+    expect(listingKindChip('offsite')).toEqual({ label: 'Standalone', color: 'grape' });
+    expect(listingKindChip('onsite')).toEqual({ label: 'Embedded', color: 'blue' });
   });
 });
 

--- a/src/components/Apps/__tests__/appListingScreenshotViewerWiring.test.ts
+++ b/src/components/Apps/__tests__/appListingScreenshotViewerWiring.test.ts
@@ -324,4 +324,98 @@ describe('🔴 the screenshot viewer is WIRED to the gallery that owns the list'
       ).toMatch(stacked(stackId));
     }
   });
+
+  /**
+   * 🔴 THE SECOND CONSUMER: `/apps/mine`'s ROW MEDIA.
+   *
+   * `MyAppsBody` reuses this same viewer for a row's icon + cover. It is the same class
+   * of seam as the gallery's, for the same reason, and it lives here for the reason
+   * this whole file exists: the browser suite that measures it for real
+   * (`MyAppsBody.browser.test.tsx`) runs only as the preview pipeline's report-only
+   * `preview / component-tests`. A guard that lives only there cannot block a
+   * regression.
+   *
+   * 🔴 THE RELATIONSHIP, not the components. `listingMediaShots` (in the blocking unit
+   * project) decides the ORDER of `[cover, icon]`, and `listingMediaIndex` answers
+   * "where is the one that was clicked". Both are pinned arithmetically in
+   * `myAppsView.test.ts`. What NEITHER of them can see is the page handing the viewer a
+   * list built by one rule and an index computed by another — at which point clicking
+   * the icon opens the cover, every arithmetic test stays green, and nothing errors.
+   * That join is the checkable claim, so it is checked.
+   *
+   * NOT CAUGHT here (and deliberately not claimed): whether the click actually reaches
+   * `openMedia`, or what renders. That is the browser file's job.
+   */
+  it('🔴 /apps/mine feeds the viewer the SAME row list its index is computed from', () => {
+    const MINE = path.resolve(__dirname, '../MyAppsBody.tsx');
+    const src = norm(stripComments(fs.readFileSync(MINE, 'utf8')));
+
+    // Positive controls: the matchers can see their targets, and the stripper is what
+    // stops this file's own prose (which names every one of these bindings verbatim)
+    // from satisfying the gate.
+    expect(norm('<AppListingScreenshotViewer shots={x} />')).toContain(
+      '<AppListingScreenshotViewer'
+    );
+    expect(
+      norm(stripComments('/* <AppListingScreenshotViewer listingMediaShots( */'))
+    ).not.toContain('<AppListingScreenshotViewer');
+
+    const WHY =
+      'MyAppsBody no longer mounts AppListingScreenshotViewer, or no longer builds its ' +
+      '`shots` from `listingMediaShots(mediaRow)` and its `index` from the SAME ' +
+      '`mediaTarget` that `listingMediaIndex` wrote. Those two ARE the shared index ' +
+      'space: a viewer reading a list built any other way opens a different image than ' +
+      'the one that was clicked, and every unit test on the arithmetic stays green ' +
+      'while it does. See `listingMediaShots` in myAppsView.ts.';
+
+    // The seam exists…
+    expect(src, WHY).toContain('<AppListingScreenshotViewer');
+    // …and is fed the row list, not a hand-rolled array.
+    expect(src, WHY).toContain('shots={mediaRow ? listingMediaShots(mediaRow) : []}');
+    // …with the index the OPEN handler wrote, via the paired index function.
+    expect(src, WHY).toContain('index={mediaRow ? mediaTarget?.index ?? null : null}');
+    expect(src, WHY).toContain('const index = listingMediaIndex(row, which);');
+
+    // 🔴 AND THE CLICK TARGET IS A REAL BUTTON, not an `<img onClick>` — the same rule
+    // the screenshot tile follows two tests up, applied to this consumer. An image with
+    // a click handler is not tab-reachable, not Enter/Space-activatable, and exposes no
+    // accessible name.
+    const BTN =
+      "MyAppsBody's row media is no longer a real button (UnstyledButton with an " +
+      'aria-label). An <img onClick> renders as a mouse-only affordance that LOOKS ' +
+      'wired up. See MediaButton.';
+    const btn = norm(fnBody(stripComments(fs.readFileSync(MINE, 'utf8')), 'MediaButton'));
+    expect(btn, BTN).not.toBe('');
+    expect(btn, BTN).toContain('<UnstyledButton');
+    expect(btn, BTN).toContain('onClick={onOpen}');
+    expect(btn, BTN).toContain('aria-label={label}');
+    // The handler belongs to the button, and the image is only its child.
+    expect(src, BTN).not.toContain('<img onClick');
+
+    /**
+     * 🔴 THE PLACEHOLDER MUST STAY INERT, and this is the half that is easy to lose in
+     * a refactor that "simplifies" the two branches into one wrapper. Asserted on the
+     * FUNCTION BODIES: the early `if (!row.iconUrl) return (<div …>)` / `if
+     * (!row.coverUrl)` must come BEFORE anything that mounts a MediaButton, so the
+     * no-image path cannot reach it.
+     */
+    const stripped = stripComments(fs.readFileSync(MINE, 'utf8'));
+    for (const [fn, guard] of [
+      ['ListingIcon', 'if (!row.iconUrl)'],
+      ['ListingCover', 'if (!row.coverUrl)'],
+    ] as const) {
+      const body = norm(fnBody(stripped, fn));
+      const WHY_PH =
+        `${fn} no longer returns its placeholder BEFORE reaching MediaButton. A ` +
+        `placeholder wrapped in a button is a focusable control that opens an empty ` +
+        `viewer — a dead tab stop on nearly every row of this table (measured: all 11 ` +
+        `removed listings have a null cover).`;
+      expect(body, WHY_PH).not.toBe('');
+      expect(body, WHY_PH).toContain(guard);
+      const guardAt = body.indexOf(guard);
+      const buttonAt = body.indexOf('<MediaButton');
+      expect(buttonAt, WHY_PH).toBeGreaterThan(-1);
+      expect(guardAt, WHY_PH).toBeLessThan(buttonAt);
+    }
+  });
 });

--- a/src/components/Apps/__tests__/myAppsView.test.ts
+++ b/src/components/Apps/__tests__/myAppsView.test.ts
@@ -3,9 +3,13 @@ import { describe, expect, it } from 'vitest';
 import {
   INACTIVE_LISTING_STATUSES,
   INACTIVE_PAGE_SIZE,
+  isActionableOrphan,
   isInactiveListing,
+  listingMediaIndex,
+  listingMediaShots,
   MY_APPS_CONTAINER_SIZE,
   myAppListingHref,
+  orphanGroupStartsOpen,
   pageCount,
   pageSlice,
   partitionMyAppRows,
@@ -262,5 +266,200 @@ describe('MY_APPS_CONTAINER_SIZE', () => {
     // The page went from a single-column card list to a two-image table when it absorbed
     // /apps/my-submissions; 1100 is the width that made the old submissions table clip.
     expect(MY_APPS_CONTAINER_SIZE).toBeGreaterThan(1100);
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * The row's two images, as ONE viewer list
+ * ------------------------------------------------------------------ */
+
+/**
+ * 🔴 THESE TWO FUNCTIONS ARE A PAIR, AND THE PAIRING IS WHAT IS PINNED.
+ *
+ * `listingMediaShots` decides the ORDER; `listingMediaIndex` answers "where is the one
+ * that was clicked". A disagreement between them opens the WRONG picture — the icon's
+ * click landing on the cover — and nothing errors, nothing looks broken, and no
+ * rendering test that only checks "a viewer opened" can see it. So every case below
+ * asserts the two against each other, not just each on its own.
+ */
+describe('listingMediaShots / listingMediaIndex — the row media viewer list', () => {
+  const media = (
+    name: string,
+    coverUrl: string | null,
+    iconUrl: string | null
+  ): { name: string; coverUrl: string | null; iconUrl: string | null } => ({
+    name,
+    coverUrl,
+    iconUrl,
+  });
+
+  it('COVER FIRST, then the icon — both present', () => {
+    // Pairwise-distinct urls and a name that appears in neither, so a mutant returning
+    // the wrong url (or the same url twice) cannot pass by coincidence.
+    const row = media('Zephyr', 'https://cdn/cover-a.png', 'https://cdn/icon-b.png');
+    expect(listingMediaShots(row)).toEqual([
+      { url: 'https://cdn/cover-a.png', caption: 'Zephyr cover image' },
+      { url: 'https://cdn/icon-b.png', caption: 'Zephyr icon' },
+    ]);
+    expect(listingMediaIndex(row, 'cover')).toBe(0);
+    expect(listingMediaIndex(row, 'icon')).toBe(1);
+  });
+
+  it('🔴 the icon SHIFTS TO 0 when there is no cover — the index is positional', () => {
+    const row = media('Quill', null, 'https://cdn/icon-c.png');
+    expect(listingMediaShots(row)).toEqual([
+      { url: 'https://cdn/icon-c.png', caption: 'Quill icon' },
+    ]);
+    // The whole reason the index is computed rather than assumed: with the cover gone,
+    // the icon is entry 0, and an implementation that returned a fixed 1 would open a
+    // viewer on an index that does not exist.
+    expect(listingMediaIndex(row, 'icon')).toBe(0);
+    expect(listingMediaIndex(row, 'cover')).toBeNull();
+  });
+
+  it('a cover with no icon keeps the cover at 0', () => {
+    const row = media('Harbor', 'https://cdn/cover-d.png', null);
+    expect(listingMediaShots(row)).toEqual([
+      { url: 'https://cdn/cover-d.png', caption: 'Harbor cover image' },
+    ]);
+    expect(listingMediaIndex(row, 'cover')).toBe(0);
+    expect(listingMediaIndex(row, 'icon')).toBeNull();
+  });
+
+  it('🔴 neither image → an EMPTY list and null for both, so nothing is clickable', () => {
+    const row = media('Vellum', null, null);
+    expect(listingMediaShots(row)).toEqual([]);
+    expect(listingMediaIndex(row, 'cover')).toBeNull();
+    expect(listingMediaIndex(row, 'icon')).toBeNull();
+  });
+
+  /**
+   * 🔴 THE CASE A `findIndex(s => s.url === url)` IMPLEMENTATION GETS WRONG. When a
+   * listing's icon and cover are the SAME url, a url lookup collapses both to entry 0,
+   * so clicking the icon opens the cover — and because the pixels are identical, it
+   * looks correct. Only the position can tell them apart.
+   */
+  it('🔴 identical icon and cover urls are still TWO distinct positions', () => {
+    const same = 'https://cdn/same-image.png';
+    const row = media('Twin', same, same);
+    expect(listingMediaShots(row)).toHaveLength(2);
+    expect(listingMediaIndex(row, 'cover')).toBe(0);
+    expect(listingMediaIndex(row, 'icon')).toBe(1);
+  });
+
+  it('every returned index really addresses an entry in the list it is paired with', () => {
+    // The relationship, quantified over every media shape rather than the four above.
+    for (const cover of ['https://cdn/c.png', null]) {
+      for (const icon of ['https://cdn/i.png', null]) {
+        const row = media('Atlas', cover, icon);
+        const shots = listingMediaShots(row);
+        for (const which of ['cover', 'icon'] as const) {
+          const idx = listingMediaIndex(row, which);
+          const url = which === 'cover' ? cover : icon;
+          if (url === null) {
+            expect(idx, `${which} absent → null`).toBeNull();
+          } else {
+            expect(idx, `${which} present → an index`).not.toBeNull();
+            expect(shots[idx as number]?.url, `${which} @ ${idx}`).toBe(url);
+          }
+        }
+      }
+    }
+  });
+
+  it('every caption is non-empty — the viewer uses it as the image accessible name', () => {
+    // `AppListingScreenshotViewer` sets `alt=""` whenever a caption is present (the
+    // caption renders as visible text beside the image), so an empty caption would
+    // leave the image unnamed rather than merely uncaptioned.
+    const shots = listingMediaShots(media('Ridge', 'https://cdn/c.png', 'https://cdn/i.png'));
+    for (const s of shots) {
+      expect(s.caption ?? '').not.toBe('');
+      expect(s.caption).toContain('Ridge');
+    }
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * Which orphaned submissions are ACTIONABLE
+ * ------------------------------------------------------------------ */
+
+/**
+ * 🔴 THIS PREDICATE IS THE ONLY THING CARRYING FORWARD A MEASURED GUARANTEE. The
+ * "Submissions without a listing" group is now collapsible; before, it was
+ * unconditionally visible because it is the ONLY surface showing a rejection reason and
+ * the "your app was rejected" notification deep-links to this page (production
+ * 2026-08-20: 3 of 3 rejected and 27 of 33 withdrawn on-site requests were otherwise
+ * unreachable). Collapsing it is only safe because this returns `true` for exactly the
+ * rows those reasons are about. A mutant that narrows it re-hides a rejection.
+ */
+describe('isActionableOrphan / orphanGroupStartsOpen', () => {
+  const orphan = (over: Partial<Parameters<typeof isActionableOrphan>[0]> = {}) => ({
+    status: 'approved',
+    rejectionReason: null,
+    canWithdraw: false,
+    ...over,
+  });
+
+  it('🔴 a REJECTION REASON is actionable — it is the only text saying what to fix', () => {
+    expect(
+      isActionableOrphan(orphan({ status: 'rejected', rejectionReason: 'scope never used' }))
+    ).toBe(true);
+  });
+
+  it('🔴 a rejection reason is actionable on ANY status, not only `rejected`', () => {
+    // The reason is the signal, not the status word — a withdrawn request that was
+    // reviewed first still carries the reviewer's note, and it is still the only copy.
+    expect(
+      isActionableOrphan(orphan({ status: 'withdrawn', rejectionReason: 'missing icon' }))
+    ).toBe(true);
+  });
+
+  it('🔴 PENDING + the server says withdrawable → actionable (a decision still open)', () => {
+    expect(isActionableOrphan(orphan({ status: 'pending', canWithdraw: true }))).toBe(true);
+  });
+
+  it('🔴 BOTH halves of the pending rule are required', () => {
+    // pending but NOT withdrawable — the server's own refusal, mirrored. Offering the
+    // group open here would promise an action that 403s.
+    expect(isActionableOrphan(orphan({ status: 'pending', canWithdraw: false }))).toBe(false);
+    // withdrawable-looking but NOT pending — a decided request cannot be withdrawn.
+    expect(isActionableOrphan(orphan({ status: 'approved', canWithdraw: true }))).toBe(false);
+    expect(isActionableOrphan(orphan({ status: 'rejected', canWithdraw: true }))).toBe(false);
+  });
+
+  it('an ABSENT canWithdraw is read as false — the safe direction', () => {
+    const { canWithdraw: _drop, ...noFlag } = orphan({ status: 'pending' });
+    expect(isActionableOrphan(noFlag)).toBe(false);
+  });
+
+  it('🔴 a WHITESPACE-ONLY reason is not a reason', () => {
+    // `rejectionReason: ' '` renders as an empty red line. Treating it as actionable
+    // would open the group on nothing at all.
+    expect(isActionableOrphan(orphan({ status: 'rejected', rejectionReason: '   ' }))).toBe(false);
+    expect(isActionableOrphan(orphan({ status: 'rejected', rejectionReason: '' }))).toBe(false);
+  });
+
+  it('settled history is NOT actionable', () => {
+    expect(isActionableOrphan(orphan({ status: 'withdrawn' }))).toBe(false);
+    expect(isActionableOrphan(orphan({ status: 'approved' }))).toBe(false);
+    expect(isActionableOrphan(orphan({ status: 'rejected' }))).toBe(false);
+  });
+
+  it('🔴 the group opens if ANY row is actionable, not only the first', () => {
+    // A `rows[0]`-only mutant passes a one-row fixture and every "first row" fixture.
+    // The actionable row is LAST here, behind two settled ones.
+    const rows = [
+      orphan({ status: 'withdrawn' }),
+      orphan({ status: 'approved' }),
+      orphan({ status: 'pending', canWithdraw: true }),
+    ];
+    expect(orphanGroupStartsOpen(rows)).toBe(true);
+  });
+
+  it('all-settled → CLOSED, and an empty list → CLOSED', () => {
+    expect(
+      orphanGroupStartsOpen([orphan({ status: 'withdrawn' }), orphan({ status: 'approved' })])
+    ).toBe(false);
+    expect(orphanGroupStartsOpen([])).toBe(false);
   });
 });

--- a/src/components/Apps/__tests__/standaloneWordingCallSites.test.ts
+++ b/src/components/Apps/__tests__/standaloneWordingCallSites.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 import {
+  EMBEDDED_KIND_LABEL,
   LISTING_KIND_APP_LABELS,
   LISTING_KIND_LABELS,
   STANDALONE_KIND_LABEL,
@@ -69,24 +70,68 @@ const SRC = path.resolve(__dirname, '../../..');
 const SCAN_ROOTS = ['components/Apps', 'components/AppBlocks', 'pages/apps'];
 
 /**
- * The retired wordings, as WHOLE PHRASES.
+ * The retired wordings.
  *
- * 🔴 Deliberately NOT a bare `offsite` / `external`. `'offsite'` is a stored VALUE
- * (the Prisma column, the REST enum, the `StoreListingKind` union) and appears in
- * hundreds of legitimate places; a rule that matched it would either be allowlisted
- * into uselessness or would push someone into renaming the value to satisfy it —
- * which is the one outcome rule (4) exists to prevent. Every phrase below is
- * unambiguously prose: none of them is, or can be, a value.
+ * 🔴 Deliberately NOT a bare `offsite` / lowercase `external`. `'offsite'` is a stored
+ * VALUE (the Prisma column, the REST enum, the `StoreListingKind` union) and appears in
+ * hundreds of legitimate places; lowercase `'external'` is likewise the `SubmitMode` id,
+ * a testid fragment and a glyph key. A rule that matched either would be allowlisted
+ * into uselessness, or would push someone into renaming the value to satisfy it — the
+ * one outcome rule (4) exists to prevent.
+ *
+ * 🔴 THE PHRASE-ONLY VERSION OF THIS LIST WAS TOO NARROW, MEASURED. It held only
+ * `external app` / `off-site` / `offsite app`, so a surface rendering the kind as a
+ * BARE one-word label was invisible to it. Two live instances survived the whole #4247
+ * sweep that way: `myAppsView.listingKindLabel` (a shadowing duplicate returning
+ * `'On-site' | 'External'`, which is what `/apps/mine` actually rendered) and
+ * `unifiedReviewRow`'s `badge: 'External'` on the moderator queue. Both spelled a
+ * retired word in a string no phrase pattern could match. So the list now also carries:
+ *
+ *   - `/^\s*External\s*$/` — CASE-SENSITIVE and WHOLE-STRING. Capital-E `External`
+ *     standing alone is only ever a rendered label; lowercase `external` is a value
+ *     (see above), and `External` inside a longer phrase ("External site", the heading
+ *     over an outbound URL on the public listing page) is ordinary English about a
+ *     website rather than the kind's name. This is the same case-based discriminator
+ *     {@link KIND_LABEL_WORD} already uses for `Standalone` vs `standalone`.
+ *   - `/\bon-site\b/i` — HYPHENATED, anywhere, either case. The hyphen is what makes
+ *     this safe to match as a substring: the stored values are `onsite` / `offsite`
+ *     with NO hyphen, so a hyphenated `on-site` can only ever be copy. That is the
+ *     identical reasoning behind the pre-existing `/off-site/i`, which has always been
+ *     a substring rule for the same reason.
+ *
+ * 🔴 WHAT THIS STILL DOES NOT COVER, stated rather than implied: a retired word inside
+ * a longer phrase that is not one of the four patterns — `"External-link submissions"`
+ * on the moderator queue is the live example. Widening to catch it would also catch
+ * `"External site"`, and there is no mechanical rule separating the two. It is left
+ * uncaught deliberately; the ledger's claim is bare LABELS plus the four phrases.
  */
-const RETIRED_WORDINGS: RegExp[] = [/external app/i, /off-site/i, /offsite app/i];
+const RETIRED_WORDINGS: RegExp[] = [
+  /external app/i,
+  /off-site/i,
+  /offsite app/i,
+  /^\s*External\s*$/,
+  /\bon-site\b/i,
+];
 
 /**
- * The kind label as a human reads it. Capital-S `Standalone` as a whole word is the
- * kind's NAME; lowercase `standalone` is an ordinary English adverb/adjective and is
- * deliberately NOT matched — see ALLOWED_LOWERCASE_PROSE for why that distinction is
- * load-bearing rather than lazy.
+ * The kind labels as a human reads them. Capital-S `Standalone` / capital-E `Embedded`
+ * as whole words are the kinds' NAMES; lowercase `standalone` is an ordinary English
+ * adverb/adjective and is deliberately NOT matched — see ALLOWED_LOWERCASE_PROSE for
+ * why that distinction is load-bearing rather than lazy.
+ *
+ * 🔴 `Embedded` JOINED THIS RULE WITH THE RENAME, so the on-site label gets the same
+ * GROWS protection the off-site one has always had — otherwise a new surface could
+ * hardcode `'Embedded'` and no rule in this file would see it (it is the CORRECT word,
+ * so the retired-wording rule cannot, and it is not enrolled, so the SHRINKS rules
+ * cannot either). Measured before adding it: `Embedded` appeared in **0** user-facing
+ * strings across the scan roots, so this pins a clean floor rather than grandfathering.
+ *
+ * 🔴 `\bEmbedded\b` DOES NOT MATCH `Embedding`, and that is the whole point of the
+ * word-boundary form. `AppSettingsModal`'s `MODEL_TYPE_OPTIONS` renders `'Embedding'`
+ * for `ModelType.TextualInversion` — the collision the rename was once deferred over.
+ * That model-type label is NOT renamed and must stay matchable by nothing here.
  */
-const KIND_LABEL_WORD = /\bStandalone\b/;
+const KIND_LABEL_WORD = /\bStandalone\b|\bEmbedded\b/;
 
 /**
  * 🔴 WHY LOWERCASE `standalone` IS OUT OF SCOPE, recorded so nobody "tightens" this
@@ -141,6 +186,37 @@ const ENROLLED: Record<string, string> = {
   'components/Apps/appListingCardView.ts': 'store card kind badge label',
   'components/Apps/appListingDetailRows.ts': 'listing detail "Kind" row',
   'components/Apps/OffsiteReviewQueue.tsx': 'moderator queue + reports section headings',
+  // 🔴 THE FIVE THE WIDENED RETIRED-WORDING RULE FOUND (PR A). Every one rendered a
+  // BARE one-word kind label, which the phrase-only rule structurally could not see —
+  // see the note on RETIRED_WORDINGS. Four of them were spelling a RETIRED word in
+  // production; the fifth (`appListingCardView`'s onsite branch, `'App'`) was spelling
+  // a word that is not the kind's name at all.
+  'components/Apps/unifiedReviewRow.ts': 'moderator queue kind-column badge',
+  'components/Apps/AppListingsModerationTable.tsx': 'moderation table kind SegmentedControl',
+  'components/Apps/appListingModerationTableView.ts': 'moderation table per-row kind chip',
+  'pages/apps/mine.tsx': '/apps/mine page subtitle naming both kinds',
+  'pages/apps/review.tsx': '/apps/review page subtitle naming both kinds',
+};
+
+/**
+ * 🔴 `components/Apps/MyAppsBody.tsx` AND `components/Apps/myAppsView.ts` ARE
+ * DELIBERATELY ABSENT FROM {@link ENROLLED}, and the absence is a decision, not an
+ * oversight.
+ *
+ * `/apps/mine` no longer renders a kind AT ALL — the row's kind badge was deleted (the
+ * author knows what they built; the kind lives on the listing detail and edit pages).
+ * Enrolling a surface asserts it RESOLVES the word from the one source, which is only a
+ * meaningful claim about a surface that renders one; enrolling a page that renders none
+ * would make the SHRINKS rules pass on an import kept alive for nothing.
+ *
+ * The absence is pinned where it can actually be observed — `MyAppsBody.browser.test.tsx`
+ * asserts no row shape emits the kind-badge testid — so restoring the badge is a visible
+ * change rather than a silent one. `myAppsView.ts`'s own shadowing `listingKindLabel` is
+ * DELETED (see that file's header); it is not re-pointed at the canonical module.
+ */
+const DELIBERATELY_UNENROLLED: Record<string, string> = {
+  'components/Apps/MyAppsBody.tsx': '/apps/mine renders no kind label at all — badge deleted',
+  'components/Apps/myAppsView.ts': 'the shadowing listingKindLabel was deleted, not re-pointed',
 };
 
 /** The one module allowed to spell the word as a literal. */
@@ -216,6 +292,31 @@ function findHardcodedKindLabel(fileName: string, text: string): string[] {
   );
 }
 
+/**
+ * Does this source REALLY import the one label module?
+ *
+ * 🔴 AN AST WALK, NOT `raw.includes(LABEL_SOURCE_IMPORT)`, AND THE SUBSTRING FORM WAS
+ * MEASURABLY WRONG — it counted a mention of the module path in a COMMENT as an import.
+ * That is the same defect the whole file avoids for retired wordings (see
+ * `userFacingStrings`), reappearing in the enrolment half: every file here discusses
+ * this module in prose, so a surface could revert to a hardcoded literal, keep one
+ * sentence of docstring naming the module, and satisfy the SHRINKS rule while importing
+ * nothing. Found by dogfooding — the deliberately-unenrolled check below went red on a
+ * file whose only occurrence of the path was in its own explanatory header.
+ *
+ * ONE predicate, used by BOTH the SHRINKS rule and the unenrolled rule, so the two
+ * cannot drift apart and disagree about what "enrolled" means.
+ */
+function importsLabelSource(fileName: string, text: string): boolean {
+  const sf = parseTsx(fileName, text);
+  return sf.statements.some(
+    (st) =>
+      ts.isImportDeclaration(st) &&
+      ts.isStringLiteral(st.moduleSpecifier) &&
+      st.moduleSpecifier.text === LABEL_SOURCE_IMPORT
+  );
+}
+
 // ---------------------------------------------------------------------------
 // 🔴 VALIDATE THE INSTRUMENT BEFORE READING ITS VERDICT.
 //
@@ -229,6 +330,7 @@ describe('🔴 the scanner (negative + positive controls)', () => {
       export function S() {
         const heading = 'List an external app';
         const sub = \`a pending off-site listing for \${name}\`;
+        const chip = { label: 'External', value: 'offsite' };
         return (
           <div>
             <Badge title="External App">On-site and external</Badge>
@@ -238,10 +340,58 @@ describe('🔴 the scanner (negative + positive controls)', () => {
         );
       }`;
     const hits = findRetiredWording('bad.tsx', bad);
-    // 'external app', 'off-site', 'External App', 'offsite app', 'Off-Site' = 5.
-    // (The JSX text "On-site and external" is NOT a hit — "external" alone is not a
-    // banned phrase, which is exactly the narrowness the rule needs to stay usable.)
-    expect(hits).toHaveLength(5);
+    // 'external app', 'off-site', bare 'External', 'External App', the JSX text
+    // "On-site and external", 'offsite app', 'Off-Site' = 7.
+    //
+    // 🔴 THE LAST TWO ARE THE WIDENING, AND THIS COMMENT USED TO ASSERT THE OPPOSITE.
+    // It read: `the JSX text "On-site and external" is NOT a hit — "external" alone is
+    // not a banned phrase`. True of the phrase rule, and precisely the narrowness that
+    // let `/apps/mine` and `unifiedReviewRow` render a BARE retired label undetected.
+    // A bare capital-E `External` and a hyphenated `on-site` are hits now.
+    expect(hits).toHaveLength(7);
+  });
+
+  /**
+   * 🔴 THE TWO NEW RULES, EXERCISED AGAINST THE FORMS THEY MUST **NOT** MATCH. Each is
+   * a narrowness claim made in the RETIRED_WORDINGS docblock, driven through the
+   * scanner rather than asserted in prose.
+   */
+  it('POSITIVE + NEGATIVE CONTROL: bare `External` and hyphenated `on-site`', () => {
+    // Hits: the bare label in every render shape a label takes.
+    const bareLabels = `
+      export function S() {
+        const a = [{ value: 'offsite', label: 'External' }];
+        return (
+          <div>
+            <Badge>External</Badge>
+            <Text title="On-site" />
+            <Alert label={'On-site app'} />
+          </div>
+        );
+      }`;
+    expect(findRetiredWording('bare.tsx', bareLabels)).toHaveLength(4);
+
+    // 🔴 MISSES: lowercase `external` is the `SubmitMode` id, a testid fragment and a
+    // glyph key — matching it would force a VALUE rename, which rule (4) forbids.
+    // And `External` inside a phrase is ordinary English about a website.
+    const notLabels = `
+      export function S({ mode }: { mode: string }) {
+        onSelect('external');
+        const t = 'apps-submit-mode-card-external';
+        return (
+          <div data-testid={t}>
+            <Title>External site</Title>
+            <Text>Open external site</Text>
+            <Text>Update your external-link app.</Text>
+          </div>
+        );
+      }`;
+    expect(findRetiredWording('notlabels.tsx', notLabels)).toEqual([]);
+
+    // 🔴 AND THE UNHYPHENATED STORED VALUES SURVIVE — `onsite` is a value, `on-site`
+    // is copy, and only the hyphen separates them.
+    const values = `export const k = { a: 'onsite', b: 'offsite' };`;
+    expect(findRetiredWording('values.tsx', values)).toEqual([]);
   });
 
   it('POSITIVE CONTROL: it FINDS a hardcoded kind label in every render shape', () => {
@@ -253,10 +403,28 @@ describe('🔴 the scanner (negative + positive controls)', () => {
             <Badge>Standalone</Badge>
             <Text title="Standalone app" />
             <Text>{\`a pending Standalone submission\`}</Text>
+            <Badge>Embedded</Badge>
+            <Text title="Embedded app" />
           </div>
         );
       }`;
-    expect(findHardcodedKindLabel('bad.tsx', bad)).toHaveLength(4);
+    expect(findHardcodedKindLabel('bad.tsx', bad)).toHaveLength(6);
+  });
+
+  /**
+   * 🔴 THE COLLISION THE RENAME WAS ONCE DEFERRED OVER, AS A NEGATIVE CONTROL. If
+   * `KIND_LABEL_WORD` is ever loosened to a stem (`/Embedd/`, `/\bEmbed/`), this goes
+   * red — and it must, because `'Embedding'` is `ModelType.TextualInversion`'s public
+   * label in `AppSettingsModal`, not a listing kind, and is deliberately unrenamed.
+   */
+  it('NEGATIVE CONTROL: the model-type label `Embedding` is NOT the kind label', () => {
+    const modelTypes = `
+      const MODEL_TYPE_OPTIONS = [
+        { value: ModelType.TextualInversion, label: 'Embedding' },
+        { value: ModelType.LORA, label: 'LoRA' },
+      ];`;
+    expect(findHardcodedKindLabel('modeltypes.tsx', modelTypes)).toEqual([]);
+    expect(findRetiredWording('modeltypes.tsx', modelTypes)).toEqual([]);
   });
 
   it('NEGATIVE CONTROL: the ENROLLED form is not flagged', () => {
@@ -367,7 +535,7 @@ describe('🔒 the App-store kind label has ONE source', () => {
   it('🔴 SHRINKS: every enrolled surface resolves the label from the ONE source', () => {
     const unenrolled = Object.keys(ENROLLED).filter((rel) => {
       const raw = fs.readFileSync(path.join(SRC, rel), 'utf8');
-      return !raw.includes(LABEL_SOURCE_IMPORT);
+      return !importsLabelSource(rel, raw);
     });
     expect(unenrolled).toEqual([]);
   });
@@ -394,6 +562,34 @@ describe('🔒 the App-store kind label has ONE source', () => {
       expect(reason.length).toBeGreaterThan(10);
     }
   });
+
+  /**
+   * 🔴 THE DELIBERATE NON-ENROLMENTS ARE ASSERTED, NOT ASSUMED. A file that is simply
+   * missing from {@link ENROLLED} and a file that is missing ON PURPOSE look identical
+   * from here, and the second one needs a reason on the record — otherwise "just add it
+   * to ENROLLED" is the obvious-looking fix for a red that should never happen.
+   *
+   * The claim: each of these files exists, is scanned, and holds NO kind label at all —
+   * neither a hardcoded one nor an import of the source module. A surface that starts
+   * rendering the kind again fails here and has to make a decision.
+   */
+  it('🔴 the deliberately-unenrolled surfaces render NO kind label at all', () => {
+    const rels = SCANNED.map((s) => s.rel);
+    for (const [rel, reason] of Object.entries(DELIBERATELY_UNENROLLED)) {
+      expect(reason.length).toBeGreaterThan(10);
+      expect(rel in ENROLLED, `${rel} is in BOTH lists — pick one`).toBe(false);
+      expect(rels, `${rel} is no longer scanned`).toContain(rel);
+      const raw = fs.readFileSync(path.join(SRC, rel), 'utf8');
+      expect(findHardcodedKindLabel(rel, raw), `${rel}: ${reason}`).toEqual([]);
+      expect(findRetiredWording(rel, raw), `${rel}: ${reason}`).toEqual([]);
+      expect(
+        importsLabelSource(rel, raw),
+        `${rel} imports the kind-label source again. ${reason} — if it now renders a ` +
+          `kind, move it to ENROLLED and delete its entry here; if the import is dead, ` +
+          `remove the import.`
+      ).toBe(false);
+    }
+  });
 });
 
 describe('🔒 the label constants, pinned as WHOLE normalised strings', () => {
@@ -404,27 +600,50 @@ describe('🔒 the label constants, pinned as WHOLE normalised strings', () => {
    * a human reads them, typed out.
    */
   it('the kind labels are exactly these words', () => {
-    expect(LISTING_KIND_LABELS).toEqual({ onsite: 'On-site', offsite: 'Standalone' });
+    expect(LISTING_KIND_LABELS).toEqual({ onsite: 'Embedded', offsite: 'Standalone' });
     expect(LISTING_KIND_APP_LABELS).toEqual({
-      onsite: 'On-site app',
+      onsite: 'Embedded app',
       offsite: 'Standalone app',
     });
     expect(STANDALONE_KIND_LABEL).toBe('Standalone');
+    expect(EMBEDDED_KIND_LABEL).toBe('Embedded');
     expect(listingKindLabel('offsite')).toBe('Standalone');
-    expect(listingKindLabel('onsite')).toBe('On-site');
+    expect(listingKindLabel('onsite')).toBe('Embedded');
     expect(listingKindAppLabel('offsite')).toBe('Standalone app');
-    expect(listingKindAppLabel('onsite')).toBe('On-site app');
+    expect(listingKindAppLabel('onsite')).toBe('Embedded app');
   });
 
   /**
-   * 🔴 "On-site" IS DELIBERATELY UNCHANGED. Renaming it to "Embedded" was considered
-   * and deferred — "Embedded" collides with "Embedding" (TextualInversion) one panel
-   * away in `AppSettingsModal`. This pins the deferral so it is a decision, not drift.
+   * 🔴 THE DEFERRAL WAS LIFTED ON PURPOSE — AND THIS TEST IS THE INVERSE OF WHAT IT
+   * USED TO BE.
+   *
+   * It previously read `expect(LISTING_KIND_LABELS.onsite).not.toContain('Embedded')`,
+   * pinning a decision to DEFER the "On-site" → "Embedded" rename because "Embedded"
+   * reads close to "Embedding" (`ModelType.TextualInversion`) in `AppSettingsModal`.
+   * That deferral is reversed by an explicit product decision, so the assertion is
+   * inverted rather than deleted: the rename stays a recorded DECISION in both
+   * directions, and a future revert to "On-site" fails HERE with this comment attached
+   * instead of reading as ordinary copy drift.
+   *
+   * 🔴 THE COLLISION SURVIVES, AND ITS MITIGATION IS PINNED TOO. `'Embedding'` is NOT
+   * renamed — it names a real model type with its own public vocabulary — so the rule
+   * is that a kind label rendered near a model-type list uses the `… app` form, whose
+   * noun disambiguates. That is why `LISTING_KIND_APP_LABELS.onsite` must keep the
+   * suffix rather than collapsing to the bare word.
    */
-  it('the on-site label was NOT reworded', () => {
-    expect(LISTING_KIND_LABELS.onsite).toBe('On-site');
-    expect(LISTING_KIND_LABELS.onsite).not.toContain('Embedded');
-    expect(LISTING_KIND_APP_LABELS.onsite).not.toContain('Embedded');
+  it('🔴 the on-site label WAS reworded to "Embedded" — a decision, not drift', () => {
+    expect(LISTING_KIND_LABELS.onsite).toBe('Embedded');
+    expect(LISTING_KIND_LABELS.onsite).toContain('Embedded');
+    expect(LISTING_KIND_APP_LABELS.onsite).toContain('Embedded');
+    // The retired word is GONE from both forms — the half a rename most often forgets.
+    expect(LISTING_KIND_LABELS.onsite).not.toContain('On-site');
+    expect(LISTING_KIND_APP_LABELS.onsite).not.toContain('On-site');
+    // …and the disambiguating noun survives, because the `Embedding` collision does.
+    expect(LISTING_KIND_APP_LABELS.onsite).toBe('Embedded app');
+    // The model-type label it collides with is NOT this module's to rename, and the
+    // guard above must not match it: `\bEmbedded\b` is not `Embedding`.
+    expect(KIND_LABEL_WORD.test('Embedding')).toBe(false);
+    expect(KIND_LABEL_WORD.test('Embedded')).toBe(true);
   });
 
   it('every kind in the closed set has a label (no kind can render undefined)', () => {

--- a/src/components/Apps/__tests__/standaloneWordingCallSites.test.ts
+++ b/src/components/Apps/__tests__/standaloneWordingCallSites.test.ts
@@ -70,6 +70,31 @@ const SRC = path.resolve(__dirname, '../../..');
 const SCAN_ROOTS = ['components/Apps', 'components/AppBlocks', 'pages/apps'];
 
 /**
+ * 🔴 THE ROOTS FOR THE **TEST** SWEEP, AND WHY THEY ARE A SEPARATE LIST.
+ *
+ * `SCAN_ROOTS` above walks PRODUCTION files only — `walk()` excludes `*.test.ts(x)` /
+ * `*.browser.test.ts(x)` by construction. That exclusion is correct for the enrolment
+ * rules (a test SHOULD pin a label as a literal; deriving the expectation from the
+ * constant is the vacuous-test failure this repo bans), but it left a hole the size of
+ * a directory: **a test asserting a RETIRED wording is on screen was invisible to every
+ * rule in this file.**
+ *
+ * 🔴 MEASURED, NOT HYPOTHETICAL. `src/tests/pages/apps/invites-transfer-blocked.browser
+ * .test.tsx` asserted `toHaveTextContent(/On-site app/i)`. The kind rename made that
+ * assertion false, every rule here stayed green, the whole `unit` tier stayed green, and
+ * the only thing that caught it was the preview pipeline's `component-tests` job — which
+ * is report-only, runs 187 files (not the App-store subset), and is the tier a local
+ * `vitest src/components/Apps` run cannot see. Note the shape: this file's docblock
+ * claims rule (1) fails "when the set GROWS", and for `src/tests/**` it could not. A
+ * guard narrower than its own description reads as coverage while providing none.
+ *
+ * `src/tests` is the page-level suite (it is NOT reached by `SCAN_ROOTS`, which are all
+ * under `src/components` and `src/pages`), and the App-store component tests sit beside
+ * their components, so both are listed.
+ */
+const TEST_SCAN_ROOTS = ['tests', 'components/Apps', 'components/AppBlocks', 'pages/apps'];
+
+/**
  * The retired wordings.
  *
  * 🔴 Deliberately NOT a bare `offsite` / lowercase `external`. `'offsite'` is a stored
@@ -239,6 +264,17 @@ function walk(dir: string, out: string[] = []): string[] {
   return out;
 }
 
+/** The MIRROR of {@link walk}: test files ONLY. See {@link TEST_SCAN_ROOTS}. */
+function walkTests(dir: string, out: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkTests(full, out);
+    else if (/\.(test|browser\.test)\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
 /**
  * Every string a HUMAN could read in this source, as `{ line, text }`.
  *
@@ -290,6 +326,106 @@ function findHardcodedKindLabel(fileName: string, text: string): string[] {
   return userFacingStrings(fileName, text).flatMap(({ line, text: s }) =>
     KIND_LABEL_WORD.test(s) ? [String(line)] : []
   );
+}
+
+/**
+ * 🔴 TEXT A TEST ASSERTS IS **ON SCREEN** — not a test title, not fixture data.
+ *
+ * This is the whole reason the test sweep is a separate extractor rather than
+ * `userFacingStrings` pointed at a wider root. Measured over the 286 test files in
+ * `TEST_SCAN_ROOTS`, the naive version produced **7** retired-wording hits of which
+ * **6 were noise**: five were `test(...)` / `describe(...)` TITLES naming the SCENARIO
+ * ("🔴 an ON-SITE listing — transfer stays available" — a true sentence about the
+ * fixture's `kind`, not a claim about copy), and one was an app-name fixture
+ * (`name: 'Offsite App'`). Six false positives out of seven is precisely the
+ * "allowlisted into uselessness" outcome this file's own `RETIRED_WORDINGS` docblock
+ * warns about, and it would have buried the one real hit.
+ *
+ * So the rule keys on the ONE thing that makes a string a claim about rendered copy:
+ * it is an argument to a text-matching assertion. Collected:
+ *   - the argument to `toHaveTextContent` / `toHaveAccessibleName` and the
+ *     `*ByText` / `*ByLabelText` / `*ByAltText` / `*ByTitle` / `*ByPlaceholderText`
+ *     query family (string, template or REGEX — the live defect was a regex);
+ *   - the `name:` option of `getByRole(role, { name })`, which is how this repo
+ *     addresses a button by its accessible name;
+ *   - the value of `toHaveAttribute('aria-label' | 'title' | 'alt', …)`.
+ *
+ * 🔴 WHAT IT DOES NOT COVER, stated rather than implied: `toBe` / `toEqual` on a
+ * view-model field (`expect(row.badge).toBe('Standalone')`). That is a claim about a
+ * FUNCTION'S RETURN, not about the screen, and widening to it would re-admit every
+ * fixture literal in the repo. Those call sites are covered instead by the production
+ * SHRINKS/GROWS rules on the module the function lives in.
+ */
+const TEXT_ASSERTION_CALLS = new Set([
+  'toHaveTextContent',
+  'toHaveAccessibleName',
+  'getByText',
+  'findByText',
+  'queryByText',
+  'getByLabelText',
+  'findByLabelText',
+  'queryByLabelText',
+  'getByAltText',
+  'getByTitle',
+  'getByPlaceholderText',
+]);
+const ROLE_QUERY_CALLS = new Set(['getByRole', 'findByRole', 'queryByRole']);
+const LABELLING_ATTRS = new Set(['aria-label', 'title', 'alt']);
+
+function assertedScreenText(fileName: string, text: string): { line: number; text: string }[] {
+  const sf = parseTsx(fileName, text);
+  const out: { line: number; text: string }[] = [];
+  const at = (n: ts.Node) => sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1;
+
+  /** The literal text of a string / template / REGEX argument, or null if it is dynamic. */
+  const literalOf = (n: ts.Node): string | null => {
+    if (ts.isStringLiteral(n) || ts.isNoSubstitutionTemplateLiteral(n)) return n.text;
+    // A regex's SOURCE is the assertion — `/On-site app/i` is the live defect's shape.
+    if (ts.isRegularExpressionLiteral(n)) return n.text;
+    if (ts.isTemplateExpression(n)) {
+      return [n.head.text, ...n.templateSpans.map((s) => s.literal.text)].join(' ');
+    }
+    return null;
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const name = node.expression.name.text;
+      if (TEXT_ASSERTION_CALLS.has(name)) {
+        for (const a of node.arguments) {
+          const v = literalOf(a);
+          if (v !== null) out.push({ line: at(a), text: v });
+        }
+      } else if (ROLE_QUERY_CALLS.has(name) && node.arguments.length >= 2) {
+        const opts = node.arguments[1];
+        if (ts.isObjectLiteralExpression(opts)) {
+          for (const p of opts.properties) {
+            if (ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === 'name') {
+              const v = literalOf(p.initializer);
+              if (v !== null) out.push({ line: at(p.initializer), text: v });
+            }
+          }
+        }
+      } else if (name === 'toHaveAttribute' && node.arguments.length >= 2) {
+        const attr = literalOf(node.arguments[0]);
+        if (attr !== null && LABELLING_ATTRS.has(attr)) {
+          const v = literalOf(node.arguments[1]);
+          if (v !== null) out.push({ line: at(node.arguments[1]), text: v });
+        }
+      }
+    }
+    node.forEachChild(visit);
+  };
+  visit(sf);
+  return out;
+}
+
+/** Retired-wording hits among the text a TEST asserts is on screen. */
+function findAssertedRetiredWording(fileName: string, text: string): string[] {
+  return assertedScreenText(fileName, text).flatMap(({ line, text: s }) => {
+    const hit = RETIRED_WORDINGS.find((re) => re.test(s));
+    return hit ? [`${line}:${hit.source}`] : [];
+  });
 }
 
 /**
@@ -491,6 +627,101 @@ const SCANNED = SCAN_ROOTS.flatMap((root) => walk(path.join(SRC, root))).map((fi
   rel: path.relative(SRC, file).split(path.sep).join('/'),
   raw: fs.readFileSync(file, 'utf8'),
 }));
+
+const SCANNED_TESTS = TEST_SCAN_ROOTS.flatMap((root) => walkTests(path.join(SRC, root))).map(
+  (file) => ({
+    rel: path.relative(SRC, file).split(path.sep).join('/'),
+    raw: fs.readFileSync(file, 'utf8'),
+  })
+);
+
+describe('🔴 NO TEST ASSERTS A RETIRED WORDING IS ON SCREEN', () => {
+  /**
+   * 🔴 THE CONTROLS COME FIRST, because this rule's headline assertion is a ZERO and a
+   * reassuring zero is indistinguishable from an extractor wired to nothing. Both
+   * directions are driven through synthetic sources whose answer is known, so neither
+   * can go stale when the tree changes.
+   */
+  it('POSITIVE CONTROL: it FINDS a retired wording in every assertion shape', () => {
+    const bad = `
+      test('a scenario about an on-site listing', async () => {
+        await expect.element(card).toHaveTextContent(/On-site app/i);
+        await expect.element(page.getByText('an external app')).toBeInTheDocument();
+        await expect.element(page.getByRole('button', { name: 'Off-site thing' })).toBeVisible();
+        await expect.element(el).toHaveAttribute('aria-label', 'the off-site one');
+      });`;
+    // FOUR hits — one per shape. The test TITLE also contains "on-site" and is NOT one
+    // of them; that is the whole point of the extractor.
+    expect(findAssertedRetiredWording('bad.browser.test.tsx', bad)).toHaveLength(4);
+  });
+
+  /**
+   * 🔴 THE CONTROL THAT JUSTIFIES THE EXTRACTOR'S NARROWNESS. Measured on the real tree,
+   * the naive "every user-facing string" version produced 7 hits of which 6 were these
+   * two shapes. If someone later "simplifies" this rule to reuse `userFacingStrings`,
+   * this goes red and names the reason.
+   */
+  it('NEGATIVE CONTROL: a test TITLE and FIXTURE DATA are not screen claims', () => {
+    const noise = `
+      const CATALOG = [{ id: 'a', kind: 'offsite', name: 'Offsite App' }];
+      describe('🔴 an ON-SITE listing — transfer stays available', () => {
+        test('…and the off-site payload renders the other way', async () => {
+          state.context = contextFor({ kind: 'offsite' });
+          expect(row.badge).toBe('External');
+        });
+      });`;
+    expect(findAssertedRetiredWording('noise.browser.test.tsx', noise)).toEqual([]);
+    // …and the naive extractor DOES flag them, which is why the two are different
+    // functions rather than one shared one.
+    expect(findRetiredWording('noise.browser.test.tsx', noise).length).toBeGreaterThan(0);
+  });
+
+  it('NEGATIVE CONTROL: the CURRENT wording asserted on screen is fine', () => {
+    const good = `
+      test('renders the kind', async () => {
+        await expect.element(card).toHaveTextContent(/Embedded app/i);
+        await expect.element(page.getByText('Standalone app')).toBeInTheDocument();
+        await expect.element(page.getByRole('button', { name: 'Embedded' })).toBeVisible();
+      });`;
+    expect(findAssertedRetiredWording('good.browser.test.tsx', good)).toEqual([]);
+  });
+
+  /**
+   * 🔴 A FLOOR ON THE TEST SWEEP ITSELF — the same reason `SCANNED` has one. A
+   * `TEST_SCAN_ROOTS` typo, or a `walkTests` that silently matches nothing, turns the
+   * rule below into a green no-op. Both numbers are asserted: the FILE count (the walk
+   * reached the directories) and the EXTRACTED-ASSERTION count (the extractor actually
+   * pulled screen claims out of them). A widened root that finds nothing is
+   * indistinguishable from one wired to nothing.
+   */
+  it('POSITIVE CONTROL: the test sweep really visited the suites', () => {
+    expect(SCANNED_TESTS.length).toBeGreaterThan(200);
+    const rels = SCANNED_TESTS.map((s) => s.rel);
+    // The specific file the live defect lived in, named so a move is loud.
+    expect(rels).toContain('tests/pages/apps/invites-transfer-blocked.browser.test.tsx');
+    // …and `src/tests/**` is genuinely reached, which NO other rule in this file does.
+    expect(rels.filter((r) => r.startsWith('tests/')).length).toBeGreaterThan(20);
+    const extracted = SCANNED_TESTS.reduce(
+      (n, { rel, raw }) => n + assertedScreenText(rel, raw).length,
+      0
+    );
+    expect(extracted).toBeGreaterThan(500);
+  });
+
+  /**
+   * 🔴 THE RULE. A test that asserts a retired wording is on screen is either testing a
+   * surface that was never renamed, or it is a stale expectation that will fail the
+   * moment the rename lands — and it fails in the REPORT-ONLY browser tier, hours later,
+   * on a job that runs 187 files rather than the App-store subset a developer runs
+   * locally.
+   */
+  it('🔴 no test asserts a retired wording is rendered', () => {
+    const offenders = SCANNED_TESTS.flatMap(({ rel, raw }) =>
+      findAssertedRetiredWording(rel, raw).map((h) => `${rel}:${h}`)
+    );
+    expect(offenders).toEqual([]);
+  });
+});
 
 describe('🔒 the App-store kind label has ONE source', () => {
   /**

--- a/src/components/Apps/__tests__/unifiedReviewRow.test.ts
+++ b/src/components/Apps/__tests__/unifiedReviewRow.test.ts
@@ -129,8 +129,9 @@ describe('offsiteRequestToUnifiedRow', () => {
     const req = offsite({ id: 'o1', slug: 'ext-app' });
     const row = offsiteRequestToUnifiedRow(req, vi.fn());
     expect(row.key).toBe('offsite:o1');
+    // 🔴 The ROUTING VALUE is untouched by the copy rename — only `badge` moved.
     expect(row.kind).toBe('offsite');
-    expect(row.badge).toBe('External');
+    expect(row.badge).toBe('Standalone');
     expect(row.badgeColor).toBe('grape');
     expect(row.title).toBe('External App');
     expect(row.slug).toBe('ext-app');
@@ -257,7 +258,7 @@ describe('offsiteRequestToUnifiedRow — on-site listing-media revision (kind: o
   it('an absent kind (older payload) still behaves as an external listing', () => {
     const row = offsiteRequestToUnifiedRow(offsite({ id: 'o9', slug: 's' }), vi.fn());
     expect(row.key).toBe('offsite:o9');
-    expect(row.badge).toBe('External');
+    expect(row.badge).toBe('Standalone');
   });
 });
 
@@ -294,7 +295,7 @@ function row(key: string, iso: string): UnifiedReviewRow {
     key,
     // `onsite:` = code review; everything else routes to the listing modal.
     kind: isOnsiteCode ? 'onsite' : 'offsite',
-    badge: isOnsiteCode ? 'App' : key.startsWith('onsite-listing:') ? 'Listing media' : 'External',
+    badge: isOnsiteCode ? 'App' : key.startsWith('onsite-listing:') ? 'Listing media' : 'Standalone',
     badgeColor: isOnsiteCode ? 'blue' : key.startsWith('onsite-listing:') ? 'teal' : 'grape',
     title: key,
     submitter: null,

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -45,7 +45,7 @@ import type {
   ListingCard,
   ListingRecommendRollup,
 } from '~/server/schema/blocks/app-listing-read.schema';
-import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
+import { EMBEDDED_KIND_LABEL, STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import type { AppListingStatus } from '~/server/services/blocks/app-listing-status.constants';
 
 /** Kind badge shown on the card face. */
@@ -53,7 +53,13 @@ export type ListingBadgeKind = 'onsite' | 'offsite';
 export type ListingBadge = { label: string; kind: ListingBadgeKind };
 
 /**
- * The kind badge: on-site apps read "App"; every off-site app reads "Standalone".
+ * The kind badge: on-site apps read "Embedded"; every off-site app reads "Standalone".
+ *
+ * 🔴 BOTH BRANCHES NOW RESOLVE FROM `listingKindLabels`. The onsite branch used to
+ * return a hardcoded `'App'` — the CORRECT-looking word, which is why no copy sweep
+ * ever surfaced it and why the ledger's retired-wording rule could not see it either.
+ * A literal here is what let this surface and `appListingDetailRows` disagree about
+ * the same listing before, so neither side spells the word any more.
  *
  * 🔴 Off-site used to fork into two BADGES — "Connect app" (a linked OAuth
  * client) vs "Off-site" (no client) — derived from `connectClientId`. That fork
@@ -66,7 +72,7 @@ export type ListingBadge = { label: string; kind: ListingBadgeKind };
  * but the other one.
  */
 export function getListingBadge(card: Pick<ListingCard, 'kind' | 'kindData'>): ListingBadge {
-  if (card.kindData.kind === 'onsite') return { label: 'App', kind: 'onsite' };
+  if (card.kindData.kind === 'onsite') return { label: EMBEDDED_KIND_LABEL, kind: 'onsite' };
   return { label: STANDALONE_KIND_LABEL, kind: 'offsite' };
 }
 

--- a/src/components/Apps/appListingDetailRows.ts
+++ b/src/components/Apps/appListingDetailRows.ts
@@ -39,7 +39,10 @@
  * thresholds. See that module's header.
  */
 
-import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
+import {
+  LISTING_KIND_APP_LABELS,
+  STANDALONE_KIND_LABEL,
+} from '~/components/Apps/listingKindLabels';
 import { getRatingLabel } from '~/utils/rating-label';
 import { marketplaceCategoryLabel } from '~/server/services/blocks/marketplace-categories.constants';
 import { offsiteContentRatingLabel } from '~/shared/constants/browsingLevel.constants';
@@ -82,7 +85,7 @@ export type ListingDetailRow = {
  * filter uses.
  */
 function kindLabel(detail: Pick<ListingDetail, 'kindData'>): string {
-  return detail.kindData.kind === 'onsite' ? 'On-site app' : STANDALONE_KIND_LABEL;
+  return detail.kindData.kind === 'onsite' ? LISTING_KIND_APP_LABELS.onsite : STANDALONE_KIND_LABEL;
 }
 
 /**

--- a/src/components/Apps/appListingModerationTableView.ts
+++ b/src/components/Apps/appListingModerationTableView.ts
@@ -18,6 +18,7 @@
  *     request) → off-site only, and only when a pending request exists.
  */
 
+import { LISTING_KIND_LABELS } from '~/components/Apps/listingKindLabels';
 import type { ModerationListingRow } from '~/server/services/blocks/app-listing.service';
 
 /**
@@ -124,6 +125,6 @@ export type ListingKindChip = { label: string; color: string };
 /** Chip for a listing's `kind` (the per-row kind badge). */
 export function listingKindChip(kind: string): ListingKindChip {
   return kind === 'offsite'
-    ? { label: 'external', color: 'grape' }
-    : { label: 'on-site', color: 'blue' };
+    ? { label: LISTING_KIND_LABELS.offsite, color: 'grape' }
+    : { label: LISTING_KIND_LABELS.onsite, color: 'blue' };
 }

--- a/src/components/Apps/listingKindLabels.ts
+++ b/src/components/Apps/listingKindLabels.ts
@@ -23,23 +23,43 @@ import type { StoreListingKind } from '~/shared/utils/store-visibility-scope';
  * module and must stay that way. Map for display at the render site; never rename
  * the value. `__tests__/standaloneWordingCallSites.test.ts` pins that constraint.
  *
- * ## 🔴 "On-site" is DELIBERATELY unchanged
+ * ## 🔴 "On-site" → "Embedded": THE DEFERRAL WAS LIFTED, DELIBERATELY
  *
- * Renaming "On-site" → "Embedded" was considered and DEFERRED: "Embedded" collides
- * with "Embedding" (TextualInversion) one panel away in `AppSettingsModal`. This
- * module carries the on-site label only so both kinds resolve from one place — it is
- * not a licence to reword it.
+ * This module used to record that renaming "On-site" → "Embedded" had been DEFERRED,
+ * because "Embedded" reads close to "Embedding" (TextualInversion) — a model-type
+ * option one panel away in `AppSettingsModal.tsx`. **That deferral is reversed by an
+ * explicit product decision.** The kinds are now **Embedded** (runs inside Civitai)
+ * and **Standalone** (hosted elsewhere), which say what the kinds ARE; "On-site" said
+ * only where they were not.
+ *
+ * 🔴 THE COLLISION SURVIVES THE DECISION — it was not disproved, it was accepted, so
+ * the mitigation is written down rather than left to memory:
+ *
+ *   - The model-type label **`'Embedding'` is NOT renamed.** It names a
+ *     `ModelType.TextualInversion`, a completely different concept with its own
+ *     public vocabulary; renaming it to dodge a UI adjacency would be the copy
+ *     change breaking the larger contract.
+ *   - **Where a kind label can render in the same view as a model-type list, prefer
+ *     the `LISTING_KIND_APP_LABELS` form** (`'Embedded app'`). The noun is the
+ *     disambiguator: "Embedded app" cannot be read as a model type, while a bare
+ *     "Embedded" beside "Embedding" can. `AppSettingsModal` is the measured instance
+ *     (its `MODEL_TYPE_OPTIONS` carries `'Embedding'`), and it renders no kind label
+ *     today — so this is the rule for the next surface, not a repair of an existing one.
+ *
+ * `standaloneWordingCallSites.test.ts` pins the new labels literally and pins that the
+ * lift was a decision (it asserts the labels DO carry the new word, where it used to
+ * assert they did not).
  */
 
 /** kind → the bare noun a human reads. */
 export const LISTING_KIND_LABELS: Record<StoreListingKind, string> = {
-  onsite: 'On-site',
+  onsite: 'Embedded',
   offsite: 'Standalone',
 };
 
 /** kind → the label as a full noun phrase ("… app"), for table cells and badges. */
 export const LISTING_KIND_APP_LABELS: Record<StoreListingKind, string> = {
-  onsite: 'On-site app',
+  onsite: 'Embedded app',
   offsite: 'Standalone app',
 };
 
@@ -49,6 +69,16 @@ export const LISTING_KIND_APP_LABELS: Record<StoreListingKind, string> = {
  * badge uses, instead of re-typing the word.
  */
 export const STANDALONE_KIND_LABEL = LISTING_KIND_LABELS.offsite;
+
+/**
+ * The onsite label on its own — the mirror of {@link STANDALONE_KIND_LABEL}, and it
+ * exists for the same reason: prose that names the kind in a sentence ("Embedded and
+ * Standalone apps") composes from the same constant the badge uses instead of
+ * re-typing the word. Before this existed, every prose site that named the on-site
+ * kind hardcoded it, which is how `/apps/mine` and `/apps/review` ended up spelling it
+ * two different ways.
+ */
+export const EMBEDDED_KIND_LABEL = LISTING_KIND_LABELS.onsite;
 
 /** kind → bare display label. */
 export function listingKindLabel(kind: StoreListingKind): string {

--- a/src/components/Apps/myAppsView.ts
+++ b/src/components/Apps/myAppsView.ts
@@ -188,9 +188,97 @@ export function historyStatusColor(status: string): string {
   }
 }
 
-/** Human label for a listing kind. */
-export function listingKindLabel(kind: string): string {
-  return kind === 'onsite' ? 'On-site' : 'External';
+/**
+ * 🔴 `listingKindLabel` USED TO LIVE HERE AND IS GONE ON PURPOSE. Do not re-add it.
+ *
+ * It was a second, DIVERGENT implementation of the App-store kind label (it returned
+ * `'On-site' | 'External'`) whose NAME COLLIDED with the canonical
+ * `~/components/Apps/listingKindLabels`' export of the same name. The collision is
+ * what made the drift invisible: `MyAppsBody` imported the local one, the import line
+ * read exactly like the enrolled one, and the ledger's own SHRINKS rule could not see
+ * it because this page was never enrolled. That is how `/apps/mine` kept rendering
+ * the retired word "External" straight through the #4247 wording sweep.
+ *
+ * `/apps/mine` no longer renders a kind at all (see `MyAppsBody`'s `StatusBadges`),
+ * so there is no caller to re-point at the canonical module — the function is
+ * DELETED rather than left dead. Any future surface that needs the word imports
+ * `LISTING_KIND_LABELS` / `listingKindLabel` from `listingKindLabels` and enrols in
+ * `__tests__/standaloneWordingCallSites.test.ts`.
+ */
+
+/** Which of a row's two images a click was on. Positional, not URL-keyed — see below. */
+export type MyAppMediaKind = 'cover' | 'icon';
+
+/**
+ * The row's images as a VIEWER LIST — `[cover, icon]`, absent entries skipped.
+ *
+ * 🔴 ONE LIST FOR BOTH IMAGES, so prev/next works. Opening each image in its own
+ * single-entry modal is the shape that looks right and is worse: the viewer's arrows
+ * would be permanently disabled and the `N / M` counter would always read `1 / 1`.
+ *
+ * 🔴 COVER FIRST. The order is the ONE thing `listingMediaIndex` depends on, so it is
+ * stated here rather than inferred at the call site — the two functions are a pair and
+ * a disagreement between them opens the wrong picture with nothing erroring.
+ *
+ * The captions are what give the viewer's `<img>` its accessible name: the viewer sets
+ * `alt=""` whenever a caption is present (the caption is rendered as visible text
+ * beside it), so an empty caption here would leave the image unnamed.
+ */
+export function listingMediaShots(
+  row: Pick<MyAppRow, 'name' | 'iconUrl' | 'coverUrl'>
+): { url: string; caption: string | null }[] {
+  const shots: { url: string; caption: string | null }[] = [];
+  if (row.coverUrl) shots.push({ url: row.coverUrl, caption: `${row.name} cover image` });
+  if (row.iconUrl) shots.push({ url: row.iconUrl, caption: `${row.name} icon` });
+  return shots;
+}
+
+/**
+ * Where `which` sits in {@link listingMediaShots}, or `null` when that image is absent.
+ *
+ * 🔴 POSITIONAL, NOT A URL LOOKUP. A `findIndex` on the url would collapse the two
+ * entries whenever a listing's icon and cover happen to be the SAME url — clicking the
+ * icon would open the cover. `null` is the signal that there is nothing to view, which
+ * is what keeps a placeholder inert.
+ */
+export function listingMediaIndex(
+  row: Pick<MyAppRow, 'iconUrl' | 'coverUrl'>,
+  which: MyAppMediaKind
+): number | null {
+  if (which === 'cover') return row.coverUrl ? 0 : null;
+  if (!row.iconUrl) return null;
+  return row.coverUrl ? 1 : 0;
+}
+
+/**
+ * Is this orphaned submission one the author can DO something about?
+ *
+ * Two shapes, and each is a call to action rather than a status: a REJECTION REASON is
+ * the only text on the whole record telling the developer what to change, and a
+ * PENDING request the server says this caller may withdraw is a decision still open to
+ * them. Everything else — an approved-and-superseded request, an already-withdrawn
+ * one, a rejection with no reason attached — is history.
+ */
+export function isActionableOrphan(row: {
+  status: string;
+  rejectionReason: string | null;
+  canWithdraw?: boolean;
+}): boolean {
+  if ((row.rejectionReason ?? '').trim().length > 0) return true;
+  return row.status === 'pending' && row.canWithdraw === true;
+}
+
+/**
+ * Does the "Submissions without a listing" group start OPEN?
+ *
+ * 🔴 THIS IS WHAT PRESERVES THE GROUP'S ORIGINAL GUARANTEE while collapsing it. See
+ * `OrphanedSubmissionsSection`'s header for the measured reason the group must not
+ * simply be hidden behind a toggle.
+ */
+export function orphanGroupStartsOpen(
+  rows: readonly { status: string; rejectionReason: string | null; canWithdraw?: boolean }[]
+): boolean {
+  return rows.some(isActionableOrphan);
 }
 
 /**

--- a/src/components/Apps/unifiedReviewRow.ts
+++ b/src/components/Apps/unifiedReviewRow.ts
@@ -1,3 +1,4 @@
+import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import type { AnyRequest } from '~/components/Apps/OnsiteReviewModal';
 import type { OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';
 
@@ -57,7 +58,10 @@ export type UnifiedReviewRow = {
   kind: UnifiedReviewKind;
   /** Kind-column display badge — DECOUPLED from the routing `kind` so an on-site
    *  listing-media revision (routing `offsite`) can show a "Listing media" badge
-   *  distinct from an external listing's "External" badge. Adapter-controlled. */
+   *  distinct from an off-site listing's kind badge. 🔴 THE KIND WORD IS NOT SPELLED
+   *  HERE: it resolves from `listingKindLabels` (this site used to emit a bare
+   *  hardcoded "External" — a LIVE instance of the retired wording that the ledger's
+   *  `/external app/i` regex could not see). Adapter-controlled. */
   badge: string;
   badgeColor: string;
   /** App / listing display name (falls back to the slug). */
@@ -245,7 +249,7 @@ export function offsiteRequestToUnifiedRow(
     key: isOnsiteListing ? `onsite-listing:${req.id}` : `offsite:${req.id}`,
     // Routing kind is `offsite` for BOTH (they open the same listing modal).
     kind: 'offsite',
-    badge: isOnsiteListing ? 'Listing media' : 'External',
+    badge: isOnsiteListing ? 'Listing media' : STANDALONE_KIND_LABEL,
     badgeColor: isOnsiteListing ? 'teal' : 'grape',
     title: req.appListing?.name ?? req.slug,
     slug: req.slug,

--- a/src/pages/apps/mine.tsx
+++ b/src/pages/apps/mine.tsx
@@ -3,6 +3,7 @@ import { IconArrowRight } from '@tabler/icons-react';
 import Link from 'next/link';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { MyAppsBody } from '~/components/Apps/MyAppsBody';
+import { EMBEDDED_KIND_LABEL, STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import { MY_APPS_CONTAINER_SIZE } from '~/components/Apps/myAppsView';
 import { Meta } from '~/components/Meta/Meta';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -48,7 +49,10 @@ export default function MyAppsPage() {
       <AppsPageLayout
         size={MY_APPS_CONTAINER_SIZE}
         title="My apps"
-        subtitle="Apps you own and apps you collaborate on, on-site and standalone. Open a row to see its submission history."
+        // 🔴 COMPOSED FROM THE KIND LABELS, not retyped. This subtitle spelled the
+        // kinds by hand and drifted from every other surface; enrolled in
+        // `standaloneWordingCallSites.test.ts` so it cannot drift again.
+        subtitle={`Apps you own and apps you collaborate on, ${EMBEDDED_KIND_LABEL} and ${STANDALONE_KIND_LABEL}. Open a row to see its submission history.`}
         actions={
           <Button component={Link} href="/apps/submit" rightSection={<IconArrowRight size={16} />}>
             Submit a new app

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -40,6 +40,7 @@ import type {
 import { Meta } from '~/components/Meta/Meta';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
+import { EMBEDDED_KIND_LABEL, STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -195,7 +196,7 @@ export default function ReviewQueuePage() {
       <AppsPageLayout
         size={APPS_PAGE_WIDTHS['/apps/review']}
         title="App publish-request queue"
-        subtitle="Moderator review for Apps. On-site + external submissions share one queue per tab; Pending is oldest-first, history is newest-first."
+        subtitle={`Moderator review for Apps. ${EMBEDDED_KIND_LABEL} + ${STANDALONE_KIND_LABEL} submissions share one queue per tab; Pending is oldest-first, history is newest-first.`}
       >
         <ActivePreviewsPanel />
 

--- a/src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx
+++ b/src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx
@@ -195,7 +195,11 @@ describe('the payload fake honours its input (positive control)', () => {
     const card = page.getByTestId('apps-transfer-aot_1');
     await expect.element(card).toBeInTheDocument();
     await expect.element(card).toHaveTextContent('Shiny Thing');
-    await expect.element(card).toHaveTextContent(/On-site app/i);
+    // The kind badge, on the store's own word (see `listingKindLabels`). This assertion
+    // is the one the kind rename broke, and it broke INVISIBLY: it lives under
+    // `src/tests/**`, which no rule in `standaloneWordingCallSites.test.ts` reached until
+    // that ledger grew a test sweep. See TEST_SCAN_ROOTS there.
+    await expect.element(card).toHaveTextContent(/Embedded app/i);
   });
 
   test('…and a different payload renders differently (same assertion, other shape)', async () => {


### PR DESCRIPTION
PR A of a 4-PR plan. Four changes to `/apps/mine` and the kind-label vocabulary behind it.

## 🔴 No stored VALUE was renamed

This is a **copy** change. `onsite` / `offsite` are untouched everywhere they are a value: the `AppListing.kind` column, the public `/api/v1/apps` response enum, `STORE_LISTING_KINDS`, `ListingKind`, `listingKindFilterSchema`, the `public-external` visibility scope and the `app-listings-public-external` Flipt key. Rule (4) of `standaloneWordingCallSites.test.ts` asserts each of those explicitly and is green.

Both new retired-wording patterns were chosen so that **no value can match them**: lowercase `external` is the `SubmitMode` id / a testid fragment / a glyph key and is deliberately not matched; the stored values are `onsite`/`offsite` with **no hyphen**, so a hyphenated `on-site` can only ever be copy.

---

## A1 — Embedded / Standalone, single-sourced

`listingKindLabels.ts` is the one source. `onsite` → `'Embedded'` / `'Embedded app'`; offsite unchanged. A new `EMBEDDED_KIND_LABEL` mirrors `STANDALONE_KIND_LABEL` so prose composes from a constant instead of retyping the word.

The module docblock's "the Embedded rename was DEFERRED" section is rewritten to record that the deferral was **lifted by an explicit product decision**, plus the surviving collision and its mitigation: `'Embedding'` (`ModelType.TextualInversion`, `AppSettingsModal.tsx`) is **not** renamed, and where a kind label can render in the same view as a model-type list the `LISTING_KIND_APP_LABELS` form (`'Embedded app'`) is preferred so the noun disambiguates.

**Sites enrolled** (each rendered a kind label without importing the module):

| site | was | now |
|---|---|---|
| `unifiedReviewRow.ts:248` | `'External'` | `STANDALONE_KIND_LABEL` |
| `AppListingsModerationTable.tsx:419` | `'On-site'` | `LISTING_KIND_LABELS.onsite` |
| `AppListingsModerationTable.tsx:420` | `'External'` | `LISTING_KIND_LABELS.offsite` |
| `appListingCardView.ts:69` | `'App'` | `EMBEDDED_KIND_LABEL` |
| `appListingDetailRows.ts:85` | `'On-site app'` | `LISTING_KIND_APP_LABELS.onsite` |
| `appListingModerationTableView.ts:128` | `'external'` / `'on-site'` | `LISTING_KIND_LABELS.*` |
| `pages/apps/mine.tsx:51` | prose | composed from both constants |
| `pages/apps/review.tsx:198` | prose | composed from both constants |
| `OffsiteReviewQueue.tsx:575` | prose `on-site` | composed |

**Two of these were not in the brief and are worth flagging.** `AppListingsModerationTable.tsx:420` carried a second retired word (`'External'`) right beside the `'On-site'` one. And `appListingModerationTableView.listingKindChip` was a **fourth** divergent kind-label implementation — lowercase `'external'` / `'on-site'`, rendered as the per-row chip on the moderation table — that nobody had noticed.

**Ledger changes** (`standaloneWordingCallSites.test.ts`):
- `RETIRED_WORDINGS` gains `/^\s*External\s*$/` (case-sensitive, whole-string) and `/\bon-site\b/i` (hyphenated, anywhere). The rationale for each narrowness choice is written into the docblock.
- `KIND_LABEL_WORD` gains `\bEmbedded\b`, so the onsite label gets the same GROWS protection the offsite one always had. Measured before adding it: `Embedded` appeared in **0** user-facing strings across the scan roots. `\bEmbedded\b` cannot match `Embedding`, and there is a negative control asserting exactly that.
- The `:426-427` `.not.toContain('Embedded')` assertions — the negative pin against this rename — are **inverted, not deleted**, with a comment recording that the deferral was lifted deliberately. A future revert to "On-site" now fails there with that comment attached.
- `ENROLLED` grows by the five newly-enrolled files plus the two pages.
- New: a `DELIBERATELY_UNENROLLED` map (see A2) asserting those files render no kind label at all.

---

## A2 — The kind badge is gone from `/apps/mine`

`MyAppsBody.tsx`'s `Badge` (testid `apps-mine-kind-<id>`) is deleted. Kind remains on the listing detail and edit pages.

**`myAppsView.listingKindLabel` is deleted, not left dead.** It was a divergent duplicate returning `'On-site' | 'External'` whose *name collided* with the canonical export — which is precisely why this page kept rendering the retired word straight through the #4247 sweep: the import line read exactly like the enrolled one. A header comment in `myAppsView.ts` records that and says not to re-add it.

`MyAppsBody.tsx` / `myAppsView.ts` are **not** added to `ENROLLED` — enrolling asserts a surface *resolves* the word, which is only meaningful for a surface that renders one. The **absence** is pinned instead, deliberately: across both layouts and three row shapes, with a positive control (rows and the surviving status/role badges must be present, so the zeros are a fact about the badge and not about an empty page) and a prefix-namespace check so a restored badge under a new id cannot walk it.

---

## A3 — Icon and cover open the image viewer

Reuses **`AppListingScreenshotViewer`**. `ImageViewer` / `ImageDetailModal` were rejected for a structural reason, not by omission: both are keyed on a numeric civitai `Image` id and driven by a `?imageId=` query param, and a `/apps/mine` row carries a CDN URL **string** (`getEdgeUrl`) with no image id to hand them. The screenshot viewer is URL-keyed, which is the shape this page has.

- Seeded with **both** images — `[cover, icon]`, absent entries skipped — opening at the index of whichever was clicked, so prev/next works instead of two isolated single-image modals.
- The order/index pair is two pure functions in `myAppsView.ts` (`listingMediaShots` / `listingMediaIndex`), so the arithmetic is pinned in the **blocking** `unit` project. `listingMediaIndex` is positional rather than a URL lookup — a `findIndex` on the url collapses both entries when a listing's icon and cover are the same url, and clicking the icon would open the cover.
- **Placeholders are inert**: no button, no `tabIndex`, no pointer cursor. This table's rows are mostly incomplete listings (all 11 `removed` listings have a null cover), so a placeholder button would add a dead tab stop to nearly every row.
- The controls are real `UnstyledButton`s with per-app accessible names ("View cover image for {name}"), keyboard-operable, correct focus ring. **Mantine `Anchor` is deliberately avoided** — its root sets `color: var(--mantine-color-anchor)` and recolours every `currentColor` child, which would turn the "No cover" glyph link-blue; that bug is invisible on the has-image path.
- Its `stackId` is inert here (no `Modal.Stack` ancestor, and `/apps/mine` nests no dialogs) — a documented property of that component.

`appListingScreenshotViewerWiring.test.ts` does **not** assert a set of consumers, so nothing there had to be worked around. It was **extended** anyway, in its own file, with a seam guard for this second consumer — for exactly the reason that file's header gives: the browser suite that measures this for real is report-only in CI, so a guard that lives only there cannot block a regression.

---

## A4 — "Submissions without a listing" collapses, and opens itself when actionable

- **"Hide if 0" was already implemented and tested** (`MyAppsBody.tsx` guards on `orphanedSubmissions.length > 0`; test `'no group at all when there is nothing orphaned'`). It was not re-implemented. **Verified: it still holds** — the guard is unchanged and that test is green in the run below.
- The group is now its own `Collapse`, **closed by default**, **open on arrival** when any row has a non-empty `rejectionReason` or is `pending` with `canWithdraw`.
- The `:1044-1057` docblock is **rewritten, not deleted**. Its three original reasons for "ALWAYS VISIBLE" — the only surface showing a rejection reason, the "your app was rejected" notification deep-links here, and 3/3 rejected + 27/33 withdrawn on-site requests were unreachable before it existed — are all restated, and the new rule is justified from them: every one of those reasons is about a row the author can still ACT on, which is what auto-open preserves. It is still not nested under the Inactive collapse.
- The count `Badge` stays on the collapsed header.
- `'the group is NOT hidden behind the Inactive collapse'` is **rewritten to the new rule**, not deleted: still not inside the Inactive collapse (asserted as DOM *containment*, because Mantine's `Collapse` keeps children mounted so a presence check cannot tell open from closed), and open-without-interaction when actionable (asserted via `aria-expanded`).

---

## Test matrix — red at `origin/main`, green at HEAD

Measured by copying the new/updated specs into a clean `origin/main` worktree and running them against base source.

**Browser tier** (`MyAppsBody.browser.test.tsx`) — **15 red at base, all green at HEAD**:

| test | base | HEAD |
|---|---|---|
| no kind badge — table layout | ❌ | ✅ |
| no kind badge — card layout | ❌ | ✅ |
| clicking the ICON opens the viewer on the icon | ❌ | ✅ |
| clicking the COVER opens the viewer on the cover | ❌ | ✅ |
| prev/next moves between the row's two images | ❌ | ✅ |
| a row with only an icon opens a ONE-entry viewer | ❌ | ✅ |
| cover present, icon absent: cover clickable, icon inert | ❌ | ✅ |
| the button names disambiguate BETWEEN rows | ❌ | ✅ |
| the control opens on Enter, not only on click | ❌ | ✅ |
| the viewer closes again | ❌ | ✅ |
| NOT inside Inactive, and OPEN without interaction when actionable | ❌ | ✅ |
| a PENDING withdrawable orphan also opens the group | ❌ | ✅ |
| nothing actionable → CLOSED, count still on the header | ❌ | ✅ |
| a closed group opens on click | ❌ | ✅ |
| the toggle's aria-controls resolves to the panel | ❌ | ✅ |

**🔴 One test is an INVARIANT GUARD, not regression coverage, and is labelled as such in the file**: `INVARIANT GUARD: neither placeholder is a button, focusable, or clickable` **passes at `origin/main`** — at base nothing on the row was clickable at all, so it pins an invariant the bug never violated. It earns its place (it is what stands between a future "merge the two branches into one wrapper" refactor and a dead tab stop on every incomplete row) but it is not evidence.

**Unit tier** — 27 red at base across 7 files, all green at HEAD: every case in the new `listingMediaShots` / `listingMediaIndex` / `isActionableOrphan` / `orphanGroupStartsOpen` describes; the `/apps/mine` viewer seam in `appListingScreenshotViewerWiring.test.ts`; and the relabelled pins in `standaloneWordingCallSites` / `appListingCardView` / `appListingDetailRows` / `appListingModerationTableView` / `unifiedReviewRow`.

The scanner **CONTROL** tests (`POSITIVE CONTROL: …`, `POSITIVE + NEGATIVE CONTROL: bare External and hyphenated on-site`, `NEGATIVE CONTROL: the model-type label Embedding`) pass at base too — they run against synthetic fixtures by construction. They are instrument validation, named as such, and are not counted as regression coverage.

## Mutation table — every guard broken on purpose

Each mutant is the narrowest expression that can be wrong; the file is restored and re-hashed after every run so a failed restore cannot leak into the next mutant. **Every mutant was killed by the assertion that owns it**, not by a neighbouring guard.

| # | mutant | killed by | failing assertion |
|---|---|---|---|
| M1 | `LISTING_KIND_LABELS.onsite` back to `'On-site'` | 3 tests | `the on-site label WAS reworded to "Embedded"` |
| M2 | `listingMediaShots` order swapped | 2 | `expected [icon,cover] to deeply equal [cover,icon]` |
| M3 | `listingMediaIndex` icon branch hardcodes `1` | 2 | `expected 1 to be +0` (the no-cover case) |
| M4 | drop the `pending && canWithdraw` clause | 2 | `PENDING + the server says withdrawable → actionable` |
| M5 | drop `.trim()` from the reason check | 1 | `a WHITESPACE-ONLY reason is not a reason` |
| M6 | `orphanGroupStartsOpen` reads `rows[0]` only | 1 | `the group opens if ANY row is actionable` |
| M7 | remove the bare-`External` rule | 2 controls | `expected length 7, got 6` |
| M8 | remove the hyphenated-`on-site` rule | 2 controls | `expected length 7, got 6` |
| M9 | loosen `KIND_LABEL_WORD` to the stem `/Embedd/` | 3 | `NEGATIVE CONTROL: the model-type label 'Embedding'` |
| M10 | `MyAppsBody` hand-rolls the viewer list | 1 | the `/apps/mine` seam's own WHY message |
| M11 | move the placeholder guard after `MediaButton` | 1 | `ListingIcon no longer returns its placeholder BEFORE…` |
| B1 | restore a kind badge on the row | 2 | `apl_k_on rendered a kind badge` |
| B2 | wrap the icon placeholder in `MediaButton` | 2 | `icon placeholder is wrapped in a button` |
| B3 | viewer always opens at index 0 | 1 | `the icon button must open the ICON` |
| B4 | viewer seeded with one image | 3 | `the icon button must open the ICON` |
| B5 | media control loses its accessible name | 8 | `Cannot find element … 'View icon image for …'` |
| B6 | orphan group never auto-opens | 3 | `OPEN without interaction when actionable` |
| B7 | orphan group always open | 2 | `nothing actionable → CLOSED` |
| B8 | count badge moved inside the collapse | 1 | `the count badge is not on the toggle header` |
| B9 | orphan group nested inside Inactive | 1 | strict-mode violation: two `apps-mine-orphaned` |
| B10 | `aria-controls` points at nothing | 1 | `aria-controls="…-nope" resolves to no element` |
| PC | positive control (unit): invert `partitionMyAppRows` | 3 | pre-existing partition tests |
| PC | positive control (browser): drop the role badge testid | 3 | pre-existing role-badge tests |

**Two defects the sweep found, both fixed in this PR:**

1. **B8 initially SURVIVED.** The "count still on the header" test asserted `toHaveTextContent('3')`, which Mantine's `Collapse` satisfies with the badge *inside* the collapse — children stay mounted when closed. The test's name claimed coverage it did not provide. It is now a structural containment assertion (the badge is on the toggle, not in the panel) and kills the mutant.
2. **B2 initially reported `Tests no tests`.** That was a *setup error*, not a survivor: the mutation produced unbalanced JSX, the module failed to import, and vitest reported "no tests" — which reads exactly like a clean pass. Re-run with syntactically valid JSX, it is killed.

A third defect, found while writing the ledger: its SHRINKS rule used `raw.includes(LABEL_SOURCE_IMPORT)`, so a mention of the module path **in a comment** counted as an import — the same blindness the retired-wording rule avoids with an AST walk. It is now an AST import check, shared by both rules.

## Gate runs (first measurement, pre-rebase — superseded by the re-run above)

- `pnpm test:unit:run` (the gating tier): **34 failed / 19321 passed at HEAD vs 33 failed / 19302 passed at `origin/main`**. The single delta is `src/server/__tests__/eventloop-watchdog.capture.test.ts › exposes the ratio distribution and the threshold echo` — a timing test that waits 10 s for an event-loop watchdog metric to settle. It is in a file that is **already red at base** (its sibling case fails on both trees), this PR touches **no** `src/server` file, and run in isolation the file is identically red on both trees (1 failed / 8 passed, ~12.3 s, same case). Load-sensitive pre-existing red, not this PR's.
- `pnpm test:component`, `src/components/Apps`: **73 files / 1055 tests, all passing.**
- `MyAppsBody.browser.test.tsx` alone: **71 passed, 7.2 s**, converging across three consecutive runs.
- `pnpm typecheck`: **43 errors at HEAD, 43 at `origin/main`, byte-identical** — zero delta. (All in `packages/civitai-db*` / `image.service.ts`, pre-existing.) `tsconfig.json` excludes `src/**/__tests__/**`, so the test files were typechecked **deliberately** via a config that drops that exclusion: 944 errors on both trees, and the diff is **zero net new** (the 4 "HEAD-only" entries are the same 4 pre-existing errors at line numbers my comments shifted).

---

## Rebased onto #4341 (`999f9363a8`) — hunk-survival check

`main` moved under this branch after it was first pushed. #4341 touches two files this PR also touches (`ListingProblemsIndicator.tsx`, `MyAppsBody.browser.test.tsx`). The rebase was clean, and a clean rebase is not a clean merge — so #4341's hunks were verified **by content, per hunk**, not inferred from the absence of a conflict:

| marker | file | result |
|---|---|---|
| `` key={`${p.code}:${p.label}`} `` (the actual fix) | ListingProblemsIndicator | ✅ present |
| `THE KEY IS code+label, NOT code, BECAUSE A CODE IS NOT UNIQUE PER ROW` | ListingProblemsIndicator | ✅ |
| ``until `listMyAppListings` started passing `assetScans` `` | ListingProblemsIndicator | ✅ |
| ``ONE `blocked-media` (and one `scanning-media`) `` | ListingProblemsIndicator | ✅ |
| `two problems sharing one CODE both reach the reader` (the new test) | MyAppsBody.browser.test | ✅ |
| `apl_twoblocked` (its fixture row id) | MyAppsBody.browser.test | ✅ |
| `Replace the blocked icon before it can publish` | MyAppsBody.browser.test | ✅ |
| `Replace the blocked cover before it can publish` | MyAppsBody.browser.test | ✅ |
| `WHAT THIS KILLS: any "fix" that DEDUPES the list by code` | MyAppsBody.browser.test | ✅ |
| `SURVIVED its own mutant in this harness` | MyAppsBody.browser.test | ✅ |
| `await userEvent.hover(indicator as HTMLElement);` | MyAppsBody.browser.test | ✅ |

Two stronger checks beyond the markers:
- `git diff 999f9363a8 HEAD -- ListingProblemsIndicator.tsx` is **empty** — that file is byte-identical to #4341's version.
- `git diff 999f9363a8 HEAD -- MyAppsBody.browser.test.tsx` removes exactly **7** lines, and every one is mine (the two kind-badge assertions and the 5 lines of the orphan test I rewrote). None of #4341's 57 added lines was dropped.

#4341's own new test passes on this branch (it is one of the 72 below).

**⚠️ One correction to the hand-off note I was given.** It said "`ListingProblemsIndicator` now **dedupes** problems by code". It does not — the diff changes the React `key` from `p.code` to `` `${p.code}:${p.label}` ``, and #4341's own test docblock explicitly says *"WHAT THIS KILLS: any 'fix' that DEDUPES the list by code — the obvious wrong answer … and the one that silently hides which asset the author has to replace."* Deduping is the behaviour that PR guards **against**. Nothing in this PR relies on either reading — no fixture here passes `problems` — but the note is inverted and would mislead the next person.

The second note (that `listMine` rows can now carry `blocked-media` / `scanning-media`) is correct and required no change here: no fixture or assertion in this PR assumes a six-code set, because none of the tests added here passes `problems` at all.

## Matrix re-run on the NEW base (`999f9363a8`)

A rebase resets the verification gate, so everything below was re-measured against the new `origin/main`, not the old one.

- **Browser harness health at the new base**: pristine `origin/main` spec + source → **57 passed, 6.2 s**. (First-ever cold run in this worktree gave 55 failed / 832 s — the documented cold-cascade garbage. Every verdict quoted here is from a warm, converged run.)
- **Red at new base**: the same **15** browser tests, and the same **27** unit tests across 7 files. Unchanged from the pre-rebase measurement.
- **Green at HEAD on the new base**: `MyAppsBody.browser.test.tsx` **72 passed** (71 mine + #4341's), 8.4 s. `vitest --project unit src/components/Apps` **1175 passed**.
- **Mutation sweep re-run in full on the new base**: **23 / 23 killed** (12 unit incl. positive control, 11 browser incl. positive control), each by its own guard's assertion.
- **`pnpm typecheck`**: 12 errors at HEAD, 12 at base, **byte-identical — zero delta**.
- **`pnpm test:unit:run`** (the gating tier): **33 failed / 19398 passed at HEAD vs 33 failed / 19378 passed at base — zero HEAD-only failures, +20 net new passing tests.** (The single `eventloop-watchdog` delta seen in the pre-rebase run did not reproduce; it was a load flake on a box running three other agents' suites, in a file already red on both trees and which this PR does not touch.)
- **Prettier**: the "changed files" gate blocks on **added** files only (modified files are `continue-on-error`). This PR adds no files. The 6 modified files prettier reports are **unformatted identically at `origin/main`** — measured on both trees, same 6 — so this PR introduces **zero** new formatting violations. `appListingScreenshotViewerWiring.test.ts` was clean at base and my addition made it dirty; that one is formatted.

## Deliberately not done

- **`"External-link submissions"`** (`OffsiteReviewQueue.tsx:193`) is left as-is and the widened rule does **not** catch it. Widening to catch `External` inside a phrase would also catch `"External site"` on the public listing page — a heading over an outbound URL, which is ordinary English about a website rather than the kind's name — and there is no mechanical rule separating the two. This limitation is written into the `RETIRED_WORDINGS` docblock rather than left implicit.
- `unifiedReviewRow`'s `'App'` / `'App + media'` badges are unchanged: those name the *submission type* (code bundle / listing media / both), a different axis from the listing kind.
- `offsite-moderation.service.ts:1199` throws `'On-site listing not found.'` — a server error string outside the App-store scan roots. Not touched.

---

## 🔴 Follow-up: `preview / component-tests` was RED, and it was mine

The first push was reported here as green off a local run of `vitest --project component src/components/Apps` — **73 files / 1056 tests**. CI's `component` project runs **187 files / 2048 tests**. I validated a subset and described it as though it covered the tier; that is the error that let this through, and it is corrected below.

### The failure

`src/tests/pages/apps/invites-transfer-blocked.browser.test.tsx:198` asserted
`await expect.element(card).toHaveTextContent(/On-site app/i);` — a label this PR renamed to `Embedded app`. Line 208 of the same test asserts `'Standalone app'` and was unaffected, which is why only one arm broke.

Not a flake, checked three ways before touching it: PR #4347 runs the same suite and passes it (187/187); exactly one test sat at the 15 s matcher ceiling while the rest of the suite ran normally (load inflates every test in a run, a failed assertion inflates exactly one); and 186 files passed around it — a converged single failure, not cold-cascade drift.

### Why every guard in this PR missed it — the guard is fixed, not just the string

The enrolment ledger's `SCAN_ROOTS` are `['components/Apps', 'components/AppBlocks', 'pages/apps']`, and its `walk()` **excludes `*.test.ts(x)` by construction**. So:

- `src/tests/**` was outside the roots entirely, and
- every test file everywhere was outside the walk.

The ledger's own docblock claims rule (1) fails "when the set GROWS". For an entire directory it could not. **That is a guard narrower than its own description — which reads as coverage while providing none, and is worse than no guard because it stops anyone looking.**

Fixed by adding a second sweep with its own roots (`TEST_SCAN_ROOTS`, including `tests`) and its own extractor, `assertedScreenText`.

**The extractor is narrow on purpose, and the narrowness is measured.** Pointing the existing `userFacingStrings` at the wider root produced **7** hits of which **6 were noise** — five `test(...)`/`describe(...)` TITLES naming the scenario ("🔴 an ON-SITE listing — transfer stays available", a true sentence about the fixture's `kind`), and one app-name fixture (`name: 'Offsite App'`). Six-of-seven noise is the "allowlisted into uselessness" outcome the ledger's own docblock warns about, and it would have buried the one real hit. So the rule keys on the one thing that makes a string a claim about rendered copy: it is an argument to a text-matching assertion — `toHaveTextContent` / `toHaveAccessibleName`, the `*ByText` / `*ByLabelText` / `*ByAltText` / `*ByTitle` / `*ByPlaceholderText` family (string, template **or regex** — the live defect was a regex), the `name:` option of `getByRole`, and the value of `toHaveAttribute('aria-label'|'title'|'alt', …)`.

Deliberately **not** covered, stated rather than implied: `toBe`/`toEqual` on a view-model field (`expect(row.badge).toBe('Standalone')`). That is a claim about a function's return, not about the screen; widening to it re-admits every fixture literal in the repo. Those sites are covered by the production SHRINKS/GROWS rules on the module the function lives in.

### The red → green pair (the proof the widened root can actually see the directory)

A widened root that finds nothing is indistinguishable from one wired to nothing, so both halves are reported.

| | files scanned | screen-text assertions extracted | retired-wording hits |
|---|---|---|---|
| widened ledger at the **pre-fix** tip | 286 | 1297 | **2** |
| after the two fixes | 286 | 1297 | **0** |

The 2 it named at the pre-fix tip:
```
tests/pages/apps/invites-transfer-blocked.browser.test.tsx:198:\bon-site\b   ← the CI failure
components/Apps/UnifiedReviewList.browser.test.tsx:87:external app
```
Watched red (`Tests 1 failed | 28 passed`), then green (`29 passed`) after the fixes — and confirmed by a second, independent standalone sweeper reaching the same 2 → 0. **The extracted-assertion count is unchanged at 1297 across both**, so the zero is a fact about the code and not about the extractor breaking.

Controls shipped alongside it, because the headline assertion is a zero: a positive control finding a retired wording in all four assertion shapes; a negative control proving a test TITLE and fixture data are *not* screen claims (and asserting the naive extractor *does* flag them, so the two functions cannot be "simplified" back into one); a negative control that the *current* wording is fine; and a floor control on the sweep itself (>200 files, >20 under `tests/`, >500 extracted assertions, and the defect's own file named so a move is loud).

### The two fixes

1. `invites-transfer-blocked.browser.test.tsx:198` → `/Embedded app/i`.
2. `UnifiedReviewList.browser.test.tsx` — the second hit was a listing **name** fixture, `'My External App'`, asserted via `getByText`. Genuine false positive for a copy rule, but a bad fixture regardless: a fixture whose value spells a kind wording is indistinguishable from a copy defect to any scanner, and is exactly the shape that can satisfy a kind-badge assertion by accident. Renamed to neutral proper nouns (`'Wayfarer'`, `'Lighthouse'`) rather than allowlisted.

### Hydration verdict: PRE-EXISTING, and by design

The `Uncaught Error: Hydration failed…` in the pod log is **not** from this PR. It originates in
`src/components/Apps/AppsSubNav.ssrHydration.browser.test.tsx` → **"🔴 INSTRUMENT CHECK: a genuine server/client divergence IS reported by BOTH signals"** — a deliberate negative control that manufactures a divergence and asserts both signals report it. The stderr is that control's expected output.

Compared against #4347's pod log as instructed, before concluding:

| | hydration lines | originating test | that file's result |
|---|---|---|---|
| #4347 (187/187 pass) | **1** | `AppsSubNav.ssrHydration…` INSTRUMENT CHECK | passes |
| #4346 (mine) | **1** | same file, same test | passes |

Identical count, identical origin, and the file appears nowhere in either failure list. No action.

### Full-tier verification (the thing I got wrong the first time)

Ran the **whole** `component` project locally — `pnpm test:component`, not the
`src/components/Apps` subset — and compared against CI's own numbers:

| run | files | tests | result |
|---|---|---|---|
| CI, #4347 (a passing PR, for reference) | 187 | 2032 | all pass |
| CI, #4346 **pre-fix** | 187 | 2048 | **1 failed** / 2047 passed |
| local, **post-fix**, run 1 | **187** | **2048** | **all pass** |

The file count matches CI's exactly, and the test denominator matches #4346's own
pre-fix run at 2048 — so the same 2048 tests ran, and the one CI failed on now passes.
The two touched specs were also run directly (2 files / 17 tests, 9.3 s, green).

Reported honestly: my first push claimed this tier was green on the strength of a
**73-file / 1056-test** subset. That is the mistake, not a detail of it. 187 is the
number that matters, and it is the one quoted from here on.
