### PR TITLE
test(images): restore the carousel component suite, red on main since #4364

### DIFF
--- a/src/components/Image/AsPosts/ImagesAsPostsCardLazyCarousel.browser.test.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsCardLazyCarousel.browser.test.tsx
@@ -172,8 +172,14 @@ vi.mock('~/components/Image/ContextMenu/ImagesAsPostsContextMenu', () => ({
 }));
 vi.mock('~/components/Image/Meta/ImageMetaPopover', () => ({ ImageMetaPopover2: () => null }));
 vi.mock('~/components/Cards/components/HoverActionButton', () => ({ default: () => null }));
+// A whole-module factory REPLACES the module, so it must carry every export the
+// import graph reaches — not just the one this test renders. #4364 pulled
+// RemixedCardFlyout into ImagesAsPostsCard, and that component imports
+// `triggerRoutedDialog` from here, so a factory listing only RoutedDialogLink turns
+// into an import-time SyntaxError for the whole file.
 vi.mock('~/components/Dialog/RoutedDialogLink', () => ({
   RoutedDialogLink: ({ children }: any) => <a>{children}</a>,
+  triggerRoutedDialog: vi.fn(),
 }));
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ imageGeneration: false }),


### PR DESCRIPTION

`ImagesAsPostsCardLazyCarousel.browser.test.tsx` fails at IMPORT time on main:

    SyntaxError: The requested module '/src/components/Dialog/RoutedDialogLink.tsx'
    does not provide an export named 'triggerRoutedDialog'

#4364 added `RemixedCardFlyout` to `ImagesAsPostsCard`, and that component imports
`triggerRoutedDialog` from `RoutedDialogLink`. This test replaces that module with a
whole-module `vi.mock` factory listing only `RoutedDialogLink`, so the new import
resolves against a module that no longer has it.

A whole-module factory REPLACES the module rather than extending it, so it has to
carry every export the import graph reaches, not just the one the test renders. That
makes this class of breakage a normal consequence of adding an import three files
away, with nothing at the call site to hint at it.

Why it went unnoticed: an import failure reports a failed FILE and ZERO failing
TESTS, so the run reads

    Test Files  1 failed | 187 passed (188)
    Tests       2053 passed (2053)

and the tier is report-only, so nothing blocked. The nine tests in this file have
not executed since #4364 landed.

Matrix, run locally against real Chromium:

  origin/main            1 file failed, "Tests no tests"  (the import error above)
  origin/main + this fix 1 file passed, 9 tests passed

Scope is one line plus a comment; no product code changes.

