### PR TITLE
fix(blocklist): enforce the message-pattern list on comments, and make both lists survive HTML and lookalikes

### DIFF
--- a/src/server/controllers/__tests__/comment.controller.block-check.test.ts
+++ b/src/server/controllers/__tests__/comment.controller.block-check.test.ts
@@ -10,8 +10,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * edits as well as creates.
  */
 
-const { amIBlockedByUser, mockCreateOrUpdateComment, mockHasEntityAccess } = vi.hoisted(() => ({
+const {
+  amIBlockedByUser,
+  mockCreateOrUpdateComment,
+  mockHasEntityAccess,
+  throwOnBlockedCommentContent,
+} = vi.hoisted(() => ({
   amIBlockedByUser: vi.fn(async (..._a: unknown[]): Promise<boolean> => false),
+  throwOnBlockedCommentContent: vi.fn(async (..._a: unknown[]): Promise<void> => undefined),
   mockCreateOrUpdateComment: vi.fn(
     async (..._a: unknown[]): Promise<unknown> => ({
       id: 1,
@@ -24,9 +30,7 @@ const { amIBlockedByUser, mockCreateOrUpdateComment, mockHasEntityAccess } = vi.
 }));
 
 vi.mock('~/server/services/user.service', () => ({ amIBlockedByUser }));
-vi.mock('~/server/services/blocklist.service', () => ({
-  throwOnBlockedLinkDomain: vi.fn(async () => undefined),
-}));
+vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedCommentContent }));
 vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
 vi.mock('~/server/rewards', () => ({ reportAcceptedReward: { apply: vi.fn() } }));
 vi.mock('~/server/services/common.service', () => ({
@@ -105,7 +109,38 @@ beforeEach(() => {
   vi.clearAllMocks();
   amIBlockedByUser.mockResolvedValue(false);
   mockHasEntityAccess.mockResolvedValue([{ hasAccess: true }]);
+  throwOnBlockedCommentContent.mockResolvedValue(undefined);
   arrange();
+});
+
+/**
+ * The blocklist guard is mocked in every suite that reaches a call site, so nothing observed
+ * that the wiring existed: deleting the call, or hardcoding `{ isModerator: true }` here, left
+ * the whole workspace green. The second is the production state 868kw2f8y was filed about.
+ */
+describe('upsertCommentHandler - blocklist guard wiring', () => {
+  it('runs the guard once on the submitted content, with the caller moderator flag', async () => {
+    await upsertCommentHandler({ ctx: ctx(), input: baseInput });
+    expect(throwOnBlockedCommentContent).toHaveBeenCalledTimes(1);
+    expect(throwOnBlockedCommentContent).toHaveBeenCalledWith('<p>hello</p>', {
+      isModerator: false,
+    });
+  });
+
+  it('forwards a moderator through to the guard rather than deciding locally', async () => {
+    await upsertCommentHandler({ ctx: ctx({ isModerator: true }), input: baseInput });
+    expect(throwOnBlockedCommentContent).toHaveBeenCalledWith('<p>hello</p>', {
+      isModerator: true,
+    });
+  });
+
+  // Ordering: a guard running AFTER the write would leave the phishing comment in the table
+  // and merely fail the request.
+  it('rejects before writing when the guard throws', async () => {
+    throwOnBlockedCommentContent.mockRejectedValueOnce(new Error('blocked'));
+    await expect(upsertCommentHandler({ ctx: ctx(), input: baseInput })).rejects.toThrow();
+    expect(mockCreateOrUpdateComment).not.toHaveBeenCalled();
+  });
 });
 
 describe('upsertCommentHandler — block enforcement', () => {

--- a/src/server/controllers/comment.controller.ts
+++ b/src/server/controllers/comment.controller.ts
@@ -38,7 +38,7 @@ import {
 import { DEFAULT_PAGE_SIZE } from '~/server/utils/pagination-helpers';
 import { dbRead } from '../db/client';
 import { hasEntityAccess } from '../services/common.service';
-import { throwOnBlockedLinkDomain } from '~/server/services/blocklist.service';
+import { throwOnBlockedCommentContent } from '~/server/services/blocklist.service';
 
 export const getCommentsInfiniteHandler = async ({
   input,
@@ -112,7 +112,7 @@ export const upsertCommentHandler = async ({
   input: CommentUpsertInput;
 }) => {
   try {
-    await throwOnBlockedLinkDomain(input.content);
+    await throwOnBlockedCommentContent(input.content, { isModerator: ctx.user.isModerator });
     const { ownerId, locked } = ctx;
     const { modelId } = input;
 

--- a/src/server/routers/__tests__/comics.router.createChapterComment.test.ts
+++ b/src/server/routers/__tests__/comics.router.createChapterComment.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as FeatureFlagsService from '~/server/services/feature-flags.service';
+
+/**
+ * `createChapterComment` is the third comment write path, and until 868kw2f8y it had no
+ * blocklist check of any kind — not even the link-domain one the other two carried. It is also
+ * the only one with no neighbouring suite to lean on: deleting the guard call was invisible to
+ * every test in the workspace.
+ *
+ * These assert the CALL and its ORDERING, which is all a mocked guard can pin. The ordering half
+ * is the point: a guard running after the writes would leave the phishing comment in the table
+ * and merely fail the request.
+ */
+
+const { throwOnBlockedCommentContent } = vi.hoisted(() => ({
+  throwOnBlockedCommentContent: vi.fn(async (..._a: unknown[]): Promise<void> => undefined),
+}));
+
+vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedCommentContent }));
+
+// `isFlagProtected` recomputes flags from the user via `getFeatureFlags` and ignores `ctx.features`,
+// so a non-moderator caller is FORBIDDEN before reaching the handler. Spread the real module rather
+// than listing exports, so this does not couple the suite to the router's whole import graph.
+vi.mock('~/server/services/feature-flags.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsService>()),
+  getFeatureFlags: () => ({ comicCreator: true }),
+}));
+
+import { comicsRouter } from '../comics.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const USER_ID = 7;
+
+function fakeCtx({ isModerator = false }: { isModerator?: boolean } = {}) {
+  return {
+    user: { id: USER_ID, isModerator },
+    // `isAcceptableOrigin` rejects with "Please use the public API instead" without this, which
+    // would make the rejection assertions below pass on the wrong error.
+    acceptableOrigin: true,
+    needsUpdate: false,
+    // Session auth, not an API key: `requiredScope` is checked against this.
+    tokenScope: TokenScope.Full,
+    // `comicCreator` opens `isFlagProtected`; `ruOrchestratorProxy` absent makes the region
+    // proxy middleware early-return without touching the response.
+    features: { comicCreator: true } as never,
+    req: undefined,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    track: { comment: vi.fn(), commentEvent: vi.fn() } as never,
+    ip: '127.0.0.1',
+    fingerprint: 'test' as never,
+  };
+}
+
+const input = { projectId: 1, chapterPosition: 0, content: '<p>nice chapter</p>' } as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  throwOnBlockedCommentContent.mockResolvedValue(undefined);
+  dbMock.dbWrite.thread.upsert.mockResolvedValue({ id: 1, locked: false });
+  dbMock.dbWrite.commentV2.create.mockResolvedValue({
+    id: 99,
+    content: 'x',
+    createdAt: new Date(),
+  });
+  dbMock.dbWrite.thread.update.mockResolvedValue({ id: 1 });
+  dbMock.dbRead.comicProject.findUnique.mockResolvedValue({ userId: USER_ID, name: 'p' });
+});
+
+describe('comics.createChapterComment - blocklist guard wiring', () => {
+  it('runs the guard once on the submitted content, with the caller moderator flag', async () => {
+    const caller = comicsRouter.createCaller(fakeCtx() as never);
+    await caller.createChapterComment(input);
+
+    expect(throwOnBlockedCommentContent).toHaveBeenCalledTimes(1);
+    expect(throwOnBlockedCommentContent).toHaveBeenCalledWith('<p>nice chapter</p>', {
+      isModerator: false,
+    });
+  });
+
+  it('forwards a moderator through to the guard rather than deciding locally', async () => {
+    const caller = comicsRouter.createCaller(fakeCtx({ isModerator: true }) as never);
+    await caller.createChapterComment(input);
+
+    expect(throwOnBlockedCommentContent).toHaveBeenCalledWith('<p>nice chapter</p>', {
+      isModerator: true,
+    });
+  });
+
+  it('rejects before writing the comment OR the thread when the guard throws', async () => {
+    throwOnBlockedCommentContent.mockRejectedValueOnce(new Error('blocked'));
+    const caller = comicsRouter.createCaller(fakeCtx() as never);
+
+    // Named, not bare: a bare `.rejects.toThrow()` passes on any middleware rejection, which is
+    // exactly how this test passed while the two above were failing on an auth error.
+    await expect(caller.createChapterComment(input)).rejects.toThrow('blocked');
+    expect(dbMock.dbWrite.commentV2.create).not.toHaveBeenCalled();
+    // The thread upsert too: a rejected comment must not leave a Thread row behind, which is
+    // why the guard sits above it rather than beside the create.
+    expect(dbMock.dbWrite.thread.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/comics.router.ts
+++ b/src/server/routers/comics.router.ts
@@ -10,6 +10,9 @@ import {
   isFlagProtected,
 } from '~/server/trpc';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { throwOnBlockedCommentContent } from '~/server/services/blocklist.service';
+import { getSanitizedStringSchema } from '~/server/schema/utils.schema';
+import { COMMENT_ALLOWED_TAGS } from '~/utils/html-sanitize-helpers';
 import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 import { regionProxyMiddleware } from '~/server/orchestrator/region-proxy.middleware';
 import {
@@ -6285,10 +6288,23 @@ export const comicsRouter = router({
       z.object({
         projectId: z.number().int(),
         chapterPosition: z.number().int().min(0),
-        content: z.string().min(1).max(10000),
+        // Sanitised like every other comment write. Without this the row reached both the
+        // blocklist guard and the database as raw HTML, so an entity-escaped host
+        // (`blocked&#46;example`) carried no literal dot for the link matcher to see and then
+        // decoded back to a live URL in `RenderHtml` at read time — a bypass the other two
+        // paths do not have, because their zod schema decodes entities before the guard runs.
+        //
+        // No `allowStickers`: this path does not charge for sticker uses the way `upsertComment`
+        // does, so permitting the markup here would make paid stickers free.
+        content: getSanitizedStringSchema({ allowedTags: COMMENT_ALLOWED_TAGS })
+          .refine((v) => v.length > 0, 'Cannot be empty')
+          .refine((v) => v.length <= 10000, 'Comment content too long'),
       })
     )
     .mutation(async ({ ctx, input }) => {
+      // Before the thread upsert: a rejected comment must not leave a Thread row behind.
+      await throwOnBlockedCommentContent(input.content, { isModerator: ctx.user.isModerator });
+
       // Find or create thread for this chapter (upsert avoids race condition)
       const thread = await dbWrite.thread.upsert({
         where: {

--- a/src/server/services/__tests__/blocklist.comment-content.service.test.ts
+++ b/src/server/services/__tests__/blocklist.comment-content.service.test.ts
@@ -1,0 +1,349 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+import { throwOnBlockedCommentContent } from '../blocklist.service';
+import { BlocklistType } from '~/server/common/enums';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
+
+void dbMock;
+void loggingMock;
+
+const redisGet = redisMock.redis.get;
+
+/**
+ * `getBlocklistData` reads redis first and skips the DB entirely on a hit, so a keyed
+ * `get` stub drives the whole guard. Keyed rather than a flat `mockResolvedValue` because
+ * this guard reads BOTH lists — one blob would serve the patterns as link domains too.
+ */
+function setLists({ domains = [], patterns = [] }: { domains?: string[]; patterns?: string[] }) {
+  redisGet.mockImplementation(async (key: string) => {
+    if (key.endsWith(`:${BlocklistType.LinkDomain}`))
+      return JSON.stringify({ type: BlocklistType.LinkDomain, data: domains });
+    if (key.endsWith(`:${BlocklistType.MessagePattern}`))
+      return JSON.stringify({ type: BlocklistType.MessagePattern, data: patterns });
+    return null;
+  });
+}
+
+const rejection = async (content: string) => {
+  try {
+    await throwOnBlockedCommentContent(content);
+  } catch (e) {
+    return e;
+  }
+  return null;
+};
+
+const PHISH = 'phish-verify592807.example';
+
+describe('throwOnBlockedCommentContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lets an ordinary comment through', async () => {
+    setLists({
+      domains: ['blocked.example'],
+      patterns: [PHISH, 'to safely unlock your held balance'],
+    });
+    await expect(
+      throwOnBlockedCommentContent('<p>Great model, thanks for sharing!</p>')
+    ).resolves.toBeUndefined();
+  });
+
+  /**
+   * The ticket itself (868kw2f8y). `MessagePattern` was enforced on DMs and on nothing else,
+   * which is how 366 accounts posted phishing comments in four hours on 2026-08-24. Revert the
+   * `MessagePattern` read in `throwOnBlockedCommentContent` and this is the assertion that fails.
+   */
+  it('enforces the MessagePattern list on comments, not only on DMs', async () => {
+    setLists({ patterns: ['to safely unlock your held balance'] });
+
+    const error = await rejection(
+      '<p>Please verify your identity to safely unlock your held balance.</p>'
+    );
+    expect(error).toBeInstanceOf(TRPCError);
+    expect((error as TRPCError).code).toBe('BAD_REQUEST');
+  });
+
+  /**
+   * 🔴 Do not "simplify" this guard to scan one normalised form. Each case below is a form
+   * that a DIFFERENT single choice misses, and all four were measured against the real
+   * sanitiser before this test was written:
+   *
+   * - a tag inside the pattern defeats the raw string
+   * - an `href` is gone once tags are stripped, so the stripped form misses a link whose
+   *   visible text is only "click"
+   * - `removeTags` joins with a SPACE, which does not close the first case
+   * - joining with nothing glues adjacent block tags, which breaks a pattern needing the space
+   *
+   * If you remove a form, one of these four goes green-but-useless rather than failing.
+   */
+  describe('scans every form, because no single form covers all of them', () => {
+    it('catches a pattern split by an inline tag', async () => {
+      setLists({ patterns: [PHISH] });
+      const error = await rejection(
+        `<p>Verify at https://phish-verify<strong>5</strong>92807.example/x</p>`
+      );
+      expect(error).toBeInstanceOf(TRPCError);
+    });
+
+    it('catches a pattern split by a sticker span', async () => {
+      setLists({ patterns: [PHISH] });
+      const error = await rejection(
+        `<p>https://phish-verify<span data-type="sticker" data-id="1"></span>592807.example/x</p>`
+      );
+      expect(error).toBeInstanceOf(TRPCError);
+    });
+
+    it('catches a blocked domain that exists only inside an href', async () => {
+      setLists({ domains: ['phish-verify592807.example'] });
+      const error = await rejection(`<p><a href="https://${PHISH}/x" rel="ugc">click</a></p>`);
+      expect(error).toBeInstanceOf(TRPCError);
+    });
+
+    it('catches a multi-word pattern spanning two block tags', async () => {
+      setLists({ patterns: ['unlock your held balance'] });
+      const error = await rejection('<p>unlock</p><p>your held balance</p>');
+      expect(error).toBeInstanceOf(TRPCError);
+    });
+  });
+
+  /**
+   * 19 of the 90 live entries are non-ASCII, several of them Unicode skins of an entry that is
+   * also on the list in ASCII — moderators were adding a row per alphabet because the matcher
+   * compared code points. Both directions have to work or the folding is worse than useless:
+   * fold only the content and those 19 entries stop matching anything at all.
+   */
+  describe('folds confusables on both sides', () => {
+    it('catches small-caps content against an ASCII pattern', async () => {
+      setLists({ patterns: ['example security desk'] });
+      const error = await rejection('<p>ᴇxᴀᴍᴘʟᴇ sᴇᴄᴜʀɪᴛʏ ᴅᴇsᴋ here, verify your account</p>');
+      expect(error).toBeInstanceOf(TRPCError);
+    });
+
+    /**
+     * 🔴 The stored PATTERN is deliberately not folded, and this is the test that says so.
+     * Do not "fix" it by folding entries in `substringEntries` so a stylised row catches its
+     * ASCII spelling. Measured on the live list: 17 of the 19 non-ASCII rows fold to a string
+     * nobody added, and two fold to a single ordinary English word that appeared in 44 of
+     * 94,376 comments and 42 of 87,113 DMs over 30 days. A substring rule that eats a common
+     * word cannot be undone by a moderator; a missing ASCII row can be added by one. The live
+     * rows are deliberately not quoted here — this repo is public.
+     */
+    it('does not let a stylised entry become an ASCII rule nobody wrote', async () => {
+      setLists({ patterns: ['ᴀᴄᴄᴏᴜɴᴛ'] });
+      await expect(
+        throwOnBlockedCommentContent('<p>Updated my account settings, thanks!</p>')
+      ).resolves.toBeUndefined();
+
+      // Control: the stylised spelling the moderator actually typed is still blocked, so the
+      // pass above is the entry staying narrow rather than the rule being inert.
+      expect(await rejection('<p>complete your ᴀᴄᴄᴏᴜɴᴛ now</p>')).toBeInstanceOf(TRPCError);
+    });
+
+    /**
+     * Link domains are matched with `===` against `url.host`, so folding a stored domain yields
+     * one more exact host and cannot broaden anything - which is why `exactEntries` folds and
+     * `substringEntries` does not. Drop the fold in `exactEntries` and this fails: 6 of the 696
+     * live domain rows are non-ASCII and would then enforce nothing.
+     */
+    it('catches an ASCII host against a non-ASCII stored domain entry', async () => {
+      setLists({
+        domains: [
+          '\u{1D5BE}\u{1D5D1}\u{1D5BA}\u{1D5C6}\u{1D5C9}\u{1D5C5}\u{1D5BE}verify.short.example',
+        ],
+      });
+      const error = await rejection('<p>go to https://exampleverify.short.example/x now</p>');
+      expect(error).toBeInstanceOf(TRPCError);
+    });
+
+    /**
+     * NFKC specifically. Obscenity's confusables map already covers fullwidth and several maths
+     * blocks, so most stylised fixtures still pass with `.normalize('NFKC')` deleted. U+1D42F
+     * (MATHEMATICAL BOLD SMALL V) is one the map does NOT carry, so this is the fixture that
+     * actually pins the step.
+     */
+    it('catches a mathematical-alphanumeric character the confusables map does not cover', async () => {
+      setLists({ patterns: ['phish-verify592807.example'] });
+      const error = await rejection('<p>go to phish-\u{1D42F}erify592807.example now</p>');
+      expect(error).toBeInstanceOf(TRPCError);
+    });
+
+    /**
+     * The variation selector supplement (U+E0100-U+E01EF) is category `Mn`, so `\p{Cf}` misses
+     * it - the same bypass as the tag characters above, one block over.
+     */
+    it('catches a variation selector inserted mid-pattern', async () => {
+      setLists({ patterns: [PHISH] });
+      const error = await rejection('<p>go to phish-verify\u{E0100}592807.example now</p>');
+      expect(error).toBeInstanceOf(TRPCError);
+    });
+
+    it('catches a Cyrillic lookalike domain', async () => {
+      setLists({ patterns: [PHISH] });
+      // The leading character is U+0440 (Cyrillic er), not an ASCII `p`. It is invisible as a
+      // difference, so do not retype this fixture by eye.
+      const error = await rejection('<p>go to рhish-verify592807.example now</p>');
+      expect(error).toBeInstanceOf(TRPCError);
+    });
+
+    it('catches a zero-width space inserted mid-pattern', async () => {
+      setLists({ patterns: [PHISH] });
+      const error = await rejection('<p>go to phish-verify​592807.example now</p>');
+      expect(error).toBeInstanceOf(TRPCError);
+    });
+
+    /**
+     * A hand-written list of invisible characters is a normaliser with an invisible hole. This
+     * one is a Unicode TAG character (U+E0020) - renders as nothing, legal between two letters,
+     * and missed by the enumeration that preceded `\p{Cf}` here, along with 144 others.
+     * Narrow `INVISIBLE` in `confusable-fold.ts` back to a literal list and this is what fails.
+     */
+    it('catches an invisible character outside the obvious zero-width block', async () => {
+      setLists({ patterns: [PHISH] });
+      const error = await rejection('<p>go to phish-verify\u{E0020}592807.example now</p>');
+      expect(error).toBeInstanceOf(TRPCError);
+    });
+
+    /**
+     * 🔴 The one way this feature can take the site down. `includes('')` is true for every
+     * string, so a single empty pattern blocks every comment — and folding MANUFACTURES that
+     * case, because a pattern of nothing but invisible characters folds to `''`. Delete the
+     * `.filter(...)` in `matchableEntries` and this test is the only thing that says so.
+     */
+    it('does not block every comment when a pattern folds away to nothing', async () => {
+      setLists({ patterns: ['​​', ''] });
+      await expect(
+        throwOnBlockedCommentContent('<p>Lovely work, thanks for posting.</p>')
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  /**
+   * Host spellings that mean the same host to a browser but not to `===`. Each of these was
+   * verified to PASS the guard before the fix, against an entry the plain URL is blocked by.
+   */
+  describe('normalises the host before comparing it to the domain list', () => {
+    const DOMAIN = 'blocked.example';
+
+    it('blocks a plain URL (the control the three below are measured against)', async () => {
+      setLists({ domains: [DOMAIN] });
+      expect(await rejection('<p>see https://blocked.example/x</p>')).toBeInstanceOf(TRPCError);
+    });
+
+    /**
+     * The one that mattered most. `sanitizeHtml` stores a scheme-relative href verbatim, the
+     * browser resolves it to a live link, and a scheme-anchored regex sees no URL at all - so
+     * this defeated the whole domain half of the guard with a one-character edit.
+     */
+    it('blocks a scheme-relative href', async () => {
+      setLists({ domains: [DOMAIN] });
+      expect(
+        await rejection('<p><a href="//blocked.example/x" rel="ugc">click</a></p>')
+      ).toBeInstanceOf(TRPCError);
+    });
+
+    it('blocks a host carrying a non-default port', async () => {
+      setLists({ domains: [DOMAIN] });
+      expect(await rejection('<p>see http://blocked.example:8080/x</p>')).toBeInstanceOf(TRPCError);
+    });
+
+    it('blocks a trailing-dot FQDN', async () => {
+      setLists({ domains: [DOMAIN] });
+      expect(await rejection('<p>see https://blocked.example./x</p>')).toBeInstanceOf(TRPCError);
+    });
+
+    /**
+     * The cost of making the scheme optional: a bare `//` now anchors a match wherever it
+     * appears, so a pasted path or code comment can be parsed as a link. That direction only
+     * ever over-blocks, never bypasses — these three pin where the line actually falls, because
+     * "it only over-blocks" is not an answer to "does it reject legitimate comments".
+     */
+    it('ignores a scheme-less path with no dotted host in it', async () => {
+      setLists({ domains: [DOMAIN] });
+      await expect(
+        throwOnBlockedCommentContent('<pre><code>src = "//assets/img/logo.png";</code></pre>')
+      ).resolves.toBeUndefined();
+    });
+
+    it('ignores a scheme-less path whose host is not on the list', async () => {
+      setLists({ domains: [DOMAIN] });
+      await expect(
+        throwOnBlockedCommentContent('<pre><code>fetch("//cdn.jsdelivr.net/x");</code></pre>')
+      ).resolves.toBeUndefined();
+    });
+
+    // The one real over-block, pinned as chosen: a scheme-less reference to a LISTED host is
+    // still a working link once rendered, so blocking it in a code block is the right answer.
+    it('blocks a scheme-less reference to a listed host even inside a code block', async () => {
+      setLists({ domains: [DOMAIN] });
+      expect(
+        await rejection('<pre><code>fetch("//blocked.example/x");</code></pre>')
+      ).toBeInstanceOf(TRPCError);
+    });
+
+    // Not covered on purpose: matching a subdomain against a bare entry would also block every
+    // subdomain of every host on the list, which is a moderation decision rather than a
+    // normalisation one. Pinned so the omission reads as chosen.
+    it('does NOT block a subdomain of a listed host', async () => {
+      setLists({ domains: [DOMAIN] });
+      await expect(
+        throwOnBlockedCommentContent('<p>see https://www.blocked.example/x</p>')
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  /**
+   * `' '` is a substring of essentially every comment, so a single whitespace entry is the same
+   * site-wide outage as an empty one. The write path filters on length alone, so a moderator
+   * pasting a stray space stores one.
+   */
+  it('does not block every comment when an entry is only whitespace', async () => {
+    setLists({ patterns: [' ', '\u00a0'] });
+    await expect(
+      throwOnBlockedCommentContent('<p>Lovely work, thanks for posting.</p>')
+    ).resolves.toBeUndefined();
+  });
+
+  /**
+   * Decision 1, 2026-08-24: moderators are exempt, as they already are on DMs. Several of these
+   * patterns ARE the phishing text, and quoting it to warn people is a thing moderators do —
+   * there is a live comment on the site doing exactly that.
+   */
+  it('exempts moderators from BOTH lists, links included', async () => {
+    setLists({ patterns: ['to safely unlock your held balance'], domains: ['blocked.example'] });
+
+    // The link half is the deliberate part: on `main` moderators WERE subject to the
+    // link-domain check on comments, and this exemption removes that. Justin's call,
+    // 2026-08-24, asked explicitly after the review flagged it as an unintended relaxation.
+    // Do not restore the link check for moderators without re-asking.
+    await expect(
+      throwOnBlockedCommentContent('<p>this scam links to https://blocked.example/x</p>', {
+        isModerator: true,
+      })
+    ).resolves.toBeUndefined();
+    expect(await rejection('<p>this scam links to https://blocked.example/x</p>')).toBeInstanceOf(
+      TRPCError
+    );
+
+    setLists({ patterns: ['to safely unlock your held balance'] });
+
+    await expect(
+      throwOnBlockedCommentContent(
+        '<p>Scam alert: "to safely unlock your held balance" is a phish.</p>',
+        {
+          isModerator: true,
+        }
+      )
+    ).resolves.toBeUndefined();
+
+    // Control: the same content from a non-moderator is rejected, so the pass above is the
+    // exemption and not an inert list.
+    expect(
+      await rejection('<p>Scam alert: "to safely unlock your held balance" is a phish.</p>')
+    ).toBeInstanceOf(TRPCError);
+  });
+});

--- a/src/server/services/__tests__/blocklist.service.test.ts
+++ b/src/server/services/__tests__/blocklist.service.test.ts
@@ -10,6 +10,7 @@ import {
   getClientBenignLists,
   stripBenignPhrases,
   throwOnBlockedLinkDomain,
+  throwOnBlockedMessagePattern,
   upsertBlocklist,
 } from '../blocklist.service';
 import { BlocklistType } from '~/server/common/enums';
@@ -303,5 +304,63 @@ describe('getClientBenignLists', () => {
 
     expect(result.prompt).toEqual(['teen titans']);
     expect(result.profanityWords).toEqual(['spreadsheet']);
+  });
+});
+
+/**
+ * The DM path. It was the only surface enforcing `MessagePattern` before 868kw2f8y and it had no
+ * test at all, so the folding added to it there was unobserved - and the empty-entry case is
+ * WORSE here than on comments: this path throws a plain `Error`, which the tRPC layer turns into
+ * a 500 on every DM, where the comment path throws a BAD_REQUEST.
+ */
+describe('throwOnBlockedMessagePattern', () => {
+  const setPatterns = (patterns: string[]) =>
+    redisGet.mockResolvedValue(
+      JSON.stringify({ type: BlocklistType.MessagePattern, data: patterns })
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lets an ordinary message through', async () => {
+    setPatterns(['to safely unlock your held balance']);
+    await expect(
+      throwOnBlockedMessagePattern('hey, nice work on that model')
+    ).resolves.toBeUndefined();
+  });
+
+  it('blocks a message matching a pattern', async () => {
+    setPatterns(['to safely unlock your held balance']);
+    await expect(
+      throwOnBlockedMessagePattern('click here to safely unlock your held balance')
+    ).rejects.toThrow();
+  });
+
+  // The half of decision 2C that reaches DMs: content is folded, so a lookalike spelling still
+  // meets an ASCII rule. Remove the folded second pass and this is what fails.
+  it('folds the message so a lookalike spelling still matches an ASCII pattern', async () => {
+    setPatterns(['example security desk']);
+    // Small-caps, not ASCII.
+    await expect(
+      throwOnBlockedMessagePattern(
+        '\u1D07x\u1D00\u1D0D\u1D18\u029F\u1D07 s\u1D07\u1D04\u1D1C\u0280\u026A\u1D1B\u028F \u1D05\u1D07s\u1D0B here'
+      )
+    ).rejects.toThrow();
+  });
+
+  // Entries are NOT folded, for the same reason as on comments: `includes` means a folded entry
+  // becomes a broader rule. See the comment on `substringEntries`.
+  it('does not let a stylised entry become an ASCII rule nobody wrote', async () => {
+    setPatterns(['\u1D00\u1D04\u1D04\u1D0F\u1D1C\u0274\u1D1B']);
+    await expect(
+      throwOnBlockedMessagePattern('updated my account settings')
+    ).resolves.toBeUndefined();
+  });
+
+  // A 500 on every DM if this regresses.
+  it('does not block every message when an entry is empty', async () => {
+    setPatterns(['', 'to safely unlock your held balance']);
+    await expect(throwOnBlockedMessagePattern('hello there')).resolves.toBeUndefined();
   });
 });

--- a/src/server/services/__tests__/commentsv2.appListing.service.test.ts
+++ b/src/server/services/__tests__/commentsv2.appListing.service.test.ts
@@ -44,7 +44,7 @@ write.commentV2.update.mockResolvedValue({ id: 1 });
 write.$transaction.mockImplementation(async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx));
 // No blocklist round-trip in a unit test; the comment content passes.
 vi.mock('~/server/services/blocklist.service', () => ({
-  throwOnBlockedLinkDomain: vi.fn(async () => undefined),
+  throwOnBlockedCommentContent: vi.fn(async () => undefined),
 }));
 // otel `withSpan` → passthrough (avoid booting the telemetry SDK in node env).
 vi.mock('~/server/utils/otel-helpers', () => ({

--- a/src/server/services/__tests__/commentsv2.blockCheck.service.test.ts
+++ b/src/server/services/__tests__/commentsv2.blockCheck.service.test.ts
@@ -8,8 +8,9 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
  * only creates left the block trivially bypassable.
  */
 
-const { amIBlockedByUser, tx } = vi.hoisted(() => ({
+const { amIBlockedByUser, throwOnBlockedCommentContent, tx } = vi.hoisted(() => ({
   amIBlockedByUser: vi.fn(async (..._a: unknown[]): Promise<boolean> => false),
+  throwOnBlockedCommentContent: vi.fn(async (..._a: unknown[]): Promise<void> => undefined),
   // 🔴 `tx` stays a SEPARATE object from the write client, because every assertion below is
   // on `db.tx.*` and means "written inside the transaction". Inheriting the canonical
   // `$transaction` would hand the callback `dbMock.dbWrite` and collapse the two, so an
@@ -55,9 +56,7 @@ dbMock.dbWrite.$transaction.mockImplementation(async (cb: (t: typeof tx) => Prom
 );
 
 vi.mock('~/server/services/user.service', () => ({ amIBlockedByUser }));
-vi.mock('~/server/services/blocklist.service', () => ({
-  throwOnBlockedLinkDomain: vi.fn(async () => undefined),
-}));
+vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedCommentContent }));
 vi.mock('~/server/utils/otel-helpers', () => ({
   withSpan: (_name: string, fn: () => unknown) => fn(),
 }));
@@ -74,6 +73,46 @@ const baseCreate = {
 beforeEach(() => {
   vi.clearAllMocks();
   amIBlockedByUser.mockResolvedValue(false);
+  throwOnBlockedCommentContent.mockResolvedValue(undefined);
+});
+
+/**
+ * The blocklist guard is wired at exactly three call sites and mocked in every suite that
+ * reaches one, so nothing observed that the wiring existed: deleting the call in
+ * `commentsv2.service.ts`, or hardcoding `{ isModerator: true }`, left the whole workspace
+ * green. That second mutation is the production state 868kw2f8y was filed about.
+ *
+ * These assert the CALL, which is the only thing a mocked guard can pin.
+ */
+describe('upsertComment - blocklist guard wiring', () => {
+  it('runs the guard once, passing the author moderator flag', async () => {
+    await upsertComment({ ...baseCreate });
+    expect(throwOnBlockedCommentContent).toHaveBeenCalledTimes(1);
+    expect(throwOnBlockedCommentContent).toHaveBeenCalledWith('hello', { isModerator: undefined });
+  });
+
+  it('forwards a moderator through to the guard rather than deciding locally', async () => {
+    await upsertComment({ ...baseCreate, isModerator: true } as Parameters<
+      typeof upsertComment
+    >[0]);
+    expect(throwOnBlockedCommentContent).toHaveBeenCalledWith('hello', { isModerator: true });
+  });
+
+  // Ordering, which nothing else pins: a guard that ran AFTER the write would leave the
+  // phishing comment in the table and merely fail the request.
+  it('rejects before writing anything when the guard throws', async () => {
+    throwOnBlockedCommentContent.mockRejectedValueOnce(new Error('blocked'));
+    await expect(upsertComment({ ...baseCreate })).rejects.toThrow('blocked');
+    expect(db.tx.commentV2.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects before writing anything on the edit path too', async () => {
+    throwOnBlockedCommentContent.mockRejectedValueOnce(new Error('blocked'));
+    await expect(
+      upsertComment({ ...baseCreate, id: 5 } as Parameters<typeof upsertComment>[0])
+    ).rejects.toThrow('blocked');
+    expect(db.tx.commentV2.update).not.toHaveBeenCalled();
+  });
 });
 
 describe('upsertComment — block enforcement on create', () => {

--- a/src/server/services/blocklist.service.ts
+++ b/src/server/services/blocklist.service.ts
@@ -8,6 +8,8 @@ import { throwBadRequestError } from '~/server/utils/errorHandling';
 import { createLruCache } from '~/server/utils/lru-cache';
 import { logToAxiom } from '~/server/logging/client';
 import { buildBenignPhraseRegex, stripBenignPhrasesWith } from '~/shared/utils/benign-phrases';
+import { removeTags, removeTagsCompact } from '~/utils/string-helpers';
+import { foldConfusables } from '~/server/utils/confusable-fold';
 
 export type BlocklistDTO = {
   id?: number;
@@ -110,19 +112,42 @@ export async function getBlocklistData(type: BlocklistType) {
 }
 
 // #region [blocked links]
-export async function throwOnBlockedLinkDomain(value: string) {
-  const blockedDomains = await getBlocklistData(BlocklistType.LinkDomain);
-  const matches = value
-    .toLowerCase()
-    .match(
-      /(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])/gim
-    );
+/**
+ * The scheme is OPTIONAL, which is the whole point of the leading group. `sanitizeHtml` stores a
+ * scheme-relative `href` verbatim (it prepends `http://` only to compute the host it checks), so
+ * `<a href="//evil.example/x">click</a>` survives to the database and the browser resolves it to
+ * a live link — while a scheme-anchored regex sees no URL at all and the guard passes it.
+ * A dotted host is still required after the slashes, so ordinary `//` in prose does not match.
+ */
+const LINK_PATTERN =
+  /(?:(?:http|ftp|https):)?\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])/gim;
+
+/**
+ * The spellings of a host that mean the same host to a browser but not to `===`.
+ *
+ * `url.host` carries the port, and a trailing dot is a legal absolute-root FQDN, so
+ * `evil.example:8080` and `evil.example.` both resolve for the reader and both miss an entry of
+ * `evil.example`. Comparing against every spelling can only match more, never less.
+ *
+ * Subdomains are deliberately NOT covered: matching `www.evil.example` against an entry of
+ * `evil.example` is a moderation policy change (it would also block every subdomain of any host
+ * on the list), not a normalisation fix.
+ */
+function hostSpellings(url: URL) {
+  const withoutPort = url.hostname;
+  return [url.host, withoutPort, withoutPort.replace(/\.$/, '')];
+}
+
+function findBlockedLinkDomains(value: string, blockedDomains: string[]) {
+  const matches = value.toLowerCase().match(LINK_PATTERN);
   const blockedFor: string[] = [];
   if (matches) {
     for (const match of matches) {
       let url: URL;
       try {
-        url = new URL(match);
+        // A scheme-relative match has no scheme for `new URL()` to parse. Which scheme we
+        // invent is irrelevant — only the host is read back.
+        url = new URL(match.startsWith('//') ? `https:${match}` : match);
       } catch {
         // A regex-matched substring that `new URL()` can't parse isn't a URL we
         // can attribute to a host, so it can't be a blocked-domain hit. Skip it
@@ -131,9 +156,16 @@ export async function throwOnBlockedLinkDomain(value: string) {
         // matches the link regex but `new URL()` rejects the invalid IPv4 octet.
         continue;
       }
-      if (blockedDomains.some((x) => x === url.host)) blockedFor.push(match);
+      const spellings = hostSpellings(url);
+      if (blockedDomains.some((x) => spellings.includes(x))) blockedFor.push(match);
     }
   }
+  return blockedFor;
+}
+
+export async function throwOnBlockedLinkDomain(value: string) {
+  const blockedDomains = await getBlocklistData(BlocklistType.LinkDomain);
+  const blockedFor = findBlockedLinkDomains(value, blockedDomains);
 
   // User-input validation rejection → BAD_REQUEST (400), not a plain Error (which
   // the tRPC layer would wrap as INTERNAL_SERVER_ERROR / 500).
@@ -207,13 +239,141 @@ export async function getClientBenignLists(): Promise<ClientBenignLists> {
 // #endregion
 
 // #region [blocked message patterns]
+/**
+ * Returns the matched pattern, or `undefined`. Callers must test against `undefined` and NOT
+ * for truthiness: an empty pattern matches every string and returns `''`, so a truthiness test
+ * silently swallows exactly the case `substringEntries` exists to prevent — and swallowing it
+ * looks like the guard working.
+ */
+function findBlockedPattern(value: string, blockedPatterns: string[]) {
+  const lowerValue = value.toLowerCase();
+  return blockedPatterns.find((pattern) => lowerValue.includes(pattern));
+}
+
+/**
+ * Entries for a SUBSTRING match. Empties dropped, and deliberately NOT folded.
+ *
+ * 🔴 Folding a substring rule rewrites what the rule means. Measured against the 90 live
+ * `MessagePattern` rows: 17 of the 19 non-ASCII ones fold to a string nobody added, and two of
+ * them fold to a single ordinary English word. Their live ASCII neighbours are all narrow
+ * multi-word phrases containing that word, so a moderator adding a stylised-only row was
+ * drawing exactly that distinction. Folding erases it, and `includes` then rejects every
+ * comment carrying the bare word — 44 of 94,376 comments and 42 of 87,113 DMs over 30 days on
+ * production. (The rows are not quoted here: this repo is public, and a term list tells a
+ * reader what is blocked while a stated absence tells them what is not.)
+ *
+ * Folding the CONTENT is still done, and is the half that stops the bypass: homoglyph text
+ * reaches an ASCII rule that way. The other consequence, stated because it is not obvious: a
+ * folded form is always ASCII, so a non-ASCII entry can only ever be found in the RAW form,
+ * byte for byte. 19 of the 90 live rows are in that position. That is not a regression — they
+ * were equally narrow on DMs before this — but it is the reason the answer is to normalise at
+ * WRITE time in the moderator UI, where broadening a rule can be a visible deliberate act. The cost of not folding entries is narrower and it is the safe
+ * direction — a stylised-only row no longer catches the plain-ASCII spelling, which a moderator
+ * can add as a row, whereas nobody can undo a rule that silently ate a common word.
+ *
+ * 🔴 The empty filter is not defensive tidying either. `includes('')` is true for every string,
+ * so one empty entry blocks every comment on the site.
+ */
+function substringEntries(entries: string[]) {
+  return entries.filter((entry) => entry.trim().length > 0);
+}
+
+/**
+ * Entries for an EXACT match — link domains, compared with `===` against `url.host`.
+ *
+ * These ARE folded, and safely enough: an exact-match rule cannot broaden WITHIN a namespace,
+ * because a folded host is just one more host that has to be equalled in full. Note the
+ * qualifier — folding crosses namespaces, so a lookalike entry manufactures the REAL domain as
+ * a live rule. Checked against the 6 non-ASCII rows live today: every one folds to its intended
+ * target and none is a mainstream domain. Adding a lookalike of a domain we do not want to
+ * block would block it here and nowhere else, since `throwOnBlockedLinkDomain` does not fold. That is the whole difference from
+ * `substringEntries` above, and it is why the two exist separately rather than as one helper
+ * with a flag. 6 of the 696 live link domains are non-ASCII — styled Unicode and
+ * invisible-character spellings — and folding them is what makes those rows enforce at all.
+ */
+function exactEntries(entries: string[]) {
+  return [...new Set([...entries, ...entries.map(foldConfusables)])].filter(
+    (entry) => entry.trim().length > 0
+  );
+}
+
 export async function throwOnBlockedMessagePattern(value: string) {
   const blockedPatterns = await getBlocklistData(BlocklistType.MessagePattern);
   if (!blockedPatterns.length) return;
 
-  const lowerValue = value.toLowerCase();
-  const matched = blockedPatterns.find((pattern) => lowerValue.includes(pattern));
-  if (matched) throw new Error(`Message blocked by content filter`);
+  const matchable = substringEntries(blockedPatterns);
+  const matched =
+    findBlockedPattern(value, matchable) ?? findBlockedPattern(foldConfusables(value), matchable);
+  // BAD_REQUEST, not a bare `Error`: this is a rejection of user input, and a plain throw
+  // reaches the client as a 500 that tells the sender nothing.
+  if (matched !== undefined) throwBadRequestError('Message blocked by content filter');
+}
+// #endregion
+
+// #region [comment content]
+/**
+ * The forms of a comment a pattern could be hiding in. Comments are stored as HTML, and
+ * scanning any single form has a measured hole in it:
+ *
+ * - the raw string misses a pattern split by a tag. `phish-verify<strong>5</strong>92807.example`
+ *   is the shape the editor stores, and `strong`/`em`/`u`/`s`/`span`/`code`/`a` all survive
+ *   `COMMENT_ALLOWED_TAGS`. A sticker `<span>` splits a pattern the same way.
+ * - the tag-stripped text misses anything that only exists in an attribute. Drop the tag from
+ *   `<a href="https://evil.example/x">click</a>` and the URL is gone; what is left is "click".
+ * - `removeTags` (tag to a space, then collapse) does not close the first hole — `id 592807`
+ *   still fails to match. Joining with nothing does not close the third: it glues
+ *   `<p>a</p><p>b</p>` into `ab`, so a multi-word pattern that needs the space stops matching.
+ *
+ * Hence every form, not a chosen one. Scanning an extra form can only make the filter match
+ * more, never less, so a form added later cannot open a bypass.
+ *
+ * 🔴 Keeping the RAW form is load-bearing beyond the `href` case. Because it is scanned, every
+ * literal substring of the stored string is always visible to the matcher, whatever malformed
+ * markup does to the derived forms — an attribute value containing `>` desynchronises the tag
+ * regex, and the raw form is what still carries the URL. Drop it as redundant (the other two
+ * look like supersets, and are not) and that guarantee goes with it.
+ *
+ * The collapse in `removeTags` is load-bearing, not tidiness: `</p><p>` becomes TWO spaces, and
+ * a pattern carrying one space then misses the very case this form exists for.
+ */
+export function scannableCommentForms(content: string) {
+  const forms = [content, removeTagsCompact(content), removeTags(content)];
+  return [...new Set([...forms, ...forms.map(foldConfusables)])];
+}
+
+/**
+ * Both blocklists over a comment. Comments never called the pattern list at all until now,
+ * which is how 366 accounts posted phishing comments in four hours on 2026-08-24 while the
+ * same patterns were being enforced on DMs.
+ *
+ * Moderators are exempt from BOTH lists. Several of these patterns ARE the phishing text, and
+ * quoting it to warn people is a thing moderators do — one such comment is live on the site
+ * today. The link half was raised explicitly (it was NOT exempt on `main`) and kept exempt on
+ * purpose, 2026-08-24; do not restore it without asking.
+ *
+ * The DM precedent is not uniform and should not be cited as though it were: chat SEND exempts
+ * moderators from both lists, chat EDIT exempts nobody.
+ */
+export async function throwOnBlockedCommentContent(
+  content: string,
+  { isModerator = false }: { isModerator?: boolean } = {}
+) {
+  if (isModerator) return;
+
+  const [blockedDomains, blockedPatterns] = await Promise.all([
+    getBlocklistData(BlocklistType.LinkDomain),
+    getBlocklistData(BlocklistType.MessagePattern),
+  ]);
+  const matchable = substringEntries(blockedPatterns);
+  const matchableDomains = exactEntries(blockedDomains);
+
+  for (const form of scannableCommentForms(content)) {
+    const blockedFor = findBlockedLinkDomains(form, matchableDomains);
+    if (blockedFor.length) throwBadRequestError(`invalid urls: ${blockedFor.join(', ')}`);
+
+    if (findBlockedPattern(form, matchable) !== undefined)
+      throwBadRequestError('Comment blocked by content filter');
+  }
 }
 // #endregion
 

--- a/src/server/services/commentsv2.service.ts
+++ b/src/server/services/commentsv2.service.ts
@@ -10,7 +10,7 @@ import type {
   CommentConnectorInput,
   GetCommentsInfiniteInput,
 } from './../schema/commentv2.schema';
-import { throwOnBlockedLinkDomain } from '~/server/services/blocklist.service';
+import { throwOnBlockedCommentContent } from '~/server/services/blocklist.service';
 import {
   getBlockCheckOwnerIdsForComment,
   throwIfBlockedByEntityOwner,
@@ -265,7 +265,7 @@ export const upsertComment = async ({
   isModerator?: boolean;
   track?: Parameters<typeof recordStickerUsage>[0]['track'];
 }) => {
-  await throwOnBlockedLinkDomain(data.content);
+  await throwOnBlockedCommentContent(data.content, { isModerator });
   // Edits too, not just creates — a comment written before the block would otherwise stay editable
   // into anything afterwards. An edit resolves its target from the stored comment rather than from
   // `entityType`/`entityId`: those are client-supplied and never checked against the comment being

--- a/src/server/utils/confusable-fold.ts
+++ b/src/server/utils/confusable-fold.ts
@@ -1,0 +1,54 @@
+import { resolveConfusablesTransformer } from 'obscenity';
+
+const confusable = resolveConfusablesTransformer().transform;
+
+/**
+ * Characters that render as nothing but sit between two letters. A zero-width space inside a
+ * blocked domain is invisible to the reader and defeats a substring match, and unlike the
+ * lookalikes below no case or normalisation step removes it.
+ *
+ * `\p{Cf}` rather than a hand-written list, because a hand-written list is a normaliser with a
+ * hole in it and the hole is invisible: an earlier enumeration here missed the Unicode tag block
+ * (`U+E0020`-`U+E007F`), the musical format controls and 143 others, every one of them invisible
+ * and legal between two letters. The explicit additions are the invisibles that are NOT `Cf` —
+ * Hangul fillers (`Lo`), the combining grapheme joiner and BOTH variation selector blocks — the
+ * supplement at `U+E0100`-`U+E01EF` is `Mn` too, and is the same bypass one block over from the
+ * tag characters. Verified a strict superset of what it replaced over every non-surrogate code
+ * point.
+ *
+ * Written as escapes on purpose: spelled literally, this class is a run of characters that
+ * renders as an empty pair of brackets, and nobody can review or edit it.
+ */
+const INVISIBLE =
+  /[\p{Cf}\u034F\u115F\u1160\u17B4\u17B5\u180B-\u180D\u3164\uFE00-\uFE0F\uFFA0\u{E0100}-\u{E01EF}]/gu;
+
+/**
+ * Text as a blocklist should see it: one spelling per glyph, whatever alphabet it was typed in.
+ *
+ * 19 of the 90 live `MessagePattern` entries are non-ASCII, and several are Unicode skins of an
+ * entry that is ALSO on the list in ASCII. Moderators were adding one row per alphabet by hand
+ * because the matcher compared raw code points.
+ *
+ * Three steps, because each covers a class the others miss (measured over 8 samples drawn from
+ * the live list):
+ *
+ * - NFKC folds the mathematical alphanumerics and the fullwidth forms. Obscenity's map leaves
+ *   two characters of the bold-math sample behind on its own.
+ * - The invisible strip covers zero-width and bidi characters, which survive both other steps.
+ * - Obscenity's confusables map folds the small-caps block and the Cyrillic/Greek lookalikes,
+ *   which NFKC deliberately does not touch — they are distinct letters, not compatibility forms.
+ *
+ * **Fold both sides.** Folding only the content leaves those 19 entries unmatchable, which is
+ * worse than not folding at all: the guard would look stronger and enforce less.
+ */
+export function foldConfusables(value: string) {
+  const pre = value.normalize('NFKC').replace(INVISIBLE, '');
+
+  let out = '';
+  for (const char of pre) {
+    const folded = confusable(char.codePointAt(0) as number);
+    if (folded !== undefined) out += String.fromCodePoint(folded);
+  }
+
+  return out.toLowerCase();
+}

--- a/src/utils/string-helpers.ts
+++ b/src/utils/string-helpers.ts
@@ -143,7 +143,10 @@ export function camelCase(str: string) {
 
 const validModelExtensions = ['.ckpt', '.pt', '.safetensors', '.sft', '.bin', '.gguf', '.onnx'];
 
-export function sanitizeDownloadFilename(value: string, fallbackExtension = '.safetensors'): string {
+export function sanitizeDownloadFilename(
+  value: string,
+  fallbackExtension = '.safetensors'
+): string {
   let name = value
     .trim()
     .replace(/["\\\r\n\t]/g, '') // strip Content-Disposition-breaking chars
@@ -209,14 +212,34 @@ export function getModel3DUrl({ id, name }: { id: number; name?: string | null }
 }
 
 /**
+ * One HTML tag. `[^<>]` (not `[^>]`) so an unterminated run of `<` can't force quadratic
+ * backtracking (ReDoS) — a `<` always starts a fresh potential tag.
+ *
+ * Deliberately NOT exported. A shared module-scope regex carrying `g` is safe only while every
+ * consumer uses `String.replace`, which resets `lastIndex`; the first caller to reach for
+ * `.test()` or `.exec()` gets a guard that is inert on every other invocation. The two joins
+ * callers actually want are exported as functions instead.
+ */
+const HTML_TAG = /<[^<>]*>/g;
+
+/**
+ * Tags removed with nothing in their place, so `civitai.id<strong>5</strong>92807.click` reads
+ * as one string. The comment blocklist needs this alongside `removeTags`: neither join alone is
+ * enough, because collapsing to a space defeats a pattern split mid-token, while joining with
+ * nothing glues `<p>a</p><p>b</p>` into `ab`.
+ */
+export function removeTagsCompact(str: string) {
+  if (!str) return '';
+  return str.replace(HTML_TAG, '');
+}
+
+/**
  * @see https://www.geeksforgeeks.org/how-to-strip-out-html-tags-from-a-string-using-javascript/
  */
 export function removeTags(str: string) {
   if (!str) return '';
 
-  // Replace all HTML tags with a single space. `[^<>]` (not `[^>]`) so an unterminated run of
-  // `<` can't force quadratic backtracking (ReDoS) — a `<` always starts a fresh potential tag.
-  const stringWithoutTags = str.replace(/<[^<>]*>/g, ' ');
+  const stringWithoutTags = str.replace(HTML_TAG, ' ');
 
   // Replace multiple spaces with a single space
   const stringWithoutExtraSpaces = stringWithoutTags.replace(/\s+/g, ' ');


### PR DESCRIPTION
Closes ClickUp `868kw2f8y`.

## What was wrong

`throwOnBlockedMessagePattern` had exactly two callers, both chat — `chat.service.ts` (send) and `chat.controller.ts` (edit). **No comment path called it**, while the list holds 90 live entries of real phishing copy. On 2026-08-24 a few hundred throwaway accounts posted phishing comments against patterns that were already being enforced on DMs.

Three comment write paths, not two. The third had no blocklist check of any kind:

| path | before | after |
|---|---|---|
| `comment.controller.ts` (v1, model comments) | link check only | both lists |
| `commentsv2.service.ts` (everything else) | link check only | both lists |
| `comics.router.ts` `createChapterComment` | **nothing** | both lists |

That third path was also storing **unsanitised** HTML, so an entity-escaped host carried no literal dot for the matcher and decoded back to a working link at render time. It now uses the same sanitised schema as the other two — without stickers, since that path never charged for them.

## Comment content is HTML, and that defeats a substring match on its own

Measured with the repo's real `sanitizeHtml` and the real matcher: a blocked host matches, and the same host with one `<strong>` inside it returns null. `strong`, `em`, `u`, `s`, `span`, `code` and `a` all survive `COMMENT_ALLOWED_TAGS`, and a sticker `<span>` splits an entry the same way. **This hole was already live in the link check comments have always had.**

No single normalisation closes it:

| form | tag split mid-token | host only in `href` | multi-word across `<p>` |
|---|---|---|---|
| raw | miss | catch | miss |
| tags → nothing | catch | **miss** | miss |
| `removeTags` (tags → space, collapse) | miss | miss | catch |

Stripping tags discards the `href`, so a link whose visible text is "click" becomes invisible — a fix that *replaced* raw scanning would have been a regression. All three are scanned, and the raw form is load-bearing beyond that case: because it is scanned, every literal substring of the stored string stays visible whatever malformed markup does to the derived forms.

## A scheme-relative href defeated the domain list entirely

`sanitizeHtml` stores `//host/x` verbatim and the browser resolves it to a live link, while a scheme-anchored regex saw no URL at all. The scheme is now optional, and every host spelling is compared — `url.host` carries a port, and a trailing dot is a legal FQDN, so both missed an exact entry.

Subdomains deliberately still do not match: that would block every subdomain of every listed host, which is a moderation policy change rather than a normalisation fix. A test pins the omission as chosen.

This lives in `findBlockedLinkDomains`, so it also closes the same bypasses on the eight other surfaces that call `throwOnBlockedLinkDomain`.

## Entries are folded only where matching is exact

19 of the 90 pattern entries and 6 of the 696 link domains are non-ASCII — moderators adding one row per alphabet by hand, because the matcher compared raw code points.

Folding the **content** is the half that stops the bypass, and it applies to both lists and to DMs. Folding the **stored entries** is only safe where the comparison is exact:

- **Link domains** are compared with `===` against `url.host`, so a folded host is one more host that must be equalled in full. Folded — this is what makes those 6 rows enforce at all.
- **Message patterns** are matched with `includes`. Folding rewrites the rule into a broader one: measured against the live list, **17 of the 19 non-ASCII rows fold to a string nobody added**, two of them to an ordinary English word appearing in tens of thousands of legitimate comments and DMs. Not folded.

`foldConfusables` composes NFKC, an invisible-character strip (`\p{Cf}` plus the non-`Cf` invisibles — a hand-written list missed the Unicode tag block and 144 others), and obscenity's confusables map, which is already a dependency.

## Tests

The guard is wired at three call sites and **nothing observed any of them** — deleting a call, or hardcoding the moderator flag to `true`, left the entire workspace green. Wiring and ordering tests added at all three, plus the DM path, which had no tests at all.

Every assertion was checked by breaking the code it covers. Each of these fails on revert, as an assertion naming a wrong value in single-digit milliseconds rather than a timeout:

| mutation | failures |
|---|---|
| pattern enforcement removed | 4 |
| raw form only | 3 |
| stripped forms only (drops `href`) | 1 |
| no folded content forms | 6 |
| entry folding re-introduced | 2 |
| no empty/whitespace entry filter | 1 |
| scheme required again | 1 |
| host equality only | 2 |
| guard call deleted (per call site) | 4 / 3 / 3 |

Two of these tests initially **could not fail** and were fixed in the code, not the test — one because a matched empty string is falsy and was swallowed by a truthiness check, one because a hand-typed escape sequence was the wrong character.

## Also

Whitespace-only entries are filtered — a single space matches every comment as surely as an empty one. Chat throws `BAD_REQUEST` rather than a bare `Error`, which reached the client as a 500 on a validation refusal. The shared tag regex is module-private again behind `removeTags` / `removeTagsCompact`, so no later caller can trip its `lastIndex`.

Moderators are exempt from both lists by decision, 2026-08-24.

## Verification

`typecheck` 0 errors. `lint` clean on changed files. `prettier:check` clean. `test:lint-rules` 17 files / 323 tests. Full unit suite `1371 passed | 1 skipped (1374)` with 2 unrelated timeouts (`home-block-fetch-sizing`, `user-payment-configuration.tipalti-status`) that pass in isolation at 7/7 and 32/32 and reference nothing in this diff — contention on a loaded box. `blocks.router.workflow.test.ts` collected 358, so the submodule was initialised.

## Not covered

Model and version descriptions, articles, posts, bounties, resource reviews, app listings and profile bios still have no pattern-list enforcement — filed as `868kw6t61`, along with write-time entry normalisation for the entries that can never match. A thread-lock bypass on comment edit found during review is `868kw8e4k`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)