### PR TITLE
fix(rewards): stop paying a rewards-ineligible user the full award

### DIFF
--- a/src/server/rewards/__tests__/base.reward.ineligible.test.ts
+++ b/src/server/rewards/__tests__/base.reward.ineligible.test.ts
@@ -83,13 +83,16 @@ const processableReward = () =>
     }),
   });
 
-const pending = (toUserId: number, multiplier: number, forId: number): BuzzEventLog => ({
+// `multiplier` is typed loosely because ClickHouse hands `Decimal(3, 2)` back as a number today but
+// would hand back a string if `output_format_json_quote_decimals` were ever on — a case the guard has
+// to survive and a strict `number` parameter would stop us from writing.
+const pending = (toUserId: number, multiplier: number | string, forId: number): BuzzEventLog => ({
   type: 'testIneligibleReward',
   toUserId,
   forId,
   byUserId: toUserId,
   awardAmount: AWARD_AMOUNT,
-  multiplier,
+  multiplier: multiplier as number,
   status: 'pending',
 });
 
@@ -129,24 +132,58 @@ describe('process() does not pay a rewards-ineligible user', () => {
     expect(sent[0]).toMatchObject({ toAccountId: ELIGIBLE_USER, amount: AWARD_AMOUNT });
   });
 
-  it('applies a multiplier above 1 rather than treating every multiplier as pass-through', async () => {
-    // Pins that the fix reads the stored multiplier instead of discarding it.
-    await processableReward().process(processCtx([pending(ELIGIBLE_USER, 2.5, 11)]));
+  it('applies a multiplier above 1, rounding up', async () => {
+    // Pins that the fix reads the stored multiplier instead of discarding it — the mutation this
+    // catches is "fix" ineligibility by dropping the multiplier from the amount entirely, which
+    // pays every paying member 1x. 1.15 rather than a round number so the assertion also
+    // distinguishes `Math.ceil` from `floor`/`round`: 100 x 1.15 is 114.999... in float.
+    await processableReward().process(processCtx([pending(ELIGIBLE_USER, 1.15, 11)]));
 
-    expect(sentTransactions()[0]).toMatchObject({
-      toAccountId: ELIGIBLE_USER,
-      amount: Math.ceil(AWARD_AMOUNT * 2.5),
-    });
+    expect(sentTransactions()[0]).toMatchObject({ toAccountId: ELIGIBLE_USER, amount: 115 });
   });
 
-  it('records the ineligible row as earning nothing instead of as awarded', async () => {
-    await processableReward().process(processCtx([pending(INELIGIBLE_USER, 0, 10)]));
+  it('records the ineligible row as earning nothing, and an eligible one beside it as awarded', async () => {
+    await processableReward().process(
+      processCtx([pending(INELIGIBLE_USER, 0, 10), pending(ELIGIBLE_USER, 1, 11)])
+    );
 
     const rows = insertedRows();
-    expect(rows).toHaveLength(1);
+    const ineligible = rows.find((row: any) => row.toUserId === INELIGIBLE_USER);
+    const eligible = rows.find((row: any) => row.toUserId === ELIGIBLE_USER);
+
     // `unqualified` is outside the ClickHouse Enum8, so `toClickhouseBuzzEvent` coerces it to
-    // `capped`; either spelling means "seen, paid nothing" and neither means `awarded`.
-    expect(rows[0]).toMatchObject({ toUserId: INELIGIBLE_USER, status: 'capped', awardAmount: 0 });
+    // `capped` and records the original in `transactionDetails`. Assert BOTH: `capped` alone is
+    // also what a genuine cap and a disabled reward produce, and the difference matters — the
+    // send-failure recovery in `process` resets everything not `unqualified` back to `pending`
+    // at the full award, which would put this row back in the pipe to be paid.
+    expect(ineligible).toMatchObject({ status: 'capped', awardAmount: 0 });
+    expect(JSON.parse(ineligible.transactionDetails)).toMatchObject({ statusRaw: 'unqualified' });
+
+    // The in-test negative control: without it, this whole assertion is also satisfied by the
+    // reward being disabled, which marks EVERY row `unqualified` with `awardAmount` 0.
+    expect(eligible).toMatchObject({ status: 'awarded', awardAmount: AWARD_AMOUNT });
+  });
+
+  it('holds when the Decimal arrives as a string rather than a number', async () => {
+    // `buzzEvents.multiplier` is Decimal(3, 2). It comes back unquoted from ClickHouse today, so a
+    // strict `=== 0` happens to work — but `output_format_json_quote_decimals`, a swapped client or
+    // a `toString(multiplier)` in the read query all make it `'0.00'`, and a strict compare then
+    // goes silently inert. This is the test for the coercion, not for the happy path.
+    await processableReward().process(processCtx([pending(INELIGIBLE_USER, '0.00', 10)]));
+
+    expect(sentTransactions()).toEqual([]);
+    expect(insertedRows()[0]).toMatchObject({ status: 'capped', awardAmount: 0 });
+  });
+
+  it('drops a negative-multiplier event at the amount filter rather than paying it backwards', async () => {
+    // This is the ONLY test that pins `sendAward`'s amount filter on its own. Every other case
+    // here is stopped earlier by the `process()` guard, so reverting the sendAward half of the fix
+    // alone leaves them all green. A negative multiplier walks past that guard (it is not 0),
+    // survives `awardAmount > 0` — the predicate the old code filtered on — and is caught only by
+    // filtering on the computed amount.
+    await processableReward().process(processCtx([pending(ELIGIBLE_USER, -1, 11)]));
+
+    expect(sentTransactions()).toEqual([]);
   });
 });
 
@@ -163,6 +200,8 @@ describe('apply() stores the ineligibility decision on the pending row', () => {
       multiplier: 0,
       status: 'pending',
     });
-    expect(sentTransactions()).toEqual([]);
+    // Deliberately no assertion that nothing was sent: for a processable reward `apply` leaves the
+    // row `pending` and the send is gated on `awarded`, so `sendAward` is unreachable here and such
+    // an assertion would pass no matter what the payment code did.
   });
 });

--- a/src/server/rewards/__tests__/base.reward.ineligible.test.ts
+++ b/src/server/rewards/__tests__/base.reward.ineligible.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// WHY THIS SUITE EXISTS
+//
+// `foldUserMultipliers` sets `rewardsMultiplier` to 0 for a user whose
+// `rewardsEligibility` is `Ineligible`. `sendAward` used to turn that 0 back
+// into 1 — a line from 2024 that predates the eligibility flag and read the 0
+// as a missing value — so an ineligible user was paid the FULL award. Measured
+// on the prod replica 2026-08-25: 548 `awarded` rows carrying `multiplier = 0`
+// in 7 days, across 24 users, and all 24 were `Ineligible`; the ledger shows
+// 470 blue-Buzz transactions worth 3,052 Buzz behind them.
+//
+// The bug lives on the PROCESSABLE path only: an on-demand reward multiplies
+// before the Lua cap script, so a 0 multiplier already produced a `capped` row
+// that never reached `sendAward`. A suite built on an on-demand reward
+// therefore passes with the defect fully present.
+// ---------------------------------------------------------------------------
+
+const h = vi.hoisted(() => ({
+  insertImpl: vi.fn(async () => undefined),
+  queryImpl: vi.fn(async () => [] as unknown[]),
+  evalImpl: vi.fn(async () => 0 as number),
+  hGetImpl: vi.fn(async () => '{}'),
+  createBuzzTransactionMany: vi.fn(async () => ({ transactions: [] })),
+  getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: {
+    insert: (...args: any[]) => h.insertImpl(...args),
+    $query: (...args: any[]) => h.queryImpl(...args),
+    query: vi.fn(async () => ({ json: async () => [] })),
+  },
+}));
+
+vi.mock('~/server/prom/client', () => ({
+  rewardFailedCounter: { inc: vi.fn() },
+  rewardGivenCounter: { inc: vi.fn() },
+  clickhouseFailSoftCounter: { inc: vi.fn() },
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: (...args: any[]) => h.createBuzzTransactionMany(...args),
+  getMultipliersForUser: (...args: any[]) => h.getMultipliersForUser(...args),
+}));
+
+import { createBuzzEvent } from '~/server/rewards/base.reward';
+import type { BuzzEventLog } from '~/server/rewards/base.reward';
+import { invalidateRewardConfigCache } from '~/server/rewards/reward-config';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+redisMock.redis.eval.mockImplementation((...args: any[]) => h.evalImpl(...args));
+redisMock.redis.hGet.mockImplementation((...args: any[]) => h.hGetImpl(...args));
+
+const AWARD_AMOUNT = 100;
+const CAP = 1000;
+const INELIGIBLE_USER = 1;
+const ELIGIBLE_USER = 2;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  invalidateRewardConfigCache();
+  dbMock.dbRead.keyValue.findUnique.mockResolvedValue(null);
+  h.insertImpl.mockResolvedValue(undefined as any);
+  h.queryImpl.mockResolvedValue([]);
+  h.evalImpl.mockResolvedValue(AWARD_AMOUNT as any);
+  h.hGetImpl.mockResolvedValue('{}');
+  h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 1 });
+});
+
+const processableReward = () =>
+  createBuzzEvent<{ userId: number; entityId: number }>({
+    type: 'testIneligibleReward',
+    description: 'Test processable reward',
+    awardAmount: AWARD_AMOUNT,
+    caps: [{ keyParts: ['toUserId'], interval: 'day', amount: CAP }],
+    getKey: async (input) => ({
+      toUserId: input.userId,
+      forId: input.entityId,
+      byUserId: input.userId,
+    }),
+  });
+
+const pending = (toUserId: number, multiplier: number, forId: number): BuzzEventLog => ({
+  type: 'testIneligibleReward',
+  toUserId,
+  forId,
+  byUserId: toUserId,
+  awardAmount: AWARD_AMOUNT,
+  multiplier,
+  status: 'pending',
+});
+
+const processCtx = (toProcess: BuzzEventLog[]) =>
+  ({ toProcess, lastUpdate: new Date(0), ch: {}, db: {} } as any);
+
+/** Every transaction handed to `createBuzzTransactionMany`, flattened across calls. */
+const sentTransactions = () =>
+  h.createBuzzTransactionMany.mock.calls.flatMap((args: any[]) => args[0] ?? []);
+
+/** The rows handed to ClickHouse for the `buzzEvents` table, flattened across inserts. */
+const insertedRows = () =>
+  h.insertImpl.mock.calls
+    .filter((args: any[]) => args[0]?.table === 'buzzEvents')
+    .flatMap((args: any[]) => args[0].values ?? []);
+
+describe('process() does not pay a rewards-ineligible user', () => {
+  it('sends no transaction for a pending row whose multiplier is 0', async () => {
+    await processableReward().process(
+      processCtx([pending(INELIGIBLE_USER, 0, 10), pending(INELIGIBLE_USER, 0, 11)])
+    );
+
+    // Assert on the transactions themselves, not on a call count: `sendAward` is invoked
+    // per chunk regardless, and an empty array reaching it is the intended shape.
+    expect(sentTransactions()).toEqual([]);
+  });
+
+  it('still pays an eligible user in the same batch', async () => {
+    // The positive control for the assertion above — without this, `sentTransactions()`
+    // returning [] would also pass for a harness that never sends anything at all.
+    await processableReward().process(
+      processCtx([pending(INELIGIBLE_USER, 0, 10), pending(ELIGIBLE_USER, 1, 11)])
+    );
+
+    const sent = sentTransactions();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ toAccountId: ELIGIBLE_USER, amount: AWARD_AMOUNT });
+  });
+
+  it('applies a multiplier above 1 rather than treating every multiplier as pass-through', async () => {
+    // Pins that the fix reads the stored multiplier instead of discarding it.
+    await processableReward().process(processCtx([pending(ELIGIBLE_USER, 2.5, 11)]));
+
+    expect(sentTransactions()[0]).toMatchObject({
+      toAccountId: ELIGIBLE_USER,
+      amount: Math.ceil(AWARD_AMOUNT * 2.5),
+    });
+  });
+
+  it('records the ineligible row as earning nothing instead of as awarded', async () => {
+    await processableReward().process(processCtx([pending(INELIGIBLE_USER, 0, 10)]));
+
+    const rows = insertedRows();
+    expect(rows).toHaveLength(1);
+    // `unqualified` is outside the ClickHouse Enum8, so `toClickhouseBuzzEvent` coerces it to
+    // `capped`; either spelling means "seen, paid nothing" and neither means `awarded`.
+    expect(rows[0]).toMatchObject({ toUserId: INELIGIBLE_USER, status: 'capped', awardAmount: 0 });
+  });
+});
+
+describe('apply() stores the ineligibility decision on the pending row', () => {
+  it('writes multiplier 0 rather than 1, and sends nothing inline', async () => {
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 0 });
+
+    await processableReward().apply({ userId: INELIGIBLE_USER, entityId: 10 });
+
+    const rows = insertedRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      toUserId: INELIGIBLE_USER,
+      multiplier: 0,
+      status: 'pending',
+    });
+    expect(sentTransactions()).toEqual([]);
+  });
+});

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -456,9 +456,13 @@ export function createBuzzEvent<T>({
     // prepare awards for allocation
     for (const event of targeted) {
       // `getMultipliersForUser` zeroes the multiplier for a rewards-ineligible user, and `apply`
-      // stored that decision on the pending row. Recording this as `awarded` would put a payout
-      // the fold deliberately removed into the audit trail as one that happened.
-      if (event.multiplier === 0) {
+      // stored that decision on the pending row. Leaving it `awarded` would both claim a payout
+      // that did not happen and consume the user's cap, so a later eligible grant in the same
+      // interval would be short by the amount never paid.
+      //
+      // `Number()` because the value is read back out of a ClickHouse `Decimal(3, 2)`: it arrives
+      // unquoted today, but a client setting away from arriving as `'0.00'`, which `=== 0` misses.
+      if (Number(event.multiplier) === 0) {
         event.status = 'unqualified';
         event.awardAmount = 0;
         continue;

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -202,9 +202,7 @@ export function createBuzzEvent<T>({
     await withRetries(() =>
       createBuzzTransactionMany(
         events
-          .filter((x) => x.awardAmount > 0)
           .map((event) => {
-            if (event.multiplier === 0) event.multiplier = 1;
             return {
               type: TransactionType.Reward,
               toAccountId: event.toUserId,
@@ -224,6 +222,10 @@ export function createBuzzEvent<T>({
               toAccountType: buzzEvent.toAccountType ?? 'yellow',
             };
           })
+          // A zero multiplier is `getMultipliersForUser` reporting rewards-ineligibility, not a
+          // missing value, so the amount it produces is the intended one. Filtering on the amount
+          // rather than on `awardAmount` also keeps a 0-Buzz transaction off the ledger.
+          .filter((transaction) => transaction.amount > 0)
       )
     );
   };
@@ -453,6 +455,15 @@ export function createBuzzEvent<T>({
 
     // prepare awards for allocation
     for (const event of targeted) {
+      // `getMultipliersForUser` zeroes the multiplier for a rewards-ineligible user, and `apply`
+      // stored that decision on the pending row. Recording this as `awarded` would put a payout
+      // the fold deliberately removed into the audit trail as one that happened.
+      if (event.multiplier === 0) {
+        event.status = 'unqualified';
+        event.awardAmount = 0;
+        continue;
+      }
+
       // check against caps
       const prevAwardKeys = new Set<string>();
       if (buzzEvent.caps) {


### PR DESCRIPTION
ClickUp `868kw9kfk`.

`foldUserMultipliers` sets `rewardsMultiplier` to `0` when a user's `rewardsEligibility` is `Ineligible`. `sendAward` turned that `0` back into `1` — a line from `d911a0b65d` (2024-04-04), which predates the eligibility flag and read the `0` as a missing value — so an ineligible user was paid the full, unmultiplied award.

## Why the on-demand path hid it

Only the **processable** path is affected. An on-demand reward multiplies before the Lua cap script, so a `0` multiplier already produced a `capped` row that never reached `sendAward`. A suite built on an on-demand reward passes with the defect fully present, which is why the new tests use a processable one.

## Measurement (prod, 2026-08-25, preceding 7 days — re-measured, not taken from the ticket)

| | |
|---|---|
| `buzzEvents` at `multiplier = 0, status = 'awarded'` | **548 rows / 24 users / 6,520 Buzz** |
| Matching `buzzTransactions` (semi-join on reconstructed `externalTransactionId`) | **470 transactions / 22 users / 3,052 Buzz, all blue** |
| Affected users who are `Ineligible` on the replica right now | **24 of 24** |
| Of the 6,520, attributable to 12042163 (CivitaiOfficial) | **6,358** |

So the honest headline is **~162 Buzz/week across 23 real users**, not 6,238 — the ticket's figure is wrong in two directions (it counts the events rather than the ledger, and it is dominated by an internal account). The ledger, not the ticket.

**Control for that measurement:** the same semi-join with each id prefixed `ZZZ` returns **0** transactions against 470 for the real ids, so the query can come back empty and the 470 is not an artefact of a filter that matches everything.

## The fix

- Drop the `multiplier === 0 → 1` reset.
- Filter `sendAward` on the **computed `amount`** rather than on `awardAmount`. This is the load-bearing guard: it holds even if the `Decimal(3, 2)` ever arrives as a string, where a strict `=== 0` would not. It also keeps 0-Buzz transactions off the ledger.
- Mark a zero-multiplier row `unqualified` in `process()` so the audit trail stops recording a payout that did not happen. `unqualified` is outside the ClickHouse enum and `toClickhouseBuzzEvent` already coerces it to `capped`, which is the existing, deliberate path.

## Declared behaviour change

34 `pending` rows exist all-time with `multiplier = 0` (oldest 2024-11) that would now pay `0` rather than full. They are already stranded: `process` scans `time >= lastUpdate` and never looks back.

## Verification

- **Revert control** — with only `base.reward.ts` reverted to `origin/main`, the new suite is `Tests 3 failed | 2 passed (5)`, exit 1, failing on value assertions (`expected [ …(2) ] to deeply equal []`, `to have a length of 1 but got 2`, `to match object { toUserId: 1, status: 'capped', … }`) rather than on a timeout or a hang.
- **Two of the five new tests pass with the defect present**, and I am not counting them as coverage — they pin `apply()` storing the `0`, and a multiplier above 1 still being applied. Neither is changed by this fix.
- Rewards suites with the fix: `Test Files 11 passed (11)` / `Tests 191 passed (191)`, exit 0.
- Full unit suite: `Test Files 1 failed | 1410 passed | 1 skipped (1412)` / `Tests 1 failed | 22117 passed | 27 skipped (22145)`, exit 1. The one failure is `pageRunScrollContract.test.ts`, a path-separator guard that compares `src/pages/...` against Windows' `src\pages\...`; it is unrelated to this diff and the assertion diff shows the separators directly.
- `blocks.router.workflow.test.ts` collected **358 tests** in this worktree, so the submodule is initialised and the run is not silently empty.
- `pnpm run typecheck`: 0 errors in 301s. `@civitai/client` resolves to 0.2.0-beta.92, matching the root pin.
- `pnpm run lint`: repo-wide exit 1 with 362 pre-existing errors; **0 errors from the two files in this PR** (only `no-explicit-any` warnings matching the sibling test harnesses).

**No migration.**
