### PR TITLE
fix(generation): resource picker withheld Newest from moderators

### DIFF
--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectFilters.tsx
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectFilters.tsx
@@ -15,6 +15,8 @@ import { useLocalStorage } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp, IconFilter } from '@tabler/icons-react';
 import { uniq } from 'lodash-es';
 import React, { useState } from 'react';
+import { isSortAvailable } from '~/components/Filters/sort-availability';
+import { useSortAvailability } from '~/components/Filters/useSortAvailability';
 import { useResourceSelectContext } from '~/components/ImageGeneration/GenerationForm/ResourceSelectProvider';
 import type {
   ResourceFilter,
@@ -24,7 +26,6 @@ import { resourceSort } from '~/components/ImageGeneration/GenerationForm/resour
 import { SelectMenuV2 } from '~/components/SelectMenu/SelectMenu';
 import useIsClient from '~/hooks/useIsClient';
 import { useIsMobile } from '~/hooks/useIsMobile';
-import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import type { BaseModel } from '~/shared/constants/basemodel.constants';
 import { activeBaseModels } from '~/shared/constants/basemodel.constants';
 import { ModelType } from '~/shared/utils/prisma/enums';
@@ -226,12 +227,14 @@ export function ResourceSelectFiltersDropdown() {
 }
 
 export function ResourceSelectSort() {
-  const features = useFeatureFlags();
+  const availability = useSortAvailability();
   const { sort, setSort } = useResourceSelectContext();
 
+  // `value: x.label` — the keys here are lowercase (`relevance|popularity|newest`)
+  // and the shared predicate matches on the display label.
   const options = Object.entries(resourceSort)
     .map(([k, v]) => ({ label: v, value: k }))
-    .filter((x) => !(!features.canViewNsfw && x.label === 'Newest'));
+    .filter((x) => isSortAvailable({ type: 'models', value: x.label }, availability));
 
   return (
     <SelectMenuV2

--- a/src/components/ImageGeneration/GenerationForm/__tests__/ResourceSelectSort.test.ts
+++ b/src/components/ImageGeneration/GenerationForm/__tests__/ResourceSelectSort.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ClickUp 868kv6mzm. The generation resource picker carried its own copy of the
+// Newest-sort rule — `!(!features.canViewNsfw && x.label === 'Newest')` — which had
+// no moderator bypass, so a moderator on a domain without `canViewNsfw` saw Newest in
+// every feed sort menu and not in this one. #4296 extracted the rule into
+// `isSortAvailable` and moved only one of the two copies.
+//
+// This asserts the picker's OPTIONS, not the predicate. `isSortAvailable` has its own
+// tests in src/components/Filters/__tests__/sort-availability.test.ts and they stay
+// green if this component goes back to its private copy — only rendering the
+// component catches that.
+
+const { availabilityMock, selectMenuSpy } = vi.hoisted(() => ({
+  availabilityMock: vi.fn(),
+  selectMenuSpy: vi.fn(),
+}));
+
+vi.mock('~/components/Filters/useSortAvailability', () => ({
+  useSortAvailability: availabilityMock,
+}));
+
+// Mocked even though the component no longer calls it, so that REVERTING the fix
+// fails on an assertion instead of on "useFeatureFlags can only be used inside
+// FeatureFlagsCtx". A revert that throws at render proves only that something
+// changed; a revert that returns the wrong option list names what broke. Do not
+// delete this because it looks unused — it is what makes the control legible.
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ canViewNsfw: availabilityMock().canViewNsfw }),
+}));
+
+vi.mock('~/components/ImageGeneration/GenerationForm/ResourceSelectProvider', () => ({
+  useResourceSelectContext: () => ({ sort: 'relevance', setSort: vi.fn() }),
+}));
+
+// Stubbed to capture the options it is handed. Asserting on rendered menu text would
+// mean opening a Mantine dropdown to see the items, which tests the menu rather than
+// the rule.
+vi.mock('~/components/SelectMenu/SelectMenu', () => ({
+  SelectMenuV2: (props: { options?: { label: string; value: string }[] }) => {
+    selectMenuSpy(props.options);
+    return null;
+  },
+}));
+
+import { ResourceSelectSort } from '~/components/ImageGeneration/GenerationForm/ResourceSelectFilters';
+
+const labelsFor = (availability: {
+  isModerator: boolean;
+  canViewNsfw: boolean;
+  showNsfw: boolean;
+}) => {
+  availabilityMock.mockReturnValue(availability);
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    createRoot(container).render(createElement(ResourceSelectSort));
+  });
+  expect(selectMenuSpy, 'SelectMenuV2 never rendered — the component moved').toHaveBeenCalled();
+  return (selectMenuSpy.mock.calls.at(-1)![0] as { label: string }[]).map((o) => o.label);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ResourceSelectSort options', () => {
+  it('offers Newest to a moderator on a domain that cannot view NSFW', () => {
+    // The finding. Before the shared predicate this returned Relevance + Popularity.
+    expect(labelsFor({ isModerator: true, canViewNsfw: false, showNsfw: false })).toEqual([
+      'Relevance',
+      'Popularity',
+      'Newest',
+    ]);
+  });
+
+  it('still withholds Newest from a non-moderator on that domain', () => {
+    // The control. Without it the case above passes against a build that offers every
+    // sort to everyone, which is a different bug — the rule not running at all.
+    expect(labelsFor({ isModerator: false, canViewNsfw: false, showNsfw: false })).toEqual([
+      'Relevance',
+      'Popularity',
+    ]);
+  });
+
+  it('does not withhold Newest from a non-moderator who merely browses SFW', () => {
+    // `showNsfw: false` withholds Newest on the IMAGES feed only. This picker is a
+    // model picker, so passing `type: 'models'` is load-bearing — passing 'images'
+    // would strip Newest here and this is the assertion that would catch it.
+    expect(labelsFor({ isModerator: false, canViewNsfw: true, showNsfw: false })).toEqual([
+      'Relevance',
+      'Popularity',
+      'Newest',
+    ]);
+  });
+});


### PR DESCRIPTION
Closes ClickUp [868kv6mzm](https://app.clickup.com/t/868kv6mzm). Approved by Justin.

## The bug

`ResourceSelectFilters.tsx` carried its own copy of the Newest-sort rule:

```ts
.filter((x) => !(!features.canViewNsfw && x.label === 'Newest'));
```

#4296 extracted that rule into `isSortAvailable` (`src/components/Filters/sort-availability.ts`) and moved **one** of the two copies. The extracted predicate gained a moderator bypass; this one did not.

Effect: a moderator on a domain without `canViewNsfw` sees **Newest** in every feed sort menu and **not** in the generation resource picker.

#4296 left this copy alone deliberately — applying the shared predicate changes what moderators see in a different feature, and doing that inside a hubs fix was the wrong place. Justin has approved the change on its own: *"We should make it universal there with the moderator bypass. I can't think of any reason why we wouldn't adopt the shared predicate."*

## The fix

```ts
.filter((x) => isSortAvailable({ type: 'models', value: x.label }, availability));
```

Two arguments are load-bearing and neither is obvious:

- **`type: 'models'`** — the `showNsfw` clause in `isSortAvailable` applies to the images feed alone. Passing `'images'` here would start stripping Newest from a *model* picker for any SFW-by-choice viewer. There is a test for exactly this.
- **`value: x.label`** — `resourceSort`'s keys are lowercase (`relevance|popularity|newest`) and the predicate matches on the display label.

The only behaviour change is the moderator bypass. For a non-moderator the emitted option list is identical to before, which the two control tests pin.

`useFeatureFlags` is no longer imported by this file; `useSortAvailability` supplies `canViewNsfw` along with `isModerator` and `showNsfw`.

## Verification

The test asserts the **picker's options**, not the predicate. `isSortAvailable` already has its own tests in `src/components/Filters/__tests__/sort-availability.test.ts` and they stay green if this component goes back to a private copy — only rendering the component catches that.

**The control — reverting the fix:**

```
Test Files  1 failed (1)
     Tests  1 failed | 2 passed (3)

AssertionError: expected [ 'Relevance', 'Popularity' ]
              to deeply equal [ 'Relevance', 'Popularity', 'Newest' ]
```

One test fails, naming the missing option. Both controls keep passing, so they are not merely co-failing with their neighbour.

Two deliberate choices in the test, both of which look like mistakes:

1. **`~/providers/FeatureFlagsProvider` is mocked even though the component no longer calls it.** Without it a revert dies at render with `useFeatureFlags can only be used inside FeatureFlagsCtx`. A crash proves *something* changed; an assertion names *what broke*. My first version of this control had exactly that problem — all 3 failed on a provider error rather than on the option list. There is a comment saying not to delete the mock as unused.
2. **The file is `.test.ts`, not `.test.tsx`.** The `unit` project's include is `src/**/*.test.ts`. As `.tsx` it collected zero tests and reported `No test files found` while exiting in a way that reads like a pass. It uses `createElement` rather than JSX for that reason.

Full unit suite on this branch, rebased onto current `main`:

```
Test Files  1376 passed | 1 skipped (1377)
     Tests  21551 passed | 27 skipped (21578)
```

1376 + 1 = 1377, so every file is accounted for. Stating that explicitly because the previous run on this branch reported `1373 passed | 1 skipped (1376)` — two vitest workers had died, two files never ran, and it exited 1 while reporting no failures. Zero `ELIFECYCLE` in this run.

`blocks.router.workflow.test.ts` collected **358** tests, so the submodule is initialised. `pnpm run typecheck` 0 errors; eslint clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)