### PR TITLE
fix(model-files): the type guard from #4344 was inverted, and two related hazards

### DIFF
--- a/src/server/services/__tests__/model-file-header-correction.service.test.ts
+++ b/src/server/services/__tests__/model-file-header-correction.service.test.ts
@@ -1,14 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import type * as ModelFileService from '~/server/services/model-file.service';
+import type * as TensorMetadataService from '~/server/services/tensor-metadata.service';
+import type * as CacheHelpers from '~/server/utils/cache-helpers';
 
-const { deleteFilesForModelVersionCache } = vi.hoisted(() => ({
-  deleteFilesForModelVersionCache: vi.fn(),
-}));
+const { deleteFilesForModelVersionCache, bustFullTensorAnalysis, bustFetchThroughCache } =
+  vi.hoisted(() => ({
+    deleteFilesForModelVersionCache: vi.fn(),
+    bustFullTensorAnalysis: vi.fn(),
+    bustFetchThroughCache: vi.fn(),
+  }));
 
 vi.mock('~/server/services/model-file.service', async (importOriginal) => ({
   ...(await importOriginal<typeof ModelFileService>()),
   deleteFilesForModelVersionCache,
+}));
+vi.mock('~/server/services/tensor-metadata.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof TensorMetadataService>()),
+  bustFullTensorAnalysis,
+}));
+vi.mock('~/server/utils/cache-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof CacheHelpers>()),
+  bustFetchThroughCache,
 }));
 
 const executeRaw = dbMock.dbWrite.$executeRaw;
@@ -42,6 +55,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   executeRaw.mockResolvedValue(1);
   deleteFilesForModelVersionCache.mockResolvedValue(undefined);
+  bustFetchThroughCache.mockResolvedValue(undefined);
 });
 
 describe('getModelFileHeaderCorrections — precision', () => {
@@ -160,57 +174,86 @@ describe('getModelFileHeaderCorrections — type', () => {
     ).toEqual({ type: 'VAE' });
   });
 
-  // 🔴 The detection misreads whole architectures: an LLM's own weights match the
-  // embed_tokens + layers.N text-encoder rule, and a vision-language model's match
-  // VisionEncoder. Relabelling those drops the file out of primaryFileTypesByModelType,
-  // so it stops being the version's primary file on the download path. A correction may
-  // never demote a file that is already primary. Do not remove this guard.
+  /**
+   * 🔴 These were previously relabelled — an LLM's own weights to 'Text Encoder', a VLM's
+   * to 'CLIPVision', a MotionModule's to 'Enhancement LoRA' — by detection rules the source
+   * documents as misreads of those architectures. On those model types the header has said
+   * nothing unambiguous about the file's ROLE, so the answer is 'Model': it is the model's
+   * own weights. Fixed at the source, in getModelFileTypeCorrection.
+   *
+   * The first attempt instead let the relabel happen and blocked it downstream whenever it
+   * would drop the file out of primaryFileTypesByModelType. That guard was INVERTED — see
+   * the Checkpoint cases below, which it refused — while still mis-typing any file that was
+   * not already the primary one. Do not reintroduce it.
+   */
   it.each([
-    ['LLM', 'Model', 'TextEncoder'],
-    ['VisionLanguage', 'Model', 'VisionEncoder'],
-    ['MotionModule', 'Model', 'LoRA'],
+    ['LLM', 'TextEncoder'],
+    ['VisionLanguage', 'VisionEncoder'],
+    ['VisionLanguage', 'TextEncoder'],
+    ['MotionModule', 'LoRA'],
+  ] as const)('leaves a %s model own weights file as Model', (modelType, detectedModelType) => {
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'SafeTensor',
+        dtypeCounts: bf16Counts,
+        detectedModelType,
+        currentFp: 'bf16',
+        currentFileType: 'Model',
+        modelType,
+      })
+    ).toEqual({});
+  });
+
+  /**
+   * 🔴 The case this feature exists for, and the one the removed guard refused: 'VAE' is
+   * not in primaryFileTypesByModelType.Checkpoint, so a VAE wrongly uploaded as a
+   * checkpoint's main weights file was detected correctly and then left alone. Measured
+   * before the fix: `expected {} to deeply equal { type: 'VAE' }`.
+   */
+  it.each([
+    ['VAE', 'VAE'],
+    ['TextEncoder', 'Text Encoder'],
+    ['ControlNet', 'ControlNet'],
   ] as const)(
-    'refuses a %s correction that would drop the file out of the primary set',
-    (modelType, currentFileType, detectedModelType) => {
+    'corrects a %s mis-filed as a Checkpoint own weights file',
+    (detectedModelType, expected) => {
       expect(
         getModelFileHeaderCorrections({
           format: 'SafeTensor',
           dtypeCounts: bf16Counts,
           detectedModelType,
           currentFp: 'bf16',
-          currentFileType,
-          modelType,
+          currentFileType: 'Model',
+          modelType: 'Checkpoint',
         })
-      ).toEqual({});
+      ).toEqual({ type: expected });
     }
   );
 
-  it('still corrects a non-primary file on a model type with a primary set', () => {
-    // 'Other' is not primary for LLM, so nothing is demoted and the fix goes through.
+  it('still corrects a non-primary file', () => {
     expect(
       getModelFileHeaderCorrections({
         format: 'SafeTensor',
         dtypeCounts: bf16Counts,
-        detectedModelType: 'TextEncoder',
+        detectedModelType: 'VAE',
         currentFp: 'bf16',
         currentFileType: 'Other',
-        modelType: 'LLM',
+        modelType: 'Checkpoint',
       })
-    ).toEqual({ type: 'Text Encoder' });
+    ).toEqual({ type: 'VAE' });
   });
 
-  it('allows a correction that stays inside the primary set', () => {
-    // 'Diffusion Model' is primary for Checkpoint alongside 'Model', so this is not a demotion.
+  it('leaves a Checkpoint own weights file alone when the header agrees', () => {
     expect(
       getModelFileHeaderCorrections({
         format: 'SafeTensor',
         dtypeCounts: bf16Counts,
         detectedModelType: 'DiffusionModel',
         currentFp: 'bf16',
-        currentFileType: 'Model',
+        currentFileType: 'Diffusion Model',
         modelType: 'Checkpoint',
       })
-    ).toEqual({ type: 'Diffusion Model' });
+    ).toEqual({});
   });
 });
 
@@ -310,6 +353,38 @@ describe('applyModelFileHeaderCorrections', () => {
     ]);
   });
 
+  /**
+   * 🔴 `file.type` is an INPUT to the cached tensor analysis — `supportsTensorVramEstimate`
+   * gates `vramEstimate` on it — and neither tensor cache key varies with type. Without
+   * this bust a corrected file keeps a `vramEstimate` that is now wrong for a month in
+   * redis, and up to a year at the CDN because the 200 carries `immutable`.
+   */
+  it('busts the tensor analysis caches when the TYPE changed', async () => {
+    await applyModelFileHeaderCorrections({ ...target, corrections: { type: 'VAE' } });
+
+    expect(bustFullTensorAnalysis).toHaveBeenCalledWith(target.fileId);
+    const keys = bustFetchThroughCache.mock.calls.map((c) => c[0]);
+    expect(keys).toHaveLength(2);
+    expect(keys.some((k: string) => k.endsWith(`tensor-metadata:${target.fileId}`))).toBe(true);
+    expect(keys.some((k: string) => k.endsWith(`tensor-metadata-summary:${target.fileId}`))).toBe(
+      true
+    );
+    // The full blob is stored brotli-compressed; busting it without that flag evicts the
+    // entry instead of marking it stale, and the bust silently no-ops.
+    const full = bustFetchThroughCache.mock.calls.find((c) =>
+      String(c[0]).endsWith(`tensor-metadata:${target.fileId}`)
+    );
+    expect(full?.[1]).toEqual({ compress: true });
+  });
+
+  it('does not bust the tensor caches for a precision-only correction', async () => {
+    await applyModelFileHeaderCorrections({ ...target, corrections: { fp: 'bf16' } });
+
+    expect(deleteFilesForModelVersionCache).toHaveBeenCalledTimes(1);
+    expect(bustFullTensorAnalysis).not.toHaveBeenCalled();
+    expect(bustFetchThroughCache).not.toHaveBeenCalled();
+  });
+
   it('does not bust the cache when the url guard rejected the write', async () => {
     executeRaw.mockResolvedValue(0);
 
@@ -318,6 +393,7 @@ describe('applyModelFileHeaderCorrections', () => {
     ).resolves.toBe(false);
 
     expect(deleteFilesForModelVersionCache).not.toHaveBeenCalled();
+    expect(bustFullTensorAnalysis).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/__tests__/model-file-header-correction.service.test.ts
+++ b/src/server/services/__tests__/model-file-header-correction.service.test.ts
@@ -106,7 +106,7 @@ describe('getModelFileHeaderCorrections — precision', () => {
     ).toEqual({ fp: 'mxfp8' });
   });
 
-  // 🔴 The whole point of FP_HEADER_CANNOT_STATE. Each of these is a value no safetensors
+  // 🔴 The whole point of FP_HEADER_MAY_REPLACE. Each of these is a value no safetensors
   // header can express, so the header is SILENT about it rather than disagreeing. Because
   // the correction runs on read, overwriting one re-applies over any manual fix — the
   // creator can never get their record back. Do not "fix" these to expect a correction.
@@ -120,6 +120,24 @@ describe('getModelFileHeaderCorrections — precision', () => {
     expect(getModelFileHeaderCorrections({ format: 'SafeTensor', dtypeCounts, currentFp })).toEqual(
       {}
     );
+  });
+
+  /**
+   * 🔴 Precisions are MOD-MANAGED at runtime (`modelFileOptions`); `constants.modelFileFp`
+   * is only the fallback. A deny-list of "values the header cannot state" silently stops
+   * covering anything a mod adds after it is written, and the first read then overwrites a
+   * correct value — permanently, since the correction re-applies over any manual fix. The
+   * allow-list makes an unknown precision refused by construction. This test is the guard
+   * on that: it uses a value that is in NO list in the codebase.
+   */
+  it('refuses to overwrite a precision it has never heard of', () => {
+    expect(
+      getModelFileHeaderCorrections({
+        format: 'SafeTensor',
+        dtypeCounts: bf16Counts,
+        currentFp: 'fp4_scaled_future_mod_added' as never,
+      })
+    ).toEqual({});
   });
 
   // The complement, and it must be able to FAIL: an earlier version of this asserted

--- a/src/server/services/model-file-header-correction.service.ts
+++ b/src/server/services/model-file-header-correction.service.ts
@@ -1,9 +1,10 @@
 import { Prisma } from '@prisma/client';
 import type { ModelFileType } from '~/server/common/constants';
 import { dbWrite } from '~/server/db/client';
+import { REDIS_KEYS } from '~/server/redis/client';
 import { deleteFilesForModelVersionCache } from '~/server/services/model-file.service';
-import type { ModelType } from '~/shared/utils/prisma/enums';
-import { primaryFileTypesByModelType } from '~/utils/file-display-helpers';
+import { bustFullTensorAnalysis } from '~/server/services/tensor-metadata.service';
+import { bustFetchThroughCache } from '~/server/utils/cache-helpers';
 import { getDominantFpFromDtypes } from '~/utils/file-helpers';
 import type {
   DetectedModelTensorType,
@@ -77,30 +78,6 @@ const FP_HEADER_CANNOT_STATE: readonly string[] = [
 ];
 
 /**
- * A type correction must never move a file OUT of the primary set for its model type.
- *
- * 🔴 The detection is heuristic and reads several architectures wrongly: an LLM's own
- * weights match `hasLlmTextEncoder` (embed_tokens + layers.N), and a vision-language
- * model's match VisionEncoder. Relabelling those to 'Text Encoder'/'CLIPVision' drops
- * the file out of `primaryFileTypesByModelType[LLM|VisionLanguage]`, so it stops being
- * the version's primary file and loses the download-path scoring bonus.
- *
- * A file that is NOT currently primary is the mis-filed case this feature exists for and
- * stays correctable. This only refuses to demote one that already is.
- */
-function wouldDemoteFromPrimary(
-  modelType: string | null | undefined,
-  currentFileType: string | null | undefined,
-  correctedType: ModelFileType
-) {
-  const primary = primaryFileTypesByModelType[modelType as ModelType] as
-    | readonly string[]
-    | undefined;
-  if (!primary) return false;
-  return primary.includes(currentFileType ?? '') && !primary.includes(correctedType);
-}
-
-/**
  * What the tensor header says should change on a file record. Pure — split from the
  * write below so upload-time auto-detect can reuse the judgement without a database.
  */
@@ -120,7 +97,7 @@ export function getModelFileHeaderCorrections({
     corrections.fp = fp;
 
   const type = getModelFileTypeCorrection({ detectedModelType, modelType, currentFileType });
-  if (type && !wouldDemoteFromPrimary(modelType, currentFileType, type)) corrections.type = type;
+  if (type) corrections.type = type;
 
   return corrections;
 }
@@ -183,8 +160,24 @@ export async function applyModelFileHeaderCorrections({
   // "something actually changed". Without them, every concurrent viewer inside the
   // replica-lag window after the first correction rewrites the same values and busts the
   // cache again: N dead tuples and N busts per window on a hot file.
-  if (updated > 0) await deleteFilesForModelVersionCache(modelVersionId);
-  return updated > 0;
+  if (updated === 0) return false;
+
+  await deleteFilesForModelVersionCache(modelVersionId);
+
+  // 🔴 `file.type` is an INPUT to the cached analysis, not just a field beside it:
+  // `supportsTensorVramEstimate` gates `vramEstimate` on it, and neither tensor cache key
+  // varies with type. Correcting the type into or out of the weights-file set therefore
+  // pins a `vramEstimate` that is now wrong for a month in redis — and up to a year at the
+  // CDN, since the 200 carries `immutable`. Only on a type change; precision is not an input.
+  if (type) {
+    bustFullTensorAnalysis(fileId);
+    await Promise.all([
+      bustFetchThroughCache(`${REDIS_KEYS.CACHES.TENSOR_METADATA}:${fileId}`, { compress: true }),
+      bustFetchThroughCache(`${REDIS_KEYS.CACHES.TENSOR_METADATA_SUMMARY}:${fileId}`),
+    ]);
+  }
+
+  return true;
 }
 
 /**

--- a/src/server/services/model-file-header-correction.service.ts
+++ b/src/server/services/model-file-header-correction.service.ts
@@ -34,48 +34,32 @@ type FileTarget = {
 };
 
 /**
- * Precisions a safetensors header can never state, so a stored one is never overwritten.
+ * The only stored precisions a safetensors header is allowed to overwrite.
  *
- * 🔴 The header carries a dtype, and these values are not dtypes. Two ways they hide:
+ * 🔴 Stated as an ALLOW-list on purpose. The obvious shape is a deny-list of values the
+ * header cannot express, and that shape is unsafe here: `constants.modelFileFp` is only a
+ * FALLBACK — precisions are mod-managed at runtime through `modelFileOptions`
+ * (`model-file.service.ts` `getModelFileOptions` / `addModelFileOptions`). A deny-list
+ * silently stops covering every precision a mod adds after it is written, and since this
+ * correction runs on READ, the first overwrite re-applies over any manual fix. Inverted,
+ * an unknown precision is refused by construction and the list cannot drift.
  *
- * - `fp8_scaled` / `fp8_mixed` are scaling schemes layered on an F8 dtype. The header
- *   reads F8 and says nothing about the scaling.
- * - `nf4` / `nvfp4` / `int4` are packed into `U8` (bitsandbytes) or `I32` (GPTQ/AWQ),
- *   which `SAFETENSORS_DTYPE_TO_FP` deliberately leaves unmapped. The quantized bulk
- *   therefore contributes NOTHING to the vote, and the winner is whatever the auxiliary
- *   layernorm/embedding/scale tensors are — typically fp16.
+ * These four are exactly the values a dtype can state. Everything else is refused because
+ * the header is SILENT about it, not because it disagrees:
  *
- * In both cases the header is SILENT, not contradicting, and taking it literally writes
- * a wrong value over a right one. It is unrecoverable rather than merely wrong: this runs
- * on read, so it re-applies over any correction the creator makes by hand.
+ * - `fp8_scaled` / `fp8_mixed` are scaling schemes layered on an F8 dtype.
+ * - `nf4` / `nvfp4` / `int4`, and GPTQ/AWQ `int8`, pack into `U8` / `I32`, which
+ *   `SAFETENSORS_DTYPE_TO_FP` deliberately leaves unmapped — so the quantized bulk
+ *   contributes NOTHING to the byte-share vote and the winner is whatever leftover fp16
+ *   housekeeping tensors are present.
+ * - `mxfp8` and `int8` ARE emittable, and are still excluded: mxfp8 is inferred from
+ *   F8_E8M0 scale tensors an exporter may store as `U8` instead, and true `I8` cannot be
+ *   told from the GPTQ case. Correcting a file already labelled with one is worth little
+ *   next to overwriting a right value permanently.
  *
- * 🔴 The test is SILENCE, not "can the mapper emit it". Those come apart, and where they
- * do the emittable-means-safe proxy fails open:
- *
- * - `mxfp8` is emittable but is not a dtype either — it is inferred from F8_E8M0-typed
- *   scale tensors. An exporter that stores those scales as `U8` (permitted: E8M0 is
- *   byte-wide) leaves no signal, the vote returns plain `fp8`, and a correct value is lost.
- * - `int8` is emittable from `I8`, but GPTQ/AWQ at 8 bits packs into the unmapped `I32` —
- *   the same mechanism as int4, with leftover fp16 tensors winning the vote.
- *
- * Both are on the list for that reason. The cost is only that a file ALREADY labelled
- * mxfp8 or int8 is never re-corrected; an empty `fp` is still filled from the header, and
- * a wrong fp32/fp16/bf16/fp8 is still fixed.
- *
- * Traded away knowingly: keying on the HEADER's answer instead would let a positive mxfp8
- * identification overwrite a stored `fp8_scaled`. Correcting a mislabelled file is worth
- * little next to destroying a right value permanently, and this runs on read, so a bad
- * overwrite re-applies over any manual fix. Prefer the refusal in both directions.
+ * An absent `fp` is always fillable — that is the backlog this feature exists for.
  */
-const FP_HEADER_CANNOT_STATE: readonly string[] = [
-  'fp8_scaled',
-  'fp8_mixed',
-  'mxfp8',
-  'int8',
-  'nf4',
-  'nvfp4',
-  'int4',
-];
+const FP_HEADER_MAY_REPLACE: readonly string[] = ['fp32', 'fp16', 'bf16', 'fp8'];
 
 /**
  * What the tensor header says should change on a file record. Pure — split from the
@@ -93,7 +77,7 @@ export function getModelFileHeaderCorrections({
   if (format !== 'SafeTensor') return corrections;
 
   const fp = getDominantFpFromDtypes(dtypeCounts ?? []);
-  if (fp && fp !== currentFp && !FP_HEADER_CANNOT_STATE.includes(currentFp ?? ''))
+  if (fp && fp !== currentFp && (!currentFp || FP_HEADER_MAY_REPLACE.includes(currentFp)))
     corrections.fp = fp;
 
   const type = getModelFileTypeCorrection({ detectedModelType, modelType, currentFileType });

--- a/src/utils/model-tensor-metadata.ts
+++ b/src/utils/model-tensor-metadata.ts
@@ -256,7 +256,14 @@ export function getModelFileTypeCorrection({
       compatibleTypes = modelType === 'Checkpoint' ? ['Model', 'Pruned Model'] : ['Model'];
       break;
     case 'LoRA':
-      if (modelType === 'LORA' || modelType === 'DoRA' || modelType === 'LoCon') {
+      // A MotionModule's own weights are LoRA-shaped (AnimateDiff), so the paired
+      // down/up tensors identify the model, not an enhancement bolted onto it.
+      if (
+        modelType === 'LORA' ||
+        modelType === 'DoRA' ||
+        modelType === 'LoCon' ||
+        modelType === 'MotionModule'
+      ) {
         canonicalType = 'Model';
         compatibleTypes = ['Model', 'Pruned Model'];
       } else {
@@ -267,11 +274,20 @@ export function getModelFileTypeCorrection({
       canonicalType = modelType === 'VAE' ? 'Model' : 'VAE';
       break;
     case 'TextEncoder':
-      canonicalType = modelType === 'TextEncoder' ? 'Model' : 'Text Encoder';
+      // 🔴 `hasLlmTextEncoder` fires on embed_tokens + layers.N, which is every decoder
+      // LLM — so on an LLM or VLM this detection IS the model's own weights and the
+      // header has said nothing unambiguous about the file's role. Answering 'Model'
+      // here is what makes that true at the source; an earlier version instead let the
+      // relabel happen and tried to catch the damage downstream, which both blocked
+      // real corrections and still mis-typed any file not already the primary one.
+      canonicalType =
+        modelType === 'TextEncoder' || modelType === 'LLM' || modelType === 'VisionLanguage'
+          ? 'Model'
+          : 'Text Encoder';
       break;
     case 'VisionEncoder':
       canonicalType =
-        modelType === 'CLIPVision'
+        modelType === 'CLIPVision' || modelType === 'VisionLanguage'
           ? 'Model'
           : modelType === 'CLIP'
           ? 'Vision Encoder'


### PR DESCRIPTION
Follow-up to #4344 (merged as `1411b6ca33`). Two correctness bugs and one drift hazard, all found by the **three review lanes that had not run before #4344 merged** — `civitai-intent-review`, `civitai-perf-review` and `civitai-reuse-review`. I had run only correctness and tests. That gap is the story of this PR.

Every finding below was confirmed by **running the code**, not by reading it.

## 1. The type guard was inverted — it blocked real corrections and permitted known-bad ones

#4344 refused any type correction that would move a file out of `primaryFileTypesByModelType[modelType]`. Measured on `1411b6ca33`:

```
✕ a VAE uploaded as the Model file of a Checkpoint version
  AssertionError: expected {} to deeply equal { type: 'VAE' }

✕ an LLM file typed Other, where the code documents the detection as a misread
  AssertionError: expected { type: 'Text Encoder' } to deeply equal {}
```

- **`'VAE'` is not in `primaryFileTypesByModelType.Checkpoint`**, so a VAE wrongly uploaded as a checkpoint's main weights file — the classic mis-file this feature exists for — was detected correctly and then left alone.
- Meanwhile the guard did nothing for a file that was *not* already primary, so an LLM file typed `'Other'` was still relabelled `'Text Encoder'` by a rule the source itself documents as a misread of LLM weights. #4344 even had a test asserting that as desired.

**Root cause: I fixed a correctness-lane finding at the wrong layer** — I patched the consequence (the download-path demotion) instead of the ambiguity that caused it.

**Fix at the source.** On an `LLM` or `VisionLanguage` model the text/vision-encoder detections *are* the model's own weights; on a `MotionModule` so is the LoRA shape. The answer is `'Model'` — the same `modelType === X ? 'Model' : …` pattern the mapper already used for VAE, UNet and ControlNet. With the ambiguity resolved the downstream guard had nothing left to protect and only refused real corrections, so it is removed.

## 2. A type correction left a stale VRAM estimate cached for a month

`supportsTensorVramEstimate({ modelType, fileType: file.type })` gates `vramEstimate`, so **`ModelFile.type` is an input to the cached analysis** — but neither `TENSOR_METADATA` nor `TENSOR_METADATA_SUMMARY` varies with type, and nothing in the repo busts either. #4344 is what made `file.type` mutate on the read path, so a corrected file kept a `vramEstimate` that is now wrong for `CacheTTL.month` in redis, and up to a year at the CDN because the 200 carries `immutable`.

Now busted on a **type** change only (precision is not an input), reusing the existing `bustFullTensorAnalysis` for the in-process LRU. The full blob is brotli-compressed, so its bust passes `{ compress: true }` — without that flag the entry is evicted instead of marked stale and the bust silently no-ops.

## 3. The precision rule was a deny-list, and precisions are mod-managed at runtime

`constants.modelFileFp` is only a **fallback**; precisions live in the `modelFileOptions` KeyValue row and mods add them at runtime. A deny-list of "values the header cannot state" silently stops covering anything added after it is written — and since this runs on read, the first overwrite re-applies over any manual fix. That is the same unrecoverable failure the list was added to prevent.

Inverted to an allow-list of the four values a dtype can actually state (`fp32`, `fp16`, `bf16`, `fp8`), so an unknown precision is refused **by construction** rather than by remembering to edit an array. An absent `fp` is still always fillable.

## Verification

```
pnpm run typecheck                  OK — 0 type errors
pnpm exec eslint <changed files>    0 errors
affected suites                     Test Files 6 passed (6) / Tests 153 passed (153)
```

Five positive controls, each reverted, each red:

| reverted | failure |
|---|---|
| LLM/VLM own-weights fix | 3 red, `expected { type: 'Text Encoder' } to deeply equal {}` |
| MotionModule arm | `expected { type: 'Enhancement LoRA' } to deeply equal {}` |
| tensor-cache bust on type | `expected "vi.fn()" to be called with arguments: [ 42 ]` |
| `{ compress: true }` on the full-blob bust | `expected {} to deeply equal { compress: true }` |
| allow-list back to a deny-list | `expected { fp: 'bf16' } to deeply equal {}` |

## Cleared by the perf lane, on record

Steady state is genuinely free: once corrected, the path issues no query and no redis command. Replica lag measured at **3 ms**, and inside that window the `IS DISTINCT FROM` predicates make the UPDATE match 0 rows — no lock, no dead tuple, no bust. `detectModelTypeFromTensors` runs on a redis **miss only** (≈3.9 µs/tensor), never on the LRU or summary path. `url: true` adds no I/O — the heap tuple was already fetched.

Two things it logged rather than flagged, filed rather than fixed here: ~977k rows are one anonymous origin request from an UPDATE each, and this route has no rate limit; and every correction is a non-HOT update against 7 indexes (~390 MB heap churn across the whole wave, no TOAST — measured max `pg_column_size(metadata)` 450 B).

## Not fixed here

- `'Vision Encoder'` has no case in `inferComponentType` or `fileTypeToComponentTypeMap`, so a file corrected to it drops out of component grouping. Pre-existing gap that this feature makes reachable — reuse lane's finding, worth its own PR.
- Tensor caches are still not busted when `updateFile` replaces a file's `url` — [868kw8dre](https://app.clickup.com/t/868kw8dre).
