### PR TITLE
fix(blocklist): scope every write to (id, type) and take the row lock

### DIFF
--- a/apps/moderator/src/lib/server/__tests__/blocklist-remove.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/blocklist-remove.test.ts
@@ -1,28 +1,38 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * `removeBlocklistItems` used to return void while its caller reported `count: items.length` — the
- * number SUBMITTED. So a removal that matched nothing still rendered "Removed 1 item." above a chip
- * that was still there. These pin the count against what the row actually lost.
+ * Two properties of the blocklist writers, neither visible from the page:
+ *
+ * 1. The count reported is what the row actually LOST, not what was submitted. It used to return
+ *    void while the caller reported `items.length`, so a removal that matched nothing still
+ *    rendered "Removed 1 item." above a chip that was still there.
+ * 2. Every statement is scoped to (id, type), not to id alone. The posted id and the posted type
+ *    are independent form fields; without the type predicate a hand-crafted post merges one type's
+ *    entries into another type's row.
  */
 
 type Call = [string, unknown[]];
 
-/** Rows keyed by id, so a query scoped to the wrong id resolves to nothing rather than passing. */
-let rows: Record<number, string[]>;
+let rows: Record<number, { type: string; data: string[] }>;
 const updateSpy = vi.fn();
 const setSpy = vi.fn();
+/** Set by the SELECT chain, so a read that stops taking the row lock is visible here. */
+let lockedReads = 0;
 
 const wheres = (calls: Call[]) => calls.filter(([m]) => m === 'where').map(([, a]) => a);
-const scopedId = (calls: Call[]) => {
-  const match = wheres(calls).find(([column, op]) => column === 'id' && op === '=');
-  return match?.[2] as number | undefined;
-};
+const scope = (calls: Call[]) => ({
+  id: wheres(calls).find(([column, op]) => column === 'id' && op === '=')?.[2] as
+    | number
+    | undefined,
+  type: wheres(calls).find(([column, op]) => column === 'type' && op === '=')?.[2] as
+    | string
+    | undefined,
+});
 
 function chain(record: (calls: Call[]) => void, resolve: (calls: Call[]) => unknown) {
   const calls: Call[] = [];
   const builder: Record<string, unknown> = {};
-  for (const method of ['select', 'set', 'where', 'orderBy', 'returning']) {
+  for (const method of ['select', 'set', 'where', 'orderBy', 'returning', 'forUpdate', 'values']) {
     builder[method] = (...args: unknown[]) => {
       calls.push([method, args]);
       return builder;
@@ -36,72 +46,122 @@ function chain(record: (calls: Call[]) => void, resolve: (calls: Call[]) => unkn
   builder.executeTakeFirstOrThrow = settle;
   builder.execute = async () => {
     record(calls);
-    const id = scopedId(calls);
-    // `readBlocklistRow` selects by TYPE, not id, and expects an array.
-    return id === undefined
-      ? Object.entries(rows).map(([rowId, data]) => ({
-          id: Number(rowId),
-          type: 'EmailDomain',
-          data,
-        }))
-      : [];
+    const { id, type } = scope(calls);
+    // `readBlocklistRow` selects by TYPE with no id, and expects an array.
+    if (id !== undefined) return [];
+    return Object.entries(rows)
+      .filter(([, row]) => row.type === type)
+      .map(([rowId, row]) => ({ id: Number(rowId), type: row.type, data: row.data }));
   };
   return builder;
 }
 
+/** Resolves a row the way the emitted SQL would: only the predicates actually present apply. */
+const findRow = (calls: Call[]) => {
+  const { id, type } = scope(calls);
+  if (id === undefined) return undefined;
+  const row = rows[id];
+  if (!row) return undefined;
+  if (type !== undefined && row.type !== type) return undefined;
+  return row;
+};
+
+const selectFrom = () =>
+  chain(
+    (calls) => {
+      if (calls.some(([m]) => m === 'forUpdate')) lockedReads += 1;
+    },
+    (calls) => {
+      const row = findRow(calls);
+      return row ? { data: row.data } : undefined;
+    }
+  );
+
+const updateTable = () =>
+  chain(
+    (calls) => updateSpy(calls),
+    (calls) => {
+      const { id } = scope(calls);
+      const row = findRow(calls);
+      expect(row, 'an UPDATE here must resolve to exactly one row').toBeDefined();
+      const set = calls.find(([m]) => m === 'set')?.[1][0] as { data: string[] };
+      rows[id as number] = { type: (row as { type: string }).type, data: set.data };
+      return { id, type: (row as { type: string }).type, data: set.data };
+    }
+  );
+
+const insertInto = () =>
+  chain(
+    () => undefined,
+    (calls) => {
+      const values = calls.find(([m]) => m === 'values')?.[1][0] as {
+        type: string;
+        data: string[];
+      };
+      const id = Math.max(0, ...Object.keys(rows).map(Number)) + 1;
+      rows[id] = { type: values.type, data: values.data };
+      return { id, type: values.type, data: values.data };
+    }
+  );
+
+const client = { selectFrom, updateTable, insertInto };
+
 vi.mock('../db', () => ({
   dbRead: {},
   dbWrite: {
-    selectFrom: () =>
-      chain(
-        () => undefined,
-        (calls) => {
-          const id = scopedId(calls);
-          return id !== undefined && rows[id] ? { data: rows[id] } : undefined;
-        }
-      ),
-    updateTable: () =>
-      chain(
-        (calls) => updateSpy(calls),
-        (calls) => {
-          const id = scopedId(calls);
-          expect(id, 'an UPDATE here must be scoped to a single row').toBeDefined();
-          const set = calls.find(([m]) => m === 'set')?.[1][0] as { data: string[] };
-          rows[id as number] = set.data;
-          return { id, type: 'EmailDomain', data: set.data };
-        }
-      ),
+    ...client,
+    transaction: () => ({
+      execute: async (cb: (trx: typeof client) => unknown) => cb(client),
+    }),
   },
 }));
 
 vi.mock('../redis', () => ({ getRedis: () => ({ get: async () => null, set: setSpy }) }));
 vi.mock('../axiom', () => ({ logToAxiom: vi.fn() }));
 
-const { removeBlocklistItems } = await import('../blocklist.service');
+const { removeBlocklistItems, upsertBlocklist, BlocklistRowMismatchError } = await import(
+  '../blocklist.service'
+);
 
 beforeEach(() => {
   vi.clearAllMocks();
-  rows = { 1: ['spam.example', 'junk.example', 'trash.example'] };
+  lockedReads = 0;
+  rows = {
+    1: { type: 'EmailDomain', data: ['spam.example', 'junk.example', 'trash.example'] },
+    4: { type: 'MessagePattern', data: ['unfreeze your funds'] },
+  };
 });
 
 describe('removeBlocklistItems', () => {
   it('returns how many entries the row actually lost', async () => {
-    const removed = await removeBlocklistItems({ id: 1, items: ['spam.example'] });
+    const removed = await removeBlocklistItems({
+      id: 1,
+      type: 'EmailDomain',
+      items: ['spam.example'],
+    });
 
     expect(removed).toBe(1);
-    expect(rows[1]).toEqual(['junk.example', 'trash.example']);
+    expect(rows[1].data).toEqual(['junk.example', 'trash.example']);
   });
 
   it('returns 0 for an entry that is not on the list, and writes nothing', async () => {
-    const removed = await removeBlocklistItems({ id: 1, items: ['never-added.example'] });
+    const removed = await removeBlocklistItems({
+      id: 1,
+      type: 'EmailDomain',
+      items: ['never-added.example'],
+    });
 
     expect(removed).toBe(0);
     expect(updateSpy).not.toHaveBeenCalled();
-    expect(rows[1]).toHaveLength(3);
+    expect(rows[1].data).toHaveLength(3);
   });
 
   it('returns 0 for a stale row id rather than reporting the submitted count', async () => {
-    const removed = await removeBlocklistItems({ id: 999, items: ['spam.example'] });
+    const removed = await removeBlocklistItems({
+      id: 999,
+      type: 'EmailDomain',
+      items: ['spam.example'],
+    });
 
     expect(removed).toBe(0);
     expect(updateSpy).not.toHaveBeenCalled();
@@ -110,6 +170,7 @@ describe('removeBlocklistItems', () => {
   it('counts only the entries that were present, not the whole submission', async () => {
     const removed = await removeBlocklistItems({
       id: 1,
+      type: 'EmailDomain',
       items: ['spam.example', 'never-added.example'],
     });
 
@@ -117,8 +178,53 @@ describe('removeBlocklistItems', () => {
   });
 
   it('does not re-cache when nothing was removed', async () => {
-    await removeBlocklistItems({ id: 1, items: ['never-added.example'] });
+    await removeBlocklistItems({ id: 1, type: 'EmailDomain', items: ['never-added.example'] });
 
     expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses an id that belongs to a different type, leaving that row untouched', async () => {
+    const removed = await removeBlocklistItems({
+      id: 1,
+      type: 'MessagePattern',
+      items: ['spam.example'],
+    });
+
+    expect(removed).toBe(0);
+    expect(rows[1].data).toEqual(['spam.example', 'junk.example', 'trash.example']);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('reads the row under a lock, so an overlapping removal cannot restore what it dropped', async () => {
+    await removeBlocklistItems({ id: 1, type: 'EmailDomain', items: ['spam.example'] });
+
+    expect(lockedReads, 'the read before the filtered write must be FOR UPDATE').toBe(1);
+  });
+});
+
+describe('upsertBlocklist', () => {
+  it('merges into the row when the id and type agree', async () => {
+    await upsertBlocklist({ id: 1, type: 'EmailDomain', blocklist: ['New.Example'] });
+
+    expect(rows[1].data).toEqual(['spam.example', 'junk.example', 'trash.example', 'new.example']);
+  });
+
+  it('refuses an id belonging to another type instead of merging across lists', async () => {
+    await expect(
+      upsertBlocklist({ id: 1, type: 'MessagePattern', blocklist: ['unfreeze your funds'] })
+    ).rejects.toBeInstanceOf(BlocklistRowMismatchError);
+
+    expect(rows[1].data, 'the EmailDomain row must not gain a message pattern').toEqual([
+      'spam.example',
+      'junk.example',
+      'trash.example',
+    ]);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('reads the row under a lock before merging', async () => {
+    await upsertBlocklist({ id: 1, type: 'EmailDomain', blocklist: ['new.example'] });
+
+    expect(lockedReads, 'the read before the merged write must be FOR UPDATE').toBe(1);
   });
 });

--- a/apps/moderator/src/lib/server/__tests__/blocklist-remove.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/blocklist-remove.test.ts
@@ -1,23 +1,32 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * Two properties of the blocklist writers, neither visible from the page:
+ * Four properties of the blocklist writers, none of them visible from the page:
  *
- * 1. The count reported is what the row actually LOST, not what was submitted. It used to return
- *    void while the caller reported `items.length`, so a removal that matched nothing still
- *    rendered "Removed 1 item." above a chip that was still there.
+ * 1. The count reported is what the row actually GAINED or LOST, not what was submitted.
  * 2. Every statement is scoped to (id, type), not to id alone. The posted id and the posted type
  *    are independent form fields; without the type predicate a hand-crafted post merges one type's
  *    entries into another type's row.
+ * 3. The locked read and the write run inside ONE transaction. A lock taken by a transaction that
+ *    has already committed is inert.
+ * 4. The write BUSTS the shared Redis key rather than rewriting it, because writing a snapshot is
+ *    itself an unserialised read-modify-write over the artifact every reader enforces from.
  */
 
 type Call = [string, unknown[]];
+type On = 'dbWrite' | 'trx';
 
 let rows: Record<number, { type: string; data: string[] }>;
-const updateSpy = vi.fn();
+const updateSpy = vi.fn<(arg: { on: On; wheres: unknown[][] }) => void>();
+const insertSpy = vi.fn<(arg: { on: On; type: string; data: string[] }) => void>();
 const setSpy = vi.fn();
-/** Set by the SELECT chain, so a read that stops taking the row lock is visible here. */
-let lockedReads = 0;
+const delSpy = vi.fn();
+/** Which client each locked read ran on. Empty means a read stopped taking the row lock at all. */
+let lockedReads: On[] = [];
+/** How many transactions were opened. Zero means the statements ran outside one. */
+let transactions = 0;
+/** An UPDATE whose predicates resolved no row — recorded, never asserted inside the resolver. */
+let unscopedUpdates = 0;
 
 const wheres = (calls: Call[]) => calls.filter(([m]) => m === 'where').map(([, a]) => a);
 const scope = (calls: Call[]) => ({
@@ -46,51 +55,56 @@ function chain(record: (calls: Call[]) => void, resolve: (calls: Call[]) => unkn
   builder.executeTakeFirstOrThrow = settle;
   builder.execute = async () => {
     record(calls);
-    const { id, type } = scope(calls);
-    // `readBlocklistRow` selects by TYPE with no id, and expects an array.
-    if (id !== undefined) return [];
-    return Object.entries(rows)
-      .filter(([, row]) => row.type === type)
-      .map(([rowId, row]) => ({ id: Number(rowId), type: row.type, data: row.data }));
+    return matching(calls).map(([id, row]) => ({ id, type: row.type, data: row.data }));
   };
   return builder;
 }
 
-/** Resolves a row the way the emitted SQL would: only the predicates actually present apply. */
-const findRow = (calls: Call[]) => {
+/**
+ * Rows the emitted SQL would match: ONLY the predicates actually present apply, in id order. A fake
+ * that refused a row for some other reason would let a dropped predicate pass for the wrong cause.
+ */
+function matching(calls: Call[]): [number, { type: string; data: string[] }][] {
   const { id, type } = scope(calls);
-  if (id === undefined) return undefined;
-  const row = rows[id];
-  if (!row) return undefined;
-  if (type !== undefined && row.type !== type) return undefined;
-  return row;
-};
+  return Object.entries(rows)
+    .map(([rowId, row]) => [Number(rowId), row] as [number, { type: string; data: string[] }])
+    .filter(
+      ([rowId, row]) =>
+        (id === undefined || rowId === id) && (type === undefined || row.type === type)
+    )
+    .sort((a, b) => a[0] - b[0]);
+}
 
-const selectFrom = () =>
+const selectFrom = (on: On) =>
   chain(
     (calls) => {
-      if (calls.some(([m]) => m === 'forUpdate')) lockedReads += 1;
+      if (calls.some(([m]) => m === 'forUpdate')) lockedReads.push(on);
     },
     (calls) => {
-      const row = findRow(calls);
-      return row ? { data: row.data } : undefined;
+      const [first] = matching(calls);
+      return first ? { id: first[0], data: first[1].data } : undefined;
     }
   );
 
-const updateTable = () =>
+const updateTable = (on: On) =>
   chain(
-    (calls) => updateSpy(calls),
+    (calls) => updateSpy({ on, wheres: wheres(calls) }),
     (calls) => {
-      const { id } = scope(calls);
-      const row = findRow(calls);
-      expect(row, 'an UPDATE here must resolve to exactly one row').toBeDefined();
+      const [first] = matching(calls);
+      // Counted, not asserted: an `expect` inside a resolver throws THROUGH the service, so the
+      // failure surfaces as a service error at an unrelated call site instead of as an assertion.
+      if (!first) {
+        unscopedUpdates += 1;
+        return undefined;
+      }
+      const [id, row] = first;
       const set = calls.find(([m]) => m === 'set')?.[1][0] as { data: string[] };
-      rows[id as number] = { type: (row as { type: string }).type, data: set.data };
-      return { id, type: (row as { type: string }).type, data: set.data };
+      rows[id] = { type: row.type, data: set.data };
+      return { id, type: row.type, data: set.data };
     }
   );
 
-const insertInto = () =>
+const insertInto = (on: On) =>
   chain(
     () => undefined,
     (calls) => {
@@ -98,25 +112,45 @@ const insertInto = () =>
         type: string;
         data: string[];
       };
+      insertSpy({ on, type: values.type, data: values.data });
       const id = Math.max(0, ...Object.keys(rows).map(Number)) + 1;
       rows[id] = { type: values.type, data: values.data };
       return { id, type: values.type, data: values.data };
     }
   );
 
-const client = { selectFrom, updateTable, insertInto };
+/**
+ * 🔴 The transaction client is a DISTINCT object from `dbWrite`, and every statement records which
+ * one it ran on. With ONE shared object the fake cannot tell `trx.selectFrom` from
+ * `dbWrite.selectFrom` — so deleting the `dbWrite.transaction().execute(...)` wrapper and running
+ * the same statements on the bare client left every test green with the atomicity fix fully
+ * reverted. A lock held by a transaction that has already committed is inert, and that is exactly
+ * the shape that reads as fixed and is not.
+ */
+const clientFor = (on: On) => ({
+  selectFrom: () => selectFrom(on),
+  updateTable: () => updateTable(on),
+  insertInto: () => insertInto(on),
+});
+
+const trxClient = clientFor('trx');
 
 vi.mock('../db', () => ({
   dbRead: {},
   dbWrite: {
-    ...client,
+    ...clientFor('dbWrite'),
     transaction: () => ({
-      execute: async (cb: (trx: typeof client) => unknown) => cb(client),
+      execute: async (cb: (trx: unknown) => unknown) => {
+        transactions += 1;
+        return cb(trxClient);
+      },
     }),
   },
 }));
 
-vi.mock('../redis', () => ({ getRedis: () => ({ get: async () => null, set: setSpy }) }));
+vi.mock('../redis', () => ({
+  getRedis: () => ({ get: async () => null, set: setSpy, del: delSpy }),
+}));
 vi.mock('../axiom', () => ({ logToAxiom: vi.fn() }));
 
 const { removeBlocklistItems, upsertBlocklist, BlocklistRowMismatchError } = await import(
@@ -125,88 +159,137 @@ const { removeBlocklistItems, upsertBlocklist, BlocklistRowMismatchError } = awa
 
 beforeEach(() => {
   vi.clearAllMocks();
-  lockedReads = 0;
+  lockedReads = [];
+  transactions = 0;
+  unscopedUpdates = 0;
   rows = {
     1: { type: 'EmailDomain', data: ['spam.example', 'junk.example', 'trash.example'] },
     4: { type: 'MessagePattern', data: ['unfreeze your funds'] },
   };
 });
 
+/** Both writers must satisfy these, so they are asserted for each rather than for one. */
+const expectLockedInsideOneTransaction = () => {
+  expect(transactions, 'the statements must run inside a transaction').toBe(1);
+  expect(lockedReads, 'the read must be FOR UPDATE, on the transaction client').toEqual(['trx']);
+  expect(unscopedUpdates, 'no UPDATE may resolve a row its predicates should exclude').toBe(0);
+  expect(updateSpy.mock.calls.map(([arg]) => arg.on)).not.toContain('dbWrite');
+};
+
 describe('removeBlocklistItems', () => {
   it('returns how many entries the row actually lost', async () => {
-    const removed = await removeBlocklistItems({
+    const { count } = await removeBlocklistItems({
       id: 1,
       type: 'EmailDomain',
       items: ['spam.example'],
     });
 
-    expect(removed).toBe(1);
+    expect(count).toBe(1);
     expect(rows[1].data).toEqual(['junk.example', 'trash.example']);
+    expectLockedInsideOneTransaction();
+  });
+
+  it('scopes the UPDATE to the type as well as the id', async () => {
+    await removeBlocklistItems({ id: 1, type: 'EmailDomain', items: ['spam.example'] });
+
+    // The UPDATE runs only after the scoped SELECT already matched, so the fake resolves the same
+    // row with or without this predicate. Nothing but reading the statement can see it.
+    expect(updateSpy.mock.calls[0][0].wheres).toEqual([
+      ['id', '=', 1],
+      ['type', '=', 'EmailDomain'],
+    ]);
   });
 
   it('returns 0 for an entry that is not on the list, and writes nothing', async () => {
-    const removed = await removeBlocklistItems({
+    const { count } = await removeBlocklistItems({
       id: 1,
       type: 'EmailDomain',
       items: ['never-added.example'],
     });
 
-    expect(removed).toBe(0);
+    expect(count).toBe(0);
     expect(updateSpy).not.toHaveBeenCalled();
     expect(rows[1].data).toHaveLength(3);
   });
 
   it('returns 0 for a stale row id rather than reporting the submitted count', async () => {
-    const removed = await removeBlocklistItems({
+    const { count } = await removeBlocklistItems({
       id: 999,
       type: 'EmailDomain',
       items: ['spam.example'],
     });
 
-    expect(removed).toBe(0);
+    expect(count).toBe(0);
     expect(updateSpy).not.toHaveBeenCalled();
   });
 
   it('counts only the entries that were present, not the whole submission', async () => {
-    const removed = await removeBlocklistItems({
+    const { count } = await removeBlocklistItems({
       id: 1,
       type: 'EmailDomain',
       items: ['spam.example', 'never-added.example'],
     });
 
-    expect(removed).toBe(1);
-  });
-
-  it('does not re-cache when nothing was removed', async () => {
-    await removeBlocklistItems({ id: 1, type: 'EmailDomain', items: ['never-added.example'] });
-
-    expect(setSpy).not.toHaveBeenCalled();
+    expect(count).toBe(1);
   });
 
   it('refuses an id that belongs to a different type, leaving that row untouched', async () => {
-    const removed = await removeBlocklistItems({
+    const { count } = await removeBlocklistItems({
       id: 1,
       type: 'MessagePattern',
       items: ['spam.example'],
     });
 
-    expect(removed).toBe(0);
+    expect(count).toBe(0);
     expect(rows[1].data).toEqual(['spam.example', 'junk.example', 'trash.example']);
     expect(updateSpy).not.toHaveBeenCalled();
-  });
-
-  it('reads the row under a lock, so an overlapping removal cannot restore what it dropped', async () => {
-    await removeBlocklistItems({ id: 1, type: 'EmailDomain', items: ['spam.example'] });
-
-    expect(lockedReads, 'the read before the filtered write must be FOR UPDATE').toBe(1);
   });
 });
 
 describe('upsertBlocklist', () => {
-  it('merges into the row when the id and type agree', async () => {
-    await upsertBlocklist({ id: 1, type: 'EmailDomain', blocklist: ['New.Example'] });
+  it('merges into the row when the id and type agree, and counts what it gained', async () => {
+    const { count } = await upsertBlocklist({
+      id: 1,
+      type: 'EmailDomain',
+      blocklist: ['New.Example'],
+    });
 
+    expect(count).toBe(1);
     expect(rows[1].data).toEqual(['spam.example', 'junk.example', 'trash.example', 'new.example']);
+    expectLockedInsideOneTransaction();
+  });
+
+  it('reports what the row GAINED, not what was submitted', async () => {
+    // Two of the three are already on the list. Reporting 3 is the "the screen says it happened"
+    // defect the removal count was fixed for, on the other half of the same page.
+    const { count } = await upsertBlocklist({
+      id: 1,
+      type: 'EmailDomain',
+      blocklist: ['spam.example', 'junk.example', 'new.example'],
+    });
+
+    expect(count).toBe(1);
+  });
+
+  it('reports 0 and writes nothing when every entry is already on the list', async () => {
+    const { count } = await upsertBlocklist({
+      id: 1,
+      type: 'EmailDomain',
+      blocklist: ['spam.example'],
+    });
+
+    expect(count).toBe(0);
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(delSpy).not.toHaveBeenCalled();
+  });
+
+  it('scopes the UPDATE to the type as well as the id', async () => {
+    await upsertBlocklist({ id: 1, type: 'EmailDomain', blocklist: ['new.example'] });
+
+    expect(updateSpy.mock.calls[0][0].wheres).toEqual([
+      ['id', '=', 1],
+      ['type', '=', 'EmailDomain'],
+    ]);
   });
 
   it('refuses an id belonging to another type instead of merging across lists', async () => {
@@ -220,11 +303,70 @@ describe('upsertBlocklist', () => {
       'trash.example',
     ]);
     expect(updateSpy).not.toHaveBeenCalled();
+    expect(delSpy).not.toHaveBeenCalled();
   });
 
-  it('reads the row under a lock before merging', async () => {
-    await upsertBlocklist({ id: 1, type: 'EmailDomain', blocklist: ['new.example'] });
+  it('merges into the existing row of the type when no id was posted', async () => {
+    // `UsernameExact` is a tab with no row in production, so its adds arrive with no `id` — and an
+    // unconditional insert there gives the type a second row whose entries are never enforced.
+    // The same shape reaches every other tab from a stale form.
+    const { count } = await upsertBlocklist({ type: 'EmailDomain', blocklist: ['new.example'] });
 
-    expect(lockedReads, 'the read before the merged write must be FOR UPDATE').toBe(1);
+    expect(count).toBe(1);
+    expect(
+      insertSpy,
+      'a type that already has a row must not gain a second'
+    ).not.toHaveBeenCalled();
+    expect(rows[1].data).toContain('new.example');
+    expect(Object.keys(rows)).toHaveLength(2);
+  });
+
+  it('inserts only when the type genuinely has no row', async () => {
+    const { count } = await upsertBlocklist({ type: 'UsernameExact', blocklist: ['Scammer'] });
+
+    expect(count).toBe(1);
+    expect(insertSpy).toHaveBeenCalledWith({
+      on: 'trx',
+      type: 'UsernameExact',
+      data: ['scammer'],
+    });
+  });
+});
+
+describe('the shared cache key', () => {
+  it('is DELETED, never rewritten with a snapshot', async () => {
+    // A snapshot write is an unserialised read-modify-write over the artifact every reader
+    // enforces from, so two edits the row lock correctly serialised can still land their cache
+    // writes in the other order and leave the loser's list under a month TTL. Deletes commute.
+    await removeBlocklistItems({ id: 1, type: 'EmailDomain', items: ['spam.example'] });
+
+    expect(delSpy).toHaveBeenCalledWith('system:blocklist:EmailDomain');
+    expect(
+      setSpy,
+      'a write must not repopulate the key it just invalidated'
+    ).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed bust instead of throwing over a committed write', async () => {
+    // The row is already written. Throwing here tells the operator the write failed, and their
+    // retry then finds the entry gone, gets "Nothing was removed", and reloads onto the stale
+    // cache showing the chip still present.
+    delSpy.mockRejectedValueOnce(new Error('redis down'));
+
+    const { count, cacheStale } = await removeBlocklistItems({
+      id: 1,
+      type: 'EmailDomain',
+      items: ['junk.example'],
+    });
+
+    expect(count).toBe(1);
+    expect(cacheStale).toBe(true);
+    expect(rows[1].data, 'the row still lost the entry').not.toContain('junk.example');
+  });
+
+  it('is not busted when the write changed nothing', async () => {
+    await removeBlocklistItems({ id: 1, type: 'EmailDomain', items: ['never-added.example'] });
+
+    expect(delSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/moderator/src/lib/server/__tests__/blocklist-remove.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/blocklist-remove.test.ts
@@ -27,6 +27,8 @@ let lockedReads: On[] = [];
 let transactions = 0;
 /** An UPDATE whose predicates resolved no row — recorded, never asserted inside the resolver. */
 let unscopedUpdates = 0;
+/** Every `orderBy` the code emitted, so the ordering is pinned rather than supplied by the fake. */
+let orderBys: unknown[][] = [];
 
 const wheres = (calls: Call[]) => calls.filter(([m]) => m === 'where').map(([, a]) => a);
 const scope = (calls: Call[]) => ({
@@ -61,24 +63,34 @@ function chain(record: (calls: Call[]) => void, resolve: (calls: Call[]) => unkn
 }
 
 /**
- * Rows the emitted SQL would match: ONLY the predicates actually present apply, in id order. A fake
- * that refused a row for some other reason would let a dropped predicate pass for the wrong cause.
+ * Rows the emitted SQL would match: ONLY the predicates actually present apply. A fake that refused
+ * a row for some other reason would let a dropped predicate pass for the wrong cause.
+ *
+ * 🔴 Ordering is applied ONLY when `orderBy('id','asc')` was actually recorded. Sorting
+ * unconditionally hands the code a guarantee it may not have emitted — deleting the `orderBy` then
+ * passes every test while Postgres is free to return any row of the type, which on a duplicate is
+ * the "the edit went to the row nobody reads" bug this file exists to prevent. Unordered, the fake
+ * returns rows HIGHEST id first, so the wrong element surfaces as a wrong value.
  */
 function matching(calls: Call[]): [number, { type: string; data: string[] }][] {
   const { id, type } = scope(calls);
-  return Object.entries(rows)
+  const ordersById = calls.some(
+    ([m, args]) => m === 'orderBy' && args[0] === 'id' && args[1] === 'asc'
+  );
+  const matched = Object.entries(rows)
     .map(([rowId, row]) => [Number(rowId), row] as [number, { type: string; data: string[] }])
     .filter(
       ([rowId, row]) =>
         (id === undefined || rowId === id) && (type === undefined || row.type === type)
-    )
-    .sort((a, b) => a[0] - b[0]);
+    );
+  return matched.sort((a, b) => (ordersById ? a[0] - b[0] : b[0] - a[0]));
 }
 
 const selectFrom = (on: On) =>
   chain(
     (calls) => {
       if (calls.some(([m]) => m === 'forUpdate')) lockedReads.push(on);
+      for (const [method, args] of calls) if (method === 'orderBy') orderBys.push(args);
     },
     (calls) => {
       const [first] = matching(calls);
@@ -153,13 +165,13 @@ vi.mock('../redis', () => ({
 }));
 vi.mock('../axiom', () => ({ logToAxiom: vi.fn() }));
 
-const { removeBlocklistItems, upsertBlocklist, BlocklistRowMismatchError } = await import(
-  '../blocklist.service'
-);
+const { removeBlocklistItems, upsertBlocklist, getBlocklistDTO, BlocklistRowMismatchError } =
+  await import('../blocklist.service');
 
 beforeEach(() => {
   vi.clearAllMocks();
   lockedReads = [];
+  orderBys = [];
   transactions = 0;
   unscopedUpdates = 0;
   rows = {
@@ -167,6 +179,11 @@ beforeEach(() => {
     4: { type: 'MessagePattern', data: ['unfreeze your funds'] },
   };
 });
+
+/** A second row for a type. Nothing prevents one, and which row wins is the whole question. */
+const addDuplicateEmailDomainRow = () => {
+  rows[9] = { type: 'EmailDomain', data: ['duplicate-row-nobody-reads.example'] };
+};
 
 /** Both writers must satisfy these, so they are asserted for each rather than for one. */
 const expectLockedInsideOneTransaction = () => {
@@ -321,15 +338,57 @@ describe('upsertBlocklist', () => {
     expect(Object.keys(rows)).toHaveLength(2);
   });
 
-  it('inserts only when the type genuinely has no row', async () => {
-    const { count } = await upsertBlocklist({ type: 'UsernameExact', blocklist: ['Scammer'] });
+  it('merges into the LOWEST row of the type, the one readBlocklistRow enforces', async () => {
+    // 🔴 Needs a type with TWO rows. With one, every ordering picks the same row, so dropping the
+    // `orderBy` — or reading the wrong end of the result — passes while an add lands on a row
+    // nobody reads: banner says "Added 1 item", cache busted, page reloads unchanged.
+    addDuplicateEmailDomainRow();
 
-    expect(count).toBe(1);
+    await upsertBlocklist({ type: 'EmailDomain', blocklist: ['new.example'] });
+
+    expect(rows[1].data, 'the lowest row is the one that must gain the entry').toContain(
+      'new.example'
+    );
+    expect(rows[9].data).toEqual(['duplicate-row-nobody-reads.example']);
+  });
+
+  it('asks for id order rather than relying on the row it happens to get back', async () => {
+    addDuplicateEmailDomainRow();
+
+    await upsertBlocklist({ type: 'EmailDomain', blocklist: ['new.example'] });
+
+    expect(orderBys, 'the locking read must order by id ASC').toContainEqual(['id', 'asc']);
+  });
+
+  it('inserts only when the type genuinely has no row, and counts every entry inserted', async () => {
+    // More than one item, because `return items.length` and `return 1` are indistinguishable on a
+    // single-entry insert — and seeding a brand-new tab from a pasted list is exactly that case.
+    const { count } = await upsertBlocklist({
+      type: 'UsernameExact',
+      blocklist: ['Scammer', 'Phisher', 'Spammer'],
+    });
+
+    expect(count).toBe(3);
     expect(insertSpy).toHaveBeenCalledWith({
       on: 'trx',
       type: 'UsernameExact',
-      data: ['scammer'],
+      data: ['scammer', 'phisher', 'spammer'],
     });
+  });
+});
+
+describe('which row the system enforces', () => {
+  // `readBlocklistRow` decides this for every reader in three apps, and after this change it is the
+  // ONLY caller of the cache populate — so a write busts the key and the very next read through
+  // here pins a value for a month. Dropping its `orderBy` was invisible before this test.
+  it('reads the LOWEST row of the type', async () => {
+    addDuplicateEmailDomainRow();
+
+    const dto = await getBlocklistDTO({ type: 'EmailDomain' });
+
+    expect(dto.id).toBe(1);
+    expect(dto.data).toEqual(['spam.example', 'junk.example', 'trash.example']);
+    expect(orderBys, 'the read must order by id ASC').toContainEqual(['id', 'asc']);
   });
 });
 

--- a/apps/moderator/src/lib/server/blocklist.service.ts
+++ b/apps/moderator/src/lib/server/blocklist.service.ts
@@ -1,10 +1,12 @@
+import type { Transaction } from 'kysely';
+import type { DB } from '@civitai/db-schema/kysely';
 import { REDIS_KEYS, type RedisKeyTemplateCache } from '@civitai/redis';
 import { dbWrite } from './db';
 import { logToAxiom } from './axiom';
 import { getRedis } from './redis';
 
-// Writes BOTH the Blocklist table AND the shared Redis cache (same key/shape/TTL the main app reads), so
-// main-app validators see edits with no callback.
+// Owns the Blocklist table AND the shared Redis key the main app reads. Writers BUST that key rather
+// than rewriting it, so a main-app validator repopulates from the table on its next read.
 
 export type BlocklistDTO = { id?: number; type: string; data: string[] };
 
@@ -15,6 +17,36 @@ const blocklistKey = (type: string) =>
 
 async function setCache(data: BlocklistDTO) {
   await getRedis().set(blocklistKey(data.type), JSON.stringify(data), { EX: MONTH_TTL });
+}
+
+/**
+ * 🔴 DELETE, never a re-read written back. Writing a snapshot is itself a read-modify-write with no
+ * lock over it, so two edits that the row lock correctly serialised could still land their cache
+ * writes in the other order and leave the LOSER's list under a month TTL — with every enforcement
+ * path reading Redis first, that is the lost update the row lock exists to prevent, moved to the
+ * artifact that actually gates. Deletes commute; the next read repopulates.
+ *
+ * Returns false rather than throwing. The row is already committed by the time this runs, and a
+ * throw here reports failure for a write that succeeded — on the remove path the operator's retry
+ * then finds the entry gone, gets "Nothing was removed", reloads, and sees the chip still there
+ * because the stale cache is what serves the page. Same rule as `a04fa6a608` on the session cache.
+ */
+async function bustCache(type: string): Promise<boolean> {
+  try {
+    await getRedis().del(blocklistKey(type));
+    return true;
+  } catch (error) {
+    void logToAxiom({
+      name: 'blocklist-cache-bust-failed',
+      type: 'error',
+      message: 'Blocklist row was written but its cache key was not cleared; readers stay stale',
+      details: {
+        blocklistType: type,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    return false;
+  }
 }
 
 /**
@@ -84,6 +116,17 @@ export class BlocklistRowMismatchError extends Error {
   }
 }
 
+/** What a write did, and whether readers will see it before the month TTL expires. */
+export type BlocklistWriteResult = { count: number; cacheStale: boolean };
+
+/**
+ * Adds entries, returning how many the row actually GAINED — not how many were submitted. Since
+ * both branches dedupe, re-adding entries that are already on the list changes nothing, and the
+ * page reporting the submitted count is the same "the screen says it happened" defect the removal
+ * count was fixed for.
+ *
+ * Throws `BlocklistRowMismatchError` when `id` names no row of `type`.
+ */
 export async function upsertBlocklist({
   id,
   type,
@@ -92,57 +135,48 @@ export async function upsertBlocklist({
   id?: number;
   type: string;
   blocklist: string[];
-}): Promise<void> {
+}): Promise<BlocklistWriteResult> {
   const items = [
     ...new Set(blocklist.map((item) => item.toLowerCase()).filter((x) => x.length > 0)),
   ];
 
-  if (!id) {
-    await dbWrite
-      .insertInto('Blocklist')
-      .values({ type, data: items, updatedAt: new Date() })
-      .returning(['id'])
-      .executeTakeFirstOrThrow();
-  } else {
-    // The read and the write share one transaction and the read takes a row lock, because the
-    // merge below is read-modify-write over the WHOLE array: two overlapping edits each computed
-    // their merge from the same pre-state and the later write restored what the earlier one
-    // dropped, both reporting success. The lock also covers the cron in the main app, which edits
-    // this same column.
-    const merged = await dbWrite.transaction().execute(async (trx) => {
-      const existing = await trx
-        .selectFrom('Blocklist')
-        .select(['data'])
-        // `type` as well as `id`, and it is a SECURITY predicate rather than a tidiness one: the
-        // posted id and the posted type are two independent form fields, so without it a
-        // hand-crafted post (or a stale tab) merges one type's entries into another type's row —
-        // benign phrases into a deny list, phishing patterns into the email-domain list.
-        .where('id', '=', id)
-        .where('type', '=', type)
-        .forUpdate()
-        .executeTakeFirst();
-      if (!existing) return undefined;
+  // One transaction with a locked read, because the merge is read-modify-write over the WHOLE
+  // array: two overlapping edits each computed their merge from the same pre-state and the later
+  // write restored what the earlier one dropped, both reporting success. The other writer is the
+  // main app's weekly cron, editing this same column through its own client, so the lock has to be
+  // in the database rather than in either app.
+  const added = await dbWrite.transaction().execute(async (trx) => {
+    const existing = await readRowForWrite(trx, type, id);
 
-      const next = [...new Set([...existing.data, ...items])];
+    if (!existing) {
+      // An `id` that names no row of this type is a stale tab or a hand-crafted post. Refuse; do
+      // NOT fall through to an insert, which would add a second row for the type.
+      if (id !== undefined) return undefined;
       await trx
-        .updateTable('Blocklist')
-        .set({ data: next, updatedAt: new Date() })
-        .where('id', '=', id)
-        .where('type', '=', type)
+        .insertInto('Blocklist')
+        .values({ type, data: items, updatedAt: new Date() })
+        .returning(['id'])
         .executeTakeFirstOrThrow();
-      return next;
-    });
+      return items.length;
+    }
 
-    // Refusing beats falling back to an insert: an id that matches no row of this type means the
-    // operator is acting on a list they are not looking at, and creating a second row for the type
-    // is the duplicate-row state `readBlocklistRow` exists to work around.
-    if (!merged) throw new BlocklistRowMismatchError();
-  }
+    const next = [...new Set([...existing.data, ...items])];
+    const gained = next.length - existing.data.length;
+    if (gained === 0) return 0;
 
-  // Cache the row that WINS the read, not the one just written. Caching the written row is what let
-  // an edit to a duplicate row silently promote it to the live answer for the whole month TTL — and
-  // this key is shared with the main app, so it would poison that read too.
-  await setCache(await readBlocklistRow(type));
+    await trx
+      .updateTable('Blocklist')
+      .set({ data: next, updatedAt: new Date() })
+      // `type` here as well as on the read. It is redundant while both run under one lock, and it
+      // is the predicate that still holds if anyone later moves either statement out.
+      .where('id', '=', existing.id)
+      .where('type', '=', type)
+      .executeTakeFirstOrThrow();
+    return gained;
+  });
+
+  if (added === undefined) throw new BlocklistRowMismatchError();
+  return { count: added, cacheStale: added > 0 ? !(await bustCache(type)) : false };
 }
 
 /**
@@ -160,19 +194,13 @@ export async function removeBlocklistItems({
   id: number;
   type: string;
   items: string[];
-}): Promise<number> {
+}): Promise<BlocklistWriteResult> {
   const lower = items.map((x) => x.toLowerCase());
 
   // Same lock and the same reason as `upsertBlocklist`: without it two chips removed in quick
   // succession each filtered the same pre-state and the second write put the first one back.
   const removed = await dbWrite.transaction().execute(async (trx) => {
-    const row = await trx
-      .selectFrom('Blocklist')
-      .select(['data'])
-      .where('id', '=', id)
-      .where('type', '=', type)
-      .forUpdate()
-      .executeTakeFirst();
+    const row = await readRowForWrite(trx, type, id);
     if (!row) return 0;
 
     const filtered = row.data.filter((item) => !lower.includes(item));
@@ -182,14 +210,33 @@ export async function removeBlocklistItems({
     await trx
       .updateTable('Blocklist')
       .set({ data: filtered, updatedAt: new Date() })
-      .where('id', '=', id)
+      .where('id', '=', row.id)
       .where('type', '=', type)
       .executeTakeFirstOrThrow();
     return count;
   });
 
-  if (removed === 0) return 0;
+  return { count: removed, cacheStale: removed > 0 ? !(await bustCache(type)) : false };
+}
 
-  await setCache(await readBlocklistRow(type));
-  return removed;
+/**
+ * The row a write is about to edit, locked until the transaction commits.
+ *
+ * Scoped to `type` always, and to `id` only when one was submitted. Both arrive as independent
+ * form fields, so filtering on the id alone let one type's entries be merged into another type's
+ * row — benign phrases into a deny list, phishing patterns into the email-domain list. With no id
+ * it takes the LOWEST row of the type, the same one `readBlocklistRow` enforces, so an add from a
+ * tab whose type has no row yet cannot append to a row nobody reads.
+ *
+ * ⚠️ What this still cannot serialise: two adds for a type with NO row at all. There is no row to
+ * lock, so both insert and the type ends up with two rows — enforced deterministically by
+ * `readBlocklistRow`, and reported to Axiom, but with one row's entries inert. Closing that needs a
+ * unique index on `Blocklist.type`, which is a migration.
+ */
+function readRowForWrite(trx: Transaction<DB>, type: string, id?: number) {
+  const scoped = trx.selectFrom('Blocklist').select(['id', 'data']).where('type', '=', type);
+  return (id === undefined ? scoped : scoped.where('id', '=', id))
+    .orderBy('id', 'asc')
+    .forUpdate()
+    .executeTakeFirst();
 }

--- a/apps/moderator/src/lib/server/blocklist.service.ts
+++ b/apps/moderator/src/lib/server/blocklist.service.ts
@@ -77,6 +77,13 @@ export async function getBlocklistDTO({ type }: { type: string }): Promise<Block
   return result;
 }
 
+export class BlocklistRowMismatchError extends Error {
+  constructor() {
+    super('That blocklist row does not belong to this type.');
+    this.name = 'BlocklistRowMismatchError';
+  }
+}
+
 export async function upsertBlocklist({
   id,
   type,
@@ -86,67 +93,103 @@ export async function upsertBlocklist({
   type: string;
   blocklist: string[];
 }): Promise<void> {
-  const items = blocklist.map((item) => item.toLowerCase()).filter((x) => x.length > 0);
+  const items = [
+    ...new Set(blocklist.map((item) => item.toLowerCase()).filter((x) => x.length > 0)),
+  ];
 
-  let result: BlocklistDTO;
   if (!id) {
-    result = await dbWrite
+    await dbWrite
       .insertInto('Blocklist')
       .values({ type, data: items, updatedAt: new Date() })
-      .returning(['id', 'type', 'data'])
+      .returning(['id'])
       .executeTakeFirstOrThrow();
   } else {
-    const existing = await dbWrite
-      .selectFrom('Blocklist')
-      .select('data')
-      .where('id', '=', id)
-      .executeTakeFirst();
-    const merged = [...new Set([...(existing?.data ?? []), ...items])];
-    result = await dbWrite
-      .updateTable('Blocklist')
-      .set({ data: merged, updatedAt: new Date() })
-      .where('id', '=', id)
-      .returning(['id', 'type', 'data'])
-      .executeTakeFirstOrThrow();
+    // The read and the write share one transaction and the read takes a row lock, because the
+    // merge below is read-modify-write over the WHOLE array: two overlapping edits each computed
+    // their merge from the same pre-state and the later write restored what the earlier one
+    // dropped, both reporting success. The lock also covers the cron in the main app, which edits
+    // this same column.
+    const merged = await dbWrite.transaction().execute(async (trx) => {
+      const existing = await trx
+        .selectFrom('Blocklist')
+        .select(['data'])
+        // `type` as well as `id`, and it is a SECURITY predicate rather than a tidiness one: the
+        // posted id and the posted type are two independent form fields, so without it a
+        // hand-crafted post (or a stale tab) merges one type's entries into another type's row —
+        // benign phrases into a deny list, phishing patterns into the email-domain list.
+        .where('id', '=', id)
+        .where('type', '=', type)
+        .forUpdate()
+        .executeTakeFirst();
+      if (!existing) return undefined;
+
+      const next = [...new Set([...existing.data, ...items])];
+      await trx
+        .updateTable('Blocklist')
+        .set({ data: next, updatedAt: new Date() })
+        .where('id', '=', id)
+        .where('type', '=', type)
+        .executeTakeFirstOrThrow();
+      return next;
+    });
+
+    // Refusing beats falling back to an insert: an id that matches no row of this type means the
+    // operator is acting on a list they are not looking at, and creating a second row for the type
+    // is the duplicate-row state `readBlocklistRow` exists to work around.
+    if (!merged) throw new BlocklistRowMismatchError();
   }
 
-  // Cache the row that WINS the read, not the one just written. Caching `result` is what let an
-  // edit to a duplicate row silently promote it to the live answer for the whole month TTL —
-  // and this key is shared with the main app, so it would poison that read too.
-  await setCache(await readBlocklistRow(result.type));
+  // Cache the row that WINS the read, not the one just written. Caching the written row is what let
+  // an edit to a duplicate row silently promote it to the live answer for the whole month TTL — and
+  // this key is shared with the main app, so it would poison that read too.
+  await setCache(await readBlocklistRow(type));
 }
 
 /**
  * Returns how many entries were actually dropped, which is NOT the number submitted: a stale `id`
- * (the DTO is Redis-cached for a month), an entry already gone, or one stored in a case the
- * lowercased needle cannot match all end in zero. The page reports this number, so "Removed 1
- * item." above a chip that is still there is a state the UI can no longer reach.
+ * (the DTO is Redis-cached for a month), an `id` belonging to another type, an entry already gone,
+ * or one stored in a case the lowercased needle cannot match all end in zero. The page reports this
+ * number, so "Removed 1 item." above a chip that is still there is a state the UI can no longer
+ * reach.
  */
 export async function removeBlocklistItems({
   id,
+  type,
   items,
 }: {
   id: number;
+  type: string;
   items: string[];
 }): Promise<number> {
   const lower = items.map((x) => x.toLowerCase());
-  const row = await dbWrite
-    .selectFrom('Blocklist')
-    .select('data')
-    .where('id', '=', id)
-    .executeTakeFirst();
-  if (!row) return 0;
 
-  const filtered = row.data.filter((item) => !lower.includes(item));
-  const removed = row.data.length - filtered.length;
+  // Same lock and the same reason as `upsertBlocklist`: without it two chips removed in quick
+  // succession each filtered the same pre-state and the second write put the first one back.
+  const removed = await dbWrite.transaction().execute(async (trx) => {
+    const row = await trx
+      .selectFrom('Blocklist')
+      .select(['data'])
+      .where('id', '=', id)
+      .where('type', '=', type)
+      .forUpdate()
+      .executeTakeFirst();
+    if (!row) return 0;
+
+    const filtered = row.data.filter((item) => !lower.includes(item));
+    const count = row.data.length - filtered.length;
+    if (count === 0) return 0;
+
+    await trx
+      .updateTable('Blocklist')
+      .set({ data: filtered, updatedAt: new Date() })
+      .where('id', '=', id)
+      .where('type', '=', type)
+      .executeTakeFirstOrThrow();
+    return count;
+  });
+
   if (removed === 0) return 0;
 
-  const updated = await dbWrite
-    .updateTable('Blocklist')
-    .set({ data: filtered, updatedAt: new Date() })
-    .where('id', '=', id)
-    .returning(['id', 'type', 'data'])
-    .executeTakeFirstOrThrow();
-  await setCache(await readBlocklistRow(updated.type));
+  await setCache(await readBlocklistRow(type));
   return removed;
 }

--- a/apps/moderator/src/lib/server/blocklist.service.ts
+++ b/apps/moderator/src/lib/server/blocklist.service.ts
@@ -15,16 +15,24 @@ const MONTH_TTL = 60 * 60 * 24 * 30; // matches the main app's CacheTTL.month
 const blocklistKey = (type: string) =>
   `${REDIS_KEYS.SYSTEM.BLOCKLIST}:${type}` as RedisKeyTemplateCache;
 
+/** The cache-aside populate, and the ONLY `set` in this file — see `bustCache` for why writers never. */
 async function setCache(data: BlocklistDTO) {
   await getRedis().set(blocklistKey(data.type), JSON.stringify(data), { EX: MONTH_TTL });
 }
 
 /**
  * 🔴 DELETE, never a re-read written back. Writing a snapshot is itself a read-modify-write with no
- * lock over it, so two edits that the row lock correctly serialised could still land their cache
- * writes in the other order and leave the LOSER's list under a month TTL — with every enforcement
- * path reading Redis first, that is the lost update the row lock exists to prevent, moved to the
- * artifact that actually gates. Deletes commute; the next read repopulates.
+ * lock over it, so two WRITERS the row lock correctly serialised could still land their cache
+ * writes in the other order and leave the LOSER's list under a month TTL. Deletes commute with each
+ * other, so that ordering no longer decides anything.
+ *
+ * ⚠️ What this does NOT close, stated because the obvious reading of "deletes commute" is that it
+ * does: a DELETE does not commute with the POPULATE in `getBlocklistDTO`, which is plain
+ * cache-aside. A reader that missed and read the row before the commit can `set` its pre-write
+ * snapshot AFTER the bust, pinning it for the whole month TTL — and since a write guarantees the
+ * next read misses, and the page reloads through `load` on every submit, two moderators submitting
+ * seconds apart is enough. Closing it needs a lease, a version, or a TTL short enough that the
+ * staleness is bounded; none of those is in this change.
  *
  * Returns false rather than throwing. The row is already committed by the time this runs, and a
  * throw here reports failure for a write that succeeded — on the remove path the operator's retry
@@ -61,11 +69,11 @@ async function bustCache(type: string): Promise<boolean> {
  * both must agree, because they read and write the SAME Redis key.
  */
 async function readBlocklistRow(type: string): Promise<BlocklistDTO> {
-  // `dbWrite`, not `dbRead`, and this is load-bearing: both writers below re-read through here
-  // and then cache the result for a MONTH. Off the replica, a write-then-read races replication
-  // and would pin the PRE-EDIT row into a key the main app also reads — a moderator's change
-  // silently undone for 30 days, which is the failure this function exists to prevent. The
-  // writers already read writer-side for the same reason.
+  // `dbWrite`, not `dbRead`, and this is MORE load-bearing since the writers stopped calling this:
+  // its one caller is the cache-aside populate in `getBlocklistDTO`, and a write busts the key, so
+  // the very next read is a post-write read that pins a value for a MONTH. Off the replica that
+  // read races replication and caches the PRE-EDIT row for 30 days — a moderator's change silently
+  // undone. Do not "optimise" this to `dbRead` because no write path reaches it any more.
   const rows = await dbWrite
     .selectFrom('Blocklist')
     .select(['id', 'type', 'data'])
@@ -228,10 +236,17 @@ export async function removeBlocklistItems({
  * it takes the LOWEST row of the type, the same one `readBlocklistRow` enforces, so an add from a
  * tab whose type has no row yet cannot append to a row nobody reads.
  *
- * ⚠️ What this still cannot serialise: two adds for a type with NO row at all. There is no row to
- * lock, so both insert and the type ends up with two rows — enforced deterministically by
- * `readBlocklistRow`, and reported to Axiom, but with one row's entries inert. Closing that needs a
- * unique index on `Blocklist.type`, which is a migration.
+ * ⚠️ What this still cannot serialise: two adds for a type with NO row at all. `FOR UPDATE` locks
+ * NOTHING when it matches nothing (same trap as `app-listing-review.service.ts`), so both insert and
+ * the type ends up with two rows — enforced deterministically by `readBlocklistRow` and reported to
+ * Axiom, but with one row's entries inert. `UsernameExact` is a tab with no row in production, so
+ * the window is the initial seeding of a new tab, which is when two people are most likely to both
+ * be in it.
+ *
+ * Two closes, neither taken here: a unique index on `Blocklist.type` (a migration, and the honest
+ * one), or `pg_advisory_xact_lock` on the type as the transaction's first statement (no migration,
+ * but it introduces a blocking primitive with no `lock_timeout` into both apps for a window this
+ * narrow). Filed rather than folded in — do not read this as "unfixable without a migration".
  */
 function readRowForWrite(trx: Transaction<DB>, type: string, id?: number) {
   const scoped = trx.selectFrom('Blocklist').select(['id', 'data']).where('type', '=', type);

--- a/apps/moderator/src/lib/server/blocklist.service.ts
+++ b/apps/moderator/src/lib/server/blocklist.service.ts
@@ -29,10 +29,14 @@ async function setCache(data: BlocklistDTO) {
  * ⚠️ What this does NOT close, stated because the obvious reading of "deletes commute" is that it
  * does: a DELETE does not commute with the POPULATE in `getBlocklistDTO`, which is plain
  * cache-aside. A reader that missed and read the row before the commit can `set` its pre-write
- * snapshot AFTER the bust, pinning it for the whole month TTL — and since a write guarantees the
- * next read misses, and the page reloads through `load` on every submit, two moderators submitting
- * seconds apart is enough. Closing it needs a lease, a version, or a TTL short enough that the
- * staleness is bounded; none of those is in this change.
+ * snapshot AFTER the bust, pinning it for the whole month TTL.
+ *
+ * The causation runs to the NEXT write, not this one: a bust guarantees the following read misses,
+ * and the page reloads through `load` on every submit, so a reader is typically mid-fill when the
+ * write AFTER this one commits — two moderators submitting seconds apart is enough. This write's
+ * own bust cannot put a reader into this write's window, because a miss it caused reads a row that
+ * is already updated. Closing it needs a lease, a version, or a TTL short enough that the staleness
+ * is bounded; none of those is in this change.
  *
  * Returns false rather than throwing. The row is already committed by the time this runs, and a
  * throw here reports failure for a write that succeeded — on the remove path the operator's retry

--- a/apps/moderator/src/routes/blocklists/+page.server.ts
+++ b/apps/moderator/src/routes/blocklists/+page.server.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type { Actions, PageServerLoad } from './$types';
 import { parseQuery } from '$lib/server/query';
 import { BLOCKLIST_TYPES } from '$lib/blocklist';
+import { parseRowId } from './form';
 import {
   BlocklistRowMismatchError,
   getBlocklistDTO,
@@ -33,11 +34,11 @@ export const actions: Actions = {
   add: async ({ request }) => {
     const form = await request.formData();
     const type = String(form.get('type') ?? '');
-    const idRaw = form.get('id');
-    const id = idRaw ? Number(idRaw) : undefined;
+    const id = parseRowId(form.get('id'));
     const items = parseItems(form.get('blocklist'));
 
     if (!isType(type)) return fail(400, { error: 'Invalid blocklist type.' });
+    if (id === null) return fail(400, { error: 'Invalid blocklist row.' });
     if (items.length === 0) return fail(400, { error: 'No items to add.' });
 
     // `type` and `id` arrive as two independent form fields, so the pair is checked in the
@@ -66,7 +67,7 @@ export const actions: Actions = {
   remove: async ({ request }) => {
     const form = await request.formData();
     const type = String(form.get('type') ?? '');
-    const id = Number(form.get('id'));
+    const id = parseRowId(form.get('id'));
     const items = parseItems(form.get('blocklist'));
 
     if (!isType(type)) return fail(400, { error: 'Invalid blocklist type.' });

--- a/apps/moderator/src/routes/blocklists/+page.server.ts
+++ b/apps/moderator/src/routes/blocklists/+page.server.ts
@@ -42,8 +42,9 @@ export const actions: Actions = {
 
     // `type` and `id` arrive as two independent form fields, so the pair is checked in the
     // statement itself rather than here — see `upsertBlocklist`.
+    let result;
     try {
-      await upsertBlocklist({ id, type, blocklist: items });
+      result = await upsertBlocklist({ id, type, blocklist: items });
     } catch (error) {
       if (error instanceof BlocklistRowMismatchError)
         return fail(409, {
@@ -51,7 +52,16 @@ export const actions: Actions = {
         });
       throw error;
     }
-    return { success: true, action: 'add', count: items.length };
+
+    // The count the row GAINED, not the count submitted. Re-adding entries already on the list is
+    // a no-op, and reporting the submission as if it landed is the defect the removal count was
+    // fixed for.
+    if (result.count === 0)
+      return fail(409, {
+        error: 'Nothing was added — every one of those entries is already on this list.',
+      });
+
+    return { success: true, action: 'add', count: result.count, cacheStale: result.cacheStale };
   },
   remove: async ({ request }) => {
     const form = await request.formData();
@@ -63,15 +73,15 @@ export const actions: Actions = {
     if (!id) return fail(400, { error: 'Nothing to remove from.' });
     if (items.length === 0) return fail(400, { error: 'No items to remove.' });
 
-    const count = await removeBlocklistItems({ id, type, items });
+    const result = await removeBlocklistItems({ id, type, items });
     // A submitted-but-unmatched removal is a failure, not a quiet "Removed 0 items." The list is
     // served from a month-long Redis cache, so the likeliest cause is that this page is stale. An
     // id belonging to another type lands here too.
-    if (count === 0)
+    if (result.count === 0)
       return fail(409, {
         error: 'Nothing was removed — those entries are no longer on this list. Reload the page.',
       });
 
-    return { success: true, action: 'remove', count };
+    return { success: true, action: 'remove', count: result.count, cacheStale: result.cacheStale };
   },
 };

--- a/apps/moderator/src/routes/blocklists/+page.server.ts
+++ b/apps/moderator/src/routes/blocklists/+page.server.ts
@@ -4,6 +4,7 @@ import type { Actions, PageServerLoad } from './$types';
 import { parseQuery } from '$lib/server/query';
 import { BLOCKLIST_TYPES } from '$lib/blocklist';
 import {
+  BlocklistRowMismatchError,
   getBlocklistDTO,
   upsertBlocklist,
   removeBlocklistItems,
@@ -39,20 +40,33 @@ export const actions: Actions = {
     if (!isType(type)) return fail(400, { error: 'Invalid blocklist type.' });
     if (items.length === 0) return fail(400, { error: 'No items to add.' });
 
-    await upsertBlocklist({ id, type, blocklist: items });
+    // `type` and `id` arrive as two independent form fields, so the pair is checked in the
+    // statement itself rather than here — see `upsertBlocklist`.
+    try {
+      await upsertBlocklist({ id, type, blocklist: items });
+    } catch (error) {
+      if (error instanceof BlocklistRowMismatchError)
+        return fail(409, {
+          error: 'That list has changed since this page loaded. Reload and try again.',
+        });
+      throw error;
+    }
     return { success: true, action: 'add', count: items.length };
   },
   remove: async ({ request }) => {
     const form = await request.formData();
+    const type = String(form.get('type') ?? '');
     const id = Number(form.get('id'));
     const items = parseItems(form.get('blocklist'));
 
+    if (!isType(type)) return fail(400, { error: 'Invalid blocklist type.' });
     if (!id) return fail(400, { error: 'Nothing to remove from.' });
     if (items.length === 0) return fail(400, { error: 'No items to remove.' });
 
-    const count = await removeBlocklistItems({ id, items });
+    const count = await removeBlocklistItems({ id, type, items });
     // A submitted-but-unmatched removal is a failure, not a quiet "Removed 0 items." The list is
-    // served from a month-long Redis cache, so the likeliest cause is that this page is stale.
+    // served from a month-long Redis cache, so the likeliest cause is that this page is stale. An
+    // id belonging to another type lands here too.
     if (count === 0)
       return fail(409, {
         error: 'Nothing was removed — those entries are no longer on this list. Reload the page.',

--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -135,6 +135,14 @@
 {:else if form?.success}
   <div class="mb-4 max-w-xl rounded-md border border-teal-500/30 bg-teal-500/10 p-2 text-sm text-teal-300">
     {form.action === 'add' ? 'Added' : 'Removed'} {form.count} item{form.count === 1 ? '' : 's'}.
+    {#if form.cacheStale}
+      <!-- The row is written; only the cache clear failed. Saying so beats both alternatives: a
+           bare success above a list that still shows the old entries reads as the write being lost,
+           and an error reads as a write that never happened and invites a retry. -->
+      <span class="text-amber-300">
+        The cached copy could not be refreshed, so this list may keep showing its previous contents.
+      </span>
+    {/if}
   </div>
 {/if}
 

--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -48,9 +48,9 @@
     text = '';
   }
 
-  // Duplicates are reachable: `upsertBlocklist` dedupes only on its update branch, so the first save
-  // of a type persists whatever was submitted. They would collide as `{#each}` keys, and each chip
-  // now carries a remove control identified by that same string.
+  // Duplicates are reachable in rows written before `upsertBlocklist` deduped its insert branch as
+  // well as its update branch. They would collide as `{#each}` keys, and each chip carries a remove
+  // control identified by that same string.
   const sortedItems = $derived(
     [...new Set(data.blocklist.data)].sort((a, b) => a.localeCompare(b))
   );
@@ -198,6 +198,7 @@
               use:enhance={submitChip(item)}
               class="relative"
             >
+              <input type="hidden" name="type" value={data.type} />
               <input type="hidden" name="id" value={data.blocklist.id} />
               <input type="hidden" name="blocklist" value={item} />
               <!-- The badge styling stays on this span, NOT on the form. `badgeVariants` carries

--- a/apps/moderator/src/routes/blocklists/__tests__/parse-row-id.test.ts
+++ b/apps/moderator/src/routes/blocklists/__tests__/parse-row-id.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { parseRowId } from '../form';
+
+/**
+ * `id` is a hidden form field, so every value here is something a client can actually post.
+ *
+ * The three outcomes are distinct and none may collapse into another: `undefined` means "no row was
+ * named, act on the type", a number means "act on that row", and `null` means "refuse" — which is
+ * the one the old `raw ? Number(raw) : undefined` had no way to express.
+ */
+describe('parseRowId', () => {
+  it('reads a normal row id', () => {
+    expect(parseRowId('42')).toBe(42);
+  });
+
+  it('treats an absent or empty field as no row named', () => {
+    expect(parseRowId(null)).toBeUndefined();
+    expect(parseRowId('')).toBeUndefined();
+  });
+
+  it('refuses a non-numeric id instead of letting NaN reach the query', () => {
+    // 🔴 The regression this exists for. `Number('abc')` is NaN, and NaN is neither falsy-as-a-form
+    // -value nor `undefined`, so the old coercion sent it to `where('id','=',NaN)`. `pg` serialises
+    // that as the text `NaN`, Postgres answers `invalid input syntax for type integer`, and the
+    // error escapes the BlocklistRowMismatchError catch as a 500.
+    expect(parseRowId('abc')).toBeNull();
+  });
+
+  it('refuses values that survive Number() but are not row ids', () => {
+    expect(parseRowId('1e999'), 'Infinity').toBeNull();
+    expect(parseRowId('1.5'), 'non-integer').toBeNull();
+    expect(parseRowId('-1'), 'negative').toBeNull();
+    expect(parseRowId('0'), 'no row has id 0, and 0 used to mean "insert"').toBeNull();
+  });
+});

--- a/apps/moderator/src/routes/blocklists/form.ts
+++ b/apps/moderator/src/routes/blocklists/form.ts
@@ -1,0 +1,25 @@
+/**
+ * Parsing of the blocklist form's own fields.
+ *
+ * Its own module rather than living in `+page.server.ts`, because that file imports the service,
+ * which imports the database client, which throws on a missing `DATABASE_URL` at import time — so
+ * nothing in it can be unit-tested without standing up an environment.
+ */
+
+/**
+ * `undefined` for an absent field, `null` for anything that is not a usable row id, the number
+ * otherwise. The three are distinct and none may collapse into another: `undefined` means "no row
+ * named, act on the type", a number means "act on that row", `null` means "refuse".
+ *
+ * 🔴 Not `raw ? Number(raw) : undefined`. `id` is a hidden form field, so the client picks it.
+ * `Number('abc')` is `NaN`, which is neither falsy as a form value nor `undefined`, so it reached
+ * `where('id', '=', NaN)` — and `pg` serialises that as the text `NaN`, which Postgres rejects with
+ * `invalid input syntax for type integer`. That escapes the `BlocklistRowMismatchError` catch as a
+ * 500 rather than the `fail(400)` every other malformed field here produces. `1e999` (`Infinity`)
+ * and `1.5` arrive by the same door.
+ */
+export function parseRowId(raw: FormDataEntryValue | null): number | undefined | null {
+  if (raw === null || String(raw).length === 0) return undefined;
+  const id = Number(raw);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -140,6 +140,7 @@ const IO_CALL_NAMES = new Set([
   'bust', // bustMvCache etc.
   'bustUserSettings',
   'getUserSettings',
+  'bustCache',
   'bustMvCache',
   'invalidateManyImageExistence',
   // email

--- a/src/server/services/__tests__/blocklist.service.test.ts
+++ b/src/server/services/__tests__/blocklist.service.test.ts
@@ -239,10 +239,22 @@ describe('what an edit does to the shared cache key', () => {
     await edit();
 
     expect(redisMock.redis.del).toHaveBeenCalledWith('system:blocklist:EmailDomain');
+    expect(redisMock.redis.del).toHaveBeenCalledTimes(1);
     expect(
       redisMock.redis.set,
       'an edit must not repopulate the key it just invalidated'
     ).not.toHaveBeenCalled();
+  });
+
+  it('busts the key for the type it was given, not a hardcoded one', async () => {
+    // Every other assertion here uses EmailDomain, so a hardcoded key would pass all of them.
+    await upsertBlocklist({
+      id: 8,
+      type: BlocklistType.MessagePattern,
+      blocklist: ['unfreeze your funds'],
+    });
+
+    expect(redisMock.redis.del).toHaveBeenCalledWith('system:blocklist:MessagePattern');
   });
 
   it('does not report failure when the key could not be cleared', async () => {
@@ -367,7 +379,14 @@ describe('what an edit is allowed to touch', () => {
   });
 
   it('locks the lowest row of the type when no id was submitted', async () => {
-    dbMock.dbWrite.$queryRaw.mockResolvedValue([{ id: 3, data: ['a.example'] }]);
+    // 🔴 TWO rows, and that is the whole point of the fixture. With one, `locked[0]` and
+    // `locked.at(-1)` are the same object, so merging into the HIGHEST-id row passes every
+    // assertion while the `ORDER BY id ASC` stays in the statement to reassure the reader — the
+    // duplicate-row promotion this file exists to prevent, hidden behind a text match.
+    dbMock.dbWrite.$queryRaw.mockResolvedValue([
+      { id: 3, data: ['lowest.example'] },
+      { id: 8, data: ['highest.example'] },
+    ]);
     dbMock.dbWrite.blocklist.updateMany.mockResolvedValue({ count: 1 });
 
     await upsertBlocklist({ type: BlocklistType.EmailDomain, blocklist: ['new.example'] });
@@ -376,13 +395,32 @@ describe('what an edit is allowed to touch', () => {
     // `readBlocklistRow` would then never enforce.
     expect(dbMock.dbWrite.blocklist.create).not.toHaveBeenCalled();
     expect(dbMock.dbWrite.blocklist.updateMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: 3, type: BlocklistType.EmailDomain } })
+      expect.objectContaining({
+        // The row id AND the data it merged from, so reading the wrong element of `locked`
+        // fails on a value rather than on a regex over SQL text.
+        where: { id: 3, type: BlocklistType.EmailDomain },
+        data: { data: ['lowest.example', 'new.example'] },
+      })
     );
 
     const [fragments] = dbMock.dbWrite.$queryRaw.mock.calls[0] as [readonly string[]];
     const statement = fragments.join('?').replace(/\s+/g, ' ');
     expect(statement).toMatch(/ORDER BY id ASC/);
     expect(statement).toMatch(/FOR UPDATE/);
+  });
+
+  it('throws and busts nothing when the locked update matches no row', async () => {
+    // Unreachable while the lock holds, which is exactly why it needs a test: the guard exists so
+    // that moving either statement out of the transaction fails loudly instead of writing nothing,
+    // reporting success, and busting a key over a row that never changed.
+    dbMock.dbWrite.$queryRaw.mockResolvedValue([{ id: 1, data: ['a.example'] }]);
+    dbMock.dbWrite.blocklist.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      upsertBlocklist({ id: 1, type: BlocklistType.EmailDomain, blocklist: ['new.example'] })
+    ).rejects.toThrow(/matched 0 rows/);
+
+    expect(redisMock.redis.del).not.toHaveBeenCalled();
   });
 
   it('inserts only when the type has no row at all', async () => {

--- a/src/server/services/__tests__/blocklist.service.test.ts
+++ b/src/server/services/__tests__/blocklist.service.test.ts
@@ -213,68 +213,46 @@ describe('a type with more than one Blocklist row', () => {
   });
 });
 
-describe('what an edit writes into the cache', () => {
+describe('what an edit does to the shared cache key', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     redisGet.mockResolvedValue(null);
-  });
-
-  // The production incident was not the read: `upsertBlocklist` cached the row it had just
-  // written under a key scoped to the TYPE, so editing the duplicate row promoted it to the
-  // live answer for a month. Reverting to `data: result` leaves every read-side test green,
-  // so this is the only thing standing between that bug and a re-introduction.
-  const twoRows = () => {
-    // Deliberately the SAME order-and-where-honouring fake as the read tests: a fake that
-    // returns a fixed array would make `id: 1` below the fixture's answer rather than the
-    // code's.
-    dbMock.dbWrite.blocklist.findMany.mockImplementation(
-      async (args?: { where?: { type?: string }; orderBy?: { id?: 'asc' | 'desc' } }) => {
-        const rows = [
-          { id: 8, type: BlocklistType.EmailDomain, data: ['c.example'] },
-          { id: 1, type: BlocklistType.EmailDomain, data: ['a.example', 'b.example'] },
-        ];
-        const type = args?.where?.type;
-        const filtered = type ? rows.filter((row) => row.type === type) : [...rows];
-        const direction = args?.orderBy?.id;
-        if (!direction) return filtered;
-        return filtered.sort((a, b) => (direction === 'desc' ? b.id - a.id : a.id - b.id));
-      }
-    );
-    // The merge now reads through a locking `SELECT ... FOR UPDATE`, so the row the edit starts
-    // from comes back here rather than from `findUnique`.
-    dbMock.dbWrite.$queryRaw.mockResolvedValue([{ data: ['c.example'] }]);
+    dbMock.dbWrite.$queryRaw.mockResolvedValue([{ id: 8, data: ['c.example'] }]);
     dbMock.dbWrite.blocklist.updateMany.mockResolvedValue({ count: 1 });
-  };
-
-  const cachedPayload = () => {
-    const call = redisMock.redis.set.mock.calls.at(-1);
-    return call ? JSON.parse(call[1] as string) : undefined;
-  };
-
-  it('caches the row that WINS the read, not the row that was just edited', async () => {
-    twoRows();
-
-    await upsertBlocklist({
-      id: 8,
-      type: BlocklistType.EmailDomain,
-      blocklist: ['new.example'],
-    });
-
-    const cached = cachedPayload();
-    expect(cached?.id).toBe(1);
-    expect(cached?.data).toEqual(['a.example', 'b.example']);
   });
 
-  it('writes under a key scoped to the type', async () => {
-    twoRows();
+  const edit = () =>
+    upsertBlocklist({ id: 8, type: BlocklistType.EmailDomain, blocklist: ['new.example'] });
 
-    await upsertBlocklist({
-      id: 8,
-      type: BlocklistType.EmailDomain,
-      blocklist: ['new.example'],
-    });
+  /**
+   * This used to cache a re-read of the winning row, which fixed one bug and left another: the
+   * re-read and the `SET` are themselves an unserialised read-modify-write over the key, so two
+   * edits the row lock correctly serialised could still land their cache writes in the other
+   * order and leave the LOSER's list under a month TTL. Every enforcement path reads this key
+   * first, so that is the lost update the row lock exists to prevent, moved to the artifact that
+   * actually gates. A delete commutes; the next read repopulates from the table.
+   *
+   * It also makes the old duplicate-row-promotion incident unrepresentable rather than merely
+   * guarded: there is no snapshot to pick the wrong row for.
+   */
+  it('DELETES the key rather than writing a snapshot back', async () => {
+    await edit();
 
-    expect(redisMock.redis.set.mock.calls.at(-1)?.[0]).toBe('system:blocklist:EmailDomain');
+    expect(redisMock.redis.del).toHaveBeenCalledWith('system:blocklist:EmailDomain');
+    expect(
+      redisMock.redis.set,
+      'an edit must not repopulate the key it just invalidated'
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not report failure when the key could not be cleared', async () => {
+    // The row is already committed. Throwing here tells the caller a write failed that
+    // succeeded, and the weekly cron would then re-add domains it had already added. Same rule
+    // as `a04fa6a608` on the session cache: log it, do not surface it.
+    redisMock.redis.del.mockRejectedValueOnce(new Error('redis down'));
+
+    await expect(edit()).resolves.toBeUndefined();
+    expect(dbMock.dbWrite.blocklist.updateMany).toHaveBeenCalled();
   });
 });
 
@@ -301,11 +279,11 @@ describe('what an edit is allowed to touch', () => {
 
     expect(dbMock.dbWrite.blocklist.updateMany).not.toHaveBeenCalled();
     expect(dbMock.dbWrite.blocklist.create).not.toHaveBeenCalled();
-    expect(redisMock.redis.set).not.toHaveBeenCalled();
+    expect(redisMock.redis.del).not.toHaveBeenCalled();
   });
 
   it('carries the type into the UPDATE as well as the locking read', async () => {
-    dbMock.dbWrite.$queryRaw.mockResolvedValue([{ data: ['a.example'] }]);
+    dbMock.dbWrite.$queryRaw.mockResolvedValue([{ id: 1, data: ['a.example'] }]);
     dbMock.dbWrite.blocklist.updateMany.mockResolvedValue({ count: 1 });
 
     await upsertBlocklist({
@@ -332,6 +310,91 @@ describe('what an edit is allowed to touch', () => {
     expect(statement).toMatch(/type = \?/);
     expect(statement).toMatch(/FOR UPDATE/);
     expect(values).toEqual([1, BlocklistType.EmailDomain]);
+  });
+
+  /**
+   * 🔴 The default `$transaction` mock hands the callback the SAME node the assertions read, so it
+   * cannot tell `tx.$queryRaw` from `dbWrite.$queryRaw`. Deleting the `$transaction` wrapper and
+   * running the body against the bare client left every other test here green — with `FOR UPDATE`
+   * still in the statement, and the lock held by a transaction that has already committed. An
+   * inert lock is the shape that reads as fixed and is not, so this overrides the mock with a
+   * DISTINCT tx object and asserts both statements were issued on it.
+   */
+  it('issues the locking read and the update on the TRANSACTION client', async () => {
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: 1, data: ['a.example'] }]),
+      blocklist: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+    };
+    // `Once`, not a standing implementation: `vi.clearAllMocks()` clears CALLS but not
+    // implementations, so a standing override here leaks into every later test in the file and
+    // sends their statements to this dead `tx` object.
+    dbMock.dbWrite.$transaction.mockImplementationOnce(async (cb: (client: unknown) => unknown) =>
+      cb(tx)
+    );
+
+    await upsertBlocklist({ id: 1, type: BlocklistType.EmailDomain, blocklist: ['new.example'] });
+
+    expect(tx.$queryRaw, 'the locked read must run inside the transaction').toHaveBeenCalledTimes(
+      1
+    );
+    expect(tx.blocklist.updateMany, 'the write must run inside the same one').toHaveBeenCalledTimes(
+      1
+    );
+    expect(dbMock.dbWrite.$queryRaw).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.blocklist.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('gives the transaction a budget larger than Prisma’s 5s default', async () => {
+    // The one caller is a weekly cron with no retry, and this path had no transaction before, so
+    // both of Prisma’s ceilings (maxWait 2s, timeout 5s) are new ways for it to fail — at a cost
+    // of a week’s disposable-domain additions.
+    dbMock.dbWrite.$queryRaw.mockResolvedValue([{ id: 1, data: ['a.example'] }]);
+    dbMock.dbWrite.blocklist.updateMany.mockResolvedValue({ count: 1 });
+
+    await upsertBlocklist({ id: 1, type: BlocklistType.EmailDomain, blocklist: ['new.example'] });
+
+    expect(
+      dbMock.dbWrite.$transaction,
+      'the edit must open a transaction at all'
+    ).toHaveBeenCalled();
+    const options = dbMock.dbWrite.$transaction.mock.calls[0][1] as
+      | { maxWait?: number; timeout?: number }
+      | undefined;
+    // Named rather than destructured: without the guard, dropping the options argument fails as a
+    // TypeError on `undefined`, which reads as a broken test rather than a missing budget.
+    expect(options?.timeout ?? 5_000).toBeGreaterThan(5_000);
+    expect(options?.maxWait ?? 2_000).toBeGreaterThan(2_000);
+  });
+
+  it('locks the lowest row of the type when no id was submitted', async () => {
+    dbMock.dbWrite.$queryRaw.mockResolvedValue([{ id: 3, data: ['a.example'] }]);
+    dbMock.dbWrite.blocklist.updateMany.mockResolvedValue({ count: 1 });
+
+    await upsertBlocklist({ type: BlocklistType.EmailDomain, blocklist: ['new.example'] });
+
+    // Not an insert: a type that already has a row must not gain a second, whose entries
+    // `readBlocklistRow` would then never enforce.
+    expect(dbMock.dbWrite.blocklist.create).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.blocklist.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 3, type: BlocklistType.EmailDomain } })
+    );
+
+    const [fragments] = dbMock.dbWrite.$queryRaw.mock.calls[0] as [readonly string[]];
+    const statement = fragments.join('?').replace(/\s+/g, ' ');
+    expect(statement).toMatch(/ORDER BY id ASC/);
+    expect(statement).toMatch(/FOR UPDATE/);
+  });
+
+  it('inserts only when the type has no row at all', async () => {
+    dbMock.dbWrite.$queryRaw.mockResolvedValue([]);
+
+    await upsertBlocklist({ type: BlocklistType.UsernameExact, blocklist: ['Scammer'] });
+
+    expect(dbMock.dbWrite.blocklist.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { data: ['scammer'], type: BlocklistType.UsernameExact },
+      })
+    );
   });
 });
 

--- a/src/server/services/__tests__/blocklist.service.test.ts
+++ b/src/server/services/__tests__/blocklist.service.test.ts
@@ -240,12 +240,10 @@ describe('what an edit writes into the cache', () => {
         return filtered.sort((a, b) => (direction === 'desc' ? b.id - a.id : a.id - b.id));
       }
     );
-    dbMock.dbWrite.blocklist.findUnique.mockResolvedValue({ data: ['c.example'] });
-    dbMock.dbWrite.blocklist.update.mockResolvedValue({
-      id: 8,
-      type: BlocklistType.EmailDomain,
-      data: ['c.example', 'new.example'],
-    });
+    // The merge now reads through a locking `SELECT ... FOR UPDATE`, so the row the edit starts
+    // from comes back here rather than from `findUnique`.
+    dbMock.dbWrite.$queryRaw.mockResolvedValue([{ data: ['c.example'] }]);
+    dbMock.dbWrite.blocklist.updateMany.mockResolvedValue({ count: 1 });
   };
 
   const cachedPayload = () => {
@@ -277,6 +275,63 @@ describe('what an edit writes into the cache', () => {
     });
 
     expect(redisMock.redis.set.mock.calls.at(-1)?.[0]).toBe('system:blocklist:EmailDomain');
+  });
+});
+
+describe('what an edit is allowed to touch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisGet.mockResolvedValue(null);
+  });
+
+  // The id and the type reach `upsertBlocklist` as two independent values — in the moderator
+  // spoke they are two form fields on the same POST. Scoping the statements to the id alone
+  // let one type's entries be merged into another type's row, which on a deny list means
+  // arbitrary strings start blocking things.
+  it('refuses an id that belongs to no row of the submitted type, and writes nothing', async () => {
+    dbMock.dbWrite.$queryRaw.mockResolvedValue([]);
+
+    await expect(
+      upsertBlocklist({
+        id: 1,
+        type: BlocklistType.MessagePattern,
+        blocklist: ['unfreeze your funds'],
+      })
+    ).rejects.toThrow(/does not belong to this type/);
+
+    expect(dbMock.dbWrite.blocklist.updateMany).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.blocklist.create).not.toHaveBeenCalled();
+    expect(redisMock.redis.set).not.toHaveBeenCalled();
+  });
+
+  it('carries the type into the UPDATE as well as the locking read', async () => {
+    dbMock.dbWrite.$queryRaw.mockResolvedValue([{ data: ['a.example'] }]);
+    dbMock.dbWrite.blocklist.updateMany.mockResolvedValue({ count: 1 });
+
+    await upsertBlocklist({
+      id: 1,
+      type: BlocklistType.EmailDomain,
+      blocklist: ['new.example'],
+    });
+
+    expect(dbMock.dbWrite.blocklist.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 1, type: BlocklistType.EmailDomain },
+      })
+    );
+
+    // The read is raw SQL, so the mock answers whatever it is asked and cannot tell a correctly
+    // scoped statement from one scoped to the id alone. Read the statement instead. The
+    // interpolated values are asserted separately because joining the template's static parts
+    // drops them.
+    const [fragments, ...values] = dbMock.dbWrite.$queryRaw.mock.calls[0] as [
+      readonly string[],
+      ...unknown[]
+    ];
+    const statement = fragments.join('?').replace(/\s+/g, ' ');
+    expect(statement).toMatch(/type = \?/);
+    expect(statement).toMatch(/FOR UPDATE/);
+    expect(values).toEqual([1, BlocklistType.EmailDomain]);
   });
 });
 

--- a/src/server/services/blocklist.service.ts
+++ b/src/server/services/blocklist.service.ts
@@ -28,6 +28,35 @@ async function setCache({ type, data }: { type: string; data: BlocklistDTO }) {
   });
 }
 
+/**
+ * 🔴 DELETE, never a re-read written back. Writing a snapshot is itself a read-modify-write with no
+ * lock over it, so two edits the row lock correctly serialised could still land their cache writes
+ * in the other order, leaving the LOSER's list under a month TTL. Every enforcement path reads this
+ * key first, so that is the lost update the row lock exists to prevent, moved to the artifact that
+ * actually gates. Deletes commute; the next read repopulates.
+ *
+ * The moderator spoke busts the same key the same way. The two must agree.
+ *
+ * Never throws: the row is already committed by the time this runs, and the caller reporting
+ * failure for a write that succeeded invites a retry of a write that already landed — the rule
+ * `a04fa6a608` established for the session cache.
+ */
+async function bustCache(type: string) {
+  try {
+    await redis.del(getBlocklistKey(type));
+  } catch (error) {
+    logToAxiom({
+      name: 'blocklist-cache-bust-failed',
+      type: 'error',
+      message: 'Blocklist row was written but its cache key was not cleared; readers stay stale',
+      details: {
+        blocklistType: type,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    }).catch(() => undefined);
+  }
+}
+
 /** An `id` that belongs to no row of the submitted `type`. Twin of the moderator spoke's. */
 export class BlocklistRowMismatchError extends Error {
   constructor() {
@@ -41,37 +70,65 @@ export async function upsertBlocklist({ id, type, blocklist }: UpsertBlocklistSc
     ...new Set(blocklist.map((item) => item.toLowerCase()).filter((x) => x.length > 0)),
   ];
 
-  if (!id) {
-    await dbWrite.blocklist.create({ data: { data: blocklistData, type }, select: { id: true } });
-  } else {
-    // The read and the write share one transaction and the read takes a row lock. The merge is
-    // read-modify-write over the whole array, so two overlapping edits each computed their merge
-    // from the same pre-state and the later write restored what the earlier one dropped, both
-    // reporting success. The other writer is the moderator spoke, editing the same column through
-    // its own client — which is why the lock has to be in the database rather than in either app.
-    const merged = await dbWrite.$transaction(async (tx) => {
-      const locked = await tx.$queryRaw<{ data: string[] }[]>`
-        SELECT data FROM "Blocklist" WHERE id = ${id} AND type = ${type} FOR UPDATE
-      `;
-      if (!locked.length) return undefined;
+  // The read and the write share one transaction and the read takes a row lock. The merge is
+  // read-modify-write over the whole array, so two overlapping edits each computed their merge
+  // from the same pre-state and the later write restored what the earlier one dropped, both
+  // reporting success. The other writer is the moderator spoke, editing the same column through
+  // its own client — which is why the lock has to be in the database rather than in either app.
+  const merged = await dbWrite.$transaction(
+    async (tx) => {
+      // Scoped to `type` always, and to `id` only when one was given — the same rule as the
+      // spoke's `readRowForWrite`, and the two have to agree because they write one Redis key.
+      // With no id it locks the LOWEST row of the type, which is the row `readBlocklistRow`
+      // enforces, so an add can never append to a duplicate row nobody reads.
+      //
+      // Verified against dev Postgres 18 through Prisma 6.13 rather than assumed: a `text[]`
+      // column comes back from `$queryRaw` as a real JS array, so the spread below merges
+      // entries and not characters.
+      const locked =
+        id === undefined
+          ? await tx.$queryRaw<{ id: number; data: string[] }[]>`
+              SELECT id, data FROM "Blocklist" WHERE type = ${type} ORDER BY id ASC FOR UPDATE
+            `
+          : await tx.$queryRaw<{ id: number; data: string[] }[]>`
+              SELECT id, data FROM "Blocklist" WHERE id = ${id} AND type = ${type} FOR UPDATE
+            `;
+
+      if (!locked.length) {
+        // An `id` naming no row of this type is refused, never turned into an insert: a second row
+        // for a type is the state `readBlocklistRow` exists to survive.
+        if (id !== undefined) return undefined;
+        await tx.blocklist.create({ data: { data: blocklistData, type }, select: { id: true } });
+        return blocklistData;
+      }
 
       const next = [...new Set([...locked[0].data, ...blocklistData])];
-      // `updateMany`, not `update`: it is the only Prisma write that takes a non-unique `where`,
-      // and `type` has to be in it. The posted id and the posted type are independent inputs, so
-      // without that predicate an id from another type merges these entries into that row —
-      // benign phrases into a deny list, phishing patterns into the email-domain list.
-      await tx.blocklist.updateMany({ where: { id, type }, data: { data: next } });
+      // `updateMany`, not `update`: it is the only Prisma UPDATE that takes a non-unique
+      // `where`, and `type` has to be in it. The posted id and the posted type are independent
+      // inputs, so without that predicate an id from another type merges these entries into that
+      // row — benign phrases into a deny list, phishing patterns into the email-domain list.
+      // (`@updatedAt` still applies here; measured, because `updateMany` skipping it would have
+      // been invisible.)
+      const { count } = await tx.blocklist.updateMany({
+        where: { id: locked[0].id, type },
+        data: { data: next },
+      });
+      // Unreachable while the locking read above holds: a row it returned is locked to commit,
+      // so nothing can delete or re-type it underneath. Asserted anyway so the guarantee is
+      // local — anyone who later moves either statement out of this transaction gets a failure
+      // instead of a silent zero-row success that then caches a stale row for a month.
+      if (count !== 1) throw new Error(`blocklist update matched ${count} rows under a row lock`);
       return next;
-    });
+    },
+    // Prisma's defaults are maxWait 2s / timeout 5s, and this path had no transaction before, so
+    // both ceilings are new. The one caller is a weekly cron with no retry: a 2s wait for a
+    // connection on a busy pool would cost a week's worth of disposable-domain additions.
+    { maxWait: 10_000, timeout: 30_000 }
+  );
 
-    // Refusing beats falling back to an insert: creating a second row for the type is the
-    // duplicate-row state `readBlocklistRow` exists to work around.
-    if (!merged) throw new BlocklistRowMismatchError();
-  }
+  if (!merged) throw new BlocklistRowMismatchError();
 
-  // Refresh from the deterministic read, not from the row just written: caching that is what let
-  // an edit to a duplicate row silently promote it to the live one.
-  await setCache({ type, data: await readBlocklistRow(type as BlocklistType) });
+  await bustCache(type);
 }
 
 /**

--- a/src/server/services/blocklist.service.ts
+++ b/src/server/services/blocklist.service.ts
@@ -28,29 +28,50 @@ async function setCache({ type, data }: { type: string; data: BlocklistDTO }) {
   });
 }
 
+/** An `id` that belongs to no row of the submitted `type`. Twin of the moderator spoke's. */
+export class BlocklistRowMismatchError extends Error {
+  constructor() {
+    super('That blocklist row does not belong to this type.');
+    this.name = 'BlocklistRowMismatchError';
+  }
+}
+
 export async function upsertBlocklist({ id, type, blocklist }: UpsertBlocklistSchema) {
-  const existingBlocklistData = !id
-    ? []
-    : await dbWrite.blocklist
-        .findUnique({ where: { id }, select: { data: true } })
-        .then((result) => result?.data ?? []);
+  const blocklistData = [
+    ...new Set(blocklist.map((item) => item.toLowerCase()).filter((x) => x.length > 0)),
+  ];
 
-  const blocklistData = blocklist.map((item) => item.toLowerCase()).filter((x) => x.length > 0);
+  if (!id) {
+    await dbWrite.blocklist.create({ data: { data: blocklistData, type }, select: { id: true } });
+  } else {
+    // The read and the write share one transaction and the read takes a row lock. The merge is
+    // read-modify-write over the whole array, so two overlapping edits each computed their merge
+    // from the same pre-state and the later write restored what the earlier one dropped, both
+    // reporting success. The other writer is the moderator spoke, editing the same column through
+    // its own client — which is why the lock has to be in the database rather than in either app.
+    const merged = await dbWrite.$transaction(async (tx) => {
+      const locked = await tx.$queryRaw<{ data: string[] }[]>`
+        SELECT data FROM "Blocklist" WHERE id = ${id} AND type = ${type} FOR UPDATE
+      `;
+      if (!locked.length) return undefined;
 
-  const result = !id
-    ? await dbWrite.blocklist.create({
-        data: { data: blocklistData, type },
-        select: { id: true, type: true, data: true },
-      })
-    : await dbWrite.blocklist.update({
-        where: { id },
-        data: { data: [...new Set([...existingBlocklistData, ...blocklistData])] },
-        select: { id: true, type: true, data: true },
-      });
-  if (!result) throw new Error('failed to update blocklist');
-  // Refresh from the deterministic read, not from `result`: caching the row just written
-  // is what let an edit to a duplicate row silently promote it to the live one.
-  await setCache({ type: result.type, data: await readBlocklistRow(result.type as BlocklistType) });
+      const next = [...new Set([...locked[0].data, ...blocklistData])];
+      // `updateMany`, not `update`: it is the only Prisma write that takes a non-unique `where`,
+      // and `type` has to be in it. The posted id and the posted type are independent inputs, so
+      // without that predicate an id from another type merges these entries into that row —
+      // benign phrases into a deny list, phishing patterns into the email-domain list.
+      await tx.blocklist.updateMany({ where: { id, type }, data: { data: next } });
+      return next;
+    });
+
+    // Refusing beats falling back to an insert: creating a second row for the type is the
+    // duplicate-row state `readBlocklistRow` exists to work around.
+    if (!merged) throw new BlocklistRowMismatchError();
+  }
+
+  // Refresh from the deterministic read, not from the row just written: caching that is what let
+  // an edit to a duplicate row silently promote it to the live one.
+  await setCache({ type, data: await readBlocklistRow(type as BlocklistType) });
 }
 
 /**

--- a/src/server/services/blocklist.service.ts
+++ b/src/server/services/blocklist.service.ts
@@ -30,10 +30,15 @@ async function setCache({ type, data }: { type: string; data: BlocklistDTO }) {
 
 /**
  * 🔴 DELETE, never a re-read written back. Writing a snapshot is itself a read-modify-write with no
- * lock over it, so two edits the row lock correctly serialised could still land their cache writes
- * in the other order, leaving the LOSER's list under a month TTL. Every enforcement path reads this
- * key first, so that is the lost update the row lock exists to prevent, moved to the artifact that
- * actually gates. Deletes commute; the next read repopulates.
+ * lock over it, so two WRITERS the row lock correctly serialised could still land their cache writes
+ * in the other order, leaving the LOSER's list under a month TTL. Deletes commute with each other,
+ * so that ordering no longer decides anything.
+ *
+ * ⚠️ What this does NOT close: a DELETE does not commute with the POPULATE in `getBlocklistDTO`,
+ * which is plain cache-aside. A reader that missed and read the row before the commit can `set` its
+ * pre-write snapshot AFTER the bust, pinning it for the month TTL. A write guarantees the next read
+ * misses, so a bust actively drives readers into that window. Closing it needs a lease, a version,
+ * or a TTL short enough to bound the staleness; none of those is in this change.
  *
  * The moderator spoke busts the same key the same way. The two must agree.
  *
@@ -79,8 +84,14 @@ export async function upsertBlocklist({ id, type, blocklist }: UpsertBlocklistSc
     async (tx) => {
       // Scoped to `type` always, and to `id` only when one was given — the same rule as the
       // spoke's `readRowForWrite`, and the two have to agree because they write one Redis key.
-      // With no id it locks the LOWEST row of the type, which is the row `readBlocklistRow`
-      // enforces, so an add can never append to a duplicate row nobody reads.
+      // With no id it locks the rows of the type in id order and takes the FIRST, which is the row
+      // `readBlocklistRow` enforces — so an add can never append to an EXISTING duplicate row
+      // nobody reads. It does not stop one being created; see the create branch below.
+      //
+      // 🔴 `ORDER BY id ASC` and `locked[0]` are one decision, not two. Reading `locked.at(-1)`
+      // here merges into the highest-id row while the SQL still says ASC, which is the
+      // duplicate-row promotion this file exists to prevent, with the ordering still in the
+      // statement to reassure whoever greps for it.
       //
       // Verified against dev Postgres 18 through Prisma 6.13 rather than assumed: a `text[]`
       // column comes back from `$queryRaw` as a real JS array, so the spread below merges
@@ -97,6 +108,12 @@ export async function upsertBlocklist({ id, type, blocklist }: UpsertBlocklistSc
       if (!locked.length) {
         // An `id` naming no row of this type is refused, never turned into an insert: a second row
         // for a type is the state `readBlocklistRow` exists to survive.
+        //
+        // ⚠️ The create below is NOT serialised. `FOR UPDATE` locks nothing when it matches
+        // nothing, so two concurrent no-id upserts for a type with no row both reach it and the
+        // type ends up with two. Unreachable from this app — the only caller always passes an id —
+        // but the spoke's twin is reachable, and the closes are a unique index on `Blocklist.type`
+        // or an advisory lock on the type, not this predicate.
         if (id !== undefined) return undefined;
         await tx.blocklist.create({ data: { data: blocklistData, type }, select: { id: true } });
         return blocklistData;
@@ -132,13 +149,15 @@ export async function upsertBlocklist({ id, type, blocklist }: UpsertBlocklistSc
 }
 
 /**
- * Nothing stops a type having more than one row, and `EmailDomain` has two in production
- * — 8292 entries against 3, with the 3 present in neither the other row nor anything
- * else. The old read took `findFirst` with no `orderBy`, so which set was live was up to
- * Postgres; worse, `upsertBlocklist` wrote the row it had just touched into a cache key
- * scoped to the TYPE, so the last row a moderator edited won for a month regardless. The
- * loser's entries were simply not enforced, and the winner could change on an unrelated
- * edit.
+ * Nothing stops a type having more than one row. `EmailDomain` had two in production when this
+ * was written — 8292 entries against 3, the 3 present nowhere else — and the old `findFirst` with
+ * no `orderBy` let Postgres decide which set was enforced. (Re-checked 2026-08-24: every type now
+ * has exactly one row, so the guard is currently inert. It is kept because nothing PREVENTS a
+ * duplicate; see the first-insert race in `upsertBlocklist`.)
+ *
+ * No writer calls this any more. Its one caller is the cache-aside populate in `getBlocklistDTO` —
+ * so this is what decides which row the whole system enforces, and a write busts the key, making
+ * the next read a post-write read that pins a value for a month.
  *
  * This picks the lowest id, always, and reports the duplicate. It deliberately does NOT
  * union the rows: for a deny-list a union blocks more, but for the benign lists a union

--- a/src/server/services/blocklist.service.ts
+++ b/src/server/services/blocklist.service.ts
@@ -36,9 +36,14 @@ async function setCache({ type, data }: { type: string; data: BlocklistDTO }) {
  *
  * ⚠️ What this does NOT close: a DELETE does not commute with the POPULATE in `getBlocklistDTO`,
  * which is plain cache-aside. A reader that missed and read the row before the commit can `set` its
- * pre-write snapshot AFTER the bust, pinning it for the month TTL. A write guarantees the next read
- * misses, so a bust actively drives readers into that window. Closing it needs a lease, a version,
- * or a TTL short enough to bound the staleness; none of those is in this change.
+ * pre-write snapshot AFTER the bust, pinning it for the month TTL.
+ *
+ * The causation runs to the NEXT write, not this one: a bust guarantees the following read misses,
+ * so a reader is typically mid-fill when the write AFTER this one commits — and back-to-back writes
+ * are ordinary here, a moderator removing chips one at a time. This write's own bust cannot put a
+ * reader into this write's window, because a miss it caused reads a row that is already updated.
+ * Closing it needs a lease, a version, or a TTL short enough to bound the staleness; none of those
+ * is in this change.
  *
  * The moderator spoke busts the same key the same way. The two must agree.
  *


### PR DESCRIPTION
Closes `868kuacyb` and `868kv0wpm`. Two defects on the same two statements, in both copies of the service, so one PR rather than two that rewrite each other.

## 868kuacyb — add/remove acted on a raw id

The posted `id` and the posted `type` are two independent form fields. The route validated the type against `BLOCKLIST_TYPES` but never checked the id belonged to it, and every statement filtered on the id alone.

Posting `type=MessagePattern` with the `EmailDomain` row id merged phishing patterns into the email deny list. `setCache` then refreshed under the row's real type, so the page reloaded unchanged while the banner said "Added 1 item." `remove` took an id with no type at all.

Both statements now carry the type. An id belonging to no row of the submitted type is **refused**, not silently turned into an insert.

**The insert branch was the live half.** With no `id` the old code inserted unconditionally — and `UsernameExact` is one of the eight tabs with **no row in production** (verified: 8 rows, one per type), so every add on that tab is an insert. Two moderators, or one with a stale tab, gave the type a second row whose entries `readBlocklistRow` never enforces, above a banner saying "Added N items." No forgery needed. `id=abc` or `id=0` also reached that branch, since the route coerced with `idRaw ? Number(idRaw) : undefined`.

The locking read is now scoped to `type` always and to `id` only when one was posted; with no id it locks the **lowest row of the type** — the row `readBlocklistRow` enforces — and merges into it, inserting only when the type genuinely has none.

The ticket's second half — remove reporting success when nothing was removed — was already fixed on `main` by #4254's `fail(409)`. Verified, not assumed.

## 868kv0wpm — read-modify-write with no lock

Both writers read the whole `text[]`, computed a new array in JS, and wrote it back, outside any transaction. Two overlapping edits each started from the same pre-state and the later write restored what the earlier one dropped. Both reported success.

The read and the write now share one transaction and the read takes a row lock.

**Measured against a real Postgres 18**, two concurrent removals of `a` and `b` from `["a","b","c","d"]`, each with a 250 ms window between read and write:

| | result |
|---|---|
| no lock | `["a","c","d"]` — `a` came back |
| `FOR UPDATE` | `["c","d"]` |

### The cache was the other half of the same bug

Two reviewers caught this independently, and they were right. Writing `setCache(await readBlocklistRow(type))` after the commit is **itself** an unserialised read-modify-write over `system:blocklist:<type>`, under a month-long TTL — so two edits the row lock had correctly serialised could still land their cache writes in the other order and leave the loser's list cached. Every enforcement path reads Redis first and only falls through on a miss, so that is the same lost update, moved from the row to the artifact that actually gates.

Writers now **DELETE** the key. Deletes commute; the next read repopulates from the table. It also makes the old duplicate-row-promotion incident unrepresentable rather than merely guarded — there is no snapshot left to pick the wrong row for.

A failed bust no longer 500s a write that already committed (the rule `a04fa6a608` set for the session cache). It is logged to Axiom, and the page says the row was written but its cached copy may be stale — because the alternative, on the remove path, is an operator retrying, being told "Nothing was removed", reloading onto the stale cache, and seeing the chip still there.

## Two driver assumptions, settled rather than assumed

A review called `$queryRaw<{ data: string[] }>` an unverified assumption on a destructive path: if a `text[]` came back in its literal form, the spread would merge **characters**, turning an 8,292-entry list into ~90k one-character entries inside a weekly cron that then logs success. Fair, and no mock could ever have told us. Run against dev Postgres 18 through Prisma 6.13:

```
Array.isArray(data)  : true
spread of data       : ["a.example","b.example"]
updateMany count     : 1
updatedAt moved      : true
```

So the array decoding is fine, and `@updatedAt` survives the `update` → `updateMany` switch — the spoke sets `updatedAt` explicitly and the main app relies on Prisma, and that divergence is now measured rather than believed.

## Choices worth arguing with

- **Not `RETURNING OLD`** for the removed count, which would have made this one statement. It is PG18-only and `docker-compose.base.yml` pins `postgres:17` for local development.
- **Explicit `{ maxWait: 10_000, timeout: 30_000 }`.** This path had no transaction before, so Prisma's 2 s / 5 s defaults are two new ways for it to fail — and the only caller is a weekly cron with no retry, so a busy write pool would cost a week of disposable-domain additions. There is no precedent for explicit options elsewhere in `src/server/services/`.
- **`updateMany`** in the main app: the only Prisma *update* that takes a non-unique `where`, and `type` has to be in it.
- **Add now reports what the row GAINED.** Re-adding entries already present is a no-op, and "Added 50 items" over 48 duplicates is the defect the removal count was fixed for, on the other half of the same page. A submission that adds nothing now returns 409 rather than a success banner — the one moderator-visible behaviour change here.

## Mutation controls

Every row is a deliberate revert, run against the suite it belongs to.

| mutation | result |
|---|---|
| spoke: transaction wrapper deleted, statements on the bare client | 1 failed — *the statements must run inside a transaction* |
| spoke: `forUpdate()` removed | 2 failed — *the read must be FOR UPDATE, on the transaction client* |
| spoke: `type` dropped from the locking read | 3 failed |
| spoke: `type` dropped from the UPDATE only | 2 failed |
| spoke: `DEL` → `SET` a snapshot | 2 failed |
| spoke: failed bust rethrows | 1 failed |
| spoke: insert branch unconditional | 1 failed — *a type that already has a row must not gain a second* |
| spoke: count reports the submission | 2 failed |
| main: transaction wrapper deleted | 2 failed — *the locked read must run inside the transaction* |
| main: `DEL` → `SET` | 1 failed |
| main: failed bust rethrows | 1 failed |
| main: no-id branch always inserts | 1 failed |
| main: transaction options removed | 1 failed — `expected 5000 to be greater than 5000` |

All are assertion failures naming a wrong value, in single-digit milliseconds. None is a timeout or a hang.

One of these first came back as `Tests no tests` — a mutant that failed to **compile**, which exits looking exactly like one that was caught. It was rewritten to compile before being believed.

### The fakes were the reason two of those were needed

Both suites' transaction fakes handed the callback the **same** client object the assertions read, so deleting the `$transaction` wrapper left every test green with `FOR UPDATE` held by a transaction that had already committed. An inert lock is the shape that reads as fixed and is not. Both fakes now use a distinct `trx` object and assert which client each statement ran on.

## Verification

- `pnpm run typecheck` — 0 errors
- `apps/moderator` `svelte-check` — 9350 files, 0 errors. ⚠️ It first reported a **stale** `$types`: `svelte-check` resolves `ActionData` through a generated `proxy+page.server.ts` that only `svelte-kit sync` rewrites, and it still held the previous commit's action returns. `sync` fixed it with no source change. `CLAUDE.md` says to reach for `check` only after changing the **route tree**; changing what an action *returns* goes stale the same way.
- `pnpm run lint` clean on the changed files; `apps/moderator` lint clean
- `pnpm run test:lint-rules` — `Test Files 18 passed (18)`
- `pnpm run test:apps:run` — `Test Files 83 passed (83)`
- `pnpm run test:unit:run` — `Test Files 1383 passed | 1 skipped (1384)`, `Tests 21757 passed | 27 skipped (21784)`, exit 0
- `blocks.router.workflow.test.ts` collected **358 tests**, so the submodule is initialised and the run means something

## What this still does not fix

Two adds for a type that has **no row at all** can still both insert: there is no row to lock. The window is narrow and the outcome is survivable — `readBlocklistRow` picks deterministically and reports the duplicate to Axiom — but it is real.

The honest close is a unique index on `Blocklist.type`. My first pass deferred that saying the two live `EmailDomain` rows had to be consolidated first; **that rationale was stale** — production now has exactly one row per type, so `CREATE UNIQUE INDEX CONCURRENTLY` is available today. Filing it rather than folding a migration into this PR.

Also noted and not touched: `apps/auth/src/lib/server/auth/blocklist.ts` repopulates `system:blocklist:EmailDomain` on a cold cache with no `orderBy` — a third writer of this key that picks an arbitrary row. Pre-existing, and its own ticket.

No migration. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
