### PR TITLE
feat(notifications): tell a sticker placer when a placement is declined or expires

### DIFF
--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -197,6 +197,19 @@ describe('the sticker placer hears about an acceptance', () => {
     );
   });
 
+  /**
+   * A decline that is neither waived nor carrying a receipted fee has not
+   * finished settling. `planPayout` re-reads the legs with no `orderBy`, so a
+   * resume can pay the placer's refund while the fee leg is still stranded —
+   * and "your Buzz has been refunded" would then be wrong in the expensive
+   * direction, because the fee is still owed and will be taken.
+   */
+  it('says nothing about money while the fee outcome is still unknown', () => {
+    expect(resolved({ status: 'declined', amount: 500, refundPaid: true }).message).toBe(
+      'somebody declined your sticker.'
+    );
+  });
+
   it('states the fee it kept even while the rest is still in flight', () => {
     // The fee half is observed — it has its own receipt — so it is still true
     // when the placer's leg has not landed. Dropping the whole sentence there

--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -262,6 +262,19 @@ describe('the sticker placer hears about an acceptance', () => {
         String.raw`pt\.kind IN \('principalToPlacer', 'feeToPlacer'\)[\s\S]{0,80}pt\."transactionId" IS NOT NULL`
       )
     );
+
+    // 🔴 AND the key name, which the anchor above does not mention. The two
+    // check different things: the anchor proves the predicate is right, this
+    // proves the value reaches `prepareMessage` under the name it reads. Rename
+    // the key in the jsonb alone and every other assertion in this file still
+    // passes, while `details.refundPaid` is permanently undefined and no placer
+    // is ever told their Buzz came back — on any branch.
+    //
+    // It was briefly absent because the anchor REPLACED it rather than joining
+    // it. That is invisible in a diff: the new assertion is strictly stronger
+    // about the predicate and strictly weaker about the name, and a diff only
+    // shows you the first half.
+    expect(stripped).toContain("'refundPaid', EXISTS (");
     expect(sql).toContain("pt.kind = 'feeToOwner'");
     expect(sql).toContain(`'feeWaived', p."feeWaived"`);
   });

--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -245,16 +245,23 @@ describe('the sticker placer hears about an acceptance', () => {
     expect(stripped).toMatch(
       new RegExp(String.raw`pt\.kind = 'feeToOwner'[\s\S]{0,80}pt\."transactionId" IS NOT NULL`)
     );
+    // 🔴 Anchored from the KIND LIST, not from the key name. The kinds are what
+    // give `refundPaid` its meaning — swap them to `feeToOwner` and the flag
+    // becomes "the OWNER got paid", so a non-waived decline says "the rest has
+    // been refunded" while the placer's leg is exactly as stranded as before.
+    // Tying the two together means neither half can move without the other.
+    //
+    // It is also the tighter anchor. Measured: 21 characters of the 80 budget
+    // here, against 187 of 200 anchoring from `'refundPaid', EXISTS (` — which
+    // one inserted clause was enough to break. If this ever does go red on a
+    // reformat, do NOT simply raise the number: a budget wide enough to reach
+    // the NEXT `transactionId` filter silently reopens the cross-occurrence hole
+    // the fee anchor above exists to close.
     expect(stripped).toMatch(
-      new RegExp(String.raw`'refundPaid', EXISTS \([\s\S]{0,200}pt\."transactionId" IS NOT NULL`)
+      new RegExp(
+        String.raw`pt\.kind IN \('principalToPlacer', 'feeToPlacer'\)[\s\S]{0,80}pt\."transactionId" IS NOT NULL`
+      )
     );
-
-    // 🔴 The kind list is what gives `refundPaid` its meaning, and it was the
-    // key name alone that was pinned. Swapping it to `feeToOwner` turns the flag
-    // into "the OWNER got paid", so a non-waived decline says "the rest has been
-    // refunded" while the placer's leg is exactly as stranded as before — which
-    // is the failure this gate exists to prevent, reachable in one word.
-    expect(stripped).toContain("pt.kind IN ('principalToPlacer', 'feeToPlacer')");
     expect(sql).toContain("pt.kind = 'feeToOwner'");
     expect(sql).toContain(`'feeWaived', p."feeWaived"`);
   });

--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -137,7 +137,12 @@ describe('the sticker placer hears about an acceptance', () => {
   it('promises no refund a free decline never earned', () => {
     // amount 0 by DB constraint. "Your Buzz has been refunded" would send someone
     // looking for a credit that never existed.
-    expect(resolved({ status: 'declined', amount: 0 }).message).toBe(
+    // `refundPaid: true` so the receipt gate is not what is doing the work here.
+    // What suppresses the money sentence on a free decline is the fee test — a
+    // free row has no escrow and so no `feeToOwner` leg — and that is the guard
+    // this pins. The `paidPlacement` check that used to sit in front of it was
+    // deleted as dead code once this fixture proved removing it changed nothing.
+    expect(resolved({ status: 'declined', amount: 0, refundPaid: true }).message).toBe(
       'somebody declined your sticker.'
     );
   });
@@ -169,7 +174,8 @@ describe('the sticker placer hears about an acceptance', () => {
   });
 
   it('says nothing about money when a free placement expires', () => {
-    expect(resolved({ status: 'expired', amount: 0 }).message).toBe(
+    // `refundPaid: true` for the same reason as the free decline above.
+    expect(resolved({ status: 'expired', amount: 0, refundPaid: true }).message).toBe(
       "Your sticker placement on somebody's image expired."
     );
   });
@@ -230,8 +236,25 @@ describe('the sticker placer hears about an acceptance', () => {
     // transactionId and the Buzz calls happen afterwards, outside that
     // transaction — so without these filters the message promises a refund that
     // may never have moved, and on a stranded leg never will.
-    expect(sql).toContain('pt."transactionId" IS NOT NULL');
-    expect(sql).toContain("'refundPaid', EXISTS (");
+    // 🔴 Anchored to their OWN occurrences. `pt."transactionId" IS NOT NULL`
+    // appears twice, so a single file-wide `toContain` is satisfied by either —
+    // deleting it from the fee subselect alone would ship "They kept 25 Buzz"
+    // on a fee that has not moved, printing nothing.
+    const stripped = sql.replace(/--[^\n]*/g, '');
+
+    expect(stripped).toMatch(
+      new RegExp(String.raw`pt\.kind = 'feeToOwner'[\s\S]{0,80}pt\."transactionId" IS NOT NULL`)
+    );
+    expect(stripped).toMatch(
+      new RegExp(String.raw`'refundPaid', EXISTS \([\s\S]{0,200}pt\."transactionId" IS NOT NULL`)
+    );
+
+    // 🔴 The kind list is what gives `refundPaid` its meaning, and it was the
+    // key name alone that was pinned. Swapping it to `feeToOwner` turns the flag
+    // into "the OWNER got paid", so a non-waived decline says "the rest has been
+    // refunded" while the placer's leg is exactly as stranded as before — which
+    // is the failure this gate exists to prevent, reachable in one word.
+    expect(stripped).toContain("pt.kind IN ('principalToPlacer', 'feeToPlacer')");
     expect(sql).toContain("pt.kind = 'feeToOwner'");
     expect(sql).toContain(`'feeWaived', p."feeWaived"`);
   });

--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -95,10 +95,90 @@ describe('the sticker placer hears about an acceptance', () => {
     expect(await query('sticker-placement-resolved')).toContain('\'imageId\', p."targetId"');
   });
 
-  it('selects approvals and moderator removals, nothing else', async () => {
-    // Not `declined` and not `expired`: a declined sticker never appeared
-    // anywhere, and an expiry is nobody deciding anything.
-    expect(statusesSelectedBy(await query('sticker-placement-resolved'))).toBe('approved,removed');
+  /**
+   * `pending` is the one that must never be here: it would tell a placer their
+   * placement was resolved while it is still waiting, and the row would be
+   * selected again for real when it settles.
+   *
+   * `declined` and `expired` joined the set on 2026-08-24 (`868kv5d36`). They were
+   * excluded on 2026-08-18 on the grounds that a declined sticker never appeared
+   * anywhere — true of the sticker, and not of the money, which is why the call
+   * was reversed.
+   */
+  it('selects every settled outcome and nothing pending', async () => {
+    expect(statusesSelectedBy(await query('sticker-placement-resolved'))).toBe(
+      'approved,declined,expired,removed'
+    );
+  });
+
+  /**
+   * 🔴 Every sentence here is a claim about someone's Buzz, so each case asserts
+   * the WHOLE string rather than a fragment. A `toContain('declined')` passes
+   * against all three of these, including the two where the money sentence is
+   * wrong.
+   *
+   * The money itself, read off `placementPaymentSplit`: `declined` keeps
+   * `declineFeeAmount(...)` with the owner and refunds the rest; `expired`
+   * refunds everything. `feeWaived` is the column that separates a decline that
+   * refunded in full from one that did not — `removedBy` is NULL on a decline.
+   */
+  const resolved = (details: Record<string, unknown>) =>
+    defs['sticker-placement-resolved'].prepareMessage({
+      type: 'sticker-placement-resolved',
+      details: { imageId: 74, ownerUsername: 'somebody', ...details },
+    } as Parameters<Def['prepareMessage']>[0])!;
+
+  it('quotes what a decline actually kept', () => {
+    expect(resolved({ status: 'declined', amount: 500, feeToOwner: 25 }).message).toBe(
+      'somebody declined your sticker. They kept 25 Buzz; the rest has been refunded.'
+    );
+  });
+
+  it('promises no refund a free decline never earned', () => {
+    // amount 0 by DB constraint. "Your Buzz has been refunded" would send someone
+    // looking for a credit that never existed.
+    expect(resolved({ status: 'declined', amount: 0 }).message).toBe(
+      'somebody declined your sticker.'
+    );
+  });
+
+  it('says the whole escrow came back when the fee was waived', () => {
+    // declineByBlock and declineUnshowableHost. Claiming a fee was kept here is a
+    // false statement about a balance, and `removedBy` is NULL so it cannot be
+    // used to tell this from the case above.
+    expect(resolved({ status: 'declined', amount: 500, feeWaived: true }).message).toBe(
+      'somebody declined your sticker. Your Buzz has been refunded.'
+    );
+  });
+
+  it('tells a placer their Buzz came back when nobody answered', () => {
+    expect(resolved({ status: 'expired', amount: 500 }).message).toBe(
+      "Your sticker placement on somebody's image expired. Your Buzz has been refunded."
+    );
+  });
+
+  it('says nothing about money when a free placement expires', () => {
+    expect(resolved({ status: 'expired', amount: 0 }).message).toBe(
+      "Your sticker placement on somebody's image expired."
+    );
+  });
+
+  it('sends both new outcomes to the plain image, not the reveal', () => {
+    // There is no sticker on that image to show. The approval branch is the only
+    // one that reveals.
+    expect(resolved({ status: 'declined', amount: 500 }).url).toBe('/images/74');
+    expect(resolved({ status: 'expired', amount: 500 }).url).toBe('/images/74');
+  });
+
+  it('reads the fee from the ledger row rather than recomputing it', async () => {
+    const sql = await query('sticker-placement-resolved');
+
+    // The per-space rate can move between the placement and the decline, so a
+    // recomputed figure eventually disagrees with /user/transactions for the same
+    // event. The unique index on (placementId, kind) makes this a lookup.
+    expect(sql).toContain("'feeToOwner', (");
+    expect(sql).toContain("pt.kind = 'feeToOwner'");
+    expect(sql).toContain(`'feeWaived', p."feeWaived"`);
   });
 
   it('reads the moment the owner acted, not the moment the placement was made', async () => {

--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -129,9 +129,9 @@ describe('the sticker placer hears about an acceptance', () => {
     } as Parameters<Def['prepareMessage']>[0])!;
 
   it('quotes what a decline actually kept', () => {
-    expect(resolved({ status: 'declined', amount: 500, feeToOwner: 25 }).message).toBe(
-      'somebody declined your sticker. They kept 25 Buzz; the rest has been refunded.'
-    );
+    expect(
+      resolved({ status: 'declined', amount: 500, feeToOwner: 25, refundPaid: true }).message
+    ).toBe('somebody declined your sticker. They kept 25 Buzz; the rest has been refunded.');
   });
 
   it('promises no refund a free decline never earned', () => {
@@ -146,13 +146,24 @@ describe('the sticker placer hears about an acceptance', () => {
     // declineByBlock and declineUnshowableHost. Claiming a fee was kept here is a
     // false statement about a balance, and `removedBy` is NULL so it cannot be
     // used to tell this from the case above.
-    expect(resolved({ status: 'declined', amount: 500, feeWaived: true }).message).toBe(
-      'somebody declined your sticker. Your Buzz has been refunded.'
-    );
+    // 🔴 `feeToOwner` is what makes this able to fail. Without a fee row the fee
+    // is 0, `!(0 > 0)` is already true, and the right-hand disjunct alone
+    // produces the asserted string — so deleting `details.feeWaived ||` passed
+    // the test named for that flag. The fixture has to carry a fee for the flag
+    // to be the thing under test, and the test above it is then its control.
+    expect(
+      resolved({
+        status: 'declined',
+        amount: 500,
+        feeWaived: true,
+        feeToOwner: 25,
+        refundPaid: true,
+      }).message
+    ).toBe('somebody declined your sticker. Your Buzz has been refunded.');
   });
 
   it('tells a placer their Buzz came back when nobody answered', () => {
-    expect(resolved({ status: 'expired', amount: 500 }).message).toBe(
+    expect(resolved({ status: 'expired', amount: 500, refundPaid: true }).message).toBe(
       "Your sticker placement on somebody's image expired. Your Buzz has been refunded."
     );
   });
@@ -163,11 +174,36 @@ describe('the sticker placer hears about an acceptance', () => {
     );
   });
 
-  it('sends both new outcomes to the plain image, not the reveal', () => {
-    // There is no sticker on that image to show. The approval branch is the only
-    // one that reveals.
-    expect(resolved({ status: 'declined', amount: 500 }).url).toBe('/images/74');
-    expect(resolved({ status: 'expired', amount: 500 }).url).toBe('/images/74');
+  /* Deleted: a test asserting both new branches return `/images/74`.
+     `url` is computed once before any branch and every branch returns it, so no
+     change to either new branch could turn it red — and the one mutation it did
+     catch, editing that shared line, is already covered above. It also named a
+     "reveal URL" that does not exist in this file. */
+
+  /**
+   * 🔴 The refund sentence is a claim about money that MOVED. Until the leg has a
+   * receipt it has not, and a leg that exhausts its attempts never will.
+   *
+   * Both directions, because a message that never promises a refund would pass a
+   * one-sided version of this and be useless.
+   */
+  it('promises a refund only once the refund has a receipt', () => {
+    const unpaid = resolved({ status: 'expired', amount: 500 }).message;
+    const paid = resolved({ status: 'expired', amount: 500, refundPaid: true }).message;
+
+    expect(unpaid).toBe("Your sticker placement on somebody's image expired.");
+    expect(paid).toBe(
+      "Your sticker placement on somebody's image expired. Your Buzz has been refunded."
+    );
+  });
+
+  it('states the fee it kept even while the rest is still in flight', () => {
+    // The fee half is observed — it has its own receipt — so it is still true
+    // when the placer's leg has not landed. Dropping the whole sentence there
+    // would tell someone nothing happened.
+    expect(resolved({ status: 'declined', amount: 500, feeToOwner: 25 }).message).toBe(
+      'somebody declined your sticker. They kept 25 Buzz.'
+    );
   });
 
   it('reads the fee from the ledger row rather than recomputing it', async () => {
@@ -177,8 +213,32 @@ describe('the sticker placer hears about an acceptance', () => {
     // recomputed figure eventually disagrees with /user/transactions for the same
     // event. The unique index on (placementId, kind) makes this a lookup.
     expect(sql).toContain("'feeToOwner', (");
+    // 🔴 A receipt, not a plan. settlePlacement writes the legs with a NULL
+    // transactionId and the Buzz calls happen afterwards, outside that
+    // transaction — so without these filters the message promises a refund that
+    // may never have moved, and on a stranded leg never will.
+    expect(sql).toContain('pt."transactionId" IS NOT NULL');
+    expect(sql).toContain("'refundPaid', EXISTS (");
     expect(sql).toContain("pt.kind = 'feeToOwner'");
     expect(sql).toContain(`'feeWaived', p."feeWaived"`);
+  });
+
+  /**
+   * 🔴 Each new branch's OWN time window, not just "resolvedAt appears somewhere".
+   * The approved branch satisfies a file-wide `toContain` on its own, so swapping
+   * the expired branch to `expiresAt` — which is exactly what its comment says it
+   * is avoiding — passed every other assertion in this file.
+   */
+  it.each(['declined', 'expired'])('windows the %s branch on resolvedAt', async (status) => {
+    // Comments stripped locally: `withoutSqlComments` lives in a later describe
+    // block and is not in scope here. The prose in these branches names both
+    // `resolvedAt` and `expiresAt`, so an unstripped match would pass on a
+    // comment.
+    const sql = (await query('sticker-placement-resolved')).replace(/--[^\n]*/g, '');
+
+    expect(sql).toMatch(
+      new RegExp(String.raw`p\.status = '${status}'[\s\S]{0,160}p\."resolvedAt" > '`)
+    );
   });
 
   it('reads the moment the owner acted, not the moment the placement was made', async () => {
@@ -302,6 +362,29 @@ describe('a moderator ending a placement reaches the person who paid', () => {
       expect(sql).toContain('\'removedBy\', p."removedBy"');
       expect(sql).toContain('\'wasLive\', p."takenDownAt" IS NOT NULL');
       expect(sql).toContain("'amount', p.amount");
+
+      // 🔴 `status` is the worst key in this object to lose, and nothing checked
+      // it. Every message test fabricates it, so dropping `'status', p.status`
+      // from the jsonb passes all of them — and `prepareMessage` then falls
+      // through every branch and returns the trailing "accepted your sticker".
+      // Every decline, expiry and takedown would tell the placer their sticker
+      // was accepted.
+      //
+      // The dedupe-key test below reads `p.status "status"`, the outer projected
+      // COLUMN. That is a different expression and survives the mutation intact,
+      // which is why it does not cover this.
+      expect(sql).toContain("'status', p.status");
+
+      // Without these the sentence reads "undefined declined your sticker".
+      // Four of the five money assertions are about the sentence around this
+      // name and none of them can see where the name comes from.
+      expect(sql).toContain("'ownerUsername', u.username");
+      expect(sql).toContain('JOIN "User" u ON u.id = p."ownerId"');
+
+      // Feeds the notification's actor, so losing it blanks the avatar. The
+      // detail-fetcher's own suite hand-builds `ownerId`, so both sides of that
+      // seam are fabricated and neither goes red.
+      expect(sql).toContain('\'ownerId\', p."ownerId"');
     }
   });
 

--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -491,6 +491,15 @@ describe('a moderator ending a placement reaches the person who paid', () => {
    * whose payout is principal AND fee back to the placer. Telling that person
    * their Buzz is gone is a false statement about their balance, and it is the
    * mistake a single "moderator removals are not refunded" rule would make.
+   *
+   * ⚠️ This asserts the sentence UNGATED, unlike the decline and expiry ones,
+   * which now require a receipted leg before promising a refund. That is scope
+   * rather than oversight: `moderatorRemovalMessage` is shared, and the remix
+   * query does not project `refundPaid` at all, so extending the receipt rule
+   * here is a change to two queries and not just to a message.
+   *
+   * If someone does extend it, THIS assertion is the one that has to change —
+   * and it changing is the fix, not a regression. Do not preserve it.
    */
   it.each(['sticker-placement-resolved', 'remix-gallery-resolved'])(
     '%s promises the refund a pending cosmetic takedown actually pays',

--- a/src/server/notifications/__tests__/placement-resolved-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-resolved-notification.test.ts
@@ -180,11 +180,37 @@ describe('the sticker placer hears about an acceptance', () => {
     );
   });
 
-  /* Deleted: a test asserting both new branches return `/images/74`.
-     `url` is computed once before any branch and every branch returns it, so no
-     change to either new branch could turn it red — and the one mutation it did
-     catch, editing that shared line, is already covered above. It also named a
-     "reveal URL" that does not exist in this file. */
+  /**
+   * 🔴 This test was DELETED as unfalsifiable and then had to come back, and the
+   * reason is worth more than the test.
+   *
+   * When it was written, `url` was computed once before any branch and every
+   * branch returned it, so nothing branch-specific could fail. True then. #4338
+   * then pointed the APPROVAL branch at `imageWithStickersUrl`, which made the
+   * branches differ — and the deletion, plus the comment explaining it, said
+   * there was nothing here worth testing on the exact property the merge had
+   * just made testable.
+   *
+   * A restored assertion gets re-run against a new base. An ABSENCE has nothing
+   * to re-check, and the prose explaining it is not executable. So: when a review
+   * concludes "delete this, it cannot fail", that conclusion is pinned to the
+   * shape of the code at that moment, and it is the first thing to revisit after
+   * anything merges into the same function.
+   *
+   * A discriminator rather than a constant. Asserting the plain URL alone would
+   * still pass if every branch collapsed back onto one string, which is the state
+   * this started in.
+   */
+  it('sends the outcomes with no sticker to see to the plain image', () => {
+    const approved = resolved({ status: 'approved' }).url;
+
+    for (const status of ['declined', 'expired'])
+      expect(resolved({ status, amount: 500 }).url).toBe('/images/74');
+
+    // The negative control: the approval branch reveals, so the two are not the
+    // same string and this cannot pass by every branch agreeing.
+    expect(approved).not.toBe('/images/74');
+  });
 
   /**
    * 🔴 The refund sentence is a claim about money that MOVED. Until the leg has a

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -75,6 +75,44 @@ function moderatorRemovalMessage({
     : `${what} The Buzz you paid is not refunded.`;
 }
 
+/**
+ * Whether this row moved any of the placer's Buzz at all.
+ *
+ * A free placement is `amount` 0 by DB constraint, so every sentence about money
+ * is false of it -- including "your Buzz has been refunded", which would have
+ * someone looking for a credit that never existed.
+ */
+const paidPlacement = (details: Record<string, unknown>) => Number(details.amount ?? 0) > 0;
+
+/**
+ * What a decline actually cost, in one sentence.
+ *
+ * Three cases, because the money is genuinely three different things:
+ *
+ * - **Free.** Nothing moved. The daily allowance is spent either way, but that is
+ *   a fact about the allowance rather than about a refund.
+ * - **Fee waived.** `declineByBlock` and `declineUnshowableHost` return the whole
+ *   escrow (`FEE_WAIVING_ACTIONS`), so "they kept N Buzz" would be a false
+ *   statement about someone's balance. `feeWaived` is a column on the row --
+ *   `removedBy` is NULL on a decline and cannot tell these apart.
+ * - **Fee taken.** `declined` splits `toOwner = declineFeeAmount(...)` and
+ *   `toPlacer = amount - toOwner`, so part of the payment stays with the creator.
+ *
+ * The number comes from the `feeToOwner` ledger row rather than from recomputing
+ * `declineFeeAmount`: the rate is per-space and can move between the placement
+ * and the decline, so a recomputed figure would eventually disagree with the one
+ * on `/user/transactions` for the same event.
+ */
+function declineMessage(details: Record<string, unknown>) {
+  const declined = `${details.ownerUsername} declined your sticker`;
+  if (!paidPlacement(details)) return `${declined}.`;
+
+  const fee = Number(details.feeToOwner ?? 0);
+  if (details.feeWaived || !(fee > 0)) return `${declined}. Your Buzz has been refunded.`;
+
+  return `${declined}. They kept ${fee} Buzz; the rest has been refunded.`;
+}
+
 export const placementNotifications = createNotificationProcessor({
   'sticker-placement-pending': {
     displayName: 'Sticker awaiting your review',
@@ -450,16 +488,22 @@ export const placementNotifications = createNotificationProcessor({
    * The sticker placer's side, and the gap Ellie reported: a placement could be
    * accepted and the only signal was the placer's Buzz balance moving.
    *
-   * Approval, and the moderator removal modes. No decline and no expiry (Justin,
-   * 2026-08-18): a declined sticker never appeared anywhere. An OWNER removal is
-   * still silent here and is not on the remix type -- that asymmetry is
+   * Approval, the moderator removal modes, DECLINE and EXPIRY. An OWNER removal
+   * is still silent here and is not on the remix type -- that asymmetry is
    * deliberate (Justin, 2026-08-21).
    *
+   * Decline and expiry were deliberately excluded on 2026-08-18, on the grounds
+   * that a declined sticker never appeared anywhere. Reversed on 2026-08-24
+   * (`868kv5d36`) because that reasoning covers the sticker and not the money: a
+   * decline keeps the placer's fee, so the only signal they had was a balance
+   * that went down. Justin also asked for expiry, so a placer learns their Buzz
+   * came back rather than inferring it.
+   *
    * Covers free placements as well as paid, unlike the pending pair, which split
-   * because their messages quote an amount and a free row's is 0. This one quotes
-   * none -- `amount` reaches the message only to decide whether there is a
-   * sentence about the money at all -- so one type serves both and a creator
-   * muting it mutes both.
+   * because their messages quote an amount and a free row's is 0. The branches
+   * here choose their own sentence about money from `free` and `feeWaived`, so a
+   * free placement is never told about Buzz that did not move and one type still
+   * serves both.
    *
    * An `auto` space approves at the call site, so its placer gets this seconds
    * after placing, confirming something they watched happen. Left that way on
@@ -468,7 +512,9 @@ export const placementNotifications = createNotificationProcessor({
    * `resolvedAt` -- would be a rule we invented and would have to keep true.
    */
   'sticker-placement-resolved': {
-    displayName: 'Your sticker placement was answered',
+    // "Resolved", not "answered": expiry is the outcome where nobody answered,
+    // and this is the label on the mute switch.
+    displayName: 'Your sticker placement was resolved',
     category: NotificationCategory.Creator,
     prepareMessage: ({ details }) => {
       if (details.status === 'removed')
@@ -484,6 +530,23 @@ export const placementNotifications = createNotificationProcessor({
           // what the link is for.
           url: `/images/${details.imageId}`,
         };
+      // The plain image URL for every outcome the sticker is not there to see.
+      // Only an approval gets the revealing one.
+      const plain = `/images/${details.imageId}`;
+
+      if (details.status === 'declined') return { message: declineMessage(details), url: plain };
+
+      if (details.status === 'expired')
+        return {
+          // Not "they did not answer in time". The outcome is the same whether
+          // the creator was busy or away, and what a placer needs from this
+          // sentence is what happened to their Buzz, not whose fault it was.
+          message: `Your sticker placement on ${details.ownerUsername}'s image expired.${
+            paidPlacement(details) ? ' Your Buzz has been refunded.' : ''
+          }`,
+          url: plain,
+        };
+
       return {
         message: `${details.ownerUsername} accepted your sticker`,
         url: imageWithStickersUrl(details.imageId),
@@ -503,7 +566,20 @@ export const placementNotifications = createNotificationProcessor({
             'status', p.status,
             'removedBy', p."removedBy",
             'wasLive', p."takenDownAt" IS NOT NULL,
-            'amount', p.amount
+            'amount', p.amount,
+            -- The two things a decline's money sentence turns on, and both are
+            -- columns on the row rather than a join: removedBy is NULL on a
+            -- decline and cannot tell a waived fee from a taken one.
+            'feeWaived', p."feeWaived",
+            -- What was actually taken, not what today's rate would compute. The
+            -- rate is per-space and can move between the placement and the
+            -- decline. NULL where no fee leg was ever claimed, which is the
+            -- waived and free cases. Hits the unique index on
+            -- (placementId, kind), so it is a lookup rather than a scan.
+            'feeToOwner', (
+              SELECT pt.amount FROM "PlacementTransaction" pt
+              WHERE pt."placementId" = p.id AND pt.kind = 'feeToOwner'
+            )
           ) as "details"
         FROM "Placement" p
         JOIN "User" u ON u.id = p."ownerId"
@@ -543,6 +619,25 @@ export const placementNotifications = createNotificationProcessor({
               p.status = 'removed'
               AND p."removedBy" IN ('moderator', 'cosmeticTakedown')
               AND p."takenDownAt" IS NULL
+              AND p."resolvedAt" IS NOT NULL
+              AND p."resolvedAt" > '${lastSent}'
+            )
+            OR (
+              -- The creator said no. settlePlacement stamps resolvedAt for every
+              -- decline mode, including the two that waive the fee, so one branch
+              -- covers all three and the MESSAGE picks its money sentence from
+              -- feeWaived and amount.
+              p.status = 'declined'
+              AND p."resolvedAt" IS NOT NULL
+              AND p."resolvedAt" > '${lastSent}'
+            )
+            OR (
+              -- Nobody answered. expirePlacements runs over status = 'pending'
+              -- regardless of free, and 'expire' stamps resolvedAt like any other
+              -- settled outcome -- so this needs no expiresAt window of its own,
+              -- which would re-report a row whose deadline passed long before the
+              -- job reached it.
+              p.status = 'expired'
               AND p."resolvedAt" IS NOT NULL
               AND p."resolvedAt" > '${lastSent}'
             )

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -504,9 +504,14 @@ export const placementNotifications = createNotificationProcessor({
    *
    * Covers free placements as well as paid, unlike the pending pair, which split
    * because their messages quote an amount and a free row's is 0. The branches
-   * here choose their own sentence about money from `free` and `feeWaived`, so a
-   * free placement is never told about Buzz that did not move and one type still
-   * serves both.
+   * here choose their own sentence about money from `amount`, `feeWaived` and
+   * `refundPaid` -- NOT from `free`, which is a column on the row and is not in
+   * this payload -- so a free placement is never told about Buzz that did not
+   * move and one type still serves both.
+   *
+   * `refundPaid` is a receipt rather than a plan. See the subquery that builds
+   * it: a settled row's payout legs exist before the Buzz calls do, so a refund
+   * sentence derived from the status alone can be permanently false.
    *
    * An `auto` space approves at the call site, so its placer gets this seconds
    * after placing, confirming something they watched happen. Left that way on

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -108,9 +108,12 @@ function declineMessage(details: Record<string, unknown>) {
   if (!paidPlacement(details)) return `${declined}.`;
 
   const fee = Number(details.feeToOwner ?? 0);
-  if (details.feeWaived || !(fee > 0)) return `${declined}. Your Buzz has been refunded.`;
+  const refunded = details.refundPaid ? ' Your Buzz has been refunded.' : '';
+  const rest = details.refundPaid ? '; the rest has been refunded' : '';
 
-  return `${declined}. They kept ${fee} Buzz; the rest has been refunded.`;
+  if (details.feeWaived || !(fee > 0)) return `${declined}.${refunded}`;
+
+  return `${declined}. They kept ${fee} Buzz${rest}.`;
 }
 
 export const placementNotifications = createNotificationProcessor({
@@ -542,7 +545,7 @@ export const placementNotifications = createNotificationProcessor({
           // the creator was busy or away, and what a placer needs from this
           // sentence is what happened to their Buzz, not whose fault it was.
           message: `Your sticker placement on ${details.ownerUsername}'s image expired.${
-            paidPlacement(details) ? ' Your Buzz has been refunded.' : ''
+            paidPlacement(details) && details.refundPaid ? ' Your Buzz has been refunded.' : ''
           }`,
           url: plain,
         };
@@ -579,6 +582,27 @@ export const placementNotifications = createNotificationProcessor({
             'feeToOwner', (
               SELECT pt.amount FROM "PlacementTransaction" pt
               WHERE pt."placementId" = p.id AND pt.kind = 'feeToOwner'
+                AND pt."transactionId" IS NOT NULL
+            ),
+            -- 🔴 Whether the placer's money has actually MOVED, not whether it
+            -- was planned. settlePlacement writes the status flip and the payout
+            -- legs in one transaction with transactionId NULL on every leg; the
+            -- Buzz calls happen afterwards, outside it, and runLeg can decline
+            -- the lock, fail, or exhaust its attempts and stop. The
+            -- notification job runs every minute off the committed row, so
+            -- without this "your Buzz has been refunded" is a claim about a
+            -- movement nobody has observed -- and on a stranded leg it stays
+            -- false, with the placer's balance as the thing disagreeing.
+            --
+            -- One flag for both placer-directed kinds. A partial payout (the
+            -- principal receipted, the fee refund not) reads as refunded, which
+            -- is the direction that errs toward saying less rather than saying
+            -- something false.
+            'refundPaid', EXISTS (
+              SELECT 1 FROM "PlacementTransaction" pt
+              WHERE pt."placementId" = p.id
+                AND pt.kind IN ('principalToPlacer', 'feeToPlacer')
+                AND pt."transactionId" IS NOT NULL
             )
           ) as "details"
         FROM "Placement" p

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -105,8 +105,13 @@ const paidPlacement = (details: Record<string, unknown>) => Number(details.amoun
  */
 function declineMessage(details: Record<string, unknown>) {
   const declined = `${details.ownerUsername} declined your sticker`;
-  if (!paidPlacement(details)) return `${declined}.`;
 
+  // No `paidPlacement` check here, deliberately. A free row is `amount` 0 and
+  // has no escrow, so it has no `feeToOwner` leg either — the "fee outcome
+  // unknown" return below already covers it, and a second guard in front of it
+  // was dead code that two tests were nonetheless claiming to exercise. Measured
+  // by deleting it: nothing changed. The expiry branch still needs its own
+  // check, because its money sentence is not behind a fee test.
   const fee = Number(details.feeToOwner ?? 0);
   const refunded = details.refundPaid ? ' Your Buzz has been refunded.' : '';
   const rest = details.refundPaid ? '; the rest has been refunded' : '';

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -111,7 +111,17 @@ function declineMessage(details: Record<string, unknown>) {
   const refunded = details.refundPaid ? ' Your Buzz has been refunded.' : '';
   const rest = details.refundPaid ? '; the rest has been refunded' : '';
 
-  if (details.feeWaived || !(fee > 0)) return `${declined}.${refunded}`;
+  // Waived: the whole escrow comes back, so the refund clause is the only thing
+  // to say and `refundPaid` decides whether it is true yet.
+  if (details.feeWaived) return `${declined}.${refunded}`;
+
+  // 🔴 Neither waived nor carrying a receipted fee means this decline has not
+  // finished settling, and "your Buzz has been refunded" would be wrong in the
+  // direction that matters: a fee is still owed and will be taken. It is
+  // reachable because `planPayout` re-reads the legs with no `orderBy`, so a
+  // sweeper-driven resume can receipt the placer's refund while the fee leg is
+  // still stranded. Saying nothing about money is true at every moment.
+  if (!(fee > 0)) return `${declined}.`;
 
   return `${declined}. They kept ${fee} Buzz${rest}.`;
 }

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -676,6 +676,15 @@ export const placementNotifications = createNotificationProcessor({
               -- settled outcome -- so this needs no expiresAt window of its own,
               -- which would re-report a row whose deadline passed long before the
               -- job reached it.
+              -- ⚠️ This also selects a FAILED CREATION. createStickerPlacement
+              -- compensates a failure by calling settlePlacement with 'expire',
+              -- so the row is indistinguishable from one that timed out -- and
+              -- the placer, who already saw an error, is told it "expired".
+              -- Accepted knowingly (Justin, 2026-08-24) rather than missed: the
+              -- path is rare and the receipt gate above keeps the sentence from
+              -- claiming a refund that did not happen. Telling the two apart
+              -- needs a column the row does not carry, so do not "fix" this with
+              -- a WHERE clause -- it would need the unwind to mark itself first.
               p.status = 'expired'
               AND p."resolvedAt" IS NOT NULL
               AND p."resolvedAt" > '${lastSent}'


### PR DESCRIPTION
`868kv5d36`. A declined sticker placement notified nobody, and the placer lost their fee with no signal but a balance that had gone down.

Reverses the 2026-08-18 decision to leave decline and expiry silent, on Justin's instruction of 2026-08-24. That reasoning — "a declined sticker never appeared anywhere" — is true of the sticker and not of the money. He also asked for expiry, so a placer learns their Buzz came back rather than inferring it.

## Shape

Extends `sticker-placement-resolved` rather than adding a type (his choice), so one mute switch still covers everything that happens to a placement after it is made. The display name moves from "answered" to "resolved", because expiry is the outcome where nobody answered — the setting keys on `type`, not on the label, so existing opt-outs are unaffected.

## The money, read off `placementPaymentSplit` rather than off comments

| Outcome | What moves |
|---|---|
| `declined` | `toOwner = declineFeeAmount(amount, rate)`, `toPlacer = amount - toOwner` — **fee kept, rest refunded** |
| `expired` | `toPlacer: amount` — **everything refunded** |

So the decline branch is three sentences, because the money is genuinely three things:

- **Free** — `amount` is 0 by DB constraint, so nothing is said about Buzz. "Your Buzz has been refunded" would send someone looking for a credit that never existed.
- **Fee waived** — `declineByBlock` and `declineUnshowableHost` return the whole escrow, so "they kept N Buzz" would be a false statement about a balance. Read off the `feeWaived` column: `removedBy` is NULL on a decline and cannot tell these apart.
- **Fee taken** — quotes what the creator kept.

That figure comes from the `feeToOwner` ledger row, not from recomputing `declineFeeAmount`. The rate is per-space and can move between the placement and the decline, so a recomputed number would eventually contradict what `/user/transactions` shows for the same event. The subquery hits the unique index on `(placementId, kind)`.

Both new query branches key on `resolvedAt`, like every branch already there. Expiry needs no `expiresAt` window of its own — `expirePlacements` runs over `status = 'pending'` regardless of `free`, and `expire` stamps `resolvedAt` like any other settled outcome; a deadline window would re-report rows whose deadline passed long before the job reached them.

Declined and expired both link to the plain image URL. There is no sticker there to see.

## Verification

- `pnpm run typecheck` — 0 errors. Lint — 0 errors in the changed files.
- Full unit suite: **`Test Files 1378 passed | 1 skipped (1379)`**, **`Tests 21631 passed | 27 skipped (21658)`**, exit 0. Both lines account for every file and every test.
- `blocks.router.workflow.test.ts` collected **358 tests**, so the submodule is initialised.

**Controls, run rather than reasoned about:**

- Drop the fee sentence and treat every paid decline as fully refunded → `expected 'somebody declined your sticker. Your …' to be 'somebody declined your sticker. They …'`
- Drop the `expired` query branch → `expected 'approved,declined,removed' to be 'approved,declined,expired,removed'`

**One near-miss worth recording.** An edit adding the two new SQL fields silently did not land — the script that wrote it asserted after the replace and before the write. Every message test still passed, because they hand-build their `details`. The only thing that caught it was an assertion on the emitted SQL. Without that, every paid decline would have read *"Your Buzz has been refunded"*, which is false for the common case.

## Note for whoever merges second

`prepareMessage` for this processor is also touched by #4338, which points the *approval* branch at a reveal URL. One function, small conflict, no dependency in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review round — two money findings, both fixed

**The refund sentences were asserted from the payout PLAN, not from receipts.** `settlePlacement` writes the status flip and the payout legs in one transaction with `transactionId` NULL on every leg; the Buzz calls happen afterwards, outside it, and `runLeg` can decline the lock, fail, or exhaust its attempts and stop with nothing but an Axiom line. The notification job runs every minute off the committed row — so *"your Buzz has been refunded"* was a claim about a movement nobody had observed, and on a stranded leg it stays false with the placer's balance as the thing disagreeing.

Both refund clauses now require a receipted placer-directed leg, and the fee lookup requires one too.

**A residual in the other direction**, found on re-review: `planPayout` re-reads the legs with no `orderBy`, so a sweeper-driven resume can receipt the placer's refund while the fee leg is still stranded — *"your Buzz has been refunded"* while a fee is still owed and will be taken. A decline that is neither waived nor carrying a receipted fee now says nothing about money, which is true at every moment.

## Review round — the tests

Three keys the query emits and the message branches on were asserted **nowhere**: `status`, `ownerUsername`, `ownerId`. Dropping `'status', p.status` made every decline, expiry and takedown say *"accepted your sticker"* — with all 36 tests green, because they hand-build their `details`.

The waived-fee test could not fail: its fixture omitted `feeToOwner`, so the `!(fee > 0)` fallback produced the asserted string and deleting `details.feeWaived ||` passed the test named for that flag.

Neither new query branch was pinned to `resolvedAt` — swapping the expired branch to `expiresAt`, which its own comment says it is avoiding, turned nothing red.

One test deleted: `url` is computed once before any branch, so nothing branch-specific could have failed it.

## A known limitation, accepted deliberately

`createStickerPlacement` compensates a **failed** creation by calling `settlePlacement({ action: 'expire' })`, so the row is indistinguishable from one that timed out — and the placer, who already saw an error, is told it "expired". Telling the two apart needs a column the row does not carry.

Justin's call, 2026-08-24: ship it. The path is rare and the receipt gate keeps the sentence from claiming a refund that did not happen. **Recorded in the query itself**, including why a `WHERE` clause cannot fix it, so the next reader does not try.

## Verification after the fix round

- Typecheck 0, lint 0, `src/server/notifications/__tests__` → **`Test Files 19 passed (19)`, `Tests 340 passed (340)`**.
- Four controls, each failing on its own named test: dropping `'status', p.status`; deleting `details.feeWaived ||`; swapping the expired branch to `expiresAt`; removing the receipt gate.


---

## Scope of the receipt gate — two of the three places the sentence occurs

Stating this plainly because the honest version is narrower than "this PR made the refund sentences truthful".

The gate applies to the **decline and expiry** branches of the **sticker** type. It does **not** apply to `moderatorRemovalMessage`, which still promises `Your Buzz has been refunded.` from the status alone, on both surfaces — and the remix query does not project `refundPaid` at all, so extending it there is a change to two queries rather than to one message.

That is deliberate scope, not an oversight, and it is documented next to the assertion that pins the ungated behaviour — including the instruction that when someone does extend it, **that assertion changing is the fix and not a regression**. But the docblock is only found by someone already in the file, so it belongs here too.

## What the test suite is worth now

Every key `prepareMessage` reads is asserted against the **emitted SQL**, not against a fixture: `imageId`, `status`, `ownerUsername`, `ownerId`, `removedBy`, `wasLive`, `amount`, `feeWaived`, `feeToOwner`, `refundPaid`.

Four of those seams were open when the review started. The first — `status` — meant that dropping one key from the `jsonb_build_object` would have told **every declined, expired and taken-down placement that it was accepted**, with the whole file green, because the message tests hand-build their details.

Twelve findings across four review rounds. Five of them existed only because an earlier fix round created them.
