### PR TITLE
fix(images): a cursored BitDex fallback no longer restarts the feed at page 1

### DIFF
--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -74,10 +74,14 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
     { enabled: !!currentUser && selected != null }
   );
 
-  const { images, isLoading, fetchNextPage, hasNextPage, isRefetching } = useQueryImages(
-    remixSubmitPickerFilters(currentUser?.id),
-    { enabled: !!currentUser }
-  );
+  const {
+    images,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+    isRefetching,
+    isError: imagesFailed,
+  } = useQueryImages(remixSubmitPickerFilters(currentUser?.id), { enabled: !!currentUser });
 
   const price = visibility?.price ?? null;
 
@@ -381,9 +385,15 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                 ))}
               </div>
 
-              {/* Scroll-to-load, which is what a populated grid should do. */}
+              {/* Scroll-to-load, which is what a populated grid should do.
+
+                  `!imagesFailed` is load-bearing: `hasNextPage` is derived from the last
+                  SUCCESSFUL page, so it stays true after a failed fetch and this loader
+                  would otherwise stay mounted in view and re-fire every ~500ms with no
+                  backoff. The feed proper swaps in SearchRetryBanner on error; this
+                  surface has no such affordance, so it must simply stop. */}
               {hasNextPage && (
-                <InViewLoader loadFn={fetchNextPage} loadCondition={!isRefetching}>
+                <InViewLoader loadFn={fetchNextPage} loadCondition={!isRefetching && !imagesFailed}>
                   <Group justify="center" py="md">
                     <Loader size="sm" />
                   </Group>

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:3985':
+  'server/services/image.service.ts:4043':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4115':
+  'server/services/image.service.ts:4184':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4827':
+  'server/services/image.service.ts:4896':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5941':
+  'server/services/image.service.ts:6010':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -206,7 +206,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4115')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4184')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/metrics/__tests__/bitdex-feed-serve.metrics.test.ts
+++ b/src/server/metrics/__tests__/bitdex-feed-serve.metrics.test.ts
@@ -15,7 +15,7 @@ import {
 /**
  * 🔴 THE RUNTIME LABEL-NARROWING GUARDS, WHICH NOTHING ELSE REACHES.
  *
- * The module's header claims a hard cardinality bound of 14 series and says the
+ * The module's header claims a hard cardinality bound of 20 series and says the
  * bound "rests on CODE, not on the erased types". That claim is only true if the
  * `is…` checks in the two `record…` functions actually run and actually drop an
  * unrecognised value. Nothing else in the suite can test them: every other caller

--- a/src/server/metrics/__tests__/metrics-endpoint-seeds-bitdex-feed-serve.test.ts
+++ b/src/server/metrics/__tests__/metrics-endpoint-seeds-bitdex-feed-serve.test.ts
@@ -51,7 +51,7 @@ describe('/api/metrics registers + seeds the BitDex serve-outcome counters at mo
     expect(client.register.getSingleMetric(FAILURES_METRIC)).toBeUndefined();
   });
 
-  it('🔴 after loading the page module, all 8 outcome × mode series exist at 0', async () => {
+  it('🔴 after loading the page module, all 14 outcome × mode series exist at 0', async () => {
     await import('~/pages/api/metrics');
 
     const metric = client.register.getSingleMetric(RESULT_METRIC) as unknown as
@@ -60,7 +60,7 @@ describe('/api/metrics registers + seeds the BitDex serve-outcome counters at mo
     expect(metric).toBeDefined();
 
     const { values } = await metric!.get();
-    // Derived from the unions, not hardcoded: a 5th outcome or a 3rd mode must
+    // Derived from the unions, not hardcoded: an 8th outcome or a 3rd mode must
     // be seeded too, and this must fail until it is.
     const { BITDEX_SERVE_MODES, BITDEX_SERVE_OUTCOMES } = await import(
       '~/server/metrics/bitdex-feed-serve.metrics'

--- a/src/server/metrics/bitdex-feed-serve.metrics.ts
+++ b/src/server/metrics/bitdex-feed-serve.metrics.ts
@@ -154,12 +154,27 @@ import client, { type Counter, type Registry } from 'prom-client';
  *   page was empty. This is the value this issue exists to make observable.
  * - `fallback_exception` — the application's own code threw while handling the
  *   response. Distinct owner, distinct response.
+ *
+ * The two below are empty CURSORED pages, which since 2026-08-24 do not fall
+ * back at all. They are named apart from the `fallback_*` family on purpose: a
+ * `bdx:` cursor is unreadable by the fallback backend, so routing one there
+ * restarts the user's scroll at page 1. Counting these as `fallback_*` would
+ * leave those counters describing a fallback that no longer happens — the same
+ * drift as a counter whose meaning changes while its name does not.
+ *
+ * - `cursored_end` — an empty cursored page where every query succeeded. The
+ *   feed was ended honestly. Routine, and the paginated twin of `fallback_empty`.
+ * - `cursored_error` — an empty cursored page where at least one query failed,
+ *   raised to the client as a retryable 503. The paginated twin of
+ *   `fallback_error`, and the one worth alerting on.
  */
 export const BITDEX_SERVE_OUTCOMES = [
   'served',
   'fallback_empty',
   'fallback_error',
   'fallback_exception',
+  'cursored_end',
+  'cursored_error',
 ] as const;
 export type BitdexServeOutcome = (typeof BITDEX_SERVE_OUTCOMES)[number];
 

--- a/src/server/metrics/bitdex-feed-serve.metrics.ts
+++ b/src/server/metrics/bitdex-feed-serve.metrics.ts
@@ -123,11 +123,11 @@
 // not the backend team. It reads a flat zero today, which makes it a clean
 // tripwire rather than a redundant series.
 //
-// 🔴 CARDINALITY: 4 outcomes × 2 modes = 8 series, plus 6 failure reasons = 14
+// 🔴 CARDINALITY: 7 outcomes × 2 modes = 14 series, plus 6 failure reasons = 20
 // series per process, TOTAL, and the bound rests on CODE — every label value is
 // narrowed at runtime against a closed union declared once in this file, and an
 // unrecognised value is DROPPED rather than passed through or relabelled to a
-// plausible default (either would make the "14 series" claim a wish). Explicitly
+// plausible default (either would make the "20 series" claim a wish). Explicitly
 // disqualified as labels: user id, cursor, filter shape, sort, model/post ids,
 // and the raw status code — this fires once per feed request on the highest-
 // traffic path in the application, nothing caches it, and prom-client retains
@@ -167,6 +167,11 @@ import client, { type Counter, type Registry } from 'prom-client';
  * - `cursored_error` — an empty cursored page where at least one query failed,
  *   raised to the client as a retryable 503. The paginated twin of
  *   `fallback_error`, and the one worth alerting on.
+ * - `cursored_skip` — an empty cursored page where every query succeeded but the
+ *   cursor is still live: the pass budget ran out, not the index. The cursor is
+ *   handed back so the client skips forward. NOT an end of feed, and separated
+ *   from `cursored_end` because treating it as one truncates a feed that still
+ *   has content.
  */
 export const BITDEX_SERVE_OUTCOMES = [
   'served',
@@ -175,6 +180,7 @@ export const BITDEX_SERVE_OUTCOMES = [
   'fallback_exception',
   'cursored_end',
   'cursored_error',
+  'cursored_skip',
 ] as const;
 export type BitdexServeOutcome = (typeof BITDEX_SERVE_OUTCOMES)[number];
 
@@ -231,7 +237,7 @@ type MetricsBundle = {
 };
 
 /**
- * Initialise all 14 series to 0 at registration.
+ * Initialise all 20 series to 0 at registration.
  *
  * 🔴 WHY, AND WHY IT IS NOT COSMETIC. prom-client only materialises a child
  * series on its first `inc()`, so without this a process exposes NOTHING for a
@@ -248,7 +254,7 @@ type MetricsBundle = {
  * and an absent series must be distinguishable, and today for those they are
  * not.
  *
- * Free by construction: 14 series is this family's whole cardinality budget, so
+ * Free by construction: 20 series is this family's whole cardinality budget, so
  * seeding costs exactly what a fully-exercised process already costs and cannot
  * grow.
  *
@@ -297,8 +303,8 @@ export function ensureRegisterBitdexFeedServeMetrics(
       'One increment = one request, NOT one page shown to a user (shadow requests reach nobody) and NOT every request routed to the primary path: the moderator queues declined before any query is issued are deliberately outside this denominator. ' +
       'Deliberate exceptions to that denominator include: outcome=fallback_exception, which is emitted from the caller catch arms and is NOT gated on a query having been issued (it means the application threw on this path, which is worth paging on even if it threw before the first call); and a deployment with no endpoint configured, which reports a failure without a request leaving the process and so records fallback_error rather than going quiet. ' +
       'Also note a request whose FEED query returned early can still be counted, because the parallel own-content query may have gone out regardless (the condition is the skipOwnExcluded predicate in the feed service, not a property of the feed query). So this is "requests that engaged the backend", NOT "requests whose feed query went out", and must not be read as the latter. ' +
-      'outcome (served = BitDex answered and its documents were returned; fallback_empty = every query succeeded and the merged post-filtered result was still empty, so the index genuinely had nothing — not a defect; fallback_error = the result was empty AND at least one query in the request failed, so the emptiness is untrustworthy; fallback_exception = the application code itself threw while handling the response — page the app team, not the backend team). ' +
-      'mode (primary = BitDex served the user or its failure sent the request to Meilisearch; shadow = the same path ran in the background for comparison and Meilisearch served the user regardless).',
+      'outcome (served = BitDex answered and its documents were returned; fallback_empty = every query succeeded and the merged post-filtered result was still empty, so the index genuinely had nothing — not a defect; fallback_error = the result was empty AND at least one query in the request failed, so the emptiness is untrustworthy; fallback_exception = the application code itself threw while handling the response — page the app team, not the backend team; cursored_end = an empty page on a request carrying a bdx: cursor where every query succeeded, so the feed was ended rather than restarted at page 1 — routine, the paginated twin of fallback_empty; cursored_error = the same but at least one query failed, raised to the client as a retryable 503 — the paginated twin of fallback_error, and the one worth alerting on; cursored_skip = an empty page whose cursor is still live, i.e. the pass budget ran out rather than the index — the cursor is handed back and the client skips forward, so this is NOT an end of feed). ' +
+      'mode (primary = the request was served from the BitDex path — BitDex answered, or its failure sent the request to Meilisearch, or for the cursored_* outcomes the request was ended or failed WITHOUT reaching Meilisearch; shadow = the same path ran in the background for comparison and Meilisearch served the user regardless. The cursored_* outcomes never occur in shadow: they are gated on serving).',
     ['outcome', 'mode']
   );
 

--- a/src/server/services/__tests__/bitdex-empty-fallback.test.ts
+++ b/src/server/services/__tests__/bitdex-empty-fallback.test.ts
@@ -245,22 +245,108 @@ describe('BitDex primary — empty result falls back to Meilisearch for every ca
     expect(result.data).toEqual([]);
   });
 
-  // INVARIANT GUARD + the paginated decision: a subsequent page never issues the
-  // own-excluded pass, so an empty page already returned the fallback signal
-  // before this change and still does. Pinned so the decision is explicit.
-  it('authenticated + paginated (bdx cursor) + zero documents → falls back to Meili, no own-excluded pass', async () => {
+  // THE PAGINATED DECISION, REVERSED ON PURPOSE 2026-08-24 — read this before
+  // "fixing" it back.
+  //
+  // This arm used to assert `source === 'meili'`, pinned by @ZacxDev on
+  // 2026-08-14 (777845bab2) with the note "pinned so the decision is explicit".
+  // That pin did its job: it is why this change is deliberate rather than
+  // accidental. The decision was revisited by Justin on 2026-08-24 and changed,
+  // and @ZacxDev was told before the diff landed.
+  //
+  // Why it changed: falling back handed the Meili path a `bdx:` cursor it cannot
+  // parse. `getAllImagesIndex` splits cursors on `offset|entryTimestamp` behind
+  // two `isNumber` guards, so a `bdx:` cursor degrades `offset` to 0 AND drops
+  // the `entry` pin — the user's infinite scroll silently restarts at the top of
+  // a feed reshuffled by anything published since. Falling back was never
+  // landing them on "the same Meili page"; it was landing them on page 1.
+  it('authenticated + paginated (bdx cursor) + zero documents, nothing failed → ends the feed', async () => {
     serve({ main: EMPTY_PAGE, ownExcluded: page([ownPrivateDoc]) });
 
     const result = await getImagesFromSearch(
       authedInput({ cursor: 'bdx:{"sortAt":1700000000,"id":101}' })
     );
 
-    expect(result.source).toBe('meili');
+    // NOT 'meili'. Retrying cannot produce different content when nothing failed,
+    // so the honest answer is that the feed is over.
+    expect(result.source).toBe('bitdex');
     expect(result.data).toEqual([]);
+    expect(result.nextCursor).toBeUndefined();
     // The own-excluded pass is first-page-only; proving it never ran is what
     // makes "the paginated arm is unchanged" a claim about the code and not
     // about the fake.
     expect(queryBitdexMock.mock.calls.filter((c) => isOwnExcludedQuery(c[1]))).toHaveLength(0);
+  });
+
+  // The other half of the split. An empty page whose query FAILED is not an empty
+  // feed — nobody knows what was in the index — so it must not be reported as the
+  // end of the feed, and must not fall back to Meili either.
+  it('authenticated + paginated (bdx cursor) + a FAILED query → throws SERVICE_UNAVAILABLE', async () => {
+    queryBitdexMock.mockImplementation(
+      async (
+        _index: string,
+        _filters: unknown,
+        _sort?: unknown,
+        _limit?: number,
+        _cursor?: unknown,
+        _offset?: number,
+        _includeDocs?: unknown,
+        onFailure?: (reason: string) => void
+      ) => {
+        onFailure?.('http_error');
+        return null;
+      }
+    );
+
+    await expect(
+      getImagesFromSearch(authedInput({ cursor: 'bdx:{"sortAt":1700000000,"id":101}' }))
+    ).rejects.toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
+  });
+
+  // A MALFORMED `bdx:` cursor must be treated as cursored too. The decision turns
+  // on what the caller sent, not on whether we could parse it: an unparseable
+  // `bdx:` cursor is still meaningless to Meili, so routing it there degrades
+  // offset to 0 exactly as a well-formed one would. Gating on the parsed value
+  // instead of the prefix reopens the bug for this input, and nothing else in
+  // this file would notice.
+  it('authenticated + UNPARSEABLE bdx cursor + zero documents → ends the feed, does not fall back', async () => {
+    // Both passes empty on purpose. An unparseable cursor still leaves
+    // `skipOwnExcluded` false (that decision reads the PARSED cursor), so seeding
+    // the own-excluded pass here would serve page-1 content and this test would
+    // be asserting that behaviour rather than the fallback decision.
+    serve({});
+
+    const result = await getImagesFromSearch(authedInput({ cursor: 'bdx:{not valid json' }));
+
+    expect(result.source).toBe('bitdex');
+    expect(result.data).toEqual([]);
+    expect(result.nextCursor).toBeUndefined();
+  });
+
+  // SCOPE CONTROL for both tests above. The same failure on a FIRST page still
+  // falls back to Meili. Without this, the two tests would pass equally well if
+  // the change had made every empty BitDex page throw, which would take the
+  // whole feed down whenever BitDex was briefly unhealthy.
+  it('authenticated + FIRST page + a FAILED query → still falls back to Meili', async () => {
+    queryBitdexMock.mockImplementation(
+      async (
+        _index: string,
+        _filters: unknown,
+        _sort?: unknown,
+        _limit?: number,
+        _cursor?: unknown,
+        _offset?: number,
+        _includeDocs?: unknown,
+        onFailure?: (reason: string) => void
+      ) => {
+        onFailure?.('http_error');
+        return null;
+      }
+    );
+
+    const result = await getImagesFromSearch(authedInput());
+
+    expect(result.source).toBe('meili');
   });
 });
 

--- a/src/server/services/__tests__/bitdex-empty-fallback.test.ts
+++ b/src/server/services/__tests__/bitdex-empty-fallback.test.ts
@@ -300,7 +300,13 @@ describe('BitDex primary — empty result falls back to Meilisearch for every ca
 
     await expect(
       getImagesFromSearch(authedInput({ cursor: 'bdx:{"sortAt":1700000000,"id":101}' }))
-    ).rejects.toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
+    ).rejects.toMatchObject({
+      code: 'SERVICE_UNAVAILABLE',
+      // The message, not just the code: image.service.ts throws SERVICE_UNAVAILABLE
+      // from five sites and the other four all say "overloaded". Matching the code
+      // alone would let this pass on somebody else's throw.
+      message: 'Image feed is temporarily unavailable — please retry.',
+    });
   });
 
   // A MALFORMED `bdx:` cursor must be treated as cursored too. The decision turns
@@ -323,11 +329,82 @@ describe('BitDex primary — empty result falls back to Meilisearch for every ca
     expect(result.nextCursor).toBeUndefined();
   });
 
-  // SCOPE CONTROL for both tests above. The same failure on a FIRST page still
-  // falls back to Meili. Without this, the two tests would pass equally well if
-  // the change had made every empty BitDex page throw, which would take the
-  // whole feed down whenever BitDex was briefly unhealthy.
+  // 🔴 TRUNCATION GUARD. An empty page whose cursor is STILL LIVE means the pass
+  // budget ran out, not the index — `fetchBitdexPrimary`'s loop is bounded by
+  // MAX_PASSES as well as by `!result.cursor`, and an ordinary filter can empty
+  // every page it sees while more content sits behind the cursor. Ending the feed
+  // there truncates it permanently, which is strictly worse than the page-1
+  // restart this whole change exists to fix. Do not "simplify" the `liveCursor`
+  // branch away: nothing else here would notice, and the metric would label the
+  // truncated feed `cursored_end`, i.e. healthy.
+  it('authenticated + paginated (bdx cursor) + empty page but a LIVE cursor → hands the cursor back, does not end the feed', async () => {
+    // Every query succeeds and returns a FULL page with a cursor, but every
+    // document belongs to another user and is Private, so postFilterBitdexDocs
+    // removes all of them. The loop therefore exhausts MAX_PASSES with
+    // `lastCursor` still live and `accumulated` empty.
+    //
+    // A page with ZERO documents would NOT reproduce this: the loop breaks on
+    // `!result?.documents?.length` BEFORE assigning lastCursor, so that fake
+    // tests a different path and this guard would pass for the wrong reason.
+    // `Private` on ANOTHER user's doc, deliberately: postFilterBitdexDocs drops it
+    // before `isPublicallyPublished` runs, so `publicationHolds` never moves and the
+    // emptied-page allowance is never granted — every iteration charges the pass
+    // budget. An UNPUBLISHED doc would also empty the page but would trip that
+    // allowance, reaching this branch through a 1500ms wall-clock budget instead,
+    // i.e. load-sensitive on CI. Do not swap the field.
+    const othersPrivateDoc = { ...publicDoc, id: 900, userId: 7, availability: 'Private' };
+    // Terminal after 5 pages. The service stops at MAX_PASSES (3), so the cap is
+    // never reached and the assertions are unchanged — but a fake that paged
+    // forever would turn a regression here into an unreportable hang instead of a
+    // failure, which is what `no-unbounded-paging-fake` exists to prevent.
+    let pagesServed = 0;
+    queryBitdexMock.mockImplementation(async () => {
+      pagesServed++;
+      return {
+        documents: [othersPrivateDoc],
+        cursor: pagesServed >= 5 ? undefined : { sortAt: 1699999999, id: 99 },
+      };
+    });
+
+    const result = await getImagesFromSearch(
+      authedInput({ cursor: 'bdx:{"sortAt":1700000000,"id":101}' })
+    );
+
+    expect(result.source).toBe('bitdex');
+    expect(result.data).toEqual([]);
+    // 🔴 Assert the cursor's IDENTITY, not merely that one came back. The fake's
+    // cursor (1699999999/99) is deliberately different from the input cursor
+    // (1700000000/101), so this dies to the plausible "simplification" of echoing
+    // the INPUT cursor back — which `toBeDefined()` and `toContain('bdx:')` both
+    // accept, and which ships an infinite client loop: same cursor in, empty page
+    // and the same cursor out, forever. That is worse than the truncation this
+    // branch fixes, because truncation at least terminates.
+    //
+    // It also pins that the skip path uses the SAME `bdx:${JSON.stringify(...)}`
+    // encoding as the served path, which is a second copy of that wire format.
+    expect(result.nextCursor).toBe('bdx:{"sortAt":1699999999,"id":99}');
+    // The loop stopped on its own pass budget, well short of the fake's cap.
+    expect(pagesServed).toBeLessThan(5);
+  });
+
+  // SCOPE CONTROL. The same failure on a FIRST page still falls back to Meili.
+  //
+  // The mutation this uniquely catches is HOISTING THE THROW OUT OF THE GATE:
+  //     if (anyQueryFailed) throw new BitdexCursoredPageUnavailable();
+  //     if (cursoredServe) return { data: [], nextCursor: liveCursor };
+  // That 503s the whole feed whenever BitDex is briefly unhealthy, and this is the
+  // only test in the file that dies to it. (Dropping the cursor condition instead
+  // is already caught by the three first-page fallback tests above, so do not
+  // justify this test by that mutation — it would read as redundant and get
+  // deleted.)
   it('authenticated + FIRST page + a FAILED query → still falls back to Meili', async () => {
+    // Counted, and asserted below. Asserting `source === 'meili'` alone would make
+    // this a duplicate of the ordinary-empty-page test if `onFailure` ever stopped
+    // being threaded through (an arg-order change in `queryBitdex`, or the
+    // pre-filter dropping the param): the fake's `onFailure?.()` would silently
+    // no-op, `anyQueryFailed` would stay false, and this test would keep passing
+    // while no longer exercising a failure at all.
+    let failuresSignalled = 0;
     queryBitdexMock.mockImplementation(
       async (
         _index: string,
@@ -339,6 +416,7 @@ describe('BitDex primary — empty result falls back to Meilisearch for every ca
         _includeDocs?: unknown,
         onFailure?: (reason: string) => void
       ) => {
+        failuresSignalled++;
         onFailure?.('http_error');
         return null;
       }
@@ -347,6 +425,7 @@ describe('BitDex primary — empty result falls back to Meilisearch for every ca
     const result = await getImagesFromSearch(authedInput());
 
     expect(result.source).toBe('meili');
+    expect(failuresSignalled).toBeGreaterThan(0);
   });
 });
 

--- a/src/server/services/__tests__/bitdex-feed-source.test.ts
+++ b/src/server/services/__tests__/bitdex-feed-source.test.ts
@@ -524,6 +524,113 @@ describe('bitdex_primary_result_total moves, and moves a DIFFERENT series per ou
     expect(seriesThatMoved(before, after)).toEqual([]);
   });
 
+  // 🔴 THE CURSORED SPLIT. Cursored requests stopped falling back on 2026-08-24,
+  // so counting them as `fallback_*` would leave those counters describing a
+  // fallback that no longer happens. These three assert the SPLIT, which the
+  // behaviour tests in bitdex-empty-fallback.test.ts cannot see (they never read
+  // metrics) and the metric tests cannot see either (they derive their expected
+  // series from the union and never run the service). Delete the ternary in
+  // `fetchBitdexPrimary` and, without these, everything stays green.
+  //
+  // The load-bearing half of each is the `toEqual([...])` exact match: it asserts
+  // the `fallback_*` twin did NOT also move.
+  it('🔴 PRIMARY, cursored + empty + nothing failed → cursored_end{primary} +1, NOT fallback_empty', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+    // cursor undefined → the loop breaks on "no more pages", so the index really
+    // is exhausted and this is an END, not a skip.
+    queryBitdexMock.mockResolvedValue({ documents: [], cursor: undefined });
+    const before = await readOutcomes();
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: CURRENT_USER_ID,
+      cursor: 'bdx:{"sortAt":1700000000,"id":101}',
+    });
+
+    const after = await readOutcomes();
+    expect(result.source).toBe('bitdex');
+    expect(seriesThatMoved(before, after)).toEqual([key('cursored_end', 'primary')]);
+  });
+
+  it('🔴 PRIMARY, cursored + empty but a LIVE cursor → cursored_skip{primary} +1, NOT cursored_end', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+    // A full page whose documents the post-filter drops, with the cursor still
+    // live: the pass budget runs out, not the index. Recording this as
+    // `cursored_end` would label a feed that did NOT end as one that did — the
+    // truncation this outcome exists to keep visible.
+    // Terminal after 5 pages: the service stops at MAX_PASSES (3) so the cap is
+    // never reached, but a fake that paged forever would turn a regression into a
+    // hang rather than a failure.
+    let pagesServed = 0;
+    queryBitdexMock.mockImplementation(async () => {
+      pagesServed++;
+      return {
+        documents: [{ ...bitdexDoc, id: 900, userId: 7, availability: 'Private' }],
+        cursor: pagesServed >= 5 ? undefined : { sortAt: 1699999999, id: 99 },
+      };
+    });
+    const before = await readOutcomes();
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: CURRENT_USER_ID,
+      cursor: 'bdx:{"sortAt":1700000000,"id":101}',
+    });
+
+    const after = await readOutcomes();
+    expect(result.source).toBe('bitdex');
+    expect(seriesThatMoved(before, after)).toEqual([key('cursored_skip', 'primary')]);
+    expect(pagesServed).toBeLessThan(5);
+  });
+
+  it('🔴 PRIMARY, cursored + a call FAILS → cursored_error{primary} +1, NOT fallback_error or fallback_exception', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+    queryBitdexMock.mockImplementation(async (...args: unknown[]) => {
+      const onFailure = args.find((a) => typeof a === 'function') as
+        | ((reason: string) => void)
+        | undefined;
+      onFailure?.('http_5xx');
+      return null;
+    });
+    const before = await readOutcomes();
+
+    await expect(
+      getImagesFromSearch({
+        ...baseInput,
+        currentUserId: CURRENT_USER_ID,
+        cursor: 'bdx:{"sortAt":1700000000,"id":101}',
+      })
+    ).rejects.toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
+
+    const after = await readOutcomes();
+    // `fallback_exception` must NOT appear: the sentinel is re-raised BEFORE the
+    // catch arm records it. Move that `instanceof` check below the recording and
+    // this is the assertion that goes red.
+    expect(seriesThatMoved(before, after)).toEqual([key('cursored_error', 'primary')]);
+  });
+
+  it('🔴 SHADOW, cursored + empty → fallback_empty{shadow}, NEVER a cursored_* outcome', async () => {
+    // The split is gated on `opts.serving`, which shadow does not pass. Drop that
+    // gate and an empty cursored shadow request throws into the detached catch,
+    // recording fallback_exception{shadow} — moving a documented tripwire off the
+    // flat zero that makes it useful. Nothing else in the suite sees that.
+    getFliptVariantMock.mockResolvedValue('shadow');
+    queryBitdexMock.mockResolvedValue({ documents: [], cursor: undefined });
+    const before = await readOutcomes();
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: CURRENT_USER_ID,
+      cursor: 'bdx:{"sortAt":1700000000,"id":101}',
+    });
+    expect(result.source).toBe('meili');
+
+    await vi.waitFor(async () => {
+      const after = await readOutcomes();
+      expect(seriesThatMoved(before, after)).toEqual([key('fallback_empty', 'shadow')]);
+    });
+  });
+
   it('SHADOW, BitDex answers with documents → served{mode="shadow"} +1 (Meili still serves the user)', async () => {
     getFliptVariantMock.mockResolvedValue('shadow');
     const before = await readOutcomes();

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3217,6 +3217,19 @@ function isScheduledForFuture(
  * The main query is fully cacheable (no per-user filter clauses).
  * Returns null if BitDex can't serve the request.
  */
+/**
+ * A cursored BitDex page came back empty because a query FAILED, so falling back to
+ * Meili would silently restart the user's scroll at page 1. Caught by the only
+ * caller that serves users and re-raised as a retryable 503.
+ *
+ * A dedicated class rather than a TRPCError: `fetchBitdexPrimary`'s call site
+ * swallows every throw and falls through to Meili, which is correct for the
+ * app-side map/merge/sort bugs that catch exists for. This one must survive it,
+ * and matching on TRPCError would also catch throws from deeper in the query path
+ * whose fallback behaviour is not ours to change.
+ */
+class BitdexCursoredPageUnavailable extends Error {}
+
 async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boolean } = {}) {
   // Two moderator queues BitDex cannot answer, declined so Meili does.
   //
@@ -3445,11 +3458,17 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
 
   // Decode BitDex keyset cursor from "offset|bdx:JSON" format
   let bitdexCursor: any = undefined;
+  // Tracked separately from the parsed value because the fallback decision turns
+  // on "the caller sent a bdx: cursor", not on "we understood it". A cursor that
+  // fails to parse is still meaningless to Meili, so treating it as uncursored
+  // would send it down the very path that degrades offset to 0.
+  let hasBdxCursor = false;
   if (input.cursor) {
     const raw = input.cursor.toString();
     const pipeIdx = raw.indexOf('|');
     const entryPart = pipeIdx >= 0 ? raw.slice(pipeIdx + 1) : raw;
     if (entryPart.startsWith('bdx:')) {
+      hasBdxCursor = true;
       try {
         bitdexCursor = JSON.parse(entryPart.slice(4));
       } catch {}
@@ -3923,18 +3942,46 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
     // request that never contacted BitDex is neither of these things, and
     // recording it would make this counter's denominator disagree with its own
     // help string.
+    // A cursored request that is being SERVED does not fall back (see below), so
+    // it is recorded under its own outcomes rather than inflating `fallback_*`
+    // with requests that never fell back.
+    const cursoredServe = hasBdxCursor && !!opts.serving;
     if (bitdexCallsObserved > 0)
-      recordBitdexPrimaryResult(anyQueryFailed ? 'fallback_error' : 'fallback_empty', serveMode);
+      recordBitdexPrimaryResult(
+        cursoredServe
+          ? anyQueryFailed
+            ? 'cursored_error'
+            : 'cursored_end'
+          : anyQueryFailed
+          ? 'fallback_error'
+          : 'fallback_empty',
+        serveMode
+      );
 
-    // ⚠️ A cursored request does not fall back cleanly — the Meili path parses
-    // cursors as `offset|entryTimestamp` (:2594) and a `bdx:{…}` cursor fails
-    // both `isNumber` guards, so offset degrades to 0. An earlier revision of
-    // this PR ended the feed instead, and that was wrong: the paginated fallback
-    // is a DELIBERATE, pinned decision — see the invariant guard
-    // "authenticated + paginated (bdx cursor) + zero documents → falls back to
-    // Meili" in bitdex-empty-fallback.test.ts, whose comment says it is "pinned
-    // so the decision is explicit". Reversing it belongs in a change that owns
-    // that decision, not in this one. Raised separately.
+    // A cursored request must NOT fall back to Meili. The Meili path parses
+    // cursors as `offset|entryTimestamp` (:2666) and a `bdx:{…}` cursor fails
+    // both `isNumber` guards, so `offset` degrades to 0 AND the `entry` pin is
+    // lost — the user's infinite scroll silently restarts at the top of a feed
+    // that has been reshuffled by anything published since. No error, no empty
+    // page, just the wrong content.
+    //
+    // The two empties are answered differently because only one of them is worth
+    // retrying, which is the whole reason the split above exists:
+    //   • a call FAILED  → nobody knows what was in the index. Throw, so the
+    //     client retries the same cursor and can land on the real page.
+    //   • nothing failed → the page really is empty. End the feed. Retrying
+    //     cannot produce different content, and `fallback_empty` is the bulk of
+    //     normal fallback volume, so erroring here would spin the client on the
+    //     routine case.
+    //
+    // Shadow mode is deliberately excluded: it serves nobody, and throwing there
+    // would move `fallback_exception{serve_mode="shadow"}` off the flat zero that
+    // makes it a usable tripwire for app-side throws.
+    if (cursoredServe) {
+      if (anyQueryFailed) throw new BitdexCursoredPageUnavailable();
+      return { data: [], nextCursor: undefined };
+    }
+
     return null;
   }
 
@@ -4018,6 +4065,17 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
       if (result) return { ...result, source: 'bitdex' as const };
       console.log('[BitDex] PRIMARY returned no results, falling through to Meili');
     } catch (err) {
+      // Re-raised, not swallowed: this is the one throw from `fetchBitdexPrimary`
+      // that means "do not fall through to Meili". Falling through would hand the
+      // Meili path a `bdx:` cursor it cannot parse and restart the user's scroll
+      // at page 1, which is the defect this branch exists to prevent.
+      if (err instanceof BitdexCursoredPageUnavailable) {
+        throw new TRPCError({
+          code: 'SERVICE_UNAVAILABLE',
+          message: 'Image feed is temporarily unavailable — please retry.',
+          cause: err,
+        });
+      }
       console.error('[BitDex] PRIMARY error, falling through to Meili:', err);
       recordBitdexError(err);
       // Distinct from `fallback_error`, and the distinction is the point: the

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3946,11 +3946,20 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
     // it is recorded under its own outcomes rather than inflating `fallback_*`
     // with requests that never fell back.
     const cursoredServe = hasBdxCursor && !!opts.serving;
+    // A LIVE cursor with an empty page means the pass budget ran out, NOT the
+    // index. The loop above is bounded by MAX_PASSES as well as by `!result.cursor`,
+    // and an ordinary filter can empty every page it sees (a poi-heavy slice under
+    // `disablePoi`, a private-heavy one) while more content sits behind the cursor.
+    // Ending the feed there would truncate it permanently, which is worse than the
+    // page-1 restart this branch exists to fix.
+    const liveCursor = lastCursor ? `bdx:${JSON.stringify(lastCursor)}` : undefined;
     if (bitdexCallsObserved > 0)
       recordBitdexPrimaryResult(
         cursoredServe
           ? anyQueryFailed
             ? 'cursored_error'
+            : liveCursor
+            ? 'cursored_skip'
             : 'cursored_end'
           : anyQueryFailed
           ? 'fallback_error'
@@ -3958,28 +3967,30 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
         serveMode
       );
 
-    // A cursored request must NOT fall back to Meili. The Meili path parses
-    // cursors as `offset|entryTimestamp` (:2666) and a `bdx:{…}` cursor fails
-    // both `isNumber` guards, so `offset` degrades to 0 AND the `entry` pin is
-    // lost — the user's infinite scroll silently restarts at the top of a feed
-    // that has been reshuffled by anything published since. No error, no empty
-    // page, just the wrong content.
+    // A cursored request must NOT fall back to Meili. `getAllImagesIndex` parses
+    // cursors as `offset|entryTimestamp` behind two `isNumber` guards (see its
+    // `cursorParsed`), and a `bdx:{…}` cursor fails both — so `offset` degrades
+    // to 0 AND the `entry` pin is lost, and the user's infinite scroll silently
+    // restarts at the top of a feed reshuffled by anything published since. No
+    // error, no empty page, just the wrong content.
     //
     // The two empties are answered differently because only one of them is worth
     // retrying, which is the whole reason the split above exists:
     //   • a call FAILED  → nobody knows what was in the index. Throw, so the
     //     client retries the same cursor and can land on the real page.
-    //   • nothing failed → the page really is empty. End the feed. Retrying
-    //     cannot produce different content, and `fallback_empty` is the bulk of
-    //     normal fallback volume, so erroring here would spin the client on the
-    //     routine case.
+    //   • nothing failed → no error. `fallback_empty` is the bulk of normal
+    //     fallback volume, so erroring here would spin the client on the routine
+    //     case. Whether that means END or SKIP is decided by `liveCursor` below.
     //
     // Shadow mode is deliberately excluded: it serves nobody, and throwing there
     // would move `fallback_exception{serve_mode="shadow"}` off the flat zero that
     // makes it a usable tripwire for app-side throws.
     if (cursoredServe) {
       if (anyQueryFailed) throw new BitdexCursoredPageUnavailable();
-      return { data: [], nextCursor: undefined };
+      // `liveCursor` undefined here means the loop broke on `!result.cursor` — the
+      // index really is exhausted, so the feed is over. Otherwise hand the cursor
+      // back and let the client skip forward over the emptied region.
+      return { data: [], nextCursor: liveCursor };
     }
 
     return null;


### PR DESCRIPTION
## What

A cursored BitDex request no longer falls back to Meilisearch.

`getAllImagesIndex` parses cursors as `offset|entryTimestamp` behind two `isNumber` guards. A `bdx:{…}` cursor fails both, so `offset` degrades to 0 **and** the `entry` pin is lost — the user's infinite scroll silently restarts at the top of a feed reshuffled by anything published since. No error, no empty page, just the wrong content partway down.

| case | before | after |
|---|---|---|
| cursored, a query failed | restart at page 1 | **503**, client retries the same cursor |
| cursored, clean empty, cursor dead | restart at page 1 | end the feed |
| cursored, clean empty, cursor **live** | restart at page 1 | hand the cursor back, client skips forward |
| first page, any of the above | fall back to Meili | unchanged |

Fixes `868ktb2zu`.

## ⚠️ This reverses a pinned decision

The paginated fallback was pinned by @ZacxDev on 2026-08-14 (`777845bab2`) with the note *"pinned so the decision is explicit"*. That pin did its job — it is why this change is deliberate rather than accidental. Revisited and changed by Justin on 2026-08-24, and @ZacxDev was told before this landed. The test records the new decision, who made it and why, rather than simply flipping the assertion.

The brief's third option — translate the cursor so the fallback lands on the right Meili page — was superseded: translating *is* falling back.

## Why the empty case is not an error

The two empties are answered differently because only one is worth retrying. The service's own comment records that `fallback_empty` ("every call succeeded and the index had nothing") is *routine, and the bulk of today's fallback volume*. Erroring on all of it would spin the client on the common case.

## Three defects the review caught in the first revision

All three are the same shape as the bug being fixed — silently wrong, nothing red.

1. **Feed truncation.** `data.length === 0` was read as "index exhausted", but the pass loop is bounded by `MAX_PASSES` as well as by `!result.cursor`. An ordinary filter can empty every page while content remains behind the cursor, so the first revision *permanently ended* those feeds — worse than a wrong page, because truncation does not recover. And it was recorded as `cursored_end`, i.e. healthy.
2. **A client retry storm.** `RemixGallerySubmitModal` renders `InViewLoader` off `hasNextPage`, which derives from the last *successful* page and stays true after a failure. With no `isError` branch it re-fired every ~500ms, unbounded, for as long as an outage lasted. `ImagesInfinite` was already covered by its retry banner; these are the only two surfaces on this query.
3. **Three deliberate decisions asserted by nothing** — the metric split, the shadow exclusion, and that the sentinel path does not double-record. Each was defended by a paragraph of comment and survived deletion on a fully green run.

## Metrics

Adds `cursored_end`, `cursored_error` and `cursored_skip` rather than reusing `fallback_empty` / `fallback_error`, which would leave those counters describing a fallback that no longer happens — a counter whose meaning changed while its name did not.

Shadow mode is excluded from the split: it serves nobody, and throwing there would move `fallback_exception{mode="shadow"}` off the flat zero that makes it a usable tripwire.

⚠️ **Dashboards on `fallback_empty` / `fallback_error` will see cursored volume move to the new labels.** That is the intent, but it moves a number someone may be watching.

⚠️ **For whoever owns alerting:** during a BitDex degradation these 503s land in `civitai_app_http_errors_total{status="503"}` on `image.getInfinite`, the highest-QPS tRPC route, which has never contributed to that series before. A 5xx-rate alert that has never seen this route contribute will fire.

Retry amplification is bounded: tRPC retries at most once, the loader is disarmed on error, backoff caps at 60s and stops after 10 attempts, and `heavyProcedure`'s bulkhead caps in-flight requests per pod.

## Controls

Every mutation below was applied and run, and fails **exactly** the named test and no other. A mutant that only fails to compile is not a control, so each was checked for the runner's own summary line before being counted.

| mutation | fails |
|---|---|
| remove the cursored branch | both arms + the malformed case |
| gate on the parsed cursor | the malformed case |
| caller swallows the sentinel | the 503 case |
| drop the cursor condition | first-page control + 3 pre-existing guards |
| `nextCursor` back to `undefined` | the truncation guard |
| echo the **input** cursor back | the truncation guard |
| collapse `cursored_skip` | the skip metric case |
| delete the outcome ternary | both cursored metric cases |
| drop the shadow gate | the shadow metric case |
| record exception before re-raising | the `cursored_error` metric case |

The echo mutation matters most: `toBeDefined()` and `toContain('bdx:')` both accept the client's own cursor handed straight back, which ships an infinite scroll loop — same cursor in, empty page and same cursor out. The assertion now pins the cursor's identity.

## Verification

- `pnpm run typecheck` — **0 type errors**
- `pnpm run test:lint-rules` — 17 files / 323 tests, exit 0
- `pnpm run test:unit:run` — `Test Files 1373 passed | 1 skipped`, one failure: `home-block-fetch-sizing.test.ts`, a **60s timeout** that passes 3/3 run alone and imports nothing in this diff. Contention on a shared box.
- `eslint` on the changed files — 4 errors, **3 identical on `origin/main`** (line numbers shifted by exactly the insertion count), 0 new.
- `blocks.router.workflow.test.ts` collects **358 tests**, not zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
