### PR TITLE
feat(announcements): point creators at the Creator Studio composer from their own profile

### DIFF
--- a/src/components/Announcements/CreatorAnnouncementsEntry.tsx
+++ b/src/components/Announcements/CreatorAnnouncementsEntry.tsx
@@ -6,31 +6,32 @@ import {
   CREATOR_ANNOUNCEMENTS_URL,
   creatorAnnouncementsEntryVariant,
 } from '~/components/Announcements/creator-announcements-entry';
-import {
-  useCreatorAnnouncementsFeature,
-  useQueryCreatorAnnouncements,
-} from '~/components/Announcements/creator-announcements.utils';
+import { useCreatorAnnouncementsFeature } from '~/components/Announcements/creator-announcements.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 
 export function CreatorAnnouncementsEntry({
   userId,
   userMuted,
+  announcementCount,
+  announcementsLoading,
   className,
 }: {
   userId: number;
   userMuted: boolean;
+  announcementCount: number;
+  announcementsLoading: boolean;
   className?: string;
 }) {
   const currentUser = useCurrentUser();
   const featureEnabled = useCreatorAnnouncementsFeature();
-  const { announcements } = useQueryCreatorAnnouncements(userId);
 
   const variant = creatorAnnouncementsEntryVariant({
     featureEnabled,
     currentUserId: currentUser?.id,
     profileUserId: userId,
     profileUserMuted: userMuted,
-    announcementCount: announcements.length,
+    announcementCount,
+    announcementsLoading,
   });
 
   if (!variant) return null;

--- a/src/components/Announcements/CreatorAnnouncementsEntry.tsx
+++ b/src/components/Announcements/CreatorAnnouncementsEntry.tsx
@@ -1,0 +1,67 @@
+import { Anchor, Button, Text } from '@mantine/core';
+import { IconSpeakerphone } from '@tabler/icons-react';
+import clsx from 'clsx';
+
+import {
+  CREATOR_ANNOUNCEMENTS_URL,
+  creatorAnnouncementsEntryVariant,
+} from '~/components/Announcements/creator-announcements-entry';
+import {
+  useCreatorAnnouncementsFeature,
+  useQueryCreatorAnnouncements,
+} from '~/components/Announcements/creator-announcements.utils';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+
+export function CreatorAnnouncementsEntry({
+  userId,
+  userMuted,
+  className,
+}: {
+  userId: number;
+  userMuted: boolean;
+  className?: string;
+}) {
+  const currentUser = useCurrentUser();
+  const featureEnabled = useCreatorAnnouncementsFeature();
+  const { announcements } = useQueryCreatorAnnouncements(userId);
+
+  const variant = creatorAnnouncementsEntryVariant({
+    featureEnabled,
+    currentUserId: currentUser?.id,
+    profileUserId: userId,
+    profileUserMuted: userMuted,
+    announcementCount: announcements.length,
+  });
+
+  if (!variant) return null;
+
+  if (variant === 'manage')
+    return (
+      <div className={clsx('flex justify-end', className)}>
+        <Anchor href={CREATOR_ANNOUNCEMENTS_URL} target="_blank" rel="noreferrer" size="xs">
+          Manage announcements in Creator Studio
+        </Anchor>
+      </div>
+    );
+
+  return (
+    <div className={className}>
+      <div className="flex flex-wrap items-center gap-3 rounded-lg border border-gray-3 p-3 dark:border-dark-4">
+        <IconSpeakerphone size={24} className="shrink-0" />
+        <Text size="sm" className="flex-1">
+          Post an announcement to tell your followers what you&apos;re working on.
+        </Text>
+        <Button
+          component="a"
+          href={CREATOR_ANNOUNCEMENTS_URL}
+          target="_blank"
+          rel="noreferrer"
+          size="compact-sm"
+          variant="light"
+        >
+          Open Creator Studio
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Announcements/CreatorAnnouncementsEntry.tsx
+++ b/src/components/Announcements/CreatorAnnouncementsEntry.tsx
@@ -14,12 +14,14 @@ export function CreatorAnnouncementsEntry({
   userMuted,
   announcementCount,
   announcementsLoading,
+  announcementsErrored,
   className,
 }: {
   userId: number;
   userMuted: boolean;
   announcementCount: number;
   announcementsLoading: boolean;
+  announcementsErrored: boolean;
   className?: string;
 }) {
   const currentUser = useCurrentUser();
@@ -32,6 +34,7 @@ export function CreatorAnnouncementsEntry({
     profileUserMuted: userMuted,
     announcementCount,
     announcementsLoading,
+    announcementsErrored,
   });
 
   if (!variant) return null;

--- a/src/components/Announcements/creator-announcements-entry.test.ts
+++ b/src/components/Announcements/creator-announcements-entry.test.ts
@@ -15,6 +15,7 @@ const base = {
   profileUserMuted: false,
   announcementCount: 0,
   announcementsLoading: false,
+  announcementsErrored: false,
 };
 
 describe('creatorAnnouncementsEntryVariant', () => {
@@ -35,6 +36,19 @@ describe('creatorAnnouncementsEntryVariant', () => {
       creatorAnnouncementsEntryVariant({
         ...base,
         announcementsLoading: true,
+        announcementCount: 0,
+      })
+    ).toBeNull();
+  });
+
+  // A failed fetch is an UNKNOWN count, not an empty one: isLoading is already false and the data has
+  // fallen back to [], so gating on loading alone shows the first-announcement prompt to a creator
+  // with ten of them. Do not collapse this into the loading check.
+  it('renders nothing when the count failed to load, rather than assuming zero', () => {
+    expect(
+      creatorAnnouncementsEntryVariant({
+        ...base,
+        announcementsErrored: true,
         announcementCount: 0,
       })
     ).toBeNull();
@@ -66,11 +80,9 @@ describe('creatorAnnouncementsEntryVariant', () => {
     ).toBeNull();
   });
 
-  // Asserts only what this module owns — the path. The host lives in CREATOR_STUDIO_URL, and
-  // spelling it out here would make a spoke rename redden an announcements test.
+  // Built from CREATOR_STUDIO_URL rather than spelled out, so a spoke rename does not redden an
+  // announcements test — but still exact, so an interposed path segment fails here.
   it('deep-links to the announcements page, not the Creator Studio root', () => {
-    expect(CREATOR_ANNOUNCEMENTS_URL.startsWith(CREATOR_STUDIO_URL)).toBe(true);
-    expect(CREATOR_ANNOUNCEMENTS_URL).not.toBe(CREATOR_STUDIO_URL);
-    expect(CREATOR_ANNOUNCEMENTS_URL.endsWith('/announcements')).toBe(true);
+    expect(CREATOR_ANNOUNCEMENTS_URL).toBe(`${CREATOR_STUDIO_URL}/announcements`);
   });
 });

--- a/src/components/Announcements/creator-announcements-entry.test.ts
+++ b/src/components/Announcements/creator-announcements-entry.test.ts
@@ -4,6 +4,7 @@ import {
   CREATOR_ANNOUNCEMENTS_URL,
   creatorAnnouncementsEntryVariant,
 } from '~/components/Announcements/creator-announcements-entry';
+import { CREATOR_STUDIO_URL } from '~/shared/constants/creator-studio.constants';
 
 const OWNER = 42;
 
@@ -13,9 +14,12 @@ const base = {
   profileUserId: OWNER,
   profileUserMuted: false,
   announcementCount: 0,
+  announcementsLoading: false,
 };
 
 describe('creatorAnnouncementsEntryVariant', () => {
+  // The point of this entry point is discovery, and the carousel renders nothing at a zero count —
+  // so the empty case is the one that must keep showing something. This test is what protects it.
   it('shows the empty-state prompt to an owner with no announcements', () => {
     expect(creatorAnnouncementsEntryVariant(base)).toBe('empty');
   });
@@ -24,10 +28,16 @@ describe('creatorAnnouncementsEntryVariant', () => {
     expect(creatorAnnouncementsEntryVariant({ ...base, announcementCount: 2 })).toBe('manage');
   });
 
-  // The point of this entry point is discovery, and the carousel renders nothing at zero — so the
-  // empty state is the case that must not be dropped.
-  it('is visible at a zero count, where the carousel itself renders nothing', () => {
-    expect(creatorAnnouncementsEntryVariant({ ...base, announcementCount: 0 })).not.toBeNull();
+  // An unsettled count reads as zero. Without this gate an owner with announcements sees the
+  // "post your first one" prompt on every load until the query settles, then watches it swap.
+  it('renders nothing while the count is still loading, rather than assuming zero', () => {
+    expect(
+      creatorAnnouncementsEntryVariant({
+        ...base,
+        announcementsLoading: true,
+        announcementCount: 0,
+      })
+    ).toBeNull();
   });
 
   describe('owner-only', () => {
@@ -50,13 +60,17 @@ describe('creatorAnnouncementsEntryVariant', () => {
   // Deliberate: a muted creator's announcements do not render on their profile, so pointing them at
   // the composer would send them to write something nobody can see. Do not drop this to simplify the
   // signature — the muted check is the reason it takes the profile user at all.
-  it('hides it from a muted owner, who cannot have announcements rendered', () => {
+  it('hides it from a muted owner, whose announcements do not render', () => {
     expect(
       creatorAnnouncementsEntryVariant({ ...base, profileUserMuted: true, announcementCount: 2 })
     ).toBeNull();
   });
 
+  // Asserts only what this module owns — the path. The host lives in CREATOR_STUDIO_URL, and
+  // spelling it out here would make a spoke rename redden an announcements test.
   it('deep-links to the announcements page, not the Creator Studio root', () => {
-    expect(CREATOR_ANNOUNCEMENTS_URL).toBe('https://creator-studio.civitai.com/announcements');
+    expect(CREATOR_ANNOUNCEMENTS_URL.startsWith(CREATOR_STUDIO_URL)).toBe(true);
+    expect(CREATOR_ANNOUNCEMENTS_URL).not.toBe(CREATOR_STUDIO_URL);
+    expect(CREATOR_ANNOUNCEMENTS_URL.endsWith('/announcements')).toBe(true);
   });
 });

--- a/src/components/Announcements/creator-announcements-entry.test.ts
+++ b/src/components/Announcements/creator-announcements-entry.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CREATOR_ANNOUNCEMENTS_URL,
+  creatorAnnouncementsEntryVariant,
+} from '~/components/Announcements/creator-announcements-entry';
+
+const OWNER = 42;
+
+const base = {
+  featureEnabled: true,
+  currentUserId: OWNER as number | null | undefined,
+  profileUserId: OWNER,
+  profileUserMuted: false,
+  announcementCount: 0,
+};
+
+describe('creatorAnnouncementsEntryVariant', () => {
+  it('shows the empty-state prompt to an owner with no announcements', () => {
+    expect(creatorAnnouncementsEntryVariant(base)).toBe('empty');
+  });
+
+  it('shows the manage link to an owner who already has announcements', () => {
+    expect(creatorAnnouncementsEntryVariant({ ...base, announcementCount: 2 })).toBe('manage');
+  });
+
+  // The point of this entry point is discovery, and the carousel renders nothing at zero — so the
+  // empty state is the case that must not be dropped.
+  it('is visible at a zero count, where the carousel itself renders nothing', () => {
+    expect(creatorAnnouncementsEntryVariant({ ...base, announcementCount: 0 })).not.toBeNull();
+  });
+
+  describe('owner-only', () => {
+    it('hides it from another signed-in user viewing the profile', () => {
+      expect(creatorAnnouncementsEntryVariant({ ...base, currentUserId: OWNER + 1 })).toBeNull();
+    });
+
+    it('hides it from a signed-out visitor', () => {
+      expect(creatorAnnouncementsEntryVariant({ ...base, currentUserId: undefined })).toBeNull();
+      expect(creatorAnnouncementsEntryVariant({ ...base, currentUserId: null })).toBeNull();
+    });
+  });
+
+  it('hides it behind the creatorAnnouncements flag', () => {
+    expect(
+      creatorAnnouncementsEntryVariant({ ...base, featureEnabled: false, announcementCount: 2 })
+    ).toBeNull();
+  });
+
+  // Deliberate: a muted creator's announcements do not render on their profile, so pointing them at
+  // the composer would send them to write something nobody can see. Do not drop this to simplify the
+  // signature — the muted check is the reason it takes the profile user at all.
+  it('hides it from a muted owner, who cannot have announcements rendered', () => {
+    expect(
+      creatorAnnouncementsEntryVariant({ ...base, profileUserMuted: true, announcementCount: 2 })
+    ).toBeNull();
+  });
+
+  it('deep-links to the announcements page, not the Creator Studio root', () => {
+    expect(CREATOR_ANNOUNCEMENTS_URL).toBe('https://creator-studio.civitai.com/announcements');
+  });
+});

--- a/src/components/Announcements/creator-announcements-entry.ts
+++ b/src/components/Announcements/creator-announcements-entry.ts
@@ -11,6 +11,7 @@ export function creatorAnnouncementsEntryVariant({
   profileUserMuted,
   announcementCount,
   announcementsLoading,
+  announcementsErrored,
 }: {
   featureEnabled: boolean;
   currentUserId?: number | null;
@@ -18,14 +19,16 @@ export function creatorAnnouncementsEntryVariant({
   profileUserMuted: boolean;
   announcementCount: number;
   announcementsLoading: boolean;
+  announcementsErrored: boolean;
 }): CreatorAnnouncementsEntryVariant | null {
   if (!featureEnabled) return null;
   if (profileUserMuted) return null;
   if (currentUserId !== profileUserId) return null;
 
-  // An unsettled count reads as zero, which would show the "post your first one" prompt to a creator
-  // who already has announcements — the one state the carousel above deliberately renders nothing in.
-  if (announcementsLoading) return null;
+  // An unknown count reads as zero, which would show the "post your first one" prompt to a creator
+  // who already has announcements. A failed fetch is unknown too, not empty — `isLoading` is false by
+  // then and the data falls back to [], so dropping the error half reinstates the bug on that path.
+  if (announcementsLoading || announcementsErrored) return null;
 
   return announcementCount > 0 ? 'manage' : 'empty';
 }

--- a/src/components/Announcements/creator-announcements-entry.ts
+++ b/src/components/Announcements/creator-announcements-entry.ts
@@ -1,0 +1,25 @@
+import { CREATOR_STUDIO_URL } from '~/shared/constants/creator-studio.constants';
+
+export const CREATOR_ANNOUNCEMENTS_URL = `${CREATOR_STUDIO_URL}/announcements`;
+
+export type CreatorAnnouncementsEntryVariant = 'empty' | 'manage';
+
+export function creatorAnnouncementsEntryVariant({
+  featureEnabled,
+  currentUserId,
+  profileUserId,
+  profileUserMuted,
+  announcementCount,
+}: {
+  featureEnabled: boolean;
+  currentUserId?: number | null;
+  profileUserId: number;
+  profileUserMuted: boolean;
+  announcementCount: number;
+}): CreatorAnnouncementsEntryVariant | null {
+  if (!featureEnabled) return null;
+  if (profileUserMuted) return null;
+  if (currentUserId == null || currentUserId !== profileUserId) return null;
+
+  return announcementCount > 0 ? 'manage' : 'empty';
+}

--- a/src/components/Announcements/creator-announcements-entry.ts
+++ b/src/components/Announcements/creator-announcements-entry.ts
@@ -10,16 +10,22 @@ export function creatorAnnouncementsEntryVariant({
   profileUserId,
   profileUserMuted,
   announcementCount,
+  announcementsLoading,
 }: {
   featureEnabled: boolean;
   currentUserId?: number | null;
   profileUserId: number;
   profileUserMuted: boolean;
   announcementCount: number;
+  announcementsLoading: boolean;
 }): CreatorAnnouncementsEntryVariant | null {
   if (!featureEnabled) return null;
   if (profileUserMuted) return null;
-  if (currentUserId == null || currentUserId !== profileUserId) return null;
+  if (currentUserId !== profileUserId) return null;
+
+  // An unsettled count reads as zero, which would show the "post your first one" prompt to a creator
+  // who already has announcements — the one state the carousel above deliberately renders nothing in.
+  if (announcementsLoading) return null;
 
   return announcementCount > 0 ? 'manage' : 'empty';
 }

--- a/src/components/Announcements/creator-announcements.utils.ts
+++ b/src/components/Announcements/creator-announcements.utils.ts
@@ -9,12 +9,17 @@ export function useCreatorAnnouncementsFeature() {
 
 export function useQueryCreatorAnnouncements(userId?: number, limit = 10) {
   const enabled = useCreatorAnnouncementsFeature();
-  const { data, isLoading } = trpc.announcement.getCreatorAnnouncements.useQuery(
+  const { data, isLoading, isError } = trpc.announcement.getCreatorAnnouncements.useQuery(
     { userId: userId as number, limit },
     { enabled: enabled && !!userId }
   );
 
-  return { announcements: data ?? [], isLoading: enabled && !!userId ? isLoading : false };
+  const active = enabled && !!userId;
+  return {
+    announcements: data ?? [],
+    isLoading: active ? isLoading : false,
+    isError: active ? isError : false,
+  };
 }
 
 export function useQueryFollowedAnnouncements(enabled = true, limit = 20) {

--- a/src/components/Profile/ProfileHeader.tsx
+++ b/src/components/Profile/ProfileHeader.tsx
@@ -28,7 +28,11 @@ export function ProfileHeader({ username }: { username: string }) {
     username,
   });
   const isMobile = useContainerSmallerThan('sm');
-  const { announcements, isLoading: announcementsLoading } = useQueryCreatorAnnouncements(user?.id);
+  const {
+    announcements,
+    isLoading: announcementsLoading,
+    isError: announcementsErrored,
+  } = useQueryCreatorAnnouncements(user?.id);
 
   const cover = user?.profile?.coverImage;
   const images = useMemo(
@@ -142,6 +146,7 @@ export function ProfileHeader({ username }: { username: string }) {
           userMuted={user.muted}
           announcementCount={announcements.length}
           announcementsLoading={announcementsLoading}
+          announcementsErrored={announcementsErrored}
           className="container"
         />
         {renderMessage()}
@@ -168,6 +173,7 @@ export function ProfileHeader({ username }: { username: string }) {
         userMuted={user.muted}
         announcementCount={announcements.length}
         announcementsLoading={announcementsLoading}
+        announcementsErrored={announcementsErrored}
         className="container"
       />
       {renderMessage()}

--- a/src/components/Profile/ProfileHeader.tsx
+++ b/src/components/Profile/ProfileHeader.tsx
@@ -28,7 +28,7 @@ export function ProfileHeader({ username }: { username: string }) {
     username,
   });
   const isMobile = useContainerSmallerThan('sm');
-  const { announcements } = useQueryCreatorAnnouncements(user?.id);
+  const { announcements, isLoading: announcementsLoading } = useQueryCreatorAnnouncements(user?.id);
 
   const cover = user?.profile?.coverImage;
   const images = useMemo(
@@ -137,7 +137,13 @@ export function ProfileHeader({ username }: { username: string }) {
     return (
       <div className="flex flex-col gap-3">
         {!user.muted && <CreatorAnnouncementsCarousel userId={user.id} className="container" />}
-        <CreatorAnnouncementsEntry userId={user.id} userMuted={user.muted} className="container" />
+        <CreatorAnnouncementsEntry
+          userId={user.id}
+          userMuted={user.muted}
+          announcementCount={announcements.length}
+          announcementsLoading={announcementsLoading}
+          className="container"
+        />
         {renderMessage()}
         <div className="flex flex-col">
           {renderCoverImage()}
@@ -157,7 +163,13 @@ export function ProfileHeader({ username }: { username: string }) {
     <Stack>
       {renderCoverImage()}
       {!user.muted && <CreatorAnnouncementsCarousel userId={user.id} className="container" />}
-      <CreatorAnnouncementsEntry userId={user.id} userMuted={user.muted} className="container" />
+      <CreatorAnnouncementsEntry
+        userId={user.id}
+        userMuted={user.muted}
+        announcementCount={announcements.length}
+        announcementsLoading={announcementsLoading}
+        className="container"
+      />
       {renderMessage()}
     </Stack>
   );

--- a/src/components/Profile/ProfileHeader.tsx
+++ b/src/components/Profile/ProfileHeader.tsx
@@ -6,6 +6,7 @@ import React, { useMemo } from 'react';
 
 import { MediaHash } from '~/components/ImageHash/ImageHash';
 import { CreatorAnnouncementsCarousel } from '~/components/Announcements/CreatorAnnouncementsCarousel';
+import { CreatorAnnouncementsEntry } from '~/components/Announcements/CreatorAnnouncementsEntry';
 import { useQueryCreatorAnnouncements } from '~/components/Announcements/creator-announcements.utils';
 import { ProfileSidebar } from '~/components/Profile/ProfileSidebar';
 import { shouldShowProfileMessage } from '~/components/Profile/profile.utils';
@@ -136,6 +137,7 @@ export function ProfileHeader({ username }: { username: string }) {
     return (
       <div className="flex flex-col gap-3">
         {!user.muted && <CreatorAnnouncementsCarousel userId={user.id} className="container" />}
+        <CreatorAnnouncementsEntry userId={user.id} userMuted={user.muted} className="container" />
         {renderMessage()}
         <div className="flex flex-col">
           {renderCoverImage()}
@@ -155,6 +157,7 @@ export function ProfileHeader({ username }: { username: string }) {
     <Stack>
       {renderCoverImage()}
       {!user.muted && <CreatorAnnouncementsCarousel userId={user.id} className="container" />}
+      <CreatorAnnouncementsEntry userId={user.id} userMuted={user.muted} className="container" />
       {renderMessage()}
     </Stack>
   );


### PR DESCRIPTION
@
Closes the discovery gap in [868kwp6c8](https://app.clickup.com/t/868kwp6c8).

Creator announcements are authored in the Creator Studio, and nothing on civitai.com linked to them. The carousel on a profile renders nothing at a zero count, so the feature was invisible to any creator who had never used it.

Surface was Justin's call: an own-profile affordance, chosen over a user-menu entry, because it sits where the announcements themselves appear and it covers the empty state.

## What it does

An owner-only entry point directly under the profile carousel:

- **no announcements** — a prompt with an "Open Creator Studio" button
- **has announcements** — a small right-aligned "Manage announcements in Creator Studio" link

Both deep-link to `https://creator-studio.civitai.com/announcements`, built from the existing `CREATOR_STUDIO_URL` constant.

## Gating

`creatorAnnouncementsEntryVariant` is a pure function, so the visibility rule is testable without a browser:

- behind the same `creatorAnnouncements` flag that gates the carousel and the Creator Studio page
- owner-only — a signed-out or mismatched viewer gets nothing
- hidden for a **muted** creator, whose announcements do not render on their profile at all, so pointing them at the composer would send them to write something nobody can see
- hidden while the count is **unknown** — both in-flight and failed. `isLoading` is false once a query settles into error and the data falls back to `[]`, so an error reads as "zero" and would show the first-announcement prompt to a creator who has ten

## Verification

- `pnpm run typecheck` — `OK, 0 type errors`
- `eslint` over the five touched files — exit 0
- `pnpm run test:unit:run` — the only failing file is `src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts`, which fails identically on `origin/main` with these changes stashed out
- `blocks.router.workflow.test.ts` collected **358** tests

The new tests were checked against seven mutations of the helper — dropping each of the four guard clauses, flipping `> 0` to `>= 0`, interposing a path segment in the URL, and dropping each half of the unknown-count gate. All seven fail with an assertion naming the wrong value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qiAeExq4rs2p8c9fBhKGv
@