### PR TITLE
fix(apps): make the listing-completeness advisory KIND-AWARE (on-site copy lives in block.manifest.json)

### DIFF
--- a/scripts/mutation/listing-problems-kind.mutation.py
+++ b/scripts/mutation/listing-problems-kind.mutation.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Mutation battery for the KIND dimension of the listing-completeness advisory.
+
+Committed so the PR's mutation claims are AUDITABLE FROM ARTIFACTS rather than
+reconstructible only from a table in the PR body. Re-run it and diff the output.
+
+    scripts/mutation/listing-problems-kind.mutation.py            # run the battery
+    scripts/mutation/listing-problems-kind.mutation.py --list     # just print the mutants
+
+Method, and why each part is there:
+
+  * Each mutant asserts its target text occurs EXACTLY ONCE before replacing. A
+    `count=1` replace on an ambiguous pattern hits an occurrence you did not picture.
+  * Each mutant is the NARROWEST expression that can be wrong. None removes a guard
+    together with its enclosing condition — that kind of mutant dies for the wrong
+    reason and proves nothing about the guard.
+  * BASELINE RECONCILIATION: the baseline total is measured at the start, and every
+    mutant's run must produce the SAME total. A run whose total differs was truncated
+    or panicked, so its verdict is UNATTRIBUTED — never SURVIVED. (A sibling battery
+    once scored a mutant SURVIVED off a run that died a quarter of the way in.)
+  * DEFINED vs VERDICTS-PRODUCED are reported separately, so a mutant that silently
+    failed to apply cannot be counted as coverage.
+  * M0 is a POSITIVE CONTROL: a mutant known to be caught, kept in the batch so a run
+    that has stopped executing anything cannot report a clean sweep.
+
+Every mutation is reverted from a byte copy of the original in a `finally`, so an
+interrupted run leaves the tree clean.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER = ROOT / "scripts/mutation/listing-problems-kind.suite.sh"
+RUN_LOG = ROOT / ".mutation-run.log"
+
+LP = "src/server/services/blocks/listing-problems.ts"
+AA = "src/server/services/blocks/app-access.service.ts"
+BR = "src/server/routers/blocks.router.ts"
+OS_ = "src/server/services/blocks/offsite-listing.service.ts"
+
+CAT_ONSITE = (
+    "'Missing category — resubmit to apply it; "
+    "set \"category\" in block.manifest.json first if your app has none'"
+)
+
+# id, file, find, replace, what defect it expresses
+MUTANTS: list[tuple[str, str, str, str, str]] = [
+    ("M0-CTRL", LP,
+     "'empty-tagline': 'Missing tagline',",
+     "'empty-tagline': 'MUTANT-CONTROL',",
+     "POSITIVE CONTROL: off-site tagline label is garbage. Must die loudly."),
+
+    ("M1", LP,
+     "listing.kind === 'onsite' ? TEXT_PROBLEM.onsite : TEXT_PROBLEM.offsite",
+     "listing.kind === 'offsite' ? TEXT_PROBLEM.onsite : TEXT_PROBLEM.offsite",
+     "the kind comparison names the WRONG literal (arms swapped)."),
+
+    ("M2", LP,
+     "listing.kind === 'onsite' ? TEXT_PROBLEM.onsite : TEXT_PROBLEM.offsite",
+     "listing.kind === 'onsite' ? TEXT_PROBLEM.offsite : TEXT_PROBLEM.offsite",
+     "the ON-SITE arm collapses to off-site == THE ORIGINAL DEFECT, exactly."),
+
+    ("M3", LP,
+     "listing.kind === 'onsite' ? TEXT_PROBLEM.onsite : TEXT_PROBLEM.offsite",
+     "listing.kind === 'onsite' ? TEXT_PROBLEM.onsite : TEXT_PROBLEM.onsite",
+     "the OFF-SITE arm gets manifest advice (the defect pointing the other way)."),
+
+    ("M4", LP,
+     "'empty-tagline': 'Missing tagline — set \"tagline\" in block.manifest.json and resubmit',",
+     "'empty-tagline': 'Missing tagline',",
+     "ONE on-site label regresses to the original; the others stay correct."),
+
+    ("M5", LP,
+     "'empty-description':\n      'Missing description — set \"description\" in block.manifest.json and resubmit',",
+     "'empty-description':\n      'Missing description — set \"tagline\" in block.manifest.json and resubmit',",
+     "an on-site label names the WRONG manifest key."),
+
+    ("M6", LP,
+     "problems.push({ code: 'empty-tagline', label: text['empty-tagline'], severity: 'advisory' });",
+     "problems.push({ code: 'empty-tagline', label: text['empty-description'], severity: 'advisory' });",
+     "the label lookup uses the WRONG key at one push site."),
+
+    ("M7", LP,
+     "  if (isEmpty(listing.category))\n    problems.push({ code: 'empty-category', label: text['empty-category'], severity: 'advisory' });",
+     "  if (isEmpty(listing.category))\n    problems.push({ code: 'empty-category', label: TEXT_PROBLEM.offsite['empty-category'], severity: 'advisory' });",
+     "one code stays kind-BLIND while the other two are fixed (a PARTIAL fix)."),
+
+    ("M8", AA,
+     "          kind,\n          iconId: r.iconId ?? null,",
+     "          kind: 'offsite' as typeof kind,\n          iconId: r.iconId ?? null,",
+     "CALLER 1 (listMine) hardcodes offsite instead of threading the row's kind."),
+
+    ("M9", AA,
+     "          kind,\n          iconId: r.iconId ?? null,",
+     "          kind: 'onsite' as typeof kind,\n          iconId: r.iconId ?? null,",
+     "CALLER 1 hardcodes onsite (the mirror of M8)."),
+
+    ("M10", BR,
+     "              kind: listing.kind as ListingProblemKind,",
+     "              kind: 'onsite' as ListingProblemKind,",
+     "CALLER 2 spells its where-clause's conclusion instead of reading the column."),
+
+    ("M11", BR,
+     "          status: true,\n          kind: true,\n          iconId: true,",
+     "          status: true,\n          iconId: true,",
+     "CALLER 2 stops PROJECTING kind (the silent-revert route)."),
+
+    ("M12", OS_,
+     "          kind: (r.appListing.kind ?? 'offsite') as ListingProblemKind,",
+     "          kind: 'offsite' as ListingProblemKind,",
+     "CALLER 3 hardcodes offsite — wrong for the on-site media revisions it returns."),
+
+    ("M13", OS_,
+     "      kind: true,\n      iconId: true,\n      coverId: true,",
+     "      iconId: true,\n      coverId: true,",
+     "CALLER 3 stops PROJECTING the listing's kind."),
+
+    # --- added after the #4370 adversarial audit ------------------------------
+    ("M14", OS_,
+     "          kind: (r.appListing.kind ?? 'offsite') as ListingProblemKind,",
+     "          kind: (r.kind ?? 'offsite') as ListingProblemKind,",
+     "CALLER 3 reads the REQUEST's kind instead of the LISTING's. SURVIVED the "
+     "pre-audit battery, because every fixture set the two equal — the audit found "
+     "it. Killed now by the one fixture that makes them disagree."),
+
+    ("M15", LP,
+     "    'empty-category':\n      " + CAT_ONSITE + ",",
+     "    'empty-category': 'Missing category — set \"category\" in block.manifest.json and resubmit',",
+     "the on-site category label reverts to MANIFEST-FIRST — the wrong diagnosis the "
+     "audit caught: inert once a moderator has curated, because (3a)'s null-gate no "
+     "longer fires."),
+]
+
+
+def run() -> tuple[int | None, int | None, list[str]]:
+    p = subprocess.run(["bash", str(RUNNER), str(RUN_LOG)], capture_output=True, text=True)
+    out = p.stdout
+    m = re.search(
+        r"Tests\s+(?:(\d+) failed \| )?(\d+) passed(?: \| (\d+) skipped)? \((\d+)\)", out
+    )
+    if not m:
+        return None, None, ["<<UNPARSEABLE>>: " + out.strip()[:400]]
+    return int(m.group(1) or 0), int(m.group(4)), [l for l in out.splitlines() if l.startswith("× ")]
+
+
+def main() -> int:
+    if "--list" in sys.argv:
+        for mid, rel, _f, _r, why in MUTANTS:
+            print(f"{mid:9} {rel.split('/')[-1]:28} {why}")
+        return 0
+
+    print("measuring baseline (unmutated tree)...", flush=True)
+    base_failed, baseline_total, _ = run()
+    if base_failed is None:
+        print("FATAL: could not parse the baseline run; is the suite runnable?")
+        return 2
+    if base_failed:
+        print(f"FATAL: baseline is RED ({base_failed} failing). Fix that before mutating.")
+        return 2
+    print(f"baseline: {baseline_total} tests, 0 failing\n", flush=True)
+
+    results = []
+    for mid, rel, find, repl, why in MUTANTS:
+        path = ROOT / rel
+        orig = path.read_text()
+        n = orig.count(find)
+        if n != 1:
+            results.append({"id": mid, "file": rel, "why": why,
+                            "verdict": "NOT-APPLIED", "occurrences": n})
+            print(f"{mid}: NOT-APPLIED (target occurs {n}x, expected exactly 1)", flush=True)
+            continue
+        backup = path.with_suffix(path.suffix + ".mutbak")
+        shutil.copyfile(path, backup)
+        try:
+            path.write_text(orig.replace(find, repl, 1))
+            failed, total, names = run()
+            if failed is None:
+                verdict = "UNATTRIBUTED (unparseable run)"
+            elif total != baseline_total:
+                verdict = f"UNATTRIBUTED (total {total} != baseline {baseline_total})"
+            elif failed > 0:
+                verdict = "KILLED"
+            else:
+                verdict = "SURVIVED"
+            results.append({"id": mid, "file": rel, "why": why, "verdict": verdict,
+                            "failed": failed, "total": total, "killers": names})
+            print(f"{mid}: {verdict}  failed={failed} total={total}", flush=True)
+            for nm in names[:6]:
+                print("      " + nm, flush=True)
+        finally:
+            shutil.copyfile(backup, path)
+            backup.unlink()
+
+    (ROOT / "scripts/mutation/listing-problems-kind.results.json").write_text(
+        json.dumps({"baselineTotal": baseline_total, "results": results}, indent=2) + "\n"
+    )
+    RUN_LOG.unlink(missing_ok=True)
+
+    defined = len(MUTANTS)
+    produced = sum(1 for r in results if r.get("verdict") in ("KILLED", "SURVIVED"))
+    killed = sum(1 for r in results if r.get("verdict") == "KILLED")
+    survived = sum(1 for r in results if r.get("verdict") == "SURVIVED")
+    print(f"\nDEFINED={defined}  VERDICTS-PRODUCED={produced}  KILLED={killed}  "
+          f"SURVIVED={survived}  OTHER={defined - produced}")
+    return 0 if (produced == defined and killed == defined) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mutation/listing-problems-kind.results.json
+++ b/scripts/mutation/listing-problems-kind.results.json
@@ -1,0 +1,272 @@
+{
+  "baselineTotal": 154,
+  "results": [
+    {
+      "id": "M0-CTRL",
+      "file": "src/server/services/blocks/listing-problems.ts",
+      "why": "POSITIVE CONTROL: off-site tagline label is garbage. Must die loudly.",
+      "verdict": "KILLED",
+      "failed": 10,
+      "total": 154,
+      "killers": [
+        "\u00d7 POSITIVE CONTROL \u2014 an OFF-SITE row still produces the ORIGINAL labels, verbatim",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 the service reads EACH row's own kind, not a constant",
+        "\u00d7 POSITIVE CONTROL \u2014 an OFF-SITE submission still produces the ORIGINAL label, verbatim",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 each row reads its OWN listing kind",
+        "\u00d7 the MIRROR \u2014 an on-site request pointing at an off-site listing takes the OFF-SITE label",
+        "\u00d7 a fake that omits the listing kind degrades to the ORIGINAL labels, and never throws",
+        "\u00d7 empty-tagline reads \"Missing tagline\"",
+        "\u00d7 yields the ORIGINAL (off-site) label, not the manifest one",
+        "\u00d7 a PROTOTYPE key is not mistaken for a known kind (the table must not fail open)",
+        "\u00d7 \ud83d\udd34 DISCRIMINATING CONTROL \u2014 a row whose kind COLUMN says offsite gets the ORIGINAL label"
+      ]
+    },
+    {
+      "id": "M1",
+      "file": "src/server/services/blocks/listing-problems.ts",
+      "why": "the kind comparison names the WRONG literal (arms swapped).",
+      "verdict": "KILLED",
+      "failed": 20,
+      "total": 154,
+      "killers": [
+        "\u00d7 empty-description reads \"Missing description\"",
+        "\u00d7 empty-tagline reads \"Missing tagline\"",
+        "\u00d7 empty-category reads \"Missing category\"",
+        "\u00d7 empty-description reads \"Missing description \u2014 set \"description\" in block.manifest.json and resubmit\"",
+        "\u00d7 empty-tagline reads \"Missing tagline \u2014 set \"tagline\" in block.manifest.json and resubmit\"",
+        "\u00d7 empty-category reads \"Missing category \u2014 resubmit to apply it; set \"category\" in block.manifest.json first if your app has none\"",
+        "\u00d7 \ud83d\udd34 the ON-SITE category label leads with RESUBMIT and marks the manifest CONDITIONAL",
+        "\u00d7 \ud83d\udd34 description/tagline are the MIRROR \u2014 manifest FIRST, because for them it IS the whole remedy",
+        "\u00d7 an ON-SITE row names block.manifest.json for all three text problems",
+        "\u00d7 POSITIVE CONTROL \u2014 an OFF-SITE row still produces the ORIGINAL labels, verbatim",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 the service reads EACH row's own kind, not a constant",
+        "\u00d7 an ON-SITE media revision names block.manifest.json",
+        "\u00d7 POSITIVE CONTROL \u2014 an OFF-SITE submission still produces the ORIGINAL label, verbatim",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 each row reads its OWN listing kind",
+        "\u00d7 \ud83d\udd34 request.kind and listing.kind DISAGREE \u2014 the LISTING wins",
+        "\u00d7 the MIRROR \u2014 an on-site request pointing at an off-site listing takes the OFF-SITE label",
+        "\u00d7 a fake that omits the listing kind degrades to the ORIGINAL labels, and never throws",
+        "\u00d7 an ON-SITE backing listing names block.manifest.json",
+        "\u00d7 \ud83d\udd34 DISCRIMINATING CONTROL \u2014 a row whose kind COLUMN says offsite gets the ORIGINAL label",
+        "\u00d7 a narrow fake omitting `kind` degrades to the on-site labels (this query only admits on-site rows)"
+      ]
+    },
+    {
+      "id": "M2",
+      "file": "src/server/services/blocks/listing-problems.ts",
+      "why": "the ON-SITE arm collapses to off-site == THE ORIGINAL DEFECT, exactly.",
+      "verdict": "KILLED",
+      "failed": 13,
+      "total": 154,
+      "killers": [
+        "\u00d7 empty-description reads \"Missing description \u2014 set \"description\" in block.manifest.json and resubmit\"",
+        "\u00d7 empty-tagline reads \"Missing tagline \u2014 set \"tagline\" in block.manifest.json and resubmit\"",
+        "\u00d7 empty-category reads \"Missing category \u2014 resubmit to apply it; set \"category\" in block.manifest.json first if your app has none\"",
+        "\u00d7 the two arms DIFFER for all three codes (guards against both arms collapsing to one table)",
+        "\u00d7 \ud83d\udd34 the ON-SITE category label leads with RESUBMIT and marks the manifest CONDITIONAL",
+        "\u00d7 \ud83d\udd34 description/tagline are the MIRROR \u2014 manifest FIRST, because for them it IS the whole remedy",
+        "\u00d7 an ON-SITE row names block.manifest.json for all three text problems",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 the service reads EACH row's own kind, not a constant",
+        "\u00d7 an ON-SITE media revision names block.manifest.json",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 each row reads its OWN listing kind",
+        "\u00d7 \ud83d\udd34 request.kind and listing.kind DISAGREE \u2014 the LISTING wins",
+        "\u00d7 an ON-SITE backing listing names block.manifest.json",
+        "\u00d7 a narrow fake omitting `kind` degrades to the on-site labels (this query only admits on-site rows)"
+      ]
+    },
+    {
+      "id": "M3",
+      "file": "src/server/services/blocks/listing-problems.ts",
+      "why": "the OFF-SITE arm gets manifest advice (the defect pointing the other way).",
+      "verdict": "KILLED",
+      "failed": 13,
+      "total": 154,
+      "killers": [
+        "\u00d7 empty-description reads \"Missing description\"",
+        "\u00d7 empty-tagline reads \"Missing tagline\"",
+        "\u00d7 empty-category reads \"Missing category\"",
+        "\u00d7 the two arms DIFFER for all three codes (guards against both arms collapsing to one table)",
+        "\u00d7 yields the ORIGINAL (off-site) label, not the manifest one",
+        "\u00d7 a PROTOTYPE key is not mistaken for a known kind (the table must not fail open)",
+        "\u00d7 POSITIVE CONTROL \u2014 an OFF-SITE row still produces the ORIGINAL labels, verbatim",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 the service reads EACH row's own kind, not a constant",
+        "\u00d7 POSITIVE CONTROL \u2014 an OFF-SITE submission still produces the ORIGINAL label, verbatim",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 each row reads its OWN listing kind",
+        "\u00d7 the MIRROR \u2014 an on-site request pointing at an off-site listing takes the OFF-SITE label",
+        "\u00d7 a fake that omits the listing kind degrades to the ORIGINAL labels, and never throws",
+        "\u00d7 \ud83d\udd34 DISCRIMINATING CONTROL \u2014 a row whose kind COLUMN says offsite gets the ORIGINAL label"
+      ]
+    },
+    {
+      "id": "M4",
+      "file": "src/server/services/blocks/listing-problems.ts",
+      "why": "ONE on-site label regresses to the original; the others stay correct.",
+      "verdict": "KILLED",
+      "failed": 10,
+      "total": 154,
+      "killers": [
+        "\u00d7 empty-tagline reads \"Missing tagline \u2014 set \"tagline\" in block.manifest.json and resubmit\"",
+        "\u00d7 the two arms DIFFER for all three codes (guards against both arms collapsing to one table)",
+        "\u00d7 \ud83d\udd34 description/tagline are the MIRROR \u2014 manifest FIRST, because for them it IS the whole remedy",
+        "\u00d7 an ON-SITE row names block.manifest.json for all three text problems",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 the service reads EACH row's own kind, not a constant",
+        "\u00d7 an ON-SITE media revision names block.manifest.json",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 each row reads its OWN listing kind",
+        "\u00d7 \ud83d\udd34 request.kind and listing.kind DISAGREE \u2014 the LISTING wins",
+        "\u00d7 an ON-SITE backing listing names block.manifest.json",
+        "\u00d7 a narrow fake omitting `kind` degrades to the on-site labels (this query only admits on-site rows)"
+      ]
+    },
+    {
+      "id": "M5",
+      "file": "src/server/services/blocks/listing-problems.ts",
+      "why": "an on-site label names the WRONG manifest key.",
+      "verdict": "KILLED",
+      "failed": 3,
+      "total": 154,
+      "killers": [
+        "\u00d7 empty-description reads \"Missing description \u2014 set \"description\" in block.manifest.json and resubmit\"",
+        "\u00d7 an ON-SITE row names block.manifest.json for all three text problems",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 the service reads EACH row's own kind, not a constant"
+      ]
+    },
+    {
+      "id": "M6",
+      "file": "src/server/services/blocks/listing-problems.ts",
+      "why": "the label lookup uses the WRONG key at one push site.",
+      "verdict": "KILLED",
+      "failed": 17,
+      "total": 154,
+      "killers": [
+        "\u00d7 empty-tagline reads \"Missing tagline\"",
+        "\u00d7 empty-tagline reads \"Missing tagline \u2014 set \"tagline\" in block.manifest.json and resubmit\"",
+        "\u00d7 the three ON-SITE labels are distinct from each other (no copy-paste of one field name)",
+        "\u00d7 yields the ORIGINAL (off-site) label, not the manifest one",
+        "\u00d7 a PROTOTYPE key is not mistaken for a known kind (the table must not fail open)",
+        "\u00d7 an ON-SITE row names block.manifest.json for all three text problems",
+        "\u00d7 POSITIVE CONTROL \u2014 an OFF-SITE row still produces the ORIGINAL labels, verbatim",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 the service reads EACH row's own kind, not a constant",
+        "\u00d7 an ON-SITE media revision names block.manifest.json",
+        "\u00d7 POSITIVE CONTROL \u2014 an OFF-SITE submission still produces the ORIGINAL label, verbatim",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 each row reads its OWN listing kind",
+        "\u00d7 \ud83d\udd34 request.kind and listing.kind DISAGREE \u2014 the LISTING wins",
+        "\u00d7 the MIRROR \u2014 an on-site request pointing at an off-site listing takes the OFF-SITE label",
+        "\u00d7 a fake that omits the listing kind degrades to the ORIGINAL labels, and never throws",
+        "\u00d7 an ON-SITE backing listing names block.manifest.json",
+        "\u00d7 \ud83d\udd34 DISCRIMINATING CONTROL \u2014 a row whose kind COLUMN says offsite gets the ORIGINAL label",
+        "\u00d7 a narrow fake omitting `kind` degrades to the on-site labels (this query only admits on-site rows)"
+      ]
+    },
+    {
+      "id": "M7",
+      "file": "src/server/services/blocks/listing-problems.ts",
+      "why": "one code stays kind-BLIND while the other two are fixed (a PARTIAL fix).",
+      "verdict": "KILLED",
+      "failed": 5,
+      "total": 154,
+      "killers": [
+        "\u00d7 empty-category reads \"Missing category \u2014 resubmit to apply it; set \"category\" in block.manifest.json first if your app has none\"",
+        "\u00d7 the two arms DIFFER for all three codes (guards against both arms collapsing to one table)",
+        "\u00d7 \ud83d\udd34 the ON-SITE category label leads with RESUBMIT and marks the manifest CONDITIONAL",
+        "\u00d7 an ON-SITE row names block.manifest.json for all three text problems",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 the service reads EACH row's own kind, not a constant"
+      ]
+    },
+    {
+      "id": "M8",
+      "file": "src/server/services/blocks/app-access.service.ts",
+      "why": "CALLER 1 (listMine) hardcodes offsite instead of threading the row's kind.",
+      "verdict": "KILLED",
+      "failed": 2,
+      "total": 154,
+      "killers": [
+        "\u00d7 an ON-SITE row names block.manifest.json for all three text problems",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 the service reads EACH row's own kind, not a constant"
+      ]
+    },
+    {
+      "id": "M9",
+      "file": "src/server/services/blocks/app-access.service.ts",
+      "why": "CALLER 1 hardcodes onsite (the mirror of M8).",
+      "verdict": "KILLED",
+      "failed": 2,
+      "total": 154,
+      "killers": [
+        "\u00d7 POSITIVE CONTROL \u2014 an OFF-SITE row still produces the ORIGINAL labels, verbatim",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 the service reads EACH row's own kind, not a constant"
+      ]
+    },
+    {
+      "id": "M10",
+      "file": "src/server/routers/blocks.router.ts",
+      "why": "CALLER 2 spells its where-clause's conclusion instead of reading the column.",
+      "verdict": "KILLED",
+      "failed": 1,
+      "total": 154,
+      "killers": [
+        "\u00d7 \ud83d\udd34 DISCRIMINATING CONTROL \u2014 a row whose kind COLUMN says offsite gets the ORIGINAL label"
+      ]
+    },
+    {
+      "id": "M11",
+      "file": "src/server/routers/blocks.router.ts",
+      "why": "CALLER 2 stops PROJECTING kind (the silent-revert route).",
+      "verdict": "KILLED",
+      "failed": 1,
+      "total": 154,
+      "killers": [
+        "\u00d7 the listing query PROJECTS `kind` (a dropped projection silently reverts this)"
+      ]
+    },
+    {
+      "id": "M12",
+      "file": "src/server/services/blocks/offsite-listing.service.ts",
+      "why": "CALLER 3 hardcodes offsite \u2014 wrong for the on-site media revisions it returns.",
+      "verdict": "KILLED",
+      "failed": 3,
+      "total": 154,
+      "killers": [
+        "\u00d7 an ON-SITE media revision names block.manifest.json",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 each row reads its OWN listing kind",
+        "\u00d7 \ud83d\udd34 request.kind and listing.kind DISAGREE \u2014 the LISTING wins"
+      ]
+    },
+    {
+      "id": "M13",
+      "file": "src/server/services/blocks/offsite-listing.service.ts",
+      "why": "CALLER 3 stops PROJECTING the listing's kind.",
+      "verdict": "KILLED",
+      "failed": 1,
+      "total": 154,
+      "killers": [
+        "\u00d7 the query PROJECTS the LISTING's kind, not only the REQUEST's"
+      ]
+    },
+    {
+      "id": "M14",
+      "file": "src/server/services/blocks/offsite-listing.service.ts",
+      "why": "CALLER 3 reads the REQUEST's kind instead of the LISTING's. SURVIVED the pre-audit battery, because every fixture set the two equal \u2014 the audit found it. Killed now by the one fixture that makes them disagree.",
+      "verdict": "KILLED",
+      "failed": 2,
+      "total": 154,
+      "killers": [
+        "\u00d7 \ud83d\udd34 request.kind and listing.kind DISAGREE \u2014 the LISTING wins",
+        "\u00d7 the MIRROR \u2014 an on-site request pointing at an off-site listing takes the OFF-SITE label"
+      ]
+    },
+    {
+      "id": "M15",
+      "file": "src/server/services/blocks/listing-problems.ts",
+      "why": "the on-site category label reverts to MANIFEST-FIRST \u2014 the wrong diagnosis the audit caught: inert once a moderator has curated, because (3a)'s null-gate no longer fires.",
+      "verdict": "KILLED",
+      "failed": 4,
+      "total": 154,
+      "killers": [
+        "\u00d7 empty-category reads \"Missing category \u2014 resubmit to apply it; set \"category\" in block.manifest.json first if your app has none\"",
+        "\u00d7 \ud83d\udd34 the ON-SITE category label leads with RESUBMIT and marks the manifest CONDITIONAL",
+        "\u00d7 an ON-SITE row names block.manifest.json for all three text problems",
+        "\u00d7 \ud83d\udd34 BOTH KINDS ON ONE PAGE diverge \u2014 the service reads EACH row's own kind, not a constant"
+      ]
+    }
+  ]
+}

--- a/scripts/mutation/listing-problems-kind.suite.sh
+++ b/scripts/mutation/listing-problems-kind.suite.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run every suite that covers the KIND dimension of the listing-completeness advisory,
+# in ONE vitest invocation, and COUNT the result rather than reading an exit code.
+#
+# 🔴 THE TEST PATHS ARE PASSED LITERALLY, never through an unquoted variable. Under zsh
+# an unquoted `$FILES` does NOT word-split, so vitest receives one bogus filter, matches
+# nothing, and prints "No test files found" with a nonzero status — which reads exactly
+# like a real failure and cost a debugging round the first time.
+#
+# Usage: scripts/mutation/listing-problems-kind.suite.sh <output-log-path>
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Guard the VALUE, not just the cd: `cd ""` is a no-op returning 0 on bash <= 5.2.
+[ -n "$ROOT" ] && [ -d "$ROOT" ] || { echo "cannot resolve repo root" >&2; exit 9; }
+OUT="${1:?usage: $0 <output-log-path>}"
+cd "$ROOT" || exit 9
+
+pnpm vitest run --project unit \
+  src/server/services/blocks/__tests__/listing-problems.test.ts \
+  src/server/services/blocks/__tests__/listing-problems.kind.test.ts \
+  src/server/services/blocks/__tests__/app-access.my-app-listings-kind-problems.test.ts \
+  src/server/services/blocks/__tests__/app-listing-assets.scan-batch.test.ts \
+  src/server/services/__tests__/block-registry.marketplace-meta.test.ts \
+  src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts \
+  src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts \
+  > "$OUT" 2>&1
+rc=$?
+
+plain=$(sed 's/\x1b\[[0-9;]*m//g' "$OUT")
+total_line=$(printf '%s\n' "$plain" | grep -aE '^ *Tests +' | tail -1)
+echo "rc=$rc | $total_line"
+# Emit the failing test NAMES so a mutant's verdict can be attributed to a specific
+# guard rather than to "something went red".
+printf '%s\n' "$plain" | grep -aE '^ *× ' | sed 's/^ *//;s/ [0-9]*ms$//'

--- a/src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts
+++ b/src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts
@@ -323,3 +323,157 @@ describe('listMyPublishRequests — OWNER-ONLY scoping (guards the build-failure
     expect(args.select.reviewedAt).toBe(true); // the STRANDED-detection anchor
   });
 });
+
+// ---------------------------------------------------------------------------
+// The KIND seam of the completeness advisory.
+// ---------------------------------------------------------------------------
+
+/**
+ * 🔴 `computeListingProblems` now gives DIFFERENT advice per listing kind for
+ * `empty-description` / `empty-tagline` / `empty-category`, because an ON-SITE listing's
+ * copy has no author surface other than `block.manifest.json` — `approveRequest`'s
+ * (3b-sync) re-sync overwrites those scalars from the manifest on every subsequent-version
+ * approve. This router is one of THREE call sites that must thread the kind; a call site
+ * that is missed keeps the old, wrong advice on its surface and NOTHING else goes red.
+ *
+ * 🔴 THE OFF-SITE CASE HERE IS THE DISCRIMINATING CONTROL, and it is deliberately an
+ * ANOMALOUS row. This query's `where` filters `kind: 'onsite'`, so in production every row
+ * is on-site — which means an assertion that on-site rows get the manifest label passes
+ * EQUALLY against a hardcoded literal `'onsite'` at the call site. Feeding a row whose
+ * `kind` COLUMN says `offsite` is the only case that can tell "reads the column" from
+ * "spells the constant": it fails iff the value is hardcoded. That is why the router
+ * projects the column instead of restating the filter's conclusion.
+ *
+ * 🔴 WHICH CASES ARE REGRESSION COVERAGE. Measured at `origin/main` d345b654a2: 3 of the
+ * 5 cases below go RED — the on-site label, the `kind` projection, and the narrow-fake
+ * degrade. The other 2 PASS at base and are INVARIANT GUARDS, not coverage of this bug:
+ * at base EVERY listing got the original label, so the off-site discriminating control
+ * and the code-invariance case were green by construction. The discriminating control
+ * still earns its place — it is the ONLY case that kills a hardcoded `'onsite'` at the
+ * call site (M10 in the sweep), which no on-site assertion can do.
+ */
+describe('listMyPublishRequests — the advisory is KIND-AWARE', () => {
+  const MANIFEST_TAGLINE = 'Missing tagline — set "tagline" in block.manifest.json and resubmit';
+  const ORIGINAL_TAGLINE = 'Missing tagline';
+
+  /** A request row whose backing listing has every asset but NO tagline. */
+  const requestRow = (id: string, blockId: string) => ({
+    id,
+    appBlockId: null,
+    slug: `app-${id}`,
+    version: '1.0.0',
+    status: 'approved',
+    submittedAt: new Date('2026-01-01'),
+    reviewedAt: new Date('2026-01-02'),
+    rejectionReason: null,
+    approvalNotes: null,
+    deployState: 'live',
+    deployDetail: null,
+    deployUpdatedAt: new Date('2026-01-02'),
+    fileSummary: null,
+    manifestDiffSummary: null,
+    appBlock: { id: blockId, manifest: PAGE_MANIFEST, _count: { userSubscriptions: 0 } },
+  });
+
+  /**
+   * The listing row as the (select-honouring) query would return it. Assets present and
+   * pairwise distinct (icon 41, cover 53, screenshots 7) so only the TEXT problem fires
+   * and no expected value can be produced by reading a neighbouring field. `kind` has no
+   * default — every call states it.
+   */
+  const listingRow = (id: string, blockId: string, kind: string) => ({
+    id,
+    appBlockId: blockId,
+    status: 'approved',
+    kind,
+    iconId: 41,
+    coverId: 53,
+    description: 'A description.',
+    tagline: null,
+    category: 'utility',
+    _count: { screenshots: 7 },
+  });
+
+  const taglineLabelOf = (row: { problems: { code: string; label: string }[] }) =>
+    row.problems.find((p) => p.code === 'empty-tagline')?.label;
+
+  it('an ON-SITE backing listing names block.manifest.json', async () => {
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([requestRow('req-on', 'blk-on')]);
+    mockDbRead.appListing.findMany.mockResolvedValue([listingRow('l-on', 'blk-on', 'onsite')]);
+
+    const caller = blocksRouter.createCaller(fakeCtx(owner) as never);
+    const rows = await caller.listMyPublishRequests();
+
+    // Positive control: exactly the one text problem, so the label assertion is not
+    // reading whichever problem happened to land first.
+    expect(rows[0].problems.map((p) => p.code)).toEqual(['empty-tagline']);
+    expect(taglineLabelOf(rows[0])).toBe(MANIFEST_TAGLINE);
+  });
+
+  it('🔴 DISCRIMINATING CONTROL — a row whose kind COLUMN says offsite gets the ORIGINAL label', async () => {
+    // Fails iff the call site hardcodes 'onsite' instead of reading the projected column.
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([
+      requestRow('req-off', 'blk-off'),
+    ]);
+    mockDbRead.appListing.findMany.mockResolvedValue([listingRow('l-off', 'blk-off', 'offsite')]);
+
+    const caller = blocksRouter.createCaller(fakeCtx(owner) as never);
+    const rows = await caller.listMyPublishRequests();
+
+    expect(rows[0].problems.map((p) => p.code)).toEqual(['empty-tagline']);
+    expect(taglineLabelOf(rows[0])).toBe(ORIGINAL_TAGLINE);
+  });
+
+  it('the CODE is identical either way (wire contract — a released CLI branches on `code`)', async () => {
+    for (const kind of ['onsite', 'offsite']) {
+      vi.clearAllMocks();
+      mockIsAppBlocksEnabled.mockResolvedValue(true);
+      mockDbRead.blockUserSubscription.groupBy.mockResolvedValue([]);
+      mockDbRead.appListingModerationEvent.findMany.mockResolvedValue([]);
+      mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([requestRow('req-k', 'blk-k')]);
+      mockDbRead.appListing.findMany.mockResolvedValue([listingRow('l-k', 'blk-k', kind)]);
+
+      const caller = blocksRouter.createCaller(fakeCtx(owner) as never);
+      const rows = await caller.listMyPublishRequests();
+      expect(
+        rows[0].problems.map((p) => p.code),
+        `kind=${kind}`
+      ).toEqual(['empty-tagline']);
+    }
+  });
+
+  it('the listing query PROJECTS `kind` (a dropped projection silently reverts this)', async () => {
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([requestRow('req-p', 'blk-p')]);
+    mockDbRead.appListing.findMany.mockResolvedValue([listingRow('l-p', 'blk-p', 'onsite')]);
+
+    const caller = blocksRouter.createCaller(fakeCtx(owner) as never);
+    await caller.listMyPublishRequests();
+
+    const args = mockDbRead.appListing.findMany.mock.calls[0][0] as {
+      select: Record<string, unknown>;
+      where: Record<string, unknown>;
+    };
+    expect(args.select.kind).toBe(true);
+    // The filter this projection deliberately does NOT restate at the call site.
+    expect(args.where.kind).toBe('onsite');
+  });
+
+  it('a narrow fake omitting `kind` degrades to the on-site labels (this query only admits on-site rows)', async () => {
+    // The pre-existing cases in this file use exactly such a fake; this pins that the
+    // fallback is the honest one for THIS caller rather than an accident.
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([requestRow('req-n', 'blk-n')]);
+    mockDbRead.appListing.findMany.mockResolvedValue([
+      {
+        id: 'l-n',
+        appBlockId: 'blk-n',
+        status: 'approved',
+        tagline: null,
+        _count: { screenshots: 7 },
+      },
+    ]);
+
+    const caller = blocksRouter.createCaller(fakeCtx(owner) as never);
+    const rows = await caller.listMyPublishRequests();
+    expect(taglineLabelOf(rows[0])).toBe(MANIFEST_TAGLINE);
+  });
+});

--- a/src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts
+++ b/src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts
@@ -344,7 +344,7 @@ describe('listMyPublishRequests — OWNER-ONLY scoping (guards the build-failure
  * "spells the constant": it fails iff the value is hardcoded. That is why the router
  * projects the column instead of restating the filter's conclusion.
  *
- * 🔴 WHICH CASES ARE REGRESSION COVERAGE. Measured at `origin/main` d345b654a2: 3 of the
+ * 🔴 WHICH CASES ARE REGRESSION COVERAGE. Measured at `origin/main` 4bfd4c16d: 3 of the
  * 5 cases below go RED — the on-site label, the `kind` projection, and the narrow-fake
  * degrade. The other 2 PASS at base and are INVARIANT GUARDS, not coverage of this bug:
  * at base EVERY listing got the original label, so the off-site discriminating control

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -114,7 +114,10 @@ import {
   validateBlockCheckpoint,
 } from '~/server/services/blocks/checkpoint.service';
 import { getModelShowcaseImages } from '~/server/services/blocks/showcase.service';
-import { computeListingProblems } from '~/server/services/blocks/listing-problems';
+import {
+  computeListingProblems,
+  type ListingProblemKind,
+} from '~/server/services/blocks/listing-problems';
 import { getRequestDomainColor, isHostForColor } from '~/server/utils/server-domain';
 // Type-only: the runtime `resolveCanGenerateForVersions` is loaded via a
 // dynamic import() inside assertViewerCanGeneratePageResources so the heavy
@@ -2259,6 +2262,17 @@ export const blocksRouter = router({
         tagline: string | null;
         category: string | null;
         screenshotCount: number;
+        /**
+         * The listing's kind, threaded into `computeListingProblems` so the three
+         * empty-text problems name the right remedy.
+         *
+         * 🔴 PROJECTED, NOT ASSUMED, even though the `where` below filters
+         * `kind: 'onsite'`. A literal `'onsite'` at the call site would be a SECOND
+         * place that has to stay in step with that filter, and it would go wrong
+         * SILENTLY (wrong advice, no error) if the filter is ever widened. Reading
+         * the column costs nothing and cannot drift.
+         */
+        kind: string;
       }
     >();
     if (appBlockIds.length) {
@@ -2268,6 +2282,7 @@ export const blocksRouter = router({
           id: true,
           appBlockId: true,
           status: true,
+          kind: true,
           iconId: true,
           coverId: true,
           description: true,
@@ -2287,6 +2302,9 @@ export const blocksRouter = router({
           listingByBlockId.set(l.appBlockId, {
             id: l.id,
             status: l.status,
+            // A narrow test fake that ignores `select` yields `undefined`; the `where`
+            // clause above admits only on-site rows, so that is the honest fallback.
+            kind: l.kind ?? 'onsite',
             iconId: l.iconId,
             coverId: l.coverId,
             description: l.description,
@@ -2349,6 +2367,7 @@ export const blocksRouter = router({
         // version) — nothing to flag until a listing row exists.
         problems: listing
           ? computeListingProblems({
+              kind: listing.kind as ListingProblemKind,
               iconId: listing.iconId,
               coverId: listing.coverId,
               screenshotCount: listing.screenshotCount,

--- a/src/server/services/__tests__/block-registry.marketplace-meta.test.ts
+++ b/src/server/services/__tests__/block-registry.marketplace-meta.test.ts
@@ -308,3 +308,73 @@ describe('BlockRegistry.getMarketplaceMeta — mod seed read (F-E E4)', () => {
     expect(await BlockRegistry.getMarketplaceMeta('missing')).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// The curation/advisory SEAM: curation writes the BLOCK, never the LISTING.
+// ---------------------------------------------------------------------------
+
+/**
+ * 🔴 THIS PINS A FACT ANOTHER MODULE'S USER-FACING COPY IS DERIVED FROM.
+ * `computeListingProblems` (`listing-problems.ts`) tells an on-site author how to clear
+ * `empty-category`, and its wording depends entirely on WHERE a curated category lands.
+ *
+ * `setMarketplaceMeta` writes `AppBlock.category` and nothing else — it never touches
+ * `app_listings`. That is what makes this state reachable by DESIGN, not by accident:
+ *
+ *   author omits `category`      → listing minted with `category: null`
+ *   moderator curates            → `AppBlock.category` set, `AppListing.category` STILL null
+ *   ⇒ the advisory fires, and the store card genuinely shows no category
+ *
+ * The listing column is only rewritten at an APPROVE — `mapAppBlockToListing` (first
+ * approve / backfill) and `buildListingScalarSync` (3b-sync, subsequent-version), both
+ * of which read `AppBlock.category`. So the remedy that ALWAYS clears the problem is
+ * "get a new version approved"; editing the manifest is inert once a moderator has
+ * curated, because (3a)'s null-gate no longer fires. The advisory's label says exactly
+ * that, in that order.
+ *
+ * 🔴 IF THIS TEST EVER GOES RED because curation started writing the listing row too,
+ * the divergence is CLOSED and `listing-problems.ts`'s `empty-category` label should be
+ * revisited — the manifest-first wording would become correct again. That is the whole
+ * reason this guard is here rather than a comment: a comment claiming a relationship
+ * cannot notice when the relationship stops holding.
+ *
+ * 🔴 THIS IS AN INVARIANT GUARD, NOT REGRESSION COVERAGE — it passes at `origin/main`
+ * and always has, because `setMarketplaceMeta` never wrote the listing row. It is not
+ * evidence that anything was fixed. Its job is to make a fact that USER-FACING COPY IN
+ * ANOTHER MODULE depends on fail loudly if it ever stops being true, so label it as
+ * such rather than counting it toward the bug's coverage.
+ */
+describe('🔴 setMarketplaceMeta writes the BLOCK only — the listing row is untouched', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbWrite.appBlock.findUnique.mockResolvedValue({ id: 'ab_c', status: 'approved' });
+    mockDbWrite.appBlock.update.mockResolvedValue({
+      id: 'ab_c',
+      status: 'approved',
+      category: 'utility',
+      featured: false,
+      featuredOrder: null,
+    });
+  });
+
+  it('curating a category updates appBlock and NEVER appListing', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.setMarketplaceMeta({ appBlockId: 'ab_c', category: 'utility' });
+
+    // POSITIVE CONTROL FIRST: the write we DO expect actually happened, and carried the
+    // category. Without this, the two `not.toHaveBeenCalled()` below would pass just as
+    // well against a method that wrote nothing at all.
+    expect(mockDbWrite.appBlock.update).toHaveBeenCalledTimes(1);
+    const data = mockDbWrite.appBlock.update.mock.calls[0][0].data as { category?: unknown };
+    expect(data.category).toBe('utility');
+
+    // The claim itself: no listing write, on EITHER client. `dbRead`/`dbWrite` are
+    // distinct in the canonical mock, so this cannot be satisfied by checking one.
+    for (const client of [mockDbWrite, mockDbRead]) {
+      expect(client.appListing.update).not.toHaveBeenCalled();
+      expect(client.appListing.updateMany).not.toHaveBeenCalled();
+      expect(client.appListing.create).not.toHaveBeenCalled();
+      expect(client.appListing.upsert).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/server/services/blocks/__tests__/app-access.my-app-listings-kind-problems.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.my-app-listings-kind-problems.test.ts
@@ -1,0 +1,261 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * `listMyAppListings` (`appListings.listMine`) — THE KIND SEAM of the completeness
+ * advisory.
+ *
+ * 🔴 WHY THIS FILE EXISTS, AND WHY THE PURE SUITE IS NOT ENOUGH. `computeListingProblems`
+ * now branches on `kind`, and `listing-problems.kind.test.ts` covers that branch
+ * exhaustively — as a PURE function, against a fixture that hands it `kind` directly.
+ * None of that says the SERVICE actually threads the row's kind into it. This is the
+ * `isolation-seam` shape that already bit this exact file family once: the pure suite and
+ * the service suite were each green while two of the eight codes were structurally
+ * unreachable, because nothing built the combined state. A `kind` the service never
+ * passes would leave `/apps/mine` — the ONLY surface this advisory renders on — showing
+ * the off-site advice for every on-site listing, with both suites green.
+ *
+ * 🔴 `listMine` RETURNS BOTH KINDS ON ONE PAGE, so this is not a per-caller constant that
+ * could be hardcoded: the same response can carry an on-site row and an off-site row, and
+ * they must disagree about the remedy. The cases below put both on one page and assert
+ * they diverge — an implementation that passed a literal kind, or read the wrong row's
+ * kind, fails here and cannot fail anywhere else.
+ *
+ * 🔴 EVERY CASE IS PAIRED, and the OFF-SITE row is the POSITIVE CONTROL. An on-site-only
+ * assertion would also pass against an implementation that gave BOTH kinds the manifest
+ * label. The `findMany` fake HONOURS `select`, so a service that stops projecting `kind`
+ * gets `undefined` here — which the implementation degrades to the off-site labels, so
+ * the on-site expectations go red. That is the intended detection route for a dropped
+ * projection.
+ *
+ * 🔴 `dbRead` AND `dbWrite` ARE DISTINCT (the canonical `dbMock` keeps them so) — this
+ * family has twice been bitten by aliasing them. This LIST read must never touch the
+ * primary, and the last case says so.
+ *
+ * 🔴 WHICH CASES ARE REGRESSION COVERAGE. Measured at `origin/main` d345b654a2: 2 of the
+ * 7 cases here go RED — "an ON-SITE row names block.manifest.json" and "BOTH KINDS ON ONE
+ * PAGE diverge". The other 5 PASS at base and are INVARIANT GUARDS, NOT coverage of this
+ * bug. Two of them earn their place a different way: `listMine` ALREADY selected `kind`
+ * at base (it feeds `capabilitiesForKind`), so "the service PROJECTS `kind`" can never
+ * have been red — it exists to stop that projection being removed as dead weight, which
+ * is the route by which this fix would silently revert. Likewise the off-site positive
+ * control is green at base by construction; its job is to kill a mutant that gives BOTH
+ * kinds the manifest label (M9 in the sweep), which no on-site assertion can do.
+ */
+
+const mockDb = dbMock.dbRead;
+const mockWriteDb = dbMock.dbWrite;
+
+const { listMyAppListings } = await import('~/server/services/blocks/app-access.service');
+
+const OWNER = 11;
+
+/** The EXACT pre-change labels — what an OFF-SITE row must still produce. */
+const ORIGINAL_LABEL = {
+  'empty-description': 'Missing description',
+  'empty-tagline': 'Missing tagline',
+  'empty-category': 'Missing category',
+} as const;
+
+/** The ON-SITE labels, spelled out rather than imported from the implementation. */
+const MANIFEST_LABEL = {
+  'empty-description':
+    'Missing description — set "description" in block.manifest.json and resubmit',
+  'empty-tagline': 'Missing tagline — set "tagline" in block.manifest.json and resubmit',
+  'empty-category': 'Missing category — set "category" in block.manifest.json and resubmit',
+} as const;
+
+type Stored = {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+  kind: string;
+  appBlockId: string | null;
+  updatedAt: Date;
+  icon: { url: string | null } | null;
+  cover: { url: string | null } | null;
+  iconId: number | null;
+  coverId: number | null;
+  description: string | null;
+  tagline: string | null;
+  category: string | null;
+  _count: { screenshots: number };
+  columnUserId: number;
+};
+
+/**
+ * A listing whose ASSETS are all present and whose TEXT is all EMPTY.
+ *
+ * 🔴 That is the inverse of the scan-suite's fixture and is deliberate: it means every
+ * code these assertions see is a TEXT code, so `toEqual([...])` on the whole list can be
+ * exact rather than a `toContain` that would pass while the rest of the advisory broke.
+ *
+ * Asset ids are PAIRWISE DISTINCT (icon 41, cover 53) and distinct from the screenshot
+ * count (7), so an operand swap between adjacent arguments changes the ANSWER rather than
+ * merely the argument, and no assertion's expected value can be produced by reading the
+ * wrong field. `kind` has NO default — every caller below states it, so a fixture cannot
+ * quietly inherit one arm.
+ */
+function stored(over: Partial<Stored> & { id: string; kind: string }): Stored {
+  return {
+    slug: `slug-${over.id}`,
+    name: `Name ${over.id}`,
+    status: 'approved',
+    appBlockId: null,
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    icon: { url: 'icon-uuid' },
+    cover: { url: 'cover-uuid' },
+    iconId: 41,
+    coverId: 53,
+    description: null,
+    tagline: null,
+    category: null,
+    _count: { screenshots: 7 },
+    columnUserId: OWNER,
+    ...over,
+  };
+}
+
+/** `appListing.findMany` fake — HONOURS `select`, and evaluates the ownership probe. */
+function findManyFake(table: Stored[]) {
+  return async (...a: unknown[]): Promise<unknown[]> => {
+    const args = (a[0] ?? {}) as {
+      where?: { OR?: Array<Record<string, unknown>>; id?: { in: string[] } };
+      take?: number;
+      select?: Record<string, unknown>;
+    };
+    const where = args.where ?? {};
+    let rows = table;
+    if (where.id?.in) rows = rows.filter((r) => where.id!.in.includes(r.id));
+    if (where.OR) {
+      const userId = ((): number | undefined => {
+        for (const branch of where.OR) if (typeof branch.userId === 'number') return branch.userId;
+        return undefined;
+      })();
+      rows = rows.filter((r) => r.columnUserId === userId);
+    }
+    const select = args.select;
+    return rows.slice(0, args.take ?? rows.length).map((r) => {
+      if (!select) return { ...r };
+      const out: Record<string, unknown> = {};
+      for (const key of Object.keys(select)) {
+        if (select[key]) out[key] = (r as unknown as Record<string, unknown>)[key];
+      }
+      return out;
+    });
+  };
+}
+
+/** The problem list on the row with this id, as `code → label`. */
+async function labelsFor(id: string): Promise<Record<string, string>> {
+  const rows = await listMyAppListings({ userId: OWNER });
+  const row = rows.find((r) => r.appListingId === id);
+  expect(row, `no row for ${id}`).toBeDefined();
+  return Object.fromEntries(row!.problems.map((p) => [p.code, p.label]));
+}
+
+beforeEach(() => {
+  // 🔴 EXPLICIT, not relied upon: `no-direct-shared-module-mock` registers `dbMock`
+  // globally and its reset is per-FILE, not per-test, so "called once" arms would
+  // accumulate across cases in this file without this.
+  vi.clearAllMocks();
+  mockDb.appListing.findMany.mockImplementation(async () => []);
+  mockDb.appCollaborator.findMany.mockImplementation(async () => []);
+  mockDb.appListingScreenshot.findMany.mockImplementation(async () => []);
+  mockDb.image.findMany.mockImplementation(async () => []);
+});
+
+describe('🔴 listMyAppListings — the row KIND reaches the advisory', () => {
+  /**
+   * 🔴 THE FIXTURE GUARD. Both rows must declare a kind, and they must DIFFER — a page
+   * where both rows are the same kind cannot distinguish "the service threads each row's
+   * own kind" from "the service passes one constant".
+   */
+  const onsiteRow = stored({ id: 'l-on', kind: 'onsite' });
+  const offsiteRow = stored({ id: 'l-off', kind: 'offsite' });
+
+  it('🔴 fixture guard — the two rows declare DIFFERENT, known kinds', () => {
+    for (const r of [onsiteRow, offsiteRow]) {
+      expect(Object.prototype.hasOwnProperty.call(r, 'kind')).toBe(true);
+      expect(['onsite', 'offsite']).toContain(r.kind);
+    }
+    expect(onsiteRow.kind).not.toBe(offsiteRow.kind);
+  });
+
+  it('an ON-SITE row names block.manifest.json for all three text problems', async () => {
+    mockDb.appListing.findMany.mockImplementation(findManyFake([onsiteRow]));
+    const labels = await labelsFor('l-on');
+    expect(labels['empty-description']).toBe(MANIFEST_LABEL['empty-description']);
+    expect(labels['empty-tagline']).toBe(MANIFEST_LABEL['empty-tagline']);
+    expect(labels['empty-category']).toBe(MANIFEST_LABEL['empty-category']);
+  });
+
+  it('POSITIVE CONTROL — an OFF-SITE row still produces the ORIGINAL labels, verbatim', async () => {
+    mockDb.appListing.findMany.mockImplementation(findManyFake([offsiteRow]));
+    const labels = await labelsFor('l-off');
+    expect(labels['empty-description']).toBe(ORIGINAL_LABEL['empty-description']);
+    expect(labels['empty-tagline']).toBe(ORIGINAL_LABEL['empty-tagline']);
+    expect(labels['empty-category']).toBe(ORIGINAL_LABEL['empty-category']);
+  });
+
+  it("🔴 BOTH KINDS ON ONE PAGE diverge — the service reads EACH row's own kind, not a constant", async () => {
+    mockDb.appListing.findMany.mockImplementation(findManyFake([onsiteRow, offsiteRow]));
+    const rows = await listMyAppListings({ userId: OWNER });
+
+    // Positive control on the page itself: both rows are present and both carry
+    // problems, so "they differ" is not a comparison of two empty lists.
+    expect(rows.map((r) => r.appListingId).sort()).toEqual(['l-off', 'l-on']);
+    const byId = Object.fromEntries(
+      rows.map((r) => [
+        r.appListingId,
+        Object.fromEntries(r.problems.map((p) => [p.code, p.label])),
+      ])
+    );
+    expect(Object.keys(byId['l-on'])).toEqual([
+      'empty-description',
+      'empty-tagline',
+      'empty-category',
+    ]);
+    expect(Object.keys(byId['l-off'])).toEqual([
+      'empty-description',
+      'empty-tagline',
+      'empty-category',
+    ]);
+
+    for (const code of ['empty-description', 'empty-tagline', 'empty-category'] as const) {
+      expect(byId['l-on'][code]).toBe(MANIFEST_LABEL[code]);
+      expect(byId['l-off'][code]).toBe(ORIGINAL_LABEL[code]);
+      expect(byId['l-on'][code]).not.toBe(byId['l-off'][code]);
+    }
+  });
+
+  it('the CODES are identical across the two rows (wire contract — a released CLI branches on `code`)', async () => {
+    mockDb.appListing.findMany.mockImplementation(findManyFake([onsiteRow, offsiteRow]));
+    const rows = await listMyAppListings({ userId: OWNER });
+    const codesOf = (id: string) =>
+      rows.find((r) => r.appListingId === id)!.problems.map((p) => p.code);
+    // Against a LITERAL, not against each other — comparing the two arms would pass if
+    // both were equally wrong.
+    const expected = ['empty-description', 'empty-tagline', 'empty-category'];
+    expect(codesOf('l-on')).toEqual(expected);
+    expect(codesOf('l-off')).toEqual(expected);
+  });
+
+  it('the service PROJECTS `kind` (a dropped projection is what would silently revert this)', async () => {
+    mockDb.appListing.findMany.mockImplementation(findManyFake([onsiteRow]));
+    await listMyAppListings({ userId: OWNER });
+    const hydrateCall = mockDb.appListing.findMany.mock.calls.find(
+      (c) => (c[0] as { select?: Record<string, unknown> })?.select?.description
+    );
+    expect(hydrateCall, 'no hydrate call selecting the advisory fields').toBeDefined();
+    expect((hydrateCall![0] as { select: Record<string, unknown> }).select.kind).toBe(true);
+  });
+
+  it('reads the REPLICA only — the primary is never touched', async () => {
+    mockDb.appListing.findMany.mockImplementation(findManyFake([onsiteRow, offsiteRow]));
+    await listMyAppListings({ userId: OWNER });
+    expect(mockWriteDb.appListing.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/app-access.my-app-listings-kind-problems.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.my-app-listings-kind-problems.test.ts
@@ -33,7 +33,7 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
  * family has twice been bitten by aliasing them. This LIST read must never touch the
  * primary, and the last case says so.
  *
- * 🔴 WHICH CASES ARE REGRESSION COVERAGE. Measured at `origin/main` d345b654a2: 2 of the
+ * 🔴 WHICH CASES ARE REGRESSION COVERAGE. Measured at `origin/main` 4bfd4c16d: 2 of the
  * 7 cases here go RED — "an ON-SITE row names block.manifest.json" and "BOTH KINDS ON ONE
  * PAGE diverge". The other 5 PASS at base and are INVARIANT GUARDS, NOT coverage of this
  * bug. Two of them earn their place a different way: `listMine` ALREADY selected `kind`
@@ -63,7 +63,8 @@ const MANIFEST_LABEL = {
   'empty-description':
     'Missing description — set "description" in block.manifest.json and resubmit',
   'empty-tagline': 'Missing tagline — set "tagline" in block.manifest.json and resubmit',
-  'empty-category': 'Missing category — set "category" in block.manifest.json and resubmit',
+  'empty-category':
+    'Missing category — resubmit to apply it; set "category" in block.manifest.json first if your app has none',
 } as const;
 
 type Stored = {

--- a/src/server/services/blocks/__tests__/app-listing-assets.scan-batch.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.scan-batch.test.ts
@@ -247,6 +247,10 @@ const scanToEntry: ListingAssetScanEntry = { kind: 'cover', status: 'pending' } 
 describe('🔴 the batch output is what computeListingProblems consumes', () => {
   it('both type directions round-trip through the advisory', () => {
     const { problems } = computeListingProblems({
+      // Scan codes are kind-INVARIANT; `offsite` is the arm whose labels this file's
+      // sibling suites already pin. Declared explicitly so the case cannot silently
+      // run against the implementation's unrecognised-kind fallback.
+      kind: 'offsite',
       iconId: 7,
       coverId: 9,
       screenshotCount: 1,
@@ -274,6 +278,7 @@ describe('🔴 the batch output is what computeListingProblems consumes', () => 
     );
     const byListing = await loadListingAssetScansBatch([{ id: 'a', iconId: 10, coverId: 20 }], db);
     const { problems } = computeListingProblems({
+      kind: 'offsite',
       iconId: 10,
       coverId: 20,
       screenshotCount: 1,

--- a/src/server/services/blocks/__tests__/listing-problems.kind.test.ts
+++ b/src/server/services/blocks/__tests__/listing-problems.kind.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeListingProblems,
+  type ListingProblemCode,
+  type ListingProblemInput,
+  type ListingProblemKind,
+} from '~/server/services/blocks/listing-problems';
+
+/**
+ * `computeListingProblems` — THE KIND DIMENSION of the three empty-text problems.
+ *
+ * 🔴 WHY THIS FILE EXISTS. The function was KIND-BLIND: it emitted
+ * `empty-description` / `empty-tagline` / `empty-category` with the label "Missing
+ * <field>" for EVERY listing. On an OFF-SITE listing that is right — the author typed
+ * that copy into the submit wizard and can go and fix it. On an ON-SITE listing it is
+ * WRONG, not merely terse: those four scalars have no author surface other than
+ * `block.manifest.json`, and `approveRequest`'s (3b-sync) MANIFEST-GOVERNED COPY
+ * RE-SYNC (`publish-request.service.ts`, scoped `kind: 'onsite'`) overwrites them from
+ * the manifest on EVERY subsequent-version approve. So an on-site author who followed
+ * the old advice — assuming they found any surface at all — would have their edit
+ * reverted at the next approve. `/apps/mine` was telling them to do something that
+ * cannot work.
+ *
+ * 🔴 EVERY CASE IS PAIRED ACROSS KINDS, deliberately, and the OFF-SITE arm is the
+ * POSITIVE CONTROL. An on-site-only assertion would pass just as well against an
+ * implementation that gave BOTH kinds the manifest label — which would be a new defect
+ * with the same shape as the old one, pointing the other way. The off-site cases below
+ * pin the ORIGINAL label strings verbatim (`ORIGINAL_LABEL`), so the two arms can only
+ * both pass if the function actually branches.
+ *
+ * 🔴 LABELS ARE PINNED AS WHOLE NORMALISED STRINGS, not matched by keyword. A
+ * `toMatch(/manifest/i)` guard is walkable by re-wording, and the artifact under test
+ * here IS prose — the label is the entire deliverable. A cosmetic reword must fail this
+ * file; that is the price of the claim being machine-checkable.
+ *
+ * 🔴 THE CODES AND SEVERITIES ARE ASSERTED KIND-INVARIANT. `problems[]` ships over tRPC
+ * to a released `@civitai/cli` (`civitai app doctor`) which branches on `code`. The
+ * kind-invariance cases below are what make "this change cannot break that CLI" a
+ * tested claim rather than a sentence in a PR body.
+ *
+ * 🔴 WHICH CASES ARE REGRESSION COVERAGE, AND WHICH ARE MERELY INVARIANT GUARDS.
+ * Measured at `origin/main` d345b654a2: 4 of the 18 cases here go RED — the three
+ * ON-SITE label cases and "the two arms DIFFER". Those are the regression coverage.
+ * The other 14 PASS at base and are INVARIANT GUARDS: they pin behaviour the defect
+ * never violated (the off-site labels, the code list, the severities, the never-throws
+ * degrade). They are not evidence that anything was fixed — they are evidence that
+ * nothing ELSE moved, which is the whole wire-contract claim. Both are worth having;
+ * only the first four should be counted as coverage of the bug.
+ */
+
+/** The EXACT pre-change labels. An off-site listing must still produce these, verbatim. */
+const ORIGINAL_LABEL = {
+  'empty-description': 'Missing description',
+  'empty-tagline': 'Missing tagline',
+  'empty-category': 'Missing category',
+} as const;
+
+/** The on-site labels, spelled out here rather than imported from the implementation. */
+const MANIFEST_LABEL = {
+  'empty-description':
+    'Missing description — set "description" in block.manifest.json and resubmit',
+  'empty-tagline': 'Missing tagline — set "tagline" in block.manifest.json and resubmit',
+  'empty-category': 'Missing category — set "category" in block.manifest.json and resubmit',
+} as const;
+
+type TextCode = keyof typeof ORIGINAL_LABEL;
+
+const TEXT_CODES: TextCode[] = ['empty-description', 'empty-tagline', 'empty-category'];
+const KINDS: ListingProblemKind[] = ['onsite', 'offsite'];
+
+/** Which INPUT field each text code reads — so a case can empty exactly one. */
+const FIELD_OF: Record<TextCode, 'description' | 'tagline' | 'category'> = {
+  'empty-description': 'description',
+  'empty-tagline': 'tagline',
+  'empty-category': 'category',
+};
+
+/**
+ * A fully-complete listing of a given kind — no problems at all.
+ *
+ * The asset ids are PAIRWISE DISTINCT (icon 41, cover 53, screenshot count 7) and
+ * distinct from every other integer this file names, so an operand swap between two
+ * adjacent arguments changes the ANSWER rather than merely the argument. The text
+ * values are distinct from each other AND from every label constant above, so no
+ * assertion's expected value can be produced by echoing an input.
+ */
+function complete(kind: ListingProblemKind): ListingProblemInput {
+  return {
+    kind,
+    iconId: 41,
+    coverId: 53,
+    screenshotCount: 7,
+    description: 'A long-form description of what this app actually does.',
+    tagline: 'One line about it',
+    category: 'utility',
+  };
+}
+
+/** A listing of `kind` with exactly ONE text field emptied. */
+function missingOne(kind: ListingProblemKind, code: TextCode): ListingProblemInput {
+  return { ...complete(kind), [FIELD_OF[code]]: null };
+}
+
+const problemsOf = (input: ListingProblemInput) => computeListingProblems(input).problems;
+const labelOf = (input: ListingProblemInput, code: ListingProblemCode) =>
+  problemsOf(input).find((p) => p.code === code)?.label;
+
+// ---------------------------------------------------------------------------
+// Fixture guard — the whole suite runs ONE arm if a fixture forgets `kind`.
+// ---------------------------------------------------------------------------
+
+describe('🔴 fixture guard — every fixture in this file carries an EXPLICIT, KNOWN kind', () => {
+  /**
+   * 🔴 THIS GUARD IS NOT CEREMONY. The failure it prevents is silent and total: `kind`
+   * is not validated at runtime, and the implementation degrades an unrecognised value
+   * to the off-site labels rather than throwing (its "never throws" contract). So a
+   * fixture that omitted `kind` — or carried a typo like `'on-site'` — would take the
+   * off-site branch, and EVERY on-site case below would then be asserting off-site
+   * behaviour against on-site expectations. That fails loudly here, and only here;
+   * downstream it would read as an implementation bug.
+   *
+   * `tsconfig.json` excludes `src/**\/__tests__/**`, so the REQUIRED `kind` field on
+   * `ListingProblemInput` is not enforced by `pnpm typecheck` for this file. The type is
+   * the enforcement for production call sites; this is the enforcement here.
+   */
+  const everyFixture: ListingProblemInput[] = [
+    ...KINDS.map(complete),
+    ...KINDS.flatMap((k) => TEXT_CODES.map((c) => missingOne(k, c))),
+  ];
+
+  it('enumerates a non-zero number of fixtures (positive control — an empty list would pass vacuously)', () => {
+    // 2 complete + 2 kinds x 3 codes = 8. Named literally so a fixture silently
+    // disappearing from the list above cannot leave this describe asserting nothing.
+    expect(everyFixture).toHaveLength(8);
+  });
+
+  it('every fixture declares a kind drawn from the known set', () => {
+    for (const f of everyFixture) {
+      expect(KINDS).toContain(f.kind);
+    }
+  });
+
+  it('the fixtures cover BOTH kinds (a single-arm suite would prove nothing)', () => {
+    expect(new Set(everyFixture.map((f) => f.kind))).toEqual(new Set(['onsite', 'offsite']));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The matrix: one case per KIND per CODE.
+// ---------------------------------------------------------------------------
+
+describe('empty-text labels are KIND-AWARE — one case per kind per code', () => {
+  describe('OFF-SITE (positive control: the ORIGINAL labels, verbatim)', () => {
+    for (const code of TEXT_CODES) {
+      it(`${code} reads "${ORIGINAL_LABEL[code]}"`, () => {
+        expect(labelOf(missingOne('offsite', code), code)).toBe(ORIGINAL_LABEL[code]);
+      });
+    }
+  });
+
+  describe('ON-SITE (names block.manifest.json — the only author surface)', () => {
+    for (const code of TEXT_CODES) {
+      it(`${code} reads "${MANIFEST_LABEL[code]}"`, () => {
+        expect(labelOf(missingOne('onsite', code), code)).toBe(MANIFEST_LABEL[code]);
+      });
+    }
+  });
+
+  it('the two arms DIFFER for all three codes (guards against both arms collapsing to one table)', () => {
+    for (const code of TEXT_CODES) {
+      expect(labelOf(missingOne('onsite', code), code)).not.toBe(
+        labelOf(missingOne('offsite', code), code)
+      );
+    }
+  });
+
+  it('the three ON-SITE labels are distinct from each other (no copy-paste of one field name)', () => {
+    const labels = TEXT_CODES.map((c) => labelOf(missingOne('onsite', c), c));
+    expect(new Set(labels).size).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wire contract: codes + severities do NOT move with kind.
+// ---------------------------------------------------------------------------
+
+describe('🔴 WIRE CONTRACT — codes and severities are KIND-INVARIANT', () => {
+  /**
+   * The released `@civitai/cli` (`civitai app doctor`) consumes `problems[]` over tRPC
+   * and branches on `code`. Renaming a code, dropping one, or SUPPRESSING these three on
+   * the on-site arm would all break it — the last of those silently, by making its
+   * on-site branch unreachable. These cases pin that none of it happened.
+   */
+  it('an ON-SITE listing still EMITS all three text codes (they are not suppressed)', () => {
+    const codes = problemsOf({
+      kind: 'onsite',
+      iconId: 41,
+      coverId: 53,
+      screenshotCount: 7,
+      description: null,
+      tagline: null,
+      category: null,
+    }).map((p) => p.code);
+    expect(codes).toEqual(['empty-description', 'empty-tagline', 'empty-category']);
+  });
+
+  it('both kinds emit the SAME code list, in the SAME order, for the same input', () => {
+    const codesFor = (kind: ListingProblemKind) =>
+      problemsOf({
+        kind,
+        iconId: null,
+        coverId: null,
+        screenshotCount: 0,
+        description: null,
+        tagline: '   ',
+        category: null,
+        assetScans: [
+          { kind: 'icon', status: 'blocked' },
+          { kind: 'cover', status: 'pending' },
+        ],
+      }).map((p) => p.code);
+
+    const expected: ListingProblemCode[] = [
+      'missing-icon',
+      'missing-cover',
+      'no-screenshots',
+      'empty-description',
+      'empty-tagline',
+      'empty-category',
+      'blocked-media',
+      'scanning-media',
+    ];
+    // Asserted against a LITERAL, not against the other kind's output — comparing the
+    // two arms to each other would pass if both were equally wrong.
+    expect(codesFor('onsite')).toEqual(expected);
+    expect(codesFor('offsite')).toEqual(expected);
+  });
+
+  it('the three text problems stay ADVISORY on BOTH kinds', () => {
+    for (const kind of KINDS) {
+      for (const code of TEXT_CODES) {
+        expect(problemsOf(missingOne(kind, code)).find((p) => p.code === code)?.severity).toBe(
+          'advisory'
+        );
+      }
+    }
+  });
+
+  it('the NON-text problems carry byte-identical labels on both kinds', () => {
+    const nonText = (kind: ListingProblemKind) =>
+      problemsOf({
+        kind,
+        iconId: null,
+        coverId: null,
+        screenshotCount: 0,
+        description: 'has one',
+        tagline: 'has one',
+        category: 'utility',
+        assetScans: [
+          { kind: 'screenshot', status: 'blocked' },
+          { kind: 'icon', status: 'pending' },
+        ],
+      });
+    // Positive control: this fixture must actually produce problems, or "identical"
+    // would be a comparison of two empty arrays.
+    expect(nonText('onsite')).toHaveLength(5);
+    expect(nonText('onsite')).toEqual(nonText('offsite'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Never-throws.
+// ---------------------------------------------------------------------------
+
+describe('🔴 an unrecognised kind degrades to the ORIGINAL labels and never throws', () => {
+  /**
+   * `kind` reaches the services as a `string` from the `app_listings.kind` COLUMN and is
+   * CAST, not parsed. A row carrying anything else must not take down the whole
+   * `/apps/mine` page — the module header promises "Never throws". The degrade direction
+   * is the off-site (original) labels: inventing manifest advice for a listing that may
+   * not be manifest-governed is the actively harmful direction, and it is the exact
+   * defect this change exists to fix.
+   */
+  const weird = (k: string) =>
+    computeListingProblems({
+      ...complete('offsite'),
+      kind: k as ListingProblemKind,
+      tagline: null,
+    });
+
+  it('does not throw on an unknown kind', () => {
+    expect(() => weird('external')).not.toThrow();
+    expect(() => weird('')).not.toThrow();
+  });
+
+  it('yields the ORIGINAL (off-site) label, not the manifest one', () => {
+    expect(weird('external').problems.find((p) => p.code === 'empty-tagline')?.label).toBe(
+      ORIGINAL_LABEL['empty-tagline']
+    );
+  });
+
+  it('a PROTOTYPE key is not mistaken for a known kind (the table must not fail open)', () => {
+    // `TEXT_PROBLEM['constructor']` is truthy on a plain object literal, so a `?? default`
+    // lookup would silently accept it and then read `.['empty-tagline']` off `Object` —
+    // producing `undefined` as the label. Pin that the label is a real string either way.
+    const label = weird('constructor').problems.find((p) => p.code === 'empty-tagline')?.label;
+    expect(label).toBe(ORIGINAL_LABEL['empty-tagline']);
+  });
+});

--- a/src/server/services/blocks/__tests__/listing-problems.kind.test.ts
+++ b/src/server/services/blocks/__tests__/listing-problems.kind.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -6,6 +9,28 @@ import {
   type ListingProblemInput,
   type ListingProblemKind,
 } from '~/server/services/blocks/listing-problems';
+import type { ListingKind } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * 🔴 ASSIGNABILITY PIN between `ListingKind` (the schema's) and `ListingProblemKind`
+ * (this module's deliberate re-declaration). Widening one without the other breaks the
+ * `listMine` call site, and this states the relationship where a reader of the type
+ * will look for it.
+ *
+ * 🔴 IT IS NOT THE LOAD-BEARING GUARD, AND SAYING SO IS THE POINT. `tsconfig.json`
+ * EXCLUDES `src/**\/__tests__/**`, so these two lines are checked only by the
+ * deliberate test-typecheck pass, never by the root `pnpm typecheck` or by CI's
+ * typecheck gate. What actually catches a one-sided widening is
+ * `app-access.service.ts` passing a `ListingKind` into this type's parameter slot.
+ * A previous version of the type's own docblock claimed THIS FILE held the pin while
+ * the file contained no reference to `ListingKind` at all — a comment reading as
+ * coverage while providing none. Both halves are now true.
+ */
+const _kindWidensBothWays: [ListingProblemKind, ListingKind] = [
+  'onsite' as ListingKind,
+  'offsite' as ListingProblemKind,
+];
+void _kindWidensBothWays;
 
 /**
  * `computeListingProblems` — THE KIND DIMENSION of the three empty-text problems.
@@ -40,13 +65,15 @@ import {
  * tested claim rather than a sentence in a PR body.
  *
  * 🔴 WHICH CASES ARE REGRESSION COVERAGE, AND WHICH ARE MERELY INVARIANT GUARDS.
- * Measured at `origin/main` d345b654a2: 4 of the 18 cases here go RED — the three
- * ON-SITE label cases and "the two arms DIFFER". Those are the regression coverage.
- * The other 14 PASS at base and are INVARIANT GUARDS: they pin behaviour the defect
- * never violated (the off-site labels, the code list, the severities, the never-throws
- * degrade). They are not evidence that anything was fixed — they are evidence that
- * nothing ELSE moved, which is the whole wire-contract claim. Both are worth having;
- * only the first four should be counted as coverage of the bug.
+ * Measured at `origin/main` 4bfd4c16d: 6 of the 23 cases here go RED — the three
+ * ON-SITE label cases, "the two arms DIFFER", and the two label-SHAPE cases (category
+ * leads with RESUBMIT; description/tagline are the mirror). Those are the regression
+ * coverage. The other 17 PASS at base and are INVARIANT GUARDS: they pin behaviour the
+ * defect never violated (the off-site labels, the code list, the severities, the
+ * never-throws degrade, and the source scanner's own controls). They are not evidence
+ * that anything was fixed — they are evidence that nothing ELSE moved, which is the
+ * whole wire-contract claim. Both are worth having; only the six should be counted as
+ * coverage of the bug.
  */
 
 /** The EXACT pre-change labels. An off-site listing must still produce these, verbatim. */
@@ -61,7 +88,8 @@ const MANIFEST_LABEL = {
   'empty-description':
     'Missing description — set "description" in block.manifest.json and resubmit',
   'empty-tagline': 'Missing tagline — set "tagline" in block.manifest.json and resubmit',
-  'empty-category': 'Missing category — set "category" in block.manifest.json and resubmit',
+  'empty-category':
+    'Missing category — resubmit to apply it; set "category" in block.manifest.json first if your app has none',
 } as const;
 
 type TextCode = keyof typeof ORIGINAL_LABEL;
@@ -144,6 +172,89 @@ describe('🔴 fixture guard — every fixture in this file carries an EXPLICIT,
   it('the fixtures cover BOTH kinds (a single-arm suite would prove nothing)', () => {
     expect(new Set(everyFixture.map((f) => f.kind))).toEqual(new Set(['onsite', 'offsite']));
   });
+
+  /**
+   * 🔴 THE THREE CASES ABOVE ONLY SEE THE FACTORY, AND THAT IS A REAL GAP.
+   * `everyFixture` enumerates what `complete()`/`missingOne()` produce — 8 objects. The
+   * WIRE CONTRACT describe below builds its inputs as INLINE OBJECT LITERALS instead,
+   * and those are invisible to a runtime enumeration. There is no live gap today (every
+   * inline literal does carry `kind`), but a future one that forgot it would silently
+   * run the unrecognised-kind fallback with the guard above still green — which is
+   * precisely the failure this whole describe exists to prevent, arriving through the
+   * door the guard does not watch.
+   *
+   * So this scans THIS FILE'S OWN SOURCE and requires every inline literal handed to
+   * `computeListingProblems(` / `problemsOf(` to declare `kind` (directly, or by
+   * spreading a factory that does). A literal is anything whose first non-space
+   * character after `(` is `{`; a call passing a variable is skipped, because the
+   * variable was built by the factory this guard already covers.
+   */
+  const FIXTURE_SPREADS = ['...complete(', '...missingOne('];
+
+  /** Returns the offending literals — empty means clean. Exported shape kept simple so
+   *  the positive control below can drive it with synthetic source. */
+  function kindlessLiterals(source: string): string[] {
+    const bad: string[] = [];
+    for (const fn of ['computeListingProblems(', 'problemsOf(']) {
+      let from = 0;
+      for (;;) {
+        const at = source.indexOf(fn, from);
+        if (at === -1) break;
+        from = at + fn.length;
+        let i = from;
+        while (i < source.length && /\s/.test(source[i])) i++;
+        if (source[i] !== '{') continue; // a variable, not an inline literal
+        // Brace-match the literal.
+        let depth = 0;
+        let end = i;
+        for (; end < source.length; end++) {
+          if (source[end] === '{') depth++;
+          else if (source[end] === '}' && --depth === 0) break;
+        }
+        // A literal we cannot brace-match is reported, never silently skipped.
+        if (depth !== 0) {
+          bad.push('<unparseable literal>');
+          continue;
+        }
+        const literal = source.slice(i, end + 1);
+        const declaresKind = /[{,]\s*kind\s*[:,]/.test(literal);
+        const spreadsFixture = FIXTURE_SPREADS.some((s) => literal.includes(s));
+        if (!declaresKind && !spreadsFixture) bad.push(literal.replace(/\s+/g, ' ').slice(0, 90));
+      }
+    }
+    return bad;
+  }
+
+  const ownSource = readFileSync(fileURLToPath(import.meta.url), 'utf8');
+
+  it('🔴 POSITIVE CONTROL — the scanner CAN see a kindless literal', () => {
+    // Validate the instrument before reading its verdict. Without this, the clean
+    // result below is indistinguishable from a scanner wired to nothing.
+    //
+    // 🔴 ASSEMBLED FROM PIECES, NOT WRITTEN VERBATIM. The scanner reads this file's own
+    // source, so a literal bad example spelled out here would be found by the real scan
+    // and fail the clean-file case below — which is exactly what happened on the first
+    // run. That is the scanner working; keeping the pieces apart is the fix. (The two
+    // GOOD examples below can stay verbatim: they declare `kind` / spread a factory, so
+    // the real scan passes over them.)
+    const planted = ['problemsOf', '({ iconId: 1, coverId: 2, screenshotCount: 0 });'].join('');
+    expect(kindlessLiterals(planted)).toHaveLength(1);
+    // ...and does NOT flag the two legitimate shapes.
+    expect(kindlessLiterals(`problemsOf({ kind: 'onsite', iconId: 1 });`)).toEqual([]);
+    expect(kindlessLiterals(`problemsOf({ ...complete('offsite'), tagline: null });`)).toEqual([]);
+  });
+
+  it('🔴 the scanner actually READ this file (a zero over empty input proves nothing)', () => {
+    // The other half of the control: a non-zero count of literals was examined.
+    expect(ownSource.length).toBeGreaterThan(2000);
+    const inlineCalls = (ownSource.match(/(computeListingProblems|problemsOf)\(\s*\{/g) ?? [])
+      .length;
+    expect(inlineCalls).toBeGreaterThanOrEqual(6);
+  });
+
+  it('every INLINE literal passed to the advisory declares a kind', () => {
+    expect(kindlessLiterals(ownSource)).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -178,6 +289,47 @@ describe('empty-text labels are KIND-AWARE — one case per kind per code', () =
   it('the three ON-SITE labels are distinct from each other (no copy-paste of one field name)', () => {
     const labels = TEXT_CODES.map((c) => labelOf(missingOne('onsite', c), c));
     expect(new Set(labels).size).toBe(3);
+  });
+
+  /**
+   * 🔴 `empty-category` IS DELIBERATELY ASYMMETRIC WITH THE OTHER TWO, AND THE
+   * ASYMMETRY IS THE CORRECTED REASONING — pin it, or a later "let's make these
+   * consistent" tidy-up silently restores a wrong diagnosis.
+   *
+   * `description` and `tagline` are re-derived FROM THE MANIFEST on every sync
+   * (`resolveListingDescription` / `resolveListingTagline`), so for those two the
+   * manifest genuinely is the whole remedy and the label leads with it.
+   *
+   * `category` is NOT. It reaches `app_listings.category` only from
+   * `AppBlock.category` at an APPROVE, and `setMarketplaceMeta` (moderator curation)
+   * writes the BLOCK without touching the LISTING — a state the advisory cannot see.
+   * In it, editing the manifest is INERT ((3a)'s null-gate does not fire) while
+   * resubmitting is what clears the problem. So this label must lead with the action
+   * that always works and mark the manifest key conditional.
+   * `block-registry.marketplace-meta.test.ts` pins the curation-write fact this rests on.
+   */
+  it('🔴 the ON-SITE category label leads with RESUBMIT and marks the manifest CONDITIONAL', () => {
+    const label = labelOf(missingOne('onsite', 'empty-category'), 'empty-category')!;
+    const resubmitAt = label.toLowerCase().indexOf('resubmit');
+    const manifestAt = label.indexOf('block.manifest.json');
+    expect(resubmitAt).toBeGreaterThan(-1);
+    expect(manifestAt).toBeGreaterThan(-1);
+    // Order is the claim: the always-works action comes first.
+    expect(resubmitAt).toBeLessThan(manifestAt);
+    // ...and the manifest half is hedged, not stated as the remedy.
+    expect(label).toMatch(/\bif\b/);
+  });
+
+  it('🔴 description/tagline are the MIRROR — manifest FIRST, because for them it IS the whole remedy', () => {
+    for (const code of ['empty-description', 'empty-tagline'] as const) {
+      const label = labelOf(missingOne('onsite', code), code)!;
+      const manifestAt = label.indexOf('block.manifest.json');
+      const resubmitAt = label.toLowerCase().indexOf('resubmit');
+      expect(manifestAt).toBeGreaterThan(-1);
+      expect(resubmitAt).toBeGreaterThan(manifestAt);
+      // Unhedged: no conditional, unlike category.
+      expect(label).not.toMatch(/\bif\b/);
+    }
   });
 });
 

--- a/src/server/services/blocks/__tests__/listing-problems.test.ts
+++ b/src/server/services/blocks/__tests__/listing-problems.test.ts
@@ -7,8 +7,18 @@ import {
 } from '~/server/services/blocks/listing-problems';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 
-/** A fully-complete listing (no problems). Spread + override per case. */
+/**
+ * A fully-complete listing (no problems). Spread + override per case.
+ *
+ * 🔴 `kind` IS EXPLICIT AND IS `offsite` DELIBERATELY. Every label assertion in this
+ * file predates the kind dimension and pins the ORIGINAL text, which is now the OFF-SITE
+ * arm — so this file doubles as the regression guard that the off-site labels did not
+ * move. The ON-SITE arm and the kind matrix live in `listing-problems.kind.test.ts`.
+ * Omitting `kind` here would silently run this whole file against the implementation's
+ * fallback rather than a declared arm.
+ */
 const complete: ListingProblemInput = {
+  kind: 'offsite',
   iconId: 10,
   coverId: 20,
   screenshotCount: 3,
@@ -21,6 +31,18 @@ const codes = (input: ListingProblemInput): ListingProblemCode[] =>
   computeListingProblems(input).problems.map((p) => p.code);
 
 describe('computeListingProblems', () => {
+  /**
+   * 🔴 FIXTURE GUARD. `kind` is not validated at runtime and an unrecognised value
+   * degrades to the off-site labels, so a fixture that DROPPED `kind` would still make
+   * this whole file pass — while asserting against the fallback instead of a declared
+   * arm. `tsconfig.json` excludes `src/**\/__tests__/**`, so the REQUIRED field on
+   * `ListingProblemInput` is not enforced here by `pnpm typecheck`; this is.
+   */
+  it('🔴 the shared `complete` fixture declares an EXPLICIT kind', () => {
+    expect(complete.kind).toBe('offsite');
+    expect(Object.prototype.hasOwnProperty.call(complete, 'kind')).toBe(true);
+  });
+
   it('returns NO problems for an all-complete listing', () => {
     const result = computeListingProblems(complete);
     expect(result.problems).toEqual([]);
@@ -80,6 +102,7 @@ describe('computeListingProblems', () => {
 
   it('flags EVERY problem for a fully-empty listing, in a stable order', () => {
     const result = computeListingProblems({
+      kind: 'offsite',
       iconId: null,
       coverId: null,
       screenshotCount: 0,

--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -1068,11 +1068,12 @@ describe('listMySubmissions (lastModerationAction for removed listings)', () => 
  * assertion would pass equally against an implementation that gave BOTH kinds the
  * manifest label, which is the same defect pointing the other way.
  *
- * 🔴 WHICH CASES ARE REGRESSION COVERAGE. Measured at `origin/main` d345b654a2: 3 of the
- * 8 cases below go RED — the on-site media revision, "BOTH KINDS ON ONE PAGE diverge",
- * and the listing-kind projection. The other 5 PASS at base and are INVARIANT GUARDS
- * (the fixture guard, the off-site positive control, code invariance, the degrade path).
- * They pin what must NOT move; they are not evidence the defect was fixed.
+ * 🔴 WHICH CASES ARE REGRESSION COVERAGE. Measured at `origin/main` 4bfd4c16d: 4 of the
+ * 10 cases below go RED — the on-site media revision, "BOTH KINDS ON ONE PAGE diverge",
+ * the listing-kind projection, and "request.kind and listing.kind DISAGREE". The other 6
+ * PASS at base and are INVARIANT GUARDS (the fixture guard, the off-site positive
+ * control, code invariance, the degrade path, and the disagreement MIRROR). They pin
+ * what must NOT move; they are not evidence the defect was fixed.
  */
 describe('listMySubmissions (the advisory is KIND-AWARE)', () => {
   const MANIFEST_TAGLINE = 'Missing tagline — set "tagline" in block.manifest.json and resubmit';
@@ -1085,11 +1086,26 @@ describe('listMySubmissions (the advisory is KIND-AWARE)', () => {
    * operand swap changes the ANSWER rather than the argument. `kind` has NO default —
    * every call states it, so a fixture cannot quietly inherit one arm.
    */
-  const requestRow = (id: string, listingId: string, kind: string) => ({
+  const requestRow = (
+    id: string,
+    listingId: string,
+    kind: string,
+    /**
+     * The REQUEST's kind, which defaults to matching the listing's.
+     *
+     * 🔴 IT IS A SEPARATE PARAMETER SO THE TWO CAN BE MADE TO DISAGREE. They are
+     * different columns on different tables and they agree at every request-create
+     * site today — which is exactly why a fixture that always sets them equal cannot
+     * tell `r.appListing.kind` from `r.kind`. An audit mutant that read the REQUEST's
+     * kind SURVIVED all 132 tests for that reason. The stated rationale for reading
+     * the listing's is that they MIGHT diverge, so one fixture has to make them.
+     */
+    requestKind: string = kind
+  ) => ({
     id,
     appListingId: listingId,
     slug: `app-${id}`,
-    kind: kind === 'onsite' ? 'onsite' : 'offsite',
+    kind: requestKind,
     status: 'approved',
     appListing: {
       name: `App ${id}`,
@@ -1187,6 +1203,50 @@ describe('listMySubmissions (the advisory is KIND-AWARE)', () => {
     // request's kind would be a derived surface standing in for the defining one.
     expect(select.appListing.select.kind).toBe(true);
     expect(select.kind).toBe(true);
+  });
+
+  /**
+   * 🔴 THE DISCRIMINATING CASE FOR LISTING-KIND-vs-REQUEST-KIND, and the ONLY one.
+   *
+   * Every other fixture in this describe sets `request.kind === appListing.kind`,
+   * because that is what production does at all three request-create sites. The
+   * consequence, found by an adversarial audit of #4370: a mutant changing the call
+   * site from `r.appListing.kind` to `r.kind` SURVIVED the entire 132-test battery.
+   * Not a live hole — the two genuinely agree today — but the stated rationale for
+   * reading the LISTING's column is precisely that they are independent and might
+   * diverge, and a rationale nothing can falsify is not a tested claim.
+   *
+   * This fixture makes them disagree in the direction that matters: an OFF-SITE
+   * request row pointing at an ON-SITE listing. The advisory is a statement about the
+   * LISTING, so the manifest label must win. Reading `r.kind` yields the original
+   * label and fails here — which is what turns the comment into a guard.
+   */
+  it('🔴 request.kind and listing.kind DISAGREE — the LISTING wins', async () => {
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([requestRow('r_split', 'apl_split', 'onsite', 'offsite')])
+      .mockResolvedValueOnce([]);
+    const res = await listMySubmissions({ userId: OWNER });
+
+    // Positive control on the fixture itself: the two really do disagree, so this case
+    // cannot quietly degrade into another copy of the aligned ones.
+    const row = mockRead.appListingPublishRequest.findMany.mock.results[0].value as Promise<
+      Array<{ kind: string; appListing: { kind: string } }>
+    >;
+    const [first] = await row;
+    expect(first.kind).toBe('offsite');
+    expect(first.appListing.kind).toBe('onsite');
+
+    expect(res.items[0].problems.map((p) => p.code)).toEqual(['empty-tagline']);
+    expect(taglineLabelOf(res.items[0])).toBe(MANIFEST_TAGLINE);
+  });
+
+  it('the MIRROR — an on-site request pointing at an off-site listing takes the OFF-SITE label', async () => {
+    // Both directions, so the case cannot pass by the arms having been swapped.
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([requestRow('r_split2', 'apl_split2', 'offsite', 'onsite')])
+      .mockResolvedValueOnce([]);
+    const res = await listMySubmissions({ userId: OWNER });
+    expect(taglineLabelOf(res.items[0])).toBe(ORIGINAL_TAGLINE);
   });
 
   it('a fake that omits the listing kind degrades to the ORIGINAL labels, and never throws', async () => {

--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -255,9 +255,9 @@ describe('updateListing', () => {
       where: { id: 'apl_new_1' },
       data: { contentRating: 'g' },
     });
-    expect(updateCalls.every((c) => (c as { where: { id: string } }).where.id !== 'apl_parent')).toBe(
-      true
-    );
+    expect(
+      updateCalls.every((c) => (c as { where: { id: string } }).where.id !== 'apl_parent')
+    ).toBe(true);
   });
 
   it('DRAFT + contentRating change → edits IN PLACE (no shadow — pre-approval, no gate to bypass)', async () => {
@@ -300,16 +300,20 @@ describe('updateListing', () => {
     expect(res.shadowId).toBe('apl_new_1');
     // The shadow was created as a draft revision of the parent.
     const shadowData = mockWrite.appListing.create.mock.calls[0][0].data as Row;
-    expect(shadowData).toMatchObject({ status: 'draft', revisionOfId: 'apl_parent', appBlockId: null });
+    expect(shadowData).toMatchObject({
+      status: 'draft',
+      revisionOfId: 'apl_parent',
+      appBlockId: null,
+    });
     // The FULL patch was written to the SHADOW, never the live parent.
     const updateCalls = mockWrite.appListing.update.mock.calls.map((c) => c[0]);
     expect(updateCalls).toContainEqual({
       where: { id: 'apl_new_1' },
       data: { name: 'Brand New Name', tagline: 'also this' },
     });
-    expect(updateCalls.every((c) => (c as { where: { id: string } }).where.id !== 'apl_parent')).toBe(
-      true
-    );
+    expect(
+      updateCalls.every((c) => (c as { where: { id: string } }).where.id !== 'apl_parent')
+    ).toBe(true);
   });
 
   it('approved + externalUrl change → treated as MATERIAL → shadow path', async () => {
@@ -433,8 +437,18 @@ describe('beginListingRevision', () => {
     // Screenshots were copied (imageId/order/caption preserved) onto the shadow.
     const shots = mockWrite.appListingScreenshot.createMany.mock.calls[0][0].data as Row[];
     expect(shots).toHaveLength(2);
-    expect(shots[0]).toMatchObject({ appListingId: 'apl_new_1', imageId: 10, order: 0, caption: 'a' });
-    expect(shots[1]).toMatchObject({ appListingId: 'apl_new_1', imageId: 11, order: 1, caption: null });
+    expect(shots[0]).toMatchObject({
+      appListingId: 'apl_new_1',
+      imageId: 10,
+      order: 0,
+      caption: 'a',
+    });
+    expect(shots[1]).toMatchObject({
+      appListingId: 'apl_new_1',
+      imageId: 11,
+      order: 1,
+      caption: null,
+    });
   });
 
   it('idempotent: an existing shadow is returned as-is (no second clone)', async () => {
@@ -471,9 +485,9 @@ describe('beginListingRevision', () => {
     mockWrite.appListing.create.mockRejectedValueOnce(
       Object.assign(new Error('deadlock detected'), { code: 'P2034' })
     );
-    await expect(
-      beginListingRevision({ listingId: 'apl_parent', userId: OWNER })
-    ).rejects.toThrow('deadlock detected');
+    await expect(beginListingRevision({ listingId: 'apl_parent', userId: OWNER })).rejects.toThrow(
+      'deadlock detected'
+    );
   });
 
   it('non-approved parent → INVALID_REVISION', async () => {
@@ -614,7 +628,10 @@ describe('submitListingRevision', () => {
     mockRead.appListingPublishRequest.findFirst.mockResolvedValue(null);
     await expect(
       submitListingRevision({ shadowId: 'apl_shadow', userId: OWNER })
-    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('externalUrl') });
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('externalUrl'),
+    });
     expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
   });
 });
@@ -701,7 +718,11 @@ describe('approveExternalRequest (revision apply)', () => {
       approvalNotes: 'nice edit',
     });
     // Returns the LIVE parent id + slug (not the shadow).
-    expect(res).toEqual({ publishRequestId: 'alpr_rev', listingId: 'apl_parent', slug: 'cool-app' });
+    expect(res).toEqual({
+      publishRequestId: 'alpr_rev',
+      listingId: 'apl_parent',
+      slug: 'cool-app',
+    });
 
     // The request flip re-points appListingId at the PARENT + marks approved.
     const reqCall = mockWrite.appListingPublishRequest.updateMany.mock.calls[0][0] as {
@@ -969,14 +990,24 @@ describe('listMySubmissions (lastModerationAction for removed listings)', () => 
     appListingId: 'apl_removed',
     slug: 'gone-app',
     status: 'approved',
-    appListing: { name: 'Gone App', revisionOfId: null, status: 'removed', _count: { screenshots: 3 } },
+    appListing: {
+      name: 'Gone App',
+      revisionOfId: null,
+      status: 'removed',
+      _count: { screenshots: 3 },
+    },
   };
   const liveRequestRow = {
     id: 'alpr_live',
     appListingId: 'apl_live',
     slug: 'live-app',
     status: 'approved',
-    appListing: { name: 'Live App', revisionOfId: null, status: 'approved', _count: { screenshots: 3 } },
+    appListing: {
+      name: 'Live App',
+      revisionOfId: null,
+      status: 'approved',
+      _count: { screenshots: 3 },
+    },
   };
 
   it('attaches the latest moderation-event action for a REMOVED listing (owner-unpublish → eligible)', async () => {
@@ -1011,5 +1042,176 @@ describe('listMySubmissions (lastModerationAction for removed listings)', () => 
     const res = await listMySubmissions({ userId: OWNER });
     expect(mockRead.$queryRaw).not.toHaveBeenCalled();
     expect(res.items[0]).toMatchObject({ lastModerationAction: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listMySubmissions — the KIND seam of the completeness advisory
+// ---------------------------------------------------------------------------
+
+/**
+ * 🔴 `listMySubmissions` IS NOT AN OFF-SITE-ONLY READ, despite living in
+ * `offsite-listing.service`. Its `where` carries an explicit `{ kind: 'onsite' }`
+ * OR-branch (pinned by the shadow-handling describe above) so ON-SITE MEDIA REVISIONS
+ * appear on /apps/my-submissions — an on-site listing is auto-created and has no own
+ * publish request, so its only representation IS the revision request. That makes this
+ * the one caller of `computeListingProblems` where BOTH kinds genuinely arrive on the
+ * same page, and where a hardcoded `'offsite'` would be wrong in production rather than
+ * merely fragile.
+ *
+ * The three empty-text problems now name a different remedy per kind: an on-site
+ * listing's name/tagline/description/category have NO author surface other than
+ * `block.manifest.json`, and `approveRequest`'s (3b-sync) re-sync overwrites them from
+ * the manifest on every subsequent-version approve.
+ *
+ * 🔴 EVERY CASE IS PAIRED and the OFF-SITE arm is the POSITIVE CONTROL — an on-site-only
+ * assertion would pass equally against an implementation that gave BOTH kinds the
+ * manifest label, which is the same defect pointing the other way.
+ *
+ * 🔴 WHICH CASES ARE REGRESSION COVERAGE. Measured at `origin/main` d345b654a2: 3 of the
+ * 8 cases below go RED — the on-site media revision, "BOTH KINDS ON ONE PAGE diverge",
+ * and the listing-kind projection. The other 5 PASS at base and are INVARIANT GUARDS
+ * (the fixture guard, the off-site positive control, code invariance, the degrade path).
+ * They pin what must NOT move; they are not evidence the defect was fixed.
+ */
+describe('listMySubmissions (the advisory is KIND-AWARE)', () => {
+  const MANIFEST_TAGLINE = 'Missing tagline — set "tagline" in block.manifest.json and resubmit';
+  const ORIGINAL_TAGLINE = 'Missing tagline';
+
+  /**
+   * A request row whose backing listing has every asset but NO tagline, so exactly ONE
+   * problem fires and a whole-list assertion can be exact. Asset ids are pairwise
+   * distinct (icon 41, cover 53) and distinct from the screenshot count (7), so an
+   * operand swap changes the ANSWER rather than the argument. `kind` has NO default —
+   * every call states it, so a fixture cannot quietly inherit one arm.
+   */
+  const requestRow = (id: string, listingId: string, kind: string) => ({
+    id,
+    appListingId: listingId,
+    slug: `app-${id}`,
+    kind: kind === 'onsite' ? 'onsite' : 'offsite',
+    status: 'approved',
+    appListing: {
+      name: `App ${id}`,
+      revisionOfId: null,
+      status: 'approved',
+      kind,
+      iconId: 41,
+      coverId: 53,
+      description: 'A description.',
+      tagline: null,
+      category: 'utility',
+      screenshots: [],
+      _count: { screenshots: 7 },
+    },
+  });
+
+  const taglineLabelOf = (item: { problems: { code: string; label: string }[] }) =>
+    item.problems.find((p) => p.code === 'empty-tagline')?.label;
+
+  it('🔴 fixture guard — the two fixtures declare DIFFERENT, known LISTING kinds', () => {
+    const on = requestRow('r_on', 'apl_on', 'onsite');
+    const off = requestRow('r_off', 'apl_off', 'offsite');
+    for (const r of [on, off]) {
+      expect(Object.prototype.hasOwnProperty.call(r.appListing, 'kind')).toBe(true);
+      expect(['onsite', 'offsite']).toContain(r.appListing.kind);
+    }
+    expect(on.appListing.kind).not.toBe(off.appListing.kind);
+  });
+
+  it('an ON-SITE media revision names block.manifest.json', async () => {
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([requestRow('r_on', 'apl_on', 'onsite')])
+      .mockResolvedValueOnce([]);
+    const res = await listMySubmissions({ userId: OWNER });
+    // Positive control: exactly the one text problem.
+    expect(res.items[0].problems.map((p) => p.code)).toEqual(['empty-tagline']);
+    expect(taglineLabelOf(res.items[0])).toBe(MANIFEST_TAGLINE);
+  });
+
+  it('POSITIVE CONTROL — an OFF-SITE submission still produces the ORIGINAL label, verbatim', async () => {
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([requestRow('r_off', 'apl_off', 'offsite')])
+      .mockResolvedValueOnce([]);
+    const res = await listMySubmissions({ userId: OWNER });
+    expect(res.items[0].problems.map((p) => p.code)).toEqual(['empty-tagline']);
+    expect(taglineLabelOf(res.items[0])).toBe(ORIGINAL_TAGLINE);
+  });
+
+  it('🔴 BOTH KINDS ON ONE PAGE diverge — each row reads its OWN listing kind', async () => {
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([
+        requestRow('r_on', 'apl_on', 'onsite'),
+        requestRow('r_off', 'apl_off', 'offsite'),
+      ])
+      .mockResolvedValueOnce([]);
+    const res = await listMySubmissions({ userId: OWNER });
+
+    expect(res.items.map((i) => i.id)).toEqual(['r_on', 'r_off']);
+    const labels = Object.fromEntries(res.items.map((i) => [i.id, taglineLabelOf(i)]));
+    expect(labels['r_on']).toBe(MANIFEST_TAGLINE);
+    expect(labels['r_off']).toBe(ORIGINAL_TAGLINE);
+    expect(labels['r_on']).not.toBe(labels['r_off']);
+  });
+
+  it('the CODE is identical either way (wire contract — a released CLI branches on `code`)', async () => {
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([
+        requestRow('r_on', 'apl_on', 'onsite'),
+        requestRow('r_off', 'apl_off', 'offsite'),
+      ])
+      .mockResolvedValueOnce([]);
+    const res = await listMySubmissions({ userId: OWNER });
+    for (const item of res.items) {
+      expect(
+        item.problems.map((p) => p.code),
+        item.id
+      ).toEqual(['empty-tagline']);
+    }
+  });
+
+  it("the query PROJECTS the LISTING's kind, not only the REQUEST's", async () => {
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([requestRow('r_on', 'apl_on', 'onsite')])
+      .mockResolvedValueOnce([]);
+    await listMySubmissions({ userId: OWNER });
+    // The mock's arg is typed `unknown`; cast the ARG, not a property of it — reaching
+    // through an `unknown` is a type error even in this (root-typecheck-excluded)
+    // directory, and this file should not add to that backlog.
+    const args = mockRead.appListingPublishRequest.findMany.mock.calls[0][0] as {
+      select: { kind?: boolean; appListing: { select: Record<string, unknown> } };
+    };
+    const select = args.select;
+    // 🔴 BOTH, and the nested one is the load-bearing half: they are different columns on
+    // different tables, and the advisory is a statement about the LISTING. Reading the
+    // request's kind would be a derived surface standing in for the defining one.
+    expect(select.appListing.select.kind).toBe(true);
+    expect(select.kind).toBe(true);
+  });
+
+  it('a fake that omits the listing kind degrades to the ORIGINAL labels, and never throws', async () => {
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([
+        {
+          id: 'r_bare',
+          appListingId: 'apl_bare',
+          slug: 'bare',
+          status: 'approved',
+          appListing: {
+            name: 'Bare',
+            revisionOfId: null,
+            status: 'approved',
+            iconId: 41,
+            coverId: 53,
+            description: 'A description.',
+            tagline: null,
+            category: 'utility',
+            _count: { screenshots: 7 },
+          },
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    const res = await listMySubmissions({ userId: OWNER });
+    expect(taglineLabelOf(res.items[0])).toBe(ORIGINAL_TAGLINE);
   });
 });

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -1109,6 +1109,11 @@ async function hydrateMyAppListings(
         // the map (which cannot happen for a row that was in `subjects`) degrades to `[]`,
         // i.e. the pre-scan-dimension behaviour, never to an invented problem.
         problems: computeListingProblems({
+          // 🔴 The row's OWN kind, not a constant: `listMine` returns BOTH kinds, and the
+          // three empty-text problems give different (opposite) advice per kind. This is
+          // the same `kind` the row already reports, so the advisory and the capabilities
+          // can never disagree about what sort of listing this is.
+          kind,
           iconId: r.iconId ?? null,
           coverId: r.coverId ?? null,
           screenshotCount: r._count?.screenshots ?? 0,

--- a/src/server/services/blocks/listing-problems.ts
+++ b/src/server/services/blocks/listing-problems.ts
@@ -40,8 +40,17 @@ export type ListingAssetScan = {
  * 🔴 STRUCTURALLY IDENTICAL TO `ListingKind` (app-listing-read.schema) and
  * deliberately re-declared here rather than imported: this module is PURE and is
  * imported by `app-access.service` at the top of its import graph — see the note
- * at that import. Widening either side without the other is caught by
- * `listing-problems.kind.test.ts`, which pins the two as assignable.
+ * at that import.
+ *
+ * 🔴 WHAT ACTUALLY CATCHES A ONE-SIDED WIDENING: the `listMine` CALL SITE in
+ * `app-access.service.ts`, which passes a `ListingKind`-typed value straight into
+ * this type's parameter slot. Adding a member to `ListingKind` alone is therefore a
+ * `tsc` error there, under the ROOT typecheck. (An earlier version of this comment
+ * claimed the pin lived in `listing-problems.kind.test.ts`; it did not — that file
+ * held no assignability assertion at all. There is now a belt-and-braces one there,
+ * but it sits under `src/**\/__tests__/**`, which `tsconfig.json` EXCLUDES, so it is
+ * only checked by the deliberate test-typecheck pass. The call site is the load-
+ * bearing half; the test is the documentation.)
  */
 export type ListingProblemKind = 'onsite' | 'offsite';
 
@@ -149,13 +158,38 @@ const ASSET_PROBLEM: Record<MissingAsset, ListingProblem> = {
  * simply stop firing. Correcting the label is the only change that improves every
  * consumer without moving the contract.
  *
- * 🔴 `category` IS MANIFEST-FIXABLE **IN THE CASE THAT FIRES**, which is not obvious:
- * (3b-sync) sources it from `AppBlock.category`, not the manifest, so a moderator's
- * curated category survives a version bump. But step (3a) writes the manifest
- * `category` onto that column whenever it is still NULL — so an on-site listing can
- * only be missing a category when `AppBlock.category` is null, which means no manifest
- * declared one either. The manifest is therefore the correct remedy exactly when this
- * problem exists.
+ * 🔴 `category` IS THE ODD ONE OUT — ITS LABEL LEADS WITH "RESUBMIT", NOT WITH THE
+ * MANIFEST, AND THAT ASYMMETRY IS LOAD-BEARING. `description` and `tagline` are
+ * re-derived from the manifest on every sync (`resolveListingDescription` /
+ * `resolveListingTagline` in `buildListingScalarSync`), so for those two the manifest
+ * genuinely IS the whole remedy. `category` is NOT: (3b-sync) sources it from
+ * `AppBlock.category`, and step (3a) copies the manifest value onto that column ONLY
+ * while it is still NULL, so that a moderator's curation survives a version bump.
+ *
+ * Enumerating every writer of `app_listings.category` for an on-site row — all THREE
+ * of them — is what makes the divergence visible:
+ *   1. `publish-request.service` (submit-draft, ~:1307) — FIRST-VERSION SUBMIT ONLY.
+ *      Mints the pre-approval draft and is the one path that takes `category`
+ *      straight off the manifest, because no `AppBlock` exists yet.
+ *   2. `mapAppBlockToListing` — first approve / backfill. Reads `AppBlock.category`.
+ *   3. `buildListingScalarSync` — (3b-sync), SUBSEQUENT-VERSION approve. Same source.
+ *
+ * 🔴 `setMarketplaceMeta` — the moderator curation path — writes `AppBlock.category`
+ * and NOTHING ELSE; it never touches the listing row. So the designed curation flow
+ * reaches a state this advisory cannot distinguish: author omits `category` ⇒ listing
+ * minted null ⇒ moderator curates ⇒ `AppBlock.category` set, `AppListing.category`
+ * STILL null ⇒ this problem fires. If the author then "sets it in the manifest",
+ * (3a)'s null-gate does NOT fire, their value is DISCARDED, and (3b-sync) writes the
+ * moderator's. The problem clears — but the manifest edit was inert, and an author who
+ * wanted a DIFFERENT category can never get it that way.
+ *
+ * The problem firing is correct either way (the store card reads the listing column,
+ * which genuinely has none). What was wrong was the DIAGNOSIS: the thing that always
+ * clears it is an approved new version; the manifest key matters only when no category
+ * is set anywhere. The label says exactly that, in that order. Pinned by
+ * `listing-problems.kind.test.ts` (the whole string) and by
+ * `block-registry.marketplace-meta.test.ts` (that `setMarketplaceMeta` writes only the
+ * block) — if that ever changes, this wording should be revisited.
  */
 const TEXT_PROBLEM: Record<
   ListingProblemKind,
@@ -170,7 +204,12 @@ const TEXT_PROBLEM: Record<
     'empty-description':
       'Missing description — set "description" in block.manifest.json and resubmit',
     'empty-tagline': 'Missing tagline — set "tagline" in block.manifest.json and resubmit',
-    'empty-category': 'Missing category — set "category" in block.manifest.json and resubmit',
+    // 🔴 LEADS WITH THE ACTION THAT ALWAYS WORKS, and marks the manifest key
+    // CONDITIONAL — see the `category` note above. A moderator-curated category lives
+    // on `AppBlock.category` and reaches the listing only at the next approve, so
+    // "set it in the manifest" is inert in that state while "resubmit" is not.
+    'empty-category':
+      'Missing category — resubmit to apply it; set "category" in block.manifest.json first if your app has none',
   },
 };
 

--- a/src/server/services/blocks/listing-problems.ts
+++ b/src/server/services/blocks/listing-problems.ts
@@ -16,6 +16,13 @@ import {
  * publish/approve; it only drives the warning icon + popover on the submissions
  * list. Both the on-site (`listMyPublishRequests`) and off-site
  * (`listMySubmissions`) procs project the needed fields and call this per row.
+ *
+ * 🔴 KIND-AWARE. `empty-description` / `empty-tagline` / `empty-category` name a
+ * DIFFERENT remedy on an on-site listing than on an off-site one, because on-site
+ * copy has no author surface other than `block.manifest.json`. `kind` is a REQUIRED
+ * input for that reason — see {@link ListingProblemInput.kind} and
+ * {@link TEXT_PROBLEM}. The codes and severities are kind-INVARIANT (a released CLI
+ * branches on `code`).
  */
 
 /** The scan state of a single ATTACHED asset — feeds the scan dimension below. */
@@ -25,7 +32,29 @@ export type ListingAssetScan = {
   status: 'scanned' | 'pending' | 'blocked';
 };
 
+/**
+ * Which STORE LISTING this advisory is about. `onsite` = a hosted App Block whose
+ * copy is manifest-governed; `offsite` = an external-link listing whose copy the
+ * author typed into the submit wizard / listing editor.
+ *
+ * 🔴 STRUCTURALLY IDENTICAL TO `ListingKind` (app-listing-read.schema) and
+ * deliberately re-declared here rather than imported: this module is PURE and is
+ * imported by `app-access.service` at the top of its import graph — see the note
+ * at that import. Widening either side without the other is caught by
+ * `listing-problems.kind.test.ts`, which pins the two as assignable.
+ */
+export type ListingProblemKind = 'onsite' | 'offsite';
+
 export type ListingProblemInput = {
+  /**
+   * The listing's kind. 🔴 REQUIRED, NOT OPTIONAL-WITH-A-DEFAULT, and that is the
+   * whole enforcement mechanism: the three text problems below give DIFFERENT advice
+   * per kind, so a caller that forgets to thread it would silently emit the wrong
+   * remedy on a whole surface. A default would fail OPEN — the exact defect this
+   * function is being fixed for. Making it required turns "a caller was missed" into
+   * a compile error at every one of the three call sites.
+   */
+  kind: ListingProblemKind;
   /** Image FK for the listing icon (null ⇒ missing). */
   iconId: number | null;
   /** Image FK for the listing cover (null ⇒ missing). */
@@ -81,7 +110,11 @@ export type ListingProblemsResult = { problems: ListingProblem[] };
  * screenshots are optional → `advisory` ("recommended").
  */
 const ASSET_PROBLEM: Record<MissingAsset, ListingProblem> = {
-  icon: { code: 'missing-icon', label: 'Missing icon (required before publishing)', severity: 'blocking' },
+  icon: {
+    code: 'missing-icon',
+    label: 'Missing icon (required before publishing)',
+    severity: 'blocking',
+  },
   cover: {
     code: 'missing-cover',
     label: 'Missing cover image (required before publishing)',
@@ -91,6 +124,53 @@ const ASSET_PROBLEM: Record<MissingAsset, ListingProblem> = {
     code: 'no-screenshots',
     label: 'No screenshots (recommended, optional)',
     severity: 'advisory',
+  },
+};
+
+/**
+ * The three EMPTY-TEXT problems, per listing kind — the kind-aware half of this
+ * surface.
+ *
+ * 🔴 WHY THE LABELS DIFFER BUT THE CODES DO NOT. An on-site listing's
+ * `name`/`tagline`/`description`/`category` have NO author surface other than
+ * `block.manifest.json`: the `/apps/<appBlockId>/edit` Listing tab is media-only
+ * ("ONSITE = ASSETS-ONLY"), and `approveRequest`'s (3b-sync) MANIFEST-GOVERNED COPY
+ * RE-SYNC re-derives all four from the manifest on EVERY subsequent-version approve
+ * (`publish-request.service.ts`, scoped `kind: 'onsite'`). So the off-site advice
+ * — "go fill this field in" — is not merely unhelpful on an on-site listing, it is
+ * WRONG: any value set some other way is reverted at the next approve. Off-site copy
+ * IS author-supplied through the wizard, so its labels are the original text and must
+ * stay that way.
+ *
+ * 🔴 THE CODES ARE A WIRE CONTRACT AND ARE UNCHANGED. `problems[]` ships over tRPC to
+ * a RELEASED `@civitai/cli` (`civitai app doctor`) which branches on `code`. Renaming
+ * or dropping one would break it silently, and SUPPRESSING these three on the on-site
+ * arm would be the same break wearing a different hat — the CLI's on-site branch would
+ * simply stop firing. Correcting the label is the only change that improves every
+ * consumer without moving the contract.
+ *
+ * 🔴 `category` IS MANIFEST-FIXABLE **IN THE CASE THAT FIRES**, which is not obvious:
+ * (3b-sync) sources it from `AppBlock.category`, not the manifest, so a moderator's
+ * curated category survives a version bump. But step (3a) writes the manifest
+ * `category` onto that column whenever it is still NULL — so an on-site listing can
+ * only be missing a category when `AppBlock.category` is null, which means no manifest
+ * declared one either. The manifest is therefore the correct remedy exactly when this
+ * problem exists.
+ */
+const TEXT_PROBLEM: Record<
+  ListingProblemKind,
+  Record<'empty-description' | 'empty-tagline' | 'empty-category', string>
+> = {
+  offsite: {
+    'empty-description': 'Missing description',
+    'empty-tagline': 'Missing tagline',
+    'empty-category': 'Missing category',
+  },
+  onsite: {
+    'empty-description':
+      'Missing description — set "description" in block.manifest.json and resubmit',
+    'empty-tagline': 'Missing tagline — set "tagline" in block.manifest.json and resubmit',
+    'empty-category': 'Missing category — set "category" in block.manifest.json and resubmit',
   },
 };
 
@@ -118,12 +198,34 @@ export function computeListingProblems(listing: ListingProblemInput): ListingPro
     for (const missing of assets.missing) problems.push(ASSET_PROBLEM[missing]);
   }
 
+  // Kind-aware LABELS; codes + severities are identical across kinds (see TEXT_PROBLEM).
+  //
+  // 🔴 AN EXPLICIT EQUALITY BRANCH, NOT A `TEXT_PROBLEM[kind] ?? default` LOOKUP. `kind`
+  // reaches us from the `app_listings.kind` COLUMN as a `string` the services CAST — it is
+  // never parsed — so the index expression is effectively untrusted. Indexing a plain
+  // object literal with an inherited key (`'constructor'`, `'toString'`) returns something
+  // TRUTHY, which `??` happily accepts; the next lookup then yields `undefined` and the
+  // author is shown a listing problem with NO label at all. Branching on equality has no
+  // such hole, and it needs no `Object.create(null)` ceremony to be safe.
+  //
+  // 🔴 THE `else` IS A NEVER-THROWS GUARD, NOT A DEFAULT FOR CALLERS. `kind` is REQUIRED,
+  // so a caller that forgets it is a COMPILE error — that is the real enforcement. This
+  // branch exists so one anomalous row cannot take down the whole `/apps/mine` page,
+  // breaking the header's "Never throws" contract. It degrades to the ORIGINAL, pre-kind
+  // labels rather than inventing manifest advice for a listing that may not be
+  // manifest-governed — the actively harmful direction, and the exact defect this
+  // kind-awareness exists to fix.
+  const text = listing.kind === 'onsite' ? TEXT_PROBLEM.onsite : TEXT_PROBLEM.offsite;
   if (isEmpty(listing.description))
-    problems.push({ code: 'empty-description', label: 'Missing description', severity: 'advisory' });
+    problems.push({
+      code: 'empty-description',
+      label: text['empty-description'],
+      severity: 'advisory',
+    });
   if (isEmpty(listing.tagline))
-    problems.push({ code: 'empty-tagline', label: 'Missing tagline', severity: 'advisory' });
+    problems.push({ code: 'empty-tagline', label: text['empty-tagline'], severity: 'advisory' });
   if (isEmpty(listing.category))
-    problems.push({ code: 'empty-category', label: 'Missing category', severity: 'advisory' });
+    problems.push({ code: 'empty-category', label: text['empty-category'], severity: 'advisory' });
 
   // Scan dimension (Item 1): a still-`pending` asset is advisory (it will resolve);
   // a `blocked` asset is BLOCKING — the listing can't go live until it's replaced

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -44,7 +44,10 @@ import { assertOffsiteListingActionable } from '~/server/services/blocks/app-lis
 // TYPE-ONLY (erased at compile time) — the runtime reach into `app-access.service` stays
 // a dynamic import, so this adds nothing to the module graph. See `resolveListingRole`.
 import type { AppRole } from '~/server/services/blocks/app-access.service';
-import { computeListingProblems } from '~/server/services/blocks/listing-problems';
+import {
+  computeListingProblems,
+  type ListingProblemKind,
+} from '~/server/services/blocks/listing-problems';
 import { measureUploadedImage } from '~/server/services/blocks/measure-uploaded-image';
 import { storedObjectEtagMetadata } from '~/server/services/blocks/stored-object-integrity';
 import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
@@ -3164,6 +3167,18 @@ const mySubmissionSelect = {
   appListing: {
     select: {
       ...submissionSelect.appListing.select,
+      /**
+       * The LISTING's kind, feeding `computeListingProblems`' kind-aware empty-text
+       * labels.
+       *
+       * 🔴 THE LISTING'S KIND, NOT THE REQUEST'S, even though `submissionSelect`
+       * already carries `kind` on the REQUEST and the two agree today. They are
+       * different columns on different tables, and the advisory is a statement about
+       * the LISTING — reusing the request's would be a derived surface standing in for
+       * the defining one. Selected only on `mySubmissionSelect` (the author-facing
+       * read); the mod queues that spread the base `submissionSelect` are untouched.
+       */
+      kind: true,
       iconId: true,
       coverId: true,
       description: true,
@@ -3342,6 +3357,13 @@ export async function listMySubmissions(opts: { userId: number } & ListOffsiteRe
     // was deleted) — nothing to flag.
     problems: r.appListing
       ? computeListingProblems({
+          // 🔴 `listMySubmissions` IS NOT AN OFF-SITE-ONLY READ despite this file's name:
+          // its `where` has an explicit `{ kind: 'onsite' }` OR-branch so on-site MEDIA
+          // REVISIONS appear on /apps/my-submissions. A hardcoded 'offsite' here would
+          // therefore give manifest-governed listings the author-surface advice — exactly
+          // the defect being fixed. A fake that ignores `select` degrades to the original
+          // labels rather than throwing.
+          kind: (r.appListing.kind ?? 'offsite') as ListingProblemKind,
           iconId: r.appListing.iconId,
           coverId: r.appListing.coverId,
           screenshotCount: r.appListing._count.screenshots,


### PR DESCRIPTION
## The defect

`computeListingProblems` (`src/server/services/blocks/listing-problems.ts`) was **kind-blind**. It emitted `empty-description` / `empty-tagline` / `empty-category` with the label `Missing <field>` for **every** listing.

On an **off-site** listing that is right — the author typed that copy into the submit wizard and can go fix it.

On an **on-site** listing it is **wrong, not merely terse**. Those scalars have no author surface other than `block.manifest.json`:

- the `/apps/[appBlockId]/edit` Listing tab is media-only ("ONSITE = ASSETS-ONLY"), and
- `approveRequest`'s **(3b-sync) MANIFEST-GOVERNED COPY RE-SYNC** (`src/server/services/blocks/publish-request.service.ts`, scoped `kind: 'onsite'`) re-derives `name`/`tagline`/`description`/`category` from the manifest on **every subsequent-version approve**.

So an on-site author who found some other way to set a tagline would have it **reverted at the next approve**. `/apps/mine` was telling them to do something that cannot work.

## Decision: KEEP the codes, CORRECT the labels (not suppress)

I went with the brief's leaning, and the data supports it on three independent grounds:

1. **The gap is real.** The store page genuinely renders no tagline. Suppressing trades *wrong advice* for *no advice* — an author would see "no problems" while their store card is blank. Correcting the label is the only option that is both true and actionable.
2. **Suppression is a wire-contract break wearing a different hat.** `problems[]` ships over tRPC to a released `@civitai/cli` that branches on `code`. Dropping these three from the on-site arm doesn't error — it makes the CLI's on-site branch **structurally unreachable**, silently. That is the same failure mode as renaming a code, just harder to notice.
3. **The advice is accurate in every reachable state** — which for `category` took a correction; see the audit section below. `description`/`tagline` are re-derived from the manifest on every sync, so for those the manifest genuinely is the whole remedy. `category` is not: it reaches the listing only from `AppBlock.category` at an approve, and moderator curation writes the block without the listing. Its label therefore leads with **resubmit** and marks the manifest key conditional. That asymmetry is deliberate and pinned by a test, so a later "make these consistent" tidy-up cannot silently restore the wrong diagnosis.

Labels now:

| code | off-site (unchanged) | on-site (new) |
|---|---|---|
| `empty-description` | `Missing description` | `Missing description — set "description" in block.manifest.json and resubmit` |
| `empty-tagline` | `Missing tagline` | `Missing tagline — set "tagline" in block.manifest.json and resubmit` |
| `empty-category` | `Missing category` | `Missing category — resubmit to apply it; set "category" in block.manifest.json first if your app has none` |

**`severity` is unchanged (`advisory`) on both arms. The five other codes are byte-identical on both arms.**

## 🔴 Wire-contract impact on `civitai/cli` #488 (`civitai app doctor`)

Please read this before merging #488, or vice-versa.

- **No `code` value is renamed, removed, added, or suppressed.** Asserted, not just claimed: `listing-problems.kind.test.ts` pins that both kinds emit the **same code list in the same order** for the same input, against a literal (not against each other — comparing the two arms would pass if both were equally wrong). Same assertion at all three call sites.
- **`severity` is unchanged** on every code, both kinds.
- **The three `label` strings CHANGE for on-site listings only.** If the CLI renders the server's `label`, on-site output now names `block.manifest.json`. If it renders its own remedy text, nothing changes. Either way it keeps working — nothing it branches on moved.
- **This makes #488's kind-branching workaround redundant**, since the server now returns correct per-kind advice and the CLI already receives `kind` on the row. **Not doing that here** — different repo, different release cadence. Suggested follow-up: drop the client-side branch and render `label`, so the advice lives in one place. No rush, and no breakage if it never happens.

## Threading `kind` — how I found all the callers

`kind` is a **REQUIRED** field on `ListingProblemInput`, deliberately not optional-with-a-default. A default would fail open — a missed caller would keep the old advice on a whole surface with everything green. Required makes it a **compile error** at every call site, which is what actually enumerates them.

Found by `grep -rn "computeListingProblems" src/` (the defining surface — the function itself), not by trusting a list. Three production call sites, all threaded:

| Proc | File | Kind source |
|---|---|---|
| `appListings.listMine` | `src/server/services/blocks/app-access.service.ts` | the row's own `kind` (already selected — feeds `capabilitiesForKind`) |
| `appListings.listMySubmissions` | `src/server/services/blocks/offsite-listing.service.ts` | **added** `kind` to `mySubmissionSelect.appListing.select` |
| `blocks.listMyPublishRequests` | `src/server/routers/blocks.router.ts` | **added** `kind: true` to the listing projection |

Two things worth flagging:

- **`listMySubmissions` is not an off-site-only read**, despite the file it lives in. Its `where` has an explicit `{ kind: 'onsite' }` OR-branch so on-site *media revisions* appear on /apps/my-submissions. A hardcoded `'offsite'` there would have been wrong in production, not merely fragile. It reads the **listing's** kind, not the **request's** — different columns on different tables; they agree today, but the advisory is a statement about the listing, and using the request's would be a derived surface standing in for the defining one.
- **`blocks.listMyPublishRequests` projects `kind` even though its `where` filters `kind: 'onsite'`.** Restating a filter's conclusion at the call site creates a second place that must stay in step, and it would go wrong *silently* if the filter were ever widened. One extra column, no drift possible. There is a test that fails iff the value is hardcoded.

**No component change.** `ListingProblemsIndicator` renders whatever `label` it is handed and keys on `code:label`, so longer labels need nothing. The existing component tests supply their own `label` props, so they are unaffected — verified by grep, not assumed.

## One defect found in my own implementation, by a test

I first wrote the lookup as `TEXT_PROBLEM[listing.kind] ?? TEXT_PROBLEM.offsite`. The prototype-key case I'd written to guard against fail-open caught it: `kind` is an **untrusted cast** off the `app_listings.kind` column, and indexing a plain object literal with an inherited key (`'constructor'`, `'toString'`) returns something **truthy**, which `??` happily accepts — the next lookup then yields `undefined` and the author sees a listing problem with **no label at all**. Replaced with an explicit equality branch, which has no such hole and needs no `Object.create(null)` ceremony. The `else` is a never-throws guard (the module header promises it), degrading to the **original** labels — never inventing manifest advice for a listing that may not be manifest-governed.

## Test matrix — RED at `origin/main` 4bfd4c16d, green at HEAD

Re-measured after the rebase, in a pristine detached worktree of **`origin/main` 4bfd4c16d** with **only the test files** copied in (source diff vs `origin/main` confirmed empty). **15 regression cases.**

| File | red @ base | green @ HEAD | The RED cases |
|---|---|---|---|
| `__tests__/listing-problems.kind.test.ts` | 6 / 23 | 23 / 23 | the 3 ON-SITE label cases; "the two arms DIFFER"; the 2 label-SHAPE cases |
| `__tests__/app-access.my-app-listings-kind-problems.test.ts` | 2 / 7 | 7 / 7 | "an ON-SITE row names block.manifest.json"; "BOTH KINDS ON ONE PAGE diverge" |
| `routers/__tests__/blocks.router.listMyPublishRequests.test.ts` | 3 / 12 | 12 / 12 | on-site label; "the listing query PROJECTS `kind`"; narrow-fake degrade |
| `__tests__/offsite-listing.edit.service.test.ts` | 4 / 51 | 51 / 51 | on-site media revision; "BOTH KINDS diverge"; "PROJECTS the LISTING's kind"; "request.kind and listing.kind DISAGREE" |
| `__tests__/listing-problems.test.ts` | 0 / 26 | 26 / 26 | — **invariant guards only** |
| `__tests__/app-listing-assets.scan-batch.test.ts` | 0 / 20 | 20 / 20 | — **invariant guards only** |
| `services/__tests__/block-registry.marketplace-meta.test.ts` | 0 / 15 | 15 / 15 | — **invariant guard only** (the curation-write fact the category label rests on) |

**The green-at-base cases are labelled INVARIANT GUARDS in the files themselves and are not counted as coverage of this bug.** They pin what must *not* move (the off-site labels, the code list, the severities, the never-throws degrade) — that is the entire wire-contract claim, so they earn their place, but by a different argument. Two are called out specifically because they can *never* have been red and still matter:

- `listMine` **already** selected `kind` at base (it feeds `capabilitiesForKind`), so "the service PROJECTS `kind`" was never red. It exists to stop that projection being deleted as dead weight — the route by which this fix would silently revert.
- The off-site positive controls are green at base by construction. Their job is to kill a mutant that gives **both** kinds the manifest label, which no on-site assertion can do.

**Per-kind-per-code coverage** is a case each (2 kinds × 3 codes), not one aggregate assertion, with the off-site arm as the explicit positive control at every level. Labels are pinned as **whole normalised strings**, not keyword-matched — the artifact under test here *is* prose, so a `toMatch(/manifest/i)` guard would be walkable by re-wording. A cosmetic reword will fail these tests; that is the price of the claim being machine-checkable.

**Fixture guards.** `tsconfig.json` excludes `src/**/__tests__/**`, so the REQUIRED `kind` field is not enforced there by `pnpm typecheck` — and an unrecognised kind degrades silently rather than throwing, so a fixture that dropped `kind` would make a whole file assert against the fallback while passing. Every fixture declares `kind` explicitly, and each file carries a runtime guard that enumerates its fixtures, asserts a non-zero count (so an emptied list can't pass vacuously), and asserts both kinds are represented.

## Mutation table — 16 defined / 16 verdicts produced / 16 killed

Every run totalled **exactly 154 tests**, matching the baseline — so no run was truncated and no verdict is unattributed. Re-run in full against the exact source being committed (after Prettier), not against an earlier draft.

| # | File | Mutation | Verdict | Killed by (its own guard's assertion) |
|---|---|---|---|---|
| M0 | listing-problems | **positive control**: off-site tagline label → garbage | KILLED (9) | off-site label pins + both positive controls |
| M1 | listing-problems | `kind === 'onsite'` → `=== 'offsite'` (arms swapped) | KILLED (16) | all 6 per-kind label cases |
| M2 | listing-problems | on-site arm → off-site table (**the original defect, exactly**) | KILLED (10) | 3 on-site labels + "arms DIFFER" + both seams |
| M3 | listing-problems | off-site arm → on-site table (defect, other way) | KILLED (12) | 3 off-site labels + never-throws degrade |
| M4 | listing-problems | ONE on-site label regresses to the original | KILLED (8) | that code's on-site case + "arms DIFFER" |
| M5 | listing-problems | an on-site label names the WRONG manifest key | KILLED (3) | `empty-category` on-site case |
| M6 | listing-problems | label lookup uses the wrong key at one push site | KILLED (15) | "the three ON-SITE labels are distinct" |
| M7 | listing-problems | one code stays kind-blind (**a partial fix**) | KILLED (4) | `empty-category` on-site case |
| M8 | app-access | caller 1 hardcodes `'offsite'` | KILLED (2) | "an ON-SITE row names block.manifest.json" |
| M9 | app-access | caller 1 hardcodes `'onsite'` | KILLED (2) | the off-site **positive control** |
| M10 | blocks.router | caller 2 hardcodes `'onsite'` | KILLED (1) | **only** the discriminating control |
| M11 | blocks.router | caller 2 stops PROJECTING `kind` | KILLED (1) | the projection assertion |
| M12 | offsite-listing | caller 3 hardcodes `'offsite'` | KILLED (2) | "an ON-SITE media revision names block.manifest.json" |
| M13 | offsite-listing | caller 3 stops PROJECTING the listing's kind | KILLED (1) | the listing-kind projection assertion |
| M14 | offsite-listing | caller 3 reads the **request's** kind, not the listing's | KILLED (2) | the two request-vs-listing disagreement cases |
| M15 | listing-problems | on-site category label reverts to **manifest-first** (the wrong diagnosis) | KILLED (4) | the whole-string pin + the RESUBMIT-leads asymmetry case |

Notes on how this table was produced, since a mutation table is worth exactly what its method is worth:

- Each mutant asserts its target text occurs **exactly once** before replacing, so a `count=1` replace cannot land on an occurrence I didn't picture.
- Each mutant is the **narrowest wrong expression** — no mutant removes a guard together with its enclosing condition.
- **M8 was initially malformed and I caught it via a SURVIVED verdict**, which is the honest reason to reconcile rather than assume. My first version *inserted* `kind: 'offsite'` before the existing `kind` shorthand; duplicate object keys mean the later one wins, so it was a **no-op mutant** — it survived because it expressed no defect, not because coverage was missing. TS would have flagged the duplicate key, but vitest strips types without checking, so it ran. Rewritten to actually replace the value; it now dies to 2 tests. **The first sweep's `SURVIVED` was a fact about my mutant, not about the code.**
- **M10, M11, M13 are each killed by exactly ONE test**, and in each case it is a control that looks redundant (green at base) until you try to hardcode or drop the value. M9 is killed by **two** — an earlier draft of this body said "M9 and M10 are each killed by exactly one test", which contradicted my own table two paragraphs above it. The table was right; the prose was wrong, and an overstated mutation claim is exactly the thing that gets cited later instead of re-derived. Corrected.

---

## Adversarial-audit round (post-#4361 rebase)

Rebased onto `origin/main` **4bfd4c16d** (which now contains #4361). `app-access.service.ts` merged clean; both markers re-verified present — the call-site comment **and** `kind: true` in the `hydrateMyAppListings` select, which was flagged as the likely casualty of a careless resolution *because it looks redundant*. Everything below is a fix on top.

### 🔴 FIXED — `empty-category` named the wrong remedy

My original justification was **wrong**, and the source comment repeated it. The argument was: (3a) fills `AppBlock.category` from the manifest whenever it is null, so a missing category implies no manifest category, so the manifest is the fix.

The advisory does not read `AppBlock.category`. It reads **`AppListing.category`**, and **`setMarketplaceMeta` — the moderator curation path — writes `AppBlock.category` only. It never touches the listing row.** So the *designed* curation flow reaches a state my reasoning skipped:

1. Author omits `category` → listing minted `null`.
2. Moderator curates → `AppBlock.category` set, `AppListing.category` **still null**.
3. Advisory fires *"set it in block.manifest.json and resubmit."*
4. Author complies → **(3a)'s null-gate does not fire** → their value is **discarded** → (3b-sync) writes the **moderator's**.

The problem firing was always correct (the store card reads the listing column and genuinely has none). The **diagnosis** was wrong: what clears it is an approved new version; the manifest key matters only when no category is set anywhere. An author who wanted a *different* category could never get it that way.

Enumerating this turned up a **third writer** of the column the audit's "exactly two" missed — **(submit-draft)** in `publish-request.service.ts` (~:1307) mints the pre-approval draft straight from the manifest, because no `AppBlock` exists yet. It does **not** rescue the old claim (it is a create, not a rewrite of an existing null), but the corrected comment lists all three.

Fixed in the label, the comment, and pinned three ways:
- the whole corrected string, verbatim;
- **the asymmetry itself** — `empty-category` must lead with *resubmit* and hedge the manifest; `description`/`tagline` must do the opposite, because for them the manifest genuinely is the whole remedy. Without this a later "make these consistent" tidy-up silently restores the wrong diagnosis;
- **`block-registry.marketplace-meta.test.ts`** now pins that curation writes the block and never the listing — with a positive control that the expected write did happen, so the two `not.toHaveBeenCalled()` cannot pass against a method that wrote nothing. If that ever goes red the divergence has closed and this label should be revisited. A comment claiming a relationship cannot notice when the relationship stops holding.

### 🔴 FIXED — a comment claimed a guard that did not exist

`ListingProblemKind`'s docblock said assignability with `ListingKind` was *"caught by `listing-problems.kind.test.ts`, which pins the two as assignable."* That file contained **zero** references to `ListingKind`. The hazard **is** covered — by the `listMine` call site passing a `ListingKind` into this type's slot, under the **root** typecheck — so the comment now names that, and the test carries a belt-and-braces pin which says out loud that it is checked only by the deliberate test-typecheck pass. Both halves are now true.

### FIXED — LISTING-vs-REQUEST kind was pinned only structurally

The audit's mutant reading `r.kind` instead of `r.appListing.kind` **SURVIVED all 132 tests**, because every fixture set the two equal. Correct that it is not a live hole — but my stated rationale is precisely that they are independent columns that might diverge, and a rationale nothing can falsify is not a tested claim. `requestRow` now takes the request kind separately, and two cases make them disagree **in both directions**. That mutant is now **M14** in the committed battery and dies to exactly those two.

### FIXED — the fixture guard only saw the factory

It enumerated the 8 objects `complete()`/`missingOne()` produce; the WIRE CONTRACT describe builds inline literals it could not see. It now scans the file's own source and requires every inline literal handed to the advisory to declare `kind`. **The scanner immediately flagged its own planted control string** (which lives in the source) — that is the instrument working; the control is now assembled from pieces. Both controls present: a planted bad literal it must flag, and a non-zero count of literals actually examined.

### FIXED — the M9 prose contradicted my own table

Noted below in the mutation section. The table was right (M9 is killed by **2**); the prose said one.

### Battery now committed

`scripts/mutation/listing-problems-kind.mutation.py` + `.suite.sh` + `.results.json`. Re-run it and diff. It measures its own baseline, refuses to run against a red tree, reconciles every mutant's total against that baseline (a differing total is **UNATTRIBUTED**, never SURVIVED), reports DEFINED vs VERDICTS-PRODUCED separately, and keeps a known-caught positive control in the batch.

### ACKNOWLEDGED, NOT FIXED — `description` is an undeclared manifest key

Confirmed the auditor's reading independently, and I agree it is real: the key is honoured at runtime but declared nowhere an author would look, and `civitai app validate` accepts both it and a bogus key silently. Filed in `datapacket-talos:claudedocs/app-platform-followups-2026-08-25.md` §3 per the operator's decision; **not** holding this PR.

My independent read is in the report accompanying this PR: **the label is still the best available advice**, because the key genuinely works — the failure mode is a silent no-op on a typo, which is a *validator* gap, and suppressing the advice would leave the author with no remedy at all rather than an undocumented one.

### ACKNOWLEDGED, NOT FIXED — manifest `description` is length-unbounded

Pre-existing on `main`; this PR does not create it, but it does convert a field nobody used into one authors are now told to fill. The fix belongs with the schema + validator + SDK byte-mirrors (the same cross-repo surface as the item above), not here. Filed alongside it.

## Gates

| Gate | Result |
|---|---|
| `pnpm test:unit:run` | **1408 files passed, 1 skipped; 22106 tests passed, 25 skipped, 0 failed** (rc=0) |
| `pnpm typecheck` | **0 errors** (rc=0) |
| Test-file typecheck — the repo's own `scripts/ci/typecheck-tests-gate.mjs` | **Byte-identical at base and HEAD**: 920 errors / 175 files, the same 53 unbaselined and the same 7 worse, per-file lists `diff`-clean. The gate is RED on `origin/main` already (baseline 784/140 has drifted); **this PR adds nothing to it**, and I measured that rather than inferring it. Also cross-checked with a raw `tsc` run: 921 vs 921, and the 8 apparent new/gone entries are the SAME diagnostics shifted by my insertions — identical once line numbers are stripped. |
| My two new test files, specifically | **0 type errors.** (The 2 diagnostics matching my file globs are pre-existing `BigInt` errors in `block-registry.marketplace-meta.test.ts`, identical at base.) |
| Typecheck positive control | Confirmed the instrument goes red on my files — and `TS2741: Property 'kind' is missing … but required in ListingProblemInput` is exactly the omitted-fixture hazard, caught structurally. |
| ESLint (own files) | **0 findings in the two new files.** The one `error` in `blocks.router.listMyPublishRequests.test.ts` is at line 27, pre-existing, reproduced at base. |
| Prettier | clean on all 10 files |
| `pnpm test:component` | **not run — no component file is touched.** `ListingProblemsIndicator` is unmodified and the component tests supply their own `label` props (verified by grep). |

### `preview / component-tests` is RED, and it is NOT this PR — first bad commit named

CI shows `preview / component-tests` failing (report-only, non-blocking). It is a **pre-existing breakage on `main`**, and I bisected it rather than waving at it:

```
FAIL src/components/Image/AsPosts/ImagesAsPostsCardLazyCarousel.browser.test.tsx
Caused by: SyntaxError: The requested module '/src/components/Dialog/RoutedDialogLink.tsx'
           does not provide an export named 'triggerRoutedDialog'
Test Files  1 failed | 188 passed (189)
Tests       2062 passed (2062)
```

Attribution, measured:

| PR | its base | `component-tests` |
|---|---|---|
| #4368 | `ea9d8dd3c6` | **pass** |
| #4372 | `9214e2235e` | **pass** |
| #4377 (leaderboard, unrelated) | `d4c4a4e4cb` | **fail** |
| #4370 (this) | `4bfd4c16dc` | **fail** |

Those bases are linear ancestors, so the first bad commit is **`d4c4a4e4cb` — #4365 `feat(image-feed): Published/Draft toggle`**, which touches `src/components/Image/Infinite/UserMediaInfinite.tsx` and `MediaFiltersDropdown.tsx`. The reported "missing export" is not real — `triggerRoutedDialog` **is** exported from `RoutedDialogLink.tsx:13` and ~10 other modules import it successfully — so this is a module-init/circular-import ordering artifact in browser-mode ESM, which is exactly what an added import edge in that graph causes.

Why it cannot be this PR, structurally: the `component` project's include glob is `src/**/*.browser.test.tsx`, and **this PR contains zero `.browser.test.tsx` files** — its diff is server code, server tests, and `scripts/mutation/`. The 188→189 file-count difference vs #4368 is also fully accounted for by intervening commits (#4361 alone added two component test files), not by anything here.

Two limits I am not papering over: I could not reproduce locally (the sandbox cannot launch `chrome-headless-shell`), and #4377's pipeline logs were pruned before I could confirm its failure is the *same* one rather than merely concurrent — so its row is evidence of a red gate at that base, not proof of an identical stack. Worth a separate issue against #4365; not this PR's to fix.

## Merge / rebase state

- **Rebased onto `origin/main` 4bfd4c16d**, which now contains #4361. Rebase applied clean (rc=0, no conflicts).
- **#4361 has MERGED** (`4bfd4c16d`). Before the rebase I test-merged against its head — 0 conflicts, typecheck clean, 171/171 across 6 suites spanning both. After the rebase I re-verified **both** markers in `app-access.service.ts` survived: the call-site comment `The row's OWN kind, not a constant`, **and** `kind: true` in the `hydrateMyAppListings` select. The latter was specifically flagged as the likely casualty of a careless resolution *because it looks redundant* — it is not: dropping it is mutant **M11**'s sibling and would silently revert the fix on `/apps/mine`.
- Nothing else on `main` touches my files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
