### PR TITLE
fix(dev-server): stop the daemon popping a terminal window that steals focus

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -33,7 +33,7 @@ node .claude/skills/dev-server/cli.mjs stop <session-id>
 
 ## Which node the daemon runs on — and why it is sticky
 
-The daemon is spawned with `process.execPath` (`cli.mjs:70`, `console.mjs:89`), i.e. **whatever node ran
+The daemon is spawned with `process.execPath` (`cli.mjs:71`, `console.mjs:90`), i.e. **whatever node ran
 the CLI verb that first started it**. It then passes its own environment down to every `next dev` it
 supervises. So the node you happened to have on `PATH` the first time you typed any command above is the
 node the whole tree runs on, until someone shuts the daemon down — and nothing records which one that was.

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -61,14 +61,14 @@ async function startDaemon() {
     stdio: 'ignore',
     cwd: projectRoot,
     windowsHide: true,
-    shell: true,
   };
 
-  // Use quoted command string for shell: true on Windows. No --port: the daemon resolves
-  // DEV_DAEMON_PORT through the same function this file does, off the environment it inherits
-  // here, so the two cannot disagree about where it lives.
-  const command = `"${process.execPath}" "${serverScript}"`;
-  const child = spawn(command, [], spawnOptions);
+  // No shell. windowsHide reaches only the process node creates, so with `shell: true` it lands on
+  // cmd.exe and never on the daemon cmd.exe then starts: that node gets a fresh console, Windows 11
+  // hands it to the default terminal app, and a Windows Terminal window opens and takes focus off
+  // whatever the user was doing. No --port: the daemon resolves DEV_DAEMON_PORT through the same
+  // function this file does, off the environment it inherits here, so the two cannot disagree.
+  const child = spawn(process.execPath, [serverScript], spawnOptions);
   child.unref();
 
   writeFileSync(pidFile, String(child.pid));

--- a/.claude/skills/dev-server/console.mjs
+++ b/.claude/skills/dev-server/console.mjs
@@ -86,9 +86,9 @@ async function isDaemonRunning() {
 }
 
 async function startDaemon() {
-  const command = `"${process.execPath}" "${serverScript}"`;
-  const child = spawn(command, [], {
-    detached: true, stdio: 'ignore', cwd: projectRoot, windowsHide: true, shell: true,
+  // No shell — see cli.mjs startDaemon.
+  const child = spawn(process.execPath, [serverScript], {
+    detached: true, stdio: 'ignore', cwd: projectRoot, windowsHide: true,
   });
   child.unref();
   writeFileSync(pidFile, String(child.pid));

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -52,6 +52,10 @@ function resolvePrimaryCheckout() {
       cwd: projectRoot,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      // The daemon has no console of its own, so every console child it starts without this
+      // allocates one — which Windows 11 hands to the default terminal app, popping a Windows
+      // Terminal window that takes focus. Piping stdio does not prevent the allocation.
+      windowsHide: true,
       // This runs at module load, before the listener exists, so a wedged git would hang the daemon
       // where `ensureDaemon` reports a bare "Failed to start daemon" with nothing naming git.
       timeout: 5000,
@@ -336,6 +340,7 @@ function getGitBranch(dir) {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     });
     return result.trim();
   } catch (e) {
@@ -484,6 +489,7 @@ function runCommand(cmd, args, cwd, env, log) {
       env,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: process.platform === 'win32',
+      windowsHide: true,
     });
     const pipe = (stream, level) =>
       stream.on('data', (d) => {
@@ -769,6 +775,7 @@ class DevSession {
       env,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: isWindows,
+      windowsHide: true,
     };
 
     // Use process groups on Unix for proper cleanup
@@ -905,7 +912,7 @@ class DevSession {
   killProcessTree(proc) {
     try {
       if (process.platform === 'win32') {
-        spawn('taskkill', ['/pid', String(proc.pid), '/f', '/t'], { shell: true });
+        spawn('taskkill', ['/pid', String(proc.pid), '/f', '/t'], { shell: true, windowsHide: true });
       } else {
         process.kill(-proc.pid, 'SIGKILL');
       }
@@ -1375,6 +1382,7 @@ class RgbProxy {
       env: process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: isWindows,
+      windowsHide: true,
     };
     if (!isWindows) spawnOptions.detached = true;
 
@@ -1443,7 +1451,7 @@ class RgbProxy {
       proc.once('exit', () => resolve(this.getStatus()));
       try {
         if (process.platform === 'win32') {
-          spawn('taskkill', ['/pid', String(proc.pid), '/f', '/t'], { shell: true });
+          spawn('taskkill', ['/pid', String(proc.pid), '/f', '/t'], { shell: true, windowsHide: true });
         } else {
           process.kill(-proc.pid, 'SIGKILL');
         }
@@ -1661,6 +1669,7 @@ class AuthHub {
       env: this.spawnEnv(),
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: isWindows,
+      windowsHide: true,
     };
     if (!isWindows) spawnOptions.detached = true;
 
@@ -1778,7 +1787,7 @@ class AuthHub {
       proc.once('exit', resolve);
       try {
         if (process.platform === 'win32') {
-          spawn('taskkill', ['/pid', String(proc.pid), '/f', '/t'], { shell: true });
+          spawn('taskkill', ['/pid', String(proc.pid), '/f', '/t'], { shell: true, windowsHide: true });
         } else {
           process.kill(-proc.pid, 'SIGKILL');
         }

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -191,6 +191,7 @@ export function defaultStartRun({ worktree, args, onLog, onExit }) {
       // the order they were actually written. See createOutputCapture.
       stdio: ['ignore', capture.writeFd, capture.writeFd],
       shell: isWindows,
+      windowsHide: true,
       // Its own process group, so the kill below can take the whole vitest tree. Without this,
       // killing by negative pid names no group, fails with ESRCH, and leaves the run burning
       // cores while its slot is handed to the next caller.

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -20,6 +20,7 @@ function git(args, cwd) {
     cwd,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
   }).trim();
 }
 
@@ -123,6 +124,7 @@ function spawnGh(args, cwd) {
       cwd,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
   } catch {
     return null;

--- a/scripts/__tests__/dev-server-no-console-window.test.ts
+++ b/scripts/__tests__/dev-server-no-console-window.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+
+// On Windows a console child with no console of its own gets a fresh one, and Windows 11 hands that
+// to the default terminal app — a Windows Terminal window opens and takes focus. `windowsHide`
+// suppresses it, but node applies it only to the process IT creates: with `shell: true` it lands on
+// cmd.exe, and the process cmd.exe then starts is created with default flags. The daemon is spawned
+// detached with stdio ignored, so it owns no console to lend, and every one of its children is in
+// that position. Piping stdio does not prevent the allocation.
+const SKILL = resolve(__dirname, '../../.claude/skills/dev-server');
+
+const FILES = [
+  'cli.mjs',
+  'console.mjs',
+  'scripts/daemon.mjs',
+  'scripts/test-queue.mjs',
+  'scripts/worktree.mjs',
+];
+
+const read = (file: string) => readFileSync(resolve(SKILL, file), 'utf8');
+
+/** The object literal enclosing `at`, by brace balance. */
+function enclosingLiteral(source: string, at: number) {
+  let depth = 0;
+  let open = -1;
+  for (let i = at; i >= 0; i--) {
+    if (source[i] === '}') depth++;
+    else if (source[i] === '{') {
+      if (depth === 0) {
+        open = i;
+        break;
+      }
+      depth--;
+    }
+  }
+  if (open === -1) return null;
+  depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0)
+        return { text: source.slice(open, i + 1), line: source.slice(0, open).split('\n').length };
+    }
+  }
+  return null;
+}
+
+describe('the dev-server skill never pops a console window', () => {
+  it.each(FILES)('every spawn option object in %s hides the console', (file) => {
+    const source = read(file);
+    const offenders: string[] = [];
+    for (let i = source.indexOf('stdio:'); i !== -1; i = source.indexOf('stdio:', i + 1)) {
+      const literal = enclosingLiteral(source, i);
+      if (literal && !literal.text.includes('windowsHide')) {
+        offenders.push(`${file}:${literal.line}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it.each(['cli.mjs', 'console.mjs'])('%s starts the daemon without a shell', (file) => {
+    const source = read(file);
+    const start = source.indexOf('async function startDaemon');
+    expect(start).toBeGreaterThan(-1);
+    const body = source.slice(start, source.indexOf('\n}', start));
+    expect(body).toContain('spawn(process.execPath, [serverScript]');
+    expect(body.replace(/^\s*\/\/.*$/gm, '')).not.toMatch(/\bshell\s*:/);
+  });
+});

--- a/scripts/__tests__/dev-server-port-reservation.test.ts
+++ b/scripts/__tests__/dev-server-port-reservation.test.ts
@@ -260,6 +260,7 @@ describe('dev-server restart wiring', () => {
       if (process.platform === 'win32') {
         expect(spawnMock).toHaveBeenCalledWith('taskkill', ['/pid', '6161', '/f', '/t'], {
           shell: true,
+          windowsHide: true,
         });
       } else {
         expect(killSpy).toHaveBeenCalledWith(-6161, 'SIGKILL');
@@ -507,6 +508,7 @@ describe('dev-server session process lifecycle', () => {
       if (process.platform === 'win32') {
         expect(spawnMock).toHaveBeenCalledWith('taskkill', ['/pid', '31337', '/f', '/t'], {
           shell: true,
+          windowsHide: true,
         });
       } else {
         expect(killSpy).toHaveBeenCalledWith(-31337, 'SIGKILL');


### PR DESCRIPTION
## The symptom

Running a dev-server CLI verb makes a terminal window appear on Windows, and it takes focus away from whatever you were doing.

## What actually creates it

`cli.mjs` `startDaemon` (and its copy in `console.mjs`) spawned the daemon with `shell: true`:

```js
const command = `"${process.execPath}" "${serverScript}"`;
const child = spawn(command, [], { detached: true, stdio: 'ignore', windowsHide: true, shell: true });
```

`windowsHide` was already there, and did nothing useful. Node applies it to the process **it** creates — with `shell: true` that is `cmd.exe`. The node process `cmd.exe` then starts is created with default flags, has no console to inherit, and so allocates a fresh one. On Windows 11 the default terminal app is Windows Terminal, which opens that console as a visible window and activates it.

Piping stdio does not prevent the allocation; `detached` does not either.

## Evidence

A window watcher (`EnumWindows`-free: per-process `MainWindowHandle` plus `GetForegroundWindow`, 
polled) with a positive control — it sees Notepad open, take focus, and close.

Interleaved A/B on the real `cli.mjs`, pointed at a stub daemon so nothing live was touched:

| run | result |
|---|---|
| before | Windows Terminal window, titled with the daemon command line |
| after | no window, no focus change |
| before | Windows Terminal window + focus stolen |
| after | no window, no focus change |

Across six runs of the unpatched shape the window appeared every time; focus was stolen in four.

**Baseline:** 10 minutes of ordinary fleet traffic (510 console-host spawns from Bash tool calls and daemon children) produced zero new windows. Ordinary Bash calls are not implicated.

## Why the fix is bigger than one line

Removing the shell leaves the daemon with **no console of its own** — the popped console was the daemon's. Every child it spawns is then in exactly the position that pops a window: `npm run dev` per session, `taskkill` per stop, the queued vitest run, the branch watcher's `git`. Verified with a console-less parent: inner spawn without `windowsHide` pops a window and steals focus (2/2), with it, nothing (2/2). So `windowsHide: true` goes on every spawn/exec in the skill.

## Guard

`scripts/__tests__/dev-server-no-console-window.test.ts` asserts both halves. Mutation-checked: restoring `shell: true` in `startDaemon` and removing one `windowsHide` each make it fail.

## Verification

- `scripts/__tests__` — 439 passed, 1 skipped
- `pnpm run test:lint-rules` — 336 passed
- all seven dev-server skill selftests green

Full unit suite not run: the diff touches no `src/` file. Two exact-object assertions on the `taskkill` spawn in `dev-server-port-reservation.test.ts` pinned the old option object and were updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)