### PR TITLE
fix(image-feed): BitDex served drafts to a creator who asked for scheduled

### DIFF
--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:3968':
+  'server/services/image.service.ts:3985':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4098':
+  'server/services/image.service.ts:4115':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4810':
+  'server/services/image.service.ts:4827':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5924':
+  'server/services/image.service.ts:5941':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -206,7 +206,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4098')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4115')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/services/__tests__/bitdex-scheduled-content.test.ts
+++ b/src/server/services/__tests__/bitdex-scheduled-content.test.ts
@@ -521,6 +521,54 @@ describe('BitDex primary feed — content is not served before its publish time'
     expect(ids).toContain(202);
   });
 
+  it('opting in with `scheduled` surfaces scheduled work and STILL holds back drafts', async () => {
+    // ClickUp 868kt9y1w, BitDex half. `scheduled` sets `wantsUnpublished`, which
+    // skips the publication guard on this merge entirely — so a creator who asked
+    // for their scheduled posts also received every never-published draft they own.
+    // Same symptom the Meili builders had.
+    //
+    // Both docs arrive through the own-excluded pass together, which is the point:
+    // the opt-in has to separate them rather than admit or refuse the pair. 202 is
+    // scheduled (future `sortAt`), 404 is a draft (`publishedAt: null`).
+    queryBitdexMock.mockImplementation(async (_index: string, filters: unknown) =>
+      isOwnExcludedQuery(filters) ? page([rescheduledDoc, neverPublishedDoc]) : page([publishedDoc])
+    );
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID,
+      scheduled: true,
+    });
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    // Asserted on IDs rather than a count: `getInfinite({ids})` is known to drop
+    // its ids and return the global feed, so a count here could pass against a
+    // result that is not this query's at all.
+    expect(ids).toContain(101);
+    expect(ids).toContain(202);
+    expect(ids).not.toContain(404);
+  });
+
+  it('a moderator’s own-excluded merge is unchanged by that rule', async () => {
+    // The control. The fix is scoped to non-moderators — a moderator's `scheduled`
+    // request is declined outright so Meili answers it (see the tests above), and
+    // their own unpublished content still arrives through this pass. Without this,
+    // narrowing the moderator branch too would keep the test above green while
+    // silently changing what #4148 deliberately built.
+    queryBitdexMock.mockImplementation(async (_index: string, filters: unknown) =>
+      isOwnExcludedQuery(filters) ? page([neverPublishedDoc]) : page([publishedDoc])
+    );
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID,
+      isModerator: true,
+    });
+    const ids = result.data.map((i: { id: number }) => i.id);
+
+    expect(ids).toContain(404);
+  });
+
   it('stops skipping emptied pages at the bound instead of walking forever', async () => {
     // The pagination test above proves the ALLOWANCE; this proves the BOUND.
     // Without it, deleting the `emptiedPages < MAX_EMPTIED_PAGES` condition

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3833,6 +3833,23 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
     if (!wantsUnpublished && (!input.isModerator || input.publishedOnly)) {
       const mergeNow = Date.now();
       ownDocs = ownDocs.filter((d) => isPublicallyPublished(d, mergeNow, stats));
+    } else if (wantsUnpublished && !input.isModerator) {
+      // `scheduled` is a non-moderator's ONLY opt-in here, and it means scheduled —
+      // not "everything unpublished". The BitDex query cannot draw that line
+      // (`isPublished = false` carries both, see the own-excluded scope above), so it
+      // is drawn on the way out, where `publishedAtUnix` still separates a
+      // never-published draft (null) from one whose time has not come (future).
+      //
+      // Equivalent to what the two Meili builders now emit: their arms are
+      // `publishedAtUnix <= snappedNow` and `(userId = me AND publishedAtUnix >
+      // snappedNow)`, whose union is exactly "the field exists". Both backends
+      // therefore answer `scheduled` the same way, which is the property the
+      // `wantsUnpublished` comment above exists to protect.
+      ownDocs = ownDocs.filter((d) => {
+        if (d.publishedAtUnix != null) return true;
+        stats.publicationHolds++;
+        return false;
+      });
     }
 
     if (ownDocs.length) {


### PR DESCRIPTION
The BitDex half of ClickUp [868kt9y1w](https://app.clickup.com/t/868kt9y1w). Approved by Justin: *"As long as this makes it so that it agrees with meili, we're good."*

Sibling of #4331, which fixes the same user-visible bug on the Meilisearch path. **Not stacked** — this is based directly on `main`.

## The bug

`scheduled` sets `wantsUnpublished`, and `wantsUnpublished` skips the publication guard on the own-excluded merge (`image.service.ts:3817`) **entirely**. So a creator who opted in to see their scheduled posts also received every never-published draft they own — drafts, bounty entry uploads, storage posts, orphans.

Same symptom users reported on the Meili path: turn Scheduled on, get a gallery full of work you never posted.

Owner-only. Nothing leaks to anyone else.

## Why it was not caught by the existing gate

The BitDex **query** genuinely cannot draw this line — `isPublished = false` carries both scheduled and never-published, with no separate signal, and the comment at `:3558` says so. The unified gate was a correct reading of what the query can express.

What it missed is that the **application** can still tell them apart after the fact: `publishedAtUnix` is `null` for a draft and in the future for a scheduled post. `isPublicallyPublished` already relies on exactly that distinction a few lines up. So the line gets drawn on the way out instead of in the query.

## The fix

```ts
} else if (wantsUnpublished && !input.isModerator) {
  ownDocs = ownDocs.filter((d) => {
    if (d.publishedAtUnix != null) return true;
    stats.publicationHolds++;
    return false;
  });
}
```

**The equivalence to Meili is exact, which is the point.** The two Meili builders emit `publishedAtUnix <= snappedNow` and `(userId = me AND publishedAtUnix > snappedNow)`. The union of those two arms is precisely *"the field exists"* — which is `publishedAtUnix != null`. Both backends now answer `scheduled` identically, which is the property the `wantsUnpublished` comment above it exists to protect.

**Scoped to non-moderators.** A moderator's `scheduled` request is declined outright so Meili answers it, and their own unpublished content still arrives through this pass — #4148 built that deliberately. There is a control test pinning it, because narrowing the moderator branch too would keep the main assertion green while silently undoing that work.

## Verification

**Revert control:**

```
Tests  1 failed | 19 passed (20)
AssertionError: expected [ 202, 101, 404 ] to not include 404
```

404 is the draft that leaked. 202 is still present, so the opt-in itself still works — the test is not passing by refusing everything. The other 19, including the moderator control, keep passing.

The test routes both documents through the own-excluded pass **together**, which is the case that matters: the opt-in has to separate them, not admit or refuse the pair. It asserts on IDs rather than a count, because `getInfinite({ids})` is known to drop its ids and return the global feed — I confirmed that live against prod today, so a count here could pass against a result that is not this query's at all.

Full suite on this branch:

```
Test Files  2 failed | 1376 passed | 1 skipped (1379)
Tests       7 failed | 21619 passed | 27 skipped (21653)
```

**Those 7 failures are pre-existing on `main` and not from this change.** Control — the same full suite on unmodified `origin/main` in the same worktree:

```
Test Files  2 failed | 1381 passed | 1 skipped (1384)
Tests       7 failed | 21744 passed | 27 skipped (21778)
```

Same two files (`user-payment-configuration.tipalti-status.test.ts`, `home-block-fetch-sizing.test.ts`), same seven tests, with no diff of mine present at all. Both totals account for every file. Those two files also pass `39 passed (39)` twice when run alone on a quiet box, so they are flaky under full-suite parallelism rather than broken — filed separately rather than fixed here.

`pnpm run typecheck` 0 errors. The 3 eslint errors in `image.service.ts` are at 204 / 4780 / 6685 and are pre-existing; none is in this diff.

## Why `flipt-eval-context.test.ts` is in the diff

Its ledger pins Flipt call sites by `file:LINE`, and this insertion shifted four `image.service.ts` rows by +17. Line numbers updated; **no Flipt behaviour changed**. That gate fails in a file your diff never touched, which reads like a broken `main` — run it before the full suite, not after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Re-verified after rebase (2026-08-24)

This PR went `CONFLICTING / DIRTY` the moment #4331 merged — both edit the same four `image.service.ts` ledger rows in `flipt-eval-context.test.ts`, so merging either guarantees conflicting the other. `image.service.ts` itself auto-merged cleanly both times; the conflict carries no information about the changes.

Rebased onto current `main`, ledger re-pointed +17 (`3968→3985`, `4098→4115`, `4810→4827`, `5924→5941`) from the numbers the gate itself printed. **Current SHA `9ab286429e`** — the earlier `3c288970cb` no longer exists.

Full suite on the rebased branch:

```
Test Files  1390 passed | 1 skipped (1391)
Tests       21796 passed | 27 skipped (21823)
```

1390 + 1 = 1391, so every file is accounted for. Zero `ELIFECYCLE`, exit 0 read from the printed line rather than the harness notification. The two files noted above as pre-existing flakes (`user-payment-configuration.tipalti-status`, `home-block-fetch-sizing`) passed in this run.
