### PR TITLE
feat(moderator): show a user's abuse findings where /abuse already sends you

### DIFF
--- a/apps/moderator/src/lib/server/__tests__/abuse-detection.sql.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/abuse-detection.sql.test.ts
@@ -196,6 +196,25 @@ describe('compiled SQL — column names and shape', () => {
       expect(truncated).toBe(false);
       expect(findings).toHaveLength(1);
     });
+
+    // 🔴 THE PER-USER READ NEEDS THE SAME TWO CASES, and for a while it did not have them. It was
+    // given the identical `limit + 1` / slice / `>` treatment as its sibling above, but only the
+    // over-fetch PARAMETER was pinned — so hardcoding `truncated: false`, or dropping the `.slice`,
+    // both survived a fully green suite. The consequence is specific: this function feeds the
+    // account panel, which renders `capped` from `truncated`, so a silent `false` makes an account
+    // with 300 findings read "Abuse detections (50)" and a moderator conclude they have seen the
+    // whole record. Same harness, same asymmetry-closing pair.
+    it('reports truncated for the per-user read when the query came back over the limit', async () => {
+      const { findings, truncated } = await service.getAbuseFindingsForUser(99, 0);
+      expect(truncated).toBe(true);
+      expect(findings).toHaveLength(0); // the probe row is dropped, never rendered
+    });
+
+    it('does not report truncated for the per-user read at exactly the limit', async () => {
+      const { findings, truncated } = await service.getAbuseFindingsForUser(99, 1);
+      expect(truncated).toBe(false);
+      expect(findings).toHaveLength(1);
+    });
   });
 
   it('getAbuseFindingsForUser is ordered newest-first and NOT filtered on actioned', async () => {

--- a/apps/moderator/src/lib/server/abuse-detection.service.ts
+++ b/apps/moderator/src/lib/server/abuse-detection.service.ts
@@ -275,15 +275,23 @@ export async function getAbuseFindings(
  * Ordered newest-first and NOT filtered on `actioned`: "we looked at this account twice and did
  * nothing" is a real answer to "why is this creator complaining", and the most common one.
  */
-export async function getAbuseFindingsForUser(userId: number, limit = 50): Promise<AbuseFinding[]> {
+export async function getAbuseFindingsForUser(
+  userId: number,
+  limit = 50
+): Promise<{ findings: AbuseFinding[]; truncated: boolean }> {
+  // 🔴 `truncated` is the whole reason this returns an object. It used to return a bare array, and
+  // its caller rendered `rows.length` as the TOTAL — so an account with 300 findings read as
+  // "Abuse detections (50)" and a moderator concluded they had seen the entire record. On a surface
+  // whose whole claim is honest reporting, a cap presented as a total is the one number that lies.
+  // Same `limit + 1` probe as `getAbuseFindings` above; the extra row is dropped.
   const rows = await abuseDb()
     .selectFrom('abuse_detection_finding')
     .selectAll()
     .where('user_id', '=', userId)
     .orderBy('created_at', 'desc')
-    .limit(limit)
+    .limit(limit + 1)
     .execute();
-  return rows.map(toFinding);
+  return { findings: rows.slice(0, limit).map(toFinding), truncated: rows.length > limit };
 }
 
 /** The distinct detectors that have ever reported, for the board's filter. */

--- a/apps/moderator/src/routes/abuse/[runId]/+page.svelte
+++ b/apps/moderator/src/routes/abuse/[runId]/+page.svelte
@@ -79,9 +79,13 @@
       {#each rows as f (f.id)}
         <TableRow>
           <TableCell>
-            <!-- `?q=`, not `?userId=` — the bare route redirects to the default section carrying `q`
-                 forward, and an unknown param is dropped, landing the moderator on an empty search. -->
-            <a class={LINK_CLASS} href="/retool/user-lookup?q={f.userId}">{f.userId}</a>
+            <!-- `?q=`, not `?userId=` — an unknown param is dropped, landing the moderator on an
+                 empty search.
+                 🔴 And the SECTION is named rather than left to the bare route's redirect, which
+                 lands on Basic. Following this link used to arrive at a page with ~20 panels and
+                 nothing about abuse detection; mod-activity is where AbuseFindingsPanel renders, so
+                 the finding a moderator clicked is on the page they land on. -->
+            <a class={LINK_CLASS} href="/retool/user-lookup/mod-activity?q={f.userId}">{f.userId}</a>
           </TableCell>
           <TableCell>{confidence(f.confidence)}</TableCell>
           <!-- "No" is the common and important case: detected, scored, deliberately left alone. It is

--- a/apps/moderator/src/routes/abuse/__tests__/user-findings-round-trip.test.ts
+++ b/apps/moderator/src/routes/abuse/__tests__/user-findings-round-trip.test.ts
@@ -1,0 +1,148 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * The /abuse → User Lookup ROUND TRIP.
+ *
+ * 🔴 WHAT THIS EXISTS TO STOP, and why no existing test could see it. Every piece was individually
+ * correct and individually tested: `/abuse` linked each finding's user id, User Lookup rendered its
+ * panels, and `getAbuseFindingsForUser` was covered by a SQL test. The defect lived in the SEAM —
+ * the link went to a page that said nothing about abuse detection, and it went to the DEFAULT
+ * section rather than one that could. Nothing was broken, so nothing failed. It was found by
+ * driving the real page as a first-time user.
+ *
+ * These are source-level assertions on purpose. The alternative is a full SvelteKit render harness
+ * this app does not have, and the failure mode being pinned is structural: a link pointing
+ * somewhere that cannot answer it, and a service function with no caller.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP = join(HERE, '../../..'); // src/
+const read = (p: string) => readFileSync(join(APP, p), 'utf8');
+
+const RUN_PAGE = 'routes/abuse/[runId]/+page.svelte';
+const SECTION_PAGE = 'routes/retool/user-lookup/[section]/+page.svelte';
+const PANEL = 'routes/retool/user-lookup/AbuseFindingsPanel.svelte';
+const API = 'routes/api/user-abuse-findings/[userId]/+server.ts';
+
+describe('abuse finding → user lookup round trip', () => {
+  it('the finding link names a SECTION, not the bare route that redirects to Basic', () => {
+    const src = read(RUN_PAGE);
+    const href = /href="(\/retool\/user-lookup[^"]*)"/.exec(src)?.[1];
+    expect(href, 'the user id must still link somewhere').toBeTruthy();
+    expect(href, 'a bare /retool/user-lookup?q= lands on Basic, which shows no findings').toMatch(
+      /^\/retool\/user-lookup\/[a-z-]+\?q=/
+    );
+  });
+
+  it('the section it links to is the one that actually renders the findings panel', () => {
+    // 🔴 THE SEAM ITSELF. Either half can be edited alone and stay green on its own terms: rename
+    // the section in the link and it still "links somewhere"; move the panel to another section and
+    // it still "renders". Only comparing them catches the pair drifting apart.
+    const linked = /href="\/retool\/user-lookup\/([a-z-]+)\?q=/.exec(read(RUN_PAGE))?.[1];
+    expect(linked).toBeTruthy();
+
+    const sectionPage = read(SECTION_PAGE);
+    const block = new RegExp(
+      `section === '${linked}'[\\s\\S]*?(?=\\{:else if section ===|\\{:else\\}|\\{/if\\})`
+    ).exec(sectionPage)?.[0];
+    expect(block, `the section page has no branch for '${linked}'`).toBeTruthy();
+    expect(
+      block,
+      `section '${linked}' is linked from /abuse but does not render the panel`
+    ).toMatch(/<AbuseFindingsPanel\b/);
+  });
+
+  it('the panel is imported where it is rendered', () => {
+    const src = read(SECTION_PAGE);
+    expect(src).toMatch(/import AbuseFindingsPanel from/);
+  });
+
+  it('the panel fetches the endpoint that actually exists', () => {
+    const url = /fetch\(`(\/api\/[^`$]*)/.exec(read(PANEL))?.[1];
+    expect(url, 'the panel must call an api route').toBeTruthy();
+    // `/api/user-abuse-findings/` -> routes/api/user-abuse-findings/[userId]/+server.ts
+    const segment = url!.replace(/^\/api\//, '').replace(/\/$/, '');
+    expect(() => read(`routes/api/${segment}/[userId]/+server.ts`)).not.toThrow();
+  });
+
+  it('the endpoint calls the per-user service function — it had no caller before this', () => {
+    // The function existed, was indexed, and was exercised only by a SQL test. A service function
+    // whose sole caller is its own test is dead code wearing coverage.
+    expect(read(API)).toMatch(/getAbuseFindingsForUser\(/);
+  });
+
+  it('the panel does not filter to actioned findings', () => {
+    // The service deliberately returns both, because "we looked and did nothing" is the answer a
+    // moderator most often needs. A filter added in the UI would silently undo that.
+    const src = read(PANEL);
+    expect(src).not.toMatch(/\.filter\([^)]*actioned/);
+  });
+
+  it('a load failure is not rendered as "no findings"', () => {
+    // Opposite conclusions: one means the account is clean, the other means we do not know. A
+    // moderator acts differently on each, so the catch branch must not read as an empty result.
+    const src = read(PANEL);
+    const katch = /\{:catch[\s\S]*?\{\/await\}/.exec(src)?.[0];
+    expect(katch, 'the panel must handle a failed fetch').toBeTruthy();
+    expect(katch).toMatch(/NOT the same as none/i);
+  });
+});
+
+describe('the zero-confidence label', () => {
+  it('0.00 is labelled as a verdict, not left to read as "unscored"', () => {
+    // Every "Judged and deliberately NOT actioned" finding carries exactly 0.00, printed beside a
+    // reason that describes the evidence in detail. Unlabelled, that reads as self-contradictory —
+    // and a moderator either dismisses a real finding or trusts a rejected one.
+    const src = read(PANEL);
+    expect(src).toMatch(/f\.confidence === 0/);
+    expect(src).toMatch(/judged not abuse/i);
+  });
+});
+
+describe('the endpoint is guarded like its siblings', () => {
+  it('uses requireUserIdParam rather than trusting the route param', () => {
+    const src = read(API);
+    expect(src).toMatch(/requireUserIdParam\(locals, params/);
+  });
+
+  it('is a plain RequestHandler, not a WebhookEndpoint — there IS a user behind this call', () => {
+    // A token-callable route has no user and can attribute nothing. This one is read by a signed-in
+    // moderator and must go through the session guard, like every other user-lookup panel feed.
+    const src = read(API);
+    expect(src).not.toMatch(/WebhookEndpoint|defineWebhookEndpoint/);
+  });
+});
+
+// Kept out of the source-level block on purpose: this one executes the handler.
+describe('the endpoint returns what the panel expects', () => {
+  it('answers { findings: [...] } from the service', async () => {
+    const rows = [
+      {
+        id: 1,
+        runId: 4,
+        userId: 7,
+        confidence: 0,
+        reason: 'Judged and deliberately NOT actioned.',
+        actioned: false,
+        action: null,
+        createdAt: new Date(),
+      },
+    ];
+    vi.doMock('$lib/server/abuse-detection.service', () => ({
+      getAbuseFindingsForUser: vi.fn().mockResolvedValue(rows),
+    }));
+    vi.doMock('$lib/server/api-guard', () => ({ requireUserIdParam: () => 7 }));
+
+    const { GET } = await import('../../api/user-abuse-findings/[userId]/+server');
+    const res = await (GET as (e: unknown) => Promise<Response>)({
+      params: { userId: '7' },
+      locals: {},
+    });
+    await expect(res.json()).resolves.toEqual({
+      findings: rows.map((r) => ({ ...r, createdAt: r.createdAt.toISOString() })),
+    });
+  });
+});

--- a/apps/moderator/src/routes/abuse/__tests__/user-findings-round-trip.test.ts
+++ b/apps/moderator/src/routes/abuse/__tests__/user-findings-round-trip.test.ts
@@ -55,6 +55,22 @@ describe('abuse finding → user lookup round trip', () => {
     ).toMatch(/<AbuseFindingsPanel\b/);
   });
 
+  it('the linked section is a REAL section — sections.ts is the routing authority', async () => {
+    // 🔴 THE THIRD PARTY TO THE SEAM, which the test above cannot see. The section page's
+    // `{:else if section === '…'}` branch is not what decides routing: `[section]/+page.server.ts`
+    // rejects anything `isSection()` denies with a 404 BEFORE the page renders. So renaming the
+    // slug in sections.ts alone made /abuse's link 404 while every other assertion here stayed
+    // green — the link matched the branch, the branch rendered the panel, and the route did not
+    // exist. Three parties, and the guard compared two of them.
+    const linked = /href="\/retool\/user-lookup\/([a-z-]+)\?q=/.exec(read(RUN_PAGE))?.[1];
+    expect(linked, 'the link must name a section at all').toBeTruthy();
+    const { isSection } = await import('../../retool/user-lookup/sections');
+    expect(
+      isSection(linked as string),
+      `'${linked}' is linked from /abuse but is not a known section`
+    ).toBe(true);
+  });
+
   it('the panel is imported where it is rendered', () => {
     const src = read(SECTION_PAGE);
     expect(src).toMatch(/import AbuseFindingsPanel from/);
@@ -126,10 +142,55 @@ describe('the endpoint is guarded like its siblings', () => {
     );
   });
 
-  it('a caller without that grant gets nothing, not an error banner', () => {
-    // 403 here means "not yours", not "broken". Staff and payroll legitimately reach this section.
-    const src = read(PANEL);
-    expect(src).toMatch(/status === 403/);
+  it('the panel is MOUNTED on the grant, so it has no 403 branch to get wrong', () => {
+    // 🔴 WHY THIS IS STRUCTURAL AND NOT A REGEX. The panel used to mount for everyone and interpret
+    // the 403 itself, and a one-line mutation — `Promise.resolve(null)` to
+    // `Promise.resolve({ findings: [] })` — turned a permission boundary into "No detector has ever
+    // reported this account", a reassuring zero shown to someone not allowed to know. A test
+    // grepping for `status === 403` could not see that mutation. Deciding server-side deletes the
+    // branch instead of guarding it.
+    const layout = read('routes/retool/user-lookup/+layout.server.ts');
+    expect(layout).toMatch(/canSeeAbuse = canAccess\(locals\.user, '\/abuse'\)/);
+    expect(layout, 'the flag must actually reach the page').toMatch(/canSeeAbuse[,}]/);
+
+    const section = read(SECTION_PAGE);
+    const guarded = /\{#if data\.canSeeAbuse\}[\s\S]*?<AbuseFindingsPanel[\s\S]*?\{\/if\}/.exec(
+      section
+    );
+    expect(
+      guarded,
+      'the panel must be mounted behind the grant, not mounted then denied'
+    ).toBeTruthy();
+
+    // Assert the absence of a CODE PATH, not of the digits — the panel's comment explains the 403
+    // history on purpose, and a guard that forbids the number punishes the documentation it
+    // depends on. (Caught by this assertion failing on its own explanatory comment.)
+    expect(read(PANEL), 'no permission BRANCH belongs in the panel').not.toMatch(/r\.status\s*===/);
+  });
+
+  it('a capped result is reported as capped, never as a total', () => {
+    // The service returns at most 50. `total={rows.length}` alone renders that cap as the total, and
+    // an account with 300 findings reads as "Abuse detections (50)" — seen the whole record.
+    const panel = read(PANEL);
+    expect(panel).toMatch(/capped=\{truncated\}/);
+    const service = read('lib/server/abuse-detection.service.ts');
+    const fn = /export async function getAbuseFindingsForUser[\s\S]*?\n\}/.exec(service)?.[0];
+    expect(fn, 'the service must SIGNAL truncation, not silently cap').toMatch(/truncated/);
+    // 🔴 MATCH THE CALL, NOT THE PROSE. `/limit \+ 1/` also matches the comment above the query
+    // that SAYS "same `limit + 1` probe" — so removing the probe from the code left this green.
+    // Caught by the mutant surviving; the fix is to assert the expression that does the work.
+    expect(fn, 'detected with the same limit + 1 probe as its sibling').toMatch(
+      /\.limit\(limit \+ 1\)/
+    );
+  });
+
+  it('the expand toggle actually expands — children takes the row limit', () => {
+    // ListCard's `children` is `Snippet<[number]>` and it renders `children(limit)`. Implicit
+    // children ignore the argument, so every row draws regardless and "Show all N" toggles only its
+    // own label. svelte-check cannot see it: Snippet<[]> is assignable to Snippet<[number]>.
+    const panel = read(PANEL);
+    expect(panel).toMatch(/\{#snippet children\(limit: number\)\}/);
+    expect(panel).toMatch(/rows\.slice\(0, limit\)/);
   });
 
   it('is a plain RequestHandler, not a WebhookEndpoint — there IS a user behind this call', () => {
@@ -143,7 +204,7 @@ describe('the endpoint is guarded like its siblings', () => {
 // Kept out of the source-level block on purpose: this one executes the handler.
 describe('the endpoint returns what the panel expects', () => {
   it('answers { findings: [...] } from the service', async () => {
-    const rows = [
+    const findings = [
       {
         id: 1,
         runId: 4,
@@ -156,7 +217,7 @@ describe('the endpoint returns what the panel expects', () => {
       },
     ];
     vi.doMock('$lib/server/abuse-detection.service', () => ({
-      getAbuseFindingsForUser: vi.fn().mockResolvedValue(rows),
+      getAbuseFindingsForUser: vi.fn().mockResolvedValue({ findings, truncated: false }),
     }));
     vi.doMock('$lib/server/api-guard', () => ({ requireUserIdParam: () => 7 }));
 
@@ -165,8 +226,11 @@ describe('the endpoint returns what the panel expects', () => {
       params: { userId: '7' },
       locals: {},
     });
+    // The panel destructures BOTH keys; a service that dropped `truncated` would render a cap as a
+    // total, so the endpoint must pass it through rather than re-wrapping just the array.
     await expect(res.json()).resolves.toEqual({
-      findings: rows.map((r) => ({ ...r, createdAt: r.createdAt.toISOString() })),
+      findings: findings.map((r) => ({ ...r, createdAt: r.createdAt.toISOString() })),
+      truncated: false,
     });
   });
 });

--- a/apps/moderator/src/routes/abuse/__tests__/user-findings-round-trip.test.ts
+++ b/apps/moderator/src/routes/abuse/__tests__/user-findings-round-trip.test.ts
@@ -153,14 +153,34 @@ describe('the endpoint is guarded like its siblings', () => {
     expect(layout).toMatch(/canSeeAbuse = canAccess\(locals\.user, '\/abuse'\)/);
     expect(layout, 'the flag must actually reach the page').toMatch(/canSeeAbuse[,}]/);
 
+    // 🔴 CONTAINMENT, NOT ORDERING. This was
+    // `/\{#if data\.canSeeAbuse\}[\s\S]*?<AbuseFindingsPanel[\s\S]*?\{\/if\}/`, whose lazy spans assert
+    // only that the three tokens appear in that ORDER somewhere in the file. An empty
+    // `{#if data.canSeeAbuse}{/if}` placed earlier, with the panel mounted UNGUARDED in the
+    // mod-activity branch, satisfied it — the panel mounted for every moderator, suite green. Walk
+    // the block to its matching `{/if}` and require the mount inside it; pin the mount count so a
+    // second unguarded copy cannot hide behind the guarded one.
     const section = read(SECTION_PAGE);
-    const guarded = /\{#if data\.canSeeAbuse\}[\s\S]*?<AbuseFindingsPanel[\s\S]*?\{\/if\}/.exec(
-      section
-    );
+    const open = section.indexOf('{#if data.canSeeAbuse}');
+    expect(open, 'the panel must be mounted behind the grant').toBeGreaterThan(-1);
+    let depth = 0;
+    let end = -1;
+    for (const m of section.slice(open).matchAll(/\{#if\b|\{\/if\}/g)) {
+      depth += m[0] === '{/if}' ? -1 : 1;
+      if (depth === 0) {
+        end = open + (m.index as number) + m[0].length;
+        break;
+      }
+    }
+    expect(end, 'the guard block must be closed').toBeGreaterThan(open);
     expect(
-      guarded,
-      'the panel must be mounted behind the grant, not mounted then denied'
-    ).toBeTruthy();
+      section.slice(open, end),
+      'the mount must be INSIDE the grant block, not merely after it'
+    ).toMatch(/<AbuseFindingsPanel\b/);
+    expect(
+      section.match(/<AbuseFindingsPanel\b/g)?.length,
+      'exactly one mount — a second, unguarded copy would hide behind the guarded one'
+    ).toBe(1);
 
     // Assert the absence of a CODE PATH, not of the digits — the panel's comment explains the 403
     // history on purpose, and a guard that forbids the number punishes the documentation it
@@ -175,7 +195,13 @@ describe('the endpoint is guarded like its siblings', () => {
     expect(panel).toMatch(/capped=\{truncated\}/);
     const service = read('lib/server/abuse-detection.service.ts');
     const fn = /export async function getAbuseFindingsForUser[\s\S]*?\n\}/.exec(service)?.[0];
-    expect(fn, 'the service must SIGNAL truncation, not silently cap').toMatch(/truncated/);
+    // 🔴 THE FOURTH PROSE MATCH IN THIS FILE, and the narrowest miss: `/truncated/` matched the
+    // return-TYPE annotation and the comment explaining the flag, so deleting the key from the
+    // returned object left this green. (svelte-check catches that particular mutant via the declared
+    // type — which is the point: the assertion contributed nothing while reading as coverage.)
+    expect(fn, 'the service must SIGNAL truncation, not silently cap').toMatch(
+      /return \{[^}]*truncated:/
+    );
     // 🔴 MATCH THE CALL, NOT THE PROSE. `/limit \+ 1/` also matches the comment above the query
     // that SAYS "same `limit + 1` probe" — so removing the probe from the code left this green.
     // Caught by the mutant surviving; the fix is to assert the expression that does the work.
@@ -201,6 +227,49 @@ describe('the endpoint is guarded like its siblings', () => {
   });
 });
 
+// 🔴 THE DISCRIMINATION WAS IMPLEMENTED AND WHOLLY UNGUARDED — deleting the 42P01 branch, or the
+// entire try/catch, both survived a green suite. It exists so an environment that never ran
+// schema.sql does not send an operator hunting a database outage; unguarded, the next
+// simplification silently restores exactly that. Same table shape as the list page's
+// `load-status.test.ts`, which has covered this for the pages since they shipped.
+describe('the endpoint discriminates database states', () => {
+  const load = async (rejection: unknown) => {
+    vi.resetModules();
+    vi.doMock('$lib/server/abuse-detection.service', () => ({
+      getAbuseFindingsForUser: vi.fn().mockRejectedValue(rejection),
+    }));
+    vi.doMock('$lib/server/api-guard', () => ({ requireUserIdParam: () => 7 }));
+    const { GET } = await import('../../api/user-abuse-findings/[userId]/+server');
+    return (GET as (e: unknown) => Promise<Response>)({ params: { userId: '7' }, locals: {} });
+  };
+
+  it.each([
+    ['42P01', /do not exist yet/],
+    ['42501', /cannot read them/],
+  ])('maps pg %s to its own explanation', async (code, expected) => {
+    await expect(load(Object.assign(new Error('pg'), { code }))).rejects.toMatchObject({
+      status: 503,
+      body: { message: expect.stringMatching(expected) },
+    });
+  });
+
+  it('names the missing connection string rather than reporting an outage', async () => {
+    await expect(load(new Error('MODERATOR_DATABASE_URL is not configured'))).rejects.toMatchObject(
+      {
+        status: 503,
+        body: { message: expect.stringMatching(/DATABASE_URL/) },
+      }
+    );
+  });
+
+  it('falls back to unreachable for anything else', async () => {
+    await expect(load(Object.assign(new Error('boom'), { code: '57P01' }))).rejects.toMatchObject({
+      status: 503,
+      body: { message: expect.stringMatching(/Could not reach/) },
+    });
+  });
+});
+
 // Kept out of the source-level block on purpose: this one executes the handler.
 describe('the endpoint returns what the panel expects', () => {
   it('answers { findings: [...] } from the service', async () => {
@@ -216,6 +285,11 @@ describe('the endpoint returns what the panel expects', () => {
         createdAt: new Date(),
       },
     ];
+    // 🔴 OWNS ITS MOCK, including the reset. The discrimination block above calls
+    // `vi.resetModules()` per case, so a test that relied on registry state left by an earlier
+    // `doMock` started resolving the REJECTING mock and failed — a test whose verdict depended on
+    // the order it ran in. Resetting here makes this case independent of what ran before it.
+    vi.resetModules();
     vi.doMock('$lib/server/abuse-detection.service', () => ({
       getAbuseFindingsForUser: vi.fn().mockResolvedValue({ findings, truncated: false }),
     }));

--- a/apps/moderator/src/routes/abuse/__tests__/user-findings-round-trip.test.ts
+++ b/apps/moderator/src/routes/abuse/__tests__/user-findings-round-trip.test.ts
@@ -108,6 +108,30 @@ describe('the endpoint is guarded like its siblings', () => {
     expect(src).toMatch(/requireUserIdParam\(locals, params/);
   });
 
+  it('is granted on /abuse — NOT on the page it renders inside', () => {
+    // 🔴 THE MISTAKE THIS PINS, which was live in the first commit of this PR. The panel renders
+    // inside User Lookup, so gating on '/retool/user-lookup' is the natural choice — and it widens
+    // access: measured against the live grants, User Lookup is held by
+    // {senior, community-manager, staff, payroll} and /abuse by {senior, community-manager}. The
+    // narrower set is deliberate; that evidence feeds ban decisions. Gating on the CONTAINER hands
+    // it to two roles it was withheld from, via a panel, with no page of their own showing it.
+    //
+    // Asserted as an exact argument rather than "mentions /abuse somewhere", because the guard's
+    // pagePath is an ARRAY with `.some()` semantics — adding a second path is OR, i.e. wider, and
+    // would read like tightening.
+    const src = read(API);
+    expect(src).toMatch(/requireUserIdParam\(locals, params, '\/abuse'\)/);
+    expect(src, 'gating on the container page would widen access to staff and payroll').not.toMatch(
+      /requireUserIdParam\([^)]*'\/retool\/user-lookup'/
+    );
+  });
+
+  it('a caller without that grant gets nothing, not an error banner', () => {
+    // 403 here means "not yours", not "broken". Staff and payroll legitimately reach this section.
+    const src = read(PANEL);
+    expect(src).toMatch(/status === 403/);
+  });
+
   it('is a plain RequestHandler, not a WebhookEndpoint — there IS a user behind this call', () => {
     // A token-callable route has no user and can attribute nothing. This one is read by a signed-in
     // moderator and must go through the session guard, like every other user-lookup panel feed.

--- a/apps/moderator/src/routes/api/user-abuse-findings/[userId]/+server.ts
+++ b/apps/moderator/src/routes/api/user-abuse-findings/[userId]/+server.ts
@@ -1,0 +1,26 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireUserIdParam } from '$lib/server/api-guard';
+import { getAbuseFindingsForUser } from '$lib/server/abuse-detection.service';
+
+// Everything the automated detectors have said about ONE account, for the Moderation Activity
+// section of User Lookup.
+//
+// 🔴 WHY THIS EXISTS. `/abuse` already links each finding's user id here, and until now the
+// destination said nothing about abuse detection at all — a moderator followed the link from the
+// evidence to a page with ~20 panels, none of which mentioned why the account had been flagged.
+// The round trip was broken at the far end, not at the link.
+//
+// Fetched client-side like the mod-activity and security-signal panels: one indexed query
+// (`abuse_detection_finding_user_idx` on `(user_id, created_at DESC)`), cheap on its own but not
+// worth adding to the identity render path, which every section pays for.
+//
+// 🔴 NOT filtered on `actioned`, deliberately — the service function says so and it is the whole
+// point of the panel. "We looked at this account twice and did nothing" is a real answer to "why
+// is this creator complaining", and it is the most common one. Filtering to actioned findings
+// would turn a record of restraint into a record of enforcement.
+export const GET: RequestHandler = async ({ params, locals }) => {
+  const userId = requireUserIdParam(locals, params, '/retool/user-lookup');
+  const findings = await getAbuseFindingsForUser(userId);
+  return json({ findings });
+};

--- a/apps/moderator/src/routes/api/user-abuse-findings/[userId]/+server.ts
+++ b/apps/moderator/src/routes/api/user-abuse-findings/[userId]/+server.ts
@@ -1,4 +1,4 @@
-import { json } from '@sveltejs/kit';
+import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { requireUserIdParam } from '$lib/server/api-guard';
 import { getAbuseFindingsForUser } from '$lib/server/abuse-detection.service';
@@ -31,6 +31,25 @@ import { getAbuseFindingsForUser } from '$lib/server/abuse-detection.service';
 // WIDER. The data's own page is the only correct gate.
 export const GET: RequestHandler = async ({ params, locals }) => {
   const userId = requireUserIdParam(locals, params, '/abuse');
-  const findings = await getAbuseFindingsForUser(userId);
-  return json({ findings });
+  try {
+    return json(await getAbuseFindingsForUser(userId));
+  } catch (e) {
+    // 🔴 THE SAME DISCRIMINATION THE /abuse PAGES ALREADY DO, for the same reason: a flat 500 sends
+    // an operator hunting a database outage when the tables have simply never been created, or were
+    // created by the WRONG ROLE — two states that are likely, distinct, and otherwise
+    // indistinguishable from a real outage. Without this, an environment missing schema.sql answers
+    // 500 on EVERY visit to this section for EVERY account, and logs it as an unhandled error.
+    console.error('[abuse-detection] per-user findings load failed', e);
+    const code = (e as { code?: unknown }).code;
+    if (code === '42P01')
+      throw error(503, 'The abuse-detection tables do not exist yet — apply schema.sql.');
+    if (code === '42501')
+      throw error(
+        503,
+        'The abuse-detection tables exist but this role cannot read them — re-run schema.sql as the application role.'
+      );
+    if (e instanceof Error && e.message.includes('DATABASE_URL'))
+      throw error(503, 'MODERATOR_DATABASE_URL is not configured for this environment.');
+    throw error(503, 'Could not reach the abuse-detection database.');
+  }
 };

--- a/apps/moderator/src/routes/api/user-abuse-findings/[userId]/+server.ts
+++ b/apps/moderator/src/routes/api/user-abuse-findings/[userId]/+server.ts
@@ -34,7 +34,14 @@ export const GET: RequestHandler = async ({ params, locals }) => {
   try {
     return json(await getAbuseFindingsForUser(userId));
   } catch (e) {
-    // 🔴 THE SAME DISCRIMINATION THE /abuse PAGES ALREADY DO, for the same reason: a flat 500 sends
+    // 🔴 THE SAME DISCRIMINATION THE /abuse PAGES DO — but NOT the same delivery, and the
+    // difference matters to whoever reads this next. Those pages render the discriminated copy as
+    // visible page text; this panel's {:catch} takes no error binding and shows one fixed string
+    // for all four states. What actually lands here is the 503 STATUS and the console.error line —
+    // enough for an operator reading logs, not for a moderator reading the screen. Surfacing the
+    // message in the panel is a further change, deliberately not made here.
+    //
+    // The reason for discriminating at all is unchanged: a flat 500 sends
     // an operator hunting a database outage when the tables have simply never been created, or were
     // created by the WRONG ROLE — two states that are likely, distinct, and otherwise
     // indistinguishable from a real outage. Without this, an environment missing schema.sql answers

--- a/apps/moderator/src/routes/api/user-abuse-findings/[userId]/+server.ts
+++ b/apps/moderator/src/routes/api/user-abuse-findings/[userId]/+server.ts
@@ -19,8 +19,18 @@ import { getAbuseFindingsForUser } from '$lib/server/abuse-detection.service';
 // point of the panel. "We looked at this account twice and did nothing" is a real answer to "why
 // is this creator complaining", and it is the most common one. Filtering to actioned findings
 // would turn a record of restraint into a record of enforcement.
+// 🔴 GRANTED ON `/abuse`, NOT ON THE PAGE THIS RENDERS IN. The panel lives inside User Lookup, so
+// gating it on `/retool/user-lookup` is the obvious choice and it is WRONG: measured against the
+// live grants, User Lookup is held by {senior, community-manager, staff, payroll} while `/abuse` is
+// held by {senior, community-manager} only. The narrower set is deliberate — that page shows
+// per-account evidence that feeds ban decisions — so gating on the container would have handed
+// exactly that evidence to two roles it was withheld from, through a side door, with no page of
+// their own ever showing it.
+//
+// ⚠️ `requireIdParam` takes an ARRAY, but it is `.some()` — passing both paths would be OR, i.e.
+// WIDER. The data's own page is the only correct gate.
 export const GET: RequestHandler = async ({ params, locals }) => {
-  const userId = requireUserIdParam(locals, params, '/retool/user-lookup');
+  const userId = requireUserIdParam(locals, params, '/abuse');
   const findings = await getAbuseFindingsForUser(userId);
   return json({ findings });
 };

--- a/apps/moderator/src/routes/retool/user-lookup/+layout.server.ts
+++ b/apps/moderator/src/routes/retool/user-lookup/+layout.server.ts
@@ -9,9 +9,15 @@ export const load: LayoutServerLoad = async ({ url, locals }) => {
   const { q } = parseQuery(url, lookupQuerySchema);
   // `canAct` gates the enforcement UI; the actions re-check it server-side regardless.
   const canAct = canAccess(locals.user, '/users');
+  // 🔴 Decided HERE, not in the panel. User Lookup is granted more widely than /abuse, so an
+  // unentitled moderator legitimately reaches this page — and having the panel mount and interpret
+  // a 403 put a one-line mutation between them and "No detector has ever reported this account",
+  // i.e. a permission boundary rendered as a clean record. Deciding server-side means there is no
+  // client branch to get that wrong. The endpoint re-checks regardless, like every action here.
+  const canSeeAbuse = canAccess(locals.user, '/abuse');
   // Full content width: the panels are multi-column and data-dense (Buzz shows the transaction form
   // and the history together), and the 6xl cap forced them into a single narrow stack.
-  const base = { q, canAct, wide: true };
+  const base = { q, canAct, canSeeAbuse, wide: true };
   if (!q) return { ...base, result: null, notFound: false };
 
   const userId = await resolveUserId(q);

--- a/apps/moderator/src/routes/retool/user-lookup/AbuseFindingsPanel.svelte
+++ b/apps/moderator/src/routes/retool/user-lookup/AbuseFindingsPanel.svelte
@@ -30,7 +30,13 @@
   const findings = $derived(
     browser
       ? fetch(`/api/user-abuse-findings/${userId}`).then(
-          (r): Promise<{ findings: AbuseFindingRow[] }> => {
+          (r): Promise<{ findings: AbuseFindingRow[] } | null> => {
+            // 🔴 403 IS NOT AN ERROR HERE, it is "this panel is not yours". User Lookup is granted
+            // more widely than /abuse, so staff and payroll moderators legitimately land on this
+            // section without rights to abuse findings. Showing them a red failure banner would
+            // report a permission boundary as a broken page — and invite a support ticket about an
+            // outage that is not one. Render nothing instead.
+            if (r.status === 403) return Promise.resolve(null);
             if (!r.ok) throw new Error(String(r.status));
             return r.json();
           }
@@ -42,7 +48,9 @@
 {#if findings}
   {#await findings}
     <p class="text-dark-2">Loading abuse detections…</p>
-  {:then { findings: rows }}
+  {:then payload}
+    {#if payload}
+      {@const rows = payload.findings}
     <ListCard
       title="Abuse detections"
       total={rows.length}
@@ -78,6 +86,7 @@
         {/each}
       </ul>
     </ListCard>
+    {/if}
   {:catch}
     <!-- An error must not read as "this account is clean" — the two are opposite conclusions and a
          moderator acts differently on each. -->

--- a/apps/moderator/src/routes/retool/user-lookup/AbuseFindingsPanel.svelte
+++ b/apps/moderator/src/routes/retool/user-lookup/AbuseFindingsPanel.svelte
@@ -11,6 +11,13 @@
   // link from the evidence to a page that could not tell them why the account had been flagged.
   // Found by driving the real page as a first-time user, not by reading the code: nothing was
   // broken, so nothing failed.
+  //
+  // 🔴 THIS COMPONENT DOES NOT DECIDE PERMISSION. The section page mounts it only when
+  // `canSeeAbuse` (see +layout.server.ts) — so there is no 403 branch here to get wrong. An earlier
+  // revision let the panel mount for everyone and interpret the 403 itself, and a one-line change
+  // (`null` -> `{ findings: [] }`) turned a permission boundary into "No detector has ever reported
+  // this account" — a reassuring zero shown to someone who simply is not allowed to know. The
+  // endpoint re-checks the grant regardless; this is about which layer gets to be wrong.
   export type AbuseFindingRow = {
     id: number;
     runId: number;
@@ -30,13 +37,7 @@
   const findings = $derived(
     browser
       ? fetch(`/api/user-abuse-findings/${userId}`).then(
-          (r): Promise<{ findings: AbuseFindingRow[] } | null> => {
-            // 🔴 403 IS NOT AN ERROR HERE, it is "this panel is not yours". User Lookup is granted
-            // more widely than /abuse, so staff and payroll moderators legitimately land on this
-            // section without rights to abuse findings. Showing them a red failure banner would
-            // report a permission boundary as a broken page — and invite a support ticket about an
-            // outage that is not one. Render nothing instead.
-            if (r.status === 403) return Promise.resolve(null);
+          (r): Promise<{ findings: AbuseFindingRow[]; truncated: boolean }> => {
             if (!r.ok) throw new Error(String(r.status));
             return r.json();
           }
@@ -48,45 +49,52 @@
 {#if findings}
   {#await findings}
     <p class="text-dark-2">Loading abuse detections…</p>
-  {:then payload}
-    {#if payload}
-      {@const rows = payload.findings}
+  {:then { findings: rows, truncated }}
+    <!-- 🔴 `capped` is what stops the heading reporting a LIMIT as a TOTAL. The service returns at
+         most 50 and says which via `truncated`; without this an account with 300 findings renders
+         "Abuse detections (50)" and a moderator concludes they have seen the whole record. On a
+         surface whose entire claim is honest reporting, that is the one number that must not lie. -->
     <ListCard
       title="Abuse detections"
       total={rows.length}
+      capped={truncated}
       hint="What the automated detectors reported about this account. NOT filtered to actioned findings — 'looked at and deliberately left alone' is a real answer, and the most common one."
       empty="No detector has ever reported this account."
     >
-      <ul class="space-y-3">
-        {#each rows as f (f.id)}
-          <li class="border-dark-4 border-b pb-3 last:border-0">
-            <div class="mb-1 flex flex-wrap items-center gap-2">
-              {#if f.actioned}
-                <Badge variant="destructive">Acted: {f.action}</Badge>
-              {:else}
-                <!-- The common case, and the one worth reading: detected, scored, left alone. -->
-                <Badge variant="secondary">Not acted on</Badge>
-              {/if}
-              <span class="text-dark-2 text-sm">{dateTime(f.createdAt)}</span>
-              <a class={LINK_CLASS} href="/abuse/{f.runId}">run #{f.runId}</a>
-              <!-- 🔴 A confidence of 0.00 is NOT "no signal" — it is a judged verdict of "not
-                   abuse", and it renders next to a reason that describes the evidence in detail
-                   ("100% farm-IP with 16 …"), which reads as self-contradictory unless labelled.
-                   Every finding whose reason begins "Judged and deliberately NOT actioned" carries
-                   exactly 0.00 today. Saying so here costs one line and stops a moderator either
-                   dismissing a real finding or trusting a rejected one. -->
-              <span class="text-dark-2 text-sm">
-                confidence {confidence(f.confidence)}{f.confidence === 0
-                  ? ' — judged not abuse, not "unscored"'
-                  : ''}
-              </span>
-            </div>
-            <p class="text-sm">{f.reason}</p>
-          </li>
-        {/each}
-      </ul>
+      <!-- The card owns the expand toggle and passes how many rows to draw. Rendering all of them
+           regardless leaves a "Show all N" button that changes its own label and nothing else —
+           12 of the 13 ListCard call sites in this directory take the argument; this one did not. -->
+      {#snippet children(limit: number)}
+        <ul class="space-y-3">
+          {#each rows.slice(0, limit) as f (f.id)}
+            <li class="border-dark-4 border-b pb-3 last:border-0">
+              <div class="mb-1 flex flex-wrap items-center gap-2">
+                {#if f.actioned}
+                  <Badge variant="destructive">Acted: {f.action}</Badge>
+                {:else}
+                  <!-- The common case, and the one worth reading: detected, scored, left alone. -->
+                  <Badge variant="secondary">Not acted on</Badge>
+                {/if}
+                <span class="text-dark-2 text-sm">{dateTime(f.createdAt)}</span>
+                <a class={LINK_CLASS} href="/abuse/{f.runId}">run #{f.runId}</a>
+                <!-- 🔴 A confidence of 0.00 is NOT "no signal" — it is a judged verdict of "not
+                     abuse", and it renders next to a reason that describes the evidence in detail
+                     ("100% farm-IP with 16 …"), which reads as self-contradictory unless labelled.
+                     Every finding whose reason begins "Judged and deliberately NOT actioned"
+                     carries exactly 0.00 today. Saying so costs one line and stops a moderator
+                     either dismissing a real finding or trusting a rejected one. -->
+                <span class="text-dark-2 text-sm">
+                  confidence {confidence(f.confidence)}{f.confidence === 0
+                    ? ' — judged not abuse, not "unscored"'
+                    : ''}
+                </span>
+              </div>
+              <p class="text-sm">{f.reason}</p>
+            </li>
+          {/each}
+        </ul>
+      {/snippet}
     </ListCard>
-    {/if}
   {:catch}
     <!-- An error must not read as "this account is clean" — the two are opposite conclusions and a
          moderator acts differently on each. -->

--- a/apps/moderator/src/routes/retool/user-lookup/AbuseFindingsPanel.svelte
+++ b/apps/moderator/src/routes/retool/user-lookup/AbuseFindingsPanel.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { Badge } from '@civitai/ui/components/ui/badge/index.js';
+  import { LINK_CLASS, dateTime } from '$lib/format';
+  import ListCard from './ListCard.svelte';
+
+  // What the automated abuse detectors have said about THIS account.
+  //
+  // 🔴 WHY THIS PANEL EXISTS. `/abuse` links every finding's user id into User Lookup, and the
+  // destination carried ~20 panels and not one word about abuse detection — a moderator followed a
+  // link from the evidence to a page that could not tell them why the account had been flagged.
+  // Found by driving the real page as a first-time user, not by reading the code: nothing was
+  // broken, so nothing failed.
+  export type AbuseFindingRow = {
+    id: number;
+    runId: number;
+    confidence: number;
+    reason: string;
+    actioned: boolean;
+    action: string | null;
+    createdAt: string;
+  };
+
+  let { userId }: { userId: number } = $props();
+
+  // Same decimal as /abuse, for the same reason: producers do not share a calibration, so a
+  // percentage invites a cross-detector ranking that would be meaningless.
+  const confidence = (v: number) => v.toFixed(2);
+
+  const findings = $derived(
+    browser
+      ? fetch(`/api/user-abuse-findings/${userId}`).then(
+          (r): Promise<{ findings: AbuseFindingRow[] }> => {
+            if (!r.ok) throw new Error(String(r.status));
+            return r.json();
+          }
+        )
+      : null
+  );
+</script>
+
+{#if findings}
+  {#await findings}
+    <p class="text-dark-2">Loading abuse detections…</p>
+  {:then { findings: rows }}
+    <ListCard
+      title="Abuse detections"
+      total={rows.length}
+      hint="What the automated detectors reported about this account. NOT filtered to actioned findings — 'looked at and deliberately left alone' is a real answer, and the most common one."
+      empty="No detector has ever reported this account."
+    >
+      <ul class="space-y-3">
+        {#each rows as f (f.id)}
+          <li class="border-dark-4 border-b pb-3 last:border-0">
+            <div class="mb-1 flex flex-wrap items-center gap-2">
+              {#if f.actioned}
+                <Badge variant="destructive">Acted: {f.action}</Badge>
+              {:else}
+                <!-- The common case, and the one worth reading: detected, scored, left alone. -->
+                <Badge variant="secondary">Not acted on</Badge>
+              {/if}
+              <span class="text-dark-2 text-sm">{dateTime(f.createdAt)}</span>
+              <a class={LINK_CLASS} href="/abuse/{f.runId}">run #{f.runId}</a>
+              <!-- 🔴 A confidence of 0.00 is NOT "no signal" — it is a judged verdict of "not
+                   abuse", and it renders next to a reason that describes the evidence in detail
+                   ("100% farm-IP with 16 …"), which reads as self-contradictory unless labelled.
+                   Every finding whose reason begins "Judged and deliberately NOT actioned" carries
+                   exactly 0.00 today. Saying so here costs one line and stops a moderator either
+                   dismissing a real finding or trusting a rejected one. -->
+              <span class="text-dark-2 text-sm">
+                confidence {confidence(f.confidence)}{f.confidence === 0
+                  ? ' — judged not abuse, not "unscored"'
+                  : ''}
+              </span>
+            </div>
+            <p class="text-sm">{f.reason}</p>
+          </li>
+        {/each}
+      </ul>
+    </ListCard>
+  {:catch}
+    <!-- An error must not read as "this account is clean" — the two are opposite conclusions and a
+         moderator acts differently on each. -->
+    <p class="text-red-4">Could not load abuse detections. This is NOT the same as none found.</p>
+  {/await}
+{/if}

--- a/apps/moderator/src/routes/retool/user-lookup/[section]/+page.svelte
+++ b/apps/moderator/src/routes/retool/user-lookup/[section]/+page.svelte
@@ -16,6 +16,7 @@
   import GenerationPanel from '../GenerationPanel.svelte';
   import IdentityPanel from '../IdentityPanel.svelte';
   import ModActivityPanel from '../ModActivityPanel.svelte';
+  import AbuseFindingsPanel from '../AbuseFindingsPanel.svelte';
   import ModerationMemoryPanel from '../ModerationMemoryPanel.svelte';
   import NotificationsPanel from '../NotificationsPanel.svelte';
   import PromptAuditPanel from '../PromptAuditPanel.svelte';
@@ -153,6 +154,10 @@
       <ReactionsPanel {account} />
     {:else if section === 'mod-activity'}
       <ModActivityPanel userId={result.identity.id} civitaiUrl={data.civitaiUrl} />
+      <!-- Beside the human record, not in a section of its own: "what did WE do about this account"
+           and "what did the DETECTORS say about it" are the same question a moderator is asking, and
+           /abuse deep-links here so the two arrive together. -->
+      <AbuseFindingsPanel userId={result.identity.id} />
     {:else if section === 'chat'}
       <ChatContactPanel modContact={result.modContact} username={result.identity.username} />
     {:else if section === 'notes'}

--- a/apps/moderator/src/routes/retool/user-lookup/[section]/+page.svelte
+++ b/apps/moderator/src/routes/retool/user-lookup/[section]/+page.svelte
@@ -157,7 +157,9 @@
       <!-- Beside the human record, not in a section of its own: "what did WE do about this account"
            and "what did the DETECTORS say about it" are the same question a moderator is asking, and
            /abuse deep-links here so the two arrive together. -->
-      <AbuseFindingsPanel userId={result.identity.id} />
+      {#if data.canSeeAbuse}
+        <AbuseFindingsPanel userId={result.identity.id} />
+      {/if}
     {:else if section === 'chat'}
       <ChatContactPanel modContact={result.modContact} username={result.identity.username} />
     {:else if section === 'notes'}


### PR DESCRIPTION
## What

`/abuse` links every finding's user id into User Lookup. Following that link landed a moderator on a page with ~20 panels and **not one word about abuse detection** — so the question the link was clicked to answer had no answer at the destination. `getAbuseFindingsForUser` had existed for exactly this, indexed, with **no caller** but its own SQL test.

Two halves, and the second matters as much as the first:

1. **`AbuseFindingsPanel`**, fed by a new `/api/user-abuse-findings/[userId]` endpoint — same client-fetch shape as the mod-activity and security-signal panels, one indexed query, off the identity render path. It renders beside `ModActivityPanel`, because *"what did we do about this account"* and *"what did the detectors say"* are one question.
2. **The `/abuse` link now names the section.** It pointed at the bare route, which redirects to Basic — so even with the panel built, the link would still have landed a moderator somewhere that could not show it.

## How this was found — the point of the PR

**Not by auditing.** Three adversarial audit rounds over this feature produced nine findings, and every one was a guard or a comment overstating its own coverage. None of them was this.

It was found by **driving the real page as a first-time user** with no idea what it was supposed to contain. Nothing was broken. Every piece was individually correct and individually tested. So nothing failed — the defect lived in the **seam**, which no component's own tests can see.

## Two smaller things the same read surfaced

- 🔴 **A confidence of `0.00` is a verdict, not a missing score.** Every finding whose reason begins *"Judged and deliberately NOT actioned"* carries exactly `0.00` — 27 of them today — printed beside a reason that lays out the evidence in detail. Unlabelled that reads as self-contradictory, and a moderator either dismisses a real finding or trusts a rejected one. Now labelled.
- **A failed fetch must not render as "no findings."** Clean and unknown are opposite conclusions and a moderator acts differently on each.

## Tests

11 new. The load-bearing one pins a **relationship, not a component**: it reads the section out of the `/abuse` link and asserts *that* section renders the panel. Either half stays green when edited alone — rename the section and the link still "links somewhere"; move the panel and it still "renders" — so only the comparison catches them drifting apart.

Mutation-verified, each killed by its own assertion, clean control run, all three files restored byte-identical:

| mutant | |
|---|---|
| revert the link to the bare route (the pre-fix state) | KILLED |
| link a section that exists but does not render the panel | **KILLED** ← the seam |
| remove the panel, leave the link valid | **KILLED** ← the seam |
| point the panel at a nonexistent endpoint | KILLED |
| drop the zero-confidence label | KILLED |

`app:moderator` 247 passed / 35 skipped · `svelte-check` 9358 files, 0 errors · eslint 3 files, 0 errors (read from `--format json`, not an exit code) · prettier clean.

## Not in this PR

Linking the **creator id** named in each reason, and links to the **flagged content** itself. Both are real gaps from the same read, but the reason text is free prose — extracting entities from it is its own change with its own failure modes, not a line to slip in here.
