### PR TITLE
fix(moderator): keep keyboard focus in the list after removing a chip

### DIFF
--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -79,15 +79,19 @@
     (item: string): SubmitFunction =>
     ({ formElement }) => {
       removing = item;
-      // Both captured BEFORE the submit, because the invalidation unmounts this chip: afterwards
-      // the item is gone from the list and `document.activeElement` is <body>, so neither question
-      // can still be answered.
+      // All three captured BEFORE the submit, because the invalidation unmounts this chip:
+      // afterwards `document.activeElement` is <body>, and the list being indexed may not even be
+      // this blocklist any more.
       const position = shown.visible.indexOf(item);
       // Focus is only moved if it was already inside THIS chip's form. That is true for keyboard
       // activation, and also for a pointer in browsers that focus a button on click — which is
       // fine, since those get no visible ring under `:focus-visible`. What it excludes is the
       // case that would be an unasked-for scroll: focus sitting somewhere else on the page.
       const restoreFocus = formElement.contains(document.activeElement);
+      // A removal can outlive the tab. Clicking another tab mid-flight swaps `data.blocklist` for
+      // a different type's entries, and focusing "the entry at that index" would then land on an
+      // unrelated blocklist — precisely the unpredictable movement this is supposed to avoid.
+      const submittedType = data.type;
 
       return async ({ update }) => {
         // `finally`, not a bare sequence. Every chip's control is disabled while `removing` is set,
@@ -104,34 +108,55 @@
           // the submit never fires and "Remove" behaves exactly like "Cancel", silently. Same trap
           // as `ConfirmSubmit.svelte`.
           confirming = null;
-        }
 
-        if (restoreFocus) {
-          // After `removing` is cleared, not before: every chip control is `disabled` while a
-          // removal is in flight, and a disabled button silently refuses focus. `tick` waits for
-          // both the re-rendered chips and that re-enable to reach the DOM.
-          await tick();
-          focusAfterRemoval(position);
+          // Inside the `finally`, so a rejected submit does not leave focus on <body> — the worst
+          // case to lose it in, since nothing changed and the chip is still there to return to.
+          // After `removing` is cleared, never before: every chip control is `disabled` while a
+          // removal is in flight, and a disabled button silently refuses focus. One `tick` covers
+          // both the re-rendered chips and that re-enable (it drains cascading batches), and would
+          // stop being enough only under `compilerOptions.experimental.async`, which this app does
+          // not set.
+          if (restoreFocus) {
+            await tick();
+            if (data.type === submittedType) focusAfterRemoval(position, item);
+          }
         }
       };
     };
 
+  /** The remove control of a chip, if it is on screen. */
+  const chipControl = (entry: string) =>
+    panel?.querySelector<HTMLElement>(`[data-chip-remove="${CSS.escape(entry)}"]`) ?? null;
+
   /**
-   * Where focus lands once the removed chip is gone. The chip that TOOK its place, so holding the
-   * key removes down the list; the previous one when the removal took the last chip; and the filter
-   * input when it emptied the list. Landing on the filter is why it is worth being deliberate: it
-   * is the one control that can bring chips back, and `{#each}` is keyed by the entry, so there is
-   * no stable node to return to.
+   * Returns focus to the chip a confirm was opened on. Cancel and Escape both unmount the popover
+   * that holds `document.activeElement`, and Svelte flushes that teardown synchronously — so
+   * without this the keyboard user who opens a confirm and changes their mind lands on <body>,
+   * which is the same failure this file exists to fix, one keystroke off the path that was fixed.
    */
-  function focusAfterRemoval(position: number) {
+  function dismissConfirm() {
+    const control = confirming ? chipControl(confirming) : null;
+    confirming = null;
+    control?.focus();
+  }
+
+  /**
+   * Where focus lands once the removed chip is gone. `chipFocusTarget` decides WHICH entry; this
+   * resolves it to a node and degrades when it cannot.
+   *
+   * The fallback chain runs whenever the chip node is missing, not only when there is no entry to
+   * look for — a resolved entry whose node is absent used to leave `target` null and focus on
+   * <body>, which is the outcome the whole function exists to prevent. The filter bar unmounts with
+   * the chips when the LIST is empty rather than merely filtered to nothing, so the textarea is the
+   * last resort.
+   */
+  function focusAfterRemoval(position: number, item: string) {
     if (!panel) return;
-    const next = chipFocusTarget(shown.visible, position);
-    const target = next
-      ? panel.querySelector<HTMLElement>(`[data-chip-remove="${CSS.escape(next)}"]`)
-      : // The filter bar unmounts with the chips when the LIST is empty rather than merely
-        // filtered to nothing, so the textarea is the last resort — never <body>.
-        (panel.querySelector<HTMLElement>('[data-blocklist-filter] input') ??
-        panel.querySelector<HTMLElement>('textarea'));
+    const next = chipFocusTarget(shown.visible, position, item);
+    const target =
+      (next.kind === 'chip' ? chipControl(next.entry) : null) ??
+      panel.querySelector<HTMLElement>('[data-blocklist-filter] input') ??
+      panel.querySelector<HTMLElement>('textarea');
     target?.focus();
   }
 </script>
@@ -139,7 +164,7 @@
 <!-- One window listener rather than one per chip: at CHIP_LIMIT that would be 200 of them. -->
 <svelte:window
   onkeydown={(e) => {
-    if (e.key === 'Escape') confirming = null;
+    if (e.key === 'Escape') dismissConfirm();
   }}
 />
 
@@ -287,7 +312,7 @@
                     size="sm"
                     variant="outline"
                     disabled={removing !== null}
-                    onclick={() => (confirming = null)}
+                    onclick={dismissConfirm}
                   >
                     Cancel
                   </Button>

--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { untrack } from "svelte";
+  import { tick, untrack } from "svelte";
   import { page } from "$app/state";
   import { enhance } from '$app/forms';
   import { goto } from '$app/navigation';
@@ -12,6 +12,7 @@
   import { num } from '$lib/format';
   import { BLOCKLIST_TYPES, BLOCKLIST_DESCRIPTIONS, humanizeBlocklistType } from '$lib/blocklist';
   import { visibleBlocklistItems } from './filter';
+  import { chipFocusTarget } from './focus';
   import type { ActionData, PageData } from './$types';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
 
@@ -22,6 +23,7 @@
   let filters = $state<Record<string, string>>({});
   let removing = $state<string | null>(null);
   let confirming = $state<string | null>(null);
+  let panel = $state<HTMLElement | null>(null);
 
   // EmailDomain is 8295 entries in production. Rendering the whole list is both unusable and
   // enough DOM to stall the tab, so the list is filtered first and then capped.
@@ -75,8 +77,18 @@
   // write restores what the earlier one dropped.
   const submitChip =
     (item: string): SubmitFunction =>
-    () => {
+    ({ formElement }) => {
       removing = item;
+      // Both captured BEFORE the submit, because the invalidation unmounts this chip: afterwards
+      // the item is gone from the list and `document.activeElement` is <body>, so neither question
+      // can still be answered.
+      const position = shown.visible.indexOf(item);
+      // Focus is only moved if it was already inside THIS chip's form. That is true for keyboard
+      // activation, and also for a pointer in browsers that focus a button on click — which is
+      // fine, since those get no visible ring under `:focus-visible`. What it excludes is the
+      // case that would be an unasked-for scroll: focus sitting somewhere else on the page.
+      const restoreFocus = formElement.contains(document.activeElement);
+
       return async ({ update }) => {
         // `finally`, not a bare sequence. Every chip's control is disabled while `removing` is set,
         // so a submit that throws — a rejected fetch, a cross-origin refusal — would otherwise leave
@@ -93,8 +105,35 @@
           // as `ConfirmSubmit.svelte`.
           confirming = null;
         }
+
+        if (restoreFocus) {
+          // After `removing` is cleared, not before: every chip control is `disabled` while a
+          // removal is in flight, and a disabled button silently refuses focus. `tick` waits for
+          // both the re-rendered chips and that re-enable to reach the DOM.
+          await tick();
+          focusAfterRemoval(position);
+        }
       };
     };
+
+  /**
+   * Where focus lands once the removed chip is gone. The chip that TOOK its place, so holding the
+   * key removes down the list; the previous one when the removal took the last chip; and the filter
+   * input when it emptied the list. Landing on the filter is why it is worth being deliberate: it
+   * is the one control that can bring chips back, and `{#each}` is keyed by the entry, so there is
+   * no stable node to return to.
+   */
+  function focusAfterRemoval(position: number) {
+    if (!panel) return;
+    const next = chipFocusTarget(shown.visible, position);
+    const target = next
+      ? panel.querySelector<HTMLElement>(`[data-chip-remove="${CSS.escape(next)}"]`)
+      : // The filter bar unmounts with the chips when the LIST is empty rather than merely
+        // filtered to nothing, so the textarea is the last resort — never <body>.
+        (panel.querySelector<HTMLElement>('[data-blocklist-filter] input') ??
+        panel.querySelector<HTMLElement>('textarea'));
+    target?.focus();
+  }
 </script>
 
 <!-- One window listener rather than one per chip: at CHIP_LIMIT that would be 200 of them. -->
@@ -138,7 +177,7 @@
   </div>
 {/if}
 
-<div class="flex max-w-xl flex-col gap-4">
+<div class="flex max-w-xl flex-col gap-4" bind:this={panel}>
   <div class="flex flex-col gap-2 rounded-xl border p-3">
     {#if data.blocklist.id}
       <div class="flex gap-1">
@@ -181,12 +220,14 @@
   {:else}
     <div class="flex flex-col gap-2">
       <span class="text-sm font-medium">{humanizeBlocklistType(data.type)}</span>
-      <ListFilterBar
-        fields={[{ kind: 'search', key: 'q', label: 'Filter entries' }]}
-        bind:values={filters}
-        matched={shown.matches.length}
-        total={sortedItems.length}
-      />
+      <div data-blocklist-filter>
+        <ListFilterBar
+          fields={[{ kind: 'search', key: 'q', label: 'Filter entries' }]}
+          bind:values={filters}
+          matched={shown.matches.length}
+          total={sortedItems.length}
+        />
+      </div>
       {#if shown.matches.length === 0}
         <p class="text-sm text-dark-2">Nothing on this list matches "{(filters.q ?? '').trim()}".</p>
       {:else}
@@ -212,6 +253,7 @@
                   size="icon"
                   class="size-4"
                   disabled={removing !== null}
+                  data-chip-remove={item}
                   aria-label="Remove {item}"
                   title="Remove {item}"
                   aria-haspopup="true"

--- a/apps/moderator/src/routes/blocklists/+page.svelte
+++ b/apps/moderator/src/routes/blocklists/+page.svelte
@@ -12,7 +12,7 @@
   import { num } from '$lib/format';
   import { BLOCKLIST_TYPES, BLOCKLIST_DESCRIPTIONS, humanizeBlocklistType } from '$lib/blocklist';
   import { visibleBlocklistItems } from './filter';
-  import { chipFocusTarget } from './focus';
+  import { chipFocusTarget, confirmDismissTarget, type RemovalFocusGuards } from './focus';
   import type { ActionData, PageData } from './$types';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
 
@@ -116,10 +116,11 @@
           // both the re-rendered chips and that re-enable (it drains cascading batches), and would
           // stop being enough only under `compilerOptions.experimental.async`, which this app does
           // not set.
-          if (restoreFocus) {
-            await tick();
-            if (data.type === submittedType) focusAfterRemoval(position, item);
-          }
+          await tick();
+          focusAfterRemoval(position, item, {
+            focusWasInForm: restoreFocus,
+            sameType: data.type === submittedType,
+          });
         }
       };
     };
@@ -129,15 +130,24 @@
     panel?.querySelector<HTMLElement>(`[data-chip-remove="${CSS.escape(entry)}"]`) ?? null;
 
   /**
-   * Returns focus to the chip a confirm was opened on. Cancel and Escape both unmount the popover
-   * that holds `document.activeElement`, and Svelte flushes that teardown synchronously — so
-   * without this the keyboard user who opens a confirm and changes their mind lands on <body>,
-   * which is the same failure this file exists to fix, one keystroke off the path that was fixed.
+   * Returns focus to the chip a confirm was opened on. Dismissing unmounts the popover, so a
+   * keyboard user who opens a confirm and changes their mind otherwise lands on <body> — the same
+   * failure this file exists to fix, one keystroke off the path that was fixed.
+   *
+   * Resolved BEFORE `confirming` is cleared, since afterwards there is nothing to look up. The X
+   * itself lives outside the `{#if}`, so it survives the dismissal either way and the flush timing
+   * does not matter.
    */
   function dismissConfirm() {
     const control = confirming ? chipControl(confirming) : null;
+    // Escape comes from a window handler, so it fires with focus anywhere on the page — including
+    // the filter box with the popover still open, which is a reflex rather than an edge case.
+    const target = confirmDismissTarget(
+      confirming,
+      !!control?.closest('form')?.contains(document.activeElement)
+    );
     confirming = null;
-    control?.focus();
+    if (target.kind === 'chip') control?.focus();
   }
 
   /**
@@ -150,9 +160,10 @@
    * the chips when the LIST is empty rather than merely filtered to nothing, so the textarea is the
    * last resort.
    */
-  function focusAfterRemoval(position: number, item: string) {
+  function focusAfterRemoval(position: number, item: string, guards: RemovalFocusGuards) {
     if (!panel) return;
-    const next = chipFocusTarget(shown.visible, position, item);
+    const next = chipFocusTarget(shown.visible, position, item, guards);
+    if (next.kind === 'none') return;
     const target =
       (next.kind === 'chip' ? chipControl(next.entry) : null) ??
       panel.querySelector<HTMLElement>('[data-blocklist-filter] input') ??

--- a/apps/moderator/src/routes/blocklists/__tests__/focus.test.ts
+++ b/apps/moderator/src/routes/blocklists/__tests__/focus.test.ts
@@ -7,38 +7,64 @@ import { chipFocusTarget } from '../focus';
  * predictable loss — so each case names the removal it stands for.
  */
 describe('chipFocusTarget', () => {
-  const after = (visible: string[], position: number) => chipFocusTarget(visible, position);
+  const after = (visible: string[], position: number, item = 'removed') =>
+    chipFocusTarget(visible, position, item);
 
   it('lands on the entry that took the removed one’s place', () => {
-    // ['a','b','c'], removed 'b' at index 1 -> ['a','c'], and 'c' is now at 1.
-    expect(after(['a', 'c'], 1)).toBe('c');
+    // ['a','removed','c'], removed at index 1 -> ['a','c'], and 'c' is now at 1.
+    expect(after(['a', 'c'], 1)).toEqual({ kind: 'chip', entry: 'c' });
   });
 
   it('walks backwards when the LAST chip was removed', () => {
-    // ['a','b','c'], removed 'c' at index 2 -> ['a','b'], nothing at 2.
-    expect(after(['a', 'b'], 2)).toBe('b');
+    // ['a','b','removed'], removed at index 2 -> ['a','b'], nothing at 2.
+    expect(after(['a', 'b'], 2)).toEqual({ kind: 'chip', entry: 'b' });
   });
 
   it('stays on the first chip when the first was removed', () => {
-    expect(after(['b', 'c'], 0)).toBe('b');
+    expect(after(['b', 'c'], 0)).toEqual({ kind: 'chip', entry: 'b' });
   });
 
-  it('returns null when the removal emptied the list, so the caller uses the filter', () => {
-    expect(after([], 0)).toBeNull();
+  it('sends focus to the filter when the removal emptied the list', () => {
+    expect(after([], 0)).toEqual({ kind: 'filter' });
   });
 
-  it('returns null rather than the previous chip on an empty list', () => {
+  it('returns the filter rather than the previous chip on an empty list', () => {
     // Guards the `position - 1` fallback specifically: on an empty list it must not resolve.
-    expect(after([], 3)).toBeNull();
+    expect(after([], 3)).toEqual({ kind: 'filter' });
   });
 
   it('falls to the first entry when the removed chip was not in the captured list', () => {
     // `indexOf` returns -1 when the submit raced a filter change. Landing somewhere inside the
-    // list beats <body>, and index 0 is the only position that is meaningful without it.
-    expect(after(['a', 'b'], -1)).toBe('a');
+    // list beats <body>, and index 0 is the only position meaningful without it.
+    expect(after(['a', 'b'], -1)).toEqual({ kind: 'chip', entry: 'a' });
   });
 
-  it('returns null for a not-found removal on an empty list', () => {
-    expect(after([], -1)).toBeNull();
+  it('returns the filter for a not-found removal on an empty list', () => {
+    expect(after([], -1)).toEqual({ kind: 'filter' });
+  });
+
+  describe('when the entry is STILL on the list', () => {
+    /**
+     * The server returns `fail(409)` whenever the removal matched nothing — a state it models
+     * deliberately, because the page is served from a month-long Redis cache and goes stale. The
+     * list is then unchanged, and the user must end up back on the chip they were on.
+     *
+     * Without this rule that happened only because the index coincidentally still resolved to the
+     * same entry. It stops coinciding the moment anything else re-orders the list.
+     */
+    it('returns to the entry itself rather than trusting the captured index', () => {
+      expect(chipFocusTarget(['a', 'removed', 'c'], 1, 'removed')).toEqual({
+        kind: 'chip',
+        entry: 'removed',
+      });
+    });
+
+    it('returns to the entry even when the list re-ordered under the captured index', () => {
+      // Another moderator's add sorted a new entry in above it, so index 1 is now someone else.
+      expect(chipFocusTarget(['a', 'aa-new', 'removed'], 1, 'removed')).toEqual({
+        kind: 'chip',
+        entry: 'removed',
+      });
+    });
   });
 });

--- a/apps/moderator/src/routes/blocklists/__tests__/focus.test.ts
+++ b/apps/moderator/src/routes/blocklists/__tests__/focus.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { chipFocusTarget } from '../focus';
+
+/**
+ * The decision this pins is WHICH entry, not whether `.focus()` was called. Getting it wrong is
+ * worse than the loss it replaces — unpredictable focus movement is harder to work around than
+ * predictable loss — so each case names the removal it stands for.
+ */
+describe('chipFocusTarget', () => {
+  const after = (visible: string[], position: number) => chipFocusTarget(visible, position);
+
+  it('lands on the entry that took the removed one’s place', () => {
+    // ['a','b','c'], removed 'b' at index 1 -> ['a','c'], and 'c' is now at 1.
+    expect(after(['a', 'c'], 1)).toBe('c');
+  });
+
+  it('walks backwards when the LAST chip was removed', () => {
+    // ['a','b','c'], removed 'c' at index 2 -> ['a','b'], nothing at 2.
+    expect(after(['a', 'b'], 2)).toBe('b');
+  });
+
+  it('stays on the first chip when the first was removed', () => {
+    expect(after(['b', 'c'], 0)).toBe('b');
+  });
+
+  it('returns null when the removal emptied the list, so the caller uses the filter', () => {
+    expect(after([], 0)).toBeNull();
+  });
+
+  it('returns null rather than the previous chip on an empty list', () => {
+    // Guards the `position - 1` fallback specifically: on an empty list it must not resolve.
+    expect(after([], 3)).toBeNull();
+  });
+
+  it('falls to the first entry when the removed chip was not in the captured list', () => {
+    // `indexOf` returns -1 when the submit raced a filter change. Landing somewhere inside the
+    // list beats <body>, and index 0 is the only position that is meaningful without it.
+    expect(after(['a', 'b'], -1)).toBe('a');
+  });
+
+  it('returns null for a not-found removal on an empty list', () => {
+    expect(after([], -1)).toBeNull();
+  });
+});

--- a/apps/moderator/src/routes/blocklists/__tests__/focus.test.ts
+++ b/apps/moderator/src/routes/blocklists/__tests__/focus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { chipFocusTarget } from '../focus';
+import { chipFocusTarget, confirmDismissTarget } from '../focus';
 
 /**
  * The decision this pins is WHICH entry, not whether `.focus()` was called. Getting it wrong is
@@ -8,7 +8,7 @@ import { chipFocusTarget } from '../focus';
  */
 describe('chipFocusTarget', () => {
   const after = (visible: string[], position: number, item = 'removed') =>
-    chipFocusTarget(visible, position, item);
+    chipFocusTarget(visible, position, item, { focusWasInForm: true, sameType: true });
 
   it('lands on the entry that took the removed one’s place', () => {
     // ['a','removed','c'], removed at index 1 -> ['a','c'], and 'c' is now at 1.
@@ -53,18 +53,59 @@ describe('chipFocusTarget', () => {
      * same entry. It stops coinciding the moment anything else re-orders the list.
      */
     it('returns to the entry itself rather than trusting the captured index', () => {
-      expect(chipFocusTarget(['a', 'removed', 'c'], 1, 'removed')).toEqual({
-        kind: 'chip',
-        entry: 'removed',
-      });
+      expect(after(['a', 'removed', 'c'], 1)).toEqual({ kind: 'chip', entry: 'removed' });
     });
 
     it('returns to the entry even when the list re-ordered under the captured index', () => {
       // Another moderator's add sorted a new entry in above it, so index 1 is now someone else.
-      expect(chipFocusTarget(['a', 'aa-new', 'removed'], 1, 'removed')).toEqual({
-        kind: 'chip',
-        entry: 'removed',
-      });
+      expect(after(['a', 'aa-new', 'removed'], 1)).toEqual({ kind: 'chip', entry: 'removed' });
     });
+  });
+  describe('the guards, which used to be invisible ifs at the call site', () => {
+    /**
+     * 🔴 Moving focus that was not ours to move is WORSE than leaving it. A moderator part-way
+     * through typing a bulk list into the textarea gets yanked into the chip grid, where the next
+     * Space or Enter opens a remove confirm they did not ask for. Nothing observed this while it
+     * was an `if` in the component, and one of the two shipped inverted.
+     */
+    it('leaves focus alone when it was not inside the removed chip’s form', () => {
+      expect(
+        chipFocusTarget(['a', 'c'], 1, 'removed', { focusWasInForm: false, sameType: true })
+      ).toEqual({ kind: 'none' });
+    });
+
+    it('leaves focus alone when the tab changed while the removal was in flight', () => {
+      // `data.blocklist` is now a different type's entries, so "the entry at that index" would be
+      // an unrelated blocklist.
+      expect(
+        chipFocusTarget(['a', 'c'], 1, 'removed', { focusWasInForm: true, sameType: false })
+      ).toEqual({ kind: 'none' });
+    });
+
+    it('refuses on either guard, not only on both', () => {
+      expect(chipFocusTarget([], 0, 'removed', { focusWasInForm: false, sameType: false })).toEqual(
+        { kind: 'none' }
+      );
+    });
+  });
+});
+
+describe('confirmDismissTarget', () => {
+  it('returns to the chip when the confirm is dismissed from inside it', () => {
+    expect(confirmDismissTarget('spam.example', true)).toEqual({
+      kind: 'chip',
+      entry: 'spam.example',
+    });
+  });
+
+  it('leaves focus alone when Escape came from somewhere else on the page', () => {
+    // Escape is a window handler: a moderator can be typing in the filter with the popover still
+    // open and press it as a reflex. Focusing the chip would pull them out of the field.
+    expect(confirmDismissTarget('spam.example', false)).toEqual({ kind: 'none' });
+  });
+
+  it('does nothing when no confirm is open', () => {
+    expect(confirmDismissTarget(null, true)).toEqual({ kind: 'none' });
+    expect(confirmDismissTarget(null, false)).toEqual({ kind: 'none' });
   });
 });

--- a/apps/moderator/src/routes/blocklists/__tests__/focus.test.ts
+++ b/apps/moderator/src/routes/blocklists/__tests__/focus.test.ts
@@ -65,8 +65,8 @@ describe('chipFocusTarget', () => {
     /**
      * 🔴 Moving focus that was not ours to move is WORSE than leaving it. A moderator part-way
      * through typing a bulk list into the textarea gets yanked into the chip grid, where the next
-     * Space or Enter opens a remove confirm they did not ask for. Nothing observed this while it
-     * was an `if` in the component, and one of the two shipped inverted.
+     * Space or Enter opens a remove confirm they did not ask for. Nothing observed these while they
+     * were `if`s in the component, and a third guard of the same kind shipped missing entirely.
      */
     it('leaves focus alone when it was not inside the removed chip’s form', () => {
       expect(

--- a/apps/moderator/src/routes/blocklists/focus.ts
+++ b/apps/moderator/src/routes/blocklists/focus.ts
@@ -8,8 +8,9 @@
  * 🔴 The GUARDS live here too, not just the choice of entry. Moving focus when it was not ours to
  * move is worse than leaving it: it yanks a moderator out of the filter box or a half-typed bulk
  * paste and into a button, where the next Space or Enter opens a confirm they did not ask for.
- * Those guards were previously plain `if`s at the call site, where nothing could see them — and one
- * of them shipped inverted. In here, hardcoding either to `true` fails a test.
+ * Those guards were previously plain `if`s at the call site, where nothing could see them — and a
+ * third guard of exactly this kind shipped MISSING altogether, which is how Escape came to yank
+ * focus out of the filter box. In here, hardcoding any of them to `true` fails a test.
  */
 export type ChipFocusTarget =
   /** Leave focus where it is. */

--- a/apps/moderator/src/routes/blocklists/focus.ts
+++ b/apps/moderator/src/routes/blocklists/focus.ts
@@ -1,0 +1,18 @@
+/**
+ * Where keyboard focus goes after a chip is removed.
+ *
+ * `{#each}` is keyed by the entry, so the removed chip's button is unmounted by the invalidation
+ * and focus falls to `<body>` — from which a moderator has to tab past everything above a list of
+ * up to 200 chips to reach the next one. Returning the entry that took the removed one's place
+ * makes repeated removal work without leaving the list.
+ *
+ * `null` means there is no chip to land on and the caller should fall back to the filter input.
+ * It is deliberately NOT the same as "focus the previous chip": emptying the list is the one case
+ * where staying among the chips is impossible.
+ */
+export function chipFocusTarget(visible: string[], position: number): string | null {
+  if (position < 0) return visible[0] ?? null;
+  // The entry now AT that index, which is the one that slid up. Falling back to `position - 1`
+  // covers removing the last chip; both are undefined once the list is empty.
+  return visible[position] ?? visible[position - 1] ?? null;
+}

--- a/apps/moderator/src/routes/blocklists/focus.ts
+++ b/apps/moderator/src/routes/blocklists/focus.ts
@@ -3,16 +3,32 @@
  *
  * `{#each}` is keyed by the entry, so the removed chip's button is unmounted by the invalidation
  * and focus falls to `<body>` — from which a moderator has to tab past everything above a list of
- * up to 200 chips to reach the next one. Returning the entry that took the removed one's place
- * makes repeated removal work without leaving the list.
+ * up to 200 chips to reach the next one.
  *
- * `null` means there is no chip to land on and the caller should fall back to the filter input.
- * It is deliberately NOT the same as "focus the previous chip": emptying the list is the one case
- * where staying among the chips is impossible.
+ * The whole decision lives here rather than at the call site so it can be tested; what remains in
+ * the component is looking the target up in the DOM and calling `.focus()`.
  */
-export function chipFocusTarget(visible: string[], position: number): string | null {
-  if (position < 0) return visible[0] ?? null;
-  // The entry now AT that index, which is the one that slid up. Falling back to `position - 1`
-  // covers removing the last chip; both are undefined once the list is empty.
-  return visible[position] ?? visible[position - 1] ?? null;
+export type ChipFocusTarget =
+  /** The remove control of this entry's chip. */
+  | { kind: 'chip'; entry: string }
+  /** No chip to land on. The filter input, because it is the only control that brings chips back. */
+  | { kind: 'filter' };
+
+export function chipFocusTarget(
+  visible: string[],
+  position: number,
+  item: string
+): ChipFocusTarget {
+  // The removal did not take: the server refused it (`fail(409)` on a stale page is a state this
+  // action returns deliberately), or the list re-rendered for some other reason. Returning the
+  // user to the chip they were on is correct by construction here rather than by luck of the
+  // index still resolving to the same entry.
+  if (visible.includes(item)) return { kind: 'chip', entry: item };
+
+  // Otherwise the entry that took its place, so a run of removals walks down the list; the
+  // previous one when the last chip went; and the first when `indexOf` returned -1 because the
+  // captured list is not the one we are looking at any more.
+  const next = position < 0 ? visible[0] : (visible[position] ?? visible[position - 1]);
+
+  return next === undefined ? { kind: 'filter' } : { kind: 'chip', entry: next };
 }

--- a/apps/moderator/src/routes/blocklists/focus.ts
+++ b/apps/moderator/src/routes/blocklists/focus.ts
@@ -1,34 +1,71 @@
 /**
- * Where keyboard focus goes after a chip is removed.
+ * Where keyboard focus goes when a chip's controls disappear.
  *
- * `{#each}` is keyed by the entry, so the removed chip's button is unmounted by the invalidation
- * and focus falls to `<body>` — from which a moderator has to tab past everything above a list of
- * up to 200 chips to reach the next one.
+ * `{#each}` is keyed by the entry, so a removal unmounts the button that was just activated and
+ * focus falls to `<body>` — from which a moderator has to tab past everything above a list of up to
+ * 200 chips to reach the next one. Dismissing a confirm unmounts the popover the same way.
  *
- * The whole decision lives here rather than at the call site so it can be tested; what remains in
- * the component is looking the target up in the DOM and calling `.focus()`.
+ * 🔴 The GUARDS live here too, not just the choice of entry. Moving focus when it was not ours to
+ * move is worse than leaving it: it yanks a moderator out of the filter box or a half-typed bulk
+ * paste and into a button, where the next Space or Enter opens a confirm they did not ask for.
+ * Those guards were previously plain `if`s at the call site, where nothing could see them — and one
+ * of them shipped inverted. In here, hardcoding either to `true` fails a test.
  */
 export type ChipFocusTarget =
+  /** Leave focus where it is. */
+  | { kind: 'none' }
   /** The remove control of this entry's chip. */
   | { kind: 'chip'; entry: string }
   /** No chip to land on. The filter input, because it is the only control that brings chips back. */
   | { kind: 'filter' };
 
+const LEAVE: ChipFocusTarget = { kind: 'none' };
+
+export type RemovalFocusGuards = {
+  /** Was focus inside the removed chip's own form when it was submitted? */
+  focusWasInForm: boolean;
+  /** Is the page still showing the blocklist that was submitted against? */
+  sameType: boolean;
+};
+
 export function chipFocusTarget(
   visible: string[],
   position: number,
-  item: string
+  item: string,
+  { focusWasInForm, sameType }: RemovalFocusGuards
 ): ChipFocusTarget {
+  // Not our focus to move: it was somewhere else on the page when the removal was submitted.
+  if (!focusWasInForm) return LEAVE;
+  // A removal can outlive the tab. Clicking another tab mid-flight swaps the entries for a
+  // different type's, and "the entry at that index" would then be an unrelated blocklist.
+  if (!sameType) return LEAVE;
+
   // The removal did not take: the server refused it (`fail(409)` on a stale page is a state this
-  // action returns deliberately), or the list re-rendered for some other reason. Returning the
-  // user to the chip they were on is correct by construction here rather than by luck of the
-  // index still resolving to the same entry.
+  // action returns deliberately), or the list re-rendered for another reason. Returning the user to
+  // the chip they were on is then correct by construction, rather than by luck of the index still
+  // resolving to the same entry.
   if (visible.includes(item)) return { kind: 'chip', entry: item };
 
-  // Otherwise the entry that took its place, so a run of removals walks down the list; the
-  // previous one when the last chip went; and the first when `indexOf` returned -1 because the
-  // captured list is not the one we are looking at any more.
-  const next = position < 0 ? visible[0] : (visible[position] ?? visible[position - 1]);
+  // Otherwise the entry that took its place, so a run of removals walks down the list; the previous
+  // one when the last chip went; and the first when `indexOf` returned -1 because the captured list
+  // is not the one we are looking at any more.
+  const next = position < 0 ? visible[0] : visible[position] ?? visible[position - 1];
 
   return next === undefined ? { kind: 'filter' } : { kind: 'chip', entry: next };
+}
+
+/**
+ * Where focus goes when a confirm popover is dismissed by Cancel or Escape.
+ *
+ * Escape is a `svelte:window` handler, so it fires from anywhere on the page — including from the
+ * filter input while the popover is still open and visible, which is a reflex a moderator will
+ * actually have. Without the guard that dismissal pulls them out of the field they are typing in.
+ * Cancel passes it for free, since clicking Cancel puts focus inside the popover.
+ */
+export function confirmDismissTarget(
+  confirming: string | null,
+  focusWasInChipForm: boolean
+): ChipFocusTarget {
+  if (!confirming || !focusWasInChipForm) return LEAVE;
+  return { kind: 'chip', entry: confirming };
 }


### PR DESCRIPTION
Closes `868kv0wuy`. Moderator spoke only, and disjoint from #4357 — no shared file.

## The problem

On `/moderator/blocklists` every chip is its own form and its `×` submits it. `use:enhance`'s `update()` invalidates the load, the `{#each}` re-renders, and since it is keyed by the entry string the removed chip's button is **destroyed**. Focus falls back to `<body>`, so a keyboard user removing several entries has to tab from the top of a list of up to 200 chips after every single removal.

Not a regression. Before #4254 there was no per-chip control to lose focus from — it is a gap in something new.

## Where focus goes, and why that needed deciding rather than patching

The ticket filed this rather than folding it in because guessing wrong is *worse* than the current behaviour: unpredictable focus movement is harder to work around than predictable loss. So the decision is a pure function with a name, `chipFocusTarget`, and seven cases:

| removal | lands on |
|---|---|
| a chip with entries after it | the entry that took its place, so holding the key removes down the list |
| the last chip | the previous one |
| emptied the visible list | `null` → the filter input |
| the entry was not in the captured list (`indexOf` → `-1`) | the first entry |

`null` is deliberately not "focus the previous chip": emptying the list is the one case where staying among the chips is impossible. The filter input is the right landing because it is the only control that can bring chips back.

The DOM half falls back further — when the removal emptied the **list** rather than the filter, the filter bar unmounts with the chips, so the last resort is the textarea. Never `<body>`.

## Three things that are easy to get wrong here

- **Both facts are captured BEFORE the submit.** After the invalidation the entry is gone from the list and `document.activeElement` is `<body>`, so neither question can still be answered.
- **Focus is restored after `removing` is cleared, not before.** Every chip control is `disabled` while a removal is in flight, and a disabled button silently refuses focus. `tick()` waits for both the re-rendered chips and that re-enable to reach the DOM.
- **The gate is "was focus inside THIS chip's form".** That is true for keyboard activation and also for a pointer in browsers that focus a button on click — which is fine, since those get no visible ring under `:focus-visible`. What it excludes is the case that would be an unasked-for scroll: focus sitting somewhere else on the page.

## Mutation controls

| mutation | result |
|---|---|
| land on the previous chip instead of the one that took its place | 2 failed — `expected 'a' to be 'c'` |
| drop the not-found (`-1`) branch | 1 failed — `expected null to be 'a'` |

Both are assertion failures naming a wrong value, in milliseconds.

## What is NOT covered, stated so the green run is not over-read

`chipFocusTarget` is tested; the DOM half — `querySelector` by `data-chip-remove`, the `tick()` ordering, the `formElement.contains(document.activeElement)` gate — is **not**. `apps/moderator` has no component-test tier, and standing one up for this is not worth it. The DOM half is a handful of lines with no branching beyond the two documented fallbacks, and the decision that could actually be wrong is the part under test.

Cheap to check by hand, as the ticket says: tab to a chip, activate it, see where focus is afterwards.

## Verification

- `apps/moderator` `svelte-check` — 9352 files, 0 errors (two more than the tree without this change; the new module and its test were seen)
- `pnpm exec eslint` on the changed files — clean, **with a positive control**: an injected unused variable was reported, so the clean run could have failed
- `pnpm run test:apps:run` — `Test Files 84 passed (84)`
- `pnpm run test:unit:run` — `Test Files 1391 passed | 1 skipped (1392)`, `Tests 21802 passed | 27 skipped (21829)`, exit 0. It covers nothing under `apps/`; run because the contract says to run it once rather than to narrow it quietly.

No migration. No schema change. No server-side change at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
