### PR TITLE
fix(remix-gallery): apply the full public rules to the sent-list host read

### DIFF
--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -2155,12 +2155,55 @@ describe('the reads a Buzz figure is rendered from', () => {
     expect(hostReads).toHaveLength(1);
     const sql = flatten(hostReads[0]);
 
-    expect(sql).toContain('p."availability" !=');
+    // 🔴 The leading `AND` is part of every assertion, and that is the whole
+    // point of them. Matching the fragment alone pins the spelling of a clause
+    // without pinning how it JOINS the others — measured: flipping one `AND` to
+    // `OR` left all five green while making the entire WHERE permissive, which
+    // is worse than deleting any single clause.
+    expect(sql).toContain('AND p."availability" !=');
     expect(boundValues(hostReads[0])).toContain(Availability.Private);
     // `IS NOT NULL` alone served a scheduled post ahead of its own publish time.
-    expect(sql).toContain('p."publishedAt" < now()');
-    expect(sql).toContain('i."needsReview" IS NULL');
-    expect(sql).toContain('NOT i."acceptableMinor"');
+    expect(sql).toContain('AND p."publishedAt" < now()');
+    expect(sql).toContain('AND i."needsReview" IS NULL');
+    expect(sql).toContain('AND NOT i."acceptableMinor"');
+    expect(sql).not.toContain('OR ');
+  });
+
+  /**
+   * 🔴 The withholding above must never become a disappearance. This list is the
+   * submitter's own record of where their Buzz went, and the withdraw button
+   * beside each row is the only route back to an escrow that otherwise sits
+   * until expiry.
+   *
+   * So a host the nine clauses exclude has to come back as `targetImage: null`
+   * on a row that is still there — not as a filtered-out row. The owner's
+   * received queue deliberately does the opposite (`:1861` filters on
+   * `row.image && row.targetImage`), and copying that one line into this
+   * function is a plausible tidy-up that passes every other test in this file
+   * while vanishing a pending row and its withdraw.
+   */
+  it('keeps the row when the host is withheld, so the withdraw survives', async () => {
+    placementFindMany.mockResolvedValue([
+      {
+        id: 1,
+        targetId: HOST_IMAGE,
+        ownerId: OWNER,
+        status: 'pending',
+        data: { imageId: REMIX_IMAGE },
+      },
+    ]);
+    // What the filtered read returns once the host stops meeting the rules.
+    queryRaw.mockImplementation(async () => []);
+
+    const rows = await getMyRemixGallerySubmissions({
+      placerId: PLACER,
+      domainLevels: allBrowsingLevelsFlag,
+      viewerLevels: allBrowsingLevelsFlag,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(1);
+    expect(rows[0].targetImage).toBeNull();
   });
 
   it('the submitter’s pending rows on the image detail card', async () => {

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { NsfwLevel } from '~/server/common/enums';
+import { Availability } from '~/shared/utils/prisma/enums';
 import {
   allBrowsingLevelsFlag,
   sfwBrowsingLevelsFlag,
@@ -2120,6 +2121,46 @@ describe('the reads a Buzz figure is rendered from', () => {
     // something to inspect — deleting it as pointless removes the guard's
     // anchor with nothing turning red.
     expect(placementFindMany).toHaveBeenCalled();
+  });
+
+  /**
+   * 🔴 Named for the decision, because the clauses look like padding next to the
+   * five that were already there and read like an obvious tidy-up to delete.
+   *
+   * The host on this list belongs to somebody else. Every clause below admitted
+   * a host the submitter could still see after its owner had stopped showing it
+   * to anyone else, and none is implied by the `ingestion = 'Scanned'` beside
+   * them — a moderator flag leaves `ingestion` untouched, and a scheduled post
+   * carries a non-null FUTURE `publishedAt`.
+   *
+   * Asserted on the ONE read that joins `Post`. The joined text of every
+   * `queryRaw` call would pass if a clause landed in the submitter's own-image
+   * read instead, which is a different question about a different person's
+   * picture.
+   */
+  it('fetches the host under the full public rules, not published-only', async () => {
+    placementFindMany.mockResolvedValue([
+      { id: 1, targetId: HOST_IMAGE, ownerId: OWNER, data: { imageId: REMIX_IMAGE } },
+    ]);
+
+    await getMyRemixGallerySubmissions({
+      placerId: PLACER,
+      domainLevels: allBrowsingLevelsFlag,
+      viewerLevels: allBrowsingLevelsFlag,
+    });
+
+    const hostReads = queryRaw.mock.calls.filter((call) => flatten(call).includes('JOIN "Post"'));
+    // Exactly one, so the assertions below cannot be satisfied by some other
+    // read that happens to carry the same words.
+    expect(hostReads).toHaveLength(1);
+    const sql = flatten(hostReads[0]);
+
+    expect(sql).toContain('p."availability" !=');
+    expect(boundValues(hostReads[0])).toContain(Availability.Private);
+    // `IS NOT NULL` alone served a scheduled post ahead of its own publish time.
+    expect(sql).toContain('p."publishedAt" < now()');
+    expect(sql).toContain('i."needsReview" IS NULL');
+    expect(sql).toContain('NOT i."acceptableMinor"');
   });
 
   it('the submitter’s pending rows on the image detail card', async () => {

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -1950,7 +1950,21 @@ export async function getMyRemixGallerySubmissions({
         JOIN "Post" p ON p.id = i."postId"
         WHERE i.id IN (${Prisma.join(targetIds)})
           AND p."publishedAt" IS NOT NULL
+          -- Four clauses the public rules carry and this copy did not. Each
+          -- admitted a host the submitter could still see after its owner had
+          -- stopped showing it to anybody else. (No backticks below: a template
+          -- literal ends at the first one.)
+          --   now() - a scheduled post carries a non-null FUTURE publishedAt,
+          --   so IS NOT NULL served it ahead of its own publish time;
+          --   availability - a post inherits it from the model version, so it
+          --   can be published AND private;
+          --   needsReview / acceptableMinor - a moderator flag leaves ingestion
+          --   at 'Scanned', so neither is implied by the line above.
+          AND p."publishedAt" < now()
+          AND p."availability" != ${Availability.Private}
           AND i.ingestion = 'Scanned'
+          AND i."needsReview" IS NULL
+          AND NOT i."acceptableMinor"
           AND NOT i."tosViolation"
           AND NOT i.minor
           AND NOT i.poi

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -1959,7 +1959,7 @@ export async function getMyRemixGallerySubmissions({
           --   availability - a post inherits it from the model version, so it
           --   can be published AND private;
           --   needsReview / acceptableMinor - a moderator flag leaves ingestion
-          --   at 'Scanned', so neither is implied by the line above.
+          --   at 'Scanned', so neither is implied by the ingestion clause below.
           AND p."publishedAt" < now()
           AND p."availability" != ${Availability.Private}
           AND i.ingestion = 'Scanned'


### PR DESCRIPTION
Found by an adversarial review of #4381, which could not refute that change and reported this instead: the identical defect, live, in the function #4381 cannot reach.

## The gap

`getMyRemixGallerySubmissions` is the structural twin of the sticker list fixed in #4381 — the submitter's own "where did my remix land" list. It runs two reads: the submitter's own images (unfiltered, correct), then a **second raw-SQL read for the host images, which belong to other people**.

Its own comment claims that second read applies "the same visibility filter the public feed applies". It carried five of the nine clauses. Each of the four missing ones admitted a host the submitter could still see after its owner had stopped showing it to anyone else, and **none is implied by the `ingestion = 'Scanned'` already beside them**:

| clause | what it admitted |
|---|---|
| `p."publishedAt" < now()` | a scheduled post carries a non-null **future** `publishedAt`, so `IS NOT NULL` served it ahead of its own publish time |
| `p."availability" != Private` | a post inherits availability from its model version, so it can be published **and** private |
| `i."needsReview" IS NULL` | a moderator flag leaves `ingestion` at `Scanned` |
| `NOT i."acceptableMinor"` | likewise, and it is the load-bearing minor column |

#4364 fixed `entryIsVisible` — the gallery **ordering** query. This sent-list read is a separate copy in raw SQL, so neither that fix nor #4381's Prisma-side fix could reach it. Same underlying rule: **a read that skips hydration inherits none of hydration's guards.**

No owner arm, deliberately, matching both precedents. Self-submission is refused, so the host on this list is never the submitter's own image.

## Live exposure: zero rows, with positive controls

| | |
|---|---|
| remix placements, pending/approved, with a host post | 342 |
| host post Private / scheduled / needsReview / acceptableMinor | **0 / 0 / 0 / 0** |

Positive controls, because a zero from a predicate that cannot match is worthless: **2,607** posts are published *and* Private, and scheduled posts, `needsReview` images and `acceptableMinor` images each hit a 100-row cap when counted. Every predicate matches plenty site-wide; the intersection with placements is genuinely empty.

**Latent, not live.** Fixed because the exposure is the transition and nothing prevents the first one.

## Control: four mutants, one per clause

Deleting the block wholesale fails on the first assertion and proves nothing about the other three, so each clause was deleted on its own:

```
now             -> exit=1 | Tests 1 failed | 134 passed (135)
availability    -> exit=1 | Tests 1 failed | 134 passed (135)
needsReview     -> exit=1 | Tests 1 failed | 134 passed (135)
acceptableMinor -> exit=1 | Tests 1 failed | 134 passed (135)
```

**4 of 4 caught, no survivors**, each naming its own clause rather than failing generically:

```
expected '...SELECT i.id, i.url...' to contain 'p."publishedAt" < now()'
expected '...SELECT i.id, i.url...' to contain 'i."needsReview" IS NULL'
expected '...SELECT i.id, i.url...' to contain 'NOT i."acceptableMinor"'
```

The test first asserts that **exactly one** read joins `Post`, then asserts on that call. The joined text of every `queryRaw` call would pass if a clause landed in the submitter's own-image read instead — a different question about a different person's picture.

## Deliberately not in this PR

An earlier draft of this work also touched `getPendingRemixGallerySubmissions` and `queueImageIsListable`, which have the same omissions. Both were **decided against**, and the reasons are recorded here so they are not re-discovered as bugs:

- **`getPendingRemixGallerySubmissions`** — its single read covers both the submitter's image and the **owner's own** host image, and `:1861` filters on `row.image && row.targetImage`, so a blanket clause **drops the row entirely**. The owner then loses the approve/decline buttons and the placement expires, costing them the decline fee. The clauses are not separately targetable without splitting the read.
- **`queueImageIsListable`** — display-only. `expirePlacements` is `{ status, expiresAt }` and never consults it. Tightening it would widen an expiry-refund treatment the docblock at `:1474` already states as intended policy.

**Known-false comment, left alone:** `remix-gallery.service.ts:1789` says a failing host "renders as a placeholder". It does not — `:1861` drops the row. It sits in the function this PR was asked to leave untouched, so it is flagged rather than fixed.

**Also noted:** `placement-image.selector.ts`'s docblock says "This is no longer the only copy" and names `entryIsVisible` as the second. Counting this read and `queueImageIsListable` there are four. Not edited from this branch, to keep it independent of #4381.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — repo-wide red (362 pre-existing errors, 1,337 files). Names this test file only for two **pre-existing** `no-explicit-any` warnings at line 109 (`type AnyFn`), untouched by this diff — the hunks are lines 3 and 2126-2165
- `pnpm exec prettier --write` on both files
- `pnpm run test:unit:run` — run `t60mikn`, verbatim:

```
FAIL |unit| src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
Test Files  1 failed | 1410 passed | 1 skipped (1412)
Tests  1 failed | 22116 passed | 27 skipped (22144)
```

Files 1410+1+1 = 1412; tests 22116+1+27 = 22144. Both add up, so no worker died and no file silently failed to run. The single failure is `pageRunScrollContract.test.ts`, a Windows path-separator assert (`src\pages\...` vs `src/pages/...`) that is currently red on **every** branch on this machine — confirmed independently across four unrelated worktrees, including ones that have since merged. It is being fixed separately. Excluding that one and nothing else.

- `blocks.router.workflow.test.ts` re-run on **this branch** at `e35b9d13d4`: **358 passed (358)**. Non-zero, so the `event-engine-common` submodule is initialised and the run covered real code rather than silently collecting nothing.


---

## Review, and what changed after it

Adversarially reviewed at `e35b9d13d4` — verdict **MERGE**, no confirmed defect. It verified against prod `information_schema` that `Post.availability` is NOT NULL (so `!=` cannot silently drop rows), that `needsReview IS NULL` is the same clause the public feed uses rather than an over-exclusion, and that the session timezone is UTC so `< now()` casts cleanly.

**The review predates the current head, so here is the delta rather than an assurance that it is small:**

```
git diff e35b9d13d4 <head> -- src/server/services/remix-gallery.service.ts
-          --   at 'Scanned', so neither is implied by the line above.
+          --   at 'Scanned', so neither is implied by the ingestion clause below.
```

**One comment line. The shipped SQL is byte-identical to what was reviewed**; every other change since is in the test file. (That comment fix is the reviewer's own note — the `ingestion` clause sits below the block, not above it.)

### Two gaps the review found in the tests, both measured rather than argued

**1. The clause assertions did not pin the conjunction.** They matched `p."availability" !=` — the fragment *without* its leading `AND`. So they pinned each clause's spelling and said nothing about how the clauses join. Flipping one `AND` to `OR` was measured to leave all five green:

```
Tests  135 passed (135)   exit 0
```

That is a **worse** outcome than deleting a clause — one `OR` makes the entire `WHERE` permissive — and a clean four-of-four deletion sweep is structurally blind to it. The assertions now carry the leading `AND`, with a negative on `OR ` beside them.

**2. Nothing asserted that a withheld host keeps its row.** The behaviour was already correct, but untested, and the regression that would break it is a *plausible tidy-up*: copying the owner queue's `.filter((row) => row.image && row.targetImage)` into this function. That passed all 135 tests while vanishing a pending row and its withdraw **with the submitter's Buzz still in escrow**. Now pinned by a named test.

### Mutants, re-run after the rebase rather than carried over

```
CAUGHT  now                  | 1 failed | 135 passed (136)
CAUGHT  availability         | 1 failed | 135 passed (136)
CAUGHT  needsReview          | 1 failed | 135 passed (136)
CAUGHT  acceptableMinor      | 1 failed | 135 passed (136)
CAUGHT  and_to_or            | 1 failed | 135 passed (136)
CAUGHT  owner_filter_copied  | 1 failed | 135 passed (136)
```

**6 of 6, no survivors.** Re-run on the rebased tree, because a rebase is a new diff — the controls are evidence about the diff *in the tree it will land in*, not about the diff in the abstract.
