### PR TITLE
test: hoist cold service imports out of test bodies (fixes the red full suite on main)

### DIFF
--- a/src/components/Sticker/__tests__/pack-purchase-key.test.ts
+++ b/src/components/Sticker/__tests__/pack-purchase-key.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
+// Module scope, not a test body: from a body this transform is charged to one test's 60s
+// budget. See vitest.config.mts.
+import { purchaseCanBeRetriedFresh } from '~/components/Sticker/sticker.util';
 import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
 
 /**
@@ -90,8 +93,6 @@ const trpcError = (httpStatus: number) => ({ data: { httpStatus } });
 
 describe('classifying a failed purchase', () => {
   it('releases on anything the server declined', async () => {
-    const { purchaseCanBeRetriedFresh } = await import('~/components/Sticker/sticker.util');
-
     // 400 covers every refusal in the purchase path now that they are TRPCErrors;
     // the others are here because the rule is the class, not the number.
     for (const status of [400, 401, 403, 404, 409, 422])
@@ -103,8 +104,6 @@ describe('classifying a failed purchase', () => {
    * which is exactly the case the old string matching could not see.
    */
   it('holds the key on anything that might have gone through', async () => {
-    const { purchaseCanBeRetriedFresh } = await import('~/components/Sticker/sticker.util');
-
     for (const error of [
       trpcError(500),
       trpcError(502),

--- a/src/server/services/__tests__/home-block-fetch-sizing.test.ts
+++ b/src/server/services/__tests__/home-block-fetch-sizing.test.ts
@@ -1,11 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HomeBlockType } from '~/shared/utils/prisma/enums';
 import { GET_ALL_IMAGES_PER_MODEL_SLIM } from '~/server/utils/model-getall-images';
-// Imported at module scope, never lazily from a test body. This module's graph pulls
-// image.service, model.service, collection.service and leaderboard.service; loading it measured
-// 39.7s against a 60s testTimeout. From a test body that whole cost is charged to ONE test's
-// budget, so the file reds on ambient load alone — it did, repeatedly, on main. At module scope
-// it lands in collection, which no timeout bounds. See vitest.config.mts.
+// Module scope, never a test body: from a body this graph's transform is charged to ONE test's
+// 60s budget (39.7s running the file alone on a 32-core Windows box, past 60s inside a full
+// suite — that is how it reddened main). At module scope it moves to collection, which nothing
+// bounds, so a real hang here has no timeout to name it. See vitest.config.mts.
 import { getHomeBlockData, resolveFeedFetchLimit } from '~/server/services/home-block.service';
 import type * as ModelService from '~/server/services/model.service';
 

--- a/src/server/services/__tests__/home-block-fetch-sizing.test.ts
+++ b/src/server/services/__tests__/home-block-fetch-sizing.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HomeBlockType } from '~/shared/utils/prisma/enums';
 import { GET_ALL_IMAGES_PER_MODEL_SLIM } from '~/server/utils/model-getall-images';
+// Imported at module scope, never lazily from a test body. This module's graph pulls
+// image.service, model.service, collection.service and leaderboard.service; loading it measured
+// 39.7s against a 60s testTimeout. From a test body that whole cost is charged to ONE test's
+// budget, so the file reds on ambient load alone — it did, repeatedly, on main. At module scope
+// it lands in collection, which no timeout bounds. See vitest.config.mts.
+import { getHomeBlockData, resolveFeedFetchLimit } from '~/server/services/home-block.service';
 import type * as ModelService from '~/server/services/model.service';
 
 const { getModelsWithImagesAndModelVersionsMock, getFeaturedModelsMock } = vi.hoisted(() => ({
@@ -13,10 +19,6 @@ vi.mock('~/server/services/model.service', async (importOriginal) => ({
   getModelsWithImagesAndModelVersions: getModelsWithImagesAndModelVersionsMock,
   getFeaturedModels: getFeaturedModelsMock,
 }));
-
-async function loadService() {
-  return import('~/server/services/home-block.service');
-}
 
 const callArgs = () =>
   getModelsWithImagesAndModelVersionsMock.mock.calls[0]?.[0] as unknown as {
@@ -40,16 +42,12 @@ beforeEach(() => {
 // homepage feeds shipped 3x what anyone had chosen.
 describe('feed fetch size', () => {
   it('fetches exactly the configured limit', async () => {
-    const { getHomeBlockData } = await loadService();
-
     await getHomeBlockData({ input: {}, homeBlock: modelsFeed({ limit: 42 }) });
 
     expect(callArgs().input.limit).toBe(42);
   });
 
   it('still fetches exactly the configured limit when maxPerUser is set', async () => {
-    const { getHomeBlockData } = await loadService();
-
     await getHomeBlockData({ input: {}, homeBlock: modelsFeed({ limit: 42, maxPerUser: 2 }) });
 
     expect(callArgs().input.limit).toBe(42);
@@ -59,23 +57,17 @@ describe('feed fetch size', () => {
   // the images branch too without mocking `image.service` — which is on the shared-mock
   // migration ratchet, and a new direct mock there moves that count the wrong way.
   it('does not scale the configured limit', async () => {
-    const { resolveFeedFetchLimit } = await loadService();
-
     expect(resolveFeedFetchLimit(42)).toBe(42);
     expect(resolveFeedFetchLimit(7)).toBe(7);
   });
 
   it('clamps a mistyped limit to the ceiling', async () => {
-    const { resolveFeedFetchLimit } = await loadService();
-
     expect(resolveFeedFetchLimit(5000)).toBe(100);
   });
 
   // `Math.min(undefined, n)` is NaN, which would reach the fetch unchecked — the metadata is
   // cast, never parsed, so the schema default cannot rescue it.
   it('falls back to the schema default when limit is missing', async () => {
-    const { resolveFeedFetchLimit } = await loadService();
-
     expect(resolveFeedFetchLimit(undefined)).toBe(28);
   });
 });
@@ -85,8 +77,6 @@ describe('feed fetch size', () => {
 // shorter block for some viewers. These pin the pair at both call sites.
 describe('per-model image cap', () => {
   it('caps and bias-slices the models Feed block', async () => {
-    const { getHomeBlockData } = await loadService();
-
     await getHomeBlockData({ input: {}, homeBlock: modelsFeed({ limit: 42 }) });
 
     expect(getModelsWithImagesAndModelVersionsMock).toHaveBeenCalledTimes(1);
@@ -95,8 +85,6 @@ describe('per-model image cap', () => {
   });
 
   it('caps and bias-slices the FeaturedModelVersion block', async () => {
-    const { getHomeBlockData } = await loadService();
-
     await getHomeBlockData({
       input: {},
       homeBlock: { id: 2, type: HomeBlockType.FeaturedModelVersion, metadata: {} },

--- a/src/server/services/__tests__/home-block-fetch-sizing.test.ts
+++ b/src/server/services/__tests__/home-block-fetch-sizing.test.ts
@@ -4,7 +4,8 @@ import { GET_ALL_IMAGES_PER_MODEL_SLIM } from '~/server/utils/model-getall-image
 // Module scope, never a test body: from a body this graph's transform is charged to ONE test's
 // 60s budget (39.7s running the file alone on a 32-core Windows box, past 60s inside a full
 // suite — that is how it reddened main). At module scope it moves to collection, which nothing
-// bounds, so a real hang here has no timeout to name it. See vitest.config.mts.
+// bounds, so a real hang here has no timeout to name it. See vitest.config.mts; the
+// measurements behind these numbers are in PR #4363.
 import { getHomeBlockData, resolveFeedFetchLimit } from '~/server/services/home-block.service';
 import type * as ModelService from '~/server/services/model.service';
 

--- a/src/server/services/__tests__/user-payment-configuration.tipalti-status.test.ts
+++ b/src/server/services/__tests__/user-payment-configuration.tipalti-status.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { isBlockedTipaltiStatus, TipaltiStatus } from '~/server/common/enums';
 import { Tipalti } from '~/server/http/tipalti/tipalti.schema';
+// Module scope, never a test body: from a body this graph's transform is charged to ONE test's
+// 60s budget (42.8s running the file alone on a 32-core Windows box, 53-67s recorded inside full
+// suites, and it has already timed out on main). At module scope it moves to collection, which
+// nothing bounds, so a real hang here has no timeout to name it. See vitest.config.mts.
+import { updateByTipaltiAccount } from '~/server/services/user-payment-configuration.service';
 import type * as NotificationService from '~/server/services/notification.service';
 
 const { mockCreateNotification } = vi.hoisted(() => ({
@@ -43,10 +48,6 @@ const update = async (args: {
   );
   dbMock.dbWrite.userPaymentConfiguration.update.mockResolvedValue(
     config(args.incomingStatus, args.incomingPayable)
-  );
-
-  const { updateByTipaltiAccount } = await import(
-    '~/server/services/user-payment-configuration.service'
   );
 
   return updateByTipaltiAccount({

--- a/src/server/services/__tests__/user-payment-configuration.tipalti-status.test.ts
+++ b/src/server/services/__tests__/user-payment-configuration.tipalti-status.test.ts
@@ -5,7 +5,8 @@ import { Tipalti } from '~/server/http/tipalti/tipalti.schema';
 // Module scope, never a test body: from a body this graph's transform is charged to ONE test's
 // 60s budget (42.8s running the file alone on a 32-core Windows box, 53-67s recorded inside full
 // suites, and it has already timed out on main). At module scope it moves to collection, which
-// nothing bounds, so a real hang here has no timeout to name it. See vitest.config.mts.
+// nothing bounds, so a real hang here has no timeout to name it. See vitest.config.mts;
+// the measurements behind these numbers are in PR #4363.
 import { updateByTipaltiAccount } from '~/server/services/user-payment-configuration.service';
 import type * as NotificationService from '~/server/services/notification.service';
 

--- a/src/server/utils/__tests__/comment-permalink.ssr.test.ts
+++ b/src/server/utils/__tests__/comment-permalink.ssr.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+// Module scope, not a test body: from a body this transform is charged to one test's 60s
+// budget. See vitest.config.mts.
+import { getServerSideProps } from '~/pages/comments/v2/[id]';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 
 /**
@@ -76,7 +79,6 @@ const row = (entity: Record<string, unknown>) => ({
 });
 
 const run = async () => {
-  const { getServerSideProps } = await import('~/pages/comments/v2/[id]');
   return (await (getServerSideProps as any)({
     params: { id: String(COMMENT_ID) },
     req: { url: `/comments/v2/${COMMENT_ID}`, headers: {}, cookies: {} },

--- a/src/tests/pages/apps/review/review-detail-page-gate.test.ts
+++ b/src/tests/pages/apps/review/review-detail-page-gate.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Module scope, not a test body: from a body this transform is charged to one test's 60s
+// budget. See vitest.config.mts.
+import '~/pages/apps/review/[publishRequestId]';
 
 /**
  * PER-SUBMISSION REVIEW PAGE SSR gate (`/apps/review/<publishRequestId>`).
@@ -57,7 +60,9 @@ vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true, appReviewPage: true }),
 }));
-vi.mock('~/utils/trpc', () => ({ trpc: { blocks: { getPublishRequest: { useQuery: () => ({}) } } } }));
+vi.mock('~/utils/trpc', () => ({
+  trpc: { blocks: { getPublishRequest: { useQuery: () => ({}) } } },
+}));
 
 function makeCtx(
   opts: {
@@ -85,7 +90,6 @@ function makeCtx(
 }
 
 async function loadResolver() {
-  await import('~/pages/apps/review/[publishRequestId]');
   if (!capturedResolver.fn) throw new Error('resolver not captured');
   return capturedResolver.fn;
 }

--- a/src/tests/pages/apps/run/run-page-maturity.test.ts
+++ b/src/tests/pages/apps/run/run-page-maturity.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Module scope, not a test body: from a body this transform is charged to one test's 60s
+// budget. See vitest.config.mts.
+import '~/pages/apps/run/[slug]/[[...path]]';
 
 /**
  * NSFW-APP-RED-ONLY — run-page SSR gate (`/apps/run/<slug>`).
@@ -72,7 +75,6 @@ function makeCtx(host: string, slug = 'cool-app') {
 }
 
 async function loadResolver() {
-  await import('~/pages/apps/run/[slug]/[[...path]]');
   if (!capturedResolver.fn) throw new Error('resolver not captured');
   return capturedResolver.fn;
 }


### PR DESCRIPTION
Fixes the red full-suite run on `main` reported in ClickUp `868kw9wf1`, and sweeps four more files with the same defect.

## It is not cross-file pollution

The ticket's hypothesis was shared state leaking between files. It isn't, and it mechanically cannot be: the `unit` projects run `pool: 'forks'` with `isolate: true`, one fresh process per test file.

`home-block-fetch-sizing.test.ts` called `await loadService()` from **inside every test body** — a cold `import()` of `home-block.service`, whose graph pulls `image.service` (8k lines), `model.service`, `collection.service` and `leaderboard.service`. That whole transform is charged to **one test's 60s budget**. This is the anti-pattern `vitest.config.mts:186-197` already documents, along with the fix.

The daemon's own log of the red run (`t47q9gr`, tensor-header-autocorrect):

```
× fetches exactly the configured limit 60022ms
  → Error: Test timed out in 60000ms.
× still fetches exactly the configured limit when maxPerUser is set 3ms
  → TypeError: getHomeBlockData is not a function
... (five more, 1-6ms each)
Test Files  1 failed | 1382 passed | 1 skipped (1384)
```

One timeout; the other six are fallout from the aborted module load, not six independent failures.

Vitest's sequencer sorts slowest-first, so the file ran **first**, when all 31 workers are cold-transforming at once. Self-reinforcing, which is why it stuck to some worktrees and not others.

## Measurements, on a fresh worktree at bare `origin/main`

| | before | after |
|---|---|---|
| `home-block-fetch-sizing` test 1, run alone | 39,662ms | 4ms |
| `home-block-fetch-sizing` file, inside a full suite | 36,704ms (rank 3 of 1389) | 11ms (rank 1213) |
| `tipalti-status` worst test, run alone | 42,773ms | 6ms |
| `tipalti-status` file, inside a full suite | 31,943ms | 74ms |

The in-suite figures come from Vitest's own sequencer cache (`node_modules/.vite/vitest/*/results.json`), which records a per-file duration each run. Two clarifications so the numbers reconcile:

- `home-block-fetch-sizing` appears twice above with different in-suite figures — **36,704ms** (a full suite that passed, in my worktree) and **60,022ms** (the run that timed out, in tensor-header-autocorrect). Different runs on different trees, not a contradiction: the point is that even the passing one burned 61% of the budget.
- `tipalti-status` was recorded at **66,741ms** (tensor-header-autocorrect), **58,957ms** (bdx-cursor-fallback) and **53,348ms** (mine, after home-block was fixed but before this file was) — already at or past the 60s ceiling, which is why it is in this PR rather than a follow-up. The 31,943ms row above is a later, quieter run of the same file.

At module scope the load lands in the **collection phase**, which no timeout bounds.

## How each fix is proven

A two-sided control at `--testTimeout=5000`. It fails if the import is still charged to a test, and it fails if the hoist broke a mock or a captured resolver — so passing it establishes both.

| file | pre-fix @5s | post-fix @5s |
|---|---|---|
| `home-block-fetch-sizing` | `6 failed \| 1 passed (7)` | `7 passed (7)` |
| `tipalti-status` | `8 failed \| 24 passed (32)` | `32 passed (32)` |
| `comment-permalink.ssr` | `3 failed \| 7 passed (10)` | `10 passed (10)` |
| `pack-purchase-key` | `1 failed \| 7 passed (8)` | `8 passed (8)` |
| `run-page-maturity` | `1 failed \| 5 passed (6)` | `6 passed (6)` |
| `review-detail-page-gate` | `1 failed \| 6 passed (7)` | `7 passed (7)` |

## Scope

Two files were **over the ceiling** and had already reddened `main` — `home-block-fetch-sizing` and `tipalti-status`, the latter recorded in the ticket's own run table under `t3xsc3a`. The other four are margin, not live bugs: their worst tests are 8.9-19.6s, where the two that broke sat at 39.7s and 42.8s.

Three files in the same size band are **deliberately left alone**:

- `dev-tunnel-page.test.ts` — its mock assigns two different resolvers by call order (`sspCallCount === 0 ? capturedDev : capturedRun`), so hoisting both imports changes when that ordering resolves. 9.9s of payoff against real risk.
- `publish-request.orchestration.test.ts` — 9.8s worst test across **112** tests. Nothing concentrated to move.
- `trpc-batch-link-wiring.test.ts` — already imports in `beforeAll`, the fallback `vitest.config.mts` sanctions for exactly this cost.

Also unaddressed, and a different problem: four slow files (`audit-matching-equivalence` 30.7s, `release-app-skew-guard` 25.4s, `user-settings-race` 24.6s, `typecheck-tests-gate` 19.1s) already import at module scope. Their time is real test execution and no hoist applies.

## Verification

- `pnpm run typecheck` — `0 type errors`
- `pnpm run lint` — `4354 problems (362 errors, 3992 warnings)`, **byte-identical to the same run before these changes**; the only entries touching these files are pre-existing `no-explicit-any` warnings, shifted by the added lines
- `pnpm run test:unit:run` — green twice at each stage. Latest: `Test Files 1388 passed | 1 skipped (1389)`, `Tests 21774 passed | 27 skipped (21801)`, exit 0
- `blocks.router.workflow.test.ts` collected **358 tests**, confirming the worktree's submodule is initialised and the runs mean something

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review notes (adversarial pass, read-only, pinned to 0f4b5c9157)

**Not strictly better — one honest trade.** These six files now evaluate their graph at collection, which nothing bounds. If one of those modules ever throws on import, the file reports a collection error and contributes **zero** tests rather than N named failures. Vitest still exits nonzero, so it is not silent, but a summary skim would read as fine. The merge run is checked for nonzero collected counts for exactly this reason. Likewise, a genuine hang in module init no longer has a 60s timeout to name it. That is the sanctioned trade for removing a live 60s cliff, not a free win.

**One sibling deliberately not converted, with the number.** `review-preview-page-gate.test.ts` has the identical lazy-import shape and sits beside two files this PR converts. Measured before touching it: **worst test 148ms**, and it *passes* a `--testTimeout=5000` run unchanged. The control cannot even demonstrate a fix there, so converting it would be risk for no measured gain. Its header comment says it "Mirrors `run-page-maturity.test.ts`", but that sentence describes the mocking strategy — capture the resolver via a mocked `createServerSideProps` — which this PR does not change.

**Pre-existing, filed as [868kwahh2](https://app.clickup.com/t/868kwahh2) rather than fixed here:** `run-page-maturity.test.ts:41-47` mocks `~/server/utils/server-domain` with a *reimplementation* of `ratingAllowedOnHost`, so it asserts against a copy of the gate rather than the gate. Mutating the real `ratingAllowedOnHost` reds nothing in that file. It does still catch the page ceasing to consult the gate. On `main` already, unchanged by this PR.

The four slow files whose cost is real execution rather than imports are filed as [868kwahh4](https://app.clickup.com/t/868kwahh4).
