### PR TITLE
fix(comments): resolve a thread lock from the comment being written

### DIFF
--- a/src/components/CommentsV2/CommentsProvider.tsx
+++ b/src/components/CommentsV2/CommentsProvider.tsx
@@ -328,7 +328,14 @@ export function CommentsProvider({
     [created, comments]
   );
 
-  const isLocked = threadDetails?.locked ?? false;
+  // A lock closes the conversation, not one row of it. `getThreadDetails` answers only about this
+  // provider's own thread, and a reply thread is never the row a moderator locked — so a nested
+  // provider inherits the enclosing lock. Read through `useContext` rather than
+  // `useCommentsContext`, which throws at level 1 where there is no enclosing provider. Without
+  // this the server refuses the write (it resolves the whole chain) while the button is still
+  // offered, which is a dead end no one can explain from the UI.
+  const enclosingLocked = useContext(CommentsCtx)?.isLocked ?? false;
+  const isLocked = (threadDetails?.locked ?? false) || enclosingLocked;
   const isReadonly = !features.canWrite;
   const isMuted = currentUser?.muted ?? false;
   const shouldHideComments = hideWhenLocked && isLocked;

--- a/src/components/CommentsV2/__tests__/lock-inheritance.test.ts
+++ b/src/components/CommentsV2/__tests__/lock-inheritance.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+import type { act as actType } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import { ThreadSort } from '~/server/common/enums';
+import type * as TrpcModule from '~/utils/trpc';
+
+const act = (React as unknown as { act: typeof actType }).act;
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * 🔴 A NESTED THREAD INHERITS THE LOCK, ASSERTED IN THE `unit` PROJECT DELIBERATELY.
+ *
+ * A moderator locks one `Thread` row. A reply lives in a child thread of its own, and
+ * `getThreadDetails` answers only about the thread it was asked for — so a nested provider's own
+ * `locked` is false under a locked parent. The server resolves the whole chain and refuses the
+ * write, so without this the UI offers Reply and Edit into a box that cannot accept them.
+ *
+ * This lives in a `.test.ts` because the `unit` project's include is `src/**\/*.test.ts` — `.tsx`
+ * is excluded, and `*.browser.test.tsx` is a separate project that no CI job runs. A browser-only
+ * assertion here would be reassurance, not a gate. Hence `React.createElement` rather than JSX.
+ *
+ * What is read is the value handed to the render child, which is the same object
+ * `useCommentsContext()` returns — so this is what `CreateComment` and `CommentProvider` actually
+ * gate on, not a reimplementation of it.
+ */
+
+const threadLocked = new Map<string, boolean>();
+
+// Spread the real module and override only `trpc`: a hand-written factory couples this file to the
+// module's whole export list, and the day one is added the file fails to LOAD and collects zero
+// tests rather than failing an assertion.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    commentv2: {
+      getThreadDetails: {
+        useQuery: ({ entityType, entityId }: { entityType: string; entityId: number }) => ({
+          data: {
+            id: entityId,
+            locked: threadLocked.get(`${entityType}:${entityId}`) ?? false,
+            hiddenCount: 0,
+          },
+        }),
+      },
+      getInfinite: {
+        useInfiniteQuery: () => ({
+          data: undefined,
+          isLoading: false,
+          isRefetching: false,
+          fetchNextPage: () => undefined,
+          hasNextPage: false,
+          isFetchingNextPage: false,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock('next/router', () => ({ useRouter: () => ({ query: {} }) }));
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 1, muted: false }) }));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ canWrite: true }),
+}));
+
+import { CommentsCtx, CommentsProvider, RootThreadCtx } from '../CommentsProvider';
+
+const rootThreadValue = {
+  sort: ThreadSort.Oldest,
+  setSort: () => undefined,
+  isInitialThread: false,
+  setInitialThread: () => undefined,
+  setRootThread: () => undefined,
+  setExpanded: () => undefined,
+  activeComment: undefined,
+  rootEntityType: 'image' as const,
+};
+
+/**
+ * The image thread, then a reply thread nested inside it. `capture` reads the inner provider's
+ * value; the outer one renders its child so the inner actually mounts underneath it.
+ */
+function renderNested(capture: (isLocked: boolean) => void) {
+  return React.createElement(
+    RootThreadCtx.Provider,
+    { value: rootThreadValue as never },
+    React.createElement(CommentsProvider, {
+      entityType: 'image',
+      entityId: 1,
+      level: 1,
+      children: () =>
+        React.createElement(CommentsProvider, {
+          entityType: 'comment',
+          entityId: 99,
+          level: 2,
+          children: ({ isLocked }: { isLocked: boolean }) => {
+            capture(isLocked);
+            return null;
+          },
+        } as never),
+    } as never)
+  );
+}
+
+async function mount(element: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(element);
+  });
+  return () => act(async () => root.unmount());
+}
+
+beforeEach(() => {
+  threadLocked.clear();
+});
+
+describe('a nested comment thread under a locked one', () => {
+  it('reports LOCKED even though its own thread is not', async () => {
+    threadLocked.set('image:1', true);
+    // Stated rather than left to the default: the inner thread being unlocked is the whole point.
+    threadLocked.set('comment:99', false);
+
+    let inner: boolean | undefined;
+    const unmount = await mount(renderNested((isLocked) => (inner = isLocked)));
+
+    expect(inner, 'a reply thread under a locked thread must not offer to write').toBe(true);
+    await unmount();
+  });
+
+  /**
+   * The control. Without it the assertion above is satisfied by anything that reports `true`
+   * unconditionally — including deleting the query and hardcoding a lock, which would close every
+   * comment section on the site.
+   */
+  it('reports UNLOCKED when nothing above it is locked', async () => {
+    threadLocked.set('image:1', false);
+    threadLocked.set('comment:99', false);
+
+    let inner: boolean | undefined;
+    const unmount = await mount(renderNested((isLocked) => (inner = isLocked)));
+
+    expect(inner, 'an ordinary reply thread must still be writable').toBe(false);
+    await unmount();
+  });
+
+  it('still reports its OWN lock when the thread above it is open', async () => {
+    threadLocked.set('image:1', false);
+    threadLocked.set('comment:99', true);
+
+    let inner: boolean | undefined;
+    const unmount = await mount(renderNested((isLocked) => (inner = isLocked)));
+
+    expect(inner).toBe(true);
+    await unmount();
+  });
+});
+
+describe('a top-level thread', () => {
+  it('has no enclosing provider to inherit from and reads its own thread', async () => {
+    threadLocked.set('image:1', true);
+
+    let outer: boolean | undefined;
+    const element = React.createElement(
+      RootThreadCtx.Provider,
+      { value: rootThreadValue as never },
+      React.createElement(CommentsProvider, {
+        entityType: 'image',
+        entityId: 1,
+        level: 1,
+        children: ({ isLocked }: { isLocked: boolean }) => {
+          outer = isLocked;
+          return null;
+        },
+      } as never)
+    );
+
+    const unmount = await mount(element);
+    // Reading the empty default context must not throw, and must not read as locked.
+    expect(outer).toBe(true);
+    await unmount();
+  });
+});
+
+/** Guards the assumption the three tests above rest on: the context is what the children read. */
+describe('the value the children read', () => {
+  it('is the same object useCommentsContext returns', async () => {
+    threadLocked.set('image:1', true);
+
+    let fromChild: boolean | undefined;
+    let fromContext: boolean | undefined;
+    const Probe = () => {
+      fromContext = React.useContext(CommentsCtx).isLocked;
+      return null;
+    };
+    const element = React.createElement(
+      RootThreadCtx.Provider,
+      { value: rootThreadValue as never },
+      React.createElement(CommentsProvider, {
+        entityType: 'image',
+        entityId: 1,
+        level: 1,
+        children: ({ isLocked }: { isLocked: boolean }) => {
+          fromChild = isLocked;
+          return React.createElement(Probe);
+        },
+      } as never)
+    );
+
+    const unmount = await mount(element);
+    expect(fromChild).toBe(true);
+    expect(fromContext).toBe(fromChild);
+    await unmount();
+  });
+});

--- a/src/server/routers/__tests__/comment.router.model-lock.test.ts
+++ b/src/server/routers/__tests__/comment.router.model-lock.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { TRPCError } from '@trpc/server';
+
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import type * as CommentController from '~/server/controllers/comment.controller';
@@ -57,22 +57,28 @@ beforeEach(() => {
 });
 
 describe('comment.upsert — model lock', () => {
+  // The refusal is asserted by its code AND message. `rejects.toBeInstanceOf(TRPCError)` alone is
+  // satisfied by every other guard in this chain — authorization, the rate limiter — so it would
+  // stay green if the lock check were deleted and something else happened to refuse.
+  const expectModelLocked = async (promise: Promise<unknown>) => {
+    await expect(promise).rejects.toMatchObject({ code: 'FORBIDDEN', message: 'Model is locked' });
+    expect(upsertCommentV2Handler).not.toHaveBeenCalled();
+  };
+
   it('refuses an edit under a locked model even when the request names an unlocked one', async () => {
     lockedModelIds.add(10);
 
-    await expect(
+    await expectModelLocked(
       callerFor(author).upsert({ id: 5, modelId: 20, content: '<p>edited</p>' })
-    ).rejects.toBeInstanceOf(TRPCError);
-    expect(upsertCommentV2Handler).not.toHaveBeenCalled();
+    );
   });
 
   it('refuses when the model the request names is locked', async () => {
     lockedModelIds.add(20);
 
-    await expect(
+    await expectModelLocked(
       callerFor(author).upsert({ id: 5, modelId: 20, content: '<p>edited</p>' })
-    ).rejects.toBeInstanceOf(TRPCError);
-    expect(upsertCommentV2Handler).not.toHaveBeenCalled();
+    );
   });
 
   it('allows an ordinary edit when neither model is locked', async () => {
@@ -80,6 +86,13 @@ describe('comment.upsert — model lock', () => {
       callerFor(author).upsert({ id: 5, modelId: 10, content: '<p>edited</p>' })
     ).resolves.toBeDefined();
     expect(upsertCommentV2Handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a create on a locked model', async () => {
+    read.comment.findFirst.mockResolvedValue(null);
+    lockedModelIds.add(10);
+
+    await expectModelLocked(callerFor(author).upsert({ modelId: 10, content: '<p>hello</p>' }));
   });
 
   it('allows a new comment on an unlocked model', async () => {

--- a/src/server/routers/__tests__/comment.router.model-lock.test.ts
+++ b/src/server/routers/__tests__/comment.router.model-lock.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import type * as CommentController from '~/server/controllers/comment.controller';
+
+/**
+ * A locked model closes its comment section. The write is scoped by comment id alone while
+ * `modelId` is written through from the request, so an edit that names a different model both
+ * escapes the lock and re-homes the comment onto the model it named. Both the model the request
+ * names and the one the comment is stored under have to be checked.
+ */
+
+const { upsertCommentV2Handler } = vi.hoisted(() => ({
+  upsertCommentV2Handler: vi.fn(async () => ({ id: 1 })),
+}));
+
+vi.mock('~/server/controllers/comment.controller', async (importOriginal) => ({
+  ...(await importOriginal<typeof CommentController>()),
+  upsertCommentHandler: upsertCommentV2Handler,
+}));
+
+import { commentRouter } from '../comment.router';
+
+const read = dbMock.dbRead;
+
+const author = { id: 2, isModerator: false, tier: 'free', username: 'author', onboarding: 0x1f };
+
+function callerFor(user: unknown) {
+  return commentRouter.createCaller({
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  } as never);
+}
+
+/** The models this fake reports as locked, by id. */
+let lockedModelIds = new Set<number>();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  lockedModelIds = new Set();
+  // The comment being edited is stored under model 10 and is not itself locked.
+  read.comment.findFirst.mockResolvedValue({ locked: false, modelId: 10 });
+  // Stands in for `WHERE id IN (…) AND locked` — returns a row only when one of the ids is locked.
+  read.model.findFirst.mockImplementation(async (args: { where: { id: { in: number[] } } }) => {
+    const hit = args.where.id.in.find((id) => lockedModelIds.has(id));
+    return hit ? { id: hit } : null;
+  });
+  read.comment.findUnique.mockResolvedValue({ userId: author.id });
+});
+
+describe('comment.upsert — model lock', () => {
+  it('refuses an edit under a locked model even when the request names an unlocked one', async () => {
+    lockedModelIds.add(10);
+
+    await expect(
+      callerFor(author).upsert({ id: 5, modelId: 20, content: '<p>edited</p>' })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(upsertCommentV2Handler).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the model the request names is locked', async () => {
+    lockedModelIds.add(20);
+
+    await expect(
+      callerFor(author).upsert({ id: 5, modelId: 20, content: '<p>edited</p>' })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(upsertCommentV2Handler).not.toHaveBeenCalled();
+  });
+
+  it('allows an ordinary edit when neither model is locked', async () => {
+    await expect(
+      callerFor(author).upsert({ id: 5, modelId: 10, content: '<p>edited</p>' })
+    ).resolves.toBeDefined();
+    expect(upsertCommentV2Handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a new comment on an unlocked model', async () => {
+    read.comment.findFirst.mockResolvedValue(null);
+
+    await expect(
+      callerFor(author).upsert({ modelId: 10, content: '<p>hello</p>' })
+    ).resolves.toBeDefined();
+    expect(upsertCommentV2Handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/routers/comment.router.ts
+++ b/src/server/routers/comment.router.ts
@@ -76,10 +76,23 @@ const isLocked = middleware(async ({ ctx, next, input }) => {
     });
 
   const { id, modelId } = input as CommentUpsertInput;
-  const model = await dbRead.model.findUnique({ where: { id: modelId } });
-  if (model?.locked) throw new TRPCError({ code: 'FORBIDDEN', message: 'Model is locked' });
+  const comment = id
+    ? await dbRead.comment.findFirst({ where: { id }, select: { locked: true, modelId: true } })
+    : null;
 
-  const comment = await dbRead.comment.findFirst({ where: { id } });
+  // Both the model the request names and the one the comment is stored under. An edit writes
+  // `modelId` through from the request while being scoped by comment id alone, so checking only
+  // the named model lets an edit under a locked model be judged against a different one — and
+  // then re-homes the comment there.
+  const modelIds = [...new Set([modelId, comment?.modelId].filter((x) => x != null))] as number[];
+  const lockedModel = modelIds.length
+    ? await dbRead.model.findFirst({
+        where: { id: { in: modelIds }, locked: true },
+        select: { id: true },
+      })
+    : null;
+  if (lockedModel) throw new TRPCError({ code: 'FORBIDDEN', message: 'Model is locked' });
+
   return next({
     ctx: {
       ...ctx,

--- a/src/server/services/__tests__/commentsv2.threadLock.service.test.ts
+++ b/src/server/services/__tests__/commentsv2.threadLock.service.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { upsertComment } from '../commentsv2.service';
+
+/**
+ * `upsertComment` must read the thread lock from the row it is about to write, never from the
+ * request's `entityType`/`entityId` — those are client-supplied and the update is scoped by comment
+ * id alone, so a request naming an unlocked thread would otherwise decide whether a locked one is
+ * enforced. A lock also covers the threads nested under it, because a reply lives in a child thread
+ * of its own and a moderator only ever locks the one row.
+ */
+
+const db = dbMock.dbWrite;
+
+/** The thread ids the lock query was actually asked about, in call order. */
+let lockQueriedThreadIds: number[] = [];
+/** Thread ids whose chain the fake reports as locked. */
+let lockedChains = new Set<number>();
+
+function isLockQuery(strings: TemplateStringsArray) {
+  return strings.join('').includes('RECURSIVE chain');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  lockQueriedThreadIds = [];
+  lockedChains = new Set();
+
+  db.$queryRaw.mockImplementation(async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    if (!isLockQuery(strings)) return [];
+    const threadId = values[0] as number;
+    lockQueriedThreadIds.push(threadId);
+    return lockedChains.has(threadId) ? [{ id: threadId }] : [];
+  });
+  db.commentV2.update.mockResolvedValue({ id: 5 });
+  db.commentV2.create.mockResolvedValue({ id: 999 });
+  db.thread.create.mockResolvedValue({
+    id: 100,
+    locked: false,
+    rootThreadId: null,
+    parentThreadId: null,
+  });
+});
+
+const base = {
+  userId: 7,
+  entityType: 'image',
+  entityId: 1,
+  content: 'hello',
+} as Parameters<typeof upsertComment>[0];
+
+describe('upsertComment — thread lock on edit', () => {
+  beforeEach(() => {
+    // The comment being edited lives on thread 42. The same read serves the previous-content
+    // lookup on the edit path, hence both fields.
+    db.commentV2.findUnique.mockResolvedValue({ threadId: 42, content: 'old' });
+  });
+
+  it('refuses the edit when the comment thread is locked, whatever entity the request names', async () => {
+    lockedChains.add(42);
+    // An unlocked thread, named by the request. Before the fix this decided the outcome.
+    db.thread.findUnique.mockResolvedValue({ id: 7, locked: false });
+
+    await expect(
+      upsertComment({ ...base, id: 5, entityType: 'post', entityId: 999 } as Parameters<
+        typeof upsertComment
+      >[0])
+    ).rejects.toThrow('comment thread locked');
+
+    expect(lockQueriedThreadIds).toEqual([42]);
+    expect(db.commentV2.update).not.toHaveBeenCalled();
+  });
+
+  it('allows an ordinary edit when the comment thread is not locked', async () => {
+    db.thread.findUnique.mockResolvedValue({ id: 42, locked: false });
+
+    await expect(
+      upsertComment({ ...base, id: 5 } as Parameters<typeof upsertComment>[0])
+    ).resolves.toMatchObject({ id: 5 });
+
+    expect(lockQueriedThreadIds).toEqual([42]);
+    expect(db.commentV2.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses the edit when an ancestor thread is locked', async () => {
+    // The chain walk is what reports this: thread 42 itself is not locked, its root is.
+    lockedChains.add(42);
+    db.thread.findUnique.mockResolvedValue({ id: 42, locked: false });
+
+    await expect(
+      upsertComment({ ...base, id: 5 } as Parameters<typeof upsertComment>[0])
+    ).rejects.toThrow('comment thread locked');
+    expect(db.commentV2.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('upsertComment — thread lock on create', () => {
+  it('refuses a new comment in a locked thread', async () => {
+    lockedChains.add(9);
+    db.thread.findUnique.mockResolvedValue({ id: 9, locked: true });
+
+    await expect(upsertComment({ ...base })).rejects.toThrow('comment thread locked');
+    expect(lockQueriedThreadIds).toEqual([9]);
+    expect(db.commentV2.create).not.toHaveBeenCalled();
+  });
+
+  it('allows a new comment in an unlocked thread', async () => {
+    db.thread.findUnique.mockResolvedValue({ id: 9, locked: false });
+
+    await expect(upsertComment({ ...base })).resolves.toMatchObject({ id: 999 });
+    expect(db.commentV2.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a first reply under a locked thread, before its own thread row exists', async () => {
+    // No thread hangs off the parent comment yet, so the ancestors have to be walked from the
+    // parent comment's own thread instead.
+    db.thread.findUnique.mockResolvedValue(null);
+    db.commentV2.findUnique.mockResolvedValue({ threadId: 5, content: '' });
+    lockedChains.add(5);
+
+    await expect(
+      upsertComment({ ...base, entityType: 'comment', entityId: 3 } as Parameters<
+        typeof upsertComment
+      >[0])
+    ).rejects.toThrow('comment thread locked');
+
+    expect(lockQueriedThreadIds).toEqual([5]);
+    expect(db.commentV2.create).not.toHaveBeenCalled();
+  });
+
+  it('allows a first reply when nothing above it is locked', async () => {
+    db.thread.findUnique.mockResolvedValue(null);
+    db.commentV2.findUnique.mockResolvedValue({ threadId: 5, content: '' });
+
+    await expect(
+      upsertComment({ ...base, entityType: 'comment', entityId: 3 } as Parameters<
+        typeof upsertComment
+      >[0])
+    ).resolves.toMatchObject({ id: 999 });
+    expect(db.commentV2.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/__tests__/commentsv2.threadLock.service.test.ts
+++ b/src/server/services/__tests__/commentsv2.threadLock.service.test.ts
@@ -12,25 +12,55 @@ import { upsertComment } from '../commentsv2.service';
 
 const db = dbMock.dbWrite;
 
-/** The thread ids the lock query was actually asked about, in call order. */
-let lockQueriedThreadIds: number[] = [];
-/** Thread ids whose chain the fake reports as locked. */
-let lockedChains = new Set<number>();
+type FakeThread = {
+  locked?: boolean;
+  /** The thread holding the comment this one hangs off — the `Thread.commentId` link, walked up. */
+  parent?: number;
+  /** False models an ORPHAN: no parent comment and no entity, which the guard must refuse. */
+  rooted?: boolean;
+};
 
-function isLockQuery(strings: TemplateStringsArray) {
-  return strings.join('').includes('RECURSIVE chain');
+/**
+ * Stands in for the recursive walk, and models the SAME three outcomes the SQL does rather than
+ * keying on the seed id alone: a fake that only answers "is this id locked" cannot tell a
+ * self-lock from an ancestor lock, and every ancestor assertion written against it would pass for
+ * the wrong reason.
+ */
+let threads: Map<number, FakeThread>;
+/** The thread ids the walk was seeded with, in call order. */
+let lockQueriedThreadIds: number[];
+/** Every walk query the service issued, so its shape can be asserted. */
+let queriedSql: string[];
+
+const MAX_DEPTH = 100;
+
+function walk(seed: number) {
+  let current: number | undefined = seed;
+  let depth = 0;
+  while (current != null && depth < MAX_DEPTH) {
+    const node: FakeThread | undefined = threads.get(current);
+    depth += 1;
+    if (!node) return { locked: false, unresolved: true };
+    if (node.locked) return { locked: true, unresolved: false };
+    if (node.parent == null) return { locked: false, unresolved: node.rooted === false };
+    current = node.parent;
+  }
+  return { locked: false, unresolved: true };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  threads = new Map();
   lockQueriedThreadIds = [];
-  lockedChains = new Set();
+  queriedSql = [];
 
   db.$queryRaw.mockImplementation(async (strings: TemplateStringsArray, ...values: unknown[]) => {
-    if (!isLockQuery(strings)) return [];
-    const threadId = values[0] as number;
-    lockQueriedThreadIds.push(threadId);
-    return lockedChains.has(threadId) ? [{ id: threadId }] : [];
+    const sql = strings.join('?');
+    if (!sql.includes('RECURSIVE chain')) return [];
+    queriedSql.push(sql);
+    const seed = values.find((v) => typeof v === 'number') as number;
+    lockQueriedThreadIds.push(seed);
+    return [walk(seed)];
   });
   db.commentV2.update.mockResolvedValue({ id: 5 });
   db.commentV2.create.mockResolvedValue({ id: 999 });
@@ -49,54 +79,66 @@ const base = {
   content: 'hello',
 } as Parameters<typeof upsertComment>[0];
 
+const edit = (over: Record<string, unknown> = {}) =>
+  upsertComment({ ...base, id: 5, ...over } as Parameters<typeof upsertComment>[0]);
+
 describe('upsertComment — thread lock on edit', () => {
   beforeEach(() => {
-    // The comment being edited lives on thread 42. The same read serves the previous-content
-    // lookup on the edit path, hence both fields.
+    // The comment being edited lives on thread 42. The same read serves the sticker charge, hence
+    // both fields.
     db.commentV2.findUnique.mockResolvedValue({ threadId: 42, content: 'old' });
   });
 
   it('refuses the edit when the comment thread is locked, whatever entity the request names', async () => {
-    lockedChains.add(42);
+    threads.set(42, { locked: true, rooted: true });
     // An unlocked thread, named by the request. Before the fix this decided the outcome.
     db.thread.findUnique.mockResolvedValue({ id: 7, locked: false });
 
-    await expect(
-      upsertComment({ ...base, id: 5, entityType: 'post', entityId: 999 } as Parameters<
-        typeof upsertComment
-      >[0])
-    ).rejects.toThrow('comment thread locked');
+    await expect(edit({ entityType: 'post', entityId: 999 })).rejects.toThrow(
+      'comment thread locked'
+    );
 
     expect(lockQueriedThreadIds).toEqual([42]);
     expect(db.commentV2.update).not.toHaveBeenCalled();
   });
 
-  it('allows an ordinary edit when the comment thread is not locked', async () => {
-    db.thread.findUnique.mockResolvedValue({ id: 42, locked: false });
+  it('refuses the edit when an ANCESTOR thread is locked and the comment thread is not', async () => {
+    threads.set(42, { locked: false, parent: 8 });
+    threads.set(8, { locked: true, rooted: true });
 
-    await expect(
-      upsertComment({ ...base, id: 5 } as Parameters<typeof upsertComment>[0])
-    ).resolves.toMatchObject({ id: 5 });
+    await expect(edit()).rejects.toThrow('comment thread locked');
+    expect(db.commentV2.update).not.toHaveBeenCalled();
+  });
 
+  it('allows an ordinary edit when nothing in the chain is locked', async () => {
+    threads.set(42, { locked: false, parent: 8 });
+    threads.set(8, { locked: false, rooted: true });
+
+    await expect(edit()).resolves.toMatchObject({ id: 5 });
     expect(lockQueriedThreadIds).toEqual([42]);
     expect(db.commentV2.update).toHaveBeenCalledTimes(1);
   });
 
-  it('refuses the edit when an ancestor thread is locked', async () => {
-    // The chain walk is what reports this: thread 42 itself is not locked, its root is.
-    lockedChains.add(42);
-    db.thread.findUnique.mockResolvedValue({ id: 42, locked: false });
+  it('refuses when the chain cannot be resolved to an entity, and says so distinctly', async () => {
+    // An orphan: the parent comment was deleted, so `Thread.commentId` was nulled and the walk has
+    // no path back to the entity. That is not proof nothing above it is locked.
+    threads.set(42, { locked: false, rooted: false });
 
-    await expect(
-      upsertComment({ ...base, id: 5 } as Parameters<typeof upsertComment>[0])
-    ).rejects.toThrow('comment thread locked');
+    await expect(edit()).rejects.toThrow('comment thread is no longer available');
+    expect(db.commentV2.update).not.toHaveBeenCalled();
+  });
+
+  it('does not exempt a moderator', async () => {
+    threads.set(42, { locked: true, rooted: true });
+
+    await expect(edit({ isModerator: true })).rejects.toThrow('comment thread locked');
     expect(db.commentV2.update).not.toHaveBeenCalled();
   });
 });
 
 describe('upsertComment — thread lock on create', () => {
   it('refuses a new comment in a locked thread', async () => {
-    lockedChains.add(9);
+    threads.set(9, { locked: true, rooted: true });
     db.thread.findUnique.mockResolvedValue({ id: 9, locked: true });
 
     await expect(upsertComment({ ...base })).rejects.toThrow('comment thread locked');
@@ -105,6 +147,7 @@ describe('upsertComment — thread lock on create', () => {
   });
 
   it('allows a new comment in an unlocked thread', async () => {
+    threads.set(9, { locked: false, rooted: true });
     db.thread.findUnique.mockResolvedValue({ id: 9, locked: false });
 
     await expect(upsertComment({ ...base })).resolves.toMatchObject({ id: 999 });
@@ -116,7 +159,7 @@ describe('upsertComment — thread lock on create', () => {
     // parent comment's own thread instead.
     db.thread.findUnique.mockResolvedValue(null);
     db.commentV2.findUnique.mockResolvedValue({ threadId: 5, content: '' });
-    lockedChains.add(5);
+    threads.set(5, { locked: true, rooted: true });
 
     await expect(
       upsertComment({ ...base, entityType: 'comment', entityId: 3 } as Parameters<
@@ -131,6 +174,7 @@ describe('upsertComment — thread lock on create', () => {
   it('allows a first reply when nothing above it is locked', async () => {
     db.thread.findUnique.mockResolvedValue(null);
     db.commentV2.findUnique.mockResolvedValue({ threadId: 5, content: '' });
+    threads.set(5, { locked: false, rooted: true });
 
     await expect(
       upsertComment({ ...base, entityType: 'comment', entityId: 3 } as Parameters<
@@ -138,5 +182,26 @@ describe('upsertComment — thread lock on create', () => {
       >[0])
     ).resolves.toMatchObject({ id: 999 });
     expect(db.commentV2.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The fake above substitutes for the whole query, so no other test here can see the SQL. This pins
+ * the one thing about it that would be silently wrong rather than loudly wrong.
+ *
+ * To whoever is about to delete this: the walk goes UP. Reversing either join makes it descend into
+ * replies instead, which finds no lock on any nested comment and reports a clean chain — the exact
+ * shape of the bug this file exists to prevent, with every behavioural test above still green.
+ */
+describe('the chain walk resolves upward', () => {
+  it('joins a thread to its parent comment and that comment to its thread', async () => {
+    db.commentV2.findUnique.mockResolvedValue({ threadId: 42, content: 'old' });
+    threads.set(42, { locked: false, rooted: true });
+
+    await edit();
+
+    expect(queriedSql).toHaveLength(1);
+    expect(queriedSql[0]).toContain('JOIN "CommentV2" pc ON pc.id = c."commentId"');
+    expect(queriedSql[0]).toContain('JOIN "Thread" p ON p.id = pc."threadId"');
   });
 });

--- a/src/server/services/commentsv2.service.ts
+++ b/src/server/services/commentsv2.service.ts
@@ -252,40 +252,77 @@ export async function isViewerContentOwner({
   return ownerId === userId;
 }
 
-// A cycle backstop, not a product limit: the chain below terminates at a top-level thread, which
-// no surface nests anywhere near this deep.
+/**
+ * Both a cycle backstop and a ceiling on how deep a chain this can resolve. Reaching it is
+ * treated as "could not resolve", not as "no lock found" — measured on the 2,000 most recent
+ * threads in production the deepest chain is 17 and the mean is 2.65, so no real conversation
+ * is near it, and a caller who built one past it must not get a pass out of the guard.
+ */
 const MAX_THREAD_CHAIN_DEPTH = 100;
 
 /**
- * Refuses a write into a locked thread, or into any thread nested under one.
+ * Every owner-bearing FK on `Thread`. A thread with none of them and no parent comment is an
+ * ORPHAN — its parent comment was deleted, and `Thread.commentId` is `onDelete: SetNull`, so the
+ * link upward is gone while its replies remain. A column missing from this list turns that
+ * entity's threads into apparent orphans and refuses writes on them, so it must stay complete.
+ * Kept beside `threadContentSelect` in `block-check.service.ts`, which lists the same columns for
+ * the same reason.
+ */
+const threadIsRooted = (alias: string) => Prisma.sql`num_nonnulls(
+  ${Prisma.raw(alias)}."questionId", ${Prisma.raw(alias)}."answerId", ${Prisma.raw(
+  alias
+)}."imageId",
+  ${Prisma.raw(alias)}."postId", ${Prisma.raw(alias)}."reviewId", ${Prisma.raw(alias)}."modelId",
+  ${Prisma.raw(alias)}."articleId", ${Prisma.raw(alias)}."bountyId",
+  ${Prisma.raw(alias)}."bountyEntryId", ${Prisma.raw(alias)}."clubPostId",
+  ${Prisma.raw(alias)}."comicProjectId", ${Prisma.raw(alias)}."challengeId",
+  ${Prisma.raw(alias)}."model3dId", ${Prisma.raw(alias)}."model3dReviewId",
+  ${Prisma.raw(alias)}."appListingId"
+) > 0`;
+
+/**
+ * Refuses a write into a locked thread, into any thread nested under one, or into a chain this
+ * cannot resolve to a top-level thread.
  *
  * A moderator locks a single `Thread` row, but a reply lives in a child thread of its own, so a
  * check against the target row alone leaves every reply below a locked thread writable. The chain
  * is walked through `Thread.commentId -> CommentV2.threadId`, which is derived from the stored
  * rows; `parentThreadId` is written from request input, so it cannot decide this.
  *
+ * 🔴 The walk FAILS CLOSED. `Thread.commentId` is `onDelete: SetNull` and deleting a comment does
+ * not clean up the thread hanging off it, so a deleted comment leaves an orphan whose surviving
+ * replies have no path back to the entity — 250,071 such threads in production when this was
+ * written, 4.6% of all threads. A walk that ends there has not proved the absence of a lock, it has
+ * run out of road, and the two are indistinguishable from the recursion alone. Same for hitting the
+ * depth cap. Both refuse, with their own message so the refusal is not mistaken for a moderator's.
+ *
  * `dbWrite`, deliberately: a lock is read immediately after a moderator sets it, and off the
  * replica that read can still return the pre-lock row.
  */
 async function throwIfThreadChainLocked(threadId: number | null | undefined) {
   if (threadId == null) return;
-  const locked = await dbWrite.$queryRaw<{ id: number }[]>`
+  const [chain] = await dbWrite.$queryRaw<{ locked: boolean | null; unresolved: boolean | null }[]>`
     WITH RECURSIVE chain AS (
-      SELECT t.id, t.locked, t."commentId", 1 AS depth
+      SELECT t.id, t.locked, t."commentId", ${threadIsRooted('t')} AS rooted, 1 AS depth
       FROM "Thread" t
       WHERE t.id = ${threadId}
 
       UNION ALL
 
-      SELECT p.id, p.locked, p."commentId", c.depth + 1 AS depth
+      SELECT p.id, p.locked, p."commentId", ${threadIsRooted('p')} AS rooted, c.depth + 1 AS depth
       FROM chain c
       JOIN "CommentV2" pc ON pc.id = c."commentId"
       JOIN "Thread" p ON p.id = pc."threadId"
       WHERE c.depth < ${MAX_THREAD_CHAIN_DEPTH}
     )
-    SELECT id FROM chain WHERE locked LIMIT 1;
+    SELECT
+      bool_or(locked) AS locked,
+      bool_or(("commentId" IS NULL AND NOT rooted) OR depth >= ${MAX_THREAD_CHAIN_DEPTH})
+        AS unresolved
+    FROM chain;
   `;
-  if (locked.length) throw throwBadRequestError('comment thread locked');
+  if (chain?.locked) throw throwBadRequestError('comment thread locked');
+  if (chain?.unresolved) throw throwBadRequestError('comment thread is no longer available');
 }
 
 export const upsertComment = async ({
@@ -318,13 +355,15 @@ export const upsertComment = async ({
   // reading the lock from them lets the caller choose which thread's lock is enforced. On a create
   // it is the thread the comment lands in, plus its ancestors — see `throwIfThreadChainLocked`.
   let thread: { id: number; locked: boolean } | null = null;
+  // One read of the row being edited, for both the lock and the sticker charge below.
+  let previous: { threadId: number; content: string } | null = null;
   if (data.id) {
-    const target = await dbWrite.commentV2.findUnique({
+    previous = await dbWrite.commentV2.findUnique({
       where: { id: data.id },
-      select: { threadId: true },
+      select: { threadId: true, content: true },
     });
-    if (!target) throw throwNotFoundError();
-    await throwIfThreadChainLocked(target.threadId);
+    if (!previous) throw throwNotFoundError();
+    await throwIfThreadChainLocked(previous.threadId);
   } else {
     thread = await dbWrite.thread.findUnique({
       where: { [`${entityType}Id`]: entityId } as unknown as Prisma.ThreadWhereUniqueInput,
@@ -349,9 +388,6 @@ export const upsertComment = async ({
   // empty comment and editing stickers in would be free. The spend runs inside
   // the same transaction as the write below — charging in its own transaction
   // would debit uses and then lose the comment to any failure in between.
-  const previous = data.id
-    ? await dbWrite.commentV2.findUnique({ where: { id: data.id }, select: { content: true } })
-    : null;
   const chargeStickers = (tx: Prisma.TransactionClient) =>
     spendStickerUses({
       userId,

--- a/src/server/services/commentsv2.service.ts
+++ b/src/server/services/commentsv2.service.ts
@@ -252,6 +252,42 @@ export async function isViewerContentOwner({
   return ownerId === userId;
 }
 
+// A cycle backstop, not a product limit: the chain below terminates at a top-level thread, which
+// no surface nests anywhere near this deep.
+const MAX_THREAD_CHAIN_DEPTH = 100;
+
+/**
+ * Refuses a write into a locked thread, or into any thread nested under one.
+ *
+ * A moderator locks a single `Thread` row, but a reply lives in a child thread of its own, so a
+ * check against the target row alone leaves every reply below a locked thread writable. The chain
+ * is walked through `Thread.commentId -> CommentV2.threadId`, which is derived from the stored
+ * rows; `parentThreadId` is written from request input, so it cannot decide this.
+ *
+ * `dbWrite`, deliberately: a lock is read immediately after a moderator sets it, and off the
+ * replica that read can still return the pre-lock row.
+ */
+async function throwIfThreadChainLocked(threadId: number | null | undefined) {
+  if (threadId == null) return;
+  const locked = await dbWrite.$queryRaw<{ id: number }[]>`
+    WITH RECURSIVE chain AS (
+      SELECT t.id, t.locked, t."commentId", 1 AS depth
+      FROM "Thread" t
+      WHERE t.id = ${threadId}
+
+      UNION ALL
+
+      SELECT p.id, p.locked, p."commentId", c.depth + 1 AS depth
+      FROM chain c
+      JOIN "CommentV2" pc ON pc.id = c."commentId"
+      JOIN "Thread" p ON p.id = pc."threadId"
+      WHERE c.depth < ${MAX_THREAD_CHAIN_DEPTH}
+    )
+    SELECT id FROM chain WHERE locked LIMIT 1;
+  `;
+  if (locked.length) throw throwBadRequestError('comment thread locked');
+}
+
 export const upsertComment = async ({
   userId,
   entityType,
@@ -277,13 +313,37 @@ export const upsertComment = async ({
       isModerator,
     });
   else await throwIfBlockedByEntityOwner({ userId, entityType, entityId, isModerator });
-  // only check for threads on comment create
-  let thread = await dbWrite.thread.findUnique({
-    where: { [`${entityType}Id`]: entityId } as unknown as Prisma.ThreadWhereUniqueInput,
-    select: { id: true, locked: true },
-  });
-
-  if (thread?.locked) throw throwBadRequestError('comment thread locked');
+  // The lock is resolved from the row being written. On an edit that is the stored comment's own
+  // thread: `entityType`/`entityId` are client-supplied and never checked against the comment, so
+  // reading the lock from them lets the caller choose which thread's lock is enforced. On a create
+  // it is the thread the comment lands in, plus its ancestors — see `throwIfThreadChainLocked`.
+  let thread: { id: number; locked: boolean } | null = null;
+  if (data.id) {
+    const target = await dbWrite.commentV2.findUnique({
+      where: { id: data.id },
+      select: { threadId: true },
+    });
+    if (!target) throw throwNotFoundError();
+    await throwIfThreadChainLocked(target.threadId);
+  } else {
+    thread = await dbWrite.thread.findUnique({
+      where: { [`${entityType}Id`]: entityId } as unknown as Prisma.ThreadWhereUniqueInput,
+      select: { id: true, locked: true },
+    });
+    // A reply's own thread row is created lazily, so on the first reply to a comment there is no
+    // thread yet to carry the ancestors — walk from the parent comment's thread instead.
+    const anchorThreadId =
+      thread?.id ??
+      (entityType === 'comment'
+        ? (
+            await dbWrite.commentV2.findUnique({
+              where: { id: entityId },
+              select: { threadId: true },
+            })
+          )?.threadId
+        : undefined);
+    await throwIfThreadChainLocked(anchorThreadId);
+  }
 
   // An edit that adds stickers must pay for the ones it added, or posting an
   // empty comment and editing stickers in would be free. The spend runs inside


### PR DESCRIPTION
Resolves a comment thread's lock from the rows being written, and extends a lock to the threads nested under it.

`upsertComment` read `Thread.locked` through the request's `entityType`/`entityId`, while the write it guards is scoped by comment id alone. The two were never checked against each other, so an edit was judged against whichever thread the request named. It now resolves the thread from the stored comment.

A lock is set on a single `Thread` row, but a reply lives in a child thread of its own, so nothing above the target row was consulted and a reply below a locked thread was accepted. `throwIfThreadChainLocked` walks up through `Thread.commentId -> CommentV2.threadId` — the stored linkage, not `parentThreadId`, which is written from request input — and refuses if any thread in the chain is locked. Reads go to `dbWrite`, so a lock set moments earlier is visible.

The legacy model-comment surface had the same split: `Model.locked` was read from the request's `modelId` while `createOrUpdateComment` writes that field through from the request. It now checks the model the request names **and** the one the comment is stored under, which is the same pair `getBlockCheckOwnerIdsForModelComment` already resolves for the block check.

Moderators are not exempted, because they were not before — the previous check threw for everyone. Worth deciding separately: the client's `canEdit` does let a moderator through, so the two disagree, but that predates this.

## Tests

`commentsv2.threadLock.service.test.ts` (7) and `comment.router.model-lock.test.ts` (4). Both include the ordinary-use direction, not only the refusal.

Reverting `commentsv2.service.ts` and re-running: **5 failed | 2 passed (7)**, with assertions naming values — `expected [] to deeply equal [ 42 ]`, `promise resolved "{ id: 5 }" instead of rejecting`. The two that still pass are the two ordinary-use cases, which is correct.

Reverting `comment.router.ts`: **2 failed | 2 passed (4)**. One of those two failures is honest; the other falls out because the reverted code calls `findUnique` where the fake implements `findFirst`, so it does not carry weight on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MkJyhc4BdEnHTHBZyvxqx

---

## After an adversarial review (`b3a201fd8b`)

**The walk failed open at orphaned threads.** `Thread.commentId` is `onDelete: SetNull` and deleting a comment does not clean up the thread hanging off it, so those exist in bulk — 250,071 in production, 4.6% of all threads. A walk ending there has not proved the absence of a lock; it has run out of road, and from the recursion alone the two look identical. It now refuses, as does exhausting the depth cap. Both had been fail-open.

**The read side did not match.** `isLocked` came from `getThreadDetails` for one thread row, so a nested provider under a locked thread still rendered Reply and Edit while the server refused the write. Nested providers now inherit the enclosing lock through context — no extra query. All 49 locked threads in production today are entity-level and none is a comment subthread, so this was the only live behavioural change the PR introduced.

**Worth not misreading in the diff:** the legacy middleware's `comment.findFirst({ where: { id } })` ran with `id` undefined on every create, which Prisma treats as no filter — `ctx.locked` came from an arbitrary row of `Comment`. The `id ? … : null` makes it deterministically false. `findFirst` → `findFirst` is not a no-op here.

**Not fixed, and not claimed to be:** an edit can still re-home a comment onto another *unlocked* model, and nothing checks a legacy parent comment's locked state. This closes the lock escape, not the re-homing.

### Per-gap mutation controls

A single mutation reddening everything would mean the three gaps are not separately covered.

| mutation | fails |
|---|---|
| edit branch resolves the request-named thread again | 5, all edit-path |
| create branch checks only its own thread row | 2, the create/reply pair |
| drop the fail-closed refusal | 1, the orphan test |
| service file reverted to `ea9d8dd3c6` | 8 of 10 |
