### PR TITLE
fix(chat): count unread badge over both inbox statuses

### DIFF
--- a/docs/features/chat-dm-redesign.md
+++ b/docs/features/chat-dm-redesign.md
@@ -101,8 +101,11 @@ Active / Pending / Archived:
 - **Requests** — `Invited` where `filteredAt IS NOT NULL`
 - **Archived** — `Ignored`, `Left`, `Kicked` (unchanged)
 
-`getUnreadMessagesForUserHandler` must exclude members with `filteredAt` set, or a filtered
-request still rings the header badge and the filtering achieves nothing.
+`getUnreadMessagesForUserHandler` counts the Inbox bucket, so it selects on the same two things:
+members with `filteredAt` set are excluded (or a filtered request still rings the header badge and
+the filtering achieves nothing), and both inbox statuses are included (or an unfiltered invitation
+rings a badge no tab accounts for). It selects that list from `inboxStatuses` in
+`src/shared/utils/chat.ts` for that reason.
 
 Accepting a request needs no extra handling: the existing invite accept/reject moves the member
 to `Joined`, and the bucket rule only consults `filteredAt` for `Invited` members, so the thread

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -313,10 +313,7 @@ export function ChatList() {
               {filteredData.map((d) => {
                 const myMember = d.chatMembers.find((cm) => cm.userId === currentUser?.id);
                 const otherMembers = d.chatMembers.filter((cm) => cm.userId !== currentUser?.id);
-                const unreadCount =
-                  myMember?.status === ChatMemberStatus.Invited
-                    ? 0
-                    : chatCounts?.find((cc) => cc.chatId === d.id)?.cnt;
+                const unreadCount = chatCounts?.find((cc) => cc.chatId === d.id)?.cnt;
                 const isModSender = !!otherMembers.find(
                   (om) => om.isOwner === true && om.user.isModerator === true
                 );

--- a/src/server/controllers/chat.controller.ts
+++ b/src/server/controllers/chat.controller.ts
@@ -22,7 +22,7 @@ import type {
 } from '~/server/schema/chat.schema';
 import { resolveChatSettings } from '~/server/schema/chat.schema';
 import { truncateAuditValue } from '~/server/common/chat-audit.constants';
-import { deriveMuteColumns, scopeMemberPrivacy } from '~/shared/utils/chat';
+import { deriveMuteColumns, inboxStatuses, scopeMemberPrivacy } from '~/shared/utils/chat';
 import {
   throwOnBlockedLinkDomain,
   throwOnBlockedMessagePattern,
@@ -190,6 +190,8 @@ export const getChatsForUserHandler = async ({ ctx }: { ctx: ProtectedContext })
   }
 };
 
+const inboxStatusLiterals = inboxStatuses.map((status) => `'${status}'`).join(', ');
+
 /**
  * Get number of unread messages for user
  */
@@ -203,6 +205,10 @@ export const getUnreadMessagesForUserHandler = async ({
   try {
     const { id: userId } = ctx.user;
 
+    // The badge counts what the Inbox tab holds, so the membership filter is
+    // `chatBucketFor`'s inbox case spelled in SQL. Requests (filteredAt set) are
+    // deliberately absent: a filtered request that still lights the header badge
+    // is not filtered.
     const unread = await dbRead.$queryRaw<{ chatId: number; cnt: number }[]>`
       select memb."chatId"          as "chatId",
              count(msg.id)::integer as "cnt"
@@ -215,27 +221,14 @@ export const getUnreadMessagesForUserHandler = async ({
                           (memb."clearedAt" is null or msg."createdAt" > memb."clearedAt") and
                           msg."deletedAt" is null
       where memb."userId" = ${userId}
-        and memb.status = 'Joined'
+        and memb.status in (${Prisma.raw(inboxStatusLiterals)})
         and memb."notifyLevel" <> 'None'
         and memb."filteredAt" is null
         and msg."userId" != ${userId}
       group by memb."chatId"
     `;
 
-    // Requests (filteredAt set) are deliberately absent: a filtered request that
-    // still lights the header badge is not filtered.
-    const pending = await dbRead.$queryRaw<{ chatId: number; cnt: number }[]>`
-      select memb."chatId" as "chatId",
-             1             as "cnt"
-      from "ChatMember" memb
-      where memb."userId" = ${userId}
-        and memb.status = 'Invited'
-        and memb."notifyLevel" <> 'None'
-        and memb."filteredAt" is null
-      group by memb."chatId"
-    `;
-
-    return [...unread, ...pending];
+    return unread;
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);

--- a/src/server/services/__tests__/chat-bucket.test.ts
+++ b/src/server/services/__tests__/chat-bucket.test.ts
@@ -1,6 +1,8 @@
+import { readFileSync } from 'fs';
+import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { ChatMemberStatus } from '~/shared/utils/prisma/enums';
-import { chatBucketFor } from '~/shared/utils/chat';
+import { chatBucketFor, inboxStatuses } from '~/shared/utils/chat';
 
 /**
  * Which rail bucket a membership lands in.
@@ -70,5 +72,59 @@ describe('a filtered membership is always actionable', () => {
     // membership must bucket back to the inbox.
     expect(chatBucketFor(member(ChatMemberStatus.Joined, null))).toBe('Inbox');
     expect(chatBucketFor(member(ChatMemberStatus.Invited, null))).toBe('Inbox');
+  });
+});
+
+/**
+ * The header badge cannot be exercised here — it is raw SQL — so what is pinned
+ * is the list the query interpolates. It selected `Joined` alone while the rail
+ * bucketed on `filteredAt`, so an unfiltered invitation lit the badge and then
+ * appeared under no tab's count: not Requests (unfiltered), not Inbox
+ * (`status <> 'Joined'`), and the row's own indicator was zeroed for `Invited`.
+ */
+describe('inboxStatuses', () => {
+  it('names exactly the statuses an unfiltered membership can hold in the inbox', () => {
+    const derived = Object.values(ChatMemberStatus).filter(
+      (status) => chatBucketFor({ status, filteredAt: null }) === 'Inbox'
+    );
+
+    expect([...inboxStatuses].sort()).toEqual([...derived].sort());
+  });
+
+  it('includes an unfiltered invitation — the badge counts it, so a tab has to', () => {
+    expect(inboxStatuses).toContain(ChatMemberStatus.Invited);
+    expect(inboxStatuses).toContain(ChatMemberStatus.Joined);
+  });
+
+  it('excludes every archived status', () => {
+    for (const status of [
+      ChatMemberStatus.Ignored,
+      ChatMemberStatus.Left,
+      ChatMemberStatus.Kicked,
+    ]) {
+      expect(inboxStatuses).not.toContain(status);
+    }
+  });
+});
+
+describe('🔴 the unread-badge query selects on the shared inbox statuses', () => {
+  const source = readFileSync(
+    path.resolve(__dirname, '../../controllers/chat.controller.ts'),
+    'utf8'
+  );
+
+  const handler = source.slice(source.indexOf('export const getUnreadMessagesForUserHandler'));
+  const body = handler.slice(0, handler.indexOf('\nexport const '));
+
+  it('positive control — the handler body was actually located', () => {
+    // Without this, a slice that came back empty would make the assertions below
+    // vacuously green.
+    expect(body).toContain('$queryRaw');
+    expect(body.length).toBeGreaterThan(200);
+  });
+
+  it('interpolates the shared list rather than naming a status inline', () => {
+    expect(body).toContain('memb.status in (${Prisma.raw(inboxStatusLiterals)})');
+    expect(body).not.toMatch(/memb\.status\s*=\s*'/);
   });
 });

--- a/src/shared/utils/chat.ts
+++ b/src/shared/utils/chat.ts
@@ -24,6 +24,19 @@ export function chatBucketFor(member: {
 }
 
 /**
+ * The statuses an unfiltered membership can hold and still be in the inbox.
+ * The header badge counts inbox conversations, so its query has to select on
+ * the same thing the rail buckets on — it selected `Joined` alone, and an
+ * unfiltered invitation then lit a badge no tab could account for.
+ *
+ * `chatBucketFor` stays the definition; a test pins this list to it.
+ */
+export const inboxStatuses: ChatMemberStatus[] = [
+  ChatMemberStatus.Joined,
+  ChatMemberStatus.Invited,
+];
+
+/**
  * Shared by the `createMessageInput` cap and the composer's counter. Lives here
  * rather than in `server/common/constants` because `chat.schema.ts` is a leaf the
  * client `_app` bundle imports — pulling the server constants module in from


### PR DESCRIPTION
The header badge selected `status = 'Joined'` while the rail buckets on `filteredAt`, so an unfiltered invitation lit the badge but appeared under no tab's count — and the separate pending-invite query added a row the Requests tab could never show. Both queries collapse into one that selects on the shared `inboxStatuses` list, pinned to `chatBucketFor` by a test, and the list row drops its `Invited` zeroing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868kv5myr`). Reviewed locally before push.