### PR TITLE
fix(sticker-book): cap the grid at 7 columns, centre it, and fill the rows

### DIFF
--- a/src/components/StickerBook/StickerBookGrid.tsx
+++ b/src/components/StickerBook/StickerBookGrid.tsx
@@ -7,6 +7,7 @@ import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApp
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
 import type { StickerBookSide } from '~/components/StickerBook/sticker-book.util';
+import { STICKER_BOOK_MAX_COLUMNS } from '~/shared/utils/sticker-book';
 import type { RouterOutput } from '~/types/router';
 
 type BookItems = RouterOutput['stickerBook']['get']['placed'];
@@ -22,6 +23,15 @@ type BookItems = RouterOutput['stickerBook']['get']['placed'];
  */
 const CARD_WIDTH = 280;
 const CARD_HEIGHT = Math.round((CARD_WIDTH * 9) / 7);
+const GRID_GAP = 12;
+
+/**
+ * Centred and capped, because uncapped `auto-fill` was the one grid on the
+ * profile that kept adding columns to the edge of the window — every other one
+ * goes through `MasonryContainer`, which stops at seven and centres itself.
+ */
+export const STICKER_BOOK_MAX_WIDTH =
+  STICKER_BOOK_MAX_COLUMNS * CARD_WIDTH + (STICKER_BOOK_MAX_COLUMNS - 1) * GRID_GAP;
 
 /**
  * The images in one section, drawn with the standard feed card.
@@ -79,8 +89,8 @@ export function StickerBookGrid({
     // control.
     <ImagesProvider images={visible} hideStickerBadge revealStickers>
       <div
-        className="grid items-start gap-3"
-        style={{ gridTemplateColumns: `repeat(auto-fill, ${CARD_WIDTH}px)` }}
+        className="grid items-start"
+        style={{ gridTemplateColumns: `repeat(auto-fill, ${CARD_WIDTH}px)`, gap: GRID_GAP }}
       >
         {shown.map((item) => (
           <div key={item.imageId} className="relative">

--- a/src/components/StickerBook/StickerBookGrid.tsx
+++ b/src/components/StickerBook/StickerBookGrid.tsx
@@ -4,10 +4,11 @@ import { useMemo } from 'react';
 import { ImagesCard } from '~/components/Image/Infinite/ImagesCard';
 import { ImagesProvider } from '~/components/Image/Providers/ImagesProvider';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { useMasonryContext } from '~/components/MasonryColumns/MasonryProvider';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
 import type { StickerBookSide } from '~/components/StickerBook/sticker-book.util';
-import { STICKER_BOOK_MAX_COLUMNS } from '~/shared/utils/sticker-book';
+import { constants } from '~/server/common/constants';
 import type { RouterOutput } from '~/types/router';
 
 type BookItems = RouterOutput['stickerBook']['get']['placed'];
@@ -21,17 +22,23 @@ type BookItems = RouterOutput['stickerBook']['get']['placed'];
  * The height is that width at the 7:9 the profile sections use, so the grid
  * keeps its rhythm whatever each picture's own aspect is.
  */
-const CARD_WIDTH = 280;
-const CARD_HEIGHT = Math.round((CARD_WIDTH * 9) / 7);
-const GRID_GAP = 12;
-
 /**
- * Centred and capped, because uncapped `auto-fill` was the one grid on the
- * profile that kept adding columns to the edge of the window — every other one
- * goes through `MasonryContainer`, which stops at seven and centres itself.
+ * 🔴 320 and 16 are NOT free numbers — they are what makes `MasonryContainer`
+ * usable here.
+ *
+ * That component snaps its width to an exact column multiple and centres it, and
+ * it computes those steps in SCSS from hard-coded `$width: 320; $gap: 16`. There
+ * is no prop path. At any other pair its container is the wrong size — at 280 it
+ * leaves room for an eighth card, defeating the seven-column ceiling. Change
+ * either number and the grid silently stops lining up with its own container.
+ *
+ * (It also sidesteps a bug rather than tripping it: `MasonryProvider` shadows
+ * its own `gap` prop with a local `const gap = 16` when computing column count.
+ * At 16 the shadow is a no-op.)
  */
-export const STICKER_BOOK_MAX_WIDTH =
-  STICKER_BOOK_MAX_COLUMNS * CARD_WIDTH + (STICKER_BOOK_MAX_COLUMNS - 1) * GRID_GAP;
+const CARD_WIDTH = constants.cardSizes.image;
+const CARD_HEIGHT = Math.round((CARD_WIDTH * 9) / 7);
+const GRID_GAP = 16;
 
 /**
  * The images in one section, drawn with the standard feed card.
@@ -50,6 +57,7 @@ export function StickerBookGrid({
   items,
   side,
   emptyMessage,
+  wholeRowsOnly,
 }: {
   items: BookItems;
   side: StickerBookSide;
@@ -60,15 +68,36 @@ export function StickerBookGrid({
    * blank space.
    */
   emptyMessage?: string;
+  /**
+   * Draw only COMPLETE rows — the tab's preview, where a part-filled last row is
+   * the reported defect ("what's the two blank image spots for?").
+   *
+   * 🔴 Trimming here rather than on the server is the only place it can be
+   * correct: the column count is a property of the viewport, and the viewer's
+   * own hides drop rows AFTER the server has counted. A fetch size cannot know
+   * either. The remainder is not lost — "View all" is the whole section.
+   *
+   * Off for the drill-in page, which is the full list and must not hide its tail.
+   */
+  wholeRowsOnly?: boolean;
 }) {
   const images = useMemo(() => items.map((item) => item.image), [items]);
   // The viewer's own hides, the same way every other grid applies them. Blocks
   // are enforced on the server; hides are a preference and live here.
   const { items: visible } = useApplyHiddenPreferences({ type: 'images', data: images });
-  const shown = useMemo(() => {
+  const survived = useMemo(() => {
     const ids = new Set(visible.map((image) => image.id));
     return items.filter((item) => ids.has(item.imageId));
   }, [items, visible]);
+
+  // From the same container that lays the grid out, so the two cannot disagree.
+  const { columnCount } = useMasonryContext();
+  const shown = useMemo(() => {
+    // `columnCount` is 0 until the container has measured, and a partial row is
+    // better than an empty section while that resolves.
+    if (!wholeRowsOnly || !columnCount || survived.length < columnCount) return survived;
+    return survived.slice(0, Math.floor(survived.length / columnCount) * columnCount);
+  }, [survived, columnCount, wholeRowsOnly]);
 
   if (!shown.length)
     return (
@@ -82,8 +111,8 @@ export function StickerBookGrid({
     );
 
   return (
-    // 🔴 `hideStickerBadge`: the chip shares the reaction row, and at a 280px
-    // card it squeezes the reaction counts until they clip. This page is about
+    // 🔴 `hideStickerBadge`: the chip shares the reaction row and squeezes the
+    // reaction counts until they clip. This page is about
     // stickers, so the count it was carrying says nothing new here — and
     // `revealStickers` is what draws them, so removing the chip removes no
     // control.

--- a/src/components/StickerBook/StickerBookGrid.tsx
+++ b/src/components/StickerBook/StickerBookGrid.tsx
@@ -8,6 +8,7 @@ import { useMasonryContext } from '~/components/MasonryColumns/MasonryProvider';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
 import type { StickerBookSide } from '~/components/StickerBook/sticker-book.util';
+import { wholeRows } from '~/components/StickerBook/sticker-book.util';
 import { constants } from '~/server/common/constants';
 import type { RouterOutput } from '~/types/router';
 
@@ -21,8 +22,7 @@ type BookItems = RouterOutput['stickerBook']['get']['placed'];
  *
  * The height is that width at the 7:9 the profile sections use, so the grid
  * keeps its rhythm whatever each picture's own aspect is.
- */
-/**
+ *
  * 🔴 320 and 16 are NOT free numbers — they are what makes `MasonryContainer`
  * usable here.
  *
@@ -92,12 +92,10 @@ export function StickerBookGrid({
 
   // From the same container that lays the grid out, so the two cannot disagree.
   const { columnCount } = useMasonryContext();
-  const shown = useMemo(() => {
-    // `columnCount` is 0 until the container has measured, and a partial row is
-    // better than an empty section while that resolves.
-    if (!wholeRowsOnly || !columnCount || survived.length < columnCount) return survived;
-    return survived.slice(0, Math.floor(survived.length / columnCount) * columnCount);
-  }, [survived, columnCount, wholeRowsOnly]);
+  const shown = useMemo(
+    () => (wholeRowsOnly ? wholeRows(survived, columnCount) : survived),
+    [survived, columnCount, wholeRowsOnly]
+  );
 
   if (!shown.length)
     return (
@@ -116,6 +114,10 @@ export function StickerBookGrid({
     // stickers, so the count it was carrying says nothing new here — and
     // `revealStickers` is what draws them, so removing the chip removes no
     // control.
+    // `visible`, not `shown`: the card dialog's gallery is the SECTION, and the
+    // whole-rows trim is a layout tidy rather than a visibility decision — an
+    // image it left off the last row is one this viewer may see, so paging into
+    // it is correct. Withheld and hidden images are already gone from `visible`.
     <ImagesProvider images={visible} hideStickerBadge revealStickers>
       <div
         className="grid items-start"

--- a/src/components/StickerBook/StickerBookSection.tsx
+++ b/src/components/StickerBook/StickerBookSection.tsx
@@ -1,9 +1,9 @@
 import { Button, Group, Text, ThemeIcon, Title } from '@mantine/core';
 import { IconArrowRight } from '@tabler/icons-react';
-import clsx from 'clsx';
 import type { ReactNode } from 'react';
+import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
-import { StickerBookGrid, STICKER_BOOK_MAX_WIDTH } from '~/components/StickerBook/StickerBookGrid';
+import { StickerBookGrid } from '~/components/StickerBook/StickerBookGrid';
 import type { StickerBookSide } from '~/components/StickerBook/sticker-book.util';
 import type { RouterOutput } from '~/types/router';
 
@@ -16,30 +16,11 @@ type BookItems = RouterOutput['stickerBook']['get']['placed'];
  * profile overview reads that way and this tab sits beside it — Justin's call on
  * review. The negative margin lets the band's colour reach the container's edges
  * while the content stays on the page's own gutter.
- */
-/**
- * The grid's own ceiling, centred — what `MasonryContainer` does for every other
- * grid on the site.
  *
- * On the band it wraps the heading and the cards TOGETHER, so a shaded band's
- * colour still reaches the window's edges while its content lines up with the
- * cards. Wrapping only the grid would leave the heading and its "View all"
- * hanging off to the left of what they label on a wide monitor.
+ * `MasonryContainer` wraps the heading and the cards TOGETHER: it snaps to an
+ * exact column multiple and centres, so wrapping only the grid would leave the
+ * heading and its "View all" hanging to the left of what they label.
  */
-export function StickerBookWidth({
-  children,
-  className,
-}: {
-  children: ReactNode;
-  className?: string;
-}) {
-  return (
-    <div className={clsx('mx-auto w-full', className)} style={{ maxWidth: STICKER_BOOK_MAX_WIDTH }}>
-      {children}
-    </div>
-  );
-}
-
 export function StickerBookBand({
   title,
   icon,
@@ -56,7 +37,7 @@ export function StickerBookBand({
 }) {
   return (
     <section className={`-mx-3 px-3 py-6 ${shaded ? 'bg-gray-1 dark:bg-dark-8' : ''}`.trim()}>
-      <StickerBookWidth>
+      <MasonryContainer p={0}>
         <Group justify="space-between" align="center" mb="md" wrap="nowrap">
           <Group gap="sm" wrap="nowrap" className="min-w-0">
             <ThemeIcon size="xl" color="dark" variant="default">
@@ -69,7 +50,7 @@ export function StickerBookBand({
           {action}
         </Group>
         {children}
-      </StickerBookWidth>
+      </MasonryContainer>
     </section>
   );
 }
@@ -115,7 +96,7 @@ export function StickerBookSection({
       }
     >
       {items.length ? (
-        <StickerBookGrid items={items} side={side} emptyMessage={emptyMessage} />
+        <StickerBookGrid items={items} side={side} emptyMessage={emptyMessage} wholeRowsOnly />
       ) : (
         <Text size="sm" c="dimmed">
           {emptyMessage}

--- a/src/components/StickerBook/StickerBookSection.tsx
+++ b/src/components/StickerBook/StickerBookSection.tsx
@@ -1,8 +1,9 @@
 import { Button, Group, Text, ThemeIcon, Title } from '@mantine/core';
 import { IconArrowRight } from '@tabler/icons-react';
+import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
-import { StickerBookGrid } from '~/components/StickerBook/StickerBookGrid';
+import { StickerBookGrid, STICKER_BOOK_MAX_WIDTH } from '~/components/StickerBook/StickerBookGrid';
 import type { StickerBookSide } from '~/components/StickerBook/sticker-book.util';
 import type { RouterOutput } from '~/types/router';
 
@@ -16,6 +17,29 @@ type BookItems = RouterOutput['stickerBook']['get']['placed'];
  * review. The negative margin lets the band's colour reach the container's edges
  * while the content stays on the page's own gutter.
  */
+/**
+ * The grid's own ceiling, centred — what `MasonryContainer` does for every other
+ * grid on the site.
+ *
+ * On the band it wraps the heading and the cards TOGETHER, so a shaded band's
+ * colour still reaches the window's edges while its content lines up with the
+ * cards. Wrapping only the grid would leave the heading and its "View all"
+ * hanging off to the left of what they label on a wide monitor.
+ */
+export function StickerBookWidth({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={clsx('mx-auto w-full', className)} style={{ maxWidth: STICKER_BOOK_MAX_WIDTH }}>
+      {children}
+    </div>
+  );
+}
+
 export function StickerBookBand({
   title,
   icon,
@@ -32,18 +56,20 @@ export function StickerBookBand({
 }) {
   return (
     <section className={`-mx-3 px-3 py-6 ${shaded ? 'bg-gray-1 dark:bg-dark-8' : ''}`.trim()}>
-      <Group justify="space-between" align="center" mb="md" wrap="nowrap">
-        <Group gap="sm" wrap="nowrap" className="min-w-0">
-          <ThemeIcon size="xl" color="dark" variant="default">
-            {icon}
-          </ThemeIcon>
-          <Title order={3} className="truncate">
-            {title}
-          </Title>
+      <StickerBookWidth>
+        <Group justify="space-between" align="center" mb="md" wrap="nowrap">
+          <Group gap="sm" wrap="nowrap" className="min-w-0">
+            <ThemeIcon size="xl" color="dark" variant="default">
+              {icon}
+            </ThemeIcon>
+            <Title order={3} className="truncate">
+              {title}
+            </Title>
+          </Group>
+          {action}
         </Group>
-        {action}
-      </Group>
-      {children}
+        {children}
+      </StickerBookWidth>
     </section>
   );
 }

--- a/src/components/StickerBook/StickerBookSectionPage.tsx
+++ b/src/components/StickerBook/StickerBookSectionPage.tsx
@@ -2,8 +2,11 @@ import { Alert, Button, Group, Loader, Text, Title } from '@mantine/core';
 import { BackButton } from '~/components/BackButton/BackButton';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { useState } from 'react';
+import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
+import { MasonryProvider } from '~/components/MasonryColumns/MasonryProvider';
 import { StickerBookGrid } from '~/components/StickerBook/StickerBookGrid';
-import { StickerBookWidth } from '~/components/StickerBook/StickerBookSection';
+import { constants } from '~/server/common/constants';
+import { STICKER_BOOK_MAX_COLUMNS } from '~/shared/utils/sticker-book';
 import type { StickerBookSide } from '~/components/StickerBook/sticker-book.util';
 import { stickerBookSectionCopy } from '~/components/StickerBook/sticker-book.util';
 import { trpc } from '~/utils/trpc';
@@ -58,52 +61,61 @@ export function StickerBookSectionPage({
   const copy = stickerBookSectionCopy(side, { username, isOwner: data.isOwner });
 
   return (
-    <StickerBookWidth className="flex flex-col gap-4">
-      {/* The shared back button rather than a link with an arrow glyph in it:
+    // Its own provider: this is a separate route, not rendered inside the tab.
+    <MasonryProvider
+      columnWidth={constants.cardSizes.image}
+      maxColumnCount={STICKER_BOOK_MAX_COLUMNS}
+      maxSingleColumnWidth={450}
+    >
+      <MasonryContainer p={0}>
+        <div className="flex flex-col gap-4">
+          {/* The shared back button rather than a link with an arrow glyph in it:
           it also goes back through history when there is history, so arriving
           from the tab returns to the scroll position it was left at. */}
-      <div>
-        <BackButton url={`/user/${username}/sticker-book`}>
-          <Text size="sm">Back to the sticker book</Text>
-        </BackButton>
-        <Title order={2} mt={4}>
-          {copy.title}
-        </Title>
-      </div>
+          <div>
+            <BackButton url={`/user/${username}/sticker-book`}>
+              <Text size="sm">Back to the sticker book</Text>
+            </BackButton>
+            <Title order={2} mt={4}>
+              {copy.title}
+            </Title>
+          </div>
 
-      <StickerBookGrid items={data.items} side={side} emptyMessage={copy.empty} />
+          <StickerBookGrid items={data.items} side={side} emptyMessage={copy.empty} />
 
-      {/* Two different empty states, because `hasMore` is decided before the
+          {/* Two different empty states, because `hasMore` is decided before the
           image filter runs: page 3 of a walk whose images were all unpublished
           is legitimately empty with a working Next button, and the
           nothing-here-yet copy would tell a creator with hundreds that they have
           none. */}
-      {/* Page 2 and beyond only. The first page's empty states belong to the
+          {/* Page 2 and beyond only. The first page's empty states belong to the
           grid, which is the one that knows whether the viewer's own hides
           emptied it — this page counts the server's rows and would contradict
           it. */}
-      {!data.items.length && page > 1 && (
-        <Text size="sm" c="dimmed">
-          Nothing on this page. Try the next one.
-        </Text>
-      )}
+          {!data.items.length && page > 1 && (
+            <Text size="sm" c="dimmed">
+              Nothing on this page. Try the next one.
+            </Text>
+          )}
 
-      <Group>
-        {page > 1 && (
-          <Button variant="default" onClick={() => setPage((current) => current - 1)}>
-            Previous
-          </Button>
-        )}
-        {data.hasMore && (
-          <Button
-            variant="default"
-            loading={isFetching}
-            onClick={() => setPage((current) => current + 1)}
-          >
-            Next
-          </Button>
-        )}
-      </Group>
-    </StickerBookWidth>
+          <Group>
+            {page > 1 && (
+              <Button variant="default" onClick={() => setPage((current) => current - 1)}>
+                Previous
+              </Button>
+            )}
+            {data.hasMore && (
+              <Button
+                variant="default"
+                loading={isFetching}
+                onClick={() => setPage((current) => current + 1)}
+              >
+                Next
+              </Button>
+            )}
+          </Group>
+        </div>
+      </MasonryContainer>
+    </MasonryProvider>
   );
 }

--- a/src/components/StickerBook/StickerBookSectionPage.tsx
+++ b/src/components/StickerBook/StickerBookSectionPage.tsx
@@ -3,6 +3,7 @@ import { BackButton } from '~/components/BackButton/BackButton';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { useState } from 'react';
 import { StickerBookGrid } from '~/components/StickerBook/StickerBookGrid';
+import { StickerBookWidth } from '~/components/StickerBook/StickerBookSection';
 import type { StickerBookSide } from '~/components/StickerBook/sticker-book.util';
 import { stickerBookSectionCopy } from '~/components/StickerBook/sticker-book.util';
 import { trpc } from '~/utils/trpc';
@@ -57,7 +58,7 @@ export function StickerBookSectionPage({
   const copy = stickerBookSectionCopy(side, { username, isOwner: data.isOwner });
 
   return (
-    <div className="flex flex-col gap-4">
+    <StickerBookWidth className="flex flex-col gap-4">
       {/* The shared back button rather than a link with an arrow glyph in it:
           it also goes back through history when there is history, so arriving
           from the tab returns to the scroll position it was left at. */}
@@ -103,6 +104,6 @@ export function StickerBookSectionPage({
           </Button>
         )}
       </Group>
-    </div>
+    </StickerBookWidth>
   );
 }

--- a/src/components/StickerBook/StickerBookView.tsx
+++ b/src/components/StickerBook/StickerBookView.tsx
@@ -23,14 +23,14 @@ import { useState } from 'react';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
-import {
-  StickerBookBand,
-  StickerBookSection,
-  StickerBookWidth,
-} from '~/components/StickerBook/StickerBookSection';
+import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
+import { MasonryProvider } from '~/components/MasonryColumns/MasonryProvider';
+import { StickerBookBand, StickerBookSection } from '~/components/StickerBook/StickerBookSection';
+import { constants } from '~/server/common/constants';
 import { StickerBookSettingsModal } from '~/components/StickerBook/StickerBookSettingsModal';
 import { StickerBookStickers } from '~/components/StickerBook/StickerBookStickers';
 import { stickerBookSectionCopy } from '~/components/StickerBook/sticker-book.util';
+import { STICKER_BOOK_MAX_COLUMNS } from '~/shared/utils/sticker-book';
 import { Currency } from '~/shared/utils/prisma/enums';
 import { numberWithCommas } from '~/utils/number-helpers';
 import { trpc } from '~/utils/trpc';
@@ -85,22 +85,30 @@ export function StickerBookView({ username }: { username: string }) {
   const receivedCopy = stickerBookSectionCopy('owner', { username, isOwner });
 
   return (
-    <div className="flex flex-col">
+    // 🔴 `MasonryContainer` reads this context and THROWS without it, and the
+    // profile layout supplies none. Same props the profile's own image tab uses,
+    // so the two tabs lay out identically.
+    <MasonryProvider
+      columnWidth={constants.cardSizes.image}
+      maxColumnCount={STICKER_BOOK_MAX_COLUMNS}
+      maxSingleColumnWidth={450}
+      className="flex flex-col"
+    >
       {access.moderatorOverride && (
-        <StickerBookWidth>
+        <MasonryContainer p={0}>
           <Alert color="yellow" icon={<IconShieldCheck size={18} />} mb="md">
             <Text size="sm">
               {username} has hidden some or all of this. You can see it because you&rsquo;re a
               moderator; other visitors cannot.
             </Text>
           </Alert>
-        </StickerBookWidth>
+        </MasonryContainer>
       )}
 
       {/* The shop page's header shape: an icon, the creator's name for the thing,
           and the one number worth stating — with no page title above it, because
           no other profile tab carries one. */}
-      <StickerBookWidth>
+      <MasonryContainer p={0}>
         <Group justify="space-between" align="flex-start" wrap="nowrap" py="md">
           <Group gap="md" align="center" wrap="nowrap" className="min-w-0">
             <ThemeIcon size={48} radius="xl" variant="light" color="yellow">
@@ -145,7 +153,7 @@ export function StickerBookView({ username }: { username: string }) {
             )}
           </Group>
         </Group>
-      </StickerBookWidth>
+      </MasonryContainer>
 
       {access.canViewStickers && !!data.stickers.length && (
         <StickerBookBand
@@ -201,7 +209,7 @@ export function StickerBookView({ username }: { username: string }) {
       />
 
       {nothingYet && isOwner && (
-        <StickerBookWidth>
+        <MasonryContainer p={0}>
           <Alert color="blue" mt="md">
             <Text size="sm">
               Nothing in your book yet. Buy a sticker in the{' '}
@@ -211,12 +219,12 @@ export function StickerBookView({ username }: { username: string }) {
               and put one on an image, or turn stickers on for your own images from the gear above.
             </Text>
           </Alert>
-        </StickerBookWidth>
+        </MasonryContainer>
       )}
 
       {isOwner && (
         <StickerBookSettingsModal opened={settingsOpen} onClose={() => setSettingsOpen(false)} />
       )}
-    </div>
+    </MasonryProvider>
   );
 }

--- a/src/components/StickerBook/StickerBookView.tsx
+++ b/src/components/StickerBook/StickerBookView.tsx
@@ -23,7 +23,11 @@ import { useState } from 'react';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
-import { StickerBookBand, StickerBookSection } from '~/components/StickerBook/StickerBookSection';
+import {
+  StickerBookBand,
+  StickerBookSection,
+  StickerBookWidth,
+} from '~/components/StickerBook/StickerBookSection';
 import { StickerBookSettingsModal } from '~/components/StickerBook/StickerBookSettingsModal';
 import { StickerBookStickers } from '~/components/StickerBook/StickerBookStickers';
 import { stickerBookSectionCopy } from '~/components/StickerBook/sticker-book.util';
@@ -83,61 +87,65 @@ export function StickerBookView({ username }: { username: string }) {
   return (
     <div className="flex flex-col">
       {access.moderatorOverride && (
-        <Alert color="yellow" icon={<IconShieldCheck size={18} />} mb="md">
-          <Text size="sm">
-            {username} has hidden some or all of this. You can see it because you&rsquo;re a
-            moderator; other visitors cannot.
-          </Text>
-        </Alert>
+        <StickerBookWidth>
+          <Alert color="yellow" icon={<IconShieldCheck size={18} />} mb="md">
+            <Text size="sm">
+              {username} has hidden some or all of this. You can see it because you&rsquo;re a
+              moderator; other visitors cannot.
+            </Text>
+          </Alert>
+        </StickerBookWidth>
       )}
 
       {/* The shop page's header shape: an icon, the creator's name for the thing,
           and the one number worth stating — with no page title above it, because
           no other profile tab carries one. */}
-      <Group justify="space-between" align="flex-start" wrap="nowrap" py="md">
-        <Group gap="md" align="center" wrap="nowrap" className="min-w-0">
-          <ThemeIcon size={48} radius="xl" variant="light" color="yellow">
-            <IconSticker size={28} />
-          </ThemeIcon>
-          <Stack gap={2} className="min-w-0">
-            <Title order={1} size="h2">
-              {username}&apos;s Sticker Book
-            </Title>
-            {access.canViewEarnings && data.earnedBuzz !== null ? (
-              <Group gap={4} wrap="nowrap">
-                <CurrencyIcon currency={Currency.BUZZ} size={16} />
-                <Text size="sm">
-                  <Text span fw={700}>
-                    {numberWithCommas(data.earnedBuzz)} Buzz
-                  </Text>{' '}
-                  earned from stickers on {isOwner ? 'your' : 'their'} images
+      <StickerBookWidth>
+        <Group justify="space-between" align="flex-start" wrap="nowrap" py="md">
+          <Group gap="md" align="center" wrap="nowrap" className="min-w-0">
+            <ThemeIcon size={48} radius="xl" variant="light" color="yellow">
+              <IconSticker size={28} />
+            </ThemeIcon>
+            <Stack gap={2} className="min-w-0">
+              <Title order={1} size="h2">
+                {username}&apos;s Sticker Book
+              </Title>
+              {access.canViewEarnings && data.earnedBuzz !== null ? (
+                <Group gap={4} wrap="nowrap">
+                  <CurrencyIcon currency={Currency.BUZZ} size={16} />
+                  <Text size="sm">
+                    <Text span fw={700}>
+                      {numberWithCommas(data.earnedBuzz)} Buzz
+                    </Text>{' '}
+                    earned from stickers on {isOwner ? 'your' : 'their'} images
+                  </Text>
+                </Group>
+              ) : (
+                <Text size="sm" c="dimmed">
+                  {isOwner
+                    ? 'Your stickers, where you have put them, and what people have put on your work.'
+                    : `Stickers ${username} owns and the images they have been part of.`}
                 </Text>
-              </Group>
-            ) : (
-              <Text size="sm" c="dimmed">
-                {isOwner
-                  ? 'Your stickers, where you have put them, and what people have put on your work.'
-                  : `Stickers ${username} owns and the images they have been part of.`}
-              </Text>
-            )}
-          </Stack>
-        </Group>
+              )}
+            </Stack>
+          </Group>
 
-        <Group gap="xs" wrap="nowrap">
-          {isOwner && (
-            <Tooltip label="Sticker settings">
-              <ActionIcon
-                variant="default"
-                size="lg"
-                onClick={() => setSettingsOpen(true)}
-                aria-label="Manage sticker placement settings"
-              >
-                <IconSettings size={18} />
-              </ActionIcon>
-            </Tooltip>
-          )}
+          <Group gap="xs" wrap="nowrap">
+            {isOwner && (
+              <Tooltip label="Sticker settings">
+                <ActionIcon
+                  variant="default"
+                  size="lg"
+                  onClick={() => setSettingsOpen(true)}
+                  aria-label="Manage sticker placement settings"
+                >
+                  <IconSettings size={18} />
+                </ActionIcon>
+              </Tooltip>
+            )}
+          </Group>
         </Group>
-      </Group>
+      </StickerBookWidth>
 
       {access.canViewStickers && !!data.stickers.length && (
         <StickerBookBand
@@ -193,15 +201,17 @@ export function StickerBookView({ username }: { username: string }) {
       />
 
       {nothingYet && isOwner && (
-        <Alert color="blue" mt="md">
-          <Text size="sm">
-            Nothing in your book yet. Buy a sticker in the{' '}
-            <Text component={Link} href="/shop" c="blue.4" inherit>
-              shop
-            </Text>{' '}
-            and put one on an image, or turn stickers on for your own images from the gear above.
-          </Text>
-        </Alert>
+        <StickerBookWidth>
+          <Alert color="blue" mt="md">
+            <Text size="sm">
+              Nothing in your book yet. Buy a sticker in the{' '}
+              <Text component={Link} href="/shop" c="blue.4" inherit>
+                shop
+              </Text>{' '}
+              and put one on an image, or turn stickers on for your own images from the gear above.
+            </Text>
+          </Alert>
+        </StickerBookWidth>
       )}
 
       {isOwner && (

--- a/src/components/StickerBook/__tests__/sticker-book.util.test.ts
+++ b/src/components/StickerBook/__tests__/sticker-book.util.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { wholeRows } from '~/components/StickerBook/sticker-book.util';
+
+/**
+ * The tab's whole-rows trim, tested as arithmetic.
+ *
+ * Deliberately NOT a component test. The column count reaches the grid from a
+ * ResizeObserver behind a 100ms debounce, and component tests load no
+ * stylesheet — so "at this viewport, expect N cards" would measure an unstyled
+ * width and assert a lie. The contract has no width in it.
+ */
+describe('wholeRows', () => {
+  it('drops the part-filled last row', () => {
+    // 14 and 4, NOT 8 and 4: at 8 the floor-arithmetic and a naive
+    // `slice(0, columnCount * 2)` agree, so a two-row fixture cannot tell a
+    // correct implementation from one that only ever draws two rows.
+    expect(wholeRows([...Array(14).keys()], 4)).toEqual([...Array(12).keys()]);
+  });
+
+  it('keeps an exact multiple whole', () => {
+    expect(wholeRows([...Array(14).keys()], 7)).toHaveLength(14);
+  });
+
+  it('keeps everything when there are FEWER items than columns', () => {
+    // Without this guard the result is `[]`, and an empty grid renders
+    // "Everything here is from creators you have hidden." to a viewer who has
+    // hidden nobody — a wrong and alarming message on any small section.
+    expect(wholeRows([1, 2, 3], 4)).toEqual([1, 2, 3]);
+  });
+
+  it('passes everything through before the container has measured', () => {
+    // `columnCount` is 0 until the resize observer fires. Unguarded,
+    // `Math.floor(n / 0) * 0` is NaN and `slice(0, NaN)` is `[]` — the same
+    // wrong message, on every first paint.
+    expect(wholeRows([1, 2, 3, 4, 5], 0)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('draws every complete row, not just the first', () => {
+    expect(wholeRows([...Array(14).keys()], 3)).toHaveLength(12);
+  });
+});

--- a/src/components/StickerBook/sticker-book.util.ts
+++ b/src/components/StickerBook/sticker-book.util.ts
@@ -36,3 +36,23 @@ export function stickerBookSectionCopy(
       : 'Nothing here yet.',
   };
 }
+
+/**
+ * The prefix of `items` that fills COMPLETE rows of a `columnCount`-wide grid.
+ *
+ * Extracted from the grid so it can be tested without a DOM: the column count
+ * arrives from a ResizeObserver behind a 100ms debounce, and component tests
+ * load no stylesheet, so any "at this viewport, expect N cards" assertion is
+ * measuring an unstyled width. The contract has no width in it — given a column
+ * count, draw `floor(n / c) * c`.
+ *
+ * 🔴 Both guards are load-bearing, and both fail the same alarming way. Fewer
+ * items than columns must return them ALL, and a column count of 0 — which is
+ * what the provider reports until it has measured — must pass through. Either
+ * one removed returns an empty array, and the grid then tells a viewer who has
+ * hidden nobody that "Everything here is from creators you have hidden."
+ */
+export function wholeRows<T>(items: T[], columnCount: number): T[] {
+  if (!columnCount || items.length < columnCount) return items;
+  return items.slice(0, Math.floor(items.length / columnCount) * columnCount);
+}

--- a/src/server/services/__tests__/sticker-book.service.test.ts
+++ b/src/server/services/__tests__/sticker-book.service.test.ts
@@ -118,22 +118,36 @@ const oneStickeredImage = () => {
  * a test can withhold the odd half and still have enough left to fill the page.
  */
 const manyStickeredImages = (count: number) => {
-  const all = Array.from({ length: count }, (_, i) => ({
-    targetId: 900 + i,
-    _max: { createdAt: new Date(2026, 0, 1, 0, count - i) },
-  }));
+  const rows = (base: number) =>
+    Array.from({ length: count }, (_, i) => ({
+      targetId: base + i,
+      _max: { createdAt: new Date(2026, 0, 1, 0, count - i) },
+    }));
 
-  // 🔴 HONOURS `take` AND `skip`. A flat `mockResolvedValue` hands back every row
-  // whatever the query asked for, which makes the overfetch invisible: the walk
-  // sees all 40 candidates even with the overfetch removed, and a test named for
-  // it passes over code that does not do it. Caught by reverting
-  // `SECTION_OVERFETCH` and watching this stay green.
-  placementGroupBy.mockImplementation(async (args: { take?: number; skip?: number }) => {
-    const from = args?.skip ?? 0;
-    return all.slice(from, from + (args?.take ?? all.length));
-  });
+  // 🔴 HONOURS `take` AND `skip`, and DISPATCHES ON `where`.
+  //
+  // `take`: a flat `mockResolvedValue` hands back every row whatever the query
+  // asked for, which makes the overfetch invisible — the walk sees all the
+  // candidates even with the overfetch removed, and a test named for it passes
+  // over code that does not do it. Caught by reverting `SECTION_OVERFETCH`.
+  //
+  // `where`: without this the two sections return IDENTICAL rows, so the two
+  // per-section hydrations hold the same map and sharing one between them is
+  // unobservable. In production their image sets are disjoint and the loser's
+  // `attach` finds nothing — an empty row.
+  placementGroupBy.mockImplementation(
+    async (args: { take?: number; skip?: number; where?: { placerId?: number } }) => {
+      const all = rows(args?.where?.placerId ? PLACED_BASE : RECEIVED_BASE);
+      const from = args?.skip ?? 0;
+      return all.slice(from, from + (args?.take ?? all.length));
+    }
+  );
   placementFindMany.mockResolvedValue([]);
 };
+
+/** Disjoint id ranges, so a section drawing the other one's images is visible. */
+const PLACED_BASE = 900;
+const RECEIVED_BASE = 5000;
 
 const EARNED = 1234;
 
@@ -419,7 +433,7 @@ describe('getStickerBook — what leaves the server', () => {
     // The cap, overfetched, plus the one row that decides `hasMore`. Asserted as
     // the cap it came from rather than as 241, so raising the cap fails here
     // rather than silently letting a caller ask for 5000.
-    for (const call of placementGroupBy.mock.calls) expect(call[0].take).toBe(60 * 4 + 1);
+    for (const call of placementGroupBy.mock.calls) expect(call[0].take).toBe(60 * 2 + 1);
   });
 
   it('asks the tab for WHOLE ROWS of the grid, not a round number', async () => {
@@ -460,10 +474,35 @@ describe('getStickerBook — what leaves the server', () => {
 
     const book = await getStickerBook({ username: 'creator', ...viewer(CREATOR), ...levels });
 
-    expect(book.placed).toHaveLength(STICKER_BOOK_TAB_LIMIT);
-    // The survivors, not the first fourteen candidates — a walk that ignored the
-    // filter would return odd ids too and still have the right length.
-    for (const row of book.placed) expect(row.imageId % 2).toBe(0);
+    // 🔴 The exact ids in order, not a length and a parity check.
+    //
+    // A parity loop here CANNOT FAIL: `attach` drops any row whose id is absent
+    // from the hydration map, and that map holds only the evens — so every row
+    // reaching the assertion is even whatever the walk did. Length alone is just
+    // as weak: it stays green under a walk that reverses the candidates (oldest
+    // first), or pushes `groups[0]` fourteen times. Only the id list sees those.
+    expect(book.placed.map((row) => row.imageId)).toEqual(
+      Array.from({ length: STICKER_BOOK_TAB_LIMIT }, (_, i) => PLACED_BASE + i * 2)
+    );
+  });
+
+  it('keeps the two sections hydrated apart', async () => {
+    // One `sectionImages` per section. Shared, the second hydration erases the
+    // first and the losing section renders empty — and with a fixture whose two
+    // sections return the same rows, that mutation is invisible.
+    manyStickeredImages(20);
+
+    const book = await getStickerBook({ username: 'creator', ...viewer(CREATOR), ...levels });
+
+    expect(book.placed.map((row) => row.imageId)).toEqual(
+      Array.from({ length: STICKER_BOOK_TAB_LIMIT }, (_, i) => PLACED_BASE + i)
+    );
+    expect(book.received.map((row) => row.imageId)).toEqual(
+      Array.from({ length: STICKER_BOOK_TAB_LIMIT }, (_, i) => RECEIVED_BASE + i)
+    );
+    // One feed query per section. A regression to hydrating twice would still
+    // return the right rows, so the count is the only thing that sees it.
+    expect(allImages).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/server/services/__tests__/sticker-book.service.test.ts
+++ b/src/server/services/__tests__/sticker-book.service.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import type * as ImageService from '~/server/services/image.service';
 import type * as UserPreferences from '~/server/services/user-preferences.service';
+import { STICKER_BOOK_MAX_COLUMNS, STICKER_BOOK_TAB_LIMIT } from '~/shared/utils/sticker-book';
 
 const blockedPairIds = vi.fn(async () => [] as number[]);
 /**
@@ -109,6 +110,29 @@ const oneStickeredImage = () => {
       nsfwLevel: 1,
     },
   ]);
+};
+
+/**
+ * A section with more images than the tab draws, so a count assertion is about
+ * the tab's own limit rather than about the fixture running out. Ids are even so
+ * a test can withhold the odd half and still have enough left to fill the page.
+ */
+const manyStickeredImages = (count: number) => {
+  const all = Array.from({ length: count }, (_, i) => ({
+    targetId: 900 + i,
+    _max: { createdAt: new Date(2026, 0, 1, 0, count - i) },
+  }));
+
+  // 🔴 HONOURS `take` AND `skip`. A flat `mockResolvedValue` hands back every row
+  // whatever the query asked for, which makes the overfetch invisible: the walk
+  // sees all 40 candidates even with the overfetch removed, and a test named for
+  // it passes over code that does not do it. Caught by reverting
+  // `SECTION_OVERFETCH` and watching this stay green.
+  placementGroupBy.mockImplementation(async (args: { take?: number; skip?: number }) => {
+    const from = args?.skip ?? 0;
+    return all.slice(from, from + (args?.take ?? all.length));
+  });
+  placementFindMany.mockResolvedValue([]);
 };
 
 const EARNED = 1234;
@@ -392,10 +416,54 @@ describe('getStickerBook — what leaves the server', () => {
   it('bounds the section limit rather than passing a caller number through', async () => {
     await getStickerBook({ username: 'creator', ...viewer(CREATOR), limit: 5000, ...levels });
 
-    // The cap plus the one row that decides `hasMore`. Asserted as the cap it
-    // came from rather than as 61, so raising the cap fails here rather than
-    // silently letting a caller ask for 5000.
-    for (const call of placementGroupBy.mock.calls) expect(call[0].take).toBe(60 + 1);
+    // The cap, overfetched, plus the one row that decides `hasMore`. Asserted as
+    // the cap it came from rather than as 241, so raising the cap fails here
+    // rather than silently letting a caller ask for 5000.
+    for (const call of placementGroupBy.mock.calls) expect(call[0].take).toBe(60 * 4 + 1);
+  });
+
+  it('asks the tab for WHOLE ROWS of the grid, not a round number', async () => {
+    // 🔴 Do not "simplify" this to a literal. The tab's fetch is two full rows at
+    // the grid's seven-column ceiling, and the two are multiplied in
+    // `shared/utils/sticker-book` precisely so they cannot drift. A limit that
+    // is not a whole multiple of the ceiling leaves the last row short on a wide
+    // window, which is the bug this replaced (Ellie, 2026-08-24: "what's the two
+    // blank image spots for?"). If you change the column ceiling, this moves
+    // with it on its own; if you hardcode either number, it stops protecting
+    // anything.
+    // Twenty stickered images, all visible — more than the tab draws, so the
+    // count below is the tab's decision rather than the fixture running out.
+    manyStickeredImages(20);
+
+    const book = await getStickerBook({ username: 'creator', ...viewer(CREATOR), ...levels });
+
+    // Asserted on what the tab RECEIVES, not on the query's `take`, which is now
+    // the overfetch window and says nothing about how many cards get drawn.
+    // As an object so a failure prints the numbers that disagree: asserted bare
+    // it reads `expected 5 to be +0`, naming neither the count nor the ceiling.
+    expect({
+      columns: STICKER_BOOK_MAX_COLUMNS,
+      shown: book.placed.length,
+      shortInLastRow: book.placed.length % STICKER_BOOK_MAX_COLUMNS,
+    }).toMatchObject({ shown: STICKER_BOOK_TAB_LIMIT, shortInLastRow: 0 });
+  });
+
+  it('overfetches so images the feed withholds cannot leave the tab short', async () => {
+    // Forty candidates with every other one withheld. Without the overfetch the
+    // tab asks for exactly its 14, loses half of them to the feed, and draws the
+    // half-empty last row this was reported for.
+    manyStickeredImages(40);
+    allImages.mockImplementation(async ({ ids }: { ids?: number[] }) => ({
+      items: (ids ?? []).filter((id) => id % 2 === 0).map((id) => ({ id, url: `url-${id}` })),
+      nextCursor: undefined,
+    }));
+
+    const book = await getStickerBook({ username: 'creator', ...viewer(CREATOR), ...levels });
+
+    expect(book.placed).toHaveLength(STICKER_BOOK_TAB_LIMIT);
+    // The survivors, not the first fourteen candidates — a walk that ignored the
+    // filter would return odd ids too and still have the right length.
+    for (const row of book.placed) expect(row.imageId % 2).toBe(0);
   });
 });
 

--- a/src/server/services/__tests__/sticker-book.service.test.ts
+++ b/src/server/services/__tests__/sticker-book.service.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import type * as ImageService from '~/server/services/image.service';
 import type * as UserPreferences from '~/server/services/user-preferences.service';
-import { STICKER_BOOK_MAX_COLUMNS, STICKER_BOOK_TAB_LIMIT } from '~/shared/utils/sticker-book';
+import { STICKER_BOOK_TAB_LIMIT } from '~/shared/utils/sticker-book';
 
 const blockedPairIds = vi.fn(async () => [] as number[]);
 /**
@@ -137,7 +137,13 @@ const manyStickeredImages = (count: number) => {
   // `attach` finds nothing — an empty row.
   placementGroupBy.mockImplementation(
     async (args: { take?: number; skip?: number; where?: { placerId?: number } }) => {
-      const all = rows(args?.where?.placerId ? PLACED_BASE : RECEIVED_BASE);
+      // 🔴 `typeof === 'number'`, NOT truthiness. On the owner side the service
+      // builds `placerId: blocked`, and `blocked` is `{ notIn: [...] }` — an
+      // object, so truthy — the moment the viewer has any block. A truthy test
+      // would hand both sections the same rows again and silently un-observe the
+      // isolation the tests below exist to hold.
+      const placedSide = typeof args?.where?.placerId === 'number';
+      const all = rows(placedSide ? PLACED_BASE : RECEIVED_BASE);
       const from = args?.skip ?? 0;
       return all.slice(from, from + (args?.take ?? all.length));
     }
@@ -430,36 +436,17 @@ describe('getStickerBook — what leaves the server', () => {
   it('bounds the section limit rather than passing a caller number through', async () => {
     await getStickerBook({ username: 'creator', ...viewer(CREATOR), limit: 5000, ...levels });
 
-    // The cap, overfetched, plus the one row that decides `hasMore`. Asserted as
-    // the cap it came from rather than as 241, so raising the cap fails here
-    // rather than silently letting a caller ask for 5000.
+    // The cap, overfetched, plus the lookahead row. Written as arithmetic over
+    // the two literals rather than as 121, so raising either fails here rather
+    // than silently letting a caller ask for 5000.
     for (const call of placementGroupBy.mock.calls) expect(call[0].take).toBe(60 * 2 + 1);
-  });
 
-  it('asks the tab for WHOLE ROWS of the grid, not a round number', async () => {
-    // 🔴 Do not "simplify" this to a literal. The tab's fetch is two full rows at
-    // the grid's seven-column ceiling, and the two are multiplied in
-    // `shared/utils/sticker-book` precisely so they cannot drift. A limit that
-    // is not a whole multiple of the ceiling leaves the last row short on a wide
-    // window, which is the bug this replaced (Ellie, 2026-08-24: "what's the two
-    // blank image spots for?"). If you change the column ceiling, this moves
-    // with it on its own; if you hardcode either number, it stops protecting
-    // anything.
-    // Twenty stickered images, all visible — more than the tab draws, so the
-    // count below is the tab's decision rather than the fixture running out.
-    manyStickeredImages(20);
-
-    const book = await getStickerBook({ username: 'creator', ...viewer(CREATOR), ...levels });
-
-    // Asserted on what the tab RECEIVES, not on the query's `take`, which is now
-    // the overfetch window and says nothing about how many cards get drawn.
-    // As an object so a failure prints the numbers that disagree: asserted bare
-    // it reads `expected 5 to be +0`, naming neither the count nor the ceiling.
-    expect({
-      columns: STICKER_BOOK_MAX_COLUMNS,
-      shown: book.placed.length,
-      shortInLastRow: book.placed.length % STICKER_BOOK_MAX_COLUMNS,
-    }).toMatchObject({ shown: STICKER_BOOK_TAB_LIMIT, shortInLastRow: 0 });
+    // 🔴 The invariant the clamp exists for, which the clamp itself cannot show:
+    // `imagesForBook` passes `ids.length` as `getInfiniteImagesSchema`'s limit,
+    // and that schema caps at 200. Today's window is 121 so this passes without
+    // the clamp — it goes red only when someone raises `MAX_SECTION_LIMIT`
+    // WITHOUT it, which is the 500 that takes stickers and earnings down too.
+    for (const call of placementGroupBy.mock.calls) expect(call[0].take).toBeLessThanOrEqual(200);
   });
 
   it('overfetches so images the feed withholds cannot leave the tab short', async () => {

--- a/src/server/services/sticker-book.service.ts
+++ b/src/server/services/sticker-book.service.ts
@@ -7,13 +7,19 @@ import type { StickerBookSettings } from '~/shared/utils/sticker-book';
 import { getStickerBalances } from '~/server/services/sticker.service';
 import { getBlockedPairIds } from '~/server/services/user-preferences.service';
 import { PLACEMENT_OWNER_PAYOUT_KINDS } from '~/shared/utils/placement';
-import { stickerBookAccess, STICKER_BOOK_TAB_LIMIT } from '~/shared/utils/sticker-book';
+import {
+  stickerBookAccess,
+  STICKER_BOOK_OVERFETCH,
+  STICKER_BOOK_PAGE_LIMIT,
+  STICKER_BOOK_TAB_LIMIT,
+} from '~/shared/utils/sticker-book';
 
 const SURFACE = 'sticker' as const;
 const TARGET_TYPE = 'image' as const;
 
 /**
- * How many placement rows a section may consider before it stops.
+ * The largest page a caller may ask a section for. NOT how many rows it reads —
+ * the overfetch below means a section considers up to `limit * OVERFETCH + 1`.
  */
 const MAX_SECTION_LIMIT = 60;
 
@@ -37,7 +43,7 @@ const MAX_SECTION_LIMIT = 60;
  * empty answer on an account whose images were all unpublished, so a section
  * whose overfetch is exhausted still comes back short rather than walking.
  */
-const SECTION_OVERFETCH = 2;
+const SECTION_OVERFETCH = STICKER_BOOK_OVERFETCH;
 
 /**
  * The most ids `imagesForBook` may hand the feed in one call.
@@ -167,10 +173,19 @@ async function getPlacementSection({
   if (resolveVisible) {
     const visible = await resolveVisible(groups.map((group) => group.targetId));
     const chosen: typeof groups = [];
-    // Walk in order, taking what survives until the page is full. `overran` is
-    // the honest `hasMore`: rows were left unconsumed, so there is definitely
-    // another page. Exhausting the whole overfetch without filling the page also
-    // means more, since the window itself was the limit.
+    // Walk in order, taking what survives until the page is full.
+    //
+    // 🔴 `hasMore` ON THIS BRANCH HAS NO READER, so nothing verifies it. The tab
+    // is the only caller that overfetches and it discards `hasMore`; the paged
+    // drill-in never takes this path. The reasoning below is why it is written
+    // this way, NOT a tested guarantee — anyone giving the tab a "load more"
+    // should write the test before trusting it. Kept rather than deleted because
+    // that caller is the obvious next step and the arithmetic is easy to get
+    // subtly wrong.
+    //
+    // `overran` means rows were left unconsumed, so there is definitely another
+    // page. Exhausting the whole window without filling the page also means
+    // more, since the window itself was the limit.
     let overran = false;
     for (const group of groups) {
       if (chosen.length >= limit) {
@@ -423,7 +438,7 @@ export async function getStickerBookSection({
   username,
   side,
   page = 1,
-  limit = 30,
+  limit = STICKER_BOOK_PAGE_LIMIT,
   browsingLevel,
   user,
   isModerator = false,

--- a/src/server/services/sticker-book.service.ts
+++ b/src/server/services/sticker-book.service.ts
@@ -7,20 +7,30 @@ import type { StickerBookSettings } from '~/shared/utils/sticker-book';
 import { getStickerBalances } from '~/server/services/sticker.service';
 import { getBlockedPairIds } from '~/server/services/user-preferences.service';
 import { PLACEMENT_OWNER_PAYOUT_KINDS } from '~/shared/utils/placement';
-import { stickerBookAccess } from '~/shared/utils/sticker-book';
+import { stickerBookAccess, STICKER_BOOK_TAB_LIMIT } from '~/shared/utils/sticker-book';
 
 const SURFACE = 'sticker' as const;
 const TARGET_TYPE = 'image' as const;
 
 /**
  * How many placement rows a section may consider before it stops.
- *
- * The window is on the PLACEMENTS, and the images are filtered afterwards, so a
- * section can come back shorter than its limit. That is the honest shape: the
- * alternative is looping until the page is full, which on an account whose
- * images were all unpublished is an unbounded scan for an empty answer.
  */
 const MAX_SECTION_LIMIT = 60;
+
+/**
+ * How far past the page to look so the image filter cannot under-fill it.
+ *
+ * The window is on the PLACEMENTS and the images are filtered afterwards, so
+ * without this a section comes back short whenever any of its images are
+ * unpublished — on the tab that lands as a ragged last row under a grid sized
+ * for whole ones. `limit * 4 + 1` is the shape the collections and comics
+ * listings already use; the `+ 1` is the row that proves there is a next page.
+ *
+ * Bounded on purpose. Looping until the page is full is an unbounded scan for an
+ * empty answer on an account whose images were all unpublished, so a section
+ * whose overfetch is exhausted still comes back short rather than walking.
+ */
+const SECTION_OVERFETCH = 4;
 
 /**
  * One section of the book: images carrying approved sticker placements, one card
@@ -51,6 +61,7 @@ async function getPlacementSection({
   limit,
   skip = 0,
   blockedIds,
+  resolveVisible,
 }: {
   userId: number;
   side: 'placer' | 'owner';
@@ -74,6 +85,18 @@ async function getPlacementSection({
    * because the two are one word apart and only one of them is a safety control.
    */
   blockedIds: number[];
+  /**
+   * Which of a set of image ids the viewer may actually be shown, as a lookup.
+   *
+   * Passed in rather than called here so the overfetch is filtered against the
+   * SAME hydration the cards are drawn from — a second `getAllImages` beside it
+   * is a second answer to "may this be seen", and the two can disagree.
+   *
+   * Omitted by the paged drill-in, which cannot overfetch: its `skip` counts
+   * GROUPS, so consuming a variable number of them per page would repeat or
+   * skip rows across the boundary.
+   */
+  resolveVisible?: (ids: number[]) => Promise<Map<number, unknown>>;
 }) {
   const blocked = blockedIds.length ? { notIn: blockedIds } : undefined;
   // Written out per side rather than with a computed key. A computed key that
@@ -96,22 +119,43 @@ async function getPlacementSection({
           placerId: blocked,
         };
 
+  const windowSize = resolveVisible ? limit * SECTION_OVERFETCH + 1 : limit + 1;
+
   const groups = await dbRead.placement.groupBy({
     by: ['targetId'],
     where,
     _max: { createdAt: true },
     orderBy: { _max: { createdAt: 'desc' } },
-    take: limit + 1,
+    take: windowSize,
     skip,
   });
 
   if (!groups.length) return { items: [], hasMore: false };
 
+  let page = groups.slice(0, limit);
   // Read off the row past the page, BEFORE the image filter drops anything. A
   // page that came back short because its images were unpublished still has a
   // next page, and deciding from what survived would end the walk early.
-  const hasMore = groups.length > limit;
-  const page = groups.slice(0, limit);
+  let hasMore = groups.length > limit;
+
+  if (resolveVisible) {
+    const visible = await resolveVisible(groups.map((group) => group.targetId));
+    const chosen: typeof groups = [];
+    // Walk in order, taking what survives until the page is full. `overran` is
+    // the honest `hasMore`: rows were left unconsumed, so there is definitely
+    // another page. Exhausting the whole overfetch without filling the page also
+    // means more, since the window itself was the limit.
+    let overran = false;
+    for (const group of groups) {
+      if (chosen.length >= limit) {
+        overran = true;
+        break;
+      }
+      if (visible.has(group.targetId)) chosen.push(group);
+    }
+    page = chosen;
+    hasMore = overran || groups.length === windowSize;
+  }
 
   const targetIds = page.map((group) => group.targetId);
 
@@ -253,6 +297,31 @@ async function imagesForBook({
  * nobody has to act on a row here, unlike the review queues, which keep a
  * withheld row so its escrow can still be answered.
  */
+/**
+ * One section's hydration, done once and read twice.
+ *
+ * `resolveVisible` decides which of the overfetched rows survive; `attach` then
+ * dresses the chosen ones. Both read the SAME map, so the rows the section kept
+ * and the images it draws cannot come from two different answers to "may this be
+ * seen" — and it is one `getAllImages` per section rather than two.
+ */
+function sectionImages(browsingLevel: number, user?: SessionUser) {
+  let byId = new Map<number, Awaited<ReturnType<typeof imagesForBook>>[number]>();
+
+  return {
+    resolveVisible: async (ids: number[]) => {
+      const images = await imagesForBook({ ids, browsingLevel, user });
+      byId = new Map(images.map((image) => [image.id, image]));
+      return byId;
+    },
+    attach: <T extends { imageId: number }>(rows: T[]) =>
+      rows.flatMap((row) => {
+        const image = byId.get(row.imageId);
+        return image ? [{ ...row, image }] : [];
+      }),
+  };
+}
+
 async function withImages<T extends { imageId: number }>(
   rows: T[],
   browsingLevel: number,
@@ -365,7 +434,7 @@ export async function getStickerBook({
   browsingLevel,
   user,
   isModerator = false,
-  limit = 12,
+  limit = STICKER_BOOK_TAB_LIMIT,
 }: {
   username: string;
   browsingLevel: number;
@@ -391,6 +460,12 @@ export async function getStickerBook({
   const sectionLimit = Math.min(Math.max(limit, 1), MAX_SECTION_LIMIT);
   const blockedIds = viewerId ? await getBlockedPairIds(viewerId) : [];
 
+  // One per section, and NOT shared: each holds the map its own overfetch was
+  // filtered against, and a shared one would be overwritten by whichever section
+  // hydrated last.
+  const placedImages = sectionImages(browsingLevel, user);
+  const receivedImages = sectionImages(browsingLevel, user);
+
   const [holdings, placed, received, earnedBuzz] = await Promise.all([
     // Newest acquisition first — the order the placement tray presents the same
     // collection in.
@@ -402,12 +477,14 @@ export async function getStickerBook({
       side: 'placer',
       limit: sectionLimit,
       blockedIds,
+      resolveVisible: placedImages.resolveVisible,
     }),
     getPlacementSection({
       userId: subject.id,
       side: 'owner',
       limit: sectionLimit,
       blockedIds,
+      resolveVisible: receivedImages.resolveVisible,
     }),
     access.canViewEarnings ? getEarnedBuzz(subject.id) : Promise.resolve(null),
   ]);
@@ -424,8 +501,12 @@ export async function getStickerBook({
     })),
     // The row's items only. `hasMore` belongs to the drill-in page, which asks
     // for its own pages; on the tab the "View all" link is there either way.
-    placed: await withImages(placed.items, browsingLevel, user),
-    received: await withImages(received.items, browsingLevel, user),
+    //
+    // Attached from the hydration the overfetch was already filtered against —
+    // re-fetching here would ask "may this be seen" a second time and could
+    // answer differently.
+    placed: placedImages.attach(placed.items),
+    received: receivedImages.attach(received.items),
     earnedBuzz,
   };
 }

--- a/src/server/services/sticker-book.service.ts
+++ b/src/server/services/sticker-book.service.ts
@@ -23,14 +23,38 @@ const MAX_SECTION_LIMIT = 60;
  * The window is on the PLACEMENTS and the images are filtered afterwards, so
  * without this a section comes back short whenever any of its images are
  * unpublished — on the tab that lands as a ragged last row under a grid sized
- * for whole ones. `limit * 4 + 1` is the shape the collections and comics
- * listings already use; the `+ 1` is the row that proves there is a next page.
+ * for whole ones. `limit * N + 1` is the shape `api/v1/collections` uses; the
+ * `+ 1` is the row that proves there is a next page.
+ *
+ * 🔴 TWO, not four, and measured rather than picked. Across all 1,463 placement
+ * targets in production, 97.3% survive the feed filter at full browsing level —
+ * so a 4x window multiplied the hydration ~3.8x to recover an average of 0.4
+ * rows. Under the SFW clamp survival is 33.4% and some sections cannot be
+ * filled by any multiplier, which is a short row to tolerate rather than a
+ * number to raise.
  *
  * Bounded on purpose. Looping until the page is full is an unbounded scan for an
  * empty answer on an account whose images were all unpublished, so a section
  * whose overfetch is exhausted still comes back short rather than walking.
  */
-const SECTION_OVERFETCH = 4;
+const SECTION_OVERFETCH = 2;
+
+/**
+ * The most ids `imagesForBook` may hand the feed in one call.
+ *
+ * 🔴 NOT a tuning number. `getInfiniteImagesSchema` caps its `limit` at 200
+ * (`server/schema/image.schema.ts`), and `imagesForBook` passes `ids.length` as
+ * that limit — so a longer array does not fetch more, it throws a ZodError out
+ * of the section and 500s the whole `stickerBook.get` query, stickers and
+ * earnings included, because the sections sit in one `Promise.all`.
+ *
+ * Reachable from the wire: `limit` is caller-supplied up to 60 on a public
+ * procedure. At the overfetch above the window tops out at 121, so this does
+ * not bind today and no account is near it either — the largest section in
+ * production is 98. It is here because the product of two constants going over
+ * 200 is a 500, and neither constant looks dangerous on its own.
+ */
+const MAX_HYDRATED_IDS = 200;
 
 /**
  * One section of the book: images carrying approved sticker placements, one card
@@ -119,7 +143,9 @@ async function getPlacementSection({
           placerId: blocked,
         };
 
-  const windowSize = resolveVisible ? limit * SECTION_OVERFETCH + 1 : limit + 1;
+  const windowSize = resolveVisible
+    ? Math.min(limit * SECTION_OVERFETCH + 1, MAX_HYDRATED_IDS)
+    : limit + 1;
 
   const groups = await dbRead.placement.groupBy({
     by: ['targetId'],
@@ -290,20 +316,22 @@ async function imagesForBook({
 }
 
 /**
- * The section's rows with their image attached, and rows whose image the feed
- * withheld dropped.
- *
- * Dropped rather than sent without a picture: a book is a browse surface and
- * nobody has to act on a row here, unlike the review queues, which keep a
- * withheld row so its escrow can still be answered.
- */
-/**
  * One section's hydration, done once and read twice.
  *
  * `resolveVisible` decides which of the overfetched rows survive; `attach` then
  * dresses the chosen ones. Both read the SAME map, so the rows the section kept
  * and the images it draws cannot come from two different answers to "may this be
  * seen" — and it is one `getAllImages` per section rather than two.
+ *
+ * `attach` drops a row whose image the feed withheld rather than sending it
+ * without a picture: a book is a browse surface and nobody has to act on a row
+ * here, unlike the review queues, which keep a withheld row so its escrow can
+ * still be answered.
+ *
+ * 🔴 One instance per SECTION. `byId` is overwritten on each `resolveVisible`,
+ * so two sections sharing an instance would have the second hydration erase the
+ * first and `attach` would find nothing for the loser — an empty row, not an
+ * error.
  */
 function sectionImages(browsingLevel: number, user?: SessionUser) {
   let byId = new Map<number, Awaited<ReturnType<typeof imagesForBook>>[number]>();
@@ -322,22 +350,22 @@ function sectionImages(browsingLevel: number, user?: SessionUser) {
   };
 }
 
+/**
+ * Hydrate rows that were already chosen — the paged drill-in, which does not
+ * overfetch and so has nothing to filter against first.
+ *
+ * Built on `sectionImages` rather than repeating its body: the decision to DROP
+ * a withheld row rather than keep it is a product call, and encoded twice it
+ * gets changed once and the tab and its drill-in start disagreeing.
+ */
 async function withImages<T extends { imageId: number }>(
   rows: T[],
   browsingLevel: number,
   user?: SessionUser
 ) {
-  const images = await imagesForBook({
-    ids: rows.map((row) => row.imageId),
-    browsingLevel,
-    user,
-  });
-  const byId = new Map(images.map((image) => [image.id, image]));
-
-  return rows.flatMap((row) => {
-    const image = byId.get(row.imageId);
-    return image ? [{ ...row, image }] : [];
-  });
+  const section = sectionImages(browsingLevel, user);
+  await section.resolveVisible(rows.map((row) => row.imageId));
+  return section.attach(rows);
 }
 
 /**

--- a/src/shared/utils/__tests__/sticker-book.test.ts
+++ b/src/shared/utils/__tests__/sticker-book.test.ts
@@ -1,3 +1,10 @@
+import {
+  STICKER_BOOK_MAX_COLUMNS,
+  STICKER_BOOK_OVERFETCH,
+  STICKER_BOOK_PAGE_LIMIT,
+  STICKER_BOOK_TAB_LIMIT,
+  STICKER_BOOK_TAB_ROWS,
+} from '~/shared/utils/sticker-book';
 import { describe, expect, it } from 'vitest';
 import { stickerBookAccess } from '~/shared/utils/sticker-book';
 
@@ -101,5 +108,29 @@ describe('stickerBookAccess', () => {
 
     expect(access.canViewBook).toBe(true);
     expect(access.canViewStickers).toBe(true);
+  });
+});
+
+describe('the grid constants, which are load-bearing on each other', () => {
+  it('fetches WHOLE ROWS of the grid, so the tab never draws a short last row', () => {
+    // 🔴 Written as the product, not as 14. The tab's fetch is a row COUNT: a
+    // limit that is not a whole multiple of the column ceiling leaves the last
+    // row short, which is the report this pair was written for (Ellie,
+    // 2026-08-24: "what's the two blank image spots for?").
+    expect(STICKER_BOOK_TAB_LIMIT).toBe(STICKER_BOOK_MAX_COLUMNS * STICKER_BOOK_TAB_ROWS);
+    expect(STICKER_BOOK_TAB_LIMIT % STICKER_BOOK_MAX_COLUMNS).toBe(0);
+  });
+
+  it("keeps the tab's candidate window inside the drill-in's first page", () => {
+    // 🔴 The tab overfetches; the drill-in does not. While the tab's window is a
+    // subset of page 1, "View all" always shows a superset of the row it was
+    // clicked from. Break this and the page can come back EMPTY under a row
+    // showing a full grid — and nothing else in the repo checks it, because the
+    // page size moves with none of the constants that would break it.
+    // Bare, because the failure already names both numbers:
+    // `expected 43 to be less than or equal to 30`.
+    expect(STICKER_BOOK_TAB_LIMIT * STICKER_BOOK_OVERFETCH + 1).toBeLessThanOrEqual(
+      STICKER_BOOK_PAGE_LIMIT
+    );
   });
 });

--- a/src/shared/utils/sticker-book.ts
+++ b/src/shared/utils/sticker-book.ts
@@ -10,6 +10,21 @@
  * the positive ("showStickerBook") would make every account that predates this
  * feature read as hidden.
  */
+/**
+ * Where the grid stops widening, and how much of it the profile tab shows.
+ *
+ * Seven is the ceiling every other grid on the site uses — `MasonryProvider`
+ * defaults `maxColumnCount` to 7 — and the tab's fetch is two full rows of it.
+ *
+ * 🔴 They live together because the fetch is a ROW COUNT wearing a number: a
+ * limit that is not a whole multiple of the ceiling leaves the tab's last row
+ * short, which is the report this pair was written for. Multiplied rather than
+ * written as 14 so the two cannot drift apart.
+ */
+export const STICKER_BOOK_MAX_COLUMNS = 7;
+export const STICKER_BOOK_TAB_ROWS = 2;
+export const STICKER_BOOK_TAB_LIMIT = STICKER_BOOK_MAX_COLUMNS * STICKER_BOOK_TAB_ROWS;
+
 export type StickerBookSettings = {
   hideStickerBook?: boolean;
   hidePurchasedStickers?: boolean;

--- a/src/shared/utils/sticker-book.ts
+++ b/src/shared/utils/sticker-book.ts
@@ -20,10 +20,26 @@
  * limit that is not a whole multiple of the ceiling leaves the tab's last row
  * short, which is the report this pair was written for. Multiplied rather than
  * written as 14 so the two cannot drift apart.
+ *
+ * 🔴 AND the tab's candidate window must stay inside the drill-in's first page:
+ * `TAB_LIMIT * OVERFETCH + 1 <= PAGE_LIMIT`. Today that is 29 <= 30 — one row of
+ * headroom. Break it and the tab can show cards that "View all" page 1 does not,
+ * which surfaces as "nothing here yet" under a full row. Raising the columns or
+ * the rows does NOT carry the page size with it; there is a test on this.
  */
 export const STICKER_BOOK_MAX_COLUMNS = 7;
 export const STICKER_BOOK_TAB_ROWS = 2;
 export const STICKER_BOOK_TAB_LIMIT = STICKER_BOOK_MAX_COLUMNS * STICKER_BOOK_TAB_ROWS;
+
+/** One page of the "View all" drill-in. */
+export const STICKER_BOOK_PAGE_LIMIT = 30;
+
+/**
+ * How far past the page a section looks so the image filter cannot under-fill
+ * it. Lives here rather than in the service so the containment invariant below
+ * can be asserted against the drill-in's page size.
+ */
+export const STICKER_BOOK_OVERFETCH = 2;
 
 export type StickerBookSettings = {
   hideStickerBook?: boolean;


### PR DESCRIPTION
Reported by Ellie in DM on 2026-08-24, with a screenshot:

> "what's the two blank image spots for?" … "I have way more stickered if you go to view all"

## What it was

Not a wrong count — there is no count label on these sections. Two things on one row: the grid had **no column ceiling** (bare `repeat(auto-fill, 280px)` in a container with no max width, so it added columns to the edge of the window), and the per-section fetch of 12 **could not fill the rows** — it isn't a whole multiple of the ceiling, and the window is on the *placements* while the images are filtered afterwards, so a section came back short whenever any of its images were unpublished.

## The change

**Use `MasonryContainer`, the thing every other grid on the site uses.** It caps at 7 columns and centres — but it snaps its width to an *exact column multiple* before centring, and that snap is the part that matters. It can't take a 280px card: its steps are generated in SCSS from hard-coded `320/16` with no prop path, and at 280 its container leaves room for an eighth card. So the card moves to `constants.cardSizes.image` and the gap to 16 — matching the rest of the site. That also **sidesteps rather than trips** `MasonryProvider` shadowing its own `gap` prop with a local `const gap = 16`.

**Draw only complete rows on the tab.** Bigger cards mean fewer columns, and no fixed count is flush at every width: **12 divides by 3, 4 and 6; 14 does not.** A count alone cannot fix this. The tab takes its column count from the same container that lays the grid out and trims to `floor(n / cols) * cols`. The remainder is not lost — "View all" is the whole section, and that page is deliberately **not** trimmed.

**Overfetch, so the image filter can't under-fill the row** — `limit * 2 + 1`, the shape `api/v1/collections` uses. Filtered against the *same* hydration the cards are drawn from, so the rows a section keeps and the images it draws can't come from two different answers to "may this be seen". One `getAllImages` per section instead of two.

## Measured

**Layout** — six viewports, gaps in the last row, before → after the whole-rows trim (same build otherwise):

| viewport | cols | before | after |
|---|---|---|---|
| 1440 | 3 | 1 gap | **0** |
| 1680 | 4 | 2 gaps | **0** |
| 1920 | 4 | 2 gaps | **0** |
| 2200 | 5 | 1 gap | **0** |
| 2560 | 6 | 4 gaps | **0** |
| 3000 | 7 | 0 gaps | **0** |

Gutters equal left and right at every width. "View all" verified **untrimmed** (21 cards, ragged tail — correct, it's the full list).

**Overfetch** — same request, `nemo474`: `placed 9 → 14`.

**The multiplier is measured, not picked.** Across all 1,463 production placement targets, **97.3%** survive the feed filter at full browsing level, so a 4× window multiplied hydration ~3.8× to recover an average of **0.4 rows**. Under the SFW clamp survival is 33.4% and some sections can't be filled by any multiplier — a short row to tolerate, not a number to raise.

**Latency**: on `main` the two `getAllImages` calls ran *serially* after the `Promise.all`; here they run inside it. The tab loses a full round trip despite each call being larger.

## Fixed from review

- **A latent 500 on a public endpoint.** `imagesForBook` passes `ids.length` as `getInfiniteImagesSchema`'s limit, capped at 200; a caller-supplied `limit` of 60 with a 4× window made 241 and threw, taking out the whole query. Reproduced in isolation (241 throws, 200 doesn't). Not reachable today — prod's largest section is 98. Clamped, and the smaller multiplier puts the ceiling at 121 anyway.
- **A false claim in a comment**: collections uses this overfetch shape; comics uses `(limit + 1) * 5`. Corrected.
- `withImages` now builds on `sectionImages` rather than repeating its body, so the drop-a-withheld-row decision is encoded once.

## Tests

**One of the new assertions could not fail.** `attach` drops any row absent from the hydration map, so every row was even by construction whatever the walk did — the parity check did no work. Replaced with the exact ordered id list. The fixture also now dispatches on `where`; without it both sections returned identical rows and sharing one hydration between them was invisible.

Four mutations verified failing, each naming the actual ids:

| mutation | prints |
|---|---|
| share one `sectionImages` | `expected [] to deeply equal [900, 902, …]` |
| walk reversed | `expected [928, 926, …]` |
| push `groups[0]` ×14 | `expected [900, 900, 900, …]` |
| overfetch removed | `expected […×8] to equal […×14]` |

⚠️ **The whole-rows trim has no test.** No `*.browser.test.tsx` was added, and those run in no CI job regardless. Its only evidence is the browser measurement above.

## Verification

- `pnpm run typecheck` — **0 type errors**
- `pnpm exec eslint` over all 6 changed files — **0 problems**
- `pnpm run test:unit:run` — `Test Files 1 failed | 1395 passed | 1 skipped (1397)`, `Tests 1 failed | 21878 passed | 27 skipped (21906)`

The one failure is `pageRunScrollContract.test.ts`, a Windows-only path-separator guard. **Pre-existing** — it fails identically with this diff stashed. `blocks.router.workflow.test.ts` collected **358** tests, so the submodule is initialised and the run was real.

No migration. No schema change.
