### PR TITLE
feat(text-moderation): measure a text policy per surface, and let one surface run it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,8 @@ docs/working/
 docs/incidents/
 .claude/*.local.*
 .claude/skills/cloudflare/.port-tmp-path
+# Also holds the XGuard tuning harness: scanner policy prose and corpora extracted
+# from prod. This repo is public; a policy file here would be an evasion guide.
 local/
 .eslintcache
 nul

--- a/apps/moderator/src/lib/server/xguard-api.ts
+++ b/apps/moderator/src/lib/server/xguard-api.ts
@@ -8,6 +8,22 @@ import { env } from '$env/dynamic/private';
 export function labConnectionString(): string {
   const url = env.MODERATOR_DATABASE_URL;
   if (!url) error(500, 'MODERATOR_DATABASE_URL is not configured');
+
+  // Consumers of this string build a bare `pg.Client`, which verifies the certificate chain. The
+  // cnpg pooler presents a self-signed one, so `sslmode=require` fails there with
+  // SELF_SIGNED_CERT_IN_CHAIN — encrypted-but-unverified is what this host needs. Rewriting it here
+  // rather than at each call site because eval-core and rate-core each open their own connection.
+  // An explicit `sslmode=disable` (a plain local docker Postgres) is left alone.
+  try {
+    const parsed = new URL(url);
+    const sslmode = parsed.searchParams.get('sslmode');
+    if (sslmode && sslmode !== 'disable' && sslmode !== 'no-verify') {
+      parsed.searchParams.set('sslmode', 'no-verify');
+      return parsed.toString();
+    }
+  } catch {
+    // Not a parseable URL — hand it back untouched and let pg report the real problem.
+  }
   return url;
 }
 

--- a/apps/moderator/src/lib/server/xguard-lab.ts
+++ b/apps/moderator/src/lib/server/xguard-lab.ts
@@ -114,11 +114,19 @@ function labUrl(): string {
 
 // `sslNoVerify` turns SSL ON while skipping cert verification, which is what the cnpg cluster
 // needs and what a plain local docker Postgres rejects outright ("The server does not support SSL
-// connections"). Decide from the host so the same code works in both places.
-function isLocalHost(url: string): boolean {
+// connections").
+//
+// An explicit `sslmode` in the URL decides it; the hostname is only consulted when the URL says
+// nothing. Reading the hostname first is wrong because the cluster is reached in dev through a
+// local port-forward, so a cnpg tunnel and the docker-compose Postgres are both `localhost` and
+// the two need opposite answers.
+function wantsSsl(url: string): boolean {
   try {
-    const { hostname } = new URL(url);
-    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+    const parsed = new URL(url);
+    const sslmode = parsed.searchParams.get('sslmode');
+    if (sslmode) return sslmode !== 'disable';
+    const { hostname } = parsed;
+    return !(hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1');
   } catch {
     return false;
   }
@@ -134,7 +142,7 @@ function createLabDb(): Kysely<LabDB> {
   const { dbWrite } = createKyselyClients<LabDB>({
     connectionString: url,
     replicaConnectionString: url,
-    sslNoVerify: !isLocalHost(url),
+    sslNoVerify: wantsSsl(url),
   });
   return dbWrite;
 }

--- a/apps/moderator/src/routes/api/xguard/runs/+server.ts
+++ b/apps/moderator/src/routes/api/xguard/runs/+server.ts
@@ -82,6 +82,12 @@ export const POST = defineWebhookEndpoint({
       .max(1)
       .optional()
       .describe("Override the version's stored threshold."),
+    mode: z
+      .enum(['prompt', 'text'])
+      .optional()
+      .describe(
+        'Override the scanner to measure against. Normally omit it: the mode is derived from the samples themselves (model listings are `text`, generation prompts are `prompt`). Pass it only to force a comparison the data would not choose.'
+      ),
     note: z
       .string()
       .trim()
@@ -94,7 +100,7 @@ export const POST = defineWebhookEndpoint({
   notes: [
     'A run needs confirmed ground truth. With none, this fails 400 rather than producing a run of n/a.',
   ],
-  handler: async ({ label, version, batch, threshold, note }) => {
+  handler: async ({ label, version, batch, threshold, mode, note }) => {
     let resolveRunId: (id: string) => void = () => {};
     const created = new Promise<string>((resolve) => {
       resolveRunId = resolve;
@@ -106,6 +112,7 @@ export const POST = defineWebhookEndpoint({
       policyVersion: version,
       batch,
       thresholdOverride: threshold,
+      mode,
       note,
       orchestrator: orchestratorEnv(),
       onRunCreated: resolveRunId,

--- a/apps/moderator/src/routes/xguard/labels/[name]/+page.server.ts
+++ b/apps/moderator/src/routes/xguard/labels/[name]/+page.server.ts
@@ -2,7 +2,7 @@ import { error, fail } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import { requireAccess } from '$lib/server/access';
 import { getLabDb } from '$lib/server/xguard-lab';
-import { env } from '$env/dynamic/private';
+import { labConnectionString, orchestratorEnv } from '$lib/server/xguard-api';
 import { runEvaluation } from '../../../../../xguard-lab/eval-core';
 
 // Policy editor. Every save is a NEW version, never an update in place: `eval_run.policy_id`
@@ -106,16 +106,16 @@ export const actions: Actions = {
     const version = Number(form.get('version'));
     if (!Number.isFinite(version)) return fail(400, { message: 'Pick a version to evaluate' });
 
-    const connectionString = env.MODERATOR_DATABASE_URL;
-    if (!connectionString)
-      return fail(500, { message: 'MODERATOR_DATABASE_URL is not configured' });
-
     try {
+      // `labConnectionString()` rather than the raw env var: this opens a bare `pg.Client`, which
+      // verifies the certificate chain the cnpg pooler cannot satisfy. No `mode` — it is derived
+      // from the samples, so clicking Evaluate cannot measure a batch against the wrong scanner.
       const summary = await runEvaluation({
-        connectionString,
+        connectionString: labConnectionString(),
         label: params.name,
         policyVersion: version,
         note: `from the policy editor`,
+        orchestrator: orchestratorEnv(),
       });
       return { evaluated: summary };
     } catch (err) {

--- a/apps/moderator/xguard-lab/README.md
+++ b/apps/moderator/xguard-lab/README.md
@@ -4,7 +4,7 @@ Infrastructure for developing XGuard labels: sample live prompts, have a model r
 
 The point is the loop, not any one label. Adding a label is adding an entry to `labels.ts` and running the rater again over samples you already have.
 
-Scoping doc: `_local/docs/plans/xguard-regex-retirement-scoping.md`. Tuning harness: `_local/docs/plans/xguard-age-labels/`.
+Scoping doc: `local/xguard-regex-retirement-scoping.md`. Tuning harness: `local/xguard-tuning-harness/`.
 
 ## Which database
 

--- a/apps/moderator/xguard-lab/eval-core.ts
+++ b/apps/moderator/xguard-lab/eval-core.ts
@@ -13,7 +13,7 @@
  * both, which is what the types here claim.
  */
 import pg from 'pg';
-import { scan, type LabelPolicy, type OrchestratorConfig } from './xguard-client';
+import { scan, type LabelPolicy, type OrchestratorConfig, type XGuardMode } from './xguard-client';
 
 export type EvalOptions = {
   connectionString: string;
@@ -22,6 +22,12 @@ export type EvalOptions = {
   policyVersion?: number;
   /** Restrict to one sampling batch. Omit for every sample with ground truth. */
   batch?: string;
+  /**
+   * Which scanner to measure against. Must match how the content is scanned in production, or the
+   * run reports a number for a registry the content never passes through — model listings are
+   * `text`, generation prompts are `prompt`.
+   */
+  mode?: XGuardMode;
   thresholdOverride?: number;
   concurrency?: number;
   limit?: number;
@@ -39,6 +45,8 @@ export type EvalOptions = {
 export type EvalSummary = {
   runId: string;
   label: string;
+  /** Scanner this run actually measured against, after resolution. Never assume it. */
+  mode: XGuardMode;
   policyLabel: string;
   threshold: number;
   total: number;
@@ -59,6 +67,7 @@ type GroundTruthRow = {
   sample_id: string;
   positive_prompt: string;
   negative_prompt: string | null;
+  source: string;
   expected: boolean;
   reviewers: string;
 };
@@ -72,6 +81,7 @@ const GROUND_TRUTH_SQL = `
   SELECT h.sample_id::text AS sample_id,
          s.positive_prompt,
          s.negative_prompt,
+         s.source,
          count(*) FILTER (WHERE h.verdict) > count(*) FILTER (WHERE NOT h.verdict) AS expected,
          count(*) AS reviewers
     FROM human_judgement h
@@ -79,10 +89,51 @@ const GROUND_TRUTH_SQL = `
    WHERE h.label = $1
      AND h.excluded_reason IS NULL
      AND ($2::text IS NULL OR s.batch = $2)
-   GROUP BY h.sample_id, s.positive_prompt, s.negative_prompt
+   GROUP BY h.sample_id, s.positive_prompt, s.negative_prompt, s.source
   HAVING count(*) FILTER (WHERE h.verdict) <> count(*) FILTER (WHERE NOT h.verdict)
    ORDER BY h.sample_id
 `;
+
+/**
+ * Which scanner a sample belongs to, by where it came from.
+ *
+ * Derived rather than defaulted, because a default is silent and wrong half the time: an operator
+ * clicking Evaluate has no reason to know that `prompt` and `text` are different registries, and a
+ * run measured against the wrong one still returns a confident-looking number.
+ *
+ * An unknown source throws instead of falling back. A new sampler is one line here; a silent
+ * fallback is a number nobody can trust.
+ */
+const MODE_BY_SOURCE: Record<string, XGuardMode> = {
+  xguardPromptResults: 'prompt',
+  // Every entity that flows through EntityModeration is scanned in text mode. The sampler writes
+  // `source` as the entity type lowercased, so a new one is a line here, not a code change.
+  model: 'text',
+  article: 'text',
+  challenge: 'text',
+  wildcardsetcategory: 'text',
+};
+
+function resolveMode(sources: string[], override?: XGuardMode): XGuardMode {
+  if (override) return override;
+  const distinct = [...new Set(sources)];
+  const modes = new Set(
+    distinct.map((s) => {
+      const mode = MODE_BY_SOURCE[s];
+      if (!mode)
+        throw new Error(
+          `sample source "${s}" has no scanner mapping — add it to MODE_BY_SOURCE in eval-core.ts, or pass an explicit mode`
+        );
+      return mode;
+    })
+  );
+  // Two scanners averaged into one precision number is not a measurement of either.
+  if (modes.size > 1)
+    throw new Error(
+      `this ground truth mixes scanner modes (${[...modes].join(', ')}) — evaluate one batch at a time, or pass an explicit mode`
+    );
+  return [...modes][0];
+}
 
 export async function runEvaluation(opts: EvalOptions): Promise<EvalSummary> {
   const client = new pg.Client({ connectionString: opts.connectionString });
@@ -117,7 +168,17 @@ export async function runEvaluation(opts: EvalOptions): Promise<EvalSummary> {
       policyLabel = `v${opts.policyVersion}`;
     } else {
       // Empty policy = don't send an override = measure the live registry.
-      policy = { label: opts.label, policy: '', threshold: opts.thresholdOverride ?? 0.4 };
+      //
+      // The threshold is REQUIRED here rather than defaulted. A baseline exists to say what
+      // production does today, and production's threshold lives in the orchestrator registry, not
+      // in this file — a default silently measures a different operating point and records it as
+      // "live". That has happened, and the resulting number was believed for a day.
+      if (opts.thresholdOverride === undefined)
+        throw new Error(
+          `a live baseline needs an explicit threshold — read the label's real one with ` +
+            `\`xguard-manager get <prompt|text>\` and pass it, so the number describes production`
+        );
+      policy = { label: opts.label, policy: '', threshold: opts.thresholdOverride };
       policyLabel = 'live';
     }
 
@@ -134,6 +195,14 @@ export async function runEvaluation(opts: EvalOptions): Promise<EvalSummary> {
       );
     }
 
+    // Resolved from the samples themselves, before anything is scanned. `eval_run` has no column
+    // for it, so it is prefixed onto the note — a run whose mode you cannot recover is a number you
+    // cannot compare against any other run.
+    const mode = resolveMode(
+      rows.map((r) => r.source),
+      opts.mode
+    );
+
     const { rows: runRows } = await client.query<{ id: string }>(
       `INSERT INTO eval_run (label, policy_id, policy_label, threshold, batch, total, note)
        VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id::text`,
@@ -144,14 +213,14 @@ export async function runEvaluation(opts: EvalOptions): Promise<EvalSummary> {
         policy.threshold,
         opts.batch ?? null,
         rows.length,
-        opts.note ?? null,
+        `[${mode}] ${opts.note ?? ''}`.trim(),
       ]
     );
     const runId = runRows[0].id;
     opts.onRunCreated?.(runId);
 
     try {
-      return await score(client, runId, rows, policy, policyId, policyLabel, opts);
+      return await score(client, runId, rows, policy, policyId, policyLabel, mode, opts);
     } catch (err) {
       // A run left on `status = 'running'` is indistinguishable from one still working, so a caller polling
       // for completion would wait forever on a run that died. Record the death.
@@ -178,6 +247,7 @@ async function score(
   policy: LabelPolicy,
   policyId: string | null,
   policyLabel: string,
+  mode: XGuardMode,
   opts: EvalOptions
 ): Promise<EvalSummary> {
   let next = 0;
@@ -199,6 +269,7 @@ async function score(
           const results = await scan({
             input: { positivePrompt: row.positive_prompt, negativePrompt: row.negative_prompt },
             policies: [policy],
+            mode,
             orchestrator: opts.orchestrator,
           });
           const hit = results.find((r) => r.label?.toLowerCase() === opts.label.toLowerCase());
@@ -273,6 +344,7 @@ async function score(
   return {
     runId,
     label: opts.label,
+    mode,
     policyLabel,
     threshold: policy.threshold,
     total: rows.length,

--- a/apps/moderator/xguard-lab/import-policy.ts
+++ b/apps/moderator/xguard-lab/import-policy.ts
@@ -2,7 +2,7 @@
  * Import a policy-set JSON into `label_policy` as the next version of each label it defines.
  *
  *   pnpm exec tsx --env-file=.env apps/moderator/xguard-lab/import-policy.ts \
- *     --file _local/docs/plans/xguard-age-labels/policies/age-split-v6-block.json
+ *     --file local/xguard-tuning-harness/policies/age-split-v6-block.json
  *
  * Same shape the tuning harness uses:
  *   { name, note?, combine?, labels: [{ label, policy, threshold, action? }] }

--- a/apps/moderator/xguard-lab/labels.ts
+++ b/apps/moderator/xguard-lab/labels.ts
@@ -1,18 +1,113 @@
 /**
- * The label set under development.
+ * The label set under development, and the content domains it can be applied to.
  *
- * These rubrics are what the AI rater judges against. They are deliberately NOT
- * the same text as the XGuard policies: XGuard policies are written to steer a
- * small guard model with an `- x:` / `sec` grammar, while these are written to
- * be read by a strong model and, just as importantly, by the moderator deciding
- * whether they agree. If the two ever disagree, this file is the intent.
+ * These rubrics are what the AI rater judges against. They are deliberately NOT the same text as
+ * the XGuard policies: XGuard policies are written to steer a small guard model with an `- x:` /
+ * `sec` grammar, while these are written to be read by a strong model and, just as importantly, by
+ * the moderator deciding whether they agree. If the two ever disagree, this file is the intent.
  *
- * Scope note: age and sexual only for now. Celebrity/POI stays on the existing
- * regex list - it is an intentional block on a name list, and a list is the
- * right tool for that. Violence is deferred.
+ * A LABEL IS A JUDGEMENT; A DOMAIN IS WHAT IT IS READ AGAINST. "Does this text assert a minor" is
+ * the same question whether the text is a generation prompt, a model listing, an article or a
+ * bounty. What changes is the shape of the input and the conventions of the people writing it —
+ * booru activation tags mean one thing in a listing and another in a prompt, and a negative prompt
+ * exists in only one of them. Keeping those apart is what lets one rubric serve every surface
+ * rather than growing a near-duplicate per surface.
+ *
+ * So: put the judgement in `rubric`, put "what is this text" in `DOMAINS`, and put a convention
+ * that genuinely only holds on one surface in `domainNotes`. A rubric that names its surface is a
+ * rubric that cannot be reused.
+ *
+ * Scope note: Celebrity is absent from `prompt` on purpose — POI prompts are blocked on a name
+ * list, which is the right tool for an intentional block. It is present for `modelListing` because
+ * nothing has produced an automated poi signal for a model since the LLM scanner died in 2025-04,
+ * and measuring whether XGuard can is how we find out. Violence is deferred everywhere.
  */
+
+/**
+ * What the text IS. The preamble every rubric is read under, so no rubric has to restate it.
+ */
+export const DOMAINS = {
+  prompt: {
+    label: 'image-generation prompt',
+    preamble: `You judge image-generation prompts. The text is a request for an image: someone is asking a model to produce what it describes.
+
+The prompt may run hundreds of tokens with the deciding term buried in style boilerplate, in a non-English section, or inside a LoRA or embedding filename. Read all of it.
+
+A term appearing ONLY in the negative prompt is an exclusion. The user is asking to avoid it, so it must never make the verdict true.`,
+  },
+  modelListing: {
+    label: 'model listing',
+    preamble: `You judge model listings. The text is an uploader's title, description, and sometimes their trigger words. Nobody is requesting an image — someone is describing an asset they built, so "the text requests X" reasoning does not apply. Judge what the listing claims the model depicts or produces.
+
+Two conventions matter and mislead constantly. A booru-style trigger-word list ("1girl, solo, long_hair, big breasts") is an activation vocabulary the uploader types to invoke a concept, not a description of output. And naming a franchise, game, doujin or artist identifies where a subject came from, not what this model makes.
+
+A bare model name with no description contains nothing to judge.`,
+  },
+  article: {
+    label: 'article',
+    preamble: `You judge articles. The text is an author's title followed by long-form prose they published — a guide, a review, an announcement, a tutorial. Nobody is requesting an image and nobody is describing an asset for download.
+
+Length is the trap here. An article can discuss a subject at length, quote others, describe what a model or image contains, or argue about policy, without itself being the thing it describes. Judge what the article IS, not every topic it mentions in passing.
+
+No label has been measured against this domain yet — no entry in \`LABELS\` claims it. Add one only alongside moderator verdicts on articles, or it will be a rubric nobody has checked.`,
+  },
+} as const;
+
+export type DomainKey = keyof typeof DOMAINS;
+
+/**
+ * Where a sample came from decides which domain it is read as. Derived rather than passed, for the
+ * same reason the scanner mode is: whoever kicks off a rating pass has no reason to know the
+ * distinction exists, and a default is silently wrong for half the batches.
+ *
+ * An unknown source throws. A new sampler is one line here; a silent fallback is a corpus rated
+ * against the wrong preamble with nothing to show for it.
+ */
+export const DOMAIN_BY_SOURCE: Record<string, DomainKey> = {
+  xguardPromptResults: 'prompt',
+  model: 'modelListing',
+  article: 'article',
+};
+
+export function domainForSource(source: string): DomainKey {
+  const domain = DOMAIN_BY_SOURCE[source];
+  if (!domain)
+    throw new Error(
+      `sample source "${source}" has no domain mapping — add it to DOMAIN_BY_SOURCE in labels.ts`
+    );
+  return domain;
+}
+
+export type LabelDef = {
+  description: string;
+  /** The judgement, stated without reference to what kind of text it is read against. */
+  rubric: string;
+  /** Domains this label is meaningful for. A label absent here is not merely untested — it is out of scope. */
+  domains: readonly DomainKey[];
+  /** Rules that genuinely hold on one surface only. Appended after the rubric for that domain. */
+  domainNotes?: Partial<Record<DomainKey, string>>;
+};
+
+/**
+ * Compose what the rater is told: what the text is, then the judgement, then any convention
+ * specific to this surface. One place, so a new domain never means editing every rubric.
+ */
+export function rubricFor(label: LabName, domain: DomainKey): string {
+  // Read through `LabelDef` rather than the `as const` literal: the literal narrows `domains` to
+  // its own tuple, so `includes` would reject every other domain at the type level and
+  // `domainNotes` would not exist on labels that omit it.
+  const def: LabelDef = LABELS[label];
+  if (!def.domains.includes(domain))
+    throw new Error(
+      `label "${label}" is not defined for domain "${domain}" — add it to that label's \`domains\` if it should be`
+    );
+  const note = def.domainNotes?.[domain];
+  return [DOMAINS[domain].preamble, `LABEL: ${label}`, def.rubric, note].filter(Boolean).join('\n\n');
+}
+
 export const LABELS = {
   AgeAsserted: {
+    domains: ['prompt'],
     description: 'The prompt names a person under 18 in words you can quote.',
     rubric: `TRUE when the prompt names a person under 18 in words you can point at and quote.
 
@@ -36,6 +131,7 @@ FALSE for:
   },
 
   AgeNegated: {
+    domains: ['prompt'],
     description: 'The prompt states the subject is an adult.',
     rubric: `TRUE when the prompt states, in words, that the subject is an adult.
 
@@ -54,6 +150,7 @@ FALSE for:
   },
 
   SexualNudity: {
+    domains: ['prompt'],
     description:
       'The prompt requests nudity or exposed genitals, without necessarily requesting an act.',
     rubric: `TRUE when the prompt requests a subject who is nude, partially nude, or has genitals, breasts or buttocks exposed.
@@ -72,6 +169,7 @@ FALSE for:
   },
 
   SexualAct: {
+    domains: ['prompt'],
     description: 'The prompt requests a sex act taking place.',
     rubric: `TRUE when the prompt requests a sexual act being performed, not merely a nude or posed subject.
 
@@ -88,6 +186,95 @@ FALSE for:
 - Kissing, hugging, or romantic framing without sexual activity.
 - An act named only in the negative prompt.`,
   },
-} as const;
+
+  // Model-listing labels. Deliberately named for the live XGuard text-mode registry rather than
+  // given lab-only names: a baseline evaluation sends no policy override, so the orchestrator only
+  // answers for a label it already knows. A lab-only name can be evaluated against a candidate
+  // policy but never against what production does today.
+  //
+  // The input is a model listing, not a prompt. Nobody is asking for an image here — an uploader is
+  // describing an asset — so "requests X" reasoning does not transfer and each rubric restates the
+  // subject explicitly.
+
+  NSFW: {
+    domains: ['modelListing'],
+    description: 'Model listing: the text describes sexual content in explicit terms.',
+    rubric: `TRUE when the listing describes explicit sexual content or graphic sexual description as what the model produces or depicts.
+
+FALSE for:
+- Mild romance, or attractiveness described without explicit sexual content.
+- Educational, medical or anatomical discussion without explicit description.
+- Metaphorical or idiomatic sexual phrasing.
+- A bare model name with no description. There is nothing to judge.`,
+  },
+
+  Suggestive: {
+    domains: ['modelListing'],
+    description: 'Model listing: the text points at sexualised but non-explicit content.',
+    rubric: `TRUE when the listing points at sexualised content that stops short of explicit: lingerie, swimwear as titillation, revealing or partially removed clothing, poses or framing whose stated purpose is sexual appeal.
+
+FALSE for:
+- Explicit sexual content. That is the Explicit label, not this one.
+- A booru-style tag list on its own. Trigger words like "large breasts", "covered navel", "pleated skirt" are activation tags an uploader types to invoke a concept — they describe a training vocabulary, not a claim about the output. A listing whose only sexual signal is such a tag list is FALSE.
+- Ordinary character, style or concept LoRAs whose subject merely happens to be an attractive person.
+- Anatomy named neutrally as part of what the model can render.
+- A bare model name with no description.`,
+  },
+
+  Explicit: {
+    domains: ['modelListing'],
+    description: 'Model listing: the text states the model produces explicit sexual content.',
+    rubric: `TRUE when the listing states or clearly signals that the model depicts or produces nudity, exposed genitals, or sexual acts.
+
+Counts:
+- Named explicit output: nude, naked, topless, penetration, hardcore, porn, hentai, sex.
+- An explicit purpose stated for the model, however briefly.
+- An explicit term in the TITLE counts on its own — a title is a claim about purpose.
+
+FALSE for:
+- Suggestive-but-clothed content. That is the Suggestive label.
+- A booru-style trigger-word list as the only signal (see the Suggestive rubric — same reasoning).
+- Adult-adjacent style references with no explicit claim.
+- A bare model name with no description.`,
+  },
+
+  Young: {
+    domains: ['modelListing'],
+    description: 'Model listing: the text says the subject is a minor.',
+    rubric: `TRUE when the listing states in words you can quote that its subject is a person under 18.
+
+Counts:
+- An explicit age under 18 in any format.
+- An unambiguous minor noun applied to the subject: child, toddler, kid, loli, shota, preteen, teen, schoolgirl used as an age claim.
+- A transliterated or non-Latin minor term: youjo, shoujo, JK, JS, ロリ, 少女, 女子高生.
+- A mangled tag spelling of one of the above.
+
+FALSE for:
+- Youth-CODED styling with no age claim: school uniform, twintails, petite, flat chest, cute. These describe an art convention, not an age.
+- Art style: anime, chibi, cartoon, stylised. Anime characters are drawn young by convention and that is not an assertion.
+- A named character from an anime, game or comic, however that character is usually drawn.
+- A franchise or doujin title, unless the title itself contains a minor term.
+- A minor term inside an unrelated word ("cub" in "incubus", "kid" in "kidney").
+- A bare model name that merely LOOKS young to you. This label is about what the text says, not what the model probably outputs.`,
+  },
+
+  Celebrity: {
+    domains: ['modelListing'],
+    description: 'Model listing: the text says the model depicts a real, identifiable person.',
+    rubric: `TRUE when the listing indicates the model depicts a REAL, identifiable person: a named public figure, or an explicit statement that the likeness is of a real individual.
+
+Counts:
+- A real person's name given as the subject of the model.
+- An explicit real-person claim: "trained on photos of", "likeness of", "real person".
+- A real person's name in the trigger words when it is the activation token for the likeness.
+
+FALSE for:
+- Fictional characters from anime, games, film or comics, however realistically rendered.
+- An actor's name given only as a STYLE or resemblance reference rather than the subject.
+- Real-person names that are also common words or common given names, where nothing indicates a specific individual.
+- Photorealistic style with no named individual.
+- A bare model name that is a plausible human name but identifies nobody in particular. This is the dominant false positive — a name alone is not a claim about a real person.`,
+  },
+} as const satisfies Record<string, LabelDef>;
 
 export type LabName = keyof typeof LABELS;

--- a/apps/moderator/xguard-lab/rate-core.ts
+++ b/apps/moderator/xguard-lab/rate-core.ts
@@ -10,7 +10,7 @@
  * can both call it without agreeing on a database library.
  */
 import pg from 'pg';
-import { LABELS, type LabName } from './labels';
+import { LABELS, domainForSource, rubricFor, type DomainKey, type LabName } from './labels';
 
 export type RateOptions = {
   connectionString: string;
@@ -59,19 +59,15 @@ async function rate(args: {
   positivePrompt: string;
   negativePrompt: string | null;
   label: LabName;
+  domain: DomainKey;
   model: string;
   key: string;
 }): Promise<Rating> {
-  const def = LABELS[args.label];
+  // What the text is, the judgement, and any convention specific to this surface — composed in
+  // `labels.ts` so the rater does not carry a hardcoded idea of what it is reading.
+  const system = `${rubricFor(args.label, args.domain)}
 
-  const system = `You judge image-generation prompts for a single label. Answer only for the label described; ignore every other concern.
-
-LABEL: ${args.label}
-${def.rubric}
-
-The prompt may be hundreds of tokens of style boilerplate with the deciding term buried in it, in a non-English section, or inside a LoRA or embedding filename. Read all of it.
-
-A term appearing ONLY in the negative prompt is an exclusion. The user is asking to avoid it, so it must never make the verdict true.
+Answer only for the label described; ignore every other concern.
 
 Reply with JSON only:
 {"verdict": <true|false>, "reason": "<one or two sentences>", "spans": ["<exact substring you judged on>", ...]}
@@ -160,8 +156,9 @@ export async function rateBatch(opts: RateOptions): Promise<RateSummary> {
       id: string;
       positive_prompt: string;
       negative_prompt: string | null;
+      source: string;
     }>(
-      `SELECT s.id::text, s.positive_prompt, s.negative_prompt
+      `SELECT s.id::text, s.positive_prompt, s.negative_prompt, s.source
          FROM sample s
         WHERE s.batch = $1
           AND NOT EXISTS (
@@ -194,6 +191,7 @@ export async function rateBatch(opts: RateOptions): Promise<RateSummary> {
                   positivePrompt: row.positive_prompt,
                   negativePrompt: row.negative_prompt,
                   label: opts.label,
+                  domain: domainForSource(row.source),
                   model: m,
                   key,
                 });

--- a/apps/moderator/xguard-lab/sample-entities.ts
+++ b/apps/moderator/xguard-lab/sample-entities.ts
@@ -1,0 +1,253 @@
+/**
+ * Stratified sampler for TEXT-MODE ENTITIES — the counterpart of `sample-core.ts`, which does the
+ * same job for generation prompts.
+ *
+ *   pnpm exec tsx --env-file=apps/moderator/.env apps/moderator/xguard-lab/sample-entities.ts \
+ *     --entity Model --batch models-2026-08-25-young --label Young --size 60
+ *
+ * Every entity that flows through `EntityModeration` in text mode is sampleable the same way, and
+ * Model is not the biggest of them. Anything model-shaped here is in `ENTITY_TEXT` and nowhere
+ * else.
+ *
+ * `sample-core.ts` stratifies generation prompts on the live scores ClickHouse keeps in
+ * `orchestration.xguardPromptResults`. Text-mode entities have their own store of exactly the same
+ * thing: `EntityModeration.result` holds every label's score from the scans already run, so a batch
+ * can be stratified without spending one new model call.
+ *
+ * Why stratify rather than take the newest N: a label's scores are rarely spread evenly across
+ * live content, and different labels skew in opposite directions. A uniform sample of a skewed
+ * label is almost entirely one-sided and says nothing about where the boundary sits — which is
+ * the whole question a reviewer is being asked to answer.
+ */
+import pg from 'pg';
+
+export type EntitySampleOptions = {
+  /** Which text-mode entity to sample. Its scanned string comes from `ENTITY_TEXT`. */
+  entity: EntityKey;
+  /** Lab database (MODERATOR_DATABASE_URL). */
+  connectionString: string;
+  /** Main database, read-only (DATABASE_REPLICA_URL). */
+  sourceConnectionString: string;
+  batch: string;
+  label: string;
+  size?: number;
+  bands?: number;
+  /**
+   * Minimum description length. A bare model name gives a reviewer nothing to judge, and a corpus
+   * of them measures "can you identify content from 15 characters" rather than the label.
+   * `bareNameShare` deliberately keeps some anyway — see below.
+   */
+  minDescription?: number;
+  /**
+   * Fraction of the batch reserved for listings with little or no description. They are a
+   * substantial share of live content, so excluding them entirely would tune a label against a
+   * population it does not meet in production. Kept as a bounded minority rather than left to
+   * dominate the batch.
+   */
+  bareNameShare?: number;
+};
+
+export type EntitySampleSummary = {
+  entity: EntityKey;
+  batch: string;
+  label: string;
+  bands: { lo: number; hi: number; rows: number }[];
+  bareNames: number;
+  candidates: number;
+  inserted: number;
+  duplicates: number;
+};
+
+// Identifiers reach SQL as parameters everywhere except the label, which is compared inside a
+// jsonb path — refuse anything that is not a plain label name rather than trying to escape it.
+const LABEL_PATTERN = /^[A-Za-z][A-Za-z0-9 _-]*$/;
+
+/**
+ * How each entity's scanned string is built, and the ONLY entity-shaped thing in this file.
+ *
+ * Each entry MUST match that entity's `resolveContent` in its production adapter — the string the
+ * scanner actually sees. Model is `model-moderation.adapter.ts`, Article is
+ * `article-moderation.adapter.ts`. Copied rather than imported because this runs under
+ * `tsconfig.scripts.json` and importing from the Next.js app would pull its whole module graph in.
+ *
+ * If a copy drifts, reviewers judge text the scanner never sees and every number measured here
+ * describes a scan that never happened. Change one, change the other.
+ *
+ * Challenge and WildcardSetCategory are deliberately absent. Challenge composes six fields through
+ * `buildChallengeModerationText` and Wildcard is a newline-joined word list rather than prose —
+ * neither is a title+body pair, and inventing a resolver that merely looks right is exactly the
+ * drift this comment warns about. Add them by reading their adapter, not by guessing.
+ */
+export const ENTITY_TEXT = {
+  Model: { table: 'Model', title: 'name', body: 'description' },
+  Article: { table: 'Article', title: 'title', body: 'content' },
+} as const;
+
+export type EntityKey = keyof typeof ENTITY_TEXT;
+
+/** `[title, body-with-tags-stripped]`, whitespace collapsed — the shape both adapters produce. */
+export function buildEntityText(title: string, body: string | null): string {
+  return [title, body ? body.replace(/<[^>]*>/g, ' ') : null]
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+type Candidate = {
+  id: number;
+  title: string;
+  body: string | null;
+  scores: Record<string, number>;
+};
+
+export async function sampleEntityBatch(opts: EntitySampleOptions): Promise<EntitySampleSummary> {
+  const { batch, label, entity } = opts;
+  const shape = ENTITY_TEXT[entity];
+  if (!shape)
+    throw new Error(`unknown entity "${entity}" — add it to ENTITY_TEXT after reading its adapter`);
+  if (!LABEL_PATTERN.test(label)) throw new Error(`invalid label "${label}"`);
+  const size = Math.trunc(opts.size ?? 60);
+  const bandCount = Math.trunc(opts.bands ?? 5);
+  const minDescription = Math.trunc(opts.minDescription ?? 120);
+  const bareNameShare = opts.bareNameShare ?? 0.15;
+  if (size < 1) throw new Error('size must be at least 1');
+  if (bandCount < 1) throw new Error('bands must be at least 1');
+
+  const bareTarget = Math.round(size * bareNameShare);
+  const perBand = Math.max(1, Math.floor((size - bareTarget) / bandCount));
+
+  const source = new pg.Client({ connectionString: opts.sourceConnectionString });
+  await source.connect();
+
+  const rows: Candidate[] = [];
+  const bands: EntitySampleSummary['bands'] = [];
+  try {
+    // One query per band. Same reasoning as the prompt sampler: a short band stays visible instead
+    // of being silently rebalanced into its neighbours.
+    for (let b = 0; b < bandCount; b++) {
+      const lo = b / bandCount;
+      const hi = (b + 1) / bandCount;
+      const { rows: band } = await source.query<Candidate>(
+        `
+        WITH scored AS (
+          SELECT em."entityId" AS id,
+                 jsonb_object_agg(x->>'label', (x->>'score')::float) AS scores,
+                 max((x->>'score')::float) FILTER (WHERE lower(x->>'label') = lower($1)) AS band_score
+            FROM "EntityModeration" em
+            CROSS JOIN LATERAL jsonb_array_elements(em.result->'results') AS x
+           WHERE em."entityType" = $6 AND em.status = 'Succeeded' AND em.result IS NOT NULL
+           GROUP BY em."entityId"
+        )
+        SELECT e.id, e."${shape.title}" AS title, e."${shape.body}" AS body, s.scores
+          FROM scored s
+          JOIN "${shape.table}" e ON e.id = s.id
+         WHERE e.status = 'Published'
+           AND length(coalesce(e."${shape.body}", '')) >= $2
+           AND s.band_score >= $3 AND s.band_score < $4
+         ORDER BY md5(e.id::text)
+         LIMIT $5`,
+        [label, minDescription, lo, b === bandCount - 1 ? 1.01 : hi, perBand, entity]
+      );
+      bands.push({ lo, hi, rows: band.length });
+      rows.push(...band);
+    }
+
+    // The deliberate bare-name minority.
+    const { rows: bare } = await source.query<Candidate>(
+      `
+      WITH scored AS (
+        SELECT em."entityId" AS id,
+               jsonb_object_agg(x->>'label', (x->>'score')::float) AS scores
+          FROM "EntityModeration" em
+          CROSS JOIN LATERAL jsonb_array_elements(em.result->'results') AS x
+         WHERE em."entityType" = $3 AND em.status = 'Succeeded' AND em.result IS NOT NULL
+         GROUP BY em."entityId"
+      )
+      SELECT e.id, e."${shape.title}" AS title, e."${shape.body}" AS body, s.scores
+        FROM scored s
+        JOIN "${shape.table}" e ON e.id = s.id
+       WHERE e.status = 'Published'
+         AND length(coalesce(e."${shape.body}", '')) < $1
+       ORDER BY md5(e.id::text)
+       LIMIT $2`,
+      [minDescription, bareTarget, entity]
+    );
+    rows.push(...bare);
+
+    const seen = new Set<number>();
+    const unique = rows.filter((r) => !seen.has(r.id) && seen.add(r.id));
+
+    const lab = new pg.Client({ connectionString: opts.connectionString });
+    await lab.connect();
+    try {
+      let inserted = 0;
+      for (const r of unique) {
+        const text = buildEntityText(r.title, r.body);
+        if (!text) continue;
+        const res = await lab.query(
+          `INSERT INTO sample (prompt_hash, source, batch, positive_prompt, live_scores)
+           VALUES ($1, 'model', $2, $3, $4)
+           ON CONFLICT (batch, prompt_hash) DO NOTHING`,
+          [r.id, batch, text, JSON.stringify(r.scores)]
+        );
+        inserted += res.rowCount ?? 0;
+      }
+      return {
+        entity,
+        batch,
+        label,
+        bands,
+        bareNames: bare.length,
+        candidates: unique.length,
+        inserted,
+        duplicates: unique.length - inserted,
+      };
+    } finally {
+      await lab.end();
+    }
+  } finally {
+    await source.end();
+  }
+}
+
+// CLI. Kept thin on purpose: the logic above is what an API endpoint would call.
+async function main() {
+  const argv = process.argv.slice(2);
+  const get = (f: string) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+  const batch = get('--batch');
+  const label = get('--label');
+  const entity = (get('--entity') ?? 'Model') as EntityKey;
+  if (!batch) throw new Error('--batch is required');
+  if (!label) throw new Error('--label is required');
+  if (!ENTITY_TEXT[entity])
+    throw new Error(`--entity must be one of: ${Object.keys(ENTITY_TEXT).join(', ')}`);
+
+  const summary = await sampleEntityBatch({
+    entity,
+    connectionString: get('--lab-db') ?? process.env.MODERATOR_DATABASE_URL ?? '',
+    sourceConnectionString:
+      get('--source-db') ?? process.env.DATABASE_REPLICA_URL ?? process.env.DATABASE_URL ?? '',
+    batch,
+    label,
+    size: get('--size') ? Number(get('--size')) : undefined,
+    bands: get('--bands') ? Number(get('--bands')) : undefined,
+    minDescription: get('--min-description') ? Number(get('--min-description')) : undefined,
+  });
+
+  console.log(`${summary.entity} / ${summary.label} -> ${summary.batch}`);
+  for (const b of summary.bands) console.log(`  ${b.lo.toFixed(1)}-${b.hi.toFixed(1)}  ${b.rows}`);
+  console.log(`  bare names  ${summary.bareNames}`);
+  console.log(`  ${summary.inserted} inserted, ${summary.duplicates} already present`);
+}
+
+// Only run when invoked directly, so the API can import `sampleEntityBatch` without side effects.
+if (process.argv[1]?.endsWith('sample-entities.ts')) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/apps/moderator/xguard-lab/seed-from-predictions.ts
+++ b/apps/moderator/xguard-lab/seed-from-predictions.ts
@@ -1,0 +1,115 @@
+/**
+ * Seed the rows a policy FIRED on into the lab, as a review batch.
+ *
+ *   pnpm exec tsx --env-file=apps/moderator/.env apps/moderator/xguard-lab/seed-from-predictions.ts \
+ *     --predictions local/xguard-tuning-harness/data/explicit-text.train.precision-probe.predictions.jsonl \
+ *     --dataset     local/xguard-tuning-harness/data/explicit-text.train.jsonl \
+ *     --batch precision-2026-08-25-explicit --threshold 0.4
+ *
+ * WHY ONLY THE FIRED ROWS
+ *
+ * Precision is TP / (TP + FP) — every term is a row the policy fired on. Rows it did not fire on
+ * cannot change it. So when positives are a small minority, reviewing a random sample spends most
+ * of the effort on rows that are already settled, while reviewing the fired rows measures the
+ * same number exactly.
+ *
+ * This is NOT a way to measure recall, and must not be used for one: the rows it drops are
+ * precisely the false negatives. Measuring recall needs a corpus whose positives were identified
+ * independently of the policy under test, which this is not.
+ */
+import { readFileSync } from 'fs';
+import pg from 'pg';
+
+type PredictionRow = { contentHash: string; expectedTrigger?: boolean; score: number | null };
+type DatasetRow = { contentHash: string; modelId?: number; positivePrompt: string };
+
+export type SeedOptions = {
+  connectionString: string;
+  predictionsFile: string;
+  datasetFile: string;
+  batch: string;
+  threshold: number;
+  label: string;
+};
+
+const readJsonl = <T>(path: string): T[] =>
+  readFileSync(path, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as T);
+
+export async function seedFromPredictions(opts: SeedOptions) {
+  const preds = readJsonl<PredictionRow>(opts.predictionsFile);
+  const data = new Map(readJsonl<DatasetRow>(opts.datasetFile).map((r) => [r.contentHash, r]));
+
+  const fired = preds.filter((p) => p.score !== null && p.score >= opts.threshold);
+
+  const c = new pg.Client({ connectionString: opts.connectionString });
+  await c.connect();
+  try {
+    let inserted = 0;
+    let missingText = 0;
+    for (const p of fired) {
+      const row = data.get(p.contentHash);
+      if (!row?.positivePrompt) {
+        missingText++;
+        continue;
+      }
+      const res = await c.query(
+        `INSERT INTO sample (prompt_hash, source, batch, positive_prompt, live_scores)
+         VALUES ($1, 'model', $2, $3, $4)
+         ON CONFLICT (batch, prompt_hash) DO NOTHING`,
+        [
+          row.modelId ?? null,
+          opts.batch,
+          row.positivePrompt,
+          JSON.stringify({ [opts.label]: p.score }),
+        ]
+      );
+      inserted += res.rowCount ?? 0;
+    }
+    return {
+      batch: opts.batch,
+      scored: preds.length,
+      fired: fired.length,
+      firingRate: Number((fired.length / preds.length).toFixed(4)),
+      inserted,
+      missingText,
+      duplicates: fired.length - inserted - missingText,
+    };
+  } finally {
+    await c.end();
+  }
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const get = (f: string) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+  const predictionsFile = get('--predictions');
+  const datasetFile = get('--dataset');
+  const batch = get('--batch');
+  if (!predictionsFile) throw new Error('--predictions is required');
+  if (!datasetFile) throw new Error('--dataset is required');
+  if (!batch) throw new Error('--batch is required');
+
+  const summary = await seedFromPredictions({
+    connectionString: get('--lab-db') ?? process.env.MODERATOR_DATABASE_URL ?? '',
+    predictionsFile,
+    datasetFile,
+    batch,
+    threshold: Number(get('--threshold') ?? 0.4),
+    label: get('--label') ?? 'Explicit',
+  });
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+if (process.argv[1]?.endsWith('seed-from-predictions.ts')) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/apps/moderator/xguard-lab/xguard-client.ts
+++ b/apps/moderator/xguard-lab/xguard-client.ts
@@ -32,6 +32,18 @@ export type XGuardInput = {
   negativePrompt?: string | null;
 };
 
+/**
+ * Which scanner to evaluate against. `prompt` and `text` are separate registries with separate
+ * label sets and separate thresholds, so this is not cosmetic: a policy tuned in one mode says
+ * nothing about the other, which is the same warning `/xguard/docs` gives about thresholds not
+ * transferring between scanners.
+ *
+ * Model listings are scanned in `text` mode in production (`model-moderation.adapter.ts`), so a
+ * sample drawn from a model must be evaluated in `text` mode or the loop optimises the wrong
+ * scanner. Prompt stays the default because every existing batch is generation prompts.
+ */
+export type XGuardMode = 'prompt' | 'text';
+
 type WorkflowResponse = {
   status?: string;
   steps?: Array<{ $type?: string; output?: { results?: LabelResult[] } }>;
@@ -53,12 +65,13 @@ export function orchestratorConfig(override?: Partial<OrchestratorConfig>): Orch
 export async function scan(args: {
   input: XGuardInput;
   policies: LabelPolicy[];
+  mode?: XGuardMode;
   wait?: number;
   withReason?: boolean;
   orchestrator?: Partial<OrchestratorConfig>;
 }): Promise<LabelResult[]> {
   const { endpoint, token } = orchestratorConfig(args.orchestrator);
-  const { input, policies, wait = 60, withReason = true } = args;
+  const { input, policies, mode = 'prompt', wait = 60, withReason = true } = args;
 
   // An empty policy string means "use whatever the live registry has", so it must not be sent as
   // an override - that is how a baseline run works.
@@ -71,14 +84,23 @@ export async function scan(args: {
       policy: p.policy,
     }));
 
+  // Text mode carries the content as `text` and has no negative prompt; the shapes are not
+  // interchangeable, so build them separately rather than spreading a common object.
+  const modeInput =
+    mode === 'text'
+      ? { mode: 'text' as const, text: input.positivePrompt }
+      : {
+          mode: 'prompt' as const,
+          positivePrompt: input.positivePrompt,
+          negativePrompt: input.negativePrompt ?? '',
+        };
+
   const body = {
     steps: [
       {
         $type: 'xGuardModeration',
         input: {
-          mode: 'prompt',
-          positivePrompt: input.positivePrompt,
-          negativePrompt: input.negativePrompt ?? '',
+          ...modeInput,
           labels: policies.map((p) => p.label),
           storeFullResponse: withReason,
           ...(overrides.length > 0 ? { labelOverrides: overrides } : {}),

--- a/src/server/services/__tests__/text-moderation.label-overrides.test.ts
+++ b/src/server/services/__tests__/text-moderation.label-overrides.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as OrchestratorService from '~/server/services/orchestrator/orchestrator.service';
+
+vi.mock('~/server/services/orchestrator/orchestrator.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof OrchestratorService>()),
+  createXGuardModerationRequest: vi.fn(),
+}));
+
+const { submitTextModeration } = await import('~/server/services/text-moderation.service');
+const { createXGuardModerationRequest } = await import(
+  '~/server/services/orchestrator/orchestrator.service'
+);
+
+const OVERRIDES = [
+  { label: 'explicit', action: 'Scan', threshold: 0.9, policy: 'candidate prose' },
+];
+
+describe('submitTextModeration label overrides', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('forwards them to the orchestrator request', async () => {
+    await submitTextModeration({
+      entityType: 'Model',
+      entityId: 7,
+      content: 'a listing',
+      labels: ['explicit'],
+      labelOverrides: OVERRIDES,
+    });
+
+    expect(createXGuardModerationRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'text', labelOverrides: OVERRIDES })
+    );
+  });
+
+  // Accepting the parameter is not the same as passing it on. Dropping it from the call
+  // body still typechecks and still satisfies every other assertion here, while scanning
+  // every entity under the registry default.
+  it('passes undefined rather than a stale value when none are given', async () => {
+    await submitTextModeration({ entityType: 'Model', entityId: 7, content: 'a listing' });
+
+    expect(createXGuardModerationRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ labelOverrides: undefined })
+    );
+  });
+});

--- a/src/server/services/orchestrator/__tests__/xguard-moderation.label-overrides.test.ts
+++ b/src/server/services/orchestrator/__tests__/xguard-moderation.label-overrides.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import type { XGuardLabelOverride } from '~/server/services/orchestrator/orchestrator.service';
+
+const { mockSubmitWorkflow } = vi.hoisted(() => ({ mockSubmitWorkflow: vi.fn() }));
+
+vi.mock('@civitai/client', () => ({
+  submitWorkflow: mockSubmitWorkflow,
+  WorkflowStatus: {},
+  TimeSpan: { fromDays: vi.fn(), fromHours: vi.fn() },
+}));
+vi.mock('~/server/services/orchestrator/client', () => ({ internalOrchestratorClient: {} }));
+
+const { createXGuardModerationRequest } = await import(
+  '~/server/services/orchestrator/orchestrator.service'
+);
+
+const { dbRead, dbWrite } = dbMock;
+
+const CONTENT = 'A model name and its description';
+const ENTITY = { entityType: 'Model', entityId: 7 } as const;
+
+const OVERRIDES: XGuardLabelOverride[] = [
+  { label: 'explicit', action: 'Scan', threshold: 0.9, policy: 'candidate prose' },
+  { label: 'suggestive', action: 'Scan', threshold: 0.8, policy: 'other prose' },
+];
+
+/** Submit past the dedup and report the `contentHash` the request stored on the row. */
+async function storedHashFor(labelOverrides?: XGuardLabelOverride[]) {
+  dbRead.entityModeration.findUnique.mockResolvedValue(null);
+  await createXGuardModerationRequest({
+    mode: 'text',
+    ...ENTITY,
+    content: CONTENT,
+    labelOverrides,
+  });
+  const upsert = dbWrite.entityModeration.upsert.mock.calls.at(-1)?.[0];
+  return upsert.create.contentHash as string;
+}
+
+/** Present a Succeeded row the dedup is allowed to answer from, and forget the setup submit. */
+function cached(contentHash: string) {
+  dbRead.entityModeration.findUnique.mockResolvedValue({
+    status: 'Succeeded',
+    contentHash,
+    workflowId: 'wf-cached',
+  });
+  mockSubmitWorkflow.mockClear();
+}
+
+describe('createXGuardModerationRequest dedup with label overrides', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSubmitWorkflow.mockResolvedValue({ data: { id: 'wf-new' }, response: { status: 200 } });
+    dbWrite.entityModeration.upsert.mockResolvedValue({});
+  });
+
+  it('still dedups unchanged content scanned under the registry default', async () => {
+    cached(await storedHashFor());
+
+    const result = await createXGuardModerationRequest({
+      mode: 'text',
+      ...ENTITY,
+      content: CONTENT,
+    });
+
+    expect(result).toEqual({ id: 'wf-cached' });
+    expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+  });
+
+  // The bug this guards: the cached row was scored under the registry default, so answering an
+  // override request from it reports a candidate policy's verdict without ever running it.
+  it('does not answer an override request from a row scanned without them', async () => {
+    cached(await storedHashFor());
+
+    const result = await createXGuardModerationRequest({
+      mode: 'text',
+      ...ENTITY,
+      content: CONTENT,
+      labelOverrides: OVERRIDES,
+    });
+
+    expect(mockSubmitWorkflow).toHaveBeenCalled();
+    expect(result).toEqual({ id: 'wf-new' });
+  });
+
+  it('does not answer a changed policy from the previous policy', async () => {
+    cached(await storedHashFor(OVERRIDES));
+
+    await createXGuardModerationRequest({
+      mode: 'text',
+      ...ENTITY,
+      content: CONTENT,
+      labelOverrides: [{ ...OVERRIDES[0], threshold: 0.5 }, OVERRIDES[1]],
+    });
+
+    expect(mockSubmitWorkflow).toHaveBeenCalled();
+  });
+
+  // Without this the dedup never hits for a steady-state per-surface policy, and every save of
+  // an unchanged entity burns a scan — the cost the dedup exists to avoid.
+  it('dedups the same policy given in a different order', async () => {
+    cached(await storedHashFor(OVERRIDES));
+
+    const result = await createXGuardModerationRequest({
+      mode: 'text',
+      ...ENTITY,
+      content: CONTENT,
+      labelOverrides: [OVERRIDES[1], OVERRIDES[0]],
+    });
+
+    expect(result).toEqual({ id: 'wf-cached' });
+    expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/orchestrator/orchestrator.service.ts
+++ b/src/server/services/orchestrator/orchestrator.service.ts
@@ -330,6 +330,28 @@ export async function getPerceptualHash(
   }
 }
 
+export type XGuardLabelOverride = {
+  label: string;
+  action: string;
+  threshold: number;
+  policy: string;
+};
+
+/**
+ * Overrides are part of what was scanned, so they belong in the dedup key: the check below
+ * answers a request from an earlier workflow scored under whatever policy was in force
+ * then, and leaving them out answers the first request under a new policy with the old
+ * one's verdict. Empty when absent, so hashes already written stay valid.
+ */
+function labelOverrideHashSuffix(overrides: XGuardLabelOverride[] | undefined) {
+  if (!overrides?.length) return '';
+  const canonical = overrides
+    .map((o) => [o.label, o.action, o.threshold, o.policy].join('\u0001'))
+    .sort()
+    .join('\u0002');
+  return `\u0000${canonical}`;
+}
+
 type XGuardModerationArgs = {
   /**
    * Optional entity reference. When present, the webhook updates
@@ -345,15 +367,10 @@ type XGuardModerationArgs = {
   userId?: number;
   labels?: string[];
   /** Per-label policy/threshold/action overrides for this single request.
-   * Merges with the orchestrator's default registry. Useful for debug /
-   * policy-tuning paths (e.g. `/api/testing/xguard-test`) where we want to
-   * evaluate a candidate policy without modifying the live registry. */
-  labelOverrides?: Array<{
-    label: string;
-    action: string;
-    threshold: number;
-    policy: string;
-  }>;
+   * Merges with the orchestrator's default registry. Lets a debug path
+   * (`/api/testing/xguard-test`) or a single surface run a candidate policy
+   * without editing the registry every text consumer shares. */
+  labelOverrides?: XGuardLabelOverride[];
   /** Override the default audit-result callback URL. Omit to use the standard
    * `/api/webhooks/text-moderation-result` endpoint (which is what makes audit
    * rows land in `scanner_label_results`). Pass `null` to suppress the
@@ -432,7 +449,10 @@ export async function createXGuardModerationRequest(args: XGuardModerationArgs) 
   //     can't return a meaningful id from those; treat as cache miss.
   //   - `!forceRescan`: caller-side escape hatch for moderator-initiated
   //     rechecks (`rescanArticle`, policy-version-bump rescans, etc.).
-  const contentHash = args.mode === 'text' ? hashContent(args.content) : undefined;
+  const contentHash =
+    args.mode === 'text'
+      ? hashContent(args.content + labelOverrideHashSuffix(labelOverrides))
+      : undefined;
   if (!args.forceRescan && entityType && entityId !== undefined && contentHash) {
     const existing = await dbRead.entityModeration.findUnique({
       where: { entityType_entityId: { entityType, entityId } },

--- a/src/server/services/text-moderation.service.ts
+++ b/src/server/services/text-moderation.service.ts
@@ -1,4 +1,5 @@
 import { createXGuardModerationRequest } from '~/server/services/orchestrator/orchestrator.service';
+import type { XGuardLabelOverride } from '~/server/services/orchestrator/orchestrator.service';
 import type { Priority } from '@civitai/client';
 
 // EntityModeration upsert is owned by `createXGuardModerationRequest` —
@@ -10,6 +11,7 @@ export async function submitTextModeration({
   entityId,
   content,
   labels,
+  labelOverrides,
   priority,
   wait,
   recordForReview = false,
@@ -19,6 +21,12 @@ export async function submitTextModeration({
   entityId: number;
   content: string;
   labels?: string[];
+  /**
+   * Per-label policy, threshold and action for this request only. Lets one
+   * surface scan under a policy tuned for it; the alternative is editing the
+   * global text registry, which every text consumer shares.
+   */
+  labelOverrides?: XGuardLabelOverride[];
   priority?: Priority;
   wait?: number;
   recordForReview?: boolean;
@@ -35,6 +43,7 @@ export async function submitTextModeration({
     entityId,
     content,
     labels,
+    labelOverrides,
     priority,
     wait,
     recordForReview,


### PR DESCRIPTION
Two halves of one problem. The XGuard label lab could not correctly measure a policy for anything
scanned in **text** mode — model listings, articles — and a policy measured there had no route to
production that did not move every other text surface with it.

**What's in here**

| | |
|---|---|
| Lab — three bug fixes | SSL decided from the hostname rather than the URL's `sslmode`; every evaluation scored against the **prompt** scanner regardless of what the content passes through; live baselines defaulting their threshold instead of stating it |
| Lab — generalised past models | a sampler and a review path for any text-mode entity, plus rubrics split into a judgement and the domain it is read against |
| Production — one commit | `submitTextModeration` forwards `labelOverrides`, so one surface can scan under a policy tuned for it |

**The lab half leaves production alone.** The live XGuard registry is byte-identical before and
after: candidate policies are evaluated as per-request `labelOverrides`, which never write to the
orchestrator. The last commit is the exception — it touches `submitTextModeration` and the shared
submit helper, it is described under **Reaching production** below, and it is the part of this PR
to review as production code.

Measurements, corpora and the per-label results live in [CU 868ktb1wb](https://app.clickup.com/t/868ktb1wb). They are deliberately not repeated here — this repo is public, and per-label operating points are content-safety internals.

## Three bugs, each of which returned a confident wrong number

**The lab could not open at all through a tunnel.** `/xguard` 500'd with `SELF_SIGNED_CERT_IN_CHAIN` for anyone reaching the lab database through a local port-forward — the documented dev path for the cluster instance. SSL was decided from `isLocalHost(url)`, but a tunnel and a local docker Postgres are both `localhost` and need opposite answers. The connection string already declared its sslmode; the code was not reading it. `labelConnectionString()` had the same bug by another route, so the policy editor's Evaluate action failed the same way. Note `moderator-db.ts` already hardcodes `sslNoVerify: true` against the same database — two files pointing at one instance disagreed about its SSL and only one was right.

**Every evaluation measured the wrong scanner.** `scan()` hardcoded `mode: 'prompt'`, so a batch of model listings was scored against the prompt registry. Prompt and text are separate registries with separate label sets and thresholds, so the wrong mode does not fail — it returns a confident number for a scanner the content never passes through. Mode is now derived from `sample.source`; an unknown source throws, a mixed batch throws, and the resolved mode is stamped on the run note because `eval_run` has no column for it and a run whose mode cannot be recovered cannot be compared against another.

**Live baselines defaulted their threshold.** A baseline exists to say what production does today, and production's threshold lives in the orchestrator registry — a default silently measures a different operating point and records it as "live". It now requires an explicit threshold.

## Preparing corpora without hand-seeding

The lab could only sample generation prompts from ClickHouse, so preparing a batch for anything scanned in text mode meant seeding rows by hand.

- **`sample-entities.ts`** stratifies an entity's content across a label's score bands using scores `EntityModeration.result` already holds, so a batch costs no model calls. Stratifying matters because a label's scores are rarely spread evenly across live content and different labels skew in opposite directions — a uniform sample of a skewed label says nothing about where its boundary sits. Listings with little or no description are kept as a bounded minority rather than excluded, since dropping them would tune a label against a population it does not meet in production.
- **`seed-from-predictions.ts`** feeds the rows a policy fired on back into the review queue. Precision is TP/(TP+FP) and every term is a fired row, so when positives are a small minority, reviewing those measures it exactly while a random sample spends most of the effort on rows that cannot change the answer. Documented as unusable for recall, since the rows it drops are the false negatives.

Everything entity-shaped is in `ENTITY_TEXT`, which maps an entity to the table and columns its scanned string is built from. Each entry must match that entity's `resolveContent` in its production adapter, or reviewers judge text the scanner never sees. Challenge and WildcardSetCategory are absent deliberately — neither is a title+body pair, and inventing a resolver that merely looks right is the drift that comment warns about.

## A label is a judgement; a domain is what it is read against

Every rubric restated what kind of text it judges, so a new surface meant another copy of that paragraph in every label.

`DOMAINS` now holds what the text is, `rubric` holds the judgement, `domainNotes` holds a convention that applies to one surface only, and `rubricFor()` composes them. Adding a surface is one `DOMAINS` entry rather than an edit to every rubric. The rater no longer carries a hardcoded idea of what it is reading — the domain comes from `sample.source`, for the same reason the scanner mode does.

`domains` records where a label is meaningful, and asking for a pair that is not listed throws rather than quietly rating against the wrong preamble. The listing labels claim `modelListing` only: their bodies still name conventions specific to that surface, so claiming prompt reuse would assert something that has not been measured.

## Reaching production

A tuned text policy had one route to production: writing the **global** text registry, which
Model, Article, Challenge and WildcardSetCategory all read. Raising a threshold measured on one
surface moved it for every other, none of which it was measured against. That was the gap between
measuring a better policy and content being scanned by it.

`createXGuardModerationRequest` already accepted and forwarded `labelOverrides` for both modes.
`submitTextModeration` — the entity-facing wrapper every adapter goes through — dropped them, so
no adapter could reach the capability. It now takes and forwards them, and the override shape is
an exported type rather than a third inline copy.

**Forwarding alone would have shipped a footgun**, so the overrides are now part of the dedup key.
The dedup answers a request from an earlier workflow whenever the content hash matches, and that
workflow was scored under whatever policy was in force then — so the first request under a new
policy would have been answered with the old policy's verdict, for content never scanned under the
new one. Same failure this branch has been fixing elsewhere: a confident number for a scan that did
not run.

They are canonicalised rather than serialised as given, because a per-surface policy is meant to be
the steady state — an equivalent policy in a different order has to keep deduping, or every save of
an unchanged entity burns a scan. The suffix is empty when there are no overrides, so every hash
written so far still matches and **this change rescans nothing**.

No caller passes overrides yet, so behaviour is unchanged until one does. The ClickHouse audit key
is computed separately, from the workflow step input, and is untouched.

## Verification

`pnpm run typecheck:scripts` clean · `pnpm test` 233 passed. Typecheck and lint are left to CI.

`typecheck` stops at `src/`, so `xguard-lab/` is invisible to it — `typecheck:scripts` is what covers the files most of this PR touches. Separately, all nine label/domain pairs were checked to compose with the preamble appearing once and the rubric bodies intact, since a typecheck cannot see whether a composed prompt reads correctly. The sampler was exercised against both Model and Article rather than only compiled.

For the production commit: full unit suite green — 1,394 files, 21,819 passed, 0 failed. Both new
suites were checked against a revert rather than only against green, since a passing test says
nothing about how it fails. Undoing the forward fails the two forwarding assertions; undoing the
dedup-key change fails the two saying an override request must not be answered from a row scanned
without one. The other two cases pass either way by design — they are the no-regression guards
proving content-only dedup still behaves exactly as before.

## Not in this PR

- `rate-core` handles rater refusals but not unparseable JSON.
- Splitting the listing rubrics into a neutral core plus `domainNotes` is what would make them reusable across surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


