### PR TITLE
fix(search-index-cleanup): resume a truncated scan instead of restarting it

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1895,6 +1895,16 @@ export const REDIS_SYS_KEYS = {
     LEGACY_UPGRADE_LOCK: 'session:legacy-upgrade-lock',
   },
   JOB: 'job',
+  SEARCH_INDEX_CLEANUP: {
+    // Per-index keyset scan cursor for the nightly search-index cleanup, so a pass
+    // that could not walk a whole index in one run RESUMES next run instead of
+    // restarting from the bottom and re-walking the same prefix forever.
+    // Hash: field = cleanup index key ('models', 'users', …), value = JSON
+    // { lastId, startedAt, covered }. No TTL — staleness is bounded in code by
+    // `startedAt`, and an expiry would silently look identical to a completed pass.
+    // See src/server/meilisearch/cleanup-cursor.ts.
+    CURSORS: 'search-index-cleanup:cursors',
+  },
   METRIC_RECONCILIATION: {
     // Last completed nightly reaction-exactness result, so the hourly job can
     // re-publish its gauges after a pod roll. See metric-reconciliation-audit.ts.

--- a/src/server/jobs/__tests__/search-index-cleanup.test.ts
+++ b/src/server/jobs/__tests__/search-index-cleanup.test.ts
@@ -79,6 +79,7 @@ type Stats = {
   passCovered: number;
   resumedFrom: number | null;
   cursorPersisted: number | null;
+  cursorCleared: boolean;
   cursorDiscardReason: string | null;
   emptyPageRetries: number;
 };
@@ -106,6 +107,7 @@ function stats(over: Partial<Stats> & { key: string }): Stats {
     passCovered: over.idsScanned ?? 0,
     resumedFrom: null,
     cursorPersisted: null,
+    cursorCleared: false,
     cursorDiscardReason: null,
     emptyPageRetries: 0,
     ...over,
@@ -422,6 +424,80 @@ describe('search-index-cleanup: the coverage band is calibrated, not incidental'
   });
 });
 
+// 🔴 The other half of the seam. This table is byte-for-byte the one in
+// src/server/meilisearch/__tests__/cleanup.test.ts, where the same rows assert whether
+// `cleanupIndex` KEEPS its resume cursor. Here they assert the job's `incomplete`
+// verdict, and the two must be exact negations.
+//
+// They were not. `cleanupIndex` cleared the cursor at >= 50% coverage while this job
+// alarmed below 75%, so a pass at 0.60 was logged truncated at error level AND had its
+// resume point discarded in the same run — the next run restarted at the bottom. Row 3
+// is that case. If a future change moves one consumer's threshold, one of these two
+// tables goes red.
+const COVERAGE_BAND: { total: number; covered: number; reachedEnd: boolean }[] = [
+  { total: 8000, covered: 2000, reachedEnd: false }, // 0.250 — both clauses flag
+  { total: 8000, covered: 4000, reachedEnd: false }, // 0.500 — the old cursor threshold
+  { total: 8000, covered: 4800, reachedEnd: false }, // 0.600 — INSIDE the old gap
+  { total: 8000, covered: 6800, reachedEnd: true }, //  0.850 — only the RATIO clause spares it
+  { total: 2000, covered: 1200, reachedEnd: true }, //  0.600 — only the FLOOR clause spares it
+  { total: 8000, covered: 7900, reachedEnd: true }, //  0.9875 — comfortably finished
+];
+
+describe('search-index-cleanup: `incomplete` is the exact negation of "the cursor cleared"', () => {
+  for (const { total, covered, reachedEnd } of COVERAGE_BAND) {
+    it(`covered ${covered} of ${total} → incomplete=${!reachedEnd}`, async () => {
+      cleanupAllIndexes.mockResolvedValue([
+        stats({
+          key: 'users',
+          idsScanned: covered,
+          passCovered: covered,
+          staleFound: 31,
+          deleted: 17,
+          totalInIndex: total,
+          stoppedEarly: false,
+          // What `cleanupIndex` did with the cursor for this same row.
+          cursorCleared: reachedEnd,
+          cursorPersisted: reachedEnd ? null : covered,
+        }),
+      ]);
+
+      await searchIndexCleanupJob.run({}).result;
+
+      const payload = payloadFor('users');
+      expect(payload?.incomplete).toBe(!reachedEnd);
+      expect(payload?.type).toBe(reachedEnd ? 'info' : 'error');
+      // Stated as the identity, not as two independent facts: this is the seam.
+      expect(payload?.incomplete).toBe(!payload?.cursorCleared);
+    });
+  }
+});
+
+describe('search-index-cleanup: a cursor being discarded is stated, not inferred', () => {
+  it('says the cursor was cleared, so it is distinguishable from a failed write', async () => {
+    // Both leave `cursorPersisted: null`, and they are opposite events.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'tools',
+        idsScanned: 91,
+        staleFound: 7,
+        deleted: 3,
+        totalInIndex: 91,
+        cursorCleared: true,
+        resumedFrom: 44,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const payload = payloadFor('tools');
+    expect(payload?.cursorCleared).toBe(true);
+    expect(payload?.message).toBe(
+      'tools: scanned 91, stale 7, deleted 3, resumed from id 44, ' +
+        'cursor cleared — the next run starts over'
+    );
+  });
+});
+
 describe('search-index-cleanup: an index the run never reached is reported', () => {
   it('names every configured index that was never attempted', async () => {
     // `cleanupAllIndexes` stops iterating on cancellation, so the indexes it
@@ -486,6 +562,33 @@ describe('search-index-cleanup: an unreadable index is not filed as healthy', ()
       'users: scan STOPPED EARLY after 0 id(s) (index document count unavailable); ' +
         '1 error(s) — scanned 0, stale 0, deleted 0'
     );
+  });
+
+  it('reports no coverage for an EMPTY index rather than NaN', async () => {
+    // A total of zero is a real state (a freshly created index), and it is the input
+    // that makes the coverage division degenerate: dividing by it yields NaN, which
+    // serialises into the log payload and compares false against every threshold
+    // without ever erroring. `null` is the honest answer, and the same one the
+    // unknown-total case gives.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'bounties',
+        idsScanned: 0,
+        passCovered: 0,
+        staleFound: 0,
+        deleted: 0,
+        totalInIndex: 0,
+        stoppedEarly: false,
+        cursorCleared: true,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const payload = payloadFor('bounties');
+    expect(payload?.coverage).toBe(null);
+    expect(payload?.incomplete).toBe(false);
+    expect(payload?.type).toBe('info');
   });
 
   it('does not invent a coverage verdict when the total is unknown but the scan finished', async () => {

--- a/src/server/jobs/__tests__/search-index-cleanup.test.ts
+++ b/src/server/jobs/__tests__/search-index-cleanup.test.ts
@@ -90,6 +90,15 @@ type Stats = {
  * `passCovered` defaults to this run's `idsScanned`, which is what a pass that never
  * resumed reports. A resumed run is the case where the two differ, and the tests that
  * care about it set it explicitly.
+ *
+ * 🔴 `cursorCleared: false` is the default because that is what the REAL scan produces
+ * for this scenario — a completed pass with nothing stored discards nothing. It briefly
+ * was not: `clearScanCursor` returned `true` unconditionally, so production put "cursor
+ * cleared" on every healthy line for every index while this fake said otherwise, and
+ * the `stays quiet about the ordinary case` test below asserted a message production
+ * would never emit. A fixture encoding a shape the code cannot produce is worse than no
+ * fixture — it certifies the wrong behaviour. The real-code side of this is pinned in
+ * cleanup.test.ts ("`cursorCleared` means a cursor was actually discarded").
  */
 function stats(over: Partial<Stats> & { key: string }): Stats {
   return {

--- a/src/server/jobs/__tests__/search-index-cleanup.test.ts
+++ b/src/server/jobs/__tests__/search-index-cleanup.test.ts
@@ -76,9 +76,20 @@ type Stats = {
   idsSkipped: number;
   rescuedByPrimary: number;
   indexingAtStart: boolean | null;
+  passCovered: number;
+  resumedFrom: number | null;
+  cursorPersisted: number | null;
+  cursorDiscardReason: string | null;
+  emptyPageRetries: number;
 };
 
-/** A healthy, complete pass by default; each test overrides only what it means. */
+/**
+ * A healthy, complete pass by default; each test overrides only what it means.
+ *
+ * `passCovered` defaults to this run's `idsScanned`, which is what a pass that never
+ * resumed reports. A resumed run is the case where the two differ, and the tests that
+ * care about it set it explicitly.
+ */
 function stats(over: Partial<Stats> & { key: string }): Stats {
   return {
     indexName: `${over.key}_v1`,
@@ -92,6 +103,11 @@ function stats(over: Partial<Stats> & { key: string }): Stats {
     idsSkipped: 0,
     rescuedByPrimary: 0,
     indexingAtStart: false,
+    passCovered: over.idsScanned ?? 0,
+    resumedFrom: null,
+    cursorPersisted: null,
+    cursorDiscardReason: null,
+    emptyPageRetries: 0,
     ...over,
   };
 }
@@ -509,6 +525,129 @@ describe('search-index-cleanup: the requested scan batch', () => {
     const opts = cleanupAllIndexes.mock.calls[0][1] as { batch: number; apply: boolean };
     expect(opts.batch).toBe(10000);
     expect(opts.apply).toBe(true);
+  });
+
+  it('opts the nightly run into the shared cross-run cursor', async () => {
+    // The cron is the only caller that owns the cursor. Without this flag the scan
+    // restarts at the bottom every night and a pass it cannot finish in one run
+    // makes zero cumulative progress — the defect, unchanged, with a store sitting
+    // beside it doing nothing.
+    cleanupAllIndexes.mockResolvedValue([]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const opts = cleanupAllIndexes.mock.calls[0][1] as { resumable?: boolean };
+    expect(opts.resumable).toBe(true);
+  });
+});
+
+describe('search-index-cleanup: a resumed run is judged on the PASS, not on the run', () => {
+  it('does not call a resumed run truncated for scanning only the remainder', async () => {
+    // A run that picked up at a stored cursor scans what is LEFT. Reading coverage
+    // off its own `idsScanned` files every such run as a 3%-coverage failure —
+    // which would make the resume mechanism look like a regression in the very log
+    // line built to detect truncation, and train people to ignore it.
+    // Pairwise-distinct: 30000 / 950000 / 1000000 / 41 / 17 share no value.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'users',
+        idsScanned: 30000,
+        passCovered: 950000,
+        staleFound: 41,
+        deleted: 17,
+        totalInIndex: 1000000,
+        stoppedEarly: false,
+        resumedFrom: 8123456,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const payload = payloadFor('users');
+    expect(payload?.type).toBe('info');
+    expect(payload?.incomplete).toBe(false);
+    // `scanned` still reports THIS run; `covered` and `coverage` report the pass.
+    expect(payload?.scanned).toBe(30000);
+    expect(payload?.covered).toBe(950000);
+    expect(payload?.coverage).toBe(0.95);
+    expect(payload?.message).toBe(
+      'users: scanned 30000, stale 41, deleted 17, resumed from id 8123456'
+    );
+  });
+
+  it('still flags a pass whose CUMULATIVE coverage is implausibly low', async () => {
+    // The other side: resuming must not become a way to never be called truncated.
+    // Two runs into the pass and still at 15% of the index — the shape of the real
+    // incident — stays an error.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'users',
+        idsScanned: 900000,
+        passCovered: 1803688,
+        staleFound: 25,
+        deleted: 25,
+        totalInIndex: 11610246,
+        stoppedEarly: false,
+        resumedFrom: 903688,
+        cursorPersisted: 1903688,
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const payload = payloadFor('users');
+    expect(payload?.type).toBe('error');
+    expect(payload?.incomplete).toBe(true);
+    expect(payload?.message).toBe(
+      'users: scan reached the end of the index but covered only 1803688 of 11610246 document(s) — ' +
+        'scanned 900000, stale 25, deleted 25, resumed from id 903688, ' +
+        'cursor saved at id 1903688 for the next run'
+    );
+  });
+
+  it('says so when a stored cursor was discarded and the run silently restarted', async () => {
+    // A run that restarted from the bottom because the stored value could not be
+    // trusted is safe, but it is NOT the same event as a completed pass rolling
+    // over — and the two are indistinguishable in the scan itself.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'articles',
+        idsScanned: 640,
+        staleFound: 19,
+        deleted: 11,
+        totalInIndex: 700,
+        cursorDiscardReason: 'stale',
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    const payload = payloadFor('articles');
+    expect(payload?.cursorDiscardReason).toBe('stale');
+    expect(payload?.message).toBe(
+      'articles: scanned 640, stale 19, deleted 11, ' +
+        'stored cursor discarded (stale) — restarted from id 0'
+    );
+  });
+
+  it('stays quiet about the ordinary case of nothing being stored', async () => {
+    // `missing` is what every run after a completed pass reports. A line for it
+    // would appear nightly on every index and mean nothing.
+    cleanupAllIndexes.mockResolvedValue([
+      stats({
+        key: 'tools',
+        idsScanned: 55,
+        staleFound: 4,
+        deleted: 2,
+        totalInIndex: 55,
+        cursorDiscardReason: 'missing',
+      }),
+    ]);
+
+    await searchIndexCleanupJob.run({}).result;
+
+    expect(payloadFor('tools')?.message).toBe('tools: scanned 55, stale 4, deleted 2');
+    expect(payloadFor('tools')?.cursorDiscardReason).toBe('missing');
   });
 });
 

--- a/src/server/jobs/search-index-cleanup.ts
+++ b/src/server/jobs/search-index-cleanup.ts
@@ -1,5 +1,6 @@
 import { createJob } from './job';
 import { CLEANUP_INDEXES, cleanupAllIndexes } from '~/server/meilisearch/cleanup';
+import { assessPassCoverage } from '~/server/meilisearch/cleanup-coverage';
 import { logToAxiom } from '~/server/logging/client';
 
 // Page size REQUESTED per keyset scan. `cleanupIndex` clamps this down to each
@@ -17,25 +18,13 @@ import { logToAxiom } from '~/server/logging/client';
 const SCAN_BATCH = 10000;
 
 /**
- * How far `idsScanned` may fall short of the pre-scan document count before the
- * run is called incomplete on the counts alone.
- *
- * A shortfall is NORMAL: `totalInIndex` is a snapshot taken before a scan that
- * then runs for a long time, and a separate cleanup job issues delete-by-filter
- * against most of these indexes every five minutes, so documents legitimately
- * disappear from under the cursor. The authoritative truncation signal is
- * `stoppedEarly` — a fact about how the loop exited, immune to that drift —
- * and this band is only the backstop for "the loop claimed to finish but
- * covered implausibly little".
- *
- * The band is a judgement, not a measurement, and it is deliberately loose:
- * the real incident it has to catch was a 63% shortfall. Every run logs
- * `scanned`, `total` and `coverage`, so it can be re-derived from data rather
- * than re-guessed.
+ * 🔴 The coverage band that decides "incomplete" USED TO LIVE HERE, open-coded, while
+ * `cleanupIndex` carried a second copy with a different number to decide whether to keep
+ * its resume cursor. They disagreed, and a pass landing between the two thresholds was
+ * reported truncated at error level while its resume point was discarded in the same run.
+ * Both now call `assessPassCoverage`, which owns the constants — do not reintroduce a
+ * local threshold here.
  */
-const COVERAGE_SHORTFALL_RATIO = 0.25;
-const COVERAGE_SHORTFALL_FLOOR = 1000;
-
 export const searchIndexCleanupJob = createJob(
   'search-index-cleanup',
   '0 2 * * *',
@@ -91,18 +80,12 @@ export const searchIndexCleanupJob = createJob(
       // exists to make trustworthy. `passCovered` carries the ids earlier runs of the
       // same pass already walked past.
       const covered = r.passCovered;
-      const coverage = r.totalInIndex && r.totalInIndex > 0 ? covered / r.totalInIndex : null;
-      const shortfall = r.totalInIndex === null ? null : r.totalInIndex - covered;
-      const lowCoverage =
-        !r.stoppedEarly &&
-        shortfall !== null &&
-        // A count taken while the engine was mid-ingest is a moving number, so
-        // a shortfall against it is not evidence of anything.
-        r.indexingAtStart !== true &&
-        shortfall > COVERAGE_SHORTFALL_FLOOR &&
-        shortfall > (r.totalInIndex as number) * COVERAGE_SHORTFALL_RATIO;
+      // 🔴 The SAME call `cleanupIndex` makes to decide whether to clear the cursor.
+      // `incomplete` and "the cursor was discarded" are now the one boolean, negated —
+      // that identity is the fix, and it is asserted directly in the tests.
+      const { reachedEnd, lowCoverage, coverage } = assessPassCoverage(r);
 
-      const incomplete = r.stoppedEarly || lowCoverage;
+      const incomplete = !reachedEnd;
       // `errors > 0` escalates on its own. The case that forces this: an index
       // the engine cannot serve at all fails BOTH `getStats` and `getSettings`,
       // so `totalInIndex` stays null and no coverage comparison is possible —
@@ -137,6 +120,9 @@ export const searchIndexCleanupJob = createJob(
       if (r.resumedFrom !== null) cursorNotes.push(`resumed from id ${r.resumedFrom}`);
       if (r.cursorPersisted !== null)
         cursorNotes.push(`cursor saved at id ${r.cursorPersisted} for the next run`);
+      // Stated, not inferred. A discarded cursor and a failed write both leave
+      // `cursorPersisted: null`, and they are opposite events.
+      if (r.cursorCleared) cursorNotes.push('cursor cleared — the next run starts over');
       // A discarded cursor means the run silently restarted from the bottom. `missing`
       // is the normal aftermath of a completed pass and is not worth a line.
       if (r.cursorDiscardReason !== null && r.cursorDiscardReason !== 'missing')
@@ -158,6 +144,7 @@ export const searchIndexCleanupJob = createJob(
         covered,
         resumedFrom: r.resumedFrom,
         cursorPersisted: r.cursorPersisted,
+        cursorCleared: r.cursorCleared,
         cursorDiscardReason: r.cursorDiscardReason,
         emptyPageRetries: r.emptyPageRetries,
         stale: r.staleFound,

--- a/src/server/jobs/search-index-cleanup.ts
+++ b/src/server/jobs/search-index-cleanup.ts
@@ -43,6 +43,12 @@ export const searchIndexCleanupJob = createJob(
     const results = await cleanupAllIndexes(null, {
       apply: true,
       batch: SCAN_BATCH,
+      // 🔴 The cron is the ONLY caller that owns the shared cursor. A pass that cannot
+      // walk an index inside one run resumes here next run instead of restarting at the
+      // bottom and re-walking the same clean prefix forever. Dry runs and the one-off
+      // script leave it alone, so an ad-hoc invocation cannot move the nightly job's
+      // position.
+      resumable: true,
       jobContext,
       onError: ({ key, offset, error }) => {
         // `offset === -1` is the sentinel for preflight or delete-phase
@@ -77,8 +83,16 @@ export const searchIndexCleanupJob = createJob(
       //    lookup failed. The cursor advanced past them, so this can be
       //    non-zero on a scan that DID reach the end.
       //  - lowCoverage: the loop finished, but covered implausibly little.
-      const coverage = r.totalInIndex && r.totalInIndex > 0 ? r.idsScanned / r.totalInIndex : null;
-      const shortfall = r.totalInIndex === null ? null : r.totalInIndex - r.idsScanned;
+      //
+      // 🔴 Coverage is measured over the PASS, not the run. A run that resumed from a
+      // stored cursor scans only the remainder of the index, so its own `idsScanned` is
+      // legitimately a fraction of `totalInIndex` — reading coverage off it would file
+      // every resumed run as truncated, which is precisely the signal this reporting
+      // exists to make trustworthy. `passCovered` carries the ids earlier runs of the
+      // same pass already walked past.
+      const covered = r.passCovered;
+      const coverage = r.totalInIndex && r.totalInIndex > 0 ? covered / r.totalInIndex : null;
+      const shortfall = r.totalInIndex === null ? null : r.totalInIndex - covered;
       const lowCoverage =
         !r.stoppedEarly &&
         shortfall !== null &&
@@ -106,7 +120,7 @@ export const searchIndexCleanupJob = createJob(
         );
       } else if (lowCoverage) {
         problems.push(
-          `scan reached the end of the index but covered only ${r.idsScanned} of ` +
+          `scan reached the end of the index but covered only ${covered} of ` +
             `${r.totalInIndex} document(s)`
         );
       }
@@ -115,17 +129,37 @@ export const searchIndexCleanupJob = createJob(
       }
       if (r.errors > 0) problems.push(`${r.errors} error(s)`);
 
+      // Where this run started and where it left the cursor. Without them a resumed
+      // run and a from-the-bottom run produce identical-looking lines, and the defect
+      // this whole mechanism fixes — a cursor that never moves between nights — is
+      // only visible by comparing them across runs.
+      const cursorNotes: string[] = [];
+      if (r.resumedFrom !== null) cursorNotes.push(`resumed from id ${r.resumedFrom}`);
+      if (r.cursorPersisted !== null)
+        cursorNotes.push(`cursor saved at id ${r.cursorPersisted} for the next run`);
+      // A discarded cursor means the run silently restarted from the bottom. `missing`
+      // is the normal aftermath of a completed pass and is not worth a line.
+      if (r.cursorDiscardReason !== null && r.cursorDiscardReason !== 'missing')
+        cursorNotes.push(
+          `stored cursor discarded (${r.cursorDiscardReason}) — restarted from id 0`
+        );
+
+      const tail =
+        `scanned ${r.idsScanned}, stale ${r.staleFound}, deleted ${r.deleted}` +
+        (cursorNotes.length > 0 ? `, ${cursorNotes.join(', ')}` : '');
+
       logToAxiom({
         type: level,
         name: 'search-index-cleanup',
         message:
-          problems.length > 0
-            ? `${r.key}: ${problems.join('; ')} — scanned ${r.idsScanned}, stale ${
-                r.staleFound
-              }, deleted ${r.deleted}`
-            : `${r.key}: scanned ${r.idsScanned}, stale ${r.staleFound}, deleted ${r.deleted}`,
+          problems.length > 0 ? `${r.key}: ${problems.join('; ')} — ${tail}` : `${r.key}: ${tail}`,
         key: r.key,
         scanned: r.idsScanned,
+        covered,
+        resumedFrom: r.resumedFrom,
+        cursorPersisted: r.cursorPersisted,
+        cursorDiscardReason: r.cursorDiscardReason,
+        emptyPageRetries: r.emptyPageRetries,
         stale: r.staleFound,
         deleted: r.deleted,
         errors: r.errors,

--- a/src/server/meilisearch/__tests__/cleanup.test.ts
+++ b/src/server/meilisearch/__tests__/cleanup.test.ts
@@ -51,8 +51,19 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
 import { REDIS_SYS_KEYS } from '~/server/redis/client';
 
-import { CLEANUP_INDEXES, cleanupIndex } from '~/server/meilisearch/cleanup';
+import {
+  CLEANUP_INDEXES,
+  cleanupIndex,
+  EMPTY_PAGE_BACKOFF_BUDGET_MS,
+  EMPTY_PAGE_BACKOFF_MS,
+  EMPTY_PAGE_CONFIRM_DELAY_MS,
+  EMPTY_PAGE_TRUST_COVERAGE,
+} from '~/server/meilisearch/cleanup';
 import { MAX_CURSOR_AGE_MS, readScanCursor } from '~/server/meilisearch/cleanup-cursor';
+
+/** ids 1..n, dense — the fixtures below need indexes big enough to clear the absolute
+ *  shortfall floor, which no toy fixture can. */
+const idsUpTo = (n: number) => Array.from({ length: n }, (_, i) => i + 1);
 
 // The two eligibility lookups the code makes, and they are DIFFERENT questions:
 //   dbRead  — the cheap filter run over every scanned page.
@@ -681,10 +692,9 @@ describe('cleanupIndex: a truncated pass RESUMES rather than restarting', () => 
     // new mechanism — every truncated pass would clear and restart at the bottom,
     // and cumulative progress would still be zero, now with a cursor bolted on.
     //
-    // 24 documents reported by the engine; the scan is fed one page then nothing.
+    // 8000 documents; the scan is fed one page of 300 and then nothing.
     const fake = makeFakeIndex({
-      docs: [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24],
-      totalOverride: 24,
+      docs: idsUpTo(8000),
       emptyOnCalls: [2, 3, 4, 5, 6, 7],
     });
     setFakeIndex(fake);
@@ -692,7 +702,7 @@ describe('cleanupIndex: a truncated pass RESUMES rather than restarting', () => 
 
     const stats = await cleanupIndex(modelsCfg, {
       apply: false,
-      batch: 3,
+      batch: 300,
       resumable: true,
       delay: rec.delay,
     });
@@ -700,10 +710,11 @@ describe('cleanupIndex: a truncated pass RESUMES rather than restarting', () => 
     // The loop DID exit through its terminator — that is not in dispute and the
     // reporting is unchanged.
     expect(stats.stoppedEarly).toBe(false);
-    // But 3 of 24 is not a pass that reached the end, so the cursor is kept.
-    expect(stats.passCovered).toBe(3);
-    expect(stats.cursorPersisted).toBe(6);
-    expect(storedCursor('models')).toMatchObject({ lastId: 6, covered: 3 });
+    // But 300 of 8000 is not a pass that reached the end, so the cursor is kept.
+    expect(stats.passCovered).toBe(300);
+    expect(stats.cursorPersisted).toBe(300);
+    expect(stats.cursorCleared).toBe(false);
+    expect(storedCursor('models')).toMatchObject({ lastId: 300, covered: 300 });
   });
 
   it('persists where it got to when the scan STOPS EARLY', async () => {
@@ -775,40 +786,41 @@ describe('cleanupIndex: a truncated pass RESUMES rather than restarting', () => 
     // on its own. Asserted on the UNION of the ids the engine actually served, not
     // on per-run counts: a run that re-walked the same prefix produces identical
     // counts and a very different union.
-    const docs = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24];
+    const docs = idsUpTo(8000);
     const rec = makeDelayRecorder();
 
     // Run 1: one page, then the engine answers empty for the whole confirmation
-    // schedule. 3 of 12 covered, so the pass is not credited and the cursor is kept.
+    // schedule. 300 of 8000 covered, so the pass is not credited and the cursor is kept.
     const runOne = makeFakeIndex({ docs, emptyOnCalls: [2, 3, 4, 5, 6, 7] });
     setFakeIndex(runOne);
     const one = await cleanupIndex(modelsCfg, {
       apply: false,
-      batch: 3,
+      batch: 300,
       resumable: true,
       delay: rec.delay,
     });
 
-    expect(one.idsScanned).toBe(3);
-    expect(one.cursorPersisted).toBe(6);
+    expect(one.idsScanned).toBe(300);
+    expect(one.cursorPersisted).toBe(300);
 
-    // Run 2: same index, engine healthy. It must pick up at 6, not at the bottom.
+    // Run 2: same index, engine healthy. It must pick up at 300, not at the bottom.
     const runTwo = makeFakeIndex({ docs });
     setFakeIndex(runTwo);
     const two = await cleanupIndex(modelsCfg, {
       apply: false,
-      batch: 3,
+      batch: 300,
       resumable: true,
       delay: rec.delay,
     });
 
-    expect(two.resumedFrom).toBe(6);
-    expect(runTwo.searchCalls[0].filter).toBe('id > 6');
-    expect(two.idsScanned).toBe(9);
-    // The pass total carries run 1's 3 forward, which is what lets run 2 be judged
-    // complete despite scanning only nine of the twelve documents itself.
-    expect(two.passCovered).toBe(12);
+    expect(two.resumedFrom).toBe(300);
+    expect(runTwo.searchCalls[0].filter).toBe('id > 300');
+    expect(two.idsScanned).toBe(7700);
+    // The pass total carries run 1's 300 forward, which is what lets run 2 be judged
+    // complete despite scanning only 7700 of the 8000 documents itself.
+    expect(two.passCovered).toBe(8000);
     expect(two.cursorPersisted).toBe(null);
+    expect(two.cursorCleared).toBe(true);
     expect(storedCursor('models')).toBeUndefined();
 
     const servedOne = runOne.served.flat();
@@ -817,6 +829,118 @@ describe('cleanupIndex: a truncated pass RESUMES rather than restarting', () => 
     expect([...servedOne, ...servedTwo].sort((a, b) => a - b)).toEqual(docs);
     // Stated separately and positively: run 2 re-walked nothing run 1 had covered.
     for (const id of servedOne) expect(servedTwo).not.toContain(id);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 🔴 ONE definition of "the pass reached the end"
+//
+// This shipped with TWO. `cleanupIndex` cleared its cursor at >= 50% coverage;
+// the job logged `incomplete: true` below 75%. A pass landing in [0.50, 0.75)
+// therefore reported itself truncated at error level AND discarded its resume
+// point in the same run — the next run restarted at the bottom, which is the
+// defect the cursor exists to fix, intact above 50%.
+//
+// COVERAGE_BAND below is written as literal fixture values, never read off the
+// implementation, and the SAME table drives the job's `incomplete` verdict in
+// search-index-cleanup.test.ts. If the two consumers ever disagree again, one
+// of the two tables goes red.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const COVERAGE_BAND: { total: number; covered: number; reachedEnd: boolean }[] = [
+  // total, pass coverage, and whether that counts as having reached the end.
+  { total: 8000, covered: 2000, reachedEnd: false }, // 0.250 — both clauses flag
+  { total: 8000, covered: 4000, reachedEnd: false }, // 0.500 — the old cursor threshold
+  { total: 8000, covered: 4800, reachedEnd: false }, // 0.600 — INSIDE the old gap
+  { total: 8000, covered: 6800, reachedEnd: true }, //  0.850 — only the RATIO clause spares it
+  { total: 2000, covered: 1200, reachedEnd: true }, //  0.600 — only the FLOOR clause spares it
+  { total: 8000, covered: 7900, reachedEnd: true }, //  0.9875 — comfortably finished
+];
+
+describe('cleanupIndex: keeping the cursor and reporting incomplete are ONE decision', () => {
+  for (const { total, covered, reachedEnd } of COVERAGE_BAND) {
+    it(`covered ${covered} of ${total} → ${
+      reachedEnd ? 'clears' : 'KEEPS'
+    } the cursor`, async () => {
+      // One page of `covered` ids, then the engine answers empty for the whole
+      // confirmation schedule — a truncated pass that exits through the terminator,
+      // which is the only case where coverage decides anything.
+      const fake = makeFakeIndex({
+        docs: idsUpTo(total),
+        emptyOnCalls: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+      });
+      setFakeIndex(fake);
+      const rec = makeDelayRecorder();
+
+      const stats = await cleanupIndex(modelsCfg, {
+        apply: false,
+        batch: covered,
+        resumable: true,
+        delay: rec.delay,
+      });
+
+      expect(stats.passCovered).toBe(covered);
+      expect(stats.stoppedEarly).toBe(false);
+      expect(stats.cursorCleared).toBe(reachedEnd);
+      expect(stats.cursorPersisted).toBe(reachedEnd ? null : covered);
+      expect(storedCursor('models')).toEqual(
+        reachedEnd ? undefined : expect.objectContaining({ lastId: covered, covered })
+      );
+    });
+  }
+
+  it('credits a pass the engine was mid-ingest for, however little it covered', async () => {
+    // The suppression clause inside the shared predicate: a document count taken
+    // while the engine was ingesting is a moving number, so a shortfall against it is
+    // not evidence of anything. No resumable fixture exercised this, so deleting the
+    // clause changed nothing observable.
+    const fake = makeFakeIndex({
+      docs: idsUpTo(8000),
+      isIndexing: true,
+      emptyOnCalls: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+    });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 300,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    // 300 of 8000 would otherwise KEEP the cursor — see the table above.
+    expect(stats.passCovered).toBe(300);
+    expect(stats.indexingAtStart).toBe(true);
+    expect(stats.cursorCleared).toBe(true);
+    expect(storedCursor('models')).toBeUndefined();
+  });
+});
+
+describe('cleanupIndex: a cursor the scan could not advance past is DISCARDED', () => {
+  it('clears rather than persists when the monotonicity guard fires', async () => {
+    // 🔴 Persisting it wedges the whole index: every later run resumes at the same
+    // cursor, trips the same guard on its first page, and examines ZERO documents —
+    // for as long as the staleness bound allows. Before the cursor existed, everything
+    // below the bad page was still cleaned nightly. Clearing restores exactly that.
+    seedCursor('models', { lastId: 5, startedAt: Date.now() - 60_000, covered: 5 });
+    const fake = makeFakeIndex({ docs: [7], frozenPage: [7] });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 5,
+      maxBatches: 50,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(stats.stoppedEarly).toBe(true);
+    expect(stats.errors).toBe(1);
+    expect(stats.cursorPersisted).toBe(null);
+    expect(stats.cursorCleared).toBe(true);
+    expect(storedCursor('models')).toBeUndefined();
   });
 });
 
@@ -887,6 +1011,29 @@ describe('cleanupIndex: a stored cursor cannot be carried indefinitely', () => {
     expect(stats.idsScanned).toBe(10);
   });
 
+  it('accepts a cursor that covered exactly as many ids as exist below it', async () => {
+    // The upper bound on `covered` is `lastId + 1`, because ids are non-negative and
+    // strictly increasing, so a pass standing at id 6 may have walked past ids 0..6 —
+    // seven of them. Sitting a fixture ON that boundary is what separates the correct
+    // bound from `covered > lastId`, which rejects a legal cursor and silently restarts
+    // the pass from the bottom every night.
+    seedCursor('models', { lastId: 6, startedAt: Date.now() - 60_000, covered: 7 });
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], totalOverride: 8 });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 10,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(stats.resumedFrom).toBe(6);
+    expect(stats.cursorDiscardReason).toBe(null);
+    expect(fake.searchCalls[0].filter).toBe('id > 6');
+  });
+
   it('treats a FUTURE-dated cursor as stale rather than as one that can never expire', async () => {
     // Clock skew (or a hand-edited value) makes the age negative, which passes an
     // upper-bound test forever — the one way the bound could be defeated silently.
@@ -913,6 +1060,17 @@ describe('cleanupIndex: an unusable stored cursor fails SAFE', () => {
     ['carries a non-numeric lastId', '{"lastId":"6","startedAt":1,"covered":5}', 'invalid'],
     ['carries a NaN startedAt', '{"lastId":6,"startedAt":null,"covered":5}', 'invalid'],
     ['carries a negative lastId', '{"lastId":-3,"startedAt":1,"covered":5}', 'invalid'],
+    // `covered` is the sole input to BOTH coverage judgements — whether an empty page
+    // is believed, and whether the pass is credited — so an absurd value silently
+    // credits a pass that covered nothing. None of these were checked at first.
+    ['is missing covered', '{"lastId":6,"startedAt":1}', 'invalid'],
+    ['carries a non-numeric covered', '{"lastId":6,"startedAt":1,"covered":"5"}', 'invalid'],
+    ['carries a negative covered', '{"lastId":6,"startedAt":1,"covered":-5}', 'invalid'],
+    [
+      'claims to have covered more ids than exist below the cursor',
+      '{"lastId":6,"startedAt":1,"covered":9999}',
+      'invalid',
+    ],
   ];
 
   for (const [label, raw, reason] of unusable) {
@@ -956,27 +1114,67 @@ describe('cleanupIndex: an unusable stored cursor fails SAFE', () => {
     expect(stats.idsScanned).toBe(10);
   });
 
-  it('completes the scan even when the cursor cannot be written back', async () => {
+  it('completes the scan and RAISES AN ERROR when the cursor cannot be written back', async () => {
+    // The truncated pass loses its position, so the next run restarts at the bottom —
+    // defect B, for this index, tonight. Silent, that is indistinguishable from a
+    // healthy rollover, because both leave `cursorPersisted: null`.
     redisMock.sysRedis.hSet.mockRejectedValue(new Error('sysRedis unavailable'));
     const fake = makeFakeIndex({
-      docs: [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24],
+      docs: idsUpTo(8000),
       emptyOnCalls: [2, 3, 4, 5, 6, 7],
     });
     setFakeIndex(fake);
     const rec = makeDelayRecorder();
+    const errors: string[] = [];
 
     const stats = await cleanupIndex(modelsCfg, {
       apply: false,
-      batch: 3,
+      batch: 300,
       resumable: true,
       delay: rec.delay,
+      onError: ({ error }) => errors.push(error.message),
     });
 
-    // The scan's own results are intact; only the hand-off to the next run is lost,
-    // and it says so rather than claiming a cursor was saved.
-    expect(stats.idsScanned).toBe(3);
-    expect(stats.staleFound).toBe(3);
+    // The scan's own results are intact; only the hand-off to the next run is lost.
+    expect(stats.idsScanned).toBe(300);
+    expect(stats.staleFound).toBe(300);
     expect(stats.cursorPersisted).toBe(null);
+    expect(stats.cursorCleared).toBe(false);
+    expect(stats.errors).toBe(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('could not PERSIST the scan cursor');
+    expect(errors[0]).toContain('restart from the beginning');
+  });
+
+  it('RAISES AN ERROR when a completed pass cannot CLEAR its cursor', async () => {
+    // 🔴 The worst silent failure available here. Reads succeed and writes are rejected
+    // (redis at maxmemory, or a read-only replica): the completed pass fails to clear,
+    // the next run resumes at the TOP of the index, scans nothing, carries the old
+    // `covered` forward so the counts still look complete — and files
+    // `info … scanned 0, stale 0, deleted 0` nightly until the staleness bound expires
+    // the cursor. An index getting zero cleanup while reporting healthy is precisely
+    // what this job's reporting exists to prevent.
+    seedCursor('models', { lastId: 4, startedAt: Date.now() - 60_000, covered: 4 });
+    redisMock.sysRedis.hDel.mockRejectedValue(new Error('sysRedis unavailable'));
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8] });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+    const errors: string[] = [];
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 8,
+      resumable: true,
+      delay: rec.delay,
+      onError: ({ error }) => errors.push(error.message),
+    });
+
+    expect(stats.idsScanned).toBe(4);
+    expect(stats.cursorCleared).toBe(false);
+    expect(stats.errors).toBe(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('could not CLEAR the scan cursor');
+    expect(errors[0]).toContain('may scan nothing');
   });
 
   it('INVARIANT GUARD (green on unfixed code): a scan without `resumable` never touches the store', async () => {
@@ -1042,7 +1240,7 @@ describe('cleanupIndex: an empty page is re-asked harder when coverage says it c
     // The job holds a 2 h lock; the confirmation must not become an unbounded
     // retry loop inside it. Five attempts, 30 s of waiting for one empty page.
     const fake = makeFakeIndex({
-      docs: [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24],
+      docs: idsUpTo(8000),
       emptyOnCalls: [2, 3, 4, 5, 6, 7, 8, 9, 10],
     });
     setFakeIndex(fake);
@@ -1050,7 +1248,7 @@ describe('cleanupIndex: an empty page is re-asked harder when coverage says it c
 
     const stats = await cleanupIndex(modelsCfg, {
       apply: false,
-      batch: 3,
+      batch: 300,
       resumable: true,
       delay: rec.delay,
     });
@@ -1060,7 +1258,107 @@ describe('cleanupIndex: an empty page is re-asked harder when coverage says it c
     expect(stats.emptyPageRetries).toBe(5);
     // Six searches after page 1: the empty one, then five confirmations.
     expect(fake.searchCalls.length).toBe(7);
-    expect(stats.cursorPersisted).toBe(6);
+    expect(stats.cursorPersisted).toBe(300);
+  });
+
+  it('stops escalating once the backoff BUDGET is spent', async () => {
+    // 🔴 The budget is charged for EVERY delay, the first included. It used to exempt
+    // the first, which meant it bounded nothing about how many empty pages could be
+    // confirmed — the "~5 minutes per index" the comment promised was not what ran.
+    //
+    // The shipped budget is 5 minutes and no fixture of a runnable size reaches it, so
+    // the clamp would ship having never once executed. Injected here at 7 s, which the
+    // real schedule crosses on its fourth step: 1000 + 2000 + 4000 = 7000, and the next
+    // 8000 does not fit.
+    const fake = makeFakeIndex({
+      docs: idsUpTo(8000),
+      emptyOnCalls: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+    });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 300,
+      resumable: true,
+      delay: rec.delay,
+      emptyPageBackoffBudgetMs: 7000,
+    });
+
+    expect(rec.delays).toEqual([1000, 2000, 4000]);
+    expect(stats.emptyPageRetries).toBe(3);
+    expect(stats.cursorPersisted).toBe(300);
+  });
+
+  it('still confirms ONCE, cheaply, when the budget is gone before any escalation', async () => {
+    // Believing an empty page on sight is the original defect, so an exhausted budget
+    // must degrade to the pre-existing single confirmation — not to none, and not to
+    // the 1000 ms first escalation step, which is what a naive `break` would leave.
+    const fake = makeFakeIndex({
+      docs: idsUpTo(8000),
+      emptyOnCalls: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+    });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 300,
+      resumable: true,
+      delay: rec.delay,
+      emptyPageBackoffBudgetMs: 100,
+    });
+
+    expect(rec.delays).toEqual([500]);
+    expect(stats.emptyPageRetries).toBe(1);
+    // The page was still re-asked: two searches after page 1 would mean none.
+    expect(fake.searchCalls.length).toBe(3);
+  });
+
+  it('escalates at a coverage INSIDE the trust band, and does not just above it', async () => {
+    // Narrows the surviving range for EMPTY_PAGE_TRUST_COVERAGE from both sides. Without
+    // these the fixtures sat at 0.25 and >= 1.0, so any value in (0.25, 1.0] — including
+    // 0.5 — produced identical output on every test in the file.
+    const escalating = makeFakeIndex({
+      docs: idsUpTo(8000),
+      emptyOnCalls: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+    });
+    setFakeIndex(escalating);
+    const recEsc = makeDelayRecorder();
+    // 4800 of 8000 = 0.60, below the 0.90 trust threshold.
+    await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 4800,
+      resumable: true,
+      delay: recEsc.delay,
+    });
+    expect(recEsc.delays).toEqual([1000, 2000, 4000, 8000, 15000]);
+
+    const trusted = makeFakeIndex({
+      docs: idsUpTo(8000),
+      emptyOnCalls: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+    });
+    setFakeIndex(trusted);
+    const recTrust = makeDelayRecorder();
+    // 7600 of 8000 = 0.95, above it.
+    await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 7600,
+      resumable: true,
+      delay: recTrust.delay,
+    });
+    expect(recTrust.delays).toEqual([500]);
+  });
+
+  it('pins the empty-page constants by value', async () => {
+    // Every test above reads the SCHEDULE through behaviour, which is what makes them
+    // independent of the numbers — and therefore blind to the numbers changing. Same
+    // lesson as the staleness bound: the band fixtures narrow the survivable range, the
+    // value pin closes it.
+    expect(EMPTY_PAGE_CONFIRM_DELAY_MS).toBe(500);
+    expect(EMPTY_PAGE_BACKOFF_MS).toEqual([1000, 2000, 4000, 8000, 15000]);
+    expect(EMPTY_PAGE_TRUST_COVERAGE).toBe(0.9);
+    expect(EMPTY_PAGE_BACKOFF_BUDGET_MS).toBe(5 * 60 * 1000);
   });
 
   it('INVARIANT GUARD (green on unfixed code): a genuinely exhausted index still ends on one cheap confirm', async () => {
@@ -1083,6 +1381,31 @@ describe('cleanupIndex: an empty page is re-asked harder when coverage says it c
     expect(stats.emptyPageRetries).toBe(1);
     expect(fake.searchCalls.map((c) => c.filter)).toEqual(['id > -1', 'id > 10', 'id > 10']);
     expect(stats.stoppedEarly).toBe(false);
+  });
+
+  it('handles an index the engine reports as EMPTY without inventing a coverage', async () => {
+    // A total of ZERO is a real state (a freshly created index) and it is the one input
+    // that makes the coverage division degenerate: guarding on `total !== null` alone
+    // computes 0/0 and yields NaN, which then flows into the logged `coverage` field
+    // and compares false against every threshold without ever erroring.
+    const fake = makeFakeIndex({ docs: [], totalOverride: 0 });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 10,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(stats.totalInIndex).toBe(0);
+    expect(stats.idsScanned).toBe(0);
+    expect(stats.passCovered).toBe(0);
+    expect(stats.stoppedEarly).toBe(false);
+    // An empty index is a finished pass, not a truncated one.
+    expect(stats.cursorCleared).toBe(true);
+    expect(rec.delays).toEqual([500]);
   });
 
   it('still confirms once when the index total is unknown', async () => {

--- a/src/server/meilisearch/__tests__/cleanup.test.ts
+++ b/src/server/meilisearch/__tests__/cleanup.test.ts
@@ -60,6 +60,10 @@ import {
   EMPTY_PAGE_TRUST_COVERAGE,
 } from '~/server/meilisearch/cleanup';
 import { MAX_CURSOR_AGE_MS, readScanCursor } from '~/server/meilisearch/cleanup-cursor';
+import {
+  COVERAGE_SHORTFALL_FLOOR,
+  COVERAGE_SHORTFALL_RATIO,
+} from '~/server/meilisearch/cleanup-coverage';
 
 /** ids 1..n, dense — the fixtures below need indexes big enough to clear the absolute
  *  shortfall floor, which no toy fixture can. */
@@ -858,10 +862,29 @@ const COVERAGE_BAND: { total: number; covered: number; reachedEnd: boolean }[] =
 ];
 
 describe('cleanupIndex: keeping the cursor and reporting incomplete are ONE decision', () => {
+  it('pins the coverage band constants by value', async () => {
+    // 🔴 Same lesson as the staleness bound and the empty-page constants, and it applies
+    // here HARDER: consolidating the predicate promoted these two from deciding a log
+    // line to deciding, alone, whether a truncated pass keeps its resume cursor.
+    //
+    // The six-row table below reads them purely through behaviour, which is what makes
+    // it independent of the numbers — and therefore blind to the numbers moving. Its
+    // rows only bracket the ratio to roughly [0.15, 0.4) and the floor to [800, 3000];
+    // measured, 0.15 / 0.39 / 800 / 3000 all survive it. The table narrows the
+    // survivable range, the value pin closes it.
+    expect(COVERAGE_SHORTFALL_RATIO).toBe(0.25);
+    expect(COVERAGE_SHORTFALL_FLOOR).toBe(1000);
+  });
+
   for (const { total, covered, reachedEnd } of COVERAGE_BAND) {
     it(`covered ${covered} of ${total} → ${
       reachedEnd ? 'clears' : 'KEEPS'
     } the cursor`, async () => {
+      // A cursor at id 0 with nothing covered, so the "clears" rows have something
+      // real to clear and `cursorCleared` is a fact rather than a formality. It is
+      // equivalent to starting from the bottom: the filter becomes `id > 0`, and ids
+      // here are 1..total.
+      seedCursor('models', { lastId: 0, startedAt: Date.now() - 60_000, covered: 0 });
       // One page of `covered` ids, then the engine answers empty for the whole
       // confirmation schedule — a truncated pass that exits through the terminator,
       // which is the only case where coverage decides anything.
@@ -894,6 +917,7 @@ describe('cleanupIndex: keeping the cursor and reporting incomplete are ONE deci
     // while the engine was ingesting is a moving number, so a shortfall against it is
     // not evidence of anything. No resumable fixture exercised this, so deleting the
     // clause changed nothing observable.
+    seedCursor('models', { lastId: 0, startedAt: Date.now() - 60_000, covered: 0 });
     const fake = makeFakeIndex({
       docs: idsUpTo(8000),
       isIndexing: true,
@@ -918,11 +942,69 @@ describe('cleanupIndex: keeping the cursor and reporting incomplete are ONE deci
 });
 
 describe('cleanupIndex: a cursor the scan could not advance past is DISCARDED', () => {
-  it('clears rather than persists when the monotonicity guard fires', async () => {
-    // 🔴 Persisting it wedges the whole index: every later run resumes at the same
-    // cursor, trips the same guard on its first page, and examines ZERO documents —
-    // for as long as the staleness bound allows. Before the cursor existed, everything
-    // below the bad page was still cleaned nightly. Clearing restores exactly that.
+  it('clears when the guard fires on the FIRST page of a resumed run', async () => {
+    // 🔴 The wedge. `frozenPage` answers [7] whatever the filter, and the stored cursor
+    // is already 7 — so the very first page of the resumed run cannot advance. Persist
+    // that and every later run reproduces the identical abort and examines ZERO
+    // documents, for as long as the staleness bound allows. Before the cursor existed,
+    // everything below the bad page was still cleaned nightly; clearing restores that.
+    seedCursor('models', { lastId: 7, startedAt: Date.now() - 60_000, covered: 7 });
+    const fake = makeFakeIndex({ docs: [7], frozenPage: [7] });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 5,
+      maxBatches: 50,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(stats.resumedFrom).toBe(7);
+    // Nothing was examined: the guard fired before the first page was judged.
+    expect(stats.idsScanned).toBe(0);
+    expect(stats.stoppedEarly).toBe(true);
+    expect(stats.errors).toBe(1);
+    expect(stats.cursorPersisted).toBe(null);
+    expect(stats.cursorCleared).toBe(true);
+    expect(storedCursor('models')).toBeUndefined();
+  });
+
+  it('does not claim a COMPLETED pass when the wedge clear fails', async () => {
+    // A comment or a message is a claim like any other. This error also fires on the
+    // wedge path, where the pass explicitly did not complete — saying "after a
+    // completed pass" there sends whoever reads it looking for the wrong thing.
+    seedCursor('models', { lastId: 7, startedAt: Date.now() - 60_000, covered: 7 });
+    redisMock.sysRedis.hDel.mockRejectedValue(new Error('sysRedis unavailable'));
+    const fake = makeFakeIndex({ docs: [7], frozenPage: [7] });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+    const errors: string[] = [];
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 5,
+      maxBatches: 50,
+      resumable: true,
+      delay: rec.delay,
+      onError: ({ error }) => errors.push(error.message),
+    });
+
+    expect(stats.cursorCleared).toBe(false);
+    const clearError = errors.find((m) => m.includes('could not CLEAR the scan cursor'));
+    expect(clearError).toBeDefined();
+    expect(clearError).toContain('after aborting on a cursor it could not advance past');
+    expect(clearError).not.toContain('after a completed pass');
+  });
+
+  it('KEEPS the cursor when the guard fires after the run made progress', async () => {
+    // 🔴 The other half, and the one a broad fix gets wrong. Same frozen page, but the
+    // stored cursor is 5, so page 1 DOES advance (5 -> 7) and is judged; the guard only
+    // fires on page 2. That run cleaned everything between 5 and 7 — discarding its
+    // cursor throws a whole night's progress away and restarts at the bottom, which is
+    // the exact cost this change exists to eliminate. There is no wedge here either:
+    // the next run resumes at 7, which is a DIFFERENT cursor from the one that aborted.
     seedCursor('models', { lastId: 5, startedAt: Date.now() - 60_000, covered: 5 });
     const fake = makeFakeIndex({ docs: [7], frozenPage: [7] });
     setFakeIndex(fake);
@@ -936,9 +1018,60 @@ describe('cleanupIndex: a cursor the scan could not advance past is DISCARDED', 
       delay: rec.delay,
     });
 
+    expect(stats.resumedFrom).toBe(5);
+    expect(stats.idsScanned).toBe(1);
     expect(stats.stoppedEarly).toBe(true);
     expect(stats.errors).toBe(1);
+    expect(stats.cursorCleared).toBe(false);
+    expect(stats.cursorPersisted).toBe(7);
+    expect(storedCursor('models')).toMatchObject({ lastId: 7 });
+  });
+});
+
+describe('cleanupIndex: `cursorCleared` means a cursor was actually discarded', () => {
+  it('does NOT claim a clear when there was nothing stored', async () => {
+    // 🔴 The common path: almost every run completes with nothing stored. Reporting
+    // those as "cursor cleared" put that note on every healthy nightly line for every
+    // index and drained the field of the meaning it was added for — the same noise
+    // deliberately suppressed for `cursorDiscardReason: 'missing'`, arriving from the
+    // other side.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8] });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 8,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(stats.cursorDiscardReason).toBe('missing');
+    expect(stats.cursorCleared).toBe(false);
     expect(stats.cursorPersisted).toBe(null);
+    expect(storedCursor('models')).toBeUndefined();
+    // 🔴 And it is NOT an error. "Nothing to clear" is genuinely a third outcome:
+    // folding it into `failed` would raise an error on every healthy nightly run of
+    // every index, which is the same noise as the false `cursorCleared`, arriving
+    // through the alarm instead of the log line.
+    expect(stats.errors).toBe(0);
+  });
+
+  it('DOES claim a clear when a stored cursor was discarded', async () => {
+    // The positive half. Without it, "never report a clear" would pass the case above.
+    seedCursor('models', { lastId: 4, startedAt: Date.now() - 60_000, covered: 4 });
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8] });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 8,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(stats.resumedFrom).toBe(4);
     expect(stats.cursorCleared).toBe(true);
     expect(storedCursor('models')).toBeUndefined();
   });
@@ -1403,8 +1536,12 @@ describe('cleanupIndex: an empty page is re-asked harder when coverage says it c
     expect(stats.idsScanned).toBe(0);
     expect(stats.passCovered).toBe(0);
     expect(stats.stoppedEarly).toBe(false);
-    // An empty index is a finished pass, not a truncated one.
-    expect(stats.cursorCleared).toBe(true);
+    // An empty index is a finished pass, not a truncated one — nothing is carried
+    // forward. Nothing was stored either, so nothing was cleared: `cursorCleared`
+    // reports a discarded cursor, not the decision to discard one.
+    expect(stats.cursorCleared).toBe(false);
+    expect(stats.cursorPersisted).toBe(null);
+    expect(storedCursor('models')).toBeUndefined();
     expect(rec.delays).toEqual([500]);
   });
 

--- a/src/server/meilisearch/__tests__/cleanup.test.ts
+++ b/src/server/meilisearch/__tests__/cleanup.test.ts
@@ -47,8 +47,12 @@ import type * as MeiliClient from '~/server/meilisearch/client';
 // mock it itself — a per-file mock object freezes that file's shape for every
 // later file that shares the worker. See docs/testing/shared-module-mocks.md.
 import { dbMock } from '~/__tests__/mocks/db.mock';
+// `~/server/redis/client` is a CANONICAL shared-module mock too — same rule, same reason.
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { REDIS_SYS_KEYS } from '~/server/redis/client';
 
 import { CLEANUP_INDEXES, cleanupIndex } from '~/server/meilisearch/cleanup';
+import { MAX_CURSOR_AGE_MS, readScanCursor } from '~/server/meilisearch/cleanup-cursor';
 
 // The two eligibility lookups the code makes, and they are DIFFERENT questions:
 //   dbRead  — the cheap filter run over every scanned page.
@@ -89,8 +93,14 @@ function makeFakeIndex(opts: {
   frozenPage?: number[];
   isIndexing?: boolean;
   onSearch?: (call: number) => void;
+  /** Override the document count the engine reports, when it must differ from `docs`. */
+  totalOverride?: number;
 }) {
   const searchCalls: { filter: string; limit: number }[] = [];
+  // Every id the engine actually handed back, page by page. The cumulative-progress
+  // test asserts on the UNION of these across two runs — a per-run count cannot tell
+  // "run 2 covered nine documents" from "run 2 re-covered the same three, twice".
+  const served: number[][] = [];
   const deleted: number[][] = [];
   // How many searches had been issued at the moment each delete was made. This
   // is what distinguishes "deleted while scanning" from "deleted after the
@@ -101,7 +111,7 @@ function makeFakeIndex(opts: {
 
   const index = {
     getStats: async () => ({
-      numberOfDocuments: opts.docs.length,
+      numberOfDocuments: opts.totalOverride ?? opts.docs.length,
       isIndexing: opts.isIndexing ?? false,
     }),
     getSettings: async () => ({
@@ -115,8 +125,14 @@ function makeFakeIndex(opts: {
       calls += 1;
       searchCalls.push({ filter: params.filter, limit: params.limit });
       opts.onSearch?.(calls);
-      if (opts.frozenPage) return { hits: rows(opts.frozenPage) };
-      if (opts.emptyOnCalls?.includes(calls)) return { hits: [] as { id: number }[] };
+      if (opts.frozenPage) {
+        served.push([...opts.frozenPage]);
+        return { hits: rows(opts.frozenPage) };
+      }
+      if (opts.emptyOnCalls?.includes(calls)) {
+        served.push([]);
+        return { hits: [] as { id: number }[] };
+      }
       const match = /^id > (-?\d+)$/.exec(params.filter);
       if (!match) throw new Error(`unexpected filter: ${params.filter}`);
       const cursor = Number(match[1]);
@@ -125,7 +141,9 @@ function makeFakeIndex(opts: {
         opts.maxTotalHits ?? Number.POSITIVE_INFINITY,
         opts.pageCap ?? Number.POSITIVE_INFINITY
       );
-      return { hits: rows(opts.docs.filter((d) => d > cursor).slice(0, cap)) };
+      const hits = opts.docs.filter((d) => d > cursor).slice(0, cap);
+      served.push([...hits]);
+      return { hits: rows(hits) };
     },
     deleteDocuments: async (ids: number[]) => {
       deleted.push([...ids]);
@@ -134,7 +152,7 @@ function makeFakeIndex(opts: {
     },
   };
 
-  return { index, searchCalls, deleted, deletedAfterSearches };
+  return { index, searchCalls, deleted, deletedAfterSearches, served };
 }
 
 function setFakeIndex(fake: { index: unknown }) {
@@ -158,7 +176,63 @@ function makeJobContext() {
 const modelsCfg = CLEANUP_INDEXES.find((c) => c.key === 'models');
 if (!modelsCfg) throw new Error('models cleanup config missing');
 
+// ─── Cursor store ───────────────────────────────────────────────────────────
+
+/**
+ * A real in-memory hash behind the canonical `sysRedis` node, so the cursor tests run
+ * the PRODUCTION store module — its JSON encoding, its validation and its staleness
+ * bound — instead of a hand-written stand-in that could agree with a wrong
+ * implementation. The seam replaced is the redis command, which is the lowest one
+ * available; everything above it is the code under test.
+ */
+const cursorHash = new Map<string, string>();
+const CURSORS_KEY = REDIS_SYS_KEYS.SEARCH_INDEX_CLEANUP.CURSORS;
+
+function installCursorStore() {
+  cursorHash.clear();
+  // Call history pools across a whole file (the canonical mocks reset per FILE, not per
+  // test), so the "never touched the store" case would otherwise read every earlier
+  // test's calls as its own.
+  redisMock.sysRedis.hGet.mockClear();
+  redisMock.sysRedis.hSet.mockClear();
+  redisMock.sysRedis.hDel.mockClear();
+  redisMock.sysRedis.hGet.mockImplementation(async (key: string, field: string) =>
+    key === CURSORS_KEY ? cursorHash.get(field) ?? null : null
+  );
+  redisMock.sysRedis.hSet.mockImplementation(async (key: string, field: string, value: string) => {
+    if (key === CURSORS_KEY) cursorHash.set(field, String(value));
+    return 1;
+  });
+  redisMock.sysRedis.hDel.mockImplementation(async (key: string, field: string) => {
+    if (key !== CURSORS_KEY) return 0;
+    return cursorHash.delete(field) ? 1 : 0;
+  });
+}
+
+/** Write a stored cursor exactly as production would, without going through a scan. */
+function seedCursor(key: string, cursor: { lastId: number; startedAt: number; covered: number }) {
+  cursorHash.set(key, JSON.stringify(cursor));
+}
+
+function storedCursor(key: string) {
+  const raw = cursorHash.get(key);
+  return raw === undefined ? undefined : (JSON.parse(raw) as Record<string, number>);
+}
+
+/**
+ * Records the delays the scan ASKS for and resolves immediately.
+ *
+ * The escalation is the property under test and it is 30 s of real waiting — a suite
+ * that actually spent it could not run, and one that shrank the constants would be
+ * asserting against its own fixture rather than the shipped schedule.
+ */
+function makeDelayRecorder() {
+  const delays: number[] = [];
+  return { delays, delay: async (ms: number) => void delays.push(ms) };
+}
+
 beforeEach(() => {
+  installCursorStore();
   // MUTATE the canonical nodes, never replace them: consumer modules captured
   // these exact function identities when they were first evaluated and will not
   // re-read them. `mockClear` drops call history but keeps the implementation,
@@ -505,5 +579,535 @@ describe('cleanupIndex: deletions are flushed incrementally', () => {
     expect(batchesSeen).toBe(2);
     expect(fake.deleted).toEqual([[1, 2]]);
     expect(stats.deleted).toBe(2);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cross-run cursor persistence
+//
+// The defect: the scan always restarted at the bottom of the index. A pass that
+// cannot walk a multi-million-document index inside one nightly run therefore
+// re-walked the same already-clean prefix every night and could never reach the
+// region past its stopping point — measured in production, the boundary of the
+// un-scanned region did not move by a single id across two consecutive runs.
+//
+// 🔴 No page size fixes this. A from-scratch scan that cannot finish in one run
+// makes ZERO cumulative progress by construction, whatever the page size.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('cleanupIndex: a truncated pass RESUMES rather than restarting', () => {
+  it('starts the next page from the stored cursor, not from the bottom of the index', async () => {
+    // Stored: lastId 6, covered 5. Deliberately DIFFERENT numbers — an
+    // implementation that seeded the carried coverage from the cursor id (or vice
+    // versa) would be invisible if they matched. `covered` is legitimately lower
+    // than `lastId` here: ids are not dense, and documents are deleted from under
+    // the cursor while a pass runs.
+    seedCursor('models', { lastId: 6, startedAt: Date.now() - 60_000, covered: 5 });
+    // The engine reports 8 documents against ten real ones: `totalInIndex` is a
+    // pre-scan snapshot of an index other jobs delete from continuously, and one
+    // index has legitimately reported coverage slightly ABOVE 1 for that reason.
+    // Every number in this fixture is distinct from every other.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], totalOverride: 8 });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 3,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    // 🔴 The first request is `id > 6`, NOT `id > -1` (the un-fixed behaviour),
+    // `id > 7` (resume-past-the-cursor, which skips one document every run,
+    // permanently) or `id > 5` (resume-before-it, which re-walks one document).
+    expect(fake.searchCalls.map((c) => c.filter)).toEqual([
+      'id > 6',
+      'id > 9',
+      'id > 10',
+      'id > 10',
+    ]);
+    expect(stats.resumedFrom).toBe(6);
+    expect(stats.cursorDiscardReason).toBe(null);
+    // Four ids scanned this run (7,8,9,10); the pass has now covered 5 + 4 = 9.
+    // Every number here is distinct from every other, and from the index total.
+    expect(stats.idsScanned).toBe(4);
+    expect(stats.passCovered).toBe(9);
+    expect(stats.totalInIndex).toBe(8);
+    expect(stats.stoppedEarly).toBe(false);
+  });
+
+  it('RESETS the cursor when the pass genuinely reaches the end, so the next run starts over', async () => {
+    // Without the reset the cursor sits at the top of the index forever and the
+    // low-id region — where a document that was eligible when indexed and has
+    // since gone stale actually lives — is never re-examined again.
+    seedCursor('models', { lastId: 4, startedAt: Date.now() - 60_000, covered: 4 });
+    const first = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8] });
+    setFakeIndex(first);
+    const rec = makeDelayRecorder();
+
+    const one = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 8,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(one.resumedFrom).toBe(4);
+    expect(one.cursorPersisted).toBe(null);
+    expect(storedCursor('models')).toBeUndefined();
+
+    // Stated behaviourally, not just as an empty map: the very next run walks the
+    // whole index from the bottom again.
+    const second = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8] });
+    setFakeIndex(second);
+    const two = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 8,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(two.resumedFrom).toBe(null);
+    expect(two.cursorDiscardReason).toBe('missing');
+    expect(second.searchCalls[0].filter).toBe('id > -1');
+    expect(two.idsScanned).toBe(8);
+  });
+
+  it('does NOT reset the cursor when a confirmed-empty page arrives at low coverage', async () => {
+    // The trap this exists for: an empty page is the exact signal the engine
+    // produces transiently under write load, so treating it as "reached the end"
+    // and clearing the cursor would carry the original defect straight into the
+    // new mechanism — every truncated pass would clear and restart at the bottom,
+    // and cumulative progress would still be zero, now with a cursor bolted on.
+    //
+    // 24 documents reported by the engine; the scan is fed one page then nothing.
+    const fake = makeFakeIndex({
+      docs: [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24],
+      totalOverride: 24,
+      emptyOnCalls: [2, 3, 4, 5, 6, 7],
+    });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 3,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    // The loop DID exit through its terminator — that is not in dispute and the
+    // reporting is unchanged.
+    expect(stats.stoppedEarly).toBe(false);
+    // But 3 of 24 is not a pass that reached the end, so the cursor is kept.
+    expect(stats.passCovered).toBe(3);
+    expect(stats.cursorPersisted).toBe(6);
+    expect(storedCursor('models')).toMatchObject({ lastId: 6, covered: 3 });
+  });
+
+  it('persists where it got to when the scan STOPS EARLY', async () => {
+    // A run killed by the job lock, a cancellation or an unrecoverable engine
+    // error is the commonest truncation of all, and it must not throw its
+    // position away either.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9] });
+    setFakeIndex(fake);
+    const jobContext = makeJobContext();
+    const rec = makeDelayRecorder();
+    let batchesSeen = 0;
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 3,
+      resumable: true,
+      delay: rec.delay,
+      jobContext: jobContext as never,
+      onBatch: () => {
+        batchesSeen += 1;
+        if (batchesSeen === 2) jobContext.status = 'canceled';
+      },
+    });
+
+    expect(stats.stoppedEarly).toBe(true);
+    expect(stats.idsScanned).toBe(6);
+    expect(stats.cursorPersisted).toBe(6);
+    expect(storedCursor('models')).toMatchObject({ lastId: 6, covered: 6 });
+  });
+
+  it('counts ids the cursor walked past WITHOUT judging toward the pass coverage', async () => {
+    // A batch whose eligibility lookup failed is skipped, but the cursor advances
+    // past it — so those ids were covered by the scan's POSITION even though they
+    // were not examined. Leaving them out understates coverage, which then refutes
+    // completion on a pass that really did reach the end, and the cursor is held
+    // when it should have rolled over.
+    //
+    // Pairwise-distinct: 6 / 4 / 9 / 3 / 16 / 18 share no value.
+    seedCursor('models', { lastId: 6, startedAt: Date.now() - 60_000, covered: 4 });
+    const fake = makeFakeIndex({
+      docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+    });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+    // Three consecutive rejections exhaust the retry envelope for the first page.
+    readQuery
+      .mockRejectedValueOnce(new Error('replica blip'))
+      .mockRejectedValueOnce(new Error('replica blip'))
+      .mockRejectedValueOnce(new Error('replica blip'))
+      .mockResolvedValue([]);
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 3,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(stats.idsScanned).toBe(9);
+    expect(stats.idsSkipped).toBe(3);
+    expect(stats.passCovered).toBe(16);
+    expect(stats.stoppedEarly).toBe(false);
+    // 16 of 18 is a pass that reached the end, so it rolls over.
+    expect(storedCursor('models')).toBeUndefined();
+  });
+
+  it('makes CUMULATIVE progress: two truncated runs together cover the whole index', async () => {
+    // 🔴 The claim the whole change exists for, and it cannot be made by either run
+    // on its own. Asserted on the UNION of the ids the engine actually served, not
+    // on per-run counts: a run that re-walked the same prefix produces identical
+    // counts and a very different union.
+    const docs = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24];
+    const rec = makeDelayRecorder();
+
+    // Run 1: one page, then the engine answers empty for the whole confirmation
+    // schedule. 3 of 12 covered, so the pass is not credited and the cursor is kept.
+    const runOne = makeFakeIndex({ docs, emptyOnCalls: [2, 3, 4, 5, 6, 7] });
+    setFakeIndex(runOne);
+    const one = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 3,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(one.idsScanned).toBe(3);
+    expect(one.cursorPersisted).toBe(6);
+
+    // Run 2: same index, engine healthy. It must pick up at 6, not at the bottom.
+    const runTwo = makeFakeIndex({ docs });
+    setFakeIndex(runTwo);
+    const two = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 3,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(two.resumedFrom).toBe(6);
+    expect(runTwo.searchCalls[0].filter).toBe('id > 6');
+    expect(two.idsScanned).toBe(9);
+    // The pass total carries run 1's 3 forward, which is what lets run 2 be judged
+    // complete despite scanning only nine of the twelve documents itself.
+    expect(two.passCovered).toBe(12);
+    expect(two.cursorPersisted).toBe(null);
+    expect(storedCursor('models')).toBeUndefined();
+
+    const servedOne = runOne.served.flat();
+    const servedTwo = runTwo.served.flat();
+    // Union: every document, exactly once across the two runs.
+    expect([...servedOne, ...servedTwo].sort((a, b) => a - b)).toEqual(docs);
+    // Stated separately and positively: run 2 re-walked nothing run 1 had covered.
+    for (const id of servedOne) expect(servedTwo).not.toContain(id);
+  });
+});
+
+describe('cleanupIndex: a stored cursor cannot be carried indefinitely', () => {
+  it('pins the bound at seven days', async () => {
+    // The boundary cases below are written against the SYMBOL, which is what makes
+    // them independent of the value — and therefore blind to the value changing.
+    // The choice is load-bearing and argued from the job's cadence: nightly, so
+    // seven consecutive resumes, which at the rate the largest index was observed
+    // to scan is enough for one full sweep. Widening it silently is how an index
+    // drifts into never re-checking early ids.
+    expect(MAX_CURSOR_AGE_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it('resumes from a cursor that is just inside the staleness bound', async () => {
+    // Boundary, lower side. Paired with the case below so the bound is observable
+    // in BOTH directions — either one alone is satisfied by an implementation that
+    // ignores the age entirely, or by one that ignores the cursor entirely.
+    seedCursor('models', {
+      lastId: 6,
+      startedAt: Date.now() - MAX_CURSOR_AGE_MS,
+      covered: 5,
+    });
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 10,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(stats.resumedFrom).toBe(6);
+    expect(fake.searchCalls[0].filter).toBe('id > 6');
+    // The pass covered 5 + 4 = 9 of 10, so it is credited and rolls over. Pins the
+    // completion threshold from ABOVE — raising it toward 1 holds a cursor on a pass
+    // that plainly finished, and the un-scanned tail of a shrinking index would then
+    // wedge the rollover permanently.
+    expect(stats.passCovered).toBe(9);
+    expect(storedCursor('models')).toBeUndefined();
+  });
+
+  it('forces a from-the-bottom pass once a cursor is older than the bound', async () => {
+    // Boundary, upper side: one millisecond past. Without this an index that
+    // truncates every single night would carry one cursor forever and drift into
+    // never re-checking early ids at all.
+    seedCursor('models', {
+      lastId: 6,
+      startedAt: Date.now() - (MAX_CURSOR_AGE_MS + 1),
+      covered: 5,
+    });
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 10,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(stats.resumedFrom).toBe(null);
+    expect(stats.cursorDiscardReason).toBe('stale');
+    expect(fake.searchCalls[0].filter).toBe('id > -1');
+    expect(stats.idsScanned).toBe(10);
+  });
+
+  it('treats a FUTURE-dated cursor as stale rather than as one that can never expire', async () => {
+    // Clock skew (or a hand-edited value) makes the age negative, which passes an
+    // upper-bound test forever — the one way the bound could be defeated silently.
+    seedCursor('models', { lastId: 6, startedAt: Date.now() + 60_000, covered: 5 });
+
+    const { cursor, reason } = await readScanCursor('models');
+
+    expect(cursor).toBe(null);
+    expect(reason).toBe('stale');
+  });
+});
+
+describe('cleanupIndex: an unusable stored cursor fails SAFE', () => {
+  // 🔴 The direction matters more than the detection. Restarting re-examines
+  // documents that were already examined, which costs time. Skipping ahead on a
+  // value nobody could validate leaves a region of the index unexamined with
+  // nothing to indicate it — and this job bulk-deletes.
+
+  const unusable: [string, string, string][] = [
+    ['is not JSON at all', 'not json', 'unparseable'],
+    ['is JSON but not an object', '42', 'invalid'],
+    ['is null', 'null', 'invalid'],
+    ['is missing startedAt', '{"lastId":6,"covered":5}', 'invalid'],
+    ['carries a non-numeric lastId', '{"lastId":"6","startedAt":1,"covered":5}', 'invalid'],
+    ['carries a NaN startedAt', '{"lastId":6,"startedAt":null,"covered":5}', 'invalid'],
+    ['carries a negative lastId', '{"lastId":-3,"startedAt":1,"covered":5}', 'invalid'],
+  ];
+
+  for (const [label, raw, reason] of unusable) {
+    it(`starts from the beginning when the stored value ${label}`, async () => {
+      cursorHash.set('models', raw);
+      const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
+      setFakeIndex(fake);
+      const rec = makeDelayRecorder();
+
+      const stats = await cleanupIndex(modelsCfg, {
+        apply: false,
+        batch: 10,
+        resumable: true,
+        delay: rec.delay,
+      });
+
+      expect(stats.resumedFrom).toBe(null);
+      expect(stats.cursorDiscardReason).toBe(reason);
+      expect(fake.searchCalls[0].filter).toBe('id > -1');
+      // The whole index, not a suffix of it.
+      expect(stats.idsScanned).toBe(10);
+    });
+  }
+
+  it('starts from the beginning when the store itself cannot be read', async () => {
+    redisMock.sysRedis.hGet.mockRejectedValue(new Error('sysRedis unavailable'));
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 10,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(stats.resumedFrom).toBe(null);
+    expect(stats.cursorDiscardReason).toBe('unreadable');
+    expect(fake.searchCalls[0].filter).toBe('id > -1');
+    expect(stats.idsScanned).toBe(10);
+  });
+
+  it('completes the scan even when the cursor cannot be written back', async () => {
+    redisMock.sysRedis.hSet.mockRejectedValue(new Error('sysRedis unavailable'));
+    const fake = makeFakeIndex({
+      docs: [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24],
+      emptyOnCalls: [2, 3, 4, 5, 6, 7],
+    });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 3,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    // The scan's own results are intact; only the hand-off to the next run is lost,
+    // and it says so rather than claiming a cursor was saved.
+    expect(stats.idsScanned).toBe(3);
+    expect(stats.staleFound).toBe(3);
+    expect(stats.cursorPersisted).toBe(null);
+  });
+
+  it('INVARIANT GUARD (green on unfixed code): a scan without `resumable` never touches the store', async () => {
+    // Not a regression test — the un-fixed code had no store at all. It pins the
+    // opt-in, so a dry run or the one-off script cannot move the position the
+    // nightly job resumes from.
+    seedCursor('models', { lastId: 6, startedAt: Date.now(), covered: 5 });
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, { apply: false, batch: 10, delay: rec.delay });
+
+    expect(fake.searchCalls[0].filter).toBe('id > -1');
+    expect(stats.resumedFrom).toBe(null);
+    expect(stats.cursorPersisted).toBe(null);
+    expect(redisMock.sysRedis.hGet).not.toHaveBeenCalled();
+    expect(redisMock.sysRedis.hSet).not.toHaveBeenCalled();
+    expect(redisMock.sysRedis.hDel).not.toHaveBeenCalled();
+    // And the seeded cursor is exactly as it was.
+    expect(storedCursor('models')).toMatchObject({ lastId: 6, covered: 5 });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// An empty page is evidence, weighed against coverage — not a terminator
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('cleanupIndex: an empty page is re-asked harder when coverage says it cannot be the end', () => {
+  it('escalates the backoff and carries on when documents reappear', async () => {
+    // 20 documents, 5 per page. The engine answers empty at calls 2, 3 and 4 —
+    // three consecutive empties at 25% coverage, which one 500 ms retry cannot
+    // clear. The write batch the real engine was applying took far longer than that.
+    const fake = makeFakeIndex({
+      docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+      emptyOnCalls: [2, 3, 4],
+    });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 5,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    // Every document, not the five the first page happened to carry.
+    expect(stats.idsScanned).toBe(20);
+    expect(stats.stoppedEarly).toBe(false);
+    expect(stats.passCovered).toBe(20);
+    // 🔴 The schedule itself, in order: the delays ESCALATE. A constant-delay
+    // implementation retries just as many times and produces [1000,1000,1000,…].
+    // The trailing 500 is the cheap single confirm of the genuine end, taken
+    // because coverage by then agrees the scan is there.
+    expect(rec.delays).toEqual([1000, 2000, 4000, 500]);
+    expect(stats.emptyPageRetries).toBe(4);
+    // The pass completed, so nothing is carried into the next run.
+    expect(storedCursor('models')).toBeUndefined();
+  });
+
+  it('gives up after a BOUNDED number of escalating re-asks rather than looping', async () => {
+    // The job holds a 2 h lock; the confirmation must not become an unbounded
+    // retry loop inside it. Five attempts, 30 s of waiting for one empty page.
+    const fake = makeFakeIndex({
+      docs: [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24],
+      emptyOnCalls: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+    });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 3,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(rec.delays).toEqual([1000, 2000, 4000, 8000, 15000]);
+    expect(rec.delays.reduce((a, b) => a + b, 0)).toBe(30_000);
+    expect(stats.emptyPageRetries).toBe(5);
+    // Six searches after page 1: the empty one, then five confirmations.
+    expect(fake.searchCalls.length).toBe(7);
+    expect(stats.cursorPersisted).toBe(6);
+  });
+
+  it('INVARIANT GUARD (green on unfixed code): a genuinely exhausted index still ends on one cheap confirm', async () => {
+    // Not a regression test — the un-fixed code already confirmed once at 500 ms.
+    // It pins the other side of the trade: escalation is conditional on coverage,
+    // so the common case (the scan really is at the end) pays nothing extra and a
+    // seven-index run is not lengthened by 30 s per index for no reason.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 10,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(rec.delays).toEqual([500]);
+    expect(stats.emptyPageRetries).toBe(1);
+    expect(fake.searchCalls.map((c) => c.filter)).toEqual(['id > -1', 'id > 10', 'id > 10']);
+    expect(stats.stoppedEarly).toBe(false);
+  });
+
+  it('still confirms once when the index total is unknown', async () => {
+    // `getStats` failing leaves coverage unknowable. The scan must neither invent a
+    // verdict nor spend 30 s per empty page on every index it cannot measure.
+    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6] });
+    (fake.index as { getStats: () => Promise<unknown> }).getStats = async () => {
+      throw new Error('stats unavailable');
+    };
+    setFakeIndex(fake);
+    const rec = makeDelayRecorder();
+
+    const stats = await cleanupIndex(modelsCfg, {
+      apply: false,
+      batch: 6,
+      resumable: true,
+      delay: rec.delay,
+    });
+
+    expect(stats.totalInIndex).toBe(null);
+    expect(rec.delays).toEqual([500]);
+    // Coverage refutes nothing when there is nothing to compare against, so the
+    // pass is credited and the cursor is cleared rather than held on a judgement
+    // that could not be made.
+    expect(stats.cursorPersisted).toBe(null);
+    expect(storedCursor('models')).toBeUndefined();
   });
 });

--- a/src/server/meilisearch/cleanup-coverage.ts
+++ b/src/server/meilisearch/cleanup-coverage.ts
@@ -1,0 +1,88 @@
+/**
+ * THE single definition of "this cleanup pass reached the end of the index".
+ *
+ * 🔴 This module exists because that predicate was open-coded twice and the two copies
+ * DISAGREED. `cleanupIndex` cleared its resume cursor at >= 50% coverage while the job
+ * logged `incomplete: true` below 75%, so a pass landing in [0.50, 0.75) reported itself
+ * truncated at error level AND threw its resume point away in the same run — the next
+ * run restarted at the bottom, which is exactly the defect the cursor exists to fix,
+ * intact above 50%. One rule, one place: both consumers call this, so the log verdict
+ * and the cursor decision cannot drift apart again.
+ *
+ * The band itself is unchanged from the one the job already used, and is calibrated
+ * against two independent failure directions:
+ *
+ *  - The RATIO alone would make a small index shout over a few hundred documents.
+ *  - The FLOOR alone would let a 10%-covered multi-million-document index pass.
+ *
+ * They are deliberately NOT redundant, and the tests pin each one with a fixture where
+ * only that clause is decisive.
+ */
+
+/**
+ * How far the pass may fall short of the pre-scan document count, as a fraction, before
+ * the count refutes the loop's own claim to have finished.
+ *
+ * A shortfall is NORMAL: `totalInIndex` is a snapshot taken before a scan that then runs
+ * for a long time against indexes another job deletes from every few minutes, so the two
+ * numbers legitimately disagree on a perfectly complete run. The band is a judgement, not
+ * a measurement, and is deliberately loose — the real incident it has to catch was an 84%
+ * shortfall.
+ */
+export const COVERAGE_SHORTFALL_RATIO = 0.25;
+
+/**
+ * Absolute floor beneath which a shortfall is never treated as evidence of anything.
+ *
+ * Consequence worth stating plainly: an index holding fewer than ~1,333 documents can
+ * never be judged low-coverage, so a pass over one always counts as having reached the
+ * end. That is intended — such an index is walked in a page or two and there is nothing
+ * to resume. A pass that stopped early is still incomplete regardless of this floor,
+ * because `stoppedEarly` is a fact about how the loop exited, not a count.
+ */
+export const COVERAGE_SHORTFALL_FLOOR = 1000;
+
+export type PassCoverageInput = {
+  /** The loop exited for any reason other than its own terminator. */
+  stoppedEarly: boolean;
+  /**
+   * Ids walked past by the whole PASS — this run plus every earlier run it resumed from.
+   * NOT the run's own `idsScanned`: a resumed run scans only the remainder of the index,
+   * so judging it on its own count files every resumed run as truncated.
+   */
+  passCovered: number;
+  /** The engine's pre-scan document count, or null if it could not be read. */
+  totalInIndex: number | null;
+  /** Whether the engine was mid-ingest when that count was taken. */
+  indexingAtStart: boolean | null;
+};
+
+export type PassCoverageVerdict = {
+  /**
+   * 🔴 The one definition. True means: end the pass, clear the resume cursor, and report
+   * a healthy run. False means: the pass did not finish, so it keeps its cursor AND is
+   * reported incomplete. These two consequences are now the same boolean by construction.
+   */
+  reachedEnd: boolean;
+  /** The loop terminated, but the document count refutes it. */
+  lowCoverage: boolean;
+  coverage: number | null;
+  shortfall: number | null;
+};
+
+export function assessPassCoverage(r: PassCoverageInput): PassCoverageVerdict {
+  const total = r.totalInIndex;
+  const coverage = total !== null && total > 0 ? r.passCovered / total : null;
+  const shortfall = total === null ? null : total - r.passCovered;
+
+  const lowCoverage =
+    !r.stoppedEarly &&
+    shortfall !== null &&
+    // A count taken while the engine was mid-ingest is a moving number, so a shortfall
+    // against it is not evidence of anything.
+    r.indexingAtStart !== true &&
+    shortfall > COVERAGE_SHORTFALL_FLOOR &&
+    shortfall > (total as number) * COVERAGE_SHORTFALL_RATIO;
+
+  return { reachedEnd: !r.stoppedEarly && !lowCoverage, lowCoverage, coverage, shortfall };
+}

--- a/src/server/meilisearch/cleanup-cursor.ts
+++ b/src/server/meilisearch/cleanup-cursor.ts
@@ -95,6 +95,19 @@ export async function readScanCursor(key: string, now = Date.now()): Promise<Rea
     return { cursor: null, reason: 'invalid' };
   if (typeof covered !== 'number' || !Number.isFinite(covered) || covered < 0)
     return { cursor: null, reason: 'invalid' };
+  // 🔴 `covered` is the sole input to both coverage judgements — whether an empty page
+  // is believed, and whether the pass is credited as finished — so an absurd value
+  // silently credits a pass that covered nothing. Ids are non-negative and strictly
+  // increasing, so a pass standing at `lastId` cannot have walked past more than
+  // `lastId + 1` of them. That is a structural invariant, not a heuristic.
+  //
+  // What this does NOT catch: an index rebuilt or bulk-deleted between runs, which
+  // shrinks `totalInIndex` while `covered` legitimately carries the old, larger figure.
+  // No validation here can see that. It self-heals in one night — the resumed page sits
+  // above every surviving id, so the scan gets an empty page at apparently-complete
+  // coverage, credits the pass, clears the cursor, and the next run walks the rebuilt
+  // index from the bottom.
+  if (covered > lastId + 1) return { cursor: null, reason: 'invalid' };
 
   const age = now - startedAt;
   // A future-dated `startedAt` (clock skew, or a hand-edited value) would make `age`

--- a/src/server/meilisearch/cleanup-cursor.ts
+++ b/src/server/meilisearch/cleanup-cursor.ts
@@ -1,0 +1,136 @@
+import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+
+/**
+ * Cross-run scan cursor for the nightly search-index cleanup.
+ *
+ * The scan walks an index by keyset (`id > cursor`) and, on a multi-million-document
+ * index, cannot always finish inside one nightly run. Without persistence every run
+ * restarts at the bottom, so a pass that is repeatedly truncated re-walks the same
+ * already-clean low-id prefix every night and NEVER reaches the region past its
+ * stopping point — cumulative progress is exactly zero no matter how large the page
+ * size is. This module is the state that makes the next run continue instead.
+ *
+ * Storage is `sysRedis`, the same client the job's own lock already uses, in one hash
+ * keyed by cleanup index. It is durable across pod rolls, needs no schema change, and
+ * losing it is harmless: a missing cursor means "start from the bottom", which is the
+ * pre-existing behaviour.
+ */
+
+export type ScanCursor = {
+  /** Highest id already walked past in this pass. The next page asks for `id > lastId`. */
+  lastId: number;
+  /** When the pass this cursor belongs to first started, epoch ms. Bounds its staleness. */
+  startedAt: number;
+  /**
+   * Ids walked past across EVERY run of this pass so far (judged + skipped). A resumed
+   * run scans only the remainder, so this — not the run's own count — is what a
+   * coverage verdict about the pass has to be computed from.
+   */
+  covered: number;
+};
+
+/**
+ * How long one pass may be carried across runs before the next run is forced back to
+ * the bottom of the index regardless of where it stopped.
+ *
+ * Seven days, because the job is nightly: an index that truncates every single night
+ * gets at most seven consecutive resumes to finish a full sweep, and the largest index
+ * covered ~1.8M of ~11.6M documents in the run that exposed this, so seven runs is
+ * enough to complete one pass at the observed rate. The bound is what stops a
+ * persistently-truncating index from drifting into never re-examining early ids: past
+ * it, a document that went stale near the bottom of the id space would wait for the
+ * cursor to lap the whole index, which could be indefinitely.
+ */
+export const MAX_CURSOR_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Why a stored cursor was not used. Reported so a run that silently restarted from the
+ * bottom is distinguishable from one that had nothing stored — the two look identical
+ * in the scan itself and have completely different causes.
+ */
+export type CursorDiscardReason =
+  | 'none' // used
+  | 'missing' // nothing stored
+  | 'unreadable' // the store could not be read
+  | 'unparseable' // stored, but not JSON
+  | 'invalid' // parsed, but not a cursor record
+  | 'stale'; // older than MAX_CURSOR_AGE_MS (or dated in the future)
+
+export type ReadCursorResult = { cursor: ScanCursor | null; reason: CursorDiscardReason };
+
+const FIELD = (key: string) => key;
+
+/**
+ * Every rejection here resolves to `{ cursor: null }` — start from the beginning.
+ *
+ * 🔴 That direction is the whole safety argument. Restarting re-examines documents that
+ * were already examined, which costs time; skipping ahead on a value we could not
+ * validate would leave a region of the index unexamined with nothing to indicate it.
+ * A cursor is only ever trusted when it parses to a whole record whose age we can bound.
+ */
+export async function readScanCursor(key: string, now = Date.now()): Promise<ReadCursorResult> {
+  let raw: string | null;
+  try {
+    raw = (await sysRedis.hGet(REDIS_SYS_KEYS.SEARCH_INDEX_CLEANUP.CURSORS, FIELD(key))) ?? null;
+  } catch {
+    return { cursor: null, reason: 'unreadable' };
+  }
+  if (raw === null || raw === undefined || raw === '') return { cursor: null, reason: 'missing' };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { cursor: null, reason: 'unparseable' };
+  }
+  if (!parsed || typeof parsed !== 'object') return { cursor: null, reason: 'invalid' };
+
+  const rec = parsed as Record<string, unknown>;
+  const { lastId, startedAt, covered } = rec;
+  // `typeof NaN === 'number'`, and NaN survives every comparison below as false, so it
+  // would read as a cursor whose age can never exceed the bound. Check finiteness.
+  if (typeof lastId !== 'number' || !Number.isFinite(lastId) || lastId < 0)
+    return { cursor: null, reason: 'invalid' };
+  if (typeof startedAt !== 'number' || !Number.isFinite(startedAt))
+    return { cursor: null, reason: 'invalid' };
+  if (typeof covered !== 'number' || !Number.isFinite(covered) || covered < 0)
+    return { cursor: null, reason: 'invalid' };
+
+  const age = now - startedAt;
+  // A future-dated `startedAt` (clock skew, or a hand-edited value) would make `age`
+  // negative and pass an upper-bound test forever, which is the one way the staleness
+  // bound could be defeated silently. Treat it as stale.
+  if (age < 0 || age > MAX_CURSOR_AGE_MS) return { cursor: null, reason: 'stale' };
+
+  return { cursor: { lastId, startedAt, covered }, reason: 'none' };
+}
+
+/** Persist the point a truncated pass stopped at. Failure is reported, never thrown. */
+export async function writeScanCursor(key: string, cursor: ScanCursor): Promise<boolean> {
+  try {
+    await sysRedis.hSet(
+      REDIS_SYS_KEYS.SEARCH_INDEX_CLEANUP.CURSORS,
+      FIELD(key),
+      JSON.stringify(cursor)
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Drop the cursor so the next run starts over from the bottom.
+ *
+ * Called only when a pass genuinely completed. Without it the cursor would sit at the
+ * top of the index forever and the low-id region — where documents that were eligible
+ * when indexed and have since gone stale actually live — would never be re-examined.
+ */
+export async function clearScanCursor(key: string): Promise<boolean> {
+  try {
+    await sysRedis.hDel(REDIS_SYS_KEYS.SEARCH_INDEX_CLEANUP.CURSORS, FIELD(key));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/server/meilisearch/cleanup-cursor.ts
+++ b/src/server/meilisearch/cleanup-cursor.ts
@@ -133,17 +133,34 @@ export async function writeScanCursor(key: string, cursor: ScanCursor): Promise<
 }
 
 /**
+ * Why a clear did or did not happen. Three outcomes, not two.
+ *
+ * 🔴 `absent` exists because collapsing it into `cleared` made the flag lie on the
+ * common path: the overwhelming majority of runs complete with nothing stored, so an
+ * unconditional `true` put "cursor cleared — the next run starts over" on EVERY healthy
+ * nightly line for EVERY index, and the field stopped meaning the thing it was added to
+ * report. Collapsing it into `failed` instead would be worse — it would raise an error
+ * every night. It is genuinely a third outcome.
+ */
+export type ClearCursorOutcome =
+  | 'cleared' // a stored cursor was discarded
+  | 'absent' // there was nothing stored; the next run starts from the bottom anyway
+  | 'failed'; // the store rejected the write — the stale cursor is still there
+
+/**
  * Drop the cursor so the next run starts over from the bottom.
  *
- * Called only when a pass genuinely completed. Without it the cursor would sit at the
- * top of the index forever and the low-id region — where documents that were eligible
- * when indexed and have since gone stale actually live — would never be re-examined.
+ * Called when a pass genuinely completed. Without it the cursor would sit at the top of
+ * the index forever and the low-id region — where documents that were eligible when
+ * indexed and have since gone stale actually live — would never be re-examined.
  */
-export async function clearScanCursor(key: string): Promise<boolean> {
+export async function clearScanCursor(key: string): Promise<ClearCursorOutcome> {
   try {
-    await sysRedis.hDel(REDIS_SYS_KEYS.SEARCH_INDEX_CLEANUP.CURSORS, FIELD(key));
-    return true;
+    const removed = await sysRedis.hDel(REDIS_SYS_KEYS.SEARCH_INDEX_CLEANUP.CURSORS, FIELD(key));
+    // A non-numeric answer means we cannot claim a cursor was discarded, so report the
+    // weaker `absent`: over-reporting a clear is the defect this return value fixes.
+    return Number(removed) > 0 ? 'cleared' : 'absent';
   } catch {
-    return false;
+    return 'failed';
   }
 }

--- a/src/server/meilisearch/cleanup.ts
+++ b/src/server/meilisearch/cleanup.ts
@@ -706,12 +706,17 @@ export async function cleanupIndex(
     const nextId = docIds[docIds.length - 1];
     if (!(nextId > lastId)) {
       stats.errors += 1;
-      // 🔴 A cursor the scan could not advance past must NOT be handed to the next
-      // run. Persisting it makes every subsequent run trip this same guard on its
-      // first page and examine ZERO documents, for as long as the staleness bound
-      // allows — turning a bad page into a whole index going uncleaned. Before the
-      // cursor existed, everything below the bad page was still cleaned nightly;
-      // discarding the cursor restores exactly that.
+      // 🔴 A cursor the scan could not advance past on the FIRST page of a resumed run
+      // must NOT be handed to the next run: persisting it makes every later run trip
+      // this same guard immediately and examine ZERO documents, for as long as the
+      // staleness bound allows — turning one bad page into a whole index going
+      // uncleaned. Before the cursor existed, everything below the bad page was still
+      // cleaned nightly, and discarding restores exactly that.
+      //
+      // Recorded, not acted on here: whether this abort should discard depends on
+      // whether the run made progress first, which is decided after the loop by
+      // `wedgedOnResume`. Discarding unconditionally would throw away a whole night's
+      // work whenever the guard fires deep into a pass.
       cursorUnadvanceable = true;
       opts.onError?.({
         key: cfg.key,
@@ -818,16 +823,32 @@ export async function cleanupIndex(
      */
     const verdict = assessPassCoverage(stats);
 
-    if (verdict.reachedEnd || cursorUnadvanceable) {
+    /**
+     * 🔴 The wedge is specifically a guard that fires on the FIRST page of a RESUMED
+     * run — there, and only there, persisting the unchanged cursor makes every later
+     * run reproduce the identical abort and examine zero documents.
+     *
+     * Firing after real progress is a different event: the run walked from
+     * `resumedFrom` up to `lastId` and cleaned everything on the way. Discarding the
+     * cursor then throws a whole night's progress away and restarts at the bottom,
+     * which is the exact cost this change exists to eliminate — so that case keeps its
+     * cursor like any other truncated pass. `lastId === stats.resumedFrom` is the
+     * discriminator; a pass that never resumed has `resumedFrom === null`, which no
+     * numeric `lastId` can equal, and it has nothing stored to wedge on anyway.
+     */
+    const wedgedOnResume = cursorUnadvanceable && lastId === stats.resumedFrom;
+
+    if (verdict.reachedEnd || wedgedOnResume) {
       // Start the next run from the bottom. Without this the cursor sits at the top
       // of the index forever and the low-id region — where a document that was
       // eligible when it was indexed and has since gone stale actually lives — is
-      // never re-examined. `cursorUnadvanceable` lands here too, deliberately: see
-      // the monotonicity guard for why a cursor the scan could not pass must be
-      // discarded rather than handed on.
-      const cleared = await clearScanCursor(cfg.key);
-      stats.cursorCleared = cleared;
-      if (!cleared) {
+      // never re-examined.
+      const outcome = await clearScanCursor(cfg.key);
+      // `absent` is NOT a clear. The overwhelming majority of runs complete with
+      // nothing stored, and reporting those as "cursor cleared" put the note on every
+      // healthy nightly line for every index and drained the field of meaning.
+      stats.cursorCleared = outcome === 'cleared';
+      if (outcome === 'failed') {
         // 🔴 Loud, because the silent version is the worst failure this code has.
         // A completed pass that cannot clear its cursor resumes at the TOP of the
         // index next run, scans nothing, carries the old `covered` forward so the
@@ -839,8 +860,14 @@ export async function cleanupIndex(
           key: cfg.key,
           offset: -1,
           error: new Error(
-            `could not CLEAR the scan cursor for ${cfg.indexName} after a completed pass; ` +
-              `the next run will resume at id ${lastId} and may scan nothing`
+            `could not CLEAR the scan cursor for ${cfg.indexName} ` +
+              // Not "after a completed pass" unconditionally: on the wedge path the
+              // pass explicitly did NOT complete, and a message that says otherwise
+              // sends the reader looking for the wrong thing.
+              (wedgedOnResume
+                ? 'after aborting on a cursor it could not advance past'
+                : 'after a completed pass') +
+              `; the next run will resume at id ${lastId} and may scan nothing`
           ),
         });
       }

--- a/src/server/meilisearch/cleanup.ts
+++ b/src/server/meilisearch/cleanup.ts
@@ -16,6 +16,7 @@ import {
   writeScanCursor,
   type CursorDiscardReason,
 } from '~/server/meilisearch/cleanup-cursor';
+import { assessPassCoverage } from '~/server/meilisearch/cleanup-coverage';
 import { userSearchIndexEligibilitySql } from '~/server/search-index/user-index-eligibility';
 import type { JobContext } from '~/server/jobs/job';
 import {
@@ -25,6 +26,49 @@ import {
   CollectionReadConfiguration,
   ModelStatus,
 } from '~/shared/utils/prisma/enums';
+
+/**
+ * How long to wait before re-asking the same cursor after an empty page that COVERAGE
+ * ALREADY AGREES IS THE END. Also the delay used once the escalation budget below is
+ * exhausted, so an exhausted budget degrades to exactly the pre-existing single confirm
+ * rather than to a longer or an absent one.
+ */
+export const EMPTY_PAGE_CONFIRM_DELAY_MS = 500;
+
+/**
+ * Escalating re-asks for an empty page arriving while coverage says the scan is nowhere
+ * near the end. Measured: the engine's task queue was about an hour behind and applying
+ * writes in large batches when it answered empty at 15.5% coverage, and replaying the
+ * identical query off-peak walked 400 pages without ever hitting an end. One retry at
+ * 500 ms cannot clear a write batch that takes far longer.
+ *
+ * Five attempts, 30 s of waiting for one empty page.
+ */
+export const EMPTY_PAGE_BACKOFF_MS = [1000, 2000, 4000, 8000, 15000];
+
+/**
+ * Coverage at or above which an empty page is taken at close to face value and gets only
+ * the cheap single confirmation. Deliberately generous and NOT exact: `totalInIndex` is a
+ * pre-scan snapshot that drifts while the scan runs, and one index has legitimately
+ * reported coverage slightly ABOVE 1 because documents were added mid-scan.
+ */
+export const EMPTY_PAGE_TRUST_COVERAGE = 0.9;
+
+/**
+ * Ceiling on time spent ESCALATING, per index per run: 5 minutes.
+ *
+ * 🔴 State precisely what this does and does not bound, because an earlier version of
+ * this comment claimed a total it did not enforce. EVERY delay is charged against it,
+ * including the first — so escalation really is capped at 5 minutes per index, ~35
+ * minutes across the seven configured indexes, against the job's 2 h lock.
+ *
+ * What it does NOT bound: every empty page still gets ONE confirmation even after the
+ * budget is gone, because never confirming at all is the original defect. That residual
+ * is `EMPTY_PAGE_CONFIRM_DELAY_MS` per empty page, and empty pages are bounded by pages,
+ * since a transient empty that then yields documents advances the cursor. So the true
+ * worst case is 5 min of escalation plus 0.5 s per empty page.
+ */
+export const EMPTY_PAGE_BACKOFF_BUDGET_MS = 5 * 60 * 1000;
 
 export type CleanupIndexKey =
   | 'models'
@@ -191,6 +235,13 @@ export type CleanupOptions = {
    * suite that really slept through it could not run. Defaults to real time.
    */
   delay?: (ms: number) => Promise<void>;
+  /**
+   * Escalation budget for empty-page confirmation. Overridable for the same reason as
+   * `delay`: at the shipped 5 minutes no fixture of a runnable size ever reaches it, so
+   * the clamp would ship having never once executed. Defaults to
+   * `EMPTY_PAGE_BACKOFF_BUDGET_MS`.
+   */
+  emptyPageBackoffBudgetMs?: number;
   onBatch?: (info: { key: string; offset: number; scanned: number; stale: number }) => void;
   onError?: (info: { key: string; offset: number; error: Error }) => void;
   onDelete?: (info: { key: string; chunk: number; ids: number }) => void;
@@ -239,8 +290,14 @@ export type CleanupIndexStats = {
   passCovered: number;
   /** The stored cursor this run resumed from, or null if it started from the bottom. */
   resumedFrom: number | null;
-  /** The cursor left behind for the next run, or null if the pass completed. */
+  /** The cursor left behind for the next run, or null if none was. */
   cursorPersisted: number | null;
+  /**
+   * Whether the stored cursor was DISCARDED at the end of this run, so the next run
+   * starts from the bottom. Reported rather than inferred from `cursorPersisted: null`,
+   * which a healthy completed pass and a failed write emit identically.
+   */
+  cursorCleared: boolean;
   /**
    * Why a stored cursor was NOT used, or null if one was. `missing` after a completed
    * pass is normal; `unparseable`/`invalid`/`unreadable` mean the run silently restarted
@@ -303,6 +360,7 @@ export async function cleanupIndex(
     passCovered: 0,
     resumedFrom: null,
     cursorPersisted: null,
+    cursorCleared: false,
     cursorDiscardReason: null,
     emptyPageRetries: 0,
   };
@@ -443,6 +501,9 @@ export async function cleanupIndex(
   const MAX_CONSECUTIVE_PG_FAILURES = 10;
   let consecutivePgFailures = 0;
 
+  /** Set when the monotonicity guard fired; see the guard for why it forbids persisting. */
+  let cursorUnadvanceable = false;
+
   // One keyset page, already reduced to the numeric ids it carried.
   const fetchPage = async (cursor: number): Promise<number[]> => {
     const page = await withRetries(() =>
@@ -456,38 +517,7 @@ export async function cleanupIndex(
     return page.hits.map((r) => r.id).filter((n): n is number => Number.isFinite(n));
   };
 
-  // How long to wait before re-asking the same cursor after an empty page that
-  // COVERAGE ALREADY AGREES IS THE END. See `confirmEmptyPage` below.
-  const EMPTY_PAGE_CONFIRM_DELAY_MS = 500;
-
-  /**
-   * Escalating re-asks for an empty page arriving while coverage says the scan is
-   * nowhere near the end. Measured: the engine's task queue was about an hour behind
-   * and applying writes in large batches when it answered empty at 15.5% coverage,
-   * and replaying the identical query off-peak walked 400 pages without ever hitting
-   * an end. One retry at 500 ms cannot clear a write batch that takes far longer.
-   *
-   * Five attempts, 30 s of waiting for one empty page.
-   */
-  const EMPTY_PAGE_BACKOFF_MS = [1000, 2000, 4000, 8000, 15000];
-
-  /**
-   * Coverage at or above which an empty page is taken at close to face value and gets
-   * only the cheap single confirmation. Deliberately generous and NOT exact:
-   * `totalInIndex` is a pre-scan snapshot that drifts while the scan runs, and one
-   * index has legitimately reported coverage slightly ABOVE 1 because documents were
-   * added mid-scan.
-   */
-  const EMPTY_PAGE_TRUST_COVERAGE = 0.9;
-
-  /**
-   * Hard ceiling on time spent re-asking empty pages for THIS index in THIS run:
-   * 5 minutes, so all seven configured indexes together cannot spend more than ~35
-   * minutes of the job's 2 h lock on backoff. The first confirmation of any empty
-   * page is always taken — the budget only gates escalation past it — so an exhausted
-   * budget degrades to the previous behaviour rather than to no confirmation at all.
-   */
-  const EMPTY_PAGE_BACKOFF_BUDGET_MS = 5 * 60 * 1000;
+  const backoffBudgetMs = opts.emptyPageBackoffBudgetMs ?? EMPTY_PAGE_BACKOFF_BUDGET_MS;
   let emptyPageBackoffSpentMs = 0;
 
   /**
@@ -519,16 +549,29 @@ export async function cleanupIndex(
         : EMPTY_PAGE_BACKOFF_MS;
 
     let page: number[] = [];
-    for (let i = 0; i < schedule.length; i++) {
-      const ms = schedule[i];
-      // `i > 0`: the first confirmation is unconditional, so the budget can never
-      // reduce this below the single confirm the scan already did.
-      if (i > 0 && emptyPageBackoffSpentMs + ms > EMPTY_PAGE_BACKOFF_BUDGET_MS) break;
+    let asked = 0;
+    for (const ms of schedule) {
+      // EVERY delay is charged, the first included. An earlier version exempted it,
+      // which meant the budget bounded nothing about how many empty pages could be
+      // confirmed — the documented "~5 minutes per index" was not what ran.
+      if (emptyPageBackoffSpentMs + ms > backoffBudgetMs) break;
       emptyPageBackoffSpentMs += ms;
       stats.emptyPageRetries += 1;
+      asked += 1;
       await delay(ms);
       page = await fetchPage(cursor);
       if (page.length > 0) return page;
+    }
+
+    // Budget gone before a single re-ask. Confirm ONCE anyway, at the cheap delay:
+    // believing an empty page on sight is the original defect, and this must never
+    // degrade below the single confirmation the scan already did before this change.
+    // Charged too, so the spend figure stays truthful.
+    if (asked === 0) {
+      emptyPageBackoffSpentMs += EMPTY_PAGE_CONFIRM_DELAY_MS;
+      stats.emptyPageRetries += 1;
+      await delay(EMPTY_PAGE_CONFIRM_DELAY_MS);
+      page = await fetchPage(cursor);
     }
     return page;
   };
@@ -552,8 +595,15 @@ export async function cleanupIndex(
    * rather than costing a re-examination tomorrow.
    *
    * If the primary cannot be reached the chunk is NOT deleted. The safe
-   * failure direction here is to delete nothing: an undeleted stale document
-   * is picked up by the next nightly run, a wrongly deleted live one is not.
+   * failure direction here is to delete nothing: an undeleted stale document is
+   * picked up by a LATER pass, a wrongly deleted live one is not.
+   *
+   * ⚠️ "Later pass", not "tomorrow". Under `resumable` the next run continues ABOVE
+   * these ids, so they are re-examined when the cursor next laps the index — at most
+   * one pass away, bounded by the cursor staleness limit. That is a real change in
+   * cleanup LATENCY for a truncating index, and the trade the cursor buys: before it,
+   * these ids were re-examined the next night, but the ids above the truncation point
+   * were never examined at all.
    */
   const flushDeletions = async (final: boolean) => {
     if (!opts.apply) return;
@@ -656,6 +706,13 @@ export async function cleanupIndex(
     const nextId = docIds[docIds.length - 1];
     if (!(nextId > lastId)) {
       stats.errors += 1;
+      // 🔴 A cursor the scan could not advance past must NOT be handed to the next
+      // run. Persisting it makes every subsequent run trip this same guard on its
+      // first page and examine ZERO documents, for as long as the staleness bound
+      // allows — turning a bad page into a whole index going uncleaned. Before the
+      // cursor existed, everything below the bad page was still cleaned nightly;
+      // discarding the cursor restores exactly that.
+      cursorUnadvanceable = true;
       opts.onError?.({
         key: cfg.key,
         offset: lastId,
@@ -701,8 +758,10 @@ export async function cleanupIndex(
       // Postgres-side error survived retries. Don't abandon the whole
       // index for a single transient batch — advance the cursor and try
       // the next page. We'll miss cleanup for the ids in this batch this
-      // run; the next nightly run will catch them. But cap consecutive
-      // failures so a hard outage doesn't grind through millions of ids.
+      // run; a LATER PASS will catch them — under `resumable` the next RUN
+      // continues above them, so it is when the cursor next laps the index,
+      // not tomorrow. But cap consecutive failures so a hard outage doesn't
+      // grind through millions of ids.
       stats.errors += 1;
       consecutivePgFailures += 1;
       // These ids were fetched but never judged. The cursor advances past them
@@ -746,39 +805,45 @@ export async function cleanupIndex(
 
   if (resumable) {
     /**
-     * 🔴 "Genuinely reached the end" is NOT "we saw an empty page".
+     * 🔴 "Genuinely reached the end" is NOT "we saw an empty page", and it is NOT a
+     * judgement made here. It is `assessPassCoverage` — the SINGLE definition, shared
+     * with the job that logs the verdict.
      *
-     * The empty page is the very signal the engine produces transiently under write
-     * load, and trusting it here is what would carry the original defect into the
-     * cursor: a pass truncated at 15% would clear its cursor, restart at the bottom
-     * next run, and cumulative progress would stay at zero with a cursor bolted on.
-     *
-     * So completion needs BOTH: the loop exited through its terminator (rather than
-     * an error, a cancellation or the non-advancing-cursor guard), AND the pass
-     * covered a plausible share of the index the engine said was there.
-     *
-     * The share is deliberately loose. `totalInIndex` is a pre-scan snapshot against
-     * an index other jobs delete from every few minutes, so it drifts; the number
-     * that has to be separable from it is the 0.155 the real truncation produced,
-     * an order of magnitude below this. And when the count was taken mid-ingest, or
-     * could not be read at all, coverage refutes nothing — the pass is credited,
-     * because the alternative is holding a cursor on a judgement we cannot make.
+     * Both facts matter. The empty page is the very signal the engine produces
+     * transiently under write load, so trusting it alone would carry the original
+     * defect into the cursor. And computing a second, private threshold here is how
+     * this code shipped with the two disagreeing: the cursor cleared at 50% while the
+     * job alarmed below 75%, so a pass in between reported itself truncated and threw
+     * its resume point away in the same run.
      */
-    const COMPLETION_MIN_COVERAGE = 0.5;
-    const coverageRefutesCompletion =
-      stats.totalInIndex !== null &&
-      stats.totalInIndex > 0 &&
-      stats.indexingAtStart !== true &&
-      stats.passCovered < stats.totalInIndex * COMPLETION_MIN_COVERAGE;
+    const verdict = assessPassCoverage(stats);
 
-    const completed = !stats.stoppedEarly && !coverageRefutesCompletion;
-
-    if (completed) {
+    if (verdict.reachedEnd || cursorUnadvanceable) {
       // Start the next run from the bottom. Without this the cursor sits at the top
       // of the index forever and the low-id region — where a document that was
       // eligible when it was indexed and has since gone stale actually lives — is
-      // never re-examined.
-      await clearScanCursor(cfg.key);
+      // never re-examined. `cursorUnadvanceable` lands here too, deliberately: see
+      // the monotonicity guard for why a cursor the scan could not pass must be
+      // discarded rather than handed on.
+      const cleared = await clearScanCursor(cfg.key);
+      stats.cursorCleared = cleared;
+      if (!cleared) {
+        // 🔴 Loud, because the silent version is the worst failure this code has.
+        // A completed pass that cannot clear its cursor resumes at the TOP of the
+        // index next run, scans nothing, carries the old `covered` forward so the
+        // count still looks complete, and reports `info … scanned 0, stale 0,
+        // deleted 0` — an index getting zero cleanup while looking healthy, nightly,
+        // until the staleness bound expires it.
+        stats.errors += 1;
+        opts.onError?.({
+          key: cfg.key,
+          offset: -1,
+          error: new Error(
+            `could not CLEAR the scan cursor for ${cfg.indexName} after a completed pass; ` +
+              `the next run will resume at id ${lastId} and may scan nothing`
+          ),
+        });
+      }
     } else if (lastId >= 0) {
       const persisted = await writeScanCursor(cfg.key, {
         lastId,
@@ -786,6 +851,20 @@ export async function cleanupIndex(
         covered: stats.passCovered,
       });
       if (persisted) stats.cursorPersisted = lastId;
+      else {
+        // The pass was truncated and its position could not be saved, so the next run
+        // restarts at the bottom — defect B, for this index, this night. Silent, it is
+        // indistinguishable from a healthy rollover.
+        stats.errors += 1;
+        opts.onError?.({
+          key: cfg.key,
+          offset: -1,
+          error: new Error(
+            `could not PERSIST the scan cursor for ${cfg.indexName} at id ${lastId}; ` +
+              `the next run will restart from the beginning of the index`
+          ),
+        });
+      }
     }
   }
 

--- a/src/server/meilisearch/cleanup.ts
+++ b/src/server/meilisearch/cleanup.ts
@@ -10,6 +10,12 @@ import {
   USERS_SEARCH_INDEX,
 } from '~/server/common/constants';
 import { searchClient } from '~/server/meilisearch/client';
+import {
+  clearScanCursor,
+  readScanCursor,
+  writeScanCursor,
+  type CursorDiscardReason,
+} from '~/server/meilisearch/cleanup-cursor';
 import { userSearchIndexEligibilitySql } from '~/server/search-index/user-index-eligibility';
 import type { JobContext } from '~/server/jobs/job';
 import {
@@ -173,6 +179,18 @@ export type CleanupOptions = {
   maxBatches?: number;
   /** Max ids per delete call. Meili accepts large bodies; keep chunks sane. */
   deleteChunkSize?: number;
+  /**
+   * Read/write the shared cross-run scan cursor. OFF by default so a dry run or an
+   * ad-hoc invocation of the one-off script cannot move the position the nightly job
+   * resumes from; the cron opts in.
+   */
+  resumable?: boolean;
+  /**
+   * How the scan waits. Overridable so a test can assert the empty-page backoff
+   * SCHEDULE without spending it — the escalation is the property under test, and a
+   * suite that really slept through it could not run. Defaults to real time.
+   */
+  delay?: (ms: number) => Promise<void>;
   onBatch?: (info: { key: string; offset: number; scanned: number; stale: number }) => void;
   onError?: (info: { key: string; offset: number; error: Error }) => void;
   onDelete?: (info: { key: string; chunk: number; ids: number }) => void;
@@ -212,6 +230,25 @@ export type CleanupIndexStats = {
   rescuedByPrimary: number;
   /** `isIndexing` as reported alongside the document count, or null if unread. */
   indexingAtStart: boolean | null;
+  /**
+   * Ids walked past by the whole PASS — this run plus every earlier run it resumed
+   * from. A resumed run scans only the remainder of the index, so its own `idsScanned`
+   * is legitimately a fraction of `totalInIndex`; any coverage verdict has to be
+   * computed from this instead, or every resumed run reads as truncated.
+   */
+  passCovered: number;
+  /** The stored cursor this run resumed from, or null if it started from the bottom. */
+  resumedFrom: number | null;
+  /** The cursor left behind for the next run, or null if the pass completed. */
+  cursorPersisted: number | null;
+  /**
+   * Why a stored cursor was NOT used, or null if one was. `missing` after a completed
+   * pass is normal; `unparseable`/`invalid`/`unreadable` mean the run silently restarted
+   * from the bottom, which is safe but is not the same event and should not look like one.
+   */
+  cursorDiscardReason: CursorDiscardReason | null;
+  /** How many times an empty page was re-asked before the scan believed it. */
+  emptyPageRetries: number;
 };
 
 /**
@@ -263,6 +300,11 @@ export async function cleanupIndex(
     idsSkipped: 0,
     rescuedByPrimary: 0,
     indexingAtStart: null,
+    passCovered: 0,
+    resumedFrom: null,
+    cursorPersisted: null,
+    cursorDiscardReason: null,
+    emptyPageRetries: 0,
   };
 
   try {
@@ -317,7 +359,36 @@ export async function cleanupIndex(
   // Keyset (cursor) pagination over `id`. Per-call cost is O(batch) on
   // Meilisearch regardless of depth — replaces offset pagination where
   // deep pages were saturating LMDB read I/O on the search host.
+  //
+  // 🔴 The starting point is READ FROM DURABLE STATE, not hardcoded to the bottom.
+  // A scan that cannot walk a multi-million-document index inside one nightly run
+  // and then restarts at the bottom re-examines the same already-clean prefix every
+  // night and can NEVER reach the region past where it stopped — measured, the
+  // boundary of the unscanned region did not move by a single id across two
+  // consecutive nightly runs. No page size fixes that: a from-scratch scan that
+  // cannot finish in one run makes zero cumulative progress by construction.
+  const resumable = opts.resumable === true;
   let lastId = -1;
+  // When the pass that owns this cursor first started, and how much of the index it
+  // has walked past in total. Both are carried across runs; both are reset here when
+  // the run starts a fresh pass.
+  let passStartedAt = Date.now();
+  let carriedCovered = 0;
+
+  if (resumable) {
+    const { cursor, reason } = await readScanCursor(cfg.key);
+    stats.cursorDiscardReason = reason === 'none' ? null : reason;
+    if (cursor) {
+      // Resume AT the stored id, not one past it: the page filter is `id > lastId`,
+      // so the stored value is the last id already walked past and the next page
+      // begins with the one after it. Storing-then-incrementing here would skip
+      // exactly one document per run, permanently.
+      lastId = cursor.lastId;
+      passStartedAt = cursor.startedAt;
+      carriedCovered = cursor.covered;
+      stats.resumedFrom = cursor.lastId;
+    }
+  }
 
   // Stale ids awaiting deletion. Deliberately NOT an accumulator for the whole
   // index: deletions are flushed as the scan runs, so a run that is cancelled
@@ -338,6 +409,7 @@ export async function cleanupIndex(
   // inner try/catch would treat the cancellation as a transient error and
   // burn through the backoff before bailing.
   const MAX_ATTEMPTS = 3;
+  const delay = opts.delay ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   const withRetries = async <T>(fn: () => Promise<T>): Promise<T> => {
     let lastErr: unknown;
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
@@ -357,7 +429,7 @@ export async function cleanupIndex(
         lastErr = err;
         if (attempt < MAX_ATTEMPTS) {
           // Linear backoff: 1000ms, 1500ms.
-          await new Promise((r) => setTimeout(r, attempt * 500 + 500));
+          await delay(attempt * 500 + 500);
         }
       }
     }
@@ -384,9 +456,82 @@ export async function cleanupIndex(
     return page.hits.map((r) => r.id).filter((n): n is number => Number.isFinite(n));
   };
 
-  // How long to wait before re-asking the same cursor after an empty page.
-  // See the confirmation below for why an empty page is not trusted first time.
+  // How long to wait before re-asking the same cursor after an empty page that
+  // COVERAGE ALREADY AGREES IS THE END. See `confirmEmptyPage` below.
   const EMPTY_PAGE_CONFIRM_DELAY_MS = 500;
+
+  /**
+   * Escalating re-asks for an empty page arriving while coverage says the scan is
+   * nowhere near the end. Measured: the engine's task queue was about an hour behind
+   * and applying writes in large batches when it answered empty at 15.5% coverage,
+   * and replaying the identical query off-peak walked 400 pages without ever hitting
+   * an end. One retry at 500 ms cannot clear a write batch that takes far longer.
+   *
+   * Five attempts, 30 s of waiting for one empty page.
+   */
+  const EMPTY_PAGE_BACKOFF_MS = [1000, 2000, 4000, 8000, 15000];
+
+  /**
+   * Coverage at or above which an empty page is taken at close to face value and gets
+   * only the cheap single confirmation. Deliberately generous and NOT exact:
+   * `totalInIndex` is a pre-scan snapshot that drifts while the scan runs, and one
+   * index has legitimately reported coverage slightly ABOVE 1 because documents were
+   * added mid-scan.
+   */
+  const EMPTY_PAGE_TRUST_COVERAGE = 0.9;
+
+  /**
+   * Hard ceiling on time spent re-asking empty pages for THIS index in THIS run:
+   * 5 minutes, so all seven configured indexes together cannot spend more than ~35
+   * minutes of the job's 2 h lock on backoff. The first confirmation of any empty
+   * page is always taken — the budget only gates escalation past it — so an exhausted
+   * budget degrades to the previous behaviour rather than to no confirmation at all.
+   */
+  const EMPTY_PAGE_BACKOFF_BUDGET_MS = 5 * 60 * 1000;
+  let emptyPageBackoffSpentMs = 0;
+
+  /**
+   * Coverage of the whole PASS so far, or null when the index total is unknown.
+   * Includes ids carried from earlier runs of the same pass, and ids the cursor walked
+   * past without judging — both were covered by the scan's position even though only
+   * one of them was examined.
+   */
+  const passCoverageSoFar = (): number | null => {
+    if (stats.totalInIndex === null || stats.totalInIndex <= 0) return null;
+    return (carriedCovered + stats.idsScanned + stats.idsSkipped) / stats.totalInIndex;
+  };
+
+  /**
+   * Re-ask `cursor` after an empty page and return whatever the last attempt saw.
+   *
+   * 🔴 An empty page is EVIDENCE, weighed against coverage — not a terminator. When the
+   * scan has covered nearly the whole index, an empty page is what the end of the index
+   * looks like and one cheap confirm is enough. When it has covered a fraction, an empty
+   * page contradicts the index's own document count, and the thing most likely to
+   * produce it is the engine being mid-write — so it is re-asked with escalating
+   * backoff before being believed.
+   */
+  const confirmEmptyPage = async (cursor: number): Promise<number[]> => {
+    const coverage = passCoverageSoFar();
+    const schedule =
+      coverage === null || coverage >= EMPTY_PAGE_TRUST_COVERAGE
+        ? [EMPTY_PAGE_CONFIRM_DELAY_MS]
+        : EMPTY_PAGE_BACKOFF_MS;
+
+    let page: number[] = [];
+    for (let i = 0; i < schedule.length; i++) {
+      const ms = schedule[i];
+      // `i > 0`: the first confirmation is unconditional, so the budget can never
+      // reduce this below the single confirm the scan already did.
+      if (i > 0 && emptyPageBackoffSpentMs + ms > EMPTY_PAGE_BACKOFF_BUDGET_MS) break;
+      emptyPageBackoffSpentMs += ms;
+      stats.emptyPageRetries += 1;
+      await delay(ms);
+      page = await fetchPage(cursor);
+      if (page.length > 0) return page;
+    }
+    return page;
+  };
 
   let chunkIdx = 0;
 
@@ -475,17 +620,13 @@ export async function cleanupIndex(
     try {
       docIds = await fetchPage(lastId);
 
-      // An empty page is the ONLY terminator, and it is not trusted on its
-      // first appearance. The engine can be concurrently applying document
-      // additions and deletions while we scan, and a transient empty reply
-      // at a cursor that still has documents past it would otherwise end the
-      // scan early — silently, and reported as success. Re-ask the SAME
-      // cursor once after a short pause; only a second empty reply ends the
-      // scan. Costs one extra query per index per run.
-      if (docIds.length === 0) {
-        await new Promise((r) => setTimeout(r, EMPTY_PAGE_CONFIRM_DELAY_MS));
-        docIds = await fetchPage(lastId);
-      }
+      // An empty page is the ONLY terminator, and it is not trusted on sight.
+      // The engine can be concurrently applying document additions and deletions
+      // while we scan, and a transient empty reply at a cursor that still has
+      // documents past it would otherwise end the scan early — silently, and
+      // reported as success. `confirmEmptyPage` re-asks the SAME cursor, escalating
+      // when the index's own document count says we cannot possibly be at the end.
+      if (docIds.length === 0) docIds = await confirmEmptyPage(lastId);
     } catch (err) {
       // Cancellation surfaced from withRetries is a clean stop, not a failure.
       if (opts.jobContext && opts.jobContext.status !== 'running') break;
@@ -600,6 +741,53 @@ export async function cleanupIndex(
   // Whatever is left over after the loop, including the tail of a scan that
   // stopped early. A cancelled run returns from inside the flush instead.
   await flushDeletions(true);
+
+  stats.passCovered = carriedCovered + stats.idsScanned + stats.idsSkipped;
+
+  if (resumable) {
+    /**
+     * 🔴 "Genuinely reached the end" is NOT "we saw an empty page".
+     *
+     * The empty page is the very signal the engine produces transiently under write
+     * load, and trusting it here is what would carry the original defect into the
+     * cursor: a pass truncated at 15% would clear its cursor, restart at the bottom
+     * next run, and cumulative progress would stay at zero with a cursor bolted on.
+     *
+     * So completion needs BOTH: the loop exited through its terminator (rather than
+     * an error, a cancellation or the non-advancing-cursor guard), AND the pass
+     * covered a plausible share of the index the engine said was there.
+     *
+     * The share is deliberately loose. `totalInIndex` is a pre-scan snapshot against
+     * an index other jobs delete from every few minutes, so it drifts; the number
+     * that has to be separable from it is the 0.155 the real truncation produced,
+     * an order of magnitude below this. And when the count was taken mid-ingest, or
+     * could not be read at all, coverage refutes nothing — the pass is credited,
+     * because the alternative is holding a cursor on a judgement we cannot make.
+     */
+    const COMPLETION_MIN_COVERAGE = 0.5;
+    const coverageRefutesCompletion =
+      stats.totalInIndex !== null &&
+      stats.totalInIndex > 0 &&
+      stats.indexingAtStart !== true &&
+      stats.passCovered < stats.totalInIndex * COMPLETION_MIN_COVERAGE;
+
+    const completed = !stats.stoppedEarly && !coverageRefutesCompletion;
+
+    if (completed) {
+      // Start the next run from the bottom. Without this the cursor sits at the top
+      // of the index forever and the low-id region — where a document that was
+      // eligible when it was indexed and has since gone stale actually lives — is
+      // never re-examined.
+      await clearScanCursor(cfg.key);
+    } else if (lastId >= 0) {
+      const persisted = await writeScanCursor(cfg.key, {
+        lastId,
+        startedAt: passStartedAt,
+        covered: stats.passCovered,
+      });
+      if (persisted) stats.cursorPersisted = lastId;
+    }
+  }
 
   return stats;
 }


### PR DESCRIPTION
Follow-up to #4315. Two defects showed up on the first production run of that
change; the second is the one that matters.

> **Reviewers:** this PR has been through two rounds of adversarial audit. Round 1
> found a 🔴 (two thresholds disagreeing) plus five 🟡s; the delta re-audit confirmed
> all six fixed and found four more. Everything is addressed — see
> **"What the audits changed"** below.

## A — a confirmed-empty page was trusted as the end of the index

The largest index reported:

```
scan reached the end of the index but covered only 1803688 of 11610246 document(s)
coverage=0.1554  incomplete=true  stoppedEarly=false
```

That decomposes as 180 full pages plus a partial one, then two empty pages 500 ms
apart. At that moment the engine's task queue was roughly an hour behind and
applying writes in large batches. **Control:** replaying the identical scan query
off-peak walked 400 pages without ever hitting an end. So the empty page was a
transient artefact of concurrent writes, not the end of the index — and one retry
at 500 ms cannot outlast a write batch that takes far longer.

## B — the scan always restarted at the bottom

`lastId` began at `-1` on every run. A pass that cannot walk a multi-million-
document index inside one nightly run therefore re-walked the same already-clean
low-id prefix every night and could **never** reach the region past its stopping
point. Measured: the boundary of the un-scanned region did not move by a single
id across two consecutive nightly runs.

🔴 **No page size fixes this.** A from-scratch scan that cannot finish in one run
makes *zero* cumulative progress by construction, whatever the page size — a
bigger page only changes where the same wall falls.

---

## What this changes

### 1. Cross-run cursor persistence (the core change)

`src/server/meilisearch/cleanup-cursor.ts` stores one record per index:
`{ lastId, startedAt, covered }`.

**Storage choice — `sysRedis`.** The job already holds its run lock there
(`REDIS_SYS_KEYS.JOB` via the run-jobs route), and the nightly metric-
reconciliation job already persists a cross-run snapshot the same way
(`REDIS_SYS_KEYS.METRIC_RECONCILIATION.NIGHTLY_EXACTNESS`, plain `get`/`set` of
JSON, no TTL). This follows that established pattern rather than inventing one:
durable across pod rolls, no schema change, and losing the value is harmless
because a missing cursor means "start from the bottom", which is exactly the
previous behaviour. Stored as one hash keyed by cleanup index
(`REDIS_SYS_KEYS.SEARCH_INDEX_CLEANUP.CURSORS`). No TTL — an expiry would be
indistinguishable from a completed pass, so staleness is bounded in code instead.

**Resume semantics.** A run resumes **at** the stored id, not one past it: the
page filter is `id > lastId`, so the stored value is the last id already walked
past and the next page begins with the one after it. Resuming at `lastId + 1`
would skip exactly one document per run, permanently.

**Reset semantics — ONE definition, shared.** `cleanup-coverage.ts` owns
`assessPassCoverage`, and both `cleanupIndex` (deciding whether to clear the
cursor) and the job (deciding whether to log `incomplete`) call it. A pass is
credited as having reached the end only when **both** hold:

- the loop exited through its terminator (not an error, a cancellation, or the
  non-advancing-cursor guard), **and**
- the shortfall against the engine's document count clears neither the 25% ratio
  nor the 1000-document absolute floor.

Deliberately *not* "we saw an empty page" — that is defect A, and trusting it
would carry the same bug into the new mechanism. The band is loose on purpose:
`totalInIndex` is a pre-scan snapshot of an index other jobs delete from
continuously, so it drifts, and one index has legitimately reported coverage
slightly *above* 1 because documents were added mid-scan. What it has to separate
is the 0.155 the real truncation produced. When the count was taken mid-ingest, or
could not be read at all, coverage refutes nothing and the pass is credited,
because the alternative is holding a cursor on a judgement we cannot make.

On completion the cursor is **cleared**, so the next run starts over from the
bottom. Without that it would sit at the top of the index forever and the low-id
region — where a document that was eligible when it was indexed and has since gone
stale actually lives — would never be re-examined.

**Staleness bound — seven days.** A cursor carried longer than that is discarded
and the next run starts from the bottom. Rationale: the job is nightly, so seven
days is seven consecutive resumes, and at the rate the largest index was observed
to scan (~1/6 of itself per run) seven runs is enough to complete one full sweep.
A future-dated `startedAt` (clock skew) is also treated as stale — otherwise a
negative age passes an upper-bound test forever.

**Fail-safe direction.** Missing, unreadable, unparseable or structurally invalid
stored values all start from the beginning and say which. Restarting re-examines
documents that were already examined, which costs time; skipping ahead on a value
nobody could validate would leave a region of the index unexamined with nothing to
indicate it — and this job bulk-deletes.

**Opt-in.** Persistence is behind a `resumable` flag taken only by the cron, so a
dry run or the one-off script cannot move the position the nightly job resumes from.

**Coverage is measured over the PASS, not the run.** A resumed run legitimately
scans only the remainder, so reading coverage off its own `idsScanned` would file
every resumed run as truncated. `passCovered` carries what earlier runs of the same
pass walked past, including ids the cursor advanced over without judging.

### ⚠️ The observable trade: low-id cleanup latency

Worth stating plainly, because the rest of this description frames the cursor only
as protection. Before, a document that went stale near the bottom of the id space
was re-examined **the next night**, every night. Now, on an index whose pass is
being truncated, it is re-examined when the cursor next **laps the index** — up to
one full pass, bounded by the seven-day staleness limit.

That is the trade the cursor buys: the ids *above* the truncation point were
previously never examined at all. On an index that finishes its pass in one run —
which is all of them except the largest — nothing changes, because the cursor is
cleared at the end of every run.

### 2. An empty page is weighed against coverage

When an empty page arrives while coverage says the scan cannot be at the end, it
is re-asked with escalating backoff: **1 s, 2 s, 4 s, 8 s, 15 s — 30 s for one
empty page**. When coverage already agrees the scan is at the end (≥ 0.9, generous
because the total drifts), the previous single 500 ms confirm is kept, so the
common case costs nothing extra. If it still looks empty the pass ends,
`incomplete` reporting is unchanged, and the cursor is persisted.

**What the budget bounds, precisely.** `EMPTY_PAGE_BACKOFF_BUDGET_MS` caps
**escalation** at 5 minutes per index per run — every delay is charged against it,
the first included. It does **not** cap total confirmation time: every empty page
still gets *one* re-ask even after the budget is gone, because believing an empty
page on sight is the original defect. That residual is 500 ms per empty page, and
empty pages are bounded by pages, since a transient empty that then yields
documents advances the cursor. So the worst case is 5 min of escalation plus 0.5 s
per empty page, per index.

### 3. Reporting

Each per-index line now carries `covered`, `resumedFrom`, `cursorPersisted`,
`cursorCleared`, `cursorDiscardReason` and `emptyPageRetries`, and the message says
where the run resumed from, where it left the cursor, and whether the cursor was
discarded. `cursorCleared` means a stored cursor was *actually* removed — "there was
nothing to clear" is a distinct outcome and stays quiet, the same way
`cursorDiscardReason: 'missing'` does. Without that a resumed run and a from-the-bottom run produce identical
lines, and "the cursor never moves between nights" — the defect itself — is only
visible by comparing them across runs.

Out of scope and untouched: `maxTotalHits` in `onIndexSetup`, the `isIndexing`
pre-scan snapshot, `PrismaClients` typing, the comics index.

---

## What the audits changed

🔴 **Two thresholds disagreed, and the fix was inert in the gap.** `cleanupIndex`
cleared the cursor at ≥ 50% coverage while the job logged `incomplete: true` below
75%. A pass landing in **[0.50, 0.75)** reported itself truncated at error level
**and discarded its resume point in the same run** — defect B unfixed, at higher
coverage, with the invariant this PR exists to establish holding only below 50%.
Nothing distinguished it: a discarded cursor and a healthy pass both left
`cursorPersisted: null`.

Fixed structurally, not by editing the constant. `cleanup-coverage.ts` now owns the
single predicate and both consumers call it, so `incomplete` and "the cursor was
discarded" are one boolean, negated. A `COVERAGE_BAND` fixture table drives *both*
consumers — six literal rows including one at 0.60, inside the old gap — so a
future divergence turns one of the two tables red. Clearing is now also logged
rather than inferred from a null.

🟡 **A failed cursor write or clear was silent.** Both now raise an error. The
clear case is the worst failure available here: reads succeed, writes are rejected
(redis at maxmemory, a read-only replica), the completed pass fails to clear, the
next run resumes at the *top* of the index, scans nothing, carries the old coverage
forward so the counts still look complete, and files `info … scanned 0, stale 0,
deleted 0` nightly until the staleness bound expires it.

🟡 **A non-advancing page wedged a whole index.** The monotonicity guard broke
without advancing, and the unchanged cursor was then persisted — so every later run
tripped the same guard on its first page and examined zero documents. That cursor
is now **discarded**, restoring the pre-cursor behaviour where everything below the
bad page was still cleaned nightly.

🟡 **The backoff budget did not bound what its comment claimed.** It exempted the
first re-ask of every empty page, so it bounded nothing about how many could be
confirmed. Every delay is now charged; an exhausted budget still confirms once, at
500 ms (it had regressed to the 1000 ms escalation step).

🟡 **Two comments were false and safety-relevant** — both said an undeleted stale
document is picked up by "the next nightly run", which is not true under resumable
scanning. Corrected, with the latency trade stated (see above).

🟡 **`covered` was validated only as a finite non-negative number**, yet it is the
sole input to both coverage judgements. Now bounded by `lastId + 1`, a structural
invariant. The rebuilt-index case it cannot see (a shrunken `totalInIndex` against a
carried-forward `covered`) is documented and self-heals in one night.

Also fixed while in there: an index the engine reports as **empty** no longer
divides by zero into a NaN coverage.

### Round 2 — the delta re-audit (third commit)

The re-audit confirmed the 🔴 and all five 🟡s genuinely fixed, executing an 18-mutant
battery of its own to check rather than tracing it. It then found four more.

🟡 **The band constants were still not pinned by value — and consolidating made them
more load-bearing, not less.** Before, `COVERAGE_SHORTFALL_RATIO` and
`COVERAGE_SHORTFALL_FLOOR` decided a log line; after, they are the single decision for
both `incomplete` and whether a truncated pass keeps its cursor. Measured with all 87
tests green: `RATIO → 0.15`, `RATIO → 0.39`, `FLOOR → 800` and `FLOOR → 3000` **all
survived** — the six-row table brackets them only to roughly [0.15, 0.4) and
[800, 3000]. The identical value pin had already been written for the empty-page
constants, with a comment stating the lesson, and simply was not applied to the pair the
consolidation promoted. Pinned; all four mutants now die (N1–N4).

🟡 **`cursorCleared: true` fired when there was nothing to clear.** `clearScanCursor`
discarded `hDel`'s count and returned `true` unconditionally, so *every* healthy nightly
run of *all seven* indexes carried "cursor cleared — the next run starts over", and the
field stopped meaning "a stored cursor was discarded" — the exact noise deliberately
suppressed for `cursorDiscardReason: 'missing'`, arriving from the other side.

🔴 **The suite could not see it, because a fixture encoded a shape production could not
produce**: the job's healthy-pass helper defaulted `cursorCleared: false`, so a test
asserted a message the real code would never emit for that scenario. `clearScanCursor`
now returns `'cleared' | 'absent' | 'failed'` — `absent` is genuinely a third outcome,
since folding it into `failed` would raise an error every night on every index (N6
proves that direction is now caught too). Both directions are pinned by tests against
the *real* scan, and the fixture matches what production produces.

🟡 **The wedge fix was over-broad.** It discarded the cursor whenever the monotonicity
guard fired, with no condition on whether the run had advanced — so a guard firing after
hours of progress threw the whole pass away and restarted at the bottom, which is the
exact cost this PR exists to eliminate. The wedge only exists when the guard fires on the
**first page of a resumed run**, where persisting reproduces the same abort forever.
Narrowed to `cursorUnadvanceable && lastId === resumedFrom`, and the progress-losing
shape — guard fires deep into a resumed pass ⇒ cursor **kept** — is now tested.

🟢 **The clear-failure message asserted "after a completed pass"** on a path where the
pass explicitly did not complete. It now names the wedge case, and a test pins that it
does *not* claim completion there.

Explicitly left alone at the re-audit's direction: the tightened band making a
scan-≈0-documents state reachable at lower drift (loud, and self-healing — a real
consequence of consolidating onto the stricter number), and `cleanup-coverage.ts` having
no dedicated test file (testing it through both consumers is what makes the seam
assertion meaningful).

Filed as follow-ups, deliberately not in this PR: intra-run checkpointing; the
seven-day bound's headroom; CAS for overlapping runs; orphan hash fields when an
index leaves the set.

---

## Tests

**92 tests across the two files, green at HEAD (counted `✓`, not an exit code).**
31 pre-existing, 61 new.

### Red-at-base matrix

Base = `origin/main` sources for `cleanup.ts` and `search-index-cleanup.ts`, with
the two new leaf modules present (their absence is a module-not-found, not a
behavioural red).

| | at base | at HEAD |
|---|---|---|
| 31 pre-existing tests | **31 pass** (control) | 31 pass |
| 54 new tests | **RED** | green |
| 7 new tests | green | green |

**54 red at base**, covering: resume from a stored cursor (and *not* at `cursor±1`
— the exact filter sequence is pinned); reset after a genuine completion, plus the
next run then starting from the bottom; the six-row coverage band deciding
keep-vs-clear; the mid-ingest suppression; persisting after a stopped-early or
cancelled run; discarding an unadvanceable cursor; the staleness bound in both
directions; every unusable-stored-value case including the four new `covered` ones;
store read, write and clear failures raising errors; escalating backoff carrying the
scan past a transient empty page; the budget clamp and its cheap-confirm fallback;
the trust-coverage band from both sides; cumulative progress across two runs; and
the job-side reporting and identity cases.

**7 green-at-base, labelled as such and NOT counted as regression coverage:**

- `pins the bound at seven days`, `pins the empty-page constants by value` and
  `pins the coverage band constants by value` — value pins on constants; the
  behavioural tests read them through the symbol, which is what makes them blind to the
  value changing. Killed by M36 / M19-M21-M27 / N1-N4.
- `treats a FUTURE-dated cursor as stale` — a direct unit assertion on the new
  `readScanCursor`. Killed by M35.
- `reports no coverage for an EMPTY index rather than NaN` — a guard on pre-existing
  job behaviour that the refactor had to preserve. Killed by M13.
- the three `COVERAGE_BAND` rows that expect `incomplete=true` — the job at base
  already alarmed below 75%, so those rows pass there. The three `incomplete=false`
  rows are red at base, and the cursor-side half of every row is red at base.

Two tests titled `INVARIANT GUARD` pin behaviour that is unchanged from base (a scan
without `resumable` must not touch the store; a genuinely exhausted index still ends
on one cheap confirm). They fail at base only because they read fields that do not
exist there, so they are not counted as regression coverage either — their value is
the mutants they kill.

### Cumulative progress

Asserted end-to-end, not per-run: run 1 covers a 300-document prefix of an 8000-
document index and is truncated by a confirmed-empty page at low coverage; run 2
resumes from the persisted cursor and covers the remaining 7700. The assertion is on
the **union of the ids the engine actually served** across both runs — equal to the
whole index — plus a positive statement that run 2 re-walked nothing run 1 had
covered. Per-run counts cannot tell "run 2 covered 7700 documents" from "run 2
re-covered the same 300, repeatedly".

### Mutation battery — round 3, re-run in full

Each fix round resets the gate, so the whole battery was re-derived and re-run, not just
mutants for what changed: **59 mutants, 58 killed, 1 equivalent.** Same discipline
throughout — pristine copy per mutant, mutation verified to have landed on disk, verdicts
read from vitest's counted summary (never an exit code), files restored byte-for-byte
between mutants, positive control travelling in the batch (M48, killed, 22 tests).

Every constant that decides anything is now pinned by value *and* bracketed by
behavioural fixtures: the band pair (N1–N4, after all four survived round 2), the
staleness bound (M36), and the empty-page schedule, trust threshold and budget
(M19–M21, M27). `COMPLETION_MIN_COVERAGE` no longer exists — the band is shared, and its
two constants are killed in both directions (M8–M11).

| # | mutation | verdict |
|---|---|---|
| M1 / M2 / M3 | resume at `cursor+1` / `cursor-1` / ignore the cursor | KILLED |
| M4 | **AUDIT REGRESSION**: `cleanupIndex` re-grows its own 50% threshold | KILLED |
| M5 | trust the empty page alone (`reachedEnd := !stoppedEarly`) | KILLED |
| M6 / M7 | always / never reached the end | KILLED |
| M8 / M9 | shortfall FLOOR 1000 → 100 / → 5000 | KILLED |
| M10 / M11 | shortfall RATIO 0.25 → 0.05 / → 0.75 | KILLED |
| M12 | mid-ingest suppression clause removed | KILLED |
| M13 | coverage divides by a zero total (NaN) | KILLED |
| M14 / M15 | pass coverage forgets earlier runs / skipped ids | KILLED |
| M16 | backoff never escalates | KILLED |
| M17 / M18 | coverage never consulted — always cheap / always escalate | KILLED |
| M19 / M20 | trust-coverage 0.9 → 0.5 / → 0.99 | KILLED |
| M21 | cheap confirm delay 500 → 1000 | KILLED |
| M22 | empty page believed on sight | KILLED |
| M23 | **AUDIT**: backoff budget check removed entirely | KILLED |
| M24 | **AUDIT**: budget exempts the first re-ask again | KILLED |
| M25 | **AUDIT**: exhausted budget stops confirming altogether | KILLED |
| M26 | **AUDIT**: post-exhaustion confirm uses the 1 s step | KILLED |
| M27 | budget default 5 min → 50 min | KILLED |
| M28 | persist/clear branches swapped | KILLED |
| M29 | **AUDIT**: an unadvanceable cursor is persisted | KILLED |
| M30 / M31 | **AUDIT**: a failed clear / persist is silent | KILLED |
| M32 | `cursorCleared` never reported | KILLED |
| M33 / M34 / M35 | staleness bound inverted / off-by-one / future-date guard removed | KILLED |
| M36 | staleness bound widened 10× | KILLED |
| M37 / M38 / M39 | fail-safe inverted: unparseable skips ahead / `lastId` coerced / unreadable trusted | KILLED |
| M40 | **AUDIT**: `covered` not validated against `lastId` | KILLED |
| M41 | **AUDIT**: `covered` bound off by one (`> lastId`) | KILLED |
| M42 | `covered` negativity check removed | KILLED |
| M43 | the nightly job stops opting into the cursor | KILLED |
| M44 | the job reads coverage off the run, not the pass | KILLED |
| M45 | the job re-grows its own 75% threshold | **EQUIVALENT** |
| M46 / M47 | the job hides the cursor notes / the cleared-cursor note | KILLED |
| N1 / N2 | **RE-AUDIT**: shortfall RATIO 0.25 → 0.15 / → 0.39 (both survived round 2) | KILLED |
| N3 / N4 | **RE-AUDIT**: shortfall FLOOR 1000 → 800 / → 3000 (both survived round 2) | KILLED |
| N5 | **RE-AUDIT**: `clearScanCursor` claims a clear unconditionally | KILLED |
| N6 | **RE-AUDIT**: nothing-to-clear reported as a failure (nightly false alarm) | KILLED |
| N7 | **RE-AUDIT**: a real clear reported as absent | KILLED |
| N8 | **RE-AUDIT**: wedge fix broadened again (discards after real progress) | KILLED |
| N9 | **RE-AUDIT**: wedge fix disabled entirely (index stays wedged) | KILLED |
| N10 | **RE-AUDIT**: wedge discriminator inverted | KILLED |
| N11 | **RE-AUDIT**: clear-failure message claims a completed pass on the wedge path | KILLED |
| M48 | POSITIVE CONTROL — the scan starts one page in | KILLED (22 tests) |

**M45 is declared equivalent, not omitted.** It inlines the shared predicate into the
job with the *same* constants, so it computes the same verdict on every input and no
behavioural test can distinguish it — what it breaks is single-source-of-truth, which
is structural. The hazard that actually matters is a copy that *disagrees*, and that is
M4, which dies: the `COVERAGE_BAND` tables catch divergence, which is the defect this
round fixed.

Two mutants remain equivalent under this fixture set and are likewise declared:
`lastId >= 0` → `> 0` on the persist branch (differs only for a pass that stopped having
covered exactly id 0), and the `covered`/`lastId` bound at a cursor of `-1`.

N6 initially survived round 3 — the "nothing was stored" test asserted the flag but not
that the run stayed error-free. Reported here as killed only after adding that assertion
and re-running it alongside the positive control.

### Other checks

- **Full `unit*` project**: 1396 files passed, 1 skipped; **21939 tests passed, 25
  skipped, 0 failed**. Canonical shared mocks used throughout
  (`~/__tests__/mocks/db.mock`, `redis.mock`, `logging.mock`);
  `direct-mock-allowlist.json` is untouched.
- **`pnpm typecheck`**: 0 errors.
- **`tsc -p tsconfig.tests.json`**: 921 errors at base and 921 at HEAD, measured on
  this tree. Compared as sets of `file(line,col): error TSxxxx`, the diff is **empty**
  — **delta 0** — and no error is reported in any file this PR touches.
- **ESLint**: 0 problems on the seven changed files. The instrument was validated
  against a throwaway file with real violations, which it reported.
- **Prettier**: clean this round; all files byte-identical to `prettier <file>` output,
  checked per file with `cmp` rather than relying on the `--check` success sentence
  (which also prints on zero matches).
