### PR TITLE
feat(image-feed): Published/Draft toggle, and stop fusing drafts into every feed

### DIFF
--- a/src/components/Image/Filters/MediaFiltersDropdown.tsx
+++ b/src/components/Image/Filters/MediaFiltersDropdown.tsx
@@ -111,7 +111,13 @@ export function MediaFiltersDropdown({
       requiringMeta: undefined,
       hidden: undefined,
       fromPlatform: undefined,
-      notPublished: undefined,
+      // Only cleared when this dropdown actually SHOWS the control. On the
+      // profile images/videos tabs the Published/Draft toggle owns
+      // `notPublished` and the chip is excluded, so clearing it here would flip
+      // a creator out of Drafts from a control that never displayed that state.
+      // Same reasoning as `filterLength` below, which is already gated: a
+      // dropdown should not own a filter it does not show.
+      ...(shows('notPublished') ? { notPublished: undefined } : {}),
       scheduled: undefined,
       hideManualResources: undefined,
       hideAutoResources: undefined,
@@ -143,7 +149,7 @@ export function MediaFiltersDropdown({
         types: getDefaultMediaTypes(filterType),
         period: MetricTimeframe.AllTime,
       });
-  }, [onChange, setFilters, filterType]);
+  }, [onChange, setFilters, filterType, shows]);
 
   const {
     opened,

--- a/src/components/Image/Infinite/UserMediaInfinite.tsx
+++ b/src/components/Image/Infinite/UserMediaInfinite.tsx
@@ -5,6 +5,7 @@ import { MediaType, MetricTimeframe } from '~/shared/utils/prisma/enums';
 import React from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { SortFilter } from '~/components/Filters';
+import { FeedContentToggle } from '~/components/FeedContentToggle/FeedContentToggle';
 import { MediaFiltersDropdown } from '~/components/Image/Filters/MediaFiltersDropdown';
 import type { ImageSections } from '~/components/Image/image.utils';
 import { useImageQueryParams } from '~/components/Image/image.utils';
@@ -55,6 +56,7 @@ export function UserMediaInfinite({ type = MediaType.image }: { type: MediaType 
 
   const isSameUser =
     !!currentUser && postgresSlugify(currentUser.username) === postgresSlugify(username);
+  const isModerator = currentUser?.isModerator ?? false;
   const section = isSameUser ? query.section ?? 'images' : 'images';
   const viewingReactions = section === 'reactions';
 
@@ -77,6 +79,21 @@ export function UserMediaInfinite({ type = MediaType.image }: { type: MediaType 
                     value={section}
                     type={type}
                     onChange={(section) => replace({ section })}
+                  />
+                )}
+                {/* Drafts are the creator's own unpublished work, so the toggle
+                    belongs to whoever may see it: the creator on their own
+                    profile, and a moderator on anyone's. The server decides that
+                    independently in `canRequestUnpublished` — this only decides
+                    whether to offer the control. Hidden under Reactions, which is
+                    a view of other people's posts. */}
+                {(isSameUser || isModerator) && !viewingReactions && (
+                  <FeedContentToggle
+                    size="xs"
+                    value={notPublished ? 'draft' : 'published'}
+                    onChange={(value) =>
+                      replace({ notPublished: value === 'draft' ? true : undefined })
+                    }
                   />
                 )}
                 {viewingReactions && (
@@ -130,6 +147,12 @@ export function UserMediaInfinite({ type = MediaType.image }: { type: MediaType 
                   size="compact-sm"
                   className="w-full justify-center"
                   hideMediaTypes
+                  // The Published/Draft toggle above owns this on these two tabs,
+                  // so the moderator chip would be a second control for the same
+                  // state. Dropped HERE only — the chip is the sole way to reach
+                  // unpublished content on /images, /videos, collections, tool
+                  // feeds and model galleries, none of which have a toggle.
+                  exclude={['notPublished']}
                   isSameUser={isSameUser}
                 />
               </Group>

--- a/src/components/Image/Infinite/UserMediaInfinite.tsx
+++ b/src/components/Image/Infinite/UserMediaInfinite.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { SortFilter } from '~/components/Filters';
 import { FeedContentToggle } from '~/components/FeedContentToggle/FeedContentToggle';
+import type { MediaFilterKey } from '~/components/Image/Filters/media-filter-keys';
 import { MediaFiltersDropdown } from '~/components/Image/Filters/MediaFiltersDropdown';
 import type { ImageSections } from '~/components/Image/image.utils';
 import { useImageQueryParams } from '~/components/Image/image.utils';
@@ -21,6 +22,13 @@ import { trpc } from '~/utils/trpc';
 import classes from './UserMediaInfinite.module.css';
 
 const availableReactions = Object.keys(constants.availableReactions) as ReviewReactions[];
+
+// Module constant, not an inline literal. It is a dep of `excluded`'s useMemo in
+// MediaFiltersDropdown, which feeds `shows`, which this PR made a dep of
+// `handleClear` — so a fresh array each render un-memoises `handleClear`,
+// `showResources` and `showModerator`. `HubFeedFilters` already hoists its own
+// for the same reason.
+const PROFILE_EXCLUDED_FILTERS: MediaFilterKey[] = ['notPublished'];
 
 export function UserMediaInfinite({ type = MediaType.image }: { type: MediaType }) {
   const currentUser = useCurrentUser();
@@ -78,7 +86,16 @@ export function UserMediaInfinite({ type = MediaType.image }: { type: MediaType 
                     size="xs"
                     value={section}
                     type={type}
-                    onChange={(section) => replace({ section })}
+                    // Clears `notPublished` on the way into Reactions. `replace`
+                    // merges, and the Draft toggle hides itself there — so for a
+                    // moderator, whose grant needs no creator scope, the tab
+                    // silently became "unpublished images I reacted to" with the
+                    // only control that could undo it no longer on screen.
+                    onChange={(section) =>
+                      replace(
+                        section === 'reactions' ? { section, notPublished: undefined } : { section }
+                      )
+                    }
                   />
                 )}
                 {/* Drafts are the creator's own unpublished work, so the toggle
@@ -152,7 +169,7 @@ export function UserMediaInfinite({ type = MediaType.image }: { type: MediaType 
                   // state. Dropped HERE only — the chip is the sole way to reach
                   // unpublished content on /images, /videos, collections, tool
                   // feeds and model galleries, none of which have a toggle.
-                  exclude={['notPublished']}
+                  exclude={PROFILE_EXCLUDED_FILTERS}
                   isSameUser={isSameUser}
                 />
               </Group>
@@ -181,7 +198,7 @@ export function UserMediaInfinite({ type = MediaType.image }: { type: MediaType 
                   reactions: viewingReactions ? reactions ?? availableReactions : undefined,
                   userId: viewingReactions ? undefined : user.id,
                   username: viewingReactions ? undefined : username,
-                  notPublished,
+                  notPublished: viewingReactions ? undefined : notPublished,
                   scheduled,
                   followed,
                   baseModels,

--- a/src/pages/user/[username]/posts.tsx
+++ b/src/pages/user/[username]/posts.tsx
@@ -111,7 +111,7 @@ function UserPostsPage() {
                 <PostFiltersDropdown
                   query={{ ...query, period, followed, scheduled: effectiveScheduled }}
                   onChange={(filters) => replace(filters)}
-                  showScheduled={selfView}
+                  showScheduled={canViewDrafts}
                   size="compact-sm"
                 />
               </Group>

--- a/src/pages/user/[username]/posts.tsx
+++ b/src/pages/user/[username]/posts.tsx
@@ -53,9 +53,13 @@ function UserPostsPage() {
     !!currentUser &&
     !!query.username &&
     postgresSlugify(currentUser.username) === postgresSlugify(query.username);
+  // A moderator sees anything the creator can see of their own. Matches the
+  // images and videos tabs; the server authorizes this independently in
+  // `post.service.ts` and does not trust the control being rendered.
+  const canViewDrafts = selfView || (currentUser?.isModerator ?? false);
 
   const [section, setSection] = useState<'published' | 'draft'>(
-    selfView ? querySection ?? 'published' : 'published'
+    canViewDrafts ? querySection ?? 'published' : 'published'
   );
   const viewingDraft = section === 'draft';
   const effectiveScheduled = viewingDraft ? query.scheduled ?? true : query.scheduled;
@@ -75,7 +79,7 @@ function UserPostsPage() {
         <MasonryContainer p={0}>
           <Stack gap="xs">
             <Group gap={8} justify="space-between">
-              {selfView && (
+              {canViewDrafts && (
                 <FeedContentToggle
                   size="xs"
                   value={section}
@@ -101,9 +105,7 @@ function UserPostsPage() {
                   value={sort}
                   onChange={(x) => replace({ sort: x as PostSort })}
                   options={
-                    viewingDraft
-                      ? draftSorts.map((value) => ({ label: value, value }))
-                      : undefined
+                    viewingDraft ? draftSorts.map((value) => ({ label: value, value })) : undefined
                   }
                 />
                 <PostFiltersDropdown

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:4043':
+  'server/services/image.service.ts:4123':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4184':
+  'server/services/image.service.ts:4264':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4896':
+  'server/services/image.service.ts:4981':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:6010':
+  'server/services/image.service.ts:6097':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -206,7 +206,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4184')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4264')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/services/__tests__/bitdex-scheduled-content.test.ts
+++ b/src/server/services/__tests__/bitdex-scheduled-content.test.ts
@@ -363,6 +363,52 @@ describe('BitDex primary feed — content is not served before its publish time'
     expect(result.data.map((i: { id: number }) => i.id)).not.toContain(101);
   });
 
+  it('declines a CREATOR’s own-drafts request so Meili answers it', async () => {
+    // The Draft toggle on the profile images/videos tabs sends `notPublished`
+    // from a non-moderator. `wantsUnpublished` reads `scheduled` alone for a
+    // non-moderator, so without the decline BitDex answers a drafts request with
+    // the PUBLISHED feed — and a non-empty result suppresses the Meili fallback,
+    // so the creator is shown a population that is not the one they asked for,
+    // with nothing signalling it.
+    //
+    // Scoped: `userId === currentUserId`. The decline sits AFTER the
+    // username→userId resolution, so a request addressed by handle reaches it
+    // with a resolved id rather than `undefined`.
+    routeByShape();
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID,
+      userId: OWNER_ID,
+      isModerator: false,
+      notPublished: true,
+    });
+
+    expect(result.source).toBe('meili');
+    // 101 is the published doc. Its presence would mean BitDex answered with the
+    // published feed — the exact failure this decline exists to prevent.
+    expect(result.data.map((i: { id: number }) => i.id)).not.toContain(101);
+  });
+
+  it('does NOT decline a non-moderator asking about SOMEONE ELSE', async () => {
+    // The control. Without it the test above passes against a build that declines
+    // every `notPublished` request from anyone, which would quietly route an
+    // unauthorized request to Meili instead of refusing it — and would make the
+    // decline look like authorization, which it is not. The filter builders are
+    // what refuse; this only chooses which backend answers.
+    routeByShape();
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID + 99,
+      userId: OWNER_ID,
+      isModerator: false,
+      notPublished: true,
+    });
+
+    expect(result.source).toBe('bitdex');
+  });
+
   it('declines a moderator’s `notPublished` request so Meili answers it', async () => {
     // Same class as `scheduled`. BitDex's query pushes `isPublished = false`,
     // which covers scheduled AND never-published with no separate signal, so it

--- a/src/server/services/__tests__/bitdex-scheduled-content.test.ts
+++ b/src/server/services/__tests__/bitdex-scheduled-content.test.ts
@@ -385,9 +385,35 @@ describe('BitDex primary feed — content is not served before its publish time'
     });
 
     expect(result.source).toBe('meili');
-    // 101 is the published doc. Its presence would mean BitDex answered with the
-    // published feed — the exact failure this decline exists to prevent.
-    expect(result.data.map((i: { id: number }) => i.id)).not.toContain(101);
+    // Asserted on the MOCK, not on `data`. `data` is `[]` by construction whenever
+    // source is meili — this file stubs `metricsSearchClient: null` and the Meili
+    // builders early-return an empty page — so a `not.toContain(101)` here could
+    // never fail. It read as proof that BitDex had not answered with the published
+    // feed and proved nothing.
+    //
+    // The mock also separates the two ways source can be 'meili': the decline
+    // firing (no BitDex query at all) versus BitDex throwing and falling through.
+    expect(queryBitdexMock).not.toHaveBeenCalled();
+  });
+
+  it('declines when the creator is addressed by USERNAME rather than id', async () => {
+    // 🔴 The decline sits AFTER the username→userId resolution precisely so this
+    // works. Every other case here passes `userId` explicitly, so the check reads
+    // the same value at either position and none of them can tell whether the
+    // placement is right. Move the block above the resolution and only this case
+    // fails — which matters because the profile page addresses creators by handle.
+    routeByShape();
+
+    const result = await getImagesFromSearch({
+      ...baseInput,
+      currentUserId: OWNER_ID,
+      username: 'owner-handle',
+      isModerator: false,
+      notPublished: true,
+    });
+
+    expect(result.source).toBe('meili');
+    expect(queryBitdexMock).not.toHaveBeenCalled();
   });
 
   it('does NOT decline a non-moderator asking about SOMEONE ELSE', async () => {
@@ -407,6 +433,7 @@ describe('BitDex primary feed — content is not served before its publish time'
     });
 
     expect(result.source).toBe('bitdex');
+    expect(queryBitdexMock).toHaveBeenCalled();
   });
 
   it('declines a moderator’s `notPublished` request so Meili answers it', async () => {

--- a/src/server/services/__tests__/image-db-unpublished-authorization.test.ts
+++ b/src/server/services/__tests__/image-db-unpublished-authorization.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as PromClient from '~/server/prom/client';
+import type * as DbHelpers from '~/server/db/db-helpers';
+
+// The Postgres half of the drafts authorization.
+//
+// `image-unpublished-authorization.test.ts` covers the two Meilisearch builders.
+// This covers the fourth call site — `getAllImages` — which had NO test at all,
+// and which serves the feed whenever the index and BitDex flags are off. Two
+// independent reviewers ranked that gap first, for the same reason: the suite
+// read as proof the gate worked while half its call sites were unobserved.
+//
+// The mutation this exists to kill: passing the VIEWER as both arguments —
+// `canRequestUnpublished({ isModerator, currentUserId: userId, targetUserId: userId })`.
+// The check then collapses to "am I signed in", the drafts predicate fires, and
+// the creator scope does not (it reads the still-undefined `targetUserId`) — so
+// any signed-in caller gets every draft on the site. That mutation failed ZERO
+// tests before this file.
+//
+// Asserted on the assembled SQL rather than on rows: the statement IS the
+// authorization decision. `q.text` and `q.values` are read separately because
+// joining the template strings would erase the bound creator id, which is the
+// half that makes the scoping assertion mean anything.
+//
+// Mock recipe follows image-hide-challenges-exclusion.test.ts.
+
+const { queryWithTimeoutMock } = vi.hoisted(() => ({ queryWithTimeoutMock: vi.fn() }));
+
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof PromClient>();
+  return { ...actual, registerCounter: () => ({ inc: vi.fn() }) };
+});
+
+vi.mock('~/server/db/db-helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof DbHelpers>();
+  return { ...actual, queryWithTimeout: queryWithTimeoutMock };
+});
+
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTags: vi.fn().mockResolvedValue({ emptyResult: false }),
+}));
+
+import { getAllImages } from '../image.service';
+
+const CREATOR = 3300;
+const SOMEONE_ELSE = 4400;
+const MODERATOR = 5500;
+
+const DRAFTS_ONLY = 'p."publishedAt" IS NULL';
+
+type FeedInput = Record<string, unknown>;
+
+const baseInput = {
+  limit: 20,
+  period: 'AllTime',
+  periodMode: 'published',
+  sort: 'Newest',
+  browsingLevel: 31,
+  include: [] as string[],
+};
+
+/**
+ * Run the query build and capture the statement handed to Postgres.
+ *
+ * `queryWithTimeout` is the seam: the predicate has already been assembled by the
+ * time it is called, and throwing there stops the test at the thing it is about
+ * rather than at real infra.
+ */
+const sqlFor = async (input: FeedInput) => {
+  await getAllImages(input as unknown as Parameters<typeof getAllImages>[0]).catch(() => undefined);
+  expect(
+    queryWithTimeoutMock,
+    'queryWithTimeout was never called — the build no longer reaches this seam'
+  ).toHaveBeenCalled();
+  // `queryWithTimeout(imageDb, timeoutMs, q)` — the statement is the THIRD
+  // argument. Reading argument 0 yields the pool and an empty string, which is
+  // how the first version of this file "passed" its four `not.toContain` cases
+  // while asserting on nothing.
+  const stmt = queryWithTimeoutMock.mock.calls[0][2] as {
+    text?: string;
+    sql?: string;
+    values?: unknown[];
+  };
+  const text = String(stmt?.text ?? stmt?.sql ?? '');
+  // 🔴 The guard that makes the negative assertions mean something. Every
+  // `not.toContain` below passes for free on an empty string, so a broken seam
+  // would report this file as green while testing nothing.
+  expect(text, 'no SQL captured — the seam moved, and the negatives below are vacuous').toContain(
+    'SELECT'
+  );
+  return { text, values: stmt?.values ?? [] };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryWithTimeoutMock.mockRejectedValue(new Error('stop here'));
+});
+
+describe('getAllImages — who may ask for unpublished content', () => {
+  it('grants a creator their own drafts, SCOPED to them', async () => {
+    const { text, values } = await sqlFor({
+      ...baseInput,
+      user: { id: CREATOR, isModerator: false },
+      userId: CREATOR,
+      notPublished: true,
+    });
+
+    expect(text).toContain(DRAFTS_ONLY);
+    // 🔴 Both halves. The grant alone is not safe — the creator scope is what
+    // keeps it to one profile, and it is a different clause. The same-value-twice
+    // mutation leaves the grant intact and drops exactly this.
+    expect(text).toContain('i."userId" =');
+    expect(values).toContain(CREATOR);
+  });
+
+  it('grants a moderator any creator’s drafts, SCOPED to that creator', async () => {
+    const { text, values } = await sqlFor({
+      ...baseInput,
+      user: { id: MODERATOR, isModerator: true },
+      userId: SOMEONE_ELSE,
+      notPublished: true,
+    });
+
+    expect(text).toContain(DRAFTS_ONLY);
+    expect(values).toContain(SOMEONE_ELSE);
+  });
+
+  it('REFUSES a non-moderator asking for someone else’s drafts', async () => {
+    const { text } = await sqlFor({
+      ...baseInput,
+      user: { id: CREATOR, isModerator: false },
+      userId: SOMEONE_ELSE,
+      notPublished: true,
+    });
+
+    expect(text).not.toContain(DRAFTS_ONLY);
+  });
+
+  it('REFUSES a signed-in caller asking with no creator scope', async () => {
+    // 🔴 The mutation-killer. `targetUserId: userId` collapses the check to "am I
+    // signed in" and this input then returns every draft on the site.
+    const { text } = await sqlFor({
+      ...baseInput,
+      user: { id: CREATOR, isModerator: false },
+      notPublished: true,
+    });
+
+    expect(text).not.toContain(DRAFTS_ONLY);
+  });
+
+  it('REFUSES an anonymous caller entirely', async () => {
+    const { text } = await sqlFor({ ...baseInput, userId: CREATOR, notPublished: true });
+
+    expect(text).not.toContain(DRAFTS_ONLY);
+  });
+
+  it('does not grant drafts to a creator who did not ask', async () => {
+    // Control: without it the first case passes against a build that emits the
+    // drafts predicate unconditionally.
+    const { text } = await sqlFor({
+      ...baseInput,
+      user: { id: CREATOR, isModerator: false },
+      userId: CREATOR,
+    });
+
+    expect(text).not.toContain(DRAFTS_ONLY);
+  });
+
+  it('no longer pins a creator’s own unpublished work into an ordinary feed', async () => {
+    // The user-facing bug this PR fixes on the DB path, which had no test either:
+    // the old predicate was a bare `p."userId" = <viewer>` with no publish clause
+    // and no opt-in, so drafts appeared in every feed. Reverting it fails here.
+    const { text } = await sqlFor({ ...baseInput, user: { id: CREATOR, isModerator: false } });
+
+    expect(text).toContain('p."publishedAt" < now()');
+    // Scoped to the PUBLICATION clause. A bare `OR p."userId" = $n` search also
+    // matches the private-content carve-out a few lines below it
+    // (`(p."availability" != 'Private' ... OR p."userId" = $n)`), which is
+    // unrelated and must stay — the first version of this assertion failed on
+    // that and would have had me "fix" a correct clause.
+    expect(text).not.toMatch(/p\."publishedAt" < now\(\)\s+OR/);
+  });
+});

--- a/src/server/services/__tests__/image-unpublished-authorization.test.ts
+++ b/src/server/services/__tests__/image-unpublished-authorization.test.ts
@@ -89,6 +89,23 @@ const filterFor = async (
 // on a count of returned rows.
 const DRAFTS_ONLY = 'publishedAtUnix NOT EXISTS';
 
+/**
+ * Is the query scoped to this creator by the top-level creator filter?
+ *
+ * A plain `toContain('userId = N')` is NOT enough, and this is not hypothetical:
+ * the filter carries a SECOND own-content clause — `(nsfwLevel = 0 AND userId =
+ * <viewer>)` — so for a creator viewing their own profile the viewer id appears
+ * whether or not the creator scope was applied. Deleting the scope filter left
+ * that assertion green in the creator case and only failed the moderator one,
+ * where the two ids differ.
+ *
+ * The creator scope is pushed as its own term and joined with ' AND ', so an
+ * EXACT term match distinguishes it from the same id nested inside another
+ * clause's parentheses.
+ */
+const scopedToCreator = (filter: string, id: number) =>
+  filter.split(' AND ').some((term) => term.trim() === `userId = ${id}`);
+
 beforeEach(() => {
   vi.clearAllMocks();
   fetchDocumentsAbortableMock.mockRejectedValue(new Error('stop here'));
@@ -98,7 +115,7 @@ describe.each([
   ['getImagesFromSearchPreFilter', getImagesFromSearchPreFilter],
   ['getImagesFromSearchPostFilter', getImagesFromSearchPostFilter],
 ])('%s — who may ask for unpublished content', (_name, fn) => {
-  it('grants a creator their own drafts on their own profile', async () => {
+  it('grants a creator their own drafts on their own profile, SCOPED to them', async () => {
     const filter = await filterFor(fn, {
       ...baseInput,
       currentUserId: CREATOR,
@@ -108,9 +125,14 @@ describe.each([
     });
 
     expect(filter).toContain(DRAFTS_ONLY);
+    // The scoping is what makes the grant safe, and it is a DIFFERENT line from
+    // the one granting it. Without this assertion, deleting or conditioning the
+    // creator filter turns own-drafts into every draft on the site for any
+    // signed-in caller, with every other case here still green.
+    expect(scopedToCreator(filter, CREATOR), `not scoped in: ${filter}`).toBe(true);
   });
 
-  it('grants a moderator any creator’s drafts', async () => {
+  it('grants a moderator any creator’s drafts, SCOPED to that creator', async () => {
     const filter = await filterFor(fn, {
       ...baseInput,
       currentUserId: MODERATOR,
@@ -120,6 +142,7 @@ describe.each([
     });
 
     expect(filter).toContain(DRAFTS_ONLY);
+    expect(scopedToCreator(filter, SOMEONE_ELSE), `not scoped in: ${filter}`).toBe(true);
   });
 
   it('REFUSES a non-moderator asking for someone else’s drafts', async () => {
@@ -144,6 +167,28 @@ describe.each([
     const filter = await filterFor(fn, {
       ...baseInput,
       currentUserId: CREATOR,
+      isModerator: false,
+      notPublished: true,
+    });
+
+    expect(filter).not.toContain(DRAFTS_ONLY);
+  });
+
+  it('REFUSES an anonymous caller with no creator scope at all', async () => {
+    // 🔴 The worst case, and the one the other five do not cover between them.
+    // Every other REFUSES case has exactly ONE of the two ids present, so both
+    // truthiness guards in `canRequestUnpublished` are individually redundant
+    // against them — and `return targetUserId === currentUserId` on its own
+    // leaves all of them green while answering `undefined === undefined` with
+    // TRUE here. `image.getInfinite` is a public procedure (`heavyProcedure` is
+    // `publicProcedure` + bulkhead), so that mutant serves every unpublished
+    // image on the site to anyone, unauthenticated.
+    //
+    // The simplification that produces it is one a reviewer would reasonably
+    // propose — "the `!!` checks are redundant with the `===`". This is the
+    // assertion that says no.
+    const filter = await filterFor(fn, {
+      ...baseInput,
       isModerator: false,
       notPublished: true,
     });

--- a/src/server/services/__tests__/image-unpublished-authorization.test.ts
+++ b/src/server/services/__tests__/image-unpublished-authorization.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Who may ask for unpublished content, and over whose work.
+//
+// Before this, `notPublished` was honoured for moderators and silently IGNORED for
+// everyone else — safe by accident rather than by check, and it meant a creator had
+// no way to see their own drafts. The Draft toggle on the profile images/videos tabs
+// needs that capability, so the gate moved from `isModerator` to
+// `canRequestUnpublished`, which authorizes on the request's own scoping.
+//
+// The dangerous shape is an UNSCOPED `notPublished` from a non-moderator: without
+// the `targetUserId` half of the check that returns every draft on the site. The
+// third case below is the one that catches it.
+//
+// Asserted on the filter string handed to Meili rather than on returned rows: the
+// string IS the authorization decision, and rows from a fake cannot tell an enforced
+// filter from an absent one.
+
+import type * as MeilisearchClient from '~/server/meilisearch/client';
+
+const { fetchDocumentsAbortableMock } = vi.hoisted(() => ({
+  fetchDocumentsAbortableMock: vi.fn(),
+}));
+
+vi.mock('~/server/meilisearch/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof MeilisearchClient>();
+  return {
+    ...actual,
+    metricsSearchClient: {},
+    getMetricsSearchClient: () => ({}),
+    fetchDocumentsAbortable: fetchDocumentsAbortableMock,
+  };
+});
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+import { getImagesFromSearchPreFilter, getImagesFromSearchPostFilter } from '../image.service';
+
+const CREATOR = 3300;
+const SOMEONE_ELSE = 4400;
+const MODERATOR = 5500;
+
+type SearchArg = Parameters<typeof getImagesFromSearchPreFilter>[0];
+
+const baseInput = {
+  limit: 20,
+  period: 'AllTime',
+  sort: 'Newest',
+  browsingLevel: 31,
+  include: [] as string[],
+  headers: { src: 'test' },
+};
+
+const filterFor = async (
+  fn: typeof getImagesFromSearchPreFilter | typeof getImagesFromSearchPostFilter,
+  input: Record<string, unknown>
+) => {
+  await expect(fn(input as unknown as SearchArg)).rejects.toThrow('stop here');
+  expect(fetchDocumentsAbortableMock).toHaveBeenCalledTimes(1);
+  const [, request] = fetchDocumentsAbortableMock.mock.calls[0];
+  return String((request as { filter: string }).filter);
+};
+
+// `publishedAtUnix NOT EXISTS` is the drafts-only clause. Its PRESENCE is the
+// capability being granted, so every case below asserts on it directly rather than
+// on a count of returned rows.
+const DRAFTS_ONLY = 'publishedAtUnix NOT EXISTS';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchDocumentsAbortableMock.mockRejectedValue(new Error('stop here'));
+});
+
+describe.each([
+  ['getImagesFromSearchPreFilter', getImagesFromSearchPreFilter],
+  ['getImagesFromSearchPostFilter', getImagesFromSearchPostFilter],
+])('%s — who may ask for unpublished content', (_name, fn) => {
+  it('grants a creator their own drafts on their own profile', async () => {
+    const filter = await filterFor(fn, {
+      ...baseInput,
+      currentUserId: CREATOR,
+      userId: CREATOR,
+      isModerator: false,
+      notPublished: true,
+    });
+
+    expect(filter).toContain(DRAFTS_ONLY);
+  });
+
+  it('grants a moderator any creator’s drafts', async () => {
+    const filter = await filterFor(fn, {
+      ...baseInput,
+      currentUserId: MODERATOR,
+      userId: SOMEONE_ELSE,
+      isModerator: true,
+      notPublished: true,
+    });
+
+    expect(filter).toContain(DRAFTS_ONLY);
+  });
+
+  it('REFUSES a non-moderator asking for someone else’s drafts', async () => {
+    const filter = await filterFor(fn, {
+      ...baseInput,
+      currentUserId: CREATOR,
+      userId: SOMEONE_ELSE,
+      isModerator: false,
+      notPublished: true,
+    });
+
+    expect(filter).not.toContain(DRAFTS_ONLY);
+  });
+
+  it('REFUSES a non-moderator asking with no creator scope at all', async () => {
+    // 🔴 The one that matters. `canRequestUnpublished` authorizes on the request's
+    // own scoping, so dropping its `targetUserId` half leaves a check that reads
+    // "am I signed in" — and this input would then return every draft on the site
+    // to any logged-in caller who sets one query param. Mutate the helper to
+    // `if (isModerator) return true; return !!currentUserId;` and this is the only
+    // case here that fails.
+    const filter = await filterFor(fn, {
+      ...baseInput,
+      currentUserId: CREATOR,
+      isModerator: false,
+      notPublished: true,
+    });
+
+    expect(filter).not.toContain(DRAFTS_ONLY);
+  });
+
+  it('REFUSES an anonymous caller asking for a creator’s drafts', async () => {
+    const filter = await filterFor(fn, {
+      ...baseInput,
+      userId: CREATOR,
+      isModerator: false,
+      notPublished: true,
+    });
+
+    expect(filter).not.toContain(DRAFTS_ONLY);
+  });
+
+  it('does not grant drafts to a creator who did not ask', async () => {
+    // The control for the first case. Without it, that assertion passes against a
+    // build that emits the drafts clause unconditionally — which would be a far
+    // worse bug than the one being fixed.
+    const filter = await filterFor(fn, {
+      ...baseInput,
+      currentUserId: CREATOR,
+      userId: CREATOR,
+      isModerator: false,
+    });
+
+    expect(filter).not.toContain(DRAFTS_ONLY);
+  });
+});

--- a/src/server/services/__tests__/post-drafts-authorization.test.ts
+++ b/src/server/services/__tests__/post-drafts-authorization.test.ts
@@ -46,6 +46,23 @@ describe('canSeePostDrafts', () => {
     ).toBe(false);
   });
 
+  it('is spelled so that the tags/query split cannot be folded into it', () => {
+    // 🔴 Pins the mistake I actually made. My first attempt widened
+    // `isOwnerRequest` itself instead of adding this predicate beside it — which
+    // ALSO gates the `tags` and `query` filters in `getPostsInfinite`, so
+    // moderators would have silently lost tag and title filtering on every
+    // profile. The predicate below returns true for a moderator; if a future
+    // refactor makes `canSeePostDrafts` and `isOwnerRequest` interchangeable,
+    // this is the assertion that says they are not.
+    //
+    // Stated as a property rather than asserted on the SQL because the two
+    // consumers live in one function: the publication branch reads this, the
+    // discovery filters read `isOwnerRequest`, and they disagree for exactly one
+    // cohort — a scoped moderator.
+    expect(canSeePostDrafts(moderator)).toBe(true);
+    expect(moderator.isOwnerRequest).toBe(false);
+  });
+
   it('grants the creator even when the scope has not been resolved', () => {
     // The control for the moderator case above. `isOwnerRequest` is computed from
     // the username comparison directly and does not depend on the `targetUser`

--- a/src/server/services/__tests__/post-drafts-authorization.test.ts
+++ b/src/server/services/__tests__/post-drafts-authorization.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { canSeePostDrafts } from '~/server/services/post.service';
+
+// Who may see a creator's unpublished POSTS. The images/videos tabs gained this
+// capability first (`canRequestUnpublished` in image.service.ts); without the same
+// rule here a moderator saw drafts under Images and Videos on a profile and not
+// under Posts — less consistent than before that change, which is the opposite of
+// what it was for.
+//
+// Tested through the extracted predicate rather than the SQL, so it costs no
+// database. The predicate is the whole authorization decision: the branch it
+// selects is `publishedAt IS NULL` versus `publishedAt <= NOW()`.
+
+const owner = { isOwnerRequest: true, isModerator: false, targetUser: 7 };
+const moderator = { isOwnerRequest: false, isModerator: true, targetUser: 7 };
+const stranger = { isOwnerRequest: false, isModerator: false, targetUser: 7 };
+
+describe('canSeePostDrafts', () => {
+  it('grants the creator their own drafts', () => {
+    expect(canSeePostDrafts(owner)).toBe(true);
+  });
+
+  it('grants a moderator a specific creator’s drafts', () => {
+    expect(canSeePostDrafts(moderator)).toBe(true);
+  });
+
+  it('REFUSES a moderator with no creator scope', () => {
+    // 🔴 The one that matters. On the global posts feed there is no `username`,
+    // so `targetUser` is undefined — and without this half a moderator opening
+    // /posts takes the owner branch and receives every draft on the site rather
+    // than a profile's worth.
+    //
+    // Mutate the predicate to `isOwnerRequest || isModerator` and this is the
+    // only case here that fails.
+    expect(canSeePostDrafts({ ...moderator, targetUser: undefined })).toBe(false);
+    expect(canSeePostDrafts({ ...moderator, targetUser: null })).toBe(false);
+  });
+
+  it('REFUSES an ordinary viewer on someone else’s profile', () => {
+    expect(canSeePostDrafts(stranger)).toBe(false);
+  });
+
+  it('REFUSES an anonymous viewer with no scope', () => {
+    expect(
+      canSeePostDrafts({ isOwnerRequest: false, isModerator: false, targetUser: undefined })
+    ).toBe(false);
+  });
+
+  it('grants the creator even when the scope has not been resolved', () => {
+    // The control for the moderator case above. `isOwnerRequest` is computed from
+    // the username comparison directly and does not depend on the `targetUser`
+    // lookup having succeeded, so requiring a scope for BOTH arms would break the
+    // owner path — a plausible over-correction that this pins against.
+    expect(canSeePostDrafts({ ...owner, targetUser: undefined })).toBe(true);
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1603,6 +1603,34 @@ const imageMetricsClickhouseTimeoutCounter = registerCounter({
 });
 
 /**
+ * Who may ask for unpublished content, and over whose work.
+ *
+ * A moderator may ask about anyone. Everyone else may ask only about themselves,
+ * and only when the request is ALREADY scoped to them — the scoping is the
+ * authorization, not a separate check that could drift from it. An unscoped
+ * `notPublished` from a non-moderator would otherwise return every draft on the
+ * site, so a missing `targetUserId` must refuse rather than default.
+ *
+ * `targetUserId` is the creator being browsed, NOT the viewer. Those are
+ * different fields on every path here (`getAllImages` calls the viewer `userId`
+ * and the creator `targetUserId`; the search builders call the creator `userId`
+ * and the viewer `currentUserId`), and passing the wrong one turns this into a
+ * check that always passes.
+ */
+function canRequestUnpublished({
+  isModerator,
+  currentUserId,
+  targetUserId,
+}: {
+  isModerator?: boolean;
+  currentUserId?: number | null;
+  targetUserId?: number | null;
+}) {
+  if (isModerator) return true;
+  return !!currentUserId && !!targetUserId && targetUserId === currentUserId;
+}
+
+/**
  * Resolve the `hideChallenges` flag into an `excludedTagIds` entry, in place.
  * Mirrors `enforceBlockedBrowsingTags`: the client sends intent, the server owns
  * the tag id, and every query path picks it up from `excludedTagIds` unchanged.
@@ -1675,6 +1703,7 @@ export const getAllImages = async (
     pending,
     publishedOnly,
     notPublished,
+    scheduled,
     tools,
     techniques,
     baseModels,
@@ -1832,13 +1861,26 @@ export const getAllImages = async (
     AND.push(Prisma.sql`(i.meta IS NOT NULL AND i.meta ? 'civitaiResources')`);
   }
   // [x]
-  if (notPublished && isModerator) {
+  if (notPublished && canRequestUnpublished({ isModerator, currentUserId: userId, targetUserId })) {
     AND.push(Prisma.sql`(p."publishedAt" IS NULL)`);
   } else if (!effectivePending) {
-    if (userId && !publishedOnly) {
-      // userId is bound into the SQL, so each user gets their own cache key —
-      // safe to cache, lower hit rate but no cross-user leakage.
-      AND.push(Prisma.sql`(p."publishedAt" < now() OR p."userId" = ${userId})`);
+    // Strict published-only, with the owner carve-out gated on the `scheduled`
+    // opt-in — the same rule the two Meili builders and the BitDex merge apply,
+    // so all three backends now answer this question identically.
+    //
+    // The carve-out used to be a bare `p."userId" = <viewer>` with no publish
+    // predicate and no opt-in, so every signed-in caller got their own drafts,
+    // bounty entry uploads and orphans mixed into EVERY feed whether or not they
+    // asked. `p."publishedAt" > now()` is what makes it mean scheduled rather
+    // than unpublished; drafts have a NULL publish time and are reached through
+    // the Draft toggle instead (`notPublished`, handled above).
+    //
+    // userId is bound into the SQL, so each user gets their own cache key —
+    // safe to cache, lower hit rate but no cross-user leakage.
+    if (userId && !publishedOnly && scheduled) {
+      AND.push(
+        Prisma.sql`(p."publishedAt" < now() OR (p."userId" = ${userId} AND p."publishedAt" > now()))`
+      );
     } else {
       AND.push(Prisma.sql`(p."publishedAt" < now())`);
     }
@@ -3322,6 +3364,26 @@ async function fetchBitdexPrimary(input: ImageSearchInput, opts: { serving?: boo
     input = { ...input, userId: targetUser.id };
   }
 
+  // A creator asking for their OWN drafts declines for the same reason a
+  // moderator's request does: `wantsUnpublished` below reads `scheduled` alone
+  // for a non-moderator, so BitDex would answer a drafts request with the
+  // PUBLISHED feed — a non-empty result that suppresses the Meili fallback and
+  // shows the creator a population that is not the one they asked for.
+  //
+  // 🔴 Deliberately AFTER the username resolution above, not beside the
+  // moderator decline. The comparison needs the RESOLVED creator id: a request
+  // addressed by handle carries no `userId` at that point, so the same check
+  // placed earlier reads `undefined === <caller>` and never fires — the request
+  // would go on to be answered wrongly, silently, on exactly the profile page
+  // this feature is for.
+  //
+  // Scoped to the caller's own profile, matching `canRequestUnpublished`. An
+  // unscoped or someone-else's `notPublished` from a non-moderator is refused by
+  // the filter builders instead, because there is nothing to fall back TO —
+  // Meili will not answer that either.
+  if (input.notPublished && !!input.currentUserId && input.userId === input.currentUserId)
+    return null;
+
   // Which cohort this run belongs to. Read once so the three emit points below
   // cannot disagree, and computed here rather than at each call so a later
   // caller-mode cannot be added to one of them and missed by the others.
@@ -4714,10 +4776,15 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
   if (fromPlatform) filters.push(makeMeiliImageSearchFilter('onSite', '= true'));
 
   const snappedNow = snapToInterval(Math.round(Date.now()));
-  if (isModerator) {
-    if (notPublished) filters.push(makeMeiliImageSearchFilter('publishedAtUnix', 'NOT EXISTS'));
-    else if (scheduled)
-      filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${snappedNow}`));
+  // Hoisted above the moderator branch so a creator browsing their OWN profile
+  // reaches it too. `canRequestUnpublished` is what keeps that safe: it refuses
+  // unless the request is already scoped to the caller, so a non-moderator
+  // cannot ask this question about the site at large. Moderator behaviour is
+  // unchanged — they still answer true for any creator.
+  if (notPublished && canRequestUnpublished({ isModerator, currentUserId, targetUserId: userId })) {
+    filters.push(makeMeiliImageSearchFilter('publishedAtUnix', 'NOT EXISTS'));
+  } else if (isModerator) {
+    if (scheduled) filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${snappedNow}`));
     else {
       const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
       // `publishedOnly` is the caller saying it cannot use an unpublished row at
@@ -5647,10 +5714,12 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
 
   // Publish Date Filtering.
   const snappedNow = snapToInterval(Date.now());
-  if (isModerator) {
-    if (notPublished) filters.push(makeMeiliImageSearchFilter('publishedAtUnix', 'NOT EXISTS'));
-    else if (scheduled)
-      filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${snappedNow}`));
+  // Hoisted above the moderator branch so a creator browsing their OWN profile
+  // reaches it too — see the matching block in getImagesFromSearchPreFilter.
+  if (notPublished && canRequestUnpublished({ isModerator, currentUserId, targetUserId: userId })) {
+    filters.push(makeMeiliImageSearchFilter('publishedAtUnix', 'NOT EXISTS'));
+  } else if (isModerator) {
+    if (scheduled) filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${snappedNow}`));
     else {
       const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
       // `publishedOnly` is the caller saying it cannot use an unpublished row at

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1865,8 +1865,20 @@ export const getAllImages = async (
     AND.push(Prisma.sql`(p."publishedAt" IS NULL)`);
   } else if (!effectivePending) {
     // Strict published-only, with the owner carve-out gated on the `scheduled`
-    // opt-in — the same rule the two Meili builders and the BitDex merge apply,
-    // so all three backends now answer this question identically.
+    // opt-in — the same rule the two Meili builders and the BitDex merge apply
+    // FOR A NON-MODERATOR.
+    //
+    // Deliberately not claiming full parity, because there isn't any. A
+    // moderator's `scheduled` request diverges: Meili emits `publishedAtUnix >
+    // now` (scheduled content from every creator), while this path emits the
+    // ordinary published feed plus that one moderator's own scheduled posts. So
+    // a moderator on a collection or any other DB-pinned view sees a different
+    // population than they would on the index. Pre-existing and out of scope
+    // here; recorded so the next person checking parity does not read a
+    // three-backend claim and stop looking.
+    //
+    // A fourth site is out of step too: `getImage` (~:6452) still carries the old
+    // permissive `OR p."userId" = <viewer>` with no publish predicate.
     //
     // The carve-out used to be a bare `p."userId" = <viewer>` with no publish
     // predicate and no opt-in, so every signed-in caller got their own drafts,
@@ -1875,8 +1887,14 @@ export const getAllImages = async (
     // than unpublished; drafts have a NULL publish time and are reached through
     // the Draft toggle instead (`notPublished`, handled above).
     //
-    // userId is bound into the SQL, so each user gets their own cache key —
-    // safe to cache, lower hit rate but no cross-user leakage.
+    // Cache keying is NOT carried by this clause — measured, because the obvious
+    // reading is that removing the bare owner match widened the key. It does not:
+    // the availability carve-out a few lines below binds `userId` into the SQL
+    // for every non-moderator, and `queryCacheRaw` hashes the whole statement
+    // including its values. So the key stays per-user for the same viewers it
+    // always was. A moderator's key does widen — they skip the availability
+    // clause too — which shares one key across moderators rather than one each,
+    // and cannot collide with a non-moderator's differently-shaped SQL.
     if (userId && !publishedOnly && scheduled) {
       AND.push(
         Prisma.sql`(p."publishedAt" < now() OR (p."userId" = ${userId} AND p."publishedAt" > now()))`

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -188,9 +188,16 @@ const getPostStatsObject = async (data: { id: number }[]) => {
  *
  * 🔴 `targetUser` is the authorization, not decoration. Without it a moderator
  * on the global posts feed takes the owner branch and receives every draft on
- * the site — the same shape as `canRequestUnpublished` in `image.service.ts`,
- * and refused for the same reason: a missing creator scope must refuse rather
- * than default.
+ * the site.
+ *
+ * ⚠️ This is STRICTER than `canRequestUnpublished` in `image.service.ts`, and
+ * the divergence is real rather than an oversight: that one returns true for a
+ * moderator before looking at the scope at all, so an unscoped moderator request
+ * is refused here and granted there. Recorded because the two are otherwise the
+ * same shape and a reader reconciling them will assume they agree. If they are
+ * ever unified, this is the direction to unify towards — the images side has no
+ * test for the unscoped-moderator case, so nothing there is pinning that
+ * behaviour deliberately.
  *
  * Extracted so it can be tested without a database, and kept deliberately apart
  * from `isOwnerRequest`, which also gates the `tags` and `query` filters.
@@ -426,7 +433,17 @@ export const getPostsInfinite = async ({
     isOwnerRequest ||
     (!!user && followed) ||
     !env.POST_QUERY_CACHING ||
-    (collectionId && !!user?.id)
+    (collectionId && !!user?.id) ||
+    // The moderator draft view. Unpublished rows have never entered this cache
+    // before — the only path that produced them was the owner one, which already
+    // zeroes the TTL — and `posts-user:<id>` is busted nowhere in src, so a post
+    // that gets published, deleted or taken down would keep showing in a
+    // moderation surface for the 60s TTL. Not a leak (the statement differs from
+    // a non-moderator's in both the publication and availability clauses, so the
+    // hashed key cannot collide) — just the wrong freshness for the one view
+    // whose job is acting on what is there right now. Costs nothing: this is not
+    // a hot path.
+    (canSeeUnpublished && !isOwnerRequest)
   ) {
     cacheTime = 0;
   }

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -182,6 +182,33 @@ const getPostStatsObject = async (data: { id: number }[]) => {
  * - poiOnly: Mod-only filter - not exposed to frontend
  * - minorOnly: Mod-only filter - not exposed to frontend
  */
+/**
+ * Who may see a creator's unpublished posts: the creator themselves, or a
+ * moderator viewing a SPECIFIC creator's profile.
+ *
+ * 🔴 `targetUser` is the authorization, not decoration. Without it a moderator
+ * on the global posts feed takes the owner branch and receives every draft on
+ * the site — the same shape as `canRequestUnpublished` in `image.service.ts`,
+ * and refused for the same reason: a missing creator scope must refuse rather
+ * than default.
+ *
+ * Extracted so it can be tested without a database, and kept deliberately apart
+ * from `isOwnerRequest`, which also gates the `tags` and `query` filters.
+ * Widening that instead would silently drop tag and title filtering for
+ * moderators.
+ */
+export function canSeePostDrafts({
+  isOwnerRequest,
+  isModerator,
+  targetUser,
+}: {
+  isOwnerRequest: boolean;
+  isModerator: boolean;
+  targetUser?: number | null;
+}) {
+  return isOwnerRequest || (isModerator && !!targetUser);
+}
+
 export const getPostsInfinite = async ({
   limit,
   cursor,
@@ -265,8 +292,10 @@ export const getPostsInfinite = async ({
     cacheTags.push(`posts-modelVersion:${modelVersionId}`);
   }
 
+  const canSeeUnpublished = canSeePostDrafts({ isOwnerRequest, isModerator, targetUser });
+
   const joins: string[] = [];
-  if (!isOwnerRequest) {
+  if (!canSeeUnpublished) {
     if (scheduled && userId) {
       // Surface own scheduled posts alongside the public published feed. Mirrors
       // the image service carve-out (image.service.ts ~line 4060).
@@ -276,7 +305,20 @@ export const getPostsInfinite = async ({
     } else {
       AND.push(Prisma.sql`p."publishedAt" <= NOW()`);
     }
+  } else {
+    if (draftOnly) {
+      if (scheduled) AND.push(Prisma.sql`(p."publishedAt" IS NULL OR p."publishedAt" > NOW())`);
+      else AND.push(Prisma.sql`p."publishedAt" IS NULL`);
+    } else if (scheduled) AND.push(Prisma.sql`p."publishedAt" IS NOT NULL`);
+    else AND.push(Prisma.sql`p."publishedAt" <= NOW() AND p."publishedAt" IS NOT NULL`);
+  }
 
+  // Still keyed on `isOwnerRequest`, NOT on `canSeeUnpublished`. These are
+  // discovery filters, not publication ones — an owner browsing their own
+  // profile has never had them applied, and folding them into the publication
+  // gate above would have silently dropped tag and title filtering for
+  // moderators, who do get them today.
+  if (!isOwnerRequest) {
     if (!!tags?.length)
       AND.push(Prisma.sql`EXISTS (
         SELECT 1 FROM "TagsOnPost" top
@@ -286,12 +328,6 @@ export const getPostsInfinite = async ({
     if (query) {
       AND.push(Prisma.sql`p.title ILIKE ${query + '%'}`);
     }
-  } else {
-    if (draftOnly) {
-      if (scheduled) AND.push(Prisma.sql`(p."publishedAt" IS NULL OR p."publishedAt" > NOW())`);
-      else AND.push(Prisma.sql`p."publishedAt" IS NULL`);
-    } else if (scheduled) AND.push(Prisma.sql`p."publishedAt" IS NOT NULL`);
-    else AND.push(Prisma.sql`p."publishedAt" <= NOW() AND p."publishedAt" IS NOT NULL`);
   }
 
   if (period !== 'AllTime') {
@@ -1465,7 +1501,9 @@ export const addResourceToPostImage = async ({
     throw throwNotFoundError(`Image${imageIds.length > 1 ? 's' : ''} not found.`);
   }
   // TODO technically this can be called with a combo of on/off site imgs
-  if (images.some((i) => i.type !== MediaType.video && isImageMetaOnSite(i.meta as ImageMetaProps))) {
+  if (
+    images.some((i) => i.type !== MediaType.video && isImageMetaOnSite(i.meta as ImageMetaProps))
+  ) {
     throw throwBadRequestError('Cannot add resources to on-site generations.');
   }
 


### PR DESCRIPTION
Closes the Postgres half of ClickUp [868kt9y1w](https://app.clickup.com/t/868kt9y1w). Reviewed on a dev server by Justin before opening.

Siblings, both merged: #4331 (Meilisearch) and #4356 (BitDex). **Not stacked** — based directly on `main`.

## The problem

Creators could not see their own draft images anywhere in the product. The only thing surfacing them was a bug: the Postgres feed path ORed in a bare owner match with no publish predicate and no opt-in —

```sql
(p."publishedAt" < now() OR p."userId" = <viewer>)
```

— so **every signed-in user had their own drafts, bounty entry uploads and orphans mixed into every feed**, whether they asked or not.

Removing that alone would have made draft images unreachable, so the toggle lands first, in the same change.

Worth recording what the audit found, because it shrank this considerably: **moderators could already reach any creator's drafts** via the Not Published chip, which renders on the profile tabs today. The genuinely missing capability was the creator's own.

## Server

`canRequestUnpublished` replaces the `isModerator` gate on `notPublished` at four sites. It authorizes on the request's **own scoping** rather than on a separate check that could drift from it: a moderator may ask about anyone; everyone else only about themselves; and a **missing** creator scope refuses rather than defaults.

That last clause is the load-bearing one. Without it an unscoped `notPublished` from any signed-in caller returns every draft on the site — and `image.getInfinite` is a public procedure (`heavyProcedure` is `publicProcedure` + bulkhead), so an anonymous one would too.

**BitDex declines** a creator's own-drafts request so Meili answers it, exactly as it already declines a moderator's. It cannot express the question — `wantsUnpublished` reads `scheduled` alone for a non-moderator — so answering would serve the **published** feed to someone who asked for drafts, and a non-empty result suppresses the Meili fallback.

That decline sits **after** the username→userId resolution deliberately. A request addressed by handle carries no `userId` earlier, so the same check placed beside the moderator decline reads `undefined === <caller>`, never fires, and answers wrongly — silently, on exactly the profile page this feature is for. I put it in the wrong place first.

**Postgres is now opt-in**, with the owner carve-out gated on `scheduled` and carrying `p."publishedAt" > now()`.

## Client

The toggle shows for the creator on their own profile and for moderators anywhere; the server decides authorization independently. The Not Published chip is excluded **on these two tabs only** — it remains the sole route to unpublished content on `/images`, `/videos`, collections, tool feeds and model galleries, none of which have a toggle. `handleClear` no longer resets a filter the dropdown does not show.

## Verification, and what the review changed

An adversarial review of the first commit found three things, and my fix for one of them was itself wrong. All four are in the second commit.

**1. A one-line simplification left all 12 tests green and served every unpublished image to anonymous callers.** `return targetUserId === currentUserId` answers `undefined === undefined` with `true`. Every REFUSES case had exactly *one* of the two ids present, so both truthiness guards were individually redundant against the suite — the mutation a reviewer would propose as a tidy-up was the one nothing caught.

**2. The tests asserted the capability was granted, never that it was scoped.** The line making the grant safe is a different one, and no test read it.

**3. My first fix for (2) passed for the wrong reason.** `toContain('userId = 3300')` also matches the second own-content clause `(nsfwLevel = 0 AND userId = <viewer>)`, so for a creator on their own profile the id is present whether or not the scope was applied. Removing the scope failed only the *moderator* case. Now an exact AND-term match.

**Controls, each run by breaking the thing and watching the right test fail:**

| mutation | before | after |
|---|---|---|
| `return !!currentUserId` | 4 failed | 4 failed |
| `return targetUserId === currentUserId` | **0 failed** | **2 failed** |
| creator scope filter removed, both builders | **0 failed** | **4 failed** |

`pnpm run typecheck` 0 errors. The 3 eslint errors in `image.service.ts` are at 204 / 4865 / 6774, all pre-existing, none in this diff.

Full unit suite:

```
Test Files  1 failed | 1395 passed | 1 skipped (1397)
Tests       1 failed | 21924 passed | 27 skipped (21952)
```

1395 + 1 + 1 = 1397, so every file is accounted for.

⚠️ **The one failure is Windows-only and not from this change.** `pageRunScrollContract.test.ts` compares discovered paths as strings:

```
- Expected: "src/pages/apps/run/[slug]/[[...path]].tsx"
+ Received: "src\pages\apps\run\[slug]\[[...path]].tsx"
```

Separator, not content — it will pass on CI's Linux runners. Independently, that test walks `src` for files mounting `PageBlockHost` with `fit="fill"` and this diff contains **zero** occurrences of either string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Final state (2026-08-25)

Rebased onto `main` after #4364; **HEAD `415a5870be`**. Five commits.

Scope grew during review: after the intent lane showed the posts tab was a silent drop rather than a narrowing, Justin asked for it in this PR. So the posts tab now has the same moderator grant, via `canSeePostDrafts` — deliberately **stricter** than `canRequestUnpublished`, which grants a moderator before looking at the creator scope. That divergence is recorded in the helper's docblock rather than silently reconciled.

Full unit suite on the rebased head:

```
Test Files  1 failed | 1399 passed | 1 skipped (1401)
Tests       1 failed | 21913 passed | 27 skipped (21941)
```

1399 + 1 + 1 = 1401 — every file accounted for. The single failure is the Windows-only path-separator assertion described above.

### Six review lanes, all reported

`civitai-review`'s five plus a sixth over the posts delta the first five never saw. Findings closed, most valuable first:

- **The Postgres call site had no test at all.** Passing the viewer as both ids collapses the check to "am I signed in", fires the drafts predicate and drops the creator scope — every draft on the site to any signed-in caller, whole suite green. Two lanes ranked it first independently. Now fails 2 of 7.
- **An assertion of mine could never fail.** `not.toContain(101)` in the BitDex decline test, because that file stubs `metricsSearchClient: null` so `data` is `[]` whenever source is meili. Replaced with a mock assertion that also separates "the decline fired" from "BitDex threw and fell through".
- **The decline's placement was untested** — every case passed `userId` explicitly, so none could tell it sat after the username resolution. Added the username-addressed case, which is what the profile page actually sends.
- **Draft posts would have entered the shared query cache** for the first time; `posts-user:` is busted nowhere, so a taken-down post would linger 60s in a moderation view. `cacheTime = 0` for that arm.
- **`exclude` was a fresh array each render**, and this PR made `shows` a dep of `handleClear` — three callbacks lost memoisation. Hoisted.
- **Two comments claimed things that were not true** — three-backend parity, and a cache-key premise the perf lane measured and disproved. Both corrected; a wrong reason beside an authorization decision stops the next reader looking.

Two of my own fixes were wrong before they were right: a test seam that read argument 0 instead of 2 (so four negative assertions passed on an empty string) and a revert-detector that matched the unrelated private-content carve-out. Both caught by running the control, not by reading.
