### PR TITLE
fix(trpc): make a resolver-set edge-cache opt-out actually take effect

### DIFF
--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -14,6 +14,7 @@ import { isClientAbortError } from '~/server/utils/errorHandling';
 import { appRouter } from '~/server/routers';
 import { runWithSerializeCtx, serializeCtxFromRequest } from '~/server/logging/trpc-serialize-log';
 import { getTrpcMaxBatchSize } from '~/server/trpc/batch-cap';
+import { willEdgeCache } from '~/server/trpc/edge-cache-headers';
 
 export const config = {
   api: {
@@ -51,16 +52,18 @@ const trpcHandler = createNextApiHandler({
   maxBatchSize: getTrpcMaxBatchSize(),
   responseMeta: ({ ctx, type, errors }) => {
     const headers: Record<string, string> = {};
-    const willEdgeCache = ctx?.cache && !!ctx?.cache.edgeTTL && ctx?.cache.edgeTTL > 0;
-    if (willEdgeCache && type === 'query' && errors.length === 0) {
-      ctx.res?.removeHeader('Set-Cookie');
+    // Single-sourced in `~/server/trpc/edge-cache-headers` so that tests asserting a
+    // middleware chain's cache outcome import THIS predicate instead of re-declaring it.
+    const cache = ctx?.cache;
+    if (willEdgeCache(cache) && type === 'query' && errors.length === 0) {
+      ctx?.res?.removeHeader('Set-Cookie');
       headers['Cache-Control'] = [
         'public',
-        `max-age=${ctx.cache.browserTTL ?? 0}`,
-        `s-maxage=${ctx.cache.edgeTTL ?? 0}`,
-        `stale-while-revalidate=${ctx.cache.staleWhileRevalidate ?? 0}`,
+        `max-age=${cache.browserTTL ?? 0}`,
+        `s-maxage=${cache.edgeTTL ?? 0}`,
+        `stale-while-revalidate=${cache.staleWhileRevalidate ?? 0}`,
       ].join(', ');
-      if (ctx.cache.tags) headers['Cache-Tag'] = ctx.cache.tags.join(', ');
+      if (cache.tags) headers['Cache-Tag'] = cache.tags.join(', ');
     }
 
     return Object.keys(headers).length > 0 ? { headers } : {};

--- a/src/server/__tests__/middleware.trpc.edge-cache-precedence.test.ts
+++ b/src/server/__tests__/middleware.trpc.edge-cache-precedence.test.ts
@@ -87,9 +87,17 @@ function rootCtx() {
     acceptableOrigin: true,
     tokenScope: TokenScope.Full,
     cache: { ...SENTINEL, canCache: true, skip: false },
-    // `applyDomainFeature` (src/server/trpc.ts) dereferences this unguarded, ahead of
-    // `edgeCacheIt`, on every `publicProcedure`. Without it the call dies with a
-    // TypeError before the middleware under test runs.
+    // Present for context realism only — MEASURED INERT for this file: delete this key
+    // and all 3 tests here still pass. `applyDomainFeature` (src/server/trpc.ts) does
+    // read `ctx.features.canViewNsfw`, but only on the authenticated arm: with `ctx.req`
+    // undefined, `parseVerifiedBotHeader(undefined)` returns null and the `&&`
+    // short-circuits before the property is reached, and the anonymous branch of
+    // `maxAllowed` never reads it either. Every case in this file is anonymous.
+    //
+    // Said plainly because the previous version of this comment claimed omitting the key
+    // "dies with a TypeError before the middleware under test runs" — that is false here,
+    // and it is the same defect (a test-context key documented as load-bearing that the
+    // code path never touches) that this PR exists to fix.
     features: { canViewNsfw: false },
   };
 }

--- a/src/server/__tests__/middleware.trpc.edge-cache-precedence.test.ts
+++ b/src/server/__tests__/middleware.trpc.edge-cache-precedence.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// `edgeCacheIt` returns early when `!isProd`, so the TTL-assigning block only runs with
+// this mocked true. Same shape as `middleware.trpc.test.ts`.
+vi.mock('~/env/other', () => ({
+  isDev: false,
+  isProd: true,
+  isTest: false,
+  isPreview: false,
+}));
+
+vi.mock('~/env/client', () => ({
+  env: {
+    NEXT_PUBLIC_BASE_URL: 'http://localhost:3000',
+    NEXT_PUBLIC_CIVITAI_LINK: 'http://localhost:3000',
+  },
+  formatErrors: () => [],
+}));
+
+import type { Context } from '~/server/createContext';
+import { edgeCacheIt } from '~/server/middleware.trpc';
+import { createCallerFactory, publicProcedure, router } from '~/server/trpc';
+import { willEdgeCache } from '~/server/trpc/edge-cache-headers';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * PRECEDENCE between `edgeCacheIt`'s two TTL-overriding inputs: a resolver-set
+ * `ctx.cache.skip` versus a configured `expireAt`.
+ *
+ * `edgeCacheIt` computes the request TTL in three steps:
+ *
+ *     let reqTTL = ctx.cache.skip ? 0 : ttl;                      // incoming skip
+ *     if (expireAt) reqTTL = Math.floor(...);                     // scheduled expiry
+ *     const result = await next();
+ *     if (ctx.cache?.skip) reqTTL = 0;                            // resolver-set skip
+ *
+ * Before the third line existed, `expireAt` silently overrode a pre-set `skip`. It now
+ * loses to it. That is the intended ordering, not an accident of where the line landed:
+ * `expireAt` says "this content goes stale at time T", which is a statement about content
+ * that IS cacheable; `skip` says "this particular response must not be cached at all".
+ * The stronger claim wins — a response the resolver declared uncacheable does not become
+ * cacheable because someone also scheduled when it should expire.
+ *
+ * ── WHY A SYNTHETIC PROCEDURE ───────────────────────────────────────────────────────────
+ * `expireAt` has ZERO production call sites today (`git grep` finds only its type
+ * declaration and its single use inside `edgeCacheIt`), so there is no real procedure that
+ * combines it with a resolver-set `skip` and therefore no cross-file relationship to pin.
+ * The dimension is real regardless — the option is exported and reachable — so it is
+ * exercised here on a purpose-built router rather than by bending an existing one. Note
+ * this is a synthetic PROCEDURE driven by the real `createCallerFactory` runner, not a
+ * hand-invoked middleware: the ordering under test is an ordering of real chain steps, so
+ * the chain is real and only the procedure is synthetic.
+ *
+ * Without this file the mutant `if (ctx.cache?.skip && !expireAt) reqTTL = 0;` — i.e. a
+ * restoration of the old precedence — survives the whole suite.
+ */
+
+/** Comfortably distinguishable from the `ttl` below and from any context default. */
+const EXPIRE_IN_SECONDS = 900;
+const expireAt = () => new Date(Date.now() + EXPIRE_IN_SECONDS * 1000);
+
+/** Not 0, not 900, not a context default. */
+const TTL = 60;
+
+const SENTINEL = { browserTTL: 111, edgeTTL: 222, staleWhileRevalidate: 333 };
+
+const testRouter = router({
+  // Resolver only learns its response is uncacheable once it has produced one — the
+  // shape `home-block.getHomeBlock` has in production, plus an `expireAt`.
+  optsOutAfterResolving: publicProcedure
+    .use(edgeCacheIt({ ttl: TTL, expireAt }))
+    .query(({ ctx }) => {
+      if (ctx.cache) ctx.cache.skip = true;
+      return { resolved: true };
+    }),
+  // Control: identical procedure, identical `expireAt`, resolver does NOT opt out.
+  keepsTheScheduledExpiry: publicProcedure
+    .use(edgeCacheIt({ ttl: TTL, expireAt }))
+    .query(() => ({ resolved: true })),
+});
+
+const createCaller = createCallerFactory(testRouter);
+
+function rootCtx() {
+  return {
+    user: undefined,
+    acceptableOrigin: true,
+    tokenScope: TokenScope.Full,
+    cache: { ...SENTINEL, canCache: true, skip: false },
+    // `applyDomainFeature` (src/server/trpc.ts) dereferences this unguarded, ahead of
+    // `edgeCacheIt`, on every `publicProcedure`. Without it the call dies with a
+    // TypeError before the middleware under test runs.
+    features: { canViewNsfw: false },
+  };
+}
+
+describe('edgeCacheIt — skip vs expireAt precedence', () => {
+  it('CONTROL: expireAt drives the TTL when the resolver does not opt out', async () => {
+    const root = rootCtx();
+
+    await createCaller(root as unknown as Context).keepsTheScheduledExpiry();
+
+    // Proof `expireAt` is genuinely in play on these procedures — without this the
+    // opt-out assertion below could pass on a chain where `expireAt` never ran, and the
+    // `&& !expireAt` mutant would have nothing to disagree with.
+    expect(root.cache.edgeTTL).toBeGreaterThan(TTL);
+    expect(root.cache.edgeTTL).toBeLessThanOrEqual(EXPIRE_IN_SECONDS);
+    expect(root.cache.edgeTTL).toBeGreaterThanOrEqual(EXPIRE_IN_SECONDS - 5);
+    expect(root.cache.edgeTTL).not.toBe(SENTINEL.edgeTTL);
+    expect(willEdgeCache(root.cache)).toBe(true);
+  });
+
+  it('a resolver-set skip BEATS expireAt — the TTL is zeroed, not the scheduled expiry', async () => {
+    const root = rootCtx();
+
+    await createCaller(root as unknown as Context).optsOutAfterResolving();
+
+    expect(root.cache.edgeTTL).toBe(0);
+    expect(root.cache.browserTTL).toBe(0);
+    expect(willEdgeCache(root.cache)).toBe(false);
+  });
+
+  it('an INCOMING skip also beats expireAt', async () => {
+    const root = rootCtx();
+    root.cache.skip = true;
+
+    await createCaller(root as unknown as Context).keepsTheScheduledExpiry();
+
+    // The pre-`next()` read is overwritten by the `expireAt` line immediately below it,
+    // so this outcome comes entirely from the post-resolver re-read. A caller that set
+    // `skip` upstream (`model.getAll`) therefore gets the same answer either way.
+    expect(root.cache.edgeTTL).toBe(0);
+    expect(willEdgeCache(root.cache)).toBe(false);
+  });
+});

--- a/src/server/controllers/home-block.controller.ts
+++ b/src/server/controllers/home-block.controller.ts
@@ -145,7 +145,19 @@ export const getHomeBlocksByIdHandler = async ({
       user: ctx.user,
     });
 
-    if (homeBlock?.type === 'Announcement') ctx.cache.skip = true;
+    // `&& ctx.cache` because `ctx.cache` really is null on the SSG prefetch path —
+    // `createServerSideHelpers` builds the context with `cache: null as any`
+    // (`~/server/utils/server-side-helpers.ts`), and that `as any` is why `strict: true`
+    // does not flag the unguarded form. Today only `getHomeBlocks` (the list) is
+    // prefetched (`src/pages/index.tsx`), so this line is not reachable from there and
+    // the guard is precautionary; it is here so that reachability stops being the thing
+    // holding it up.
+    //
+    // Sibling writers of `ctx.cache` from inside a resolver are INCONSISTENT about this,
+    // so do not take any single one as the convention: `system.router.getBenignPhrases`
+    // and `model.controller.getModelsPagedSimpleHandler` both guard, while
+    // `model.controller.getModelsInfiniteHandler` does not.
+    if (homeBlock?.type === HomeBlockType.Announcement && ctx.cache) ctx.cache.skip = true;
 
     if (!homeBlock) {
       throw throwNotFoundError('Home block not found');

--- a/src/server/middleware.trpc.ts
+++ b/src/server/middleware.trpc.ts
@@ -295,6 +295,12 @@ export function edgeCacheIt({ ttl = 60 * 3, expireAt, tags }: EdgeCacheItProps =
     if (expireAt) reqTTL = Math.floor((expireAt().getTime() - Date.now()) / 1000);
 
     const result = await next();
+    // Re-read `skip` now that the resolver has run. The read above happens before
+    // `next()`, so a resolver that only knows its response is uncacheable once it has
+    // produced it (e.g. `home-block.getHomeBlock` on an Announcement block) sets a flag
+    // nothing looks at again. `canCache` is already read on the line below, after the
+    // resolver, and this puts `skip` on the same footing.
+    if (ctx.cache?.skip) reqTTL = 0;
     if (result.ok && ctx.cache?.canCache) {
       ctx.cache.browserTTL = isProd ? Math.min(60, reqTTL) : 0;
       ctx.cache.edgeTTL = reqTTL;

--- a/src/server/middleware.trpc.ts
+++ b/src/server/middleware.trpc.ts
@@ -300,6 +300,18 @@ export function edgeCacheIt({ ttl = 60 * 3, expireAt, tags }: EdgeCacheItProps =
     // produced it (e.g. `home-block.getHomeBlock` on an Announcement block) sets a flag
     // nothing looks at again. `canCache` is already read on the line below, after the
     // resolver, and this puts `skip` on the same footing.
+    //
+    // PRECEDENCE, deliberate and now pinned by test: `skip` BEATS `expireAt`. Sitting
+    // after the `expireAt` assignment above, this line overrides a scheduled expiry
+    // rather than being overridden by it. That is the intended ordering — `expireAt`
+    // says "this content goes stale at time T", which is a statement about content that
+    // IS cacheable, whereas `skip` says "this particular response must not be cached at
+    // all". A response the resolver has declared uncacheable does not become cacheable
+    // because someone also scheduled when it should expire; the stronger claim wins.
+    // (Before this line existed the ordering was the other way round and nothing said
+    // so, so it was accidental rather than chosen.) Reintroducing an `expireAt` guard
+    // here — `if (ctx.cache?.skip && !expireAt)` — is caught by
+    // `middleware.trpc.edge-cache-precedence.test.ts`.
     if (ctx.cache?.skip) reqTTL = 0;
     if (result.ok && ctx.cache?.canCache) {
       ctx.cache.browserTTL = isProd ? Math.min(60, reqTTL) : 0;

--- a/src/server/routers/__tests__/home-block.router.edge-cache-chain.test.ts
+++ b/src/server/routers/__tests__/home-block.router.edge-cache-chain.test.ts
@@ -104,8 +104,9 @@ type Ctx = {
   tokenScope: number;
   cache: CacheState;
   // Read by `applyDomainFeature` (src/server/trpc.ts) as `ctx.features.canViewNsfw`,
-  // ahead of the cache middleware. Omitting it is not "a permissive default" — it is a
-  // TypeError that ends the call before `edgeCacheIt` runs.
+  // ahead of the cache middleware — but ONLY on the authenticated arm. Measured: drop
+  // this key and 7 of the 9 tests here still pass; the two that fail are exactly the
+  // `user: { id: 1 }` cases.
   features: { canViewNsfw: boolean };
 };
 
@@ -134,15 +135,17 @@ function rootCtx(
     cache: { ...ttls, canCache: true, skip: false },
     // ⚠️ `canViewNsfw`, NOT `alternateHome`. An earlier revision of this file set
     // `features: { alternateHome: true }` and documented it as what satisfies
-    // `isFlagProtected('alternateHome')`. That was wrong in both directions, and only
-    // measuring it showed so: `isFlagProtected` resolves the flag through
-    // `getFeatureFlags(ctx)` (`~/server/services/feature-flags.service.ts`), which
-    // computes from the session/Flipt and never reads a `ctx.features` property — so the
-    // key was INERT, and setting it to `false` does NOT produce a FORBIDDEN. What
-    // `ctx.features` is actually needed for is `applyDomainFeature`, which dereferences
-    // `ctx.features.canViewNsfw` unguarded; drop the object and the call dies with a
-    // TypeError before `edgeCacheIt` is reached. `false` is the realistic value for the
-    // anonymous public caller these tests model.
+    // `isFlagProtected('alternateHome')`. That was wrong, and only measuring it showed
+    // so: `isFlagProtected` resolves the flag through `getFeatureFlags(ctx)`
+    // (`~/server/services/feature-flags.service.ts`), which computes from the
+    // session/Flipt and never reads a `ctx.features` property — so the key was INERT,
+    // and setting it to `false` does NOT produce a FORBIDDEN.
+    //
+    // `canViewNsfw` is the key `ctx.features` is genuinely needed for, via
+    // `applyDomainFeature` — but be exact about the scope, because the first attempt at
+    // THIS comment overreached too: it is reached only on the AUTHENTICATED arm (see the
+    // type above for the measurement). `false` is the realistic value for the anonymous
+    // public caller most of these tests model.
     features: { canViewNsfw: false },
   };
 }

--- a/src/server/routers/__tests__/home-block.router.edge-cache-chain.test.ts
+++ b/src/server/routers/__tests__/home-block.router.edge-cache-chain.test.ts
@@ -22,8 +22,7 @@ vi.mock('~/env/client', () => ({
   formatErrors: () => [],
 }));
 
-// tRPC's `_def.middlewares` ends with the wrapper that invokes the resolver, so running
-// the real chain runs the real handler — which is the point: the flag under test is set
+// The real caller runs the real handler — which is the point: the flag under test is set
 // by the handler. Stub only the one service call it makes so the chain completes without
 // a database.
 import type * as HomeBlockService from '~/server/services/home-block.service';
@@ -35,12 +34,16 @@ vi.mock('~/server/services/home-block.service', async (importOriginal) => ({
   getHomeBlockById,
 }));
 
+import type { Context } from '~/server/createContext';
 import { homeBlockRouter } from '~/server/routers/home-block.router';
+import { createCallerFactory } from '~/server/trpc';
+import { willEdgeCache } from '~/server/trpc/edge-cache-headers';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { HomeBlockType } from '~/shared/utils/prisma/enums';
 
 /**
- * `homeBlock.getHomeBlock`'s middleware chain, run in order, asserting the values
- * `responseMeta` reads off the context when the chain is done.
+ * `homeBlock.getHomeBlock` driven through the REAL tRPC caller, asserting the values
+ * `responseMeta` reads off the context when the call is done.
  *
  * The subject is a cross-file relationship no single-surface test can see:
  * `home-block.controller` sets `ctx.cache.skip = true` for an Announcement block from
@@ -48,24 +51,48 @@ import { TokenScope } from '~/shared/constants/token-scope.constants';
  * thing that reads it. A test of either half alone passes whether or not the write ever
  * reaches the read.
  *
+ * ── WHY `createCallerFactory` AND NOT A HAND-ROLLED RUNNER ──────────────────────────────
+ * An earlier revision of this file walked `_def.middlewares` itself and re-implemented
+ * tRPC's context merge. That reconstruction was faithful when it was written and still
+ * wrong in two ways that mattered: it forwarded the RAW input rather than the parsed one
+ * (so zod's output never reached the resolver), and it had no per-middleware try/catch
+ * (so it could not produce the `{ ok: false }` result the real runner produces). Both are
+ * gone here, and more to the point a future `@trpc/server` upgrade can no longer silently
+ * invalidate the test by changing a runner this file was pretending to be.
+ *
  * Two properties this pins that an isolated test cannot:
  *
  * 1. **`edgeCacheIt` writes the ROOT context here.** Unlike `model.getAll`, nothing in
- *    this chain replaces `ctx.cache` with a copy, so the middleware's assignments land
- *    on the same object `responseMeta` is handed
- *    (`ctxManager.valueOrUndefined()` in `src/pages/api/trpc/[trpc].ts`). That is what
- *    makes the resolver's write observable at the wire at all.
+ *    this chain replaces `ctx.cache` with a copy, so the middleware's assignments land on
+ *    the same object `responseMeta` is handed (`ctxManager.valueOrUndefined()` in
+ *    `src/pages/api/trpc/[trpc].ts`). Driving the real caller demonstrates that directly:
+ *    the context asserted below is the very object handed to `createCaller`, and tRPC's
+ *    own per-middleware `{ ...ctx, ...next.ctx }` shallow merge is what keeps `cache`
+ *    shared across the copies.
  * 2. **Where the read sits relative to `await next()` is load-bearing.** The resolver
- *    cannot know it is returning an Announcement until it has run, so a `skip` read
- *    taken before `next()` can only ever see the incoming value. Moving the read back
- *    above `next()` makes the guard inert again — and leaves a middleware-only test
- *    green, because that test never runs the resolver.
+ *    cannot know it is returning an Announcement until it has run, so a `skip` read taken
+ *    before `next()` can only ever see the incoming value. Moving the read back above
+ *    `next()` makes the guard inert again — and leaves a middleware-only test green,
+ *    because that test never runs the resolver.
+ *
+ * The cache verdict is asserted through `willEdgeCache`, IMPORTED from
+ * `~/server/trpc/edge-cache-headers` — the same function `responseMeta` calls. It used to
+ * be re-declared here, which made it a guard that agreed with its own copy while the real
+ * predicate could be changed underneath it.
  *
  * A SENTINEL root TTL is what keeps the assertions non-vacuous: `edgeCacheIt`'s own ttl
  * for this procedure (60) is byte-identical to the anonymous context default (60), so
  * with production values "wrote the TTL" and "left the default alone" are the same
  * observation. Tests that need the production defaults ask for them explicitly.
  */
+type CacheState = {
+  browserTTL: number;
+  edgeTTL: number;
+  staleWhileRevalidate: number;
+  canCache: boolean;
+  skip: boolean;
+};
+
 type Ctx = {
   user?: { id: number; isModerator?: boolean };
   // `isAcceptableOrigin` (src/server/trpc.ts) runs ahead of these middlewares on every
@@ -75,27 +102,12 @@ type Ctx = {
   acceptableOrigin: boolean;
   // `enforceTokenScope` runs ahead of the cache middleware too.
   tokenScope: number;
-  cache: {
-    browserTTL: number;
-    edgeTTL: number;
-    staleWhileRevalidate: number;
-    canCache: boolean;
-    skip: boolean;
-  };
-  features: Record<string, boolean>;
+  cache: CacheState;
+  // Read by `applyDomainFeature` (src/server/trpc.ts) as `ctx.features.canViewNsfw`,
+  // ahead of the cache middleware. Omitting it is not "a permissive default" — it is a
+  // TypeError that ends the call before `edgeCacheIt` runs.
+  features: { canViewNsfw: boolean };
 };
-
-type Middleware = (opts: {
-  input?: unknown;
-  ctx: Ctx;
-  next: (opts?: { ctx?: Partial<Ctx> }) => unknown;
-  path: string;
-  // tRPC's own input-parsing middleware is part of this chain and calls it.
-  getRawInput: () => Promise<unknown>;
-  type: string;
-}) => Promise<unknown>;
-
-const PATH = 'homeBlock.getHomeBlock';
 
 /**
  * Deliberately not 60, not 0, and not equal to each other, so every assertion below can
@@ -109,11 +121,7 @@ const PROD_DEFAULTS = {
   authenticated: { browserTTL: 0, edgeTTL: 0, staleWhileRevalidate: 0 },
 };
 
-const middlewares = (
-  homeBlockRouter as unknown as {
-    _def: { procedures: Record<string, { _def: { middlewares: Middleware[] } }> };
-  }
-)._def.procedures.getHomeBlock._def.middlewares;
+const createCaller = createCallerFactory(homeBlockRouter);
 
 function rootCtx(
   user: Ctx['user'] | undefined,
@@ -124,48 +132,37 @@ function rootCtx(
     acceptableOrigin: true,
     tokenScope: TokenScope.Full,
     cache: { ...ttls, canCache: true, skip: false },
-    // `getHomeBlock` is behind `isFlagProtected('alternateHome')`, which throws FORBIDDEN
-    // without it and would end the chain before `edgeCacheIt`.
-    features: { alternateHome: true },
+    // ⚠️ `canViewNsfw`, NOT `alternateHome`. An earlier revision of this file set
+    // `features: { alternateHome: true }` and documented it as what satisfies
+    // `isFlagProtected('alternateHome')`. That was wrong in both directions, and only
+    // measuring it showed so: `isFlagProtected` resolves the flag through
+    // `getFeatureFlags(ctx)` (`~/server/services/feature-flags.service.ts`), which
+    // computes from the session/Flipt and never reads a `ctx.features` property — so the
+    // key was INERT, and setting it to `false` does NOT produce a FORBIDDEN. What
+    // `ctx.features` is actually needed for is `applyDomainFeature`, which dereferences
+    // `ctx.features.canViewNsfw` unguarded; drop the object and the call dies with a
+    // TypeError before `edgeCacheIt` is reached. `false` is the realistic value for the
+    // anonymous public caller these tests model.
+    features: { canViewNsfw: false },
   };
 }
 
 /**
- * Run the whole chain, replicating tRPC's context merge exactly:
- *   ctx = nextOpts?.ctx ? { ...opts.ctx, ...nextOpts.ctx } : opts.ctx
- * Returns the root context — the one `responseMeta` is handed.
+ * Call the procedure through tRPC's own caller. Returns the root context — the one
+ * `responseMeta` is handed — plus whatever the procedure resolved to.
  */
-async function runChain(opts: {
+async function callGetHomeBlock(opts: {
   user?: Ctx['user'];
   ttls?: { browserTTL: number; edgeTTL: number; staleWhileRevalidate: number };
 }) {
   const root = rootCtx(opts.user, opts.ttls ?? SENTINEL);
-  const input = { id: 7 };
-  let i = 0;
-
-  const step = async (ctx: Ctx): Promise<unknown> => {
-    if (i >= middlewares.length) return { ok: true, data: {}, marker: undefined, ctx };
-    const mw = middlewares[i++];
-    return mw({
-      input,
-      ctx,
-      path: PATH,
-      getRawInput: async () => input,
-      type: 'query',
-      next: (nextOpts?: { ctx?: Partial<Ctx> }) =>
-        step(nextOpts?.ctx ? ({ ...ctx, ...nextOpts.ctx } as Ctx) : ctx),
-    });
-  };
-
-  const result = (await step(root)) as { ok?: boolean };
-  return { root, result };
+  const caller = createCaller(root as unknown as Context);
+  const data = await caller.getHomeBlock({ id: 7 });
+  return { root, data };
 }
 
-/** `responseMeta`'s own predicate, src/pages/api/trpc/[trpc].ts. */
-const willEdgeCache = (ctx: Ctx) => !!ctx.cache && !!ctx.cache.edgeTTL && ctx.cache.edgeTTL > 0;
-
-const announcement = { id: 7, type: 'Announcement', metadata: {} };
-const collection = { id: 7, type: 'Collection', metadata: {} };
+const announcement = { id: 7, type: HomeBlockType.Announcement, metadata: {} };
+const collection = { id: 7, type: HomeBlockType.Collection, metadata: {} };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -176,22 +173,22 @@ describe('homeBlock.getHomeBlock edge-cache chain', () => {
     it('zeroes the edge TTL the response header is built from (anonymous)', async () => {
       getHomeBlockById.mockResolvedValue(announcement);
 
-      const { root } = await runChain({ ttls: PROD_DEFAULTS.anonymous });
+      const { root } = await callGetHomeBlock({ ttls: PROD_DEFAULTS.anonymous });
 
       expect(root.cache.edgeTTL).toBe(0);
-      expect(willEdgeCache(root)).toBe(false);
+      expect(willEdgeCache(root.cache)).toBe(false);
     });
 
     it('zeroes the edge TTL for an authenticated caller too', async () => {
       getHomeBlockById.mockResolvedValue(announcement);
 
-      const { root } = await runChain({
+      const { root } = await callGetHomeBlock({
         user: { id: 1 },
         ttls: PROD_DEFAULTS.authenticated,
       });
 
       expect(root.cache.edgeTTL).toBe(0);
-      expect(willEdgeCache(root)).toBe(false);
+      expect(willEdgeCache(root.cache)).toBe(false);
     });
 
     // The two assertions above use the production defaults, where "wrote 0" and "the
@@ -200,7 +197,7 @@ describe('homeBlock.getHomeBlock edge-cache chain', () => {
     it('WRITES the zero rather than leaving the incoming TTL alone', async () => {
       getHomeBlockById.mockResolvedValue(announcement);
 
-      const { root } = await runChain({});
+      const { root } = await callGetHomeBlock({});
 
       expect(root.cache.edgeTTL).toBe(0);
       expect(root.cache.browserTTL).toBe(0);
@@ -212,7 +209,7 @@ describe('homeBlock.getHomeBlock edge-cache chain', () => {
     it('still runs the cache-assignment block (staleWhileRevalidate is written)', async () => {
       getHomeBlockById.mockResolvedValue(announcement);
 
-      const { root } = await runChain({});
+      const { root } = await callGetHomeBlock({});
 
       expect(root.cache.staleWhileRevalidate).toBe(30);
       expect(root.cache.staleWhileRevalidate).not.toBe(SENTINEL.staleWhileRevalidate);
@@ -225,32 +222,58 @@ describe('homeBlock.getHomeBlock edge-cache chain', () => {
     it('writes the middleware ttl for an anonymous caller', async () => {
       getHomeBlockById.mockResolvedValue(collection);
 
-      const { root } = await runChain({});
+      const { root } = await callGetHomeBlock({});
 
       expect(root.cache.edgeTTL).toBe(60);
       expect(root.cache.browserTTL).toBe(60);
-      expect(willEdgeCache(root)).toBe(true);
+      expect(willEdgeCache(root.cache)).toBe(true);
     });
 
     it('writes the middleware ttl for an authenticated caller', async () => {
       getHomeBlockById.mockResolvedValue(collection);
 
-      const { root } = await runChain({
+      const { root } = await callGetHomeBlock({
         user: { id: 1 },
         ttls: PROD_DEFAULTS.authenticated,
       });
 
       expect(root.cache.edgeTTL).toBe(60);
-      expect(willEdgeCache(root)).toBe(true);
+      expect(willEdgeCache(root.cache)).toBe(true);
     });
   });
 
-  it('leaves the chain succeeding — the opt-out is not an error path', async () => {
+  it('leaves the call succeeding — the opt-out is not an error path', async () => {
     getHomeBlockById.mockResolvedValue(announcement);
 
-    const { result } = await runChain({});
+    const { data } = await callGetHomeBlock({});
 
-    expect(result.ok).toBe(true);
+    expect(data).toEqual(announcement);
     expect(getHomeBlockById).toHaveBeenCalledTimes(1);
+  });
+
+  // Reachability control. Every assertion above is a claim about middlewares that ran;
+  // this shows the real chain is genuinely being executed rather than short-circuited
+  // into a shape where `edgeCacheIt` is never reached and 0 means "nothing happened".
+  it('is running the real chain — an earlier middleware can still stop it', async () => {
+    getHomeBlockById.mockResolvedValue(collection);
+    const root = rootCtx(undefined, SENTINEL);
+    root.acceptableOrigin = false;
+
+    const caller = createCaller(root as unknown as Context);
+    await expect(caller.getHomeBlock({ id: 7 })).rejects.toThrow();
+
+    // The sentinel survives untouched, and the resolver never ran: proof that reaching
+    // `edgeCacheIt` at all is a property of this chain and not of the harness.
+    expect(root.cache.edgeTTL).toBe(SENTINEL.edgeTTL);
+    expect(root.cache.browserTTL).toBe(SENTINEL.browserTTL);
+    expect(getHomeBlockById).not.toHaveBeenCalled();
+  });
+
+  // The fixture is the enum member, not the string literal the controller happens to
+  // compare against today, so the fixture cannot drift away from the value under test.
+  it('pins the fixture to the enum the controller branches on', () => {
+    expect(HomeBlockType.Announcement).toBe('Announcement');
+    expect(announcement.type).toBe(HomeBlockType.Announcement);
+    expect(collection.type).not.toBe(HomeBlockType.Announcement);
   });
 });

--- a/src/server/routers/__tests__/home-block.router.edge-cache-chain.test.ts
+++ b/src/server/routers/__tests__/home-block.router.edge-cache-chain.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `edgeCacheIt` returns early when `!isProd`, so the TTL-assigning block only runs
+// with this mocked true. Same shape as `middleware.trpc.test.ts`.
+vi.mock('~/env/other', () => ({
+  isDev: false,
+  isProd: true,
+  isTest: false,
+  isPreview: false,
+}));
+
+// `setup.ts` mocks `~/env/server` globally but NOT `~/env/client`, which validates the
+// client schema at module load and THROWS on a miss. Importing the real router reaches
+// it through the controller's import graph. A miss fails the whole FILE as a suite-level
+// error with zero failing tests, so pin it here rather than depend on ambient env. Same
+// shape as `middleware.trpc.rate-limit-key.test.ts`.
+vi.mock('~/env/client', () => ({
+  env: {
+    NEXT_PUBLIC_BASE_URL: 'http://localhost:3000',
+    NEXT_PUBLIC_CIVITAI_LINK: 'http://localhost:3000',
+  },
+  formatErrors: () => [],
+}));
+
+// tRPC's `_def.middlewares` ends with the wrapper that invokes the resolver, so running
+// the real chain runs the real handler — which is the point: the flag under test is set
+// by the handler. Stub only the one service call it makes so the chain completes without
+// a database.
+import type * as HomeBlockService from '~/server/services/home-block.service';
+
+const { getHomeBlockById } = vi.hoisted(() => ({ getHomeBlockById: vi.fn() }));
+
+vi.mock('~/server/services/home-block.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof HomeBlockService>()),
+  getHomeBlockById,
+}));
+
+import { homeBlockRouter } from '~/server/routers/home-block.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * `homeBlock.getHomeBlock`'s middleware chain, run in order, asserting the values
+ * `responseMeta` reads off the context when the chain is done.
+ *
+ * The subject is a cross-file relationship no single-surface test can see:
+ * `home-block.controller` sets `ctx.cache.skip = true` for an Announcement block from
+ * INSIDE the resolver, and `edgeCacheIt` (`src/server/middleware.trpc.ts`) is the only
+ * thing that reads it. A test of either half alone passes whether or not the write ever
+ * reaches the read.
+ *
+ * Two properties this pins that an isolated test cannot:
+ *
+ * 1. **`edgeCacheIt` writes the ROOT context here.** Unlike `model.getAll`, nothing in
+ *    this chain replaces `ctx.cache` with a copy, so the middleware's assignments land
+ *    on the same object `responseMeta` is handed
+ *    (`ctxManager.valueOrUndefined()` in `src/pages/api/trpc/[trpc].ts`). That is what
+ *    makes the resolver's write observable at the wire at all.
+ * 2. **Where the read sits relative to `await next()` is load-bearing.** The resolver
+ *    cannot know it is returning an Announcement until it has run, so a `skip` read
+ *    taken before `next()` can only ever see the incoming value. Moving the read back
+ *    above `next()` makes the guard inert again — and leaves a middleware-only test
+ *    green, because that test never runs the resolver.
+ *
+ * A SENTINEL root TTL is what keeps the assertions non-vacuous: `edgeCacheIt`'s own ttl
+ * for this procedure (60) is byte-identical to the anonymous context default (60), so
+ * with production values "wrote the TTL" and "left the default alone" are the same
+ * observation. Tests that need the production defaults ask for them explicitly.
+ */
+type Ctx = {
+  user?: { id: number; isModerator?: boolean };
+  // `isAcceptableOrigin` (src/server/trpc.ts) runs ahead of these middlewares on every
+  // publicProcedure and throws UNAUTHORIZED without it, so the chain never reaches the
+  // cache middleware at all. It is also why an error response can never carry a cache
+  // header: `responseMeta` only sets one when `errors.length === 0`.
+  acceptableOrigin: boolean;
+  // `enforceTokenScope` runs ahead of the cache middleware too.
+  tokenScope: number;
+  cache: {
+    browserTTL: number;
+    edgeTTL: number;
+    staleWhileRevalidate: number;
+    canCache: boolean;
+    skip: boolean;
+  };
+  features: Record<string, boolean>;
+};
+
+type Middleware = (opts: {
+  input?: unknown;
+  ctx: Ctx;
+  next: (opts?: { ctx?: Partial<Ctx> }) => unknown;
+  path: string;
+  // tRPC's own input-parsing middleware is part of this chain and calls it.
+  getRawInput: () => Promise<unknown>;
+  type: string;
+}) => Promise<unknown>;
+
+const PATH = 'homeBlock.getHomeBlock';
+
+/**
+ * Deliberately not 60, not 0, and not equal to each other, so every assertion below can
+ * tell "the middleware wrote this" from "the context default survived".
+ */
+const SENTINEL = { browserTTL: 111, edgeTTL: 222, staleWhileRevalidate: 333 };
+
+/** What `createContext` builds for each caller shape (src/server/createContext.ts). */
+const PROD_DEFAULTS = {
+  anonymous: { browserTTL: 60, edgeTTL: 60, staleWhileRevalidate: 30 },
+  authenticated: { browserTTL: 0, edgeTTL: 0, staleWhileRevalidate: 0 },
+};
+
+const middlewares = (
+  homeBlockRouter as unknown as {
+    _def: { procedures: Record<string, { _def: { middlewares: Middleware[] } }> };
+  }
+)._def.procedures.getHomeBlock._def.middlewares;
+
+function rootCtx(
+  user: Ctx['user'] | undefined,
+  ttls: { browserTTL: number; edgeTTL: number; staleWhileRevalidate: number }
+): Ctx {
+  return {
+    user,
+    acceptableOrigin: true,
+    tokenScope: TokenScope.Full,
+    cache: { ...ttls, canCache: true, skip: false },
+    // `getHomeBlock` is behind `isFlagProtected('alternateHome')`, which throws FORBIDDEN
+    // without it and would end the chain before `edgeCacheIt`.
+    features: { alternateHome: true },
+  };
+}
+
+/**
+ * Run the whole chain, replicating tRPC's context merge exactly:
+ *   ctx = nextOpts?.ctx ? { ...opts.ctx, ...nextOpts.ctx } : opts.ctx
+ * Returns the root context — the one `responseMeta` is handed.
+ */
+async function runChain(opts: {
+  user?: Ctx['user'];
+  ttls?: { browserTTL: number; edgeTTL: number; staleWhileRevalidate: number };
+}) {
+  const root = rootCtx(opts.user, opts.ttls ?? SENTINEL);
+  const input = { id: 7 };
+  let i = 0;
+
+  const step = async (ctx: Ctx): Promise<unknown> => {
+    if (i >= middlewares.length) return { ok: true, data: {}, marker: undefined, ctx };
+    const mw = middlewares[i++];
+    return mw({
+      input,
+      ctx,
+      path: PATH,
+      getRawInput: async () => input,
+      type: 'query',
+      next: (nextOpts?: { ctx?: Partial<Ctx> }) =>
+        step(nextOpts?.ctx ? ({ ...ctx, ...nextOpts.ctx } as Ctx) : ctx),
+    });
+  };
+
+  const result = (await step(root)) as { ok?: boolean };
+  return { root, result };
+}
+
+/** `responseMeta`'s own predicate, src/pages/api/trpc/[trpc].ts. */
+const willEdgeCache = (ctx: Ctx) => !!ctx.cache && !!ctx.cache.edgeTTL && ctx.cache.edgeTTL > 0;
+
+const announcement = { id: 7, type: 'Announcement', metadata: {} };
+const collection = { id: 7, type: 'Collection', metadata: {} };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('homeBlock.getHomeBlock edge-cache chain', () => {
+  describe('Announcement block — the resolver opts out', () => {
+    it('zeroes the edge TTL the response header is built from (anonymous)', async () => {
+      getHomeBlockById.mockResolvedValue(announcement);
+
+      const { root } = await runChain({ ttls: PROD_DEFAULTS.anonymous });
+
+      expect(root.cache.edgeTTL).toBe(0);
+      expect(willEdgeCache(root)).toBe(false);
+    });
+
+    it('zeroes the edge TTL for an authenticated caller too', async () => {
+      getHomeBlockById.mockResolvedValue(announcement);
+
+      const { root } = await runChain({
+        user: { id: 1 },
+        ttls: PROD_DEFAULTS.authenticated,
+      });
+
+      expect(root.cache.edgeTTL).toBe(0);
+      expect(willEdgeCache(root)).toBe(false);
+    });
+
+    // The two assertions above use the production defaults, where "wrote 0" and "the
+    // anonymous default was never overwritten" are distinguishable only for the
+    // authenticated arm. From a sentinel root, 0 can ONLY have been written.
+    it('WRITES the zero rather than leaving the incoming TTL alone', async () => {
+      getHomeBlockById.mockResolvedValue(announcement);
+
+      const { root } = await runChain({});
+
+      expect(root.cache.edgeTTL).toBe(0);
+      expect(root.cache.browserTTL).toBe(0);
+    });
+
+    // Discriminates this fix from a `canCache = false`-shaped one: that route skips the
+    // whole assignment block, so the sentinel would survive on every field. Here the
+    // block runs and only the TTLs are zero.
+    it('still runs the cache-assignment block (staleWhileRevalidate is written)', async () => {
+      getHomeBlockById.mockResolvedValue(announcement);
+
+      const { root } = await runChain({});
+
+      expect(root.cache.staleWhileRevalidate).toBe(30);
+      expect(root.cache.staleWhileRevalidate).not.toBe(SENTINEL.staleWhileRevalidate);
+    });
+  });
+
+  describe('non-Announcement block — unchanged, still edge-cached', () => {
+    // Positive control for every assertion above: without these, "edgeTTL is 0" would
+    // also pass with `edgeCacheIt` absent, inert, or never reached.
+    it('writes the middleware ttl for an anonymous caller', async () => {
+      getHomeBlockById.mockResolvedValue(collection);
+
+      const { root } = await runChain({});
+
+      expect(root.cache.edgeTTL).toBe(60);
+      expect(root.cache.browserTTL).toBe(60);
+      expect(willEdgeCache(root)).toBe(true);
+    });
+
+    it('writes the middleware ttl for an authenticated caller', async () => {
+      getHomeBlockById.mockResolvedValue(collection);
+
+      const { root } = await runChain({
+        user: { id: 1 },
+        ttls: PROD_DEFAULTS.authenticated,
+      });
+
+      expect(root.cache.edgeTTL).toBe(60);
+      expect(willEdgeCache(root)).toBe(true);
+    });
+  });
+
+  it('leaves the chain succeeding — the opt-out is not an error path', async () => {
+    getHomeBlockById.mockResolvedValue(announcement);
+
+    const { result } = await runChain({});
+
+    expect(result.ok).toBe(true);
+    expect(getHomeBlockById).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/routers/system.router.ts
+++ b/src/server/routers/system.router.ts
@@ -44,9 +44,13 @@ export const systemRouter = router({
     .query(async ({ ctx }) => {
       const lists = await getClientBenignLists();
       // A fail-open result is a 200 the edge would otherwise hold for an hour, pinning empty
-      // whitelists site-wide off one transient error. `ctx.cache.skip` does NOT work from
-      // here: `edgeCacheIt` reads it to compute the TTL BEFORE it calls this resolver, so it
-      // is only usable by something upstream of the procedure. `canCache` is read after.
+      // whitelists site-wide off one transient error.
+      //
+      // `ctx.cache.skip = true` would now also work from here — `edgeCacheIt` re-reads it
+      // after the resolver returns. `canCache: false` is kept because it is the stronger
+      // statement: it is the one flag that also suppresses the sibling `cacheIt`
+      // middleware's Redis write, so a resolver marking its own result uncacheable does not
+      // have to know which cache middlewares its procedure happens to carry.
       //
       // All three, not just `canCache`: with `canCache: false` the middleware skips the block
       // that assigns the TTLs, so they keep the context defaults — which for an ANONYMOUS

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -174,7 +174,14 @@ export const getHomeBlockById = async ({
   id,
   domain,
 }: GetHomeBlockByIdInputSchema & {
-  // SessionUser required because it's passed down to getHomeBlockData
+  // Accepted and deliberately NOT read. The body destructures `id` and `domain` only;
+  // the block is resolved through `getHomeBlockCached`, whose entry is keyed on the
+  // block row and the domain, so the result is identical for every caller.
+  //
+  // Keep it that way. `homeBlock.getHomeBlock` is edge-cached, which means one caller's
+  // response body is served to every other caller that hits the same URL. Reading `user`
+  // here to personalize the result would make a shared cache entry caller-specific and
+  // leak it across users.
   user?: SessionUser;
 }) => {
   const homeBlockFindArgs = {

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -401,8 +401,11 @@ export const getHomeBlockData = async ({
   // `domain` isn't part of the public getHomeBlocks input — it's supplied by the
   // by-id cached path, which is the only caller whose blocks are domain-scoped.
   input: GetHomeBlocksInputSchema & { domain?: DomainColor };
-  // Optional, and on the hot path it is absent. When supplied it IS read — it is passed
-  // to `getCollectionItemsByCollectionId` below, which uses it for models/posts/etc.
+  // Optional, and on the hot path it is absent. When supplied it IS read, in TWO places
+  // below, both of which make the body caller-dependent: it is passed whole to
+  // `getCollectionItemsByCollectionId` (which uses it for models/posts/etc.), and read as
+  // `user?.isModerator` for `getLeaderboardsWithResults`. Either one is enough to poison
+  // the shared entry described below.
   //
   // But the by-id path never supplies it: `getHomeBlockCached`
   // (`~/server/services/home-block-cache.service.ts`) calls this function with

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -174,14 +174,20 @@ export const getHomeBlockById = async ({
   id,
   domain,
 }: GetHomeBlockByIdInputSchema & {
-  // Accepted and deliberately NOT read. The body destructures `id` and `domain` only;
-  // the block is resolved through `getHomeBlockCached`, whose entry is keyed on the
-  // block row and the domain, so the result is identical for every caller.
+  // Accepted and deliberately NOT read. The body destructures `id` and `domain` only.
   //
-  // Keep it that way. `homeBlock.getHomeBlock` is edge-cached, which means one caller's
-  // response body is served to every other caller that hits the same URL. Reading `user`
-  // here to personalize the result would make a shared cache entry caller-specific and
-  // leak it across users.
+  // Keep it that way, for two independent reasons — the first is the one that binds:
+  //
+  // 1. The result is stored in a SHARED Redis entry with no user segment. This path goes
+  //    through `getHomeBlockCached` (`~/server/services/home-block-cache.service.ts`),
+  //    whose key is built from the block's type, its identifier and the domain only.
+  //    Personalizing the result off `user` would therefore write one caller's body under
+  //    a key every other caller reads — a cross-user leak that exists even with
+  //    `edgeCacheIt` removed from the procedure entirely, because the leak is in the
+  //    server-side cache, not in the response headers.
+  //
+  // 2. `homeBlock.getHomeBlock` is additionally edge-cached, so a personalized body would
+  //    also be served from the edge to every other caller of the same URL.
   user?: SessionUser;
 }) => {
   const homeBlockFindArgs = {
@@ -395,8 +401,19 @@ export const getHomeBlockData = async ({
   // `domain` isn't part of the public getHomeBlocks input — it's supplied by the
   // by-id cached path, which is the only caller whose blocks are domain-scoped.
   input: GetHomeBlocksInputSchema & { domain?: DomainColor };
-  // Session user required because it's passed down to collection get items service
-  // which requires it for models/posts/etc
+  // Optional, and on the hot path it is absent. When supplied it IS read — it is passed
+  // to `getCollectionItemsByCollectionId` below, which uses it for models/posts/etc.
+  //
+  // But the by-id path never supplies it: `getHomeBlockCached`
+  // (`~/server/services/home-block-cache.service.ts`) calls this function with
+  // `{ homeBlock, input }` and no `user`, so collection items already resolve as
+  // ANONYMOUS there. That is the correct state, not an oversight to be tidied up.
+  //
+  // 🔴 Do NOT start passing a user through that caller. `getHomeBlockCached` stores the
+  // result under a Redis key built from type/identifier/domain with no user segment, so
+  // a user-dependent body would be written into an entry every other caller reads —
+  // poisoning a shared cache entry and leaking one user's view to everyone else. If a
+  // personalized variant is ever genuinely needed, it needs its own key, not this one.
   user?: SessionUser;
 }): Promise<HomeBlockWithData | null> => {
   const metadata = await resolveHomeBlockMetadata(homeBlock);

--- a/src/server/trpc/edge-cache-headers.ts
+++ b/src/server/trpc/edge-cache-headers.ts
@@ -14,11 +14,29 @@
  * object inside the guarded block, so narrowing to a fixed local shape would throw those
  * away. `cache is T` narrows off only `null | undefined`.
  *
- * ⚠️ The leading `!!cache.edgeTTL` is load-bearing and NOT redundant with `> 0`: it is
- * what rejects `edgeTTL === 0`, which is precisely the value `edgeCacheIt` writes when a
- * resolver opts out (`ctx.cache.skip`). Because it short-circuits on 0 first, relaxing
- * the comparison alone — `> 0` to `>= 0` — changes nothing; widening this predicate to
- * treat 0 as cacheable requires dropping the `!!` as well. Both halves are the guard.
+ * ⚠️ Do not widen this predicate: `edgeTTL === 0` is exactly what `edgeCacheIt` writes
+ * when a resolver opts out (`ctx.cache.skip`), and treating 0 as cacheable would undo
+ * every such opt-out at once.
+ *
+ * But be precise about WHY, because the obvious reading is wrong and was written down
+ * here once already. At RUNTIME the two halves are redundant on `number | null |
+ * undefined`: `!!cache.edgeTTL` and `cache.edgeTTL > 0` reject the same values, so
+ * NEITHER single-half mutant is killable — measured, both survive the suite 12/12
+ * (`> 0` → `>= 0`, and dropping the `!!` while keeping `> 0`). What `!!cache.edgeTTL`
+ * actually buys is TYPE NARROWING: remove it and `cache.edgeTTL > 0` stops compiling
+ * with `TS18049: 'cache.edgeTTL' is possibly 'null' or 'undefined'`.
+ *
+ * The consequence for anyone testing this: a mutant that changes both halves at once
+ * proves nothing about either. Isolate them, and expect a widening mutation to be caught
+ * by `tsc`, not by vitest.
+ *
+ * KNOWN LIMIT, stated rather than papered over: extracting this makes the predicate
+ * single-sourced, but nothing asserts that `responseMeta` still CALLS it. Measured —
+ * re-inline the condition at the call site in `src/pages/api/trpc/[trpc].ts` and the
+ * suite stays fully green. Closing that seam properly means moving the header-building
+ * out of `responseMeta` so a test can drive the real thing; a test that greps the route
+ * for this import would be a spelled guard, i.e. the exact shape this file exists to
+ * replace, so it is deliberately not done here.
  */
 export type EdgeCacheReadable = {
   edgeTTL?: number | null;

--- a/src/server/trpc/edge-cache-headers.ts
+++ b/src/server/trpc/edge-cache-headers.ts
@@ -1,0 +1,31 @@
+/**
+ * The single definition of "this response will be edge-cached".
+ *
+ * Extracted out of `src/pages/api/trpc/[trpc].ts` so there is exactly ONE place the
+ * condition is written. It used to be an inline expression in `responseMeta`, which
+ * meant a test asserting the cache outcome of a middleware chain had to RE-DECLARE it —
+ * and a re-declared predicate is a spelled guard, not a structural one: the copy in the
+ * test keeps agreeing with itself while the real one is changed underneath it. Anything
+ * that wants to assert "this response would/would not carry a `Cache-Control`" must
+ * import this function, so that changing it is visible to those assertions.
+ *
+ * Deliberately a type predicate, and deliberately generic over the caller's own cache
+ * type: `responseMeta` reads `browserTTL` / `staleWhileRevalidate` / `tags` off the same
+ * object inside the guarded block, so narrowing to a fixed local shape would throw those
+ * away. `cache is T` narrows off only `null | undefined`.
+ *
+ * ⚠️ The leading `!!cache.edgeTTL` is load-bearing and NOT redundant with `> 0`: it is
+ * what rejects `edgeTTL === 0`, which is precisely the value `edgeCacheIt` writes when a
+ * resolver opts out (`ctx.cache.skip`). Because it short-circuits on 0 first, relaxing
+ * the comparison alone — `> 0` to `>= 0` — changes nothing; widening this predicate to
+ * treat 0 as cacheable requires dropping the `!!` as well. Both halves are the guard.
+ */
+export type EdgeCacheReadable = {
+  edgeTTL?: number | null;
+};
+
+export function willEdgeCache<T extends EdgeCacheReadable>(
+  cache: T | null | undefined
+): cache is T {
+  return !!cache && !!cache.edgeTTL && cache.edgeTTL > 0;
+}


### PR DESCRIPTION
## The defect

`edgeCacheIt` (`src/server/middleware.trpc.ts`) computes the request TTL from
`ctx.cache.skip` **before** it calls `await next()`:

```ts
let reqTTL = ctx.cache.skip ? 0 : (ttl as number);
if (expireAt) reqTTL = Math.floor((expireAt().getTime() - Date.now()) / 1000);

const result = await next();          // <- the resolver runs HERE
if (result.ok && ctx.cache?.canCache) {
  ctx.cache.edgeTTL = reqTTL;
  ...
}
```

So an opt-out set *inside* a resolver is read before the resolver runs, and never
takes effect. `home-block.controller.ts` does exactly that:

```ts
if (homeBlock?.type === 'Announcement') ctx.cache.skip = true;
```

`homeBlock.getHomeBlock` is `.use(edgeCacheIt({ ttl: 60 }))`, so Announcement blocks
were cached for 60s against an explicit intent not to. For an **authenticated**
caller it was worse than a no-op: the context default is `0`, and the middleware
overwrote it with `60` — i.e. the guard's presence made those responses *more*
cacheable than the default, not less.

`canCache` does not have this problem — it is read *after* `next()` — which is why the
same in-resolver pattern works in `model.controller.ts`.

> ⚠️ **Read the live-impact correction in the comment thread before merging.** The
> `HomeBlockType.Announcement` render branch is commented out in `src/pages/home/index.tsx`,
> so the first-party app never calls this procedure with an Announcement block. This is
> defence in depth on a dormant path, not a measurable behaviour change.

## The change

`src/server/middleware.trpc.ts` — re-read `skip` once the resolver has returned, on
the same footing as `canCache`:

```ts
const result = await next();
if (ctx.cache?.skip) reqTTL = 0;
if (result.ok && ctx.cache?.canCache) { ... }
```

Idempotent for the existing upstream caller: `model.getAll` sets `skip` in a
middleware ahead of `edgeCacheIt`, so the value re-read is the value it set.

### `skip` now beats `expireAt` — deliberate, and now pinned

The new line sits *after* the `if (expireAt)` assignment, so it overrides a scheduled
expiry rather than being overridden by it. Before this PR the precedence ran the other
way. **That ordering is intended, not incidental:** `expireAt` says "this content goes
stale at time T", which is a statement about content that *is* cacheable; `skip` says
"this response must not be cached at all". A response the resolver has declared
uncacheable does not become cacheable because someone also scheduled its expiry — the
stronger claim wins.

It was accidental until now, so it is written down in the middleware and pinned by a
test. `expireAt` has **zero production call sites** today (only its type declaration and
its one use inside `edgeCacheIt`), so there is no real procedure combining it with a
resolver-set `skip`; the dimension is exercised on a purpose-built router driven through
the real tRPC caller (`src/server/__tests__/middleware.trpc.edge-cache-precedence.test.ts`),
with a control arm proving `expireAt` is genuinely in play.

### `willEdgeCache` is now single-sourced

`responseMeta`'s edge-cache predicate was an inline expression in
`src/pages/api/trpc/[trpc].ts`, which meant the chain test had to **re-declare** it — a
guard that keeps agreeing with its own copy while the real one changes underneath it. It
now lives in `src/server/trpc/edge-cache-headers.ts` and both the route and the tests
import it. `responseMeta`'s behaviour is unchanged; the local is narrowed off the cache
object instead of off `ctx` so the type predicate keeps the fields the header build reads.

### Comments corrected

- **`home-block.service.ts` / `getHomeBlockById`** — now leads with the reason that
  actually binds: the by-id result is stored in a **shared Redis entry keyed on
  type/identifier/domain with no user segment**
  (`src/server/services/home-block-cache.service.ts`), so reading `user` would serve one
  caller's body to another **even with `edgeCacheIt` removed entirely**. Edge caching is
  kept as the second reason. (This is the amendment offered in the correction comment.)
- **`home-block.service.ts` / `getHomeBlockData`** — the mirror-image stale comment, also
  flagged in that comment thread. Unlike the one above, this function *does* read `user`
  when given one — but `getHomeBlockCached` calls it **without** one, so collection items
  already resolve as anonymous on the by-id path. The comment now says so, and says
  explicitly that passing a user through that caller would poison a shared cache entry.
  **No behaviour change: the fix is the comment, not the argument.**
- **`system.router.ts`** — `getBenignPhrases` carried a comment stating `ctx.cache.skip`
  "does NOT work from here". This PR makes that false, so it is updated.

### `home-block.controller.ts` — null guard

`ctx.cache` really is `null` on the SSG prefetch path (`createServerSideHelpers` builds it
as `cache: null as any`, which is why `strict: true` does not flag the unguarded write).
Only the *list* procedure is prefetched today, so the line is not reachable from there —
the guard is precautionary, added because this PR makes that line load-bearing. The
fixture/branch also moves from the string literal to `HomeBlockType.Announcement`.

Sibling writers are **inconsistent** about this guard and the comment says so rather than
claiming a convention: `system.router.getBenignPhrases` and
`model.controller.getModelsPagedSimpleHandler` guard; `model.controller.getModelsInfiniteHandler`
does not. That third site is left alone here — it is a hot unrelated handler and not this
PR's business.

## Behaviour change worth naming: `Set-Cookie`

`responseMeta` calls `ctx.res?.removeHeader('Set-Cookie')` **inside** the
`willEdgeCache` branch. With `edgeTTL` now `0` for an opted-out response, that branch is
skipped, so an Announcement response **can now carry `Set-Cookie` where it previously
could not**. This is the safer direction — the header was only being stripped because the
response was about to be shared, and it is no longer being shared — but it is a real
change in emitted headers and nobody had written it down.

## Blast radius

`git grep -n 'cache\.skip'` plus a wider sweep for `cache: { ...ctx.cache` across
`src/`, non-test hits only:

| Site | Role |
|---|---|
| `createContext.ts` (×3) | type + the `skip: false` defaults |
| `middleware.trpc.ts` | the pre-`next()` read, now paired with a post-`next()` read |
| `home-block.controller.ts` | the only resolver that writes it — the inert one |
| `model.router.ts` | writes it **upstream**, on a spread **copy** (`cache: { ...ctx.cache, skip }`), so the root object is untouched |
| `system.router.ts` | comment only |

No third writer.

## Tests

Two files:

- `src/server/routers/__tests__/home-block.router.edge-cache-chain.test.ts` — the real
  `homeBlock.getHomeBlock` chain, including the real resolver (only the one service call
  it makes is stubbed), asserting the values `responseMeta` reads off the root context.
- `src/server/__tests__/middleware.trpc.edge-cache-precedence.test.ts` — the
  `skip` vs `expireAt` precedence, on a synthetic router.

**Both now drive `createCallerFactory`, not a hand-rolled runner.** The first revision of
the chain test walked `_def.middlewares` and re-implemented tRPC's context merge. That
reconstruction was verified faithful against `@trpc/server` 11.17.0 and was still wrong in
two ways: it forwarded the **raw** input rather than zod's parsed output, and it had **no
per-middleware try/catch**, so it could not produce the `{ ok: false }` result the real
runner produces. Driving the library's own caller removes both, and means a future tRPC
upgrade cannot silently invalidate the test by changing a runner the file was pretending
to be. The root context stays observable because tRPC's per-middleware `{ ...ctx, ...next.ctx }`
merge is shallow — `cache` is the same object in every copy — which is exactly the property
the test is asserting.

Sentinel TTLs (111 / 222 / 333) rather than realistic ones: the anonymous context default
and this procedure's own `ttl` are both `60`, so with production values "wrote the TTL" and
"left the default alone" are byte-identical and the assertion would be vacuous. Tests that
need the production defaults ask for them explicitly.

Red at `origin/main` (`middleware.trpc.ts` and `home-block.controller.ts` restored to
`origin/main` content, tree otherwise unchanged) → **2 files failed, 5 failed | 7 passed (12)**.
Green at HEAD → **2 files passed, 12 passed (12)**.

The 7 that pass in both columns are **invariant guards, not regression coverage**, and are
labelled as such: positive controls proving `edgeCacheIt` is live and reached (a
non-Announcement block still gets `60`, anonymous and authenticated), one discriminating
this fix from a `canCache: false`-shaped one (`staleWhileRevalidate` is still written, so
the assignment block runs and only the TTLs are zero), a reachability control (an earlier
middleware can still stop the chain, and the sentinel then survives untouched), the
`expireAt` control arm, the enum pin, and one asserting the opt-out is not an error path.

### Mutation battery

Both files run for every mutant. Counts are Test Files / Tests.

| Mutant | Files | Tests | Verdict | Died on |
|---|---|---|---|---|
| M0 baseline (HEAD) | 2 passed | **12 passed** | GREEN | — |
| M1 guard deleted (= `origin/main`) | 2 failed | 5 failed / 7 passed | KILLED | `expected 60 to be +0`, `expected 900 to be +0` |
| M2 guard moved above `await next()` | 2 failed | 4 failed / 8 passed | KILLED | `expected 60 to be +0`, `expected 900 to be +0` |
| M3 guard assigns `5` instead of `0` | 2 failed | 5 failed / 7 passed | KILLED | `expected 5 to be +0` |
| M4 `skip && !expireAt` (old precedence) | 1 failed / 1 passed | 2 failed / 10 passed | KILLED | `expected 900 to be +0` |
| M5 `willEdgeCache`: `> 0` → `>= 0` | 2 passed | 12 passed | **SURVIVED — equivalent** | — |
| M6 `willEdgeCache`: drop `!!`, `>= 0` | 2 failed | 4 failed / 8 passed | KILLED | `expected true to be false` |
| CTRL unrelated code (must survive) | 2 passed | 12 passed | SURVIVED ✅ | — |

M2 is the one that matters for the "verified in isolation" failure mode: a test of
`edgeCacheIt` alone, or of the controller alone, stays green under it, because neither
ever builds the combined state. M4 is the mutant that **survived the previous revision of
this PR** — the precedence was unpinned. M3's distinct message is the battery's own
control that each mutant genuinely ran, and CTRL confirms the battery is not simply
failing everything.

**M5 is an equivalent mutant and is reported as such rather than as a gap.** The predicate
is `!!cache && !!cache.edgeTTL && cache.edgeTTL > 0`; the `!!cache.edgeTTL` short-circuits
on `0` first, so relaxing the comparison alone cannot change any outcome and *no* test can
kill it. M6 — dropping the `!!` as well, which is what "widen this predicate to treat 0 as
cacheable" actually looks like — is killable and is killed, by the imported-predicate
assertions specifically (`expected true to be false`). That pair is what demonstrates the
test is bound to the real `willEdgeCache` rather than to a copy. Both halves of the
predicate are load-bearing and the module says so.

### One thing the new reachability control found

The previous revision set `features: { alternateHome: true }` on the test context and
documented it as what satisfies `isFlagProtected('alternateHome')`. Measured, that was
wrong in both directions: `isFlagProtected` resolves through `getFeatureFlags(ctx)`, which
computes from the session and never reads a `ctx.features` property — so the key was
**inert**, and setting it to `false` does not produce a `FORBIDDEN`. What `ctx.features` is
actually needed for is `applyDomainFeature`, which dereferences `ctx.features.canViewNsfw`
unguarded ahead of `edgeCacheIt`. The context now carries `canViewNsfw` and the comment
says why.

### Suites run

- `src/server/routers/__tests__/` + `src/server/__tests__/` — **114 files / 2198 tests, all passed**
- the neighbouring `home-block-*` service, `HomeBlocks` component, `middleware.trpc` and
  `trpc-batching` suites — **9 files / 91 tests, all passed**
- `pnpm typecheck` — **0 errors** (validated: a planted type error in the new module is
  detected, 1 error / rc 2)
- `scripts/ci/typecheck-tests-gate.mjs` — reports **BLOCKED**, and that is **pre-existing**:
  run against unmodified `origin/main` sources in the same worktree the output is
  byte-identical except the program size (**1352 → 1354 test files**), i.e. the gate does see
  both new files and they contribute **0** errors.
- `eslint` on the changed files — **0 errors** (5 pre-existing warnings, none on changed
  lines; validated by planting two rule violations and confirming detection)

## Note for #4347

`model.router.edge-cache-skip.test.ts` on that branch cites `home-block.controller.ts` as
*"a live instance of that mistake"*. Once this merges that sentence is stale — worth a
one-line touch-up on whichever lands second. The two PRs touch disjoint files (#4347 does
not modify `middleware.trpc.ts`), so there is no textual conflict.
