### PR TITLE
fix(prompt-audit): strip benign phrases from the normalized prompt

### DIFF
--- a/src/server/services/orchestrator/__tests__/promptAuditing.benign-phrases.accents.test.ts
+++ b/src/server/services/orchestrator/__tests__/promptAuditing.benign-phrases.accents.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A moderator-whitelisted phrase must stay whitelisted when the creator spells it with an
+ * accent. `auditPromptEnriched` folds accents (`normalizeText`) before the detector runs, so
+ * the strip has to run over that same folded text — stripping the RAW prompt matched one
+ * alphabet while the detector read another, and `émma stone` was blocked while the identical
+ * plain spelling was allowed.
+ *
+ * 🔴 If this file fails, do NOT repair it by handing `stripBenignPhrases` the raw prompt
+ * again. That is the defect, and it goes green. The plain-ASCII case below is the control:
+ * it passes with and without the fix, so a run where only the accented case fails is the
+ * ordering bug and nothing else.
+ *
+ * The source guard from #4375 cannot see this path — it scans `includesPoi(` call sites and
+ * the POI check here lives inside `auditPromptEnriched`. This behavioural test is the guard.
+ */
+
+const { mockStripBenignPhrases, mockModeratePrompt, mockProhibited } = vi.hoisted(() => ({
+  mockStripBenignPhrases: vi.fn(),
+  mockModeratePrompt: vi.fn(async () => ({ flagged: false, categories: [] as string[] })),
+  mockProhibited: vi.fn(),
+}));
+
+vi.mock('~/server/services/blocklist.service', () => ({
+  stripBenignPhrases: mockStripBenignPhrases,
+}));
+vi.mock('~/server/integrations/moderation', () => ({
+  extModeration: { moderatePrompt: mockModeratePrompt },
+}));
+
+import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
+import { buildBenignPhraseRegex, stripBenignPhrasesWith } from '~/shared/utils/benign-phrases';
+import { includesPoi } from '~/utils/metadata/audit';
+import { normalizeText } from '~/utils/normalize-text';
+import '~/__tests__/mocks/db.mock';
+import '~/__tests__/mocks/logging.mock';
+import '~/__tests__/mocks/redis.mock';
+
+// `emma stone` is a real entry in words-poi.json, so the detector genuinely fires on it —
+// the whitelist is the only thing that can clear these prompts.
+const WHITELIST = ['emma stone'];
+
+const optionsFor = (prompt: string) => ({
+  prompt,
+  negativePrompt: '',
+  userId: 5,
+  isGreen: false,
+  track: { prohibitedRequest: mockProhibited },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const pattern = buildBenignPhraseRegex(WHITELIST);
+  mockStripBenignPhrases.mockImplementation(async (text: string | undefined) =>
+    stripBenignPhrasesWith(text, pattern)
+  );
+});
+
+describe('auditPromptServer — a whitelisted phrase stays whitelisted when accented', () => {
+  it('the detector fires on both spellings without the whitelist', () => {
+    expect(includesPoi(normalizeText('emma stone portrait'))).toBe('emma stone');
+    expect(includesPoi(normalizeText('émma stone portrait'))).toBe('emma stone');
+  });
+
+  it('allows the plain spelling (control — green with and without the fix)', async () => {
+    await expect(auditPromptServer(optionsFor('emma stone portrait'))).resolves.toBeUndefined();
+    expect(mockProhibited).not.toHaveBeenCalled();
+  });
+
+  it('allows the accented spelling', async () => {
+    await expect(auditPromptServer(optionsFor('émma stone portrait'))).resolves.toBeUndefined();
+    expect(mockProhibited).not.toHaveBeenCalled();
+  });
+
+  it('still blocks a POI name that is NOT whitelisted, accented or not', async () => {
+    await expect(auditPromptServer(optionsFor('tom cruise portrait'))).rejects.toThrow();
+    await expect(auditPromptServer(optionsFor('tóm cruise portrait'))).rejects.toThrow();
+  });
+});

--- a/src/server/services/orchestrator/__tests__/promptAuditing.benign-phrases.accents.test.ts
+++ b/src/server/services/orchestrator/__tests__/promptAuditing.benign-phrases.accents.test.ts
@@ -41,6 +41,10 @@ import '~/__tests__/mocks/redis.mock';
 // the whitelist is the only thing that can clear these prompts.
 const WHITELIST = ['emma stone'];
 
+// What both spellings must audit down to: the phrase blanked to one space, the separator that
+// preceded `portrait` still there. Measured, not guessed — an earlier single-space guess failed.
+const AUDITED = '  portrait';
+
 const optionsFor = (prompt: string) => ({
   prompt,
   negativePrompt: '',
@@ -63,18 +67,45 @@ describe('auditPromptServer — a whitelisted phrase stays whitelisted when acce
     expect(includesPoi(normalizeText('émma stone portrait'))).toBe('emma stone');
   });
 
+  // Asserting the audited text, not just that the promise resolved. `moderatePrompt` is the
+  // last consumer of the audited copy, so its argument IS that copy — which pins that exactly
+  // the phrase was blanked. `resolves` alone stays green if a future strip swallows the whole
+  // prompt, and an empty audited prompt short-circuits the detector into success for anything.
   it('allows the plain spelling (control — green with and without the fix)', async () => {
     await expect(auditPromptServer(optionsFor('emma stone portrait'))).resolves.toBeUndefined();
+    expect(mockModeratePrompt).toHaveBeenCalledWith(AUDITED);
     expect(mockProhibited).not.toHaveBeenCalled();
   });
 
   it('allows the accented spelling', async () => {
     await expect(auditPromptServer(optionsFor('émma stone portrait'))).resolves.toBeUndefined();
+    expect(mockModeratePrompt).toHaveBeenCalledWith(AUDITED);
     expect(mockProhibited).not.toHaveBeenCalled();
   });
 
+  // `toThrow(/celebrity names/)` rather than a bare `toThrow`: the catch in auditPromptServer is
+  // blanket, so a TypeError from a broken mock also rejects and a bare matcher calls that a pass
+  // on a run where the POI gate never fired.
   it('still blocks a POI name that is NOT whitelisted, accented or not', async () => {
-    await expect(auditPromptServer(optionsFor('tom cruise portrait'))).rejects.toThrow();
-    await expect(auditPromptServer(optionsFor('tóm cruise portrait'))).rejects.toThrow();
+    await expect(auditPromptServer(optionsFor('tom cruise portrait'))).rejects.toThrow(
+      /celebrity names/
+    );
+    await expect(auditPromptServer(optionsFor('tóm cruise portrait'))).rejects.toThrow(
+      /celebrity names/
+    );
+  });
+
+  // The only place in the suite where raw-vs-normalized is observable: every other prompt
+  // constant is pure ASCII, so `normalizeText` is the identity on it and an assertion naming
+  // the raw text passes either way. Reporting must keep the accent — it is the evidence a
+  // moderator needs on an obfuscated prompt.
+  it('reports the RAW prompt, accent intact, when the audit blocks', async () => {
+    await expect(auditPromptServer(optionsFor('tóm cruise portrait'))).rejects.toThrow(
+      /celebrity names/
+    );
+
+    expect(mockProhibited).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: 'tóm cruise portrait' })
+    );
   });
 });

--- a/src/server/services/orchestrator/promptAuditing.ts
+++ b/src/server/services/orchestrator/promptAuditing.ts
@@ -7,6 +7,7 @@ import { decodeRedisString } from '~/server/redis/buffer-decode';
 import { stripBenignPhrases } from '~/server/services/blocklist.service';
 import { applyPendingReviewMute } from '~/server/services/user-restriction.service';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
+import { normalizeText } from '~/utils/normalize-text';
 import {
   auditPromptEnriched,
   isSoftBlock,
@@ -246,9 +247,14 @@ export async function auditPromptServer(options: AuditPromptOptions): Promise<vo
     // generation gate and the post-generation scan audit agree on what's benign.
     // Only the audited copy is cleaned — the original prompt is what gets generated,
     // reported to ClickHouse, and stored on the blocked-prompt entry below.
+    //
+    // 🔴 Strip the NORMALIZED copy. `auditPromptEnriched` folds accents before the
+    // detector runs, so stripping raw text matches one alphabet while the detector
+    // reads another and a whitelisted `emma stone` still blocks `émma stone`. The
+    // scan paths in image-scan-result.service.ts already normalize first.
     const [auditedPrompt, auditedNegativePrompt] = await Promise.all([
-      stripBenignPhrases(prompt, BlocklistType.PromptBenignPhrase),
-      stripBenignPhrases(negativePrompt, BlocklistType.NegativeBenignPhrase),
+      stripBenignPhrases(normalizeText(prompt), BlocklistType.PromptBenignPhrase),
+      stripBenignPhrases(normalizeText(negativePrompt), BlocklistType.NegativeBenignPhrase),
     ]);
 
     // Run regex-based audit (enriched to capture structured trigger data)


### PR DESCRIPTION
@
## The bug, live today

`auditPromptServer` strips the moderator benign-phrase whitelist from the **raw** prompt, but `auditPromptEnriched` folds accents (`normalizeText`) before the POI/minor detector reads it. The strip matches one alphabet and the detector reads another, so a whitelisted phrase stops being whitelisted the moment a creator spells it with an accent.

Measured, with `emma stone` on the whitelist:

| prompt | before | after |
| --- | --- | --- |
| `emma stone portrait` | allowed | allowed |
| `émma stone portrait` | **blocked** | allowed |

The plain spelling is the control: it is allowed both ways, so the accent is the whole difference. This blocks every creator, not a subset.

## The fix

Normalize before stripping — which is what the two scan paths in `image-scan-result.service.ts` already do. `promptAuditing.ts` was the lone outlier; this makes it four of four server call sites.

## What does not change

The raw prompt still reaches everything it reached before: what gets generated, what `reportProhibitedRequest` sends to ClickHouse, and what is stored on the blocked-prompt entry. There is now a test that would fail if that changed.

## A decision, stated rather than slipped in

The stripped copy is also what reaches `extModeration.moderatePrompt`, so the external classifier now receives normalized text instead of raw. That is consistent with the regex detector and with the scan paths, and an accent-obfuscated prompt no longer arrives at the classifier obfuscated. Raised with Justin separately rather than left as a side effect.

Worth noting precisely: the classifier receives normalized text for **every** prompt, not only ones that hit the whitelist — `stripBenignPhrases` returns its input untouched when the pattern is null, so the normalize is unconditional.

## A second user-visible change, found in review

`MAX_AUDIT_PROMPT_LENGTH` (20,000) is checked *inside* `auditPromptEnriched`, **before** it normalizes. Moving the normalize earlier means the gate now measures the expanded string.

Measured NFD expansion: **Hangul 2.4-3.0x**, **Arabic ~1.2-2.0x**, Latin/Cyrillic/Vietnamese 1.0x. So a 7,000-char Korean prompt is 21,000 chars after folding - raw passes the gate, normalized does not, and it now returns `Prompt exceeds the maximum allowed length` where it previously audited normally. Threshold is roughly 6,667-8,333 Korean chars, ~10,000 Arabic.

Sized as honestly as the data allows: across 91,844 rows of `prohibitedRequests` over 30 days the longest prompt of any script is 5,998 chars and Hangul appears in 0.07% of rows, so nothing observed comes close. That table holds blocked prompts only, so it is a biased sample, and no table holds all submitted prompts - very likely unreachable, not provably so.

The other side of it: before this change a 20,000-char Korean prompt passed the gate and then expanded to 60,000, so the POI and nsfw lists scanned 3x past the cap. That amplification is now closed.

Accepted deliberately rather than shipped silently.

## Verification

Every assertion in the new file has a demonstrated failure mode, each reddening only its own test:

| control | result |
| --- | --- |
| revert the fix | `Tests 1 failed \| 4 passed (5)` — only `allows the accented spelling` |
| send normalized text to `reportProhibitedRequest` | `Tests 1 failed \| 4 passed (5)` — only `reports the RAW prompt` |

- `pnpm run typecheck` — 0 errors.
- `pnpm run test:lint-rules` — `Test Files 20 passed (20)`, `Tests 336 passed (336)`.
- `pnpm run test:unit:run` — `Test Files 1 failed | 1400 passed | 1 skipped (1402)`. The one failure is `src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts`, a Windows path-separator assertion (`src/pages/...` vs `src\pages\...`), pre-existing: it fails identically on the unmodified base, confirmed on two separate clean runs.
- `blocks.router.workflow.test.ts` collected 358 tests, so the submodule is initialised and the run means something.

## Reviewed

Five review lanes over the diff, prompted to refute. No lane could make the fix more permissive on any path — the change makes the strip and the detector read the same string, which is strictly safer than the pre-fix state. Two follow-ups came out of it that are not in this PR because they change what a moderator whitelist entry *means*; both are with Justin, and neither has live impact today (checked prod: 15 benign-phrase entries, 0 non-ASCII).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@
