### PR TITLE
feat(placements): link out to your sticker book from the sticker queue

### DIFF
--- a/src/components/Placement/PlacementsPanel.tsx
+++ b/src/components/Placement/PlacementsPanel.tsx
@@ -1,8 +1,8 @@
 import { Anchor, Container, Group, SegmentedControl, Stack, Text, Title } from '@mantine/core';
 import { IconSticker } from '@tabler/icons-react';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Meta } from '~/components/Meta/Meta';
+import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { useQueryNotificationsCount } from '~/components/Notifications/notifications.utils';
 import { QueueCountBadge } from '~/components/Placement/QueueCountBadge';
 import { RemixSubmissionQueue } from '~/components/Placement/RemixSubmissionQueue';
@@ -12,6 +12,7 @@ import {
   PLACEMENT_SURFACE_TABS,
   type PlacementSurfaceTab,
 } from '~/components/Placement/queue-routes';
+import { stickerBookUrl } from '~/components/StickerBook/sticker-book.util';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 
@@ -59,7 +60,7 @@ export function PlacementsPanel() {
   // redirects a flag-less viewer away rather than rendering.
   const stickerBookHref =
     features.stickerBook && currentUser?.username
-      ? `/user/${currentUser.username}/sticker-book`
+      ? stickerBookUrl(currentUser.username)
       : undefined;
 
   const counts: Record<PlacementSurfaceTab, number> = {

--- a/src/components/Placement/PlacementsPanel.tsx
+++ b/src/components/Placement/PlacementsPanel.tsx
@@ -1,4 +1,6 @@
-import { Container, SegmentedControl, Stack, Text, Title } from '@mantine/core';
+import { Anchor, Container, Group, SegmentedControl, Stack, Text, Title } from '@mantine/core';
+import { IconSticker } from '@tabler/icons-react';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Meta } from '~/components/Meta/Meta';
 import { useQueryNotificationsCount } from '~/components/Notifications/notifications.utils';
@@ -10,6 +12,8 @@ import {
   PLACEMENT_SURFACE_TABS,
   type PlacementSurfaceTab,
 } from '~/components/Placement/queue-routes';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 
 /**
  * Everything waiting on this creator, in one place.
@@ -31,6 +35,8 @@ import {
  */
 export function PlacementsPanel() {
   const router = useRouter();
+  const currentUser = useCurrentUser();
+  const features = useFeatureFlags();
   const { pendingStickerPlacements, pendingRemixSubmissions } = useQueryNotificationsCount();
 
   const surface: PlacementSurfaceTab = isPlacementSurfaceTab(router.query.type)
@@ -49,6 +55,13 @@ export function PlacementsPanel() {
       { shallow: true }
     );
 
+  // No username, no link: the book is a profile route, and the page itself
+  // redirects a flag-less viewer away rather than rendering.
+  const stickerBookHref =
+    features.stickerBook && currentUser?.username
+      ? `/user/${currentUser.username}/sticker-book`
+      : undefined;
+
   const counts: Record<PlacementSurfaceTab, number> = {
     sticker: pendingStickerPlacements,
     remix: pendingRemixSubmissions,
@@ -65,6 +78,15 @@ export function PlacementsPanel() {
               <Text size="sm" c="dimmed">
                 What is waiting on your images, and what you have sent to other creators&apos;.
               </Text>
+              {/* Sticker surface only: the remix queue has no book behind it. */}
+              {surface === 'sticker' && stickerBookHref && (
+                <Anchor component={Link} href={stickerBookHref} size="sm" mt={4}>
+                  <Group gap={4} wrap="nowrap">
+                    <IconSticker size={14} />
+                    Your sticker book
+                  </Group>
+                </Anchor>
+              )}
             </div>
 
             <SegmentedControl

--- a/src/components/Placement/__tests__/placements-panel.browser.test.tsx
+++ b/src/components/Placement/__tests__/placements-panel.browser.test.tsx
@@ -21,7 +21,7 @@ import { renderWithProviders } from '../../../../test/component-setup';
 const { sticker, remix, viewer } = vi.hoisted(() => ({
   sticker: { value: 0 },
   remix: { value: 0 },
-  viewer: { username: 'zippy' as string | null, stickerBook: true },
+  viewer: { signedIn: true, username: 'zippy' as string | undefined, stickerBook: true },
 }));
 
 // `next/router` is stubbed by the shared harness (test/component-setup), and a
@@ -38,7 +38,9 @@ vi.mock('~/components/Notifications/notifications.utils', () => ({
 }));
 vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
 vi.mock('~/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => (viewer.username ? { id: 7, username: viewer.username } : null),
+  // Signed-in-ness and having a username are separate states: `username` is
+  // optional on the session, so a signed-in account can carry none.
+  useCurrentUser: () => (viewer.signedIn ? { id: 7, username: viewer.username } : null),
 }));
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ stickerBook: viewer.stickerBook }),
@@ -57,6 +59,7 @@ beforeEach(() => {
   useRouter().query = {};
   sticker.value = 0;
   remix.value = 0;
+  viewer.signedIn = true;
   viewer.username = 'zippy';
   viewer.stickerBook = true;
 });
@@ -165,8 +168,21 @@ describe('the way out to the sticker book', () => {
     expect(bookLink().elements()).toHaveLength(0);
   });
 
-  test('is gone when there is no signed-in username to build it from', async () => {
-    viewer.username = null;
+  test('is gone when nobody is signed in', async () => {
+    viewer.signedIn = false;
+    renderWithProviders(<Placements />);
+
+    await expect.element(page.getByText('sticker queue')).toBeInTheDocument();
+    expect(bookLink().elements()).toHaveLength(0);
+  });
+
+  test('is gone for a signed-in account that has no username yet', async () => {
+    // 🔴 This is what the `?.username` gate is FOR, and it is not the test above.
+    // `username` is optional on the session, so a pre-onboarding account is
+    // signed in with none. Gate on the USER instead of the USERNAME and every
+    // other test here still passes while this one renders
+    // `/user/undefined/sticker-book`. Do not merge these two cases back together.
+    viewer.username = undefined;
     renderWithProviders(<Placements />);
 
     await expect.element(page.getByText('sticker queue')).toBeInTheDocument();

--- a/src/components/Placement/__tests__/placements-panel.browser.test.tsx
+++ b/src/components/Placement/__tests__/placements-panel.browser.test.tsx
@@ -18,9 +18,10 @@ import { renderWithProviders } from '../../../../test/component-setup';
  * "mark all as read" once wiped for the whole session.
  */
 
-const { sticker, remix } = vi.hoisted(() => ({
+const { sticker, remix, viewer } = vi.hoisted(() => ({
   sticker: { value: 0 },
   remix: { value: 0 },
+  viewer: { username: 'zippy' as string | null, stickerBook: true },
 }));
 
 // `next/router` is stubbed by the shared harness (test/component-setup), and a
@@ -36,6 +37,12 @@ vi.mock('~/components/Notifications/notifications.utils', () => ({
   }),
 }));
 vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => (viewer.username ? { id: 7, username: viewer.username } : null),
+}));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ stickerBook: viewer.stickerBook }),
+}));
 vi.mock('~/components/Placement/StickerPlacementQueue', () => ({
   StickerPlacementQueue: () => <div>sticker queue</div>,
 }));
@@ -50,6 +57,8 @@ beforeEach(() => {
   useRouter().query = {};
   sticker.value = 0;
   remix.value = 0;
+  viewer.username = 'zippy';
+  viewer.stickerBook = true;
 });
 
 describe('which queue is on screen', () => {
@@ -120,5 +129,47 @@ describe('the counts on the control', () => {
     renderWithProviders(<Placements />);
 
     await expect.element(page.getByText('99+')).toBeInTheDocument();
+  });
+});
+
+describe('the way out to the sticker book', () => {
+  // The queue is reached from a notification and every row on it is about a
+  // sticker, but nothing on the page reached the book those stickers live in.
+  const bookLink = () => page.getByRole('link', { name: 'Your sticker book' });
+
+  test("points at the viewer's own book", async () => {
+    renderWithProviders(<Placements />);
+
+    // The href, read exactly. A `name` locator matches as a SUBSTRING, so a
+    // link that merely EXISTS proves nothing about where it goes — and the
+    // failure this guards is a book URL built from the wrong username.
+    await expect.element(bookLink()).toHaveAttribute('href', '/user/zippy/sticker-book');
+  });
+
+  test('is gone on the remix surface', async () => {
+    // Remixes have no sticker book behind them.
+    useRouter().query = { type: 'remix' };
+    renderWithProviders(<Placements />);
+
+    await expect.element(page.getByText('remix queue')).toBeInTheDocument();
+    expect(bookLink().elements()).toHaveLength(0);
+  });
+
+  test('is gone when the sticker book is not enabled for this viewer', async () => {
+    // The route redirects a flag-less viewer straight back off it, so a link
+    // shown here would be a link to nowhere.
+    viewer.stickerBook = false;
+    renderWithProviders(<Placements />);
+
+    await expect.element(page.getByText('sticker queue')).toBeInTheDocument();
+    expect(bookLink().elements()).toHaveLength(0);
+  });
+
+  test('is gone when there is no signed-in username to build it from', async () => {
+    viewer.username = null;
+    renderWithProviders(<Placements />);
+
+    await expect.element(page.getByText('sticker queue')).toBeInTheDocument();
+    expect(bookLink().elements()).toHaveLength(0);
   });
 });

--- a/src/components/StickerBook/StickerBookSectionPage.tsx
+++ b/src/components/StickerBook/StickerBookSectionPage.tsx
@@ -8,7 +8,7 @@ import { StickerBookGrid } from '~/components/StickerBook/StickerBookGrid';
 import { constants } from '~/server/common/constants';
 import { STICKER_BOOK_MAX_COLUMNS } from '~/shared/utils/sticker-book';
 import type { StickerBookSide } from '~/components/StickerBook/sticker-book.util';
-import { stickerBookSectionCopy } from '~/components/StickerBook/sticker-book.util';
+import { stickerBookSectionCopy, stickerBookUrl } from '~/components/StickerBook/sticker-book.util';
 import { trpc } from '~/utils/trpc';
 
 /**
@@ -73,7 +73,7 @@ export function StickerBookSectionPage({
           it also goes back through history when there is history, so arriving
           from the tab returns to the scroll position it was left at. */}
           <div>
-            <BackButton url={`/user/${username}/sticker-book`}>
+            <BackButton url={stickerBookUrl(username)}>
               <Text size="sm">Back to the sticker book</Text>
             </BackButton>
             <Title order={2} mt={4}>

--- a/src/components/StickerBook/StickerBookView.tsx
+++ b/src/components/StickerBook/StickerBookView.tsx
@@ -29,7 +29,7 @@ import { StickerBookBand, StickerBookSection } from '~/components/StickerBook/St
 import { constants } from '~/server/common/constants';
 import { StickerBookSettingsModal } from '~/components/StickerBook/StickerBookSettingsModal';
 import { StickerBookStickers } from '~/components/StickerBook/StickerBookStickers';
-import { stickerBookSectionCopy } from '~/components/StickerBook/sticker-book.util';
+import { stickerBookSectionCopy, stickerBookUrl } from '~/components/StickerBook/sticker-book.util';
 import { STICKER_BOOK_MAX_COLUMNS } from '~/shared/utils/sticker-book';
 import { Currency } from '~/shared/utils/prisma/enums';
 import { numberWithCommas } from '~/utils/number-helpers';
@@ -80,7 +80,7 @@ export function StickerBookView({ username }: { username: string }) {
     );
 
   const nothingYet = !data.placed.length && !data.received.length && !data.stickers.length;
-  const bookHref = `/user/${username}/sticker-book`;
+  const bookHref = stickerBookUrl(username);
   const placedCopy = stickerBookSectionCopy('placer', { username, isOwner });
   const receivedCopy = stickerBookSectionCopy('owner', { username, isOwner });
 

--- a/src/components/StickerBook/sticker-book.util.ts
+++ b/src/components/StickerBook/sticker-book.util.ts
@@ -6,6 +6,16 @@ export function isStickerBookSide(value: unknown): value is StickerBookSide {
 }
 
 /**
+ * The book's route, written once.
+ *
+ * Beside the copy below for the same reason: a rename gets fixed in the spellings
+ * someone greps and missed in the one they don't.
+ */
+export function stickerBookUrl(username: string) {
+  return `/user/${username}/sticker-book`;
+}
+
+/**
  * Every string a section is described by, in one place.
  *
  * The row on the tab and the page behind its "View all" are the same section,

--- a/src/components/StickerBook/sticker-book.util.ts
+++ b/src/components/StickerBook/sticker-book.util.ts
@@ -6,10 +6,11 @@ export function isStickerBookSide(value: unknown): value is StickerBookSide {
 }
 
 /**
- * The book's route, written once.
+ * The absolute book URL, for the three places that build one.
  *
- * Beside the copy below for the same reason: a rename gets fixed in the spellings
- * someone greps and missed in the one they don't.
+ * Deliberately not the profile nav's `${baseUrl}/sticker-book` — that row is
+ * built like all ten tabs beside it, and pulling one out to call this would
+ * make that table worse, not better.
  */
 export function stickerBookUrl(username: string) {
   return `/user/${username}/sticker-book`;


### PR DESCRIPTION
Closes ClickUp [868kwp6dv](https://app.clickup.com/t/868kwp6dv).

On `/user/placements` there was no route to your sticker book. The page is where a creator lands from a pending-placement notification and every row on it is about a sticker, but the book those stickers live in was unreachable from there.

**Where it went.** The page header, beside the Placements title — not the selection card. The selection card only exists once rows are ticked, and its other two controls are Approve and Decline, which are irreversible and both move Buzz. Justin picked the header over the selection card.

**When it shows.** Sticker surface only (the remix queue has no book behind it), and only with a signed-in username and the `stickerBook` flag — the book route redirects anyone else straight back off it, so a link shown without both would be a link to nowhere.

## Verification

| Check | Result |
|---|---|
| `pnpm run typecheck` | `typecheck: OK — 0 type errors in 303s`, exit 0, unfiltered |
| `pnpm run lint` | exit 1 on 362 pre-existing repo-wide errors; neither changed file appears in the output |
| `pnpm exec prettier --write` | both files |
| `pnpm run test:unit:run` | `Test Files 1 failed \| 1409 passed \| 1 skipped (1411)`, exit 1 — the one failure is pre-existing, see below |
| `blocks.router.workflow.test.ts` | `Tests 358 passed (358)` — nonzero, so the submodule is initialised |
| component suite, touched file | `Test Files 1 passed (1)` / `Tests 11 passed (11)`, exit 0 |

**The unit failure is not from this diff.** `src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts` fails on a Windows path separator (`src\pages\...` vs `src/pages/...`). Reverting both changed files and re-running that file alone reproduces it identically: `Tests 1 failed | 9 passed (10)`.

## Controls

Both directions, because three of the four new tests are absence assertions and those pass for free:

- **Revert the component, keep the tests** → `Tests 1 failed | 10 passed (11)`, reading `Cannot find element with locator: getByRole('link', { name: 'Your sticker book' })`. An assertion naming what is missing, not a timeout.
- **Keep the link, strip all three gates** (surface, flag, username) → `Tests 3 failed | 8 passed (11)`, each absence test named individually. Without that mutant they would be green whatever the gates did.

The href test reads the attribute exactly rather than trusting the locator: a `name` locator matches as a substring, so a link that merely exists proves nothing about where it goes.

Note for anyone running the component suite in a fresh worktree: a stale `node_modules/.vite` made `next/link` throw `Cannot read properties of null (reading 'useContext')` and reported 7 failures that had nothing to do with the code. `rm -rf node_modules/.vite` fixed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds4mdmgMjhWPNhT5U9DpFe