### PR TITLE
fix(placement): exclude private host posts from the placement image read

### DIFF
--- a/src/server/selectors/placement-image.selector.ts
+++ b/src/server/selectors/placement-image.selector.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@prisma/client';
+import { Availability } from '~/shared/utils/prisma/enums';
 
 /**
  * The host image behind a placement, as every placement surface reads it.
@@ -48,11 +49,27 @@ export const placementImageSelect = Prisma.validator<Prisma.ImageSelect>()({
  * added here does NOT reach the remix gallery and has to be added there too —
  * `acceptableMinor`, the clause this docblock calls out, was already missing
  * from that copy once. The two also differ deliberately today: the SQL copy
- * excludes private posts, level 0, and licence-restricted images, and this one
- * leaves those to its caller.
+ * excludes level 0 and licence-restricted images, and this one leaves those to
+ * its caller.
+ *
+ * 🔴 Published is not public. A post inherits its availability from the model
+ * version, so it can be published AND private, and nothing on the placement
+ * submission path reads the column — such an image is stickered and approved
+ * normally, and only turns private afterwards. Surfaces that hydrate through
+ * `getAllImages` never needed this because that carries its own private guard;
+ * this read does not hydrate, so without the clause it hands back the url of an
+ * image its owner marked not-public. Same defect, same fix as `entryIsVisible`
+ * in `remix-gallery.service.ts` (#4364).
+ *
+ * No owner arm, deliberately, for the same reason it has none there:
+ * `getAllImages` re-admits a private image to its own author, which is right on
+ * their own feed and wrong on a surface built around somebody else's picture.
  */
 export const publishedPlacementImageWhere = (): Prisma.ImageWhereInput => ({
-  post: { publishedAt: { not: null, lte: new Date() } },
+  post: {
+    publishedAt: { not: null, lte: new Date() },
+    availability: { not: Availability.Private },
+  },
   ingestion: 'Scanned',
   tosViolation: false,
   minor: false,

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { NsfwLevel } from '~/server/common/enums';
+import { Availability } from '~/shared/utils/prisma/enums';
 import {
   allBrowsingLevelsFlag,
   sfwBrowsingLevelsFlag,
@@ -1781,7 +1782,10 @@ describe('getMyStickerPlacements', () => {
     // `publishedAt: { not: null }` check that has been here all along.
     expect(where).toEqual({
       id: { in: [IMAGE] },
-      post: { publishedAt: { not: null, lte: expect.any(Date) } },
+      post: {
+        publishedAt: { not: null, lte: expect.any(Date) },
+        availability: { not: Availability.Private },
+      },
       ingestion: 'Scanned',
       tosViolation: false,
       minor: false,
@@ -1789,6 +1793,31 @@ describe('getMyStickerPlacements', () => {
       needsReview: null,
       acceptableMinor: false,
     });
+  });
+
+  /**
+   * 🔴 Named for the decision so it is not refactored away as a duplicate of the
+   * assertion above. Published and public are different columns: a post inherits
+   * its availability from its model version, so a sticker is placed and approved
+   * on an image that is live, and the owner turns the post private afterwards.
+   * Nothing on the placement path reads the column, and this read does not go
+   * through `getAllImages`, so this clause is the only thing standing between
+   * the placer's list and a url its owner marked not-public.
+   *
+   * Asserted on the ARGUMENT because the Prisma mock ignores `where` entirely —
+   * a row filter written over the returned fixtures would pass with the clause
+   * deleted. Deliberately no owner arm; see the selector's docblock.
+   */
+  it('excludes a private host post from the placer list', async () => {
+    placementFindMany.mockResolvedValue([sentRow(1)]);
+    imageFindMany.mockResolvedValue([hostImage()]);
+
+    await getMyStickerPlacements({ placerId: PLACER, ...LEVELS });
+
+    const { where } = imageFindMany.mock.calls.at(-1)?.[0] as {
+      where: { post?: Record<string, unknown> };
+    };
+    expect(where.post?.availability).toEqual({ not: Availability.Private });
   });
 
   it('keeps the row when the host image fails those rules', async () => {

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -1814,6 +1814,13 @@ describe('getMyStickerPlacements', () => {
 
     await getMyStickerPlacements({ placerId: PLACER, ...LEVELS });
 
+    // ONE read, asserted before the argument is. Both assertions here read
+    // `calls.at(-1)`, so a second unfiltered `image.findMany` added ahead of
+    // this one — its rows merged into the same map — leaves the last call
+    // compliant and every argument check green while the urls it fetched flow
+    // out. The count is what makes that unwritable.
+    expect(imageFindMany).toHaveBeenCalledTimes(1);
+
     const { where } = imageFindMany.mock.calls.at(-1)?.[0] as {
       where: { post?: Record<string, unknown> };
     };


### PR DESCRIPTION
Ticket `868kwb8z6`.

## The gap

A post inherits its `availability` from its model version, so it can be **published AND private**, and nothing on the sticker placement path reads the column — a sticker is placed and approved on an image that is live, and the owner turns the post private afterwards.

`getMyStickerPlacements` (the placer's own "where did my sticker end up" list) fetches the host image with a direct `image.findMany` rather than hydrating through `getAllImages`, so it inherited none of that path's private guard and kept serving the host image's `url` after the post went private.

This is the same defect and the same fix as `entryIsVisible` in `remix-gallery.service.ts`, which landed in #4364. The general rule: **a read that skips hydration inherits none of hydration's guards.**

## The fix

One clause, in the shared `publishedPlacementImageWhere()` rather than at the caller — that helper's stated contract is "whether a host image may be shown at all, independent of who is looking", which is exactly what availability is. The viewer/domain-dependent rules (browsing level, licence restriction) stay at the caller as before.

No owner arm, deliberately, matching the #4364 precedent: `getAllImages` re-admits a private image to its own author, which is right on their own feed and wrong on a surface built around somebody else's picture.

## Scope, measured

`publishedPlacementImageWhere()` has exactly one caller (`sticker-placement.service.ts:1136`). The owner queue reads the owner's own uploads unfiltered by design, and the sticker book hydrates through `getAllImages`, so neither is affected.

## Live exposure: zero rows today

Measured against the prod replica before writing any code:

| | |
|---|---|
| sticker placements, all statuses | 2,362 |
| of those, `pending`/`approved` with a joinable post | 2,000 |
| of those, host post `availability = 'Private'` | **0** |

Positive control for that zero: **2,607** posts in prod are published *and* Private, so the predicate is capable of matching — the intersection with sticker placements is genuinely empty right now. So this is a **latent gap with no live instances**, not an active leak.

## Control

Reverting the one clause and re-running the suite:

```
FAIL  getMyStickerPlacements > fetches the host image under the public visibility rules
FAIL  getMyStickerPlacements > excludes a private host post from the placer list
AssertionError: expected undefined to deeply equal { not: 'Private' }
Test Files  1 failed (1)
     Tests  2 failed | 96 passed (98)     exit 1
```

Restored: `98 passed (98)`, exit 0. The failure names the missing value rather than timing out.

The new test is asserted on the **argument** to `image.findMany`, not on returned rows, because the Prisma mock ignores `where` entirely — a filter written over returned fixtures would pass with the clause deleted. It is named for the decision so it is not later removed as a duplicate of the assertion above it.

## Verification

- `pnpm run typecheck` — OK, 0 type errors
- `pnpm run lint` — repo-wide red (362 pre-existing errors across 1,337 files); **neither file in this diff appears in the output**
- `pnpm exec prettier` — both files already formatted
- `pnpm run test:unit:run` — `Test Files 1 failed | 1409 passed | 1 skipped (1411)`, exit 1. The one failure is `pageRunScrollContract.test.ts`, a Windows path-separator assertion (`src\pages\...` vs `src/pages/...`); confirmed pre-existing by stashing this diff and re-running that file on the same base — still red.
- `blocks.router.workflow.test.ts` collected **358 tests**, so the submodule is initialised and the run is meaningful.
