### PR TITLE
fix(test): normalise separators in the pageRunScrollContract guard

### DIFF
--- a/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
+++ b/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
@@ -236,7 +236,10 @@ describe('the run page and its host agree on who owns the height', () => {
           // without reopening that hole.)
           if (!/\bPageBlockHost\b/.test(src)) continue;
           if (/\bfit=(["']fill["']|\{\s*['"]fill['"]\s*\})/.test(src))
-            offenders.push(path.relative(REPO_ROOT, full));
+            // Posix separators, so the expectation below reads the same on every
+            // platform. Without this the walk yields `src\pages\…` on Windows and
+            // the guard fails there while staying green on Linux CI.
+            offenders.push(path.relative(REPO_ROOT, full).split(path.sep).join('/'));
         }
       }
     };


### PR DESCRIPTION
@
`src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts` walks `src` with `path.join` and pushed `path.relative(REPO_ROOT, full)` verbatim into `offenders`, then compared that against a hard-coded forward-slash path. On Windows the walk yields `src\pages\apps\run\[slug]\[[...path]].tsx`, so this file fails on every Windows box and passes on `ubuntu-latest` CI — it was the only failing file in an otherwise clean full unit suite locally.

Fix: collect offenders as posix paths with `.split(path.sep).join("/")`, the spelling already used at 24 other call sites under `src`.

**Controls run on Windows (commit `2d4fcb1bff`):**

- Positive: `pnpm exec vitest run --project "unit*" src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts` -> `Test Files 1 passed (1)` / `Tests 10 passed (10)`. Before the change the same command failed on the separator mismatch.
- Mutation: adding `fit="fill"` to the dev-tunnel mounter `src/pages/apps/dev/[blockId].tsx` reddens the guard, naming that file:

```
AssertionError: expected [ ...(2) ] to deeply equal [ Array(1) ]
+   "src/pages/apps/dev/[blockId].tsx",
    "src/pages/apps/run/[slug]/[[...path]].tsx",
```

  The mutation was reverted with `git checkout --` and the restore verified by reading the file.

**Sweep of the same class elsewhere.** Two populations were checked, and the second is the one the claim rests on:

1. The 34 other test files under `src` that call `path.relative` (43 call sites). 24 already normalise with `.split(path.sep).join("/")`, 6 with `.replace(/\/g, "/")`; the rest use the value in a failure message only, compare it against `[]` (separator-agnostic — a native-separator path still reddens, only the printed spelling differs), or compare native output against `path.join`-built expectations (symmetric on both platforms).
2. That grep cannot see a walk that builds paths with `path.join` or `globSync` and never calls `path.relative`. Widening to every test file under `src` that touches the filesystem gives 57 files, 23 of which the first population missed. All 23 either normalise by another spelling (`.split("\\").join("/")`) or build forward-slash relatives by construction. One of them — `hostThemeChangeParity.test.ts:194` — carries the exact assertion shape this ticket is about, compared against non-empty forward-slash literals; it normalises at `:132`.

No other file needed changing. This one was the only site comparing native separators against a non-empty forward-slash literal.

Not fixed here, recorded as follow-ups rather than widened into this PR: the offender regex `/\bfit=(["\x27]fill["\x27]|\{\s*[\x27"]fill[\x27"]\s*\})/` is fail-open on `fit={someVar}` and `fit = "fill"`; a forwarding wrapper around `PageBlockHost` would take its consumers out of the walk entirely; and `:129` ("neither half can be reverted on its own") passes on a full revert of both halves, since it asserts the two are equal rather than both true.

Closes 868kwbbfa
@