### PR TITLE
fix(stickers): box tile artwork square and contain it

### DIFF
--- a/src/components/Placement/StickerPlacementQueue.tsx
+++ b/src/components/Placement/StickerPlacementQueue.tsx
@@ -184,7 +184,7 @@ function StickerArt({
           src={art.url}
           alt={`:${art.slug}:`}
           options={{ height: 96, anim: art.animated, optimized: true }}
-          style={{ height: 48, width: 'auto', ...stickerArtworkStyle(data) }}
+          style={{ height: 48, width: 48, objectFit: 'contain', ...stickerArtworkStyle(data) }}
         />
       </div>
       <Text size="10px" c="dimmed" className="max-w-[80px] truncate">

--- a/src/components/StickerBook/StickerBookStickers.tsx
+++ b/src/components/StickerBook/StickerBookStickers.tsx
@@ -103,7 +103,10 @@ function StickerTile({
             src={art.url}
             alt={`:${art.slug}:`}
             options={{ height: 144, anim: art.animated, optimized: true }}
-            style={{ height: 72, width: 'auto' }}
+            // Boxed square and contained, the way jumbo boxes a wide sticker.
+            // With the width left to the artwork, a 2:1 sticker overflowed the
+            // tile and the resulting max-width clamp squashed it.
+            style={{ height: 72, width: 72, objectFit: 'contain' }}
           />
           {showQuantity && (
             <Text size="xs" c="dimmed">


### PR DESCRIPTION
The "Your stickers" tile on the sticker book was the one sticker surface without `objectFit: 'contain'`. It pinned the height and left the width to the artwork, so Tailwind's `img { max-width: 100% }` clamped anything wider than the tile and squashed it — a 2:1 sticker rendered 88x72 instead of 144x72.

Both tiles are now a square box with the art contained and centered — the shape `StickerInventoryCard`, `StickerSuggestionList` and `Sticker` itself already use, and the one `stickerMaxWidth` documents for jumbo. Square stickers are unchanged.

The placement queue's thumbnail is included for consistency. It was **not** distorting — its plate has no width constraint, so nothing clamped the art — but it was one width constraint away from the same bug, and an art-driven width made every row's text column start somewhere different.

Deliberately not touched: the placed sticker and the draft (`StickerPlacementOverlay`, `DraftSticker`) are width-driven with `height: auto`, and boxing those square would shrink a wide sticker on the image. The inline list rows keep `width: 'auto'` — they already contain, and they are rows rather than tiles.

Measured against prod: of 40 published sticker cosmetics, 31 are square, 6 are taller than wide (already narrower than the tile, unaffected), and 3 are 1.6:1 or wider — the distorted ones.

Not run: typecheck, lint, tests. CSS-only, and component tests here render without a stylesheet, so a measured assertion could not fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)