### PR TITLE
fix(moderator): record who edited a blocklist

### DIFF
--- a/apps/moderator/src/lib/server/__tests__/blocklist-remove.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/blocklist-remove.test.ts
@@ -165,6 +165,14 @@ vi.mock('../redis', () => ({
 }));
 vi.mock('../axiom', () => ({ logToAxiom: vi.fn() }));
 
+const recordModActivitySpy = vi.fn();
+vi.mock('../mod-activity', () => ({
+  recordModActivity: (...args: unknown[]) => recordModActivitySpy(...args),
+}));
+
+/** The moderator making the edit. Attribution is the whole point, so it is never a default. */
+const MOD_ID = 77;
+
 const { removeBlocklistItems, upsertBlocklist, getBlocklistDTO, BlocklistRowMismatchError } =
   await import('../blocklist.service');
 
@@ -196,6 +204,7 @@ const expectLockedInsideOneTransaction = () => {
 describe('removeBlocklistItems', () => {
   it('returns how many entries the row actually lost', async () => {
     const { count } = await removeBlocklistItems({
+      userId: MOD_ID,
       id: 1,
       type: 'EmailDomain',
       items: ['spam.example'],
@@ -207,7 +216,12 @@ describe('removeBlocklistItems', () => {
   });
 
   it('scopes the UPDATE to the type as well as the id', async () => {
-    await removeBlocklistItems({ id: 1, type: 'EmailDomain', items: ['spam.example'] });
+    await removeBlocklistItems({
+      userId: MOD_ID,
+      id: 1,
+      type: 'EmailDomain',
+      items: ['spam.example'],
+    });
 
     // The UPDATE runs only after the scoped SELECT already matched, so the fake resolves the same
     // row with or without this predicate. Nothing but reading the statement can see it.
@@ -219,6 +233,7 @@ describe('removeBlocklistItems', () => {
 
   it('returns 0 for an entry that is not on the list, and writes nothing', async () => {
     const { count } = await removeBlocklistItems({
+      userId: MOD_ID,
       id: 1,
       type: 'EmailDomain',
       items: ['never-added.example'],
@@ -231,6 +246,7 @@ describe('removeBlocklistItems', () => {
 
   it('returns 0 for a stale row id rather than reporting the submitted count', async () => {
     const { count } = await removeBlocklistItems({
+      userId: MOD_ID,
       id: 999,
       type: 'EmailDomain',
       items: ['spam.example'],
@@ -242,6 +258,7 @@ describe('removeBlocklistItems', () => {
 
   it('counts only the entries that were present, not the whole submission', async () => {
     const { count } = await removeBlocklistItems({
+      userId: MOD_ID,
       id: 1,
       type: 'EmailDomain',
       items: ['spam.example', 'never-added.example'],
@@ -252,6 +269,7 @@ describe('removeBlocklistItems', () => {
 
   it('refuses an id that belongs to a different type, leaving that row untouched', async () => {
     const { count } = await removeBlocklistItems({
+      userId: MOD_ID,
       id: 1,
       type: 'MessagePattern',
       items: ['spam.example'],
@@ -266,6 +284,7 @@ describe('removeBlocklistItems', () => {
 describe('upsertBlocklist', () => {
   it('merges into the row when the id and type agree, and counts what it gained', async () => {
     const { count } = await upsertBlocklist({
+      userId: MOD_ID,
       id: 1,
       type: 'EmailDomain',
       blocklist: ['New.Example'],
@@ -280,6 +299,7 @@ describe('upsertBlocklist', () => {
     // Two of the three are already on the list. Reporting 3 is the "the screen says it happened"
     // defect the removal count was fixed for, on the other half of the same page.
     const { count } = await upsertBlocklist({
+      userId: MOD_ID,
       id: 1,
       type: 'EmailDomain',
       blocklist: ['spam.example', 'junk.example', 'new.example'],
@@ -290,6 +310,7 @@ describe('upsertBlocklist', () => {
 
   it('reports 0 and writes nothing when every entry is already on the list', async () => {
     const { count } = await upsertBlocklist({
+      userId: MOD_ID,
       id: 1,
       type: 'EmailDomain',
       blocklist: ['spam.example'],
@@ -301,7 +322,12 @@ describe('upsertBlocklist', () => {
   });
 
   it('scopes the UPDATE to the type as well as the id', async () => {
-    await upsertBlocklist({ id: 1, type: 'EmailDomain', blocklist: ['new.example'] });
+    await upsertBlocklist({
+      userId: MOD_ID,
+      id: 1,
+      type: 'EmailDomain',
+      blocklist: ['new.example'],
+    });
 
     expect(updateSpy.mock.calls[0][0].wheres).toEqual([
       ['id', '=', 1],
@@ -311,7 +337,12 @@ describe('upsertBlocklist', () => {
 
   it('refuses an id belonging to another type instead of merging across lists', async () => {
     await expect(
-      upsertBlocklist({ id: 1, type: 'MessagePattern', blocklist: ['unfreeze your funds'] })
+      upsertBlocklist({
+        userId: MOD_ID,
+        id: 1,
+        type: 'MessagePattern',
+        blocklist: ['unfreeze your funds'],
+      })
     ).rejects.toBeInstanceOf(BlocklistRowMismatchError);
 
     expect(rows[1].data, 'the EmailDomain row must not gain a message pattern').toEqual([
@@ -327,7 +358,11 @@ describe('upsertBlocklist', () => {
     // `UsernameExact` is a tab with no row in production, so its adds arrive with no `id` — and an
     // unconditional insert there gives the type a second row whose entries are never enforced.
     // The same shape reaches every other tab from a stale form.
-    const { count } = await upsertBlocklist({ type: 'EmailDomain', blocklist: ['new.example'] });
+    const { count } = await upsertBlocklist({
+      userId: MOD_ID,
+      type: 'EmailDomain',
+      blocklist: ['new.example'],
+    });
 
     expect(count).toBe(1);
     expect(
@@ -344,7 +379,11 @@ describe('upsertBlocklist', () => {
     // nobody reads: banner says "Added 1 item", cache busted, page reloads unchanged.
     addDuplicateEmailDomainRow();
 
-    await upsertBlocklist({ type: 'EmailDomain', blocklist: ['new.example'] });
+    await upsertBlocklist({
+      userId: MOD_ID,
+      type: 'EmailDomain',
+      blocklist: ['new.example'],
+    });
 
     expect(rows[1].data, 'the lowest row is the one that must gain the entry').toContain(
       'new.example'
@@ -355,7 +394,11 @@ describe('upsertBlocklist', () => {
   it('asks for id order rather than relying on the row it happens to get back', async () => {
     addDuplicateEmailDomainRow();
 
-    await upsertBlocklist({ type: 'EmailDomain', blocklist: ['new.example'] });
+    await upsertBlocklist({
+      userId: MOD_ID,
+      type: 'EmailDomain',
+      blocklist: ['new.example'],
+    });
 
     expect(orderBys, 'the locking read must order by id ASC').toContainEqual(['id', 'asc']);
   });
@@ -364,6 +407,7 @@ describe('upsertBlocklist', () => {
     // More than one item, because `return items.length` and `return 1` are indistinguishable on a
     // single-entry insert — and seeding a brand-new tab from a pasted list is exactly that case.
     const { count } = await upsertBlocklist({
+      userId: MOD_ID,
       type: 'UsernameExact',
       blocklist: ['Scammer', 'Phisher', 'Spammer'],
     });
@@ -374,6 +418,92 @@ describe('upsertBlocklist', () => {
       type: 'UsernameExact',
       data: ['scammer', 'phisher', 'spammer'],
     });
+  });
+});
+
+describe('moderator attribution', () => {
+  // An edit to a moderation control with no ModActivity row is unattributable after the fact: the
+  // Blocklist row carries only `updatedAt`, so who added or removed an entry is recoverable from
+  // nothing else. Deleting these calls loses that with no other symptom.
+  it('records who added entries, against the row that changed', async () => {
+    await upsertBlocklist({
+      userId: MOD_ID,
+      id: 1,
+      type: 'EmailDomain',
+      blocklist: ['new.example'],
+    });
+
+    expect(recordModActivitySpy).toHaveBeenCalledWith({
+      userId: MOD_ID,
+      entityType: 'blocklist',
+      entityId: 1,
+      activity: 'add',
+    });
+  });
+
+  it('records the INSERTED row id when the type had no row yet', async () => {
+    // The id is only knowable from the insert's own RETURNING. Passing the submitted (absent) id
+    // here would record `undefined` against a row that does exist.
+    await upsertBlocklist({
+      userId: MOD_ID,
+      type: 'UsernameExact',
+      blocklist: ['scammer'],
+    });
+
+    const newId = Number(Object.keys(rows).find((id) => rows[Number(id)].type === 'UsernameExact'));
+    expect(newId).toBeGreaterThan(0);
+    expect(recordModActivitySpy).toHaveBeenCalledWith({
+      userId: MOD_ID,
+      entityType: 'blocklist',
+      entityId: newId,
+      activity: 'add',
+    });
+  });
+
+  it('records who removed entries, against the row that changed', async () => {
+    await removeBlocklistItems({
+      userId: MOD_ID,
+      id: 1,
+      type: 'EmailDomain',
+      items: ['spam.example'],
+    });
+
+    expect(recordModActivitySpy).toHaveBeenCalledWith({
+      userId: MOD_ID,
+      entityType: 'blocklist',
+      entityId: 1,
+      activity: 'remove',
+    });
+  });
+
+  it('records nothing when the write changed nothing', async () => {
+    await upsertBlocklist({
+      userId: MOD_ID,
+      id: 1,
+      type: 'EmailDomain',
+      blocklist: ['spam.example'],
+    });
+    await removeBlocklistItems({
+      userId: MOD_ID,
+      id: 1,
+      type: 'EmailDomain',
+      items: ['never-added.example'],
+    });
+
+    expect(recordModActivitySpy).not.toHaveBeenCalled();
+  });
+
+  it('records nothing when the row belongs to another type', async () => {
+    await expect(
+      upsertBlocklist({
+        userId: MOD_ID,
+        id: 1,
+        type: 'MessagePattern',
+        blocklist: ['unfreeze your funds'],
+      })
+    ).rejects.toBeInstanceOf(BlocklistRowMismatchError);
+
+    expect(recordModActivitySpy).not.toHaveBeenCalled();
   });
 });
 
@@ -397,7 +527,12 @@ describe('the shared cache key', () => {
     // A snapshot write is an unserialised read-modify-write over the artifact every reader
     // enforces from, so two edits the row lock correctly serialised can still land their cache
     // writes in the other order and leave the loser's list under a month TTL. Deletes commute.
-    await removeBlocklistItems({ id: 1, type: 'EmailDomain', items: ['spam.example'] });
+    await removeBlocklistItems({
+      userId: MOD_ID,
+      id: 1,
+      type: 'EmailDomain',
+      items: ['spam.example'],
+    });
 
     expect(delSpy).toHaveBeenCalledWith('system:blocklist:EmailDomain');
     expect(
@@ -413,6 +548,7 @@ describe('the shared cache key', () => {
     delSpy.mockRejectedValueOnce(new Error('redis down'));
 
     const { count, cacheStale } = await removeBlocklistItems({
+      userId: MOD_ID,
       id: 1,
       type: 'EmailDomain',
       items: ['junk.example'],
@@ -424,7 +560,12 @@ describe('the shared cache key', () => {
   });
 
   it('is not busted when the write changed nothing', async () => {
-    await removeBlocklistItems({ id: 1, type: 'EmailDomain', items: ['never-added.example'] });
+    await removeBlocklistItems({
+      userId: MOD_ID,
+      id: 1,
+      type: 'EmailDomain',
+      items: ['never-added.example'],
+    });
 
     expect(delSpy).not.toHaveBeenCalled();
   });

--- a/apps/moderator/src/lib/server/blocklist.service.ts
+++ b/apps/moderator/src/lib/server/blocklist.service.ts
@@ -132,7 +132,9 @@ export class BlocklistRowMismatchError extends Error {
 /** What a write did, and whether readers will see it before the month TTL expires. */
 export type BlocklistWriteResult = { count: number; cacheStale: boolean };
 
-/** What the transaction changed, and which row it changed — `recordModActivity` needs the row id. */
+/** What the transaction changed, and which row it changed — `recordModActivity` needs the row id.
+ *  Absent when no row matched at all: the submitted id names no row of this type there, so it must
+ *  not be reached for as a stand-in. */
 type Written = { count: number; rowId: number };
 
 /**
@@ -228,9 +230,9 @@ export async function removeBlocklistItems({
 
   // Same lock and the same reason as `upsertBlocklist`: without it two chips removed in quick
   // succession each filtered the same pre-state and the second write put the first one back.
-  const removed = await dbWrite.transaction().execute(async (trx): Promise<Written> => {
+  const removed = await dbWrite.transaction().execute(async (trx): Promise<Written | undefined> => {
     const row = await readRowForWrite(trx, type, id);
-    if (!row) return { count: 0, rowId: id };
+    if (!row) return undefined;
 
     const filtered = row.data.filter((item) => !lower.includes(item));
     const count = row.data.length - filtered.length;
@@ -245,7 +247,7 @@ export async function removeBlocklistItems({
     return { count, rowId: row.id };
   });
 
-  if (removed.count === 0) return { count: 0, cacheStale: false };
+  if (!removed || removed.count === 0) return { count: 0, cacheStale: false };
 
   const cacheStale = !(await bustCache(type));
   await recordModActivity({

--- a/apps/moderator/src/lib/server/blocklist.service.ts
+++ b/apps/moderator/src/lib/server/blocklist.service.ts
@@ -133,8 +133,8 @@ export class BlocklistRowMismatchError extends Error {
 export type BlocklistWriteResult = { count: number; cacheStale: boolean };
 
 /** What the transaction changed, and which row it changed — `recordModActivity` needs the row id.
- *  Absent when no row matched at all: the submitted id names no row of this type there, so it must
- *  not be reached for as a stand-in. */
+ *  Absent when a submitted id matched no row of the type: the id names no row there, so it must not
+ *  be reached for as a stand-in. */
 type Written = { count: number; rowId: number };
 
 /**
@@ -232,6 +232,10 @@ export async function removeBlocklistItems({
   // succession each filtered the same pre-state and the second write put the first one back.
   const removed = await dbWrite.transaction().execute(async (trx): Promise<Written | undefined> => {
     const row = await readRowForWrite(trx, type, id);
+    // `undefined` means a quiet zero here, and a thrown `BlocklistRowMismatchError` in
+    // `upsertBlocklist` — same signature, opposite reading. Deliberate: the remove action turns a
+    // zero into its own 409, and has no try/catch, so copying upsert's `throw` guard across turns
+    // that message into a 500.
     if (!row) return undefined;
 
     const filtered = row.data.filter((item) => !lower.includes(item));

--- a/apps/moderator/src/lib/server/blocklist.service.ts
+++ b/apps/moderator/src/lib/server/blocklist.service.ts
@@ -2,6 +2,7 @@ import type { Transaction } from 'kysely';
 import type { DB } from '@civitai/db-schema/kysely';
 import { REDIS_KEYS, type RedisKeyTemplateCache } from '@civitai/redis';
 import { dbWrite } from './db';
+import { recordModActivity } from './mod-activity';
 import { logToAxiom } from './axiom';
 import { getRedis } from './redis';
 
@@ -131,6 +132,9 @@ export class BlocklistRowMismatchError extends Error {
 /** What a write did, and whether readers will see it before the month TTL expires. */
 export type BlocklistWriteResult = { count: number; cacheStale: boolean };
 
+/** What the transaction changed, and which row it changed — `recordModActivity` needs the row id. */
+type Written = { count: number; rowId: number };
+
 /**
  * Adds entries, returning how many the row actually GAINED — not how many were submitted. Since
  * both branches dedupe, re-adding entries that are already on the list changes nothing, and the
@@ -143,10 +147,12 @@ export async function upsertBlocklist({
   id,
   type,
   blocklist,
+  userId,
 }: {
   id?: number;
   type: string;
   blocklist: string[];
+  userId: number;
 }): Promise<BlocklistWriteResult> {
   const items = [
     ...new Set(blocklist.map((item) => item.toLowerCase()).filter((x) => x.length > 0)),
@@ -157,24 +163,24 @@ export async function upsertBlocklist({
   // write restored what the earlier one dropped, both reporting success. The other writer is the
   // main app's weekly cron, editing this same column through its own client, so the lock has to be
   // in the database rather than in either app.
-  const added = await dbWrite.transaction().execute(async (trx) => {
+  const added = await dbWrite.transaction().execute(async (trx): Promise<Written | undefined> => {
     const existing = await readRowForWrite(trx, type, id);
 
     if (!existing) {
       // An `id` that names no row of this type is a stale tab or a hand-crafted post. Refuse; do
       // NOT fall through to an insert, which would add a second row for the type.
       if (id !== undefined) return undefined;
-      await trx
+      const inserted = await trx
         .insertInto('Blocklist')
         .values({ type, data: items, updatedAt: new Date() })
         .returning(['id'])
         .executeTakeFirstOrThrow();
-      return items.length;
+      return { count: items.length, rowId: inserted.id };
     }
 
     const next = [...new Set([...existing.data, ...items])];
     const gained = next.length - existing.data.length;
-    if (gained === 0) return 0;
+    if (gained === 0) return { count: 0, rowId: existing.id };
 
     await trx
       .updateTable('Blocklist')
@@ -184,11 +190,20 @@ export async function upsertBlocklist({
       .where('id', '=', existing.id)
       .where('type', '=', type)
       .executeTakeFirstOrThrow();
-    return gained;
+    return { count: gained, rowId: existing.id };
   });
 
   if (added === undefined) throw new BlocklistRowMismatchError();
-  return { count: added, cacheStale: added > 0 ? !(await bustCache(type)) : false };
+  if (added.count === 0) return { count: 0, cacheStale: false };
+
+  const cacheStale = !(await bustCache(type));
+  await recordModActivity({
+    userId,
+    entityType: 'blocklist',
+    entityId: added.rowId,
+    activity: 'add',
+  });
+  return { count: added.count, cacheStale };
 }
 
 /**
@@ -202,22 +217,24 @@ export async function removeBlocklistItems({
   id,
   type,
   items,
+  userId,
 }: {
   id: number;
   type: string;
   items: string[];
+  userId: number;
 }): Promise<BlocklistWriteResult> {
   const lower = items.map((x) => x.toLowerCase());
 
   // Same lock and the same reason as `upsertBlocklist`: without it two chips removed in quick
   // succession each filtered the same pre-state and the second write put the first one back.
-  const removed = await dbWrite.transaction().execute(async (trx) => {
+  const removed = await dbWrite.transaction().execute(async (trx): Promise<Written> => {
     const row = await readRowForWrite(trx, type, id);
-    if (!row) return 0;
+    if (!row) return { count: 0, rowId: id };
 
     const filtered = row.data.filter((item) => !lower.includes(item));
     const count = row.data.length - filtered.length;
-    if (count === 0) return 0;
+    if (count === 0) return { count: 0, rowId: row.id };
 
     await trx
       .updateTable('Blocklist')
@@ -225,10 +242,19 @@ export async function removeBlocklistItems({
       .where('id', '=', row.id)
       .where('type', '=', type)
       .executeTakeFirstOrThrow();
-    return count;
+    return { count, rowId: row.id };
   });
 
-  return { count: removed, cacheStale: removed > 0 ? !(await bustCache(type)) : false };
+  if (removed.count === 0) return { count: 0, cacheStale: false };
+
+  const cacheStale = !(await bustCache(type));
+  await recordModActivity({
+    userId,
+    entityType: 'blocklist',
+    entityId: removed.rowId,
+    activity: 'remove',
+  });
+  return { count: removed.count, cacheStale };
 }
 
 /**

--- a/apps/moderator/src/routes/blocklists/+page.server.ts
+++ b/apps/moderator/src/routes/blocklists/+page.server.ts
@@ -31,7 +31,7 @@ const isType = (t: string): t is (typeof BLOCKLIST_TYPES)[number] =>
   (BLOCKLIST_TYPES as readonly string[]).includes(t);
 
 export const actions: Actions = {
-  add: async ({ request }) => {
+  add: async ({ request, locals }) => {
     const form = await request.formData();
     const type = String(form.get('type') ?? '');
     const id = parseRowId(form.get('id'));
@@ -45,7 +45,7 @@ export const actions: Actions = {
     // statement itself rather than here — see `upsertBlocklist`.
     let result;
     try {
-      result = await upsertBlocklist({ id, type, blocklist: items });
+      result = await upsertBlocklist({ id, type, blocklist: items, userId: locals.user.id });
     } catch (error) {
       if (error instanceof BlocklistRowMismatchError)
         return fail(409, {
@@ -64,7 +64,7 @@ export const actions: Actions = {
 
     return { success: true, action: 'add', count: result.count, cacheStale: result.cacheStale };
   },
-  remove: async ({ request }) => {
+  remove: async ({ request, locals }) => {
     const form = await request.formData();
     const type = String(form.get('type') ?? '');
     const id = parseRowId(form.get('id'));
@@ -74,7 +74,7 @@ export const actions: Actions = {
     if (!id) return fail(400, { error: 'Nothing to remove from.' });
     if (items.length === 0) return fail(400, { error: 'No items to remove.' });
 
-    const result = await removeBlocklistItems({ id, type, items });
+    const result = await removeBlocklistItems({ id, type, items, userId: locals.user.id });
     // A submitted-but-unmatched removal is a failure, not a quiet "Removed 0 items." The list is
     // served from a month-long Redis cache, so the likeliest cause is that this page is stale. An
     // id belonging to another type lands here too.


### PR DESCRIPTION
Closes ClickUp `868kv0vyk`.

## What

`upsertBlocklist` and `removeBlocklistItems` in `apps/moderator` wrote no `ModActivity` row, while twelve sibling services in the same app do. The `Blocklist` row carries only `updatedAt`, so who added or removed an entry on a moderation control was recoverable from nothing.

Both writers now call `recordModActivity({ entityType: 'blocklist', entityId: <row id>, activity: 'add' | 'remove' })`, matching the sibling shape (`model3d.service.ts`, `moderation-memory.service.ts`).

Details worth reading:

- Recorded **after** the transaction commits, not inside it, and only when the write actually changed the row (`count > 0`). A no-op add or an unmatched removal records nothing.
- The insert branch records the **inserted** row id, which is only knowable from the insert's own `RETURNING` — the submitted id is absent in that case.
- `entityType: 'blocklist'` has no entry in `entity-url.ts`, so the row renders as unlinked text, which is correct: a blocklist has no standalone page.
- Verified against prod: `ModActivity` has **no** unique index (pkey plus three non-unique), so the append-only `onConflict(doNothing)` insert keeps every event — repeat edits to the same row each get a row.

## Verification

- `svelte-check`: `COMPLETED 9354 FILES 0 ERRORS 0 WARNINGS`. Positive control: a bad `userId` type gives `1 ERRORS`, exit 1.
- `apps/moderator` eslint: clean, exit 0.
- `vitest run --project 'app:*'`: `Test Files 85 passed (85)`, `Tests 891 passed | 35 skipped (926)`, exit 0.
- Controls on the new tests: deleting both `recordModActivity` calls fails 3 of them; recording the submitted id instead of the inserted one on the insert branch fails 1.

No migration. Nothing was exercised against the moderator dev server, whose `DATABASE_URL` points at production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)