### PR TITLE
feat(chat): add group chats with an admin who manages members

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260821000000_chat_group_identity/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260821000000_chat_group_identity/migration.sql
@@ -1,0 +1,16 @@
+-- Group chats: identity moves from the member-set hash to the row id.
+--
+-- `Chat.hash` stays the dedupe key for 1:1 conversations, so re-opening a DM
+-- still returns the existing thread. Groups carry NULL instead — Postgres treats
+-- nulls as distinct in a unique index, so any number of groups can hold the same
+-- people, and adding or removing a member no longer rewrites a constrained value.
+
+ALTER TABLE "Chat" ADD COLUMN "isGroup" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Chat" ADD COLUMN "name" TEXT;
+ALTER TABLE "Chat" ALTER COLUMN "hash" DROP NOT NULL;
+
+-- Existing 3+ member threads become real groups and release their hash, so the
+-- first membership change on one cannot collide with another identical set.
+UPDATE "Chat" c
+SET "isGroup" = true, "hash" = NULL
+WHERE (SELECT COUNT(*) FROM "ChatMember" m WHERE m."chatId" = c."id") > 2;

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -5315,8 +5315,14 @@ model ClubMetric {
 model Chat {
   id        Int      @id @default(autoincrement())
   createdAt DateTime @default(now())
-  hash      String   @unique // hash of asc-sorted userIds
+  // Hash of asc-sorted userIds, and the dedupe key for 1:1 conversations. Null
+  // for groups: a group is identified by its row id, so two groups may hold the
+  // same people. Postgres treats nulls as distinct, so the unique index still
+  // holds for the 1:1 rows it applies to.
+  hash      String?  @unique
   ownerId   Int
+  isGroup   Boolean  @default(false)
+  name      String?
 
   owner User @relation(fields: [ownerId], references: [id])
 

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -1622,8 +1622,10 @@ export type Changelog = {
 export type Chat = {
   id: Generated<number>;
   createdAt: Generated<Timestamp>;
-  hash: string;
+  hash: string | null;
   ownerId: number;
+  isGroup: Generated<boolean>;
+  name: string | null;
 };
 export type ChatMember = {
   id: Generated<number>;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -3478,8 +3478,10 @@ export interface ClubMetric {
 export interface Chat {
   id: number;
   createdAt: Date;
-  hash: string;
+  hash: string | null;
   ownerId: number;
+  isGroup: boolean;
+  name: string | null;
   owner?: User;
   chatMembers?: ChatMember[];
   messages?: ChatMessage[];

--- a/packages/civitai-db-schema/src/schema-drift/drift-baseline.json
+++ b/packages/civitai-db-schema/src/schema-drift/drift-baseline.json
@@ -24,6 +24,72 @@
       "field": "judgingEngine"
     },
     {
+      "fingerprint": "missing-column|Chat|isGroup|Chat|isGroup",
+      "kind": "missing-column",
+      "tier": "pending",
+      "table": "Chat",
+      "columns": [
+        "isGroup"
+      ],
+      "model": "Chat",
+      "field": "isGroup"
+    },
+    {
+      "fingerprint": "missing-column|Chat|name|Chat|name",
+      "kind": "missing-column",
+      "tier": "pending",
+      "table": "Chat",
+      "columns": [
+        "name"
+      ],
+      "model": "Chat",
+      "field": "name"
+    },
+    {
+      "fingerprint": "missing-column|ChatMember|clearedAt|ChatMember|clearedAt",
+      "kind": "missing-column",
+      "tier": "pending",
+      "table": "ChatMember",
+      "columns": [
+        "clearedAt"
+      ],
+      "model": "ChatMember",
+      "field": "clearedAt"
+    },
+    {
+      "fingerprint": "missing-column|ChatMember|filteredAt|ChatMember|filteredAt",
+      "kind": "missing-column",
+      "tier": "pending",
+      "table": "ChatMember",
+      "columns": [
+        "filteredAt"
+      ],
+      "model": "ChatMember",
+      "field": "filteredAt"
+    },
+    {
+      "fingerprint": "missing-column|ChatMember|pinnedAt|ChatMember|pinnedAt",
+      "kind": "missing-column",
+      "tier": "pending",
+      "table": "ChatMember",
+      "columns": [
+        "pinnedAt"
+      ],
+      "model": "ChatMember",
+      "field": "pinnedAt"
+    },
+    {
+      "fingerprint": "missing-column|ChatMessage|deletedAt|ChatMessage|deletedAt",
+      "kind": "missing-column",
+      "tier": "pending",
+      "table": "ChatMessage",
+      "columns": [
+        "deletedAt"
+      ],
+      "model": "ChatMessage",
+      "field": "deletedAt"
+    },
+    {
       "fingerprint": "missing-column|ModelFlag|sfwOnly|ModelFlag|sfwOnly",
       "kind": "missing-column",
       "tier": "pending",
@@ -550,6 +616,17 @@
       ],
       "model": "ChallengeEvent",
       "field": "createdById"
+    },
+    {
+      "fingerprint": "nullability|Chat|hash|Chat|hash|optional",
+      "kind": "nullability",
+      "tier": "enforced",
+      "table": "Chat",
+      "columns": [
+        "hash"
+      ],
+      "model": "Chat",
+      "field": "hash"
     },
     {
       "fingerprint": "nullability|CollectionMetric|updatedAt|CollectionMetric|updatedAt|required",

--- a/src/components/Chat/ChatActions.tsx
+++ b/src/components/Chat/ChatActions.tsx
@@ -13,10 +13,14 @@ import {
   IconPinnedOff,
   IconSettings,
   IconTrash,
+  IconPencil,
+  IconUserPlus,
   IconX,
 } from '@tabler/icons-react';
 import produce from 'immer';
-import React from 'react';
+import React, { useState } from 'react';
+import { ChatAddMembersModal } from '~/components/Chat/ChatAddMembersModal';
+import { ChatRenameModal } from '~/components/Chat/ChatRenameModal';
 import { useChatStore } from '~/components/Chat/ChatProvider';
 import { openReportModal } from '~/components/Dialog/triggers/report';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -30,13 +34,18 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
 export const ChatActions = ({ chatObj }: { chatObj?: ChatListMessage }) => {
   const currentUser = useCurrentUser();
   const queryUtils = trpc.useUtils();
+  const [addingMembers, setAddingMembers] = useState(false);
+  const [renaming, setRenaming] = useState(false);
 
   const myMember = chatObj?.chatMembers.find((cm) => cm.userId === currentUser?.id);
   const modSender = chatObj?.chatMembers.find(
     (cm) => cm.userId !== currentUser?.id && cm.isOwner === true && cm.user.isModerator === true
   );
   const cantLeave = modSender?.status === ChatMemberStatus.Joined && !myMember?.user.isModerator;
-  const isGroup = (chatObj?.chatMembers.length ?? 0) > 2;
+  // `chatMembers.length` is the fallback for threads that predate `Chat.isGroup`
+  // and have not been backfilled.
+  const isGroup = !!chatObj?.isGroup || (chatObj?.chatMembers.length ?? 0) > 2;
+  const isAdmin = isGroup && !!currentUser && chatObj?.ownerId === currentUser.id;
   const isMuted = myMember?.notifyLevel === ChatNotifyLevel.None;
   const isPinned = !!myMember?.pinnedAt;
 
@@ -166,6 +175,21 @@ export const ChatActions = ({ chatObj }: { chatObj?: ChatListMessage }) => {
             </LegacyActionIcon>
           </Menu.Target>
           <Menu.Dropdown>
+            {isJoined && isAdmin && (
+              <>
+                <Menu.Label>Admin actions</Menu.Label>
+                <Menu.Item
+                  leftSection={<IconUserPlus size={18} />}
+                  onClick={() => setAddingMembers(true)}
+                >
+                  Add members
+                </Menu.Item>
+                <Menu.Item leftSection={<IconPencil size={18} />} onClick={() => setRenaming(true)}>
+                  Rename group
+                </Menu.Item>
+                <Menu.Divider />
+              </>
+            )}
             {isJoined && (
               <>
                 <Menu.Item
@@ -249,6 +273,16 @@ export const ChatActions = ({ chatObj }: { chatObj?: ChatListMessage }) => {
       <LegacyActionIcon onClick={() => useChatStore.setState({ open: false })}>
         <IconX />
       </LegacyActionIcon>
+      {!!chatObj && (
+        <>
+          <ChatAddMembersModal
+            chatObj={chatObj}
+            opened={addingMembers}
+            onClose={() => setAddingMembers(false)}
+          />
+          <ChatRenameModal chatObj={chatObj} opened={renaming} onClose={() => setRenaming(false)} />
+        </>
+      )}
     </Group>
   );
 };

--- a/src/components/Chat/ChatActionsV1.tsx
+++ b/src/components/Chat/ChatActionsV1.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Group, Menu, Text, Tooltip } from '@mantine/core';
+import { Group, Menu, Text, Tooltip } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
 import { ChatMemberStatus } from '~/shared/utils/prisma/enums';
 import {
@@ -8,10 +8,14 @@ import {
   IconDoorExit,
   IconFlag,
   IconSettings,
+  IconPencil,
+  IconUserPlus,
   IconX,
 } from '@tabler/icons-react';
 import produce from 'immer';
-import React from 'react';
+import React, { useState } from 'react';
+import { ChatAddMembersModal } from '~/components/Chat/ChatAddMembersModal';
+import { ChatRenameModal } from '~/components/Chat/ChatRenameModal';
 import { useChatStore } from '~/components/Chat/ChatProvider';
 import { openReportModal } from '~/components/Dialog/triggers/report';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -25,13 +29,18 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
 export const ChatActionsV1 = ({ chatObj }: { chatObj?: ChatListMessage }) => {
   const currentUser = useCurrentUser();
   const queryUtils = trpc.useUtils();
+  const [addingMembers, setAddingMembers] = useState(false);
+  const [renaming, setRenaming] = useState(false);
 
-  // const isOwner = myMember?.isOwner === true;
   const myMember = chatObj?.chatMembers.find((cm) => cm.userId === currentUser?.id);
   const modSender = chatObj?.chatMembers.find(
     (cm) => cm.userId !== currentUser?.id && cm.isOwner === true && cm.user.isModerator === true
   );
   const cantLeave = modSender?.status === ChatMemberStatus.Joined && !myMember?.user.isModerator;
+  // `chatMembers.length` is the fallback for threads that predate `Chat.isGroup`
+  // and have not been backfilled.
+  const isGroup = !!chatObj?.isGroup || (chatObj?.chatMembers.length ?? 0) > 2;
+  const isAdmin = isGroup && !!currentUser && chatObj?.ownerId === currentUser.id;
 
   const { mutate: modifyMembership } = trpc.chat.modifyUser.useMutation({
     onSuccess(data, req) {
@@ -123,11 +132,24 @@ export const ChatActionsV1 = ({ chatObj }: { chatObj?: ChatListMessage }) => {
           </Menu.Target>
           <Menu.Dropdown>
             <>
-              {/*<Menu.Label>Owner Actions</Menu.Label>*/}
-              {/*TODO enable these*/}
-              {/*{isOwner && <Menu.Item leftSection={<IconUserPlus size={18} />}>Add users</Menu.Item>}*/}
-              {/*{isOwner && <Menu.Item leftSection={<IconUserX size={18} />}>Ban users</Menu.Item>}*/}
-              {/*<Menu.Label>Chat Actions</Menu.Label>*/}
+              {isAdmin && myMember?.status === ChatMemberStatus.Joined && (
+                <>
+                  <Menu.Label>Admin Actions</Menu.Label>
+                  <Menu.Item
+                    leftSection={<IconUserPlus size={18} />}
+                    onClick={() => setAddingMembers(true)}
+                  >
+                    Add users
+                  </Menu.Item>
+                  <Menu.Item
+                    leftSection={<IconPencil size={18} />}
+                    onClick={() => setRenaming(true)}
+                  >
+                    Rename group
+                  </Menu.Item>
+                  <Menu.Label>Chat Actions</Menu.Label>
+                </>
+              )}
               {myMember?.status === ChatMemberStatus.Joined && (
                 <Menu.Item
                   leftSection={
@@ -177,6 +199,16 @@ export const ChatActionsV1 = ({ chatObj }: { chatObj?: ChatListMessage }) => {
       <LegacyActionIcon onClick={() => useChatStore.setState({ open: false })}>
         <IconX />
       </LegacyActionIcon>
+      {!!chatObj && (
+        <>
+          <ChatAddMembersModal
+            chatObj={chatObj}
+            opened={addingMembers}
+            onClose={() => setAddingMembers(false)}
+          />
+          <ChatRenameModal chatObj={chatObj} opened={renaming} onClose={() => setRenaming(false)} />
+        </>
+      )}
     </Group>
   );
 };

--- a/src/components/Chat/ChatAddMembersModal.tsx
+++ b/src/components/Chat/ChatAddMembersModal.tsx
@@ -1,0 +1,123 @@
+import { Button, Group, Modal, Stack, Text } from '@mantine/core';
+import { IconX } from '@tabler/icons-react';
+import { useState } from 'react';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { QuickSearchDropdown } from '~/components/Search/QuickSearchDropdown';
+import type { SearchIndexDataMap } from '~/components/Search/search.utils2';
+import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
+import { MAX_CHAT_MEMBERS } from '~/shared/utils/chat';
+import { ChatMemberStatus } from '~/shared/utils/prisma/enums';
+import type { ChatListMessage } from '~/types/router';
+import { showErrorNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+type PickedUser = SearchIndexDataMap['users'][number];
+
+const openStatuses: ChatMemberStatus[] = [ChatMemberStatus.Invited, ChatMemberStatus.Joined];
+
+export function ChatAddMembersModal({
+  chatObj,
+  opened,
+  onClose,
+}: {
+  chatObj: ChatListMessage;
+  opened: boolean;
+  onClose: () => void;
+}) {
+  const [selected, setSelected] = useState<PickedUser[]>([]);
+  const queryUtils = trpc.useUtils();
+
+  const currentMembers = chatObj.chatMembers.filter((cm) => openStatuses.includes(cm.status));
+  const seatsLeft = MAX_CHAT_MEMBERS - currentMembers.length;
+
+  const close = () => {
+    setSelected([]);
+    onClose();
+  };
+
+  const { mutate, isPending } = trpc.chat.addUser.useMutation({
+    onSuccess(data) {
+      queryUtils.chat.getAllByUser.setData(undefined, (old) =>
+        old?.map((c) => (c.id === data.id ? { ...c, chatMembers: data.chatMembers } : c))
+      );
+      close();
+    },
+    onError(error) {
+      showErrorNotification({
+        title: 'Failed to add members.',
+        error: new Error(error.message),
+        autoClose: false,
+      });
+    },
+  });
+
+  const handleAdd = () => {
+    if (!selected.length) return;
+    mutate({ chatId: chatObj.id, userIds: selected.map((u) => u.id) });
+  };
+
+  const excluded = [...currentMembers.map((cm) => ({ id: cm.userId })), ...selected];
+
+  return (
+    <Modal opened={opened} onClose={close} title="Add members" centered>
+      <Stack>
+        {seatsLeft <= 0 ? (
+          <Text size="sm">{`This group is full (${MAX_CHAT_MEMBERS} members).`}</Text>
+        ) : (
+          <>
+            <QuickSearchDropdown
+              disableInitialSearch
+              supportedIndexes={['users']}
+              onItemSelected={(_entity, item) => {
+                if (selected.length >= seatsLeft) {
+                  showErrorNotification({
+                    title: 'Maximum members reached',
+                    error: {
+                      message: `You can add ${seatsLeft} more ${
+                        seatsLeft === 1 ? 'member' : 'members'
+                      }`,
+                    },
+                    autoClose: false,
+                  });
+                  return;
+                }
+                setSelected((prev) => [...prev, item as PickedUser]);
+              }}
+              dropdownItemLimit={25}
+              showIndexSelect={false}
+              startingIndex="users"
+              placeholder="Select users"
+              filters={excluded
+                .map((x) => `AND NOT id=${x.id}`)
+                .join(' ')
+                .slice(4)}
+            />
+            {selected.length > 0 && (
+              <Group>
+                {selected.map((u) => (
+                  <Group key={u.id} gap="xs">
+                    <UserAvatar user={u} size="md" withUsername />
+                    <LegacyActionIcon
+                      title="Remove user"
+                      onClick={() => setSelected((prev) => prev.filter((su) => su.id !== u.id))}
+                    >
+                      <IconX />
+                    </LegacyActionIcon>
+                  </Group>
+                ))}
+              </Group>
+            )}
+          </>
+        )}
+        <Group justify="flex-end">
+          <Button variant="light" color="gray" onClick={close}>
+            Cancel
+          </Button>
+          <Button disabled={isPending || !selected.length} onClick={handleAdd}>
+            Add
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -175,6 +175,7 @@ export function ChatList() {
       searchInput.length > 0
         ? tabData.filter((d) => {
             if (
+              d.name?.toLowerCase().includes(searchInput) ||
               d.chatMembers
                 .filter((cm) => cm.userId !== currentUser?.id)
                 .some((cm) => cm.user.username?.toLowerCase().includes(searchInput))
@@ -369,7 +370,7 @@ export function ChatList() {
                           c={hasMod ? 'red' : undefined}
                           highlight={searchInput}
                         >
-                          {otherMembers.map((cm) => cm.user.username).join(', ')}
+                          {d.name ?? otherMembers.map((cm) => cm.user.username).join(', ')}
                         </Highlight>
                         {!!myMember?.pinnedAt && (
                           <IconPin size={12} style={{ flex: 'none', opacity: 0.6 }} />

--- a/src/components/Chat/ChatListV1.tsx
+++ b/src/components/Chat/ChatListV1.tsx
@@ -1,6 +1,5 @@
 import type { GroupProps } from '@mantine/core';
 import {
-  ActionIcon,
   Badge,
   Box,
   Button,
@@ -208,6 +207,7 @@ export function ChatListV1() {
       searchInput.length > 0
         ? tabData.filter((d) => {
             if (
+              d.name?.toLowerCase().includes(searchInput) ||
               d.chatMembers
                 .filter((cm) => cm.userId !== currentUser?.id)
                 .some((cm) => cm.user.username?.toLowerCase().includes(searchInput))
@@ -418,7 +418,7 @@ export function ChatListV1() {
                         c={hasMod ? 'red' : undefined}
                         highlight={searchInput}
                       >
-                        {otherMembers.map((cm) => cm.user.username).join(', ')}
+                        {d.name ?? otherMembers.map((cm) => cm.user.username).join(', ')}
                       </Highlight>
                       {/* TODO this is kind of a hack, we should be returning only valid latest message */}
                       {!!d.messages[0]?.content && myMember?.status === ChatMemberStatus.Joined && (

--- a/src/components/Chat/ChatMemberMenu.tsx
+++ b/src/components/Chat/ChatMemberMenu.tsx
@@ -1,0 +1,97 @@
+import { Menu, Text } from '@mantine/core';
+import { openConfirmModal } from '@mantine/modals';
+import { IconCrown, IconDotsVertical, IconUserX } from '@tabler/icons-react';
+import produce from 'immer';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { ChatMemberStatus } from '~/shared/utils/prisma/enums';
+import type { ChatListMessage } from '~/types/router';
+import { showErrorNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * Admin-only actions on one other member of a group. Rendered beside the member
+ * chip rather than on it, so the avatar keeps its profile link.
+ */
+export function ChatMemberMenu({
+  chatObj,
+  member,
+}: {
+  chatObj: ChatListMessage;
+  member: ChatListMessage['chatMembers'][number];
+}) {
+  const queryUtils = trpc.useUtils();
+
+  const { mutate, isPending } = trpc.chat.modifyUser.useMutation({
+    onSuccess(data, req) {
+      queryUtils.chat.getAllByUser.setData(
+        undefined,
+        produce((old) => {
+          const tChat = old?.find((c) => c.id === chatObj.id);
+          if (!tChat) return old;
+
+          if (req.isOwner) {
+            for (const cm of tChat.chatMembers) cm.isOwner = cm.id === req.chatMemberId;
+            tChat.ownerId = data.userId;
+          } else {
+            const tMember = tChat.chatMembers.find((cm) => cm.id === req.chatMemberId);
+            if (tMember) tMember.status = data.status;
+          }
+        })
+      );
+    },
+    onError(error) {
+      showErrorNotification({
+        title: 'Failed to update member.',
+        error: new Error(error.message),
+        autoClose: false,
+      });
+    },
+  });
+
+  const promoteModal = () =>
+    openConfirmModal({
+      title: `Make ${member.user.username} the group admin?`,
+      children: (
+        <Text size="sm">
+          They will be able to add and remove members. You will no longer be the admin.
+        </Text>
+      ),
+      centered: true,
+      labels: { confirm: 'Make admin', cancel: 'Cancel' },
+      onConfirm: () => mutate({ chatMemberId: member.id, isOwner: true }),
+    });
+
+  const removeModal = () =>
+    openConfirmModal({
+      title: `Remove ${member.user.username} from this group?`,
+      children: <Text size="sm">They will no longer be able to post in this conversation.</Text>,
+      centered: true,
+      labels: { confirm: 'Remove', cancel: 'Cancel' },
+      confirmProps: { color: 'red' },
+      onConfirm: () => mutate({ chatMemberId: member.id, status: ChatMemberStatus.Kicked }),
+    });
+
+  return (
+    <Menu withArrow position="bottom-end" withinPortal>
+      <Menu.Target>
+        <LegacyActionIcon
+          size="sm"
+          disabled={isPending}
+          aria-label={`Member options for ${member.user.username}`}
+        >
+          <IconDotsVertical size={16} />
+        </LegacyActionIcon>
+      </Menu.Target>
+      <Menu.Dropdown>
+        {member.status === ChatMemberStatus.Joined && (
+          <Menu.Item leftSection={<IconCrown size={18} />} onClick={promoteModal}>
+            Make admin
+          </Menu.Item>
+        )}
+        <Menu.Item leftSection={<IconUserX size={18} />} color="red" onClick={removeModal}>
+          Remove from group
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/src/components/Chat/ChatRenameModal.tsx
+++ b/src/components/Chat/ChatRenameModal.tsx
@@ -1,0 +1,67 @@
+import { Button, Group, Modal, Stack, TextInput } from '@mantine/core';
+import { useEffect, useState } from 'react';
+import { MAX_CHAT_NAME_LENGTH } from '~/server/schema/chat.schema';
+import type { ChatListMessage } from '~/types/router';
+import { showErrorNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+export function ChatRenameModal({
+  chatObj,
+  opened,
+  onClose,
+}: {
+  chatObj: ChatListMessage;
+  opened: boolean;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState(chatObj.name ?? '');
+  const queryUtils = trpc.useUtils();
+
+  // Reopening after someone else renamed the group should show their name, not
+  // the one this component first mounted with.
+  useEffect(() => {
+    if (opened) setName(chatObj.name ?? '');
+  }, [opened, chatObj.name]);
+
+  const { mutate, isPending } = trpc.chat.updateChat.useMutation({
+    onSuccess(data) {
+      queryUtils.chat.getAllByUser.setData(undefined, (old) =>
+        old?.map((c) => (c.id === data.id ? { ...c, name: data.name } : c))
+      );
+      onClose();
+    },
+    onError(error) {
+      showErrorNotification({
+        title: 'Failed to rename group.',
+        error: new Error(error.message),
+        autoClose: false,
+      });
+    },
+  });
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="Rename group" centered>
+      <Stack>
+        <TextInput
+          label="Group name"
+          placeholder="Leave blank to use the member list"
+          value={name}
+          maxLength={MAX_CHAT_NAME_LENGTH}
+          onChange={(e) => setName(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !isPending) mutate({ chatId: chatObj.id, name });
+          }}
+          data-autofocus
+        />
+        <Group justify="flex-end">
+          <Button variant="light" color="gray" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button disabled={isPending} onClick={() => mutate({ chatId: chatObj.id, name })}>
+            Save
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/components/Chat/ChatSettings.tsx
+++ b/src/components/Chat/ChatSettings.tsx
@@ -103,9 +103,10 @@ export function ChatSettings() {
   const myMember = chat?.chatMembers.find((cm) => cm.userId === currentUser?.id);
   const otherMembers = chat?.chatMembers.filter((cm) => cm.userId !== currentUser?.id) ?? [];
   const conversationName =
-    otherMembers.length === 1
+    chat?.name ??
+    (otherMembers.length === 1
       ? otherMembers[0]?.user.username ?? 'This conversation'
-      : 'This group';
+      : 'This group');
 
   // The conversation scope has nothing to hang off once the chat closes.
   const scope = myMember ? settingsScope : 'global';

--- a/src/components/Chat/ChatSignals.ts
+++ b/src/components/Chat/ChatSignals.ts
@@ -110,7 +110,7 @@ export const useChatNewMessageSignal = () => {
         play();
       }
     },
-    [queryUtils, play, currentUser, currentUser?.id, features.chat]
+    [queryUtils, play, currentUser, features.chat]
   );
 
   useSignalConnection(SignalMessages.ChatNewMessage, onUpdate);
@@ -182,6 +182,30 @@ export const useChatMessageUpdatedSignal = () => {
   );
 
   useSignalConnection(SignalMessages.ChatMessageUpdated, onUpdate);
+};
+
+/**
+ * A rename lands on everyone else's list, which otherwise keeps showing the old
+ * title until something else refetches it.
+ */
+export const useChatRoomUpdatedSignal = () => {
+  const queryUtils = trpc.useUtils();
+
+  const onUpdate = useCallback(
+    ({ id, name }: { id: number; name: string | null }) => {
+      queryUtils.chat.getAllByUser.setData(
+        undefined,
+        produce((old) => {
+          const thisChat = old?.find((c) => c.id === id);
+          if (!thisChat) return old;
+          thisChat.name = name;
+        })
+      );
+    },
+    [queryUtils]
+  );
+
+  useSignalConnection(SignalMessages.ChatRoomUpdated, onUpdate);
 };
 
 export const useChatNewRoomSignal = () => {

--- a/src/components/Chat/ExistingChat.tsx
+++ b/src/components/Chat/ExistingChat.tsx
@@ -59,6 +59,8 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { constants } from '~/server/common/constants';
 import { SignalMessages } from '~/server/common/enums';
 import type { isTypingOutput } from '~/server/schema/chat.schema';
+import { ChatMemberMenu } from '~/components/Chat/ChatMemberMenu';
+import { activeMemberStatuses } from '~/shared/utils/chat';
 import { ChatMemberStatus, ChatMessageType } from '~/shared/utils/prisma/enums';
 import type { ChatAllMessages } from '~/types/router';
 import { formatDate } from '~/utils/date-helpers';
@@ -191,6 +193,12 @@ export function ExistingChat() {
     () => thisChat?.chatMembers.filter((cm) => cm.userId !== currentUser?.id),
     [thisChat, currentUser]
   );
+  // `chatMembers.length` is the fallback for threads that predate `Chat.isGroup`
+  // and have not been backfilled.
+  const isGroupAdmin =
+    (!!thisChat?.isGroup || (thisChat?.chatMembers.length ?? 0) > 2) &&
+    !!currentUser &&
+    thisChat?.ownerId === currentUser.id;
   // const lastViewed = myMember?.lastViewedMessageId;
   const modSender = useMemo(
     () => thisChat?.chatMembers.find((cm) => cm.isOwner === true && cm.user.isModerator === true),
@@ -448,49 +456,54 @@ export function ExistingChat() {
               {/* TODO online status (later), blocked users, etc */}
 
               {otherMembers?.map((cm) => (
-                <Button key={cm.userId} variant="light" color="gray" size="compact-sm">
-                  <UserAvatar
-                    user={cm.user}
-                    size="xs"
-                    withUsername
-                    linkToProfile
-                    badge={
-                      <Group gap={6} ml={4} align="center">
-                        {cm.user.isModerator ? (
-                          <Image
-                            src="/images/civ-c.png"
-                            title="Moderator"
-                            alt="Moderator"
-                            className="size-4"
-                          />
-                        ) : undefined}
-                        {cm.isOwner === true ? (
-                          <Box title="Creator" display="flex">
-                            <IconCrown size={16} fill="currentColor" />
+                <Group key={cm.userId} gap={2} wrap="nowrap">
+                  <Button variant="light" color="gray" size="compact-sm">
+                    <UserAvatar
+                      user={cm.user}
+                      size="xs"
+                      withUsername
+                      linkToProfile
+                      badge={
+                        <Group gap={6} ml={4} align="center">
+                          {cm.user.isModerator ? (
+                            <Image
+                              src="/images/civ-c.png"
+                              title="Moderator"
+                              alt="Moderator"
+                              className="size-4"
+                            />
+                          ) : undefined}
+                          {cm.isOwner === true ? (
+                            <Box title="Creator" display="flex">
+                              <IconCrown size={16} fill="currentColor" />
+                            </Box>
+                          ) : undefined}
+                          <Box
+                            title={
+                              cm.status === ChatMemberStatus.Invited ||
+                              cm.status === ChatMemberStatus.Ignored
+                                ? 'Invited'
+                                : cm.status
+                            }
+                            display="flex"
+                          >
+                            {cm.status === ChatMemberStatus.Joined ? (
+                              <IconCircleCheck size={16} color="green" />
+                            ) : cm.status === ChatMemberStatus.Left ||
+                              cm.status === ChatMemberStatus.Kicked ? (
+                              <IconCircleX size={16} color="orangered" />
+                            ) : (
+                              <IconCircleMinus size={16} />
+                            )}
                           </Box>
-                        ) : undefined}
-                        <Box
-                          title={
-                            cm.status === ChatMemberStatus.Invited ||
-                            cm.status === ChatMemberStatus.Ignored
-                              ? 'Invited'
-                              : cm.status
-                          }
-                          display="flex"
-                        >
-                          {cm.status === ChatMemberStatus.Joined ? (
-                            <IconCircleCheck size={16} color="green" />
-                          ) : cm.status === ChatMemberStatus.Left ||
-                            cm.status === ChatMemberStatus.Kicked ? (
-                            <IconCircleX size={16} color="orangered" />
-                          ) : (
-                            <IconCircleMinus size={16} />
-                          )}
-                        </Box>
-                      </Group>
-                    }
-                  />
-                </Button>
+                        </Group>
+                      }
+                    />
+                  </Button>
+                  {isGroupAdmin && !!thisChat && activeMemberStatuses.includes(cm.status) && (
+                    <ChatMemberMenu chatObj={thisChat} member={cm} />
+                  )}
+                </Group>
               ))}
             </Group>
           )}

--- a/src/components/Chat/ExistingChatV1.tsx
+++ b/src/components/Chat/ExistingChatV1.tsx
@@ -56,6 +56,8 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { constants } from '~/server/common/constants';
 import { SignalMessages } from '~/server/common/enums';
 import type { isTypingOutput } from '~/server/schema/chat.schema';
+import { ChatMemberMenu } from '~/components/Chat/ChatMemberMenu';
+import { activeMemberStatuses } from '~/shared/utils/chat';
 import { ChatMemberStatus, ChatMessageType } from '~/shared/utils/prisma/enums';
 import type { ChatAllMessages } from '~/types/router';
 import { formatDate } from '~/utils/date-helpers';
@@ -164,6 +166,12 @@ export function ExistingChatV1() {
     () => thisChat?.chatMembers.filter((cm) => cm.userId !== currentUser?.id),
     [thisChat, currentUser]
   );
+  // `chatMembers.length` is the fallback for threads that predate `Chat.isGroup`
+  // and have not been backfilled.
+  const isGroupAdmin =
+    (!!thisChat?.isGroup || (thisChat?.chatMembers.length ?? 0) > 2) &&
+    !!currentUser &&
+    thisChat?.ownerId === currentUser.id;
   // const lastViewed = myMember?.lastViewedMessageId;
   const modSender = useMemo(
     () => thisChat?.chatMembers.find((cm) => cm.isOwner === true && cm.user.isModerator === true),
@@ -412,49 +420,54 @@ export function ExistingChatV1() {
               {/* TODO online status (later), blocked users, etc */}
 
               {otherMembers?.map((cm) => (
-                <Button key={cm.userId} variant="light" color="gray" size="compact-sm">
-                  <UserAvatar
-                    user={cm.user}
-                    size="xs"
-                    withUsername
-                    linkToProfile
-                    badge={
-                      <Group gap={6} ml={4} align="center">
-                        {cm.user.isModerator ? (
-                          <Image
-                            src="/images/civ-c.png"
-                            title="Moderator"
-                            alt="Moderator"
-                            className="size-4"
-                          />
-                        ) : undefined}
-                        {cm.isOwner === true ? (
-                          <Box title="Creator" display="flex">
-                            <IconCrown size={16} fill="currentColor" />
+                <Group key={cm.userId} gap={2} wrap="nowrap">
+                  <Button variant="light" color="gray" size="compact-sm">
+                    <UserAvatar
+                      user={cm.user}
+                      size="xs"
+                      withUsername
+                      linkToProfile
+                      badge={
+                        <Group gap={6} ml={4} align="center">
+                          {cm.user.isModerator ? (
+                            <Image
+                              src="/images/civ-c.png"
+                              title="Moderator"
+                              alt="Moderator"
+                              className="size-4"
+                            />
+                          ) : undefined}
+                          {cm.isOwner === true ? (
+                            <Box title="Creator" display="flex">
+                              <IconCrown size={16} fill="currentColor" />
+                            </Box>
+                          ) : undefined}
+                          <Box
+                            title={
+                              cm.status === ChatMemberStatus.Invited ||
+                              cm.status === ChatMemberStatus.Ignored
+                                ? 'Invited'
+                                : cm.status
+                            }
+                            display="flex"
+                          >
+                            {cm.status === ChatMemberStatus.Joined ? (
+                              <IconCircleCheck size={16} color="green" />
+                            ) : cm.status === ChatMemberStatus.Left ||
+                              cm.status === ChatMemberStatus.Kicked ? (
+                              <IconCircleX size={16} color="orangered" />
+                            ) : (
+                              <IconCircleMinus size={16} />
+                            )}
                           </Box>
-                        ) : undefined}
-                        <Box
-                          title={
-                            cm.status === ChatMemberStatus.Invited ||
-                            cm.status === ChatMemberStatus.Ignored
-                              ? 'Invited'
-                              : cm.status
-                          }
-                          display="flex"
-                        >
-                          {cm.status === ChatMemberStatus.Joined ? (
-                            <IconCircleCheck size={16} color="green" />
-                          ) : cm.status === ChatMemberStatus.Left ||
-                            cm.status === ChatMemberStatus.Kicked ? (
-                            <IconCircleX size={16} color="orangered" />
-                          ) : (
-                            <IconCircleMinus size={16} />
-                          )}
-                        </Box>
-                      </Group>
-                    }
-                  />
-                </Button>
+                        </Group>
+                      }
+                    />
+                  </Button>
+                  {isGroupAdmin && !!thisChat && activeMemberStatuses.includes(cm.status) && (
+                    <ChatMemberMenu chatObj={thisChat} member={cm} />
+                  )}
+                </Group>
               ))}
             </Group>
           )}

--- a/src/components/Chat/NewChat.tsx
+++ b/src/components/Chat/NewChat.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Button, Center, Divider, Group, Stack, Text } from '@mantine/core';
+import { Alert, Box, Button, Center, Divider, Group, Stack, Text, TextInput } from '@mantine/core';
 import { useLocalStorage } from '@mantine/hooks';
 import { IconCheck, IconX } from '@tabler/icons-react';
 import { useState } from 'react';
@@ -8,12 +8,15 @@ import { QuickSearchDropdown } from '~/components/Search/QuickSearchDropdown';
 import type { SearchIndexDataMap } from '~/components/Search/search.utils2';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { MAX_CHAT_MEMBERS } from '~/shared/utils/chat';
+import { MAX_CHAT_NAME_LENGTH } from '~/server/schema/chat.schema';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 
 export function NewChat() {
   const selectedUsers = useChatStore((state) => state.selectedUsers);
+  const [groupName, setGroupName] = useState('');
   const [isCreating, setIsCreating] = useState(false);
   const [acking, setAcking] = useState(false);
   const currentUser = useCurrentUser();
@@ -63,6 +66,7 @@ export function NewChat() {
           return [{ ...data, createdAt: new Date(data.createdAt) }, ...old];
         });
 
+        setGroupName('');
         useChatStore.setState({
           isCreating: false,
           selectedUsers: [],
@@ -90,6 +94,8 @@ export function NewChat() {
     });
   };
 
+  const isGroup = selectedUsers.length > 1;
+
   const handleNewChat = () => {
     setIsCreating(true);
     if (!currentUser) {
@@ -100,8 +106,10 @@ export function NewChat() {
       });
       return;
     }
+    const trimmedName = groupName.trim();
     mutate({
       userIds: [...selectedUsers.map((u) => u.id!), currentUser.id],
+      name: isGroup && trimmedName.length ? trimmedName : undefined,
     });
   };
 
@@ -143,11 +151,10 @@ export function NewChat() {
           supportedIndexes={['users']}
           onItemSelected={(_entity, item) => {
             const newUsers = [...selectedUsers, item as SearchIndexDataMap['users'][number]];
-            // TODO make this a constant
-            if (newUsers.length > 9) {
+            if (newUsers.length > MAX_CHAT_MEMBERS - 1) {
               showErrorNotification({
                 title: 'Maximum users reached',
-                error: { message: 'You can select up to 9 users' },
+                error: { message: `You can select up to ${MAX_CHAT_MEMBERS - 1} users` },
                 autoClose: false,
               });
               return;
@@ -164,6 +171,17 @@ export function NewChat() {
             .slice(4)}
         />
       </Box>
+      {isGroup && (
+        <Box px="sm" pt="sm">
+          <TextInput
+            label="Group name"
+            placeholder="Optional"
+            value={groupName}
+            maxLength={MAX_CHAT_NAME_LENGTH}
+            onChange={(e) => setGroupName(e.currentTarget.value)}
+          />
+        </Box>
+      )}
       <Box p="sm" style={{ flexGrow: 1 }}>
         {selectedUsers.length === 0 ? (
           <Center mt="md">
@@ -196,6 +214,7 @@ export function NewChat() {
           variant="light"
           color="gray"
           onClick={() => {
+            setGroupName('');
             useChatStore.setState({ isCreating: false, selectedUsers: [] });
           }}
         >

--- a/src/components/Signals/SignalsRegistrar.tsx
+++ b/src/components/Signals/SignalsRegistrar.tsx
@@ -8,6 +8,7 @@ import {
   useChatMessageUpdatedSignal,
   useChatNewMessageSignal,
   useChatNewRoomSignal,
+  useChatRoomUpdatedSignal,
 } from '~/components/Chat/ChatSignals';
 import { useNotificationSignal } from '~/components/Notifications/notifications.utils';
 import { useSessionRefreshSignal } from '~/components/Signals/SessionRefreshSignal';
@@ -41,6 +42,7 @@ export function SignalsRegistrar() {
 
   useChatNewMessageSignal();
   useChatNewRoomSignal();
+  useChatRoomUpdatedSignal();
   useChatMessageDeletedSignal();
   useChatMessageUpdatedSignal();
 

--- a/src/server/common/enums.ts
+++ b/src/server/common/enums.ts
@@ -143,6 +143,7 @@ export enum SignalMessages {
   ChatTypingStatus = 'chat:typing-status',
   ChatMessageDeleted = 'chat:message-deleted',
   ChatMessageUpdated = 'chat:message-updated',
+  ChatRoomUpdated = 'chat:room-updated',
   OrchestratorUpdate = 'orchestrator-job:status-update',
   TextToImageUpdate = 'orchestrator:text-to-image-update',
   WorkflowUpdate = 'orchestrator:workflow-update',
@@ -449,7 +450,6 @@ export enum NewOrderSignalActions {
 export enum ExternalModerationType {
   Clavata = 'Clavata',
 }
-
 
 export enum MarketplacePaymentMethod {
   CashApp = 'CashApp',

--- a/src/server/controllers/chat.controller.ts
+++ b/src/server/controllers/chat.controller.ts
@@ -17,6 +17,7 @@ import type {
   DeleteMessageInput,
   MarkChatReadInput,
   ModifyUserInput,
+  UpdateChatInput,
   UpdateMessageInput,
   UserSettingsChat,
 } from '~/server/schema/chat.schema';
@@ -36,7 +37,21 @@ import {
   singleChatSelect,
 } from '~/server/selectors/chat.selector';
 import { profileImageSelect } from '~/server/selectors/image.selector';
-import { createMessage, maxUsersPerChat, upsertChat } from '~/server/services/chat.service';
+import {
+  assertChatNameAllowed,
+  createMessage,
+  maxUsersPerChat,
+  resolveChatRecipients,
+  upsertChat,
+} from '~/server/services/chat.service';
+import {
+  assertCanPromote,
+  assertGroupAdmin,
+  assertRoomForMembers,
+  isActiveMember,
+  normalizeChatName,
+  selectNextOwner,
+} from '~/server/utils/chat-group';
 import { getUserSettings, patchUserSettings } from '~/server/services/user.service';
 import { withSignals } from '~/server/signals/wrapper';
 import {
@@ -282,6 +297,8 @@ export const createChatHandler = async ({
     const chat = await upsertChat({
       userId,
       userIds: dedupedUserIds,
+      isGroup: input.isGroup,
+      name: input.name,
       isModerator,
       isSupporter,
     });
@@ -294,7 +311,73 @@ export const createChatHandler = async ({
 };
 
 /**
- * Add a user to an existing chat
+ * Rename a group. Passing a blank name clears it, so the title falls back to the
+ * member list.
+ */
+export const updateChatHandler = async ({
+  input,
+  ctx,
+}: {
+  input: UpdateChatInput;
+  ctx: ProtectedContext;
+}) => {
+  try {
+    const { id: userId, bannedAt, isModerator } = ctx.user;
+    if (bannedAt) throw throwAuthorizationError('You are banned from performing this action');
+
+    const existing = await dbWrite.chat.findFirst({
+      where: { id: input.chatId },
+      select: { id: true, isGroup: true, ownerId: true, name: true },
+    });
+
+    if (!existing) {
+      throw throwNotFoundError(`Could not find chat with id: (${input.chatId})`);
+    }
+
+    assertGroupAdmin({ chat: existing, actorId: userId, isModerator });
+
+    const name = normalizeChatName(input.name);
+    await assertChatNameAllowed(name);
+
+    const updated = await dbWrite.chat.update({
+      where: { id: existing.id },
+      data: { name },
+      select: {
+        ...singleChatSelect,
+        ...latestChat,
+      },
+    });
+
+    // Renaming to the name it already has should not announce itself.
+    if (name === existing.name) return updated;
+
+    withSignals(() =>
+      fetch(
+        `${env.SIGNALS_ENDPOINT}/groups/chat:${existing.id}/signals/${SignalMessages.ChatRoomUpdated}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: existing.id, name }),
+        }
+      )
+    ).catch(() => undefined);
+
+    await createMessage({
+      chatId: existing.id,
+      contentType: ChatMessageType.Markdown,
+      content: name ? `Group renamed to "${name}"` : 'Group name removed',
+      userId: -1,
+    });
+
+    return updated;
+  } catch (error) {
+    if (error instanceof TRPCError) throw error;
+    else throw throwDbError(error);
+  }
+};
+
+/**
+ * Add members to an existing group chat.
  */
 export const addUsersHandler = async ({
   input,
@@ -304,71 +387,94 @@ export const addUsersHandler = async ({
   ctx: ProtectedContext;
 }) => {
   try {
-    const { id: userId } = ctx.user;
+    const { id: userId, bannedAt, isModerator } = ctx.user;
+    if (bannedAt) throw throwAuthorizationError('You are banned from performing this action');
 
     const existing = await dbWrite.chat.findFirst({
       where: { id: input.chatId },
       select: {
+        id: true,
+        isGroup: true,
         ownerId: true,
         chatMembers: {
-          select: {
-            userId: true,
-          },
+          select: { id: true, userId: true, status: true },
         },
       },
     });
 
     if (!existing) {
-      throw throwBadRequestError(`Could not find chat with id: (${input.chatId})`);
+      throw throwNotFoundError(`Could not find chat with id: (${input.chatId})`);
     }
 
-    if (existing.ownerId !== userId) {
-      throw throwBadRequestError(`Cannot add users to a chat you are not the owner of`);
-    }
+    assertGroupAdmin({ chat: existing, actorId: userId, isModerator });
 
-    const dedupedUserIds = uniq(input.userIds);
-    const existingChatMemberIds = existing.chatMembers.map((cm) => cm.userId);
-    let usersToAdd = dedupedUserIds.filter((uid) => !existingChatMemberIds.includes(uid));
-
-    // don't pull users who have disabled chat into a chat (mods bypass)
-    if (!ctx.user.isModerator && usersToAdd.length) {
-      const settings = await Promise.all(usersToAdd.map((id) => getUserSettings(id)));
-      usersToAdd = usersToAdd.filter((_, i) => settings[i]?.features?.chat !== false);
-      if (!usersToAdd.length) {
-        throw throwBadRequestError('The requested users are not accepting chat requests');
-      }
-    }
-
-    const mergedUsers = [...existingChatMemberIds, ...usersToAdd];
-    if (mergedUsers.length >= maxUsersPerChat) {
-      throw throwBadRequestError(`Must choose fewer than ${maxUsersPerChat - 1} users`);
-    }
-
-    const usersExist = await dbRead.user.count({
-      where: { id: { in: usersToAdd } },
+    const membersByUserId = new Map(existing.chatMembers.map((cm) => [cm.userId, cm]));
+    const requested = uniq(input.userIds).filter((uid) => {
+      const member = membersByUserId.get(uid);
+      // A member who left or was removed can be invited back; one who is still
+      // in the group is a no-op rather than an error.
+      return !member || !isActiveMember(member);
     });
 
-    if (usersExist !== usersToAdd.length) {
-      // could probably tell them which users here
+    if (!requested.length) {
+      throw throwBadRequestError('Those users are already in this chat');
+    }
+
+    const { allowed, filteredIds } = await resolveChatRecipients({
+      userId,
+      recipientIds: requested,
+      isModerator,
+    });
+
+    if (!allowed.length) {
+      throw throwBadRequestError('The requested users are not accepting chat requests');
+    }
+
+    assertRoomForMembers({
+      members: existing.chatMembers,
+      adding: allowed.length,
+      limit: maxUsersPerChat,
+    });
+
+    const users = await dbRead.user.findMany({
+      where: { id: { in: allowed } },
+      select: { id: true, username: true },
+    });
+
+    if (users.length !== allowed.length) {
       throw throwBadRequestError(
-        `Some requested users do not exist (${usersExist}/${usersToAdd.length})`
+        `Some requested users do not exist (${users.length}/${allowed.length})`
       );
     }
 
-    mergedUsers.sort((a, b) => a - b);
-    const hash = mergedUsers.join('-');
+    const toReinvite = allowed.map((uid) => membersByUserId.get(uid)).filter(isDefined);
+    const toCreate = allowed.filter((uid) => !membersByUserId.has(uid));
 
     const insertedChat = await dbWrite.$transaction(async (tx) => {
-      await tx.chatMember.createMany({
-        data: usersToAdd.map((uta) => ({
-          userId: uta,
-          chatId: input.chatId,
-          status: ChatMemberStatus.Invited,
-        })),
-      });
-      return tx.chat.update({
-        where: { id: input.chatId },
-        data: { hash },
+      if (toCreate.length) {
+        await tx.chatMember.createMany({
+          data: toCreate.map((uid) => ({
+            userId: uid,
+            chatId: existing.id,
+            status: ChatMemberStatus.Invited,
+            filteredAt: filteredIds.has(uid) ? new Date() : undefined,
+          })),
+        });
+      }
+      for (const member of toReinvite) {
+        await tx.chatMember.update({
+          where: { id: member.id },
+          data: {
+            status: ChatMemberStatus.Invited,
+            kickedAt: null,
+            leftAt: null,
+            ignoredAt: null,
+            filteredAt: filteredIds.has(member.userId) ? new Date() : null,
+          },
+        });
+      }
+      return tx.chat.findFirstOrThrow({
+        where: { id: existing.id },
         select: {
           ...singleChatSelect,
           ...latestChat,
@@ -376,7 +482,7 @@ export const addUsersHandler = async ({
       });
     });
 
-    for (const cmId of usersToAdd) {
+    for (const cmId of allowed) {
       withSignals(() =>
         fetch(`${env.SIGNALS_ENDPOINT}/users/${cmId}/signals/${SignalMessages.ChatNewRoom}`, {
           method: 'POST',
@@ -386,15 +492,20 @@ export const addUsersHandler = async ({
       ).catch(() => undefined);
     }
 
-    // TODO return data?
-    return;
+    const addedNames = users.map((u) => u.username ?? `User ${u.id}`);
+    await createMessage({
+      chatId: existing.id,
+      contentType: ChatMessageType.Markdown,
+      content: `${addedNames.join(', ')} ${addedNames.length > 1 ? 'were' : 'was'} added`,
+      userId: -1,
+    });
+
+    return insertedChat;
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
   }
 };
-
-// TODO when owner leaves chat, select new owner
 
 /**
  * Update a member of a chat
@@ -409,9 +520,9 @@ export const modifyUserHandler = async ({
   try {
     const { id: userId } = ctx.user;
 
-    const { chatMemberId, status, isPinned, isMuted, notifyLevel, ...rest } = input;
+    const { chatMemberId, status, isPinned, isMuted, notifyLevel, isOwner, ...rest } = input;
 
-    const definedValues = { status, isPinned, isMuted, notifyLevel, ...rest };
+    const definedValues = { status, isPinned, isMuted, notifyLevel, isOwner, ...rest };
     const definedValuesLength = Object.values(definedValues).filter(
       (val) => val !== undefined
     ).length;
@@ -423,8 +534,10 @@ export const modifyUserHandler = async ({
     const existing = await dbWrite.chatMember.findFirst({
       where: { id: chatMemberId },
       select: {
+        id: true,
         userId: true,
         status: true,
+        isOwner: true,
         user: {
           select: {
             username: true,
@@ -435,15 +548,20 @@ export const modifyUserHandler = async ({
           select: {
             id: true,
             ownerId: true,
+            isGroup: true,
             owner: {
               select: {
                 isModerator: true,
               },
             },
             chatMembers: {
-              where: { isOwner: true },
               select: {
+                id: true,
+                userId: true,
+                isOwner: true,
                 status: true,
+                createdAt: true,
+                joinedAt: true,
               },
             },
           },
@@ -455,7 +573,16 @@ export const modifyUserHandler = async ({
       throw throwBadRequestError(`Could not find chat member`);
     }
 
-    if (status === ChatMemberStatus.Kicked) {
+    const ownerMember = existing.chat.chatMembers.find((cm) => cm.isOwner);
+
+    if (isOwner) {
+      assertCanPromote({
+        chat: existing.chat,
+        target: existing,
+        actorId: userId,
+        isModerator: ctx.user.isModerator,
+      });
+    } else if (status === ChatMemberStatus.Kicked) {
       // I guess owners can kick themselves out :/
       if (existing.chat.ownerId !== userId) {
         throw throwBadRequestError(`Cannot modify users for a chat you are not the owner of`);
@@ -469,10 +596,35 @@ export const modifyUserHandler = async ({
     if (
       status === ChatMemberStatus.Left &&
       existing.chat.owner.isModerator &&
-      existing.chat.chatMembers[0]?.status === ChatMemberStatus.Joined &&
+      ownerMember?.status === ChatMemberStatus.Joined &&
       !existing.user.isModerator
     ) {
       throw throwBadRequestError(`Cannot leave a moderator chat while they are still present`);
+    }
+
+    // Handing the group over is a two-row move, so it does not go through the
+    // single-column update below.
+    if (isOwner) {
+      const [, promoted] = await dbWrite.$transaction([
+        dbWrite.chatMember.updateMany({
+          where: { chatId: existing.chat.id, isOwner: true },
+          data: { isOwner: false },
+        }),
+        dbWrite.chatMember.update({ where: { id: chatMemberId }, data: { isOwner: true } }),
+        dbWrite.chat.update({
+          where: { id: existing.chat.id },
+          data: { ownerId: existing.userId },
+        }),
+      ]);
+
+      await createMessage({
+        chatId: existing.chat.id,
+        contentType: ChatMessageType.Markdown,
+        content: `${existing.user.username} is now the group admin`,
+        userId: -1,
+      });
+
+      return promoted;
     }
 
     // TODO if a moderator rejoins, auto-rejoin other users
@@ -495,6 +647,33 @@ export const modifyUserHandler = async ({
     });
 
     const statusChanged = !!status && status !== existing.status;
+
+    // An owner who leaves takes the only account that can administer the group
+    // with them, so the group is handed to the longest-joined member who stays.
+    let successor: { userId: number; username: string | null } | undefined;
+    if (
+      statusChanged &&
+      existing.chat.isGroup &&
+      existing.isOwner &&
+      (status === ChatMemberStatus.Left || status === ChatMemberStatus.Kicked)
+    ) {
+      const next = selectNextOwner(existing.chat.chatMembers, chatMemberId);
+      if (next) {
+        await dbWrite.$transaction([
+          dbWrite.chatMember.update({ where: { id: chatMemberId }, data: { isOwner: false } }),
+          dbWrite.chatMember.update({ where: { id: next.id }, data: { isOwner: true } }),
+          dbWrite.chat.update({
+            where: { id: existing.chat.id },
+            data: { ownerId: next.userId },
+          }),
+        ]);
+        const nextUser = await dbRead.user.findUnique({
+          where: { id: next.userId },
+          select: { username: true },
+        });
+        successor = { userId: next.userId, username: nextUser?.username ?? null };
+      }
+    }
 
     if (statusChanged && status !== ChatMemberStatus.Invited) {
       // Awaited to order the group change before the system message below, but
@@ -523,6 +702,15 @@ export const modifyUserHandler = async ({
           userId: -1,
         });
       }
+    }
+
+    if (successor) {
+      await createMessage({
+        chatId: existing.chat.id,
+        contentType: ChatMessageType.Markdown,
+        content: `${successor.username ?? `User ${successor.userId}`} is now the group admin`,
+        userId: -1,
+      });
     }
 
     return resp;

--- a/src/server/routers/chat.router.ts
+++ b/src/server/routers/chat.router.ts
@@ -1,4 +1,5 @@
 import {
+  addUsersHandler,
   clearChatHandler,
   createChatHandler,
   createMessageHandler,
@@ -6,6 +7,7 @@ import {
   getChatAuditHandler,
   getModeratorChatHandler,
   getChatsForUserHandler,
+  updateChatHandler,
   updateMessageHandler,
   getInfiniteMessagesHandler,
   getMessageByIdHandler,
@@ -18,10 +20,12 @@ import {
   setUserSettingsHandler,
 } from '~/server/controllers/chat.controller';
 import {
+  addUsersInput,
   clearChatInput,
   createChatInput,
   createMessageInput,
   deleteMessageInput,
+  updateChatInput,
   updateMessageInput,
   getInfiniteMessagesInput,
   getMessageByIdInput,
@@ -51,7 +55,14 @@ export const chatRouter = router({
     .meta({ requiredScope: TokenScope.SocialWrite })
     .input(createChatInput)
     .mutation(createChatHandler),
-  // addUser: guardedProcedure.input(addUsersInput).mutation(addUsersHandler),
+  addUser: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(addUsersInput)
+    .mutation(addUsersHandler),
+  updateChat: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(updateChatInput)
+    .mutation(updateChatHandler),
   modifyUser: protectedProcedure
     .meta({ requiredScope: TokenScope.SocialWrite })
     .input(modifyUserInput)

--- a/src/server/schema/chat.schema.ts
+++ b/src/server/schema/chat.schema.ts
@@ -5,21 +5,37 @@ import { MAX_CHAT_MESSAGE_LENGTH } from '~/shared/utils/chat';
 import { chatLayoutSlugs } from '~/shared/constants/chat-layout';
 import { chatThemeSlugs } from '~/shared/constants/chat-theme';
 
+export const MAX_CHAT_NAME_LENGTH = 60;
+
 export type CreateChatInput = z.infer<typeof createChatInput>;
 export const createChatInput = z.object({
   userIds: z.array(z.number()),
+  // Omitted means "infer from the member count". Passing it lets a caller start
+  // a group with two people, which is the only way to have two threads with the
+  // same person.
+  isGroup: z.boolean().optional(),
+  name: z.string().trim().min(1).max(MAX_CHAT_NAME_LENGTH).optional(),
+});
+
+/** Rename a group. `null` (or blank) clears the name back to the member-list title. */
+export type UpdateChatInput = z.infer<typeof updateChatInput>;
+export const updateChatInput = z.object({
+  chatId: z.number(),
+  name: z.string().trim().max(MAX_CHAT_NAME_LENGTH).nullable(),
 });
 
 export type AddUsersInput = z.infer<typeof addUsersInput>;
 export const addUsersInput = z.object({
   chatId: z.number(),
-  userIds: z.array(z.number()),
+  userIds: z.array(z.number()).min(1),
 });
 
 export type ModifyUserInput = z.infer<typeof modifyUserInput>;
 export const modifyUserInput = z.object({
   chatMemberId: z.number(),
-  // isOwner: z.boolean().optional(), // probably shouldn't be able to change this for now
+  // Promotion only. `false` has no meaning on its own — a group without an admin
+  // cannot be administered — so handing over is the only way to stop being one.
+  isOwner: z.literal(true).optional(),
   isMuted: z.boolean().optional(),
   status: z.enum(ChatMemberStatus).optional(),
   lastViewedMessageId: z.number().optional(),

--- a/src/server/selectors/chat.selector.ts
+++ b/src/server/selectors/chat.selector.ts
@@ -8,6 +8,8 @@ export const singleChatSelect = Prisma.validator<Prisma.ChatSelect>()({
   createdAt: true,
   hash: true,
   ownerId: true,
+  isGroup: true,
+  name: true,
   chatMembers: {
     // where: { status: { in: [ChatMemberStatus.Joined, ChatMemberStatus.Invited] } },
     select: {

--- a/src/server/services/__tests__/chat-group.test.ts
+++ b/src/server/services/__tests__/chat-group.test.ts
@@ -1,0 +1,249 @@
+import { TRPCError } from '@trpc/server';
+import { describe, expect, it } from 'vitest';
+import {
+  assertCanPromote,
+  assertGroupAdmin,
+  assertRoomForMembers,
+  normalizeChatName,
+  resolveChatIdentity,
+  selectNextOwner,
+} from '~/server/utils/chat-group';
+import type { GroupMemberLike } from '~/server/utils/chat-group';
+import { ChatMemberStatus } from '~/shared/utils/prisma/enums';
+
+/**
+ * Group chats (868kv2rht). Membership used to be frozen at creation, so the
+ * rules that matter here are the ones that let it move without letting anyone
+ * move it: exactly one admin, and only that admin adding, removing or handing
+ * over.
+ */
+
+const at = (iso: string) => new Date(iso);
+
+const member = (overrides: Partial<GroupMemberLike> & { id: number }): GroupMemberLike => ({
+  userId: overrides.id * 100,
+  isOwner: false,
+  status: ChatMemberStatus.Joined,
+  createdAt: at('2026-01-01T00:00:00Z'),
+  joinedAt: null,
+  ...overrides,
+});
+
+const group = { isGroup: true, ownerId: 1 };
+
+describe('resolveChatIdentity', () => {
+  it('keeps the member-set hash for a 1:1 so re-opening a DM finds the thread', () => {
+    expect(resolveChatIdentity({ userIds: [7, 3] })).toEqual({ isGroup: false, hash: '3-7' });
+  });
+
+  it('gives a group no hash, so two groups with the same people can coexist', () => {
+    const first = resolveChatIdentity({ userIds: [3, 7, 9] });
+    const second = resolveChatIdentity({ userIds: [9, 7, 3] });
+    expect(first).toEqual({ isGroup: true, hash: null });
+    expect(second).toEqual({ isGroup: true, hash: null });
+  });
+
+  it('honours an explicit group of two, which is the only way to have a second thread with one person', () => {
+    expect(resolveChatIdentity({ userIds: [3, 7], isGroup: true })).toEqual({
+      isGroup: true,
+      hash: null,
+    });
+  });
+
+  it('honours an explicit 1:1 even with a repeated id', () => {
+    expect(resolveChatIdentity({ userIds: [3, 7, 7] })).toEqual({ isGroup: false, hash: '3-7' });
+  });
+});
+
+describe('normalizeChatName', () => {
+  it('keeps a real name, trimmed', () => {
+    expect(normalizeChatName('  Weekend crew  ')).toBe('Weekend crew');
+  });
+
+  it('preserves inner spacing', () => {
+    expect(normalizeChatName('the  gang')).toBe('the  gang');
+  });
+
+  it('collapses every flavour of "no name" to null, so a cleared name falls back to the member list', () => {
+    for (const blank of ['', '   ', '\t\n', null, undefined]) {
+      expect(normalizeChatName(blank)).toBeNull();
+    }
+  });
+});
+
+describe('assertGroupAdmin', () => {
+  it('allows the owner', () => {
+    expect(() => assertGroupAdmin({ chat: group, actorId: 1 })).not.toThrow();
+  });
+
+  it('rejects a member who is not the owner', () => {
+    expect(() => assertGroupAdmin({ chat: group, actorId: 2 })).toThrow(TRPCError);
+  });
+
+  it('allows a moderator to unstick a group they do not own', () => {
+    expect(() => assertGroupAdmin({ chat: group, actorId: 2, isModerator: true })).not.toThrow();
+  });
+
+  it('rejects a 1:1 conversation, which has no membership to administer', () => {
+    expect(() => assertGroupAdmin({ chat: { isGroup: false, ownerId: 1 }, actorId: 1 })).toThrow(
+      TRPCError
+    );
+    // A moderator does not turn a DM into a group either.
+    expect(() =>
+      assertGroupAdmin({ chat: { isGroup: false, ownerId: 1 }, actorId: 9, isModerator: true })
+    ).toThrow(TRPCError);
+  });
+});
+
+describe('assertRoomForMembers', () => {
+  const seats = (count: number, status = ChatMemberStatus.Joined) =>
+    Array.from({ length: count }, () => ({ status }));
+
+  it('allows filling the last seat exactly', () => {
+    expect(() => assertRoomForMembers({ members: seats(9), adding: 1, limit: 10 })).not.toThrow();
+  });
+
+  it('rejects one past the limit', () => {
+    expect(() => assertRoomForMembers({ members: seats(10), adding: 1, limit: 10 })).toThrow(
+      TRPCError
+    );
+    expect(() => assertRoomForMembers({ members: seats(9), adding: 2, limit: 10 })).toThrow(
+      TRPCError
+    );
+  });
+
+  it('does not count members who left or were removed', () => {
+    const members = [
+      ...seats(8),
+      ...seats(4, ChatMemberStatus.Left),
+      ...seats(4, ChatMemberStatus.Kicked),
+    ];
+    expect(() => assertRoomForMembers({ members, adding: 2, limit: 10 })).not.toThrow();
+    expect(() => assertRoomForMembers({ members, adding: 3, limit: 10 })).toThrow(TRPCError);
+  });
+});
+
+// Renaming shares `assertGroupAdmin` with adding and removing, so the gate is
+// covered above. These pin that a rename cannot be the one action that escapes it.
+describe('rename authorization', () => {
+  it('rejects a non-owner', () => {
+    expect(() => assertGroupAdmin({ chat: group, actorId: 2 })).toThrow(TRPCError);
+  });
+
+  it('rejects renaming a 1:1, which has no name to show', () => {
+    expect(() => assertGroupAdmin({ chat: { isGroup: false, ownerId: 1 }, actorId: 1 })).toThrow(
+      TRPCError
+    );
+  });
+});
+
+describe('assertCanPromote', () => {
+  const target = member({ id: 2, status: ChatMemberStatus.Joined });
+
+  it('allows the owner to hand the group to a joined member', () => {
+    expect(() => assertCanPromote({ chat: group, target, actorId: 1 })).not.toThrow();
+  });
+
+  it('rejects a non-owner', () => {
+    expect(() => assertCanPromote({ chat: group, target, actorId: 2 })).toThrow(TRPCError);
+    expect(() => assertCanPromote({ chat: group, target, actorId: 3 })).toThrow(TRPCError);
+  });
+
+  it('rejects promoting the current admin', () => {
+    expect(() =>
+      assertCanPromote({ chat: group, target: { ...target, isOwner: true }, actorId: 1 })
+    ).toThrow(TRPCError);
+  });
+
+  it('rejects a member who has not joined, so the group cannot be parked on someone absent', () => {
+    for (const status of [
+      ChatMemberStatus.Invited,
+      ChatMemberStatus.Ignored,
+      ChatMemberStatus.Left,
+      ChatMemberStatus.Kicked,
+    ]) {
+      expect(() =>
+        assertCanPromote({ chat: group, target: { ...target, status }, actorId: 1 })
+      ).toThrow(TRPCError);
+    }
+  });
+});
+
+describe('selectNextOwner', () => {
+  it('picks the longest-joined remaining member', () => {
+    const members = [
+      member({ id: 1, isOwner: true, joinedAt: at('2026-01-01T00:00:00Z') }),
+      member({ id: 2, joinedAt: at('2026-03-01T00:00:00Z') }),
+      member({ id: 3, joinedAt: at('2026-02-01T00:00:00Z') }),
+    ];
+    expect(selectNextOwner(members, 1)?.id).toBe(3);
+  });
+
+  it('never returns the member who is leaving', () => {
+    const members = [
+      member({ id: 1, isOwner: true, joinedAt: at('2026-01-01T00:00:00Z') }),
+      member({ id: 2, joinedAt: at('2026-02-01T00:00:00Z') }),
+    ];
+    expect(selectNextOwner(members, 1)?.id).toBe(2);
+    expect(selectNextOwner(members, 2)?.id).toBe(1);
+  });
+
+  it('skips members who already left or were removed', () => {
+    const members = [
+      member({ id: 1, isOwner: true, joinedAt: at('2026-01-01T00:00:00Z') }),
+      member({ id: 2, status: ChatMemberStatus.Left, joinedAt: at('2026-01-02T00:00:00Z') }),
+      member({ id: 3, status: ChatMemberStatus.Kicked, joinedAt: at('2026-01-03T00:00:00Z') }),
+      member({ id: 4, joinedAt: at('2026-06-01T00:00:00Z') }),
+    ];
+    expect(selectNextOwner(members, 1)?.id).toBe(4);
+  });
+
+  it('prefers a joined member over an invited one regardless of seniority', () => {
+    const members = [
+      member({ id: 1, isOwner: true, joinedAt: at('2026-01-01T00:00:00Z') }),
+      member({
+        id: 2,
+        status: ChatMemberStatus.Invited,
+        createdAt: at('2026-01-02T00:00:00Z'),
+      }),
+      member({ id: 3, joinedAt: at('2026-09-01T00:00:00Z') }),
+    ];
+    expect(selectNextOwner(members, 1)?.id).toBe(3);
+  });
+
+  it('falls back to an invited member rather than leaving the group ownerless', () => {
+    const members = [
+      member({ id: 1, isOwner: true, joinedAt: at('2026-01-01T00:00:00Z') }),
+      member({ id: 2, status: ChatMemberStatus.Invited, createdAt: at('2026-02-01T00:00:00Z') }),
+    ];
+    expect(selectNextOwner(members, 1)?.id).toBe(2);
+  });
+
+  it('falls back to createdAt when a member has no joinedAt', () => {
+    const members = [
+      member({ id: 1, isOwner: true, joinedAt: at('2026-01-01T00:00:00Z') }),
+      member({ id: 2, createdAt: at('2026-05-01T00:00:00Z'), joinedAt: null }),
+      member({ id: 3, createdAt: at('2026-04-01T00:00:00Z'), joinedAt: null }),
+    ];
+    expect(selectNextOwner(members, 1)?.id).toBe(3);
+  });
+
+  it('breaks ties on member id so the choice is stable', () => {
+    const sameMoment = at('2026-01-01T00:00:00Z');
+    const members = [
+      member({ id: 1, isOwner: true, joinedAt: sameMoment }),
+      member({ id: 5, joinedAt: sameMoment }),
+      member({ id: 3, joinedAt: sameMoment }),
+    ];
+    expect(selectNextOwner(members, 1)?.id).toBe(3);
+    expect(selectNextOwner([...members].reverse(), 1)?.id).toBe(3);
+  });
+
+  it('returns undefined when the leaver is the last one standing', () => {
+    const members = [
+      member({ id: 1, isOwner: true }),
+      member({ id: 2, status: ChatMemberStatus.Left }),
+    ];
+    expect(selectNextOwner(members, 1)).toBeUndefined();
+  });
+});

--- a/src/server/services/chat.service.ts
+++ b/src/server/services/chat.service.ts
@@ -1,4 +1,5 @@
 import dayjs from '~/shared/utils/dayjs';
+import { uniq } from 'lodash-es';
 import { find as findLinks } from 'linkifyjs';
 import { unfurl } from 'unfurl.js';
 import { linkifyOptions } from '~/components/Chat/util';
@@ -17,7 +18,8 @@ import {
 import { BlockedByUsers, BlockedUsers } from '~/server/services/user-preferences.service';
 import { getUserSettings } from '~/server/services/user.service';
 import { withSignals } from '~/server/signals/wrapper';
-import { decideDmRouting, getChatHash } from '~/server/utils/chat';
+import { decideDmRouting } from '~/server/utils/chat';
+import { normalizeChatName, resolveChatIdentity } from '~/server/utils/chat-group';
 import { REDIS_SYS_KEYS } from '~/server/redis/client';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
 import {
@@ -27,12 +29,13 @@ import {
 import { getOwnedStickerCosmetics } from '~/server/services/cosmetic.service';
 import { createLimiter } from '~/server/utils/rate-limiting';
 import { resolveStickerTokens, stripStickerTokens } from '~/shared/utils/sticker-token';
+import { MAX_CHAT_MEMBERS } from '~/shared/utils/chat';
 import { ChatMemberStatus, ChatMessageType, UserEngagementType } from '~/shared/utils/prisma/enums';
 import type { ChatAllMessages, ChatCreateChat } from '~/types/router';
 
 export const maxChats = 1000;
 export const maxChatsPerDay = 10;
-export const maxUsersPerChat = 10;
+export const maxUsersPerChat = MAX_CHAT_MEMBERS;
 
 // Message rate limiting — stricter for new accounts (< 7 days old)
 const newAccountAgeDays = 7;
@@ -102,51 +105,89 @@ const evaluateDmPolicies = async ({
   return { refused, filtered };
 };
 
-export const upsertChat = async ({
-  userIds,
-  isModerator,
-  isSupporter,
+/**
+ * Who out of `recipientIds` may actually be pulled into a conversation with
+ * `userId`, and which of them land in Requests rather than an inbox. Shared by
+ * chat creation and by adding members to an existing group, so a group invite
+ * cannot be used to route around a block or a DM policy that a new chat would
+ * have honoured.
+ */
+export const resolveChatRecipients = async ({
   userId,
-}: CreateChatInput & { userId: number; isModerator?: boolean; isSupporter?: boolean }) => {
-  const hash = getChatHash(userIds);
-  // filter out blocked users from userIds
+  recipientIds,
+  isModerator,
+}: {
+  userId: number;
+  recipientIds: number[];
+  isModerator?: boolean;
+}) => {
   const blockedUsers = await Promise.all([
     BlockedUsers.getCached({ userId }),
     BlockedByUsers.getCached({ userId }),
   ]);
-  const blockedUserIds = [...new Set(blockedUsers.flat().map((u) => u.id))];
-  userIds = userIds.filter((u) => !blockedUserIds.includes(u));
+  const blockedUserIds = new Set(blockedUsers.flat().map((u) => u.id));
+  let allowed = recipientIds.filter((u) => u !== userId && !blockedUserIds.has(u));
 
   // Apply each recipient's DM policy (mods bypass). Only `nobody` refuses; a
   // sender who fails a `following`/`mutuals` policy still gets a chat, it just
   // lands in the recipient's Requests instead of their inbox.
   let filteredIds = new Set<number>();
-  if (!isModerator) {
-    const { refused, filtered } = await evaluateDmPolicies({
-      userId,
-      recipientIds: userIds.filter((u) => u !== userId),
-    });
-    if (refused.size) userIds = userIds.filter((u) => !refused.has(u));
+  if (!isModerator && allowed.length) {
+    const { refused, filtered } = await evaluateDmPolicies({ userId, recipientIds: allowed });
+    if (refused.size) allowed = allowed.filter((u) => !refused.has(u));
     filteredIds = filtered;
   }
 
-  // `userIds` includes the creator; everyone else is a recipient. If every
-  // requested recipient was dropped (blocked, or not accepting chat), there is
-  // no one to talk to — surface a friendly error instead of silently creating
-  // a chat that only contains the creator.
-  const remainingRecipients = userIds.filter((u) => u !== userId);
-  if (remainingRecipients.length === 0) {
+  return { allowed, filteredIds };
+};
+
+/**
+ * A group name is user-authored text shown to every member, so it goes through
+ * the same blocklists as a message rather than being trusted because it is short.
+ */
+export const assertChatNameAllowed = async (name: string | null) => {
+  if (!name) return;
+  await throwOnBlockedLinkDomain(name);
+  await throwOnBlockedMessagePattern(name);
+};
+
+export const upsertChat = async ({
+  userIds,
+  isGroup,
+  name,
+  isModerator,
+  isSupporter,
+  userId,
+}: CreateChatInput & { userId: number; isModerator?: boolean; isSupporter?: boolean }) => {
+  const { allowed, filteredIds } = await resolveChatRecipients({
+    userId,
+    recipientIds: uniq(userIds),
+    isModerator,
+  });
+
+  // If every requested recipient was dropped (blocked, or not accepting chat),
+  // there is no one to talk to — surface a friendly error instead of silently
+  // creating a chat that only contains the creator.
+  if (allowed.length === 0) {
     throw throwBadRequestError('This user is not accepting chat requests');
   }
 
-  const existing = await dbWrite.chat.findFirst({
-    where: { hash },
-    select: {
-      ...singleChatSelect,
-      ...latestChat,
-    },
-    // select: { id: true },
-  });
+  userIds = [userId, ...allowed];
+  const identity = resolveChatIdentity({ userIds, isGroup });
+  const chatName = identity.isGroup ? normalizeChatName(name) : null;
+  await assertChatNameAllowed(chatName);
+
+  // A group's identity is its row id, so it never dedupes: asking for a group
+  // with people you already have a group with is a request for a second group.
+  const existing = identity.hash
+    ? await dbWrite.chat.findFirst({
+        where: { hash: identity.hash },
+        select: {
+          ...singleChatSelect,
+          ...latestChat,
+        },
+      })
+    : null;
 
   if (!!existing) {
     // Re-opening a chat still has to respect the recipient's policy. Returning
@@ -215,7 +256,12 @@ export const upsertChat = async ({
 
   const createdChat = await dbWrite.$transaction(async (tx) => {
     const newChat = await tx.chat.create({
-      data: { hash, ownerId: userId },
+      data: {
+        hash: identity.hash,
+        ownerId: userId,
+        isGroup: identity.isGroup,
+        name: chatName,
+      },
       select: { id: true, createdAt: true },
     });
 

--- a/src/server/services/user-payment-configuration.service.ts
+++ b/src/server/services/user-payment-configuration.service.ts
@@ -290,10 +290,6 @@ export async function createTipaltiPayee({ userId }: { userId: number }) {
   }
 }
 
-// Two spellings of the same terminal state, so a move between them is not a new rejection.
-const isBlockedTipaltiStatus = (status: string) =>
-  status === TipaltiStatus.Blocked || status === TipaltiStatus.BlockedByProvider;
-
 export async function updateByTipaltiAccount({
   tipaltiAccountId,
   tipaltiAccountStatus,

--- a/src/server/utils/chat-group.ts
+++ b/src/server/utils/chat-group.ts
@@ -1,0 +1,127 @@
+import { ChatMemberStatus } from '~/shared/utils/prisma/enums';
+import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
+import { getChatHash } from '~/server/utils/chat';
+import { activeMemberStatuses } from '~/shared/utils/chat';
+
+export type GroupChatLike = {
+  isGroup: boolean;
+  ownerId: number;
+};
+
+export type GroupMemberLike = {
+  id: number;
+  userId: number;
+  isOwner: boolean;
+  status: ChatMemberStatus;
+  createdAt: Date;
+  joinedAt?: Date | null;
+};
+
+export const isActiveMember = (member: Pick<GroupMemberLike, 'status'>) =>
+  activeMemberStatuses.includes(member.status);
+
+/**
+ * A group name is optional, so blank and absent have to mean the same thing —
+ * otherwise a cleared field stores `''` and renders as a nameless title bar
+ * rather than falling back to the member list.
+ */
+export const normalizeChatName = (name?: string | null) => {
+  const trimmed = name?.trim();
+  return trimmed?.length ? trimmed : null;
+};
+
+/**
+ * Identity of a new chat. A 1:1 keeps the member-set hash so re-opening a DM
+ * returns the existing thread; a group gets none, because two groups with the
+ * same people are two different groups.
+ */
+export const resolveChatIdentity = ({
+  userIds,
+  isGroup,
+}: {
+  userIds: number[];
+  isGroup?: boolean;
+}) => {
+  const group = isGroup ?? new Set(userIds).size > 2;
+  return { isGroup: group, hash: group ? null : getChatHash(userIds) };
+};
+
+/**
+ * Gate for every membership change only an admin may make: adding, removing and
+ * handing over the group. Moderators pass so they can unstick a group whose
+ * owner is gone.
+ */
+export const assertGroupAdmin = ({
+  chat,
+  actorId,
+  isModerator,
+}: {
+  chat: GroupChatLike;
+  actorId: number;
+  isModerator?: boolean;
+}) => {
+  if (!chat.isGroup) {
+    throw throwBadRequestError('This conversation is not a group chat');
+  }
+  if (chat.ownerId !== actorId && !isModerator) {
+    throw throwAuthorizationError('Only the group admin can manage members');
+  }
+};
+
+/**
+ * Seats are counted over active members only — a member who left or was removed
+ * has given theirs back.
+ */
+export const assertRoomForMembers = ({
+  members,
+  adding,
+  limit,
+}: {
+  members: Pick<GroupMemberLike, 'status'>[];
+  adding: number;
+  limit: number;
+}) => {
+  const occupied = members.filter(isActiveMember).length;
+  if (occupied + adding > limit) {
+    throw throwBadRequestError(`A group chat cannot have more than ${limit} members`);
+  }
+};
+
+export const assertCanPromote = ({
+  chat,
+  target,
+  actorId,
+  isModerator,
+}: {
+  chat: GroupChatLike;
+  target: Pick<GroupMemberLike, 'userId' | 'status' | 'isOwner'>;
+  actorId: number;
+  isModerator?: boolean;
+}) => {
+  assertGroupAdmin({ chat, actorId, isModerator });
+  if (target.isOwner) {
+    throw throwBadRequestError('This member is already the group admin');
+  }
+  if (target.status !== ChatMemberStatus.Joined) {
+    throw throwBadRequestError('Only a member who has joined the group can be made admin');
+  }
+};
+
+/**
+ * Who inherits a group when its admin leaves. Longest-joined first, so the
+ * group lands with whoever has been in it longest rather than whoever was
+ * invited most recently; ties break on member id to keep the choice stable.
+ */
+export const selectNextOwner = (
+  members: GroupMemberLike[],
+  leavingMemberId: number
+): GroupMemberLike | undefined => {
+  const seniority = (m: GroupMemberLike) => (m.joinedAt ?? m.createdAt).getTime();
+  const eligible = members.filter((m) => m.id !== leavingMemberId && isActiveMember(m));
+  const joined = eligible.filter((m) => m.status === ChatMemberStatus.Joined);
+  // Nobody has accepted yet: an invited member still beats leaving the group
+  // ownerless, since an ownerless group can never be administered again.
+  const pool = joined.length ? joined : eligible;
+
+  return [...pool].sort((a, b) => seniority(a) - seniority(b) || a.id - b.id)[0];
+};

--- a/src/shared/utils/chat.ts
+++ b/src/shared/utils/chat.ts
@@ -2,6 +2,12 @@ import { ChatMemberStatus, ChatNotifyLevel } from '~/shared/utils/prisma/enums';
 
 export type ChatBucket = 'Inbox' | 'Requests' | 'Archived';
 
+/** A membership that still occupies a seat and can still read the conversation. */
+export const activeMemberStatuses: ChatMemberStatus[] = [
+  ChatMemberStatus.Invited,
+  ChatMemberStatus.Joined,
+];
+
 const archivedStatuses: ChatMemberStatus[] = [
   ChatMemberStatus.Ignored,
   ChatMemberStatus.Left,
@@ -31,6 +37,13 @@ export function chatBucketFor(member: {
  * not see.
  */
 export const MAX_CHAT_MESSAGE_LENGTH = 2000;
+
+/**
+ * Seat cap for a conversation, shared by the server guard and the member
+ * pickers so the UI stops at the same number the API refuses at. Here rather
+ * than in `chat.service` because the pickers are client components.
+ */
+export const MAX_CHAT_MEMBERS = 10;
 
 /**
  * Whether an incoming message should ring for a member, given their


### PR DESCRIPTION
Group chats now carry their own identity — `Chat.isGroup` plus an optional `name`, with `hash` nullable so a group is keyed by row id instead of its member set, letting membership change and letting two groups hold the same people. The chat owner acts as admin, able to add and remove members, rename the group, and hand admin over, with a `ChatRoomUpdated` signal so renames land on everyone else's list.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868kv2rht`). Reviewed locally before push.