### PR TITLE
refactor(creator-program): derive the bankable Buzz list instead of writing it out

### DIFF
--- a/src/server/services/__tests__/creator-program.service.test.ts
+++ b/src/server/services/__tests__/creator-program.service.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterAll, beforeAll } from 'vites
 import { REDIS_KEYS } from '~/server/redis/client';
 import { OnboardingSteps } from '~/server/common/enums';
 import { MIN_CREATOR_SCORE } from '~/shared/constants/creator-program.constants';
-import { TransactionType } from '~/shared/constants/buzz.constants';
+import { TransactionType, buzzBankTypes } from '~/shared/constants/buzz.constants';
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────────
 const {
@@ -183,7 +183,7 @@ describe('userCapCache peak-earning query', () => {
     const [parts, ...values] = call as [string[], ...any[]];
     const sql = parts.reduce((acc, part, i) => acc + part + (values[i] ?? ''), '');
 
-    return { sql, result };
+    return { sql, values, result };
   }
 
   beforeEach(() => {
@@ -201,6 +201,15 @@ describe('userCapCache peak-earning query', () => {
 
     expect(sql).toMatch(/type IN \('compensation'\)/);
     expect(sql).toMatch(/type = 'purchase' AND fromAccountId != 0/);
+  });
+
+  // The interpolated list decides which Buzz counts toward Peak Earning Month, and so toward a
+  // creator's Cap; a wrong list returns a plausible wrong number rather than an error. Pinned to
+  // the derivation, not to a literal, so re-hardcoding the list fails here.
+  it('interpolates the bankable-type list derived from buzzBankTypes', async () => {
+    const { values } = await runLookup([userId]);
+
+    expect(values).toContain(buzzBankTypes.map((type) => `'${type}'`).join(', '));
   });
 
   it('derives the cap from the peak month returned by ClickHouse', async () => {

--- a/src/server/services/__tests__/creator-program.service.test.ts
+++ b/src/server/services/__tests__/creator-program.service.test.ts
@@ -203,13 +203,15 @@ describe('userCapCache peak-earning query', () => {
     expect(sql).toMatch(/type = 'purchase' AND fromAccountId != 0/);
   });
 
-  // The interpolated list decides which Buzz counts toward Peak Earning Month, and so toward a
-  // creator's Cap; a wrong list returns a plausible wrong number rather than an error. Pinned to
-  // the derivation, not to a literal, so re-hardcoding the list fails here.
-  it('interpolates the bankable-type list derived from buzzBankTypes', async () => {
-    const { values } = await runLookup([userId]);
+  // This clause decides which Buzz counts toward Peak Earning Month, and so toward a creator's Cap;
+  // both halves of it return a plausible wrong number rather than an error. Asserted as column AND
+  // list together: on the list alone, narrowing `toAccountType` to `fromAccountType` sums Buzz
+  // leaving the account instead of arriving and every test in this block still passes.
+  it('narrows the peak-earning sum to the bankable types arriving in the account', async () => {
+    const { sql } = await runLookup([userId]);
 
-    expect(values).toContain(buzzBankTypes.map((type) => `'${type}'`).join(', '));
+    const bankable = buzzBankTypes.map((type) => `'${type}'`).join(', ');
+    expect(sql).toContain(`toAccountType IN (${bankable})`);
   });
 
   it('derives the cap from the peak month returned by ClickHouse', async () => {

--- a/src/server/services/__tests__/creator-program.service.test.ts
+++ b/src/server/services/__tests__/creator-program.service.test.ts
@@ -212,8 +212,8 @@ describe('userCapCache peak-earning query', () => {
     const { sql } = await runLookup([userId]);
 
     const bankable = buzzBankTypes.map((type) => `'${type}'`).join(', ');
-    // String.raw, not a plain template: `\n` and `\s` in one are a newline and the letter s, so the
-    // pattern would match nothing and this assertion would never fire.
+    // String.raw, not a plain template: `\s` in one is the letter s, which cannot consume the
+    // query's indentation, so the pattern matches nothing and this test fails outright.
     expect(sql).toMatch(new RegExp(String.raw`\n\s*AND toAccountType IN \(${bankable}\)`));
   });
 

--- a/src/server/services/__tests__/creator-program.service.test.ts
+++ b/src/server/services/__tests__/creator-program.service.test.ts
@@ -183,7 +183,7 @@ describe('userCapCache peak-earning query', () => {
     const [parts, ...values] = call as [string[], ...any[]];
     const sql = parts.reduce((acc, part, i) => acc + part + (values[i] ?? ''), '');
 
-    return { sql, values, result };
+    return { sql, result };
   }
 
   beforeEach(() => {
@@ -203,15 +203,18 @@ describe('userCapCache peak-earning query', () => {
     expect(sql).toMatch(/type = 'purchase' AND fromAccountId != 0/);
   });
 
-  // This clause decides which Buzz counts toward Peak Earning Month, and so toward a creator's Cap;
-  // both halves of it return a plausible wrong number rather than an error. Asserted as column AND
-  // list together: on the list alone, narrowing `toAccountType` to `fromAccountType` sums Buzz
-  // leaving the account instead of arriving and every test in this block still passes.
+  // This clause decides which Buzz counts toward Peak Earning Month, and so toward a creator's Cap,
+  // and a wrong one returns a plausible number rather than an error. Column and list are asserted
+  // together, anchored to the line: asserting the list alone left `toAccountType` free, and
+  // narrowing it to `fromAccountType` passed every test in this block. The anchor is what makes
+  // commenting the clause out fail, since the text would otherwise still be present in the query.
   it('narrows the peak-earning sum to the bankable types arriving in the account', async () => {
     const { sql } = await runLookup([userId]);
 
     const bankable = buzzBankTypes.map((type) => `'${type}'`).join(', ');
-    expect(sql).toContain(`toAccountType IN (${bankable})`);
+    // String.raw, not a plain template: `\n` and `\s` in one are a newline and the letter s, so the
+    // pattern would match nothing and this assertion would never fire.
+    expect(sql).toMatch(new RegExp(String.raw`\n\s*AND toAccountType IN \(${bankable}\)`));
   });
 
   it('derives the cap from the peak month returned by ClickHouse', async () => {

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -48,7 +48,7 @@ import {
   getTransactionsReportResultSchema,
 } from '~/server/schema/buzz.schema';
 import {
-  buzzBankTypes,
+  buzzBankTypesSql,
   BuzzTypes,
   buzzSpendTypes,
   CASH_SETTLED_ALIASES,
@@ -1440,8 +1440,6 @@ export async function getEarnPotential({ userId, username }: GetEarnPotentialSch
   return potential;
 }
 
-const BANKABLE_ACCOUNT_TYPES_SQL = buzzBankTypes.map((type) => `'${type}'`).join(', ');
-
 const earnedCache = createCachedObject<{ id: number; earned: number }>({
   key: REDIS_KEYS.BUZZ.EARNED,
   idKey: 'id',
@@ -1457,7 +1455,7 @@ const earnedCache = createCachedObject<{ id: number; earned: number }>({
         (type IN ('compensation')) -- Generation
         OR (type = 'purchase' AND fromAccountId != 0) -- Early Access
       )
-      AND toAccountType IN (${BANKABLE_ACCOUNT_TYPES_SQL})
+      AND toAccountType IN (${buzzBankTypesSql})
       AND toAccountId IN (${ids})
       AND toStartOfMonth(date) = toStartOfMonth(subtractMonths(now(), 1))
       GROUP BY toAccountId;
@@ -1485,7 +1483,7 @@ export async function getPoolForecast({ userId, username }: GetEarnPotentialSche
         SELECT
           SUM(amount) AS balance
         FROM buzzTransactions
-        WHERE toAccountType IN (${BANKABLE_ACCOUNT_TYPES_SQL})
+        WHERE toAccountType IN (${buzzBankTypesSql})
         AND (
           (type IN ('compensation')) -- Generation
           OR (type = 'purchase' AND fromAccountId != 0) -- Early Access
@@ -1506,7 +1504,7 @@ export async function getPoolForecast({ userId, username }: GetEarnPotentialSche
         SELECT
             SUM(amount) / 1000 AS balance
         FROM buzzTransactions
-        WHERE toAccountType IN (${BANKABLE_ACCOUNT_TYPES_SQL})
+        WHERE toAccountType IN (${buzzBankTypesSql})
         AND type = 'purchase'
         AND fromAccountId = 0
         AND externalTransactionId NOT LIKE 'renewalBonus:%'

--- a/src/server/services/creator-program.service.ts
+++ b/src/server/services/creator-program.service.ts
@@ -12,7 +12,11 @@ import { dbWrite } from '~/server/db/client';
 import { REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { decodeRedisString } from '~/server/redis/buffer-decode';
 import type { BuzzCreatorProgramType, BuzzSpendType } from '~/shared/constants/buzz.constants';
-import { TransactionType, buzzBankTypes } from '~/shared/constants/buzz.constants';
+import {
+  TransactionType,
+  buzzBankTypes,
+  buzzBankTypesSql,
+} from '~/shared/constants/buzz.constants';
 import type {
   CashWithdrawalMetadataSchema,
   CompensationPoolInput,
@@ -71,8 +75,6 @@ type UserCapCacheItem = {
   cap: number;
 };
 
-const BANKABLE_BUZZ_TYPES_STRING = `'yellow', 'green'`;
-
 const getBankAccountType = (_buzzType?: BuzzSpendType): BuzzCreatorProgramType => {
   return 'creatorProgramBank';
 };
@@ -123,7 +125,7 @@ const createUserCapCache = () => {
           (type IN ('compensation')) -- Generation Comp
           OR (type = 'purchase' AND fromAccountId != 0) -- Early Access
         )
-        AND toAccountType IN (${BANKABLE_BUZZ_TYPES_STRING})
+        AND toAccountType IN (${buzzBankTypesSql})
         AND toAccountId IN (${ids})
         AND toStartOfMonth(date) >= toStartOfMonth(subtractMonths(now(), ${PEAK_EARNING_WINDOW}))
         AND toStartOfMonth(date) < toStartOfMonth(now())
@@ -325,7 +327,7 @@ async function getPoolValue(month?: Date) {
     SELECT
         SUM(amount) / 1000 AS balance
     FROM buzzTransactions
-    WHERE toAccountType IN (${BANKABLE_BUZZ_TYPES_STRING})
+    WHERE toAccountType IN (${buzzBankTypesSql})
     AND (
       type = 'purchase'
       OR (type = 'redeemable' AND description LIKE 'Redeemed code SH-%')
@@ -362,7 +364,7 @@ async function getPoolForecast(month?: Date) {
     SELECT
       SUM(amount) AS balance
     FROM buzzTransactions
-    WHERE toAccountType IN (${BANKABLE_BUZZ_TYPES_STRING})
+    WHERE toAccountType IN (${buzzBankTypesSql})
     AND (
       (type IN ('compensation','tip')) -- Generation
       OR (type = 'purchase' AND fromAccountId != 0) -- Early Access
@@ -902,12 +904,12 @@ export async function getPoolParticipants(month?: Date, includeNegativeAmounts =
       -- Banks
       toAccountType = '${bankAccountType}'
       AND toAccountId = ${monthAccount}
-      AND fromAccountType IN (${BANKABLE_BUZZ_TYPES_STRING})
+      AND fromAccountType IN (${buzzBankTypesSql})
     ) OR (
       -- Extracts
       fromAccountType = '${bankAccountType}'
       AND fromAccountId = ${monthAccount}
-      AND toAccountType IN (${BANKABLE_BUZZ_TYPES_STRING})
+      AND toAccountType IN (${buzzBankTypesSql})
     )
     GROUP BY userId
     ${includeNegativeAmounts ? '' : 'HAVING amount > 0'};

--- a/src/shared/constants/buzz.constants.ts
+++ b/src/shared/constants/buzz.constants.ts
@@ -124,6 +124,8 @@ export const buzzBankTypes = buzzSpendTypes.filter((type) => {
   const config = buzzTypeConfig[type];
   return config.type === 'spend' && config.bankable;
 }) as BuzzSpendType[];
+/** Quoted list for `IN (...)` in the ClickHouse buzzTransactions queries. */
+export const buzzBankTypesSql = buzzBankTypes.map((type) => `'${type}'`).join(', ');
 export const buzzPurchaseTypes = buzzSpendTypes.filter((type) => {
   const config = buzzTypeConfig[type];
   return config.type === 'spend' && config.purchasable;


### PR DESCRIPTION
Closes ClickUp `868kw8buk`.

## The lists agreed today — no wrong Cap was served

Checked before touching anything, because a divergence here would be a live bug rather than a refactor:

- `creator-program.service.ts` carried `const BANKABLE_BUZZ_TYPES_STRING = \`'yellow', 'green'\``.
- `buzzBankTypes` derives from `buzzTypeConfig`, where exactly `green` and `yellow` carry `bankable: true` (`blue` has no flag, `red` is `disabled`), so it is `['green','yellow']`.

Same set, different order, and order is meaningless inside `IN (...)`. I also checked the spelling against prod rather than trusting the constant: `buzzTransactions` over the last 30 days holds exactly `blue`, `yellow`, `green`, `creatorProgramBank`, `cashSettled`, `cashPending` as `toAccountType`, all lowercase, matching the keys. So no casing trap either.

## What changed

One derivation, in `buzz.constants.ts` beside `buzzBankTypes`:

```ts
export const buzzBankTypesSql = buzzBankTypes.map((type) => `'${type}'`).join(', ');
```

`creator-program.service.ts` used the hand-written string at **5** ClickHouse sites — one of them the peak-earning query behind a creator's Cap, where a wrong list returns a plausible wrong number rather than an error. `buzz.service.ts` had its own identical `buzzBankTypes.map(...)` copy at 3 sites. Both now read the one export. The emitted SQL is unchanged in shape; only the interpolated value's source moved.

⚠️ Worth a reviewer's eye: `bankable` in `buzzTypeConfig` now drives both the UI (which tiles `CreatorProgramV2` renders, `SUPPORTED_BUZZ`, the schema `z.enum`) **and** which historical rows count toward pool value, pool forecast and Peak Earning Month. Before this diff the creator-program half was insulated by its own literal. That coupling is the point of the change, but it means flipping `bankable` on a colour for a UI reason retroactively moves the compensation pool and every Cap, behind day-long caches, with no error.

## The test, and what the controls did

The assertion pins the **column and the list together**, anchored to the line:

```ts
expect(sql).toMatch(new RegExp(String.raw`\n\s*AND toAccountType IN \(${bankable}\)`));
```

Every one of these mutations was run, not reasoned about, and each fails with the new test named — `Tests 1 failed | 42 passed (43)`:

| mutation | why it matters |
|---|---|
| re-hardcode the list as `'yellow', 'green'` | the defect this PR removes |
| `toAccountType` → `fromAccountType` | swaps a receiving-side restriction for a sending-side one; **green under an earlier, weaker version of this test** |
| comment the clause out with `--` | leaves no account-type filter at all, inflating every Cap with blue Buzz; **green under a plain `toContain`** |
| drop `String.raw` | `\s` becomes the letter `s`, matches nothing, test goes red rather than silently passing |

Unmutated: `Tests 43 passed (43)`. Known residual, stated rather than hidden: a trailing `OR toAccountType = 'blue'` appended to the clause still passes, since nothing anchors the clause's end.

Also: marking `blue` bankable in `buzzTypeConfig` makes the emitted list `'blue', 'green', 'yellow'`, so the string genuinely follows the constant rather than being pinned to today's value. (Probe only; not in the diff.)

## Verification

- `pnpm run typecheck`: `OK — 0 type errors in 244s`.
- `pnpm run test:unit:run` on this SHA: `Test Files 1 failed | 1395 passed | 1 skipped (1397)`, `Tests 1 failed | 21876 passed | 27 skipped (21904)`, exit 1. The one failure is `pageRunScrollContract.test.ts`, a path-separator guard reading `src\pages\...` on Windows — **pre-existing**: it fails identically (`Tests 1 failed | 9 passed (10)`) in a second worktree on the same base whose `src/` is untouched.
- `blocks.router.workflow.test.ts` collected **358** tests, so the submodule is initialised and the run means something.
- Lint: repo-wide `pnpm run lint` is red on `main` (`4364 problems (362 errors…)`), so I scoped it — the four touched files carry 4 errors on this branch and the identical 4 on stashed `main`. Zero added.

No migration, no behaviour change intended, no generation flows exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)